### PR TITLE
fix(draft-pr): improve draft review request panes

### DIFF
--- a/Alas/Sources/Center/Commit/CommitMessageEditorView.swift
+++ b/Alas/Sources/Center/Commit/CommitMessageEditorView.swift
@@ -10,6 +10,9 @@ struct CommitMessageEditorView: View {
     let availableAgents: [AgentDefinition]
     let onGenerate: () -> Void
     let primaryAction: CommitPrimaryAction
+    var iconName: String = "commit"
+    var editorDisabled: Bool = false
+    var onDismissError: () -> Void = {}
     var accessory: AnyView? = nil
 
     @Environment(\.theme) private var theme
@@ -33,7 +36,7 @@ struct CommitMessageEditorView: View {
             subjectField
             bodyField
             if let error {
-                InlineErrorStrip(message: error, onDismiss: {})
+                InlineErrorStrip(message: error, onDismiss: onDismissError)
             }
         }
         .padding(12)
@@ -61,10 +64,12 @@ struct CommitMessageEditorView: View {
 
     private var headerRow: some View {
         HStack(spacing: 8) {
-            Icon(name: "commit", size: 12, color: theme.color("accent"))
+            Icon(name: iconName, size: 12, color: theme.color("accent"))
             Text(title)
                 .font(.system(size: 12, weight: .semibold))
                 .foregroundColor(theme.color("fg"))
+                .lineLimit(1)
+                .truncationMode(.middle)
             Spacer()
             if let accessory {
                 accessory
@@ -127,7 +132,7 @@ struct CommitMessageEditorView: View {
             )
             .clipShape(RoundedRectangle(cornerRadius: 6))
             .focused($focused, equals: .subject)
-            .disabled(busy)
+            .disabled(busy || editorDisabled)
     }
 
     private var bodyField: some View {
@@ -154,7 +159,7 @@ struct CommitMessageEditorView: View {
             )
             .clipShape(RoundedRectangle(cornerRadius: 6))
             .focused($focused, equals: .body)
-            .disabled(busy)
+            .disabled(busy || editorDisabled)
     }
 
     /// Render the modifier + key glyphs of a `KeyboardShortcut` for display

--- a/Alas/Sources/Center/ReviewRequest/DraftReviewRequestTabView.swift
+++ b/Alas/Sources/Center/ReviewRequest/DraftReviewRequestTabView.swift
@@ -65,7 +65,7 @@ struct DraftReviewRequestTabView: View {
 
     var body: some View {
         VStack(spacing: 0) {
-            header
+            reviewRequestEditor
             contextBrowser
         }
         .onAppear { hydrateFromTabState() }
@@ -79,11 +79,54 @@ struct DraftReviewRequestTabView: View {
         }
     }
 
-    private var header: some View {
+    private var reviewRequestEditor: some View {
+        VStack(spacing: 0) {
+            CommitMessageEditorView(
+                subject: $title,
+                bodyText: $bodyText,
+                aiToolId: appState.bind(\.changes.aiToolId),
+                title: editorTitle,
+                busy: busy,
+                error: error,
+                availableAgents: appState.agentRegistry.enabled(),
+                onGenerate: handleGenerate,
+                primaryAction: CommitPrimaryAction(
+                    label: "Create \(tabState.provider.reviewRequestLabel)",
+                    isEnabled: canCreate,
+                    showSavedState: false,
+                    handler: createReviewRequest
+                ),
+                iconName: "branch",
+                editorDisabled: tabState.createdURL != nil,
+                onDismissError: { self.error = nil },
+                accessory: AnyView(
+                    Toggle(isOn: $createAsDraft) {
+                        Text("Draft")
+                            .font(.system(size: 11))
+                            .foregroundColor(theme.color("fg-dim"))
+                    }
+                    .toggleStyle(.checkbox)
+                    .disabled(busy || tabState.createdURL != nil)
+                )
+            )
+            if hasEditorMessages {
+                editorMessages
+            }
+        }
+    }
+
+    private var hasEditorMessages: Bool {
+        warning != nil || (validationMessage != nil && tabState.createdURL == nil) || tabState.createdURL != nil
+    }
+
+    private var editorTitle: String {
+        let repo = tabState.repositorySlug.isEmpty ? "Unknown repository" : tabState.repositorySlug
+        return "\(tabState.provider.displayName) \(tabState.provider.reviewRequestLabel) · \(repo) · \(tabState.branchName) -> \(tabState.baseBranch)"
+    }
+
+    @ViewBuilder
+    private var editorMessages: some View {
         VStack(alignment: .leading, spacing: 8) {
-            headerRow
-            titleField
-            bodyEditor
             if let warning {
                 Text(warning)
                     .font(.system(size: 10.5))
@@ -96,9 +139,6 @@ struct DraftReviewRequestTabView: View {
                     .foregroundColor(theme.color("fg-dim"))
                     .frame(maxWidth: .infinity, alignment: .leading)
             }
-            if let error {
-                InlineErrorStrip(message: error, onDismiss: { self.error = nil })
-            }
             if let createdURL = tabState.createdURL {
                 HStack(spacing: 6) {
                     Icon(name: "link", size: 11, color: theme.color("accent"))
@@ -108,11 +148,16 @@ struct DraftReviewRequestTabView: View {
                         .lineLimit(1)
                         .truncationMode(.middle)
                         .textSelection(.enabled)
+                    Spacer()
+                    AlasButton(title: "Open \(tabState.provider.reviewRequestLabel)", icon: "arrow.up.right.square") {
+                        NSWorkspace.shared.open(createdURL)
+                    }
                 }
                 .frame(maxWidth: .infinity, alignment: .leading)
             }
         }
-        .padding(12)
+        .padding(.horizontal, 12)
+        .padding(.vertical, 8)
         .background(
             LinearGradient(
                 colors: [theme.color("composer-bg-top"), theme.color("composer-bg-bot")],
@@ -120,18 +165,6 @@ struct DraftReviewRequestTabView: View {
                 endPoint: .bottom
             )
         )
-        .overlay(alignment: .top) {
-            LinearGradient(
-                colors: [
-                    Color.clear,
-                    theme.color("accent-glow"),
-                    Color.clear,
-                ],
-                startPoint: .leading,
-                endPoint: .trailing
-            )
-            .frame(height: 1)
-        }
         .overlay(Divider().opacity(0.5), alignment: .bottom)
     }
 
@@ -272,14 +305,13 @@ struct DraftReviewRequestTabView: View {
             contextSectionTitle("Commits")
             ScrollView {
                 LazyVStack(alignment: .leading, spacing: 0) {
-                    ForEach(Array((context?.commitSubjects ?? []).enumerated()), id: \.offset) { _, subject in
-                        Text(subject)
-                            .font(.system(size: 11))
-                            .foregroundColor(theme.color("fg"))
-                            .lineLimit(2)
-                            .frame(maxWidth: .infinity, alignment: .leading)
-                            .padding(.horizontal, 10)
-                            .padding(.vertical, 6)
+                    ForEach(Array((context?.commits ?? []).enumerated()), id: \.element.id) { index, commit in
+                        CommitRow(
+                            commit: commit,
+                            isLast: index == (context?.commits.count ?? 0) - 1,
+                            onSelect: {},
+                            onCopySHA: { Clipboard.copy(commit.sha) }
+                        )
                     }
                 }
             }
@@ -334,39 +366,39 @@ struct DraftReviewRequestTabView: View {
                     let preview = selectedDiffPreview(in: context)
                     if let selectedPath,
                        let file = context.changedFiles.first(where: { $0.path == selectedPath }) {
-                        HStack(spacing: 8) {
-                            Text(file.path)
-                                .font(.system(size: 12, weight: .semibold))
-                                .foregroundColor(theme.color("fg"))
-                                .lineLimit(1)
-                                .truncationMode(.middle)
-                            Spacer()
-                            Text("\(file.status)  +\(file.add) -\(file.del)")
-                                .font(.system(size: 11, design: .monospaced))
-                                .foregroundColor(theme.color("fg-dim"))
-                        }
+                        DraftReviewRequestDiffPreviewView(
+                            preview: DraftReviewRequestDiffPreview(
+                                path: selectedPath,
+                                file: file,
+                                rawDiff: preview.diff
+                            ),
+                            codeFontFamily: appState.config.code.fontFamily,
+                            codeFontSize: CGFloat(appState.config.code.fontSize)
+                        )
                     } else {
                         Text("Branch diff")
                             .font(.system(size: 12, weight: .semibold))
                             .foregroundColor(theme.color("fg"))
-                    }
-                    ScrollView([.horizontal, .vertical]) {
-                        Text(preview.diff.isEmpty ? "No committed diff." : preview.diff)
-                            .font(.system(
-                                size: CGFloat(appState.config.code.fontSize),
-                                design: .monospaced
-                            ))
-                            .foregroundColor(theme.color("fg"))
-                            .textSelection(.enabled)
                             .frame(maxWidth: .infinity, alignment: .leading)
                             .padding(12)
+                        ScrollView([.horizontal, .vertical]) {
+                            Text(preview.diff.isEmpty ? "No committed diff." : preview.diff)
+                                .font(CenterTypography.codeFont(
+                                    family: appState.config.code.fontFamily,
+                                    size: CGFloat(appState.config.code.fontSize)
+                                ))
+                                .foregroundColor(theme.color("fg"))
+                                .textSelection(.enabled)
+                                .frame(maxWidth: .infinity, alignment: .topLeading)
+                                .padding(12)
+                        }
+                        .background(theme.color("field-bg"))
+                        .overlay(
+                            RoundedRectangle(cornerRadius: 6)
+                                .strokeBorder(theme.color("line"), lineWidth: 0.5)
+                        )
+                        .clipShape(RoundedRectangle(cornerRadius: 6))
                     }
-                    .background(theme.color("field-bg"))
-                    .overlay(
-                        RoundedRectangle(cornerRadius: 6)
-                            .strokeBorder(theme.color("line"), lineWidth: 0.5)
-                    )
-                    .clipShape(RoundedRectangle(cornerRadius: 6))
                 }
                 .padding(12)
             } else {
@@ -560,6 +592,101 @@ struct DraftReviewRequestTabView: View {
         case "D": return theme.color("del")
         case "R", "C": return theme.color("accent")
         default: return theme.color("fg-dim")
+        }
+    }
+}
+
+struct DraftReviewRequestDiffPreview {
+    let path: String
+    let file: CommitChangedFile
+    let rawDiff: String
+
+    var parsedDiff: ParsedDiff {
+        DiffParser.parse(rawDiff)
+    }
+
+    var fileExtension: String {
+        LanguageRegistry.highlighterExtension(forPath: path)
+    }
+
+    var title: String {
+        (path as NSString).lastPathComponent
+    }
+
+    var directory: String {
+        (path as NSString).deletingLastPathComponent
+    }
+}
+
+private struct DraftReviewRequestDiffPreviewView: View {
+    let preview: DraftReviewRequestDiffPreview
+    let codeFontFamily: String
+    let codeFontSize: CGFloat
+
+    @Environment(\.theme) private var theme
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            header
+            content
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
+        .background(theme.color("bg-1"))
+        .overlay(
+            RoundedRectangle(cornerRadius: 6)
+                .strokeBorder(theme.color("line"), lineWidth: 0.5)
+        )
+        .clipShape(RoundedRectangle(cornerRadius: 6))
+    }
+
+    private var header: some View {
+        HStack(spacing: 8) {
+            Text(preview.title)
+                .font(CenterTypography.codeFont(family: codeFontFamily, size: codeFontSize))
+                .foregroundColor(theme.color("fg"))
+                .lineLimit(1)
+            if !preview.directory.isEmpty {
+                Text("·").foregroundColor(theme.color("fg-faint"))
+                Text(preview.directory)
+                    .font(.system(size: codeFontSize - 2))
+                    .foregroundColor(theme.color("fg-dim"))
+                    .lineLimit(1)
+                    .truncationMode(.middle)
+            }
+            Spacer()
+            Text("\(preview.file.status)  +\(preview.file.add) -\(preview.file.del)")
+                .font(.system(size: 11, design: .monospaced))
+                .foregroundColor(theme.color("fg-dim"))
+        }
+        .padding(.horizontal, 16)
+        .padding(.vertical, 8)
+        .background(theme.color("bg-2"))
+        .overlay(Divider().opacity(0.4), alignment: .bottom)
+    }
+
+    @ViewBuilder
+    private var content: some View {
+        let parsed = preview.parsedDiff
+        if parsed.hunks.isEmpty {
+            Text("No changes for \(preview.path)")
+                .foregroundColor(theme.color("fg-dim"))
+                .padding()
+                .frame(maxWidth: .infinity, alignment: .leading)
+        } else {
+            ScrollView(.vertical) {
+                VStack(alignment: .leading, spacing: 0) {
+                    ForEach(Array(parsed.hunks.enumerated()), id: \.offset) { _, hunk in
+                        HunkView(
+                            hunk: hunk,
+                            fileExtension: preview.fileExtension,
+                            codeFontFamily: codeFontFamily,
+                            codeFontSize: codeFontSize
+                        )
+                    }
+                }
+                .padding(.vertical, 8)
+            }
+            .defaultScrollAnchor(.topLeading)
         }
     }
 }

--- a/Alas/Sources/Git/GitService+ReviewRequestDraft.swift
+++ b/Alas/Sources/Git/GitService+ReviewRequestDraft.swift
@@ -2,6 +2,7 @@ import Foundation
 
 struct ReviewRequestDraftContext: Equatable {
     let commitSubjects: [String]
+    let commits: [CommitInfo]
     let changedFiles: [CommitChangedFile]
     let diff: String
     let fileDiffsByPath: [String: String]
@@ -15,16 +16,20 @@ extension GitService {
             ["log", "\(baseRef)..HEAD", "--pretty=format:%s"],
             cwd: worktreePath
         )
+        async let commitsResult = Process.git(
+            ["log", "\(baseRef)..HEAD", "--pretty=tformat:%x1e%H%x1f%h%x1f%an%x1f%aI%x1f%s", "--numstat"],
+            cwd: worktreePath
+        )
         async let diffResult = Process.git(
-            ["diff", "--no-color", "-M", diffRange],
+            ["-c", "core.quotePath=false", "diff", "--no-color", "-M", diffRange],
             cwd: worktreePath
         )
         async let filesResult = Process.git(
-            ["diff", "--no-color", "-M", "--numstat", diffRange],
+            ["-c", "core.quotePath=false", "diff", "--no-color", "-M", "--numstat", diffRange],
             cwd: worktreePath
         )
         async let namesResult = Process.git(
-            ["diff", "--no-color", "-M", "--name-status", diffRange],
+            ["-c", "core.quotePath=false", "diff", "--no-color", "-M", "--name-status", diffRange],
             cwd: worktreePath
         )
         async let statusResult = Process.git(
@@ -33,12 +38,14 @@ extension GitService {
         )
 
         let subjects = try await subjectsResult
+        let commits = try await commitsResult
         let diff = try await diffResult
         let files = try await filesResult
         let names = try await namesResult
         let status = try await statusResult
 
         try Self.assertReviewRequestSuccess(subjects)
+        try Self.assertReviewRequestSuccess(commits)
         try Self.assertReviewRequestSuccess(diff)
         try Self.assertReviewRequestSuccess(files)
         try Self.assertReviewRequestSuccess(names)
@@ -53,6 +60,8 @@ extension GitService {
         for file in changedFiles {
             let fileDiff = try await Process.git(
                 [
+                    "-c",
+                    "core.quotePath=false",
                     "diff",
                     "--no-color",
                     "-M",
@@ -67,6 +76,7 @@ extension GitService {
 
         return ReviewRequestDraftContext(
             commitSubjects: commitSubjects,
+            commits: Self.reviewRequestCommits(log: commits.stdout),
             changedFiles: changedFiles,
             diff: diff.stdout,
             fileDiffsByPath: fileDiffsByPath,
@@ -100,6 +110,51 @@ extension GitService {
                     del: stat.del
                 )
             }
+    }
+
+    private static func reviewRequestCommits(log: String) -> [CommitInfo] {
+        let records = log
+            .split(separator: "\u{1e}", omittingEmptySubsequences: true)
+            .map(String.init)
+        let isoFormatter = ISO8601DateFormatter()
+        isoFormatter.formatOptions = [.withInternetDateTime]
+
+        return records.compactMap { record in
+            let trimmed = record.trimmingCharacters(in: .whitespacesAndNewlines)
+            guard !trimmed.isEmpty else { return nil }
+            let lines = trimmed.split(separator: "\n", omittingEmptySubsequences: false)
+            guard let headerLine = lines.first else { return nil }
+            let fields = headerLine.split(separator: "\u{1f}", maxSplits: 4, omittingEmptySubsequences: false)
+            guard fields.count == 5 else { return nil }
+
+            let rawSubject = String(fields[4])
+            let (tag, subject) = CommitInfo.parseConventional(subject: rawSubject)
+            var filesChanged = 0
+            var additions = 0
+            var deletions = 0
+            for line in lines.dropFirst() {
+                let trimmedLine = line.trimmingCharacters(in: .whitespaces)
+                if trimmedLine.isEmpty { continue }
+                let parts = trimmedLine.split(separator: "\t", omittingEmptySubsequences: false)
+                guard parts.count >= 3 else { continue }
+                filesChanged += 1
+                if let add = Int(parts[0]) { additions += add }
+                if let del = Int(parts[1]) { deletions += del }
+            }
+
+            return CommitInfo(
+                sha: String(fields[0]),
+                shortSha: String(fields[1]),
+                author: String(fields[2]),
+                authorInitials: CommitInfo.initials(for: String(fields[2])),
+                date: isoFormatter.date(from: String(fields[3])) ?? Date(timeIntervalSince1970: 0),
+                subject: subject,
+                conventionalTag: tag,
+                filesChanged: filesChanged,
+                insertions: additions,
+                deletions: deletions
+            )
+        }
     }
 }
 

--- a/AlasTests/GitServiceReviewRequestDraftTests.swift
+++ b/AlasTests/GitServiceReviewRequestDraftTests.swift
@@ -26,6 +26,13 @@ struct GitServiceReviewRequestDraftTests {
         )
 
         #expect(context.commitSubjects == ["feat: add committed file"])
+        #expect(context.commits.count == 1)
+        #expect(context.commits[0].subject == "add committed file")
+        #expect(context.commits[0].conventionalTag == "feat")
+        #expect(context.commits[0].author == "Test User")
+        #expect(context.commits[0].filesChanged == 1)
+        #expect(context.commits[0].insertions == 1)
+        #expect(context.commits[0].deletions == 0)
         #expect(context.changedFiles.map(\.path) == ["Sources/A.swift"])
         #expect(context.diff.contains("Sources/A.swift"))
         #expect(context.fileDiffsByPath["Sources/A.swift"]?.contains("Sources/A.swift") == true)
@@ -62,6 +69,31 @@ struct GitServiceReviewRequestDraftTests {
         #expect(!aDiff.contains("Sources/B.swift"))
         #expect(bDiff.contains("Sources/B.swift"))
         #expect(!bDiff.contains("Sources/A.swift"))
+    }
+
+    @Test func loadsDiffForNonASCIIChangedFile() async throws {
+        let repo = try makeRepo()
+        defer { try? FileManager.default.removeItem(at: repo) }
+
+        try await git(["init", "-b", "main"], cwd: repo)
+        try await git(["config", "user.email", "test@example.com"], cwd: repo)
+        try await git(["config", "user.name", "Test User"], cwd: repo)
+        try write("README.md", "Initial\n", in: repo)
+        try await git(["add", "README.md"], cwd: repo)
+        try await git(["commit", "-m", "chore: initial"], cwd: repo)
+        try await git(["checkout", "-b", "feature/unicode-path"], cwd: repo)
+        try write("Sources/Café.swift", "let café = 1\n", in: repo)
+        try await git(["add", "Sources/Café.swift"], cwd: repo)
+        try await git(["commit", "-m", "feat: add unicode path"], cwd: repo)
+
+        let context = try await GitService().reviewRequestDraftContext(
+            worktreePath: repo,
+            baseRef: "main"
+        )
+
+        #expect(context.changedFiles.map(\.path) == ["Sources/Café.swift"])
+        #expect(context.diff.contains("Sources/Café.swift"))
+        #expect(context.fileDiffsByPath["Sources/Café.swift"]?.contains("let café = 1") == true)
     }
 
     @Test func loadsBranchDiffFromMergeBaseWhenBaseBranchHasAdvanced() async throws {

--- a/AlasTests/Integrations/ReviewRequestDraftTests.swift
+++ b/AlasTests/Integrations/ReviewRequestDraftTests.swift
@@ -3,6 +3,29 @@ import Testing
 @testable import Alas
 
 struct ReviewRequestDraftTests {
+    @Test func parsesSelectedFileDiffPreviewIntoHunks() {
+        let raw = """
+        diff --git a/Sources/A.swift b/Sources/A.swift
+        index 1111111..2222222 100644
+        --- a/Sources/A.swift
+        +++ b/Sources/A.swift
+        @@ -1,1 +1,1 @@
+        -let value = 1
+        +let value = 2
+        """
+
+        let preview = DraftReviewRequestDiffPreview(
+            path: "Sources/A.swift",
+            file: CommitChangedFile(path: "Sources/A.swift", originalPath: nil, status: "M", add: 1, del: 1),
+            rawDiff: raw
+        )
+
+        #expect(preview.parsedDiff.hunks.count == 1)
+        #expect(preview.fileExtension == "swift")
+        #expect(preview.title == "A.swift")
+        #expect(preview.directory == "Sources")
+    }
+
     @Test func parsesGeneratedTitleAndBody() throws {
         let parsed = try ReviewRequestDraft.parseGeneratedMessage("""
         Add review request drafts


### PR DESCRIPTION
## Summary
- Reuse the shared commit message editor for draft GitHub/GitLab review request title and body editing.
- Render selected draft review request file diffs through the existing parsed hunk UI with language-aware highlighting.
- Show draft review request commits with the same commit row treatment used elsewhere, backed by richer commit metadata.

## Testing
- `xcodegen`
- `xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -quiet build`
- `xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -only-testing:AlasTests/GitServiceReviewRequestDraftTests -only-testing:AlasTests/ReviewRequestDraftTests test`

Note: a local full `xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' test` run was interrupted after sitting silent for several minutes in the `ACP terminal routing` suite.