### PR TITLE
Route review handoffs to empty ACP chats

### DIFF
--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -667,6 +667,7 @@
 		B79D01EECD92181B710D2648 /* CommitInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C01FBF2EE3668E6772CEB1D /* CommitInfo.swift */; };
 		B7D79703ABCAFBC04A0091E5 /* VisualEffectView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D97EF761C70A3AF83C00879A /* VisualEffectView.swift */; };
 		B7F78A0034B7EC38072C1116 /* AlasGhosttySmokeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 69CE1F098A251F24BC352816 /* AlasGhosttySmokeTests.swift */; };
+		B82F5295F500E46C381A8D52 /* ReviewLoopHandoffRoutingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 694DDEC8133EFBC33822BC26 /* ReviewLoopHandoffRoutingTests.swift */; };
 		B834ADF0BB988121361AF334 /* tool-call-content-blocks.json in Resources */ = {isa = PBXBuildFile; fileRef = F0641A41FC56C8F251D0C2BC /* tool-call-content-blocks.json */; };
 		B83DBBA1D5090E5E757B01F5 /* CloseTabConfirmationPolicyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5337D60F19641CF933A1F855 /* CloseTabConfirmationPolicyTests.swift */; };
 		B8412B44C090B4AA6A892D25 /* ACPMessages.swift in Sources */ = {isa = PBXBuildFile; fileRef = D46B68FD01B15E3EEA09CB79 /* ACPMessages.swift */; };
@@ -1317,6 +1318,7 @@
 		6821B71680094791995C4975 /* ShortcutsPane.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShortcutsPane.swift; sourceTree = "<group>"; };
 		68B6937D50514C34A2C14BE1 /* TerminalServiceZmxTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TerminalServiceZmxTests.swift; sourceTree = "<group>"; };
 		69024633944E9FFF6DA76FAE /* RootView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RootView.swift; sourceTree = "<group>"; };
+		694DDEC8133EFBC33822BC26 /* ReviewLoopHandoffRoutingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReviewLoopHandoffRoutingTests.swift; sourceTree = "<group>"; };
 		695C887147631ACF1FA73C3F /* MergeView3Way.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MergeView3Way.swift; sourceTree = "<group>"; };
 		69B7FA3997B6A60397B56CD4 /* MergeConflictBinaryView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MergeConflictBinaryView.swift; sourceTree = "<group>"; };
 		69CE1F098A251F24BC352816 /* AlasGhosttySmokeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlasGhosttySmokeTests.swift; sourceTree = "<group>"; };
@@ -2141,6 +2143,7 @@
 				01675626CE431DD5867636BF /* RepoGroupViewLayoutTests.swift */,
 				220514C66CF29B6FD04EAB0B /* RepoSelectorModelTests.swift */,
 				784A5C206CA363AB14B709E6 /* RepoSelectorRecentsTests.swift */,
+				694DDEC8133EFBC33822BC26 /* ReviewLoopHandoffRoutingTests.swift */,
 				54635D583B6B308B75ABCE63 /* RightPaneSelectionStateResolverTests.swift */,
 				6713F5A8712C0962BED1EFEA /* RightPaneStateBaseBranchTests.swift */,
 				4973BDD06953B7A1EB9A7A66 /* RightPaneStateDiscardPathsTests.swift */,
@@ -4501,6 +4504,7 @@
 				35705563BBEDDC1D0092C1F5 /* RepoSelectorRecentsTests.swift in Sources */,
 				9409E946054E7D837A479137 /* ReviewLoopDrawerTests.swift in Sources */,
 				096304FB0EA9B5EC04D76C49 /* ReviewLoopHandoffBuilderTests.swift in Sources */,
+				B82F5295F500E46C381A8D52 /* ReviewLoopHandoffRoutingTests.swift in Sources */,
 				9654335704CB69BA7216DD63 /* ReviewLoopStateTests.swift in Sources */,
 				D8957FC6D928555E7C360B6E /* ReviewReadinessModelTests.swift in Sources */,
 				518D1D069F821B232469C414 /* ReviewRequestContextBuilderTests.swift in Sources */,

--- a/Alas/Sources/App/AppState.swift
+++ b/Alas/Sources/App/AppState.swift
@@ -3040,7 +3040,8 @@ final class AppState {
 
         if case .acpSession(let tabState) = tabs.activeTab(forWorktree: worktree.id),
            let session = manager.placeholderSession(id: tabState.sessionId),
-           !session.composerDraft.hasContent {
+           session.hydrationState == .ready,
+           session.composerDraft.isEmpty {
             manager.persistComposerDraft(
                 ACPComposerDraft(segments: [.text(initialPrompt)]),
                 for: session

--- a/Alas/Sources/App/AppState.swift
+++ b/Alas/Sources/App/AppState.swift
@@ -3026,6 +3026,32 @@ final class AppState {
         tabs.append(acpSession: state, to: worktree.id)
     }
 
+    /// Route a prepared handoff into the active ACP tab when its composer is
+    /// safely empty; otherwise preserve the current draft and open a new tab.
+    func openACPHandoff(agentID: String, initialPrompt: String) {
+        guard !initialPrompt.isEmpty else {
+            openNewACPSession(agentID: agentID, initialPrompt: nil)
+            return
+        }
+        guard let worktreeId = selectedWorktreeId,
+              let worktree = worktree(withId: worktreeId),
+              let manager = acpManager(for: worktree)
+        else { return }
+
+        if case .acpSession(let tabState) = tabs.activeTab(forWorktree: worktree.id),
+           let session = manager.placeholderSession(id: tabState.sessionId),
+           !session.composerDraft.hasContent {
+            manager.persistComposerDraft(
+                ACPComposerDraft(segments: [.text(initialPrompt)]),
+                for: session
+            )
+            tabs.activate(worktreeId: worktree.id, tabId: tabState.id)
+            return
+        }
+
+        openNewACPSession(agentID: agentID, initialPrompt: initialPrompt)
+    }
+
     func openReviewLoopHandoff(from reviewLoop: ReviewLoopState, actionKind: ReviewReadinessActionKind) {
         guard let snapshot = reviewLoop.snapshot else { return }
         guard actionKind == .openAgentHandoff else { return }
@@ -3039,7 +3065,7 @@ final class AppState {
                 detail: "Prepare a focused agent handoff."
             )
         )
-        openNewACPSession(agentID: agentID, initialPrompt: prompt)
+        openACPHandoff(agentID: agentID, initialPrompt: prompt)
     }
 
     nonisolated static func reviewLoopHandoffActionKind(for request: ReviewRequest?) -> ReviewLoopActionKind {

--- a/Alas/Sources/App/AppState.swift
+++ b/Alas/Sources/App/AppState.swift
@@ -3041,6 +3041,7 @@ final class AppState {
         if case .acpSession(let tabState) = tabs.activeTab(forWorktree: worktree.id),
            let session = manager.placeholderSession(id: tabState.sessionId),
            session.agentId == agentID,
+           !manager.isMirror(sessionId: tabState.sessionId),
            session.hydrationState == .ready,
            session.transcript.messages.isEmpty,
            session.queue.isEmpty,

--- a/Alas/Sources/App/AppState.swift
+++ b/Alas/Sources/App/AppState.swift
@@ -3040,7 +3040,10 @@ final class AppState {
 
         if case .acpSession(let tabState) = tabs.activeTab(forWorktree: worktree.id),
            let session = manager.placeholderSession(id: tabState.sessionId),
+           session.agentId == agentID,
            session.hydrationState == .ready,
+           session.transcript.messages.isEmpty,
+           session.queue.isEmpty,
            session.composerDraft.isEmpty {
             manager.persistComposerDraft(
                 ACPComposerDraft(segments: [.text(initialPrompt)]),

--- a/AlasTests/ReviewLoopHandoffRoutingTests.swift
+++ b/AlasTests/ReviewLoopHandoffRoutingTests.swift
@@ -58,6 +58,51 @@ struct ReviewLoopHandoffRoutingTests {
         #expect(state.tabs.activeTabId(forWorktree: worktreeId) == newTab.id)
     }
 
+    @Test func handoffOpensNewACPChatWhenActiveComposerHasWhitespaceOnlyText() throws {
+        let state = makeState()
+        state.openNewACPSession(agentID: "test-agent")
+        let existing = try #require(acpTabs(in: state).first)
+        let worktreeId = try #require(state.selectedWorktreeId)
+        let manager = try #require(state.acpManager(forWorktreeId: worktreeId))
+        let existingSession = try #require(manager.placeholderSession(id: existing.sessionId))
+        let whitespaceDraft = ACPComposerDraft(segments: [.text(" \n\t")])
+        manager.persistComposerDraft(whitespaceDraft, for: existingSession)
+
+        state.openACPHandoff(agentID: "test-agent", initialPrompt: "Review feedback")
+
+        let tabs = acpTabs(in: state)
+        #expect(tabs.count == 2)
+        #expect(sessionFor(tab: existing, in: state)?.composerDraft == whitespaceDraft)
+        let newTab = try #require(tabs.last)
+        #expect(newTab.id != existing.id)
+        #expect(sessionFor(tab: newTab, in: state)?.composerDraft == ACPComposerDraft(segments: [.text("Review feedback")]))
+        #expect(state.tabs.activeTabId(forWorktree: worktreeId) == newTab.id)
+    }
+
+    @Test func handoffOpensNewACPChatWhenActiveRestoredSessionHasNotHydrated() async throws {
+        let state = makeState()
+        let worktreeId = try #require(state.selectedWorktreeId)
+        let restoredSessionId = "restored-\(UUID().uuidString)"
+        let persistedDraft = ACPComposerDraft(segments: [.text("Persisted draft")])
+        try seedPersistedSession(id: restoredSessionId, worktreeId: worktreeId, draft: persistedDraft)
+        let existing = ACPSessionTabState(sessionId: restoredSessionId, title: "Restored")
+        state.tabs.append(acpSession: existing, to: worktreeId)
+
+        state.openACPHandoff(agentID: "test-agent", initialPrompt: "Review feedback")
+
+        let tabs = acpTabs(in: state)
+        #expect(tabs.count == 2)
+        let manager = try #require(state.acpManager(forWorktreeId: worktreeId))
+        let restoredSession = try #require(manager.placeholderSession(id: restoredSessionId))
+        #expect(restoredSession.hydrationState == .loading)
+        let newTab = try #require(tabs.last)
+        #expect(newTab.id != existing.id)
+        #expect(sessionFor(tab: newTab, in: state)?.composerDraft == ACPComposerDraft(segments: [.text("Review feedback")]))
+
+        await manager.hydrateIfNeeded(id: restoredSessionId)
+        #expect(restoredSession.composerDraft == persistedDraft)
+    }
+
     @Test func handoffOpensNewACPChatWhenNoActiveACPChatExists() throws {
         let state = makeState()
 
@@ -124,5 +169,28 @@ struct ReviewLoopHandoffRoutingTests {
     private func sessionFor(tab: ACPSessionTabState, in state: AppState) -> ACPSession? {
         guard let worktreeId = state.selectedWorktreeId else { return nil }
         return state.acpManager(forWorktreeId: worktreeId)?.placeholderSession(id: tab.sessionId)
+    }
+
+    private func seedPersistedSession(id: String, worktreeId: String, draft: ACPComposerDraft) throws {
+        let storeURL = Paths.acpSessionsDB(forWorktreeId: worktreeId)
+        try? FileManager.default.removeItem(at: storeURL)
+        try FileManager.default.createDirectory(
+            at: storeURL.deletingLastPathComponent(),
+            withIntermediateDirectories: true
+        )
+        let store = try ACPSessionStore(path: storeURL.path)
+        try store.upsertSession(.init(
+            id: id,
+            agentId: "test-agent",
+            title: "Restored",
+            currentModel: nil,
+            currentMode: nil,
+            autoRun: false,
+            createdAt: 0,
+            updatedAt: 0,
+            lastOpenedAt: 0,
+            archived: false
+        ))
+        try store.upsertComposerDraft(sessionId: id, draft: draft, updatedAt: 1)
     }
 }

--- a/AlasTests/ReviewLoopHandoffRoutingTests.swift
+++ b/AlasTests/ReviewLoopHandoffRoutingTests.swift
@@ -103,6 +103,65 @@ struct ReviewLoopHandoffRoutingTests {
         #expect(restoredSession.composerDraft == persistedDraft)
     }
 
+    @Test func handoffOpensNewACPChatWhenActiveSessionHasTranscriptHistory() throws {
+        let state = makeState()
+        state.openNewACPSession(agentID: "test-agent")
+        let existing = try #require(acpTabs(in: state).first)
+        let worktreeId = try #require(state.selectedWorktreeId)
+        let manager = try #require(state.acpManager(forWorktreeId: worktreeId))
+        let existingSession = try #require(manager.placeholderSession(id: existing.sessionId))
+        existingSession.recordUserPrompt(text: "Previous prompt", attachments: [])
+
+        state.openACPHandoff(agentID: "test-agent", initialPrompt: "Review feedback")
+
+        let tabs = acpTabs(in: state)
+        #expect(tabs.count == 2)
+        #expect(sessionFor(tab: existing, in: state)?.transcript.messages.count == 1)
+        let newTab = try #require(tabs.last)
+        #expect(newTab.id != existing.id)
+        #expect(sessionFor(tab: newTab, in: state)?.composerDraft == ACPComposerDraft(segments: [.text("Review feedback")]))
+        #expect(state.tabs.activeTabId(forWorktree: worktreeId) == newTab.id)
+    }
+
+    @Test func handoffOpensNewACPChatWhenActiveSessionHasQueuedPrompt() throws {
+        let state = makeState()
+        state.openNewACPSession(agentID: "test-agent")
+        let existing = try #require(acpTabs(in: state).first)
+        let worktreeId = try #require(state.selectedWorktreeId)
+        let manager = try #require(state.acpManager(forWorktreeId: worktreeId))
+        let existingSession = try #require(manager.placeholderSession(id: existing.sessionId))
+        existingSession.enqueue(blocks: [.text("Queued prompt")])
+
+        state.openACPHandoff(agentID: "test-agent", initialPrompt: "Review feedback")
+
+        let tabs = acpTabs(in: state)
+        #expect(tabs.count == 2)
+        #expect(sessionFor(tab: existing, in: state)?.queue.count == 1)
+        let newTab = try #require(tabs.last)
+        #expect(newTab.id != existing.id)
+        #expect(sessionFor(tab: newTab, in: state)?.composerDraft == ACPComposerDraft(segments: [.text("Review feedback")]))
+        #expect(state.tabs.activeTabId(forWorktree: worktreeId) == newTab.id)
+    }
+
+    @Test func handoffOpensNewACPChatWhenActiveSessionUsesDifferentAgent() throws {
+        let state = makeState()
+        state.openNewACPSession(agentID: "other-agent")
+        let existing = try #require(acpTabs(in: state).first)
+        let worktreeId = try #require(state.selectedWorktreeId)
+
+        state.openACPHandoff(agentID: "test-agent", initialPrompt: "Review feedback")
+
+        let tabs = acpTabs(in: state)
+        #expect(tabs.count == 2)
+        #expect(sessionFor(tab: existing, in: state)?.composerDraft == .empty)
+        let newTab = try #require(tabs.last)
+        #expect(newTab.id != existing.id)
+        let newSession = try #require(sessionFor(tab: newTab, in: state))
+        #expect(newSession.agentId == "test-agent")
+        #expect(newSession.composerDraft == ACPComposerDraft(segments: [.text("Review feedback")]))
+        #expect(state.tabs.activeTabId(forWorktree: worktreeId) == newTab.id)
+    }
+
     @Test func handoffOpensNewACPChatWhenNoActiveACPChatExists() throws {
         let state = makeState()
 
@@ -150,8 +209,20 @@ struct ReviewLoopHandoffRoutingTests {
                     isEnabled: true,
                     builtinLogoAssetName: nil
                 ),
+                AgentDefinition(
+                    id: "other-agent",
+                    displayName: "Other Agent",
+                    binary: "other-agent",
+                    binaryOverride: nil,
+                    promptModeArgs: [],
+                    bypassPermissionsFlag: nil,
+                    extraTerminalArgs: nil,
+                    isBuiltin: false,
+                    isEnabled: true,
+                    builtinLogoAssetName: nil
+                ),
             ],
-            installedIds: ["test-agent"]
+            installedIds: ["test-agent", "other-agent"]
         )
         return state
     }

--- a/AlasTests/ReviewLoopHandoffRoutingTests.swift
+++ b/AlasTests/ReviewLoopHandoffRoutingTests.swift
@@ -162,6 +162,35 @@ struct ReviewLoopHandoffRoutingTests {
         #expect(state.tabs.activeTabId(forWorktree: worktreeId) == newTab.id)
     }
 
+    @Test func handoffOpensNewACPChatWhenActiveSessionIsMirror() throws {
+        let state = makeState()
+        state.openNewACPSession(agentID: "test-agent")
+        let existing = try #require(acpTabs(in: state).first)
+        let worktreeId = try #require(state.selectedWorktreeId)
+        let manager = try #require(state.acpManager(forWorktreeId: worktreeId))
+        let mirrorOwner = ACPSessionManager(
+            worktreeId: worktreeId,
+            worktreePath: "/tmp/mirror-owner",
+            store: try ACPSessionStore(path: Paths.acpSessionsDB(forWorktreeId: worktreeId).path),
+            instanceId: "mirror-owner",
+            pid: Int64(getpid())
+        )
+        #expect(mirrorOwner.acquireWriterLease(sessionId: existing.sessionId))
+        #expect(manager.isMirror(sessionId: existing.sessionId))
+
+        state.openACPHandoff(agentID: "test-agent", initialPrompt: "Review feedback")
+
+        let tabs = acpTabs(in: state)
+        #expect(tabs.count == 2)
+        #expect(sessionFor(tab: existing, in: state)?.composerDraft == .empty)
+        let newTab = try #require(tabs.last)
+        #expect(newTab.id != existing.id)
+        #expect(sessionFor(tab: newTab, in: state)?.composerDraft == ACPComposerDraft(segments: [.text("Review feedback")]))
+        #expect(state.tabs.activeTabId(forWorktree: worktreeId) == newTab.id)
+
+        mirrorOwner.releaseWriterLease(sessionId: existing.sessionId)
+    }
+
     @Test func handoffOpensNewACPChatWhenNoActiveACPChatExists() throws {
         let state = makeState()
 

--- a/AlasTests/ReviewLoopHandoffRoutingTests.swift
+++ b/AlasTests/ReviewLoopHandoffRoutingTests.swift
@@ -1,0 +1,128 @@
+import Foundation
+import Testing
+@testable import Alas
+
+@MainActor
+@Suite(.serialized)
+struct ReviewLoopHandoffRoutingTests {
+    private struct MemoryStore: PersistenceStoreProtocol {
+        let projectsFile: ProjectsFile
+
+        func write<T: Encodable>(_: T, to _: URL) throws {}
+
+        func readIfExists<T: Decodable>(_ type: T.Type, from _: URL) throws -> T? {
+            if type == ProjectsFile.self {
+                return projectsFile as? T
+            }
+            if type == AppConfig.self {
+                return AppConfig.defaults as? T
+            }
+            return nil
+        }
+    }
+
+    @Test func handoffReusesActiveACPChatWithEmptyComposer() throws {
+        let state = makeState()
+        state.openNewACPSession(agentID: "test-agent")
+        let initialTabs = acpTabs(in: state)
+        let existing = try #require(initialTabs.first)
+
+        state.openACPHandoff(agentID: "test-agent", initialPrompt: "Review feedback")
+
+        let tabs = acpTabs(in: state)
+        #expect(tabs.count == 1)
+        #expect(tabs.first?.id == existing.id)
+        let session = try #require(sessionFor(tab: existing, in: state))
+        #expect(session.composerDraft == ACPComposerDraft(segments: [.text("Review feedback")]))
+        let worktreeId = try #require(state.selectedWorktreeId)
+        #expect(state.tabs.activeTabId(forWorktree: worktreeId) == existing.id)
+    }
+
+    @Test func handoffOpensNewACPChatWhenActiveComposerHasText() throws {
+        let state = makeState()
+        state.openNewACPSession(agentID: "test-agent")
+        let existing = try #require(acpTabs(in: state).first)
+        let worktreeId = try #require(state.selectedWorktreeId)
+        let manager = try #require(state.acpManager(forWorktreeId: worktreeId))
+        let existingSession = try #require(manager.placeholderSession(id: existing.sessionId))
+        manager.persistComposerDraft(ACPComposerDraft(segments: [.text("Existing draft")]), for: existingSession)
+
+        state.openACPHandoff(agentID: "test-agent", initialPrompt: "Review feedback")
+
+        let tabs = acpTabs(in: state)
+        #expect(tabs.count == 2)
+        #expect(sessionFor(tab: existing, in: state)?.composerDraft == ACPComposerDraft(segments: [.text("Existing draft")]))
+        let newTab = try #require(tabs.last)
+        #expect(newTab.id != existing.id)
+        #expect(sessionFor(tab: newTab, in: state)?.composerDraft == ACPComposerDraft(segments: [.text("Review feedback")]))
+        #expect(state.tabs.activeTabId(forWorktree: worktreeId) == newTab.id)
+    }
+
+    @Test func handoffOpensNewACPChatWhenNoActiveACPChatExists() throws {
+        let state = makeState()
+
+        state.openACPHandoff(agentID: "test-agent", initialPrompt: "Review feedback")
+
+        let tabs = acpTabs(in: state)
+        let newTab = try #require(tabs.first)
+        #expect(tabs.count == 1)
+        #expect(sessionFor(tab: newTab, in: state)?.composerDraft == ACPComposerDraft(segments: [.text("Review feedback")]))
+    }
+
+    private func makeState() -> AppState {
+        let project = ProjectConfig(
+            id: UUID().uuidString,
+            name: "Project",
+            path: "/tmp/project-\(UUID().uuidString)",
+            color: "blue",
+            addedAt: Date()
+        )
+        let state = AppState(store: MemoryStore(projectsFile: ProjectsFile(projects: [project])))
+        let worktree = Worktree(
+            id: UUID().uuidString,
+            projectId: project.id,
+            name: "main",
+            branch: "main",
+            path: URL(fileURLWithPath: project.path),
+            status: .clean,
+            lastActivity: Date()
+        )
+        state.projectsManager.insertOptimisticWorktree(worktree)
+        state.selectedWorktreeId = worktree.id
+        state.config.changes.aiToolId = "test-agent"
+        state.agentRegistry = AgentRegistry(
+            builtinState: [:],
+            customs: [
+                AgentDefinition(
+                    id: "test-agent",
+                    displayName: "Test Agent",
+                    binary: "test-agent",
+                    binaryOverride: nil,
+                    promptModeArgs: [],
+                    bypassPermissionsFlag: nil,
+                    extraTerminalArgs: nil,
+                    isBuiltin: false,
+                    isEnabled: true,
+                    builtinLogoAssetName: nil
+                ),
+            ],
+            installedIds: ["test-agent"]
+        )
+        return state
+    }
+
+    private func acpTabs(in state: AppState) -> [ACPSessionTabState] {
+        guard let worktreeId = state.selectedWorktreeId else { return [] }
+        return state.tabs.tabs(forWorktree: worktreeId).compactMap { tab in
+            if case .acpSession(let tabState) = tab {
+                return tabState
+            }
+            return nil
+        }
+    }
+
+    private func sessionFor(tab: ACPSessionTabState, in state: AppState) -> ACPSession? {
+        guard let worktreeId = state.selectedWorktreeId else { return nil }
+        return state.acpManager(forWorktreeId: worktreeId)?.placeholderSession(id: tab.sessionId)
+    }
+}


### PR DESCRIPTION
## Summary
- route review handoff prompts into the active ACP chat when it is already hydrated and structurally empty
- preserve existing composer drafts, including whitespace-only drafts and unhydrated restored sessions, by opening a new ACP pane instead
- add routing regression coverage for safe reuse and fallback cases

## Validation
- xcodegen
- xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -quiet build
- xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -only-testing:AlasTests/ReviewLoopHandoffRoutingTests test

Full xcodebuild test was started but stayed silent for several minutes and was interrupted after no result output.