### PR TITLE
feat(github/gitlab): add review evidence inspector tab

### DIFF
--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -42,7 +42,6 @@
 		095A19B85DFA5EBA5A24786D /* AdvancedPane.swift in Sources */ = {isa = PBXBuildFile; fileRef = E16C4F54FB3E390F80208DA1 /* AdvancedPane.swift */; };
 		095E7D98616FB77A9F8BDFD9 /* ACPSessionManagerRetentionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6D1AAAE396590865426C592A /* ACPSessionManagerRetentionTests.swift */; };
 		096304FB0EA9B5EC04D76C49 /* ReviewLoopHandoffBuilderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4EC688020FD7B6A2A4393B72 /* ReviewLoopHandoffBuilderTests.swift */; };
-		0A8F6C41A4B5609E30D9C2A1 /* ReviewEvidenceModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A8F6C40A4B5609E30D9C2A1 /* ReviewEvidenceModel.swift */; };
 		0A480D9D7CE5BB837D7BCA13 /* GitService+Staging.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2F90D03073708AA01531533 /* GitService+Staging.swift */; };
 		0B11B8038CBA3A6F05E34895 /* GatekeeperAssessorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 137E9C84D7F32E747F0AF4C0 /* GatekeeperAssessorTests.swift */; };
 		0B6ADBF320E6130E5888CAA7 /* RemoteSessionGatewayTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37011506F459800FFF6D12A9 /* RemoteSessionGatewayTests.swift */; };
@@ -495,6 +494,7 @@
 		859AD39BA8D5A9FCC905648D /* ImageDiffViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 120D10644A278775A9AE1990 /* ImageDiffViewTests.swift */; };
 		85C7E65296AB9500FF52060A /* session-update-plan.json in Resources */ = {isa = PBXBuildFile; fileRef = 7094534860369BA79FC5A877 /* session-update-plan.json */; };
 		85EAA2D64D794E045BDF7532 /* MergeAgentTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C14BF0C745544F99CB3C6006 /* MergeAgentTests.swift */; };
+		8617CC447747E25550D93CFF /* ReviewEvidenceTabView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A043EA16DB135402FCA1E892 /* ReviewEvidenceTabView.swift */; };
 		864B31874E286ED036347975 /* ACPLaunchSpecNpmPackageTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6BDB3231FFACC0398F973876 /* ACPLaunchSpecNpmPackageTests.swift */; };
 		86718F7E55531B8E4356D7D1 /* PaneTree.swift in Sources */ = {isa = PBXBuildFile; fileRef = A2943FBB1D6371EFAC9BBE68 /* PaneTree.swift */; };
 		86759BF3DE64FFAA4FE98822 /* ACPPromptCapabilitiesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C2D7EA3F2B69C0A8D2F8F8A5 /* ACPPromptCapabilitiesTests.swift */; };
@@ -600,7 +600,6 @@
 		A03338AC85E6EC8201D56F95 /* TreeSitterGo in Frameworks */ = {isa = PBXBuildFile; productRef = DB0D87DDDAD70492540E6906 /* TreeSitterGo */; };
 		A050BAECF89694B0D613C5D2 /* EditorBuffer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 64E96E26D5F53F217BFD1F49 /* EditorBuffer.swift */; };
 		A05391FF4907AB0870A79C02 /* ReviewEvidenceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4B05E0E44B026AE7E8EA3101 /* ReviewEvidenceTests.swift */; };
-		A08F6C41A4B5609E30D9C2B2 /* ReviewEvidenceModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A08F6C40A4B5609E30D9C2B2 /* ReviewEvidenceModelTests.swift */; };
 		A0B5074B10E732616C917D10 /* DragHandleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1379AD82025AFEABD37EFC42 /* DragHandleTests.swift */; };
 		A0F1E46BC1A9E2CC21805EE7 /* FilesTabFilterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1977C85C3DFD1F232A2755AD /* FilesTabFilterTests.swift */; };
 		A15C8E0D7A942160A74BD68E /* ImageDiffPairResolver.swift in Sources */ = {isa = PBXBuildFile; fileRef = D568D53950A3CA2CD1F4EECB /* ImageDiffPairResolver.swift */; };
@@ -788,11 +787,13 @@
 		CF3567FA9501C1358D754D42 /* BlockedLanguageServerNudgeResolverTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D081C8802733D2532DBCD74D /* BlockedLanguageServerNudgeResolverTests.swift */; };
 		CF6CC4CD0C7841CA79DB0E4E /* ACPPlanPillState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CDDDC4C6146165CA4C7474E /* ACPPlanPillState.swift */; };
 		CF81F0AE28C56D1DF5AD871B /* SurfaceViewShortcutTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2935EB661338757C478CD86 /* SurfaceViewShortcutTests.swift */; };
+		CFBCD5E3D345BCA65888E7BB /* TabsManagerReviewEvidenceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 75610F1E65DB417E5240D649 /* TabsManagerReviewEvidenceTests.swift */; };
 		D002012348D4DA7E124632BF /* SpacePagerIndicator.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9294E94F46763CC8DCD93A3 /* SpacePagerIndicator.swift */; };
 		D05BDEF0D8651A9C2BD8C857 /* Seg.swift in Sources */ = {isa = PBXBuildFile; fileRef = 489C9B383554D7DAB170C2F8 /* Seg.swift */; };
 		D0F4A4F5BF5F1C3C625F11D9 /* Clipboard.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0E6600436B01C75D85C01FFA /* Clipboard.swift */; };
 		D10A8F47A537C1C8969752B1 /* ACPMessageTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8A0A083659269CDD16A6764 /* ACPMessageTests.swift */; };
 		D13AFC98364971915782491C /* ProjectConfigTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B3FF64CC698074BFDE2A36A /* ProjectConfigTests.swift */; };
+		D1B12A9BA62CBB99E0DB1E28 /* ReviewEvidenceModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0FBEABA73057C9F165A66CD /* ReviewEvidenceModelTests.swift */; };
 		D1C14B54BE27D97E354F448B /* ProcessGitDataTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF741B889D6DC8B1F4EB350F /* ProcessGitDataTests.swift */; };
 		D1F372532A0F9607051020F5 /* HarnessDetectorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F198697EB5305E5ECE97BC61 /* HarnessDetectorTests.swift */; };
 		D1FF11465D1309A56FCFFAF0 /* AppConfigCodeInstallTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8ACFACD788DF2035534F62E /* AppConfigCodeInstallTests.swift */; };
@@ -846,6 +847,7 @@
 		DEBB0627BD0426369D18CAD4 /* FileSearchDialog.swift in Sources */ = {isa = PBXBuildFile; fileRef = F97EB3FA3E3C1206D76A9668 /* FileSearchDialog.swift */; };
 		DEC1744FA9C8A26294FF0671 /* CompletionEngineTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E0CD4F3AC6DD83BC45459475 /* CompletionEngineTests.swift */; };
 		DF8CAD5714483408B8BD72F7 /* GitService+Discard.swift in Sources */ = {isa = PBXBuildFile; fileRef = 90817EC3BAA727EF6D9FBD97 /* GitService+Discard.swift */; };
+		DF93C8550C7A78C2A03CF56A /* ReviewEvidenceModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7FF257B37B6E9EA4D97C67D4 /* ReviewEvidenceModel.swift */; };
 		E0AA2F46C6E53C547FEB6495 /* ClaudeCodeACPInstallerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4B2FAABB50C8BE2321A1B1DD /* ClaudeCodeACPInstallerTests.swift */; };
 		E175AE346DFAD0B62827C921 /* ProjectPicker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3CE948F94DB2759E66CD4DEF /* ProjectPicker.swift */; };
 		E1DA1C6BF9D5E157DAF6EE00 /* ClaudeInstallerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6016A3CF87F34222C533D350 /* ClaudeInstallerTests.swift */; };
@@ -1008,7 +1010,6 @@
 		09246CDA0F77D86F05727407 /* ShellEnvResolverTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShellEnvResolverTests.swift; sourceTree = "<group>"; };
 		0934F7BB22E33263B63925B7 /* ImageDiffPair.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageDiffPair.swift; sourceTree = "<group>"; };
 		09D238B1262EB2BC6AFCF621 /* LanguageServerRegistry.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LanguageServerRegistry.swift; sourceTree = "<group>"; };
-		0A8F6C40A4B5609E30D9C2A1 /* ReviewEvidenceModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReviewEvidenceModel.swift; sourceTree = "<group>"; };
 		0A216C9D856D2A6C43964E74 /* AppConfigHarnessTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppConfigHarnessTests.swift; sourceTree = "<group>"; };
 		0A442AC7909A919582DF4372 /* SQLiteStatement.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SQLiteStatement.swift; sourceTree = "<group>"; };
 		0AAF2B901624C0629A1E3357 /* RightPaneStateUnstagePathsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RightPaneStateUnstagePathsTests.swift; sourceTree = "<group>"; };
@@ -1254,7 +1255,6 @@
 		4A777C0D1DB412458D46A628 /* TerminalCLIInjectionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TerminalCLIInjectionTests.swift; sourceTree = "<group>"; };
 		4AED8A6EE8EF0CC317D7A4C7 /* AgentBuiltinsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentBuiltinsTests.swift; sourceTree = "<group>"; };
 		4B05E0E44B026AE7E8EA3101 /* ReviewEvidenceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReviewEvidenceTests.swift; sourceTree = "<group>"; };
-		A08F6C40A4B5609E30D9C2B2 /* ReviewEvidenceModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReviewEvidenceModelTests.swift; sourceTree = "<group>"; };
 		4B1FE6E8E631C115C1AF02F9 /* GatekeeperAssessor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GatekeeperAssessor.swift; sourceTree = "<group>"; };
 		4B2FAABB50C8BE2321A1B1DD /* ClaudeCodeACPInstallerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClaudeCodeACPInstallerTests.swift; sourceTree = "<group>"; };
 		4B3300F31455EE1BDF7BDE15 /* ZmxClientTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ZmxClientTests.swift; sourceTree = "<group>"; };
@@ -1404,6 +1404,7 @@
 		74D394D40BC9060833DD640A /* LSPInstaller.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LSPInstaller.swift; sourceTree = "<group>"; };
 		7544FD20BC61E587CAFAC099 /* AgentRegistry.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentRegistry.swift; sourceTree = "<group>"; };
 		7554DEF788B5448132F2B93F /* BulkConflictResolveReport.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BulkConflictResolveReport.swift; sourceTree = "<group>"; };
+		75610F1E65DB417E5240D649 /* TabsManagerReviewEvidenceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabsManagerReviewEvidenceTests.swift; sourceTree = "<group>"; };
 		75DFDC1BD30B1D1CC469D54C /* ZmxEnvTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ZmxEnvTests.swift; sourceTree = "<group>"; };
 		7615FEA1F225EBDE52CF5E14 /* ACPSessionManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPSessionManager.swift; sourceTree = "<group>"; };
 		764489A630CC6D79FCE0A26A /* GitService+ReviewLoop.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "GitService+ReviewLoop.swift"; sourceTree = "<group>"; };
@@ -1439,6 +1440,7 @@
 		7F4A17C42833BE6190A45AF3 /* GitService+CommitEditing.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "GitService+CommitEditing.swift"; sourceTree = "<group>"; };
 		7F4B57FBB6E595E5DF1C6F93 /* ACPMarkdownLiveStylerImageChipTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPMarkdownLiveStylerImageChipTests.swift; sourceTree = "<group>"; };
 		7F8802F19E02CED256495755 /* ACPTerminalTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPTerminalTests.swift; sourceTree = "<group>"; };
+		7FF257B37B6E9EA4D97C67D4 /* ReviewEvidenceModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReviewEvidenceModel.swift; sourceTree = "<group>"; };
 		7FFC9539E615699AC90A7412 /* ProjectsManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProjectsManager.swift; sourceTree = "<group>"; };
 		802EF6C18E2E27F68F6B770E /* ImageDiffSwipeView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageDiffSwipeView.swift; sourceTree = "<group>"; };
 		8062405A67C934905EE61D98 /* TextEditCoordinates.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TextEditCoordinates.swift; sourceTree = "<group>"; };
@@ -1544,6 +1546,7 @@
 		9FF41571C93C1C34A77951E2 /* GitRefNameInputFilter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GitRefNameInputFilter.swift; sourceTree = "<group>"; };
 		9FF99EC1C513C5D76D690BC2 /* ReleaseChecker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReleaseChecker.swift; sourceTree = "<group>"; };
 		A00CFC045C4BF9C13B4105BF /* ConflictMarkerParserTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConflictMarkerParserTests.swift; sourceTree = "<group>"; };
+		A043EA16DB135402FCA1E892 /* ReviewEvidenceTabView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReviewEvidenceTabView.swift; sourceTree = "<group>"; };
 		A1BC298112812E38C99E0B71 /* ACPAdapterUpdateStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPAdapterUpdateStoreTests.swift; sourceTree = "<group>"; };
 		A203964F9055BEF3F6142684 /* CodexACPInstallerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CodexACPInstallerTests.swift; sourceTree = "<group>"; };
 		A218B5125FC963339E40605E /* TabsManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabsManager.swift; sourceTree = "<group>"; };
@@ -1589,6 +1592,7 @@
 		AF2F716F911BB20B3E78C40B /* AgentDefinition.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentDefinition.swift; sourceTree = "<group>"; };
 		B0D0ED01C390D1F729993B13 /* MarkdownImageLoaderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MarkdownImageLoaderTests.swift; sourceTree = "<group>"; };
 		B0F47561DB37D2ED72B6BE25 /* ReviewLoopDrawerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReviewLoopDrawerTests.swift; sourceTree = "<group>"; };
+		B0FBEABA73057C9F165A66CD /* ReviewEvidenceModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReviewEvidenceModelTests.swift; sourceTree = "<group>"; };
 		B133843C0559BBD6E769ABB8 /* ACPManagerAccessorsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPManagerAccessorsTests.swift; sourceTree = "<group>"; };
 		B15DFCD74150803355CC0A95 /* RightPaneSelectionState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RightPaneSelectionState.swift; sourceTree = "<group>"; };
 		B1615F1953C6FE9D1A30A1A2 /* ACPImageEncoding.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPImageEncoding.swift; sourceTree = "<group>"; };
@@ -2258,6 +2262,7 @@
 				9F650CFAC8E61B1EC99CD04A /* TabActivityPulseTransitionTests.swift */,
 				14907D679267359B3FB8A848 /* TabMergeConflictCodingTests.swift */,
 				70377E10CD6D08B225BDFABE /* TabsManagerBufferTests.swift */,
+				75610F1E65DB417E5240D649 /* TabsManagerReviewEvidenceTests.swift */,
 				83A8622BA130E8FA339EDCEB /* TabsManagerReviewRequestDraftTests.swift */,
 				D6A9977C979705A40595FD5E /* TabsManagerTests.swift */,
 				4A777C0D1DB412458D46A628 /* TerminalCLIInjectionTests.swift */,
@@ -2338,6 +2343,14 @@
 				EE0C0029F439C282D474ED77 /* ACPFileWriter.swift */,
 			);
 			path = FileWriter;
+			sourceTree = "<group>";
+		};
+		22F204D0F6846057D6505326 /* ReviewEvidence */ = {
+			isa = PBXGroup;
+			children = (
+				A043EA16DB135402FCA1E892 /* ReviewEvidenceTabView.swift */,
+			);
+			path = ReviewEvidence;
 			sourceTree = "<group>";
 		};
 		28DACFA5F60339EEE14A135F /* Protocol */ = {
@@ -2580,7 +2593,7 @@
 				B5D2DA50E978EB0571D6A74C /* GitHubCLIProvider.swift */,
 				6C4E2F83F9EAB77B96EBA152 /* GitLabCLIProvider.swift */,
 				FC11F5C6667A6ECB74E066AE /* ReviewEvidence.swift */,
-				0A8F6C40A4B5609E30D9C2A1 /* ReviewEvidenceModel.swift */,
+				7FF257B37B6E9EA4D97C67D4 /* ReviewEvidenceModel.swift */,
 				2D4CC3ED497796474F107EBE /* ReviewLoopDrawer.swift */,
 				17F7DB6F391F1AAA9FED1A86 /* ReviewLoopHandoffBuilder.swift */,
 				0299820D15A2A4C7838B2CE9 /* ReviewLoopState.swift */,
@@ -2788,6 +2801,7 @@
 				EA78AC4E93C2130046C92571 /* Commit */,
 				DF2861B461606810647C1676 /* ImageDiff */,
 				073E19743F9145840DD47C8B /* Merge */,
+				22F204D0F6846057D6505326 /* ReviewEvidence */,
 				4AF44827354C470592274005 /* ReviewRequest */,
 			);
 			path = Center;
@@ -3368,8 +3382,8 @@
 				DE74A483930F70A0C79CC3E8 /* CodeHostRemoteDetectorTests.swift */,
 				8C28D64372B5B4C734A92533 /* GitHubCLIProviderTests.swift */,
 				C371360F83FE318A5B8AEDBF /* GitLabCLIProviderTests.swift */,
+				B0FBEABA73057C9F165A66CD /* ReviewEvidenceModelTests.swift */,
 				4B05E0E44B026AE7E8EA3101 /* ReviewEvidenceTests.swift */,
-				A08F6C40A4B5609E30D9C2B2 /* ReviewEvidenceModelTests.swift */,
 				B0F47561DB37D2ED72B6BE25 /* ReviewLoopDrawerTests.swift */,
 				4EC688020FD7B6A2A4393B72 /* ReviewLoopHandoffBuilderTests.swift */,
 				3939B27EA8D7A562048E5932 /* ReviewLoopStateTests.swift */,
@@ -4242,7 +4256,8 @@
 				2DE20AB5DAEF233BE008E5AA /* RepoSelectorRow.swift in Sources */,
 				1B387AAB575A42ED1AFB5D46 /* RepoSelectorRowView.swift in Sources */,
 				77CDD88F7C517095DE580B50 /* ReviewEvidence.swift in Sources */,
-				0A8F6C41A4B5609E30D9C2A1 /* ReviewEvidenceModel.swift in Sources */,
+				DF93C8550C7A78C2A03CF56A /* ReviewEvidenceModel.swift in Sources */,
+				8617CC447747E25550D93CFF /* ReviewEvidenceTabView.swift in Sources */,
 				DB29057E7147A0774BC2B835 /* ReviewLoopDrawer.swift in Sources */,
 				877BEC66CEBB5C495536FA20 /* ReviewLoopHandoffBuilder.swift in Sources */,
 				F5626F154B2CF446FF3F917B /* ReviewLoopState.swift in Sources */,
@@ -4663,8 +4678,8 @@
 				133597E7D43CFE746EF4EF2B /* RepoGroupViewLayoutTests.swift in Sources */,
 				737EC7C9A35C9ED61ED67B83 /* RepoSelectorModelTests.swift in Sources */,
 				35705563BBEDDC1D0092C1F5 /* RepoSelectorRecentsTests.swift in Sources */,
+				D1B12A9BA62CBB99E0DB1E28 /* ReviewEvidenceModelTests.swift in Sources */,
 				A05391FF4907AB0870A79C02 /* ReviewEvidenceTests.swift in Sources */,
-				A08F6C41A4B5609E30D9C2B2 /* ReviewEvidenceModelTests.swift in Sources */,
 				9409E946054E7D837A479137 /* ReviewLoopDrawerTests.swift in Sources */,
 				096304FB0EA9B5EC04D76C49 /* ReviewLoopHandoffBuilderTests.swift in Sources */,
 				B82F5295F500E46C381A8D52 /* ReviewLoopHandoffRoutingTests.swift in Sources */,
@@ -4710,6 +4725,7 @@
 				90F619F67402DB675E2614CC /* TabActivityPulseTransitionTests.swift in Sources */,
 				2EA0D9B6F711518ECBF14CF7 /* TabMergeConflictCodingTests.swift in Sources */,
 				0563F6A02BFFE6B5013D2190 /* TabsManagerBufferTests.swift in Sources */,
+				CFBCD5E3D345BCA65888E7BB /* TabsManagerReviewEvidenceTests.swift in Sources */,
 				418D526733AA6B50A66CCCAF /* TabsManagerReviewRequestDraftTests.swift in Sources */,
 				E822ADCC0B35087C38FB01A3 /* TabsManagerTests.swift in Sources */,
 				BEFFE99F341935C249CA4943 /* TerminalCLIInjectionTests.swift in Sources */,

--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -42,6 +42,7 @@
 		095A19B85DFA5EBA5A24786D /* AdvancedPane.swift in Sources */ = {isa = PBXBuildFile; fileRef = E16C4F54FB3E390F80208DA1 /* AdvancedPane.swift */; };
 		095E7D98616FB77A9F8BDFD9 /* ACPSessionManagerRetentionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6D1AAAE396590865426C592A /* ACPSessionManagerRetentionTests.swift */; };
 		096304FB0EA9B5EC04D76C49 /* ReviewLoopHandoffBuilderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4EC688020FD7B6A2A4393B72 /* ReviewLoopHandoffBuilderTests.swift */; };
+		0A8F6C41A4B5609E30D9C2A1 /* ReviewEvidenceModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A8F6C40A4B5609E30D9C2A1 /* ReviewEvidenceModel.swift */; };
 		0A480D9D7CE5BB837D7BCA13 /* GitService+Staging.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2F90D03073708AA01531533 /* GitService+Staging.swift */; };
 		0B11B8038CBA3A6F05E34895 /* GatekeeperAssessorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 137E9C84D7F32E747F0AF4C0 /* GatekeeperAssessorTests.swift */; };
 		0B6ADBF320E6130E5888CAA7 /* RemoteSessionGatewayTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37011506F459800FFF6D12A9 /* RemoteSessionGatewayTests.swift */; };
@@ -599,6 +600,7 @@
 		A03338AC85E6EC8201D56F95 /* TreeSitterGo in Frameworks */ = {isa = PBXBuildFile; productRef = DB0D87DDDAD70492540E6906 /* TreeSitterGo */; };
 		A050BAECF89694B0D613C5D2 /* EditorBuffer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 64E96E26D5F53F217BFD1F49 /* EditorBuffer.swift */; };
 		A05391FF4907AB0870A79C02 /* ReviewEvidenceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4B05E0E44B026AE7E8EA3101 /* ReviewEvidenceTests.swift */; };
+		A08F6C41A4B5609E30D9C2B2 /* ReviewEvidenceModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A08F6C40A4B5609E30D9C2B2 /* ReviewEvidenceModelTests.swift */; };
 		A0B5074B10E732616C917D10 /* DragHandleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1379AD82025AFEABD37EFC42 /* DragHandleTests.swift */; };
 		A0F1E46BC1A9E2CC21805EE7 /* FilesTabFilterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1977C85C3DFD1F232A2755AD /* FilesTabFilterTests.swift */; };
 		A15C8E0D7A942160A74BD68E /* ImageDiffPairResolver.swift in Sources */ = {isa = PBXBuildFile; fileRef = D568D53950A3CA2CD1F4EECB /* ImageDiffPairResolver.swift */; };
@@ -1006,6 +1008,7 @@
 		09246CDA0F77D86F05727407 /* ShellEnvResolverTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShellEnvResolverTests.swift; sourceTree = "<group>"; };
 		0934F7BB22E33263B63925B7 /* ImageDiffPair.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageDiffPair.swift; sourceTree = "<group>"; };
 		09D238B1262EB2BC6AFCF621 /* LanguageServerRegistry.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LanguageServerRegistry.swift; sourceTree = "<group>"; };
+		0A8F6C40A4B5609E30D9C2A1 /* ReviewEvidenceModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReviewEvidenceModel.swift; sourceTree = "<group>"; };
 		0A216C9D856D2A6C43964E74 /* AppConfigHarnessTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppConfigHarnessTests.swift; sourceTree = "<group>"; };
 		0A442AC7909A919582DF4372 /* SQLiteStatement.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SQLiteStatement.swift; sourceTree = "<group>"; };
 		0AAF2B901624C0629A1E3357 /* RightPaneStateUnstagePathsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RightPaneStateUnstagePathsTests.swift; sourceTree = "<group>"; };
@@ -1251,6 +1254,7 @@
 		4A777C0D1DB412458D46A628 /* TerminalCLIInjectionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TerminalCLIInjectionTests.swift; sourceTree = "<group>"; };
 		4AED8A6EE8EF0CC317D7A4C7 /* AgentBuiltinsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentBuiltinsTests.swift; sourceTree = "<group>"; };
 		4B05E0E44B026AE7E8EA3101 /* ReviewEvidenceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReviewEvidenceTests.swift; sourceTree = "<group>"; };
+		A08F6C40A4B5609E30D9C2B2 /* ReviewEvidenceModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReviewEvidenceModelTests.swift; sourceTree = "<group>"; };
 		4B1FE6E8E631C115C1AF02F9 /* GatekeeperAssessor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GatekeeperAssessor.swift; sourceTree = "<group>"; };
 		4B2FAABB50C8BE2321A1B1DD /* ClaudeCodeACPInstallerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClaudeCodeACPInstallerTests.swift; sourceTree = "<group>"; };
 		4B3300F31455EE1BDF7BDE15 /* ZmxClientTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ZmxClientTests.swift; sourceTree = "<group>"; };
@@ -2576,6 +2580,7 @@
 				B5D2DA50E978EB0571D6A74C /* GitHubCLIProvider.swift */,
 				6C4E2F83F9EAB77B96EBA152 /* GitLabCLIProvider.swift */,
 				FC11F5C6667A6ECB74E066AE /* ReviewEvidence.swift */,
+				0A8F6C40A4B5609E30D9C2A1 /* ReviewEvidenceModel.swift */,
 				2D4CC3ED497796474F107EBE /* ReviewLoopDrawer.swift */,
 				17F7DB6F391F1AAA9FED1A86 /* ReviewLoopHandoffBuilder.swift */,
 				0299820D15A2A4C7838B2CE9 /* ReviewLoopState.swift */,
@@ -3364,6 +3369,7 @@
 				8C28D64372B5B4C734A92533 /* GitHubCLIProviderTests.swift */,
 				C371360F83FE318A5B8AEDBF /* GitLabCLIProviderTests.swift */,
 				4B05E0E44B026AE7E8EA3101 /* ReviewEvidenceTests.swift */,
+				A08F6C40A4B5609E30D9C2B2 /* ReviewEvidenceModelTests.swift */,
 				B0F47561DB37D2ED72B6BE25 /* ReviewLoopDrawerTests.swift */,
 				4EC688020FD7B6A2A4393B72 /* ReviewLoopHandoffBuilderTests.swift */,
 				3939B27EA8D7A562048E5932 /* ReviewLoopStateTests.swift */,
@@ -4236,6 +4242,7 @@
 				2DE20AB5DAEF233BE008E5AA /* RepoSelectorRow.swift in Sources */,
 				1B387AAB575A42ED1AFB5D46 /* RepoSelectorRowView.swift in Sources */,
 				77CDD88F7C517095DE580B50 /* ReviewEvidence.swift in Sources */,
+				0A8F6C41A4B5609E30D9C2A1 /* ReviewEvidenceModel.swift in Sources */,
 				DB29057E7147A0774BC2B835 /* ReviewLoopDrawer.swift in Sources */,
 				877BEC66CEBB5C495536FA20 /* ReviewLoopHandoffBuilder.swift in Sources */,
 				F5626F154B2CF446FF3F917B /* ReviewLoopState.swift in Sources */,
@@ -4657,6 +4664,7 @@
 				737EC7C9A35C9ED61ED67B83 /* RepoSelectorModelTests.swift in Sources */,
 				35705563BBEDDC1D0092C1F5 /* RepoSelectorRecentsTests.swift in Sources */,
 				A05391FF4907AB0870A79C02 /* ReviewEvidenceTests.swift in Sources */,
+				A08F6C41A4B5609E30D9C2B2 /* ReviewEvidenceModelTests.swift in Sources */,
 				9409E946054E7D837A479137 /* ReviewLoopDrawerTests.swift in Sources */,
 				096304FB0EA9B5EC04D76C49 /* ReviewLoopHandoffBuilderTests.swift in Sources */,
 				B82F5295F500E46C381A8D52 /* ReviewLoopHandoffRoutingTests.swift in Sources */,

--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -440,6 +440,7 @@
 		7602FDB0353222613CD39FFE /* FileIndexTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3855FBA3E4444960418639E9 /* FileIndexTests.swift */; };
 		763947308C99E2D3CB565889 /* AgentKind.swift in Sources */ = {isa = PBXBuildFile; fileRef = 53C792D59DBFFF6C28F2D426 /* AgentKind.swift */; };
 		771CD72B94194370E783F7DD /* StartupScriptResolverTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9D3C76F2F0F6BCE4023A9D7F /* StartupScriptResolverTests.swift */; };
+		77CDD88F7C517095DE580B50 /* ReviewEvidence.swift in Sources */ = {isa = PBXBuildFile; fileRef = FC11F5C6667A6ECB74E066AE /* ReviewEvidence.swift */; };
 		78D25A04EAE26A0F3021A057 /* Paths.swift in Sources */ = {isa = PBXBuildFile; fileRef = 364213292935A05F3B52F51F /* Paths.swift */; };
 		7950F5765E0B95EB1CB5B818 /* ACPNewChatEmptyStatePolicy.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF80D59C3200AD3215D1E140 /* ACPNewChatEmptyStatePolicy.swift */; };
 		79575F0DA597D2C2DFCDC9E2 /* LSPMessagesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE7675D7F75E36E9C81193C8 /* LSPMessagesTests.swift */; };
@@ -597,6 +598,7 @@
 		9FDF577BDD6D5C47635229DE /* ACPSessionByteAccountingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 52B5F3FFF8AEF13BC48DCFBD /* ACPSessionByteAccountingTests.swift */; };
 		A03338AC85E6EC8201D56F95 /* TreeSitterGo in Frameworks */ = {isa = PBXBuildFile; productRef = DB0D87DDDAD70492540E6906 /* TreeSitterGo */; };
 		A050BAECF89694B0D613C5D2 /* EditorBuffer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 64E96E26D5F53F217BFD1F49 /* EditorBuffer.swift */; };
+		A05391FF4907AB0870A79C02 /* ReviewEvidenceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4B05E0E44B026AE7E8EA3101 /* ReviewEvidenceTests.swift */; };
 		A0B5074B10E732616C917D10 /* DragHandleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1379AD82025AFEABD37EFC42 /* DragHandleTests.swift */; };
 		A0F1E46BC1A9E2CC21805EE7 /* FilesTabFilterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1977C85C3DFD1F232A2755AD /* FilesTabFilterTests.swift */; };
 		A15C8E0D7A942160A74BD68E /* ImageDiffPairResolver.swift in Sources */ = {isa = PBXBuildFile; fileRef = D568D53950A3CA2CD1F4EECB /* ImageDiffPairResolver.swift */; };
@@ -1248,6 +1250,7 @@
 		4A27D815CB567E3FEF2D3E6B /* InstallSourceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InstallSourceTests.swift; sourceTree = "<group>"; };
 		4A777C0D1DB412458D46A628 /* TerminalCLIInjectionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TerminalCLIInjectionTests.swift; sourceTree = "<group>"; };
 		4AED8A6EE8EF0CC317D7A4C7 /* AgentBuiltinsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentBuiltinsTests.swift; sourceTree = "<group>"; };
+		4B05E0E44B026AE7E8EA3101 /* ReviewEvidenceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReviewEvidenceTests.swift; sourceTree = "<group>"; };
 		4B1FE6E8E631C115C1AF02F9 /* GatekeeperAssessor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GatekeeperAssessor.swift; sourceTree = "<group>"; };
 		4B2FAABB50C8BE2321A1B1DD /* ClaudeCodeACPInstallerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClaudeCodeACPInstallerTests.swift; sourceTree = "<group>"; };
 		4B3300F31455EE1BDF7BDE15 /* ZmxClientTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ZmxClientTests.swift; sourceTree = "<group>"; };
@@ -1868,6 +1871,7 @@
 		FB5B73ECBD730B5BB24E2240 /* ACPSessionManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPSessionManagerTests.swift; sourceTree = "<group>"; };
 		FBC01971BF41E6D0B9B317CF /* CodeTextView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CodeTextView.swift; sourceTree = "<group>"; };
 		FBFB85AF60C0E4520ED0DA8E /* AgentLauncherDialog.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentLauncherDialog.swift; sourceTree = "<group>"; };
+		FC11F5C6667A6ECB74E066AE /* ReviewEvidence.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReviewEvidence.swift; sourceTree = "<group>"; };
 		FC4A215AF2876091E31F6F8A /* LineEnding.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LineEnding.swift; sourceTree = "<group>"; };
 		FC8E722C16FFBEEEC43337D5 /* ACPSetupCheck.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPSetupCheck.swift; sourceTree = "<group>"; };
 		FC93F4FB957C2CCD4E1E2326 /* CodeEditorView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CodeEditorView.swift; sourceTree = "<group>"; };
@@ -2571,6 +2575,7 @@
 				82E98F9835497D830C12AA8F /* CodeHostRemoteDetector.swift */,
 				B5D2DA50E978EB0571D6A74C /* GitHubCLIProvider.swift */,
 				6C4E2F83F9EAB77B96EBA152 /* GitLabCLIProvider.swift */,
+				FC11F5C6667A6ECB74E066AE /* ReviewEvidence.swift */,
 				2D4CC3ED497796474F107EBE /* ReviewLoopDrawer.swift */,
 				17F7DB6F391F1AAA9FED1A86 /* ReviewLoopHandoffBuilder.swift */,
 				0299820D15A2A4C7838B2CE9 /* ReviewLoopState.swift */,
@@ -3358,6 +3363,7 @@
 				DE74A483930F70A0C79CC3E8 /* CodeHostRemoteDetectorTests.swift */,
 				8C28D64372B5B4C734A92533 /* GitHubCLIProviderTests.swift */,
 				C371360F83FE318A5B8AEDBF /* GitLabCLIProviderTests.swift */,
+				4B05E0E44B026AE7E8EA3101 /* ReviewEvidenceTests.swift */,
 				B0F47561DB37D2ED72B6BE25 /* ReviewLoopDrawerTests.swift */,
 				4EC688020FD7B6A2A4393B72 /* ReviewLoopHandoffBuilderTests.swift */,
 				3939B27EA8D7A562048E5932 /* ReviewLoopStateTests.swift */,
@@ -4229,6 +4235,7 @@
 				E3158A4D8FBD36D06D421D28 /* RepoSelectorRecents.swift in Sources */,
 				2DE20AB5DAEF233BE008E5AA /* RepoSelectorRow.swift in Sources */,
 				1B387AAB575A42ED1AFB5D46 /* RepoSelectorRowView.swift in Sources */,
+				77CDD88F7C517095DE580B50 /* ReviewEvidence.swift in Sources */,
 				DB29057E7147A0774BC2B835 /* ReviewLoopDrawer.swift in Sources */,
 				877BEC66CEBB5C495536FA20 /* ReviewLoopHandoffBuilder.swift in Sources */,
 				F5626F154B2CF446FF3F917B /* ReviewLoopState.swift in Sources */,
@@ -4649,6 +4656,7 @@
 				133597E7D43CFE746EF4EF2B /* RepoGroupViewLayoutTests.swift in Sources */,
 				737EC7C9A35C9ED61ED67B83 /* RepoSelectorModelTests.swift in Sources */,
 				35705563BBEDDC1D0092C1F5 /* RepoSelectorRecentsTests.swift in Sources */,
+				A05391FF4907AB0870A79C02 /* ReviewEvidenceTests.swift in Sources */,
 				9409E946054E7D837A479137 /* ReviewLoopDrawerTests.swift in Sources */,
 				096304FB0EA9B5EC04D76C49 /* ReviewLoopHandoffBuilderTests.swift in Sources */,
 				B82F5295F500E46C381A8D52 /* ReviewLoopHandoffRoutingTests.swift in Sources */,

--- a/Alas/Sources/App/AppState.swift
+++ b/Alas/Sources/App/AppState.swift
@@ -3136,6 +3136,16 @@ final class AppState {
         openACPHandoff(agentID: agentID, initialPrompt: prompt)
     }
 
+    func openReviewEvidenceHandoff(snapshot: ReviewLoopSnapshot, detail: ReviewEvidenceDetail) {
+        let agentID = config.changes.aiToolId
+        guard agentID != "none", agent(id: agentID) != nil else { return }
+        let prompt = ReviewLoopHandoffBuilder.buildSelectedEvidencePrompt(
+            snapshot: snapshot,
+            detail: detail
+        )
+        openACPHandoff(agentID: agentID, initialPrompt: prompt)
+    }
+
     nonisolated static func reviewLoopHandoffActionKind(for request: ReviewRequest?) -> ReviewLoopActionKind {
         if request?.hasActionableFeedback == true {
             return .prepareReviewHandoff

--- a/Alas/Sources/Center/CenterPaneView.swift
+++ b/Alas/Sources/Center/CenterPaneView.swift
@@ -223,6 +223,11 @@ struct CenterPaneView: View {
                         )
                         .id(draftState.id)
                     case .reviewEvidence(let evidenceState):
+                        let _ = state.rightPaneStore.state(
+                            for: worktree,
+                            baseBranch: state.config.worktrees.baseBranch,
+                            trackUpstreamForCommits: state.config.changes.trackUpstreamForCommits
+                        )
                         ReviewEvidenceTabView(
                             worktreePath: worktree.path,
                             tabState: evidenceState,

--- a/Alas/Sources/Center/CenterPaneView.swift
+++ b/Alas/Sources/Center/CenterPaneView.swift
@@ -222,6 +222,13 @@ struct CenterPaneView: View {
                             appState: state
                         )
                         .id(draftState.id)
+                    case .reviewEvidence(let evidenceState):
+                        ReviewEvidenceTabView(
+                            worktreePath: worktree.path,
+                            tabState: evidenceState,
+                            appState: state
+                        )
+                        .id(evidenceState.id)
                     case .imagePreview(let s):
                         ImagePreviewTabView(worktreePath: worktree.path,
                                              relativePath: s.relativePath,

--- a/Alas/Sources/Center/ReviewEvidence/ReviewEvidenceTabView.swift
+++ b/Alas/Sources/Center/ReviewEvidence/ReviewEvidenceTabView.swift
@@ -1,0 +1,566 @@
+import AppKit
+import SwiftUI
+
+struct ReviewEvidenceTabView: View {
+    let worktreePath: URL
+    let tabState: ReviewEvidenceTabState
+    @Bindable var appState: AppState
+
+    @State private var model: ReviewEvidenceModel?
+    @State private var selectedSection: ReviewEvidenceSection
+    @State private var loadNonce = 0
+    @State private var isRerunningFailedChecks = false
+    @State private var loadGeneration = 0
+
+    @Environment(\.theme) private var theme
+
+    init(worktreePath: URL, tabState: ReviewEvidenceTabState, appState: AppState) {
+        self.worktreePath = worktreePath
+        self.tabState = tabState
+        self.appState = appState
+        _selectedSection = State(initialValue: tabState.selectedSection)
+    }
+
+    private var snapshot: ReviewLoopSnapshot? {
+        appState.rightPaneStore.activeState(worktreeId: tabState.worktreeId)?.reviewLoop.snapshot
+    }
+
+    private var loadKey: String {
+        let head = snapshot?.local.headSHA ?? "no-head"
+        let request = snapshot?.reviewRequest.map { "\($0.provider.rawValue):\($0.number)" } ?? "no-request"
+        return "\(tabState.id):\(head):\(request):\(loadNonce)"
+    }
+
+    var body: some View {
+        VStack(spacing: 0) {
+            header
+            Divider()
+            content
+        }
+        .background(theme.color("bg-0"))
+        .task(id: loadKey) {
+            await loadEvidence()
+        }
+        .onChange(of: tabState.selectedSection) { _, section in
+            applySelectedSection(section, loadDetail: true)
+        }
+    }
+
+    @ViewBuilder
+    private var header: some View {
+        HStack(spacing: 10) {
+            Icon(name: "doc.text.magnifyingglass", size: 14, color: theme.color("accent"))
+            VStack(alignment: .leading, spacing: 3) {
+                Text(identityTitle)
+                    .font(.system(size: 12, weight: .semibold))
+                    .foregroundColor(theme.color("fg"))
+                    .lineLimit(1)
+                HStack(spacing: 6) {
+                    Text(requestTitle)
+                        .font(.system(size: 11))
+                        .foregroundColor(theme.color("fg-dim"))
+                        .lineLimit(1)
+                        .truncationMode(.middle)
+                        .textSelection(.enabled)
+                    if let snapshot {
+                        statusChips(snapshot)
+                    }
+                }
+            }
+            Spacer()
+            if model?.isLoadingList == true {
+                Spinner(lineWidth: 1.5, duration: 0.7)
+                    .frame(width: 14, height: 14)
+            }
+            AlasButton(title: "Refresh", icon: "arrow.clockwise") {
+                loadNonce += 1
+            }
+            if let url = reviewRequestURL {
+                AlasButton(title: snapshotProvider.openReviewRequestTitle, icon: "arrow.up.right.square") {
+                    NSWorkspace.shared.open(url)
+                }
+            }
+        }
+        .padding(.horizontal, 14)
+        .padding(.vertical, 10)
+        .background(theme.color("bg-1"))
+    }
+
+    @ViewBuilder
+    private var content: some View {
+        if let unavailableMessage {
+            unavailableState(message: unavailableMessage)
+        } else if let model {
+            if let message = model.errorMessage, model.ciItems.isEmpty, model.feedbackItems.isEmpty {
+                unavailableState(message: message)
+            } else {
+                evidenceBrowser(model: model)
+            }
+        } else {
+            Spinner()
+                .frame(width: 20, height: 20)
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
+        }
+    }
+
+    private func evidenceBrowser(model: ReviewEvidenceModel) -> some View {
+        VStack(spacing: 0) {
+            Picker("Evidence section", selection: sectionSelectionBinding(model: model)) {
+                ForEach(ReviewEvidenceSection.allCases, id: \.self) { section in
+                    Text(section.displayName).tag(section)
+                }
+            }
+            .pickerStyle(.segmented)
+            .labelsHidden()
+            .frame(width: 220)
+            .padding(.vertical, 10)
+
+            Divider()
+
+            HStack(spacing: 0) {
+                evidenceList(model: model)
+                    .frame(minWidth: 220, idealWidth: 300, maxWidth: 360, maxHeight: .infinity)
+                    .background(theme.color("bg-1"))
+                Divider()
+                detailPane(model: model)
+                    .frame(maxWidth: .infinity, maxHeight: .infinity)
+                    .background(theme.color("bg-0"))
+            }
+        }
+    }
+
+    private func evidenceList(model: ReviewEvidenceModel) -> some View {
+        let items = model.items(for: selectedSection)
+
+        return Group {
+            if model.isLoadingList {
+                Spinner()
+                    .frame(width: 18, height: 18)
+                    .frame(maxWidth: .infinity, maxHeight: .infinity)
+            } else if items.isEmpty {
+                Text(emptyText(for: selectedSection))
+                    .font(.system(size: 12, weight: .medium))
+                    .foregroundColor(theme.color("fg-dim"))
+                    .frame(maxWidth: .infinity, maxHeight: .infinity)
+            } else {
+                ScrollView {
+                    LazyVStack(spacing: 0) {
+                        ForEach(items) { item in
+                            evidenceRow(item: item, isSelected: isSelected(item, in: model))
+                        }
+                    }
+                    .padding(.vertical, 6)
+                }
+            }
+        }
+    }
+
+    private func evidenceRow(item: ReviewEvidenceItem, isSelected: Bool) -> some View {
+        Button {
+            if let model {
+                selectItem(item, in: model, loadDetail: true)
+            }
+        } label: {
+            HStack(alignment: .top, spacing: 8) {
+                statusDot(for: item.status)
+                    .padding(.top, 4)
+                VStack(alignment: .leading, spacing: 4) {
+                    Text(item.title)
+                        .font(.system(size: 12, weight: .semibold))
+                        .foregroundColor(theme.color("fg"))
+                        .lineLimit(2)
+                    if let subtitle = item.subtitle, !subtitle.isEmpty {
+                        Text(subtitle)
+                            .font(.system(size: 11))
+                            .foregroundColor(theme.color("fg-dim"))
+                            .lineLimit(2)
+                    }
+                }
+                Spacer(minLength: 0)
+            }
+            .padding(.horizontal, 10)
+            .padding(.vertical, 8)
+            .contentShape(Rectangle())
+            .background(isSelected ? theme.color("accent").opacity(0.18) : Color.clear)
+        }
+        .buttonStyle(.plain)
+    }
+
+    @ViewBuilder
+    private func detailPane(model: ReviewEvidenceModel) -> some View {
+        if model.isLoadingDetail {
+            VStack(spacing: 10) {
+                Spinner()
+                    .frame(width: 20, height: 20)
+                Text("Loading evidence detail")
+                    .font(.system(size: 12))
+                    .foregroundColor(theme.color("fg-dim"))
+            }
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
+        } else if let detail = visibleDetail(in: model) {
+            VStack(spacing: 0) {
+                detailHeader(detail, snapshot: model.snapshot)
+                Divider()
+                ScrollView([.horizontal, .vertical]) {
+                    Text(detail.body)
+                        .font(CenterTypography.codeFont(
+                            family: appState.config.code.fontFamily,
+                            size: CGFloat(appState.config.code.fontSize)
+                        ))
+                        .foregroundColor(theme.color("fg"))
+                        .textSelection(.enabled)
+                        .frame(maxWidth: .infinity, alignment: .topLeading)
+                        .padding(12)
+                }
+            }
+        } else {
+            Text("Select an evidence item")
+                .font(.system(size: 12, weight: .medium))
+                .foregroundColor(theme.color("fg-dim"))
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
+        }
+    }
+
+    private func detailHeader(_ detail: ReviewEvidenceDetail, snapshot: ReviewLoopSnapshot) -> some View {
+        HStack(spacing: 8) {
+            VStack(alignment: .leading, spacing: 3) {
+                Text(detail.item.title)
+                    .font(.system(size: 12, weight: .semibold))
+                    .foregroundColor(theme.color("fg"))
+                    .lineLimit(1)
+                if let location = detailLocation(detail) {
+                    Text(location)
+                        .font(.system(size: 11, design: .monospaced))
+                        .foregroundColor(theme.color("fg-dim"))
+                        .lineLimit(1)
+                        .truncationMode(.middle)
+                }
+            }
+            Spacer()
+            if let url = detail.item.providerURL {
+                AlasButton(title: "Open in Browser", icon: "arrow.up.right.square") {
+                    NSWorkspace.shared.open(url)
+                }
+            }
+            if canRerunFailedChecks(for: detail, snapshot: snapshot) {
+                AlasButton(title: isRerunningFailedChecks ? "Rerunning" : "Rerun Failed", icon: "arrow.clockwise") {
+                    rerunFailedChecks(snapshot: snapshot)
+                }
+                .disabled(isRerunningFailedChecks)
+            }
+            AlasButton(title: "Copy Context", icon: "doc.on.doc") {
+                copyContext(detail)
+            }
+            AlasButton(title: "Send to Agent", icon: "sparkle", style: .primary) {
+                appState.openReviewEvidenceHandoff(snapshot: snapshot, detail: detail)
+            }
+        }
+        .padding(.horizontal, 12)
+        .padding(.vertical, 10)
+        .background(theme.color("bg-1"))
+    }
+
+    private var unavailableMessage: String? {
+        guard let snapshot else {
+            return "Review evidence is unavailable because review state is not loaded."
+        }
+        guard snapshot.remote != nil else {
+            return "Review evidence is unavailable because the code host remote was not found."
+        }
+        guard snapshot.providerAvailable else {
+            return "Provider CLI unavailable."
+        }
+        guard snapshot.providerAuthenticated else {
+            return "Provider authentication required."
+        }
+        guard CodeHostProviderRegistry.live().provider(for: snapshot.remote?.kind ?? tabState.provider) != nil else {
+            return "Review evidence is unavailable because \(snapshotProvider.displayName) is not supported."
+        }
+        return nil
+    }
+
+    private var snapshotProvider: CodeHostKind {
+        snapshot?.reviewRequest?.provider ?? snapshot?.remote?.kind ?? tabState.provider
+    }
+
+    private var identityTitle: String {
+        let provider = snapshotProvider
+        let slug = snapshot?.remote?.repositorySlug ?? tabState.repositorySlug
+        let number = snapshot?.reviewRequest?.number ?? tabState.number
+        let requestNumber = number > 0 ? "\(provider.reviewRequestNumberPrefix)\(number)" : ""
+        return [provider.displayName, provider.reviewRequestLabel, requestNumber, slug]
+            .filter { !$0.isEmpty }
+            .joined(separator: " ")
+    }
+
+    private var requestTitle: String {
+        let title = snapshot?.reviewRequest?.title ?? tabState.title
+        return title.isEmpty ? "Review evidence" : title
+    }
+
+    private var reviewRequestURL: URL? {
+        let url = snapshot?.reviewRequest?.url ?? tabState.url
+        return url.isFileURL ? nil : url
+    }
+
+    private func loadEvidence() async {
+        guard let snapshot, let remote = snapshot.remote else {
+            model = nil
+            return
+        }
+        guard snapshot.providerAvailable, snapshot.providerAuthenticated else {
+            model = nil
+            return
+        }
+        guard let provider = CodeHostProviderRegistry.live().provider(for: remote.kind) else {
+            model = nil
+            return
+        }
+
+        loadGeneration += 1
+        let generation = loadGeneration
+        let initialSection = selectedSection
+        let loaded = ReviewEvidenceModel(
+            snapshot: snapshot,
+            provider: provider,
+            cwd: worktreePath,
+            initialSection: initialSection
+        )
+        model = loaded
+        await loaded.load()
+        guard generation == loadGeneration else { return }
+        if loaded.items(for: selectedSection).isEmpty,
+           selectedSection == initialSection,
+           !loaded.items(for: loaded.selectedSection).isEmpty {
+            selectedSection = loaded.selectedSection
+        }
+        let selectedItemID: String?
+        if selectedSection != loaded.selectedSection {
+            if let item = loaded.items(for: selectedSection).first {
+                loaded.select(itemID: item.id, section: selectedSection)
+                selectedItemID = loaded.selectedItemID
+            } else {
+                selectedItemID = nil
+            }
+        } else {
+            selectedItemID = loaded.selectedItemID
+        }
+        persistSelection(section: selectedSection, itemID: selectedItemID)
+    }
+
+    private func isSelected(_ item: ReviewEvidenceItem, in model: ReviewEvidenceModel) -> Bool {
+        model.selectedSection == selectedSection && model.selectedItemID == item.id
+    }
+
+    private func sectionSelectionBinding(model: ReviewEvidenceModel) -> Binding<ReviewEvidenceSection> {
+        Binding(
+            get: { selectedSection },
+            set: { section in
+                applySelectedSection(section, loadDetail: true)
+            }
+        )
+    }
+
+    private func visibleDetail(in model: ReviewEvidenceModel) -> ReviewEvidenceDetail? {
+        guard model.selectedSection == selectedSection else { return nil }
+        return model.selectedDetail
+    }
+
+    @ViewBuilder
+    private func statusChips(_ snapshot: ReviewLoopSnapshot) -> some View {
+        HStack(spacing: 4) {
+            evidenceChip(title: "Checks \(checksText(snapshot.reviewRequest?.worstCheckBucket))", tone: checksTone(snapshot.reviewRequest?.worstCheckBucket))
+            if let request = snapshot.reviewRequest {
+                evidenceChip(title: "Review \(reviewText(request.reviewDecision))", tone: reviewTone(request.reviewDecision))
+                evidenceChip(title: "Merge \(mergeText(request.mergeState))", tone: mergeTone(request.mergeState))
+            }
+        }
+    }
+
+    private func evidenceChip(title: String, tone: ReviewReadinessModel.Chip.Tone) -> some View {
+        Text(title)
+            .font(.system(size: 10, weight: .semibold))
+            .foregroundColor(chipForeground(tone))
+            .lineLimit(1)
+            .padding(.horizontal, 6)
+            .padding(.vertical, 2)
+            .background(chipBackground(tone))
+            .clipShape(RoundedRectangle(cornerRadius: 4, style: .continuous))
+    }
+
+    private func checksText(_ bucket: ReviewCheckBucket?) -> String {
+        guard let bucket else { return "none" }
+        switch bucket {
+        case .pass: return "passing"
+        case .fail: return "failed"
+        case .pending: return "running"
+        case .skipping: return "skipped"
+        case .cancel: return "cancelled"
+        case .unknown: return "unknown"
+        }
+    }
+
+    private func reviewText(_ decision: ReviewDecision) -> String {
+        switch decision {
+        case .approved: return "approved"
+        case .changesRequested: return "changes requested"
+        case .reviewRequired: return "required"
+        case .unknown: return "unknown"
+        }
+    }
+
+    private func mergeText(_ state: ReviewMergeState) -> String {
+        switch state {
+        case .clean: return "clean"
+        case .blocked: return "blocked"
+        case .dirty: return "dirty"
+        case .unstable: return "unstable"
+        case .unknown: return "unknown"
+        }
+    }
+
+    private func checksTone(_ bucket: ReviewCheckBucket?) -> ReviewReadinessModel.Chip.Tone {
+        switch bucket {
+        case .pass: .success
+        case .fail: .danger
+        case .pending: .accent
+        case .cancel, .unknown: .warning
+        case .skipping, nil: .muted
+        }
+    }
+
+    private func reviewTone(_ decision: ReviewDecision) -> ReviewReadinessModel.Chip.Tone {
+        switch decision {
+        case .approved: .success
+        case .changesRequested: .warning
+        case .reviewRequired, .unknown: .muted
+        }
+    }
+
+    private func mergeTone(_ state: ReviewMergeState) -> ReviewReadinessModel.Chip.Tone {
+        switch state {
+        case .clean: .success
+        case .blocked, .dirty, .unstable: .warning
+        case .unknown: .muted
+        }
+    }
+
+    private func chipForeground(_ tone: ReviewReadinessModel.Chip.Tone) -> Color {
+        switch tone {
+        case .accent: theme.color("accent")
+        case .success: theme.color("add")
+        case .warning: theme.color("warn")
+        case .danger: theme.color("del")
+        case .muted: theme.color("fg-dim")
+        }
+    }
+
+    private func chipBackground(_ tone: ReviewReadinessModel.Chip.Tone) -> Color {
+        chipForeground(tone).opacity(0.14)
+    }
+
+    private func canRerunFailedChecks(for detail: ReviewEvidenceDetail, snapshot: ReviewLoopSnapshot) -> Bool {
+        guard detail.item.section == .ci,
+              detail.item.status == .failed,
+              snapshot.providerCapabilities.canRerunFailedChecks,
+              let request = snapshot.reviewRequest
+        else { return false }
+        return request.checks.contains {
+            $0.id == detail.item.id && $0.bucket == .fail && $0.workflow != nil
+        }
+    }
+
+    private func rerunFailedChecks(snapshot: ReviewLoopSnapshot) {
+        guard let rightPaneState = appState.rightPaneStore.activeState(worktreeId: tabState.worktreeId) else { return }
+        isRerunningFailedChecks = true
+        Task { @MainActor in
+            if await rightPaneState.reviewLoop.rerunFailedChecks(snapshot: snapshot) {
+                await rightPaneState.refresh()
+                loadNonce += 1
+            }
+            isRerunningFailedChecks = false
+        }
+    }
+
+    private func applySelectedSection(_ section: ReviewEvidenceSection, loadDetail: Bool) {
+        selectedSection = section
+        guard let model, let item = model.items(for: section).first else {
+            persistSelection(section: section, itemID: nil)
+            return
+        }
+        selectItem(item, in: model, loadDetail: loadDetail)
+    }
+
+    private func selectItem(_ item: ReviewEvidenceItem, in model: ReviewEvidenceModel, loadDetail: Bool) {
+        selectedSection = item.section
+        model.select(itemID: item.id, section: item.section)
+        persistSelection(section: item.section, itemID: item.id)
+        guard loadDetail else { return }
+        Task { await model.loadSelectedDetail() }
+    }
+
+    private func persistSelection(section: ReviewEvidenceSection, itemID: String?) {
+        appState.tabs.updateReviewEvidenceSelection(
+            worktreeId: tabState.worktreeId,
+            tabId: tabState.id,
+            selectedSection: section,
+            selectedItemID: itemID
+        )
+    }
+
+    private func emptyText(for section: ReviewEvidenceSection) -> String {
+        switch section {
+        case .ci: "No failed checks"
+        case .feedback: "No actionable feedback"
+        }
+    }
+
+    private func detailLocation(_ detail: ReviewEvidenceDetail) -> String? {
+        guard let filePath = detail.filePath else { return detail.item.subtitle }
+        if let line = detail.line {
+            return "\(filePath):\(line)"
+        }
+        return filePath
+    }
+
+    private func copyContext(_ detail: ReviewEvidenceDetail) {
+        let pasteboard = NSPasteboard.general
+        pasteboard.clearContents()
+        pasteboard.setString(ReviewEvidenceContextFormatter.format(detail), forType: .string)
+    }
+
+    private func statusDot(for status: ReviewEvidenceStatus) -> some View {
+        Circle()
+            .fill(statusColor(status))
+            .frame(width: 7, height: 7)
+    }
+
+    private func statusColor(_ status: ReviewEvidenceStatus) -> Color {
+        switch status {
+        case .failed, .actionable:
+            theme.color("del")
+        case .pending:
+            theme.color("warn")
+        case .passed, .resolved:
+            theme.color("add")
+        case .cancelled, .unknown:
+            theme.color("fg-faint")
+        }
+    }
+
+    private func unavailableState(message: String) -> some View {
+        VStack(spacing: 8) {
+            Icon(name: "alert", size: 18, color: theme.color("fg-dim"))
+            Text(message)
+                .font(.system(size: 12, weight: .medium))
+                .foregroundColor(theme.color("fg-dim"))
+                .multilineTextAlignment(.center)
+                .textSelection(.enabled)
+            AlasButton(title: "Refresh", icon: "arrow.clockwise") {
+                loadNonce += 1
+            }
+        }
+        .padding(24)
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+    }
+}

--- a/Alas/Sources/Center/ReviewEvidence/ReviewEvidenceTabView.swift
+++ b/Alas/Sources/Center/ReviewEvidence/ReviewEvidenceTabView.swift
@@ -118,7 +118,7 @@ struct ReviewEvidenceTabView: View {
                     .frame(width: 14, height: 14)
             }
             AlasButton(title: "Refresh", icon: "arrow.clockwise") {
-                loadNonce += 1
+                refreshEvidence()
             }
             if let url = reviewRequestURL {
                 AlasButton(title: snapshotProvider.openReviewRequestTitle, icon: "arrow.up.right.square") {
@@ -620,10 +620,19 @@ struct ReviewEvidenceTabView: View {
                 .multilineTextAlignment(.center)
                 .textSelection(.enabled)
             AlasButton(title: "Refresh", icon: "arrow.clockwise") {
-                loadNonce += 1
+                refreshEvidence()
             }
         }
         .padding(24)
         .frame(maxWidth: .infinity, maxHeight: .infinity)
+    }
+
+    private func refreshEvidence() {
+        Task { @MainActor in
+            if let rightPaneState = appState.rightPaneStore.activeState(worktreeId: tabState.worktreeId) {
+                await rightPaneState.refresh()
+            }
+            loadNonce += 1
+        }
     }
 }

--- a/Alas/Sources/Center/ReviewEvidence/ReviewEvidenceTabView.swift
+++ b/Alas/Sources/Center/ReviewEvidence/ReviewEvidenceTabView.swift
@@ -21,8 +21,13 @@ struct ReviewEvidenceTabView: View {
         _selectedSection = State(initialValue: tabState.selectedSection)
     }
 
-    private var snapshot: ReviewLoopSnapshot? {
+    private var activeSnapshot: ReviewLoopSnapshot? {
         appState.rightPaneStore.activeState(worktreeId: tabState.worktreeId)?.reviewLoop.snapshot
+    }
+
+    private var snapshot: ReviewLoopSnapshot? {
+        guard let activeSnapshot, tabState.matches(activeSnapshot) else { return nil }
+        return activeSnapshot
     }
 
     private var loadKey: String {
@@ -301,9 +306,13 @@ struct ReviewEvidenceTabView: View {
     }
 
     private var unavailableMessage: String? {
-        guard let snapshot else {
+        guard let activeSnapshot else {
             return "Review evidence is unavailable because review state is not loaded."
         }
+        guard tabState.matches(activeSnapshot) else {
+            return staleReviewRequestMessage(activeSnapshot)
+        }
+        let snapshot = activeSnapshot
         guard snapshot.remote != nil else {
             return "Review evidence is unavailable because the code host remote was not found."
         }
@@ -317,6 +326,14 @@ struct ReviewEvidenceTabView: View {
             return "Review evidence is unavailable because \(snapshotProvider.displayName) is not supported."
         }
         return nil
+    }
+
+    private func staleReviewRequestMessage(_ snapshot: ReviewLoopSnapshot) -> String {
+        let expected = "\(tabState.provider.displayName) \(tabState.provider.reviewRequestNumberPrefix)\(tabState.number)"
+        guard let request = snapshot.reviewRequest else {
+            return "Review evidence is for \(expected), but no active review request was found."
+        }
+        return "Review evidence is for \(expected), but the active review request is \(request.displayIdentity)."
     }
 
     private var snapshotProvider: CodeHostKind {

--- a/Alas/Sources/Center/ReviewEvidence/ReviewEvidenceTabView.swift
+++ b/Alas/Sources/Center/ReviewEvidence/ReviewEvidenceTabView.swift
@@ -27,8 +27,48 @@ struct ReviewEvidenceTabView: View {
 
     private var loadKey: String {
         let head = snapshot?.local.headSHA ?? "no-head"
-        let request = snapshot?.reviewRequest.map { "\($0.provider.rawValue):\($0.number)" } ?? "no-request"
-        return "\(tabState.id):\(head):\(request):\(loadNonce)"
+        let providerState = "\(snapshot?.providerAvailable == true):\(snapshot?.providerAuthenticated == true)"
+        let request = snapshot?.reviewRequest.map(reviewEvidenceRevisionKey) ?? "no-request"
+        return "\(tabState.id):\(head):\(providerState):\(request):\(loadNonce)"
+    }
+
+    private func reviewEvidenceRevisionKey(for request: ReviewRequest) -> String {
+        let checks = request.checks
+            .sorted { $0.id < $1.id }
+            .map { check in
+                let completedAt = check.completedAt.map { String($0.timeIntervalSince1970) } ?? "nil"
+                return [
+                    check.id,
+                    check.name,
+                    check.workflow ?? "nil",
+                    check.bucket.rawValue,
+                    check.detailURL?.absoluteString ?? "nil",
+                    completedAt
+                ].joined(separator: ",")
+            }
+            .joined(separator: ";")
+        let threads = request.threads
+            .sorted { $0.id < $1.id }
+            .map { thread in
+                [
+                    thread.id,
+                    thread.author ?? "nil",
+                    thread.body,
+                    thread.url?.absoluteString ?? "nil",
+                    String(thread.isResolved),
+                    String(thread.isActionable)
+                ].joined(separator: ",")
+            }
+            .joined(separator: ";")
+        return [
+            request.id,
+            request.state.rawValue,
+            String(request.isDraft),
+            request.reviewDecision.rawValue,
+            request.mergeState.rawValue,
+            checks,
+            threads
+        ].joined(separator: "|")
     }
 
     var body: some View {

--- a/Alas/Sources/Center/ReviewEvidence/ReviewEvidenceTabView.swift
+++ b/Alas/Sources/Center/ReviewEvidence/ReviewEvidenceTabView.swift
@@ -324,7 +324,8 @@ struct ReviewEvidenceTabView: View {
             snapshot: snapshot,
             provider: provider,
             cwd: worktreePath,
-            initialSection: initialSection
+            initialSection: initialSection,
+            initialItemID: tabState.selectedItemID
         )
         model = loaded
         await loaded.load()
@@ -477,6 +478,9 @@ struct ReviewEvidenceTabView: View {
             if await rightPaneState.reviewLoop.rerunFailedChecks(snapshot: snapshot) {
                 await rightPaneState.refresh()
                 loadNonce += 1
+            } else {
+                let message = rightPaneState.reviewLoop.lastError ?? "Rerun failed."
+                model?.showSelectedDetailError(message)
             }
             isRerunningFailedChecks = false
         }

--- a/Alas/Sources/Center/ReviewEvidence/ReviewEvidenceTabView.swift
+++ b/Alas/Sources/Center/ReviewEvidence/ReviewEvidenceTabView.swift
@@ -347,6 +347,8 @@ struct ReviewEvidenceTabView: View {
             selectedItemID = loaded.selectedItemID
         }
         persistSelection(section: selectedSection, itemID: selectedItemID)
+        guard selectedItemID != nil else { return }
+        await loaded.loadSelectedDetail()
     }
 
     private func isSelected(_ item: ReviewEvidenceItem, in model: ReviewEvidenceModel) -> Bool {

--- a/Alas/Sources/Center/ReviewEvidence/ReviewEvidenceTabView.swift
+++ b/Alas/Sources/Center/ReviewEvidence/ReviewEvidenceTabView.swift
@@ -30,6 +30,11 @@ struct ReviewEvidenceTabView: View {
         return activeSnapshot
     }
 
+    private var canSendToAgent: Bool {
+        let agentID = appState.config.changes.aiToolId
+        return agentID != "none" && appState.agent(id: agentID) != nil
+    }
+
     private var loadKey: String {
         let head = snapshot?.local.headSHA ?? "no-head"
         let providerState = "\(snapshot?.providerAvailable == true):\(snapshot?.providerAuthenticated == true)"
@@ -299,6 +304,7 @@ struct ReviewEvidenceTabView: View {
             AlasButton(title: "Send to Agent", icon: "sparkle", style: .primary) {
                 appState.openReviewEvidenceHandoff(snapshot: snapshot, detail: detail)
             }
+            .disabled(!canSendToAgent)
         }
         .padding(.horizontal, 12)
         .padding(.vertical, 10)

--- a/Alas/Sources/Center/Tab.swift
+++ b/Alas/Sources/Center/Tab.swift
@@ -117,6 +117,13 @@ struct ReviewEvidenceTabState: Codable, Equatable, Identifiable {
         url = request.url
         title = request.title
     }
+
+    func matches(_ snapshot: ReviewLoopSnapshot) -> Bool {
+        guard let request = snapshot.reviewRequest else { return false }
+        return request.provider == provider
+            && request.remote.repositorySlug == repositorySlug
+            && request.number == number
+    }
 }
 
 struct CommitTabState: Codable, Equatable, Identifiable {

--- a/Alas/Sources/Center/Tab.swift
+++ b/Alas/Sources/Center/Tab.swift
@@ -103,10 +103,12 @@ struct ReviewEvidenceTabState: Codable, Equatable, Identifiable {
         self.title = request?.title ?? ""
         self.selectedSection = initialSection ?? .ci
         self.selectedItemID = nil
+        let host = remote?.host ?? self.url.host ?? ""
         self.id = [
             "review-evidence",
             worktreeId,
             provider.rawValue,
+            host,
             repositorySlug,
             "\(number)",
         ].joined(separator: ":")
@@ -121,6 +123,7 @@ struct ReviewEvidenceTabState: Codable, Equatable, Identifiable {
     func matches(_ snapshot: ReviewLoopSnapshot) -> Bool {
         guard let request = snapshot.reviewRequest else { return false }
         return request.provider == provider
+            && request.remote.host.lowercased() == (url.host ?? "").lowercased()
             && request.remote.repositorySlug == repositorySlug
             && request.number == number
     }

--- a/Alas/Sources/Center/Tab.swift
+++ b/Alas/Sources/Center/Tab.swift
@@ -10,6 +10,7 @@ enum Tab: Codable, Equatable, Identifiable {
     case commitEditor(CommitEditorTabState)
     case draftCommit(DraftCommitTabState)
     case draftReviewRequest(DraftReviewRequestTabState)
+    case reviewEvidence(ReviewEvidenceTabState)
     case imagePreview(ImagePreviewTabState)
     case mergeConflict(MergeConflictTabState)
     case acpSession(ACPSessionTabState)
@@ -23,6 +24,7 @@ enum Tab: Codable, Equatable, Identifiable {
         case .commitEditor(let s): return s.id
         case .draftCommit(let s):  return s.id
         case .draftReviewRequest(let s): return s.id
+        case .reviewEvidence(let s): return s.id
         case .imagePreview(let s): return s.id
         case .mergeConflict(let s): return s.id
         case .acpSession(let s):   return s.id
@@ -38,6 +40,7 @@ enum Tab: Codable, Equatable, Identifiable {
         case .commitEditor(let s): return s.title
         case .draftCommit:         return "Draft commit"
         case .draftReviewRequest(let s): return s.displayTitle
+        case .reviewEvidence(let s): return s.displayTitle
         case .imagePreview(let s): return s.title
         case .mergeConflict(let s): return s.title
         case .acpSession(let s):   return s.title
@@ -53,6 +56,7 @@ enum Tab: Codable, Equatable, Identifiable {
         case .commitEditor: return "commit"
         case .draftCommit:  return "commit"
         case .draftReviewRequest: return "pull-request"
+        case .reviewEvidence: return "doc.text.magnifyingglass"
         case .imagePreview: return "image"
         case .mergeConflict: return "diff"
         case .acpSession:   return "sparkle"
@@ -66,6 +70,52 @@ enum Tab: Codable, Equatable, Identifiable {
         case .mergeConflict(let s): return s.relativePath
         default:                   return nil
         }
+    }
+}
+
+struct ReviewEvidenceTabState: Codable, Equatable, Identifiable {
+    let id: TabID
+    let worktreeId: String
+    let provider: CodeHostKind
+    let repositorySlug: String
+    let number: Int
+    var url: URL
+    var title: String
+    var selectedSection: ReviewEvidenceSection
+    var selectedItemID: String?
+
+    var displayTitle: String {
+        "\(provider.reviewRequestLabel) evidence"
+    }
+
+    init(
+        worktreeId: String,
+        snapshot: ReviewLoopSnapshot,
+        initialSection: ReviewEvidenceSection?
+    ) {
+        let request = snapshot.reviewRequest
+        let remote = request?.remote ?? snapshot.remote
+        self.worktreeId = worktreeId
+        self.provider = request?.provider ?? remote?.kind ?? .github
+        self.repositorySlug = remote?.repositorySlug ?? ""
+        self.number = request?.number ?? 0
+        self.url = request?.url ?? remote?.webURL ?? URL(fileURLWithPath: "/")
+        self.title = request?.title ?? ""
+        self.selectedSection = initialSection ?? .ci
+        self.selectedItemID = nil
+        self.id = [
+            "review-evidence",
+            worktreeId,
+            provider.rawValue,
+            repositorySlug,
+            "\(number)",
+        ].joined(separator: ":")
+    }
+
+    mutating func refreshSnapshotMetadata(from snapshot: ReviewLoopSnapshot) {
+        guard let request = snapshot.reviewRequest else { return }
+        url = request.url
+        title = request.title
     }
 }
 

--- a/Alas/Sources/Center/TabsManager.swift
+++ b/Alas/Sources/Center/TabsManager.swift
@@ -680,6 +680,59 @@ final class TabsManager {
         return tab
     }
 
+    @discardableResult
+    func openOrFocusReviewEvidence(
+        worktreeId: String,
+        snapshot: ReviewLoopSnapshot,
+        initialSection: ReviewEvidenceSection?
+    ) -> Tab {
+        let baseState = ReviewEvidenceTabState(
+            worktreeId: worktreeId,
+            snapshot: snapshot,
+            initialSection: initialSection
+        )
+        if var file = byWorktree[worktreeId],
+           let idx = file.tabs.firstIndex(where: { $0.id == baseState.id }),
+           case .reviewEvidence(var existing) = file.tabs[idx] {
+            existing.refreshSnapshotMetadata(from: snapshot)
+            if let initialSection {
+                if existing.selectedSection != initialSection {
+                    existing.selectedItemID = nil
+                }
+                existing.selectedSection = initialSection
+            }
+            let tab = Tab.reviewEvidence(existing)
+            file.tabs[idx] = tab
+            file.activeTabId = tab.id
+            byWorktree[worktreeId] = file
+            persist(worktreeId)
+            return tab
+        }
+        let tab = Tab.reviewEvidence(baseState)
+        append(tab, to: worktreeId)
+        return tab
+    }
+
+    @discardableResult
+    func updateReviewEvidenceSelection(
+        worktreeId: String,
+        tabId: TabID,
+        selectedSection: ReviewEvidenceSection,
+        selectedItemID: String?
+    ) -> Tab? {
+        guard var file = byWorktree[worktreeId],
+              let idx = file.tabs.firstIndex(where: { $0.id == tabId }),
+              case .reviewEvidence(var state) = file.tabs[idx]
+        else { return nil }
+        state.selectedSection = selectedSection
+        state.selectedItemID = selectedItemID
+        let tab = Tab.reviewEvidence(state)
+        file.tabs[idx] = tab
+        byWorktree[worktreeId] = file
+        persist(worktreeId)
+        return tab
+    }
+
     /// Clear any stashed draft commit state for the given worktree.
     /// Used when the user explicitly discards the draft (via tab context
     /// menu) or after a successful commit consumes the draft.

--- a/Alas/Sources/Integrations/CodeHost/CodeHostProvider.swift
+++ b/Alas/Sources/Integrations/CodeHost/CodeHostProvider.swift
@@ -62,6 +62,20 @@ protocol CodeHostProvider: Sendable {
         cwd: URL
     ) async throws -> URL
     func checks(remote: CodeHostRemote, request: ReviewRequest, cwd: URL) async throws -> [ReviewCheck]
+    func failedCheckEvidence(remote: CodeHostRemote, request: ReviewRequest, cwd: URL) async throws -> [ReviewEvidenceItem]
+    func checkEvidenceDetail(
+        remote: CodeHostRemote,
+        request: ReviewRequest,
+        item: ReviewEvidenceItem,
+        cwd: URL
+    ) async throws -> ReviewEvidenceDetail
+    func feedbackEvidence(remote: CodeHostRemote, request: ReviewRequest, cwd: URL) async throws -> [ReviewEvidenceItem]
+    func feedbackEvidenceDetail(
+        remote: CodeHostRemote,
+        request: ReviewRequest,
+        item: ReviewEvidenceItem,
+        cwd: URL
+    ) async throws -> ReviewEvidenceDetail
     func rerunFailedChecks(
         remote: CodeHostRemote,
         branch: String,
@@ -73,6 +87,67 @@ protocol CodeHostProvider: Sendable {
 
 extension CodeHostProvider {
     var capabilities: CodeHostProviderCapabilities { .readOnly }
+
+    func failedCheckEvidence(remote: CodeHostRemote, request: ReviewRequest, cwd: URL) async throws -> [ReviewEvidenceItem] {
+        request.checks
+            .filter { $0.bucket == .fail }
+            .map {
+                ReviewEvidenceItem(
+                    id: $0.id,
+                    section: .ci,
+                    title: $0.name,
+                    subtitle: $0.workflow,
+                    status: .failed,
+                    providerURL: $0.detailURL
+                )
+            }
+    }
+
+    func checkEvidenceDetail(
+        remote: CodeHostRemote,
+        request: ReviewRequest,
+        item: ReviewEvidenceItem,
+        cwd: URL
+    ) async throws -> ReviewEvidenceDetail {
+        ReviewEvidenceDetail(
+            item: item,
+            body: "Open this check in the provider to inspect full logs.",
+            filePath: nil,
+            line: nil,
+            isTruncated: false
+        )
+    }
+
+    func feedbackEvidence(remote: CodeHostRemote, request: ReviewRequest, cwd: URL) async throws -> [ReviewEvidenceItem] {
+        request.threads
+            .filter { !$0.isResolved && $0.isActionable }
+            .map {
+                ReviewEvidenceItem(
+                    id: $0.id,
+                    section: .feedback,
+                    title: $0.author ?? "reviewer",
+                    subtitle: String($0.body.prefix(120)),
+                    status: .actionable,
+                    providerURL: $0.url
+                )
+            }
+    }
+
+    func feedbackEvidenceDetail(
+        remote: CodeHostRemote,
+        request: ReviewRequest,
+        item: ReviewEvidenceItem,
+        cwd: URL
+    ) async throws -> ReviewEvidenceDetail {
+        let thread = request.threads.first { $0.id == item.id }
+        return ReviewEvidenceDetail(
+            item: item,
+            body: thread?.body ?? "Open this feedback in the provider to inspect full context.",
+            filePath: nil,
+            line: nil,
+            isTruncated: false
+        )
+    }
 }
 
 struct CodeHostProviderRegistry: Sendable {

--- a/Alas/Sources/Integrations/CodeHost/CodeHostProvider.swift
+++ b/Alas/Sources/Integrations/CodeHost/CodeHostProvider.swift
@@ -119,7 +119,7 @@ extension CodeHostProvider {
     }
 
     func feedbackEvidence(remote: CodeHostRemote, request: ReviewRequest, cwd: URL) async throws -> [ReviewEvidenceItem] {
-        request.threads
+        let items = request.threads
             .filter { !$0.isResolved && $0.isActionable }
             .map {
                 ReviewEvidenceItem(
@@ -131,6 +131,10 @@ extension CodeHostProvider {
                     providerURL: $0.url
                 )
             }
+        if items.isEmpty, request.reviewDecision == .changesRequested {
+            return [ReviewEvidenceFallbacks.changesRequestedItem(request: request)]
+        }
+        return items
     }
 
     func feedbackEvidenceDetail(
@@ -139,6 +143,9 @@ extension CodeHostProvider {
         item: ReviewEvidenceItem,
         cwd: URL
     ) async throws -> ReviewEvidenceDetail {
+        if item.id == ReviewEvidenceFallbacks.changesRequestedID {
+            return ReviewEvidenceFallbacks.changesRequestedDetail(item: item, request: request)
+        }
         let thread = request.threads.first { $0.id == item.id }
         return ReviewEvidenceDetail(
             item: item,

--- a/Alas/Sources/Integrations/CodeHost/GitHubCLIProvider.swift
+++ b/Alas/Sources/Integrations/CodeHost/GitHubCLIProvider.swift
@@ -191,9 +191,14 @@ struct GitHubCLIProvider: CodeHostProvider {
             )
         }
 
+        var args = ["run", "view", runID, "--log-failed", "-R", remote.repositorySlug]
+        if let jobID = Self.githubJobID(from: item.providerURL) {
+            args.append(contentsOf: ["--job", jobID])
+        }
+
         let result = try await runner.run(
             "gh",
-            args: ["run", "view", runID, "--log-failed", "-R", remote.repositorySlug],
+            args: args,
             cwd: cwd
         )
         guard result.exitCode == 0 else {
@@ -402,6 +407,20 @@ struct GitHubCLIProvider: CodeHostProvider {
         }
         let runID = components[runIDIndex]
         return runID.isEmpty ? nil : runID
+    }
+
+    static func githubJobID(from url: URL?) -> String? {
+        guard let url else { return nil }
+        let components = url.pathComponents
+        guard let jobIndex = components.firstIndex(of: "job") else {
+            return nil
+        }
+        let jobIDIndex = components.index(after: jobIndex)
+        guard jobIDIndex < components.endIndex else {
+            return nil
+        }
+        let jobID = components[jobIDIndex]
+        return jobID.isEmpty ? nil : jobID
     }
 
     private static func parseReviewThreadsPage(_ json: String) throws -> ReviewThreadsPage {

--- a/Alas/Sources/Integrations/CodeHost/GitHubCLIProvider.swift
+++ b/Alas/Sources/Integrations/CodeHost/GitHubCLIProvider.swift
@@ -159,6 +159,68 @@ struct GitHubCLIProvider: CodeHostProvider {
         return try Self.parseChecks(result.stdout)
     }
 
+    func failedCheckEvidence(remote: CodeHostRemote, request: ReviewRequest, cwd: URL) async throws -> [ReviewEvidenceItem] {
+        request.checks
+            .filter { $0.bucket == .fail }
+            .map {
+                ReviewEvidenceItem(
+                    id: $0.id,
+                    section: .ci,
+                    title: $0.name,
+                    subtitle: $0.workflow,
+                    status: .failed,
+                    providerURL: $0.detailURL
+                )
+            }
+    }
+
+    func checkEvidenceDetail(
+        remote: CodeHostRemote,
+        request: ReviewRequest,
+        item: ReviewEvidenceItem,
+        cwd: URL
+    ) async throws -> ReviewEvidenceDetail {
+        _ = request
+        guard let runID = Self.githubRunID(from: item.providerURL) else {
+            return ReviewEvidenceDetail(
+                item: item,
+                body: "Open this check in GitHub to inspect full logs.",
+                filePath: nil,
+                line: nil,
+                isTruncated: false
+            )
+        }
+
+        let result = try await runner.run(
+            "gh",
+            args: ["run", "view", runID, "--log-failed", "-R", remote.repositorySlug],
+            cwd: cwd
+        )
+        guard result.exitCode == 0 else {
+            throw CodeHostProviderError.commandFailed(command: "gh run view", stderr: result.stderr)
+        }
+
+        return ReviewEvidenceDetail.truncated(item: item, body: result.stdout, filePath: nil, line: nil)
+    }
+
+    func feedbackEvidenceDetail(
+        remote: CodeHostRemote,
+        request: ReviewRequest,
+        item: ReviewEvidenceItem,
+        cwd: URL
+    ) async throws -> ReviewEvidenceDetail {
+        _ = remote
+        _ = cwd
+        let thread = request.threads.first { $0.id == item.id }
+        return ReviewEvidenceDetail(
+            item: item,
+            body: thread?.body ?? "Open this thread in GitHub to inspect full context.",
+            filePath: nil,
+            line: nil,
+            isTruncated: false
+        )
+    }
+
     private func reviewThreads(
         remote: CodeHostRemote,
         request: ReviewRequest,
@@ -326,6 +388,20 @@ struct GitHubCLIProvider: CodeHostProvider {
 
     static func parseReviewThreads(_ json: String) throws -> [ReviewThreadSummary] {
         try parseReviewThreadsPage(json).threads
+    }
+
+    static func githubRunID(from url: URL?) -> String? {
+        guard let url else { return nil }
+        let components = url.pathComponents
+        guard let runsIndex = components.firstIndex(of: "runs") else {
+            return nil
+        }
+        let runIDIndex = components.index(after: runsIndex)
+        guard runIDIndex < components.endIndex else {
+            return nil
+        }
+        let runID = components[runIDIndex]
+        return runID.isEmpty ? nil : runID
     }
 
     private static func parseReviewThreadsPage(_ json: String) throws -> ReviewThreadsPage {

--- a/Alas/Sources/Integrations/CodeHost/GitHubCLIProvider.swift
+++ b/Alas/Sources/Integrations/CodeHost/GitHubCLIProvider.swift
@@ -216,6 +216,9 @@ struct GitHubCLIProvider: CodeHostProvider {
     ) async throws -> ReviewEvidenceDetail {
         _ = remote
         _ = cwd
+        if item.id == ReviewEvidenceFallbacks.changesRequestedID {
+            return ReviewEvidenceFallbacks.changesRequestedDetail(item: item, request: request)
+        }
         let thread = request.threads.first { $0.id == item.id }
         return ReviewEvidenceDetail(
             item: item,

--- a/Alas/Sources/Integrations/CodeHost/GitLabCLIProvider.swift
+++ b/Alas/Sources/Integrations/CodeHost/GitLabCLIProvider.swift
@@ -138,6 +138,73 @@ struct GitLabCLIProvider: CodeHostProvider {
         return try Self.parsePipeline(result.stdout)
     }
 
+    func failedCheckEvidence(remote: CodeHostRemote, request: ReviewRequest, cwd: URL) async throws -> [ReviewEvidenceItem] {
+        request.checks
+            .filter { $0.bucket == .fail }
+            .map {
+                ReviewEvidenceItem(
+                    id: $0.id,
+                    section: .ci,
+                    title: $0.name,
+                    subtitle: $0.workflow,
+                    status: .failed,
+                    providerURL: $0.detailURL
+                )
+            }
+    }
+
+    func checkEvidenceDetail(
+        remote: CodeHostRemote,
+        request: ReviewRequest,
+        item: ReviewEvidenceItem,
+        cwd: URL
+    ) async throws -> ReviewEvidenceDetail {
+        _ = request
+        guard let jobID = Self.gitLabJobID(from: item.providerURL) else {
+            return ReviewEvidenceDetail(
+                item: item,
+                body: "Open this job in GitLab to inspect full logs.",
+                filePath: nil,
+                line: nil,
+                isTruncated: false
+            )
+        }
+
+        let result = try await runner.run(
+            "glab",
+            args: ["ci", "trace", jobID, "-R", remote.repositorySlug],
+            cwd: cwd
+        )
+        guard result.exitCode == 0 else {
+            throw CodeHostProviderError.commandFailed(command: "glab ci trace", stderr: result.stderr)
+        }
+
+        return ReviewEvidenceDetail.truncated(
+            item: item,
+            body: result.stdout,
+            filePath: nil,
+            line: nil
+        )
+    }
+
+    func feedbackEvidenceDetail(
+        remote: CodeHostRemote,
+        request: ReviewRequest,
+        item: ReviewEvidenceItem,
+        cwd: URL
+    ) async throws -> ReviewEvidenceDetail {
+        _ = remote
+        _ = cwd
+        let thread = request.threads.first { $0.id == item.id }
+        return ReviewEvidenceDetail(
+            item: item,
+            body: thread?.body ?? "Open this discussion in GitLab to inspect full context.",
+            filePath: nil,
+            line: nil,
+            isTruncated: false
+        )
+    }
+
     func rerunFailedChecks(
         remote: CodeHostRemote,
         branch: String,
@@ -595,6 +662,22 @@ struct GitLabCLIProvider: CodeHostProvider {
         var components = URLComponents(url: requestURL, resolvingAgainstBaseURL: false)
         components?.fragment = "note_\(id)"
         return components?.url
+    }
+
+    static func gitLabJobID(from url: URL?) -> String? {
+        guard let url else {
+            return nil
+        }
+        let pathComponents = url.pathComponents
+        guard let jobsIndex = pathComponents.firstIndex(of: "jobs") else {
+            return nil
+        }
+        let idIndex = pathComponents.index(after: jobsIndex)
+        guard idIndex < pathComponents.endIndex else {
+            return nil
+        }
+        let id = pathComponents[idIndex].trimmingCharacters(in: .whitespacesAndNewlines)
+        return id.isEmpty ? nil : id
     }
 
     private static func checkID(for pipeline: GitLabPipeline) -> String {

--- a/Alas/Sources/Integrations/CodeHost/GitLabCLIProvider.swift
+++ b/Alas/Sources/Integrations/CodeHost/GitLabCLIProvider.swift
@@ -195,6 +195,9 @@ struct GitLabCLIProvider: CodeHostProvider {
     ) async throws -> ReviewEvidenceDetail {
         _ = remote
         _ = cwd
+        if item.id == ReviewEvidenceFallbacks.changesRequestedID {
+            return ReviewEvidenceFallbacks.changesRequestedDetail(item: item, request: request)
+        }
         let thread = request.threads.first { $0.id == item.id }
         return ReviewEvidenceDetail(
             item: item,

--- a/Alas/Sources/Integrations/CodeHost/ReviewEvidence.swift
+++ b/Alas/Sources/Integrations/CodeHost/ReviewEvidence.swift
@@ -1,0 +1,112 @@
+import Foundation
+
+enum ReviewEvidenceSection: String, Codable, Equatable, Sendable, CaseIterable {
+    case ci
+    case feedback
+
+    var displayName: String {
+        switch self {
+        case .ci: "CI"
+        case .feedback: "Feedback"
+        }
+    }
+}
+
+enum ReviewEvidenceStatus: String, Codable, Equatable, Sendable {
+    case failed
+    case pending
+    case passed
+    case cancelled
+    case actionable
+    case resolved
+    case unknown
+
+    var isBlocking: Bool {
+        switch self {
+        case .failed, .actionable:
+            true
+        case .pending, .passed, .cancelled, .resolved, .unknown:
+            false
+        }
+    }
+}
+
+struct ReviewEvidenceItem: Identifiable, Codable, Equatable, Sendable {
+    let id: String
+    let section: ReviewEvidenceSection
+    let title: String
+    let subtitle: String?
+    let status: ReviewEvidenceStatus
+    let providerURL: URL?
+}
+
+struct ReviewEvidenceDetail: Codable, Equatable, Sendable {
+    let item: ReviewEvidenceItem
+    let body: String
+    let filePath: String?
+    let line: Int?
+    let isTruncated: Bool
+
+    static func truncated(
+        item: ReviewEvidenceItem,
+        body: String,
+        filePath: String?,
+        line: Int?,
+        maxLength: Int = 8_000
+    ) -> ReviewEvidenceDetail {
+        guard body.count > maxLength else {
+            return ReviewEvidenceDetail(item: item, body: body, filePath: filePath, line: line, isTruncated: false)
+        }
+
+        let marker = "\n\n[Log truncated by Alas.]"
+        guard maxLength > marker.count else {
+            return ReviewEvidenceDetail(
+                item: item,
+                body: String(marker.prefix(max(0, maxLength))),
+                filePath: filePath,
+                line: line,
+                isTruncated: true
+            )
+        }
+
+        let prefixLength = max(0, maxLength - marker.count)
+        return ReviewEvidenceDetail(
+            item: item,
+            body: String(body.prefix(prefixLength)) + marker,
+            filePath: filePath,
+            line: line,
+            isTruncated: true
+        )
+    }
+}
+
+enum ReviewEvidenceContextFormatter {
+    static func format(_ detail: ReviewEvidenceDetail) -> String {
+        var lines: [String] = [
+            "Section: \(detail.item.section.displayName)",
+            "Title: \(detail.item.title)",
+            "Status: \(detail.item.status.rawValue)",
+        ]
+
+        if let subtitle = detail.item.subtitle, !subtitle.isEmpty {
+            lines.append("Source: \(subtitle)")
+        }
+        if let url = detail.item.providerURL {
+            lines.append("URL: \(url.absoluteString)")
+        }
+        if let filePath = detail.filePath {
+            if let line = detail.line {
+                lines.append("Location: \(filePath):\(line)")
+            } else {
+                lines.append("Location: \(filePath)")
+            }
+        }
+        if detail.isTruncated {
+            lines.append("Truncated: true")
+        }
+
+        lines.append("")
+        lines.append(detail.body)
+        return lines.joined(separator: "\n")
+    }
+}

--- a/Alas/Sources/Integrations/CodeHost/ReviewEvidence.swift
+++ b/Alas/Sources/Integrations/CodeHost/ReviewEvidence.swift
@@ -80,6 +80,35 @@ struct ReviewEvidenceDetail: Codable, Equatable, Sendable {
     }
 }
 
+enum ReviewEvidenceFallbacks {
+    static let changesRequestedID = "review-decision:changes-requested"
+
+    static func changesRequestedItem(request: ReviewRequest) -> ReviewEvidenceItem {
+        ReviewEvidenceItem(
+            id: changesRequestedID,
+            section: .feedback,
+            title: "Changes requested",
+            subtitle: "No unresolved review thread summaries were loaded.",
+            status: .actionable,
+            providerURL: request.url
+        )
+    }
+
+    static func changesRequestedDetail(item: ReviewEvidenceItem, request: ReviewRequest) -> ReviewEvidenceDetail {
+        ReviewEvidenceDetail(
+            item: item,
+            body: """
+            The \(request.provider.reviewRequestLabel) review decision is changes requested, but Alas did not load any unresolved review thread summaries for this request.
+
+            Open the \(request.provider.reviewRequestLabel) in \(request.provider.displayName) to inspect the full review, or send this context to an agent with the review request URL.
+            """,
+            filePath: nil,
+            line: nil,
+            isTruncated: false
+        )
+    }
+}
+
 enum ReviewEvidenceContextFormatter {
     static func format(_ detail: ReviewEvidenceDetail) -> String {
         var lines: [String] = [

--- a/Alas/Sources/Integrations/CodeHost/ReviewEvidenceModel.swift
+++ b/Alas/Sources/Integrations/CodeHost/ReviewEvidenceModel.swift
@@ -1,0 +1,153 @@
+import Foundation
+import Observation
+
+@Observable
+@MainActor
+final class ReviewEvidenceModel {
+    let snapshot: ReviewLoopSnapshot
+    private let provider: any CodeHostProvider
+    private let cwd: URL
+    private let initialSection: ReviewEvidenceSection?
+    private var detailRequestID = 0
+
+    private(set) var ciItems: [ReviewEvidenceItem] = []
+    private(set) var feedbackItems: [ReviewEvidenceItem] = []
+    private(set) var selectedSection: ReviewEvidenceSection
+    private(set) var selectedItemID: String?
+    private(set) var selectedDetail: ReviewEvidenceDetail?
+    private(set) var isLoadingList = false
+    private(set) var isLoadingDetail = false
+    private(set) var errorMessage: String?
+
+    var selectedItem: ReviewEvidenceItem? {
+        guard let selectedItemID else { return nil }
+        return items(for: selectedSection).first { $0.id == selectedItemID }
+    }
+
+    init(
+        snapshot: ReviewLoopSnapshot,
+        provider: any CodeHostProvider,
+        cwd: URL,
+        initialSection: ReviewEvidenceSection?
+    ) {
+        self.snapshot = snapshot
+        self.provider = provider
+        self.cwd = cwd
+        self.initialSection = initialSection
+        self.selectedSection = initialSection ?? .ci
+    }
+
+    func load() async {
+        guard let remote = snapshot.remote, let request = snapshot.reviewRequest else {
+            errorMessage = "Review request not found."
+            return
+        }
+
+        isLoadingList = true
+        errorMessage = nil
+
+        do {
+            async let ci = provider.failedCheckEvidence(remote: remote, request: request, cwd: cwd)
+            async let feedback = provider.feedbackEvidence(remote: remote, request: request, cwd: cwd)
+            let (loadedCI, loadedFeedback) = try await (ci, feedback)
+            ciItems = loadedCI
+            feedbackItems = loadedFeedback
+            chooseInitialSelection()
+            isLoadingList = false
+        } catch {
+            isLoadingList = false
+            errorMessage = error.localizedDescription
+        }
+    }
+
+    func select(itemID: String, section: ReviewEvidenceSection) {
+        detailRequestID += 1
+        selectedSection = section
+        selectedItemID = itemID
+        selectedDetail = nil
+        isLoadingDetail = false
+    }
+
+    func loadSelectedDetail() async {
+        guard let remote = snapshot.remote, let request = snapshot.reviewRequest else {
+            errorMessage = "Review request not found."
+            return
+        }
+        guard let item = selectedItem else {
+            selectedDetail = nil
+            return
+        }
+
+        detailRequestID += 1
+        let requestID = detailRequestID
+        let requestedItemID = item.id
+        let requestedSection = item.section
+        isLoadingDetail = true
+        errorMessage = nil
+
+        do {
+            let detail: ReviewEvidenceDetail
+            switch item.section {
+            case .ci:
+                detail = try await provider.checkEvidenceDetail(
+                    remote: remote,
+                    request: request,
+                    item: item,
+                    cwd: cwd
+                )
+            case .feedback:
+                detail = try await provider.feedbackEvidenceDetail(
+                    remote: remote,
+                    request: request,
+                    item: item,
+                    cwd: cwd
+                )
+            }
+            guard requestID == detailRequestID,
+                  selectedItemID == requestedItemID,
+                  selectedSection == requestedSection
+            else { return }
+            selectedDetail = detail
+        } catch {
+            guard requestID == detailRequestID,
+                  selectedItemID == requestedItemID,
+                  selectedSection == requestedSection
+            else { return }
+            errorMessage = error.localizedDescription
+            selectedDetail = ReviewEvidenceDetail(
+                item: item,
+                body: error.localizedDescription,
+                filePath: nil,
+                line: nil,
+                isTruncated: false
+            )
+        }
+        isLoadingDetail = false
+    }
+
+    func items(for section: ReviewEvidenceSection) -> [ReviewEvidenceItem] {
+        switch section {
+        case .ci:
+            ciItems
+        case .feedback:
+            feedbackItems
+        }
+    }
+
+    private func chooseInitialSelection() {
+        if let selectedItemID, items(for: selectedSection).contains(where: { $0.id == selectedItemID }) {
+            return
+        }
+
+        if initialSection == .feedback, let item = feedbackItems.first {
+            select(itemID: item.id, section: .feedback)
+        } else if let item = ciItems.first {
+            select(itemID: item.id, section: .ci)
+        } else if let item = feedbackItems.first {
+            select(itemID: item.id, section: .feedback)
+        } else {
+            selectedItemID = nil
+            selectedDetail = nil
+        }
+    }
+}

--- a/Alas/Sources/Integrations/CodeHost/ReviewEvidenceModel.swift
+++ b/Alas/Sources/Integrations/CodeHost/ReviewEvidenceModel.swift
@@ -28,13 +28,15 @@ final class ReviewEvidenceModel {
         snapshot: ReviewLoopSnapshot,
         provider: any CodeHostProvider,
         cwd: URL,
-        initialSection: ReviewEvidenceSection?
+        initialSection: ReviewEvidenceSection?,
+        initialItemID: String? = nil
     ) {
         self.snapshot = snapshot
         self.provider = provider
         self.cwd = cwd
         self.initialSection = initialSection
         self.selectedSection = initialSection ?? .ci
+        self.selectedItemID = initialItemID
     }
 
     func load() async {
@@ -132,6 +134,28 @@ final class ReviewEvidenceModel {
         case .feedback:
             feedbackItems
         }
+    }
+
+    func showSelectedDetailError(_ message: String) {
+        guard let item = selectedItem else {
+            errorMessage = message
+            return
+        }
+        errorMessage = message
+        let existingBody = selectedDetail?.body
+        let body: String
+        if let existingBody, !existingBody.isEmpty {
+            body = "\(message)\n\n\(existingBody)"
+        } else {
+            body = message
+        }
+        selectedDetail = ReviewEvidenceDetail(
+            item: item,
+            body: body,
+            filePath: selectedDetail?.filePath,
+            line: selectedDetail?.line,
+            isTruncated: selectedDetail?.isTruncated ?? false
+        )
     }
 
     private func chooseInitialSelection() {

--- a/Alas/Sources/Integrations/CodeHost/ReviewLoopHandoffBuilder.swift
+++ b/Alas/Sources/Integrations/CodeHost/ReviewLoopHandoffBuilder.swift
@@ -55,6 +55,64 @@ enum ReviewLoopHandoffBuilder {
         return truncate(lines.joined(separator: "\n"))
     }
 
+    static func buildSelectedEvidencePrompt(snapshot: ReviewLoopSnapshot, detail: ReviewEvidenceDetail) -> String {
+        let finalInstruction = "Please inspect the relevant files, explain the likely cause, and propose the smallest safe fix. Do not merge or post remote comments."
+        let header: [String]
+        guard let request = snapshot.reviewRequest else {
+            header = [
+                "Investigate this review-loop evidence item for Alas.",
+                "",
+                "Branch: \(snapshot.local.branchName)",
+                "Base: \(snapshot.local.baseBranch)",
+                "Evidence section: \(detail.item.section.displayName)",
+                "",
+            ]
+            return buildSelectedEvidencePrompt(header: header, detail: detail, finalInstruction: finalInstruction)
+        }
+
+        header = [
+            "Investigate this review-loop evidence item for Alas.",
+            "",
+            "\(request.provider.displayName) \(request.provider.reviewRequestLabel): \(request.url.absoluteString)",
+            "Title: \(request.title)",
+            "Branch: \(snapshot.local.branchName)",
+            "Base: \(request.baseRefName)",
+            "Head SHA: \(snapshot.local.headSHA)",
+            "Evidence section: \(detail.item.section.displayName)",
+            "",
+        ]
+        return buildSelectedEvidencePrompt(header: header, detail: detail, finalInstruction: finalInstruction)
+    }
+
+    private static func buildSelectedEvidencePrompt(
+        header: [String],
+        detail: ReviewEvidenceDetail,
+        finalInstruction: String
+    ) -> String {
+        let headerText = header.joined(separator: "\n")
+        let footerText = "\n\n\(finalInstruction)"
+        let availableContextLength = maxPromptLength - headerText.count - footerText.count
+        let context = truncateEvidenceContext(
+            ReviewEvidenceContextFormatter.format(detail),
+            maxLength: max(0, availableContextLength)
+        )
+        let prompt = headerText + context + footerText
+        guard prompt.count <= maxPromptLength else {
+            let availableHeaderLength = max(0, maxPromptLength - context.count - footerText.count)
+            return String(headerText.prefix(availableHeaderLength)) + context + footerText
+        }
+        return prompt
+    }
+
+    private static func truncateEvidenceContext(_ context: String, maxLength: Int) -> String {
+        guard context.count > maxLength else { return context }
+        let marker = "\n\n[Evidence context truncated by Alas.]"
+        guard maxLength > marker.count else {
+            return String(marker.prefix(max(0, maxLength)))
+        }
+        return String(context.prefix(maxLength - marker.count)) + marker
+    }
+
     private static func truncate(_ prompt: String) -> String {
         guard prompt.count > maxPromptLength else { return prompt }
         return String(prompt.prefix(maxPromptLength)) + "\n\n[Context truncated by Alas.]"

--- a/Alas/Sources/Integrations/CodeHost/ReviewReadinessModel.swift
+++ b/Alas/Sources/Integrations/CodeHost/ReviewReadinessModel.swift
@@ -47,6 +47,7 @@ struct ReviewReadinessModel: Equatable, Sendable {
             case .createReviewRequest: "plus"
             case .openReviewRequest: "arrow.up.right.square"
             case .rerunFailedChecks: "arrow.clockwise"
+            case .inspectReviewEvidence: "doc.text.magnifyingglass"
             case .openAgentHandoff: "sparkle"
             case .merge: "arrow.triangle.merge"
             }
@@ -54,9 +55,9 @@ struct ReviewReadinessModel: Equatable, Sendable {
 
         var emphasis: Emphasis {
             switch kind {
-            case .pushBranch, .forcePushBranch, .createReviewRequest, .openAgentHandoff:
+            case .pushBranch, .forcePushBranch, .createReviewRequest, .inspectReviewEvidence:
                 .primary
-            case .refresh, .openReviewRequest, .rerunFailedChecks, .merge:
+            case .refresh, .openReviewRequest, .rerunFailedChecks, .openAgentHandoff, .merge:
                 .normal
             }
         }
@@ -203,8 +204,8 @@ struct ReviewReadinessModel: Equatable, Sendable {
             if request.hasRerunnableFailedCheck, snapshot.providerCapabilities.canRerunFailedChecks {
                 actions.append(Action(kind: .rerunFailedChecks, title: "Rerun", isEnabled: true))
             }
-            if (request.worstCheckBucket == .fail || request.hasActionableFeedback), canOpenAgentHandoff {
-                actions.append(Action(kind: .openAgentHandoff, title: "Open in Agent", isEnabled: true))
+            if request.worstCheckBucket == .fail || request.hasActionableFeedback {
+                actions.append(Action(kind: .inspectReviewEvidence, title: "Inspect", isEnabled: true))
             }
         } else if canCreateReviewRequest(snapshot) {
             actions.append(Action(kind: .createReviewRequest, title: "Create \(requestLabel)", isEnabled: true))
@@ -276,6 +277,7 @@ enum ReviewReadinessActionKind: String, Codable, Equatable, Sendable {
     case createReviewRequest
     case openReviewRequest
     case rerunFailedChecks
+    case inspectReviewEvidence
     case openAgentHandoff
     case merge
 }

--- a/Alas/Sources/Right/RightPaneState.swift
+++ b/Alas/Sources/Right/RightPaneState.swift
@@ -246,6 +246,23 @@ final class RightPaneState {
         case .openAgentHandoff:
             guard canOpenReviewLoopHandoff(appState: appState) else { return }
             appState.openReviewLoopHandoff(from: reviewLoop, actionKind: action)
+        case .inspectReviewEvidence:
+            guard let snapshot = reviewLoop.snapshot,
+                  snapshot.reviewRequest != nil
+            else { return }
+            let section: ReviewEvidenceSection?
+            if snapshot.reviewRequest?.worstCheckBucket == .fail {
+                section = .ci
+            } else if snapshot.reviewRequest?.hasActionableFeedback == true {
+                section = .feedback
+            } else {
+                section = nil
+            }
+            appState.tabs.openOrFocusReviewEvidence(
+                worktreeId: worktree.id,
+                snapshot: snapshot,
+                initialSection: section
+            )
         case .pushBranch, .forcePushBranch:
             guard let snapshot = reviewLoop.snapshot else { return }
             Task { @MainActor in

--- a/AlasTests/Integrations/CodeHostProviderTests.swift
+++ b/AlasTests/Integrations/CodeHostProviderTests.swift
@@ -55,6 +55,90 @@ struct CodeHostProviderTests {
         #expect(result.stdout.trimmingCharacters(in: .whitespacesAndNewlines) == "/custom/provider/bin:/usr/bin:/bin")
     }
 
+    @Test func defaultEvidenceMethodsUseSummaryData() async throws {
+        let remote = CodeHostRemote(
+            kind: .github,
+            host: "github.com",
+            owner: "mrmans0n",
+            repository: "alas",
+            remoteName: "origin",
+            webURL: URL(string: "https://github.com/mrmans0n/alas")!
+        )
+        let request = ReviewRequest(
+            remote: remote,
+            number: 42,
+            title: "Review evidence",
+            url: URL(string: "https://github.com/mrmans0n/alas/pull/42")!,
+            state: .open,
+            isDraft: false,
+            headRefName: "feature/evidence",
+            baseRefName: "main",
+            reviewDecision: .changesRequested,
+            mergeState: .blocked,
+            checks: [
+                ReviewCheck(
+                    id: "check-passed",
+                    name: "build",
+                    workflow: "CI",
+                    bucket: .pass,
+                    detailURL: URL(string: "https://github.com/build")!,
+                    completedAt: nil
+                ),
+                ReviewCheck(
+                    id: "check-1",
+                    name: "test",
+                    workflow: "CI",
+                    bucket: .fail,
+                    detailURL: URL(string: "https://github.com/run")!,
+                    completedAt: nil
+                ),
+                ReviewCheck(
+                    id: "check-pending",
+                    name: "lint",
+                    workflow: "CI",
+                    bucket: .pending,
+                    detailURL: URL(string: "https://github.com/lint")!,
+                    completedAt: nil
+                ),
+            ],
+            threads: [
+                ReviewThreadSummary(
+                    id: "thread-1",
+                    author: "reviewer",
+                    body: "Please fix this.",
+                    url: URL(string: "https://github.com/thread")!,
+                    isResolved: false,
+                    isActionable: true
+                ),
+                ReviewThreadSummary(
+                    id: "thread-resolved",
+                    author: "reviewer",
+                    body: "Already handled.",
+                    url: URL(string: "https://github.com/resolved")!,
+                    isResolved: true,
+                    isActionable: true
+                ),
+                ReviewThreadSummary(
+                    id: "thread-non-actionable",
+                    author: "reviewer",
+                    body: "Looks good.",
+                    url: URL(string: "https://github.com/non-actionable")!,
+                    isResolved: false,
+                    isActionable: false
+                ),
+            ]
+        )
+        let provider = FakeCodeHostProvider(kind: .github)
+
+        let ci = try await provider.failedCheckEvidence(remote: remote, request: request, cwd: URL(fileURLWithPath: "/tmp/alas"))
+        let feedback = try await provider.feedbackEvidence(remote: remote, request: request, cwd: URL(fileURLWithPath: "/tmp/alas"))
+
+        #expect(ci.map(\.id) == ["check-1"])
+        #expect(ci.first?.status == .failed)
+        #expect(feedback.map(\.id) == ["thread-1"])
+        #expect(feedback.first?.status == .actionable)
+    }
+
     private struct FakeCodeHostProvider: CodeHostProvider {
         let kind: CodeHostKind
         let capabilities: CodeHostProviderCapabilities = .readOnly

--- a/AlasTests/Integrations/CodeHostProviderTests.swift
+++ b/AlasTests/Integrations/CodeHostProviderTests.swift
@@ -139,6 +139,45 @@ struct CodeHostProviderTests {
         #expect(feedback.first?.status == .actionable)
     }
 
+    @Test func defaultFeedbackEvidenceSynthesizesChangesRequestedWhenThreadsAreMissing() async throws {
+        let remote = CodeHostRemote(
+            kind: .github,
+            host: "github.com",
+            owner: "mrmans0n",
+            repository: "alas",
+            remoteName: "origin",
+            webURL: URL(string: "https://github.com/mrmans0n/alas")!
+        )
+        let request = ReviewRequest(
+            remote: remote,
+            number: 42,
+            title: "Review evidence",
+            url: URL(string: "https://github.com/mrmans0n/alas/pull/42")!,
+            state: .open,
+            isDraft: false,
+            headRefName: "feature/evidence",
+            baseRefName: "main",
+            reviewDecision: .changesRequested,
+            mergeState: .blocked,
+            checks: [],
+            threads: []
+        )
+        let provider = FakeCodeHostProvider(kind: .github)
+
+        let feedback = try await provider.feedbackEvidence(remote: remote, request: request, cwd: URL(fileURLWithPath: "/tmp/alas"))
+        let detail = try await provider.feedbackEvidenceDetail(
+            remote: remote,
+            request: request,
+            item: #require(feedback.first),
+            cwd: URL(fileURLWithPath: "/tmp/alas")
+        )
+
+        #expect(feedback.map(\.id) == [ReviewEvidenceFallbacks.changesRequestedID])
+        #expect(feedback.first?.status == .actionable)
+        #expect(detail.body.contains("review decision is changes requested"))
+        #expect(detail.item.providerURL == request.url)
+    }
+
     private struct FakeCodeHostProvider: CodeHostProvider {
         let kind: CodeHostKind
         let capabilities: CodeHostProviderCapabilities = .readOnly

--- a/AlasTests/Integrations/GitHubCLIProviderTests.swift
+++ b/AlasTests/Integrations/GitHubCLIProviderTests.swift
@@ -356,6 +356,80 @@ struct GitHubCLIProviderTests {
         #expect(checks[0].bucket == .fail)
     }
 
+    @Test func failedCheckEvidenceUsesFailedChecksOnly() async throws {
+        let checks = try GitHubCLIProvider.parseChecks(Self.failedChecksOutput)
+        let request = Self.makeRequest(checks: checks)
+
+        let evidence = try await GitHubCLIProvider().failedCheckEvidence(
+            remote: Self.remote,
+            request: request,
+            cwd: Self.cwd
+        )
+
+        #expect(evidence == [
+            ReviewEvidenceItem(
+                id: checks[0].id,
+                section: .ci,
+                title: "test",
+                subtitle: "CI",
+                status: .failed,
+                providerURL: URL(string: "https://github.com/mrmans0n/alas/actions/runs/1/job/3")
+            ),
+        ])
+    }
+
+    @Test func checkEvidenceDetailLoadsRunLogForWorkflowCheck() async throws {
+        let checks = try GitHubCLIProvider.parseChecks(Self.failedChecksOutput)
+        let request = Self.makeRequest(checks: checks)
+        let runner = FakeRunner(results: [
+            ProcessResult(exitCode: 0, stdout: "failure details", stderr: ""),
+        ])
+        let provider = GitHubCLIProvider(runner: runner)
+        let item = try #require(try await provider.failedCheckEvidence(
+            remote: Self.remote,
+            request: request,
+            cwd: Self.cwd
+        ).first)
+
+        let detail = try await provider.checkEvidenceDetail(
+            remote: Self.remote,
+            request: request,
+            item: item,
+            cwd: Self.cwd
+        )
+
+        #expect(detail.body.contains("failure details"))
+        #expect(detail.isTruncated == false)
+        #expect(await runner.commands == [
+            FakeRunner.Command(
+                executable: "gh",
+                args: ["run", "view", "1", "--log-failed", "-R", "mrmans0n/alas"],
+                cwd: Self.cwd
+            ),
+        ])
+    }
+
+    @Test func feedbackEvidenceDetailUsesThreadBody() async throws {
+        let threads = try GitHubCLIProvider.parseReviewThreads(Self.reviewThreadsOutput)
+        let request = Self.makeRequest(threads: threads)
+        let provider = GitHubCLIProvider()
+        let item = try #require(try await provider.feedbackEvidence(
+            remote: Self.remote,
+            request: request,
+            cwd: Self.cwd
+        ).first)
+
+        let detail = try await provider.feedbackEvidenceDetail(
+            remote: Self.remote,
+            request: request,
+            item: item,
+            cwd: Self.cwd
+        )
+
+        #expect(detail.body == "Please tighten this branch lookup.")
+        #expect(detail.item.providerURL == URL(string: "https://github.com/mrmans0n/alas/pull/42#discussion_r1"))
+    }
+
     @Test func checksTreatNoChecksReportedAsEmptyChecks() async throws {
         let request = try #require(try GitHubCLIProvider.parsePRList(Self.prListOutput, remote: Self.remote))
         let runner = FakeRunner(results: [
@@ -556,6 +630,26 @@ struct GitHubCLIProviderTests {
     )
 
     private static let cwd = URL(fileURLWithPath: "/tmp/alas")
+
+    private static func makeRequest(
+        checks: [ReviewCheck] = [],
+        threads: [ReviewThreadSummary] = []
+    ) -> ReviewRequest {
+        ReviewRequest(
+            remote: Self.remote,
+            number: 42,
+            title: "Add GitHub provider",
+            url: URL(string: "https://github.com/mrmans0n/alas/pull/42")!,
+            state: .open,
+            isDraft: false,
+            headRefName: "feature/github-provider",
+            baseRefName: "main",
+            reviewDecision: .approved,
+            mergeState: .clean,
+            checks: checks,
+            threads: threads
+        )
+    }
 
     private static let prListOutput = """
     [

--- a/AlasTests/Integrations/GitHubCLIProviderTests.swift
+++ b/AlasTests/Integrations/GitHubCLIProviderTests.swift
@@ -461,6 +461,27 @@ struct GitHubCLIProviderTests {
         #expect(detail.item.providerURL == URL(string: "https://github.com/mrmans0n/alas/pull/42#discussion_r1"))
     }
 
+    @Test func feedbackEvidenceDetailUsesChangesRequestedFallback() async throws {
+        let request = Self.makeRequest(reviewDecision: .changesRequested)
+        let provider = GitHubCLIProvider()
+        let item = try #require(try await provider.feedbackEvidence(
+            remote: Self.remote,
+            request: request,
+            cwd: Self.cwd
+        ).first)
+
+        let detail = try await provider.feedbackEvidenceDetail(
+            remote: Self.remote,
+            request: request,
+            item: item,
+            cwd: Self.cwd
+        )
+
+        #expect(item.id == ReviewEvidenceFallbacks.changesRequestedID)
+        #expect(detail.body.contains("review decision is changes requested"))
+        #expect(detail.item.providerURL == request.url)
+    }
+
     @Test func checksTreatNoChecksReportedAsEmptyChecks() async throws {
         let request = try #require(try GitHubCLIProvider.parsePRList(Self.prListOutput, remote: Self.remote))
         let runner = FakeRunner(results: [
@@ -664,7 +685,8 @@ struct GitHubCLIProviderTests {
 
     private static func makeRequest(
         checks: [ReviewCheck] = [],
-        threads: [ReviewThreadSummary] = []
+        threads: [ReviewThreadSummary] = [],
+        reviewDecision: ReviewDecision = .approved
     ) -> ReviewRequest {
         ReviewRequest(
             remote: Self.remote,
@@ -675,7 +697,7 @@ struct GitHubCLIProviderTests {
             isDraft: false,
             headRefName: "feature/github-provider",
             baseRefName: "main",
-            reviewDecision: .approved,
+            reviewDecision: reviewDecision,
             mergeState: .clean,
             checks: checks,
             threads: threads

--- a/AlasTests/Integrations/GitHubCLIProviderTests.swift
+++ b/AlasTests/Integrations/GitHubCLIProviderTests.swift
@@ -403,6 +403,37 @@ struct GitHubCLIProviderTests {
         #expect(await runner.commands == [
             FakeRunner.Command(
                 executable: "gh",
+                args: ["run", "view", "1", "--log-failed", "-R", "mrmans0n/alas", "--job", "3"],
+                cwd: Self.cwd
+            ),
+        ])
+    }
+
+    @Test func checkEvidenceDetailFallsBackToRunLogWhenJobIDIsUnavailable() async throws {
+        let request = Self.makeRequest(checks: [])
+        let runner = FakeRunner(results: [
+            ProcessResult(exitCode: 0, stdout: "failure details", stderr: ""),
+        ])
+        let provider = GitHubCLIProvider(runner: runner)
+        let item = ReviewEvidenceItem(
+            id: "ci:test",
+            section: .ci,
+            title: "test",
+            subtitle: "CI",
+            status: .failed,
+            providerURL: URL(string: "https://github.com/mrmans0n/alas/actions/runs/1")
+        )
+
+        _ = try await provider.checkEvidenceDetail(
+            remote: Self.remote,
+            request: request,
+            item: item,
+            cwd: Self.cwd
+        )
+
+        #expect(await runner.commands == [
+            FakeRunner.Command(
+                executable: "gh",
                 args: ["run", "view", "1", "--log-failed", "-R", "mrmans0n/alas"],
                 cwd: Self.cwd
             ),

--- a/AlasTests/Integrations/GitLabCLIProviderTests.swift
+++ b/AlasTests/Integrations/GitLabCLIProviderTests.swift
@@ -480,6 +480,72 @@ struct GitLabCLIProviderTests {
         }
     }
 
+    @Test func failedCheckEvidenceUsesFailedPipelineJobs() async throws {
+        let checks = try GitLabCLIProvider.parsePipeline(Self.pipelineWithFailedJobsOutput)
+        let request = Self.makeRequest(checks: checks)
+
+        let evidence = try await GitLabCLIProvider().failedCheckEvidence(
+            remote: Self.remote,
+            request: request,
+            cwd: Self.cwd
+        )
+
+        #expect(evidence.map(\.title) == ["test", "lint"])
+        #expect(evidence.allSatisfy { $0.status == .failed })
+    }
+
+    @Test func checkEvidenceDetailLoadsGitLabTraceForJobID() async throws {
+        let runner = FakeRunner(results: [
+            ProcessResult(exitCode: 0, stdout: "failed assertion\n", stderr: ""),
+        ])
+        let checks = try GitLabCLIProvider.parsePipeline(Self.pipelineWithFailedJobsOutput)
+        let request = Self.makeRequest(checks: checks)
+        let item = try #require(try await GitLabCLIProvider(runner: runner).failedCheckEvidence(
+            remote: Self.remote,
+            request: request,
+            cwd: Self.cwd
+        ).first)
+
+        let detail = try await GitLabCLIProvider(runner: runner).checkEvidenceDetail(
+            remote: Self.remote,
+            request: request,
+            item: item,
+            cwd: Self.cwd
+        )
+
+        #expect(detail.body.contains("failed assertion"))
+        #expect(await runner.commands == [
+            FakeRunner.Command(
+                executable: "glab",
+                args: ["ci", "trace", "102", "-R", "platform/mobile/alas"],
+                cwd: Self.cwd
+            ),
+        ])
+    }
+
+    @Test func feedbackEvidenceDetailUsesDiscussionBody() async throws {
+        let threads = try GitLabCLIProvider.parseDiscussions(
+            Self.discussionsOutput,
+            requestURL: URL(string: "https://gitlab.example.com/platform/mobile/alas/-/merge_requests/42")!
+        )
+        let request = Self.makeRequest(threads: threads)
+        let item = try #require(try await GitLabCLIProvider().feedbackEvidence(
+            remote: Self.remote,
+            request: request,
+            cwd: Self.cwd
+        ).first)
+
+        let detail = try await GitLabCLIProvider().feedbackEvidenceDetail(
+            remote: Self.remote,
+            request: request,
+            item: item,
+            cwd: Self.cwd
+        )
+
+        #expect(detail.body.contains("Please"))
+        #expect(detail.item.status == .actionable)
+    }
+
     @Test func currentReviewRequestUsesExpectedMRListCommand() async throws {
         let runner = FakeRunner(results: [
             ProcessResult(exitCode: 0, stdout: Self.mrListOutput, stderr: ""),
@@ -1023,6 +1089,26 @@ struct GitLabCLIProviderTests {
     )
 
     private static let cwd = URL(fileURLWithPath: "/tmp/alas")
+
+    private static func makeRequest(
+        checks: [ReviewCheck] = [],
+        threads: [ReviewThreadSummary] = []
+    ) -> ReviewRequest {
+        ReviewRequest(
+            remote: Self.remote,
+            number: 42,
+            title: "Add GitLab provider",
+            url: URL(string: "https://gitlab.example.com/platform/mobile/alas/-/merge_requests/42")!,
+            state: .open,
+            isDraft: false,
+            headRefName: "feature/gitlab-provider",
+            baseRefName: "main",
+            reviewDecision: .unknown,
+            mergeState: .unknown,
+            checks: checks,
+            threads: threads
+        )
+    }
 
     private static let mrListOutput = """
     [

--- a/AlasTests/Integrations/ReviewEvidenceModelTests.swift
+++ b/AlasTests/Integrations/ReviewEvidenceModelTests.swift
@@ -41,6 +41,43 @@ struct ReviewEvidenceModelTests {
         #expect(model.selectedDetail?.body == "Please simplify this.")
     }
 
+    @Test func loadRestoresPersistedSelectedItemWhenStillPresent() async {
+        let model = ReviewEvidenceModel(
+            snapshot: Self.snapshot(),
+            provider: FakeCodeHostProvider(feedbackItems: [
+                Self.feedbackItem(id: "feedback:thread-1", title: "reviewer", body: "First comment."),
+                Self.feedbackItem(id: "feedback:thread-2", title: "maintainer", body: "Second comment."),
+            ]),
+            cwd: URL(fileURLWithPath: "/tmp/alas"),
+            initialSection: .feedback,
+            initialItemID: "feedback:thread-2"
+        )
+
+        await model.load()
+
+        #expect(model.selectedSection == .feedback)
+        #expect(model.selectedItem?.id == "feedback:thread-2")
+    }
+
+    @Test func selectedDetailErrorPreservesSelectedItem() async {
+        let model = ReviewEvidenceModel(
+            snapshot: Self.snapshot(),
+            provider: FakeCodeHostProvider(),
+            cwd: URL(fileURLWithPath: "/tmp/alas"),
+            initialSection: .ci
+        )
+
+        await model.load()
+        await model.loadSelectedDetail()
+        model.showSelectedDetailError("Rerun failed: permission denied")
+
+        #expect(model.selectedSection == .ci)
+        #expect(model.selectedItem?.id == "ci:test")
+        #expect(model.selectedDetail?.item.id == "ci:test")
+        #expect(model.selectedDetail?.body.contains("Rerun failed: permission denied") == true)
+        #expect(model.selectedDetail?.body.contains("Assertion failed in Tests.swift") == true)
+    }
+
     @Test func staleDetailResponseDoesNotOverwriteCurrentSelection() async {
         let provider = SuspendedDetailProvider()
         let model = ReviewEvidenceModel(
@@ -134,6 +171,17 @@ struct ReviewEvidenceModelTests {
         )
         return request
     }
+
+    private static func feedbackItem(id: String, title: String, body: String) -> ReviewEvidenceItem {
+        ReviewEvidenceItem(
+            id: id,
+            section: .feedback,
+            title: title,
+            subtitle: body,
+            status: .actionable,
+            providerURL: URL(string: "https://github.com/discussion/\(id)")
+        )
+    }
 }
 
 private actor EvidenceProviderRecorder {
@@ -155,9 +203,35 @@ private actor EvidenceProviderRecorder {
 
 private struct FakeCodeHostProvider: CodeHostProvider {
     let recorder: EvidenceProviderRecorder?
+    let ciItems: [ReviewEvidenceItem]
+    let feedbackItems: [ReviewEvidenceItem]
 
-    init(recorder: EvidenceProviderRecorder? = nil) {
+    init(
+        recorder: EvidenceProviderRecorder? = nil,
+        ciItems: [ReviewEvidenceItem] = [
+            ReviewEvidenceItem(
+                id: "ci:test",
+                section: .ci,
+                title: "Tests",
+                subtitle: "CI",
+                status: .failed,
+                providerURL: URL(string: "https://github.com/run")
+            ),
+        ],
+        feedbackItems: [ReviewEvidenceItem] = [
+            ReviewEvidenceItem(
+                id: "feedback:thread-1",
+                section: .feedback,
+                title: "reviewer",
+                subtitle: "Please simplify this.",
+                status: .actionable,
+                providerURL: URL(string: "https://github.com/discussion")
+            ),
+        ]
+    ) {
         self.recorder = recorder
+        self.ciItems = ciItems
+        self.feedbackItems = feedbackItems
     }
 
     var kind: CodeHostKind { .github }
@@ -195,16 +269,7 @@ private struct FakeCodeHostProvider: CodeHostProvider {
     }
 
     func failedCheckEvidence(remote: CodeHostRemote, request: ReviewRequest, cwd: URL) async throws -> [ReviewEvidenceItem] {
-        [
-            ReviewEvidenceItem(
-                id: "ci:test",
-                section: .ci,
-                title: "Tests",
-                subtitle: "CI",
-                status: .failed,
-                providerURL: URL(string: "https://github.com/run")
-            ),
-        ]
+        ciItems
     }
 
     func checkEvidenceDetail(
@@ -224,16 +289,7 @@ private struct FakeCodeHostProvider: CodeHostProvider {
     }
 
     func feedbackEvidence(remote: CodeHostRemote, request: ReviewRequest, cwd: URL) async throws -> [ReviewEvidenceItem] {
-        [
-            ReviewEvidenceItem(
-                id: "feedback:thread-1",
-                section: .feedback,
-                title: "reviewer",
-                subtitle: "Please simplify this.",
-                status: .actionable,
-                providerURL: URL(string: "https://github.com/discussion")
-            ),
-        ]
+        feedbackItems
     }
 
     func feedbackEvidenceDetail(

--- a/AlasTests/Integrations/ReviewEvidenceModelTests.swift
+++ b/AlasTests/Integrations/ReviewEvidenceModelTests.swift
@@ -63,8 +63,50 @@ struct ReviewEvidenceModelTests {
         #expect(!model.isLoadingDetail)
     }
 
+    @Test func modelReportsMissingReviewRequest() async {
+        let model = ReviewEvidenceModel(
+            snapshot: Self.snapshot(reviewRequest: nil),
+            provider: FakeCodeHostProvider(),
+            cwd: URL(fileURLWithPath: "/tmp/alas"),
+            initialSection: nil
+        )
+
+        await model.load()
+
+        #expect(model.errorMessage == "Review request not found.")
+        #expect(model.ciItems.isEmpty)
+        #expect(model.feedbackItems.isEmpty)
+    }
+
     private static func snapshot() -> ReviewLoopSnapshot {
-        let remote = CodeHostRemote(
+        snapshot(reviewRequest: Self.reviewRequest())
+    }
+
+    private static func snapshot(reviewRequest: ReviewRequest?) -> ReviewLoopSnapshot {
+        let remote = Self.remote()
+
+        return ReviewLoopSnapshot(
+            local: ReviewLoopLocalState(
+                branchName: "feature/review-loop",
+                headSHA: "abc",
+                baseBranch: "main",
+                hasWorkingTreeChanges: false,
+                hasStagedChanges: false,
+                aheadCommitCount: 2,
+                hasUpstream: true,
+                needsPush: false
+            ),
+            remote: remote,
+            reviewRequest: reviewRequest,
+            providerAvailable: true,
+            providerAuthenticated: true,
+            providerCapabilities: .githubCLI,
+            errorMessage: nil
+        )
+    }
+
+    private static func remote() -> CodeHostRemote {
+        CodeHostRemote(
             kind: .github,
             host: "github.com",
             owner: "mrmans0n",
@@ -72,6 +114,10 @@ struct ReviewEvidenceModelTests {
             remoteName: "origin",
             webURL: URL(string: "https://github.com/mrmans0n/alas")!
         )
+    }
+
+    private static func reviewRequest() -> ReviewRequest {
+        let remote = Self.remote()
         let request = ReviewRequest(
             remote: remote,
             number: 428,
@@ -86,25 +132,7 @@ struct ReviewEvidenceModelTests {
             checks: [],
             threads: []
         )
-
-        return ReviewLoopSnapshot(
-            local: ReviewLoopLocalState(
-                branchName: "feature/review-loop",
-                headSHA: "abc",
-                baseBranch: "main",
-                hasWorkingTreeChanges: false,
-                hasStagedChanges: false,
-                aheadCommitCount: 2,
-                hasUpstream: true,
-                needsPush: false
-            ),
-            remote: remote,
-            reviewRequest: request,
-            providerAvailable: true,
-            providerAuthenticated: true,
-            providerCapabilities: .githubCLI,
-            errorMessage: nil
-        )
+        return request
     }
 }
 

--- a/AlasTests/Integrations/ReviewEvidenceModelTests.swift
+++ b/AlasTests/Integrations/ReviewEvidenceModelTests.swift
@@ -1,0 +1,314 @@
+import Foundation
+import Testing
+@testable import Alas
+
+@MainActor
+struct ReviewEvidenceModelTests {
+    @Test func genericInspectSelectsFailedCIBeforeFeedback() async {
+        let recorder = EvidenceProviderRecorder()
+        let model = ReviewEvidenceModel(
+            snapshot: Self.snapshot(),
+            provider: FakeCodeHostProvider(recorder: recorder),
+            cwd: URL(fileURLWithPath: "/tmp/alas"),
+            initialSection: nil
+        )
+
+        await model.load()
+
+        #expect(model.selectedSection == .ci)
+        #expect(model.selectedItem?.id == "ci:test")
+        #expect(model.ciItems.count == 1)
+        #expect(model.feedbackItems.count == 1)
+        let counts = await recorder.detailCounts()
+        #expect(counts.ci == 0)
+        #expect(counts.feedback == 0)
+    }
+
+    @Test func loadingDetailPreservesSelectionAndStoresDetail() async {
+        let model = ReviewEvidenceModel(
+            snapshot: Self.snapshot(),
+            provider: FakeCodeHostProvider(),
+            cwd: URL(fileURLWithPath: "/tmp/alas"),
+            initialSection: .feedback
+        )
+
+        await model.load()
+        #expect(model.selectedSection == .feedback)
+        #expect(model.selectedItem?.id == "feedback:thread-1")
+        await model.loadSelectedDetail()
+
+        #expect(model.selectedSection == .feedback)
+        #expect(model.selectedDetail?.body == "Please simplify this.")
+    }
+
+    @Test func staleDetailResponseDoesNotOverwriteCurrentSelection() async {
+        let provider = SuspendedDetailProvider()
+        let model = ReviewEvidenceModel(
+            snapshot: Self.snapshot(),
+            provider: provider,
+            cwd: URL(fileURLWithPath: "/tmp/alas"),
+            initialSection: nil
+        )
+
+        await model.load()
+        let task = Task { await model.loadSelectedDetail() }
+        await provider.waitForCIDetailCall()
+
+        model.select(itemID: "feedback:thread-1", section: .feedback)
+        await provider.completeCIDetail()
+        await task.value
+
+        #expect(model.selectedSection == .feedback)
+        #expect(model.selectedDetail == nil)
+        #expect(!model.isLoadingDetail)
+    }
+
+    private static func snapshot() -> ReviewLoopSnapshot {
+        let remote = CodeHostRemote(
+            kind: .github,
+            host: "github.com",
+            owner: "mrmans0n",
+            repository: "alas",
+            remoteName: "origin",
+            webURL: URL(string: "https://github.com/mrmans0n/alas")!
+        )
+        let request = ReviewRequest(
+            remote: remote,
+            number: 428,
+            title: "Review loop",
+            url: URL(string: "https://github.com/mrmans0n/alas/pull/428")!,
+            state: .open,
+            isDraft: false,
+            headRefName: "feature/review-loop",
+            baseRefName: "main",
+            reviewDecision: .changesRequested,
+            mergeState: .blocked,
+            checks: [],
+            threads: []
+        )
+
+        return ReviewLoopSnapshot(
+            local: ReviewLoopLocalState(
+                branchName: "feature/review-loop",
+                headSHA: "abc",
+                baseBranch: "main",
+                hasWorkingTreeChanges: false,
+                hasStagedChanges: false,
+                aheadCommitCount: 2,
+                hasUpstream: true,
+                needsPush: false
+            ),
+            remote: remote,
+            reviewRequest: request,
+            providerAvailable: true,
+            providerAuthenticated: true,
+            providerCapabilities: .githubCLI,
+            errorMessage: nil
+        )
+    }
+}
+
+private actor EvidenceProviderRecorder {
+    private var ciDetailCalls = 0
+    private var feedbackDetailCalls = 0
+
+    func recordCIDetail() {
+        ciDetailCalls += 1
+    }
+
+    func recordFeedbackDetail() {
+        feedbackDetailCalls += 1
+    }
+
+    func detailCounts() -> (ci: Int, feedback: Int) {
+        (ciDetailCalls, feedbackDetailCalls)
+    }
+}
+
+private struct FakeCodeHostProvider: CodeHostProvider {
+    let recorder: EvidenceProviderRecorder?
+
+    init(recorder: EvidenceProviderRecorder? = nil) {
+        self.recorder = recorder
+    }
+
+    var kind: CodeHostKind { .github }
+    var capabilities: CodeHostProviderCapabilities { .githubCLI }
+
+    func isAvailable() async -> Bool { true }
+
+    func isAuthenticated(remote: CodeHostRemote, cwd: URL) async -> Bool { true }
+
+    func currentReviewRequest(
+        remote: CodeHostRemote,
+        branch: String,
+        headOwner: String?,
+        baseBranch: String,
+        cwd: URL
+    ) async throws -> ReviewRequest? {
+        nil
+    }
+
+    func createReviewRequest(
+        remote: CodeHostRemote,
+        branch: String,
+        headOwner: String?,
+        baseBranch: String,
+        title: String,
+        body: String,
+        isDraft: Bool,
+        cwd: URL
+    ) async throws -> URL {
+        URL(string: "https://github.com/mrmans0n/alas/pull/428")!
+    }
+
+    func checks(remote: CodeHostRemote, request: ReviewRequest, cwd: URL) async throws -> [ReviewCheck] {
+        []
+    }
+
+    func failedCheckEvidence(remote: CodeHostRemote, request: ReviewRequest, cwd: URL) async throws -> [ReviewEvidenceItem] {
+        [
+            ReviewEvidenceItem(
+                id: "ci:test",
+                section: .ci,
+                title: "Tests",
+                subtitle: "CI",
+                status: .failed,
+                providerURL: URL(string: "https://github.com/run")
+            ),
+        ]
+    }
+
+    func checkEvidenceDetail(
+        remote: CodeHostRemote,
+        request: ReviewRequest,
+        item: ReviewEvidenceItem,
+        cwd: URL
+    ) async throws -> ReviewEvidenceDetail {
+        await recorder?.recordCIDetail()
+        return ReviewEvidenceDetail(
+            item: item,
+            body: "Assertion failed in Tests.swift",
+            filePath: nil,
+            line: nil,
+            isTruncated: false
+        )
+    }
+
+    func feedbackEvidence(remote: CodeHostRemote, request: ReviewRequest, cwd: URL) async throws -> [ReviewEvidenceItem] {
+        [
+            ReviewEvidenceItem(
+                id: "feedback:thread-1",
+                section: .feedback,
+                title: "reviewer",
+                subtitle: "Please simplify this.",
+                status: .actionable,
+                providerURL: URL(string: "https://github.com/discussion")
+            ),
+        ]
+    }
+
+    func feedbackEvidenceDetail(
+        remote: CodeHostRemote,
+        request: ReviewRequest,
+        item: ReviewEvidenceItem,
+        cwd: URL
+    ) async throws -> ReviewEvidenceDetail {
+        await recorder?.recordFeedbackDetail()
+        return ReviewEvidenceDetail(
+            item: item,
+            body: "Please simplify this.",
+            filePath: nil,
+            line: nil,
+            isTruncated: false
+        )
+    }
+
+    func rerunFailedChecks(
+        remote: CodeHostRemote,
+        branch: String,
+        headSHA: String,
+        request: ReviewRequest?,
+        cwd: URL
+    ) async throws {}
+}
+
+private actor SuspendedDetailProvider: CodeHostProvider {
+    nonisolated let kind: CodeHostKind = .github
+    nonisolated let capabilities: CodeHostProviderCapabilities = .githubCLI
+
+    private var ciDetailContinuation: CheckedContinuation<ReviewEvidenceDetail, Never>?
+    private var ciDetailWaiters: [CheckedContinuation<Void, Never>] = []
+    private var didCallCIDetail = false
+
+    func waitForCIDetailCall() async {
+        if didCallCIDetail { return }
+        await withCheckedContinuation { continuation in
+            ciDetailWaiters.append(continuation)
+        }
+    }
+
+    func completeCIDetail() {
+        ciDetailContinuation?.resume(returning: ReviewEvidenceDetail(
+            item: Self.makeCIItem(),
+            body: "Late CI detail",
+            filePath: nil,
+            line: nil,
+            isTruncated: false
+        ))
+        ciDetailContinuation = nil
+    }
+
+    func isAvailable() async -> Bool { true }
+    func isAuthenticated(remote: CodeHostRemote, cwd: URL) async -> Bool { true }
+    func currentReviewRequest(remote: CodeHostRemote, branch: String, headOwner: String?, baseBranch: String, cwd: URL) async throws -> ReviewRequest? { nil }
+    func createReviewRequest(remote: CodeHostRemote, branch: String, headOwner: String?, baseBranch: String, title: String, body: String, isDraft: Bool, cwd: URL) async throws -> URL { remote.webURL }
+    func checks(remote: CodeHostRemote, request: ReviewRequest, cwd: URL) async throws -> [ReviewCheck] { [] }
+
+    func failedCheckEvidence(remote: CodeHostRemote, request: ReviewRequest, cwd: URL) async throws -> [ReviewEvidenceItem] {
+        [Self.makeCIItem()]
+    }
+
+    func checkEvidenceDetail(remote: CodeHostRemote, request: ReviewRequest, item: ReviewEvidenceItem, cwd: URL) async throws -> ReviewEvidenceDetail {
+        didCallCIDetail = true
+        for waiter in ciDetailWaiters {
+            waiter.resume()
+        }
+        ciDetailWaiters.removeAll()
+        return await withCheckedContinuation { continuation in
+            ciDetailContinuation = continuation
+        }
+    }
+
+    func feedbackEvidence(remote: CodeHostRemote, request: ReviewRequest, cwd: URL) async throws -> [ReviewEvidenceItem] {
+        [Self.makeFeedbackItem()]
+    }
+
+    func feedbackEvidenceDetail(remote: CodeHostRemote, request: ReviewRequest, item: ReviewEvidenceItem, cwd: URL) async throws -> ReviewEvidenceDetail {
+        ReviewEvidenceDetail(item: item, body: "Feedback detail", filePath: nil, line: nil, isTruncated: false)
+    }
+
+    func rerunFailedChecks(remote: CodeHostRemote, branch: String, headSHA: String, request: ReviewRequest?, cwd: URL) async throws {}
+
+    private nonisolated static func makeCIItem() -> ReviewEvidenceItem {
+        ReviewEvidenceItem(
+            id: "ci:test",
+            section: .ci,
+            title: "Tests",
+            subtitle: "CI",
+            status: .failed,
+            providerURL: URL(string: "https://github.com/run")
+        )
+    }
+
+    private nonisolated static func makeFeedbackItem() -> ReviewEvidenceItem {
+        ReviewEvidenceItem(
+            id: "feedback:thread-1",
+            section: .feedback,
+            title: "reviewer",
+            subtitle: "Please simplify this.",
+            status: .actionable,
+            providerURL: URL(string: "https://github.com/discussion")
+        )
+    }
+}

--- a/AlasTests/Integrations/ReviewEvidenceTests.swift
+++ b/AlasTests/Integrations/ReviewEvidenceTests.swift
@@ -1,0 +1,54 @@
+import Foundation
+import Testing
+@testable import Alas
+
+struct ReviewEvidenceTests {
+    @Test func logDetailTruncatesDeterministically() {
+        let item = ReviewEvidenceItem(
+            id: "ci:test",
+            section: .ci,
+            title: "test",
+            subtitle: "CI",
+            status: .failed,
+            providerURL: URL(string: "https://github.com/mrmans0n/alas/actions/runs/1/job/2")
+        )
+
+        let detail = ReviewEvidenceDetail.truncated(
+            item: item,
+            body: String(repeating: "x", count: 12_000),
+            filePath: nil,
+            line: nil,
+            maxLength: 4_000
+        )
+
+        #expect(detail.body.count == 4_000)
+        #expect(detail.body.hasSuffix("\n\n[Log truncated by Alas.]"))
+        #expect(detail.isTruncated)
+    }
+
+    @Test func contextIncludesProviderURLAndLocation() {
+        let item = ReviewEvidenceItem(
+            id: "feedback:thread-1",
+            section: .feedback,
+            title: "reviewer",
+            subtitle: "Please simplify this.",
+            status: .actionable,
+            providerURL: URL(string: "https://github.com/mrmans0n/alas/pull/42#discussion_r1")
+        )
+        let detail = ReviewEvidenceDetail(
+            item: item,
+            body: "Please simplify this branch lookup.",
+            filePath: "Alas/Sources/Right/RightPaneState.swift",
+            line: 240,
+            isTruncated: false
+        )
+
+        let context = ReviewEvidenceContextFormatter.format(detail)
+
+        #expect(context.contains("Section: Feedback"))
+        #expect(context.contains("Title: reviewer"))
+        #expect(context.contains("URL: https://github.com/mrmans0n/alas/pull/42#discussion_r1"))
+        #expect(context.contains("Location: Alas/Sources/Right/RightPaneState.swift:240"))
+        #expect(context.contains("Please simplify this branch lookup."))
+    }
+}

--- a/AlasTests/Integrations/ReviewLoopHandoffBuilderTests.swift
+++ b/AlasTests/Integrations/ReviewLoopHandoffBuilderTests.swift
@@ -149,6 +149,63 @@ struct ReviewLoopHandoffBuilderTests {
         #expect(prompt.contains("State: Provider unavailable"))
     }
 
+    @Test func selectedEvidencePromptIncludesEvidenceBody() {
+        let request = Self.makeReviewRequest()
+        let item = ReviewEvidenceItem(
+            id: "ci:test",
+            section: .ci,
+            title: "Tests",
+            subtitle: "CI",
+            status: .failed,
+            providerURL: URL(string: "https://github.com/run")
+        )
+        let detail = ReviewEvidenceDetail(
+            item: item,
+            body: "Assertion failed in Tests.swift",
+            filePath: nil,
+            line: nil,
+            isTruncated: false
+        )
+
+        let prompt = ReviewLoopHandoffBuilder.buildSelectedEvidencePrompt(
+            snapshot: Self.makeSnapshot(request: request),
+            detail: detail
+        )
+
+        #expect(prompt.contains("GitHub PR: https://github.com/mrmans0n/alas/pull/428"))
+        #expect(prompt.contains("Evidence section: CI"))
+        #expect(prompt.contains("Assertion failed in Tests.swift"))
+        #expect(prompt.contains("Do not merge or post remote comments."))
+    }
+
+    @Test func selectedEvidencePromptPreservesSafetyInstructionWhenEvidenceIsLong() {
+        let request = Self.makeReviewRequest()
+        let detail = ReviewEvidenceDetail(
+            item: ReviewEvidenceItem(
+                id: "ci:test",
+                section: .ci,
+                title: "Tests",
+                subtitle: "CI",
+                status: .failed,
+                providerURL: URL(string: "https://github.com/run")
+            ),
+            body: String(repeating: "failure details\n", count: 1_000),
+            filePath: nil,
+            line: nil,
+            isTruncated: false
+        )
+
+        let prompt = ReviewLoopHandoffBuilder.buildSelectedEvidencePrompt(
+            snapshot: Self.makeSnapshot(request: request),
+            detail: detail
+        )
+
+        #expect(prompt.count <= 4_500)
+        #expect(prompt.contains("[Evidence context truncated by Alas.]"))
+        #expect(prompt.contains("Do not merge or post remote comments."))
+        #expect(prompt.hasSuffix("Do not merge or post remote comments."))
+    }
+
     @Test func longReviewPromptIsTruncated() {
         let title = String(repeating: "Review note ", count: 1_000)
         let request = Self.makeReviewRequest(

--- a/AlasTests/Integrations/ReviewReadinessModelTests.swift
+++ b/AlasTests/Integrations/ReviewReadinessModelTests.swift
@@ -130,7 +130,7 @@ struct ReviewReadinessModelTests {
         #expect(model.actions.contains(Action(kind: .createReviewRequest, title: "Create MR", isEnabled: true)))
     }
 
-    @Test func failedChecksExposeRerunAndAgentHandoffWhenSupported() {
+    @Test func failedChecksExposeRerunAndInspectWhenSupported() {
         let request = Self.makeReviewRequest(checks: [Self.makeCheck(bucket: .fail)])
         let model = ReviewReadinessModel(
             snapshot: Self.makeSnapshot(reviewRequest: request),
@@ -141,10 +141,11 @@ struct ReviewReadinessModelTests {
         #expect(model.chips.map(\ReviewReadinessModel.Chip.title) == ["CI failed"])
         #expect(model.chips.map(\ReviewReadinessModel.Chip.tone) == [.danger])
         #expect(model.actions.contains(Action(kind: .rerunFailedChecks, title: "Rerun", isEnabled: true)))
-        #expect(model.actions.contains(Action(kind: .openAgentHandoff, title: "Open in Agent", isEnabled: true)))
+        #expect(model.actions.contains(Action(kind: .inspectReviewEvidence, title: "Inspect", isEnabled: true)))
+        #expect(!model.actions.map(\.kind).contains(.openAgentHandoff))
     }
 
-    @Test func failedChecksHideRerunForReadOnlyProviderButKeepAgentHandoff() {
+    @Test func failedChecksHideRerunForReadOnlyProviderButKeepInspect() {
         let request = Self.makeReviewRequest(checks: [Self.makeCheck(bucket: .fail)])
         let model = ReviewReadinessModel(
             snapshot: Self.makeSnapshot(reviewRequest: request, providerCapabilities: .readOnly),
@@ -154,10 +155,11 @@ struct ReviewReadinessModelTests {
 
         #expect(model.chips.map(\ReviewReadinessModel.Chip.title) == ["CI failed"])
         #expect(!model.actions.map(\ReviewReadinessModel.Action.kind).contains(.rerunFailedChecks))
-        #expect(model.actions.contains(Action(kind: .openAgentHandoff, title: "Open in Agent", isEnabled: true)))
+        #expect(model.actions.contains(Action(kind: .inspectReviewEvidence, title: "Inspect", isEnabled: true)))
+        #expect(!model.actions.map(\.kind).contains(.openAgentHandoff))
     }
 
-    @Test func externalFailedChecksHideRerunButKeepAgentHandoff() {
+    @Test func externalFailedChecksHideRerunButKeepInspect() {
         let externalCheck = ReviewCheck(
             id: "buildkite",
             name: "Buildkite",
@@ -175,10 +177,11 @@ struct ReviewReadinessModelTests {
 
         #expect(model.chips.map(\ReviewReadinessModel.Chip.title) == ["CI failed"])
         #expect(!model.actions.map(\ReviewReadinessModel.Action.kind).contains(.rerunFailedChecks))
-        #expect(model.actions.contains(Action(kind: .openAgentHandoff, title: "Open in Agent", isEnabled: true)))
+        #expect(model.actions.contains(Action(kind: .inspectReviewEvidence, title: "Inspect", isEnabled: true)))
+        #expect(!model.actions.map(\.kind).contains(.openAgentHandoff))
     }
 
-    @Test func changesRequestedExposesReviewFeedbackAndAgentHandoff() {
+    @Test func changesRequestedExposesReviewFeedbackAndInspect() {
         let request = Self.makeReviewRequest(reviewDecision: .changesRequested)
         let model = ReviewReadinessModel(
             snapshot: Self.makeSnapshot(reviewRequest: request),
@@ -188,7 +191,29 @@ struct ReviewReadinessModelTests {
 
         #expect(model.chips.map(\ReviewReadinessModel.Chip.title) == ["Review feedback"])
         #expect(model.chips.map(\ReviewReadinessModel.Chip.tone) == [.warning])
-        #expect(model.actions.contains(Action(kind: .openAgentHandoff, title: "Open in Agent", isEnabled: true)))
+        #expect(model.actions.contains(Action(kind: .inspectReviewEvidence, title: "Inspect", isEnabled: true)))
+        #expect(!model.actions.map(\.kind).contains(.openAgentHandoff))
+    }
+
+    @Test func actionableReviewThreadExposesInspect() {
+        let thread = ReviewThreadSummary(
+            id: "thread-1",
+            author: "reviewer",
+            body: "Please adjust this",
+            url: URL(string: "https://github.com/mrmans0n/alas/pull/428#discussion_r1"),
+            isResolved: false,
+            isActionable: true
+        )
+        let request = Self.makeReviewRequest(threads: [thread])
+        let model = ReviewReadinessModel(
+            snapshot: Self.makeSnapshot(reviewRequest: request),
+            lastError: nil,
+            canOpenAgentHandoff: false
+        )
+
+        #expect(model.chips.map(\ReviewReadinessModel.Chip.title) == ["Review feedback"])
+        #expect(model.actions.contains(Action(kind: .inspectReviewEvidence, title: "Inspect", isEnabled: true)))
+        #expect(!model.actions.map(\.kind).contains(.openAgentHandoff))
     }
 
     @Test func approvedCleanRequestIsReadyWithoutMergeAction() {
@@ -246,8 +271,9 @@ struct ReviewReadinessModelTests {
         #expect(actions[.openReviewRequest]?.emphasis == .normal)
         #expect(actions[.rerunFailedChecks]?.iconName == "arrow.clockwise")
         #expect(actions[.rerunFailedChecks]?.emphasis == .normal)
-        #expect(actions[.openAgentHandoff]?.iconName == "sparkle")
-        #expect(actions[.openAgentHandoff]?.emphasis == .primary)
+        #expect(actions[.inspectReviewEvidence]?.iconName == "doc.text.magnifyingglass")
+        #expect(actions[.inspectReviewEvidence]?.emphasis == .primary)
+        #expect(actions[.openAgentHandoff] == nil)
     }
 
     @Test func lastErrorBecomesBlockingTextWhileFactsStillIncludeBranch() {

--- a/AlasTests/RightPaneStateReviewLoopPushTests.swift
+++ b/AlasTests/RightPaneStateReviewLoopPushTests.swift
@@ -34,6 +34,27 @@ struct RightPaneStateReviewLoopPushTests {
         })
     }
 
+    @Test func inspectReviewEvidenceActionNoopsWithoutReviewRequest() {
+        let worktreeId = "wt-review-evidence-no-request"
+        defer { try? FileManager.default.removeItem(at: Paths.tabsFile(forWorktreeId: worktreeId)) }
+        let appState = AppState(store: MemoryStore())
+        let worktree = Worktree(
+            id: worktreeId,
+            projectId: "p1",
+            name: "feature/review-loop",
+            branch: "feature/review-loop",
+            path: URL(fileURLWithPath: "/tmp/repo"),
+            status: .clean,
+            lastActivity: Date(timeIntervalSince1970: 0)
+        )
+        let state = RightPaneState(worktree: worktree, baseBranch: "main")
+        state.reviewLoop.setSnapshotForTests(Self.makeSnapshot())
+
+        state.handleReviewReadinessAction(.inspectReviewEvidence, appState: appState)
+
+        #expect(appState.tabs.tabs(forWorktree: worktreeId).isEmpty)
+    }
+
     @Test func normalPushArgumentsDoNotForce() {
         let snapshot = Self.makeSnapshot()
 

--- a/AlasTests/TabsManagerReviewEvidenceTests.swift
+++ b/AlasTests/TabsManagerReviewEvidenceTests.swift
@@ -1,0 +1,173 @@
+import Foundation
+import Testing
+@testable import Alas
+
+@MainActor
+struct TabsManagerReviewEvidenceTests {
+    @Test func opensOrFocusesReviewEvidenceTabForSameRequest() {
+        let worktreeId = "review-evidence-open"
+        defer { try? FileManager.default.removeItem(at: Paths.tabsFile(forWorktreeId: worktreeId)) }
+        let manager = TabsManager()
+        let snapshot = Self.snapshot()
+
+        let first = manager.openOrFocusReviewEvidence(
+            worktreeId: worktreeId,
+            snapshot: snapshot,
+            initialSection: nil
+        )
+        let second = manager.openOrFocusReviewEvidence(
+            worktreeId: worktreeId,
+            snapshot: snapshot,
+            initialSection: .feedback
+        )
+
+        #expect(first.id == second.id)
+        #expect(manager.tabs(forWorktree: worktreeId).count == 1)
+        #expect(manager.activeTabId(forWorktree: worktreeId) == first.id)
+    }
+
+    @Test func focusingExistingReviewEvidenceTabRefreshesSectionAndMetadata() {
+        let worktreeId = "review-evidence-refresh"
+        defer { try? FileManager.default.removeItem(at: Paths.tabsFile(forWorktreeId: worktreeId)) }
+        let manager = TabsManager()
+        let first = manager.openOrFocusReviewEvidence(
+            worktreeId: worktreeId,
+            snapshot: Self.snapshot(title: "Old title", url: URL(string: "https://github.com/mrmans0n/alas/pull/42")!),
+            initialSection: .ci
+        )
+
+        let second = manager.openOrFocusReviewEvidence(
+            worktreeId: worktreeId,
+            snapshot: Self.snapshot(title: "New title", url: URL(string: "https://github.com/mrmans0n/alas/pull/42/files")!),
+            initialSection: .feedback
+        )
+
+        #expect(second.id == first.id)
+        guard case .reviewEvidence(let state) = second else {
+            Issue.record("Expected review evidence tab")
+            return
+        }
+        #expect(state.selectedSection == .feedback)
+        #expect(state.title == "New title")
+        #expect(state.url == URL(string: "https://github.com/mrmans0n/alas/pull/42/files"))
+    }
+
+    @Test func persistedLocalSelectionDoesNotBlockLaterInspectRetargeting() {
+        let worktreeId = "review-evidence-retarget"
+        defer { try? FileManager.default.removeItem(at: Paths.tabsFile(forWorktreeId: worktreeId)) }
+        let manager = TabsManager()
+        let snapshot = Self.snapshot()
+
+        let opened = manager.openOrFocusReviewEvidence(
+            worktreeId: worktreeId,
+            snapshot: snapshot,
+            initialSection: .ci
+        )
+        _ = manager.updateReviewEvidenceSelection(
+            worktreeId: worktreeId,
+            tabId: opened.id,
+            selectedSection: .feedback,
+            selectedItemID: "thread-1"
+        )
+
+        let retargeted = manager.openOrFocusReviewEvidence(
+            worktreeId: worktreeId,
+            snapshot: snapshot,
+            initialSection: .ci
+        )
+
+        guard case .reviewEvidence(let state) = retargeted else {
+            Issue.record("Expected review evidence tab")
+            return
+        }
+        #expect(state.selectedSection == .ci)
+        #expect(state.selectedItemID == nil)
+        #expect(manager.tabs(forWorktree: worktreeId).count == 1)
+    }
+
+    @Test func differentReviewRequestOpensSeparateEvidenceTab() {
+        let worktreeId = "review-evidence-separate-request"
+        defer { try? FileManager.default.removeItem(at: Paths.tabsFile(forWorktreeId: worktreeId)) }
+        let manager = TabsManager()
+
+        let first = manager.openOrFocusReviewEvidence(
+            worktreeId: worktreeId,
+            snapshot: Self.snapshot(number: 42),
+            initialSection: nil
+        )
+        let second = manager.openOrFocusReviewEvidence(
+            worktreeId: worktreeId,
+            snapshot: Self.snapshot(number: 43),
+            initialSection: nil
+        )
+
+        #expect(first.id != second.id)
+        #expect(manager.tabs(forWorktree: worktreeId).count == 2)
+        #expect(manager.activeTabId(forWorktree: worktreeId) == second.id)
+    }
+
+    @Test func reviewEvidenceTabStateCodableRoundTrips() throws {
+        let state = ReviewEvidenceTabState(
+            worktreeId: "wt-1",
+            snapshot: Self.snapshot(),
+            initialSection: .feedback
+        )
+
+        let data = try JSONEncoder().encode(state)
+        let decoded = try JSONDecoder().decode(ReviewEvidenceTabState.self, from: data)
+
+        #expect(decoded == state)
+        #expect(decoded.selectedSection == .feedback)
+        #expect(decoded.provider == .github)
+        #expect(decoded.number == 42)
+    }
+
+    private static func snapshot(
+        number: Int = 42,
+        title: String = "Review evidence",
+        url: URL = URL(string: "https://github.com/mrmans0n/alas/pull/42")!
+    ) -> ReviewLoopSnapshot {
+        let remote = CodeHostRemote(
+            kind: .github,
+            host: "github.com",
+            owner: "mrmans0n",
+            repository: "alas",
+            remoteName: "origin",
+            webURL: URL(string: "https://github.com/mrmans0n/alas")!
+        )
+        let request = ReviewRequest(
+            remote: remote,
+            number: number,
+            title: title,
+            url: url,
+            state: .open,
+            isDraft: false,
+            headRefName: "feature/review-evidence",
+            baseRefName: "main",
+            reviewDecision: .changesRequested,
+            mergeState: .blocked,
+            checks: [],
+            threads: []
+        )
+        return ReviewLoopSnapshot(
+            local: ReviewLoopLocalState(
+                branchName: "feature/review-evidence",
+                headSHA: "abc123",
+                baseBranch: "main",
+                hasWorkingTreeChanges: false,
+                hasStagedChanges: false,
+                aheadCommitCount: 1,
+                hasUpstream: true,
+                upstreamRemoteName: "origin",
+                upstreamBranchName: "feature/review-evidence",
+                needsPush: false
+            ),
+            remote: remote,
+            reviewRequest: request,
+            providerAvailable: true,
+            providerAuthenticated: true,
+            providerCapabilities: .githubCLI,
+            errorMessage: nil
+        )
+    }
+}

--- a/AlasTests/TabsManagerReviewEvidenceTests.swift
+++ b/AlasTests/TabsManagerReviewEvidenceTests.swift
@@ -115,6 +115,7 @@ struct TabsManagerReviewEvidenceTests {
 
         #expect(state.matches(Self.snapshot(number: 42)))
         #expect(!state.matches(Self.snapshot(number: 43)))
+        #expect(!state.matches(Self.snapshot(number: 42, host: "github.example.com")))
     }
 
     @Test func reviewEvidenceTabStateCodableRoundTrips() throws {
@@ -136,15 +137,17 @@ struct TabsManagerReviewEvidenceTests {
     private static func snapshot(
         number: Int = 42,
         title: String = "Review evidence",
-        url: URL = URL(string: "https://github.com/mrmans0n/alas/pull/42")!
+        url: URL? = nil,
+        host: String = "github.com"
     ) -> ReviewLoopSnapshot {
+        let url = url ?? URL(string: "https://\(host)/mrmans0n/alas/pull/\(number)")!
         let remote = CodeHostRemote(
             kind: .github,
-            host: "github.com",
+            host: host,
             owner: "mrmans0n",
             repository: "alas",
             remoteName: "origin",
-            webURL: URL(string: "https://github.com/mrmans0n/alas")!
+            webURL: URL(string: "https://\(host)/mrmans0n/alas")!
         )
         let request = ReviewRequest(
             remote: remote,

--- a/AlasTests/TabsManagerReviewEvidenceTests.swift
+++ b/AlasTests/TabsManagerReviewEvidenceTests.swift
@@ -106,6 +106,17 @@ struct TabsManagerReviewEvidenceTests {
         #expect(manager.activeTabId(forWorktree: worktreeId) == second.id)
     }
 
+    @Test func reviewEvidenceTabStateMatchesOnlyItsRequest() {
+        let state = ReviewEvidenceTabState(
+            worktreeId: "review-evidence-match",
+            snapshot: Self.snapshot(number: 42),
+            initialSection: nil
+        )
+
+        #expect(state.matches(Self.snapshot(number: 42)))
+        #expect(!state.matches(Self.snapshot(number: 43)))
+    }
+
     @Test func reviewEvidenceTabStateCodableRoundTrips() throws {
         let state = ReviewEvidenceTabState(
             worktreeId: "wt-1",

--- a/docs/superpowers/specs/2026-06-04-review-evidence-tab-design.md
+++ b/docs/superpowers/specs/2026-06-04-review-evidence-tab-design.md
@@ -1,0 +1,276 @@
+---
+title: "Review evidence center tab for PR/MR CI and feedback"
+date: 2026-06-04
+project: alas
+phase: design
+---
+
+# Review Evidence Center Tab
+
+## Summary
+
+Add a center tab for inspecting review-loop evidence from GitHub and GitLab.
+The first completed section is CI failure inspection; unresolved review
+feedback uses the same tab because both workflows are evidence the user reviews
+before deciding whether to ask an agent to act.
+
+The Changes drawer remains a compact status and next-action surface. It should
+show states such as `CI failed`, `Review feedback`, and `Ready`, then open the
+center tab with an `Inspect` action when detailed evidence needs real estate.
+
+## Goals
+
+- Help users review agent output safely before publishing or continuing.
+- Make CI failures explorable inside Alas instead of forcing a browser jump for
+  every failed job.
+- Surface actionable PR/MR feedback as individual work items.
+- Preserve the current provider-neutral GitHub/GitLab architecture.
+- Avoid turning the right sidebar drawer into a provider dashboard.
+
+## Non-Goals
+
+- Replace GitHub or GitLab PR/MR pages.
+- Store provider credentials or bypass `gh` / `glab` authentication.
+- Fetch large logs during normal Changes drawer refresh.
+- Add autonomous remote commenting, thread resolution, or merge behavior.
+- Build a full provider timeline in this iteration.
+
+## UX
+
+The center tab should feel like a review workbench, not a provider clone.
+
+### Entry Points
+
+- The Changes drawer keeps showing compact review-loop state.
+- When CI has failed or actionable feedback exists, the primary action becomes
+  `Inspect`.
+- `Inspect` opens or focuses the review evidence tab for the worktree.
+- Opening from a CI failure selects the first failed check.
+- Opening from review feedback selects the first actionable thread.
+- If both CI failure and feedback exist, generic `Inspect` selects CI first
+  because CI is objective and often blocks review.
+
+### Tab Layout
+
+Top bar:
+
+- Provider identity, such as `GitHub #465` or `GitLab !42`.
+- PR/MR title.
+- Status chips for checks, review, and merge readiness.
+- Actions for refresh and open PR/MR.
+
+Main layout:
+
+- A left evidence list.
+- A right detail pane.
+- A segmented control for `CI` and `Feedback`.
+
+CI evidence rows show:
+
+- Check/job name.
+- Workflow, pipeline, or source; omit this line when the provider does not
+  return one.
+- Provider status and severity.
+- Timestamp; omit this line when the provider does not return one.
+
+CI details show:
+
+- Check/job name.
+- Workflow or pipeline.
+- Status.
+- Provider link.
+- Bounded log excerpt.
+- Whether the excerpt was truncated.
+
+Feedback evidence rows show:
+
+- Reviewer.
+- Short comment preview.
+- File and line; omit this line when the provider does not return location
+  metadata.
+- Resolved/actionable state.
+
+Feedback details show:
+
+- Reviewer.
+- Comment body.
+- File and line; omit this line when the provider does not return location
+  metadata.
+- Provider link.
+- Thread state.
+
+Footer/detail actions:
+
+- `Copy Context`.
+- `Open in Browser`.
+- `Rerun Failed` for CI where supported.
+- `Send to Agent`.
+
+Empty and blocking states should be factual:
+
+- `No failed checks`.
+- `No actionable feedback`.
+- `Review request not found`.
+- `Provider CLI unavailable`.
+- `Provider authentication required`.
+
+## Architecture
+
+Add a new center tab type named `reviewEvidence`.
+
+Core pieces:
+
+- `ReviewEvidenceTabState`: worktree id, provider identity, request number/url,
+  selected section, and selected item id.
+- `ReviewEvidenceTabView`: center-pane UI with `CI` and `Feedback` sections.
+- `ReviewEvidenceModel`: observable tab model that loads evidence lists and
+  detail data lazily.
+- `ReviewEvidenceItem`: provider-neutral list row data.
+- `ReviewEvidenceDetail`: provider-neutral selected-item detail.
+
+The existing `ReviewLoopDrawer` and `ReviewReadinessModel` continue to render
+summary state. They should open the tab rather than fetch or display heavy
+evidence details.
+
+### Data Flow
+
+1. Review loop refresh detects local/provider summary state.
+2. The drawer shows `CI failed`, `Review feedback`, or another compact state.
+3. The user selects `Inspect`.
+4. `TabsManager` opens or focuses the worktree's review evidence tab.
+5. The tab loads detailed CI/thread evidence through the provider registry.
+6. Selecting an evidence item loads detail data lazily.
+7. User actions copy context, open provider URLs, rerun failed jobs, or send a
+   focused prompt to the configured agent.
+8. After rerun or agent work, normal Changes refresh updates both the drawer
+   and the tab.
+
+### Provider-Neutral Detail Model
+
+Use small provider-neutral types for the first pass:
+
+```swift
+enum ReviewEvidenceSection: String, Codable, Equatable, Sendable {
+    case ci
+    case feedback
+}
+
+enum ReviewEvidenceStatus: String, Codable, Equatable, Sendable {
+    case failed
+    case pending
+    case passed
+    case cancelled
+    case actionable
+    case resolved
+    case unknown
+}
+
+struct ReviewEvidenceItem: Identifiable, Equatable, Sendable {
+    let id: String
+    let section: ReviewEvidenceSection
+    let title: String
+    let subtitle: String?
+    let status: ReviewEvidenceStatus
+    let providerURL: URL?
+}
+
+struct ReviewEvidenceDetail: Equatable, Sendable {
+    let item: ReviewEvidenceItem
+    let body: String
+    let filePath: String?
+    let line: Int?
+    let isTruncated: Bool
+}
+```
+
+Extend `CodeHostProvider` with detail-oriented reads:
+
+```swift
+func failedCheckEvidence(
+    remote: CodeHostRemote,
+    request: ReviewRequest,
+    cwd: URL
+) async throws -> [ReviewEvidenceItem]
+
+func checkEvidenceDetail(
+    remote: CodeHostRemote,
+    request: ReviewRequest,
+    item: ReviewEvidenceItem,
+    cwd: URL
+) async throws -> ReviewEvidenceDetail
+
+func feedbackEvidence(
+    remote: CodeHostRemote,
+    request: ReviewRequest,
+    cwd: URL
+) async throws -> [ReviewEvidenceItem]
+
+func feedbackEvidenceDetail(
+    remote: CodeHostRemote,
+    request: ReviewRequest,
+    item: ReviewEvidenceItem,
+    cwd: URL
+) async throws -> ReviewEvidenceDetail
+```
+
+GitHub maps this through `gh pr checks`, `gh run view`, job/log APIs where
+available, and GraphQL review threads. GitLab maps through `glab ci get`,
+`glab ci trace` or job APIs where needed, and unresolved MR discussions.
+
+The drawer refresh must not call log/detail APIs. Only the center tab fetches
+heavy detail data.
+
+## Error Handling
+
+- If the provider CLI is missing or unauthenticated, the tab shows the same
+  provider-blocking state as the drawer.
+- If logs cannot be fetched, keep the evidence row visible and show a detail
+  error with `Open in Browser` and `Copy Provider URL`.
+- If a check or thread disappears between refresh and selection, clear the
+  selection and reload the list.
+- If log output is too large, truncate deterministically and show a truncation
+  marker.
+- If rerun fails, show the command error inline in the CI detail pane and
+  preserve the selected item.
+
+## Testing
+
+Add focused Swift Testing coverage for:
+
+- GitHub failed check and log-reference parsing.
+- GitLab pipeline/job evidence parsing.
+- Evidence model section selection, including CI winning over feedback for
+  generic `Inspect`.
+- Tab open/focus behavior and stable selected item ids.
+- Handoff builder output for selected CI and feedback evidence.
+- UI/model states for empty, loading, error, truncated-log, missing CLI, and
+  unauthenticated provider states.
+
+Provider subprocess tests should use fake command runners. Real `gh` and
+`glab` subprocess coverage should stay manual or separately gated because it
+depends on developer authentication and remote state.
+
+## Acceptance Criteria
+
+1. A worktree with a failed GitHub or GitLab check can open a center review
+   evidence tab from the Changes drawer.
+2. The CI section lists failed checks/jobs and shows a bounded detail excerpt
+   for the selected item.
+3. The user can copy selected CI context, open the provider URL, rerun failed
+   jobs where supported, and send selected CI context to an agent.
+4. The Feedback section lists unresolved/actionable PR/MR threads and shows a
+   selected thread detail preview.
+5. The user can copy selected feedback context, open the provider URL, and send
+   selected feedback context to an agent.
+6. The Changes drawer stays compact and does not fetch heavy log or thread
+   detail during normal refresh.
+7. Provider errors are visible in the tab without losing the selected evidence
+   context when possible.
+
+## Future Work
+
+- Add a `Local Review` section for guided review of unmerged local changes.
+- Add ready-to-merge and post-merge archive flows after evidence review is
+  stable.
+- Add richer provider metadata if users need labels, assignees, reviewers, or a
+  short timeline.


### PR DESCRIPTION
## Summary
- Add provider-neutral review evidence models and GitHub/GitLab CI/feedback detail loading.
- Add a Review Evidence center tab opened from the Changes drawer `Inspect` action.
- Add selected evidence handoff, rerun error surfacing, and persisted evidence selection handling.

## Test Plan
- `rtk xcodegen`
- `rtk xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -quiet build`
- `rtk xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -test-timeouts-enabled YES -maximum-test-execution-time-allowance 120 test`