### PR TITLE
feat(remote): drive ACP sessions from the phone (take over, send, stop)

### DIFF
--- a/Alas/Resources/RemoteWeb/app.js
+++ b/Alas/Resources/RemoteWeb/app.js
@@ -6,7 +6,8 @@ let reconnectDelay = 1500;
 const maxReconnectDelay = 30000;
 let dismissedQuestion = null;   // {sessionId, requestId} the user closed; suppress re-shows of that exact prompt (ids aren't unique across sessions)
 
-function setStatus(s) { $("status").textContent = s; }
+// state ∈ {connecting, ok, bad} drives the chip's dot/border color via [data-state].
+function setStatus(s, state) { const e = $("status"); e.textContent = s; e.dataset.state = state || "connecting"; }
 function showGate(title, msg, retry) {
   $("gate-title").textContent = title;
   $("gate-msg").textContent = msg;
@@ -54,14 +55,14 @@ async function connect() {
   if (ws) { try { ws.close(); } catch (_) {} }   // drop any prior (possibly half-open) socket
   ws = new WebSocket(`ws://${location.host}/ws`, [token]);   // token as subprotocol
   ws.onopen = () => {
-    setStatus("connected");
+    setStatus("Connected", "ok");
     hideGate();
     reconnectDelay = 1500;   // reset back-off after a good connection
     send({ type: "listSessions" });
     if (currentSession) send({ type: "subscribe", sessionId: currentSession });   // re-sync after reconnect
   };
   ws.onclose = () => {
-    setStatus("disconnected — reconnecting…");
+    setStatus("Reconnecting…", "bad");
     setTimeout(connect, reconnectDelay);
     reconnectDelay = Math.min(reconnectDelay * 2, maxReconnectDelay);   // capped exponential back-off
   };
@@ -84,7 +85,7 @@ function handle(msg) {
     case "questionRequest": if (msg.sessionId === currentSession) showQuestion(msg.sessionId, msg.payload); break;
     case "questionResolved": if (msg.sessionId === currentSession) { dismissedQuestion = null; hideQuestion(); } break;
     case "sessionClosed": if (msg.sessionId === currentSession) showSessions(); break;
-    case "error": setStatus("error: " + (msg.message ?? "(unknown)")); break;
+    case "error": setStatus("Error", "bad"); $("status").title = msg.message ?? ""; break;
     default: console.warn("unknown message type", msg.type);
   }
 }
@@ -110,6 +111,7 @@ function renderSessions(sessions) {
 
 function openSession(id) {
   currentSession = id; messages = new Map(); dismissedQuestion = null; canDrive = false; canDriveKnown = false;
+  $("back").classList.remove("hidden"); $("nav-title").classList.add("hidden");   // bar shows ‹ Sessions
   $("sessions").classList.add("hidden"); $("transcript").classList.remove("hidden");
   $("messages").innerHTML = ""; renderDriveBar("idle"); send({ type: "subscribe", sessionId: id });
 }
@@ -117,6 +119,7 @@ function showSessions() {
   if (currentSession) send({ type: "unsubscribe", sessionId: currentSession });
   currentSession = null; canDrive = false; canDriveKnown = false;
   hidePermission(); hideQuestion();          // never leave a sheet over the list
+  $("back").classList.add("hidden"); $("nav-title").classList.remove("hidden");   // bar shows app title
   $("drivebar").classList.add("hidden");
   $("transcript").classList.add("hidden"); $("sessions").classList.remove("hidden");
   send({ type: "listSessions" });
@@ -124,14 +127,14 @@ function showSessions() {
 
 function renderMessages(forceBottom) {
   const box = $("messages");
-  // The page itself scrolls (sticky bar + body), so use window scroll metrics.
-  const atBottom = forceBottom || (window.innerHeight + window.scrollY >= document.body.scrollHeight - 120);
+  // #messages is the scroll container (fixed shell), so use its own metrics.
+  const atBottom = forceBottom || (box.scrollTop + box.clientHeight >= box.scrollHeight - 120);
   // Preserve which tool/thought cards the user expanded across re-renders.
   const open = new Set();
   box.querySelectorAll("details[open]").forEach(d => { if (d.dataset.sid) open.add(d.dataset.sid); });
   box.innerHTML = "";
   for (const [sid, m] of messages) box.appendChild(renderMessage(m, sid, open));
-  if (atBottom) requestAnimationFrame(() => window.scrollTo(0, document.body.scrollHeight));
+  if (atBottom) requestAnimationFrame(() => { box.scrollTop = box.scrollHeight; });
 }
 
 function el(tag, cls, text) { const e = document.createElement(tag); if (cls) e.className = cls; if (text != null) e.textContent = text; return e; }
@@ -371,4 +374,25 @@ $("permission").onclick = (e) => { if (e.target.id === "permission") hidePermiss
 
 $("back").onclick = showSessions;
 $("gate-retry").onclick = () => location.reload();
+
+// iOS overlays the keyboard without shrinking the layout viewport, so a
+// 100dvh shell ends up taller than the visible area when the field is focused.
+// Drive the shell height from the *visual* viewport (which does shrink for the
+// keyboard) and keep the transcript pinned to the bottom as it resizes.
+const vp = window.visualViewport;
+if (vp) {
+  const syncViewport = () => {
+    // Pin the fixed shell to the visual viewport's box: height shrinks for the
+    // keyboard, and top follows offsetTop so the shell doesn't slide off-screen
+    // when iOS scrolls the page to reveal the focused field.
+    document.body.style.height = vp.height + "px";
+    document.body.style.top = vp.offsetTop + "px";
+    const box = $("messages");
+    if (box) box.scrollTop = box.scrollHeight;
+  };
+  vp.addEventListener("resize", syncViewport);
+  vp.addEventListener("scroll", syncViewport);
+  syncViewport();
+}
+
 connect();

--- a/Alas/Resources/RemoteWeb/app.js
+++ b/Alas/Resources/RemoteWeb/app.js
@@ -5,6 +5,7 @@ let canDrive = false, canDriveKnown = false;
 let reconnectDelay = 1500;
 const maxReconnectDelay = 30000;
 let dismissedQuestion = null;   // {sessionId, requestId} the user closed; suppress re-shows of that exact prompt (ids aren't unique across sessions)
+let lastSentText = null;        // text of the most recent sendPrompt, kept so a server promptRejected can restore it instead of losing the message
 
 // state ∈ {connecting, ok, bad} drives the chip's dot/border color via [data-state].
 function setStatus(s, state) { const e = $("status"); e.textContent = s; e.dataset.state = state || "connecting"; }
@@ -85,6 +86,7 @@ function handle(msg) {
     case "questionRequest": if (msg.sessionId === currentSession) showQuestion(msg.sessionId, msg.payload); break;
     case "questionResolved": if (msg.sessionId === currentSession) { dismissedQuestion = null; hideQuestion(); } break;
     case "sessionClosed": if (msg.sessionId === currentSession) showSessions(); break;
+    case "promptRejected": if (msg.sessionId === currentSession) restoreRejectedPrompt(); break;
     case "error": setStatus("Error", "bad"); $("status").title = msg.message ?? ""; break;
     default: console.warn("unknown message type", msg.type);
   }
@@ -357,8 +359,20 @@ function sendPrompt() {
   const text = ta.value.trim();
   if (!text || !currentSession || !canDrive) return;
   send({ type: "sendPrompt", sessionId: currentSession, text });
+  lastSentText = text;                               // keep until the server accepts (or rejects) it
   ta.value = "";
   autoGrowPrompt();                                  // collapse back to one row
+}
+
+// The server dropped our prompt (lease went stale, etc.). Put the text back so
+// the message isn't silently lost — but only if the user hasn't typed a new one.
+function restoreRejectedPrompt() {
+  const ta = $("prompt");
+  if (lastSentText && !ta.value) {
+    ta.value = lastSentText;
+    autoGrowPrompt();
+  }
+  lastSentText = null;
 }
 
 $("takeover").onclick = () => { if (currentSession) send({ type: "takeOver", sessionId: currentSession }); };

--- a/Alas/Resources/RemoteWeb/app.js
+++ b/Alas/Resources/RemoteWeb/app.js
@@ -336,7 +336,12 @@ function renderDriveBar(streamingState) {
   $("takeover").classList.toggle("hidden", canDrive);
   $("composer").classList.toggle("hidden", !canDrive);
   if (canDrive) {
-    const busy = streamingState === "streaming" || streamingState === "sending";
+    // A turn is interruptible in every non-idle state — including while it's
+    // blocked on a permission/question prompt — mirroring the native composer
+    // (composerAction returns .stop for sending/streaming/awaiting*). Without
+    // the awaiting states, dismissing a prompt sheet would strand the user on
+    // Send with no way to cancel the running turn.
+    const busy = streamingState !== "idle";
     $("send").classList.toggle("hidden", busy);
     $("stop").classList.toggle("hidden", !busy);
   }

--- a/Alas/Resources/RemoteWeb/app.js
+++ b/Alas/Resources/RemoteWeb/app.js
@@ -339,17 +339,24 @@ function renderDriveBar(streamingState) {
   }
 }
 
+function autoGrowPrompt() {
+  const ta = $("prompt");
+  ta.style.height = "auto";                          // shrink back before measuring
+  ta.style.height = Math.min(ta.scrollHeight, window.innerHeight * 0.4) + "px";
+}
 function sendPrompt() {
   const ta = $("prompt");
   const text = ta.value.trim();
   if (!text || !currentSession || !canDrive) return;
   send({ type: "sendPrompt", sessionId: currentSession, text });
   ta.value = "";
+  autoGrowPrompt();                                  // collapse back to one row
 }
 
 $("takeover").onclick = () => { if (currentSession) send({ type: "takeOver", sessionId: currentSession }); };
 $("send").onclick = sendPrompt;
 $("stop").onclick = () => { if (currentSession) send({ type: "stop", sessionId: currentSession }); };
+$("prompt").addEventListener("input", autoGrowPrompt);
 $("prompt").addEventListener("keydown", (e) => {
   if (e.key === "Enter" && !e.shiftKey) { e.preventDefault(); sendPrompt(); }
 });

--- a/Alas/Resources/RemoteWeb/app.js
+++ b/Alas/Resources/RemoteWeb/app.js
@@ -1,6 +1,7 @@
 const tokenKey = "alas.remote.token";
 const $ = (id) => document.getElementById(id);
 let ws, currentSession = null, messages = new Map();
+let canDrive = false;
 let reconnectDelay = 1500;
 const maxReconnectDelay = 30000;
 let dismissedQuestion = null;   // {sessionId, requestId} the user closed; suppress re-shows of that exact prompt (ids aren't unique across sessions)
@@ -72,10 +73,10 @@ function send(obj) { ws && ws.readyState === 1 && ws.send(JSON.stringify(obj)); 
 function handle(msg) {
   switch (msg.type) {
     case "sessionList": renderSessions(msg.sessions); break;
-    case "transcriptSnapshot": messages = new Map(); msg.messages.forEach(m => messages.set(m.stableId, m)); if (msg.sessionId === currentSession) renderMessages(true); break;
+    case "transcriptSnapshot": messages = new Map(); msg.messages.forEach(m => messages.set(m.stableId, m)); if (msg.sessionId === currentSession) { canDrive = msg.canDrive; renderMessages(true); renderDriveBar(msg.streamingState); } break;
     // The server re-sends the full transcript each time, keyed by stable position
     // ids, so replace (don't append) to avoid accumulating duplicate copies.
-    case "transcriptDelta": messages = new Map(); msg.upserts.forEach(m => messages.set(m.stableId, m)); if (msg.sessionId === currentSession) renderMessages(false); break;
+    case "transcriptDelta": messages = new Map(); msg.upserts.forEach(m => messages.set(m.stableId, m)); if (msg.sessionId === currentSession) { canDrive = msg.canDrive; renderMessages(false); renderDriveBar(msg.streamingState); } break;
     // Scope prompt events to the session currently open — a stale/in-flight
     // event for a session the user already left must not pop or close a sheet.
     case "permissionRequest": if (msg.sessionId === currentSession) showPermission(msg.sessionId, msg.payload); break;
@@ -108,14 +109,16 @@ function renderSessions(sessions) {
 }
 
 function openSession(id) {
-  currentSession = id; messages = new Map(); dismissedQuestion = null;
+  currentSession = id; messages = new Map(); dismissedQuestion = null; canDrive = false;
   $("sessions").classList.add("hidden"); $("transcript").classList.remove("hidden");
-  $("messages").innerHTML = ""; send({ type: "subscribe", sessionId: id });
+  $("messages").innerHTML = ""; renderDriveBar("idle"); send({ type: "subscribe", sessionId: id });
 }
 function showSessions() {
   if (currentSession) send({ type: "unsubscribe", sessionId: currentSession });
-  currentSession = null;
+  currentSession = null; canDrive = false;
   hidePermission(); hideQuestion();          // never leave a sheet over the list
+  $("takeover").classList.add("hidden");
+  $("composer").classList.add("hidden");
   $("transcript").classList.add("hidden"); $("sessions").classList.remove("hidden");
   send({ type: "listSessions" });
 }
@@ -321,6 +324,32 @@ function dismissQuestion() {
   if (questionState) dismissedQuestion = { sessionId: questionState.sessionId, requestId: questionState.requestId };   // keep this exact prompt dismissed across re-sends
   hideQuestion();
 }
+function renderDriveBar(streamingState) {
+  const driving = currentSession && canDrive;
+  $("takeover").classList.toggle("hidden", !currentSession || canDrive);
+  $("composer").classList.toggle("hidden", !driving);
+  if (driving) {
+    const busy = streamingState === "streaming" || streamingState === "sending";
+    $("send").classList.toggle("hidden", busy);
+    $("stop").classList.toggle("hidden", !busy);
+  }
+}
+
+function sendPrompt() {
+  const ta = $("prompt");
+  const text = ta.value.trim();
+  if (!text || !currentSession || !canDrive) return;
+  send({ type: "sendPrompt", sessionId: currentSession, text });
+  ta.value = "";
+}
+
+$("takeover").onclick = () => { if (currentSession) send({ type: "takeOver", sessionId: currentSession }); };
+$("send").onclick = sendPrompt;
+$("stop").onclick = () => { if (currentSession) send({ type: "stop", sessionId: currentSession }); };
+$("prompt").addEventListener("keydown", (e) => {
+  if (e.key === "Enter" && !e.shiftKey) { e.preventDefault(); sendPrompt(); }
+});
+
 $("question-submit").onclick = submitQuestion;
 // Explicit Close + backdrop tap — a sheet can always be dismissed, and a closed
 // question stays closed even if the server keeps re-sending it.

--- a/Alas/Resources/RemoteWeb/app.js
+++ b/Alas/Resources/RemoteWeb/app.js
@@ -1,7 +1,7 @@
 const tokenKey = "alas.remote.token";
 const $ = (id) => document.getElementById(id);
 let ws, currentSession = null, messages = new Map();
-let canDrive = false;
+let canDrive = false, canDriveKnown = false;
 let reconnectDelay = 1500;
 const maxReconnectDelay = 30000;
 let dismissedQuestion = null;   // {sessionId, requestId} the user closed; suppress re-shows of that exact prompt (ids aren't unique across sessions)
@@ -73,10 +73,10 @@ function send(obj) { ws && ws.readyState === 1 && ws.send(JSON.stringify(obj)); 
 function handle(msg) {
   switch (msg.type) {
     case "sessionList": renderSessions(msg.sessions); break;
-    case "transcriptSnapshot": messages = new Map(); msg.messages.forEach(m => messages.set(m.stableId, m)); if (msg.sessionId === currentSession) { canDrive = msg.canDrive; renderMessages(true); renderDriveBar(msg.streamingState); } break;
+    case "transcriptSnapshot": messages = new Map(); msg.messages.forEach(m => messages.set(m.stableId, m)); if (msg.sessionId === currentSession) { canDrive = msg.canDrive; canDriveKnown = true; renderMessages(true); renderDriveBar(msg.streamingState); } break;
     // The server re-sends the full transcript each time, keyed by stable position
     // ids, so replace (don't append) to avoid accumulating duplicate copies.
-    case "transcriptDelta": messages = new Map(); msg.upserts.forEach(m => messages.set(m.stableId, m)); if (msg.sessionId === currentSession) { canDrive = msg.canDrive; renderMessages(false); renderDriveBar(msg.streamingState); } break;
+    case "transcriptDelta": messages = new Map(); msg.upserts.forEach(m => messages.set(m.stableId, m)); if (msg.sessionId === currentSession) { canDrive = msg.canDrive; canDriveKnown = true; renderMessages(false); renderDriveBar(msg.streamingState); } break;
     // Scope prompt events to the session currently open — a stale/in-flight
     // event for a session the user already left must not pop or close a sheet.
     case "permissionRequest": if (msg.sessionId === currentSession) showPermission(msg.sessionId, msg.payload); break;
@@ -109,16 +109,15 @@ function renderSessions(sessions) {
 }
 
 function openSession(id) {
-  currentSession = id; messages = new Map(); dismissedQuestion = null; canDrive = false;
+  currentSession = id; messages = new Map(); dismissedQuestion = null; canDrive = false; canDriveKnown = false;
   $("sessions").classList.add("hidden"); $("transcript").classList.remove("hidden");
   $("messages").innerHTML = ""; renderDriveBar("idle"); send({ type: "subscribe", sessionId: id });
 }
 function showSessions() {
   if (currentSession) send({ type: "unsubscribe", sessionId: currentSession });
-  currentSession = null; canDrive = false;
+  currentSession = null; canDrive = false; canDriveKnown = false;
   hidePermission(); hideQuestion();          // never leave a sheet over the list
-  $("takeover").classList.add("hidden");
-  $("composer").classList.add("hidden");
+  $("drivebar").classList.add("hidden");
   $("transcript").classList.add("hidden"); $("sessions").classList.remove("hidden");
   send({ type: "listSessions" });
 }
@@ -325,10 +324,15 @@ function dismissQuestion() {
   hideQuestion();
 }
 function renderDriveBar(streamingState) {
-  const driving = currentSession && canDrive;
-  $("takeover").classList.toggle("hidden", !currentSession || canDrive);
-  $("composer").classList.toggle("hidden", !driving);
-  if (driving) {
+  // Keep the whole bar hidden until the first snapshot tells us the real
+  // canDrive — otherwise the take-over banner flashes while opening a session
+  // we actually own, and an empty bar strip shows before any state arrives.
+  const known = !!currentSession && canDriveKnown;
+  $("drivebar").classList.toggle("hidden", !known);
+  if (!known) return;
+  $("takeover").classList.toggle("hidden", canDrive);
+  $("composer").classList.toggle("hidden", !canDrive);
+  if (canDrive) {
     const busy = streamingState === "streaming" || streamingState === "sending";
     $("send").classList.toggle("hidden", busy);
     $("stop").classList.toggle("hidden", !busy);

--- a/Alas/Resources/RemoteWeb/index.html
+++ b/Alas/Resources/RemoteWeb/index.html
@@ -4,7 +4,7 @@
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
   <title>Alas Remote</title>
-  <link rel="stylesheet" href="/style.css?v=14" />
+  <link rel="stylesheet" href="/style.css?v=15" />
 </head>
 <body>
   <header id="bar"><span id="status">connecting…</span></header>
@@ -13,6 +13,14 @@
     <section id="transcript" class="view hidden">
       <button id="back">‹ Sessions</button>
       <div id="messages"></div>
+      <div id="drivebar">
+        <button id="takeover" class="hidden">Take over to drive</button>
+        <div id="composer" class="hidden">
+          <textarea id="prompt" rows="1" placeholder="Message…"></textarea>
+          <button id="send">Send</button>
+          <button id="stop" class="hidden">Stop</button>
+        </div>
+      </div>
     </section>
   </main>
   <div id="permission" class="sheet hidden">
@@ -38,8 +46,8 @@
       <button id="gate-retry" class="hidden">Try again</button>
     </div>
   </div>
-  <script src="/marked.min.js?v=14"></script>
-  <script src="/purify.min.js?v=14"></script>
-  <script src="/app.js?v=14"></script>
+  <script src="/marked.min.js?v=15"></script>
+  <script src="/purify.min.js?v=15"></script>
+  <script src="/app.js?v=15"></script>
 </body>
 </html>

--- a/Alas/Resources/RemoteWeb/index.html
+++ b/Alas/Resources/RemoteWeb/index.html
@@ -4,7 +4,7 @@
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
   <title>Alas Remote</title>
-  <link rel="stylesheet" href="/style.css?v=21" />
+  <link rel="stylesheet" href="/style.css?v=22" />
 </head>
 <body>
   <header id="bar">
@@ -53,8 +53,8 @@
       <button id="gate-retry" class="hidden">Try again</button>
     </div>
   </div>
-  <script src="/marked.min.js?v=21"></script>
-  <script src="/purify.min.js?v=21"></script>
-  <script src="/app.js?v=21"></script>
+  <script src="/marked.min.js?v=22"></script>
+  <script src="/purify.min.js?v=22"></script>
+  <script src="/app.js?v=22"></script>
 </body>
 </html>

--- a/Alas/Resources/RemoteWeb/index.html
+++ b/Alas/Resources/RemoteWeb/index.html
@@ -4,21 +4,28 @@
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
   <title>Alas Remote</title>
-  <link rel="stylesheet" href="/style.css?v=15" />
+  <link rel="stylesheet" href="/style.css?v=20" />
 </head>
 <body>
-  <header id="bar"><span id="status">connecting…</span></header>
+  <header id="bar">
+    <button id="back" class="hidden">‹ Sessions</button>
+    <span id="nav-title">Alas Remote</span>
+    <span id="status" class="chip" data-state="connecting">connecting…</span>
+  </header>
   <main>
     <section id="sessions" class="view"><h1>Sessions</h1><div id="session-list"></div></section>
     <section id="transcript" class="view hidden">
-      <button id="back">‹ Sessions</button>
       <div id="messages"></div>
       <div id="drivebar">
         <button id="takeover" class="hidden">Take over to drive</button>
         <div id="composer" class="hidden">
           <textarea id="prompt" rows="1" placeholder="Message…"></textarea>
-          <button id="send">Send</button>
-          <button id="stop" class="hidden">Stop</button>
+          <button id="send" aria-label="Send">
+            <svg viewBox="0 0 24 24" width="19" height="19" aria-hidden="true"><path d="M12 19V5M6 11l6-6 6 6" fill="none" stroke="currentColor" stroke-width="2.4" stroke-linecap="round" stroke-linejoin="round"/></svg>
+          </button>
+          <button id="stop" class="hidden" aria-label="Stop">
+            <svg viewBox="0 0 24 24" width="16" height="16" aria-hidden="true"><rect x="6" y="6" width="12" height="12" rx="2.6" fill="currentColor"/></svg>
+          </button>
         </div>
       </div>
     </section>
@@ -46,8 +53,8 @@
       <button id="gate-retry" class="hidden">Try again</button>
     </div>
   </div>
-  <script src="/marked.min.js?v=15"></script>
-  <script src="/purify.min.js?v=15"></script>
-  <script src="/app.js?v=15"></script>
+  <script src="/marked.min.js?v=20"></script>
+  <script src="/purify.min.js?v=20"></script>
+  <script src="/app.js?v=20"></script>
 </body>
 </html>

--- a/Alas/Resources/RemoteWeb/index.html
+++ b/Alas/Resources/RemoteWeb/index.html
@@ -4,7 +4,7 @@
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
   <title>Alas Remote</title>
-  <link rel="stylesheet" href="/style.css?v=20" />
+  <link rel="stylesheet" href="/style.css?v=21" />
 </head>
 <body>
   <header id="bar">
@@ -53,8 +53,8 @@
       <button id="gate-retry" class="hidden">Try again</button>
     </div>
   </div>
-  <script src="/marked.min.js?v=20"></script>
-  <script src="/purify.min.js?v=20"></script>
-  <script src="/app.js?v=20"></script>
+  <script src="/marked.min.js?v=21"></script>
+  <script src="/purify.min.js?v=21"></script>
+  <script src="/app.js?v=21"></script>
 </body>
 </html>

--- a/Alas/Resources/RemoteWeb/style.css
+++ b/Alas/Resources/RemoteWeb/style.css
@@ -19,10 +19,27 @@
   --del: oklch(0.72 0.16 25);
 }
 * { box-sizing: border-box; }
-body { margin: 0; color: var(--fg); background: linear-gradient(180deg, var(--bg-1), var(--bg-0)) fixed; -webkit-font-smoothing: antialiased; }
+/* Fixed-height app shell: header + scrolling body + pinned footer, sized to the
+   *dynamic* viewport (dvh) so it tracks iOS's collapsing toolbar instead of
+   overflowing past the visible screen the way 100vh does. */
+html, body { height: 100%; }
+/* position:fixed locks the shell to the viewport so iOS can't scroll the
+   document when the keyboard opens; JS then drives height from
+   window.visualViewport so the shell tracks the keyboard exactly. The
+   100dvh is the no-JS fallback. */
+body { margin: 0; position: fixed; top: 0; left: 0; right: 0; height: 100vh; height: 100dvh; display: flex; flex-direction: column; overflow: hidden; color: var(--fg); background: linear-gradient(180deg, var(--bg-1), var(--bg-0)) fixed; -webkit-font-smoothing: antialiased; }
+main { flex: 1 1 auto; min-height: 0; display: flex; flex-direction: column; }
 
-#bar { position: sticky; top: 0; z-index: 5; padding: calc(env(safe-area-inset-top) + 6px) 14px 8px; background: color-mix(in oklab, var(--bg-1), transparent 6%); backdrop-filter: blur(8px); font-size: 13px; color: var(--fg-faint); border-bottom: 0.5px solid var(--line-soft); }
-.view { padding: 6px 12px 28px; }
+#bar { flex: 0 0 auto; z-index: 5; display: flex; align-items: center; gap: 10px; padding: calc(env(safe-area-inset-top) + 8px) 12px 8px; background: color-mix(in oklab, var(--bg-1), transparent 6%); backdrop-filter: blur(8px); border-bottom: 0.5px solid var(--line-soft); }
+#nav-title { font-size: 16px; font-weight: 600; color: var(--fg); }
+/* Connection chip: dot + label, color driven by [data-state]. */
+#status.chip { margin-left: auto; display: inline-flex; align-items: center; gap: 6px; padding: 4px 10px 4px 9px; border-radius: 999px; font-size: 12px; font-weight: 600; color: var(--fg-muted); background: color-mix(in oklab, var(--bg-3) 70%, transparent); border: 0.5px solid var(--line); white-space: nowrap; }
+#status.chip::before { content: ""; width: 7px; height: 7px; border-radius: 50%; background: var(--fg-faint); flex-shrink: 0; }
+#status[data-state="ok"]::before { background: var(--add); box-shadow: 0 0 6px color-mix(in oklab, var(--add) 70%, transparent); }
+#status[data-state="bad"]::before { background: var(--del); }
+#status[data-state="connecting"]::before { background: oklch(0.82 0.13 90); }
+/* The active view fills the shell; long content scrolls inside it, not the page. */
+.view { flex: 1 1 auto; min-height: 0; overflow-y: auto; -webkit-overflow-scrolling: touch; padding: 6px 12px calc(28px + env(safe-area-inset-bottom)); }
 .hidden { display: none !important; }   /* !important: beats .sheet's later display:flex */
 
 /* Sessions list */
@@ -31,10 +48,11 @@ h1 { font-size: 22px; font-weight: 700; margin: 12px 4px 10px; }
 .session-row { display: flex; justify-content: space-between; align-items: center; gap: 10px; width: 100%; padding: 15px 10px; border: none; border-bottom: 0.5px solid var(--line-soft); background: none; color: var(--fg); font: inherit; font-size: 15px; text-align: left; cursor: pointer; -webkit-tap-highlight-color: transparent; }
 .session-row:active { background: var(--bg-2); }
 .session-row .status { color: var(--accent); font-size: 11px; flex-shrink: 0; }
-#back { background: none; border: none; color: var(--accent); font-size: 15px; padding: 6px 2px 10px; cursor: pointer; }
+#back { background: none; border: none; color: var(--accent); font-size: 15px; padding: 4px 2px; margin: -4px 0; cursor: pointer; -webkit-tap-highlight-color: transparent; }
 
-/* Transcript */
-#messages { display: flex; flex-direction: column; }
+/* Transcript: a non-scrolling column — only #messages scrolls, #drivebar pins. */
+#transcript { display: flex; flex-direction: column; overflow: hidden; padding: 0; }
+#messages { flex: 1 1 auto; min-height: 0; overflow-y: auto; -webkit-overflow-scrolling: touch; padding: 2px 12px 8px; display: flex; flex-direction: column; }
 .msg { margin: 5px 0; line-height: 1.5; font-size: 15px; overflow-wrap: anywhere; white-space: pre-wrap; }
 .m-agent { align-self: stretch; color: var(--fg); padding: 1px 2px; }
 .m-user { align-self: flex-end; max-width: 82%; padding: 9px 13px; color: var(--fg); background: linear-gradient(180deg, color-mix(in oklab, var(--accent) 32%, transparent), color-mix(in oklab, var(--accent) 20%, transparent)); border: 0.5px solid color-mix(in oklab, var(--accent) 50%, transparent); border-radius: 13px 13px 4px 13px; box-shadow: 0 2px 8px rgba(0,0,0,.2); }
@@ -83,11 +101,19 @@ h1 { font-size: 22px; font-weight: 700; margin: 12px 4px 10px; }
 .tool-body { margin: 0; padding: 9px 11px; border-top: 0.5px solid var(--line-soft); background: color-mix(in oklab, var(--bg-0) 55%, transparent); font-family: ui-monospace, monospace; font-size: 11.5px; line-height: 1.45; color: var(--fg-muted); white-space: pre; overflow-x: auto; max-height: 46vh; overflow-y: auto; }
 
 /* Composer / drive bar */
-#drivebar { position: sticky; bottom: 0; padding: 8px 10px calc(8px + env(safe-area-inset-bottom)); background: color-mix(in oklab, var(--bg-1), transparent 4%); backdrop-filter: blur(8px); border-top: 0.5px solid var(--line-soft); }
-#takeover { width: 100%; padding: 12px; border: 0.5px solid var(--accent); border-radius: 10px; background: color-mix(in oklab, var(--accent) 16%, transparent); color: var(--fg); font-size: 15px; cursor: pointer; }
-#composer { display: flex; gap: 8px; align-items: flex-end; }
-#prompt { flex: 1; min-height: 38px; max-height: 40vh; padding: 9px 12px; border: 0.5px solid var(--line); border-radius: 12px; background: var(--bg-0); color: var(--fg); font: inherit; font-size: 15px; resize: none; }
-#composer button { padding: 0 16px; height: 38px; border: none; border-radius: 10px; font-size: 15px; font-weight: 600; cursor: pointer; }
+#drivebar { flex: 0 0 auto; padding: 8px 10px calc(8px + env(safe-area-inset-bottom)); background: color-mix(in oklab, var(--bg-1), transparent 4%); backdrop-filter: blur(8px); border-top: 0.5px solid var(--line-soft); }
+#takeover { width: 100%; padding: 13px; border: 0.5px solid color-mix(in oklab, var(--accent) 55%, transparent); border-radius: 21px; background: color-mix(in oklab, var(--accent) 16%, transparent); color: var(--fg); font-size: 15px; font-weight: 600; cursor: pointer; -webkit-tap-highlight-color: transparent; }
+#takeover:active { background: color-mix(in oklab, var(--accent) 24%, transparent); }
+/* One rounded field; the action button docks bottom-right and the textarea
+   grows above it. align-items:flex-end keeps the button pinned to the last line. */
+#composer { display: flex; gap: 7px; align-items: flex-end; padding: 5px 5px 5px 15px; background: var(--bg-0); border: 0.5px solid var(--line); border-radius: 22px; }
+#composer:focus-within { border-color: color-mix(in oklab, var(--accent) 60%, var(--line)); }
+/* font-size MUST be ≥16px: iOS auto-zooms (and inflates the viewport) on focus
+   of any smaller field. */
+#prompt { flex: 1; min-height: 24px; max-height: 40vh; padding: 7px 0; border: none; background: none; color: var(--fg); font: inherit; font-size: 16px; line-height: 1.35; resize: none; outline: none; }
+#prompt::placeholder { color: var(--fg-faint); }
+#composer button { flex-shrink: 0; width: 34px; height: 34px; padding: 0; border: none; border-radius: 50%; display: flex; align-items: center; justify-content: center; cursor: pointer; -webkit-tap-highlight-color: transparent; transition: transform .08s; }
+#composer button:active { transform: scale(0.92); }
 #send { background: var(--accent); color: var(--bg-0); }
 #stop { background: var(--del); color: var(--fg); }
 

--- a/Alas/Resources/RemoteWeb/style.css
+++ b/Alas/Resources/RemoteWeb/style.css
@@ -82,6 +82,15 @@ h1 { font-size: 22px; font-weight: 700; margin: 12px 4px 10px; }
 .m-tool[open] .tool-chev { transform: rotate(180deg); }
 .tool-body { margin: 0; padding: 9px 11px; border-top: 0.5px solid var(--line-soft); background: color-mix(in oklab, var(--bg-0) 55%, transparent); font-family: ui-monospace, monospace; font-size: 11.5px; line-height: 1.45; color: var(--fg-muted); white-space: pre; overflow-x: auto; max-height: 46vh; overflow-y: auto; }
 
+/* Composer / drive bar */
+#drivebar { position: sticky; bottom: 0; padding: 8px 10px calc(8px + env(safe-area-inset-bottom)); background: color-mix(in oklab, var(--bg-1), transparent 4%); backdrop-filter: blur(8px); border-top: 0.5px solid var(--line-soft); }
+#takeover { width: 100%; padding: 12px; border: 0.5px solid var(--accent); border-radius: 10px; background: color-mix(in oklab, var(--accent) 16%, transparent); color: var(--fg); font-size: 15px; cursor: pointer; }
+#composer { display: flex; gap: 8px; align-items: flex-end; }
+#prompt { flex: 1; min-height: 38px; max-height: 40vh; padding: 9px 12px; border: 0.5px solid var(--line); border-radius: 12px; background: var(--bg-0); color: var(--fg); font: inherit; font-size: 15px; resize: none; }
+#composer button { padding: 0 16px; height: 38px; border: none; border-radius: 10px; font-size: 15px; font-weight: 600; cursor: pointer; }
+#send { background: var(--accent); color: var(--bg-0); }
+#stop { background: var(--del); color: var(--fg); }
+
 /* Pair / error gate (full screen) */
 #gate { position: fixed; inset: 0; z-index: 20; display: flex; align-items: center; justify-content: center; padding: 28px; background: linear-gradient(180deg, var(--bg-1), var(--bg-0)); }
 .gate-card { text-align: center; max-width: 320px; }

--- a/Alas/Sources/ACP/Session/ACPSessionManager.swift
+++ b/Alas/Sources/ACP/Session/ACPSessionManager.swift
@@ -59,15 +59,23 @@ final class ACPSessionManager: ObservableObject {
 
     /// Submit a prompt using the same path the local composer uses (`.auto`
     /// intent resolves to send-now or enqueue based on agent state). Returns
-    /// false if the session isn't live or needs auth (the `submit` guards).
+    /// false if we no longer hold the lease, or the session isn't live / needs
+    /// auth (the `submit` guards).
+    ///
+    /// Re-checks `isWriter` at the point of action: a cross-process takeover can
+    /// land between the gateway's `isWriter` gate and here, and `submit`'s
+    /// `.idle`/`.disconnected` path would otherwise enqueue + persist the prompt
+    /// as a mirror — injecting it into a session another instance now drives.
     @discardableResult
     func sendPrompt(for id: ACPSession.ID, text: String) -> Bool {
-        submit(sessionId: id, text: text, attachments: [], intent: .auto, onCompleted: { _ in })
+        guard isWriter(for: id) else { return false }
+        return submit(sessionId: id, text: text, attachments: [], intent: .auto, onCompleted: { _ in })
     }
 
-    /// Interrupt the in-flight turn (same as the composer Stop / Esc).
+    /// Interrupt the in-flight turn (same as the composer Stop / Esc). Guarded
+    /// on the live lease for the same cross-process-takeover reason as `sendPrompt`.
     func interrupt(for id: ACPSession.ID) {
-        guard let runner = runners[id] else { return }
+        guard isWriter(for: id), let runner = runners[id] else { return }
         Task { await runner.userCancel() }
     }
 

--- a/Alas/Sources/ACP/Session/ACPSessionManager.swift
+++ b/Alas/Sources/ACP/Session/ACPSessionManager.swift
@@ -43,8 +43,19 @@ final class ACPSessionManager: ObservableObject {
     /// Lightweight summaries for the remote sessions list.
     var sessionRows: [ACPSessionRow] { recent }
 
-    /// Whether this instance currently holds the writer lease for the session.
-    func isWriter(for id: ACPSession.ID) -> Bool { _ownedLeases.contains(id) }
+    /// Whether this instance is the legitimate current writer for the session —
+    /// gates every remote drive action (`canDrive`, `sendPrompt`, `stop`).
+    ///
+    /// Requires BOTH the in-memory claim AND store agreement: after another
+    /// window takes over, the former owner keeps the id in `_ownedLeases` until
+    /// its heartbeat stands down (~5s). Trusting the in-memory set alone would
+    /// let a phone connected to the old owner keep writing into a session
+    /// another instance now drives — corrupting the active conversation. So we
+    /// also consult the store row via `anotherLiveInstanceOwnsLease`, the same
+    /// guard the local write path (`holdsLeaseForWrite`) relies on.
+    func isWriter(for id: ACPSession.ID) -> Bool {
+        _ownedLeases.contains(id) && !anotherLiveInstanceOwnsLease(sessionId: id)
+    }
 
     /// Submit a prompt using the same path the local composer uses (`.auto`
     /// intent resolves to send-now or enqueue based on agent state). Returns

--- a/Alas/Sources/ACP/Session/ACPSessionManager.swift
+++ b/Alas/Sources/ACP/Session/ACPSessionManager.swift
@@ -43,6 +43,23 @@ final class ACPSessionManager: ObservableObject {
     /// Lightweight summaries for the remote sessions list.
     var sessionRows: [ACPSessionRow] { recent }
 
+    /// Whether this instance currently holds the writer lease for the session.
+    func isWriter(for id: ACPSession.ID) -> Bool { _ownedLeases.contains(id) }
+
+    /// Submit a prompt using the same path the local composer uses (`.auto`
+    /// intent resolves to send-now or enqueue based on agent state). No-op
+    /// returns false if the session isn't live.
+    @discardableResult
+    func sendPrompt(for id: ACPSession.ID, text: String) -> Bool {
+        submit(sessionId: id, text: text, attachments: [], intent: .auto, onCompleted: { _ in })
+    }
+
+    /// Interrupt the in-flight turn (same as the composer Stop / Esc).
+    func interrupt(for id: ACPSession.ID) {
+        guard let runner = runners[id] else { return }
+        Task { await runner.userCancel() }
+    }
+
     /// Sessions for which THIS instance holds the writer lease (backing store).
     var _ownedLeases: Set<ACPSession.ID> = []
     /// Per-session periodic heartbeat tasks (backing store).

--- a/Alas/Sources/ACP/Session/ACPSessionManager.swift
+++ b/Alas/Sources/ACP/Session/ACPSessionManager.swift
@@ -47,8 +47,8 @@ final class ACPSessionManager: ObservableObject {
     func isWriter(for id: ACPSession.ID) -> Bool { _ownedLeases.contains(id) }
 
     /// Submit a prompt using the same path the local composer uses (`.auto`
-    /// intent resolves to send-now or enqueue based on agent state). No-op
-    /// returns false if the session isn't live.
+    /// intent resolves to send-now or enqueue based on agent state). Returns
+    /// false if the session isn't live or needs auth (the `submit` guards).
     @discardableResult
     func sendPrompt(for id: ACPSession.ID, text: String) -> Bool {
         submit(sessionId: id, text: text, attachments: [], intent: .auto, onCompleted: { _ in })

--- a/Alas/Sources/ACP/Session/ACPSessionManager.swift
+++ b/Alas/Sources/ACP/Session/ACPSessionManager.swift
@@ -58,18 +58,29 @@ final class ACPSessionManager: ObservableObject {
     }
 
     /// Submit a prompt using the same path the local composer uses (`.auto`
-    /// intent resolves to send-now or enqueue based on agent state). Returns
-    /// false if we no longer hold the lease, or the session isn't live / needs
-    /// auth (the `submit` guards).
+    /// intent resolves to send-now or enqueue based on agent state).
+    ///
+    /// `onResult` fires exactly once with the final outcome so the gateway can
+    /// tell the client to restore the text on failure (the local composer uses
+    /// the same callback to reinstate its draft):
+    /// - `false` immediately when we no longer hold the lease or `submit`
+    ///   refuses synchronously (no live session / needs auth);
+    /// - otherwise the eventual `submit` completion — `true` once the prompt is
+    ///   sent or safely queued, `false` if the `session/prompt` RPC later fails
+    ///   (auth/network/agent error) on the already-`.ready` path.
     ///
     /// Re-checks `isWriter` at the point of action: a cross-process takeover can
     /// land between the gateway's `isWriter` gate and here, and `submit`'s
     /// `.idle`/`.disconnected` path would otherwise enqueue + persist the prompt
     /// as a mirror — injecting it into a session another instance now drives.
-    @discardableResult
-    func sendPrompt(for id: ACPSession.ID, text: String) -> Bool {
-        guard isWriter(for: id) else { return false }
-        return submit(sessionId: id, text: text, attachments: [], intent: .auto, onCompleted: { _ in })
+    func sendPrompt(for id: ACPSession.ID, text: String, onResult: @escaping @MainActor (Bool) -> Void) {
+        guard isWriter(for: id) else {
+            onResult(false)
+            return
+        }
+        let accepted = submit(sessionId: id, text: text, attachments: [], intent: .auto,
+                              onCompleted: { ok in onResult(ok) })
+        if !accepted { onResult(false) }   // submit refused synchronously; onCompleted won't fire
     }
 
     /// Interrupt the in-flight turn (same as the composer Stop / Esc). Guarded

--- a/Alas/Sources/App/AppState.swift
+++ b/Alas/Sources/App/AppState.swift
@@ -3216,7 +3216,8 @@ extension AppState: RemoteSessionsProvider {
                     id: row.id,
                     title: row.title,
                     agentId: row.agentId,
-                    status: state.map(RemoteSessionGateway.stateString) ?? "idle"
+                    status: state.map(RemoteSessionGateway.stateString) ?? "idle",
+                    canDrive: false // TODO(P2-T4): real canDrive via isWriter
                 ))
             }
         }

--- a/Alas/Sources/App/AppState.swift
+++ b/Alas/Sources/App/AppState.swift
@@ -3272,11 +3272,14 @@ extension AppState: RemoteSessionsProvider {
         }
     }
 
-    func sendPrompt(for id: String, text: String) {
+    /// Returns whether the prompt was accepted (false when the owning manager
+    /// refuses it — e.g. the session needs auth — or no manager owns the id),
+    /// so the gateway can tell the client to restore the text.
+    func sendPrompt(for id: String, text: String) -> Bool {
         for mgr in acpManagers.values where mgr.liveSession(for: id) != nil {
-            mgr.sendPrompt(for: id, text: text)
-            return
+            return mgr.sendPrompt(for: id, text: text)
         }
+        return false
     }
 
     func stop(for id: String) {

--- a/Alas/Sources/App/AppState.swift
+++ b/Alas/Sources/App/AppState.swift
@@ -3259,4 +3259,30 @@ extension AppState: RemoteSessionsProvider {
             return
         }
     }
+
+    func isWriter(for id: String) -> Bool {
+        for mgr in acpManagers.values where mgr.isWriter(for: id) { return true }
+        return false
+    }
+
+    func takeOver(for id: String) {
+        for mgr in acpManagers.values where mgr.liveSession(for: id) != nil {
+            mgr.takeOver(sessionId: id)
+            return
+        }
+    }
+
+    func sendPrompt(for id: String, text: String) {
+        for mgr in acpManagers.values where mgr.liveSession(for: id) != nil {
+            mgr.sendPrompt(for: id, text: text)
+            return
+        }
+    }
+
+    func stop(for id: String) {
+        for mgr in acpManagers.values where mgr.liveSession(for: id) != nil {
+            mgr.interrupt(for: id)
+            return
+        }
+    }
 }

--- a/Alas/Sources/App/AppState.swift
+++ b/Alas/Sources/App/AppState.swift
@@ -3217,7 +3217,7 @@ extension AppState: RemoteSessionsProvider {
                     title: row.title,
                     agentId: row.agentId,
                     status: state.map(RemoteSessionGateway.stateString) ?? "idle",
-                    canDrive: false // TODO(P2-T4): real canDrive via isWriter
+                    canDrive: mgr.isWriter(for: row.id)
                 ))
             }
         }

--- a/Alas/Sources/App/AppState.swift
+++ b/Alas/Sources/App/AppState.swift
@@ -3272,14 +3272,14 @@ extension AppState: RemoteSessionsProvider {
         }
     }
 
-    /// Returns whether the prompt was accepted (false when the owning manager
-    /// refuses it — e.g. the session needs auth — or no manager owns the id),
-    /// so the gateway can tell the client to restore the text.
-    func sendPrompt(for id: String, text: String) -> Bool {
+    /// `onResult` fires once (false when no manager owns the id, the manager
+    /// refuses, or delivery later fails) so the gateway can restore the text.
+    func sendPrompt(for id: String, text: String, onResult: @escaping @MainActor (Bool) -> Void) {
         for mgr in acpManagers.values where mgr.liveSession(for: id) != nil {
-            return mgr.sendPrompt(for: id, text: text)
+            mgr.sendPrompt(for: id, text: text, onResult: onResult)
+            return
         }
-        return false
+        onResult(false)
     }
 
     func stop(for id: String) {

--- a/Alas/Sources/Remote/Gateway/RemoteSessionGateway.swift
+++ b/Alas/Sources/Remote/Gateway/RemoteSessionGateway.swift
@@ -50,6 +50,16 @@ final class RemoteSessionGateway {
             applyQuestionAnswer(sessionId: id, requestId: requestId, answers: answers)
         case .takeOver(let id):
             provider.takeOver(for: id)
+            // Takeover seizes the writer lease synchronously but mostly mutates
+            // lease/agent state, not the transcript — so the objectWillChange
+            // delta that normally carries `canDrive` may never fire on an idle
+            // session. Push a snapshot now so the client learns canDrive=true
+            // immediately and the composer unlocks (otherwise the take-over
+            // button stays up and sendPrompt stays blocked until some unrelated
+            // transcript mutation happens to occur).
+            if let session = provider.session(for: id) {
+                sendSnapshot(id: id, session: session)
+            }
         case .sendPrompt(let id, let text):
             let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
             guard provider.isWriter(for: id), !trimmed.isEmpty else { return }

--- a/Alas/Sources/Remote/Gateway/RemoteSessionGateway.swift
+++ b/Alas/Sources/Remote/Gateway/RemoteSessionGateway.swift
@@ -62,7 +62,13 @@ final class RemoteSessionGateway {
             }
         case .sendPrompt(let id, let text):
             let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
-            guard provider.isWriter(for: id), !trimmed.isEmpty else { return }
+            guard provider.isWriter(for: id), !trimmed.isEmpty else {
+                // Drop, but tell the client so it can restore the user's text
+                // rather than silently losing it (e.g. canDrive went stale
+                // because a takeover's attach failed and released the lease).
+                send(.promptRejected(sessionId: id))
+                return
+            }
             provider.sendPrompt(for: id, text: trimmed)
         case .stop(let id):
             guard provider.isWriter(for: id) else { return }

--- a/Alas/Sources/Remote/Gateway/RemoteSessionGateway.swift
+++ b/Alas/Sources/Remote/Gateway/RemoteSessionGateway.swift
@@ -62,17 +62,17 @@ final class RemoteSessionGateway {
             }
         case .sendPrompt(let id, let text):
             let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
-            guard provider.isWriter(for: id), !trimmed.isEmpty else {
-                // Drop, but tell the client so it can restore the user's text
-                // rather than silently losing it (e.g. canDrive went stale
-                // because a takeover's attach failed and released the lease).
+            guard !trimmed.isEmpty else {
                 send(.promptRejected(sessionId: id))
                 return
             }
-            // We're the writer, but the manager can still refuse (e.g. the
-            // session needs auth) — surface that as a rejection too.
-            if !provider.sendPrompt(for: id, text: trimmed) {
-                send(.promptRejected(sessionId: id))
+            // The manager owns the writer/lease re-check and the eventual
+            // delivery result. Emit promptRejected on any failure — refused
+            // now (not writer / needs auth) OR a session/prompt RPC that fails
+            // later — so the client restores the user's text instead of losing
+            // it.
+            provider.sendPrompt(for: id, text: trimmed) { [weak self] accepted in
+                if !accepted { self?.send(.promptRejected(sessionId: id)) }
             }
         case .stop(let id):
             guard provider.isWriter(for: id) else { return }

--- a/Alas/Sources/Remote/Gateway/RemoteSessionGateway.swift
+++ b/Alas/Sources/Remote/Gateway/RemoteSessionGateway.swift
@@ -48,6 +48,8 @@ final class RemoteSessionGateway {
             applyDecision(sessionId: id, requestId: requestId, optionId: optionId, persistScope: persistScope)
         case .questionAnswer(let id, let requestId, let answers):
             applyQuestionAnswer(sessionId: id, requestId: requestId, answers: answers)
+        case .takeOver, .sendPrompt, .stop:
+            break // TODO(P2-T3): implement drive verbs
         }
     }
 
@@ -66,6 +68,7 @@ final class RemoteSessionGateway {
         let wire = session.transcript.messages.enumerated().map { Self.toWire($0.element, index: $0.offset) }
         send(.transcriptSnapshot(sessionId: id,
                                  streamingState: Self.stateString(session.transcript.streamingState),
+                                 canDrive: false, // TODO(P2-T3): real canDrive
                                  messages: wire))
         emitPendingPermissionIfAny(id: id, session: session)
         emitPendingQuestionIfAny(id: id, session: session)
@@ -96,6 +99,7 @@ final class RemoteSessionGateway {
         let wire = session.transcript.messages.enumerated().map { Self.toWire($0.element, index: $0.offset) }
         send(.transcriptDelta(sessionId: id,
                               streamingState: Self.stateString(session.transcript.streamingState),
+                              canDrive: false, // TODO(P2-T3): real canDrive
                               upserts: wire))
         emitPendingPermissionIfAny(id: id, session: session)
         emitPendingQuestionIfAny(id: id, session: session)

--- a/Alas/Sources/Remote/Gateway/RemoteSessionGateway.swift
+++ b/Alas/Sources/Remote/Gateway/RemoteSessionGateway.swift
@@ -69,7 +69,11 @@ final class RemoteSessionGateway {
                 send(.promptRejected(sessionId: id))
                 return
             }
-            provider.sendPrompt(for: id, text: trimmed)
+            // We're the writer, but the manager can still refuse (e.g. the
+            // session needs auth) — surface that as a rejection too.
+            if !provider.sendPrompt(for: id, text: trimmed) {
+                send(.promptRejected(sessionId: id))
+            }
         case .stop(let id):
             guard provider.isWriter(for: id) else { return }
             provider.stop(for: id)

--- a/Alas/Sources/Remote/Gateway/RemoteSessionGateway.swift
+++ b/Alas/Sources/Remote/Gateway/RemoteSessionGateway.swift
@@ -48,8 +48,15 @@ final class RemoteSessionGateway {
             applyDecision(sessionId: id, requestId: requestId, optionId: optionId, persistScope: persistScope)
         case .questionAnswer(let id, let requestId, let answers):
             applyQuestionAnswer(sessionId: id, requestId: requestId, answers: answers)
-        case .takeOver, .sendPrompt, .stop:
-            break // TODO(P2-T3): implement drive verbs
+        case .takeOver(let id):
+            provider.takeOver(for: id)
+        case .sendPrompt(let id, let text):
+            let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
+            guard provider.isWriter(for: id), !trimmed.isEmpty else { return }
+            provider.sendPrompt(for: id, text: trimmed)
+        case .stop(let id):
+            guard provider.isWriter(for: id) else { return }
+            provider.stop(for: id)
         }
     }
 
@@ -68,7 +75,7 @@ final class RemoteSessionGateway {
         let wire = session.transcript.messages.enumerated().map { Self.toWire($0.element, index: $0.offset) }
         send(.transcriptSnapshot(sessionId: id,
                                  streamingState: Self.stateString(session.transcript.streamingState),
-                                 canDrive: false, // TODO(P2-T3): real canDrive
+                                 canDrive: provider.isWriter(for: id),
                                  messages: wire))
         emitPendingPermissionIfAny(id: id, session: session)
         emitPendingQuestionIfAny(id: id, session: session)
@@ -99,7 +106,7 @@ final class RemoteSessionGateway {
         let wire = session.transcript.messages.enumerated().map { Self.toWire($0.element, index: $0.offset) }
         send(.transcriptDelta(sessionId: id,
                               streamingState: Self.stateString(session.transcript.streamingState),
-                              canDrive: false, // TODO(P2-T3): real canDrive
+                              canDrive: provider.isWriter(for: id),
                               upserts: wire))
         emitPendingPermissionIfAny(id: id, session: session)
         emitPendingQuestionIfAny(id: id, session: session)

--- a/Alas/Sources/Remote/Gateway/RemoteSessionsProvider.swift
+++ b/Alas/Sources/Remote/Gateway/RemoteSessionsProvider.swift
@@ -11,6 +11,8 @@ protocol RemoteSessionsProvider: AnyObject {
     func answerQuestion(for id: String, _ response: ACPQuestionResponse)
     func isWriter(for id: String) -> Bool
     func takeOver(for id: String)
-    func sendPrompt(for id: String, text: String)
+    /// Returns whether the prompt was accepted; the gateway emits
+    /// `promptRejected` when it is not so the client can restore the text.
+    func sendPrompt(for id: String, text: String) -> Bool
     func stop(for id: String)
 }

--- a/Alas/Sources/Remote/Gateway/RemoteSessionsProvider.swift
+++ b/Alas/Sources/Remote/Gateway/RemoteSessionsProvider.swift
@@ -9,4 +9,8 @@ protocol RemoteSessionsProvider: AnyObject {
     func permissionPolicy(for id: String) -> ACPPermissionPolicy?
     func hydrateIfNeeded(id: String) async
     func answerQuestion(for id: String, _ response: ACPQuestionResponse)
+    func isWriter(for id: String) -> Bool
+    func takeOver(for id: String)
+    func sendPrompt(for id: String, text: String)
+    func stop(for id: String)
 }

--- a/Alas/Sources/Remote/Gateway/RemoteSessionsProvider.swift
+++ b/Alas/Sources/Remote/Gateway/RemoteSessionsProvider.swift
@@ -11,8 +11,9 @@ protocol RemoteSessionsProvider: AnyObject {
     func answerQuestion(for id: String, _ response: ACPQuestionResponse)
     func isWriter(for id: String) -> Bool
     func takeOver(for id: String)
-    /// Returns whether the prompt was accepted; the gateway emits
-    /// `promptRejected` when it is not so the client can restore the text.
-    func sendPrompt(for id: String, text: String) -> Bool
+    /// `onResult` fires once with the final outcome (false = refused now or
+    /// failed delivery later); the gateway emits `promptRejected` on false so
+    /// the client can restore the text instead of losing it.
+    func sendPrompt(for id: String, text: String, onResult: @escaping @MainActor (Bool) -> Void)
     func stop(for id: String)
 }

--- a/Alas/Sources/Remote/Protocol/RemoteMessageWireJSON.swift
+++ b/Alas/Sources/Remote/Protocol/RemoteMessageWireJSON.swift
@@ -14,7 +14,8 @@ struct RemoteSessionSummary: Codable, Equatable, Sendable {
     let id: String
     let title: String
     let agentId: String
-    let status: String        // "idle" | "streaming" | "awaitingPermission"
+    let status: String       // "idle" | "streaming" | "awaitingPermission" | "awaitingInput"
+    let canDrive: Bool       // this remote-host instance currently holds the writer lease
 }
 
 /// A permission request surfaced to the client.

--- a/Alas/Sources/Remote/Protocol/RemoteProtocol.swift
+++ b/Alas/Sources/Remote/Protocol/RemoteProtocol.swift
@@ -7,10 +7,13 @@ enum RemoteClientMessage: Equatable, Sendable {
     case unsubscribe(sessionId: String)
     case permissionDecision(sessionId: String, requestId: Int, optionId: String, persistScope: String?)
     case questionAnswer(sessionId: String, requestId: Int, answers: [RemoteQuestionAnswer])
+    case takeOver(sessionId: String)
+    case sendPrompt(sessionId: String, text: String)
+    case stop(sessionId: String)
 }
 
 extension RemoteClientMessage: Codable {
-    private enum CodingKeys: String, CodingKey { case type, sessionId, requestId, optionId, persistScope, answers }
+    private enum CodingKeys: String, CodingKey { case type, sessionId, requestId, optionId, persistScope, answers, text }
 
     init(from decoder: Decoder) throws {
         let c = try decoder.container(keyedBy: CodingKeys.self)
@@ -29,6 +32,14 @@ extension RemoteClientMessage: Codable {
                 sessionId: try c.decode(String.self, forKey: .sessionId),
                 requestId: try c.decode(Int.self, forKey: .requestId),
                 answers: try c.decode([RemoteQuestionAnswer].self, forKey: .answers))
+        case "takeOver":
+            self = .takeOver(sessionId: try c.decode(String.self, forKey: .sessionId))
+        case "sendPrompt":
+            self = .sendPrompt(
+                sessionId: try c.decode(String.self, forKey: .sessionId),
+                text: try c.decode(String.self, forKey: .text))
+        case "stop":
+            self = .stop(sessionId: try c.decode(String.self, forKey: .sessionId))
         case let other:
             throw DecodingError.dataCorruptedError(forKey: .type, in: c, debugDescription: "unknown type \(other)")
         }
@@ -53,6 +64,16 @@ extension RemoteClientMessage: Codable {
             try c.encode(s, forKey: .sessionId)
             try c.encode(r, forKey: .requestId)
             try c.encode(a, forKey: .answers)
+        case .takeOver(let s):
+            try c.encode("takeOver", forKey: .type)
+            try c.encode(s, forKey: .sessionId)
+        case .sendPrompt(let s, let t):
+            try c.encode("sendPrompt", forKey: .type)
+            try c.encode(s, forKey: .sessionId)
+            try c.encode(t, forKey: .text)
+        case .stop(let s):
+            try c.encode("stop", forKey: .type)
+            try c.encode(s, forKey: .sessionId)
         }
     }
 }
@@ -60,8 +81,8 @@ extension RemoteClientMessage: Codable {
 /// Server → client. `type` discriminates.
 enum RemoteServerMessage: Equatable, Sendable {
     case sessionList(sessions: [RemoteSessionSummary])
-    case transcriptSnapshot(sessionId: String, streamingState: String, messages: [RemoteWireMessage])
-    case transcriptDelta(sessionId: String, streamingState: String, upserts: [RemoteWireMessage])
+    case transcriptSnapshot(sessionId: String, streamingState: String, canDrive: Bool, messages: [RemoteWireMessage])
+    case transcriptDelta(sessionId: String, streamingState: String, canDrive: Bool, upserts: [RemoteWireMessage])
     case permissionRequest(sessionId: String, payload: RemotePermissionPayload)
     case permissionResolved(sessionId: String, requestId: Int)
     case questionRequest(sessionId: String, payload: RemoteQuestionPayload)
@@ -72,7 +93,7 @@ enum RemoteServerMessage: Equatable, Sendable {
 
 extension RemoteServerMessage: Codable {
     private enum CodingKeys: String, CodingKey {
-        case type, sessions, sessionId, streamingState, messages, upserts, payload, requestId, message
+        case type, sessions, sessionId, streamingState, canDrive, messages, upserts, payload, requestId, message
     }
 
     init(from decoder: Decoder) throws {
@@ -83,11 +104,13 @@ extension RemoteServerMessage: Codable {
             self = .transcriptSnapshot(
                 sessionId: try c.decode(String.self, forKey: .sessionId),
                 streamingState: try c.decode(String.self, forKey: .streamingState),
+                canDrive: try c.decode(Bool.self, forKey: .canDrive),
                 messages: try c.decode([RemoteWireMessage].self, forKey: .messages))
         case "transcriptDelta":
             self = .transcriptDelta(
                 sessionId: try c.decode(String.self, forKey: .sessionId),
                 streamingState: try c.decode(String.self, forKey: .streamingState),
+                canDrive: try c.decode(Bool.self, forKey: .canDrive),
                 upserts: try c.decode([RemoteWireMessage].self, forKey: .upserts))
         case "permissionRequest":
             self = .permissionRequest(
@@ -117,15 +140,17 @@ extension RemoteServerMessage: Codable {
         switch self {
         case .sessionList(let s): try c.encode("sessionList", forKey: .type)
         try c.encode(s, forKey: .sessions)
-        case .transcriptSnapshot(let id, let st, let m):
+        case .transcriptSnapshot(let id, let st, let cd, let m):
             try c.encode("transcriptSnapshot", forKey: .type)
             try c.encode(id, forKey: .sessionId)
             try c.encode(st, forKey: .streamingState)
+            try c.encode(cd, forKey: .canDrive)
             try c.encode(m, forKey: .messages)
-        case .transcriptDelta(let id, let st, let u):
+        case .transcriptDelta(let id, let st, let cd, let u):
             try c.encode("transcriptDelta", forKey: .type)
             try c.encode(id, forKey: .sessionId)
             try c.encode(st, forKey: .streamingState)
+            try c.encode(cd, forKey: .canDrive)
             try c.encode(u, forKey: .upserts)
         case .permissionRequest(let id, let p):
             try c.encode("permissionRequest", forKey: .type)

--- a/Alas/Sources/Remote/Protocol/RemoteProtocol.swift
+++ b/Alas/Sources/Remote/Protocol/RemoteProtocol.swift
@@ -88,6 +88,10 @@ enum RemoteServerMessage: Equatable, Sendable {
     case questionRequest(sessionId: String, payload: RemoteQuestionPayload)
     case questionResolved(sessionId: String, requestId: Int)
     case sessionClosed(sessionId: String)
+    /// The server dropped a `sendPrompt` (caller is no longer the writer, or
+    /// the prompt was empty), so the client should restore the user's text
+    /// instead of silently losing it.
+    case promptRejected(sessionId: String)
     case error(message: String)
 }
 
@@ -129,6 +133,7 @@ extension RemoteServerMessage: Codable {
                 sessionId: try c.decode(String.self, forKey: .sessionId),
                 requestId: try c.decode(Int.self, forKey: .requestId))
         case "sessionClosed": self = .sessionClosed(sessionId: try c.decode(String.self, forKey: .sessionId))
+        case "promptRejected": self = .promptRejected(sessionId: try c.decode(String.self, forKey: .sessionId))
         case "error": self = .error(message: try c.decode(String.self, forKey: .message))
         case let other:
             throw DecodingError.dataCorruptedError(forKey: .type, in: c, debugDescription: "unknown type \(other)")
@@ -169,6 +174,8 @@ extension RemoteServerMessage: Codable {
             try c.encode(id, forKey: .sessionId)
             try c.encode(r, forKey: .requestId)
         case .sessionClosed(let id): try c.encode("sessionClosed", forKey: .type)
+        try c.encode(id, forKey: .sessionId)
+        case .promptRejected(let id): try c.encode("promptRejected", forKey: .type)
         try c.encode(id, forKey: .sessionId)
         case .error(let m): try c.encode("error", forKey: .type)
         try c.encode(m, forKey: .message)

--- a/AlasTests/Remote/ACPManagerAccessorsTests.swift
+++ b/AlasTests/Remote/ACPManagerAccessorsTests.swift
@@ -72,7 +72,9 @@ struct ACPManagerAccessorsTests {
         let mgr = try makeManager()
         let s = mgr.createSession(agentId: "claude")
         #expect(mgr.isWriter(for: s.id) == false)
-        #expect(mgr.sendPrompt(for: s.id, text: "hi") == false)
+        var result: Bool?
+        mgr.sendPrompt(for: s.id, text: "hi") { result = $0 }
+        #expect(result == false)   // refused synchronously
         #expect(s.queue.isEmpty)   // nothing enqueued/persisted as a mirror
     }
 }

--- a/AlasTests/Remote/ACPManagerAccessorsTests.swift
+++ b/AlasTests/Remote/ACPManagerAccessorsTests.swift
@@ -38,8 +38,7 @@ struct ACPManagerAccessorsTests {
     }
 
     @Test func isWriterReflectsOwnedLeases() throws {
-        let url = FileManager.default.temporaryDirectory.appendingPathComponent("acp-writer-\(UUID()).sqlite")
-        let mgr = ACPSessionManager(worktreeId: "wt", worktreePath: "/tmp", store: try ACPSessionStore(path: url.path))
+        let mgr = try makeManager()
         let s = mgr.createSession(agentId: "claude")
         #expect(mgr.isWriter(for: s.id) == false)
         mgr._ownedLeases.insert(s.id)

--- a/AlasTests/Remote/ACPManagerAccessorsTests.swift
+++ b/AlasTests/Remote/ACPManagerAccessorsTests.swift
@@ -64,4 +64,15 @@ struct ACPManagerAccessorsTests {
                              pid: Int64(ProcessInfo.processInfo.processIdentifier), now: now)
         #expect(mgr.isWriter(for: s.id) == false)  // store says another live instance owns it
     }
+
+    @Test func sendPromptRefusedWhenNotWriter() throws {
+        // Re-checks the lease at call time: a manager that isn't the writer must
+        // refuse the remote prompt instead of enqueuing it as a mirror (closing
+        // the TOCTOU window between the gateway's isWriter gate and submit).
+        let mgr = try makeManager()
+        let s = mgr.createSession(agentId: "claude")
+        #expect(mgr.isWriter(for: s.id) == false)
+        #expect(mgr.sendPrompt(for: s.id, text: "hi") == false)
+        #expect(s.queue.isEmpty)   // nothing enqueued/persisted as a mirror
+    }
 }

--- a/AlasTests/Remote/ACPManagerAccessorsTests.swift
+++ b/AlasTests/Remote/ACPManagerAccessorsTests.swift
@@ -44,4 +44,24 @@ struct ACPManagerAccessorsTests {
         mgr._ownedLeases.insert(s.id)
         #expect(mgr.isWriter(for: s.id) == true)
     }
+
+    @Test func isWriterFalseWhenAnotherLiveInstanceOwnsLease() throws {
+        // Regression: after another window seizes the lease, the former owner
+        // keeps the id in `_ownedLeases` until its heartbeat stands down
+        // (~leaseStaleAfter seconds). isWriter must consult the store and report
+        // false in that window so a phone on the old owner can't keep writing
+        // into a session another instance now drives.
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("acp-accessors-\(UUID()).sqlite")
+        let store = try ACPSessionStore(path: url.path)
+        let mgr = ACPSessionManager(worktreeId: "wt", worktreePath: "/tmp", store: store)
+        let s = mgr.createSession(agentId: "claude")
+        mgr._ownedLeases.insert(s.id)
+        #expect(mgr.isWriter(for: s.id) == true)   // we claim it; no conflicting store row
+        // Another LIVE instance seizes the store lease (fresh heartbeat, live pid).
+        let now = Int64(Date().timeIntervalSince1970)
+        try store.seizeLease(sessionId: s.id, instanceId: "other-window",
+                             pid: Int64(ProcessInfo.processInfo.processIdentifier), now: now)
+        #expect(mgr.isWriter(for: s.id) == false)  // store says another live instance owns it
+    }
 }

--- a/AlasTests/Remote/ACPManagerAccessorsTests.swift
+++ b/AlasTests/Remote/ACPManagerAccessorsTests.swift
@@ -36,4 +36,13 @@ struct ACPManagerAccessorsTests {
         let session = mgr.createSession(agentId: "claude")
         #expect(mgr.sessionRows.contains { $0.id == session.id })
     }
+
+    @Test func isWriterReflectsOwnedLeases() throws {
+        let url = FileManager.default.temporaryDirectory.appendingPathComponent("acp-writer-\(UUID()).sqlite")
+        let mgr = ACPSessionManager(worktreeId: "wt", worktreePath: "/tmp", store: try ACPSessionStore(path: url.path))
+        let s = mgr.createSession(agentId: "claude")
+        #expect(mgr.isWriter(for: s.id) == false)
+        mgr._ownedLeases.insert(s.id)
+        #expect(mgr.isWriter(for: s.id) == true)
+    }
 }

--- a/AlasTests/Remote/RemoteProtocolTests.swift
+++ b/AlasTests/Remote/RemoteProtocolTests.swift
@@ -148,8 +148,14 @@ struct RemoteProtocolTests {
     }
 
     @Test func snapshotCarriesCanDrive() throws {
-        let snap = RemoteServerMessage.transcriptSnapshot(sessionId: "s1", streamingState: "idle", canDrive: false, messages: [])
+        let snap = RemoteServerMessage.transcriptSnapshot(sessionId: "s1", streamingState: "idle", canDrive: true, messages: [])
         let data = try JSONEncoder().encode(snap)
         #expect(try JSONDecoder().decode(RemoteServerMessage.self, from: data) == snap)
+    }
+
+    @Test func clientDriveVerbsRoundTrip() throws {
+        #expect(try roundTrip(RemoteClientMessage.takeOver(sessionId: "s1")) == .takeOver(sessionId: "s1"))
+        #expect(try roundTrip(RemoteClientMessage.sendPrompt(sessionId: "s1", text: "hello")) == .sendPrompt(sessionId: "s1", text: "hello"))
+        #expect(try roundTrip(RemoteClientMessage.stop(sessionId: "s1")) == .stop(sessionId: "s1"))
     }
 }

--- a/AlasTests/Remote/RemoteProtocolTests.swift
+++ b/AlasTests/Remote/RemoteProtocolTests.swift
@@ -44,6 +44,7 @@ struct RemoteProtocolTests {
         let snap = RemoteServerMessage.transcriptSnapshot(
             sessionId: "s1",
             streamingState: "streaming",
+            canDrive: false,
             messages: [RemoteWireMessage(stableId: "m0", kind: "agent", text: "hi", json: nil)]
         )
         #expect(try roundTrip(snap) == snap)
@@ -51,7 +52,7 @@ struct RemoteProtocolTests {
 
     @Test func sessionListRoundTrips() throws {
         let list = RemoteServerMessage.sessionList(sessions: [
-            RemoteSessionSummary(id: "s1", title: "Build feature", agentId: "claude", status: "streaming")
+            RemoteSessionSummary(id: "s1", title: "Build feature", agentId: "claude", status: "streaming", canDrive: false)
         ])
         #expect(try roundTrip(list) == list)
     }
@@ -60,6 +61,7 @@ struct RemoteProtocolTests {
         let delta = RemoteServerMessage.transcriptDelta(
             sessionId: "s1",
             streamingState: "idle",
+            canDrive: false,
             upserts: [RemoteWireMessage(stableId: "m1", kind: "toolCall", text: nil, json: #"{"name":"bash"}"#)]
         )
         #expect(try roundTrip(delta) == delta)
@@ -122,5 +124,32 @@ struct RemoteProtocolTests {
             requestId: 4,
             answers: [RemoteQuestionAnswer(questionId: "q1", selectedOptionIds: ["o1"])])
         #expect(try roundTrip(msg) == msg)
+    }
+
+    @Test func clientMessageDecodesSendPrompt() throws {
+        let json = #"{"type":"sendPrompt","sessionId":"s1","text":"hello"}"#.data(using: .utf8)!
+        let msg = try JSONDecoder().decode(RemoteClientMessage.self, from: json)
+        #expect(msg == .sendPrompt(sessionId: "s1", text: "hello"))
+    }
+
+    @Test func clientMessageDecodesTakeOverAndStop() throws {
+        let t = try JSONDecoder().decode(RemoteClientMessage.self, from: #"{"type":"takeOver","sessionId":"s1"}"#.data(using: .utf8)!)
+        #expect(t == .takeOver(sessionId: "s1"))
+        let s = try JSONDecoder().decode(RemoteClientMessage.self, from: #"{"type":"stop","sessionId":"s1"}"#.data(using: .utf8)!)
+        #expect(s == .stop(sessionId: "s1"))
+    }
+
+    @Test func sessionSummaryCarriesCanDrive() throws {
+        let list = RemoteServerMessage.sessionList(sessions: [
+            RemoteSessionSummary(id: "s1", title: "T", agentId: "claude", status: "idle", canDrive: true)
+        ])
+        let data = try JSONEncoder().encode(list)
+        #expect(try JSONDecoder().decode(RemoteServerMessage.self, from: data) == list)
+    }
+
+    @Test func snapshotCarriesCanDrive() throws {
+        let snap = RemoteServerMessage.transcriptSnapshot(sessionId: "s1", streamingState: "idle", canDrive: false, messages: [])
+        let data = try JSONEncoder().encode(snap)
+        #expect(try JSONDecoder().decode(RemoteServerMessage.self, from: data) == snap)
     }
 }

--- a/AlasTests/Remote/RemoteProtocolTests.swift
+++ b/AlasTests/Remote/RemoteProtocolTests.swift
@@ -85,6 +85,11 @@ struct RemoteProtocolTests {
         #expect(try roundTrip(resolved) == resolved)
     }
 
+    @Test func promptRejectedRoundTrips() throws {
+        let rejected = RemoteServerMessage.promptRejected(sessionId: "s1")
+        #expect(try roundTrip(rejected) == rejected)
+    }
+
     @Test func questionRequestRoundTrips() throws {
         let req = RemoteServerMessage.questionRequest(
             sessionId: "s1",

--- a/AlasTests/Remote/RemoteServerIntegrationTests.swift
+++ b/AlasTests/Remote/RemoteServerIntegrationTests.swift
@@ -29,7 +29,7 @@ struct RemoteServerIntegrationTests {
         let s = mgr.createSession(agentId: "claude")
         s.transcript.messages = [.agent(id: UUID(), StreamingText("hello-remote"))]
         provider.sessions[s.id] = s
-        provider.summaries = [RemoteSessionSummary(id: s.id, title: "T", agentId: "claude", status: "idle")]
+        provider.summaries = [RemoteSessionSummary(id: s.id, title: "T", agentId: "claude", status: "idle", canDrive: false)]
 
         let assets = RemoteWebAssets(root: URL(fileURLWithPath: NSTemporaryDirectory()))
         let pairing = RemotePairingService(store: InMemoryDeviceStore())
@@ -66,7 +66,7 @@ struct RemoteServerIntegrationTests {
         @unknown default: payload = nil
         }
         guard let data = payload,
-              case .transcriptSnapshot(_, _, let msgs)? = try? JSONDecoder().decode(RemoteServerMessage.self, from: data) else {
+              case .transcriptSnapshot(_, _, _, let msgs)? = try? JSONDecoder().decode(RemoteServerMessage.self, from: data) else {
             Issue.record("expected snapshot frame, got \(received)")
             task.cancel(with: .goingAway, reason: nil)
             server.stop()
@@ -84,7 +84,7 @@ struct RemoteServerIntegrationTests {
         let s = mgr.createSession(agentId: "claude")
         s.transcript.messages = [.agent(id: UUID(), StreamingText("hello-remote"))]
         provider.sessions[s.id] = s
-        provider.summaries = [RemoteSessionSummary(id: s.id, title: "T", agentId: "claude", status: "idle")]
+        provider.summaries = [RemoteSessionSummary(id: s.id, title: "T", agentId: "claude", status: "idle", canDrive: false)]
 
         let assets = RemoteWebAssets(root: URL(fileURLWithPath: NSTemporaryDirectory()))
         let pairing = RemotePairingService(store: InMemoryDeviceStore())

--- a/AlasTests/Remote/RemoteSessionGatewayTests.swift
+++ b/AlasTests/Remote/RemoteSessionGatewayTests.swift
@@ -8,6 +8,10 @@ final class FakeSessionsProvider: RemoteSessionsProvider {
     var sessions: [String: ACPSession] = [:]
     var policies: [String: ACPPermissionPolicy] = [:]
     var lastQuestionResponse: (id: String, response: ACPQuestionResponse)?
+    var writers: Set<String> = []
+    var tookOver: [String] = []
+    var prompts: [(id: String, text: String)] = []
+    var stopped: [String] = []
     func sessionSummaries() -> [RemoteSessionSummary] { summaries }
     func session(for id: String) -> ACPSession? { sessions[id] }
     func permissionPolicy(for id: String) -> ACPPermissionPolicy? { policies[id] }
@@ -15,6 +19,15 @@ final class FakeSessionsProvider: RemoteSessionsProvider {
     func answerQuestion(for id: String, _ response: ACPQuestionResponse) {
         lastQuestionResponse = (id, response)
     }
+
+    func isWriter(for id: String) -> Bool { writers.contains(id) }
+    func takeOver(for id: String) {
+        tookOver.append(id)
+        writers.insert(id)
+    }
+
+    func sendPrompt(for id: String, text: String) { prompts.append((id, text)) }
+    func stop(for id: String) { stopped.append(id) }
 }
 
 #if DEBUG
@@ -281,5 +294,47 @@ struct RemoteSessionGatewayTests {
         try await Task.sleep(nanoseconds: 250_000_000)
         #expect(!sent.contains { if case .transcriptDelta = $0 { return true }
         return false })
+    }
+
+    @Test func takeOverRoutesToProvider() async {
+        let provider = FakeSessionsProvider()
+        let gw = RemoteSessionGateway(provider: provider) { _ in }
+        await gw.handle(.takeOver(sessionId: "s1"))
+        #expect(provider.tookOver == ["s1"])
+    }
+
+    @Test func sendPromptRoutesOnlyWhenWriter() async {
+        let provider = FakeSessionsProvider()
+        let gw = RemoteSessionGateway(provider: provider) { _ in }
+        await gw.handle(.sendPrompt(sessionId: "s1", text: "hi")) // not writer → ignored
+        #expect(provider.prompts.isEmpty)
+        provider.writers.insert("s1")
+        await gw.handle(.sendPrompt(sessionId: "s1", text: "hi"))
+        #expect(provider.prompts.map(\.text) == ["hi"])
+    }
+
+    @Test func stopRoutesOnlyWhenWriter() async {
+        let provider = FakeSessionsProvider()
+        let gw = RemoteSessionGateway(provider: provider) { _ in }
+        await gw.handle(.stop(sessionId: "s1"))
+        #expect(provider.stopped.isEmpty)
+        provider.writers.insert("s1")
+        await gw.handle(.stop(sessionId: "s1"))
+        #expect(provider.stopped == ["s1"])
+    }
+
+    @Test func snapshotCarriesCanDrive() async throws {
+        let provider = FakeSessionsProvider()
+        let s = try makeSessionWithAgentText("hello")
+        provider.sessions["s1"] = s
+        provider.writers.insert("s1")
+        var sent: [RemoteServerMessage] = []
+        let gw = RemoteSessionGateway(provider: provider) { sent.append($0) }
+        await gw.handle(.subscribe(sessionId: "s1"))
+        let drive = sent.compactMap { msg -> Bool? in
+            if case .transcriptSnapshot(_, _, let canDrive, _) = msg { return canDrive }
+            return nil
+        }.first
+        #expect(drive == true)
     }
 }

--- a/AlasTests/Remote/RemoteSessionGatewayTests.swift
+++ b/AlasTests/Remote/RemoteSessionGatewayTests.swift
@@ -313,6 +313,16 @@ struct RemoteSessionGatewayTests {
         #expect(provider.prompts.map(\.text) == ["hi"])
     }
 
+    @Test func sendPromptTrimsAndIgnoresBlankEvenWhenWriter() async {
+        let provider = FakeSessionsProvider()
+        provider.writers.insert("s1")
+        let gw = RemoteSessionGateway(provider: provider) { _ in }
+        await gw.handle(.sendPrompt(sessionId: "s1", text: "   \n  ")) // blank → ignored
+        #expect(provider.prompts.isEmpty)
+        await gw.handle(.sendPrompt(sessionId: "s1", text: "  hi  ")) // trimmed before forwarding
+        #expect(provider.prompts.map(\.text) == ["hi"])
+    }
+
     @Test func stopRoutesOnlyWhenWriter() async {
         let provider = FakeSessionsProvider()
         let gw = RemoteSessionGateway(provider: provider) { _ in }

--- a/AlasTests/Remote/RemoteSessionGatewayTests.swift
+++ b/AlasTests/Remote/RemoteSessionGatewayTests.swift
@@ -348,6 +348,23 @@ struct RemoteSessionGatewayTests {
         #expect(provider.prompts.map(\.text) == ["hi"])
     }
 
+    @Test func droppedSendPromptEmitsRejection() async {
+        // A non-writer sendPrompt must tell the client it was dropped so the
+        // composer can restore the text instead of silently losing the message.
+        let provider = FakeSessionsProvider()
+        var sent: [RemoteServerMessage] = []
+        let gw = RemoteSessionGateway(provider: provider) { sent.append($0) }
+        await gw.handle(.sendPrompt(sessionId: "s1", text: "hi")) // not writer
+        #expect(provider.prompts.isEmpty)
+        #expect(sent.contains(.promptRejected(sessionId: "s1")))
+        // When we ARE the writer the prompt routes and no rejection is sent.
+        sent.removeAll()
+        provider.writers.insert("s1")
+        await gw.handle(.sendPrompt(sessionId: "s1", text: "hi"))
+        #expect(provider.prompts.map(\.text) == ["hi"])
+        #expect(!sent.contains { if case .promptRejected = $0 { return true } else { return false } })
+    }
+
     @Test func stopRoutesOnlyWhenWriter() async {
         let provider = FakeSessionsProvider()
         let gw = RemoteSessionGateway(provider: provider) { _ in }

--- a/AlasTests/Remote/RemoteSessionGatewayTests.swift
+++ b/AlasTests/Remote/RemoteSessionGatewayTests.swift
@@ -122,6 +122,31 @@ struct RemoteSessionGatewayTests {
         #expect(msgs.contains { $0.kind == "agent" && $0.text == "hello" })
     }
 
+    @Test func takeOverPushesSnapshotWithCanDrive() async throws {
+        // Regression: takeover seizes the writer lease synchronously but mutates
+        // lease/agent state rather than the transcript, so the objectWillChange
+        // delta may never fire on an idle session. The gateway must push a
+        // snapshot itself so the client learns canDrive=true and unlocks the
+        // composer instead of waiting for an unrelated transcript mutation.
+        let provider = FakeSessionsProvider()
+        let s = try makeSessionWithAgentText("hi")
+        provider.sessions["s1"] = s
+        var sent: [RemoteServerMessage] = []
+        let gw = RemoteSessionGateway(provider: provider) { sent.append($0) }
+        await gw.handle(.takeOver(sessionId: "s1"))
+        #expect(provider.tookOver == ["s1"])
+        let snap = sent.last { msg in
+            if case .transcriptSnapshot = msg { return true }
+            return false
+        }
+        guard case .transcriptSnapshot(let id, _, let canDrive, _)? = snap else {
+            Issue.record("expected a snapshot after takeOver, got \(sent)")
+            return
+        }
+        #expect(id == "s1")
+        #expect(canDrive == true)
+    }
+
     @Test func permissionDecisionCallsPolicyWhenRequestMatches() async throws {
         let provider = FakeSessionsProvider()
         let s = try makeSessionWithAgentText("x")

--- a/AlasTests/Remote/RemoteSessionGatewayTests.swift
+++ b/AlasTests/Remote/RemoteSessionGatewayTests.swift
@@ -87,7 +87,7 @@ struct RemoteSessionGatewayTests {
 
     @Test func listSessionsEmitsSummaries() async {
         let provider = FakeSessionsProvider()
-        provider.summaries = [RemoteSessionSummary(id: "s1", title: "T", agentId: "claude", status: "idle")]
+        provider.summaries = [RemoteSessionSummary(id: "s1", title: "T", agentId: "claude", status: "idle", canDrive: false)]
         var sent: [RemoteServerMessage] = []
         let gw = RemoteSessionGateway(provider: provider) { sent.append($0) }
         await gw.handle(.listSessions)
@@ -101,7 +101,7 @@ struct RemoteSessionGatewayTests {
         var sent: [RemoteServerMessage] = []
         let gw = RemoteSessionGateway(provider: provider) { sent.append($0) }
         await gw.handle(.subscribe(sessionId: "s1"))
-        guard case .transcriptSnapshot(let id, _, let msgs)? = sent.first else {
+        guard case .transcriptSnapshot(let id, _, _, let msgs)? = sent.first else {
             Issue.record("expected snapshot, got \(sent)")
             return
         }
@@ -262,7 +262,7 @@ struct RemoteSessionGatewayTests {
         s.transcript.messages.append(.agent(id: UUID(), StreamingText("more")))  // fires objectWillChange
         try await Task.sleep(nanoseconds: 250_000_000)  // > coalesce window
         let delta = sent.compactMap { msg -> [RemoteWireMessage]? in
-            if case .transcriptDelta(_, _, let upserts) = msg { return upserts }
+            if case .transcriptDelta(_, _, _, let upserts) = msg { return upserts }
             return nil
         }.last
         let delta2 = try #require(delta, "expected a transcriptDelta after mutation")

--- a/AlasTests/Remote/RemoteSessionGatewayTests.swift
+++ b/AlasTests/Remote/RemoteSessionGatewayTests.swift
@@ -11,6 +11,7 @@ final class FakeSessionsProvider: RemoteSessionsProvider {
     var writers: Set<String> = []
     var tookOver: [String] = []
     var prompts: [(id: String, text: String)] = []
+    var sendPromptAccepts = true   // simulate the manager refusing a submit (e.g. needs auth)
     var stopped: [String] = []
     func sessionSummaries() -> [RemoteSessionSummary] { summaries }
     func session(for id: String) -> ACPSession? { sessions[id] }
@@ -26,7 +27,10 @@ final class FakeSessionsProvider: RemoteSessionsProvider {
         writers.insert(id)
     }
 
-    func sendPrompt(for id: String, text: String) { prompts.append((id, text)) }
+    func sendPrompt(for id: String, text: String) -> Bool {
+        prompts.append((id, text))
+        return sendPromptAccepts
+    }
     func stop(for id: String) { stopped.append(id) }
 }
 
@@ -357,12 +361,19 @@ struct RemoteSessionGatewayTests {
         await gw.handle(.sendPrompt(sessionId: "s1", text: "hi")) // not writer
         #expect(provider.prompts.isEmpty)
         #expect(sent.contains(.promptRejected(sessionId: "s1")))
-        // When we ARE the writer the prompt routes and no rejection is sent.
+        // When we ARE the writer and the manager accepts, the prompt routes
+        // and no rejection is sent.
         sent.removeAll()
         provider.writers.insert("s1")
         await gw.handle(.sendPrompt(sessionId: "s1", text: "hi"))
         #expect(provider.prompts.map(\.text) == ["hi"])
         #expect(!sent.contains { if case .promptRejected = $0 { return true } else { return false } })
+        // Writer, but the manager refuses the submit (e.g. needs auth) — the
+        // client must still be told so it can restore the text.
+        sent.removeAll()
+        provider.sendPromptAccepts = false
+        await gw.handle(.sendPrompt(sessionId: "s1", text: "later"))
+        #expect(sent.contains(.promptRejected(sessionId: "s1")))
     }
 
     @Test func stopRoutesOnlyWhenWriter() async {

--- a/AlasTests/Remote/RemoteSessionGatewayTests.swift
+++ b/AlasTests/Remote/RemoteSessionGatewayTests.swift
@@ -27,9 +27,10 @@ final class FakeSessionsProvider: RemoteSessionsProvider {
         writers.insert(id)
     }
 
-    func sendPrompt(for id: String, text: String) -> Bool {
-        prompts.append((id, text))
-        return sendPromptAccepts
+    func sendPrompt(for id: String, text: String, onResult: @escaping @MainActor (Bool) -> Void) {
+        let accepted = writers.contains(id) && sendPromptAccepts
+        if accepted { prompts.append((id, text)) }
+        onResult(accepted)
     }
     func stop(for id: String) { stopped.append(id) }
 }


### PR DESCRIPTION
## Summary

Phase 2 of the remote control feature. Phase 1 (#474) let a paired phone **watch** ACP sessions live and answer permission/question prompts. This makes the remote **interactive**: from the phone you can take over a session, send new prompts, and stop the in-flight turn — driving *through* the in-process `ACPSessionManager` (reusing the #461 single-writer lease/takeover model), never as a separate instance.

Scope is intentionally limited to **take over + send prompt + stop**. Model/mode/auto-run pickers, attachments, and auto-takeover-on-send are deferred to a later phase.

### What's here

- **Wire protocol**: new client verbs `takeOver(sessionId:)`, `sendPrompt(sessionId:,text:)`, `stop(sessionId:)`; `canDrive` added to the session summary and transcript snapshot/delta so the client knows when it holds the writer lease.
- **Manager accessors**: `isWriter(for:)`, `sendPrompt(for:text:)` (routes through the same `submit(intent:.auto)` path the local composer uses), and `interrupt(for:)`.
- **Gateway + provider + AppState**: route the new verbs to the manager that owns the session; gate `sendPrompt`/`stop` behind `isWriter`; trim and ignore blank prompts.
- **Web client**: a drive bar that shows a *Take over* button until you hold the lease, then a composer (auto-growing textarea, send/stop). Plus a mobile-chrome pass — composer pinned to a full-height `dvh` flex shell, connection status folded into the app bar as a chip, and iOS keyboard/viewport handling (`visualViewport` + 16px no-zoom).

## Test plan

- `AlasTests/Remote/*` — 77 Remote tests pass (protocol round-trips, gateway routing + `isWriter` gating, blank-prompt rejection, `canDrive` snapshot regression guard, manager accessors).
- Manual E2E on device: paired phone takes over a live session, sends a prompt that reaches the agent and streams a response back, and Stop interrupts a turn. Verified the writer-takeover stands down the previous owner.
- `swiftformat Alas AlasTests --lint` clean.