### PR TITLE
Add polish conventional commit verb

### DIFF
--- a/Alas/Sources/Git/CommitInfo.swift
+++ b/Alas/Sources/Git/CommitInfo.swift
@@ -17,7 +17,7 @@ struct CommitInfo: Identifiable, Hashable {
 extension CommitInfo {
     static let recognisedTypes: Set<String> = [
         "feat", "fix", "chore", "refactor", "perf", "docs", "test", "ci", "build",
-        "style", "revert", "tune", "harden",
+        "style", "revert", "tune", "harden", "polish",
     ]
 
     /// Splits a commit subject of the form

--- a/AlasTests/CommitInfoTests.swift
+++ b/AlasTests/CommitInfoTests.swift
@@ -43,7 +43,7 @@ struct CommitInfoTests {
     @Test func recognisesAllExpectedTypes() {
         for type in [
             "feat", "fix", "chore", "refactor", "perf", "docs", "test", "ci", "build",
-            "style", "revert", "tune", "harden",
+            "style", "revert", "tune", "harden", "polish",
         ] {
             let (tag, _) = CommitInfo.parseConventional(subject: "\(type): something")
             #expect(tag == type, "expected \(type) to be recognised")
@@ -78,6 +78,12 @@ struct CommitInfoTests {
         let (tag, stripped) = CommitInfo.parseConventional(subject: "tune(sidebar): tweak row spacing")
         #expect(tag == "tune")
         #expect(stripped == "tweak row spacing")
+    }
+
+    @Test func extractsPolishPrefix() {
+        let (tag, stripped) = CommitInfo.parseConventional(subject: "polish: refine commit chips")
+        #expect(tag == "polish")
+        #expect(stripped == "refine commit chips")
     }
 
     @Test func initialsEmpty() {


### PR DESCRIPTION
## Summary
- add polish to recognized conventional commit verbs
- cover polish prefix parsing in CommitInfo tests

## Validation
- xcodegen
- xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -quiet build
- xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -only-testing:AlasTests/CommitInfoTests test