### PR TITLE
feat(acp): let the @ mention picker pick directories

### DIFF
--- a/Alas/Sources/ACP/UI/ACPMentionPicker.swift
+++ b/Alas/Sources/ACP/UI/ACPMentionPicker.swift
@@ -246,6 +246,19 @@ enum MentionFuzzy {
         return ordered.map { root.appendingPathComponent($0, isDirectory: true) }
     }
 
+    /// Directory URLs to add to the picker for a `git ls-files`-style listing.
+    /// The caller resolves each entry's on-disk directory-ness: untracked
+    /// directories arrive collapsed with git's trailing slash, but submodule
+    /// gitlinks arrive like a file path (no slash). Normalizing directory
+    /// entries to a trailing slash lets `ancestorDirectories` emit the entry
+    /// itself — not just its parent — so submodule folders stay pickable.
+    static func pickerDirectories(forEntries entries: [(path: String, isDirectory: Bool)], root: URL) -> [URL] {
+        let normalized = entries.map { entry -> String in
+            entry.isDirectory && !entry.path.hasSuffix("/") ? entry.path + "/" : entry.path
+        }
+        return ancestorDirectories(forRelativePaths: normalized, root: root)
+    }
+
     static func rank(files: [URL], query: String, limit: Int, relativeTo root: URL) -> [URL] {
         let tokens = query
             .split(whereSeparator: \.isWhitespace)

--- a/Alas/Sources/ACP/UI/ACPMentionPicker.swift
+++ b/Alas/Sources/ACP/UI/ACPMentionPicker.swift
@@ -45,7 +45,7 @@ struct ACPMentionPickerView: View {
             Image(systemName: "at")
                 .font(.system(size: 11, weight: .semibold))
                 .foregroundStyle(theme.color("accent"))
-            TextField("Search files in worktree…", text: $query)
+            TextField("Search files & folders…", text: $query)
                 .textFieldStyle(.plain)
                 .font(.system(size: 12, design: .monospaced))
                 .focused($searchFocused)
@@ -98,7 +98,7 @@ struct ACPMentionPickerView: View {
 
         Button { onPick(file) } label: {
             HStack(spacing: 8) {
-                Image(systemName: "doc.text")
+                Image(systemName: file.hasDirectoryPath ? "folder" : "doc.text")
                     .font(.system(size: 10))
                     .foregroundStyle(isOn ? theme.color("accent") : theme.color("fg-faint"))
                     .frame(width: 14)
@@ -214,12 +214,36 @@ enum MentionFuzzy {
                 it.skipDescendants()
                 continue
             }
-            let isDir = (try? url.resourceValues(forKeys: [.isDirectoryKey]).isDirectory) ?? false
-            if isDir { continue }
+            // Directories are pickable too — the enumerator yields them with
+            // `hasDirectoryPath` set, which the picker uses to show a folder
+            // icon and to emit a directory resource link. We still recurse into
+            // them (no `skipDescendants`) so their files remain available.
             out.append(url)
         }
         out.sort { $0.lastPathComponent.lowercased() < $1.lastPathComponent.lowercased() }
         return out
+    }
+
+    /// Derive every directory implied by a set of worktree-relative paths, as
+    /// directory-flagged URLs under `root`. `git ls-files` only emits files
+    /// (collapsing untracked directories to a trailing-slash entry), so tracked
+    /// directories never appear on their own — we reconstruct the full set from
+    /// each path's ancestors. A trailing slash marks the whole path as a
+    /// directory; otherwise the last component is a file and is dropped.
+    static func ancestorDirectories(forRelativePaths paths: [String], root: URL) -> [URL] {
+        var seen = Set<String>()
+        var ordered: [String] = []
+        for path in paths {
+            let isDirEntry = path.hasSuffix("/")
+            let comps = path.split(separator: "/").map(String.init)
+            let dirCount = isDirEntry ? comps.count : comps.count - 1
+            guard dirCount > 0 else { continue }
+            for end in 1...dirCount {
+                let dir = comps[0..<end].joined(separator: "/")
+                if seen.insert(dir).inserted { ordered.append(dir) }
+            }
+        }
+        return ordered.map { root.appendingPathComponent($0, isDirectory: true) }
     }
 
     static func rank(files: [URL], query: String, limit: Int, relativeTo root: URL) -> [URL] {

--- a/Alas/Sources/ACP/UI/ACPTabView.swift
+++ b/Alas/Sources/ACP/UI/ACPTabView.swift
@@ -310,12 +310,21 @@ private struct ACPSessionView: View {
                                 let url = root.appendingPathComponent(entry.relativePath)
                                 guard (try? url.checkResourceIsReachable()) ?? false else { continue }
                                 if let isDir = try? url.resourceValues(forKeys: [.isDirectoryKey]).isDirectory, isDir {
+                                    // Untracked directory collapsed by `git ls-files`;
+                                    // expand it so its files and subdirectories show.
                                     let sub = MentionFuzzy.collectFiles(under: url, limit: 5000)
                                     result.append(contentsOf: sub)
                                 } else {
                                     result.append(url)
                                 }
                             }
+                            // `git ls-files` lists files only — reconstruct every
+                            // directory (tracked included) so directories are
+                            // pickable in the @ menu, flagged for the folder icon.
+                            result += MentionFuzzy.ancestorDirectories(
+                                forRelativePaths: entries.map(\.relativePath),
+                                root: root
+                            )
                             return result
                         }
                     ) { text, attachments, intent, draft, onPromptFinished -> Bool in

--- a/Alas/Sources/ACP/UI/ACPTabView.swift
+++ b/Alas/Sources/ACP/UI/ACPTabView.swift
@@ -306,25 +306,26 @@ private struct ACPSessionView: View {
                             guard let entries = await entries else { return [] }
                             let root = worktree.path
                             var result: [URL] = []
+                            var dirEntries: [(path: String, isDirectory: Bool)] = []
                             for entry in entries {
                                 let url = root.appendingPathComponent(entry.relativePath)
                                 guard (try? url.checkResourceIsReachable()) ?? false else { continue }
-                                if let isDir = try? url.resourceValues(forKeys: [.isDirectoryKey]).isDirectory, isDir {
-                                    // Untracked directory collapsed by `git ls-files`;
-                                    // expand it so its files and subdirectories show.
+                                let isDir = (try? url.resourceValues(forKeys: [.isDirectoryKey]).isDirectory) ?? false
+                                if isDir {
+                                    // Untracked directory or submodule gitlink; expand
+                                    // it so its files and subdirectories show too.
                                     let sub = MentionFuzzy.collectFiles(under: url, limit: 5000)
                                     result.append(contentsOf: sub)
                                 } else {
                                     result.append(url)
                                 }
+                                dirEntries.append((entry.relativePath, isDir))
                             }
                             // `git ls-files` lists files only — reconstruct every
-                            // directory (tracked included) so directories are
-                            // pickable in the @ menu, flagged for the folder icon.
-                            result += MentionFuzzy.ancestorDirectories(
-                                forRelativePaths: entries.map(\.relativePath),
-                                root: root
-                            )
+                            // directory (tracked dirs and submodules included) so
+                            // they are pickable in the @ menu, flagged for the
+                            // folder icon.
+                            result += MentionFuzzy.pickerDirectories(forEntries: dirEntries, root: root)
                             return result
                         }
                     ) { text, attachments, intent, draft, onPromptFinished -> Bool in

--- a/AlasTests/ACP/UI/ACPMentionPickerTests.swift
+++ b/AlasTests/ACP/UI/ACPMentionPickerTests.swift
@@ -33,4 +33,80 @@ struct ACPMentionPickerTests {
 
         #expect(matches.first == root.appendingPathComponent("Sources/App.swift"))
     }
+
+    @Test("collectFiles includes directories alongside files, flagged as directories")
+    func collectFilesIncludesDirectories() throws {
+        let root = try makeTempTree([
+            "Sources/App.swift",
+            "Sources/Model.swift",
+            "docs/guide.md",
+            ".git/config",
+            "node_modules/pkg/index.js",
+            ".hidden/secret.txt",
+        ])
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let collected = MentionFuzzy.collectFiles(under: root, limit: 5000)
+        // Canonicalize both sides through resolvingSymlinksInPath so the
+        // enumerator's /private-prefixed output and `root` agree before
+        // stripping the prefix.
+        let rootPath = root.resolvingSymlinksInPath().path
+        let relatives = Set(collected.map {
+            $0.resolvingSymlinksInPath().path.replacingOccurrences(of: rootPath + "/", with: "")
+        })
+
+        // Directories are now pickable entries.
+        #expect(relatives.contains("Sources"))
+        #expect(relatives.contains("docs"))
+        // Their files are still present.
+        #expect(relatives.contains("Sources/App.swift"))
+        #expect(relatives.contains("docs/guide.md"))
+        // Skipped/hidden trees stay excluded — directory and contents alike.
+        #expect(!relatives.contains(".git"))
+        #expect(!relatives.contains("node_modules"))
+        #expect(!relatives.contains(".hidden"))
+
+        // Directory URLs carry the directory designation so the picker can
+        // render a folder icon and emit a directory resource link.
+        let sourcesDir = try #require(collected.first { $0.lastPathComponent == "Sources" })
+        #expect(sourcesDir.hasDirectoryPath)
+        let appFile = try #require(collected.first { $0.lastPathComponent == "App.swift" })
+        #expect(!appFile.hasDirectoryPath)
+    }
+
+    @Test("ancestorDirectories derives every implied directory from file paths")
+    func ancestorDirectoriesFromFilePaths() {
+        let root = URL(fileURLWithPath: "/tmp/project")
+        let paths = [
+            "README.md",                       // root file → no directories
+            "Sources/App.swift",               // → Sources
+            "Sources/ACP/UI/Composer.swift",   // → Sources, Sources/ACP, Sources/ACP/UI
+            "build/",                          // untracked dir entry → build
+            "docs/api/v1/",                    // nested untracked dir → docs, docs/api, docs/api/v1
+        ]
+
+        let dirs = MentionFuzzy.ancestorDirectories(forRelativePaths: paths, root: root)
+        let rels = Set(dirs.map { $0.path.replacingOccurrences(of: root.path + "/", with: "") })
+
+        #expect(rels == [
+            "Sources", "Sources/ACP", "Sources/ACP/UI",
+            "build", "docs", "docs/api", "docs/api/v1",
+        ])
+        // Every returned URL is flagged as a directory for folder-icon rendering.
+        #expect(dirs.allSatisfy { $0.hasDirectoryPath })
+    }
+
+    private func makeTempTree(_ relativeFiles: [String]) throws -> URL {
+        let fm = FileManager.default
+        let root = fm.temporaryDirectory
+            .appendingPathComponent("mention-picker-\(UUID().uuidString)", isDirectory: true)
+        for rel in relativeFiles {
+            let fileURL = root.appendingPathComponent(rel)
+            try fm.createDirectory(at: fileURL.deletingLastPathComponent(), withIntermediateDirectories: true)
+            try Data().write(to: fileURL)
+        }
+        // Resolve symlinks (/var → /private on macOS) so the enumerator's
+        // standardized output shares this prefix for relative-path stripping.
+        return root.resolvingSymlinksInPath()
+    }
 }

--- a/AlasTests/ACP/UI/ACPMentionPickerTests.swift
+++ b/AlasTests/ACP/UI/ACPMentionPickerTests.swift
@@ -96,6 +96,27 @@ struct ACPMentionPickerTests {
         #expect(dirs.allSatisfy { $0.hasDirectoryPath })
     }
 
+    @Test("pickerDirectories surfaces submodule folders despite missing trailing slash")
+    func pickerDirectoriesIncludesSubmodules() {
+        let root = URL(fileURLWithPath: "/tmp/project")
+        // `git ls-files` gives untracked collapsed dirs a trailing slash but
+        // emits submodule gitlinks like a file path (no slash) — the caller
+        // resolves directory-ness from disk and passes it through.
+        let entries: [(path: String, isDirectory: Bool)] = [
+            ("README.md", false),
+            ("Sources/App.swift", false),
+            ("ThirdParty/ghostty", true),   // nested submodule gitlink, no slash
+            ("build/", true),               // untracked dir collapsed by git
+            ("sub", true),                  // root-level submodule gitlink
+        ]
+
+        let dirs = MentionFuzzy.pickerDirectories(forEntries: entries, root: root)
+        let rels = Set(dirs.map { $0.path.replacingOccurrences(of: root.path + "/", with: "") })
+
+        #expect(rels == ["Sources", "ThirdParty", "ThirdParty/ghostty", "build", "sub"])
+        #expect(dirs.allSatisfy { $0.hasDirectoryPath })
+    }
+
     private func makeTempTree(_ relativeFiles: [String]) throws -> URL {
         let fm = FileManager.default
         let root = fm.temporaryDirectory


### PR DESCRIPTION
## What

The ACP composer's `@` mention dialog only surfaced files. You can now pick **directories** too.

- `collectFiles` no longer skips directories — the `FileManager` enumerator already yields them flagged (`hasDirectoryPath`), and we keep recursing so their files stay available.
- The picker row shows a **folder** icon for directories (document icon for files).
- A picked directory is inserted as a chip and sent to the agent as a directory `resource_link`. The send path already handled this gracefully — `embeddedTextResource` only inlines regular files, so directories pass through untouched.

## The subtlety

The two file sources behave differently:

- The `FileManager` fallback (`collectFiles`) naturally surfaces directories.
- The real-app `filesProvider` is backed by `git ls-files`, which lists **files only** — it collapses *untracked* directories into a `dir/` entry and never emits *tracked* directories. So `Sources/` and friends would never appear.

Fixed with a new pure helper, `MentionFuzzy.ancestorDirectories(forRelativePaths:root:)`, that reconstructs the full directory set from each path's ancestors, layered on top of the existing file list.

## Tests

TDD, each test watched failing first:

- `collectFiles` includes directories (flagged) and still excludes `.git` / `node_modules` / hidden trees.
- `ancestorDirectories` derives every implied directory (tracked + untracked, all levels) and flags each as a directory.

`xcodebuild … build` succeeds; full `… test` → 3316 tests pass.
