### PR TITLE
feat(remote): phone composer parity — model/mode/auto-run, image attachments, auto-takeover

### DIFF
--- a/Alas/Resources/RemoteWeb/app.js
+++ b/Alas/Resources/RemoteWeb/app.js
@@ -6,6 +6,7 @@ let reconnectDelay = 1500;
 const maxReconnectDelay = 30000;
 let dismissedQuestion = null;   // {sessionId, requestId} the user closed; suppress re-shows of that exact prompt (ids aren't unique across sessions)
 let lastSentText = null;        // text of the most recent sendPrompt, kept so a server promptRejected can restore it instead of losing the message
+let lastSentAttachments = [];   // images of the most recent sendPrompt, restored alongside the text on promptRejected
 let sessionConfig = null;       // {models,modes,currentModel,currentMode,autoRunEnabled,acceptsImages} for the open session, or null
 let pendingAttachments = [];    // [{name, mimeType, dataBase64}] staged for the next sendPrompt
 const ATTACH_CAP = 10 * 1000 * 1000;   // 10 MB running total — matches the server's maxAttachmentsBytes
@@ -375,20 +376,27 @@ function sendPrompt() {
   ensureWriter();                                    // grab the wheel first; ordered before the prompt
   send({ type: "sendPrompt", sessionId: currentSession, text, attachments: pendingAttachments });
   lastSentText = text;                               // keep until the server accepts (or rejects) it
+  lastSentAttachments = pendingAttachments;          // ditto for the staged images
   ta.value = "";
   clearAttachments();
   autoGrowPrompt();                                  // collapse back to one row
 }
 
-// The server dropped our prompt (lease went stale, etc.). Put the text back so
-// the message isn't silently lost — but only if the user hasn't typed a new one.
+// The server dropped our prompt (lease went stale, materialize failed, etc.).
+// Put the text AND staged images back so the message isn't silently lost — but
+// only if the user hasn't started composing a new one.
 function restoreRejectedPrompt() {
   const ta = $("prompt");
   if (lastSentText && !ta.value) {
     ta.value = lastSentText;
     autoGrowPrompt();
   }
+  if (lastSentAttachments.length && pendingAttachments.length === 0) {
+    pendingAttachments = lastSentAttachments.slice();
+    renderChips();
+  }
   lastSentText = null;
+  lastSentAttachments = [];
 }
 
 // --- Session config sheet (⚙) + attachments (📎) ---

--- a/Alas/Resources/RemoteWeb/app.js
+++ b/Alas/Resources/RemoteWeb/app.js
@@ -387,13 +387,13 @@ function sendPrompt() {
 // only if the user hasn't started composing a new one.
 function restoreRejectedPrompt() {
   const ta = $("prompt");
-  if (lastSentText && !ta.value) {
-    ta.value = lastSentText;
-    autoGrowPrompt();
-  }
-  if (lastSentAttachments.length && pendingAttachments.length === 0) {
-    pendingAttachments = lastSentAttachments.slice();
-    renderChips();
+  // Only restore if the user hasn't started a new message — no new text AND no
+  // newly-staged images — otherwise we'd splice the failed prompt's content
+  // into their new draft.
+  const composingNew = !!ta.value || pendingAttachments.length > 0;
+  if (!composingNew) {
+    if (lastSentText) { ta.value = lastSentText; autoGrowPrompt(); }
+    if (lastSentAttachments.length) { pendingAttachments = lastSentAttachments.slice(); renderChips(); }
   }
   lastSentText = null;
   lastSentAttachments = [];

--- a/Alas/Resources/RemoteWeb/app.js
+++ b/Alas/Resources/RemoteWeb/app.js
@@ -6,6 +6,9 @@ let reconnectDelay = 1500;
 const maxReconnectDelay = 30000;
 let dismissedQuestion = null;   // {sessionId, requestId} the user closed; suppress re-shows of that exact prompt (ids aren't unique across sessions)
 let lastSentText = null;        // text of the most recent sendPrompt, kept so a server promptRejected can restore it instead of losing the message
+let sessionConfig = null;       // {models,modes,currentModel,currentMode,autoRunEnabled,acceptsImages} for the open session, or null
+let pendingAttachments = [];    // [{name, mimeType, dataBase64}] staged for the next sendPrompt
+const ATTACH_CAP = 10 * 1000 * 1000;   // 10 MB running total — matches the server's maxAttachmentsBytes
 
 // state ∈ {connecting, ok, bad} drives the chip's dot/border color via [data-state].
 function setStatus(s, state) { const e = $("status"); e.textContent = s; e.dataset.state = state || "connecting"; }
@@ -85,6 +88,7 @@ function handle(msg) {
     case "permissionResolved": if (msg.sessionId === currentSession) hidePermission(); break;
     case "questionRequest": if (msg.sessionId === currentSession) showQuestion(msg.sessionId, msg.payload); break;
     case "questionResolved": if (msg.sessionId === currentSession) { dismissedQuestion = null; hideQuestion(); } break;
+    case "sessionConfig": if (msg.sessionId === currentSession) { sessionConfig = msg; renderConfigAffordances(); } break;
     case "sessionClosed": if (msg.sessionId === currentSession) showSessions(); break;
     case "promptRejected": if (msg.sessionId === currentSession) restoreRejectedPrompt(); break;
     case "error": setStatus("Error", "bad"); $("status").title = msg.message ?? ""; break;
@@ -113,13 +117,15 @@ function renderSessions(sessions) {
 
 function openSession(id) {
   currentSession = id; messages = new Map(); dismissedQuestion = null; canDrive = false; canDriveKnown = false;
+  sessionConfig = null; clearAttachments();
   $("back").classList.remove("hidden"); $("nav-title").classList.add("hidden");   // bar shows ‹ Sessions
   $("sessions").classList.add("hidden"); $("transcript").classList.remove("hidden");
-  $("messages").innerHTML = ""; renderDriveBar("idle"); send({ type: "subscribe", sessionId: id });
+  $("messages").innerHTML = ""; renderConfigAffordances(); renderDriveBar("idle"); send({ type: "subscribe", sessionId: id });
 }
 function showSessions() {
   if (currentSession) send({ type: "unsubscribe", sessionId: currentSession });
   currentSession = null; canDrive = false; canDriveKnown = false;
+  sessionConfig = null; clearAttachments(); hideConfig(); renderConfigAffordances();
   hidePermission(); hideQuestion();          // never leave a sheet over the list
   $("back").classList.add("hidden"); $("nav-title").classList.remove("hidden");   // bar shows app title
   $("drivebar").classList.add("hidden");
@@ -335,18 +341,25 @@ function renderDriveBar(streamingState) {
   const known = !!currentSession && canDriveKnown;
   $("drivebar").classList.toggle("hidden", !known);
   if (!known) return;
+  // The composer is always available — typing/acting as a non-writer
+  // auto-takes the wheel (ensureWriter). The take-over PILL only appears when
+  // we don't hold the lease, as a no-typing way to grab it.
+  $("composer").classList.remove("hidden");
   $("takeover").classList.toggle("hidden", canDrive);
-  $("composer").classList.toggle("hidden", !canDrive);
-  if (canDrive) {
-    // A turn is interruptible in every non-idle state — including while it's
-    // blocked on a permission/question prompt — mirroring the native composer
-    // (composerAction returns .stop for sending/streaming/awaiting*). Without
-    // the awaiting states, dismissing a prompt sheet would strand the user on
-    // Send with no way to cancel the running turn.
-    const busy = streamingState !== "idle";
-    $("send").classList.toggle("hidden", busy);
-    $("stop").classList.toggle("hidden", !busy);
-  }
+  // A turn is interruptible in every non-idle state — including while it's
+  // blocked on a permission/question prompt — mirroring the native composer
+  // (composerAction returns .stop for sending/streaming/awaiting*). Without
+  // the awaiting states, dismissing a prompt sheet would strand the user on
+  // Send with no way to cancel the running turn.
+  const busy = streamingState !== "idle";
+  $("send").classList.toggle("hidden", busy);
+  $("stop").classList.toggle("hidden", !busy);
+}
+
+// takeOver seizes the lease synchronously server-side and messages are ordered,
+// so a follow-up action sent right after lands as the writer.
+function ensureWriter() {
+  if (!canDrive && currentSession) send({ type: "takeOver", sessionId: currentSession });
 }
 
 function autoGrowPrompt() {
@@ -357,10 +370,13 @@ function autoGrowPrompt() {
 function sendPrompt() {
   const ta = $("prompt");
   const text = ta.value.trim();
-  if (!text || !currentSession || !canDrive) return;
-  send({ type: "sendPrompt", sessionId: currentSession, text });
+  if (!currentSession) return;
+  if (!text && pendingAttachments.length === 0) return;   // nothing to send
+  ensureWriter();                                    // grab the wheel first; ordered before the prompt
+  send({ type: "sendPrompt", sessionId: currentSession, text, attachments: pendingAttachments });
   lastSentText = text;                               // keep until the server accepts (or rejects) it
   ta.value = "";
+  clearAttachments();
   autoGrowPrompt();                                  // collapse back to one row
 }
 
@@ -375,9 +391,102 @@ function restoreRejectedPrompt() {
   lastSentText = null;
 }
 
+// --- Session config sheet (⚙) + attachments (📎) ---
+// Show/hide the 📎 button and rebuild the config sheet from the latest
+// sessionConfig. Called on every sessionConfig and when entering/leaving a
+// session so affordances reflect the open session (or nothing).
+function renderConfigAffordances() {
+  const cfg = sessionConfig;
+  $("attach").classList.toggle("hidden", !(cfg && cfg.acceptsImages));
+  renderConfigSheet();
+}
+
+function renderConfigSheet() {
+  const cfg = sessionConfig;
+  const models = (cfg && cfg.models) || [];
+  const modes = (cfg && cfg.modes) || [];
+  $("cfg-model-section").classList.toggle("hidden", models.length === 0);
+  $("cfg-mode-section").classList.toggle("hidden", modes.length === 0);
+
+  const fill = (box, items, current, act) => {
+    box.innerHTML = "";
+    items.forEach(it => {
+      const btn = el("button", "option-btn", it.name);
+      if (it.id === current) btn.classList.add("is-selected");
+      btn.onclick = () => { ensureWriter(); act(it.id); };
+      box.appendChild(btn);
+    });
+  };
+  fill($("cfg-models"), models, cfg && cfg.currentModel, id => send({ type: "setModel", sessionId: currentSession, modelId: id }));
+  fill($("cfg-modes"), modes, cfg && cfg.currentMode, id => send({ type: "setMode", sessionId: currentSession, modeId: id }));
+  $("cfg-autorun").checked = !!(cfg && cfg.autoRunEnabled);
+}
+
+function showConfig() { renderConfigSheet(); $("cfg").classList.remove("hidden"); }
+function hideConfig() { $("cfg").classList.add("hidden"); }
+
+// --- Attachments ---
+function b64Bytes(b64) { return Math.floor(b64.length * 3 / 4); }   // decoded size estimate, good enough for the cap
+function attachedBytes() { return pendingAttachments.reduce((n, a) => n + b64Bytes(a.dataBase64), 0); }
+
+function clearAttachments() { pendingAttachments = []; renderChips(); }
+
+function renderChips() {
+  const box = $("chips");
+  box.innerHTML = "";
+  pendingAttachments.forEach((a, i) => {
+    const chip = el("div", "chip");
+    const img = el("img");
+    img.src = "data:" + a.mimeType + ";base64," + a.dataBase64;
+    img.alt = a.name;
+    const x = el("button", "chip-x", "✕");
+    x.setAttribute("aria-label", "Remove attachment");
+    x.onclick = () => { pendingAttachments.splice(i, 1); renderChips(); };
+    chip.append(img, x);
+    box.appendChild(chip);
+  });
+  box.classList.toggle("hidden", pendingAttachments.length === 0);
+}
+
+function readAttachment(file) {
+  return new Promise((resolve, reject) => {
+    const r = new FileReader();
+    r.onload = () => {
+      const s = String(r.result);
+      const comma = s.indexOf(",");                  // strip the "data:<mime>;base64," prefix
+      resolve(comma >= 0 ? s.slice(comma + 1) : s);
+    };
+    r.onerror = () => reject(r.error);
+    r.readAsDataURL(file);
+  });
+}
+
+async function onFilesPicked(files) {
+  for (const file of files) {
+    const b64 = await readAttachment(file);
+    if (attachedBytes() + b64Bytes(b64) > ATTACH_CAP) {
+      alert("Attachments can total at most 10 MB.");
+      break;
+    }
+    pendingAttachments.push({ name: file.name, mimeType: file.type, dataBase64: b64 });
+    renderChips();
+  }
+}
+
+$("config").onclick = showConfig;
+$("cfg-close").onclick = hideConfig;
+$("cfg").onclick = (e) => { if (e.target.id === "cfg") hideConfig(); };
+$("cfg-autorun").onchange = (e) => { ensureWriter(); send({ type: "setAutoRun", sessionId: currentSession, enabled: e.target.checked }); };
+$("attach").onclick = () => $("file").click();
+$("file").onchange = async (e) => {
+  const files = Array.from(e.target.files || []);
+  $("file").value = "";                              // reset so the same file can be re-picked
+  await onFilesPicked(files);
+};
+
 $("takeover").onclick = () => { if (currentSession) send({ type: "takeOver", sessionId: currentSession }); };
 $("send").onclick = sendPrompt;
-$("stop").onclick = () => { if (currentSession) send({ type: "stop", sessionId: currentSession }); };
+$("stop").onclick = () => { if (!currentSession) return; ensureWriter(); send({ type: "stop", sessionId: currentSession }); };
 $("prompt").addEventListener("input", autoGrowPrompt);
 $("prompt").addEventListener("keydown", (e) => {
   if (e.key === "Enter" && !e.shiftKey) { e.preventDefault(); sendPrompt(); }

--- a/Alas/Resources/RemoteWeb/index.html
+++ b/Alas/Resources/RemoteWeb/index.html
@@ -4,7 +4,7 @@
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
   <title>Alas Remote</title>
-  <link rel="stylesheet" href="/style.css?v=24" />
+  <link rel="stylesheet" href="/style.css?v=25" />
 </head>
 <body>
   <header id="bar">
@@ -80,8 +80,8 @@
       <button id="gate-retry" class="hidden">Try again</button>
     </div>
   </div>
-  <script src="/marked.min.js?v=24"></script>
-  <script src="/purify.min.js?v=24"></script>
-  <script src="/app.js?v=24"></script>
+  <script src="/marked.min.js?v=25"></script>
+  <script src="/purify.min.js?v=25"></script>
+  <script src="/app.js?v=25"></script>
 </body>
 </html>

--- a/Alas/Resources/RemoteWeb/index.html
+++ b/Alas/Resources/RemoteWeb/index.html
@@ -4,7 +4,7 @@
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
   <title>Alas Remote</title>
-  <link rel="stylesheet" href="/style.css?v=22" />
+  <link rel="stylesheet" href="/style.css?v=23" />
 </head>
 <body>
   <header id="bar">
@@ -17,15 +17,25 @@
     <section id="transcript" class="view hidden">
       <div id="messages"></div>
       <div id="drivebar">
-        <button id="takeover" class="hidden">Take over to drive</button>
+        <button id="takeover" class="hidden">Take over</button>
         <div id="composer" class="hidden">
-          <textarea id="prompt" rows="1" placeholder="Message…"></textarea>
-          <button id="send" aria-label="Send">
-            <svg viewBox="0 0 24 24" width="19" height="19" aria-hidden="true"><path d="M12 19V5M6 11l6-6 6 6" fill="none" stroke="currentColor" stroke-width="2.4" stroke-linecap="round" stroke-linejoin="round"/></svg>
-          </button>
-          <button id="stop" class="hidden" aria-label="Stop">
-            <svg viewBox="0 0 24 24" width="16" height="16" aria-hidden="true"><rect x="6" y="6" width="12" height="12" rx="2.6" fill="currentColor"/></svg>
-          </button>
+          <div id="chips" class="hidden"></div>
+          <div id="composer-row">
+            <button id="attach" class="hidden" aria-label="Attach image">
+              <svg viewBox="0 0 24 24" width="19" height="19" aria-hidden="true"><path d="M21 11.5l-8.5 8.5a5 5 0 0 1-7-7l8.5-8.5a3.3 3.3 0 0 1 4.7 4.7l-8.5 8.5a1.6 1.6 0 0 1-2.3-2.3l7.8-7.8" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
+            </button>
+            <textarea id="prompt" rows="1" placeholder="Message…"></textarea>
+            <button id="config" aria-label="Configure session">
+              <svg viewBox="0 0 24 24" width="19" height="19" aria-hidden="true"><path d="M12 15.5a3.5 3.5 0 1 0 0-7 3.5 3.5 0 0 0 0 7z" fill="none" stroke="currentColor" stroke-width="2"/><path d="M19.4 13a7.7 7.7 0 0 0 0-2l2-1.6-2-3.4-2.4 1a7.7 7.7 0 0 0-1.7-1l-.4-2.5h-3.8l-.4 2.5a7.7 7.7 0 0 0-1.7 1l-2.4-1-2 3.4 2 1.6a7.7 7.7 0 0 0 0 2l-2 1.6 2 3.4 2.4-1a7.7 7.7 0 0 0 1.7 1l.4 2.5h3.8l.4-2.5a7.7 7.7 0 0 0 1.7-1l2.4 1 2-3.4-2-1.6z" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linejoin="round"/></svg>
+            </button>
+            <button id="send" aria-label="Send">
+              <svg viewBox="0 0 24 24" width="19" height="19" aria-hidden="true"><path d="M12 19V5M6 11l6-6 6 6" fill="none" stroke="currentColor" stroke-width="2.4" stroke-linecap="round" stroke-linejoin="round"/></svg>
+            </button>
+            <button id="stop" class="hidden" aria-label="Stop">
+              <svg viewBox="0 0 24 24" width="16" height="16" aria-hidden="true"><rect x="6" y="6" width="12" height="12" rx="2.6" fill="currentColor"/></svg>
+            </button>
+          </div>
+          <input id="file" type="file" accept="image/*" multiple hidden />
         </div>
       </div>
     </section>
@@ -45,6 +55,23 @@
       <button id="question-close" class="sheet-close">Close</button>
     </div>
   </div>
+  <div id="cfg" class="sheet hidden">
+    <div class="sheet-card">
+      <div id="cfg-model-section">
+        <p class="sheet-title">Model</p>
+        <div id="cfg-models"></div>
+      </div>
+      <div id="cfg-mode-section">
+        <p class="sheet-title">Mode</p>
+        <div id="cfg-modes"></div>
+      </div>
+      <label id="cfg-autorun-row">
+        <span>Auto-run tools</span>
+        <input id="cfg-autorun" type="checkbox" />
+      </label>
+      <button id="cfg-close" class="sheet-close">Close</button>
+    </div>
+  </div>
   <div id="gate" class="hidden">
     <div class="gate-card">
       <div class="gate-icon" id="gate-icon">⚠</div>
@@ -53,8 +80,8 @@
       <button id="gate-retry" class="hidden">Try again</button>
     </div>
   </div>
-  <script src="/marked.min.js?v=22"></script>
-  <script src="/purify.min.js?v=22"></script>
-  <script src="/app.js?v=22"></script>
+  <script src="/marked.min.js?v=23"></script>
+  <script src="/purify.min.js?v=23"></script>
+  <script src="/app.js?v=23"></script>
 </body>
 </html>

--- a/Alas/Resources/RemoteWeb/index.html
+++ b/Alas/Resources/RemoteWeb/index.html
@@ -4,7 +4,7 @@
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
   <title>Alas Remote</title>
-  <link rel="stylesheet" href="/style.css?v=23" />
+  <link rel="stylesheet" href="/style.css?v=24" />
 </head>
 <body>
   <header id="bar">
@@ -80,8 +80,8 @@
       <button id="gate-retry" class="hidden">Try again</button>
     </div>
   </div>
-  <script src="/marked.min.js?v=23"></script>
-  <script src="/purify.min.js?v=23"></script>
-  <script src="/app.js?v=23"></script>
+  <script src="/marked.min.js?v=24"></script>
+  <script src="/purify.min.js?v=24"></script>
+  <script src="/app.js?v=24"></script>
 </body>
 </html>

--- a/Alas/Resources/RemoteWeb/style.css
+++ b/Alas/Resources/RemoteWeb/style.css
@@ -102,20 +102,36 @@ h1 { font-size: 22px; font-weight: 700; margin: 12px 4px 10px; }
 
 /* Composer / drive bar */
 #drivebar { flex: 0 0 auto; padding: 8px 10px calc(8px + env(safe-area-inset-bottom)); background: color-mix(in oklab, var(--bg-1), transparent 4%); backdrop-filter: blur(8px); border-top: 0.5px solid var(--line-soft); }
-#takeover { width: 100%; padding: 13px; border: 0.5px solid color-mix(in oklab, var(--accent) 55%, transparent); border-radius: 21px; background: color-mix(in oklab, var(--accent) 16%, transparent); color: var(--fg); font-size: 15px; font-weight: 600; cursor: pointer; -webkit-tap-highlight-color: transparent; }
+/* Take-over PILL: a compact, no-typing way to grab the lease. Sits above the
+   always-present composer (the composer itself also auto-takes on any action). */
+#takeover { display: block; margin: 0 auto 8px; padding: 7px 16px; border: 0.5px solid color-mix(in oklab, var(--accent) 55%, transparent); border-radius: 999px; background: color-mix(in oklab, var(--accent) 16%, transparent); color: var(--fg); font-size: 13px; font-weight: 600; cursor: pointer; -webkit-tap-highlight-color: transparent; }
 #takeover:active { background: color-mix(in oklab, var(--accent) 24%, transparent); }
 /* One rounded field; the action button docks bottom-right and the textarea
    grows above it. align-items:flex-end keeps the button pinned to the last line. */
-#composer { display: flex; gap: 7px; align-items: flex-end; padding: 5px 5px 5px 15px; background: var(--bg-0); border: 0.5px solid var(--line); border-radius: 22px; }
-#composer:focus-within { border-color: color-mix(in oklab, var(--accent) 60%, var(--line)); }
+#composer-row { display: flex; gap: 7px; align-items: flex-end; padding: 5px 5px 5px 5px; background: var(--bg-0); border: 0.5px solid var(--line); border-radius: 22px; }
+#composer-row:focus-within { border-color: color-mix(in oklab, var(--accent) 60%, var(--line)); }
+/* Thumbnail row above the composer — horizontal, scrollable small previews. */
+#chips { display: flex; gap: 8px; overflow-x: auto; -webkit-overflow-scrolling: touch; padding: 2px 4px 8px; }
+#chips .chip { position: relative; flex: 0 0 auto; }
+#chips .chip img { width: 54px; height: 54px; object-fit: cover; border-radius: 9px; border: 0.5px solid var(--line); display: block; }
+#chips .chip-x { position: absolute; top: -6px; right: -6px; width: 18px; height: 18px; padding: 0; border: none; border-radius: 50%; background: var(--bg-4); color: var(--fg); font-size: 11px; line-height: 18px; display: flex; align-items: center; justify-content: center; cursor: pointer; -webkit-tap-highlight-color: transparent; }
 /* font-size MUST be ≥16px: iOS auto-zooms (and inflates the viewport) on focus
    of any smaller field. */
 #prompt { flex: 1; min-height: 24px; max-height: 40vh; padding: 7px 0; border: none; background: none; color: var(--fg); font: inherit; font-size: 16px; line-height: 1.35; resize: none; outline: none; }
+#attach.hidden + #prompt { padding-left: 9px; }   /* breathing room when the attach button is hidden */
 #prompt::placeholder { color: var(--fg-faint); }
-#composer button { flex-shrink: 0; width: 34px; height: 34px; padding: 0; border: none; border-radius: 50%; display: flex; align-items: center; justify-content: center; cursor: pointer; -webkit-tap-highlight-color: transparent; transition: transform .08s; }
-#composer button:active { transform: scale(0.92); }
+#composer-row button { flex-shrink: 0; width: 34px; height: 34px; padding: 0; border: none; border-radius: 50%; display: flex; align-items: center; justify-content: center; cursor: pointer; -webkit-tap-highlight-color: transparent; transition: transform .08s; }
+#composer-row button:active { transform: scale(0.92); }
 #send { background: var(--accent); color: var(--bg-0); }
 #stop { background: var(--del); color: var(--fg); }
+/* Secondary icon buttons (attach, config) — muted, no fill. */
+#attach, #config { background: none; color: var(--fg-dim); }
+#attach:active, #config:active { color: var(--fg-muted); }
+
+/* Config sheet (⚙) — reuses .option-btn / .is-selected for the radio lists. */
+#cfg-model-section, #cfg-mode-section { margin-bottom: 14px; }
+#cfg-autorun-row { display: flex; align-items: center; justify-content: space-between; gap: 12px; padding: 12px 14px; margin: 6px 0; border: 1px solid var(--bg-4); border-radius: 10px; background: var(--bg-1); color: var(--fg); font-size: 15px; cursor: pointer; }
+#cfg-autorun { width: 20px; height: 20px; accent-color: var(--accent); cursor: pointer; }
 
 /* Pair / error gate (full screen) */
 #gate { position: fixed; inset: 0; z-index: 20; display: flex; align-items: center; justify-content: center; padding: 28px; background: linear-gradient(180deg, var(--bg-1), var(--bg-0)); }

--- a/Alas/Sources/ACP/Session/ACPSessionManager.swift
+++ b/Alas/Sources/ACP/Session/ACPSessionManager.swift
@@ -90,6 +90,46 @@ final class ACPSessionManager: ObservableObject {
         Task { await runner.userCancel() }
     }
 
+    /// Pending model/mode to apply once a runner registers (the writer took over
+    /// but `attach` is still in flight). Keyed by session id. Applied in `attach`.
+    var pendingModel: [ACPSession.ID: String] = [:]
+    var pendingMode: [ACPSession.ID: String] = [:]
+
+    /// Toggle auto-run for a remotely-driven session. Writer-gated; persists.
+    func setAutoRun(for id: ACPSession.ID, enabled: Bool) {
+        guard isWriter(for: id), let session = sessions[id] else { return }
+        session.autoRunEnabled = enabled
+        persist(session)
+    }
+
+    /// Select the agent model. Optimistically updates + persists, then issues the
+    /// agent RPC on the live runner — or records it pending until `attach`
+    /// registers one (post-takeover window). Writer-gated.
+    func setModel(for id: ACPSession.ID, modelId: String) {
+        guard isWriter(for: id), let session = sessions[id] else { return }
+        session.currentModel = modelId
+        persist(session)
+        guard let runner = runners[id] else {
+            pendingModel[id] = modelId
+            return
+        }
+        let remoteId = session.remoteSessionId ?? id
+        Task { try? await runner.connection.setModel(sessionId: remoteId, modelId: modelId) }
+    }
+
+    /// Select the agent mode. Same semantics as `setModel`.
+    func setMode(for id: ACPSession.ID, modeId: String) {
+        guard isWriter(for: id), let session = sessions[id] else { return }
+        session.currentMode = modeId
+        persist(session)
+        guard let runner = runners[id] else {
+            pendingMode[id] = modeId
+            return
+        }
+        let remoteId = session.remoteSessionId ?? id
+        Task { try? await runner.connection.setMode(sessionId: remoteId, modeId: modeId) }
+    }
+
     /// Sessions for which THIS instance holds the writer lease (backing store).
     var _ownedLeases: Set<ACPSession.ID> = []
     /// Per-session periodic heartbeat tasks (backing store).
@@ -486,6 +526,8 @@ final class ACPSessionManager: ObservableObject {
         sessions[id] = nil
         sessionRefCounts.removeValue(forKey: id)
         planSidebarVisibility.removeValue(forKey: id)
+        pendingModel.removeValue(forKey: id)
+        pendingMode.removeValue(forKey: id)
     }
 
     func deleteSession(id: ACPSession.ID) {
@@ -496,6 +538,8 @@ final class ACPSessionManager: ObservableObject {
         sessions[id] = nil
         sessionRefCounts.removeValue(forKey: id)
         planSidebarVisibility.removeValue(forKey: id)
+        pendingModel.removeValue(forKey: id)
+        pendingMode.removeValue(forKey: id)
         try? store.deleteSession(id: id)
         refreshRecent()
     }
@@ -983,6 +1027,10 @@ extension ACPSessionManager {
         stopHeartbeat(sessionId: sessionId)
         stopWriterWatch(sessionId: sessionId)
         _ownedLeases.remove(sessionId)
+        // We no longer own the lease — drop any not-yet-applied config so it
+        // can't fire against a session another instance now drives.
+        pendingModel.removeValue(forKey: sessionId)
+        pendingMode.removeValue(forKey: sessionId)
         if let runner = runners.removeValue(forKey: sessionId) {
             runner.invalidateActivePrompt()
             runner.stop()
@@ -1409,6 +1457,14 @@ extension ACPSessionManager {
                 sendTranscriptAsContext(sessionId: sessionId, agentName: nil)
             } else {
                 runner.flushQueueIfIdle()
+            }
+            if let m = pendingModel.removeValue(forKey: sessionId) {
+                let remoteId = session.remoteSessionId ?? sessionId
+                Task { try? await runner.connection.setModel(sessionId: remoteId, modelId: m) }
+            }
+            if let m = pendingMode.removeValue(forKey: sessionId) {
+                let remoteId = session.remoteSessionId ?? sessionId
+                Task { try? await runner.connection.setMode(sessionId: remoteId, modeId: m) }
             }
             stderrTask.cancel()
         } catch {

--- a/Alas/Sources/ACP/Session/ACPSessionManager.swift
+++ b/Alas/Sources/ACP/Session/ACPSessionManager.swift
@@ -73,12 +73,12 @@ final class ACPSessionManager: ObservableObject {
     /// land between the gateway's `isWriter` gate and here, and `submit`'s
     /// `.idle`/`.disconnected` path would otherwise enqueue + persist the prompt
     /// as a mirror — injecting it into a session another instance now drives.
-    func sendPrompt(for id: ACPSession.ID, text: String, onResult: @escaping @MainActor (Bool) -> Void) {
+    func sendPrompt(for id: ACPSession.ID, text: String, attachments: [ACPMessage.Attachment], onResult: @escaping @MainActor (Bool) -> Void) {
         guard isWriter(for: id) else {
             onResult(false)
             return
         }
-        let accepted = submit(sessionId: id, text: text, attachments: [], intent: .auto,
+        let accepted = submit(sessionId: id, text: text, attachments: attachments, intent: .auto,
                               onCompleted: { ok in onResult(ok) })
         if !accepted { onResult(false) }   // submit refused synchronously; onCompleted won't fire
     }

--- a/Alas/Sources/ACP/Session/ACPSessionManager.swift
+++ b/Alas/Sources/ACP/Session/ACPSessionManager.swift
@@ -1458,11 +1458,21 @@ extension ACPSessionManager {
             } else {
                 runner.flushQueueIfIdle()
             }
+            // Drain a pending model/mode picked during the post-takeover window.
+            // The load result just above overwrote `currentModel`/`currentMode`
+            // with the agent's restored values, so reapply + persist the user's
+            // choice before firing the RPC — `session/set_model` returns nothing
+            // and not every agent emits a follow-up update, so the local config
+            // and stored row would otherwise drift off the agent's actual state.
             if let m = pendingModel.removeValue(forKey: sessionId) {
+                session.currentModel = m
+                persist(session)
                 let remoteId = session.remoteSessionId ?? sessionId
                 Task { try? await runner.connection.setModel(sessionId: remoteId, modelId: m) }
             }
             if let m = pendingMode.removeValue(forKey: sessionId) {
+                session.currentMode = m
+                persist(session)
                 let remoteId = session.remoteSessionId ?? sessionId
                 Task { try? await runner.connection.setMode(sessionId: remoteId, modeId: m) }
             }

--- a/Alas/Sources/App/AppState.swift
+++ b/Alas/Sources/App/AppState.swift
@@ -3284,12 +3284,23 @@ extension AppState: RemoteSessionsProvider {
 
     /// `onResult` fires once (false when no manager owns the id, the manager
     /// refuses, or delivery later fails) so the gateway can restore the text.
-    func sendPrompt(for id: String, text: String, onResult: @escaping @MainActor (Bool) -> Void) {
+    func sendPrompt(for id: String, text: String, attachments: [ACPMessage.Attachment], onResult: @escaping @MainActor (Bool) -> Void) {
         for mgr in acpManagers.values where mgr.liveSession(for: id) != nil {
-            mgr.sendPrompt(for: id, text: text, onResult: onResult)
+            mgr.sendPrompt(for: id, text: text, attachments: attachments, onResult: onResult)
             return
         }
         onResult(false)
+    }
+
+    func writeAttachment(_ data: Data, mimeType: String, name: String?, for id: String) -> URL? {
+        guard let mgr = acpManagers.values.first(where: { $0.liveSession(for: id) != nil }),
+              let session = mgr.liveSession(for: id) else { return nil }
+        let dir = Paths.acpAttachmentsDir(forWorktreeId: session.worktreeId)
+        try? FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        let ext = mimeType == "image/png" ? "png" : (mimeType == "image/jpeg" ? "jpg" : "img")
+        let url = dir.appendingPathComponent("\(UUID().uuidString).\(ext)")
+        do { try data.write(to: url) } catch { return nil }
+        return url
     }
 
     func stop(for id: String) {

--- a/Alas/Sources/App/AppState.swift
+++ b/Alas/Sources/App/AppState.swift
@@ -3298,4 +3298,40 @@ extension AppState: RemoteSessionsProvider {
             return
         }
     }
+
+    func setModel(for id: String, modelId: String) {
+        for mgr in acpManagers.values where mgr.liveSession(for: id) != nil {
+            mgr.setModel(for: id, modelId: modelId)
+            return
+        }
+    }
+
+    func setMode(for id: String, modeId: String) {
+        for mgr in acpManagers.values where mgr.liveSession(for: id) != nil {
+            mgr.setMode(for: id, modeId: modeId)
+            return
+        }
+    }
+
+    func setAutoRun(for id: String, enabled: Bool) {
+        for mgr in acpManagers.values where mgr.liveSession(for: id) != nil {
+            mgr.setAutoRun(for: id, enabled: enabled)
+            return
+        }
+    }
+
+    func sessionConfig(for id: String) -> RemoteSessionConfig? {
+        for mgr in acpManagers.values {
+            guard let s = mgr.liveSession(for: id) else { continue }
+            return RemoteSessionConfig(
+                sessionId: id,
+                models: s.availableModels.map { RemoteModelInfo(id: $0.id, name: $0.name) },
+                modes: s.availableModes.map { RemoteModelInfo(id: $0.id, name: $0.name) },
+                currentModel: s.currentModel,
+                currentMode: s.currentMode,
+                autoRunEnabled: s.autoRunEnabled,
+                acceptsImages: s.promptCapabilities.image)
+        }
+        return nil
+    }
 }

--- a/Alas/Sources/Remote/Gateway/RemoteSessionGateway.swift
+++ b/Alas/Sources/Remote/Gateway/RemoteSessionGateway.swift
@@ -131,6 +131,8 @@ final class RemoteSessionGateway {
     // MARK: attachment materialization
 
     private static let maxAttachmentsBytes = 10_000_000
+    /// Max images per prompt — parity with the native composer's limit.
+    static let maxAttachmentCount = 10
 
     /// Decode wire attachments to files under acp-attachments/. Returns nil if the
     /// batch violates the size cap or any entry isn't a real image (caller rejects
@@ -143,6 +145,9 @@ final class RemoteSessionGateway {
     /// leave earlier files orphaned; a mid-batch write failure rolls back what
     /// it wrote.
     private func materialize(_ wire: [RemoteAttachment], for sessionId: String) -> [ACPMessage.Attachment]? {
+        // Cap the count before decoding/writing (parity with the native composer's
+        // maxImagesPerMessage) so one prompt can't spray thousands of tiny files.
+        guard wire.count <= Self.maxAttachmentCount else { return nil }
         var decoded: [(data: Data, mimeType: String, name: String?)] = []
         var total = 0
         for a in wire {

--- a/Alas/Sources/Remote/Gateway/RemoteSessionGateway.swift
+++ b/Alas/Sources/Remote/Gateway/RemoteSessionGateway.swift
@@ -403,8 +403,14 @@ final class RemoteSessionGateway {
     static func toWire(_ message: ACPMessage, index: Int) -> RemoteWireMessage {
         let sid = "m\(index)"
         switch message {
-        case .user(_, let text, _):
-            return .init(stableId: sid, kind: "user", text: text, json: nil)
+        case .user(_, let text, let attachments):
+            // The wire carries user text only; surface attachments as a labelled
+            // placeholder so an image-only prompt isn't a blank bubble on the
+            // phone (we don't serve the image bytes to the client in v1).
+            var parts: [String] = []
+            if !text.isEmpty { parts.append(text) }
+            parts.append(contentsOf: attachments.map { "🖼 \($0.name ?? "Image")" })
+            return .init(stableId: sid, kind: "user", text: parts.joined(separator: "\n\n"), json: nil)
         case .agent(_, let streaming):
             return .init(stableId: sid, kind: "agent", text: streaming.value, json: nil)
         case .thought(_, let streaming):

--- a/Alas/Sources/Remote/Gateway/RemoteSessionGateway.swift
+++ b/Alas/Sources/Remote/Gateway/RemoteSessionGateway.swift
@@ -14,6 +14,9 @@ final class RemoteSessionGateway {
     private let provider: RemoteSessionsProvider
     private let send: (RemoteServerMessage) -> Void
     private var subscriptions: [String: AnyCancellable] = [:]
+    private var configSubscriptions: [String: AnyCancellable] = [:]
+    private var configCoalesce: [String: Task<Void, Never>] = [:]
+    private var lastConfig: [String: RemoteSessionConfig] = [:]
     private var coalesce: [String: Task<Void, Never>] = [:]
     // Per-session request id of the permission/question prompt we last surfaced,
     // so we can tell the client to dismiss it if it gets resolved elsewhere.
@@ -43,6 +46,10 @@ final class RemoteSessionGateway {
             observe(id: id, session: session)
         case .unsubscribe(let id):
             subscriptions[id] = nil
+            configSubscriptions[id] = nil
+            configCoalesce[id]?.cancel()
+            configCoalesce[id] = nil
+            lastConfig[id] = nil
             coalesce[id]?.cancel()
             coalesce[id] = nil
             lastPermissionReq[id] = nil
@@ -95,6 +102,10 @@ final class RemoteSessionGateway {
     /// Tear down all observation (called when the connection closes).
     func close() {
         subscriptions.removeAll()
+        configSubscriptions.removeAll()
+        configCoalesce.values.forEach { $0.cancel() }
+        configCoalesce.removeAll()
+        lastConfig.removeAll()
         coalesce.values.forEach { $0.cancel() }
         coalesce.removeAll()
         lastPermissionReq.removeAll()
@@ -128,6 +139,32 @@ final class RemoteSessionGateway {
                 try? await Task.sleep(nanoseconds: Self.coalesceNanos)
                 guard !Task.isCancelled, let self, let session else { return }
                 self.sendDelta(id: id, session: session)
+            }
+        }
+        // Re-emit sessionConfig when the session's config publishers change.
+        // ACPSession.objectWillChange fires for ANY @Published change (agentState,
+        // queue, etc.), not just config — and BEFORE the value settles. Coalesce
+        // a run-loop turn's worth of fires into one next-tick read (zero-delay,
+        // mirroring the transcript coalesce above) and dedupe against the last
+        // config so non-config churn never reaches the wire.
+        configSubscriptions[id]?.cancel()
+        configCoalesce[id]?.cancel()
+        configSubscriptions[id] = session.objectWillChange.sink { [weak self, weak session] _ in
+            guard let self, let session else { return }
+            self.configCoalesce[id]?.cancel()
+            self.configCoalesce[id] = Task { @MainActor [weak self, weak session] in
+                guard !Task.isCancelled, let self, let session else { return }
+                let cfg = RemoteSessionConfig(
+                    sessionId: id,
+                    models: session.availableModels.map { RemoteModelInfo(id: $0.id, name: $0.name) },
+                    modes: session.availableModes.map { RemoteModelInfo(id: $0.id, name: $0.name) },
+                    currentModel: session.currentModel,
+                    currentMode: session.currentMode,
+                    autoRunEnabled: session.autoRunEnabled,
+                    acceptsImages: session.promptCapabilities.image)
+                guard self.lastConfig[id] != cfg else { return }
+                self.lastConfig[id] = cfg
+                self.send(.sessionConfig(cfg))
             }
         }
     }

--- a/Alas/Sources/Remote/Gateway/RemoteSessionGateway.swift
+++ b/Alas/Sources/Remote/Gateway/RemoteSessionGateway.swift
@@ -98,7 +98,13 @@ final class RemoteSessionGateway {
             // later — so the client restores the user's text instead of losing
             // it.
             provider.sendPrompt(for: id, text: trimmed, attachments: materialized) { [weak self] accepted in
-                if !accepted { self?.send(.promptRejected(sessionId: id)) }
+                guard let self else { return }
+                if !accepted {
+                    self.send(.promptRejected(sessionId: id))
+                    // Refused after we wrote the files (needs-auth, or a takeover
+                    // landed mid-flight) — clean them up so they don't orphan.
+                    self.discardAttachmentFiles(materialized)
+                }
             }
         case .stop(let id):
             guard provider.isWriter(for: id) else { return }
@@ -122,19 +128,41 @@ final class RemoteSessionGateway {
 
     /// Decode wire attachments to files under acp-attachments/. Returns nil if the
     /// batch violates the size cap or mimeType allowlist (caller rejects the send).
+    ///
+    /// The whole batch is validated + decoded BEFORE any file is written, so a
+    /// later bad/oversize entry can't leave earlier files orphaned on disk; a
+    /// mid-batch write failure rolls back the files already written.
     private func materialize(_ wire: [RemoteAttachment], for sessionId: String) -> [ACPMessage.Attachment]? {
+        var decoded: [(data: Data, mimeType: String, name: String?)] = []
         var total = 0
-        var out: [ACPMessage.Attachment] = []
         for a in wire {
             guard a.mimeType.hasPrefix(Self.allowedAttachmentPrefix),
                   let data = Data(base64Encoded: a.dataBase64) else { return nil }
             total += data.count
             guard total <= Self.maxAttachmentsBytes else { return nil }
-            guard let url = provider.writeAttachment(data, mimeType: a.mimeType, name: a.name, for: sessionId)
-            else { return nil }
-            out.append(.init(uri: url.absoluteString, name: a.name, mimeType: a.mimeType))
+            decoded.append((data, a.mimeType, a.name))
+        }
+        var written: [URL] = []
+        var out: [ACPMessage.Attachment] = []
+        for d in decoded {
+            guard let url = provider.writeAttachment(d.data, mimeType: d.mimeType, name: d.name, for: sessionId) else {
+                written.forEach { try? FileManager.default.removeItem(at: $0) }
+                return nil
+            }
+            written.append(url)
+            out.append(.init(uri: url.absoluteString, name: d.name, mimeType: d.mimeType))
         }
         return out
+    }
+
+    /// Best-effort delete of attachment files we wrote but that never made it
+    /// into the conversation (the manager refused the prompt after materialize).
+    private func discardAttachmentFiles(_ attachments: [ACPMessage.Attachment]) {
+        for a in attachments {
+            if let url = URL(string: a.uri), url.isFileURL {
+                try? FileManager.default.removeItem(at: url)
+            }
+        }
     }
 
     /// Tear down all observation (called when the connection closes).

--- a/Alas/Sources/Remote/Gateway/RemoteSessionGateway.swift
+++ b/Alas/Sources/Remote/Gateway/RemoteSessionGateway.swift
@@ -131,23 +131,26 @@ final class RemoteSessionGateway {
     // MARK: attachment materialization
 
     private static let maxAttachmentsBytes = 10_000_000
-    private static let allowedAttachmentPrefix = "image/"
 
     /// Decode wire attachments to files under acp-attachments/. Returns nil if the
-    /// batch violates the size cap or mimeType allowlist (caller rejects the send).
+    /// batch violates the size cap or any entry isn't a real image (caller rejects
+    /// the send).
     ///
-    /// The whole batch is validated + decoded BEFORE any file is written, so a
-    /// later bad/oversize entry can't leave earlier files orphaned on disk; a
-    /// mid-batch write failure rolls back the files already written.
+    /// The bytes are sniffed for real PNG/JPEG/GIF/WebP magic — parity with the
+    /// native composer's `ACPImageStaging`, instead of trusting the client MIME —
+    /// and the sniffed type is what we store. The whole batch is validated +
+    /// decoded BEFORE any file is written, so a later bad/oversize entry can't
+    /// leave earlier files orphaned; a mid-batch write failure rolls back what
+    /// it wrote.
     private func materialize(_ wire: [RemoteAttachment], for sessionId: String) -> [ACPMessage.Attachment]? {
         var decoded: [(data: Data, mimeType: String, name: String?)] = []
         var total = 0
         for a in wire {
-            guard a.mimeType.hasPrefix(Self.allowedAttachmentPrefix),
-                  let data = Data(base64Encoded: a.dataBase64) else { return nil }
+            guard let data = Data(base64Encoded: a.dataBase64) else { return nil }
             total += data.count
             guard total <= Self.maxAttachmentsBytes else { return nil }
-            decoded.append((data, a.mimeType, a.name))
+            guard let mime = ACPImageStaging.sniffMIME(data) else { return nil }   // real image only
+            decoded.append((data, mime, a.name))
         }
         var written: [URL] = []
         var out: [ACPMessage.Attachment] = []

--- a/Alas/Sources/Remote/Gateway/RemoteSessionGateway.swift
+++ b/Alas/Sources/Remote/Gateway/RemoteSessionGateway.swift
@@ -97,15 +97,22 @@ final class RemoteSessionGateway {
             // now (not writer / needs auth) OR a session/prompt RPC that fails
             // later — so the client restores the user's text instead of losing
             // it.
+            // True only while the call below is still on the stack. A refusal
+            // observed in that window is SYNCHRONOUS — the manager refused
+            // before recording the user message (no live session / needs auth),
+            // so its attachment files are orphans to delete. A refusal that
+            // arrives LATER means `sendNow` already recorded the message with
+            // these file URIs (the transcript bubble references them), so we
+            // must keep the files.
+            var refusalIsSynchronous = true
             provider.sendPrompt(for: id, text: trimmed, attachments: materialized) { [weak self] accepted in
                 guard let self else { return }
                 if !accepted {
                     self.send(.promptRejected(sessionId: id))
-                    // Refused after we wrote the files (needs-auth, or a takeover
-                    // landed mid-flight) — clean them up so they don't orphan.
-                    self.discardAttachmentFiles(materialized)
+                    if refusalIsSynchronous { self.discardAttachmentFiles(materialized) }
                 }
             }
+            refusalIsSynchronous = false
         case .stop(let id):
             guard provider.isWriter(for: id) else { return }
             provider.stop(for: id)

--- a/Alas/Sources/Remote/Gateway/RemoteSessionGateway.swift
+++ b/Alas/Sources/Remote/Gateway/RemoteSessionGateway.swift
@@ -70,10 +70,26 @@ final class RemoteSessionGateway {
             if let session = provider.session(for: id) {
                 sendSnapshot(id: id, session: session)
             }
-        case .sendPrompt(let id, let text):
-            let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
-            guard !trimmed.isEmpty else {
+        case .sendPrompt(let id, let text, let attachments):
+            // Pre-check the lease BEFORE materializing — `materialize` writes the
+            // decoded images to disk, and a non-writer must be rejected without
+            // leaving orphan files under acp-attachments/. The manager re-checks
+            // isWriter too (TOCTOU defense for a takeover that lands mid-flight),
+            // so this is an early-out, not the authoritative gate. Auto-takeover
+            // still works: the client sends `takeOver` (synchronous lease seize)
+            // before `sendPrompt`, so isWriter is already true here.
+            guard provider.isWriter(for: id) else {
                 send(.promptRejected(sessionId: id))
+                return
+            }
+            let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
+            let hasContent = !trimmed.isEmpty || !attachments.isEmpty
+            guard hasContent else {
+                send(.promptRejected(sessionId: id))
+                return
+            }
+            guard let materialized = materialize(attachments, for: id) else {
+                send(.promptRejected(sessionId: id))   // oversize / non-image
                 return
             }
             // The manager owns the writer/lease re-check and the eventual
@@ -81,7 +97,7 @@ final class RemoteSessionGateway {
             // now (not writer / needs auth) OR a session/prompt RPC that fails
             // later — so the client restores the user's text instead of losing
             // it.
-            provider.sendPrompt(for: id, text: trimmed) { [weak self] accepted in
+            provider.sendPrompt(for: id, text: trimmed, attachments: materialized) { [weak self] accepted in
                 if !accepted { self?.send(.promptRejected(sessionId: id)) }
             }
         case .stop(let id):
@@ -97,6 +113,28 @@ final class RemoteSessionGateway {
             guard provider.isWriter(for: id) else { return }
             provider.setAutoRun(for: id, enabled: enabled)
         }
+    }
+
+    // MARK: attachment materialization
+
+    private static let maxAttachmentsBytes = 10_000_000
+    private static let allowedAttachmentPrefix = "image/"
+
+    /// Decode wire attachments to files under acp-attachments/. Returns nil if the
+    /// batch violates the size cap or mimeType allowlist (caller rejects the send).
+    private func materialize(_ wire: [RemoteAttachment], for sessionId: String) -> [ACPMessage.Attachment]? {
+        var total = 0
+        var out: [ACPMessage.Attachment] = []
+        for a in wire {
+            guard a.mimeType.hasPrefix(Self.allowedAttachmentPrefix),
+                  let data = Data(base64Encoded: a.dataBase64) else { return nil }
+            total += data.count
+            guard total <= Self.maxAttachmentsBytes else { return nil }
+            guard let url = provider.writeAttachment(data, mimeType: a.mimeType, name: a.name, for: sessionId)
+            else { return nil }
+            out.append(.init(uri: url.absoluteString, name: a.name, mimeType: a.mimeType))
+        }
+        return out
     }
 
     /// Tear down all observation (called when the connection closes).

--- a/Alas/Sources/Remote/Gateway/RemoteSessionGateway.swift
+++ b/Alas/Sources/Remote/Gateway/RemoteSessionGateway.swift
@@ -37,6 +37,9 @@ final class RemoteSessionGateway {
                 return
             }
             sendSnapshot(id: id, session: session)
+            if let cfg = provider.sessionConfig(for: id) {
+                send(.sessionConfig(cfg))
+            }
             observe(id: id, session: session)
         case .unsubscribe(let id):
             subscriptions[id] = nil
@@ -77,6 +80,15 @@ final class RemoteSessionGateway {
         case .stop(let id):
             guard provider.isWriter(for: id) else { return }
             provider.stop(for: id)
+        case .setModel(let id, let modelId):
+            guard provider.isWriter(for: id) else { return }
+            provider.setModel(for: id, modelId: modelId)
+        case .setMode(let id, let modeId):
+            guard provider.isWriter(for: id) else { return }
+            provider.setMode(for: id, modeId: modeId)
+        case .setAutoRun(let id, let enabled):
+            guard provider.isWriter(for: id) else { return }
+            provider.setAutoRun(for: id, enabled: enabled)
         }
     }
 

--- a/Alas/Sources/Remote/Gateway/RemoteSessionsProvider.swift
+++ b/Alas/Sources/Remote/Gateway/RemoteSessionsProvider.swift
@@ -16,4 +16,10 @@ protocol RemoteSessionsProvider: AnyObject {
     /// the client can restore the text instead of losing it.
     func sendPrompt(for id: String, text: String, onResult: @escaping @MainActor (Bool) -> Void)
     func stop(for id: String)
+    func setModel(for id: String, modelId: String)
+    func setMode(for id: String, modeId: String)
+    func setAutoRun(for id: String, enabled: Bool)
+    /// Projection of the session's config for the `sessionConfig` wire message,
+    /// or nil if the session isn't live.
+    func sessionConfig(for id: String) -> RemoteSessionConfig?
 }

--- a/Alas/Sources/Remote/Gateway/RemoteSessionsProvider.swift
+++ b/Alas/Sources/Remote/Gateway/RemoteSessionsProvider.swift
@@ -14,7 +14,10 @@ protocol RemoteSessionsProvider: AnyObject {
     /// `onResult` fires once with the final outcome (false = refused now or
     /// failed delivery later); the gateway emits `promptRejected` on false so
     /// the client can restore the text instead of losing it.
-    func sendPrompt(for id: String, text: String, onResult: @escaping @MainActor (Bool) -> Void)
+    func sendPrompt(for id: String, text: String, attachments: [ACPMessage.Attachment], onResult: @escaping @MainActor (Bool) -> Void)
+    /// Decode a base64 image to a file under the session's acp-attachments dir.
+    /// Returns the file URL on success, nil on any write error.
+    func writeAttachment(_ data: Data, mimeType: String, name: String?, for id: String) -> URL?
     func stop(for id: String)
     func setModel(for id: String, modelId: String)
     func setMode(for id: String, modeId: String)

--- a/Alas/Sources/Remote/Protocol/RemoteProtocol.swift
+++ b/Alas/Sources/Remote/Protocol/RemoteProtocol.swift
@@ -1,5 +1,20 @@
 import Foundation
 
+struct RemoteModelInfo: Codable, Equatable, Sendable {
+    let id: String
+    let name: String
+}
+
+struct RemoteSessionConfig: Codable, Equatable, Sendable {
+    let sessionId: String
+    let models: [RemoteModelInfo]
+    let modes: [RemoteModelInfo]
+    let currentModel: String?
+    let currentMode: String?
+    let autoRunEnabled: Bool
+    let acceptsImages: Bool
+}
+
 /// Client → server. `type` discriminates.
 enum RemoteClientMessage: Equatable, Sendable {
     case listSessions

--- a/Alas/Sources/Remote/Protocol/RemoteProtocol.swift
+++ b/Alas/Sources/Remote/Protocol/RemoteProtocol.swift
@@ -25,10 +25,13 @@ enum RemoteClientMessage: Equatable, Sendable {
     case takeOver(sessionId: String)
     case sendPrompt(sessionId: String, text: String)
     case stop(sessionId: String)
+    case setModel(sessionId: String, modelId: String)
+    case setMode(sessionId: String, modeId: String)
+    case setAutoRun(sessionId: String, enabled: Bool)
 }
 
 extension RemoteClientMessage: Codable {
-    private enum CodingKeys: String, CodingKey { case type, sessionId, requestId, optionId, persistScope, answers, text }
+    private enum CodingKeys: String, CodingKey { case type, sessionId, requestId, optionId, persistScope, answers, text, modelId, modeId, enabled }
 
     init(from decoder: Decoder) throws {
         let c = try decoder.container(keyedBy: CodingKeys.self)
@@ -55,6 +58,12 @@ extension RemoteClientMessage: Codable {
                 text: try c.decode(String.self, forKey: .text))
         case "stop":
             self = .stop(sessionId: try c.decode(String.self, forKey: .sessionId))
+        case "setModel":
+            self = .setModel(sessionId: try c.decode(String.self, forKey: .sessionId), modelId: try c.decode(String.self, forKey: .modelId))
+        case "setMode":
+            self = .setMode(sessionId: try c.decode(String.self, forKey: .sessionId), modeId: try c.decode(String.self, forKey: .modeId))
+        case "setAutoRun":
+            self = .setAutoRun(sessionId: try c.decode(String.self, forKey: .sessionId), enabled: try c.decode(Bool.self, forKey: .enabled))
         case let other:
             throw DecodingError.dataCorruptedError(forKey: .type, in: c, debugDescription: "unknown type \(other)")
         }
@@ -89,6 +98,18 @@ extension RemoteClientMessage: Codable {
         case .stop(let s):
             try c.encode("stop", forKey: .type)
             try c.encode(s, forKey: .sessionId)
+        case .setModel(let id, let m):
+            try c.encode("setModel", forKey: .type)
+            try c.encode(id, forKey: .sessionId)
+            try c.encode(m, forKey: .modelId)
+        case .setMode(let id, let m):
+            try c.encode("setMode", forKey: .type)
+            try c.encode(id, forKey: .sessionId)
+            try c.encode(m, forKey: .modeId)
+        case .setAutoRun(let id, let e):
+            try c.encode("setAutoRun", forKey: .type)
+            try c.encode(id, forKey: .sessionId)
+            try c.encode(e, forKey: .enabled)
         }
     }
 }
@@ -107,12 +128,14 @@ enum RemoteServerMessage: Equatable, Sendable {
     /// the prompt was empty), so the client should restore the user's text
     /// instead of silently losing it.
     case promptRejected(sessionId: String)
+    case sessionConfig(RemoteSessionConfig)
     case error(message: String)
 }
 
 extension RemoteServerMessage: Codable {
     private enum CodingKeys: String, CodingKey {
         case type, sessions, sessionId, streamingState, canDrive, messages, upserts, payload, requestId, message
+        case models, modes, currentModel, currentMode, autoRunEnabled, acceptsImages
     }
 
     init(from decoder: Decoder) throws {
@@ -149,6 +172,15 @@ extension RemoteServerMessage: Codable {
                 requestId: try c.decode(Int.self, forKey: .requestId))
         case "sessionClosed": self = .sessionClosed(sessionId: try c.decode(String.self, forKey: .sessionId))
         case "promptRejected": self = .promptRejected(sessionId: try c.decode(String.self, forKey: .sessionId))
+        case "sessionConfig":
+            self = .sessionConfig(RemoteSessionConfig(
+                sessionId: try c.decode(String.self, forKey: .sessionId),
+                models: try c.decode([RemoteModelInfo].self, forKey: .models),
+                modes: try c.decode([RemoteModelInfo].self, forKey: .modes),
+                currentModel: try c.decodeIfPresent(String.self, forKey: .currentModel),
+                currentMode: try c.decodeIfPresent(String.self, forKey: .currentMode),
+                autoRunEnabled: try c.decode(Bool.self, forKey: .autoRunEnabled),
+                acceptsImages: try c.decode(Bool.self, forKey: .acceptsImages)))
         case "error": self = .error(message: try c.decode(String.self, forKey: .message))
         case let other:
             throw DecodingError.dataCorruptedError(forKey: .type, in: c, debugDescription: "unknown type \(other)")
@@ -192,6 +224,15 @@ extension RemoteServerMessage: Codable {
         try c.encode(id, forKey: .sessionId)
         case .promptRejected(let id): try c.encode("promptRejected", forKey: .type)
         try c.encode(id, forKey: .sessionId)
+        case .sessionConfig(let cfg):
+            try c.encode("sessionConfig", forKey: .type)
+            try c.encode(cfg.sessionId, forKey: .sessionId)
+            try c.encode(cfg.models, forKey: .models)
+            try c.encode(cfg.modes, forKey: .modes)
+            try c.encodeIfPresent(cfg.currentModel, forKey: .currentModel)
+            try c.encodeIfPresent(cfg.currentMode, forKey: .currentMode)
+            try c.encode(cfg.autoRunEnabled, forKey: .autoRunEnabled)
+            try c.encode(cfg.acceptsImages, forKey: .acceptsImages)
         case .error(let m): try c.encode("error", forKey: .type)
         try c.encode(m, forKey: .message)
         }

--- a/Alas/Sources/Remote/Protocol/RemoteProtocol.swift
+++ b/Alas/Sources/Remote/Protocol/RemoteProtocol.swift
@@ -5,6 +5,12 @@ struct RemoteModelInfo: Codable, Equatable, Sendable {
     let name: String
 }
 
+struct RemoteAttachment: Codable, Equatable, Sendable {
+    let name: String?
+    let mimeType: String
+    let dataBase64: String
+}
+
 struct RemoteSessionConfig: Codable, Equatable, Sendable {
     let sessionId: String
     let models: [RemoteModelInfo]
@@ -23,7 +29,7 @@ enum RemoteClientMessage: Equatable, Sendable {
     case permissionDecision(sessionId: String, requestId: Int, optionId: String, persistScope: String?)
     case questionAnswer(sessionId: String, requestId: Int, answers: [RemoteQuestionAnswer])
     case takeOver(sessionId: String)
-    case sendPrompt(sessionId: String, text: String)
+    case sendPrompt(sessionId: String, text: String, attachments: [RemoteAttachment])
     case stop(sessionId: String)
     case setModel(sessionId: String, modelId: String)
     case setMode(sessionId: String, modeId: String)
@@ -31,7 +37,7 @@ enum RemoteClientMessage: Equatable, Sendable {
 }
 
 extension RemoteClientMessage: Codable {
-    private enum CodingKeys: String, CodingKey { case type, sessionId, requestId, optionId, persistScope, answers, text, modelId, modeId, enabled }
+    private enum CodingKeys: String, CodingKey { case type, sessionId, requestId, optionId, persistScope, answers, text, attachments, modelId, modeId, enabled }
 
     init(from decoder: Decoder) throws {
         let c = try decoder.container(keyedBy: CodingKeys.self)
@@ -55,7 +61,8 @@ extension RemoteClientMessage: Codable {
         case "sendPrompt":
             self = .sendPrompt(
                 sessionId: try c.decode(String.self, forKey: .sessionId),
-                text: try c.decode(String.self, forKey: .text))
+                text: try c.decode(String.self, forKey: .text),
+                attachments: try c.decodeIfPresent([RemoteAttachment].self, forKey: .attachments) ?? [])
         case "stop":
             self = .stop(sessionId: try c.decode(String.self, forKey: .sessionId))
         case "setModel":
@@ -91,10 +98,11 @@ extension RemoteClientMessage: Codable {
         case .takeOver(let s):
             try c.encode("takeOver", forKey: .type)
             try c.encode(s, forKey: .sessionId)
-        case .sendPrompt(let s, let t):
+        case .sendPrompt(let s, let t, let a):
             try c.encode("sendPrompt", forKey: .type)
             try c.encode(s, forKey: .sessionId)
             try c.encode(t, forKey: .text)
+            try c.encode(a, forKey: .attachments)
         case .stop(let s):
             try c.encode("stop", forKey: .type)
             try c.encode(s, forKey: .sessionId)

--- a/Alas/Sources/Remote/Server/RemoteConnection.swift
+++ b/Alas/Sources/Remote/Server/RemoteConnection.swift
@@ -33,6 +33,8 @@ final class RemoteConnection: @unchecked Sendable {
     /// arrival order — clients rely on this (e.g. a `takeOver` must land before
     /// the `sendPrompt` that follows it). Mutated only on `queue`.
     private var processingTail: Task<Void, Never>?
+    /// Reassembles fragmented WebSocket messages before they're decoded.
+    private var reassembler = WebSocketReassembler()
     /// The device this connection authenticated as, set on `queue` once the WS
     /// upgrade succeeds. Queue-confined; the server learns it via the
     /// `onAuthenticated` hop rather than reading this cross-queue.
@@ -234,27 +236,38 @@ final class RemoteConnection: @unchecked Sendable {
             inbound = buffer
 
             switch frame.opcode {
-            case .text, .binary:
-                if let msg = try? JSONDecoder().decode(RemoteClientMessage.self, from: frame.payload),
-                   let gateway {
-                    // Chain onto the tail so messages are handled strictly in
-                    // arrival order (each awaits the previous). Independent
-                    // tasks could otherwise interleave and, e.g., run a
-                    // `sendPrompt` before the `takeOver` sent just before it.
-                    let previous = processingTail
-                    processingTail = Task { @MainActor in
-                        await previous?.value
-                        await gateway.handle(msg)
-                    }
+            case .text, .binary, .continuation:
+                // Reassemble fragmented messages (RFC 6455 §5.4) before decoding;
+                // a single message may arrive split across continuation frames.
+                switch reassembler.accept(frame) {
+                case .message(let payload): dispatchMessage(payload)
+                case .incomplete: break
+                case .violation:
+                    teardown()
+                    return
                 }
             case .ping:
                 send(WebSocketFrame.encode(opcode: .pong, payload: frame.payload)) {}
             case .close:
                 teardown()
                 return
-            case .continuation, .pong:
+            case .pong:
                 break
             }
+        }
+    }
+
+    /// Decode a (reassembled) message payload and chain its handling onto the
+    /// per-connection tail so messages run in strict arrival order — each awaits
+    /// the previous. Independent tasks could otherwise interleave and, e.g., run
+    /// a `sendPrompt` before the `takeOver` the client sent just before it.
+    private func dispatchMessage(_ payload: Data) {
+        guard let msg = try? JSONDecoder().decode(RemoteClientMessage.self, from: payload),
+              let gateway else { return }
+        let previous = processingTail
+        processingTail = Task { @MainActor in
+            await previous?.value
+            await gateway.handle(msg)
         }
     }
 

--- a/Alas/Sources/Remote/Server/RemoteConnection.swift
+++ b/Alas/Sources/Remote/Server/RemoteConnection.swift
@@ -28,6 +28,11 @@ final class RemoteConnection: @unchecked Sendable {
     private var isWebSocket = false
     private var gateway: RemoteSessionGateway?
     private var closed = false
+    /// Tail of the per-connection message-processing chain. Each decoded frame's
+    /// `gateway.handle` awaits the previous one, so messages are processed in
+    /// arrival order — clients rely on this (e.g. a `takeOver` must land before
+    /// the `sendPrompt` that follows it). Mutated only on `queue`.
+    private var processingTail: Task<Void, Never>?
     /// The device this connection authenticated as, set on `queue` once the WS
     /// upgrade succeeds. Queue-confined; the server learns it via the
     /// `onAuthenticated` hop rather than reading this cross-queue.
@@ -232,7 +237,15 @@ final class RemoteConnection: @unchecked Sendable {
             case .text, .binary:
                 if let msg = try? JSONDecoder().decode(RemoteClientMessage.self, from: frame.payload),
                    let gateway {
-                    Task { @MainActor in await gateway.handle(msg) }
+                    // Chain onto the tail so messages are handled strictly in
+                    // arrival order (each awaits the previous). Independent
+                    // tasks could otherwise interleave and, e.g., run a
+                    // `sendPrompt` before the `takeOver` sent just before it.
+                    let previous = processingTail
+                    processingTail = Task { @MainActor in
+                        await previous?.value
+                        await gateway.handle(msg)
+                    }
                 }
             case .ping:
                 send(WebSocketFrame.encode(opcode: .pong, payload: frame.payload)) {}
@@ -266,6 +279,8 @@ final class RemoteConnection: @unchecked Sendable {
     private func teardown() {
         guard !closed else { return }
         closed = true
+        processingTail?.cancel()
+        processingTail = nil
         if let gateway { Task { @MainActor in gateway.close() } }
         gateway = nil
         conn.cancel()

--- a/Alas/Sources/Remote/Server/WebSocketFrame.swift
+++ b/Alas/Sources/Remote/Server/WebSocketFrame.swift
@@ -7,10 +7,9 @@ struct WebSocketFrame: Equatable {
 
     /// Hard cap on a single inbound frame's declared payload length. Larger
     /// frames are rejected rather than buffered, bounding memory and closing
-    /// off a trivial "declare a huge length" denial-of-service. The remote
-    /// protocol's messages (transcript deltas, decisions) are small, so 10 MB
-    /// sits comfortably above any legitimate frame.
-    static let maxPayloadLength = 10_000_000
+    /// off a trivial "declare a huge length" denial-of-service.
+    /// ~16 MB: fits a ~10 MB image base64-encoded (~13.3 MB) plus JSON overhead.
+    static let maxPayloadLength = 16_000_000
 
     /// Server→client frames are never masked (RFC 6455 §5.1).
     static func encode(opcode: Opcode, payload: Data) -> Data {

--- a/Alas/Sources/Remote/Server/WebSocketFrame.swift
+++ b/Alas/Sources/Remote/Server/WebSocketFrame.swift
@@ -4,6 +4,9 @@ struct WebSocketFrame: Equatable {
     enum Opcode: UInt8 { case continuation = 0x0, text = 0x1, binary = 0x2, close = 0x8, ping = 0x9, pong = 0xA }
     let opcode: Opcode
     let payload: Data
+    /// FIN bit: false means more continuation frames follow (a fragmented
+    /// message, RFC 6455 §5.4); callers must reassemble before decoding.
+    let fin: Bool
 
     /// Hard cap on a single inbound frame's declared payload length. Larger
     /// frames are rejected rather than buffered, bounding memory and closing
@@ -77,6 +80,51 @@ struct WebSocketFrame: Equatable {
         var payload = [UInt8](bytes[idx..<idx + len])
         if masked { for i in 0..<payload.count { payload[i] ^= mask[i % 4] } }
         buffer.removeFirst(idx + len)
-        return WebSocketFrame(opcode: opcode, payload: Data(payload))
+        return WebSocketFrame(opcode: opcode, payload: Data(payload), fin: (bytes[0] & 0x80) != 0)
+    }
+}
+
+/// Reassembles fragmented WebSocket data messages (RFC 6455 §5.4). Feed every
+/// decoded `.text`/`.binary`/`.continuation` frame; the caller handles control
+/// frames (ping/close/pong) separately and must NOT pass them here.
+struct WebSocketReassembler {
+    enum Outcome: Equatable {
+        case message(Data)   // a complete (possibly reassembled) message
+        case incomplete      // buffering; awaiting more continuation frames
+        case violation       // malformed sequence — caller should close
+    }
+
+    private var fragmentOpcode: WebSocketFrame.Opcode?
+    private var buffer = Data()
+    private let maxBytes: Int
+
+    init(maxBytes: Int = WebSocketFrame.maxPayloadLength) { self.maxBytes = maxBytes }
+
+    mutating func accept(_ frame: WebSocketFrame) -> Outcome {
+        switch frame.opcode {
+        case .text, .binary:
+            // A new data message must not begin while one is still fragmenting.
+            guard fragmentOpcode == nil else { return .violation }
+            if frame.fin { return .message(frame.payload) }
+            fragmentOpcode = frame.opcode
+            buffer = frame.payload
+            return buffer.count <= maxBytes ? .incomplete : reset(.violation)
+        case .continuation:
+            guard fragmentOpcode != nil else { return .violation }   // continuation without a start
+            buffer.append(frame.payload)
+            guard buffer.count <= maxBytes else { return reset(.violation) }
+            guard frame.fin else { return .incomplete }
+            let message = buffer
+            _ = reset(.incomplete)
+            return .message(message)
+        case .close, .ping, .pong:
+            return .violation   // control frames must not be routed here
+        }
+    }
+
+    private mutating func reset(_ outcome: Outcome) -> Outcome {
+        fragmentOpcode = nil
+        buffer = Data()
+        return outcome
     }
 }

--- a/AlasTests/Remote/ACPManagerAccessorsTests.swift
+++ b/AlasTests/Remote/ACPManagerAccessorsTests.swift
@@ -73,7 +73,7 @@ struct ACPManagerAccessorsTests {
         let s = mgr.createSession(agentId: "claude")
         #expect(mgr.isWriter(for: s.id) == false)
         var result: Bool?
-        mgr.sendPrompt(for: s.id, text: "hi") { result = $0 }
+        mgr.sendPrompt(for: s.id, text: "hi", attachments: []) { result = $0 }
         #expect(result == false)   // refused synchronously
         #expect(s.queue.isEmpty)   // nothing enqueued/persisted as a mirror
     }

--- a/AlasTests/Remote/ACPManagerAccessorsTests.swift
+++ b/AlasTests/Remote/ACPManagerAccessorsTests.swift
@@ -77,4 +77,26 @@ struct ACPManagerAccessorsTests {
         #expect(result == false)   // refused synchronously
         #expect(s.queue.isEmpty)   // nothing enqueued/persisted as a mirror
     }
+
+    @Test func setAutoRunRequiresWriter() throws {
+        let mgr = try makeManager()
+        let s = mgr.createSession(agentId: "claude")
+        mgr.setAutoRun(for: s.id, enabled: true)
+        #expect(s.autoRunEnabled == false)          // not writer → ignored
+        mgr._ownedLeases.insert(s.id)
+        mgr.setAutoRun(for: s.id, enabled: true)
+        #expect(s.autoRunEnabled == true)
+    }
+
+    @Test func setModelOptimisticallyUpdatesAndRequiresWriter() throws {
+        let mgr = try makeManager()
+        let s = mgr.createSession(agentId: "claude")
+        mgr.setModel(for: s.id, modelId: "opus")
+        #expect(s.currentModel == nil)              // not writer → ignored
+        mgr._ownedLeases.insert(s.id)
+        mgr.setModel(for: s.id, modelId: "opus")
+        #expect(s.currentModel == "opus")           // optimistic update even with no runner
+        mgr.setMode(for: s.id, modeId: "ask")
+        #expect(s.currentMode == "ask")
+    }
 }

--- a/AlasTests/Remote/RemoteProtocolTests.swift
+++ b/AlasTests/Remote/RemoteProtocolTests.swift
@@ -163,4 +163,42 @@ struct RemoteProtocolTests {
         #expect(try roundTrip(RemoteClientMessage.sendPrompt(sessionId: "s1", text: "hello")) == .sendPrompt(sessionId: "s1", text: "hello"))
         #expect(try roundTrip(RemoteClientMessage.stop(sessionId: "s1")) == .stop(sessionId: "s1"))
     }
+
+    @Test func sessionConfigRoundTrips() throws {
+        let cfg = RemoteServerMessage.sessionConfig(.init(
+            sessionId: "s1",
+            models: [.init(id: "opus", name: "Opus"), .init(id: "sonnet", name: "Sonnet")],
+            modes: [.init(id: "ask", name: "Ask")],
+            currentModel: "opus", currentMode: "ask",
+            autoRunEnabled: true, acceptsImages: true))
+        #expect(try roundTrip(cfg) == cfg)
+    }
+
+    @Test func clientConfigVerbsDecode() throws {
+        let setModel = try JSONDecoder().decode(RemoteClientMessage.self,
+            from: Data(#"{"type":"setModel","sessionId":"s1","modelId":"opus"}"#.utf8))
+        #expect(setModel == .setModel(sessionId: "s1", modelId: "opus"))
+        let setMode = try JSONDecoder().decode(RemoteClientMessage.self,
+            from: Data(#"{"type":"setMode","sessionId":"s1","modeId":"ask"}"#.utf8))
+        #expect(setMode == .setMode(sessionId: "s1", modeId: "ask"))
+        let setAuto = try JSONDecoder().decode(RemoteClientMessage.self,
+            from: Data(#"{"type":"setAutoRun","sessionId":"s1","enabled":true}"#.utf8))
+        #expect(setAuto == .setAutoRun(sessionId: "s1", enabled: true))
+    }
+
+    @Test func clientConfigVerbsRoundTrip() throws {
+        // Guards against an encoder-side modelId/modeId key mixup.
+        #expect(try roundTrip(RemoteClientMessage.setModel(sessionId: "s1", modelId: "opus")) == .setModel(sessionId: "s1", modelId: "opus"))
+        #expect(try roundTrip(RemoteClientMessage.setMode(sessionId: "s1", modeId: "ask")) == .setMode(sessionId: "s1", modeId: "ask"))
+        #expect(try roundTrip(RemoteClientMessage.setAutoRun(sessionId: "s1", enabled: true)) == .setAutoRun(sessionId: "s1", enabled: true))
+    }
+
+    @Test func sessionConfigRoundTripsWithNilCurrent() throws {
+        // currentModel/currentMode nil → encodeIfPresent omits the keys; decode must still round-trip.
+        let cfg = RemoteServerMessage.sessionConfig(.init(
+            sessionId: "s1", models: [], modes: [],
+            currentModel: nil, currentMode: nil,
+            autoRunEnabled: false, acceptsImages: false))
+        #expect(try roundTrip(cfg) == cfg)
+    }
 }

--- a/AlasTests/Remote/RemoteProtocolTests.swift
+++ b/AlasTests/Remote/RemoteProtocolTests.swift
@@ -134,7 +134,7 @@ struct RemoteProtocolTests {
     @Test func clientMessageDecodesSendPrompt() throws {
         let json = #"{"type":"sendPrompt","sessionId":"s1","text":"hello"}"#.data(using: .utf8)!
         let msg = try JSONDecoder().decode(RemoteClientMessage.self, from: json)
-        #expect(msg == .sendPrompt(sessionId: "s1", text: "hello"))
+        #expect(msg == .sendPrompt(sessionId: "s1", text: "hello", attachments: []))
     }
 
     @Test func clientMessageDecodesTakeOverAndStop() throws {
@@ -160,7 +160,7 @@ struct RemoteProtocolTests {
 
     @Test func clientDriveVerbsRoundTrip() throws {
         #expect(try roundTrip(RemoteClientMessage.takeOver(sessionId: "s1")) == .takeOver(sessionId: "s1"))
-        #expect(try roundTrip(RemoteClientMessage.sendPrompt(sessionId: "s1", text: "hello")) == .sendPrompt(sessionId: "s1", text: "hello"))
+        #expect(try roundTrip(RemoteClientMessage.sendPrompt(sessionId: "s1", text: "hello", attachments: [])) == .sendPrompt(sessionId: "s1", text: "hello", attachments: []))
         #expect(try roundTrip(RemoteClientMessage.stop(sessionId: "s1")) == .stop(sessionId: "s1"))
     }
 
@@ -200,5 +200,13 @@ struct RemoteProtocolTests {
             currentModel: nil, currentMode: nil,
             autoRunEnabled: false, acceptsImages: false))
         #expect(try roundTrip(cfg) == cfg)
+    }
+
+    @Test func sendPromptWithAttachmentsRoundTrips() throws {
+        let msg = RemoteClientMessage.sendPrompt(
+            sessionId: "s1",
+            text: "look",
+            attachments: [RemoteAttachment(name: "a.png", mimeType: "image/png", dataBase64: "AAAA")])
+        #expect(try roundTrip(msg) == msg)
     }
 }

--- a/AlasTests/Remote/RemoteSessionGatewayTests.swift
+++ b/AlasTests/Remote/RemoteSessionGatewayTests.swift
@@ -41,10 +41,12 @@ final class FakeSessionsProvider: RemoteSessionsProvider {
         onResult(accepted)
     }
 
+    var writtenAttachmentURLs: [URL] = []
     func writeAttachment(_ data: Data, mimeType: String, name: String?, for id: String) -> URL? {
         let ext = mimeType == "image/png" ? "png" : (mimeType == "image/jpeg" ? "jpg" : "img")
         let url = FileManager.default.temporaryDirectory.appendingPathComponent("\(UUID()).\(ext)")
         do { try data.write(to: url) } catch { return nil }
+        writtenAttachmentURLs.append(url)
         return url
     }
 
@@ -493,5 +495,22 @@ struct RemoteSessionGatewayTests {
         await gw.handle(.sendPrompt(sessionId: "s1", text: "look", attachments: [.init(name: "a.png", mimeType: "image/png", dataBase64: "iVBORw0KGgo=")]))
         #expect(provider.lastAttachments.count == 1)
         #expect(!sent.contains { if case .promptRejected = $0 { return true } else { return false } })
+    }
+
+    @Test func refusedSendDiscardsAttachmentFiles() async {
+        // Writer at gateway time, but the manager refuses the submit (e.g. a
+        // takeover landed mid-flight / needs auth). The files we wrote during
+        // materialize must be cleaned up rather than orphaned on disk.
+        let provider = FakeSessionsProvider()
+        provider.writers.insert("s1")
+        provider.sendPromptAccepts = false
+        var sent: [RemoteServerMessage] = []
+        let gw = RemoteSessionGateway(provider: provider) { sent.append($0) }
+        await gw.handle(.sendPrompt(sessionId: "s1", text: "look", attachments: [.init(name: "a.png", mimeType: "image/png", dataBase64: "iVBORw0KGgo=")]))
+        #expect(sent.contains(.promptRejected(sessionId: "s1")))
+        #expect(!provider.writtenAttachmentURLs.isEmpty)
+        for url in provider.writtenAttachmentURLs {
+            #expect(!FileManager.default.fileExists(atPath: url.path))
+        }
     }
 }

--- a/AlasTests/Remote/RemoteSessionGatewayTests.swift
+++ b/AlasTests/Remote/RemoteSessionGatewayTests.swift
@@ -32,13 +32,18 @@ final class FakeSessionsProvider: RemoteSessionsProvider {
         writers.insert(id)
     }
 
+    var sendPromptResultIsAsync = false   // deliver onResult on a later tick (models a late delivery failure)
     func sendPrompt(for id: String, text: String, attachments: [ACPMessage.Attachment], onResult: @escaping @MainActor (Bool) -> Void) {
         let accepted = writers.contains(id) && sendPromptAccepts
         if accepted {
             prompts.append((id, text))
             lastAttachments = attachments
         }
-        onResult(accepted)
+        if sendPromptResultIsAsync {
+            Task { @MainActor in onResult(accepted) }
+        } else {
+            onResult(accepted)
+        }
     }
 
     var writtenAttachmentURLs: [URL] = []
@@ -512,5 +517,26 @@ struct RemoteSessionGatewayTests {
         for url in provider.writtenAttachmentURLs {
             #expect(!FileManager.default.fileExists(atPath: url.path))
         }
+    }
+
+    @Test func lateFailureKeepsAttachmentFiles() async throws {
+        // A LATE (async) delivery failure means sendNow already recorded the
+        // user message referencing these file URIs — the gateway must NOT
+        // delete them (only synchronous refusals, never recorded, are cleaned).
+        let provider = FakeSessionsProvider()
+        provider.writers.insert("s1")
+        provider.sendPromptAccepts = false
+        provider.sendPromptResultIsAsync = true
+        var sent: [RemoteServerMessage] = []
+        let gw = RemoteSessionGateway(provider: provider) { sent.append($0) }
+        await gw.handle(.sendPrompt(sessionId: "s1", text: "look", attachments: [.init(name: "a.png", mimeType: "image/png", dataBase64: "iVBORw0KGgo=")]))
+        try await Task.sleep(nanoseconds: 30_000_000)   // let the async onResult land
+        #expect(sent.contains(.promptRejected(sessionId: "s1")))
+        #expect(!provider.writtenAttachmentURLs.isEmpty)
+        for url in provider.writtenAttachmentURLs {
+            #expect(FileManager.default.fileExists(atPath: url.path))   // kept
+        }
+        // cleanup
+        for url in provider.writtenAttachmentURLs { try? FileManager.default.removeItem(at: url) }
     }
 }

--- a/AlasTests/Remote/RemoteSessionGatewayTests.swift
+++ b/AlasTests/Remote/RemoteSessionGatewayTests.swift
@@ -13,6 +13,10 @@ final class FakeSessionsProvider: RemoteSessionsProvider {
     var prompts: [(id: String, text: String)] = []
     var sendPromptAccepts = true   // simulate the manager refusing a submit (e.g. needs auth)
     var stopped: [String] = []
+    var models: [(id: String, model: String)] = []
+    var modes: [(id: String, mode: String)] = []
+    var autoRuns: [(id: String, enabled: Bool)] = []
+    var configs: [String: RemoteSessionConfig] = [:]
     func sessionSummaries() -> [RemoteSessionSummary] { summaries }
     func session(for id: String) -> ACPSession? { sessions[id] }
     func permissionPolicy(for id: String) -> ACPPermissionPolicy? { policies[id] }
@@ -32,7 +36,12 @@ final class FakeSessionsProvider: RemoteSessionsProvider {
         if accepted { prompts.append((id, text)) }
         onResult(accepted)
     }
+
     func stop(for id: String) { stopped.append(id) }
+    func setModel(for id: String, modelId: String) { models.append((id, modelId)) }
+    func setMode(for id: String, modeId: String) { modes.append((id, modeId)) }
+    func setAutoRun(for id: String, enabled: Bool) { autoRuns.append((id, enabled)) }
+    func sessionConfig(for id: String) -> RemoteSessionConfig? { configs[id] }
 }
 
 #if DEBUG

--- a/AlasTests/Remote/RemoteSessionGatewayTests.swift
+++ b/AlasTests/Remote/RemoteSessionGatewayTests.swift
@@ -492,6 +492,18 @@ struct RemoteSessionGatewayTests {
         #expect(sent.contains(.promptRejected(sessionId: "s1")))
     }
 
+    @Test func renamedNonImageWithImageMimeRejected() async {
+        // Client claims image/png but the bytes aren't a real image — the byte
+        // sniff must reject it rather than trusting the MIME, and write no file.
+        let provider = FakeSessionsProvider()
+        provider.writers.insert("s1")
+        var sent: [RemoteServerMessage] = []
+        let gw = RemoteSessionGateway(provider: provider) { sent.append($0) }
+        await gw.handle(.sendPrompt(sessionId: "s1", text: "x", attachments: [.init(name: "evil.png", mimeType: "image/png", dataBase64: "AAAAAAAAAAA=")]))
+        #expect(sent.contains(.promptRejected(sessionId: "s1")))
+        #expect(provider.writtenAttachmentURLs.isEmpty)
+    }
+
     @Test func validImageAttachmentSends() async {
         let provider = FakeSessionsProvider()
         provider.writers.insert("s1")

--- a/AlasTests/Remote/RemoteSessionGatewayTests.swift
+++ b/AlasTests/Remote/RemoteSessionGatewayTests.swift
@@ -437,4 +437,20 @@ struct RemoteSessionGatewayTests {
         await gw.handle(.subscribe(sessionId: "s1"))
         #expect(sent.contains { if case .sessionConfig = $0 { return true } else { return false } })
     }
+
+    @Test func sessionConfigChangeEmitsUpdate() async throws {
+        let provider = FakeSessionsProvider()
+        let s = try makeSessionWithAgentText("hi")
+        s.availableModels = [.init(id: "opus", name: "Opus", description: nil)]
+        provider.sessions["s1"] = s
+        provider.configs["s1"] = .init(sessionId: "s1", models: [], modes: [], currentModel: nil,
+            currentMode: nil, autoRunEnabled: false, acceptsImages: false)
+        var sent: [RemoteServerMessage] = []
+        let gw = RemoteSessionGateway(provider: provider) { sent.append($0) }
+        await gw.handle(.subscribe(sessionId: "s1"))
+        sent.removeAll()
+        s.currentModel = "opus"                    // mutate config
+        try await Task.sleep(nanoseconds: 50_000_000)
+        #expect(sent.contains { if case .sessionConfig = $0 { return true } else { return false } })
+    }
 }

--- a/AlasTests/Remote/RemoteSessionGatewayTests.swift
+++ b/AlasTests/Remote/RemoteSessionGatewayTests.swift
@@ -492,6 +492,16 @@ struct RemoteSessionGatewayTests {
         #expect(sent.contains(.promptRejected(sessionId: "s1")))
     }
 
+    @Test func imageOnlyUserMessageRendersPlaceholder() {
+        // An image-only prompt (empty text) must not serialize to a blank bubble.
+        let msg = ACPMessage.user(id: UUID(), text: "",
+            attachments: [.init(uri: "file:///tmp/shot.png", name: "shot.png", mimeType: "image/png")])
+        let wire = RemoteSessionGateway.toWire(msg, index: 0)
+        #expect(wire.kind == "user")
+        #expect(wire.text?.contains("shot.png") == true)
+        #expect((wire.text ?? "").isEmpty == false)
+    }
+
     @Test func renamedNonImageWithImageMimeRejected() async {
         // Client claims image/png but the bytes aren't a real image — the byte
         // sniff must reject it rather than trusting the MIME, and write no file.

--- a/AlasTests/Remote/RemoteSessionGatewayTests.swift
+++ b/AlasTests/Remote/RemoteSessionGatewayTests.swift
@@ -410,4 +410,31 @@ struct RemoteSessionGatewayTests {
         }.first
         #expect(drive == true)
     }
+
+    @Test func configVerbsRouteOnlyWhenWriter() async {
+        let provider = FakeSessionsProvider()
+        let gw = RemoteSessionGateway(provider: provider) { _ in }
+        await gw.handle(.setModel(sessionId: "s1", modelId: "opus"))   // not writer
+        await gw.handle(.setAutoRun(sessionId: "s1", enabled: true))
+        #expect(provider.models.isEmpty && provider.autoRuns.isEmpty)
+        provider.writers.insert("s1")
+        await gw.handle(.setModel(sessionId: "s1", modelId: "opus"))
+        await gw.handle(.setMode(sessionId: "s1", modeId: "ask"))
+        await gw.handle(.setAutoRun(sessionId: "s1", enabled: true))
+        #expect(provider.models.map(\.model) == ["opus"])
+        #expect(provider.modes.map(\.mode) == ["ask"])
+        #expect(provider.autoRuns.map(\.enabled) == [true])
+    }
+
+    @Test func subscribeEmitsSessionConfig() async throws {
+        let provider = FakeSessionsProvider()
+        let s = try makeSessionWithAgentText("hi")
+        provider.sessions["s1"] = s
+        provider.configs["s1"] = .init(sessionId: "s1", models: [.init(id: "opus", name: "Opus")],
+            modes: [], currentModel: "opus", currentMode: nil, autoRunEnabled: false, acceptsImages: true)
+        var sent: [RemoteServerMessage] = []
+        let gw = RemoteSessionGateway(provider: provider) { sent.append($0) }
+        await gw.handle(.subscribe(sessionId: "s1"))
+        #expect(sent.contains { if case .sessionConfig = $0 { return true } else { return false } })
+    }
 }

--- a/AlasTests/Remote/RemoteSessionGatewayTests.swift
+++ b/AlasTests/Remote/RemoteSessionGatewayTests.swift
@@ -11,6 +11,7 @@ final class FakeSessionsProvider: RemoteSessionsProvider {
     var writers: Set<String> = []
     var tookOver: [String] = []
     var prompts: [(id: String, text: String)] = []
+    var lastAttachments: [ACPMessage.Attachment] = []
     var sendPromptAccepts = true   // simulate the manager refusing a submit (e.g. needs auth)
     var stopped: [String] = []
     var models: [(id: String, model: String)] = []
@@ -31,10 +32,20 @@ final class FakeSessionsProvider: RemoteSessionsProvider {
         writers.insert(id)
     }
 
-    func sendPrompt(for id: String, text: String, onResult: @escaping @MainActor (Bool) -> Void) {
+    func sendPrompt(for id: String, text: String, attachments: [ACPMessage.Attachment], onResult: @escaping @MainActor (Bool) -> Void) {
         let accepted = writers.contains(id) && sendPromptAccepts
-        if accepted { prompts.append((id, text)) }
+        if accepted {
+            prompts.append((id, text))
+            lastAttachments = attachments
+        }
         onResult(accepted)
+    }
+
+    func writeAttachment(_ data: Data, mimeType: String, name: String?, for id: String) -> URL? {
+        let ext = mimeType == "image/png" ? "png" : (mimeType == "image/jpeg" ? "jpg" : "img")
+        let url = FileManager.default.temporaryDirectory.appendingPathComponent("\(UUID()).\(ext)")
+        do { try data.write(to: url) } catch { return nil }
+        return url
     }
 
     func stop(for id: String) { stopped.append(id) }
@@ -345,10 +356,10 @@ struct RemoteSessionGatewayTests {
     @Test func sendPromptRoutesOnlyWhenWriter() async {
         let provider = FakeSessionsProvider()
         let gw = RemoteSessionGateway(provider: provider) { _ in }
-        await gw.handle(.sendPrompt(sessionId: "s1", text: "hi")) // not writer → ignored
+        await gw.handle(.sendPrompt(sessionId: "s1", text: "hi", attachments: [])) // not writer → ignored
         #expect(provider.prompts.isEmpty)
         provider.writers.insert("s1")
-        await gw.handle(.sendPrompt(sessionId: "s1", text: "hi"))
+        await gw.handle(.sendPrompt(sessionId: "s1", text: "hi", attachments: []))
         #expect(provider.prompts.map(\.text) == ["hi"])
     }
 
@@ -356,9 +367,9 @@ struct RemoteSessionGatewayTests {
         let provider = FakeSessionsProvider()
         provider.writers.insert("s1")
         let gw = RemoteSessionGateway(provider: provider) { _ in }
-        await gw.handle(.sendPrompt(sessionId: "s1", text: "   \n  ")) // blank → ignored
+        await gw.handle(.sendPrompt(sessionId: "s1", text: "   \n  ", attachments: [])) // blank → ignored
         #expect(provider.prompts.isEmpty)
-        await gw.handle(.sendPrompt(sessionId: "s1", text: "  hi  ")) // trimmed before forwarding
+        await gw.handle(.sendPrompt(sessionId: "s1", text: "  hi  ", attachments: [])) // trimmed before forwarding
         #expect(provider.prompts.map(\.text) == ["hi"])
     }
 
@@ -368,21 +379,21 @@ struct RemoteSessionGatewayTests {
         let provider = FakeSessionsProvider()
         var sent: [RemoteServerMessage] = []
         let gw = RemoteSessionGateway(provider: provider) { sent.append($0) }
-        await gw.handle(.sendPrompt(sessionId: "s1", text: "hi")) // not writer
+        await gw.handle(.sendPrompt(sessionId: "s1", text: "hi", attachments: [])) // not writer
         #expect(provider.prompts.isEmpty)
         #expect(sent.contains(.promptRejected(sessionId: "s1")))
         // When we ARE the writer and the manager accepts, the prompt routes
         // and no rejection is sent.
         sent.removeAll()
         provider.writers.insert("s1")
-        await gw.handle(.sendPrompt(sessionId: "s1", text: "hi"))
+        await gw.handle(.sendPrompt(sessionId: "s1", text: "hi", attachments: []))
         #expect(provider.prompts.map(\.text) == ["hi"])
         #expect(!sent.contains { if case .promptRejected = $0 { return true } else { return false } })
         // Writer, but the manager refuses the submit (e.g. needs auth) — the
         // client must still be told so it can restore the text.
         sent.removeAll()
         provider.sendPromptAccepts = false
-        await gw.handle(.sendPrompt(sessionId: "s1", text: "later"))
+        await gw.handle(.sendPrompt(sessionId: "s1", text: "later", attachments: []))
         #expect(sent.contains(.promptRejected(sessionId: "s1")))
     }
 
@@ -452,5 +463,35 @@ struct RemoteSessionGatewayTests {
         s.currentModel = "opus"                    // mutate config
         try await Task.sleep(nanoseconds: 50_000_000)
         #expect(sent.contains { if case .sessionConfig = $0 { return true } else { return false } })
+    }
+
+    @Test func oversizeAttachmentRejected() async {
+        let provider = FakeSessionsProvider()
+        provider.writers.insert("s1")
+        var sent: [RemoteServerMessage] = []
+        let gw = RemoteSessionGateway(provider: provider) { sent.append($0) }
+        let big = String(repeating: "A", count: 14_000_000)   // ~10.5MB decoded > cap
+        await gw.handle(.sendPrompt(sessionId: "s1", text: "x", attachments: [.init(name: nil, mimeType: "image/png", dataBase64: big)]))
+        #expect(provider.lastAttachments.isEmpty)
+        #expect(sent.contains(.promptRejected(sessionId: "s1")))
+    }
+
+    @Test func nonImageAttachmentRejected() async {
+        let provider = FakeSessionsProvider()
+        provider.writers.insert("s1")
+        var sent: [RemoteServerMessage] = []
+        let gw = RemoteSessionGateway(provider: provider) { sent.append($0) }
+        await gw.handle(.sendPrompt(sessionId: "s1", text: "x", attachments: [.init(name: "f.txt", mimeType: "text/plain", dataBase64: "AAAA")]))
+        #expect(sent.contains(.promptRejected(sessionId: "s1")))
+    }
+
+    @Test func validImageAttachmentSends() async {
+        let provider = FakeSessionsProvider()
+        provider.writers.insert("s1")
+        var sent: [RemoteServerMessage] = []
+        let gw = RemoteSessionGateway(provider: provider) { sent.append($0) }
+        await gw.handle(.sendPrompt(sessionId: "s1", text: "look", attachments: [.init(name: "a.png", mimeType: "image/png", dataBase64: "iVBORw0KGgo=")]))
+        #expect(provider.lastAttachments.count == 1)
+        #expect(!sent.contains { if case .promptRejected = $0 { return true } else { return false } })
     }
 }

--- a/AlasTests/Remote/RemoteSessionGatewayTests.swift
+++ b/AlasTests/Remote/RemoteSessionGatewayTests.swift
@@ -502,6 +502,21 @@ struct RemoteSessionGatewayTests {
         #expect((wire.text ?? "").isEmpty == false)
     }
 
+    @Test func tooManyAttachmentsRejected() async {
+        // Count cap (parity with ACPComposer.maxImagesPerMessage) — a single
+        // prompt can't write an unbounded number of tiny files.
+        let provider = FakeSessionsProvider()
+        provider.writers.insert("s1")
+        var sent: [RemoteServerMessage] = []
+        let gw = RemoteSessionGateway(provider: provider) { sent.append($0) }
+        let many = (0..<(RemoteSessionGateway.maxAttachmentCount + 1)).map { _ in
+            RemoteAttachment(name: "a.png", mimeType: "image/png", dataBase64: "iVBORw0KGgo=")
+        }
+        await gw.handle(.sendPrompt(sessionId: "s1", text: "x", attachments: many))
+        #expect(sent.contains(.promptRejected(sessionId: "s1")))
+        #expect(provider.writtenAttachmentURLs.isEmpty)   // rejected before any write
+    }
+
     @Test func renamedNonImageWithImageMimeRejected() async {
         // Client claims image/png but the bytes aren't a real image — the byte
         // sniff must reject it rather than trusting the MIME, and write no file.

--- a/AlasTests/Remote/WebSocketFrameTests.swift
+++ b/AlasTests/Remote/WebSocketFrameTests.swift
@@ -3,6 +3,45 @@ import Foundation
 @testable import Alas
 
 struct WebSocketFrameTests {
+    @Test func decodeExposesFinBit() throws {
+        // FIN=0 text frame (byte0 0x01), masked, "hi".
+        var notFinal = Data([0x01, 0x82, 1, 2, 3, 4, 0x68 ^ 1, 0x69 ^ 2])
+        #expect(try WebSocketFrame.decode(from: &notFinal)?.fin == false)
+        var final = Data([0x81, 0x82, 1, 2, 3, 4, 0x68 ^ 1, 0x69 ^ 2])
+        #expect(try WebSocketFrame.decode(from: &final)?.fin == true)
+    }
+
+    @Test func reassemblerPassesCompleteMessage() {
+        var r = WebSocketReassembler()
+        #expect(r.accept(.init(opcode: .text, payload: Data("hi".utf8), fin: true)) == .message(Data("hi".utf8)))
+    }
+
+    @Test func reassemblerJoinsFragments() {
+        var r = WebSocketReassembler()
+        #expect(r.accept(.init(opcode: .text, payload: Data("he".utf8), fin: false)) == .incomplete)
+        #expect(r.accept(.init(opcode: .continuation, payload: Data("ll".utf8), fin: false)) == .incomplete)
+        #expect(r.accept(.init(opcode: .continuation, payload: Data("o".utf8), fin: true)) == .message(Data("hello".utf8)))
+        // Reassembler is reusable for the next message after completing one.
+        #expect(r.accept(.init(opcode: .text, payload: Data("x".utf8), fin: true)) == .message(Data("x".utf8)))
+    }
+
+    @Test func reassemblerRejectsContinuationWithoutStart() {
+        var r = WebSocketReassembler()
+        #expect(r.accept(.init(opcode: .continuation, payload: Data(), fin: true)) == .violation)
+    }
+
+    @Test func reassemblerRejectsNewMessageMidFragment() {
+        var r = WebSocketReassembler()
+        _ = r.accept(.init(opcode: .text, payload: Data("a".utf8), fin: false))
+        #expect(r.accept(.init(opcode: .text, payload: Data("b".utf8), fin: true)) == .violation)
+    }
+
+    @Test func reassemblerEnforcesMaxBytes() {
+        var r = WebSocketReassembler(maxBytes: 3)
+        #expect(r.accept(.init(opcode: .text, payload: Data("ab".utf8), fin: false)) == .incomplete)
+        #expect(r.accept(.init(opcode: .continuation, payload: Data("cd".utf8), fin: true)) == .violation)
+    }
+
     @Test func encodesShortTextFrameUnmasked() {
         let out = WebSocketFrame.encode(opcode: .text, payload: Data("hi".utf8))
         // FIN+text=0x81, len=2, "hi"


### PR DESCRIPTION
## Summary

Phase 3 of the remote control feature. Phase 1 (#474) let a paired phone **watch** ACP sessions; Phase 2 (#476) made it **drive** (take over, send, stop). This brings the remote composer to **parity with the native one**:

- **A — Config controls:** model picker, mode picker, and auto-run toggle, behind a ⚙ sheet. New writer-gated wire verbs `setModel`/`setMode`/`setAutoRun` route gateway → `RemoteSessionsProvider` → `AppState` → `ACPSessionManager` (optimistic update + persist + agent RPC, or a pending-config buffered and applied after a post-takeover `attach`). A new `sessionConfig` server message projects model/mode/auto-run/`acceptsImages`, sent on subscribe and re-emitted (coalesced + deduped) when config changes on the Mac.
- **B — Image attachments:** `sendPrompt` carries `attachments: [RemoteAttachment]` (base64, images only, ~10 MB/message). The gateway writer-gates, validates an `image/*` mimeType allowlist + cumulative cap, decodes, writes files (UUID names) under the existing `acp-attachments/` dir, and feeds the existing `submit → hydrate` path. WS payload cap raised to 16 MB. Files are rolled back / discarded if a batch is rejected.
- **C — Auto-takeover:** any write action (Send / Stop / config change) implicitly takes over first when you're not the writer — no new verb needed (ordered messages + synchronous lease seize). The web composer is now always visible with a compact "Take over" pill, ⚙ config sheet, and 📎 removable image chips.

All write paths stay gated on the store-backed `isWriter` from Phase 2.

## Test plan

- `AlasTests/Remote/*` — **85 tests / 6 suites pass.** New coverage: config verb routing + writer-gating, `sessionConfig` round-trip + emit-on-subscribe + live-change, attachment round-trip, oversize/non-image rejection, valid-image send, and attachment-file cleanup on rejection; manager config setters (writer-gate + optimistic update) and `sendPrompt` lease re-check.
- `swiftformat Alas AlasTests --lint` clean.
- Manual E2E on device: switch model/mode (Mac reflects it), toggle auto-run, attach + send an image, and confirm auto-takeover fires from a viewing (non-writer) state.

Built via subagent-driven development with per-task spec + code-quality reviews and a final holistic review.