### PR TITLE
fix(acp): queued message actions

### DIFF
--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -130,6 +130,7 @@
 		22FDE2FB05952993DA2D0EB7 /* WorkingTreeSectionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 866CFEB75B7F754485C6BE77 /* WorkingTreeSectionView.swift */; };
 		23013D3D2538AC2D1BD3403D /* ChangesTabView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C682FF74C86B77BDCF46CF25 /* ChangesTabView.swift */; };
 		238BBB5FC59949CE6ABAFBEF /* ACPCodeBlockHighlighterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 81773A01826A91080F5A2E95 /* ACPCodeBlockHighlighterTests.swift */; };
+		23F92214B30096D070419921 /* ACPQueuedBubbleActionMetricsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5733BF1C52BA0FCFB2724D57 /* ACPQueuedBubbleActionMetricsTests.swift */; };
 		2434A66A45EDF2609BA9F1D3 /* session-update-config-options.json in Resources */ = {isa = PBXBuildFile; fileRef = 97DA8F50DDCDAA15CCEA2004 /* session-update-config-options.json */; };
 		24F8EA15B87C38C319B8A66B /* AlasField.swift in Sources */ = {isa = PBXBuildFile; fileRef = D9E6D61B213F3378243B4A26 /* AlasField.swift */; };
 		250F0E2CB26CC16D2FFDB9DD /* DiffSelectableTextView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 23FECFF5D8673A3A8E7A1431 /* DiffSelectableTextView.swift */; };
@@ -1306,6 +1307,7 @@
 		56780EE994E2CA14A3ABBA7B /* MergeActionGutter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MergeActionGutter.swift; sourceTree = "<group>"; };
 		56BF141F589820AA91674BD0 /* TreeSitterJavaScript */ = {isa = PBXFileReference; lastKnownFileType = folder; name = TreeSitterJavaScript; path = ThirdParty/TreeSitterJavaScript; sourceTree = SOURCE_ROOT; };
 		56D1AC9E1E00C3C5C234382C /* TouchTargetSmokeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TouchTargetSmokeTests.swift; sourceTree = "<group>"; };
+		5733BF1C52BA0FCFB2724D57 /* ACPQueuedBubbleActionMetricsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPQueuedBubbleActionMetricsTests.swift; sourceTree = "<group>"; };
 		576619C2726DFDE8F627AE19 /* CommitsAheadTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommitsAheadTests.swift; sourceTree = "<group>"; };
 		57713D7143CFD53124E0523F /* AlasHookCommand.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlasHookCommand.swift; sourceTree = "<group>"; };
 		57B7225443DF69C32D25338D /* SpacesPane.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpacesPane.swift; sourceTree = "<group>"; };
@@ -2665,6 +2667,7 @@
 				80BAFADCDC3E349AC3DBDDEA /* ACPPlanPillStateTests.swift */,
 				96A230290E0029D45CA1B907 /* ACPPlanSidebarVisibilityTests.swift */,
 				44ACE3DEC81C465524111058 /* ACPQuestionPromptTests.swift */,
+				5733BF1C52BA0FCFB2724D57 /* ACPQueuedBubbleActionMetricsTests.swift */,
 				98A7F35818C95A567DDA586A /* ACPSelectChipTests.swift */,
 				0AB6FA9F258818E8B464CB0A /* ACPSetupNudgeBannerModeTests.swift */,
 				EDABAB5EEE4C15A78B5429E6 /* ComposerActionTests.swift */,
@@ -4411,6 +4414,7 @@
 				EA6EFDDEAE3FF9D878824EDC /* ACPProcessLivenessTests.swift in Sources */,
 				86759BF3DE64FFAA4FE98822 /* ACPPromptCapabilitiesTests.swift in Sources */,
 				1A56FAF2DE8FFB95272EE948 /* ACPQuestionPromptTests.swift in Sources */,
+				23F92214B30096D070419921 /* ACPQueuedBubbleActionMetricsTests.swift in Sources */,
 				A383F1C9B0B00B2805576209 /* ACPScrollDirectionClassifierTests.swift in Sources */,
 				702EC5CB48F37FC8B6F27FA4 /* ACPSelectChipTests.swift in Sources */,
 				9159297D87B2AA9B7A03F072 /* ACPSessionAgentStateTests.swift in Sources */,

--- a/Alas/Sources/ACP/Session/ACPSession.swift
+++ b/Alas/Sources/ACP/Session/ACPSession.swift
@@ -407,11 +407,19 @@ final class ACPSession: ObservableObject, Identifiable {
         guard let idx = queue.firstIndex(where: { $0.id == id }) else { return false }
         guard queue[idx].status == .pending else { return false }
 
+        let protectedPrefixCount = (queue.first?.status == .sending) ? 1 : 0
+        for bypassedIndex in protectedPrefixCount ..< idx {
+            if queue[bypassedIndex].status == .pending,
+               queue[bypassedIndex].lastError != nil {
+                queue[bypassedIndex].transcriptRecorded = false
+            }
+        }
+
         var item = queue.remove(at: idx)
         item.status = .pending
         item.lastError = nil
 
-        let insertAt = (queue.first?.status == .sending) ? 1 : 0
+        let insertAt = protectedPrefixCount
         queue.insert(item, at: min(insertAt, queue.count))
         return true
     }

--- a/Alas/Sources/ACP/Session/ACPSession.swift
+++ b/Alas/Sources/ACP/Session/ACPSession.swift
@@ -398,6 +398,24 @@ final class ACPSession: ObservableObject, Identifiable {
         queue.insert(item, at: min(dst, queue.count))
     }
 
+    /// Promote a pending queued item to the next drainable position and clear
+    /// any previous send error. If a `.sending` head is already in-flight, the
+    /// forced item is placed immediately behind it so completion can pop the
+    /// current head safely.
+    @discardableResult
+    func forceQueueItem(id: UUID) -> Bool {
+        guard let idx = queue.firstIndex(where: { $0.id == id }) else { return false }
+        guard queue[idx].status == .pending else { return false }
+
+        var item = queue.remove(at: idx)
+        item.status = .pending
+        item.lastError = nil
+
+        let insertAt = (queue.first?.status == .sending) ? 1 : 0
+        queue.insert(item, at: min(insertAt, queue.count))
+        return true
+    }
+
     /// Edit the prompt blocks of a `.pending` item. No-op for `.sending`.
     /// Clears any captured draft — the old segments no longer describe the
     /// new blocks, so a later edit falls back to the heuristic on the

--- a/Alas/Sources/ACP/Session/ACPSession.swift
+++ b/Alas/Sources/ACP/Session/ACPSession.swift
@@ -81,6 +81,11 @@ final class ACPSession: ObservableObject, Identifiable {
     /// persisted session fields instead.
     @Published var firstRunConnectingPhase: ACPFirstRunConnectingPhase?
 
+    /// Runtime-only marker for a forced queue item parked behind the current
+    /// `.sending` head. If that head fails, it moves behind this item so the
+    /// explicit force-send remains next.
+    private var forceSendAfterSendingHeadId: UUID?
+
     var imageInputSupported: Bool { promptCapabilities.image }
     var embeddedContextSupported: Bool { promptCapabilities.embeddedContext }
 
@@ -369,6 +374,9 @@ final class ACPSession: ObservableObject, Identifiable {
     func removeFromQueue(id: UUID) {
         guard let idx = queue.firstIndex(where: { $0.id == id }) else { return }
         if queue[idx].status == .sending { return }
+        if forceSendAfterSendingHeadId == id {
+            forceSendAfterSendingHeadId = nil
+        }
         queue.remove(at: idx)
     }
 
@@ -382,6 +390,9 @@ final class ACPSession: ObservableObject, Identifiable {
     func takeForEditing(id: UUID) -> ACPComposerDraft? {
         guard let idx = queue.firstIndex(where: { $0.id == id }) else { return nil }
         guard queue[idx].status == .pending else { return nil }
+        if forceSendAfterSendingHeadId == id {
+            forceSendAfterSendingHeadId = nil
+        }
         let item = queue.remove(at: idx)
         return item.restorableDraft
     }
@@ -421,6 +432,7 @@ final class ACPSession: ObservableObject, Identifiable {
 
         let insertAt = protectedPrefixCount
         queue.insert(item, at: min(insertAt, queue.count))
+        forceSendAfterSendingHeadId = protectedPrefixCount == 1 ? item.id : nil
         return true
     }
 
@@ -446,6 +458,7 @@ final class ACPSession: ObservableObject, Identifiable {
     func clearPendingQueue() -> [QueuedPrompt] {
         let snapshot = queue.filter { $0.status == .pending }
         queue.removeAll { $0.status == .pending }
+        forceSendAfterSendingHeadId = nil
         return snapshot
     }
 
@@ -484,7 +497,11 @@ final class ACPSession: ObservableObject, Identifiable {
     @discardableResult
     func popQueueHead() -> QueuedPrompt? {
         guard !queue.isEmpty, queue[0].status == .sending else { return nil }
-        return queue.removeFirst()
+        let item = queue.removeFirst()
+        if forceSendAfterSendingHeadId == item.id {
+            forceSendAfterSendingHeadId = nil
+        }
+        return item
     }
 
     /// Roll the `.sending` head back to `.pending` with an error message.
@@ -492,8 +509,17 @@ final class ACPSession: ObservableObject, Identifiable {
     /// the user sees "Retry" on the bubble.
     func setQueueHeadError(_ message: String) {
         guard !queue.isEmpty else { return }
-        queue[0].status = .pending
-        queue[0].lastError = message
+        var item = queue.removeFirst()
+        item.status = .pending
+        item.lastError = message
+
+        if let forcedId = forceSendAfterSendingHeadId,
+           let forcedIndex = queue.firstIndex(where: { $0.id == forcedId }) {
+            queue.insert(item, at: min(forcedIndex + 1, queue.count))
+        } else {
+            queue.insert(item, at: 0)
+        }
+        forceSendAfterSendingHeadId = nil
     }
 
     /// Replace the queue wholesale with a normalized restore set. Called
@@ -501,6 +527,7 @@ final class ACPSession: ObservableObject, Identifiable {
     /// store. `.sending` items get flipped to `.pending` here so the
     /// flusher re-attempts on next idle.
     func restoreQueue(_ items: [QueuedPrompt]) {
+        forceSendAfterSendingHeadId = nil
         queue = items.map { $0.normalizedAfterRestore() }
     }
 

--- a/Alas/Sources/ACP/UI/ACPMessageList.swift
+++ b/Alas/Sources/ACP/UI/ACPMessageList.swift
@@ -11,6 +11,7 @@ struct ACPMessageList: View {
     /// Callbacks invoked by the pending bubbles + header. The host wires
     /// these to the runner.
     let onQueueEdit: (QueuedPrompt) -> Void
+    let onQueueForceSend: (UUID) -> Void
     let onQueueRemove: (UUID) -> Void
     let onQueueRetry: (UUID) -> Void
     let onQueueReorder: (Int, Int) -> Void
@@ -134,6 +135,7 @@ struct ACPMessageList: View {
                             if item.status != .sending {
                                 ACPQueuedBubble(
                                     item: item,
+                                    onForceSend: { onQueueForceSend(item.id) },
                                     onEdit: { onQueueEdit(item) },
                                     onRemove: { onQueueRemove(item.id) },
                                     onRetry: { onQueueRetry(item.id) }

--- a/Alas/Sources/ACP/UI/ACPQueuedBubble.swift
+++ b/Alas/Sources/ACP/UI/ACPQueuedBubble.swift
@@ -3,11 +3,12 @@ import SwiftUI
 
 /// A single queued-item bubble, rendered below the transcript. Right-
 /// aligned (same as the user message bubble) but with a dashed border,
-/// reduced opacity, and a "Queued" pill. Hover reveals edit / remove
-/// affordances. Items in `.sending` lose those affordances and gain a
-/// spinner-edged border.
+/// reduced opacity, and a "Queued" pill. Hover reveals send / edit / remove
+/// affordances without changing their reserved layout. Items in `.sending`
+/// lose those affordances and gain a spinner-edged border.
 struct ACPQueuedBubble: View {
     let item: QueuedPrompt
+    let onForceSend: () -> Void
     let onEdit: () -> Void
     let onRemove: () -> Void
     let onRetry: () -> Void
@@ -19,22 +20,25 @@ struct ACPQueuedBubble: View {
         HStack(alignment: .top, spacing: 6) {
             Spacer(minLength: 40)
             VStack(alignment: .trailing, spacing: 4) {
-                HStack(spacing: 6) {
-                    if item.status == .sending {
-                        ProgressView().scaleEffect(0.45).frame(width: 12, height: 12)
+                HStack(alignment: .center, spacing: 6) {
+                    HStack(spacing: 6) {
+                        if item.status == .sending {
+                            ProgressView().scaleEffect(0.45).frame(width: 12, height: 12)
+                        }
+                        Text(item.status == .sending ? "Sending" : "Queued")
+                            .font(.system(size: 9, weight: .semibold))
+                            .tracking(0.4)
+                            .textCase(.uppercase)
+                            .foregroundStyle(theme.color("fg-faint"))
+                        if let err = item.lastError {
+                            Text("· \(err)")
+                                .font(.system(size: 9, weight: .medium))
+                                .foregroundStyle(theme.color("del"))
+                                .lineLimit(1)
+                        }
                     }
-                    Text(item.status == .sending ? "Sending" : "Queued")
-                        .font(.system(size: 9, weight: .semibold))
-                        .tracking(0.4)
-                        .textCase(.uppercase)
-                        .foregroundStyle(theme.color("fg-faint"))
-                    if let err = item.lastError {
-                        Text("· \(err)")
-                            .font(.system(size: 9, weight: .medium))
-                            .foregroundStyle(theme.color("del"))
-                            .lineLimit(1)
-                    }
-                    if isHovering, item.status == .pending {
+                    .lineLimit(1)
+                    if item.status == .pending {
                         actionsRow
                     }
                 }
@@ -89,42 +93,87 @@ struct ACPQueuedBubble: View {
 
     private var actionsRow: some View {
         HStack(spacing: 4) {
-            if item.lastError != nil {
-                Button(action: onRetry) {
-                    Image(systemName: "arrow.clockwise")
-                        .font(.system(size: 10, weight: .semibold))
-                        .foregroundStyle(theme.color("warn"))
-                }
-                .buttonStyle(.plain)
-                .help("Retry")
-            }
-            Button(action: onEdit) {
-                Image(systemName: "pencil")
-                    .font(.system(size: 10, weight: .semibold))
-                    .foregroundStyle(theme.color("fg-muted"))
-            }
-            .buttonStyle(.plain)
-            .help("Edit")
-            Button(action: onRemove) {
-                Image(systemName: "xmark")
-                    .font(.system(size: 10, weight: .semibold))
-                    .foregroundStyle(theme.color("fg-muted"))
-            }
-            .buttonStyle(.plain)
-            .help("Remove from queue")
+            actionButton(
+                systemName: "paperplane.fill",
+                foreground: theme.color("accent"),
+                help: "Send now",
+                action: onForceSend
+            )
+            actionButton(
+                systemName: "arrow.clockwise",
+                foreground: theme.color("warn"),
+                help: "Retry",
+                action: onRetry
+            )
+            .opacity(item.lastError == nil ? 0 : 1)
+            .allowsHitTesting(item.lastError != nil)
+            .accessibilityHidden(item.lastError == nil)
+            actionButton(
+                systemName: "pencil",
+                foreground: theme.color("fg-muted"),
+                help: "Edit",
+                action: onEdit
+            )
+            actionButton(
+                systemName: "xmark",
+                foreground: theme.color("fg-muted"),
+                help: "Remove from queue",
+                action: onRemove
+            )
         }
+        .frame(width: ACPQueuedBubbleActionMetrics.reservedWidth, alignment: .trailing)
+        .opacity(actionsVisible ? 1 : 0)
+        .allowsHitTesting(actionsVisible)
+        .accessibilityHidden(!actionsVisible)
     }
 
+    private var actionsVisible: Bool {
+        isHovering && item.status == .pending
+    }
+
+    private func actionButton(
+        systemName: String,
+        foreground: Color,
+        help: String,
+        action: @escaping () -> Void
+    ) -> some View {
+        Button(action: action) {
+            Image(systemName: systemName)
+                .font(.system(size: 10, weight: .semibold))
+                .foregroundStyle(foreground)
+                .frame(
+                    width: ACPQueuedBubbleActionMetrics.buttonSize,
+                    height: ACPQueuedBubbleActionMetrics.buttonSize
+                )
+                .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+        .help(help)
+    }
+}
+
+enum ACPQueuedBubbleActionMetrics {
+    static let buttonSize: CGFloat = 16
+    static let buttonSpacing: CGFloat = 4
+    static let reservedButtonSlots = 4
+
+    static var reservedWidth: CGFloat {
+        CGFloat(reservedButtonSlots) * buttonSize
+            + CGFloat(reservedButtonSlots - 1) * buttonSpacing
+    }
+}
+
+private extension ACPQueuedBubble {
     /// Staged file URLs for the queued prompt's image blocks, so an image-only
     /// queued item still shows a thumbnail (its text preview is empty).
-    private var imageURLs: [URL] {
+    var imageURLs: [URL] {
         item.blocks.compactMap { block in
             if case .image(_, let uri, _) = block, let uri { return URL(string: uri) }
             return nil
         }
     }
 
-    private static func textPreview(of blocks: [ACPContentBlock]) -> String {
+    static func textPreview(of blocks: [ACPContentBlock]) -> String {
         blocks.compactMap { b -> String? in
             if case .text(let s) = b { return s }
             return nil

--- a/Alas/Sources/ACP/UI/ACPTabView.swift
+++ b/Alas/Sources/ACP/UI/ACPTabView.swift
@@ -250,6 +250,11 @@ private struct ACPSessionView: View {
                                     // that was waiting behind a `lastError` head.
                                     manager.runners[sessionId]?.flushQueueIfIdle()
                                 },
+                                onQueueForceSend: isMirror ? { _ in } : { id in
+                                    guard session.forceQueueItem(id: id) else { return }
+                                    manager.persistQueue(for: session)
+                                    manager.runners[sessionId]?.flushQueueIfIdle()
+                                },
                                 onQueueRemove: isMirror ? { _ in } : { id in
                                     session.removeFromQueue(id: id)
                                     manager.persistQueue(for: session)

--- a/AlasTests/ACP/Session/ACPSessionQueueAPITests.swift
+++ b/AlasTests/ACP/Session/ACPSessionQueueAPITests.swift
@@ -55,6 +55,68 @@ struct ACPSessionQueueAPITests {
         #expect(s.queue[0].blocks == [.text("a")])
     }
 
+    @Test("forceQueueItem promotes a pending tail item to the head")
+    func forceQueueItemPromotesPendingTail() {
+        let s = mkSession()
+        s.enqueue(blocks: [.text("a")])
+        s.enqueue(blocks: [.text("b")])
+        let id = s.queue[1].id
+
+        #expect(s.forceQueueItem(id: id))
+        #expect(s.queue.map { $0.blocks } == [[.text("b")], [.text("a")]])
+        #expect(s.queue[0].status == .pending)
+    }
+
+    @Test("forceQueueItem clears a previous queue error")
+    func forceQueueItemClearsError() {
+        let s = mkSession()
+        s.enqueue(blocks: [.text("a")])
+        s.queue[0].lastError = "network"
+        let id = s.queue[0].id
+
+        #expect(s.forceQueueItem(id: id))
+        #expect(s.queue[0].id == id)
+        #expect(s.queue[0].lastError == nil)
+        #expect(s.queue[0].status == .pending)
+    }
+
+    @Test("forceQueueItem refuses a .sending item")
+    func forceQueueItemRefusesSending() {
+        let s = mkSession()
+        s.enqueue(blocks: [.text("in-flight")])
+        s.enqueue(blocks: [.text("next")])
+        s.markQueueHeadSending()
+        let id = s.queue[0].id
+
+        #expect(!s.forceQueueItem(id: id))
+        #expect(s.queue.map { $0.blocks } == [[.text("in-flight")], [.text("next")]])
+        #expect(s.queue[0].status == .sending)
+    }
+
+    @Test("forceQueueItem inserts after a .sending head")
+    func forceQueueItemInsertsAfterSendingHead() {
+        let s = mkSession()
+        s.enqueue(blocks: [.text("in-flight")])
+        s.enqueue(blocks: [.text("a")])
+        s.enqueue(blocks: [.text("b")])
+        s.markQueueHeadSending()
+        let id = s.queue[2].id
+
+        #expect(s.forceQueueItem(id: id))
+        #expect(s.queue.map { $0.blocks } == [[.text("in-flight")], [.text("b")], [.text("a")]])
+        #expect(s.queue[0].status == .sending)
+        #expect(s.queue[1].status == .pending)
+    }
+
+    @Test("forceQueueItem returns false for an unknown id")
+    func forceQueueItemUnknown() {
+        let s = mkSession()
+        s.enqueue(blocks: [.text("a")])
+
+        #expect(!s.forceQueueItem(id: UUID()))
+        #expect(s.queue.map { $0.blocks } == [[.text("a")]])
+    }
+
     @Test("clearPendingQueue() removes all .pending items but leaves .sending head")
     func clearPendingKeepsSending() {
         let s = mkSession()

--- a/AlasTests/ACP/Session/ACPSessionQueueAPITests.swift
+++ b/AlasTests/ACP/Session/ACPSessionQueueAPITests.swift
@@ -108,6 +108,41 @@ struct ACPSessionQueueAPITests {
         #expect(s.queue[1].status == .pending)
     }
 
+    @Test("setQueueHeadError keeps a forced item ahead of a failed in-flight head")
+    func setQueueHeadErrorKeepsForcedItemAheadOfFailedHead() {
+        let s = mkSession()
+        s.enqueue(blocks: [.text("in-flight")])
+        s.enqueue(blocks: [.text("a")])
+        s.enqueue(blocks: [.text("forced")])
+        s.markQueueHeadSending()
+        let id = s.queue[2].id
+
+        #expect(s.forceQueueItem(id: id))
+        s.setQueueHeadError("network")
+
+        #expect(s.queue.map { $0.blocks } == [[.text("forced")], [.text("in-flight")], [.text("a")]])
+        #expect(s.queue[0].lastError == nil)
+        #expect(s.queue[1].lastError == "network")
+        #expect(s.queue[1].status == .pending)
+    }
+
+    @Test("setQueueHeadError leaves failed head first when the forced item was removed")
+    func setQueueHeadErrorFallsBackWhenForcedItemRemoved() {
+        let s = mkSession()
+        s.enqueue(blocks: [.text("in-flight")])
+        s.enqueue(blocks: [.text("a")])
+        s.enqueue(blocks: [.text("forced")])
+        s.markQueueHeadSending()
+        let id = s.queue[2].id
+
+        #expect(s.forceQueueItem(id: id))
+        s.removeFromQueue(id: id)
+        s.setQueueHeadError("network")
+
+        #expect(s.queue.map { $0.blocks } == [[.text("in-flight")], [.text("a")]])
+        #expect(s.queue[0].lastError == "network")
+    }
+
     @Test("forceQueueItem resets recorded failed prompts it bypasses")
     func forceQueueItemResetsBypassedRecordedFailures() {
         let s = mkSession()

--- a/AlasTests/ACP/Session/ACPSessionQueueAPITests.swift
+++ b/AlasTests/ACP/Session/ACPSessionQueueAPITests.swift
@@ -108,6 +108,42 @@ struct ACPSessionQueueAPITests {
         #expect(s.queue[1].status == .pending)
     }
 
+    @Test("forceQueueItem resets recorded failed prompts it bypasses")
+    func forceQueueItemResetsBypassedRecordedFailures() {
+        let s = mkSession()
+        s.enqueue(blocks: [.text("failed")])
+        s.enqueue(blocks: [.text("clean")])
+        s.enqueue(blocks: [.text("forced")])
+        s.queue[0].lastError = "network"
+        s.queue[0].transcriptRecorded = true
+        s.queue[1].transcriptRecorded = true
+        let id = s.queue[2].id
+
+        #expect(s.forceQueueItem(id: id))
+        #expect(s.queue.map { $0.blocks } == [[.text("forced")], [.text("failed")], [.text("clean")]])
+        #expect(s.queue[1].lastError == "network")
+        #expect(s.queue[1].transcriptRecorded == false)
+        #expect(s.queue[2].transcriptRecorded == true)
+    }
+
+    @Test("forceQueueItem keeps sending head recorded when bypassing failed pending prompt")
+    func forceQueueItemKeepsSendingHeadRecorded() {
+        let s = mkSession()
+        s.enqueue(blocks: [.text("in-flight")])
+        s.enqueue(blocks: [.text("failed")])
+        s.enqueue(blocks: [.text("forced")])
+        s.markQueueHeadSending()
+        s.queue[0].transcriptRecorded = true
+        s.queue[1].lastError = "network"
+        s.queue[1].transcriptRecorded = true
+        let id = s.queue[2].id
+
+        #expect(s.forceQueueItem(id: id))
+        #expect(s.queue.map { $0.blocks } == [[.text("in-flight")], [.text("forced")], [.text("failed")]])
+        #expect(s.queue[0].transcriptRecorded == true)
+        #expect(s.queue[2].transcriptRecorded == false)
+    }
+
     @Test("forceQueueItem returns false for an unknown id")
     func forceQueueItemUnknown() {
         let s = mkSession()

--- a/AlasTests/ACP/UI/ACPQueuedBubbleActionMetricsTests.swift
+++ b/AlasTests/ACP/UI/ACPQueuedBubbleActionMetricsTests.swift
@@ -1,0 +1,24 @@
+import CoreGraphics
+import Testing
+@testable import Alas
+
+@Suite("ACPQueuedBubble action metrics")
+struct ACPQueuedBubbleActionMetricsTests {
+    @Test("reserved action width accounts for every action slot")
+    func reservedWidthAccountsForActionSlots() {
+        #expect(ACPQueuedBubbleActionMetrics.reservedButtonSlots == 4)
+        #expect(ACPQueuedBubbleActionMetrics.reservedWidth == 76)
+    }
+
+    @Test("edit and remove slots keep stable offsets when retry is hidden")
+    func editAndRemoveSlotsStayStableWhenRetryIsHidden() {
+        let button = ACPQueuedBubbleActionMetrics.buttonSize
+        let spacing = ACPQueuedBubbleActionMetrics.buttonSpacing
+
+        let editSlotLeading = 2 * (button + spacing)
+        let removeSlotLeading = 3 * (button + spacing)
+
+        #expect(editSlotLeading < ACPQueuedBubbleActionMetrics.reservedWidth)
+        #expect(removeSlotLeading + button == ACPQueuedBubbleActionMetrics.reservedWidth)
+    }
+}

--- a/AlasTests/Remote/WebSocketFrameTests.swift
+++ b/AlasTests/Remote/WebSocketFrameTests.swift
@@ -5,9 +5,9 @@ import Foundation
 struct WebSocketFrameTests {
     @Test func decodeExposesFinBit() throws {
         // FIN=0 text frame (byte0 0x01), masked, "hi".
-        var notFinal = Data([0x01, 0x82, 1, 2, 3, 4, 0x68 ^ 1, 0x69 ^ 2])
+        var notFinal = Data([0x01, 0x82, 1, 2, 3, 4, UInt8(0x68) ^ 1, UInt8(0x69) ^ 2])
         #expect(try WebSocketFrame.decode(from: &notFinal)?.fin == false)
-        var final = Data([0x81, 0x82, 1, 2, 3, 4, 0x68 ^ 1, 0x69 ^ 2])
+        var final = Data([0x81, 0x82, 1, 2, 3, 4, UInt8(0x68) ^ 1, UInt8(0x69) ^ 2])
         #expect(try WebSocketFrame.decode(from: &final)?.fin == true)
     }
 


### PR DESCRIPTION
## Summary
- stabilize ACP queued-message row actions with a fixed reserved action area
- add a pending queued-row send-now control wired through existing queue flush behavior
- cover force-send state behavior and queued action layout metrics

## Tests
- xcodegen
- xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -quiet build
- xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' test