### PR TITLE
fix(settings): center settings dropdown controls

### DIFF
--- a/Alas/Sources/Settings/AgentsPane.swift
+++ b/Alas/Sources/Settings/AgentsPane.swift
@@ -129,7 +129,7 @@ struct AgentsPane: View {
             Label("Chat", systemImage: "sparkle").tag(AppConfig.LauncherMode.acp)
         }
         .pickerStyle(.menu)
-        .frame(width: 240)
+        .settingsDropdownFrame()
     }
 
     private var autoLaunchPicker: some View {
@@ -152,7 +152,7 @@ struct AgentsPane: View {
             }
         }
         .pickerStyle(.menu)
-        .frame(width: 240)
+        .settingsDropdownFrame()
     }
 
     private var cardGrid: some View {

--- a/Alas/Sources/Settings/AppearancePane.swift
+++ b/Alas/Sources/Settings/AppearancePane.swift
@@ -117,7 +117,7 @@ struct AppearancePane: View {
                                 }
                             }
                             .labelsHidden()
-                            .frame(width: 240)
+                            .settingsDropdownFrame()
 
                             Button {
                                 cycleSidebarMaterial(by: 1)

--- a/Alas/Sources/Settings/ChangesPane.swift
+++ b/Alas/Sources/Settings/ChangesPane.swift
@@ -106,7 +106,7 @@ struct ChangesPane: View {
             Text("None").tag("none")
         }
         .pickerStyle(.menu)
-        .frame(width: 240)
+        .settingsDropdownFrame()
     }
 }
 

--- a/Alas/Sources/Settings/FontFamilyPicker.swift
+++ b/Alas/Sources/Settings/FontFamilyPicker.swift
@@ -33,6 +33,7 @@ struct FontFamilyPicker: View {
             .clipShape(RoundedRectangle(cornerRadius: 6))
         }
         .buttonStyle(.plain)
+        .settingsDropdownFrame()
         .popover(isPresented: $open, arrowEdge: .bottom) {
             popoverBody
         }

--- a/Alas/Sources/Settings/SettingsRow.swift
+++ b/Alas/Sources/Settings/SettingsRow.swift
@@ -2,6 +2,7 @@ import SwiftUI
 
 enum SettingsRowLayout {
     static let columnSpacing: CGFloat = 16
+    static let dropdownControlWidth: CGFloat = 240
 
     static func columnWidth(for rowWidth: CGFloat) -> CGFloat {
         max(0, (rowWidth - columnSpacing) / 2)
@@ -35,5 +36,11 @@ struct SettingsRow<Control: View>: View {
         .frame(maxWidth: .infinity, alignment: .leading)
         .padding(.vertical, 10)
         .overlay(Divider().opacity(0.5), alignment: .top)
+    }
+}
+
+extension View {
+    func settingsDropdownFrame() -> some View {
+        frame(width: SettingsRowLayout.dropdownControlWidth, alignment: .leading)
     }
 }

--- a/Alas/Sources/Settings/WorktreesPane.swift
+++ b/Alas/Sources/Settings/WorktreesPane.swift
@@ -36,7 +36,7 @@ struct WorktreesPane: View {
                             Text("Manual").tag(AppConfig.WorktreeSortMode.manual)
                         }
                         .pickerStyle(.menu)
-                        .frame(width: 240)
+                        .settingsDropdownFrame()
                     }
                 }
                 SettingsGroup(title: "Branch defaults") {

--- a/AlasTests/SettingsSectionTests.swift
+++ b/AlasTests/SettingsSectionTests.swift
@@ -12,6 +12,10 @@ struct SettingsSectionTests {
         #expect(SettingsRowLayout.columnWidth(for: 8) == 0)
     }
 
+    @Test func settingsDropdownControlsUseStandardWidth() {
+        #expect(SettingsRowLayout.dropdownControlWidth == 240)
+    }
+
     @Test func sidebarSectionsDoNotIncludeStandaloneMarkdown() {
         let labels = SettingsSection.allCases.map(\.label)
 


### PR DESCRIPTION
## Summary
- Centralize settings dropdown width in `SettingsRowLayout.dropdownControlWidth`.
- Apply the shared dropdown frame helper to settings menu pickers and the font family picker for consistent leading alignment.

## Testing
- Added coverage for the standard settings dropdown width.