### PR TITLE
fix(acp): keep composer clear of hero content on short panes

### DIFF
--- a/Alas/Sources/ACP/UI/ACPComposerShell.swift
+++ b/Alas/Sources/ACP/UI/ACPComposerShell.swift
@@ -14,6 +14,35 @@ enum ACPComposerPlacement: Equatable {
             return min(max(target, 96), min(320, roomAwareMaximum))
         }
     }
+
+    /// Bottom padding for the centred hero content shown in the empty and
+    /// first-run-connecting states, so it always clears the floating
+    /// composer.
+    ///
+    /// The composer floats at `bottomInset(.raisedEmpty)` and is roughly
+    /// `pillHeight` tall, so its top edge sits `inset + pillHeight` above the
+    /// pane's bottom. The hero content is centre-aligned, so with bottom
+    /// padding `p` its lower edge lands at `(H + p) / 2 - contentHeight / 2`.
+    /// Solving for a constant `gap` above the composer gives
+    /// `p = 2*gap + 2*pillHeight + contentHeight + 2*inset - H`. That lands on
+    /// the historical 210pt on a ~900pt pane (so large panes are unchanged)
+    /// and grows as the pane shrinks — the previous fixed 210 let the composer
+    /// overlap the starter chips on short panes.
+    ///
+    /// On very short panes the result is capped so the content's top edge
+    /// stays on-screen (trading the gap for visibility rather than clipping
+    /// the artwork under the toolbar).
+    static func raisedHeroBottomPadding(containerHeight: CGFloat) -> CGFloat {
+        let inset = bottomInset(for: .raisedEmpty, containerHeight: containerHeight)
+        let pillHeight: CGFloat = 98     // empty composer pill (input floor + controls)
+        let contentHeight: CGFloat = 150 // mark + title/subtitle + starter chips
+        let gap: CGFloat = 76            // breathing room above the composer
+        let topMargin: CGFloat = 16
+
+        let desired = 2 * gap + 2 * pillHeight + contentHeight + 2 * inset - containerHeight
+        let fitCap = containerHeight - contentHeight - 2 * topMargin
+        return max(0, min(desired, fitCap))
+    }
 }
 
 /// Floating glass pill composer. Wraps the AppKit-backed `ACPInputField`

--- a/Alas/Sources/ACP/UI/ACPFirstRunConnectingView.swift
+++ b/Alas/Sources/ACP/UI/ACPFirstRunConnectingView.swift
@@ -11,6 +11,10 @@ enum ACPFirstRunConnectingViewCopy {
 struct ACPFirstRunConnectingView: View {
     let agentDisplayName: String
     let phase: ACPFirstRunConnectingPhase
+    /// Bottom padding that lifts the centred content clear of the floating
+    /// composer. Responsive to pane height so the composer never overlaps the
+    /// phase chips on short panes (see `raisedHeroBottomPadding`).
+    let bottomInset: CGFloat
 
     @Environment(\.theme) private var theme
 
@@ -36,7 +40,7 @@ struct ACPFirstRunConnectingView: View {
         .frame(maxWidth: 640)
         .padding(.horizontal, 28)
         .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .center)
-        .padding(.bottom, 210)
+        .padding(.bottom, bottomInset)
         .accessibilityElement(children: .contain)
         .accessibilityLabel("Connecting new \(agentDisplayName) chat")
     }

--- a/Alas/Sources/ACP/UI/ACPNewChatEmptyStateView.swift
+++ b/Alas/Sources/ACP/UI/ACPNewChatEmptyStateView.swift
@@ -2,6 +2,10 @@ import SwiftUI
 
 struct ACPNewChatEmptyStateView: View {
     let agentDisplayName: String
+    /// Bottom padding that lifts the centred content clear of the floating
+    /// composer. Responsive to pane height so the composer never overlaps the
+    /// starter chips on short panes (see `raisedHeroBottomPadding`).
+    let bottomInset: CGFloat
     let onStarterPrompt: (ACPStarterPrompt) -> Void
 
     @Environment(\.theme) private var theme
@@ -22,7 +26,7 @@ struct ACPNewChatEmptyStateView: View {
         .frame(maxWidth: 640)
         .padding(.horizontal, 28)
         .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .center)
-        .padding(.bottom, 210)
+        .padding(.bottom, bottomInset)
         .accessibilityElement(children: .contain)
         .accessibilityLabel("New \(agentDisplayName) chat")
     }

--- a/Alas/Sources/ACP/UI/ACPTabView.swift
+++ b/Alas/Sources/ACP/UI/ACPTabView.swift
@@ -198,12 +198,16 @@ private struct ACPSessionView: View {
 
     private var transcriptAndComposer: some View {
         GeometryReader { proxy in
+            let heroBottomInset = ACPComposerPlacement.raisedHeroBottomPadding(
+                containerHeight: proxy.size.height
+            )
             HStack(spacing: 0) {
                 ZStack(alignment: .bottom) {
                     if let phase = firstRunConnectingPhase {
                         ACPFirstRunConnectingView(
                             agentDisplayName: state.agent(id: session.agentId)?.displayName ?? session.agentId,
-                            phase: phase
+                            phase: phase,
+                            bottomInset: heroBottomInset
                         )
                     } else if isConnecting {
                         ACPConnectingPlaceholder(
@@ -213,6 +217,7 @@ private struct ACPSessionView: View {
                         if isNewEmptySession {
                             ACPNewChatEmptyStateView(
                                 agentDisplayName: state.agent(id: session.agentId)?.displayName ?? session.agentId,
+                                bottomInset: heroBottomInset,
                                 onStarterPrompt: insertStarterPrompt
                             )
                             .transition(

--- a/AlasTests/ACP/UI/ACPNewChatEmptyStateTests.swift
+++ b/AlasTests/ACP/UI/ACPNewChatEmptyStateTests.swift
@@ -1,3 +1,4 @@
+import CoreGraphics
 import Foundation
 import Testing
 @testable import Alas
@@ -172,5 +173,42 @@ struct ACPNewChatEmptyStateTests {
         #expect(shortRaised > bottom)
         #expect(regularRaised > shortRaised)
         #expect(tallRaised == 320)
+    }
+
+    @Test("raised hero padding keeps centred content clear of the composer on small panes")
+    func raisedHeroPaddingClearsComposerOnSmallPanes() {
+        // Mirrors the geometry the production layout uses: the hero content is
+        // centre-aligned and the composer floats at `raisedEmpty`. These two
+        // constants track the documented model in `raisedHeroBottomPadding`;
+        // if they drift, this guards the no-overlap contract that was the
+        // whole point of making the padding responsive.
+        let pillHeight: CGFloat = 98
+        let contentHeight: CGFloat = 150
+
+        for h in stride(from: CGFloat(400), through: CGFloat(1_200), by: 20) {
+            let inset = ACPComposerPlacement.bottomInset(for: .raisedEmpty, containerHeight: h)
+            let pad = ACPComposerPlacement.raisedHeroBottomPadding(containerHeight: h)
+
+            let composerTop = inset + pillHeight
+            let contentBottom = (h + pad) / 2 - contentHeight / 2
+            let contentTop = (h + pad) / 2 + contentHeight / 2
+
+            // Never overlaps the floating composer …
+            #expect(contentBottom >= composerTop)
+            // … and never clips above the top of the pane.
+            #expect(contentTop <= h)
+        }
+    }
+
+    @Test("raised hero padding preserves the historical placement on large panes")
+    func raisedHeroPaddingMatchesLegacyOnLargePanes() {
+        // The previous layout hardcoded 210pt; the responsive value must land
+        // on it for a roomy pane so large windows look unchanged, then grow as
+        // the pane shrinks.
+        #expect(ACPComposerPlacement.raisedHeroBottomPadding(containerHeight: 900) == 210)
+        #expect(
+            ACPComposerPlacement.raisedHeroBottomPadding(containerHeight: 600)
+                > ACPComposerPlacement.raisedHeroBottomPadding(containerHeight: 900)
+        )
     }
 }


### PR DESCRIPTION
## Problem

On small / short ACP panes, the empty state ("What should we work on?") and the first-run "Connecting…" state looked broken: the floating chat composer overlapped the content above it (the starter / phase chips slid behind the pill).

The two centred hero views (`ACPNewChatEmptyStateView`, `ACPFirstRunConnectingView`) lifted themselves above the composer with a hardcoded `.padding(.bottom, 210)`. But the composer floats at a **dynamic** inset (`raisedEmpty` ≈ 0.34 × pane height), so the fixed 210 only left a comfortable gap on tall panes — the gap shrinks as the pane gets shorter and goes negative below ~400pt.

## Fix

Replace the magic `210` with `ACPComposerPlacement.raisedHeroBottomPadding(containerHeight:)`, derived from the same placement math:

- Solves the centring geometry for a **constant gap** above the floating composer.
- Lands on exactly `210` at a ~900pt pane, so **large windows are visually unchanged**.
- **Grows** as the pane shrinks, restoring the gap on short panes.
- **Capped** on very short panes so the artwork stays on-screen rather than clipping under the toolbar.

`ACPTabView` computes it once from the existing `GeometryReader` and threads it into both hero views. The connecting skeleton (`ACPConnectingPlaceholder`) is unchanged — it uses the normal bottom composer placement, like the real transcript.

## Tests

Added to `ACPNewChatEmptyStateTests`:
- No-overlap invariant across pane heights 400–1200 (content clears the composer and never clips the top).
- Back-compat: `== 210` at 900pt and grows below.