### PR TITLE
feat(acp): highlight chat code and tool output

### DIFF
--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -602,6 +602,7 @@
 		A05391FF4907AB0870A79C02 /* ReviewEvidenceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4B05E0E44B026AE7E8EA3101 /* ReviewEvidenceTests.swift */; };
 		A0B5074B10E732616C917D10 /* DragHandleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1379AD82025AFEABD37EFC42 /* DragHandleTests.swift */; };
 		A0F1E46BC1A9E2CC21805EE7 /* FilesTabFilterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1977C85C3DFD1F232A2755AD /* FilesTabFilterTests.swift */; };
+		A139CD869FCFF8F4CFB7E50D /* ACPSyntaxHighlightedText.swift in Sources */ = {isa = PBXBuildFile; fileRef = C72B05E51A4C6FAE18666DBC /* ACPSyntaxHighlightedText.swift */; };
 		A15C8E0D7A942160A74BD68E /* ImageDiffPairResolver.swift in Sources */ = {isa = PBXBuildFile; fileRef = D568D53950A3CA2CD1F4EECB /* ImageDiffPairResolver.swift */; };
 		A19649A790595DF4F48C3824 /* TerminalService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1AFC62A30044F71F0F16C3FB /* TerminalService.swift */; };
 		A19D418808D8CCCE04242E07 /* EditorLSPStatusResolverTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 209B2EDBA4EB4BF7A854FF96 /* EditorLSPStatusResolverTests.swift */; };
@@ -1683,6 +1684,7 @@
 		C6CA79B71B4AA72697392702 /* NumstatParser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NumstatParser.swift; sourceTree = "<group>"; };
 		C6E896FEA37B4691BD16E2DD /* EditorBufferTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditorBufferTests.swift; sourceTree = "<group>"; };
 		C7206BC51596AE2A57D8B28B /* InlineErrorStrip.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InlineErrorStrip.swift; sourceTree = "<group>"; };
+		C72B05E51A4C6FAE18666DBC /* ACPSyntaxHighlightedText.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPSyntaxHighlightedText.swift; sourceTree = "<group>"; };
 		C741E646CFDECE0AF9520265 /* ACPSteerUndoToast.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPSteerUndoToast.swift; sourceTree = "<group>"; };
 		C78D0715973BD840FDE95AA2 /* CloseTabConfirmationPolicy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CloseTabConfirmationPolicy.swift; sourceTree = "<group>"; };
 		C7A24E28C231CEA4225C23F0 /* EditorTheme.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditorTheme.swift; sourceTree = "<group>"; };
@@ -2919,6 +2921,7 @@
 				93C3F02ECEA5D545FA268DB8 /* ACPSlashPicker.swift */,
 				96C6D6594CCA4EBC83BDF264 /* ACPStarterPrompt.swift */,
 				C741E646CFDECE0AF9520265 /* ACPSteerUndoToast.swift */,
+				C72B05E51A4C6FAE18666DBC /* ACPSyntaxHighlightedText.swift */,
 				C3BC736DAAD590624B840923 /* ACPSystemNoticeView.swift */,
 				B832ED19AC178DAD77C78D37 /* ACPTabView.swift */,
 				CBFD1CE53DE229626220B457 /* ACPTerminalTailView.swift */,
@@ -3942,6 +3945,7 @@
 				1B7A283F7F585BA8D67C1959 /* ACPSteerUndoToast.swift in Sources */,
 				3537561BEB5D7D8666C7DFFD /* ACPStreamingText.swift in Sources */,
 				9624AE35A36692177C9EBD38 /* ACPSubmitIntent.swift in Sources */,
+				A139CD869FCFF8F4CFB7E50D /* ACPSyntaxHighlightedText.swift in Sources */,
 				8510C6B68C2CF6664574C161 /* ACPSystemNoticeView.swift in Sources */,
 				F66BDC777D0BFDE306E8880A /* ACPTabView.swift in Sources */,
 				E44EBD2F2F9A398207E55C6D /* ACPTerminal.swift in Sources */,

--- a/Alas/Sources/ACP/Session/ACPMessage.swift
+++ b/Alas/Sources/ACP/Session/ACPMessage.swift
@@ -64,6 +64,9 @@ enum ACPMessage: Equatable {
         /// truncated). Computed at apply() time so we don't repeatedly
         /// scan the full content during rendering.
         var preview: String?
+        /// Supported explicit language label from a wrapping markdown fence
+        /// that was removed from `content`.
+        var contentLanguage: String?
         var locations: [String]
         /// Terminal IDs referenced by this call's structured content, in
         /// declaration order. The expanded card renders one
@@ -94,7 +97,7 @@ enum ACPMessage: Equatable {
 
         init(toolCallId: String, title: String, kind: String? = nil,
              status: String, content: String = "", preview: String? = nil,
-             locations: [String] = [], terminalIds: [String] = [])
+             contentLanguage: String? = nil, locations: [String] = [], terminalIds: [String] = [])
         {
             self.toolCallId = toolCallId
             self.title = title
@@ -102,6 +105,7 @@ enum ACPMessage: Equatable {
             self.status = status
             self.content = content
             self.preview = preview
+            self.contentLanguage = contentLanguage
             self.locations = locations
             self.terminalIds = terminalIds
         }
@@ -111,7 +115,7 @@ enum ACPMessage: Equatable {
         // session history doesn't go blank after upgrade.
         enum CodingKeys: String, CodingKey {
             case toolCallId, title, kind, status, content, preview,
-                 contentSummary, locations, terminalIds
+                 contentSummary, contentLanguage, locations, terminalIds
         }
         init(from decoder: Decoder) throws {
             let c = try decoder.container(keyedBy: CodingKeys.self)
@@ -122,6 +126,7 @@ enum ACPMessage: Equatable {
             content = (try? c.decode(String.self, forKey: .content)) ?? ""
             preview = (try? c.decode(String.self, forKey: .preview))
                 ?? (try? c.decode(String.self, forKey: .contentSummary))
+            contentLanguage = try? c.decode(String.self, forKey: .contentLanguage)
             locations = (try? c.decode([String].self, forKey: .locations)) ?? []
             terminalIds = (try? c.decode([String].self, forKey: .terminalIds)) ?? []
         }
@@ -133,6 +138,7 @@ enum ACPMessage: Equatable {
             try c.encode(status, forKey: .status)
             try c.encode(content, forKey: .content)
             try c.encodeIfPresent(preview, forKey: .preview)
+            try c.encodeIfPresent(contentLanguage, forKey: .contentLanguage)
             try c.encode(locations, forKey: .locations)
             try c.encode(terminalIds, forKey: .terminalIds)
         }
@@ -148,6 +154,7 @@ enum ACPMessage: Equatable {
                 && lhs.status == rhs.status
                 && lhs.content == rhs.content
                 && lhs.preview == rhs.preview
+                && lhs.contentLanguage == rhs.contentLanguage
                 && lhs.locations == rhs.locations
         }
 
@@ -158,6 +165,7 @@ enum ACPMessage: Equatable {
             hasher.combine(status)
             hasher.combine(content)
             hasher.combine(preview)
+            hasher.combine(contentLanguage)
             hasher.combine(locations)
         }
     }

--- a/Alas/Sources/ACP/Session/ACPSession.swift
+++ b/Alas/Sources/ACP/Session/ACPSession.swift
@@ -236,7 +236,8 @@ final class ACPSession: ObservableObject, Identifiable {
             return [i]
         case .toolCall(let payload):
             let items = payload.content ?? []
-            let full = Self.stripWrappingFence(Self.flatten(items),
+            let raw = Self.flatten(items)
+            let full = Self.stripWrappingFence(raw,
                                                isFinal: Self.isFinalStatus(payload.status))
             transcript.messages.append(.toolCall(.init(
                 toolCallId: payload.toolCallId,
@@ -245,6 +246,7 @@ final class ACPSession: ObservableObject, Identifiable {
                 status: payload.status,
                 content: full,
                 preview: Self.previewLine(full),
+                contentLanguage: Self.wrappingFenceLanguage(raw),
                 locations: payload.locations?.map(\.path) ?? [],
                 terminalIds: Self.extractTerminalIds(items))))
             didAppendTranscriptMessage()
@@ -259,10 +261,12 @@ final class ACPSession: ObservableObject, Identifiable {
                     // unconditionally, including the empty case, so a
                     // text/diff-only final update doesn't leave a stale
                     // terminal tail rendering in the card.
-                    let full = Self.stripWrappingFence(Self.flatten(c),
+                    let raw = Self.flatten(c)
+                    let full = Self.stripWrappingFence(raw,
                                                       isFinal: Self.isFinalStatus(tc.status))
                     tc.content = full
                     tc.preview = Self.previewLine(full)
+                    tc.contentLanguage = Self.wrappingFenceLanguage(raw)
                     tc.terminalIds = Self.extractTerminalIds(c)
                 }
             }
@@ -600,6 +604,15 @@ final class ACPSession: ObservableObject, Identifiable {
             }
         }
         return lines.joined(separator: "\n")
+    }
+
+    static func wrappingFenceLanguage(_ full: String) -> String? {
+        guard let first = full.split(separator: "\n", omittingEmptySubsequences: false).first else {
+            return nil
+        }
+        let line = String(first)
+        guard line.hasPrefix("```") else { return nil }
+        return ACPCodeLanguage.highlighterExtension(for: String(line.dropFirst(3)))
     }
 
     private static func isOpeningFence(_ line: String) -> Bool {

--- a/Alas/Sources/ACP/UI/ACPCodeBlockHighlighter.swift
+++ b/Alas/Sources/ACP/UI/ACPCodeBlockHighlighter.swift
@@ -21,6 +21,17 @@ enum ACPCodeLanguage {
             normalized = String(normalized.dropFirst())
         }
 
+        return canonicalExtension(for: normalized)
+    }
+
+    static func highlighterExtension(forPath path: String?) -> String? {
+        guard let path else { return nil }
+        let ext = LanguageRegistry.highlighterExtension(forPath: path)
+        guard !ext.isEmpty else { return nil }
+        return supportedHighlighterExtension(ext)
+    }
+
+    private static func canonicalExtension(for normalized: String) -> String? {
         switch normalized {
         case "swift": return "swift"
         case "py", "python": return "py"
@@ -49,6 +60,7 @@ enum ACPCodeLanguage {
         case "diff": return "diff"
         case "patch": return "patch"
         case "html": return "html"
+        case "htm": return "htm"
         case "xml": return "xml"
         case "css": return "css"
         case "scss": return "scss"
@@ -62,8 +74,102 @@ enum ACPCodeLanguage {
         case "dockerfile": return "dockerfile"
         case "sql", "pl", "perl", "ex", "exs", "elixir", "ini":
             return nil
-        default: return nil
+        default:
+            return nil
         }
+    }
+
+    private static func supportedHighlighterExtension(_ ext: String) -> String? {
+        let normalized = ext.lowercased()
+        if LanguageRegistry.language(forFileExtension: normalized) != nil {
+            return normalized
+        }
+        switch normalized {
+        case "diff", "patch", "xml", "scss", "sass":
+            return normalized
+        default:
+            return nil
+        }
+    }
+}
+
+enum ACPToolOutputSyntax {
+    static func highlighterExtension(content: String, locations: [String]) -> String? {
+        if looksLikeDiff(content) {
+            return "diff"
+        }
+        guard locations.count == 1 else {
+            return nil
+        }
+        return ACPCodeLanguage.highlighterExtension(forPath: locations[0])
+    }
+
+    private static func looksLikeDiff(_ content: String) -> Bool {
+        let lines = content
+            .split(separator: "\n", omittingEmptySubsequences: false)
+            .map(String.init)
+
+        guard !lines.isEmpty else { return false }
+        if lines.contains(where: { $0.hasPrefix("diff --git ") }) {
+            return true
+        }
+        if lines.contains(where: isUnifiedHunkHeader) {
+            return true
+        }
+
+        for index in lines.indices {
+            let line = lines[index]
+            guard line.hasPrefix("--- ") else { continue }
+            let path = String(line.dropFirst(4)).trimmingCharacters(in: .whitespacesAndNewlines)
+            guard isPathLikeDiffHeader(path) else { continue }
+            let tail = lines[lines.index(after: index)...].prefix(8)
+            let hasRemoval = tail.contains { isDiffChangeLine($0, marker: "-") }
+            let hasAddition = tail.contains { isDiffChangeLine($0, marker: "+") }
+            if hasRemoval || hasAddition {
+                return true
+            }
+        }
+        return false
+    }
+
+    private static func isUnifiedHunkHeader(_ line: String) -> Bool {
+        let parts = line.split(whereSeparator: { $0.isWhitespace }).map(String.init)
+        guard parts.count >= 4,
+              parts[0] == "@@",
+              isUnifiedRange(parts[1], marker: "-"),
+              isUnifiedRange(parts[2], marker: "+"),
+              parts[3] == "@@" else {
+            return false
+        }
+        return true
+    }
+
+    private static func isUnifiedRange(_ token: String, marker: Character) -> Bool {
+        guard token.first == marker else { return false }
+        let range = token.dropFirst()
+        guard !range.isEmpty else { return false }
+        let segments = range.split(separator: ",", omittingEmptySubsequences: false)
+        guard segments.count == 1 || segments.count == 2 else { return false }
+        return segments.allSatisfy { !$0.isEmpty && $0.allSatisfy(\.isNumber) }
+    }
+
+    private static func isPathLikeDiffHeader(_ path: String) -> Bool {
+        path.contains("/") || !(path as NSString).pathExtension.isEmpty
+    }
+
+    private static func isDiffChangeLine(_ line: String, marker: Character) -> Bool {
+        guard line.first == marker else { return false }
+        if marker == "-", line.hasPrefix("--- ") { return false }
+        if marker == "+", line.hasPrefix("+++ ") { return false }
+
+        let body = line.dropFirst()
+        guard let first = body.first else { return false }
+        guard first.isWhitespace else { return true }
+
+        let indentation = body.prefix(while: { $0.isWhitespace })
+        let rest = body.dropFirst(indentation.count)
+        guard rest.contains(where: { !$0.isWhitespace }) else { return false }
+        return indentation.count > 1 || indentation.contains("\t")
     }
 }
 

--- a/Alas/Sources/ACP/UI/ACPCodeBlockHighlighter.swift
+++ b/Alas/Sources/ACP/UI/ACPCodeBlockHighlighter.swift
@@ -96,6 +96,9 @@ enum ACPCodeLanguage {
 
 enum ACPToolOutputSyntax {
     static func highlighterExtension(content: String, locations: [String]) -> String? {
+        if let fencedLanguage = wholeOutputFenceLanguage(content) {
+            return fencedLanguage
+        }
         if looksLikeDiff(content) {
             return "diff"
         }
@@ -103,6 +106,22 @@ enum ACPToolOutputSyntax {
             return nil
         }
         return ACPCodeLanguage.highlighterExtension(forPath: locations[0])
+    }
+
+    private static func wholeOutputFenceLanguage(_ content: String) -> String? {
+        var lines = content
+            .split(separator: "\n", omittingEmptySubsequences: false)
+            .map(String.init)
+        guard let first = lines.first, first.hasPrefix("```"),
+              let language = ACPCodeLanguage.highlighterExtension(for: String(first.dropFirst(3))) else {
+            return nil
+        }
+        lines.removeFirst()
+        while let last = lines.last, last.isEmpty {
+            lines.removeLast()
+        }
+        guard lines.last == "```" else { return nil }
+        return language
     }
 
     private static func looksLikeDiff(_ content: String) -> Bool {

--- a/Alas/Sources/ACP/UI/ACPCodeBlockHighlighter.swift
+++ b/Alas/Sources/ACP/UI/ACPCodeBlockHighlighter.swift
@@ -72,7 +72,8 @@ enum ACPCodeLanguage {
         case "tf", "terraform": return "tf"
         case "tfvars": return "tfvars"
         case "dockerfile": return "dockerfile"
-        case "sql", "pl", "perl", "ex", "exs", "elixir", "ini":
+        case "sql": return "sql"
+        case "pl", "perl", "ex", "exs", "elixir", "ini":
             return nil
         default:
             return nil
@@ -85,7 +86,7 @@ enum ACPCodeLanguage {
             return normalized
         }
         switch normalized {
-        case "diff", "patch", "xml", "scss", "sass":
+        case "diff", "patch", "xml", "scss", "sass", "sql":
             return normalized
         default:
             return nil

--- a/Alas/Sources/ACP/UI/ACPMarkdownText.swift
+++ b/Alas/Sources/ACP/UI/ACPMarkdownText.swift
@@ -296,16 +296,11 @@ private struct CodeBlockView: View {
         VStack(alignment: .leading, spacing: 0) {
             header
             ScrollView(.horizontal, showsIndicators: false) {
-                Text(AttributedString(ACPCodeBlockHighlighter.attributedString(
-                    code: code,
-                    language: language,
-                    theme: theme
-                )))
-                .font(.system(size: 12, design: .monospaced))
-                .foregroundStyle(theme.color("fg"))
-                .lineSpacing(2)
-                .textSelection(.enabled)
-                .frame(maxWidth: .infinity, alignment: .leading)
+                ACPSyntaxHighlightedText(
+                    text: code,
+                    explicitLanguage: language,
+                    fontSize: 12
+                )
                 .padding(.horizontal, 10).padding(.vertical, 8)
             }
         }

--- a/Alas/Sources/ACP/UI/ACPSyntaxHighlightedText.swift
+++ b/Alas/Sources/ACP/UI/ACPSyntaxHighlightedText.swift
@@ -1,0 +1,105 @@
+import AppKit
+import SwiftUI
+
+struct ACPSyntaxHighlightCacheKey: Equatable {
+    let text: String
+    let resolvedExtension: String?
+    let themeKey: String
+    let fontSize: CGFloat
+
+    init(text: String, resolvedExtension: String?, theme: Theme, fontSize: CGFloat) {
+        self.text = text
+        self.resolvedExtension = resolvedExtension
+        self.themeKey = Self.themeKey(theme)
+        self.fontSize = fontSize
+    }
+
+    private static func themeKey(_ theme: Theme) -> String {
+        let tokenKey = theme.tokens
+            .sorted { $0.key < $1.key }
+            .map { "\($0.key)=\($0.value)" }
+            .joined(separator: "|")
+        let overrideKey = theme.resolvedColorOverrides
+            .sorted { $0.key < $1.key }
+            .map { "\($0.key)=\(colorKey($0.value))" }
+            .joined(separator: "|")
+        return "id=\(theme.id)|accent=\(theme.accentOverrideHex ?? "")|tokens=\(tokenKey)|overrides=\(overrideKey)"
+    }
+
+    private static func colorKey(_ color: Color) -> String {
+        let nsColor = NSColor(color)
+        guard let normalized = nsColor.usingColorSpace(.sRGB) else {
+            return nsColor.description
+        }
+        return String(
+            format: "r=%.6f,g=%.6f,b=%.6f,a=%.6f",
+            Double(normalized.redComponent),
+            Double(normalized.greenComponent),
+            Double(normalized.blueComponent),
+            Double(normalized.alphaComponent)
+        )
+    }
+}
+
+@MainActor
+private final class ACPSyntaxHighlightedTextCache: ObservableObject {
+    private var key: ACPSyntaxHighlightCacheKey?
+    private var value: AttributedString?
+
+    func attributedString(
+        text: String,
+        explicitLanguage: String?,
+        sourcePath: String?,
+        theme: Theme,
+        fontSize: CGFloat
+    ) -> AttributedString {
+        let resolvedExtension = explicitLanguage.flatMap(ACPCodeLanguage.highlighterExtension(for:))
+            ?? ACPCodeLanguage.highlighterExtension(forPath: sourcePath)
+        let nextKey = ACPSyntaxHighlightCacheKey(
+            text: text,
+            resolvedExtension: resolvedExtension,
+            theme: theme,
+            fontSize: fontSize
+        )
+        if key == nextKey, let value {
+            return value
+        }
+
+        let highlighted = AttributedString(ACPCodeBlockHighlighter.attributedString(
+            code: text,
+            language: resolvedExtension,
+            theme: theme,
+            fontSize: fontSize
+        ))
+        key = nextKey
+        value = highlighted
+        return highlighted
+    }
+}
+
+struct ACPSyntaxHighlightedText: View {
+    let text: String
+    var explicitLanguage: String? = nil
+    var sourcePath: String? = nil
+    var fontSize: CGFloat = 12
+    var lineSpacing: CGFloat = 2
+
+    @Environment(\.theme) private var theme
+    @StateObject private var cache = ACPSyntaxHighlightedTextCache()
+
+    var body: some View {
+        Text(cache.attributedString(
+            text: text,
+            explicitLanguage: explicitLanguage,
+            sourcePath: sourcePath,
+            theme: theme,
+            fontSize: fontSize
+        ))
+        .font(.system(size: fontSize, design: .monospaced))
+        .foregroundStyle(theme.color("fg"))
+        .lineSpacing(lineSpacing)
+        .textSelection(.enabled)
+        .fixedSize(horizontal: false, vertical: true)
+        .frame(maxWidth: .infinity, alignment: .leading)
+    }
+}

--- a/Alas/Sources/ACP/UI/ACPToolCallCard.swift
+++ b/Alas/Sources/ACP/UI/ACPToolCallCard.swift
@@ -111,7 +111,7 @@ struct ACPToolCallCard: View {
                     ScrollView(.horizontal, showsIndicators: false) {
                         ACPSyntaxHighlightedText(
                             text: displayContent,
-                            explicitLanguage: ACPToolOutputSyntax.highlighterExtension(
+                            explicitLanguage: toolCall.contentLanguage ?? ACPToolOutputSyntax.highlighterExtension(
                                 content: displayContent,
                                 locations: toolCall.locations
                             ),

--- a/Alas/Sources/ACP/UI/ACPToolCallCard.swift
+++ b/Alas/Sources/ACP/UI/ACPToolCallCard.swift
@@ -109,13 +109,14 @@ struct ACPToolCallCard: View {
             } else {
                 if !displayContent.isEmpty {
                     ScrollView(.horizontal, showsIndicators: false) {
-                        Text(displayContent)
-                            .font(.system(size: 11.5, design: .monospaced))
-                            .foregroundStyle(theme.color("fg-muted"))
-                            .lineSpacing(2)
-                            .textSelection(.enabled)
-                            .fixedSize(horizontal: false, vertical: true)
-                            .frame(maxWidth: .infinity, alignment: .leading)
+                        ACPSyntaxHighlightedText(
+                            text: displayContent,
+                            explicitLanguage: ACPToolOutputSyntax.highlighterExtension(
+                                content: displayContent,
+                                locations: toolCall.locations
+                            ),
+                            fontSize: 11.5
+                        )
                             .padding(.horizontal, 12).padding(.vertical, 10)
                     }
                     .background(theme.color("bg-0").opacity(0.55))

--- a/AlasTests/ACP/Session/ACPMessageWireTests.swift
+++ b/AlasTests/ACP/Session/ACPMessageWireTests.swift
@@ -50,6 +50,28 @@ struct ACPMessageWireTests {
         #expect(decoded == tc)
     }
 
+    @Test("tool call decodes missing content language as nil")
+    func toolCallMissingContentLanguageDecodesAsNil() throws {
+        let payload = """
+        {
+          "toolCallId": "tc1",
+          "title": "read",
+          "kind": "fs.read",
+          "status": "completed",
+          "content": "abc",
+          "preview": "abc",
+          "locations": ["/a"],
+          "terminalIds": []
+        }
+        """.data(using: .utf8)!
+        let wire = try ACPMessageWire.decode(kind: "tool_call", payload: payload)
+        guard case let .toolCall(decoded) = wire else {
+            #expect(Bool(false), "expected .toolCall, got \(wire)")
+            return
+        }
+        #expect(decoded.contentLanguage == nil)
+    }
+
     @Test("unknown kind decodes to system notice")
     func unknownKind() throws {
         let wire = try ACPMessageWire.decode(kind: "mystery", payload: Data())

--- a/AlasTests/ACP/Session/ACPSessionTests.swift
+++ b/AlasTests/ACP/Session/ACPSessionTests.swift
@@ -377,7 +377,24 @@ struct ACPSessionTests {
             rawOutput: nil)))
         if case .toolCall(let tc) = session.transcript.messages[0] {
             #expect(tc.content == "let x = 1\nlet y = 2")
+            #expect(tc.contentLanguage == "swift")
             #expect(tc.preview == "let x = 1")
+        } else { Issue.record("expected toolCall message") }
+    }
+
+    @Test("toolCallUpdate preserves supported wrapped fence language")
+    func toolCallUpdatePreservesWrappedFenceLanguage() async {
+        let session = ACPSession(id: "s", agentId: "claude", worktreeId: "w", title: "t")
+        session.apply(.toolCall(.init(
+            toolCallId: "tc-sql", title: "query", kind: "read", status: "in_progress",
+            content: nil, locations: nil, rawInput: nil, rawOutput: nil)))
+        session.apply(.toolCallUpdate(.init(
+            toolCallId: "tc-sql", status: "completed",
+            content: [.content(.text("```sql\nSELECT id FROM users\n```"))],
+            rawOutput: nil)))
+        if case .toolCall(let tc) = session.transcript.messages[0] {
+            #expect(tc.content == "SELECT id FROM users")
+            #expect(tc.contentLanguage == "sql")
         } else { Issue.record("expected toolCall message") }
     }
 
@@ -390,6 +407,7 @@ struct ACPSessionTests {
             locations: nil, rawInput: nil, rawOutput: nil)))
         if case .toolCall(let tc) = session.transcript.messages[0] {
             #expect(tc.content == "partial output")
+            #expect(tc.contentLanguage == nil)
         } else { Issue.record("expected toolCall message") }
     }
 
@@ -402,6 +420,7 @@ struct ACPSessionTests {
             locations: nil, rawInput: nil, rawOutput: nil)))
         if case .toolCall(let tc) = session.transcript.messages[0] {
             #expect(tc.content == "hello\n```\ninner\n```\nworld")
+            #expect(tc.contentLanguage == nil)
         } else { Issue.record("expected toolCall message") }
     }
 }

--- a/AlasTests/ACP/UI/ACPCodeBlockHighlighterTests.swift
+++ b/AlasTests/ACP/UI/ACPCodeBlockHighlighterTests.swift
@@ -1,4 +1,5 @@
 import AppKit
+import SwiftUI
 import Testing
 @testable import Alas
 
@@ -252,5 +253,78 @@ struct ACPCodeBlockHighlighterTests {
         let swiftAttributed = AttributedString(nsAttributed)
 
         #expect(String(swiftAttributed.characters) == "let value = 1")
+    }
+
+    @Test("highlight cache key changes with language and theme inputs")
+    func highlightedTextCacheKeyTracksInputs() throws {
+        let dark = try Theme.loadBundled(id: "cool-slate")
+        let light = try Theme.loadBundled(id: "light")
+        var accentTheme = dark
+        accentTheme.accentOverrideHex = "#123456"
+        var tokenOverrideTheme = dark
+        tokenOverrideTheme.resolvedColorOverrides = [
+            "fg": Color(.sRGB, red: 1, green: 0, blue: 0, opacity: 1),
+        ]
+        var changedTokens = dark.tokens
+        changedTokens["fg"] = "\(changedTokens["fg"] ?? "") changed"
+        let rawTokenTheme = Theme(id: dark.id, name: dark.name, tokens: changedTokens)
+
+        let a = ACPSyntaxHighlightCacheKey(
+            text: "let value = 1",
+            resolvedExtension: "swift",
+            theme: dark,
+            fontSize: 12
+        )
+        let b = ACPSyntaxHighlightCacheKey(
+            text: "let value = 1",
+            resolvedExtension: "diff",
+            theme: dark,
+            fontSize: 12
+        )
+        let c = ACPSyntaxHighlightCacheKey(
+            text: "let value = 1",
+            resolvedExtension: "swift",
+            theme: light,
+            fontSize: 12
+        )
+        let differentText = ACPSyntaxHighlightCacheKey(
+            text: "let value = 2",
+            resolvedExtension: "swift",
+            theme: dark,
+            fontSize: 12
+        )
+        let differentFontSize = ACPSyntaxHighlightCacheKey(
+            text: "let value = 1",
+            resolvedExtension: "swift",
+            theme: dark,
+            fontSize: 13
+        )
+        let differentAccent = ACPSyntaxHighlightCacheKey(
+            text: "let value = 1",
+            resolvedExtension: "swift",
+            theme: accentTheme,
+            fontSize: 12
+        )
+        let differentRawToken = ACPSyntaxHighlightCacheKey(
+            text: "let value = 1",
+            resolvedExtension: "swift",
+            theme: rawTokenTheme,
+            fontSize: 12
+        )
+        let differentResolvedColorOverride = ACPSyntaxHighlightCacheKey(
+            text: "let value = 1",
+            resolvedExtension: "swift",
+            theme: tokenOverrideTheme,
+            fontSize: 12
+        )
+
+        #expect(a == a)
+        #expect(a != b)
+        #expect(a != c)
+        #expect(a != differentText)
+        #expect(a != differentFontSize)
+        #expect(a != differentAccent)
+        #expect(a != differentRawToken)
+        #expect(a != differentResolvedColorOverride)
     }
 }

--- a/AlasTests/ACP/UI/ACPCodeBlockHighlighterTests.swift
+++ b/AlasTests/ACP/UI/ACPCodeBlockHighlighterTests.swift
@@ -74,12 +74,15 @@ struct ACPCodeBlockHighlighterTests {
         #expect(ACPCodeLanguage.highlighterExtension(for: "terraform") == "tf")
         #expect(ACPCodeLanguage.highlighterExtension(for: "tfvars") == "tfvars")
         #expect(ACPCodeLanguage.highlighterExtension(for: "dockerfile") == "dockerfile")
+        #expect(ACPCodeLanguage.highlighterExtension(for: "sql") == "sql")
     }
 
     @Test("future-known unsupported ACP fence labels remain plain")
     func futureKnownUnsupportedFenceLabelsRemainPlain() {
-        #expect(ACPCodeLanguage.highlighterExtension(for: "sql") == nil)
+        #expect(ACPCodeLanguage.highlighterExtension(for: "pl") == nil)
         #expect(ACPCodeLanguage.highlighterExtension(for: "perl") == nil)
+        #expect(ACPCodeLanguage.highlighterExtension(for: "ex") == nil)
+        #expect(ACPCodeLanguage.highlighterExtension(for: "exs") == nil)
         #expect(ACPCodeLanguage.highlighterExtension(for: "elixir") == nil)
         #expect(ACPCodeLanguage.highlighterExtension(for: "ini") == nil)
     }
@@ -93,7 +96,7 @@ struct ACPCodeBlockHighlighterTests {
         #expect(ACPCodeLanguage.highlighterExtension(forPath: "page.htm") == "htm")
         #expect(ACPCodeLanguage.highlighterExtension(forPath: "styles.scss") == "scss")
         #expect(ACPCodeLanguage.highlighterExtension(forPath: "changes.patch") == "patch")
-        #expect(ACPCodeLanguage.highlighterExtension(forPath: "query.sql") == nil)
+        #expect(ACPCodeLanguage.highlighterExtension(forPath: "query.sql") == "sql")
         #expect(ACPCodeLanguage.highlighterExtension(forPath: "README") == nil)
     }
 
@@ -164,8 +167,8 @@ struct ACPCodeBlockHighlighterTests {
             locations: ["Sources/App.swift", "Sources/Other.swift"]
         ) == nil)
         #expect(ACPToolOutputSyntax.highlighterExtension(
-            content: "SELECT * FROM users",
-            locations: ["query.sql"]
+            content: "theme = cool-slate",
+            locations: ["config.ini"]
         ) == nil)
     }
 
@@ -196,8 +199,8 @@ struct ACPCodeBlockHighlighterTests {
         #expect(try foregroundColor(for: "fff", in: css) != editorTheme.defaultFG)
     }
 
-    @Test("future-known unsupported ACP labels keep attributed output plain")
-    func futureKnownUnsupportedAttributedOutputRemainsPlain() throws {
+    @Test("SQL labels apply non-default ACP syntax colors")
+    func sqlLabelsApplySyntaxColors() throws {
         let theme = try Theme.loadBundled(id: "cool-slate")
         let editorTheme = EditorTheme(theme: theme)
         let attributed = ACPCodeBlockHighlighter.attributedString(
@@ -207,7 +210,7 @@ struct ACPCodeBlockHighlighterTests {
         )
 
         #expect(attributed.string == "SELECT id FROM users WHERE active = true;")
-        #expect(allForegroundColors(in: attributed, equal: editorTheme.defaultFG))
+        #expect(try foregroundColor(for: "SELECT", in: attributed) != editorTheme.defaultFG)
     }
 
     @Test("Swift code applies syntax color while preserving monospaced font")
@@ -370,8 +373,8 @@ struct ACPCodeBlockHighlighterTests {
     func toolOutputUnsupportedPathRemainsPlain() throws {
         let theme = try Theme.loadBundled(id: "cool-slate")
         let editorTheme = EditorTheme(theme: theme)
-        let content = "SELECT id FROM users"
-        let ext = ACPToolOutputSyntax.highlighterExtension(content: content, locations: ["query.sql"])
+        let content = "theme = cool-slate"
+        let ext = ACPToolOutputSyntax.highlighterExtension(content: content, locations: ["config.ini"])
         let attributed = ACPCodeBlockHighlighter.attributedString(
             code: content,
             language: ext,

--- a/AlasTests/ACP/UI/ACPCodeBlockHighlighterTests.swift
+++ b/AlasTests/ACP/UI/ACPCodeBlockHighlighterTests.swift
@@ -110,6 +110,28 @@ struct ACPCodeBlockHighlighterTests {
         #expect(ACPToolOutputSyntax.highlighterExtension(content: content, locations: ["Sources/App.swift"]) == "diff")
     }
 
+    @Test("tool output syntax uses whole-output fenced labels")
+    func toolOutputSyntaxUsesWholeOutputFencedLabels() {
+        let content = """
+        ```sql
+        SELECT id FROM users
+        ```
+        """
+        #expect(ACPToolOutputSyntax.highlighterExtension(content: content, locations: []) == "sql")
+    }
+
+    @Test("tool output syntax prefers fenced labels over diff shape")
+    func toolOutputSyntaxPrefersFencedLabelsOverDiffShape() {
+        let content = """
+        ```swift
+        @@ -1 +1 @@
+        -old
+        +new
+        ```
+        """
+        #expect(ACPToolOutputSyntax.highlighterExtension(content: content, locations: []) == "swift")
+    }
+
     @Test("tool output syntax detects ACP-flattened diffs")
     func toolOutputSyntaxDetectsACPFlattenedDiffs() {
         let content = """

--- a/AlasTests/ACP/UI/ACPCodeBlockHighlighterTests.swift
+++ b/AlasTests/ACP/UI/ACPCodeBlockHighlighterTests.swift
@@ -327,4 +327,59 @@ struct ACPCodeBlockHighlighterTests {
         #expect(a != differentRawToken)
         #expect(a != differentResolvedColorOverride)
     }
+
+    @Test("tool output diff choice applies diff syntax colors")
+    func toolOutputDiffChoiceAppliesColors() throws {
+        let theme = try Theme.loadBundled(id: "cool-slate")
+        let editorTheme = EditorTheme(theme: theme)
+        let content = """
+        @@ -1 +1 @@
+        -old
+        +new
+        """
+        let ext = ACPToolOutputSyntax.highlighterExtension(content: content, locations: ["Sources/App.swift"])
+        let attributed = ACPCodeBlockHighlighter.attributedString(
+            code: content,
+            language: ext,
+            theme: theme,
+            fontSize: 11.5
+        )
+
+        #expect(ext == "diff")
+        #expect(try foregroundColor(for: "@@", in: attributed) != editorTheme.defaultFG)
+    }
+
+    @Test("tool output single path choice applies file syntax colors")
+    func toolOutputSinglePathChoiceAppliesColors() throws {
+        let theme = try Theme.loadBundled(id: "cool-slate")
+        let editorTheme = EditorTheme(theme: theme)
+        let content = "func greet() {}"
+        let ext = ACPToolOutputSyntax.highlighterExtension(content: content, locations: ["Sources/App.swift"])
+        let attributed = ACPCodeBlockHighlighter.attributedString(
+            code: content,
+            language: ext,
+            theme: theme,
+            fontSize: 11.5
+        )
+
+        #expect(ext == "swift")
+        #expect(try foregroundColor(for: "func", in: attributed) != editorTheme.defaultFG)
+    }
+
+    @Test("tool output unsupported path remains default-colored")
+    func toolOutputUnsupportedPathRemainsPlain() throws {
+        let theme = try Theme.loadBundled(id: "cool-slate")
+        let editorTheme = EditorTheme(theme: theme)
+        let content = "SELECT id FROM users"
+        let ext = ACPToolOutputSyntax.highlighterExtension(content: content, locations: ["query.sql"])
+        let attributed = ACPCodeBlockHighlighter.attributedString(
+            code: content,
+            language: ext,
+            theme: theme,
+            fontSize: 11.5
+        )
+
+        #expect(ext == nil)
+        #expect(allForegroundColors(in: attributed, equal: editorTheme.defaultFG))
+    }
 }

--- a/AlasTests/ACP/UI/ACPCodeBlockHighlighterTests.swift
+++ b/AlasTests/ACP/UI/ACPCodeBlockHighlighterTests.swift
@@ -83,6 +83,91 @@ struct ACPCodeBlockHighlighterTests {
         #expect(ACPCodeLanguage.highlighterExtension(for: "ini") == nil)
     }
 
+    @Test("path resolution maps only supported editor highlighter paths")
+    func pathResolutionMapsSupportedPaths() {
+        #expect(ACPCodeLanguage.highlighterExtension(forPath: "Sources/App.swift") == "swift")
+        #expect(ACPCodeLanguage.highlighterExtension(forPath: "script.py") == "py")
+        #expect(ACPCodeLanguage.highlighterExtension(forPath: "package.json") == "json")
+        #expect(ACPCodeLanguage.highlighterExtension(forPath: "Dockerfile") == "dockerfile")
+        #expect(ACPCodeLanguage.highlighterExtension(forPath: "page.htm") == "htm")
+        #expect(ACPCodeLanguage.highlighterExtension(forPath: "styles.scss") == "scss")
+        #expect(ACPCodeLanguage.highlighterExtension(forPath: "changes.patch") == "patch")
+        #expect(ACPCodeLanguage.highlighterExtension(forPath: "query.sql") == nil)
+        #expect(ACPCodeLanguage.highlighterExtension(forPath: "README") == nil)
+    }
+
+    @Test("tool output syntax prefers diff shape over paths")
+    func toolOutputSyntaxPrefersDiffShape() {
+        let content = """
+        @@ -1,2 +1,2 @@
+        -old
+        +new
+        """
+        #expect(ACPToolOutputSyntax.highlighterExtension(content: content, locations: ["Sources/App.swift"]) == "diff")
+    }
+
+    @Test("tool output syntax detects ACP-flattened diffs")
+    func toolOutputSyntaxDetectsACPFlattenedDiffs() {
+        let content = """
+        --- a.swift
+        -let old = 1
+        +let new = 2
+        """
+        #expect(ACPToolOutputSyntax.highlighterExtension(content: content, locations: []) == "diff")
+    }
+
+    @Test("tool output syntax detects ACP-flattened diffs with indented code")
+    func toolOutputSyntaxDetectsACPFlattenedDiffsWithIndentedCode() {
+        let content = """
+        --- Sources/App.swift
+        -    let old = 1
+        +    let new = 2
+        """
+        #expect(ACPToolOutputSyntax.highlighterExtension(content: content, locations: []) == "diff")
+    }
+
+    @Test("tool output syntax rejects section headings that resemble hunk markers")
+    func toolOutputSyntaxRejectsSectionHeadingHunkMarkers() {
+        #expect(ACPToolOutputSyntax.highlighterExtension(
+            content: "@@ Section @@",
+            locations: ["Sources/App.swift"]
+        ) == "swift")
+    }
+
+    @Test("tool output syntax rejects markdown-like flattened diff markers")
+    func toolOutputSyntaxRejectsMarkdownLikeFlattenedDiffMarkers() {
+        let content = """
+        --- Notes
+        - item one
+        + item two
+        """
+        #expect(ACPToolOutputSyntax.highlighterExtension(content: content, locations: []) == nil)
+    }
+
+    @Test("tool output syntax uses exactly one supported location path")
+    func toolOutputSyntaxUsesSingleSupportedPath() {
+        #expect(ACPToolOutputSyntax.highlighterExtension(
+            content: "let value = 1",
+            locations: ["Sources/App.swift"]
+        ) == "swift")
+    }
+
+    @Test("tool output syntax remains plain for ambiguous or unsupported paths")
+    func toolOutputSyntaxRejectsAmbiguousOutput() {
+        #expect(ACPToolOutputSyntax.highlighterExtension(
+            content: "let value = 1",
+            locations: []
+        ) == nil)
+        #expect(ACPToolOutputSyntax.highlighterExtension(
+            content: "let value = 1",
+            locations: ["Sources/App.swift", "Sources/Other.swift"]
+        ) == nil)
+        #expect(ACPToolOutputSyntax.highlighterExtension(
+            content: "SELECT * FROM users",
+            locations: ["query.sql"]
+        ) == nil)
+    }
+
     @Test("supported labels apply non-default ACP syntax colors")
     func supportedLabelsApplySyntaxColors() throws {
         let theme = try Theme.loadBundled(id: "cool-slate")

--- a/docs/superpowers/specs/2026-06-08-acp-chat-syntax-highlighting-design.md
+++ b/docs/superpowers/specs/2026-06-08-acp-chat-syntax-highlighting-design.md
@@ -1,0 +1,86 @@
+# ACP Chat Syntax Highlighting Design
+
+## Context
+
+ACP markdown fenced code blocks already render through `ACPCodeBlockHighlighter`, which maps common fence labels to editor highlighter extensions and delegates to `TreeSitterHighlighter`. The editor highlighter and `LanguageRegistry` are the source of truth for supported syntax highlighting: Swift, Python, JavaScript/JSX, TypeScript/TSX, Bash/Zsh, Markdown, JSON, YAML, TOML, Rust, Go, Java, Kotlin, C/C++, HTML, CSS, PHP, Ruby, Lua, HCL/Terraform, Dockerfile, plus regex fallback for diff/patch.
+
+Expanded tool-call output in `ACPToolCallCard` currently renders as plain monospaced `Text`. Tool cards are collapsed by default, which gives us a natural lazy boundary for syntax highlighting.
+
+## Goals
+
+- Use the existing editor-backed syntax highlighter for ACP chat rendering.
+- Highlight fenced code blocks for every language already supported by the editor highlighter.
+- Highlight expanded tool output conservatively when it is clearly a diff or a single supported file dump.
+- Keep collapsed tool calls cheap by doing highlight work only when expanded output is rendered.
+- Preserve plain monospaced fallback behavior for unsupported or ambiguous output.
+
+## Non-Goals
+
+- Do not add new grammar packages or expand editor language support.
+- Do not sniff arbitrary JSON, YAML, shell, or other languages from content without a path.
+- Do not move UI highlighting state into persisted ACP transcript models.
+- Do not change structured file edit rendering through `InlineDiffView`.
+
+## Architecture
+
+Add a reusable ACP syntax-highlighted text path for monospaced code-like blocks. It should be usable by fenced markdown code blocks and expanded tool-call output. The reusable path receives text, an optional explicit language label, an optional source path, a theme, and a font size. It resolves an extension, asks `ACPCodeBlockHighlighter` for attributed output, and renders a SwiftUI `Text` from the resulting `AttributedString`.
+
+Keep `TreeSitterHighlighter` and `LanguageRegistry` as the only source of supported language coverage. `ACPCodeLanguage` should grow from fence-label mapping into a small ACP-facing resolver:
+
+- explicit markdown fence labels map to existing highlighter extensions;
+- paths map through `LanguageRegistry.highlighterExtension(forPath:)`;
+- path-derived extensions pass through only when they are supported by `LanguageRegistry` or by the existing highlighter fallback for diff/patch-style extensions;
+- unsupported labels or paths return nil and render plain.
+
+This keeps ACP behavior aligned with the editor without duplicating language coverage lists in multiple places.
+
+## Tool Output Inference
+
+Expanded tool output uses conservative inference:
+
+1. If output shape clearly looks like a unified diff, render as `diff`. Examples include `diff --git`, hunk headers such as `@@ -1 +1 @@`, or ACP-flattened diffs with a `--- path` header followed by added/removed lines.
+2. Otherwise, if the tool call has exactly one location/path and that path maps to a supported highlighter extension, render with that language.
+3. Otherwise, render plain monospaced output.
+
+Explicit fenced markdown language labels remain stronger than any path inference. Generic tool output does not infer JSON/YAML/Shell/etc. from content alone.
+
+If a completed off-window tool call has truncated in-memory content, the current first-expansion load path remains unchanged. Highlighting runs against the display content after the full content is loaded.
+
+## Lazy Rendering And Caching
+
+Syntax highlighting for tool output should be view-lazy: collapsed `ACPToolCallCard` rows should not create highlighted attributed output. The highlighted view only exists inside the expanded body.
+
+Add lightweight view-local caching for highlighted output. The cache key should include:
+
+- text;
+- resolved highlighter extension, or nil for plain output;
+- theme identity or the specific colors used by `EditorTheme`;
+- font size.
+
+Unsupported or failed highlighting should return default-colored monospaced text, matching today's fenced-code fallback.
+
+## Components
+
+- `ACPCodeLanguage`: resolve explicit labels, supported paths, and conservative tool-output extensions.
+- `ACPCodeBlockHighlighter`: continue producing `NSAttributedString` from code, extension, theme, and font size.
+- New reusable highlighted SwiftUI text view/helper: bridge `NSAttributedString` to Swift `AttributedString`, preserve monospaced font, text selection, line spacing, and existing colors.
+- `ACPMarkdownText` code-block rendering: use the shared helper while preserving current visual layout.
+- `ACPToolCallCard` expanded output: use the shared helper with conservative tool-output inference.
+
+## Error Handling
+
+All highlighting failures are non-fatal. If language resolution fails, Tree-sitter query loading fails, parsing fails, or generated ranges are invalid, output remains readable as plain monospaced text. Tool-card expansion and full-content loading should behave exactly as they do today.
+
+## Testing
+
+Add or extend Swift Testing coverage for:
+
+- fence label resolution still maps current supported ACP labels;
+- path-based resolution maps supported editor paths and rejects unsupported paths;
+- diff-shape detection recognizes unified diffs and ACP-flattened diffs;
+- tool-call output chooses `diff` for diff-shaped output;
+- tool-call output chooses a single supported location path;
+- tool-call output remains plain for unknown paths, multiple paths, and no paths;
+- existing code-block highlighting tests remain green.
+
+No broad UI snapshot test is required for this pass because the behavior is mostly resolver and attributed-string output logic.


### PR DESCRIPTION
## Summary
- Reuse the editor highlighter for ACP fenced code blocks and expanded tool output.
- Add conservative tool-output language inference for diffs, supported file paths, SQL fallback, and preserved wrapping fence labels.
- Add view-local highlighted text caching keyed by content, language, theme inputs, and font size.

## Test Plan
- `rtk xcodegen`
- `rtk xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -quiet build`
- `rtk xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' test`