### PR TITLE
fix(remote): tool cards on mobile

### DIFF
--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -47,6 +47,7 @@
 		0B6ADBF320E6130E5888CAA7 /* RemoteSessionGatewayTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37011506F459800FFF6D12A9 /* RemoteSessionGatewayTests.swift */; };
 		0BA997A903C1DC2A41D64E22 /* AgentRunner.swift in Sources */ = {isa = PBXBuildFile; fileRef = A919B8770029DBE7FCFF0EE2 /* AgentRunner.swift */; };
 		0BBFEE487AF71AD858B19EC5 /* ACPPermissionPrompt.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0BCD93747BF71CB256038314 /* ACPPermissionPrompt.swift */; };
+		0C0C65E3012A722B10816F8D /* RemoteWebAssetTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5AA5809066E33EB30E09E0D8 /* RemoteWebAssetTests.swift */; };
 		0C54356D0ACEDD5275FFB6EB /* CodeLanguageDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A727D24652E45B98C10917F8 /* CodeLanguageDetailView.swift */; };
 		0CF488290CC525EA7C11A43C /* DiffParserTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE26221DC8E8837FFEB87474 /* DiffParserTests.swift */; };
 		0D17211026C6790B96CC6578 /* CopyFeedbackState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5C8BF1EC24E449A302A1E25C /* CopyFeedbackState.swift */; };
@@ -1316,6 +1317,7 @@
 		5A2EFB5253073D6A4A328FE0 /* RemoteConnection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteConnection.swift; sourceTree = "<group>"; };
 		5A43A7D90E591CFD18088C70 /* AgentLauncherModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentLauncherModel.swift; sourceTree = "<group>"; };
 		5A85E1D1600F487D359F363F /* RightPaneStateFileTreeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RightPaneStateFileTreeTests.swift; sourceTree = "<group>"; };
+		5AA5809066E33EB30E09E0D8 /* RemoteWebAssetTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteWebAssetTests.swift; sourceTree = "<group>"; };
 		5B3FF64CC698074BFDE2A36A /* ProjectConfigTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProjectConfigTests.swift; sourceTree = "<group>"; };
 		5BAC89A6B9D5DC926AC18E13 /* MergeConflictTabView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MergeConflictTabView.swift; sourceTree = "<group>"; };
 		5BB6172AE118D2F9A40FD534 /* AgentsPane.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentsPane.swift; sourceTree = "<group>"; };
@@ -1957,6 +1959,7 @@
 				C02B44D8CC0AE48BFA9CD88E /* RemoteProtocolTests.swift */,
 				A79A06E48E215BF7B9EC2408 /* RemoteServerIntegrationTests.swift */,
 				37011506F459800FFF6D12A9 /* RemoteSessionGatewayTests.swift */,
+				5AA5809066E33EB30E09E0D8 /* RemoteWebAssetTests.swift */,
 				DF919734A34EEB87FA61FE07 /* WebSocketFrameTests.swift */,
 			);
 			path = Remote;
@@ -4675,6 +4678,7 @@
 				A7B9BDE0F2EB1D1769EC81B5 /* RemoteProtocolTests.swift in Sources */,
 				A962107126052DEF597CB7FA /* RemoteServerIntegrationTests.swift in Sources */,
 				0B6ADBF320E6130E5888CAA7 /* RemoteSessionGatewayTests.swift in Sources */,
+				0C0C65E3012A722B10816F8D /* RemoteWebAssetTests.swift in Sources */,
 				133597E7D43CFE746EF4EF2B /* RepoGroupViewLayoutTests.swift in Sources */,
 				737EC7C9A35C9ED61ED67B83 /* RepoSelectorModelTests.swift in Sources */,
 				35705563BBEDDC1D0092C1F5 /* RepoSelectorRecentsTests.swift in Sources */,

--- a/Alas/Resources/RemoteWeb/app.js
+++ b/Alas/Resources/RemoteWeb/app.js
@@ -133,7 +133,7 @@ function renderMessages(forceBottom) {
   const atBottom = forceBottom || (box.scrollTop + box.clientHeight >= box.scrollHeight - 120);
   // Preserve which tool/thought cards the user expanded across re-renders.
   const open = new Set();
-  box.querySelectorAll("details[open]").forEach(d => { if (d.dataset.sid) open.add(d.dataset.sid); });
+  box.querySelectorAll(".m-collapsible.is-open").forEach(d => { if (d.dataset.sid) open.add(d.dataset.sid); });
   box.innerHTML = "";
   for (const [sid, m] of messages) box.appendChild(renderMessage(m, sid, open));
   if (atBottom) requestAnimationFrame(() => { box.scrollTop = box.scrollHeight; });
@@ -165,8 +165,7 @@ function renderMessage(m, sid, open) {
   } else if (m.kind === "systemNotice") {
     node = el("div", "msg m-systemNotice", m.text || "");
   } else if (m.kind === "thought") {
-    node = el("details", "msg m-thought");
-    node.append(el("summary", null, "Thinking…"), el("div", "thought-body", m.text || ""));
+    node = thoughtCard(m.text || "");
   } else if (m.kind === "toolCall") {
     node = toolCard(jparse(m.json) || {});
   } else if (m.kind === "fileEdit") {
@@ -177,11 +176,25 @@ function renderMessage(m, sid, open) {
   } else {
     node = el("div", "msg m-agent", m.text || "");
   }
-  if (node.tagName === "DETAILS") {            // restore prior expand state
+  if (node.classList?.contains("m-collapsible")) {            // restore prior expand state
     node.dataset.sid = sid;
-    if (open && open.has(sid)) node.open = true;
+    if (open && open.has(sid)) setCardOpen(node, true);
   }
   return node;
+}
+
+function thoughtCard(text) {
+  const d = el("div", "msg m-thought m-collapsible");
+  const button = el("button", "thought-toggle", "Thinking…");
+  button.type = "button";
+  button.dataset.cardToggle = "true";
+  button.setAttribute("aria-expanded", "false");
+  const body = el("div", "thought-body", text);
+  body.dataset.cardBody = "true";
+  body.hidden = true;
+  button.onclick = () => setCardOpen(d, !d.classList.contains("is-open"));
+  d.append(button, body);
+  return d;
 }
 
 function toolCard(tc) {
@@ -195,14 +208,29 @@ function toolCard(tc) {
 }
 
 function structCard(verb, name, body, preview) {
-  const d = el("details", "msg m-tool");
-  const sum = el("summary");
-  sum.append(el("span", "tool-verb", verb));
-  sum.append(el("span", "tool-name", name || ""));
-  sum.append(el("span", "tool-preview", preview || ""));
-  sum.append(el("span", "tool-chev", "⌄"));
-  d.append(sum, el("pre", "tool-body", body || ""));
+  const d = el("div", "msg m-tool m-collapsible");
+  const button = el("button", "tool-toggle");
+  button.type = "button";
+  button.dataset.cardToggle = "true";
+  button.setAttribute("aria-expanded", "false");
+  button.append(el("span", "tool-verb", verb));
+  button.append(el("span", "tool-name", name || ""));
+  button.append(el("span", "tool-preview", preview || ""));
+  button.append(el("span", "tool-chev", "⌄"));
+  const content = el("pre", "tool-body", body || "");
+  content.dataset.cardBody = "true";
+  content.hidden = true;
+  button.onclick = () => setCardOpen(d, !d.classList.contains("is-open"));
+  d.append(button, content);
   return d;
+}
+
+function setCardOpen(card, isOpen) {
+  card.classList.toggle("is-open", isOpen);
+  const body = card.querySelector("[data-card-body]");
+  if (body) body.hidden = !isOpen;
+  const toggle = card.querySelector("[data-card-toggle]");
+  if (toggle) toggle.setAttribute("aria-expanded", isOpen ? "true" : "false");
 }
 
 function planText(o) {

--- a/Alas/Resources/RemoteWeb/style.css
+++ b/Alas/Resources/RemoteWeb/style.css
@@ -80,24 +80,22 @@ h1 { font-size: 22px; font-weight: 700; margin: 12px 4px 10px; }
 
 /* Thinking — collapsed by default, left accent rule */
 .m-thought { align-self: stretch; border-left: 1.5px solid var(--bg-4); padding-left: 11px; margin: 6px 0; }
-.m-thought > summary { list-style: none; cursor: pointer; color: var(--fg-faint); font-size: 11px; padding: 3px 0; }
-.m-thought > summary::-webkit-details-marker { display: none; }
-.m-thought > summary::before { content: "•••  "; }
-.m-thought[open] > summary::before { content: "×  "; }
+.thought-toggle { display: block; width: 100%; border: none; background: none; color: var(--fg-faint); font: inherit; font-size: 11px; text-align: left; padding: 3px 0; cursor: pointer; -webkit-tap-highlight-color: transparent; }
+.thought-toggle::before { content: "•••  "; }
+.m-thought.is-open .thought-toggle::before { content: "×  "; }
 .m-thought .thought-body { color: var(--fg-dim); font-style: italic; font-size: 13px; line-height: 1.5; padding: 4px 0 2px; }
 
 /* Tool call / structured card — collapsed by default */
 .m-tool { align-self: stretch; background: color-mix(in oklab, var(--bg-1) 60%, transparent); border: 0.5px solid var(--line); border-radius: 8px; margin: 5px 0; overflow: hidden; }
-.m-tool[open] { border-color: var(--bg-4); }
-.m-tool > summary { list-style: none; cursor: pointer; display: flex; align-items: center; gap: 8px; padding: 8px 10px; }
-.m-tool > summary::-webkit-details-marker { display: none; }
+.m-tool.is-open { border-color: var(--bg-4); }
+.tool-toggle { width: 100%; border: none; background: none; color: inherit; font: inherit; cursor: pointer; display: flex; align-items: center; gap: 8px; padding: 8px 10px; text-align: left; -webkit-tap-highlight-color: transparent; }
 .tool-verb { flex-shrink: 0; font-size: 10px; font-weight: 700; letter-spacing: .6px; text-transform: uppercase; color: var(--accent); }
 .tool-name { color: var(--fg-muted); font-family: ui-monospace, monospace; font-size: 12px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
 .tool-preview { flex: 1; min-width: 0; color: var(--fg-faint); font-family: ui-monospace, monospace; font-size: 11px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
 .tool-status { flex-shrink: 0; margin-left: auto; font-size: 12px; font-weight: 700; }
 .tool-status.ok { color: var(--add); } .tool-status.err { color: var(--del); } .tool-status.run { color: var(--fg-faint); }
 .tool-chev { flex-shrink: 0; color: var(--fg-faint); font-size: 11px; transition: transform .15s; }
-.m-tool[open] .tool-chev { transform: rotate(180deg); }
+.m-tool.is-open .tool-chev { transform: rotate(180deg); }
 .tool-body { margin: 0; padding: 9px 11px; border-top: 0.5px solid var(--line-soft); background: color-mix(in oklab, var(--bg-0) 55%, transparent); font-family: ui-monospace, monospace; font-size: 11.5px; line-height: 1.45; color: var(--fg-muted); white-space: pre; overflow-x: auto; max-height: 46vh; overflow-y: auto; }
 
 /* Composer / drive bar */

--- a/AlasTests/Remote/RemoteWebAssetTests.swift
+++ b/AlasTests/Remote/RemoteWebAssetTests.swift
@@ -1,0 +1,28 @@
+import Foundation
+import Testing
+
+struct RemoteWebAssetTests {
+    private func asset(_ relativePath: String) throws -> String {
+        let root = URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+        let url = root
+            .appendingPathComponent("Alas")
+            .appendingPathComponent("Resources")
+            .appendingPathComponent("RemoteWeb")
+            .appendingPathComponent(relativePath)
+        return try String(contentsOf: url, encoding: .utf8)
+    }
+
+    @Test func toolCardsUseExplicitToggleInsteadOfNativeDetails() throws {
+        let app = try asset("app.js")
+        let css = try asset("style.css")
+
+        #expect(app.contains(#"const d = el("div", "msg m-tool m-collapsible")"#))
+        #expect(app.contains("setCardOpen"))
+        #expect(app.contains(#"setAttribute("aria-expanded""#))
+        #expect(!app.contains(#"const d = el("details", "msg m-tool")"#))
+        #expect(!css.contains(".m-tool > summary"))
+    }
+}


### PR DESCRIPTION
## Summary
- Replace native remote web tool/thought disclosure elements with explicit button-driven collapsibles
- Preserve expanded card state across transcript rerenders
- Add a remote web asset regression test for the mobile-safe markup

## Verification
- `node --check Alas/Resources/RemoteWeb/app.js`
- `xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' test -only-testing:AlasTests/RemoteWebAssetTests`
- `xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -quiet build`

Full suite was attempted locally; it did not complete cleanly. The visible failure was in `ACPSessionManagerAttachRestoreTests`, unrelated to the remote web asset change.