### PR TITLE
fix(acp): clear restored transcript context marker

### DIFF
--- a/Alas/Sources/ACP/Session/ACPSession.swift
+++ b/Alas/Sources/ACP/Session/ACPSession.swift
@@ -81,6 +81,8 @@ final class ACPSession: ObservableObject, Identifiable {
     /// persisted session fields instead.
     @Published var firstRunConnectingPhase: ACPFirstRunConnectingPhase?
 
+    private var contextRecoveryExpiryTask: Task<Void, Never>?
+
     /// Runtime-only marker for a forced queue item parked behind the current
     /// `.sending` head. If that head fails, it moves behind this item so the
     /// explicit force-send remains next.
@@ -191,6 +193,7 @@ final class ACPSession: ObservableObject, Identifiable {
     }
 
     deinit {
+        contextRecoveryExpiryTask?.cancel()
         // Foundation cannot await main-actor methods from deinit; dispatch.
         let host = terminalHost
         Task { @MainActor in host.killAll() }
@@ -224,6 +227,7 @@ final class ACPSession: ObservableObject, Identifiable {
     func apply(_ update: ACPSessionUpdate) -> Set<Int> {
         switch update {
         case .agentMessageChunk(let block):
+            clearRestoredContextRecoveryStatus()
             let txt = text(of: block)
             let i = appendStreaming(text: txt, locate: { lastAgent() },
                                     makeNew: { .agent(id: UUID(), StreamingText(txt)) })
@@ -235,11 +239,13 @@ final class ACPSession: ObservableObject, Identifiable {
             transcript.completedOutputBoundaryMessageIds.removeAll()
             return [transcript.messages.count - 1]
         case .agentThoughtChunk(let block):
+            clearRestoredContextRecoveryStatus()
             let txt = text(of: block)
             let i = appendStreaming(text: txt, locate: { lastThought() },
                                     makeNew: { .thought(id: UUID(), StreamingText(txt)) })
             return [i]
         case .toolCall(let payload):
+            clearRestoredContextRecoveryStatus()
             let items = payload.content ?? []
             let full = Self.stripWrappingFence(Self.flatten(items),
                                                isFinal: Self.isFinalStatus(payload.status))
@@ -256,6 +262,7 @@ final class ACPSession: ObservableObject, Identifiable {
             transcript.completedOutputBoundaryMessageIds.removeAll()
             return [transcript.messages.count - 1]
         case .toolCallUpdate(let u):
+            clearRestoredContextRecoveryStatus()
             let touched = updateToolCall(id: u.toolCallId) { tc in
                 if let s = u.status { tc.status = s }
                 if let c = u.content {
@@ -273,6 +280,7 @@ final class ACPSession: ObservableObject, Identifiable {
             }
             return touched.map { [$0] } ?? []
         case .plan(let entries):
+            clearRestoredContextRecoveryStatus()
             let items = entries.map { ACPMessage.PlanItem(content: $0.content, status: $0.status) }
             // Overwrite the existing plan in place only if it belongs to
             // the current turn (i.e. sits after the latest user prompt).
@@ -310,12 +318,24 @@ final class ACPSession: ObservableObject, Identifiable {
         }
     }
 
+    func markContextRecoveryRestored(expiryNanoseconds: UInt64 = 30_000_000_000) {
+        contextRecoveryExpiryTask?.cancel()
+        contextRecoveryStatus = .restored
+        contextRecoveryExpiryTask = Task { @MainActor [weak self] in
+            try? await Task.sleep(nanoseconds: expiryNanoseconds)
+            guard !Task.isCancelled, self?.contextRecoveryStatus == .restored else { return }
+            self?.contextRecoveryStatus = nil
+            self?.contextRecoveryExpiryTask = nil
+        }
+    }
+
     func appendSystemNotice(_ text: String) {
         transcript.messages.append(.systemNotice(id: UUID(), text: text))
         didAppendTranscriptMessage()
     }
 
     func appendFileEdit(_ edit: ACPMessage.FileEdit) {
+        clearRestoredContextRecoveryStatus()
         transcript.messages.append(.fileEdit(id: UUID(), edit))
         didAppendTranscriptMessage()
         transcript.completedOutputBoundaryMessageIds.removeAll()
@@ -746,6 +766,13 @@ final class ACPSession: ObservableObject, Identifiable {
             toolCallIndices[tc.toolCallId] = index
         }
         advanceRenderWindowIfFollowingTail()
+    }
+
+    private func clearRestoredContextRecoveryStatus() {
+        guard contextRecoveryStatus == .restored else { return }
+        contextRecoveryExpiryTask?.cancel()
+        contextRecoveryExpiryTask = nil
+        contextRecoveryStatus = nil
     }
 
     private func rebuildToolCallIndices() {

--- a/Alas/Sources/ACP/Session/ACPSessionManager.swift
+++ b/Alas/Sources/ACP/Session/ACPSessionManager.swift
@@ -1541,7 +1541,7 @@ extension ACPSessionManager {
             if delivered {
                 self.persistContextRecoveryPending(sessionId: sessionId, pending: false)
                 session.contextRestoreWarning = nil
-                session.contextRecoveryStatus = .restored
+                session.markContextRecoveryRestored()
             } else {
                 session.contextRecoveryStatus = .failed("Transcript recovery failed.")
             }

--- a/AlasTests/ACP/Session/ACPSessionTests.swift
+++ b/AlasTests/ACP/Session/ACPSessionTests.swift
@@ -206,6 +206,36 @@ struct ACPSessionTests {
         ))
     }
 
+    @Test("restored context recovery marker clears when agent output starts")
+    func restoredContextRecoveryMarkerClearsWhenAgentOutputStarts() async {
+        let session = ACPSession(id: "s", agentId: "codex", worktreeId: "w", title: "t")
+        session.markContextRecoveryRestored(expiryNanoseconds: 60_000_000_000)
+
+        session.apply(.agentMessageChunk(.text("answer")))
+
+        #expect(session.contextRecoveryStatus == nil)
+    }
+
+    @Test("context recovery failure remains visible when agent output starts")
+    func contextRecoveryFailureRemainsVisibleWhenAgentOutputStarts() async {
+        let session = ACPSession(id: "s", agentId: "codex", worktreeId: "w", title: "t")
+        session.contextRecoveryStatus = .failed("Transcript recovery failed.")
+
+        session.apply(.agentMessageChunk(.text("answer")))
+
+        #expect(session.contextRecoveryStatus == .failed("Transcript recovery failed."))
+    }
+
+    @Test("restored context recovery marker expires")
+    func restoredContextRecoveryMarkerExpires() async throws {
+        let session = ACPSession(id: "s", agentId: "codex", worktreeId: "w", title: "t")
+        session.markContextRecoveryRestored(expiryNanoseconds: 1_000_000)
+
+        try await Task.sleep(nanoseconds: 20_000_000)
+
+        #expect(session.contextRecoveryStatus == nil)
+    }
+
     @Test("plan update creates / replaces the plan message")
     func plan() async {
         let session = ACPSession(id: "s", agentId: "claude", worktreeId: "w", title: "t")


### PR DESCRIPTION
## Summary

- Clear the "Transcript restored as model context" success marker when new agent output starts.
- Expire the restored marker after 30 seconds if the agent stays idle.
- Keep failed recovery state visible when subsequent agent output arrives.

## Validation

- `xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -quiet build`

## Notes

- Local `xcodebuild ... test` currently fails before tests execute with Xcode reporting the generated `.build/ghostty/GhosttyKit.xcframework` as missing during the test action, despite the build action succeeding with the same artifact present.