### PR TITLE
fix(diff): resolve LFS image blobs in comparisons

### DIFF
--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -443,6 +443,7 @@
 		771CD72B94194370E783F7DD /* StartupScriptResolverTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9D3C76F2F0F6BCE4023A9D7F /* StartupScriptResolverTests.swift */; };
 		77CDD88F7C517095DE580B50 /* ReviewEvidence.swift in Sources */ = {isa = PBXBuildFile; fileRef = FC11F5C6667A6ECB74E066AE /* ReviewEvidence.swift */; };
 		78D25A04EAE26A0F3021A057 /* Paths.swift in Sources */ = {isa = PBXBuildFile; fileRef = 364213292935A05F3B52F51F /* Paths.swift */; };
+		79212B50265AAC9A392957C9 /* GitLFSBlobResolver.swift in Sources */ = {isa = PBXBuildFile; fileRef = 90F0CBE40E2CF0251ABE72AE /* GitLFSBlobResolver.swift */; };
 		7950F5765E0B95EB1CB5B818 /* ACPNewChatEmptyStatePolicy.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF80D59C3200AD3215D1E140 /* ACPNewChatEmptyStatePolicy.swift */; };
 		79575F0DA597D2C2DFCDC9E2 /* LSPMessagesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE7675D7F75E36E9C81193C8 /* LSPMessagesTests.swift */; };
 		7A0D3E122F34EF1A2A04984F /* EnvBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 159FE807399835B0821E1CAB /* EnvBuilder.swift */; };
@@ -1491,6 +1492,7 @@
 		906D92F7AD84F313508D9CFD /* ACPComposerShell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPComposerShell.swift; sourceTree = "<group>"; };
 		90817EC3BAA727EF6D9FBD97 /* GitService+Discard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "GitService+Discard.swift"; sourceTree = "<group>"; };
 		90D74C28EB7B8C3CBC53994D /* MergeAgent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MergeAgent.swift; sourceTree = "<group>"; };
+		90F0CBE40E2CF0251ABE72AE /* GitLFSBlobResolver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GitLFSBlobResolver.swift; sourceTree = "<group>"; };
 		910CB5077C8E89A778F1E896 /* ChangesTreeBuilder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChangesTreeBuilder.swift; sourceTree = "<group>"; };
 		9110E0F4F4EF24444FA0BE3A /* JetBrainsMonoNerdFont-Regular.ttf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "JetBrainsMonoNerdFont-Regular.ttf"; sourceTree = "<group>"; };
 		91B5694DB75F80C8D7B51E82 /* MergeConflictToolbar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MergeConflictToolbar.swift; sourceTree = "<group>"; };
@@ -2388,6 +2390,7 @@
 				E1703FC5CD7DF16F4450E274 /* DiffParser.swift */,
 				339EA6ACAF180AADEC12841F /* FileTreeBuilder.swift */,
 				BDEA5E54A30636928F5D3B3E /* GitIgnoreService.swift */,
+				90F0CBE40E2CF0251ABE72AE /* GitLFSBlobResolver.swift */,
 				269CE27A6F4F2E663EDF9052 /* GitNameValidator.swift */,
 				9FF41571C93C1C34A77951E2 /* GitRefNameInputFilter.swift */,
 				B7CE7B4DAFDB65A79308FB63 /* GitService.swift */,
@@ -4110,6 +4113,7 @@
 				7D75AEB67376431930CB37E3 /* GitEventFilter.swift in Sources */,
 				C1D83EEBE3AF4ABC04B3F7EB /* GitHubCLIProvider.swift in Sources */,
 				B66EE6A2445C0DDA607788C2 /* GitIgnoreService.swift in Sources */,
+				79212B50265AAC9A392957C9 /* GitLFSBlobResolver.swift in Sources */,
 				EA2BAFA70ED22F6085EB1971 /* GitLabCLIProvider.swift in Sources */,
 				175951CE78A1446A9131BA1F /* GitNameValidator.swift in Sources */,
 				CD227C48AA85A5E74A92DF3F /* GitRefNameInputFilter.swift in Sources */,

--- a/Alas/Sources/Center/ImageDiff/GitService+ImageDiff.swift
+++ b/Alas/Sources/Center/ImageDiff/GitService+ImageDiff.swift
@@ -172,7 +172,10 @@ extension GitService {
             }
             return nil
         }
-        return NSImage(data: result.stdout)
+        return await GitLFSBlobResolver.image(
+            fromGitBlobData: result.stdout,
+            worktreePath: worktreePath
+        )
     }
 
     fileprivate func frameCount(for image: NSImage?) -> Int {

--- a/Alas/Sources/Center/MergeConflictBinaryView.swift
+++ b/Alas/Sources/Center/MergeConflictBinaryView.swift
@@ -109,6 +109,15 @@ private struct ImageStageView: NSViewRepresentable {
         let capturedCwd = worktreePath
         coordinator.loadTask = Task {
             let data = await Self.readStageData(stage: capturedStage, path: capturedPath, cwd: capturedCwd)
+            let image: NSImage?
+            if let data {
+                image = await GitLFSBlobResolver.image(
+                    fromGitBlobData: data,
+                    worktreePath: capturedCwd
+                )
+            } else {
+                image = nil
+            }
             if Task.isCancelled { return }
             await MainActor.run {
                 // Defensive: only apply if the coordinator's key still matches
@@ -116,7 +125,7 @@ private struct ImageStageView: NSViewRepresentable {
                 // mid-await, the new task already updated lastKey and we'd be
                 // setting an image for an outdated request.
                 guard coordinator.lastKey == capturedKey else { return }
-                if let data, let image = NSImage(data: data) {
+                if let image {
                     view.image = image
                 } else {
                     view.image = nil

--- a/Alas/Sources/Git/GitLFSBlobResolver.swift
+++ b/Alas/Sources/Git/GitLFSBlobResolver.swift
@@ -15,10 +15,14 @@ enum GitLFSBlobResolver {
     private static func lfsObjectData(forPointerData data: Data, worktreePath: URL) async -> Data? {
         guard let pointer = parsePointer(data) else { return nil }
         guard let commonDir = await gitCommonDirectory(worktreePath: worktreePath) else { return nil }
+        guard let storageDir = await lfsStorageDirectory(
+            worktreePath: worktreePath,
+            commonDir: commonDir
+        ) else { return nil }
 
         let oid = pointer.oid
-        let objectURL = commonDir
-            .appendingPathComponent("lfs/objects")
+        let objectURL = storageDir
+            .appendingPathComponent("objects")
             .appendingPathComponent(String(oid.prefix(2)))
             .appendingPathComponent(String(oid.dropFirst(2).prefix(2)))
             .appendingPathComponent(oid)
@@ -41,6 +45,23 @@ enum GitLFSBlobResolver {
             return URL(fileURLWithPath: path)
         }
         return worktreePath.appendingPathComponent(path)
+    }
+
+    private static func lfsStorageDirectory(worktreePath: URL, commonDir: URL) async -> URL? {
+        let result = try? await Process.git(
+            ["config", "--path", "--get", "lfs.storage"],
+            cwd: worktreePath
+        )
+        guard let result, result.exitCode == 0 else {
+            return commonDir.appendingPathComponent("lfs")
+        }
+
+        let path = result.stdout.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !path.isEmpty else { return commonDir.appendingPathComponent("lfs") }
+        if path.hasPrefix("/") {
+            return URL(fileURLWithPath: path)
+        }
+        return commonDir.appendingPathComponent(path)
     }
 
     private static func parsePointer(_ data: Data) -> LFSPointer? {

--- a/Alas/Sources/Git/GitLFSBlobResolver.swift
+++ b/Alas/Sources/Git/GitLFSBlobResolver.swift
@@ -1,0 +1,76 @@
+import AppKit
+import Foundation
+
+enum GitLFSBlobResolver {
+    static func image(fromGitBlobData data: Data, worktreePath: URL) async -> NSImage? {
+        if let image = NSImage(data: data) {
+            return image
+        }
+        guard let objectData = await lfsObjectData(forPointerData: data, worktreePath: worktreePath) else {
+            return nil
+        }
+        return NSImage(data: objectData)
+    }
+
+    private static func lfsObjectData(forPointerData data: Data, worktreePath: URL) async -> Data? {
+        guard let pointer = parsePointer(data) else { return nil }
+        guard let commonDir = await gitCommonDirectory(worktreePath: worktreePath) else { return nil }
+
+        let oid = pointer.oid
+        let objectURL = commonDir
+            .appendingPathComponent("lfs/objects")
+            .appendingPathComponent(String(oid.prefix(2)))
+            .appendingPathComponent(String(oid.dropFirst(2).prefix(2)))
+            .appendingPathComponent(oid)
+        guard let objectData = try? Data(contentsOf: objectURL) else { return nil }
+        if let size = pointer.size, objectData.count != size {
+            return nil
+        }
+        return objectData
+    }
+
+    private static func gitCommonDirectory(worktreePath: URL) async -> URL? {
+        let result = try? await Process.git(
+            ["rev-parse", "--git-common-dir"],
+            cwd: worktreePath
+        )
+        guard let result, result.exitCode == 0 else { return nil }
+        let path = result.stdout.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !path.isEmpty else { return nil }
+        if path.hasPrefix("/") {
+            return URL(fileURLWithPath: path)
+        }
+        return worktreePath.appendingPathComponent(path)
+    }
+
+    private static func parsePointer(_ data: Data) -> LFSPointer? {
+        guard data.count <= 1024,
+              let text = String(data: data, encoding: .utf8)
+        else { return nil }
+
+        let lines = text.split(separator: "\n", omittingEmptySubsequences: false)
+        guard lines.first == "version https://git-lfs.github.com/spec/v1" else {
+            return nil
+        }
+
+        var oid: String?
+        var size: Int?
+        for line in lines.dropFirst() {
+            if line.hasPrefix("oid sha256:") {
+                oid = String(line.dropFirst("oid sha256:".count))
+            } else if line.hasPrefix("size ") {
+                size = Int(line.dropFirst("size ".count))
+            }
+        }
+
+        guard let oid, oid.count == 64, oid.allSatisfy(\.isHexDigit) else {
+            return nil
+        }
+        return LFSPointer(oid: oid, size: size)
+    }
+
+    private struct LFSPointer {
+        let oid: String
+        let size: Int?
+    }
+}

--- a/AlasTests/ImageDiffPairLoaderTests.swift
+++ b/AlasTests/ImageDiffPairLoaderTests.swift
@@ -34,6 +34,51 @@ struct ImageDiffPairLoaderTests {
         )!
     }
 
+    private func writeLFSPointer(
+        for data: Data,
+        named fileName: String,
+        in repo: URL
+    ) async throws {
+        let oid = try await sha256Hex(data)
+        let pointer = """
+        version https://git-lfs.github.com/spec/v1
+        oid sha256:\(oid)
+        size \(data.count)
+
+        """
+        let objectDir = repo
+            .appendingPathComponent(".git/lfs/objects")
+            .appendingPathComponent(String(oid.prefix(2)))
+            .appendingPathComponent(String(oid.dropFirst(2).prefix(2)))
+        try FileManager.default.createDirectory(at: objectDir, withIntermediateDirectories: true)
+        try data.write(to: objectDir.appendingPathComponent(oid))
+        try pointer.write(
+            to: repo.appendingPathComponent(fileName),
+            atomically: true,
+            encoding: .utf8
+        )
+    }
+
+    private func sha256Hex(_ data: Data) async throws -> String {
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/usr/bin/shasum")
+        process.arguments = ["-a", "256"]
+
+        let input = Pipe()
+        let output = Pipe()
+        process.standardInput = input
+        process.standardOutput = output
+        process.standardError = Pipe()
+        try process.run()
+        input.fileHandleForWriting.write(data)
+        try input.fileHandleForWriting.close()
+        process.waitUntilExit()
+
+        let stdout = output.fileHandleForReading.readDataToEndOfFile()
+        let text = String(data: stdout, encoding: .utf8) ?? ""
+        return String(text.prefix(while: { $0 != " " }))
+    }
+
     @Test func loadsModifiedImagePair() async throws {
         let repo = try await makeRepo()
         defer { try? FileManager.default.removeItem(at: repo) }
@@ -220,5 +265,46 @@ struct ImageDiffPairLoaderTests {
         #expect(stagedPair.kind == .added)
         #expect(stagedPair.before == nil)
         #expect(stagedPair.after != nil)
+    }
+
+    @Test func loadsLFSImageFromHeadPointerForUnstagedDiff() async throws {
+        let repo = try await makeRepo()
+        defer { try? FileManager.default.removeItem(at: repo) }
+
+        try await writeLFSPointer(for: PngFixture.red, named: "logo.png", in: repo)
+        _ = try await Process.git(["add", "logo.png"], cwd: repo)
+        _ = try await Process.git(["commit", "-q", "-m", "lfs image"], cwd: repo)
+
+        try PngFixture.blue.write(to: repo.appendingPathComponent("logo.png"))
+
+        let pair = try await GitService().imageDiffPair(
+            worktreePath: repo, relativePath: "logo.png", staged: false
+        )
+        #expect(pair.kind == .modified)
+        #expect(pair.before != nil)
+        #expect(pair.after != nil)
+    }
+
+    @Test func loadsLFSImageFromIndexPointerForStagedDiff() async throws {
+        let repo = try await makeRepo()
+        defer { try? FileManager.default.removeItem(at: repo) }
+
+        try "seed\n".write(
+            to: repo.appendingPathComponent("seed.txt"),
+            atomically: true,
+            encoding: .utf8
+        )
+        _ = try await Process.git(["add", "seed.txt"], cwd: repo)
+        _ = try await Process.git(["commit", "-q", "-m", "seed"], cwd: repo)
+
+        try await writeLFSPointer(for: PngFixture.green, named: "new.png", in: repo)
+        _ = try await Process.git(["add", "new.png"], cwd: repo)
+
+        let pair = try await GitService().imageDiffPair(
+            worktreePath: repo, relativePath: "new.png", staged: true
+        )
+        #expect(pair.kind == .added)
+        #expect(pair.before == nil)
+        #expect(pair.after != nil)
     }
 }

--- a/AlasTests/ImageDiffPairLoaderTests.swift
+++ b/AlasTests/ImageDiffPairLoaderTests.swift
@@ -37,7 +37,8 @@ struct ImageDiffPairLoaderTests {
     private func writeLFSPointer(
         for data: Data,
         named fileName: String,
-        in repo: URL
+        in repo: URL,
+        storageDirectory: URL? = nil
     ) async throws {
         let oid = try await sha256Hex(data)
         let pointer = """
@@ -46,8 +47,8 @@ struct ImageDiffPairLoaderTests {
         size \(data.count)
 
         """
-        let objectDir = repo
-            .appendingPathComponent(".git/lfs/objects")
+        let objectDir = (storageDirectory ?? repo.appendingPathComponent(".git/lfs"))
+            .appendingPathComponent("objects")
             .appendingPathComponent(String(oid.prefix(2)))
             .appendingPathComponent(String(oid.dropFirst(2).prefix(2)))
         try FileManager.default.createDirectory(at: objectDir, withIntermediateDirectories: true)
@@ -305,6 +306,30 @@ struct ImageDiffPairLoaderTests {
         )
         #expect(pair.kind == .added)
         #expect(pair.before == nil)
+        #expect(pair.after != nil)
+    }
+
+    @Test func loadsLFSImageFromConfiguredStorage() async throws {
+        let repo = try await makeRepo()
+        defer { try? FileManager.default.removeItem(at: repo) }
+
+        _ = try await Process.git(["config", "lfs.storage", "custom-lfs"], cwd: repo)
+        try await writeLFSPointer(
+            for: PngFixture.red,
+            named: "logo.png",
+            in: repo,
+            storageDirectory: repo.appendingPathComponent(".git/custom-lfs")
+        )
+        _ = try await Process.git(["add", "logo.png"], cwd: repo)
+        _ = try await Process.git(["commit", "-q", "-m", "lfs image"], cwd: repo)
+
+        try PngFixture.blue.write(to: repo.appendingPathComponent("logo.png"))
+
+        let pair = try await GitService().imageDiffPair(
+            worktreePath: repo, relativePath: "logo.png", staged: false
+        )
+        #expect(pair.kind == .modified)
+        #expect(pair.before != nil)
         #expect(pair.after != nil)
     }
 }


### PR DESCRIPTION
## Summary
- Resolve Git LFS pointer blobs to local LFS objects when image blob decoding fails.
- Reuse the same image blob resolver for commit/draft image comparisons and merge-conflict image stages.
- Respect configured `lfs.storage` values and add regression coverage for default and custom LFS storage.

## Root cause
Image comparisons loaded historical/index image contents with `git show <ref>:<path>` and passed those bytes directly to `NSImage`. For Git LFS-tracked images, those bytes are the small pointer file, not the actual media object, so the UI rendered missing before/after images.

## Validation
- `xcodegen`
- `xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -quiet build`
- `xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' test -only-testing:AlasTests/ImageDiffPairLoaderTests`
- GitHub Actions `Build` #2054 passed