### PR TITLE
feat(remote): improve remote session list worktree summaries

### DIFF
--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -524,6 +524,7 @@
 		8B3D1B7B55629E989FCE53D1 /* ACPPermissionPolicyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F31D837F83B4F8B9FB348BD /* ACPPermissionPolicyTests.swift */; };
 		8BF52AFF90954B767B9D7E65 /* ACPSession.swift in Sources */ = {isa = PBXBuildFile; fileRef = BBBEFD27FD7013D458435779 /* ACPSession.swift */; };
 		8C1E756AFF4125E7ED04E0B8 /* RemoteConnection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A2EFB5253073D6A4A328FE0 /* RemoteConnection.swift */; };
+		8C492CBACC6D6DACE56DADA9 /* RemoteWorktreeSummaryBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9DD81682586D187AB70D1CDB /* RemoteWorktreeSummaryBuilder.swift */; };
 		8CEA8B0352538A42B8DC01A9 /* EmptyTabViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA09B830D18CCEE251D0E10A /* EmptyTabViewTests.swift */; };
 		8D22459A108B6BF47AEA71F7 /* session-update-available-models.json in Resources */ = {isa = PBXBuildFile; fileRef = 1B0785F1FFC8008C74009584 /* session-update-available-models.json */; };
 		8D5D146F9BF86EE4D058A309 /* CodeHostProviderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2449596651B3FE84E8E3832B /* CodeHostProviderTests.swift */; };
@@ -559,6 +560,7 @@
 		9624AE35A36692177C9EBD38 /* ACPSubmitIntent.swift in Sources */ = {isa = PBXBuildFile; fileRef = A655F5AA40CA10A7685794F7 /* ACPSubmitIntent.swift */; };
 		9654335704CB69BA7216DD63 /* ReviewLoopStateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3939B27EA8D7A562048E5932 /* ReviewLoopStateTests.swift */; };
 		965621529CB4BD82DD646B76 /* ACPManagerAccessorsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B133843C0559BBD6E769ABB8 /* ACPManagerAccessorsTests.swift */; };
+		9666162EC5BE3445EEBCDEA1 /* RemoteWorktreeSummaryBuilderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20A5D6E7C4527B459EFC2CBB /* RemoteWorktreeSummaryBuilderTests.swift */; };
 		9707DC02317F0E92AB06196B /* ImageDiffModeApplicabilityTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FFE911B77AC087704180BDB5 /* ImageDiffModeApplicabilityTests.swift */; };
 		970B6BCA824C6AF4DA812946 /* ProcessMemoryProbe.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5AA350F5909E28954C623B7 /* ProcessMemoryProbe.swift */; };
 		9737C1A3CD708D28C62FD6A5 /* ACPMessageStableIdTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6048519B4C444FCB46A11E49 /* ACPMessageStableIdTests.swift */; };
@@ -1089,6 +1091,7 @@
 		2071DA26A16E9A4A5AC5B3C3 /* AgentDetector.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentDetector.swift; sourceTree = "<group>"; };
 		208C9ABAF59F523D2DDC2F2A /* EditorOverlayPanelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditorOverlayPanelTests.swift; sourceTree = "<group>"; };
 		209B2EDBA4EB4BF7A854FF96 /* EditorLSPStatusResolverTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditorLSPStatusResolverTests.swift; sourceTree = "<group>"; };
+		20A5D6E7C4527B459EFC2CBB /* RemoteWorktreeSummaryBuilderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteWorktreeSummaryBuilderTests.swift; sourceTree = "<group>"; };
 		2119507B66D09AF3DF347280 /* AlasGhostty.App.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlasGhostty.App.swift; sourceTree = "<group>"; };
 		215C9AE9FBCB1FD9F6D030FE /* GhosttyHost.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GhosttyHost.swift; sourceTree = "<group>"; };
 		21FCF9A0DD5C474C9E5EC50A /* session-update-tool-call.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "session-update-tool-call.json"; sourceTree = "<group>"; };
@@ -1543,6 +1546,7 @@
 		9D209865BE187943BF14B830 /* AgentRunnerInvocationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentRunnerInvocationTests.swift; sourceTree = "<group>"; };
 		9D3C76F2F0F6BCE4023A9D7F /* StartupScriptResolverTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StartupScriptResolverTests.swift; sourceTree = "<group>"; };
 		9D7D83CD76ABF9FED3B29F62 /* ImageDiffView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageDiffView.swift; sourceTree = "<group>"; };
+		9DD81682586D187AB70D1CDB /* RemoteWorktreeSummaryBuilder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteWorktreeSummaryBuilder.swift; sourceTree = "<group>"; };
 		9DF8B5E766D2B3649D2555ED /* ACPInitializeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPInitializeTests.swift; sourceTree = "<group>"; };
 		9F31D837F83B4F8B9FB348BD /* ACPPermissionPolicyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPPermissionPolicyTests.swift; sourceTree = "<group>"; };
 		9F3A345F0B643467352DB5F3 /* ProcessKiller.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProcessKiller.swift; sourceTree = "<group>"; };
@@ -1964,6 +1968,7 @@
 				A79A06E48E215BF7B9EC2408 /* RemoteServerIntegrationTests.swift */,
 				37011506F459800FFF6D12A9 /* RemoteSessionGatewayTests.swift */,
 				5AA5809066E33EB30E09E0D8 /* RemoteWebAssetTests.swift */,
+				20A5D6E7C4527B459EFC2CBB /* RemoteWorktreeSummaryBuilderTests.swift */,
 				DF919734A34EEB87FA61FE07 /* WebSocketFrameTests.swift */,
 			);
 			path = Remote;
@@ -2044,6 +2049,7 @@
 			children = (
 				CDE49D2437D7E6AC9D67F136 /* RemoteSessionGateway.swift */,
 				33EBE6A3E0CA30D8910E68F8 /* RemoteSessionsProvider.swift */,
+				9DD81682586D187AB70D1CDB /* RemoteWorktreeSummaryBuilder.swift */,
 			);
 			path = Gateway;
 			sourceTree = "<group>";
@@ -4257,6 +4263,7 @@
 				C3E59948BD9108C1BD3243AD /* RemoteServerPane.swift in Sources */,
 				C7AD6F2DDAE9E11920277D41 /* RemoteSessionGateway.swift in Sources */,
 				A770A357750B4713AF21C0E0 /* RemoteSessionsProvider.swift in Sources */,
+				8C492CBACC6D6DACE56DADA9 /* RemoteWorktreeSummaryBuilder.swift in Sources */,
 				A7340B3C1C6B2BC7189F3695 /* RepoDot.swift in Sources */,
 				2C9C311A6DFC9DC5954F5CC2 /* RepoGroupView.swift in Sources */,
 				A2B0E4C1D80EB12F7BECE7FC /* RepoSelectorDialog.swift in Sources */,
@@ -4687,6 +4694,7 @@
 				A962107126052DEF597CB7FA /* RemoteServerIntegrationTests.swift in Sources */,
 				0B6ADBF320E6130E5888CAA7 /* RemoteSessionGatewayTests.swift in Sources */,
 				0C0C65E3012A722B10816F8D /* RemoteWebAssetTests.swift in Sources */,
+				9666162EC5BE3445EEBCDEA1 /* RemoteWorktreeSummaryBuilderTests.swift in Sources */,
 				133597E7D43CFE746EF4EF2B /* RepoGroupViewLayoutTests.swift in Sources */,
 				737EC7C9A35C9ED61ED67B83 /* RepoSelectorModelTests.swift in Sources */,
 				35705563BBEDDC1D0092C1F5 /* RepoSelectorRecentsTests.swift in Sources */,

--- a/Alas/Resources/RemoteWeb/app.js
+++ b/Alas/Resources/RemoteWeb/app.js
@@ -99,21 +99,57 @@ function handle(msg) {
 
 function renderSessions(sessions) {
   const list = $("session-list"); list.innerHTML = "";
-  sessions.forEach(s => {
-    // A real <button> is natively tappable on iOS Safari (a plain <li> with a
-    // JS click handler is not, even with cursor:pointer).
-    const row = document.createElement("button");
-    row.type = "button";
-    row.className = "session-row";
-    const title = document.createElement("span");
-    title.textContent = s.title;                 // textContent: safe against agent-set titles
-    const status = document.createElement("span");
-    status.className = "status";
-    status.textContent = s.status;
-    row.append(title, status);
-    row.onclick = () => openSession(s.id);
-    list.appendChild(row);
-  });
+  sessions.forEach(s => list.appendChild(renderSessionRow(s)));
+}
+
+function renderSessionRow(s) {
+  const row = document.createElement("button");
+  row.type = "button";
+  row.className = "session-row session-row-card";
+
+  const head = el("div", "session-head");
+  const title = el("span", "session-title", s.title);
+  const status = el("span", "status", s.status);
+  head.append(title, status);
+  row.append(head);
+
+  if (s.worktree) {
+    row.append(el("div", "session-worktree", `${s.worktree.projectName} / ${s.worktree.worktreeName}`));
+    const meta = el("div", "session-meta");
+    const parts = sessionMetaParts(s.worktree);
+    parts.forEach(part => meta.append(part));
+    row.append(meta);
+    row.title = s.worktree.path || "";
+  } else {
+    row.classList.add("session-row-minimal");
+  }
+
+  row.onclick = () => openSession(s.id);
+  return row;
+}
+
+function sessionMetaParts(worktree) {
+  if (!worktree.metricsAvailable) return [el("span", "", "changes unavailable")];
+
+  const parts = [];
+  if (worktree.commitCount > 0) parts.push(el("span", "", plural(worktree.commitCount, "commit")));
+  if (worktree.conflictCount > 0) parts.push(el("span", "meta-conflict", plural(worktree.conflictCount, "conflict")));
+  if (worktree.changedFileCount > 0) parts.push(el("span", "", plural(worktree.changedFileCount, "file")));
+
+  const line = [];
+  if (worktree.addedLines > 0) line.push(el("span", "meta-add", "+" + worktree.addedLines));
+  if (worktree.deletedLines > 0) line.push(el("span", "meta-del", "-" + worktree.deletedLines));
+  if (line.length) {
+    const group = el("span", "meta-lines");
+    line.forEach(item => group.append(item));
+    parts.push(group);
+  }
+
+  return parts.length ? parts : [el("span", "", "clean")];
+}
+
+function plural(count, singular) {
+  return `${count} ${singular}${count === 1 ? "" : "s"}`;
 }
 
 function openSession(id) {

--- a/Alas/Resources/RemoteWeb/app.js
+++ b/Alas/Resources/RemoteWeb/app.js
@@ -105,7 +105,7 @@ function renderSessions(sessions) {
 function renderSessionRow(s) {
   const row = document.createElement("button");
   row.type = "button";
-  row.className = "session-row session-row-card";
+  row.className = "session-row";
 
   const head = el("div", "session-head");
   const title = el("span", "session-title", s.title);
@@ -114,6 +114,7 @@ function renderSessionRow(s) {
   row.append(head);
 
   if (s.worktree) {
+    row.classList.add("session-row-card");
     row.append(el("div", "session-worktree", `${s.worktree.projectName} / ${s.worktree.worktreeName}`));
     const meta = el("div", "session-meta");
     const parts = sessionMetaParts(s.worktree);

--- a/Alas/Resources/RemoteWeb/index.html
+++ b/Alas/Resources/RemoteWeb/index.html
@@ -4,7 +4,7 @@
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
   <title>Alas Remote</title>
-  <link rel="stylesheet" href="/style.css?v=26" />
+  <link rel="stylesheet" href="/style.css?v=27" />
 </head>
 <body>
   <header id="bar">
@@ -80,8 +80,8 @@
       <button id="gate-retry" class="hidden">Try again</button>
     </div>
   </div>
-  <script src="/marked.min.js?v=26"></script>
-  <script src="/purify.min.js?v=26"></script>
-  <script src="/app.js?v=26"></script>
+  <script src="/marked.min.js?v=27"></script>
+  <script src="/purify.min.js?v=27"></script>
+  <script src="/app.js?v=27"></script>
 </body>
 </html>

--- a/Alas/Resources/RemoteWeb/style.css
+++ b/Alas/Resources/RemoteWeb/style.css
@@ -59,6 +59,7 @@ h1 { font-size: 22px; font-weight: 700; margin: 12px 4px 10px; }
 .meta-del { color: var(--del); }
 .meta-conflict { color: oklch(0.82 0.13 90); }
 .session-row-minimal { display: flex; justify-content: space-between; align-items: center; gap: 10px; padding: 15px 10px; border-bottom: 0.5px solid var(--line-soft); background: none; }
+.session-row-minimal .session-head { flex: 1; }
 .session-row-minimal:active { background: var(--bg-2); }
 #back { background: none; border: none; color: var(--accent); font-size: 15px; padding: 4px 2px; margin: -4px 0; cursor: pointer; -webkit-tap-highlight-color: transparent; }
 

--- a/Alas/Resources/RemoteWeb/style.css
+++ b/Alas/Resources/RemoteWeb/style.css
@@ -44,10 +44,22 @@ main { flex: 1 1 auto; min-height: 0; display: flex; flex-direction: column; }
 
 /* Sessions list */
 h1 { font-size: 22px; font-weight: 700; margin: 12px 4px 10px; }
-#session-list { list-style: none; padding: 0; margin: 0; }
-.session-row { display: flex; justify-content: space-between; align-items: center; gap: 10px; width: 100%; padding: 15px 10px; border: none; border-bottom: 0.5px solid var(--line-soft); background: none; color: var(--fg); font: inherit; font-size: 15px; text-align: left; cursor: pointer; -webkit-tap-highlight-color: transparent; }
-.session-row:active { background: var(--bg-2); }
-.session-row .status { color: var(--accent); font-size: 11px; flex-shrink: 0; }
+#session-list { list-style: none; padding: 0; margin: 0; display: flex; flex-direction: column; gap: 10px; }
+.session-row { width: 100%; border: none; color: var(--fg); font: inherit; text-align: left; cursor: pointer; -webkit-tap-highlight-color: transparent; }
+.session-row-card { display: block; padding: 12px; border: 0.5px solid var(--line); border-radius: 10px; background: color-mix(in oklab, var(--bg-2) 54%, transparent); }
+.session-row-card:active { background: var(--bg-3); }
+.session-head { display: flex; align-items: center; gap: 8px; min-width: 0; }
+.session-title { flex: 1; min-width: 0; font-size: 15px; font-weight: 650; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.session-row .status { color: var(--accent); font-size: 11px; flex-shrink: 0; white-space: nowrap; }
+.session-worktree { margin-top: 6px; color: var(--fg-muted); font-size: 12px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.session-meta { margin-top: 9px; display: flex; flex-wrap: wrap; gap: 8px; color: var(--fg-dim); font-size: 11px; line-height: 1.3; }
+.session-meta span { min-width: 0; }
+.meta-lines { display: inline-flex; gap: 5px; }
+.meta-add { color: var(--add); }
+.meta-del { color: var(--del); }
+.meta-conflict { color: oklch(0.82 0.13 90); }
+.session-row-minimal { display: flex; justify-content: space-between; align-items: center; gap: 10px; padding: 15px 10px; border-bottom: 0.5px solid var(--line-soft); background: none; }
+.session-row-minimal:active { background: var(--bg-2); }
 #back { background: none; border: none; color: var(--accent); font-size: 15px; padding: 4px 2px; margin: -4px 0; cursor: pointer; -webkit-tap-highlight-color: transparent; }
 
 /* Transcript: a non-scrolling column — only #messages scrolls, #drivebar pins. */

--- a/Alas/Sources/App/AppState.swift
+++ b/Alas/Sources/App/AppState.swift
@@ -2172,6 +2172,15 @@ final class AppState {
         return nil
     }
 
+    private func projectAndWorktree(withWorktreeId id: String) -> (project: ProjectConfig, worktree: Worktree)? {
+        for project in projects {
+            if let worktree = projectsManager.worktrees(projectId: project.id).first(where: { $0.id == id }) {
+                return (project, worktree)
+            }
+        }
+        return nil
+    }
+
     private func projectPath(forWorktreeId id: String) -> String? {
         guard let worktree = worktree(withId: id) else { return nil }
         return projects.first(where: { $0.id == worktree.projectId })?.path
@@ -3217,9 +3226,44 @@ final class AppState {
 // `acpManagers` dictionary. Aggregates across every live per-worktree manager;
 // worktrees not opened this run simply don't appear (documented v1 behavior).
 extension AppState: RemoteSessionsProvider {
-    func sessionSummaries() -> [RemoteSessionSummary] {
+    private func remoteWorktreeSummary(project: ProjectConfig, worktree: Worktree) async -> RemoteWorktreeSummary {
+        let git = GitService()
+        do {
+            async let status = git.status(worktreePath: worktree.path)
+            async let commits = git.commitsAhead(
+                at: worktree.path,
+                baseBranch: config.worktrees.baseBranch,
+                ignoreUpstream: !config.changes.trackUpstreamForCommits
+            )
+            let (changes, commitResult) = try await (status, commits)
+            return RemoteWorktreeSummaryBuilder.make(
+                projectName: project.name,
+                worktree: worktree,
+                metrics: .available(
+                    comparisonRef: commitResult.comparisonRef,
+                    commitCount: commitResult.commits.count,
+                    changes: changes
+                )
+            )
+        } catch {
+            return RemoteWorktreeSummaryBuilder.make(
+                projectName: project.name,
+                worktree: worktree,
+                metrics: .unavailable
+            )
+        }
+    }
+
+    func sessionSummaries() async -> [RemoteSessionSummary] {
         var out: [RemoteSessionSummary] = []
         for mgr in acpManagers.values {
+            let worktreeSummary: RemoteWorktreeSummary?
+            if let resolved = projectAndWorktree(withWorktreeId: mgr.worktreeId) {
+                worktreeSummary = await remoteWorktreeSummary(project: resolved.project, worktree: resolved.worktree)
+            } else {
+                worktreeSummary = nil
+            }
+
             for row in mgr.sessionRows where !row.archived {
                 let state = mgr.runners[row.id]?.session.transcript.streamingState
                 out.append(RemoteSessionSummary(
@@ -3227,7 +3271,8 @@ extension AppState: RemoteSessionsProvider {
                     title: row.title,
                     agentId: row.agentId,
                     status: state.map(RemoteSessionGateway.stateString) ?? "idle",
-                    canDrive: mgr.isWriter(for: row.id)
+                    canDrive: mgr.isWriter(for: row.id),
+                    worktree: worktreeSummary
                 ))
             }
         }

--- a/Alas/Sources/Remote/Gateway/RemoteSessionGateway.swift
+++ b/Alas/Sources/Remote/Gateway/RemoteSessionGateway.swift
@@ -18,6 +18,8 @@ final class RemoteSessionGateway {
     private var configCoalesce: [String: Task<Void, Never>] = [:]
     private var lastConfig: [String: RemoteSessionConfig] = [:]
     private var coalesce: [String: Task<Void, Never>] = [:]
+    private var sessionListRefresh: Task<Void, Never>?
+    private var sessionListGeneration = 0
     // Per-session request id of the permission/question prompt we last surfaced,
     // so we can tell the client to dismiss it if it gets resolved elsewhere.
     private var lastPermissionReq: [String: Int] = [:]
@@ -32,7 +34,7 @@ final class RemoteSessionGateway {
     func handle(_ message: RemoteClientMessage) async {
         switch message {
         case .listSessions:
-            send(.sessionList(sessions: await provider.sessionSummaries()))
+            refreshSessionList()
         case .subscribe(let id):
             await provider.hydrateIfNeeded(id: id)
             guard let session = provider.session(for: id) else {
@@ -125,6 +127,18 @@ final class RemoteSessionGateway {
         case .setAutoRun(let id, let enabled):
             guard provider.isWriter(for: id) else { return }
             provider.setAutoRun(for: id, enabled: enabled)
+        }
+    }
+
+    private func refreshSessionList() {
+        sessionListGeneration += 1
+        let generation = sessionListGeneration
+        sessionListRefresh?.cancel()
+        sessionListRefresh = Task { @MainActor [weak self] in
+            guard let self else { return }
+            let summaries = await provider.sessionSummaries()
+            guard !Task.isCancelled, generation == sessionListGeneration else { return }
+            send(.sessionList(sessions: summaries))
         }
     }
 

--- a/Alas/Sources/Remote/Gateway/RemoteSessionGateway.swift
+++ b/Alas/Sources/Remote/Gateway/RemoteSessionGateway.swift
@@ -196,6 +196,8 @@ final class RemoteSessionGateway {
 
     /// Tear down all observation (called when the connection closes).
     func close() {
+        sessionListRefresh?.cancel()
+        sessionListRefresh = nil
         subscriptions.removeAll()
         configSubscriptions.removeAll()
         configCoalesce.values.forEach { $0.cancel() }

--- a/Alas/Sources/Remote/Gateway/RemoteSessionGateway.swift
+++ b/Alas/Sources/Remote/Gateway/RemoteSessionGateway.swift
@@ -32,7 +32,7 @@ final class RemoteSessionGateway {
     func handle(_ message: RemoteClientMessage) async {
         switch message {
         case .listSessions:
-            send(.sessionList(sessions: provider.sessionSummaries()))
+            send(.sessionList(sessions: await provider.sessionSummaries()))
         case .subscribe(let id):
             await provider.hydrateIfNeeded(id: id)
             guard let session = provider.session(for: id) else {

--- a/Alas/Sources/Remote/Gateway/RemoteSessionsProvider.swift
+++ b/Alas/Sources/Remote/Gateway/RemoteSessionsProvider.swift
@@ -4,7 +4,7 @@ import Foundation
 /// production wires it to AppState (Task 8).
 @MainActor
 protocol RemoteSessionsProvider: AnyObject {
-    func sessionSummaries() -> [RemoteSessionSummary]
+    func sessionSummaries() async -> [RemoteSessionSummary]
     func session(for id: String) -> ACPSession?
     func permissionPolicy(for id: String) -> ACPPermissionPolicy?
     func hydrateIfNeeded(id: String) async

--- a/Alas/Sources/Remote/Gateway/RemoteWorktreeSummaryBuilder.swift
+++ b/Alas/Sources/Remote/Gateway/RemoteWorktreeSummaryBuilder.swift
@@ -1,0 +1,46 @@
+import Foundation
+
+enum RemoteWorktreeSummaryMetrics: Equatable {
+    case available(comparisonRef: String?, commitCount: Int, changes: [ChangedFile])
+    case unavailable
+}
+
+enum RemoteWorktreeSummaryBuilder {
+    static func make(
+        projectName: String,
+        worktree: Worktree,
+        metrics: RemoteWorktreeSummaryMetrics
+    ) -> RemoteWorktreeSummary {
+        switch metrics {
+        case .available(let comparisonRef, let commitCount, let changes):
+            let uniquePaths = Set(changes.map(\.path))
+            return RemoteWorktreeSummary(
+                projectName: projectName,
+                worktreeName: worktree.name,
+                branch: worktree.branch,
+                path: worktree.path.path,
+                metricsAvailable: true,
+                comparisonRef: comparisonRef,
+                commitCount: commitCount,
+                changedFileCount: uniquePaths.count,
+                addedLines: changes.reduce(0) { $0 + $1.add },
+                deletedLines: changes.reduce(0) { $0 + $1.del },
+                conflictCount: changes.filter { $0.conflict != nil }.count
+            )
+        case .unavailable:
+            return RemoteWorktreeSummary(
+                projectName: projectName,
+                worktreeName: worktree.name,
+                branch: worktree.branch,
+                path: worktree.path.path,
+                metricsAvailable: false,
+                comparisonRef: nil,
+                commitCount: 0,
+                changedFileCount: 0,
+                addedLines: 0,
+                deletedLines: 0,
+                conflictCount: 0
+            )
+        }
+    }
+}

--- a/Alas/Sources/Remote/Protocol/RemoteMessageWireJSON.swift
+++ b/Alas/Sources/Remote/Protocol/RemoteMessageWireJSON.swift
@@ -10,12 +10,43 @@ struct RemoteWireMessage: Codable, Equatable, Sendable {
     let json: String?         // JSON string for structured kinds; nil otherwise
 }
 
+struct RemoteWorktreeSummary: Codable, Equatable, Sendable {
+    let projectName: String
+    let worktreeName: String
+    let branch: String
+    let path: String
+    let metricsAvailable: Bool
+    let comparisonRef: String?
+    let commitCount: Int
+    let changedFileCount: Int
+    let addedLines: Int
+    let deletedLines: Int
+    let conflictCount: Int
+}
+
 struct RemoteSessionSummary: Codable, Equatable, Sendable {
     let id: String
     let title: String
     let agentId: String
     let status: String       // "idle" | "streaming" | "awaitingPermission" | "awaitingInput"
     let canDrive: Bool       // this remote-host instance currently holds the writer lease
+    let worktree: RemoteWorktreeSummary?
+
+    init(
+        id: String,
+        title: String,
+        agentId: String,
+        status: String,
+        canDrive: Bool,
+        worktree: RemoteWorktreeSummary? = nil
+    ) {
+        self.id = id
+        self.title = title
+        self.agentId = agentId
+        self.status = status
+        self.canDrive = canDrive
+        self.worktree = worktree
+    }
 }
 
 /// A permission request surfaced to the client.

--- a/AlasTests/Remote/RemoteProtocolTests.swift
+++ b/AlasTests/Remote/RemoteProtocolTests.swift
@@ -57,6 +57,47 @@ struct RemoteProtocolTests {
         #expect(try roundTrip(list) == list)
     }
 
+    @Test func sessionSummaryRoundTripsWithoutWorktreePayload() throws {
+        let summary = RemoteSessionSummary(
+            id: "s1",
+            title: "Build feature",
+            agentId: "claude",
+            status: "idle",
+            canDrive: true
+        )
+        #expect(try roundTrip(summary) == summary)
+    }
+
+    @Test func sessionSummaryRoundTripsWithWorktreePayload() throws {
+        let summary = RemoteSessionSummary(
+            id: "s1",
+            title: "Build feature",
+            agentId: "claude",
+            status: "streaming",
+            canDrive: false,
+            worktree: RemoteWorktreeSummary(
+                projectName: "alas",
+                worktreeName: "nacho-improve-remote-sessions",
+                branch: "nacho/improve-remote-sessions",
+                path: "/tmp/alas",
+                metricsAvailable: true,
+                comparisonRef: "origin/main",
+                commitCount: 3,
+                changedFileCount: 7,
+                addedLines: 184,
+                deletedLines: 39,
+                conflictCount: 0
+            )
+        )
+        #expect(try roundTrip(summary) == summary)
+    }
+
+    @Test func sessionSummaryDecodesLegacyPayloadWithoutWorktree() throws {
+        let json = #"{"id":"s1","title":"T","agentId":"codex","status":"idle","canDrive":false}"#
+        let decoded = try JSONDecoder().decode(RemoteSessionSummary.self, from: Data(json.utf8))
+        #expect(decoded == RemoteSessionSummary(id: "s1", title: "T", agentId: "codex", status: "idle", canDrive: false))
+    }
+
     @Test func transcriptDeltaRoundTrips() throws {
         let delta = RemoteServerMessage.transcriptDelta(
             sessionId: "s1",

--- a/AlasTests/Remote/RemoteSessionGatewayTests.swift
+++ b/AlasTests/Remote/RemoteSessionGatewayTests.swift
@@ -409,6 +409,29 @@ struct RemoteSessionGatewayTests {
         return false })
     }
 
+    @Test func closeCancelsPendingSessionListRefresh() async {
+        let provider = FakeSessionsProvider()
+        provider.summaries = [RemoteSessionSummary(id: "s1", title: "T", agentId: "claude", status: "idle", canDrive: false)]
+        provider.pauseSessionSummaries = true
+        var sent: [RemoteServerMessage] = []
+        let gw = RemoteSessionGateway(provider: provider) { sent.append($0) }
+
+        await gw.handle(.listSessions)
+        for _ in 0..<10 {
+            if provider.sessionSummariesCallCount == 1 { break }
+            await Task.yield()
+        }
+        gw.close()
+        provider.resumeSessionSummaries()
+        for _ in 0..<10 {
+            if !sent.isEmpty { break }
+            await Task.yield()
+        }
+
+        #expect(provider.sessionSummariesCallCount == 1)
+        #expect(sent.isEmpty)
+    }
+
     @Test func takeOverRoutesToProvider() async {
         let provider = FakeSessionsProvider()
         let gw = RemoteSessionGateway(provider: provider) { _ in }

--- a/AlasTests/Remote/RemoteSessionGatewayTests.swift
+++ b/AlasTests/Remote/RemoteSessionGatewayTests.swift
@@ -19,9 +19,20 @@ final class FakeSessionsProvider: RemoteSessionsProvider {
     var autoRuns: [(id: String, enabled: Bool)] = []
     var configs: [String: RemoteSessionConfig] = [:]
     var sessionSummariesCallCount = 0
+    var pauseSessionSummaries = false
+    private var sessionSummariesContinuation: CheckedContinuation<[RemoteSessionSummary], Never>?
     func sessionSummaries() async -> [RemoteSessionSummary] {
         sessionSummariesCallCount += 1
+        if pauseSessionSummaries {
+            return await withCheckedContinuation { continuation in
+                sessionSummariesContinuation = continuation
+            }
+        }
         return summaries
+    }
+    func resumeSessionSummaries() {
+        sessionSummariesContinuation?.resume(returning: summaries)
+        sessionSummariesContinuation = nil
     }
     func session(for id: String) -> ACPSession? { sessions[id] }
     func permissionPolicy(for id: String) -> ACPPermissionPolicy? { policies[id] }
@@ -140,8 +151,48 @@ struct RemoteSessionGatewayTests {
         var sent: [RemoteServerMessage] = []
         let gw = RemoteSessionGateway(provider: provider) { sent.append($0) }
         await gw.handle(.listSessions)
+        await Task.yield()
         #expect(provider.sessionSummariesCallCount == 1)
         #expect(sent == [.sessionList(sessions: provider.summaries)])
+    }
+
+    @Test func listSessionsDoesNotBlockFollowingSubscribe() async throws {
+        let provider = FakeSessionsProvider()
+        provider.summaries = [RemoteSessionSummary(id: "s1", title: "T", agentId: "claude", status: "idle", canDrive: false)]
+        provider.pauseSessionSummaries = true
+        provider.sessions["s1"] = try makeSessionWithAgentText("hello")
+        var sent: [RemoteServerMessage] = []
+        let gw = RemoteSessionGateway(provider: provider) { sent.append($0) }
+
+        var listHandleReturned = false
+        let listTask = Task { @MainActor in
+            await gw.handle(.listSessions)
+            listHandleReturned = true
+        }
+        for _ in 0..<10 {
+            if provider.sessionSummariesCallCount == 1 { break }
+            await Task.yield()
+        }
+
+        #expect(provider.sessionSummariesCallCount == 1)
+        #expect(listHandleReturned == true)
+        #expect(sent.isEmpty)
+
+        await gw.handle(.subscribe(sessionId: "s1"))
+        #expect(sent.contains { message in
+            if case .transcriptSnapshot(let id, _, _, _) = message {
+                return id == "s1"
+            }
+            return false
+        })
+
+        provider.resumeSessionSummaries()
+        await listTask.value
+        for _ in 0..<10 {
+            if sent.last == .sessionList(sessions: provider.summaries) { break }
+            await Task.yield()
+        }
+        #expect(sent.last == .sessionList(sessions: provider.summaries))
     }
 
     @Test func subscribeEmitsSnapshot() async throws {

--- a/AlasTests/Remote/RemoteSessionGatewayTests.swift
+++ b/AlasTests/Remote/RemoteSessionGatewayTests.swift
@@ -18,7 +18,11 @@ final class FakeSessionsProvider: RemoteSessionsProvider {
     var modes: [(id: String, mode: String)] = []
     var autoRuns: [(id: String, enabled: Bool)] = []
     var configs: [String: RemoteSessionConfig] = [:]
-    func sessionSummaries() -> [RemoteSessionSummary] { summaries }
+    var sessionSummariesCallCount = 0
+    func sessionSummaries() async -> [RemoteSessionSummary] {
+        sessionSummariesCallCount += 1
+        return summaries
+    }
     func session(for id: String) -> ACPSession? { sessions[id] }
     func permissionPolicy(for id: String) -> ACPPermissionPolicy? { policies[id] }
     func hydrateIfNeeded(id: String) async {}
@@ -136,6 +140,7 @@ struct RemoteSessionGatewayTests {
         var sent: [RemoteServerMessage] = []
         let gw = RemoteSessionGateway(provider: provider) { sent.append($0) }
         await gw.handle(.listSessions)
+        #expect(provider.sessionSummariesCallCount == 1)
         #expect(sent == [.sessionList(sessions: provider.summaries)])
     }
 

--- a/AlasTests/Remote/RemoteWebAssetTests.swift
+++ b/AlasTests/Remote/RemoteWebAssetTests.swift
@@ -25,4 +25,19 @@ struct RemoteWebAssetTests {
         #expect(!app.contains(#"const d = el("details", "msg m-tool")"#))
         #expect(!css.contains(".m-tool > summary"))
     }
+
+    @Test func sessionRowsRenderWorktreeSummaryCards() throws {
+        let app = try asset("app.js")
+        let css = try asset("style.css")
+        let html = try asset("index.html")
+
+        #expect(app.contains("function sessionMetaParts"))
+        #expect(app.contains("function renderSessionRow"))
+        #expect(app.contains(#""changes unavailable""#))
+        #expect(app.contains(#""clean""#))
+        #expect(css.contains(".session-row-card"))
+        #expect(css.contains(".session-meta"))
+        #expect(html.contains("/app.js?v=27"))
+        #expect(html.contains("/style.css?v=27"))
+    }
 }

--- a/AlasTests/Remote/RemoteWorktreeSummaryBuilderTests.swift
+++ b/AlasTests/Remote/RemoteWorktreeSummaryBuilderTests.swift
@@ -1,0 +1,63 @@
+import Foundation
+import Testing
+@testable import Alas
+
+struct RemoteWorktreeSummaryBuilderTests {
+    private func worktree() -> Worktree {
+        Worktree(
+            id: "wt",
+            projectId: "p",
+            name: "feature-branch",
+            branch: "nacho/feature-branch",
+            path: URL(fileURLWithPath: "/tmp/alas-feature"),
+            status: .dirty,
+            lastActivity: Date(timeIntervalSince1970: 0)
+        )
+    }
+
+    @Test func availableMetricsSummarizeCommitsUniqueFilesLinesAndConflicts() {
+        let summary = RemoteWorktreeSummaryBuilder.make(
+            projectName: "alas",
+            worktree: worktree(),
+            metrics: .available(
+                comparisonRef: "origin/main",
+                commitCount: 3,
+                changes: [
+                    ChangedFile(path: "A.swift", status: "M", stage: .staged, add: 10, del: 2, renameFrom: nil),
+                    ChangedFile(path: "A.swift", status: "M", stage: .unstaged, add: 1, del: 0, renameFrom: nil),
+                    ChangedFile(path: "B.swift", status: "U", stage: .unstaged, add: 4, del: 5, renameFrom: nil, conflict: .bothModified),
+                ]
+            )
+        )
+
+        #expect(summary.projectName == "alas")
+        #expect(summary.worktreeName == "feature-branch")
+        #expect(summary.branch == "nacho/feature-branch")
+        #expect(summary.path == "/tmp/alas-feature")
+        #expect(summary.metricsAvailable)
+        #expect(summary.comparisonRef == "origin/main")
+        #expect(summary.commitCount == 3)
+        #expect(summary.changedFileCount == 2)
+        #expect(summary.addedLines == 15)
+        #expect(summary.deletedLines == 7)
+        #expect(summary.conflictCount == 1)
+    }
+
+    @Test func unavailableMetricsKeepIdentityAndZeroCounts() {
+        let summary = RemoteWorktreeSummaryBuilder.make(
+            projectName: "alas",
+            worktree: worktree(),
+            metrics: .unavailable
+        )
+
+        #expect(summary.projectName == "alas")
+        #expect(summary.worktreeName == "feature-branch")
+        #expect(summary.metricsAvailable == false)
+        #expect(summary.comparisonRef == nil)
+        #expect(summary.commitCount == 0)
+        #expect(summary.changedFileCount == 0)
+        #expect(summary.addedLines == 0)
+        #expect(summary.deletedLines == 0)
+        #expect(summary.conflictCount == 0)
+    }
+}

--- a/docs/superpowers/specs/2026-06-08-remote-session-list-worktree-summary-design.md
+++ b/docs/superpowers/specs/2026-06-08-remote-session-list-worktree-summary-design.md
@@ -1,0 +1,186 @@
+# Remote Session List Worktree Summary Design
+
+## Context
+
+The remote web UI currently lists ACP sessions with only a title and streaming status. When multiple sessions are available, the user cannot tell which worktree a session belongs to, whether that worktree has local changes, or whether it has commits waiting relative to the same comparison logic used by the native Changes pane.
+
+The remote UI is bundled with the macOS app, so this design can evolve the wire payload and web renderer together. The existing `RemoteSessionSummary` payload carries only `id`, `title`, `agentId`, `status`, and `canDrive`.
+
+## Goals
+
+- Make the remote sessions list distinguish sessions by worktree.
+- Surface current lightweight git state for each session's worktree.
+- Match the native right pane's definition of commits ahead.
+- Keep the list compact and scannable on mobile.
+- Preserve fallback behavior when git probing fails.
+
+## Non-Goals
+
+- No file preview list.
+- No staged vs. unstaged breakdown.
+- No inline diff details.
+- No per-row asynchronous loading state in the web UI.
+
+## UX
+
+Render each session as a compact mini-card.
+
+The primary row shows:
+
+- Session title on the left.
+- Session status on the right.
+
+The second line shows:
+
+- `project name / worktree name`
+
+The metadata line shows only non-empty segments:
+
+- `N commits` for commits ahead of the comparison ref.
+- `N conflicts` when conflicted files exist.
+- `N files` when uncommitted changed files exist.
+- `+A -D` when uncommitted line counts are non-zero.
+- `clean` only when metrics are available and commit count, changed file count, and conflict count are all zero.
+
+Example:
+
+```text
+Fix remote auth prompt          awaiting input
+alas / nacho-improve-remote-sessions
+3 commits · 7 files · +184 -39
+```
+
+Conflict example:
+
+```text
+Resolve stuck checkout          streaming
+alas / bugfix-zmx-launch
+1 commit · 2 conflicts · 5 files · +62 -18
+```
+
+Clean example:
+
+```text
+Plan sidebar polish             idle
+alas / main
+clean
+```
+
+Avoid `dirty worktree` copy because visible file and line counts already communicate uncommitted changes.
+
+## Data Model
+
+Extend `RemoteSessionSummary` with an optional worktree summary payload.
+
+Suggested shape:
+
+```swift
+struct RemoteWorktreeSummary: Codable, Equatable, Sendable {
+    let projectName: String
+    let worktreeName: String
+    let branch: String
+    let path: String
+    let metricsAvailable: Bool
+    let comparisonRef: String?
+    let commitCount: Int
+    let changedFileCount: Int
+    let addedLines: Int
+    let deletedLines: Int
+    let conflictCount: Int
+}
+
+struct RemoteSessionSummary: Codable, Equatable, Sendable {
+    let id: String
+    let title: String
+    let agentId: String
+    let status: String
+    let canDrive: Bool
+    let worktree: RemoteWorktreeSummary?
+}
+```
+
+The payload stays optional so old minimal summaries and test fixtures remain easy to decode.
+
+## Backend Flow
+
+Change `RemoteSessionsProvider.sessionSummaries()` to async so list refresh can compute fresh lightweight git data.
+
+When the gateway handles `listSessions`:
+
+1. Await `provider.sessionSummaries()`.
+2. Emit one `sessionList` message with complete rows.
+
+In `AppState.sessionSummaries()`:
+
+1. Iterate live ACP managers as today.
+2. For each session row, resolve `manager.worktreeId` to a known `Worktree` and `ProjectConfig`.
+3. Build the base session fields from the ACP row and runner state.
+4. If the worktree resolves, compute the worktree summary with:
+   - `GitService.status(worktreePath:)`
+   - `GitService.commitsAhead(at:baseBranch:ignoreUpstream:)`
+5. Use the app config's right-pane semantics:
+   - `baseBranch = config.worktrees.baseBranch`
+   - `ignoreUpstream = !config.changes.trackUpstreamForCommits`
+
+The commit count is `commitsAhead(...).commits.count`. The comparison ref is the returned `comparisonRef`.
+
+The changed file count is the number of `ChangedFile` entries from `status`. The conflict count is the number of entries whose `conflict` is non-nil. Added and deleted lines are totals across those `ChangedFile` entries.
+
+## Error Handling
+
+Git summary failures must not remove a session from the list.
+
+Fallback rules:
+
+- If git probing fails but worktree identity is known, include project/worktree identity with `metricsAvailable = false`; numeric counts should be zero and ignored by the browser.
+- If the worktree cannot be resolved, send the old minimal session summary with `worktree = nil`.
+- The browser renders a minimal row when `worktree` is missing.
+- The browser renders `changes unavailable` when identity exists but `metricsAvailable` is false.
+
+## Web Rendering
+
+Update `Alas/Resources/RemoteWeb/app.js` so `renderSessions` creates card rows:
+
+- Title and status header.
+- Worktree identity line when `s.worktree` exists.
+- Metadata line computed from summary fields.
+- Minimal legacy row when no worktree payload exists.
+
+Update `Alas/Resources/RemoteWeb/style.css` to replace the current flat `.session-row` with mini-card styling:
+
+- Keep rows as real `<button>` elements for mobile tap behavior.
+- Use no nested cards; each session button is the card.
+- Preserve safe-area and current dark theme tokens.
+- Support long project/worktree/session names with ellipsis.
+
+## Tests
+
+Add focused tests:
+
+- `RemoteProtocolTests` covers `RemoteSessionSummary` encoding and decoding with and without worktree summary payload.
+- `RemoteSessionGatewayTests` covers async `listSessions` emission.
+- Backend summary projection tests cover:
+  - Commit count.
+  - Changed file count.
+  - Added/deleted line totals.
+  - Conflict count.
+  - Worktree resolution fallback.
+  - Git metrics failure fallback.
+
+If direct `AppState` testing becomes too heavyweight, factor the count/metadata projection into a small helper with injected inputs and test that helper directly.
+
+Manual verification should include a static remote web sample or a local remote session list showing:
+
+- Clean worktree.
+- Commits only.
+- Uncommitted changes only.
+- Commits plus uncommitted changes.
+- Conflicts.
+
+Final implementation verification should use the project commands:
+
+```bash
+xcodegen
+xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -quiet build
+xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' test
+```


### PR DESCRIPTION
## Summary

- Adds worktree metadata and lightweight git summaries to remote session list responses.
- Renders compact remote session cards with project/worktree identity, commit counts, changed file counts, line totals, conflicts, and clean fallback state.
- Preserves the minimal legacy row layout when no worktree payload is available.

## Validation

- `xcodegen`
- `xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -quiet build`
- `xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' test`