### PR TITLE
fix(acp): keep queued controls clickable

### DIFF
--- a/Alas/Sources/ACP/Session/ACPSession.swift
+++ b/Alas/Sources/ACP/Session/ACPSession.swift
@@ -473,12 +473,9 @@ final class ACPSession: ObservableObject, Identifiable {
         queue.insert(contentsOf: snapshot, at: insertAt)
     }
 
-    /// Number of queue items that should render as bubbles below the
-    /// transcript. Excludes the `.sending` head because its prompt has
-    /// already been appended to the transcript by `ACPSessionRunner.sendNow`
-    /// (and the composer's Stop pill conveys the in-flight state). Without
-    /// this, the user sees the same message twice — once in the transcript,
-    /// once as a "Sending" queued bubble.
+    /// Number of pending queue items. The transcript UI may render additional
+    /// queue rows, such as an in-flight `.sending` head, for row-local status
+    /// and action placement.
     var visibleQueueCount: Int {
         queue.reduce(0) { $0 + ($1.status == .sending ? 0 : 1) }
     }

--- a/Alas/Sources/ACP/UI/ACPMessageList.swift
+++ b/Alas/Sources/ACP/UI/ACPMessageList.swift
@@ -127,8 +127,11 @@ struct ACPMessageList: View {
                             StreamingCaret().frame(width: 8, height: 14)
                                 .id("__streaming_caret__")
                         }
-                        if session.visibleQueueCount > 1 {
-                            ACPQueueHeader(count: session.visibleQueueCount, onClear: onQueueClearAll)
+                        let queueHeaderCount = Self.queueHeaderCount(
+                            statuses: session.queue.map(\.status)
+                        )
+                        if queueHeaderCount > 1 {
+                            ACPQueueHeader(count: queueHeaderCount, onClear: onQueueClearAll)
                                 .id("__queue_header__")
                         }
                         ForEach(Array(session.queue.enumerated()), id: \.element.id) { idx, item in
@@ -323,6 +326,12 @@ struct ACPMessageList: View {
         switch status {
         case .pending, .sending:
             return true
+        }
+    }
+
+    nonisolated static func queueHeaderCount(statuses: [QueuedPrompt.Status]) -> Int {
+        statuses.reduce(0) { count, status in
+            count + (shouldRenderQueueBubble(status: status) ? 1 : 0)
         }
     }
 

--- a/Alas/Sources/ACP/UI/ACPMessageList.swift
+++ b/Alas/Sources/ACP/UI/ACPMessageList.swift
@@ -132,7 +132,7 @@ struct ACPMessageList: View {
                                 .id("__queue_header__")
                         }
                         ForEach(Array(session.queue.enumerated()), id: \.element.id) { idx, item in
-                            if item.status != .sending {
+                            if Self.shouldRenderQueueBubble(status: item.status) {
                                 ACPQueuedBubble(
                                     item: item,
                                     onForceSend: { onQueueForceSend(item.id) },
@@ -145,6 +145,10 @@ struct ACPMessageList: View {
                                           let uuid = UUID(uuidString: s),
                                           let src = session.queue.firstIndex(where: { $0.id == uuid })
                                     else { return false }
+                                    guard Self.canDropQueuedItem(
+                                        sourceStatus: session.queue[src].status,
+                                        targetStatus: item.status
+                                    ) else { return false }
                                     onQueueReorder(src, idx)
                                     return true
                                 }
@@ -306,13 +310,27 @@ struct ACPMessageList: View {
         .frame(height: 1)
     }
 
-    static func topPaginationIndicator(
+    nonisolated static func topPaginationIndicator(
         visibleHead: Int,
         isBackfillingOlderMessages: Bool
     ) -> ACPTopPaginationIndicator {
         if isBackfillingOlderMessages { return .spinner }
         if visibleHead > 0 { return .sentinel }
         return .hidden
+    }
+
+    nonisolated static func shouldRenderQueueBubble(status: QueuedPrompt.Status) -> Bool {
+        switch status {
+        case .pending, .sending:
+            return true
+        }
+    }
+
+    nonisolated static func canDropQueuedItem(
+        sourceStatus: QueuedPrompt.Status?,
+        targetStatus: QueuedPrompt.Status
+    ) -> Bool {
+        sourceStatus == .pending && targetStatus == .pending
     }
 
     /// macOS 14 fallback path. The Tahoe (macOS 15+) ScrollView is no longer

--- a/Alas/Sources/ACP/UI/ACPQueuedBubble.swift
+++ b/Alas/Sources/ACP/UI/ACPQueuedBubble.swift
@@ -156,10 +156,16 @@ enum ACPQueuedBubbleActionMetrics {
     static let buttonSize: CGFloat = 16
     static let buttonSpacing: CGFloat = 4
     static let reservedButtonSlots = 4
+    static let actionGroupToContentSpacing: CGFloat = 8
+    static let minimumLeadingSpacerWidth: CGFloat = 16
 
     static var reservedWidth: CGFloat {
         CGFloat(reservedButtonSlots) * buttonSize
             + CGFloat(reservedButtonSlots - 1) * buttonSpacing
+    }
+
+    static var reservedAccessoryWidth: CGFloat {
+        reservedWidth + actionGroupToContentSpacing
     }
 }
 

--- a/Alas/Sources/ACP/UI/ACPQueuedBubble.swift
+++ b/Alas/Sources/ACP/UI/ACPQueuedBubble.swift
@@ -13,72 +13,100 @@ struct ACPQueuedBubble: View {
     let onRemove: () -> Void
     let onRetry: () -> Void
 
-    @State private var isHovering = false
+    @StateObject private var hover = ACPDelayedHoverVisibility()
     @Environment(\.theme) private var theme
 
     var body: some View {
-        HStack(alignment: .top, spacing: 6) {
-            Spacer(minLength: 40)
+        let preview = Self.textPreview(of: item.blocks)
+
+        HStack(alignment: .top, spacing: 0) {
+            Spacer(minLength: ACPQueuedBubbleActionMetrics.minimumLeadingSpacerWidth)
             VStack(alignment: .trailing, spacing: 4) {
-                HStack(alignment: .center, spacing: 6) {
-                    HStack(spacing: 6) {
-                        if item.status == .sending {
-                            ProgressView().scaleEffect(0.45).frame(width: 12, height: 12)
-                        }
-                        Text(item.status == .sending ? "Sending" : "Queued")
-                            .font(.system(size: 9, weight: .semibold))
-                            .tracking(0.4)
-                            .textCase(.uppercase)
-                            .foregroundStyle(theme.color("fg-faint"))
-                        if let err = item.lastError {
-                            Text("· \(err)")
-                                .font(.system(size: 9, weight: .medium))
-                                .foregroundStyle(theme.color("del"))
-                                .lineLimit(1)
-                        }
-                    }
-                    .lineLimit(1)
-                    if item.status == .pending {
-                        actionsRow
-                    }
+                statusRow
+                if !imageURLs.isEmpty, !preview.isEmpty {
+                    imageRow
                 }
-                if !imageURLs.isEmpty {
-                    HStack(spacing: 4) {
-                        ForEach(Array(imageURLs.enumerated()), id: \.offset) { _, url in
-                            if let image = NSImage(contentsOf: url) {
-                                Image(nsImage: image)
-                                    .resizable()
-                                    .aspectRatio(contentMode: .fill)
-                                    .frame(width: 48, height: 48)
-                                    .clipShape(RoundedRectangle(cornerRadius: 6))
-                            }
-                        }
-                    }
-                }
-                let preview = Self.textPreview(of: item.blocks)
-                if !preview.isEmpty {
-                    ACPMarkdownText(raw: preview)
-                        .padding(.vertical, 9).padding(.horizontal, 13)
-                        .background(theme.color("accent").opacity(0.10))
-                        .clipShape(
-                            UnevenRoundedRectangle(
-                                cornerRadii: .init(topLeading: 12, bottomLeading: 12, bottomTrailing: 4, topTrailing: 12)
-                            )
-                        )
-                        .overlay(
-                            UnevenRoundedRectangle(
-                                cornerRadii: .init(topLeading: 12, bottomLeading: 12, bottomTrailing: 4, topTrailing: 12)
-                            )
-                            .strokeBorder(borderColor, style: borderStyle)
-                        )
-                }
+                queuedContentRow(preview: preview)
             }
             .opacity(item.status == .sending ? 0.85 : 0.6)
-            .frame(maxWidth: 540, alignment: .trailing)
+            .frame(maxWidth: contentColumnMaxWidth, alignment: .trailing)
         }
         .frame(maxWidth: .infinity)
-        .onHover { isHovering = $0 }
+        .onHover { inside in
+            if inside { hover.enter() } else { hover.leave() }
+        }
         .modifier(PendingDraggableModifier(enabled: item.status == .pending, payload: item.id.uuidString))
+    }
+
+    private var statusRow: some View {
+        HStack(spacing: 6) {
+            if item.status == .sending {
+                ProgressView().scaleEffect(0.45).frame(width: 12, height: 12)
+            }
+            Text(item.status == .sending ? "Sending" : "Queued")
+                .font(.system(size: 9, weight: .semibold))
+                .tracking(0.4)
+                .textCase(.uppercase)
+                .foregroundStyle(theme.color("fg-faint"))
+            if let err = item.lastError {
+                Text("· \(err)")
+                    .font(.system(size: 9, weight: .medium))
+                    .foregroundStyle(theme.color("del"))
+                    .lineLimit(1)
+            }
+        }
+        .lineLimit(1)
+    }
+
+    private var imageRow: some View {
+        HStack(spacing: 4) {
+            ForEach(Array(imageURLs.enumerated()), id: \.offset) { _, url in
+                if let image = NSImage(contentsOf: url) {
+                    Image(nsImage: image)
+                        .resizable()
+                        .aspectRatio(contentMode: .fill)
+                        .frame(width: 48, height: 48)
+                        .clipShape(RoundedRectangle(cornerRadius: 6))
+                }
+            }
+        }
+    }
+
+    @ViewBuilder
+    private func queuedContentRow(preview: String) -> some View {
+        if !preview.isEmpty {
+            HStack(alignment: .center, spacing: ACPQueuedBubbleActionMetrics.actionGroupToContentSpacing) {
+                if item.status == .pending { actionsRow }
+                textBubble(preview)
+            }
+        } else if !imageURLs.isEmpty {
+            HStack(alignment: .center, spacing: ACPQueuedBubbleActionMetrics.actionGroupToContentSpacing) {
+                if item.status == .pending { actionsRow }
+                imageRow
+            }
+        } else if item.status == .pending {
+            HStack(alignment: .center, spacing: ACPQueuedBubbleActionMetrics.actionGroupToContentSpacing) {
+                actionsRow
+                Color.clear.frame(width: 0, height: ACPQueuedBubbleActionMetrics.buttonSize)
+            }
+        }
+    }
+
+    private func textBubble(_ preview: String) -> some View {
+        ACPMarkdownText(raw: preview)
+            .padding(.vertical, 9).padding(.horizontal, 13)
+            .background(theme.color("accent").opacity(0.10))
+            .clipShape(
+                UnevenRoundedRectangle(
+                    cornerRadii: .init(topLeading: 12, bottomLeading: 12, bottomTrailing: 4, topTrailing: 12)
+                )
+            )
+            .overlay(
+                UnevenRoundedRectangle(
+                    cornerRadii: .init(topLeading: 12, bottomLeading: 12, bottomTrailing: 4, topTrailing: 12)
+                )
+                .strokeBorder(borderColor, style: borderStyle)
+            )
     }
 
     private var borderColor: Color {
@@ -128,7 +156,13 @@ struct ACPQueuedBubble: View {
     }
 
     private var actionsVisible: Bool {
-        isHovering && item.status == .pending
+        hover.isVisible && item.status == .pending
+    }
+
+    private var contentColumnMaxWidth: CGFloat {
+        item.status == .pending
+            ? 540 + ACPQueuedBubbleActionMetrics.reservedAccessoryWidth
+            : 540
     }
 
     private func actionButton(

--- a/AlasTests/ACP/UI/ACPMessageListPaginationTests.swift
+++ b/AlasTests/ACP/UI/ACPMessageListPaginationTests.swift
@@ -44,4 +44,12 @@ struct ACPMessageListPaginationTests {
         #expect(!ACPMessageList.canDropQueuedItem(sourceStatus: .pending, targetStatus: .sending))
         #expect(!ACPMessageList.canDropQueuedItem(sourceStatus: nil, targetStatus: .pending))
     }
+
+    @Test("queue header count matches rendered queue bubbles")
+    func queueHeaderCountMatchesRenderedQueueBubbles() {
+        #expect(ACPMessageList.queueHeaderCount(statuses: []) == 0)
+        #expect(ACPMessageList.queueHeaderCount(statuses: [.pending]) == 1)
+        #expect(ACPMessageList.queueHeaderCount(statuses: [.sending]) == 1)
+        #expect(ACPMessageList.queueHeaderCount(statuses: [.sending, .pending]) == 2)
+    }
 }

--- a/AlasTests/ACP/UI/ACPMessageListPaginationTests.swift
+++ b/AlasTests/ACP/UI/ACPMessageListPaginationTests.swift
@@ -30,4 +30,18 @@ struct ACPMessageListPaginationTests {
             isBackfillingOlderMessages: true
         ) == .spinner)
     }
+
+    @Test("queue bubbles render pending and sending items")
+    func queueBubblesRenderPendingAndSendingItems() {
+        #expect(ACPMessageList.shouldRenderQueueBubble(status: .pending))
+        #expect(ACPMessageList.shouldRenderQueueBubble(status: .sending))
+    }
+
+    @Test("queue drops only accept pending items onto pending targets")
+    func queueDropsOnlyAcceptPendingItemsOntoPendingTargets() {
+        #expect(ACPMessageList.canDropQueuedItem(sourceStatus: .pending, targetStatus: .pending))
+        #expect(!ACPMessageList.canDropQueuedItem(sourceStatus: .sending, targetStatus: .pending))
+        #expect(!ACPMessageList.canDropQueuedItem(sourceStatus: .pending, targetStatus: .sending))
+        #expect(!ACPMessageList.canDropQueuedItem(sourceStatus: nil, targetStatus: .pending))
+    }
 }

--- a/AlasTests/ACP/UI/ACPQueuedBubbleActionMetricsTests.swift
+++ b/AlasTests/ACP/UI/ACPQueuedBubbleActionMetricsTests.swift
@@ -21,4 +21,11 @@ struct ACPQueuedBubbleActionMetricsTests {
         #expect(editSlotLeading < ACPQueuedBubbleActionMetrics.reservedWidth)
         #expect(removeSlotLeading + button == ACPQueuedBubbleActionMetrics.reservedWidth)
     }
+
+    @Test("left actions reserve a stable lane beside queued content")
+    func leftActionsReserveStableLaneBesideQueuedContent() {
+        #expect(ACPQueuedBubbleActionMetrics.actionGroupToContentSpacing == 8)
+        #expect(ACPQueuedBubbleActionMetrics.minimumLeadingSpacerWidth == 16)
+        #expect(ACPQueuedBubbleActionMetrics.reservedAccessoryWidth == 84)
+    }
 }

--- a/docs/superpowers/specs/2026-06-08-acp-queued-controls-design.md
+++ b/docs/superpowers/specs/2026-06-08-acp-queued-controls-design.md
@@ -1,0 +1,55 @@
+# ACP Queued Controls Design
+
+## Context
+
+Queued prompt controls in the ACP chat pane currently appear inside the queued bubble's header row. They are only visible while the bubble is hovered. Because the controls sit outside the practical hover path, they can disappear before the pointer reaches them, making send, retry, edit, and remove hard or impossible to click.
+
+Normal ACP transcript messages already solve a related problem with a hover region that keeps the action affordance alive while the pointer moves from content to the control. Queued prompts need the same interaction reliability while preserving their visual identity as right-aligned, pending user prompts.
+
+## Design
+
+Pending queued prompts keep the existing right-aligned dashed text bubble and the existing `Queued` status label above it.
+
+The action group moves to the left side of the text bubble. The group is vertically centered against the text bubble body, not against the full queued row and not against the status label. This keeps the controls visually attached to the content they modify.
+
+The hover region covers the full queued row, including the text bubble and the action group. Moving the pointer from the bubble to the icons must keep the icons visible and hit-testable. The controls should remain mounted and switch visibility through opacity and hit testing, following the existing ACP gutter pattern.
+
+Sending queued prompts keep the existing sending status and spinner behavior and do not expose actions.
+
+## Components
+
+`ACPQueuedBubble` remains responsible for rendering a single queued prompt and invoking the existing callbacks:
+
+- `onForceSend`
+- `onRetry`
+- `onEdit`
+- `onRemove`
+
+Its layout changes from a header-embedded actions row to a content row where the action group is a sibling of the bubble column. The action group reserves its width so hover reveal does not shift the bubble.
+
+If the queued prompt contains image thumbnails and text, the controls align to the text bubble. If the queued prompt has no text preview, the controls align to the visible queued content area.
+
+## Behavior
+
+For a pending queued item:
+
+1. Hovering anywhere across the queued row reveals the actions.
+2. Hovering the action group itself keeps the actions revealed.
+3. Leaving both the row and the action group hides the actions.
+4. Retry is only hit-testable and accessible when `lastError` is present.
+5. Drag and drop reordering remains limited to pending queued items.
+
+For a sending queued item:
+
+1. Actions remain hidden and disabled.
+2. The existing sending opacity, spinner, and border styling remain unchanged.
+
+## Testing
+
+Add or update focused SwiftUI-level coverage where practical for the pure layout or state behavior. Manual verification should cover:
+
+- Hovering the queued row reveals the actions.
+- Moving from the bubble to each icon keeps the actions clickable.
+- Pending items can still be force-sent, retried after an error, edited, removed, and reordered.
+- Sending items do not reveal actions.
+- Narrow panes do not overlap the action group with the queued bubble text.


### PR DESCRIPTION
## Summary

- Move pending queued ACP controls into a stable lane to the left of the queued bubble.
- Keep the hover region on the full queued row so moving from the bubble to the controls does not hide them.
- Render sending queued items again while keeping queue drag/drop pending-only.

## Validation

- `xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' test -only-testing:AlasTests/ACPMessageListPaginationTests`
- `xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' test -only-testing:AlasTests/ACPQueuedBubbleActionMetricsTests`
- `xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -quiet build`

Full `xcodebuild ... test` was attempted locally, but the run hung around ACP terminal routing tests and was terminated instead of being counted as a pass.