### PR TITLE
feat(editor): add find and replace

### DIFF
--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -249,6 +249,7 @@
 		4058A537B8CAE76FE7EFE184 /* ACPSessionHydrationStateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1DC1B975662D135B148443BC /* ACPSessionHydrationStateTests.swift */; };
 		40A21E55EB86B5F3D42AEFF2 /* InlineDiffView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 531DB20F5FBC0D8240778FE6 /* InlineDiffView.swift */; };
 		40D9FD39D36ADE353B9971E8 /* MergeRegionVisualLayoutTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 256257983A4B1E1E674DF5B8 /* MergeRegionVisualLayoutTests.swift */; };
+		4107D595F9EBF8A1FC69E101 /* EditorFindRequestTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EB950CFAAADD11E84E783E1F /* EditorFindRequestTests.swift */; };
 		412F8D73E3E5CD7F57CD799A /* CompletionWindowController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 31F3A80227DD4A52C4752722 /* CompletionWindowController.swift */; };
 		4151B68B1CF0A947AEC4C00A /* ACPAuthNudgeBannerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F68B06E93430D1C7B02F6BB2 /* ACPAuthNudgeBannerTests.swift */; };
 		4153DAD75F27395D2D385BED /* LanguageServerAvailabilityTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A8CC42BD54479E057902D392 /* LanguageServerAvailabilityTests.swift */; };
@@ -1825,6 +1826,7 @@
 		EB1E14CFAC880D31CE8FBE8F /* ChangesPane.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChangesPane.swift; sourceTree = "<group>"; };
 		EB44F87B415733A4B2F2A990 /* DraftCommitTabStateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DraftCommitTabStateTests.swift; sourceTree = "<group>"; };
 		EB52B59655B85764D85CFB7F /* LineEndingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LineEndingTests.swift; sourceTree = "<group>"; };
+		EB950CFAAADD11E84E783E1F /* EditorFindRequestTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditorFindRequestTests.swift; sourceTree = "<group>"; };
 		EBB8043A52927E5E935E2F9B /* ImageDiffPairLoaderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageDiffPairLoaderTests.swift; sourceTree = "<group>"; };
 		EBBBF87CC508451B2C0F3A66 /* .gitkeep */ = {isa = PBXFileReference; path = .gitkeep; sourceTree = "<group>"; };
 		EBBFE202A6AB6F0EFB46EB5D /* MergeConflictTextStorage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MergeConflictTextStorage.swift; sourceTree = "<group>"; };
@@ -2138,6 +2140,7 @@
 				35543E9F4994774A3743BC12 /* EditorBufferStoreTests.swift */,
 				C6E896FEA37B4691BD16E2DD /* EditorBufferTests.swift */,
 				6033DBD8BF13A76978A653A3 /* EditorFindControllerTests.swift */,
+				EB950CFAAADD11E84E783E1F /* EditorFindRequestTests.swift */,
 				209B2EDBA4EB4BF7A854FF96 /* EditorLSPStatusResolverTests.swift */,
 				208C9ABAF59F523D2DDC2F2A /* EditorOverlayPanelTests.swift */,
 				E98FAFF3AE36A17EE6AD029C /* EditorTabStateMarkdownCodableTests.swift */,
@@ -4565,6 +4568,7 @@
 				3B7D77B9E71C66ACB1E007D7 /* EditorBufferStoreTests.swift in Sources */,
 				C91AE8901B9D4B16A1EE67FB /* EditorBufferTests.swift in Sources */,
 				B9BEA46E818C321122713F41 /* EditorFindControllerTests.swift in Sources */,
+				4107D595F9EBF8A1FC69E101 /* EditorFindRequestTests.swift in Sources */,
 				A19D418808D8CCCE04242E07 /* EditorLSPStatusResolverTests.swift in Sources */,
 				0EB3B61ECD46CCF450E717BF /* EditorOverlayPanelTests.swift in Sources */,
 				1EBF9B83C26B9518AF70D2F3 /* EditorTabStateMarkdownCodableTests.swift in Sources */,

--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -937,6 +937,7 @@
 		F92535799AE74C9BF1DC3D88 /* EditorLSPStatusOverridePicker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 73B17505E5DB94014B6FCB18 /* EditorLSPStatusOverridePicker.swift */; };
 		F9BE25DD2C3A008328978575 /* AgentAutoLaunch.swift in Sources */ = {isa = PBXBuildFile; fileRef = 25C1AD69581AAE3D34624F23 /* AgentAutoLaunch.swift */; };
 		F9C3EA369FF29AC5D7BCA3C6 /* AgentHookSocketServerCLITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB19F036D793E5DFBBD3C675 /* AgentHookSocketServerCLITests.swift */; };
+		FA2FB05351C86883B303D538 /* EditorFindHighlightRenderer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 94255B602EB04BD063346B3E /* EditorFindHighlightRenderer.swift */; };
 		FAC5B044ADA2ECF467814CE4 /* ConflictsSection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 561094BA96058468F12002A1 /* ConflictsSection.swift */; };
 		FB2AE30704F39C0BDA83F3CC /* ACPConfigOptionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9877AAC39AAB55596495B816 /* ACPConfigOptionTests.swift */; };
 		FB51C37DBD897B3A690DCDC3 /* ACPNewChatEmptyStateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0CE3F0637B3CA27B1D87080 /* ACPNewChatEmptyStateTests.swift */; };
@@ -1511,6 +1512,7 @@
 		93CDC9895F48619E97461875 /* CodePane.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CodePane.swift; sourceTree = "<group>"; };
 		93F451C90EC9036CA8A7A04C /* AgentBuiltins.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentBuiltins.swift; sourceTree = "<group>"; };
 		941BC60920D6A87164610273 /* WorktreeLaunchSurface.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorktreeLaunchSurface.swift; sourceTree = "<group>"; };
+		94255B602EB04BD063346B3E /* EditorFindHighlightRenderer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditorFindHighlightRenderer.swift; sourceTree = "<group>"; };
 		9427B922BAFA43AF6EB21080 /* CommitInfoTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommitInfoTests.swift; sourceTree = "<group>"; };
 		942B0DCA09E1297D9380C58C /* AppQuitAction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppQuitAction.swift; sourceTree = "<group>"; };
 		949B319CFA57A23CE36F2AAE /* LanguageServerAvailability.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LanguageServerAvailability.swift; sourceTree = "<group>"; };
@@ -3270,6 +3272,7 @@
 				BFD267BE3F08611B376F3CC7 /* EditorConflictBanner.swift */,
 				679E62B501E0490F48CCA830 /* EditorFindBarView.swift */,
 				55DE02E1672044B68F9DE0B1 /* EditorFindController.swift */,
+				94255B602EB04BD063346B3E /* EditorFindHighlightRenderer.swift */,
 				D99E47A1F0E3C85A34EABBE6 /* EditorLSPStatus.swift */,
 				BDABED76CD2A552B1781D3F4 /* EditorLSPStatusBadge.swift */,
 				73B17505E5DB94014B6FCB18 /* EditorLSPStatusOverridePicker.swift */,
@@ -4091,6 +4094,7 @@
 				DEBA25FCF25D26395BD04F73 /* EditorConflictBanner.swift in Sources */,
 				3E9F2C02A264024FC020172D /* EditorFindBarView.swift in Sources */,
 				25B497084FDEA8605FF8C5CA /* EditorFindController.swift in Sources */,
+				FA2FB05351C86883B303D538 /* EditorFindHighlightRenderer.swift in Sources */,
 				BFB0E1885389D75F93C98BCF /* EditorLSPStatus.swift in Sources */,
 				3A108152BB33EF9B00FC2F1B /* EditorLSPStatusBadge.swift in Sources */,
 				F92535799AE74C9BF1DC3D88 /* EditorLSPStatusOverridePicker.swift in Sources */,

--- a/Alas/Sources/App/AlasApp.swift
+++ b/Alas/Sources/App/AlasApp.swift
@@ -226,10 +226,25 @@ struct AlasApp: App {
             .keyboardShortcut(state.shortcut(for: .splitSelectionIntoLines))
             .disabled(!state.hasActiveCodeEditorTab)
             Divider()
-            Button("Find and Replace") {
-                NotificationCenter.default.post(name: .alasShowFindReplace, object: nil)
+            Button("Find") {
+                NotificationCenter.default.post(name: .alasShowFindReplace, object: EditorFindRequest.showFind)
             }
             .keyboardShortcut(state.shortcut(for: .findAndReplace))
+            .disabled(!state.hasActiveCodeEditorTab)
+            Button("Find and Replace") {
+                NotificationCenter.default.post(name: .alasShowFindReplace, object: EditorFindRequest.showReplace)
+            }
+            .keyboardShortcut(state.shortcut(for: .replaceInEditor))
+            .disabled(!state.hasActiveCodeEditorTab)
+            Button("Find Next") {
+                NotificationCenter.default.post(name: .alasShowFindReplace, object: EditorFindRequest.findNext)
+            }
+            .keyboardShortcut("g", modifiers: .command)
+            .disabled(!state.hasActiveCodeEditorTab)
+            Button("Find Previous") {
+                NotificationCenter.default.post(name: .alasShowFindReplace, object: EditorFindRequest.findPrevious)
+            }
+            .keyboardShortcut("g", modifiers: [.command, .shift])
             .disabled(!state.hasActiveCodeEditorTab)
         }
         CommandGroup(after: .toolbar) {

--- a/Alas/Sources/App/RootView.swift
+++ b/Alas/Sources/App/RootView.swift
@@ -573,3 +573,10 @@ extension Notification.Name {
     static let codeEditorDidAttach  = Notification.Name("CodeEditorDidAttach")
     static let codeEditorDidDetach  = Notification.Name("CodeEditorDidDetach")
 }
+
+enum EditorFindRequest: Equatable, Sendable {
+    case showFind
+    case showReplace
+    case findNext
+    case findPrevious
+}

--- a/Alas/Sources/Center/EditorTabView.swift
+++ b/Alas/Sources/Center/EditorTabView.swift
@@ -193,15 +193,15 @@ struct EditorTabView: View {
             return
         }
 
-        let previousActiveLocation = activeMatchLocation()
+        let anchor = navigationAnchor(for: direction)
         findController.refreshMatches(selecting: .none)
         guard findController.matchCount > 0 else {
             updateFindStatus()
             return
         }
 
-        if let previousActiveLocation {
-            selectMatch(around: previousActiveLocation, direction: direction)
+        if let anchor {
+            selectMatch(around: anchor, direction: direction)
         } else {
             switch direction {
             case .previous:
@@ -271,10 +271,20 @@ struct EditorTabView: View {
         }
     }
 
-    private func activeMatchLocation() -> Int? {
-        guard let activeMatchIndex = findController.activeMatchIndex,
-              findController.matches.indices.contains(activeMatchIndex) else { return nil }
-        return findController.matches[activeMatchIndex].location
+    private func navigationAnchor(for direction: EditorFindBarView.FindDirection) -> Int? {
+        guard let textView = activeTextView else { return nil }
+        let selection = textView.selectedRange()
+        let textLength = (textView.string as NSString).length
+        guard selection.location != NSNotFound,
+              selection.location >= 0,
+              NSMaxRange(selection) <= textLength else { return nil }
+
+        switch direction {
+        case .previous:
+            return selection.location
+        case .next:
+            return NSMaxRange(selection)
+        }
     }
 
     private func selectMatch(around location: Int, direction: EditorFindBarView.FindDirection) {
@@ -286,7 +296,7 @@ struct EditorTabView: View {
             index = findController.matches.lastIndex { $0.location < location }
                 ?? findController.matches.count - 1
         case .next:
-            index = findController.matches.firstIndex { $0.location > location }
+            index = findController.matches.firstIndex { $0.location >= location }
                 ?? 0
         }
         _ = findController.selectMatch(at: index)

--- a/Alas/Sources/Center/EditorTabView.swift
+++ b/Alas/Sources/Center/EditorTabView.swift
@@ -56,7 +56,9 @@ struct EditorTabView: View {
     @State private var replaceText: String = ""
     @State private var isCaseSensitive: Bool = false
     @State private var findStatusText: String = ""
+    @State private var findHighlightRenderer = EditorFindHighlightRenderer()
     @State private var activeTextView: CodeTextView? = nil
+    @State private var fallbackEscapeHandler: (() -> Bool)? = nil
     @FocusState private var findFieldFocused: Bool
     @FocusState private var replaceFieldFocused: Bool
 
@@ -109,6 +111,9 @@ struct EditorTabView: View {
         }
         .background(theme.color("bg-1"))
         .onDisappear {
+            clearFindHighlights()
+            activeTextView?.escapeHandler = nil
+            fallbackEscapeHandler = nil
             findPresentation = .hidden
             findStatusText = ""
             findController.textView = nil
@@ -119,13 +124,24 @@ struct EditorTabView: View {
                   let notifTabId = info["tabId"] as? TabID,
                   notifTabId == tabId,
                   let textView = info["textView"] as? CodeTextView else { return }
+            clearFindHighlights()
+            if activeTextView !== textView {
+                activeTextView?.escapeHandler = fallbackEscapeHandler
+                fallbackEscapeHandler = textView.escapeHandler
+            }
             activeTextView = textView
             findController.textView = textView
+            findHighlightRenderer.attach(textView: textView)
+            installEscapeHandler(on: textView)
+            renderFindHighlights()
         }
         .onReceive(NotificationCenter.default.publisher(for: .codeEditorDidDetach)) { notification in
             guard let info = notification.userInfo,
                   let notifTabId = info["tabId"] as? TabID,
                   notifTabId == tabId else { return }
+            clearFindHighlights()
+            activeTextView?.escapeHandler = nil
+            fallbackEscapeHandler = nil
             activeTextView = nil
             findController.textView = nil
         }
@@ -220,6 +236,7 @@ struct EditorTabView: View {
             updateFindStatus()
         } else {
             findStatusText = findText.isEmpty ? "" : "No matches"
+            renderFindHighlights()
         }
     }
 
@@ -233,11 +250,13 @@ struct EditorTabView: View {
         } else {
             findStatusText = "Replaced \(count) matches"
         }
+        renderFindHighlights()
     }
 
     private func closeFindBar() {
         findPresentation = .hidden
         findStatusText = ""
+        clearFindHighlights()
         findFieldFocused = false
         replaceFieldFocused = false
         activeTextView?.window?.makeFirstResponder(activeTextView)
@@ -258,10 +277,12 @@ struct EditorTabView: View {
     private func updateFindStatus() {
         guard !findText.isEmpty else {
             findStatusText = ""
+            clearFindHighlights()
             return
         }
         guard findController.matchCount > 0 else {
             findStatusText = "No matches"
+            clearFindHighlights()
             return
         }
         if let activeMatchNumber = findController.activeMatchNumber {
@@ -269,6 +290,34 @@ struct EditorTabView: View {
         } else {
             findStatusText = ""
         }
+        renderFindHighlights()
+    }
+
+    private func installEscapeHandler(on textView: CodeTextView) {
+        let fallbackEscapeHandler = fallbackEscapeHandler
+        textView.escapeHandler = {
+            if findPresentation != .hidden {
+                closeFindBar()
+                return true
+            }
+            return fallbackEscapeHandler?() ?? false
+        }
+    }
+
+    private func renderFindHighlights() {
+        guard findPresentation != .hidden, !findText.isEmpty else {
+            clearFindHighlights()
+            return
+        }
+        findHighlightRenderer.render(
+            matches: findController.matches,
+            activeIndex: findController.activeMatchIndex,
+            color: NSColor.systemYellow.withAlphaComponent(0.28)
+        )
+    }
+
+    private func clearFindHighlights() {
+        findHighlightRenderer.clear()
     }
 
     private func navigationAnchor(for direction: EditorFindBarView.FindDirection) -> Int? {

--- a/Alas/Sources/Center/EditorTabView.swift
+++ b/Alas/Sources/Center/EditorTabView.swift
@@ -30,6 +30,12 @@ private struct LSPStatusProbes {
     }
 }
 
+private enum EditorFindPresentation: Equatable {
+    case hidden
+    case find
+    case replace
+}
+
 struct EditorTabView: View {
     let worktreePath: URL
     let relativePath: String
@@ -44,13 +50,15 @@ struct EditorTabView: View {
     @Environment(\.theme) var theme
     @Environment(\.openWindow) private var openWindow
 
-    @State private var findBarVisible: Bool = false
+    @State private var findPresentation: EditorFindPresentation = .hidden
     @State private var findController = EditorFindController()
     @State private var findText: String = ""
     @State private var replaceText: String = ""
-    @State private var findBarMessage: String? = nil
+    @State private var isCaseSensitive: Bool = false
+    @State private var findStatusText: String = ""
     @State private var activeTextView: CodeTextView? = nil
     @FocusState private var findFieldFocused: Bool
+    @FocusState private var replaceFieldFocused: Bool
 
     var body: some View {
         VStack(spacing: 0) {
@@ -66,62 +74,22 @@ struct EditorTabView: View {
             }
             InstallNudgeBanner(appState: appState, absolutePath: nudgeAbsolutePath)
             BlockedNudgeBanner(appState: appState, absolutePath: nudgeAbsolutePath)
-            if findBarVisible {
+            if findPresentation != .hidden {
                 EditorFindBarView(
                     findText: $findText,
                     replaceText: $replaceText,
-                    message: $findBarMessage,
+                    isCaseSensitive: $isCaseSensitive,
                     findFieldFocused: $findFieldFocused,
-                    onFind: { direction in
-                        findController.findString = findText
-                        guard !findText.isEmpty else { return }
-                        guard let textView = activeTextView else { return }
-                        let start: Int
-                        switch direction {
-                        case .previous:
-                            start = textView.selectedRange().location
-                        case .next:
-                            start = textView.selectedRange().location + textView.selectedRange().length
-                        }
-                        let range: NSRange?
-                        switch direction {
-                        case .previous:
-                            range = findController.previousMatchRange(upTo: start)
-                        case .next:
-                            range = findController.nextMatchRange(startingAt: start)
-                        }
-                        if let range {
-                            textView.setSelectedRange(range)
-                            textView.scrollRangeToVisible(range)
-                        } else {
-                            findBarMessage = "No matches"
-                        }
-                    },
-                    onReplace: {
-                        findController.findString = findText
-                        findController.replacementString = replaceText
-                        if findController.replaceCurrent() {
-                            findBarMessage = nil
-                        } else {
-                            findBarMessage = "No matches"
-                        }
-                    },
-                    onReplaceAll: {
-                        findController.findString = findText
-                        findController.replacementString = replaceText
-                        let count = findController.replaceAll()
-                        if count == 0 {
-                            findBarMessage = "No matches"
-                        } else if count == 1 {
-                            findBarMessage = "Replaced 1 match"
-                        } else {
-                            findBarMessage = "Replaced \(count) matches"
-                        }
-                    },
-                    onDone: {
-                        findBarVisible = false
-                        findBarMessage = nil
-                    }
+                    replaceFieldFocused: $replaceFieldFocused,
+                    showsReplace: findPresentation == .replace,
+                    statusText: findStatusText,
+                    canReplace: findController.canReplace,
+                    onFindChanged: refreshFindFromUserInput,
+                    onToggleCaseSensitive: toggleCaseSensitive,
+                    onFind: navigateFind,
+                    onReplace: replaceCurrentMatch,
+                    onReplaceAll: replaceAllMatches,
+                    onDone: closeFindBar
                 )
             }
             CodeEditorView(
@@ -141,7 +109,8 @@ struct EditorTabView: View {
         }
         .background(theme.color("bg-1"))
         .onDisappear {
-            findBarVisible = false
+            findPresentation = .hidden
+            findStatusText = ""
             findController.textView = nil
             activeTextView = nil
         }
@@ -160,11 +129,160 @@ struct EditorTabView: View {
             activeTextView = nil
             findController.textView = nil
         }
-        .onReceive(NotificationCenter.default.publisher(for: .alasShowFindReplace)) { _ in
-            guard appState.tabs.activeTabId(forWorktree: worktreeId) == tabId else { return }
-            findBarVisible = true
-            findFieldFocused = true
+        .onReceive(NotificationCenter.default.publisher(for: .alasShowFindReplace)) { notification in
+            handleFindRequest(notification)
         }
+    }
+
+    private func handleFindRequest(_ notification: Notification) {
+        guard appState.tabs.activeTabId(forWorktree: worktreeId) == tabId else { return }
+
+        let request = notification.object as? EditorFindRequest ?? .showReplace
+        switch request {
+        case .showFind:
+            showFindBar(.find, prefillFromSelection: true)
+            focusFindField()
+        case .showReplace:
+            showFindBar(.replace, prefillFromSelection: true)
+            if findText.isEmpty {
+                focusFindField()
+            } else {
+                focusReplaceField()
+            }
+        case .findNext:
+            if findPresentation == .hidden {
+                showFindBarForNavigation()
+            }
+            navigateFind(.next)
+        case .findPrevious:
+            if findPresentation == .hidden {
+                showFindBarForNavigation()
+            }
+            navigateFind(.previous)
+        }
+    }
+
+    private func showFindBar(_ presentation: EditorFindPresentation, prefillFromSelection: Bool) {
+        if prefillFromSelection, let selectedText = selectedSingleLineText() {
+            findText = selectedText
+        }
+
+        findPresentation = presentation
+        refreshFindMatches(selecting: findText.isEmpty ? .none : .nearestFromSelection)
+    }
+
+    private func showFindBarForNavigation() {
+        findPresentation = .find
+        refreshFindMatches(selecting: .none)
+    }
+
+    private func refreshFindFromUserInput() {
+        refreshFindMatches(selecting: findText.isEmpty ? .none : .nearestFromSelection)
+    }
+
+    private func toggleCaseSensitive() {
+        refreshFindMatches(selecting: findText.isEmpty ? .none : .nearestFromSelection)
+    }
+
+    private func navigateFind(_ direction: EditorFindBarView.FindDirection) {
+        syncFindController()
+        guard !findText.isEmpty else {
+            findController.refreshMatches(selecting: .none)
+            updateFindStatus()
+            focusFindField()
+            return
+        }
+
+        switch direction {
+        case .previous:
+            _ = findController.selectPrevious()
+        case .next:
+            _ = findController.selectNext()
+        }
+        updateFindStatus()
+    }
+
+    private func replaceCurrentMatch() {
+        syncFindController()
+        let didReplace = findController.replaceCurrent()
+        if didReplace {
+            updateFindStatus()
+        } else {
+            findStatusText = findText.isEmpty ? "" : "No matches"
+        }
+    }
+
+    private func replaceAllMatches() {
+        syncFindController()
+        let count = findController.replaceAll()
+        if count == 0 {
+            findStatusText = findText.isEmpty ? "" : "No matches"
+        } else if count == 1 {
+            findStatusText = "Replaced 1 match"
+        } else {
+            findStatusText = "Replaced \(count) matches"
+        }
+    }
+
+    private func closeFindBar() {
+        findPresentation = .hidden
+        findStatusText = ""
+        findFieldFocused = false
+        replaceFieldFocused = false
+        activeTextView?.window?.makeFirstResponder(activeTextView)
+    }
+
+    private func refreshFindMatches(selecting selection: EditorFindController.RefreshSelection) {
+        syncFindController()
+        findController.refreshMatches(selecting: selection)
+        updateFindStatus()
+    }
+
+    private func syncFindController() {
+        findController.findString = findText
+        findController.replacementString = replaceText
+        findController.isCaseSensitive = isCaseSensitive
+    }
+
+    private func updateFindStatus() {
+        guard !findText.isEmpty else {
+            findStatusText = ""
+            return
+        }
+        guard findController.matchCount > 0 else {
+            findStatusText = "No matches"
+            return
+        }
+        if let activeMatchNumber = findController.activeMatchNumber {
+            findStatusText = "\(activeMatchNumber) of \(findController.matchCount)"
+        } else {
+            findStatusText = ""
+        }
+    }
+
+    private func selectedSingleLineText() -> String? {
+        guard let textView = activeTextView else { return nil }
+        guard textView.selectedRanges.count == 1 else { return nil }
+        let selectedRange = textView.selectedRange()
+        guard selectedRange.location != NSNotFound, selectedRange.length > 0 else { return nil }
+
+        let text = textView.string as NSString
+        guard selectedRange.location >= 0, NSMaxRange(selectedRange) <= text.length else { return nil }
+
+        let selectedText = text.substring(with: selectedRange)
+        guard !selectedText.isEmpty,
+              selectedText.rangeOfCharacter(from: .newlines) == nil else { return nil }
+        return selectedText
+    }
+
+    private func focusFindField() {
+        replaceFieldFocused = false
+        findFieldFocused = true
+    }
+
+    private func focusReplaceField() {
+        findFieldFocused = false
+        replaceFieldFocused = true
     }
 
     private var nudgeAbsolutePath: String {

--- a/Alas/Sources/Center/EditorTabView.swift
+++ b/Alas/Sources/Center/EditorTabView.swift
@@ -148,6 +148,11 @@ struct EditorTabView: View {
         .onReceive(NotificationCenter.default.publisher(for: .alasShowFindReplace)) { notification in
             handleFindRequest(notification)
         }
+        .onReceive(NotificationCenter.default.publisher(for: NSText.didChangeNotification)) { notification in
+            guard let textView = notification.object as? CodeTextView,
+                  textView === activeTextView else { return }
+            handleEditorTextChanged()
+        }
     }
 
     private func handleFindRequest(_ notification: Notification) {
@@ -272,6 +277,13 @@ struct EditorTabView: View {
         findController.findString = findText
         findController.replacementString = replaceText
         findController.isCaseSensitive = isCaseSensitive
+    }
+
+    private func handleEditorTextChanged() {
+        guard findPresentation != .hidden else { return }
+        syncFindController()
+        _ = findController.countMatches()
+        updateFindStatus()
     }
 
     private func updateFindStatus() {

--- a/Alas/Sources/Center/EditorTabView.swift
+++ b/Alas/Sources/Center/EditorTabView.swift
@@ -193,11 +193,22 @@ struct EditorTabView: View {
             return
         }
 
-        switch direction {
-        case .previous:
-            _ = findController.selectPrevious()
-        case .next:
-            _ = findController.selectNext()
+        let previousActiveLocation = activeMatchLocation()
+        findController.refreshMatches(selecting: .none)
+        guard findController.matchCount > 0 else {
+            updateFindStatus()
+            return
+        }
+
+        if let previousActiveLocation {
+            selectMatch(around: previousActiveLocation, direction: direction)
+        } else {
+            switch direction {
+            case .previous:
+                _ = findController.selectPrevious()
+            case .next:
+                _ = findController.selectNext()
+            }
         }
         updateFindStatus()
     }
@@ -258,6 +269,27 @@ struct EditorTabView: View {
         } else {
             findStatusText = ""
         }
+    }
+
+    private func activeMatchLocation() -> Int? {
+        guard let activeMatchIndex = findController.activeMatchIndex,
+              findController.matches.indices.contains(activeMatchIndex) else { return nil }
+        return findController.matches[activeMatchIndex].location
+    }
+
+    private func selectMatch(around location: Int, direction: EditorFindBarView.FindDirection) {
+        guard !findController.matches.isEmpty else { return }
+
+        let index: Int
+        switch direction {
+        case .previous:
+            index = findController.matches.lastIndex { $0.location < location }
+                ?? findController.matches.count - 1
+        case .next:
+            index = findController.matches.firstIndex { $0.location > location }
+                ?? 0
+        }
+        _ = findController.selectMatch(at: index)
     }
 
     private func selectedSingleLineText() -> String? {

--- a/Alas/Sources/Center/EditorTabView.swift
+++ b/Alas/Sources/Center/EditorTabView.swift
@@ -85,7 +85,7 @@ struct EditorTabView: View {
                     replaceFieldFocused: $replaceFieldFocused,
                     showsReplace: findPresentation == .replace,
                     statusText: findStatusText,
-                    canReplace: findController.canReplace,
+                    canReplace: canReplaceMatches,
                     onFindChanged: refreshFindFromUserInput,
                     onToggleCaseSensitive: toggleCaseSensitive,
                     onFind: navigateFind,
@@ -236,6 +236,11 @@ struct EditorTabView: View {
 
     private func replaceCurrentMatch() {
         syncFindController()
+        guard activeTextView?.isEditable == true else {
+            findStatusText = findText.isEmpty ? "" : "Read-only"
+            renderFindHighlights()
+            return
+        }
         let didReplace = findController.replaceCurrent()
         if didReplace {
             updateFindStatus()
@@ -247,6 +252,11 @@ struct EditorTabView: View {
 
     private func replaceAllMatches() {
         syncFindController()
+        guard activeTextView?.isEditable == true else {
+            findStatusText = findText.isEmpty ? "" : "Read-only"
+            renderFindHighlights()
+            return
+        }
         let count = findController.replaceAll()
         if count == 0 {
             findStatusText = findText.isEmpty ? "" : "No matches"
@@ -277,6 +287,10 @@ struct EditorTabView: View {
         findController.findString = findText
         findController.replacementString = replaceText
         findController.isCaseSensitive = isCaseSensitive
+    }
+
+    private var canReplaceMatches: Bool {
+        findController.canReplace && activeTextView?.isEditable == true
     }
 
     private func handleEditorTextChanged() {

--- a/Alas/Sources/Code/Editor/CodeTextView.swift
+++ b/Alas/Sources/Code/Editor/CodeTextView.swift
@@ -642,6 +642,10 @@ final class CodeTextView: NSTextView, FontSizeResponder {
     }
 
     override func performKeyEquivalent(with event: NSEvent) -> Bool {
+        if event.keyCode == 53, escapeHandler?() == true {
+            return true
+        }
+
         let modifiers = event.modifierFlags.intersection(.deviceIndependentFlagsMask)
         let isCommandOnly = modifiers.contains(.command)
             && !modifiers.contains(.shift)

--- a/Alas/Sources/Code/Editor/EditorFindBarView.swift
+++ b/Alas/Sources/Code/Editor/EditorFindBarView.swift
@@ -3,9 +3,15 @@ import SwiftUI
 struct EditorFindBarView: View {
     @Binding var findText: String
     @Binding var replaceText: String
-    @Binding var message: String?
+    @Binding var isCaseSensitive: Bool
     @FocusState.Binding var findFieldFocused: Bool
+    @FocusState.Binding var replaceFieldFocused: Bool
 
+    let showsReplace: Bool
+    let statusText: String
+    let canReplace: Bool
+    let onFindChanged: () -> Void
+    let onToggleCaseSensitive: () -> Void
     let onFind: (_ direction: FindDirection) -> Void
     let onReplace: () -> Void
     let onReplaceAll: () -> Void
@@ -19,7 +25,7 @@ struct EditorFindBarView: View {
     @Environment(\.theme) var theme
 
     var body: some View {
-        HStack(spacing: 12) {
+        HStack(spacing: 8) {
             HStack(spacing: 4) {
                 Image(systemName: "magnifyingglass")
                     .foregroundColor(theme.color("fg-muted"))
@@ -28,53 +34,93 @@ struct EditorFindBarView: View {
                     .focused($findFieldFocused)
                     .textFieldStyle(PlainTextFieldStyle())
                     .font(.system(size: 12))
-                    .frame(minWidth: 120)
+                    .frame(width: 180)
                     .onSubmit { onFind(.next) }
+                    .onChange(of: findText) { _ in
+                        onFindChanged()
+                    }
             }
             .padding(.horizontal, 8)
             .padding(.vertical, 4)
             .background(theme.color("bg-2"))
             .cornerRadius(6)
 
-            HStack(spacing: 4) {
-                TextField("Replace", text: $replaceText)
-                    .textFieldStyle(PlainTextFieldStyle())
-                    .font(.system(size: 12))
-                    .frame(minWidth: 120)
-                    .onSubmit { onReplace() }
+            if showsReplace {
+                HStack(spacing: 4) {
+                    TextField("Replace", text: $replaceText)
+                        .focused($replaceFieldFocused)
+                        .textFieldStyle(PlainTextFieldStyle())
+                        .font(.system(size: 12))
+                        .frame(width: 180)
+                        .onSubmit { onReplace() }
+                }
+                .padding(.horizontal, 8)
+                .padding(.vertical, 4)
+                .background(theme.color("bg-2"))
+                .cornerRadius(6)
             }
-            .padding(.horizontal, 8)
-            .padding(.vertical, 4)
-            .background(theme.color("bg-2"))
-            .cornerRadius(6)
 
-            Button("Replace") {
-                onReplace()
-            }
-            .font(.system(size: 11, weight: .medium))
-            .disabled(findText.isEmpty)
+            HStack(spacing: 2) {
+                Button(action: { onFind(.previous) }) {
+                    Image(systemName: "chevron.up")
+                        .font(.system(size: 10, weight: .semibold))
+                        .frame(width: 22, height: 22)
+                }
+                .help("Previous match")
+                .disabled(findText.isEmpty)
 
-            Button("All") {
-                onReplaceAll()
+                Button(action: { onFind(.next) }) {
+                    Image(systemName: "chevron.down")
+                        .font(.system(size: 10, weight: .semibold))
+                        .frame(width: 22, height: 22)
+                }
+                .help("Next match")
+                .disabled(findText.isEmpty)
             }
-            .font(.system(size: 11, weight: .medium))
-            .disabled(findText.isEmpty)
+            .buttonStyle(PlainButtonStyle())
+
+            Button(action: {
+                isCaseSensitive.toggle()
+                onToggleCaseSensitive()
+            }) {
+                Text("Aa")
+                    .font(.system(size: 11, weight: .semibold))
+                    .foregroundColor(isCaseSensitive ? theme.color("accent") : theme.color("fg-muted"))
+                    .frame(width: 26, height: 22)
+            }
+            .buttonStyle(PlainButtonStyle())
+            .help("Match case")
+
+            Text(statusText)
+                .font(.system(size: 11))
+                .foregroundColor(theme.color("fg-muted"))
+                .lineLimit(1)
+                .frame(width: 90, alignment: .trailing)
+
+            if showsReplace {
+                Button("Replace") {
+                    onReplace()
+                }
+                .font(.system(size: 11, weight: .medium))
+                .disabled(!canReplace)
+
+                Button("All") {
+                    onReplaceAll()
+                }
+                .font(.system(size: 11, weight: .medium))
+                .disabled(!canReplace)
+            }
 
             Spacer(minLength: 8)
-
-            if let msg = message {
-                Text(msg)
-                    .font(.system(size: 11))
-                    .foregroundColor(theme.color("fg-muted"))
-                    .lineLimit(1)
-            }
 
             Button(action: onDone) {
                 Image(systemName: "xmark")
                     .font(.system(size: 11, weight: .medium))
                     .foregroundColor(theme.color("fg-muted"))
+                    .frame(width: 22, height: 22)
             }
             .buttonStyle(PlainButtonStyle())
+            .help("Close")
         }
         .padding(.horizontal, 12)
         .padding(.vertical, 8)

--- a/Alas/Sources/Code/Editor/EditorFindBarView.swift
+++ b/Alas/Sources/Code/Editor/EditorFindBarView.swift
@@ -25,7 +25,7 @@ struct EditorFindBarView: View {
     @Environment(\.theme) var theme
 
     var body: some View {
-        HStack(spacing: 8) {
+        HStack(spacing: showsReplace ? 4 : 8) {
             HStack(spacing: 4) {
                 Image(systemName: "magnifyingglass")
                     .foregroundColor(theme.color("fg-muted"))
@@ -34,14 +34,14 @@ struct EditorFindBarView: View {
                     .focused($findFieldFocused)
                     .textFieldStyle(PlainTextFieldStyle())
                     .font(.system(size: 12))
-                    .frame(minWidth: 72, idealWidth: 180, maxWidth: 220)
+                    .frame(minWidth: 36, idealWidth: showsReplace ? 120 : 180, maxWidth: .infinity)
                     .layoutPriority(2)
                     .onSubmit { onFind(.next) }
                     .onChange(of: findText) { _ in
                         onFindChanged()
                     }
             }
-            .padding(.horizontal, 8)
+            .padding(.horizontal, showsReplace ? 6 : 8)
             .padding(.vertical, 4)
             .background(theme.color("bg-2"))
             .cornerRadius(6)
@@ -52,11 +52,11 @@ struct EditorFindBarView: View {
                         .focused($replaceFieldFocused)
                         .textFieldStyle(PlainTextFieldStyle())
                         .font(.system(size: 12))
-                        .frame(minWidth: 72, idealWidth: 180, maxWidth: 220)
+                        .frame(minWidth: 36, idealWidth: 120, maxWidth: .infinity)
                         .layoutPriority(1)
                         .onSubmit { onReplace() }
                 }
-                .padding(.horizontal, 8)
+                .padding(.horizontal, 6)
                 .padding(.vertical, 4)
                 .background(theme.color("bg-2"))
                 .cornerRadius(6)
@@ -102,25 +102,33 @@ struct EditorFindBarView: View {
                 .foregroundColor(theme.color("fg-muted"))
                 .lineLimit(1)
                 .truncationMode(.tail)
-                .frame(minWidth: 44, idealWidth: 90, maxWidth: 100, alignment: .trailing)
+                .frame(minWidth: 0, idealWidth: showsReplace ? 52 : 90, maxWidth: showsReplace ? 64 : 100, alignment: .trailing)
 
             if showsReplace {
-                Button("Replace") {
+                Button {
                     onReplace()
+                } label: {
+                    Image(systemName: "arrow.right")
+                        .font(.system(size: 10, weight: .semibold))
+                        .frame(width: 22, height: 22)
                 }
-                .font(.system(size: 11, weight: .medium))
+                .buttonStyle(PlainButtonStyle())
+                .help("Replace current match")
                 .accessibilityLabel("Replace current match")
                 .disabled(!canReplace)
 
-                Button("All") {
+                Button {
                     onReplaceAll()
+                } label: {
+                    Image(systemName: "arrow.triangle.2.circlepath")
+                        .font(.system(size: 10, weight: .semibold))
+                        .frame(width: 22, height: 22)
                 }
-                .font(.system(size: 11, weight: .medium))
+                .buttonStyle(PlainButtonStyle())
+                .help("Replace all matches")
                 .accessibilityLabel("Replace all matches")
                 .disabled(!canReplace)
             }
-
-            Spacer(minLength: 8)
 
             Button(action: onDone) {
                 Image(systemName: "xmark")

--- a/Alas/Sources/Code/Editor/EditorFindBarView.swift
+++ b/Alas/Sources/Code/Editor/EditorFindBarView.swift
@@ -34,7 +34,8 @@ struct EditorFindBarView: View {
                     .focused($findFieldFocused)
                     .textFieldStyle(PlainTextFieldStyle())
                     .font(.system(size: 12))
-                    .frame(width: 180)
+                    .frame(minWidth: 72, idealWidth: 180, maxWidth: 220)
+                    .layoutPriority(2)
                     .onSubmit { onFind(.next) }
                     .onChange(of: findText) { _ in
                         onFindChanged()
@@ -51,7 +52,8 @@ struct EditorFindBarView: View {
                         .focused($replaceFieldFocused)
                         .textFieldStyle(PlainTextFieldStyle())
                         .font(.system(size: 12))
-                        .frame(width: 180)
+                        .frame(minWidth: 72, idealWidth: 180, maxWidth: 220)
+                        .layoutPriority(1)
                         .onSubmit { onReplace() }
                 }
                 .padding(.horizontal, 8)
@@ -67,6 +69,7 @@ struct EditorFindBarView: View {
                         .frame(width: 22, height: 22)
                 }
                 .help("Previous match")
+                .accessibilityLabel("Previous match")
                 .disabled(findText.isEmpty)
 
                 Button(action: { onFind(.next) }) {
@@ -75,6 +78,7 @@ struct EditorFindBarView: View {
                         .frame(width: 22, height: 22)
                 }
                 .help("Next match")
+                .accessibilityLabel("Next match")
                 .disabled(findText.isEmpty)
             }
             .buttonStyle(PlainButtonStyle())
@@ -90,24 +94,29 @@ struct EditorFindBarView: View {
             }
             .buttonStyle(PlainButtonStyle())
             .help("Match case")
+            .accessibilityLabel("Match case")
+            .accessibilityValue(isCaseSensitive ? "On" : "Off")
 
             Text(statusText)
                 .font(.system(size: 11))
                 .foregroundColor(theme.color("fg-muted"))
                 .lineLimit(1)
-                .frame(width: 90, alignment: .trailing)
+                .truncationMode(.tail)
+                .frame(minWidth: 44, idealWidth: 90, maxWidth: 100, alignment: .trailing)
 
             if showsReplace {
                 Button("Replace") {
                     onReplace()
                 }
                 .font(.system(size: 11, weight: .medium))
+                .accessibilityLabel("Replace current match")
                 .disabled(!canReplace)
 
                 Button("All") {
                     onReplaceAll()
                 }
                 .font(.system(size: 11, weight: .medium))
+                .accessibilityLabel("Replace all matches")
                 .disabled(!canReplace)
             }
 
@@ -121,6 +130,7 @@ struct EditorFindBarView: View {
             }
             .buttonStyle(PlainButtonStyle())
             .help("Close")
+            .accessibilityLabel("Close find bar")
         }
         .padding(.horizontal, 12)
         .padding(.vertical, 8)

--- a/Alas/Sources/Code/Editor/EditorFindBarView.swift
+++ b/Alas/Sources/Code/Editor/EditorFindBarView.swift
@@ -144,5 +144,25 @@ struct EditorFindBarView: View {
         .padding(.vertical, 8)
         .background(theme.color("bg-1"))
         .overlay(Divider().opacity(0.5), alignment: .bottom)
+        .onExitCommand(perform: onDone)
+        .onKeyPress { press in
+            handleKeyPress(press)
+        }
+    }
+
+    private func handleKeyPress(_ press: KeyPress) -> KeyPress.Result {
+        switch press.key {
+        case .escape:
+            onDone()
+            return .handled
+        case .return:
+            if press.modifiers.contains(.shift) {
+                onFind(.previous)
+                return .handled
+            }
+            return .ignored
+        default:
+            return .ignored
+        }
     }
 }

--- a/Alas/Sources/Code/Editor/EditorFindController.swift
+++ b/Alas/Sources/Code/Editor/EditorFindController.swift
@@ -7,6 +7,13 @@ import Foundation
 /// flow through the normal pipeline.
 @MainActor
 final class EditorFindController {
+    enum RefreshSelection {
+        case none
+        case first
+        case nearestFromSelection
+        case preservingActiveLocation(Int)
+    }
+
     /// Set by the hosting `EditorTabView` after the coordinator attaches.
     weak var textView: CodeTextView?
 
@@ -16,12 +23,104 @@ final class EditorFindController {
     /// Replace string used as replacement text.
     var replacementString: String = ""
 
+    /// Whether matching should require exact case.
+    var isCaseSensitive: Bool = false
+
+    /// Non-overlapping matches for current find string.
+    private(set) var matches: [NSRange] = []
+
+    /// Zero-based index into `matches` for the selected match.
+    private(set) var activeMatchIndex: Int?
+
+    /// One-based active match number for display.
+    var activeMatchNumber: Int? {
+        activeMatchIndex.map { $0 + 1 }
+    }
+
     /// Number of matches for current find string.
     private(set) var matchCount: Int = 0
 
     /// Whether there are any replacements.
     var canReplace: Bool {
         !findString.isEmpty && matchCount > 0
+    }
+
+    /// Recomputes match state and optionally selects a match.
+    func refreshMatches(selecting selection: RefreshSelection) {
+        guard let textView = textView, !findString.isEmpty else {
+            clearMatches()
+            return
+        }
+
+        matches = collectMatches(in: textView.string as NSString)
+        matchCount = matches.count
+        guard !matches.isEmpty else {
+            activeMatchIndex = nil
+            return
+        }
+
+        switch selection {
+        case .none:
+            activeMatchIndex = nil
+        case .first:
+            _ = selectMatch(at: 0)
+        case .nearestFromSelection:
+            _ = selectNearestMatch(to: textView.selectedRange())
+        case .preservingActiveLocation(let location):
+            _ = selectMatch(at: indexOfMatch(atOrAfter: location) ?? 0)
+        }
+    }
+
+    /// Selects the next match, wrapping to the first match from the last.
+    @discardableResult
+    func selectNext() -> Bool {
+        guard !findString.isEmpty else {
+            clearMatches()
+            return false
+        }
+        if matches.isEmpty {
+            refreshMatches(selecting: .nearestFromSelection)
+            return activeMatchIndex != nil
+        }
+        let index = activeMatchIndex.map { ($0 + 1) % matches.count }
+            ?? indexOfMatch(atOrAfter: textView?.selectedRange().location ?? 0)
+            ?? 0
+        return selectMatch(at: index)
+    }
+
+    /// Selects the previous match, wrapping to the last match from the first.
+    @discardableResult
+    func selectPrevious() -> Bool {
+        guard !findString.isEmpty else {
+            clearMatches()
+            return false
+        }
+        if matches.isEmpty {
+            refreshMatches(selecting: .nearestFromSelection)
+            return activeMatchIndex != nil
+        }
+        let index: Int
+        if let activeMatchIndex {
+            index = (activeMatchIndex - 1 + matches.count) % matches.count
+        } else {
+            let location = textView?.selectedRange().location ?? 0
+            index = indexOfMatch(beforeOrAt: location) ?? matches.count - 1
+        }
+        return selectMatch(at: index)
+    }
+
+    /// Selects a match by zero-based index.
+    @discardableResult
+    func selectMatch(at index: Int) -> Bool {
+        guard matches.indices.contains(index), let textView = textView else {
+            activeMatchIndex = nil
+            return false
+        }
+        let range = matches[index]
+        activeMatchIndex = index
+        textView.setSelectedRange(range)
+        textView.scrollRangeToVisible(range)
+        return true
     }
 
     /// Find the next match starting from `searchLocation` and return its UTF-16
@@ -32,7 +131,7 @@ final class EditorFindController {
         let text = textView.string as NSString
         guard searchLocation <= text.length else { return nil }
         let range = NSRange(location: searchLocation, length: text.length - searchLocation)
-        let found = text.range(of: findString, options: [], range: range)
+        let found = text.range(of: findString, options: searchOptions, range: range)
         guard found.location != NSNotFound else { return nil }
         return found
     }
@@ -44,7 +143,7 @@ final class EditorFindController {
         let text = textView.string as NSString
         let searchEnd = min(searchLocation, text.length)
         let range = NSRange(location: 0, length: searchEnd)
-        let found = text.range(of: findString, options: .backwards, range: range)
+        let found = text.range(of: findString, options: searchOptions.union(.backwards), range: range)
         guard found.location != NSNotFound else { return nil }
         return found
     }
@@ -61,8 +160,7 @@ final class EditorFindController {
 
         // If the selection is not a valid match, search from cursor position,
         // wrapping to the start if no match is found ahead.
-        let selectionIsMatch = foundRange.length == findString.utf16.count
-            && text.substring(with: foundRange) == findString
+        let selectionIsMatch = rangeIsMatch(foundRange, in: text)
         if !selectionIsMatch {
             let searchStart = foundRange.location
             if let match = nextMatchRange(startingAt: searchStart)
@@ -72,8 +170,7 @@ final class EditorFindController {
             }
         }
 
-        guard foundRange.length == findString.utf16.count,
-              text.substring(with: foundRange) == findString else { return false }
+        guard rangeIsMatch(foundRange, in: text) else { return false }
 
         textView.autoPairDisabled = true
         defer { textView.autoPairDisabled = false }
@@ -82,9 +179,9 @@ final class EditorFindController {
 
         let updatedLength = (textView.string as NSString).length
         let searchStart = min(foundRange.location + replacementString.utf16.count, updatedLength)
-        if let nextRange = nextMatchRange(startingAt: searchStart) {
-            textView.setSelectedRange(nextRange)
-            textView.scrollRangeToVisible(nextRange)
+        refreshMatches(selecting: .preservingActiveLocation(searchStart))
+        if activeMatchIndex == nil, !matches.isEmpty {
+            _ = selectMatch(at: 0)
         }
         return true
     }
@@ -94,19 +191,17 @@ final class EditorFindController {
     func replaceAll() -> Int {
         guard let textView = textView else { return 0 }
         guard textView.isEditable else { return 0 }
-        guard !findString.isEmpty else { return 0 }
+        guard !findString.isEmpty else {
+            clearMatches()
+            return 0
+        }
 
         let text = textView.string as NSString
-        var locations: [Int] = []
-        var current = 0
-        while current <= text.length - findString.utf16.count {
-            let range = NSRange(location: current, length: text.length - current)
-            let found = text.range(of: findString, options: [], range: range)
-            if found.location == NSNotFound { break }
-            locations.append(found.location)
-            current = found.location + found.length
+        let replacementRanges = collectMatches(in: text)
+        guard !replacementRanges.isEmpty else {
+            refreshMatches(selecting: .none)
+            return 0
         }
-        guard !locations.isEmpty else { return 0 }
 
         let count: Int
         if let undoManager = textView.undoManager {
@@ -117,29 +212,28 @@ final class EditorFindController {
             textView.autoPairDisabled = true
             defer { textView.autoPairDisabled = false }
 
-            count = locations.reversed().reduce(0) { acc, loc in
-                let replacementNSRange = NSRange(location: loc, length: findString.utf16.count)
-                textView.insertText(replacementString, replacementRange: replacementNSRange)
+            count = replacementRanges.reversed().reduce(0) { acc, range in
+                textView.insertText(replacementString, replacementRange: range)
                 return acc + 1
             }
         } else {
             textView.autoPairDisabled = true
             defer { textView.autoPairDisabled = false }
 
-            count = locations.reversed().reduce(0) { acc, loc in
-                let replacementNSRange = NSRange(location: loc, length: findString.utf16.count)
-                textView.insertText(replacementString, replacementRange: replacementNSRange)
+            count = replacementRanges.reversed().reduce(0) { acc, range in
+                textView.insertText(replacementString, replacementRange: range)
                 return acc + 1
             }
         }
 
         // After replace-all, move cursor to the first replacement.
-        if let firstLocation = locations.first {
+        if let firstLocation = replacementRanges.first?.location {
             let newNSRange = NSRange(location: firstLocation, length: replacementString.utf16.count)
             if firstLocation <= (textView.string as NSString).length {
                 textView.setSelectedRange(newNSRange)
             }
         }
+        refreshMatches(selecting: .none)
         return count
     }
 
@@ -147,22 +241,85 @@ final class EditorFindController {
     func countMatches() -> Int {
         guard let textView = textView else { return 0 }
         guard !findString.isEmpty else {
-            matchCount = 0
+            clearMatches()
             return 0
         }
 
         let text = textView.string as NSString
-        var count = 0
-        var current = 0
+        let activeLocation = activeMatchIndex.flatMap { matches.indices.contains($0) ? matches[$0].location : nil }
+        matches = collectMatches(in: text)
+        matchCount = matches.count
+        activeMatchIndex = activeLocation.flatMap { location in
+            matches.firstIndex { $0.location == location }
+        }
+        return matchCount
+    }
 
+    private var searchOptions: NSString.CompareOptions {
+        isCaseSensitive ? [] : [.caseInsensitive]
+    }
+
+    private func collectMatches(in text: NSString) -> [NSRange] {
+        guard !findString.isEmpty else { return [] }
+
+        var result: [NSRange] = []
+        var current = 0
         while current <= text.length - findString.utf16.count {
             let range = NSRange(location: current, length: text.length - current)
-            let found = text.range(of: findString, options: [], range: range)
+            let found = text.range(of: findString, options: searchOptions, range: range)
             if found.location == NSNotFound { break }
-            count += 1
+            result.append(found)
             current = found.location + found.length
         }
-        matchCount = count
-        return count
+        return result
+    }
+
+    private func rangeIsMatch(_ range: NSRange, in text: NSString) -> Bool {
+        guard !findString.isEmpty else { return false }
+        guard range.location != NSNotFound,
+              range.location >= 0,
+              range.length == findString.utf16.count,
+              NSMaxRange(range) <= text.length else { return false }
+
+        return text.compare(findString, options: searchOptions, range: range) == .orderedSame
+    }
+
+    private func clearMatches() {
+        matches = []
+        activeMatchIndex = nil
+        matchCount = 0
+    }
+
+    private func indexOfMatch(atOrAfter location: Int) -> Int? {
+        matches.firstIndex { $0.location >= location }
+    }
+
+    private func indexOfMatch(beforeOrAt location: Int) -> Int? {
+        matches.lastIndex { $0.location <= location }
+    }
+
+    private func selectNearestMatch(to selection: NSRange) -> Bool {
+        if let containingIndex = matches.firstIndex(where: { NSLocationInRange(selection.location, $0) }) {
+            return selectMatch(at: containingIndex)
+        }
+        let location = selection.location + selection.length
+        let nearestIndex = matches.indices.min { lhs, rhs in
+            distance(from: location, to: matches[lhs]) < distance(from: location, to: matches[rhs])
+        }
+        guard let nearestIndex else {
+            activeMatchIndex = nil
+            return false
+        }
+        return selectMatch(at: nearestIndex)
+    }
+
+    private func distance(from location: Int, to range: NSRange) -> Int {
+        if location < range.location {
+            return range.location - location
+        }
+        if location > NSMaxRange(range) {
+            return location - NSMaxRange(range)
+        }
+        return 0
     }
 }

--- a/Alas/Sources/Code/Editor/EditorFindHighlightRenderer.swift
+++ b/Alas/Sources/Code/Editor/EditorFindHighlightRenderer.swift
@@ -1,0 +1,46 @@
+import AppKit
+
+@MainActor
+final class EditorFindHighlightRenderer {
+    private weak var textView: CodeTextView?
+    private var highlightedRanges: [NSRange] = []
+
+    func attach(textView: CodeTextView) {
+        if self.textView !== textView {
+            clear()
+            self.textView = textView
+        }
+    }
+
+    func clear() {
+        guard let layoutManager = textView?.layoutManager else {
+            highlightedRanges.removeAll()
+            return
+        }
+
+        for range in highlightedRanges {
+            layoutManager.removeTemporaryAttribute(.backgroundColor, forCharacterRange: range)
+        }
+        highlightedRanges.removeAll()
+    }
+
+    func render(matches: [NSRange], activeIndex: Int?, color: NSColor) {
+        clear()
+
+        guard let textView,
+              let layoutManager = textView.layoutManager,
+              !matches.isEmpty else { return }
+
+        let textLength = (textView.string as NSString).length
+        for (index, range) in matches.enumerated() {
+            guard index != activeIndex,
+                  range.location != NSNotFound,
+                  range.location >= 0,
+                  range.length > 0,
+                  NSMaxRange(range) <= textLength else { continue }
+
+            layoutManager.addTemporaryAttribute(.backgroundColor, value: color, forCharacterRange: range)
+            highlightedRanges.append(range)
+        }
+    }
+}

--- a/Alas/Sources/Code/Editor/EditorFindHighlightRenderer.swift
+++ b/Alas/Sources/Code/Editor/EditorFindHighlightRenderer.swift
@@ -3,7 +3,6 @@ import AppKit
 @MainActor
 final class EditorFindHighlightRenderer {
     private weak var textView: CodeTextView?
-    private var highlightedRanges: [NSRange] = []
 
     func attach(textView: CodeTextView) {
         if self.textView !== textView {
@@ -15,24 +14,15 @@ final class EditorFindHighlightRenderer {
     func clear() {
         guard let textView,
               let layoutManager = textView.layoutManager else {
-            highlightedRanges.removeAll()
             return
         }
 
         let textLength = (textView.string as NSString).length
-        for range in highlightedRanges {
-            guard range.location != NSNotFound,
-                  range.location >= 0,
-                  range.length > 0,
-                  range.location < textLength else { continue }
-
-            let cleanupRange = NSRange(
-                location: range.location,
-                length: min(range.length, textLength - range.location)
-            )
-            layoutManager.removeTemporaryAttribute(.backgroundColor, forCharacterRange: cleanupRange)
-        }
-        highlightedRanges.removeAll()
+        guard textLength > 0 else { return }
+        layoutManager.removeTemporaryAttribute(
+            .backgroundColor,
+            forCharacterRange: NSRange(location: 0, length: textLength)
+        )
     }
 
     func render(matches: [NSRange], activeIndex: Int?, color: NSColor) {
@@ -51,7 +41,6 @@ final class EditorFindHighlightRenderer {
                   NSMaxRange(range) <= textLength else { continue }
 
             layoutManager.addTemporaryAttribute(.backgroundColor, value: color, forCharacterRange: range)
-            highlightedRanges.append(range)
         }
     }
 }

--- a/Alas/Sources/Code/Editor/EditorFindHighlightRenderer.swift
+++ b/Alas/Sources/Code/Editor/EditorFindHighlightRenderer.swift
@@ -13,13 +13,24 @@ final class EditorFindHighlightRenderer {
     }
 
     func clear() {
-        guard let layoutManager = textView?.layoutManager else {
+        guard let textView,
+              let layoutManager = textView.layoutManager else {
             highlightedRanges.removeAll()
             return
         }
 
+        let textLength = (textView.string as NSString).length
         for range in highlightedRanges {
-            layoutManager.removeTemporaryAttribute(.backgroundColor, forCharacterRange: range)
+            guard range.location != NSNotFound,
+                  range.location >= 0,
+                  range.length > 0,
+                  range.location < textLength else { continue }
+
+            let cleanupRange = NSRange(
+                location: range.location,
+                length: min(range.length, textLength - range.location)
+            )
+            layoutManager.removeTemporaryAttribute(.backgroundColor, forCharacterRange: cleanupRange)
         }
         highlightedRanges.removeAll()
     }

--- a/Alas/Sources/Persistence/AppConfig.swift
+++ b/Alas/Sources/Persistence/AppConfig.swift
@@ -714,6 +714,10 @@ private extension AppConfig {
         let replaceKey = ShortcutAction.replaceInEditor.rawValue
         guard let legacyOverride = shortcutOverrides[legacyKey],
               !shortcutOverrides.keys.contains(replaceKey) else { return }
+        if legacyOverride == ShortcutAction.findAndReplace.defaultBinding {
+            shortcutOverrides.removeValue(forKey: legacyKey)
+            return
+        }
         shortcutOverrides.updateValue(legacyOverride, forKey: replaceKey)
         shortcutOverrides.removeValue(forKey: legacyKey)
     }

--- a/Alas/Sources/Persistence/AppConfig.swift
+++ b/Alas/Sources/Persistence/AppConfig.swift
@@ -704,6 +704,18 @@ extension AppConfig {
             (try? c.decode([String: SidebarChromeOverride].self, forKey: .sidebarChromeOverrides)) ?? [:]
         shortcutOverrides =
             (try? c.decode([String: ShortcutBinding?].self, forKey: .shortcutOverrides)) ?? [:]
+        migrateLegacyFindAndReplaceShortcutOverride()
+    }
+}
+
+private extension AppConfig {
+    mutating func migrateLegacyFindAndReplaceShortcutOverride() {
+        let legacyKey = ShortcutAction.findAndReplace.rawValue
+        let replaceKey = ShortcutAction.replaceInEditor.rawValue
+        guard let legacyOverride = shortcutOverrides[legacyKey],
+              !shortcutOverrides.keys.contains(replaceKey) else { return }
+        shortcutOverrides.updateValue(legacyOverride, forKey: replaceKey)
+        shortcutOverrides.removeValue(forKey: legacyKey)
     }
 }
 

--- a/Alas/Sources/Shortcuts/ShortcutAction.swift
+++ b/Alas/Sources/Shortcuts/ShortcutAction.swift
@@ -14,7 +14,7 @@ enum ShortcutGroup: String, CaseIterable, Sendable {
 
 enum ShortcutAction: String, CaseIterable, Codable, Sendable {
     // Global
-    case searchFiles, switchRepository, findAndReplace, toggleSidebar, toggleRightPane,
+    case searchFiles, switchRepository, findAndReplace, replaceInEditor, toggleSidebar, toggleRightPane,
          createProject, newWorktree, focusMainWorktree, newTerminalTab, launchAgentTerminal, launchAgentChat,
          increaseFontSize, decreaseFontSize, resetFontSize
     // Code editor
@@ -26,7 +26,7 @@ enum ShortcutAction: String, CaseIterable, Codable, Sendable {
 
     var group: ShortcutGroup {
         switch self {
-        case .searchFiles, .switchRepository, .findAndReplace, .toggleSidebar, .toggleRightPane,
+        case .searchFiles, .switchRepository, .findAndReplace, .replaceInEditor, .toggleSidebar, .toggleRightPane,
              .createProject, .newWorktree, .focusMainWorktree, .newTerminalTab, .launchAgentTerminal, .launchAgentChat,
              .increaseFontSize, .decreaseFontSize, .resetFontSize:
             return .global
@@ -45,7 +45,8 @@ enum ShortcutAction: String, CaseIterable, Codable, Sendable {
         switch self {
         case .searchFiles:              return "Search Files"
         case .switchRepository:         return "Switch Repository"
-        case .findAndReplace:           return "Find and Replace"
+        case .findAndReplace:           return "Find"
+        case .replaceInEditor:          return "Find and Replace"
         case .toggleSidebar:            return "Toggle Sidebar"
         case .toggleRightPane:          return "Toggle Right Sidebar"
         case .createProject:            return "Create Project"
@@ -91,7 +92,7 @@ enum ShortcutAction: String, CaseIterable, Codable, Sendable {
     var appliesInTerminal: Bool {
         switch self {
         case .splitSelectionIntoLines, .toggleMarkdownPreview,
-             .commitInComposer, .findAndReplace:
+             .commitInComposer, .findAndReplace, .replaceInEditor:
             return false
         default:
             return true
@@ -102,7 +103,8 @@ enum ShortcutAction: String, CaseIterable, Codable, Sendable {
         switch self {
         case .searchFiles:              return .init(key: "p",          modifiers: [.command])
         case .switchRepository:         return .init(key: "k",          modifiers: [.command])
-        case .findAndReplace:           return .init(key: "f",          modifiers: [.command, .option])
+        case .findAndReplace:           return .init(key: "f",          modifiers: [.command])
+        case .replaceInEditor:          return .init(key: "r",          modifiers: [.command])
         case .toggleSidebar:            return .init(key: "b",          modifiers: [.command])
         case .toggleRightPane:          return .init(key: "b",          modifiers: [.command, .option])
         case .createProject:            return .init(key: "n",          modifiers: [.command, .shift])

--- a/AlasTests/AppConfigShortcutsCodingTests.swift
+++ b/AlasTests/AppConfigShortcutsCodingTests.swift
@@ -52,6 +52,19 @@ struct AppConfigShortcutsCodingTests {
         #expect(decoded.shortcutOverrides[ShortcutAction.findAndReplace.rawValue] == nil)
     }
 
+    @Test func dropsLegacyFindOverrideWhenItCollidesWithNewFindDefault() throws {
+        var cfg = AppConfig.defaults
+        cfg.shortcutOverrides = [
+            ShortcutAction.findAndReplace.rawValue: ShortcutAction.findAndReplace.defaultBinding
+        ]
+
+        let data = try JSONEncoder().encode(cfg)
+        let decoded = try JSONDecoder().decode(AppConfig.self, from: data)
+
+        #expect(decoded.shortcutOverrides[ShortcutAction.replaceInEditor.rawValue] == nil)
+        #expect(decoded.shortcutOverrides[ShortcutAction.findAndReplace.rawValue] == nil)
+    }
+
     @Test func preservesExplicitNewReplaceOverrideDuringFindMigration() throws {
         var cfg = AppConfig.defaults
         let legacy = ShortcutBinding(key: "j", modifiers: [.command, .option])

--- a/AlasTests/AppConfigShortcutsCodingTests.swift
+++ b/AlasTests/AppConfigShortcutsCodingTests.swift
@@ -37,4 +37,48 @@ struct AppConfigShortcutsCodingTests {
         #expect(decoded.shortcutOverrides.keys.contains(ShortcutAction.switchRepository.rawValue))
         #expect(decoded.shortcutOverrides[ShortcutAction.switchRepository.rawValue] == .some(nil))
     }
+
+    @Test func migratesLegacyFindAndReplaceOverrideToReplaceAction() throws {
+        var cfg = AppConfig.defaults
+        let custom = ShortcutBinding(key: "j", modifiers: [.command, .option])
+        cfg.shortcutOverrides = [
+            ShortcutAction.findAndReplace.rawValue: custom
+        ]
+
+        let data = try JSONEncoder().encode(cfg)
+        let decoded = try JSONDecoder().decode(AppConfig.self, from: data)
+
+        #expect(decoded.shortcutOverrides[ShortcutAction.replaceInEditor.rawValue] == .some(custom))
+        #expect(decoded.shortcutOverrides[ShortcutAction.findAndReplace.rawValue] == nil)
+    }
+
+    @Test func preservesExplicitNewReplaceOverrideDuringFindMigration() throws {
+        var cfg = AppConfig.defaults
+        let legacy = ShortcutBinding(key: "j", modifiers: [.command, .option])
+        let replacement = ShortcutBinding(key: "r", modifiers: [.command, .option])
+        cfg.shortcutOverrides = [
+            ShortcutAction.findAndReplace.rawValue: legacy,
+            ShortcutAction.replaceInEditor.rawValue: replacement,
+        ]
+
+        let data = try JSONEncoder().encode(cfg)
+        let decoded = try JSONDecoder().decode(AppConfig.self, from: data)
+
+        #expect(decoded.shortcutOverrides[ShortcutAction.replaceInEditor.rawValue] == .some(replacement))
+        #expect(decoded.shortcutOverrides[ShortcutAction.findAndReplace.rawValue] == .some(legacy))
+    }
+
+    @Test func migratesLegacyFindAndReplaceUnbindToReplaceAction() throws {
+        var cfg = AppConfig.defaults
+        cfg.shortcutOverrides = [
+            ShortcutAction.findAndReplace.rawValue: nil
+        ]
+
+        let data = try JSONEncoder().encode(cfg)
+        let decoded = try JSONDecoder().decode(AppConfig.self, from: data)
+
+        #expect(decoded.shortcutOverrides.keys.contains(ShortcutAction.replaceInEditor.rawValue))
+        #expect(decoded.shortcutOverrides[ShortcutAction.replaceInEditor.rawValue] == .some(nil))
+        #expect(decoded.shortcutOverrides[ShortcutAction.findAndReplace.rawValue] == nil)
+    }
 }

--- a/AlasTests/EditorFindControllerTests.swift
+++ b/AlasTests/EditorFindControllerTests.swift
@@ -126,6 +126,42 @@ struct EditorFindControllerTests {
         #expect(controller.matchCount == 3)
     }
 
+    @Test func defaultSearchIsCaseInsensitive() {
+        let textView = makeTextView("Cat cat CAT catalog")
+        let controller = EditorFindController()
+        controller.textView = textView
+        controller.findString = "cat"
+
+        controller.refreshMatches(selecting: .first)
+
+        #expect(controller.matches.map(\.location) == [0, 4, 8, 12])
+        #expect(controller.matchCount == 4)
+        #expect(controller.activeMatchIndex == 0)
+        #expect(controller.activeMatchNumber == 1)
+        #expect(textView.selectedRange() == NSRange(location: 0, length: 3))
+        #expect(controller.nextMatchRange(startingAt: 1) == NSRange(location: 4, length: 3))
+        #expect(controller.previousMatchRange(upTo: 11) == NSRange(location: 8, length: 3))
+        #expect(controller.countMatches() == 4)
+    }
+
+    @Test func caseSensitiveSearchOnlyMatchesExactCase() {
+        let textView = makeTextView("Cat cat CAT catalog")
+        let controller = EditorFindController()
+        controller.textView = textView
+        controller.findString = "cat"
+        controller.isCaseSensitive = true
+
+        controller.refreshMatches(selecting: .first)
+
+        #expect(controller.matches.map(\.location) == [4, 12])
+        #expect(controller.matchCount == 2)
+        #expect(controller.activeMatchIndex == 0)
+        #expect(textView.selectedRange() == NSRange(location: 4, length: 3))
+        #expect(controller.nextMatchRange(startingAt: 0) == NSRange(location: 4, length: 3))
+        #expect(controller.previousMatchRange(upTo: 12) == NSRange(location: 4, length: 3))
+        #expect(controller.countMatches() == 2)
+    }
+
     @Test func findNextJumpsToMatch() {
         let textView = makeTextView("hello world hello")
         let controller = EditorFindController()
@@ -150,6 +186,55 @@ struct EditorFindControllerTests {
         #expect(range != nil)
         #expect(range?.location == 12)
         #expect(range?.length == 5)
+    }
+
+    @Test func selectNextWrapsToFirstMatch() {
+        let textView = makeTextView("one two one")
+        let controller = EditorFindController()
+        controller.textView = textView
+        controller.findString = "one"
+
+        controller.refreshMatches(selecting: .first)
+        #expect(controller.selectNext() == true)
+        #expect(controller.activeMatchIndex == 1)
+        #expect(textView.selectedRange() == NSRange(location: 8, length: 3))
+
+        #expect(controller.selectNext() == true)
+        #expect(controller.activeMatchIndex == 0)
+        #expect(controller.activeMatchNumber == 1)
+        #expect(textView.selectedRange() == NSRange(location: 0, length: 3))
+    }
+
+    @Test func selectPreviousWrapsToLastMatch() {
+        let textView = makeTextView("one two one")
+        let controller = EditorFindController()
+        controller.textView = textView
+        controller.findString = "one"
+
+        controller.refreshMatches(selecting: .first)
+
+        #expect(controller.selectPrevious() == true)
+        #expect(controller.activeMatchIndex == 1)
+        #expect(controller.activeMatchNumber == 2)
+        #expect(textView.selectedRange() == NSRange(location: 8, length: 3))
+    }
+
+    @Test func emptyQueryClearsMatches() {
+        let textView = makeTextView("one two one")
+        let controller = EditorFindController()
+        controller.textView = textView
+        controller.findString = "one"
+        controller.refreshMatches(selecting: .first)
+
+        controller.findString = ""
+        controller.refreshMatches(selecting: .first)
+
+        #expect(controller.matches.isEmpty)
+        #expect(controller.matchCount == 0)
+        #expect(controller.activeMatchIndex == nil)
+        #expect(controller.activeMatchNumber == nil)
+        #expect(controller.selectNext() == false)
+        #expect(controller.selectPrevious() == false)
     }
 
     @Test func replaceCurrentStartsFromCursor() {
@@ -178,6 +263,42 @@ struct EditorFindControllerTests {
 
         #expect(controller.replaceCurrent() == true)
         #expect(textView.string == "xx bb aa")
+    }
+
+    @Test func replaceCurrentUsesCaseInsensitiveSelectedMatchAndRecomputes() {
+        let textView = makeTextView("Cat cat CAT")
+        textView.setSelectedRange(NSRange(location: 0, length: 3))
+        let controller = EditorFindController()
+        controller.textView = textView
+        controller.findString = "cat"
+        controller.replacementString = "dog"
+        controller.refreshMatches(selecting: .first)
+
+        #expect(controller.replaceCurrent() == true)
+
+        #expect(textView.string == "dog cat CAT")
+        #expect(controller.matches.map(\.location) == [4, 8])
+        #expect(controller.matchCount == 2)
+        #expect(controller.activeMatchIndex == 0)
+        #expect(controller.activeMatchNumber == 1)
+        #expect(textView.selectedRange() == NSRange(location: 4, length: 3))
+    }
+
+    @Test func replaceAllIsCaseInsensitiveByDefault() {
+        let textView = makeTextView("Cat cat CAT")
+        let controller = EditorFindController()
+        controller.textView = textView
+        controller.findString = "cat"
+        controller.replacementString = "dog"
+        controller.refreshMatches(selecting: .first)
+
+        let count = controller.replaceAll()
+
+        #expect(count == 3)
+        #expect(textView.string == "dog dog dog")
+        #expect(controller.matches.isEmpty)
+        #expect(controller.matchCount == 0)
+        #expect(controller.activeMatchIndex == nil)
     }
 
     @Test func replaceCurrentNoOpOnReadOnly() {

--- a/AlasTests/EditorFindControllerTests.swift
+++ b/AlasTests/EditorFindControllerTests.swift
@@ -301,6 +301,24 @@ struct EditorFindControllerTests {
         #expect(controller.activeMatchIndex == nil)
     }
 
+    @Test func replaceAllCaseSensitiveOnlyReplacesExactCaseMatches() {
+        let textView = makeTextView("Cat cat CAT cat")
+        let controller = EditorFindController()
+        controller.textView = textView
+        controller.findString = "cat"
+        controller.replacementString = "dog"
+        controller.isCaseSensitive = true
+        controller.refreshMatches(selecting: .first)
+
+        let count = controller.replaceAll()
+
+        #expect(count == 2)
+        #expect(textView.string == "Cat dog CAT dog")
+        #expect(controller.matches.isEmpty)
+        #expect(controller.matchCount == 0)
+        #expect(controller.activeMatchIndex == nil)
+    }
+
     @Test func replaceCurrentNoOpOnReadOnly() {
         let textView = makeTextView("hello world")
         textView.isEditable = false

--- a/AlasTests/EditorFindRequestTests.swift
+++ b/AlasTests/EditorFindRequestTests.swift
@@ -1,0 +1,19 @@
+import Testing
+@testable import Alas
+
+struct EditorFindRequestTests {
+    @Test func requestsAreEquatable() {
+        #expect(EditorFindRequest.showFind == .showFind)
+        #expect(EditorFindRequest.showFind != .showReplace)
+        #expect(EditorFindRequest.findNext != .findPrevious)
+    }
+
+    @Test func requestsAreSendable() {
+        requireSendable(EditorFindRequest.showFind)
+        requireSendable(EditorFindRequest.showReplace)
+        requireSendable(EditorFindRequest.findNext)
+        requireSendable(EditorFindRequest.findPrevious)
+    }
+
+    private func requireSendable<T: Sendable>(_: T) {}
+}

--- a/AlasTests/ShortcutActionTests.swift
+++ b/AlasTests/ShortcutActionTests.swift
@@ -22,7 +22,8 @@ struct ShortcutActionTests {
         let expected: [(ShortcutAction, String, [ShortcutBinding.Modifier])] = [
             (.searchFiles,          "p",          [.command]),
             (.switchRepository,     "k",          [.command]),
-            (.findAndReplace,       "f",          [.command, .option]),
+            (.findAndReplace,       "f",          [.command]),
+            (.replaceInEditor,      "r",          [.command]),
             (.toggleSidebar,        "b",          [.command]),
             (.toggleRightPane,      "b",          [.command, .option]),
             (.createProject,        "n",          [.command, .shift]),
@@ -57,7 +58,7 @@ struct ShortcutActionTests {
 
     @Test func groupAssignmentsMatchSpec() {
         let global: Set<ShortcutAction> = [
-            .searchFiles, .switchRepository, .findAndReplace, .toggleSidebar, .toggleRightPane,
+            .searchFiles, .switchRepository, .findAndReplace, .replaceInEditor, .toggleSidebar, .toggleRightPane,
             .createProject, .newWorktree, .newTerminalTab, .launchAgentTerminal, .launchAgentChat,
             .focusMainWorktree, .increaseFontSize, .decreaseFontSize, .resetFontSize,
         ]
@@ -80,6 +81,17 @@ struct ShortcutActionTests {
             case .commit:     #expect(commit.contains(a), "\(a) miscategorized")
             }
         }
+    }
+
+    @Test func editorFindActionsAreGlobalAndNotReservedInTerminal() {
+        #expect(ShortcutAction.findAndReplace.rawValue == "findAndReplace")
+        #expect(ShortcutAction.findAndReplace.label == "Find")
+        #expect(ShortcutAction.findAndReplace.group == .global)
+        #expect(!ShortcutAction.findAndReplace.appliesInTerminal)
+
+        #expect(ShortcutAction.replaceInEditor.label == "Find and Replace")
+        #expect(ShortcutAction.replaceInEditor.group == .global)
+        #expect(!ShortcutAction.replaceInEditor.appliesInTerminal)
     }
 
     @Test func reservedBindingsContainsStandards() {

--- a/AlasTests/ShortcutResolverTests.swift
+++ b/AlasTests/ShortcutResolverTests.swift
@@ -72,6 +72,14 @@ struct ShortcutResolverTests {
         #expect(conflict == .launchAgentChat)
     }
 
+    @Test func conflictDetectsReplaceInEditorDefaultBinding() async {
+        let state = makeState()
+        let binding = ShortcutBinding(key: "r", modifiers: [.command])
+        let conflict = state.conflict(for: binding, excluding: .searchFiles)
+        #expect(conflict == .replaceInEditor)
+        #expect(!ShortcutAction.replaceInEditor.appliesInTerminal)
+    }
+
     @Test func conflictNilWhenNoneFound() async {
         let state = makeState()
         let weird = ShortcutBinding(key: "j", modifiers: [.command, .control, .shift])

--- a/docs/superpowers/specs/2026-06-08-editor-find-replace-design.md
+++ b/docs/superpowers/specs/2026-06-08-editor-find-replace-design.md
@@ -1,0 +1,139 @@
+# Editor Find and Replace Design
+
+## Context
+
+Alas already has a partial editor find/replace implementation in `EditorFindController`, `EditorFindBarView`, and `EditorTabView`. The current version opens a replace-oriented bar through the configurable `findAndReplace` action, defaults to `Cmd-Option-F`, searches case-sensitively, and does not yet provide standard find-only behavior, match counters, wrapping navigation, selected-text prefill, case controls, or all-match highlighting.
+
+This design evolves that existing editor-scoped implementation. It does not introduce project-wide search, regex, whole-word matching, or native `NSTextFinder` integration.
+
+## User Behavior
+
+`Cmd-F` opens a compact find UI in the active text editor pane, focuses the find field, and preloads the current editor selection when the selection is non-empty and single-line. Typing updates matches live. The default search is plain-text and case-insensitive.
+
+`Cmd-R` opens the same UI with replace controls visible. If a search term already exists, it focuses the replace field; otherwise it focuses the find field. The replace value may be empty, which deletes matches.
+
+Navigation wraps around the document. `Enter` and `Cmd-G` select the next match. `Shift-Enter` and `Cmd-Shift-G` select the previous match. Buttons in the find bar provide the same previous and next behavior. The UI shows the active match and total count as `3 of 12`; no matches shows `No matches`.
+
+Replace supports:
+
+- `Replace`: replace the active selected match, then move to the next match.
+- `All`: replace all non-overlapping matches in the document.
+- Read-only editors: no mutation, with the UI staying in find mode and reporting no replacement.
+
+`Esc` closes the bar, clears find highlights, and returns focus to the editor.
+
+## Matching Semantics
+
+Search is plain text only. Matching uses UTF-16 `NSRange` values so it remains compatible with `NSTextView`, existing selection APIs, and replacement operations.
+
+The default is case-insensitive matching. A visible `Aa` toggle switches to case-sensitive matching. Changing the query or case toggle recomputes the match list and updates the active match/count.
+
+Matches are non-overlapping. Empty queries produce no matches, no highlights, and disabled replacement actions.
+
+## Components
+
+`EditorFindController` remains a `@MainActor` controller scoped to one `CodeTextView`. It becomes the state and behavior owner for:
+
+- `findString`
+- `replacementString`
+- `isCaseSensitive`
+- current `matches: [NSRange]`
+- active match index
+- match count/status
+- next/previous selection with wrapping
+- replace current
+- replace all
+
+The active match remains the normal `CodeTextView` selection. That preserves native scrolling, cursor visibility, editing, undo, dirty tracking, and LSP `didChange` behavior.
+
+`EditorTabView` owns presentation state:
+
+- hidden
+- find visible
+- replace visible
+
+It listens for editor find requests only when its tab is active. It wires the controller to the `CodeTextView` through the existing `.codeEditorDidAttach` / `.codeEditorDidDetach` notifications. It also handles selection prefill, field focus, close behavior, and focus return to the editor.
+
+`EditorFindBarView` becomes a compact reusable SwiftUI bar. It renders:
+
+- find text field
+- optional replace text field/row
+- previous and next controls
+- `Aa` case-sensitive toggle
+- match count/status text
+- replace current and replace all buttons when replace mode is visible
+- close button
+
+The bar should keep stable dimensions for controls so changing count text or button states does not shift the editor layout.
+
+## Commands and Shortcuts
+
+The app commands post richer editor find notifications:
+
+- Find: `Cmd-F`
+- Find and Replace: `Cmd-R`
+- Find Next: `Cmd-G`
+- Find Previous: `Cmd-Shift-G`
+
+The existing `ShortcutAction.findAndReplace` raw action should be retained for settings compatibility, but relabeled and re-defaulted as the configurable Find action with `Cmd-F`. A new shortcut action owns Find and Replace with default `Cmd-R`.
+
+`Cmd-G` and `Cmd-Shift-G` are fixed standard editor commands rather than user-configurable shortcuts, matching common macOS editor behavior.
+
+Terminal focus must not reserve these editor shortcuts. The command buttons should remain disabled when there is no active code editor tab.
+
+## Highlighting
+
+Find highlighting is a small editor-scoped helper that applies temporary background attributes through the active text view/layout manager for all current matches. The active match is represented by the normal text selection; non-active matches receive the temporary highlight.
+
+Highlights clear when:
+
+- the query becomes empty
+- the bar closes
+- the tab detaches
+- the text view changes
+- the active editor changes
+
+The syntax highlighter and LSP coordinator remain responsible for their existing attributes. Find highlighting should not be folded into the Tree-sitter or LSP feature code.
+
+## Data Flow
+
+1. A command posts an editor find request with a mode or navigation direction.
+2. The active `EditorTabView` receives it and opens or updates the find bar.
+3. `EditorTabView` optionally prefills from the current single-line editor selection.
+4. User edits to the query or case toggle update `EditorFindController`.
+5. The controller recomputes matches and selects an appropriate active match.
+6. The highlight helper redraws non-active matches.
+7. Navigation changes the active match and scrolls it into view.
+8. Replacement uses `CodeTextView.insertText(_:replacementRange:)` so undo, dirty tracking, auto-pair suppression, and LSP edit propagation use existing editor paths.
+
+## Error Handling and Edge Cases
+
+No active text view: find commands do nothing.
+
+Empty query: no matches, no highlight, replacement buttons disabled.
+
+No matches: show `No matches`, leave document text unchanged.
+
+Read-only text view: replacement operations return no mutation and leave text unchanged.
+
+Replacement changes match ranges: recompute matches after each replacement operation.
+
+Selection prefill: only use selected text when the selected range is non-empty and does not include a line break. Multi-cursor selections do not prefill from multiple ranges.
+
+## Testing
+
+Tests should be added before implementation for controller behavior:
+
+- default case-insensitive matching
+- case-sensitive toggle
+- match index and count
+- next and previous wrapping
+- empty query behavior
+- selected-match replacement under case-insensitive matching
+- replace current recomputes and advances
+- replace all count and document mutation
+- read-only replacement no-op
+
+Shortcut tests should update the expected defaults for Find and Find and Replace, verify no duplicate defaults, and cover the new action grouping.
+
+UI behavior that is difficult to unit test should be covered by focused Swift tests around notification payload parsing and tab-level state helpers where practical.


### PR DESCRIPTION
## Summary
- Add editor-scoped find and replace with Cmd-F, Cmd-R, Cmd-G/Cmd-Shift-G navigation, match counts, case toggle, and replace current/all.
- Highlight non-active matches and clear highlights safely across text edits, detach, and close.
- Update shortcut defaults and migrate legacy Find and Replace shortcut overrides.

## Testing
- `rtk xcodegen`
- `rtk xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -quiet build`
- `rtk xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' test`