### PR TITLE
fix(acp): transcript tail sticking after content growth

### DIFF
--- a/Alas/Sources/ACP/UI/ACPMessageList.swift
+++ b/Alas/Sources/ACP/UI/ACPMessageList.swift
@@ -181,10 +181,13 @@ struct ACPMessageList: View {
                     onHeadFrame: { handleHeadFramePreference($0, proxy: proxy) },
                     onPaused: { setFollowsTranscriptTail(false) },
                     onAtBottom: { setFollowsTranscriptTail(true) },
-                    onGeometry: { prevMinY, newMinY, viewportH, contentH in
+                    onGeometry: { old, new in
                         handleScrollGeometry(
-                            previousMinY: prevMinY, newMinY: newMinY,
-                            viewportHeight: viewportH, contentHeight: contentH,
+                            previousMinY: old.minY,
+                            newMinY: new.minY,
+                            viewportHeight: new.viewportHeight,
+                            previousContentHeight: old.contentHeight,
+                            contentHeight: new.contentHeight,
                             proxy: proxy)
                     }
                 ))
@@ -342,6 +345,21 @@ struct ACPMessageList: View {
         sourceStatus == .pending && targetStatus == .pending
     }
 
+    nonisolated static func shouldRestoreTailAfterContentGrowth(
+        previousContentHeight: CGFloat,
+        newContentHeight: CGFloat,
+        viewportHeight: CGFloat,
+        newMinY: CGFloat,
+        followsTranscriptTail: Bool
+    ) -> Bool {
+        guard followsTranscriptTail else { return false }
+        guard newContentHeight > previousContentHeight + ACPScrollDirectionClassifier.upwardEpsilon else {
+            return false
+        }
+        let distanceFromBottom = max(0, newContentHeight - viewportHeight - newMinY)
+        return distanceFromBottom > ACPScrollDirectionClassifier.bottomTolerance
+    }
+
     /// macOS 14 fallback path. The Tahoe (macOS 15+) ScrollView is no longer
     /// backed by an `NSScrollView`, and `frame(in:.named:)` reported through a
     /// `PreferenceKey` stops delivering live values during scroll, so this
@@ -376,6 +394,7 @@ struct ACPMessageList: View {
         previousMinY: CGFloat,
         newMinY: CGFloat,
         viewportHeight: CGFloat,
+        previousContentHeight: CGFloat,
         contentHeight: CGFloat,
         proxy: ScrollViewProxy
     ) {
@@ -393,6 +412,16 @@ struct ACPMessageList: View {
         case .userScrolledUp: setFollowsTranscriptTail(false)
         case .userAtBottom: setFollowsTranscriptTail(true)
         case .noChange: break
+        }
+        if Self.shouldRestoreTailAfterContentGrowth(
+            previousContentHeight: previousContentHeight,
+            newContentHeight: contentHeight,
+            viewportHeight: viewportHeight,
+            newMinY: newMinY,
+            followsTranscriptTail: session.followsTranscriptTail
+        ) {
+            scrollToTail(proxy: proxy, animated: false)
+            return
         }
         // Head-step pagination: reveal an older chunk as the viewport nears the
         // top of the content. When restored to the tail, `newMinY` is large, so
@@ -497,8 +526,7 @@ private struct ACPTranscriptScrollTracking: ViewModifier {
     let onHeadFrame: (CGRect) -> Void
     let onPaused: () -> Void
     let onAtBottom: () -> Void
-    /// `(previousMinY, newMinY, viewportHeight, contentHeight)`.
-    let onGeometry: (CGFloat, CGFloat, CGFloat, CGFloat) -> Void
+    let onGeometry: (ACPScrollProbe, ACPScrollProbe) -> Void
 
     @ViewBuilder
     func body(content: Content) -> some View {
@@ -509,7 +537,7 @@ private struct ACPTranscriptScrollTracking: ViewModifier {
                     viewportHeight: geo.visibleRect.height,
                     contentHeight: geo.contentSize.height)
             } action: { old, new in
-                onGeometry(old.minY, new.minY, new.viewportHeight, new.contentHeight)
+                onGeometry(old, new)
             }
         } else {
             content

--- a/AlasTests/ACP/UI/ACPMessageListPaginationTests.swift
+++ b/AlasTests/ACP/UI/ACPMessageListPaginationTests.swift
@@ -1,4 +1,5 @@
 import Testing
+import CoreGraphics
 @testable import Alas
 
 @Suite("ACPMessageList pagination")
@@ -51,5 +52,47 @@ struct ACPMessageListPaginationTests {
         #expect(ACPMessageList.queueHeaderCount(statuses: [.pending]) == 1)
         #expect(ACPMessageList.queueHeaderCount(statuses: [.sending]) == 1)
         #expect(ACPMessageList.queueHeaderCount(statuses: [.sending, .pending]) == 2)
+    }
+
+    @Test("content growth restores the tail when tail-follow is still enabled")
+    func contentGrowthRestoresTailWhenFollowing() {
+        let viewportHeight: CGFloat = 600
+        let previousContentHeight: CGFloat = 5_000
+        let newContentHeight: CGFloat = 5_220
+        let oldTailOffset = previousContentHeight - viewportHeight
+
+        #expect(ACPMessageList.shouldRestoreTailAfterContentGrowth(
+            previousContentHeight: previousContentHeight,
+            newContentHeight: newContentHeight,
+            viewportHeight: viewportHeight,
+            newMinY: oldTailOffset,
+            followsTranscriptTail: true
+        ))
+    }
+
+    @Test("content growth does not restore the tail after the user paused tail-follow")
+    func contentGrowthDoesNotRestoreWhenTailFollowPaused() {
+        #expect(!ACPMessageList.shouldRestoreTailAfterContentGrowth(
+            previousContentHeight: 5_000,
+            newContentHeight: 5_220,
+            viewportHeight: 600,
+            newMinY: 4_400,
+            followsTranscriptTail: false
+        ))
+    }
+
+    @Test("content growth does not issue an extra restore when already at the new tail")
+    func contentGrowthDoesNotRestoreWhenAlreadyAtTail() {
+        let viewportHeight: CGFloat = 600
+        let newContentHeight: CGFloat = 5_220
+        let newTailOffset = newContentHeight - viewportHeight
+
+        #expect(!ACPMessageList.shouldRestoreTailAfterContentGrowth(
+            previousContentHeight: 5_000,
+            newContentHeight: newContentHeight,
+            viewportHeight: viewportHeight,
+            newMinY: newTailOffset,
+            followsTranscriptTail: true
+        ))
     }
 }


### PR DESCRIPTION
## Summary
- Keep ACP transcript tail-following sticky when content height grows after a scroll restore
- Preserve intentional user scroll-up pauses before issuing a follow-up tail restore
- Add regression coverage for content-growth tail restore behavior

## Verification
- `rtk xcodegen`
- `rtk xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -quiet build`
- `rtk xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -only-testing:AlasTests/ACPScrollDirectionClassifierTests -only-testing:AlasTests/ACPUserScrollEventTests -only-testing:AlasTests/ACPMessageListPaginationTests test`
- `rtk proxy zsh -lc 'log=/tmp/alas-full-xcodebuild-test.log; rm -f "$log"; xcodebuild -project Alas.xcodeproj -scheme Alas -destination "platform=macOS" -quiet test > "$log" 2>&1 & pid=$!; while kill -0 $pid 2>/dev/null; do echo "xcodebuild test still running"; sleep 20; done; wait $pid; rc=$?; tail -n 120 "$log"; exit $rc'`