### PR TITLE
Fix ACP intro layout overlap

### DIFF
--- a/Alas/Sources/ACP/UI/ACPComposerShell.swift
+++ b/Alas/Sources/ACP/UI/ACPComposerShell.swift
@@ -2,46 +2,13 @@ import SwiftUI
 
 enum ACPComposerPlacement: Equatable {
     case bottom
-    case raisedEmpty
+    case inFlow
 
     static func bottomInset(for placement: ACPComposerPlacement, containerHeight: CGFloat) -> CGFloat {
         switch placement {
-        case .bottom:
+        case .bottom, .inFlow:
             return 18
-        case .raisedEmpty:
-            let target = containerHeight * 0.34
-            let roomAwareMaximum = max(96, containerHeight - 260)
-            return min(max(target, 96), min(320, roomAwareMaximum))
         }
-    }
-
-    /// Bottom padding for the centred hero content shown in the empty and
-    /// first-run-connecting states, so it always clears the floating
-    /// composer.
-    ///
-    /// The composer floats at `bottomInset(.raisedEmpty)` and is roughly
-    /// `pillHeight` tall, so its top edge sits `inset + pillHeight` above the
-    /// pane's bottom. The hero content is centre-aligned, so with bottom
-    /// padding `p` its lower edge lands at `(H + p) / 2 - contentHeight / 2`.
-    /// Solving for a constant `gap` above the composer gives
-    /// `p = 2*gap + 2*pillHeight + contentHeight + 2*inset - H`. That lands on
-    /// the historical 210pt on a ~900pt pane (so large panes are unchanged)
-    /// and grows as the pane shrinks — the previous fixed 210 let the composer
-    /// overlap the starter chips on short panes.
-    ///
-    /// On very short panes the result is capped so the content's top edge
-    /// stays on-screen (trading the gap for visibility rather than clipping
-    /// the artwork under the toolbar).
-    static func raisedHeroBottomPadding(containerHeight: CGFloat) -> CGFloat {
-        let inset = bottomInset(for: .raisedEmpty, containerHeight: containerHeight)
-        let pillHeight: CGFloat = 98     // empty composer pill (input floor + controls)
-        let contentHeight: CGFloat = 150 // mark + title/subtitle + starter chips
-        let gap: CGFloat = 76            // breathing room above the composer
-        let topMargin: CGFloat = 16
-
-        let desired = 2 * gap + 2 * pillHeight + contentHeight + 2 * inset - containerHeight
-        let fitCap = containerHeight - contentHeight - 2 * topMargin
-        return max(0, min(desired, fitCap))
     }
 }
 
@@ -93,13 +60,24 @@ struct ACPComposer: View {
     }
 
     var body: some View {
-        GeometryReader { proxy in
-            composerLayout(
-                bottomInset: ACPComposerPlacement.bottomInset(
-                    for: placement,
-                    containerHeight: proxy.size.height
+        switch placement {
+        case .inFlow:
+            composerRow
+                .padding(.top, 28)
+                .padding(
+                    .bottom,
+                    ACPComposerPlacement.bottomInset(for: .inFlow, containerHeight: 0)
                 )
-            )
+                .frame(maxWidth: .infinity)
+        case .bottom:
+            GeometryReader { proxy in
+                composerLayout(
+                    bottomInset: ACPComposerPlacement.bottomInset(
+                        for: placement,
+                        containerHeight: proxy.size.height
+                    )
+                )
+            }
         }
     }
 

--- a/Alas/Sources/ACP/UI/ACPFirstRunConnectingPolicy.swift
+++ b/Alas/Sources/ACP/UI/ACPFirstRunConnectingPolicy.swift
@@ -52,6 +52,6 @@ enum ACPFirstRunConnectingPolicy {
         firstRunConnecting: Bool,
         newEmptySession: Bool
     ) -> ACPComposerPlacement {
-        (firstRunConnecting || newEmptySession) ? .raisedEmpty : .bottom
+        (firstRunConnecting || newEmptySession) ? .inFlow : .bottom
     }
 }

--- a/Alas/Sources/ACP/UI/ACPFirstRunConnectingView.swift
+++ b/Alas/Sources/ACP/UI/ACPFirstRunConnectingView.swift
@@ -11,9 +11,8 @@ enum ACPFirstRunConnectingViewCopy {
 struct ACPFirstRunConnectingView: View {
     let agentDisplayName: String
     let phase: ACPFirstRunConnectingPhase
-    /// Bottom padding that lifts the centred content clear of the floating
-    /// composer. Responsive to pane height so the composer never overlaps the
-    /// phase chips on short panes (see `raisedHeroBottomPadding`).
+    /// Extra bottom padding when this view is hosted without an in-flow
+    /// composer.
     let bottomInset: CGFloat
 
     @Environment(\.theme) private var theme

--- a/Alas/Sources/ACP/UI/ACPNewChatEmptyStateView.swift
+++ b/Alas/Sources/ACP/UI/ACPNewChatEmptyStateView.swift
@@ -2,9 +2,8 @@ import SwiftUI
 
 struct ACPNewChatEmptyStateView: View {
     let agentDisplayName: String
-    /// Bottom padding that lifts the centred content clear of the floating
-    /// composer. Responsive to pane height so the composer never overlaps the
-    /// starter chips on short panes (see `raisedHeroBottomPadding`).
+    /// Extra bottom padding when this view is hosted without an in-flow
+    /// composer.
     let bottomInset: CGFloat
     let onStarterPrompt: (ACPStarterPrompt) -> Void
 

--- a/Alas/Sources/ACP/UI/ACPTabView.swift
+++ b/Alas/Sources/ACP/UI/ACPTabView.swift
@@ -198,30 +198,31 @@ private struct ACPSessionView: View {
 
     private var transcriptAndComposer: some View {
         GeometryReader { proxy in
-            let heroBottomInset = ACPComposerPlacement.raisedHeroBottomPadding(
-                containerHeight: proxy.size.height
-            )
             HStack(spacing: 0) {
                 ZStack(alignment: .bottom) {
                     if let phase = firstRunConnectingPhase {
-                        ACPFirstRunConnectingView(
-                            agentDisplayName: state.agent(id: session.agentId)?.displayName ?? session.agentId,
-                            phase: phase,
-                            bottomInset: heroBottomInset
-                        )
-                    } else if isConnecting {
-                        ACPConnectingPlaceholder(
-                            agentDisplayName: state.agent(id: session.agentId)?.displayName ?? session.agentId
-                        )
-                    } else {
-                        if isNewEmptySession {
+                        introStateAndComposer {
+                            ACPFirstRunConnectingView(
+                                agentDisplayName: state.agent(id: session.agentId)?.displayName ?? session.agentId,
+                                phase: phase,
+                                bottomInset: 0
+                            )
+                        }
+                    } else if isNewEmptySession {
+                        introStateAndComposer {
                             ACPNewChatEmptyStateView(
                                 agentDisplayName: state.agent(id: session.agentId)?.displayName ?? session.agentId,
-                                bottomInset: heroBottomInset,
+                                bottomInset: 0,
                                 onStarterPrompt: insertStarterPrompt
                             )
                             .transition(
                                 .opacity.combined(with: .move(edge: .top))
+                            )
+                        }
+                    } else {
+                        if isConnecting {
+                            ACPConnectingPlaceholder(
+                                agentDisplayName: state.agent(id: session.agentId)?.displayName ?? session.agentId
                             )
                         } else {
                             ACPMessageList(
@@ -300,105 +301,23 @@ private struct ACPSessionView: View {
                             )
                             .transition(.opacity)
                         }
-                    }
 
-                    ACPComposer(
-                        session: session,
-                        manager: manager,
-                        worktreeRoot: worktree.path,
-                        agentLookup: { state.agent(id: $0) },
-                        sendOnEnter: state.config.harness.acpSendOnEnter,
-                        focusRequest: composerFocusRequest,
-                        placement: composerPlacement,
-                        filesProvider: { [state, worktree] in
-                            await state.fileIndex.invalidate(forWorktreePath: worktree.path)
-                            async let entries = try? state.fileIndex.entries(forWorktreePath: worktree.path)
-                            guard let entries = await entries else { return [] }
-                            let root = worktree.path
-                            var result: [URL] = []
-                            var dirEntries: [(path: String, isDirectory: Bool)] = []
-                            for entry in entries {
-                                let url = root.appendingPathComponent(entry.relativePath)
-                                guard (try? url.checkResourceIsReachable()) ?? false else { continue }
-                                let isDir = (try? url.resourceValues(forKeys: [.isDirectoryKey]).isDirectory) ?? false
-                                if isDir {
-                                    // Untracked directory or submodule gitlink; expand
-                                    // it so its files and subdirectories show too.
-                                    let sub = MentionFuzzy.collectFiles(under: url, limit: 5000)
-                                    result.append(contentsOf: sub)
-                                } else {
-                                    result.append(url)
-                                }
-                                dirEntries.append((entry.relativePath, isDir))
-                            }
-                            // `git ls-files` lists files only — reconstruct every
-                            // directory (tracked dirs and submodules included) so
-                            // they are pickable in the @ menu, flagged for the
-                            // folder icon.
-                            result += MentionFuzzy.pickerDirectories(forEntries: dirEntries, root: root)
-                            return result
-                        }
-                    ) { text, attachments, intent, draft, onPromptFinished -> Bool in
-                        // `intent` is already resolved by the composer for keyboard
-                        // submits; the toolbar send button bypasses the keyboard
-                        // inversion and supplies its own intent directly. No
-                        // further resolution here.
-                        //
-                        // The eager in-memory clear happens AFTER `manager.submit`
-                        // returns but BEFORE the completion closure can run (the
-                        // submit's completion is always dispatched via a Task,
-                        // so it runs on a later main-actor tick). The
-                        // suspendedRevision captured below identifies the post-
-                        // clear state — if the user has typed a new draft by the
-                        // time the completion fires, the conditional checks in
-                        // purge/reinstate skip and the new draft survives.
-                        var suspendedRevision: Int = -1
-                        let accepted = manager.submit(
-                            sessionId: sessionId,
-                            text: text,
-                            attachments: attachments,
-                            intent: intent,
-                            draft: draft
-                        ) { succeeded in
-                            if suspendedRevision >= 0 {
-                                if succeeded {
-                                    manager.purgeSuspendedComposerDraft(
-                                        for: session,
-                                        suspendedRevision: suspendedRevision
-                                    )
-                                } else {
-                                    manager.reinstateSuspendedComposerDraft(
-                                        draft,
-                                        for: session,
-                                        suspendedRevision: suspendedRevision
-                                    )
-                                }
-                            }
-                            onPromptFinished(succeeded)
-                        }
-                        if accepted {
-                            suspendedRevision = manager.suspendComposerDraftForSubmission(
-                                draft, for: session
-                            )
-                        }
-                        return accepted
-                    }
-                    .disabled(isMirror)
-                    .opacity(isMirror ? 0.5 : 1)
+                        composerView(placement: composerPlacement)
 
-                    if let undo = session.steerUndo, !undo.snapshot.isEmpty {
-                        VStack {
-                            Spacer()
-                            ACPSteerUndoToast(
-                                discardedCount: undo.snapshot.count,
-                                onUndo: { manager.runners[sessionId]?.steerUndo() },
-                                onDismiss: { session.steerUndo = nil }
-                            )
-                            .id(undo.id)
-                            .padding(.bottom, 200)
+                        if let undo = session.steerUndo, !undo.snapshot.isEmpty {
+                            VStack {
+                                Spacer()
+                                ACPSteerUndoToast(
+                                    discardedCount: undo.snapshot.count,
+                                    onUndo: { manager.runners[sessionId]?.steerUndo() },
+                                    onDismiss: { session.steerUndo = nil }
+                                )
+                                .id(undo.id)
+                                .padding(.bottom, 200)
+                            }
+                            .frame(maxWidth: .infinity)
+                            .transition(.opacity)
                         }
-                        .frame(maxWidth: .infinity)
-                        .transition(.opacity)
                     }
                 }
                 .animation(emptyStateAnimation, value: isNewEmptySession)
@@ -429,6 +348,103 @@ private struct ACPSessionView: View {
                 updatePlanSidebar(paneWidth: proxy.size.width)
             }
         }
+    }
+
+    private func introStateAndComposer<Intro: View>(
+        @ViewBuilder intro: () -> Intro
+    ) -> some View {
+        VStack(spacing: 0) {
+            intro()
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
+            composerView(placement: .inFlow)
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+    }
+
+    private func composerView(placement: ACPComposerPlacement) -> some View {
+        ACPComposer(
+            session: session,
+            manager: manager,
+            worktreeRoot: worktree.path,
+            agentLookup: { state.agent(id: $0) },
+            sendOnEnter: state.config.harness.acpSendOnEnter,
+            focusRequest: composerFocusRequest,
+            placement: placement,
+            filesProvider: { [state, worktree] in
+                await state.fileIndex.invalidate(forWorktreePath: worktree.path)
+                async let entries = try? state.fileIndex.entries(forWorktreePath: worktree.path)
+                guard let entries = await entries else { return [] }
+                let root = worktree.path
+                var result: [URL] = []
+                var dirEntries: [(path: String, isDirectory: Bool)] = []
+                for entry in entries {
+                    let url = root.appendingPathComponent(entry.relativePath)
+                    guard (try? url.checkResourceIsReachable()) ?? false else { continue }
+                    let isDir = (try? url.resourceValues(forKeys: [.isDirectoryKey]).isDirectory) ?? false
+                    if isDir {
+                        // Untracked directory or submodule gitlink; expand
+                        // it so its files and subdirectories show too.
+                        let sub = MentionFuzzy.collectFiles(under: url, limit: 5000)
+                        result.append(contentsOf: sub)
+                    } else {
+                        result.append(url)
+                    }
+                    dirEntries.append((entry.relativePath, isDir))
+                }
+                // `git ls-files` lists files only - reconstruct every
+                // directory (tracked dirs and submodules included) so
+                // they are pickable in the @ menu, flagged for the
+                // folder icon.
+                result += MentionFuzzy.pickerDirectories(forEntries: dirEntries, root: root)
+                return result
+            }
+        ) { text, attachments, intent, draft, onPromptFinished -> Bool in
+            // `intent` is already resolved by the composer for keyboard
+            // submits; the toolbar send button bypasses the keyboard
+            // inversion and supplies its own intent directly. No
+            // further resolution here.
+            //
+            // The eager in-memory clear happens AFTER `manager.submit`
+            // returns but BEFORE the completion closure can run (the
+            // submit's completion is always dispatched via a Task,
+            // so it runs on a later main-actor tick). The
+            // suspendedRevision captured below identifies the post-
+            // clear state - if the user has typed a new draft by the
+            // time the completion fires, the conditional checks in
+            // purge/reinstate skip and the new draft survives.
+            var suspendedRevision: Int = -1
+            let accepted = manager.submit(
+                sessionId: sessionId,
+                text: text,
+                attachments: attachments,
+                intent: intent,
+                draft: draft
+            ) { succeeded in
+                if suspendedRevision >= 0 {
+                    if succeeded {
+                        manager.purgeSuspendedComposerDraft(
+                            for: session,
+                            suspendedRevision: suspendedRevision
+                        )
+                    } else {
+                        manager.reinstateSuspendedComposerDraft(
+                            draft,
+                            for: session,
+                            suspendedRevision: suspendedRevision
+                        )
+                    }
+                }
+                onPromptFinished(succeeded)
+            }
+            if accepted {
+                suspendedRevision = manager.suspendComposerDraftForSubmission(
+                    draft, for: session
+                )
+            }
+            return accepted
+        }
+        .disabled(isMirror)
+        .opacity(isMirror ? 0.5 : 1)
     }
 
     @ViewBuilder

--- a/AlasTests/ACP/UI/ACPFirstRunConnectingPolicyTests.swift
+++ b/AlasTests/ACP/UI/ACPFirstRunConnectingPolicyTests.swift
@@ -130,16 +130,16 @@ struct ACPFirstRunConnectingPolicyTests {
         #expect(ACPFirstRunConnectingPolicy.phase(for: session) == nil)
     }
 
-    @Test("composer placement is raised during first-run connecting or new empty state")
-    func composerPlacementPolicyRaisesFirstRunConnecting() {
+    @Test("composer placement is in flow during first-run connecting or new empty state")
+    func composerPlacementPolicyKeepsIntroStatesInFlow() {
         #expect(ACPFirstRunConnectingPolicy.composerPlacement(
             firstRunConnecting: true,
             newEmptySession: false
-        ) == .raisedEmpty)
+        ) == .inFlow)
         #expect(ACPFirstRunConnectingPolicy.composerPlacement(
             firstRunConnecting: false,
             newEmptySession: true
-        ) == .raisedEmpty)
+        ) == .inFlow)
         #expect(ACPFirstRunConnectingPolicy.composerPlacement(
             firstRunConnecting: false,
             newEmptySession: false

--- a/AlasTests/ACP/UI/ACPNewChatEmptyStateTests.swift
+++ b/AlasTests/ACP/UI/ACPNewChatEmptyStateTests.swift
@@ -1,4 +1,3 @@
-import CoreGraphics
 import Foundation
 import Testing
 @testable import Alas
@@ -162,53 +161,24 @@ struct ACPNewChatEmptyStateTests {
         ])
     }
 
-    @Test("raised composer placement scales with available height")
-    func raisedComposerPlacementScalesWithAvailableHeight() {
+    @Test("composer bottom spacing is stable")
+    func composerBottomSpacingIsStable() {
         let bottom = ACPComposerPlacement.bottomInset(for: .bottom, containerHeight: 800)
-        let shortRaised = ACPComposerPlacement.bottomInset(for: .raisedEmpty, containerHeight: 360)
-        let regularRaised = ACPComposerPlacement.bottomInset(for: .raisedEmpty, containerHeight: 720)
-        let tallRaised = ACPComposerPlacement.bottomInset(for: .raisedEmpty, containerHeight: 1_200)
+        let inFlow = ACPComposerPlacement.bottomInset(for: .inFlow, containerHeight: 800)
 
         #expect(bottom == 18)
-        #expect(shortRaised > bottom)
-        #expect(regularRaised > shortRaised)
-        #expect(tallRaised == 320)
+        #expect(inFlow == 18)
     }
 
-    @Test("raised hero padding keeps centred content clear of the composer on small panes")
-    func raisedHeroPaddingClearsComposerOnSmallPanes() {
-        // Mirrors the geometry the production layout uses: the hero content is
-        // centre-aligned and the composer floats at `raisedEmpty`. These two
-        // constants track the documented model in `raisedHeroBottomPadding`;
-        // if they drift, this guards the no-overlap contract that was the
-        // whole point of making the padding responsive.
-        let pillHeight: CGFloat = 98
-        let contentHeight: CGFloat = 150
-
-        for h in stride(from: CGFloat(400), through: CGFloat(1_200), by: 20) {
-            let inset = ACPComposerPlacement.bottomInset(for: .raisedEmpty, containerHeight: h)
-            let pad = ACPComposerPlacement.raisedHeroBottomPadding(containerHeight: h)
-
-            let composerTop = inset + pillHeight
-            let contentBottom = (h + pad) / 2 - contentHeight / 2
-            let contentTop = (h + pad) / 2 + contentHeight / 2
-
-            // Never overlaps the floating composer …
-            #expect(contentBottom >= composerTop)
-            // … and never clips above the top of the pane.
-            #expect(contentTop <= h)
-        }
-    }
-
-    @Test("raised hero padding preserves the historical placement on large panes")
-    func raisedHeroPaddingMatchesLegacyOnLargePanes() {
-        // The previous layout hardcoded 210pt; the responsive value must land
-        // on it for a roomy pane so large windows look unchanged, then grow as
-        // the pane shrinks.
-        #expect(ACPComposerPlacement.raisedHeroBottomPadding(containerHeight: 900) == 210)
-        #expect(
-            ACPComposerPlacement.raisedHeroBottomPadding(containerHeight: 600)
-                > ACPComposerPlacement.raisedHeroBottomPadding(containerHeight: 900)
-        )
+    @Test("initial empty states keep composer in normal vertical flow")
+    func initialEmptyStatesKeepComposerInNormalVerticalFlow() {
+        #expect(ACPFirstRunConnectingPolicy.composerPlacement(
+            firstRunConnecting: true,
+            newEmptySession: false
+        ) == .inFlow)
+        #expect(ACPFirstRunConnectingPolicy.composerPlacement(
+            firstRunConnecting: false,
+            newEmptySession: true
+        ) == .inFlow)
     }
 }


### PR DESCRIPTION
## Summary

- Render ACP first-run and new-empty intro states as a normal vertical layout with the composer in flow beneath the intro content.
- Remove the old raised floating composer placement and stale responsive padding model.
- Update ACP layout policy tests to assert intro states use in-flow composer placement.

## Why

The previous intro layout used a bottom-aligned overlay for both the hero content and composer. On smaller panes, the starter/phase chips could still occupy the same vertical space as the composer despite padding calculations. Moving these intro states into a column prevents overlap by construction.

## Validation

- `xcodegen`
- `xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -quiet build`
- `xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS,arch=arm64' -only-testing:AlasTests/ACPNewChatEmptyStateTests -only-testing:AlasTests/ACPFirstRunConnectingPolicyTests -quiet test`

Full local `xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' test` was attempted multiple times but hung with orphaned `Alas.app` test-host processes in this worktree.