### PR TITLE
Fix queued prompt send state

### DIFF
--- a/Alas/Sources/ACP/Session/ACPSessionRunner.swift
+++ b/Alas/Sources/ACP/Session/ACPSessionRunner.swift
@@ -817,6 +817,37 @@ extension ACPSessionRunner {
         sendNow(blocks: head.blocks, queuedItemId: head.id)
     }
 
+    /// User clicked the row-local "send now" affordance for a queued item.
+    /// While idle this just promotes the item to the drainable head. While a
+    /// turn is active, it behaves like steering: cancel the current turn,
+    /// discard the remaining queue, and send the selected queued prompt.
+    func forceSendQueuedItem(id: UUID) {
+        guard holdsLeaseForWrite() else { return }
+        guard let idx = session.queue.firstIndex(where: { $0.id == id }),
+              session.queue[idx].status == .pending
+        else { return }
+
+        if session.transcript.streamingState == .idle,
+           activePromptID == nil,
+           !steerInProgress {
+            guard session.forceQueueItem(id: id) else { return }
+            persistQueue()
+            flushQueueIfIdle()
+            return
+        }
+
+        guard session.agentState == .ready else {
+            guard session.forceQueueItem(id: id) else { return }
+            persistQueue()
+            flushQueueIfIdle()
+            return
+        }
+
+        let item = session.queue.remove(at: idx)
+        persistQueue()
+        steer(blocks: item.blocks)
+    }
+
     /// Cancel the in-flight turn (if any), discard the ENTIRE queue
     /// (including any `.sending` head whose `sendNow` task is mid-RPC),
     /// then send the new prompt as a fresh turn. Only the `.pending`

--- a/Alas/Sources/ACP/Session/ACPSessionRunner.swift
+++ b/Alas/Sources/ACP/Session/ACPSessionRunner.swift
@@ -845,7 +845,7 @@ extension ACPSessionRunner {
 
         let item = session.queue.remove(at: idx)
         persistQueue()
-        steer(blocks: item.blocks)
+        steer(blocks: item.blocks, recordUserPrompt: !item.transcriptRecorded)
     }
 
     /// Cancel the in-flight turn (if any), discard the ENTIRE queue
@@ -859,6 +859,7 @@ extension ACPSessionRunner {
     /// resolves to a no-op.
     func steer(
         blocks: [ACPContentBlock],
+        recordUserPrompt: Bool = true,
         onPromptFinished: (@MainActor (_ succeeded: Bool) -> Void)? = nil
     ) {
         let snapshot = session.queue.filter { $0.status == .pending }
@@ -903,7 +904,12 @@ extension ACPSessionRunner {
                     onPromptFinished?(false)
                     return
                 }
-                self.sendNow(blocks: blocks, queuedItemId: nil, onPromptFinished: onPromptFinished)
+                self.sendNow(
+                    blocks: blocks,
+                    queuedItemId: nil,
+                    recordUserPrompt: recordUserPrompt,
+                    onPromptFinished: onPromptFinished
+                )
             }
         }
     }
@@ -944,6 +950,7 @@ extension ACPSessionRunner {
     func sendNow(
         blocks: [ACPContentBlock],
         queuedItemId: UUID?,
+        recordUserPrompt: Bool = true,
         onPromptFinished: (@MainActor (_ succeeded: Bool) -> Void)? = nil
     ) {
         let promptID = nextPromptID
@@ -979,6 +986,7 @@ extension ACPSessionRunner {
                 // before-question. Skip for a queued retry whose prompt
                 // is already in the transcript from the previous attempt.
                 let shouldRecord: Bool = {
+                    guard recordUserPrompt else { return false }
                     if let qid = queuedItemId,
                        let idx = self.session.queue.firstIndex(where: { $0.id == qid }),
                        self.session.queue[idx].transcriptRecorded {

--- a/Alas/Sources/ACP/UI/ACPComposerShell.swift
+++ b/Alas/Sources/ACP/UI/ACPComposerShell.swift
@@ -199,7 +199,7 @@ struct ACPComposer: View {
                     action: currentAction,
                     onPrimary: handlePrimary,
                     onMenu: handleMenu,
-                    queueBadgeCount: session.queue.count
+                    queueBadgeCount: session.visibleQueueCount
                 )
             }
             .padding(.horizontal, 2)

--- a/Alas/Sources/ACP/UI/ACPMessageList.swift
+++ b/Alas/Sources/ACP/UI/ACPMessageList.swift
@@ -324,8 +324,10 @@ struct ACPMessageList: View {
 
     nonisolated static func shouldRenderQueueBubble(status: QueuedPrompt.Status) -> Bool {
         switch status {
-        case .pending, .sending:
+        case .pending:
             return true
+        case .sending:
+            return false
         }
     }
 

--- a/Alas/Sources/ACP/UI/ACPTabView.swift
+++ b/Alas/Sources/ACP/UI/ACPTabView.swift
@@ -256,9 +256,7 @@ private struct ACPSessionView: View {
                                     manager.runners[sessionId]?.flushQueueIfIdle()
                                 },
                                 onQueueForceSend: isMirror ? { _ in } : { id in
-                                    guard session.forceQueueItem(id: id) else { return }
-                                    manager.persistQueue(for: session)
-                                    manager.runners[sessionId]?.flushQueueIfIdle()
+                                    manager.runners[sessionId]?.forceSendQueuedItem(id: id)
                                 },
                                 onQueueRemove: isMirror ? { _ in } : { id in
                                     session.removeFromQueue(id: id)

--- a/AlasTests/ACP/Session/ACPSessionRunnerQueueTests.swift
+++ b/AlasTests/ACP/Session/ACPSessionRunnerQueueTests.swift
@@ -360,6 +360,32 @@ struct ACPSessionRunnerQueueTests {
         #expect(try store.loadQueue(sessionId: "s").isEmpty)
     }
 
+    @Test("forceSendQueuedItem while busy does not double-record a failed queued retry")
+    func forceSendQueuedItemWhileBusyPreservesRecordedRetry() async throws {
+        let (runner, mock, session, _) = try mkRunner()
+        mock.script(method: "session/prompt") { _ in Data("null".utf8) }
+        session.agentState = .ready
+        session.transcript.streamingState = .streaming
+        session.recordUserPrompt(text: "selected", attachments: [])
+        session.enqueue(blocks: [.text("first")])
+        session.enqueue(blocks: [.text("selected")])
+        session.queue[1].lastError = "network"
+        session.queue[1].transcriptRecorded = true
+        let selectedId = session.queue[1].id
+        runner.persistQueue()
+
+        runner.forceSendQueuedItem(id: selectedId)
+        try await Task.sleep(nanoseconds: 250_000_000)
+
+        let prompts = mock.sent.filter { $0.method == "session/prompt" }
+        #expect(prompts.count == 1)
+        var userTexts: [String] = []
+        for msg in session.transcript.messages {
+            if case .user(_, let text, _) = msg { userTexts.append(text) }
+        }
+        #expect(userTexts == ["selected"])
+    }
+
     @Test("userCancel() drains queue after canceling the running turn")
     func cancelThenFlushDrainsQueue() async throws {
         let (runner, mock, session, _) = try mkRunner()

--- a/AlasTests/ACP/Session/ACPSessionRunnerQueueTests.swift
+++ b/AlasTests/ACP/Session/ACPSessionRunnerQueueTests.swift
@@ -332,6 +332,34 @@ struct ACPSessionRunnerQueueTests {
         #expect(try store.loadQueue(sessionId: "s").isEmpty)
     }
 
+    @Test("forceSendQueuedItem while busy steers with the selected queued item")
+    func forceSendQueuedItemWhileBusySteersSelectedItem() async throws {
+        let (runner, mock, session, store) = try mkRunner()
+        mock.script(method: "session/prompt") { _ in Data("null".utf8) }
+        session.agentState = .ready
+        session.transcript.streamingState = .streaming
+        session.enqueue(blocks: [.text("first")])
+        session.enqueue(blocks: [.text("selected")])
+        session.enqueue(blocks: [.text("third")])
+        let selectedId = session.queue[1].id
+        runner.persistQueue()
+
+        runner.forceSendQueuedItem(id: selectedId)
+        try await Task.sleep(nanoseconds: 250_000_000)
+
+        #expect(mock.sent.contains { $0.method == "session/cancel" })
+        let prompts = mock.sent.filter { $0.method == "session/prompt" }
+        #expect(prompts.count == 1)
+        var userTexts: [String] = []
+        for msg in session.transcript.messages {
+            if case .user(_, let text, _) = msg { userTexts.append(text) }
+        }
+        #expect(userTexts == ["selected"])
+        #expect(session.queue.isEmpty)
+        #expect(runner.steerUndoSnapshot()?.map { $0.blocks } == [[.text("first")], [.text("third")]])
+        #expect(try store.loadQueue(sessionId: "s").isEmpty)
+    }
+
     @Test("userCancel() drains queue after canceling the running turn")
     func cancelThenFlushDrainsQueue() async throws {
         let (runner, mock, session, _) = try mkRunner()

--- a/AlasTests/ACP/UI/ACPMessageListPaginationTests.swift
+++ b/AlasTests/ACP/UI/ACPMessageListPaginationTests.swift
@@ -31,10 +31,10 @@ struct ACPMessageListPaginationTests {
         ) == .spinner)
     }
 
-    @Test("queue bubbles render pending and sending items")
-    func queueBubblesRenderPendingAndSendingItems() {
+    @Test("queue bubbles render pending items only")
+    func queueBubblesRenderPendingItemsOnly() {
         #expect(ACPMessageList.shouldRenderQueueBubble(status: .pending))
-        #expect(ACPMessageList.shouldRenderQueueBubble(status: .sending))
+        #expect(!ACPMessageList.shouldRenderQueueBubble(status: .sending))
     }
 
     @Test("queue drops only accept pending items onto pending targets")
@@ -49,7 +49,7 @@ struct ACPMessageListPaginationTests {
     func queueHeaderCountMatchesRenderedQueueBubbles() {
         #expect(ACPMessageList.queueHeaderCount(statuses: []) == 0)
         #expect(ACPMessageList.queueHeaderCount(statuses: [.pending]) == 1)
-        #expect(ACPMessageList.queueHeaderCount(statuses: [.sending]) == 1)
-        #expect(ACPMessageList.queueHeaderCount(statuses: [.sending, .pending]) == 2)
+        #expect(ACPMessageList.queueHeaderCount(statuses: [.sending]) == 0)
+        #expect(ACPMessageList.queueHeaderCount(statuses: [.sending, .pending]) == 1)
     }
 }


### PR DESCRIPTION
## Summary
- hide in-flight queued prompts from the visible queued UI and badge count
- make the queued row send action steer with the selected queued prompt while busy
- add regression coverage for queued visibility and force-send behavior

## Verification
- `xcodegen`
- `ALAS_ZMX_OPTIONAL=1 xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -quiet build`
- `ALAS_ZMX_OPTIONAL=1 xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' test`