### PR TITLE
feat(diff): close stale diff tabs after discard

### DIFF
--- a/Alas/Sources/Center/TabsManager.swift
+++ b/Alas/Sources/Center/TabsManager.swift
@@ -975,6 +975,20 @@ final class TabsManager {
         persist(worktreeId)
     }
 
+    @discardableResult
+    func closeDiffTabs(worktreeId: String, relativePaths: some Sequence<String>) -> [TabID] {
+        let pathSet = Set(relativePaths)
+        guard !pathSet.isEmpty else { return [] }
+        let tabIds = tabs(forWorktree: worktreeId).compactMap { tab -> TabID? in
+            guard case .diff(let state) = tab, pathSet.contains(state.relativePath) else { return nil }
+            return state.id
+        }
+        for tabId in tabIds {
+            close(worktreeId: worktreeId, tabId: tabId)
+        }
+        return tabIds
+    }
+
     func closeOthers(worktreeId: String, keeping tabId: TabID) -> [TabID] {
         guard var file = byWorktree[worktreeId] else { return [] }
         let closed = file.tabs.filter { $0.id != tabId }.map(\.id)

--- a/Alas/Sources/Right/RightPaneState.swift
+++ b/Alas/Sources/Right/RightPaneState.swift
@@ -792,7 +792,11 @@ final class RightPaneState {
             return
         }
         await refresh()
-        closeDiffTabs?(paths)
+        let remainingChangedPaths = Set(changes.flatMap(Self.unstagePaths(for:)))
+        let cleanPaths = paths.filter { !remainingChangedPaths.contains($0) }
+        if !cleanPaths.isEmpty {
+            closeDiffTabs?(cleanPaths)
+        }
     }
 
     /// Run `git diff HEAD -- <file>` (or `--cached` on unborn HEAD, or

--- a/Alas/Sources/Right/RightPaneStore.swift
+++ b/Alas/Sources/Right/RightPaneStore.swift
@@ -54,12 +54,7 @@ final class RightPaneStore {
             new.trackUpstreamForCommits = trackUpstreamForCommits
             new.closeDiffTabs = { [weak self] paths in
                 guard let app = self?.appState else { return }
-                let pathSet = Set(paths)
-                for tab in app.tabs.tabs(forWorktree: id) {
-                    if case .diff(let s) = tab, pathSet.contains(s.relativePath) {
-                        app.closeTab(worktreeId: id, tabId: s.id)
-                    }
-                }
+                app.tabs.closeDiffTabs(worktreeId: id, relativePaths: paths)
             }
             new.openConflict = { [weak self] path in
                 guard let app = self?.appState else { return }

--- a/AlasTests/TabsManagerTests.swift
+++ b/AlasTests/TabsManagerTests.swift
@@ -34,6 +34,22 @@ struct TabsManagerTests {
         #expect(mgr.activeTabId(forWorktree: worktreeId) == nil)
     }
 
+    @Test func closingDiffTabsByPathClosesAllMatchingDiffsOnly() {
+        let worktreeId = "tabs-manager-closing-diff-tabs-by-path"
+        defer { try? FileManager.default.removeItem(at: Paths.tabsFile(forWorktreeId: worktreeId)) }
+        let mgr = TabsManager()
+        let editor = mgr.appendEditor(worktreeId: worktreeId, title: "a.txt", relativePath: "a.txt")
+        let unstaged = mgr.appendDiff(worktreeId: worktreeId, title: "a.txt", relativePath: "a.txt")
+        let staged = mgr.appendDiff(worktreeId: worktreeId, title: "a.txt (staged)", relativePath: "a.txt", staged: true)
+        let other = mgr.appendDiff(worktreeId: worktreeId, title: "b.txt", relativePath: "b.txt")
+
+        let closed = mgr.closeDiffTabs(worktreeId: worktreeId, relativePaths: ["a.txt"])
+
+        #expect(closed == [unstaged.id, staged.id])
+        #expect(mgr.tabs(forWorktree: worktreeId).map(\.id) == [editor.id, other.id])
+        #expect(mgr.activeTabId(forWorktree: worktreeId) == other.id)
+    }
+
     @Test func activatingTabNumberUsesOneBasedWorktreeLocalOrder() {
         let worktreeId = "tabs-manager-activate-tab-number"
         defer { try? FileManager.default.removeItem(at: Paths.tabsFile(forWorktreeId: worktreeId)) }


### PR DESCRIPTION
## Summary
- Close open diff tabs for files whose changes were discarded after the working tree refresh confirms they are clean.
- Centralize diff-tab matching in `TabsManager`, covering both staged and unstaged diff tabs for the same path.
- Add focused tab-manager coverage for closing matching diff tabs.

## Validation
- `xcodegen`
- `xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -quiet build`
- Focused tests for `TabsManagerTests` and `RightPaneStateDiscardTests`

Note: full `xcodebuild ... test` was attempted twice during implementation but hung silently in the broader suite; focused tests passed.