### PR TITLE
feat(terminal): add Open sessions manager to Terminal settings

### DIFF
--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -709,6 +709,7 @@
 		BAE4D422FC3950E61FEE1D15 /* AppIntents.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = CA43AA9C8462D579E733B46C /* AppIntents.framework */; };
 		BAE6B1D93387807ADD7ED0CC /* ACPImageThumbnail.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5E1462C85D0E49127BCED81 /* ACPImageThumbnail.swift */; };
 		BB565B8EE9BA20EE961B32FB /* ThemeSidebarContrastTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B70ED4990428C46B69784970 /* ThemeSidebarContrastTests.swift */; };
+		BC0EC69E1BC62514BBE129E7 /* OpenSessionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEFCC9CAC7B3254708748815 /* OpenSessionsTests.swift */; };
 		BC19B95DAAC3943FF1BE5817 /* CommitTabView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 59DBB72EE97F0E906442919B /* CommitTabView.swift */; };
 		BC4B8B193F020CBEA02B01A6 /* ACPMessageWireTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2468AD293C8215FAF390C907 /* ACPMessageWireTests.swift */; };
 		BC98C2BCDB4F6C88C66117A6 /* InlineErrorStrip.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7206BC51596AE2A57D8B28B /* InlineErrorStrip.swift */; };
@@ -918,6 +919,7 @@
 		EF276F4856AA2E82C2ECDC7E /* CodeHostModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = C96C5E43E973803E6FD1528C /* CodeHostModels.swift */; };
 		F078F588859E4B2E906D704A /* AlasToggle.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1841997CCBDB9611576B930C /* AlasToggle.swift */; };
 		F0CB2589DDF3082F6996A117 /* ACPPlanSidebarVisibilityTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 96A230290E0029D45CA1B907 /* ACPPlanSidebarVisibilityTests.swift */; };
+		F1299CAAD4DBF766CC56CB8F /* OpenSessions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4068B3E83F9A82C2E3F8A6A1 /* OpenSessions.swift */; };
 		F18EB035A8972F21D23F3810 /* SearchFooter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 39DFD138FE855D8CFC464847 /* SearchFooter.swift */; };
 		F1AB5B4DF8A59DF85D585058 /* RemoteWeb in Resources */ = {isa = PBXBuildFile; fileRef = B586C7A794B846F3AD9228BD /* RemoteWeb */; };
 		F1C4DD0D3A95ED5301EE2AC9 /* ACPTranscriptMarkdownCacheEvictionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3708552C2BF0E70F10C76B63 /* ACPTranscriptMarkdownCacheEvictionTests.swift */; };
@@ -1227,6 +1229,7 @@
 		3F3914A1820E1098DA558CD0 /* ACPTerminalHostTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPTerminalHostTests.swift; sourceTree = "<group>"; };
 		3F4C58E8C0B1BC5B7CB2BBCB /* Code.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Code.swift; sourceTree = "<group>"; };
 		3F79A184C86BE6C6BF72EB57 /* ACPMessageList.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPMessageList.swift; sourceTree = "<group>"; };
+		4068B3E83F9A82C2E3F8A6A1 /* OpenSessions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OpenSessions.swift; sourceTree = "<group>"; };
 		4069925EE709DD18AEA810B3 /* ShortcutResolver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShortcutResolver.swift; sourceTree = "<group>"; };
 		410A42B1C46E68965FD36793 /* ShortcutChip.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShortcutChip.swift; sourceTree = "<group>"; };
 		412B2AF1B68E3B56DE21EB91 /* DiagnosticsRangeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiagnosticsRangeTests.swift; sourceTree = "<group>"; };
@@ -1785,6 +1788,7 @@
 		DE2AC16E9220C05F670BE3EB /* ACPMarkdownText.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPMarkdownText.swift; sourceTree = "<group>"; };
 		DE74A483930F70A0C79CC3E8 /* CodeHostRemoteDetectorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CodeHostRemoteDetectorTests.swift; sourceTree = "<group>"; };
 		DE7675D7F75E36E9C81193C8 /* LSPMessagesTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LSPMessagesTests.swift; sourceTree = "<group>"; };
+		DEFCC9CAC7B3254708748815 /* OpenSessionsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OpenSessionsTests.swift; sourceTree = "<group>"; };
 		DF919734A34EEB87FA61FE07 /* WebSocketFrameTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebSocketFrameTests.swift; sourceTree = "<group>"; };
 		DF9310EAA75C6B6567F303B6 /* ACPChipState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPChipState.swift; sourceTree = "<group>"; };
 		DFBD2A49431277EB68106AAA /* ACPConnectingPlaceholder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPConnectingPlaceholder.swift; sourceTree = "<group>"; };
@@ -2224,6 +2228,7 @@
 				4D5507CA73F4EE1717FD4D79 /* NumstatParserTests.swift */,
 				0E9F9769B8C6EC2F87092F1B /* OKLCHTests.swift */,
 				292B5DA9EC17ED07588C48FD /* OpenCodeInstallerTests.swift */,
+				DEFCC9CAC7B3254708748815 /* OpenSessionsTests.swift */,
 				4DA7089B238D285A1A2040CA /* PaneLeafEncodeTests.swift */,
 				16C9E59E3987C1D3C9989D91 /* PaneTreeTests.swift */,
 				295319DB8544C170DDD6328D /* PathsTests.swift */,
@@ -3577,6 +3582,7 @@
 				159FE807399835B0821E1CAB /* EnvBuilder.swift */,
 				BCA505FF2E6CFA8278C95C6E /* GhosttyConfigBuilder.swift */,
 				215C9AE9FBCB1FD9F6D030FE /* GhosttyHost.swift */,
+				4068B3E83F9A82C2E3F8A6A1 /* OpenSessions.swift */,
 				A2943FBB1D6371EFAC9BBE68 /* PaneTree.swift */,
 				2B142F2A747C7F2D96E8BAD1 /* SessionRegistry.swift */,
 				C56EFAFF71ABDBCDECAAA305 /* StartupScriptInstaller.swift */,
@@ -4242,6 +4248,7 @@
 				7B25B1405BFDE5570B267213 /* NumstatParser.swift in Sources */,
 				74E1B2C42F77908AA597EF45 /* OKLCH.swift in Sources */,
 				6A10E9DF8A052DBDFF477863 /* OpenCodeInstaller.swift in Sources */,
+				F1299CAAD4DBF766CC56CB8F /* OpenSessions.swift in Sources */,
 				082582F4BBA9DCFF0EAB9588 /* OperationCard.swift in Sources */,
 				86718F7E55531B8E4356D7D1 /* PaneTree.swift in Sources */,
 				78D25A04EAE26A0F3021A057 /* Paths.swift in Sources */,
@@ -4678,6 +4685,7 @@
 				D55386035B99B2B1769ED47F /* NumstatParserTests.swift in Sources */,
 				43EC5CF874B360B9092691A5 /* OKLCHTests.swift in Sources */,
 				1ECA2C8485DB484C5C687F3D /* OpenCodeInstallerTests.swift in Sources */,
+				BC0EC69E1BC62514BBE129E7 /* OpenSessionsTests.swift in Sources */,
 				4BDE8C92734D3A60645C0500 /* PaneLeafEncodeTests.swift in Sources */,
 				CAE7524F4289A256FF1069FC /* PaneTreeTests.swift in Sources */,
 				497D21A67A062CE6282008CD /* PathsTests.swift in Sources */,

--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -490,6 +490,7 @@
 		835AFE4A9EA0889E0AF316BD /* ChangeSummaryVisibilityTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E4E465A2468376AA840ADFBC /* ChangeSummaryVisibilityTests.swift */; };
 		839AF384DDFF728207769920 /* ACPContentBlockImageTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4D4DEBF2A9CFDCFDAD288499 /* ACPContentBlockImageTests.swift */; };
 		83A76F6425CD1406DA85B0E9 /* ACPUserScrollEventTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0535D92433898E76670B9FF0 /* ACPUserScrollEventTests.swift */; };
+		84103C99FE430DB2B36982D1 /* OpenSessionsSection.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE35A47BA74E306A4699B27D /* OpenSessionsSection.swift */; };
 		84C505BF196A3BDA23C80235 /* LanguageServerConfigMasonPrefill.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC01D9A0927AF9DD7524CEB7 /* LanguageServerConfigMasonPrefill.swift */; };
 		84E96EB0EF4267784462B866 /* ACPComposerImageExtractTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A637073E5D65DAA4E0CF6EA4 /* ACPComposerImageExtractTests.swift */; };
 		8510C6B68C2CF6664574C161 /* ACPSystemNoticeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3BC736DAAD590624B840923 /* ACPSystemNoticeView.swift */; };
@@ -1910,6 +1911,7 @@
 		FDE53456308778DF77B18AF4 /* ACPImageEncodingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPImageEncodingTests.swift; sourceTree = "<group>"; };
 		FE09B83A747269494B206F23 /* UpdateThrottle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UpdateThrottle.swift; sourceTree = "<group>"; };
 		FE2CDF03A998BADF20163D5A /* GitServiceUpstreamTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GitServiceUpstreamTests.swift; sourceTree = "<group>"; };
+		FE35A47BA74E306A4699B27D /* OpenSessionsSection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OpenSessionsSection.swift; sourceTree = "<group>"; };
 		FE5FDAB31C577FC38CE53032 /* ComposerAction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ComposerAction.swift; sourceTree = "<group>"; };
 		FE66950F2226F1182DCDD39A /* RightPaneView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RightPaneView.swift; sourceTree = "<group>"; };
 		FEB2EC20D23F9A4F50B1A6E3 /* TerminalPane.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TerminalPane.swift; sourceTree = "<group>"; };
@@ -2774,6 +2776,7 @@
 				F61EB45499D244E44EB170BC /* MergeBulkResolvePromptEditorWindow.swift */,
 				749E3289E4C70DA7E4DD80E6 /* MergeSingleResolvePromptEditorWindow.swift */,
 				0B2F41880B917155F7ADE622 /* MonospaceFontCatalog.swift */,
+				FE35A47BA74E306A4699B27D /* OpenSessionsSection.swift */,
 				01B42244BDE33A69EDE16562 /* PromptEditorBody.swift */,
 				07A17183B064CAB5EB5D5C11 /* ReviewRequestPromptEditorWindow.swift */,
 				6A190D4B29B35C457AA9829F /* SettingsBinding.swift */,
@@ -4249,6 +4252,7 @@
 				74E1B2C42F77908AA597EF45 /* OKLCH.swift in Sources */,
 				6A10E9DF8A052DBDFF477863 /* OpenCodeInstaller.swift in Sources */,
 				F1299CAAD4DBF766CC56CB8F /* OpenSessions.swift in Sources */,
+				84103C99FE430DB2B36982D1 /* OpenSessionsSection.swift in Sources */,
 				082582F4BBA9DCFF0EAB9588 /* OperationCard.swift in Sources */,
 				86718F7E55531B8E4356D7D1 /* PaneTree.swift in Sources */,
 				78D25A04EAE26A0F3021A057 /* Paths.swift in Sources */,

--- a/Alas/Sources/Settings/OpenSessionsSection.swift
+++ b/Alas/Sources/Settings/OpenSessionsSection.swift
@@ -10,7 +10,7 @@ struct OpenSessionsSection: View {
 
     @State private var snapshot: OpenSessionsSnapshot = .empty
     @State private var isLoading = false
-    @State private var hasLoaded = false
+    @State private var loadTask: Task<Void, Never>? = nil
     @State private var confirmKillRow: OpenSessionRow? = nil
     @State private var confirmKillAllIdle = false
 
@@ -22,10 +22,8 @@ struct OpenSessionsSection: View {
 
             if !state.terminal.zmxClient.isAvailable {
                 note("Persistent sessions are disabled.")
-            } else if !hasLoaded && isLoading {
-                note("Loading…")
             } else if snapshot.isEmpty {
-                note("No open sessions.")
+                note(isLoading ? "Loading…" : "No open sessions.")
             } else {
                 if !snapshot.active.isEmpty {
                     subsectionLabel("Active in this window")
@@ -45,13 +43,13 @@ struct OpenSessionsSection: View {
         .alert("Kill this session?", isPresented: Binding(
             get: { confirmKillRow != nil },
             set: { if !$0 { confirmKillRow = nil } }
-        )) {
+        ), presenting: confirmKillRow) { row in
             Button("Cancel", role: .cancel) { confirmKillRow = nil }
             Button("Kill", role: .destructive) {
-                if let row = confirmKillRow { performKill(row) }
+                performKill(row)
                 confirmKillRow = nil
             }
-        } message: {
+        } message: { _ in
             Text("This session has clients attached and may belong to another Alas window.")
         }
         .alert("Kill all idle sessions?", isPresented: $confirmKillAllIdle) {
@@ -76,6 +74,7 @@ struct OpenSessionsSection: View {
                     AlasButton(title: "Kill all idle", style: .subtle) { confirmKillAllIdle = true }
                 }
                 AlasButton(title: "Refresh", icon: "arrow.clockwise") { reload() }
+                    .disabled(isLoading)
             }
         }
         .padding(.bottom, 8)
@@ -119,13 +118,15 @@ struct OpenSessionsSection: View {
     }
 
     private func reload(delay: TimeInterval = 0) {
+        loadTask?.cancel()
         isLoading = true
-        Task {
+        loadTask = Task {
             if delay > 0 { try? await Task.sleep(nanoseconds: UInt64(delay * 1_000_000_000)) }
+            guard !Task.isCancelled else { return }
             let snap = await state.terminal.loadOpenSessions()
+            guard !Task.isCancelled else { return }
             snapshot = snap
             isLoading = false
-            hasLoaded = true
         }
     }
 }

--- a/Alas/Sources/Settings/OpenSessionsSection.swift
+++ b/Alas/Sources/Settings/OpenSessionsSection.swift
@@ -1,0 +1,201 @@
+import SwiftUI
+
+/// Settings › Terminal "Open sessions" section: lists this window's tracked
+/// zmx sessions and orphaned/other `alas-*` sessions, with per-row kill and a
+/// "Kill all idle" bulk action. Loads on appear, after any kill, and on the
+/// Refresh button — no background polling.
+struct OpenSessionsSection: View {
+    @Bindable var state: AppState
+    @Environment(\.theme) var theme
+
+    @State private var snapshot: OpenSessionsSnapshot = .empty
+    @State private var isLoading = false
+    @State private var hasLoaded = false
+    @State private var confirmKillRow: OpenSessionRow? = nil
+    @State private var confirmKillAllIdle = false
+
+    private var idleCount: Int { snapshot.orphaned.filter(\.isIdle).count }
+
+    var body: some View {
+        SettingsGroup(title: "Open sessions") {
+            header
+
+            if !state.terminal.zmxClient.isAvailable {
+                note("Persistent sessions are disabled.")
+            } else if !hasLoaded && isLoading {
+                note("Loading…")
+            } else if snapshot.isEmpty {
+                note("No open sessions.")
+            } else {
+                if !snapshot.active.isEmpty {
+                    subsectionLabel("Active in this window")
+                    ForEach(snapshot.active) { row in
+                        OpenSessionRowView(row: row, onKill: { kill(row) })
+                    }
+                }
+                if !snapshot.orphaned.isEmpty {
+                    subsectionLabel("Other / orphaned")
+                    ForEach(snapshot.orphaned) { row in
+                        OpenSessionRowView(row: row, onKill: { kill(row) })
+                    }
+                }
+            }
+        }
+        .onAppear { reload() }
+        .alert("Kill this session?", isPresented: Binding(
+            get: { confirmKillRow != nil },
+            set: { if !$0 { confirmKillRow = nil } }
+        )) {
+            Button("Cancel", role: .cancel) { confirmKillRow = nil }
+            Button("Kill", role: .destructive) {
+                if let row = confirmKillRow { performKill(row) }
+                confirmKillRow = nil
+            }
+        } message: {
+            Text("This session has clients attached and may belong to another Alas window.")
+        }
+        .alert("Kill all idle sessions?", isPresented: $confirmKillAllIdle) {
+            Button("Cancel", role: .cancel) { }
+            Button("Kill \(idleCount)", role: .destructive) {
+                state.terminal.killIdleOrphans(snapshot)
+                reload(delay: 0.4)
+            }
+        } message: {
+            Text("Kills \(idleCount) idle session\(idleCount == 1 ? "" : "s") with nothing attached.")
+        }
+    }
+
+    private var header: some View {
+        HStack(alignment: .top, spacing: SettingsRowLayout.columnSpacing) {
+            Text("Long-running zmx sessions. Idle ones can be killed to reclaim resources.")
+                .font(.system(size: 11.5))
+                .foregroundColor(theme.color("fg-dim"))
+                .frame(maxWidth: .infinity, alignment: .leading)
+            HStack(spacing: 8) {
+                if idleCount > 0 {
+                    AlasButton(title: "Kill all idle", style: .subtle) { confirmKillAllIdle = true }
+                }
+                AlasButton(title: "Refresh", icon: "arrow.clockwise") { reload() }
+            }
+        }
+        .padding(.bottom, 8)
+    }
+
+    private func subsectionLabel(_ text: String) -> some View {
+        Text(text.uppercased())
+            .font(.system(size: 10, weight: .semibold))
+            .tracking(0.5)
+            .foregroundColor(theme.color("fg-dim"))
+            .padding(.top, 12)
+            .padding(.bottom, 2)
+    }
+
+    private func note(_ text: String) -> some View {
+        Text(text)
+            .font(.system(size: 12))
+            .foregroundColor(theme.color("fg-dim"))
+            .padding(.vertical, 10)
+    }
+
+    // MARK: actions
+
+    /// In-use orphans go through a confirm; everything else kills immediately.
+    private func kill(_ row: OpenSessionRow) {
+        if case .orphanInUse = row.kind {
+            confirmKillRow = row
+        } else {
+            performKill(row)
+        }
+    }
+
+    private func performKill(_ row: OpenSessionRow) {
+        switch row.kind {
+        case let .active(leafId, worktreeId):
+            state.terminal.closeSession(id: leafId, worktreeId: worktreeId)
+        case .orphanIdle, .orphanInUse:
+            state.terminal.killOrphanSession(name: row.name)
+        }
+        reload(delay: 0.4)
+    }
+
+    private func reload(delay: TimeInterval = 0) {
+        isLoading = true
+        Task {
+            if delay > 0 { try? await Task.sleep(nanoseconds: UInt64(delay * 1_000_000_000)) }
+            let snap = await state.terminal.loadOpenSessions()
+            snapshot = snap
+            isLoading = false
+            hasLoaded = true
+        }
+    }
+}
+
+/// One row in the open-sessions list: a title (working-dir leaf or session
+/// name), a subtitle (full path · command · age), an orphan-state badge, and
+/// a Kill button.
+private struct OpenSessionRowView: View {
+    let row: OpenSessionRow
+    let onKill: () -> Void
+    @Environment(\.theme) var theme
+
+    private var title: String {
+        if let dir = row.startDir, !dir.isEmpty {
+            return (dir as NSString).lastPathComponent
+        }
+        return row.name
+    }
+
+    private var subtitleParts: [String] {
+        var parts: [String] = []
+        if let dir = row.startDir, !dir.isEmpty { parts.append(dir) }
+        if let cmd = row.cmd, !cmd.isEmpty { parts.append(cmd) }
+        if let age = relativeAge(createdEpoch: row.created, now: Date()) { parts.append(age) }
+        return parts
+    }
+
+    var body: some View {
+        HStack(alignment: .top, spacing: SettingsRowLayout.columnSpacing) {
+            VStack(alignment: .leading, spacing: 2) {
+                HStack(spacing: 6) {
+                    Text(title).font(.system(size: 12.5, weight: .medium))
+                        .foregroundColor(theme.color("fg"))
+                    badge
+                }
+                if !subtitleParts.isEmpty {
+                    Text(subtitleParts.joined(separator: " · "))
+                        .font(.system(size: 11))
+                        .foregroundColor(theme.color("fg-dim"))
+                        .lineLimit(1)
+                        .truncationMode(.middle)
+                }
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .padding(.top, 4)
+            AlasButton(title: "Kill", style: .subtle, action: onKill)
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .padding(.vertical, 10)
+        .overlay(Divider().opacity(0.5), alignment: .top)
+    }
+
+    @ViewBuilder private var badge: some View {
+        switch row.kind {
+        case .active:
+            EmptyView()
+        case .orphanIdle:
+            badgeLabel("idle", color: theme.color("fg-muted"))
+        case .orphanInUse:
+            badgeLabel("in use", color: theme.color("accent"))
+        }
+    }
+
+    private func badgeLabel(_ text: String, color: Color) -> some View {
+        Text(text.uppercased())
+            .font(.system(size: 9, weight: .semibold))
+            .tracking(0.5)
+            .foregroundColor(color)
+            .padding(.horizontal, 5)
+            .padding(.vertical, 1)
+            .overlay(RoundedRectangle(cornerRadius: 4).strokeBorder(color.opacity(0.5), lineWidth: 0.5))
+    }
+}

--- a/Alas/Sources/Settings/OpenSessionsSection.swift
+++ b/Alas/Sources/Settings/OpenSessionsSection.swift
@@ -49,8 +49,12 @@ struct OpenSessionsSection: View {
                 performKill(row)
                 confirmKillRow = nil
             }
-        } message: { _ in
-            Text("This session has clients attached and may belong to another Alas window.")
+        } message: { row in
+            if case .active = row.kind {
+                Text("This terminal tab and the process running in it will be terminated.")
+            } else {
+                Text("This session has clients attached and may belong to another Alas window.")
+            }
         }
         .alert("Kill all idle sessions?", isPresented: $confirmKillAllIdle) {
             Button("Cancel", role: .cancel) { }
@@ -98,11 +102,17 @@ struct OpenSessionsSection: View {
 
     // MARK: actions
 
-    /// In-use orphans go through a confirm; everything else kills immediately.
+    /// Active tabs honor the "confirm before closing terminal tabs" setting;
+    /// in-use orphans always confirm (they may belong to another window);
+    /// idle orphans kill immediately.
     private func kill(_ row: OpenSessionRow) {
-        if case .orphanInUse = row.kind {
+        switch row.kind {
+        case .active:
+            if state.config.terminal.confirmCloseTabs { confirmKillRow = row }
+            else { performKill(row) }
+        case .orphanInUse:
             confirmKillRow = row
-        } else {
+        case .orphanIdle:
             performKill(row)
         }
     }

--- a/Alas/Sources/Settings/TerminalPane.swift
+++ b/Alas/Sources/Settings/TerminalPane.swift
@@ -44,6 +44,8 @@ struct TerminalPane: View {
                     }
                 }
 
+                OpenSessionsSection(state: state)
+
                 SettingsGroup(title: "Startup scripts") {
                     SettingsRow(name: "Run on session open",
                                 desc: "Executed in every new terminal pane after the shell starts.") {

--- a/Alas/Sources/Terminal/OpenSessions.swift
+++ b/Alas/Sources/Terminal/OpenSessions.swift
@@ -72,12 +72,15 @@ enum OpenSessionsClassifier {
             infoByBareName[bare] = info
         }
 
-        let trackedWithName = tracked.compactMap { ref -> (String, TrackedSessionRef)? in
-            ref.zmxSessionName.map { ($0, ref) }
+        // Registry should not emit duplicate zmxSessionNames; if it somehow
+        // does, last write wins so we never produce two rows with the same id.
+        var trackedByName: [String: TrackedSessionRef] = [:]
+        for ref in tracked {
+            if let name = ref.zmxSessionName { trackedByName[name] = ref }
         }
-        let trackedNames = Set(trackedWithName.map(\.0))
+        let trackedNames = Set(trackedByName.keys)
 
-        let active: [OpenSessionRow] = trackedWithName.map { bareName, ref in
+        let active: [OpenSessionRow] = trackedByName.map { bareName, ref in
             let info = infoByBareName[bareName]
             return OpenSessionRow(
                 name: bareName,

--- a/Alas/Sources/Terminal/OpenSessions.swift
+++ b/Alas/Sources/Terminal/OpenSessions.swift
@@ -1,0 +1,70 @@
+// OpenSessions.swift
+// View-model types + the pure classifier behind the Settings › Terminal
+// "Open sessions" section. Splits `zmx ls` output into the sessions this
+// window owns ("active") and everything else ("orphaned"), and judges each
+// orphan idle vs in-use by its attached-client count.
+
+import Foundation
+
+/// A live registry entry projected into a value type, so the pure classifier
+/// never has to touch the `@MainActor` `TerminalSession`/`SessionRegistry`.
+struct TrackedSessionRef: Equatable, Sendable {
+    let leafId: String
+    let worktreeId: String
+    /// Bare (unprefixed) zmx session name, or nil when the pane isn't
+    /// zmx-backed (keep-alive off or zmx unavailable).
+    let zmxSessionName: String?
+}
+
+/// One open zmx session as rendered in the settings list.
+struct OpenSessionRow: Identifiable, Equatable, Sendable {
+    enum Kind: Equatable, Sendable {
+        case active(leafId: String, worktreeId: String)  // tracked by this window
+        case orphanIdle                                   // clients == 0
+        case orphanInUse                                  // clients >= 1 or unknown
+    }
+
+    let name: String        // bare zmx session name; unique per session
+    let kind: Kind
+    let startDir: String?
+    let cmd: String?
+    let clients: Int?
+    let created: Int?       // unix epoch seconds
+
+    var id: String { name }
+
+    var isOrphan: Bool {
+        switch kind {
+        case .active: return false
+        case .orphanIdle, .orphanInUse: return true
+        }
+    }
+
+    var isIdle: Bool {
+        if case .orphanIdle = kind { return true }
+        return false
+    }
+}
+
+/// The two-bucket result the settings view renders.
+struct OpenSessionsSnapshot: Equatable, Sendable {
+    var active: [OpenSessionRow]
+    var orphaned: [OpenSessionRow]
+
+    static let empty = OpenSessionsSnapshot(active: [], orphaned: [])
+
+    var isEmpty: Bool { active.isEmpty && orphaned.isEmpty }
+}
+
+/// Compact "started N ago" label from a unix-epoch creation time. Returns
+/// nil when the timestamp is missing or in the future. `now` is injected so
+/// the function stays pure and testable.
+func relativeAge(createdEpoch: Int?, now: Date) -> String? {
+    guard let createdEpoch else { return nil }
+    let seconds = Int(now.timeIntervalSince1970) - createdEpoch
+    if seconds < 0 { return nil }
+    if seconds < 60 { return "just now" }
+    if seconds < 3600 { return "\(seconds / 60)m ago" }
+    if seconds < 86_400 { return "\(seconds / 3600)h ago" }
+    return "\(seconds / 86_400)d ago"
+}

--- a/Alas/Sources/Terminal/OpenSessions.swift
+++ b/Alas/Sources/Terminal/OpenSessions.swift
@@ -56,6 +56,60 @@ struct OpenSessionsSnapshot: Equatable, Sendable {
     var isEmpty: Bool { active.isEmpty && orphaned.isEmpty }
 }
 
+/// Pure split of `zmx ls` output into active (this-window) vs orphaned
+/// sessions. No subprocess, no actor isolation — directly unit-testable.
+enum OpenSessionsClassifier {
+    static func classify(
+        infos: [ZmxSessionInfo],
+        tracked: [TrackedSessionRef],
+        sessionPrefix: String
+    ) -> OpenSessionsSnapshot {
+        // Bare-name -> info, so active lookups and orphan filtering both work
+        // off the prefix-stripped name the registry uses.
+        var infoByBareName: [String: ZmxSessionInfo] = [:]
+        for info in infos where info.name.hasPrefix(sessionPrefix) {
+            let bare = String(info.name.dropFirst(sessionPrefix.count))
+            infoByBareName[bare] = info
+        }
+
+        let trackedWithName = tracked.compactMap { ref -> (String, TrackedSessionRef)? in
+            ref.zmxSessionName.map { ($0, ref) }
+        }
+        let trackedNames = Set(trackedWithName.map(\.0))
+
+        let active: [OpenSessionRow] = trackedWithName.map { bareName, ref in
+            let info = infoByBareName[bareName]
+            return OpenSessionRow(
+                name: bareName,
+                kind: .active(leafId: ref.leafId, worktreeId: ref.worktreeId),
+                startDir: info?.startDir,
+                cmd: info?.cmd,
+                clients: info?.clients,
+                created: info?.created
+            )
+        }
+        .sorted { $0.name < $1.name }
+
+        var orphaned: [OpenSessionRow] = []
+        for (bareName, info) in infoByBareName {
+            guard bareName.hasPrefix("alas-") else { continue }  // ours only
+            guard !trackedNames.contains(bareName) else { continue } // already active
+            let kind: OpenSessionRow.Kind = (info.clients ?? 1) == 0 ? .orphanIdle : .orphanInUse
+            orphaned.append(OpenSessionRow(
+                name: bareName,
+                kind: kind,
+                startDir: info.startDir,
+                cmd: info.cmd,
+                clients: info.clients,
+                created: info.created
+            ))
+        }
+        orphaned.sort { $0.name < $1.name }
+
+        return OpenSessionsSnapshot(active: active, orphaned: orphaned)
+    }
+}
+
 /// Compact "started N ago" label from a unix-epoch creation time. Returns
 /// nil when the timestamp is missing or in the future. `now` is injected so
 /// the function stays pure and testable.

--- a/Alas/Sources/Terminal/TerminalService.swift
+++ b/Alas/Sources/Terminal/TerminalService.swift
@@ -294,6 +294,40 @@ final class TerminalService {
         }
     }
 
+    /// Snapshot of the currently-open zmx sessions for the Settings ›
+    /// Terminal "Open sessions" list. Runs `zmx ls` off-main (it blocks up
+    /// to ~5s), then classifies the result against this window's registry.
+    func loadOpenSessions() async -> OpenSessionsSnapshot {
+        guard zmxClient.isAvailable else { return .empty }
+        let prefix = ProcessInfo.processInfo.environment["ZMX_SESSION_PREFIX"] ?? ""
+        let tracked = registry.all.map {
+            TrackedSessionRef(leafId: $0.id, worktreeId: $0.worktreeId, zmxSessionName: $0.zmxSessionName)
+        }
+        let client = zmxClient
+        let infos = await Task.detached { client.listSessionInfos() }.value
+        return OpenSessionsClassifier.classify(infos: infos, tracked: tracked, sessionPrefix: prefix)
+    }
+
+    /// Kill a single orphaned session by its bare name. `ZmxClient.killSession`
+    /// re-prepends `ZMX_SESSION_PREFIX` itself, matching the create/kill
+    /// symmetry used everywhere else. Dispatched off-main and tracked so a
+    /// hung daemon never blocks the UI and `waitForPendingKills` can drain it.
+    func killOrphanSession(name: String) {
+        let client = zmxClient
+        dispatchTrackedKill { client.killSession(name: name) }
+    }
+
+    /// Kill every idle (`clients == 0`) orphan in `snapshot` — the
+    /// "grown wild" cleanup. Active and in-use rows are left untouched.
+    func killIdleOrphans(_ snapshot: OpenSessionsSnapshot) {
+        let names = snapshot.orphaned.filter(\.isIdle).map(\.name)
+        guard !names.isEmpty else { return }
+        let client = zmxClient
+        dispatchTrackedKill {
+            for name in names { client.killSession(name: name) }
+        }
+    }
+
     /// Pure filter exposed for tests: pick the scoped `alas-*` sessions
     /// belonging to one of our worktrees that no known leaf claims.
     /// Returns bare (unprefixed) names so callers can pass them straight to

--- a/Alas/Sources/Terminal/Zmx/ZmxClient.swift
+++ b/Alas/Sources/Terminal/Zmx/ZmxClient.swift
@@ -4,6 +4,10 @@ import os
 struct ZmxSessionInfo: Equatable, Sendable {
     let name: String
     let startDir: String?
+    var pid: Int?
+    var clients: Int?
+    var created: Int?
+    var cmd: String?
 }
 
 /// Thin Swift wrapper around the bundled `zmx` CLI. Exposes the three
@@ -146,16 +150,25 @@ final class ZmxClient: Sendable {
             .split(separator: "\t", omittingEmptySubsequences: true)
         var name: String?
         var startDir: String?
+        var pid: Int?
+        var clients: Int?
+        var created: Int?
+        var cmd: String?
         for field in fields {
             let parts = field.split(separator: "=", maxSplits: 1, omittingEmptySubsequences: false)
             guard parts.count == 2 else { continue }
+            let value = String(parts[1])
             switch parts[0] {
-            case "name": name = String(parts[1])
-            case "start_dir": startDir = String(parts[1])
+            case "name": name = value
+            case "start_dir": startDir = value
+            case "pid": pid = Int(value)
+            case "clients": clients = Int(value)
+            case "created": created = Int(value)
+            case "cmd": cmd = value
             default: break
             }
         }
         guard let name else { return nil }
-        return ZmxSessionInfo(name: name, startDir: startDir)
+        return ZmxSessionInfo(name: name, startDir: startDir, pid: pid, clients: clients, created: created, cmd: cmd)
     }
 }

--- a/AlasTests/OpenSessionsTests.swift
+++ b/AlasTests/OpenSessionsTests.swift
@@ -43,4 +43,83 @@ struct OpenSessionsTests {
     @Test func relativeAgeExactlyAtDayBoundary() {
         #expect(relativeAge(createdEpoch: 1_000_000 - 86_400, now: now) == "1d ago")
     }
+
+    // MARK: - classifier
+
+    private func info(
+        _ name: String, clients: Int? = nil, dir: String? = nil,
+        cmd: String? = nil, created: Int? = nil
+    ) -> ZmxSessionInfo {
+        ZmxSessionInfo(name: name, startDir: dir, pid: nil, clients: clients, created: created, cmd: cmd)
+    }
+
+    @Test func classifySplitsActiveFromOrphaned() {
+        let tracked = [
+            TrackedSessionRef(leafId: "leaf-1", worktreeId: "wt-1", zmxSessionName: "alas-aaaa-1111"),
+        ]
+        let infos = [
+            info("alas-aaaa-1111", clients: 1, dir: "/work/one"),  // active (tracked)
+            info("alas-bbbb-2222", clients: 0, dir: "/work/two"),  // orphan idle
+            info("alas-cccc-3333", clients: 2, dir: "/work/three"), // orphan in-use
+        ]
+
+        let snap = OpenSessionsClassifier.classify(infos: infos, tracked: tracked, sessionPrefix: "")
+
+        #expect(snap.active.map(\.name) == ["alas-aaaa-1111"])
+        #expect(snap.active.first?.kind == .active(leafId: "leaf-1", worktreeId: "wt-1"))
+        #expect(snap.orphaned.map(\.name) == ["alas-bbbb-2222", "alas-cccc-3333"])
+        #expect(snap.orphaned[0].kind == .orphanIdle)
+        #expect(snap.orphaned[1].kind == .orphanInUse)
+    }
+
+    @Test func classifyTreatsUnknownClientCountAsInUse() {
+        let infos = [info("alas-bbbb-2222", clients: nil, dir: "/x")]
+        let snap = OpenSessionsClassifier.classify(infos: infos, tracked: [], sessionPrefix: "")
+        #expect(snap.orphaned.first?.kind == .orphanInUse)
+    }
+
+    @Test func classifyIgnoresNonAlasSessions() {
+        let infos = [info("tmux-default", clients: 0), info("zellij-x", clients: 1)]
+        let snap = OpenSessionsClassifier.classify(infos: infos, tracked: [], sessionPrefix: "")
+        #expect(snap.isEmpty)
+    }
+
+    @Test func classifyShowsLegacyUnscopedAsOrphan() {
+        // Legacy `alas-<uuid>` names are still ours and should appear.
+        let infos = [info("alas-DEADBEEF-1234-5678", clients: 0, dir: "/legacy")]
+        let snap = OpenSessionsClassifier.classify(infos: infos, tracked: [], sessionPrefix: "")
+        #expect(snap.orphaned.map(\.name) == ["alas-DEADBEEF-1234-5678"])
+        #expect(snap.orphaned.first?.kind == .orphanIdle)
+    }
+
+    @Test func classifyKeepsTrackedTabWhenDaemonDied() {
+        // Tracked session has no matching `zmx ls` row (daemon gone) — still
+        // shown as active so the user can close it cleanly.
+        let tracked = [
+            TrackedSessionRef(leafId: "leaf-9", worktreeId: "wt-9", zmxSessionName: "alas-dead-beef"),
+        ]
+        let snap = OpenSessionsClassifier.classify(infos: [], tracked: tracked, sessionPrefix: "")
+        #expect(snap.active.map(\.name) == ["alas-dead-beef"])
+        #expect(snap.active.first?.startDir == nil)
+    }
+
+    @Test func classifySkipsTrackedRefsWithoutZmxName() {
+        let tracked = [TrackedSessionRef(leafId: "leaf-x", worktreeId: "wt-x", zmxSessionName: nil)]
+        let snap = OpenSessionsClassifier.classify(infos: [], tracked: tracked, sessionPrefix: "")
+        #expect(snap.isEmpty)
+    }
+
+    @Test func classifyStripsSessionPrefixBeforeMatching() {
+        let tracked = [
+            TrackedSessionRef(leafId: "leaf-1", worktreeId: "wt-1", zmxSessionName: "alas-aaaa-1111"),
+        ]
+        let infos = [
+            info("dev_alas-aaaa-1111", clients: 1),  // prefixed match -> active
+            info("dev_alas-bbbb-2222", clients: 0),  // prefixed orphan
+            info("other_alas-cccc-3333", clients: 0), // wrong prefix -> ignored
+        ]
+        let snap = OpenSessionsClassifier.classify(infos: infos, tracked: tracked, sessionPrefix: "dev_")
+        #expect(snap.active.map(\.name) == ["alas-aaaa-1111"])
+        #expect(snap.orphaned.map(\.name) == ["alas-bbbb-2222"])
+    }
 }

--- a/AlasTests/OpenSessionsTests.swift
+++ b/AlasTests/OpenSessionsTests.swift
@@ -31,4 +31,16 @@ struct OpenSessionsTests {
     @Test func relativeAgeDays() {
         #expect(relativeAge(createdEpoch: 1_000_000 - 2 * 86_400, now: now) == "2d ago")
     }
+
+    @Test func relativeAgeExactlyAtMinuteBoundary() {
+        #expect(relativeAge(createdEpoch: 1_000_000 - 60, now: now) == "1m ago")
+    }
+
+    @Test func relativeAgeExactlyAtHourBoundary() {
+        #expect(relativeAge(createdEpoch: 1_000_000 - 3600, now: now) == "1h ago")
+    }
+
+    @Test func relativeAgeExactlyAtDayBoundary() {
+        #expect(relativeAge(createdEpoch: 1_000_000 - 86_400, now: now) == "1d ago")
+    }
 }

--- a/AlasTests/OpenSessionsTests.swift
+++ b/AlasTests/OpenSessionsTests.swift
@@ -1,0 +1,34 @@
+import Foundation
+import Testing
+@testable import Alas
+
+@Suite
+struct OpenSessionsTests {
+    // MARK: - relativeAge
+
+    private let now = Date(timeIntervalSince1970: 1_000_000)
+
+    @Test func relativeAgeNilWhenNoTimestamp() {
+        #expect(relativeAge(createdEpoch: nil, now: now) == nil)
+    }
+
+    @Test func relativeAgeNilWhenInFuture() {
+        #expect(relativeAge(createdEpoch: 1_000_100, now: now) == nil)
+    }
+
+    @Test func relativeAgeJustNowUnderAMinute() {
+        #expect(relativeAge(createdEpoch: 1_000_000 - 30, now: now) == "just now")
+    }
+
+    @Test func relativeAgeMinutes() {
+        #expect(relativeAge(createdEpoch: 1_000_000 - 5 * 60, now: now) == "5m ago")
+    }
+
+    @Test func relativeAgeHours() {
+        #expect(relativeAge(createdEpoch: 1_000_000 - 3 * 3600, now: now) == "3h ago")
+    }
+
+    @Test func relativeAgeDays() {
+        #expect(relativeAge(createdEpoch: 1_000_000 - 2 * 86_400, now: now) == "2d ago")
+    }
+}

--- a/AlasTests/OpenSessionsTests.swift
+++ b/AlasTests/OpenSessionsTests.swift
@@ -72,6 +72,18 @@ struct OpenSessionsTests {
         #expect(snap.orphaned[1].kind == .orphanInUse)
     }
 
+    @Test func classifyTrackedSessionWithZeroClientsStaysActiveNotOrphan() {
+        // A tracked tab whose daemon reports clients=0 must NOT leak into the
+        // orphaned/idle bucket — otherwise killIdleOrphans could reap a live tab.
+        let tracked = [
+            TrackedSessionRef(leafId: "leaf-1", worktreeId: "wt-1", zmxSessionName: "alas-aaaa-1111"),
+        ]
+        let infos = [info("alas-aaaa-1111", clients: 0)]
+        let snap = OpenSessionsClassifier.classify(infos: infos, tracked: tracked, sessionPrefix: "")
+        #expect(snap.active.map(\.name) == ["alas-aaaa-1111"])
+        #expect(snap.orphaned.isEmpty)
+    }
+
     @Test func classifyTreatsUnknownClientCountAsInUse() {
         let infos = [info("alas-bbbb-2222", clients: nil, dir: "/x")]
         let snap = OpenSessionsClassifier.classify(infos: infos, tracked: [], sessionPrefix: "")
@@ -121,5 +133,6 @@ struct OpenSessionsTests {
         let snap = OpenSessionsClassifier.classify(infos: infos, tracked: tracked, sessionPrefix: "dev_")
         #expect(snap.active.map(\.name) == ["alas-aaaa-1111"])
         #expect(snap.orphaned.map(\.name) == ["alas-bbbb-2222"])
+        #expect(snap.active.first?.clients == 1)
     }
 }

--- a/AlasTests/TerminalServiceZmxTests.swift
+++ b/AlasTests/TerminalServiceZmxTests.swift
@@ -633,7 +633,6 @@ struct TerminalServiceZmxTests {
 
         svc.killOrphanSession(name: "alas-aaaa-1111")
         svc.waitForPendingKills(timeout: 2.0)
-        await waitForCalls(recorder, count: 1) { $0.calls.count }
 
         #expect(recorder.calls.contains(.init(
             executable: URL(fileURLWithPath: "/fake/Contents/Resources/zmx/zmx"),
@@ -652,7 +651,6 @@ struct TerminalServiceZmxTests {
 
         svc.killIdleOrphans(snap)
         svc.waitForPendingKills(timeout: 2.0)
-        await waitForCalls(recorder, count: 2) { $0.calls.count }
 
         let killed = Set(recorder.calls.filter { $0.args.first == "kill" }.map { $0.args[1] })
         #expect(killed == ["alas-idle-1", "alas-idle-2"])

--- a/AlasTests/TerminalServiceZmxTests.swift
+++ b/AlasTests/TerminalServiceZmxTests.swift
@@ -596,4 +596,65 @@ struct TerminalServiceZmxTests {
         #expect(plan.args == [])
         #expect(recorder.calls.isEmpty)
     }
+
+    // MARK: open-sessions wrappers
+
+    @Test func loadOpenSessionsClassifiesAgainstRegistry() async {
+        let recorder = RecordingRunner()
+        let activeName = ZmxSessionName.derive(worktreeId: "wt-1", leafId: "leaf-abc")
+        recorder.resultsByFirstArg["ls"] = SubprocessRunner.Result(
+            exitCode: 0,
+            stdout: """
+              name=\(activeName)\tpid=1\tclients=1\tcreated=1779957881\tstart_dir=/work/active\tcmd=/bin/zsh -l
+              name=alas-aaaaaaaaaaaaaaaa-bbbbbbbbbbbbbbbb\tpid=2\tclients=0\tcreated=1779957882\tstart_dir=/work/orphan\tcmd=/bin/zsh
+
+            """,
+            stderr: ""
+        )
+        let svc = TerminalService(zmxClient: ZmxClient(env: makeZmxEnv(), runner: recorder.runner()))
+        let surface = AlasGhostty.SurfaceView(testIO: FakeGhosttySurfaceIO())
+        svc.registry.register(TerminalSession(
+            id: "leaf-abc", worktreeId: "wt-1", projectId: "proj-1",
+            surface: surface, executable: "/bin/zsh", args: [],
+            zmxSessionName: activeName
+        ))
+
+        let snap = await svc.loadOpenSessions()
+
+        #expect(snap.active.map(\.name) == [activeName])
+        #expect(snap.active.first?.kind == .active(leafId: "leaf-abc", worktreeId: "wt-1"))
+        #expect(snap.orphaned.map(\.name) == ["alas-aaaaaaaaaaaaaaaa-bbbbbbbbbbbbbbbb"])
+        #expect(snap.orphaned.first?.isIdle == true)
+    }
+
+    @Test func killOrphanSessionRunsZmxKill() async {
+        let recorder = RecordingRunner()
+        let svc = TerminalService(zmxClient: ZmxClient(env: makeZmxEnv(), runner: recorder.runner()))
+
+        svc.killOrphanSession(name: "alas-aaaa-1111")
+        svc.waitForPendingKills(timeout: 2.0)
+        await waitForCalls(recorder, count: 1) { $0.calls.count }
+
+        #expect(recorder.calls.contains(.init(
+            executable: URL(fileURLWithPath: "/fake/Contents/Resources/zmx/zmx"),
+            args: ["kill", "alas-aaaa-1111"]
+        )))
+    }
+
+    @Test func killIdleOrphansKillsOnlyIdleRows() async {
+        let recorder = RecordingRunner()
+        let svc = TerminalService(zmxClient: ZmxClient(env: makeZmxEnv(), runner: recorder.runner()))
+        let snap = OpenSessionsSnapshot(active: [], orphaned: [
+            OpenSessionRow(name: "alas-idle-1", kind: .orphanIdle, startDir: nil, cmd: nil, clients: 0, created: nil),
+            OpenSessionRow(name: "alas-busy-1", kind: .orphanInUse, startDir: nil, cmd: nil, clients: 2, created: nil),
+            OpenSessionRow(name: "alas-idle-2", kind: .orphanIdle, startDir: nil, cmd: nil, clients: 0, created: nil),
+        ])
+
+        svc.killIdleOrphans(snap)
+        svc.waitForPendingKills(timeout: 2.0)
+        await waitForCalls(recorder, count: 2) { $0.calls.count }
+
+        let killed = Set(recorder.calls.filter { $0.args.first == "kill" }.map { $0.args[1] })
+        #expect(killed == ["alas-idle-1", "alas-idle-2"])
+    }
 }

--- a/AlasTests/ZmxClientTests.swift
+++ b/AlasTests/ZmxClientTests.swift
@@ -231,13 +231,44 @@ struct ZmxClientTests {
         #expect(infos == [
             ZmxSessionInfo(
                 name: "alas-old-leaf",
-                startDir: "/Users/nacho/.alas/.worktrees/alas/nacho-new-worktree-acp"
+                startDir: "/Users/nacho/.alas/.worktrees/alas/nacho-new-worktree-acp",
+                pid: 25367,
+                clients: 1,
+                created: 1779957881,
+                cmd: "/bin/zsh -l"
             ),
             ZmxSessionInfo(
                 name: "alas-other",
-                startDir: "/Volumes/Workspace/alas"
+                startDir: "/Volumes/Workspace/alas",
+                pid: 25368,
+                clients: 0,
+                created: 1779957882,
+                cmd: "/bin/zsh -l -i"
             ),
         ])
         #expect(recorder.calls[0].args == ["ls"])
+    }
+
+    @Test
+    func listSessionInfosToleratesMissingAndMalformedFields() {
+        let recorder = RecordingRunner()
+        recorder.result = SubprocessRunner.Result(
+            exitCode: 0,
+            stdout: """
+              name=alas-minimal
+              name=alas-bad\tclients=notanumber\tcreated=\tpid=12
+              clients=3\tstart_dir=/tmp
+
+            """,
+            stderr: ""
+        )
+        let client = ZmxClient(env: env(available: true), runner: recorder.runner())
+        let infos = client.listSessionInfos()
+
+        // Row 3 has no `name=` field and is dropped entirely.
+        #expect(infos == [
+            ZmxSessionInfo(name: "alas-minimal", startDir: nil, pid: nil, clients: nil, created: nil, cmd: nil),
+            ZmxSessionInfo(name: "alas-bad", startDir: nil, pid: 12, clients: nil, created: nil, cmd: nil),
+        ])
     }
 }


### PR DESCRIPTION
## Summary

Adds an **Open sessions** section to Settings → Terminal that lists currently-open long-running zmx sessions and lets you kill them — aimed at catching sessions that "grow wild" (leaks from crashes, killed worktrees, or other instances).

- **Active in this window** — sessions tracked by this Alas window (from the registry). Kill routes through the normal `closeSession` path, so the registry stays consistent, and honors the existing "confirm before closing terminal tabs" setting.
- **Other / orphaned** — `alas-*` sessions in `zmx ls` not tracked here, badged **idle** (`clients == 0`) or **in use** (`clients ≥ 1`). Idle kills immediately; in-use kills require an explicit confirm, since they may belong to another Alas window (shared `ZMX_DIR`).
- **Kill all idle** — bulk-reaps every idle orphan behind a counted confirm.
- Loads on appear, after any kill, and via Refresh — no background polling. `zmx ls`/`kill` run off-main via the existing tracked-kill machinery.

### How it's built (layered)
- `ZmxSessionInfo` parser extended to capture the full `zmx ls` field set (`pid`, `clients`, `created`, `cmd`).
- `OpenSessionsClassifier` — a pure, unit-tested function splitting `zmx ls` output into active vs orphaned (idle/in-use), with `ZMX_SESSION_PREFIX` stripping and an explicit guard so a tracked tab reporting `clients=0` can never leak into "Kill all idle".
- `TerminalService.loadOpenSessions()` / `killOrphanSession(name:)` / `killIdleOrphans(_:)` wrappers.
- `OpenSessionsSection` SwiftUI view, wired into `TerminalPane`.

## Test Plan
- [x] `xcodebuild ... test` — full suite green (3476 tests, 0 failures)
- [x] Unit tests: parser (full + malformed fields), classifier (active/orphaned, idle/in-use, legacy/non-alas, daemon-died, prefix), service load + kill routing, `relativeAge`
- [ ] Settings → Terminal shows the **Open sessions** group between "Sessions" and "Startup scripts"
- [ ] An open tab appears under "Active in this window" with its working dir; killing it respects the confirm-close setting
- [ ] Orphaned `alas-*` sessions appear with idle/in-use badge + age; Refresh reloads; in-use kill prompts a confirm
- [ ] "Kill all idle" appears when ≥1 idle orphan exists and reaps them after confirm