### PR TITLE
Fix remote tool call cards

### DIFF
--- a/Alas/Resources/RemoteWeb/app.js
+++ b/Alas/Resources/RemoteWeb/app.js
@@ -358,10 +358,25 @@ function toolCard(tc) {
   const verb = TOOL_VERB[tc.kind] || (tc.kind ? cap(tc.kind) : "Tool");
   const name = tc.title || (tc.locations && tc.locations[0]) || "";
   const card = structCard(verb, name && name.toLowerCase() !== verb.toLowerCase() ? name : "",
-                          (typeof tc.content === "string" && tc.content) ? tc.content : "No output.", tc.preview);
+                          toolBody(tc), tc.preview);
   const [ch, scls] = TOOL_STATUS[tc.status] || [tc.status || "", "run"];
   card.querySelector(".tool-chev").insertAdjacentElement("beforebegin", el("span", "tool-status " + scls, ch));
   return card;
+}
+
+function toolBody(tc) {
+  if (typeof tc.content === "string" && tc.content) return tc.content;
+  const rows = [
+    ["toolCallId", tc.toolCallId],
+    ["title", tc.title],
+    ["kind", tc.kind],
+    ["status", tc.status],
+    ["preview", tc.preview],
+    ["locations", Array.isArray(tc.locations) ? tc.locations.join("\n") : ""],
+    ["terminalIds", Array.isArray(tc.terminalIds) ? tc.terminalIds.join("\n") : ""]
+  ].filter(([, value]) => typeof value === "string" && value.length > 0);
+  if (!rows.length) return "Tool invoked.";
+  return rows.map(([key, value]) => `${key}: ${value}`).join("\n");
 }
 
 function structCard(verb, name, body, preview) {

--- a/Alas/Resources/RemoteWeb/index.html
+++ b/Alas/Resources/RemoteWeb/index.html
@@ -11,7 +11,7 @@
   <link rel="icon" href="/icon.svg" type="image/svg+xml" />
   <link rel="apple-touch-icon" href="/icon-180.png" />
   <title>Alas Remote</title>
-  <link rel="stylesheet" href="/style.css?v=28" />
+  <link rel="stylesheet" href="/style.css?v=29" />
 </head>
 <body>
   <header id="bar">
@@ -99,7 +99,7 @@
   </div>
   <script src="/marked.min.js?v=28"></script>
   <script src="/purify.min.js?v=28"></script>
-  <script src="/app.js?v=28"></script>
+  <script src="/app.js?v=29"></script>
   <script>
     if ("serviceWorker" in navigator) {
       window.addEventListener("load", () => {

--- a/Alas/Resources/RemoteWeb/style.css
+++ b/Alas/Resources/RemoteWeb/style.css
@@ -105,9 +105,9 @@ h1 { font-size: 22px; font-weight: 700; margin: 12px 4px 10px; }
 .m-thought .thought-body { color: var(--fg-dim); font-style: italic; font-size: 13px; line-height: 1.5; padding: 4px 0 2px; }
 
 /* Tool call / structured card — collapsed by default */
-.m-tool { align-self: stretch; background: color-mix(in oklab, var(--bg-1) 60%, transparent); border: 0.5px solid var(--line); border-radius: 8px; margin: 5px 0; overflow: hidden; }
+.m-tool { align-self: stretch; color: var(--fg); background: color-mix(in oklab, var(--bg-1) 60%, transparent); border: 0.5px solid var(--line); border-radius: 8px; margin: 5px 0; overflow: hidden; }
 .m-tool.is-open { border-color: var(--bg-4); }
-.tool-toggle { width: 100%; border: none; background: none; color: inherit; font: inherit; cursor: pointer; display: flex; align-items: center; gap: 8px; padding: 8px 10px; text-align: left; -webkit-tap-highlight-color: transparent; }
+.tool-toggle { appearance: none; -webkit-appearance: none; width: 100%; border: none; background: none; color: var(--fg); font: inherit; cursor: pointer; display: flex; align-items: center; gap: 8px; padding: 8px 10px; text-align: left; -webkit-tap-highlight-color: transparent; }
 .tool-verb { flex-shrink: 0; font-size: 10px; font-weight: 700; letter-spacing: .6px; text-transform: uppercase; color: var(--accent); }
 .tool-name { color: var(--fg-muted); font-family: ui-monospace, monospace; font-size: 12px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
 .tool-preview { flex: 1; min-width: 0; color: var(--fg-faint); font-family: ui-monospace, monospace; font-size: 11px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }

--- a/Alas/Resources/RemoteWeb/sw.js
+++ b/Alas/Resources/RemoteWeb/sw.js
@@ -1,9 +1,9 @@
-const CACHE_NAME = "alas-remote-shell-v4";
+const CACHE_NAME = "alas-remote-shell-v5";
 const SHELL_ASSETS = [
   "/",
   "/index.html",
-  "/style.css?v=28",
-  "/app.js?v=28",
+  "/style.css?v=29",
+  "/app.js?v=29",
   "/marked.min.js?v=28",
   "/purify.min.js?v=28",
   "/manifest.webmanifest",

--- a/AlasTests/Remote/RemoteWebAssetTests.swift
+++ b/AlasTests/Remote/RemoteWebAssetTests.swift
@@ -22,8 +22,21 @@ struct RemoteWebAssetTests {
         #expect(app.contains(#"const d = el("div", "msg m-tool m-collapsible")"#))
         #expect(app.contains("setCardOpen"))
         #expect(app.contains(#"setAttribute("aria-expanded""#))
+        #expect(app.contains("function toolBody"))
+        #expect(app.contains(#""toolCallId""#))
         #expect(!app.contains(#"const d = el("details", "msg m-tool")"#))
         #expect(!css.contains(".m-tool > summary"))
+    }
+
+    @Test func toolCardMobileFixBustsServiceWorkerAssetCache() throws {
+        let html = try asset("index.html")
+        let sw = try asset("sw.js")
+
+        #expect(html.contains(#"/app.js?v=29"#))
+        #expect(html.contains(#"/style.css?v=29"#))
+        #expect(sw.contains(#"const CACHE_NAME = "alas-remote-shell-v5";"#))
+        #expect(sw.contains(#""/app.js?v=29""#))
+        #expect(sw.contains(#""/style.css?v=29""#))
     }
 
     @Test func sessionRowsRenderWorktreeSummaryCards() throws {
@@ -37,8 +50,8 @@ struct RemoteWebAssetTests {
         #expect(app.contains(#""clean""#))
         #expect(css.contains(".session-row-card"))
         #expect(css.contains(".session-meta"))
-        #expect(html.contains("/app.js?v=28"))
-        #expect(html.contains("/style.css?v=28"))
+        #expect(html.contains("/app.js?v=29"))
+        #expect(html.contains("/style.css?v=29"))
     }
 
     @Test func remoteWebExposesSessionRenameControls() throws {
@@ -63,8 +76,8 @@ struct RemoteWebAssetTests {
         #expect(css.contains(".session-open"))
         #expect(css.contains("#detail-title"))
         #expect(css.contains(".sheet-input"))
-        #expect(sw.contains(#""/app.js?v=28""#))
-        #expect(sw.contains(#""/style.css?v=28""#))
+        #expect(sw.contains(#""/app.js?v=29""#))
+        #expect(sw.contains(#""/style.css?v=29""#))
     }
 
     @Test func serviceWorkerKeepsControlAndDiagnosticRoutesNetworkOnly() throws {


### PR DESCRIPTION
## Summary
- Bust the remote web shell cache so mobile clients pick up the tool-card rendering fix.
- Render useful tool-call metadata when a tool invocation has no output content.
- Make remote tool-card row text explicit on mobile browsers.

## Validation
- xcodegen
- xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -quiet build
- xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' test