### PR TITLE
improve(acp): chat wide layout and typography settings

### DIFF
--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -872,6 +872,7 @@
 		E29D10B84F406C38E2F4C457 /* FileResultRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3375A79ACFD3567389DA855C /* FileResultRow.swift */; };
 		E2A3B2DB4B1F9A7C318921D7 /* ACPImageStaging.swift in Sources */ = {isa = PBXBuildFile; fileRef = 98796FD86FE05979A2BCBCF3 /* ACPImageStaging.swift */; };
 		E2A49F787B3DC3F45E92854D /* AgentEditView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9E480C05A2AA6FF8863B7C5 /* AgentEditView.swift */; };
+		E2B39318C3417839BAE511A7 /* ACPChatTypographyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3659703F6EB9AD2454C2898B /* ACPChatTypographyTests.swift */; };
 		E30243803319861ACA6A4513 /* ACPSessionManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB5B73ECBD730B5BB24E2240 /* ACPSessionManagerTests.swift */; };
 		E30832C33A680645C481826F /* ANSIStreamTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 86CB3F953562BAFB284B5DB7 /* ANSIStreamTests.swift */; };
 		E31120BCB281A62D767D85BC /* HunkPatchBuilderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA486F66BE4CEB2A16EB148B /* HunkPatchBuilderTests.swift */; };
@@ -962,6 +963,7 @@
 		FDB1BD021ED0D2C7247E42D5 /* RightPaneStateLoadOlderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3C89163A30EA4D278E86959 /* RightPaneStateLoadOlderTests.swift */; };
 		FE1517EC14DCB1C29528C865 /* StatusParserTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DBA6A9F78C8E8CDF6D170BDD /* StatusParserTests.swift */; };
 		FE5846F4401C702264817399 /* SpaceEmojiPickerSelectionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 28777B087266D8AE174BA233 /* SpaceEmojiPickerSelectionTests.swift */; };
+		FE5F2F9B468D045194B9443B /* ACPChatTypography.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5DC558BE723378DCC7AA5B55 /* ACPChatTypography.swift */; };
 		FF23739CD41997C6DD44E18B /* ACPFileWriter.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE0C0029F439C282D474ED77 /* ACPFileWriter.swift */; };
 		FF4707BB143F25062DD3BC43 /* AgentAutoLaunchTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 36F875ED8D44E6C298588E60 /* AgentAutoLaunchTests.swift */; };
 		FF7DDFC667CE2E3964B51FA5 /* LSPInstallProgressSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2379C3F8504AD2EE73130AC4 /* LSPInstallProgressSheet.swift */; };
@@ -1190,6 +1192,7 @@
 		35D6BBD77A210BB378E217FC /* GitRefNameInputFilterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GitRefNameInputFilterTests.swift; sourceTree = "<group>"; };
 		364213292935A05F3B52F51F /* Paths.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Paths.swift; sourceTree = "<group>"; };
 		364507D55CD5D73CD44819E7 /* InstallerHostTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InstallerHostTests.swift; sourceTree = "<group>"; };
+		3659703F6EB9AD2454C2898B /* ACPChatTypographyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPChatTypographyTests.swift; sourceTree = "<group>"; };
 		36992F601C8EB6C3D45B584F /* SearchKbd.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchKbd.swift; sourceTree = "<group>"; };
 		36B06AE8BA5FBDEAD4586616 /* SearchKind.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchKind.swift; sourceTree = "<group>"; };
 		36F875ED8D44E6C298588E60 /* AgentAutoLaunchTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentAutoLaunchTests.swift; sourceTree = "<group>"; };
@@ -1343,6 +1346,7 @@
 		5C8BF1EC24E449A302A1E25C /* CopyFeedbackState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CopyFeedbackState.swift; sourceTree = "<group>"; };
 		5CC16D06302D9AD3C9F0BE3C /* TreeSitterHighlighter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TreeSitterHighlighter.swift; sourceTree = "<group>"; };
 		5D486FD440D802AEC65D1555 /* MarkdownFileType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MarkdownFileType.swift; sourceTree = "<group>"; };
+		5DC558BE723378DCC7AA5B55 /* ACPChatTypography.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPChatTypography.swift; sourceTree = "<group>"; };
 		5DD723B8C15EF2413C5D935D /* BlockedLanguageServerNudgeResolver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BlockedLanguageServerNudgeResolver.swift; sourceTree = "<group>"; };
 		5E21106B4804D62C1D3C7F62 /* AlasGhostty.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlasGhostty.swift; sourceTree = "<group>"; };
 		5EF6536F169B7C7B2C339B1C /* ACPAdapterVersionCheckerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPAdapterVersionCheckerTests.swift; sourceTree = "<group>"; };
@@ -2688,6 +2692,7 @@
 			isa = PBXGroup;
 			children = (
 				90762AFB51B237B783D4190C /* ACPChatLayoutTests.swift */,
+				3659703F6EB9AD2454C2898B /* ACPChatTypographyTests.swift */,
 				81773A01826A91080F5A2E95 /* ACPCodeBlockHighlighterTests.swift */,
 				2B7ADCB7C4178FE036A31214 /* ACPComposerActionButtonMetricsTests.swift */,
 				B9454F0214E21F91473C96F6 /* ACPComposerDraftBridgeTests.swift */,
@@ -2920,6 +2925,7 @@
 				CE2AD8D0539591C434F51418 /* ACPAuthNudgeBanner.swift */,
 				D3EDEEB00185F9C717205540 /* ACPAutoRunToggle.swift */,
 				6D8E02BB3FEB3C71AEEBBE6F /* ACPChatLayout.swift */,
+				5DC558BE723378DCC7AA5B55 /* ACPChatTypography.swift */,
 				530767799372FE03C3695656 /* ACPCodeBlockHighlighter.swift */,
 				C496549308D5C3DD20E988AD /* ACPComposer.swift */,
 				E69452CB123EB0AABB632F03 /* ACPComposerActionButton.swift */,
@@ -3912,6 +3918,7 @@
 				56B6EF95B863B557992AE9DA /* ACPAutoRunToggle.swift in Sources */,
 				88A139C7B3C3C9F20EF5945A /* ACPChangeNotifier.swift in Sources */,
 				25311FAD068B5590F459CED9 /* ACPChatLayout.swift in Sources */,
+				FE5F2F9B468D045194B9443B /* ACPChatTypography.swift in Sources */,
 				C00E549FA69AB3D3C55B85EB /* ACPChipState.swift in Sources */,
 				A70A62FDF7EA38F99D9E2B06 /* ACPClient.swift in Sources */,
 				EACD40C757361FC2C78F912A /* ACPCodeBlockHighlighter.swift in Sources */,
@@ -4423,6 +4430,7 @@
 				4151B68B1CF0A947AEC4C00A /* ACPAuthNudgeBannerTests.swift in Sources */,
 				AC2EA26D999115E66DF40142 /* ACPChangeNotifierTests.swift in Sources */,
 				AEB565CDE2F5AEAE088A1A79 /* ACPChatLayoutTests.swift in Sources */,
+				E2B39318C3417839BAE511A7 /* ACPChatTypographyTests.swift in Sources */,
 				5E5600E6451068BCBF732ABD /* ACPChipStateTests.swift in Sources */,
 				238BBB5FC59949CE6ABAFBEF /* ACPCodeBlockHighlighterTests.swift in Sources */,
 				33A0FC862C45CDFF47053A04 /* ACPComposerActionButtonMetricsTests.swift in Sources */,

--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -136,6 +136,7 @@
 		2434A66A45EDF2609BA9F1D3 /* session-update-config-options.json in Resources */ = {isa = PBXBuildFile; fileRef = 97DA8F50DDCDAA15CCEA2004 /* session-update-config-options.json */; };
 		24F8EA15B87C38C319B8A66B /* AlasField.swift in Sources */ = {isa = PBXBuildFile; fileRef = D9E6D61B213F3378243B4A26 /* AlasField.swift */; };
 		250F0E2CB26CC16D2FFDB9DD /* DiffSelectableTextView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 23FECFF5D8673A3A8E7A1431 /* DiffSelectableTextView.swift */; };
+		25311FAD068B5590F459CED9 /* ACPChatLayout.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6D8E02BB3FEB3C71AEEBBE6F /* ACPChatLayout.swift */; };
 		25347EFEF1B5F7F4915DB120 /* DebounceTimerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 179A74F3A825DA1EC4C4E0FC /* DebounceTimerTests.swift */; };
 		255E9EAE89D521E08EB90918 /* JSONHookSettingsFile.swift in Sources */ = {isa = PBXBuildFile; fileRef = 137F79BD0DEB96B6F756ABD4 /* JSONHookSettingsFile.swift */; };
 		2584552219DE6987E1E6AF36 /* AgentRunError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3BF2F213480B30034B25B2B8 /* AgentRunError.swift */; };
@@ -658,6 +659,7 @@
 		ADAE65B8D982CD4411235D32 /* CodeHostRemoteDetector.swift in Sources */ = {isa = PBXBuildFile; fileRef = 82E98F9835497D830C12AA8F /* CodeHostRemoteDetector.swift */; };
 		ADF6D3B634D9CCA17D7884EC /* PiACPInstallerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C6641006D2208E28C46AAB2 /* PiACPInstallerTests.swift */; };
 		AE179E24A9E308150D1FD1D5 /* CommitPromptStatusTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1E40B5F193E3CB5EB5BA945A /* CommitPromptStatusTests.swift */; };
+		AEB565CDE2F5AEAE088A1A79 /* ACPChatLayoutTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 90762AFB51B237B783D4190C /* ACPChatLayoutTests.swift */; };
 		AF2263B61D95A8BFF0972E93 /* AgentHookEvent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 136BDA12046FB352E183D6A4 /* AgentHookEvent.swift */; };
 		AFD24C0A5D5625A1843751C1 /* ACPFirstRunConnectingPhase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 73539FDFE4BDBD4D3B4DE546 /* ACPFirstRunConnectingPhase.swift */; };
 		B055F47062645975A500E2EF /* ACPPlanPill.swift in Sources */ = {isa = PBXBuildFile; fileRef = B7AAAEB5A9C69FC459AAD70B /* ACPPlanPill.swift */; };
@@ -1393,6 +1395,7 @@
 		6D1AAAE396590865426C592A /* ACPSessionManagerRetentionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPSessionManagerRetentionTests.swift; sourceTree = "<group>"; };
 		6D46BDE72E52818061452ECB /* CommitRowTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommitRowTests.swift; sourceTree = "<group>"; };
 		6D788808DF3BE405143F91F7 /* ReleaseInfoTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReleaseInfoTests.swift; sourceTree = "<group>"; };
+		6D8E02BB3FEB3C71AEEBBE6F /* ACPChatLayout.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPChatLayout.swift; sourceTree = "<group>"; };
 		6DF0AEE54BDB4FC4FD5E02F4 /* GitServiceStagingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GitServiceStagingTests.swift; sourceTree = "<group>"; };
 		6DF51E6FAFBB47E2F31DA287 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		6E8B52175A7F6144B4C52010 /* EditorTabView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditorTabView.swift; sourceTree = "<group>"; };
@@ -1506,6 +1509,7 @@
 		8EDED937A8E8340D6E685A6E /* GitNameValidatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GitNameValidatorTests.swift; sourceTree = "<group>"; };
 		8EF52FE71B7FB41328859734 /* MarkdownRenderer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MarkdownRenderer.swift; sourceTree = "<group>"; };
 		906D92F7AD84F313508D9CFD /* ACPComposerShell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPComposerShell.swift; sourceTree = "<group>"; };
+		90762AFB51B237B783D4190C /* ACPChatLayoutTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPChatLayoutTests.swift; sourceTree = "<group>"; };
 		90817EC3BAA727EF6D9FBD97 /* GitService+Discard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "GitService+Discard.swift"; sourceTree = "<group>"; };
 		90D74C28EB7B8C3CBC53994D /* MergeAgent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MergeAgent.swift; sourceTree = "<group>"; };
 		90F0CBE40E2CF0251ABE72AE /* GitLFSBlobResolver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GitLFSBlobResolver.swift; sourceTree = "<group>"; };
@@ -2683,6 +2687,7 @@
 		4A87288C819AD4B9E41D1858 /* UI */ = {
 			isa = PBXGroup;
 			children = (
+				90762AFB51B237B783D4190C /* ACPChatLayoutTests.swift */,
 				81773A01826A91080F5A2E95 /* ACPCodeBlockHighlighterTests.swift */,
 				2B7ADCB7C4178FE036A31214 /* ACPComposerActionButtonMetricsTests.swift */,
 				B9454F0214E21F91473C96F6 /* ACPComposerDraftBridgeTests.swift */,
@@ -2914,6 +2919,7 @@
 			children = (
 				CE2AD8D0539591C434F51418 /* ACPAuthNudgeBanner.swift */,
 				D3EDEEB00185F9C717205540 /* ACPAutoRunToggle.swift */,
+				6D8E02BB3FEB3C71AEEBBE6F /* ACPChatLayout.swift */,
 				530767799372FE03C3695656 /* ACPCodeBlockHighlighter.swift */,
 				C496549308D5C3DD20E988AD /* ACPComposer.swift */,
 				E69452CB123EB0AABB632F03 /* ACPComposerActionButton.swift */,
@@ -3905,6 +3911,7 @@
 				6E66AD13D1763D61F619F3D1 /* ACPAuthNudgeBanner.swift in Sources */,
 				56B6EF95B863B557992AE9DA /* ACPAutoRunToggle.swift in Sources */,
 				88A139C7B3C3C9F20EF5945A /* ACPChangeNotifier.swift in Sources */,
+				25311FAD068B5590F459CED9 /* ACPChatLayout.swift in Sources */,
 				C00E549FA69AB3D3C55B85EB /* ACPChipState.swift in Sources */,
 				A70A62FDF7EA38F99D9E2B06 /* ACPClient.swift in Sources */,
 				EACD40C757361FC2C78F912A /* ACPCodeBlockHighlighter.swift in Sources */,
@@ -4415,6 +4422,7 @@
 				D95A7FAF0B955642ED9D7521 /* ACPAuthFailureTests.swift in Sources */,
 				4151B68B1CF0A947AEC4C00A /* ACPAuthNudgeBannerTests.swift in Sources */,
 				AC2EA26D999115E66DF40142 /* ACPChangeNotifierTests.swift in Sources */,
+				AEB565CDE2F5AEAE088A1A79 /* ACPChatLayoutTests.swift in Sources */,
 				5E5600E6451068BCBF732ABD /* ACPChipStateTests.swift in Sources */,
 				238BBB5FC59949CE6ABAFBEF /* ACPCodeBlockHighlighterTests.swift in Sources */,
 				33A0FC862C45CDFF47053A04 /* ACPComposerActionButtonMetricsTests.swift in Sources */,

--- a/Alas/Sources/ACP/UI/ACPChatLayout.swift
+++ b/Alas/Sources/ACP/UI/ACPChatLayout.swift
@@ -1,0 +1,16 @@
+import CoreGraphics
+
+enum ACPChatLayout {
+    static let defaultContentMaxWidth: CGFloat = 720
+    static let wideContentMaxWidth: CGFloat = 960
+
+    static func contentMaxWidth(forPaneWidth paneWidth: CGFloat) -> CGFloat {
+        let growthStartPaneWidth: CGFloat = 1_080
+        guard paneWidth > growthStartPaneWidth else {
+            return defaultContentMaxWidth
+        }
+
+        let extraWidth = paneWidth - growthStartPaneWidth
+        return min(wideContentMaxWidth, defaultContentMaxWidth + extraWidth)
+    }
+}

--- a/Alas/Sources/ACP/UI/ACPChatLayout.swift
+++ b/Alas/Sources/ACP/UI/ACPChatLayout.swift
@@ -4,6 +4,16 @@ enum ACPChatLayout {
     static let defaultContentMaxWidth: CGFloat = 720
     static let wideContentMaxWidth: CGFloat = 960
 
+    static func chatColumnWidth(
+        forPaneWidth paneWidth: CGFloat,
+        planSidebarVisible: Bool
+    ) -> CGFloat {
+        guard planSidebarVisible else {
+            return paneWidth
+        }
+        return max(0, paneWidth - ACPPlanSidebar.width)
+    }
+
     static func contentMaxWidth(forPaneWidth paneWidth: CGFloat) -> CGFloat {
         let growthStartPaneWidth: CGFloat = 1_080
         guard paneWidth > growthStartPaneWidth else {

--- a/Alas/Sources/ACP/UI/ACPChatTypography.swift
+++ b/Alas/Sources/ACP/UI/ACPChatTypography.swift
@@ -1,0 +1,44 @@
+import AppKit
+import SwiftUI
+
+struct ACPChatTypography: Equatable {
+    static let `default` = ACPChatTypography(
+        fontFamily: "JetBrainsMono Nerd Font",
+        fontSize: 13
+    )
+
+    let fontFamily: String
+    let baseSize: CGFloat
+
+    init(fontFamily: String, fontSize: Int) {
+        self.fontFamily = fontFamily
+        self.baseSize = CGFloat(max(8, min(64, fontSize)))
+    }
+
+    var paragraphSize: CGFloat { baseSize + 0.5 }
+    var quoteSize: CGFloat { baseSize }
+    var codeSize: CGFloat { max(8, baseSize - 1) }
+    var tableBodySize: CGFloat { max(8, baseSize - 1) }
+    var tableHeaderSize: CGFloat { max(8, baseSize - 1.5) }
+    var labelSize: CGFloat { max(8, baseSize - 3) }
+
+    func headingSize(level: Int) -> CGFloat {
+        switch level {
+        case 1: return baseSize + 6
+        case 2: return baseSize + 4
+        case 3: return baseSize + 2
+        default: return baseSize + 1
+        }
+    }
+
+    func swiftUIFont(size: CGFloat, weight: Font.Weight = .regular) -> Font {
+        Font(appKitFont(size: size)).weight(weight)
+    }
+
+    func appKitFont(size: CGFloat? = nil) -> NSFont {
+        CenterTypography.resolveCodeFont(
+            family: fontFamily,
+            size: size ?? baseSize
+        )
+    }
+}

--- a/Alas/Sources/ACP/UI/ACPChatTypography.swift
+++ b/Alas/Sources/ACP/UI/ACPChatTypography.swift
@@ -31,14 +31,38 @@ struct ACPChatTypography: Equatable {
         }
     }
 
-    func swiftUIFont(size: CGFloat, weight: Font.Weight = .regular) -> Font {
-        Font(appKitFont(size: size)).weight(weight)
+    func swiftUIFont(
+        size: CGFloat,
+        weight: Font.Weight = .regular,
+        traits: NSFontTraitMask = []
+    ) -> Font {
+        Font(appKitFont(size: size, traits: traits)).weight(weight)
     }
 
-    func appKitFont(size: CGFloat? = nil) -> NSFont {
-        CenterTypography.resolveCodeFont(
+    func appKitFont(size: CGFloat? = nil, traits: NSFontTraitMask = []) -> NSFont {
+        var font = CenterTypography.resolveCodeFont(
             family: fontFamily,
             size: size ?? baseSize
         )
+        guard !traits.isEmpty else { return font }
+
+        if traits.contains(.boldFontMask) {
+            font = NSFontManager.shared.convert(font, toHaveTrait: .boldFontMask)
+        }
+        if traits.contains(.italicFontMask) {
+            font = NSFontManager.shared.convert(font, toHaveTrait: .italicFontMask)
+        }
+
+        var symbolicTraits = font.fontDescriptor.symbolicTraits
+        if traits.contains(.boldFontMask) {
+            symbolicTraits.insert(.bold)
+        }
+        if traits.contains(.italicFontMask) {
+            symbolicTraits.insert(.italic)
+        }
+        let descriptor = font.fontDescriptor.withSymbolicTraits(symbolicTraits)
+        guard let traitFont = NSFont(descriptor: descriptor, size: size ?? baseSize)
+        else { return font }
+        return traitFont
     }
 }

--- a/Alas/Sources/ACP/UI/ACPCodeBlockHighlighter.swift
+++ b/Alas/Sources/ACP/UI/ACPCodeBlockHighlighter.swift
@@ -198,11 +198,12 @@ enum ACPCodeBlockHighlighter {
         code: String,
         language: String?,
         theme: Theme,
+        fontFamily: String = ACPChatTypography.default.fontFamily,
         fontSize: CGFloat = 12
     ) -> NSAttributedString {
         let editorTheme = EditorTheme(theme: theme)
         let baseAttributes: [NSAttributedString.Key: Any] = [
-            .font: NSFont.monospacedSystemFont(ofSize: fontSize, weight: .regular),
+            .font: CenterTypography.resolveCodeFont(family: fontFamily, size: fontSize),
             .foregroundColor: editorTheme.defaultFG,
         ]
         let attributed = NSMutableAttributedString(string: code, attributes: baseAttributes)

--- a/Alas/Sources/ACP/UI/ACPComposer.swift
+++ b/Alas/Sources/ACP/UI/ACPComposer.swift
@@ -22,6 +22,7 @@ struct ACPInputField: NSViewRepresentable {
     /// — queue while busy). False when the user inverted the setting so
     /// ⏎ steers; the placeholder reverses accordingly while busy.
     let sendOnEnter: Bool
+    let typography: ACPChatTypography
     /// Persists the current composer draft after text storage changes.
     let onDraftChange: (ACPComposerDraft) -> Void
     /// Clears the persisted draft after an accepted submission.
@@ -41,7 +42,7 @@ struct ACPInputField: NSViewRepresentable {
         let textView = ACPNSTextView()
         textView.delegate = context.coordinator
         textView.coordinator = context.coordinator
-        textView.font = NSFont.systemFont(ofSize: 13)
+        textView.applyChatTypography(typography)
         textView.isRichText = true
         textView.allowsUndo = true
         textView.textContainerInset = NSSize(width: 6, height: 6)
@@ -86,6 +87,7 @@ struct ACPInputField: NSViewRepresentable {
         context.coordinator.promptSuggestions = session.promptSuggestions
         context.coordinator.theme = context.environment.theme
         context.coordinator.sendOnEnter = sendOnEnter
+        context.coordinator.typography = typography
         if context.coordinator.focusRequest != focusRequest {
             context.coordinator.focusRequest = focusRequest
             if let tv = nsView.documentView as? ACPNSTextView,
@@ -94,6 +96,7 @@ struct ACPInputField: NSViewRepresentable {
             }
         }
         if let tv = nsView.documentView as? ACPNSTextView {
+            tv.applyChatTypography(typography)
             tv.placeholderText = Self.placeholder(for: session.transcript.streamingState, sendOnEnter: sendOnEnter)
             tv.needsDisplay = true
             context.coordinator.syncPersistedDraft(composer.draft, into: tv)
@@ -130,6 +133,7 @@ struct ACPInputField: NSViewRepresentable {
             isFocused: $isFocused,
             focusRequest: focusRequest,
             sendOnEnter: sendOnEnter,
+            typography: typography,
             onDraftChange: onDraftChange,
             onDraftClear: onDraftClear,
             onSubmit: onSubmit,
@@ -150,6 +154,7 @@ struct ACPInputField: NSViewRepresentable {
         /// visible ↑ button always submits with the intent the button's
         /// help text advertises.
         var sendOnEnter: Bool
+        var typography: ACPChatTypography
         let onDraftChange: (ACPComposerDraft) -> Void
         let onDraftClear: () -> Void
         let onSubmit: ACPComposerSubmitHandler
@@ -188,6 +193,7 @@ struct ACPInputField: NSViewRepresentable {
             isFocused: Binding<Bool> = .constant(false),
             focusRequest: Int,
             sendOnEnter: Bool,
+            typography: ACPChatTypography = .default,
             onDraftChange: @escaping (ACPComposerDraft) -> Void,
             onDraftClear: @escaping () -> Void,
             onSubmit: @escaping ACPComposerSubmitHandler,
@@ -198,6 +204,7 @@ struct ACPInputField: NSViewRepresentable {
             self.isFocused = isFocused
             self.focusRequest = focusRequest
             self.sendOnEnter = sendOnEnter
+            self.typography = typography
             self.lastSyncedDraft = initialDraft
             self.onDraftChange = onDraftChange
             self.onDraftClear = onDraftClear
@@ -285,7 +292,11 @@ struct ACPInputField: NSViewRepresentable {
             let work = DispatchWorkItem { [weak self] in
                 guard let self else { return }
                 guard self.pendingRestyleGeneration == generation else { return }
-                ACPMarkdownLiveStyler.restyle(storage, in: self.pendingRestyleRange)
+                ACPMarkdownLiveStyler.restyle(
+                    storage,
+                    in: self.pendingRestyleRange,
+                    typography: self.typography
+                )
                 self.pendingRestyleRange = nil
                 self.pendingRestyleWork = nil
             }
@@ -346,8 +357,8 @@ struct ACPInputField: NSViewRepresentable {
                 tv.dismissSlashPanel()
             }
             restoringDraft = true
-            storage.setAttributedString(Self.attributedString(from: draft))
-            ACPMarkdownLiveStyler.restyle(storage)
+            storage.setAttributedString(Self.attributedString(from: draft, typography: typography))
+            ACPMarkdownLiveStyler.restyle(storage, typography: typography)
             textView.needsDisplay = true
             restoringDraft = false
             lastSyncedDraft = draft
@@ -422,10 +433,13 @@ struct ACPInputField: NSViewRepresentable {
             return ACPComposerDraft(segments: segments)
         }
 
-        static func attributedString(from draft: ACPComposerDraft) -> NSAttributedString {
+        static func attributedString(
+            from draft: ACPComposerDraft,
+            typography: ACPChatTypography = .default
+        ) -> NSAttributedString {
             let result = NSMutableAttributedString(string: "")
             let baseAttributes: [NSAttributedString.Key: Any] = [
-                .font: NSFont.systemFont(ofSize: 13),
+                .font: typography.appKitFont(),
                 .foregroundColor: NSColor.labelColor,
             ]
             for segment in draft.segments {
@@ -503,6 +517,7 @@ extension NSAttributedString.Key {
 
 final class ACPNSTextView: NSTextView {
     weak var coordinator: ACPInputField.Coordinator?
+    private var chatTypography: ACPChatTypography = .default
 
     /// Greyed-out hint drawn when the storage is empty. Matches the Cursor
     /// chat composer's placeholder.
@@ -519,18 +534,29 @@ final class ACPNSTextView: NSTextView {
     private var mentionPanel: ACPMentionPanel?
     private var mentionStart: Int = -1
 
-    private static var baseTypingAttributes: [NSAttributedString.Key: Any] {
+    private var baseTypingAttributes: [NSAttributedString.Key: Any] {
         [
-            .font: NSFont.systemFont(ofSize: 13),
+            .font: chatTypography.appKitFont(),
             .foregroundColor: NSColor.labelColor,
         ]
+    }
+
+    func applyChatTypography(_ typography: ACPChatTypography) {
+        guard chatTypography != typography || font == nil else { return }
+        chatTypography = typography
+        font = typography.appKitFont()
+        typingAttributes = baseTypingAttributes
+        if let textStorage {
+            ACPMarkdownLiveStyler.restyle(textStorage, typography: typography)
+        }
+        needsDisplay = true
     }
 
     override func draw(_ dirtyRect: NSRect) {
         super.draw(dirtyRect)
         guard (string).isEmpty, !placeholderText.isEmpty else { return }
         let attrs: [NSAttributedString.Key: Any] = [
-            .font: font ?? NSFont.systemFont(ofSize: 13),
+            .font: font ?? chatTypography.appKitFont(),
             .foregroundColor: NSColor.secondaryLabelColor,
         ]
         let origin = NSPoint(
@@ -736,7 +762,7 @@ final class ACPNSTextView: NSTextView {
             // user types right after the chip is the normal label color
             // immediately — otherwise it inherits color-less attributes and
             // renders black until the debounced restyler repaints the line.
-            let baseAttrs = Self.baseTypingAttributes
+            let baseAttrs = baseTypingAttributes
             chipString.append(NSAttributedString(string: " ", attributes: baseAttrs))
             let insertAt = selectedRange()
             textStorage?.replaceCharacters(in: insertAt, with: chipString)
@@ -874,7 +900,7 @@ final class ACPNSTextView: NSTextView {
             location: min(replacementRange.location, textStorage.length),
             length: min(replacementRange.length, max(0, textStorage.length - replacementRange.location))
         )
-        let attrs = Self.baseTypingAttributes
+        let attrs = baseTypingAttributes
         typingAttributes = attrs
         insertText(text, replacementRange: boundedRange)
         typingAttributes = attrs
@@ -902,7 +928,7 @@ final class ACPNSTextView: NSTextView {
             .attachmentURI: url.absoluteString,
             .toolTip: url.path,
         ], range: NSRange(location: 0, length: chipString.length))
-        let baseAttrs = Self.baseTypingAttributes
+        let baseAttrs = baseTypingAttributes
         chipString.append(NSAttributedString(string: " ", attributes: baseAttrs))
 
         let replacementRange = mentionReplacementRange(in: textStorage)

--- a/Alas/Sources/ACP/UI/ACPComposerShell.swift
+++ b/Alas/Sources/ACP/UI/ACPComposerShell.swift
@@ -28,6 +28,7 @@ struct ACPComposer: View {
     let focusRequest: Int
     let placement: ACPComposerPlacement
     let contentMaxWidth: CGFloat
+    let typography: ACPChatTypography
     let onSubmit: ACPComposerSubmitHandler
     let filesProvider: (@Sendable () async -> [URL])?
 
@@ -46,6 +47,7 @@ struct ACPComposer: View {
         focusRequest: Int = 0,
         placement: ACPComposerPlacement = .bottom,
         contentMaxWidth: CGFloat = ACPChatLayout.defaultContentMaxWidth,
+        typography: ACPChatTypography = .default,
         filesProvider: (@Sendable () async -> [URL])? = nil,
         onSubmit: @escaping ACPComposerSubmitHandler
     ) {
@@ -58,6 +60,7 @@ struct ACPComposer: View {
         self.focusRequest = focusRequest
         self.placement = placement
         self.contentMaxWidth = contentMaxWidth
+        self.typography = typography
         self.filesProvider = filesProvider
         self.onSubmit = onSubmit
     }
@@ -137,6 +140,7 @@ struct ACPComposer: View {
                 isFocused: $inputFocused,
                 focusRequest: focusRequest,
                 sendOnEnter: sendOnEnter,
+                typography: typography,
                 onDraftChange: { draft in
                     manager.persistComposerDraft(draft, for: session)
                     hasText = draft.hasContent

--- a/Alas/Sources/ACP/UI/ACPComposerShell.swift
+++ b/Alas/Sources/ACP/UI/ACPComposerShell.swift
@@ -27,6 +27,7 @@ struct ACPComposer: View {
     let sendOnEnter: Bool
     let focusRequest: Int
     let placement: ACPComposerPlacement
+    let contentMaxWidth: CGFloat
     let onSubmit: ACPComposerSubmitHandler
     let filesProvider: (@Sendable () async -> [URL])?
 
@@ -44,6 +45,7 @@ struct ACPComposer: View {
         sendOnEnter: Bool,
         focusRequest: Int = 0,
         placement: ACPComposerPlacement = .bottom,
+        contentMaxWidth: CGFloat = ACPChatLayout.defaultContentMaxWidth,
         filesProvider: (@Sendable () async -> [URL])? = nil,
         onSubmit: @escaping ACPComposerSubmitHandler
     ) {
@@ -55,6 +57,7 @@ struct ACPComposer: View {
         self.sendOnEnter = sendOnEnter
         self.focusRequest = focusRequest
         self.placement = placement
+        self.contentMaxWidth = contentMaxWidth
         self.filesProvider = filesProvider
         self.onSubmit = onSubmit
     }
@@ -84,7 +87,7 @@ struct ACPComposer: View {
     private var composerRow: some View {
         HStack {
             Spacer(minLength: 0)
-            pill.frame(maxWidth: 720)
+            pill.frame(maxWidth: contentMaxWidth)
             Spacer(minLength: 0)
         }
         .padding(.horizontal, 24)

--- a/Alas/Sources/ACP/UI/ACPMarkdownLiveStyler.swift
+++ b/Alas/Sources/ACP/UI/ACPMarkdownLiveStyler.swift
@@ -13,25 +13,18 @@ enum ACPMarkdownLiveStyler {
     private static let italicUnder = try! NSRegularExpression(pattern: "(?<!_)_([^_\\n]+?)_(?!_)")
     private static let code = try! NSRegularExpression(pattern: "`([^`\\n]+?)`")
 
-    // Fonts cached once. Every restyle() call previously asked
-    // NSFontManager.shared for the italic variant — that's a global
-    // lock acquire per keystroke, and the two italic spellings shared
-    // the same lookup. baseFont/boldFont/codeFont were also being
-    // re-allocated per call.
-    private static let baseFont: NSFont = .systemFont(ofSize: 13)
-    private static let boldFont: NSFont = .boldSystemFont(ofSize: 13)
-    private static let codeFont: NSFont = .monospacedSystemFont(ofSize: 12, weight: .regular)
-    private static let italicFont: NSFont = {
-        let family = NSFont.systemFont(ofSize: 13).familyName ?? "System"
-        return NSFontManager.shared.font(withFamily: family, traits: .italicFontMask, weight: 5, size: 13)
-            ?? NSFont.systemFont(ofSize: 13)
-    }()
-
-    static func restyle(_ storage: NSTextStorage) {
-        restyle(storage, in: nil)
+    static func restyle(
+        _ storage: NSTextStorage,
+        typography: ACPChatTypography = .default
+    ) {
+        restyle(storage, in: nil, typography: typography)
     }
 
-    static func restyle(_ storage: NSTextStorage, in requestedRange: NSRange?) {
+    static func restyle(
+        _ storage: NSTextStorage,
+        in requestedRange: NSRange?,
+        typography: ACPChatTypography = .default
+    ) {
         guard storage.length > 0 else { return }
 
         // Restrict the styling work to the line(s) touched by the latest
@@ -54,6 +47,11 @@ enum ACPMarkdownLiveStyler {
 
         storage.beginEditing()
         defer { storage.endEditing() }
+
+        let baseFont = typography.appKitFont()
+        let boldFont = typography.appKitFont(traits: .boldFontMask)
+        let italicFont = typography.appKitFont(traits: .italicFontMask)
+        let codeFont = typography.appKitFont(size: typography.codeSize)
 
         // Reset to defaults — but preserve our chip attributes so existing
         // mention AND image chips don't get bulldozed (their `.attachment`

--- a/Alas/Sources/ACP/UI/ACPMarkdownText.swift
+++ b/Alas/Sources/ACP/UI/ACPMarkdownText.swift
@@ -13,6 +13,7 @@ import AppKit
 struct ACPMarkdownText: View {
     let raw: String
     var cache: ACPMarkdownBlockCache? = nil
+    var typography: ACPChatTypography = .default
     @Environment(\.theme) private var theme
 
     var body: some View {
@@ -37,13 +38,17 @@ struct ACPMarkdownText: View {
         switch block {
         case .heading(let level, let text):
             Text(ACPMarkdownText.inlineMarkdown(text))
-                .font(.system(size: headingSize(level), weight: .bold))
+                .font(typography.swiftUIFont(
+                    size: typography.headingSize(level: level),
+                    weight: .bold,
+                    traits: .boldFontMask
+                ))
                 .foregroundStyle(theme.color("fg"))
                 .textSelection(.enabled)
                 .padding(.top, level == 1 ? 4 : 2)
         case .paragraph(let text):
             Text(ACPMarkdownText.inlineMarkdown(text))
-                .font(.system(size: 13.5))
+                .font(typography.swiftUIFont(size: typography.paragraphSize))
                 .foregroundStyle(theme.color("fg"))
                 .lineSpacing(3)
                 .textSelection(.enabled)
@@ -54,14 +59,17 @@ struct ACPMarkdownText: View {
                     .fill(theme.color("accent").opacity(0.55))
                     .frame(width: 2)
                 Text(ACPMarkdownText.inlineMarkdown(text))
-                    .font(.system(size: 13).italic())
+                    .font(typography.swiftUIFont(
+                        size: typography.quoteSize,
+                        traits: .italicFontMask
+                    ))
                     .foregroundStyle(theme.color("fg-muted"))
                     .lineSpacing(2)
                     .textSelection(.enabled)
                 Spacer(minLength: 0)
             }
         case .code(let lang, let body):
-            CodeBlockView(language: lang, code: body)
+            CodeBlockView(language: lang, code: body, typography: typography)
         case .table(let header, let rows):
             tableView(header: header, rows: rows)
         }
@@ -91,7 +99,11 @@ struct ACPMarkdownText: View {
             ForEach(0..<columnCount, id: \.self) { i in
                 let value = i < cells.count ? cells[i] : ""
                 Text(ACPMarkdownText.inlineMarkdown(value))
-                    .font(.system(size: isHeader ? 11.5 : 12, weight: isHeader ? .semibold : .regular))
+                    .font(typography.swiftUIFont(
+                        size: isHeader ? typography.tableHeaderSize : typography.tableBodySize,
+                        weight: isHeader ? .semibold : .regular,
+                        traits: isHeader ? .boldFontMask : []
+                    ))
                     .foregroundStyle(isHeader ? theme.color("fg-muted") : theme.color("fg"))
                     .frame(minWidth: 80, alignment: .leading)
                     .padding(.horizontal, 10).padding(.vertical, 6)
@@ -101,15 +113,6 @@ struct ACPMarkdownText: View {
             }
         }
         .background(isHeader ? theme.color("bg-2").opacity(0.5) : Color.clear)
-    }
-
-    private func headingSize(_ level: Int) -> CGFloat {
-        switch level {
-        case 1: return 19
-        case 2: return 17
-        case 3: return 15
-        default: return 14
-        }
     }
 
     // MARK: - Inline memoization
@@ -289,6 +292,7 @@ struct ACPMarkdownText: View {
 private struct CodeBlockView: View {
     let language: String?
     let code: String
+    let typography: ACPChatTypography
     @Environment(\.theme) private var theme
     @State private var copied = false
 
@@ -299,7 +303,8 @@ private struct CodeBlockView: View {
                 ACPSyntaxHighlightedText(
                     text: code,
                     explicitLanguage: language,
-                    fontSize: 12
+                    fontFamily: typography.fontFamily,
+                    fontSize: typography.codeSize
                 )
                 .padding(.horizontal, 10).padding(.vertical, 8)
             }
@@ -314,7 +319,11 @@ private struct CodeBlockView: View {
         HStack(spacing: 8) {
             if let lang = language, !lang.isEmpty {
                 Text(lang)
-                    .font(.system(size: 10, weight: .semibold, design: .monospaced))
+                    .font(typography.swiftUIFont(
+                        size: typography.labelSize,
+                        weight: .semibold,
+                        traits: .boldFontMask
+                    ))
                     .tracking(0.4)
                     .textCase(.uppercase)
                     .foregroundStyle(theme.color("fg-faint"))
@@ -336,9 +345,9 @@ private struct CodeBlockView: View {
         Button(action: copy) {
             HStack(spacing: 4) {
                 Image(systemName: copied ? "checkmark" : "doc.on.doc")
-                    .font(.system(size: 10, weight: copied ? .bold : .regular))
+                    .font(.system(size: typography.labelSize, weight: copied ? .bold : .regular))
                 Text(copied ? "Copied" : "Copy")
-                    .font(.system(size: 10, weight: .medium))
+                    .font(.system(size: typography.labelSize, weight: .medium))
             }
             .foregroundStyle(copied ? theme.color("add") : theme.color("fg-muted"))
             .padding(.horizontal, 6).padding(.vertical, 2)

--- a/Alas/Sources/ACP/UI/ACPMessageList.swift
+++ b/Alas/Sources/ACP/UI/ACPMessageList.swift
@@ -4,6 +4,7 @@ import SwiftUI
 struct ACPMessageList: View {
     @ObservedObject var session: ACPSession
     @ObservedObject var transcript: ACPTranscript
+    let contentMaxWidth: CGFloat
     let onOpenDiff: (String) -> Void
     let policy: ACPPermissionPolicy?
     let scopeKey: String
@@ -138,6 +139,7 @@ struct ACPMessageList: View {
                             if Self.shouldRenderQueueBubble(status: item.status) {
                                 ACPQueuedBubble(
                                     item: item,
+                                    contentMaxWidth: contentMaxWidth,
                                     onForceSend: { onQueueForceSend(item.id) },
                                     onEdit: { onQueueEdit(item) },
                                     onRemove: { onQueueRemove(item.id) },
@@ -169,7 +171,7 @@ struct ACPMessageList: View {
                             .frame(height: composerSpacerHeight)
                             .id("__composer_spacer__")
                     }
-                    .frame(maxWidth: 720, alignment: .leading)
+                    .frame(maxWidth: contentMaxWidth, alignment: .leading)
                     .padding(.horizontal, 28 + ACPMessageGutterLayout.laneWidth)
                     .padding(.top, 24)
                     .frame(maxWidth: .infinity, alignment: .center)

--- a/Alas/Sources/ACP/UI/ACPMessageList.swift
+++ b/Alas/Sources/ACP/UI/ACPMessageList.swift
@@ -5,6 +5,7 @@ struct ACPMessageList: View {
     @ObservedObject var session: ACPSession
     @ObservedObject var transcript: ACPTranscript
     let contentMaxWidth: CGFloat
+    let typography: ACPChatTypography
     let onOpenDiff: (String) -> Void
     let policy: ACPPermissionPolicy?
     let scopeKey: String
@@ -140,6 +141,7 @@ struct ACPMessageList: View {
                                 ACPQueuedBubble(
                                     item: item,
                                     contentMaxWidth: contentMaxWidth,
+                                    typography: typography,
                                     onForceSend: { onQueueForceSend(item.id) },
                                     onEdit: { onQueueEdit(item) },
                                     onRemove: { onQueueRemove(item.id) },
@@ -479,11 +481,21 @@ struct ACPMessageList: View {
         switch m {
         case .user(_, let text, let attachments):
             ACPMessageGutter(markdown: { text }) {
-                UserMessageRow(text: text, attachments: attachments)
+                UserMessageRow(
+                    text: text,
+                    attachments: attachments,
+                    contentMaxWidth: contentMaxWidth,
+                    typography: typography
+                )
             }
         case .agent(let id, let buf):
             ACPMessageGutter(markdown: { buf.value }) {
-                AgentMessageRow(messageId: id.uuidString, transcript: transcript, buffer: buf)
+                AgentMessageRow(
+                    messageId: id.uuidString,
+                    transcript: transcript,
+                    buffer: buf,
+                    typography: typography
+                )
             }
         case .thought(_, let buf):
             ACPThoughtView(buffer: buf)
@@ -764,6 +776,8 @@ final class ACPDelayedHoverVisibility: ObservableObject {
 private struct UserMessageRow: View {
     let text: String
     let attachments: [ACPMessage.Attachment]
+    let contentMaxWidth: CGFloat
+    let typography: ACPChatTypography
     @Environment(\.theme) private var theme
     var body: some View {
         HStack {
@@ -792,7 +806,7 @@ private struct UserMessageRow: View {
                         }
                     }
                 }
-                ACPMarkdownText(raw: text)
+                ACPMarkdownText(raw: text, typography: typography)
                     .padding(.vertical, 9)
                     .padding(.horizontal, 13)
                     .background(
@@ -817,7 +831,7 @@ private struct UserMessageRow: View {
                     )
                     .shadow(color: .black.opacity(0.2), radius: 8, y: 2)
             }
-            .frame(maxWidth: 540, alignment: .trailing)
+            .frame(maxWidth: contentMaxWidth * 0.75, alignment: .trailing)
         }
         .frame(maxWidth: .infinity)
     }
@@ -829,8 +843,13 @@ private struct AgentMessageRow: View {
     let messageId: String
     let transcript: ACPTranscript
     @ObservedObject var buffer: StreamingText
+    let typography: ACPChatTypography
     var body: some View {
-        ACPMarkdownText(raw: buffer.value, cache: transcript.markdownCache(forMessage: messageId))
+        ACPMarkdownText(
+            raw: buffer.value,
+            cache: transcript.markdownCache(forMessage: messageId),
+            typography: typography
+        )
             .frame(maxWidth: .infinity, alignment: .leading)
     }
 }

--- a/Alas/Sources/ACP/UI/ACPPlanSidebar.swift
+++ b/Alas/Sources/ACP/UI/ACPPlanSidebar.swift
@@ -12,6 +12,8 @@ import SwiftUI
 ///
 /// Spec: `docs/superpowers/specs/2026-05-29-acp-plan-sidebar-design.md` (§3)
 struct ACPPlanSidebar: View {
+    static let width: CGFloat = 320
+
     @ObservedObject var transcript: ACPTranscript
     let onMinimize: () -> Void
     @Environment(\.theme) private var theme
@@ -36,7 +38,7 @@ struct ACPPlanSidebar: View {
                 Color.clear.frame(height: 1)
             }
         }
-        .frame(width: 320)
+        .frame(width: Self.width)
         .frame(maxHeight: .infinity)
         .accessibilityElement(children: .contain)
         .accessibilityLabel(accessibilityLabel(for: items))

--- a/Alas/Sources/ACP/UI/ACPQueuedBubble.swift
+++ b/Alas/Sources/ACP/UI/ACPQueuedBubble.swift
@@ -9,6 +9,7 @@ import SwiftUI
 struct ACPQueuedBubble: View {
     let item: QueuedPrompt
     let contentMaxWidth: CGFloat
+    let typography: ACPChatTypography
     let onForceSend: () -> Void
     let onEdit: () -> Void
     let onRemove: () -> Void
@@ -94,7 +95,7 @@ struct ACPQueuedBubble: View {
     }
 
     private func textBubble(_ preview: String) -> some View {
-        ACPMarkdownText(raw: preview)
+        ACPMarkdownText(raw: preview, typography: typography)
             .padding(.vertical, 9).padding(.horizontal, 13)
             .background(theme.color("accent").opacity(0.10))
             .clipShape(

--- a/Alas/Sources/ACP/UI/ACPQueuedBubble.swift
+++ b/Alas/Sources/ACP/UI/ACPQueuedBubble.swift
@@ -8,6 +8,7 @@ import SwiftUI
 /// lose those affordances and gain a spinner-edged border.
 struct ACPQueuedBubble: View {
     let item: QueuedPrompt
+    let contentMaxWidth: CGFloat
     let onForceSend: () -> Void
     let onEdit: () -> Void
     let onRemove: () -> Void
@@ -160,9 +161,10 @@ struct ACPQueuedBubble: View {
     }
 
     private var contentColumnMaxWidth: CGFloat {
-        item.status == .pending
-            ? 540 + ACPQueuedBubbleActionMetrics.reservedAccessoryWidth
-            : 540
+        let bubbleMaxWidth = contentMaxWidth * 0.75
+        return item.status == .pending
+            ? bubbleMaxWidth + ACPQueuedBubbleActionMetrics.reservedAccessoryWidth
+            : bubbleMaxWidth
     }
 
     private func actionButton(

--- a/Alas/Sources/ACP/UI/ACPSyntaxHighlightedText.swift
+++ b/Alas/Sources/ACP/UI/ACPSyntaxHighlightedText.swift
@@ -5,12 +5,20 @@ struct ACPSyntaxHighlightCacheKey: Equatable {
     let text: String
     let resolvedExtension: String?
     let themeKey: String
+    let fontFamily: String
     let fontSize: CGFloat
 
-    init(text: String, resolvedExtension: String?, theme: Theme, fontSize: CGFloat) {
+    init(
+        text: String,
+        resolvedExtension: String?,
+        theme: Theme,
+        fontFamily: String = ACPChatTypography.default.fontFamily,
+        fontSize: CGFloat
+    ) {
         self.text = text
         self.resolvedExtension = resolvedExtension
         self.themeKey = Self.themeKey(theme)
+        self.fontFamily = fontFamily
         self.fontSize = fontSize
     }
 
@@ -51,6 +59,7 @@ private final class ACPSyntaxHighlightedTextCache: ObservableObject {
         explicitLanguage: String?,
         sourcePath: String?,
         theme: Theme,
+        fontFamily: String,
         fontSize: CGFloat
     ) -> AttributedString {
         let resolvedExtension = explicitLanguage.flatMap(ACPCodeLanguage.highlighterExtension(for:))
@@ -59,6 +68,7 @@ private final class ACPSyntaxHighlightedTextCache: ObservableObject {
             text: text,
             resolvedExtension: resolvedExtension,
             theme: theme,
+            fontFamily: fontFamily,
             fontSize: fontSize
         )
         if key == nextKey, let value {
@@ -69,6 +79,7 @@ private final class ACPSyntaxHighlightedTextCache: ObservableObject {
             code: text,
             language: resolvedExtension,
             theme: theme,
+            fontFamily: fontFamily,
             fontSize: fontSize
         ))
         key = nextKey
@@ -81,6 +92,7 @@ struct ACPSyntaxHighlightedText: View {
     let text: String
     var explicitLanguage: String? = nil
     var sourcePath: String? = nil
+    var fontFamily: String = ACPChatTypography.default.fontFamily
     var fontSize: CGFloat = 12
     var lineSpacing: CGFloat = 2
 
@@ -93,9 +105,10 @@ struct ACPSyntaxHighlightedText: View {
             explicitLanguage: explicitLanguage,
             sourcePath: sourcePath,
             theme: theme,
+            fontFamily: fontFamily,
             fontSize: fontSize
         ))
-        .font(.system(size: fontSize, design: .monospaced))
+        .font(Font(CenterTypography.resolveCodeFont(family: fontFamily, size: fontSize)))
         .foregroundStyle(theme.color("fg"))
         .lineSpacing(lineSpacing)
         .textSelection(.enabled)

--- a/Alas/Sources/ACP/UI/ACPTabView.swift
+++ b/Alas/Sources/ACP/UI/ACPTabView.swift
@@ -205,13 +205,17 @@ private struct ACPSessionView: View {
 
     private var transcriptAndComposer: some View {
         GeometryReader { proxy in
+            let chatColumnWidth = ACPChatLayout.chatColumnWidth(
+                forPaneWidth: proxy.size.width,
+                planSidebarVisible: showPlanSidebar
+            )
             let chatContentMaxWidth = ACPChatLayout.contentMaxWidth(
-                forPaneWidth: proxy.size.width
+                forPaneWidth: chatColumnWidth
             )
             HStack(spacing: 0) {
                 ZStack(alignment: .bottom) {
                     if let phase = firstRunConnectingPhase {
-                        introStateAndComposer {
+                        introStateAndComposer(contentMaxWidth: chatContentMaxWidth) {
                             ACPFirstRunConnectingView(
                                 agentDisplayName: state.agent(id: session.agentId)?.displayName ?? session.agentId,
                                 phase: phase,
@@ -219,7 +223,7 @@ private struct ACPSessionView: View {
                             )
                         }
                     } else if isNewEmptySession {
-                        introStateAndComposer {
+                        introStateAndComposer(contentMaxWidth: chatContentMaxWidth) {
                             ACPNewChatEmptyStateView(
                                 agentDisplayName: state.agent(id: session.agentId)?.displayName ?? session.agentId,
                                 bottomInset: 0,
@@ -365,12 +369,17 @@ private struct ACPSessionView: View {
     }
 
     private func introStateAndComposer<Intro: View>(
+        contentMaxWidth: CGFloat,
         @ViewBuilder intro: () -> Intro
     ) -> some View {
         VStack(spacing: 0) {
             intro()
                 .frame(maxWidth: .infinity, maxHeight: .infinity)
-            composerView(placement: .inFlow)
+            composerView(
+                placement: .inFlow,
+                contentMaxWidth: contentMaxWidth,
+                typography: chatTypography
+            )
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
     }

--- a/Alas/Sources/ACP/UI/ACPTabView.swift
+++ b/Alas/Sources/ACP/UI/ACPTabView.swift
@@ -196,6 +196,13 @@ private struct ACPSessionView: View {
         .spring(response: 0.32, dampingFraction: 0.86)
     }
 
+    private var chatTypography: ACPChatTypography {
+        ACPChatTypography(
+            fontFamily: state.config.agents.chatFontFamily,
+            fontSize: state.config.agents.chatFontSize
+        )
+    }
+
     private var transcriptAndComposer: some View {
         GeometryReader { proxy in
             let chatContentMaxWidth = ACPChatLayout.contentMaxWidth(
@@ -232,6 +239,7 @@ private struct ACPSessionView: View {
                                 session: session,
                                 transcript: session.transcript,
                                 contentMaxWidth: chatContentMaxWidth,
+                                typography: chatTypography,
                                 onOpenDiff: { relativePath in
                                     state.openDiffTab(forFileInWorktree: worktree, relativePath: relativePath)
                                 },
@@ -306,7 +314,8 @@ private struct ACPSessionView: View {
 
                         composerView(
                             placement: composerPlacement,
-                            contentMaxWidth: chatContentMaxWidth
+                            contentMaxWidth: chatContentMaxWidth,
+                            typography: chatTypography
                         )
 
                         if let undo = session.steerUndo, !undo.snapshot.isEmpty {
@@ -368,7 +377,8 @@ private struct ACPSessionView: View {
 
     private func composerView(
         placement: ACPComposerPlacement,
-        contentMaxWidth: CGFloat = ACPChatLayout.defaultContentMaxWidth
+        contentMaxWidth: CGFloat = ACPChatLayout.defaultContentMaxWidth,
+        typography: ACPChatTypography? = nil
     ) -> some View {
         ACPComposer(
             session: session,
@@ -379,6 +389,7 @@ private struct ACPSessionView: View {
             focusRequest: composerFocusRequest,
             placement: placement,
             contentMaxWidth: contentMaxWidth,
+            typography: typography ?? chatTypography,
             filesProvider: { [state, worktree] in
                 await state.fileIndex.invalidate(forWorktreePath: worktree.path)
                 async let entries = try? state.fileIndex.entries(forWorktreePath: worktree.path)

--- a/Alas/Sources/ACP/UI/ACPTabView.swift
+++ b/Alas/Sources/ACP/UI/ACPTabView.swift
@@ -198,6 +198,9 @@ private struct ACPSessionView: View {
 
     private var transcriptAndComposer: some View {
         GeometryReader { proxy in
+            let chatContentMaxWidth = ACPChatLayout.contentMaxWidth(
+                forPaneWidth: proxy.size.width
+            )
             HStack(spacing: 0) {
                 ZStack(alignment: .bottom) {
                     if let phase = firstRunConnectingPhase {
@@ -228,6 +231,7 @@ private struct ACPSessionView: View {
                             ACPMessageList(
                                 session: session,
                                 transcript: session.transcript,
+                                contentMaxWidth: chatContentMaxWidth,
                                 onOpenDiff: { relativePath in
                                     state.openDiffTab(forFileInWorktree: worktree, relativePath: relativePath)
                                 },
@@ -300,7 +304,10 @@ private struct ACPSessionView: View {
                             .transition(.opacity)
                         }
 
-                        composerView(placement: composerPlacement)
+                        composerView(
+                            placement: composerPlacement,
+                            contentMaxWidth: chatContentMaxWidth
+                        )
 
                         if let undo = session.steerUndo, !undo.snapshot.isEmpty {
                             VStack {
@@ -359,7 +366,10 @@ private struct ACPSessionView: View {
         .frame(maxWidth: .infinity, maxHeight: .infinity)
     }
 
-    private func composerView(placement: ACPComposerPlacement) -> some View {
+    private func composerView(
+        placement: ACPComposerPlacement,
+        contentMaxWidth: CGFloat = ACPChatLayout.defaultContentMaxWidth
+    ) -> some View {
         ACPComposer(
             session: session,
             manager: manager,
@@ -368,6 +378,7 @@ private struct ACPSessionView: View {
             sendOnEnter: state.config.harness.acpSendOnEnter,
             focusRequest: composerFocusRequest,
             placement: placement,
+            contentMaxWidth: contentMaxWidth,
             filesProvider: { [state, worktree] in
                 await state.fileIndex.invalidate(forWorktreePath: worktree.path)
                 async let entries = try? state.fileIndex.entries(forWorktreePath: worktree.path)

--- a/Alas/Sources/Center/CenterTypography.swift
+++ b/Alas/Sources/Center/CenterTypography.swift
@@ -27,28 +27,44 @@ enum CenterTypography {
         guard !family.isEmpty else {
             return .monospacedSystemFont(ofSize: size, weight: .regular)
         }
+        let fixedFontNames = Set(NSFontManager.shared.availableFontNames(with: .fixedPitchFontMask) ?? [])
+
+        func fixedPitchFont(named name: String) -> NSFont? {
+            guard fixedFontNames.contains(name),
+                  let font = NSFont(name: name, size: size),
+                  font.isFixedPitch
+            else { return nil }
+            return font
+        }
+
         // The picker stores family names (e.g. "JetBrains Mono"), but
         // NSFont(name:size:) requires the PostScript name of a specific
         // face ("JetBrainsMono-Regular"). Walk the family's members and
         // pick the face closest to regular weight (NSFontManager weight 5).
         let members = NSFontManager.shared.availableMembers(ofFontFamily: family) ?? []
         if !members.isEmpty {
-            let sorted = members.sorted { lhs, rhs in
+            let fixedMembers = members.filter { row in
+                guard let psName = row.first as? String else { return false }
+                return fixedFontNames.contains(psName)
+            }
+            let sorted = fixedMembers.sorted { lhs, rhs in
                 let lw = (lhs.count > 2 ? lhs[2] as? Int : nil) ?? 5
                 let rw = (rhs.count > 2 ? rhs[2] as? Int : nil) ?? 5
                 return abs(lw - 5) < abs(rw - 5)
             }
             if let psName = sorted.first?.first as? String,
-               let font = NSFont(name: psName, size: size) {
+               let font = fixedPitchFont(named: psName) {
                 return font
             }
         }
         if let font = NSFont(name: family, size: size),
+           font.isFixedPitch,
            font.familyName == family || font.fontName == family {
             return font
         }
         let descriptor = NSFontDescriptor(fontAttributes: [.family: family])
         if let font = NSFont(descriptor: descriptor, size: size),
+           font.isFixedPitch,
            font.familyName == family {
             return font
         }

--- a/Alas/Sources/Persistence/AppConfig.swift
+++ b/Alas/Sources/Persistence/AppConfig.swift
@@ -326,9 +326,12 @@ struct AppConfig: Codable, Equatable {
         /// segmented control inside the launcher; this just picks the
         /// starting mode.
         var defaultLauncherMode: LauncherMode
+        var chatFontFamily: String
+        var chatFontSize: Int
 
         enum CodingKeys: String, CodingKey {
-            case builtinState, custom, worktreeAutoLaunch, defaultLauncherMode
+            case builtinState, custom, worktreeAutoLaunch, defaultLauncherMode,
+                 chatFontFamily, chatFontSize
         }
     }
 
@@ -432,7 +435,9 @@ struct AppConfig: Codable, Equatable {
                 agentId: nil,
                 useBypassPermissions: false
             ),
-            defaultLauncherMode: .terminal
+            defaultLauncherMode: .terminal,
+            chatFontFamily: "JetBrainsMono Nerd Font",
+            chatFontSize: 13
         ),
         files: Files(showIgnored: true),
         recentProjectIds: [],
@@ -680,11 +685,20 @@ extension AppConfig {
             let defaultMode = (try? agentsContainer.decode(
                 LauncherMode.self, forKey: .defaultLauncherMode
             )) ?? .terminal
+            let chatFontFamily = (try? agentsContainer.decode(
+                String.self, forKey: .chatFontFamily
+            )) ?? "JetBrainsMono Nerd Font"
+            let rawChatFontSize = (try? agentsContainer.decode(
+                Int.self, forKey: .chatFontSize
+            )) ?? 13
+            let chatFontSize = max(8, min(64, rawChatFontSize))
             agents = Agents(
                 builtinState: state,
                 custom: custom,
                 worktreeAutoLaunch: autoLaunch,
-                defaultLauncherMode: defaultMode
+                defaultLauncherMode: defaultMode,
+                chatFontFamily: chatFontFamily,
+                chatFontSize: chatFontSize
             )
         } else {
             agents = Agents(
@@ -693,7 +707,9 @@ extension AppConfig {
                 worktreeAutoLaunch: WorktreeAutoLaunch(
                     agentId: nil, useBypassPermissions: false
                 ),
-                defaultLauncherMode: .terminal
+                defaultLauncherMode: .terminal,
+                chatFontFamily: "JetBrainsMono Nerd Font",
+                chatFontSize: 13
             )
         }
         if let filesContainer = try? c.nestedContainer(

--- a/Alas/Sources/Settings/AgentsPane.swift
+++ b/Alas/Sources/Settings/AgentsPane.swift
@@ -69,6 +69,22 @@ struct AgentsPane: View {
                 }
 
                 SettingsGroup(title: "Chat") {
+                    SettingsRow(name: "Font family") {
+                        FontFamilyPicker(
+                            family: state.bind(\.agents.chatFontFamily),
+                            catalog: MonospaceFontCatalog.families()
+                        )
+                    }
+                    SettingsRow(name: "Font size") {
+                        AlasField(text: Binding(
+                            get: { String(state.config.agents.chatFontSize) },
+                            set: {
+                                let raw = Int($0) ?? 13
+                                state.config.agents.chatFontSize = max(8, min(64, raw))
+                                state.saveConfig()
+                            }
+                        ), monospaced: true).frame(width: 80)
+                    }
                     SettingsRow(name: "While busy, ⏎ queues; ⌥⏎ steers",
                                 desc: "Turn off to swap — ⏎ steers and ⌥⏎ queues. Steering cancels the running turn and discards any pending queue items.") {
                         AlasToggle(on: Binding(

--- a/AlasTests/ACP/UI/ACPChatLayoutTests.swift
+++ b/AlasTests/ACP/UI/ACPChatLayoutTests.swift
@@ -1,0 +1,22 @@
+import Testing
+@testable import Alas
+
+@Suite("ACP chat layout")
+struct ACPChatLayoutTests {
+    @Test func keepsCurrentWidthForNormalPanes() {
+        #expect(ACPChatLayout.contentMaxWidth(forPaneWidth: 900) == 720)
+        #expect(ACPChatLayout.contentMaxWidth(forPaneWidth: 1_080) == 720)
+    }
+
+    @Test func growsOnWidePanes() {
+        let width = ACPChatLayout.contentMaxWidth(forPaneWidth: 1_200)
+
+        #expect(width > 720)
+        #expect(width < 960)
+    }
+
+    @Test func capsOnUltrawidePanes() {
+        #expect(ACPChatLayout.contentMaxWidth(forPaneWidth: 1_600) == 960)
+        #expect(ACPChatLayout.contentMaxWidth(forPaneWidth: 3_000) == 960)
+    }
+}

--- a/AlasTests/ACP/UI/ACPChatLayoutTests.swift
+++ b/AlasTests/ACP/UI/ACPChatLayoutTests.swift
@@ -19,4 +19,20 @@ struct ACPChatLayoutTests {
         #expect(ACPChatLayout.contentMaxWidth(forPaneWidth: 1_600) == 960)
         #expect(ACPChatLayout.contentMaxWidth(forPaneWidth: 3_000) == 960)
     }
+
+    @Test func planSidebarReducesEffectiveChatColumnWidth() {
+        #expect(ACPChatLayout.chatColumnWidth(
+            forPaneWidth: 1_200,
+            planSidebarVisible: true
+        ) == 880)
+    }
+
+    @Test func planSidebarKeepsMediumPanesAtCurrentChatWidth() {
+        let chatColumnWidth = ACPChatLayout.chatColumnWidth(
+            forPaneWidth: 1_200,
+            planSidebarVisible: true
+        )
+
+        #expect(ACPChatLayout.contentMaxWidth(forPaneWidth: chatColumnWidth) == 720)
+    }
 }

--- a/AlasTests/ACP/UI/ACPChatTypographyTests.swift
+++ b/AlasTests/ACP/UI/ACPChatTypographyTests.swift
@@ -1,0 +1,32 @@
+import Testing
+@testable import Alas
+
+@Suite("ACP chat typography")
+struct ACPChatTypographyTests {
+    @Test func clampsBaseSize() {
+        #expect(ACPChatTypography(fontFamily: "", fontSize: 2).baseSize == 8)
+        #expect(ACPChatTypography(fontFamily: "", fontSize: 200).baseSize == 64)
+    }
+
+    @Test func derivesReadableSizesFromBaseSize() {
+        let typography = ACPChatTypography(fontFamily: "SF Mono", fontSize: 14)
+
+        #expect(typography.baseSize == 14)
+        #expect(typography.paragraphSize == 14.5)
+        #expect(typography.quoteSize == 14)
+        #expect(typography.codeSize == 13)
+        #expect(typography.tableBodySize == 13)
+        #expect(typography.tableHeaderSize == 12.5)
+        #expect(typography.labelSize == 11)
+    }
+
+    @Test func derivesHeadingSizesFromBaseSize() {
+        let typography = ACPChatTypography(fontFamily: "SF Mono", fontSize: 13)
+
+        #expect(typography.headingSize(level: 1) == 19)
+        #expect(typography.headingSize(level: 2) == 17)
+        #expect(typography.headingSize(level: 3) == 15)
+        #expect(typography.headingSize(level: 4) == 14)
+        #expect(typography.headingSize(level: 99) == 14)
+    }
+}

--- a/AlasTests/AppConfigAgentsCodingTests.swift
+++ b/AlasTests/AppConfigAgentsCodingTests.swift
@@ -10,6 +10,11 @@ struct AppConfigAgentsCodingTests {
         #expect(AppConfig.defaults.agents.worktreeAutoLaunch.useBypassPermissions == false)
     }
 
+    @Test func defaultsHaveChatAppearance() {
+        #expect(AppConfig.defaults.agents.chatFontFamily == "JetBrainsMono Nerd Font")
+        #expect(AppConfig.defaults.agents.chatFontSize == 13)
+    }
+
     @Test func decodesLegacyConfigWithoutAgentsKey() throws {
         let json = """
         {
@@ -127,5 +132,68 @@ struct AppConfigAgentsCodingTests {
         #expect(cfg.agents.custom.isEmpty)
         #expect(cfg.agents.worktreeAutoLaunch.agentId == nil)
         #expect(cfg.agents.worktreeAutoLaunch.useBypassPermissions == false)
+    }
+
+    @Test func decodesPartialAgentsBlockWithMissingChatAppearance() throws {
+        let json = """
+        {
+          "themeId": "cool-slate",
+          "accent": "teal",
+          "matchSystemTheme": false,
+          "sidebarWidth": 244,
+          "rightPaneWidth": 320,
+          "rightPaneVisible": true,
+          "general": {
+            "launchAtLogin": false, "closeToTray": true, "confirmQuit": true,
+            "autoUpdate": true, "updateChannel": "Stable",
+            "crashReports": false, "usageAnalytics": false
+          },
+          "worktrees": {
+            "rootPath": "~/.alas/worktrees",
+            "pathTemplate": "{worktreeRoot}/{repo}/{branch}",
+            "branchPrefix": "feature/", "baseBranch": "main",
+            "trackUpstream": true, "deleteBranchOnRemove": true,
+            "autoFetch": true, "fetchIntervalMinutes": 5, "pruneStale": false
+          },
+          "terminal": {
+            "shell": "/bin/zsh", "workingDirectory": "worktreeRoot",
+            "startupScript": "", "worktreeCreateScript": "",
+            "inheritParentEnv": true, "fontFamily": "JetBrains Mono",
+            "fontSize": 13, "cursorStyle": "beam", "cursorBlink": true,
+            "scrollbackLines": 10000, "bell": "visual"
+          },
+          "harness": {"notifyOnFinish": true, "notifyOnAwaiting": true},
+          "agents": {}
+        }
+        """
+        let cfg = try JSONDecoder().decode(AppConfig.self, from: Data(json.utf8))
+        #expect(cfg.agents.chatFontFamily == "JetBrainsMono Nerd Font")
+        #expect(cfg.agents.chatFontSize == 13)
+    }
+
+    @Test func decodesChatFontSizeWithClamp() throws {
+        var low = AppConfig.defaults
+        low.agents.chatFontSize = 2
+        let lowData = try JSONEncoder().encode(low)
+        let lowDecoded = try JSONDecoder().decode(AppConfig.self, from: lowData)
+        #expect(lowDecoded.agents.chatFontSize == 8)
+
+        var high = AppConfig.defaults
+        high.agents.chatFontSize = 200
+        let highData = try JSONEncoder().encode(high)
+        let highDecoded = try JSONDecoder().decode(AppConfig.self, from: highData)
+        #expect(highDecoded.agents.chatFontSize == 64)
+    }
+
+    @Test func roundTripsChatAppearance() throws {
+        var cfg = AppConfig.defaults
+        cfg.agents.chatFontFamily = "SF Mono"
+        cfg.agents.chatFontSize = 16
+
+        let data = try JSONEncoder().encode(cfg)
+        let decoded = try JSONDecoder().decode(AppConfig.self, from: data)
+
+        #expect(decoded.agents.chatFontFamily == "SF Mono")
+        #expect(decoded.agents.chatFontSize == 16)
     }
 }

--- a/docs/superpowers/specs/2026-06-10-acp-chat-wide-layout-and-fonts-design.md
+++ b/docs/superpowers/specs/2026-06-10-acp-chat-wide-layout-and-fonts-design.md
@@ -1,0 +1,139 @@
+# ACP Chat Wide Layout and Fonts Design
+
+## Summary
+
+Improve the central ACP chat pane on wide monitors without changing the current
+small-screen experience. The transcript and composer should reclaim some unused
+horizontal space, but remain bounded so prose stays readable. Add chat-specific
+font family and font size settings under Settings > Agents > Chat, matching the
+terminal and editor preference model.
+
+## Goals
+
+- Keep existing small and medium pane behavior visually unchanged.
+- Expand the ACP transcript and composer on wide panes from the current `720 pt`
+  reading column to a `960 pt` maximum.
+- Keep the inline plan sidebar independent from the chat column width.
+- Let users configure ACP chat font family and base font size from
+  Settings > Agents > Chat.
+- Apply chat typography consistently across ACP prose, user messages, queued
+  previews, tables, quotes, headings, fenced code blocks, and composer input.
+
+## Non-Goals
+
+- No user-facing chat width setting in this pass.
+- No changes to terminal or code editor font settings.
+- No redesign of ACP message row styling, composer controls, or plan sidebar
+  visibility rules.
+- No change to mobile/remote chat surfaces.
+
+## Layout
+
+The current ACP chat content is capped at `720 pt` in both `ACPMessageList` and
+`ACPComposer`. Replace those independent constants with a shared pure layout
+calculation.
+
+The calculation should:
+
+- Return `720 pt` for panes that cannot comfortably fit more.
+- Grow only after the center pane is clearly wide enough.
+- Cap at `960 pt`.
+- Preserve existing horizontal padding and gutter behavior.
+- Be easy to unit test without SwiftUI rendering.
+
+The resulting max width is applied to:
+
+- The transcript content stack in `ACPMessageList`.
+- The composer pill in `ACPComposer`.
+- Any ACP row whose internal width currently assumes the old `720 pt` column
+  and would otherwise look inconsistent inside the wider column.
+
+User message bubbles should still be constrained within the chat column rather
+than stretching to the full pane. Code blocks and tables may use the wider
+column, because horizontal content benefits from the extra room.
+
+The existing `ACPPlanSidebar` remains a separate `320 pt` column controlled by
+`ACPPlanSidebarVisibility`. The chat width calculation should use the width
+available to the chat side after the sidebar is laid out by the existing
+`HStack`, not try to account for the sidebar itself.
+
+## Chat Typography Settings
+
+Add chat appearance fields to `AppConfig.Agents`, because the UI location is
+Settings > Agents > Chat and these settings are specific to ACP chat rather
+than terminal harness behavior:
+
+- `chatFontFamily: String`, default `"JetBrainsMono Nerd Font"`.
+- `chatFontSize: Int`, default `13`, clamped to `[8, 64]` during decode and
+  writes.
+
+Settings > Agents > Chat should add:
+
+- `Font family`, using the existing `FontFamilyPicker` and
+  `MonospaceFontCatalog.families()`.
+- `Font size`, using the same numeric `AlasField` pattern as Terminal and Code.
+
+ACP views should receive a small value object, for example `ACPChatTypography`,
+with the resolved family and base size. It should expose derived sizes for:
+
+- paragraph text
+- headings
+- quotes
+- table cells and headers
+- fenced code
+- small labels such as code block headers and copy controls where appropriate
+
+This keeps current relative sizing intact while making the base preference
+effective. The initial mapping should preserve the current defaults when
+`chatFontSize == 13`.
+
+## Data Flow
+
+`ACPSessionView` reads `state.config.agents.chatFontFamily` and
+`state.config.agents.chatFontSize`, builds the typography value, and passes it
+to the transcript and composer subtree.
+
+`ACPMarkdownText` should accept typography explicitly rather than reading
+`AppState`, so it remains reusable and testable. Call sites in:
+
+- `ACPMessageList`
+- `ACPQueuedBubble`
+- `ACPMarkdownText.CodeBlockView`
+
+should thread the same typography value through nested markdown/code views.
+
+The composer input field should use the same base chat font. If the AppKit field
+needs an additional initializer or binding for font injection, that plumbing is
+part of this change.
+
+## Compatibility
+
+Older config files that lack the new agent fields must decode with defaults.
+Encoding should include the new fields once saved.
+
+The new width logic should not move small panes, because existing users already
+have a good layout there. The cap should prevent very wide line lengths on
+ultrawide displays.
+
+## Testing
+
+Add Swift Testing coverage for:
+
+- `AppConfig` default chat font values.
+- Backward-compatible decode when `agents` lacks chat font fields.
+- Font size clamping on decode.
+- The pure ACP chat width calculation at narrow, current, wide, and ultrawide
+  pane widths.
+
+Run the standard verification before finishing implementation:
+
+```bash
+xcodegen
+xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -quiet build
+xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' test
+```
+
+## Open Decisions
+
+None. The approved layout direction is the moderate adaptive cap: grow from
+`720 pt` to a `960 pt` maximum, without adding a separate width setting.


### PR DESCRIPTION
## Summary
- Expand the ACP chat transcript/composer width adaptively on wide panes, capped at a readable 960pt.
- Add persisted chat font family and font size settings under Settings > Agents > Chat.
- Apply the configured chat typography through markdown, code blocks, queued prompts, and composer input.

## Test Plan
- `xcodegen`
- `xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -quiet build`
- `xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -only-testing:AlasTests/ACPChatTypographyTests -only-testing:AlasTests/ACPCodeBlockHighlighterTests -only-testing:AlasTests/ACPComposerDraftBridgeTests test`

## Notes
- Full local `xcodebuild ... test` was attempted, but it reproducibly stalled in the pre-existing `ACPSessionTerminalRoutingTests` terminal/create test, including when that suite was run in isolation.