### PR TITLE
feat(acp): linkify bare ACP transcript URLs

### DIFF
--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -895,6 +895,7 @@
 		E6CB573877637461E11CACAF /* InstallRecipe.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F80EA8C6EFF2C0A8F02C62D /* InstallRecipe.swift */; };
 		E6F317EB2FF5522C77B30B62 /* ACPMarkdownText.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE2AC16E9220C05F670BE3EB /* ACPMarkdownText.swift */; };
 		E703B4895A0337310A17FED6 /* GitService+ImageDiff.swift in Sources */ = {isa = PBXBuildFile; fileRef = A8EFC853C0D2EB4AC2B01D9E /* GitService+ImageDiff.swift */; };
+		E71191CF46FA3E7BC2C4A91E /* ACPBareURLLinkifierTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F59AAA1AFFBA04A837BCBA13 /* ACPBareURLLinkifierTests.swift */; };
 		E77C416471C1AAADF35EE085 /* MemorySnapshot.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BCE20FA56461E66A58A7AA2 /* MemorySnapshot.swift */; };
 		E7C047F37A5C7100149FED4A /* ImageDiffPairResolverTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 76942B028C3CBAED16BC4CC1 /* ImageDiffPairResolverTests.swift */; };
 		E822ADCC0B35087C38FB01A3 /* TabsManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D6A9977C979705A40595FD5E /* TabsManagerTests.swift */; };
@@ -1889,6 +1890,7 @@
 		F332906E17C5865856DBB90B /* ACPSessionRunner.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPSessionRunner.swift; sourceTree = "<group>"; };
 		F3678A2904CBBFAC939C9275 /* SettingsGroup.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsGroup.swift; sourceTree = "<group>"; };
 		F3AB3D6DF4A23648F0C45AC5 /* GitServiceCommitEditingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GitServiceCommitEditingTests.swift; sourceTree = "<group>"; };
+		F59AAA1AFFBA04A837BCBA13 /* ACPBareURLLinkifierTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPBareURLLinkifierTests.swift; sourceTree = "<group>"; };
 		F5C6A07D7C67D02C8638D8C1 /* LSPMessages.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LSPMessages.swift; sourceTree = "<group>"; };
 		F61EB45499D244E44EB170BC /* MergeBulkResolvePromptEditorWindow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MergeBulkResolvePromptEditorWindow.swift; sourceTree = "<group>"; };
 		F6883364648BF4B9F5DA131F /* EditorOverlayPanel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditorOverlayPanel.swift; sourceTree = "<group>"; };
@@ -3176,6 +3178,7 @@
 			isa = PBXGroup;
 			children = (
 				AD85FA11903B85EA889596A3 /* ACPAttachmentMimeTypeTests.swift */,
+				F59AAA1AFFBA04A837BCBA13 /* ACPBareURLLinkifierTests.swift */,
 				2CFB62547E5E1FD480BD0322 /* ACPChangeNotifierTests.swift */,
 				239125BB939233233D405EB8 /* ACPChipStateTests.swift */,
 				D1B15CAE2163ED7C1A670F46 /* ACPComposerDraftTests.swift */,
@@ -4428,6 +4431,7 @@
 				B339F5B376407CFD88B0E7B8 /* ACPAttachmentMimeTypeTests.swift in Sources */,
 				D95A7FAF0B955642ED9D7521 /* ACPAuthFailureTests.swift in Sources */,
 				4151B68B1CF0A947AEC4C00A /* ACPAuthNudgeBannerTests.swift in Sources */,
+				E71191CF46FA3E7BC2C4A91E /* ACPBareURLLinkifierTests.swift in Sources */,
 				AC2EA26D999115E66DF40142 /* ACPChangeNotifierTests.swift in Sources */,
 				5E5600E6451068BCBF732ABD /* ACPChipStateTests.swift in Sources */,
 				238BBB5FC59949CE6ABAFBEF /* ACPCodeBlockHighlighterTests.swift in Sources */,

--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -31,6 +31,7 @@
 		065F01BB553C415040414D37 /* ImageDiffSwipeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 802EF6C18E2E27F68F6B770E /* ImageDiffSwipeView.swift */; };
 		065F1A7FCF81FF29BAEF5A86 /* ScopeRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4D131C3F1E4BE68A850097A4 /* ScopeRow.swift */; };
 		06AD46194E45984A1297D928 /* CommitHeaderViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E43F9F04AF6A6FF0A4D328F4 /* CommitHeaderViewTests.swift */; };
+		0722316C2ADB93575221246D /* ACPBareURLLinkifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = B2F3473392B284B69E6621DB /* ACPBareURLLinkifier.swift */; };
 		07385C7266A0694AB7F4E872 /* AppStateSpacesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EFDB90A7F9E58F4C1A258D23 /* AppStateSpacesTests.swift */; };
 		07BB2B329992BA535053BB80 /* ACPSetupNudgeBannerModeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0AB6FA9F258818E8B464CB0A /* ACPSetupNudgeBannerModeTests.swift */; };
 		082582F4BBA9DCFF0EAB9588 /* OperationCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4941BFBEEEAF9DE9E1752548 /* OperationCard.swift */; };
@@ -1629,6 +1630,7 @@
 		B24ABE96ED3C62146A3CED62 /* EmptyState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EmptyState.swift; sourceTree = "<group>"; };
 		B27595490B7D883CF5D9FFD5 /* Tab.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Tab.swift; sourceTree = "<group>"; };
 		B29505F108227C8F43822585 /* ACPLaunchCatalogTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPLaunchCatalogTests.swift; sourceTree = "<group>"; };
+		B2F3473392B284B69E6621DB /* ACPBareURLLinkifier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPBareURLLinkifier.swift; sourceTree = "<group>"; };
 		B3C89163A30EA4D278E86959 /* RightPaneStateLoadOlderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RightPaneStateLoadOlderTests.swift; sourceTree = "<group>"; };
 		B3EC1A61207050A2585288FB /* RightPaneVisibilityTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RightPaneVisibilityTests.swift; sourceTree = "<group>"; };
 		B44D759586280250330A9A04 /* FontSizeCommands.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FontSizeCommands.swift; sourceTree = "<group>"; };
@@ -2751,6 +2753,7 @@
 		51D8A9EE658EB05F836A321A /* Session */ = {
 			isa = PBXGroup;
 			children = (
+				B2F3473392B284B69E6621DB /* ACPBareURLLinkifier.swift */,
 				419EF533C4D29448483045DA /* ACPChangeNotifier.swift */,
 				DF9310EAA75C6B6567F303B6 /* ACPChipState.swift */,
 				A47981117B0CDB5F71DECD64 /* ACPComposerDraft.swift */,
@@ -3919,6 +3922,7 @@
 				FB5FD89FC2800E173FC31E7A /* ACPAuthFailure.swift in Sources */,
 				6E66AD13D1763D61F619F3D1 /* ACPAuthNudgeBanner.swift in Sources */,
 				56B6EF95B863B557992AE9DA /* ACPAutoRunToggle.swift in Sources */,
+				0722316C2ADB93575221246D /* ACPBareURLLinkifier.swift in Sources */,
 				88A139C7B3C3C9F20EF5945A /* ACPChangeNotifier.swift in Sources */,
 				C00E549FA69AB3D3C55B85EB /* ACPChipState.swift in Sources */,
 				A70A62FDF7EA38F99D9E2B06 /* ACPClient.swift in Sources */,

--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -83,6 +83,7 @@
 		13FF5AC96D9F0C14264096D9 /* ImageDiffSideBySideView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 379D90AD620EAF6E84A04902 /* ImageDiffSideBySideView.swift */; };
 		14775ED3C1BC3A084B2147C1 /* HeadReader.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB2EB554CB6AF797545DB95D /* HeadReader.swift */; };
 		14BC25FE7259A545420F28AA /* ComposerAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE5FDAB31C577FC38CE53032 /* ComposerAction.swift */; };
+		162363BDA6BC54B372C77B91 /* ACPMarkdownTextBareURLTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8718406234B8C879B9D0CAB1 /* ACPMarkdownTextBareURLTests.swift */; };
 		162A6ABEAE92BB3AD1511567 /* AdvancedSettingsVisibilityTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1CD33324CA36118FCEA2BE2 /* AdvancedSettingsVisibilityTests.swift */; };
 		165300DDFFB445D8AAE7A5E5 /* MarkdownFileTypeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 19C327BB65463E878DDCDA5E /* MarkdownFileTypeTests.swift */; };
 		16F5212404948970EAFCFE62 /* MarkdownPreviewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0D4901C499EFE969EC36D116 /* MarkdownPreviewController.swift */; };
@@ -1488,6 +1489,7 @@
 		866CFEB75B7F754485C6BE77 /* WorkingTreeSectionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkingTreeSectionView.swift; sourceTree = "<group>"; };
 		8673293AD419AA36F7DF02A9 /* CommitsOlderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommitsOlderTests.swift; sourceTree = "<group>"; };
 		86CB3F953562BAFB284B5DB7 /* ANSIStreamTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ANSIStreamTests.swift; sourceTree = "<group>"; };
+		8718406234B8C879B9D0CAB1 /* ACPMarkdownTextBareURLTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPMarkdownTextBareURLTests.swift; sourceTree = "<group>"; };
 		87F9063CCA0DA839EB342993 /* CursorModelVariants.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CursorModelVariants.swift; sourceTree = "<group>"; };
 		881B46F8FCAF830239357372 /* ImageDiffDifferenceComputer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageDiffDifferenceComputer.swift; sourceTree = "<group>"; };
 		88379ACE40F42BE4A3257659 /* ThemeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThemeTests.swift; sourceTree = "<group>"; };
@@ -2707,6 +2709,7 @@
 				A53358B7D4D68BE2471187D4 /* ACPImageStagingTests.swift */,
 				84E56989C04A4A478D68084C /* ACPMarkdownBlockCacheTests.swift */,
 				7F4B57FBB6E595E5DF1C6F93 /* ACPMarkdownLiveStylerImageChipTests.swift */,
+				8718406234B8C879B9D0CAB1 /* ACPMarkdownTextBareURLTests.swift */,
 				E941397D0207F68135B3464D /* ACPMentionPickerTests.swift */,
 				9272E334A0A5DF460514CF01 /* ACPMessageListPaginationTests.swift */,
 				D0CE3F0637B3CA27B1D87080 /* ACPNewChatEmptyStateTests.swift */,
@@ -4463,6 +4466,7 @@
 				965621529CB4BD82DD646B76 /* ACPManagerAccessorsTests.swift in Sources */,
 				21A94ADFA16F85C7ACAB4DA1 /* ACPMarkdownBlockCacheTests.swift in Sources */,
 				6E0481CC3B5D8676A6E8BE69 /* ACPMarkdownLiveStylerImageChipTests.swift in Sources */,
+				162363BDA6BC54B372C77B91 /* ACPMarkdownTextBareURLTests.swift in Sources */,
 				26F83C65E75B5F44024FEF1F /* ACPMentionPickerTests.swift in Sources */,
 				FD7719ABDA6CFCF28BB0F800 /* ACPMessageListPaginationTests.swift in Sources */,
 				9737C1A3CD708D28C62FD6A5 /* ACPMessageStableIdTests.swift in Sources */,

--- a/Alas/Resources/RemoteWeb/app.js
+++ b/Alas/Resources/RemoteWeb/app.js
@@ -359,6 +359,8 @@ function rewriteMarkdownBareUrls(text, preserveFencedCodeBlocks) {
           if (htmlBlockTag) {
             out += line;
             if (!closingRawHtmlBlockTag(line, htmlBlockTag)) openingHtmlBlockTag = htmlBlockTag;
+          } else if (markdownIndentedCodeBlockLine(line)) {
+            out += line;
           } else {
             out += rewriteInlineBareUrls(line, inlineState, text, lineEnd);
           }
@@ -501,6 +503,17 @@ function codeFenceDelimiter(line, allowsTrailingText) {
 
 function closesCodeFence(candidate, openingFence) {
   return candidate.marker === openingFence.marker && candidate.length >= openingFence.length;
+}
+
+function markdownIndentedCodeBlockLine(line) {
+  let leadingSpaces = 0;
+  for (let i = 0; i < line.length; i += 1) {
+    if (line[i] === "\t") return true;
+    if (line[i] !== " ") return false;
+    leadingSpaces += 1;
+    if (leadingSpaces >= 4) return true;
+  }
+  return false;
 }
 
 const rawHtmlBlockTags = new Set([

--- a/Alas/Resources/RemoteWeb/app.js
+++ b/Alas/Resources/RemoteWeb/app.js
@@ -335,7 +335,8 @@ function rewriteMarkdownBareUrls(text, preserveFencedCodeBlocks) {
       allowsIndentedCodeBlock = !!closedFence;
     } else if (openingHtmlBlockTag) {
       out += line;
-      const closedHtmlBlock = closingRawHtmlBlockTag(line, openingHtmlBlockTag);
+      const closedHtmlBlock = closingRawHtmlBlockTag(line, openingHtmlBlockTag) ||
+        rawHtmlBlockEndsAtBlankLine(line, openingHtmlBlockTag);
       if (closedHtmlBlock) openingHtmlBlockTag = null;
       allowsIndentedCodeBlock = closedHtmlBlock;
     } else if (inlineState.codeSpanDelimiterLength == null &&
@@ -549,6 +550,8 @@ const rawHtmlVoidBlockTags = new Set([
   "param", "source", "track", "wbr",
 ]);
 
+const rawHtmlExplicitCloseBlockTags = new Set(["pre", "script", "style"]);
+
 function openingRawHtmlBlockTag(line) {
   let i = 0;
   let leadingSpaces = 0;
@@ -570,6 +573,10 @@ function openingRawHtmlBlockTag(line) {
   const tag = match[1].toLowerCase();
   if (!rawHtmlBlockTags.has(tag) || rawHtmlVoidBlockTags.has(tag)) return null;
   return tag;
+}
+
+function rawHtmlBlockEndsAtBlankLine(line, tag) {
+  return !tag.startsWith("#") && !rawHtmlExplicitCloseBlockTags.has(tag) && markdownBlankLine(line);
 }
 
 function closingRawHtmlBlockTag(line, tag) {

--- a/Alas/Resources/RemoteWeb/app.js
+++ b/Alas/Resources/RemoteWeb/app.js
@@ -375,13 +375,13 @@ function rewriteMarkdownBareUrls(text, preserveFencedCodeBlocks) {
             allowsIndentedCodeBlock = true;
           } else {
             out += rewriteInlineBareUrls(line, inlineState, text, lineEnd);
-            allowsIndentedCodeBlock = markdownBlankLine(line);
+            allowsIndentedCodeBlock = markdownAllowsIndentedCodeBlockAfterLine(line);
           }
         }
       }
     } else {
       out += rewriteInlineBareUrls(line, inlineState, text, lineEnd);
-      allowsIndentedCodeBlock = markdownBlankLine(line);
+      allowsIndentedCodeBlock = markdownAllowsIndentedCodeBlockAfterLine(line);
     }
 
     lineStart = lineEnd;
@@ -521,6 +521,29 @@ function closesCodeFence(candidate, openingFence) {
 
 function markdownBlankLine(line) {
   return /^[\s]*$/.test(line);
+}
+
+function markdownAllowsIndentedCodeBlockAfterLine(line) {
+  return markdownBlankLine(line) || markdownAtxHeadingLine(line);
+}
+
+function markdownAtxHeadingLine(line) {
+  let i = 0;
+  let leadingSpaces = 0;
+  while (i < line.length && line[i] === " ") {
+    leadingSpaces += 1;
+    if (leadingSpaces > 3) return false;
+    i += 1;
+  }
+
+  let markerCount = 0;
+  while (i < line.length && line[i] === "#" && markerCount < 6) {
+    markerCount += 1;
+    i += 1;
+  }
+  if (markerCount === 0) return false;
+  if (i >= line.length) return true;
+  return /\s/.test(line[i]);
 }
 
 function markdownIndentedCodeBlockLine(line) {

--- a/Alas/Resources/RemoteWeb/app.js
+++ b/Alas/Resources/RemoteWeb/app.js
@@ -899,8 +899,7 @@ function markdownReferenceDefinition(line) {
 }
 
 function markdownReferenceDefinitionDestinationContinuationLine(line) {
-  const content = indentedReferenceDefinitionContinuationContent(line);
-  return content !== null && content.length > 0;
+  return line.trim().length > 0;
 }
 
 function markdownReferenceDefinitionTitleContinuationLine(line) {

--- a/Alas/Resources/RemoteWeb/app.js
+++ b/Alas/Resources/RemoteWeb/app.js
@@ -315,6 +315,7 @@ function rewriteMarkdownBareUrls(text, preserveFencedCodeBlocks) {
   let lineStart = 0;
   let openingFence = null;
   let openingHtmlBlockTag = null;
+  let allowsIndentedCodeBlock = true;
   let referenceDefinitionContinuation = null;
   const inlineState = {
     codeSpanDelimiterLength: null,
@@ -329,45 +330,57 @@ function rewriteMarkdownBareUrls(text, preserveFencedCodeBlocks) {
     if (openingFence) {
       out += line;
       const closingFence = closingCodeFenceDelimiter(line);
-      if (closingFence && closesCodeFence(closingFence, openingFence)) openingFence = null;
+      const closedFence = closingFence && closesCodeFence(closingFence, openingFence);
+      if (closedFence) openingFence = null;
+      allowsIndentedCodeBlock = !!closedFence;
     } else if (openingHtmlBlockTag) {
       out += line;
-      if (closingRawHtmlBlockTag(line, openingHtmlBlockTag)) openingHtmlBlockTag = null;
+      const closedHtmlBlock = closingRawHtmlBlockTag(line, openingHtmlBlockTag);
+      if (closedHtmlBlock) openingHtmlBlockTag = null;
+      allowsIndentedCodeBlock = closedHtmlBlock;
     } else if (inlineState.codeSpanDelimiterLength == null &&
                referenceDefinitionContinuation === "destination" &&
                markdownReferenceDefinitionDestinationContinuationLine(line)) {
       out += line;
       referenceDefinitionContinuation = "title";
+      allowsIndentedCodeBlock = false;
     } else if (inlineState.codeSpanDelimiterLength == null &&
                referenceDefinitionContinuation === "title" &&
                markdownReferenceDefinitionTitleContinuationLine(line)) {
       out += line;
       referenceDefinitionContinuation = null;
+      allowsIndentedCodeBlock = false;
     } else if (inlineState.codeSpanDelimiterLength == null) {
       const referenceDefinition = markdownReferenceDefinition(line);
       if (referenceDefinition) {
         out += line;
         referenceDefinitionContinuation = referenceDefinition.hasDestination ? "title" : "destination";
+        allowsIndentedCodeBlock = false;
       } else {
         referenceDefinitionContinuation = null;
         const lineFence = openingCodeFenceDelimiter(line);
         if (lineFence) {
           out += line;
           openingFence = lineFence;
+          allowsIndentedCodeBlock = false;
         } else {
           const htmlBlockTag = openingRawHtmlBlockTag(line);
           if (htmlBlockTag) {
             out += line;
             if (!closingRawHtmlBlockTag(line, htmlBlockTag)) openingHtmlBlockTag = htmlBlockTag;
-          } else if (markdownIndentedCodeBlockLine(line)) {
+            allowsIndentedCodeBlock = !openingHtmlBlockTag;
+          } else if (allowsIndentedCodeBlock && markdownIndentedCodeBlockLine(line)) {
             out += line;
+            allowsIndentedCodeBlock = true;
           } else {
             out += rewriteInlineBareUrls(line, inlineState, text, lineEnd);
+            allowsIndentedCodeBlock = markdownBlankLine(line);
           }
         }
       }
     } else {
       out += rewriteInlineBareUrls(line, inlineState, text, lineEnd);
+      allowsIndentedCodeBlock = markdownBlankLine(line);
     }
 
     lineStart = lineEnd;
@@ -503,6 +516,10 @@ function codeFenceDelimiter(line, allowsTrailingText) {
 
 function closesCodeFence(candidate, openingFence) {
   return candidate.marker === openingFence.marker && candidate.length >= openingFence.length;
+}
+
+function markdownBlankLine(line) {
+  return /^[\s]*$/.test(line);
 }
 
 function markdownIndentedCodeBlockLine(line) {

--- a/Alas/Resources/RemoteWeb/app.js
+++ b/Alas/Resources/RemoteWeb/app.js
@@ -918,34 +918,69 @@ function markdownReferenceDefinition(line) {
   if (!normalizeMarkdownReferenceLabel(label)) return null;
 
   const afterColon = line.slice(labelEnd + 2).trim();
-  return { label, hasDestination: afterColon.length > 0 };
+  if (afterColon.length === 0) return { label, hasDestination: false };
+  if (!markdownReferenceDefinitionDestinationContent(afterColon)) return null;
+  return { label, hasDestination: true };
 }
 
 function markdownReferenceDefinitionDestinationContinuationLine(line) {
-  return line.trim().length > 0;
+  return markdownReferenceDefinitionDestinationContent(line.trim());
 }
 
 function markdownReferenceDefinitionTitleContinuationLine(line) {
   const content = indentedReferenceDefinitionContinuationContent(line);
   if (content === null) return false;
 
-  let contentEnd = content.length;
-  while (contentEnd > 0 && /\s/.test(content[contentEnd - 1])) contentEnd -= 1;
-  if (contentEnd === 0) return false;
+  return markdownReferenceDefinitionTitleContent(content.trim());
+}
+
+function markdownReferenceDefinitionDestinationContent(content) {
+  if (!content) return false;
+
+  let i = 0;
+  if (content[i] === "<") {
+    i += 1;
+    let isEscaped = false;
+    while (i < content.length) {
+      const ch = content[i];
+      if (isEscaped) {
+        isEscaped = false;
+      } else if (ch === "\\") {
+        isEscaped = true;
+      } else if (ch === ">") {
+        const rest = content.slice(i + 1).trim();
+        return rest.length === 0 || markdownReferenceDefinitionTitleContent(rest);
+      } else if (ch === "\n" || ch === "\r") {
+        return false;
+      }
+      i += 1;
+    }
+    return false;
+  }
+
+  while (i < content.length && !/\s/.test(content[i])) i += 1;
+  if (i === 0) return false;
+
+  const rest = content.slice(i).trim();
+  return rest.length === 0 || markdownReferenceDefinitionTitleContent(rest);
+}
+
+function markdownReferenceDefinitionTitleContent(content) {
+  if (!content) return false;
 
   const opener = content[0];
   const closer = opener === "(" ? ")" : opener;
   if (opener !== "\"" && opener !== "'" && opener !== "(") return false;
 
   let isEscaped = false;
-  for (let j = 1; j < contentEnd; j += 1) {
+  for (let j = 1; j < content.length; j += 1) {
     const ch = content[j];
     if (isEscaped) {
       isEscaped = false;
     } else if (ch === "\\") {
       isEscaped = true;
     } else if (ch === closer) {
-      return j === contentEnd - 1;
+      return j === content.length - 1;
     }
   }
 

--- a/Alas/Resources/RemoteWeb/app.js
+++ b/Alas/Resources/RemoteWeb/app.js
@@ -836,7 +836,10 @@ function markdownReferenceLabels(text) {
       const closingFence = closingCodeFenceDelimiter(line);
       if (closingFence && closesCodeFence(closingFence, openingFence)) openingFence = null;
     } else if (openingHtmlBlockTag) {
-      if (closingRawHtmlBlockTag(line, openingHtmlBlockTag)) openingHtmlBlockTag = null;
+      if (closingRawHtmlBlockTag(line, openingHtmlBlockTag) ||
+          rawHtmlBlockEndsAtBlankLine(line, openingHtmlBlockTag)) {
+        openingHtmlBlockTag = null;
+      }
     } else if (pendingDefinitionLabel !== null) {
       if (markdownReferenceDefinitionDestinationContinuationLine(line)) {
         labels.add(normalizeMarkdownReferenceLabel(pendingDefinitionLabel));

--- a/Alas/Resources/RemoteWeb/app.js
+++ b/Alas/Resources/RemoteWeb/app.js
@@ -674,7 +674,14 @@ function startsWithWebScheme(text, i) {
 
 function hasValidBoundaryBefore(text, i) {
   if (i === 0) return true;
-  return /\s|[\(\[\{"']/.test(text[i - 1]);
+  const previous = text[i - 1];
+  if (/[*_~]/.test(previous)) {
+    let delimiterRunStart = i - 1;
+    while (delimiterRunStart > 0 && text[delimiterRunStart - 1] === previous) delimiterRunStart -= 1;
+    if (delimiterRunStart === 0) return true;
+    return /\s|[\(\[\{"']/.test(text[delimiterRunStart - 1]);
+  }
+  return /\s|[\(\[\{"']/.test(previous);
 }
 
 function rawUrlEnd(text, start) {
@@ -689,8 +696,17 @@ function rawUrlEnd(text, start) {
 function trimmedUrlEnd(text, start, rawEnd) {
   let end = rawEnd;
   const surplusClosings = unbalancedClosingSurplus(text, start, rawEnd);
+  const emphasisDelimiterRun = markdownEmphasisDelimiterRunBeforeUrlStart(text, start);
+  let remainingEmphasisDelimitersToTrim = emphasisDelimiterRun ? emphasisDelimiterRun.length : 0;
   while (end > start) {
     const ch = text[end - 1];
+    if (emphasisDelimiterRun &&
+        remainingEmphasisDelimitersToTrim > 0 &&
+        ch === emphasisDelimiterRun.delimiter) {
+      remainingEmphasisDelimitersToTrim -= 1;
+      end -= 1;
+      continue;
+    }
     if (".,;:!?\"'".includes(ch)) {
       end -= 1;
       continue;
@@ -703,6 +719,15 @@ function trimmedUrlEnd(text, start, rawEnd) {
     break;
   }
   return end;
+}
+
+function markdownEmphasisDelimiterRunBeforeUrlStart(text, start) {
+  if (start === 0) return null;
+  const delimiter = text[start - 1];
+  if (!/[*_~]/.test(delimiter)) return null;
+  let length = 1;
+  for (let i = start - 2; i >= 0 && text[i] === delimiter; i -= 1) length += 1;
+  return { delimiter, length };
 }
 
 function unbalancedClosingSurplus(text, start, end) {

--- a/Alas/Resources/RemoteWeb/app.js
+++ b/Alas/Resources/RemoteWeb/app.js
@@ -524,7 +524,7 @@ function markdownBlankLine(line) {
 }
 
 function markdownAllowsIndentedCodeBlockAfterLine(line) {
-  return markdownBlankLine(line) || markdownAtxHeadingLine(line);
+  return markdownBlankLine(line) || markdownAtxHeadingLine(line) || markdownThematicBreakLine(line);
 }
 
 function markdownAtxHeadingLine(line) {
@@ -544,6 +544,36 @@ function markdownAtxHeadingLine(line) {
   if (markerCount === 0) return false;
   if (i >= line.length) return true;
   return /\s/.test(line[i]);
+}
+
+function markdownThematicBreakLine(line) {
+  let i = 0;
+  let leadingSpaces = 0;
+  while (i < line.length && line[i] === " ") {
+    leadingSpaces += 1;
+    if (leadingSpaces > 3) return false;
+    i += 1;
+  }
+
+  let marker = null;
+  let markerCount = 0;
+  while (i < line.length) {
+    const ch = line[i];
+    if (ch === "\n" || ch === "\r") break;
+    if (ch === " " || ch === "\t") {
+      i += 1;
+      continue;
+    }
+    if (marker === null) {
+      if (ch !== "-" && ch !== "_" && ch !== "*") return false;
+      marker = ch;
+    }
+    if (ch !== marker) return false;
+    markerCount += 1;
+    i += 1;
+  }
+
+  return markerCount >= 3;
 }
 
 function markdownIndentedCodeBlockLine(line) {

--- a/Alas/Resources/RemoteWeb/app.js
+++ b/Alas/Resources/RemoteWeb/app.js
@@ -666,7 +666,10 @@ function hasValidBoundaryBefore(text, i) {
 
 function rawUrlEnd(text, start) {
   let i = start;
-  while (i < text.length && !/[\s<>\[\]\x00-\x1F\x7F]/.test(text[i])) i += 1;
+  while (i < text.length && !/[\s<>\x00-\x1F\x7F]/.test(text[i])) {
+    if (text[i] === "]" && text[i + 1] === "[") break;
+    i += 1;
+  }
   return i;
 }
 

--- a/Alas/Resources/RemoteWeb/app.js
+++ b/Alas/Resources/RemoteWeb/app.js
@@ -1002,6 +1002,7 @@ function markdownDestinationEnd(text, start) {
     } else if (/\s/.test(ch)) {
       if (hasDestinationContent && depth === 1) canStartTitleQuote = true;
     } else {
+      if (canStartTitleQuote) return -1;
       hasDestinationContent = true;
       canStartTitleQuote = false;
     }

--- a/Alas/Resources/RemoteWeb/app.js
+++ b/Alas/Resources/RemoteWeb/app.js
@@ -1,5 +1,9 @@
 const tokenKey = "alas.remote.token";
 const $ = (id) => document.getElementById(id);
+function listen(id, event, handler) {
+  const element = $(id);
+  if (element && typeof element.addEventListener === "function") element.addEventListener(event, handler);
+}
 let ws, currentSession = null, messages = new Map();
 let sessionTitles = new Map();
 let canDrive = false, canDriveKnown = false;
@@ -298,6 +302,646 @@ function renderMessages(forceBottom) {
 
 function el(tag, cls, text) { const e = document.createElement(tag); if (cls) e.className = cls; if (text != null) e.textContent = text; return e; }
 function jparse(s) { try { return JSON.parse(s); } catch { return null; } }
+
+function linkifyBareUrls(text) {
+  if (!text || (!text.includes("http://") && !text.includes("https://"))) return text || "";
+  return rewriteMarkdownBareUrls(text, true);
+}
+
+function rewriteMarkdownBareUrls(text, preserveFencedCodeBlocks) {
+  if (!preserveFencedCodeBlocks) return rewriteInlineBareUrls(text);
+
+  let out = "";
+  let lineStart = 0;
+  let openingFence = null;
+  let openingHtmlBlockTag = null;
+  let referenceDefinitionContinuation = null;
+  const inlineState = {
+    codeSpanDelimiterLength: null,
+    referenceLabels: markdownReferenceLabels(text),
+  };
+
+  while (lineStart < text.length) {
+    const newline = text.indexOf("\n", lineStart);
+    const lineEnd = newline === -1 ? text.length : newline + 1;
+    const line = text.slice(lineStart, lineEnd);
+
+    if (openingFence) {
+      out += line;
+      const closingFence = closingCodeFenceDelimiter(line);
+      if (closingFence && closesCodeFence(closingFence, openingFence)) openingFence = null;
+    } else if (openingHtmlBlockTag) {
+      out += line;
+      if (closingRawHtmlBlockTag(line, openingHtmlBlockTag)) openingHtmlBlockTag = null;
+    } else if (inlineState.codeSpanDelimiterLength == null &&
+               referenceDefinitionContinuation === "destination" &&
+               markdownReferenceDefinitionDestinationContinuationLine(line)) {
+      out += line;
+      referenceDefinitionContinuation = "title";
+    } else if (inlineState.codeSpanDelimiterLength == null &&
+               referenceDefinitionContinuation === "title" &&
+               markdownReferenceDefinitionTitleContinuationLine(line)) {
+      out += line;
+      referenceDefinitionContinuation = null;
+    } else if (inlineState.codeSpanDelimiterLength == null) {
+      const referenceDefinition = markdownReferenceDefinition(line);
+      if (referenceDefinition) {
+        out += line;
+        referenceDefinitionContinuation = referenceDefinition.hasDestination ? "title" : "destination";
+      } else {
+        referenceDefinitionContinuation = null;
+        const lineFence = openingCodeFenceDelimiter(line);
+        if (lineFence) {
+          out += line;
+          openingFence = lineFence;
+        } else {
+          const htmlBlockTag = openingRawHtmlBlockTag(line);
+          if (htmlBlockTag) {
+            out += line;
+            if (!closingRawHtmlBlockTag(line, htmlBlockTag)) openingHtmlBlockTag = htmlBlockTag;
+          } else {
+            out += rewriteInlineBareUrls(line, inlineState, text, lineEnd);
+          }
+        }
+      }
+    } else {
+      out += rewriteInlineBareUrls(line, inlineState, text, lineEnd);
+    }
+
+    lineStart = lineEnd;
+  }
+
+  return out;
+}
+
+function rewriteInlineBareUrls(text, state, remainingTextSource, remainingTextStart) {
+  const inlineState = state || { codeSpanDelimiterLength: null };
+  let out = "";
+  let i = 0;
+
+  while (i < text.length) {
+    if (inlineState.codeSpanDelimiterLength != null) {
+      if (text[i] === "`") {
+        const closingLength = repeatedCharacterRunLength(text, i, "`");
+        if (closingLength === inlineState.codeSpanDelimiterLength) {
+          out += text.slice(i, i + closingLength);
+          i += closingLength;
+          inlineState.codeSpanDelimiterLength = null;
+          continue;
+        }
+      }
+
+      out += text[i];
+      i += 1;
+      continue;
+    }
+
+    if (text[i] === "`") {
+      const delimiterLength = repeatedCharacterRunLength(text, i, "`");
+      if (isFenceLikeBacktickDelimiterLine(text, i, delimiterLength)) {
+        out += text.slice(i, i + delimiterLength);
+        i += delimiterLength;
+        continue;
+      }
+
+      const end = codeSpanEnd(text, i);
+      if (end !== -1) {
+        out += text.slice(i, end + 1);
+        i = end + 1;
+        continue;
+      }
+
+      out += text.slice(i, i + delimiterLength);
+      i += delimiterLength;
+      const remainingTextAfterSegment = remainingTextSource == null ? text.slice(i) : remainingTextSource.slice(remainingTextStart);
+      if (hasCodeSpanEnd(remainingTextAfterSegment, delimiterLength)) {
+        inlineState.codeSpanDelimiterLength = delimiterLength;
+      }
+      continue;
+    }
+
+    if (text[i] === "<" && startsWithWebScheme(text, i + 1)) {
+      const end = text.indexOf(">", i + 1);
+      if (end !== -1) {
+        out += text.slice(i, end + 1);
+        i = end + 1;
+        continue;
+      }
+    }
+
+    if (text[i] === "<") {
+      const end = rawHtmlTagEnd(text, i);
+      if (end !== -1) {
+        out += text.slice(i, end + 1);
+        i = end + 1;
+        continue;
+      }
+    }
+
+    if (text[i] === "[") {
+      const end = markdownBracketedLinkEnd(text, i, inlineState.referenceLabels);
+      if (end !== -1) {
+        out += text.slice(i, end + 1);
+        i = end + 1;
+        continue;
+      }
+    }
+
+    if (startsWithWebScheme(text, i) && hasValidBoundaryBefore(text, i)) {
+      const rawEnd = rawUrlEnd(text, i);
+      const trimmedEnd = trimmedUrlEnd(text, i, rawEnd);
+      if (trimmedEnd > i) {
+        const urlText = text.slice(i, trimmedEnd);
+        if (isValidBareWebURL(urlText)) {
+          out += "<" + urlText + ">";
+          out += text.slice(trimmedEnd, rawEnd);
+          i = rawEnd;
+          continue;
+        }
+      }
+    }
+
+    out += text[i];
+    i += 1;
+  }
+
+  return out;
+}
+
+function openingCodeFenceDelimiter(line) {
+  return codeFenceDelimiter(line, true);
+}
+
+function closingCodeFenceDelimiter(line) {
+  return codeFenceDelimiter(line, false);
+}
+
+function codeFenceDelimiter(line, allowsTrailingText) {
+  let contentEnd = line.length;
+  while (contentEnd > 0 && /\s/.test(line[contentEnd - 1])) contentEnd -= 1;
+
+  let i = 0;
+  let leadingSpaces = 0;
+  while (i < contentEnd && line[i] === " ") {
+    leadingSpaces += 1;
+    i += 1;
+  }
+  if (leadingSpaces > 3 || i >= contentEnd) return null;
+
+  const marker = line[i];
+  if (marker !== "`" && marker !== "~") return null;
+
+  const length = repeatedCharacterRunLength(line, i, marker);
+  i += length;
+
+  if (!allowsTrailingText && i !== contentEnd) return null;
+  if (marker === "`" && line.slice(i, contentEnd).includes("`")) return null;
+  return length >= 3 ? { marker, length } : null;
+}
+
+function closesCodeFence(candidate, openingFence) {
+  return candidate.marker === openingFence.marker && candidate.length >= openingFence.length;
+}
+
+const rawHtmlBlockTags = new Set([
+  "address", "article", "aside", "base", "basefont", "blockquote", "body",
+  "caption", "center", "col", "colgroup", "dd", "details", "dialog", "dir",
+  "div", "dl", "dt", "fieldset", "figcaption", "figure", "footer", "form",
+  "frame", "frameset", "h1", "h2", "h3", "h4", "h5", "h6", "head", "header",
+  "hr", "html", "iframe", "legend", "li", "link", "main", "menu", "menuitem",
+  "nav", "noframes", "ol", "optgroup", "option", "p", "param", "section",
+  "summary", "table", "tbody", "td", "tfoot", "th", "thead", "title", "tr",
+  "track", "ul", "pre", "script", "style",
+]);
+
+const rawHtmlVoidBlockTags = new Set([
+  "area", "base", "br", "col", "embed", "hr", "img", "input", "link", "meta",
+  "param", "source", "track", "wbr",
+]);
+
+function openingRawHtmlBlockTag(line) {
+  let i = 0;
+  let leadingSpaces = 0;
+  while (i < line.length && line[i] === " ") {
+    leadingSpaces += 1;
+    i += 1;
+  }
+  if (leadingSpaces > 3 || line[i] !== "<") return null;
+
+  const rest = line.slice(i);
+  if (rest.startsWith("<!--")) return "#comment";
+  if (rest.startsWith("<?")) return "#processing-instruction";
+  if (rest.startsWith("<![CDATA[")) return "#cdata";
+  if (/^<![A-Z]/.test(rest)) return "#declaration";
+
+  const match = rest.match(/^<([A-Za-z][A-Za-z0-9-]*)(?:\s|>|\/>)/);
+  if (!match) return null;
+
+  const tag = match[1].toLowerCase();
+  if (!rawHtmlBlockTags.has(tag) || rawHtmlVoidBlockTags.has(tag)) return null;
+  return tag;
+}
+
+function closingRawHtmlBlockTag(line, tag) {
+  if (tag === "#comment") return line.includes("-->");
+  if (tag === "#processing-instruction") return line.includes("?>");
+  if (tag === "#cdata") return line.includes("]]>");
+  if (tag === "#declaration") return line.includes(">");
+  return new RegExp("</\\s*" + escapeRegExp(tag) + "\\s*>", "i").test(line);
+}
+
+function escapeRegExp(text) {
+  return text.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+function repeatedCharacterRunLength(text, start, character) {
+  let count = 0;
+  let i = start;
+  while (i < text.length && text[i] === character) {
+    count += 1;
+    i += 1;
+  }
+  return count;
+}
+
+function isFenceLikeBacktickDelimiterLine(text, start, delimiterLength) {
+  if (delimiterLength < 3) return false;
+
+  let lineStart = start;
+  while (lineStart > 0 && text[lineStart - 1] !== "\n") lineStart -= 1;
+  for (let i = lineStart; i < start; i += 1) {
+    if (text[i] !== " ") return false;
+  }
+
+  let lineEnd = start;
+  while (lineEnd < text.length && text[lineEnd] !== "\n") lineEnd += 1;
+  return !text.slice(start + delimiterLength, lineEnd).includes("`");
+}
+
+function codeSpanEnd(text, start) {
+  const delimiterLength = repeatedCharacterRunLength(text, start, "`");
+  let i = start + delimiterLength;
+  let currentLineIsBlank = false;
+
+  while (i < text.length) {
+    const ch = text[i];
+    if (ch === "\n") {
+      if (currentLineIsBlank) return -1;
+      currentLineIsBlank = true;
+      i += 1;
+    } else if (/\s/.test(ch)) {
+      i += 1;
+    } else if (ch === "`") {
+      currentLineIsBlank = false;
+      const closingLength = repeatedCharacterRunLength(text, i, "`");
+      if (closingLength === delimiterLength) return i + closingLength - 1;
+      i += closingLength;
+    } else {
+      currentLineIsBlank = false;
+      i += 1;
+    }
+  }
+
+  return -1;
+}
+
+function hasCodeSpanEnd(text, delimiterLength) {
+  let i = 0;
+  let currentLineIsBlank = true;
+
+  while (i < text.length) {
+    const ch = text[i];
+    if (ch === "\n") {
+      if (currentLineIsBlank) return false;
+      currentLineIsBlank = true;
+      i += 1;
+    } else if (/\s/.test(ch)) {
+      i += 1;
+    } else if (ch === "`") {
+      currentLineIsBlank = false;
+      const closingLength = repeatedCharacterRunLength(text, i, "`");
+      if (closingLength === delimiterLength) return true;
+      i += closingLength;
+    } else {
+      currentLineIsBlank = false;
+      i += 1;
+    }
+  }
+
+  return false;
+}
+
+function rawHtmlTagEnd(text, start) {
+  if (!isRawHtmlTagStart(text, start)) return -1;
+
+  let quote = null;
+  for (let i = start + 1; i < text.length; i += 1) {
+    const ch = text[i];
+    if (quote) {
+      if (ch === quote) quote = null;
+    } else if (ch === "\"" || ch === "'") {
+      quote = ch;
+    } else if (ch === ">") {
+      return i;
+    }
+  }
+
+  return -1;
+}
+
+function isRawHtmlTagStart(text, start) {
+  if (start >= text.length || text[start] !== "<" || start + 1 >= text.length) return false;
+  const next = text[start + 1];
+  return /[A-Za-z!/]/.test(next) || next === "?";
+}
+
+function startsWithWebScheme(text, i) {
+  return text.startsWith("https://", i) || text.startsWith("http://", i);
+}
+
+function hasValidBoundaryBefore(text, i) {
+  if (i === 0) return true;
+  return /\s|[\(\[\{"']/.test(text[i - 1]);
+}
+
+function rawUrlEnd(text, start) {
+  let i = start;
+  while (i < text.length && !/[\s<>\[\]\x00-\x1F\x7F]/.test(text[i])) i += 1;
+  return i;
+}
+
+function trimmedUrlEnd(text, start, rawEnd) {
+  let end = rawEnd;
+  const surplusClosings = unbalancedClosingSurplus(text, start, rawEnd);
+  while (end > start) {
+    const ch = text[end - 1];
+    if (".,;:!?\"'".includes(ch)) {
+      end -= 1;
+      continue;
+    }
+    if (surplusClosings[ch] > 0) {
+      surplusClosings[ch] -= 1;
+      end -= 1;
+      continue;
+    }
+    break;
+  }
+  return end;
+}
+
+function unbalancedClosingSurplus(text, start, end) {
+  const counts = {
+    "(": 0, ")": 0,
+    "[": 0, "]": 0,
+    "{": 0, "}": 0,
+    "<": 0, ">": 0,
+  };
+  for (let i = start; i < end; i += 1) {
+    if (counts[text[i]] != null) counts[text[i]] += 1;
+  }
+  return {
+    ")": Math.max(0, counts[")"] - counts["("]),
+    "]": Math.max(0, counts["]"] - counts["["]),
+    "}": Math.max(0, counts["}"] - counts["{"]),
+    ">": Math.max(0, counts[">"] - counts["<"]),
+  };
+}
+
+function isValidBareWebURL(text) {
+  let hostStart;
+  if (text.startsWith("https://")) {
+    hostStart = "https://".length;
+  } else if (text.startsWith("http://")) {
+    hostStart = "http://".length;
+  } else {
+    return false;
+  }
+
+  if (hostStart >= text.length) return false;
+  let hostEnd = text.length;
+  for (const marker of ["/", "?", "#"]) {
+    const markerIndex = text.indexOf(marker, hostStart);
+    if (markerIndex !== -1) hostEnd = Math.min(hostEnd, markerIndex);
+  }
+  return /[A-Za-z0-9]/.test(text.slice(hostStart, hostEnd));
+}
+
+function markdownBracketedLinkEnd(text, start, referenceLabels) {
+  const labelEnd = markdownLabelEnd(text, start);
+  if (labelEnd === -1) return -1;
+
+  const label = normalizeMarkdownReferenceLabel(text.slice(start + 1, labelEnd));
+  if (referenceLabels && referenceLabels.has(label)) return labelEnd;
+
+  const next = labelEnd + 1;
+  if (next >= text.length || text.slice(next).trim() === "") {
+    return referenceLabels && referenceLabels.has(label) ? labelEnd : -1;
+  }
+
+  if (text[next] === "(") {
+    const destinationEnd = markdownDestinationEnd(text, next);
+    if (destinationEnd !== -1) return destinationEnd;
+  }
+
+  if (text[next] === "[") {
+    const referenceEnd = markdownLabelEnd(text, next);
+    if (referenceEnd !== -1) {
+      const referenceLabel = text.slice(next + 1, referenceEnd);
+      const normalizedReference = normalizeMarkdownReferenceLabel(referenceLabel) || label;
+      return referenceLabels && referenceLabels.has(normalizedReference) ? referenceEnd : -1;
+    }
+  }
+
+  return -1;
+}
+
+function markdownReferenceLabels(text) {
+  const labels = new Set();
+  let lineStart = 0;
+  let openingFence = null;
+  let openingHtmlBlockTag = null;
+  let pendingDefinitionLabel = null;
+
+  while (lineStart < text.length) {
+    const newline = text.indexOf("\n", lineStart);
+    const lineEnd = newline === -1 ? text.length : newline + 1;
+    const line = text.slice(lineStart, lineEnd);
+
+    if (openingFence) {
+      const closingFence = closingCodeFenceDelimiter(line);
+      if (closingFence && closesCodeFence(closingFence, openingFence)) openingFence = null;
+    } else if (openingHtmlBlockTag) {
+      if (closingRawHtmlBlockTag(line, openingHtmlBlockTag)) openingHtmlBlockTag = null;
+    } else if (pendingDefinitionLabel !== null) {
+      if (markdownReferenceDefinitionDestinationContinuationLine(line)) {
+        labels.add(normalizeMarkdownReferenceLabel(pendingDefinitionLabel));
+      }
+      pendingDefinitionLabel = null;
+    } else {
+      const lineFence = openingCodeFenceDelimiter(line);
+      if (lineFence) {
+        openingFence = lineFence;
+      } else {
+        const htmlBlockTag = openingRawHtmlBlockTag(line);
+        if (htmlBlockTag) {
+          if (!closingRawHtmlBlockTag(line, htmlBlockTag)) openingHtmlBlockTag = htmlBlockTag;
+          lineStart = lineEnd;
+          continue;
+        }
+
+        const definition = markdownReferenceDefinition(line);
+        if (definition) {
+          if (definition.hasDestination) {
+            labels.add(normalizeMarkdownReferenceLabel(definition.label));
+          } else {
+            pendingDefinitionLabel = definition.label;
+          }
+        }
+      }
+    }
+
+    lineStart = lineEnd;
+  }
+
+  return labels;
+}
+
+function markdownReferenceDefinitionLabel(line) {
+  const definition = markdownReferenceDefinition(line);
+  return definition ? definition.label : null;
+}
+
+function markdownReferenceDefinition(line) {
+  let i = 0;
+  let leadingSpaces = 0;
+  while (i < line.length && line[i] === " ") {
+    leadingSpaces += 1;
+    i += 1;
+  }
+  if (leadingSpaces > 3 || line[i] !== "[") return null;
+
+  const labelEnd = markdownLabelEnd(line, i);
+  if (labelEnd === -1 || line[labelEnd + 1] !== ":") return null;
+
+  const label = line.slice(i + 1, labelEnd);
+  if (!normalizeMarkdownReferenceLabel(label)) return null;
+
+  const afterColon = line.slice(labelEnd + 2).trim();
+  return { label, hasDestination: afterColon.length > 0 };
+}
+
+function markdownReferenceDefinitionDestinationContinuationLine(line) {
+  const content = indentedReferenceDefinitionContinuationContent(line);
+  return content !== null && content.length > 0;
+}
+
+function markdownReferenceDefinitionTitleContinuationLine(line) {
+  const content = indentedReferenceDefinitionContinuationContent(line);
+  if (content === null) return false;
+
+  let contentEnd = content.length;
+  while (contentEnd > 0 && /\s/.test(content[contentEnd - 1])) contentEnd -= 1;
+  if (contentEnd === 0) return false;
+
+  const opener = content[0];
+  const closer = opener === "(" ? ")" : opener;
+  if (opener !== "\"" && opener !== "'" && opener !== "(") return false;
+
+  let isEscaped = false;
+  for (let j = 1; j < contentEnd; j += 1) {
+    const ch = content[j];
+    if (isEscaped) {
+      isEscaped = false;
+    } else if (ch === "\\") {
+      isEscaped = true;
+    } else if (ch === closer) {
+      return j === contentEnd - 1;
+    }
+  }
+
+  return false;
+}
+
+function indentedReferenceDefinitionContinuationContent(line) {
+  let contentEnd = line.length;
+  while (contentEnd > 0 && /\s/.test(line[contentEnd - 1])) contentEnd -= 1;
+
+  let i = 0;
+  let leadingWhitespace = 0;
+  while (i < contentEnd && (line[i] === " " || line[i] === "\t")) {
+    leadingWhitespace += 1;
+    i += 1;
+  }
+  if (leadingWhitespace === 0 || i >= contentEnd) return null;
+  return line.slice(i, contentEnd);
+}
+
+function normalizeMarkdownReferenceLabel(label) {
+  return label.trim().replace(/\s+/g, " ").toLowerCase();
+}
+
+function markdownLabelEnd(text, start) {
+  if (start >= text.length || text[start] !== "[") return -1;
+
+  let depth = 0;
+  let isEscaped = false;
+  for (let i = start; i < text.length; i += 1) {
+    const ch = text[i];
+    if (isEscaped) {
+      isEscaped = false;
+    } else if (ch === "\\") {
+      isEscaped = true;
+    } else if (ch === "[") {
+      depth += 1;
+    } else if (ch === "]") {
+      depth -= 1;
+      if (depth === 0) return i;
+    }
+  }
+
+  return -1;
+}
+
+function markdownDestinationEnd(text, start) {
+  if (start >= text.length || text[start] !== "(") return -1;
+
+  let depth = 1;
+  let isEscaped = false;
+  let quote = null;
+  let hasDestinationContent = false;
+  let canStartTitleQuote = false;
+
+  for (let i = start + 1; i < text.length; i += 1) {
+    const ch = text[i];
+    if (isEscaped) {
+      isEscaped = false;
+    } else if (ch === "\\") {
+      isEscaped = true;
+    } else if (quote) {
+      if (ch === quote) quote = null;
+    } else if (canStartTitleQuote && (ch === "\"" || ch === "'")) {
+      quote = ch;
+      canStartTitleQuote = false;
+    } else if (ch === "(") {
+      depth += 1;
+      hasDestinationContent = true;
+      canStartTitleQuote = false;
+    } else if (ch === ")") {
+      depth -= 1;
+      if (depth === 0) return i;
+      hasDestinationContent = true;
+      canStartTitleQuote = false;
+    } else if (/\s/.test(ch)) {
+      if (hasDestinationContent && depth === 1) canStartTitleQuote = true;
+    } else {
+      hasDestinationContent = true;
+      canStartTitleQuote = false;
+    }
+  }
+
+  return -1;
+}
+
 // Render markdown to sanitized HTML (agent/user prose is untrusted — DOMPurify
 // strips any script/event-handler injection). Falls back to escaped plain text
 // if the libraries didn't load.
@@ -305,7 +949,7 @@ function md(text) {
   if (typeof marked === "undefined" || typeof DOMPurify === "undefined") {
     const d = document.createElement("div"); d.textContent = text || ""; return d.innerHTML;
   }
-  return DOMPurify.sanitize(marked.parse(text || "", { gfm: true, breaks: true }));
+  return DOMPurify.sanitize(marked.parse(linkifyBareUrls(text), { gfm: true, breaks: true }));
 }
 function cap(s) { return s ? s.charAt(0).toUpperCase() + s.slice(1) : s; }
 
@@ -682,7 +1326,7 @@ $("detail-rename").onclick = () => { if (currentSession) showRenameSheet(current
 $("rename-submit").onclick = submitRename;
 $("rename-cancel").onclick = hideRenameSheet;
 $("rename-sheet").onclick = (e) => { if (e.target.id === "rename-sheet") hideRenameSheet(); };
-$("rename-input").addEventListener("keydown", (e) => {
+listen("rename-input", "keydown", (e) => {
   if (e.key === "Enter") { e.preventDefault(); submitRename(); }
   if (e.key === "Escape") { e.preventDefault(); hideRenameSheet(); }
 });
@@ -696,8 +1340,8 @@ $("file").onchange = async (e) => {
 $("takeover").onclick = () => { if (currentSession) send({ type: "takeOver", sessionId: currentSession }); };
 $("send").onclick = sendPrompt;
 $("stop").onclick = () => { if (!currentSession) return; ensureWriter(); send({ type: "stop", sessionId: currentSession }); };
-$("prompt").addEventListener("input", autoGrowPrompt);
-$("prompt").addEventListener("keydown", (e) => {
+listen("prompt", "input", autoGrowPrompt);
+listen("prompt", "keydown", (e) => {
   if (e.key === "Enter" && !e.shiftKey) { e.preventDefault(); sendPrompt(); }
 });
 

--- a/Alas/Resources/RemoteWeb/app.js
+++ b/Alas/Resources/RemoteWeb/app.js
@@ -1033,6 +1033,7 @@ function markdownDestinationEnd(text, start) {
   let depth = 1;
   let isEscaped = false;
   let quote = null;
+  let isAngleBracketDestination = false;
   let hasDestinationContent = false;
   let canStartTitleQuote = false;
 
@@ -1044,8 +1045,16 @@ function markdownDestinationEnd(text, start) {
       isEscaped = true;
     } else if (quote) {
       if (ch === quote) quote = null;
+    } else if (isAngleBracketDestination) {
+      if (ch === ">") isAngleBracketDestination = false;
+      hasDestinationContent = true;
+      canStartTitleQuote = false;
     } else if (canStartTitleQuote && (ch === "\"" || ch === "'")) {
       quote = ch;
+      canStartTitleQuote = false;
+    } else if (ch === "<" && !hasDestinationContent && depth === 1) {
+      isAngleBracketDestination = true;
+      hasDestinationContent = true;
       canStartTitleQuote = false;
     } else if (ch === "(") {
       depth += 1;

--- a/Alas/Resources/RemoteWeb/index.html
+++ b/Alas/Resources/RemoteWeb/index.html
@@ -99,7 +99,7 @@
   </div>
   <script src="/marked.min.js?v=28"></script>
   <script src="/purify.min.js?v=28"></script>
-  <script src="/app.js?v=36"></script>
+  <script src="/app.js?v=37"></script>
   <script>
     if ("serviceWorker" in navigator) {
       window.addEventListener("load", () => {

--- a/Alas/Resources/RemoteWeb/index.html
+++ b/Alas/Resources/RemoteWeb/index.html
@@ -99,7 +99,7 @@
   </div>
   <script src="/marked.min.js?v=28"></script>
   <script src="/purify.min.js?v=28"></script>
-  <script src="/app.js?v=32"></script>
+  <script src="/app.js?v=33"></script>
   <script>
     if ("serviceWorker" in navigator) {
       window.addEventListener("load", () => {

--- a/Alas/Resources/RemoteWeb/index.html
+++ b/Alas/Resources/RemoteWeb/index.html
@@ -99,7 +99,7 @@
   </div>
   <script src="/marked.min.js?v=28"></script>
   <script src="/purify.min.js?v=28"></script>
-  <script src="/app.js?v=30"></script>
+  <script src="/app.js?v=31"></script>
   <script>
     if ("serviceWorker" in navigator) {
       window.addEventListener("load", () => {

--- a/Alas/Resources/RemoteWeb/index.html
+++ b/Alas/Resources/RemoteWeb/index.html
@@ -99,7 +99,7 @@
   </div>
   <script src="/marked.min.js?v=28"></script>
   <script src="/purify.min.js?v=28"></script>
-  <script src="/app.js?v=33"></script>
+  <script src="/app.js?v=34"></script>
   <script>
     if ("serviceWorker" in navigator) {
       window.addEventListener("load", () => {

--- a/Alas/Resources/RemoteWeb/index.html
+++ b/Alas/Resources/RemoteWeb/index.html
@@ -99,7 +99,7 @@
   </div>
   <script src="/marked.min.js?v=28"></script>
   <script src="/purify.min.js?v=28"></script>
-  <script src="/app.js?v=35"></script>
+  <script src="/app.js?v=36"></script>
   <script>
     if ("serviceWorker" in navigator) {
       window.addEventListener("load", () => {

--- a/Alas/Resources/RemoteWeb/index.html
+++ b/Alas/Resources/RemoteWeb/index.html
@@ -99,7 +99,7 @@
   </div>
   <script src="/marked.min.js?v=28"></script>
   <script src="/purify.min.js?v=28"></script>
-  <script src="/app.js?v=29"></script>
+  <script src="/app.js?v=30"></script>
   <script>
     if ("serviceWorker" in navigator) {
       window.addEventListener("load", () => {

--- a/Alas/Resources/RemoteWeb/index.html
+++ b/Alas/Resources/RemoteWeb/index.html
@@ -99,7 +99,7 @@
   </div>
   <script src="/marked.min.js?v=28"></script>
   <script src="/purify.min.js?v=28"></script>
-  <script src="/app.js?v=34"></script>
+  <script src="/app.js?v=35"></script>
   <script>
     if ("serviceWorker" in navigator) {
       window.addEventListener("load", () => {

--- a/Alas/Resources/RemoteWeb/index.html
+++ b/Alas/Resources/RemoteWeb/index.html
@@ -99,7 +99,7 @@
   </div>
   <script src="/marked.min.js?v=28"></script>
   <script src="/purify.min.js?v=28"></script>
-  <script src="/app.js?v=31"></script>
+  <script src="/app.js?v=32"></script>
   <script>
     if ("serviceWorker" in navigator) {
       window.addEventListener("load", () => {

--- a/Alas/Resources/RemoteWeb/index.html
+++ b/Alas/Resources/RemoteWeb/index.html
@@ -99,7 +99,7 @@
   </div>
   <script src="/marked.min.js?v=28"></script>
   <script src="/purify.min.js?v=28"></script>
-  <script src="/app.js?v=38"></script>
+  <script src="/app.js?v=39"></script>
   <script>
     if ("serviceWorker" in navigator) {
       window.addEventListener("load", () => {

--- a/Alas/Resources/RemoteWeb/index.html
+++ b/Alas/Resources/RemoteWeb/index.html
@@ -99,7 +99,7 @@
   </div>
   <script src="/marked.min.js?v=28"></script>
   <script src="/purify.min.js?v=28"></script>
-  <script src="/app.js?v=40"></script>
+  <script src="/app.js?v=41"></script>
   <script>
     if ("serviceWorker" in navigator) {
       window.addEventListener("load", () => {

--- a/Alas/Resources/RemoteWeb/index.html
+++ b/Alas/Resources/RemoteWeb/index.html
@@ -99,7 +99,7 @@
   </div>
   <script src="/marked.min.js?v=28"></script>
   <script src="/purify.min.js?v=28"></script>
-  <script src="/app.js?v=37"></script>
+  <script src="/app.js?v=38"></script>
   <script>
     if ("serviceWorker" in navigator) {
       window.addEventListener("load", () => {

--- a/Alas/Resources/RemoteWeb/index.html
+++ b/Alas/Resources/RemoteWeb/index.html
@@ -99,7 +99,7 @@
   </div>
   <script src="/marked.min.js?v=28"></script>
   <script src="/purify.min.js?v=28"></script>
-  <script src="/app.js?v=39"></script>
+  <script src="/app.js?v=40"></script>
   <script>
     if ("serviceWorker" in navigator) {
       window.addEventListener("load", () => {

--- a/Alas/Resources/RemoteWeb/sw.js
+++ b/Alas/Resources/RemoteWeb/sw.js
@@ -1,9 +1,9 @@
-const CACHE_NAME = "alas-remote-shell-v7";
+const CACHE_NAME = "alas-remote-shell-v8";
 const SHELL_ASSETS = [
   "/",
   "/index.html",
   "/style.css?v=29",
-  "/app.js?v=31",
+  "/app.js?v=32",
   "/marked.min.js?v=28",
   "/purify.min.js?v=28",
   "/manifest.webmanifest",

--- a/Alas/Resources/RemoteWeb/sw.js
+++ b/Alas/Resources/RemoteWeb/sw.js
@@ -1,9 +1,9 @@
-const CACHE_NAME = "alas-remote-shell-v6";
+const CACHE_NAME = "alas-remote-shell-v7";
 const SHELL_ASSETS = [
   "/",
   "/index.html",
   "/style.css?v=29",
-  "/app.js?v=30",
+  "/app.js?v=31",
   "/marked.min.js?v=28",
   "/purify.min.js?v=28",
   "/manifest.webmanifest",

--- a/Alas/Resources/RemoteWeb/sw.js
+++ b/Alas/Resources/RemoteWeb/sw.js
@@ -1,9 +1,9 @@
-const CACHE_NAME = "alas-remote-shell-v13";
+const CACHE_NAME = "alas-remote-shell-v14";
 const SHELL_ASSETS = [
   "/",
   "/index.html",
   "/style.css?v=29",
-  "/app.js?v=37",
+  "/app.js?v=38",
   "/marked.min.js?v=28",
   "/purify.min.js?v=28",
   "/manifest.webmanifest",

--- a/Alas/Resources/RemoteWeb/sw.js
+++ b/Alas/Resources/RemoteWeb/sw.js
@@ -1,9 +1,9 @@
-const CACHE_NAME = "alas-remote-shell-v15";
+const CACHE_NAME = "alas-remote-shell-v16";
 const SHELL_ASSETS = [
   "/",
   "/index.html",
   "/style.css?v=29",
-  "/app.js?v=39",
+  "/app.js?v=40",
   "/marked.min.js?v=28",
   "/purify.min.js?v=28",
   "/manifest.webmanifest",

--- a/Alas/Resources/RemoteWeb/sw.js
+++ b/Alas/Resources/RemoteWeb/sw.js
@@ -1,9 +1,9 @@
-const CACHE_NAME = "alas-remote-shell-v8";
+const CACHE_NAME = "alas-remote-shell-v9";
 const SHELL_ASSETS = [
   "/",
   "/index.html",
   "/style.css?v=29",
-  "/app.js?v=32",
+  "/app.js?v=33",
   "/marked.min.js?v=28",
   "/purify.min.js?v=28",
   "/manifest.webmanifest",

--- a/Alas/Resources/RemoteWeb/sw.js
+++ b/Alas/Resources/RemoteWeb/sw.js
@@ -1,9 +1,9 @@
-const CACHE_NAME = "alas-remote-shell-v14";
+const CACHE_NAME = "alas-remote-shell-v15";
 const SHELL_ASSETS = [
   "/",
   "/index.html",
   "/style.css?v=29",
-  "/app.js?v=38",
+  "/app.js?v=39",
   "/marked.min.js?v=28",
   "/purify.min.js?v=28",
   "/manifest.webmanifest",

--- a/Alas/Resources/RemoteWeb/sw.js
+++ b/Alas/Resources/RemoteWeb/sw.js
@@ -1,9 +1,9 @@
-const CACHE_NAME = "alas-remote-shell-v10";
+const CACHE_NAME = "alas-remote-shell-v11";
 const SHELL_ASSETS = [
   "/",
   "/index.html",
   "/style.css?v=29",
-  "/app.js?v=34",
+  "/app.js?v=35",
   "/marked.min.js?v=28",
   "/purify.min.js?v=28",
   "/manifest.webmanifest",

--- a/Alas/Resources/RemoteWeb/sw.js
+++ b/Alas/Resources/RemoteWeb/sw.js
@@ -1,9 +1,9 @@
-const CACHE_NAME = "alas-remote-shell-v12";
+const CACHE_NAME = "alas-remote-shell-v13";
 const SHELL_ASSETS = [
   "/",
   "/index.html",
   "/style.css?v=29",
-  "/app.js?v=36",
+  "/app.js?v=37",
   "/marked.min.js?v=28",
   "/purify.min.js?v=28",
   "/manifest.webmanifest",

--- a/Alas/Resources/RemoteWeb/sw.js
+++ b/Alas/Resources/RemoteWeb/sw.js
@@ -1,9 +1,9 @@
-const CACHE_NAME = "alas-remote-shell-v9";
+const CACHE_NAME = "alas-remote-shell-v10";
 const SHELL_ASSETS = [
   "/",
   "/index.html",
   "/style.css?v=29",
-  "/app.js?v=33",
+  "/app.js?v=34",
   "/marked.min.js?v=28",
   "/purify.min.js?v=28",
   "/manifest.webmanifest",

--- a/Alas/Resources/RemoteWeb/sw.js
+++ b/Alas/Resources/RemoteWeb/sw.js
@@ -1,9 +1,9 @@
-const CACHE_NAME = "alas-remote-shell-v16";
+const CACHE_NAME = "alas-remote-shell-v17";
 const SHELL_ASSETS = [
   "/",
   "/index.html",
   "/style.css?v=29",
-  "/app.js?v=40",
+  "/app.js?v=41",
   "/marked.min.js?v=28",
   "/purify.min.js?v=28",
   "/manifest.webmanifest",

--- a/Alas/Resources/RemoteWeb/sw.js
+++ b/Alas/Resources/RemoteWeb/sw.js
@@ -1,9 +1,9 @@
-const CACHE_NAME = "alas-remote-shell-v11";
+const CACHE_NAME = "alas-remote-shell-v12";
 const SHELL_ASSETS = [
   "/",
   "/index.html",
   "/style.css?v=29",
-  "/app.js?v=35",
+  "/app.js?v=36",
   "/marked.min.js?v=28",
   "/purify.min.js?v=28",
   "/manifest.webmanifest",

--- a/Alas/Resources/RemoteWeb/sw.js
+++ b/Alas/Resources/RemoteWeb/sw.js
@@ -1,9 +1,9 @@
-const CACHE_NAME = "alas-remote-shell-v5";
+const CACHE_NAME = "alas-remote-shell-v6";
 const SHELL_ASSETS = [
   "/",
   "/index.html",
   "/style.css?v=29",
-  "/app.js?v=29",
+  "/app.js?v=30",
   "/marked.min.js?v=28",
   "/purify.min.js?v=28",
   "/manifest.webmanifest",

--- a/Alas/Sources/ACP/Session/ACPBareURLLinkifier.swift
+++ b/Alas/Sources/ACP/Session/ACPBareURLLinkifier.swift
@@ -7,6 +7,7 @@ enum ACPBareURLLinkifier {
         var output = ""
         var lineStart = text.startIndex
         var openingFence: CodeFenceDelimiter?
+        var openingHTMLBlockTag: String?
         var inlineState = InlineRewriteState(referenceLabels: markdownReferenceLabels(in: text))
         var referenceDefinitionContinuation: ReferenceDefinitionContinuation?
 
@@ -20,6 +21,11 @@ enum ACPBareURLLinkifier {
                 output += line
                 if closingCodeFenceDelimiter(in: line)?.closes(currentFence) == true {
                     openingFence = nil
+                }
+            } else if preserveFencedCodeBlocks, let currentHTMLBlockTag = openingHTMLBlockTag {
+                output += line
+                if closingRawHTMLBlockTag(in: line, tag: currentHTMLBlockTag) {
+                    openingHTMLBlockTag = nil
                 }
             } else if inlineState.codeSpanDelimiterLength == nil,
                       referenceDefinitionContinuation == .destination,
@@ -40,6 +46,13 @@ enum ACPBareURLLinkifier {
                       let lineFence = openingCodeFenceDelimiter(in: line) {
                 output += line
                 openingFence = lineFence
+            } else if preserveFencedCodeBlocks,
+                      inlineState.codeSpanDelimiterLength == nil,
+                      let htmlBlockTag = openingRawHTMLBlockTag(in: line) {
+                output += line
+                if !closingRawHTMLBlockTag(in: line, tag: htmlBlockTag) {
+                    openingHTMLBlockTag = htmlBlockTag
+                }
             } else {
                 if inlineState.codeSpanDelimiterLength == nil {
                     referenceDefinitionContinuation = nil
@@ -369,6 +382,83 @@ enum ACPBareURLLinkifier {
         return character.isLetter || character == "!" || character == "/" || character == "?"
     }
 
+    private static let rawHTMLBlockTags: Set<String> = [
+        "address", "article", "aside", "base", "basefont", "blockquote", "body",
+        "caption", "center", "col", "colgroup", "dd", "details", "dialog", "dir",
+        "div", "dl", "dt", "fieldset", "figcaption", "figure", "footer", "form",
+        "frame", "frameset", "h1", "h2", "h3", "h4", "h5", "h6", "head", "header",
+        "hr", "html", "iframe", "legend", "li", "link", "main", "menu", "menuitem",
+        "nav", "noframes", "ol", "optgroup", "option", "p", "param", "section",
+        "summary", "table", "tbody", "td", "tfoot", "th", "thead", "title", "tr",
+        "track", "ul", "pre", "script", "style",
+    ]
+
+    private static let rawHTMLVoidBlockTags: Set<String> = [
+        "area", "base", "br", "col", "embed", "hr", "img", "input", "link", "meta",
+        "param", "source", "track", "wbr",
+    ]
+
+    private static func openingRawHTMLBlockTag(in line: String) -> String? {
+        var index = line.startIndex
+        var leadingSpaces = 0
+        while index < line.endIndex, line[index] == " " {
+            leadingSpaces += 1
+            index = line.index(after: index)
+        }
+        guard leadingSpaces <= 3, index < line.endIndex, line[index] == "<" else { return nil }
+
+        let rest = line[index...]
+        if rest.hasPrefix("<!--") { return "#comment" }
+        if rest.hasPrefix("<?") { return "#processing-instruction" }
+        if rest.hasPrefix("<![CDATA[") { return "#cdata" }
+        if rest.hasPrefix("<!"),
+           rest.index(index, offsetBy: 2, limitedBy: line.endIndex).map({ $0 < line.endIndex && line[$0].isUppercase }) == true {
+            return "#declaration"
+        }
+
+        var tagIndex = line.index(after: index)
+        guard tagIndex < line.endIndex, line[tagIndex].isLetter else { return nil }
+        let tagStart = tagIndex
+        while tagIndex < line.endIndex, line[tagIndex].isLetter || line[tagIndex].isNumber || line[tagIndex] == "-" {
+            tagIndex = line.index(after: tagIndex)
+        }
+
+        guard tagIndex < line.endIndex else { return nil }
+        let next = line[tagIndex]
+        let hasValidTerminator: Bool
+        if next.isWhitespace || next == ">" {
+            hasValidTerminator = true
+        } else if next == "/" {
+            let afterSlash = line.index(after: tagIndex)
+            hasValidTerminator = afterSlash < line.endIndex && line[afterSlash] == ">"
+        } else {
+            hasValidTerminator = false
+        }
+        guard hasValidTerminator else { return nil }
+
+        let tag = String(line[tagStart..<tagIndex]).lowercased()
+        guard rawHTMLBlockTags.contains(tag), !rawHTMLVoidBlockTags.contains(tag) else { return nil }
+        return tag
+    }
+
+    private static func closingRawHTMLBlockTag(in line: String, tag: String) -> Bool {
+        switch tag {
+        case "#comment":
+            return line.contains("-->")
+        case "#processing-instruction":
+            return line.contains("?>")
+        case "#cdata":
+            return line.contains("]]>")
+        case "#declaration":
+            return line.contains(">")
+        default:
+            return line.range(
+                of: "</\\s*\(tag)\\s*>",
+                options: [.regularExpression, .caseInsensitive]
+            ) != nil
+        }
+    }
+
     private static func rawURLEnd(in text: String, from start: String.Index) -> String.Index {
         var index = start
         while index < text.endIndex {
@@ -554,6 +644,7 @@ enum ACPBareURLLinkifier {
         var labels: Set<String> = []
         var lineStart = text.startIndex
         var openingFence: CodeFenceDelimiter?
+        var openingHTMLBlockTag: String?
         var pendingDefinitionLabel: String?
 
         while lineStart < text.endIndex {
@@ -566,6 +657,10 @@ enum ACPBareURLLinkifier {
                 if closingCodeFenceDelimiter(in: line)?.closes(currentFence) == true {
                     openingFence = nil
                 }
+            } else if let currentHTMLBlockTag = openingHTMLBlockTag {
+                if closingRawHTMLBlockTag(in: line, tag: currentHTMLBlockTag) {
+                    openingHTMLBlockTag = nil
+                }
             } else if let label = pendingDefinitionLabel {
                 if markdownReferenceDefinitionDestinationContinuationLine(in: line) {
                     labels.insert(normalizeMarkdownReferenceLabel(label))
@@ -573,6 +668,10 @@ enum ACPBareURLLinkifier {
                 pendingDefinitionLabel = nil
             } else if let lineFence = openingCodeFenceDelimiter(in: line) {
                 openingFence = lineFence
+            } else if let htmlBlockTag = openingRawHTMLBlockTag(in: line) {
+                if !closingRawHTMLBlockTag(in: line, tag: htmlBlockTag) {
+                    openingHTMLBlockTag = htmlBlockTag
+                }
             } else if let definition = markdownReferenceDefinition(in: line) {
                 if definition.hasDestination {
                     labels.insert(normalizeMarkdownReferenceLabel(definition.label))

--- a/Alas/Sources/ACP/Session/ACPBareURLLinkifier.swift
+++ b/Alas/Sources/ACP/Session/ACPBareURLLinkifier.swift
@@ -802,8 +802,7 @@ enum ACPBareURLLinkifier {
     }
 
     private static func markdownReferenceDefinitionDestinationContinuationLine(in line: String) -> Bool {
-        guard let content = indentedReferenceDefinitionContinuationContent(in: line) else { return false }
-        return !content.isEmpty
+        !line.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
     }
 
     private static func markdownReferenceDefinitionTitleContinuationLine(in line: String) -> Bool {

--- a/Alas/Sources/ACP/Session/ACPBareURLLinkifier.swift
+++ b/Alas/Sources/ACP/Session/ACPBareURLLinkifier.swift
@@ -3,14 +3,12 @@ import Foundation
 enum ACPBareURLLinkifier {
     static func markdownAutolinkingBareURLs(_ text: String, preserveFencedCodeBlocks: Bool) -> String {
         guard text.contains("http://") || text.contains("https://") else { return text }
-        guard preserveFencedCodeBlocks else {
-            return rewriteInline(text)
-        }
 
         var output = ""
         var lineStart = text.startIndex
         var openingFence: CodeFenceDelimiter?
-        var inlineState = InlineRewriteState()
+        var inlineState = InlineRewriteState(referenceLabels: markdownReferenceLabels(in: text))
+        var referenceDefinitionContinuation: ReferenceDefinitionContinuation?
 
         while lineStart < text.endIndex {
             let lineEnd = text[lineStart...].firstIndex(of: "\n") ?? text.endIndex
@@ -18,16 +16,34 @@ enum ACPBareURLLinkifier {
             let lineRangeEnd = includesNewline ? text.index(after: lineEnd) : lineEnd
             let line = String(text[lineStart..<lineRangeEnd])
 
-            if let currentFence = openingFence {
+            if preserveFencedCodeBlocks, let currentFence = openingFence {
                 output += line
                 if closingCodeFenceDelimiter(in: line)?.closes(currentFence) == true {
                     openingFence = nil
                 }
             } else if inlineState.codeSpanDelimiterLength == nil,
+                      referenceDefinitionContinuation == .destination,
+                      markdownReferenceDefinitionDestinationContinuationLine(in: line) {
+                output += line
+                referenceDefinitionContinuation = .title
+            } else if inlineState.codeSpanDelimiterLength == nil,
+                      referenceDefinitionContinuation == .title,
+                      markdownReferenceDefinitionTitleContinuationLine(in: line) {
+                output += line
+                referenceDefinitionContinuation = nil
+            } else if inlineState.codeSpanDelimiterLength == nil,
+                      let referenceDefinition = markdownReferenceDefinition(in: line) {
+                output += line
+                referenceDefinitionContinuation = referenceDefinition.hasDestination ? .title : .destination
+            } else if preserveFencedCodeBlocks,
+                      inlineState.codeSpanDelimiterLength == nil,
                       let lineFence = openingCodeFenceDelimiter(in: line) {
                 output += line
                 openingFence = lineFence
             } else {
+                if inlineState.codeSpanDelimiterLength == nil {
+                    referenceDefinitionContinuation = nil
+                }
                 output += rewriteInline(line, state: &inlineState, remainingTextAfterSegment: text[lineRangeEnd...])
             }
 
@@ -38,12 +54,18 @@ enum ACPBareURLLinkifier {
     }
 
     private static func rewriteInline(_ text: String) -> String {
-        var state = InlineRewriteState()
+        var state = InlineRewriteState(referenceLabels: markdownReferenceLabels(in: text))
         return rewriteInline(text, state: &state)
     }
 
     private struct InlineRewriteState {
         var codeSpanDelimiterLength: Int?
+        var referenceLabels: Set<String>
+    }
+
+    private enum ReferenceDefinitionContinuation {
+        case destination
+        case title
     }
 
     private static func rewriteInline(
@@ -105,7 +127,8 @@ enum ACPBareURLLinkifier {
                 continue
             }
 
-            if text[index] == "[", let linkEnd = markdownBracketedLinkEnd(in: text, from: index) {
+            if text[index] == "[",
+               let linkEnd = markdownBracketedLinkEnd(in: text, from: index, referenceLabels: state.referenceLabels) {
                 output += text[index...linkEnd]
                 index = text.index(after: linkEnd)
                 continue
@@ -314,7 +337,10 @@ enum ACPBareURLLinkifier {
         var index = start
         while index < text.endIndex {
             let character = text[index]
-            if character.isWhitespace || character.isNewline || character.unicodeScalars.contains(where: { CharacterSet.controlCharacters.contains($0) }) {
+            if character.isWhitespace ||
+                character.isNewline ||
+                "<>[]".contains(character) ||
+                character.unicodeScalars.contains(where: { CharacterSet.controlCharacters.contains($0) }) {
                 break
             }
             index = text.index(after: index)
@@ -377,20 +403,35 @@ enum ACPBareURLLinkifier {
         return closes > opens
     }
 
-    private static func markdownBracketedLinkEnd(in text: String, from start: String.Index) -> String.Index? {
+    private static func markdownBracketedLinkEnd(
+        in text: String,
+        from start: String.Index,
+        referenceLabels: Set<String>
+    ) -> String.Index? {
         guard let labelEnd = markdownLabelEnd(in: text, from: start) else { return nil }
+        let label = normalizeMarkdownReferenceLabel(String(text[text.index(after: start)..<labelEnd]))
+        if referenceLabels.contains(label) {
+            return labelEnd
+        }
+
         let next = text.index(after: labelEnd)
-        guard next < text.endIndex else { return labelEnd }
+        guard next < text.endIndex else { return nil }
+        if text[next...].trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+            return nil
+        }
 
         if text[next] == "(", let destinationEnd = markdownDestinationEnd(in: text, from: next) {
             return destinationEnd
         }
 
         if text[next] == "[", let referenceEnd = markdownLabelEnd(in: text, from: next) {
-            return referenceEnd
+            let referenceLabel = String(text[text.index(after: next)..<referenceEnd])
+            let normalizedReference = normalizeMarkdownReferenceLabel(referenceLabel)
+            let effectiveReference = normalizedReference.isEmpty ? label : normalizedReference
+            return referenceLabels.contains(effectiveReference) ? referenceEnd : nil
         }
 
-        return labelEnd
+        return nil
     }
 
     private static func markdownLabelEnd(in text: String, from start: String.Index) -> String.Index? {
@@ -464,5 +505,123 @@ enum ACPBareURLLinkifier {
         }
 
         return nil
+    }
+
+    private struct MarkdownReferenceDefinition {
+        let label: String
+        let hasDestination: Bool
+    }
+
+    private static func markdownReferenceLabels(in text: String) -> Set<String> {
+        var labels: Set<String> = []
+        var lineStart = text.startIndex
+        var openingFence: CodeFenceDelimiter?
+        var pendingDefinitionLabel: String?
+
+        while lineStart < text.endIndex {
+            let lineEnd = text[lineStart...].firstIndex(of: "\n") ?? text.endIndex
+            let includesNewline = lineEnd < text.endIndex
+            let lineRangeEnd = includesNewline ? text.index(after: lineEnd) : lineEnd
+            let line = String(text[lineStart..<lineRangeEnd])
+
+            if let currentFence = openingFence {
+                if closingCodeFenceDelimiter(in: line)?.closes(currentFence) == true {
+                    openingFence = nil
+                }
+            } else if let label = pendingDefinitionLabel {
+                if markdownReferenceDefinitionDestinationContinuationLine(in: line) {
+                    labels.insert(normalizeMarkdownReferenceLabel(label))
+                }
+                pendingDefinitionLabel = nil
+            } else if let lineFence = openingCodeFenceDelimiter(in: line) {
+                openingFence = lineFence
+            } else if let definition = markdownReferenceDefinition(in: line) {
+                if definition.hasDestination {
+                    labels.insert(normalizeMarkdownReferenceLabel(definition.label))
+                } else {
+                    pendingDefinitionLabel = definition.label
+                }
+            }
+
+            lineStart = lineRangeEnd
+        }
+
+        return labels
+    }
+
+    private static func markdownReferenceDefinition(in line: String) -> MarkdownReferenceDefinition? {
+        var index = line.startIndex
+        var leadingSpaces = 0
+        while index < line.endIndex, line[index] == " " {
+            leadingSpaces += 1
+            index = line.index(after: index)
+        }
+        guard leadingSpaces <= 3, index < line.endIndex, line[index] == "[" else { return nil }
+        guard let labelEnd = markdownLabelEnd(in: line, from: index) else { return nil }
+        let colonIndex = line.index(after: labelEnd)
+        guard colonIndex < line.endIndex, line[colonIndex] == ":" else { return nil }
+
+        let label = String(line[line.index(after: index)..<labelEnd])
+        guard !normalizeMarkdownReferenceLabel(label).isEmpty else { return nil }
+
+        let afterColon = line[line.index(after: colonIndex)...].trimmingCharacters(in: .whitespacesAndNewlines)
+        return MarkdownReferenceDefinition(label: label, hasDestination: !afterColon.isEmpty)
+    }
+
+    private static func markdownReferenceDefinitionDestinationContinuationLine(in line: String) -> Bool {
+        guard let content = indentedReferenceDefinitionContinuationContent(in: line) else { return false }
+        return !content.isEmpty
+    }
+
+    private static func markdownReferenceDefinitionTitleContinuationLine(in line: String) -> Bool {
+        guard let content = indentedReferenceDefinitionContinuationContent(in: line) else { return false }
+        let trimmed = content.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard let opener = trimmed.first else { return false }
+        let closer: Character
+        switch opener {
+        case "\"", "'":
+            closer = opener
+        case "(":
+            closer = ")"
+        default:
+            return false
+        }
+
+        var isEscaped = false
+        var index = trimmed.index(after: trimmed.startIndex)
+        while index < trimmed.endIndex {
+            let character = trimmed[index]
+            if isEscaped {
+                isEscaped = false
+            } else if character == "\\" {
+                isEscaped = true
+            } else if character == closer {
+                return trimmed.index(after: index) == trimmed.endIndex
+            }
+            index = trimmed.index(after: index)
+        }
+
+        return false
+    }
+
+    private static func indentedReferenceDefinitionContinuationContent(in line: String) -> String? {
+        let contentEnd = trailingWhitespaceTrimmedEnd(in: line)
+        var index = line.startIndex
+        var leadingWhitespace = 0
+        while index < contentEnd, line[index] == " " || line[index] == "\t" {
+            leadingWhitespace += 1
+            index = line.index(after: index)
+        }
+        guard leadingWhitespace > 0, index < contentEnd else { return nil }
+        return String(line[index..<contentEnd])
+    }
+
+    private static func normalizeMarkdownReferenceLabel(_ label: String) -> String {
+        label
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+            .components(separatedBy: .whitespacesAndNewlines)
+            .filter { !$0.isEmpty }
+            .joined(separator: " ")
+            .lowercased()
     }
 }

--- a/Alas/Sources/ACP/Session/ACPBareURLLinkifier.swift
+++ b/Alas/Sources/ACP/Session/ACPBareURLLinkifier.swift
@@ -29,7 +29,8 @@ enum ACPBareURLLinkifier {
             } else if preserveFencedCodeBlocks, let currentHTMLBlockTag = openingHTMLBlockTag {
                 output += line
                 var closedHTMLBlock = false
-                if closingRawHTMLBlockTag(in: line, tag: currentHTMLBlockTag) {
+                if closingRawHTMLBlockTag(in: line, tag: currentHTMLBlockTag) ||
+                    rawHTMLBlockEndsAtBlankLine(in: line, tag: currentHTMLBlockTag) {
                     openingHTMLBlockTag = nil
                     closedHTMLBlock = true
                 }
@@ -451,6 +452,10 @@ enum ACPBareURLLinkifier {
         "param", "source", "track", "wbr",
     ]
 
+    private static let rawHTMLExplicitCloseBlockTags: Set<String> = [
+        "pre", "script", "style",
+    ]
+
     private static func openingRawHTMLBlockTag(in line: String) -> String? {
         var index = line.startIndex
         var leadingSpaces = 0
@@ -492,6 +497,12 @@ enum ACPBareURLLinkifier {
         let tag = String(line[tagStart..<tagIndex]).lowercased()
         guard rawHTMLBlockTags.contains(tag), !rawHTMLVoidBlockTags.contains(tag) else { return nil }
         return tag
+    }
+
+    private static func rawHTMLBlockEndsAtBlankLine(in line: String, tag: String) -> Bool {
+        !tag.hasPrefix("#") &&
+        !rawHTMLExplicitCloseBlockTags.contains(tag) &&
+        markdownBlankLine(in: line)
     }
 
     private static func closingRawHTMLBlockTag(in line: String, tag: String) -> Bool {

--- a/Alas/Sources/ACP/Session/ACPBareURLLinkifier.swift
+++ b/Alas/Sources/ACP/Session/ACPBareURLLinkifier.swift
@@ -370,7 +370,19 @@ enum ACPBareURLLinkifier {
 
     private static func hasValidBoundaryBefore(_ index: String.Index, in text: String) -> Bool {
         guard index > text.startIndex else { return true }
-        let previous = text[text.index(before: index)]
+        let previousIndex = text.index(before: index)
+        let previous = text[previousIndex]
+        if "*_~".contains(previous) {
+            var delimiterRunStart = previousIndex
+            while delimiterRunStart > text.startIndex {
+                let before = text.index(before: delimiterRunStart)
+                guard text[before] == previous else { break }
+                delimiterRunStart = before
+            }
+            guard delimiterRunStart > text.startIndex else { return true }
+            let beforeRun = text[text.index(before: delimiterRunStart)]
+            return beforeRun.isWhitespace || "([{\"'".contains(beforeRun)
+        }
         return previous.isWhitespace || "([{\"'".contains(previous)
     }
 
@@ -500,9 +512,18 @@ enum ACPBareURLLinkifier {
 
     private static func trimmedURLEnd(in text: String, from start: String.Index, rawEnd: String.Index) -> String.Index {
         var end = rawEnd
+        let emphasisDelimiterRun = markdownEmphasisDelimiterRunBeforeURLStart(start, in: text)
+        var remainingEmphasisDelimitersToTrim = emphasisDelimiterRun?.length ?? 0
         while end > start {
             let previousIndex = text.index(before: end)
             let character = text[previousIndex]
+            if let delimiter = emphasisDelimiterRun?.delimiter,
+               remainingEmphasisDelimitersToTrim > 0,
+               character == delimiter {
+                remainingEmphasisDelimitersToTrim -= 1
+                end = previousIndex
+                continue
+            }
             if ". ,;:!?\"'".filter({ !$0.isWhitespace }).contains(character) {
                 end = previousIndex
                 continue
@@ -514,6 +535,25 @@ enum ACPBareURLLinkifier {
             break
         }
         return end
+    }
+
+    private static func markdownEmphasisDelimiterRunBeforeURLStart(
+        _ start: String.Index,
+        in text: String
+    ) -> (delimiter: Character, length: Int)? {
+        guard start > text.startIndex else { return nil }
+        var index = text.index(before: start)
+        let delimiter = text[index]
+        guard "*_~".contains(delimiter) else { return nil }
+
+        var length = 1
+        while index > text.startIndex {
+            let before = text.index(before: index)
+            guard text[before] == delimiter else { break }
+            length += 1
+            index = before
+        }
+        return (delimiter, length)
     }
 
     private static func isValidBareWebURL(_ text: String) -> Bool {

--- a/Alas/Sources/ACP/Session/ACPBareURLLinkifier.swift
+++ b/Alas/Sources/ACP/Session/ACPBareURLLinkifier.swift
@@ -8,6 +8,7 @@ enum ACPBareURLLinkifier {
         var lineStart = text.startIndex
         var openingFence: CodeFenceDelimiter?
         var openingHTMLBlockTag: String?
+        var allowsIndentedCodeBlock = true
         var inlineState = InlineRewriteState(referenceLabels: markdownReferenceLabels(in: text))
         var referenceDefinitionContinuation: ReferenceDefinitionContinuation?
 
@@ -19,33 +20,43 @@ enum ACPBareURLLinkifier {
 
             if preserveFencedCodeBlocks, let currentFence = openingFence {
                 output += line
+                var closedFence = false
                 if closingCodeFenceDelimiter(in: line)?.closes(currentFence) == true {
                     openingFence = nil
+                    closedFence = true
                 }
+                allowsIndentedCodeBlock = closedFence
             } else if preserveFencedCodeBlocks, let currentHTMLBlockTag = openingHTMLBlockTag {
                 output += line
+                var closedHTMLBlock = false
                 if closingRawHTMLBlockTag(in: line, tag: currentHTMLBlockTag) {
                     openingHTMLBlockTag = nil
+                    closedHTMLBlock = true
                 }
+                allowsIndentedCodeBlock = closedHTMLBlock
             } else if inlineState.codeSpanDelimiterLength == nil,
                       referenceDefinitionContinuation == .destination,
                       markdownReferenceDefinitionDestinationContinuationLine(in: line) {
                 output += line
                 referenceDefinitionContinuation = .title
+                allowsIndentedCodeBlock = false
             } else if inlineState.codeSpanDelimiterLength == nil,
                       referenceDefinitionContinuation == .title,
                       markdownReferenceDefinitionTitleContinuationLine(in: line) {
                 output += line
                 referenceDefinitionContinuation = nil
+                allowsIndentedCodeBlock = false
             } else if inlineState.codeSpanDelimiterLength == nil,
                       let referenceDefinition = markdownReferenceDefinition(in: line) {
                 output += line
                 referenceDefinitionContinuation = referenceDefinition.hasDestination ? .title : .destination
+                allowsIndentedCodeBlock = false
             } else if preserveFencedCodeBlocks,
                       inlineState.codeSpanDelimiterLength == nil,
                       let lineFence = openingCodeFenceDelimiter(in: line) {
                 output += line
                 openingFence = lineFence
+                allowsIndentedCodeBlock = false
             } else if preserveFencedCodeBlocks,
                       inlineState.codeSpanDelimiterLength == nil,
                       let htmlBlockTag = openingRawHTMLBlockTag(in: line) {
@@ -53,15 +64,19 @@ enum ACPBareURLLinkifier {
                 if !closingRawHTMLBlockTag(in: line, tag: htmlBlockTag) {
                     openingHTMLBlockTag = htmlBlockTag
                 }
+                allowsIndentedCodeBlock = openingHTMLBlockTag == nil
             } else if preserveFencedCodeBlocks,
                       inlineState.codeSpanDelimiterLength == nil,
+                      allowsIndentedCodeBlock,
                       markdownIndentedCodeBlockLine(in: line) {
                 output += line
+                allowsIndentedCodeBlock = true
             } else {
                 if inlineState.codeSpanDelimiterLength == nil {
                     referenceDefinitionContinuation = nil
                 }
                 output += rewriteInline(line, state: &inlineState, remainingTextAfterSegment: text[lineRangeEnd...])
+                allowsIndentedCodeBlock = markdownBlankLine(in: line)
             }
 
             lineStart = lineRangeEnd
@@ -228,6 +243,10 @@ enum ACPBareURLLinkifier {
             end = previous
         }
         return end
+    }
+
+    private static func markdownBlankLine(in line: String) -> Bool {
+        line.allSatisfy { $0.isWhitespace || $0.isNewline }
     }
 
     private static func markdownIndentedCodeBlockLine(in line: String) -> Bool {

--- a/Alas/Sources/ACP/Session/ACPBareURLLinkifier.swift
+++ b/Alas/Sources/ACP/Session/ACPBareURLLinkifier.swift
@@ -743,6 +743,7 @@ enum ACPBareURLLinkifier {
         var depth = 1
         var isEscaped = false
         var quote: Character?
+        var isAngleBracketDestination = false
         var hasDestinationContent = false
         var canStartTitleQuote = false
         var index = text.index(after: start)
@@ -756,8 +757,18 @@ enum ACPBareURLLinkifier {
                 if character == currentQuote {
                     quote = nil
                 }
+            } else if isAngleBracketDestination {
+                if character == ">" {
+                    isAngleBracketDestination = false
+                }
+                hasDestinationContent = true
+                canStartTitleQuote = false
             } else if canStartTitleQuote, character == "\"" || character == "'" {
                 quote = character
+                canStartTitleQuote = false
+            } else if character == "<", !hasDestinationContent, depth == 1 {
+                isAngleBracketDestination = true
+                hasDestinationContent = true
                 canStartTitleQuote = false
             } else if character == "(" {
                 depth += 1

--- a/Alas/Sources/ACP/Session/ACPBareURLLinkifier.swift
+++ b/Alas/Sources/ACP/Session/ACPBareURLLinkifier.swift
@@ -251,7 +251,9 @@ enum ACPBareURLLinkifier {
     }
 
     private static func markdownAllowsIndentedCodeBlockAfterLine(in line: String) -> Bool {
-        markdownBlankLine(in: line) || markdownATXHeadingLine(in: line)
+        markdownBlankLine(in: line) ||
+        markdownATXHeadingLine(in: line) ||
+        markdownThematicBreakLine(in: line)
     }
 
     private static func markdownATXHeadingLine(in line: String) -> Bool {
@@ -271,6 +273,38 @@ enum ACPBareURLLinkifier {
         guard markerCount > 0 else { return false }
         guard index < line.endIndex else { return true }
         return line[index].isWhitespace || line[index].isNewline
+    }
+
+    private static func markdownThematicBreakLine(in line: String) -> Bool {
+        var index = line.startIndex
+        var leadingSpaces = 0
+        while index < line.endIndex, line[index] == " " {
+            leadingSpaces += 1
+            guard leadingSpaces <= 3 else { return false }
+            index = line.index(after: index)
+        }
+
+        var marker: Character?
+        var markerCount = 0
+        while index < line.endIndex {
+            let character = line[index]
+            if character == "\n" || character == "\r" {
+                break
+            }
+            if character == " " || character == "\t" {
+                index = line.index(after: index)
+                continue
+            }
+            if marker == nil {
+                guard character == "-" || character == "_" || character == "*" else { return false }
+                marker = character
+            }
+            guard character == marker else { return false }
+            markerCount += 1
+            index = line.index(after: index)
+        }
+
+        return markerCount >= 3
     }
 
     private static func markdownIndentedCodeBlockLine(in line: String) -> Bool {
@@ -821,16 +855,60 @@ enum ACPBareURLLinkifier {
         guard !normalizeMarkdownReferenceLabel(label).isEmpty else { return nil }
 
         let afterColon = line[line.index(after: colonIndex)...].trimmingCharacters(in: .whitespacesAndNewlines)
-        return MarkdownReferenceDefinition(label: label, hasDestination: !afterColon.isEmpty)
+        guard !afterColon.isEmpty else {
+            return MarkdownReferenceDefinition(label: label, hasDestination: false)
+        }
+        guard markdownReferenceDefinitionDestinationContent(String(afterColon)) else { return nil }
+        return MarkdownReferenceDefinition(label: label, hasDestination: true)
     }
 
     private static func markdownReferenceDefinitionDestinationContinuationLine(in line: String) -> Bool {
-        !line.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+        markdownReferenceDefinitionDestinationContent(
+            line.trimmingCharacters(in: .whitespacesAndNewlines)
+        )
     }
 
     private static func markdownReferenceDefinitionTitleContinuationLine(in line: String) -> Bool {
         guard let content = indentedReferenceDefinitionContinuationContent(in: line) else { return false }
         let trimmed = content.trimmingCharacters(in: .whitespacesAndNewlines)
+        return markdownReferenceDefinitionTitleContent(trimmed)
+    }
+
+    private static func markdownReferenceDefinitionDestinationContent(_ content: String) -> Bool {
+        guard !content.isEmpty else { return false }
+
+        var index = content.startIndex
+        if content[index] == "<" {
+            index = content.index(after: index)
+            var isEscaped = false
+            while index < content.endIndex {
+                let character = content[index]
+                if isEscaped {
+                    isEscaped = false
+                } else if character == "\\" {
+                    isEscaped = true
+                } else if character == ">" {
+                    let afterDestination = content.index(after: index)
+                    let rest = content[afterDestination...].trimmingCharacters(in: .whitespacesAndNewlines)
+                    return rest.isEmpty || markdownReferenceDefinitionTitleContent(String(rest))
+                } else if character.isNewline {
+                    return false
+                }
+                index = content.index(after: index)
+            }
+            return false
+        }
+
+        while index < content.endIndex, !content[index].isWhitespace, !content[index].isNewline {
+            index = content.index(after: index)
+        }
+        guard index > content.startIndex else { return false }
+
+        let rest = content[index...].trimmingCharacters(in: .whitespacesAndNewlines)
+        return rest.isEmpty || markdownReferenceDefinitionTitleContent(String(rest))
+    }
+
+    private static func markdownReferenceDefinitionTitleContent(_ trimmed: String) -> Bool {
         guard let opener = trimmed.first else { return false }
         let closer: Character
         switch opener {

--- a/Alas/Sources/ACP/Session/ACPBareURLLinkifier.swift
+++ b/Alas/Sources/ACP/Session/ACPBareURLLinkifier.swift
@@ -1,0 +1,468 @@
+import Foundation
+
+enum ACPBareURLLinkifier {
+    static func markdownAutolinkingBareURLs(_ text: String, preserveFencedCodeBlocks: Bool) -> String {
+        guard text.contains("http://") || text.contains("https://") else { return text }
+        guard preserveFencedCodeBlocks else {
+            return rewriteInline(text)
+        }
+
+        var output = ""
+        var lineStart = text.startIndex
+        var openingFence: CodeFenceDelimiter?
+        var inlineState = InlineRewriteState()
+
+        while lineStart < text.endIndex {
+            let lineEnd = text[lineStart...].firstIndex(of: "\n") ?? text.endIndex
+            let includesNewline = lineEnd < text.endIndex
+            let lineRangeEnd = includesNewline ? text.index(after: lineEnd) : lineEnd
+            let line = String(text[lineStart..<lineRangeEnd])
+
+            if let currentFence = openingFence {
+                output += line
+                if closingCodeFenceDelimiter(in: line)?.closes(currentFence) == true {
+                    openingFence = nil
+                }
+            } else if inlineState.codeSpanDelimiterLength == nil,
+                      let lineFence = openingCodeFenceDelimiter(in: line) {
+                output += line
+                openingFence = lineFence
+            } else {
+                output += rewriteInline(line, state: &inlineState, remainingTextAfterSegment: text[lineRangeEnd...])
+            }
+
+            lineStart = lineRangeEnd
+        }
+
+        return output
+    }
+
+    private static func rewriteInline(_ text: String) -> String {
+        var state = InlineRewriteState()
+        return rewriteInline(text, state: &state)
+    }
+
+    private struct InlineRewriteState {
+        var codeSpanDelimiterLength: Int?
+    }
+
+    private static func rewriteInline(
+        _ text: String,
+        state: inout InlineRewriteState,
+        remainingTextAfterSegment: Substring? = nil
+    ) -> String {
+        var output = ""
+        var index = text.startIndex
+
+        while index < text.endIndex {
+            if let delimiterLength = state.codeSpanDelimiterLength {
+                if text[index] == "`" {
+                    let closingLength = repeatedCharacterRunLength(in: text, from: index, matching: "`")
+                    if closingLength == delimiterLength {
+                        let end = text.index(index, offsetBy: delimiterLength)
+                        output += text[index..<end]
+                        index = end
+                        state.codeSpanDelimiterLength = nil
+                        continue
+                    }
+                }
+
+                output.append(text[index])
+                index = text.index(after: index)
+                continue
+            }
+
+            if text[index] == "`" {
+                let delimiterLength = repeatedCharacterRunLength(in: text, from: index, matching: "`")
+                if isFenceLikeBacktickDelimiterLine(in: text, at: index, delimiterLength: delimiterLength) {
+                    let end = text.index(index, offsetBy: delimiterLength)
+                    output += text[index..<end]
+                    index = end
+                    continue
+                }
+
+                if let end = codeSpanEnd(in: text, from: index) {
+                    output += text[index...end]
+                    index = text.index(after: end)
+                    continue
+                }
+
+                let end = text.index(index, offsetBy: delimiterLength)
+                output += text[index..<end]
+                index = end
+                let remainingText = remainingTextAfterSegment ?? text[index...]
+                if hasCodeSpanEnd(in: remainingText, delimiterLength: delimiterLength) {
+                    state.codeSpanDelimiterLength = delimiterLength
+                }
+                continue
+            }
+
+            if text[index] == "<",
+               startsWithWebScheme(text, at: text.index(after: index)),
+               let end = text[text.index(after: index)...].firstIndex(of: ">") {
+                output += text[index...end]
+                index = text.index(after: end)
+                continue
+            }
+
+            if text[index] == "[", let linkEnd = markdownBracketedLinkEnd(in: text, from: index) {
+                output += text[index...linkEnd]
+                index = text.index(after: linkEnd)
+                continue
+            }
+
+            if startsWithWebScheme(text, at: index), hasValidBoundaryBefore(index, in: text) {
+                let rawEnd = rawURLEnd(in: text, from: index)
+                let trimmedEnd = trimmedURLEnd(in: text, from: index, rawEnd: rawEnd)
+                if trimmedEnd > index {
+                    let urlText = String(text[index..<trimmedEnd])
+                    if isValidBareWebURL(urlText) {
+                        output += "<\(urlText)>"
+                        output += text[trimmedEnd..<rawEnd]
+                        index = rawEnd
+                        continue
+                    }
+                }
+            }
+
+            output.append(text[index])
+            index = text.index(after: index)
+        }
+
+        return output
+    }
+
+    private struct CodeFenceDelimiter {
+        let marker: Character
+        let length: Int
+
+        func closes(_ openingFence: CodeFenceDelimiter) -> Bool {
+            marker == openingFence.marker && length >= openingFence.length
+        }
+    }
+
+    private static func openingCodeFenceDelimiter(in line: String) -> CodeFenceDelimiter? {
+        codeFenceDelimiter(in: line, allowsTrailingText: true)
+    }
+
+    private static func closingCodeFenceDelimiter(in line: String) -> CodeFenceDelimiter? {
+        codeFenceDelimiter(in: line, allowsTrailingText: false)
+    }
+
+    private static func codeFenceDelimiter(in line: String, allowsTrailingText: Bool) -> CodeFenceDelimiter? {
+        let contentEnd = trailingWhitespaceTrimmedEnd(in: line)
+        var index = line.startIndex
+        var leadingSpaces = 0
+        while index < contentEnd, line[index] == " " {
+            leadingSpaces += 1
+            index = line.index(after: index)
+        }
+        guard leadingSpaces <= 3 else { return nil }
+        guard index < contentEnd else { return nil }
+
+        let first = line[index]
+        guard first == "`" || first == "~" else { return nil }
+
+        var count = 0
+        while index < contentEnd, line[index] == first {
+            count += 1
+            index = line.index(after: index)
+        }
+
+        guard allowsTrailingText || index == contentEnd else { return nil }
+        guard first != "`" || !line[index..<contentEnd].contains("`") else { return nil }
+        return count >= 3 ? CodeFenceDelimiter(marker: first, length: count) : nil
+    }
+
+    private static func trailingWhitespaceTrimmedEnd(in line: String) -> String.Index {
+        var end = line.endIndex
+        while end > line.startIndex {
+            let previous = line.index(before: end)
+            guard line[previous].isWhitespace || line[previous].isNewline else { break }
+            end = previous
+        }
+        return end
+    }
+
+    private static func isFenceLikeBacktickDelimiterLine(in text: String, at index: String.Index, delimiterLength: Int) -> Bool {
+        guard delimiterLength >= 3 else { return false }
+
+        var lineStart = index
+        while lineStart > text.startIndex {
+            let previous = text.index(before: lineStart)
+            guard text[previous] != "\n" else { break }
+            lineStart = previous
+        }
+
+        var prefixIndex = lineStart
+        while prefixIndex < index {
+            guard text[prefixIndex] == " " else { return false }
+            prefixIndex = text.index(after: prefixIndex)
+        }
+
+        var lineEnd = index
+        while lineEnd < text.endIndex, text[lineEnd] != "\n" {
+            lineEnd = text.index(after: lineEnd)
+        }
+
+        let afterDelimiter = text.index(index, offsetBy: delimiterLength)
+        return !text[afterDelimiter..<lineEnd].contains("`")
+    }
+
+    private static func codeSpanEnd(in text: String, from start: String.Index) -> String.Index? {
+        let delimiterLength = repeatedCharacterRunLength(in: text, from: start, matching: "`")
+        var index = text.index(start, offsetBy: delimiterLength)
+        var currentLineIsBlank = false
+
+        while index < text.endIndex {
+            let character = text[index]
+            if character == "\n" {
+                if currentLineIsBlank {
+                    return nil
+                }
+                currentLineIsBlank = true
+                index = text.index(after: index)
+            } else if character.isWhitespace {
+                index = text.index(after: index)
+            } else if character == "`" {
+                currentLineIsBlank = false
+                let closingLength = repeatedCharacterRunLength(in: text, from: index, matching: "`")
+                if closingLength == delimiterLength {
+                    var end = index
+                    for _ in 1..<closingLength {
+                        end = text.index(after: end)
+                    }
+                    return end
+                }
+
+                for _ in 0..<closingLength {
+                    index = text.index(after: index)
+                }
+            } else {
+                currentLineIsBlank = false
+                index = text.index(after: index)
+            }
+        }
+
+        return nil
+    }
+
+    private static func hasCodeSpanEnd(in text: Substring, delimiterLength: Int) -> Bool {
+        var index = text.startIndex
+        var currentLineIsBlank = true
+        while index < text.endIndex {
+            let character = text[index]
+            if character == "\n" {
+                if currentLineIsBlank {
+                    return false
+                }
+                currentLineIsBlank = true
+                index = text.index(after: index)
+            } else if character.isWhitespace {
+                index = text.index(after: index)
+            } else if character == "`" {
+                currentLineIsBlank = false
+                let closingLength = repeatedCharacterRunLength(in: text, from: index, matching: "`")
+                if closingLength == delimiterLength {
+                    return true
+                }
+
+                for _ in 0..<closingLength {
+                    index = text.index(after: index)
+                }
+            } else {
+                currentLineIsBlank = false
+                index = text.index(after: index)
+            }
+        }
+
+        return false
+    }
+
+    private static func repeatedCharacterRunLength(in text: String, from start: String.Index, matching character: Character) -> Int {
+        var count = 0
+        var index = start
+        while index < text.endIndex, text[index] == character {
+            count += 1
+            index = text.index(after: index)
+        }
+        return count
+    }
+
+    private static func repeatedCharacterRunLength(in text: Substring, from start: String.Index, matching character: Character) -> Int {
+        var count = 0
+        var index = start
+        while index < text.endIndex, text[index] == character {
+            count += 1
+            index = text.index(after: index)
+        }
+        return count
+    }
+
+    private static func startsWithWebScheme(_ text: String, at index: String.Index) -> Bool {
+        index <= text.endIndex &&
+        (text[index...].hasPrefix("https://") || text[index...].hasPrefix("http://"))
+    }
+
+    private static func hasValidBoundaryBefore(_ index: String.Index, in text: String) -> Bool {
+        guard index > text.startIndex else { return true }
+        let previous = text[text.index(before: index)]
+        return previous.isWhitespace || "([{\"'".contains(previous)
+    }
+
+    private static func rawURLEnd(in text: String, from start: String.Index) -> String.Index {
+        var index = start
+        while index < text.endIndex {
+            let character = text[index]
+            if character.isWhitespace || character.isNewline || character.unicodeScalars.contains(where: { CharacterSet.controlCharacters.contains($0) }) {
+                break
+            }
+            index = text.index(after: index)
+        }
+        return index
+    }
+
+    private static func trimmedURLEnd(in text: String, from start: String.Index, rawEnd: String.Index) -> String.Index {
+        var end = rawEnd
+        while end > start {
+            let previousIndex = text.index(before: end)
+            let character = text[previousIndex]
+            if ". ,;:!?\"'".filter({ !$0.isWhitespace }).contains(character) {
+                end = previousIndex
+                continue
+            }
+            if isUnbalancedClosing(character, in: text[start..<end]) {
+                end = previousIndex
+                continue
+            }
+            break
+        }
+        return end
+    }
+
+    private static func isValidBareWebURL(_ text: String) -> Bool {
+        let scheme: String
+        if text.hasPrefix("https://") {
+            scheme = "https://"
+        } else if text.hasPrefix("http://") {
+            scheme = "http://"
+        } else {
+            return false
+        }
+
+        let hostStart = text.index(text.startIndex, offsetBy: scheme.count)
+        guard hostStart < text.endIndex else { return false }
+
+        let hostEnd = text[hostStart...].firstIndex { character in
+            character == "/" || character == "?" || character == "#"
+        } ?? text.endIndex
+        let host = text[hostStart..<hostEnd]
+        return host.contains { character in
+            character.isLetter || character.isNumber
+        }
+    }
+
+    private static func isUnbalancedClosing(_ character: Character, in candidate: Substring) -> Bool {
+        let pair: (open: Character, close: Character)?
+        switch character {
+        case ")": pair = ("(", ")")
+        case "]": pair = ("[", "]")
+        case "}": pair = ("{", "}")
+        case ">": pair = ("<", ">")
+        default: pair = nil
+        }
+        guard let pair else { return false }
+        let opens = candidate.filter { $0 == pair.open }.count
+        let closes = candidate.filter { $0 == pair.close }.count
+        return closes > opens
+    }
+
+    private static func markdownBracketedLinkEnd(in text: String, from start: String.Index) -> String.Index? {
+        guard let labelEnd = markdownLabelEnd(in: text, from: start) else { return nil }
+        let next = text.index(after: labelEnd)
+        guard next < text.endIndex else { return labelEnd }
+
+        if text[next] == "(", let destinationEnd = markdownDestinationEnd(in: text, from: next) {
+            return destinationEnd
+        }
+
+        if text[next] == "[", let referenceEnd = markdownLabelEnd(in: text, from: next) {
+            return referenceEnd
+        }
+
+        return labelEnd
+    }
+
+    private static func markdownLabelEnd(in text: String, from start: String.Index) -> String.Index? {
+        guard start < text.endIndex, text[start] == "[" else { return nil }
+
+        var depth = 0
+        var isEscaped = false
+        var index = start
+        while index < text.endIndex {
+            let character = text[index]
+            if isEscaped {
+                isEscaped = false
+            } else if character == "\\" {
+                isEscaped = true
+            } else if character == "[" {
+                depth += 1
+            } else if character == "]" {
+                depth -= 1
+                if depth == 0 {
+                    return index
+                }
+            }
+            index = text.index(after: index)
+        }
+
+        return nil
+    }
+
+    private static func markdownDestinationEnd(in text: String, from start: String.Index) -> String.Index? {
+        guard start < text.endIndex, text[start] == "(" else { return nil }
+
+        var depth = 1
+        var isEscaped = false
+        var quote: Character?
+        var hasDestinationContent = false
+        var canStartTitleQuote = false
+        var index = text.index(after: start)
+        while index < text.endIndex {
+            let character = text[index]
+            if isEscaped {
+                isEscaped = false
+            } else if character == "\\" {
+                isEscaped = true
+            } else if let currentQuote = quote {
+                if character == currentQuote {
+                    quote = nil
+                }
+            } else if canStartTitleQuote, character == "\"" || character == "'" {
+                quote = character
+                canStartTitleQuote = false
+            } else if character == "(" {
+                depth += 1
+                hasDestinationContent = true
+                canStartTitleQuote = false
+            } else if character == ")" {
+                depth -= 1
+                if depth == 0 {
+                    return index
+                }
+                hasDestinationContent = true
+                canStartTitleQuote = false
+            } else if character.isWhitespace || character.isNewline {
+                if hasDestinationContent, depth == 1 {
+                    canStartTitleQuote = true
+                }
+            } else {
+                hasDestinationContent = true
+                canStartTitleQuote = false
+            }
+            index = text.index(after: index)
+        }
+
+        return nil
+    }
+}

--- a/Alas/Sources/ACP/Session/ACPBareURLLinkifier.swift
+++ b/Alas/Sources/ACP/Session/ACPBareURLLinkifier.swift
@@ -718,6 +718,9 @@ enum ACPBareURLLinkifier {
                     canStartTitleQuote = true
                 }
             } else {
+                if canStartTitleQuote {
+                    return nil
+                }
                 hasDestinationContent = true
                 canStartTitleQuote = false
             }

--- a/Alas/Sources/ACP/Session/ACPBareURLLinkifier.swift
+++ b/Alas/Sources/ACP/Session/ACPBareURLLinkifier.swift
@@ -127,6 +127,12 @@ enum ACPBareURLLinkifier {
                 continue
             }
 
+            if text[index] == "<", let end = rawHTMLTagEnd(in: text, from: index) {
+                output += text[index...end]
+                index = text.index(after: end)
+                continue
+            }
+
             if text[index] == "[",
                let linkEnd = markdownBracketedLinkEnd(in: text, from: index, referenceLabels: state.referenceLabels) {
                 output += text[index...linkEnd]
@@ -331,6 +337,36 @@ enum ACPBareURLLinkifier {
         guard index > text.startIndex else { return true }
         let previous = text[text.index(before: index)]
         return previous.isWhitespace || "([{\"'".contains(previous)
+    }
+
+    private static func rawHTMLTagEnd(in text: String, from start: String.Index) -> String.Index? {
+        guard isRawHTMLTagStart(in: text, at: start) else { return nil }
+
+        var index = text.index(after: start)
+        var quote: Character?
+        while index < text.endIndex {
+            let character = text[index]
+            if let currentQuote = quote {
+                if character == currentQuote {
+                    quote = nil
+                }
+            } else if character == "\"" || character == "'" {
+                quote = character
+            } else if character == ">" {
+                return index
+            }
+            index = text.index(after: index)
+        }
+
+        return nil
+    }
+
+    private static func isRawHTMLTagStart(in text: String, at start: String.Index) -> Bool {
+        guard start < text.endIndex, text[start] == "<" else { return false }
+        let next = text.index(after: start)
+        guard next < text.endIndex else { return false }
+        let character = text[next]
+        return character.isLetter || character == "!" || character == "/" || character == "?"
     }
 
     private static func rawURLEnd(in text: String, from start: String.Index) -> String.Index {

--- a/Alas/Sources/ACP/Session/ACPBareURLLinkifier.swift
+++ b/Alas/Sources/ACP/Session/ACPBareURLLinkifier.swift
@@ -337,13 +337,15 @@ enum ACPBareURLLinkifier {
         var index = start
         while index < text.endIndex {
             let character = text[index]
+            let nextIndex = text.index(after: index)
             if character.isWhitespace ||
                 character.isNewline ||
-                "<>[]".contains(character) ||
+                "<>".contains(character) ||
+                (character == "]" && nextIndex < text.endIndex && text[nextIndex] == "[") ||
                 character.unicodeScalars.contains(where: { CharacterSet.controlCharacters.contains($0) }) {
                 break
             }
-            index = text.index(after: index)
+            index = nextIndex
         }
         return index
     }

--- a/Alas/Sources/ACP/Session/ACPBareURLLinkifier.swift
+++ b/Alas/Sources/ACP/Session/ACPBareURLLinkifier.swift
@@ -750,7 +750,8 @@ enum ACPBareURLLinkifier {
                     openingFence = nil
                 }
             } else if let currentHTMLBlockTag = openingHTMLBlockTag {
-                if closingRawHTMLBlockTag(in: line, tag: currentHTMLBlockTag) {
+                if closingRawHTMLBlockTag(in: line, tag: currentHTMLBlockTag) ||
+                    rawHTMLBlockEndsAtBlankLine(in: line, tag: currentHTMLBlockTag) {
                     openingHTMLBlockTag = nil
                 }
             } else if let label = pendingDefinitionLabel {

--- a/Alas/Sources/ACP/Session/ACPBareURLLinkifier.swift
+++ b/Alas/Sources/ACP/Session/ACPBareURLLinkifier.swift
@@ -77,7 +77,7 @@ enum ACPBareURLLinkifier {
                     referenceDefinitionContinuation = nil
                 }
                 output += rewriteInline(line, state: &inlineState, remainingTextAfterSegment: text[lineRangeEnd...])
-                allowsIndentedCodeBlock = markdownBlankLine(in: line)
+                allowsIndentedCodeBlock = markdownAllowsIndentedCodeBlockAfterLine(in: line)
             }
 
             lineStart = lineRangeEnd
@@ -248,6 +248,29 @@ enum ACPBareURLLinkifier {
 
     private static func markdownBlankLine(in line: String) -> Bool {
         line.allSatisfy { $0.isWhitespace || $0.isNewline }
+    }
+
+    private static func markdownAllowsIndentedCodeBlockAfterLine(in line: String) -> Bool {
+        markdownBlankLine(in: line) || markdownATXHeadingLine(in: line)
+    }
+
+    private static func markdownATXHeadingLine(in line: String) -> Bool {
+        var index = line.startIndex
+        var leadingSpaces = 0
+        while index < line.endIndex, line[index] == " " {
+            leadingSpaces += 1
+            guard leadingSpaces <= 3 else { return false }
+            index = line.index(after: index)
+        }
+
+        var markerCount = 0
+        while index < line.endIndex, line[index] == "#", markerCount < 6 {
+            markerCount += 1
+            index = line.index(after: index)
+        }
+        guard markerCount > 0 else { return false }
+        guard index < line.endIndex else { return true }
+        return line[index].isWhitespace || line[index].isNewline
     }
 
     private static func markdownIndentedCodeBlockLine(in line: String) -> Bool {

--- a/Alas/Sources/ACP/Session/ACPBareURLLinkifier.swift
+++ b/Alas/Sources/ACP/Session/ACPBareURLLinkifier.swift
@@ -53,6 +53,10 @@ enum ACPBareURLLinkifier {
                 if !closingRawHTMLBlockTag(in: line, tag: htmlBlockTag) {
                     openingHTMLBlockTag = htmlBlockTag
                 }
+            } else if preserveFencedCodeBlocks,
+                      inlineState.codeSpanDelimiterLength == nil,
+                      markdownIndentedCodeBlockLine(in: line) {
+                output += line
             } else {
                 if inlineState.codeSpanDelimiterLength == nil {
                     referenceDefinitionContinuation = nil
@@ -224,6 +228,24 @@ enum ACPBareURLLinkifier {
             end = previous
         }
         return end
+    }
+
+    private static func markdownIndentedCodeBlockLine(in line: String) -> Bool {
+        var index = line.startIndex
+        var leadingSpaces = 0
+        while index < line.endIndex {
+            switch line[index] {
+            case "\t":
+                return true
+            case " ":
+                leadingSpaces += 1
+                if leadingSpaces >= 4 { return true }
+                index = line.index(after: index)
+            default:
+                return false
+            }
+        }
+        return false
     }
 
     private static func isFenceLikeBacktickDelimiterLine(in text: String, at index: String.Index, delimiterLength: Int) -> Bool {

--- a/Alas/Sources/ACP/Session/ACPTranscriptMarkdown.swift
+++ b/Alas/Sources/ACP/Session/ACPTranscriptMarkdown.swift
@@ -5,7 +5,8 @@ import Foundation
 /// Conversation-only: renders `.user` and `.agent` messages and omits
 /// every other kind (thought, tool call, file edit, plan, system notice).
 /// This is the single source of truth for formatting so whole-session
-/// export and per-message copy render identically.
+/// export/context and per-message copy render identically. Bare prose
+/// web URLs are serialized as Markdown autolinks.
 ///
 /// Reading an agent message's text touches `StreamingText.value`, which is
 /// `@MainActor`-isolated, so the rendering entry points are `@MainActor`.
@@ -22,9 +23,9 @@ enum ACPTranscriptMarkdown {
         for message in messages {
             switch message {
             case .user(_, let text, _):
-                sections.append("## You\n\n\(text)")
+                sections.append("## You\n\n\(serializedBody(text))")
             case .agent(_, let buffer):
-                sections.append("## \(agentHeading)\n\n\(buffer.value)")
+                sections.append("## \(agentHeading)\n\n\(serializedBody(buffer.value))")
             default:
                 continue
             }
@@ -32,12 +33,12 @@ enum ACPTranscriptMarkdown {
         return sections.joined(separator: "\n\n") + "\n"
     }
 
-    /// One message's raw Markdown source, or nil for non-conversation kinds.
+    /// One message's serialized Markdown source, or nil for non-conversation kinds.
     @MainActor
     static func messageBody(_ message: ACPMessage) -> String? {
         switch message {
-        case .user(_, let text, _): return text
-        case .agent(_, let buffer): return buffer.value
+        case .user(_, let text, _): return serializedBody(text)
+        case .agent(_, let buffer): return serializedBody(buffer.value)
         default: return nil
         }
     }
@@ -55,6 +56,13 @@ enum ACPTranscriptMarkdown {
     }
 
     // MARK: - Helpers
+
+    private static func serializedBody(_ text: String) -> String {
+        ACPBareURLLinkifier.markdownAutolinkingBareURLs(
+            text,
+            preserveFencedCodeBlocks: true
+        )
+    }
 
     private static func headerTitle(_ title: String) -> String {
         trimmedNonEmpty(title).flatMap { $0 == "New session" ? nil : $0 } ?? "ACP session"

--- a/Alas/Sources/ACP/UI/ACPMarkdownBlockCache.swift
+++ b/Alas/Sources/ACP/UI/ACPMarkdownBlockCache.swift
@@ -2,7 +2,7 @@ import Foundation
 
 /// Incrementally parses streaming markdown. Promotes already-completed
 /// prefix into `stableBlocks` at every blank line that lies outside a
-/// fenced code block (fence depth zero). Only the un-promoted tail is
+/// fenced code block. Only the un-promoted tail is
 /// re-parsed on each streaming chunk.
 ///
 /// Behavior-preserving: `stableBlocks + ACPMarkdownText.parse(tailUnparsed)`
@@ -35,8 +35,8 @@ final class ACPMarkdownBlockCache {
         promoteIfPossible()
     }
 
-    /// Walk tailUnparsed; find the latest blank line at fence depth zero
-    /// (counting ```-fenced blocks). Everything up to and including that
+    /// Walk tailUnparsed; find the latest blank line outside fenced code
+    /// blocks. Everything up to and including that
     /// blank line gets parsed once and frozen.
     private func promoteIfPossible() {
         guard let safeEnd = ACPMarkdownBlockCache.lastSafePromotionIndex(in: tailUnparsed) else {
@@ -55,17 +55,20 @@ final class ACPMarkdownBlockCache {
     /// stable prefix; for streaming, "fence at start of tail" implies
     /// the prior stable parse closed any earlier fences.
     static func lastSafePromotionIndex(in text: String) -> Int? {
-        var fenceDepth = 0
+        var openingFence: FenceDelimiter?
         var lastSafeEnd: Int? = nil
         var line = ""
         var idx = 0
         for ch in text {
             if ch == "\n" {
-                let trimmed = line.trimmingCharacters(in: .whitespaces)
-                if trimmed.hasPrefix("```") {
-                    fenceDepth = (fenceDepth == 0) ? 1 : 0
+                if let currentFence = openingFence {
+                    if closesFence(line, currentFence) {
+                        openingFence = nil
+                    }
+                } else if let fence = matchFence(line) {
+                    openingFence = fence
                 }
-                if trimmed.isEmpty && fenceDepth == 0 {
+                if line.trimmingCharacters(in: .whitespaces).isEmpty && openingFence == nil {
                     lastSafeEnd = idx + 1 // include the newline
                 }
                 line = ""
@@ -75,5 +78,41 @@ final class ACPMarkdownBlockCache {
             idx += 1
         }
         return lastSafeEnd
+    }
+
+    private struct FenceDelimiter {
+        let marker: Character
+        let length: Int
+    }
+
+    private static func matchFence(_ line: String) -> FenceDelimiter? {
+        var index = line.startIndex
+        var leadingSpaces = 0
+        while index < line.endIndex, line[index] == " " {
+            leadingSpaces += 1
+            guard leadingSpaces <= 3 else { return nil }
+            index = line.index(after: index)
+        }
+        guard index < line.endIndex else { return nil }
+        let fenceText = line[index...]
+        guard let marker = fenceText.first, marker == "`" || marker == "~" else { return nil }
+        let length = fenceText.prefix(while: { $0 == marker }).count
+        guard length >= 3 else { return nil }
+        return FenceDelimiter(marker: marker, length: length)
+    }
+
+    private static func closesFence(_ line: String, _ openingFence: FenceDelimiter) -> Bool {
+        var index = line.startIndex
+        var leadingSpaces = 0
+        while index < line.endIndex, line[index] == " " {
+            leadingSpaces += 1
+            guard leadingSpaces <= 3 else { return false }
+            index = line.index(after: index)
+        }
+        guard index < line.endIndex, line[index] == openingFence.marker else { return false }
+        let markerCount = line[index...].prefix(while: { $0 == openingFence.marker }).count
+        guard markerCount >= openingFence.length else { return false }
+        let afterMarker = line.index(index, offsetBy: markerCount)
+        return line[afterMarker...].allSatisfy(\.isWhitespace)
     }
 }

--- a/Alas/Sources/ACP/UI/ACPMarkdownText.swift
+++ b/Alas/Sources/ACP/UI/ACPMarkdownText.swift
@@ -214,6 +214,25 @@ struct ACPMarkdownText: View {
         return (level, String(body))
     }
 
+    private struct FenceDelimiter {
+        let marker: Character
+        let length: Int
+        let language: String?
+    }
+
+    private static func matchFence(_ trimmedLine: String) -> FenceDelimiter? {
+        guard let marker = trimmedLine.first, marker == "`" || marker == "~" else { return nil }
+        let length = trimmedLine.prefix(while: { $0 == marker }).count
+        guard length >= 3 else { return nil }
+        let language = trimmedLine.dropFirst(length).trimmingCharacters(in: .whitespaces)
+        return FenceDelimiter(marker: marker, length: length, language: language.isEmpty ? nil : language)
+    }
+
+    private static func closesFence(_ trimmedLine: String, _ openingFence: FenceDelimiter) -> Bool {
+        guard trimmedLine.first == openingFence.marker else { return false }
+        return trimmedLine.prefix(while: { $0 == openingFence.marker }).count >= openingFence.length
+    }
+
     static func parse(_ text: String) -> [Block] {
         var blocks: [Block] = []
         var i = 0
@@ -224,16 +243,15 @@ struct ACPMarkdownText: View {
             let trimmed = line.trimmingCharacters(in: .whitespaces)
 
             // Fenced code block.
-            if trimmed.hasPrefix("```") {
-                let lang = trimmed.dropFirst(3).trimmingCharacters(in: .whitespaces)
+            if let fence = matchFence(trimmed) {
                 i += 1
                 var body: [String] = []
-                while i < lines.count, !lines[i].trimmingCharacters(in: .whitespaces).hasPrefix("```") {
+                while i < lines.count, !closesFence(lines[i].trimmingCharacters(in: .whitespaces), fence) {
                     body.append(lines[i])
                     i += 1
                 }
                 if i < lines.count { i += 1 } // skip closing fence
-                blocks.append(.code(language: lang.isEmpty ? nil : lang, body: body.joined(separator: "\n")))
+                blocks.append(.code(language: fence.language, body: body.joined(separator: "\n")))
                 continue
             }
 
@@ -277,7 +295,7 @@ struct ACPMarkdownText: View {
             while i < lines.count {
                 let next = lines[i].trimmingCharacters(in: .whitespaces)
                 if next.isEmpty { break }
-                if next.hasPrefix("```") || next.hasPrefix(">") || matchHeading(next) != nil { break }
+                if matchFence(next) != nil || next.hasPrefix(">") || matchHeading(next) != nil { break }
                 para.append(lines[i])
                 i += 1
             }

--- a/Alas/Sources/ACP/UI/ACPMarkdownText.swift
+++ b/Alas/Sources/ACP/UI/ACPMarkdownText.swift
@@ -128,9 +128,13 @@ struct ACPMarkdownText: View {
         if let hit = inlineCache.object(forKey: key) {
             return AttributedString(hit)
         }
+        let renderSource = ACPBareURLLinkifier.markdownAutolinkingBareURLs(
+            s,
+            preserveFencedCodeBlocks: false
+        )
         let attr: AttributedString
         if let parsed = try? AttributedString(
-            markdown: s,
+            markdown: renderSource,
             options: AttributedString.MarkdownParsingOptions(
                 interpretedSyntax: .inlineOnlyPreservingWhitespace
             )

--- a/Alas/Sources/ACP/UI/ACPMarkdownText.swift
+++ b/Alas/Sources/ACP/UI/ACPMarkdownText.swift
@@ -230,7 +230,9 @@ struct ACPMarkdownText: View {
 
     private static func closesFence(_ trimmedLine: String, _ openingFence: FenceDelimiter) -> Bool {
         guard trimmedLine.first == openingFence.marker else { return false }
-        return trimmedLine.prefix(while: { $0 == openingFence.marker }).count >= openingFence.length
+        let markerCount = trimmedLine.prefix(while: { $0 == openingFence.marker }).count
+        guard markerCount >= openingFence.length else { return false }
+        return trimmedLine.dropFirst(markerCount).allSatisfy(\.isWhitespace)
     }
 
     static func parse(_ text: String) -> [Block] {

--- a/Alas/Sources/ACP/UI/ACPMarkdownText.swift
+++ b/Alas/Sources/ACP/UI/ACPMarkdownText.swift
@@ -220,19 +220,36 @@ struct ACPMarkdownText: View {
         let language: String?
     }
 
-    private static func matchFence(_ trimmedLine: String) -> FenceDelimiter? {
-        guard let marker = trimmedLine.first, marker == "`" || marker == "~" else { return nil }
-        let length = trimmedLine.prefix(while: { $0 == marker }).count
+    private static func matchFence(_ line: String) -> FenceDelimiter? {
+        var index = line.startIndex
+        var leadingSpaces = 0
+        while index < line.endIndex, line[index] == " " {
+            leadingSpaces += 1
+            guard leadingSpaces <= 3 else { return nil }
+            index = line.index(after: index)
+        }
+        guard index < line.endIndex else { return nil }
+        let fenceText = line[index...]
+        guard let marker = fenceText.first, marker == "`" || marker == "~" else { return nil }
+        let length = fenceText.prefix(while: { $0 == marker }).count
         guard length >= 3 else { return nil }
-        let language = trimmedLine.dropFirst(length).trimmingCharacters(in: .whitespaces)
+        let language = fenceText.dropFirst(length).trimmingCharacters(in: .whitespaces)
         return FenceDelimiter(marker: marker, length: length, language: language.isEmpty ? nil : language)
     }
 
-    private static func closesFence(_ trimmedLine: String, _ openingFence: FenceDelimiter) -> Bool {
-        guard trimmedLine.first == openingFence.marker else { return false }
-        let markerCount = trimmedLine.prefix(while: { $0 == openingFence.marker }).count
+    private static func closesFence(_ line: String, _ openingFence: FenceDelimiter) -> Bool {
+        var index = line.startIndex
+        var leadingSpaces = 0
+        while index < line.endIndex, line[index] == " " {
+            leadingSpaces += 1
+            guard leadingSpaces <= 3 else { return false }
+            index = line.index(after: index)
+        }
+        guard index < line.endIndex, line[index] == openingFence.marker else { return false }
+        let markerCount = line[index...].prefix(while: { $0 == openingFence.marker }).count
         guard markerCount >= openingFence.length else { return false }
-        return trimmedLine.dropFirst(markerCount).allSatisfy(\.isWhitespace)
+        let afterMarker = line.index(index, offsetBy: markerCount)
+        return line[afterMarker...].allSatisfy(\.isWhitespace)
     }
 
     static func parse(_ text: String) -> [Block] {
@@ -245,10 +262,10 @@ struct ACPMarkdownText: View {
             let trimmed = line.trimmingCharacters(in: .whitespaces)
 
             // Fenced code block.
-            if let fence = matchFence(trimmed) {
+            if let fence = matchFence(line) {
                 i += 1
                 var body: [String] = []
-                while i < lines.count, !closesFence(lines[i].trimmingCharacters(in: .whitespaces), fence) {
+                while i < lines.count, !closesFence(lines[i], fence) {
                     body.append(lines[i])
                     i += 1
                 }
@@ -297,7 +314,7 @@ struct ACPMarkdownText: View {
             while i < lines.count {
                 let next = lines[i].trimmingCharacters(in: .whitespaces)
                 if next.isEmpty { break }
-                if matchFence(next) != nil || next.hasPrefix(">") || matchHeading(next) != nil { break }
+                if matchFence(lines[i]) != nil || next.hasPrefix(">") || matchHeading(next) != nil { break }
                 para.append(lines[i])
                 i += 1
             }

--- a/AlasTests/ACP/Session/ACPBareURLLinkifierTests.swift
+++ b/AlasTests/ACP/Session/ACPBareURLLinkifierTests.swift
@@ -479,6 +479,33 @@ struct ACPBareURLLinkifierTests {
         #expect(output == "Open (<https://example.com/path>), then stop.")
     }
 
+    @Test("preserves balanced square brackets in URL query")
+    func preservesBalancedSquareBracketsInURLQuery() {
+        let output = ACPBareURLLinkifier.markdownAutolinkingBareURLs(
+            "Open https://example.com/search?ids[]=1 before continuing.",
+            preserveFencedCodeBlocks: true
+        )
+        #expect(output == "Open <https://example.com/search?ids[]=1> before continuing.")
+    }
+
+    @Test("excludes unmatched trailing square bracket")
+    func excludesUnmatchedTrailingSquareBracket() {
+        let output = ACPBareURLLinkifier.markdownAutolinkingBareURLs(
+            "Open [https://example.com/path]",
+            preserveFencedCodeBlocks: true
+        )
+        #expect(output == "Open [<https://example.com/path>]")
+    }
+
+    @Test("does not consume missing reference bracket as URL text")
+    func doesNotConsumeMissingReferenceBracketAsURLText() {
+        let output = ACPBareURLLinkifier.markdownAutolinkingBareURLs(
+            "See [https://example.com/path][missing].",
+            preserveFencedCodeBlocks: true
+        )
+        #expect(output == "See [<https://example.com/path>][missing].")
+    }
+
     @Test("rewrites bare http URL to Markdown autolink")
     func rewritesBareHTTPURL() {
         let output = ACPBareURLLinkifier.markdownAutolinkingBareURLs(

--- a/AlasTests/ACP/Session/ACPBareURLLinkifierTests.swift
+++ b/AlasTests/ACP/Session/ACPBareURLLinkifierTests.swift
@@ -186,6 +186,24 @@ struct ACPBareURLLinkifierTests {
         """)
     }
 
+    @Test("ends block raw HTML at blank line")
+    func endsBlockRawHTMLAtBlankLine() {
+        let input = """
+        <div>
+
+        See https://prose.example.
+        """
+        let output = ACPBareURLLinkifier.markdownAutolinkingBareURLs(
+            input,
+            preserveFencedCodeBlocks: true
+        )
+        #expect(output == """
+        <div>
+
+        See <https://prose.example>.
+        """)
+    }
+
     @Test("preserves indented code block contents")
     func preservesIndentedCodeBlockContents() {
         let input = """

--- a/AlasTests/ACP/Session/ACPBareURLLinkifierTests.swift
+++ b/AlasTests/ACP/Session/ACPBareURLLinkifierTests.swift
@@ -82,6 +82,21 @@ struct ACPBareURLLinkifierTests {
         #expect(output == input)
     }
 
+    @Test("preserves shortcut reference with unindented destination continuation")
+    func preservesShortcutReferenceWithUnindentedDestinationContinuation() {
+        let input = """
+        [https://example.com]:
+        https://target.example
+
+        [https://example.com]
+        """
+        let output = ACPBareURLLinkifier.markdownAutolinkingBareURLs(
+            input,
+            preserveFencedCodeBlocks: true
+        )
+        #expect(output == input)
+    }
+
     @Test("linkifies shortcut text when the matching no-destination definition is invalid")
     func linkifiesShortcutTextWhenNoDestinationDefinitionIsInvalid() {
         let input = """

--- a/AlasTests/ACP/Session/ACPBareURLLinkifierTests.swift
+++ b/AlasTests/ACP/Session/ACPBareURLLinkifierTests.swift
@@ -43,6 +43,16 @@ struct ACPBareURLLinkifierTests {
         #expect(output == "See [<https://example.com>] and then <https://example.org>.")
     }
 
+    @Test("linkifies emphasized bare URL text")
+    func linkifiesEmphasizedBareURLText() {
+        let input = "See **https://example.com/strong** and _https://example.org/em_."
+        let output = ACPBareURLLinkifier.markdownAutolinkingBareURLs(
+            input,
+            preserveFencedCodeBlocks: true
+        )
+        #expect(output == "See **<https://example.com/strong>** and _<https://example.org/em>_.")
+    }
+
     @Test("preserves defined reference-style and shortcut link text")
     func preservesDefinedReferenceLinkText() {
         let input = """

--- a/AlasTests/ACP/Session/ACPBareURLLinkifierTests.swift
+++ b/AlasTests/ACP/Session/ACPBareURLLinkifierTests.swift
@@ -1,0 +1,80 @@
+import Foundation
+import Testing
+@testable import Alas
+
+@Suite("ACPBareURLLinkifier")
+struct ACPBareURLLinkifierTests {
+    @Test("rewrites bare https URL to Markdown autolink")
+    func rewritesBareURL() {
+        let output = ACPBareURLLinkifier.markdownAutolinkingBareURLs(
+            "See https://example.com/path for details.",
+            preserveFencedCodeBlocks: true
+        )
+        #expect(output == "See <https://example.com/path> for details.")
+    }
+
+    @Test("preserves existing Markdown links and autolinks")
+    func preservesExistingMarkdownLinks() {
+        let input = "See [docs](https://example.com/docs) and <https://example.com/raw>."
+        let output = ACPBareURLLinkifier.markdownAutolinkingBareURLs(
+            input,
+            preserveFencedCodeBlocks: true
+        )
+        #expect(output == input)
+    }
+
+    @Test("skips inline code spans")
+    func skipsInlineCode() {
+        let input = "Run `curl https://example.com/api` and then open https://example.com/docs."
+        let output = ACPBareURLLinkifier.markdownAutolinkingBareURLs(
+            input,
+            preserveFencedCodeBlocks: true
+        )
+        #expect(output == "Run `curl https://example.com/api` and then open <https://example.com/docs>.")
+    }
+
+    @Test("skips fenced code blocks")
+    func skipsFencedCodeBlocks() {
+        let input = """
+        Before https://example.com/start.
+
+        ```sh
+        curl https://example.com/api
+        ```
+
+        After https://example.com/end.
+        """
+        let output = ACPBareURLLinkifier.markdownAutolinkingBareURLs(
+            input,
+            preserveFencedCodeBlocks: true
+        )
+        #expect(output == """
+        Before <https://example.com/start>.
+
+        ```sh
+        curl https://example.com/api
+        ```
+
+        After <https://example.com/end>.
+        """)
+    }
+
+    @Test("excludes trailing prose punctuation")
+    func excludesTrailingPunctuation() {
+        let output = ACPBareURLLinkifier.markdownAutolinkingBareURLs(
+            "Open (https://example.com/path), then stop.",
+            preserveFencedCodeBlocks: true
+        )
+        #expect(output == "Open (<https://example.com/path>), then stop.")
+    }
+
+    @Test("does not rewrite scheme-less or non-web URLs")
+    func ignoresUnsupportedURLs() {
+        let input = "Visit example.com, mailto:test@example.com, and file:///tmp/a."
+        let output = ACPBareURLLinkifier.markdownAutolinkingBareURLs(
+            input,
+            preserveFencedCodeBlocks: true
+        )
+        #expect(output == input)
+    }
+}

--- a/AlasTests/ACP/Session/ACPBareURLLinkifierTests.swift
+++ b/AlasTests/ACP/Session/ACPBareURLLinkifierTests.swift
@@ -23,24 +23,95 @@ struct ACPBareURLLinkifierTests {
         #expect(output == input)
     }
 
-    @Test("preserves reference-style link text")
-    func preservesReferenceStyleLinkText() {
+    @Test("linkifies missing reference-style link text")
+    func linkifiesMissingReferenceStyleLinkText() {
         let input = "See [https://example.com][ref] and then https://example.org."
         let output = ACPBareURLLinkifier.markdownAutolinkingBareURLs(
             input,
             preserveFencedCodeBlocks: true
         )
-        #expect(output == "See [https://example.com][ref] and then <https://example.org>.")
+        #expect(output == "See [<https://example.com>][ref] and then <https://example.org>.")
     }
 
-    @Test("preserves shortcut link text")
-    func preservesShortcutLinkText() {
+    @Test("linkifies bracketed URL text without a reference definition")
+    func linkifiesBracketedURLTextWithoutReferenceDefinition() {
         let input = "See [https://example.com] and then https://example.org."
         let output = ACPBareURLLinkifier.markdownAutolinkingBareURLs(
             input,
             preserveFencedCodeBlocks: true
         )
-        #expect(output == "See [https://example.com] and then <https://example.org>.")
+        #expect(output == "See [<https://example.com>] and then <https://example.org>.")
+    }
+
+    @Test("preserves defined reference-style and shortcut link text")
+    func preservesDefinedReferenceLinkText() {
+        let input = """
+        See [https://example.com][ref] and [https://shortcut.example].
+
+        [ref]: https://target.example
+        [https://shortcut.example]: https://shortcut-target.example
+        """
+        let output = ACPBareURLLinkifier.markdownAutolinkingBareURLs(
+            input,
+            preserveFencedCodeBlocks: true
+        )
+        #expect(output == input)
+    }
+
+    @Test("preserves defined shortcut reference followed by punctuation")
+    func preservesDefinedShortcutReferenceWithPunctuation() {
+        let input = """
+        See [https://example.com].
+
+        [https://example.com]: https://target.example
+        """
+        let output = ACPBareURLLinkifier.markdownAutolinkingBareURLs(
+            input,
+            preserveFencedCodeBlocks: true
+        )
+        #expect(output == input)
+    }
+
+    @Test("linkifies shortcut text when the matching no-destination definition is invalid")
+    func linkifiesShortcutTextWhenNoDestinationDefinitionIsInvalid() {
+        let input = """
+        [https://example.com]:
+
+        [https://example.com]
+        """
+        let output = ACPBareURLLinkifier.markdownAutolinkingBareURLs(
+            input,
+            preserveFencedCodeBlocks: true
+        )
+        #expect(output == """
+        [https://example.com]:
+
+        [<https://example.com>]
+        """)
+    }
+
+    @Test("preserves reference definitions and indented continuations")
+    func preservesReferenceDefinitionsAndContinuations() {
+        let input = """
+        [inline]: https://example.com/path "https://title.example"
+        [continued]:
+          https://continued.example/path
+          "https://continued-title.example"
+
+        See https://prose.example.
+        """
+        let output = ACPBareURLLinkifier.markdownAutolinkingBareURLs(
+            input,
+            preserveFencedCodeBlocks: true
+        )
+        #expect(output == """
+        [inline]: https://example.com/path "https://title.example"
+        [continued]:
+          https://continued.example/path
+          "https://continued-title.example"
+
+        See <https://prose.example>.
+        """)
     }
 
     @Test("preserves inline links with nested brackets in label")

--- a/AlasTests/ACP/Session/ACPBareURLLinkifierTests.swift
+++ b/AlasTests/ACP/Session/ACPBareURLLinkifierTests.swift
@@ -176,6 +176,24 @@ struct ACPBareURLLinkifierTests {
         """)
     }
 
+    @Test("preserves indented code block contents")
+    func preservesIndentedCodeBlockContents() {
+        let input = """
+            curl https://example.com/api
+
+        See https://prose.example.
+        """
+        let output = ACPBareURLLinkifier.markdownAutolinkingBareURLs(
+            input,
+            preserveFencedCodeBlocks: true
+        )
+        #expect(output == """
+            curl https://example.com/api
+
+        See <https://prose.example>.
+        """)
+    }
+
     @Test("ignores reference definitions inside raw HTML blocks")
     func ignoresReferenceDefinitionsInsideRawHTMLBlocks() {
         let input = """

--- a/AlasTests/ACP/Session/ACPBareURLLinkifierTests.swift
+++ b/AlasTests/ACP/Session/ACPBareURLLinkifierTests.swift
@@ -154,6 +154,50 @@ struct ACPBareURLLinkifierTests {
         #expect(output == #"<a href="https://example.com">x</a> and <https://prose.example>."#)
     }
 
+    @Test("preserves raw HTML block contents")
+    func preservesRawHTMLBlockContents() {
+        let input = """
+        <pre>
+        https://example.com/raw
+        </pre>
+
+        See https://prose.example.
+        """
+        let output = ACPBareURLLinkifier.markdownAutolinkingBareURLs(
+            input,
+            preserveFencedCodeBlocks: true
+        )
+        #expect(output == """
+        <pre>
+        https://example.com/raw
+        </pre>
+
+        See <https://prose.example>.
+        """)
+    }
+
+    @Test("ignores reference definitions inside raw HTML blocks")
+    func ignoresReferenceDefinitionsInsideRawHTMLBlocks() {
+        let input = """
+        <div>
+        [https://example.com]: https://target.example
+        </div>
+
+        [https://example.com]
+        """
+        let output = ACPBareURLLinkifier.markdownAutolinkingBareURLs(
+            input,
+            preserveFencedCodeBlocks: true
+        )
+        #expect(output == """
+        <div>
+        [https://example.com]: https://target.example
+        </div>
+
+        [<https://example.com>]
+        """)
+    }
+
     @Test("skips inline code spans")
     func skipsInlineCode() {
         let input = "Run `curl https://example.com/api` and then open https://example.com/docs."

--- a/AlasTests/ACP/Session/ACPBareURLLinkifierTests.swift
+++ b/AlasTests/ACP/Session/ACPBareURLLinkifierTests.swift
@@ -204,6 +204,26 @@ struct ACPBareURLLinkifierTests {
         """)
     }
 
+    @Test("linkifies indented paragraph continuation")
+    func linkifiesIndentedParagraphContinuation() {
+        let input = """
+        See details:
+            https://example.com/continued
+
+            curl https://example.com/code
+        """
+        let output = ACPBareURLLinkifier.markdownAutolinkingBareURLs(
+            input,
+            preserveFencedCodeBlocks: true
+        )
+        #expect(output == """
+        See details:
+            <https://example.com/continued>
+
+            curl https://example.com/code
+        """)
+    }
+
     @Test("ignores reference definitions inside raw HTML blocks")
     func ignoresReferenceDefinitionsInsideRawHTMLBlocks() {
         let input = """

--- a/AlasTests/ACP/Session/ACPBareURLLinkifierTests.swift
+++ b/AlasTests/ACP/Session/ACPBareURLLinkifierTests.swift
@@ -23,6 +23,56 @@ struct ACPBareURLLinkifierTests {
         #expect(output == input)
     }
 
+    @Test("preserves reference-style link text")
+    func preservesReferenceStyleLinkText() {
+        let input = "See [https://example.com][ref] and then https://example.org."
+        let output = ACPBareURLLinkifier.markdownAutolinkingBareURLs(
+            input,
+            preserveFencedCodeBlocks: true
+        )
+        #expect(output == "See [https://example.com][ref] and then <https://example.org>.")
+    }
+
+    @Test("preserves shortcut link text")
+    func preservesShortcutLinkText() {
+        let input = "See [https://example.com] and then https://example.org."
+        let output = ACPBareURLLinkifier.markdownAutolinkingBareURLs(
+            input,
+            preserveFencedCodeBlocks: true
+        )
+        #expect(output == "See [https://example.com] and then <https://example.org>.")
+    }
+
+    @Test("preserves inline links with nested brackets in label")
+    func preservesInlineLinksWithNestedBracketsInLabel() {
+        let input = "See [see [nested] https://example.com](https://target.example) and https://example.org."
+        let output = ACPBareURLLinkifier.markdownAutolinkingBareURLs(
+            input,
+            preserveFencedCodeBlocks: true
+        )
+        #expect(output == "See [see [nested] https://example.com](https://target.example) and <https://example.org>.")
+    }
+
+    @Test("preserves inline links with quoted title containing URL")
+    func preservesInlineLinksWithQuotedTitleContainingURL() {
+        let input = #"See [x](https://target.example "title) https://example.com")"#
+        let output = ACPBareURLLinkifier.markdownAutolinkingBareURLs(
+            input,
+            preserveFencedCodeBlocks: true
+        )
+        #expect(output == input)
+    }
+
+    @Test("preserves inline links with apostrophe in destination")
+    func preservesInlineLinksWithApostropheInDestination() {
+        let input = "See [x](https://example.com/it's)"
+        let output = ACPBareURLLinkifier.markdownAutolinkingBareURLs(
+            input,
+            preserveFencedCodeBlocks: true
+        )
+        #expect(output == input)
+    }
+
     @Test("skips inline code spans")
     func skipsInlineCode() {
         let input = "Run `curl https://example.com/api` and then open https://example.com/docs."
@@ -31,6 +81,124 @@ struct ACPBareURLLinkifierTests {
             preserveFencedCodeBlocks: true
         )
         #expect(output == "Run `curl https://example.com/api` and then open <https://example.com/docs>.")
+    }
+
+    @Test("skips inline code spans with multiple backticks")
+    func skipsMultiBacktickInlineCode() {
+        let input = "Run ``curl https://example.com/api`` and then open https://example.com/docs."
+        let output = ACPBareURLLinkifier.markdownAutolinkingBareURLs(
+            input,
+            preserveFencedCodeBlocks: true
+        )
+        #expect(output == "Run ``curl https://example.com/api`` and then open <https://example.com/docs>.")
+    }
+
+    @Test("skips inline code spans across lines")
+    func skipsMultilineInlineCode() {
+        let input = """
+        Run `curl
+        https://example.com/api`
+        Then open https://example.com/docs.
+        """
+        let output = ACPBareURLLinkifier.markdownAutolinkingBareURLs(
+            input,
+            preserveFencedCodeBlocks: true
+        )
+        #expect(output == """
+        Run `curl
+        https://example.com/api`
+        Then open <https://example.com/docs>.
+        """)
+    }
+
+    @Test("treats unmatched single backtick as literal text")
+    func treatsUnmatchedSingleBacktickAsLiteralText() {
+        let output = ACPBareURLLinkifier.markdownAutolinkingBareURLs(
+            "Typo ` before https://example.com",
+            preserveFencedCodeBlocks: true
+        )
+        #expect(output == "Typo ` before <https://example.com>")
+    }
+
+    @Test("treats unmatched double backtick as literal text")
+    func treatsUnmatchedDoubleBacktickAsLiteralText() {
+        let output = ACPBareURLLinkifier.markdownAutolinkingBareURLs(
+            "Typo `` before https://example.com",
+            preserveFencedCodeBlocks: true
+        )
+        #expect(output == "Typo `` before <https://example.com>")
+    }
+
+    @Test("treats multiline unmatched code delimiter as literal text")
+    func treatsMultilineUnmatchedCodeDelimiterAsLiteralText() {
+        let input = """
+        Typo ` before
+        https://example.com
+        """
+        let output = ACPBareURLLinkifier.markdownAutolinkingBareURLs(
+            input,
+            preserveFencedCodeBlocks: true
+        )
+        #expect(output == """
+        Typo ` before
+        <https://example.com>
+        """)
+    }
+
+    @Test("does not carry unmatched code span across blank line")
+    func doesNotCarryUnmatchedCodeSpanAcrossBlankLine() {
+        let input = """
+        Typo ` starts here
+
+        Open https://example.com/docs before ` another tick.
+        """
+        let output = ACPBareURLLinkifier.markdownAutolinkingBareURLs(
+            input,
+            preserveFencedCodeBlocks: true
+        )
+        #expect(output == """
+        Typo ` starts here
+
+        Open <https://example.com/docs> before ` another tick.
+        """)
+    }
+
+    @Test("rewrites fenced URLs when fence preservation is disabled")
+    func rewritesFencedURLsWhenFencePreservationIsDisabled() {
+        let input = """
+        ```sh
+        curl https://example.com/api
+        ```
+        Run `curl https://example.com/inline` and open https://example.com/docs.
+        """
+        let output = ACPBareURLLinkifier.markdownAutolinkingBareURLs(
+            input,
+            preserveFencedCodeBlocks: false
+        )
+        #expect(output == """
+        ```sh
+        curl <https://example.com/api>
+        ```
+        Run `curl https://example.com/inline` and open <https://example.com/docs>.
+        """)
+    }
+
+    @Test("does not carry unmatched code span across blank line when fence preservation is disabled")
+    func doesNotCarryUnmatchedCodeSpanAcrossBlankLineWhenFencePreservationIsDisabled() {
+        let input = """
+        Typo ` starts here
+
+        Open https://example.com/docs before ` another tick.
+        """
+        let output = ACPBareURLLinkifier.markdownAutolinkingBareURLs(
+            input,
+            preserveFencedCodeBlocks: false
+        )
+        #expect(output == """
+        Typo ` starts here
+
+        Open <https://example.com/docs> before ` another tick.
+        """)
     }
 
     @Test("skips fenced code blocks")
@@ -59,6 +227,178 @@ struct ACPBareURLLinkifierTests {
         """)
     }
 
+    @Test("does not treat four-space indented backtick line as fence")
+    func ignoresFourSpaceIndentedBacktickFenceLine() {
+        let input = """
+        Before https://example.com/start.
+
+            ```
+        https://example.com/not-code
+            ```
+
+        After https://example.com/end.
+        """
+        let output = ACPBareURLLinkifier.markdownAutolinkingBareURLs(
+            input,
+            preserveFencedCodeBlocks: true
+        )
+        #expect(output == """
+        Before <https://example.com/start>.
+
+            ```
+        <https://example.com/not-code>
+            ```
+
+        After <https://example.com/end>.
+        """)
+    }
+
+    @Test("does not close longer backtick fence with shorter backtick fence")
+    func keepsLongerBacktickFenceOpenAcrossShorterFence() {
+        let input = """
+        Before https://example.com/start.
+
+        ````sh
+        curl https://example.com/api
+        ```
+        curl https://example.com/after-shorter-fence
+        ````
+
+        After https://example.com/end.
+        """
+        let output = ACPBareURLLinkifier.markdownAutolinkingBareURLs(
+            input,
+            preserveFencedCodeBlocks: true
+        )
+        #expect(output == """
+        Before <https://example.com/start>.
+
+        ````sh
+        curl https://example.com/api
+        ```
+        curl https://example.com/after-shorter-fence
+        ````
+
+        After <https://example.com/end>.
+        """)
+    }
+
+    @Test("does not close backtick fence with trailing text")
+    func keepsBacktickFenceOpenAcrossClosingFenceWithTrailingText() {
+        let input = """
+        Before https://example.com/start.
+
+        ```swift
+        curl https://example.com/api
+        ```not-a-close
+        curl https://example.com/after-invalid-close
+        ```
+
+        After https://example.com/end.
+        """
+        let output = ACPBareURLLinkifier.markdownAutolinkingBareURLs(
+            input,
+            preserveFencedCodeBlocks: true
+        )
+        #expect(output == """
+        Before <https://example.com/start>.
+
+        ```swift
+        curl https://example.com/api
+        ```not-a-close
+        curl https://example.com/after-invalid-close
+        ```
+
+        After <https://example.com/end>.
+        """)
+    }
+
+    @Test("skips tilde fenced code blocks")
+    func skipsTildeFencedCodeBlocks() {
+        let input = """
+        Before https://example.com/start.
+
+        ~~~sh
+        curl https://example.com/api
+        ~~~
+
+        After https://example.com/end.
+        """
+        let output = ACPBareURLLinkifier.markdownAutolinkingBareURLs(
+            input,
+            preserveFencedCodeBlocks: true
+        )
+        #expect(output == """
+        Before <https://example.com/start>.
+
+        ~~~sh
+        curl https://example.com/api
+        ~~~
+
+        After <https://example.com/end>.
+        """)
+    }
+
+    @Test("does not close tilde fence with trailing text")
+    func keepsTildeFenceOpenAcrossClosingFenceWithTrailingText() {
+        let input = """
+        Before https://example.com/start.
+
+        ~~~sh
+        curl https://example.com/api
+        ~~~not-a-close
+        curl https://example.com/after-invalid-close
+        ~~~
+
+        After https://example.com/end.
+        """
+        let output = ACPBareURLLinkifier.markdownAutolinkingBareURLs(
+            input,
+            preserveFencedCodeBlocks: true
+        )
+        #expect(output == """
+        Before <https://example.com/start>.
+
+        ~~~sh
+        curl https://example.com/api
+        ~~~not-a-close
+        curl https://example.com/after-invalid-close
+        ~~~
+
+        After <https://example.com/end>.
+        """)
+    }
+
+    @Test("does not close longer tilde fence with shorter tilde fence")
+    func keepsLongerTildeFenceOpenAcrossShorterFence() {
+        let input = """
+        Before https://example.com/start.
+
+        ~~~~sh
+        curl https://example.com/api
+        ~~~
+        curl https://example.com/after-shorter-fence
+        ~~~~
+
+        After https://example.com/end.
+        """
+        let output = ACPBareURLLinkifier.markdownAutolinkingBareURLs(
+            input,
+            preserveFencedCodeBlocks: true
+        )
+        #expect(output == """
+        Before <https://example.com/start>.
+
+        ~~~~sh
+        curl https://example.com/api
+        ~~~
+        curl https://example.com/after-shorter-fence
+        ~~~~
+
+        After <https://example.com/end>.
+        """)
+    }
+
     @Test("excludes trailing prose punctuation")
     func excludesTrailingPunctuation() {
         let output = ACPBareURLLinkifier.markdownAutolinkingBareURLs(
@@ -66,6 +406,35 @@ struct ACPBareURLLinkifierTests {
             preserveFencedCodeBlocks: true
         )
         #expect(output == "Open (<https://example.com/path>), then stop.")
+    }
+
+    @Test("rewrites bare http URL to Markdown autolink")
+    func rewritesBareHTTPURL() {
+        let output = ACPBareURLLinkifier.markdownAutolinkingBareURLs(
+            "See http://example.com/path for details.",
+            preserveFencedCodeBlocks: true
+        )
+        #expect(output == "See <http://example.com/path> for details.")
+    }
+
+    @Test("does not double-wrap malformed angle autolink")
+    func doesNotDoubleWrapMalformedAngleAutolink() {
+        let input = "Open <https://example.com"
+        let output = ACPBareURLLinkifier.markdownAutolinkingBareURLs(
+            input,
+            preserveFencedCodeBlocks: true
+        )
+        #expect(output == input)
+    }
+
+    @Test("does not rewrite degenerate web URL")
+    func doesNotRewriteDegenerateWebURL() {
+        let input = "Open https://. and https://."
+        let output = ACPBareURLLinkifier.markdownAutolinkingBareURLs(
+            input,
+            preserveFencedCodeBlocks: true
+        )
+        #expect(output == input)
     }
 
     @Test("does not rewrite scheme-less or non-web URLs")

--- a/AlasTests/ACP/Session/ACPBareURLLinkifierTests.swift
+++ b/AlasTests/ACP/Session/ACPBareURLLinkifierTests.swift
@@ -144,6 +144,16 @@ struct ACPBareURLLinkifierTests {
         #expect(output == input)
     }
 
+    @Test("preserves raw HTML tag attributes")
+    func preservesRawHTMLTagAttributes() {
+        let input = #"<a href="https://example.com">x</a> and https://prose.example."#
+        let output = ACPBareURLLinkifier.markdownAutolinkingBareURLs(
+            input,
+            preserveFencedCodeBlocks: true
+        )
+        #expect(output == #"<a href="https://example.com">x</a> and <https://prose.example>."#)
+    }
+
     @Test("skips inline code spans")
     func skipsInlineCode() {
         let input = "Run `curl https://example.com/api` and then open https://example.com/docs."

--- a/AlasTests/ACP/Session/ACPBareURLLinkifierTests.swift
+++ b/AlasTests/ACP/Session/ACPBareURLLinkifierTests.swift
@@ -263,6 +263,26 @@ struct ACPBareURLLinkifierTests {
         """)
     }
 
+    @Test("preserves indented code block after heading")
+    func preservesIndentedCodeBlockAfterHeading() {
+        let input = """
+        # Example
+            curl https://example.com/api
+
+        See https://prose.example.
+        """
+        let output = ACPBareURLLinkifier.markdownAutolinkingBareURLs(
+            input,
+            preserveFencedCodeBlocks: true
+        )
+        #expect(output == """
+        # Example
+            curl https://example.com/api
+
+        See <https://prose.example>.
+        """)
+    }
+
     @Test("linkifies indented paragraph continuation")
     func linkifiesIndentedParagraphContinuation() {
         let input = """

--- a/AlasTests/ACP/Session/ACPBareURLLinkifierTests.swift
+++ b/AlasTests/ACP/Session/ACPBareURLLinkifierTests.swift
@@ -204,6 +204,22 @@ struct ACPBareURLLinkifierTests {
         """)
     }
 
+    @Test("finds shortcut reference definitions after block raw HTML blank line")
+    func findsShortcutReferenceDefinitionsAfterBlockRawHTMLBlankLine() {
+        let input = """
+        <div>
+
+        [https://example.com]: https://target.example
+
+        [https://example.com]
+        """
+        let output = ACPBareURLLinkifier.markdownAutolinkingBareURLs(
+            input,
+            preserveFencedCodeBlocks: true
+        )
+        #expect(output == input)
+    }
+
     @Test("preserves indented code block contents")
     func preservesIndentedCodeBlockContents() {
         let input = """

--- a/AlasTests/ACP/Session/ACPBareURLLinkifierTests.swift
+++ b/AlasTests/ACP/Session/ACPBareURLLinkifierTests.swift
@@ -97,6 +97,44 @@ struct ACPBareURLLinkifierTests {
         #expect(output == input)
     }
 
+    @Test("linkifies invalid reference destination continuation")
+    func linkifiesInvalidReferenceDestinationContinuation() {
+        let input = """
+        [https://example.com]:
+        See https://target.example
+
+        [https://example.com]
+        """
+        let output = ACPBareURLLinkifier.markdownAutolinkingBareURLs(
+            input,
+            preserveFencedCodeBlocks: true
+        )
+        #expect(output == """
+        [https://example.com]:
+        See <https://target.example>
+
+        [<https://example.com>]
+        """)
+    }
+
+    @Test("linkifies invalid same-line reference destination")
+    func linkifiesInvalidSameLineReferenceDestination() {
+        let input = """
+        [https://example.com]: See https://target.example
+
+        [https://example.com]
+        """
+        let output = ACPBareURLLinkifier.markdownAutolinkingBareURLs(
+            input,
+            preserveFencedCodeBlocks: true
+        )
+        #expect(output == """
+        [<https://example.com>]: See <https://target.example>
+
+        [<https://example.com>]
+        """)
+    }
+
     @Test("linkifies shortcut text when the matching no-destination definition is invalid")
     func linkifiesShortcutTextWhenNoDestinationDefinitionIsInvalid() {
         let input = """
@@ -277,6 +315,26 @@ struct ACPBareURLLinkifierTests {
         )
         #expect(output == """
         # Example
+            curl https://example.com/api
+
+        See <https://prose.example>.
+        """)
+    }
+
+    @Test("preserves indented code block after thematic break")
+    func preservesIndentedCodeBlockAfterThematicBreak() {
+        let input = """
+        ---
+            curl https://example.com/api
+
+        See https://prose.example.
+        """
+        let output = ACPBareURLLinkifier.markdownAutolinkingBareURLs(
+            input,
+            preserveFencedCodeBlocks: true
+        )
+        #expect(output == """
+        ---
             curl https://example.com/api
 
         See <https://prose.example>.

--- a/AlasTests/ACP/Session/ACPBareURLLinkifierTests.swift
+++ b/AlasTests/ACP/Session/ACPBareURLLinkifierTests.swift
@@ -207,6 +207,26 @@ struct ACPBareURLLinkifierTests {
         #expect(output == input)
     }
 
+    @Test("preserves inline links with angle bracket destination containing space")
+    func preservesInlineLinksWithAngleBracketDestinationContainingSpace() {
+        let input = "See [doc](<https://example.com/a b>)"
+        let output = ACPBareURLLinkifier.markdownAutolinkingBareURLs(
+            input,
+            preserveFencedCodeBlocks: true
+        )
+        #expect(output == input)
+    }
+
+    @Test("preserves inline links with angle bracket destination containing space and URL title")
+    func preservesInlineLinksWithAngleBracketDestinationContainingSpaceAndURLTitle() {
+        let input = #"See [doc](<https://example.com/a b> "https://title.example")"#
+        let output = ACPBareURLLinkifier.markdownAutolinkingBareURLs(
+            input,
+            preserveFencedCodeBlocks: true
+        )
+        #expect(output == input)
+    }
+
     @Test("linkifies URL inside invalid inline link destination")
     func linkifiesURLInsideInvalidInlineLinkDestination() {
         let input = "See [note](not really https://example.com)."

--- a/AlasTests/ACP/Session/ACPBareURLLinkifierTests.swift
+++ b/AlasTests/ACP/Session/ACPBareURLLinkifierTests.swift
@@ -154,6 +154,16 @@ struct ACPBareURLLinkifierTests {
         #expect(output == input)
     }
 
+    @Test("linkifies URL inside invalid inline link destination")
+    func linkifiesURLInsideInvalidInlineLinkDestination() {
+        let input = "See [note](not really https://example.com)."
+        let output = ACPBareURLLinkifier.markdownAutolinkingBareURLs(
+            input,
+            preserveFencedCodeBlocks: true
+        )
+        #expect(output == "See [note](not really <https://example.com>).")
+    }
+
     @Test("preserves raw HTML tag attributes")
     func preservesRawHTMLTagAttributes() {
         let input = #"<a href="https://example.com">x</a> and https://prose.example."#

--- a/AlasTests/ACP/Session/ACPTranscriptMarkdownTests.swift
+++ b/AlasTests/ACP/Session/ACPTranscriptMarkdownTests.swift
@@ -46,7 +46,51 @@ struct ACPTranscriptMarkdownTests {
         #expect(md == "# T\n\n## A\n\n\(raw)\n")
     }
 
-    @Test("messageBody returns raw text for user/agent, nil otherwise")
+    @Test("document autolinks bare prose URLs")
+    func documentAutolinksBareProseURLs() {
+        let messages: [ACPMessage] = [
+            .agent(id: UUID(), StreamingText("See https://example.com/path."))
+        ]
+        let md = ACPTranscriptMarkdown.document(title: "T", agentName: "A", messages: messages)
+        #expect(md == "# T\n\n## A\n\nSee <https://example.com/path>.\n")
+    }
+
+    @Test("document does not autolink fenced code URLs")
+    func documentSkipsFencedCodeURLs() {
+        let raw = """
+        Before https://example.com/start.
+
+        ```sh
+        curl https://example.com/api
+        ```
+        """
+        let messages: [ACPMessage] = [.agent(id: UUID(), StreamingText(raw))]
+        let md = ACPTranscriptMarkdown.document(title: "T", agentName: "A", messages: messages)
+        #expect(md == """
+        # T
+
+        ## A
+
+        Before <https://example.com/start>.
+
+        ```sh
+        curl https://example.com/api
+        ```
+
+        """)
+    }
+
+    @Test("messageBody returns serialized Markdown with bare URL autolinks")
+    func messageBodyAutolinksBareURLs() {
+        #expect(ACPTranscriptMarkdown.messageBody(
+            .user(id: UUID(), text: "Open https://example.com/docs.", attachments: [])
+        ) == "Open <https://example.com/docs>.")
+        #expect(ACPTranscriptMarkdown.messageBody(
+            .agent(id: UUID(), StreamingText("Use `https://example.com/api`."))
+        ) == "Use `https://example.com/api`.")
+    }
+
+    @Test("messageBody returns serialized text for user/agent, nil otherwise")
     func messageBody() {
         #expect(ACPTranscriptMarkdown.messageBody(
             .user(id: UUID(), text: "u", attachments: [])) == "u")

--- a/AlasTests/ACP/Session/ACPTranscriptMarkdownTests.swift
+++ b/AlasTests/ACP/Session/ACPTranscriptMarkdownTests.swift
@@ -80,6 +80,31 @@ struct ACPTranscriptMarkdownTests {
         """)
     }
 
+    @Test("document preserves reference definitions while autolinking prose URLs")
+    func documentPreservesReferenceDefinitions() {
+        let raw = """
+        [ref]: https://example.com/path "https://title.example"
+        [continued]:
+          https://continued.example/path
+
+        See [https://example.com/path][ref] and https://prose.example.
+        """
+        let messages: [ACPMessage] = [.agent(id: UUID(), StreamingText(raw))]
+        let md = ACPTranscriptMarkdown.document(title: "T", agentName: "A", messages: messages)
+        #expect(md == """
+        # T
+
+        ## A
+
+        [ref]: https://example.com/path "https://title.example"
+        [continued]:
+          https://continued.example/path
+
+        See [https://example.com/path][ref] and <https://prose.example>.
+
+        """)
+    }
+
     @Test("messageBody returns serialized Markdown with bare URL autolinks")
     func messageBodyAutolinksBareURLs() {
         #expect(ACPTranscriptMarkdown.messageBody(

--- a/AlasTests/ACP/UI/ACPMarkdownBlockCacheTests.swift
+++ b/AlasTests/ACP/UI/ACPMarkdownBlockCacheTests.swift
@@ -27,6 +27,17 @@ struct ACPMarkdownBlockCacheTests {
         #expect(cache.stableBlocks.count > stableAfterOpen)
     }
 
+    @Test("blank line inside an unclosed tilde fence does NOT promote stable blocks")
+    func tildeFenceKeepsUnstable() async {
+        let cache = ACPMarkdownBlockCache()
+        cache.update(with: "intro\n\n~~~sh\ncurl https://example.com/api")
+        let stableAfterOpen = cache.stableBlocks.count
+        cache.update(with: "intro\n\n~~~sh\ncurl https://example.com/api\n\nstill code")
+        #expect(cache.stableBlocks.count == stableAfterOpen)
+        cache.update(with: "intro\n\n~~~sh\ncurl https://example.com/api\n\nstill code\n~~~\n\nafter")
+        #expect(cache.stableBlocks.count > stableAfterOpen)
+    }
+
     @Test("cached output equals direct parse for the same input")
     func cacheParityWithDirectParse() async {
         let raw = """

--- a/AlasTests/ACP/UI/ACPMarkdownTextBareURLTests.swift
+++ b/AlasTests/ACP/UI/ACPMarkdownTextBareURLTests.swift
@@ -1,0 +1,70 @@
+import AppKit
+import Foundation
+import Testing
+@testable import Alas
+
+@Suite("ACPMarkdownText bare URL links")
+struct ACPMarkdownTextBareURLTests {
+    @Test("bare https URL carries a link attribute")
+    func bareURLCarriesLinkAttribute() throws {
+        let attributed = NSAttributedString(
+            ACPMarkdownText.inlineMarkdown("See https://example.com/path for details.")
+        )
+        let range = (attributed.string as NSString).range(of: "https://example.com/path")
+        try #require(range.location != NSNotFound)
+        let url = attributed.attribute(.link, at: range.location, effectiveRange: nil) as? URL
+        #expect(url?.absoluteString == "https://example.com/path")
+    }
+
+    @Test("existing Markdown link and bare URL both remain clickable")
+    func existingMarkdownLinkAndBareURLRemainClickable() throws {
+        let attributed = NSAttributedString(
+            ACPMarkdownText.inlineMarkdown("See [docs](https://example.com/docs) and https://example.com/raw.")
+        )
+        let docsRange = (attributed.string as NSString).range(of: "docs")
+        let rawRange = (attributed.string as NSString).range(of: "https://example.com/raw")
+        try #require(docsRange.location != NSNotFound)
+        try #require(rawRange.location != NSNotFound)
+        let docsURL = attributed.attribute(.link, at: docsRange.location, effectiveRange: nil) as? URL
+        let rawURL = attributed.attribute(.link, at: rawRange.location, effectiveRange: nil) as? URL
+        #expect(docsURL?.absoluteString == "https://example.com/docs")
+        #expect(rawURL?.absoluteString == "https://example.com/raw")
+    }
+
+    @Test("inline code URL is not clickable")
+    func inlineCodeURLIsNotClickable() throws {
+        let attributed = NSAttributedString(
+            ACPMarkdownText.inlineMarkdown("Run `curl https://example.com/api`.")
+        )
+        let range = (attributed.string as NSString).range(of: "https://example.com/api")
+        try #require(range.location != NSNotFound)
+        let url = attributed.attribute(.link, at: range.location, effectiveRange: nil) as? URL
+        #expect(url == nil)
+    }
+
+    @Test("trailing punctuation is not part of the link")
+    func trailingPunctuationIsNotPartOfLink() throws {
+        let attributed = NSAttributedString(
+            ACPMarkdownText.inlineMarkdown("Open (https://example.com/path), then stop.")
+        )
+        let range = (attributed.string as NSString).range(of: "https://example.com/path")
+        try #require(range.location != NSNotFound)
+        var effectiveRange = NSRange(location: 0, length: 0)
+        let url = attributed.attribute(.link, at: range.location, effectiveRange: &effectiveRange) as? URL
+        #expect(url?.absoluteString == "https://example.com/path")
+        #expect(effectiveRange == range)
+    }
+
+    @Test("bare URL with markdown delimiter stays one link")
+    func bareURLWithMarkdownDelimiterStaysOneLink() throws {
+        let attributed = NSAttributedString(
+            ACPMarkdownText.inlineMarkdown("Open https://example.com/foo*bar* now.")
+        )
+        let range = (attributed.string as NSString).range(of: "https://example.com/foo*bar*")
+        try #require(range.location != NSNotFound)
+        var effectiveRange = NSRange(location: 0, length: 0)
+        let url = attributed.attribute(.link, at: range.location, effectiveRange: &effectiveRange) as? URL
+        #expect(url?.absoluteString == "https://example.com/foo*bar*")
+        #expect(effectiveRange == range)
+    }
+}

--- a/AlasTests/ACP/UI/ACPMarkdownTextBareURLTests.swift
+++ b/AlasTests/ACP/UI/ACPMarkdownTextBareURLTests.swift
@@ -42,6 +42,17 @@ struct ACPMarkdownTextBareURLTests {
         #expect(url == nil)
     }
 
+    @Test("bracketed bare URL is clickable")
+    func bracketedBareURLIsClickable() throws {
+        let attributed = NSAttributedString(
+            ACPMarkdownText.inlineMarkdown("See [https://example.com].")
+        )
+        let range = (attributed.string as NSString).range(of: "https://example.com")
+        try #require(range.location != NSNotFound)
+        let url = attributed.attribute(.link, at: range.location, effectiveRange: nil) as? URL
+        #expect(url?.absoluteString == "https://example.com")
+    }
+
     @Test("trailing punctuation is not part of the link")
     func trailingPunctuationIsNotPartOfLink() throws {
         let attributed = NSAttributedString(

--- a/AlasTests/ACP/UI/ACPMarkdownTextBareURLTests.swift
+++ b/AlasTests/ACP/UI/ACPMarkdownTextBareURLTests.swift
@@ -5,6 +5,18 @@ import Testing
 
 @Suite("ACPMarkdownText bare URL links")
 struct ACPMarkdownTextBareURLTests {
+    @Test("tilde fenced URL parses as code block")
+    func tildeFencedURLParsesAsCodeBlock() {
+        let blocks = ACPMarkdownText.parse("""
+        ~~~sh
+        curl https://example.com/api
+        ~~~
+        """)
+        #expect(blocks == [
+            .code(language: "sh", body: "curl https://example.com/api"),
+        ])
+    }
+
     @Test("bare https URL carries a link attribute")
     func bareURLCarriesLinkAttribute() throws {
         let attributed = NSAttributedString(

--- a/AlasTests/ACP/UI/ACPMarkdownTextBareURLTests.swift
+++ b/AlasTests/ACP/UI/ACPMarkdownTextBareURLTests.swift
@@ -35,6 +35,18 @@ struct ACPMarkdownTextBareURLTests {
         ])
     }
 
+    @Test("four-space indented tilde fence stays paragraph text")
+    func fourSpaceIndentedTildeFenceStaysParagraphText() {
+        let blocks = ACPMarkdownText.parse("""
+            ~~~
+            curl https://example.com/api
+            ~~~
+        """)
+        #expect(blocks == [
+            .paragraph("    ~~~\n    curl https://example.com/api\n    ~~~"),
+        ])
+    }
+
     @Test("bare https URL carries a link attribute")
     func bareURLCarriesLinkAttribute() throws {
         let attributed = NSAttributedString(

--- a/AlasTests/ACP/UI/ACPMarkdownTextBareURLTests.swift
+++ b/AlasTests/ACP/UI/ACPMarkdownTextBareURLTests.swift
@@ -83,6 +83,17 @@ struct ACPMarkdownTextBareURLTests {
         #expect(url?.absoluteString == "https://example.com")
     }
 
+    @Test("emphasized bare URL is clickable")
+    func emphasizedBareURLIsClickable() throws {
+        let attributed = NSAttributedString(
+            ACPMarkdownText.inlineMarkdown("See **https://example.com/strong**.")
+        )
+        let range = (attributed.string as NSString).range(of: "https://example.com/strong")
+        try #require(range.location != NSNotFound)
+        let url = attributed.attribute(.link, at: range.location, effectiveRange: nil) as? URL
+        #expect(url?.absoluteString == "https://example.com/strong")
+    }
+
     @Test("trailing punctuation is not part of the link")
     func trailingPunctuationIsNotPartOfLink() throws {
         let attributed = NSAttributedString(

--- a/AlasTests/ACP/UI/ACPMarkdownTextBareURLTests.swift
+++ b/AlasTests/ACP/UI/ACPMarkdownTextBareURLTests.swift
@@ -17,6 +17,24 @@ struct ACPMarkdownTextBareURLTests {
         ])
     }
 
+    @Test("tilde fence closer rejects trailing non-whitespace text")
+    func tildeFenceCloserRejectsTrailingNonWhitespaceText() {
+        let blocks = ACPMarkdownText.parse("""
+        ~~~sh
+        curl https://example.com/api
+        ~~~not-a-close
+        curl https://example.com/next
+        ~~~
+        """)
+        #expect(blocks == [
+            .code(language: "sh", body: """
+            curl https://example.com/api
+            ~~~not-a-close
+            curl https://example.com/next
+            """),
+        ])
+    }
+
     @Test("bare https URL carries a link attribute")
     func bareURLCarriesLinkAttribute() throws {
         let attributed = NSAttributedString(

--- a/AlasTests/Remote/RemoteWebAssetTests.swift
+++ b/AlasTests/Remote/RemoteWebAssetTests.swift
@@ -32,10 +32,10 @@ struct RemoteWebAssetTests {
         let html = try asset("index.html")
         let sw = try asset("sw.js")
 
-        #expect(html.contains(#"/app.js?v=38"#))
+        #expect(html.contains(#"/app.js?v=39"#))
         #expect(html.contains(#"/style.css?v=29"#))
-        #expect(sw.contains(#"const CACHE_NAME = "alas-remote-shell-v14";"#))
-        #expect(sw.contains(#""/app.js?v=38""#))
+        #expect(sw.contains(#"const CACHE_NAME = "alas-remote-shell-v15";"#))
+        #expect(sw.contains(#""/app.js?v=39""#))
         #expect(sw.contains(#""/style.css?v=29""#))
     }
 
@@ -46,10 +46,10 @@ struct RemoteWebAssetTests {
         #expect(app.contains("function markdownBlankLine"))
         #expect(app.contains("function markdownAllowsIndentedCodeBlockAfterLine"))
         #expect(app.contains("function rawHtmlBlockEndsAtBlankLine"))
+        #expect(app.contains("function markdownReferenceDefinitionDestinationContent"))
         #expect(app.contains("markdownIndentedCodeBlockLine(line)"))
         #expect(app.components(separatedBy: "rawHtmlBlockEndsAtBlankLine(line, openingHtmlBlockTag)").count == 3)
         #expect(app.contains("if (canStartTitleQuote) return -1;"))
-        #expect(app.contains("return line.trim().length > 0;"))
         #expect(app.contains("function markdownEmphasisDelimiterRunBeforeUrlStart"))
     }
 
@@ -64,7 +64,7 @@ struct RemoteWebAssetTests {
         #expect(app.contains(#""clean""#))
         #expect(css.contains(".session-row-card"))
         #expect(css.contains(".session-meta"))
-        #expect(html.contains("/app.js?v=38"))
+        #expect(html.contains("/app.js?v=39"))
         #expect(html.contains("/style.css?v=29"))
     }
 
@@ -90,7 +90,7 @@ struct RemoteWebAssetTests {
         #expect(css.contains(".session-open"))
         #expect(css.contains("#detail-title"))
         #expect(css.contains(".sheet-input"))
-        #expect(sw.contains(#""/app.js?v=38""#))
+        #expect(sw.contains(#""/app.js?v=39""#))
         #expect(sw.contains(#""/style.css?v=29""#))
     }
 

--- a/AlasTests/Remote/RemoteWebAssetTests.swift
+++ b/AlasTests/Remote/RemoteWebAssetTests.swift
@@ -32,10 +32,10 @@ struct RemoteWebAssetTests {
         let html = try asset("index.html")
         let sw = try asset("sw.js")
 
-        #expect(html.contains(#"/app.js?v=32"#))
+        #expect(html.contains(#"/app.js?v=33"#))
         #expect(html.contains(#"/style.css?v=29"#))
-        #expect(sw.contains(#"const CACHE_NAME = "alas-remote-shell-v8";"#))
-        #expect(sw.contains(#""/app.js?v=32""#))
+        #expect(sw.contains(#"const CACHE_NAME = "alas-remote-shell-v9";"#))
+        #expect(sw.contains(#""/app.js?v=33""#))
         #expect(sw.contains(#""/style.css?v=29""#))
     }
 
@@ -43,6 +43,7 @@ struct RemoteWebAssetTests {
         let app = try asset("app.js")
 
         #expect(app.contains("function markdownIndentedCodeBlockLine"))
+        #expect(app.contains("function markdownBlankLine"))
         #expect(app.contains("markdownIndentedCodeBlockLine(line)"))
         #expect(app.contains("function markdownEmphasisDelimiterRunBeforeUrlStart"))
     }
@@ -58,7 +59,7 @@ struct RemoteWebAssetTests {
         #expect(app.contains(#""clean""#))
         #expect(css.contains(".session-row-card"))
         #expect(css.contains(".session-meta"))
-        #expect(html.contains("/app.js?v=32"))
+        #expect(html.contains("/app.js?v=33"))
         #expect(html.contains("/style.css?v=29"))
     }
 
@@ -84,7 +85,7 @@ struct RemoteWebAssetTests {
         #expect(css.contains(".session-open"))
         #expect(css.contains("#detail-title"))
         #expect(css.contains(".sheet-input"))
-        #expect(sw.contains(#""/app.js?v=32""#))
+        #expect(sw.contains(#""/app.js?v=33""#))
         #expect(sw.contains(#""/style.css?v=29""#))
     }
 

--- a/AlasTests/Remote/RemoteWebAssetTests.swift
+++ b/AlasTests/Remote/RemoteWebAssetTests.swift
@@ -32,10 +32,10 @@ struct RemoteWebAssetTests {
         let html = try asset("index.html")
         let sw = try asset("sw.js")
 
-        #expect(html.contains(#"/app.js?v=37"#))
+        #expect(html.contains(#"/app.js?v=38"#))
         #expect(html.contains(#"/style.css?v=29"#))
-        #expect(sw.contains(#"const CACHE_NAME = "alas-remote-shell-v13";"#))
-        #expect(sw.contains(#""/app.js?v=37""#))
+        #expect(sw.contains(#"const CACHE_NAME = "alas-remote-shell-v14";"#))
+        #expect(sw.contains(#""/app.js?v=38""#))
         #expect(sw.contains(#""/style.css?v=29""#))
     }
 
@@ -44,6 +44,7 @@ struct RemoteWebAssetTests {
 
         #expect(app.contains("function markdownIndentedCodeBlockLine"))
         #expect(app.contains("function markdownBlankLine"))
+        #expect(app.contains("function markdownAllowsIndentedCodeBlockAfterLine"))
         #expect(app.contains("function rawHtmlBlockEndsAtBlankLine"))
         #expect(app.contains("markdownIndentedCodeBlockLine(line)"))
         #expect(app.components(separatedBy: "rawHtmlBlockEndsAtBlankLine(line, openingHtmlBlockTag)").count == 3)
@@ -63,7 +64,7 @@ struct RemoteWebAssetTests {
         #expect(app.contains(#""clean""#))
         #expect(css.contains(".session-row-card"))
         #expect(css.contains(".session-meta"))
-        #expect(html.contains("/app.js?v=37"))
+        #expect(html.contains("/app.js?v=38"))
         #expect(html.contains("/style.css?v=29"))
     }
 
@@ -89,7 +90,7 @@ struct RemoteWebAssetTests {
         #expect(css.contains(".session-open"))
         #expect(css.contains("#detail-title"))
         #expect(css.contains(".sheet-input"))
-        #expect(sw.contains(#""/app.js?v=37""#))
+        #expect(sw.contains(#""/app.js?v=38""#))
         #expect(sw.contains(#""/style.css?v=29""#))
     }
 

--- a/AlasTests/Remote/RemoteWebAssetTests.swift
+++ b/AlasTests/Remote/RemoteWebAssetTests.swift
@@ -32,10 +32,10 @@ struct RemoteWebAssetTests {
         let html = try asset("index.html")
         let sw = try asset("sw.js")
 
-        #expect(html.contains(#"/app.js?v=35"#))
+        #expect(html.contains(#"/app.js?v=36"#))
         #expect(html.contains(#"/style.css?v=29"#))
-        #expect(sw.contains(#"const CACHE_NAME = "alas-remote-shell-v11";"#))
-        #expect(sw.contains(#""/app.js?v=35""#))
+        #expect(sw.contains(#"const CACHE_NAME = "alas-remote-shell-v12";"#))
+        #expect(sw.contains(#""/app.js?v=36""#))
         #expect(sw.contains(#""/style.css?v=29""#))
     }
 
@@ -47,6 +47,7 @@ struct RemoteWebAssetTests {
         #expect(app.contains("function rawHtmlBlockEndsAtBlankLine"))
         #expect(app.contains("markdownIndentedCodeBlockLine(line)"))
         #expect(app.components(separatedBy: "rawHtmlBlockEndsAtBlankLine(line, openingHtmlBlockTag)").count == 3)
+        #expect(app.contains("if (canStartTitleQuote) return -1;"))
         #expect(app.contains("function markdownEmphasisDelimiterRunBeforeUrlStart"))
     }
 
@@ -61,7 +62,7 @@ struct RemoteWebAssetTests {
         #expect(app.contains(#""clean""#))
         #expect(css.contains(".session-row-card"))
         #expect(css.contains(".session-meta"))
-        #expect(html.contains("/app.js?v=35"))
+        #expect(html.contains("/app.js?v=36"))
         #expect(html.contains("/style.css?v=29"))
     }
 
@@ -87,7 +88,7 @@ struct RemoteWebAssetTests {
         #expect(css.contains(".session-open"))
         #expect(css.contains("#detail-title"))
         #expect(css.contains(".sheet-input"))
-        #expect(sw.contains(#""/app.js?v=35""#))
+        #expect(sw.contains(#""/app.js?v=36""#))
         #expect(sw.contains(#""/style.css?v=29""#))
     }
 

--- a/AlasTests/Remote/RemoteWebAssetTests.swift
+++ b/AlasTests/Remote/RemoteWebAssetTests.swift
@@ -32,10 +32,10 @@ struct RemoteWebAssetTests {
         let html = try asset("index.html")
         let sw = try asset("sw.js")
 
-        #expect(html.contains(#"/app.js?v=40"#))
+        #expect(html.contains(#"/app.js?v=41"#))
         #expect(html.contains(#"/style.css?v=29"#))
-        #expect(sw.contains(#"const CACHE_NAME = "alas-remote-shell-v16";"#))
-        #expect(sw.contains(#""/app.js?v=40""#))
+        #expect(sw.contains(#"const CACHE_NAME = "alas-remote-shell-v17";"#))
+        #expect(sw.contains(#""/app.js?v=41""#))
         #expect(sw.contains(#""/style.css?v=29""#))
     }
 
@@ -45,9 +45,11 @@ struct RemoteWebAssetTests {
         #expect(app.contains("function markdownIndentedCodeBlockLine"))
         #expect(app.contains("function markdownBlankLine"))
         #expect(app.contains("function markdownAllowsIndentedCodeBlockAfterLine"))
+        #expect(app.contains("function markdownThematicBreakLine"))
         #expect(app.contains("function rawHtmlBlockEndsAtBlankLine"))
         #expect(app.contains("function markdownReferenceDefinitionDestinationContent"))
         #expect(app.contains("isAngleBracketDestination"))
+        #expect(app.contains("markdownThematicBreakLine(line)"))
         #expect(app.contains("markdownIndentedCodeBlockLine(line)"))
         #expect(app.components(separatedBy: "rawHtmlBlockEndsAtBlankLine(line, openingHtmlBlockTag)").count == 3)
         #expect(app.contains("if (canStartTitleQuote) return -1;"))
@@ -65,7 +67,7 @@ struct RemoteWebAssetTests {
         #expect(app.contains(#""clean""#))
         #expect(css.contains(".session-row-card"))
         #expect(css.contains(".session-meta"))
-        #expect(html.contains("/app.js?v=40"))
+        #expect(html.contains("/app.js?v=41"))
         #expect(html.contains("/style.css?v=29"))
     }
 
@@ -91,7 +93,7 @@ struct RemoteWebAssetTests {
         #expect(css.contains(".session-open"))
         #expect(css.contains("#detail-title"))
         #expect(css.contains(".sheet-input"))
-        #expect(sw.contains(#""/app.js?v=40""#))
+        #expect(sw.contains(#""/app.js?v=41""#))
         #expect(sw.contains(#""/style.css?v=29""#))
     }
 

--- a/AlasTests/Remote/RemoteWebAssetTests.swift
+++ b/AlasTests/Remote/RemoteWebAssetTests.swift
@@ -32,10 +32,10 @@ struct RemoteWebAssetTests {
         let html = try asset("index.html")
         let sw = try asset("sw.js")
 
-        #expect(html.contains(#"/app.js?v=36"#))
+        #expect(html.contains(#"/app.js?v=37"#))
         #expect(html.contains(#"/style.css?v=29"#))
-        #expect(sw.contains(#"const CACHE_NAME = "alas-remote-shell-v12";"#))
-        #expect(sw.contains(#""/app.js?v=36""#))
+        #expect(sw.contains(#"const CACHE_NAME = "alas-remote-shell-v13";"#))
+        #expect(sw.contains(#""/app.js?v=37""#))
         #expect(sw.contains(#""/style.css?v=29""#))
     }
 
@@ -48,6 +48,7 @@ struct RemoteWebAssetTests {
         #expect(app.contains("markdownIndentedCodeBlockLine(line)"))
         #expect(app.components(separatedBy: "rawHtmlBlockEndsAtBlankLine(line, openingHtmlBlockTag)").count == 3)
         #expect(app.contains("if (canStartTitleQuote) return -1;"))
+        #expect(app.contains("return line.trim().length > 0;"))
         #expect(app.contains("function markdownEmphasisDelimiterRunBeforeUrlStart"))
     }
 
@@ -62,7 +63,7 @@ struct RemoteWebAssetTests {
         #expect(app.contains(#""clean""#))
         #expect(css.contains(".session-row-card"))
         #expect(css.contains(".session-meta"))
-        #expect(html.contains("/app.js?v=36"))
+        #expect(html.contains("/app.js?v=37"))
         #expect(html.contains("/style.css?v=29"))
     }
 
@@ -88,7 +89,7 @@ struct RemoteWebAssetTests {
         #expect(css.contains(".session-open"))
         #expect(css.contains("#detail-title"))
         #expect(css.contains(".sheet-input"))
-        #expect(sw.contains(#""/app.js?v=36""#))
+        #expect(sw.contains(#""/app.js?v=37""#))
         #expect(sw.contains(#""/style.css?v=29""#))
     }
 

--- a/AlasTests/Remote/RemoteWebAssetTests.swift
+++ b/AlasTests/Remote/RemoteWebAssetTests.swift
@@ -32,10 +32,10 @@ struct RemoteWebAssetTests {
         let html = try asset("index.html")
         let sw = try asset("sw.js")
 
-        #expect(html.contains(#"/app.js?v=33"#))
+        #expect(html.contains(#"/app.js?v=34"#))
         #expect(html.contains(#"/style.css?v=29"#))
-        #expect(sw.contains(#"const CACHE_NAME = "alas-remote-shell-v9";"#))
-        #expect(sw.contains(#""/app.js?v=33""#))
+        #expect(sw.contains(#"const CACHE_NAME = "alas-remote-shell-v10";"#))
+        #expect(sw.contains(#""/app.js?v=34""#))
         #expect(sw.contains(#""/style.css?v=29""#))
     }
 
@@ -44,6 +44,7 @@ struct RemoteWebAssetTests {
 
         #expect(app.contains("function markdownIndentedCodeBlockLine"))
         #expect(app.contains("function markdownBlankLine"))
+        #expect(app.contains("function rawHtmlBlockEndsAtBlankLine"))
         #expect(app.contains("markdownIndentedCodeBlockLine(line)"))
         #expect(app.contains("function markdownEmphasisDelimiterRunBeforeUrlStart"))
     }
@@ -59,7 +60,7 @@ struct RemoteWebAssetTests {
         #expect(app.contains(#""clean""#))
         #expect(css.contains(".session-row-card"))
         #expect(css.contains(".session-meta"))
-        #expect(html.contains("/app.js?v=33"))
+        #expect(html.contains("/app.js?v=34"))
         #expect(html.contains("/style.css?v=29"))
     }
 
@@ -85,7 +86,7 @@ struct RemoteWebAssetTests {
         #expect(css.contains(".session-open"))
         #expect(css.contains("#detail-title"))
         #expect(css.contains(".sheet-input"))
-        #expect(sw.contains(#""/app.js?v=33""#))
+        #expect(sw.contains(#""/app.js?v=34""#))
         #expect(sw.contains(#""/style.css?v=29""#))
     }
 

--- a/AlasTests/Remote/RemoteWebAssetTests.swift
+++ b/AlasTests/Remote/RemoteWebAssetTests.swift
@@ -32,10 +32,10 @@ struct RemoteWebAssetTests {
         let html = try asset("index.html")
         let sw = try asset("sw.js")
 
-        #expect(html.contains(#"/app.js?v=31"#))
+        #expect(html.contains(#"/app.js?v=32"#))
         #expect(html.contains(#"/style.css?v=29"#))
-        #expect(sw.contains(#"const CACHE_NAME = "alas-remote-shell-v7";"#))
-        #expect(sw.contains(#""/app.js?v=31""#))
+        #expect(sw.contains(#"const CACHE_NAME = "alas-remote-shell-v8";"#))
+        #expect(sw.contains(#""/app.js?v=32""#))
         #expect(sw.contains(#""/style.css?v=29""#))
     }
 
@@ -44,6 +44,7 @@ struct RemoteWebAssetTests {
 
         #expect(app.contains("function markdownIndentedCodeBlockLine"))
         #expect(app.contains("markdownIndentedCodeBlockLine(line)"))
+        #expect(app.contains("function markdownEmphasisDelimiterRunBeforeUrlStart"))
     }
 
     @Test func sessionRowsRenderWorktreeSummaryCards() throws {
@@ -57,7 +58,7 @@ struct RemoteWebAssetTests {
         #expect(app.contains(#""clean""#))
         #expect(css.contains(".session-row-card"))
         #expect(css.contains(".session-meta"))
-        #expect(html.contains("/app.js?v=31"))
+        #expect(html.contains("/app.js?v=32"))
         #expect(html.contains("/style.css?v=29"))
     }
 
@@ -83,7 +84,7 @@ struct RemoteWebAssetTests {
         #expect(css.contains(".session-open"))
         #expect(css.contains("#detail-title"))
         #expect(css.contains(".sheet-input"))
-        #expect(sw.contains(#""/app.js?v=31""#))
+        #expect(sw.contains(#""/app.js?v=32""#))
         #expect(sw.contains(#""/style.css?v=29""#))
     }
 

--- a/AlasTests/Remote/RemoteWebAssetTests.swift
+++ b/AlasTests/Remote/RemoteWebAssetTests.swift
@@ -32,10 +32,10 @@ struct RemoteWebAssetTests {
         let html = try asset("index.html")
         let sw = try asset("sw.js")
 
-        #expect(html.contains(#"/app.js?v=34"#))
+        #expect(html.contains(#"/app.js?v=35"#))
         #expect(html.contains(#"/style.css?v=29"#))
-        #expect(sw.contains(#"const CACHE_NAME = "alas-remote-shell-v10";"#))
-        #expect(sw.contains(#""/app.js?v=34""#))
+        #expect(sw.contains(#"const CACHE_NAME = "alas-remote-shell-v11";"#))
+        #expect(sw.contains(#""/app.js?v=35""#))
         #expect(sw.contains(#""/style.css?v=29""#))
     }
 
@@ -46,6 +46,7 @@ struct RemoteWebAssetTests {
         #expect(app.contains("function markdownBlankLine"))
         #expect(app.contains("function rawHtmlBlockEndsAtBlankLine"))
         #expect(app.contains("markdownIndentedCodeBlockLine(line)"))
+        #expect(app.components(separatedBy: "rawHtmlBlockEndsAtBlankLine(line, openingHtmlBlockTag)").count == 3)
         #expect(app.contains("function markdownEmphasisDelimiterRunBeforeUrlStart"))
     }
 
@@ -60,7 +61,7 @@ struct RemoteWebAssetTests {
         #expect(app.contains(#""clean""#))
         #expect(css.contains(".session-row-card"))
         #expect(css.contains(".session-meta"))
-        #expect(html.contains("/app.js?v=34"))
+        #expect(html.contains("/app.js?v=35"))
         #expect(html.contains("/style.css?v=29"))
     }
 
@@ -86,7 +87,7 @@ struct RemoteWebAssetTests {
         #expect(css.contains(".session-open"))
         #expect(css.contains("#detail-title"))
         #expect(css.contains(".sheet-input"))
-        #expect(sw.contains(#""/app.js?v=34""#))
+        #expect(sw.contains(#""/app.js?v=35""#))
         #expect(sw.contains(#""/style.css?v=29""#))
     }
 

--- a/AlasTests/Remote/RemoteWebAssetTests.swift
+++ b/AlasTests/Remote/RemoteWebAssetTests.swift
@@ -32,10 +32,10 @@ struct RemoteWebAssetTests {
         let html = try asset("index.html")
         let sw = try asset("sw.js")
 
-        #expect(html.contains(#"/app.js?v=39"#))
+        #expect(html.contains(#"/app.js?v=40"#))
         #expect(html.contains(#"/style.css?v=29"#))
-        #expect(sw.contains(#"const CACHE_NAME = "alas-remote-shell-v15";"#))
-        #expect(sw.contains(#""/app.js?v=39""#))
+        #expect(sw.contains(#"const CACHE_NAME = "alas-remote-shell-v16";"#))
+        #expect(sw.contains(#""/app.js?v=40""#))
         #expect(sw.contains(#""/style.css?v=29""#))
     }
 
@@ -47,6 +47,7 @@ struct RemoteWebAssetTests {
         #expect(app.contains("function markdownAllowsIndentedCodeBlockAfterLine"))
         #expect(app.contains("function rawHtmlBlockEndsAtBlankLine"))
         #expect(app.contains("function markdownReferenceDefinitionDestinationContent"))
+        #expect(app.contains("isAngleBracketDestination"))
         #expect(app.contains("markdownIndentedCodeBlockLine(line)"))
         #expect(app.components(separatedBy: "rawHtmlBlockEndsAtBlankLine(line, openingHtmlBlockTag)").count == 3)
         #expect(app.contains("if (canStartTitleQuote) return -1;"))
@@ -64,7 +65,7 @@ struct RemoteWebAssetTests {
         #expect(app.contains(#""clean""#))
         #expect(css.contains(".session-row-card"))
         #expect(css.contains(".session-meta"))
-        #expect(html.contains("/app.js?v=39"))
+        #expect(html.contains("/app.js?v=40"))
         #expect(html.contains("/style.css?v=29"))
     }
 
@@ -90,7 +91,7 @@ struct RemoteWebAssetTests {
         #expect(css.contains(".session-open"))
         #expect(css.contains("#detail-title"))
         #expect(css.contains(".sheet-input"))
-        #expect(sw.contains(#""/app.js?v=39""#))
+        #expect(sw.contains(#""/app.js?v=40""#))
         #expect(sw.contains(#""/style.css?v=29""#))
     }
 

--- a/AlasTests/Remote/RemoteWebAssetTests.swift
+++ b/AlasTests/Remote/RemoteWebAssetTests.swift
@@ -32,11 +32,18 @@ struct RemoteWebAssetTests {
         let html = try asset("index.html")
         let sw = try asset("sw.js")
 
-        #expect(html.contains(#"/app.js?v=29"#))
+        #expect(html.contains(#"/app.js?v=31"#))
         #expect(html.contains(#"/style.css?v=29"#))
-        #expect(sw.contains(#"const CACHE_NAME = "alas-remote-shell-v5";"#))
-        #expect(sw.contains(#""/app.js?v=29""#))
+        #expect(sw.contains(#"const CACHE_NAME = "alas-remote-shell-v7";"#))
+        #expect(sw.contains(#""/app.js?v=31""#))
         #expect(sw.contains(#""/style.css?v=29""#))
+    }
+
+    @Test func remoteBareURLLinkifierPreservesIndentedCodeBlocks() throws {
+        let app = try asset("app.js")
+
+        #expect(app.contains("function markdownIndentedCodeBlockLine"))
+        #expect(app.contains("markdownIndentedCodeBlockLine(line)"))
     }
 
     @Test func sessionRowsRenderWorktreeSummaryCards() throws {
@@ -50,7 +57,7 @@ struct RemoteWebAssetTests {
         #expect(app.contains(#""clean""#))
         #expect(css.contains(".session-row-card"))
         #expect(css.contains(".session-meta"))
-        #expect(html.contains("/app.js?v=29"))
+        #expect(html.contains("/app.js?v=31"))
         #expect(html.contains("/style.css?v=29"))
     }
 
@@ -76,7 +83,7 @@ struct RemoteWebAssetTests {
         #expect(css.contains(".session-open"))
         #expect(css.contains("#detail-title"))
         #expect(css.contains(".sheet-input"))
-        #expect(sw.contains(#""/app.js?v=29""#))
+        #expect(sw.contains(#""/app.js?v=31""#))
         #expect(sw.contains(#""/style.css?v=29""#))
     }
 

--- a/docs/superpowers/specs/2026-06-10-acp-bare-url-linkification-design.md
+++ b/docs/superpowers/specs/2026-06-10-acp-bare-url-linkification-design.md
@@ -1,0 +1,97 @@
+# ACP Bare URL Linkification Design
+
+## Goal
+
+ACP chat transcripts should make clear bare `http://` and `https://` URLs clickable even when an agent emits plain text instead of Markdown link syntax. The behavior should apply consistently to:
+
+- native ACP transcript rendering
+- per-message copy
+- whole-transcript export/context Markdown
+- the remote web transcript
+
+Stored transcript content remains unchanged. Linkification is a presentation and serialization concern.
+
+## Non-Goals
+
+- Detecting scheme-less URLs such as `example.com`.
+- Detecting non-web schemes such as `file:`, `mailto:`, or custom app schemes.
+- Linkifying anything inside fenced code blocks or inline code spans.
+- Rewriting existing Markdown links or autolinks.
+- Replacing URL text with custom labels.
+
+## URL Rule
+
+A bare URL is linkified only when it is a clear `http://` or `https://` URL in prose:
+
+- The URL starts with `http://` or `https://`.
+- The character before it is the start of the string, whitespace, or simple opening punctuation such as `(`, `[`, `{`, `<`, or `"`.
+- The URL continues until whitespace or a control character.
+- Obvious trailing prose punctuation is excluded from the URL range, including `.`, `,`, `;`, `:`, `!`, `?`, `)`, `]`, `}`, `>`, and quotes when those characters are not structurally balanced within the URL text.
+- Existing Markdown links (`[label](https://example.com)`) and autolinks (`<https://example.com>`) are not changed.
+- Inline code spans are not changed.
+
+These rules intentionally prefer missing a marginal URL over making ambiguous text clickable.
+
+## Native Rendering
+
+`ACPMarkdownText.inlineMarkdown(_:)` remains the native inline rendering entry point. It should continue to parse Markdown with `AttributedString(markdown:options:)` first, preserving existing support for emphasis, inline code, and explicit Markdown links.
+
+After Markdown parsing, a helper applies `.link` attributes to bare URL ranges that do not already carry a link attribute. This makes plain URLs clickable in headings, paragraphs, blockquotes, and table cells without changing display text.
+
+Fenced code blocks remain rendered by `CodeBlockView`/`ACPSyntaxHighlightedText` and are not autolinked.
+
+## Markdown Serialization
+
+`ACPTranscriptMarkdown` should expose one shared transformation for Markdown serialization. `document(...)` and `messageBody(...)` use it so whole-session export/context and per-message copy behave the same way.
+
+For prose text, bare URLs are rewritten as Markdown autolinks:
+
+```markdown
+See <https://example.com/path>.
+```
+
+The visible text remains the URL in Markdown renderers, but stricter renderers receive explicit link syntax. The serializer must skip fenced code blocks, inline code spans, existing Markdown links, and existing autolinks.
+
+## Remote Web Transcript
+
+`Alas/Resources/RemoteWeb/app.js` should mirror the same conservative behavior in `md(text)`:
+
+1. Convert bare prose URLs to Markdown autolinks with a small `linkifyBareUrls(text)` helper.
+2. Pass the transformed text to `marked.parse(...)`.
+3. Continue sanitizing the generated HTML with DOMPurify before inserting it into the DOM.
+
+This keeps the remote web transcript aligned with the native app while preserving the existing sanitization boundary.
+
+## Components
+
+- `ACPBareURLLinkifier` or similarly named Swift helper:
+  - finds bare URL ranges
+  - skips Markdown links/autolinks and inline code
+  - applies link attributes for native rendering
+  - rewrites Markdown prose URLs to autolinks for serialization
+- `ACPMarkdownText.inlineMarkdown(_:)`:
+  - calls the helper after Markdown parsing
+  - keeps its existing cache behavior
+- `ACPTranscriptMarkdown`:
+  - calls the serializer helper for document and message copy output
+- `Alas/Resources/RemoteWeb/app.js`:
+  - adds a matching JavaScript helper used by `md(text)`
+
+## Testing
+
+Swift tests should cover:
+
+- native inline rendering assigns a `.link` attribute to a bare `https://...` URL
+- existing Markdown links keep their original link attribute and are not double-rewritten
+- inline code is not linkified
+- fenced code is not rewritten in copied/exported Markdown
+- trailing punctuation is excluded from the clickable/autolinked range
+- `ACPTranscriptMarkdown.document(...)` and `messageBody(...)` emit Markdown autolinks for bare prose URLs
+
+Remote web coverage should mirror the helper cases if a suitable JavaScript test harness exists. If not, keep the helper isolated and small enough to audit directly, with the Swift tests defining the intended behavior.
+
+## Risks
+
+- URL parsing can become too broad. The implementation should remain conservative and avoid scheme-less detection.
+- Native and web behavior can drift. The rules should be documented in both helpers and covered by equivalent fixtures where practical.
+- Markdown parsing edge cases can be complex. The implementation should handle the common transcript shapes well and skip ambiguous syntax rather than attempting a full CommonMark parser.


### PR DESCRIPTION
## Summary
- Add ACP bare URL linkification for native transcript rendering and transcript Markdown serialization.
- Preserve existing Markdown constructs, code spans/fences, reference links/definitions, punctuation boundaries, and square-bracket URL query text.
- Add remote web transcript linkification before Markdown rendering and sanitization.

## Test Plan
- `rtk xcodegen`
- `rtk xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -quiet build`
- `rtk xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' test`
- `rtk node --check Alas/Resources/RemoteWeb/app.js`