### PR TITLE
fix(cursor-acp): fast mode persistence

### DIFF
--- a/Alas/Sources/ACP/Protocol/ACPConfigOption.swift
+++ b/Alas/Sources/ACP/Protocol/ACPConfigOption.swift
@@ -46,6 +46,28 @@ struct ACPConfigOption: Codable, Equatable, Identifiable, Hashable {
         try c.encodeIfPresent(currentValue, forKey: .currentValue)
         try c.encode(options, forKey: .options)
     }
+
+    static func mergingSuccessfulSetResponse(
+        _ configOptions: [ACPConfigOption],
+        configId: String,
+        selectedValue: String,
+        currentConfigOptions: [ACPConfigOption]
+    ) -> [ACPConfigOption]? {
+        guard currentConfigOptions.first(where: { $0.id == configId })?.currentValue == selectedValue else {
+            return nil
+        }
+
+        return configOptions.map { option in
+            guard option.id == configId else { return option }
+            return ACPConfigOption(
+                id: option.id,
+                name: option.name,
+                type: option.type,
+                category: option.category,
+                currentValue: selectedValue,
+                options: option.options)
+        }
+    }
 }
 
 struct ACPConfigOptionItem: Codable, Equatable, Identifiable, Hashable {

--- a/Alas/Sources/ACP/UI/ACPComposerShell.swift
+++ b/Alas/Sources/ACP/UI/ACPComposerShell.swift
@@ -454,15 +454,21 @@ struct ACPComposer: View {
             case .model:
                 try? await runner.connection.setModel(sessionId: remoteId, modelId: selectedId)
             case .configOption(let id):
-                // The agent's response carries the refreshed configOptions
-                // (including dependent updates — e.g. switching reasoning
-                // effort can reshape available model variants). Overwrite
-                // the optimistic local update so dependent chips stay in
-                // sync. Empty response → keep the optimistic state.
+                // The agent's response carries refreshed configOptions
+                // (including dependent updates), but some agents echo a stale
+                // value for the option just set. Keep the successful selection
+                // for that option while still accepting dependent updates.
                 if let updated = try? await runner.connection.setConfigOption(
                     sessionId: remoteId, configId: id, value: selectedId),
                    !updated.isEmpty {
-                    session.availableConfigOptions = updated
+                    guard let merged = ACPConfigOption.mergingSuccessfulSetResponse(
+                        updated,
+                        configId: id,
+                        selectedValue: selectedId,
+                        currentConfigOptions: session.availableConfigOptions) else {
+                        return
+                    }
+                    session.availableConfigOptions = merged
                     manager.persist(session)
                 }
             }

--- a/AlasTests/ACP/Protocol/ACPConfigOptionTests.swift
+++ b/AlasTests/ACP/Protocol/ACPConfigOptionTests.swift
@@ -69,4 +69,54 @@ struct ACPConfigOptionTests {
         #expect(s.contains("\"configId\":\"effort\""))
         #expect(s.contains("\"value\":\"high\""))
     }
+
+    @Test("successful set response preserves the selected config value")
+    func mergeSuccessfulSetResponsePreservesSelectedValue() throws {
+        let staleFast = ACPConfigOption(
+            id: "fast", name: "Fast", type: "select", currentValue: "false",
+            options: [
+                ACPConfigOptionItem(id: "false", name: "Off"),
+                ACPConfigOptionItem(id: "true", name: "On"),
+            ])
+        let refreshedContext = ACPConfigOption(
+            id: "context", name: "Context", type: "select", currentValue: "1m",
+            options: [
+                ACPConfigOptionItem(id: "272k", name: "272k"),
+                ACPConfigOptionItem(id: "1m", name: "1m"),
+            ])
+        let currentFast = ACPConfigOption(
+            id: "fast", name: "Fast", type: "select", currentValue: "true",
+            options: staleFast.options)
+
+        let merged = try #require(ACPConfigOption.mergingSuccessfulSetResponse(
+            [staleFast, refreshedContext],
+            configId: "fast",
+            selectedValue: "true",
+            currentConfigOptions: [currentFast, refreshedContext]))
+
+        #expect(merged.map(\.id) == ["fast", "context"])
+        #expect(merged.first(where: { $0.id == "fast" })?.currentValue == "true")
+        #expect(merged.first(where: { $0.id == "context" })?.currentValue == "1m")
+    }
+
+    @Test("stale set response is ignored after a newer local selection")
+    func staleSetResponseIsIgnoredAfterNewerSelection() {
+        let oldResponse = ACPConfigOption(
+            id: "fast", name: "Fast", type: "select", currentValue: "true",
+            options: [
+                ACPConfigOptionItem(id: "false", name: "Off"),
+                ACPConfigOptionItem(id: "true", name: "On"),
+            ])
+        let currentFast = ACPConfigOption(
+            id: "fast", name: "Fast", type: "select", currentValue: "false",
+            options: oldResponse.options)
+
+        let merged = ACPConfigOption.mergingSuccessfulSetResponse(
+            [oldResponse],
+            configId: "fast",
+            selectedValue: "true",
+            currentConfigOptions: [currentFast])
+
+        #expect(merged == nil)
+    }
 }


### PR DESCRIPTION
## Summary
- Keep the selected ACP config-option value after a successful `session/set_config_option` call even when the agent response echoes stale state for that same option.
- Preserve refreshed dependent config options from the agent response.
- Add a regression test covering Cursor-style `fast=false` echo after selecting `true`.

## Root Cause
Cursor ACP can return a refreshed `configOptions` list whose `fast` option still contains the old current value. Alas previously replaced the optimistic local state with that response wholesale, so the Fast chip flipped back off shortly after the user enabled it.

## Validation
- `xcodegen`
- `xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -quiet build`
- `xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -only-testing:AlasTests/ACPConfigOptionTests -quiet test`

Note: the full `xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' test` run was attempted but hung locally and was interrupted after extended runtime.