### PR TITLE
feat(settings): add Chat settings section

### DIFF
--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -576,6 +576,7 @@
 		9782C5866410EFE13E670AFF /* FilesTabView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD4A3B9B1103346242438940 /* FilesTabView.swift */; };
 		97D86F05B3993A61A0302B97 /* DefinitionSnippetCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0326789AA29BD63CC1B8F81F /* DefinitionSnippetCache.swift */; };
 		97E90C02DD115438B5E12DF2 /* ACPPlanPillStateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80BAFADCDC3E349AC3DBDDEA /* ACPPlanPillStateTests.swift */; };
+		981730A24BE369F4AE9012F3 /* ChatPaneTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3986789560012DF861565F12 /* ChatPaneTests.swift */; };
 		98B61C62BB4FEDCDE271FAC1 /* WorktreeWatcherTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 321E1DBC8C06504AD3EE7D6E /* WorktreeWatcherTests.swift */; };
 		98CCFEFD7D0E8C27C6B373F6 /* ShortcutRecorder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 05B122F66B2DEA7853804624 /* ShortcutRecorder.swift */; };
 		98ED89EA20255EBB9D186AD5 /* MergeConflictBinaryDetectionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 31CE012ED93AA22C257FEB8A /* MergeConflictBinaryDetectionTests.swift */; };
@@ -824,6 +825,7 @@
 		D45D14487117192F9E5D7F0E /* ACPSessionHydratorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8D8A320D194DF0E64BF13BC5 /* ACPSessionHydratorTests.swift */; };
 		D46F8DF1FB66AD0ED92F3DF0 /* ChangesTreeBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 910CB5077C8E89A778F1E896 /* ChangesTreeBuilder.swift */; };
 		D4934B70887DE314FD73B0D1 /* GitEventFilterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3DC5DBEC068EB1BFDBB7F59 /* GitEventFilterTests.swift */; };
+		D49FD01D96C6B00C3683FBCA /* ChatPane.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0D2C54087C4501C3E7793FE /* ChatPane.swift */; };
 		D51AC3D5B34A566A90C923BB /* AgentRunnerInvocationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9D209865BE187943BF14B830 /* AgentRunnerInvocationTests.swift */; };
 		D55386035B99B2B1769ED47F /* NumstatParserTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4D5507CA73F4EE1717FD4D79 /* NumstatParserTests.swift */; };
 		D56C78F4D6A2BDFDF5A05B55 /* ACPSessionRunnerQueueTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 547176E79C529DBFE2086B88 /* ACPSessionRunnerQueueTests.swift */; };
@@ -1219,6 +1221,7 @@
 		3939B27EA8D7A562048E5932 /* ReviewLoopStateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReviewLoopStateTests.swift; sourceTree = "<group>"; };
 		3979B98C0A060BB118239A5E /* ReviewRequestContextBuilderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReviewRequestContextBuilderTests.swift; sourceTree = "<group>"; };
 		3985F2F58DB6E3BBF3520EFD /* CodexACPInstaller.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CodexACPInstaller.swift; sourceTree = "<group>"; };
+		3986789560012DF861565F12 /* ChatPaneTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatPaneTests.swift; sourceTree = "<group>"; };
 		39DFD138FE855D8CFC464847 /* SearchFooter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchFooter.swift; sourceTree = "<group>"; };
 		3A0FF718D68E15F539577F56 /* SearchResult.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchResult.swift; sourceTree = "<group>"; };
 		3A110966FCF7EA47C18BE71A /* ACPAgentProfilesTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPAgentProfilesTests.swift; sourceTree = "<group>"; };
@@ -1630,6 +1633,7 @@
 		AE35206EEBD7E3A35C3421EA /* ACPRecoveryPill.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPRecoveryPill.swift; sourceTree = "<group>"; };
 		AF2F716F911BB20B3E78C40B /* AgentDefinition.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentDefinition.swift; sourceTree = "<group>"; };
 		B0D0ED01C390D1F729993B13 /* MarkdownImageLoaderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MarkdownImageLoaderTests.swift; sourceTree = "<group>"; };
+		B0D2C54087C4501C3E7793FE /* ChatPane.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatPane.swift; sourceTree = "<group>"; };
 		B0F47561DB37D2ED72B6BE25 /* ReviewLoopDrawerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReviewLoopDrawerTests.swift; sourceTree = "<group>"; };
 		B0FBEABA73057C9F165A66CD /* ReviewEvidenceModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReviewEvidenceModelTests.swift; sourceTree = "<group>"; };
 		B133843C0559BBD6E769ABB8 /* ACPManagerAccessorsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPManagerAccessorsTests.swift; sourceTree = "<group>"; };
@@ -2150,6 +2154,7 @@
 				71A2A074CEB9C9BA2AD34DD7 /* CenterSelectionStateResolverTests.swift */,
 				E7D49EBCE99D6F1690646F80 /* ChangesTreeBuilderTests.swift */,
 				E4E465A2468376AA840ADFBC /* ChangeSummaryVisibilityTests.swift */,
+				3986789560012DF861565F12 /* ChatPaneTests.swift */,
 				A42955D4178E97347B8C942A /* ChevronStabilityTests.swift */,
 				6016A3CF87F34222C533D350 /* ClaudeInstallerTests.swift */,
 				5337D60F19641CF933A1F855 /* CloseTabConfirmationPolicyTests.swift */,
@@ -2801,6 +2806,7 @@
 				5BB6172AE118D2F9A40FD534 /* AgentsPane.swift */,
 				4B450918CC98255AD9170586 /* AppearancePane.swift */,
 				EB1E14CFAC880D31CE8FBE8F /* ChangesPane.swift */,
+				B0D2C54087C4501C3E7793FE /* ChatPane.swift */,
 				A727D24652E45B98C10917F8 /* CodeLanguageDetailView.swift */,
 				93CDC9895F48619E97461875 /* CodePane.swift */,
 				BB6A90FAE1D410744D02A454 /* CommitPromptEditorWindow.swift */,
@@ -4087,6 +4093,7 @@
 				8F5B93A115E4554430ADC0FD /* ChangesPane.swift in Sources */,
 				23013D3D2538AC2D1BD3403D /* ChangesTabView.swift in Sources */,
 				D46F8DF1FB66AD0ED92F3DF0 /* ChangesTreeBuilder.swift in Sources */,
+				D49FD01D96C6B00C3683FBCA /* ChatPane.swift in Sources */,
 				CD7FB3120E4B194063C76817 /* ClaudeCodeACPInstaller.swift in Sources */,
 				87ECE63567C08B2847844EDE /* ClaudeInstaller.swift in Sources */,
 				D0F4A4F5BF5F1C3C625F11D9 /* Clipboard.swift in Sources */,
@@ -4595,6 +4602,7 @@
 				F8143610563C28604A23B89A /* CenterSelectionStateResolverTests.swift in Sources */,
 				835AFE4A9EA0889E0AF316BD /* ChangeSummaryVisibilityTests.swift in Sources */,
 				59765FD789179C1BDC3F1BB9 /* ChangesTreeBuilderTests.swift in Sources */,
+				981730A24BE369F4AE9012F3 /* ChatPaneTests.swift in Sources */,
 				188D02B853162BF4533020E2 /* ChevronStabilityTests.swift in Sources */,
 				E0AA2F46C6E53C547FEB6495 /* ClaudeCodeACPInstallerTests.swift in Sources */,
 				E1DA1C6BF9D5E157DAF6EE00 /* ClaudeInstallerTests.swift in Sources */,

--- a/Alas/Sources/Settings/AgentsPane.swift
+++ b/Alas/Sources/Settings/AgentsPane.swift
@@ -59,58 +59,6 @@ struct AgentsPane: View {
                     }
                 }
 
-                SettingsGroup(title: "Launcher (⌥⌘T)") {
-                    SettingsRow(
-                        name: "Default launch surface",
-                        desc: "Whether the launcher opens on the Terminal or Chat tab. You can still swap with the segmented control inside the dialog."
-                    ) {
-                        defaultLauncherModePicker
-                    }
-                }
-
-                SettingsGroup(title: "Chat") {
-                    SettingsRow(name: "Font family") {
-                        FontFamilyPicker(
-                            family: state.bind(\.agents.chatFontFamily),
-                            catalog: MonospaceFontCatalog.families()
-                        )
-                    }
-                    SettingsRow(name: "Font size") {
-                        AlasField(text: Binding(
-                            get: { String(state.config.agents.chatFontSize) },
-                            set: {
-                                let raw = Int($0) ?? 13
-                                state.config.agents.chatFontSize = max(8, min(64, raw))
-                                state.saveConfig()
-                            }
-                        ), monospaced: true).frame(width: 80)
-                    }
-                    SettingsRow(name: "While busy, ⏎ queues; ⌥⏎ steers",
-                                desc: "Turn off to swap — ⏎ steers and ⌥⏎ queues. Steering cancels the running turn and discards any pending queue items.") {
-                        AlasToggle(on: Binding(
-                            get: { state.config.harness.acpSendOnEnter },
-                            set: { state.config.harness.acpSendOnEnter = $0
-                            state.saveConfig() }
-                        ))
-                    }
-                    SettingsRow(name: "Confirm before closing chat tabs",
-                                desc: "Ask before closing Chat tabs with Command-W or the tab close button.") {
-                        AlasToggle(on: Binding(
-                            get: { state.config.harness.confirmCloseChatTabs },
-                            set: { state.config.harness.confirmCloseChatTabs = $0
-                            state.saveConfig() }
-                        ))
-                    }
-                    SettingsRow(name: "⚡ Auto-run",
-                                desc: "New chat sessions start with auto-run on — the agent runs tools without asking for permission. Toggle per-session with the bolt in the composer.") {
-                        AlasToggle(on: Binding(
-                            get: { state.config.harness.acpAutoRunByDefault },
-                            set: { state.config.harness.acpAutoRunByDefault = $0
-                            state.saveConfig() }
-                        ))
-                    }
-                }
-
                 SettingsGroup(title: "Harness") {
                     SettingsRow(
                         name: "Terminal / Harness",
@@ -131,21 +79,6 @@ struct AgentsPane: View {
                 onDismiss: { editing = nil }
             )
         }
-    }
-
-    private var defaultLauncherModePicker: some View {
-        Picker("", selection: Binding(
-            get: { state.config.agents.defaultLauncherMode },
-            set: { newValue in
-                state.config.agents.defaultLauncherMode = newValue
-                state.saveConfig()
-            }
-        )) {
-            Label("Terminal", systemImage: "terminal").tag(AppConfig.LauncherMode.terminal)
-            Label("Chat", systemImage: "sparkle").tag(AppConfig.LauncherMode.acp)
-        }
-        .pickerStyle(.menu)
-        .settingsDropdownFrame()
     }
 
     private var autoLaunchPicker: some View {

--- a/Alas/Sources/Settings/ChatPane.swift
+++ b/Alas/Sources/Settings/ChatPane.swift
@@ -1,0 +1,97 @@
+import SwiftUI
+
+struct ChatPane: View {
+    @Bindable var state: AppState
+    @Environment(\.theme) var theme
+
+    var body: some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: 0) {
+                Text("Chat").font(.system(size: 18, weight: .semibold))
+                Text("Defaults for ACP chat sessions, composer behavior, and chat typography.")
+                    .font(.system(size: 12.5)).foregroundColor(theme.color("fg-dim"))
+                    .padding(.bottom, 12)
+
+                SettingsGroup(title: "Appearance") {
+                    SettingsRow(name: "Font family") {
+                        FontFamilyPicker(
+                            family: state.bind(\.agents.chatFontFamily),
+                            catalog: MonospaceFontCatalog.families()
+                        )
+                    }
+                    SettingsRow(name: "Font size") {
+                        AlasField(text: Binding(
+                            get: { String(state.config.agents.chatFontSize) },
+                            set: {
+                                let raw = Int($0) ?? 13
+                                state.config.agents.chatFontSize = max(8, min(64, raw))
+                                state.saveConfig()
+                            }
+                        ), monospaced: true).frame(width: 80)
+                    }
+                }
+
+                SettingsGroup(title: "Launcher (⌥⌘T)") {
+                    SettingsRow(
+                        name: "Default launch surface",
+                        desc: "Whether the launcher opens on the Terminal or Chat tab. You can still swap with the segmented control inside the dialog."
+                    ) {
+                        defaultLauncherModePicker
+                    }
+                }
+
+                SettingsGroup(title: "Composer") {
+                    SettingsRow(name: "While busy, ⏎ queues; ⌥⏎ steers",
+                                desc: "Turn off to swap — ⏎ steers and ⌥⏎ queues. Steering cancels the running turn and discards any pending queue items.") {
+                        AlasToggle(on: Binding(
+                            get: { state.config.harness.acpSendOnEnter },
+                            set: {
+                                state.config.harness.acpSendOnEnter = $0
+                                state.saveConfig()
+                            }
+                        ))
+                    }
+                }
+
+                SettingsGroup(title: "Sessions") {
+                    SettingsRow(name: "Confirm before closing chat tabs",
+                                desc: "Ask before closing Chat tabs with Command-W or the tab close button.") {
+                        AlasToggle(on: Binding(
+                            get: { state.config.harness.confirmCloseChatTabs },
+                            set: {
+                                state.config.harness.confirmCloseChatTabs = $0
+                                state.saveConfig()
+                            }
+                        ))
+                    }
+                    SettingsRow(name: "⚡ Auto-run",
+                                desc: "New chat sessions start with auto-run on — the agent runs tools without asking for permission. Toggle per-session with the bolt in the composer.") {
+                        AlasToggle(on: Binding(
+                            get: { state.config.harness.acpAutoRunByDefault },
+                            set: {
+                                state.config.harness.acpAutoRunByDefault = $0
+                                state.saveConfig()
+                            }
+                        ))
+                    }
+                }
+            }
+            .padding(.horizontal, 32).padding(.vertical, 24)
+        }
+    }
+
+    private var defaultLauncherModePicker: some View {
+        Picker("", selection: Binding(
+            get: { state.config.agents.defaultLauncherMode },
+            set: { newValue in
+                state.config.agents.defaultLauncherMode = newValue
+                state.saveConfig()
+            }
+        )) {
+            Label("Terminal", systemImage: "terminal").tag(AppConfig.LauncherMode.terminal)
+            Label("Chat", systemImage: "sparkle").tag(AppConfig.LauncherMode.acp)
+        }
+        .pickerStyle(.menu)
+        .settingsDropdownFrame()
+    }
+}

--- a/Alas/Sources/Settings/ChatPane.swift
+++ b/Alas/Sources/Settings/ChatPane.swift
@@ -4,6 +4,38 @@ struct ChatPane: View {
     @Bindable var state: AppState
     @Environment(\.theme) var theme
 
+    enum GroupTitles {
+        static let appearance = "Appearance"
+        static let launcher = "Launcher (⌥⌘T)"
+        static let composer = "Composer"
+        static let sessions = "Sessions"
+    }
+
+    enum RowLabels {
+        static let fontFamily = "Font family"
+        static let fontSize = "Font size"
+        static let defaultLaunchSurface = "Default launch surface"
+        static let sendOnEnter = "While busy, ⏎ queues; ⌥⏎ steers"
+        static let confirmCloseChatTabs = "Confirm before closing chat tabs"
+        static let autoRun = "⚡ Auto-run"
+    }
+
+    static let groupTitles = [
+        GroupTitles.appearance,
+        GroupTitles.launcher,
+        GroupTitles.composer,
+        GroupTitles.sessions,
+    ]
+
+    static let rowLabels = [
+        RowLabels.fontFamily,
+        RowLabels.fontSize,
+        RowLabels.defaultLaunchSurface,
+        RowLabels.sendOnEnter,
+        RowLabels.confirmCloseChatTabs,
+        RowLabels.autoRun,
+    ]
+
     var body: some View {
         ScrollView {
             VStack(alignment: .leading, spacing: 0) {
@@ -12,14 +44,14 @@ struct ChatPane: View {
                     .font(.system(size: 12.5)).foregroundColor(theme.color("fg-dim"))
                     .padding(.bottom, 12)
 
-                SettingsGroup(title: "Appearance") {
-                    SettingsRow(name: "Font family") {
+                SettingsGroup(title: GroupTitles.appearance) {
+                    SettingsRow(name: RowLabels.fontFamily) {
                         FontFamilyPicker(
                             family: state.bind(\.agents.chatFontFamily),
                             catalog: MonospaceFontCatalog.families()
                         )
                     }
-                    SettingsRow(name: "Font size") {
+                    SettingsRow(name: RowLabels.fontSize) {
                         AlasField(text: Binding(
                             get: { String(state.config.agents.chatFontSize) },
                             set: {
@@ -31,17 +63,17 @@ struct ChatPane: View {
                     }
                 }
 
-                SettingsGroup(title: "Launcher (⌥⌘T)") {
+                SettingsGroup(title: GroupTitles.launcher) {
                     SettingsRow(
-                        name: "Default launch surface",
+                        name: RowLabels.defaultLaunchSurface,
                         desc: "Whether the launcher opens on the Terminal or Chat tab. You can still swap with the segmented control inside the dialog."
                     ) {
                         defaultLauncherModePicker
                     }
                 }
 
-                SettingsGroup(title: "Composer") {
-                    SettingsRow(name: "While busy, ⏎ queues; ⌥⏎ steers",
+                SettingsGroup(title: GroupTitles.composer) {
+                    SettingsRow(name: RowLabels.sendOnEnter,
                                 desc: "Turn off to swap — ⏎ steers and ⌥⏎ queues. Steering cancels the running turn and discards any pending queue items.") {
                         AlasToggle(on: Binding(
                             get: { state.config.harness.acpSendOnEnter },
@@ -53,8 +85,8 @@ struct ChatPane: View {
                     }
                 }
 
-                SettingsGroup(title: "Sessions") {
-                    SettingsRow(name: "Confirm before closing chat tabs",
+                SettingsGroup(title: GroupTitles.sessions) {
+                    SettingsRow(name: RowLabels.confirmCloseChatTabs,
                                 desc: "Ask before closing Chat tabs with Command-W or the tab close button.") {
                         AlasToggle(on: Binding(
                             get: { state.config.harness.confirmCloseChatTabs },
@@ -64,7 +96,7 @@ struct ChatPane: View {
                             }
                         ))
                     }
-                    SettingsRow(name: "⚡ Auto-run",
+                    SettingsRow(name: RowLabels.autoRun,
                                 desc: "New chat sessions start with auto-run on — the agent runs tools without asking for permission. Toggle per-session with the bolt in the composer.") {
                         AlasToggle(on: Binding(
                             get: { state.config.harness.acpAutoRunByDefault },

--- a/Alas/Sources/Settings/SettingsNavView.swift
+++ b/Alas/Sources/Settings/SettingsNavView.swift
@@ -1,7 +1,7 @@
 import SwiftUI
 
 enum SettingsSection: String, CaseIterable, Identifiable {
-    case agents, appearance, changes, code, general, remote, shortcuts, spaces, terminal, worktrees, debug
+    case agents, appearance, changes, chat, code, general, remote, shortcuts, spaces, terminal, worktrees, debug
     var id: String { rawValue }
     var label: String {
         switch self {
@@ -9,6 +9,7 @@ enum SettingsSection: String, CaseIterable, Identifiable {
         case .agents:     return "Agents"
         case .appearance: return "Appearance"
         case .changes:    return "Changes"
+        case .chat:       return "Chat"
         case .code:       return "Code"
         case .general:    return "General"
         case .remote:     return "Remote"
@@ -24,6 +25,7 @@ enum SettingsSection: String, CaseIterable, Identifiable {
         case .agents:     return "sparkle"
         case .appearance: return "palette"
         case .changes:    return "diff"
+        case .chat:       return "message"
         case .code:       return "code"
         case .general:    return "gear"
         case .remote:     return "iphone.gen3"

--- a/Alas/Sources/Settings/SettingsNavView.swift
+++ b/Alas/Sources/Settings/SettingsNavView.swift
@@ -35,6 +35,18 @@ enum SettingsSection: String, CaseIterable, Identifiable {
         case .worktrees:  return "branch"
         }
     }
+
+    static func visibleSections(showsDebug: Bool) -> [SettingsSection] {
+        SettingsSection.allCases
+            .filter { showsDebug || $0 != .debug }
+            .sorted(by: {
+                if $0 == .general { return true }
+                if $1 == .general { return false }
+                if $0 == .debug { return false }
+                if $1 == .debug { return true }
+                return $0.label < $1.label
+            })
+    }
 }
 
 struct SettingsNavView: View {
@@ -75,15 +87,6 @@ struct SettingsNavView: View {
     }
 
     private var sections: [SettingsSection] {
-        let visible = SettingsSection.allCases
-            .filter { showsDebug || $0 != .debug }
-            .sorted(by: {
-                if $0 == .general { return true }
-                if $1 == .general { return false }
-                if $0 == .debug { return false }
-                if $1 == .debug { return true }
-                return $0.label < $1.label
-            })
-        return visible
+        SettingsSection.visibleSections(showsDebug: showsDebug)
     }
 }

--- a/Alas/Sources/Settings/SettingsWindow.swift
+++ b/Alas/Sources/Settings/SettingsWindow.swift
@@ -36,6 +36,7 @@ struct SettingsWindow: View {
                     case .agents:     AgentsPane(state: state) { section = $0 }
                     case .appearance: AppearancePane(state: state)
                     case .changes:    ChangesPane(state: state)
+                    case .chat:       ChatPane(state: state)
                     case .code:       CodePane(state: state)
                     case .shortcuts:  ShortcutsPane(state: state)
                     case .spaces:     SpacesPane(state: state)

--- a/AlasTests/ChatPaneTests.swift
+++ b/AlasTests/ChatPaneTests.swift
@@ -1,0 +1,19 @@
+import AppKit
+import SwiftUI
+import Testing
+@testable import Alas
+
+@MainActor
+struct ChatPaneTests {
+    private func currentTheme() -> Theme {
+        try! ThemeStore().current
+    }
+
+    @Test func chatPaneRendersWithoutCrashing() {
+        let view = ChatPane(state: AppState())
+            .environment(\.theme, currentTheme())
+        let controller = NSHostingController(rootView: view)
+        controller.view.layoutSubtreeIfNeeded()
+        #expect(!controller.view.subviews.isEmpty)
+    }
+}

--- a/AlasTests/ChatPaneTests.swift
+++ b/AlasTests/ChatPaneTests.swift
@@ -16,4 +16,21 @@ struct ChatPaneTests {
         controller.view.layoutSubtreeIfNeeded()
         #expect(!controller.view.subviews.isEmpty)
     }
+
+    @Test func chatPaneDefinesMovedChatControls() {
+        #expect(ChatPane.groupTitles == [
+            "Appearance",
+            "Launcher (⌥⌘T)",
+            "Composer",
+            "Sessions",
+        ])
+        #expect(ChatPane.rowLabels == [
+            "Font family",
+            "Font size",
+            "Default launch surface",
+            "While busy, ⏎ queues; ⌥⏎ steers",
+            "Confirm before closing chat tabs",
+            "⚡ Auto-run",
+        ])
+    }
 }

--- a/AlasTests/SettingsSectionTests.swift
+++ b/AlasTests/SettingsSectionTests.swift
@@ -20,6 +20,11 @@ struct SettingsSectionTests {
         let labels = SettingsSection.allCases.map(\.label)
 
         #expect(!labels.contains("Markdown"))
+    }
+
+    @Test func sidebarSectionsIncludeChat() {
+        let labels = SettingsSection.allCases.map(\.label)
+
         #expect(labels.contains("General"))
         #expect(labels.contains("Appearance"))
         #expect(labels.contains("Chat"))

--- a/AlasTests/SettingsSectionTests.swift
+++ b/AlasTests/SettingsSectionTests.swift
@@ -17,13 +17,13 @@ struct SettingsSectionTests {
     }
 
     @Test func sidebarSectionsDoNotIncludeStandaloneMarkdown() {
-        let labels = SettingsSection.allCases.map(\.label)
+        let labels = SettingsSection.visibleSections(showsDebug: true).map(\.label)
 
         #expect(!labels.contains("Markdown"))
     }
 
     @Test func sidebarSectionsIncludeChat() {
-        let labels = SettingsSection.allCases.map(\.label)
+        let labels = SettingsSection.visibleSections(showsDebug: false).map(\.label)
 
         #expect(labels.contains("General"))
         #expect(labels.contains("Appearance"))
@@ -31,9 +31,17 @@ struct SettingsSectionTests {
     }
 
     @Test func sidebarSectionsAreSortedAlphabeticallyExceptDebugLast() {
-        let labels = SettingsSection.allCases.map(\.label)
-        let mainLabels = labels.filter { $0 != "Debug" }
+        let sections = SettingsSection.visibleSections(showsDebug: true)
+        let labels = sections.map(\.label)
+        let mainLabels = Array(labels.dropFirst().dropLast())
+        #expect(labels.first == "General")
         #expect(mainLabels == mainLabels.sorted())
         #expect(labels.last == "Debug")
+    }
+
+    @Test func sidebarSectionsHideDebugWhenDisabled() {
+        let labels = SettingsSection.visibleSections(showsDebug: false).map(\.label)
+
+        #expect(!labels.contains("Debug"))
     }
 }

--- a/AlasTests/SettingsSectionTests.swift
+++ b/AlasTests/SettingsSectionTests.swift
@@ -22,6 +22,7 @@ struct SettingsSectionTests {
         #expect(!labels.contains("Markdown"))
         #expect(labels.contains("General"))
         #expect(labels.contains("Appearance"))
+        #expect(labels.contains("Chat"))
     }
 
     @Test func sidebarSectionsAreSortedAlphabeticallyExceptDebugLast() {

--- a/docs/superpowers/specs/2026-06-10-chat-settings-section-design.md
+++ b/docs/superpowers/specs/2026-06-10-chat-settings-section-design.md
@@ -1,0 +1,126 @@
+# Settings Chat Section Design
+
+## Summary
+
+Add a first-class `Settings > Chat` section and move chat-specific preferences
+out of `Settings > Agents`. The change is a UI organization pass: existing
+config storage remains unchanged so user preferences survive without a
+migration.
+
+## Goals
+
+- Add `Chat` as its own item in the Settings sidebar.
+- Keep `Agents` focused on agent registry, custom agents, and worktree
+  auto-launch behavior.
+- Move all current chat-specific settings into the new Chat pane.
+- Keep terminal harness notifications and hook installation under
+  `Settings > Terminal`.
+- Avoid persisted config key renames or migration work.
+
+## Non-Goals
+
+- No changes to ACP chat runtime behavior.
+- No changes to terminal settings, harness notifications, or hook installers.
+- No new chat settings beyond relocating existing controls.
+- No cross-link or placeholder row left behind in `Settings > Agents`.
+
+## UI Structure
+
+Add `SettingsSection.chat` with label `Chat` and a chat-oriented icon. The
+existing Settings sidebar ordering should remain alphabetic for non-debug
+sections, with `Debug` last when visible.
+
+Add a new `ChatPane` under `Alas/Sources/Settings`. It should follow the
+existing pane pattern: title, short subtitle, then `SettingsGroup` sections with
+`SettingsRow` controls.
+
+The new pane contains these groups:
+
+### Appearance
+
+- `Font family`
+  - Uses `FontFamilyPicker`.
+  - Binds to `state.config.agents.chatFontFamily`.
+- `Font size`
+  - Uses the same numeric `AlasField` pattern as Terminal and Code settings.
+  - Binds to `state.config.agents.chatFontSize`.
+  - Clamps writes to `8...64`.
+
+These fields exist in the chat typography work from PR #502. If the current
+branch does not yet contain those config keys, implementation should bring that
+work in or rebase onto it before wiring the pane.
+
+### Launcher
+
+- `Default launch surface`
+  - Uses the existing Terminal/Chat picker.
+  - Binds to `state.config.agents.defaultLauncherMode`.
+  - This belongs in Chat because it controls whether the `Option-Command-T`
+    launcher starts on Terminal or Chat.
+
+### Composer
+
+- `While busy, Return queues; Option-Return steers`
+  - Reuses the current label and behavior.
+  - Binds to `state.config.harness.acpSendOnEnter`.
+
+### Sessions
+
+- `Confirm before closing chat tabs`
+  - Binds to `state.config.harness.confirmCloseChatTabs`.
+- `Auto-run`
+  - Binds to `state.config.harness.acpAutoRunByDefault`.
+
+## Agents Pane Changes
+
+Remove the current `Launcher (Option-Command-T)` group and the current `Chat`
+group from `AgentsPane`.
+
+Keep the existing:
+
+- available agents grid
+- `Worktree auto-launch` group
+- `Harness` group linking to Terminal settings
+
+Do not add an `Open Chat Settings` row or any replacement anchor in `Agents`.
+
+## Data Model
+
+Do not introduce a new `AppConfig.Chat` model in this change. Existing fields
+stay where they are:
+
+- `agents.defaultLauncherMode`
+- `agents.chatFontFamily`
+- `agents.chatFontSize`
+- `harness.acpSendOnEnter`
+- `harness.confirmCloseChatTabs`
+- `harness.acpAutoRunByDefault`
+
+This keeps the change compatible with existing config files and avoids
+unnecessary JSON churn.
+
+## Testing
+
+Update `SettingsSectionTests` so the sidebar sections include `Chat` and remain
+alphabetic except `Debug` last.
+
+Add a `ChatPane` smoke test similar to the existing settings pane tests. The
+test should instantiate `ChatPane` with an `AppState`, inject the current theme,
+and verify it lays out without crashing.
+
+If implementation touches chat font config availability, preserve or add tests
+for:
+
+- default chat font values
+- backward-compatible decode when older config lacks chat font fields
+- font size clamping on decode
+
+## Verification
+
+Before finishing implementation, run the project-standard checks:
+
+```bash
+xcodegen
+xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -quiet build
+xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' test
+```


### PR DESCRIPTION
## Summary
- Add a first-class Settings > Chat section.
- Move chat typography, launcher, composer, and session defaults out of Settings > Agents.
- Strengthen settings tests around Chat section contents and sidebar ordering.

## Testing
- `rtk xcodegen`
- `rtk xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -quiet build`
- `rtk xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' test`