### PR TITLE
fix: restore proportional chat fonts

### DIFF
--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -345,6 +345,7 @@
 		5711B2BE2D70220A4BED5B2B /* DefinitionFeature.swift in Sources */ = {isa = PBXBuildFile; fileRef = F12340A649892955245BECB7 /* DefinitionFeature.swift */; };
 		57138814D45D03AE10BE9D67 /* ACPPermissionFSTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2B932ED9D5A485AE1545223C /* ACPPermissionFSTests.swift */; };
 		57A5A3F4F14E75F6C00A2DC0 /* ACPSessionRunnerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B91E5E766925FD6499548CFC /* ACPSessionRunnerTests.swift */; };
+		57C5E087A453B384485B4EE2 /* ChatFontCatalogTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF72CF0EA2F684D6ED3B43F5 /* ChatFontCatalogTests.swift */; };
 		57D04CD70E3A716B81F58FF8 /* RightPaneStateUnstagePathsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0AAF2B901624C0629A1E3357 /* RightPaneStateUnstagePathsTests.swift */; };
 		584066607B7E7E97A736213A /* AppQuitAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 942B0DCA09E1297D9380C58C /* AppQuitAction.swift */; };
 		5846A180EB68D905E9775401 /* GitService+ReviewLoop.swift in Sources */ = {isa = PBXBuildFile; fileRef = 764489A630CC6D79FCE0A26A /* GitService+ReviewLoop.swift */; };
@@ -698,6 +699,7 @@
 		B66EE6A2445C0DDA607788C2 /* GitIgnoreService.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDEA5E54A30636928F5D3B3E /* GitIgnoreService.swift */; };
 		B6713CE9BFA38B7F1D089E5A /* CopilotInstallerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA98E1DB8D77DE67918D6B9F /* CopilotInstallerTests.swift */; };
 		B6C31E7AC3CE21AFEA371389 /* cool-slate.json in Resources */ = {isa = PBXBuildFile; fileRef = 8DEB85132B767DB3B253620C /* cool-slate.json */; };
+		B7542C247255B91CEC68004F /* ChatFontCatalog.swift in Sources */ = {isa = PBXBuildFile; fileRef = F2AC43D07BE4012DB52A2D1B /* ChatFontCatalog.swift */; };
 		B76AD708A9FD54304F84366A /* ImageFileType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B3F942D660C7ABA8542C77D /* ImageFileType.swift */; };
 		B79D01EECD92181B710D2648 /* CommitInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C01FBF2EE3668E6772CEB1D /* CommitInfo.swift */; };
 		B7D79703ABCAFBC04A0091E5 /* VisualEffectView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D97EF761C70A3AF83C00879A /* VisualEffectView.swift */; };
@@ -1697,6 +1699,7 @@
 		BEFDCAF3F099FE539D9737E9 /* InstallSplitButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InstallSplitButton.swift; sourceTree = "<group>"; };
 		BF3AC3A1F7C5649E75015293 /* CreatingWorktreeView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CreatingWorktreeView.swift; sourceTree = "<group>"; };
 		BF3F87CE04B7E98606BF76CA /* CursorInstallerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CursorInstallerTests.swift; sourceTree = "<group>"; };
+		BF72CF0EA2F684D6ED3B43F5 /* ChatFontCatalogTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatFontCatalogTests.swift; sourceTree = "<group>"; };
 		BF7E57BC5EC8A465F26B3642 /* AlasCLIRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlasCLIRequest.swift; sourceTree = "<group>"; };
 		BFD267BE3F08611B376F3CC7 /* EditorConflictBanner.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditorConflictBanner.swift; sourceTree = "<group>"; };
 		BFE0C069E5446132D39C4DE5 /* QueuedPrompt.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QueuedPrompt.swift; sourceTree = "<group>"; };
@@ -1902,6 +1905,7 @@
 		F18E4AD4B92330FB085C821C /* FileDeviceStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileDeviceStore.swift; sourceTree = "<group>"; };
 		F198697EB5305E5ECE97BC61 /* HarnessDetectorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HarnessDetectorTests.swift; sourceTree = "<group>"; };
 		F226AB1F51ED675BC5171018 /* SidebarMaterialChoiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SidebarMaterialChoiceTests.swift; sourceTree = "<group>"; };
+		F2AC43D07BE4012DB52A2D1B /* ChatFontCatalog.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatFontCatalog.swift; sourceTree = "<group>"; };
 		F31E42DEC85081FEA8CA1BC3 /* ACPSessionLeaseTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPSessionLeaseTests.swift; sourceTree = "<group>"; };
 		F332906E17C5865856DBB90B /* ACPSessionRunner.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPSessionRunner.swift; sourceTree = "<group>"; };
 		F3678A2904CBBFAC939C9275 /* SettingsGroup.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsGroup.swift; sourceTree = "<group>"; };
@@ -2359,6 +2363,7 @@
 				08BD96F4379A0D250DE4303C /* JSONRPC */,
 				D7416CBAB1B316023E546714 /* Persistence */,
 				073D86784AF420D20A2149BB /* Remote */,
+				34382081666B7E8A95C0DA37 /* Settings */,
 				5FA3F5C4A99F2C74080DA0EF /* SQLiteKit */,
 			);
 			path = AlasTests;
@@ -2514,6 +2519,14 @@
 				4457B30E0C8A22BF06D0BC4B /* ACPPermissionScope.swift */,
 			);
 			path = Permissions;
+			sourceTree = "<group>";
+		};
+		34382081666B7E8A95C0DA37 /* Settings */ = {
+			isa = PBXGroup;
+			children = (
+				BF72CF0EA2F684D6ED3B43F5 /* ChatFontCatalogTests.swift */,
+			);
+			path = Settings;
 			sourceTree = "<group>";
 		};
 		35407CBFC8CDF3C3395FE123 /* UI */ = {
@@ -2806,6 +2819,7 @@
 				5BB6172AE118D2F9A40FD534 /* AgentsPane.swift */,
 				4B450918CC98255AD9170586 /* AppearancePane.swift */,
 				EB1E14CFAC880D31CE8FBE8F /* ChangesPane.swift */,
+				F2AC43D07BE4012DB52A2D1B /* ChatFontCatalog.swift */,
 				B0D2C54087C4501C3E7793FE /* ChatPane.swift */,
 				A727D24652E45B98C10917F8 /* CodeLanguageDetailView.swift */,
 				93CDC9895F48619E97461875 /* CodePane.swift */,
@@ -4093,6 +4107,7 @@
 				8F5B93A115E4554430ADC0FD /* ChangesPane.swift in Sources */,
 				23013D3D2538AC2D1BD3403D /* ChangesTabView.swift in Sources */,
 				D46F8DF1FB66AD0ED92F3DF0 /* ChangesTreeBuilder.swift in Sources */,
+				B7542C247255B91CEC68004F /* ChatFontCatalog.swift in Sources */,
 				D49FD01D96C6B00C3683FBCA /* ChatPane.swift in Sources */,
 				CD7FB3120E4B194063C76817 /* ClaudeCodeACPInstaller.swift in Sources */,
 				87ECE63567C08B2847844EDE /* ClaudeInstaller.swift in Sources */,
@@ -4602,6 +4617,7 @@
 				F8143610563C28604A23B89A /* CenterSelectionStateResolverTests.swift in Sources */,
 				835AFE4A9EA0889E0AF316BD /* ChangeSummaryVisibilityTests.swift in Sources */,
 				59765FD789179C1BDC3F1BB9 /* ChangesTreeBuilderTests.swift in Sources */,
+				57C5E087A453B384485B4EE2 /* ChatFontCatalogTests.swift in Sources */,
 				981730A24BE369F4AE9012F3 /* ChatPaneTests.swift in Sources */,
 				188D02B853162BF4533020E2 /* ChevronStabilityTests.swift in Sources */,
 				E0AA2F46C6E53C547FEB6495 /* ClaudeCodeACPInstallerTests.swift in Sources */,

--- a/Alas/Sources/ACP/UI/ACPChatTypography.swift
+++ b/Alas/Sources/ACP/UI/ACPChatTypography.swift
@@ -3,7 +3,7 @@ import SwiftUI
 
 struct ACPChatTypography: Equatable {
     static let `default` = ACPChatTypography(
-        fontFamily: "JetBrainsMono Nerd Font",
+        fontFamily: "",
         fontSize: 13
     )
 
@@ -40,10 +40,7 @@ struct ACPChatTypography: Equatable {
     }
 
     func appKitFont(size: CGFloat? = nil, traits: NSFontTraitMask = []) -> NSFont {
-        var font = CenterTypography.resolveCodeFont(
-            family: fontFamily,
-            size: size ?? baseSize
-        )
+        var font = resolveChatFont(size: size ?? baseSize)
         guard !traits.isEmpty else { return font }
 
         if traits.contains(.boldFontMask) {
@@ -64,5 +61,42 @@ struct ACPChatTypography: Equatable {
         guard let traitFont = NSFont(descriptor: descriptor, size: size ?? baseSize)
         else { return font }
         return traitFont
+    }
+
+    private func resolveChatFont(size: CGFloat) -> NSFont {
+        let trimmed = fontFamily.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else {
+            return NSFont.systemFont(ofSize: size)
+        }
+
+        let manager = NSFontManager.shared
+        if let members = manager.availableMembers(ofFontFamily: trimmed),
+           !members.isEmpty {
+            let regularMember = members.first { row in
+                guard row.count > 3 else { return false }
+                let rawTraits: UInt
+                if let traits = row[3] as? UInt {
+                    rawTraits = traits
+                } else if let traits = row[3] as? Int {
+                    rawTraits = UInt(traits)
+                } else {
+                    return false
+                }
+                return NSFontTraitMask(rawValue: rawTraits)
+                    .intersection([.boldFontMask, .italicFontMask])
+                    .isEmpty
+            }
+            let chosen = regularMember ?? members.first
+            if let name = chosen?.first as? String,
+               let font = NSFont(name: name, size: size) {
+                return font
+            }
+        }
+
+        if let font = NSFont(name: trimmed, size: size) {
+            return font
+        }
+
+        return NSFont.systemFont(ofSize: size)
     }
 }

--- a/Alas/Sources/Persistence/AppConfig.swift
+++ b/Alas/Sources/Persistence/AppConfig.swift
@@ -436,7 +436,7 @@ struct AppConfig: Codable, Equatable {
                 useBypassPermissions: false
             ),
             defaultLauncherMode: .terminal,
-            chatFontFamily: "JetBrainsMono Nerd Font",
+            chatFontFamily: "",
             chatFontSize: 13
         ),
         files: Files(showIgnored: true),
@@ -687,7 +687,7 @@ extension AppConfig {
             )) ?? .terminal
             let chatFontFamily = (try? agentsContainer.decode(
                 String.self, forKey: .chatFontFamily
-            )) ?? "JetBrainsMono Nerd Font"
+            )) ?? ""
             let rawChatFontSize = (try? agentsContainer.decode(
                 Int.self, forKey: .chatFontSize
             )) ?? 13
@@ -708,7 +708,7 @@ extension AppConfig {
                     agentId: nil, useBypassPermissions: false
                 ),
                 defaultLauncherMode: .terminal,
-                chatFontFamily: "JetBrainsMono Nerd Font",
+                chatFontFamily: "",
                 chatFontSize: 13
             )
         }

--- a/Alas/Sources/Settings/ChatFontCatalog.swift
+++ b/Alas/Sources/Settings/ChatFontCatalog.swift
@@ -1,0 +1,13 @@
+import AppKit
+
+/// Returns installed font family names for chat prose. Cached after first call
+/// because the system font set does not change during normal app runtime.
+enum ChatFontCatalog {
+    private static let cache: [String] = sortedFamilies(NSFontManager.shared.availableFontFamilies)
+
+    static func families() -> [String] { cache }
+
+    static func sortedFamilies(_ families: [String]) -> [String] {
+        families.sorted { $0.localizedCaseInsensitiveCompare($1) == .orderedAscending }
+    }
+}

--- a/Alas/Sources/Settings/ChatPane.swift
+++ b/Alas/Sources/Settings/ChatPane.swift
@@ -20,6 +20,11 @@ struct ChatPane: View {
         static let autoRun = "⚡ Auto-run"
     }
 
+    enum FontPickerDefaults {
+        static let defaultLabel = "System"
+        static let emptyCatalogMessage = "No fonts found"
+    }
+
     static let groupTitles = [
         GroupTitles.appearance,
         GroupTitles.launcher,
@@ -48,7 +53,9 @@ struct ChatPane: View {
                     SettingsRow(name: RowLabels.fontFamily) {
                         FontFamilyPicker(
                             family: state.bind(\.agents.chatFontFamily),
-                            catalog: MonospaceFontCatalog.families()
+                            catalog: ChatFontCatalog.families(),
+                            defaultLabel: FontPickerDefaults.defaultLabel,
+                            emptyCatalogMessage: FontPickerDefaults.emptyCatalogMessage
                         )
                     }
                     SettingsRow(name: RowLabels.fontSize) {

--- a/Alas/Sources/Settings/FontFamilyPicker.swift
+++ b/Alas/Sources/Settings/FontFamilyPicker.swift
@@ -1,15 +1,29 @@
 import SwiftUI
 import AppKit
 
-/// Popover-based picker that shows a monospace font list with per-row preview.
+/// Popover-based picker that shows a font list with per-row preview.
 /// The trigger renders the currently-selected family in that family.
 struct FontFamilyPicker: View {
     @Binding var family: String
     let catalog: [String]
+    let defaultLabel: String?
+    let emptyCatalogMessage: String
 
     @Environment(\.theme) var theme
     @State private var open = false
     @State private var search = ""
+
+    init(
+        family: Binding<String>,
+        catalog: [String],
+        defaultLabel: String? = nil,
+        emptyCatalogMessage: String = "No monospace fonts found"
+    ) {
+        self._family = family
+        self.catalog = catalog
+        self.defaultLabel = defaultLabel
+        self.emptyCatalogMessage = emptyCatalogMessage
+    }
 
     var body: some View {
         Button(action: { open.toggle() }) {
@@ -42,7 +56,10 @@ struct FontFamilyPicker: View {
     private var isInstalled: Bool { catalog.contains(family) }
 
     private var triggerLabel: String {
-        isInstalled || family.isEmpty ? family : "\(family) (not installed)"
+        if family.isEmpty, let defaultLabel {
+            return defaultLabel
+        }
+        return isInstalled || family.isEmpty ? family : "\(family) (not installed)"
     }
 
     private var triggerFont: Font {
@@ -65,17 +82,27 @@ struct FontFamilyPicker: View {
 
             Divider().background(theme.color("line"))
 
-            if catalog.isEmpty {
-                Text("No monospace fonts found")
+            if catalog.isEmpty, defaultLabel == nil {
+                Text(emptyCatalogMessage)
                     .font(.system(size: 12))
                     .foregroundColor(theme.color("fg-dim"))
                     .padding(12)
             } else {
                 ScrollView {
                     LazyVStack(alignment: .leading, spacing: 0) {
+                        if let defaultLabel {
+                            row(name: "", displayName: defaultLabel, missing: false)
+                            Divider().background(theme.color("line"))
+                        }
                         if !isInstalled, !family.isEmpty {
                             row(name: family, missing: true)
                             Divider().background(theme.color("line"))
+                        }
+                        if catalog.isEmpty {
+                            Text(emptyCatalogMessage)
+                                .font(.system(size: 12))
+                                .foregroundColor(theme.color("fg-dim"))
+                                .padding(12)
                         }
                         ForEach(filteredCatalog, id: \.self) { name in
                             row(name: name, missing: false)
@@ -89,7 +116,7 @@ struct FontFamilyPicker: View {
     }
 
     @ViewBuilder
-    private func row(name: String, missing: Bool) -> some View {
+    private func row(name: String, displayName: String? = nil, missing: Bool) -> some View {
         Button(action: {
             family = name
             open = false
@@ -99,8 +126,8 @@ struct FontFamilyPicker: View {
                     .font(.system(size: 10, weight: .semibold))
                     .foregroundColor(theme.color("fg"))
                     .opacity(name == family ? 1 : 0)
-                Text(missing ? "\(name) (not installed)" : name)
-                    .font(missing ? .system(size: 13) : .custom(name, size: 14))
+                Text(missing ? "\(name) (not installed)" : (displayName ?? name))
+                    .font(name.isEmpty || missing ? .system(size: 13) : .custom(name, size: 14))
                     .foregroundColor(missing ? theme.color("fg-dim") : theme.color("fg"))
                     .lineLimit(1)
                 Spacer()

--- a/AlasTests/ACP/UI/ACPChatTypographyTests.swift
+++ b/AlasTests/ACP/UI/ACPChatTypographyTests.swift
@@ -1,3 +1,5 @@
+import AppKit
+import Foundation
 import Testing
 @testable import Alas
 
@@ -28,5 +30,24 @@ struct ACPChatTypographyTests {
         #expect(typography.headingSize(level: 3) == 15)
         #expect(typography.headingSize(level: 4) == 14)
         #expect(typography.headingSize(level: 99) == 14)
+    }
+
+    @Test func semanticDefaultUsesSystemFont() {
+        let typography = ACPChatTypography(fontFamily: "", fontSize: 13)
+        let font = typography.appKitFont()
+
+        #expect(font.familyName == NSFont.systemFont(ofSize: 13).familyName)
+        #expect(font.pointSize == 13)
+    }
+
+    @Test func missingFamilyFallsBackToSystemFont() {
+        let typography = ACPChatTypography(
+            fontFamily: "Missing Chat Font \(UUID().uuidString)",
+            fontSize: 15
+        )
+        let font = typography.appKitFont()
+
+        #expect(font.familyName == NSFont.systemFont(ofSize: 15).familyName)
+        #expect(font.pointSize == 15)
     }
 }

--- a/AlasTests/AppConfigAgentsCodingTests.swift
+++ b/AlasTests/AppConfigAgentsCodingTests.swift
@@ -11,7 +11,7 @@ struct AppConfigAgentsCodingTests {
     }
 
     @Test func defaultsHaveChatAppearance() {
-        #expect(AppConfig.defaults.agents.chatFontFamily == "JetBrainsMono Nerd Font")
+        #expect(AppConfig.defaults.agents.chatFontFamily == "")
         #expect(AppConfig.defaults.agents.chatFontSize == 13)
     }
 
@@ -167,7 +167,7 @@ struct AppConfigAgentsCodingTests {
         }
         """
         let cfg = try JSONDecoder().decode(AppConfig.self, from: Data(json.utf8))
-        #expect(cfg.agents.chatFontFamily == "JetBrainsMono Nerd Font")
+        #expect(cfg.agents.chatFontFamily == "")
         #expect(cfg.agents.chatFontSize == 13)
     }
 

--- a/AlasTests/ChatPaneTests.swift
+++ b/AlasTests/ChatPaneTests.swift
@@ -33,4 +33,9 @@ struct ChatPaneTests {
             "⚡ Auto-run",
         ])
     }
+
+    @Test func chatPaneUsesSystemFontPickerDefaults() {
+        #expect(ChatPane.FontPickerDefaults.defaultLabel == "System")
+        #expect(ChatPane.FontPickerDefaults.emptyCatalogMessage == "No fonts found")
+    }
 }

--- a/AlasTests/Settings/ChatFontCatalogTests.swift
+++ b/AlasTests/Settings/ChatFontCatalogTests.swift
@@ -1,0 +1,17 @@
+import Testing
+@testable import Alas
+
+struct ChatFontCatalogTests {
+    @Test func sortsFamiliesCaseInsensitively() {
+        let sorted = ChatFontCatalog.sortedFamilies(["zeta", "Alpha", "beta"])
+
+        #expect(sorted == ["Alpha", "beta", "zeta"])
+    }
+
+    @Test func keepsProportionalFamiliesFromAvailableFonts() {
+        let families = ChatFontCatalog.sortedFamilies(["Helvetica", "Menlo"])
+
+        #expect(families.contains("Helvetica"))
+        #expect(families.contains("Menlo"))
+    }
+}

--- a/docs/superpowers/specs/2026-06-11-chat-proportional-fonts-design.md
+++ b/docs/superpowers/specs/2026-06-11-chat-proportional-fonts-design.md
@@ -1,0 +1,34 @@
+# Chat Proportional Fonts Design
+
+## Context
+
+Commit `d025aa6` added chat typography settings and wired chat rendering to a shared font-family setting. The setting currently uses `MonospaceFontCatalog`, so only fixed-pitch families are selectable. Before that change, ACP chat prose and the composer used the macOS system font through `.system(...)` / `NSFont.systemFont(...)`; code blocks and code-like surfaces stayed monospaced.
+
+## Goals
+
+- Let Chat settings choose proportional as well as monospaced font families.
+- Restore the default chat prose/composer font to the previous macOS system font.
+- Keep code blocks, syntax-highlighted snippets, inline diffs, terminal output, and editor/code settings on their existing monospace/code-font behavior.
+- Preserve existing persisted user choices.
+
+## Design
+
+Add a chat-specific font catalog that returns all installed font families, sorted case-insensitively. Reuse the existing `FontFamilyPicker`, but let callers provide neutral empty-state copy so Chat can say "No fonts found" while Terminal/Code can keep monospace wording.
+
+Represent the old default as an empty `chatFontFamily`, meaning "System". This avoids depending on a private or version-specific family name and matches SwiftUI/AppKit's previous semantic `.system` behavior. The picker trigger should render this as "System" and rows should include a selectable "System" option before installed families.
+
+Add a general font resolver for chat typography. For non-empty families, it should resolve the regular face from available family members using the same family-name approach as code fonts. If resolution fails, fall back to `NSFont.systemFont(ofSize:)`. `ACPChatTypography` should use this general resolver for prose, headings, quotes, the composer, and placeholders. Existing code block rendering should continue using `CenterTypography.resolveCodeFont`.
+
+Persisted configs that omit `agents.chatFontFamily` should decode to the empty semantic default. Configs that already store a specific family, including the current `"JetBrainsMono Nerd Font"` value, should keep that value.
+
+## Testing
+
+- Update config default and legacy decode tests to expect an empty chat font family.
+- Add typography resolver coverage for the semantic system default and missing-family fallback.
+- Add settings picker/catalog coverage where practical without depending on host-specific installed fonts.
+
+## Out Of Scope
+
+- Migrating existing user configs that explicitly contain `"JetBrainsMono Nerd Font"`.
+- Changing code/terminal font settings.
+- Adding per-region chat font settings.


### PR DESCRIPTION
## Summary
- Restore the chat font default to the macOS system font instead of the bundled monospace font.
- Let Chat settings list all installed font families while keeping Code and Terminal on the monospace catalog.
- Add coverage for config defaults, chat font resolution, and catalog sorting.

## Testing
- `xcodegen`
- `xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -quiet build`
- `xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -resultBundlePath /tmp/alas-full-tests.xcresult -quiet test` (3626 passed, 4 skipped, 0 failed)