### PR TITLE
fix(acp): bound ACP terminal output retention

### DIFF
--- a/Alas/Sources/ACP/Terminal/ACPTerminal.swift
+++ b/Alas/Sources/ACP/Terminal/ACPTerminal.swift
@@ -23,6 +23,7 @@ final class ACPTerminal: ObservableObject {
     /// `terminal/*` protocol calls against this id while still letting
     /// the UI render the retained buffer.
     private(set) var released: Bool = false
+    var onExit: (() -> Void)?
 
     private let process: Process
     private let pipe: Pipe
@@ -413,6 +414,7 @@ final class ACPTerminal: ObservableObject {
         }
         pipe.fileHandleForReading.readabilityHandler = nil
         exitStatus = status
+        onExit?()
         let waiters = exitWaiters
         exitWaiters.removeAll()
         for c in waiters { c.resume(returning: status) }

--- a/Alas/Sources/ACP/Terminal/ACPTerminalHost.swift
+++ b/Alas/Sources/ACP/Terminal/ACPTerminalHost.swift
@@ -9,6 +9,7 @@ enum ACPTerminalHostError: Error, Equatable {
 @MainActor
 final class ACPTerminalHost: ObservableObject {
     static let maxLiveTerminals = 32
+    static let maxRetainedFinishedTerminals = 64
 
     private(set) var sessionCwd: String
     private(set) var sessionEnv: [String: String]
@@ -48,6 +49,9 @@ final class ACPTerminalHost: ObservableObject {
                 env: env,
                 cwd: cwd,
                 outputByteLimit: limit)
+            term.onExit = { [weak self] in
+                self?.pruneFinishedTerminals()
+            }
             terminals[id] = term
             return ACPTerminalCreateResult(terminalId: id)
         } catch {
@@ -98,6 +102,10 @@ final class ACPTerminalHost: ObservableObject {
         for term in terminals.values { term.kill() }
     }
 
+    var retainedByteEstimate: UInt64 {
+        terminals.values.reduce(0) { $0 &+ UInt64($1.buffer.count) }
+    }
+
     func updateContext(sessionCwd: String, sessionEnv: [String: String]) {
         self.sessionCwd = sessionCwd
         self.sessionEnv = sessionEnv
@@ -116,5 +124,16 @@ final class ACPTerminalHost: ObservableObject {
         var out = sessionEnv
         for v in overlay ?? [] { out[v.name] = v.value }
         return out
+    }
+
+    private func pruneFinishedTerminals() {
+        let finished = terminals.values
+            .filter { $0.exitStatus != nil }
+            .sorted { $0.createdAt < $1.createdAt }
+        let overflow = finished.count - Self.maxRetainedFinishedTerminals
+        guard overflow > 0 else { return }
+        for term in finished.prefix(overflow) {
+            terminals.removeValue(forKey: term.id)
+        }
     }
 }

--- a/Alas/Sources/Diagnostics/MemoryDiagnostics.swift
+++ b/Alas/Sources/Diagnostics/MemoryDiagnostics.swift
@@ -30,6 +30,7 @@ final class MemoryDiagnostics: ObservableObject {
         var perSession: [MemorySnapshot.PerSession] = []
         var transcriptBytes: UInt64 = 0
         var markdownCacheBytes: UInt64 = 0
+        var terminalBytes: UInt64 = 0
         var sessionCount = 0
         var runnerCount = 0
         for (worktreeId, manager) in managers {
@@ -37,8 +38,10 @@ final class MemoryDiagnostics: ObservableObject {
             for session in manager.sessions.values {
                 let tx = session.transcriptByteEstimate()
                 let md = session.markdownCacheByteEstimate()
+                let term = session.terminalHost.retainedByteEstimate
                 transcriptBytes &+= tx
                 markdownCacheBytes &+= md
+                terminalBytes &+= term
                 sessionCount += 1
                 perSession.append(.init(
                     sessionId: session.id,
@@ -49,7 +52,6 @@ final class MemoryDiagnostics: ObservableObject {
                     attached: Self.isAttached(state: session.agentState)))
             }
         }
-        let terminalBytes: UInt64 = 0
         return MemorySnapshot(
             timestamp: Date(),
             physFootprint: ProcessMemoryProbe.physFootprint(),

--- a/AlasTests/ACP/Terminal/ACPTerminalHostTests.swift
+++ b/AlasTests/ACP/Terminal/ACPTerminalHostTests.swift
@@ -107,6 +107,42 @@ struct ACPTerminalHostTests {
         #expect(status.exitCode != 0 || status.signal != nil)
     }
 
+    @Test("finished terminal retention is capped")
+    func finishedTerminalRetentionIsCapped() async throws {
+        let host = ACPTerminalHost(sessionCwd: "/tmp", sessionEnv: [:])
+        for i in 0 ... ACPTerminalHost.maxRetainedFinishedTerminals {
+            let r = try host.create(.init(
+                sessionId: "s",
+                command: "/bin/echo",
+                args: ["terminal-\(i)"],
+                env: nil,
+                cwd: nil,
+                outputByteLimit: nil
+            ))
+            _ = await host.terminal(id: r.terminalId)?.waitForExit()
+        }
+
+        #expect(host.terminals.count == ACPTerminalHost.maxRetainedFinishedTerminals)
+    }
+
+    #if DEBUG
+    @Test("retained byte estimate includes terminal buffers")
+    func retainedByteEstimateIncludesTerminalBuffers() async throws {
+        let host = ACPTerminalHost(sessionCwd: "/tmp", sessionEnv: [:])
+        let r = try host.create(.init(
+            sessionId: "s",
+            command: "/bin/echo",
+            args: ["retained-output"],
+            env: nil,
+            cwd: nil,
+            outputByteLimit: nil
+        ))
+        _ = await host.terminal(id: r.terminalId)?.waitForExit()
+
+        #expect(host.retainedByteEstimate > 0)
+    }
+    #endif
+
     @Test("create errors after 32 live terminals")
     func tooManyLive() async throws {
         let host = ACPTerminalHost(sessionCwd: "/tmp", sessionEnv: [:])


### PR DESCRIPTION
## Summary

- Cap retained finished ACP terminal entries per chat session so old tool subprocess output cannot grow without bound.
- Include retained ACP terminal buffer bytes in debug memory diagnostics.
- Add regression coverage for finished terminal retention and diagnostic byte accounting.

## Validation

- `xcodegen`
- `xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -quiet build`
- `xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' test`
- `git diff --check`

## Notes

Also ran `scripts/prune-xcode-state.sh --delete` locally to remove stale Alas/Ghostty DerivedData entries.