### PR TITLE
fix(acp): keep composer font stable while typing

### DIFF
--- a/Alas/Sources/ACP/UI/ACPComposer.swift
+++ b/Alas/Sources/ACP/UI/ACPComposer.swift
@@ -584,6 +584,8 @@ final class ACPNSTextView: NSTextView {
     }
 
     override func keyDown(with event: NSEvent) {
+        typingAttributes = baseTypingAttributes
+
         // ⌃V parity with agent CLIs — paste an image when one is on the
         // clipboard. Only intercept when there IS an image, so Cocoa's
         // default ⌃V (page down / emacs binding) is otherwise preserved.
@@ -624,6 +626,7 @@ final class ACPNSTextView: NSTextView {
         }
 
         super.keyDown(with: event)
+        typingAttributes = baseTypingAttributes
 
         // After the keystroke is applied to the storage, re-evaluate
         // whether we're sitting on a `/foo…` token. This is what makes


### PR DESCRIPTION
The ACP composer briefly rendered typed text in a smaller font before "popping" to the configured size after the debounced markdown restyler ran (0.5s after the last edit). Fast typing kept the small-font state visible for longer.

Root cause: `ACPNSTextView.keyDown` did not reset `typingAttributes` to the configured chat typography. New characters inherited whatever attributes AppKit had at the caret, which diverged from the typography the restyler later applied.

Fix: reset `typingAttributes` to `baseTypingAttributes` (the configured font/color) before and after `super.keyDown`. This makes inserted characters render at the right size immediately. The debounced markdown restyler is unchanged and still does its job for `**bold**`, `*italic*`, ``code``, etc.

Tested locally:
- `xcodegen` passes.
- `xcodebuild` was blocked in this worktree by a missing `ThirdParty/zmx` submodule (unrelated to the change). CI will provide the real verification.