### PR TITLE
fix(chat): scroll restoration on tab return

### DIFF
--- a/Alas/Sources/ACP/Session/ACPSessionManager.swift
+++ b/Alas/Sources/ACP/Session/ACPSessionManager.swift
@@ -1,5 +1,13 @@
 import Foundation
 
+private struct ACPTranscriptScrollMemory: Equatable {
+    var anchorMessageId: String?
+    /// ACP view ids for persisted text rows are regenerated during hydration;
+    /// the transcript index is the durable restore target across eviction.
+    var anchorMessageIndex: Int?
+    var followsTail: Bool
+}
+
 @MainActor
 final class ACPSessionManager: ObservableObject {
     typealias ACPSetupEvaluator = @MainActor (_ spec: ACPLaunchSpec) async -> ACPSetupResult
@@ -167,6 +175,12 @@ final class ACPSessionManager: ObservableObject {
     /// evict and later recreate the session object without losing whether
     /// the plan was last rendered inline or in the toolbar pill.
     private var planSidebarVisibility: [ACPSession.ID: Bool] = [:]
+    /// Runtime-only transcript scroll memory. Kept on the manager for the
+    /// same reason as `planSidebarVisibility`: idle ACP sessions can be
+    /// evicted on tab switches, but returning to the tab should not reset
+    /// a user-paused transcript to the top of whatever render window hydrates
+    /// first.
+    private var transcriptScrollMemory: [ACPSession.ID: ACPTranscriptScrollMemory] = [:]
     /// Set to true by `shutdownBackgroundTasks` so any in-flight `attach`
     /// coroutine that resumes after dispose aborts at the pre-commit guard
     /// rather than registering a runner for a session whose manager is dead.
@@ -253,6 +267,9 @@ final class ACPSessionManager: ObservableObject {
             title: row.title, titleSource: row.titleSource, hydrationState: .loading,
             restoredFromPersistence: true)
         session.remoteSessionId = row.remoteSessionId
+        if let memory = transcriptScrollMemory[id] {
+            session.followsTranscriptTail = memory.followsTail
+        }
         sessions[id] = session
         return session
     }
@@ -384,6 +401,7 @@ final class ACPSessionManager: ObservableObject {
         }
         session.replaceTranscriptMessages(tail)
         session.transcript.visibleHead = 0
+        applyRememberedTranscriptScrollWindow(to: session, messageIndexOffset: tailStart)
         session.restoreQueue(result.queue)
         // The composer is rendered (and focused) the moment the placeholder
         // appears, so the user can start typing before hydration finishes.
@@ -510,6 +528,7 @@ final class ACPSessionManager: ObservableObject {
                   self.sessions[sessionId] === session
             else { return }
             session.prependTranscriptMessages(older)
+            self.applyRememberedTranscriptScrollWindow(to: session)
         }
         handle.task = task
         inFlightBackfills[sessionId] = task
@@ -526,6 +545,7 @@ final class ACPSessionManager: ObservableObject {
         sessions[id] = nil
         sessionRefCounts.removeValue(forKey: id)
         planSidebarVisibility.removeValue(forKey: id)
+        transcriptScrollMemory.removeValue(forKey: id)
         pendingModel.removeValue(forKey: id)
         pendingMode.removeValue(forKey: id)
     }
@@ -538,6 +558,7 @@ final class ACPSessionManager: ObservableObject {
         sessions[id] = nil
         sessionRefCounts.removeValue(forKey: id)
         planSidebarVisibility.removeValue(forKey: id)
+        transcriptScrollMemory.removeValue(forKey: id)
         pendingModel.removeValue(forKey: id)
         pendingMode.removeValue(forKey: id)
         try? store.deleteSession(id: id)
@@ -573,6 +594,46 @@ final class ACPSessionManager: ObservableObject {
 
     func rememberPlanSidebarVisibility(_ visible: Bool, for id: ACPSession.ID) {
         planSidebarVisibility[id] = visible
+    }
+
+    func rememberedTranscriptScrollAnchor(for id: ACPSession.ID) -> String? {
+        guard transcriptScrollMemory[id]?.followsTail == false else { return nil }
+        return transcriptScrollMemory[id]?.anchorMessageId
+    }
+
+    func rememberTranscriptScrollAnchor(
+        sessionId id: ACPSession.ID,
+        anchorMessageId: String?,
+        anchorMessageIndex: Int? = nil,
+        followsTail: Bool
+    ) {
+        if followsTail {
+            transcriptScrollMemory.removeValue(forKey: id)
+        } else {
+            transcriptScrollMemory[id] = ACPTranscriptScrollMemory(
+                anchorMessageId: anchorMessageId,
+                anchorMessageIndex: anchorMessageIndex,
+                followsTail: false
+            )
+        }
+        sessions[id]?.followsTranscriptTail = followsTail
+    }
+
+    private func applyRememberedTranscriptScrollWindow(
+        to session: ACPSession,
+        messageIndexOffset: Int = 0
+    ) {
+        guard let memory = transcriptScrollMemory[session.id], !memory.followsTail else { return }
+        if let index = memory.anchorMessageIndex {
+            let localIndex = index - messageIndexOffset
+            guard localIndex >= 0, localIndex < session.transcript.messages.count else { return }
+            session.transcript.setVisibleHead(localIndex)
+            return
+        }
+        guard let anchor = memory.anchorMessageId,
+              let index = session.transcript.messages.firstIndex(where: { $0.stableId == anchor })
+        else { return }
+        session.transcript.setVisibleHead(index)
     }
 
     /// Drops the cached `ACPSession` when its refcount is zero AND no live
@@ -1201,6 +1262,8 @@ extension ACPSessionManager {
         // but only when the session is following the tail (user hasn't scrolled up).
         if session.followsTranscriptTail {
             session.transcript.resetWindowToTail()
+        } else {
+            applyRememberedTranscriptScrollWindow(to: session)
         }
     }
 }
@@ -1366,6 +1429,14 @@ extension ACPSessionManager {
                                               )
                                           },
                                           onPersist: { [weak self] in self?.changeNotifier.post() },
+                                          onResumeTranscriptTail: { [weak self] in
+                                              self?.rememberTranscriptScrollAnchor(
+                                                sessionId: sessionId,
+                                                anchorMessageId: nil,
+                                                anchorMessageIndex: nil,
+                                                followsTail: true
+                                              )
+                                          },
                                           ownerInstanceId: instanceId)
             var runnerStarted = false
             func startRunnerIfNeeded() {

--- a/Alas/Sources/ACP/Session/ACPSessionRunner.swift
+++ b/Alas/Sources/ACP/Session/ACPSessionRunner.swift
@@ -30,6 +30,10 @@ final class ACPSessionRunner {
     /// contents for an open dirty buffer, falling back to disk when the
     /// closure returns `nil`. Lets the agent see what the user sees.
     private let onLiveBufferRead: ((String) -> String?)?
+    /// Called when the runner forces transcript tail-follow before recording
+    /// a user prompt, so manager-owned scroll memory stays in sync with the
+    /// runtime session state.
+    private let onResumeTranscriptTail: (() -> Void)?
     /// The sanitized + extras-merged env the agent process itself was
     /// launched with. Used to seed the terminal host so agent-spawned
     /// commands inherit exactly the same view — including the stripped
@@ -78,6 +82,7 @@ final class ACPSessionRunner {
          onLiveBufferRead: ((String) -> String?)? = nil,
          onAuthRequired: ((ACPSessionRunner, String) async -> Void)? = nil,
          onPersist: (() -> Void)? = nil,
+         onResumeTranscriptTail: (() -> Void)? = nil,
          ownerInstanceId: String? = nil)
     {
         self.session = session
@@ -92,6 +97,7 @@ final class ACPSessionRunner {
         self.suppressingLoadReplay = suppressingLoadReplay
         self.onDirtyCheck = onDirtyCheck
         self.onLiveBufferRead = onLiveBufferRead
+        self.onResumeTranscriptTail = onResumeTranscriptTail
         self.persistedMessageCount = (try? store.messageCount(sessionId: sessionId)) ?? 0
         self.seq = Int64(persistedMessageCount)
         // Capture the three values holdsLeaseForWrite() reads so the closure
@@ -1016,6 +1022,7 @@ extension ACPSessionRunner {
                     let titleBefore = self.session.title
                     if !self.session.followsTranscriptTail {
                         self.session.followsTranscriptTail = true
+                        self.onResumeTranscriptTail?()
                     }
                     self.session.recordUserPrompt(text: Self.textPreview(of: blocks),
                                                   attachments: Self.attachments(of: blocks))

--- a/Alas/Sources/ACP/UI/ACPMessageList.swift
+++ b/Alas/Sources/ACP/UI/ACPMessageList.swift
@@ -19,6 +19,8 @@ struct ACPMessageList: View {
     let onQueueReorder: (Int, Int) -> Void
     let onQueueClearAll: () -> Void
     let onRetryContextRecovery: () -> Void
+    let rememberedScrollAnchor: () -> String?
+    let onRememberScrollAnchor: (String?, Int?, Bool) -> Void
     /// Resolves the full persisted content of a tool call by id when an
     /// expanded card's in-memory content was truncated. Wired by the host
     /// to `ACPSessionManager.reloadFullToolCallContent`. Returns nil when
@@ -29,6 +31,8 @@ struct ACPMessageList: View {
     @State private var headFrame: CGRect = .zero
     @State private var lastHeadStepAt: Date = .distantPast
     @State private var scrollViewRef = ACPWeakScrollViewRef()
+    @State private var latestTopVisibleAnchor: String?
+    @State private var restoredRememberedAnchor: String?
 
     /// Height of an invisible spacer at the tail of the VStack. The
     /// composer pill plus its outer padding occupies roughly this much
@@ -50,10 +54,15 @@ struct ACPMessageList: View {
     /// filter drops `.plan` entries because the toolbar pill renders
     /// the current turn's plan instead of an inline card.
     private var visibleMessages: [ACPMessage] {
+        visibleRows.map(\.message)
+    }
+
+    private var visibleRows: [(index: Int, message: ACPMessage)] {
         let head = min(transcript.visibleHead, transcript.messages.count)
-        return transcript.messages[head...].filter {
-            if case .plan = $0 { return false }
-            return true
+        return (head..<transcript.messages.count).compactMap { index in
+            let message = transcript.messages[index]
+            if case .plan = message { return nil }
+            return (index, message)
         }
     }
 
@@ -114,8 +123,9 @@ struct ACPMessageList: View {
                                 .padding(.bottom, 4)
                                 .background(topPaginationSentinel)
                         }
-                        ForEach(visibleMessages, id: \.stableId) { message in
-                            row(for: message)
+                        ForEach(visibleRows, id: \.message.stableId) { item in
+                            row(for: item.message)
+                                .background(rowFrameReporter(id: item.message.stableId))
                         }
                         if transcript.pendingPermission != nil, let policy = policy {
                             ACPPermissionPrompt(session: session, policy: policy, scopeKey: scopeKey)
@@ -177,6 +187,7 @@ struct ACPMessageList: View {
                     .padding(.horizontal, 28 + ACPMessageGutterLayout.laneWidth)
                     .padding(.top, 24)
                     .frame(maxWidth: .infinity, alignment: .center)
+                    .modifier(ACPScrollTargetLayoutTracking())
                 }
                 .coordinateSpace(name: scrollSpaceName)
                 .modifier(ACPTranscriptScrollTracking(
@@ -195,21 +206,33 @@ struct ACPMessageList: View {
                             proxy: proxy)
                     }
                 ))
+                .modifier(ACPScrollTargetVisibilityTracking(
+                    onVisibleTargetIDs: handleVisibleTargetIDs
+                ))
                 .onAppear {
                     restoreTailIfNeeded(proxy: proxy, animated: false)
+                    restoreRememberedAnchorIfNeeded(proxy: proxy)
                 }
                 .onChange(of: viewport.size.height) { _, _ in
                     restoreTailIfNeeded(proxy: proxy, animated: false)
+                    restoreRememberedAnchorIfNeeded(proxy: proxy)
                 }
                 .onChange(of: scrollSignature) { _, _ in
                     if session.followsTranscriptTail {
                         scrollToTail(proxy: proxy, animated: true)
                     }
+                    restoreRememberedAnchorIfNeeded(proxy: proxy)
                 }
                 .onChange(of: transcript.streamingState) { _, new in
                     if session.followsTranscriptTail && (new == .streaming || new == .sending) {
                         scrollToTail(proxy: proxy, animated: true)
                     }
+                }
+                .onChange(of: transcript.visibleHead) { _, _ in
+                    restoreRememberedAnchorIfNeeded(proxy: proxy)
+                }
+                .onPreferenceChange(ACPRowFramesPreferenceKey.self) { frames in
+                    handleRowFramePreference(frames, proxy: proxy)
                 }
             }
         }
@@ -224,6 +247,21 @@ struct ACPMessageList: View {
     private func restoreTailIfNeeded(proxy: ScrollViewProxy, animated: Bool) {
         guard session.followsTranscriptTail else { return }
         scrollToTail(proxy: proxy, animated: animated)
+    }
+
+    private func restoreRememberedAnchorIfNeeded(proxy: ScrollViewProxy) {
+        guard !session.followsTranscriptTail else {
+            restoredRememberedAnchor = nil
+            return
+        }
+        guard let anchor = rememberedScrollAnchor(), restoredRememberedAnchor != anchor else { return }
+        guard visibleMessages.contains(where: { $0.stableId == anchor }) else { return }
+        isRestoringTail = true
+        proxy.scrollTo(anchor, anchor: .top)
+        restoredRememberedAnchor = anchor
+        DispatchQueue.main.async {
+            isRestoringTail = false
+        }
     }
 
     private func scrollToTail(proxy: ScrollViewProxy, animated: Bool) {
@@ -308,6 +346,61 @@ struct ACPMessageList: View {
     private func setFollowsTranscriptTail(_ follows: Bool) {
         guard session.followsTranscriptTail != follows else { return }
         session.followsTranscriptTail = follows
+        if follows {
+            onRememberScrollAnchor(nil, nil, true)
+        } else {
+            onRememberScrollAnchor(
+                latestTopVisibleAnchor,
+                transcriptIndex(forStableId: latestTopVisibleAnchor),
+                false
+            )
+            restoredRememberedAnchor = latestTopVisibleAnchor
+        }
+    }
+
+    private func handleRowFramePreference(_ frames: [String: CGRect], proxy: ScrollViewProxy) {
+        restoreRememberedAnchorIfNeeded(proxy: proxy)
+        guard let anchor = Self.topVisibleAnchorID(in: frames) else { return }
+        latestTopVisibleAnchor = anchor
+        guard !isRestoringTail else { return }
+        guard !session.followsTranscriptTail else { return }
+        if !Self.shouldRememberVisibleAnchor(
+            anchor,
+            rememberedAnchor: rememberedScrollAnchor(),
+            restoredRememberedAnchor: restoredRememberedAnchor,
+            visibleMessageIds: Set(visibleMessages.map(\.stableId)),
+            isBackfillingOlderMessages: transcript.isBackfillingOlderMessages
+        ) {
+            return
+        }
+        onRememberScrollAnchor(anchor, transcriptIndex(forStableId: anchor), false)
+        restoredRememberedAnchor = anchor
+    }
+
+    private func handleVisibleTargetIDs(_ ids: [String]) {
+        guard let anchor = Self.topVisibleScrollTargetID(
+            in: ids,
+            visibleMessageIds: Set(visibleMessages.map(\.stableId))
+        ) else { return }
+        latestTopVisibleAnchor = anchor
+        guard !isRestoringTail, !session.followsTranscriptTail else { return }
+        guard !transcript.isBackfillingOlderMessages else { return }
+        onRememberScrollAnchor(anchor, transcriptIndex(forStableId: anchor), false)
+        restoredRememberedAnchor = anchor
+    }
+
+    private func rowFrameReporter(id: String) -> some View {
+        GeometryReader { rowGeometry in
+            Color.clear.preference(
+                key: ACPRowFramesPreferenceKey.self,
+                value: [id: rowGeometry.frame(in: .named(scrollSpaceName))]
+            )
+        }
+    }
+
+    private func transcriptIndex(forStableId id: String?) -> Int? {
+        guard let id else { return nil }
+        return transcript.messages.firstIndex(where: { $0.stableId == id })
     }
 
     private var topPaginationSentinel: some View {
@@ -364,6 +457,40 @@ struct ACPMessageList: View {
         }
         let distanceFromBottom = max(0, newContentHeight - viewportHeight - newMinY)
         return distanceFromBottom > ACPScrollDirectionClassifier.bottomTolerance
+    }
+
+    nonisolated static func topVisibleAnchorID(in frames: [String: CGRect]) -> String? {
+        frames
+            .filter { _, frame in frame.height > 0 && frame.maxY > 0 }
+            .min { lhs, rhs in
+                let lhsDistance = lhs.value.minY <= 0 ? CGFloat.zero : lhs.value.minY
+                let rhsDistance = rhs.value.minY <= 0 ? CGFloat.zero : rhs.value.minY
+                if lhsDistance != rhsDistance { return lhsDistance < rhsDistance }
+                if lhs.value.maxY != rhs.value.maxY { return lhs.value.maxY < rhs.value.maxY }
+                return lhs.key < rhs.key
+            }?
+            .key
+    }
+
+    nonisolated static func topVisibleScrollTargetID(
+        in ids: [String],
+        visibleMessageIds: Set<String>
+    ) -> String? {
+        ids.first { visibleMessageIds.contains($0) }
+    }
+
+    nonisolated static func shouldRememberVisibleAnchor(
+        _ anchor: String,
+        rememberedAnchor: String?,
+        restoredRememberedAnchor: String?,
+        visibleMessageIds: Set<String>,
+        isBackfillingOlderMessages: Bool
+    ) -> Bool {
+        guard !isBackfillingOlderMessages else { return false }
+        guard let rememberedAnchor else { return true }
+        if restoredRememberedAnchor == rememberedAnchor { return true }
+        if anchor == rememberedAnchor { return true }
+        return !visibleMessageIds.contains(rememberedAnchor)
     }
 
     /// macOS 14 fallback path. The Tahoe (macOS 15+) ScrollView is no longer
@@ -524,6 +651,39 @@ private struct ACPHeadFramePreferenceKey: PreferenceKey {
     static let defaultValue: CGRect = .zero
     static func reduce(value: inout CGRect, nextValue: () -> CGRect) {
         value = nextValue()
+    }
+}
+
+private struct ACPRowFramesPreferenceKey: PreferenceKey {
+    static let defaultValue: [String: CGRect] = [:]
+    static func reduce(value: inout [String: CGRect], nextValue: () -> [String: CGRect]) {
+        value.merge(nextValue(), uniquingKeysWith: { _, new in new })
+    }
+}
+
+private struct ACPScrollTargetLayoutTracking: ViewModifier {
+    @ViewBuilder
+    func body(content: Content) -> some View {
+        if #available(macOS 15, *) {
+            content.scrollTargetLayout()
+        } else {
+            content
+        }
+    }
+}
+
+private struct ACPScrollTargetVisibilityTracking: ViewModifier {
+    let onVisibleTargetIDs: ([String]) -> Void
+
+    @ViewBuilder
+    func body(content: Content) -> some View {
+        if #available(macOS 15, *) {
+            content.onScrollTargetVisibilityChange(idType: String.self, threshold: 0.01) { ids in
+                onVisibleTargetIDs(ids)
+            }
+        } else {
+            content
+        }
     }
 }
 

--- a/Alas/Sources/ACP/UI/ACPTabView.swift
+++ b/Alas/Sources/ACP/UI/ACPTabView.swift
@@ -308,6 +308,17 @@ private struct ACPSessionView: View {
                                         agentName: state.agent(id: session.agentId)?.displayName
                                     )
                                 },
+                                rememberedScrollAnchor: {
+                                    manager.rememberedTranscriptScrollAnchor(for: sessionId)
+                                },
+                                onRememberScrollAnchor: { anchor, index, followsTail in
+                                    manager.rememberTranscriptScrollAnchor(
+                                        sessionId: sessionId,
+                                        anchorMessageId: anchor,
+                                        anchorMessageIndex: index,
+                                        followsTail: followsTail
+                                    )
+                                },
                                 onLoadFullToolCallContent: { toolCallId in
                                     manager.reloadFullToolCallContent(
                                         sessionId: sessionId, toolCallId: toolCallId)

--- a/AlasTests/ACP/Session/ACPSessionManagerHydrationTests.swift
+++ b/AlasTests/ACP/Session/ACPSessionManagerHydrationTests.swift
@@ -228,6 +228,97 @@ struct ACPSessionManagerHydrationTests {
         }
     }
 
+    @Test("remembered absolute index before tail slice waits for full backfill")
+    func rememberedAbsoluteIndexBeforeTailSliceWaitsForBackfill() async throws {
+        let path = tmpStorePath()
+        let store = try ACPSessionStore(path: path)
+        try store.upsertSession(.init(
+            id: "s", agentId: "claude", title: "t",
+            currentModel: nil, currentMode: nil, autoRun: false,
+            createdAt: 0, updatedAt: 0, lastOpenedAt: 0, archived: false))
+
+        for i in 0..<100 {
+            let m: ACPMessage = .user(id: UUID(), text: "m\(i)", attachments: [])
+            let payload = try ACPMessageCodec.encode(m)
+            try store.appendMessage(sessionId: "s", id: "m\(i)", kind: "user",
+                                    seq: Int64(i), payload: payload, createdAt: 0)
+        }
+
+        let mgr = ACPSessionManager(worktreeId: "wt", worktreePath: "/tmp/wt", store: store)
+        let s = try #require(mgr.placeholderSession(id: "s"))
+        mgr.rememberTranscriptScrollAnchor(
+            sessionId: "s",
+            anchorMessageId: nil,
+            anchorMessageIndex: 5,
+            followsTail: false
+        )
+
+        await mgr.hydrateIfNeeded(id: "s")
+
+        #expect(s.transcript.messages.count == ACPTranscript.tailWindow)
+        #expect(s.transcript.visibleHead == 0)
+        if case .user(_, let text, _) = s.transcript.messages[s.transcript.visibleHead] {
+            #expect(text == "m70")
+        } else {
+            #expect(Bool(false), "expected first tail message before backfill")
+        }
+
+        await mgr.awaitBackfill(id: "s")
+
+        #expect(s.transcript.messages.count == 100)
+        #expect(s.transcript.visibleHead == 5)
+        if case .user(_, let text, _) = s.transcript.messages[s.transcript.visibleHead] {
+            #expect(text == "m5")
+        } else {
+            #expect(Bool(false), "expected remembered absolute index after backfill")
+        }
+    }
+
+    @Test("remembered non-tail scroll anchor survives eviction and reopens around the anchor")
+    func rememberedScrollAnchorSurvivesEviction() async throws {
+        let path = tmpStorePath()
+        let store = try ACPSessionStore(path: path)
+        try store.upsertSession(.init(
+            id: "s", agentId: "claude", title: "t",
+            currentModel: nil, currentMode: nil, autoRun: false,
+            createdAt: 0, updatedAt: 0, lastOpenedAt: 0, archived: false))
+
+        var anchorId = ""
+        for i in 0..<100 {
+            let id = UUID(uuidString: String(format: "00000000-0000-0000-0000-%012d", i))!
+            if i == 40 { anchorId = id.uuidString }
+            let m: ACPMessage = .user(id: id, text: "m\(i)", attachments: [])
+            let payload = try ACPMessageCodec.encode(m)
+            try store.appendMessage(sessionId: "s", id: "m\(i)", kind: "user",
+                                    seq: Int64(i), payload: payload, createdAt: 0)
+        }
+
+        let mgr = ACPSessionManager(worktreeId: "wt", worktreePath: "/tmp/wt", store: store)
+        let first = try #require(mgr.placeholderSession(id: "s"))
+        mgr.rememberTranscriptScrollAnchor(
+            sessionId: "s",
+            anchorMessageId: anchorId,
+            anchorMessageIndex: 40,
+            followsTail: false
+        )
+        mgr.retainSession(id: "s")
+        mgr.releaseSession(id: "s")
+        #expect(mgr.sessions["s"] == nil)
+
+        let reopened = try #require(mgr.placeholderSession(id: "s"))
+        #expect(reopened !== first)
+        #expect(!reopened.followsTranscriptTail)
+
+        await mgr.hydrateIfNeeded(id: "s")
+        await mgr.awaitBackfill(id: "s")
+
+        if case .user(_, let text, _) = reopened.transcript.messages[reopened.transcript.visibleHead] {
+            #expect(text == "m40")
+        } else {
+            #expect(Bool(false), "expected remembered anchor row to be a user message")
+        }
+    }
+
     @Test("contextRestoreWarning sees the full transcript even when only tail is in memory")
     func contextRestoreWarningComputedFromFullWires() async throws {
         let path = tmpStorePath()

--- a/AlasTests/ACP/Session/ACPSessionRunnerTests.swift
+++ b/AlasTests/ACP/Session/ACPSessionRunnerTests.swift
@@ -548,18 +548,23 @@ struct ACPSessionRunnerTests {
         mock.script(method: "session/prompt") { _ in Data("{}".utf8) }
         let session = ACPSession(id: "s", agentId: "claude", worktreeId: "wt", title: "t")
         session.followsTranscriptTail = false
+        var didResumeTail = false
         let runner = ACPSessionRunner(
             session: session,
             connection: ACPConnection(client: mock),
             store: store,
             sessionId: "s",
-            worktreePath: FileManager.default.temporaryDirectory.path
+            worktreePath: FileManager.default.temporaryDirectory.path,
+            onResumeTranscriptTail: {
+                didResumeTail = true
+            }
         )
 
         runner.send(text: "new turn", attachments: [])
         try await Task.sleep(nanoseconds: 50_000_000)
 
         #expect(session.followsTranscriptTail)
+        #expect(didResumeTail)
         #expect(session.transcript.messages.count == 1)
         #expect(mock.sent.contains { $0.method == "session/prompt" })
     }

--- a/AlasTests/ACP/UI/ACPMessageListPaginationTests.swift
+++ b/AlasTests/ACP/UI/ACPMessageListPaginationTests.swift
@@ -95,4 +95,86 @@ struct ACPMessageListPaginationTests {
             followsTranscriptTail: true
         ))
     }
+
+    @Test("top visible anchor prefers the row crossing the viewport top")
+    func topVisibleAnchorPrefersRowCrossingTop() {
+        let frames: [String: CGRect] = [
+            "above": CGRect(x: 0, y: -90, width: 100, height: 50),
+            "crossing": CGRect(x: 0, y: -40, width: 100, height: 80),
+            "below": CGRect(x: 0, y: 48, width: 100, height: 80)
+        ]
+
+        #expect(ACPMessageList.topVisibleAnchorID(in: frames) == "crossing")
+    }
+
+    @Test("top visible anchor uses first row below top when no row crosses")
+    func topVisibleAnchorUsesFirstRowBelowTop() {
+        let frames: [String: CGRect] = [
+            "above": CGRect(x: 0, y: -90, width: 100, height: 50),
+            "first": CGRect(x: 0, y: 16, width: 100, height: 80),
+            "second": CGRect(x: 0, y: 120, width: 100, height: 80)
+        ]
+
+        #expect(ACPMessageList.topVisibleAnchorID(in: frames) == "first")
+    }
+
+    @Test("top visible scroll target ignores non-message targets")
+    func topVisibleScrollTargetIgnoresNonMessageTargets() {
+        #expect(ACPMessageList.topVisibleScrollTargetID(
+            in: ["__pending_perm__", "message-2", "message-3"],
+            visibleMessageIds: ["message-1", "message-2", "message-3"]
+        ) == "message-2")
+    }
+
+    @Test("top visible scroll target returns nil without visible messages")
+    func topVisibleScrollTargetReturnsNilWithoutMessages() {
+        #expect(ACPMessageList.topVisibleScrollTargetID(
+            in: ["__pending_question__", "__composer_spacer__"],
+            visibleMessageIds: ["message-1"]
+        ) == nil)
+    }
+
+    @Test("visible anchor memory accepts live anchors when the remembered id is stale")
+    func visibleAnchorMemoryAcceptsStaleRememberedIDReplacement() {
+        #expect(ACPMessageList.shouldRememberVisibleAnchor(
+            "regenerated-2",
+            rememberedAnchor: "old-2",
+            restoredRememberedAnchor: nil,
+            visibleMessageIds: ["regenerated-1", "regenerated-2", "regenerated-3"],
+            isBackfillingOlderMessages: false
+        ))
+    }
+
+    @Test("visible anchor memory waits while the remembered id is still rendered")
+    func visibleAnchorMemoryWaitsForRenderedRememberedID() {
+        #expect(!ACPMessageList.shouldRememberVisibleAnchor(
+            "message-1",
+            rememberedAnchor: "message-2",
+            restoredRememberedAnchor: nil,
+            visibleMessageIds: ["message-1", "message-2", "message-3"],
+            isBackfillingOlderMessages: false
+        ))
+    }
+
+    @Test("visible anchor memory accepts refreshed anchors after restoration")
+    func visibleAnchorMemoryAcceptsAfterRestoration() {
+        #expect(ACPMessageList.shouldRememberVisibleAnchor(
+            "message-3",
+            rememberedAnchor: "message-2",
+            restoredRememberedAnchor: "message-2",
+            visibleMessageIds: ["message-1", "message-2", "message-3"],
+            isBackfillingOlderMessages: false
+        ))
+    }
+
+    @Test("visible anchor memory waits while older messages are backfilling")
+    func visibleAnchorMemoryWaitsDuringBackfill() {
+        #expect(!ACPMessageList.shouldRememberVisibleAnchor(
+            "tail-2",
+            rememberedAnchor: "old-2",
+            restoredRememberedAnchor: nil,
+            visibleMessageIds: ["tail-1", "tail-2", "tail-3"],
+            isBackfillingOlderMessages: true
+        ))
+    }
 }


### PR DESCRIPTION
## Summary
- remember the top visible ACP transcript row when the user is not following the tail
- restore non-tail chat tabs around the remembered transcript position after idle eviction and hydration
- add regression coverage for row-anchor selection and reopened hydrated sessions

## Tests
- `rtk xcodegen`
- `rtk xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -quiet build`
- `rtk xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' test`