### PR TITLE
fix(worktree): speed up worktree selection

### DIFF
--- a/Alas/Sources/App/AppState.swift
+++ b/Alas/Sources/App/AppState.swift
@@ -417,6 +417,8 @@ final class AppState {
     private let persistenceErrorHandler: (String, String) -> Void
     @ObservationIgnored
     private let fileActionErrorHandler: (String, String) -> Void
+    @ObservationIgnored
+    private var scheduledSpacesSave: Task<Void, Never>?
 
     /// One FSEvents watcher per project, watching `<repo>/.git` to auto-refresh
     /// the sidebar when branches flip or worktrees appear/disappear externally.
@@ -655,6 +657,12 @@ final class AppState {
 
     @discardableResult
     func saveSpaces() -> Bool {
+        scheduledSpacesSave?.cancel()
+        scheduledSpacesSave = nil
+        return writeSpaces()
+    }
+
+    private func writeSpaces() -> Bool {
         do {
             try store.write(spacesManager.file, to: Paths.spacesFile)
             return true
@@ -664,11 +672,30 @@ final class AppState {
         }
     }
 
+    private func scheduleSpacesSave() {
+        scheduledSpacesSave?.cancel()
+        scheduledSpacesSave = Task { @MainActor [weak self] in
+            do {
+                try await Task.sleep(nanoseconds: 200_000_000)
+            } catch {
+                return
+            }
+            guard let self else { return }
+            self.scheduledSpacesSave = nil
+            _ = self.writeSpaces()
+        }
+    }
+
+    func flushScheduledSpacesSave() {
+        guard scheduledSpacesSave != nil else { return }
+        _ = saveSpaces()
+    }
+
     func selectWorktree(id: String?) {
         guard selectedWorktreeId != id || spacesManager.activeSpace?.lastSelectedWorktreeId != id else { return }
         selectedWorktreeId = id
         spacesManager.setLastSelectedWorktree(id)
-        saveSpaces()
+        scheduleSpacesSave()
     }
 
     @discardableResult
@@ -679,7 +706,7 @@ final class AppState {
         let selection = resolvedSelectionForActiveSpace()
         selectedWorktreeId = selection
         spacesManager.setLastSelectedWorktree(selection)
-        saveSpaces()
+        scheduleSpacesSave()
         return true
     }
 

--- a/Alas/Sources/App/RootView.swift
+++ b/Alas/Sources/App/RootView.swift
@@ -478,6 +478,7 @@ private struct RootBaseHandlers: ViewModifier {
             }
         return r
             .onReceive(NotificationCenter.default.publisher(for: NSApplication.willTerminateNotification)) { _ in
+                state.flushScheduledSpacesSave()
                 state.stopAllProjectGitWatchers()
                 state.tabs.snapshotDirtyBuffersForQuit()
                 state.flushAllACPComposerDrafts()

--- a/AlasTests/AppStateSpacesTests.swift
+++ b/AlasTests/AppStateSpacesTests.swift
@@ -112,6 +112,58 @@ struct AppStateSpacesTests {
         #expect(state.spacesManager.activeSpace?.lastSelectedWorktreeId == "wt1")
     }
 
+    @Test func selectingWorktreeDefersAndCoalescesSpacePersistence() async throws {
+        var spaceWriteCount = 0
+        var persistedSelection: String?
+        let state = AppState(store: MemoryStore(
+            projectsFile: ProjectsFile(projects: [project("p1")]),
+            writes: { value, url in
+                guard url == Paths.spacesFile else { return }
+                spaceWriteCount += 1
+                persistedSelection = (value as? SpacesFile)?
+                    .spaces
+                    .first?
+                    .lastSelectedWorktreeId
+            }
+        ))
+
+        state.selectWorktree(id: "wt1")
+        state.selectWorktree(id: "wt2")
+
+        #expect(state.selectedWorktreeId == "wt2")
+        #expect(state.spacesManager.activeSpace?.lastSelectedWorktreeId == "wt2")
+        #expect(spaceWriteCount == 0)
+
+        try await Task.sleep(nanoseconds: 350_000_000)
+
+        #expect(spaceWriteCount == 1)
+        #expect(persistedSelection == "wt2")
+    }
+
+    @Test func flushScheduledSpacesSavePersistsPendingSelectionImmediately() {
+        var spaceWriteCount = 0
+        var persistedSelection: String?
+        let state = AppState(store: MemoryStore(
+            projectsFile: ProjectsFile(projects: [project("p1")]),
+            writes: { value, url in
+                guard url == Paths.spacesFile else { return }
+                spaceWriteCount += 1
+                persistedSelection = (value as? SpacesFile)?
+                    .spaces
+                    .first?
+                    .lastSelectedWorktreeId
+            }
+        ))
+
+        state.selectWorktree(id: "wt1")
+        #expect(spaceWriteCount == 0)
+
+        state.flushScheduledSpacesSave()
+
+        #expect(spaceWriteCount == 1)
+        #expect(persistedSelection == "wt1")
+    }
+
     @Test func startupSelectionUsesRememberedActiveSpaceWorktreeBeforeFirstVisible() {
         let p1 = project("p1")
         let spaces = SpacesFile(


### PR DESCRIPTION
## Summary
- Defer and coalesce spaces persistence after worktree/space selection so the visual switch can render immediately
- Flush pending selection persistence on app termination
- Add regression coverage for deferred/coalesced selection persistence and flushing

## Verification
- `xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' test -only-testing:AlasTests/AppStateSpacesTests`
- `xcodegen`
- `xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -quiet build`

Note: A full `xcodebuild ... test` run was attempted locally but stayed silent for several minutes and was interrupted.