### PR TITLE
Suppress empty ACP context restore warning

### DIFF
--- a/Alas/Sources/ACP/Session/ACPSessionManager.swift
+++ b/Alas/Sources/ACP/Session/ACPSessionManager.swift
@@ -1451,6 +1451,7 @@ extension ACPSessionManager {
             let pendingRecovery = (try? store.loadSession(id: sessionId)?.contextRecoveryPending) == true
             let result: ACPSessionNewResult
             var restoreWarning: ACPSession.ContextRestoreWarning?
+            let hasRestorableContext = pendingRecovery || session.hasConversationTranscript
             var shouldHoldQueueForRecovery = pendingRecovery && session.hasConversationTranscript
             if firstRunAttach {
                 session.firstRunConnectingPhase = .creatingSession
@@ -1486,10 +1487,12 @@ extension ACPSessionManager {
                             persistContextRecoveryPending(sessionId: sessionId, pending: true)
                         }
                     }
-                    restoreWarning = .init(
-                        message: "Agent context could not be restored.",
-                        canSendTranscript: session.hasConversationTranscript
-                    )
+                    if hasRestorableContext {
+                        restoreWarning = .init(
+                            message: "Agent context could not be restored.",
+                            canSendTranscript: session.hasConversationTranscript
+                        )
+                    }
                     if session.hasConversationTranscript {
                         session.contextRecoveryStatus = .sendingTranscript
                     }
@@ -1505,10 +1508,12 @@ extension ACPSessionManager {
                         persistContextRecoveryPending(sessionId: sessionId, pending: true)
                     }
                 }
-                restoreWarning = .init(
-                    message: "Agent context could not be restored.",
-                    canSendTranscript: session.hasConversationTranscript
-                )
+                if hasRestorableContext {
+                    restoreWarning = .init(
+                        message: "Agent context could not be restored.",
+                        canSendTranscript: session.hasConversationTranscript
+                    )
+                }
                 if session.hasConversationTranscript {
                     session.contextRecoveryStatus = .sendingTranscript
                 }

--- a/AlasTests/ACP/Session/ACPSessionManagerAttachRestoreTests.swift
+++ b/AlasTests/ACP/Session/ACPSessionManagerAttachRestoreTests.swift
@@ -603,8 +603,8 @@ struct ACPSessionManagerAttachRestoreTests {
         #expect(try store.loadSession(id: "local")?.contextRecoveryPending == true)
     }
 
-    @Test("missing remote id falls back to session/new with no-transcript warning")
-    func missingRemoteIdFallsBackToNewWithWarning() async throws {
+    @Test("missing remote id falls back to session/new without warning for empty session")
+    func missingRemoteIdFallsBackToNewWithoutWarningForEmptySession() async throws {
         let store = try ACPSessionStore(path: tmpStorePath())
         try store.upsertSession(row(remoteSessionId: nil))
         let client = ACPMockClient()
@@ -619,8 +619,44 @@ struct ACPSessionManagerAttachRestoreTests {
         let methods = client.sent.map(\.method)
         #expect(methods == ["initialize", "session/new"])
         #expect(session.remoteSessionId == "remote-new")
-        let warning = try #require(session.contextRestoreWarning)
-        #expect(!warning.canSendTranscript)
+        #expect(session.contextRestoreWarning == nil)
+        let row = try #require(try store.loadSession(id: "local"))
+        #expect(row.remoteSessionId == "remote-new")
+        #expect(!row.contextRecoveryPending)
+    }
+
+    @Test("missing remote id warns and sends transcript recovery for nonempty session")
+    func missingRemoteIdWarnsAndSendsTranscriptRecoveryForNonemptySession() async throws {
+        let store = try ACPSessionStore(path: tmpStorePath())
+        try store.upsertSession(row(remoteSessionId: nil))
+        try appendMessage(
+            .user(id: UUID(), text: "Recover this context", attachments: []),
+            to: store,
+            seq: 0
+        )
+        let client = ACPMockClient()
+        scriptInitialize(client)
+        scriptSessionResult(client, method: "session/new", sessionId: "remote-new")
+        client.script(method: "session/prompt") { _ in Data("null".utf8) }
+        let manager = manager(store: store, client: client)
+
+        let session = try #require(manager.placeholderSession(id: "local"))
+        await manager.hydrateIfNeeded(id: "local")
+        await manager.attach(to: session.id, freshlyCreated: false)
+
+        try await waitUntil {
+            client.sent.map(\.method) == ["initialize", "session/new", "session/prompt"]
+                && session.contextRestoreWarning == nil
+        }
+        #expect(session.remoteSessionId == "remote-new")
+        #expect(session.contextRecoveryStatus == .restored)
+        let prompt = try #require(client.sent.last?.params as? ACPSessionPromptParams)
+        let block = try #require(prompt.prompt.first)
+        guard case .text(let recovery) = block else {
+            Issue.record("Expected recovery prompt")
+            return
+        }
+        #expect(recovery.contains("Recover this context"))
         let row = try #require(try store.loadSession(id: "local"))
         #expect(row.remoteSessionId == "remote-new")
         #expect(!row.contextRecoveryPending)


### PR DESCRIPTION
## Summary
- suppress ACP context restore warnings for brand-new empty sessions during attach fallback
- keep restore warnings for sessions with actual conversation transcript to recover
- add regression coverage for empty missing-remote-id and session/load fallback paths

## Validation
- xcodegen
- xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -quiet build
- focused ACPSessionManagerAttachRestoreTests

Full xcodebuild test was attempted but the local Xcode invocation wedged without compiler/test child processes and was terminated.