### PR TITLE
Build review-ready diff pane

### DIFF
--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -246,6 +246,7 @@
 		3E9B50F3BA9D7273EBA50445 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 6DF51E6FAFBB47E2F31DA287 /* Assets.xcassets */; };
 		3E9F2C02A264024FC020172D /* EditorFindBarView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 679E62B501E0490F48CCA830 /* EditorFindBarView.swift */; };
 		3EA6388E72FDD02E5242002C /* HeadReaderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F8A28C3DBC50749BB1D2BEA /* HeadReaderTests.swift */; };
+		3F0D7932AB67DDF711AF1B6F /* DiffDisplayPreferences.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5C96772DABFBCF15691FFB37 /* DiffDisplayPreferences.swift */; };
 		3F54F0437585F96F5774A3BD /* ACPSetupNudgeBanner.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6791BB640C39115289BF6D07 /* ACPSetupNudgeBanner.swift */; };
 		3FCC4EDA31A96BE121F45D44 /* ACPComposerPlaceholderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 85E54E9F53ECFE9C205788F1 /* ACPComposerPlaceholderTests.swift */; };
 		3FE3D85D5E833DE3A91FD444 /* CopilotInstaller.swift in Sources */ = {isa = PBXBuildFile; fileRef = D64C0B7363363C77718B446C /* CopilotInstaller.swift */; };
@@ -1352,6 +1353,7 @@
 		5BAC89A6B9D5DC926AC18E13 /* MergeConflictTabView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MergeConflictTabView.swift; sourceTree = "<group>"; };
 		5BB6172AE118D2F9A40FD534 /* AgentsPane.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentsPane.swift; sourceTree = "<group>"; };
 		5C8BF1EC24E449A302A1E25C /* CopyFeedbackState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CopyFeedbackState.swift; sourceTree = "<group>"; };
+		5C96772DABFBCF15691FFB37 /* DiffDisplayPreferences.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiffDisplayPreferences.swift; sourceTree = "<group>"; };
 		5CC16D06302D9AD3C9F0BE3C /* TreeSitterHighlighter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TreeSitterHighlighter.swift; sourceTree = "<group>"; };
 		5D486FD440D802AEC65D1555 /* MarkdownFileType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MarkdownFileType.swift; sourceTree = "<group>"; };
 		5DC558BE723378DCC7AA5B55 /* ACPChatTypography.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPChatTypography.swift; sourceTree = "<group>"; };
@@ -2864,12 +2866,21 @@
 				A218B5125FC963339E40605E /* TabsManager.swift */,
 				14087D57E96448EEF0B80BD9 /* TerminalTabView.swift */,
 				EA78AC4E93C2130046C92571 /* Commit */,
+				5EF1EBBC3981E285FE15042A /* Diff */,
 				DF2861B461606810647C1676 /* ImageDiff */,
 				073E19743F9145840DD47C8B /* Merge */,
 				22F204D0F6846057D6505326 /* ReviewEvidence */,
 				4AF44827354C470592274005 /* ReviewRequest */,
 			);
 			path = Center;
+			sourceTree = "<group>";
+		};
+		5EF1EBBC3981E285FE15042A /* Diff */ = {
+			isa = PBXGroup;
+			children = (
+				5C96772DABFBCF15691FFB37 /* DiffDisplayPreferences.swift */,
+			);
+			path = Diff;
 			sourceTree = "<group>";
 		};
 		5FA3F5C4A99F2C74080DA0EF /* SQLiteKit */ = {
@@ -4140,6 +4151,7 @@
 				512A41C0AB75B8D35424EBCD /* DeletingWorktreeView.swift in Sources */,
 				90958414931FC96F766F0C46 /* DiagnosticsFeature.swift in Sources */,
 				9FD539228216762192A02C69 /* DialogChrome.swift in Sources */,
+				3F0D7932AB67DDF711AF1B6F /* DiffDisplayPreferences.swift in Sources */,
 				5C9EB59AAA68656BD7190044 /* DiffOpenFileAvailability.swift in Sources */,
 				02425EBF61592A01B1FCC7D0 /* DiffParser.swift in Sources */,
 				CAD36BB3EBF8B31309B7BEFF /* DiffSelectableTextBuilder.swift in Sources */,

--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -211,6 +211,7 @@
 		376A08C73011C5CA9E445C4B /* ImageDiffView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9D7D83CD76ABF9FED3B29F62 /* ImageDiffView.swift */; };
 		37DD3F3B818131973DAA2B9B /* ACPMessageList.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F79A184C86BE6C6BF72EB57 /* ACPMessageList.swift */; };
 		387EF12B6875648E422956F7 /* Highlighted.swift in Sources */ = {isa = PBXBuildFile; fileRef = 66E8A2A1A02BD06F4B782D03 /* Highlighted.swift */; };
+		38A19A8CE98216F87C522952 /* DiffCodeText.swift in Sources */ = {isa = PBXBuildFile; fileRef = C50700F7960B44D0116F09C8 /* DiffCodeText.swift */; };
 		38B6857CDB7D094A46F653E2 /* ACPSessionByteAccounting.swift in Sources */ = {isa = PBXBuildFile; fileRef = EBF4DE84207D33D518DD7D3E /* ACPSessionByteAccounting.swift */; };
 		38DCAD9DA4B9418906700A25 /* MergeView3Way.swift in Sources */ = {isa = PBXBuildFile; fileRef = 695C887147631ACF1FA73C3F /* MergeView3Way.swift */; };
 		38EB2BAA50A7B7B37DDE2A4C /* RightPaneStateBaseBranchTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6713F5A8712C0962BED1EFEA /* RightPaneStateBaseBranchTests.swift */; };
@@ -648,6 +649,7 @@
 		A8D21135BA6C2542E3820E19 /* TreeSitterHTML in Frameworks */ = {isa = PBXBuildFile; productRef = E1F30BF52DCE8CD60F19C921 /* TreeSitterHTML */; };
 		A8EE9207A828D4D1BAF1C1C1 /* ACPTranscriptLatestPlanTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C70536C65F2A78F4935DCAD /* ACPTranscriptLatestPlanTests.swift */; };
 		A962107126052DEF597CB7FA /* RemoteServerIntegrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A79A06E48E215BF7B9EC2408 /* RemoteServerIntegrationTests.swift */; };
+		A971C64CC3136E00C5FC158C /* DiffPaneView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DF32A1544E13321E9E223AFF /* DiffPaneView.swift */; };
 		A98F3436BE8AB680178B341C /* MarkdownViewMode.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC83C13F9F6391F9CE8BF2CA /* MarkdownViewMode.swift */; };
 		A9AD5B31C3A9FCBE76A15179 /* BlockedLanguageServerNudgeResolver.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5DD723B8C15EF2413C5D935D /* BlockedLanguageServerNudgeResolver.swift */; };
 		A9D0D8D94E1D46F35D17DDBA /* CodeEditorView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FC93F4FB957C2CCD4E1E2326 /* CodeEditorView.swift */; };
@@ -946,6 +948,7 @@
 		F3E7DF34D9DDA268E40575AE /* CommitInfoTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9427B922BAFA43AF6EB21080 /* CommitInfoTests.swift */; };
 		F3EB289C9DA8B25FC26DAB58 /* MasonSnapshot.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7F42E564C149FA33CF0E9870 /* MasonSnapshot.swift */; };
 		F4B9A51A40365909B7644561 /* ShortcutsPane.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6821B71680094791995C4975 /* ShortcutsPane.swift */; };
+		F4FF07CA337DB0D0035C3C10 /* DiffPaneViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E5A257562FAB9C5932A6BD69 /* DiffPaneViewTests.swift */; };
 		F5626F154B2CF446FF3F917B /* ReviewLoopState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0299820D15A2A4C7838B2CE9 /* ReviewLoopState.swift */; };
 		F57297D50FC237F7993F7B81 /* ACPSelectChipMetricsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2D5632302DE981B0BD36273 /* ACPSelectChipMetricsTests.swift */; };
 		F60AF5FD23412D018F263322 /* NotificationDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = C19E98A53E2B793436D2F10D /* NotificationDelegate.swift */; };
@@ -1725,6 +1728,7 @@
 		C496549308D5C3DD20E988AD /* ACPComposer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPComposer.swift; sourceTree = "<group>"; };
 		C4E0BB32D1A3B26473464A0F /* ZmxEnv.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ZmxEnv.swift; sourceTree = "<group>"; };
 		C506EF972D34E2F937D4FEEC /* InstallerHost.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InstallerHost.swift; sourceTree = "<group>"; };
+		C50700F7960B44D0116F09C8 /* DiffCodeText.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiffCodeText.swift; sourceTree = "<group>"; };
 		C54F4827435F746DC54616D0 /* HookInstallNudgeResolverTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HookInstallNudgeResolverTests.swift; sourceTree = "<group>"; };
 		C56EFAFF71ABDBCDECAAA305 /* StartupScriptInstaller.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StartupScriptInstaller.swift; sourceTree = "<group>"; };
 		C5E83B4DDF185280E01CA80A /* ContentSearcherTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentSearcherTests.swift; sourceTree = "<group>"; };
@@ -1825,6 +1829,7 @@
 		DE74A483930F70A0C79CC3E8 /* CodeHostRemoteDetectorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CodeHostRemoteDetectorTests.swift; sourceTree = "<group>"; };
 		DE7675D7F75E36E9C81193C8 /* LSPMessagesTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LSPMessagesTests.swift; sourceTree = "<group>"; };
 		DEFCC9CAC7B3254708748815 /* OpenSessionsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OpenSessionsTests.swift; sourceTree = "<group>"; };
+		DF32A1544E13321E9E223AFF /* DiffPaneView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiffPaneView.swift; sourceTree = "<group>"; };
 		DF919734A34EEB87FA61FE07 /* WebSocketFrameTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebSocketFrameTests.swift; sourceTree = "<group>"; };
 		DF9310EAA75C6B6567F303B6 /* ACPChipState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPChipState.swift; sourceTree = "<group>"; };
 		DFBD2A49431277EB68106AAA /* ACPConnectingPlaceholder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPConnectingPlaceholder.swift; sourceTree = "<group>"; };
@@ -1856,6 +1861,7 @@
 		E4E465A2468376AA840ADFBC /* ChangeSummaryVisibilityTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChangeSummaryVisibilityTests.swift; sourceTree = "<group>"; };
 		E504D11F9B69ACCE7B8E5CA4 /* ACPTerminalHost.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPTerminalHost.swift; sourceTree = "<group>"; };
 		E5788263AE679D146F9BF49C /* MergeConflictMinimap.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MergeConflictMinimap.swift; sourceTree = "<group>"; };
+		E5A257562FAB9C5932A6BD69 /* DiffPaneViewTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiffPaneViewTests.swift; sourceTree = "<group>"; };
 		E63FA8816D43E1A08AE8164B /* .gitkeep */ = {isa = PBXFileReference; path = .gitkeep; sourceTree = "<group>"; };
 		E69452CB123EB0AABB632F03 /* ACPComposerActionButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPComposerActionButton.swift; sourceTree = "<group>"; };
 		E6CA3930F30444A51FB2393D /* Theme.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Theme.swift; sourceTree = "<group>"; };
@@ -2190,6 +2196,7 @@
 				6181842BEA798CB8606F222B /* DiffDisplayModelBuilderTests.swift */,
 				61D4F5B30CE2AA0220A3E45C /* DiffInlineHighlighterTests.swift */,
 				2BFCE07604D55558B13FC33B /* DiffOpenFileAvailabilityTests.swift */,
+				E5A257562FAB9C5932A6BD69 /* DiffPaneViewTests.swift */,
 				EE26221DC8E8837FFEB87474 /* DiffParserTests.swift */,
 				C34ED0F4DB5FB6620993ECFC /* DiffSelectableTextTests.swift */,
 				FB02326DBD7A82431A33C50F /* DraftAmendPrefillTests.swift */,
@@ -2890,10 +2897,12 @@
 		5EF1EBBC3981E285FE15042A /* Diff */ = {
 			isa = PBXGroup;
 			children = (
+				C50700F7960B44D0116F09C8 /* DiffCodeText.swift */,
 				CF8CB5B1DA091EE7D5DA0436 /* DiffDisplayModel.swift */,
 				00F66827E8BFF9AB51D76A96 /* DiffDisplayModelBuilder.swift */,
 				5C96772DABFBCF15691FFB37 /* DiffDisplayPreferences.swift */,
 				6561C6DA70F49EDBC69BA854 /* DiffInlineHighlighter.swift */,
+				DF32A1544E13321E9E223AFF /* DiffPaneView.swift */,
 			);
 			path = Diff;
 			sourceTree = "<group>";
@@ -4166,11 +4175,13 @@
 				512A41C0AB75B8D35424EBCD /* DeletingWorktreeView.swift in Sources */,
 				90958414931FC96F766F0C46 /* DiagnosticsFeature.swift in Sources */,
 				9FD539228216762192A02C69 /* DialogChrome.swift in Sources */,
+				38A19A8CE98216F87C522952 /* DiffCodeText.swift in Sources */,
 				A630ABCDF04C36956349606C /* DiffDisplayModel.swift in Sources */,
 				E8F4E5FAC73026DAC29FDEF7 /* DiffDisplayModelBuilder.swift in Sources */,
 				3F0D7932AB67DDF711AF1B6F /* DiffDisplayPreferences.swift in Sources */,
 				6FDE6E6F5087E811451A6AD8 /* DiffInlineHighlighter.swift in Sources */,
 				5C9EB59AAA68656BD7190044 /* DiffOpenFileAvailability.swift in Sources */,
+				A971C64CC3136E00C5FC158C /* DiffPaneView.swift in Sources */,
 				02425EBF61592A01B1FCC7D0 /* DiffParser.swift in Sources */,
 				CAD36BB3EBF8B31309B7BEFF /* DiffSelectableTextBuilder.swift in Sources */,
 				250F0E2CB26CC16D2FFDB9DD /* DiffSelectableTextView.swift in Sources */,
@@ -4666,6 +4677,7 @@
 				899FB89D155619CF846C6BDC /* DiffDisplayModelBuilderTests.swift in Sources */,
 				172298A09BC94456A27EFCB7 /* DiffInlineHighlighterTests.swift in Sources */,
 				9927E3934D3CAA9055EF5E44 /* DiffOpenFileAvailabilityTests.swift in Sources */,
+				F4FF07CA337DB0D0035C3C10 /* DiffPaneViewTests.swift in Sources */,
 				0CF488290CC525EA7C11A43C /* DiffParserTests.swift in Sources */,
 				10F83C7DA89B3BF168E47310 /* DiffSelectableTextTests.swift in Sources */,
 				5936DF2636F0B74BEAB33A57 /* DraftAmendPrefillTests.swift in Sources */,

--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -363,6 +363,7 @@
 		5B02C8E213F6EA67BEB7E5BA /* ContentResultGroupViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 97134381F91B44B46CAFE082 /* ContentResultGroupViewTests.swift */; };
 		5B415F5F89EAE4B2EEA07046 /* ShortcutResolver.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4069925EE709DD18AEA810B3 /* ShortcutResolver.swift */; };
 		5BCB202710E37EA60DCC91F0 /* ACPPlanSidebar.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC2BB41ECA8AEAB278294B8A /* ACPPlanSidebar.swift */; };
+		5C6F0DC6F76FC0B55F2F4051 /* DiffPaneTextDocumentBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 52E5D3E9FAA7B6B251C3883D /* DiffPaneTextDocumentBuilder.swift */; };
 		5C86AEAEA5497DBF5FD7D604 /* initialize-response.json in Resources */ = {isa = PBXBuildFile; fileRef = 2463B784210156F489A13FAC /* initialize-response.json */; };
 		5C9791E96E80858B5A037941 /* session-update-agent-chunk.json in Resources */ = {isa = PBXBuildFile; fileRef = 4D63B166AF2C533BE6E59365 /* session-update-agent-chunk.json */; };
 		5C9EB59AAA68656BD7190044 /* DiffOpenFileAvailability.swift in Sources */ = {isa = PBXBuildFile; fileRef = D76C02E43360C0BCFEDF5428 /* DiffOpenFileAvailability.swift */; };
@@ -860,6 +861,7 @@
 		DB199FBEEABBC119FB26E32A /* Markdown in Frameworks */ = {isa = PBXBuildFile; productRef = B69450B224F0C82A52D00662 /* Markdown */; };
 		DB29057E7147A0774BC2B835 /* ReviewLoopDrawer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D4CC3ED497796474F107EBE /* ReviewLoopDrawer.swift */; };
 		DB305015BF666EEE0F9C7BAB /* ACPFileEditCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = 29D7631D754795D16E946440 /* ACPFileEditCard.swift */; };
+		DB40AA7EB6A31B5F232EDCA3 /* DiffPaneTextDocumentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = ACCA6B39E2B172FADFD9E0E6 /* DiffPaneTextDocumentView.swift */; };
 		DBE7AD7F869B444A7C48E5B2 /* TreeSitterJava in Frameworks */ = {isa = PBXBuildFile; productRef = 33EB43DCB691861654EC147A /* TreeSitterJava */; };
 		DC0989E32F4B7BF023F784D6 /* StartupScriptInstallerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 43DF691FC778F3A71CE20FBB /* StartupScriptInstallerTests.swift */; };
 		DC394B7740FAEBD2F8ACB61F /* LSPMessages.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5C6A07D7C67D02C8638D8C1 /* LSPMessages.swift */; };
@@ -1325,6 +1327,7 @@
 		524926F2D16B1AD83FC234AB /* ChangeSummaryVisibility.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChangeSummaryVisibility.swift; sourceTree = "<group>"; };
 		52B5F3FFF8AEF13BC48DCFBD /* ACPSessionByteAccountingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPSessionByteAccountingTests.swift; sourceTree = "<group>"; };
 		52C55C85672956E1340B03B1 /* MergeSidePane.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MergeSidePane.swift; sourceTree = "<group>"; };
+		52E5D3E9FAA7B6B251C3883D /* DiffPaneTextDocumentBuilder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiffPaneTextDocumentBuilder.swift; sourceTree = "<group>"; };
 		5302E56E1C16EDECDB45CB20 /* ACPStdioClientTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPStdioClientTests.swift; sourceTree = "<group>"; };
 		530767799372FE03C3695656 /* ACPCodeBlockHighlighter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPCodeBlockHighlighter.swift; sourceTree = "<group>"; };
 		5319C6707FCBA825E5CB1003 /* HookInstallNudgeResolver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HookInstallNudgeResolver.swift; sourceTree = "<group>"; };
@@ -1637,6 +1640,7 @@
 		AAEDACEB27E6AF219054496E /* DialogChrome.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DialogChrome.swift; sourceTree = "<group>"; };
 		AB4C1B7737A289066E01C444 /* WorkspaceLSPManagerStatusTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkspaceLSPManagerStatusTests.swift; sourceTree = "<group>"; };
 		AB9D4FBF08CBAB59C08BBF1D /* ACPQuestionRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPQuestionRequest.swift; sourceTree = "<group>"; };
+		ACCA6B39E2B172FADFD9E0E6 /* DiffPaneTextDocumentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiffPaneTextDocumentView.swift; sourceTree = "<group>"; };
 		ACFF914E16884DAC97F11C76 /* SearchEmptyState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchEmptyState.swift; sourceTree = "<group>"; };
 		AD29EE0AFA5232B1ED728514 /* UnionCanvasGeometryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UnionCanvasGeometryTests.swift; sourceTree = "<group>"; };
 		AD85FA11903B85EA889596A3 /* ACPAttachmentMimeTypeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPAttachmentMimeTypeTests.swift; sourceTree = "<group>"; };
@@ -2902,6 +2906,8 @@
 				00F66827E8BFF9AB51D76A96 /* DiffDisplayModelBuilder.swift */,
 				5C96772DABFBCF15691FFB37 /* DiffDisplayPreferences.swift */,
 				6561C6DA70F49EDBC69BA854 /* DiffInlineHighlighter.swift */,
+				52E5D3E9FAA7B6B251C3883D /* DiffPaneTextDocumentBuilder.swift */,
+				ACCA6B39E2B172FADFD9E0E6 /* DiffPaneTextDocumentView.swift */,
 				DF32A1544E13321E9E223AFF /* DiffPaneView.swift */,
 			);
 			path = Diff;
@@ -4181,6 +4187,8 @@
 				3F0D7932AB67DDF711AF1B6F /* DiffDisplayPreferences.swift in Sources */,
 				6FDE6E6F5087E811451A6AD8 /* DiffInlineHighlighter.swift in Sources */,
 				5C9EB59AAA68656BD7190044 /* DiffOpenFileAvailability.swift in Sources */,
+				5C6F0DC6F76FC0B55F2F4051 /* DiffPaneTextDocumentBuilder.swift in Sources */,
+				DB40AA7EB6A31B5F232EDCA3 /* DiffPaneTextDocumentView.swift in Sources */,
 				A971C64CC3136E00C5FC158C /* DiffPaneView.swift in Sources */,
 				02425EBF61592A01B1FCC7D0 /* DiffParser.swift in Sources */,
 				CAD36BB3EBF8B31309B7BEFF /* DiffSelectableTextBuilder.swift in Sources */,

--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -88,6 +88,7 @@
 		165300DDFFB445D8AAE7A5E5 /* MarkdownFileTypeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 19C327BB65463E878DDCDA5E /* MarkdownFileTypeTests.swift */; };
 		16F5212404948970EAFCFE62 /* MarkdownPreviewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0D4901C499EFE969EC36D116 /* MarkdownPreviewController.swift */; };
 		1721FFC6A99B6E2683378552 /* ACPComposerDraftBridgeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9454F0214E21F91473C96F6 /* ACPComposerDraftBridgeTests.swift */; };
+		172298A09BC94456A27EFCB7 /* DiffInlineHighlighterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61D4F5B30CE2AA0220A3E45C /* DiffInlineHighlighterTests.swift */; };
 		1748C3645E9B769F371F69E6 /* GitServiceUpstreamTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE2CDF03A998BADF20163D5A /* GitServiceUpstreamTests.swift */; };
 		175951CE78A1446A9131BA1F /* GitNameValidator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 269CE27A6F4F2E663EDF9052 /* GitNameValidator.swift */; };
 		175D0A77579A022F3AB81E48 /* SQLiteDatabase.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF5F20AB3B3F7BCEAA56B143 /* SQLiteDatabase.swift */; };
@@ -424,6 +425,7 @@
 		6EFCC2646A708D0938485654 /* TrafficLights.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CDC00065CA8839DA1AD0E0F /* TrafficLights.swift */; };
 		6F0EA54CB15AB5507C84B4A7 /* RemoteAppStateAccessTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B72D621D704CB5B2CCA82C6 /* RemoteAppStateAccessTests.swift */; };
 		6FA1659F464BE9C03C90F787 /* GitService+CommitEditing.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7F4A17C42833BE6190A45AF3 /* GitService+CommitEditing.swift */; };
+		6FDE6E6F5087E811451A6AD8 /* DiffInlineHighlighter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6561C6DA70F49EDBC69BA854 /* DiffInlineHighlighter.swift */; };
 		7028C08DE3F176175CA1FC20 /* MergeConflictResolvedEmptyView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0914F0E19514D1DF89C74B41 /* MergeConflictResolvedEmptyView.swift */; };
 		702EC5CB48F37FC8B6F27FA4 /* ACPSelectChipTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 98A7F35818C95A567DDA586A /* ACPSelectChipTests.swift */; };
 		709F5006202FA86C750BBB69 /* IndentationMode.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3D105CB2C185958ED23164D1 /* IndentationMode.swift */; };
@@ -524,6 +526,7 @@
 		8927B4E929B4180F5B8984F1 /* ACPTranscript.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0B0317FF3C6E6D3F149FB4F5 /* ACPTranscript.swift */; };
 		8950201500394191D7D981D2 /* MarkdownRenderer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8EF52FE71B7FB41328859734 /* MarkdownRenderer.swift */; };
 		899E7B2794DD3F2114B38AFC /* StartupScriptResolver.swift in Sources */ = {isa = PBXBuildFile; fileRef = 743E347E3DE3EEAD3942CD78 /* StartupScriptResolver.swift */; };
+		899FB89D155619CF846C6BDC /* DiffDisplayModelBuilderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6181842BEA798CB8606F222B /* DiffDisplayModelBuilderTests.swift */; };
 		89A3BEAA64625C766E73F58E /* ZmxSessionNameTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 626DBFF220D347A36859AB17 /* ZmxSessionNameTests.swift */; };
 		89A5E5AD13431B6C9E16669B /* ImageFileTypeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A300F7033D91C4A0D283F75E /* ImageFileTypeTests.swift */; };
 		89F58C7178B661EAE0057622 /* ACPTerminalTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7F8802F19E02CED256495755 /* ACPTerminalTests.swift */; };
@@ -634,6 +637,7 @@
 		A5742BE7348C02324B8119D0 /* BaseBranchSelectorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6CB9643BE01E416D3D2F4454 /* BaseBranchSelectorTests.swift */; };
 		A58568C1EFF4A274FBDC83A4 /* Theme.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6CA3930F30444A51FB2393D /* Theme.swift */; };
 		A5F5FBA73F2E50F7FC86E960 /* CommitPrimaryAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45413FEBB779051893272FC7 /* CommitPrimaryAction.swift */; };
+		A630ABCDF04C36956349606C /* DiffDisplayModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF8CB5B1DA091EE7D5DA0436 /* DiffDisplayModel.swift */; };
 		A70A62FDF7EA38F99D9E2B06 /* ACPClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1EC659A56A08A30F7784428D /* ACPClient.swift */; };
 		A7340B3C1C6B2BC7189F3695 /* RepoDot.swift in Sources */ = {isa = PBXBuildFile; fileRef = 563B664D082A9523260AA2EF /* RepoDot.swift */; };
 		A75289A4560BCA2DACA0760B /* AppStateCreateWorktreeSymlinkTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E940D4265B42839BBC7681DC /* AppStateCreateWorktreeSymlinkTests.swift */; };
@@ -909,6 +913,7 @@
 		E867128A3FF1EFD04C2D65E4 /* session-new-request.json in Resources */ = {isa = PBXBuildFile; fileRef = 22677ECD3E098EBE6389D776 /* session-new-request.json */; };
 		E89811545A8AD0ED03655AA3 /* RecommendedLanguageCatalogTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B77927262BEAF31E39CE6698 /* RecommendedLanguageCatalogTests.swift */; };
 		E8CCFE313DFCCA35BE8F93D7 /* GitServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 039741E1CCAEF9770D5DEE08 /* GitServiceTests.swift */; };
+		E8F4E5FAC73026DAC29FDEF7 /* DiffDisplayModelBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 00F66827E8BFF9AB51D76A96 /* DiffDisplayModelBuilder.swift */; };
 		E9507AB389CE47A6A48C049B /* ACPProcessLiveness.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4DA695BB3D2901435BFF6C0E /* ACPProcessLiveness.swift */; };
 		E99E4DB46496707E7A3F044A /* PiACPInstaller.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE6F36C31DB1C13D86416B4B /* PiACPInstaller.swift */; };
 		EA0EE2D3301F5D79E0C1A280 /* LanguageServerAvailability.swift in Sources */ = {isa = PBXBuildFile; fileRef = 949B319CFA57A23CE36F2AAE /* LanguageServerAvailability.swift */; };
@@ -995,6 +1000,7 @@
 		00809DCA566AAAADD7448659 /* ProjectPickerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProjectPickerTests.swift; sourceTree = "<group>"; };
 		008E982C8526670670425AB8 /* EmptyTabView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EmptyTabView.swift; sourceTree = "<group>"; };
 		00B894D92F014C2ADB3CCC9B /* TreeSitterPython */ = {isa = PBXFileReference; lastKnownFileType = folder; name = TreeSitterPython; path = ThirdParty/TreeSitterPython; sourceTree = SOURCE_ROOT; };
+		00F66827E8BFF9AB51D76A96 /* DiffDisplayModelBuilder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiffDisplayModelBuilder.swift; sourceTree = "<group>"; };
 		010B026A6251DEC1BD1961C0 /* WindowConfigurator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WindowConfigurator.swift; sourceTree = "<group>"; };
 		013AF8211B98BD98B65DF632 /* TerminalCLIInjection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TerminalCLIInjection.swift; sourceTree = "<group>"; };
 		01675626CE431DD5867636BF /* RepoGroupViewLayoutTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RepoGroupViewLayoutTests.swift; sourceTree = "<group>"; };
@@ -1369,7 +1375,9 @@
 		6048519B4C444FCB46A11E49 /* ACPMessageStableIdTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPMessageStableIdTests.swift; sourceTree = "<group>"; };
 		606DD97D8F66AC2B5883F984 /* TerminalIntegrationActionsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TerminalIntegrationActionsTests.swift; sourceTree = "<group>"; };
 		60F628A45666E477DD695AD7 /* ShortcutRecorderValidationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShortcutRecorderValidationTests.swift; sourceTree = "<group>"; };
+		6181842BEA798CB8606F222B /* DiffDisplayModelBuilderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiffDisplayModelBuilderTests.swift; sourceTree = "<group>"; };
 		61C69060B922A729DD807920 /* LSPURI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LSPURI.swift; sourceTree = "<group>"; };
+		61D4F5B30CE2AA0220A3E45C /* DiffInlineHighlighterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiffInlineHighlighterTests.swift; sourceTree = "<group>"; };
 		620C4A708CD1013DE2736A00 /* AppIconTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppIconTests.swift; sourceTree = "<group>"; };
 		626DBFF220D347A36859AB17 /* ZmxSessionNameTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ZmxSessionNameTests.swift; sourceTree = "<group>"; };
 		638E94907851A6D0B4AB8F52 /* ImageDiffEndToEndTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageDiffEndToEndTests.swift; sourceTree = "<group>"; };
@@ -1377,6 +1385,7 @@
 		64CE9A3DB2C89A5B9C970ED3 /* EnvBuilderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EnvBuilderTests.swift; sourceTree = "<group>"; };
 		64E96E26D5F53F217BFD1F49 /* EditorBuffer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditorBuffer.swift; sourceTree = "<group>"; };
 		650B300A5337E2A9149CF083 /* UnionCanvasGeometry.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UnionCanvasGeometry.swift; sourceTree = "<group>"; };
+		6561C6DA70F49EDBC69BA854 /* DiffInlineHighlighter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiffInlineHighlighter.swift; sourceTree = "<group>"; };
 		65A1EB96EBED0DEDCA5CD094 /* JSONRPCStdioTransport.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JSONRPCStdioTransport.swift; sourceTree = "<group>"; };
 		65CA995EE43C73449EBF79A7 /* ClaudeInstaller.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClaudeInstaller.swift; sourceTree = "<group>"; };
 		65E853C6AAB6450A0845A7CD /* HoverFeatureBehaviorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HoverFeatureBehaviorTests.swift; sourceTree = "<group>"; };
@@ -1764,6 +1773,7 @@
 		CF41C5BD384265499AEEE4CF /* CompletionDocumentationRendererTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CompletionDocumentationRendererTests.swift; sourceTree = "<group>"; };
 		CF5143046167375A802ED378 /* SurfaceViewKeyboardTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SurfaceViewKeyboardTests.swift; sourceTree = "<group>"; };
 		CF80D59C3200AD3215D1E140 /* ACPNewChatEmptyStatePolicy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPNewChatEmptyStatePolicy.swift; sourceTree = "<group>"; };
+		CF8CB5B1DA091EE7D5DA0436 /* DiffDisplayModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiffDisplayModel.swift; sourceTree = "<group>"; };
 		D02E429B37288215EBC89571 /* CommitHeaderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommitHeaderView.swift; sourceTree = "<group>"; };
 		D081C8802733D2532DBCD74D /* BlockedLanguageServerNudgeResolverTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BlockedLanguageServerNudgeResolverTests.swift; sourceTree = "<group>"; };
 		D0CE3F0637B3CA27B1D87080 /* ACPNewChatEmptyStateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPNewChatEmptyStateTests.swift; sourceTree = "<group>"; };
@@ -2177,6 +2187,8 @@
 				AA98E1DB8D77DE67918D6B9F /* CopilotInstallerTests.swift */,
 				BF3F87CE04B7E98606BF76CA /* CursorInstallerTests.swift */,
 				179A74F3A825DA1EC4C4E0FC /* DebounceTimerTests.swift */,
+				6181842BEA798CB8606F222B /* DiffDisplayModelBuilderTests.swift */,
+				61D4F5B30CE2AA0220A3E45C /* DiffInlineHighlighterTests.swift */,
 				2BFCE07604D55558B13FC33B /* DiffOpenFileAvailabilityTests.swift */,
 				EE26221DC8E8837FFEB87474 /* DiffParserTests.swift */,
 				C34ED0F4DB5FB6620993ECFC /* DiffSelectableTextTests.swift */,
@@ -2878,7 +2890,10 @@
 		5EF1EBBC3981E285FE15042A /* Diff */ = {
 			isa = PBXGroup;
 			children = (
+				CF8CB5B1DA091EE7D5DA0436 /* DiffDisplayModel.swift */,
+				00F66827E8BFF9AB51D76A96 /* DiffDisplayModelBuilder.swift */,
 				5C96772DABFBCF15691FFB37 /* DiffDisplayPreferences.swift */,
+				6561C6DA70F49EDBC69BA854 /* DiffInlineHighlighter.swift */,
 			);
 			path = Diff;
 			sourceTree = "<group>";
@@ -4151,7 +4166,10 @@
 				512A41C0AB75B8D35424EBCD /* DeletingWorktreeView.swift in Sources */,
 				90958414931FC96F766F0C46 /* DiagnosticsFeature.swift in Sources */,
 				9FD539228216762192A02C69 /* DialogChrome.swift in Sources */,
+				A630ABCDF04C36956349606C /* DiffDisplayModel.swift in Sources */,
+				E8F4E5FAC73026DAC29FDEF7 /* DiffDisplayModelBuilder.swift in Sources */,
 				3F0D7932AB67DDF711AF1B6F /* DiffDisplayPreferences.swift in Sources */,
+				6FDE6E6F5087E811451A6AD8 /* DiffInlineHighlighter.swift in Sources */,
 				5C9EB59AAA68656BD7190044 /* DiffOpenFileAvailability.swift in Sources */,
 				02425EBF61592A01B1FCC7D0 /* DiffParser.swift in Sources */,
 				CAD36BB3EBF8B31309B7BEFF /* DiffSelectableTextBuilder.swift in Sources */,
@@ -4645,6 +4663,8 @@
 				25347EFEF1B5F7F4915DB120 /* DebounceTimerTests.swift in Sources */,
 				7EB64E55CE27886D660C5D0C /* DefinitionSnippetCacheTests.swift in Sources */,
 				BFF99F8FDEA5D05EF4E1EEC3 /* DiagnosticsRangeTests.swift in Sources */,
+				899FB89D155619CF846C6BDC /* DiffDisplayModelBuilderTests.swift in Sources */,
+				172298A09BC94456A27EFCB7 /* DiffInlineHighlighterTests.swift in Sources */,
 				9927E3934D3CAA9055EF5E44 /* DiffOpenFileAvailabilityTests.swift in Sources */,
 				0CF488290CC525EA7C11A43C /* DiffParserTests.swift in Sources */,
 				10F83C7DA89B3BF168E47310 /* DiffSelectableTextTests.swift in Sources */,

--- a/Alas/Sources/Center/CenterPaneView.swift
+++ b/Alas/Sources/Center/CenterPaneView.swift
@@ -176,6 +176,7 @@ struct CenterPaneView: View {
                             worktreePath: worktree.path,
                             relativePath: s.relativePath,
                             staged: s.staged,
+                            appState: state,
                             codeFontFamily: state.config.code.fontFamily,
                             codeFontSize: CGFloat(state.config.code.fontSize),
                             onOpenFile: openAvailable

--- a/Alas/Sources/Center/Diff/DiffCodeText.swift
+++ b/Alas/Sources/Center/Diff/DiffCodeText.swift
@@ -13,6 +13,7 @@ struct DiffCodeText: View {
     let codeFontFamily: String
     let codeFontSize: CGFloat
     let wrapLines: Bool
+    let allowHorizontalExpansion: Bool
     let showWhitespace: Bool
     let inlineSpans: [DiffInlineSpan]
     let inlineTone: DiffInlineTone
@@ -23,7 +24,7 @@ struct DiffCodeText: View {
         Text(attributedText)
             .lineSpacing(CenterTypography.textLineSpacing(forFontSize: codeFontSize))
             .lineLimit(wrapLines ? nil : 1)
-            .fixedSize(horizontal: !wrapLines, vertical: true)
+            .fixedSize(horizontal: allowHorizontalExpansion && !wrapLines, vertical: true)
             .textSelection(.enabled)
     }
 

--- a/Alas/Sources/Center/Diff/DiffCodeText.swift
+++ b/Alas/Sources/Center/Diff/DiffCodeText.swift
@@ -28,28 +28,58 @@ struct DiffCodeText: View {
     }
 
     private var attributedText: AttributedString {
-        AttributedString(attributedString())
+        AttributedString(Self.attributedString(
+            text: text,
+            fileExtension: fileExtension,
+            codeFontFamily: codeFontFamily,
+            codeFontSize: codeFontSize,
+            showWhitespace: showWhitespace,
+            inlineSpans: inlineSpans,
+            inlineTone: inlineTone,
+            theme: theme
+        ))
     }
 
-    private func attributedString() -> NSAttributedString {
-        let visibleText = Self.visibleWhitespaceText(text, enabled: showWhitespace)
+    static func attributedString(
+        text: String,
+        fileExtension: String,
+        codeFontFamily: String,
+        codeFontSize: CGFloat,
+        showWhitespace: Bool,
+        inlineSpans: [DiffInlineSpan],
+        inlineTone: DiffInlineTone,
+        theme: Theme
+    ) -> NSAttributedString {
+        let visibleText = visibleWhitespaceText(text, enabled: showWhitespace)
         let output = NSMutableAttributedString(
             string: visibleText,
-            attributes: baseAttributes
+            attributes: baseAttributes(codeFontFamily: codeFontFamily, codeFontSize: codeFontSize, theme: theme)
         )
         let visibleLength = (visibleText as NSString).length
-        let originalLength = (text as NSString).length
-        let canApplyOriginalOffsets = visibleLength == originalLength
 
-        if canApplyOriginalOffsets {
-            applySyntaxSpans(to: output, visibleLength: visibleLength)
-            applyInlineSpans(to: output, visibleLength: visibleLength)
-        }
+        applySyntaxSpans(
+            to: output,
+            text: text,
+            fileExtension: fileExtension,
+            theme: theme,
+            visibleLength: visibleLength
+        )
+        applyInlineSpans(
+            to: output,
+            inlineSpans: inlineSpans,
+            inlineTone: inlineTone,
+            theme: theme,
+            visibleLength: visibleLength
+        )
 
         return output
     }
 
-    private var baseAttributes: [NSAttributedString.Key: Any] {
+    private static func baseAttributes(
+        codeFontFamily: String,
+        codeFontSize: CGFloat,
+        theme: Theme
+    ) -> [NSAttributedString.Key: Any] {
         [
             .font: CenterTypography.resolveCodeFont(family: codeFontFamily, size: codeFontSize),
             .foregroundColor: NSColor(theme.color("fg")),
@@ -57,7 +87,13 @@ struct DiffCodeText: View {
         ]
     }
 
-    private func applySyntaxSpans(to output: NSMutableAttributedString, visibleLength: Int) {
+    private static func applySyntaxSpans(
+        to output: NSMutableAttributedString,
+        text: String,
+        fileExtension: String,
+        theme: Theme,
+        visibleLength: Int
+    ) {
         let spans = TreeSitterHighlighter.tokenize(line: text, fileExtension: fileExtension)
             .filter { isValid($0.range, in: visibleLength) }
             .sorted { $0.range.location < $1.range.location }
@@ -67,31 +103,37 @@ struct DiffCodeText: View {
             guard span.range.location >= cursor else { continue }
             output.addAttribute(
                 .foregroundColor,
-                value: NSColor(syntaxColor(for: span.capture)),
+                value: NSColor(syntaxColor(for: span.capture, theme: theme)),
                 range: span.range
             )
             cursor = NSMaxRange(span.range)
         }
     }
 
-    private func applyInlineSpans(to output: NSMutableAttributedString, visibleLength: Int) {
+    private static func applyInlineSpans(
+        to output: NSMutableAttributedString,
+        inlineSpans: [DiffInlineSpan],
+        inlineTone: DiffInlineTone,
+        theme: Theme,
+        visibleLength: Int
+    ) {
         for span in inlineSpans {
             let range = NSRange(location: span.start, length: span.length)
             guard isValid(range, in: visibleLength) else { continue }
             output.addAttribute(
                 .backgroundColor,
-                value: NSColor(inlineColor.opacity(0.24)),
+                value: NSColor(inlineColor(for: inlineTone, theme: theme).opacity(0.24)),
                 range: range
             )
         }
     }
 
-    private func isValid(_ range: NSRange, in length: Int) -> Bool {
+    private static func isValid(_ range: NSRange, in length: Int) -> Bool {
         range.location >= 0 && range.length >= 0 && NSMaxRange(range) <= length
     }
 
-    private var inlineColor: Color {
-        switch inlineTone {
+    private static func inlineColor(for tone: DiffInlineTone, theme: Theme) -> Color {
+        switch tone {
         case .add:
             return theme.color("add")
         case .del:
@@ -101,7 +143,7 @@ struct DiffCodeText: View {
         }
     }
 
-    private func syntaxColor(for capture: HighlightCapture) -> Color {
+    private static func syntaxColor(for capture: HighlightCapture, theme: Theme) -> Color {
         switch capture {
         case .keyword:
             return theme.color("syntax-keyword")
@@ -126,6 +168,6 @@ struct DiffCodeText: View {
         guard enabled else { return text }
         return text
             .replacingOccurrences(of: " ", with: "·")
-            .replacingOccurrences(of: "\t", with: "→   ")
+            .replacingOccurrences(of: "\t", with: "→")
     }
 }

--- a/Alas/Sources/Center/Diff/DiffCodeText.swift
+++ b/Alas/Sources/Center/Diff/DiffCodeText.swift
@@ -25,7 +25,6 @@ struct DiffCodeText: View {
             .lineSpacing(CenterTypography.textLineSpacing(forFontSize: codeFontSize))
             .lineLimit(wrapLines ? nil : 1)
             .fixedSize(horizontal: allowHorizontalExpansion && !wrapLines, vertical: true)
-            .textSelection(.enabled)
     }
 
     private var attributedText: AttributedString {

--- a/Alas/Sources/Center/Diff/DiffCodeText.swift
+++ b/Alas/Sources/Center/Diff/DiffCodeText.swift
@@ -1,0 +1,131 @@
+import AppKit
+import SwiftUI
+
+enum DiffInlineTone {
+    case add
+    case del
+    case accent
+}
+
+struct DiffCodeText: View {
+    let text: String
+    let fileExtension: String
+    let codeFontFamily: String
+    let codeFontSize: CGFloat
+    let wrapLines: Bool
+    let showWhitespace: Bool
+    let inlineSpans: [DiffInlineSpan]
+    let inlineTone: DiffInlineTone
+
+    @Environment(\.theme) private var theme
+
+    var body: some View {
+        Text(attributedText)
+            .lineSpacing(CenterTypography.textLineSpacing(forFontSize: codeFontSize))
+            .lineLimit(wrapLines ? nil : 1)
+            .fixedSize(horizontal: !wrapLines, vertical: true)
+            .textSelection(.enabled)
+    }
+
+    private var attributedText: AttributedString {
+        AttributedString(attributedString())
+    }
+
+    private func attributedString() -> NSAttributedString {
+        let visibleText = Self.visibleWhitespaceText(text, enabled: showWhitespace)
+        let output = NSMutableAttributedString(
+            string: visibleText,
+            attributes: baseAttributes
+        )
+        let visibleLength = (visibleText as NSString).length
+        let originalLength = (text as NSString).length
+        let canApplyOriginalOffsets = visibleLength == originalLength
+
+        if canApplyOriginalOffsets {
+            applySyntaxSpans(to: output, visibleLength: visibleLength)
+            applyInlineSpans(to: output, visibleLength: visibleLength)
+        }
+
+        return output
+    }
+
+    private var baseAttributes: [NSAttributedString.Key: Any] {
+        [
+            .font: CenterTypography.resolveCodeFont(family: codeFontFamily, size: codeFontSize),
+            .foregroundColor: NSColor(theme.color("fg")),
+            .paragraphStyle: CenterTypography.paragraphStyle(),
+        ]
+    }
+
+    private func applySyntaxSpans(to output: NSMutableAttributedString, visibleLength: Int) {
+        let spans = TreeSitterHighlighter.tokenize(line: text, fileExtension: fileExtension)
+            .filter { isValid($0.range, in: visibleLength) }
+            .sorted { $0.range.location < $1.range.location }
+
+        var cursor = 0
+        for span in spans {
+            guard span.range.location >= cursor else { continue }
+            output.addAttribute(
+                .foregroundColor,
+                value: NSColor(syntaxColor(for: span.capture)),
+                range: span.range
+            )
+            cursor = NSMaxRange(span.range)
+        }
+    }
+
+    private func applyInlineSpans(to output: NSMutableAttributedString, visibleLength: Int) {
+        for span in inlineSpans {
+            let range = NSRange(location: span.start, length: span.length)
+            guard isValid(range, in: visibleLength) else { continue }
+            output.addAttribute(
+                .backgroundColor,
+                value: NSColor(inlineColor.opacity(0.24)),
+                range: range
+            )
+        }
+    }
+
+    private func isValid(_ range: NSRange, in length: Int) -> Bool {
+        range.location >= 0 && range.length >= 0 && NSMaxRange(range) <= length
+    }
+
+    private var inlineColor: Color {
+        switch inlineTone {
+        case .add:
+            return theme.color("add")
+        case .del:
+            return theme.color("del")
+        case .accent:
+            return theme.color("accent")
+        }
+    }
+
+    private func syntaxColor(for capture: HighlightCapture) -> Color {
+        switch capture {
+        case .keyword:
+            return theme.color("syntax-keyword")
+        case .type:
+            return theme.color("syntax-type")
+        case .function:
+            return theme.color("syntax-function")
+        case .string:
+            return theme.color("add")
+        case .number:
+            return theme.color("mod")
+        case .comment:
+            return theme.color("fg-faint")
+        case .attribute, .constant:
+            return theme.color("syntax-keyword")
+        case .variable, .parameter, .property, .operator, .punctuation, .plain:
+            return theme.color("fg")
+        }
+    }
+
+    private static func visibleWhitespaceText(_ text: String, enabled: Bool) -> String {
+        guard enabled else { return text }
+        return text
+            .replacingOccurrences(of: " ", with: "·")
+            .replacingOccurrences(of: "\t", with: "→   ")
+    }
+}

--- a/Alas/Sources/Center/Diff/DiffDisplayModel.swift
+++ b/Alas/Sources/Center/Diff/DiffDisplayModel.swift
@@ -12,6 +12,8 @@ enum DiffLineSide: Int, Codable, Equatable, Comparable, Hashable {
 
 struct DiffLineAnchor: Codable, Equatable, Comparable, Hashable {
     let filePath: String
+    let hunkIndex: Int
+    let rowIndex: Int
     let side: DiffLineSide
     let oldLine: Int?
     let newLine: Int?
@@ -21,10 +23,12 @@ struct DiffLineAnchor: Codable, Equatable, Comparable, Hashable {
             return lhs.filePath < rhs.filePath
         }
 
-        let lhsEffectiveLine = lhs.newLine ?? lhs.oldLine ?? 0
-        let rhsEffectiveLine = rhs.newLine ?? rhs.oldLine ?? 0
-        if lhsEffectiveLine != rhsEffectiveLine {
-            return lhsEffectiveLine < rhsEffectiveLine
+        if lhs.hunkIndex != rhs.hunkIndex {
+            return lhs.hunkIndex < rhs.hunkIndex
+        }
+
+        if lhs.rowIndex != rhs.rowIndex {
+            return lhs.rowIndex < rhs.rowIndex
         }
 
         if lhs.side != rhs.side {

--- a/Alas/Sources/Center/Diff/DiffDisplayModel.swift
+++ b/Alas/Sources/Center/Diff/DiffDisplayModel.swift
@@ -1,0 +1,105 @@
+import Foundation
+
+enum DiffLineSide: Int, Codable, Equatable, Comparable, Hashable {
+    case old
+    case new
+    case paired
+
+    static func < (lhs: DiffLineSide, rhs: DiffLineSide) -> Bool {
+        lhs.rawValue < rhs.rawValue
+    }
+}
+
+struct DiffLineAnchor: Codable, Equatable, Comparable, Hashable {
+    let filePath: String
+    let side: DiffLineSide
+    let oldLine: Int?
+    let newLine: Int?
+
+    static func < (lhs: DiffLineAnchor, rhs: DiffLineAnchor) -> Bool {
+        if lhs.filePath != rhs.filePath {
+            return lhs.filePath < rhs.filePath
+        }
+
+        let lhsEffectiveLine = lhs.newLine ?? lhs.oldLine ?? 0
+        let rhsEffectiveLine = rhs.newLine ?? rhs.oldLine ?? 0
+        if lhsEffectiveLine != rhsEffectiveLine {
+            return lhsEffectiveLine < rhsEffectiveLine
+        }
+
+        if lhs.side != rhs.side {
+            return lhs.side < rhs.side
+        }
+
+        let lhsOldLine = lhs.oldLine ?? 0
+        let rhsOldLine = rhs.oldLine ?? 0
+        if lhsOldLine != rhsOldLine {
+            return lhsOldLine < rhsOldLine
+        }
+
+        return (lhs.newLine ?? 0) < (rhs.newLine ?? 0)
+    }
+}
+
+struct DiffSelectionRange: Equatable {
+    let first: DiffLineAnchor
+    let last: DiffLineAnchor
+
+    var normalized: ClosedRange<DiffLineAnchor> {
+        first <= last ? first...last : last...first
+    }
+
+    func contains(_ anchor: DiffLineAnchor) -> Bool {
+        normalized.contains(anchor)
+    }
+}
+
+struct DiffInlineSpan: Codable, Equatable, Hashable {
+    let start: Int
+    let length: Int
+
+    func text(in string: String) -> String {
+        let nsString = string as NSString
+        let location = max(0, min(start, nsString.length))
+        let end = max(location, min(start + length, nsString.length))
+        return nsString.substring(with: NSRange(location: location, length: end - location))
+    }
+}
+
+struct DiffDisplayLine: Identifiable, Equatable {
+    let id: String
+    let anchor: DiffLineAnchor
+    let text: String
+    let lineNumber: Int?
+    let kind: ParsedDiff.Hunk.Line.Kind
+    let inlineSpans: [DiffInlineSpan]
+    let noTrailingNewline: Bool
+}
+
+struct DiffDisplayRow: Identifiable, Equatable {
+    enum Kind: Equatable {
+        case context
+        case add
+        case delete
+        case replacement
+        case collapsed
+    }
+
+    let id: String
+    let kind: Kind
+    let old: DiffDisplayLine?
+    let new: DiffDisplayLine?
+    let collapsedLineCount: Int
+}
+
+struct DiffDisplayGroup: Identifiable, Equatable {
+    let id: String
+    let hunkHeader: String
+    let sourceHunk: ParsedDiff.Hunk
+    let rows: [DiffDisplayRow]
+}
+
+struct DiffDisplayModel: Equatable {
+    let filePath: String
+    let groups: [DiffDisplayGroup]
+}

--- a/Alas/Sources/Center/Diff/DiffDisplayModel.swift
+++ b/Alas/Sources/Center/Diff/DiffDisplayModel.swift
@@ -94,7 +94,7 @@ struct DiffDisplayRow: Identifiable, Equatable {
 
 struct DiffDisplayGroup: Identifiable, Equatable {
     let id: String
-    let hunkHeader: String
+    let header: String
     let sourceHunk: ParsedDiff.Hunk
     let rows: [DiffDisplayRow]
 }

--- a/Alas/Sources/Center/Diff/DiffDisplayModel.swift
+++ b/Alas/Sources/Center/Diff/DiffDisplayModel.swift
@@ -94,6 +94,23 @@ struct DiffDisplayRow: Identifiable, Equatable {
     let old: DiffDisplayLine?
     let new: DiffDisplayLine?
     let collapsedLineCount: Int
+    let collapsedRows: [DiffDisplayRow]
+
+    init(
+        id: String,
+        kind: Kind,
+        old: DiffDisplayLine?,
+        new: DiffDisplayLine?,
+        collapsedLineCount: Int,
+        collapsedRows: [DiffDisplayRow] = []
+    ) {
+        self.id = id
+        self.kind = kind
+        self.old = old
+        self.new = new
+        self.collapsedLineCount = collapsedLineCount
+        self.collapsedRows = collapsedRows
+    }
 }
 
 struct DiffDisplayGroup: Identifiable, Equatable {

--- a/Alas/Sources/Center/Diff/DiffDisplayModelBuilder.swift
+++ b/Alas/Sources/Center/Diff/DiffDisplayModelBuilder.swift
@@ -114,13 +114,18 @@ enum DiffDisplayModelBuilder {
             appendContextRow($0, to: &rows, filePath: filePath, hunkIndex: hunkIndex)
         }
 
+        let hiddenRows = lines
+            .dropFirst(contextEdgeCount)
+            .dropLast(contextEdgeCount)
+            .map { contextRow($0, filePath: filePath, hunkIndex: hunkIndex) }
         rows.append(
             DiffDisplayRow(
                 id: "hunk-\(hunkIndex)-row-\(rows.count)-collapsed",
                 kind: .collapsed,
                 old: nil,
                 new: nil,
-                collapsedLineCount: lines.count - (contextEdgeCount * 2)
+                collapsedLineCount: hiddenRows.count,
+                collapsedRows: hiddenRows
             )
         )
 
@@ -143,30 +148,36 @@ enum DiffDisplayModelBuilder {
         filePath: String,
         hunkIndex: Int
     ) {
+        rows.append(contextRow(source, filePath: filePath, hunkIndex: hunkIndex))
+    }
+
+    private static func contextRow(
+        _ source: IndexedLine,
+        filePath: String,
+        hunkIndex: Int
+    ) -> DiffDisplayRow {
         let line = source.line
         let rowIndex = source.index
-        rows.append(
-            DiffDisplayRow(
-                id: "hunk-\(hunkIndex)-row-\(rowIndex)-context-\(line.oldNumber ?? 0)-\(line.newNumber ?? 0)",
-                kind: .context,
-                old: displayLine(
-                    line,
-                    filePath: filePath,
-                    hunkIndex: hunkIndex,
-                    rowIndex: rowIndex,
-                    side: .old,
-                    inlineSpans: []
-                ),
-                new: displayLine(
-                    line,
-                    filePath: filePath,
-                    hunkIndex: hunkIndex,
-                    rowIndex: rowIndex,
-                    side: .new,
-                    inlineSpans: []
-                ),
-                collapsedLineCount: 0
-            )
+        return DiffDisplayRow(
+            id: "hunk-\(hunkIndex)-row-\(rowIndex)-context-\(line.oldNumber ?? 0)-\(line.newNumber ?? 0)",
+            kind: .context,
+            old: displayLine(
+                line,
+                filePath: filePath,
+                hunkIndex: hunkIndex,
+                rowIndex: rowIndex,
+                side: .old,
+                inlineSpans: []
+            ),
+            new: displayLine(
+                line,
+                filePath: filePath,
+                hunkIndex: hunkIndex,
+                rowIndex: rowIndex,
+                side: .new,
+                inlineSpans: []
+            ),
+            collapsedLineCount: 0
         )
     }
 

--- a/Alas/Sources/Center/Diff/DiffDisplayModelBuilder.swift
+++ b/Alas/Sources/Center/Diff/DiffDisplayModelBuilder.swift
@@ -1,0 +1,233 @@
+import Foundation
+
+enum DiffDisplayModelBuilder {
+    static func build(
+        diff: ParsedDiff,
+        filePath: String,
+        collapseContextThreshold: Int = 12,
+        contextEdgeCount: Int = 3
+    ) -> DiffDisplayModel {
+        let groups = diff.hunks.enumerated().map { hunkIndex, hunk in
+            DiffDisplayGroup(
+                id: "hunk-\(hunkIndex)-\(hunk.header)",
+                hunkHeader: hunk.header,
+                sourceHunk: hunk,
+                rows: buildRows(
+                    hunk: hunk,
+                    filePath: filePath,
+                    hunkIndex: hunkIndex,
+                    collapseContextThreshold: collapseContextThreshold,
+                    contextEdgeCount: contextEdgeCount
+                )
+            )
+        }
+
+        return DiffDisplayModel(filePath: filePath, groups: groups)
+    }
+
+    private static func buildRows(
+        hunk: ParsedDiff.Hunk,
+        filePath: String,
+        hunkIndex: Int,
+        collapseContextThreshold: Int,
+        contextEdgeCount: Int
+    ) -> [DiffDisplayRow] {
+        var rows: [DiffDisplayRow] = []
+        var index = 0
+
+        while index < hunk.lines.count {
+            let line = hunk.lines[index]
+            switch line.kind {
+            case .context:
+                let start = index
+                while index < hunk.lines.count, hunk.lines[index].kind == .context {
+                    index += 1
+                }
+                appendContextRows(
+                    Array(hunk.lines[start..<index]),
+                    to: &rows,
+                    filePath: filePath,
+                    hunkIndex: hunkIndex,
+                    collapseContextThreshold: collapseContextThreshold,
+                    contextEdgeCount: contextEdgeCount
+                )
+            case .delete:
+                let deleteStart = index
+                while index < hunk.lines.count, hunk.lines[index].kind == .delete {
+                    index += 1
+                }
+                let deletes = Array(hunk.lines[deleteStart..<index])
+
+                let addStart = index
+                while index < hunk.lines.count, hunk.lines[index].kind == .add {
+                    index += 1
+                }
+                let adds = Array(hunk.lines[addStart..<index])
+
+                appendChangedRows(
+                    deletes: deletes,
+                    adds: adds,
+                    to: &rows,
+                    filePath: filePath,
+                    hunkIndex: hunkIndex
+                )
+            case .add:
+                let addStart = index
+                while index < hunk.lines.count, hunk.lines[index].kind == .add {
+                    index += 1
+                }
+                let adds = Array(hunk.lines[addStart..<index])
+                appendChangedRows(
+                    deletes: [],
+                    adds: adds,
+                    to: &rows,
+                    filePath: filePath,
+                    hunkIndex: hunkIndex
+                )
+            }
+        }
+
+        return rows
+    }
+
+    private static func appendContextRows(
+        _ lines: [ParsedDiff.Hunk.Line],
+        to rows: inout [DiffDisplayRow],
+        filePath: String,
+        hunkIndex: Int,
+        collapseContextThreshold: Int,
+        contextEdgeCount: Int
+    ) {
+        guard shouldCollapse(lines, threshold: collapseContextThreshold, edgeCount: contextEdgeCount) else {
+            lines.forEach {
+                appendContextRow($0, to: &rows, filePath: filePath, hunkIndex: hunkIndex)
+            }
+            return
+        }
+
+        lines.prefix(contextEdgeCount).forEach {
+            appendContextRow($0, to: &rows, filePath: filePath, hunkIndex: hunkIndex)
+        }
+
+        rows.append(
+            DiffDisplayRow(
+                id: "hunk-\(hunkIndex)-row-\(rows.count)-collapsed",
+                kind: .collapsed,
+                old: nil,
+                new: nil,
+                collapsedLineCount: lines.count - (contextEdgeCount * 2)
+            )
+        )
+
+        lines.suffix(contextEdgeCount).forEach {
+            appendContextRow($0, to: &rows, filePath: filePath, hunkIndex: hunkIndex)
+        }
+    }
+
+    private static func shouldCollapse(
+        _ lines: [ParsedDiff.Hunk.Line],
+        threshold: Int,
+        edgeCount: Int
+    ) -> Bool {
+        lines.count > threshold && edgeCount > 0 && lines.count > edgeCount * 2
+    }
+
+    private static func appendContextRow(
+        _ line: ParsedDiff.Hunk.Line,
+        to rows: inout [DiffDisplayRow],
+        filePath: String,
+        hunkIndex: Int
+    ) {
+        rows.append(
+            DiffDisplayRow(
+                id: "hunk-\(hunkIndex)-row-\(rows.count)-context-\(line.oldNumber ?? 0)-\(line.newNumber ?? 0)",
+                kind: .context,
+                old: displayLine(line, filePath: filePath, side: .old, inlineSpans: []),
+                new: displayLine(line, filePath: filePath, side: .new, inlineSpans: []),
+                collapsedLineCount: 0
+            )
+        )
+    }
+
+    private static func appendChangedRows(
+        deletes: [ParsedDiff.Hunk.Line],
+        adds: [ParsedDiff.Hunk.Line],
+        to rows: inout [DiffDisplayRow],
+        filePath: String,
+        hunkIndex: Int
+    ) {
+        let replacementCount = min(deletes.count, adds.count)
+        for offset in 0..<replacementCount {
+            let deleteLine = deletes[offset]
+            let addLine = adds[offset]
+            let highlight = DiffInlineHighlighter.highlightDeleteAdd(old: deleteLine.text, new: addLine.text)
+            rows.append(
+                DiffDisplayRow(
+                    id: "hunk-\(hunkIndex)-row-\(rows.count)-replacement-\(deleteLine.oldNumber ?? 0)-\(addLine.newNumber ?? 0)",
+                    kind: .replacement,
+                    old: displayLine(deleteLine, filePath: filePath, side: .old, inlineSpans: highlight.oldSpans),
+                    new: displayLine(addLine, filePath: filePath, side: .new, inlineSpans: highlight.newSpans),
+                    collapsedLineCount: 0
+                )
+            )
+        }
+
+        deletes.dropFirst(replacementCount).forEach { line in
+            rows.append(
+                DiffDisplayRow(
+                    id: "hunk-\(hunkIndex)-row-\(rows.count)-delete-\(line.oldNumber ?? 0)",
+                    kind: .delete,
+                    old: displayLine(line, filePath: filePath, side: .old, inlineSpans: []),
+                    new: nil,
+                    collapsedLineCount: 0
+                )
+            )
+        }
+
+        adds.dropFirst(replacementCount).forEach { line in
+            rows.append(
+                DiffDisplayRow(
+                    id: "hunk-\(hunkIndex)-row-\(rows.count)-add-\(line.newNumber ?? 0)",
+                    kind: .add,
+                    old: nil,
+                    new: displayLine(line, filePath: filePath, side: .new, inlineSpans: []),
+                    collapsedLineCount: 0
+                )
+            )
+        }
+    }
+
+    private static func displayLine(
+        _ line: ParsedDiff.Hunk.Line,
+        filePath: String,
+        side: DiffLineSide,
+        inlineSpans: [DiffInlineSpan]
+    ) -> DiffDisplayLine {
+        let lineNumber: Int?
+        switch side {
+        case .old:
+            lineNumber = line.oldNumber
+        case .new:
+            lineNumber = line.newNumber
+        case .paired:
+            lineNumber = line.newNumber ?? line.oldNumber
+        }
+
+        let anchor = DiffLineAnchor(
+            filePath: filePath,
+            side: side,
+            oldLine: side == .new ? nil : line.oldNumber,
+            newLine: side == .old ? nil : line.newNumber
+        )
+
+        return DiffDisplayLine(
+            id: "\(anchor.filePath):\(anchor.side.rawValue):\(anchor.oldLine ?? 0):\(anchor.newLine ?? 0)",
+            anchor: anchor,
+            text: line.text,
+            lineNumber: lineNumber,
+            kind: line.kind,
+            inlineSpans: inlineSpans,
+            noTrailingNewline: line.noTrailingNewline
+        )
+    }
+}

--- a/Alas/Sources/Center/Diff/DiffDisplayModelBuilder.swift
+++ b/Alas/Sources/Center/Diff/DiffDisplayModelBuilder.swift
@@ -138,12 +138,27 @@ enum DiffDisplayModelBuilder {
         filePath: String,
         hunkIndex: Int
     ) {
+        let rowIndex = rows.count
         rows.append(
             DiffDisplayRow(
-                id: "hunk-\(hunkIndex)-row-\(rows.count)-context-\(line.oldNumber ?? 0)-\(line.newNumber ?? 0)",
+                id: "hunk-\(hunkIndex)-row-\(rowIndex)-context-\(line.oldNumber ?? 0)-\(line.newNumber ?? 0)",
                 kind: .context,
-                old: displayLine(line, filePath: filePath, side: .old, inlineSpans: []),
-                new: displayLine(line, filePath: filePath, side: .new, inlineSpans: []),
+                old: displayLine(
+                    line,
+                    filePath: filePath,
+                    hunkIndex: hunkIndex,
+                    rowIndex: rowIndex,
+                    side: .old,
+                    inlineSpans: []
+                ),
+                new: displayLine(
+                    line,
+                    filePath: filePath,
+                    hunkIndex: hunkIndex,
+                    rowIndex: rowIndex,
+                    side: .new,
+                    inlineSpans: []
+                ),
                 collapsedLineCount: 0
             )
         )
@@ -161,23 +176,46 @@ enum DiffDisplayModelBuilder {
             let deleteLine = deletes[offset]
             let addLine = adds[offset]
             let highlight = DiffInlineHighlighter.highlightDeleteAdd(old: deleteLine.text, new: addLine.text)
+            let rowIndex = rows.count
             rows.append(
                 DiffDisplayRow(
-                    id: "hunk-\(hunkIndex)-row-\(rows.count)-replacement-\(deleteLine.oldNumber ?? 0)-\(addLine.newNumber ?? 0)",
+                    id: "hunk-\(hunkIndex)-row-\(rowIndex)-replacement-\(deleteLine.oldNumber ?? 0)-\(addLine.newNumber ?? 0)",
                     kind: .replacement,
-                    old: displayLine(deleteLine, filePath: filePath, side: .old, inlineSpans: highlight.oldSpans),
-                    new: displayLine(addLine, filePath: filePath, side: .new, inlineSpans: highlight.newSpans),
+                    old: displayLine(
+                        deleteLine,
+                        filePath: filePath,
+                        hunkIndex: hunkIndex,
+                        rowIndex: rowIndex,
+                        side: .old,
+                        inlineSpans: highlight.oldSpans
+                    ),
+                    new: displayLine(
+                        addLine,
+                        filePath: filePath,
+                        hunkIndex: hunkIndex,
+                        rowIndex: rowIndex,
+                        side: .new,
+                        inlineSpans: highlight.newSpans
+                    ),
                     collapsedLineCount: 0
                 )
             )
         }
 
         deletes.dropFirst(replacementCount).forEach { line in
+            let rowIndex = rows.count
             rows.append(
                 DiffDisplayRow(
-                    id: "hunk-\(hunkIndex)-row-\(rows.count)-delete-\(line.oldNumber ?? 0)",
+                    id: "hunk-\(hunkIndex)-row-\(rowIndex)-delete-\(line.oldNumber ?? 0)",
                     kind: .delete,
-                    old: displayLine(line, filePath: filePath, side: .old, inlineSpans: []),
+                    old: displayLine(
+                        line,
+                        filePath: filePath,
+                        hunkIndex: hunkIndex,
+                        rowIndex: rowIndex,
+                        side: .old,
+                        inlineSpans: []
+                    ),
                     new: nil,
                     collapsedLineCount: 0
                 )
@@ -185,12 +223,20 @@ enum DiffDisplayModelBuilder {
         }
 
         adds.dropFirst(replacementCount).forEach { line in
+            let rowIndex = rows.count
             rows.append(
                 DiffDisplayRow(
-                    id: "hunk-\(hunkIndex)-row-\(rows.count)-add-\(line.newNumber ?? 0)",
+                    id: "hunk-\(hunkIndex)-row-\(rowIndex)-add-\(line.newNumber ?? 0)",
                     kind: .add,
                     old: nil,
-                    new: displayLine(line, filePath: filePath, side: .new, inlineSpans: []),
+                    new: displayLine(
+                        line,
+                        filePath: filePath,
+                        hunkIndex: hunkIndex,
+                        rowIndex: rowIndex,
+                        side: .new,
+                        inlineSpans: []
+                    ),
                     collapsedLineCount: 0
                 )
             )
@@ -200,6 +246,8 @@ enum DiffDisplayModelBuilder {
     private static func displayLine(
         _ line: ParsedDiff.Hunk.Line,
         filePath: String,
+        hunkIndex: Int,
+        rowIndex: Int,
         side: DiffLineSide,
         inlineSpans: [DiffInlineSpan]
     ) -> DiffDisplayLine {
@@ -215,6 +263,8 @@ enum DiffDisplayModelBuilder {
 
         let anchor = DiffLineAnchor(
             filePath: filePath,
+            hunkIndex: hunkIndex,
+            rowIndex: rowIndex,
             side: side,
             oldLine: side == .new ? nil : line.oldNumber,
             newLine: side == .old ? nil : line.newNumber

--- a/Alas/Sources/Center/Diff/DiffDisplayModelBuilder.swift
+++ b/Alas/Sources/Center/Diff/DiffDisplayModelBuilder.swift
@@ -1,6 +1,11 @@
 import Foundation
 
 enum DiffDisplayModelBuilder {
+    private struct IndexedLine {
+        let index: Int
+        let line: ParsedDiff.Hunk.Line
+    }
+
     static func build(
         diff: ParsedDiff,
         filePath: String,
@@ -36,15 +41,15 @@ enum DiffDisplayModelBuilder {
         var index = 0
 
         while index < hunk.lines.count {
-            let line = hunk.lines[index]
-            switch line.kind {
+            let line = IndexedLine(index: index, line: hunk.lines[index])
+            switch line.line.kind {
             case .context:
                 let start = index
                 while index < hunk.lines.count, hunk.lines[index].kind == .context {
                     index += 1
                 }
                 appendContextRows(
-                    Array(hunk.lines[start..<index]),
+                    (start..<index).map { IndexedLine(index: $0, line: hunk.lines[$0]) },
                     to: &rows,
                     filePath: filePath,
                     hunkIndex: hunkIndex,
@@ -56,13 +61,13 @@ enum DiffDisplayModelBuilder {
                 while index < hunk.lines.count, hunk.lines[index].kind == .delete {
                     index += 1
                 }
-                let deletes = Array(hunk.lines[deleteStart..<index])
+                let deletes = (deleteStart..<index).map { IndexedLine(index: $0, line: hunk.lines[$0]) }
 
                 let addStart = index
                 while index < hunk.lines.count, hunk.lines[index].kind == .add {
                     index += 1
                 }
-                let adds = Array(hunk.lines[addStart..<index])
+                let adds = (addStart..<index).map { IndexedLine(index: $0, line: hunk.lines[$0]) }
 
                 appendChangedRows(
                     deletes: deletes,
@@ -76,7 +81,7 @@ enum DiffDisplayModelBuilder {
                 while index < hunk.lines.count, hunk.lines[index].kind == .add {
                     index += 1
                 }
-                let adds = Array(hunk.lines[addStart..<index])
+                let adds = (addStart..<index).map { IndexedLine(index: $0, line: hunk.lines[$0]) }
                 appendChangedRows(
                     deletes: [],
                     adds: adds,
@@ -91,7 +96,7 @@ enum DiffDisplayModelBuilder {
     }
 
     private static func appendContextRows(
-        _ lines: [ParsedDiff.Hunk.Line],
+        _ lines: [IndexedLine],
         to rows: inout [DiffDisplayRow],
         filePath: String,
         hunkIndex: Int,
@@ -125,7 +130,7 @@ enum DiffDisplayModelBuilder {
     }
 
     private static func shouldCollapse(
-        _ lines: [ParsedDiff.Hunk.Line],
+        _ lines: [IndexedLine],
         threshold: Int,
         edgeCount: Int
     ) -> Bool {
@@ -133,12 +138,13 @@ enum DiffDisplayModelBuilder {
     }
 
     private static func appendContextRow(
-        _ line: ParsedDiff.Hunk.Line,
+        _ source: IndexedLine,
         to rows: inout [DiffDisplayRow],
         filePath: String,
         hunkIndex: Int
     ) {
-        let rowIndex = rows.count
+        let line = source.line
+        let rowIndex = source.index
         rows.append(
             DiffDisplayRow(
                 id: "hunk-\(hunkIndex)-row-\(rowIndex)-context-\(line.oldNumber ?? 0)-\(line.newNumber ?? 0)",
@@ -165,8 +171,8 @@ enum DiffDisplayModelBuilder {
     }
 
     private static func appendChangedRows(
-        deletes: [ParsedDiff.Hunk.Line],
-        adds: [ParsedDiff.Hunk.Line],
+        deletes: [IndexedLine],
+        adds: [IndexedLine],
         to rows: inout [DiffDisplayRow],
         filePath: String,
         hunkIndex: Int
@@ -175,14 +181,14 @@ enum DiffDisplayModelBuilder {
         for offset in 0..<replacementCount {
             let deleteLine = deletes[offset]
             let addLine = adds[offset]
-            let highlight = DiffInlineHighlighter.highlightDeleteAdd(old: deleteLine.text, new: addLine.text)
-            let rowIndex = rows.count
+            let highlight = DiffInlineHighlighter.highlightDeleteAdd(old: deleteLine.line.text, new: addLine.line.text)
+            let rowIndex = deleteLine.index
             rows.append(
                 DiffDisplayRow(
-                    id: "hunk-\(hunkIndex)-row-\(rowIndex)-replacement-\(deleteLine.oldNumber ?? 0)-\(addLine.newNumber ?? 0)",
+                    id: "hunk-\(hunkIndex)-row-\(rowIndex)-replacement-\(deleteLine.line.oldNumber ?? 0)-\(addLine.line.newNumber ?? 0)",
                     kind: .replacement,
                     old: displayLine(
-                        deleteLine,
+                        deleteLine.line,
                         filePath: filePath,
                         hunkIndex: hunkIndex,
                         rowIndex: rowIndex,
@@ -190,7 +196,7 @@ enum DiffDisplayModelBuilder {
                         inlineSpans: highlight.oldSpans
                     ),
                     new: displayLine(
-                        addLine,
+                        addLine.line,
                         filePath: filePath,
                         hunkIndex: hunkIndex,
                         rowIndex: rowIndex,
@@ -202,8 +208,9 @@ enum DiffDisplayModelBuilder {
             )
         }
 
-        deletes.dropFirst(replacementCount).forEach { line in
-            let rowIndex = rows.count
+        deletes.dropFirst(replacementCount).forEach { source in
+            let line = source.line
+            let rowIndex = source.index
             rows.append(
                 DiffDisplayRow(
                     id: "hunk-\(hunkIndex)-row-\(rowIndex)-delete-\(line.oldNumber ?? 0)",
@@ -222,8 +229,9 @@ enum DiffDisplayModelBuilder {
             )
         }
 
-        adds.dropFirst(replacementCount).forEach { line in
-            let rowIndex = rows.count
+        adds.dropFirst(replacementCount).forEach { source in
+            let line = source.line
+            let rowIndex = source.index
             rows.append(
                 DiffDisplayRow(
                     id: "hunk-\(hunkIndex)-row-\(rowIndex)-add-\(line.newNumber ?? 0)",

--- a/Alas/Sources/Center/Diff/DiffDisplayModelBuilder.swift
+++ b/Alas/Sources/Center/Diff/DiffDisplayModelBuilder.swift
@@ -167,6 +167,7 @@ enum DiffDisplayModelBuilder {
                 hunkIndex: hunkIndex,
                 rowIndex: rowIndex,
                 side: .old,
+                anchorSide: .paired,
                 inlineSpans: []
             ),
             new: displayLine(
@@ -175,6 +176,7 @@ enum DiffDisplayModelBuilder {
                 hunkIndex: hunkIndex,
                 rowIndex: rowIndex,
                 side: .new,
+                anchorSide: .paired,
                 inlineSpans: []
             ),
             collapsedLineCount: 0
@@ -268,6 +270,7 @@ enum DiffDisplayModelBuilder {
         hunkIndex: Int,
         rowIndex: Int,
         side: DiffLineSide,
+        anchorSide: DiffLineSide? = nil,
         inlineSpans: [DiffInlineSpan]
     ) -> DiffDisplayLine {
         let lineNumber: Int?
@@ -280,13 +283,14 @@ enum DiffDisplayModelBuilder {
             lineNumber = line.newNumber ?? line.oldNumber
         }
 
+        let anchorSide = anchorSide ?? side
         let anchor = DiffLineAnchor(
             filePath: filePath,
             hunkIndex: hunkIndex,
             rowIndex: rowIndex,
-            side: side,
-            oldLine: side == .new ? nil : line.oldNumber,
-            newLine: side == .old ? nil : line.newNumber
+            side: anchorSide,
+            oldLine: anchorSide == .new ? nil : line.oldNumber,
+            newLine: anchorSide == .old ? nil : line.newNumber
         )
 
         return DiffDisplayLine(

--- a/Alas/Sources/Center/Diff/DiffDisplayModelBuilder.swift
+++ b/Alas/Sources/Center/Diff/DiffDisplayModelBuilder.swift
@@ -10,7 +10,7 @@ enum DiffDisplayModelBuilder {
         let groups = diff.hunks.enumerated().map { hunkIndex, hunk in
             DiffDisplayGroup(
                 id: "hunk-\(hunkIndex)-\(hunk.header)",
-                hunkHeader: hunk.header,
+                header: hunk.header,
                 sourceHunk: hunk,
                 rows: buildRows(
                     hunk: hunk,

--- a/Alas/Sources/Center/Diff/DiffDisplayPreferences.swift
+++ b/Alas/Sources/Center/Diff/DiffDisplayPreferences.swift
@@ -1,0 +1,13 @@
+import Foundation
+
+enum DiffLayoutMode: String, Codable, Equatable, CaseIterable {
+    case split
+    case stacked
+
+    var title: String {
+        switch self {
+        case .split: return "Split"
+        case .stacked: return "Stacked"
+        }
+    }
+}

--- a/Alas/Sources/Center/Diff/DiffInlineHighlighter.swift
+++ b/Alas/Sources/Center/Diff/DiffInlineHighlighter.swift
@@ -1,0 +1,82 @@
+import Foundation
+
+enum DiffInlineHighlighter {
+    struct Result: Equatable {
+        let oldSpans: [DiffInlineSpan]
+        let newSpans: [DiffInlineSpan]
+    }
+
+    static func highlightDeleteAdd(old oldText: String, new newText: String) -> Result {
+        let oldTokens = tokenize(oldText)
+        let newTokens = tokenize(newText)
+
+        guard !oldTokens.isEmpty || !newTokens.isEmpty else {
+            return Result(oldSpans: [], newSpans: [])
+        }
+
+        guard oldTokens.contains(where: { oldToken in
+            newTokens.contains(where: { $0.text == oldToken.text })
+        }) else {
+            return Result(
+                oldSpans: fullLineSpan(for: oldText),
+                newSpans: fullLineSpan(for: newText)
+            )
+        }
+
+        var prefixCount = 0
+        while prefixCount < oldTokens.count,
+              prefixCount < newTokens.count,
+              oldTokens[prefixCount].text == newTokens[prefixCount].text {
+            prefixCount += 1
+        }
+
+        var oldSuffixIndex = oldTokens.count - 1
+        var newSuffixIndex = newTokens.count - 1
+        while oldSuffixIndex >= prefixCount,
+              newSuffixIndex >= prefixCount,
+              oldTokens[oldSuffixIndex].text == newTokens[newSuffixIndex].text {
+            oldSuffixIndex -= 1
+            newSuffixIndex -= 1
+        }
+
+        return Result(
+            oldSpans: span(from: oldTokens, lowerBound: prefixCount, upperBound: oldSuffixIndex),
+            newSpans: span(from: newTokens, lowerBound: prefixCount, upperBound: newSuffixIndex)
+        )
+    }
+
+    private struct Token: Equatable {
+        let text: String
+        let range: NSRange
+    }
+
+    private static func tokenize(_ text: String) -> [Token] {
+        let pattern = #"[A-Za-z0-9_]+|[^\sA-Za-z0-9_]"#
+        guard let regex = try? NSRegularExpression(pattern: pattern) else {
+            return []
+        }
+
+        let nsText = text as NSString
+        let fullRange = NSRange(location: 0, length: nsText.length)
+        return regex.matches(in: text, range: fullRange).map { match in
+            Token(text: nsText.substring(with: match.range), range: match.range)
+        }
+    }
+
+    private static func fullLineSpan(for text: String) -> [DiffInlineSpan] {
+        let length = (text as NSString).length
+        return length == 0 ? [] : [DiffInlineSpan(start: 0, length: length)]
+    }
+
+    private static func span(from tokens: [Token], lowerBound: Int, upperBound: Int) -> [DiffInlineSpan] {
+        guard lowerBound <= upperBound,
+              tokens.indices.contains(lowerBound),
+              tokens.indices.contains(upperBound) else {
+            return []
+        }
+
+        let start = tokens[lowerBound].range.location
+        let end = tokens[upperBound].range.location + tokens[upperBound].range.length
+        return [DiffInlineSpan(start: start, length: end - start)]
+    }
+}

--- a/Alas/Sources/Center/Diff/DiffInlineHighlighter.swift
+++ b/Alas/Sources/Center/Diff/DiffInlineHighlighter.swift
@@ -14,9 +14,8 @@ enum DiffInlineHighlighter {
             return Result(oldSpans: [], newSpans: [])
         }
 
-        guard oldTokens.contains(where: { oldToken in
-            newTokens.contains(where: { $0.text == oldToken.text })
-        }) else {
+        let newTokenTexts = Set(newTokens.map(\.text))
+        guard oldTokens.contains(where: { newTokenTexts.contains($0.text) }) else {
             return Result(
                 oldSpans: fullLineSpan(for: oldText),
                 newSpans: fullLineSpan(for: newText)
@@ -51,17 +50,14 @@ enum DiffInlineHighlighter {
     }
 
     private static func tokenize(_ text: String) -> [Token] {
-        let pattern = #"[A-Za-z0-9_]+|[^\sA-Za-z0-9_]"#
-        guard let regex = try? NSRegularExpression(pattern: pattern) else {
-            return []
-        }
-
         let nsText = text as NSString
         let fullRange = NSRange(location: 0, length: nsText.length)
-        return regex.matches(in: text, range: fullRange).map { match in
+        return tokenRegex.matches(in: text, range: fullRange).map { match in
             Token(text: nsText.substring(with: match.range), range: match.range)
         }
     }
+
+    private static let tokenRegex = try! NSRegularExpression(pattern: #"[A-Za-z0-9_]+|[^\sA-Za-z0-9_]"#)
 
     private static func fullLineSpan(for text: String) -> [DiffInlineSpan] {
         let length = (text as NSString).length

--- a/Alas/Sources/Center/Diff/DiffPaneTextDocumentBuilder.swift
+++ b/Alas/Sources/Center/Diff/DiffPaneTextDocumentBuilder.swift
@@ -7,9 +7,129 @@ struct DiffPaneTextDocumentBuilder {
         let range: NSRange
     }
 
+    struct CodeDocument {
+        let attributedString: NSAttributedString
+        let lines: [LineMetadata]
+    }
+
+    struct SplitResult {
+        let oldCode: CodeDocument
+        let oldGutter: NSAttributedString
+        let newCode: CodeDocument
+        let newGutter: NSAttributedString
+    }
+
+    struct StackedResult {
+        let code: CodeDocument
+        let gutter: NSAttributedString
+    }
+
     struct Result {
         let attributedString: NSAttributedString
         let lines: [LineMetadata]
+    }
+
+    static func buildSplit(
+        group: DiffDisplayGroup,
+        expandedCollapsedRowIDs: Set<String>,
+        fileExtension: String,
+        font: NSFont,
+        showWhitespace: Bool,
+        theme: Theme
+    ) -> SplitResult {
+        var oldColumn = ColumnAccumulator(font: font, theme: theme)
+        var newColumn = ColumnAccumulator(font: font, theme: theme)
+        let oldGutter = NSMutableAttributedString()
+        let newGutter = NSMutableAttributedString()
+        let rows = DiffPaneRowProjection.visibleRows(
+            in: group,
+            expandedCollapsedRowIDs: expandedCollapsedRowIDs
+        )
+
+        for row in rows {
+            appendGutterLine(marker(for: row.old, emptyKind: row.kind, side: .old), to: oldGutter, font: font, theme: theme, side: .old)
+            appendGutterLine(marker(for: row.new, emptyKind: row.kind, side: .new), to: newGutter, font: font, theme: theme, side: .new)
+
+            if row.kind == .collapsed {
+                oldColumn.append(
+                    collapsedCodeText(row, font: font, theme: theme),
+                    kind: row.kind
+                )
+                newColumn.append(NSAttributedString(string: "", attributes: baseAttributes(font: font, theme: theme)), kind: row.kind)
+                continue
+            }
+
+            oldColumn.append(
+                code(
+                    row.old?.text ?? "",
+                    line: row.old,
+                    fileExtension: fileExtension,
+                    font: font,
+                    showWhitespace: showWhitespace,
+                    theme: theme
+                ),
+                kind: row.kind
+            )
+            newColumn.append(
+                code(
+                    row.new?.text ?? "",
+                    line: row.new,
+                    fileExtension: fileExtension,
+                    font: font,
+                    showWhitespace: showWhitespace,
+                    theme: theme
+                ),
+                kind: row.kind
+            )
+        }
+
+        return SplitResult(
+            oldCode: oldColumn.document,
+            oldGutter: oldGutter,
+            newCode: newColumn.document,
+            newGutter: newGutter
+        )
+    }
+
+    static func buildStacked(
+        group: DiffDisplayGroup,
+        expandedCollapsedRowIDs: Set<String>,
+        fileExtension: String,
+        font: NSFont,
+        showWhitespace: Bool,
+        theme: Theme
+    ) -> StackedResult {
+        var codeColumn = ColumnAccumulator(font: font, theme: theme)
+        let gutter = NSMutableAttributedString()
+        let rows = DiffPaneRowProjection.visibleRows(
+            in: group,
+            expandedCollapsedRowIDs: expandedCollapsedRowIDs
+        )
+
+        for row in rows {
+            if row.kind == .collapsed {
+                appendGutterLine("", to: gutter, font: font, theme: theme, side: .paired)
+                codeColumn.append(collapsedCodeText(row, font: font, theme: theme), kind: row.kind)
+                continue
+            }
+
+            for line in DiffPaneRowProjection.stackedLines(for: row) {
+                appendGutterLine(marker(for: line, emptyKind: row.kind, side: line.anchor.side), to: gutter, font: font, theme: theme, side: line.anchor.side)
+                codeColumn.append(
+                    code(
+                        line.text,
+                        line: line,
+                        fileExtension: fileExtension,
+                        font: font,
+                        showWhitespace: showWhitespace,
+                        theme: theme
+                    ),
+                    kind: row.kind
+                )
+            }
+        }
+
+        return StackedResult(code: codeColumn.document, gutter: gutter)
     }
 
     static func build(
@@ -168,6 +288,22 @@ struct DiffPaneTextDocumentBuilder {
         )
     }
 
+    private static func collapsedCodeText(
+        _ row: DiffDisplayRow,
+        font: NSFont,
+        theme: Theme
+    ) -> NSAttributedString {
+        NSAttributedString(
+            string: "... \(row.collapsedLineCount) unchanged lines",
+            attributes: [
+                .font: font,
+                .foregroundColor: NSColor(theme.color("fg-dim")),
+                .backgroundColor: NSColor(theme.color("bg-2")),
+                .paragraphStyle: CenterTypography.paragraphStyle(),
+            ]
+        )
+    }
+
     private static func code(
         _ text: String,
         line: DiffDisplayLine?,
@@ -191,6 +327,19 @@ struct DiffPaneTextDocumentBuilder {
         )
     }
 
+    private static func appendGutterLine(
+        _ text: String,
+        to output: NSMutableAttributedString,
+        font: NSFont,
+        theme: Theme,
+        side: DiffLineSide
+    ) {
+        if output.length > 0 {
+            output.append(NSAttributedString(string: "\n", attributes: baseAttributes(font: font, theme: theme)))
+        }
+        output.append(marker(text, font: font, theme: theme, side: side))
+    }
+
     private static func marker(
         _ text: String,
         font: NSFont,
@@ -205,6 +354,27 @@ struct DiffPaneTextDocumentBuilder {
                 .paragraphStyle: CenterTypography.paragraphStyle(),
             ]
         )
+    }
+
+    private static func marker(
+        for line: DiffDisplayLine?,
+        emptyKind: DiffDisplayRow.Kind,
+        side: DiffLineSide
+    ) -> String {
+        guard let line else {
+            return ""
+        }
+        let number = line.lineNumber.map(String.init) ?? ""
+        let sign: String
+        switch line.kind {
+        case .add:
+            sign = "+"
+        case .delete:
+            sign = "-"
+        case .context:
+            sign = " "
+        }
+        return "\(sign)\(number)"
     }
 
     private static func prefix(
@@ -291,6 +461,39 @@ struct DiffPaneTextDocumentBuilder {
         case .context:
             return theme.color("bg-1")
         }
+    }
+}
+
+private struct ColumnAccumulator {
+    private let output = NSMutableAttributedString()
+    private var metadata: [DiffPaneTextDocumentBuilder.LineMetadata] = []
+    private let newlineAttributes: [NSAttributedString.Key: Any]
+
+    init(font: NSFont, theme: Theme) {
+        newlineAttributes = [
+            .font: font,
+            .foregroundColor: NSColor(theme.color("fg")),
+            .paragraphStyle: CenterTypography.paragraphStyle(),
+        ]
+    }
+
+    var document: DiffPaneTextDocumentBuilder.CodeDocument {
+        DiffPaneTextDocumentBuilder.CodeDocument(
+            attributedString: output,
+            lines: metadata
+        )
+    }
+
+    mutating func append(_ line: NSAttributedString, kind: DiffDisplayRow.Kind) {
+        if output.length > 0 {
+            output.append(NSAttributedString(string: "\n", attributes: newlineAttributes))
+        }
+        let start = output.length
+        output.append(line)
+        metadata.append(DiffPaneTextDocumentBuilder.LineMetadata(
+            kind: kind,
+            range: NSRange(location: start, length: line.length)
+        ))
     }
 }
 

--- a/Alas/Sources/Center/Diff/DiffPaneTextDocumentBuilder.swift
+++ b/Alas/Sources/Center/Diff/DiffPaneTextDocumentBuilder.swift
@@ -39,23 +39,23 @@ struct DiffPaneTextDocumentBuilder {
     ) -> SplitResult {
         var oldColumn = ColumnAccumulator(font: font, theme: theme)
         var newColumn = ColumnAccumulator(font: font, theme: theme)
-        let oldGutter = NSMutableAttributedString()
-        let newGutter = NSMutableAttributedString()
+        var oldGutter = GutterAccumulator(font: font, theme: theme)
+        var newGutter = GutterAccumulator(font: font, theme: theme)
         let rows = DiffPaneRowProjection.visibleRows(
             in: group,
             expandedCollapsedRowIDs: expandedCollapsedRowIDs
         )
 
         for row in rows {
-            appendGutterLine(marker(for: row.old, emptyKind: row.kind, side: .old), to: oldGutter, font: font, theme: theme, side: .old)
-            appendGutterLine(marker(for: row.new, emptyKind: row.kind, side: .new), to: newGutter, font: font, theme: theme, side: .new)
+            oldGutter.append(marker(for: row.old, emptyKind: row.kind, side: .old), side: .old)
+            newGutter.append(marker(for: row.new, emptyKind: row.kind, side: .new), side: .new)
 
             if row.kind == .collapsed {
                 oldColumn.append(
                     collapsedCodeText(row, font: font, theme: theme),
                     kind: row.kind
                 )
-                newColumn.append(NSAttributedString(string: "", attributes: baseAttributes(font: font, theme: theme)), kind: row.kind)
+                newColumn.append(emptyLayoutGlyph(font: font, theme: theme), kind: row.kind)
                 continue
             }
 
@@ -85,9 +85,9 @@ struct DiffPaneTextDocumentBuilder {
 
         return SplitResult(
             oldCode: oldColumn.document,
-            oldGutter: oldGutter,
+            oldGutter: oldGutter.attributedString,
             newCode: newColumn.document,
-            newGutter: newGutter
+            newGutter: newGutter.attributedString
         )
     }
 
@@ -100,7 +100,7 @@ struct DiffPaneTextDocumentBuilder {
         theme: Theme
     ) -> StackedResult {
         var codeColumn = ColumnAccumulator(font: font, theme: theme)
-        let gutter = NSMutableAttributedString()
+        var gutter = GutterAccumulator(font: font, theme: theme)
         let rows = DiffPaneRowProjection.visibleRows(
             in: group,
             expandedCollapsedRowIDs: expandedCollapsedRowIDs
@@ -108,13 +108,13 @@ struct DiffPaneTextDocumentBuilder {
 
         for row in rows {
             if row.kind == .collapsed {
-                appendGutterLine("", to: gutter, font: font, theme: theme, side: .paired)
+                gutter.append("", side: .paired)
                 codeColumn.append(collapsedCodeText(row, font: font, theme: theme), kind: row.kind)
                 continue
             }
 
             for line in DiffPaneRowProjection.stackedLines(for: row) {
-                appendGutterLine(marker(for: line, emptyKind: row.kind, side: line.anchor.side), to: gutter, font: font, theme: theme, side: line.anchor.side)
+                gutter.append(marker(for: line, emptyKind: row.kind, side: line.anchor.side), side: line.anchor.side)
                 codeColumn.append(
                     code(
                         line.text,
@@ -129,7 +129,7 @@ struct DiffPaneTextDocumentBuilder {
             }
         }
 
-        return StackedResult(code: codeColumn.document, gutter: gutter)
+        return StackedResult(code: codeColumn.document, gutter: gutter.attributedString)
     }
 
     static func build(
@@ -313,6 +313,9 @@ struct DiffPaneTextDocumentBuilder {
         theme: Theme
     ) -> NSAttributedString {
         guard let line else {
+            if text.isEmpty {
+                return emptyLayoutGlyph(font: font, theme: theme)
+            }
             return NSAttributedString(string: text, attributes: baseAttributes(font: font, theme: theme))
         }
         return DiffCodeText.attributedString(
@@ -327,20 +330,7 @@ struct DiffPaneTextDocumentBuilder {
         )
     }
 
-    private static func appendGutterLine(
-        _ text: String,
-        to output: NSMutableAttributedString,
-        font: NSFont,
-        theme: Theme,
-        side: DiffLineSide
-    ) {
-        if output.length > 0 {
-            output.append(NSAttributedString(string: "\n", attributes: baseAttributes(font: font, theme: theme)))
-        }
-        output.append(marker(text, font: font, theme: theme, side: side))
-    }
-
-    private static func marker(
+    fileprivate static func marker(
         _ text: String,
         font: NSFont,
         theme: Theme,
@@ -413,6 +403,17 @@ struct DiffPaneTextDocumentBuilder {
             .foregroundColor: NSColor(theme.color("fg")),
             .paragraphStyle: CenterTypography.paragraphStyle(),
         ]
+    }
+
+    private static func emptyLayoutGlyph(font: NSFont, theme: Theme) -> NSAttributedString {
+        NSAttributedString(
+            string: " ",
+            attributes: [
+                .font: font,
+                .foregroundColor: NSColor.clear,
+                .paragraphStyle: CenterTypography.paragraphStyle(),
+            ]
+        )
     }
 
     private static func inlineTone(for kind: ParsedDiff.Hunk.Line.Kind) -> DiffInlineTone {
@@ -494,6 +495,36 @@ private struct ColumnAccumulator {
             kind: kind,
             range: NSRange(location: start, length: line.length)
         ))
+    }
+}
+
+private struct GutterAccumulator {
+    private let output = NSMutableAttributedString()
+    private let font: NSFont
+    private let theme: Theme
+    private let newlineAttributes: [NSAttributedString.Key: Any]
+    private var lineCount = 0
+
+    init(font: NSFont, theme: Theme) {
+        self.font = font
+        self.theme = theme
+        newlineAttributes = [
+            .font: font,
+            .foregroundColor: NSColor(theme.color("fg")),
+            .paragraphStyle: CenterTypography.paragraphStyle(),
+        ]
+    }
+
+    var attributedString: NSAttributedString {
+        output
+    }
+
+    mutating func append(_ text: String, side: DiffLineSide) {
+        if lineCount > 0 {
+            output.append(NSAttributedString(string: "\n", attributes: newlineAttributes))
+        }
+        output.append(DiffPaneTextDocumentBuilder.marker(text, font: font, theme: theme, side: side))
+        lineCount += 1
     }
 }
 

--- a/Alas/Sources/Center/Diff/DiffPaneTextDocumentBuilder.swift
+++ b/Alas/Sources/Center/Diff/DiffPaneTextDocumentBuilder.swift
@@ -1,0 +1,309 @@
+import AppKit
+import SwiftUI
+
+struct DiffPaneTextDocumentBuilder {
+    struct LineMetadata: Equatable {
+        let kind: DiffDisplayRow.Kind
+        let range: NSRange
+    }
+
+    struct Result {
+        let attributedString: NSAttributedString
+        let lines: [LineMetadata]
+    }
+
+    static func build(
+        group: DiffDisplayGroup,
+        expandedCollapsedRowIDs: Set<String>,
+        layoutMode: DiffLayoutMode,
+        fileExtension: String,
+        font: NSFont,
+        showWhitespace: Bool,
+        theme: Theme,
+        splitColumnCharacterWidth: Int = 48
+    ) -> Result {
+        let output = NSMutableAttributedString()
+        var lines: [LineMetadata] = []
+        let rows = DiffPaneRowProjection.visibleRows(
+            in: group,
+            expandedCollapsedRowIDs: expandedCollapsedRowIDs
+        )
+
+        for row in rows {
+            if output.length > 0 {
+                output.append(NSAttributedString(string: "\n", attributes: baseAttributes(font: font, theme: theme)))
+            }
+
+            let start = output.length
+            switch row.kind {
+            case .collapsed:
+                output.append(collapsedLine(row, font: font, theme: theme))
+            case .context, .add, .delete, .replacement:
+                switch layoutMode {
+                case .split:
+                    output.append(splitLine(
+                        row,
+                        fileExtension: fileExtension,
+                        font: font,
+                        showWhitespace: showWhitespace,
+                        theme: theme,
+                        splitColumnCharacterWidth: splitColumnCharacterWidth
+                    ))
+                case .stacked:
+                    appendStackedLines(
+                        row,
+                        to: output,
+                        lines: &lines,
+                        fileExtension: fileExtension,
+                        font: font,
+                        showWhitespace: showWhitespace,
+                        theme: theme
+                    )
+                    continue
+                }
+            }
+
+            lines.append(LineMetadata(kind: row.kind, range: NSRange(location: start, length: output.length - start)))
+        }
+
+        return Result(attributedString: output, lines: lines)
+    }
+
+    private static func appendStackedLines(
+        _ row: DiffDisplayRow,
+        to output: NSMutableAttributedString,
+        lines: inout [LineMetadata],
+        fileExtension: String,
+        font: NSFont,
+        showWhitespace: Bool,
+        theme: Theme
+    ) {
+        for (index, line) in DiffPaneRowProjection.stackedLines(for: row).enumerated() {
+            if index > 0 {
+                output.append(NSAttributedString(string: "\n", attributes: baseAttributes(font: font, theme: theme)))
+            }
+            let start = output.length
+            output.append(stackedLine(
+                line,
+                fileExtension: fileExtension,
+                font: font,
+                showWhitespace: showWhitespace,
+                theme: theme
+            ))
+            lines.append(LineMetadata(kind: row.kind, range: NSRange(location: start, length: output.length - start)))
+        }
+    }
+
+    private static func splitLine(
+        _ row: DiffDisplayRow,
+        fileExtension: String,
+        font: NSFont,
+        showWhitespace: Bool,
+        theme: Theme,
+        splitColumnCharacterWidth: Int
+    ) -> NSAttributedString {
+        let output = NSMutableAttributedString()
+        let oldCode = truncatedCode(row.old?.text ?? "", width: splitColumnCharacterWidth)
+        let oldPrefix = prefix(for: row.old, emptyKind: row.kind, side: .old)
+        output.append(marker(oldPrefix, font: font, theme: theme, side: .old))
+        output.append(code(
+            oldCode,
+            line: row.old,
+            fileExtension: fileExtension,
+            font: font,
+            showWhitespace: showWhitespace,
+            theme: theme
+        ))
+        output.append(NSAttributedString(string: "\t", attributes: baseAttributes(font: font, theme: theme)))
+
+        let newCode = row.new?.text ?? ""
+        let newPrefix = prefix(for: row.new, emptyKind: row.kind, side: .new)
+        output.append(marker(newPrefix, font: font, theme: theme, side: .new))
+        output.append(code(
+            newCode,
+            line: row.new,
+            fileExtension: fileExtension,
+            font: font,
+            showWhitespace: showWhitespace,
+            theme: theme
+        ))
+        output.addAttribute(.backgroundColor, value: NSColor(rowBackground(for: row.kind, theme: theme)), range: NSRange(location: 0, length: output.length))
+        return output
+    }
+
+    private static func stackedLine(
+        _ line: DiffDisplayLine,
+        fileExtension: String,
+        font: NSFont,
+        showWhitespace: Bool,
+        theme: Theme
+    ) -> NSAttributedString {
+        let output = NSMutableAttributedString()
+        output.append(marker(prefix(for: line, emptyKind: .context, side: line.anchor.side), font: font, theme: theme, side: line.anchor.side))
+        output.append(code(
+            line.text,
+            line: line,
+            fileExtension: fileExtension,
+            font: font,
+            showWhitespace: showWhitespace,
+            theme: theme
+        ))
+        output.addAttribute(.backgroundColor, value: NSColor(lineBackground(for: line.kind, theme: theme)), range: NSRange(location: 0, length: output.length))
+        return output
+    }
+
+    private static func collapsedLine(
+        _ row: DiffDisplayRow,
+        font: NSFont,
+        theme: Theme
+    ) -> NSAttributedString {
+        NSAttributedString(
+            string: "      ... \(row.collapsedLineCount) unchanged lines",
+            attributes: [
+                .font: font,
+                .foregroundColor: NSColor(theme.color("fg-dim")),
+                .backgroundColor: NSColor(theme.color("bg-2")),
+                .paragraphStyle: CenterTypography.paragraphStyle(),
+            ]
+        )
+    }
+
+    private static func code(
+        _ text: String,
+        line: DiffDisplayLine?,
+        fileExtension: String,
+        font: NSFont,
+        showWhitespace: Bool,
+        theme: Theme
+    ) -> NSAttributedString {
+        guard let line else {
+            return NSAttributedString(string: text, attributes: baseAttributes(font: font, theme: theme))
+        }
+        return DiffCodeText.attributedString(
+            text: text,
+            fileExtension: fileExtension,
+            codeFontFamily: font.familyName ?? "",
+            codeFontSize: font.pointSize,
+            showWhitespace: showWhitespace,
+            inlineSpans: line.inlineSpans,
+            inlineTone: inlineTone(for: line.kind),
+            theme: theme
+        )
+    }
+
+    private static func marker(
+        _ text: String,
+        font: NSFont,
+        theme: Theme,
+        side: DiffLineSide
+    ) -> NSAttributedString {
+        NSAttributedString(
+            string: text,
+            attributes: [
+                .font: font,
+                .foregroundColor: NSColor(markerColor(for: side, theme: theme)),
+                .paragraphStyle: CenterTypography.paragraphStyle(),
+            ]
+        )
+    }
+
+    private static func prefix(
+        for line: DiffDisplayLine?,
+        emptyKind: DiffDisplayRow.Kind,
+        side: DiffLineSide
+    ) -> String {
+        guard let line else {
+            return "      | "
+        }
+        let number = line.lineNumber.map(String.init) ?? ""
+        let marker: String
+        switch line.kind {
+        case .add:
+            marker = "+"
+        case .delete:
+            marker = "-"
+        case .context:
+            marker = " "
+        }
+        return "\(marker)\(number.leftPadded(to: 5)) | "
+    }
+
+    private static func truncatedCode(_ text: String, width: Int) -> String {
+        guard width > 3 else { return text }
+        let ns = text as NSString
+        guard ns.length > width else {
+            return text.rightPadded(to: width)
+        }
+        return ns.substring(to: width - 3) + "..."
+    }
+
+    private static func baseAttributes(font: NSFont, theme: Theme) -> [NSAttributedString.Key: Any] {
+        [
+            .font: font,
+            .foregroundColor: NSColor(theme.color("fg")),
+            .paragraphStyle: CenterTypography.paragraphStyle(),
+        ]
+    }
+
+    private static func inlineTone(for kind: ParsedDiff.Hunk.Line.Kind) -> DiffInlineTone {
+        switch kind {
+        case .add:
+            return .add
+        case .delete:
+            return .del
+        case .context:
+            return .accent
+        }
+    }
+
+    private static func markerColor(for side: DiffLineSide, theme: Theme) -> Color {
+        switch side {
+        case .old:
+            return theme.color("del")
+        case .new:
+            return theme.color("add")
+        case .paired:
+            return theme.color("fg-faint")
+        }
+    }
+
+    private static func rowBackground(for kind: DiffDisplayRow.Kind, theme: Theme) -> Color {
+        switch kind {
+        case .add:
+            return theme.color("add").opacity(0.12)
+        case .delete:
+            return theme.color("del").opacity(0.12)
+        case .replacement:
+            return theme.color("mod").opacity(0.10)
+        case .context:
+            return theme.color("bg-1")
+        case .collapsed:
+            return theme.color("bg-2")
+        }
+    }
+
+    private static func lineBackground(for kind: ParsedDiff.Hunk.Line.Kind, theme: Theme) -> Color {
+        switch kind {
+        case .add:
+            return theme.color("add").opacity(0.12)
+        case .delete:
+            return theme.color("del").opacity(0.12)
+        case .context:
+            return theme.color("bg-1")
+        }
+    }
+}
+
+private extension String {
+    func leftPadded(to width: Int) -> String {
+        let length = (self as NSString).length
+        guard length < width else { return self }
+        return String(repeating: " ", count: width - length) + self
+    }
+
+    func rightPadded(to width: Int) -> String {
+        let length = (self as NSString).length
+        guard length < width else { return self }
+        return self + String(repeating: " ", count: width - length)
+    }
+}

--- a/Alas/Sources/Center/Diff/DiffPaneTextDocumentView.swift
+++ b/Alas/Sources/Center/Diff/DiffPaneTextDocumentView.swift
@@ -1,0 +1,201 @@
+import AppKit
+import SwiftUI
+
+struct DiffPaneTextDocumentView: NSViewRepresentable {
+    let group: DiffDisplayGroup
+    let expandedCollapsedRowIDs: Set<String>
+    let layoutMode: DiffLayoutMode
+    let wrapLines: Bool
+    let showWhitespace: Bool
+    let fileExtension: String
+    let codeFontFamily: String
+    let codeFontSize: CGFloat
+    let theme: Theme
+
+    func makeNSView(context: Context) -> DiffPaneTextDocumentScrollView {
+        DiffPaneTextDocumentScrollView()
+    }
+
+    func updateNSView(_ nsView: DiffPaneTextDocumentScrollView, context: Context) {
+        nsView.update(
+            group: group,
+            expandedCollapsedRowIDs: expandedCollapsedRowIDs,
+            layoutMode: layoutMode,
+            wrapLines: wrapLines,
+            showWhitespace: showWhitespace,
+            fileExtension: fileExtension,
+            font: CenterTypography.resolveCodeFont(family: codeFontFamily, size: codeFontSize),
+            theme: theme
+        )
+    }
+}
+
+final class DiffPaneTextDocumentScrollView: NSScrollView {
+    private static let unwrappedTextContainerWidth: CGFloat = 1_000_000
+
+    private let textView: NSTextView
+    private var latestConfiguration: Configuration?
+    private var latestViewportWidth: CGFloat = 0
+
+    override var intrinsicContentSize: NSSize {
+        NSSize(width: NSView.noIntrinsicMetric, height: measuredTextHeight())
+    }
+
+    override init(frame frameRect: NSRect) {
+        let storage = NSTextStorage()
+        let layoutManager = NSLayoutManager()
+        let container = NSTextContainer(size: NSSize(
+            width: Self.unwrappedTextContainerWidth,
+            height: CGFloat.greatestFiniteMagnitude
+        ))
+        container.lineFragmentPadding = 0
+        container.widthTracksTextView = false
+        layoutManager.addTextContainer(container)
+        storage.addLayoutManager(layoutManager)
+
+        textView = NSTextView(frame: .zero, textContainer: container)
+        super.init(frame: frameRect)
+
+        drawsBackground = false
+        borderType = .noBorder
+        hasVerticalScroller = false
+        autohidesScrollers = true
+        scrollerStyle = .overlay
+        documentView = textView
+
+        textView.isEditable = false
+        textView.isSelectable = true
+        textView.isRichText = false
+        textView.drawsBackground = false
+        textView.backgroundColor = .clear
+        textView.textContainerInset = NSSize(width: 12, height: 6)
+        textView.allowsUndo = false
+        textView.isAutomaticQuoteSubstitutionEnabled = false
+        textView.isAutomaticDashSubstitutionEnabled = false
+        textView.isAutomaticTextReplacementEnabled = false
+        textView.isAutomaticSpellingCorrectionEnabled = false
+        textView.isContinuousSpellCheckingEnabled = false
+        textView.isGrammarCheckingEnabled = false
+        textView.smartInsertDeleteEnabled = false
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("not used")
+    }
+
+    func update(
+        group: DiffDisplayGroup,
+        expandedCollapsedRowIDs: Set<String>,
+        layoutMode: DiffLayoutMode,
+        wrapLines: Bool,
+        showWhitespace: Bool,
+        fileExtension: String,
+        font: NSFont,
+        theme: Theme
+    ) {
+        latestConfiguration = Configuration(
+            group: group,
+            expandedCollapsedRowIDs: expandedCollapsedRowIDs,
+            layoutMode: layoutMode,
+            wrapLines: wrapLines,
+            showWhitespace: showWhitespace,
+            fileExtension: fileExtension,
+            font: font,
+            theme: theme
+        )
+        applyLatestConfiguration()
+    }
+
+    override func layout() {
+        super.layout()
+        if abs(contentView.bounds.width - latestViewportWidth) > 1 {
+            applyLatestConfiguration()
+        } else {
+            updateTextLayout()
+        }
+    }
+
+    private func applyLatestConfiguration() {
+        guard let config = latestConfiguration else { return }
+        latestViewportWidth = contentView.bounds.width
+        hasHorizontalScroller = config.layoutMode == .stacked && !config.wrapLines
+
+        let document = DiffPaneTextDocumentBuilder.build(
+            group: config.group,
+            expandedCollapsedRowIDs: config.expandedCollapsedRowIDs,
+            layoutMode: config.layoutMode,
+            fileExtension: config.fileExtension,
+            font: config.font,
+            showWhitespace: config.showWhitespace,
+            theme: config.theme,
+            splitColumnCharacterWidth: splitColumnCharacterWidth(font: config.font)
+        )
+        textView.textStorage?.setAttributedString(document.attributedString)
+        textView.insertionPointColor = NSColor(config.theme.color("fg"))
+        updateTextLayout()
+        invalidateIntrinsicContentSize()
+    }
+
+    private func updateTextLayout() {
+        guard let config = latestConfiguration else { return }
+        let wraps = config.wrapLines || config.layoutMode == .split
+        let viewportWidth = max(contentView.bounds.width, 1)
+
+        textView.isHorizontallyResizable = !wraps
+        textView.isVerticallyResizable = true
+        textView.minSize = NSSize(width: 0, height: 0)
+        textView.maxSize = NSSize(
+            width: wraps ? viewportWidth : Self.unwrappedTextContainerWidth,
+            height: CGFloat.greatestFiniteMagnitude
+        )
+        textView.textContainer?.widthTracksTextView = wraps
+        textView.textContainer?.heightTracksTextView = false
+        textView.textContainer?.containerSize = NSSize(
+            width: wraps ? viewportWidth - textView.textContainerInset.width * 2 : Self.unwrappedTextContainerWidth,
+            height: CGFloat.greatestFiniteMagnitude
+        )
+        textView.frame = NSRect(
+            x: 0,
+            y: 0,
+            width: wraps ? viewportWidth : max(viewportWidth, measuredTextWidth()),
+            height: measuredTextHeight()
+        )
+    }
+
+    private func measuredTextHeight() -> CGFloat {
+        guard let layoutManager = textView.layoutManager, let textContainer = textView.textContainer else {
+            return 0
+        }
+        layoutManager.ensureLayout(for: textContainer)
+        let used = layoutManager.usedRect(for: textContainer)
+        return ceil(used.height + textView.textContainerInset.height * 2)
+    }
+
+    private func measuredTextWidth() -> CGFloat {
+        guard let layoutManager = textView.layoutManager, let textContainer = textView.textContainer else {
+            return 0
+        }
+        layoutManager.ensureLayout(for: textContainer)
+        let used = layoutManager.usedRect(for: textContainer)
+        return ceil(used.width + textView.textContainerInset.width * 2)
+    }
+
+    private func splitColumnCharacterWidth(font: NSFont) -> Int {
+        let viewportWidth = max(latestViewportWidth, 320)
+        let characterWidth = max(("0" as NSString).size(withAttributes: [.font: font]).width, 1)
+        let halfPaneWidth = max((viewportWidth - 28) / 2, 120)
+        let prefixWidth: CGFloat = 8 * characterWidth
+        return max(Int((halfPaneWidth - prefixWidth) / characterWidth), 12)
+    }
+
+    private struct Configuration {
+        let group: DiffDisplayGroup
+        let expandedCollapsedRowIDs: Set<String>
+        let layoutMode: DiffLayoutMode
+        let wrapLines: Bool
+        let showWhitespace: Bool
+        let fileExtension: String
+        let font: NSFont
+        let theme: Theme
+    }
+}

--- a/Alas/Sources/Center/Diff/DiffPaneTextDocumentView.swift
+++ b/Alas/Sources/Center/Diff/DiffPaneTextDocumentView.swift
@@ -174,9 +174,10 @@ final class DiffPaneTextDocumentContainerView: NSView {
 final class DiffPaneTextScrollView: NSScrollView {
     private static let unwrappedTextContainerWidth: CGFloat = 1_000_000
 
-    private let textView: NSTextView
+    private let textView: DiffPaneCodeTextView
     private var lineLabels: [String] = []
     private var rowKinds: [DiffDisplayRow.Kind] = []
+    private var lineTones: [DiffPaneLineTone] = []
     private var wraps = false
     private var font: NSFont = .monospacedSystemFont(ofSize: 13, weight: .regular)
     private var theme: Theme?
@@ -198,7 +199,7 @@ final class DiffPaneTextScrollView: NSScrollView {
         layoutManager.addTextContainer(container)
         storage.addLayoutManager(layoutManager)
 
-        textView = NSTextView(frame: .zero, textContainer: container)
+        textView = DiffPaneCodeTextView(frame: .zero, textContainer: container)
         super.init(frame: frameRect)
 
         drawsBackground = false
@@ -217,8 +218,9 @@ final class DiffPaneTextScrollView: NSScrollView {
         textView.isRichText = false
         textView.isVerticallyResizable = true
         textView.isHorizontallyResizable = true
-        textView.drawsBackground = true
-        textView.textContainerInset = NSSize(width: 6, height: 6)
+        textView.drawsBackground = false
+        textView.backgroundColor = .clear
+        textView.textContainerInset = NSSize(width: 10, height: 8)
         textView.autoresizingMask = [.width]
         textView.allowsUndo = false
         textView.isAutomaticQuoteSubstitutionEnabled = false
@@ -243,19 +245,23 @@ final class DiffPaneTextScrollView: NSScrollView {
     ) {
         self.lineLabels = lineLabels
         self.rowKinds = document.lines.map(\.kind)
+        self.lineTones = zip(lineLabels, rowKinds).map { label, kind in
+            DiffPaneLineTone(label: label, rowKind: kind)
+        }
         self.wraps = wraps
         self.font = font
         self.theme = theme
 
         textView.textStorage?.setAttributedString(document.attributedString)
         textView.font = font
-        textView.backgroundColor = NSColor(theme.color("bg-1"))
+        textView.lineTones = lineTones
+        textView.theme = theme
         textView.insertionPointColor = NSColor(theme.color("fg"))
 
         if let ruler = verticalRulerView as? DiffPaneLineNumberRulerView {
             ruler.update(
                 labels: lineLabels,
-                rowKinds: rowKinds,
+                lineTones: lineTones,
                 rowHeight: lineHeight(),
                 contentTopInset: textView.textContainerInset.height,
                 theme: theme
@@ -335,9 +341,159 @@ final class DiffPaneTextScrollView: NSScrollView {
     }
 }
 
+enum DiffPaneLineTone: Equatable {
+    case context
+    case add
+    case delete
+    case placeholder
+    case collapsed
+
+    init(label: String, rowKind: DiffDisplayRow.Kind) {
+        if rowKind == .collapsed {
+            self = .collapsed
+        } else if label.hasPrefix("+") {
+            self = .add
+        } else if label.hasPrefix("-") {
+            self = .delete
+        } else if label.isEmpty, rowKind != .context {
+            self = .placeholder
+        } else {
+            self = .context
+        }
+    }
+}
+
+final class DiffPaneCodeTextView: NSTextView {
+    var lineTones: [DiffPaneLineTone] = [] {
+        didSet { needsDisplay = true }
+    }
+    var theme: Theme? {
+        didSet { needsDisplay = true }
+    }
+
+    override var isFlipped: Bool { true }
+
+    override func draw(_ dirtyRect: NSRect) {
+        drawLineBackgrounds(in: dirtyRect)
+        super.draw(dirtyRect)
+    }
+
+    func diffRowRects() -> [NSRect] {
+        guard let layoutManager, let textContainer else { return [] }
+        layoutManager.ensureLayout(for: textContainer)
+        let paragraphRanges = paragraphRanges(lineCount: lineTones.count)
+        return paragraphRanges.enumerated().map { index, range in
+            var rowRect = NSRect.null
+            let glyphRange = layoutManager.glyphRange(forCharacterRange: range, actualCharacterRange: nil)
+            if glyphRange.length > 0 {
+                layoutManager.enumerateLineFragments(forGlyphRange: glyphRange) { lineFragmentRect, _, _, _, _ in
+                    rowRect = rowRect.union(lineFragmentRect)
+                }
+            }
+            if rowRect.isNull {
+                rowRect = fallbackRowRect(at: index, layoutManager: layoutManager)
+            }
+            rowRect.origin.x = 0
+            rowRect.origin.y += textContainerOrigin.y
+            rowRect.size.width = max(bounds.width, visibleRect.width)
+            rowRect.size.height = max(rowRect.height, layoutManager.defaultLineHeight(for: font ?? .monospacedSystemFont(ofSize: 13, weight: .regular)))
+            return rowRect
+        }
+    }
+
+    private func drawLineBackgrounds(in dirtyRect: NSRect) {
+        guard let theme else { return }
+        let rowRects = diffRowRects()
+        for (index, rowRect) in rowRects.enumerated() {
+            guard lineTones.indices.contains(index) else { continue }
+            let tone = lineTones[index]
+            guard tone != .context else { continue }
+            guard rowRect.intersects(dirtyRect) else { continue }
+
+            rowFill(for: tone, theme: theme).setFill()
+            rowRect.fill()
+            drawRail(for: tone, rowRect: rowRect, theme: theme)
+            if tone == .placeholder {
+                drawPlaceholderHatch(in: rowRect, theme: theme)
+            }
+        }
+    }
+
+    private func paragraphRanges(lineCount: Int) -> [NSRange] {
+        let ns = string as NSString
+        var ranges: [NSRange] = []
+        var location = 0
+        for _ in 0..<lineCount {
+            if location >= ns.length {
+                ranges.append(NSRange(location: ns.length, length: 0))
+                continue
+            }
+            let searchRange = NSRange(location: location, length: ns.length - location)
+            let newline = ns.range(of: "\n", options: [], range: searchRange)
+            if newline.location == NSNotFound {
+                ranges.append(NSRange(location: location, length: ns.length - location))
+                location = ns.length
+            } else {
+                ranges.append(NSRange(location: location, length: newline.location - location))
+                location = NSMaxRange(newline)
+            }
+        }
+        return ranges
+    }
+
+    private func fallbackRowRect(at index: Int, layoutManager: NSLayoutManager) -> NSRect {
+        let lineHeight = layoutManager.defaultLineHeight(for: font ?? .monospacedSystemFont(ofSize: 13, weight: .regular))
+        return NSRect(x: 0, y: CGFloat(index) * lineHeight, width: bounds.width, height: lineHeight)
+    }
+
+    private func rowFill(for tone: DiffPaneLineTone, theme: Theme) -> NSColor {
+        switch tone {
+        case .add:
+            return NSColor(theme.color("add")).withAlphaComponent(0.18)
+        case .delete:
+            return NSColor(theme.color("del")).withAlphaComponent(0.18)
+        case .placeholder:
+            return NSColor(theme.color("bg-2")).withAlphaComponent(0.55)
+        case .collapsed:
+            return NSColor(theme.color("bg-3")).withAlphaComponent(0.72)
+        case .context:
+            return .clear
+        }
+    }
+
+    private func drawRail(for tone: DiffPaneLineTone, rowRect: NSRect, theme: Theme) {
+        let color: NSColor?
+        switch tone {
+        case .add:
+            color = NSColor(theme.color("add"))
+        case .delete:
+            color = NSColor(theme.color("del"))
+        default:
+            color = nil
+        }
+        guard let color else { return }
+        color.setFill()
+        NSRect(x: rowRect.minX, y: rowRect.minY, width: 3, height: rowRect.height).fill()
+    }
+
+    private func drawPlaceholderHatch(in rect: NSRect, theme: Theme) {
+        let path = NSBezierPath()
+        let spacing: CGFloat = 8
+        var x = rect.minX - rect.height
+        while x < rect.maxX {
+            path.move(to: NSPoint(x: x, y: rect.maxY))
+            path.line(to: NSPoint(x: x + rect.height, y: rect.minY))
+            x += spacing
+        }
+        path.lineWidth = 1
+        NSColor(theme.color("line")).withAlphaComponent(0.35).setStroke()
+        path.stroke()
+    }
+}
+
 final class DiffPaneLineNumberRulerView: NSRulerView {
     private var labels: [String] = []
-    private var rowKinds: [DiffDisplayRow.Kind] = []
+    private var lineTones: [DiffPaneLineTone] = []
     private var theme: Theme?
     var rowHeight: CGFloat = 16
     private var contentTopInset: CGFloat = 6
@@ -362,13 +518,13 @@ final class DiffPaneLineNumberRulerView: NSRulerView {
 
     func update(
         labels: [String],
-        rowKinds: [DiffDisplayRow.Kind],
+        lineTones: [DiffPaneLineTone],
         rowHeight: CGFloat,
         contentTopInset: CGFloat,
         theme: Theme
     ) {
         self.labels = labels
-        self.rowKinds = rowKinds
+        self.lineTones = lineTones
         self.rowHeight = rowHeight
         self.contentTopInset = contentTopInset
         self.theme = theme
@@ -378,27 +534,46 @@ final class DiffPaneLineNumberRulerView: NSRulerView {
 
     override func drawHashMarksAndLabels(in rect: NSRect) {
         guard let theme else { return }
-        NSColor(theme.color("bg-2")).setFill()
+        NSColor(theme.color("bg-0")).setFill()
         bounds.fill()
 
-        guard let scrollView, rowHeight > 0, !labels.isEmpty else { return }
+        guard let scrollView, !labels.isEmpty else { return }
         let visible = scrollView.contentView.bounds
-        let firstRow = max(0, Int(floor((visible.minY - contentTopInset) / rowHeight)))
-        let lastRow = min(labels.count - 1, Int(ceil((visible.maxY - contentTopInset) / rowHeight)))
-        guard firstRow <= lastRow else { return }
+        let rowRects = diffRowRects()
+        guard !rowRects.isEmpty else { return }
 
         let textHeight = ("8" as NSString).size(withAttributes: labelAttributes(for: "")).height
-        for index in firstRow...lastRow {
+        for index in rowRects.indices {
             let label = labels[index]
+            let sourceRowRect = rowRects[index]
+            guard sourceRowRect.intersects(visible) else { continue }
+            let y = sourceRowRect.minY - visible.minY
+            let rowRect = NSRect(x: 0, y: y, width: ruleThickness, height: sourceRowRect.height)
+            drawRowBackground(index: index, rowRect: rowRect, theme: theme)
             guard !label.isEmpty else { continue }
-            let y = contentTopInset + CGFloat(index) * rowHeight - visible.minY
             let drawRect = NSRect(
                 x: 0,
-                y: y + max((rowHeight - textHeight) / 2, 0),
+                y: y + max((sourceRowRect.height - textHeight) / 2, 0),
                 width: ruleThickness - horizontalPadding,
                 height: textHeight
             )
             NSString(string: label).draw(in: drawRect, withAttributes: labelAttributes(for: label))
+        }
+    }
+
+    func diffRowRects() -> [NSRect] {
+        if let textView = scrollView?.documentView as? DiffPaneCodeTextView {
+            return textView.diffRowRects().prefix(labels.count).map { rect in
+                NSRect(x: 0, y: rect.minY, width: ruleThickness, height: rect.height)
+            }
+        }
+        return labels.indices.map { index in
+            NSRect(
+                x: 0,
+                y: contentTopInset + CGFloat(index) * rowHeight,
+                width: ruleThickness,
+                height: rowHeight
+            )
         }
     }
 
@@ -443,6 +618,40 @@ final class DiffPaneLineNumberRulerView: NSRulerView {
             .foregroundColor: color,
             .paragraphStyle: paragraph,
         ]
+    }
+
+    private func drawRowBackground(index: Int, rowRect: NSRect, theme: Theme) {
+        guard lineTones.indices.contains(index) else { return }
+        let tone = lineTones[index]
+        let fill: NSColor
+        switch tone {
+        case .add:
+            fill = NSColor(theme.color("add")).withAlphaComponent(0.16)
+        case .delete:
+            fill = NSColor(theme.color("del")).withAlphaComponent(0.16)
+        case .placeholder:
+            fill = NSColor(theme.color("bg-2")).withAlphaComponent(0.55)
+        case .collapsed:
+            fill = NSColor(theme.color("bg-3")).withAlphaComponent(0.72)
+        case .context:
+            fill = .clear
+        }
+        fill.setFill()
+        rowRect.fill()
+
+        let railColor: NSColor?
+        switch tone {
+        case .add:
+            railColor = NSColor(theme.color("add"))
+        case .delete:
+            railColor = NSColor(theme.color("del"))
+        default:
+            railColor = nil
+        }
+        if let railColor {
+            railColor.setFill()
+            NSRect(x: 0, y: rowRect.minY, width: 3, height: rowRect.height).fill()
+        }
     }
 
     deinit {

--- a/Alas/Sources/Center/Diff/DiffPaneTextDocumentView.swift
+++ b/Alas/Sources/Center/Diff/DiffPaneTextDocumentView.swift
@@ -31,49 +31,28 @@ struct DiffPaneTextDocumentView: NSViewRepresentable {
 }
 
 final class DiffPaneTextDocumentContainerView: NSView {
-    private static let unwrappedTextContainerWidth: CGFloat = 1_000_000
-
-    private let oldGutterView = DiffPaneTextDocumentContainerView.makeTextView(selectable: false)
-    private let oldCodeView = DiffPaneTextDocumentContainerView.makeTextView(selectable: true)
-    private let newGutterView = DiffPaneTextDocumentContainerView.makeTextView(selectable: false)
-    private let newCodeView = DiffPaneTextDocumentContainerView.makeTextView(selectable: true)
-    private let stackedGutterView = DiffPaneTextDocumentContainerView.makeTextView(selectable: false)
-    private let stackedCodeView = DiffPaneTextDocumentContainerView.makeTextView(selectable: true)
+    private let oldPane = DiffPaneTextScrollView()
+    private let newPane = DiffPaneTextScrollView()
+    private let stackedPane = DiffPaneTextScrollView()
     private let dividerView = NSView()
 
     private var layoutMode: DiffLayoutMode = .split
-    private var wrapLines = false
-    private var font: NSFont = .monospacedSystemFont(ofSize: 13, weight: .regular)
-    private var splitLineCount = 0
-    private var stackedLineCount = 0
     private var measuredHeight: CGFloat = 0
-    private var measuredStackedWidth: CGFloat = 0
 
-    private let horizontalPadding: CGFloat = 12
-    private let gutterWidth: CGFloat = 48
-    private let columnGap: CGFloat = 10
-    private let codeGap: CGFloat = 8
     private let dividerWidth: CGFloat = 1
-    private let verticalInset = CenterTypography.rowVerticalPadding + 5
 
     override var isFlipped: Bool { true }
 
     override var intrinsicContentSize: NSSize {
-        NSSize(
-            width: layoutMode == .stacked && !wrapLines ? intrinsicStackedWidth : NSView.noIntrinsicMetric,
-            height: intrinsicHeight
-        )
+        NSSize(width: NSView.noIntrinsicMetric, height: measuredHeight)
     }
 
     override init(frame frameRect: NSRect) {
         super.init(frame: frameRect)
         wantsLayer = true
-        addSubview(oldGutterView)
-        addSubview(oldCodeView)
-        addSubview(newGutterView)
-        addSubview(newCodeView)
-        addSubview(stackedGutterView)
-        addSubview(stackedCodeView)
+        addSubview(oldPane)
+        addSubview(newPane)
+        addSubview(stackedPane)
         addSubview(dividerView)
     }
 
@@ -92,11 +71,9 @@ final class DiffPaneTextDocumentContainerView: NSView {
         theme: Theme
     ) {
         self.layoutMode = layoutMode
-        self.wrapLines = wrapLines
-        self.font = font
         layer?.backgroundColor = NSColor(theme.color("bg-1")).cgColor
-        dividerView.layer?.backgroundColor = NSColor(theme.color("line")).cgColor
         dividerView.wantsLayer = true
+        dividerView.layer?.backgroundColor = NSColor(theme.color("line")).cgColor
 
         switch layoutMode {
         case .split:
@@ -108,12 +85,21 @@ final class DiffPaneTextDocumentContainerView: NSView {
                 showWhitespace: showWhitespace,
                 theme: theme
             )
-            oldCodeView.textStorage?.setAttributedString(result.oldCode.attributedString)
-            oldGutterView.textStorage?.setAttributedString(result.oldGutter)
-            newCodeView.textStorage?.setAttributedString(result.newCode.attributedString)
-            newGutterView.textStorage?.setAttributedString(result.newGutter)
-            splitLineCount = max(result.oldCode.lines.count, result.newCode.lines.count)
-            stackedLineCount = 0
+            oldPane.update(
+                document: result.oldCode,
+                lineLabels: lineLabels(from: result.oldGutter),
+                wraps: wrapLines,
+                font: font,
+                theme: theme
+            )
+            newPane.update(
+                document: result.newCode,
+                lineLabels: lineLabels(from: result.newGutter),
+                wraps: wrapLines,
+                font: font,
+                theme: theme
+            )
+            measuredHeight = max(oldPane.documentHeight, newPane.documentHeight)
         case .stacked:
             let result = DiffPaneTextDocumentBuilder.buildStacked(
                 group: group,
@@ -123,15 +109,16 @@ final class DiffPaneTextDocumentContainerView: NSView {
                 showWhitespace: showWhitespace,
                 theme: theme
             )
-            stackedCodeView.textStorage?.setAttributedString(result.code.attributedString)
-            stackedGutterView.textStorage?.setAttributedString(result.gutter)
-            stackedLineCount = result.code.lines.count
-            splitLineCount = 0
+            stackedPane.update(
+                document: result.code,
+                lineLabels: lineLabels(from: result.gutter),
+                wraps: wrapLines,
+                font: font,
+                theme: theme
+            )
+            measuredHeight = stackedPane.documentHeight
         }
 
-        oldCodeView.insertionPointColor = NSColor(theme.color("fg"))
-        newCodeView.insertionPointColor = NSColor(theme.color("fg"))
-        stackedCodeView.insertionPointColor = NSColor(theme.color("fg"))
         updateVisibility()
         needsLayout = true
         invalidateIntrinsicContentSize()
@@ -150,128 +137,59 @@ final class DiffPaneTextDocumentContainerView: NSView {
     }
 
     private func layoutSplit() {
-        let availableWidth = max(bounds.width - horizontalPadding * 2 - columnGap - dividerWidth, 240)
-        let columnWidth = floor(availableWidth / 2)
-        let codeWidth = max(columnWidth - gutterWidth - codeGap, 40)
-        let oldX = horizontalPadding
-        let newX = horizontalPadding + columnWidth + columnGap + dividerWidth
-        let preferredHeight = lineCountHeight(splitLineCount)
+        let width = max(bounds.width, 1)
+        let paneWidth = floor((width - dividerWidth) / 2)
+        oldPane.frame = NSRect(x: 0, y: 0, width: paneWidth, height: max(bounds.height, measuredHeight))
+        dividerView.frame = NSRect(x: paneWidth, y: 0, width: dividerWidth, height: max(bounds.height, measuredHeight))
+        newPane.frame = NSRect(x: paneWidth + dividerWidth, y: 0, width: width - paneWidth - dividerWidth, height: max(bounds.height, measuredHeight))
 
-        configureTextView(oldGutterView, wraps: false, width: gutterWidth)
-        configureTextView(oldCodeView, wraps: false, width: codeWidth)
-        configureTextView(newGutterView, wraps: false, width: gutterWidth)
-        configureTextView(newCodeView, wraps: false, width: codeWidth)
-
-        let contentHeight = max(
-            preferredHeight,
-            measuredTextHeight(oldCodeView),
-            measuredTextHeight(newCodeView),
-            measuredTextHeight(oldGutterView),
-            measuredTextHeight(newGutterView)
-        )
-
-        oldGutterView.frame = NSRect(x: oldX, y: verticalInset, width: gutterWidth, height: contentHeight)
-        oldCodeView.frame = NSRect(x: oldX + gutterWidth + codeGap, y: verticalInset, width: codeWidth, height: contentHeight)
-        dividerView.frame = NSRect(
-            x: horizontalPadding + columnWidth + floor(columnGap / 2),
-            y: 0,
-            width: dividerWidth,
-            height: contentHeight + verticalInset * 2
-        )
-        newGutterView.frame = NSRect(x: newX, y: verticalInset, width: gutterWidth, height: contentHeight)
-        newCodeView.frame = NSRect(x: newX + gutterWidth + codeGap, y: verticalInset, width: codeWidth, height: contentHeight)
-        measuredHeight = contentHeight + verticalInset * 2
-        measuredStackedWidth = 0
+        oldPane.layoutSubtreeIfNeeded()
+        newPane.layoutSubtreeIfNeeded()
+        measuredHeight = max(oldPane.documentHeight, newPane.documentHeight)
+        oldPane.frame.size.height = measuredHeight
+        newPane.frame.size.height = measuredHeight
+        dividerView.frame.size.height = measuredHeight
     }
 
     private func layoutStacked() {
-        let codeX = horizontalPadding + gutterWidth + codeGap
-        let codeWidth = max(bounds.width - codeX - horizontalPadding, 80)
-        let wraps = wrapLines
-
-        configureTextView(stackedGutterView, wraps: false, width: gutterWidth)
-        configureTextView(stackedCodeView, wraps: wraps, width: codeWidth)
-
-        let contentHeight = max(
-            lineCountHeight(stackedLineCount),
-            measuredTextHeight(stackedCodeView),
-            measuredTextHeight(stackedGutterView)
-        )
-        let measuredCodeWidth = measuredTextWidth(stackedCodeView)
-
-        stackedGutterView.frame = NSRect(x: horizontalPadding, y: verticalInset, width: gutterWidth, height: contentHeight)
-        stackedCodeView.frame = NSRect(
-            x: codeX,
-            y: verticalInset,
-            width: wraps ? codeWidth : max(codeWidth, measuredCodeWidth),
-            height: contentHeight
-        )
-        measuredHeight = contentHeight + verticalInset * 2
-        measuredStackedWidth = codeX + (wraps ? codeWidth : measuredCodeWidth) + horizontalPadding
-    }
-
-    private func configureTextView(_ textView: NSTextView, wraps: Bool, width: CGFloat) {
-        textView.font = font
-        textView.isHorizontallyResizable = !wraps
-        textView.isVerticallyResizable = true
-        textView.minSize = .zero
-        textView.maxSize = NSSize(
-            width: wraps ? width : Self.unwrappedTextContainerWidth,
-            height: CGFloat.greatestFiniteMagnitude
-        )
-        textView.textContainer?.widthTracksTextView = wraps
-        textView.textContainer?.heightTracksTextView = false
-        textView.textContainer?.containerSize = NSSize(
-            width: wraps ? width : Self.unwrappedTextContainerWidth,
-            height: CGFloat.greatestFiniteMagnitude
-        )
+        stackedPane.frame = NSRect(x: 0, y: 0, width: max(bounds.width, 1), height: max(bounds.height, measuredHeight))
+        stackedPane.layoutSubtreeIfNeeded()
+        measuredHeight = stackedPane.documentHeight
+        stackedPane.frame.size.height = measuredHeight
     }
 
     private func updateVisibility() {
         let split = layoutMode == .split
-        oldGutterView.isHidden = !split
-        oldCodeView.isHidden = !split
-        newGutterView.isHidden = !split
-        newCodeView.isHidden = !split
+        oldPane.isHidden = !split
+        newPane.isHidden = !split
         dividerView.isHidden = !split
-        stackedGutterView.isHidden = split
-        stackedCodeView.isHidden = split
+        stackedPane.isHidden = split
     }
 
-    private var intrinsicHeight: CGFloat {
-        max(measuredHeight, lineCountHeight(max(splitLineCount, stackedLineCount)) + verticalInset * 2)
+    private func lineLabels(from attributedString: NSAttributedString) -> [String] {
+        attributedString.string.components(separatedBy: "\n")
+    }
+}
+
+final class DiffPaneTextScrollView: NSScrollView {
+    private static let unwrappedTextContainerWidth: CGFloat = 1_000_000
+
+    private let textView: NSTextView
+    private var lineLabels: [String] = []
+    private var rowKinds: [DiffDisplayRow.Kind] = []
+    private var wraps = false
+    private var font: NSFont = .monospacedSystemFont(ofSize: 13, weight: .regular)
+    private var theme: Theme?
+
+    var documentHeight: CGFloat {
+        max(measuredTextHeight() + textView.textContainerInset.height * 2, fallbackTextHeight())
     }
 
-    private var intrinsicStackedWidth: CGFloat {
-        max(measuredStackedWidth, bounds.width)
-    }
-
-    private func lineCountHeight(_ count: Int) -> CGFloat {
-        guard count > 0 else { return 0 }
-        return CGFloat(count) * NSLayoutManager().defaultLineHeight(for: font)
-    }
-
-    private func measuredTextHeight(_ textView: NSTextView) -> CGFloat {
-        guard let layoutManager = textView.layoutManager, let textContainer = textView.textContainer else {
-            return 0
-        }
-        layoutManager.ensureLayout(for: textContainer)
-        return ceil(layoutManager.usedRect(for: textContainer).height)
-    }
-
-    private func measuredTextWidth(_ textView: NSTextView) -> CGFloat {
-        guard let layoutManager = textView.layoutManager, let textContainer = textView.textContainer else {
-            return 0
-        }
-        layoutManager.ensureLayout(for: textContainer)
-        return ceil(layoutManager.usedRect(for: textContainer).width)
-    }
-
-    private static func makeTextView(selectable: Bool) -> NSTextView {
+    override init(frame frameRect: NSRect) {
         let storage = NSTextStorage()
         let layoutManager = NSLayoutManager()
         let container = NSTextContainer(size: NSSize(
-            width: unwrappedTextContainerWidth,
+            width: Self.unwrappedTextContainerWidth,
             height: CGFloat.greatestFiniteMagnitude
         ))
         container.lineFragmentPadding = 0
@@ -280,13 +198,28 @@ final class DiffPaneTextDocumentContainerView: NSView {
         layoutManager.addTextContainer(container)
         storage.addLayoutManager(layoutManager)
 
-        let textView = NSTextView(frame: .zero, textContainer: container)
+        textView = NSTextView(frame: .zero, textContainer: container)
+        super.init(frame: frameRect)
+
+        drawsBackground = false
+        borderType = .noBorder
+        hasVerticalScroller = false
+        hasHorizontalScroller = true
+        autohidesScrollers = true
+        scrollerStyle = .overlay
+        documentView = textView
+        hasVerticalRuler = true
+        rulersVisible = true
+        verticalRulerView = DiffPaneLineNumberRulerView(scrollView: self)
+
         textView.isEditable = false
-        textView.isSelectable = selectable
+        textView.isSelectable = true
         textView.isRichText = false
-        textView.drawsBackground = false
-        textView.backgroundColor = .clear
-        textView.textContainerInset = .zero
+        textView.isVerticallyResizable = true
+        textView.isHorizontallyResizable = true
+        textView.drawsBackground = true
+        textView.textContainerInset = NSSize(width: 6, height: 6)
+        textView.autoresizingMask = [.width]
         textView.allowsUndo = false
         textView.isAutomaticQuoteSubstitutionEnabled = false
         textView.isAutomaticDashSubstitutionEnabled = false
@@ -295,6 +228,226 @@ final class DiffPaneTextDocumentContainerView: NSView {
         textView.isContinuousSpellCheckingEnabled = false
         textView.isGrammarCheckingEnabled = false
         textView.smartInsertDeleteEnabled = false
-        return textView
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("not used")
+    }
+
+    func update(
+        document: DiffPaneTextDocumentBuilder.CodeDocument,
+        lineLabels: [String],
+        wraps: Bool,
+        font: NSFont,
+        theme: Theme
+    ) {
+        self.lineLabels = lineLabels
+        self.rowKinds = document.lines.map(\.kind)
+        self.wraps = wraps
+        self.font = font
+        self.theme = theme
+
+        textView.textStorage?.setAttributedString(document.attributedString)
+        textView.font = font
+        textView.backgroundColor = NSColor(theme.color("bg-1"))
+        textView.insertionPointColor = NSColor(theme.color("fg"))
+
+        if let ruler = verticalRulerView as? DiffPaneLineNumberRulerView {
+            ruler.update(
+                labels: lineLabels,
+                rowKinds: rowKinds,
+                rowHeight: lineHeight(),
+                contentTopInset: textView.textContainerInset.height,
+                theme: theme
+            )
+        }
+
+        needsLayout = true
+        invalidateIntrinsicContentSize()
+    }
+
+    override func layout() {
+        super.layout()
+        configureTextContainer()
+        textView.frame = NSRect(
+            x: 0,
+            y: 0,
+            width: textViewWidth(),
+            height: documentHeight
+        )
+        (verticalRulerView as? DiffPaneLineNumberRulerView)?.rowHeight = lineHeight()
+    }
+
+    override func scrollWheel(with event: NSEvent) {
+        if abs(event.scrollingDeltaY) > abs(event.scrollingDeltaX) {
+            nextResponder?.scrollWheel(with: event)
+            return
+        }
+        super.scrollWheel(with: event)
+    }
+
+    private func configureTextContainer() {
+        let contentWidth = max(contentView.bounds.width - textView.textContainerInset.width * 2, 1)
+        textView.isHorizontallyResizable = !wraps
+        textView.minSize = .zero
+        textView.maxSize = NSSize(
+            width: wraps ? contentWidth : Self.unwrappedTextContainerWidth,
+            height: CGFloat.greatestFiniteMagnitude
+        )
+        textView.textContainer?.widthTracksTextView = wraps
+        textView.textContainer?.heightTracksTextView = false
+        textView.textContainer?.containerSize = NSSize(
+            width: wraps ? contentWidth : Self.unwrappedTextContainerWidth,
+            height: CGFloat.greatestFiniteMagnitude
+        )
+    }
+
+    private func textViewWidth() -> CGFloat {
+        let contentWidth = max(contentView.bounds.width, 1)
+        if wraps {
+            return contentWidth
+        }
+        return max(contentWidth, measuredTextWidth() + textView.textContainerInset.width * 2)
+    }
+
+    private func measuredTextHeight() -> CGFloat {
+        guard let layoutManager = textView.layoutManager, let textContainer = textView.textContainer else {
+            return 0
+        }
+        layoutManager.ensureLayout(for: textContainer)
+        return ceil(layoutManager.usedRect(for: textContainer).height)
+    }
+
+    private func measuredTextWidth() -> CGFloat {
+        guard let layoutManager = textView.layoutManager, let textContainer = textView.textContainer else {
+            return 0
+        }
+        layoutManager.ensureLayout(for: textContainer)
+        return ceil(layoutManager.usedRect(for: textContainer).width)
+    }
+
+    private func fallbackTextHeight() -> CGFloat {
+        CGFloat(max(lineLabels.count, 1)) * lineHeight() + textView.textContainerInset.height * 2
+    }
+
+    private func lineHeight() -> CGFloat {
+        ceil(font.ascender + abs(font.descender) + font.leading)
+    }
+}
+
+final class DiffPaneLineNumberRulerView: NSRulerView {
+    private var labels: [String] = []
+    private var rowKinds: [DiffDisplayRow.Kind] = []
+    private var theme: Theme?
+    var rowHeight: CGFloat = 16
+    private var contentTopInset: CGFloat = 6
+    private var boundsObserver: NSObjectProtocol?
+
+    private let minimumThickness: CGFloat = 42
+    private let horizontalPadding: CGFloat = 8
+
+    init(scrollView: NSScrollView) {
+        super.init(scrollView: scrollView, orientation: .verticalRuler)
+        ruleThickness = minimumThickness
+        reservedThicknessForMarkers = 0
+        reservedThicknessForAccessoryView = 0
+        observe(scrollView: scrollView)
+    }
+
+    required init(coder: NSCoder) {
+        fatalError("not used")
+    }
+
+    override var isFlipped: Bool { true }
+
+    func update(
+        labels: [String],
+        rowKinds: [DiffDisplayRow.Kind],
+        rowHeight: CGFloat,
+        contentTopInset: CGFloat,
+        theme: Theme
+    ) {
+        self.labels = labels
+        self.rowKinds = rowKinds
+        self.rowHeight = rowHeight
+        self.contentTopInset = contentTopInset
+        self.theme = theme
+        updateThickness()
+        needsDisplay = true
+    }
+
+    override func drawHashMarksAndLabels(in rect: NSRect) {
+        guard let theme else { return }
+        NSColor(theme.color("bg-2")).setFill()
+        bounds.fill()
+
+        guard let scrollView, rowHeight > 0, !labels.isEmpty else { return }
+        let visible = scrollView.contentView.bounds
+        let firstRow = max(0, Int(floor((visible.minY - contentTopInset) / rowHeight)))
+        let lastRow = min(labels.count - 1, Int(ceil((visible.maxY - contentTopInset) / rowHeight)))
+        guard firstRow <= lastRow else { return }
+
+        let textHeight = ("8" as NSString).size(withAttributes: labelAttributes(for: "")).height
+        for index in firstRow...lastRow {
+            let label = labels[index]
+            guard !label.isEmpty else { continue }
+            let y = contentTopInset + CGFloat(index) * rowHeight - visible.minY
+            let drawRect = NSRect(
+                x: 0,
+                y: y + max((rowHeight - textHeight) / 2, 0),
+                width: ruleThickness - horizontalPadding,
+                height: textHeight
+            )
+            NSString(string: label).draw(in: drawRect, withAttributes: labelAttributes(for: label))
+        }
+    }
+
+    private func observe(scrollView: NSScrollView) {
+        scrollView.contentView.postsBoundsChangedNotifications = true
+        boundsObserver = NotificationCenter.default.addObserver(
+            forName: NSView.boundsDidChangeNotification,
+            object: scrollView.contentView,
+            queue: .main
+        ) { [weak self] _ in
+            self?.needsDisplay = true
+        }
+    }
+
+    private func updateThickness() {
+        let maxDigits = labels
+            .map { $0.trimmingCharacters(in: CharacterSet(charactersIn: "+- ")) }
+            .map(\.count)
+            .max() ?? 1
+        let sample = String(repeating: "8", count: max(maxDigits, 1)) as NSString
+        let width = ceil(sample.size(withAttributes: labelAttributes(for: "")).width)
+        ruleThickness = max(minimumThickness, width + horizontalPadding * 2)
+    }
+
+    private func labelAttributes(for label: String) -> [NSAttributedString.Key: Any] {
+        let paragraph = NSMutableParagraphStyle()
+        paragraph.alignment = .right
+        let color: NSColor
+        if let theme {
+            if label.hasPrefix("+") {
+                color = NSColor(theme.color("add"))
+            } else if label.hasPrefix("-") {
+                color = NSColor(theme.color("del"))
+            } else {
+                color = NSColor(theme.color("fg-faint"))
+            }
+        } else {
+            color = .secondaryLabelColor
+        }
+        return [
+            .font: NSFont.monospacedSystemFont(ofSize: 10, weight: .regular),
+            .foregroundColor: color,
+            .paragraphStyle: paragraph,
+        ]
+    }
+
+    deinit {
+        if let boundsObserver {
+            NotificationCenter.default.removeObserver(boundsObserver)
+        }
     }
 }

--- a/Alas/Sources/Center/Diff/DiffPaneTextDocumentView.swift
+++ b/Alas/Sources/Center/Diff/DiffPaneTextDocumentView.swift
@@ -429,6 +429,10 @@ enum DiffPaneLineTone: Equatable {
 }
 
 final class DiffPaneCodeTextView: NSTextView {
+    static func placeholderHatchRect(in rowRect: NSRect) -> NSRect {
+        rowRect.insetBy(dx: 0, dy: 1)
+    }
+
     var lineTones: [DiffPaneLineTone] = [] {
         didSet { needsDisplay = true }
     }
@@ -542,12 +546,17 @@ final class DiffPaneCodeTextView: NSTextView {
     }
 
     private func drawPlaceholderHatch(in rect: NSRect, theme: Theme) {
+        let hatchRect = Self.placeholderHatchRect(in: rect)
+        NSGraphicsContext.saveGraphicsState()
+        NSBezierPath(rect: hatchRect).addClip()
+        defer { NSGraphicsContext.restoreGraphicsState() }
+
         let path = NSBezierPath()
         let spacing: CGFloat = 8
-        var x = rect.minX - rect.height
-        while x < rect.maxX {
-            path.move(to: NSPoint(x: x, y: rect.maxY))
-            path.line(to: NSPoint(x: x + rect.height, y: rect.minY))
+        var x = hatchRect.minX - hatchRect.height
+        while x < hatchRect.maxX {
+            path.move(to: NSPoint(x: x, y: hatchRect.maxY))
+            path.line(to: NSPoint(x: x + hatchRect.height, y: hatchRect.minY))
             x += spacing
         }
         path.lineWidth = 1

--- a/Alas/Sources/Center/Diff/DiffPaneTextDocumentView.swift
+++ b/Alas/Sources/Center/Diff/DiffPaneTextDocumentView.swift
@@ -145,10 +145,26 @@ final class DiffPaneTextDocumentContainerView: NSView {
 
         oldPane.layoutSubtreeIfNeeded()
         newPane.layoutSubtreeIfNeeded()
+        synchronizeSplitRowHeights()
         measuredHeight = max(oldPane.documentHeight, newPane.documentHeight)
         oldPane.frame.size.height = measuredHeight
         newPane.frame.size.height = measuredHeight
         dividerView.frame.size.height = measuredHeight
+    }
+
+    private func synchronizeSplitRowHeights() {
+        let oldRows = oldPane.diffRowRects()
+        let newRows = newPane.diffRowRects()
+        let count = min(oldRows.count, newRows.count)
+        guard count > 0 else { return }
+
+        let rowHeights = (0..<count).map { index in
+            max(oldRows[index].height, newRows[index].height)
+        }
+        oldPane.synchronizeRowHeights(rowHeights)
+        newPane.synchronizeRowHeights(rowHeights)
+        oldPane.layoutSubtreeIfNeeded()
+        newPane.layoutSubtreeIfNeeded()
     }
 
     private func layoutStacked() {
@@ -178,6 +194,8 @@ final class DiffPaneTextScrollView: NSScrollView {
     private var lineLabels: [String] = []
     private var rowKinds: [DiffDisplayRow.Kind] = []
     private var lineTones: [DiffPaneLineTone] = []
+    private var baseDocument: DiffPaneTextDocumentBuilder.CodeDocument?
+    private var synchronizedRowHeights: [CGFloat] = []
     private var wraps = false
     private var font: NSFont = .monospacedSystemFont(ofSize: 13, weight: .regular)
     private var theme: Theme?
@@ -248,6 +266,8 @@ final class DiffPaneTextScrollView: NSScrollView {
         self.lineTones = zip(lineLabels, rowKinds).map { label, kind in
             DiffPaneLineTone(label: label, rowKind: kind)
         }
+        self.baseDocument = document
+        self.synchronizedRowHeights = []
         self.wraps = wraps
         self.font = font
         self.theme = theme
@@ -270,6 +290,51 @@ final class DiffPaneTextScrollView: NSScrollView {
 
         needsLayout = true
         invalidateIntrinsicContentSize()
+    }
+
+    func diffRowRects() -> [NSRect] {
+        textView.diffRowRects()
+    }
+
+    func synchronizeRowHeights(_ rowHeights: [CGFloat]) {
+        guard let baseDocument else { return }
+        guard rowHeights.count > 0 else { return }
+        guard rowHeights.count != synchronizedRowHeights.count
+            || zip(rowHeights, synchronizedRowHeights).contains(where: { abs($0.0 - $0.1) > 0.5 })
+        else {
+            return
+        }
+
+        let currentRows = textView.diffRowRects()
+        let synchronized = NSMutableAttributedString(attributedString: baseDocument.attributedString)
+        for index in 0..<min(rowHeights.count, baseDocument.lines.count, currentRows.count) {
+            let targetHeight = rowHeights[index]
+            let currentHeight = currentRows[index].height
+            guard targetHeight > currentHeight + 0.5 else { continue }
+
+            let range = baseDocument.lines[index].range
+            guard range.location < synchronized.length else { continue }
+            let paragraphRange = NSRange(location: range.location, length: max(range.length, 1))
+            let lineCount = max(1, Int(round(currentHeight / max(lineHeight(), 1))))
+            let targetLineHeight = targetHeight / CGFloat(lineCount)
+            let paragraph = NSMutableParagraphStyle()
+            if let existing = synchronized.attribute(.paragraphStyle, at: range.location, effectiveRange: nil) as? NSParagraphStyle {
+                paragraph.setParagraphStyle(existing)
+            } else {
+                paragraph.setParagraphStyle(CenterTypography.paragraphStyle())
+            }
+            paragraph.minimumLineHeight = targetLineHeight
+            paragraph.maximumLineHeight = targetLineHeight
+            synchronized.addAttribute(.paragraphStyle, value: paragraph, range: paragraphRange)
+        }
+
+        synchronizedRowHeights = rowHeights
+        textView.textStorage?.setAttributedString(synchronized)
+        textView.lineTones = lineTones
+        textView.theme = theme
+        needsLayout = true
+        invalidateIntrinsicContentSize()
+        (verticalRulerView as? DiffPaneLineNumberRulerView)?.needsDisplay = true
     }
 
     override func layout() {

--- a/Alas/Sources/Center/Diff/DiffPaneTextDocumentView.swift
+++ b/Alas/Sources/Center/Diff/DiffPaneTextDocumentView.swift
@@ -12,11 +12,11 @@ struct DiffPaneTextDocumentView: NSViewRepresentable {
     let codeFontSize: CGFloat
     let theme: Theme
 
-    func makeNSView(context: Context) -> DiffPaneTextDocumentScrollView {
-        DiffPaneTextDocumentScrollView()
+    func makeNSView(context: Context) -> DiffPaneTextDocumentContainerView {
+        DiffPaneTextDocumentContainerView()
     }
 
-    func updateNSView(_ nsView: DiffPaneTextDocumentScrollView, context: Context) {
+    func updateNSView(_ nsView: DiffPaneTextDocumentContainerView, context: Context) {
         nsView.update(
             group: group,
             expandedCollapsedRowIDs: expandedCollapsedRowIDs,
@@ -30,53 +30,51 @@ struct DiffPaneTextDocumentView: NSViewRepresentable {
     }
 }
 
-final class DiffPaneTextDocumentScrollView: NSScrollView {
+final class DiffPaneTextDocumentContainerView: NSView {
     private static let unwrappedTextContainerWidth: CGFloat = 1_000_000
 
-    private let textView: NSTextView
-    private var latestConfiguration: Configuration?
-    private var latestViewportWidth: CGFloat = 0
+    private let oldGutterView = DiffPaneTextDocumentContainerView.makeTextView(selectable: false)
+    private let oldCodeView = DiffPaneTextDocumentContainerView.makeTextView(selectable: true)
+    private let newGutterView = DiffPaneTextDocumentContainerView.makeTextView(selectable: false)
+    private let newCodeView = DiffPaneTextDocumentContainerView.makeTextView(selectable: true)
+    private let stackedGutterView = DiffPaneTextDocumentContainerView.makeTextView(selectable: false)
+    private let stackedCodeView = DiffPaneTextDocumentContainerView.makeTextView(selectable: true)
+    private let dividerView = NSView()
+
+    private var layoutMode: DiffLayoutMode = .split
+    private var wrapLines = false
+    private var font: NSFont = .monospacedSystemFont(ofSize: 13, weight: .regular)
+    private var splitLineCount = 0
+    private var stackedLineCount = 0
+    private var measuredHeight: CGFloat = 0
+    private var measuredStackedWidth: CGFloat = 0
+
+    private let horizontalPadding: CGFloat = 12
+    private let gutterWidth: CGFloat = 48
+    private let columnGap: CGFloat = 10
+    private let codeGap: CGFloat = 8
+    private let dividerWidth: CGFloat = 1
+    private let verticalInset = CenterTypography.rowVerticalPadding + 5
+
+    override var isFlipped: Bool { true }
 
     override var intrinsicContentSize: NSSize {
-        NSSize(width: NSView.noIntrinsicMetric, height: measuredTextHeight())
+        NSSize(
+            width: layoutMode == .stacked && !wrapLines ? intrinsicStackedWidth : NSView.noIntrinsicMetric,
+            height: intrinsicHeight
+        )
     }
 
     override init(frame frameRect: NSRect) {
-        let storage = NSTextStorage()
-        let layoutManager = NSLayoutManager()
-        let container = NSTextContainer(size: NSSize(
-            width: Self.unwrappedTextContainerWidth,
-            height: CGFloat.greatestFiniteMagnitude
-        ))
-        container.lineFragmentPadding = 0
-        container.widthTracksTextView = false
-        layoutManager.addTextContainer(container)
-        storage.addLayoutManager(layoutManager)
-
-        textView = NSTextView(frame: .zero, textContainer: container)
         super.init(frame: frameRect)
-
-        drawsBackground = false
-        borderType = .noBorder
-        hasVerticalScroller = false
-        autohidesScrollers = true
-        scrollerStyle = .overlay
-        documentView = textView
-
-        textView.isEditable = false
-        textView.isSelectable = true
-        textView.isRichText = false
-        textView.drawsBackground = false
-        textView.backgroundColor = .clear
-        textView.textContainerInset = NSSize(width: 12, height: 6)
-        textView.allowsUndo = false
-        textView.isAutomaticQuoteSubstitutionEnabled = false
-        textView.isAutomaticDashSubstitutionEnabled = false
-        textView.isAutomaticTextReplacementEnabled = false
-        textView.isAutomaticSpellingCorrectionEnabled = false
-        textView.isContinuousSpellCheckingEnabled = false
-        textView.isGrammarCheckingEnabled = false
-        textView.smartInsertDeleteEnabled = false
+        wantsLayer = true
+        addSubview(oldGutterView)
+        addSubview(oldCodeView)
+        addSubview(newGutterView)
+        addSubview(newCodeView)
+        addSubview(stackedGutterView)
+        addSubview(stackedCodeView)
+        addSubview(dividerView)
     }
 
     required init?(coder: NSCoder) {
@@ -93,109 +91,210 @@ final class DiffPaneTextDocumentScrollView: NSScrollView {
         font: NSFont,
         theme: Theme
     ) {
-        latestConfiguration = Configuration(
-            group: group,
-            expandedCollapsedRowIDs: expandedCollapsedRowIDs,
-            layoutMode: layoutMode,
-            wrapLines: wrapLines,
-            showWhitespace: showWhitespace,
-            fileExtension: fileExtension,
-            font: font,
-            theme: theme
-        )
-        applyLatestConfiguration()
+        self.layoutMode = layoutMode
+        self.wrapLines = wrapLines
+        self.font = font
+        layer?.backgroundColor = NSColor(theme.color("bg-1")).cgColor
+        dividerView.layer?.backgroundColor = NSColor(theme.color("line")).cgColor
+        dividerView.wantsLayer = true
+
+        switch layoutMode {
+        case .split:
+            let result = DiffPaneTextDocumentBuilder.buildSplit(
+                group: group,
+                expandedCollapsedRowIDs: expandedCollapsedRowIDs,
+                fileExtension: fileExtension,
+                font: font,
+                showWhitespace: showWhitespace,
+                theme: theme
+            )
+            oldCodeView.textStorage?.setAttributedString(result.oldCode.attributedString)
+            oldGutterView.textStorage?.setAttributedString(result.oldGutter)
+            newCodeView.textStorage?.setAttributedString(result.newCode.attributedString)
+            newGutterView.textStorage?.setAttributedString(result.newGutter)
+            splitLineCount = max(result.oldCode.lines.count, result.newCode.lines.count)
+            stackedLineCount = 0
+        case .stacked:
+            let result = DiffPaneTextDocumentBuilder.buildStacked(
+                group: group,
+                expandedCollapsedRowIDs: expandedCollapsedRowIDs,
+                fileExtension: fileExtension,
+                font: font,
+                showWhitespace: showWhitespace,
+                theme: theme
+            )
+            stackedCodeView.textStorage?.setAttributedString(result.code.attributedString)
+            stackedGutterView.textStorage?.setAttributedString(result.gutter)
+            stackedLineCount = result.code.lines.count
+            splitLineCount = 0
+        }
+
+        oldCodeView.insertionPointColor = NSColor(theme.color("fg"))
+        newCodeView.insertionPointColor = NSColor(theme.color("fg"))
+        stackedCodeView.insertionPointColor = NSColor(theme.color("fg"))
+        updateVisibility()
+        needsLayout = true
+        invalidateIntrinsicContentSize()
     }
 
     override func layout() {
         super.layout()
-        if abs(contentView.bounds.width - latestViewportWidth) > 1 {
-            applyLatestConfiguration()
-        } else {
-            updateTextLayout()
+        updateVisibility()
+        switch layoutMode {
+        case .split:
+            layoutSplit()
+        case .stacked:
+            layoutStacked()
         }
-    }
-
-    private func applyLatestConfiguration() {
-        guard let config = latestConfiguration else { return }
-        latestViewportWidth = contentView.bounds.width
-        hasHorizontalScroller = config.layoutMode == .stacked && !config.wrapLines
-
-        let document = DiffPaneTextDocumentBuilder.build(
-            group: config.group,
-            expandedCollapsedRowIDs: config.expandedCollapsedRowIDs,
-            layoutMode: config.layoutMode,
-            fileExtension: config.fileExtension,
-            font: config.font,
-            showWhitespace: config.showWhitespace,
-            theme: config.theme,
-            splitColumnCharacterWidth: splitColumnCharacterWidth(font: config.font)
-        )
-        textView.textStorage?.setAttributedString(document.attributedString)
-        textView.insertionPointColor = NSColor(config.theme.color("fg"))
-        updateTextLayout()
         invalidateIntrinsicContentSize()
     }
 
-    private func updateTextLayout() {
-        guard let config = latestConfiguration else { return }
-        let wraps = config.wrapLines || config.layoutMode == .split
-        let viewportWidth = max(contentView.bounds.width, 1)
+    private func layoutSplit() {
+        let availableWidth = max(bounds.width - horizontalPadding * 2 - columnGap - dividerWidth, 240)
+        let columnWidth = floor(availableWidth / 2)
+        let codeWidth = max(columnWidth - gutterWidth - codeGap, 40)
+        let oldX = horizontalPadding
+        let newX = horizontalPadding + columnWidth + columnGap + dividerWidth
+        let preferredHeight = lineCountHeight(splitLineCount)
 
+        configureTextView(oldGutterView, wraps: false, width: gutterWidth)
+        configureTextView(oldCodeView, wraps: false, width: codeWidth)
+        configureTextView(newGutterView, wraps: false, width: gutterWidth)
+        configureTextView(newCodeView, wraps: false, width: codeWidth)
+
+        let contentHeight = max(
+            preferredHeight,
+            measuredTextHeight(oldCodeView),
+            measuredTextHeight(newCodeView),
+            measuredTextHeight(oldGutterView),
+            measuredTextHeight(newGutterView)
+        )
+
+        oldGutterView.frame = NSRect(x: oldX, y: verticalInset, width: gutterWidth, height: contentHeight)
+        oldCodeView.frame = NSRect(x: oldX + gutterWidth + codeGap, y: verticalInset, width: codeWidth, height: contentHeight)
+        dividerView.frame = NSRect(
+            x: horizontalPadding + columnWidth + floor(columnGap / 2),
+            y: 0,
+            width: dividerWidth,
+            height: contentHeight + verticalInset * 2
+        )
+        newGutterView.frame = NSRect(x: newX, y: verticalInset, width: gutterWidth, height: contentHeight)
+        newCodeView.frame = NSRect(x: newX + gutterWidth + codeGap, y: verticalInset, width: codeWidth, height: contentHeight)
+        measuredHeight = contentHeight + verticalInset * 2
+        measuredStackedWidth = 0
+    }
+
+    private func layoutStacked() {
+        let codeX = horizontalPadding + gutterWidth + codeGap
+        let codeWidth = max(bounds.width - codeX - horizontalPadding, 80)
+        let wraps = wrapLines
+
+        configureTextView(stackedGutterView, wraps: false, width: gutterWidth)
+        configureTextView(stackedCodeView, wraps: wraps, width: codeWidth)
+
+        let contentHeight = max(
+            lineCountHeight(stackedLineCount),
+            measuredTextHeight(stackedCodeView),
+            measuredTextHeight(stackedGutterView)
+        )
+        let measuredCodeWidth = measuredTextWidth(stackedCodeView)
+
+        stackedGutterView.frame = NSRect(x: horizontalPadding, y: verticalInset, width: gutterWidth, height: contentHeight)
+        stackedCodeView.frame = NSRect(
+            x: codeX,
+            y: verticalInset,
+            width: wraps ? codeWidth : max(codeWidth, measuredCodeWidth),
+            height: contentHeight
+        )
+        measuredHeight = contentHeight + verticalInset * 2
+        measuredStackedWidth = codeX + (wraps ? codeWidth : measuredCodeWidth) + horizontalPadding
+    }
+
+    private func configureTextView(_ textView: NSTextView, wraps: Bool, width: CGFloat) {
+        textView.font = font
         textView.isHorizontallyResizable = !wraps
         textView.isVerticallyResizable = true
-        textView.minSize = NSSize(width: 0, height: 0)
+        textView.minSize = .zero
         textView.maxSize = NSSize(
-            width: wraps ? viewportWidth : Self.unwrappedTextContainerWidth,
+            width: wraps ? width : Self.unwrappedTextContainerWidth,
             height: CGFloat.greatestFiniteMagnitude
         )
         textView.textContainer?.widthTracksTextView = wraps
         textView.textContainer?.heightTracksTextView = false
         textView.textContainer?.containerSize = NSSize(
-            width: wraps ? viewportWidth - textView.textContainerInset.width * 2 : Self.unwrappedTextContainerWidth,
+            width: wraps ? width : Self.unwrappedTextContainerWidth,
             height: CGFloat.greatestFiniteMagnitude
         )
-        textView.frame = NSRect(
-            x: 0,
-            y: 0,
-            width: wraps ? viewportWidth : max(viewportWidth, measuredTextWidth()),
-            height: measuredTextHeight()
-        )
     }
 
-    private func measuredTextHeight() -> CGFloat {
+    private func updateVisibility() {
+        let split = layoutMode == .split
+        oldGutterView.isHidden = !split
+        oldCodeView.isHidden = !split
+        newGutterView.isHidden = !split
+        newCodeView.isHidden = !split
+        dividerView.isHidden = !split
+        stackedGutterView.isHidden = split
+        stackedCodeView.isHidden = split
+    }
+
+    private var intrinsicHeight: CGFloat {
+        max(measuredHeight, lineCountHeight(max(splitLineCount, stackedLineCount)) + verticalInset * 2)
+    }
+
+    private var intrinsicStackedWidth: CGFloat {
+        max(measuredStackedWidth, bounds.width)
+    }
+
+    private func lineCountHeight(_ count: Int) -> CGFloat {
+        guard count > 0 else { return 0 }
+        return CGFloat(count) * NSLayoutManager().defaultLineHeight(for: font)
+    }
+
+    private func measuredTextHeight(_ textView: NSTextView) -> CGFloat {
         guard let layoutManager = textView.layoutManager, let textContainer = textView.textContainer else {
             return 0
         }
         layoutManager.ensureLayout(for: textContainer)
-        let used = layoutManager.usedRect(for: textContainer)
-        return ceil(used.height + textView.textContainerInset.height * 2)
+        return ceil(layoutManager.usedRect(for: textContainer).height)
     }
 
-    private func measuredTextWidth() -> CGFloat {
+    private func measuredTextWidth(_ textView: NSTextView) -> CGFloat {
         guard let layoutManager = textView.layoutManager, let textContainer = textView.textContainer else {
             return 0
         }
         layoutManager.ensureLayout(for: textContainer)
-        let used = layoutManager.usedRect(for: textContainer)
-        return ceil(used.width + textView.textContainerInset.width * 2)
+        return ceil(layoutManager.usedRect(for: textContainer).width)
     }
 
-    private func splitColumnCharacterWidth(font: NSFont) -> Int {
-        let viewportWidth = max(latestViewportWidth, 320)
-        let characterWidth = max(("0" as NSString).size(withAttributes: [.font: font]).width, 1)
-        let halfPaneWidth = max((viewportWidth - 28) / 2, 120)
-        let prefixWidth: CGFloat = 8 * characterWidth
-        return max(Int((halfPaneWidth - prefixWidth) / characterWidth), 12)
-    }
+    private static func makeTextView(selectable: Bool) -> NSTextView {
+        let storage = NSTextStorage()
+        let layoutManager = NSLayoutManager()
+        let container = NSTextContainer(size: NSSize(
+            width: unwrappedTextContainerWidth,
+            height: CGFloat.greatestFiniteMagnitude
+        ))
+        container.lineFragmentPadding = 0
+        container.widthTracksTextView = false
+        container.heightTracksTextView = false
+        layoutManager.addTextContainer(container)
+        storage.addLayoutManager(layoutManager)
 
-    private struct Configuration {
-        let group: DiffDisplayGroup
-        let expandedCollapsedRowIDs: Set<String>
-        let layoutMode: DiffLayoutMode
-        let wrapLines: Bool
-        let showWhitespace: Bool
-        let fileExtension: String
-        let font: NSFont
-        let theme: Theme
+        let textView = NSTextView(frame: .zero, textContainer: container)
+        textView.isEditable = false
+        textView.isSelectable = selectable
+        textView.isRichText = false
+        textView.drawsBackground = false
+        textView.backgroundColor = .clear
+        textView.textContainerInset = .zero
+        textView.allowsUndo = false
+        textView.isAutomaticQuoteSubstitutionEnabled = false
+        textView.isAutomaticDashSubstitutionEnabled = false
+        textView.isAutomaticTextReplacementEnabled = false
+        textView.isAutomaticSpellingCorrectionEnabled = false
+        textView.isContinuousSpellCheckingEnabled = false
+        textView.isGrammarCheckingEnabled = false
+        textView.smartInsertDeleteEnabled = false
+        return textView
     }
 }

--- a/Alas/Sources/Center/Diff/DiffPaneView.swift
+++ b/Alas/Sources/Center/Diff/DiffPaneView.swift
@@ -1,0 +1,306 @@
+import SwiftUI
+
+struct DiffPaneHunkActions {
+    var stage: (() -> Void)?
+    var discard: (() -> Void)?
+    var dropFromCommit: (() -> Void)?
+}
+
+struct DiffPaneView: View {
+    let model: DiffDisplayModel
+    let fileExtension: String
+    @Binding var layoutMode: DiffLayoutMode
+    @Binding var wrapLines: Bool
+    @Binding var showWhitespace: Bool
+    let codeFontFamily: String
+    let codeFontSize: CGFloat
+    let hunkActions: (ParsedDiff.Hunk) -> DiffPaneHunkActions
+
+    @Environment(\.theme) private var theme
+    @State private var selection: DiffSelectionRange?
+    @State private var draftAnchor: DiffLineAnchor?
+
+    var body: some View {
+        VStack(spacing: 0) {
+            toolbar
+            ScrollView(.vertical) {
+                LazyVStack(alignment: .leading, spacing: 0) {
+                    ForEach(model.groups) { group in
+                        hunk(group)
+                    }
+                }
+                .padding(.vertical, 8)
+            }
+            .defaultScrollAnchor(.topLeading)
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
+        .background(theme.color("bg-1"))
+    }
+
+    private var toolbar: some View {
+        HStack(spacing: 8) {
+            Seg(
+                value: $layoutMode,
+                options: DiffLayoutMode.allCases.map { ($0, $0.title) }
+            )
+            Spacer()
+            toolbarButton(
+                systemName: wrapLines ? "text.justify.left" : "text.alignleft",
+                tooltip: "Wrap lines",
+                isActive: wrapLines
+            ) {
+                wrapLines.toggle()
+            }
+            toolbarButton(
+                systemName: "paragraphsign",
+                tooltip: "Show whitespace",
+                isActive: showWhitespace
+            ) {
+                showWhitespace.toggle()
+            }
+        }
+        .padding(.horizontal, 12)
+        .padding(.vertical, 7)
+        .background(theme.color("bg-2"))
+        .overlay(Rectangle().fill(theme.color("line")).frame(height: 0.5), alignment: .bottom)
+    }
+
+    private func toolbarButton(
+        systemName: String,
+        tooltip: String,
+        isActive: Bool,
+        action: @escaping () -> Void
+    ) -> some View {
+        Button(action: action) {
+            Image(systemName: systemName)
+                .font(.system(size: 12, weight: .medium))
+                .foregroundColor(isActive ? theme.color("accent") : theme.color("fg-muted"))
+                .frame(width: 24, height: 22)
+                .background(isActive ? theme.color("accent-soft") : Color.clear)
+                .clipShape(RoundedRectangle(cornerRadius: 5))
+        }
+        .buttonStyle(.plain)
+        .help(tooltip)
+    }
+
+    private func hunk(_ group: DiffDisplayGroup) -> some View {
+        VStack(alignment: .leading, spacing: 0) {
+            hunkHeader(group)
+            ForEach(group.rows) { row in
+                switch row.kind {
+                case .collapsed:
+                    collapsedRow(row)
+                case .context, .add, .delete, .replacement:
+                    switch layoutMode {
+                    case .split:
+                        splitRow(row)
+                    case .stacked:
+                        stackedRow(row)
+                    }
+                }
+            }
+        }
+    }
+
+    private func hunkHeader(_ group: DiffDisplayGroup) -> some View {
+        let actions = hunkActions(group.sourceHunk)
+        return HStack(spacing: 8) {
+            Text(group.header)
+                .font(CenterTypography.codeFont(family: codeFontFamily, size: codeFontSize - 1))
+                .foregroundColor(theme.color("fg-muted"))
+                .lineLimit(1)
+            Spacer(minLength: 12)
+            if let stage = actions.stage {
+                hunkActionButton(systemName: "plus.square", tooltip: "Stage hunk", action: stage)
+            }
+            if let discard = actions.discard {
+                hunkActionButton(systemName: "trash", tooltip: "Discard hunk", action: discard)
+            }
+            if let dropFromCommit = actions.dropFromCommit {
+                hunkActionButton(systemName: "minus.circle", tooltip: "Drop from commit", action: dropFromCommit)
+            }
+        }
+        .padding(.horizontal, 12)
+        .padding(.vertical, 5)
+        .background(theme.color("bg-2"))
+        .overlay(Rectangle().fill(theme.color("line")).frame(height: 0.5), alignment: .bottom)
+    }
+
+    private func hunkActionButton(
+        systemName: String,
+        tooltip: String,
+        action: @escaping () -> Void
+    ) -> some View {
+        Button(action: action) {
+            Image(systemName: systemName)
+                .font(.system(size: 11.5, weight: .medium))
+                .foregroundColor(theme.color("fg-muted"))
+                .frame(width: 22, height: 20)
+        }
+        .buttonStyle(.plain)
+        .help(tooltip)
+    }
+
+    private func splitRow(_ row: DiffDisplayRow) -> some View {
+        HStack(alignment: .top, spacing: 0) {
+            splitCell(line: row.old, rowKind: row.kind, side: .old)
+            Rectangle()
+                .fill(theme.color("line"))
+                .frame(width: 0.5)
+            splitCell(line: row.new, rowKind: row.kind, side: .new)
+        }
+    }
+
+    private func splitCell(
+        line: DiffDisplayLine?,
+        rowKind: DiffDisplayRow.Kind,
+        side: DiffLineSide
+    ) -> some View {
+        Group {
+            if let line {
+                lineCell(line, side: side)
+            } else {
+                emptyCell(rowKind: rowKind, side: side)
+            }
+        }
+        .frame(maxWidth: .infinity, alignment: .topLeading)
+    }
+
+    private func stackedRow(_ row: DiffDisplayRow) -> some View {
+        VStack(alignment: .leading, spacing: 0) {
+            if let old = row.old {
+                lineCell(old, side: .old)
+            }
+            if let new = row.new {
+                lineCell(new, side: .new)
+            }
+        }
+    }
+
+    private func lineCell(_ line: DiffDisplayLine, side: DiffLineSide) -> some View {
+        HStack(alignment: .top, spacing: 8) {
+            Text(line.lineNumber.map(String.init) ?? "")
+                .font(CenterTypography.codeFont(family: codeFontFamily, size: codeFontSize - 1))
+                .foregroundColor(theme.color("fg-faint"))
+                .frame(width: 44, alignment: .trailing)
+                .textSelection(.disabled)
+            DiffCodeText(
+                text: line.text,
+                fileExtension: fileExtension,
+                codeFontFamily: codeFontFamily,
+                codeFontSize: codeFontSize,
+                wrapLines: wrapLines,
+                showWhitespace: showWhitespace,
+                inlineSpans: line.inlineSpans,
+                inlineTone: inlineTone(for: line.kind)
+            )
+            if draftAnchor == line.anchor {
+                Text("Draft note")
+                    .font(.system(size: 10, weight: .medium))
+                    .foregroundColor(theme.color("accent"))
+                    .padding(.horizontal, 5)
+                    .padding(.vertical, 2)
+                    .background(theme.color("accent-soft"))
+                    .clipShape(RoundedRectangle(cornerRadius: 4))
+                    .textSelection(.disabled)
+            }
+            Spacer(minLength: 0)
+        }
+        .padding(.horizontal, 12)
+        .padding(.vertical, CenterTypography.rowVerticalPadding)
+        .frame(maxWidth: .infinity, alignment: .topLeading)
+        .background(lineBackground(for: line, side: side))
+        .overlay(selectionOverlay(for: line.anchor))
+        .contentShape(Rectangle())
+        .onTapGesture {
+            selection = DiffSelectionRange(first: line.anchor, last: line.anchor)
+        }
+        .contextMenu {
+            Button("Add Note") {
+                draftAnchor = line.anchor
+            }
+            Button("Copy Line") {
+                Clipboard.copy(line.text)
+            }
+        }
+    }
+
+    private func emptyCell(rowKind: DiffDisplayRow.Kind, side: DiffLineSide) -> some View {
+        HStack(spacing: 8) {
+            Text("")
+                .frame(width: 44)
+            Spacer(minLength: 0)
+        }
+        .padding(.horizontal, 12)
+        .padding(.vertical, CenterTypography.rowVerticalPadding)
+        .frame(maxWidth: .infinity, minHeight: codeFontSize * 1.25, alignment: .topLeading)
+        .background(emptyBackground(for: rowKind, side: side))
+    }
+
+    private func collapsedRow(_ row: DiffDisplayRow) -> some View {
+        Button {
+        } label: {
+            HStack(spacing: 8) {
+                Image(systemName: "ellipsis")
+                    .font(.system(size: 11, weight: .semibold))
+                Text("\(row.collapsedLineCount) unchanged lines")
+                    .font(.system(size: 11.5, weight: .medium))
+                Spacer()
+            }
+            .foregroundColor(theme.color("fg-dim"))
+            .padding(.horizontal, 12)
+            .padding(.vertical, 6)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .background(theme.color("bg-2"))
+            .overlay(Rectangle().fill(theme.color("line")).frame(height: 0.5), alignment: .bottom)
+        }
+        .buttonStyle(.plain)
+    }
+
+    @ViewBuilder
+    private func selectionOverlay(for anchor: DiffLineAnchor) -> some View {
+        if selection?.contains(anchor) == true {
+            Rectangle()
+                .strokeBorder(theme.color("accent").opacity(0.55), lineWidth: 1)
+        }
+    }
+
+    private func lineBackground(for line: DiffDisplayLine, side: DiffLineSide) -> Color {
+        let base: Color
+        switch line.kind {
+        case .add:
+            base = theme.color("add").opacity(0.14)
+        case .delete:
+            base = theme.color("del").opacity(0.14)
+        case .context:
+            base = theme.color("bg-1")
+        }
+
+        if selection?.contains(line.anchor) == true {
+            return theme.color("accent-soft")
+        }
+        return base
+    }
+
+    private func emptyBackground(for rowKind: DiffDisplayRow.Kind, side: DiffLineSide) -> Color {
+        switch (rowKind, side) {
+        case (.add, .old), (.replacement, .old):
+            return theme.color("bg-2").opacity(0.55)
+        case (.delete, .new), (.replacement, .new):
+            return theme.color("bg-2").opacity(0.55)
+        default:
+            return theme.color("bg-1")
+        }
+    }
+
+    private func inlineTone(for kind: ParsedDiff.Hunk.Line.Kind) -> DiffInlineTone {
+        switch kind {
+        case .add:
+            return .add
+        case .delete:
+            return .del
+        case .context:
+            return .accent
+        }
+    }
+}

--- a/Alas/Sources/Center/Diff/DiffPaneView.swift
+++ b/Alas/Sources/Center/Diff/DiffPaneView.swift
@@ -43,6 +43,25 @@ enum DiffPaneRowProjection {
     }
 }
 
+enum DiffPaneScrollPolicy {
+    static func axes(layoutMode: DiffLayoutMode, wrapLines: Bool) -> Axis.Set {
+        if wrapLines {
+            return [.vertical]
+        }
+
+        switch layoutMode {
+        case .split:
+            return [.vertical]
+        case .stacked:
+            return [.vertical, .horizontal]
+        }
+    }
+
+    static func usesIntrinsicContentWidth(layoutMode: DiffLayoutMode, wrapLines: Bool) -> Bool {
+        !wrapLines && layoutMode == .stacked
+    }
+}
+
 struct DiffPaneView: View {
     let model: DiffDisplayModel
     let fileExtension: String
@@ -69,17 +88,19 @@ struct DiffPaneView: View {
 
     private var diffBody: some View {
         GeometryReader { proxy in
-            ScrollView(scrollAxes) {
+            ScrollView(DiffPaneScrollPolicy.axes(layoutMode: layoutMode, wrapLines: wrapLines)) {
                 rowsStack
                     .frame(minWidth: proxy.size.width, alignment: .topLeading)
-                    .fixedSize(horizontal: !wrapLines, vertical: false)
+                    .fixedSize(
+                        horizontal: DiffPaneScrollPolicy.usesIntrinsicContentWidth(
+                            layoutMode: layoutMode,
+                            wrapLines: wrapLines
+                        ),
+                        vertical: false
+                    )
             }
             .defaultScrollAnchor(.topLeading)
         }
-    }
-
-    private var scrollAxes: Axis.Set {
-        wrapLines ? [.vertical] : [.vertical, .horizontal]
     }
 
     private var rowsStack: some View {
@@ -238,6 +259,10 @@ struct DiffPaneView: View {
                 codeFontFamily: codeFontFamily,
                 codeFontSize: codeFontSize,
                 wrapLines: wrapLines,
+                allowHorizontalExpansion: DiffPaneScrollPolicy.usesIntrinsicContentWidth(
+                    layoutMode: layoutMode,
+                    wrapLines: wrapLines
+                ),
                 showWhitespace: showWhitespace,
                 inlineSpans: line.inlineSpans,
                 inlineTone: inlineTone(for: line.kind)

--- a/Alas/Sources/Center/Diff/DiffPaneView.swift
+++ b/Alas/Sources/Center/Diff/DiffPaneView.swift
@@ -43,40 +43,6 @@ enum DiffPaneRowProjection {
     }
 }
 
-enum DiffPaneScrollPolicy {
-    static func axes(layoutMode: DiffLayoutMode, wrapLines: Bool) -> Axis.Set {
-        if wrapLines {
-            return [.vertical]
-        }
-
-        switch layoutMode {
-        case .split:
-            return [.vertical]
-        case .stacked:
-            return [.vertical, .horizontal]
-        }
-    }
-
-    static func usesIntrinsicContentWidth(layoutMode: DiffLayoutMode, wrapLines: Bool) -> Bool {
-        !wrapLines && layoutMode == .stacked
-    }
-}
-
-enum DiffPaneHitArea {
-    case gutter
-    case code
-}
-
-enum DiffPaneInteractionPolicy {
-    static func allowsNativeTextSelection(from hitArea: DiffPaneHitArea) -> Bool {
-        hitArea == .code
-    }
-
-    static func startsLineSelection(from hitArea: DiffPaneHitArea) -> Bool {
-        hitArea == .gutter
-    }
-}
-
 struct DiffPaneView: View {
     let model: DiffDisplayModel
     let fileExtension: String
@@ -88,8 +54,6 @@ struct DiffPaneView: View {
     let hunkActions: (ParsedDiff.Hunk) -> DiffPaneHunkActions
 
     @Environment(\.theme) private var theme
-    @State private var selection: DiffSelectionRange?
-    @State private var draftAnchor: DiffLineAnchor?
     @State private var expandedCollapsedRowIDs: Set<String> = []
 
     var body: some View {
@@ -103,16 +67,9 @@ struct DiffPaneView: View {
 
     private var diffBody: some View {
         GeometryReader { proxy in
-            ScrollView(DiffPaneScrollPolicy.axes(layoutMode: layoutMode, wrapLines: wrapLines)) {
+            ScrollView(.vertical) {
                 rowsStack
                     .frame(minWidth: proxy.size.width, alignment: .topLeading)
-                    .fixedSize(
-                        horizontal: DiffPaneScrollPolicy.usesIntrinsicContentWidth(
-                            layoutMode: layoutMode,
-                            wrapLines: wrapLines
-                        ),
-                        vertical: false
-                    )
             }
             .defaultScrollAnchor(.topLeading)
         }
@@ -125,7 +82,6 @@ struct DiffPaneView: View {
             }
         }
         .padding(.vertical, 8)
-        .textSelection(.enabled)
     }
 
     private var toolbar: some View {
@@ -177,22 +133,18 @@ struct DiffPaneView: View {
     private func hunk(_ group: DiffDisplayGroup) -> some View {
         VStack(alignment: .leading, spacing: 0) {
             hunkHeader(group)
-            ForEach(DiffPaneRowProjection.visibleRows(
-                in: group,
-                expandedCollapsedRowIDs: expandedCollapsedRowIDs
-            )) { row in
-                switch row.kind {
-                case .collapsed:
-                    collapsedRow(row)
-                case .context, .add, .delete, .replacement:
-                    switch layoutMode {
-                    case .split:
-                        splitRow(row)
-                    case .stacked:
-                        stackedRow(row)
-                    }
-                }
-            }
+            DiffPaneTextDocumentView(
+                group: group,
+                expandedCollapsedRowIDs: expandedCollapsedRowIDs,
+                layoutMode: layoutMode,
+                wrapLines: wrapLines,
+                showWhitespace: showWhitespace,
+                fileExtension: fileExtension,
+                codeFontFamily: codeFontFamily,
+                codeFontSize: codeFontSize,
+                theme: theme
+            )
+            .fixedSize(horizontal: false, vertical: true)
         }
     }
 
@@ -227,186 +179,6 @@ struct DiffPaneView: View {
     ) -> some View {
         DiffPaneActionButton(systemName: systemName, tooltip: tooltip, action: action)
             .frame(width: 22, height: 20)
-    }
-
-    private func splitRow(_ row: DiffDisplayRow) -> some View {
-        HStack(alignment: .top, spacing: 0) {
-            splitCell(line: row.old, rowKind: row.kind, side: .old)
-            Rectangle()
-                .fill(theme.color("line"))
-                .frame(width: 0.5)
-            splitCell(line: row.new, rowKind: row.kind, side: .new)
-        }
-    }
-
-    private func splitCell(
-        line: DiffDisplayLine?,
-        rowKind: DiffDisplayRow.Kind,
-        side: DiffLineSide
-    ) -> some View {
-        Group {
-            if let line {
-                lineCell(line, side: side)
-            } else {
-                emptyCell(rowKind: rowKind, side: side)
-            }
-        }
-        .frame(maxWidth: .infinity, alignment: .topLeading)
-    }
-
-    private func stackedRow(_ row: DiffDisplayRow) -> some View {
-        VStack(alignment: .leading, spacing: 0) {
-            ForEach(DiffPaneRowProjection.stackedLines(for: row)) { line in
-                lineCell(line, side: line.anchor.side)
-            }
-        }
-    }
-
-    private func lineCell(_ line: DiffDisplayLine, side: DiffLineSide) -> some View {
-        HStack(alignment: .top, spacing: 8) {
-            lineNumberCell(line)
-            DiffCodeText(
-                text: line.text,
-                fileExtension: fileExtension,
-                codeFontFamily: codeFontFamily,
-                codeFontSize: codeFontSize,
-                wrapLines: wrapLines,
-                allowHorizontalExpansion: DiffPaneScrollPolicy.usesIntrinsicContentWidth(
-                    layoutMode: layoutMode,
-                    wrapLines: wrapLines
-                ),
-                showWhitespace: showWhitespace,
-                inlineSpans: line.inlineSpans,
-                inlineTone: inlineTone(for: line.kind)
-            )
-            if draftAnchor == line.anchor {
-                Text("Draft note")
-                    .font(.system(size: 10, weight: .medium))
-                    .foregroundColor(theme.color("accent"))
-                    .padding(.horizontal, 5)
-                    .padding(.vertical, 2)
-                    .background(theme.color("accent-soft"))
-                    .clipShape(RoundedRectangle(cornerRadius: 4))
-                    .textSelection(.disabled)
-            }
-            Spacer(minLength: 0)
-        }
-        .padding(.horizontal, 12)
-        .padding(.vertical, CenterTypography.rowVerticalPadding)
-        .frame(maxWidth: .infinity, alignment: .topLeading)
-        .background(lineBackground(for: line, side: side))
-        .overlay(selectionOverlay(for: line.anchor))
-        .contextMenu {
-            Button("Add Note") {
-                draftAnchor = line.anchor
-            }
-            Button("Copy Line") {
-                Clipboard.copy(line.text)
-            }
-        }
-    }
-
-    private func lineNumberCell(_ line: DiffDisplayLine) -> some View {
-        Text(line.lineNumber.map(String.init) ?? "")
-            .font(CenterTypography.codeFont(family: codeFontFamily, size: codeFontSize - 1))
-            .foregroundColor(theme.color("fg-faint"))
-            .frame(width: 44, alignment: .trailing)
-            .textSelection(.disabled)
-            .contentShape(Rectangle())
-            .onTapGesture {
-                guard DiffPaneInteractionPolicy.startsLineSelection(from: .gutter) else { return }
-                selection = DiffSelectionController.selection(
-                    current: selection,
-                    clicked: line.anchor,
-                    extend: NSEvent.modifierFlags.contains(.shift)
-                )
-            }
-    }
-
-    private func emptyCell(rowKind: DiffDisplayRow.Kind, side: DiffLineSide) -> some View {
-        HStack(spacing: 8) {
-            Text("")
-                .frame(width: 44)
-            Spacer(minLength: 0)
-        }
-        .padding(.horizontal, 12)
-        .padding(.vertical, CenterTypography.rowVerticalPadding)
-        .frame(maxWidth: .infinity, minHeight: codeFontSize * 1.25, alignment: .topLeading)
-        .background(emptyBackground(for: rowKind, side: side))
-    }
-
-    private func collapsedRow(_ row: DiffDisplayRow) -> some View {
-        let isExpanded = expandedCollapsedRowIDs.contains(row.id)
-        return Button {
-            if isExpanded {
-                expandedCollapsedRowIDs.remove(row.id)
-            } else {
-                expandedCollapsedRowIDs.insert(row.id)
-            }
-        } label: {
-            HStack(spacing: 8) {
-                Image(systemName: isExpanded ? "chevron.down" : "chevron.right")
-                    .font(.system(size: 11, weight: .semibold))
-                Text("\(row.collapsedLineCount) unchanged lines")
-                    .font(.system(size: 11.5, weight: .medium))
-                Spacer()
-            }
-            .foregroundColor(theme.color("fg-dim"))
-            .padding(.horizontal, 12)
-            .padding(.vertical, 6)
-            .frame(maxWidth: .infinity, alignment: .leading)
-            .background(theme.color("bg-2"))
-            .overlay(Rectangle().fill(theme.color("line")).frame(height: 0.5), alignment: .bottom)
-        }
-        .buttonStyle(.plain)
-    }
-
-    @ViewBuilder
-    private func selectionOverlay(for anchor: DiffLineAnchor) -> some View {
-        if selection?.contains(anchor) == true {
-            Rectangle()
-                .strokeBorder(theme.color("accent").opacity(0.55), lineWidth: 1)
-                .allowsHitTesting(false)
-        }
-    }
-
-    private func lineBackground(for line: DiffDisplayLine, side: DiffLineSide) -> Color {
-        let base: Color
-        switch line.kind {
-        case .add:
-            base = theme.color("add").opacity(0.14)
-        case .delete:
-            base = theme.color("del").opacity(0.14)
-        case .context:
-            base = theme.color("bg-1")
-        }
-
-        if selection?.contains(line.anchor) == true {
-            return theme.color("accent-soft")
-        }
-        return base
-    }
-
-    private func emptyBackground(for rowKind: DiffDisplayRow.Kind, side: DiffLineSide) -> Color {
-        switch (rowKind, side) {
-        case (.add, .old), (.replacement, .old):
-            return theme.color("bg-2").opacity(0.55)
-        case (.delete, .new), (.replacement, .new):
-            return theme.color("bg-2").opacity(0.55)
-        default:
-            return theme.color("bg-1")
-        }
-    }
-
-    private func inlineTone(for kind: ParsedDiff.Hunk.Line.Kind) -> DiffInlineTone {
-        switch kind {
-        case .add:
-            return .add
-        case .delete:
-            return .del
-        case .context:
-            return .accent
-        }
     }
 }
 

--- a/Alas/Sources/Center/Diff/DiffPaneView.swift
+++ b/Alas/Sources/Center/Diff/DiffPaneView.swift
@@ -188,14 +188,8 @@ struct DiffPaneView: View {
         tooltip: String,
         action: @escaping () -> Void
     ) -> some View {
-        Button(action: action) {
-            Image(systemName: systemName)
-                .font(.system(size: 11.5, weight: .medium))
-                .foregroundColor(theme.color("fg-muted"))
-                .frame(width: 22, height: 20)
-        }
-        .buttonStyle(.plain)
-        .help(tooltip)
+        DiffPaneActionButton(systemName: systemName, tooltip: tooltip, action: action)
+            .frame(width: 22, height: 20)
     }
 
     private func splitRow(_ row: DiffDisplayRow) -> some View {
@@ -365,6 +359,54 @@ struct DiffPaneView: View {
             return .del
         case .context:
             return .accent
+        }
+    }
+}
+
+private struct DiffPaneActionButton: NSViewRepresentable {
+    let systemName: String
+    let tooltip: String
+    let action: () -> Void
+
+    func makeCoordinator() -> Coordinator {
+        Coordinator(action: action)
+    }
+
+    func makeNSView(context: Context) -> NSButton {
+        let button = NSButton(
+            image: image(),
+            target: context.coordinator,
+            action: #selector(Coordinator.fire)
+        )
+        button.bezelStyle = .accessoryBar
+        button.isBordered = false
+        button.imagePosition = .imageOnly
+        button.contentTintColor = .secondaryLabelColor
+        button.toolTip = tooltip
+        button.setAccessibilityLabel(tooltip)
+        return button
+    }
+
+    func updateNSView(_ button: NSButton, context: Context) {
+        context.coordinator.action = action
+        button.image = image()
+        button.toolTip = tooltip
+        button.setAccessibilityLabel(tooltip)
+    }
+
+    private func image() -> NSImage {
+        NSImage(systemSymbolName: systemName, accessibilityDescription: tooltip) ?? NSImage()
+    }
+
+    final class Coordinator: NSObject {
+        var action: () -> Void
+
+        init(action: @escaping () -> Void) {
+            self.action = action
+        }
+
+        @objc func fire() {
+            action()
         }
     }
 }

--- a/Alas/Sources/Center/Diff/DiffPaneView.swift
+++ b/Alas/Sources/Center/Diff/DiffPaneView.swift
@@ -81,15 +81,13 @@ struct DiffPaneView: View {
                 hunk(group)
             }
         }
-        .padding(.vertical, 8)
+        .padding(.horizontal, 10)
+        .padding(.vertical, 10)
     }
 
     private var toolbar: some View {
         HStack(spacing: 8) {
-            Seg(
-                value: $layoutMode,
-                options: DiffLayoutMode.allCases.map { ($0, $0.title) }
-            )
+            layoutSwitcher
             Spacer()
             toolbarButton(
                 systemName: wrapLines ? "text.justify.left" : "text.alignleft",
@@ -106,10 +104,45 @@ struct DiffPaneView: View {
                 showWhitespace.toggle()
             }
         }
-        .padding(.horizontal, 12)
-        .padding(.vertical, 7)
-        .background(theme.color("bg-2"))
+        .padding(.horizontal, 16)
+        .padding(.vertical, 9)
+        .background(theme.color("bg-1"))
         .overlay(Rectangle().fill(theme.color("line")).frame(height: 0.5), alignment: .bottom)
+    }
+
+    private var layoutSwitcher: some View {
+        HStack(spacing: 0) {
+            layoutButton(.split, systemName: "rectangle.split.2x1")
+            layoutButton(.stacked, systemName: "rectangle.split.1x2")
+        }
+        .padding(3)
+        .background(theme.color("bg-3"))
+        .clipShape(RoundedRectangle(cornerRadius: 8))
+        .overlay(
+            RoundedRectangle(cornerRadius: 8)
+                .stroke(theme.color("line"), lineWidth: 0.75)
+        )
+    }
+
+    private func layoutButton(_ mode: DiffLayoutMode, systemName: String) -> some View {
+        let active = layoutMode == mode
+        return Button {
+            layoutMode = mode
+        } label: {
+            HStack(spacing: 6) {
+                Image(systemName: systemName)
+                    .font(.system(size: 11, weight: .semibold))
+                Text(mode.title)
+                    .font(.system(size: 12, weight: .semibold))
+            }
+            .foregroundColor(active ? theme.color("fg") : theme.color("fg-muted"))
+            .padding(.horizontal, 10)
+            .frame(height: 28)
+            .background(active ? theme.color("bg-1") : Color.clear)
+            .clipShape(RoundedRectangle(cornerRadius: 6))
+        }
+        .buttonStyle(.plain)
+        .help(mode.title)
     }
 
     private func toolbarButton(
@@ -146,6 +179,13 @@ struct DiffPaneView: View {
             )
             .fixedSize(horizontal: false, vertical: true)
         }
+        .background(theme.color("bg-1"))
+        .clipShape(RoundedRectangle(cornerRadius: 7))
+        .overlay(
+            RoundedRectangle(cornerRadius: 7)
+                .stroke(theme.color("line"), lineWidth: 0.75)
+        )
+        .padding(.bottom, 10)
     }
 
     private func hunkHeader(_ group: DiffDisplayGroup) -> some View {
@@ -166,8 +206,8 @@ struct DiffPaneView: View {
                 hunkActionButton(systemName: "minus.circle", tooltip: "Drop from commit", action: dropFromCommit)
             }
         }
-        .padding(.horizontal, 12)
-        .padding(.vertical, 5)
+        .padding(.horizontal, 13)
+        .padding(.vertical, 8)
         .background(theme.color("bg-2"))
         .overlay(Rectangle().fill(theme.color("line")).frame(height: 0.5), alignment: .bottom)
     }

--- a/Alas/Sources/Center/Diff/DiffPaneView.swift
+++ b/Alas/Sources/Center/Diff/DiffPaneView.swift
@@ -1,9 +1,46 @@
+import AppKit
 import SwiftUI
 
 struct DiffPaneHunkActions {
     var stage: (() -> Void)?
     var discard: (() -> Void)?
     var dropFromCommit: (() -> Void)?
+}
+
+enum DiffSelectionController {
+    static func selection(
+        current: DiffSelectionRange?,
+        clicked anchor: DiffLineAnchor,
+        extend: Bool
+    ) -> DiffSelectionRange {
+        guard extend, let current else {
+            return DiffSelectionRange(first: anchor, last: anchor)
+        }
+        return DiffSelectionRange(first: current.first, last: anchor)
+    }
+}
+
+enum DiffPaneRowProjection {
+    static func visibleRows(
+        in group: DiffDisplayGroup,
+        expandedCollapsedRowIDs: Set<String>
+    ) -> [DiffDisplayRow] {
+        group.rows.flatMap { row in
+            guard row.kind == .collapsed, expandedCollapsedRowIDs.contains(row.id) else {
+                return [row]
+            }
+            return [row] + row.collapsedRows
+        }
+    }
+
+    static func stackedLines(for row: DiffDisplayRow) -> [DiffDisplayLine] {
+        if row.kind == .context {
+            if let new = row.new { return [new] }
+            if let old = row.old { return [old] }
+            return []
+        }
+        return [row.old, row.new].compactMap { $0 }
+    }
 }
 
 struct DiffPaneView: View {
@@ -19,22 +56,42 @@ struct DiffPaneView: View {
     @Environment(\.theme) private var theme
     @State private var selection: DiffSelectionRange?
     @State private var draftAnchor: DiffLineAnchor?
+    @State private var expandedCollapsedRowIDs: Set<String> = []
 
     var body: some View {
         VStack(spacing: 0) {
             toolbar
-            ScrollView(.vertical) {
-                LazyVStack(alignment: .leading, spacing: 0) {
-                    ForEach(model.groups) { group in
-                        hunk(group)
-                    }
-                }
-                .padding(.vertical, 8)
-            }
-            .defaultScrollAnchor(.topLeading)
+            diffBody
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
         .background(theme.color("bg-1"))
+    }
+
+    private var diffBody: some View {
+        GeometryReader { proxy in
+            ScrollView(.vertical) {
+                if wrapLines {
+                    rowsStack
+                        .frame(minWidth: proxy.size.width, alignment: .topLeading)
+                } else {
+                    ScrollView(.horizontal) {
+                        rowsStack
+                            .frame(minWidth: proxy.size.width, alignment: .topLeading)
+                            .fixedSize(horizontal: true, vertical: false)
+                    }
+                }
+            }
+            .defaultScrollAnchor(.topLeading)
+        }
+    }
+
+    private var rowsStack: some View {
+        LazyVStack(alignment: .leading, spacing: 0) {
+            ForEach(model.groups) { group in
+                hunk(group)
+            }
+        }
+        .padding(.vertical, 8)
     }
 
     private var toolbar: some View {
@@ -86,7 +143,10 @@ struct DiffPaneView: View {
     private func hunk(_ group: DiffDisplayGroup) -> some View {
         VStack(alignment: .leading, spacing: 0) {
             hunkHeader(group)
-            ForEach(group.rows) { row in
+            ForEach(DiffPaneRowProjection.visibleRows(
+                in: group,
+                expandedCollapsedRowIDs: expandedCollapsedRowIDs
+            )) { row in
                 switch row.kind {
                 case .collapsed:
                     collapsedRow(row)
@@ -168,11 +228,8 @@ struct DiffPaneView: View {
 
     private func stackedRow(_ row: DiffDisplayRow) -> some View {
         VStack(alignment: .leading, spacing: 0) {
-            if let old = row.old {
-                lineCell(old, side: .old)
-            }
-            if let new = row.new {
-                lineCell(new, side: .new)
+            ForEach(DiffPaneRowProjection.stackedLines(for: row)) { line in
+                lineCell(line, side: line.anchor.side)
             }
         }
     }
@@ -213,7 +270,11 @@ struct DiffPaneView: View {
         .overlay(selectionOverlay(for: line.anchor))
         .contentShape(Rectangle())
         .onTapGesture {
-            selection = DiffSelectionRange(first: line.anchor, last: line.anchor)
+            selection = DiffSelectionController.selection(
+                current: selection,
+                clicked: line.anchor,
+                extend: NSEvent.modifierFlags.contains(.shift)
+            )
         }
         .contextMenu {
             Button("Add Note") {
@@ -238,10 +299,16 @@ struct DiffPaneView: View {
     }
 
     private func collapsedRow(_ row: DiffDisplayRow) -> some View {
-        Button {
+        let isExpanded = expandedCollapsedRowIDs.contains(row.id)
+        return Button {
+            if isExpanded {
+                expandedCollapsedRowIDs.remove(row.id)
+            } else {
+                expandedCollapsedRowIDs.insert(row.id)
+            }
         } label: {
             HStack(spacing: 8) {
-                Image(systemName: "ellipsis")
+                Image(systemName: isExpanded ? "chevron.down" : "chevron.right")
                     .font(.system(size: 11, weight: .semibold))
                 Text("\(row.collapsedLineCount) unchanged lines")
                     .font(.system(size: 11.5, weight: .medium))

--- a/Alas/Sources/Center/Diff/DiffPaneView.swift
+++ b/Alas/Sources/Center/Diff/DiffPaneView.swift
@@ -62,6 +62,21 @@ enum DiffPaneScrollPolicy {
     }
 }
 
+enum DiffPaneHitArea {
+    case gutter
+    case code
+}
+
+enum DiffPaneInteractionPolicy {
+    static func allowsNativeTextSelection(from hitArea: DiffPaneHitArea) -> Bool {
+        hitArea == .code
+    }
+
+    static func startsLineSelection(from hitArea: DiffPaneHitArea) -> Bool {
+        hitArea == .gutter
+    }
+}
+
 struct DiffPaneView: View {
     let model: DiffDisplayModel
     let fileExtension: String
@@ -110,6 +125,7 @@ struct DiffPaneView: View {
             }
         }
         .padding(.vertical, 8)
+        .textSelection(.enabled)
     }
 
     private var toolbar: some View {
@@ -248,11 +264,7 @@ struct DiffPaneView: View {
 
     private func lineCell(_ line: DiffDisplayLine, side: DiffLineSide) -> some View {
         HStack(alignment: .top, spacing: 8) {
-            Text(line.lineNumber.map(String.init) ?? "")
-                .font(CenterTypography.codeFont(family: codeFontFamily, size: codeFontSize - 1))
-                .foregroundColor(theme.color("fg-faint"))
-                .frame(width: 44, alignment: .trailing)
-                .textSelection(.disabled)
+            lineNumberCell(line)
             DiffCodeText(
                 text: line.text,
                 fileExtension: fileExtension,
@@ -284,14 +296,6 @@ struct DiffPaneView: View {
         .frame(maxWidth: .infinity, alignment: .topLeading)
         .background(lineBackground(for: line, side: side))
         .overlay(selectionOverlay(for: line.anchor))
-        .contentShape(Rectangle())
-        .onTapGesture {
-            selection = DiffSelectionController.selection(
-                current: selection,
-                clicked: line.anchor,
-                extend: NSEvent.modifierFlags.contains(.shift)
-            )
-        }
         .contextMenu {
             Button("Add Note") {
                 draftAnchor = line.anchor
@@ -300,6 +304,23 @@ struct DiffPaneView: View {
                 Clipboard.copy(line.text)
             }
         }
+    }
+
+    private func lineNumberCell(_ line: DiffDisplayLine) -> some View {
+        Text(line.lineNumber.map(String.init) ?? "")
+            .font(CenterTypography.codeFont(family: codeFontFamily, size: codeFontSize - 1))
+            .foregroundColor(theme.color("fg-faint"))
+            .frame(width: 44, alignment: .trailing)
+            .textSelection(.disabled)
+            .contentShape(Rectangle())
+            .onTapGesture {
+                guard DiffPaneInteractionPolicy.startsLineSelection(from: .gutter) else { return }
+                selection = DiffSelectionController.selection(
+                    current: selection,
+                    clicked: line.anchor,
+                    extend: NSEvent.modifierFlags.contains(.shift)
+                )
+            }
     }
 
     private func emptyCell(rowKind: DiffDisplayRow.Kind, side: DiffLineSide) -> some View {
@@ -345,6 +366,7 @@ struct DiffPaneView: View {
         if selection?.contains(anchor) == true {
             Rectangle()
                 .strokeBorder(theme.color("accent").opacity(0.55), lineWidth: 1)
+                .allowsHitTesting(false)
         }
     }
 

--- a/Alas/Sources/Center/Diff/DiffPaneView.swift
+++ b/Alas/Sources/Center/Diff/DiffPaneView.swift
@@ -69,20 +69,17 @@ struct DiffPaneView: View {
 
     private var diffBody: some View {
         GeometryReader { proxy in
-            ScrollView(.vertical) {
-                if wrapLines {
-                    rowsStack
-                        .frame(minWidth: proxy.size.width, alignment: .topLeading)
-                } else {
-                    ScrollView(.horizontal) {
-                        rowsStack
-                            .frame(minWidth: proxy.size.width, alignment: .topLeading)
-                            .fixedSize(horizontal: true, vertical: false)
-                    }
-                }
+            ScrollView(scrollAxes) {
+                rowsStack
+                    .frame(minWidth: proxy.size.width, alignment: .topLeading)
+                    .fixedSize(horizontal: !wrapLines, vertical: false)
             }
             .defaultScrollAnchor(.topLeading)
         }
+    }
+
+    private var scrollAxes: Axis.Set {
+        wrapLines ? [.vertical] : [.vertical, .horizontal]
     }
 
     private var rowsStack: some View {

--- a/Alas/Sources/Center/Diff/DiffPaneView.swift
+++ b/Alas/Sources/Center/Diff/DiffPaneView.swift
@@ -20,6 +20,30 @@ enum DiffSelectionController {
     }
 }
 
+enum DiffCollapsedContextController {
+    static func collapsedRowIDs(in group: DiffDisplayGroup) -> Set<String> {
+        Set(group.rows.filter { $0.kind == .collapsed }.map(\.id))
+    }
+
+    static func isExpanded(_ group: DiffDisplayGroup, expandedIDs: Set<String>) -> Bool {
+        let ids = collapsedRowIDs(in: group)
+        return !ids.isEmpty && ids.isSubset(of: expandedIDs)
+    }
+
+    static func toggled(_ group: DiffDisplayGroup, expandedIDs: Set<String>) -> Set<String> {
+        let ids = collapsedRowIDs(in: group)
+        guard !ids.isEmpty else { return expandedIDs }
+
+        var updated = expandedIDs
+        if ids.isSubset(of: expandedIDs) {
+            updated.subtract(ids)
+        } else {
+            updated.formUnion(ids)
+        }
+        return updated
+    }
+}
+
 enum DiffPaneRowProjection {
     static func visibleRows(
         in group: DiffDisplayGroup,
@@ -196,6 +220,18 @@ struct DiffPaneView: View {
                 .foregroundColor(theme.color("fg-muted"))
                 .lineLimit(1)
             Spacer(minLength: 12)
+            if !DiffCollapsedContextController.collapsedRowIDs(in: group).isEmpty {
+                let expanded = DiffCollapsedContextController.isExpanded(group, expandedIDs: expandedCollapsedRowIDs)
+                hunkActionButton(
+                    systemName: expanded ? "minus.square" : "plus.square",
+                    tooltip: expanded ? "Collapse context" : "Expand context"
+                ) {
+                    expandedCollapsedRowIDs = DiffCollapsedContextController.toggled(
+                        group,
+                        expandedIDs: expandedCollapsedRowIDs
+                    )
+                }
+            }
             if let stage = actions.stage {
                 hunkActionButton(systemName: "plus.square", tooltip: "Stage hunk", action: stage)
             }

--- a/Alas/Sources/Center/DiffTabView.swift
+++ b/Alas/Sources/Center/DiffTabView.swift
@@ -4,6 +4,7 @@ struct DiffTabView: View {
     let worktreePath: URL
     let relativePath: String
     let staged: Bool
+    let appState: AppState
     var codeFontFamily: String = ""
     var codeFontSize: CGFloat = 13
     let onOpenFile: (() -> Void)?
@@ -11,6 +12,7 @@ struct DiffTabView: View {
     @Environment(\.theme) var theme
 
     @State private var diff: ParsedDiff = ParsedDiff(hunks: [])
+    @State private var displayModel: DiffDisplayModel?
     @State private var totalAdd = 0
     @State private var totalDel = 0
     @State private var loaded = false
@@ -90,31 +92,31 @@ struct DiffTabView: View {
                     .frame(maxWidth: .infinity, alignment: .leading)
                     .background(theme.color("bg-2"))
             }
-            ScrollView(.vertical) {
-                if !loaded {
-                    Spinner()
-                        .frame(width: 16, height: 16)
-                        .padding()
-                } else if diff.hunks.isEmpty {
-                    Text("No changes for \(relativePath)").foregroundColor(theme.color("fg-dim")).padding()
-                } else {
-                    VStack(alignment: .leading, spacing: 0) {
-                        ForEach(Array(diff.hunks.enumerated()), id: \.offset) { (_, hunk) in
-                            let actions = stagedHunkActions(hunk: hunk)
-                            HunkView(
-                                hunk: hunk,
-                                fileExtension: LanguageRegistry.highlighterExtension(forPath: relativePath),
-                                codeFontFamily: codeFontFamily,
-                                codeFontSize: codeFontSize,
-                                onStage: actions.stage,
-                                onDiscard: actions.discard
-                            )
-                        }
+            if !loaded {
+                Spinner()
+                    .frame(width: 16, height: 16)
+                    .padding()
+            } else if diff.hunks.isEmpty {
+                Text("No changes for \(relativePath)").foregroundColor(theme.color("fg-dim")).padding()
+            } else if let displayModel {
+                DiffPaneView(
+                    model: displayModel,
+                    fileExtension: LanguageRegistry.highlighterExtension(forPath: relativePath),
+                    layoutMode: diffLayoutBinding,
+                    wrapLines: diffWrapBinding,
+                    showWhitespace: diffWhitespaceBinding,
+                    codeFontFamily: codeFontFamily,
+                    codeFontSize: codeFontSize,
+                    hunkActions: { hunk in
+                        let actions = stagedHunkActions(hunk: hunk)
+                        return DiffPaneHunkActions(stage: actions.stage, discard: actions.discard)
                     }
-                    .padding(.vertical, 8)
-                }
+                )
+            } else {
+                Spinner()
+                    .frame(width: 16, height: 16)
+                    .padding()
             }
-            .defaultScrollAnchor(.topLeading)
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
         .background(theme.color("bg-1"))
@@ -142,6 +144,36 @@ struct DiffTabView: View {
 
     private var loadKey: String {
         "\(worktreePath.path)\u{0}\(relativePath)\u{0}\(staged)"
+    }
+
+    private var diffLayoutBinding: Binding<DiffLayoutMode> {
+        Binding(
+            get: { appState.config.changes.diffLayoutMode },
+            set: {
+                appState.config.changes.diffLayoutMode = $0
+                appState.saveConfig()
+            }
+        )
+    }
+
+    private var diffWrapBinding: Binding<Bool> {
+        Binding(
+            get: { appState.config.changes.diffWrapLines },
+            set: {
+                appState.config.changes.diffWrapLines = $0
+                appState.saveConfig()
+            }
+        )
+    }
+
+    private var diffWhitespaceBinding: Binding<Bool> {
+        Binding(
+            get: { appState.config.changes.diffShowWhitespace },
+            set: {
+                appState.config.changes.diffShowWhitespace = $0
+                appState.saveConfig()
+            }
+        )
     }
 
     private var header: some View {
@@ -188,12 +220,16 @@ struct DiffTabView: View {
         activeLoadKey = requestedLoadKey
         loaded = false
         diff = ParsedDiff(hunks: [])
+        displayModel = nil
         totalAdd = 0
         totalDel = 0
         error = nil
 
         do {
             let loadedDiff = try await git.diff(worktreePath: worktreePath, file: relativePath, staged: staged)
+            let loadedDisplayModel = await Task.detached(priority: .userInitiated) {
+                DiffDisplayModelBuilder.build(diff: loadedDiff, filePath: relativePath)
+            }.value
             // Single off-main pass instead of two `.flatMap.filter.count`
             // allocations on MainActor — for big diffs each pass copies the
             // full line array, which would stall the UI right after parse.
@@ -225,6 +261,7 @@ struct DiffTabView: View {
 
             guard !Task.isCancelled, activeLoadKey == requestedLoadKey else { return }
             diff = loadedDiff
+            displayModel = loadedDisplayModel
             totalAdd = loadedTotalAdd
             totalDel = loadedTotalDel
             isFileTracked = tracked

--- a/Alas/Sources/Center/DiffTabView.swift
+++ b/Alas/Sources/Center/DiffTabView.swift
@@ -1,5 +1,18 @@
 import SwiftUI
 
+struct DiffLoadToken: Equatable {
+    let key: String
+    let id: UUID
+
+    static func next(key: String) -> DiffLoadToken {
+        DiffLoadToken(key: key, id: UUID())
+    }
+
+    func isActive(activeKey: String?, activeID: UUID) -> Bool {
+        activeKey == key && activeID == id
+    }
+}
+
 struct DiffTabView: View {
     let worktreePath: URL
     let relativePath: String
@@ -18,6 +31,7 @@ struct DiffTabView: View {
     @State private var loaded = false
     @State private var error: String?
     @State private var activeLoadKey: String?
+    @State private var activeLoadID = UUID()
     @State private var confirmingDiscardHunk: ParsedDiff.Hunk? = nil
     @State private var isFileTracked: Bool = true
     @State private var isFileDeleted: Bool = false
@@ -217,7 +231,9 @@ struct DiffTabView: View {
 
     private func load() async {
         let requestedLoadKey = loadKey
-        activeLoadKey = requestedLoadKey
+        let requestedLoadToken = DiffLoadToken.next(key: requestedLoadKey)
+        activeLoadKey = requestedLoadToken.key
+        activeLoadID = requestedLoadToken.id
         loaded = false
         diff = ParsedDiff(hunks: [])
         displayModel = nil
@@ -227,9 +243,13 @@ struct DiffTabView: View {
 
         do {
             let loadedDiff = try await git.diff(worktreePath: worktreePath, file: relativePath, staged: staged)
+            guard isActiveLoad(requestedLoadToken) else { return }
+
             let loadedDisplayModel = await Task.detached(priority: .userInitiated) {
                 DiffDisplayModelBuilder.build(diff: loadedDiff, filePath: relativePath)
             }.value
+            guard isActiveLoad(requestedLoadToken) else { return }
+
             // Single off-main pass instead of two `.flatMap.filter.count`
             // allocations on MainActor — for big diffs each pass copies the
             // full line array, which would stall the UI right after parse.
@@ -247,10 +267,14 @@ struct DiffTabView: View {
                 }
                 return (add, del)
             }.value
+            guard isActiveLoad(requestedLoadToken) else { return }
+
             let tracked = (try? await Process.git(
                 ["ls-files", "--error-unmatch", "--", relativePath],
                 cwd: worktreePath
             ))?.exitCode == 0
+            guard isActiveLoad(requestedLoadToken) else { return }
+
             // A tracked file that's gone from disk is an unstaged deletion.
             // The diff for it has `+++ /dev/null`, so reverse-applying a
             // per-hunk patch (which uses `+++ b/<path>`) would fail — hide
@@ -259,7 +283,7 @@ struct DiffTabView: View {
                 atPath: worktreePath.appendingPathComponent(relativePath).path
             )
 
-            guard !Task.isCancelled, activeLoadKey == requestedLoadKey else { return }
+            guard isActiveLoad(requestedLoadToken) else { return }
             diff = loadedDiff
             displayModel = loadedDisplayModel
             totalAdd = loadedTotalAdd
@@ -268,10 +292,14 @@ struct DiffTabView: View {
             isFileDeleted = deleted
             loaded = true
         } catch {
-            guard !Task.isCancelled, activeLoadKey == requestedLoadKey else { return }
+            guard isActiveLoad(requestedLoadToken) else { return }
             self.error = error.localizedDescription
             loaded = true
         }
+    }
+
+    private func isActiveLoad(_ token: DiffLoadToken) -> Bool {
+        !Task.isCancelled && token.isActive(activeKey: activeLoadKey, activeID: activeLoadID)
     }
 
     private func stageHunk(_ hunk: ParsedDiff.Hunk) {

--- a/Alas/Sources/Persistence/AppConfig.swift
+++ b/Alas/Sources/Persistence/AppConfig.swift
@@ -310,10 +310,14 @@ struct AppConfig: Codable, Equatable {
         /// (default), it always compares against `worktrees.baseBranch`,
         /// so the list stays stable across pushes.
         var trackUpstreamForCommits: Bool
+        var diffLayoutMode: DiffLayoutMode
+        var diffWrapLines: Bool
+        var diffShowWhitespace: Bool
 
         enum CodingKeys: String, CodingKey {
             case aiToolId, prompt, reviewRequestPrompt, mergeBulkResolvePrompt,
-                 mergeSingleResolvePrompt, trackUpstreamForCommits
+                 mergeSingleResolvePrompt, trackUpstreamForCommits,
+                 diffLayoutMode, diffWrapLines, diffShowWhitespace
         }
     }
 
@@ -426,7 +430,10 @@ struct AppConfig: Codable, Equatable {
             reviewRequestPrompt: AppConfig.defaultReviewRequestPrompt,
             mergeBulkResolvePrompt: AppConfig.defaultMergeBulkResolvePrompt,
             mergeSingleResolvePrompt: AppConfig.defaultMergeSingleResolvePrompt,
-            trackUpstreamForCommits: false
+            trackUpstreamForCommits: false,
+            diffLayoutMode: .split,
+            diffWrapLines: false,
+            diffShowWhitespace: false
         ),
         agents: Agents(
             builtinState: [:],
@@ -652,13 +659,19 @@ extension AppConfig {
             let singleResolve = (try? changesContainer.decode(String.self, forKey: .mergeSingleResolvePrompt))
                 ?? AppConfig.defaultMergeSingleResolvePrompt
             let trackUpstream = (try? changesContainer.decode(Bool.self, forKey: .trackUpstreamForCommits)) ?? false
+            let diffLayoutMode = (try? changesContainer.decode(DiffLayoutMode.self, forKey: .diffLayoutMode)) ?? .split
+            let diffWrapLines = (try? changesContainer.decode(Bool.self, forKey: .diffWrapLines)) ?? false
+            let diffShowWhitespace = (try? changesContainer.decode(Bool.self, forKey: .diffShowWhitespace)) ?? false
             changes = Changes(
                 aiToolId: toolId,
                 prompt: prompt,
                 reviewRequestPrompt: reviewRequestPrompt,
                 mergeBulkResolvePrompt: bulkResolve,
                 mergeSingleResolvePrompt: singleResolve,
-                trackUpstreamForCommits: trackUpstream
+                trackUpstreamForCommits: trackUpstream,
+                diffLayoutMode: diffLayoutMode,
+                diffWrapLines: diffWrapLines,
+                diffShowWhitespace: diffShowWhitespace
             )
         } else {
             changes = Changes(
@@ -667,7 +680,10 @@ extension AppConfig {
                 reviewRequestPrompt: AppConfig.defaultReviewRequestPrompt,
                 mergeBulkResolvePrompt: AppConfig.defaultMergeBulkResolvePrompt,
                 mergeSingleResolvePrompt: AppConfig.defaultMergeSingleResolvePrompt,
-                trackUpstreamForCommits: false
+                trackUpstreamForCommits: false,
+                diffLayoutMode: .split,
+                diffWrapLines: false,
+                diffShowWhitespace: false
             )
         }
         if let agentsContainer = try? c.nestedContainer(

--- a/AlasTests/AppConfigChangesTests.swift
+++ b/AlasTests/AppConfigChangesTests.swift
@@ -166,4 +166,67 @@ struct AppConfigChangesTests {
         let decoded = try JSONDecoder().decode(AppConfig.self, from: data)
         #expect(decoded.changes.trackUpstreamForCommits == true)
     }
+
+    @Test func defaultsHaveDiffDisplayPreferences() {
+        #expect(AppConfig.defaults.changes.diffLayoutMode == .split)
+        #expect(AppConfig.defaults.changes.diffWrapLines == false)
+        #expect(AppConfig.defaults.changes.diffShowWhitespace == false)
+    }
+
+    @Test func decodesLegacyChangesWithoutDiffDisplayPreferences() throws {
+        let json = """
+        {
+          "themeId": "cool-slate",
+          "accent": "teal",
+          "matchSystemTheme": false,
+          "sidebarWidth": 244,
+          "rightPaneWidth": 320,
+          "rightPaneVisible": true,
+          "general": {
+            "launchAtLogin": false, "closeToTray": true, "confirmQuit": true,
+            "autoUpdate": true, "updateChannel": "Stable",
+            "crashReports": false, "usageAnalytics": false
+          },
+          "worktrees": {
+            "rootPath": "~/.alas/worktrees",
+            "pathTemplate": "{worktreeRoot}/{repo}/{branch}",
+            "branchPrefix": "feature/", "baseBranch": "main",
+            "trackUpstream": true, "deleteBranchOnRemove": true,
+            "autoFetch": true, "fetchIntervalMinutes": 5, "pruneStale": false
+          },
+          "terminal": {
+            "shell": "/bin/zsh", "workingDirectory": "worktreeRoot",
+            "startupScript": "", "worktreeCreateScript": "",
+            "inheritParentEnv": true, "fontFamily": "JetBrains Mono",
+            "fontSize": 13, "cursorStyle": "beam", "cursorBlink": true,
+            "scrollbackLines": 10000, "bell": "visual"
+          },
+          "harness": {"notifyOnFinish": true, "notifyOnAwaiting": true},
+          "changes": {
+            "aiToolId": "claude",
+            "prompt": "p",
+            "reviewRequestPrompt": "r",
+            "mergeBulkResolvePrompt": "b",
+            "mergeSingleResolvePrompt": "s",
+            "trackUpstreamForCommits": true
+          }
+        }
+        """
+        let cfg = try JSONDecoder().decode(AppConfig.self, from: Data(json.utf8))
+        #expect(cfg.changes.diffLayoutMode == .split)
+        #expect(cfg.changes.diffWrapLines == false)
+        #expect(cfg.changes.diffShowWhitespace == false)
+    }
+
+    @Test func roundTripsDiffDisplayPreferences() throws {
+        var cfg = AppConfig.defaults
+        cfg.changes.diffLayoutMode = .stacked
+        cfg.changes.diffWrapLines = true
+        cfg.changes.diffShowWhitespace = true
+        let data = try JSONEncoder().encode(cfg)
+        let decoded = try JSONDecoder().decode(AppConfig.self, from: data)
+        #expect(decoded.changes.diffLayoutMode == .stacked)
+        #expect(decoded.changes.diffWrapLines == true)
+        #expect(decoded.changes.diffShowWhitespace == true)
+    }
 }

--- a/AlasTests/DiffDisplayModelBuilderTests.swift
+++ b/AlasTests/DiffDisplayModelBuilderTests.swift
@@ -57,6 +57,28 @@ struct DiffDisplayModelBuilderTests {
         #expect(model.groups[0].sourceHunk == diff.hunks[0])
     }
 
+    @Test func contextRowsUseLayoutNeutralPairedAnchorsWhileKeepingSideLineNumbers() throws {
+        let hunk = ParsedDiff.Hunk(
+            header: "@@ -100,1 +10,1 @@",
+            oldStart: 100,
+            newStart: 10,
+            lines: [
+                .init(kind: .context, text: "let value = 1", oldNumber: 100, newNumber: 10),
+            ]
+        )
+        let model = DiffDisplayModelBuilder.build(diff: ParsedDiff(hunks: [hunk]), filePath: "a.swift")
+        let row = try #require(model.groups[0].rows.first)
+        let old = try #require(row.old)
+        let new = try #require(row.new)
+
+        #expect(old.lineNumber == 100)
+        #expect(new.lineNumber == 10)
+        #expect(old.anchor == new.anchor)
+        #expect(old.anchor.side == .paired)
+        #expect(old.anchor.oldLine == 100)
+        #expect(old.anchor.newLine == 10)
+    }
+
     @Test func collapsesLargeContextRunsInsideHunk() {
         let context = (1...12).map { (number: Int) in
             ParsedDiff.Hunk.Line(kind: .context, text: "line \(number)", oldNumber: number, newNumber: number)

--- a/AlasTests/DiffDisplayModelBuilderTests.swift
+++ b/AlasTests/DiffDisplayModelBuilderTests.swift
@@ -58,8 +58,8 @@ struct DiffDisplayModelBuilderTests {
     }
 
     @Test func collapsesLargeContextRunsInsideHunk() {
-        let context = (1...12).map {
-            ParsedDiff.Hunk.Line(kind: .context, text: "line \($0)", oldNumber: $0, newNumber: $0)
+        let context = (1...12).map { (number: Int) in
+            ParsedDiff.Hunk.Line(kind: .context, text: "line \(number)", oldNumber: number, newNumber: number)
         }
         let hunk = ParsedDiff.Hunk(header: "@@ -1,12 +1,12 @@", oldStart: 1, newStart: 1, lines: context)
         let model = DiffDisplayModelBuilder.build(
@@ -72,6 +72,37 @@ struct DiffDisplayModelBuilderTests {
         let rows = model.groups[0].rows
         #expect(rows.map(\.kind) == [.context, .context, .collapsed, .context, .context])
         #expect(rows[2].collapsedLineCount == 8)
+    }
+
+    @Test func contextAnchorsRemainStableAcrossCollapsedAndExpandedBuilds() throws {
+        let context = (1...12).map { (number: Int) in
+            ParsedDiff.Hunk.Line(kind: .context, text: "line \(number)", oldNumber: number, newNumber: number)
+        }
+        let hunk = ParsedDiff.Hunk(header: "@@ -1,12 +1,12 @@", oldStart: 1, newStart: 1, lines: context)
+        let collapsed = DiffDisplayModelBuilder.build(
+            diff: ParsedDiff(hunks: [hunk]),
+            filePath: "a.txt",
+            collapseContextThreshold: 6,
+            contextEdgeCount: 2
+        )
+        let expanded = DiffDisplayModelBuilder.build(
+            diff: ParsedDiff(hunks: [hunk]),
+            filePath: "a.txt",
+            collapseContextThreshold: 99,
+            contextEdgeCount: 2
+        )
+
+        func contextAnchors(in model: DiffDisplayModel, text: String) throws -> (old: DiffLineAnchor, new: DiffLineAnchor) {
+            let row = try #require(model.groups[0].rows.first { $0.kind == .context && $0.old?.text == text })
+            return (old: try #require(row.old?.anchor), new: try #require(row.new?.anchor))
+        }
+
+        for text in ["line 1", "line 2", "line 11", "line 12"] {
+            let collapsedAnchors = try contextAnchors(in: collapsed, text: text)
+            let expandedAnchors = try contextAnchors(in: expanded, text: text)
+            #expect(collapsedAnchors.old == expandedAnchors.old)
+            #expect(collapsedAnchors.new == expandedAnchors.new)
+        }
     }
 
     @Test func selectionRangeNormalizesAnchorOrder() {

--- a/AlasTests/DiffDisplayModelBuilderTests.swift
+++ b/AlasTests/DiffDisplayModelBuilderTests.swift
@@ -22,6 +22,7 @@ struct DiffDisplayModelBuilderTests {
         let model = DiffDisplayModelBuilder.build(diff: sampleDiff(), filePath: "Sources/Foo.swift")
         #expect(model.filePath == "Sources/Foo.swift")
         #expect(model.groups.count == 1)
+        #expect(model.groups[0].header == "@@ -10,4 +10,4 @@")
         #expect(model.groups[0].rows.count == 3)
 
         let replacement = model.groups[0].rows[1]

--- a/AlasTests/DiffDisplayModelBuilderTests.swift
+++ b/AlasTests/DiffDisplayModelBuilderTests.swift
@@ -27,8 +27,26 @@ struct DiffDisplayModelBuilderTests {
 
         let replacement = model.groups[0].rows[1]
         #expect(replacement.kind == .replacement)
-        #expect(replacement.old?.anchor == DiffLineAnchor(filePath: "Sources/Foo.swift", side: .old, oldLine: 11, newLine: nil))
-        #expect(replacement.new?.anchor == DiffLineAnchor(filePath: "Sources/Foo.swift", side: .new, oldLine: nil, newLine: 11))
+        #expect(
+            replacement.old?.anchor == DiffLineAnchor(
+                filePath: "Sources/Foo.swift",
+                hunkIndex: 0,
+                rowIndex: 1,
+                side: .old,
+                oldLine: 11,
+                newLine: nil
+            )
+        )
+        #expect(
+            replacement.new?.anchor == DiffLineAnchor(
+                filePath: "Sources/Foo.swift",
+                hunkIndex: 0,
+                rowIndex: 1,
+                side: .new,
+                oldLine: nil,
+                newLine: 11
+            )
+        )
         #expect(replacement.old?.inlineSpans.map { $0.text(in: replacement.old?.text ?? "") } == ["\"unified\""])
         #expect(replacement.new?.inlineSpans.map { $0.text(in: replacement.new?.text ?? "") } == ["layout"])
     }
@@ -57,10 +75,44 @@ struct DiffDisplayModelBuilderTests {
     }
 
     @Test func selectionRangeNormalizesAnchorOrder() {
-        let a = DiffLineAnchor(filePath: "a.txt", side: .new, oldLine: nil, newLine: 4)
-        let b = DiffLineAnchor(filePath: "a.txt", side: .new, oldLine: nil, newLine: 2)
+        let a = DiffLineAnchor(filePath: "a.txt", hunkIndex: 0, rowIndex: 4, side: .new, oldLine: nil, newLine: 4)
+        let b = DiffLineAnchor(filePath: "a.txt", hunkIndex: 0, rowIndex: 2, side: .new, oldLine: nil, newLine: 2)
         let range = DiffSelectionRange(first: a, last: b)
         #expect(range.normalized.lowerBound == b)
         #expect(range.normalized.upperBound == a)
+    }
+
+    @Test func selectionRangeUsesDisplayOrderWhenOldAndNewLineSpacesDiverge() {
+        let hunk = ParsedDiff.Hunk(
+            header: "@@ -100,3 +10,3 @@",
+            oldStart: 100,
+            newStart: 10,
+            lines: [
+                .init(kind: .context, text: "before", oldNumber: 100, newNumber: 10),
+                .init(kind: .delete, text: "old value", oldNumber: 101, newNumber: nil),
+                .init(kind: .add, text: "new value", oldNumber: nil, newNumber: 11),
+                .init(kind: .context, text: "after", oldNumber: 102, newNumber: 12),
+            ]
+        )
+
+        let model = DiffDisplayModelBuilder.build(diff: ParsedDiff(hunks: [hunk]), filePath: "a.txt")
+        let rows = model.groups[0].rows
+        let first = rows[0].old!.anchor
+        let replacementOld = rows[1].old!.anchor
+        let replacementNew = rows[1].new!.anchor
+        let last = rows[2].new!.anchor
+
+        #expect(replacementOld.hunkIndex == replacementNew.hunkIndex)
+        #expect(replacementOld.rowIndex == replacementNew.rowIndex)
+
+        let sameRowRange = DiffSelectionRange(first: replacementNew, last: replacementOld)
+        #expect(sameRowRange.normalized.lowerBound == replacementOld)
+        #expect(sameRowRange.normalized.upperBound == replacementNew)
+
+        let multiRowRange = DiffSelectionRange(first: first, last: last)
+        #expect(multiRowRange.normalized.lowerBound == first)
+        #expect(multiRowRange.normalized.upperBound == last)
+        #expect(multiRowRange.contains(replacementOld))
+        #expect(multiRowRange.contains(replacementNew))
     }
 }

--- a/AlasTests/DiffDisplayModelBuilderTests.swift
+++ b/AlasTests/DiffDisplayModelBuilderTests.swift
@@ -1,0 +1,65 @@
+import Testing
+@testable import Alas
+
+struct DiffDisplayModelBuilderTests {
+    private func sampleDiff() -> ParsedDiff {
+        ParsedDiff(hunks: [
+            ParsedDiff.Hunk(
+                header: "@@ -10,4 +10,4 @@",
+                oldStart: 10,
+                newStart: 10,
+                lines: [
+                    .init(kind: .context, text: "struct Foo {", oldNumber: 10, newNumber: 10),
+                    .init(kind: .delete, text: "    let mode = \"unified\"", oldNumber: 11, newNumber: nil),
+                    .init(kind: .add, text: "    let mode = layout", oldNumber: nil, newNumber: 11),
+                    .init(kind: .context, text: "}", oldNumber: 12, newNumber: 12),
+                ]
+            )
+        ])
+    }
+
+    @Test func buildsSplitRowsWithStableAnchors() {
+        let model = DiffDisplayModelBuilder.build(diff: sampleDiff(), filePath: "Sources/Foo.swift")
+        #expect(model.filePath == "Sources/Foo.swift")
+        #expect(model.groups.count == 1)
+        #expect(model.groups[0].rows.count == 3)
+
+        let replacement = model.groups[0].rows[1]
+        #expect(replacement.kind == .replacement)
+        #expect(replacement.old?.anchor == DiffLineAnchor(filePath: "Sources/Foo.swift", side: .old, oldLine: 11, newLine: nil))
+        #expect(replacement.new?.anchor == DiffLineAnchor(filePath: "Sources/Foo.swift", side: .new, oldLine: nil, newLine: 11))
+        #expect(replacement.old?.inlineSpans.map { $0.text(in: replacement.old?.text ?? "") } == ["\"unified\""])
+        #expect(replacement.new?.inlineSpans.map { $0.text(in: replacement.new?.text ?? "") } == ["layout"])
+    }
+
+    @Test func preservesHunkForActions() {
+        let diff = sampleDiff()
+        let model = DiffDisplayModelBuilder.build(diff: diff, filePath: "Sources/Foo.swift")
+        #expect(model.groups[0].sourceHunk == diff.hunks[0])
+    }
+
+    @Test func collapsesLargeContextRunsInsideHunk() {
+        let context = (1...12).map {
+            ParsedDiff.Hunk.Line(kind: .context, text: "line \($0)", oldNumber: $0, newNumber: $0)
+        }
+        let hunk = ParsedDiff.Hunk(header: "@@ -1,12 +1,12 @@", oldStart: 1, newStart: 1, lines: context)
+        let model = DiffDisplayModelBuilder.build(
+            diff: ParsedDiff(hunks: [hunk]),
+            filePath: "a.txt",
+            collapseContextThreshold: 6,
+            contextEdgeCount: 2
+        )
+
+        let rows = model.groups[0].rows
+        #expect(rows.map(\.kind) == [.context, .context, .collapsed, .context, .context])
+        #expect(rows[2].collapsedLineCount == 8)
+    }
+
+    @Test func selectionRangeNormalizesAnchorOrder() {
+        let a = DiffLineAnchor(filePath: "a.txt", side: .new, oldLine: nil, newLine: 4)
+        let b = DiffLineAnchor(filePath: "a.txt", side: .new, oldLine: nil, newLine: 2)
+        let range = DiffSelectionRange(first: a, last: b)
+        #expect(range.normalized.lowerBound == b)
+        #expect(range.normalized.upperBound == a)
+    }
+}

--- a/AlasTests/DiffDisplayModelBuilderTests.swift
+++ b/AlasTests/DiffDisplayModelBuilderTests.swift
@@ -74,6 +74,34 @@ struct DiffDisplayModelBuilderTests {
         #expect(rows[2].collapsedLineCount == 8)
     }
 
+    @Test func collapsedRowsCarryHiddenContextRowsWithStableAnchors() throws {
+        let context = (1...12).map { (number: Int) in
+            ParsedDiff.Hunk.Line(kind: .context, text: "line \(number)", oldNumber: number, newNumber: number)
+        }
+        let hunk = ParsedDiff.Hunk(header: "@@ -1,12 +1,12 @@", oldStart: 1, newStart: 1, lines: context)
+        let collapsed = DiffDisplayModelBuilder.build(
+            diff: ParsedDiff(hunks: [hunk]),
+            filePath: "a.txt",
+            collapseContextThreshold: 6,
+            contextEdgeCount: 2
+        )
+        let expanded = DiffDisplayModelBuilder.build(
+            diff: ParsedDiff(hunks: [hunk]),
+            filePath: "a.txt",
+            collapseContextThreshold: 99,
+            contextEdgeCount: 2
+        )
+
+        let collapsedRow = try #require(collapsed.groups[0].rows.first { $0.kind == .collapsed })
+        #expect(collapsedRow.collapsedRows.map { $0.old?.text } == (3...10).map { "line \($0)" })
+
+        for hiddenRow in collapsedRow.collapsedRows {
+            let expandedRow = try #require(expanded.groups[0].rows.first { $0.old?.text == hiddenRow.old?.text })
+            #expect(hiddenRow.old?.anchor == expandedRow.old?.anchor)
+            #expect(hiddenRow.new?.anchor == expandedRow.new?.anchor)
+        }
+    }
+
     @Test func contextAnchorsRemainStableAcrossCollapsedAndExpandedBuilds() throws {
         let context = (1...12).map { (number: Int) in
             ParsedDiff.Hunk.Line(kind: .context, text: "line \(number)", oldNumber: number, newNumber: number)

--- a/AlasTests/DiffInlineHighlighterTests.swift
+++ b/AlasTests/DiffInlineHighlighterTests.swift
@@ -1,0 +1,24 @@
+import Testing
+@testable import Alas
+
+struct DiffInlineHighlighterTests {
+    @Test func highlightsChangedWordInSingleLineReplacement() {
+        let result = DiffInlineHighlighter.highlightDeleteAdd(
+            old: "let mode = \"unified\"",
+            new: "let mode = layout"
+        )
+
+        #expect(result.oldSpans.map { $0.text(in: "let mode = \"unified\"") } == ["\"unified\""])
+        #expect(result.newSpans.map { $0.text(in: "let mode = layout") } == ["layout"])
+    }
+
+    @Test func returnsFullLineSpansWhenLinesAreCompletelyDifferent() {
+        let result = DiffInlineHighlighter.highlightDeleteAdd(
+            old: "final class Renderer {}",
+            new: "import SwiftUI"
+        )
+
+        #expect(result.oldSpans == [DiffInlineSpan(start: 0, length: 23)])
+        #expect(result.newSpans == [DiffInlineSpan(start: 0, length: 14)])
+    }
+}

--- a/AlasTests/DiffPaneViewTests.swift
+++ b/AlasTests/DiffPaneViewTests.swift
@@ -159,6 +159,22 @@ struct DiffPaneViewTests {
         #expect(extended.normalized.contains(lastAnchor))
     }
 
+    @Test func diffLoadTokenInvalidatesOlderLoadForSameKey() {
+        let key = "/repo\u{0}Sources/File.swift\u{0}false"
+        let first = DiffLoadToken.next(key: key)
+        var activeKey: String? = first.key
+        var activeID = first.id
+
+        #expect(first.isActive(activeKey: activeKey, activeID: activeID))
+
+        let second = DiffLoadToken.next(key: key)
+        activeKey = second.key
+        activeID = second.id
+
+        #expect(!first.isActive(activeKey: activeKey, activeID: activeID))
+        #expect(second.isActive(activeKey: activeKey, activeID: activeID))
+    }
+
     private func allSubviews(of view: NSView) -> [NSView] {
         view.subviews + view.subviews.flatMap { allSubviews(of: $0) }
     }

--- a/AlasTests/DiffPaneViewTests.swift
+++ b/AlasTests/DiffPaneViewTests.swift
@@ -121,6 +121,83 @@ struct DiffPaneViewTests {
         #expect(!selectableText.contains("-2"))
     }
 
+    @Test func splitPaneExposesDiffLineTonesForRailsAndPlaceholders() throws {
+        var layout = DiffLayoutMode.split
+        var wrap = false
+        var whitespace = false
+        let view = DiffPaneView(
+            model: model(),
+            fileExtension: "swift",
+            layoutMode: Binding(get: { layout }, set: { layout = $0 }),
+            wrapLines: Binding(get: { wrap }, set: { wrap = $0 }),
+            showWhitespace: Binding(get: { whitespace }, set: { whitespace = $0 }),
+            codeFontFamily: "",
+            codeFontSize: 13,
+            hunkActions: { _ in DiffPaneHunkActions() }
+        )
+        .environment(\.theme, theme())
+
+        let controller = NSHostingController(rootView: view)
+        controller.view.frame = NSRect(x: 0, y: 0, width: 900, height: 400)
+        controller.view.layoutSubtreeIfNeeded()
+
+        let codeViews = allSubviews(of: controller.view)
+            .compactMap { $0 as? DiffPaneTextScrollView }
+            .filter { !$0.isHidden }
+            .compactMap { $0.documentView as? DiffPaneCodeTextView }
+        #expect(codeViews.count == 2)
+        let tones = codeViews.flatMap(\.lineTones)
+        #expect(tones.contains(.delete))
+        #expect(tones.contains(.add))
+        #expect(tones.contains(.context))
+    }
+
+    @Test func gutterRowsAlignWithCodeRowsInSplitPane() throws {
+        var layout = DiffLayoutMode.split
+        var wrap = false
+        var whitespace = false
+        let view = DiffPaneView(
+            model: model(),
+            fileExtension: "swift",
+            layoutMode: Binding(get: { layout }, set: { layout = $0 }),
+            wrapLines: Binding(get: { wrap }, set: { wrap = $0 }),
+            showWhitespace: Binding(get: { whitespace }, set: { whitespace = $0 }),
+            codeFontFamily: "",
+            codeFontSize: 13,
+            hunkActions: { _ in DiffPaneHunkActions() }
+        )
+        .environment(\.theme, theme())
+
+        let controller = NSHostingController(rootView: view)
+        controller.view.frame = NSRect(x: 0, y: 0, width: 900, height: 400)
+        controller.view.layoutSubtreeIfNeeded()
+
+        let splitScrollViews = allSubviews(of: controller.view)
+            .compactMap { $0 as? DiffPaneTextScrollView }
+            .filter { !$0.isHidden }
+
+        for scrollView in splitScrollViews {
+            let codeView = try #require(scrollView.documentView as? DiffPaneCodeTextView)
+            let ruler = try #require(scrollView.verticalRulerView as? DiffPaneLineNumberRulerView)
+            let codeRows = codeView.diffRowRects()
+            let rulerRows = ruler.diffRowRects()
+
+            #expect(codeRows.count == rulerRows.count)
+            for index in 0..<min(codeRows.count, rulerRows.count) {
+                #expect(abs(codeRows[index].minY - rulerRows[index].minY) < 0.5)
+                #expect(abs(codeRows[index].height - rulerRows[index].height) < 0.5)
+            }
+        }
+    }
+
+    @Test func diffLineToneClassifiesRailsAndEmptyCounterparts() {
+        #expect(DiffPaneLineTone(label: "-12", rowKind: .delete) == .delete)
+        #expect(DiffPaneLineTone(label: "+13", rowKind: .add) == .add)
+        #expect(DiffPaneLineTone(label: "", rowKind: .add) == .placeholder)
+        #expect(DiffPaneLineTone(label: "", rowKind: .collapsed) == .collapsed)
+        #expect(DiffPaneLineTone(label: " 8", rowKind: .context) == .context)
+    }
+
     @Test func splitDocumentBuildsSeparateCodeAndGutterColumns() throws {
         let result = DiffPaneTextDocumentBuilder.buildSplit(
             group: try #require(model().groups.first),

--- a/AlasTests/DiffPaneViewTests.swift
+++ b/AlasTests/DiffPaneViewTests.swift
@@ -86,6 +86,16 @@ struct DiffPaneViewTests {
         #expect(DiffPaneScrollPolicy.usesIntrinsicContentWidth(layoutMode: .stacked, wrapLines: false))
     }
 
+    @Test func codeAreaKeepsNativeTextSelectionAvailable() {
+        #expect(DiffPaneInteractionPolicy.allowsNativeTextSelection(from: .code))
+        #expect(!DiffPaneInteractionPolicy.startsLineSelection(from: .code))
+    }
+
+    @Test func gutterStartsDiffLineSelection() {
+        #expect(!DiffPaneInteractionPolicy.allowsNativeTextSelection(from: .gutter))
+        #expect(DiffPaneInteractionPolicy.startsLineSelection(from: .gutter))
+    }
+
     @Test func hunkActionsRenderInPaneHeader() {
         var layout = DiffLayoutMode.split
         var wrap = false

--- a/AlasTests/DiffPaneViewTests.swift
+++ b/AlasTests/DiffPaneViewTests.swift
@@ -92,7 +92,7 @@ struct DiffPaneViewTests {
 
         let splitScrollViews = allSubviews(of: controller.view)
             .compactMap { $0 as? DiffPaneTextScrollView }
-            .filter { !$0.isHidden }
+            .filter(isEffectivelyVisible)
         let allHaveRulers = splitScrollViews.allSatisfy { scrollView in
             scrollView.verticalRulerView is DiffPaneLineNumberRulerView
         }
@@ -143,7 +143,7 @@ struct DiffPaneViewTests {
 
         let codeViews = allSubviews(of: controller.view)
             .compactMap { $0 as? DiffPaneTextScrollView }
-            .filter { !$0.isHidden }
+            .filter(isEffectivelyVisible)
             .compactMap { $0.documentView as? DiffPaneCodeTextView }
         #expect(codeViews.count == 2)
         let tones = codeViews.flatMap(\.lineTones)
@@ -174,7 +174,7 @@ struct DiffPaneViewTests {
 
         let splitScrollViews = allSubviews(of: controller.view)
             .compactMap { $0 as? DiffPaneTextScrollView }
-            .filter { !$0.isHidden }
+            .filter(isEffectivelyVisible)
 
         for scrollView in splitScrollViews {
             let codeView = try #require(scrollView.documentView as? DiffPaneCodeTextView)
@@ -188,6 +188,117 @@ struct DiffPaneViewTests {
                 #expect(abs(codeRows[index].height - rulerRows[index].height) < 0.5)
             }
         }
+    }
+
+    @Test func leadingEmptyCounterpartRowsAlignWithCodeRowsInSplitPane() throws {
+        let model = DiffDisplayModelBuilder.build(
+            diff: ParsedDiff(hunks: [
+                ParsedDiff.Hunk(
+                    header: "@@ -1,1 +1,2 @@",
+                    oldStart: 1,
+                    newStart: 1,
+                    lines: [
+                        .init(kind: .add, text: "let inserted = true", oldNumber: nil, newNumber: 1),
+                        .init(kind: .context, text: "let c = 3", oldNumber: 1, newNumber: 2),
+                    ]
+                )
+            ]),
+            filePath: "a.swift"
+        )
+        var layout = DiffLayoutMode.split
+        var wrap = false
+        var whitespace = false
+        let view = DiffPaneView(
+            model: model,
+            fileExtension: "swift",
+            layoutMode: Binding(get: { layout }, set: { layout = $0 }),
+            wrapLines: Binding(get: { wrap }, set: { wrap = $0 }),
+            showWhitespace: Binding(get: { whitespace }, set: { whitespace = $0 }),
+            codeFontFamily: "",
+            codeFontSize: 13,
+            hunkActions: { _ in DiffPaneHunkActions() }
+        )
+        .environment(\.theme, theme())
+
+        let controller = NSHostingController(rootView: view)
+        controller.view.frame = NSRect(x: 0, y: 0, width: 900, height: 400)
+        controller.view.layoutSubtreeIfNeeded()
+
+        let splitScrollViews = allSubviews(of: controller.view)
+            .compactMap { $0 as? DiffPaneTextScrollView }
+            .filter(isEffectivelyVisible)
+            .sorted { $0.frame.minX < $1.frame.minX }
+        #expect(splitScrollViews.count == 2)
+
+        let oldCodeView = try #require(splitScrollViews.first?.documentView as? DiffPaneCodeTextView)
+        let newCodeView = try #require(splitScrollViews.last?.documentView as? DiffPaneCodeTextView)
+        let oldRows = oldCodeView.diffRowRects()
+        let newRows = newCodeView.diffRowRects()
+        #expect(oldRows.count == newRows.count)
+        #expect(oldRows.count >= 2)
+        #expect(abs(oldRows[0].minY - oldCodeView.textContainerInset.height) < 0.5)
+        #expect(abs(newRows[0].minY - newCodeView.textContainerInset.height) < 0.5)
+        #expect(abs(oldRows[0].minY - newRows[0].minY) < 0.5)
+        #expect(abs(oldRows[0].height - newRows[0].height) < 0.5)
+        #expect(abs(oldRows[1].minY - newRows[1].minY) < 0.5)
+    }
+
+    @Test func wrappedEmptyCounterpartRowsReserveCounterpartHeightInSplitPane() throws {
+        let model = DiffDisplayModelBuilder.build(
+            diff: ParsedDiff(hunks: [
+                ParsedDiff.Hunk(
+                    header: "@@ -1,1 +1,2 @@",
+                    oldStart: 1,
+                    newStart: 1,
+                    lines: [
+                        .init(
+                            kind: .add,
+                            text: "let inserted = \"This is intentionally long enough to wrap inside the split pane so the empty old-side counterpart has to reserve more than one visual line of height.\"",
+                            oldNumber: nil,
+                            newNumber: 1
+                        ),
+                        .init(kind: .context, text: "let c = 3", oldNumber: 1, newNumber: 2),
+                    ]
+                )
+            ]),
+            filePath: "a.swift"
+        )
+        var layout = DiffLayoutMode.split
+        var wrap = true
+        var whitespace = false
+        let view = DiffPaneView(
+            model: model,
+            fileExtension: "swift",
+            layoutMode: Binding(get: { layout }, set: { layout = $0 }),
+            wrapLines: Binding(get: { wrap }, set: { wrap = $0 }),
+            showWhitespace: Binding(get: { whitespace }, set: { whitespace = $0 }),
+            codeFontFamily: "",
+            codeFontSize: 13,
+            hunkActions: { _ in DiffPaneHunkActions() }
+        )
+        .environment(\.theme, theme())
+
+        let controller = NSHostingController(rootView: view)
+        controller.view.frame = NSRect(x: 0, y: 0, width: 360, height: 400)
+        controller.view.layoutSubtreeIfNeeded()
+
+        let splitScrollViews = allSubviews(of: controller.view)
+            .compactMap { $0 as? DiffPaneTextScrollView }
+            .filter(isEffectivelyVisible)
+            .sorted { $0.frame.minX < $1.frame.minX }
+        #expect(splitScrollViews.count == 2)
+
+        let oldCodeView = try #require(splitScrollViews.first?.documentView as? DiffPaneCodeTextView)
+        let newCodeView = try #require(splitScrollViews.last?.documentView as? DiffPaneCodeTextView)
+        let oldRows = oldCodeView.diffRowRects()
+        let newRows = newCodeView.diffRowRects()
+
+        #expect(oldRows.count == newRows.count)
+        #expect(oldRows.count >= 2)
+        #expect(abs(oldRows[0].minY - oldCodeView.textContainerInset.height) < 0.5)
+        #expect(abs(newRows[0].minY - newCodeView.textContainerInset.height) < 0.5)
+        #expect(abs(oldRows[0].height - newRows[0].height) < 0.5)
+        #expect(abs(oldRows[1].minY - newRows[1].minY) < 0.5)
     }
 
     @Test func diffLineToneClassifiesRailsAndEmptyCounterparts() {
@@ -239,6 +350,37 @@ struct DiffPaneViewTests {
         #expect(result.gutter.string.components(separatedBy: "\n") == [" 1", "-2", "+2"])
         #expect(!result.code.attributedString.string.contains("|"))
         #expect(result.code.lines.contains { $0.kind == .replacement })
+    }
+
+    @Test func splitDocumentUsesInvisibleLayoutGlyphsForEmptyCounterparts() throws {
+        let model = DiffDisplayModelBuilder.build(
+            diff: ParsedDiff(hunks: [
+                ParsedDiff.Hunk(
+                    header: "@@ -1,1 +1,2 @@",
+                    oldStart: 1,
+                    newStart: 1,
+                    lines: [
+                        .init(kind: .add, text: "let inserted = true", oldNumber: nil, newNumber: 1),
+                        .init(kind: .context, text: "let c = 3", oldNumber: 1, newNumber: 2),
+                    ]
+                )
+            ]),
+            filePath: "a.swift"
+        )
+        let result = DiffPaneTextDocumentBuilder.buildSplit(
+            group: try #require(model.groups.first),
+            expandedCollapsedRowIDs: [],
+            fileExtension: "swift",
+            font: CenterTypography.resolveCodeFont(family: "", size: 13),
+            showWhitespace: false,
+            theme: theme()
+        )
+        let firstLine = try #require(result.oldCode.lines.first)
+
+        #expect(firstLine.kind == .add)
+        #expect(firstLine.range.length > 0)
+        #expect(result.oldCode.attributedString.string.hasPrefix(" "))
+        #expect(result.oldCode.attributedString.attribute(.foregroundColor, at: firstLine.range.location, effectiveRange: nil) as? NSColor == .clear)
     }
 
     @Test func hunkActionsRenderInPaneHeader() {
@@ -348,5 +490,16 @@ struct DiffPaneViewTests {
 
     private func allSubviews(of view: NSView) -> [NSView] {
         view.subviews + view.subviews.flatMap { allSubviews(of: $0) }
+    }
+
+    private func isEffectivelyVisible(_ view: NSView) -> Bool {
+        var current: NSView? = view
+        while let candidate = current {
+            if candidate.isHidden {
+                return false
+            }
+            current = candidate.superview
+        }
+        return true
     }
 }

--- a/AlasTests/DiffPaneViewTests.swift
+++ b/AlasTests/DiffPaneViewTests.swift
@@ -70,30 +70,64 @@ struct DiffPaneViewTests {
         #expect(controller.view.subviews.isEmpty == false)
     }
 
-    @Test func splitModeKeepsColumnsInViewportWhenWrappingIsOff() {
-        let axes = DiffPaneScrollPolicy.axes(layoutMode: .split, wrapLines: false)
+    @Test func diffPaneHostsNativeSelectableTextView() throws {
+        var layout = DiffLayoutMode.split
+        var wrap = false
+        var whitespace = false
+        let view = DiffPaneView(
+            model: model(),
+            fileExtension: "swift",
+            layoutMode: Binding(get: { layout }, set: { layout = $0 }),
+            wrapLines: Binding(get: { wrap }, set: { wrap = $0 }),
+            showWhitespace: Binding(get: { whitespace }, set: { whitespace = $0 }),
+            codeFontFamily: "",
+            codeFontSize: 13,
+            hunkActions: { _ in DiffPaneHunkActions() }
+        )
+        .environment(\.theme, theme())
 
-        #expect(axes.contains(.vertical))
-        #expect(!axes.contains(.horizontal))
-        #expect(!DiffPaneScrollPolicy.usesIntrinsicContentWidth(layoutMode: .split, wrapLines: false))
+        let controller = NSHostingController(rootView: view)
+        controller.view.frame = NSRect(x: 0, y: 0, width: 900, height: 400)
+        controller.view.layoutSubtreeIfNeeded()
+
+        let textView = try #require(allSubviews(of: controller.view).compactMap { $0 as? NSTextView }.first)
+        #expect(textView.isSelectable)
+        #expect(!textView.isEditable)
+        #expect(textView.string.contains("let b = 2"))
+        #expect(textView.string.contains("let b = 3"))
     }
 
-    @Test func stackedModeKeepsHorizontalScrollWhenWrappingIsOff() {
-        let axes = DiffPaneScrollPolicy.axes(layoutMode: .stacked, wrapLines: false)
+    @Test func splitDocumentKeepsReplacementSidesOnOneVisualRow() throws {
+        let result = DiffPaneTextDocumentBuilder.build(
+            group: try #require(model().groups.first),
+            expandedCollapsedRowIDs: [],
+            layoutMode: .split,
+            fileExtension: "swift",
+            font: CenterTypography.resolveCodeFont(family: "", size: 13),
+            showWhitespace: false,
+            theme: theme()
+        )
 
-        #expect(axes.contains(.vertical))
-        #expect(axes.contains(.horizontal))
-        #expect(DiffPaneScrollPolicy.usesIntrinsicContentWidth(layoutMode: .stacked, wrapLines: false))
+        let rows = result.attributedString.string.components(separatedBy: "\n")
+        #expect(rows.contains { $0.contains("let b = 2") && $0.contains("\t") && $0.contains("let b = 3") })
+        #expect(result.lines.contains { $0.kind == .replacement })
     }
 
-    @Test func codeAreaKeepsNativeTextSelectionAvailable() {
-        #expect(DiffPaneInteractionPolicy.allowsNativeTextSelection(from: .code))
-        #expect(!DiffPaneInteractionPolicy.startsLineSelection(from: .code))
-    }
+    @Test func stackedDocumentProjectsReplacementSidesOntoSeparateRows() throws {
+        let result = DiffPaneTextDocumentBuilder.build(
+            group: try #require(model().groups.first),
+            expandedCollapsedRowIDs: [],
+            layoutMode: .stacked,
+            fileExtension: "swift",
+            font: CenterTypography.resolveCodeFont(family: "", size: 13),
+            showWhitespace: false,
+            theme: theme()
+        )
 
-    @Test func gutterStartsDiffLineSelection() {
-        #expect(!DiffPaneInteractionPolicy.allowsNativeTextSelection(from: .gutter))
-        #expect(DiffPaneInteractionPolicy.startsLineSelection(from: .gutter))
+        let rows = result.attributedString.string.components(separatedBy: "\n")
+        #expect(rows.contains { $0.contains("let b = 2") })
+        #expect(rows.contains { $0.contains("let b = 3") })
+        #expect(!rows.contains { $0.contains("let b = 2\t") && $0.contains("let b = 3") })
     }
 
     @Test func hunkActionsRenderInPaneHeader() {

--- a/AlasTests/DiffPaneViewTests.swift
+++ b/AlasTests/DiffPaneViewTests.swift
@@ -69,4 +69,21 @@ struct DiffPaneViewTests {
         controller.view.layoutSubtreeIfNeeded()
         #expect(controller.view.subviews.isEmpty == false)
     }
+
+    @Test func visibleWhitespacePreservesInlineBackgrounds() {
+        let rendered = DiffCodeText.attributedString(
+            text: "\tlet b = 3",
+            fileExtension: "swift",
+            codeFontFamily: "",
+            codeFontSize: 13,
+            showWhitespace: true,
+            inlineSpans: [DiffInlineSpan(start: 9, length: 1)],
+            inlineTone: .add,
+            theme: theme()
+        )
+
+        #expect(rendered.string == "→let·b·=·3")
+        #expect((rendered.string as NSString).length == ("\tlet b = 3" as NSString).length)
+        #expect(rendered.attribute(.backgroundColor, at: 9, effectiveRange: nil) != nil)
+    }
 }

--- a/AlasTests/DiffPaneViewTests.swift
+++ b/AlasTests/DiffPaneViewTests.swift
@@ -70,6 +70,22 @@ struct DiffPaneViewTests {
         #expect(controller.view.subviews.isEmpty == false)
     }
 
+    @Test func splitModeKeepsColumnsInViewportWhenWrappingIsOff() {
+        let axes = DiffPaneScrollPolicy.axes(layoutMode: .split, wrapLines: false)
+
+        #expect(axes.contains(.vertical))
+        #expect(!axes.contains(.horizontal))
+        #expect(!DiffPaneScrollPolicy.usesIntrinsicContentWidth(layoutMode: .split, wrapLines: false))
+    }
+
+    @Test func stackedModeKeepsHorizontalScrollWhenWrappingIsOff() {
+        let axes = DiffPaneScrollPolicy.axes(layoutMode: .stacked, wrapLines: false)
+
+        #expect(axes.contains(.vertical))
+        #expect(axes.contains(.horizontal))
+        #expect(DiffPaneScrollPolicy.usesIntrinsicContentWidth(layoutMode: .stacked, wrapLines: false))
+    }
+
     @Test func hunkActionsRenderInPaneHeader() {
         var layout = DiffLayoutMode.split
         var wrap = false

--- a/AlasTests/DiffPaneViewTests.swift
+++ b/AlasTests/DiffPaneViewTests.swift
@@ -86,4 +86,39 @@ struct DiffPaneViewTests {
         #expect((rendered.string as NSString).length == ("\tlet b = 3" as NSString).length)
         #expect(rendered.attribute(.backgroundColor, at: 9, effectiveRange: nil) != nil)
     }
+
+    @Test func stackedProjectionRendersContextRowsOnce() throws {
+        let row = try #require(model().groups[0].rows.first)
+        #expect(row.kind == .context)
+        #expect(row.old?.text == row.new?.text)
+
+        let lines = DiffPaneRowProjection.stackedLines(for: row)
+
+        #expect(lines.map(\.text) == ["let a = 1"])
+        #expect(lines.map(\.anchor.side) == [.new])
+    }
+
+    @Test func selectionReducerExtendsRangeOnShiftClick() throws {
+        let rows = model().groups[0].rows
+        let firstAnchor = try #require(rows[0].new?.anchor)
+        let lastAnchor = try #require(rows[1].new?.anchor)
+
+        let firstSelection = DiffSelectionController.selection(
+            current: nil,
+            clicked: firstAnchor,
+            extend: false
+        )
+        #expect(firstSelection.first == firstAnchor)
+        #expect(firstSelection.last == firstAnchor)
+
+        let extended = DiffSelectionController.selection(
+            current: firstSelection,
+            clicked: lastAnchor,
+            extend: true
+        )
+        #expect(extended.first == firstAnchor)
+        #expect(extended.last == lastAnchor)
+        #expect(extended.normalized.contains(firstAnchor))
+        #expect(extended.normalized.contains(lastAnchor))
+    }
 }

--- a/AlasTests/DiffPaneViewTests.swift
+++ b/AlasTests/DiffPaneViewTests.swift
@@ -70,7 +70,7 @@ struct DiffPaneViewTests {
         #expect(controller.view.subviews.isEmpty == false)
     }
 
-    @Test func diffPaneHostsNativeSelectableCodeTextViewsWithSeparateGutters() throws {
+    @Test func splitPaneUsesMergeStyleScrollPanesWithLineRulers() throws {
         var layout = DiffLayoutMode.split
         var wrap = false
         var whitespace = false
@@ -90,16 +90,28 @@ struct DiffPaneViewTests {
         controller.view.frame = NSRect(x: 0, y: 0, width: 900, height: 400)
         controller.view.layoutSubtreeIfNeeded()
 
-        let textViews = allSubviews(of: controller.view)
-            .compactMap { $0 as? NSTextView }
+        let splitScrollViews = allSubviews(of: controller.view)
+            .compactMap { $0 as? DiffPaneTextScrollView }
             .filter { !$0.isHidden }
+        let allHaveRulers = splitScrollViews.allSatisfy { scrollView in
+            scrollView.verticalRulerView is DiffPaneLineNumberRulerView
+        }
+        let allRulersVisible = splitScrollViews.allSatisfy { scrollView in
+            scrollView.rulersVisible
+        }
+        let allHorizontallyScrollable = splitScrollViews.allSatisfy { scrollView in
+            scrollView.hasHorizontalScroller
+        }
+        #expect(splitScrollViews.count == 2)
+        #expect(allHaveRulers)
+        #expect(allRulersVisible)
+        #expect(allHorizontallyScrollable)
+
+        let textViews = splitScrollViews.compactMap { $0.documentView as? NSTextView }
         let selectableTextViews = textViews.filter(\.isSelectable)
-        let gutterTextViews = textViews.filter { !$0.isSelectable }
 
         #expect(selectableTextViews.count == 2)
-        #expect(gutterTextViews.count == 2)
         #expect(selectableTextViews.allSatisfy { !$0.isEditable })
-        #expect(gutterTextViews.allSatisfy { !$0.isEditable })
 
         let selectableText = selectableTextViews.map(\.string).joined(separator: "\n")
         #expect(selectableText.contains("let b = 2"))
@@ -107,10 +119,6 @@ struct DiffPaneViewTests {
         #expect(!selectableText.contains("|"))
         #expect(!selectableText.contains("+2"))
         #expect(!selectableText.contains("-2"))
-
-        let gutterText = gutterTextViews.map(\.string).joined(separator: "\n")
-        #expect(gutterText.contains("-2"))
-        #expect(gutterText.contains("+2"))
     }
 
     @Test func splitDocumentBuildsSeparateCodeAndGutterColumns() throws {

--- a/AlasTests/DiffPaneViewTests.swift
+++ b/AlasTests/DiffPaneViewTests.swift
@@ -26,6 +26,22 @@ struct DiffPaneViewTests {
         )
     }
 
+    private func collapsedContextModel() -> DiffDisplayModel {
+        DiffDisplayModelBuilder.build(
+            diff: ParsedDiff(hunks: [
+                ParsedDiff.Hunk(
+                    header: "@@ -1,15 +1,15 @@",
+                    oldStart: 1,
+                    newStart: 1,
+                    lines: (1...15).map {
+                        .init(kind: .context, text: "let value\($0) = \($0)", oldNumber: $0, newNumber: $0)
+                    }
+                )
+            ]),
+            filePath: "a.swift"
+        )
+    }
+
     @Test func splitModeHostsRendererWithoutCrashing() {
         var layout = DiffLayoutMode.split
         var wrap = false
@@ -188,6 +204,45 @@ struct DiffPaneViewTests {
                 #expect(abs(codeRows[index].height - rulerRows[index].height) < 0.5)
             }
         }
+    }
+
+    @Test func collapsedContextControllerTogglesHiddenRows() throws {
+        let group = try #require(collapsedContextModel().groups.first)
+        let collapsedIDs = DiffCollapsedContextController.collapsedRowIDs(in: group)
+        #expect(collapsedIDs.isEmpty == false)
+
+        let expandedIDs = DiffCollapsedContextController.toggled(group, expandedIDs: [])
+        #expect(collapsedIDs.isSubset(of: expandedIDs))
+        #expect(DiffCollapsedContextController.isExpanded(group, expandedIDs: expandedIDs))
+        #expect(DiffPaneRowProjection.visibleRows(in: group, expandedCollapsedRowIDs: expandedIDs).count > group.rows.count)
+
+        let collapsedAgain = DiffCollapsedContextController.toggled(group, expandedIDs: expandedIDs)
+        #expect(collapsedAgain.intersection(collapsedIDs).isEmpty)
+    }
+
+    @Test func collapsedContextControlRendersInPaneHeader() {
+        var layout = DiffLayoutMode.split
+        var wrap = false
+        var whitespace = false
+        let view = DiffPaneView(
+            model: collapsedContextModel(),
+            fileExtension: "swift",
+            layoutMode: Binding(get: { layout }, set: { layout = $0 }),
+            wrapLines: Binding(get: { wrap }, set: { wrap = $0 }),
+            showWhitespace: Binding(get: { whitespace }, set: { whitespace = $0 }),
+            codeFontFamily: "",
+            codeFontSize: 13,
+            hunkActions: { _ in DiffPaneHunkActions() }
+        )
+        .environment(\.theme, theme())
+
+        let controller = NSHostingController(rootView: view)
+        controller.view.frame = NSRect(x: 0, y: 0, width: 900, height: 400)
+        controller.view.layoutSubtreeIfNeeded()
+
+        let buttons = allSubviews(of: controller.view).compactMap { $0 as? NSButton }
+        let helpTexts = buttons.compactMap { $0.toolTip }
+        #expect(helpTexts.contains("Expand context"))
     }
 
     @Test func leadingEmptyCounterpartRowsAlignWithCodeRowsInSplitPane() throws {

--- a/AlasTests/DiffPaneViewTests.swift
+++ b/AlasTests/DiffPaneViewTests.swift
@@ -70,6 +70,33 @@ struct DiffPaneViewTests {
         #expect(controller.view.subviews.isEmpty == false)
     }
 
+    @Test func hunkActionsRenderInPaneHeader() {
+        var layout = DiffLayoutMode.split
+        var wrap = false
+        var whitespace = false
+        let view = DiffPaneView(
+            model: model(),
+            fileExtension: "swift",
+            layoutMode: Binding(get: { layout }, set: { layout = $0 }),
+            wrapLines: Binding(get: { wrap }, set: { wrap = $0 }),
+            showWhitespace: Binding(get: { whitespace }, set: { whitespace = $0 }),
+            codeFontFamily: "",
+            codeFontSize: 13,
+            hunkActions: { _ in
+                DiffPaneHunkActions(stage: {}, discard: {}, dropFromCommit: nil)
+            }
+        )
+        .environment(\.theme, theme())
+
+        let controller = NSHostingController(rootView: view)
+        controller.view.frame = NSRect(x: 0, y: 0, width: 900, height: 400)
+        controller.view.layoutSubtreeIfNeeded()
+        let buttons = allSubviews(of: controller.view).compactMap { $0 as? NSButton }
+        let helpTexts = buttons.compactMap { $0.toolTip }
+        #expect(helpTexts.contains("Stage hunk"))
+        #expect(helpTexts.contains("Discard hunk"))
+    }
+
     @Test func visibleWhitespacePreservesInlineBackgrounds() {
         let rendered = DiffCodeText.attributedString(
             text: "\tlet b = 3",
@@ -130,5 +157,9 @@ struct DiffPaneViewTests {
         #expect(extended.last == lastAnchor)
         #expect(extended.normalized.contains(firstAnchor))
         #expect(extended.normalized.contains(lastAnchor))
+    }
+
+    private func allSubviews(of view: NSView) -> [NSView] {
+        view.subviews + view.subviews.flatMap { allSubviews(of: $0) }
     }
 }

--- a/AlasTests/DiffPaneViewTests.swift
+++ b/AlasTests/DiffPaneViewTests.swift
@@ -70,7 +70,7 @@ struct DiffPaneViewTests {
         #expect(controller.view.subviews.isEmpty == false)
     }
 
-    @Test func diffPaneHostsNativeSelectableTextView() throws {
+    @Test func diffPaneHostsNativeSelectableCodeTextViewsWithSeparateGutters() throws {
         var layout = DiffLayoutMode.split
         var wrap = false
         var whitespace = false
@@ -90,44 +90,70 @@ struct DiffPaneViewTests {
         controller.view.frame = NSRect(x: 0, y: 0, width: 900, height: 400)
         controller.view.layoutSubtreeIfNeeded()
 
-        let textView = try #require(allSubviews(of: controller.view).compactMap { $0 as? NSTextView }.first)
-        #expect(textView.isSelectable)
-        #expect(!textView.isEditable)
-        #expect(textView.string.contains("let b = 2"))
-        #expect(textView.string.contains("let b = 3"))
+        let textViews = allSubviews(of: controller.view)
+            .compactMap { $0 as? NSTextView }
+            .filter { !$0.isHidden }
+        let selectableTextViews = textViews.filter(\.isSelectable)
+        let gutterTextViews = textViews.filter { !$0.isSelectable }
+
+        #expect(selectableTextViews.count == 2)
+        #expect(gutterTextViews.count == 2)
+        #expect(selectableTextViews.allSatisfy { !$0.isEditable })
+        #expect(gutterTextViews.allSatisfy { !$0.isEditable })
+
+        let selectableText = selectableTextViews.map(\.string).joined(separator: "\n")
+        #expect(selectableText.contains("let b = 2"))
+        #expect(selectableText.contains("let b = 3"))
+        #expect(!selectableText.contains("|"))
+        #expect(!selectableText.contains("+2"))
+        #expect(!selectableText.contains("-2"))
+
+        let gutterText = gutterTextViews.map(\.string).joined(separator: "\n")
+        #expect(gutterText.contains("-2"))
+        #expect(gutterText.contains("+2"))
     }
 
-    @Test func splitDocumentKeepsReplacementSidesOnOneVisualRow() throws {
-        let result = DiffPaneTextDocumentBuilder.build(
+    @Test func splitDocumentBuildsSeparateCodeAndGutterColumns() throws {
+        let result = DiffPaneTextDocumentBuilder.buildSplit(
             group: try #require(model().groups.first),
             expandedCollapsedRowIDs: [],
-            layoutMode: .split,
             fileExtension: "swift",
             font: CenterTypography.resolveCodeFont(family: "", size: 13),
             showWhitespace: false,
             theme: theme()
         )
 
-        let rows = result.attributedString.string.components(separatedBy: "\n")
-        #expect(rows.contains { $0.contains("let b = 2") && $0.contains("\t") && $0.contains("let b = 3") })
-        #expect(result.lines.contains { $0.kind == .replacement })
+        #expect(result.oldCode.attributedString.string.components(separatedBy: "\n") == [
+            "let a = 1",
+            "let b = 2",
+        ])
+        #expect(result.newCode.attributedString.string.components(separatedBy: "\n") == [
+            "let a = 1",
+            "let b = 3",
+        ])
+        #expect(result.oldGutter.string.components(separatedBy: "\n") == [" 1", "-2"])
+        #expect(result.newGutter.string.components(separatedBy: "\n") == [" 1", "+2"])
+        #expect(!result.oldCode.attributedString.string.contains("|"))
+        #expect(!result.newCode.attributedString.string.contains("|"))
+        #expect(result.oldCode.lines.contains { $0.kind == .replacement })
+        #expect(result.newCode.lines.contains { $0.kind == .replacement })
     }
 
-    @Test func stackedDocumentProjectsReplacementSidesOntoSeparateRows() throws {
-        let result = DiffPaneTextDocumentBuilder.build(
+    @Test func stackedDocumentBuildsCodeOnlyTextAndSeparateGutter() throws {
+        let result = DiffPaneTextDocumentBuilder.buildStacked(
             group: try #require(model().groups.first),
             expandedCollapsedRowIDs: [],
-            layoutMode: .stacked,
             fileExtension: "swift",
             font: CenterTypography.resolveCodeFont(family: "", size: 13),
             showWhitespace: false,
             theme: theme()
         )
 
-        let rows = result.attributedString.string.components(separatedBy: "\n")
-        #expect(rows.contains { $0.contains("let b = 2") })
-        #expect(rows.contains { $0.contains("let b = 3") })
-        #expect(!rows.contains { $0.contains("let b = 2\t") && $0.contains("let b = 3") })
+        let rows = result.code.attributedString.string.components(separatedBy: "\n")
+        #expect(rows == ["let a = 1", "let b = 2", "let b = 3"])
+        #expect(result.gutter.string.components(separatedBy: "\n") == [" 1", "-2", "+2"])
+        #expect(!result.code.attributedString.string.contains("|"))
+        #expect(result.code.lines.contains { $0.kind == .replacement })
     }
 
     @Test func hunkActionsRenderInPaneHeader() {

--- a/AlasTests/DiffPaneViewTests.swift
+++ b/AlasTests/DiffPaneViewTests.swift
@@ -1,0 +1,72 @@
+import AppKit
+import SwiftUI
+import Testing
+@testable import Alas
+
+@Suite(.serialized)
+@MainActor
+struct DiffPaneViewTests {
+    private func theme() -> Theme { try! ThemeStore().current }
+
+    private func model() -> DiffDisplayModel {
+        DiffDisplayModelBuilder.build(
+            diff: ParsedDiff(hunks: [
+                ParsedDiff.Hunk(
+                    header: "@@ -1,2 +1,2 @@",
+                    oldStart: 1,
+                    newStart: 1,
+                    lines: [
+                        .init(kind: .context, text: "let a = 1", oldNumber: 1, newNumber: 1),
+                        .init(kind: .delete, text: "let b = 2", oldNumber: 2, newNumber: nil),
+                        .init(kind: .add, text: "let b = 3", oldNumber: nil, newNumber: 2),
+                    ]
+                )
+            ]),
+            filePath: "a.swift"
+        )
+    }
+
+    @Test func splitModeHostsRendererWithoutCrashing() {
+        var layout = DiffLayoutMode.split
+        var wrap = false
+        var whitespace = false
+        let view = DiffPaneView(
+            model: model(),
+            fileExtension: "swift",
+            layoutMode: Binding(get: { layout }, set: { layout = $0 }),
+            wrapLines: Binding(get: { wrap }, set: { wrap = $0 }),
+            showWhitespace: Binding(get: { whitespace }, set: { whitespace = $0 }),
+            codeFontFamily: "",
+            codeFontSize: 13,
+            hunkActions: { _ in DiffPaneHunkActions() }
+        )
+        .environment(\.theme, theme())
+
+        let controller = NSHostingController(rootView: view)
+        controller.view.frame = NSRect(x: 0, y: 0, width: 900, height: 400)
+        controller.view.layoutSubtreeIfNeeded()
+        #expect(controller.view.subviews.isEmpty == false)
+    }
+
+    @Test func stackedModeHostsRendererWithoutCrashing() {
+        var layout = DiffLayoutMode.stacked
+        var wrap = true
+        var whitespace = true
+        let view = DiffPaneView(
+            model: model(),
+            fileExtension: "swift",
+            layoutMode: Binding(get: { layout }, set: { layout = $0 }),
+            wrapLines: Binding(get: { wrap }, set: { wrap = $0 }),
+            showWhitespace: Binding(get: { whitespace }, set: { whitespace = $0 }),
+            codeFontFamily: "",
+            codeFontSize: 13,
+            hunkActions: { _ in DiffPaneHunkActions() }
+        )
+        .environment(\.theme, theme())
+
+        let controller = NSHostingController(rootView: view)
+        controller.view.frame = NSRect(x: 0, y: 0, width: 520, height: 400)
+        controller.view.layoutSubtreeIfNeeded()
+        #expect(controller.view.subviews.isEmpty == false)
+    }
+}

--- a/AlasTests/DiffPaneViewTests.swift
+++ b/AlasTests/DiffPaneViewTests.swift
@@ -309,6 +309,16 @@ struct DiffPaneViewTests {
         #expect(DiffPaneLineTone(label: " 8", rowKind: .context) == .context)
     }
 
+    @Test func placeholderHatchIsInsetInsideRowRect() {
+        let rowRect = NSRect(x: 0, y: 8, width: 240, height: 22)
+        let hatchRect = DiffPaneCodeTextView.placeholderHatchRect(in: rowRect)
+
+        #expect(hatchRect.minY > rowRect.minY)
+        #expect(hatchRect.maxY < rowRect.maxY)
+        #expect(hatchRect.minX == rowRect.minX)
+        #expect(hatchRect.maxX == rowRect.maxX)
+    }
+
     @Test func splitDocumentBuildsSeparateCodeAndGutterColumns() throws {
         let result = DiffPaneTextDocumentBuilder.buildSplit(
             group: try #require(model().groups.first),

--- a/AlasTests/DiffPaneViewTests.swift
+++ b/AlasTests/DiffPaneViewTests.swift
@@ -95,7 +95,17 @@ struct DiffPaneViewTests {
         let lines = DiffPaneRowProjection.stackedLines(for: row)
 
         #expect(lines.map(\.text) == ["let a = 1"])
-        #expect(lines.map(\.anchor.side) == [.new])
+        #expect(lines.map(\.anchor.side) == [.paired])
+    }
+
+    @Test func contextSelectionSurvivesStackedProjection() throws {
+        let row = try #require(model().groups[0].rows.first)
+        let splitOldContextAnchor = try #require(row.old?.anchor)
+        let stackedContextAnchor = try #require(DiffPaneRowProjection.stackedLines(for: row).first?.anchor)
+
+        let selection = DiffSelectionRange(first: splitOldContextAnchor, last: splitOldContextAnchor)
+
+        #expect(selection.contains(stackedContextAnchor))
     }
 
     @Test func selectionReducerExtendsRangeOnShiftClick() throws {

--- a/docs/superpowers/plans/2026-06-11-review-ready-diff-pane.md
+++ b/docs/superpowers/plans/2026-06-11-review-ready-diff-pane.md
@@ -1,0 +1,1408 @@
+# Review-Ready Diff Pane Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace single-file text diff tabs with a native review-ready split/stacked diff pane while preserving existing hunk stage/discard behavior.
+
+**Architecture:** Keep `ParsedDiff` and existing `GitService.diff(...)` loading as the input contract. Add a pure display-model layer for aligned rows, anchors, inline highlights, collapsed context, and selection; then render that model through reusable SwiftUI/native views integrated into `DiffTabView`.
+
+**Tech Stack:** Swift 5.9, SwiftUI, AppKit-backed attributed text where needed, Swift Testing, XcodeGen/Xcode build.
+
+---
+
+## File Structure
+
+- Create `Alas/Sources/Center/Diff/DiffDisplayPreferences.swift`
+  - Defines `DiffLayoutMode` and the persisted preference value.
+- Create `Alas/Sources/Center/Diff/DiffDisplayModel.swift`
+  - Defines anchors, inline spans, split rows, hunk groups, selection ranges, collapsed groups, and the display model.
+- Create `Alas/Sources/Center/Diff/DiffInlineHighlighter.swift`
+  - Computes inline changed spans for paired delete/add lines.
+- Create `Alas/Sources/Center/Diff/DiffDisplayModelBuilder.swift`
+  - Converts `ParsedDiff` into `DiffDisplayModel`.
+- Create `Alas/Sources/Center/Diff/DiffPaneView.swift`
+  - Renders toolbar, split/stacked layouts, collapsed groups, line selection, hunk actions, and local draft note affordance.
+- Create `Alas/Sources/Center/Diff/DiffCodeText.swift`
+  - Small syntax-highlighted line renderer using existing tree-sitter colors and theme tokens.
+- Modify `Alas/Sources/Persistence/AppConfig.swift`
+  - Persist diff display preferences under `changes`.
+- Modify `Alas/Sources/Center/DiffTabView.swift`
+  - Replace `HunkView` text rendering path with `DiffPaneView` while keeping loading, image routing, stage/discard, and file header behavior.
+- Add `AlasTests/DiffDisplayModelBuilderTests.swift`
+  - Tests model construction, alignment, collapsed groups, anchors, and selection.
+- Add `AlasTests/DiffInlineHighlighterTests.swift`
+  - Tests inline pairing and fallback behavior.
+- Add `AlasTests/DiffPaneViewTests.swift`
+  - Hosted rendering smoke tests for split/stacked and selection affordances.
+- Modify `AlasTests/AppConfigChangesTests.swift`
+  - Tests defaults, legacy decode, and round-trip for display preferences.
+
+## Task 1: Persist Diff Display Preferences
+
+**Files:**
+- Create: `Alas/Sources/Center/Diff/DiffDisplayPreferences.swift`
+- Modify: `Alas/Sources/Persistence/AppConfig.swift`
+- Modify: `AlasTests/AppConfigChangesTests.swift`
+
+- [ ] **Step 1: Write failing AppConfig tests**
+
+Append these tests to `AppConfigChangesTests`:
+
+```swift
+@Test func defaultsHaveDiffDisplayPreferences() {
+    #expect(AppConfig.defaults.changes.diffLayoutMode == .split)
+    #expect(AppConfig.defaults.changes.diffWrapLines == false)
+    #expect(AppConfig.defaults.changes.diffShowWhitespace == false)
+}
+
+@Test func decodesLegacyChangesWithoutDiffDisplayPreferences() throws {
+    let json = """
+    {
+      "themeId": "cool-slate",
+      "accent": "teal",
+      "matchSystemTheme": false,
+      "sidebarWidth": 244,
+      "rightPaneWidth": 320,
+      "rightPaneVisible": true,
+      "general": {
+        "launchAtLogin": false, "closeToTray": true, "confirmQuit": true,
+        "autoUpdate": true, "updateChannel": "Stable",
+        "crashReports": false, "usageAnalytics": false
+      },
+      "worktrees": {
+        "rootPath": "~/.alas/worktrees",
+        "pathTemplate": "{worktreeRoot}/{repo}/{branch}",
+        "branchPrefix": "feature/", "baseBranch": "main",
+        "trackUpstream": true, "deleteBranchOnRemove": true,
+        "autoFetch": true, "fetchIntervalMinutes": 5, "pruneStale": false
+      },
+      "terminal": {
+        "shell": "/bin/zsh", "workingDirectory": "worktreeRoot",
+        "startupScript": "", "worktreeCreateScript": "",
+        "inheritParentEnv": true, "fontFamily": "JetBrains Mono",
+        "fontSize": 13, "cursorStyle": "beam", "cursorBlink": true,
+        "scrollbackLines": 10000, "bell": "visual"
+      },
+      "harness": {"notifyOnFinish": true, "notifyOnAwaiting": true},
+      "changes": {
+        "aiToolId": "claude",
+        "prompt": "p",
+        "reviewRequestPrompt": "r",
+        "mergeBulkResolvePrompt": "b",
+        "mergeSingleResolvePrompt": "s",
+        "trackUpstreamForCommits": true
+      }
+    }
+    """
+    let cfg = try JSONDecoder().decode(AppConfig.self, from: Data(json.utf8))
+    #expect(cfg.changes.diffLayoutMode == .split)
+    #expect(cfg.changes.diffWrapLines == false)
+    #expect(cfg.changes.diffShowWhitespace == false)
+}
+
+@Test func roundTripsDiffDisplayPreferences() throws {
+    var cfg = AppConfig.defaults
+    cfg.changes.diffLayoutMode = .stacked
+    cfg.changes.diffWrapLines = true
+    cfg.changes.diffShowWhitespace = true
+    let data = try JSONEncoder().encode(cfg)
+    let decoded = try JSONDecoder().decode(AppConfig.self, from: data)
+    #expect(decoded.changes.diffLayoutMode == .stacked)
+    #expect(decoded.changes.diffWrapLines == true)
+    #expect(decoded.changes.diffShowWhitespace == true)
+}
+```
+
+- [ ] **Step 2: Run the focused test and verify it fails**
+
+Run:
+
+```bash
+xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' test -only-testing:AlasTests/AppConfigChangesTests
+```
+
+Expected: fail to compile because `DiffLayoutMode`, `diffLayoutMode`, `diffWrapLines`, and `diffShowWhitespace` do not exist.
+
+- [ ] **Step 3: Add the preferences type**
+
+Create `Alas/Sources/Center/Diff/DiffDisplayPreferences.swift`:
+
+```swift
+import Foundation
+
+enum DiffLayoutMode: String, Codable, Equatable, CaseIterable {
+    case split
+    case stacked
+
+    var title: String {
+        switch self {
+        case .split: return "Split"
+        case .stacked: return "Stacked"
+        }
+    }
+}
+```
+
+- [ ] **Step 4: Add persisted fields to `AppConfig.Changes`**
+
+In `AppConfig.Changes`, add:
+
+```swift
+var diffLayoutMode: DiffLayoutMode
+var diffWrapLines: Bool
+var diffShowWhitespace: Bool
+```
+
+Add the keys to `CodingKeys`:
+
+```swift
+case diffLayoutMode, diffWrapLines, diffShowWhitespace
+```
+
+Update `AppConfig.defaults.changes` with:
+
+```swift
+diffLayoutMode: .split,
+diffWrapLines: false,
+diffShowWhitespace: false
+```
+
+In custom decode, read:
+
+```swift
+let diffLayoutMode = (try? changesContainer.decode(DiffLayoutMode.self, forKey: .diffLayoutMode)) ?? .split
+let diffWrapLines = (try? changesContainer.decode(Bool.self, forKey: .diffWrapLines)) ?? false
+let diffShowWhitespace = (try? changesContainer.decode(Bool.self, forKey: .diffShowWhitespace)) ?? false
+```
+
+Pass those values into every `Changes(...)` initializer in the decode path.
+
+- [ ] **Step 5: Run focused tests and commit**
+
+Run:
+
+```bash
+xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' test -only-testing:AlasTests/AppConfigChangesTests
+```
+
+Expected: `AppConfigChangesTests` passes.
+
+Commit:
+
+```bash
+git add Alas/Sources/Center/Diff/DiffDisplayPreferences.swift Alas/Sources/Persistence/AppConfig.swift AlasTests/AppConfigChangesTests.swift
+git commit -m "feat(diff): persist display preferences"
+```
+
+## Task 2: Build Diff Display Model
+
+**Files:**
+- Create: `Alas/Sources/Center/Diff/DiffDisplayModel.swift`
+- Create: `Alas/Sources/Center/Diff/DiffInlineHighlighter.swift`
+- Create: `Alas/Sources/Center/Diff/DiffDisplayModelBuilder.swift`
+- Add: `AlasTests/DiffInlineHighlighterTests.swift`
+- Add: `AlasTests/DiffDisplayModelBuilderTests.swift`
+
+- [ ] **Step 1: Write failing inline highlighter tests**
+
+Create `AlasTests/DiffInlineHighlighterTests.swift`:
+
+```swift
+import Testing
+@testable import Alas
+
+struct DiffInlineHighlighterTests {
+    @Test func highlightsChangedWordInSingleLineReplacement() {
+        let result = DiffInlineHighlighter.highlightDeleteAdd(
+            old: "let mode = \"unified\"",
+            new: "let mode = layout"
+        )
+
+        #expect(result.oldSpans.map { $0.text(in: "let mode = \"unified\"") } == ["\"unified\""])
+        #expect(result.newSpans.map { $0.text(in: "let mode = layout") } == ["layout"])
+    }
+
+    @Test func returnsFullLineSpansWhenLinesAreCompletelyDifferent() {
+        let result = DiffInlineHighlighter.highlightDeleteAdd(
+            old: "final class Renderer {}",
+            new: "import SwiftUI"
+        )
+
+        #expect(result.oldSpans == [DiffInlineSpan(start: 0, length: 23)])
+        #expect(result.newSpans == [DiffInlineSpan(start: 0, length: 14)])
+    }
+}
+```
+
+- [ ] **Step 2: Write failing display model tests**
+
+Create `AlasTests/DiffDisplayModelBuilderTests.swift`:
+
+```swift
+import Testing
+@testable import Alas
+
+struct DiffDisplayModelBuilderTests {
+    private func sampleDiff() -> ParsedDiff {
+        ParsedDiff(hunks: [
+            ParsedDiff.Hunk(
+                header: "@@ -10,4 +10,4 @@",
+                oldStart: 10,
+                newStart: 10,
+                lines: [
+                    .init(kind: .context, text: "struct Foo {", oldNumber: 10, newNumber: 10),
+                    .init(kind: .delete, text: "    let mode = \"unified\"", oldNumber: 11, newNumber: nil),
+                    .init(kind: .add, text: "    let mode = layout", oldNumber: nil, newNumber: 11),
+                    .init(kind: .context, text: "}", oldNumber: 12, newNumber: 12),
+                ]
+            )
+        ])
+    }
+
+    @Test func buildsSplitRowsWithStableAnchors() {
+        let model = DiffDisplayModelBuilder.build(diff: sampleDiff(), filePath: "Sources/Foo.swift")
+        #expect(model.filePath == "Sources/Foo.swift")
+        #expect(model.groups.count == 1)
+        #expect(model.groups[0].rows.count == 3)
+
+        let replacement = model.groups[0].rows[1]
+        #expect(replacement.kind == .replacement)
+        #expect(replacement.old?.anchor == DiffLineAnchor(filePath: "Sources/Foo.swift", side: .old, oldLine: 11, newLine: nil))
+        #expect(replacement.new?.anchor == DiffLineAnchor(filePath: "Sources/Foo.swift", side: .new, oldLine: nil, newLine: 11))
+        #expect(replacement.old?.inlineSpans.map(\.text(in: replacement.old?.text ?? "")) == ["\"unified\""])
+        #expect(replacement.new?.inlineSpans.map(\.text(in: replacement.new?.text ?? "")) == ["layout"])
+    }
+
+    @Test func preservesHunkForActions() {
+        let diff = sampleDiff()
+        let model = DiffDisplayModelBuilder.build(diff: diff, filePath: "Sources/Foo.swift")
+        #expect(model.groups[0].sourceHunk == diff.hunks[0])
+    }
+
+    @Test func collapsesLargeContextRunsInsideHunk() {
+        let context = (1...12).map {
+            ParsedDiff.Hunk.Line(kind: .context, text: "line \($0)", oldNumber: $0, newNumber: $0)
+        }
+        let hunk = ParsedDiff.Hunk(header: "@@ -1,12 +1,12 @@", oldStart: 1, newStart: 1, lines: context)
+        let model = DiffDisplayModelBuilder.build(
+            diff: ParsedDiff(hunks: [hunk]),
+            filePath: "a.txt",
+            collapseContextThreshold: 6,
+            contextEdgeCount: 2
+        )
+
+        let rows = model.groups[0].rows
+        #expect(rows.map(\.kind) == [.context, .context, .collapsed, .context, .context])
+        #expect(rows[2].collapsedLineCount == 8)
+    }
+
+    @Test func selectionRangeNormalizesAnchorOrder() {
+        let a = DiffLineAnchor(filePath: "a.txt", side: .new, oldLine: nil, newLine: 4)
+        let b = DiffLineAnchor(filePath: "a.txt", side: .new, oldLine: nil, newLine: 2)
+        let range = DiffSelectionRange(first: a, last: b)
+        #expect(range.normalized.lowerBound == b)
+        #expect(range.normalized.upperBound == a)
+    }
+}
+```
+
+- [ ] **Step 3: Run focused tests and verify they fail**
+
+Run:
+
+```bash
+xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' test -only-testing:AlasTests/DiffInlineHighlighterTests -only-testing:AlasTests/DiffDisplayModelBuilderTests
+```
+
+Expected: fail to compile because the new model and builder types do not exist.
+
+- [ ] **Step 4: Add the display model types**
+
+Create `Alas/Sources/Center/Diff/DiffDisplayModel.swift`:
+
+```swift
+import Foundation
+
+enum DiffLineSide: String, Codable, Equatable, Comparable, Hashable {
+    case old
+    case new
+    case paired
+
+    static func < (lhs: DiffLineSide, rhs: DiffLineSide) -> Bool {
+        lhs.sortValue < rhs.sortValue
+    }
+
+    private var sortValue: Int {
+        switch self {
+        case .old: return 0
+        case .paired: return 1
+        case .new: return 2
+        }
+    }
+}
+
+struct DiffLineAnchor: Codable, Equatable, Comparable, Hashable {
+    let filePath: String
+    let side: DiffLineSide
+    let oldLine: Int?
+    let newLine: Int?
+
+    static func < (lhs: DiffLineAnchor, rhs: DiffLineAnchor) -> Bool {
+        if lhs.filePath != rhs.filePath { return lhs.filePath < rhs.filePath }
+        let lhsLine = lhs.newLine ?? lhs.oldLine ?? 0
+        let rhsLine = rhs.newLine ?? rhs.oldLine ?? 0
+        if lhsLine != rhsLine { return lhsLine < rhsLine }
+        if lhs.side != rhs.side { return lhs.side < rhs.side }
+        return (lhs.oldLine ?? 0) < (rhs.oldLine ?? 0)
+    }
+}
+
+struct DiffSelectionRange: Equatable {
+    let first: DiffLineAnchor
+    let last: DiffLineAnchor
+
+    var normalized: ClosedRange<DiffLineAnchor> {
+        min(first, last)...max(first, last)
+    }
+
+    func contains(_ anchor: DiffLineAnchor) -> Bool {
+        normalized.contains(anchor)
+    }
+}
+
+struct DiffInlineSpan: Equatable {
+    let start: Int
+    let length: Int
+
+    func text(in source: String) -> String {
+        let ns = source as NSString
+        guard start >= 0, length >= 0, start + length <= ns.length else { return "" }
+        return ns.substring(with: NSRange(location: start, length: length))
+    }
+}
+
+struct DiffDisplayLine: Identifiable, Equatable {
+    let id: DiffLineAnchor
+    let anchor: DiffLineAnchor
+    let text: String
+    let lineNumber: Int?
+    let kind: ParsedDiff.Hunk.Line.Kind
+    let inlineSpans: [DiffInlineSpan]
+    let noTrailingNewline: Bool
+}
+
+struct DiffDisplayRow: Identifiable, Equatable {
+    enum Kind: Equatable {
+        case context
+        case add
+        case delete
+        case replacement
+        case collapsed
+    }
+
+    let id: String
+    let kind: Kind
+    let old: DiffDisplayLine?
+    let new: DiffDisplayLine?
+    let collapsedLineCount: Int
+}
+
+struct DiffDisplayGroup: Identifiable, Equatable {
+    let id: String
+    let header: String
+    let sourceHunk: ParsedDiff.Hunk
+    let rows: [DiffDisplayRow]
+}
+
+struct DiffDisplayModel: Equatable {
+    let filePath: String
+    let groups: [DiffDisplayGroup]
+}
+```
+
+- [ ] **Step 5: Add the inline highlighter**
+
+Create `Alas/Sources/Center/Diff/DiffInlineHighlighter.swift`:
+
+```swift
+import Foundation
+
+enum DiffInlineHighlighter {
+    struct Result: Equatable {
+        let oldSpans: [DiffInlineSpan]
+        let newSpans: [DiffInlineSpan]
+    }
+
+    static func highlightDeleteAdd(old: String, new: String) -> Result {
+        if old == new { return Result(oldSpans: [], newSpans: []) }
+
+        let oldTokens = tokenize(old)
+        let newTokens = tokenize(new)
+        guard !oldTokens.isEmpty, !newTokens.isEmpty else {
+            return Result(oldSpans: fullSpan(old), newSpans: fullSpan(new))
+        }
+
+        var prefix = 0
+        while prefix < oldTokens.count,
+              prefix < newTokens.count,
+              oldTokens[prefix].text == newTokens[prefix].text {
+            prefix += 1
+        }
+
+        var suffix = 0
+        while suffix + prefix < oldTokens.count,
+              suffix + prefix < newTokens.count,
+              oldTokens[oldTokens.count - 1 - suffix].text == newTokens[newTokens.count - 1 - suffix].text {
+            suffix += 1
+        }
+
+        let oldChanged = oldTokens[prefix..<(oldTokens.count - suffix)]
+        let newChanged = newTokens[prefix..<(newTokens.count - suffix)]
+
+        let oldSpans = collapse(tokens: Array(oldChanged), source: old)
+        let newSpans = collapse(tokens: Array(newChanged), source: new)
+
+        if oldSpans.isEmpty || newSpans.isEmpty {
+            return Result(oldSpans: fullSpan(old), newSpans: fullSpan(new))
+        }
+        return Result(oldSpans: oldSpans, newSpans: newSpans)
+    }
+
+    private struct Token {
+        let text: String
+        let range: NSRange
+    }
+
+    private static func tokenize(_ text: String) -> [Token] {
+        let ns = text as NSString
+        var tokens: [Token] = []
+        var start: Int?
+        var lastClass: CharacterSet?
+
+        func flush(upTo index: Int) {
+            guard let s = start else { return }
+            let range = NSRange(location: s, length: index - s)
+            if range.length > 0 {
+                tokens.append(Token(text: ns.substring(with: range), range: range))
+            }
+            start = nil
+            lastClass = nil
+        }
+
+        for index in 0..<ns.length {
+            let scalar = UnicodeScalar(ns.character(at: index)) ?? " "
+            let cls: CharacterSet
+            if CharacterSet.alphanumerics.contains(scalar) || scalar == "_" {
+                cls = .alphanumerics
+            } else if CharacterSet.whitespaces.contains(scalar) {
+                flush(upTo: index)
+                continue
+            } else {
+                cls = .punctuationCharacters
+            }
+
+            if start == nil {
+                start = index
+                lastClass = cls
+            } else if lastClass != cls {
+                flush(upTo: index)
+                start = index
+                lastClass = cls
+            }
+        }
+        flush(upTo: ns.length)
+        return tokens
+    }
+
+    private static func collapse(tokens: [Token], source: String) -> [DiffInlineSpan] {
+        guard let first = tokens.first, let last = tokens.last else { return [] }
+        let end = last.range.location + last.range.length
+        return [DiffInlineSpan(start: first.range.location, length: end - first.range.location)]
+    }
+
+    private static func fullSpan(_ text: String) -> [DiffInlineSpan] {
+        text.isEmpty ? [] : [DiffInlineSpan(start: 0, length: (text as NSString).length)]
+    }
+}
+```
+
+- [ ] **Step 6: Add the model builder**
+
+Create `Alas/Sources/Center/Diff/DiffDisplayModelBuilder.swift`:
+
+```swift
+import Foundation
+
+enum DiffDisplayModelBuilder {
+    static func build(
+        diff: ParsedDiff,
+        filePath: String,
+        collapseContextThreshold: Int = 12,
+        contextEdgeCount: Int = 3
+    ) -> DiffDisplayModel {
+        let groups = diff.hunks.enumerated().map { hunkIndex, hunk in
+            DiffDisplayGroup(
+                id: "\(filePath):hunk:\(hunkIndex)",
+                header: hunk.header,
+                sourceHunk: hunk,
+                rows: rows(
+                    for: hunk,
+                    hunkIndex: hunkIndex,
+                    filePath: filePath,
+                    collapseContextThreshold: collapseContextThreshold,
+                    contextEdgeCount: contextEdgeCount
+                )
+            )
+        }
+        return DiffDisplayModel(filePath: filePath, groups: groups)
+    }
+
+    private static func rows(
+        for hunk: ParsedDiff.Hunk,
+        hunkIndex: Int,
+        filePath: String,
+        collapseContextThreshold: Int,
+        contextEdgeCount: Int
+    ) -> [DiffDisplayRow] {
+        let aligned = alignRows(for: hunk, hunkIndex: hunkIndex, filePath: filePath)
+        return collapseContextRows(
+            aligned,
+            hunkIndex: hunkIndex,
+            filePath: filePath,
+            threshold: collapseContextThreshold,
+            edgeCount: contextEdgeCount
+        )
+    }
+
+    private static func alignRows(
+        for hunk: ParsedDiff.Hunk,
+        hunkIndex: Int,
+        filePath: String
+    ) -> [DiffDisplayRow] {
+        var rows: [DiffDisplayRow] = []
+        var index = 0
+        while index < hunk.lines.count {
+            let line = hunk.lines[index]
+            if line.kind == .context {
+                let display = displayLine(line, filePath: filePath, side: .paired)
+                rows.append(DiffDisplayRow(
+                    id: "\(filePath):\(hunkIndex):ctx:\(line.oldNumber ?? 0):\(line.newNumber ?? 0)",
+                    kind: .context,
+                    old: display,
+                    new: display,
+                    collapsedLineCount: 0
+                ))
+                index += 1
+                continue
+            }
+
+            var deletes: [ParsedDiff.Hunk.Line] = []
+            var adds: [ParsedDiff.Hunk.Line] = []
+            while index < hunk.lines.count, hunk.lines[index].kind != .context {
+                if hunk.lines[index].kind == .delete {
+                    deletes.append(hunk.lines[index])
+                } else if hunk.lines[index].kind == .add {
+                    adds.append(hunk.lines[index])
+                }
+                index += 1
+            }
+
+            let pairCount = min(deletes.count, adds.count)
+            for pairIndex in 0..<pairCount {
+                let oldLine = deletes[pairIndex]
+                let newLine = adds[pairIndex]
+                let highlights = DiffInlineHighlighter.highlightDeleteAdd(old: oldLine.text, new: newLine.text)
+                rows.append(DiffDisplayRow(
+                    id: "\(filePath):\(hunkIndex):rep:\(oldLine.oldNumber ?? 0):\(newLine.newNumber ?? 0)",
+                    kind: .replacement,
+                    old: displayLine(oldLine, filePath: filePath, side: .old, spans: highlights.oldSpans),
+                    new: displayLine(newLine, filePath: filePath, side: .new, spans: highlights.newSpans),
+                    collapsedLineCount: 0
+                ))
+            }
+
+            for oldLine in deletes.dropFirst(pairCount) {
+                rows.append(DiffDisplayRow(
+                    id: "\(filePath):\(hunkIndex):del:\(oldLine.oldNumber ?? 0)",
+                    kind: .delete,
+                    old: displayLine(oldLine, filePath: filePath, side: .old),
+                    new: nil,
+                    collapsedLineCount: 0
+                ))
+            }
+
+            for newLine in adds.dropFirst(pairCount) {
+                rows.append(DiffDisplayRow(
+                    id: "\(filePath):\(hunkIndex):add:\(newLine.newNumber ?? 0)",
+                    kind: .add,
+                    old: nil,
+                    new: displayLine(newLine, filePath: filePath, side: .new),
+                    collapsedLineCount: 0
+                ))
+            }
+        }
+        return rows
+    }
+
+    private static func collapseContextRows(
+        _ rows: [DiffDisplayRow],
+        hunkIndex: Int,
+        filePath: String,
+        threshold: Int,
+        edgeCount: Int
+    ) -> [DiffDisplayRow] {
+        guard threshold > edgeCount * 2 else { return rows }
+        var result: [DiffDisplayRow] = []
+        var index = 0
+        while index < rows.count {
+            guard rows[index].kind == .context else {
+                result.append(rows[index])
+                index += 1
+                continue
+            }
+            let start = index
+            while index < rows.count, rows[index].kind == .context {
+                index += 1
+            }
+            let run = Array(rows[start..<index])
+            if run.count > threshold {
+                result.append(contentsOf: run.prefix(edgeCount))
+                result.append(DiffDisplayRow(
+                    id: "\(filePath):\(hunkIndex):collapsed:\(start):\(run.count)",
+                    kind: .collapsed,
+                    old: nil,
+                    new: nil,
+                    collapsedLineCount: run.count - edgeCount * 2
+                ))
+                result.append(contentsOf: run.suffix(edgeCount))
+            } else {
+                result.append(contentsOf: run)
+            }
+        }
+        return result
+    }
+
+    private static func displayLine(
+        _ line: ParsedDiff.Hunk.Line,
+        filePath: String,
+        side: DiffLineSide,
+        spans: [DiffInlineSpan] = []
+    ) -> DiffDisplayLine {
+        let anchor = DiffLineAnchor(
+            filePath: filePath,
+            side: side,
+            oldLine: line.oldNumber,
+            newLine: line.newNumber
+        )
+        return DiffDisplayLine(
+            id: anchor,
+            anchor: anchor,
+            text: line.text,
+            lineNumber: line.newNumber ?? line.oldNumber,
+            kind: line.kind,
+            inlineSpans: spans,
+            noTrailingNewline: line.noTrailingNewline
+        )
+    }
+}
+```
+
+- [ ] **Step 7: Run focused tests and commit**
+
+Run:
+
+```bash
+xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' test -only-testing:AlasTests/DiffInlineHighlighterTests -only-testing:AlasTests/DiffDisplayModelBuilderTests
+```
+
+Expected: both test suites pass.
+
+Commit:
+
+```bash
+git add Alas/Sources/Center/Diff/DiffDisplayModel.swift Alas/Sources/Center/Diff/DiffInlineHighlighter.swift Alas/Sources/Center/Diff/DiffDisplayModelBuilder.swift AlasTests/DiffInlineHighlighterTests.swift AlasTests/DiffDisplayModelBuilderTests.swift
+git commit -m "feat(diff): build display model"
+```
+
+## Task 3: Render Native Split And Stacked Diff Pane
+
+**Files:**
+- Create: `Alas/Sources/Center/Diff/DiffCodeText.swift`
+- Create: `Alas/Sources/Center/Diff/DiffPaneView.swift`
+- Add: `AlasTests/DiffPaneViewTests.swift`
+
+- [ ] **Step 1: Write failing hosted rendering tests**
+
+Create `AlasTests/DiffPaneViewTests.swift`:
+
+```swift
+import AppKit
+import SwiftUI
+import Testing
+@testable import Alas
+
+@Suite(.serialized)
+@MainActor
+struct DiffPaneViewTests {
+    private func theme() -> Theme { try! ThemeStore().current }
+
+    private func model() -> DiffDisplayModel {
+        DiffDisplayModelBuilder.build(
+            diff: ParsedDiff(hunks: [
+                ParsedDiff.Hunk(
+                    header: "@@ -1,2 +1,2 @@",
+                    oldStart: 1,
+                    newStart: 1,
+                    lines: [
+                        .init(kind: .context, text: "let a = 1", oldNumber: 1, newNumber: 1),
+                        .init(kind: .delete, text: "let b = 2", oldNumber: 2, newNumber: nil),
+                        .init(kind: .add, text: "let b = 3", oldNumber: nil, newNumber: 2),
+                    ]
+                )
+            ]),
+            filePath: "a.swift"
+        )
+    }
+
+    @Test func splitModeHostsRendererWithoutCrashing() {
+        var layout = DiffLayoutMode.split
+        var wrap = false
+        var whitespace = false
+        let view = DiffPaneView(
+            model: model(),
+            fileExtension: "swift",
+            layoutMode: Binding(get: { layout }, set: { layout = $0 }),
+            wrapLines: Binding(get: { wrap }, set: { wrap = $0 }),
+            showWhitespace: Binding(get: { whitespace }, set: { whitespace = $0 }),
+            codeFontFamily: "",
+            codeFontSize: 13,
+            hunkActions: { _ in DiffPaneHunkActions() }
+        )
+        .environment(\.theme, theme())
+
+        let controller = NSHostingController(rootView: view)
+        controller.view.frame = NSRect(x: 0, y: 0, width: 900, height: 400)
+        controller.view.layoutSubtreeIfNeeded()
+        #expect(controller.view.subviews.isEmpty == false)
+    }
+
+    @Test func stackedModeHostsRendererWithoutCrashing() {
+        var layout = DiffLayoutMode.stacked
+        var wrap = true
+        var whitespace = true
+        let view = DiffPaneView(
+            model: model(),
+            fileExtension: "swift",
+            layoutMode: Binding(get: { layout }, set: { layout = $0 }),
+            wrapLines: Binding(get: { wrap }, set: { wrap = $0 }),
+            showWhitespace: Binding(get: { whitespace }, set: { whitespace = $0 }),
+            codeFontFamily: "",
+            codeFontSize: 13,
+            hunkActions: { _ in DiffPaneHunkActions() }
+        )
+        .environment(\.theme, theme())
+
+        let controller = NSHostingController(rootView: view)
+        controller.view.frame = NSRect(x: 0, y: 0, width: 520, height: 400)
+        controller.view.layoutSubtreeIfNeeded()
+        #expect(controller.view.subviews.isEmpty == false)
+    }
+}
+```
+
+- [ ] **Step 2: Run the hosted tests and verify they fail**
+
+Run:
+
+```bash
+xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' test -only-testing:AlasTests/DiffPaneViewTests
+```
+
+Expected: fail to compile because `DiffPaneView` and `DiffPaneHunkActions` do not exist.
+
+- [ ] **Step 3: Add syntax-highlighted line view**
+
+Create `Alas/Sources/Center/Diff/DiffCodeText.swift`:
+
+```swift
+import SwiftUI
+
+struct DiffCodeText: View {
+    let text: String
+    let fileExtension: String
+    let codeFontFamily: String
+    let codeFontSize: CGFloat
+    let wrapLines: Bool
+    let showWhitespace: Bool
+    let inlineSpans: [DiffInlineSpan]
+    let inlineTone: ParsedDiff.Hunk.Line.Kind
+
+    @Environment(\.theme) private var theme
+
+    var body: some View {
+        Text(attributedText)
+            .textSelection(.enabled)
+            .lineLimit(wrapLines ? nil : 1)
+            .truncationMode(.tail)
+            .font(Font(CenterTypography.resolveCodeFont(family: codeFontFamily, size: codeFontSize)))
+    }
+
+    private var attributedText: AttributedString {
+        let source = showWhitespace ? visibleWhitespace(text) : text
+        var attributed = AttributedString(source)
+        attributed.foregroundColor = theme.color("fg")
+
+        for token in TreeSitterHighlighter.tokenize(line: text, fileExtension: fileExtension) {
+            guard let range = Range(token.range, in: text) else { continue }
+            let lower = source.distance(from: source.startIndex, to: range.lowerBound)
+            let upper = source.distance(from: source.startIndex, to: range.upperBound)
+            guard let start = attributed.index(attributed.startIndex, offsetByCharacters: lower),
+                  let end = attributed.index(attributed.startIndex, offsetByCharacters: upper) else {
+                continue
+            }
+            attributed[start..<end].foregroundColor = syntaxColor(for: token.capture)
+        }
+
+        for span in inlineSpans {
+            guard let start = attributed.index(attributed.startIndex, offsetByCharacters: span.start),
+                  let end = attributed.index(start, offsetByCharacters: span.length) else {
+                continue
+            }
+            attributed[start..<end].backgroundColor = inlineBackground
+        }
+        return attributed
+    }
+
+    private var inlineBackground: Color {
+        switch inlineTone {
+        case .add: return theme.color("add").opacity(0.28)
+        case .delete: return theme.color("del").opacity(0.28)
+        case .context: return theme.color("accent").opacity(0.18)
+        }
+    }
+
+    private func syntaxColor(for capture: HighlightCapture) -> Color {
+        switch capture {
+        case .keyword: return theme.color("syntax-keyword")
+        case .type: return theme.color("syntax-type")
+        case .function: return theme.color("syntax-function")
+        case .string: return theme.color("add")
+        case .number: return theme.color("mod")
+        case .comment: return theme.color("fg-faint")
+        default: return theme.color("fg")
+        }
+    }
+
+    private func visibleWhitespace(_ value: String) -> String {
+        value.replacingOccurrences(of: " ", with: "·").replacingOccurrences(of: "\t", with: "→   ")
+    }
+}
+```
+
+Add this extension at the bottom of `DiffCodeText.swift`:
+
+```swift
+private extension AttributedString {
+    func index(_ start: AttributedString.Index, offsetByCharacters offset: Int) -> AttributedString.Index? {
+        characters.index(start, offsetBy: offset, limitedBy: endIndex)
+    }
+}
+```
+
+- [ ] **Step 4: Add the diff pane view**
+
+Create `Alas/Sources/Center/Diff/DiffPaneView.swift`:
+
+```swift
+import SwiftUI
+
+struct DiffPaneHunkActions {
+    var stage: (() -> Void)?
+    var discard: (() -> Void)?
+    var dropFromCommit: (() -> Void)?
+}
+
+struct DiffPaneView: View {
+    let model: DiffDisplayModel
+    let fileExtension: String
+    @Binding var layoutMode: DiffLayoutMode
+    @Binding var wrapLines: Bool
+    @Binding var showWhitespace: Bool
+    var codeFontFamily: String = ""
+    var codeFontSize: CGFloat = 13
+    let hunkActions: (ParsedDiff.Hunk) -> DiffPaneHunkActions
+
+    @Environment(\.theme) private var theme
+    @State private var expandedCollapsedRows: Set<String> = []
+    @State private var selection: DiffSelectionRange?
+    @State private var draftAnchor: DiffLineAnchor?
+
+    var body: some View {
+        VStack(spacing: 0) {
+            toolbar
+            ScrollView(.vertical) {
+                LazyVStack(alignment: .leading, spacing: 0) {
+                    ForEach(model.groups) { group in
+                        groupView(group)
+                    }
+                }
+                .padding(.vertical, 8)
+            }
+            .defaultScrollAnchor(.topLeading)
+        }
+        .background(theme.color("bg-1"))
+    }
+
+    private var toolbar: some View {
+        HStack(spacing: 8) {
+            Seg(value: $layoutMode, options: DiffLayoutMode.allCases.map { ($0, $0.title) })
+            Spacer()
+            iconToggle("Wrap", systemImage: "text.justify.left", isOn: $wrapLines)
+            iconToggle("Whitespace", systemImage: "paragraphsign", isOn: $showWhitespace)
+        }
+        .padding(.horizontal, 14)
+        .padding(.vertical, 7)
+        .background(theme.color("bg-2"))
+        .overlay(Divider().opacity(0.45), alignment: .bottom)
+    }
+
+    private func groupView(_ group: DiffDisplayGroup) -> some View {
+        let actions = hunkActions(group.sourceHunk)
+        return VStack(alignment: .leading, spacing: 0) {
+            hunkHeader(group: group, actions: actions)
+            ForEach(group.rows) { row in
+                rowView(row)
+            }
+        }
+    }
+
+    private func hunkHeader(group: DiffDisplayGroup, actions: DiffPaneHunkActions) -> some View {
+        HStack(spacing: 8) {
+            Text(group.header)
+                .font(CenterTypography.codeFont(family: codeFontFamily, size: (codeFontSize * 0.85).rounded()))
+                .foregroundColor(theme.color("fg-dim"))
+                .textSelection(.enabled)
+            Spacer(minLength: 8)
+            if let stage = actions.stage {
+                AlasButton(title: "Stage hunk", style: .subtle, action: stage)
+            }
+            if let discard = actions.discard {
+                AlasButton(title: "Discard hunk...", style: .subtle, action: discard)
+            }
+            if let drop = actions.dropFromCommit {
+                AlasButton(title: "Drop hunk...", style: .subtle, action: drop)
+            }
+        }
+        .padding(.horizontal, 14)
+        .padding(.vertical, 4)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(theme.color("bg-2"))
+        .overlay(Divider().opacity(0.5), alignment: .top)
+        .overlay(Divider().opacity(0.5), alignment: .bottom)
+    }
+
+    @ViewBuilder
+    private func rowView(_ row: DiffDisplayRow) -> some View {
+        if row.kind == .collapsed {
+            collapsedRow(row)
+        } else if layoutMode == .split {
+            splitRow(row)
+        } else {
+            stackedRow(row)
+        }
+    }
+
+    private func splitRow(_ row: DiffDisplayRow) -> some View {
+        HStack(spacing: 0) {
+            diffCell(row.old, side: .old, rowKind: row.kind)
+            Rectangle().fill(theme.color("line").opacity(0.5)).frame(width: 1)
+            diffCell(row.new, side: .new, rowKind: row.kind)
+        }
+        .background(rowBackground(row.kind))
+    }
+
+    private func stackedRow(_ row: DiffDisplayRow) -> some View {
+        VStack(spacing: 0) {
+            if let old = row.old, row.kind != .context {
+                diffLine(old, side: .old, rowKind: row.kind)
+            }
+            if let new = row.new {
+                diffLine(new, side: .new, rowKind: row.kind)
+            } else if row.kind == .context, let old = row.old {
+                diffLine(old, side: .paired, rowKind: row.kind)
+            }
+        }
+        .background(rowBackground(row.kind))
+    }
+
+    private func diffCell(_ line: DiffDisplayLine?, side: DiffLineSide, rowKind: DiffDisplayRow.Kind) -> some View {
+        Group {
+            if let line {
+                diffLine(line, side: side, rowKind: rowKind)
+            } else {
+                Color.clear.frame(minHeight: 22)
+            }
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+    }
+
+    private func diffLine(_ line: DiffDisplayLine, side: DiffLineSide, rowKind: DiffDisplayRow.Kind) -> some View {
+        HStack(spacing: 0) {
+            Text(lineNumberText(line, side: side))
+                .font(CenterTypography.codeFont(family: codeFontFamily, size: codeFontSize - 1))
+                .foregroundColor(markerColor(line.kind))
+                .frame(width: 62, alignment: .trailing)
+                .padding(.trailing, 8)
+            DiffCodeText(
+                text: line.text,
+                fileExtension: fileExtension,
+                codeFontFamily: codeFontFamily,
+                codeFontSize: codeFontSize,
+                wrapLines: wrapLines,
+                showWhitespace: showWhitespace,
+                inlineSpans: line.inlineSpans,
+                inlineTone: line.kind
+            )
+            .padding(.leading, 10)
+            Spacer(minLength: 0)
+            if draftAnchor == line.anchor {
+                Text("Draft note")
+                    .font(.system(size: 10, weight: .medium))
+                    .foregroundColor(theme.color("accent"))
+                    .padding(.trailing, 8)
+            }
+        }
+        .frame(minHeight: 22)
+        .contentShape(Rectangle())
+        .background(isSelected(line.anchor) ? theme.color("accent").opacity(0.14) : Color.clear)
+        .onTapGesture {
+            selection = DiffSelectionRange(first: line.anchor, last: line.anchor)
+        }
+        .contextMenu {
+            Button("Add Note") { draftAnchor = line.anchor }
+            Button("Copy Line") { Clipboard.copy(line.text) }
+        }
+    }
+
+    private func collapsedRow(_ row: DiffDisplayRow) -> some View {
+        Button {
+            if expandedCollapsedRows.contains(row.id) {
+                expandedCollapsedRows.remove(row.id)
+            } else {
+                expandedCollapsedRows.insert(row.id)
+            }
+        } label: {
+            Text("\(row.collapsedLineCount) unchanged lines")
+                .font(.system(size: 11, weight: .medium))
+                .foregroundColor(theme.color("fg-dim"))
+                .padding(.horizontal, 14)
+                .padding(.vertical, 5)
+                .frame(maxWidth: .infinity)
+        }
+        .buttonStyle(.plain)
+        .background(theme.color("bg-2").opacity(0.72))
+    }
+
+    private func iconToggle(_ title: String, systemImage: String, isOn: Binding<Bool>) -> some View {
+        Button { isOn.wrappedValue.toggle() } label: {
+            Image(systemName: systemImage)
+                .font(.system(size: 12, weight: .medium))
+                .frame(width: 24, height: 22)
+                .foregroundColor(isOn.wrappedValue ? theme.color("fg") : theme.color("fg-muted"))
+                .background(isOn.wrappedValue ? theme.color("bg-3") : Color.clear)
+                .clipShape(RoundedRectangle(cornerRadius: 4))
+        }
+        .buttonStyle(.plain)
+        .help(title)
+    }
+
+    private func isSelected(_ anchor: DiffLineAnchor) -> Bool {
+        selection?.contains(anchor) ?? false
+    }
+
+    private func lineNumberText(_ line: DiffDisplayLine, side: DiffLineSide) -> String {
+        switch side {
+        case .old: return line.anchor.oldLine.map(String.init) ?? ""
+        case .new: return line.anchor.newLine.map(String.init) ?? ""
+        case .paired: return line.lineNumber.map(String.init) ?? ""
+        }
+    }
+
+    private func rowBackground(_ kind: DiffDisplayRow.Kind) -> Color {
+        switch kind {
+        case .add: return theme.color("add").opacity(0.10)
+        case .delete: return theme.color("del").opacity(0.10)
+        case .replacement: return theme.color("mod").opacity(0.08)
+        case .context, .collapsed: return .clear
+        }
+    }
+
+    private func markerColor(_ kind: ParsedDiff.Hunk.Line.Kind) -> Color {
+        switch kind {
+        case .add: return theme.color("add")
+        case .delete: return theme.color("del")
+        case .context: return theme.color("fg-faint")
+        }
+    }
+}
+```
+
+- [ ] **Step 5: Run hosted tests and commit**
+
+Run:
+
+```bash
+xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' test -only-testing:AlasTests/DiffPaneViewTests
+```
+
+Expected: `DiffPaneViewTests` passes.
+
+Commit:
+
+```bash
+git add Alas/Sources/Center/Diff/DiffCodeText.swift Alas/Sources/Center/Diff/DiffPaneView.swift AlasTests/DiffPaneViewTests.swift
+git commit -m "feat(diff): render split and stacked pane"
+```
+
+## Task 4: Integrate Renderer Into DiffTabView
+
+**Files:**
+- Modify: `Alas/Sources/Center/DiffTabView.swift`
+- Modify: `AlasTests/DiffSelectableTextTests.swift` only if existing `HunkView` tests need updated names after integration.
+
+- [ ] **Step 1: Add a failing hosted integration test**
+
+Append this test to `DiffPaneViewTests` so integration is validated through the new view API before touching `DiffTabView`:
+
+```swift
+@Test func hunkActionsRenderInPaneHeader() {
+    var layout = DiffLayoutMode.split
+    var wrap = false
+    var whitespace = false
+    let view = DiffPaneView(
+        model: model(),
+        fileExtension: "swift",
+        layoutMode: Binding(get: { layout }, set: { layout = $0 }),
+        wrapLines: Binding(get: { wrap }, set: { wrap = $0 }),
+        showWhitespace: Binding(get: { whitespace }, set: { whitespace = $0 }),
+        codeFontFamily: "",
+        codeFontSize: 13,
+        hunkActions: { _ in
+            DiffPaneHunkActions(stage: {}, discard: {}, dropFromCommit: nil)
+        }
+    )
+    .environment(\.theme, theme())
+
+    let controller = NSHostingController(rootView: view)
+    controller.view.frame = NSRect(x: 0, y: 0, width: 900, height: 400)
+    controller.view.layoutSubtreeIfNeeded()
+    let buttons = allSubviews(of: controller.view).compactMap { $0 as? NSButton }
+    let titles = buttons.map(\.title)
+    #expect(titles.contains("Stage hunk"))
+    #expect(titles.contains("Discard hunk..."))
+}
+```
+
+Also add this helper inside the test struct:
+
+```swift
+private func allSubviews(of view: NSView) -> [NSView] {
+    view.subviews + view.subviews.flatMap { allSubviews(of: $0) }
+}
+```
+
+- [ ] **Step 2: Run focused test and verify the action contract**
+
+Run:
+
+```bash
+xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' test -only-testing:AlasTests/DiffPaneViewTests/hunkActionsRenderInPaneHeader
+```
+
+Expected: pass after Task 3. If it fails, fix `DiffPaneView` so hunk action buttons render in the hunk header before continuing.
+
+- [ ] **Step 3: Replace text diff body in `DiffTabView`**
+
+In `DiffTabView`, add the app state environment and a display model:
+
+```swift
+@EnvironmentObject private var appState: AppState
+@State private var displayModel: DiffDisplayModel?
+```
+
+After loading `loadedDiff`, build the display model off-main:
+
+```swift
+let loadedDisplayModel = await Task.detached(priority: .userInitiated) {
+    DiffDisplayModelBuilder.build(diff: loadedDiff, filePath: relativePath)
+}.value
+```
+
+Publish it with the diff:
+
+```swift
+diff = loadedDiff
+displayModel = loadedDisplayModel
+```
+
+Reset it at the start of `load()`:
+
+```swift
+displayModel = nil
+```
+
+Replace the old `ForEach(diff.hunks...) { HunkView(...) }` block with:
+
+```swift
+if let displayModel {
+    DiffPaneView(
+        model: displayModel,
+        fileExtension: LanguageRegistry.highlighterExtension(forPath: relativePath),
+        layoutMode: diffLayoutBinding,
+        wrapLines: diffWrapBinding,
+        showWhitespace: diffWhitespaceBinding,
+        codeFontFamily: codeFontFamily,
+        codeFontSize: codeFontSize,
+        hunkActions: { hunk in
+            let actions = stagedHunkActions(hunk: hunk)
+            return DiffPaneHunkActions(stage: actions.stage, discard: actions.discard)
+        }
+    )
+} else {
+    Spinner()
+        .frame(width: 16, height: 16)
+        .padding()
+}
+```
+
+Add these bindings to `DiffTabView`:
+
+```swift
+private var diffLayoutBinding: Binding<DiffLayoutMode> {
+    Binding(
+        get: { appState.config.changes.diffLayoutMode },
+        set: {
+            appState.config.changes.diffLayoutMode = $0
+            appState.saveConfig()
+        }
+    )
+}
+
+private var diffWrapBinding: Binding<Bool> {
+    Binding(
+        get: { appState.config.changes.diffWrapLines },
+        set: {
+            appState.config.changes.diffWrapLines = $0
+            appState.saveConfig()
+        }
+    )
+}
+
+private var diffWhitespaceBinding: Binding<Bool> {
+    Binding(
+        get: { appState.config.changes.diffShowWhitespace },
+        set: {
+            appState.config.changes.diffShowWhitespace = $0
+            appState.saveConfig()
+        }
+    )
+}
+```
+
+- [ ] **Step 4: Run existing diff UI tests**
+
+Run:
+
+```bash
+xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' test -only-testing:AlasTests/DiffSelectableTextTests -only-testing:AlasTests/DiffPaneViewTests
+```
+
+Expected: both suites pass. If `HunkView` tests remain valid because `HunkView` still exists for commit views, keep them.
+
+- [ ] **Step 5: Commit integration**
+
+Commit:
+
+```bash
+git add Alas/Sources/Center/DiffTabView.swift AlasTests/DiffPaneViewTests.swift AlasTests/DiffSelectableTextTests.swift
+git commit -m "feat(diff): use review-ready pane in diff tabs"
+```
+
+If `AlasTests/DiffSelectableTextTests.swift` was not modified, omit it from `git add`.
+
+## Task 5: Final Verification And Polish
+
+**Files:**
+- Modify only files needed for compile/test fixes found by verification.
+
+- [ ] **Step 1: Confirm project generation state**
+
+Run:
+
+```bash
+git diff --name-only HEAD | rg '^project\.yml$'
+```
+
+Expected: no output. If output is `project.yml`, run:
+
+```bash
+xcodegen
+git add project.yml Alas.xcodeproj
+git commit -m "chore: regenerate xcode project"
+```
+
+- [ ] **Step 2: Run focused diff and config test suites**
+
+Run:
+
+```bash
+xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' test -only-testing:AlasTests/AppConfigChangesTests -only-testing:AlasTests/DiffInlineHighlighterTests -only-testing:AlasTests/DiffDisplayModelBuilderTests -only-testing:AlasTests/DiffPaneViewTests -only-testing:AlasTests/DiffSelectableTextTests -only-testing:AlasTests/DiffParserTests
+```
+
+Expected: all selected test suites pass.
+
+- [ ] **Step 3: Run full build**
+
+Run:
+
+```bash
+xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -quiet build
+```
+
+Expected: build exits 0.
+
+- [ ] **Step 4: Run full test suite**
+
+Run:
+
+```bash
+xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' test
+```
+
+Expected: test action exits 0. If full tests fail for an unrelated existing issue, capture the failing test names, confirm the focused diff suites still pass, and include the unrelated failures in the final report.
+
+- [ ] **Step 5: Inspect git diff and commit verification fixes**
+
+Run:
+
+```bash
+git status --short
+git diff --stat
+```
+
+If verification required fixes, commit them:
+
+```bash
+git add Alas/Sources/Center/Diff Alas/Sources/Center/DiffTabView.swift Alas/Sources/Persistence/AppConfig.swift AlasTests
+git commit -m "fix(diff): polish review-ready pane"
+```
+
+Expected: working tree contains only intentional changes or is clean after commits.
+
+## Execution Notes
+
+- Follow TDD: every production change in Tasks 1-4 starts with the failing test listed in the task.
+- Keep commits per task. Do not combine unrelated fixes across tasks.
+- Preserve `HunkView`; commit and draft-commit views still use it in this V1 plan.
+- Do not edit `project.yml`; the existing `Alas/Sources` source glob picks up the new Swift files.
+- Do not add attribution footers, generated-by markers, or co-author trailers.

--- a/docs/superpowers/specs/2026-06-11-review-ready-diff-pane-design.md
+++ b/docs/superpowers/specs/2026-06-11-review-ready-diff-pane-design.md
@@ -1,0 +1,316 @@
+---
+title: "Review-ready split and stacked diff pane"
+date: 2026-06-11
+project: alas
+phase: design
+prior_art:
+  - Alas/Sources/Git/DiffParser.swift
+  - Alas/Sources/Center/DiffTabView.swift
+  - Alas/Sources/Center/DiffSelectableTextView.swift
+  - Alas/Sources/Center/DiffSelectableTextBuilder.swift
+  - Alas/Sources/Center/Commit/CommitDiffView.swift
+  - Alas/Sources/ACP/UI/InlineDiffView.swift
+  - Alas/Sources/Integrations/CodeHost/CodeHostModels.swift
+  - Alas/Sources/Integrations/CodeHost/ReviewLoopHandoffBuilder.swift
+---
+
+## TL;DR
+
+Replace the text rendering in single-file diff tabs with a native,
+review-ready diff surface inspired by diffs.com and adapted to Alas themes.
+V1 supports split and stacked layouts, inline word highlights, collapsed
+unchanged regions, wrapping and whitespace controls, line/range selection, and
+non-posting local review affordances.
+
+The first implementation stays focused on working-tree and staged single-file
+diff tabs. The renderer and anchors must be reusable so commit diffs,
+draft-commit diffs, multi-file review, GitHub/GitLab review threads, and agent
+handoff can layer on top as fast follows.
+
+## Product Direction
+
+Alas should move from a styled `git diff` transcript to a proper diff review
+surface. The reader should feel like a native, focused code-review pane: clear
+split comparison when there is space, stacked review flow when that reads
+better, low-noise controls, strong syntax highlighting, and stable anchors for
+future comments and agent handoff.
+
+This feature is also the foundation for a later human review workflow. The
+user should eventually be able to review local changes in Alas, read
+GitHub/GitLab review comments, create their own review notes, and send selected
+diff context to the current agent or another chosen agent.
+
+## V1 Scope
+
+### In Scope
+
+- Replace text diff rendering in `DiffTabView` for working-tree and staged
+  single-file tabs.
+- Preserve image diff behavior through the existing `ImageDiffView` path.
+- Preserve current file-level actions: open file and discard file.
+- Preserve current hunk-level actions: stage hunk and discard hunk.
+- Add `Split / Stacked` layout switching.
+- Add inline word or token highlights for paired delete/add replacements.
+- Add unchanged-region collapsing with expand controls.
+- Add line wrapping and whitespace visibility controls.
+- Add layout-neutral line and range selection.
+- Add local, non-posting review affordances and in-memory draft note state
+  suitable for future comment UI.
+- Keep rendering native and theme-driven.
+
+### Out Of Scope For V1
+
+- Posting comments or replies to GitHub/GitLab.
+- Resolving GitHub/GitLab review threads.
+- Rendering remote review threads inside the diff.
+- Multi-file review sessions.
+- Review queue navigation.
+- Full keyboard-first review workflow.
+- Replacing commit and draft-commit diff views unless reuse is trivial during
+  implementation.
+- Replacing image diff behavior.
+- Introducing a web diff viewer.
+
+## UX Design
+
+The diff tab remains code-first. Its header keeps the current file identity,
+path, staged badge, change counts, open-file action, and discard-file action.
+Below the header, a compact diff toolbar adds:
+
+- segmented `Split / Stacked` mode
+- wrap toggle
+- whitespace toggle
+- collapsed-context control
+- optional overflow controls for copy and future review actions
+
+In split layout, each render row has old and new cells. Context appears on both
+sides, deletions appear on the old side, additions appear on the new side, and
+empty cells use a quiet background. Replacement lines should be paired where
+possible so inline highlights show exactly what changed inside the old and new
+text.
+
+In stacked layout, the same model renders sequentially: context rows, deleted
+rows, added rows, and expandable unchanged regions. Stacked mode is both a
+user-selectable layout and the natural fallback for narrow panes.
+
+Large unchanged regions collapse into rows such as `24 unchanged lines`, with
+controls to expand that region. Collapsed state belongs to view state, not the
+loaded diff, so expanding does not reload or re-parse.
+
+Hovering a line shows a subtle gutter affordance for selection or future
+commenting. Clicking selects a line. Shift-click extends to a range. Selection
+must survive switching between split and stacked because it is anchored to
+file/side/line metadata rather than row indexes.
+
+V1 exposes local note affordances as in-memory UI state only. A selected
+line/range can open a small draft note surface, and clearing the tab clears the
+draft. These notes are not provider-backed and do not imply remote posting
+support.
+
+## Architecture
+
+Keep the existing git loading path and add a derived display model.
+
+`ParsedDiff` remains the ingestion format. It is already used by staging,
+discarding, ACP inline diffs, and commit diff views, and it preserves patch
+details such as `\ No newline at end of file`. V1 should not replace that
+contract.
+
+Add a model builder, working name `DiffDisplayModelBuilder`, that converts a
+`ParsedDiff` and file identity into render-ready groups:
+
+- file path and display metadata
+- hunk groups
+- split-aligned rows
+- stacked row representation
+- old/new line numbers
+- row kind: context, add, delete, replacement, empty, collapsed
+- inline highlight spans
+- stable anchors
+- hunk action mapping back to the source `ParsedDiff.Hunk`
+
+Add a reusable native renderer, working name `DiffPaneView`, with presentation
+state:
+
+- layout mode
+- wrap enabled
+- whitespace visible
+- collapsed group expansion
+- selected line/range anchors
+- local draft note state
+
+`DiffTabView` continues to own:
+
+- `GitService.diff(...)` loading
+- image-vs-text routing
+- total additions/deletions
+- tracked/deleted file detection
+- file-level actions
+- stage/discard hunk actions
+- error and loading states
+
+Commit and draft-commit views can continue using the current renderer until the
+fast follow, but the new renderer should be designed so those views can pass an
+already-loaded `ParsedDiff` into the same component later.
+
+## Data Flow
+
+1. `DiffTabView` asks `GitService.diff(worktreePath:file:staged:)`.
+2. Git returns unified diff text.
+3. `DiffParser` produces `ParsedDiff`.
+4. `DiffTabView` computes totals and file state as it does today.
+5. `DiffDisplayModelBuilder` builds render-ready groups through a pure,
+   value-type API that `DiffTabView` can run off the main actor before
+   publishing the display model.
+6. `DiffPaneView` renders the display model using Alas theme tokens.
+7. Hunk actions call back to the existing `DiffTabView` staging and discard
+   paths with the original `ParsedDiff.Hunk`.
+
+View state should be independent of parsing. Changing layout mode, wrapping,
+whitespace visibility, expanded collapsed groups, or selected anchors must not
+reload the diff.
+
+## Anchors
+
+Stable anchors are required in V1 because the future review features depend on
+them. Anchor identity should be layout-neutral and derived from durable diff
+metadata:
+
+- file path
+- hunk index or hunk identity
+- side: old, new, or paired
+- old line number when present
+- new line number when present
+
+Representative anchors:
+
+- old-side anchor: file path + old line
+- new-side anchor: file path + new line
+- paired replacement anchor: file path + old line + new line
+- range anchor: first anchor + last anchor + side/layout-neutral metadata
+
+The exact ID string can be internal, but tests should prove anchors stay stable
+when switching split/stacked layout and when collapsed regions expand.
+
+## Inline Highlights
+
+Inline highlights are computed in the display-model layer. Start with a
+pragmatic pairing algorithm:
+
+1. Within a contiguous change block, collect deleted lines and added lines.
+2. Pair one delete with one add when counts match.
+3. For near matches, pair lines by order when the block is small.
+4. Tokenize by words and punctuation.
+5. Mark changed token ranges on each side.
+6. Fall back to full-line add/delete emphasis for complex many-to-many blocks.
+
+This should produce useful highlights without turning V1 into a general-purpose
+diff algorithm project.
+
+## Rendering
+
+Rendering should stay native. The current `DiffSelectableTextView` proves the
+app can host selectable, syntax-highlighted AppKit text with custom gutters.
+V1 can evolve that component or introduce a sibling AppKit-backed renderer if
+split alignment and range selection are cleaner with a new structure.
+
+Split layout should not use two independent vertical scroll views. The diff
+body should have one vertical scroll source so old/new rows stay aligned. Each
+group or row can render two columns inside that single scroll context.
+
+Horizontal scrolling may be shared at the body level or handled per code pane
+if AppKit text measurement makes that more reliable. The design requirement is
+that vertical alignment is deterministic and layout changes do not lose
+selection.
+
+Syntax highlighting should keep using `TreeSitterHighlighter` per line and the
+existing theme tokens:
+
+- `add`
+- `del`
+- `bg-1`
+- `bg-2`
+- `fg`
+- `fg-dim`
+- `fg-faint`
+- `accent`
+- existing syntax tokens
+
+No new theme tokens should be added unless implementation shows a real missing
+semantic color.
+
+## Settings And Persistence
+
+Persist diff display preferences in `AppConfig` so the pane keeps the user's
+preferred reading mode across app launches:
+
+- preferred layout mode
+- wrap enabled
+- whitespace visible
+- collapsed-context default
+
+Do not add a full settings pane for V1. The toolbar controls are the only V1
+preference UI.
+
+## Fast Follows
+
+After V1 lands, use the same renderer and anchors for:
+
+- commit diff views
+- draft-commit diff views
+- a multi-file review tab over all changed files
+- GitHub/GitLab review thread rendering
+- selecting a line/range/thread and sending it to an agent
+- review queue navigation
+- keyboard-first review flow
+
+The multi-file review tab is the highest-priority fast follow. V1 should not
+make choices that assume one file forever.
+
+## Risks And Mitigations
+
+Large diffs can stall UI if model building or text layout happens on the main
+actor. Keep display-model construction pure and run it off-main from
+`DiffTabView`, keep parsing deterministic, and consider lazy group rendering if
+large files expose performance issues.
+
+Split alignment can get complicated when long lines wrap. Keep a single
+vertical scroll source and define row heights from measured content. Wrapping
+can be opt-in if initial implementation is safer without default wrapping.
+
+Review comments need stable anchors. Add anchors in V1 even though remote
+review comments are out of scope. Tests should lock down anchor stability before
+the future code-host integration depends on it.
+
+Hunk actions must keep working. Preserve the original `ParsedDiff.Hunk` for
+each hunk-level action instead of reconstructing patches from display rows.
+
+## Testing Strategy
+
+Unit tests should cover:
+
+- display-model construction from representative `ParsedDiff` hunks
+- split row alignment for context, add-only, delete-only, and replacement
+  blocks
+- stacked row order
+- inline highlight pairing and fallback cases
+- collapsed unchanged-region grouping
+- anchor stability across layout modes
+- selection range normalization
+- hunk action mapping back to the original hunk
+
+Hosted rendering tests should cover basic AppKit/SwiftUI construction and
+selection surfaces. Snapshot tests are not required unless the repo already has
+a stable pattern for them.
+
+Manual verification should include:
+
+- working-tree unstaged diff
+- staged diff
+- untracked file
+- deleted file
+- renamed file
+- large file with long lines
+- syntax-highlighted Swift file
+- plain-text file
+- image diff still routed to `ImageDiffView`


### PR DESCRIPTION
## Summary
- Add persisted split/stacked diff display preferences and a display model for aligned rows, anchors, collapsed context, inline highlights, and selection ranges.
- Replace text diff tabs with the native review-ready diff pane while preserving image diffs and hunk actions.
- Rework the diff body to use merge-style AppKit text panes with non-selectable rulers, aligned empty split rows, and themed gutter/line styling.

## Verification
- `xcodegen`
- `rtk xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -quiet build`
- `rtk xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' test`
- Focused `DiffPaneViewTests` and `DiffSelectableTextTests` during iteration