### PR TITLE
feat(changes): unify working tree changes list

### DIFF
--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -90,6 +90,7 @@
 		1721FFC6A99B6E2683378552 /* ACPComposerDraftBridgeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9454F0214E21F91473C96F6 /* ACPComposerDraftBridgeTests.swift */; };
 		1748C3645E9B769F371F69E6 /* GitServiceUpstreamTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE2CDF03A998BADF20163D5A /* GitServiceUpstreamTests.swift */; };
 		175951CE78A1446A9131BA1F /* GitNameValidator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 269CE27A6F4F2E663EDF9052 /* GitNameValidator.swift */; };
+		175AA2192F1DBD9836E08E77 /* WorkingTreeChangeGroupTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F5959FF98A5105FF7B17894 /* WorkingTreeChangeGroupTests.swift */; };
 		175D0A77579A022F3AB81E48 /* SQLiteDatabase.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF5F20AB3B3F7BCEAA56B143 /* SQLiteDatabase.swift */; };
 		1792FECCA58D7603BD4DBDE8 /* GatekeeperRemediator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8C245764E69F92CBB8D31BF6 /* GatekeeperRemediator.swift */; };
 		17BC1BC2D81DED8B5D31DF3C /* CommitsAheadTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 576619C2726DFDE8F627AE19 /* CommitsAheadTests.swift */; };
@@ -662,6 +663,7 @@
 		ADAE65B8D982CD4411235D32 /* CodeHostRemoteDetector.swift in Sources */ = {isa = PBXBuildFile; fileRef = 82E98F9835497D830C12AA8F /* CodeHostRemoteDetector.swift */; };
 		ADF6D3B634D9CCA17D7884EC /* PiACPInstallerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C6641006D2208E28C46AAB2 /* PiACPInstallerTests.swift */; };
 		AE179E24A9E308150D1FD1D5 /* CommitPromptStatusTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1E40B5F193E3CB5EB5BA945A /* CommitPromptStatusTests.swift */; };
+		AE5BC95F30EE46ED0DE74F23 /* WorkingTreeChangeGroup.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9D32294F9B916DFAFF5E9A6F /* WorkingTreeChangeGroup.swift */; };
 		AEB565CDE2F5AEAE088A1A79 /* ACPChatLayoutTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 90762AFB51B237B783D4190C /* ACPChatLayoutTests.swift */; };
 		AF2263B61D95A8BFF0972E93 /* AgentHookEvent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 136BDA12046FB352E183D6A4 /* AgentHookEvent.swift */; };
 		AFD24C0A5D5625A1843751C1 /* ACPFirstRunConnectingPhase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 73539FDFE4BDBD4D3B4DE546 /* ACPFirstRunConnectingPhase.swift */; };
@@ -1169,6 +1171,7 @@
 		2EB39DE3614B5BEC4D3EBF13 /* ACPSessionLifecycleTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPSessionLifecycleTests.swift; sourceTree = "<group>"; };
 		2EF18448EDA0DCC8B171F11D /* CommitDiffView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommitDiffView.swift; sourceTree = "<group>"; };
 		2F1CBD7C9E0119EC1656C1E2 /* GeminiInstallerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GeminiInstallerTests.swift; sourceTree = "<group>"; };
+		2F5959FF98A5105FF7B17894 /* WorkingTreeChangeGroupTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkingTreeChangeGroupTests.swift; sourceTree = "<group>"; };
 		2F59C2CF9199EC099B1814AC /* CodexInstallerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CodexInstallerTests.swift; sourceTree = "<group>"; };
 		2F8A28C3DBC50749BB1D2BEA /* HeadReaderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HeadReaderTests.swift; sourceTree = "<group>"; };
 		2FD28E0005DE3A33A974A511 /* libsqlite3.tbd */ = {isa = PBXFileReference; lastKnownFileType = "sourcecode.text-based-dylib-definition"; name = libsqlite3.tbd; path = usr/lib/libsqlite3.tbd; sourceTree = SDKROOT; };
@@ -1574,6 +1577,7 @@
 		9C45A26ADB0D1CCFBB5BEAE8 /* TerminalSession.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TerminalSession.swift; sourceTree = "<group>"; };
 		9CA420C011D4235E47A3FB1B /* RepoSelectorRecents.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RepoSelectorRecents.swift; sourceTree = "<group>"; };
 		9D209865BE187943BF14B830 /* AgentRunnerInvocationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentRunnerInvocationTests.swift; sourceTree = "<group>"; };
+		9D32294F9B916DFAFF5E9A6F /* WorkingTreeChangeGroup.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkingTreeChangeGroup.swift; sourceTree = "<group>"; };
 		9D3C76F2F0F6BCE4023A9D7F /* StartupScriptResolverTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StartupScriptResolverTests.swift; sourceTree = "<group>"; };
 		9D7D83CD76ABF9FED3B29F62 /* ImageDiffView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageDiffView.swift; sourceTree = "<group>"; };
 		9DD81682586D187AB70D1CDB /* RemoteWorktreeSummaryBuilder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteWorktreeSummaryBuilder.swift; sourceTree = "<group>"; };
@@ -2334,6 +2338,7 @@
 				56D1AC9E1E00C3C5C234382C /* TouchTargetSmokeTests.swift */,
 				AD29EE0AFA5232B1ED728514 /* UnionCanvasGeometryTests.swift */,
 				708AB670AB611EFB9D216D7C /* UpdateThrottleTests.swift */,
+				2F5959FF98A5105FF7B17894 /* WorkingTreeChangeGroupTests.swift */,
 				5F931B1EEA7F04855BAE5A43 /* WorkingTreeStageAllActionTests.swift */,
 				AB4C1B7737A289066E01C444 /* WorkspaceLSPManagerStatusTests.swift */,
 				8B94010802299E6AC5597E85 /* WorktreeCodableTests.swift */,
@@ -2636,6 +2641,7 @@
 				FE66950F2226F1182DCDD39A /* RightPaneView.swift */,
 				934BCC470703CF2DF2303357 /* SectionHeader.swift */,
 				DDE8B45ECF898B83A616586D /* SubHeader.swift */,
+				9D32294F9B916DFAFF5E9A6F /* WorkingTreeChangeGroup.swift */,
 				866CFEB75B7F754485C6BE77 /* WorkingTreeSectionView.swift */,
 				E25BFA956432F729835EA7E3 /* Commit */,
 			);
@@ -4427,6 +4433,7 @@
 				4E08D715B766E9D04B4BA0B0 /* WindowAppearance.swift in Sources */,
 				CCA4B9F1FFBE1CAC99839A07 /* WindowConfigurator.swift in Sources */,
 				DA5ED6D708DD8C0B5563AB4F /* WindowDragHandle.swift in Sources */,
+				AE5BC95F30EE46ED0DE74F23 /* WorkingTreeChangeGroup.swift in Sources */,
 				22FDE2FB05952993DA2D0EB7 /* WorkingTreeSectionView.swift in Sources */,
 				8E2FB28D4C7681611BC67537 /* WorkspaceLSPManager.swift in Sources */,
 				9D2E53FB0A57BC38C146EA5E /* WorktreeLaunchSurface.swift in Sources */,
@@ -4839,6 +4846,7 @@
 				9C4246D4FEE6C6A7D3C738A8 /* UnionCanvasGeometryTests.swift in Sources */,
 				0DA68649E5F3C0018C4309DA /* UpdateThrottleTests.swift in Sources */,
 				2DDF8175D7490F505AED7DF4 /* WebSocketFrameTests.swift in Sources */,
+				175AA2192F1DBD9836E08E77 /* WorkingTreeChangeGroupTests.swift in Sources */,
 				9BA16B0D5FC26501D54B5192 /* WorkingTreeStageAllActionTests.swift in Sources */,
 				BE70DBB10DB7106860886AD7 /* WorkspaceLSPManagerStatusTests.swift in Sources */,
 				B34227BF866AFDACB3194333 /* WorktreeCodableTests.swift in Sources */,

--- a/Alas/Sources/Right/ChangedRow.swift
+++ b/Alas/Sources/Right/ChangedRow.swift
@@ -5,6 +5,11 @@ struct ChangedRow: View {
     var depth: Int = 0
     let onSelect: () -> Void
     var onStage: (() -> Void)? = nil
+    var stageState: StageChip.DisplayState? = nil
+    var displayAdd: Int? = nil
+    var displayDel: Int? = nil
+    var onStageEntries: (() -> Void)? = nil
+    var onUnstageEntries: (() -> Void)? = nil
     var onOpenFile:       (() -> Void)? = nil
     var onCopyRelative:   (() -> Void)? = nil
     var onCopyFull:       (() -> Void)? = nil
@@ -17,10 +22,13 @@ struct ChangedRow: View {
 
     var body: some View {
         let basename = file.path.split(separator: "/").last.map(String.init) ?? file.path
+        let add = displayAdd ?? file.add
+        let del = displayDel ?? file.del
+        let resolvedStageState = stageState ?? (file.stage == .staged ? .staged : .unstaged)
         return Button(action: onSelect) {
             HStack(spacing: 6) {
                 if let onStage {
-                    StageChip(staged: file.stage == .staged, action: onStage)
+                    StageChip(state: resolvedStageState, action: onStage)
                 }
                 FileTypeIconView(filename: basename, size: 18)
                 Text(basename)
@@ -28,8 +36,8 @@ struct ChangedRow: View {
                     .lineLimit(1)
                     .truncationMode(.middle)
                 Spacer()
-                if file.add > 0 { Text("+\(file.add)").foregroundColor(theme.color("add")) }
-                if file.del > 0 { Text("−\(file.del)").foregroundColor(theme.color("del")) }
+                if add > 0 { Text("+\(add)").foregroundColor(theme.color("add")) }
+                if del > 0 { Text("−\(del)").foregroundColor(theme.color("del")) }
                 StatusBadge(status: file.status)
             }
             .font(.system(size: 11, design: .monospaced))
@@ -49,7 +57,14 @@ struct ChangedRow: View {
             Divider()
             Button("Copy Diff") { onCopyDiff?() }
             Divider()
-            if onStage != nil {
+            if onStageEntries != nil || onUnstageEntries != nil {
+                if let onStageEntries {
+                    Button("Stage") { onStageEntries() }
+                }
+                if let onUnstageEntries {
+                    Button("Unstage") { onUnstageEntries() }
+                }
+            } else if onStage != nil {
                 Button(file.stage == .staged ? "Unstage" : "Stage") { onStage?() }
             }
             Button("Discard Changes...") { onDiscard?() }

--- a/Alas/Sources/Right/ChangesTabView.swift
+++ b/Alas/Sources/Right/ChangesTabView.swift
@@ -95,7 +95,6 @@ struct ChangesTabView: View {
                 changes: nonConflictChanges,
                 expanded: $rps.workingTreeExpanded,
                 onSelect: onSelect,
-                onToggleStage: { rps.toggleStage($0) },
                 onStageAll: { rps.stageAll($0) },
                 onUnstageAll: { rps.unstageAll($0) },
                 onIgnore: { path, isDir, dest in

--- a/Alas/Sources/Right/Commit/StageChip.swift
+++ b/Alas/Sources/Right/Commit/StageChip.swift
@@ -1,10 +1,26 @@
 import SwiftUI
 
 struct StageChip: View {
-    let staged: Bool
+    enum DisplayState {
+        case unstaged
+        case staged
+        case mixed
+    }
+
+    let state: DisplayState
     let action: () -> Void
     @Environment(\.theme) var theme
     @State private var hovering = false
+
+    init(staged: Bool, action: @escaping () -> Void) {
+        self.state = staged ? .staged : .unstaged
+        self.action = action
+    }
+
+    init(state: DisplayState, action: @escaping () -> Void) {
+        self.state = state
+        self.action = action
+    }
 
     var body: some View {
         Button(action: action) {
@@ -20,40 +36,68 @@ struct StageChip: View {
             }
             .frame(width: 20, height: 20)
             .contentShape(Rectangle())
-            .opacity(staged || hovering ? 1.0 : 0.55)
+            .opacity(state != .unstaged || hovering ? 1.0 : 0.55)
         }
         .buttonStyle(.plain)
         .onHover { hovering = $0 }
-        .help(staged ? "Unstage" : "Stage")
+        .help(help)
     }
 
     private var glyph: String {
-        if staged { return hovering ? "x" : "check" }
-        return "plus"
+        switch state {
+        case .staged:
+            return hovering ? "x" : "check"
+        case .mixed:
+            return hovering ? "plus" : "minus"
+        case .unstaged:
+            return "plus"
+        }
     }
 
     private var glyphColor: Color {
-        if staged {
+        switch state {
+        case .staged:
             return hovering ? theme.color("del") : theme.color("add")
+        case .mixed:
+            return hovering ? theme.color("fg") : theme.color("warn")
+        case .unstaged:
+            return hovering ? theme.color("fg") : theme.color("fg-faint")
         }
-        return hovering ? theme.color("fg") : theme.color("fg-faint")
     }
 
     private var fill: Color {
-        if staged {
+        switch state {
+        case .staged:
             return hovering
                 ? theme.color("del").opacity(0.18)
                 : theme.color("add").opacity(0.18)
+        case .mixed:
+            return hovering
+                ? theme.color("bg-4")
+                : theme.color("warn").opacity(0.16)
+        case .unstaged:
+            return hovering ? theme.color("bg-4") : .clear
         }
-        return hovering ? theme.color("bg-4") : .clear
     }
 
     private var border: Color {
-        if staged {
+        switch state {
+        case .staged:
             return hovering
                 ? theme.color("del").opacity(0.5)
                 : theme.color("add").opacity(0.5)
+        case .mixed:
+            return hovering ? theme.color("fg-dim") : theme.color("warn").opacity(0.5)
+        case .unstaged:
+            return hovering ? theme.color("fg-dim") : theme.color("line")
         }
-        return hovering ? theme.color("fg-dim") : theme.color("line")
+    }
+
+    private var help: String {
+        switch state {
+        case .staged: return "Unstage"
+        case .mixed: return "Stage remaining changes"
+        case .unstaged: return "Stage"
+        }
     }
 }

--- a/Alas/Sources/Right/WorkingTreeChangeGroup.swift
+++ b/Alas/Sources/Right/WorkingTreeChangeGroup.swift
@@ -1,0 +1,72 @@
+import Foundation
+
+enum WorkingTreeStageState: Equatable {
+    case unstaged
+    case staged
+    case mixed
+}
+
+struct WorkingTreeChangeGroup: Identifiable, Equatable {
+    let path: String
+    let entries: [ChangedFile]
+
+    var id: String { path }
+
+    var stagedEntries: [ChangedFile] {
+        entries.filter { $0.stage == .staged }
+    }
+
+    var unstagedEntries: [ChangedFile] {
+        entries.filter { $0.stage == .unstaged }
+    }
+
+    var stageState: WorkingTreeStageState {
+        switch (stagedEntries.isEmpty, unstagedEntries.isEmpty) {
+        case (false, false): return .mixed
+        case (false, true):  return .staged
+        default:             return .unstaged
+        }
+    }
+
+    var primaryEntry: ChangedFile {
+        unstagedEntries.first ?? entries[0]
+    }
+
+    var add: Int {
+        entries.reduce(0) { $0 + $1.add }
+    }
+
+    var del: Int {
+        entries.reduce(0) { $0 + $1.del }
+    }
+
+    static func group(files: [ChangedFile]) -> [WorkingTreeChangeGroup] {
+        Dictionary(grouping: files, by: \.path)
+            .map { path, entries in
+                WorkingTreeChangeGroup(
+                    path: path,
+                    entries: entries.sorted { lhs, rhs in
+                        lhs.stage.rawValue.localizedStandardCompare(rhs.stage.rawValue) == .orderedAscending
+                    }
+                )
+            }
+            .sorted { lhs, rhs in
+                lhs.path.localizedStandardCompare(rhs.path) == .orderedAscending
+            }
+    }
+}
+
+extension Array where Element == WorkingTreeChangeGroup {
+    func groups(under folder: String) -> [WorkingTreeChangeGroup] {
+        let prefix = folder.hasSuffix("/") ? folder : folder + "/"
+        return filter { $0.path.hasPrefix(prefix) }
+    }
+
+    func stagedEntries(under folder: String) -> [ChangedFile] {
+        groups(under: folder).flatMap(\.stagedEntries)
+    }
+
+    func unstagedEntries(under folder: String) -> [ChangedFile] {
+        groups(under: folder).flatMap(\.unstagedEntries)
+    }
+}

--- a/Alas/Sources/Right/WorkingTreeChangeGroup.swift
+++ b/Alas/Sources/Right/WorkingTreeChangeGroup.swift
@@ -29,15 +29,30 @@ struct WorkingTreeChangeGroup: Identifiable, Equatable {
     }
 
     var primaryEntry: ChangedFile {
-        unstagedEntries.first ?? entries[0]
+        let primary = unstagedEntries.first ?? entries[0]
+        guard
+            primary.renameFrom == nil,
+            let renameFrom = entries.first(where: { $0.status == "R" && $0.renameFrom != nil })?.renameFrom
+        else {
+            return primary
+        }
+        return ChangedFile(
+            path: primary.path,
+            status: primary.status,
+            stage: primary.stage,
+            add: primary.add,
+            del: primary.del,
+            renameFrom: renameFrom,
+            conflict: primary.conflict
+        )
     }
 
     var add: Int {
-        entries.reduce(0) { $0 + $1.add }
+        entries.map(\.add).max() ?? 0
     }
 
     var del: Int {
-        entries.reduce(0) { $0 + $1.del }
+        entries.map(\.del).max() ?? 0
     }
 
     static func group(files: [ChangedFile]) -> [WorkingTreeChangeGroup] {

--- a/Alas/Sources/Right/WorkingTreeSectionView.swift
+++ b/Alas/Sources/Right/WorkingTreeSectionView.swift
@@ -26,8 +26,8 @@ struct WorkingTreeSectionView: View {
     private var changeGroups: [WorkingTreeChangeGroup] {
         WorkingTreeChangeGroup.group(files: changes)
     }
-    private var totalAdd: Int { changes.reduce(0) { $0 + $1.add } }
-    private var totalDel: Int { changes.reduce(0) { $0 + $1.del } }
+    private var totalAdd: Int { changeGroups.reduce(0) { $0 + $1.add } }
+    private var totalDel: Int { changeGroups.reduce(0) { $0 + $1.del } }
 
     var body: some View {
         Section {
@@ -45,7 +45,7 @@ struct WorkingTreeSectionView: View {
         } header: {
             SectionHeader(
                 title: "Working tree",
-                count: changes.count,
+                count: changeGroups.count,
                 expanded: expanded,
                 onToggle: { expanded.toggle() },
                 stats: (add: totalAdd, del: totalDel)

--- a/Alas/Sources/Right/WorkingTreeSectionView.swift
+++ b/Alas/Sources/Right/WorkingTreeSectionView.swift
@@ -4,7 +4,6 @@ struct WorkingTreeSectionView: View {
     let changes: [ChangedFile]
     @Binding var expanded: Bool
     let onSelect: (ChangedFile) -> Void
-    var onToggleStage: ((ChangedFile) -> Void)? = nil
     var onStageAll: (([ChangedFile]) -> Void)? = nil
     var onUnstageAll: (([ChangedFile]) -> Void)? = nil
     var onIgnore: ((_ path: String, _ isDirectory: Bool, _ destination: IgnoreDestination) -> Void)? = nil
@@ -20,12 +19,13 @@ struct WorkingTreeSectionView: View {
 
     @Environment(\.theme) private var theme
 
-    @State private var stagedExpanded: Bool = true
-    @State private var unstagedExpanded: Bool = true
     @State private var collapsedChangePaths: Set<String> = []
 
     private var staged:   [ChangedFile] { changes.filter { $0.stage == .staged   } }
     private var unstaged: [ChangedFile] { changes.filter { $0.stage == .unstaged } }
+    private var changeGroups: [WorkingTreeChangeGroup] {
+        WorkingTreeChangeGroup.group(files: changes)
+    }
     private var totalAdd: Int { changes.reduce(0) { $0 + $1.add } }
     private var totalDel: Int { changes.reduce(0) { $0 + $1.del } }
 
@@ -38,28 +38,8 @@ struct WorkingTreeSectionView: View {
                         .foregroundColor(theme.color("fg-faint"))
                         .padding(.horizontal, 12).padding(.vertical, 8)
                         .frame(maxWidth: .infinity, alignment: .leading)
-                } else if staged.isEmpty {
-                    flatFileTree(files: unstaged, collapseNamespace: "unstaged")
                 } else {
-                    subsection(
-                        title: "Staged",
-                        files: staged,
-                        expanded: $stagedExpanded,
-                        collapseNamespace: "staged",
-                        actionLabel: "Unstage all",
-                        onAction: { onUnstageAll?(staged) },
-                        staged: true
-                    )
-                    if !unstaged.isEmpty {
-                        subsection(
-                            title: "Changes",
-                            files: unstaged,
-                            expanded: $unstagedExpanded,
-                            collapseNamespace: "unstaged",
-                            actionLabel: "Stage all",
-                            onAction: { onStageAll?(unstaged) }
-                        )
-                    }
+                    flatFileTree(groups: changeGroups)
                 }
             }
         } header: {
@@ -69,12 +49,21 @@ struct WorkingTreeSectionView: View {
                 expanded: expanded,
                 onToggle: { expanded.toggle() },
                 stats: (add: totalAdd, del: totalDel)
-            ) {
-                if staged.isEmpty, !unstaged.isEmpty {
-                    SectionHeaderActionLink(title: "Stage all", action: { onStageAll?(unstaged) })
-                }
-            }
+            ) { }
             .contextMenu {
+                if !unstaged.isEmpty {
+                    Button("Stage All Changes") {
+                        onStageAll?(unstaged)
+                    }
+                }
+                if !staged.isEmpty {
+                    Button("Unstage All Changes") {
+                        onUnstageAll?(staged)
+                    }
+                }
+                if !changes.isEmpty {
+                    Divider()
+                }
                 Button("Discard all working tree changes...") {
                     onDiscardAll?()
                 }
@@ -84,43 +73,11 @@ struct WorkingTreeSectionView: View {
     }
 
     @ViewBuilder
-    private func flatFileTree(files: [ChangedFile], collapseNamespace: String) -> some View {
-        let filesByPath = Dictionary(uniqueKeysWithValues: files.map { ($0.path, $0) })
+    private func flatFileTree(groups: [WorkingTreeChangeGroup]) -> some View {
+        let groupsByPath = Dictionary(uniqueKeysWithValues: groups.map { ($0.path, $0) })
+        let files = groups.map(\.primaryEntry)
         ForEach(ChangesTreeBuilder.build(files: files)) { node in
-            renderNode(node, filesByPath: filesByPath, depth: 0, collapseNamespace: collapseNamespace)
-        }
-    }
-
-    @ViewBuilder
-    private func subsection(
-        title: String,
-        files: [ChangedFile],
-        expanded: Binding<Bool>,
-        collapseNamespace: String,
-        actionLabel: String?,
-        onAction: (() -> Void)?,
-        staged: Bool = false
-    ) -> some View {
-        let add = files.reduce(0) { $0 + $1.add }
-        let del = files.reduce(0) { $0 + $1.del }
-        SubHeader(
-            title: title,
-            count: files.count,
-            expanded: expanded.wrappedValue,
-            onToggle: { expanded.wrappedValue.toggle() },
-            staged: staged,
-            stats: (add, del),
-            trailing: actionLabel.map { label in
-                AnyView(
-                    SectionHeaderActionLink(title: label, action: { onAction?() })
-                )
-            }
-        )
-        if expanded.wrappedValue {
-            let filesByPath = Dictionary(uniqueKeysWithValues: files.map { ($0.path, $0) })
-            ForEach(ChangesTreeBuilder.build(files: files)) { node in
-                renderNode(node, filesByPath: filesByPath, depth: 0, collapseNamespace: collapseNamespace)
-            }
+            renderNode(node, groups: groups, groupsByPath: groupsByPath, depth: 0)
         }
     }
 
@@ -135,13 +92,13 @@ struct WorkingTreeSectionView: View {
     /// Folders that contain any tracked entry get no Ignore menu.
     private func isUntrackedSubtree(
         _ node: FileTreeNode,
-        filesByPath: [String: ChangedFile]
+        groupsByPath: [String: WorkingTreeChangeGroup]
     ) -> Bool {
         if node.kind == .file {
-            return filesByPath[node.path].map(isUntracked) ?? false
+            return groupsByPath[node.path]?.entries.allSatisfy(isUntracked) ?? false
         }
         guard let kids = node.children, !kids.isEmpty else { return false }
-        return kids.allSatisfy { isUntrackedSubtree($0, filesByPath: filesByPath) }
+        return kids.allSatisfy { isUntrackedSubtree($0, groupsByPath: groupsByPath) }
     }
 
     @ViewBuilder
@@ -161,14 +118,17 @@ struct WorkingTreeSectionView: View {
 
     private func renderNode(
         _ node: FileTreeNode,
-        filesByPath: [String: ChangedFile],
-        depth: Int,
-        collapseNamespace: String
+        groups: [WorkingTreeChangeGroup],
+        groupsByPath: [String: WorkingTreeChangeGroup],
+        depth: Int
     ) -> AnyView {
         if node.kind == .dir {
-            let collapseKey = "\(collapseNamespace):\(node.path)"
+            let collapseKey = "working-tree:\(node.path)"
             let open = !collapsedChangePaths.contains(collapseKey)
-            let folderUntracked = isUntrackedSubtree(node, filesByPath: filesByPath)
+            let folderGroups = groups.groups(under: node.path)
+            let stagedEntries = folderGroups.flatMap(\.stagedEntries)
+            let unstagedEntries = folderGroups.flatMap(\.unstagedEntries)
+            let folderUntracked = isUntrackedSubtree(node, groupsByPath: groupsByPath)
             return AnyView(
                 Group {
                     Button {
@@ -202,6 +162,19 @@ struct WorkingTreeSectionView: View {
                     }
                     .buttonStyle(.plain)
                     .contextMenu {
+                        if !unstagedEntries.isEmpty {
+                            Button("Stage Changes") {
+                                onStageAll?(unstagedEntries)
+                            }
+                        }
+                        if !stagedEntries.isEmpty {
+                            Button("Unstage Changes") {
+                                onUnstageAll?(stagedEntries)
+                            }
+                        }
+                        if !stagedEntries.isEmpty || !unstagedEntries.isEmpty {
+                            Divider()
+                        }
                         Button("Discard Changes...") {
                             onDiscardFolder?(node.path)
                         }
@@ -213,25 +186,33 @@ struct WorkingTreeSectionView: View {
                         ForEach(kids) {
                             renderNode(
                                 $0,
-                                filesByPath: filesByPath,
-                                depth: depth + 1,
-                                collapseNamespace: collapseNamespace
+                                groups: groups,
+                                groupsByPath: groupsByPath,
+                                depth: depth + 1
                             )
                         }
                     }
                 }
             )
-        } else if let file = filesByPath[node.path] {
+        } else if let group = groupsByPath[node.path] {
+            let file = group.primaryEntry
             let fileUntracked = isUntracked(file)
             let ignore: AnyView? = fileUntracked
                 ? AnyView(ignoreMenu(path: file.path, isDirectory: false))
                 : nil
+            let canStage = !group.unstagedEntries.isEmpty
+            let canUnstage = !group.stagedEntries.isEmpty
             return AnyView(
                 ChangedRow(
                     file: file,
                     depth: depth,
                     onSelect: { onSelect(file) },
-                    onStage: onToggleStage.map { fn in { fn(file) } },
+                    onStage: primaryStageAction(for: group),
+                    stageState: stageChipState(for: group.stageState),
+                    displayAdd: group.add,
+                    displayDel: group.del,
+                    onStageEntries: canStage ? { onStageAll?(group.unstagedEntries) } : nil,
+                    onUnstageEntries: canUnstage ? { onUnstageAll?(group.stagedEntries) } : nil,
                     onOpenFile: onOpenFile.map { fn in { fn(file) } },
                     onCopyRelative: onCopyRelative.map { fn in { fn(file) } },
                     onCopyFull: onCopyFull.map { fn in { fn(file) } },
@@ -246,27 +227,23 @@ struct WorkingTreeSectionView: View {
             return AnyView(EmptyView())
         }
     }
-}
 
-/// Compact link-style action used in the trailing slot of section/sub
-/// headers. Avoids AlasButton's 28pt fixed height so headers stay the
-/// same vertical size as the COMMITS header and Draft commit nudge.
-private struct SectionHeaderActionLink: View {
-    let title: String
-    let action: () -> Void
-
-    @Environment(\.theme) private var theme
-    @State private var hovering = false
-
-    var body: some View {
-        Button(action: action) {
-            Text(title)
-                .font(.system(size: 10.5, weight: .semibold))
-                .tracking(0.3)
-                .foregroundColor(hovering ? theme.color("accent") : theme.color("fg-muted"))
+    private func primaryStageAction(for group: WorkingTreeChangeGroup) -> (() -> Void)? {
+        switch group.stageState {
+        case .staged:
+            guard !group.stagedEntries.isEmpty else { return nil }
+            return { onUnstageAll?(group.stagedEntries) }
+        case .mixed, .unstaged:
+            guard !group.unstagedEntries.isEmpty else { return nil }
+            return { onStageAll?(group.unstagedEntries) }
         }
-        .buttonStyle(.plain)
-        .pointingHandCursor()
-        .onHover { hovering = $0 }
+    }
+
+    private func stageChipState(for state: WorkingTreeStageState) -> StageChip.DisplayState {
+        switch state {
+        case .staged: return .staged
+        case .mixed: return .mixed
+        case .unstaged: return .unstaged
+        }
     }
 }

--- a/AlasTests/WorkingTreeChangeGroupTests.swift
+++ b/AlasTests/WorkingTreeChangeGroupTests.swift
@@ -16,6 +16,40 @@ struct WorkingTreeChangeGroupTests {
         #expect(groups[0].primaryEntry == unstaged)
     }
 
+    @Test func mixedPrimaryEntryPreservesStagedRenameOrigin() {
+        let stagedRename = ChangedFile(
+            path: "Sources/NewName.swift",
+            status: "R",
+            stage: .staged,
+            add: 12,
+            del: 3,
+            renameFrom: "Sources/OldName.swift"
+        )
+        let unstagedEdit = changedFile(
+            "Sources/NewName.swift",
+            status: "M",
+            stage: .unstaged,
+            add: 12,
+            del: 3
+        )
+
+        let group = WorkingTreeChangeGroup.group(files: [stagedRename, unstagedEdit])[0]
+
+        #expect(group.stageState == .mixed)
+        #expect(group.primaryEntry.stage == .unstaged)
+        #expect(group.primaryEntry.renameFrom == "Sources/OldName.swift")
+    }
+
+    @Test func mixedStatsUsePerPathCountsOnce() {
+        let staged = changedFile("Sources/App.swift", status: "M", stage: .staged, add: 4, del: 2)
+        let unstaged = changedFile("Sources/App.swift", status: "M", stage: .unstaged, add: 4, del: 2)
+
+        let group = WorkingTreeChangeGroup.group(files: [staged, unstaged])[0]
+
+        #expect(group.add == 4)
+        #expect(group.del == 2)
+    }
+
     @Test func reportsCheckedAndUncheckedStateForSingleStageRows() {
         let staged = changedFile("A.swift", stage: .staged)
         let unstaged = changedFile("B.swift", stage: .unstaged)

--- a/AlasTests/WorkingTreeChangeGroupTests.swift
+++ b/AlasTests/WorkingTreeChangeGroupTests.swift
@@ -1,0 +1,58 @@
+import Testing
+@testable import Alas
+
+struct WorkingTreeChangeGroupTests {
+    @Test func groupsStagedAndUnstagedEntriesForSamePathIntoMixedRow() {
+        let staged = changedFile("Sources/App.swift", status: "M", stage: .staged, add: 4)
+        let unstaged = changedFile("Sources/App.swift", status: "M", stage: .unstaged, add: 2)
+
+        let groups = WorkingTreeChangeGroup.group(files: [staged, unstaged])
+
+        #expect(groups.count == 1)
+        #expect(groups[0].path == "Sources/App.swift")
+        #expect(groups[0].stageState == .mixed)
+        #expect(groups[0].stagedEntries == [staged])
+        #expect(groups[0].unstagedEntries == [unstaged])
+        #expect(groups[0].primaryEntry == unstaged)
+    }
+
+    @Test func reportsCheckedAndUncheckedStateForSingleStageRows() {
+        let staged = changedFile("A.swift", stage: .staged)
+        let unstaged = changedFile("B.swift", stage: .unstaged)
+
+        let groups = WorkingTreeChangeGroup.group(files: [unstaged, staged])
+
+        #expect(groups.map(\.path) == ["A.swift", "B.swift"])
+        #expect(groups.first { $0.path == "A.swift" }?.stageState == .staged)
+        #expect(groups.first { $0.path == "B.swift" }?.stageState == .unstaged)
+    }
+
+    @Test func returnsRecursiveEntriesForFolderStageMenus() {
+        let stagedRoot = changedFile("README.md", stage: .staged)
+        let stagedChild = changedFile("Sources/App.swift", stage: .staged)
+        let unstagedChild = changedFile("Sources/App.swift", stage: .unstaged)
+        let unstagedSibling = changedFile("Sources/View.swift", stage: .unstaged)
+        let stagedNested = changedFile("Sources/Models/User.swift", stage: .staged)
+
+        let groups = WorkingTreeChangeGroup.group(files: [
+            stagedRoot,
+            stagedChild,
+            unstagedChild,
+            unstagedSibling,
+            stagedNested
+        ])
+
+        #expect(groups.stagedEntries(under: "Sources") == [stagedChild, stagedNested])
+        #expect(groups.unstagedEntries(under: "Sources") == [unstagedChild, unstagedSibling])
+    }
+
+    private func changedFile(
+        _ path: String,
+        status: String = "M",
+        stage: ChangeStage = .unstaged,
+        add: Int = 1,
+        del: Int = 0
+    ) -> ChangedFile {
+        ChangedFile(path: path, status: status, stage: stage, add: add, del: del, renameFrom: nil)
+    }
+}


### PR DESCRIPTION
## Summary
- Render staged and unstaged working tree changes in one unified tree.
- Represent partially staged paths as one mixed-state row instead of duplicate staged/unstaged rows.
- Move recursive stage and unstage actions into row, folder, and Working tree context menus.
- Add grouping tests for mixed path state and recursive folder stage/unstage selection.

## Verification
- `xcodegen`
- `xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -quiet build`
- `xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' test`