### PR TITLE
fix(lsp): Kotlin LSP Gatekeeper remediation

### DIFF
--- a/Alas/Sources/Code/LSP/GatekeeperRemediator.swift
+++ b/Alas/Sources/Code/LSP/GatekeeperRemediator.swift
@@ -16,7 +16,7 @@ final class GatekeeperRemediator {
         case failed(String)
     }
 
-    typealias QuarantineRemover = (_ realPath: String) async -> Bool
+    typealias QuarantineRemover = (_ path: String) async -> Bool
     typealias Reassess = (_ realPath: String) -> GatekeeperAssessor.Result
     typealias InvalidateCache = (_ realPath: String) -> Void
 
@@ -34,8 +34,9 @@ final class GatekeeperRemediator {
         self.invalidate = invalidate
     }
 
-    func remediate(realPath: String) async -> Outcome {
-        let removed = await removeQuarantine(realPath)
+    func remediate(realPath: String, remediationTarget: String? = nil) async -> Outcome {
+        let target = remediationTarget ?? realPath
+        let removed = await removeQuarantine(target)
         invalidate(realPath)
         switch reassess(realPath) {
         case .allowed:
@@ -50,14 +51,33 @@ final class GatekeeperRemediator {
     nonisolated static func defaultRemoveQuarantine(realPath: String) async -> Bool {
         await withCheckedContinuation { continuation in
             DispatchQueue.global().async {
-                let size = realPath.withCString { cpath in
-                    removexattr(cpath, "com.apple.quarantine", 0)
-                }
-                // 0 → removed. -1 with ENOATTR → wasn't there; treat as
-                // success since the post-state matches the goal.
-                let ok = size == 0 || (size == -1 && errno == ENOATTR)
-                continuation.resume(returning: ok)
+                continuation.resume(returning: removeQuarantineRecursively(at: realPath))
             }
         }
+    }
+
+    nonisolated private static func removeQuarantineRecursively(at path: String) -> Bool {
+        var ok = removeQuarantineAttribute(at: path)
+        var isDirectory: ObjCBool = false
+        guard FileManager.default.fileExists(atPath: path, isDirectory: &isDirectory),
+              isDirectory.boolValue,
+              let enumerator = FileManager.default.enumerator(atPath: path) else {
+            return ok
+        }
+
+        for case let relativePath as String in enumerator {
+            let childPath = URL(fileURLWithPath: path).appendingPathComponent(relativePath).path
+            ok = removeQuarantineAttribute(at: childPath) && ok
+        }
+        return ok
+    }
+
+    nonisolated private static func removeQuarantineAttribute(at path: String) -> Bool {
+        let result = path.withCString { cpath in
+            removexattr(cpath, "com.apple.quarantine", 0)
+        }
+        // 0 → removed. -1 with ENOATTR → wasn't there; treat as
+        // success since the post-state matches the goal.
+        return result == 0 || (result == -1 && errno == ENOATTR)
     }
 }

--- a/Alas/Sources/Code/LSP/LanguageServerAvailability.swift
+++ b/Alas/Sources/Code/LSP/LanguageServerAvailability.swift
@@ -14,19 +14,24 @@ struct LanguageServerAvailability {
     private let xcrunFind: (String) -> String?
     private let additionalPathDirectories: [String]
     private let gatekeeperAssessor: (String) -> GatekeeperAssessor.Result
+    private let gatekeeperRemediator: (String) async -> GatekeeperRemediator.Outcome
 
     init(
         environment: [String: String] = ProcessInfo.processInfo.environment,
         fileManager: FileManager = .default,
         xcrunFind: @escaping (String) -> String? = LanguageServerAvailability.xcrunFind,
         additionalPathDirectories: [String] = LanguageServerAvailability.defaultAdditionalPathDirectories(),
-        gatekeeperAssessor: @escaping (String) -> GatekeeperAssessor.Result = { GatekeeperAssessor.shared.assess(realPath: $0) }
+        gatekeeperAssessor: @escaping (String) -> GatekeeperAssessor.Result = { GatekeeperAssessor.shared.assess(realPath: $0) },
+        gatekeeperRemediator: @escaping (String) async -> GatekeeperRemediator.Outcome = {
+            await GatekeeperRemediator().remediate(realPath: $0)
+        }
     ) {
         self.environment = environment
         self.fileManager = fileManager
         self.xcrunFind = xcrunFind
         self.additionalPathDirectories = additionalPathDirectories
         self.gatekeeperAssessor = gatekeeperAssessor
+        self.gatekeeperRemediator = gatekeeperRemediator
     }
 
     func status(for entry: LanguageServerConfig) -> Status {
@@ -46,6 +51,26 @@ struct LanguageServerAvailability {
         }
 
         return .available
+    }
+
+    func statusRemediatingGatekeeper(for entry: LanguageServerConfig) async -> Status {
+        let maxAttempts = entry.gatekeeperHelpers.count + 1
+
+        for _ in 0..<maxAttempts {
+            let current = status(for: entry)
+            guard case .blockedByGatekeeper(let realPath) = current else {
+                return current
+            }
+
+            switch await gatekeeperRemediator(realPath) {
+            case .allowed:
+                continue
+            case .stillBlocked, .failed:
+                return .blockedByGatekeeper(realPath: realPath)
+            }
+        }
+
+        return status(for: entry)
     }
 
     private func gatekeeperStatus(forResolvedPath resolved: String) -> Status {

--- a/Alas/Sources/Code/LSP/LanguageServerAvailability.swift
+++ b/Alas/Sources/Code/LSP/LanguageServerAvailability.swift
@@ -32,6 +32,23 @@ struct LanguageServerAvailability {
     func status(for entry: LanguageServerConfig) -> Status {
         guard entry.enabled else { return .disabled }
         guard let resolved = resolvedCommand(for: entry) else { return .notInstalled }
+        var assessedRealPaths = Set<String>()
+        let primary = gatekeeperStatus(forResolvedPath: resolved)
+        assessedRealPaths.insert((resolved as NSString).resolvingSymlinksInPath)
+        guard primary == .available else { return primary }
+
+        for helper in entry.gatekeeperHelpers {
+            guard let helperPath = resolvedHelper(helper, env: entry.env) else { continue }
+            let helperRealPath = (helperPath as NSString).resolvingSymlinksInPath
+            guard assessedRealPaths.insert(helperRealPath).inserted else { continue }
+            let helperStatus = gatekeeperStatus(forResolvedPath: helperRealPath)
+            guard helperStatus == .available else { return helperStatus }
+        }
+
+        return .available
+    }
+
+    private func gatekeeperStatus(forResolvedPath resolved: String) -> Status {
         let realPath = (resolved as NSString).resolvingSymlinksInPath
         switch gatekeeperAssessor(realPath) {
         case .rejected:
@@ -75,6 +92,13 @@ struct LanguageServerAvailability {
         }
         merged["PATH"] = effectivePath(env: entry.env)
         return merged
+    }
+
+    private func resolvedHelper(_ helper: String, env: [String: String]) -> String? {
+        if helper.contains("/") {
+            return fileManager.isExecutableFile(atPath: helper) ? helper : nil
+        }
+        return executableNamed(helper, env: env)
     }
 
     private func executableNamed(_ name: String, env: [String: String] = [:]) -> String? {

--- a/Alas/Sources/Code/LSP/LanguageServerAvailability.swift
+++ b/Alas/Sources/Code/LSP/LanguageServerAvailability.swift
@@ -14,7 +14,7 @@ struct LanguageServerAvailability {
     private let xcrunFind: (String) -> String?
     private let additionalPathDirectories: [String]
     private let gatekeeperAssessor: (String) -> GatekeeperAssessor.Result
-    private let gatekeeperRemediator: (String) async -> GatekeeperRemediator.Outcome
+    private let gatekeeperRemediator: (String, String) async -> GatekeeperRemediator.Outcome
 
     init(
         environment: [String: String] = ProcessInfo.processInfo.environment,
@@ -22,8 +22,8 @@ struct LanguageServerAvailability {
         xcrunFind: @escaping (String) -> String? = LanguageServerAvailability.xcrunFind,
         additionalPathDirectories: [String] = LanguageServerAvailability.defaultAdditionalPathDirectories(),
         gatekeeperAssessor: @escaping (String) -> GatekeeperAssessor.Result = { GatekeeperAssessor.shared.assess(realPath: $0) },
-        gatekeeperRemediator: @escaping (String) async -> GatekeeperRemediator.Outcome = {
-            await GatekeeperRemediator().remediate(realPath: $0)
+        gatekeeperRemediator: @escaping (String, String) async -> GatekeeperRemediator.Outcome = {
+            await GatekeeperRemediator().remediate(realPath: $0, remediationTarget: $1)
         }
     ) {
         self.environment = environment
@@ -43,26 +43,34 @@ struct LanguageServerAvailability {
         guard primary == .available else { return primary }
 
         for helper in entry.gatekeeperHelpers {
-            guard let helperPath = resolvedHelper(helper, env: entry.env) else { continue }
+            guard let helperPath = resolvedHelper(helper, env: entry.env, primaryCommandPath: resolved) else { continue }
             let helperRealPath = (helperPath as NSString).resolvingSymlinksInPath
             guard assessedRealPaths.insert(helperRealPath).inserted else { continue }
             let helperStatus = gatekeeperStatus(forResolvedPath: helperRealPath)
             guard helperStatus == .available else { return helperStatus }
         }
 
+        let rootPath = remediationTarget(for: (resolved as NSString).resolvingSymlinksInPath, entry: entry)
+        if rootPath != (resolved as NSString).resolvingSymlinksInPath,
+           assessedRealPaths.insert(rootPath).inserted {
+            let rootStatus = gatekeeperStatus(forResolvedPath: rootPath)
+            guard rootStatus == .available else { return rootStatus }
+        }
+
         return .available
     }
 
     func statusRemediatingGatekeeper(for entry: LanguageServerConfig) async -> Status {
-        let maxAttempts = entry.gatekeeperHelpers.count + 1
+        let maxAttempts = entry.gatekeeperHelpers.count + (entry.gatekeeperRemediationRootMarkers.isEmpty ? 1 : 2)
 
         for _ in 0..<maxAttempts {
             let current = status(for: entry)
             guard case .blockedByGatekeeper(let realPath) = current else {
                 return current
             }
+            let remediationTarget = remediationTarget(for: realPath, entry: entry)
 
-            switch await gatekeeperRemediator(realPath) {
+            switch await gatekeeperRemediator(realPath, remediationTarget) {
             case .allowed:
                 continue
             case .stillBlocked, .failed:
@@ -71,6 +79,25 @@ struct LanguageServerAvailability {
         }
 
         return status(for: entry)
+    }
+
+    private func remediationTarget(for realPath: String, entry: LanguageServerConfig) -> String {
+        guard !entry.gatekeeperRemediationRootMarkers.isEmpty else { return realPath }
+        var current = URL(fileURLWithPath: realPath)
+        if !isDirectory(current) {
+            current.deleteLastPathComponent()
+        }
+
+        while current.path != "/" {
+            for marker in entry.gatekeeperRemediationRootMarkers {
+                let markerPath = current.appendingPathComponent(marker).path
+                if fileManager.fileExists(atPath: markerPath) {
+                    return current.path
+                }
+            }
+            current.deleteLastPathComponent()
+        }
+        return realPath
     }
 
     private func gatekeeperStatus(forResolvedPath resolved: String) -> Status {
@@ -119,9 +146,18 @@ struct LanguageServerAvailability {
         return merged
     }
 
-    private func resolvedHelper(_ helper: String, env: [String: String]) -> String? {
+    private func resolvedHelper(_ helper: String, env: [String: String], primaryCommandPath: String) -> String? {
         if helper.contains("/") {
             return fileManager.isExecutableFile(atPath: helper) ? helper : nil
+        }
+        let primaryDirectory = URL(fileURLWithPath: primaryCommandPath)
+            .resolvingSymlinksInPath()
+            .deletingLastPathComponent()
+        for candidate in [
+            primaryDirectory.appendingPathComponent(helper).path,
+            primaryDirectory.appendingPathComponent("bin").appendingPathComponent(helper).path
+        ] where fileManager.isExecutableFile(atPath: candidate) {
+            return candidate
         }
         return executableNamed(helper, env: env)
     }
@@ -134,6 +170,11 @@ struct LanguageServerAvailability {
             }
         }
         return nil
+    }
+
+    private func isDirectory(_ url: URL) -> Bool {
+        var isDirectory: ObjCBool = false
+        return fileManager.fileExists(atPath: url.path, isDirectory: &isDirectory) && isDirectory.boolValue
     }
 
     private func effectivePath(env: [String: String]) -> String {

--- a/Alas/Sources/Code/LSP/LanguageServerRegistry.swift
+++ b/Alas/Sources/Code/LSP/LanguageServerRegistry.swift
@@ -9,6 +9,7 @@ struct LanguageServerConfig: Codable, Equatable, Identifiable, Sendable {
     var env: [String: String]
     var rootMarkers: [String]
     var gatekeeperHelpers: [String]
+    var gatekeeperRemediationRootMarkers: [String]
     var enabled: Bool
 
     init(
@@ -19,6 +20,7 @@ struct LanguageServerConfig: Codable, Equatable, Identifiable, Sendable {
         env: [String: String],
         rootMarkers: [String],
         gatekeeperHelpers: [String] = [],
+        gatekeeperRemediationRootMarkers: [String] = [],
         enabled: Bool
     ) {
         self.language = language
@@ -28,11 +30,12 @@ struct LanguageServerConfig: Codable, Equatable, Identifiable, Sendable {
         self.env = env
         self.rootMarkers = rootMarkers
         self.gatekeeperHelpers = gatekeeperHelpers
+        self.gatekeeperRemediationRootMarkers = gatekeeperRemediationRootMarkers
         self.enabled = enabled
     }
 
     private enum CodingKeys: String, CodingKey {
-        case language, extensions, command, args, env, rootMarkers, gatekeeperHelpers, enabled
+        case language, extensions, command, args, env, rootMarkers, gatekeeperHelpers, gatekeeperRemediationRootMarkers, enabled
     }
 
     init(from decoder: Decoder) throws {
@@ -44,6 +47,10 @@ struct LanguageServerConfig: Codable, Equatable, Identifiable, Sendable {
         env = try container.decode([String: String].self, forKey: .env)
         rootMarkers = try container.decode([String].self, forKey: .rootMarkers)
         gatekeeperHelpers = try container.decodeIfPresent([String].self, forKey: .gatekeeperHelpers) ?? []
+        gatekeeperRemediationRootMarkers = try container.decodeIfPresent(
+            [String].self,
+            forKey: .gatekeeperRemediationRootMarkers
+        ) ?? []
         enabled = try container.decode(Bool.self, forKey: .enabled)
     }
 }
@@ -90,6 +97,7 @@ struct LanguageServerRegistry {
                 "pom.xml", ".git"
             ],
             gatekeeperHelpers: ["intellij-server"],
+            gatekeeperRemediationRootMarkers: ["product-info.json"],
             enabled: true
         ),
         LanguageServerConfig(

--- a/Alas/Sources/Code/LSP/LanguageServerRegistry.swift
+++ b/Alas/Sources/Code/LSP/LanguageServerRegistry.swift
@@ -8,7 +8,44 @@ struct LanguageServerConfig: Codable, Equatable, Identifiable, Sendable {
     var args: [String]
     var env: [String: String]
     var rootMarkers: [String]
+    var gatekeeperHelpers: [String]
     var enabled: Bool
+
+    init(
+        language: String,
+        extensions: [String],
+        command: String,
+        args: [String],
+        env: [String: String],
+        rootMarkers: [String],
+        gatekeeperHelpers: [String] = [],
+        enabled: Bool
+    ) {
+        self.language = language
+        self.extensions = extensions
+        self.command = command
+        self.args = args
+        self.env = env
+        self.rootMarkers = rootMarkers
+        self.gatekeeperHelpers = gatekeeperHelpers
+        self.enabled = enabled
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case language, extensions, command, args, env, rootMarkers, gatekeeperHelpers, enabled
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        language = try container.decode(String.self, forKey: .language)
+        extensions = try container.decode([String].self, forKey: .extensions)
+        command = try container.decode(String.self, forKey: .command)
+        args = try container.decode([String].self, forKey: .args)
+        env = try container.decode([String: String].self, forKey: .env)
+        rootMarkers = try container.decode([String].self, forKey: .rootMarkers)
+        gatekeeperHelpers = try container.decodeIfPresent([String].self, forKey: .gatekeeperHelpers) ?? []
+        enabled = try container.decode(Bool.self, forKey: .enabled)
+    }
 }
 
 struct LanguageServerRegistry {
@@ -52,6 +89,7 @@ struct LanguageServerRegistry {
                 "settings.gradle.kts", "settings.gradle",
                 "pom.xml", ".git"
             ],
+            gatekeeperHelpers: ["intellij-server"],
             enabled: true
         ),
         LanguageServerConfig(

--- a/Alas/Sources/Code/LSP/WorkspaceLSPManager.swift
+++ b/Alas/Sources/Code/LSP/WorkspaceLSPManager.swift
@@ -87,6 +87,7 @@ final class WorkspaceLSPManager: DocumentFormatter {
     }
 
     private var holders: [Key: Holder] = [:]
+    private var pendingOpenRefs: [Key: [String: Int]] = [:]
 
     /// Bumping counter that lets `@Observable` consumers (the status badge)
     /// re-run derivations when a holder transitions starting → ready → dead.
@@ -185,18 +186,19 @@ final class WorkspaceLSPManager: DocumentFormatter {
             // this value rather than the stale `text` captured on a prior
             // call. (Codex case: tab closed and reopened with different
             // content while the server was still initializing.)
-            var pending = existing.pendingOpenText
-            if !existing.openedURIs.contains(uri) { pending[uri] = text }
-            holders[key] = Holder(client: existing.client, ready: existing.ready, refsByURI: refs, openedURIs: existing.openedURIs, versions: existing.versions, pendingOpenText: pending, texts: existing.texts, languagesByURI: existing.languagesByURI, lifeState: existing.lifeState)
+            holders[key] = holderByUpdatingRefs(existing, uri: uri, text: text, refs: refs)
             client = existing.client
             ready = existing.ready
             isFirstOpener = false
         } else {
+            addPendingOpenRef(key: key, uri: uri)
             let availability = makeAvailability()
-            switch availability.status(for: entry) {
+            switch await availability.statusRemediatingGatekeeper(for: entry) {
             case .disabled, .notInstalled:
+                _ = consumePendingOpenRef(key: key, uri: uri)
                 return nil
             case .blockedByGatekeeper(let realPath):
+                _ = consumePendingOpenRef(key: key, uri: uri)
                 NotificationCenter.default.post(
                     name: .lspBlockedByGatekeeper,
                     object: nil,
@@ -206,24 +208,34 @@ final class WorkspaceLSPManager: DocumentFormatter {
             case .available:
                 break
             }
-            let spawn = Self.resolveSpawn(
-                command: entry.command,
-                args: entry.args,
-                env: entry.env,
-                language: entry.language,
-                availability: availability
-            )
-            let transport = LSPTransport(executable: spawn.executable, arguments: spawn.arguments, environment: spawn.environment)
-            let newClient = LSPClient(transport: transport, language: languageId, rootURI: lspRoot.lspURI)
-            let task = Task<Bool, Never> {
-                do { try await newClient.initialize()
-                return true } catch { return false }
+            guard consumePendingOpenRef(key: key, uri: uri) else { return nil }
+            if let existing = holders[key] {
+                var refs = existing.refsByURI
+                refs[uri, default: 0] += 1
+                holders[key] = holderByUpdatingRefs(existing, uri: uri, text: text, refs: refs)
+                client = existing.client
+                ready = existing.ready
+                isFirstOpener = false
+            } else {
+                let spawn = Self.resolveSpawn(
+                    command: entry.command,
+                    args: entry.args,
+                    env: entry.env,
+                    language: entry.language,
+                    availability: availability
+                )
+                let transport = LSPTransport(executable: spawn.executable, arguments: spawn.arguments, environment: spawn.environment)
+                let newClient = LSPClient(transport: transport, language: languageId, rootURI: lspRoot.lspURI)
+                let task = Task<Bool, Never> {
+                    do { try await newClient.initialize()
+                    return true } catch { return false }
+                }
+                holders[key] = Holder(client: newClient, ready: task, refsByURI: [uri: 1], openedURIs: [], versions: [:], pendingOpenText: [uri: text], texts: [:], languagesByURI: [:], lifeState: .starting)
+                bumpStateTick()
+                client = newClient
+                ready = task
+                isFirstOpener = true
             }
-            holders[key] = Holder(client: newClient, ready: task, refsByURI: [uri: 1], openedURIs: [], versions: [:], pendingOpenText: [uri: text], texts: [:], languagesByURI: [:], lifeState: .starting)
-            bumpStateTick()
-            client = newClient
-            ready = task
-            isFirstOpener = true
         }
 
         let initOk = await ready.value
@@ -322,7 +334,10 @@ final class WorkspaceLSPManager: DocumentFormatter {
         let uri = fileURL.lspURI
         // See `didChange` — find the holder by URI so registry edits made
         // after the open don't strand the original server.
-        guard let key = holderKey(forURI: uri), var holder = holders[key], (holder.refsByURI[uri] ?? 0) > 0 else { return }
+        guard let key = holderKey(forURI: uri), var holder = holders[key], (holder.refsByURI[uri] ?? 0) > 0 else {
+            _ = consumePendingOpenRef(forURI: uri, withinWorktreeRoot: worktreeRoot)
+            return
+        }
         var refs = holder.refsByURI
         let newRef = (refs[uri] ?? 0) - 1
         if newRef <= 0 {
@@ -585,6 +600,54 @@ final class WorkspaceLSPManager: DocumentFormatter {
             return key
         }
         return nil
+    }
+
+    private func addPendingOpenRef(key: Key, uri: String) {
+        var refs = pendingOpenRefs[key] ?? [:]
+        refs[uri, default: 0] += 1
+        pendingOpenRefs[key] = refs
+    }
+
+    private func consumePendingOpenRef(key: Key, uri: String) -> Bool {
+        guard var refs = pendingOpenRefs[key], let count = refs[uri], count > 0 else { return false }
+        if count == 1 {
+            refs.removeValue(forKey: uri)
+        } else {
+            refs[uri] = count - 1
+        }
+        if refs.isEmpty {
+            pendingOpenRefs.removeValue(forKey: key)
+        } else {
+            pendingOpenRefs[key] = refs
+        }
+        return true
+    }
+
+    private func consumePendingOpenRef(forURI uri: String, withinWorktreeRoot worktreeRoot: URL) -> Bool {
+        let rootPath = worktreeRoot.path
+        let rootPrefix = rootPath.hasSuffix("/") ? rootPath : rootPath + "/"
+        for key in pendingOpenRefs.keys where pendingOpenRefs[key]?[uri] != nil {
+            if key.root == rootPath || key.root.hasPrefix(rootPrefix) {
+                return consumePendingOpenRef(key: key, uri: uri)
+            }
+        }
+        return false
+    }
+
+    private func holderByUpdatingRefs(_ holder: Holder, uri: String, text: String, refs: [String: Int]) -> Holder {
+        var pending = holder.pendingOpenText
+        if !holder.openedURIs.contains(uri) { pending[uri] = text }
+        return Holder(
+            client: holder.client,
+            ready: holder.ready,
+            refsByURI: refs,
+            openedURIs: holder.openedURIs,
+            versions: holder.versions,
+            pendingOpenText: pending,
+            texts: holder.texts,
+            languagesByURI: holder.languagesByURI,
+            lifeState: holder.lifeState
+        )
     }
 
     /// Worktree-scoped variant: returns a holder for `uri` only if its

--- a/AlasTests/Code/LSP/LanguageServerAvailabilityTests.swift
+++ b/AlasTests/Code/LSP/LanguageServerAvailabilityTests.swift
@@ -373,6 +373,85 @@ struct LanguageServerAvailabilityTests {
         #expect(assessed == [server.resolvingSymlinksInPath().path])
     }
 
+    @Test("auto-remediation clears quarantined helper before reporting available")
+    func remediationClearsBlockedHelper() async throws {
+        let dir = try temporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: dir) }
+        _ = try executable(named: "kotlin-lsp", in: dir)
+        let helper = try executable(named: "intellij-server", in: dir)
+        let helperPath = helper.resolvingSymlinksInPath().path
+        var blocked = Set([helperPath])
+        var remediated: [String] = []
+
+        let entry = config(language: "kotlin", command: "kotlin-lsp", gatekeeperHelpers: ["intellij-server"])
+        let availability = LanguageServerAvailability(
+            environment: ["PATH": dir.path],
+            xcrunFind: { _ in nil },
+            additionalPathDirectories: [],
+            gatekeeperAssessor: { path in blocked.contains(path) ? .rejected : .allowed },
+            gatekeeperRemediator: { path in
+                remediated.append(path)
+                blocked.remove(path)
+                return .allowed
+            }
+        )
+
+        #expect(await availability.statusRemediatingGatekeeper(for: entry) == .available)
+        #expect(remediated == [helperPath])
+    }
+
+    @Test("auto-remediation failure returns blocked helper path")
+    func remediationFailureReturnsBlockedHelper() async throws {
+        let dir = try temporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: dir) }
+        _ = try executable(named: "kotlin-lsp", in: dir)
+        let helper = try executable(named: "intellij-server", in: dir)
+        let helperPath = helper.resolvingSymlinksInPath().path
+
+        let entry = config(language: "kotlin", command: "kotlin-lsp", gatekeeperHelpers: ["intellij-server"])
+        let availability = LanguageServerAvailability(
+            environment: ["PATH": dir.path],
+            xcrunFind: { _ in nil },
+            additionalPathDirectories: [],
+            gatekeeperAssessor: { path in path == helperPath ? .rejected : .allowed },
+            gatekeeperRemediator: { _ in .failed("nope") }
+        )
+
+        let status = await availability.statusRemediatingGatekeeper(for: entry)
+
+        guard case .blockedByGatekeeper(let realPath) = status else {
+            Issue.record("Expected blocked helper path, got \(status)")
+            return
+        }
+        #expect(realPath == helperPath)
+    }
+
+    @Test("auto-remediation rechecks primary command after successful remediation")
+    func remediationRechecksPrimaryCommand() async throws {
+        let dir = try temporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let server = try executable(named: "kotlin-lsp", in: dir)
+        let serverPath = server.resolvingSymlinksInPath().path
+        var blocked = Set([serverPath])
+        var remediated: [String] = []
+
+        let entry = config(language: "kotlin", command: "kotlin-lsp")
+        let availability = LanguageServerAvailability(
+            environment: ["PATH": dir.path],
+            xcrunFind: { _ in nil },
+            additionalPathDirectories: [],
+            gatekeeperAssessor: { path in blocked.contains(path) ? .rejected : .allowed },
+            gatekeeperRemediator: { path in
+                remediated.append(path)
+                blocked.remove(path)
+                return .allowed
+            }
+        )
+
+        #expect(await availability.statusRemediatingGatekeeper(for: entry) == .available)
+        #expect(remediated == [serverPath])
+    }
+
     @Test("notInstalled commands never reach the gatekeeper assessor")
     func notInstalledSkipsAssessor() {
         var assessorCalled = false

--- a/AlasTests/Code/LSP/LanguageServerAvailabilityTests.swift
+++ b/AlasTests/Code/LSP/LanguageServerAvailabilityTests.swift
@@ -325,6 +325,40 @@ struct LanguageServerAvailabilityTests {
         #expect(realPath == helper.resolvingSymlinksInPath().path)
     }
 
+    @Test("gatekeeper helper resolves next to symlinked launcher target")
+    func helperGatekeeperResolvesNextToSymlinkedLauncherTarget() throws {
+        let dir = try temporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let pathDir = dir.appendingPathComponent("path")
+        let installDir = dir.appendingPathComponent("kotlin-server")
+        let helperDir = installDir.appendingPathComponent("bin")
+        try FileManager.default.createDirectory(at: pathDir, withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(at: helperDir, withIntermediateDirectories: true)
+
+        let launcher = try executable(named: "kotlin-lsp.sh", in: installDir)
+        let pathCommand = pathDir.appendingPathComponent("kotlin-lsp")
+        try FileManager.default.createSymbolicLink(at: pathCommand, withDestinationURL: launcher)
+        let helper = try executable(named: "intellij-server", in: helperDir)
+
+        let entry = config(language: "kotlin", command: "kotlin-lsp", gatekeeperHelpers: ["intellij-server"])
+        let availability = LanguageServerAvailability(
+            environment: ["PATH": pathDir.path],
+            xcrunFind: { _ in nil },
+            additionalPathDirectories: [],
+            gatekeeperAssessor: { path in
+                path == helper.resolvingSymlinksInPath().path ? .rejected : .allowed
+            }
+        )
+
+        let status = availability.status(for: entry)
+
+        guard case .blockedByGatekeeper(let realPath) = status else {
+            Issue.record("Expected helper block, got \(status)")
+            return
+        }
+        #expect(realPath == helper.resolvingSymlinksInPath().path)
+    }
+
     @Test("missing gatekeeper helper does not make server unavailable")
     func missingHelperDoesNotBlockAvailability() throws {
         let dir = try temporaryDirectory()
@@ -389,7 +423,7 @@ struct LanguageServerAvailabilityTests {
             xcrunFind: { _ in nil },
             additionalPathDirectories: [],
             gatekeeperAssessor: { path in blocked.contains(path) ? .rejected : .allowed },
-            gatekeeperRemediator: { path in
+            gatekeeperRemediator: { path, _ in
                 remediated.append(path)
                 blocked.remove(path)
                 return .allowed
@@ -398,6 +432,81 @@ struct LanguageServerAvailabilityTests {
 
         #expect(await availability.statusRemediatingGatekeeper(for: entry) == .available)
         #expect(remediated == [helperPath])
+    }
+
+    @Test("auto-remediation clears helper install root when marker is configured")
+    func remediationClearsHelperInstallRoot() async throws {
+        let dir = try temporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let installDir = dir.appendingPathComponent("kotlin-server")
+        let helperDir = installDir.appendingPathComponent("bin")
+        try FileManager.default.createDirectory(at: helperDir, withIntermediateDirectories: true)
+        #expect(FileManager.default.createFile(
+            atPath: installDir.appendingPathComponent("product-info.json").path,
+            contents: Data()
+        ))
+        _ = try executable(named: "kotlin-lsp.sh", in: installDir)
+        let helper = try executable(named: "intellij-server", in: helperDir)
+        let helperPath = helper.resolvingSymlinksInPath().path
+        var blocked = Set([helperPath])
+        var remediated: [String] = []
+
+        let entry = config(
+            language: "kotlin",
+            command: installDir.appendingPathComponent("kotlin-lsp.sh").path,
+            gatekeeperHelpers: ["intellij-server"],
+            gatekeeperRemediationRootMarkers: ["product-info.json"]
+        )
+        let availability = LanguageServerAvailability(
+            xcrunFind: { _ in nil },
+            additionalPathDirectories: [],
+            gatekeeperAssessor: { path in blocked.contains(path) ? .rejected : .allowed },
+            gatekeeperRemediator: { _, remediationTarget in
+                remediated.append(remediationTarget)
+                blocked.remove(helperPath)
+                return .allowed
+            }
+        )
+
+        #expect(await availability.statusRemediatingGatekeeper(for: entry) == .available)
+        #expect(remediated == [installDir.path])
+    }
+
+    @Test("auto-remediation clears install root when binaries were already allowed")
+    func remediationClearsInstallRootWhenBinariesAlreadyAllowed() async throws {
+        let dir = try temporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let installDir = dir.appendingPathComponent("kotlin-server")
+        let helperDir = installDir.appendingPathComponent("bin")
+        try FileManager.default.createDirectory(at: helperDir, withIntermediateDirectories: true)
+        #expect(FileManager.default.createFile(
+            atPath: installDir.appendingPathComponent("product-info.json").path,
+            contents: Data()
+        ))
+        _ = try executable(named: "kotlin-lsp.sh", in: installDir)
+        _ = try executable(named: "intellij-server", in: helperDir)
+        var blocked = Set([installDir.path])
+        var remediated: [String] = []
+
+        let entry = config(
+            language: "kotlin",
+            command: installDir.appendingPathComponent("kotlin-lsp.sh").path,
+            gatekeeperHelpers: ["intellij-server"],
+            gatekeeperRemediationRootMarkers: ["product-info.json"]
+        )
+        let availability = LanguageServerAvailability(
+            xcrunFind: { _ in nil },
+            additionalPathDirectories: [],
+            gatekeeperAssessor: { path in blocked.contains(path) ? .rejected : .allowed },
+            gatekeeperRemediator: { _, remediationTarget in
+                remediated.append(remediationTarget)
+                blocked.remove(remediationTarget)
+                return .allowed
+            }
+        )
+
+        #expect(await availability.statusRemediatingGatekeeper(for: entry) == .available)
+        #expect(remediated == [installDir.path])
     }
 
     @Test("auto-remediation failure returns blocked helper path")
@@ -414,7 +523,7 @@ struct LanguageServerAvailabilityTests {
             xcrunFind: { _ in nil },
             additionalPathDirectories: [],
             gatekeeperAssessor: { path in path == helperPath ? .rejected : .allowed },
-            gatekeeperRemediator: { _ in .failed("nope") }
+            gatekeeperRemediator: { _, _ in .failed("nope") }
         )
 
         let status = await availability.statusRemediatingGatekeeper(for: entry)
@@ -441,7 +550,7 @@ struct LanguageServerAvailabilityTests {
             xcrunFind: { _ in nil },
             additionalPathDirectories: [],
             gatekeeperAssessor: { path in blocked.contains(path) ? .rejected : .allowed },
-            gatekeeperRemediator: { path in
+            gatekeeperRemediator: { path, _ in
                 remediated.append(path)
                 blocked.remove(path)
                 return .allowed
@@ -475,6 +584,7 @@ struct LanguageServerAvailabilityTests {
         args: [String] = [],
         env: [String: String] = [:],
         gatekeeperHelpers: [String] = [],
+        gatekeeperRemediationRootMarkers: [String] = [],
         enabled: Bool = true
     ) -> LanguageServerConfig {
         LanguageServerConfig(
@@ -485,6 +595,7 @@ struct LanguageServerAvailabilityTests {
             env: env,
             rootMarkers: [],
             gatekeeperHelpers: gatekeeperHelpers,
+            gatekeeperRemediationRootMarkers: gatekeeperRemediationRootMarkers,
             enabled: enabled
         )
     }

--- a/AlasTests/Code/LSP/LanguageServerAvailabilityTests.swift
+++ b/AlasTests/Code/LSP/LanguageServerAvailabilityTests.swift
@@ -245,6 +245,134 @@ struct LanguageServerAvailabilityTests {
         #expect(availability.status(for: entry) == .available)
     }
 
+    @Test("available primary command checks configured gatekeeper helper")
+    func helperGatekeeperRejected() throws {
+        let dir = try temporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let server = try executable(named: "kotlin-lsp", in: dir)
+        let helper = try executable(named: "intellij-server", in: dir)
+        var assessed: [String] = []
+
+        let entry = config(language: "kotlin", command: "kotlin-lsp", gatekeeperHelpers: ["intellij-server"])
+        let availability = LanguageServerAvailability(
+            environment: ["PATH": dir.path],
+            xcrunFind: { _ in nil },
+            additionalPathDirectories: [],
+            gatekeeperAssessor: { path in
+                assessed.append(path)
+                return path == helper.resolvingSymlinksInPath().path ? .rejected : .allowed
+            }
+        )
+
+        let status = availability.status(for: entry)
+
+        guard case .blockedByGatekeeper(let realPath) = status else {
+            Issue.record("Expected helper block, got \(status)")
+            return
+        }
+        #expect(realPath == helper.resolvingSymlinksInPath().path)
+        #expect(assessed == [server.resolvingSymlinksInPath().path, helper.resolvingSymlinksInPath().path])
+    }
+
+    @Test("allowed gatekeeper helper keeps server available")
+    func helperGatekeeperAllowed() throws {
+        let dir = try temporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let server = try executable(named: "kotlin-lsp", in: dir)
+        let helper = try executable(named: "intellij-server", in: dir)
+        var assessed: [String] = []
+
+        let entry = config(language: "kotlin", command: "kotlin-lsp", gatekeeperHelpers: ["intellij-server"])
+        let availability = LanguageServerAvailability(
+            environment: ["PATH": dir.path],
+            xcrunFind: { _ in nil },
+            additionalPathDirectories: [],
+            gatekeeperAssessor: { path in
+                assessed.append(path)
+                return .allowed
+            }
+        )
+
+        #expect(availability.status(for: entry) == .available)
+        #expect(assessed == [server.resolvingSymlinksInPath().path, helper.resolvingSymlinksInPath().path])
+    }
+
+    @Test("gatekeeper helper path containing slash is assessed")
+    func helperGatekeeperPathIsAssessed() throws {
+        let dir = try temporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let helperDir = dir.appendingPathComponent("helpers")
+        try FileManager.default.createDirectory(at: helperDir, withIntermediateDirectories: true)
+        _ = try executable(named: "kotlin-lsp", in: dir)
+        let helper = try executable(named: "intellij-server", in: helperDir)
+
+        let entry = config(language: "kotlin", command: "kotlin-lsp", gatekeeperHelpers: [helper.path])
+        let availability = LanguageServerAvailability(
+            environment: ["PATH": dir.path],
+            xcrunFind: { _ in nil },
+            additionalPathDirectories: [],
+            gatekeeperAssessor: { path in
+                path == helper.resolvingSymlinksInPath().path ? .rejected : .allowed
+            }
+        )
+
+        let status = availability.status(for: entry)
+
+        guard case .blockedByGatekeeper(let realPath) = status else {
+            Issue.record("Expected helper path block, got \(status)")
+            return
+        }
+        #expect(realPath == helper.resolvingSymlinksInPath().path)
+    }
+
+    @Test("missing gatekeeper helper does not make server unavailable")
+    func missingHelperDoesNotBlockAvailability() throws {
+        let dir = try temporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let server = try executable(named: "kotlin-lsp", in: dir)
+        var assessed: [String] = []
+
+        let entry = config(language: "kotlin", command: "kotlin-lsp", gatekeeperHelpers: ["intellij-server"])
+        let availability = LanguageServerAvailability(
+            environment: ["PATH": dir.path],
+            xcrunFind: { _ in nil },
+            additionalPathDirectories: [],
+            gatekeeperAssessor: { path in
+                assessed.append(path)
+                return .allowed
+            }
+        )
+
+        #expect(availability.status(for: entry) == .available)
+        #expect(assessed == [server.resolvingSymlinksInPath().path])
+    }
+
+    @Test("duplicate helper paths are assessed once")
+    func duplicateHelperPathsAreAssessedOnce() throws {
+        let dir = try temporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let server = try executable(named: "kotlin-lsp", in: dir)
+        var assessed: [String] = []
+
+        let entry = config(
+            language: "kotlin",
+            command: "kotlin-lsp",
+            gatekeeperHelpers: ["kotlin-lsp", "kotlin-lsp"]
+        )
+        let availability = LanguageServerAvailability(
+            environment: ["PATH": dir.path],
+            xcrunFind: { _ in nil },
+            additionalPathDirectories: [],
+            gatekeeperAssessor: { path in
+                assessed.append(path)
+                return .allowed
+            }
+        )
+
+        #expect(availability.status(for: entry) == .available)
+        #expect(assessed == [server.resolvingSymlinksInPath().path])
+    }
+
     @Test("notInstalled commands never reach the gatekeeper assessor")
     func notInstalledSkipsAssessor() {
         var assessorCalled = false
@@ -262,7 +390,14 @@ struct LanguageServerAvailabilityTests {
         #expect(assessorCalled == false)
     }
 
-    private func config(language: String = "test", command: String, args: [String] = [], env: [String: String] = [:], enabled: Bool = true) -> LanguageServerConfig {
+    private func config(
+        language: String = "test",
+        command: String,
+        args: [String] = [],
+        env: [String: String] = [:],
+        gatekeeperHelpers: [String] = [],
+        enabled: Bool = true
+    ) -> LanguageServerConfig {
         LanguageServerConfig(
             language: language,
             extensions: [language],
@@ -270,8 +405,16 @@ struct LanguageServerAvailabilityTests {
             args: args,
             env: env,
             rootMarkers: [],
+            gatekeeperHelpers: gatekeeperHelpers,
             enabled: enabled
         )
+    }
+
+    private func executable(named name: String, in dir: URL) throws -> URL {
+        let url = dir.appendingPathComponent(name)
+        #expect(FileManager.default.createFile(atPath: url.path, contents: Data()))
+        try FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: url.path)
+        return url
     }
 
     private func temporaryDirectory() throws -> URL {

--- a/AlasTests/Code/LSP/LanguageServerRegistryTests.swift
+++ b/AlasTests/Code/LSP/LanguageServerRegistryTests.swift
@@ -59,6 +59,34 @@ struct LanguageServerRegistryTests {
         #expect(r.language(forFileExtension: "xyz") == nil)
     }
 
+    @Test("Kotlin built-in records intellij-server helper")
+    func kotlinGatekeeperHelper() {
+        let entry = LanguageServerRegistry.builtIns.first(where: { $0.language == "kotlin" })
+        #expect(entry?.command == "kotlin-lsp")
+        #expect(entry?.args == ["--stdio"])
+        #expect(entry?.gatekeeperHelpers == ["intellij-server"])
+    }
+
+    @Test("LanguageServerConfig decodes legacy JSON without gatekeeper helpers")
+    func legacyConfigDecodeDefaultsGatekeeperHelpers() throws {
+        let json = """
+        {
+          "language": "kotlin",
+          "extensions": ["kt", "kts"],
+          "command": "kotlin-lsp",
+          "args": ["--stdio"],
+          "env": {},
+          "rootMarkers": [".git"],
+          "enabled": true
+        }
+        """
+
+        let decoded = try JSONDecoder().decode(LanguageServerConfig.self, from: Data(json.utf8))
+
+        #expect(decoded.language == "kotlin")
+        #expect(decoded.gatekeeperHelpers == [])
+    }
+
     @Test("built-in Python entry exists")
     func python() {
         let r = LanguageServerRegistry(userDefined: [])

--- a/AlasTests/WorkspaceLSPManagerStatusTests.swift
+++ b/AlasTests/WorkspaceLSPManagerStatusTests.swift
@@ -171,7 +171,7 @@ struct WorkspaceLSPManagerStatusTests {
                     xcrunFind: { _ in nil },
                     additionalPathDirectories: [],
                     gatekeeperAssessor: { _ in box.blocked ? .rejected : .allowed },
-                    gatekeeperRemediator: { path in
+                    gatekeeperRemediator: { path, _ in
                         box.remediated.append(path)
                         box.blocked = false
                         return .allowed
@@ -219,7 +219,7 @@ struct WorkspaceLSPManagerStatusTests {
                     xcrunFind: { _ in nil },
                     additionalPathDirectories: [],
                     gatekeeperAssessor: { _ in .rejected },
-                    gatekeeperRemediator: { _ in .failed("nope") }
+                    gatekeeperRemediator: { _, _ in .failed("nope") }
                 )
             }
         )
@@ -270,7 +270,7 @@ struct WorkspaceLSPManagerStatusTests {
                     xcrunFind: { _ in nil },
                     additionalPathDirectories: [],
                     gatekeeperAssessor: { _ in box.blocked ? .rejected : .allowed },
-                    gatekeeperRemediator: { _ in await box.waitForBothRemediationAttempts() }
+                    gatekeeperRemediator: { _, _ in await box.waitForBothRemediationAttempts() }
                 )
             }
         )
@@ -325,7 +325,7 @@ struct WorkspaceLSPManagerStatusTests {
                     xcrunFind: { _ in nil },
                     additionalPathDirectories: [],
                     gatekeeperAssessor: { _ in box.blocked ? .rejected : .allowed },
-                    gatekeeperRemediator: { _ in await box.remediate() }
+                    gatekeeperRemediator: { _, _ in await box.remediate() }
                 )
             }
         )
@@ -383,7 +383,7 @@ struct WorkspaceLSPManagerStatusTests {
                     xcrunFind: { _ in nil },
                     additionalPathDirectories: [],
                     gatekeeperAssessor: { _ in box.blocked ? .rejected : .allowed },
-                    gatekeeperRemediator: { _ in await box.remediate() }
+                    gatekeeperRemediator: { _, _ in await box.remediate() }
                 )
             }
         )

--- a/AlasTests/WorkspaceLSPManagerStatusTests.swift
+++ b/AlasTests/WorkspaceLSPManagerStatusTests.swift
@@ -144,4 +144,269 @@ struct WorkspaceLSPManagerStatusTests {
         _ = mgr.availabilityStatus(forLanguage: "swift")
         #expect(box.calls == 1)
     }
+
+    @Test func openDocumentRemediatesGatekeeperBlockBeforeSpawning() async {
+        final class Box {
+            let path = "/usr/bin/true"
+            var blocked = true
+            var remediated: [String] = []
+        }
+        let box = Box()
+        let registry = LanguageServerRegistry(userDefined: [
+            LanguageServerConfig(
+                language: "swift",
+                extensions: ["swift"],
+                command: box.path,
+                args: [],
+                env: [:],
+                rootMarkers: [],
+                enabled: true
+            )
+        ])
+        let mgr = WorkspaceLSPManager(
+            registry: registry,
+            makeAvailability: {
+                LanguageServerAvailability(
+                    environment: [:],
+                    xcrunFind: { _ in nil },
+                    additionalPathDirectories: [],
+                    gatekeeperAssessor: { _ in box.blocked ? .rejected : .allowed },
+                    gatekeeperRemediator: { path in
+                        box.remediated.append(path)
+                        box.blocked = false
+                        return .allowed
+                    }
+                )
+            }
+        )
+
+        _ = await mgr.openDocument(worktreeRoot: root, fileURL: fileURL, languageId: "swift", text: "")
+
+        #expect(box.remediated == [box.path])
+        #expect(mgr.documentStatus(forFile: fileURL, worktreeRoot: root) != .none)
+    }
+
+    @Test func openDocumentPostsBlockedNotificationWhenRemediationFails() async {
+        final class Box {
+            let path = "/usr/bin/true"
+            var notificationRealPath: String?
+        }
+        let box = Box()
+        let registry = LanguageServerRegistry(userDefined: [
+            LanguageServerConfig(
+                language: "swift",
+                extensions: ["swift"],
+                command: box.path,
+                args: [],
+                env: [:],
+                rootMarkers: [],
+                enabled: true
+            )
+        ])
+        let token = NotificationCenter.default.addObserver(
+            forName: .lspBlockedByGatekeeper,
+            object: nil,
+            queue: nil
+        ) { note in
+            box.notificationRealPath = note.userInfo?["realPath"] as? String
+        }
+        defer { NotificationCenter.default.removeObserver(token) }
+        let mgr = WorkspaceLSPManager(
+            registry: registry,
+            makeAvailability: {
+                LanguageServerAvailability(
+                    environment: [:],
+                    xcrunFind: { _ in nil },
+                    additionalPathDirectories: [],
+                    gatekeeperAssessor: { _ in .rejected },
+                    gatekeeperRemediator: { _ in .failed("nope") }
+                )
+            }
+        )
+
+        _ = await mgr.openDocument(worktreeRoot: root, fileURL: fileURL, languageId: "swift", text: "")
+
+        #expect(box.notificationRealPath == box.path)
+        #expect(mgr.documentStatus(forFile: fileURL, worktreeRoot: root) == .none)
+    }
+
+    @Test func concurrentOpenDocumentsJoinHolderInsertedAfterRemediation() async {
+        final class Box {
+            let path = "/usr/bin/true"
+            var blocked = true
+            var continuations: [CheckedContinuation<GatekeeperRemediator.Outcome, Never>] = []
+
+            func waitForBothRemediationAttempts() async -> GatekeeperRemediator.Outcome {
+                await withCheckedContinuation { continuation in
+                    continuations.append(continuation)
+                    guard continuations.count == 2 else { return }
+                    blocked = false
+                    let parked = continuations
+                    continuations.removeAll()
+                    for continuation in parked {
+                        continuation.resume(returning: .allowed)
+                    }
+                }
+            }
+        }
+        let box = Box()
+        let otherFileURL = root.appendingPathComponent("other.swift")
+        let registry = LanguageServerRegistry(userDefined: [
+            LanguageServerConfig(
+                language: "swift",
+                extensions: ["swift"],
+                command: box.path,
+                args: [],
+                env: [:],
+                rootMarkers: [],
+                enabled: true
+            )
+        ])
+        let mgr = WorkspaceLSPManager(
+            registry: registry,
+            makeAvailability: {
+                LanguageServerAvailability(
+                    environment: [:],
+                    xcrunFind: { _ in nil },
+                    additionalPathDirectories: [],
+                    gatekeeperAssessor: { _ in box.blocked ? .rejected : .allowed },
+                    gatekeeperRemediator: { _ in await box.waitForBothRemediationAttempts() }
+                )
+            }
+        )
+
+        async let first: LSPClient? = mgr.openDocument(worktreeRoot: root, fileURL: fileURL, languageId: "swift", text: "")
+        async let second: LSPClient? = mgr.openDocument(worktreeRoot: root, fileURL: otherFileURL, languageId: "swift", text: "")
+        _ = await (first, second)
+
+        #expect(mgr.documentStatus(forFile: fileURL, worktreeRoot: root) != .none)
+        #expect(mgr.documentStatus(forFile: otherFileURL, worktreeRoot: root) != .none)
+    }
+
+    @Test func closeDuringRemediationCancelsPendingOpen() async {
+        final class Box {
+            let path = "/usr/bin/true"
+            var blocked = true
+            var remediation: CheckedContinuation<GatekeeperRemediator.Outcome, Never>?
+            var parked: CheckedContinuation<Void, Never>?
+
+            func remediate() async -> GatekeeperRemediator.Outcome {
+                await withCheckedContinuation { continuation in
+                    remediation = continuation
+                    parked?.resume()
+                    parked = nil
+                }
+            }
+
+            func waitUntilRemediationIsParked() async {
+                if remediation != nil { return }
+                await withCheckedContinuation { continuation in
+                    parked = continuation
+                }
+            }
+        }
+        let box = Box()
+        let registry = LanguageServerRegistry(userDefined: [
+            LanguageServerConfig(
+                language: "swift",
+                extensions: ["swift"],
+                command: box.path,
+                args: [],
+                env: [:],
+                rootMarkers: [],
+                enabled: true
+            )
+        ])
+        let mgr = WorkspaceLSPManager(
+            registry: registry,
+            makeAvailability: {
+                LanguageServerAvailability(
+                    environment: [:],
+                    xcrunFind: { _ in nil },
+                    additionalPathDirectories: [],
+                    gatekeeperAssessor: { _ in box.blocked ? .rejected : .allowed },
+                    gatekeeperRemediator: { _ in await box.remediate() }
+                )
+            }
+        )
+
+        async let opened: LSPClient? = mgr.openDocument(worktreeRoot: root, fileURL: fileURL, languageId: "swift", text: "")
+        await box.waitUntilRemediationIsParked()
+        await mgr.closeDocument(worktreeRoot: root, fileURL: fileURL, languageId: "swift")
+        box.blocked = false
+        box.remediation?.resume(returning: .allowed)
+        box.remediation = nil
+        _ = await opened
+
+        #expect(mgr.documentStatus(forFile: fileURL, worktreeRoot: root) == .none)
+    }
+
+    @Test func closeDuringRemediationCancelsPendingOpenAfterRegistryChange() async {
+        final class Box {
+            let path = "/usr/bin/true"
+            var blocked = true
+            var remediation: CheckedContinuation<GatekeeperRemediator.Outcome, Never>?
+            var parked: CheckedContinuation<Void, Never>?
+
+            func remediate() async -> GatekeeperRemediator.Outcome {
+                await withCheckedContinuation { continuation in
+                    remediation = continuation
+                    parked?.resume()
+                    parked = nil
+                }
+            }
+
+            func waitUntilRemediationIsParked() async {
+                if remediation != nil { return }
+                await withCheckedContinuation { continuation in
+                    parked = continuation
+                }
+            }
+        }
+        let box = Box()
+        let initialRegistry = LanguageServerRegistry(userDefined: [
+            LanguageServerConfig(
+                language: "swift",
+                extensions: ["swift"],
+                command: box.path,
+                args: [],
+                env: [:],
+                rootMarkers: [],
+                enabled: true
+            )
+        ])
+        let mgr = WorkspaceLSPManager(
+            registry: initialRegistry,
+            makeAvailability: {
+                LanguageServerAvailability(
+                    environment: [:],
+                    xcrunFind: { _ in nil },
+                    additionalPathDirectories: [],
+                    gatekeeperAssessor: { _ in box.blocked ? .rejected : .allowed },
+                    gatekeeperRemediator: { _ in await box.remediate() }
+                )
+            }
+        )
+
+        async let opened: LSPClient? = mgr.openDocument(worktreeRoot: root, fileURL: fileURL, languageId: "swift", text: "")
+        await box.waitUntilRemediationIsParked()
+        mgr.updateRegistry(LanguageServerRegistry(userDefined: [
+            LanguageServerConfig(
+                language: "swift",
+                extensions: ["swift"],
+                command: "/usr/bin/false",
+                args: [],
+                env: [:],
+                rootMarkers: [],
+                enabled: true
+            )
+        ]))
+        await mgr.closeDocument(worktreeRoot: root, fileURL: fileURL, languageId: "swift")
+        box.blocked = false
+        box.remediation?.resume(returning: .allowed)
+        box.remediation = nil
+        _ = await opened
+
+        #expect(mgr.documentStatus(forFile: fileURL, worktreeRoot: root) == .none)
+    }
 }

--- a/docs/superpowers/plans/2026-06-12-kotlin-lsp-gatekeeper.md
+++ b/docs/superpowers/plans/2026-06-12-kotlin-lsp-gatekeeper.md
@@ -1,0 +1,489 @@
+# Kotlin LSP Gatekeeper Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Opening Kotlin files should not trigger macOS' "`intellij-server` Not Opened" dialog when `kotlin-lsp` is installed and the helper can be un-quarantined.
+
+**Architecture:** Add helper executable metadata to language server configs, use it in availability checks, and auto-remediate quarantined primary/helper executables before launch. Existing blocked nudge UI remains the fallback when automatic remediation cannot clear quarantine.
+
+**Tech Stack:** Swift 5.9, Swift Testing, SwiftUI/macOS app, existing `LanguageServerAvailability`, `GatekeeperAssessor`, and `GatekeeperRemediator`.
+
+---
+
+## File Structure
+
+- Modify `Alas/Sources/Code/LSP/LanguageServerRegistry.swift`: add `gatekeeperHelpers` to `LanguageServerConfig`, update built-ins, and preserve Codable compatibility.
+- Modify `Alas/Sources/Code/LSP/Install/LanguageServerConfigMasonPrefill.swift`: ensure Mason/manual normalization preserves an empty helper list.
+- Modify `Alas/Sources/Code/LSP/LanguageServerAvailability.swift`: resolve/check helper commands and add async automatic remediation.
+- Modify `Alas/Sources/Code/LSP/WorkspaceLSPManager.swift`: call the new async availability path before spawning.
+- Modify `AlasTests/Code/LSP/LanguageServerRegistryTests.swift`: cover Kotlin helper metadata and legacy JSON decoding.
+- Modify `AlasTests/AppConfigCodeInstallTests.swift`: update `LanguageServerConfig` literals only when the compiler requires explicit helper arguments.
+- Modify `AlasTests/Code/LSP/LanguageServerAvailabilityTests.swift`: cover helper resolution, missing helpers, blocked helpers, and automatic remediation.
+- Modify any compile-failing test/config literals by adding `gatekeeperHelpers: []`.
+
+## Task 1: Config Model And Kotlin Metadata
+
+**Files:**
+- Modify: `Alas/Sources/Code/LSP/LanguageServerRegistry.swift`
+- Modify: `Alas/Sources/Code/LSP/Install/LanguageServerConfigMasonPrefill.swift`
+- Test: `AlasTests/Code/LSP/LanguageServerRegistryTests.swift`
+
+- [ ] **Step 1: Write failing tests for helper metadata and legacy decode**
+
+Add these tests to `LanguageServerRegistryTests`:
+
+```swift
+@Test("Kotlin built-in preflights intellij-server helper")
+func kotlinGatekeeperHelper() {
+    let entry = LanguageServerRegistry.builtIns.first(where: { $0.language == "kotlin" })
+    #expect(entry?.command == "kotlin-lsp")
+    #expect(entry?.args == ["--stdio"])
+    #expect(entry?.gatekeeperHelpers == ["intellij-server"])
+}
+
+@Test("LanguageServerConfig decodes legacy JSON without gatekeeper helpers")
+func legacyConfigDecodeDefaultsGatekeeperHelpers() throws {
+    let json = """
+    {
+      "language": "kotlin",
+      "extensions": ["kt", "kts"],
+      "command": "kotlin-lsp",
+      "args": ["--stdio"],
+      "env": {},
+      "rootMarkers": [".git"],
+      "enabled": true
+    }
+    """
+
+    let decoded = try JSONDecoder().decode(LanguageServerConfig.self, from: Data(json.utf8))
+
+    #expect(decoded.language == "kotlin")
+    #expect(decoded.gatekeeperHelpers == [])
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -only-testing:AlasTests/LanguageServerRegistryTests test`
+
+Expected: FAIL because `LanguageServerConfig` has no `gatekeeperHelpers` member.
+
+- [ ] **Step 3: Implement Codable-compatible helper metadata**
+
+Update `LanguageServerConfig` in `LanguageServerRegistry.swift` to include:
+
+```swift
+var gatekeeperHelpers: [String]
+```
+
+Add a custom `init` and decoder default:
+
+```swift
+init(
+    language: String,
+    extensions: [String],
+    command: String,
+    args: [String],
+    env: [String: String],
+    rootMarkers: [String],
+    gatekeeperHelpers: [String] = [],
+    enabled: Bool
+) {
+    self.language = language
+    self.extensions = extensions
+    self.command = command
+    self.args = args
+    self.env = env
+    self.rootMarkers = rootMarkers
+    self.gatekeeperHelpers = gatekeeperHelpers
+    self.enabled = enabled
+}
+
+private enum CodingKeys: String, CodingKey {
+    case language, extensions, command, args, env, rootMarkers, gatekeeperHelpers, enabled
+}
+
+init(from decoder: Decoder) throws {
+    let container = try decoder.container(keyedBy: CodingKeys.self)
+    language = try container.decode(String.self, forKey: .language)
+    extensions = try container.decode([String].self, forKey: .extensions)
+    command = try container.decode(String.self, forKey: .command)
+    args = try container.decode([String].self, forKey: .args)
+    env = try container.decode([String: String].self, forKey: .env)
+    rootMarkers = try container.decode([String].self, forKey: .rootMarkers)
+    gatekeeperHelpers = try container.decodeIfPresent([String].self, forKey: .gatekeeperHelpers) ?? []
+    enabled = try container.decode(Bool.self, forKey: .enabled)
+}
+```
+
+Update Kotlin's built-in entry:
+
+```swift
+rootMarkers: [
+    "build.gradle.kts", "build.gradle",
+    "settings.gradle.kts", "settings.gradle",
+    "pom.xml", ".git"
+],
+gatekeeperHelpers: ["intellij-server"],
+enabled: true
+```
+
+Update `LanguageServerConfig.prefilled(from:)` and `normalizedForSettingsSave()` if construction requires explicit helper preservation. Mason-prefilled configs should use the default empty list.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -only-testing:AlasTests/LanguageServerRegistryTests test`
+
+Expected: PASS for `LanguageServerRegistryTests`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Alas/Sources/Code/LSP/LanguageServerRegistry.swift Alas/Sources/Code/LSP/Install/LanguageServerConfigMasonPrefill.swift AlasTests/Code/LSP/LanguageServerRegistryTests.swift
+git commit -m "feat(lsp): record gatekeeper helper commands"
+```
+
+## Task 2: Helper Availability Checks
+
+**Files:**
+- Modify: `Alas/Sources/Code/LSP/LanguageServerAvailability.swift`
+- Test: `AlasTests/Code/LSP/LanguageServerAvailabilityTests.swift`
+
+- [ ] **Step 1: Write failing tests for helper resolution behavior**
+
+Add these tests to `LanguageServerAvailabilityTests`:
+
+```swift
+@Test("available primary command checks configured gatekeeper helper")
+func helperGatekeeperRejected() throws {
+    let dir = try temporaryDirectory()
+    defer { try? FileManager.default.removeItem(at: dir) }
+    let server = try executable(named: "kotlin-lsp", in: dir)
+    let helper = try executable(named: "intellij-server", in: dir)
+    var assessed: [String] = []
+
+    let entry = config(language: "kotlin", command: "kotlin-lsp", gatekeeperHelpers: ["intellij-server"])
+    let availability = LanguageServerAvailability(
+        environment: ["PATH": dir.path],
+        xcrunFind: { _ in nil },
+        additionalPathDirectories: [],
+        gatekeeperAssessor: { path in
+            assessed.append(path)
+            return path == helper.resolvingSymlinksInPath().path ? .rejected : .allowed
+        }
+    )
+
+    let status = availability.status(for: entry)
+
+    guard case .blockedByGatekeeper(let realPath) = status else {
+        Issue.record("Expected helper block, got \(status)")
+        return
+    }
+    #expect(realPath == helper.resolvingSymlinksInPath().path)
+    #expect(assessed == [server.resolvingSymlinksInPath().path, helper.resolvingSymlinksInPath().path])
+}
+
+@Test("missing gatekeeper helper does not make server unavailable")
+func missingHelperDoesNotBlockAvailability() throws {
+    let dir = try temporaryDirectory()
+    defer { try? FileManager.default.removeItem(at: dir) }
+    _ = try executable(named: "kotlin-lsp", in: dir)
+    var assessed: [String] = []
+
+    let entry = config(language: "kotlin", command: "kotlin-lsp", gatekeeperHelpers: ["intellij-server"])
+    let availability = LanguageServerAvailability(
+        environment: ["PATH": dir.path],
+        xcrunFind: { _ in nil },
+        additionalPathDirectories: [],
+        gatekeeperAssessor: { path in
+            assessed.append(path)
+            return .allowed
+        }
+    )
+
+    #expect(availability.status(for: entry) == .available)
+    #expect(assessed.count == 1)
+}
+```
+
+Update the test helper signature:
+
+```swift
+private func config(
+    language: String = "test",
+    command: String,
+    args: [String] = [],
+    env: [String: String] = [:],
+    gatekeeperHelpers: [String] = [],
+    enabled: Bool = true
+) -> LanguageServerConfig {
+    LanguageServerConfig(
+        language: language,
+        extensions: [language],
+        command: command,
+        args: args,
+        env: env,
+        rootMarkers: [],
+        gatekeeperHelpers: gatekeeperHelpers,
+        enabled: enabled
+    )
+}
+
+private func executable(named name: String, in dir: URL) throws -> URL {
+    let url = dir.appendingPathComponent(name)
+    #expect(FileManager.default.createFile(atPath: url.path, contents: Data()))
+    try FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: url.path)
+    return url
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -only-testing:AlasTests/LanguageServerAvailabilityTests test`
+
+Expected: FAIL because `LanguageServerAvailability.status(for:)` does not inspect helper commands yet.
+
+- [ ] **Step 3: Implement helper checks in synchronous status**
+
+In `LanguageServerAvailability.status(for:)`, after the primary command resolves and is allowed, iterate over `entry.gatekeeperHelpers`.
+
+Add a private helper:
+
+```swift
+private func gatekeeperStatus(forResolvedPath resolved: String) -> Status {
+    let realPath = (resolved as NSString).resolvingSymlinksInPath
+    switch gatekeeperAssessor(realPath) {
+    case .rejected:
+        return .blockedByGatekeeper(realPath: realPath)
+    case .allowed, .unknown:
+        return .available
+    }
+}
+```
+
+Update `status(for:)` shape:
+
+```swift
+func status(for entry: LanguageServerConfig) -> Status {
+    guard entry.enabled else { return .disabled }
+    guard let resolved = resolvedCommand(for: entry) else { return .notInstalled }
+    let primary = gatekeeperStatus(forResolvedPath: resolved)
+    guard primary == .available else { return primary }
+
+    for helper in entry.gatekeeperHelpers {
+        guard let helperPath = executableNamed(helper, env: entry.env) else { continue }
+        let helperStatus = gatekeeperStatus(forResolvedPath: helperPath)
+        guard helperStatus == .available else { return helperStatus }
+    }
+
+    return .available
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -only-testing:AlasTests/LanguageServerAvailabilityTests test`
+
+Expected: PASS for `LanguageServerAvailabilityTests`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Alas/Sources/Code/LSP/LanguageServerAvailability.swift AlasTests/Code/LSP/LanguageServerAvailabilityTests.swift
+git commit -m "fix(lsp): preflight gatekeeper helper commands"
+```
+
+## Task 3: Automatic Gatekeeper Remediation Before Spawn
+
+**Files:**
+- Modify: `Alas/Sources/Code/LSP/LanguageServerAvailability.swift`
+- Modify: `Alas/Sources/Code/LSP/WorkspaceLSPManager.swift`
+- Test: `AlasTests/Code/LSP/LanguageServerAvailabilityTests.swift`
+
+- [ ] **Step 1: Write failing async remediation tests**
+
+Add these tests to `LanguageServerAvailabilityTests`:
+
+```swift
+@Test("auto-remediation clears quarantined helper before reporting available")
+func autoRemediationClearsHelper() async throws {
+    let dir = try temporaryDirectory()
+    defer { try? FileManager.default.removeItem(at: dir) }
+    _ = try executable(named: "kotlin-lsp", in: dir)
+    let helper = try executable(named: "intellij-server", in: dir)
+    let helperPath = helper.resolvingSymlinksInPath().path
+    var rejectedPaths: Set<String> = [helperPath]
+    var remediated: [String] = []
+
+    let entry = config(language: "kotlin", command: "kotlin-lsp", gatekeeperHelpers: ["intellij-server"])
+    let availability = LanguageServerAvailability(
+        environment: ["PATH": dir.path],
+        xcrunFind: { _ in nil },
+        additionalPathDirectories: [],
+        gatekeeperAssessor: { path in
+            rejectedPaths.contains(path) ? .rejected : .allowed
+        },
+        gatekeeperRemediator: { path in
+            remediated.append(path)
+            rejectedPaths.remove(path)
+            return .allowed
+        }
+    )
+
+    let status = await availability.statusRemediatingGatekeeper(for: entry)
+
+    #expect(status == .available)
+    #expect(remediated == [helperPath])
+}
+
+@Test("auto-remediation failure returns blocked helper path")
+func autoRemediationFailureReturnsBlockedHelper() async throws {
+    let dir = try temporaryDirectory()
+    defer { try? FileManager.default.removeItem(at: dir) }
+    _ = try executable(named: "kotlin-lsp", in: dir)
+    let helper = try executable(named: "intellij-server", in: dir)
+    let helperPath = helper.resolvingSymlinksInPath().path
+
+    let entry = config(language: "kotlin", command: "kotlin-lsp", gatekeeperHelpers: ["intellij-server"])
+    let availability = LanguageServerAvailability(
+        environment: ["PATH": dir.path],
+        xcrunFind: { _ in nil },
+        additionalPathDirectories: [],
+        gatekeeperAssessor: { path in
+            path == helperPath ? .rejected : .allowed
+        },
+        gatekeeperRemediator: { _ in .stillBlocked }
+    )
+
+    let status = await availability.statusRemediatingGatekeeper(for: entry)
+
+    guard case .blockedByGatekeeper(let realPath) = status else {
+        Issue.record("Expected blocked helper, got \(status)")
+        return
+    }
+    #expect(realPath == helperPath)
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -only-testing:AlasTests/LanguageServerAvailabilityTests test`
+
+Expected: FAIL because the initializer has no remediator injection and `statusRemediatingGatekeeper(for:)` does not exist.
+
+- [ ] **Step 3: Implement async remediation API**
+
+In `LanguageServerAvailability`, add:
+
+```swift
+private let gatekeeperRemediator: (String) async -> GatekeeperRemediator.Outcome
+```
+
+Extend the initializer:
+
+```swift
+gatekeeperRemediator: @escaping (String) async -> GatekeeperRemediator.Outcome = {
+    await GatekeeperRemediator().remediate(realPath: $0)
+}
+```
+
+Add an async API that clears every currently visible blocked primary/helper path in one call:
+
+```swift
+func statusRemediatingGatekeeper(for entry: LanguageServerConfig) async -> Status {
+    let maxAttempts = entry.gatekeeperHelpers.count + 1
+    var lastBlockedPath: String?
+
+    for _ in 0..<maxAttempts {
+        let status = status(for: entry)
+        guard case .blockedByGatekeeper(let realPath) = status else { return status }
+        lastBlockedPath = realPath
+
+        switch await gatekeeperRemediator(realPath) {
+        case .allowed:
+            continue
+        case .stillBlocked, .failed:
+            return .blockedByGatekeeper(realPath: realPath)
+        }
+    }
+
+    if let lastBlockedPath {
+        return .blockedByGatekeeper(realPath: lastBlockedPath)
+    }
+    return status(for: entry)
+}
+```
+
+- [ ] **Step 4: Wire WorkspaceLSPManager to async remediation**
+
+In `WorkspaceLSPManager.openDocument`, replace:
+
+```swift
+switch availability.status(for: entry) {
+```
+
+with:
+
+```swift
+switch await availability.statusRemediatingGatekeeper(for: entry) {
+```
+
+Keep the existing `.blockedByGatekeeper` notification behavior unchanged.
+
+- [ ] **Step 5: Run tests to verify pass**
+
+Run: `xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -only-testing:AlasTests/LanguageServerAvailabilityTests -only-testing:AlasTests/WorkspaceLSPManagerStatusTests test`
+
+Expected: PASS for both suites.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add Alas/Sources/Code/LSP/LanguageServerAvailability.swift Alas/Sources/Code/LSP/WorkspaceLSPManager.swift AlasTests/Code/LSP/LanguageServerAvailabilityTests.swift
+git commit -m "fix(lsp): remediate gatekeeper blocks before launch"
+```
+
+## Task 4: Compile Fixes And Final Verification
+
+**Files:**
+- Modify: any `LanguageServerConfig(...)` literals that still need `gatekeeperHelpers: []`
+- Verify: generated Xcode project remains current
+
+- [ ] **Step 1: Find any remaining config literals**
+
+Run: `rg -n "LanguageServerConfig\\(" Alas/Sources AlasTests`
+
+Expected: Any direct initializer calls either rely on the default `gatekeeperHelpers: []` or explicitly preserve helper metadata.
+
+- [ ] **Step 2: Run focused LSP tests**
+
+Run: `xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -only-testing:AlasTests/LanguageServerRegistryTests -only-testing:AlasTests/LanguageServerAvailabilityTests -only-testing:AlasTests/BlockedLanguageServerNudgeResolverTests -only-testing:AlasTests/WorkspaceLSPManagerStatusTests test`
+
+Expected: PASS.
+
+- [ ] **Step 3: Run required project generation**
+
+Run: `xcodegen`
+
+Expected: completes successfully. If it changes `Alas.xcodeproj`, include that diff in the final commit.
+
+- [ ] **Step 4: Run required build**
+
+Run: `xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -quiet build`
+
+Expected: exit 0.
+
+- [ ] **Step 5: Run required test suite**
+
+Run: `xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' test`
+
+Expected: exit 0.
+
+- [ ] **Step 6: Commit final fixes when verification changed files**
+
+```bash
+git add Alas/Sources AlasTests Alas.xcodeproj project.yml
+git commit -m "test(lsp): verify kotlin gatekeeper remediation"
+```
+
+Only create this commit when Steps 1-5 produced additional file changes after Task 3.

--- a/docs/superpowers/specs/2026-06-12-kotlin-lsp-gatekeeper-design.md
+++ b/docs/superpowers/specs/2026-06-12-kotlin-lsp-gatekeeper-design.md
@@ -1,0 +1,76 @@
+# Kotlin LSP Gatekeeper Helper Remediation Design
+
+## Context
+
+Alas already has a built-in Kotlin language server configuration:
+
+- language: `kotlin`
+- extensions: `kt`, `kts`
+- command: `kotlin-lsp`
+- args: `--stdio`
+
+Before spawning a language server, Alas checks whether the configured executable is blocked by macOS Gatekeeper. The check is based on the executable's `com.apple.quarantine` extended attribute and feeds the existing blocked-language-server banner and `GatekeeperRemediator`.
+
+JetBrains' `kotlin-lsp` can spawn a helper executable named `intellij-server`. When that helper is quarantined, macOS shows a blocking "`intellij-server` Not Opened" dialog even though Alas already considered `kotlin-lsp` available. The user cannot remediate this from the current Alas prompt because the blocked executable is not the configured top-level command.
+
+## Goal
+
+Opening a Kotlin file should work out of the box when `kotlin-lsp` is installed. Alas should preflight and, when possible, automatically remove quarantine from the Kotlin helper before launching the language server.
+
+If automatic remediation fails, Alas should fall back to the existing inline blocked-language-server banner, pointing at the actual blocked helper path.
+
+## Non-Goals
+
+- Replace JetBrains `kotlin-lsp` with another Kotlin language server.
+- Add a Kotlin installer for GitHub release assets.
+- Build a generic child-process failure detector based on stderr or process exit behavior.
+- Add visible Settings UI for editing helper commands in this iteration.
+
+## Proposed Approach
+
+Extend `LanguageServerConfig` with optional helper executable metadata named `gatekeeperHelpers: [String]`.
+
+The Kotlin built-in config will keep launching `kotlin-lsp --stdio` and add `intellij-server` as a Gatekeeper helper. The helper should be resolved using the same effective PATH and per-entry environment as the primary command.
+
+`LanguageServerAvailability` will treat a language server as available only when:
+
+1. The primary command resolves and is not blocked.
+2. Every configured helper that resolves is not blocked, or can be automatically remediated.
+
+If a helper cannot be remediated, availability returns `.blockedByGatekeeper(realPath:)` for that helper path. Existing notification and banner code can then reuse the current remediation UI.
+
+## Data Flow
+
+1. `WorkspaceLSPManager.openDocument` resolves the registry entry for `kotlin`.
+2. Availability resolves `kotlin-lsp`, checks its Gatekeeper state, and auto-remediates if needed.
+3. Availability resolves `intellij-server`, checks its Gatekeeper state, and auto-remediates if needed.
+4. If both are allowed, `WorkspaceLSPManager` launches `kotlin-lsp --stdio`.
+5. If either path remains blocked, `WorkspaceLSPManager` posts `.lspBlockedByGatekeeper` with the blocked real path and does not launch.
+6. The existing blocked nudge can still offer one-click remediation and reopen Kotlin documents after success.
+
+## Compatibility
+
+Existing persisted language-server configs should decode with an empty helper list. User-defined Kotlin configs can continue to override the built-in Kotlin entry completely.
+
+The Settings Code pane does not need new controls initially. Helper metadata is a built-in/runtime concern for known server launchers, not a common user-facing configuration field.
+
+## Error Handling
+
+If a helper cannot be found, availability should not mark the server unavailable. Some launchers may embed helpers in version-specific locations or unpack them lazily. The helper preflight should only block when it resolves a concrete executable path and that path is quarantined.
+
+If quarantine removal fails or reassessment still rejects the executable, availability should return `.blockedByGatekeeper(realPath:)` for that helper. The existing banner can show the user a manual retry path.
+
+If Gatekeeper assessment errors, keep the existing fail-open behavior: return available rather than hiding a runnable server behind a false block.
+
+## Testing
+
+Add Swift Testing coverage for:
+
+- Decoding older `LanguageServerConfig` JSON without helper metadata.
+- Kotlin built-in config including `intellij-server` as a helper.
+- Availability checking helper paths after the primary command resolves.
+- Successful auto-remediation turning a quarantined helper into available status.
+- Failed auto-remediation returning `.blockedByGatekeeper` for the helper real path.
+- Missing helper command not causing `.notInstalled`.
+
+No new UI test is required because the fallback banner path already exists and remains unchanged.


### PR DESCRIPTION
## Summary

- Preflight JetBrains Kotlin LSP helper executables before spawning the server.
- Resolve helpers beside symlinked `kotlin-lsp` launcher targets, including `bin/intellij-server`.
- Recursively remove quarantine from the marked Kotlin server install root so nested native libraries such as `libfilewatcher_jni.dylib` do not trigger macOS Gatekeeper dialogs.
- Add regression coverage for launcher-relative helper lookup, package-root remediation, and open/close remediation races.

## Validation

- `xcodegen`
- `xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -quiet build`
- `xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -only-testing:AlasTests/LanguageServerAvailabilityTests -only-testing:AlasTests/GatekeeperRemediatorTests -only-testing:AlasTests/WorkspaceLSPManagerStatusTests -only-testing:AlasTests/LanguageServerRegistryTests test`

## Notes

The local full test suite previously hung in the unrelated ACP terminal routing test, so this PR relies on the focused LSP coverage plus CI for the full-suite signal.