### PR TITLE
Add LSP-aware diff review

### DIFF
--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -741,6 +741,7 @@
 		B8B0B60C8096F691F8401D31 /* TabBarView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BEC7CCBF8463A95EAAE9EBCE /* TabBarView.swift */; };
 		B8BA936481455853CFC3393F /* ANSIStream.swift in Sources */ = {isa = PBXBuildFile; fileRef = BAE3E5634CC9BA68765EA539 /* ANSIStream.swift */; };
 		B8D2EB18303D58777D79CDBA /* SearchResult.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A0FF718D68E15F539577F56 /* SearchResult.swift */; };
+		B94F61E5170AA8102AA2A022 /* DiffPaneLSP.swift in Sources */ = {isa = PBXBuildFile; fileRef = B58BD62080F250E0F0DD057F /* DiffPaneLSP.swift */; };
 		B9BEA46E818C321122713F41 /* EditorFindControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6033DBD8BF13A76978A653A3 /* EditorFindControllerTests.swift */; };
 		B9F3258E4AE2DB1E7481690A /* SubprocessRunner.swift in Sources */ = {isa = PBXBuildFile; fileRef = E06BA06E4A620EEE773E1672 /* SubprocessRunner.swift */; };
 		BACDEEE3791E66405294B328 /* ACPFirstRunConnectingPolicyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F6EDDD4D22267C26B496A6FF /* ACPFirstRunConnectingPolicyTests.swift */; };
@@ -976,6 +977,7 @@
 		F3C9321ABD5230C4FA4F7D4E /* GatekeeperRemediatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9FE7571B9A83F6BFFA6BFC6 /* GatekeeperRemediatorTests.swift */; };
 		F3E7DF34D9DDA268E40575AE /* CommitInfoTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9427B922BAFA43AF6EB21080 /* CommitInfoTests.swift */; };
 		F3EB289C9DA8B25FC26DAB58 /* MasonSnapshot.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7F42E564C149FA33CF0E9870 /* MasonSnapshot.swift */; };
+		F4796D2FCBA83BD5E71F4398 /* DiffPaneLSPTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AD920E9E496F1DC3BB894B8B /* DiffPaneLSPTests.swift */; };
 		F4B9A51A40365909B7644561 /* ShortcutsPane.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6821B71680094791995C4975 /* ShortcutsPane.swift */; };
 		F4FF07CA337DB0D0035C3C10 /* DiffPaneViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E5A257562FAB9C5932A6BD69 /* DiffPaneViewTests.swift */; };
 		F5626F154B2CF446FF3F917B /* ReviewLoopState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0299820D15A2A4C7838B2CE9 /* ReviewLoopState.swift */; };
@@ -1689,6 +1691,7 @@
 		AD29EE0AFA5232B1ED728514 /* UnionCanvasGeometryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UnionCanvasGeometryTests.swift; sourceTree = "<group>"; };
 		AD3B3FF5D7B8F892ED1972A8 /* DiffReviewSurface.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiffReviewSurface.swift; sourceTree = "<group>"; };
 		AD85FA11903B85EA889596A3 /* ACPAttachmentMimeTypeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPAttachmentMimeTypeTests.swift; sourceTree = "<group>"; };
+		AD920E9E496F1DC3BB894B8B /* DiffPaneLSPTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiffPaneLSPTests.swift; sourceTree = "<group>"; };
 		AE0A6F237480EE72CB8DBE28 /* TitlelessWindowTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TitlelessWindowTests.swift; sourceTree = "<group>"; };
 		AE35206EEBD7E3A35C3421EA /* ACPRecoveryPill.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPRecoveryPill.swift; sourceTree = "<group>"; };
 		AF2F716F911BB20B3E78C40B /* AgentDefinition.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentDefinition.swift; sourceTree = "<group>"; };
@@ -1711,6 +1714,7 @@
 		B4C486F9097A2B145D101E2C /* AlasButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlasButton.swift; sourceTree = "<group>"; };
 		B53B597B64DC2E72758FBE2A /* AgentInstaller.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentInstaller.swift; sourceTree = "<group>"; };
 		B586C7A794B846F3AD9228BD /* RemoteWeb */ = {isa = PBXFileReference; lastKnownFileType = folder; name = RemoteWeb; path = Alas/Resources/RemoteWeb; sourceTree = SOURCE_ROOT; };
+		B58BD62080F250E0F0DD057F /* DiffPaneLSP.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiffPaneLSP.swift; sourceTree = "<group>"; };
 		B58DD85A6E01972B39F2D8AD /* AgentPath.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentPath.swift; sourceTree = "<group>"; };
 		B5BEBDB5A6617C62D0F1C0D1 /* FormatOnSaveTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FormatOnSaveTests.swift; sourceTree = "<group>"; };
 		B5D2DA50E978EB0571D6A74C /* GitHubCLIProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GitHubCLIProvider.swift; sourceTree = "<group>"; };
@@ -2259,6 +2263,7 @@
 				6181842BEA798CB8606F222B /* DiffDisplayModelBuilderTests.swift */,
 				61D4F5B30CE2AA0220A3E45C /* DiffInlineHighlighterTests.swift */,
 				2BFCE07604D55558B13FC33B /* DiffOpenFileAvailabilityTests.swift */,
+				AD920E9E496F1DC3BB894B8B /* DiffPaneLSPTests.swift */,
 				E5A257562FAB9C5932A6BD69 /* DiffPaneViewTests.swift */,
 				EE26221DC8E8837FFEB87474 /* DiffParserTests.swift */,
 				A172B476A5BF7E4016431E6A /* DiffReviewModelsTests.swift */,
@@ -3000,6 +3005,7 @@
 				00F66827E8BFF9AB51D76A96 /* DiffDisplayModelBuilder.swift */,
 				5C96772DABFBCF15691FFB37 /* DiffDisplayPreferences.swift */,
 				6561C6DA70F49EDBC69BA854 /* DiffInlineHighlighter.swift */,
+				B58BD62080F250E0F0DD057F /* DiffPaneLSP.swift */,
 				52E5D3E9FAA7B6B251C3883D /* DiffPaneTextDocumentBuilder.swift */,
 				ACCA6B39E2B172FADFD9E0E6 /* DiffPaneTextDocumentView.swift */,
 				DF32A1544E13321E9E223AFF /* DiffPaneView.swift */,
@@ -4298,6 +4304,7 @@
 				3F0D7932AB67DDF711AF1B6F /* DiffDisplayPreferences.swift in Sources */,
 				6FDE6E6F5087E811451A6AD8 /* DiffInlineHighlighter.swift in Sources */,
 				5C9EB59AAA68656BD7190044 /* DiffOpenFileAvailability.swift in Sources */,
+				B94F61E5170AA8102AA2A022 /* DiffPaneLSP.swift in Sources */,
 				5C6F0DC6F76FC0B55F2F4051 /* DiffPaneTextDocumentBuilder.swift in Sources */,
 				DB40AA7EB6A31B5F232EDCA3 /* DiffPaneTextDocumentView.swift in Sources */,
 				A971C64CC3136E00C5FC158C /* DiffPaneView.swift in Sources */,
@@ -4813,6 +4820,7 @@
 				899FB89D155619CF846C6BDC /* DiffDisplayModelBuilderTests.swift in Sources */,
 				172298A09BC94456A27EFCB7 /* DiffInlineHighlighterTests.swift in Sources */,
 				9927E3934D3CAA9055EF5E44 /* DiffOpenFileAvailabilityTests.swift in Sources */,
+				F4796D2FCBA83BD5E71F4398 /* DiffPaneLSPTests.swift in Sources */,
 				F4FF07CA337DB0D0035C3C10 /* DiffPaneViewTests.swift in Sources */,
 				0CF488290CC525EA7C11A43C /* DiffParserTests.swift in Sources */,
 				59AF95D3DFDFE7736051EF4A /* DiffReviewModelsTests.swift in Sources */,

--- a/Alas/Sources/Center/CenterPaneView.swift
+++ b/Alas/Sources/Center/CenterPaneView.swift
@@ -176,6 +176,7 @@ struct CenterPaneView: View {
                             worktreePath: worktree.path,
                             relativePath: s.relativePath,
                             staged: s.staged,
+                            worktreeId: worktree.id,
                             appState: state,
                             codeFontFamily: state.config.code.fontFamily,
                             codeFontSize: CGFloat(state.config.code.fontSize),

--- a/Alas/Sources/Center/Commit/CommitDiffView.swift
+++ b/Alas/Sources/Center/Commit/CommitDiffView.swift
@@ -173,6 +173,7 @@ struct CommitDiffView: View {
                 codeFontSize: codeFontSize,
                 showsToolbar: false,
                 verticalScrollMode: .internalScroll,
+                lspContext: nil,
                 hunkActions: { hunk in
                     DiffPaneHunkActions(
                         dropFromCommit: dropHunkEnabled(file, hunk) ? { onDropHunk?(hunk) } : nil

--- a/Alas/Sources/Center/Commit/CommitTabView.swift
+++ b/Alas/Sources/Center/Commit/CommitTabView.swift
@@ -270,6 +270,32 @@ struct CommitReviewBody: View {
     var worktreePath: URL? = nil
     var appState: AppState? = nil
 
+    init(
+        session: DiffReviewLoadedSession,
+        selectedFileID: Binding<DiffReviewFileID?>,
+        railCollapsed: Binding<Bool>,
+        layoutMode: Binding<DiffLayoutMode>,
+        wrapLines: Binding<Bool>,
+        showWhitespace: Binding<Bool>,
+        codeFontFamily: String,
+        codeFontSize: CGFloat,
+        worktreeId: String? = nil,
+        worktreePath: URL? = nil,
+        appState: AppState? = nil
+    ) {
+        self.session = session
+        self._selectedFileID = selectedFileID
+        self._railCollapsed = railCollapsed
+        self._layoutMode = layoutMode
+        self._wrapLines = wrapLines
+        self._showWhitespace = showWhitespace
+        self.codeFontFamily = codeFontFamily
+        self.codeFontSize = codeFontSize
+        self.worktreeId = worktreeId
+        self.worktreePath = worktreePath
+        self.appState = appState
+    }
+
     var body: some View {
         DiffReviewSurface(
             session: session,

--- a/Alas/Sources/Center/Commit/CommitTabView.swift
+++ b/Alas/Sources/Center/Commit/CommitTabView.swift
@@ -99,7 +99,10 @@ struct CommitTabView: View {
                     wrapLines: diffPreferences.wrapLines,
                     showWhitespace: diffPreferences.showWhitespace,
                     codeFontFamily: appState.config.code.fontFamily,
-                    codeFontSize: CGFloat(appState.config.code.fontSize)
+                    codeFontSize: CGFloat(appState.config.code.fontSize),
+                    worktreeId: worktreeId,
+                    worktreePath: worktreePath,
+                    appState: appState
                 )
             } else {
                 Spinner()
@@ -263,6 +266,9 @@ struct CommitReviewBody: View {
     @Binding var showWhitespace: Bool
     let codeFontFamily: String
     let codeFontSize: CGFloat
+    var worktreeId: String? = nil
+    var worktreePath: URL? = nil
+    var appState: AppState? = nil
 
     var body: some View {
         DiffReviewSurface(
@@ -275,7 +281,10 @@ struct CommitReviewBody: View {
             codeFontFamily: codeFontFamily,
             codeFontSize: codeFontSize,
             showsSourceBadges: false,
-            showsRailDisplayControls: true
+            showsRailDisplayControls: true,
+            lspContextForFile: { file in
+                makeLSPContext(relativePath: file.summary.path)
+            }
         )
         .accessibilityIdentifier("commit-review-body")
         .background(
@@ -284,5 +293,66 @@ struct CommitReviewBody: View {
                 label: "Commit review"
             )
         )
+    }
+
+    private func makeLSPContext(relativePath: String) -> DiffPaneLSPContext? {
+        guard let worktreeId, let worktreePath, let appState else { return nil }
+        let fileURL = worktreePath.appendingPathComponent(relativePath)
+        guard FileManager.default.fileExists(atPath: fileURL.path),
+              let language = appState.lsp.language(forFileExtension: (relativePath as NSString).pathExtension)
+        else {
+            return nil
+        }
+        return DiffPaneLSPContext(
+            worktreeId: worktreeId,
+            worktreeRoot: worktreePath,
+            relativePath: relativePath,
+            language: language,
+            lsp: appState.lsp,
+            openTarget: { url, line, character in
+                openLSPTarget(
+                    url: url,
+                    worktreeId: worktreeId,
+                    worktreePath: worktreePath,
+                    appState: appState,
+                    originatingRelativePath: relativePath,
+                    language: language,
+                    line: line,
+                    character: character
+                )
+            }
+        )
+    }
+
+    private func openLSPTarget(
+        url: URL,
+        worktreeId: String,
+        worktreePath: URL,
+        appState: AppState,
+        originatingRelativePath: String,
+        language: String,
+        line: Int,
+        character: Int
+    ) {
+        let prefix = worktreePath.path + "/"
+        if url.path.hasPrefix(prefix) {
+            let relativeTarget = String(url.path.dropFirst(prefix.count))
+            appState.tabs.openEditor(
+                worktreeId: worktreeId,
+                relativePath: relativeTarget,
+                revealLine: line,
+                revealCharacter: character
+            )
+        } else {
+            appState.tabs.openExternalEditor(
+                worktreeId: worktreeId,
+                absoluteURL: url,
+                revealLine: line,
+                revealCharacter: character,
+                originatingRelativePath: originatingRelativePath,
+                originatingWorktreeRoot: worktreePath,
+                language: language
+            )
+        }
     }
 }

--- a/Alas/Sources/Center/Diff/DiffPaneLSP.swift
+++ b/Alas/Sources/Center/Diff/DiffPaneLSP.swift
@@ -30,7 +30,8 @@ enum DiffPaneLSPLineMap {
             return nil
         }
         guard let source = line.sourceLine,
-              source.anchor.side == allowedSide,
+              allowedSide == .new,
+              (source.anchor.side == .new || source.anchor.side == .paired),
               let newLine = source.anchor.newLine,
               newLine > 0
         else {

--- a/Alas/Sources/Center/Diff/DiffPaneLSP.swift
+++ b/Alas/Sources/Center/Diff/DiffPaneLSP.swift
@@ -271,7 +271,7 @@ final class DiffPaneLSPController {
                     fileURL: context.fileURL,
                     language: context.language,
                     open: { worktreeRoot, fileURL, language, text in
-                        await context.lsp.openDocument(
+                        await context.lsp.openTemporaryDocument(
                             worktreeRoot: worktreeRoot,
                             fileURL: fileURL,
                             languageId: language,
@@ -279,7 +279,7 @@ final class DiffPaneLSPController {
                         )
                     },
                     close: { worktreeRoot, fileURL, language in
-                        await context.lsp.closeDocument(
+                        await context.lsp.closeTemporaryDocument(
                             worktreeRoot: worktreeRoot,
                             fileURL: fileURL,
                             languageId: language

--- a/Alas/Sources/Center/Diff/DiffPaneLSP.swift
+++ b/Alas/Sources/Center/Diff/DiffPaneLSP.swift
@@ -134,7 +134,8 @@ final class DiffPaneLSPController {
     private let hoverWindowController = HoverWindowController()
     private var definitionPopover: NSPopover?
     private let snippetCache = DefinitionSnippetCache()
-    private var requestID: UInt64 = 0
+    private var hoverRequestID: UInt64 = 0
+    private var definitionRequestID: UInt64 = 0
     private var hoverSymbolRange: NSRange?
 
     init(textView: DiffPaneCodeTextView) {
@@ -210,8 +211,8 @@ final class DiffPaneLSPController {
             return
         }
 
-        requestID &+= 1
-        let currentRequestID = requestID
+        hoverRequestID &+= 1
+        let currentRequestID = hoverRequestID
         let contextKey = ContextKey(context)
         hoverSymbolRange = symbolRange
         hoverTask?.cancel()
@@ -222,11 +223,11 @@ final class DiffPaneLSPController {
             do {
                 result = try await client.hover(uri: context.uri, position: position)
             } catch {
-                guard self.isCurrent(currentRequestID, contextKey: contextKey) else { return }
+                guard self.isCurrentHover(currentRequestID, contextKey: contextKey) else { return }
                 self.hideHover()
                 return
             }
-            guard self.isCurrent(currentRequestID, contextKey: contextKey),
+            guard self.isCurrentHover(currentRequestID, contextKey: contextKey),
                   self.lspPosition(at: point) == position,
                   self.hoverSymbolRange == symbolRange
             else { return }
@@ -237,8 +238,8 @@ final class DiffPaneLSPController {
     private func requestDefinition(at point: NSPoint) {
         guard let context, let position = lspPosition(at: point) else { return }
 
-        requestID &+= 1
-        let currentRequestID = requestID
+        definitionRequestID &+= 1
+        let currentRequestID = definitionRequestID
         let contextKey = ContextKey(context)
         definitionPopover?.close()
         definitionTask?.cancel()
@@ -246,8 +247,9 @@ final class DiffPaneLSPController {
             guard let self else { return }
             guard let client = await self.client(for: context, expectedKey: contextKey) else { return }
             let locations = (try? await client.definition(uri: context.uri, position: position)) ?? []
-            guard self.isCurrent(currentRequestID, contextKey: contextKey),
-                  self.lspPosition(at: point) == position
+            guard self.isCurrentDefinition(currentRequestID, contextKey: contextKey),
+                  self.lspPosition(at: point) == position,
+                  self.textView?.window != nil
             else { return }
             self.handleDefinition(locations: locations, anchorPoint: point, context: context)
         }
@@ -311,6 +313,7 @@ final class DiffPaneLSPController {
         context: DiffPaneLSPContext
     ) {
         guard let textView,
+              textView.window != nil,
               let body = nonEmptyBody(result),
               let theme = textView.theme
         else {
@@ -376,7 +379,7 @@ final class DiffPaneLSPController {
         anchor point: NSPoint,
         context: DiffPaneLSPContext
     ) {
-        guard let textView else { return }
+        guard let textView, textView.window != nil else { return }
         let entries = locations.map { location -> DefinitionPickerEntry in
             let url = URL(string: location.uri)
                 ?? URL(fileURLWithPath: location.uri.removingPercentEncoding ?? location.uri)
@@ -404,11 +407,16 @@ final class DiffPaneLSPController {
         definitionPopover = popover
     }
 
-    private func isCurrent(_ requestID: UInt64, contextKey: ContextKey) -> Bool {
-        !Task.isCancelled && self.requestID == requestID && context.map(ContextKey.init) == contextKey
+    private func isCurrentHover(_ requestID: UInt64, contextKey: ContextKey) -> Bool {
+        !Task.isCancelled && hoverRequestID == requestID && context.map(ContextKey.init) == contextKey
+    }
+
+    private func isCurrentDefinition(_ requestID: UInt64, contextKey: ContextKey) -> Bool {
+        !Task.isCancelled && definitionRequestID == requestID && context.map(ContextKey.init) == contextKey
     }
 
     private func hideHover() {
+        hoverRequestID &+= 1
         hoverTask?.cancel()
         hoverTask = nil
         hoverSymbolRange = nil
@@ -423,7 +431,8 @@ final class DiffPaneLSPController {
     }
 
     private func cancelRequests() {
-        requestID &+= 1
+        hoverRequestID &+= 1
+        definitionRequestID &+= 1
         hoverTask?.cancel()
         definitionTask?.cancel()
         hoverTask = nil

--- a/Alas/Sources/Center/Diff/DiffPaneLSP.swift
+++ b/Alas/Sources/Center/Diff/DiffPaneLSP.swift
@@ -1,0 +1,44 @@
+import AppKit
+import Foundation
+
+struct DiffPaneLSPContext {
+    let worktreeId: String
+    let worktreeRoot: URL
+    let relativePath: String
+    let language: String
+    let lsp: WorkspaceLSPManager
+    let openTarget: @MainActor (URL, Int, Int) -> Void
+
+    var fileURL: URL {
+        worktreeRoot.appendingPathComponent(relativePath)
+    }
+
+    var uri: String {
+        fileURL.lspURI
+    }
+}
+
+enum DiffPaneLSPLineMap {
+    static func position(
+        at characterIndex: Int,
+        metadata: [DiffPaneTextDocumentBuilder.LineMetadata],
+        allowedSide: DiffLineSide
+    ) -> LSPPosition? {
+        guard let line = metadata.first(where: { NSLocationInRange(characterIndex, $0.range) }) else {
+            return nil
+        }
+        guard let source = line.sourceLine,
+              source.anchor.side == allowedSide,
+              let newLine = source.anchor.newLine,
+              newLine > 0
+        else {
+            return nil
+        }
+
+        let character = characterIndex - line.range.location
+        guard character >= 0, character < source.text.utf16.count else {
+            return nil
+        }
+        return LSPPosition(line: newLine - 1, character: character)
+    }
+}

--- a/Alas/Sources/Center/Diff/DiffPaneLSP.swift
+++ b/Alas/Sources/Center/Diff/DiffPaneLSP.swift
@@ -38,7 +38,11 @@ enum DiffPaneLSPLineMap {
             return nil
         }
 
-        let character = characterIndex - line.range.location
+        let sourceRange = line.sourceRange ?? line.range
+        guard NSLocationInRange(characterIndex, sourceRange) else {
+            return nil
+        }
+        let character = characterIndex - sourceRange.location
         guard character >= 0, character < source.text.utf16.count else {
             return nil
         }

--- a/Alas/Sources/Center/Diff/DiffPaneLSP.swift
+++ b/Alas/Sources/Center/Diff/DiffPaneLSP.swift
@@ -311,7 +311,7 @@ final class DiffPaneLSPController {
         let fileURL = context.fileURL
         let lineNumber = match.position.line
         let sourceText = match.sourceText
-        return await Task.detached(priority: .userInitiated) {
+        let diskMatches = await Task.detached(priority: .userInitiated) {
             guard let text = try? String(contentsOf: fileURL, encoding: .utf8) else {
                 return false
             }
@@ -321,6 +321,16 @@ final class DiffPaneLSPController {
             }
             return String(lines[lineNumber]) == sourceText
         }.value
+        guard diskMatches else { return false }
+        if let lspMatches = context.lsp.openedDocumentLineMatches(
+            forFile: fileURL,
+            worktreeRoot: context.worktreeRoot,
+            line: lineNumber,
+            text: sourceText
+        ) {
+            return lspMatches
+        }
+        return true
     }
 
     private func client(for context: DiffPaneLSPContext, expectedKey: ContextKey) async -> LSPClient? {

--- a/Alas/Sources/Center/Diff/DiffPaneLSP.swift
+++ b/Alas/Sources/Center/Diff/DiffPaneLSP.swift
@@ -1,5 +1,7 @@
 import AppKit
 import Foundation
+import Markdown
+import SwiftUI
 
 struct DiffPaneLSPContext {
     let worktreeId: String
@@ -40,5 +42,411 @@ enum DiffPaneLSPLineMap {
             return nil
         }
         return LSPPosition(line: newLine - 1, character: character)
+    }
+}
+
+@MainActor
+final class DiffPaneLSPDocumentRetain {
+    typealias Open = (_ worktreeRoot: URL, _ fileURL: URL, _ language: String, _ text: String) async -> LSPClient?
+    typealias Close = (_ worktreeRoot: URL, _ fileURL: URL, _ language: String) async -> Void
+
+    let client: LSPClient?
+
+    private let worktreeRoot: URL
+    private let fileURL: URL
+    private let language: String
+    private let closeDocument: Close
+    private var didClose = false
+
+    private init(
+        worktreeRoot: URL,
+        fileURL: URL,
+        language: String,
+        close: @escaping Close,
+        client: LSPClient?
+    ) {
+        self.worktreeRoot = worktreeRoot
+        self.fileURL = fileURL
+        self.language = language
+        self.closeDocument = close
+        self.client = client
+    }
+
+    static func open(
+        worktreeRoot: URL,
+        fileURL: URL,
+        language: String,
+        open: Open,
+        close: @escaping Close
+    ) async throws -> DiffPaneLSPDocumentRetain {
+        let text = try String(contentsOf: fileURL, encoding: .utf8)
+        let client = await open(worktreeRoot, fileURL, language, text)
+        return DiffPaneLSPDocumentRetain(
+            worktreeRoot: worktreeRoot,
+            fileURL: fileURL,
+            language: language,
+            close: close,
+            client: client
+        )
+    }
+
+    func close() async {
+        guard !didClose else { return }
+        didClose = true
+        await closeDocument(worktreeRoot, fileURL, language)
+    }
+
+    deinit {
+        guard !didClose else { return }
+        let worktreeRoot = worktreeRoot
+        let fileURL = fileURL
+        let language = language
+        let closeDocument = closeDocument
+        Task { @MainActor in
+            await closeDocument(worktreeRoot, fileURL, language)
+        }
+    }
+}
+
+@MainActor
+final class DiffPaneLSPController {
+    private struct ContextKey: Equatable {
+        let worktreeRoot: URL
+        let fileURL: URL
+        let language: String
+        let manager: ObjectIdentifier
+
+        init(_ context: DiffPaneLSPContext) {
+            self.worktreeRoot = context.worktreeRoot
+            self.fileURL = context.fileURL
+            self.language = context.language
+            self.manager = ObjectIdentifier(context.lsp)
+        }
+    }
+
+    private weak var textView: DiffPaneCodeTextView?
+    private var context: DiffPaneLSPContext?
+    private var allowedSide: DiffLineSide = .new
+    private var hoverTask: Task<Void, Never>?
+    private var definitionTask: Task<Void, Never>?
+    private var documentRetain: DiffPaneLSPDocumentRetain?
+    private let hoverWindowController = HoverWindowController()
+    private var definitionPopover: NSPopover?
+    private let snippetCache = DefinitionSnippetCache()
+    private var requestID: UInt64 = 0
+    private var hoverSymbolRange: NSRange?
+
+    init(textView: DiffPaneCodeTextView) {
+        self.textView = textView
+        textView.hoverHandler = { [weak self] point in
+            self?.requestHover(at: point)
+        }
+        textView.commandClickHandler = { [weak self] point in
+            self?.requestDefinition(at: point)
+        }
+        textView.flagsChangedHandler = { [weak self] _ in
+            self?.hideHover()
+        }
+        textView.mouseExitedHandler = { [weak self] in
+            self?.hideHover()
+        }
+    }
+
+    func update(context: DiffPaneLSPContext?, allowedSide: DiffLineSide) {
+        let oldKey = self.context.map(ContextKey.init)
+        let newKey = context.map(ContextKey.init)
+        self.context = context
+        self.allowedSide = allowedSide
+
+        if oldKey != newKey {
+            cancelRequests()
+            hideUI()
+            closeRetain()
+        }
+        if context == nil {
+            cancelRequests()
+            hideUI()
+            closeRetain()
+        }
+    }
+
+    func tearDown() {
+        cancelRequests()
+        hideUI()
+        closeRetain()
+        context = nil
+        if let textView {
+            textView.hoverHandler = nil
+            textView.commandClickHandler = nil
+            textView.flagsChangedHandler = nil
+            textView.mouseExitedHandler = nil
+        }
+    }
+
+    func lspPosition(at point: NSPoint) -> LSPPosition? {
+        guard let textView, let characterIndex = textView.characterIndex(at: point) else {
+            return nil
+        }
+        return lspPosition(forCharacterIndex: characterIndex)
+    }
+
+    func lspPosition(forCharacterIndex characterIndex: Int) -> LSPPosition? {
+        guard let textView else { return nil }
+        return DiffPaneLSPLineMap.position(
+            at: characterIndex,
+            metadata: textView.lineMetadata,
+            allowedSide: allowedSide
+        )
+    }
+
+    private func requestHover(at point: NSPoint) {
+        guard let textView,
+              let context,
+              let position = lspPosition(at: point),
+              let symbolRange = textView.symbolRange(at: point)
+        else {
+            hideHover()
+            return
+        }
+
+        requestID &+= 1
+        let currentRequestID = requestID
+        let contextKey = ContextKey(context)
+        hoverSymbolRange = symbolRange
+        hoverTask?.cancel()
+        hoverTask = Task { @MainActor [weak self] in
+            guard let self else { return }
+            guard let client = await self.client(for: context, expectedKey: contextKey) else { return }
+            let result: LSPHoverResult?
+            do {
+                result = try await client.hover(uri: context.uri, position: position)
+            } catch {
+                guard self.isCurrent(currentRequestID, contextKey: contextKey) else { return }
+                self.hideHover()
+                return
+            }
+            guard self.isCurrent(currentRequestID, contextKey: contextKey),
+                  self.lspPosition(at: point) == position,
+                  self.hoverSymbolRange == symbolRange
+            else { return }
+            self.showHover(result, symbolRange: symbolRange, fallbackPoint: point, context: context)
+        }
+    }
+
+    private func requestDefinition(at point: NSPoint) {
+        guard let context, let position = lspPosition(at: point) else { return }
+
+        requestID &+= 1
+        let currentRequestID = requestID
+        let contextKey = ContextKey(context)
+        definitionPopover?.close()
+        definitionTask?.cancel()
+        definitionTask = Task { @MainActor [weak self] in
+            guard let self else { return }
+            guard let client = await self.client(for: context, expectedKey: contextKey) else { return }
+            let locations = (try? await client.definition(uri: context.uri, position: position)) ?? []
+            guard self.isCurrent(currentRequestID, contextKey: contextKey),
+                  self.lspPosition(at: point) == position
+            else { return }
+            self.handleDefinition(locations: locations, anchorPoint: point, context: context)
+        }
+    }
+
+    private func client(for context: DiffPaneLSPContext, expectedKey: ContextKey) async -> LSPClient? {
+        guard self.context.map(ContextKey.init) == expectedKey else { return nil }
+        if let client = context.lsp.openedClient(
+            forFile: context.fileURL,
+            worktreeRoot: context.worktreeRoot,
+            language: context.language
+        ) {
+            return client
+        }
+        if documentRetain == nil {
+            do {
+                let retain = try await DiffPaneLSPDocumentRetain.open(
+                    worktreeRoot: context.worktreeRoot,
+                    fileURL: context.fileURL,
+                    language: context.language,
+                    open: { worktreeRoot, fileURL, language, text in
+                        await context.lsp.openDocument(
+                            worktreeRoot: worktreeRoot,
+                            fileURL: fileURL,
+                            languageId: language,
+                            text: text
+                        )
+                    },
+                    close: { worktreeRoot, fileURL, language in
+                        await context.lsp.closeDocument(
+                            worktreeRoot: worktreeRoot,
+                            fileURL: fileURL,
+                            languageId: language
+                        )
+                    }
+                )
+                guard self.context.map(ContextKey.init) == expectedKey else {
+                    await retain.close()
+                    return nil
+                }
+                guard retain.client != nil else {
+                    await retain.close()
+                    return nil
+                }
+                documentRetain = retain
+            } catch {
+                return nil
+            }
+        }
+        return documentRetain?.client ?? context.lsp.openedClient(
+            forFile: context.fileURL,
+            worktreeRoot: context.worktreeRoot,
+            language: context.language
+        )
+    }
+
+    private func showHover(
+        _ result: LSPHoverResult?,
+        symbolRange: NSRange,
+        fallbackPoint: NSPoint,
+        context: DiffPaneLSPContext
+    ) {
+        guard let textView,
+              let body = nonEmptyBody(result),
+              let theme = textView.theme
+        else {
+            hideHover()
+            return
+        }
+
+        let renderResult = MarkdownRenderer().render(
+            document: Document(parsing: body),
+            theme: theme,
+            monospacedFontFamily: textView.font?.familyName ?? "JetBrainsMono Nerd Font",
+            monospacedFontSize: max(1, Int((textView.font?.pointSize ?? 13).rounded())),
+            baseDirectory: context.fileURL.deletingLastPathComponent(),
+            worktreeRoot: context.worktreeRoot
+        )
+        let size = HoverFeatureTesting.computePreferredSize(for: renderResult)
+        let anchor = textView.symbolAnchorRect(for: symbolRange)
+            ?? NSRect(origin: fallbackPoint, size: .zero)
+        hoverWindowController.show(
+            result: renderResult,
+            size: size,
+            theme: theme,
+            anchor: anchor,
+            in: textView
+        )
+    }
+
+    private func nonEmptyBody(_ result: LSPHoverResult?) -> String? {
+        guard let result else { return nil }
+        let body: String
+        switch result.contents {
+        case .markupContent(_, let value):
+            body = value
+        case .plain(let value):
+            body = value
+        }
+        return body.isEmpty ? nil : body
+    }
+
+    private func handleDefinition(
+        locations: [LSPLocation],
+        anchorPoint: NSPoint,
+        context: DiffPaneLSPContext
+    ) {
+        switch locations.count {
+        case 0:
+            return
+        case 1:
+            openLocation(locations[0], context: context)
+        default:
+            presentDefinitionPicker(locations: locations, anchor: anchorPoint, context: context)
+        }
+    }
+
+    private func openLocation(_ target: LSPLocation, context: DiffPaneLSPContext) {
+        let url = URL(string: target.uri)
+            ?? URL(fileURLWithPath: target.uri.removingPercentEncoding ?? target.uri)
+        context.openTarget(url, target.range.start.line, target.range.start.character)
+    }
+
+    private func presentDefinitionPicker(
+        locations: [LSPLocation],
+        anchor point: NSPoint,
+        context: DiffPaneLSPContext
+    ) {
+        guard let textView else { return }
+        let entries = locations.map { location -> DefinitionPickerEntry in
+            let url = URL(string: location.uri)
+                ?? URL(fileURLWithPath: location.uri.removingPercentEncoding ?? location.uri)
+            let path = url.lastPathComponent.isEmpty ? url.path : url.lastPathComponent
+            return DefinitionPickerEntry(
+                displayPath: "\(path):\(location.range.start.line + 1)",
+                snippet: snippetCache.line(at: url, line: location.range.start.line)
+            )
+        }
+        let popover = NSPopover()
+        popover.behavior = .transient
+        popover.contentSize = NSSize(width: 380, height: max(60, min(320, 24 + entries.count * 36)))
+        popover.contentViewController = NSHostingController(
+            rootView: DefinitionPicker(entries: entries) { [weak self, weak popover] choice in
+                popover?.close()
+                guard let self, let choice else { return }
+                self.openLocation(locations[choice], context: context)
+            }
+        )
+        popover.show(
+            relativeTo: NSRect(origin: point, size: NSSize(width: 1, height: 1)),
+            of: textView,
+            preferredEdge: .maxY
+        )
+        definitionPopover = popover
+    }
+
+    private func isCurrent(_ requestID: UInt64, contextKey: ContextKey) -> Bool {
+        !Task.isCancelled && self.requestID == requestID && context.map(ContextKey.init) == contextKey
+    }
+
+    private func hideHover() {
+        hoverTask?.cancel()
+        hoverTask = nil
+        hoverSymbolRange = nil
+        hoverWindowController.hide()
+    }
+
+    private func hideUI() {
+        hoverWindowController.hide()
+        definitionPopover?.close()
+        definitionPopover = nil
+        hoverSymbolRange = nil
+    }
+
+    private func cancelRequests() {
+        requestID &+= 1
+        hoverTask?.cancel()
+        definitionTask?.cancel()
+        hoverTask = nil
+        definitionTask = nil
+    }
+
+    private func closeRetain() {
+        guard let retain = documentRetain else { return }
+        documentRetain = nil
+        Task { @MainActor in
+            await retain.close()
+        }
+    }
+
+    deinit {
+        hoverTask?.cancel()
+        definitionTask?.cancel()
+        let definitionPopover = definitionPopover
+        let hoverWindowController = hoverWindowController
+        let documentRetain = documentRetain
+        Task { @MainActor in
+            definitionPopover?.close()
+            hoverWindowController.hide()
+            await documentRetain?.close()
+        }
     }
 }

--- a/Alas/Sources/Center/Diff/DiffPaneLSP.swift
+++ b/Alas/Sources/Center/Diff/DiffPaneLSP.swift
@@ -21,11 +21,24 @@ struct DiffPaneLSPContext {
 }
 
 enum DiffPaneLSPLineMap {
+    struct Match: Equatable {
+        let position: LSPPosition
+        let sourceText: String
+    }
+
     static func position(
         at characterIndex: Int,
         metadata: [DiffPaneTextDocumentBuilder.LineMetadata],
         allowedSide: DiffLineSide
     ) -> LSPPosition? {
+        match(at: characterIndex, metadata: metadata, allowedSide: allowedSide)?.position
+    }
+
+    static func match(
+        at characterIndex: Int,
+        metadata: [DiffPaneTextDocumentBuilder.LineMetadata],
+        allowedSide: DiffLineSide
+    ) -> Match? {
         guard let line = metadata.first(where: { NSLocationInRange(characterIndex, $0.range) }) else {
             return nil
         }
@@ -46,7 +59,10 @@ enum DiffPaneLSPLineMap {
         guard character >= 0, character < source.text.utf16.count else {
             return nil
         }
-        return LSPPosition(line: newLine - 1, character: character)
+        return Match(
+            position: LSPPosition(line: newLine - 1, character: character),
+            sourceText: source.text
+        )
     }
 }
 
@@ -205,15 +221,26 @@ final class DiffPaneLSPController {
         )
     }
 
+    func lspMatch(forCharacterIndex characterIndex: Int) -> DiffPaneLSPLineMap.Match? {
+        guard let textView else { return nil }
+        return DiffPaneLSPLineMap.match(
+            at: characterIndex,
+            metadata: textView.lineMetadata,
+            allowedSide: allowedSide
+        )
+    }
+
     private func requestHover(at point: NSPoint) {
         guard let textView,
               let context,
-              let position = lspPosition(at: point),
+              let characterIndex = textView.characterIndex(at: point),
+              let match = lspMatch(forCharacterIndex: characterIndex),
               let symbolRange = textView.symbolRange(at: point)
         else {
             hideHover()
             return
         }
+        let position = match.position
 
         hoverRequestID &+= 1
         let currentRequestID = hoverRequestID
@@ -222,6 +249,11 @@ final class DiffPaneLSPController {
         hoverTask?.cancel()
         hoverTask = Task { @MainActor [weak self] in
             guard let self else { return }
+            guard await self.matchesCurrentSource(match, context: context) else {
+                guard self.isCurrentHover(currentRequestID, contextKey: contextKey) else { return }
+                self.hideHover()
+                return
+            }
             guard let client = await self.client(for: context, expectedKey: contextKey) else { return }
             let result: LSPHoverResult?
             do {
@@ -240,7 +272,12 @@ final class DiffPaneLSPController {
     }
 
     private func requestDefinition(at point: NSPoint) {
-        guard let context, let position = lspPosition(at: point) else { return }
+        guard let textView,
+              let context,
+              let characterIndex = textView.characterIndex(at: point),
+              let match = lspMatch(forCharacterIndex: characterIndex)
+        else { return }
+        let position = match.position
 
         definitionRequestID &+= 1
         let currentRequestID = definitionRequestID
@@ -249,6 +286,7 @@ final class DiffPaneLSPController {
         definitionTask?.cancel()
         definitionTask = Task { @MainActor [weak self] in
             guard let self else { return }
+            guard await self.matchesCurrentSource(match, context: context) else { return }
             guard let client = await self.client(for: context, expectedKey: contextKey) else { return }
             let locations = (try? await client.definition(uri: context.uri, position: position)) ?? []
             guard self.isCurrentDefinition(currentRequestID, contextKey: contextKey),
@@ -257,6 +295,32 @@ final class DiffPaneLSPController {
             else { return }
             self.handleDefinition(locations: locations, anchorPoint: point, context: context)
         }
+    }
+
+    func matchesCurrentSourceForTesting(
+        _ match: DiffPaneLSPLineMap.Match,
+        context: DiffPaneLSPContext
+    ) async -> Bool {
+        await matchesCurrentSource(match, context: context)
+    }
+
+    private func matchesCurrentSource(
+        _ match: DiffPaneLSPLineMap.Match,
+        context: DiffPaneLSPContext
+    ) async -> Bool {
+        let fileURL = context.fileURL
+        let lineNumber = match.position.line
+        let sourceText = match.sourceText
+        return await Task.detached(priority: .userInitiated) {
+            guard let text = try? String(contentsOf: fileURL, encoding: .utf8) else {
+                return false
+            }
+            let lines = text.split(separator: "\n", omittingEmptySubsequences: false)
+            guard lineNumber >= 0, lineNumber < lines.count else {
+                return false
+            }
+            return String(lines[lineNumber]) == sourceText
+        }.value
     }
 
     private func client(for context: DiffPaneLSPContext, expectedKey: ContextKey) async -> LSPClient? {

--- a/Alas/Sources/Center/Diff/DiffPaneTextDocumentBuilder.swift
+++ b/Alas/Sources/Center/Diff/DiffPaneTextDocumentBuilder.swift
@@ -7,6 +7,7 @@ struct DiffPaneTextDocumentBuilder {
         let range: NSRange
         var tone: DiffPaneLineTone? = nil
         var sourceLine: DiffDisplayLine? = nil
+        var sourceRange: NSRange? = nil
     }
 
     struct CodeDocument {
@@ -225,10 +226,12 @@ struct DiffPaneTextDocumentBuilder {
                 showWhitespace: showWhitespace,
                 theme: theme
             ))
+            let prefixLength = (prefix(for: line, emptyKind: .context, side: line.anchor.side) as NSString).length
             lines.append(LineMetadata(
                 kind: row.kind,
                 range: NSRange(location: start, length: output.length - start),
-                sourceLine: line
+                sourceLine: line,
+                sourceRange: NSRange(location: start + prefixLength, length: (line.text as NSString).length)
             ))
         }
     }
@@ -523,7 +526,8 @@ private struct ColumnAccumulator {
             kind: kind,
             range: NSRange(location: start, length: line.length),
             tone: tone,
-            sourceLine: sourceLine
+            sourceLine: sourceLine,
+            sourceRange: sourceLine.map { _ in NSRange(location: start, length: line.length) }
         ))
     }
 }

--- a/Alas/Sources/Center/Diff/DiffPaneTextDocumentBuilder.swift
+++ b/Alas/Sources/Center/Diff/DiffPaneTextDocumentBuilder.swift
@@ -6,6 +6,7 @@ struct DiffPaneTextDocumentBuilder {
         let kind: DiffDisplayRow.Kind
         let range: NSRange
         var tone: DiffPaneLineTone? = nil
+        var sourceLine: DiffDisplayLine? = nil
     }
 
     struct CodeDocument {
@@ -55,9 +56,10 @@ struct DiffPaneTextDocumentBuilder {
                 oldColumn.append(
                     collapsedCodeText(row, font: font, theme: theme),
                     kind: row.kind,
-                    tone: .collapsed
+                    tone: .collapsed,
+                    sourceLine: nil
                 )
-                newColumn.append(emptyLayoutGlyph(font: font, theme: theme), kind: row.kind, tone: .collapsed)
+                newColumn.append(emptyLayoutGlyph(font: font, theme: theme), kind: row.kind, tone: .collapsed, sourceLine: nil)
                 continue
             }
 
@@ -71,7 +73,8 @@ struct DiffPaneTextDocumentBuilder {
                     theme: theme
                 ),
                 kind: row.kind,
-                tone: tone(for: row.old, rowKind: row.kind)
+                tone: tone(for: row.old, rowKind: row.kind),
+                sourceLine: row.old
             )
             newColumn.append(
                 code(
@@ -83,7 +86,8 @@ struct DiffPaneTextDocumentBuilder {
                     theme: theme
                 ),
                 kind: row.kind,
-                tone: tone(for: row.new, rowKind: row.kind)
+                tone: tone(for: row.new, rowKind: row.kind),
+                sourceLine: row.new
             )
         }
 
@@ -113,7 +117,12 @@ struct DiffPaneTextDocumentBuilder {
         for row in rows {
             if row.kind == .collapsed {
                 gutter.append("", side: .paired)
-                codeColumn.append(collapsedCodeText(row, font: font, theme: theme), kind: row.kind, tone: .collapsed)
+                codeColumn.append(
+                    collapsedCodeText(row, font: font, theme: theme),
+                    kind: row.kind,
+                    tone: .collapsed,
+                    sourceLine: nil
+                )
                 continue
             }
 
@@ -129,7 +138,8 @@ struct DiffPaneTextDocumentBuilder {
                         theme: theme
                     ),
                     kind: row.kind,
-                    tone: tone(for: line, rowKind: row.kind)
+                    tone: tone(for: line, rowKind: row.kind),
+                    sourceLine: line
                 )
             }
         }
@@ -215,7 +225,11 @@ struct DiffPaneTextDocumentBuilder {
                 showWhitespace: showWhitespace,
                 theme: theme
             ))
-            lines.append(LineMetadata(kind: row.kind, range: NSRange(location: start, length: output.length - start)))
+            lines.append(LineMetadata(
+                kind: row.kind,
+                range: NSRange(location: start, length: output.length - start),
+                sourceLine: line
+            ))
         }
     }
 
@@ -497,7 +511,8 @@ private struct ColumnAccumulator {
     mutating func append(
         _ line: NSAttributedString,
         kind: DiffDisplayRow.Kind,
-        tone: DiffPaneLineTone? = nil
+        tone: DiffPaneLineTone? = nil,
+        sourceLine: DiffDisplayLine? = nil
     ) {
         if output.length > 0 {
             output.append(NSAttributedString(string: "\n", attributes: newlineAttributes))
@@ -507,7 +522,8 @@ private struct ColumnAccumulator {
         metadata.append(DiffPaneTextDocumentBuilder.LineMetadata(
             kind: kind,
             range: NSRange(location: start, length: line.length),
-            tone: tone
+            tone: tone,
+            sourceLine: sourceLine
         ))
     }
 }

--- a/Alas/Sources/Center/Diff/DiffPaneTextDocumentView.swift
+++ b/Alas/Sources/Center/Diff/DiffPaneTextDocumentView.swift
@@ -537,6 +537,7 @@ final class DiffPaneCodeTextView: NSTextView {
     }
 
     private var ownedTextStorage: NSTextStorage?
+    private var customTrackingArea: NSTrackingArea?
 
     var lineTones: [DiffPaneLineTone] = [] {
         didSet { needsDisplay = true }
@@ -599,15 +600,20 @@ final class DiffPaneCodeTextView: NSTextView {
 
     override func updateTrackingAreas() {
         super.updateTrackingAreas()
-        for area in trackingAreas {
-            removeTrackingArea(area)
+        if let customTrackingArea {
+            if trackingAreas.contains(where: { $0 === customTrackingArea }) {
+                removeTrackingArea(customTrackingArea)
+            }
+            self.customTrackingArea = nil
         }
-        addTrackingArea(NSTrackingArea(
+        let trackingArea = NSTrackingArea(
             rect: bounds,
             options: [.mouseMoved, .mouseEnteredAndExited, .activeInActiveApp, .inVisibleRect],
             owner: self,
             userInfo: nil
-        ))
+        )
+        customTrackingArea = trackingArea
+        addTrackingArea(trackingArea)
     }
 
     func diffRowRects() -> [NSRect] {
@@ -642,13 +648,32 @@ final class DiffPaneCodeTextView: NSTextView {
 
     func characterIndex(at point: NSPoint) -> Int? {
         guard let layoutManager, let textContainer, let storage = textStorage else { return nil }
+        let nsString = storage.string as NSString
+        guard nsString.length > 0 else { return nil }
+        layoutManager.ensureLayout(for: textContainer)
+        let origin = textContainerOrigin
         let containerPoint = NSPoint(
-            x: point.x - textContainerInset.width,
-            y: point.y - textContainerInset.height
+            x: point.x - origin.x,
+            y: point.y - origin.y
         )
+        let glyphCount = layoutManager.numberOfGlyphs
+        guard glyphCount > 0 else { return nil }
         let glyphIndex = layoutManager.glyphIndex(for: containerPoint, in: textContainer)
+        guard glyphIndex < glyphCount else { return nil }
+
+        let lineFragmentRect = layoutManager.lineFragmentRect(forGlyphAt: glyphIndex, effectiveRange: nil)
+        let lineUsedRect = layoutManager.lineFragmentUsedRect(forGlyphAt: glyphIndex, effectiveRange: nil)
+        let tolerance: CGFloat = 0.5
+        guard containerPoint.y >= lineFragmentRect.minY - tolerance,
+              containerPoint.y <= lineFragmentRect.maxY + tolerance,
+              containerPoint.x >= lineUsedRect.minX - tolerance,
+              containerPoint.x <= lineUsedRect.maxX + tolerance
+        else {
+            return nil
+        }
+
         let charIndex = layoutManager.characterIndexForGlyph(at: glyphIndex)
-        return charIndex < (storage.string as NSString).length ? charIndex : nil
+        return charIndex < nsString.length ? charIndex : nil
     }
 
     func symbolRange(at point: NSPoint) -> NSRange? {
@@ -658,10 +683,32 @@ final class DiffPaneCodeTextView: NSTextView {
     }
 
     func symbolAnchorRect(for range: NSRange) -> NSRect? {
-        guard range.length > 0, let layoutManager, let textContainer else { return nil }
-        let glyph = layoutManager.glyphIndexForCharacter(at: range.location)
+        guard range.length > 0,
+              range.location != NSNotFound,
+              let layoutManager,
+              let textContainer,
+              let storage = textStorage
+        else {
+            return nil
+        }
+        let textLength = (storage.string as NSString).length
+        guard range.location >= 0,
+              range.location < textLength,
+              range.length <= textLength - range.location
+        else {
+            return nil
+        }
+        layoutManager.ensureLayout(for: textContainer)
+        let glyphRange = layoutManager.glyphRange(forCharacterRange: range, actualCharacterRange: nil)
+        guard glyphRange.location != NSNotFound,
+              glyphRange.length > 0,
+              glyphRange.location < layoutManager.numberOfGlyphs
+        else {
+            return nil
+        }
+        let glyph = glyphRange.location
         let rect = layoutManager.boundingRect(forGlyphRange: NSRange(location: glyph, length: 1), in: textContainer)
-        return rect.offsetBy(dx: textContainerInset.width, dy: textContainerInset.height)
+        return rect.offsetBy(dx: textContainerOrigin.x, dy: textContainerOrigin.y)
     }
 
     private func drawLineBackgrounds(in dirtyRect: NSRect) {

--- a/Alas/Sources/Center/Diff/DiffPaneTextDocumentView.swift
+++ b/Alas/Sources/Center/Diff/DiffPaneTextDocumentView.swift
@@ -108,14 +108,18 @@ final class DiffPaneTextDocumentContainerView: NSView {
                 lineLabels: lineLabels(from: result.oldGutter),
                 wraps: wrapLines,
                 font: font,
-                theme: theme
+                theme: theme,
+                lspContext: nil,
+                allowedLSPSide: .old
             )
             newPane.update(
                 document: result.newCode,
                 lineLabels: lineLabels(from: result.newGutter),
                 wraps: wrapLines,
                 font: font,
-                theme: theme
+                theme: theme,
+                lspContext: nil,
+                allowedLSPSide: .new
             )
             measuredHeight = max(oldPane.documentHeight, newPane.documentHeight)
         case .stacked:
@@ -132,7 +136,9 @@ final class DiffPaneTextDocumentContainerView: NSView {
                 lineLabels: lineLabels(from: result.gutter),
                 wraps: wrapLines,
                 font: font,
-                theme: theme
+                theme: theme,
+                lspContext: nil,
+                allowedLSPSide: .new
             )
             measuredHeight = stackedPane.documentHeight
         }
@@ -294,7 +300,9 @@ final class DiffPaneTextScrollView: NSScrollView {
         lineLabels: [String],
         wraps: Bool,
         font: NSFont,
-        theme: Theme
+        theme: Theme,
+        lspContext: DiffPaneLSPContext?,
+        allowedLSPSide: DiffLineSide
     ) {
         self.lineLabels = lineLabels
         self.rowKinds = document.lines.map(\.kind)
@@ -314,8 +322,11 @@ final class DiffPaneTextScrollView: NSScrollView {
 
         textView.textStorage?.setAttributedString(document.attributedString)
         textView.font = font
+        textView.lineMetadata = document.lines
         textView.lineTones = lineTones
         textView.theme = theme
+        textView.lspContext = lspContext
+        textView.allowedLSPSide = allowedLSPSide
         textView.insertionPointColor = NSColor(theme.color("fg"))
 
         if let ruler = verticalRulerView as? DiffPaneLineNumberRulerView {
@@ -525,18 +536,78 @@ final class DiffPaneCodeTextView: NSTextView {
         nil
     }
 
+    private var ownedTextStorage: NSTextStorage?
+
     var lineTones: [DiffPaneLineTone] = [] {
         didSet { needsDisplay = true }
     }
+    var lineMetadata: [DiffPaneTextDocumentBuilder.LineMetadata] = []
+    var hoverHandler: ((NSPoint) -> Void)?
+    var commandClickHandler: ((NSPoint) -> Void)?
+    var flagsChangedHandler: ((NSEvent) -> Void)?
+    var mouseExitedHandler: (() -> Void)?
+    var lspContext: DiffPaneLSPContext?
+    var allowedLSPSide: DiffLineSide = .new
     var theme: Theme? {
         didSet { needsDisplay = true }
     }
 
     override var isFlipped: Bool { true }
 
+    override init(frame frameRect: NSRect, textContainer container: NSTextContainer?) {
+        super.init(frame: frameRect, textContainer: container)
+        if textStorage == nil, let textContainer {
+            let storage = NSTextStorage()
+            let layoutManager = NSLayoutManager()
+            layoutManager.addTextContainer(textContainer)
+            storage.addLayoutManager(layoutManager)
+            ownedTextStorage = storage
+        }
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("not used")
+    }
+
     override func draw(_ dirtyRect: NSRect) {
         drawLineBackgrounds(in: dirtyRect)
         super.draw(dirtyRect)
+    }
+
+    override func mouseMoved(with event: NSEvent) {
+        super.mouseMoved(with: event)
+        hoverHandler?(convert(event.locationInWindow, from: nil))
+    }
+
+    override func mouseDown(with event: NSEvent) {
+        if event.modifierFlags.contains(.command) {
+            commandClickHandler?(convert(event.locationInWindow, from: nil))
+            return
+        }
+        super.mouseDown(with: event)
+    }
+
+    override func flagsChanged(with event: NSEvent) {
+        super.flagsChanged(with: event)
+        flagsChangedHandler?(event)
+    }
+
+    override func mouseExited(with event: NSEvent) {
+        super.mouseExited(with: event)
+        mouseExitedHandler?()
+    }
+
+    override func updateTrackingAreas() {
+        super.updateTrackingAreas()
+        for area in trackingAreas {
+            removeTrackingArea(area)
+        }
+        addTrackingArea(NSTrackingArea(
+            rect: bounds,
+            options: [.mouseMoved, .mouseEnteredAndExited, .activeInActiveApp, .inVisibleRect],
+            owner: self,
+            userInfo: nil
+        ))
     }
 
     func diffRowRects() -> [NSRect] {
@@ -567,6 +638,30 @@ final class DiffPaneCodeTextView: NSTextView {
                 origin: origin
             )
         }
+    }
+
+    func characterIndex(at point: NSPoint) -> Int? {
+        guard let layoutManager, let textContainer, let storage = textStorage else { return nil }
+        let containerPoint = NSPoint(
+            x: point.x - textContainerInset.width,
+            y: point.y - textContainerInset.height
+        )
+        let glyphIndex = layoutManager.glyphIndex(for: containerPoint, in: textContainer)
+        let charIndex = layoutManager.characterIndexForGlyph(at: glyphIndex)
+        return charIndex < (storage.string as NSString).length ? charIndex : nil
+    }
+
+    func symbolRange(at point: NSPoint) -> NSRange? {
+        guard let index = characterIndex(at: point) else { return nil }
+        let range = (string as NSString).rangeOfWord(at: index)
+        return range.length == 0 ? nil : range
+    }
+
+    func symbolAnchorRect(for range: NSRange) -> NSRect? {
+        guard range.length > 0, let layoutManager, let textContainer else { return nil }
+        let glyph = layoutManager.glyphIndexForCharacter(at: range.location)
+        let rect = layoutManager.boundingRect(forGlyphRange: NSRange(location: glyph, length: 1), in: textContainer)
+        return rect.offsetBy(dx: textContainerInset.width, dy: textContainerInset.height)
     }
 
     private func drawLineBackgrounds(in dirtyRect: NSRect) {

--- a/Alas/Sources/Center/Diff/DiffPaneTextDocumentView.swift
+++ b/Alas/Sources/Center/Diff/DiffPaneTextDocumentView.swift
@@ -11,6 +11,7 @@ struct DiffPaneTextDocumentView: NSViewRepresentable {
     let codeFontFamily: String
     let codeFontSize: CGFloat
     let theme: Theme
+    let lspContext: DiffPaneLSPContext?
 
     func makeNSView(context: Context) -> DiffPaneTextDocumentContainerView {
         DiffPaneTextDocumentContainerView()
@@ -25,7 +26,8 @@ struct DiffPaneTextDocumentView: NSViewRepresentable {
             showWhitespace: showWhitespace,
             fileExtension: fileExtension,
             font: CenterTypography.resolveCodeFont(family: codeFontFamily, size: codeFontSize),
-            theme: theme
+            theme: theme,
+            lspContext: lspContext
         )
     }
 }
@@ -69,7 +71,8 @@ final class DiffPaneTextDocumentContainerView: NSView {
         showWhitespace: Bool,
         fileExtension: String,
         font: NSFont,
-        theme: Theme
+        theme: Theme,
+        lspContext: DiffPaneLSPContext?
     ) {
         let signature = UpdateSignature(
             group: group,
@@ -80,7 +83,8 @@ final class DiffPaneTextDocumentContainerView: NSView {
             fileExtension: fileExtension,
             fontName: font.fontName,
             fontSize: font.pointSize,
-            theme: theme
+            theme: theme,
+            lspContext: lspContext.map(UpdateSignature.LSPContextSignature.init)
         )
         guard signature != lastUpdateSignature else {
             needsLayout = true
@@ -110,7 +114,7 @@ final class DiffPaneTextDocumentContainerView: NSView {
                 font: font,
                 theme: theme,
                 lspContext: nil,
-                allowedLSPSide: .old
+                allowedLSPSide: .new
             )
             newPane.update(
                 document: result.newCode,
@@ -118,7 +122,7 @@ final class DiffPaneTextDocumentContainerView: NSView {
                 wraps: wrapLines,
                 font: font,
                 theme: theme,
-                lspContext: nil,
+                lspContext: lspContext,
                 allowedLSPSide: .new
             )
             measuredHeight = max(oldPane.documentHeight, newPane.documentHeight)
@@ -137,7 +141,7 @@ final class DiffPaneTextDocumentContainerView: NSView {
                 wraps: wrapLines,
                 font: font,
                 theme: theme,
-                lspContext: nil,
+                lspContext: lspContext,
                 allowedLSPSide: .new
             )
             measuredHeight = stackedPane.documentHeight
@@ -220,6 +224,21 @@ final class DiffPaneTextDocumentContainerView: NSView {
         let fontName: String
         let fontSize: CGFloat
         let theme: Theme
+        let lspContext: LSPContextSignature?
+
+        struct LSPContextSignature: Equatable {
+            let worktreeRoot: URL
+            let relativePath: String
+            let language: String
+            let lsp: ObjectIdentifier
+
+            init(_ context: DiffPaneLSPContext) {
+                worktreeRoot = context.worktreeRoot
+                relativePath = context.relativePath
+                language = context.language
+                lsp = ObjectIdentifier(context.lsp)
+            }
+        }
     }
 }
 

--- a/Alas/Sources/Center/Diff/DiffPaneTextDocumentView.swift
+++ b/Alas/Sources/Center/Diff/DiffPaneTextDocumentView.swift
@@ -580,8 +580,8 @@ final class DiffPaneCodeTextView: NSTextView {
     }
 
     override func mouseDown(with event: NSEvent) {
-        if event.modifierFlags.contains(.command) {
-            commandClickHandler?(convert(event.locationInWindow, from: nil))
+        if event.modifierFlags.contains(.command), let commandClickHandler {
+            commandClickHandler(convert(event.locationInWindow, from: nil))
             return
         }
         super.mouseDown(with: event)

--- a/Alas/Sources/Center/Diff/DiffPaneTextDocumentView.swift
+++ b/Alas/Sources/Center/Diff/DiffPaneTextDocumentView.swift
@@ -327,6 +327,7 @@ final class DiffPaneTextScrollView: NSScrollView {
         textView.theme = theme
         textView.lspContext = lspContext
         textView.allowedLSPSide = allowedLSPSide
+        textView.updateLSPController()
         textView.insertionPointColor = NSColor(theme.color("fg"))
 
         if let ruler = verticalRulerView as? DiffPaneLineNumberRulerView {
@@ -538,6 +539,7 @@ final class DiffPaneCodeTextView: NSTextView {
 
     private var ownedTextStorage: NSTextStorage?
     private var customTrackingArea: NSTrackingArea?
+    private var lspController: DiffPaneLSPController?
 
     var lineTones: [DiffPaneLineTone] = [] {
         didSet { needsDisplay = true }
@@ -568,6 +570,13 @@ final class DiffPaneCodeTextView: NSTextView {
 
     required init?(coder: NSCoder) {
         fatalError("not used")
+    }
+
+    deinit {
+        let lspController = lspController
+        Task { @MainActor in
+            lspController?.tearDown()
+        }
     }
 
     override func draw(_ dirtyRect: NSRect) {
@@ -709,6 +718,18 @@ final class DiffPaneCodeTextView: NSTextView {
         let glyph = glyphRange.location
         let rect = layoutManager.boundingRect(forGlyphRange: NSRange(location: glyph, length: 1), in: textContainer)
         return rect.offsetBy(dx: textContainerOrigin.x, dy: textContainerOrigin.y)
+    }
+
+    func updateLSPController() {
+        guard let lspContext else {
+            lspController?.tearDown()
+            lspController = nil
+            return
+        }
+        if lspController == nil {
+            lspController = DiffPaneLSPController(textView: self)
+        }
+        lspController?.update(context: lspContext, allowedSide: allowedLSPSide)
     }
 
     private func drawLineBackgrounds(in dirtyRect: NSRect) {

--- a/Alas/Sources/Center/Diff/DiffPaneTextDocumentView.swift
+++ b/Alas/Sources/Center/Diff/DiffPaneTextDocumentView.swift
@@ -125,6 +125,7 @@ final class DiffPaneTextDocumentContainerView: NSView {
                 lspContext: lspContext,
                 allowedLSPSide: .new
             )
+            stackedPane.clearLSPContext()
             measuredHeight = max(oldPane.documentHeight, newPane.documentHeight)
         case .stacked:
             let result = DiffPaneTextDocumentBuilder.buildStacked(
@@ -144,6 +145,8 @@ final class DiffPaneTextDocumentContainerView: NSView {
                 lspContext: lspContext,
                 allowedLSPSide: .new
             )
+            oldPane.clearLSPContext()
+            newPane.clearLSPContext()
             measuredHeight = stackedPane.documentHeight
         }
 
@@ -362,6 +365,11 @@ final class DiffPaneTextScrollView: NSScrollView {
         resetHorizontalOriginToLeading()
         needsLayout = true
         invalidateIntrinsicContentSize()
+    }
+
+    func clearLSPContext() {
+        textView.lspContext = nil
+        textView.updateLSPController()
     }
 
     func diffRowRects() -> [NSRect] {

--- a/Alas/Sources/Center/Diff/DiffPaneTextDocumentView.swift
+++ b/Alas/Sources/Center/Diff/DiffPaneTextDocumentView.swift
@@ -570,6 +570,8 @@ final class DiffPaneCodeTextView: NSTextView {
     var mouseExitedHandler: (() -> Void)?
     var lspContext: DiffPaneLSPContext?
     var allowedLSPSide: DiffLineSide = .new
+    var hasLSPContextForTesting: Bool { lspContext != nil }
+    var allowedLSPSideForTesting: DiffLineSide { allowedLSPSide }
     var theme: Theme? {
         didSet { needsDisplay = true }
     }

--- a/Alas/Sources/Center/Diff/DiffPaneView.swift
+++ b/Alas/Sources/Center/Diff/DiffPaneView.swift
@@ -82,6 +82,7 @@ struct DiffPaneView: View {
     let codeFontSize: CGFloat
     var showsToolbar: Bool = true
     var verticalScrollMode: DiffPaneVerticalScrollMode = .internalScroll
+    var lspContext: DiffPaneLSPContext? = nil
     let hunkActions: (ParsedDiff.Hunk) -> DiffPaneHunkActions
 
     @Environment(\.theme) private var theme
@@ -220,7 +221,8 @@ struct DiffPaneView: View {
                 fileExtension: fileExtension,
                 codeFontFamily: codeFontFamily,
                 codeFontSize: codeFontSize,
-                theme: theme
+                theme: theme,
+                lspContext: lspContext
             )
             .fixedSize(horizontal: false, vertical: true)
         }

--- a/Alas/Sources/Center/DiffReview/DiffReviewFileSection.swift
+++ b/Alas/Sources/Center/DiffReview/DiffReviewFileSection.swift
@@ -8,6 +8,7 @@ struct DiffReviewFileSection: View {
     let codeFontFamily: String
     let codeFontSize: CGFloat
     let showsSourceBadge: Bool
+    var lspContext: DiffPaneLSPContext? = nil
 
     @Environment(\.theme) private var theme
 
@@ -97,6 +98,7 @@ struct DiffReviewFileSection: View {
                 codeFontSize: codeFontSize,
                 showsToolbar: false,
                 verticalScrollMode: .staticHeight,
+                lspContext: lspContext,
                 hunkActions: { _ in DiffPaneHunkActions() }
             )
         } else {

--- a/Alas/Sources/Center/DiffReview/DiffReviewSurface.swift
+++ b/Alas/Sources/Center/DiffReview/DiffReviewSurface.swift
@@ -11,6 +11,7 @@ struct DiffReviewSurface: View {
     let codeFontSize: CGFloat
     var showsSourceBadges: Bool = true
     var showsRailDisplayControls: Bool = false
+    var lspContextForFile: (DiffReviewFileSectionModel) -> DiffPaneLSPContext? = { _ in nil }
 
     @Environment(\.theme) private var theme
     @State private var programmaticScroll = DiffReviewProgrammaticScrollController()
@@ -82,7 +83,8 @@ struct DiffReviewSurface: View {
                             showWhitespace: $showWhitespace,
                             codeFontFamily: codeFontFamily,
                             codeFontSize: codeFontSize,
-                            showsSourceBadge: showsSourceBadges
+                            showsSourceBadge: showsSourceBadges,
+                            lspContext: lspContextForFile(file)
                         )
                         .id(file.summary.id.rawValue)
                         .background(sectionFrameReader(for: file.summary.id))

--- a/Alas/Sources/Center/DiffTabView.swift
+++ b/Alas/Sources/Center/DiffTabView.swift
@@ -17,6 +17,7 @@ struct DiffTabView: View {
     let worktreePath: URL
     let relativePath: String
     let staged: Bool
+    let worktreeId: String
     let appState: AppState
     var codeFontFamily: String = ""
     var codeFontSize: CGFloat = 13
@@ -121,6 +122,7 @@ struct DiffTabView: View {
                     showWhitespace: diffPreferences.showWhitespace,
                     codeFontFamily: codeFontFamily,
                     codeFontSize: codeFontSize,
+                    lspContext: lspContext,
                     hunkActions: { hunk in
                         let actions = stagedHunkActions(hunk: hunk)
                         return DiffPaneHunkActions(stage: actions.stage, discard: actions.discard)
@@ -162,6 +164,58 @@ struct DiffTabView: View {
 
     private var diffPreferences: DiffPreferenceBindings {
         DiffPreferenceBindings(appState: appState)
+    }
+
+    private var lspContext: DiffPaneLSPContext? {
+        guard !isFileDeleted else { return nil }
+        guard let language = appState.lsp.language(forFileExtension: (relativePath as NSString).pathExtension) else {
+            return nil
+        }
+        return DiffPaneLSPContext(
+            worktreeId: worktreeId,
+            worktreeRoot: worktreePath,
+            relativePath: relativePath,
+            language: language,
+            lsp: appState.lsp,
+            openTarget: { url, line, character in
+                openLSPTarget(
+                    url: url,
+                    originatingRelativePath: relativePath,
+                    language: language,
+                    line: line,
+                    character: character
+                )
+            }
+        )
+    }
+
+    private func openLSPTarget(
+        url: URL,
+        originatingRelativePath: String,
+        language: String,
+        line: Int,
+        character: Int
+    ) {
+        let prefix = worktreePath.path + "/"
+        if url.path.hasPrefix(prefix) {
+            let relativeTarget = String(url.path.dropFirst(prefix.count))
+            appState.tabs.openEditor(
+                worktreeId: worktreeId,
+                relativePath: relativeTarget,
+                revealLine: line,
+                revealCharacter: character
+            )
+        } else {
+            appState.tabs.openExternalEditor(
+                worktreeId: worktreeId,
+                absoluteURL: url,
+                revealLine: line,
+                revealCharacter: character,
+                originatingRelativePath: originatingRelativePath,
+                originatingWorktreeRoot: worktreePath,
+                language: language
+            )
+        }
     }
 
     private var header: some View {

--- a/Alas/Sources/Center/DiffTabView.swift
+++ b/Alas/Sources/Center/DiffTabView.swift
@@ -167,7 +167,13 @@ struct DiffTabView: View {
     }
 
     private var lspContext: DiffPaneLSPContext? {
-        guard !isFileDeleted else { return nil }
+        let fileURL = worktreePath.appendingPathComponent(relativePath)
+        var isDirectory: ObjCBool = false
+        guard FileManager.default.fileExists(atPath: fileURL.path, isDirectory: &isDirectory),
+              !isDirectory.boolValue
+        else {
+            return nil
+        }
         guard let language = appState.lsp.language(forFileExtension: (relativePath as NSString).pathExtension) else {
             return nil
         }

--- a/Alas/Sources/Center/ReviewChanges/ReviewChangesTabView.swift
+++ b/Alas/Sources/Center/ReviewChanges/ReviewChangesTabView.swift
@@ -205,8 +205,65 @@ struct ReviewChangesTabView: View {
             showWhitespace: diffPreferences.showWhitespace,
             codeFontFamily: appState.config.code.fontFamily,
             codeFontSize: CGFloat(appState.config.code.fontSize),
-            showsSourceBadges: true
+            showsSourceBadges: true,
+            lspContextForFile: { file in
+                makeLSPContext(relativePath: file.summary.path)
+            }
         )
+    }
+
+    private func makeLSPContext(relativePath: String) -> DiffPaneLSPContext? {
+        let fileURL = worktree.path.appendingPathComponent(relativePath)
+        guard FileManager.default.fileExists(atPath: fileURL.path),
+              let language = appState.lsp.language(forFileExtension: (relativePath as NSString).pathExtension)
+        else {
+            return nil
+        }
+        return DiffPaneLSPContext(
+            worktreeId: worktree.id,
+            worktreeRoot: worktree.path,
+            relativePath: relativePath,
+            language: language,
+            lsp: appState.lsp,
+            openTarget: { url, line, character in
+                openLSPTarget(
+                    url: url,
+                    originatingRelativePath: relativePath,
+                    language: language,
+                    line: line,
+                    character: character
+                )
+            }
+        )
+    }
+
+    private func openLSPTarget(
+        url: URL,
+        originatingRelativePath: String,
+        language: String,
+        line: Int,
+        character: Int
+    ) {
+        let prefix = worktree.path.path + "/"
+        if url.path.hasPrefix(prefix) {
+            let relativeTarget = String(url.path.dropFirst(prefix.count))
+            appState.tabs.openEditor(
+                worktreeId: worktree.id,
+                relativePath: relativeTarget,
+                revealLine: line,
+                revealCharacter: character
+            )
+        } else {
+            appState.tabs.openExternalEditor(
+                worktreeId: worktree.id,
+                absoluteURL: url,
+                revealLine: line,
+                revealCharacter: character,
+                originatingRelativePath: originatingRelativePath,
+                originatingWorktreeRoot: worktree.path,
+                language: language
+            )
+        }
     }
 
     private func stateView(title: String, detail: String?, color: Color) -> some View {

--- a/Alas/Sources/Center/ReviewRequest/DraftReviewRequestTabView.swift
+++ b/Alas/Sources/Center/ReviewRequest/DraftReviewRequestTabView.swift
@@ -826,6 +826,7 @@ struct DraftReviewRequestDiffPreviewView: View {
                 codeFontSize: codeFontSize,
                 showsToolbar: false,
                 verticalScrollMode: .internalScroll,
+                lspContext: nil,
                 hunkActions: { _ in DiffPaneHunkActions() }
             )
         }

--- a/Alas/Sources/Code/LSP/Features/EditorOverlayPanel.swift
+++ b/Alas/Sources/Code/LSP/Features/EditorOverlayPanel.swift
@@ -30,7 +30,7 @@ final class EditorOverlayPanel {
         contentViewController: NSViewController,
         size: NSSize,
         anchor: NSRect,
-        in textView: CodeTextView
+        in textView: NSTextView
     ) {
         let panel = ensurePanel(size: size)
         panel.contentViewController = contentViewController
@@ -80,7 +80,7 @@ final class EditorOverlayPanel {
         panel.level = parentWindow.level
     }
 
-    func frame(for size: NSSize, anchor: NSRect, in textView: CodeTextView) -> NSRect {
+    func frame(for size: NSSize, anchor: NSRect, in textView: NSTextView) -> NSRect {
         guard let window = textView.window else {
             return NSRect(origin: .zero, size: size)
         }
@@ -112,7 +112,7 @@ final class EditorOverlayPanel {
 
 enum EditorOverlayPanelTesting {
     @MainActor
-    static func frame(for panel: EditorOverlayPanel, size: NSSize, anchor: NSRect, in textView: CodeTextView) -> NSRect {
+    static func frame(for panel: EditorOverlayPanel, size: NSSize, anchor: NSRect, in textView: NSTextView) -> NSRect {
         panel.frame(for: size, anchor: anchor, in: textView)
     }
 }

--- a/Alas/Sources/Code/LSP/Features/HoverWindowController.swift
+++ b/Alas/Sources/Code/LSP/Features/HoverWindowController.swift
@@ -15,7 +15,7 @@ final class HoverWindowController {
         size: NSSize,
         theme: Theme,
         anchor: NSRect,
-        in textView: CodeTextView
+        in textView: NSTextView
     ) {
         let root = HoverPopupView(result: result, theme: theme)
         if let hostingController {

--- a/Alas/Sources/Code/LSP/WorkspaceLSPManager.swift
+++ b/Alas/Sources/Code/LSP/WorkspaceLSPManager.swift
@@ -357,7 +357,14 @@ final class WorkspaceLSPManager: DocumentFormatter {
         // newer content wins even if an earlier opener's continuation
         // resumes first.
         if !h.openedURIs.contains(uri) {
-            let openText = h.pendingOpenText[uri] ?? text
+            let openText: String
+            if normalRefCount(forURI: uri, in: h) == 0,
+               (h.temporaryRefsByURI[uri] ?? 0) > 0,
+               let temporaryText = h.temporaryTextsByURI[uri] {
+                openText = temporaryText
+            } else {
+                openText = h.pendingOpenText[uri] ?? text
+            }
             if var holder = holders[key] {
                 holder.openedURIs.insert(uri)
                 holder.versions[uri] = 1
@@ -474,6 +481,9 @@ final class WorkspaceLSPManager: DocumentFormatter {
         holder.refsByURI = refs
         holder.temporaryRefsByURI = temporaryRefs
         holders[key] = holder
+        if ownership == .editor {
+            restorePendingTemporaryTextIfNeeded(key: key, holder: holder, uri: uri)
+        }
 
         // If the holder never reached `.ready` (init failed), it lingers
         // in the dict so the badge can show `.problem(.dead)` and offer
@@ -520,6 +530,30 @@ final class WorkspaceLSPManager: DocumentFormatter {
             holders.removeValue(forKey: key)
             bumpStateTick()
         }
+    }
+
+    private func restorePendingTemporaryTextIfNeeded(
+        key: Key,
+        holder: Holder,
+        uri: String
+    ) {
+        guard !holder.openedURIs.contains(uri),
+              normalRefCount(forURI: uri, in: holder) == 0,
+              (holder.temporaryRefsByURI[uri] ?? 0) > 0,
+              let temporaryText = holder.temporaryTextsByURI[uri]
+        else {
+            return
+        }
+        guard var current = holders[key],
+              current.client === holder.client,
+              !current.openedURIs.contains(uri),
+              normalRefCount(forURI: uri, in: current) == 0,
+              (current.temporaryRefsByURI[uri] ?? 0) > 0
+        else {
+            return
+        }
+        current.pendingOpenText[uri] = temporaryText
+        holders[key] = current
     }
 
     private func restoreTemporaryTextIfNeeded(

--- a/Alas/Sources/Code/LSP/WorkspaceLSPManager.swift
+++ b/Alas/Sources/Code/LSP/WorkspaceLSPManager.swift
@@ -67,6 +67,7 @@ final class WorkspaceLSPManager: DocumentFormatter {
         let ready: Task<Bool, Never>
         var refsByURI: [String: Int]
         var temporaryRefsByURI: [String: Int]
+        var temporaryTextsByURI: [String: String]
         var openedURIs: Set<String>
         var versions: [String: Int]   // last didChange version per URI
         var pendingOpenText: [String: String]  // latest text supplied to a not-yet-sent didOpen
@@ -301,6 +302,7 @@ final class WorkspaceLSPManager: DocumentFormatter {
                     ready: task,
                     refsByURI: [uri: 1],
                     temporaryRefsByURI: ownership == .temporary ? [uri: 1] : [:],
+                    temporaryTextsByURI: ownership == .temporary ? [uri: text] : [:],
                     openedURIs: [],
                     versions: [:],
                     pendingOpenText: [uri: text],
@@ -489,7 +491,12 @@ final class WorkspaceLSPManager: DocumentFormatter {
         if !initOk { return }
 
         // Other tabs still need this file open — nothing to send.
-        if (cur.refsByURI[uri] ?? 0) > 0 { return }
+        if (cur.refsByURI[uri] ?? 0) > 0 {
+            if ownership == .editor {
+                await restoreTemporaryTextIfNeeded(key: key, holder: cur, uri: uri, languageId: languageId)
+            }
+            return
+        }
 
         // File is fully closed. Send `didClose` if the matching `didOpen`
         // was actually delivered; otherwise the server has nothing to forget.
@@ -502,6 +509,7 @@ final class WorkspaceLSPManager: DocumentFormatter {
                 c.texts.removeValue(forKey: uri)
                 c.languagesByURI.removeValue(forKey: uri)
                 c.temporaryRefsByURI.removeValue(forKey: uri)
+                c.temporaryTextsByURI.removeValue(forKey: uri)
                 holders[key] = c
             }
         }
@@ -512,6 +520,43 @@ final class WorkspaceLSPManager: DocumentFormatter {
             holders.removeValue(forKey: key)
             bumpStateTick()
         }
+    }
+
+    private func restoreTemporaryTextIfNeeded(
+        key: Key,
+        holder: Holder,
+        uri: String,
+        languageId: String
+    ) async {
+        guard holder.openedURIs.contains(uri),
+              normalRefCount(forURI: uri, in: holder) == 0,
+              (holder.temporaryRefsByURI[uri] ?? 0) > 0,
+              let temporaryText = holder.temporaryTextsByURI[uri],
+              holder.texts[uri] != temporaryText
+        else {
+            return
+        }
+        guard var current = holders[key],
+              current.client === holder.client,
+              current.openedURIs.contains(uri),
+              normalRefCount(forURI: uri, in: current) == 0,
+              (current.temporaryRefsByURI[uri] ?? 0) > 0
+        else {
+            return
+        }
+
+        let nextVersion = (current.versions[uri] ?? 1) + 1
+        let previousText = current.texts[uri]
+        current.versions[uri] = nextVersion
+        current.texts[uri] = temporaryText
+        current.languagesByURI[uri] = languageId
+        holders[key] = current
+        try? await current.client.didChange(
+            uri: uri,
+            version: nextVersion,
+            text: temporaryText,
+            previousText: previousText
+        )
     }
 
     /// Fire-and-forget `textDocument/didSave`. Skipped if the document was
@@ -680,11 +725,13 @@ final class WorkspaceLSPManager: DocumentFormatter {
         // javascript / javascriptreact under one binary).
         let refsToReopen: [String: Int]
         let temporaryRefsToReopen: [String: Int]
+        let temporaryTextsToReopen: [String: String]
         let textsByURI: [String: String]
         let languagesByURI: [String: String]
         if let cur = holders[key], cur.client === existing.client {
             refsToReopen = cur.refsByURI
             temporaryRefsToReopen = cur.temporaryRefsByURI
+            temporaryTextsToReopen = cur.temporaryTextsByURI
             textsByURI = cur.texts.merging(cur.pendingOpenText) { current, _ in current }
             languagesByURI = cur.languagesByURI
             holders.removeValue(forKey: key)
@@ -706,8 +753,9 @@ final class WorkspaceLSPManager: DocumentFormatter {
             for _ in 0 ..< editorRefCount {
                 _ = await openDocument(worktreeRoot: reopenRoot, fileURL: fileURL, languageId: reopenLanguage, text: text)
             }
+            let temporaryText = temporaryTextsToReopen[uri] ?? text
             for _ in 0 ..< temporaryRefCount {
-                _ = await openTemporaryDocument(worktreeRoot: reopenRoot, fileURL: fileURL, languageId: reopenLanguage, text: text)
+                _ = await openTemporaryDocument(worktreeRoot: reopenRoot, fileURL: fileURL, languageId: reopenLanguage, text: temporaryText)
             }
         }
     }
@@ -799,21 +847,26 @@ final class WorkspaceLSPManager: DocumentFormatter {
         ownership: DocumentOwnership
     ) -> Holder {
         var pending = holder.pendingOpenText
+        var temporaryTexts = holder.temporaryTextsByURI
         if !holder.openedURIs.contains(uri) {
             switch ownership {
             case .editor:
                 pending[uri] = text
             case .temporary:
+                temporaryTexts[uri] = text
                 if normalRefCount(forURI: uri, in: holder) == 0 {
                     pending[uri] = text
                 }
             }
+        } else if ownership == .temporary {
+            temporaryTexts[uri] = text
         }
         return Holder(
             client: holder.client,
             ready: holder.ready,
             refsByURI: refs,
             temporaryRefsByURI: temporaryRefs,
+            temporaryTextsByURI: temporaryTexts,
             openedURIs: holder.openedURIs,
             versions: holder.versions,
             pendingOpenText: pending,

--- a/Alas/Sources/Code/LSP/WorkspaceLSPManager.swift
+++ b/Alas/Sources/Code/LSP/WorkspaceLSPManager.swift
@@ -721,7 +721,7 @@ final class WorkspaceLSPManager: DocumentFormatter {
         let uri = fileURL.lspURI
         guard let key = holderKey(forURI: uri, withinWorktreeRoot: worktreeRoot),
               let holder = holders[key] else { return false }
-        return holder.openedURIs.contains(uri)
+        return holder.openedURIs.contains(uri) && normalRefCount(forURI: uri, in: holder) > 0
     }
 
     /// Locates the holder currently tracking `uri` (regardless of which

--- a/Alas/Sources/Code/LSP/WorkspaceLSPManager.swift
+++ b/Alas/Sources/Code/LSP/WorkspaceLSPManager.swift
@@ -664,6 +664,27 @@ final class WorkspaceLSPManager: DocumentFormatter {
         return holder.client
     }
 
+    /// Returns `nil` when the file is not currently open on an LSP server.
+    /// Returns `false` when it is open but the served text does not contain
+    /// `text` at `line`.
+    func openedDocumentLineMatches(
+        forFile fileURL: URL,
+        worktreeRoot: URL,
+        line: Int,
+        text: String
+    ) -> Bool? {
+        let uri = fileURL.lspURI
+        guard let key = holderKey(forURI: uri, withinWorktreeRoot: worktreeRoot),
+              let holder = holders[key],
+              holder.openedURIs.contains(uri) else {
+            return nil
+        }
+        guard line >= 0, let servedText = holder.texts[uri] else { return false }
+        let lines = servedText.split(separator: "\n", omittingEmptySubsequences: false)
+        guard line < lines.count else { return false }
+        return String(lines[line]) == text
+    }
+
     /// Tear down the holder currently serving `fileURL` under `worktreeRoot`
     /// and re-open every URI it had open. Holder-scoped (not tab-scoped) so
     /// all tabs sharing the holder benefit from one restart — which matches

--- a/Alas/Sources/Code/LSP/WorkspaceLSPManager.swift
+++ b/Alas/Sources/Code/LSP/WorkspaceLSPManager.swift
@@ -41,13 +41,17 @@ final class WorkspaceLSPManager: DocumentFormatter {
     /// awaiting `initialize()` so a concurrent `closeDocument` can find it
     /// and update state in flight.
     ///
-    /// `refsByURI` tracks the user's open intent **per file** — the codex
-    /// scenario being: file A starts the server, file B opens during init
-    /// (sees existing holder, registers its URI), file A closes during
-    /// init. With aggregate ref counting the holder still has refCount=1
-    /// (B), so A's resumed open path would happily send `didOpen` for the
-    /// already-closed A. With per-URI counts, A's resume sees `refsByURI[A]`
-    /// is gone and skips `didOpen`, while B proceeds normally.
+    /// `refsByURI` tracks total open intent **per file**. Editor-owned refs
+    /// and temporary read-only refs both keep the URI open on the server,
+    /// while `temporaryRefsByURI` records the temporary subset so editor
+    /// opens can replace temporary disk text and closes only release the
+    /// ownership they actually hold. The codex scenario being: file A starts
+    /// the server, file B opens during init (sees existing holder, registers
+    /// its URI), file A closes during init. With aggregate ref counting the
+    /// holder still has refCount=1 (B), so A's resumed open path would
+    /// happily send `didOpen` for the already-closed A. With per-URI counts,
+    /// A's resume sees `refsByURI[A]` is gone and skips `didOpen`, while B
+    /// proceeds normally.
     ///
     /// `openedURIs` records URIs for which `didOpen` was actually delivered,
     /// so `closeDocument` only sends `didClose` when there's something
@@ -62,6 +66,7 @@ final class WorkspaceLSPManager: DocumentFormatter {
         let client: LSPClient
         let ready: Task<Bool, Never>
         var refsByURI: [String: Int]
+        var temporaryRefsByURI: [String: Int]
         var openedURIs: Set<String>
         var versions: [String: Int]   // last didChange version per URI
         var pendingOpenText: [String: String]  // latest text supplied to a not-yet-sent didOpen
@@ -76,6 +81,11 @@ final class WorkspaceLSPManager: DocumentFormatter {
         var lifeState: HolderLifeState
     }
 
+    private enum DocumentOwnership {
+        case editor
+        case temporary
+    }
+
     /// Coarse status of a document's serving holder. The resolver folds this
     /// into `EditorLSPStatus.loading` (.none and .loading), `.ready`, or
     /// `.problem(.dead)`.
@@ -88,6 +98,7 @@ final class WorkspaceLSPManager: DocumentFormatter {
 
     private var holders: [Key: Holder] = [:]
     private var pendingOpenRefs: [Key: [String: Int]] = [:]
+    private var pendingTemporaryOpenRefs: [Key: [String: Int]] = [:]
 
     /// Bumping counter that lets `@Observable` consumers (the status badge)
     /// re-run derivations when a holder transitions starting → ready → dead.
@@ -97,6 +108,7 @@ final class WorkspaceLSPManager: DocumentFormatter {
     private func bumpStateTick() { stateTick &+= 1 }
 
     private var registry: LanguageServerRegistry
+    private let makeClient: (_ executable: URL, _ arguments: [String], _ environment: [String: String], _ language: String, _ rootURI: String) -> LSPClient
 
     /// Cached per-language availability so the status badge doesn't re-run
     /// `LanguageServerAvailability.status(for:)` — which can spawn
@@ -109,11 +121,19 @@ final class WorkspaceLSPManager: DocumentFormatter {
 
     init(
         registry: LanguageServerRegistry,
-        makeAvailability: @escaping () -> LanguageServerAvailability = { LanguageServerAvailability() }
+        makeAvailability: @escaping () -> LanguageServerAvailability = { LanguageServerAvailability() },
+        makeClient: @escaping (_ executable: URL, _ arguments: [String], _ environment: [String: String], _ language: String, _ rootURI: String) -> LSPClient = { executable, arguments, environment, language, rootURI in
+            LSPClient(
+                transport: LSPTransport(executable: executable, arguments: arguments, environment: environment),
+                language: language,
+                rootURI: rootURI
+            )
+        }
     ) {
         self.registry = registry
         self.makeAvailability = makeAvailability
         self.cachedAvailability = makeAvailability()
+        self.makeClient = makeClient
     }
 
     func updateRegistry(_ registry: LanguageServerRegistry) {
@@ -157,10 +177,27 @@ final class WorkspaceLSPManager: DocumentFormatter {
     /// closed before init completed).
     @discardableResult
     func openDocument(worktreeRoot: URL, fileURL: URL, languageId: String, text: String) async -> LSPClient? {
+        await openDocument(worktreeRoot: worktreeRoot, fileURL: fileURL, languageId: languageId, text: text, ownership: .editor)
+    }
+
+    @discardableResult
+    func openTemporaryDocument(worktreeRoot: URL, fileURL: URL, languageId: String, text: String) async -> LSPClient? {
+        await openDocument(worktreeRoot: worktreeRoot, fileURL: fileURL, languageId: languageId, text: text, ownership: .temporary)
+    }
+
+    @discardableResult
+    private func openDocument(
+        worktreeRoot: URL,
+        fileURL: URL,
+        languageId: String,
+        text: String,
+        ownership: DocumentOwnership
+    ) async -> LSPClient? {
         guard let entry = registry.entry(forLanguage: languageId) else { return nil }
         let lspRoot = Self.resolveLSPRoot(fileURL: fileURL, worktreeRoot: worktreeRoot, markers: entry.rootMarkers)
         let key = Key(root: lspRoot.path, command: entry.command, args: entry.args, env: entry.env)
         let uri = fileURL.lspURI
+        var shouldReplaceTemporaryText = false
         // If a previous holder's server died (process exited, transport
         // closed) we'd otherwise reuse the dead client and silently fail to
         // deliver hover/diagnostics/definition until the user closed every
@@ -181,24 +218,39 @@ final class WorkspaceLSPManager: DocumentFormatter {
         if let existing = holders[key] {
             var refs = existing.refsByURI
             refs[uri, default: 0] += 1
+            var temporaryRefs = existing.temporaryRefsByURI
+            if ownership == .temporary {
+                temporaryRefs[uri, default: 0] += 1
+            } else if existing.openedURIs.contains(uri),
+                      normalRefCount(forURI: uri, in: existing) == 0,
+                      (existing.temporaryRefsByURI[uri] ?? 0) > 0 {
+                shouldReplaceTemporaryText = true
+            }
             // Record this open's text as the latest pending — if `didOpen`
             // hasn't been sent yet, whichever awaiter wakes first will read
             // this value rather than the stale `text` captured on a prior
             // call. (Codex case: tab closed and reopened with different
             // content while the server was still initializing.)
-            holders[key] = holderByUpdatingRefs(existing, uri: uri, text: text, refs: refs)
+            holders[key] = holderByUpdatingRefs(
+                existing,
+                uri: uri,
+                text: text,
+                refs: refs,
+                temporaryRefs: temporaryRefs,
+                ownership: ownership
+            )
             client = existing.client
             ready = existing.ready
             isFirstOpener = false
         } else {
-            addPendingOpenRef(key: key, uri: uri)
+            addPendingOpenRef(key: key, uri: uri, ownership: ownership)
             let availability = makeAvailability()
             switch await availability.statusRemediatingGatekeeper(for: entry) {
             case .disabled, .notInstalled:
-                _ = consumePendingOpenRef(key: key, uri: uri)
+                _ = consumePendingOpenRef(key: key, uri: uri, ownership: ownership)
                 return nil
             case .blockedByGatekeeper(let realPath):
-                _ = consumePendingOpenRef(key: key, uri: uri)
+                _ = consumePendingOpenRef(key: key, uri: uri, ownership: ownership)
                 NotificationCenter.default.post(
                     name: .lspBlockedByGatekeeper,
                     object: nil,
@@ -208,11 +260,26 @@ final class WorkspaceLSPManager: DocumentFormatter {
             case .available:
                 break
             }
-            guard consumePendingOpenRef(key: key, uri: uri) else { return nil }
+            guard consumePendingOpenRef(key: key, uri: uri, ownership: ownership) else { return nil }
             if let existing = holders[key] {
                 var refs = existing.refsByURI
                 refs[uri, default: 0] += 1
-                holders[key] = holderByUpdatingRefs(existing, uri: uri, text: text, refs: refs)
+                var temporaryRefs = existing.temporaryRefsByURI
+                if ownership == .temporary {
+                    temporaryRefs[uri, default: 0] += 1
+                } else if existing.openedURIs.contains(uri),
+                          normalRefCount(forURI: uri, in: existing) == 0,
+                          (existing.temporaryRefsByURI[uri] ?? 0) > 0 {
+                    shouldReplaceTemporaryText = true
+                }
+                holders[key] = holderByUpdatingRefs(
+                    existing,
+                    uri: uri,
+                    text: text,
+                    refs: refs,
+                    temporaryRefs: temporaryRefs,
+                    ownership: ownership
+                )
                 client = existing.client
                 ready = existing.ready
                 isFirstOpener = false
@@ -224,13 +291,23 @@ final class WorkspaceLSPManager: DocumentFormatter {
                     language: entry.language,
                     availability: availability
                 )
-                let transport = LSPTransport(executable: spawn.executable, arguments: spawn.arguments, environment: spawn.environment)
-                let newClient = LSPClient(transport: transport, language: languageId, rootURI: lspRoot.lspURI)
+                let newClient = makeClient(spawn.executable, spawn.arguments, spawn.environment, languageId, lspRoot.lspURI)
                 let task = Task<Bool, Never> {
                     do { try await newClient.initialize()
                     return true } catch { return false }
                 }
-                holders[key] = Holder(client: newClient, ready: task, refsByURI: [uri: 1], openedURIs: [], versions: [:], pendingOpenText: [uri: text], texts: [:], languagesByURI: [:], lifeState: .starting)
+                holders[key] = Holder(
+                    client: newClient,
+                    ready: task,
+                    refsByURI: [uri: 1],
+                    temporaryRefsByURI: ownership == .temporary ? [uri: 1] : [:],
+                    openedURIs: [],
+                    versions: [:],
+                    pendingOpenText: [uri: text],
+                    texts: [:],
+                    languagesByURI: [:],
+                    lifeState: .starting
+                )
                 bumpStateTick()
                 client = newClient
                 ready = task
@@ -294,6 +371,21 @@ final class WorkspaceLSPManager: DocumentFormatter {
                 version: 1,
                 text: openText
             )
+        } else if shouldReplaceTemporaryText {
+            if var holder = holders[key], holder.client === client, holder.openedURIs.contains(uri) {
+                let nextVersion = (holder.versions[uri] ?? 1) + 1
+                let previousText = holder.texts[uri]
+                holder.versions[uri] = nextVersion
+                holder.texts[uri] = text
+                holder.languagesByURI[uri] = languageId
+                holders[key] = holder
+                try? await client.didChange(
+                    uri: uri,
+                    version: nextVersion,
+                    text: text,
+                    previousText: previousText
+                )
+            }
         }
         return client
     }
@@ -331,14 +423,46 @@ final class WorkspaceLSPManager: DocumentFormatter {
     }
 
     func closeDocument(worktreeRoot: URL, fileURL: URL, languageId: String) async {
+        await closeDocument(worktreeRoot: worktreeRoot, fileURL: fileURL, languageId: languageId, ownership: .editor)
+    }
+
+    func closeTemporaryDocument(worktreeRoot: URL, fileURL: URL, languageId: String) async {
+        await closeDocument(worktreeRoot: worktreeRoot, fileURL: fileURL, languageId: languageId, ownership: .temporary)
+    }
+
+    private func closeDocument(
+        worktreeRoot: URL,
+        fileURL: URL,
+        languageId: String,
+        ownership: DocumentOwnership
+    ) async {
         let uri = fileURL.lspURI
         // See `didChange` — find the holder by URI so registry edits made
         // after the open don't strand the original server.
         guard let key = holderKey(forURI: uri), var holder = holders[key], (holder.refsByURI[uri] ?? 0) > 0 else {
-            _ = consumePendingOpenRef(forURI: uri, withinWorktreeRoot: worktreeRoot)
+            _ = consumePendingOpenRef(forURI: uri, withinWorktreeRoot: worktreeRoot, ownership: ownership)
             return
         }
         var refs = holder.refsByURI
+        var temporaryRefs = holder.temporaryRefsByURI
+        switch ownership {
+        case .editor:
+            guard normalRefCount(forURI: uri, in: holder) > 0 else {
+                _ = consumePendingOpenRef(forURI: uri, withinWorktreeRoot: worktreeRoot, ownership: ownership)
+                return
+            }
+        case .temporary:
+            guard (temporaryRefs[uri] ?? 0) > 0 else {
+                _ = consumePendingOpenRef(forURI: uri, withinWorktreeRoot: worktreeRoot, ownership: ownership)
+                return
+            }
+            let newTemporaryRef = (temporaryRefs[uri] ?? 0) - 1
+            if newTemporaryRef <= 0 {
+                temporaryRefs.removeValue(forKey: uri)
+            } else {
+                temporaryRefs[uri] = newTemporaryRef
+            }
+        }
         let newRef = (refs[uri] ?? 0) - 1
         if newRef <= 0 {
             refs.removeValue(forKey: uri)
@@ -346,6 +470,7 @@ final class WorkspaceLSPManager: DocumentFormatter {
             refs[uri] = newRef
         }
         holder.refsByURI = refs
+        holder.temporaryRefsByURI = temporaryRefs
         holders[key] = holder
 
         // If the holder never reached `.ready` (init failed), it lingers
@@ -376,6 +501,7 @@ final class WorkspaceLSPManager: DocumentFormatter {
                 c.pendingOpenText.removeValue(forKey: uri)
                 c.texts.removeValue(forKey: uri)
                 c.languagesByURI.removeValue(forKey: uri)
+                c.temporaryRefsByURI.removeValue(forKey: uri)
                 holders[key] = c
             }
         }
@@ -553,10 +679,12 @@ final class WorkspaceLSPManager: DocumentFormatter {
         // (typescript-language-server serves typescript / typescriptreact /
         // javascript / javascriptreact under one binary).
         let refsToReopen: [String: Int]
+        let temporaryRefsToReopen: [String: Int]
         let textsByURI: [String: String]
         let languagesByURI: [String: String]
         if let cur = holders[key], cur.client === existing.client {
             refsToReopen = cur.refsByURI
+            temporaryRefsToReopen = cur.temporaryRefsByURI
             textsByURI = cur.texts.merging(cur.pendingOpenText) { current, _ in current }
             languagesByURI = cur.languagesByURI
             holders.removeValue(forKey: key)
@@ -573,8 +701,13 @@ final class WorkspaceLSPManager: DocumentFormatter {
             guard refCount > 0, let fileURL = URL(string: uri) else { continue }
             let text = textsByURI[uri] ?? ""
             let reopenLanguage = languagesByURI[uri] ?? language
-            for _ in 0 ..< refCount {
+            let temporaryRefCount = temporaryRefsToReopen[uri] ?? 0
+            let editorRefCount = max(refCount - temporaryRefCount, 0)
+            for _ in 0 ..< editorRefCount {
                 _ = await openDocument(worktreeRoot: reopenRoot, fileURL: fileURL, languageId: reopenLanguage, text: text)
+            }
+            for _ in 0 ..< temporaryRefCount {
+                _ = await openTemporaryDocument(worktreeRoot: reopenRoot, fileURL: fileURL, languageId: reopenLanguage, text: text)
             }
         }
     }
@@ -602,45 +735,85 @@ final class WorkspaceLSPManager: DocumentFormatter {
         return nil
     }
 
-    private func addPendingOpenRef(key: Key, uri: String) {
-        var refs = pendingOpenRefs[key] ?? [:]
-        refs[uri, default: 0] += 1
-        pendingOpenRefs[key] = refs
+    private func pendingOpenRefs(for ownership: DocumentOwnership) -> [Key: [String: Int]] {
+        switch ownership {
+        case .editor: return pendingOpenRefs
+        case .temporary: return pendingTemporaryOpenRefs
+        }
     }
 
-    private func consumePendingOpenRef(key: Key, uri: String) -> Bool {
-        guard var refs = pendingOpenRefs[key], let count = refs[uri], count > 0 else { return false }
+    private func setPendingOpenRefs(_ refs: [Key: [String: Int]], for ownership: DocumentOwnership) {
+        switch ownership {
+        case .editor: pendingOpenRefs = refs
+        case .temporary: pendingTemporaryOpenRefs = refs
+        }
+    }
+
+    private func addPendingOpenRef(key: Key, uri: String, ownership: DocumentOwnership) {
+        var pending = pendingOpenRefs(for: ownership)
+        var refs = pending[key] ?? [:]
+        refs[uri, default: 0] += 1
+        pending[key] = refs
+        setPendingOpenRefs(pending, for: ownership)
+    }
+
+    private func consumePendingOpenRef(key: Key, uri: String, ownership: DocumentOwnership) -> Bool {
+        var pending = pendingOpenRefs(for: ownership)
+        guard var refs = pending[key], let count = refs[uri], count > 0 else { return false }
         if count == 1 {
             refs.removeValue(forKey: uri)
         } else {
             refs[uri] = count - 1
         }
         if refs.isEmpty {
-            pendingOpenRefs.removeValue(forKey: key)
+            pending.removeValue(forKey: key)
         } else {
-            pendingOpenRefs[key] = refs
+            pending[key] = refs
         }
+        setPendingOpenRefs(pending, for: ownership)
         return true
     }
 
-    private func consumePendingOpenRef(forURI uri: String, withinWorktreeRoot worktreeRoot: URL) -> Bool {
+    private func consumePendingOpenRef(
+        forURI uri: String,
+        withinWorktreeRoot worktreeRoot: URL,
+        ownership: DocumentOwnership
+    ) -> Bool {
         let rootPath = worktreeRoot.path
         let rootPrefix = rootPath.hasSuffix("/") ? rootPath : rootPath + "/"
-        for key in pendingOpenRefs.keys where pendingOpenRefs[key]?[uri] != nil {
+        let pending = pendingOpenRefs(for: ownership)
+        for key in pending.keys where pending[key]?[uri] != nil {
             if key.root == rootPath || key.root.hasPrefix(rootPrefix) {
-                return consumePendingOpenRef(key: key, uri: uri)
+                return consumePendingOpenRef(key: key, uri: uri, ownership: ownership)
             }
         }
         return false
     }
 
-    private func holderByUpdatingRefs(_ holder: Holder, uri: String, text: String, refs: [String: Int]) -> Holder {
+    private func holderByUpdatingRefs(
+        _ holder: Holder,
+        uri: String,
+        text: String,
+        refs: [String: Int],
+        temporaryRefs: [String: Int],
+        ownership: DocumentOwnership
+    ) -> Holder {
         var pending = holder.pendingOpenText
-        if !holder.openedURIs.contains(uri) { pending[uri] = text }
+        if !holder.openedURIs.contains(uri) {
+            switch ownership {
+            case .editor:
+                pending[uri] = text
+            case .temporary:
+                if normalRefCount(forURI: uri, in: holder) == 0 {
+                    pending[uri] = text
+                }
+            }
+        }
         return Holder(
             client: holder.client,
             ready: holder.ready,
             refsByURI: refs,
+            temporaryRefsByURI: temporaryRefs,
             openedURIs: holder.openedURIs,
             versions: holder.versions,
             pendingOpenText: pending,
@@ -648,6 +821,10 @@ final class WorkspaceLSPManager: DocumentFormatter {
             languagesByURI: holder.languagesByURI,
             lifeState: holder.lifeState
         )
+    }
+
+    private func normalRefCount(forURI uri: String, in holder: Holder) -> Int {
+        max((holder.refsByURI[uri] ?? 0) - (holder.temporaryRefsByURI[uri] ?? 0), 0)
     }
 
     /// Worktree-scoped variant: returns a holder for `uri` only if its

--- a/AlasTests/DiffPaneLSPTests.swift
+++ b/AlasTests/DiffPaneLSPTests.swift
@@ -61,6 +61,53 @@ struct DiffPaneLSPLineMapTests {
         #expect(result == LSPPosition(line: 39, character: 12))
     }
 
+    @MainActor
+    @Test func mapsPrefixedStackedRowsFromSourceCodeColumn() throws {
+        let diff = ParsedDiff(hunks: [
+            ParsedDiff.Hunk(
+                header: "@@ -1,1 +1,2 @@",
+                oldStart: 1,
+                newStart: 1,
+                lines: [
+                    .init(kind: .context, text: "let context = value", oldNumber: 1, newNumber: 1),
+                    .init(kind: .add, text: "let inserted = value", oldNumber: nil, newNumber: 2),
+                ]
+            ),
+        ])
+        let model = DiffDisplayModelBuilder.build(diff: diff, filePath: "Sources/App.swift")
+        let group = try #require(model.groups.first)
+        let document = DiffPaneTextDocumentBuilder.build(
+            group: group,
+            expandedCollapsedRowIDs: [],
+            layoutMode: .stacked,
+            fileExtension: "swift",
+            font: CenterTypography.resolveCodeFont(family: "", size: 13),
+            showWhitespace: false,
+            theme: theme()
+        )
+        let rendered = document.attributedString.string as NSString
+        let contextStart = rendered.range(of: "let context").location
+        let insertStart = rendered.range(of: "let inserted").location
+
+        #expect(contextStart != NSNotFound)
+        #expect(insertStart != NSNotFound)
+        #expect(DiffPaneLSPLineMap.position(
+            at: contextStart,
+            metadata: document.lines,
+            allowedSide: .new
+        ) == LSPPosition(line: 0, character: 0))
+        #expect(DiffPaneLSPLineMap.position(
+            at: insertStart,
+            metadata: document.lines,
+            allowedSide: .new
+        ) == LSPPosition(line: 1, character: 0))
+        #expect(DiffPaneLSPLineMap.position(
+            at: insertStart - 1,
+            metadata: document.lines,
+            allowedSide: .new
+        ) == nil)
+    }
+
     @Test func rejectsOldSideLine() {
         let line = DiffDisplayLine(
             id: "file:old:0:0",
@@ -222,5 +269,9 @@ struct DiffPaneLSPLineMapTests {
         #expect(controller.lspPosition(forCharacterIndex: 14) == nil)
 
         controller.tearDown()
+    }
+
+    private func theme() -> Theme {
+        try! ThemeStore().current
     }
 }

--- a/AlasTests/DiffPaneLSPTests.swift
+++ b/AlasTests/DiffPaneLSPTests.swift
@@ -271,6 +271,100 @@ struct DiffPaneLSPLineMapTests {
         controller.tearDown()
     }
 
+    @MainActor
+    @Test func controllerRejectsStaleSourceLineBeforeLSPRequest() async throws {
+        let root = FileManager.default.temporaryDirectory.appendingPathComponent("alas-lsp-stale-\(UUID().uuidString)")
+        let source = root.appendingPathComponent("Sources/App.swift")
+        try FileManager.default.createDirectory(at: source.deletingLastPathComponent(), withIntermediateDirectories: true)
+        try "let current = value\n".write(to: source, atomically: true, encoding: .utf8)
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let textView = DiffPaneCodeTextView(
+            frame: NSRect(x: 0, y: 0, width: 300, height: 80),
+            textContainer: NSTextContainer()
+        )
+        let renderedLine = DiffDisplayLine(
+            id: "file:new:0:0",
+            anchor: DiffLineAnchor(filePath: "Sources/App.swift", hunkIndex: 0, rowIndex: 0, side: .new, oldLine: nil, newLine: 1),
+            text: "let stale = value",
+            lineNumber: 1,
+            kind: .add,
+            inlineSpans: [],
+            noTrailingNewline: false
+        )
+        textView.lineMetadata = [
+            DiffPaneTextDocumentBuilder.LineMetadata(
+                kind: .add,
+                range: NSRange(location: 0, length: 17),
+                tone: .add,
+                sourceLine: renderedLine
+            ),
+        ]
+        let controller = DiffPaneLSPController(textView: textView)
+        controller.update(context: nil, allowedSide: .new)
+        let match = try #require(controller.lspMatch(forCharacterIndex: 4))
+        let context = DiffPaneLSPContext(
+            worktreeId: "worktree-1",
+            worktreeRoot: root,
+            relativePath: "Sources/App.swift",
+            language: "swift",
+            lsp: WorkspaceLSPManager(registry: LanguageServerRegistry(userDefined: [])),
+            openTarget: { _, _, _ in }
+        )
+
+        let isCurrent = await controller.matchesCurrentSourceForTesting(match, context: context)
+
+        #expect(!isCurrent)
+        controller.tearDown()
+    }
+
+    @MainActor
+    @Test func controllerAcceptsMatchingSourceLineBeforeLSPRequest() async throws {
+        let root = FileManager.default.temporaryDirectory.appendingPathComponent("alas-lsp-current-\(UUID().uuidString)")
+        let source = root.appendingPathComponent("Sources/App.swift")
+        try FileManager.default.createDirectory(at: source.deletingLastPathComponent(), withIntermediateDirectories: true)
+        try "let current = value\n".write(to: source, atomically: true, encoding: .utf8)
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let textView = DiffPaneCodeTextView(
+            frame: NSRect(x: 0, y: 0, width: 300, height: 80),
+            textContainer: NSTextContainer()
+        )
+        let renderedLine = DiffDisplayLine(
+            id: "file:new:0:0",
+            anchor: DiffLineAnchor(filePath: "Sources/App.swift", hunkIndex: 0, rowIndex: 0, side: .new, oldLine: nil, newLine: 1),
+            text: "let current = value",
+            lineNumber: 1,
+            kind: .add,
+            inlineSpans: [],
+            noTrailingNewline: false
+        )
+        textView.lineMetadata = [
+            DiffPaneTextDocumentBuilder.LineMetadata(
+                kind: .add,
+                range: NSRange(location: 0, length: 19),
+                tone: .add,
+                sourceLine: renderedLine
+            ),
+        ]
+        let controller = DiffPaneLSPController(textView: textView)
+        controller.update(context: nil, allowedSide: .new)
+        let match = try #require(controller.lspMatch(forCharacterIndex: 4))
+        let context = DiffPaneLSPContext(
+            worktreeId: "worktree-1",
+            worktreeRoot: root,
+            relativePath: "Sources/App.swift",
+            language: "swift",
+            lsp: WorkspaceLSPManager(registry: LanguageServerRegistry(userDefined: [])),
+            openTarget: { _, _, _ in }
+        )
+
+        let isCurrent = await controller.matchesCurrentSourceForTesting(match, context: context)
+
+        #expect(isCurrent)
+        controller.tearDown()
+    }
+
     private func theme() -> Theme {
         try! ThemeStore().current
     }

--- a/AlasTests/DiffPaneLSPTests.swift
+++ b/AlasTests/DiffPaneLSPTests.swift
@@ -33,6 +33,34 @@ struct DiffPaneLSPLineMapTests {
         #expect(result == LSPPosition(line: 41, character: 11))
     }
 
+    @Test func mapsPairedContextLineToNewFilePosition() {
+        let line = DiffDisplayLine(
+            id: "file:paired:0:0",
+            anchor: DiffLineAnchor(filePath: "Sources/App.swift", hunkIndex: 0, rowIndex: 0, side: .paired, oldLine: 40, newLine: 40),
+            text: "let context = value",
+            lineNumber: 40,
+            kind: .context,
+            inlineSpans: [],
+            noTrailingNewline: false
+        )
+        let metadata = [
+            DiffPaneTextDocumentBuilder.LineMetadata(
+                kind: .context,
+                range: NSRange(location: 0, length: 19),
+                tone: .context,
+                sourceLine: line
+            )
+        ]
+
+        let result = DiffPaneLSPLineMap.position(
+            at: 12,
+            metadata: metadata,
+            allowedSide: .new
+        )
+
+        #expect(result == LSPPosition(line: 39, character: 12))
+    }
+
     @Test func rejectsOldSideLine() {
         let line = DiffDisplayLine(
             id: "file:old:0:0",

--- a/AlasTests/DiffPaneLSPTests.swift
+++ b/AlasTests/DiffPaneLSPTests.swift
@@ -365,6 +365,99 @@ struct DiffPaneLSPLineMapTests {
         controller.tearDown()
     }
 
+    @MainActor
+    @Test func controllerRejectsSourceLineShiftedByOpenEditorBuffer() async throws {
+        let root = FileManager.default.temporaryDirectory.appendingPathComponent("alas-lsp-dirty-editor-\(UUID().uuidString)")
+        let source = root.appendingPathComponent("Sources/App.swift")
+        try FileManager.default.createDirectory(at: source.deletingLastPathComponent(), withIntermediateDirectories: true)
+        try """
+        let current = value
+        let target = value
+        """.write(to: source, atomically: true, encoding: .utf8)
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let transport = FakeTransport()
+        transport.onSend = { sent in
+            if sent.contains(#""method":"initialize""#) {
+                transport.deliverFrame(#"{"jsonrpc":"2.0","id":1,"result":{"capabilities":{"textDocumentSync":1}}}"#)
+            }
+        }
+        let manager = WorkspaceLSPManager(
+            registry: LanguageServerRegistry(userDefined: [
+                LanguageServerConfig(
+                    language: "swift",
+                    extensions: ["swift"],
+                    command: "/usr/bin/true",
+                    args: [],
+                    env: [:],
+                    rootMarkers: [],
+                    enabled: true
+                )
+            ]),
+            makeAvailability: {
+                LanguageServerAvailability(
+                    environment: [:],
+                    xcrunFind: { _ in nil },
+                    additionalPathDirectories: [],
+                    gatekeeperAssessor: { _ in .allowed }
+                )
+            },
+            makeClient: { _, _, _, language, rootURI in
+                LSPClient(transport: transport, language: language, rootURI: rootURI)
+            }
+        )
+        _ = await manager.openDocument(
+            worktreeRoot: root,
+            fileURL: source,
+            languageId: "swift",
+            text: """
+            let inserted = value
+            let current = value
+            let target = value
+            """
+        )
+
+        let textView = DiffPaneCodeTextView(
+            frame: NSRect(x: 0, y: 0, width: 300, height: 80),
+            textContainer: NSTextContainer()
+        )
+        let renderedLine = DiffDisplayLine(
+            id: "file:new:0:1",
+            anchor: DiffLineAnchor(filePath: "Sources/App.swift", hunkIndex: 0, rowIndex: 1, side: .new, oldLine: nil, newLine: 2),
+            text: "let target = value",
+            lineNumber: 2,
+            kind: .add,
+            inlineSpans: [],
+            noTrailingNewline: false
+        )
+        textView.lineMetadata = [
+            DiffPaneTextDocumentBuilder.LineMetadata(
+                kind: .add,
+                range: NSRange(location: 0, length: 18),
+                tone: .add,
+                sourceLine: renderedLine
+            ),
+        ]
+        let controller = DiffPaneLSPController(textView: textView)
+        controller.update(context: nil, allowedSide: .new)
+        let match = try #require(controller.lspMatch(forCharacterIndex: 4))
+        let context = DiffPaneLSPContext(
+            worktreeId: "worktree-1",
+            worktreeRoot: root,
+            relativePath: "Sources/App.swift",
+            language: "swift",
+            lsp: manager,
+            openTarget: { _, _, _ in }
+        )
+
+        let isCurrent = await controller.matchesCurrentSourceForTesting(match, context: context)
+
+        #expect(!isCurrent)
+        controller.tearDown()
+        await manager.closeDocument(worktreeRoot: root, fileURL: source, languageId: "swift")
+        transport.finish()
+    }
+
     private func theme() -> Theme {
         try! ThemeStore().current
     }

--- a/AlasTests/DiffPaneLSPTests.swift
+++ b/AlasTests/DiffPaneLSPTests.swift
@@ -1,3 +1,4 @@
+import AppKit
 import Foundation
 import Testing
 @testable import Alas
@@ -94,5 +95,104 @@ struct DiffPaneLSPLineMapTests {
         ]
 
         #expect(DiffPaneLSPLineMap.position(at: 5, metadata: metadata, allowedSide: .new) == nil)
+    }
+
+    @MainActor
+    @Test func retainOpenLoadsFileTextAndCallsOpenClosure() async throws {
+        let root = FileManager.default.temporaryDirectory.appendingPathComponent("alas-lsp-retain-\(UUID().uuidString)")
+        let source = root.appendingPathComponent("Sources/App.swift")
+        try FileManager.default.createDirectory(at: source.deletingLastPathComponent(), withIntermediateDirectories: true)
+        try "let value = service.fetch()\n".write(to: source, atomically: true, encoding: .utf8)
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        var captured: (URL, URL, String, String)?
+        let retain = try await DiffPaneLSPDocumentRetain.open(
+            worktreeRoot: root,
+            fileURL: source,
+            language: "swift",
+            open: { worktreeRoot, fileURL, language, text in
+                captured = (worktreeRoot, fileURL, language, text)
+                return nil
+            },
+            close: { _, _, _ in }
+        )
+        await retain.close()
+
+        let opened = try #require(captured)
+        #expect(opened.0 == root)
+        #expect(opened.1 == source)
+        #expect(opened.2 == "swift")
+        #expect(opened.3 == "let value = service.fetch()\n")
+    }
+
+    @MainActor
+    @Test func retainCloseCallsCloseClosureOnce() async throws {
+        let root = FileManager.default.temporaryDirectory.appendingPathComponent("alas-lsp-retain-\(UUID().uuidString)")
+        let source = root.appendingPathComponent("Sources/App.swift")
+        try FileManager.default.createDirectory(at: source.deletingLastPathComponent(), withIntermediateDirectories: true)
+        try "let value = 1\n".write(to: source, atomically: true, encoding: .utf8)
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        var closeCount = 0
+        let retain = try await DiffPaneLSPDocumentRetain.open(
+            worktreeRoot: root,
+            fileURL: source,
+            language: "swift",
+            open: { _, _, _, _ in nil },
+            close: { _, _, _ in closeCount += 1 }
+        )
+
+        await retain.close()
+        await retain.close()
+
+        #expect(closeCount == 1)
+    }
+
+    @MainActor
+    @Test func controllerPositionUsesTextViewMetadataAndRejectsOldSide() {
+        let textView = DiffPaneCodeTextView(
+            frame: NSRect(x: 0, y: 0, width: 300, height: 80),
+            textContainer: NSTextContainer()
+        )
+        let newLine = DiffDisplayLine(
+            id: "file:new:0:0",
+            anchor: DiffLineAnchor(filePath: "Sources/App.swift", hunkIndex: 0, rowIndex: 0, side: .new, oldLine: nil, newLine: 12),
+            text: "let value",
+            lineNumber: 12,
+            kind: .add,
+            inlineSpans: [],
+            noTrailingNewline: false
+        )
+        let oldLine = DiffDisplayLine(
+            id: "file:old:0:1",
+            anchor: DiffLineAnchor(filePath: "Sources/App.swift", hunkIndex: 0, rowIndex: 1, side: .old, oldLine: 13, newLine: nil),
+            text: "let stale",
+            lineNumber: 13,
+            kind: .delete,
+            inlineSpans: [],
+            noTrailingNewline: false
+        )
+        textView.lineMetadata = [
+            DiffPaneTextDocumentBuilder.LineMetadata(
+                kind: .add,
+                range: NSRange(location: 0, length: 9),
+                tone: .add,
+                sourceLine: newLine
+            ),
+            DiffPaneTextDocumentBuilder.LineMetadata(
+                kind: .delete,
+                range: NSRange(location: 10, length: 9),
+                tone: .delete,
+                sourceLine: oldLine
+            ),
+        ]
+
+        let controller = DiffPaneLSPController(textView: textView)
+        controller.update(context: nil, allowedSide: .new)
+
+        #expect(controller.lspPosition(forCharacterIndex: 4) == LSPPosition(line: 11, character: 4))
+        #expect(controller.lspPosition(forCharacterIndex: 14) == nil)
+
+        controller.tearDown()
     }
 }

--- a/AlasTests/DiffPaneLSPTests.swift
+++ b/AlasTests/DiffPaneLSPTests.swift
@@ -1,0 +1,98 @@
+import Foundation
+import Testing
+@testable import Alas
+
+@Suite("DiffPaneLSPLineMap")
+struct DiffPaneLSPLineMapTests {
+    @Test func mapsNewLineCharacterToRealFilePosition() {
+        let line = DiffDisplayLine(
+            id: "file:new:0:0",
+            anchor: DiffLineAnchor(filePath: "Sources/App.swift", hunkIndex: 0, rowIndex: 0, side: .new, oldLine: nil, newLine: 42),
+            text: "let value = service.fetch()",
+            lineNumber: 42,
+            kind: .add,
+            inlineSpans: [],
+            noTrailingNewline: false
+        )
+        let metadata = [
+            DiffPaneTextDocumentBuilder.LineMetadata(
+                kind: .add,
+                range: NSRange(location: 0, length: 27),
+                tone: .add,
+                sourceLine: line
+            )
+        ]
+
+        let result = DiffPaneLSPLineMap.position(
+            at: 11,
+            metadata: metadata,
+            allowedSide: .new
+        )
+
+        #expect(result == LSPPosition(line: 41, character: 11))
+    }
+
+    @Test func rejectsOldSideLine() {
+        let line = DiffDisplayLine(
+            id: "file:old:0:0",
+            anchor: DiffLineAnchor(filePath: "Sources/App.swift", hunkIndex: 0, rowIndex: 0, side: .old, oldLine: 41, newLine: nil),
+            text: "let old = value",
+            lineNumber: 41,
+            kind: .delete,
+            inlineSpans: [],
+            noTrailingNewline: false
+        )
+        let metadata = [
+            DiffPaneTextDocumentBuilder.LineMetadata(
+                kind: .delete,
+                range: NSRange(location: 0, length: 15),
+                tone: .delete,
+                sourceLine: line
+            )
+        ]
+
+        let result = DiffPaneLSPLineMap.position(
+            at: 4,
+            metadata: metadata,
+            allowedSide: .new
+        )
+
+        #expect(result == nil)
+    }
+
+    @Test func rejectsCharacterOutsideSourceText() {
+        let line = DiffDisplayLine(
+            id: "file:new:0:0",
+            anchor: DiffLineAnchor(filePath: "Sources/App.swift", hunkIndex: 0, rowIndex: 0, side: .new, oldLine: nil, newLine: 8),
+            text: "abc",
+            lineNumber: 8,
+            kind: .add,
+            inlineSpans: [],
+            noTrailingNewline: false
+        )
+        let metadata = [
+            DiffPaneTextDocumentBuilder.LineMetadata(
+                kind: .add,
+                range: NSRange(location: 10, length: 3),
+                tone: .add,
+                sourceLine: line
+            )
+        ]
+
+        #expect(DiffPaneLSPLineMap.position(at: 9, metadata: metadata, allowedSide: .new) == nil)
+        #expect(DiffPaneLSPLineMap.position(at: 13, metadata: metadata, allowedSide: .new) == nil)
+    }
+
+    @Test func rejectsCollapsedRows() {
+        let metadata = [
+            DiffPaneTextDocumentBuilder.LineMetadata(
+                kind: .collapsed,
+                range: NSRange(location: 0, length: 20),
+                tone: .collapsed,
+                sourceLine: nil
+            )
+        ]
+
+        #expect(DiffPaneLSPLineMap.position(at: 5, metadata: metadata, allowedSide: .new) == nil)
+    }
+}

--- a/AlasTests/DiffPaneViewTests.swift
+++ b/AlasTests/DiffPaneViewTests.swift
@@ -338,7 +338,9 @@ struct DiffPaneViewTests {
             lineLabels: [" 1"],
             wraps: false,
             font: font,
-            theme: theme
+            theme: theme,
+            lspContext: nil,
+            allowedLSPSide: .new
         )
         scrollView.layoutSubtreeIfNeeded()
         scrollView.contentView.scroll(to: NSPoint(x: 120, y: 0))
@@ -358,7 +360,9 @@ struct DiffPaneViewTests {
             lineLabels: [" 1"],
             wraps: false,
             font: font,
-            theme: theme
+            theme: theme,
+            lspContext: nil,
+            allowedLSPSide: .new
         )
 
         #expect(scrollView.contentView.bounds.origin.x == 0)
@@ -390,7 +394,9 @@ struct DiffPaneViewTests {
             lineLabels: ["56"],
             wraps: false,
             font: font,
-            theme: theme
+            theme: theme,
+            lspContext: nil,
+            allowedLSPSide: .new
         )
         scrollView.layoutSubtreeIfNeeded()
 
@@ -420,7 +426,9 @@ struct DiffPaneViewTests {
             lineLabels: [" 1"],
             wraps: true,
             font: font,
-            theme: theme
+            theme: theme,
+            lspContext: nil,
+            allowedLSPSide: .new
         )
         scrollView.layoutSubtreeIfNeeded()
 
@@ -450,7 +458,9 @@ struct DiffPaneViewTests {
             lineLabels: ["+56"],
             wraps: true,
             font: font,
-            theme: theme
+            theme: theme,
+            lspContext: nil,
+            allowedLSPSide: .new
         )
         scrollView.layoutSubtreeIfNeeded()
 
@@ -487,7 +497,9 @@ struct DiffPaneViewTests {
             lineLabels: ["73"],
             wraps: true,
             font: font,
-            theme: theme
+            theme: theme,
+            lspContext: nil,
+            allowedLSPSide: .new
         )
         scrollView.layoutSubtreeIfNeeded()
 
@@ -875,6 +887,54 @@ struct DiffPaneViewTests {
 
         #expect(!first.isActive(activeKey: activeKey, activeID: activeID))
         #expect(second.isActive(activeKey: activeKey, activeID: activeID))
+    }
+
+    @Test func diffPaneCodeTextViewStoresLineMetadata() throws {
+        let document = DiffPaneTextDocumentBuilder.CodeDocument(
+            attributedString: NSAttributedString(string: "let value = 1"),
+            lines: [
+                DiffPaneTextDocumentBuilder.LineMetadata(
+                    kind: .add,
+                    range: NSRange(location: 0, length: 13),
+                    tone: .add,
+                    sourceLine: DiffDisplayLine(
+                        id: "a.swift:new:0:0",
+                        anchor: DiffLineAnchor(filePath: "a.swift", hunkIndex: 0, rowIndex: 0, side: .new, oldLine: nil, newLine: 3),
+                        text: "let value = 1",
+                        lineNumber: 3,
+                        kind: .add,
+                        inlineSpans: [],
+                        noTrailingNewline: false
+                    )
+                )
+            ]
+        )
+        let scrollView = DiffPaneTextScrollView()
+        let theme = try Theme.loadBundled(id: "cool-slate")
+
+        scrollView.update(
+            document: document,
+            lineLabels: ["+3"],
+            wraps: false,
+            font: .monospacedSystemFont(ofSize: 13, weight: .regular),
+            theme: theme,
+            lspContext: nil,
+            allowedLSPSide: .new
+        )
+
+        let codeView = try #require(scrollView.documentView as? DiffPaneCodeTextView)
+        #expect(codeView.lineMetadata.count == 1)
+        #expect(codeView.lineMetadata.first?.sourceLine?.anchor.newLine == 3)
+    }
+
+    @Test func diffPaneCodeTextViewCanResolveSymbolRange() throws {
+        let textView = DiffPaneCodeTextView(frame: NSRect(x: 0, y: 0, width: 300, height: 80), textContainer: NSTextContainer())
+        textView.textStorage?.setAttributedString(NSAttributedString(string: "let value = service.fetch()"))
+        textView.layoutManager?.ensureLayout(for: textView.textContainer!)
+
+        let range = (textView.string as NSString).rangeOfWord(at: 4)
+
+        #expect(range == NSRange(location: 4, length: 5))
     }
 
     private func allSubviews(of view: NSView) -> [NSView] {

--- a/AlasTests/DiffPaneViewTests.swift
+++ b/AlasTests/DiffPaneViewTests.swift
@@ -945,6 +945,46 @@ struct DiffPaneViewTests {
         #expect(anchorRect.height > 0)
     }
 
+    @Test func diffPaneCodeTextViewHitTestingIgnoresPointsLeftOfText() throws {
+        let textView = makeDiffPaneCodeTextView(string: "let value = 1")
+        let textRect = try firstGlyphRect(in: textView, range: NSRange(location: 0, length: 3))
+        let point = NSPoint(x: textView.textContainerInset.width - 2, y: textRect.midY)
+
+        #expect(textView.characterIndex(at: point) == nil)
+    }
+
+    @Test func diffPaneCodeTextViewHitTestingIgnoresPointsRightOfLineText() throws {
+        let textView = makeDiffPaneCodeTextView(string: "short\nlet muchLongerValue = 1")
+        let firstLineRect = try firstGlyphRect(in: textView, range: NSRange(location: 0, length: 5))
+        let point = NSPoint(x: firstLineRect.maxX + 20, y: firstLineRect.midY)
+
+        #expect(textView.characterIndex(at: point) == nil)
+    }
+
+    @Test func diffPaneCodeTextViewHitTestingIgnoresPointsBelowText() throws {
+        let textView = makeDiffPaneCodeTextView(string: "let value = 1")
+        let textRect = try firstGlyphRect(in: textView, range: NSRange(location: 0, length: 3))
+        let point = NSPoint(x: textRect.midX, y: textRect.maxY + 30)
+
+        #expect(textView.characterIndex(at: point) == nil)
+    }
+
+    @Test func diffPaneCodeTextViewUpdateTrackingAreasPreservesExternalTrackingAreas() {
+        let textView = DiffPaneCodeTextView(frame: NSRect(x: 0, y: 0, width: 300, height: 80), textContainer: NSTextContainer())
+        let owner = NSObject()
+        let externalArea = NSTrackingArea(
+            rect: textView.bounds,
+            options: [.mouseMoved, .activeInActiveApp],
+            owner: owner,
+            userInfo: nil
+        )
+        textView.addTrackingArea(externalArea)
+
+        textView.updateTrackingAreas()
+
+        #expect(textView.trackingAreas.contains { $0 === externalArea })
+    }
+
     @Test func diffPaneCodeTextViewRoutesCommandClickToHandler() throws {
         let textView = DiffPaneCodeTextView(frame: NSRect(x: 0, y: 0, width: 300, height: 80), textContainer: NSTextContainer())
         let window = NSWindow(contentRect: textView.frame, styleMask: [], backing: .buffered, defer: false)
@@ -973,6 +1013,24 @@ struct DiffPaneViewTests {
         let point = try #require(clickedPoint)
         #expect(abs(point.x - anchorRect.midX) < 0.5)
         #expect(abs(point.y - anchorRect.midY) < 0.5)
+    }
+
+    private func makeDiffPaneCodeTextView(string: String) -> DiffPaneCodeTextView {
+        let textView = DiffPaneCodeTextView(frame: NSRect(x: 0, y: 0, width: 400, height: 120), textContainer: NSTextContainer())
+        textView.textContainerInset = NSSize(width: 10, height: 8)
+        let font = NSFont.monospacedSystemFont(ofSize: 13, weight: .regular)
+        textView.textStorage?.setAttributedString(NSAttributedString(string: string, attributes: [.font: font]))
+        textView.layoutManager?.ensureLayout(for: textView.textContainer!)
+        return textView
+    }
+
+    private func firstGlyphRect(in textView: DiffPaneCodeTextView, range: NSRange) throws -> NSRect {
+        let layoutManager = try #require(textView.layoutManager)
+        let textContainer = try #require(textView.textContainer)
+        layoutManager.ensureLayout(for: textContainer)
+        let glyphRange = layoutManager.glyphRange(forCharacterRange: range, actualCharacterRange: nil)
+        let rect = layoutManager.boundingRect(forGlyphRange: glyphRange, in: textContainer)
+        return rect.offsetBy(dx: textView.textContainerInset.width, dy: textView.textContainerInset.height)
     }
 
     private func allSubviews(of view: NSView) -> [NSView] {

--- a/AlasTests/DiffPaneViewTests.swift
+++ b/AlasTests/DiffPaneViewTests.swift
@@ -927,14 +927,52 @@ struct DiffPaneViewTests {
         #expect(codeView.lineMetadata.first?.sourceLine?.anchor.newLine == 3)
     }
 
-    @Test func diffPaneCodeTextViewCanResolveSymbolRange() throws {
+    @Test func diffPaneCodeTextViewResolvesSymbolsFromPoints() throws {
         let textView = DiffPaneCodeTextView(frame: NSRect(x: 0, y: 0, width: 300, height: 80), textContainer: NSTextContainer())
         textView.textStorage?.setAttributedString(NSAttributedString(string: "let value = service.fetch()"))
         textView.layoutManager?.ensureLayout(for: textView.textContainer!)
 
-        let range = (textView.string as NSString).rangeOfWord(at: 4)
+        let expectedRange = NSRange(location: 4, length: 5)
+        let anchorRect = try #require(textView.symbolAnchorRect(for: expectedRange))
+        let point = NSPoint(x: anchorRect.midX, y: anchorRect.midY)
 
-        #expect(range == NSRange(location: 4, length: 5))
+        let characterIndex = try #require(textView.characterIndex(at: point))
+        let symbolRange = try #require(textView.symbolRange(at: point))
+
+        #expect(expectedRange.contains(characterIndex))
+        #expect(symbolRange == expectedRange)
+        #expect(anchorRect.width > 0)
+        #expect(anchorRect.height > 0)
+    }
+
+    @Test func diffPaneCodeTextViewRoutesCommandClickToHandler() throws {
+        let textView = DiffPaneCodeTextView(frame: NSRect(x: 0, y: 0, width: 300, height: 80), textContainer: NSTextContainer())
+        let window = NSWindow(contentRect: textView.frame, styleMask: [], backing: .buffered, defer: false)
+        window.contentView?.addSubview(textView)
+        textView.textStorage?.setAttributedString(NSAttributedString(string: "let value = service.fetch()"))
+        textView.layoutManager?.ensureLayout(for: textView.textContainer!)
+        var clickedPoint: NSPoint?
+        textView.commandClickHandler = { clickedPoint = $0 }
+
+        let anchorRect = try #require(textView.symbolAnchorRect(for: NSRange(location: 4, length: 5)))
+        let windowPoint = textView.convert(NSPoint(x: anchorRect.midX, y: anchorRect.midY), to: nil)
+        let event = try #require(NSEvent.mouseEvent(
+            with: .leftMouseDown,
+            location: windowPoint,
+            modifierFlags: .command,
+            timestamp: 0,
+            windowNumber: window.windowNumber,
+            context: nil,
+            eventNumber: 0,
+            clickCount: 1,
+            pressure: 1
+        ))
+
+        textView.mouseDown(with: event)
+
+        let point = try #require(clickedPoint)
+        #expect(abs(point.x - anchorRect.midX) < 0.5)
+        #expect(abs(point.y - anchorRect.midY) < 0.5)
     }
 
     private func allSubviews(of view: NSView) -> [NSView] {

--- a/AlasTests/DiffReviewSurfaceTests.swift
+++ b/AlasTests/DiffReviewSurfaceTests.swift
@@ -143,6 +143,15 @@ struct DiffReviewSurfaceTests {
         var layout = DiffLayoutMode.split
         var wrap = false
         var whitespace = false
+        let manager = WorkspaceLSPManager(registry: LanguageServerRegistry(userDefined: []))
+        let context = DiffPaneLSPContext(
+            worktreeId: "worktree-1",
+            worktreeRoot: URL(fileURLWithPath: "/tmp/worktree"),
+            relativePath: "Sources/App/AlphaView.swift",
+            language: "swift",
+            lsp: manager,
+            openTarget: { _, _, _ in }
+        )
 
         let view = DiffReviewFileSection(
             file: file,
@@ -152,13 +161,15 @@ struct DiffReviewSurfaceTests {
             codeFontFamily: "SF Mono",
             codeFontSize: 13,
             showsSourceBadge: false,
-            lspContext: nil
+            lspContext: context
         )
         .environment(\.theme, theme())
 
         let controller = host(view, width: 900, height: 500)
+        let textViews = allSubviews(of: controller.view).compactMap { $0 as? DiffPaneCodeTextView }
 
         #expect(allSubviews(of: controller.view).contains { $0 is DiffPaneTextScrollView })
+        #expect(textViews.contains { $0.hasLSPContextForTesting && $0.allowedLSPSideForTesting == .new })
         #expect(subview(withAccessibilityIdentifier: "diff-pane-toolbar", in: controller.view) == nil)
     }
 

--- a/AlasTests/DiffReviewSurfaceTests.swift
+++ b/AlasTests/DiffReviewSurfaceTests.swift
@@ -132,6 +132,36 @@ struct DiffReviewSurfaceTests {
         #expect(accessibilityLabel(in: controller.view, containing: "UNSTAGED") != nil)
     }
 
+    @Test func fileSectionAcceptsLSPContextWithoutChangingLayout() {
+        let file = DiffReviewFileSectionModel(
+            summary: summary(path: "Sources/App/AlphaView.swift"),
+            parsedDiff: parsedDiff(),
+            displayModel: displayModel(),
+            placeholderMessage: nil,
+            openFile: nil
+        )
+        var layout = DiffLayoutMode.split
+        var wrap = false
+        var whitespace = false
+
+        let view = DiffReviewFileSection(
+            file: file,
+            layoutMode: Binding(get: { layout }, set: { layout = $0 }),
+            wrapLines: Binding(get: { wrap }, set: { wrap = $0 }),
+            showWhitespace: Binding(get: { whitespace }, set: { whitespace = $0 }),
+            codeFontFamily: "SF Mono",
+            codeFontSize: 13,
+            showsSourceBadge: false,
+            lspContext: nil
+        )
+        .environment(\.theme, theme())
+
+        let controller = host(view, width: 900, height: 500)
+
+        #expect(allSubviews(of: controller.view).contains { $0 is DiffPaneTextScrollView })
+        #expect(subview(withAccessibilityIdentifier: "diff-pane-toolbar", in: controller.view) == nil)
+    }
+
     @Test func placeholderSectionsRenderMessageWithoutDiffPane() {
         let file = DiffReviewFileSectionModel(
             summary: summary(path: "Assets/logo.png", status: .modified, isRenderable: false),

--- a/AlasTests/DiffReviewSurfaceTests.swift
+++ b/AlasTests/DiffReviewSurfaceTests.swift
@@ -173,6 +173,52 @@ struct DiffReviewSurfaceTests {
         #expect(subview(withAccessibilityIdentifier: "diff-pane-toolbar", in: controller.view) == nil)
     }
 
+    @Test func textDocumentViewClearsInactivePaneLSPContextWhenLayoutChanges() {
+        let manager = WorkspaceLSPManager(registry: LanguageServerRegistry(userDefined: []))
+        let context = DiffPaneLSPContext(
+            worktreeId: "worktree-1",
+            worktreeRoot: URL(fileURLWithPath: "/tmp/worktree"),
+            relativePath: "Sources/App/AlphaView.swift",
+            language: "swift",
+            lsp: manager,
+            openTarget: { _, _, _ in }
+        )
+        let container = DiffPaneTextDocumentContainerView(frame: NSRect(x: 0, y: 0, width: 900, height: 500))
+        let group = try! #require(displayModel().groups.first)
+
+        container.update(
+            group: group,
+            expandedCollapsedRowIDs: [],
+            layoutMode: .split,
+            wrapLines: false,
+            showWhitespace: false,
+            fileExtension: "swift",
+            font: CenterTypography.resolveCodeFont(family: "SF Mono", size: 13),
+            theme: theme(),
+            lspContext: context
+        )
+        container.layoutSubtreeIfNeeded()
+
+        let splitTextViews = allSubviews(of: container).compactMap { $0 as? DiffPaneCodeTextView }
+        #expect(splitTextViews.filter(\.hasLSPContextForTesting).count == 1)
+
+        container.update(
+            group: group,
+            expandedCollapsedRowIDs: [],
+            layoutMode: .stacked,
+            wrapLines: false,
+            showWhitespace: false,
+            fileExtension: "swift",
+            font: CenterTypography.resolveCodeFont(family: "SF Mono", size: 13),
+            theme: theme(),
+            lspContext: context
+        )
+        container.layoutSubtreeIfNeeded()
+
+        let stackedTextViews = allSubviews(of: container).compactMap { $0 as? DiffPaneCodeTextView }
+        #expect(stackedTextViews.filter(\.hasLSPContextForTesting).count == 1)
+    }
+
     @Test func placeholderSectionsRenderMessageWithoutDiffPane() {
         let file = DiffReviewFileSectionModel(
             summary: summary(path: "Assets/logo.png", status: .modified, isRenderable: false),

--- a/AlasTests/WorkspaceLSPManagerStatusTests.swift
+++ b/AlasTests/WorkspaceLSPManagerStatusTests.swift
@@ -502,6 +502,70 @@ struct WorkspaceLSPManagerStatusTests {
         transport.finish()
     }
 
+    @Test func editorCloseBeforeDidOpenRestoresPendingTemporaryDiffText() async {
+        final class InitializeGate {
+            var continuation: CheckedContinuation<Void, Never>?
+            var didInitialize = false
+
+            func markInitialized() {
+                didInitialize = true
+                continuation?.resume()
+                continuation = nil
+            }
+
+            func waitUntilInitializeSent() async {
+                if didInitialize { return }
+                await withCheckedContinuation { continuation in
+                    self.continuation = continuation
+                }
+            }
+        }
+        let gate = InitializeGate()
+        let transport = FakeTransport()
+        transport.onSend = { sent in
+            if sent.contains(#""method":"initialize""#) {
+                gate.markInitialized()
+            }
+        }
+        let mgr = manager(
+            withFakeEntry: "swift",
+            makeClient: { _, _, _, language, rootURI in
+                LSPClient(transport: transport, language: language, rootURI: rootURI)
+            }
+        )
+
+        async let temporary: LSPClient? = mgr.openTemporaryDocument(
+            worktreeRoot: root,
+            fileURL: fileURL,
+            languageId: "swift",
+            text: "let disk = 1\n"
+        )
+        await gate.waitUntilInitializeSent()
+        async let editor: LSPClient? = mgr.openDocument(
+            worktreeRoot: root,
+            fileURL: fileURL,
+            languageId: "swift",
+            text: "let unsaved = 2\n"
+        )
+        await Task.yield()
+        let closeEditor = Task {
+            await mgr.closeDocument(worktreeRoot: root, fileURL: fileURL, languageId: "swift")
+        }
+        await Task.yield()
+        try? await Task.sleep(nanoseconds: 10_000_000)
+
+        transport.deliverFrame(#"{"jsonrpc":"2.0","id":1,"result":{"capabilities":{"textDocumentSync":1}}}"#)
+        _ = await (temporary, editor)
+        await closeEditor.value
+
+        let didOpen = transport.sent.filter { $0.contains(#""method":"textDocument/didOpen""#) }
+        #expect(didOpen.count == 1)
+        #expect(didOpen.first?.contains(#""text":"let disk = 1\n""#) == true)
+
+        await mgr.closeTemporaryDocument(worktreeRoot: root, fileURL: fileURL, languageId: "swift")
+        transport.finish()
+    }
+
     @Test func isDocumentOpenRequiresEditorOwnedRefWhenTemporaryRetainExists() async {
         let transport = FakeTransport()
         transport.onSend = { sent in

--- a/AlasTests/WorkspaceLSPManagerStatusTests.swift
+++ b/AlasTests/WorkspaceLSPManagerStatusTests.swift
@@ -462,6 +462,46 @@ struct WorkspaceLSPManagerStatusTests {
         transport.finish()
     }
 
+    @Test func editorCloseRestoresTemporaryDiffTextWhenTemporaryRetainRemains() async {
+        let transport = FakeTransport()
+        transport.onSend = { sent in
+            if sent.contains(#""method":"initialize""#) {
+                transport.deliverFrame(#"{"jsonrpc":"2.0","id":1,"result":{"capabilities":{"textDocumentSync":1}}}"#)
+            }
+        }
+        let mgr = manager(
+            withFakeEntry: "swift",
+            makeClient: { _, _, _, language, rootURI in
+                LSPClient(transport: transport, language: language, rootURI: rootURI)
+            }
+        )
+
+        _ = await mgr.openTemporaryDocument(
+            worktreeRoot: root,
+            fileURL: fileURL,
+            languageId: "swift",
+            text: "let disk = 1\n"
+        )
+        _ = await mgr.openDocument(
+            worktreeRoot: root,
+            fileURL: fileURL,
+            languageId: "swift",
+            text: "let unsaved = 2\n"
+        )
+        await mgr.closeDocument(worktreeRoot: root, fileURL: fileURL, languageId: "swift")
+
+        let didChange = transport.sent.filter { $0.contains(#""method":"textDocument/didChange""#) }
+        #expect(didChange.count == 2)
+        #expect(didChange[0].contains(#""text":"let unsaved = 2\n""#))
+        #expect(didChange[1].contains(#""text":"let disk = 1\n""#))
+        #expect(!transport.sent.contains { $0.contains(#""method":"textDocument/didClose""#) })
+        #expect(mgr.documentStatus(forFile: fileURL, worktreeRoot: root) == .ready)
+
+        await mgr.closeTemporaryDocument(worktreeRoot: root, fileURL: fileURL, languageId: "swift")
+        #expect(transport.sent.contains { $0.contains(#""method":"textDocument/didClose""#) })
+        transport.finish()
+    }
+
     @Test func isDocumentOpenRequiresEditorOwnedRefWhenTemporaryRetainExists() async {
         let transport = FakeTransport()
         transport.onSend = { sent in

--- a/AlasTests/WorkspaceLSPManagerStatusTests.swift
+++ b/AlasTests/WorkspaceLSPManagerStatusTests.swift
@@ -15,7 +15,16 @@ struct WorkspaceLSPManagerStatusTests {
         self.fileURL = r.appendingPathComponent("main.swift")
     }
 
-    private func manager(withFakeEntry language: String = "swift") -> WorkspaceLSPManager {
+    private func manager(
+        withFakeEntry language: String = "swift",
+        makeClient: @escaping (_ executable: URL, _ arguments: [String], _ environment: [String: String], _ language: String, _ rootURI: String) -> LSPClient = { executable, arguments, environment, language, rootURI in
+            LSPClient(
+                transport: LSPTransport(executable: executable, arguments: arguments, environment: environment),
+                language: language,
+                rootURI: rootURI
+            )
+        }
+    ) -> WorkspaceLSPManager {
         let registry = LanguageServerRegistry(userDefined: [
             LanguageServerConfig(
                 language: language,
@@ -36,7 +45,8 @@ struct WorkspaceLSPManagerStatusTests {
                     additionalPathDirectories: [],
                     gatekeeperAssessor: { _ in .allowed }
                 )
-            }
+            },
+            makeClient: makeClient
         )
     }
 
@@ -408,5 +418,47 @@ struct WorkspaceLSPManagerStatusTests {
         _ = await opened
 
         #expect(mgr.documentStatus(forFile: fileURL, worktreeRoot: root) == .none)
+    }
+
+    @Test func editorOpenReplacesTemporaryDiffTextAndTemporaryCloseKeepsEditorOpen() async {
+        let transport = FakeTransport()
+        transport.onSend = { sent in
+            if sent.contains(#""method":"initialize""#) {
+                transport.deliverFrame(#"{"jsonrpc":"2.0","id":1,"result":{"capabilities":{"textDocumentSync":1}}}"#)
+            }
+        }
+        let mgr = manager(
+            withFakeEntry: "swift",
+            makeClient: { _, _, _, language, rootURI in
+                LSPClient(transport: transport, language: language, rootURI: rootURI)
+            }
+        )
+
+        _ = await mgr.openTemporaryDocument(
+            worktreeRoot: root,
+            fileURL: fileURL,
+            languageId: "swift",
+            text: "let disk = 1\n"
+        )
+        _ = await mgr.openDocument(
+            worktreeRoot: root,
+            fileURL: fileURL,
+            languageId: "swift",
+            text: "let unsaved = 2\n"
+        )
+
+        let didOpen = transport.sent.filter { $0.contains(#""method":"textDocument/didOpen""#) }
+        let didChange = transport.sent.filter { $0.contains(#""method":"textDocument/didChange""#) }
+        #expect(didOpen.count == 1)
+        #expect(didOpen.first?.contains(#""text":"let disk = 1\n""#) == true)
+        #expect(didChange.count == 1)
+        #expect(didChange.first?.contains(#""text":"let unsaved = 2\n""#) == true)
+
+        await mgr.closeTemporaryDocument(worktreeRoot: root, fileURL: fileURL, languageId: "swift")
+        #expect(!transport.sent.contains { $0.contains(#""method":"textDocument/didClose""#) })
+
+        await mgr.closeDocument(worktreeRoot: root, fileURL: fileURL, languageId: "swift")
+        #expect(transport.sent.contains { $0.contains(#""method":"textDocument/didClose""#) })
+        transport.finish()
     }
 }

--- a/AlasTests/WorkspaceLSPManagerStatusTests.swift
+++ b/AlasTests/WorkspaceLSPManagerStatusTests.swift
@@ -461,4 +461,43 @@ struct WorkspaceLSPManagerStatusTests {
         #expect(transport.sent.contains { $0.contains(#""method":"textDocument/didClose""#) })
         transport.finish()
     }
+
+    @Test func isDocumentOpenRequiresEditorOwnedRefWhenTemporaryRetainExists() async {
+        let transport = FakeTransport()
+        transport.onSend = { sent in
+            if sent.contains(#""method":"initialize""#) {
+                transport.deliverFrame(#"{"jsonrpc":"2.0","id":1,"result":{"capabilities":{"textDocumentSync":1}}}"#)
+            }
+        }
+        let mgr = manager(
+            withFakeEntry: "swift",
+            makeClient: { _, _, _, language, rootURI in
+                LSPClient(transport: transport, language: language, rootURI: rootURI)
+            }
+        )
+
+        _ = await mgr.openTemporaryDocument(
+            worktreeRoot: root,
+            fileURL: fileURL,
+            languageId: "swift",
+            text: "let disk = 1\n"
+        )
+        #expect(mgr.isDocumentOpen(fileURL: fileURL, worktreeRoot: root) == false)
+
+        _ = await mgr.openDocument(
+            worktreeRoot: root,
+            fileURL: fileURL,
+            languageId: "swift",
+            text: "let unsaved = 2\n"
+        )
+        #expect(mgr.isDocumentOpen(fileURL: fileURL, worktreeRoot: root) == true)
+
+        await mgr.closeDocument(worktreeRoot: root, fileURL: fileURL, languageId: "swift")
+        #expect(mgr.isDocumentOpen(fileURL: fileURL, worktreeRoot: root) == false)
+        #expect(mgr.documentStatus(forFile: fileURL, worktreeRoot: root) == .ready)
+
+        await mgr.closeTemporaryDocument(worktreeRoot: root, fileURL: fileURL, languageId: "swift")
+        #expect(mgr.documentStatus(forFile: fileURL, worktreeRoot: root) == .none)
+        transport.finish()
+    }
 }

--- a/docs/manual-test.md
+++ b/docs/manual-test.md
@@ -186,7 +186,10 @@ Pre-req: a Swift project, `sourcekit-lsp` available via `xcrun --find sourcekit-
 
 1. Stage a Swift change. Open the diff tab.
 2. Confirm hunks render with colored keywords / types / strings.
-3. Confirm hover does nothing (intentional — diff pane is highlight-only, no LSP).
+3. Wait for `sourcekit-lsp` to settle. Hover a symbol on the new/current side and confirm a type/docs popover appears.
+4. Cmd-click a symbol on the new/current side and confirm the editor jumps to its definition.
+5. Hover or Cmd-click deleted/old-side lines and confirm no LSP popover or navigation occurs.
+6. Switch between split and stacked diff layouts and repeat the hover / Cmd-click checks on the new/current side.
 
 ### Settings → Code
 

--- a/docs/superpowers/plans/2026-06-12-lsp-aware-diff-implementation.md
+++ b/docs/superpowers/plans/2026-06-12-lsp-aware-diff-implementation.md
@@ -386,7 +386,8 @@ Set the metadata:
 
 ```swift
 textView.lineMetadata = document.lines
-textView.updateLSP(context: lspContext, allowedSide: allowedLSPSide)
+textView.lspContext = lspContext
+textView.allowedLSPSide = allowedLSPSide
 ```
 
 Update all existing callers in `DiffPaneTextDocumentContainerView` to pass `lspContext: nil` temporarily; Task 4 wires real contexts.
@@ -399,19 +400,8 @@ var hoverHandler: ((NSPoint) -> Void)?
 var commandClickHandler: ((NSPoint) -> Void)?
 var flagsChangedHandler: ((NSEvent) -> Void)?
 var mouseExitedHandler: (() -> Void)?
-private var lspController: DiffPaneLSPController?
-
-func updateLSP(context: DiffPaneLSPContext?, allowedSide: DiffLineSide) {
-    if let context {
-        if lspController == nil {
-            lspController = DiffPaneLSPController(textView: self)
-        }
-        lspController?.update(context: context, allowedSide: allowedSide)
-    } else {
-        lspController?.tearDown()
-        lspController = nil
-    }
-}
+var lspContext: DiffPaneLSPContext?
+var allowedLSPSide: DiffLineSide = .new
 
 override func mouseMoved(with event: NSEvent) {
     super.mouseMoved(with: event)
@@ -476,7 +466,7 @@ func symbolAnchorRect(for range: NSRange) -> NSRect? {
 }
 ```
 
-In `DiffPaneCodeTextView.deinit`, call `lspController?.tearDown()`.
+Do not reference `DiffPaneLSPController` in this task. Task 3 creates and attaches the controller.
 
 - [ ] **Step 4: Run tests and verify GREEN**
 

--- a/docs/superpowers/plans/2026-06-12-lsp-aware-diff-implementation.md
+++ b/docs/superpowers/plans/2026-06-12-lsp-aware-diff-implementation.md
@@ -1,0 +1,963 @@
+# LSP-Aware Diff Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add hover/type information and Cmd-click go-to-definition to the current/new side of Alas diff panes.
+
+**Architecture:** Add a read-only diff LSP layer that maps rendered new-side diff rows back to real worktree file positions, then routes hover and definition requests through `WorkspaceLSPManager`. Keep diff panes non-editable and do not add completion, diagnostics, or old-side intelligence.
+
+**Tech Stack:** Swift 5.9+, SwiftUI/AppKit `NSTextView`, Swift Testing, Alas `WorkspaceLSPManager` and existing LSP message types.
+
+---
+
+## File Structure
+
+- Create `Alas/Sources/Center/Diff/DiffPaneLSP.swift`
+  - Owns `DiffPaneLSPContext`, `DiffPaneLSPLineMap`, `DiffPaneLSPController`, and the read-only document retain helper.
+- Modify `Alas/Sources/Center/Diff/DiffPaneTextDocumentBuilder.swift`
+  - Add source-line metadata to `LineMetadata`.
+- Modify `Alas/Sources/Center/Diff/DiffPaneTextDocumentView.swift`
+  - Store line metadata in `DiffPaneCodeTextView`, add mouse/keyboard hooks, and attach/update the LSP controller.
+- Modify `Alas/Sources/Center/Diff/DiffPaneView.swift`
+  - Accept optional `lspContext` and pass it to hunk document views.
+- Modify `Alas/Sources/Center/DiffTabView.swift`
+  - Build `DiffPaneLSPContext` for single-file working tree/staged diff tabs.
+- Modify `Alas/Sources/Center/CenterPaneView.swift`
+  - Pass `worktree.id` into `DiffTabView`.
+- Modify `Alas/Sources/Center/DiffReview/DiffReviewSurface.swift`
+  - Accept an optional LSP context factory and pass it to each file section.
+- Modify `Alas/Sources/Center/DiffReview/DiffReviewFileSection.swift`
+  - Pass per-file LSP context into `DiffPaneView`.
+- Modify `Alas/Sources/Center/ReviewChanges/ReviewChangesTabView.swift`
+  - Supply LSP contexts for the review changes surface.
+- Modify `Alas/Sources/Center/Commit/CommitTabView.swift`
+  - Supply LSP contexts for commit review, using the current worktree file where it still exists.
+- Modify tests:
+  - `AlasTests/DiffPaneViewTests.swift`
+  - `AlasTests/DiffReviewSurfaceTests.swift`
+  - Create `AlasTests/DiffPaneLSPTests.swift`
+- Modify `docs/manual-test.md`
+  - Update the diff pane LSP manual test.
+
+---
+
+### Task 1: Source Metadata And Pure Line Mapping
+
+**Files:**
+- Create: `AlasTests/DiffPaneLSPTests.swift`
+- Create: `Alas/Sources/Center/Diff/DiffPaneLSP.swift`
+- Modify: `Alas/Sources/Center/Diff/DiffPaneTextDocumentBuilder.swift`
+
+- [ ] **Step 1: Write failing mapper tests**
+
+Create `AlasTests/DiffPaneLSPTests.swift`:
+
+```swift
+import Foundation
+import Testing
+
+@Suite("DiffPaneLSPLineMap")
+struct DiffPaneLSPLineMapTests {
+    @Test func mapsNewLineCharacterToRealFilePosition() {
+        let line = DiffDisplayLine(
+            id: "file:new:0:0",
+            anchor: DiffLineAnchor(filePath: "Sources/App.swift", hunkIndex: 0, rowIndex: 0, side: .new, oldLine: nil, newLine: 42),
+            text: "let value = service.fetch()",
+            lineNumber: 42,
+            kind: .add,
+            inlineSpans: [],
+            noTrailingNewline: false
+        )
+        let metadata = [
+            DiffPaneTextDocumentBuilder.LineMetadata(
+                kind: .add,
+                range: NSRange(location: 0, length: 27),
+                tone: .add,
+                sourceLine: line
+            )
+        ]
+
+        let result = DiffPaneLSPLineMap.position(
+            at: 11,
+            metadata: metadata,
+            allowedSide: .new
+        )
+
+        #expect(result == LSPPosition(line: 41, character: 11))
+    }
+
+    @Test func rejectsOldSideLine() {
+        let line = DiffDisplayLine(
+            id: "file:old:0:0",
+            anchor: DiffLineAnchor(filePath: "Sources/App.swift", hunkIndex: 0, rowIndex: 0, side: .old, oldLine: 41, newLine: nil),
+            text: "let old = value",
+            lineNumber: 41,
+            kind: .delete,
+            inlineSpans: [],
+            noTrailingNewline: false
+        )
+        let metadata = [
+            DiffPaneTextDocumentBuilder.LineMetadata(
+                kind: .delete,
+                range: NSRange(location: 0, length: 15),
+                tone: .delete,
+                sourceLine: line
+            )
+        ]
+
+        let result = DiffPaneLSPLineMap.position(
+            at: 4,
+            metadata: metadata,
+            allowedSide: .new
+        )
+
+        #expect(result == nil)
+    }
+
+    @Test func rejectsCharacterOutsideSourceText() {
+        let line = DiffDisplayLine(
+            id: "file:new:0:0",
+            anchor: DiffLineAnchor(filePath: "Sources/App.swift", hunkIndex: 0, rowIndex: 0, side: .new, oldLine: nil, newLine: 8),
+            text: "abc",
+            lineNumber: 8,
+            kind: .add,
+            inlineSpans: [],
+            noTrailingNewline: false
+        )
+        let metadata = [
+            DiffPaneTextDocumentBuilder.LineMetadata(
+                kind: .add,
+                range: NSRange(location: 10, length: 3),
+                tone: .add,
+                sourceLine: line
+            )
+        ]
+
+        #expect(DiffPaneLSPLineMap.position(at: 9, metadata: metadata, allowedSide: .new) == nil)
+        #expect(DiffPaneLSPLineMap.position(at: 13, metadata: metadata, allowedSide: .new) == nil)
+    }
+
+    @Test func rejectsCollapsedRows() {
+        let metadata = [
+            DiffPaneTextDocumentBuilder.LineMetadata(
+                kind: .collapsed,
+                range: NSRange(location: 0, length: 20),
+                tone: .collapsed,
+                sourceLine: nil
+            )
+        ]
+
+        #expect(DiffPaneLSPLineMap.position(at: 5, metadata: metadata, allowedSide: .new) == nil)
+    }
+}
+```
+
+- [ ] **Step 2: Run tests and verify RED**
+
+Run:
+
+```bash
+rtk xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -only-testing:AlasTests/DiffPaneLSPLineMapTests test
+```
+
+Expected: build fails because `DiffPaneLSPLineMap` and `LineMetadata(sourceLine:)` do not exist.
+
+- [ ] **Step 3: Implement source metadata and mapper**
+
+In `Alas/Sources/Center/Diff/DiffPaneTextDocumentBuilder.swift`, change `LineMetadata`:
+
+```swift
+struct LineMetadata: Equatable {
+    let kind: DiffDisplayRow.Kind
+    let range: NSRange
+    var tone: DiffPaneLineTone? = nil
+    var sourceLine: DiffDisplayLine? = nil
+}
+```
+
+Update `ColumnAccumulator.append` to accept `sourceLine` and preserve it:
+
+```swift
+mutating func append(
+    _ text: NSAttributedString,
+    kind: DiffDisplayRow.Kind,
+    tone: DiffPaneLineTone? = nil,
+    sourceLine: DiffDisplayLine? = nil
+) {
+    if output.length > 0 {
+        output.append(NSAttributedString(string: "\n", attributes: DiffPaneTextDocumentBuilder.baseAttributes(font: font, theme: theme)))
+    }
+    let start = output.length
+    output.append(text)
+    metadata.append(DiffPaneTextDocumentBuilder.LineMetadata(
+        kind: kind,
+        range: NSRange(location: start, length: output.length - start),
+        tone: tone,
+        sourceLine: sourceLine
+    ))
+}
+```
+
+Pass source lines from `buildSplit`:
+
+```swift
+oldColumn.append(
+    code(row.old?.text ?? "", line: row.old, fileExtension: fileExtension, font: font, showWhitespace: showWhitespace, theme: theme),
+    kind: row.kind,
+    tone: tone(for: row.old, rowKind: row.kind),
+    sourceLine: row.old
+)
+newColumn.append(
+    code(row.new?.text ?? "", line: row.new, fileExtension: fileExtension, font: font, showWhitespace: showWhitespace, theme: theme),
+    kind: row.kind,
+    tone: tone(for: row.new, rowKind: row.kind),
+    sourceLine: row.new
+)
+```
+
+Pass source lines from `buildStacked`:
+
+```swift
+codeColumn.append(
+    code(line.text, line: line, fileExtension: fileExtension, font: font, showWhitespace: showWhitespace, theme: theme),
+    kind: row.kind,
+    tone: tone(for: line, rowKind: row.kind),
+    sourceLine: line
+)
+```
+
+For collapsed rows and empty layout rows, pass `sourceLine: nil`.
+
+Create `Alas/Sources/Center/Diff/DiffPaneLSP.swift` with the pure mapper:
+
+```swift
+import AppKit
+import Foundation
+
+struct DiffPaneLSPContext {
+    let worktreeId: String
+    let worktreeRoot: URL
+    let relativePath: String
+    let language: String
+    let lsp: WorkspaceLSPManager
+    let openTarget: @MainActor (URL, Int, Int) -> Void
+
+    var fileURL: URL {
+        worktreeRoot.appendingPathComponent(relativePath)
+    }
+
+    var uri: String {
+        fileURL.lspURI
+    }
+}
+
+enum DiffPaneLSPLineMap {
+    static func position(
+        at characterIndex: Int,
+        metadata: [DiffPaneTextDocumentBuilder.LineMetadata],
+        allowedSide: DiffLineSide
+    ) -> LSPPosition? {
+        guard let line = metadata.first(where: { NSLocationInRange(characterIndex, $0.range) }) else {
+            return nil
+        }
+        guard let source = line.sourceLine,
+              source.anchor.side == allowedSide,
+              let newLine = source.anchor.newLine,
+              newLine > 0
+        else {
+            return nil
+        }
+
+        let character = characterIndex - line.range.location
+        guard character >= 0, character < source.text.utf16.count else {
+            return nil
+        }
+        return LSPPosition(line: newLine - 1, character: character)
+    }
+}
+```
+
+- [ ] **Step 4: Run mapper tests and verify GREEN**
+
+Run:
+
+```bash
+rtk xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -only-testing:AlasTests/DiffPaneLSPLineMapTests test
+```
+
+Expected: `DiffPaneLSPLineMapTests` passes.
+
+- [ ] **Step 5: Commit**
+
+```bash
+rtk git add Alas/Sources/Center/Diff/DiffPaneLSP.swift Alas/Sources/Center/Diff/DiffPaneTextDocumentBuilder.swift AlasTests/DiffPaneLSPTests.swift
+rtk git commit -m "feat(diff): map diff rows to LSP positions"
+```
+
+---
+
+### Task 2: Diff Text View Interaction Primitives
+
+**Files:**
+- Modify: `Alas/Sources/Center/Diff/DiffPaneTextDocumentView.swift`
+- Modify: `AlasTests/DiffPaneViewTests.swift`
+
+- [ ] **Step 1: Write failing AppKit tests for metadata and hooks**
+
+Append to `AlasTests/DiffPaneViewTests.swift`:
+
+```swift
+@Test func diffPaneCodeTextViewStoresLineMetadata() throws {
+    let document = DiffPaneTextDocumentBuilder.CodeDocument(
+        attributedString: NSAttributedString(string: "let value = 1"),
+        lines: [
+            DiffPaneTextDocumentBuilder.LineMetadata(
+                kind: .add,
+                range: NSRange(location: 0, length: 13),
+                tone: .add,
+                sourceLine: DiffDisplayLine(
+                    id: "a.swift:new:0:0",
+                    anchor: DiffLineAnchor(filePath: "a.swift", hunkIndex: 0, rowIndex: 0, side: .new, oldLine: nil, newLine: 3),
+                    text: "let value = 1",
+                    lineNumber: 3,
+                    kind: .add,
+                    inlineSpans: [],
+                    noTrailingNewline: false
+                )
+            )
+        ]
+    )
+    let scrollView = DiffPaneTextScrollView()
+    let theme = try Theme.loadBundled(id: "cool-slate")
+
+    scrollView.update(
+        document: document,
+        lineLabels: ["+3"],
+        wraps: false,
+        font: .monospacedSystemFont(ofSize: 13, weight: .regular),
+        theme: theme,
+        lspContext: nil,
+        allowedLSPSide: .new
+    )
+
+    let codeView = try #require(scrollView.documentView as? DiffPaneCodeTextView)
+    #expect(codeView.lineMetadata.count == 1)
+    #expect(codeView.lineMetadata.first?.sourceLine?.anchor.newLine == 3)
+}
+
+@Test func diffPaneCodeTextViewCanResolveSymbolRange() throws {
+    let textView = DiffPaneCodeTextView(frame: NSRect(x: 0, y: 0, width: 300, height: 80), textContainer: NSTextContainer())
+    textView.textStorage?.setAttributedString(NSAttributedString(string: "let value = service.fetch()"))
+    textView.layoutManager?.ensureLayout(for: textView.textContainer!)
+
+    let range = (textView.string as NSString).rangeOfWord(at: 4)
+
+    #expect(range == NSRange(location: 4, length: 5))
+}
+```
+
+- [ ] **Step 2: Run tests and verify RED**
+
+Run:
+
+```bash
+rtk xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -only-testing:AlasTests/DiffPaneViewTests test
+```
+
+Expected: build fails because `DiffPaneTextScrollView.update` has no LSP parameters and `DiffPaneCodeTextView.lineMetadata` is not exposed.
+
+- [ ] **Step 3: Add diff text view hooks and metadata storage**
+
+In `DiffPaneTextScrollView.update`, add parameters:
+
+```swift
+func update(
+    document: DiffPaneTextDocumentBuilder.CodeDocument,
+    lineLabels: [String],
+    wraps: Bool,
+    font: NSFont,
+    theme: Theme,
+    lspContext: DiffPaneLSPContext?,
+    allowedLSPSide: DiffLineSide
+)
+```
+
+Set the metadata:
+
+```swift
+textView.lineMetadata = document.lines
+textView.updateLSP(context: lspContext, allowedSide: allowedLSPSide)
+```
+
+Update all existing callers in `DiffPaneTextDocumentContainerView` to pass `lspContext: nil` temporarily; Task 4 wires real contexts.
+
+In `DiffPaneCodeTextView`, add:
+
+```swift
+var lineMetadata: [DiffPaneTextDocumentBuilder.LineMetadata] = []
+var hoverHandler: ((NSPoint) -> Void)?
+var commandClickHandler: ((NSPoint) -> Void)?
+var flagsChangedHandler: ((NSEvent) -> Void)?
+var mouseExitedHandler: (() -> Void)?
+private var lspController: DiffPaneLSPController?
+
+func updateLSP(context: DiffPaneLSPContext?, allowedSide: DiffLineSide) {
+    if let context {
+        if lspController == nil {
+            lspController = DiffPaneLSPController(textView: self)
+        }
+        lspController?.update(context: context, allowedSide: allowedSide)
+    } else {
+        lspController?.tearDown()
+        lspController = nil
+    }
+}
+
+override func mouseMoved(with event: NSEvent) {
+    super.mouseMoved(with: event)
+    hoverHandler?(convert(event.locationInWindow, from: nil))
+}
+
+override func mouseDown(with event: NSEvent) {
+    if event.modifierFlags.contains(.command) {
+        commandClickHandler?(convert(event.locationInWindow, from: nil))
+        return
+    }
+    super.mouseDown(with: event)
+}
+
+override func flagsChanged(with event: NSEvent) {
+    super.flagsChanged(with: event)
+    flagsChangedHandler?(event)
+}
+
+override func mouseExited(with event: NSEvent) {
+    super.mouseExited(with: event)
+    mouseExitedHandler?()
+}
+
+override func updateTrackingAreas() {
+    super.updateTrackingAreas()
+    for area in trackingAreas { removeTrackingArea(area) }
+    addTrackingArea(NSTrackingArea(
+        rect: bounds,
+        options: [.mouseMoved, .mouseEnteredAndExited, .activeInActiveApp, .inVisibleRect],
+        owner: self,
+        userInfo: nil
+    ))
+}
+```
+
+Add helper methods to `DiffPaneCodeTextView`:
+
+```swift
+func characterIndex(at point: NSPoint) -> Int? {
+    guard let layoutManager, let textContainer, let storage = textStorage else { return nil }
+    let containerPoint = NSPoint(
+        x: point.x - textContainerInset.width,
+        y: point.y - textContainerInset.height
+    )
+    let glyphIndex = layoutManager.glyphIndex(for: containerPoint, in: textContainer)
+    let charIndex = layoutManager.characterIndexForGlyph(at: glyphIndex)
+    return charIndex < (storage.string as NSString).length ? charIndex : nil
+}
+
+func symbolRange(at point: NSPoint) -> NSRange? {
+    guard let index = characterIndex(at: point) else { return nil }
+    let range = (string as NSString).rangeOfWord(at: index)
+    return range.length == 0 ? nil : range
+}
+
+func symbolAnchorRect(for range: NSRange) -> NSRect? {
+    guard range.length > 0, let layoutManager, let textContainer else { return nil }
+    let glyph = layoutManager.glyphIndexForCharacter(at: range.location)
+    let rect = layoutManager.boundingRect(forGlyphRange: NSRange(location: glyph, length: 1), in: textContainer)
+    return rect.offsetBy(dx: textContainerInset.width, dy: textContainerInset.height)
+}
+```
+
+In `DiffPaneCodeTextView.deinit`, call `lspController?.tearDown()`.
+
+- [ ] **Step 4: Run tests and verify GREEN**
+
+Run:
+
+```bash
+rtk xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -only-testing:AlasTests/DiffPaneViewTests test
+```
+
+Expected: `DiffPaneViewTests` passes.
+
+- [ ] **Step 5: Commit**
+
+```bash
+rtk git add Alas/Sources/Center/Diff/DiffPaneTextDocumentView.swift AlasTests/DiffPaneViewTests.swift
+rtk git commit -m "feat(diff): add LSP-ready text view hooks"
+```
+
+---
+
+### Task 3: LSP Controller, Hover, Definition, And Balanced Retain
+
+**Files:**
+- Modify: `Alas/Sources/Center/Diff/DiffPaneLSP.swift`
+- Modify: `AlasTests/DiffPaneLSPTests.swift`
+
+- [ ] **Step 1: Write failing retain/controller tests**
+
+Append to `AlasTests/DiffPaneLSPTests.swift`:
+
+```swift
+@MainActor
+@Test func readOnlyRetainLoadsExistingFileTextAndBalancesClose() async throws {
+    let root = URL(fileURLWithPath: NSTemporaryDirectory()).appendingPathComponent(UUID().uuidString)
+    try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+    let fileURL = root.appendingPathComponent("File.swift")
+    try "let value = 1\n".write(to: fileURL, atomically: true, encoding: .utf8)
+    let recorder = DiffPaneLSPRetainRecorder()
+
+    let retain = try await DiffPaneLSPDocumentRetain.open(
+        worktreeRoot: root,
+        fileURL: fileURL,
+        language: "swift",
+        open: recorder.open,
+        close: recorder.close
+    )
+
+    #expect(recorder.openedText == "let value = 1\n")
+    await retain.close()
+    #expect(recorder.closed == true)
+}
+
+@MainActor
+@Test func linePositionRejectsOldSideThroughControllerHelper() {
+    let oldLine = DiffDisplayLine(
+        id: "file:old:0:0",
+        anchor: DiffLineAnchor(filePath: "File.swift", hunkIndex: 0, rowIndex: 0, side: .old, oldLine: 1, newLine: nil),
+        text: "let value = 0",
+        lineNumber: 1,
+        kind: .delete,
+        inlineSpans: [],
+        noTrailingNewline: false
+    )
+    let metadata = [
+        DiffPaneTextDocumentBuilder.LineMetadata(kind: .delete, range: NSRange(location: 0, length: 13), tone: .delete, sourceLine: oldLine)
+    ]
+
+    #expect(DiffPaneLSPLineMap.position(at: 4, metadata: metadata, allowedSide: .new) == nil)
+}
+
+@MainActor
+private final class DiffPaneLSPRetainRecorder {
+    var openedText: String?
+    var closed = false
+
+    func open(worktreeRoot: URL, fileURL: URL, language: String, text: String) async -> LSPClient? {
+        openedText = text
+        return nil
+    }
+
+    func close(worktreeRoot: URL, fileURL: URL, language: String) async {
+        closed = true
+    }
+}
+```
+
+- [ ] **Step 2: Run tests and verify RED**
+
+Run:
+
+```bash
+rtk xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -only-testing:AlasTests/DiffPaneLSPLineMapTests test
+```
+
+Expected: build fails because `DiffPaneLSPDocumentRetain` does not exist.
+
+- [ ] **Step 3: Implement retain and controller**
+
+In `DiffPaneLSP.swift`, add:
+
+```swift
+@MainActor
+final class DiffPaneLSPDocumentRetain {
+    typealias Open = (_ worktreeRoot: URL, _ fileURL: URL, _ language: String, _ text: String) async -> LSPClient?
+    typealias Close = (_ worktreeRoot: URL, _ fileURL: URL, _ language: String) async -> Void
+
+    private let worktreeRoot: URL
+    private let fileURL: URL
+    private let language: String
+    private let closeDocument: Close
+    private var isClosed = false
+
+    private init(worktreeRoot: URL, fileURL: URL, language: String, close: @escaping Close) {
+        self.worktreeRoot = worktreeRoot
+        self.fileURL = fileURL
+        self.language = language
+        self.closeDocument = close
+    }
+
+    static func open(
+        worktreeRoot: URL,
+        fileURL: URL,
+        language: String,
+        open: @escaping Open,
+        close: @escaping Close
+    ) async throws -> DiffPaneLSPDocumentRetain {
+        let text = try String(contentsOf: fileURL, encoding: .utf8)
+        _ = await open(worktreeRoot, fileURL, language, text)
+        return DiffPaneLSPDocumentRetain(worktreeRoot: worktreeRoot, fileURL: fileURL, language: language, close: close)
+    }
+
+    func close() async {
+        guard !isClosed else { return }
+        isClosed = true
+        await closeDocument(worktreeRoot, fileURL, language)
+    }
+
+    deinit {
+        if !isClosed {
+            let worktreeRoot = worktreeRoot
+            let fileURL = fileURL
+            let language = language
+            let closeDocument = closeDocument
+            Task { @MainActor in
+                await closeDocument(worktreeRoot, fileURL, language)
+            }
+        }
+    }
+}
+```
+
+Add `DiffPaneLSPController` in the same file. It should:
+
+- Hold weak `DiffPaneCodeTextView`.
+- Store current `DiffPaneLSPContext`, `allowedSide`, hover request id, definition request id, in-flight tasks, optional `DiffPaneLSPDocumentRetain`, and optional `HoverWindowController` / `NSPopover`.
+- Install handlers on `DiffPaneCodeTextView` in `init`.
+- On hover:
+  - Get `symbolRange(at:)`.
+  - Get character index at the symbol range location or mouse point.
+  - Map to `LSPPosition` through `DiffPaneLSPLineMap`.
+  - Get `context.lsp.openedClient(...)`; if nil, open a retain using `context.lsp.openDocument`.
+  - Request `client.hover(uri: context.uri, position: position)`.
+  - Render non-empty hover content using the same `MarkdownRenderer` and `HoverWindowController` path as `HoverFeature`.
+- On Cmd-click:
+  - Map to a position the same way.
+  - Get or retain a client.
+  - Request `client.definition(uri: context.uri, position: position)`.
+  - Open the first result through `context.openTarget`.
+  - If there are multiple results, present `DefinitionPicker` like `DefinitionFeature`.
+- On `tearDown`:
+  - Cancel tasks.
+  - Clear text view handlers.
+  - Hide hover and definition UI.
+  - Close and nil out the retain.
+
+Use this request helper shape so tests can reason about mapping independently:
+
+```swift
+func lspPosition(at point: NSPoint) -> LSPPosition? {
+    guard let textView,
+          let index = textView.characterIndex(at: point)
+    else { return nil }
+    return DiffPaneLSPLineMap.position(
+        at: index,
+        metadata: textView.lineMetadata,
+        allowedSide: allowedSide
+    )
+}
+```
+
+- [ ] **Step 4: Run tests and verify GREEN**
+
+Run:
+
+```bash
+rtk xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -only-testing:AlasTests/DiffPaneLSPLineMapTests test
+```
+
+Expected: `DiffPaneLSPLineMapTests` passes.
+
+- [ ] **Step 5: Commit**
+
+```bash
+rtk git add Alas/Sources/Center/Diff/DiffPaneLSP.swift AlasTests/DiffPaneLSPTests.swift
+rtk git commit -m "feat(diff): add read-only LSP controller"
+```
+
+---
+
+### Task 4: Thread LSP Context Through Diff Surfaces
+
+**Files:**
+- Modify: `Alas/Sources/Center/Diff/DiffPaneTextDocumentView.swift`
+- Modify: `Alas/Sources/Center/Diff/DiffPaneView.swift`
+- Modify: `Alas/Sources/Center/DiffTabView.swift`
+- Modify: `Alas/Sources/Center/CenterPaneView.swift`
+- Modify: `Alas/Sources/Center/DiffReview/DiffReviewSurface.swift`
+- Modify: `Alas/Sources/Center/DiffReview/DiffReviewFileSection.swift`
+- Modify: `Alas/Sources/Center/ReviewChanges/ReviewChangesTabView.swift`
+- Modify: `Alas/Sources/Center/Commit/CommitTabView.swift`
+- Modify: `Alas/Sources/Center/Commit/CommitDiffView.swift`
+- Modify: `Alas/Sources/Center/ReviewRequest/DraftReviewRequestTabView.swift`
+- Modify tests that construct these views.
+
+- [ ] **Step 1: Write failing propagation test**
+
+In `AlasTests/DiffReviewSurfaceTests.swift`, update `fileSectionEmbedsDiffPaneWithoutToolbarAndShowsOpenFile` to assert a no-context render still works after the initializer changes:
+
+```swift
+#expect(allSubviews(of: controller.view).contains { $0 is DiffPaneTextScrollView })
+```
+
+Add a new test:
+
+```swift
+@Test func fileSectionAcceptsLSPContextFactoryWithoutChangingLayout() {
+    let file = DiffReviewFileSectionModel(
+        summary: summary(path: "Sources/App/AlphaView.swift"),
+        parsedDiff: parsedDiff(),
+        displayModel: displayModel(),
+        placeholderMessage: nil,
+        openFile: nil
+    )
+    var layout = DiffLayoutMode.split
+    var wrap = false
+    var whitespace = false
+    let view = DiffReviewFileSection(
+        file: file,
+        layoutMode: Binding(get: { layout }, set: { layout = $0 }),
+        wrapLines: Binding(get: { wrap }, set: { wrap = $0 }),
+        showWhitespace: Binding(get: { whitespace }, set: { whitespace = $0 }),
+        codeFontFamily: "SF Mono",
+        codeFontSize: 13,
+        showsSourceBadge: false,
+        lspContext: nil
+    )
+
+    let controller = NSHostingController(rootView: view)
+    controller.view.layoutSubtreeIfNeeded()
+
+    #expect(allSubviews(of: controller.view).contains { $0 is DiffPaneTextScrollView })
+}
+```
+
+- [ ] **Step 2: Run tests and verify RED**
+
+Run:
+
+```bash
+rtk xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -only-testing:AlasTests/DiffReviewSurfaceTests test
+```
+
+Expected: build fails until initializers accept `lspContext`.
+
+- [ ] **Step 3: Add optional context parameters**
+
+In `DiffPaneTextDocumentView`, add:
+
+```swift
+let lspContext: DiffPaneLSPContext?
+```
+
+Pass it through `updateNSView` and `DiffPaneTextDocumentContainerView.update`.
+
+In split mode:
+
+```swift
+oldPane.update(..., lspContext: nil, allowedLSPSide: .new)
+newPane.update(..., lspContext: lspContext, allowedLSPSide: .new)
+```
+
+In stacked mode:
+
+```swift
+stackedPane.update(..., lspContext: lspContext, allowedLSPSide: .new)
+```
+
+In `DiffPaneView`, add:
+
+```swift
+let lspContext: DiffPaneLSPContext?
+```
+
+Give existing tests/callers `lspContext: nil` where no real context exists.
+
+In `DiffReviewFileSection`, add:
+
+```swift
+let lspContext: DiffPaneLSPContext?
+```
+
+Pass it into `DiffPaneView`.
+
+In `DiffReviewSurface`, add:
+
+```swift
+var lspContextForFile: (DiffReviewFileSectionModel) -> DiffPaneLSPContext? = { _ in nil }
+```
+
+Pass `lspContext: lspContextForFile(file)` to each `DiffReviewFileSection`.
+
+- [ ] **Step 4: Build real contexts in tab views**
+
+In `DiffTabView`, add a stored property:
+
+```swift
+let worktreeId: String
+```
+
+Update the `DiffTabView` call in `CenterPaneView`:
+
+```swift
+DiffTabView(
+    worktreePath: worktree.path,
+    relativePath: s.relativePath,
+    staged: s.staged,
+    worktreeId: worktree.id,
+    appState: state,
+    codeFontFamily: state.config.code.fontFamily,
+    codeFontSize: CGFloat(state.config.code.fontSize),
+    onOpenFile: openAvailable
+        ? { state.openFile(relativePath: s.relativePath, worktreeId: worktree.id) }
+        : nil,
+    onRequestDiscardFile: {
+        rps.requestDiscardFile(path: s.relativePath)
+    }
+)
+```
+
+Then add a computed context in `DiffTabView`:
+
+```swift
+private var lspContext: DiffPaneLSPContext? {
+    guard !isFileDeleted else { return nil }
+    guard let language = appState.lsp.language(forFileExtension: (relativePath as NSString).pathExtension) else {
+        return nil
+    }
+    return DiffPaneLSPContext(
+        worktreeId: worktreeId,
+        worktreeRoot: worktreePath,
+        relativePath: relativePath,
+        language: language,
+        lsp: appState.lsp,
+        openTarget: { url, line, character in
+            let prefix = worktreePath.path + "/"
+            if url.path.hasPrefix(prefix) {
+                let rel = String(url.path.dropFirst(prefix.count))
+                appState.tabs.openEditor(worktreeId: worktreeId, relativePath: rel, revealLine: line, revealCharacter: character)
+            } else {
+                appState.tabs.openExternalEditor(worktreeId: worktreeId, absoluteURL: url, revealLine: line, revealCharacter: character, originatingRelativePath: relativePath, originatingWorktreeRoot: worktreePath, language: language)
+            }
+        }
+    )
+}
+```
+
+In `ReviewChangesTabView.reviewSurface`, pass a factory:
+
+```swift
+lspContextForFile: { file in
+    makeLSPContext(relativePath: file.summary.path)
+}
+```
+
+Add:
+
+```swift
+private func makeLSPContext(relativePath: String) -> DiffPaneLSPContext? {
+    let fileURL = worktree.path.appendingPathComponent(relativePath)
+    guard FileManager.default.fileExists(atPath: fileURL.path),
+          let language = appState.lsp.language(forFileExtension: (relativePath as NSString).pathExtension)
+    else { return nil }
+    return DiffPaneLSPContext(
+        worktreeId: worktree.id,
+        worktreeRoot: worktree.path,
+        relativePath: relativePath,
+        language: language,
+        lsp: appState.lsp,
+        openTarget: { url, line, character in
+            openLSPTarget(url: url, originatingRelativePath: relativePath, language: language, line: line, character: character)
+        }
+    )
+}
+```
+
+Add the matching `openLSPTarget` helper in `ReviewChangesTabView`.
+
+In `CommitTabView`, pass `worktreeId`, `worktreePath`, and `appState` into `CommitReviewBody`, then use the same context factory. Keep the file-exists guard so historical/deleted commit entries quietly disable LSP.
+
+Update `CommitDiffView` and `DraftReviewRequestTabView` to pass `lspContext: nil`.
+
+- [ ] **Step 5: Run propagation tests and verify GREEN**
+
+Run:
+
+```bash
+rtk xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -only-testing:AlasTests/DiffReviewSurfaceTests test
+```
+
+Expected: `DiffReviewSurfaceTests` passes.
+
+- [ ] **Step 6: Commit**
+
+```bash
+rtk git add Alas/Sources/Center/Diff/DiffPaneTextDocumentView.swift Alas/Sources/Center/Diff/DiffPaneView.swift Alas/Sources/Center/DiffTabView.swift Alas/Sources/Center/CenterPaneView.swift Alas/Sources/Center/DiffReview/DiffReviewSurface.swift Alas/Sources/Center/DiffReview/DiffReviewFileSection.swift Alas/Sources/Center/ReviewChanges/ReviewChangesTabView.swift Alas/Sources/Center/Commit/CommitTabView.swift Alas/Sources/Center/Commit/CommitDiffView.swift Alas/Sources/Center/ReviewRequest/DraftReviewRequestTabView.swift AlasTests/DiffReviewSurfaceTests.swift AlasTests/DiffPaneViewTests.swift
+rtk git commit -m "feat(diff): enable LSP context in review surfaces"
+```
+
+---
+
+### Task 5: Manual Tests, Full Verification, And Cleanup
+
+**Files:**
+- Modify: `docs/manual-test.md`
+
+- [ ] **Step 1: Update manual test docs**
+
+In `docs/manual-test.md`, replace the diff pane LSP expectation:
+
+```markdown
+3. Hover over a symbol on the new/current side and confirm a popover appears with type info / docs after the language server is ready.
+4. Cmd-click a symbol on the new/current side and confirm Alas opens the definition in an editor tab.
+5. Confirm hover still does nothing on old/deleted-side lines.
+```
+
+- [ ] **Step 2: Run targeted test suites**
+
+Run:
+
+```bash
+rtk xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -only-testing:AlasTests/DiffPaneLSPLineMapTests -only-testing:AlasTests/DiffPaneViewTests -only-testing:AlasTests/DiffReviewSurfaceTests test
+```
+
+Expected: all targeted tests pass.
+
+- [ ] **Step 3: Regenerate the Xcode project**
+
+```bash
+rtk xcodegen
+```
+
+Expected: `Alas.xcodeproj` includes the new source and test files. If `project.yml` changes are required, commit both `project.yml` and `Alas.xcodeproj`.
+
+- [ ] **Step 4: Run required project verification**
+
+Run:
+
+```bash
+rtk xcodegen
+rtk xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -quiet build
+rtk xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' test
+```
+
+Expected: build and full test suite pass.
+
+- [ ] **Step 5: Commit docs and cleanup fixes**
+
+```bash
+rtk git add docs/manual-test.md Alas.xcodeproj project.yml
+rtk git add Alas/Sources AlasTests
+rtk git commit -m "test(diff): verify LSP-aware diff review"
+```
+
+If there are no changes after verification, do not create an empty commit.

--- a/docs/superpowers/specs/2026-06-12-lsp-aware-diff-design.md
+++ b/docs/superpowers/specs/2026-06-12-lsp-aware-diff-design.md
@@ -1,0 +1,129 @@
+# LSP-Aware Diff Design
+
+## Goal
+
+Make the new diff and review surfaces LSP-aware for code review without turning
+them into editors. The first version supports hover/type information and
+Cmd-click go-to-definition on the current/new side of text diffs. Completion,
+diagnostics, old-side intelligence, and historical virtual documents are out of
+scope.
+
+## Context
+
+Alas already has editor LSP support through `CodeEditorCoordinator`,
+`EditorBuffer`, and `WorkspaceLSPManager`. The review surfaces render diffs
+through `DiffPaneView`, `DiffPaneTextDocumentView`, and
+`DiffPaneCodeTextView`. `DiffDisplayLine` already carries source line numbers
+for old and new sides, which gives the diff enough information to map visible
+new-side rows back to positions in the real worktree file.
+
+Current manual testing documents the diff pane as syntax-highlight-only. This
+feature changes that behavior for renderable text diffs when a matching
+language server is available.
+
+## User-Facing Behavior
+
+- Hover over a symbol on a new/current-side diff line to show the same hover
+  information style used by the editor.
+- Cmd-click a symbol on a new/current-side diff line to go to its definition.
+- Old/deleted-side lines remain plain selectable diff text.
+- Files without a configured language server, deleted files, binary/image
+  files, or unrenderable diffs keep today's behavior.
+- LSP failures are quiet in the diff body: no popup, no inline error, and no
+  interruption to text selection.
+
+## Architecture
+
+Add a small read-only LSP layer around the existing diff text views.
+
+`DiffPaneLSPContext` describes the real document behind a rendered diff:
+worktree id, worktree root, relative path, inferred language id, and the
+navigation closure used to open definitions in editor tabs. The context is
+optional and is only created for files that have a current worktree path and a
+configured language.
+
+`DiffPaneLSPLineMap` is a pure mapping helper. It converts a character location
+inside a rendered diff text view into an LSP position for the real current file.
+It only returns positions for new-side lines. Split mode maps only the new
+pane. Stacked mode maps only rows whose anchor side is `.new`.
+
+`DiffPaneLSPController` is the AppKit lifecycle object attached to a
+`DiffPaneCodeTextView`. It installs hover and Cmd-click handlers, asks the line
+map for a real-file position, requests LSP hover or definition data from the
+existing LSP client, and reuses the editor popup/navigation behavior where
+practical.
+
+`DiffPaneTextDocumentBuilder.CodeDocument.LineMetadata` carries the source
+`DiffDisplayLine` for rows backed by real diff lines. This keeps the mapping
+close to the rendered attributed string instead of reconstructing rows from the
+display model later.
+
+When a diff file has no already-open editor buffer, the controller opens a
+balanced read-only LSP retain for the current worktree file by loading the file
+text from disk and calling the existing document-open path. The retain is owned
+by the mounted diff text view and is released when that view is replaced or
+tears down.
+
+## Data Flow
+
+When a diff file renders:
+
+1. The existing loader builds `ParsedDiff` and `DiffDisplayModel`.
+2. The owning tab builds an optional `DiffPaneLSPContext` if the file has a
+   current worktree path and maps to a configured language.
+3. `DiffPaneTextDocumentBuilder` emits attributed text plus line metadata for
+   every visible rendered row.
+4. `DiffPaneTextScrollView` receives the document, metadata, and optional LSP
+   context, then attaches or updates `DiffPaneLSPController`.
+5. On hover or Cmd-click, the text view converts the mouse point to a character
+   index.
+6. `DiffPaneLSPLineMap` maps that character index to the real file URI and
+   `LSPPosition(line: newLine - 1, character: offset)`.
+7. The controller uses `WorkspaceLSPManager.openedClient(forFile:worktreeRoot:language:)`
+   when a client already serves the file. If no client is open, it opens a
+   read-only LSP retain using the current file text from disk, then releases
+   that retain when the diff text view is replaced or tears down.
+8. Hover displays the existing hover popup. Definition opens the resolved
+   target through the same editor navigation path used by normal editor tabs.
+
+LSP positions always target the real current file. The diff layer must not send
+positions for synthetic diff text. If the diff has gone stale relative to disk,
+the controller should prefer no result over sending a known-wrong request.
+
+## Error Handling
+
+- No language, no LSP config, unavailable server, blocked server, starting
+  server, deleted file, or old-side line: do nothing.
+- Hover timeout, definition timeout, empty response, or request failure: do
+  nothing.
+- Definition outside the worktree: reuse the editor's external read-only file
+  behavior.
+- Stale line or character mapping: skip the request.
+- Background LSP opens created by a diff view must be balanced on teardown so a
+  review tab does not leave servers running indefinitely.
+
+## Testing
+
+Unit tests should cover `DiffPaneLSPLineMap`:
+
+- Split mode routes only new-pane rows.
+- Stacked mode routes only `.new` lines.
+- Old/deleted/collapsed/placeholder rows return no position.
+- Character offsets outside the rendered source text return no position.
+- Missing `newLine` returns no position.
+
+AppKit-focused tests should cover:
+
+- `DiffPaneTextScrollView` installs LSP handlers only when context exists.
+- Updating a diff section replaces stale line metadata.
+- Teardown removes hover/Cmd-click hooks and releases any retained LSP document.
+
+Manual tests should update the existing diff-pane section:
+
+- Stage or create a Swift change.
+- Open the review diff.
+- Hover over a symbol on the new/current side and confirm hover information
+  appears after the language server is ready.
+- Cmd-click a symbol on the new/current side and confirm Alas opens the
+  definition in an editor tab.
+- Confirm old/deleted-side hover still does nothing.


### PR DESCRIPTION
## Summary
- add source-aware diff row metadata and LSP position mapping for current-side rows
- add read-only diff hover and Cmd-click definition handling backed by existing editor LSP infrastructure
- wire diff LSP context through diff tabs, review changes, and commit review surfaces
- guard deleted/missing/stale diff rows and keep old-side rows non-LSP-aware

## Testing
- `rtk xcodegen`
- `rtk xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -quiet build`
- `rtk xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' test`