### PR TITLE
Add files-first PR review details

### DIFF
--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -135,6 +135,7 @@
 		21A94ADFA16F85C7ACAB4DA1 /* ACPMarkdownBlockCacheTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84E56989C04A4A478D68084C /* ACPMarkdownBlockCacheTests.swift */; };
 		21D97FBF7356BC50400E0265 /* CommitContextBuilderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 79F544A8DC56D0D4166E0A4F /* CommitContextBuilderTests.swift */; };
 		21DDC95793C87C46FB46E3D6 /* ImageDiffSwipeViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7018E992654E19345D8BD723 /* ImageDiffSwipeViewTests.swift */; };
+		21FBAF70DBD55FF57DAB796D /* ReviewRequestDiffLoaderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BCAB297DB983CBDD70CDDB24 /* ReviewRequestDiffLoaderTests.swift */; };
 		2281077800674169E69C6C3B /* HoverWindowControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C9032BA9542C617A09EF848 /* HoverWindowControllerTests.swift */; };
 		22FDE2FB05952993DA2D0EB7 /* WorkingTreeSectionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 866CFEB75B7F754485C6BE77 /* WorkingTreeSectionView.swift */; };
 		23013D3D2538AC2D1BD3403D /* ChangesTabView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C682FF74C86B77BDCF46CF25 /* ChangesTabView.swift */; };
@@ -965,6 +966,7 @@
 		EEB6534271EB7EA475A703DE /* HunkPatchBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A06D96DE3FEBF63E7A157DD /* HunkPatchBuilder.swift */; };
 		EF2540A211FBE06D7B30FC61 /* Code.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F4C58E8C0B1BC5B7CB2BBCB /* Code.swift */; };
 		EF276F4856AA2E82C2ECDC7E /* CodeHostModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = C96C5E43E973803E6FD1528C /* CodeHostModels.swift */; };
+		F04E4353813EB99D4459750F /* ReviewRequestDiffLoader.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD0A56D300AE7380A16F1D42 /* ReviewRequestDiffLoader.swift */; };
 		F078F588859E4B2E906D704A /* AlasToggle.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1841997CCBDB9611576B930C /* AlasToggle.swift */; };
 		F0CB2589DDF3082F6996A117 /* ACPPlanSidebarVisibilityTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 96A230290E0029D45CA1B907 /* ACPPlanSidebarVisibilityTests.swift */; };
 		F1299CAAD4DBF766CC56CB8F /* OpenSessions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4068B3E83F9A82C2E3F8A6A1 /* OpenSessions.swift */; };
@@ -1746,6 +1748,7 @@
 		BC3CA543A17D1C3DFA70A80C /* DraftCommitTabView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DraftCommitTabView.swift; sourceTree = "<group>"; };
 		BCA505FF2E6CFA8278C95C6E /* GhosttyConfigBuilder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GhosttyConfigBuilder.swift; sourceTree = "<group>"; };
 		BCA9015C063CDD90D021D928 /* TreeSitterCSS */ = {isa = PBXFileReference; lastKnownFileType = folder; name = TreeSitterCSS; path = ThirdParty/TreeSitterCSS; sourceTree = SOURCE_ROOT; };
+		BCAB297DB983CBDD70CDDB24 /* ReviewRequestDiffLoaderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReviewRequestDiffLoaderTests.swift; sourceTree = "<group>"; };
 		BCE0DA8D81AE8E0BFE54D279 /* ACPImageBlocksTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPImageBlocksTests.swift; sourceTree = "<group>"; };
 		BD4A3B9B1103346242438940 /* FilesTabView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FilesTabView.swift; sourceTree = "<group>"; };
 		BD708EEB35D93A7E7150981D /* ProjectsManagerHeadUpdatesTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProjectsManagerHeadUpdatesTests.swift; sourceTree = "<group>"; };
@@ -1821,6 +1824,7 @@
 		CC3CF39EE3E5E2AB9B0968B3 /* ACPToolCallCard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPToolCallCard.swift; sourceTree = "<group>"; };
 		CC83C13F9F6391F9CE8BF2CA /* MarkdownViewMode.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MarkdownViewMode.swift; sourceTree = "<group>"; };
 		CC958412AAB6B8788171F74A /* ReviewChangesLoaderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReviewChangesLoaderTests.swift; sourceTree = "<group>"; };
+		CD0A56D300AE7380A16F1D42 /* ReviewRequestDiffLoader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReviewRequestDiffLoader.swift; sourceTree = "<group>"; };
 		CD9289893FA7DC9DB8565353 /* MarkdownParser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MarkdownParser.swift; sourceTree = "<group>"; };
 		CDAE8FBBADF986E1E6585941 /* ReviewChangesModelsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReviewChangesModelsTests.swift; sourceTree = "<group>"; };
 		CDE49D2437D7E6AC9D67F136 /* RemoteSessionGateway.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteSessionGateway.swift; sourceTree = "<group>"; };
@@ -2777,6 +2781,7 @@
 				0299820D15A2A4C7838B2CE9 /* ReviewLoopState.swift */,
 				467E833E3CE05D82DB88C5C5 /* ReviewReadinessModel.swift */,
 				039C5E652B7A9457EB13BD70 /* ReviewRequestContextBuilder.swift */,
+				CD0A56D300AE7380A16F1D42 /* ReviewRequestDiffLoader.swift */,
 				CAB5BDBCB990CC0452BF9164 /* ReviewRequestDraft.swift */,
 			);
 			path = CodeHost;
@@ -3614,6 +3619,7 @@
 				3939B27EA8D7A562048E5932 /* ReviewLoopStateTests.swift */,
 				D52FB6333DDC1A21B0959C1B /* ReviewReadinessModelTests.swift */,
 				3979B98C0A060BB118239A5E /* ReviewRequestContextBuilderTests.swift */,
+				BCAB297DB983CBDD70CDDB24 /* ReviewRequestDiffLoaderTests.swift */,
 				5A1A152D4297DBB5B8DFF950 /* ReviewRequestDraftTests.swift */,
 			);
 			path = Integrations;
@@ -4525,6 +4531,7 @@
 				F5626F154B2CF446FF3F917B /* ReviewLoopState.swift in Sources */,
 				7BBF0BCBD3121E1C20EF93CA /* ReviewReadinessModel.swift in Sources */,
 				E541E14A713FB78AF4595FEB /* ReviewRequestContextBuilder.swift in Sources */,
+				F04E4353813EB99D4459750F /* ReviewRequestDiffLoader.swift in Sources */,
 				CDA1193EF673BA40A6548B2B /* ReviewRequestDraft.swift in Sources */,
 				2D80BC255AB24FA274617553 /* ReviewRequestPromptEditorWindow.swift in Sources */,
 				FBAB18AAEFB289EF765564C5 /* RightPaneSelectionState.swift in Sources */,
@@ -4977,6 +4984,7 @@
 				9654335704CB69BA7216DD63 /* ReviewLoopStateTests.swift in Sources */,
 				D8957FC6D928555E7C360B6E /* ReviewReadinessModelTests.swift in Sources */,
 				518D1D069F821B232469C414 /* ReviewRequestContextBuilderTests.swift in Sources */,
+				21FBAF70DBD55FF57DAB796D /* ReviewRequestDiffLoaderTests.swift in Sources */,
 				6B9E188A6C0A39C38D8723BF /* ReviewRequestDraftTests.swift in Sources */,
 				C35CB6B466364169DF2616C3 /* RightPaneSelectionStateResolverTests.swift in Sources */,
 				38EB2BAA50A7B7B37DDE2A4C /* RightPaneStateBaseBranchTests.swift in Sources */,

--- a/Alas/Sources/Center/DiffReview/DiffReviewFileSection.swift
+++ b/Alas/Sources/Center/DiffReview/DiffReviewFileSection.swift
@@ -16,7 +16,7 @@ struct DiffReviewFileSection: View {
     var body: some View {
         VStack(spacing: 0) {
             header
-            inlineFeedbackStack
+            fileLevelInlineFeedbackStack
             content
         }
         .background(theme.color("bg-1"))
@@ -88,9 +88,17 @@ struct DiffReviewFileSection: View {
     }
 
     @ViewBuilder
-    private var inlineFeedbackStack: some View {
-        if !inlineFeedback.isEmpty {
-            let display = DiffReviewInlineFeedbackDisplayPolicy.display(for: inlineFeedback)
+    private var fileLevelInlineFeedbackStack: some View {
+        let fileLevel = inlineFeedbackPlacement.fileLevel
+        if !fileLevel.isEmpty {
+            inlineFeedbackStack(fileLevel)
+        }
+    }
+
+    @ViewBuilder
+    private func inlineFeedbackStack(_ items: [DiffReviewInlineFeedback]) -> some View {
+        if !items.isEmpty {
+            let display = DiffReviewInlineFeedbackDisplayPolicy.display(for: items)
             VStack(alignment: .leading, spacing: 6) {
                 ForEach(display.visibleItems) { item in
                     DiffReviewInlineFeedbackCard(item: item)
@@ -106,22 +114,37 @@ struct DiffReviewFileSection: View {
         }
     }
 
+    private var inlineFeedbackPlacement: DiffReviewInlineFeedbackPlacement.Result {
+        guard let displayModel = file.displayModel else {
+            return DiffReviewInlineFeedbackPlacement.Result(fileLevel: inlineFeedback, byGroupID: [:])
+        }
+        return DiffReviewInlineFeedbackPlacement.position(inlineFeedback, in: displayModel.groups)
+    }
+
     @ViewBuilder
     private var content: some View {
         if let displayModel = file.displayModel {
-            DiffPaneView(
-                model: displayModel,
-                fileExtension: LanguageRegistry.highlighterExtension(forPath: file.summary.path),
-                layoutMode: $layoutMode,
-                wrapLines: $wrapLines,
-                showWhitespace: $showWhitespace,
-                codeFontFamily: codeFontFamily,
-                codeFontSize: codeFontSize,
-                showsToolbar: false,
-                verticalScrollMode: .staticHeight,
-                lspContext: lspContext,
-                hunkActions: { _ in DiffPaneHunkActions() }
-            )
+            let placement = inlineFeedbackPlacement
+            VStack(spacing: 0) {
+                ForEach(displayModel.groups) { group in
+                    if let groupFeedback = placement.byGroupID[group.id], !groupFeedback.isEmpty {
+                        inlineFeedbackStack(groupFeedback)
+                    }
+                    DiffPaneView(
+                        model: DiffDisplayModel(filePath: displayModel.filePath, groups: [group]),
+                        fileExtension: LanguageRegistry.highlighterExtension(forPath: file.summary.path),
+                        layoutMode: $layoutMode,
+                        wrapLines: $wrapLines,
+                        showWhitespace: $showWhitespace,
+                        codeFontFamily: codeFontFamily,
+                        codeFontSize: codeFontSize,
+                        showsToolbar: false,
+                        verticalScrollMode: .staticHeight,
+                        lspContext: lspContext,
+                        hunkActions: { _ in DiffPaneHunkActions() }
+                    )
+                }
+            }
         } else {
             let message = file.placeholderMessage ?? "This file cannot be rendered in the review view."
             Text(message)
@@ -182,6 +205,71 @@ struct DiffReviewFileSection: View {
             theme.color("warn")
         case .modified, .unknown:
             theme.color("fg-dim")
+        }
+    }
+}
+
+enum DiffReviewInlineFeedbackPlacement {
+    struct Result: Equatable {
+        let fileLevel: [DiffReviewInlineFeedback]
+        let byGroupID: [String: [DiffReviewInlineFeedback]]
+    }
+
+    static func position(
+        _ items: [DiffReviewInlineFeedback],
+        in groups: [DiffDisplayGroup]
+    ) -> Result {
+        var fileLevel: [DiffReviewInlineFeedback] = []
+        var byGroupID: [String: [DiffReviewInlineFeedback]] = [:]
+
+        for item in items {
+            guard let line = item.anchor.line,
+                  let group = groups.first(where: { contains(line: line, side: item.anchor.side, in: $0) })
+            else {
+                fileLevel.append(item)
+                continue
+            }
+            byGroupID[group.id, default: []].append(item)
+        }
+
+        return Result(fileLevel: fileLevel, byGroupID: byGroupID)
+    }
+
+    private static func contains(
+        line: Int,
+        side: DiffReviewInlineFeedbackSide,
+        in group: DiffDisplayGroup
+    ) -> Bool {
+        group.rows.contains { row in
+            contains(line: line, side: side, in: row)
+        }
+    }
+
+    private static func contains(
+        line: Int,
+        side: DiffReviewInlineFeedbackSide,
+        in row: DiffDisplayRow
+    ) -> Bool {
+        if rowMatches(line: line, side: side, row: row) {
+            return true
+        }
+        return row.collapsedRows.contains { collapsedRow in
+            contains(line: line, side: side, in: collapsedRow)
+        }
+    }
+
+    private static func rowMatches(
+        line: Int,
+        side: DiffReviewInlineFeedbackSide,
+        row: DiffDisplayRow
+    ) -> Bool {
+        switch side {
+        case .new:
+            return row.new?.lineNumber == line
+        case .old:
+            return row.old?.lineNumber == line
+        case .unknown:
+            return row.new?.lineNumber == line || row.old?.lineNumber == line
         }
     }
 }

--- a/Alas/Sources/Center/DiffReview/DiffReviewFileSection.swift
+++ b/Alas/Sources/Center/DiffReview/DiffReviewFileSection.swift
@@ -188,7 +188,7 @@ struct DiffReviewFileSection: View {
 
 enum DiffReviewInlineFeedbackDisplayPolicy {
     static let maximumVisibleCards = 3
-    static let cardEstimatedHeight: CGFloat = 54
+    static let cardEstimatedHeight: CGFloat = 78
     static let moreRowEstimatedHeight: CGFloat = 20
     private static let stackVerticalPadding: CGFloat = 20
     private static let rowSpacing: CGFloat = 6
@@ -255,12 +255,12 @@ private struct DiffReviewInlineFeedbackCard: View {
                     .font(.system(size: 11.5))
                     .foregroundColor(theme.color("fg"))
                     .lineLimit(3)
-                    .fixedSize(horizontal: false, vertical: true)
             }
 
             Spacer(minLength: 0)
         }
         .padding(8)
+        .frame(height: DiffReviewInlineFeedbackDisplayPolicy.cardEstimatedHeight, alignment: .top)
         .background(theme.color("bg-2"))
         .clipShape(RoundedRectangle(cornerRadius: 6))
         .overlay(

--- a/Alas/Sources/Center/DiffReview/DiffReviewFileSection.swift
+++ b/Alas/Sources/Center/DiffReview/DiffReviewFileSection.swift
@@ -308,6 +308,18 @@ enum DiffReviewInlineFeedbackDisplayPolicy {
     }
 }
 
+enum DiffReviewInlineFeedbackMarkdown {
+    @MainActor
+    static func render(_ source: String) -> AttributedString {
+        ACPMarkdownText.inlineMarkdown(source)
+    }
+
+    @MainActor
+    static func plainText(_ source: String) -> String {
+        NSAttributedString(render(source)).string
+    }
+}
+
 private struct DiffReviewInlineFeedbackCard: View {
     let item: DiffReviewInlineFeedback
 
@@ -339,7 +351,7 @@ private struct DiffReviewInlineFeedbackCard: View {
                 }
                 .lineLimit(1)
 
-                Text(item.bodyPreview)
+                Text(DiffReviewInlineFeedbackMarkdown.render(item.bodyPreview))
                     .font(.system(size: 11.5))
                     .foregroundColor(theme.color("fg"))
                     .lineLimit(3)
@@ -368,7 +380,7 @@ private struct DiffReviewInlineFeedbackCard: View {
             item.providerName,
             item.author,
             item.anchor.line.map { "line \($0)" },
-            item.bodyPreview,
+            DiffReviewInlineFeedbackMarkdown.plainText(item.bodyPreview),
         ]
         .compactMap { part in
             guard let part, !part.isEmpty else { return nil }

--- a/Alas/Sources/Center/DiffReview/DiffReviewFileSection.swift
+++ b/Alas/Sources/Center/DiffReview/DiffReviewFileSection.swift
@@ -90,9 +90,13 @@ struct DiffReviewFileSection: View {
     @ViewBuilder
     private var inlineFeedbackStack: some View {
         if !inlineFeedback.isEmpty {
+            let display = DiffReviewInlineFeedbackDisplayPolicy.display(for: inlineFeedback)
             VStack(alignment: .leading, spacing: 6) {
-                ForEach(inlineFeedback) { item in
+                ForEach(display.visibleItems) { item in
                     DiffReviewInlineFeedbackCard(item: item)
+                }
+                if display.hiddenCount > 0 {
+                    DiffReviewInlineFeedbackMoreRow(hiddenCount: display.hiddenCount)
                 }
             }
             .padding(.horizontal, 14)
@@ -182,6 +186,40 @@ struct DiffReviewFileSection: View {
     }
 }
 
+enum DiffReviewInlineFeedbackDisplayPolicy {
+    static let maximumVisibleCards = 3
+    static let cardEstimatedHeight: CGFloat = 54
+    static let moreRowEstimatedHeight: CGFloat = 20
+    private static let stackVerticalPadding: CGFloat = 20
+    private static let rowSpacing: CGFloat = 6
+
+    struct Display {
+        let visibleItems: [DiffReviewInlineFeedback]
+        let hiddenCount: Int
+    }
+
+    static func display(for items: [DiffReviewInlineFeedback]) -> Display {
+        let visibleItems = Array(items.prefix(maximumVisibleCards))
+        return Display(
+            visibleItems: visibleItems,
+            hiddenCount: max(0, items.count - visibleItems.count)
+        )
+    }
+
+    static func estimatedHeight(for itemCount: Int) -> CGFloat {
+        guard itemCount > 0 else { return 0 }
+
+        let visibleCount = min(itemCount, maximumVisibleCards)
+        let hiddenCount = max(0, itemCount - visibleCount)
+        let rowCount = visibleCount + (hiddenCount > 0 ? 1 : 0)
+        let rowHeights = CGFloat(visibleCount) * cardEstimatedHeight
+            + (hiddenCount > 0 ? moreRowEstimatedHeight : 0)
+        let spacingHeight = CGFloat(max(0, rowCount - 1)) * rowSpacing
+
+        return stackVerticalPadding + rowHeights + spacingHeight
+    }
+}
+
 private struct DiffReviewInlineFeedbackCard: View {
     let item: DiffReviewInlineFeedback
 
@@ -262,6 +300,29 @@ private struct DiffReviewInlineFeedbackCard: View {
         case .cancelled, .unknown:
             theme.color("fg-muted")
         }
+    }
+}
+
+private struct DiffReviewInlineFeedbackMoreRow: View {
+    let hiddenCount: Int
+
+    @Environment(\.theme) private var theme
+
+    var body: some View {
+        Text("+\(hiddenCount) more feedback")
+            .font(.system(size: 10.5, weight: .medium))
+            .foregroundColor(theme.color("fg-muted"))
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .padding(.horizontal, 8)
+            .frame(height: 20)
+            .background(theme.color("bg-2"))
+            .clipShape(RoundedRectangle(cornerRadius: 6))
+            .background(
+                DiffReviewAccessibilityMarker(
+                    identifier: "diff-review-inline-feedback-more",
+                    label: "+\(hiddenCount) more feedback"
+                )
+            )
     }
 }
 

--- a/Alas/Sources/Center/DiffReview/DiffReviewFileSection.swift
+++ b/Alas/Sources/Center/DiffReview/DiffReviewFileSection.swift
@@ -2,6 +2,7 @@ import SwiftUI
 
 struct DiffReviewFileSection: View {
     let file: DiffReviewFileSectionModel
+    var inlineFeedback: [DiffReviewInlineFeedback] = []
     @Binding var layoutMode: DiffLayoutMode
     @Binding var wrapLines: Bool
     @Binding var showWhitespace: Bool
@@ -15,6 +16,7 @@ struct DiffReviewFileSection: View {
     var body: some View {
         VStack(spacing: 0) {
             header
+            inlineFeedbackStack
             content
         }
         .background(theme.color("bg-1"))
@@ -83,6 +85,21 @@ struct DiffReviewFileSection: View {
         .padding(.vertical, 10)
         .background(theme.color("bg-2"))
         .overlay(Rectangle().fill(theme.color("line")).frame(height: 0.5), alignment: .bottom)
+    }
+
+    @ViewBuilder
+    private var inlineFeedbackStack: some View {
+        if !inlineFeedback.isEmpty {
+            VStack(alignment: .leading, spacing: 6) {
+                ForEach(inlineFeedback) { item in
+                    DiffReviewInlineFeedbackCard(item: item)
+                }
+            }
+            .padding(.horizontal, 14)
+            .padding(.vertical, 10)
+            .background(theme.color("bg-1"))
+            .overlay(Rectangle().fill(theme.color("line")).frame(height: 0.5), alignment: .bottom)
+        }
     }
 
     @ViewBuilder
@@ -161,6 +178,89 @@ struct DiffReviewFileSection: View {
             theme.color("warn")
         case .modified, .unknown:
             theme.color("fg-dim")
+        }
+    }
+}
+
+private struct DiffReviewInlineFeedbackCard: View {
+    let item: DiffReviewInlineFeedback
+
+    @Environment(\.theme) private var theme
+
+    var body: some View {
+        HStack(alignment: .top, spacing: 8) {
+            RoundedRectangle(cornerRadius: 2)
+                .fill(statusColor)
+                .frame(width: 3)
+
+            VStack(alignment: .leading, spacing: 4) {
+                HStack(spacing: 6) {
+                    Text(item.providerName)
+                        .font(.system(size: 10, weight: .semibold))
+                        .foregroundColor(statusColor)
+
+                    if let author = item.author, !author.isEmpty {
+                        Text(author)
+                            .font(.system(size: 10))
+                            .foregroundColor(theme.color("fg-muted"))
+                    }
+
+                    if let line = item.anchor.line {
+                        Text("line \(line)")
+                            .font(.system(size: 10))
+                            .foregroundColor(theme.color("fg-faint"))
+                    }
+                }
+                .lineLimit(1)
+
+                Text(item.bodyPreview)
+                    .font(.system(size: 11.5))
+                    .foregroundColor(theme.color("fg"))
+                    .lineLimit(3)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+
+            Spacer(minLength: 0)
+        }
+        .padding(8)
+        .background(theme.color("bg-2"))
+        .clipShape(RoundedRectangle(cornerRadius: 6))
+        .overlay(
+            RoundedRectangle(cornerRadius: 6)
+                .stroke(theme.color("line"), lineWidth: 0.5)
+        )
+        .background(
+            DiffReviewAccessibilityMarker(
+                identifier: "diff-review-inline-feedback-\(item.id)",
+                label: accessibilityLabel
+            )
+        )
+    }
+
+    private var accessibilityLabel: String {
+        [
+            item.providerName,
+            item.author,
+            item.anchor.line.map { "line \($0)" },
+            item.bodyPreview,
+        ]
+        .compactMap { part in
+            guard let part, !part.isEmpty else { return nil }
+            return part
+        }
+        .joined(separator: ", ")
+    }
+
+    private var statusColor: Color {
+        switch item.status {
+        case .actionable, .pending:
+            theme.color("accent")
+        case .failed:
+            theme.color("del")
+        case .passed, .resolved:
+            theme.color("add")
+        case .cancelled, .unknown:
+            theme.color("fg-muted")
         }
     }
 }

--- a/Alas/Sources/Center/DiffReview/DiffReviewFileSection.swift
+++ b/Alas/Sources/Center/DiffReview/DiffReviewFileSection.swift
@@ -276,8 +276,11 @@ enum DiffReviewInlineFeedbackPlacement {
 
 enum DiffReviewInlineFeedbackDisplayPolicy {
     static let maximumVisibleCards = 3
-    static let cardEstimatedHeight: CGFloat = 78
+    static let cardMinimumHeight: CGFloat = 78
     static let moreRowEstimatedHeight: CGFloat = 20
+    private static let estimatedBodyCharactersPerLine = 86
+    private static let estimatedBodyLineHeight: CGFloat = 15.5
+    private static let cardNonBodyHeight: CGFloat = 46
     private static let stackVerticalPadding: CGFloat = 20
     private static let rowSpacing: CGFloat = 6
 
@@ -300,11 +303,39 @@ enum DiffReviewInlineFeedbackDisplayPolicy {
         let visibleCount = min(itemCount, maximumVisibleCards)
         let hiddenCount = max(0, itemCount - visibleCount)
         let rowCount = visibleCount + (hiddenCount > 0 ? 1 : 0)
-        let rowHeights = CGFloat(visibleCount) * cardEstimatedHeight
+        let rowHeights = CGFloat(visibleCount) * cardMinimumHeight
             + (hiddenCount > 0 ? moreRowEstimatedHeight : 0)
         let spacingHeight = CGFloat(max(0, rowCount - 1)) * rowSpacing
 
         return stackVerticalPadding + rowHeights + spacingHeight
+    }
+
+    static func estimatedHeight(for items: [DiffReviewInlineFeedback]) -> CGFloat {
+        guard !items.isEmpty else { return 0 }
+
+        let display = display(for: items)
+        let visibleHeights = display.visibleItems.reduce(CGFloat(0)) { total, item in
+            total + estimatedCardHeight(for: item)
+        }
+        let rowCount = display.visibleItems.count + (display.hiddenCount > 0 ? 1 : 0)
+        let moreHeight = display.hiddenCount > 0 ? moreRowEstimatedHeight : 0
+        let spacingHeight = CGFloat(max(0, rowCount - 1)) * rowSpacing
+
+        return stackVerticalPadding + visibleHeights + moreHeight + spacingHeight
+    }
+
+    static func estimatedCardHeight(for item: DiffReviewInlineFeedback) -> CGFloat {
+        let bodyLineCount = estimatedLineCount(for: item.bodyPreview)
+        let bodyHeight = CGFloat(bodyLineCount) * estimatedBodyLineHeight
+
+        return max(cardMinimumHeight, cardNonBodyHeight + bodyHeight)
+    }
+
+    private static func estimatedLineCount(for source: String) -> Int {
+        let logicalLines = source.split(separator: "\n", omittingEmptySubsequences: false)
+        return logicalLines.reduce(0) { total, line in
+            total + max(1, Int(ceil(Double(line.count) / Double(estimatedBodyCharactersPerLine))))
+        }
     }
 }
 
@@ -354,13 +385,14 @@ private struct DiffReviewInlineFeedbackCard: View {
                 Text(DiffReviewInlineFeedbackMarkdown.render(item.bodyPreview))
                     .font(.system(size: 11.5))
                     .foregroundColor(theme.color("fg"))
-                    .lineLimit(3)
+                    .fixedSize(horizontal: false, vertical: true)
             }
+            .frame(maxWidth: .infinity, alignment: .leading)
 
             Spacer(minLength: 0)
         }
         .padding(8)
-        .frame(height: DiffReviewInlineFeedbackDisplayPolicy.cardEstimatedHeight, alignment: .top)
+        .frame(minHeight: DiffReviewInlineFeedbackDisplayPolicy.cardMinimumHeight, alignment: .top)
         .background(theme.color("bg-2"))
         .clipShape(RoundedRectangle(cornerRadius: 6))
         .overlay(

--- a/Alas/Sources/Center/DiffReview/DiffReviewModels.swift
+++ b/Alas/Sources/Center/DiffReview/DiffReviewModels.swift
@@ -8,6 +8,31 @@ struct DiffReviewFileID: Codable, Equatable, Hashable, Identifiable {
     var rawValue: String { "\(namespace):\(path)" }
 }
 
+enum DiffReviewInlineFeedbackSide: String, Codable, Equatable, Sendable {
+    case old
+    case new
+    case unknown
+}
+
+struct DiffReviewInlineFeedbackAnchor: Hashable, Codable, Equatable, Sendable {
+    let path: String
+    let line: Int?
+    let side: DiffReviewInlineFeedbackSide
+
+    var isFileLevel: Bool { line == nil }
+}
+
+struct DiffReviewInlineFeedback: Identifiable, Codable, Equatable, Sendable {
+    let id: String
+    let providerName: String
+    let author: String?
+    let bodyPreview: String
+    let status: ReviewEvidenceStatus
+    let providerURL: URL?
+    let anchor: DiffReviewInlineFeedbackAnchor
+    let evidenceItemID: String
+}
+
 enum DiffReviewFileStatus: String, Codable, Equatable, Hashable {
     case added
     case modified

--- a/Alas/Sources/Center/DiffReview/DiffReviewScrollSpy.swift
+++ b/Alas/Sources/Center/DiffReview/DiffReviewScrollSpy.swift
@@ -97,3 +97,85 @@ struct DiffReviewProgrammaticScrollController: Equatable {
         !isSuppressing || id == target
     }
 }
+
+struct DiffReviewScrollCommand: Equatable {
+    let id: DiffReviewFileID
+    let generation: Int
+}
+
+struct DiffReviewScrollCommandController: Equatable {
+    private var generation = 0
+
+    mutating func command(to id: DiffReviewFileID) -> DiffReviewScrollCommand {
+        generation += 1
+        return DiffReviewScrollCommand(id: id, generation: generation)
+    }
+}
+
+enum DiffReviewRenderWindow {
+    private static let leadingScreens: CGFloat = 1.25
+    private static let trailingScreens: CGFloat = 2.5
+
+    static func renderedFileIDs(
+        current: Set<DiffReviewFileID>,
+        frames: [DiffReviewSectionFrame],
+        viewportHeight: CGFloat,
+        selectedFileID: DiffReviewFileID?,
+        programmaticTarget: DiffReviewFileID?,
+        firstFileID: DiffReviewFileID?
+    ) -> Set<DiffReviewFileID> {
+        var rendered = Set(frames.compactMap { frame -> DiffReviewFileID? in
+            guard isNearViewport(frame, viewportHeight: viewportHeight) else { return nil }
+            return frame.id
+        })
+
+        if frames.isEmpty || rendered.isEmpty {
+            rendered.formUnion(current)
+        }
+
+        if let selectedFileID {
+            rendered.insert(selectedFileID)
+        }
+        if let programmaticTarget {
+            rendered.insert(programmaticTarget)
+        }
+        if let firstFileID {
+            rendered.insert(firstFileID)
+        }
+
+        return rendered
+    }
+
+    private static func isNearViewport(_ frame: DiffReviewSectionFrame, viewportHeight: CGFloat) -> Bool {
+        let height = max(viewportHeight, 1)
+        let minY = -height * leadingScreens
+        let maxY = height * trailingScreens
+        return frame.maxY >= minY && frame.minY <= maxY
+    }
+}
+
+enum DiffReviewFileSectionHeightEstimator {
+    private static let fileHeaderHeight: CGFloat = 45
+    private static let hunkHeaderHeight: CGFloat = 38
+    private static let hunkVerticalPadding: CGFloat = 20
+    private static let rowHeight: CGFloat = 22
+    private static let hunkSpacing: CGFloat = 10
+    private static let minimumHeight: CGFloat = 116
+
+    static func estimatedHeight(for file: DiffReviewFileSectionModel) -> CGFloat {
+        guard let displayModel = file.displayModel else {
+            return minimumHeight
+        }
+
+        let bodyHeight = displayModel.groups.reduce(CGFloat(0)) { total, group in
+            let rowCount = max(group.rows.count, 1)
+            return total
+                + hunkHeaderHeight
+                + hunkVerticalPadding
+                + CGFloat(rowCount) * rowHeight
+                + hunkSpacing
+        }
+
+        return max(minimumHeight, fileHeaderHeight + bodyHeight)
+    }
+}

--- a/Alas/Sources/Center/DiffReview/DiffReviewSurface.swift
+++ b/Alas/Sources/Center/DiffReview/DiffReviewSurface.swift
@@ -107,10 +107,11 @@ struct DiffReviewSurface: View {
 
     @ViewBuilder
     private func fileSection(_ file: DiffReviewFileSectionModel, isRendered: Bool) -> some View {
+        let inlineFeedback = inlineFeedbackByFileID[file.id] ?? []
         if isRendered {
             DiffReviewFileSection(
                 file: file,
-                inlineFeedback: inlineFeedbackByFileID[file.id] ?? [],
+                inlineFeedback: inlineFeedback,
                 layoutMode: $layoutMode,
                 wrapLines: $wrapLines,
                 showWhitespace: $showWhitespace,
@@ -122,7 +123,10 @@ struct DiffReviewSurface: View {
         } else {
             DiffReviewFileSectionPlaceholder(
                 file: file,
-                estimatedHeight: DiffReviewFileSectionHeightEstimator.estimatedHeight(for: file),
+                estimatedHeight: DiffReviewFileSectionHeightEstimator.estimatedHeight(
+                    for: file,
+                    inlineFeedbackCount: inlineFeedback.count
+                ),
                 showsSourceBadge: showsSourceBadges,
                 codeFontFamily: codeFontFamily,
                 codeFontSize: codeFontSize
@@ -249,6 +253,13 @@ enum DiffReviewSurfaceSelectionSync {
             fileSetKey: nextFileSetKey,
             programmaticScroll: didChangeFileSet ? DiffReviewProgrammaticScrollController() : programmaticScroll
         )
+    }
+}
+
+extension DiffReviewFileSectionHeightEstimator {
+    static func estimatedHeight(for file: DiffReviewFileSectionModel, inlineFeedbackCount: Int) -> CGFloat {
+        estimatedHeight(for: file)
+            + DiffReviewInlineFeedbackDisplayPolicy.estimatedHeight(for: inlineFeedbackCount)
     }
 }
 

--- a/Alas/Sources/Center/DiffReview/DiffReviewSurface.swift
+++ b/Alas/Sources/Center/DiffReview/DiffReviewSurface.swift
@@ -125,7 +125,7 @@ struct DiffReviewSurface: View {
                 file: file,
                 estimatedHeight: DiffReviewFileSectionHeightEstimator.estimatedHeight(
                     for: file,
-                    inlineFeedbackCount: inlineFeedback.count
+                    inlineFeedback: inlineFeedback
                 ),
                 showsSourceBadge: showsSourceBadges,
                 codeFontFamily: codeFontFamily,
@@ -260,6 +260,25 @@ extension DiffReviewFileSectionHeightEstimator {
     static func estimatedHeight(for file: DiffReviewFileSectionModel, inlineFeedbackCount: Int) -> CGFloat {
         estimatedHeight(for: file)
             + DiffReviewInlineFeedbackDisplayPolicy.estimatedHeight(for: inlineFeedbackCount)
+    }
+
+    static func estimatedHeight(
+        for file: DiffReviewFileSectionModel,
+        inlineFeedback: [DiffReviewInlineFeedback]
+    ) -> CGFloat {
+        guard let displayModel = file.displayModel else {
+            return estimatedHeight(for: file, inlineFeedbackCount: inlineFeedback.count)
+        }
+
+        let placement = DiffReviewInlineFeedbackPlacement.position(inlineFeedback, in: displayModel.groups)
+        let fileLevelHeight = DiffReviewInlineFeedbackDisplayPolicy.estimatedHeight(
+            for: placement.fileLevel.count
+        )
+        let groupHeights = placement.byGroupID.values.reduce(CGFloat(0)) { total, groupFeedback in
+            total + DiffReviewInlineFeedbackDisplayPolicy.estimatedHeight(for: groupFeedback.count)
+        }
+
+        return estimatedHeight(for: file) + fileLevelHeight + groupHeights
     }
 }
 

--- a/Alas/Sources/Center/DiffReview/DiffReviewSurface.swift
+++ b/Alas/Sources/Center/DiffReview/DiffReviewSurface.swift
@@ -267,15 +267,14 @@ extension DiffReviewFileSectionHeightEstimator {
         inlineFeedback: [DiffReviewInlineFeedback]
     ) -> CGFloat {
         guard let displayModel = file.displayModel else {
-            return estimatedHeight(for: file, inlineFeedbackCount: inlineFeedback.count)
+            return estimatedHeight(for: file)
+                + DiffReviewInlineFeedbackDisplayPolicy.estimatedHeight(for: inlineFeedback)
         }
 
         let placement = DiffReviewInlineFeedbackPlacement.position(inlineFeedback, in: displayModel.groups)
-        let fileLevelHeight = DiffReviewInlineFeedbackDisplayPolicy.estimatedHeight(
-            for: placement.fileLevel.count
-        )
+        let fileLevelHeight = DiffReviewInlineFeedbackDisplayPolicy.estimatedHeight(for: placement.fileLevel)
         let groupHeights = placement.byGroupID.values.reduce(CGFloat(0)) { total, groupFeedback in
-            total + DiffReviewInlineFeedbackDisplayPolicy.estimatedHeight(for: groupFeedback.count)
+            total + DiffReviewInlineFeedbackDisplayPolicy.estimatedHeight(for: groupFeedback)
         }
 
         return estimatedHeight(for: file) + fileLevelHeight + groupHeights

--- a/Alas/Sources/Center/DiffReview/DiffReviewSurface.swift
+++ b/Alas/Sources/Center/DiffReview/DiffReviewSurface.swift
@@ -12,6 +12,7 @@ struct DiffReviewSurface: View {
     var showsSourceBadges: Bool = true
     var showsRailDisplayControls: Bool = false
     var lspContextForFile: (DiffReviewFileSectionModel) -> DiffPaneLSPContext? = { _ in nil }
+    var inlineFeedbackByFileID: [DiffReviewFileID: [DiffReviewInlineFeedback]] = [:]
 
     @Environment(\.theme) private var theme
     @State private var programmaticScroll = DiffReviewProgrammaticScrollController()
@@ -109,6 +110,7 @@ struct DiffReviewSurface: View {
         if isRendered {
             DiffReviewFileSection(
                 file: file,
+                inlineFeedback: inlineFeedbackByFileID[file.id] ?? [],
                 layoutMode: $layoutMode,
                 wrapLines: $wrapLines,
                 showWhitespace: $showWhitespace,

--- a/Alas/Sources/Center/DiffReview/DiffReviewSurface.swift
+++ b/Alas/Sources/Center/DiffReview/DiffReviewSurface.swift
@@ -15,6 +15,9 @@ struct DiffReviewSurface: View {
 
     @Environment(\.theme) private var theme
     @State private var programmaticScroll = DiffReviewProgrammaticScrollController()
+    @State private var scrollCommandController = DiffReviewScrollCommandController()
+    @State private var scrollCommand: DiffReviewScrollCommand?
+    @State private var renderedFileIDs: Set<DiffReviewFileID> = []
     @State private var synchronizedFileSetKey: String?
 
     private static let scrollCoordinateSpace = "diff-review-scroll"
@@ -51,53 +54,89 @@ struct DiffReviewSurface: View {
             set: { selectedFileID = $0 }
         )
 
-        return ScrollViewReader { scrollProxy in
-            HStack(spacing: 0) {
-                DiffReviewRail(
-                    session: session.summary,
-                    selectedFileID: selectedBinding,
-                    collapsed: $railCollapsed,
-                    displayControls: showsRailDisplayControls ? DiffReviewDisplayControlBindings(
-                        layoutMode: $layoutMode,
-                        wrapLines: $wrapLines,
-                        showWhitespace: $showWhitespace
-                    ) : nil,
-                    onSelectFile: { id in
-                        scrollToFile(id, proxy: scrollProxy)
-                    }
-                )
-                mainReviewStream(session)
-            }
+        return HStack(spacing: 0) {
+            DiffReviewRail(
+                session: session.summary,
+                selectedFileID: selectedBinding,
+                collapsed: $railCollapsed,
+                displayControls: showsRailDisplayControls ? DiffReviewDisplayControlBindings(
+                    layoutMode: $layoutMode,
+                    wrapLines: $wrapLines,
+                    showWhitespace: $showWhitespace
+                ) : nil,
+                onSelectFile: scrollToFile
+            )
+            mainReviewStream(session, firstFileID: firstFileID)
         }
     }
 
-    private func mainReviewStream(_ session: DiffReviewLoadedSession) -> some View {
+    private func mainReviewStream(_ session: DiffReviewLoadedSession, firstFileID: DiffReviewFileID) -> some View {
         GeometryReader { viewport in
-            ScrollView(.vertical) {
-                LazyVStack(alignment: .leading, spacing: 14) {
-                    ForEach(session.files) { file in
-                        DiffReviewFileSection(
-                            file: file,
-                            layoutMode: $layoutMode,
-                            wrapLines: $wrapLines,
-                            showWhitespace: $showWhitespace,
-                            codeFontFamily: codeFontFamily,
-                            codeFontSize: codeFontSize,
-                            showsSourceBadge: showsSourceBadges,
-                            lspContext: lspContextForFile(file)
-                        )
-                        .id(file.summary.id.rawValue)
-                        .background(sectionFrameReader(for: file.summary.id))
+            ScrollViewReader { scrollProxy in
+                ScrollView(.vertical) {
+                    LazyVStack(alignment: .leading, spacing: 14) {
+                        let renderedIDs = effectiveRenderedFileIDs(firstFileID: firstFileID)
+                        ForEach(session.files) { file in
+                            fileSection(file, isRendered: renderedIDs.contains(file.id))
+                                .id(file.summary.id.rawValue)
+                                .background(sectionFrameReader(for: file.summary.id))
+                        }
+                    }
+                    .padding(16)
+                }
+                .coordinateSpace(name: Self.scrollCoordinateSpace)
+                .onPreferenceChange(DiffReviewSectionFramePreferenceKey.self) { frames in
+                    updateSelectedFileFromScroll(frames: frames, viewportHeight: viewport.size.height)
+                    updateRenderedFileIDs(
+                        frames: frames,
+                        viewportHeight: viewport.size.height,
+                        firstFileID: firstFileID
+                    )
+                }
+                .onChange(of: scrollCommand) { _, command in
+                    guard let command else { return }
+                    withAnimation(.easeInOut(duration: 0.18)) {
+                        scrollProxy.scrollTo(command.id.rawValue, anchor: .top)
                     }
                 }
-                .padding(16)
-            }
-            .coordinateSpace(name: Self.scrollCoordinateSpace)
-            .onPreferenceChange(DiffReviewSectionFramePreferenceKey.self) { frames in
-                updateSelectedFileFromScroll(frames: frames, viewportHeight: viewport.size.height)
             }
         }
         .background(theme.color("bg-1"))
+    }
+
+    @ViewBuilder
+    private func fileSection(_ file: DiffReviewFileSectionModel, isRendered: Bool) -> some View {
+        if isRendered {
+            DiffReviewFileSection(
+                file: file,
+                layoutMode: $layoutMode,
+                wrapLines: $wrapLines,
+                showWhitespace: $showWhitespace,
+                codeFontFamily: codeFontFamily,
+                codeFontSize: codeFontSize,
+                showsSourceBadge: showsSourceBadges,
+                lspContext: lspContextForFile(file)
+            )
+        } else {
+            DiffReviewFileSectionPlaceholder(
+                file: file,
+                estimatedHeight: DiffReviewFileSectionHeightEstimator.estimatedHeight(for: file),
+                showsSourceBadge: showsSourceBadges,
+                codeFontFamily: codeFontFamily,
+                codeFontSize: codeFontSize
+            )
+        }
+    }
+
+    private func effectiveRenderedFileIDs(firstFileID: DiffReviewFileID) -> Set<DiffReviewFileID> {
+        DiffReviewRenderWindow.renderedFileIDs(
+            current: renderedFileIDs,
+            frames: [],
+            viewportHeight: 0,
+            selectedFileID: selectedFileID,
+            programmaticTarget: programmaticScroll.target,
+            firstFileID: firstFileID
+        )
     }
 
     private func sectionFrameReader(for id: DiffReviewFileID) -> some View {
@@ -126,6 +165,24 @@ struct DiffReviewSurface: View {
         selectedFileID = updated
     }
 
+    private func updateRenderedFileIDs(
+        frames: [DiffReviewSectionFrame],
+        viewportHeight: CGFloat,
+        firstFileID: DiffReviewFileID
+    ) {
+        let updated = DiffReviewRenderWindow.renderedFileIDs(
+            current: renderedFileIDs,
+            frames: frames,
+            viewportHeight: viewportHeight,
+            selectedFileID: selectedFileID,
+            programmaticTarget: programmaticScroll.target,
+            firstFileID: firstFileID
+        )
+        guard updated != renderedFileIDs else { return }
+
+        renderedFileIDs = updated
+    }
+
     private func synchronizeSelectionWithSession() {
         let result = DiffReviewSurfaceSelectionSync.synchronize(
             current: selectedFileID,
@@ -137,15 +194,13 @@ struct DiffReviewSurface: View {
         selectedFileID = result.selectedFileID
         synchronizedFileSetKey = result.fileSetKey
         programmaticScroll = result.programmaticScroll
+        renderedFileIDs = []
     }
 
-    private func scrollToFile(_ id: DiffReviewFileID, proxy: ScrollViewProxy) {
+    private func scrollToFile(_ id: DiffReviewFileID) {
         selectedFileID = id
         let token = programmaticScroll.beginProgrammaticScroll(to: id)
-
-        withAnimation(.easeInOut(duration: 0.18)) {
-            proxy.scrollTo(id.rawValue, anchor: .top)
-        }
+        scrollCommand = scrollCommandController.command(to: id)
 
         Task { @MainActor in
             try? await Task.sleep(nanoseconds: 250_000_000)
@@ -200,5 +255,98 @@ struct DiffReviewSectionFramePreferenceKey: PreferenceKey {
 
     static func reduce(value: inout [DiffReviewSectionFrame], nextValue: () -> [DiffReviewSectionFrame]) {
         value.append(contentsOf: nextValue())
+    }
+}
+
+private struct DiffReviewFileSectionPlaceholder: View {
+    let file: DiffReviewFileSectionModel
+    let estimatedHeight: CGFloat
+    let showsSourceBadge: Bool
+    let codeFontFamily: String
+    let codeFontSize: CGFloat
+
+    @Environment(\.theme) private var theme
+
+    var body: some View {
+        VStack(spacing: 0) {
+            header
+            Spacer(minLength: 0)
+        }
+        .frame(maxWidth: .infinity, minHeight: estimatedHeight, maxHeight: estimatedHeight)
+        .background(theme.color("bg-1"))
+        .clipShape(RoundedRectangle(cornerRadius: 8))
+        .overlay(
+            RoundedRectangle(cornerRadius: 8)
+                .stroke(theme.color("line"), lineWidth: 0.75)
+        )
+        .accessibilityIdentifier("diff-review-file-section-placeholder-\(file.id.rawValue)")
+    }
+
+    private var header: some View {
+        HStack(spacing: 10) {
+            Text(file.summary.status.glyph)
+                .font(.system(size: 12, weight: .semibold, design: .monospaced))
+                .foregroundColor(statusColor(file.summary.status))
+                .frame(width: 16)
+            Text(file.summary.path)
+                .font(CenterTypography.codeFont(family: codeFontFamily, size: codeFontSize))
+                .foregroundColor(theme.color("fg-muted"))
+                .lineLimit(1)
+                .truncationMode(.middle)
+            sourceBadge
+            Spacer(minLength: 12)
+            if file.summary.additions > 0 {
+                Text("+\(file.summary.additions)")
+                    .foregroundColor(theme.color("add"))
+            }
+            if file.summary.deletions > 0 {
+                Text("-\(file.summary.deletions)")
+                    .foregroundColor(theme.color("del"))
+            }
+        }
+        .font(.system(size: 11, weight: .medium, design: .monospaced))
+        .padding(.horizontal, 14)
+        .padding(.vertical, 10)
+        .background(theme.color("bg-2"))
+        .overlay(Rectangle().fill(theme.color("line")).frame(height: 0.5), alignment: .bottom)
+    }
+
+    @ViewBuilder
+    private var sourceBadge: some View {
+        if showsSourceBadge, let title = file.summary.groupTitle {
+            Text(title.uppercased())
+                .font(.system(size: 9.5, weight: .semibold))
+                .foregroundColor(sourceColor)
+                .padding(.horizontal, 6)
+                .padding(.vertical, 2)
+                .background(sourceColor.opacity(0.16))
+                .clipShape(RoundedRectangle(cornerRadius: 4))
+        }
+    }
+
+    private var sourceColor: Color {
+        switch file.summary.groupID ?? file.summary.namespace {
+        case "unstaged":
+            theme.color("warn")
+        case "staged":
+            theme.color("info")
+        default:
+            theme.color("accent")
+        }
+    }
+
+    private func statusColor(_ status: DiffReviewFileStatus) -> Color {
+        switch status {
+        case .added:
+            theme.color("add")
+        case .deleted:
+            theme.color("del")
+        case .renamed, .copied:
+            theme.color("accent")
+        case .conflicted:
+            theme.color("warn")
+        case .modified, .unknown:
+            theme.color("fg-dim")
+        }
     }
 }

--- a/Alas/Sources/Center/ReviewEvidence/ReviewEvidenceTabView.swift
+++ b/Alas/Sources/Center/ReviewEvidence/ReviewEvidenceTabView.swift
@@ -201,9 +201,15 @@ struct ReviewEvidenceTabView: View {
             && feedbackItemsAreEmpty
         guard hasOnlyModelError else { return false }
 
-        return !isLoadingFiles
-            && fileErrorMessage == nil
-            && fileSession == nil
+        if fileSession != nil {
+            return false
+        }
+
+        if selectedSection == .files, isLoadingFiles || fileErrorMessage != nil {
+            return false
+        }
+
+        return true
     }
 
     static func contentRoute(

--- a/Alas/Sources/Center/ReviewEvidence/ReviewEvidenceTabView.swift
+++ b/Alas/Sources/Center/ReviewEvidence/ReviewEvidenceTabView.swift
@@ -201,13 +201,9 @@ struct ReviewEvidenceTabView: View {
             && feedbackItemsAreEmpty
         guard hasOnlyModelError else { return false }
 
-        if selectedSection == .files {
-            return !isLoadingFiles
-                && fileErrorMessage == nil
-                && fileSession == nil
-        }
-
-        return true
+        return !isLoadingFiles
+            && fileErrorMessage == nil
+            && fileSession == nil
     }
 
     static func contentRoute(

--- a/Alas/Sources/Center/ReviewEvidence/ReviewEvidenceTabView.swift
+++ b/Alas/Sources/Center/ReviewEvidence/ReviewEvidenceTabView.swift
@@ -141,7 +141,7 @@ struct ReviewEvidenceTabView: View {
         if let unavailableMessage {
             unavailableState(message: unavailableMessage)
         } else if let model {
-            if let message = model.errorMessage, model.ciItems.isEmpty, model.feedbackItems.isEmpty {
+            if let message = model.errorMessage, Self.shouldShowModelUnavailable(model) {
                 unavailableState(message: message)
             } else {
                 evidenceBrowser(model: model)
@@ -151,6 +151,13 @@ struct ReviewEvidenceTabView: View {
                 .frame(width: 20, height: 20)
                 .frame(maxWidth: .infinity, maxHeight: .infinity)
         }
+    }
+
+    static func shouldShowModelUnavailable(_ model: ReviewEvidenceModel) -> Bool {
+        model.errorMessage != nil
+            && model.ciItems.isEmpty
+            && model.feedbackItems.isEmpty
+            && model.fileSession == nil
     }
 
     private func evidenceBrowser(model: ReviewEvidenceModel) -> some View {

--- a/Alas/Sources/Center/ReviewEvidence/ReviewEvidenceTabView.swift
+++ b/Alas/Sources/Center/ReviewEvidence/ReviewEvidenceTabView.swift
@@ -56,11 +56,11 @@ struct ReviewEvidenceTabView: View {
     private var loadKey: String {
         let head = snapshot?.local.headSHA ?? "no-head"
         let providerState = "\(snapshot?.providerAvailable == true):\(snapshot?.providerAuthenticated == true)"
-        let request = snapshot?.reviewRequest.map(reviewEvidenceRevisionKey) ?? "no-request"
+        let request = snapshot?.reviewRequest.map(Self.reviewEvidenceRevisionKey) ?? "no-request"
         return "\(tabState.id):\(head):\(providerState):\(request):\(loadNonce)"
     }
 
-    private func reviewEvidenceRevisionKey(for request: ReviewRequest) -> String {
+    static func reviewEvidenceRevisionKey(for request: ReviewRequest) -> String {
         let checks = request.checks
             .sorted { $0.id < $1.id }
             .map { check in
@@ -84,7 +84,12 @@ struct ReviewEvidenceTabView: View {
                     thread.body,
                     thread.url?.absoluteString ?? "nil",
                     String(thread.isResolved),
-                    String(thread.isActionable)
+                    String(thread.isActionable),
+                    thread.location?.path ?? "nil",
+                    thread.location?.originalPath ?? "nil",
+                    thread.location?.line.map(String.init) ?? "nil",
+                    thread.location?.side.rawValue ?? "nil",
+                    thread.location?.providerPosition ?? "nil"
                 ].joined(separator: ",")
             }
             .joined(separator: ";")

--- a/Alas/Sources/Center/ReviewEvidence/ReviewEvidenceTabView.swift
+++ b/Alas/Sources/Center/ReviewEvidence/ReviewEvidenceTabView.swift
@@ -579,6 +579,7 @@ struct ReviewEvidenceTabView: View {
 
     private func emptyText(for section: ReviewEvidenceSection) -> String {
         switch section {
+        case .files: "No changed files"
         case .ci: "No failed checks"
         case .feedback: "No actionable feedback"
         }

--- a/Alas/Sources/Center/ReviewEvidence/ReviewEvidenceTabView.swift
+++ b/Alas/Sources/Center/ReviewEvidence/ReviewEvidenceTabView.swift
@@ -199,12 +199,12 @@ struct ReviewEvidenceTabView: View {
         let hasOnlyModelError = modelErrorMessage != nil
             && ciItemsAreEmpty
             && feedbackItemsAreEmpty
-            && fileSession == nil
-            && fileErrorMessage == nil
         guard hasOnlyModelError else { return false }
 
-        if selectedSection == .files, isLoadingFiles {
-            return false
+        if selectedSection == .files {
+            return !isLoadingFiles
+                && fileErrorMessage == nil
+                && fileSession == nil
         }
 
         return true

--- a/Alas/Sources/Center/ReviewEvidence/ReviewEvidenceTabView.swift
+++ b/Alas/Sources/Center/ReviewEvidence/ReviewEvidenceTabView.swift
@@ -1,6 +1,18 @@
 import AppKit
 import SwiftUI
 
+enum ReviewEvidenceFilesContentState: Equatable {
+    case loading
+    case error(String)
+    case diffSurface
+    case empty
+}
+
+enum ReviewEvidenceContentRoute: Equatable {
+    case files(ReviewEvidenceFilesContentState)
+    case evidenceBrowser
+}
+
 struct ReviewEvidenceTabView: View {
     let worktreePath: URL
     let tabState: ReviewEvidenceTabState
@@ -11,6 +23,8 @@ struct ReviewEvidenceTabView: View {
     @State private var loadNonce = 0
     @State private var isRerunningFailedChecks = false
     @State private var loadGeneration = 0
+    @State private var selectedFileID: DiffReviewFileID?
+    @State private var railCollapsed = false
 
     @Environment(\.theme) private var theme
 
@@ -33,6 +47,10 @@ struct ReviewEvidenceTabView: View {
     private var canSendToAgent: Bool {
         let agentID = appState.config.changes.aiToolId
         return agentID != "none" && appState.agent(id: agentID) != nil
+    }
+
+    private var diffPreferences: DiffPreferenceBindings {
+        DiffPreferenceBindings(appState: appState)
     }
 
     private var loadKey: String {
@@ -158,6 +176,40 @@ struct ReviewEvidenceTabView: View {
             && model.ciItems.isEmpty
             && model.feedbackItems.isEmpty
             && model.fileSession == nil
+            && model.fileErrorMessage == nil
+    }
+
+    static func contentRoute(
+        selectedSection: ReviewEvidenceSection,
+        isLoadingFiles: Bool,
+        fileErrorMessage: String?,
+        fileSession: DiffReviewLoadedSession?,
+        modelErrorMessage: String?
+    ) -> ReviewEvidenceContentRoute {
+        guard selectedSection == .files else { return .evidenceBrowser }
+
+        return .files(filesContentState(
+            isLoadingFiles: isLoadingFiles,
+            fileErrorMessage: fileErrorMessage,
+            fileSession: fileSession
+        ))
+    }
+
+    static func filesContentState(
+        isLoadingFiles: Bool,
+        fileErrorMessage: String?,
+        fileSession: DiffReviewLoadedSession?
+    ) -> ReviewEvidenceFilesContentState {
+        if isLoadingFiles {
+            return .loading
+        }
+        if let fileErrorMessage, fileSession == nil {
+            return .error(fileErrorMessage)
+        }
+        if let fileSession, !fileSession.files.isEmpty {
+            return .diffSurface
+        }
+        return .empty
     }
 
     private func evidenceBrowser(model: ReviewEvidenceModel) -> some View {
@@ -174,16 +226,73 @@ struct ReviewEvidenceTabView: View {
 
             Divider()
 
-            HStack(spacing: 0) {
-                evidenceList(model: model)
-                    .frame(minWidth: 220, idealWidth: 300, maxWidth: 360, maxHeight: .infinity)
-                    .background(theme.color("bg-1"))
-                Divider()
-                detailPane(model: model)
-                    .frame(maxWidth: .infinity, maxHeight: .infinity)
-                    .background(theme.color("bg-0"))
+            switch Self.contentRoute(
+                selectedSection: selectedSection,
+                isLoadingFiles: model.isLoadingFiles,
+                fileErrorMessage: model.fileErrorMessage,
+                fileSession: model.fileSession,
+                modelErrorMessage: model.errorMessage
+            ) {
+            case .files(let state):
+                filesPane(state: state, session: model.fileSession)
+            case .evidenceBrowser:
+                HStack(spacing: 0) {
+                    evidenceList(model: model)
+                        .frame(minWidth: 220, idealWidth: 300, maxWidth: 360, maxHeight: .infinity)
+                        .background(theme.color("bg-1"))
+                    Divider()
+                    detailPane(model: model)
+                        .frame(maxWidth: .infinity, maxHeight: .infinity)
+                        .background(theme.color("bg-0"))
+                }
             }
         }
+    }
+
+    @ViewBuilder
+    private func filesPane(state: ReviewEvidenceFilesContentState, session: DiffReviewLoadedSession?) -> some View {
+        switch state {
+        case .loading:
+            VStack(spacing: 10) {
+                Spinner()
+                    .frame(width: 20, height: 20)
+                Text("Loading files")
+                    .font(.system(size: 12))
+                    .foregroundColor(theme.color("fg-dim"))
+            }
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
+            .background(theme.color("bg-1"))
+        case .error(let message):
+            unavailableState(message: message)
+                .background(theme.color("bg-1"))
+        case .diffSurface:
+            if let session {
+                DiffReviewSurface(
+                    session: session,
+                    selectedFileID: $selectedFileID,
+                    railCollapsed: $railCollapsed,
+                    layoutMode: diffPreferences.layoutMode,
+                    wrapLines: diffPreferences.wrapLines,
+                    showWhitespace: diffPreferences.showWhitespace,
+                    codeFontFamily: appState.config.code.fontFamily,
+                    codeFontSize: CGFloat(appState.config.code.fontSize),
+                    showsSourceBadges: true,
+                    showsRailDisplayControls: true
+                )
+            } else {
+                filesEmptyState
+            }
+        case .empty:
+            filesEmptyState
+        }
+    }
+
+    private var filesEmptyState: some View {
+        Text("No changed files")
+            .font(.system(size: 12, weight: .medium))
+            .foregroundColor(theme.color("fg-dim"))
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
+            .background(theme.color("bg-1"))
     }
 
     private func evidenceList(model: ReviewEvidenceModel) -> some View {

--- a/Alas/Sources/Center/ReviewEvidence/ReviewEvidenceTabView.swift
+++ b/Alas/Sources/Center/ReviewEvidence/ReviewEvidenceTabView.swift
@@ -159,7 +159,7 @@ struct ReviewEvidenceTabView: View {
         if let unavailableMessage {
             unavailableState(message: unavailableMessage)
         } else if let model {
-            if let message = model.errorMessage, Self.shouldShowModelUnavailable(model) {
+            if let message = model.errorMessage, Self.shouldShowModelUnavailable(model, selectedSection: selectedSection) {
                 unavailableState(message: message)
             } else {
                 evidenceBrowser(model: model)
@@ -172,11 +172,42 @@ struct ReviewEvidenceTabView: View {
     }
 
     static func shouldShowModelUnavailable(_ model: ReviewEvidenceModel) -> Bool {
-        model.errorMessage != nil
-            && model.ciItems.isEmpty
-            && model.feedbackItems.isEmpty
-            && model.fileSession == nil
-            && model.fileErrorMessage == nil
+        shouldShowModelUnavailable(model, selectedSection: model.selectedSection)
+    }
+
+    static func shouldShowModelUnavailable(_ model: ReviewEvidenceModel, selectedSection: ReviewEvidenceSection) -> Bool {
+        shouldShowModelUnavailable(
+            selectedSection: selectedSection,
+            isLoadingFiles: model.isLoadingFiles,
+            fileErrorMessage: model.fileErrorMessage,
+            fileSession: model.fileSession,
+            ciItemsAreEmpty: model.ciItems.isEmpty,
+            feedbackItemsAreEmpty: model.feedbackItems.isEmpty,
+            modelErrorMessage: model.errorMessage
+        )
+    }
+
+    static func shouldShowModelUnavailable(
+        selectedSection: ReviewEvidenceSection,
+        isLoadingFiles: Bool,
+        fileErrorMessage: String?,
+        fileSession: DiffReviewLoadedSession?,
+        ciItemsAreEmpty: Bool,
+        feedbackItemsAreEmpty: Bool,
+        modelErrorMessage: String?
+    ) -> Bool {
+        let hasOnlyModelError = modelErrorMessage != nil
+            && ciItemsAreEmpty
+            && feedbackItemsAreEmpty
+            && fileSession == nil
+            && fileErrorMessage == nil
+        guard hasOnlyModelError else { return false }
+
+        if selectedSection == .files, isLoadingFiles {
+            return false
+        }
+
+        return true
     }
 
     static func contentRoute(

--- a/Alas/Sources/Center/ReviewEvidence/ReviewEvidenceTabView.swift
+++ b/Alas/Sources/Center/ReviewEvidence/ReviewEvidenceTabView.swift
@@ -206,11 +206,8 @@ struct ReviewEvidenceTabView: View {
             && feedbackItemsAreEmpty
         guard hasOnlyModelError else { return false }
 
-        if fileSession != nil {
-            return false
-        }
-
-        if selectedSection == .files, isLoadingFiles || fileErrorMessage != nil {
+        if selectedSection == .files,
+           fileSession != nil || isLoadingFiles || fileErrorMessage != nil {
             return false
         }
 

--- a/Alas/Sources/Center/ReviewEvidence/ReviewEvidenceTabView.swift
+++ b/Alas/Sources/Center/ReviewEvidence/ReviewEvidenceTabView.swift
@@ -267,7 +267,11 @@ struct ReviewEvidenceTabView: View {
                 modelErrorMessage: model.errorMessage
             ) {
             case .files(let state):
-                filesPane(state: state, session: model.fileSession)
+                filesPane(
+                    state: state,
+                    session: model.fileSession,
+                    inlineFeedbackByFileID: Self.diffSurfaceInlineFeedbackByFileID(for: model)
+                )
             case .evidenceBrowser:
                 HStack(spacing: 0) {
                     evidenceList(model: model)
@@ -283,7 +287,11 @@ struct ReviewEvidenceTabView: View {
     }
 
     @ViewBuilder
-    private func filesPane(state: ReviewEvidenceFilesContentState, session: DiffReviewLoadedSession?) -> some View {
+    private func filesPane(
+        state: ReviewEvidenceFilesContentState,
+        session: DiffReviewLoadedSession?,
+        inlineFeedbackByFileID: [DiffReviewFileID: [DiffReviewInlineFeedback]]
+    ) -> some View {
         switch state {
         case .loading:
             VStack(spacing: 10) {
@@ -310,7 +318,8 @@ struct ReviewEvidenceTabView: View {
                     codeFontFamily: appState.config.code.fontFamily,
                     codeFontSize: CGFloat(appState.config.code.fontSize),
                     showsSourceBadges: true,
-                    showsRailDisplayControls: true
+                    showsRailDisplayControls: true,
+                    inlineFeedbackByFileID: inlineFeedbackByFileID
                 )
             } else {
                 filesEmptyState
@@ -332,12 +341,12 @@ struct ReviewEvidenceTabView: View {
         let items = model.items(for: selectedSection)
 
         return Group {
-            if model.isLoadingList {
-                Spinner()
-                    .frame(width: 18, height: 18)
-                    .frame(maxWidth: .infinity, maxHeight: .infinity)
-            } else if items.isEmpty {
-                Text(emptyText(for: selectedSection))
+            if items.isEmpty {
+                Text(Self.emptyText(
+                    for: selectedSection,
+                    isLoadingList: model.isLoadingList,
+                    itemCount: items.count
+                ))
                     .font(.system(size: 12, weight: .medium))
                     .foregroundColor(theme.color("fg-dim"))
                     .frame(maxWidth: .infinity, maxHeight: .infinity)
@@ -731,12 +740,27 @@ struct ReviewEvidenceTabView: View {
         )
     }
 
-    private func emptyText(for section: ReviewEvidenceSection) -> String {
+    static func emptyText(
+        for section: ReviewEvidenceSection,
+        isLoadingList: Bool,
+        itemCount: Int
+    ) -> String {
         switch section {
-        case .files: "No changed files"
-        case .ci: "No failed checks"
-        case .feedback: "No actionable feedback"
+        case .files:
+            return "No changed files"
+        case .ci:
+            if isLoadingList && itemCount == 0 { return "Loading checks…" }
+            return "No checks"
+        case .feedback:
+            if isLoadingList && itemCount == 0 { return "Loading feedback…" }
+            return "No feedback"
         }
+    }
+
+    static func diffSurfaceInlineFeedbackByFileID(
+        for model: ReviewEvidenceModel
+    ) -> [DiffReviewFileID: [DiffReviewInlineFeedback]] {
+        model.inlineFeedbackByFileID
     }
 
     private func detailLocation(_ detail: ReviewEvidenceDetail) -> String? {

--- a/Alas/Sources/Center/ReviewEvidence/ReviewEvidenceTabView.swift
+++ b/Alas/Sources/Center/ReviewEvidence/ReviewEvidenceTabView.swift
@@ -553,6 +553,11 @@ struct ReviewEvidenceTabView: View {
 
     private func applySelectedSection(_ section: ReviewEvidenceSection, loadDetail: Bool) {
         selectedSection = section
+        if section == .files {
+            model?.select(section: section)
+            persistSelection(section: section, itemID: nil)
+            return
+        }
         guard let model, let item = model.items(for: section).first else {
             persistSelection(section: section, itemID: nil)
             return

--- a/Alas/Sources/Center/Tab.swift
+++ b/Alas/Sources/Center/Tab.swift
@@ -115,7 +115,7 @@ struct ReviewEvidenceTabState: Codable, Equatable, Identifiable {
         self.number = request?.number ?? 0
         self.url = request?.url ?? remote?.webURL ?? URL(fileURLWithPath: "/")
         self.title = request?.title ?? ""
-        self.selectedSection = initialSection ?? .ci
+        self.selectedSection = initialSection ?? .files
         self.selectedItemID = nil
         let host = remote?.host ?? self.url.host ?? ""
         self.id = [

--- a/Alas/Sources/Center/TabsManager.swift
+++ b/Alas/Sources/Center/TabsManager.swift
@@ -767,7 +767,7 @@ final class TabsManager {
               case .reviewEvidence(var state) = file.tabs[idx]
         else { return nil }
         state.selectedSection = selectedSection
-        state.selectedItemID = selectedItemID
+        state.selectedItemID = selectedSection == .files ? nil : selectedItemID
         let tab = Tab.reviewEvidence(state)
         file.tabs[idx] = tab
         byWorktree[worktreeId] = file

--- a/Alas/Sources/Integrations/CodeHost/CodeHostModels.swift
+++ b/Alas/Sources/Integrations/CodeHost/CodeHostModels.swift
@@ -119,6 +119,20 @@ struct ReviewCheck: Identifiable, Equatable, Sendable {
     let completedAt: Date?
 }
 
+enum ReviewThreadSide: String, Codable, Equatable, Sendable {
+    case old
+    case new
+    case unknown
+}
+
+struct ReviewThreadLocation: Codable, Equatable, Sendable {
+    let path: String
+    let originalPath: String?
+    let line: Int?
+    let side: ReviewThreadSide
+    let providerPosition: String?
+}
+
 struct ReviewThreadSummary: Identifiable, Equatable, Sendable {
     let id: String
     let author: String?
@@ -126,6 +140,25 @@ struct ReviewThreadSummary: Identifiable, Equatable, Sendable {
     let url: URL?
     let isResolved: Bool
     let isActionable: Bool
+    let location: ReviewThreadLocation?
+
+    init(
+        id: String,
+        author: String?,
+        body: String,
+        url: URL?,
+        isResolved: Bool,
+        isActionable: Bool,
+        location: ReviewThreadLocation? = nil
+    ) {
+        self.id = id
+        self.author = author
+        self.body = body
+        self.url = url
+        self.isResolved = isResolved
+        self.isActionable = isActionable
+        self.location = location
+    }
 }
 
 struct ReviewRequest: Identifiable, Equatable, Sendable {

--- a/Alas/Sources/Integrations/CodeHost/CodeHostProvider.swift
+++ b/Alas/Sources/Integrations/CodeHost/CodeHostProvider.swift
@@ -62,6 +62,7 @@ protocol CodeHostProvider: Sendable {
         cwd: URL
     ) async throws -> URL
     func checks(remote: CodeHostRemote, request: ReviewRequest, cwd: URL) async throws -> [ReviewCheck]
+    func reviewDiff(remote: CodeHostRemote, request: ReviewRequest, cwd: URL) async throws -> String
     func failedCheckEvidence(remote: CodeHostRemote, request: ReviewRequest, cwd: URL) async throws -> [ReviewEvidenceItem]
     func checkEvidenceDetail(
         remote: CodeHostRemote,
@@ -87,6 +88,10 @@ protocol CodeHostProvider: Sendable {
 
 extension CodeHostProvider {
     var capabilities: CodeHostProviderCapabilities { .readOnly }
+
+    func reviewDiff(remote: CodeHostRemote, request: ReviewRequest, cwd: URL) async throws -> String {
+        throw CodeHostProviderError.unsupportedProvider(remote.kind)
+    }
 
     func failedCheckEvidence(remote: CodeHostRemote, request: ReviewRequest, cwd: URL) async throws -> [ReviewEvidenceItem] {
         request.checks

--- a/Alas/Sources/Integrations/CodeHost/CodeHostProvider.swift
+++ b/Alas/Sources/Integrations/CodeHost/CodeHostProvider.swift
@@ -94,18 +94,7 @@ extension CodeHostProvider {
     }
 
     func failedCheckEvidence(remote: CodeHostRemote, request: ReviewRequest, cwd: URL) async throws -> [ReviewEvidenceItem] {
-        request.checks
-            .filter { $0.bucket == .fail }
-            .map {
-                ReviewEvidenceItem(
-                    id: $0.id,
-                    section: .ci,
-                    title: $0.name,
-                    subtitle: $0.workflow,
-                    status: .failed,
-                    providerURL: $0.detailURL
-                )
-            }
+        ReviewEvidenceCIActivityMapper.items(for: request.checks)
     }
 
     func checkEvidenceDetail(

--- a/Alas/Sources/Integrations/CodeHost/GitHubCLIProvider.swift
+++ b/Alas/Sources/Integrations/CodeHost/GitHubCLIProvider.swift
@@ -159,6 +159,18 @@ struct GitHubCLIProvider: CodeHostProvider {
         return try Self.parseChecks(result.stdout)
     }
 
+    func reviewDiff(remote: CodeHostRemote, request: ReviewRequest, cwd: URL) async throws -> String {
+        let result = try await runner.run(
+            "gh",
+            args: ["pr", "diff", "\(request.number)", "-R", remote.repositorySlug],
+            cwd: cwd
+        )
+        guard result.exitCode == 0 else {
+            throw CodeHostProviderError.commandFailed(command: "gh pr diff", stderr: result.stderr)
+        }
+        return result.stdout
+    }
+
     func failedCheckEvidence(remote: CodeHostRemote, request: ReviewRequest, cwd: URL) async throws -> [ReviewEvidenceItem] {
         request.checks
             .filter { $0.bucket == .fail }

--- a/Alas/Sources/Integrations/CodeHost/GitHubCLIProvider.swift
+++ b/Alas/Sources/Integrations/CodeHost/GitHubCLIProvider.swift
@@ -186,6 +186,15 @@ struct GitHubCLIProvider: CodeHostProvider {
         cwd: URL
     ) async throws -> ReviewEvidenceDetail {
         _ = request
+        guard item.status == .failed else {
+            return ReviewEvidenceDetail(
+                item: item,
+                body: "Open this check in GitHub to inspect current status.",
+                filePath: nil,
+                line: nil,
+                isTruncated: false
+            )
+        }
         guard let runID = Self.githubRunID(from: item.providerURL) else {
             return ReviewEvidenceDetail(
                 item: item,

--- a/Alas/Sources/Integrations/CodeHost/GitHubCLIProvider.swift
+++ b/Alas/Sources/Integrations/CodeHost/GitHubCLIProvider.swift
@@ -176,18 +176,7 @@ struct GitHubCLIProvider: CodeHostProvider {
     }
 
     func failedCheckEvidence(remote: CodeHostRemote, request: ReviewRequest, cwd: URL) async throws -> [ReviewEvidenceItem] {
-        request.checks
-            .filter { $0.bucket == .fail }
-            .map {
-                ReviewEvidenceItem(
-                    id: $0.id,
-                    section: .ci,
-                    title: $0.name,
-                    subtitle: $0.workflow,
-                    status: .failed,
-                    providerURL: $0.detailURL
-                )
-            }
+        ReviewEvidenceCIActivityMapper.items(for: request.checks)
     }
 
     func checkEvidenceDetail(

--- a/Alas/Sources/Integrations/CodeHost/GitHubCLIProvider.swift
+++ b/Alas/Sources/Integrations/CodeHost/GitHubCLIProvider.swift
@@ -711,6 +711,29 @@ private struct ReviewThreadNode: Decodable {
     let originalLine: Int?
     let diffSide: String?
     let comments: ReviewThreadCommentsConnection
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        self.id = try container.decode(String.self, forKey: .id)
+        self.isResolved = try container.decode(Bool.self, forKey: .isResolved)
+        self.isOutdated = try container.decode(Bool.self, forKey: .isOutdated)
+        self.path = try? container.decode(String.self, forKey: .path)
+        self.line = try? container.decode(Int.self, forKey: .line)
+        self.originalLine = try? container.decode(Int.self, forKey: .originalLine)
+        self.diffSide = try? container.decode(String.self, forKey: .diffSide)
+        self.comments = try container.decode(ReviewThreadCommentsConnection.self, forKey: .comments)
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case id
+        case isResolved
+        case isOutdated
+        case path
+        case line
+        case originalLine
+        case diffSide
+        case comments
+    }
 }
 
 private struct ReviewThreadCommentsConnection: Decodable {

--- a/Alas/Sources/Integrations/CodeHost/GitHubCLIProvider.swift
+++ b/Alas/Sources/Integrations/CodeHost/GitHubCLIProvider.swift
@@ -12,6 +12,10 @@ struct GitHubCLIProvider: CodeHostProvider {
               id
               isResolved
               isOutdated
+              path
+              line
+              originalLine
+              diffSide
               comments(first: 50) {
                 nodes {
                   id
@@ -459,7 +463,8 @@ struct GitHubCLIProvider: CodeHostProvider {
                 body: comment.body,
                 url: url,
                 isResolved: thread.isResolved,
-                isActionable: !thread.isResolved && !thread.isOutdated
+                isActionable: !thread.isResolved && !thread.isOutdated,
+                location: reviewThreadLocation(from: thread)
             )
         }
         return ReviewThreadsPage(threads: threads, pageInfo: connection.pageInfo)
@@ -540,6 +545,40 @@ struct GitHubCLIProvider: CodeHostProvider {
             throw CodeHostProviderError.malformedOutput(context)
         }
         return url
+    }
+
+    private static func normalizedOptionalString(_ value: String?) -> String? {
+        guard let value else {
+            return nil
+        }
+        let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
+        return trimmed.isEmpty ? nil : trimmed
+    }
+
+    private static func reviewThreadLocation(from thread: ReviewThreadNode) -> ReviewThreadLocation? {
+        guard let path = normalizedOptionalString(thread.path) else {
+            return nil
+        }
+        let side: ReviewThreadSide
+        let line: Int?
+        switch thread.diffSide?.uppercased() {
+        case "LEFT":
+            side = .old
+            line = thread.originalLine ?? thread.line
+        case "RIGHT":
+            side = .new
+            line = thread.line ?? thread.originalLine
+        default:
+            side = .unknown
+            line = thread.line ?? thread.originalLine
+        }
+        return ReviewThreadLocation(
+            path: path,
+            originalPath: nil,
+            line: line,
+            side: side,
+            providerPosition: thread.id
+        )
     }
 
     private static func parseDate(_ value: String, formatOptions: ISO8601DateFormatter.Options) -> Date? {
@@ -667,6 +706,10 @@ private struct ReviewThreadNode: Decodable {
     let id: String
     let isResolved: Bool
     let isOutdated: Bool
+    let path: String?
+    let line: Int?
+    let originalLine: Int?
+    let diffSide: String?
     let comments: ReviewThreadCommentsConnection
 }
 

--- a/Alas/Sources/Integrations/CodeHost/GitLabCLIProvider.swift
+++ b/Alas/Sources/Integrations/CodeHost/GitLabCLIProvider.swift
@@ -141,7 +141,7 @@ struct GitLabCLIProvider: CodeHostProvider {
     func reviewDiff(remote: CodeHostRemote, request: ReviewRequest, cwd: URL) async throws -> String {
         let result = try await runner.run(
             "glab",
-            args: ["mr", "diff", "\(request.number)", "-R", remote.repositorySlug],
+            args: ["mr", "diff", "\(request.number)", "--raw", "--color=never", "-R", remote.repositorySlug],
             cwd: cwd
         )
         guard result.exitCode == 0 else {

--- a/Alas/Sources/Integrations/CodeHost/GitLabCLIProvider.swift
+++ b/Alas/Sources/Integrations/CodeHost/GitLabCLIProvider.swift
@@ -138,6 +138,18 @@ struct GitLabCLIProvider: CodeHostProvider {
         return try Self.parsePipeline(result.stdout)
     }
 
+    func reviewDiff(remote: CodeHostRemote, request: ReviewRequest, cwd: URL) async throws -> String {
+        let result = try await runner.run(
+            "glab",
+            args: ["mr", "diff", "\(request.number)", "-R", remote.repositorySlug],
+            cwd: cwd
+        )
+        guard result.exitCode == 0 else {
+            throw CodeHostProviderError.commandFailed(command: "glab mr diff", stderr: result.stderr)
+        }
+        return result.stdout
+    }
+
     func failedCheckEvidence(remote: CodeHostRemote, request: ReviewRequest, cwd: URL) async throws -> [ReviewEvidenceItem] {
         request.checks
             .filter { $0.bucket == .fail }

--- a/Alas/Sources/Integrations/CodeHost/GitLabCLIProvider.swift
+++ b/Alas/Sources/Integrations/CodeHost/GitLabCLIProvider.swift
@@ -457,7 +457,8 @@ struct GitLabCLIProvider: CodeHostProvider {
                 body: note.body,
                 url: try discussionURL(note: note, requestURL: requestURL),
                 isResolved: discussion.isResolved,
-                isActionable: !discussion.isResolved
+                isActionable: !discussion.isResolved,
+                location: reviewThreadLocation(from: note)
             )
         }
     }
@@ -679,6 +680,38 @@ struct GitLabCLIProvider: CodeHostProvider {
         return components?.url
     }
 
+    private static func reviewThreadLocation(from note: GitLabDiscussionNote) -> ReviewThreadLocation? {
+        guard let position = note.position else {
+            return nil
+        }
+        let newPath = normalizedOptionalString(position.newPath)
+        let oldPath = normalizedOptionalString(position.oldPath)
+        guard let path = newPath ?? oldPath else {
+            return nil
+        }
+
+        let side: ReviewThreadSide
+        let line: Int?
+        if let newLine = position.newLine {
+            side = .new
+            line = newLine
+        } else if let oldLine = position.oldLine {
+            side = .old
+            line = oldLine
+        } else {
+            side = .unknown
+            line = nil
+        }
+
+        return ReviewThreadLocation(
+            path: path,
+            originalPath: oldPath,
+            line: line,
+            side: side,
+            providerPosition: note.id.map(String.init)
+        )
+    }
+
     static func gitLabJobID(from url: URL?) -> String? {
         guard let url else {
             return nil
@@ -886,6 +919,7 @@ private struct GitLabDiscussionNote: Decodable {
     let resolvable: Bool?
     let resolved: Bool?
     let webURL: String?
+    let position: GitLabNotePosition?
 
     var isSystem: Bool {
         system ?? false
@@ -899,11 +933,26 @@ private struct GitLabDiscussionNote: Decodable {
         case resolvable
         case resolved
         case webURL = "web_url"
+        case position
     }
 }
 
 private struct GitLabDiscussionAuthor: Decodable {
     let username: String?
+}
+
+private struct GitLabNotePosition: Decodable {
+    let newPath: String?
+    let oldPath: String?
+    let newLine: Int?
+    let oldLine: Int?
+
+    private enum CodingKeys: String, CodingKey {
+        case newPath = "new_path"
+        case oldPath = "old_path"
+        case newLine = "new_line"
+        case oldLine = "old_line"
+    }
 }
 
 private extension CharacterSet {

--- a/Alas/Sources/Integrations/CodeHost/GitLabCLIProvider.swift
+++ b/Alas/Sources/Integrations/CodeHost/GitLabCLIProvider.swift
@@ -925,6 +925,18 @@ private struct GitLabDiscussionNote: Decodable {
         system ?? false
     }
 
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        self.id = try container.decodeIfPresent(Int.self, forKey: .id)
+        self.body = try container.decode(String.self, forKey: .body)
+        self.author = try container.decodeIfPresent(GitLabDiscussionAuthor.self, forKey: .author)
+        self.system = try container.decodeIfPresent(Bool.self, forKey: .system)
+        self.resolvable = try container.decodeIfPresent(Bool.self, forKey: .resolvable)
+        self.resolved = try container.decodeIfPresent(Bool.self, forKey: .resolved)
+        self.webURL = try container.decodeIfPresent(String.self, forKey: .webURL)
+        self.position = try? container.decode(GitLabNotePosition.self, forKey: .position)
+    }
+
     private enum CodingKeys: String, CodingKey {
         case id
         case body

--- a/Alas/Sources/Integrations/CodeHost/GitLabCLIProvider.swift
+++ b/Alas/Sources/Integrations/CodeHost/GitLabCLIProvider.swift
@@ -151,18 +151,7 @@ struct GitLabCLIProvider: CodeHostProvider {
     }
 
     func failedCheckEvidence(remote: CodeHostRemote, request: ReviewRequest, cwd: URL) async throws -> [ReviewEvidenceItem] {
-        request.checks
-            .filter { $0.bucket == .fail }
-            .map {
-                ReviewEvidenceItem(
-                    id: $0.id,
-                    section: .ci,
-                    title: $0.name,
-                    subtitle: $0.workflow,
-                    status: .failed,
-                    providerURL: $0.detailURL
-                )
-            }
+        ReviewEvidenceCIActivityMapper.items(for: request.checks)
     }
 
     func checkEvidenceDetail(

--- a/Alas/Sources/Integrations/CodeHost/ReviewEvidence.swift
+++ b/Alas/Sources/Integrations/CodeHost/ReviewEvidence.swift
@@ -111,6 +111,36 @@ enum ReviewEvidenceFallbacks {
     }
 }
 
+enum ReviewEvidenceCIActivityMapper {
+    static func items(for checks: [ReviewCheck]) -> [ReviewEvidenceItem] {
+        checks.map { check in
+            ReviewEvidenceItem(
+                id: check.id,
+                section: .ci,
+                title: check.name,
+                subtitle: check.workflow,
+                status: status(for: check.bucket),
+                providerURL: check.detailURL
+            )
+        }
+    }
+
+    private static func status(for bucket: ReviewCheckBucket) -> ReviewEvidenceStatus {
+        switch bucket {
+        case .pass:
+            .passed
+        case .fail:
+            .failed
+        case .pending:
+            .pending
+        case .cancel:
+            .cancelled
+        case .skipping, .unknown:
+            .unknown
+        }
+    }
+}
+
 enum ReviewEvidenceInlineFeedbackMapper {
     static func feedbackByFileID(
         threads: [ReviewThreadSummary],

--- a/Alas/Sources/Integrations/CodeHost/ReviewEvidence.swift
+++ b/Alas/Sources/Integrations/CodeHost/ReviewEvidence.swift
@@ -200,10 +200,10 @@ private struct InlineFeedbackFileMatcher {
            let file = filesByOriginalPath[originalPath] {
             return file
         }
-        if let file = filesByOriginalPath[location.path] {
-            return file
+        if let exactCurrentPathMatch = filesByPath[location.path] {
+            return exactCurrentPathMatch
         }
-        return filesByPath[location.path]
+        return filesByOriginalPath[location.path]
     }
 
     private static func uniqueFiles(

--- a/Alas/Sources/Integrations/CodeHost/ReviewEvidence.swift
+++ b/Alas/Sources/Integrations/CodeHost/ReviewEvidence.swift
@@ -111,6 +111,149 @@ enum ReviewEvidenceFallbacks {
     }
 }
 
+enum ReviewEvidenceInlineFeedbackMapper {
+    static func feedbackByFileID(
+        threads: [ReviewThreadSummary],
+        files: [DiffReviewFileSummary],
+        providerName: String
+    ) -> [DiffReviewFileID: [DiffReviewInlineFeedback]] {
+        var grouped: [DiffReviewFileID: [DiffReviewInlineFeedback]] = [:]
+        let fileMatcher = InlineFeedbackFileMatcher(files: files)
+
+        for thread in threads where !thread.isResolved && thread.isActionable {
+            guard let location = thread.location,
+                  let file = fileMatcher.file(for: location)
+            else { continue }
+
+            let side = DiffReviewInlineFeedbackSide(location.side)
+            let anchorPath = anchorPath(for: location, matchedFile: file)
+            let feedback = DiffReviewInlineFeedback(
+                id: thread.id,
+                providerName: providerName,
+                author: thread.author,
+                bodyPreview: String(thread.body.prefix(240)),
+                status: .actionable,
+                providerURL: thread.url,
+                anchor: DiffReviewInlineFeedbackAnchor(
+                    path: anchorPath,
+                    line: location.line,
+                    side: side
+                ),
+                evidenceItemID: thread.id
+            )
+            grouped[file.id, default: []].append(feedback)
+        }
+
+        return grouped.mapValues { feedback in
+            feedback.sorted { lhs, rhs in
+                switch (lhs.anchor.line, rhs.anchor.line) {
+                case (nil, nil):
+                    return lhs.id < rhs.id
+                case (nil, _?):
+                    return true
+                case (_?, nil):
+                    return false
+                case (let lhsLine?, let rhsLine?):
+                    if lhsLine != rhsLine {
+                        return lhsLine < rhsLine
+                    }
+                    return lhs.id < rhs.id
+                }
+            }
+        }
+    }
+
+    private static func anchorPath(for location: ReviewThreadLocation, matchedFile file: DiffReviewFileSummary) -> String {
+        switch location.side {
+        case .old:
+            location.originalPath ?? file.originalPath ?? location.path
+        case .new, .unknown:
+            location.path
+        }
+    }
+}
+
+private struct InlineFeedbackFileMatcher {
+    private let filesByPath: [String: DiffReviewFileSummary]
+    private let filesByOriginalPath: [String: DiffReviewFileSummary]
+
+    init(files: [DiffReviewFileSummary]) {
+        self.filesByPath = Self.uniqueFiles(files, keyedBy: \.path)
+        self.filesByOriginalPath = Self.uniqueFiles(files.compactMap { file in
+            file.originalPath == nil ? nil : file
+        }, keyedBy: \.originalPath)
+    }
+
+    func file(for location: ReviewThreadLocation) -> DiffReviewFileSummary? {
+        switch location.side {
+        case .new:
+            filesByPath[location.path]
+        case .unknown:
+            filesByPath[location.path] ?? location.originalPath.flatMap { filesByOriginalPath[$0] }
+        case .old:
+            fileForOldSide(location)
+        }
+    }
+
+    private func fileForOldSide(_ location: ReviewThreadLocation) -> DiffReviewFileSummary? {
+        if let originalPath = location.originalPath,
+           let file = filesByOriginalPath[originalPath] {
+            return file
+        }
+        if let file = filesByOriginalPath[location.path] {
+            return file
+        }
+        return filesByPath[location.path]
+    }
+
+    private static func uniqueFiles(
+        _ files: [DiffReviewFileSummary],
+        keyedBy keyPath: KeyPath<DiffReviewFileSummary, String>
+    ) -> [String: DiffReviewFileSummary] {
+        uniqueFiles(files) { $0[keyPath: keyPath] }
+    }
+
+    private static func uniqueFiles(
+        _ files: [DiffReviewFileSummary],
+        keyedBy keyPath: KeyPath<DiffReviewFileSummary, String?>
+    ) -> [String: DiffReviewFileSummary] {
+        uniqueFiles(files) { $0[keyPath: keyPath] }
+    }
+
+    private static func uniqueFiles(
+        _ files: [DiffReviewFileSummary],
+        key: (DiffReviewFileSummary) -> String?
+    ) -> [String: DiffReviewFileSummary] {
+        var result: [String: DiffReviewFileSummary] = [:]
+        var duplicateKeys: Set<String> = []
+
+        for file in files {
+            guard let key = key(file), !key.isEmpty else { continue }
+            if result[key] != nil {
+                result[key] = nil
+                duplicateKeys.insert(key)
+            } else if !duplicateKeys.contains(key) {
+                result[key] = file
+            }
+        }
+
+        return result
+    }
+}
+
+private extension DiffReviewInlineFeedbackSide {
+    init(_ side: ReviewThreadSide) {
+        switch side {
+        case .old:
+            self = .old
+        case .new:
+            self = .new
+        case .unknown:
+            self = .unknown
+        }
+    }
+}
+
 enum ReviewEvidenceContextFormatter {
     static func format(_ detail: ReviewEvidenceDetail) -> String {
         var lines: [String] = [

--- a/Alas/Sources/Integrations/CodeHost/ReviewEvidence.swift
+++ b/Alas/Sources/Integrations/CodeHost/ReviewEvidence.swift
@@ -189,7 +189,7 @@ private struct InlineFeedbackFileMatcher {
         case .new:
             filesByPath[location.path] ?? location.originalPath.flatMap { filesByOriginalPath[$0] } ?? filesByOriginalPath[location.path]
         case .unknown:
-            filesByPath[location.path] ?? location.originalPath.flatMap { filesByOriginalPath[$0] }
+            filesByPath[location.path] ?? location.originalPath.flatMap { filesByOriginalPath[$0] } ?? filesByOriginalPath[location.path]
         case .old:
             fileForOldSide(location)
         }

--- a/Alas/Sources/Integrations/CodeHost/ReviewEvidence.swift
+++ b/Alas/Sources/Integrations/CodeHost/ReviewEvidence.swift
@@ -187,7 +187,7 @@ private struct InlineFeedbackFileMatcher {
     func file(for location: ReviewThreadLocation) -> DiffReviewFileSummary? {
         switch location.side {
         case .new:
-            filesByPath[location.path]
+            filesByPath[location.path] ?? location.originalPath.flatMap { filesByOriginalPath[$0] } ?? filesByOriginalPath[location.path]
         case .unknown:
             filesByPath[location.path] ?? location.originalPath.flatMap { filesByOriginalPath[$0] }
         case .old:

--- a/Alas/Sources/Integrations/CodeHost/ReviewEvidence.swift
+++ b/Alas/Sources/Integrations/CodeHost/ReviewEvidence.swift
@@ -196,6 +196,10 @@ private struct InlineFeedbackFileMatcher {
     }
 
     private func fileForOldSide(_ location: ReviewThreadLocation) -> DiffReviewFileSummary? {
+        if location.originalPath == nil || location.originalPath == location.path,
+           let exactCurrentPathMatch = filesByPath[location.path] {
+            return exactCurrentPathMatch
+        }
         if let originalPath = location.originalPath,
            let file = filesByOriginalPath[originalPath] {
             return file

--- a/Alas/Sources/Integrations/CodeHost/ReviewEvidence.swift
+++ b/Alas/Sources/Integrations/CodeHost/ReviewEvidence.swift
@@ -1,11 +1,13 @@
 import Foundation
 
 enum ReviewEvidenceSection: String, Codable, Equatable, Sendable, CaseIterable {
+    case files
     case ci
     case feedback
 
     var displayName: String {
         switch self {
+        case .files: "Files"
         case .ci: "CI"
         case .feedback: "Feedback"
         }

--- a/Alas/Sources/Integrations/CodeHost/ReviewEvidenceModel.swift
+++ b/Alas/Sources/Integrations/CodeHost/ReviewEvidenceModel.swift
@@ -12,6 +12,7 @@ final class ReviewEvidenceModel {
 
     private(set) var ciItems: [ReviewEvidenceItem] = []
     private(set) var feedbackItems: [ReviewEvidenceItem] = []
+    private(set) var inlineFeedbackByFileID: [DiffReviewFileID: [DiffReviewInlineFeedback]] = [:]
     private(set) var fileSession: DiffReviewLoadedSession?
     private(set) var selectedSection: ReviewEvidenceSection
     private(set) var selectedItemID: String?
@@ -46,6 +47,7 @@ final class ReviewEvidenceModel {
         guard let remote = snapshot.remote, let request = snapshot.reviewRequest else {
             isLoadingList = false
             isLoadingFiles = false
+            inlineFeedbackByFileID = [:]
             errorMessage = "Review request not found."
             return
         }
@@ -54,6 +56,7 @@ final class ReviewEvidenceModel {
         isLoadingFiles = true
         errorMessage = nil
         fileErrorMessage = nil
+        inlineFeedbackByFileID = [:]
 
         async let files: Void = loadAndPublishFiles(remote: remote, request: request)
         async let evidence: Void = loadAndPublishEvidence(remote: remote, request: request)
@@ -201,8 +204,10 @@ final class ReviewEvidenceModel {
         switch result {
         case .success(let loadedFiles):
             fileSession = loadedFiles
+            refreshInlineFeedback()
         case .failure(let error):
             fileSession = nil
+            inlineFeedbackByFileID = [:]
             fileErrorMessage = error.localizedDescription
         }
         isLoadingFiles = false
@@ -219,8 +224,10 @@ final class ReviewEvidenceModel {
             let (loadedCI, loadedFeedback) = loadedEvidence
             ciItems = loadedCI
             feedbackItems = loadedFeedback
+            refreshInlineFeedback()
             chooseInitialSelection()
         case .failure(let error):
+            refreshInlineFeedback()
             errorMessage = error.localizedDescription
         }
         isLoadingList = false
@@ -229,6 +236,21 @@ final class ReviewEvidenceModel {
     private func loadAndPublishEvidence(remote: CodeHostRemote, request: ReviewRequest) async {
         let result = await Self.loadEvidence(provider: provider, remote: remote, request: request, cwd: cwd)
         publishEvidence(result)
+    }
+
+    private func refreshInlineFeedback() {
+        guard let request = snapshot.reviewRequest,
+              let fileSession
+        else {
+            inlineFeedbackByFileID = [:]
+            return
+        }
+
+        inlineFeedbackByFileID = ReviewEvidenceInlineFeedbackMapper.feedbackByFileID(
+            threads: request.threads,
+            files: fileSession.summary.files,
+            providerName: request.provider.displayName
+        )
     }
 
     private nonisolated static func loadFiles(

--- a/Alas/Sources/Integrations/CodeHost/ReviewEvidenceModel.swift
+++ b/Alas/Sources/Integrations/CodeHost/ReviewEvidenceModel.swift
@@ -56,6 +56,7 @@ final class ReviewEvidenceModel {
         isLoadingFiles = true
         errorMessage = nil
         fileErrorMessage = nil
+        fileSession = nil
         inlineFeedbackByFileID = [:]
 
         async let files: Void = loadAndPublishFiles(remote: remote, request: request)

--- a/Alas/Sources/Integrations/CodeHost/ReviewEvidenceModel.swift
+++ b/Alas/Sources/Integrations/CodeHost/ReviewEvidenceModel.swift
@@ -55,35 +55,23 @@ final class ReviewEvidenceModel {
         errorMessage = nil
         fileErrorMessage = nil
 
-        async let filesResult = loadFiles(remote: remote, request: request)
-        async let evidenceResult = loadEvidence(remote: remote, request: request)
-        let (files, evidence) = await (filesResult, evidenceResult)
-
-        switch files {
-        case .success(let loadedFiles):
-            fileSession = loadedFiles
-        case .failure(let error):
-            fileSession = nil
-            fileErrorMessage = error.localizedDescription
-        }
-        isLoadingFiles = false
-
-        switch evidence {
-        case .success(let loadedEvidence):
-            let (loadedCI, loadedFeedback) = loadedEvidence
-            ciItems = loadedCI
-            feedbackItems = loadedFeedback
-            chooseInitialSelection()
-        case .failure(let error):
-            errorMessage = error.localizedDescription
-        }
-        isLoadingList = false
+        async let files: Void = loadAndPublishFiles(remote: remote, request: request)
+        async let evidence: Void = loadAndPublishEvidence(remote: remote, request: request)
+        _ = await (files, evidence)
     }
 
     func select(itemID: String, section: ReviewEvidenceSection) {
         detailRequestID += 1
         selectedSection = section
         selectedItemID = itemID
+        selectedDetail = nil
+        isLoadingDetail = false
+    }
+
+    func select(section: ReviewEvidenceSection) {
+        detailRequestID += 1
+        selectedSection = section
+        selectedItemID = nil
         selectedDetail = nil
         isLoadingDetail = false
     }
@@ -209,9 +197,45 @@ final class ReviewEvidenceModel {
         }
     }
 
-    private func loadFiles(
+    private func publishFiles(_ result: LoadResult<DiffReviewLoadedSession>) {
+        switch result {
+        case .success(let loadedFiles):
+            fileSession = loadedFiles
+        case .failure(let error):
+            fileSession = nil
+            fileErrorMessage = error.localizedDescription
+        }
+        isLoadingFiles = false
+    }
+
+    private func loadAndPublishFiles(remote: CodeHostRemote, request: ReviewRequest) async {
+        let result = await Self.loadFiles(provider: provider, remote: remote, request: request, cwd: cwd)
+        publishFiles(result)
+    }
+
+    private func publishEvidence(_ result: LoadResult<([ReviewEvidenceItem], [ReviewEvidenceItem])>) {
+        switch result {
+        case .success(let loadedEvidence):
+            let (loadedCI, loadedFeedback) = loadedEvidence
+            ciItems = loadedCI
+            feedbackItems = loadedFeedback
+            chooseInitialSelection()
+        case .failure(let error):
+            errorMessage = error.localizedDescription
+        }
+        isLoadingList = false
+    }
+
+    private func loadAndPublishEvidence(remote: CodeHostRemote, request: ReviewRequest) async {
+        let result = await Self.loadEvidence(provider: provider, remote: remote, request: request, cwd: cwd)
+        publishEvidence(result)
+    }
+
+    private nonisolated static func loadFiles(
+        provider: any CodeHostProvider,
         remote: CodeHostRemote,
-        request: ReviewRequest
+        request: ReviewRequest,
+        cwd: URL
     ) async -> LoadResult<DiffReviewLoadedSession> {
         do {
             let session = try await ReviewRequestDiffLoader(provider: provider).load(
@@ -225,9 +249,11 @@ final class ReviewEvidenceModel {
         }
     }
 
-    private func loadEvidence(
+    private nonisolated static func loadEvidence(
+        provider: any CodeHostProvider,
         remote: CodeHostRemote,
-        request: ReviewRequest
+        request: ReviewRequest,
+        cwd: URL
     ) async -> LoadResult<([ReviewEvidenceItem], [ReviewEvidenceItem])> {
         do {
             async let ci = provider.failedCheckEvidence(remote: remote, request: request, cwd: cwd)

--- a/Alas/Sources/Integrations/CodeHost/ReviewEvidenceModel.swift
+++ b/Alas/Sources/Integrations/CodeHost/ReviewEvidenceModel.swift
@@ -12,12 +12,15 @@ final class ReviewEvidenceModel {
 
     private(set) var ciItems: [ReviewEvidenceItem] = []
     private(set) var feedbackItems: [ReviewEvidenceItem] = []
+    private(set) var fileSession: DiffReviewLoadedSession?
     private(set) var selectedSection: ReviewEvidenceSection
     private(set) var selectedItemID: String?
     private(set) var selectedDetail: ReviewEvidenceDetail?
     private(set) var isLoadingList = false
+    private(set) var isLoadingFiles = false
     private(set) var isLoadingDetail = false
     private(set) var errorMessage: String?
+    private(set) var fileErrorMessage: String?
 
     var selectedItem: ReviewEvidenceItem? {
         guard let selectedItemID else { return nil }
@@ -35,31 +38,46 @@ final class ReviewEvidenceModel {
         self.provider = provider
         self.cwd = cwd
         self.initialSection = initialSection
-        self.selectedSection = initialSection ?? .ci
+        self.selectedSection = initialSection ?? .files
         self.selectedItemID = initialItemID
     }
 
     func load() async {
         guard let remote = snapshot.remote, let request = snapshot.reviewRequest else {
+            isLoadingList = false
+            isLoadingFiles = false
             errorMessage = "Review request not found."
             return
         }
 
         isLoadingList = true
+        isLoadingFiles = true
         errorMessage = nil
+        fileErrorMessage = nil
 
-        do {
-            async let ci = provider.failedCheckEvidence(remote: remote, request: request, cwd: cwd)
-            async let feedback = provider.feedbackEvidence(remote: remote, request: request, cwd: cwd)
-            let (loadedCI, loadedFeedback) = try await (ci, feedback)
+        async let filesResult = loadFiles(remote: remote, request: request)
+        async let evidenceResult = loadEvidence(remote: remote, request: request)
+        let (files, evidence) = await (filesResult, evidenceResult)
+
+        switch files {
+        case .success(let loadedFiles):
+            fileSession = loadedFiles
+        case .failure(let error):
+            fileSession = nil
+            fileErrorMessage = error.localizedDescription
+        }
+        isLoadingFiles = false
+
+        switch evidence {
+        case .success(let loadedEvidence):
+            let (loadedCI, loadedFeedback) = loadedEvidence
             ciItems = loadedCI
             feedbackItems = loadedFeedback
             chooseInitialSelection()
-            isLoadingList = false
-        } catch {
-            isLoadingList = false
+        case .failure(let error):
             errorMessage = error.localizedDescription
         }
+        isLoadingList = false
     }
 
     func select(itemID: String, section: ReviewEvidenceSection) {
@@ -71,6 +89,12 @@ final class ReviewEvidenceModel {
     }
 
     func loadSelectedDetail() async {
+        guard selectedSection != .files else {
+            selectedDetail = nil
+            isLoadingDetail = false
+            return
+        }
+
         guard let remote = snapshot.remote, let request = snapshot.reviewRequest else {
             errorMessage = "Review request not found."
             return
@@ -90,6 +114,10 @@ final class ReviewEvidenceModel {
         do {
             let detail: ReviewEvidenceDetail
             switch item.section {
+            case .files:
+                selectedDetail = nil
+                isLoadingDetail = false
+                return
             case .ci:
                 detail = try await provider.checkEvidenceDetail(
                     remote: remote,
@@ -129,6 +157,8 @@ final class ReviewEvidenceModel {
 
     func items(for section: ReviewEvidenceSection) -> [ReviewEvidenceItem] {
         switch section {
+        case .files:
+            []
         case .ci:
             ciItems
         case .feedback:
@@ -163,7 +193,11 @@ final class ReviewEvidenceModel {
             return
         }
 
-        if initialSection == .feedback, let item = feedbackItems.first {
+        if initialSection == nil || initialSection == .files {
+            selectedSection = .files
+            selectedItemID = nil
+            selectedDetail = nil
+        } else if initialSection == .feedback, let item = feedbackItems.first {
             select(itemID: item.id, section: .feedback)
         } else if let item = ciItems.first {
             select(itemID: item.id, section: .ci)
@@ -174,4 +208,39 @@ final class ReviewEvidenceModel {
             selectedDetail = nil
         }
     }
+
+    private func loadFiles(
+        remote: CodeHostRemote,
+        request: ReviewRequest
+    ) async -> LoadResult<DiffReviewLoadedSession> {
+        do {
+            let session = try await ReviewRequestDiffLoader(provider: provider).load(
+                remote: remote,
+                request: request,
+                cwd: cwd
+            )
+            return .success(session)
+        } catch {
+            return .failure(error)
+        }
+    }
+
+    private func loadEvidence(
+        remote: CodeHostRemote,
+        request: ReviewRequest
+    ) async -> LoadResult<([ReviewEvidenceItem], [ReviewEvidenceItem])> {
+        do {
+            async let ci = provider.failedCheckEvidence(remote: remote, request: request, cwd: cwd)
+            async let feedback = provider.feedbackEvidence(remote: remote, request: request, cwd: cwd)
+            let loadedEvidence = try await (ci, feedback)
+            return .success(loadedEvidence)
+        } catch {
+            return .failure(error)
+        }
+    }
+}
+
+private enum LoadResult<Value> {
+    case success(Value)
+    case failure(any Error)
 }

--- a/Alas/Sources/Integrations/CodeHost/ReviewRequestDiffLoader.swift
+++ b/Alas/Sources/Integrations/CodeHost/ReviewRequestDiffLoader.swift
@@ -189,13 +189,21 @@ private struct ProviderDiffFileSection {
     }
 
     private static func prefixedPaths(from payload: String) -> (old: String, new: String)? {
-        guard payload.hasPrefix("a/"),
-              let delimiter = payload.range(of: " b/")
-        else { return nil }
+        guard payload.hasPrefix("a/") else { return nil }
 
-        let oldPath = String(payload[..<delimiter.lowerBound])
-        let newPath = String(payload[payload.index(after: delimiter.lowerBound)...])
-        return (stripGitPrefix(oldPath), stripGitPrefix(newPath))
+        var candidates: [(old: String, new: String)] = []
+        var searchStart = payload.startIndex
+        while let delimiter = payload.range(of: " b/", range: searchStart..<payload.endIndex) {
+            let oldPath = String(payload[..<delimiter.lowerBound])
+            let newPath = String(payload[payload.index(after: delimiter.lowerBound)...])
+            candidates.append((stripGitPrefix(oldPath), stripGitPrefix(newPath)))
+            searchStart = payload.index(after: delimiter.lowerBound)
+        }
+
+        if let matchingCandidate = candidates.first(where: { $0.old == $0.new }) {
+            return matchingCandidate
+        }
+        return candidates.last
     }
 
     private static func quotedPaths(from payload: String) -> (old: String, new: String)? {
@@ -304,6 +312,10 @@ private struct ProviderDiffFileSection {
     private static func pathHeader(in lines: [String], prefix: String) -> String? {
         guard let rawPath = firstHeaderValue(in: lines, prefix: prefix) else { return nil }
         guard rawPath != "/dev/null" else { return nil }
+        var index = rawPath.startIndex
+        if let quotedPath = quotedPathToken(in: rawPath, index: &index) {
+            return stripGitPrefix(quotedPath)
+        }
         return stripGitPrefix(rawPath)
     }
 

--- a/Alas/Sources/Integrations/CodeHost/ReviewRequestDiffLoader.swift
+++ b/Alas/Sources/Integrations/CodeHost/ReviewRequestDiffLoader.swift
@@ -233,6 +233,10 @@ private struct ProviderDiffFileSection {
                 return value
             }
             if character == "\\" {
+                if let decodedOctalBytes = decodeOctalByteSequence(in: text, index: &index) {
+                    value.append(decodedOctalBytes)
+                    continue
+                }
                 guard let escaped = decodeEscapedCharacter(in: text, index: &index) else {
                     return nil
                 }
@@ -244,6 +248,36 @@ private struct ProviderDiffFileSection {
         }
 
         return nil
+    }
+
+    private static func decodeOctalByteSequence(in text: String, index: inout String.Index) -> String? {
+        var cursor = index
+        var bytes: [UInt8] = []
+
+        while cursor < text.endIndex, text[cursor] == "\\" {
+            let escapedIndex = text.index(after: cursor)
+            guard escapedIndex < text.endIndex, isOctalDigit(text[escapedIndex]) else {
+                break
+            }
+
+            var digitCursor = escapedIndex
+            var digits = ""
+            while digitCursor < text.endIndex, digits.count < 3, isOctalDigit(text[digitCursor]) {
+                digits.append(text[digitCursor])
+                digitCursor = text.index(after: digitCursor)
+            }
+
+            guard let value = UInt8(digits, radix: 8) else {
+                return nil
+            }
+
+            bytes.append(value)
+            cursor = digitCursor
+        }
+
+        guard !bytes.isEmpty else { return nil }
+        index = cursor
+        return String(decoding: bytes, as: UTF8.self)
     }
 
     private static func decodeEscapedCharacter(in text: String, index: inout String.Index) -> Character? {

--- a/Alas/Sources/Integrations/CodeHost/ReviewRequestDiffLoader.swift
+++ b/Alas/Sources/Integrations/CodeHost/ReviewRequestDiffLoader.swift
@@ -304,9 +304,13 @@ private struct ProviderDiffFileSection {
     }
 
     private static func firstHeaderValue(in lines: [String], prefix: String) -> String? {
-        lines
+        guard let value = (lines
             .first { $0.hasPrefix(prefix) }
-            .map { String($0.dropFirst(prefix.count)) }
+            .map { String($0.dropFirst(prefix.count)) })
+        else { return nil }
+
+        var index = value.startIndex
+        return quotedPathToken(in: value, index: &index) ?? value
     }
 
     private static func pathHeader(in lines: [String], prefix: String) -> String? {

--- a/Alas/Sources/Integrations/CodeHost/ReviewRequestDiffLoader.swift
+++ b/Alas/Sources/Integrations/CodeHost/ReviewRequestDiffLoader.swift
@@ -1,0 +1,202 @@
+import Foundation
+
+struct ReviewRequestDiffLoader {
+    let provider: any CodeHostProvider
+
+    init(provider: any CodeHostProvider) {
+        self.provider = provider
+    }
+
+    func load(
+        remote: CodeHostRemote,
+        request: ReviewRequest,
+        cwd: URL
+    ) async throws -> DiffReviewLoadedSession {
+        try Task.checkCancellation()
+        let diff = try await provider.reviewDiff(remote: remote, request: request, cwd: cwd)
+        try Task.checkCancellation()
+
+        var files: [DiffReviewFileSectionModel] = []
+        for section in splitFileSections(diff) {
+            try Task.checkCancellation()
+            files.append(try await fileSection(for: section, namespace: namespace(for: remote.kind)))
+        }
+
+        return DiffReviewLoadedSession(
+            files: files,
+            summary: DiffReviewSessionModel(files: files.map(\.summary), groupsEnabled: false)
+        )
+    }
+
+    private func fileSection(for section: ProviderDiffFileSection, namespace: String) async throws -> DiffReviewFileSectionModel {
+        let parsed = DiffParser.parse(section.rawDiff)
+        let isImage = ImageFileType.isSupported(relativePath: section.path)
+        let canRender = !parsed.hunks.isEmpty && !isImage
+        let counts = isImage ? (additions: 0, deletions: 0) : lineCounts(in: parsed)
+        let summary = DiffReviewFileSummary(
+            path: section.path,
+            namespace: namespace,
+            groupID: nil,
+            groupTitle: nil,
+            status: section.status,
+            additions: counts.additions,
+            deletions: counts.deletions,
+            isRenderable: canRender,
+            originalPath: section.originalPath
+        )
+
+        return DiffReviewFileSectionModel(
+            summary: summary,
+            parsedDiff: parsed,
+            displayModel: canRender
+                ? try await buildDisplayModel(diff: parsed, filePath: section.path)
+                : nil,
+            placeholderMessage: canRender ? nil : placeholderMessage(for: section, diff: parsed),
+            openFile: nil
+        )
+    }
+
+    private func splitFileSections(_ rawDiff: String) -> [ProviderDiffFileSection] {
+        var sections: [ProviderDiffFileSection] = []
+        var currentLines: [String] = []
+
+        func flush() {
+            guard !currentLines.isEmpty else { return }
+            let rawSection = currentLines.joined(separator: "\n")
+            if let section = ProviderDiffFileSection(rawDiff: rawSection, lines: currentLines) {
+                sections.append(section)
+            }
+            currentLines = []
+        }
+
+        for line in rawDiff.split(separator: "\n", omittingEmptySubsequences: false).map(String.init) {
+            if line.hasPrefix("diff --git ") {
+                flush()
+            }
+            currentLines.append(line)
+        }
+        flush()
+
+        return sections
+    }
+
+    private func buildDisplayModel(diff: ParsedDiff, filePath: String) async throws -> DiffDisplayModel {
+        try Task.checkCancellation()
+        let model = await Task.detached(priority: .userInitiated) {
+            DiffDisplayModelBuilder.build(diff: diff, filePath: filePath)
+        }.value
+        try Task.checkCancellation()
+        return model
+    }
+
+    private func lineCounts(in diff: ParsedDiff) -> (additions: Int, deletions: Int) {
+        diff.hunks.reduce(into: (additions: 0, deletions: 0)) { counts, hunk in
+            for line in hunk.lines {
+                switch line.kind {
+                case .add:
+                    counts.additions += 1
+                case .delete:
+                    counts.deletions += 1
+                case .context:
+                    break
+                }
+            }
+        }
+    }
+
+    private func placeholderMessage(for section: ProviderDiffFileSection, diff: ParsedDiff) -> String {
+        if ImageFileType.isSupported(relativePath: section.path) {
+            return "Image changes are not available in this review view yet."
+        }
+        if diff.hunks.isEmpty {
+            return "No text diff is available for this file."
+        }
+        return "This file cannot be rendered in the review view."
+    }
+
+    private func namespace(for kind: CodeHostKind) -> String {
+        switch kind {
+        case .github:
+            return "github-pr"
+        case .gitlab:
+            return "gitlab-mr"
+        }
+    }
+}
+
+private struct ProviderDiffFileSection {
+    let rawDiff: String
+    let path: String
+    let originalPath: String?
+    let status: DiffReviewFileStatus
+
+    init?(rawDiff: String, lines: [String]) {
+        guard let header = lines.first(where: { $0.hasPrefix("diff --git ") }) else {
+            return nil
+        }
+
+        let paths = Self.paths(fromDiffHeader: header)
+        let renameFrom = Self.firstHeaderValue(in: lines, prefix: "rename from ")
+        let renameTo = Self.firstHeaderValue(in: lines, prefix: "rename to ")
+        let copyFrom = Self.firstHeaderValue(in: lines, prefix: "copy from ")
+        let copyTo = Self.firstHeaderValue(in: lines, prefix: "copy to ")
+        let oldPath = Self.pathHeader(in: lines, prefix: "--- ")
+        let newPath = Self.pathHeader(in: lines, prefix: "+++ ")
+
+        self.rawDiff = rawDiff
+
+        if let renameTo {
+            path = renameTo
+            originalPath = renameFrom
+            status = .renamed
+        } else if let copyTo {
+            path = copyTo
+            originalPath = copyFrom
+            status = .copied
+        } else if lines.contains(where: { $0.hasPrefix("new file mode ") }) {
+            path = newPath ?? paths?.new ?? paths?.old ?? ""
+            originalPath = nil
+            status = .added
+        } else if lines.contains(where: { $0.hasPrefix("deleted file mode ") }) {
+            path = oldPath ?? paths?.old ?? paths?.new ?? ""
+            originalPath = nil
+            status = .deleted
+        } else {
+            path = newPath ?? paths?.new ?? oldPath ?? paths?.old ?? ""
+            originalPath = nil
+            status = .modified
+        }
+
+        if path.isEmpty {
+            return nil
+        }
+    }
+
+    private static func paths(fromDiffHeader header: String) -> (old: String, new: String)? {
+        let rawPaths = header
+            .dropFirst("diff --git ".count)
+            .split(separator: " ", maxSplits: 1, omittingEmptySubsequences: true)
+            .map(String.init)
+        guard rawPaths.count == 2 else { return nil }
+        return (stripGitPrefix(rawPaths[0]), stripGitPrefix(rawPaths[1]))
+    }
+
+    private static func firstHeaderValue(in lines: [String], prefix: String) -> String? {
+        lines
+            .first { $0.hasPrefix(prefix) }
+            .map { String($0.dropFirst(prefix.count)) }
+    }
+
+    private static func pathHeader(in lines: [String], prefix: String) -> String? {
+        guard let rawPath = firstHeaderValue(in: lines, prefix: prefix) else { return nil }
+        guard rawPath != "/dev/null" else { return nil }
+        return stripGitPrefix(rawPath)
+    }
+
+    private static func stripGitPrefix(_ path: String) -> String {
+        if path.hasPrefix("a/") || path.hasPrefix("b/") {
+            return String(path.dropFirst(2))
+        }
+        return path
+    }
+}

--- a/Alas/Sources/Integrations/CodeHost/ReviewRequestDiffLoader.swift
+++ b/Alas/Sources/Integrations/CodeHost/ReviewRequestDiffLoader.swift
@@ -348,13 +348,21 @@ private struct ProviderDiffFileSection {
     }
 
     private static func pathHeader(in lines: [String], prefix: String) -> String? {
-        guard let rawPath = firstHeaderValue(in: lines, prefix: prefix) else { return nil }
+        guard let rawPath = (lines
+            .first { $0.hasPrefix(prefix) }
+            .map { String($0.dropFirst(prefix.count)) })
+        else { return nil }
         guard rawPath != "/dev/null" else { return nil }
         var index = rawPath.startIndex
         if let quotedPath = quotedPathToken(in: rawPath, index: &index) {
             return stripGitPrefix(quotedPath)
         }
-        return stripGitPrefix(rawPath)
+        return stripGitPrefix(pathWithoutTabMetadata(rawPath))
+    }
+
+    private static func pathWithoutTabMetadata(_ path: String) -> String {
+        guard let tabIndex = path.firstIndex(of: "\t") else { return path }
+        return String(path[..<tabIndex])
     }
 
     private static func stripGitPrefix(_ path: String) -> String {

--- a/Alas/Sources/Integrations/CodeHost/ReviewRequestDiffLoader.swift
+++ b/Alas/Sources/Integrations/CodeHost/ReviewRequestDiffLoader.swift
@@ -173,12 +173,126 @@ private struct ProviderDiffFileSection {
     }
 
     private static func paths(fromDiffHeader header: String) -> (old: String, new: String)? {
-        let rawPaths = header
-            .dropFirst("diff --git ".count)
+        let payload = String(header.dropFirst("diff --git ".count))
+        if let quotedPaths = quotedPaths(from: payload) {
+            return quotedPaths
+        }
+        if let prefixedPaths = prefixedPaths(from: payload) {
+            return prefixedPaths
+        }
+
+        let rawPaths = payload
             .split(separator: " ", maxSplits: 1, omittingEmptySubsequences: true)
             .map(String.init)
         guard rawPaths.count == 2 else { return nil }
         return (stripGitPrefix(rawPaths[0]), stripGitPrefix(rawPaths[1]))
+    }
+
+    private static func prefixedPaths(from payload: String) -> (old: String, new: String)? {
+        guard payload.hasPrefix("a/"),
+              let delimiter = payload.range(of: " b/")
+        else { return nil }
+
+        let oldPath = String(payload[..<delimiter.lowerBound])
+        let newPath = String(payload[payload.index(after: delimiter.lowerBound)...])
+        return (stripGitPrefix(oldPath), stripGitPrefix(newPath))
+    }
+
+    private static func quotedPaths(from payload: String) -> (old: String, new: String)? {
+        var index = payload.startIndex
+        guard let oldPath = quotedPathToken(in: payload, index: &index) else {
+            return nil
+        }
+        skipSpaces(in: payload, index: &index)
+        guard let newPath = quotedPathToken(in: payload, index: &index) else {
+            return nil
+        }
+        return (stripGitPrefix(oldPath), stripGitPrefix(newPath))
+    }
+
+    private static func quotedPathToken(in text: String, index: inout String.Index) -> String? {
+        guard index < text.endIndex, text[index] == "\"" else {
+            return nil
+        }
+
+        index = text.index(after: index)
+        var value = ""
+
+        while index < text.endIndex {
+            let character = text[index]
+            if character == "\"" {
+                index = text.index(after: index)
+                return value
+            }
+            if character == "\\" {
+                guard let escaped = decodeEscapedCharacter(in: text, index: &index) else {
+                    return nil
+                }
+                value.append(escaped)
+            } else {
+                value.append(character)
+                index = text.index(after: index)
+            }
+        }
+
+        return nil
+    }
+
+    private static func decodeEscapedCharacter(in text: String, index: inout String.Index) -> Character? {
+        let escapeStart = index
+        let escapedIndex = text.index(after: escapeStart)
+        guard escapedIndex < text.endIndex else { return nil }
+
+        let escaped = text[escapedIndex]
+        switch escaped {
+        case "n":
+            index = text.index(after: escapedIndex)
+            return "\n"
+        case "r":
+            index = text.index(after: escapedIndex)
+            return "\r"
+        case "t":
+            index = text.index(after: escapedIndex)
+            return "\t"
+        case "\"", "\\":
+            index = text.index(after: escapedIndex)
+            return escaped
+        default:
+            if let octal = decodeOctalEscape(in: text, index: escapedIndex) {
+                index = octal.nextIndex
+                return octal.character
+            }
+            index = text.index(after: escapedIndex)
+            return escaped
+        }
+    }
+
+    private static func decodeOctalEscape(in text: String, index: String.Index) -> (character: Character, nextIndex: String.Index)? {
+        var cursor = index
+        var digits = ""
+
+        while cursor < text.endIndex, digits.count < 3, isOctalDigit(text[cursor]) {
+            digits.append(text[cursor])
+            cursor = text.index(after: cursor)
+        }
+
+        guard !digits.isEmpty,
+              let value = UInt32(digits, radix: 8),
+              let scalar = UnicodeScalar(value)
+        else { return nil }
+
+        return (Character(scalar), cursor)
+    }
+
+    private static func isOctalDigit(_ character: Character) -> Bool {
+        guard let scalar = character.unicodeScalars.first else { return false }
+        return scalar.value >= 48 && scalar.value <= 55
+    }
+
+    private static func skipSpaces(in text: String, index: inout String.Index) {
+        while index < text.endIndex, text[index] == " " {
+            index = text.index(after: index)
+        }
     }
 
     private static func firstHeaderValue(in lines: [String], prefix: String) -> String? {

--- a/Alas/Sources/Integrations/CodeHost/ReviewRequestDiffLoader.swift
+++ b/Alas/Sources/Integrations/CodeHost/ReviewRequestDiffLoader.swift
@@ -32,7 +32,7 @@ struct ReviewRequestDiffLoader {
         let parsed = DiffParser.parse(section.rawDiff)
         let isImage = ImageFileType.isSupported(relativePath: section.path)
         let canRender = !parsed.hunks.isEmpty && !isImage
-        let counts = isImage ? (additions: 0, deletions: 0) : lineCounts(in: parsed)
+        let counts = lineCounts(in: parsed)
         let summary = DiffReviewFileSummary(
             path: section.path,
             namespace: namespace,

--- a/AlasTests/DiffReviewSurfaceTests.swift
+++ b/AlasTests/DiffReviewSurfaceTests.swift
@@ -217,6 +217,42 @@ struct DiffReviewSurfaceTests {
         #expect(accessibilityLabel(in: controller.view, containing: "Please review this file.") != nil)
     }
 
+    @Test func fileSectionCapsInlineFeedbackCardsWithMoreRow() {
+        let file = DiffReviewFileSectionModel(
+            summary: summary(path: "Sources/App.swift"),
+            parsedDiff: parsedDiff(),
+            displayModel: displayModel(),
+            placeholderMessage: nil,
+            openFile: nil
+        )
+        let feedback = inlineFeedbackItems(count: 5, path: file.summary.path)
+        var layout = DiffLayoutMode.split
+        var wrap = false
+        var whitespace = false
+
+        let view = DiffReviewFileSection(
+            file: file,
+            inlineFeedback: feedback,
+            layoutMode: Binding(get: { layout }, set: { layout = $0 }),
+            wrapLines: Binding(get: { wrap }, set: { wrap = $0 }),
+            showWhitespace: Binding(get: { whitespace }, set: { whitespace = $0 }),
+            codeFontFamily: "",
+            codeFontSize: 13,
+            showsSourceBadge: false
+        )
+        .environment(\.theme, theme())
+
+        let controller = host(view, width: 900, height: 500)
+
+        #expect(subview(withAccessibilityIdentifier: "diff-review-inline-feedback-thread-1", in: controller.view) != nil)
+        #expect(subview(withAccessibilityIdentifier: "diff-review-inline-feedback-thread-2", in: controller.view) != nil)
+        #expect(subview(withAccessibilityIdentifier: "diff-review-inline-feedback-thread-3", in: controller.view) != nil)
+        #expect(subview(withAccessibilityIdentifier: "diff-review-inline-feedback-thread-4", in: controller.view) == nil)
+        #expect(subview(withAccessibilityIdentifier: "diff-review-inline-feedback-thread-5", in: controller.view) == nil)
+        #expect(subview(withAccessibilityIdentifier: "diff-review-inline-feedback-more", in: controller.view) != nil)
+        #expect(accessibilityLabel(in: controller.view, containing: "+2 more feedback") != nil)
+    }
+
     @Test func textDocumentViewClearsInactivePaneLSPContextWhenLayoutChanges() {
         let manager = WorkspaceLSPManager(registry: LanguageServerRegistry(userDefined: []))
         let context = DiffPaneLSPContext(
@@ -474,6 +510,25 @@ struct DiffReviewSurfaceTests {
         #expect(DiffReviewFileSectionHeightEstimator.estimatedHeight(for: large) > DiffReviewFileSectionHeightEstimator.estimatedHeight(for: small))
     }
 
+    @Test func estimatedSectionHeightReservesBoundedInlineFeedbackHeight() {
+        let file = DiffReviewFileSectionModel(
+            summary: summary(path: "Sources/App.swift"),
+            parsedDiff: parsedDiff(),
+            displayModel: displayModel(),
+            placeholderMessage: nil,
+            openFile: nil
+        )
+
+        let noFeedback = DiffReviewFileSectionHeightEstimator.estimatedHeight(for: file, inlineFeedbackCount: 0)
+        let oneFeedback = DiffReviewFileSectionHeightEstimator.estimatedHeight(for: file, inlineFeedbackCount: 1)
+        let cappedFeedback = DiffReviewFileSectionHeightEstimator.estimatedHeight(for: file, inlineFeedbackCount: 4)
+        let manyFeedback = DiffReviewFileSectionHeightEstimator.estimatedHeight(for: file, inlineFeedbackCount: 10)
+
+        #expect(oneFeedback > noFeedback)
+        #expect(cappedFeedback > oneFeedback)
+        #expect(manyFeedback == cappedFeedback)
+    }
+
     private func parsedDiff() -> ParsedDiff {
         ParsedDiff(hunks: [
             ParsedDiff.Hunk(
@@ -506,6 +561,21 @@ struct DiffReviewSurfaceTests {
             },
             summary: DiffReviewSessionModel(files: summaries, groupsEnabled: false)
         )
+    }
+
+    private func inlineFeedbackItems(count: Int, path: String) -> [DiffReviewInlineFeedback] {
+        (1...count).map { index in
+            DiffReviewInlineFeedback(
+                id: "thread-\(index)",
+                providerName: "GitHub",
+                author: "reviewer",
+                bodyPreview: "Feedback \(index).",
+                status: .actionable,
+                providerURL: nil,
+                anchor: DiffReviewInlineFeedbackAnchor(path: path, line: index, side: .new),
+                evidenceItemID: "thread-\(index)"
+            )
+        }
     }
 
     private func summary(

--- a/AlasTests/DiffReviewSurfaceTests.swift
+++ b/AlasTests/DiffReviewSurfaceTests.swift
@@ -173,6 +173,50 @@ struct DiffReviewSurfaceTests {
         #expect(subview(withAccessibilityIdentifier: "diff-pane-toolbar", in: controller.view) == nil)
     }
 
+    @Test func fileSectionRendersFileLevelInlineFeedbackBelowHeader() {
+        let file = DiffReviewFileSectionModel(
+            summary: summary(path: "Sources/App.swift"),
+            parsedDiff: parsedDiff(),
+            displayModel: displayModel(),
+            placeholderMessage: nil,
+            openFile: nil
+        )
+        let feedback = [
+            DiffReviewInlineFeedback(
+                id: "thread-file",
+                providerName: "GitHub",
+                author: "reviewer",
+                bodyPreview: "Please review this file.",
+                status: .actionable,
+                providerURL: URL(string: "https://github.com/thread-file")!,
+                anchor: DiffReviewInlineFeedbackAnchor(path: "Sources/App.swift", line: nil, side: .unknown),
+                evidenceItemID: "thread-file"
+            ),
+        ]
+        var layout = DiffLayoutMode.split
+        var wrap = false
+        var whitespace = false
+
+        let view = DiffReviewFileSection(
+            file: file,
+            inlineFeedback: feedback,
+            layoutMode: Binding(get: { layout }, set: { layout = $0 }),
+            wrapLines: Binding(get: { wrap }, set: { wrap = $0 }),
+            showWhitespace: Binding(get: { whitespace }, set: { whitespace = $0 }),
+            codeFontFamily: "",
+            codeFontSize: 13,
+            showsSourceBadge: false
+        )
+        .environment(\.theme, theme())
+
+        let controller = host(view, width: 900, height: 500)
+
+        #expect(subview(withAccessibilityIdentifier: "diff-review-inline-feedback-thread-file", in: controller.view) != nil)
+        #expect(accessibilityLabel(in: controller.view, containing: "GitHub") != nil)
+        #expect(accessibilityLabel(in: controller.view, containing: "reviewer") != nil)
+        #expect(accessibilityLabel(in: controller.view, containing: "Please review this file.") != nil)
+    }
+
     @Test func textDocumentViewClearsInactivePaneLSPContextWhenLayoutChanges() {
         let manager = WorkspaceLSPManager(registry: LanguageServerRegistry(userDefined: []))
         let context = DiffPaneLSPContext(
@@ -275,6 +319,53 @@ struct DiffReviewSurfaceTests {
         RunLoop.current.run(until: Date().addingTimeInterval(0.05))
 
         #expect(selected == first.id)
+    }
+
+    @Test func surfacePassesFeedbackToMatchingFileOnly() {
+        let first = summary(path: "Sources/App.swift")
+        let second = summary(path: "Sources/Other.swift")
+        let session = loadedSession(summaries: [first, second])
+        let feedback = [
+            first.id: [
+                DiffReviewInlineFeedback(
+                    id: "thread-app",
+                    providerName: "GitHub",
+                    author: "reviewer",
+                    bodyPreview: "App feedback.",
+                    status: .actionable,
+                    providerURL: nil,
+                    anchor: DiffReviewInlineFeedbackAnchor(path: first.path, line: 2, side: .new),
+                    evidenceItemID: "thread-app"
+                ),
+            ],
+        ]
+        var selected: DiffReviewFileID? = second.id
+        var collapsed = false
+        var layout = DiffLayoutMode.split
+        var wrap = false
+        var whitespace = false
+
+        let view = DiffReviewSurface(
+            session: session,
+            selectedFileID: Binding(get: { selected }, set: { selected = $0 }),
+            railCollapsed: Binding(get: { collapsed }, set: { collapsed = $0 }),
+            layoutMode: Binding(get: { layout }, set: { layout = $0 }),
+            wrapLines: Binding(get: { wrap }, set: { wrap = $0 }),
+            showWhitespace: Binding(get: { whitespace }, set: { whitespace = $0 }),
+            codeFontFamily: "",
+            codeFontSize: 13,
+            inlineFeedbackByFileID: feedback
+        )
+        .environment(\.theme, theme())
+
+        let controller = host(view, width: 1000, height: 700)
+
+        let matchingCards = allSubviews(of: controller.view).filter {
+            $0.accessibilityIdentifier() == "diff-review-inline-feedback-thread-app"
+        }
+        #expect(matchingCards.count == 1)
+        #expect(accessibilityLabel(in: controller.view, containing: "line 2") != nil)
+        #expect(accessibilityLabel(in: controller.view, containing: "App feedback.") != nil)
     }
 
     @Test func selectionSynchronizationClearsEmptySessions() {

--- a/AlasTests/DiffReviewSurfaceTests.swift
+++ b/AlasTests/DiffReviewSurfaceTests.swift
@@ -592,8 +592,69 @@ struct DiffReviewSurfaceTests {
         #expect(manyFeedback == cappedFeedback)
     }
 
-    @Test func inlineFeedbackCardEstimateReservesThreeLinePreviewHeight() {
-        #expect(DiffReviewInlineFeedbackDisplayPolicy.cardEstimatedHeight >= 78)
+    @Test func estimatedSectionHeightGrowsWithInlineFeedbackBodyLength() {
+        let file = DiffReviewFileSectionModel(
+            summary: summary(path: "Sources/App.swift"),
+            parsedDiff: parsedDiff(),
+            displayModel: displayModel(),
+            placeholderMessage: nil,
+            openFile: nil
+        )
+        let shortFeedback = [
+            DiffReviewInlineFeedback(
+                id: "short",
+                providerName: "GitHub",
+                author: "reviewer",
+                bodyPreview: "Short.",
+                status: .actionable,
+                providerURL: nil,
+                anchor: DiffReviewInlineFeedbackAnchor(path: file.summary.path, line: nil, side: .unknown),
+                evidenceItemID: "short"
+            ),
+        ]
+        let longFeedback = [
+            DiffReviewInlineFeedback(
+                id: "long",
+                providerName: "GitHub",
+                author: "reviewer",
+                bodyPreview: Array(repeating: "This review comment needs to remain fully visible.", count: 12).joined(separator: " "),
+                status: .actionable,
+                providerURL: nil,
+                anchor: DiffReviewInlineFeedbackAnchor(path: file.summary.path, line: nil, side: .unknown),
+                evidenceItemID: "long"
+            ),
+        ]
+
+        #expect(
+            DiffReviewFileSectionHeightEstimator.estimatedHeight(for: file, inlineFeedback: longFeedback)
+                > DiffReviewFileSectionHeightEstimator.estimatedHeight(for: file, inlineFeedback: shortFeedback)
+        )
+    }
+
+    @Test func inlineFeedbackCardEstimateUsesDynamicBodyHeight() {
+        let short = DiffReviewInlineFeedback(
+            id: "short",
+            providerName: "GitHub",
+            author: "reviewer",
+            bodyPreview: "Short.",
+            status: .actionable,
+            providerURL: nil,
+            anchor: DiffReviewInlineFeedbackAnchor(path: "Sources/App.swift", line: nil, side: .unknown),
+            evidenceItemID: "short"
+        )
+        let long = DiffReviewInlineFeedback(
+            id: "long",
+            providerName: "GitHub",
+            author: "reviewer",
+            bodyPreview: Array(repeating: "Long feedback body.", count: 24).joined(separator: " "),
+            status: .actionable,
+            providerURL: nil,
+            anchor: DiffReviewInlineFeedbackAnchor(path: "Sources/App.swift", line: nil, side: .unknown),
+            evidenceItemID: "long"
+        )
+
+        #expect(DiffReviewInlineFeedbackDisplayPolicy.estimatedCardHeight(for: long) > DiffReviewInlineFeedbackDisplayPolicy.estimatedCardHeight(for: short))
+        #expect(DiffReviewInlineFeedbackDisplayPolicy.estimatedCardHeight(for: short) >= DiffReviewInlineFeedbackDisplayPolicy.cardMinimumHeight)
     }
 
     private func parsedDiff() -> ParsedDiff {

--- a/AlasTests/DiffReviewSurfaceTests.swift
+++ b/AlasTests/DiffReviewSurfaceTests.swift
@@ -529,6 +529,10 @@ struct DiffReviewSurfaceTests {
         #expect(manyFeedback == cappedFeedback)
     }
 
+    @Test func inlineFeedbackCardEstimateReservesThreeLinePreviewHeight() {
+        #expect(DiffReviewInlineFeedbackDisplayPolicy.cardEstimatedHeight >= 78)
+    }
+
     private func parsedDiff() -> ParsedDiff {
         ParsedDiff(hunks: [
             ParsedDiff.Hunk(

--- a/AlasTests/DiffReviewSurfaceTests.swift
+++ b/AlasTests/DiffReviewSurfaceTests.swift
@@ -225,7 +225,7 @@ struct DiffReviewSurfaceTests {
             placeholderMessage: nil,
             openFile: nil
         )
-        let feedback = inlineFeedbackItems(count: 5, path: file.summary.path)
+        let feedback = inlineFeedbackItems(count: 5, path: file.summary.path, lineAnchored: false)
         var layout = DiffLayoutMode.split
         var wrap = false
         var whitespace = false
@@ -251,6 +251,48 @@ struct DiffReviewSurfaceTests {
         #expect(subview(withAccessibilityIdentifier: "diff-review-inline-feedback-thread-5", in: controller.view) == nil)
         #expect(subview(withAccessibilityIdentifier: "diff-review-inline-feedback-more", in: controller.view) != nil)
         #expect(accessibilityLabel(in: controller.view, containing: "+2 more feedback") != nil)
+    }
+
+    @Test func inlineFeedbackPlacementGroupsLineAnchoredItemsByMatchingHunk() throws {
+        let model = displayModel()
+        let firstGroup = try #require(model.groups.first)
+        let feedback = [
+            DiffReviewInlineFeedback(
+                id: "thread-new-line",
+                providerName: "GitHub",
+                author: "reviewer",
+                bodyPreview: "Review this new line.",
+                status: .actionable,
+                providerURL: nil,
+                anchor: DiffReviewInlineFeedbackAnchor(path: "Sources/App.swift", line: 2, side: .new),
+                evidenceItemID: "thread-new-line"
+            ),
+            DiffReviewInlineFeedback(
+                id: "thread-file",
+                providerName: "GitHub",
+                author: "reviewer",
+                bodyPreview: "Review the whole file.",
+                status: .actionable,
+                providerURL: nil,
+                anchor: DiffReviewInlineFeedbackAnchor(path: "Sources/App.swift", line: nil, side: .unknown),
+                evidenceItemID: "thread-file"
+            ),
+            DiffReviewInlineFeedback(
+                id: "thread-unmatched",
+                providerName: "GitHub",
+                author: "reviewer",
+                bodyPreview: "Review a line outside the diff.",
+                status: .actionable,
+                providerURL: nil,
+                anchor: DiffReviewInlineFeedbackAnchor(path: "Sources/App.swift", line: 42, side: .new),
+                evidenceItemID: "thread-unmatched"
+            ),
+        ]
+
+        let placement = DiffReviewInlineFeedbackPlacement.position(feedback, in: model.groups)
+
+        #expect(placement.byGroupID[firstGroup.id]?.map(\.id) == ["thread-new-line"])
+        #expect(placement.fileLevel.map(\.id) == ["thread-file", "thread-unmatched"])
     }
 
     @Test func textDocumentViewClearsInactivePaneLSPContextWhenLayoutChanges() {
@@ -567,7 +609,11 @@ struct DiffReviewSurfaceTests {
         )
     }
 
-    private func inlineFeedbackItems(count: Int, path: String) -> [DiffReviewInlineFeedback] {
+    private func inlineFeedbackItems(
+        count: Int,
+        path: String,
+        lineAnchored: Bool = true
+    ) -> [DiffReviewInlineFeedback] {
         (1...count).map { index in
             DiffReviewInlineFeedback(
                 id: "thread-\(index)",
@@ -576,7 +622,11 @@ struct DiffReviewSurfaceTests {
                 bodyPreview: "Feedback \(index).",
                 status: .actionable,
                 providerURL: nil,
-                anchor: DiffReviewInlineFeedbackAnchor(path: path, line: index, side: .new),
+                anchor: DiffReviewInlineFeedbackAnchor(
+                    path: path,
+                    line: lineAnchored ? index : nil,
+                    side: lineAnchored ? .new : .unknown
+                ),
                 evidenceItemID: "thread-\(index)"
             )
         }

--- a/AlasTests/DiffReviewSurfaceTests.swift
+++ b/AlasTests/DiffReviewSurfaceTests.swift
@@ -319,6 +319,70 @@ struct DiffReviewSurfaceTests {
         #expect(!result.programmaticScroll.isSuppressing)
     }
 
+    @Test func scrollCommandAdvancesGenerationForRepeatedFileSelections() {
+        let file = DiffReviewFileID(namespace: "commit", path: "Sources/App.swift")
+        var controller = DiffReviewScrollCommandController()
+
+        let first = controller.command(to: file)
+        let second = controller.command(to: file)
+
+        #expect(first.id == file)
+        #expect(second.id == file)
+        #expect(second.generation == first.generation + 1)
+    }
+
+    @Test func renderWindowKeepsSelectedTargetAndNearViewportFiles() {
+        let selected = DiffReviewFileID(namespace: "commit", path: "Selected.swift")
+        let near = DiffReviewFileID(namespace: "commit", path: "Near.swift")
+        let far = DiffReviewFileID(namespace: "commit", path: "Far.swift")
+        let target = DiffReviewFileID(namespace: "commit", path: "Target.swift")
+        let frames = [
+            DiffReviewSectionFrame(id: near, minY: 520, maxY: 820),
+            DiffReviewSectionFrame(id: far, minY: 5_000, maxY: 5_300),
+        ]
+
+        let rendered = DiffReviewRenderWindow.renderedFileIDs(
+            current: [far],
+            frames: frames,
+            viewportHeight: 500,
+            selectedFileID: selected,
+            programmaticTarget: target,
+            firstFileID: nil
+        )
+
+        #expect(rendered.contains(selected))
+        #expect(rendered.contains(target))
+        #expect(rendered.contains(near))
+        #expect(!rendered.contains(far))
+    }
+
+    @Test func estimatedSectionHeightScalesWithDiffRows() {
+        let small = DiffReviewFileSectionModel(
+            summary: summary(path: "Sources/Small.swift"),
+            parsedDiff: parsedDiff(),
+            displayModel: displayModel(),
+            placeholderMessage: nil,
+            openFile: nil
+        )
+        var largeRows = Array(
+            repeating: ParsedDiff.Hunk.Line(kind: .add, text: "let value = 1", oldNumber: nil, newNumber: 1),
+            count: 40
+        )
+        largeRows.insert(.init(kind: .context, text: "let before = 0", oldNumber: 1, newNumber: 1), at: 0)
+        let largeDiff = ParsedDiff(hunks: [
+            ParsedDiff.Hunk(header: "@@ -1,1 +1,41 @@", oldStart: 1, newStart: 1, lines: largeRows),
+        ])
+        let large = DiffReviewFileSectionModel(
+            summary: summary(path: "Sources/Large.swift", additions: 40),
+            parsedDiff: largeDiff,
+            displayModel: DiffDisplayModelBuilder.build(diff: largeDiff, filePath: "Sources/Large.swift"),
+            placeholderMessage: nil,
+            openFile: nil
+        )
+
+        #expect(DiffReviewFileSectionHeightEstimator.estimatedHeight(for: large) > DiffReviewFileSectionHeightEstimator.estimatedHeight(for: small))
+    }
+
     private func parsedDiff() -> ParsedDiff {
         ParsedDiff(hunks: [
             ParsedDiff.Hunk(

--- a/AlasTests/DiffReviewSurfaceTests.swift
+++ b/AlasTests/DiffReviewSurfaceTests.swift
@@ -295,6 +295,27 @@ struct DiffReviewSurfaceTests {
         #expect(placement.fileLevel.map(\.id) == ["thread-file", "thread-unmatched"])
     }
 
+    @MainActor
+    @Test func inlineFeedbackMarkdownRendersCommonReviewMarkup() throws {
+        let rendered = NSAttributedString(
+            DiffReviewInlineFeedbackMarkdown.render("Use **bold** and `configId`, then see [docs](https://example.com/docs).")
+        )
+
+        #expect(rendered.string == "Use bold and configId, then see docs.")
+
+        let linkRange = (rendered.string as NSString).range(of: "docs")
+        try #require(linkRange.location != NSNotFound)
+        let url = rendered.attribute(NSAttributedString.Key.link, at: linkRange.location, effectiveRange: nil) as? URL
+        #expect(url?.absoluteString == "https://example.com/docs")
+    }
+
+    @MainActor
+    @Test func inlineFeedbackMarkdownPlainTextStripsDelimitersForAccessibility() {
+        let plain = DiffReviewInlineFeedbackMarkdown.plainText("Use **bold** and `configId`.")
+
+        #expect(plain == "Use bold and configId.")
+    }
+
     @Test func textDocumentViewClearsInactivePaneLSPContextWhenLayoutChanges() {
         let manager = WorkspaceLSPManager(registry: LanguageServerRegistry(userDefined: []))
         let context = DiffPaneLSPContext(

--- a/AlasTests/Integrations/CodeHostProviderTests.swift
+++ b/AlasTests/Integrations/CodeHostProviderTests.swift
@@ -139,6 +139,30 @@ struct CodeHostProviderTests {
         #expect(feedback.first?.status == .actionable)
     }
 
+    @Test func reviewThreadSummaryPreservesLocation() throws {
+        let location = ReviewThreadLocation(
+            path: "Sources/App.swift",
+            originalPath: nil,
+            line: 42,
+            side: .new,
+            providerPosition: "github-position-1"
+        )
+        let thread = ReviewThreadSummary(
+            id: "thread-located",
+            author: "reviewer",
+            body: "Inline feedback.",
+            url: URL(string: "https://github.com/thread-located")!,
+            isResolved: false,
+            isActionable: true,
+            location: location
+        )
+
+        #expect(thread.location?.path == "Sources/App.swift")
+        #expect(thread.location?.line == 42)
+        #expect(thread.location?.side == .new)
+        #expect(thread.location?.providerPosition == "github-position-1")
+    }
+
     @Test func defaultFeedbackEvidenceSynthesizesChangesRequestedWhenThreadsAreMissing() async throws {
         let remote = CodeHostRemote(
             kind: .github,

--- a/AlasTests/Integrations/CodeHostProviderTests.swift
+++ b/AlasTests/Integrations/CodeHostProviderTests.swift
@@ -133,8 +133,8 @@ struct CodeHostProviderTests {
         let ci = try await provider.failedCheckEvidence(remote: remote, request: request, cwd: URL(fileURLWithPath: "/tmp/alas"))
         let feedback = try await provider.feedbackEvidence(remote: remote, request: request, cwd: URL(fileURLWithPath: "/tmp/alas"))
 
-        #expect(ci.map(\.id) == ["check-1"])
-        #expect(ci.first?.status == .failed)
+        #expect(ci.map(\.id) == ["check-passed", "check-1", "check-pending"])
+        #expect(ci.map(\.status) == [.passed, .failed, .pending])
         #expect(feedback.map(\.id) == ["thread-1"])
         #expect(feedback.first?.status == .actionable)
     }

--- a/AlasTests/Integrations/GitHubCLIProviderTests.swift
+++ b/AlasTests/Integrations/GitHubCLIProviderTests.swift
@@ -220,6 +220,43 @@ struct GitHubCLIProviderTests {
         ])
     }
 
+    @Test func reviewDiffUsesPRDiffCommand() async throws {
+        let runner = FakeRunner(results: [
+            ProcessResult(exitCode: 0, stdout: "diff --git a/A.swift b/A.swift\n", stderr: ""),
+        ])
+        let request = try #require(try GitHubCLIProvider.parsePRList(Self.prListOutput, remote: Self.remote))
+
+        let diff = try await GitHubCLIProvider(runner: runner).reviewDiff(
+            remote: Self.remote,
+            request: request,
+            cwd: Self.cwd
+        )
+
+        #expect(diff == "diff --git a/A.swift b/A.swift\n")
+        #expect(await runner.commands == [
+            FakeRunner.Command(
+                executable: "gh",
+                args: ["pr", "diff", "42", "-R", "mrmans0n/alas"],
+                cwd: Self.cwd
+            ),
+        ])
+    }
+
+    @Test func reviewDiffSurfacesGitHubCommandFailure() async throws {
+        let runner = FakeRunner(results: [
+            ProcessResult(exitCode: 1, stdout: "", stderr: "not found"),
+        ])
+        let request = try #require(try GitHubCLIProvider.parsePRList(Self.prListOutput, remote: Self.remote))
+
+        await #expect(throws: CodeHostProviderError.commandFailed(command: "gh pr diff", stderr: "not found")) {
+            _ = try await GitHubCLIProvider(runner: runner).reviewDiff(
+                remote: Self.remote,
+                request: request,
+                cwd: Self.cwd
+            )
+        }
+    }
+
     @Test func currentReviewRequestKeepsRequestWhenReviewThreadFetchFails() async throws {
         let runner = FakeRunner(results: [
             ProcessResult(exitCode: 0, stdout: Self.prListOutput, stderr: ""),

--- a/AlasTests/Integrations/GitHubCLIProviderTests.swift
+++ b/AlasTests/Integrations/GitHubCLIProviderTests.swift
@@ -313,6 +313,50 @@ struct GitHubCLIProviderTests {
         #expect(threads[1].isActionable == false)
     }
 
+    @Test func reviewThreadsJSONPreservesLocationMetadata() throws {
+        let threads = try GitHubCLIProvider.parseReviewThreads(
+            """
+            {
+              "data": {
+                "repository": {
+                  "pullRequest": {
+                    "reviewThreads": {
+                      "nodes": [
+                        {
+                          "id": "PRRT_kwDO",
+                          "isResolved": false,
+                          "isOutdated": false,
+                          "path": "Sources/App.swift",
+                          "line": 56,
+                          "originalLine": null,
+                          "diffSide": "RIGHT",
+                          "comments": {
+                            "nodes": [
+                              {
+                                "id": "PRRC_kwDO",
+                                "body": "Please simplify this.",
+                                "url": "https://github.com/mrmans0n/alas/pull/1#discussion_r1",
+                                "author": { "login": "reviewer" }
+                              }
+                            ]
+                          }
+                        }
+                      ],
+                      "pageInfo": { "hasNextPage": false, "endCursor": null }
+                    }
+                  }
+                }
+              }
+            }
+            """
+        )
+
+        #expect(threads.first?.location?.path == "Sources/App.swift")
+        #expect(threads.first?.location?.line == 56)
+        #expect(threads.first?.location?.side == .new)
+        #expect(threads.first?.location?.providerPosition == "PRRT_kwDO")
+    }
+
     @Test func prListFiltersByHeadOwnerWhenProvided() throws {
         let request = try #require(try GitHubCLIProvider.parsePRList(
             """

--- a/AlasTests/Integrations/GitHubCLIProviderTests.swift
+++ b/AlasTests/Integrations/GitHubCLIProviderTests.swift
@@ -480,8 +480,8 @@ struct GitHubCLIProviderTests {
         #expect(checks[0].bucket == .fail)
     }
 
-    @Test func failedCheckEvidenceUsesFailedChecksOnly() async throws {
-        let checks = try GitHubCLIProvider.parseChecks(Self.failedChecksOutput)
+    @Test func failedCheckEvidenceUsesCIActivityChecks() async throws {
+        let checks = try GitHubCLIProvider.parseChecks(Self.ciActivityChecksOutput)
         let request = Self.makeRequest(checks: checks)
 
         let evidence = try await GitHubCLIProvider().failedCheckEvidence(
@@ -490,16 +490,11 @@ struct GitHubCLIProviderTests {
             cwd: Self.cwd
         )
 
-        #expect(evidence == [
-            ReviewEvidenceItem(
-                id: checks[0].id,
-                section: .ci,
-                title: "test",
-                subtitle: "CI",
-                status: .failed,
-                providerURL: URL(string: "https://github.com/mrmans0n/alas/actions/runs/1/job/3")
-            ),
-        ])
+        #expect(evidence.map(\.id) == checks.map(\.id))
+        #expect(evidence.map(\.title) == ["build", "test", "lint", "docs", "deploy"])
+        #expect(evidence.map(\.subtitle) == ["CI", "CI", "CI", "Docs", "Deploy"])
+        #expect(evidence.map(\.status) == [.passed, .failed, .pending, .unknown, .cancelled])
+        #expect(evidence.map(\.providerURL) == checks.map(\.detailURL))
     }
 
     @Test func checkEvidenceDetailLoadsRunLogForWorkflowCheck() async throws {
@@ -872,6 +867,66 @@ struct GitHubCLIProviderTests {
         "startedAt": "2026-06-01T12:31:00Z",
         "state": "FAILURE",
         "workflow": "CI"
+      }
+    ]
+    """
+
+    private static let ciActivityChecksOutput = """
+    [
+      {
+        "bucket": "pass",
+        "completedAt": "2026-06-01T12:34:56Z",
+        "description": "Build passed",
+        "event": "push",
+        "link": "https://github.com/mrmans0n/alas/actions/runs/1/job/1",
+        "name": "build",
+        "startedAt": "2026-06-01T12:30:00Z",
+        "state": "SUCCESS",
+        "workflow": "CI"
+      },
+      {
+        "bucket": "fail",
+        "completedAt": "2026-06-01T12:35:56Z",
+        "description": "Unit tests failed",
+        "event": "push",
+        "link": "https://github.com/mrmans0n/alas/actions/runs/1/job/3",
+        "name": "test",
+        "startedAt": "2026-06-01T12:31:00Z",
+        "state": "FAILURE",
+        "workflow": "CI"
+      },
+      {
+        "bucket": "pending",
+        "completedAt": null,
+        "description": "Lint is running",
+        "event": "push",
+        "link": "https://github.com/mrmans0n/alas/actions/runs/1/job/4",
+        "name": "lint",
+        "startedAt": "2026-06-01T12:32:00Z",
+        "state": "PENDING",
+        "workflow": "CI"
+      },
+      {
+        "bucket": "skipping",
+        "completedAt": null,
+        "description": "Docs skipped",
+        "event": "push",
+        "link": "https://github.com/mrmans0n/alas/actions/runs/1/job/5",
+        "name": "docs",
+        "startedAt": null,
+        "state": "SKIPPED",
+        "workflow": "Docs"
+      },
+      {
+        "bucket": "cancel",
+        "completedAt": "2026-06-01T12:36:56Z",
+        "description": "Deploy cancelled",
+        "event": "push",
+        "link": "https://github.com/mrmans0n/alas/actions/runs/1/job/6",
+        "name": "deploy",
+        "startedAt": "2026-06-01T12:33:00Z",
+        "state": "CANCELLED",
+        "workflow": "Deploy"
       }
     ]
     """

--- a/AlasTests/Integrations/GitHubCLIProviderTests.swift
+++ b/AlasTests/Integrations/GitHubCLIProviderTests.swift
@@ -357,6 +357,49 @@ struct GitHubCLIProviderTests {
         #expect(threads.first?.location?.providerPosition == "PRRT_kwDO")
     }
 
+    @Test func reviewThreadsJSONIgnoresMalformedLocationMetadata() throws {
+        let threads = try GitHubCLIProvider.parseReviewThreads(
+            """
+            {
+              "data": {
+                "repository": {
+                  "pullRequest": {
+                    "reviewThreads": {
+                      "nodes": [
+                        {
+                          "id": "PRRT_malformed",
+                          "isResolved": false,
+                          "isOutdated": false,
+                          "path": 123,
+                          "line": "56",
+                          "originalLine": "55",
+                          "diffSide": true,
+                          "comments": {
+                            "nodes": [
+                              {
+                                "id": "PRRC_malformed",
+                                "body": "Keep this feedback.",
+                                "url": "https://github.com/mrmans0n/alas/pull/1#discussion_r2",
+                                "author": { "login": "reviewer" }
+                              }
+                            ]
+                          }
+                        }
+                      ],
+                      "pageInfo": { "hasNextPage": false, "endCursor": null }
+                    }
+                  }
+                }
+              }
+            }
+            """
+        )
+
+        #expect(threads.map(\.id) == ["PRRT_malformed"])
+        #expect(threads.first?.body == "Keep this feedback.")
+        #expect(threads.first?.location == nil)
+    }
+
     @Test func prListFiltersByHeadOwnerWhenProvided() throws {
         let request = try #require(try GitHubCLIProvider.parsePRList(
             """

--- a/AlasTests/Integrations/GitHubCLIProviderTests.swift
+++ b/AlasTests/Integrations/GitHubCLIProviderTests.swift
@@ -559,6 +559,31 @@ struct GitHubCLIProviderTests {
         ])
     }
 
+    @Test func checkEvidenceDetailDoesNotLoadFailedLogsForNonFailedCheck() async throws {
+        let request = Self.makeRequest(checks: [])
+        let runner = FakeRunner(results: [])
+        let provider = GitHubCLIProvider(runner: runner)
+        let item = ReviewEvidenceItem(
+            id: "ci:lint",
+            section: .ci,
+            title: "lint",
+            subtitle: "CI",
+            status: .pending,
+            providerURL: URL(string: "https://github.com/mrmans0n/alas/actions/runs/1")
+        )
+
+        let detail = try await provider.checkEvidenceDetail(
+            remote: Self.remote,
+            request: request,
+            item: item,
+            cwd: Self.cwd
+        )
+
+        #expect(detail.body == "Open this check in GitHub to inspect current status.")
+        #expect(detail.isTruncated == false)
+        #expect(await runner.commands.isEmpty)
+    }
+
     @Test func feedbackEvidenceDetailUsesThreadBody() async throws {
         let threads = try GitHubCLIProvider.parseReviewThreads(Self.reviewThreadsOutput)
         let request = Self.makeRequest(threads: threads)

--- a/AlasTests/Integrations/GitLabCLIProviderTests.swift
+++ b/AlasTests/Integrations/GitLabCLIProviderTests.swift
@@ -704,7 +704,7 @@ struct GitLabCLIProviderTests {
         #expect(await runner.commands == [
             FakeRunner.Command(
                 executable: "glab",
-                args: ["mr", "diff", "42", "-R", "platform/mobile/alas"],
+                args: ["mr", "diff", "42", "--raw", "--color=never", "-R", "platform/mobile/alas"],
                 cwd: Self.cwd
             ),
         ])

--- a/AlasTests/Integrations/GitLabCLIProviderTests.swift
+++ b/AlasTests/Integrations/GitLabCLIProviderTests.swift
@@ -605,6 +605,43 @@ struct GitLabCLIProviderTests {
         ))
     }
 
+    @Test func reviewDiffUsesMRDiffCommand() async throws {
+        let runner = FakeRunner(results: [
+            ProcessResult(exitCode: 0, stdout: "diff --git a/A.swift b/A.swift\n", stderr: ""),
+        ])
+        let request = try GitLabCLIProvider.parseMRView(Self.mrViewOutput, remote: Self.remote)
+
+        let diff = try await GitLabCLIProvider(runner: runner).reviewDiff(
+            remote: Self.remote,
+            request: request,
+            cwd: Self.cwd
+        )
+
+        #expect(diff == "diff --git a/A.swift b/A.swift\n")
+        #expect(await runner.commands == [
+            FakeRunner.Command(
+                executable: "glab",
+                args: ["mr", "diff", "42", "-R", "platform/mobile/alas"],
+                cwd: Self.cwd
+            ),
+        ])
+    }
+
+    @Test func reviewDiffSurfacesGitLabCommandFailure() async throws {
+        let runner = FakeRunner(results: [
+            ProcessResult(exitCode: 1, stdout: "", stderr: "not found"),
+        ])
+        let request = try GitLabCLIProvider.parseMRView(Self.mrViewOutput, remote: Self.remote)
+
+        await #expect(throws: CodeHostProviderError.commandFailed(command: "glab mr diff", stderr: "not found")) {
+            _ = try await GitLabCLIProvider(runner: runner).reviewDiff(
+                remote: Self.remote,
+                request: request,
+                cwd: Self.cwd
+            )
+        }
+    }
+
     @Test func currentReviewRequestResolvesSourceProjectIDsBeforeFilteringForkMRs() async throws {
         let runner = FakeRunner(results: [
             ProcessResult(exitCode: 0, stdout: Self.duplicateForkMRListOutput, stderr: ""),

--- a/AlasTests/Integrations/GitLabCLIProviderTests.swift
+++ b/AlasTests/Integrations/GitLabCLIProviderTests.swift
@@ -141,6 +141,41 @@ struct GitLabCLIProviderTests {
         #expect(threads[1].isActionable)
     }
 
+    @Test func discussionsJSONPreservesLocationMetadata() throws {
+        let threads = try GitLabCLIProvider.parseDiscussions(
+            """
+            [
+              {
+                "id": "discussion-1",
+                "resolved": false,
+                "notes": [
+                  {
+                    "id": 100,
+                    "body": "This needs a guard.",
+                    "system": false,
+                    "web_url": "https://gitlab.example.com/group/proj/-/merge_requests/7#note_100",
+                    "author": { "username": "reviewer" },
+                    "position": {
+                      "new_path": "Sources/App.swift",
+                      "old_path": "Sources/OldApp.swift",
+                      "new_line": 24,
+                      "old_line": null
+                    }
+                  }
+                ]
+              }
+            ]
+            """,
+            requestURL: URL(string: "https://gitlab.example.com/group/proj/-/merge_requests/7")!
+        )
+
+        #expect(threads.first?.location?.path == "Sources/App.swift")
+        #expect(threads.first?.location?.originalPath == "Sources/OldApp.swift")
+        #expect(threads.first?.location?.line == 24)
+        #expect(threads.first?.location?.side == .new)
+        #expect(threads.first?.location?.providerPosition == "100")
+    }
+
     @Test func discussionsJSONSkipsSystemOnlyDiscussions() throws {
         let threads = try GitLabCLIProvider.parseDiscussions(
             Self.systemOnlyDiscussionsOutput,

--- a/AlasTests/Integrations/GitLabCLIProviderTests.swift
+++ b/AlasTests/Integrations/GitLabCLIProviderTests.swift
@@ -572,8 +572,8 @@ struct GitLabCLIProviderTests {
             cwd: Self.cwd
         )
 
-        #expect(evidence.map(\.title) == ["build", "test", "lint"])
-        #expect(evidence.map(\.status) == [.passed, .failed, .failed])
+        #expect(evidence.map(\.title) == ["build", "test", "lint", "deploy"])
+        #expect(evidence.map(\.status) == [.passed, .failed, .failed, .pending])
     }
 
     @Test func checkEvidenceDetailLoadsGitLabTraceForJobID() async throws {
@@ -1442,6 +1442,12 @@ struct GitLabCLIProviderTests {
           "name": "lint",
           "status": "failed",
           "web_url": "https://gitlab.example.com/platform/mobile/alas/-/jobs/103"
+        },
+        {
+          "id": 104,
+          "name": "deploy",
+          "status": "running",
+          "web_url": "https://gitlab.example.com/platform/mobile/alas/-/jobs/104"
         }
       ]
     }

--- a/AlasTests/Integrations/GitLabCLIProviderTests.swift
+++ b/AlasTests/Integrations/GitLabCLIProviderTests.swift
@@ -176,6 +176,53 @@ struct GitLabCLIProviderTests {
         #expect(threads.first?.location?.providerPosition == "100")
     }
 
+    @Test func discussionsJSONIgnoresMalformedPositionMetadata() throws {
+        let threads = try GitLabCLIProvider.parseDiscussions(
+            """
+            [
+              {
+                "id": "discussion-malformed",
+                "resolved": false,
+                "notes": [
+                  {
+                    "id": 101,
+                    "body": "Keep this discussion.",
+                    "system": false,
+                    "web_url": "https://gitlab.example.com/group/proj/-/merge_requests/7#note_101",
+                    "author": { "username": "reviewer" },
+                    "position": {
+                      "new_path": 123,
+                      "old_path": "Sources/OldApp.swift",
+                      "new_line": "24",
+                      "old_line": false
+                    }
+                  }
+                ]
+              },
+              {
+                "id": "discussion-position-string",
+                "resolved": false,
+                "notes": [
+                  {
+                    "id": 102,
+                    "body": "Keep this non-object position discussion.",
+                    "system": false,
+                    "web_url": "https://gitlab.example.com/group/proj/-/merge_requests/7#note_102",
+                    "author": { "username": "reviewer" },
+                    "position": "not-a-position-object"
+                  }
+                ]
+              }
+            ]
+            """,
+            requestURL: URL(string: "https://gitlab.example.com/group/proj/-/merge_requests/7")!
+        )
+
+        #expect(threads.map(\.id) == ["discussion-malformed", "discussion-position-string"])
+        #expect(threads.first?.body == "Keep this discussion.")
+        #expect(threads.allSatisfy { $0.location == nil })
+    }
+
     @Test func discussionsJSONSkipsSystemOnlyDiscussions() throws {
         let threads = try GitLabCLIProvider.parseDiscussions(
             Self.systemOnlyDiscussionsOutput,

--- a/AlasTests/Integrations/GitLabCLIProviderTests.swift
+++ b/AlasTests/Integrations/GitLabCLIProviderTests.swift
@@ -562,7 +562,7 @@ struct GitLabCLIProviderTests {
         }
     }
 
-    @Test func failedCheckEvidenceUsesFailedPipelineJobs() async throws {
+    @Test func failedCheckEvidenceUsesPipelineJobs() async throws {
         let checks = try GitLabCLIProvider.parsePipeline(Self.pipelineWithFailedJobsOutput)
         let request = Self.makeRequest(checks: checks)
 
@@ -572,8 +572,8 @@ struct GitLabCLIProviderTests {
             cwd: Self.cwd
         )
 
-        #expect(evidence.map(\.title) == ["test", "lint"])
-        #expect(evidence.allSatisfy { $0.status == .failed })
+        #expect(evidence.map(\.title) == ["build", "test", "lint"])
+        #expect(evidence.map(\.status) == [.passed, .failed, .failed])
     }
 
     @Test func checkEvidenceDetailLoadsGitLabTraceForJobID() async throws {
@@ -582,11 +582,12 @@ struct GitLabCLIProviderTests {
         ])
         let checks = try GitLabCLIProvider.parsePipeline(Self.pipelineWithFailedJobsOutput)
         let request = Self.makeRequest(checks: checks)
-        let item = try #require(try await GitLabCLIProvider(runner: runner).failedCheckEvidence(
+        let evidence = try await GitLabCLIProvider(runner: runner).failedCheckEvidence(
             remote: Self.remote,
             request: request,
             cwd: Self.cwd
-        ).first)
+        )
+        let item = try #require(evidence.first { $0.title == "test" })
 
         let detail = try await GitLabCLIProvider(runner: runner).checkEvidenceDetail(
             remote: Self.remote,

--- a/AlasTests/Integrations/ReviewEvidenceModelTests.swift
+++ b/AlasTests/Integrations/ReviewEvidenceModelTests.swift
@@ -175,7 +175,7 @@ struct ReviewEvidenceModelTests {
         #expect(!ReviewEvidenceTabView.shouldShowModelUnavailable(model))
     }
 
-    @Test func evidenceErrorWithFileErrorStillShowsUnavailableForCIAndFeedback() {
+    @Test func evidenceErrorWithFileErrorKeepsBrowserAvailableForCIAndFeedback() {
         let ciUnavailable = ReviewEvidenceTabView.shouldShowModelUnavailable(
             selectedSection: .ci,
             isLoadingFiles: false,
@@ -195,8 +195,32 @@ struct ReviewEvidenceModelTests {
             modelErrorMessage: "feedback unavailable"
         )
 
-        #expect(ciUnavailable)
-        #expect(feedbackUnavailable)
+        #expect(!ciUnavailable)
+        #expect(!feedbackUnavailable)
+    }
+
+    @Test func evidenceErrorWithLoadedFilesKeepsBrowserAvailableForCIAndFeedback() {
+        let ciUnavailable = ReviewEvidenceTabView.shouldShowModelUnavailable(
+            selectedSection: .ci,
+            isLoadingFiles: false,
+            fileErrorMessage: nil,
+            fileSession: Self.loadedSession(),
+            ciItemsAreEmpty: true,
+            feedbackItemsAreEmpty: true,
+            modelErrorMessage: "checks unavailable"
+        )
+        let feedbackUnavailable = ReviewEvidenceTabView.shouldShowModelUnavailable(
+            selectedSection: .feedback,
+            isLoadingFiles: false,
+            fileErrorMessage: nil,
+            fileSession: Self.loadedSession(),
+            ciItemsAreEmpty: true,
+            feedbackItemsAreEmpty: true,
+            modelErrorMessage: "feedback unavailable"
+        )
+
+        #expect(!ciUnavailable)
+        #expect(!feedbackUnavailable)
     }
 
     @Test func emptyFileSessionChoosesEmptyState() {

--- a/AlasTests/Integrations/ReviewEvidenceModelTests.swift
+++ b/AlasTests/Integrations/ReviewEvidenceModelTests.swift
@@ -236,6 +236,56 @@ struct ReviewEvidenceModelTests {
         #expect(feedback[copiedFromApp.id] == nil)
     }
 
+    @Test func inlineFeedbackMappingPrefersExactCurrentPathWhenOldSideOriginalPathEqualsPath() {
+        let modifiedFile = DiffReviewFileSummary(
+            path: "Sources/App.swift",
+            namespace: "github-pr",
+            groupID: nil,
+            groupTitle: nil,
+            status: .modified,
+            additions: 2,
+            deletions: 2,
+            isRenderable: true
+        )
+        let copiedFromApp = DiffReviewFileSummary(
+            path: "Sources/AppCopy.swift",
+            namespace: "github-pr",
+            groupID: nil,
+            groupTitle: nil,
+            status: .copied,
+            additions: 3,
+            deletions: 1,
+            isRenderable: true,
+            originalPath: "Sources/App.swift"
+        )
+        let threads = [
+            ReviewThreadSummary(
+                id: "thread-old-side-same-original-path",
+                author: "reviewer",
+                body: "GitLab reports old_path and new_path as the same file.",
+                url: URL(string: "https://github.com/discussion/old-same"),
+                isResolved: false,
+                isActionable: true,
+                location: ReviewThreadLocation(
+                    path: "Sources/App.swift",
+                    originalPath: "Sources/App.swift",
+                    line: 5,
+                    side: .old,
+                    providerPosition: "old-same"
+                )
+            ),
+        ]
+
+        let feedback = ReviewEvidenceInlineFeedbackMapper.feedbackByFileID(
+            threads: threads,
+            files: [modifiedFile, copiedFromApp],
+            providerName: "GitHub"
+        )
+
+        #expect(feedback[modifiedFile.id]?.map(\.id) == ["thread-old-side-same-original-path"])
+        #expect(feedback[copiedFromApp.id] == nil)
+    }
+
     @Test func inlineFeedbackMappingFallsBackToOriginalPathForNewSideWhenCurrentPathIsMissing() {
         let renamedFile = DiffReviewFileSummary(
             path: "Sources/NewApp.swift",

--- a/AlasTests/Integrations/ReviewEvidenceModelTests.swift
+++ b/AlasTests/Integrations/ReviewEvidenceModelTests.swift
@@ -230,6 +230,50 @@ struct ReviewEvidenceModelTests {
         ))
     }
 
+    @Test func inlineFeedbackMappingFallsBackToOriginalPathForUnknownSideWhenCurrentPathIsMissing() {
+        let renamedFile = DiffReviewFileSummary(
+            path: "Sources/NewApp.swift",
+            namespace: "github-pr",
+            groupID: nil,
+            groupTitle: nil,
+            status: .renamed,
+            additions: 4,
+            deletions: 3,
+            isRenderable: true,
+            originalPath: "Sources/OldApp.swift"
+        )
+        let threads = [
+            ReviewThreadSummary(
+                id: "thread-unknown-side-original-path",
+                author: "reviewer",
+                body: "Provider omitted side data.",
+                url: URL(string: "https://github.com/discussion/unknown-original"),
+                isResolved: false,
+                isActionable: true,
+                location: ReviewThreadLocation(
+                    path: "Sources/OldApp.swift",
+                    originalPath: nil,
+                    line: 8,
+                    side: .unknown,
+                    providerPosition: "unknown-original"
+                )
+            ),
+        ]
+
+        let feedback = ReviewEvidenceInlineFeedbackMapper.feedbackByFileID(
+            threads: threads,
+            files: [renamedFile],
+            providerName: "GitHub"
+        )
+
+        #expect(feedback[renamedFile.id]?.map(\.id) == ["thread-unknown-side-original-path"])
+        #expect(feedback[renamedFile.id]?.first?.anchor == DiffReviewInlineFeedbackAnchor(
+            path: "Sources/OldApp.swift",
+            line: 8,
+            side: .unknown
+        ))
+    }
+
     @Test func modelPublishesInlineFeedbackAfterFilesAndEvidenceLoad() async throws {
         let model = ReviewEvidenceModel(
             snapshot: Self.snapshot(reviewRequest: Self.reviewRequest(threads: [

--- a/AlasTests/Integrations/ReviewEvidenceModelTests.swift
+++ b/AlasTests/Integrations/ReviewEvidenceModelTests.swift
@@ -59,6 +59,54 @@ struct ReviewEvidenceModelTests {
         #expect(model.feedbackItems.isEmpty)
     }
 
+    @Test func evidencePublishesWhileFileLoadIsSuspended() async {
+        let provider = SuspendedLoadProvider(suspendDiff: true)
+        let model = ReviewEvidenceModel(
+            snapshot: Self.snapshot(),
+            provider: provider,
+            cwd: URL(fileURLWithPath: "/tmp/alas"),
+            initialSection: nil
+        )
+
+        let task = Task { await model.load() }
+        await provider.waitForDiffCall()
+        await provider.waitForEvidenceCalls()
+
+        #expect(await Self.waitUntil { !model.ciItems.isEmpty && !model.feedbackItems.isEmpty })
+        #expect(model.ciItems.map(\.id) == ["ci:test"])
+        #expect(model.feedbackItems.map(\.id) == ["feedback:thread-1"])
+        #expect(!model.isLoadingList)
+        #expect(model.fileSession == nil)
+        #expect(model.isLoadingFiles)
+
+        await provider.completeDiff()
+        await task.value
+    }
+
+    @Test func filesPublishWhileEvidenceLoadIsSuspended() async {
+        let provider = SuspendedLoadProvider(suspendEvidence: true)
+        let model = ReviewEvidenceModel(
+            snapshot: Self.snapshot(),
+            provider: provider,
+            cwd: URL(fileURLWithPath: "/tmp/alas"),
+            initialSection: nil
+        )
+
+        let task = Task { await model.load() }
+        await provider.waitForEvidenceCalls()
+        await provider.waitForDiffCall()
+
+        #expect(await Self.waitUntil { model.fileSession != nil })
+        #expect(model.fileSession?.files.map(\.summary.path) == ["Sources/App.swift"])
+        #expect(!model.isLoadingFiles)
+        #expect(model.ciItems.isEmpty)
+        #expect(model.feedbackItems.isEmpty)
+        #expect(model.isLoadingList)
+
+        await provider.completeEvidence()
+        await task.value
+    }
+
     @Test func loadingSelectedDetailForFilesClearsDetailWithoutProviderCalls() async {
         let recorder = EvidenceProviderRecorder()
         let model = ReviewEvidenceModel(
@@ -77,6 +125,29 @@ struct ReviewEvidenceModelTests {
         let counts = await recorder.detailCounts()
         #expect(counts.ci == 0)
         #expect(counts.feedback == 0)
+    }
+
+    @Test func selectingFilesCancelsSuspendedDetailLoad() async {
+        let provider = SuspendedDetailProvider()
+        let model = ReviewEvidenceModel(
+            snapshot: Self.snapshot(),
+            provider: provider,
+            cwd: URL(fileURLWithPath: "/tmp/alas"),
+            initialSection: .ci
+        )
+
+        await model.load()
+        let task = Task { await model.loadSelectedDetail() }
+        await provider.waitForCIDetailCall()
+
+        model.select(section: .files)
+        await provider.completeCIDetail()
+        await task.value
+
+        #expect(model.selectedSection == .files)
+        #expect(model.selectedItemID == nil)
+        #expect(model.selectedDetail == nil)
+        #expect(!model.isLoadingDetail)
     }
 
     @Test func loadingDetailPreservesSelectionAndStoresDetail() async {
@@ -237,6 +308,16 @@ struct ReviewEvidenceModelTests {
             status: .actionable,
             providerURL: URL(string: "https://github.com/discussion/\(id)")
         )
+    }
+
+    private static func waitUntil(_ predicate: () -> Bool) async -> Bool {
+        for _ in 0..<50 {
+            if predicate() {
+                return true
+            }
+            try? await Task.sleep(for: .milliseconds(10))
+        }
+        return predicate()
     }
 }
 
@@ -410,6 +491,143 @@ private struct FakeCodeHostProvider: CodeHostProvider {
         request: ReviewRequest?,
         cwd: URL
     ) async throws {}
+}
+
+private actor SuspendedLoadProvider: CodeHostProvider {
+    nonisolated let kind: CodeHostKind = .github
+    nonisolated let capabilities: CodeHostProviderCapabilities = .githubCLI
+
+    private let suspendDiff: Bool
+    private let suspendEvidence: Bool
+    private var diffContinuation: CheckedContinuation<String, Never>?
+    private var ciContinuation: CheckedContinuation<[ReviewEvidenceItem], Never>?
+    private var feedbackContinuation: CheckedContinuation<[ReviewEvidenceItem], Never>?
+    private var diffWaiters: [CheckedContinuation<Void, Never>] = []
+    private var evidenceWaiters: [CheckedContinuation<Void, Never>] = []
+    private var didCallDiff = false
+    private var didCallCI = false
+    private var didCallFeedback = false
+
+    init(suspendDiff: Bool = false, suspendEvidence: Bool = false) {
+        self.suspendDiff = suspendDiff
+        self.suspendEvidence = suspendEvidence
+    }
+
+    func waitForDiffCall() async {
+        if didCallDiff { return }
+        await withCheckedContinuation { continuation in
+            diffWaiters.append(continuation)
+        }
+    }
+
+    func waitForEvidenceCalls() async {
+        if didCallCI && didCallFeedback { return }
+        await withCheckedContinuation { continuation in
+            evidenceWaiters.append(continuation)
+        }
+    }
+
+    func completeDiff() {
+        diffContinuation?.resume(returning: Self.diff)
+        diffContinuation = nil
+    }
+
+    func completeEvidence() {
+        ciContinuation?.resume(returning: [Self.makeCIItem()])
+        ciContinuation = nil
+        feedbackContinuation?.resume(returning: [Self.makeFeedbackItem()])
+        feedbackContinuation = nil
+    }
+
+    func isAvailable() async -> Bool { true }
+    func isAuthenticated(remote: CodeHostRemote, cwd: URL) async -> Bool { true }
+    func currentReviewRequest(remote: CodeHostRemote, branch: String, headOwner: String?, baseBranch: String, cwd: URL) async throws -> ReviewRequest? { nil }
+    func createReviewRequest(remote: CodeHostRemote, branch: String, headOwner: String?, baseBranch: String, title: String, body: String, isDraft: Bool, cwd: URL) async throws -> URL { remote.webURL }
+    func checks(remote: CodeHostRemote, request: ReviewRequest, cwd: URL) async throws -> [ReviewCheck] { [] }
+
+    func reviewDiff(remote: CodeHostRemote, request: ReviewRequest, cwd: URL) async throws -> String {
+        didCallDiff = true
+        resumeDiffWaiters()
+        guard suspendDiff else { return Self.diff }
+        return await withCheckedContinuation { continuation in
+            diffContinuation = continuation
+        }
+    }
+
+    func failedCheckEvidence(remote: CodeHostRemote, request: ReviewRequest, cwd: URL) async throws -> [ReviewEvidenceItem] {
+        didCallCI = true
+        resumeEvidenceWaitersIfReady()
+        guard suspendEvidence else { return [Self.makeCIItem()] }
+        return await withCheckedContinuation { continuation in
+            ciContinuation = continuation
+        }
+    }
+
+    func feedbackEvidence(remote: CodeHostRemote, request: ReviewRequest, cwd: URL) async throws -> [ReviewEvidenceItem] {
+        didCallFeedback = true
+        resumeEvidenceWaitersIfReady()
+        guard suspendEvidence else { return [Self.makeFeedbackItem()] }
+        return await withCheckedContinuation { continuation in
+            feedbackContinuation = continuation
+        }
+    }
+
+    func checkEvidenceDetail(remote: CodeHostRemote, request: ReviewRequest, item: ReviewEvidenceItem, cwd: URL) async throws -> ReviewEvidenceDetail {
+        ReviewEvidenceDetail(item: item, body: "CI detail", filePath: nil, line: nil, isTruncated: false)
+    }
+
+    func feedbackEvidenceDetail(remote: CodeHostRemote, request: ReviewRequest, item: ReviewEvidenceItem, cwd: URL) async throws -> ReviewEvidenceDetail {
+        ReviewEvidenceDetail(item: item, body: "Feedback detail", filePath: nil, line: nil, isTruncated: false)
+    }
+
+    func rerunFailedChecks(remote: CodeHostRemote, branch: String, headSHA: String, request: ReviewRequest?, cwd: URL) async throws {}
+
+    private func resumeDiffWaiters() {
+        for waiter in diffWaiters {
+            waiter.resume()
+        }
+        diffWaiters.removeAll()
+    }
+
+    private func resumeEvidenceWaitersIfReady() {
+        guard didCallCI && didCallFeedback else { return }
+        for waiter in evidenceWaiters {
+            waiter.resume()
+        }
+        evidenceWaiters.removeAll()
+    }
+
+    private nonisolated static let diff = """
+    diff --git a/Sources/App.swift b/Sources/App.swift
+    index 111..222 100644
+    --- a/Sources/App.swift
+    +++ b/Sources/App.swift
+    @@ -1 +1 @@
+    -let old = true
+    +let new = true
+    """
+
+    private nonisolated static func makeCIItem() -> ReviewEvidenceItem {
+        ReviewEvidenceItem(
+            id: "ci:test",
+            section: .ci,
+            title: "Tests",
+            subtitle: "CI",
+            status: .failed,
+            providerURL: URL(string: "https://github.com/run")
+        )
+    }
+
+    private nonisolated static func makeFeedbackItem() -> ReviewEvidenceItem {
+        ReviewEvidenceItem(
+            id: "feedback:thread-1",
+            section: .feedback,
+            title: "reviewer",
+            subtitle: "Please simplify this.",
+            status: .actionable,
+            providerURL: URL(string: "https://github.com/discussion")
+        )
+    }
 }
 
 private actor SuspendedDetailProvider: CodeHostProvider {

--- a/AlasTests/Integrations/ReviewEvidenceModelTests.swift
+++ b/AlasTests/Integrations/ReviewEvidenceModelTests.swift
@@ -175,6 +175,30 @@ struct ReviewEvidenceModelTests {
         #expect(!ReviewEvidenceTabView.shouldShowModelUnavailable(model))
     }
 
+    @Test func evidenceErrorWithFileErrorStillShowsUnavailableForCIAndFeedback() {
+        let ciUnavailable = ReviewEvidenceTabView.shouldShowModelUnavailable(
+            selectedSection: .ci,
+            isLoadingFiles: false,
+            fileErrorMessage: "diff unavailable",
+            fileSession: nil,
+            ciItemsAreEmpty: true,
+            feedbackItemsAreEmpty: true,
+            modelErrorMessage: "checks unavailable"
+        )
+        let feedbackUnavailable = ReviewEvidenceTabView.shouldShowModelUnavailable(
+            selectedSection: .feedback,
+            isLoadingFiles: false,
+            fileErrorMessage: "diff unavailable",
+            fileSession: nil,
+            ciItemsAreEmpty: true,
+            feedbackItemsAreEmpty: true,
+            modelErrorMessage: "feedback unavailable"
+        )
+
+        #expect(ciUnavailable)
+        #expect(feedbackUnavailable)
+    }
+
     @Test func emptyFileSessionChoosesEmptyState() {
         let content = ReviewEvidenceTabView.contentRoute(
             selectedSection: .files,

--- a/AlasTests/Integrations/ReviewEvidenceModelTests.swift
+++ b/AlasTests/Integrations/ReviewEvidenceModelTests.swift
@@ -175,7 +175,7 @@ struct ReviewEvidenceModelTests {
         #expect(!ReviewEvidenceTabView.shouldShowModelUnavailable(model))
     }
 
-    @Test func evidenceErrorWithFileErrorKeepsBrowserAvailableForCIAndFeedback() {
+    @Test func evidenceErrorWithOnlyFileErrorShowsUnavailableForCIAndFeedback() {
         let ciUnavailable = ReviewEvidenceTabView.shouldShowModelUnavailable(
             selectedSection: .ci,
             isLoadingFiles: false,
@@ -195,8 +195,8 @@ struct ReviewEvidenceModelTests {
             modelErrorMessage: "feedback unavailable"
         )
 
-        #expect(!ciUnavailable)
-        #expect(!feedbackUnavailable)
+        #expect(ciUnavailable)
+        #expect(feedbackUnavailable)
     }
 
     @Test func evidenceErrorWithLoadedFilesKeepsBrowserAvailableForCIAndFeedback() {

--- a/AlasTests/Integrations/ReviewEvidenceModelTests.swift
+++ b/AlasTests/Integrations/ReviewEvidenceModelTests.swift
@@ -118,6 +118,33 @@ struct ReviewEvidenceModelTests {
         #expect(content == .files(.diffSurface))
     }
 
+    @Test func filesLoadingWithEvidenceErrorDoesNotShowModelUnavailable() async {
+        let provider = SuspendedLoadProvider(suspendDiff: true, ciError: TestError(message: "checks unavailable"))
+        let model = ReviewEvidenceModel(
+            snapshot: Self.snapshot(),
+            provider: provider,
+            cwd: URL(fileURLWithPath: "/tmp/alas"),
+            initialSection: nil
+        )
+
+        let task = Task { await model.load() }
+        await provider.waitForDiffCall()
+        await provider.waitForEvidenceCalls()
+
+        #expect(await Self.waitUntil { model.errorMessage == "checks unavailable" && model.isLoadingFiles })
+        #expect(ReviewEvidenceTabView.contentRoute(
+            selectedSection: .files,
+            isLoadingFiles: model.isLoadingFiles,
+            fileErrorMessage: model.fileErrorMessage,
+            fileSession: model.fileSession,
+            modelErrorMessage: model.errorMessage
+        ) == .files(.loading))
+        #expect(!ReviewEvidenceTabView.shouldShowModelUnavailable(model, selectedSection: .files))
+
+        await provider.completeDiff()
+        await task.value
+    }
+
     @Test func fileErrorWithoutSessionChoosesFileErrorState() {
         let content = ReviewEvidenceTabView.contentRoute(
             selectedSection: .files,
@@ -642,6 +669,8 @@ private actor SuspendedLoadProvider: CodeHostProvider {
 
     private let suspendDiff: Bool
     private let suspendEvidence: Bool
+    private let ciError: TestError?
+    private let feedbackError: TestError?
     private var diffContinuation: CheckedContinuation<String, Never>?
     private var ciContinuation: CheckedContinuation<[ReviewEvidenceItem], Never>?
     private var feedbackContinuation: CheckedContinuation<[ReviewEvidenceItem], Never>?
@@ -651,9 +680,16 @@ private actor SuspendedLoadProvider: CodeHostProvider {
     private var didCallCI = false
     private var didCallFeedback = false
 
-    init(suspendDiff: Bool = false, suspendEvidence: Bool = false) {
+    init(
+        suspendDiff: Bool = false,
+        suspendEvidence: Bool = false,
+        ciError: TestError? = nil,
+        feedbackError: TestError? = nil
+    ) {
         self.suspendDiff = suspendDiff
         self.suspendEvidence = suspendEvidence
+        self.ciError = ciError
+        self.feedbackError = feedbackError
     }
 
     func waitForDiffCall() async {
@@ -700,6 +736,9 @@ private actor SuspendedLoadProvider: CodeHostProvider {
     func failedCheckEvidence(remote: CodeHostRemote, request: ReviewRequest, cwd: URL) async throws -> [ReviewEvidenceItem] {
         didCallCI = true
         resumeEvidenceWaitersIfReady()
+        if let ciError {
+            throw ciError
+        }
         guard suspendEvidence else { return [Self.makeCIItem()] }
         return await withCheckedContinuation { continuation in
             ciContinuation = continuation
@@ -709,6 +748,9 @@ private actor SuspendedLoadProvider: CodeHostProvider {
     func feedbackEvidence(remote: CodeHostRemote, request: ReviewRequest, cwd: URL) async throws -> [ReviewEvidenceItem] {
         didCallFeedback = true
         resumeEvidenceWaitersIfReady()
+        if let feedbackError {
+            throw feedbackError
+        }
         guard suspendEvidence else { return [Self.makeFeedbackItem()] }
         return await withCheckedContinuation { continuation in
             feedbackContinuation = continuation

--- a/AlasTests/Integrations/ReviewEvidenceModelTests.swift
+++ b/AlasTests/Integrations/ReviewEvidenceModelTests.swift
@@ -440,6 +440,38 @@ struct ReviewEvidenceModelTests {
         #expect(model.inlineFeedbackByFileID[fileID]?.map(\.id) == ["thread-1"])
     }
 
+    @Test func reviewEvidenceFilesRouteUsesModelInlineFeedbackForDiffSurface() async throws {
+        let model = ReviewEvidenceModel(
+            snapshot: Self.snapshot(reviewRequest: Self.reviewRequest(threads: [
+                ReviewThreadSummary(
+                    id: "thread-1",
+                    author: "reviewer",
+                    body: "Please simplify this.",
+                    url: URL(string: "https://github.com/discussion"),
+                    isResolved: false,
+                    isActionable: true,
+                    location: ReviewThreadLocation(
+                        path: "Sources/App.swift",
+                        originalPath: nil,
+                        line: 1,
+                        side: .new,
+                        providerPosition: "thread-1"
+                    )
+                ),
+            ])),
+            provider: FakeCodeHostProvider(),
+            cwd: URL(fileURLWithPath: "/tmp/alas"),
+            initialSection: .files
+        )
+
+        await model.load()
+
+        let fileID = try #require(model.fileSession?.files.first?.id)
+        let feedback = ReviewEvidenceTabView.diffSurfaceInlineFeedbackByFileID(for: model)
+
+        #expect(feedback[fileID]?.map(\.id) == ["thread-1"])
+    }
+
     @Test func modelClearsInlineFeedbackWithoutReviewRequest() async {
         let model = ReviewEvidenceModel(
             snapshot: Self.snapshot(reviewRequest: nil),
@@ -572,6 +604,13 @@ struct ReviewEvidenceModelTests {
 
         #expect(ciContent == .evidenceBrowser)
         #expect(feedbackContent == .evidenceBrowser)
+    }
+
+    @Test func evidenceBrowserEmptyTextReflectsLoadingState() {
+        #expect(ReviewEvidenceTabView.emptyText(for: .ci, isLoadingList: true, itemCount: 0) == "Loading checks…")
+        #expect(ReviewEvidenceTabView.emptyText(for: .ci, isLoadingList: false, itemCount: 0) == "No checks")
+        #expect(ReviewEvidenceTabView.emptyText(for: .feedback, isLoadingList: true, itemCount: 0) == "Loading feedback…")
+        #expect(ReviewEvidenceTabView.emptyText(for: .feedback, isLoadingList: false, itemCount: 0) == "No feedback")
     }
 
     @Test func filesLoadedWithEvidenceErrorStillChoosesFilesContent() {

--- a/AlasTests/Integrations/ReviewEvidenceModelTests.swift
+++ b/AlasTests/Integrations/ReviewEvidenceModelTests.swift
@@ -748,7 +748,16 @@ struct ReviewEvidenceModelTests {
         #expect(feedbackUnavailable)
     }
 
-    @Test func evidenceErrorWithLoadedFilesKeepsBrowserAvailableForCIAndFeedback() {
+    @Test func evidenceErrorWithLoadedFilesStillShowsUnavailableForCIAndFeedback() {
+        let filesUnavailable = ReviewEvidenceTabView.shouldShowModelUnavailable(
+            selectedSection: .files,
+            isLoadingFiles: false,
+            fileErrorMessage: nil,
+            fileSession: Self.loadedSession(),
+            ciItemsAreEmpty: true,
+            feedbackItemsAreEmpty: true,
+            modelErrorMessage: "checks unavailable"
+        )
         let ciUnavailable = ReviewEvidenceTabView.shouldShowModelUnavailable(
             selectedSection: .ci,
             isLoadingFiles: false,
@@ -768,8 +777,9 @@ struct ReviewEvidenceModelTests {
             modelErrorMessage: "feedback unavailable"
         )
 
-        #expect(!ciUnavailable)
-        #expect(!feedbackUnavailable)
+        #expect(!filesUnavailable)
+        #expect(ciUnavailable)
+        #expect(feedbackUnavailable)
     }
 
     @Test func emptyFileSessionChoosesEmptyState() {

--- a/AlasTests/Integrations/ReviewEvidenceModelTests.swift
+++ b/AlasTests/Integrations/ReviewEvidenceModelTests.swift
@@ -4,7 +4,7 @@ import Testing
 
 @MainActor
 struct ReviewEvidenceModelTests {
-    @Test func genericInspectSelectsFailedCIBeforeFeedback() async {
+    @Test func defaultLoadSelectsFilesAndLoadsEvidenceWithoutDetailCalls() async {
         let recorder = EvidenceProviderRecorder()
         let model = ReviewEvidenceModel(
             snapshot: Self.snapshot(),
@@ -15,10 +15,65 @@ struct ReviewEvidenceModelTests {
 
         await model.load()
 
-        #expect(model.selectedSection == .ci)
-        #expect(model.selectedItem?.id == "ci:test")
+        #expect(model.selectedSection == .files)
+        #expect(model.selectedItem == nil)
+        #expect(model.fileSession?.files.map(\.summary.path) == ["Sources/App.swift"])
         #expect(model.ciItems.count == 1)
         #expect(model.feedbackItems.count == 1)
+        let counts = await recorder.detailCounts()
+        #expect(counts.ci == 0)
+        #expect(counts.feedback == 0)
+    }
+
+    @Test func fileLoaderFailureLeavesEvidenceLoadedAndSetsFileError() async {
+        let model = ReviewEvidenceModel(
+            snapshot: Self.snapshot(),
+            provider: FakeCodeHostProvider(diffError: TestError(message: "diff unavailable")),
+            cwd: URL(fileURLWithPath: "/tmp/alas"),
+            initialSection: nil
+        )
+
+        await model.load()
+
+        #expect(model.fileSession == nil)
+        #expect(model.fileErrorMessage == "diff unavailable")
+        #expect(model.errorMessage == nil)
+        #expect(model.ciItems.map(\.id) == ["ci:test"])
+        #expect(model.feedbackItems.map(\.id) == ["feedback:thread-1"])
+    }
+
+    @Test func evidenceFailureLeavesLoadedFileSessionAndSetsError() async {
+        let model = ReviewEvidenceModel(
+            snapshot: Self.snapshot(),
+            provider: FakeCodeHostProvider(ciError: TestError(message: "checks unavailable")),
+            cwd: URL(fileURLWithPath: "/tmp/alas"),
+            initialSection: nil
+        )
+
+        await model.load()
+
+        #expect(model.fileSession?.files.map(\.summary.path) == ["Sources/App.swift"])
+        #expect(model.fileErrorMessage == nil)
+        #expect(model.errorMessage == "checks unavailable")
+        #expect(model.ciItems.isEmpty)
+        #expect(model.feedbackItems.isEmpty)
+    }
+
+    @Test func loadingSelectedDetailForFilesClearsDetailWithoutProviderCalls() async {
+        let recorder = EvidenceProviderRecorder()
+        let model = ReviewEvidenceModel(
+            snapshot: Self.snapshot(),
+            provider: FakeCodeHostProvider(recorder: recorder),
+            cwd: URL(fileURLWithPath: "/tmp/alas"),
+            initialSection: nil
+        )
+
+        await model.load()
+        await model.loadSelectedDetail()
+
+        #expect(model.selectedSection == .files)
+        #expect(model.selectedDetail == nil)
+        #expect(!model.isLoadingDetail)
         let counts = await recorder.detailCounts()
         #expect(counts.ci == 0)
         #expect(counts.feedback == 0)
@@ -84,7 +139,7 @@ struct ReviewEvidenceModelTests {
             snapshot: Self.snapshot(),
             provider: provider,
             cwd: URL(fileURLWithPath: "/tmp/alas"),
-            initialSection: nil
+            initialSection: .ci
         )
 
         await model.load()
@@ -111,6 +166,7 @@ struct ReviewEvidenceModelTests {
         await model.load()
 
         #expect(model.errorMessage == "Review request not found.")
+        #expect(model.fileSession == nil)
         #expect(model.ciItems.isEmpty)
         #expect(model.feedbackItems.isEmpty)
     }
@@ -201,10 +257,20 @@ private actor EvidenceProviderRecorder {
     }
 }
 
+private struct TestError: LocalizedError {
+    let message: String
+
+    var errorDescription: String? { message }
+}
+
 private struct FakeCodeHostProvider: CodeHostProvider {
     let recorder: EvidenceProviderRecorder?
     let ciItems: [ReviewEvidenceItem]
     let feedbackItems: [ReviewEvidenceItem]
+    let diff: String
+    let diffError: TestError?
+    let ciError: TestError?
+    let feedbackError: TestError?
 
     init(
         recorder: EvidenceProviderRecorder? = nil,
@@ -227,11 +293,27 @@ private struct FakeCodeHostProvider: CodeHostProvider {
                 status: .actionable,
                 providerURL: URL(string: "https://github.com/discussion")
             ),
-        ]
+        ],
+        diff: String = """
+        diff --git a/Sources/App.swift b/Sources/App.swift
+        index 111..222 100644
+        --- a/Sources/App.swift
+        +++ b/Sources/App.swift
+        @@ -1 +1 @@
+        -let old = true
+        +let new = true
+        """,
+        diffError: TestError? = nil,
+        ciError: TestError? = nil,
+        feedbackError: TestError? = nil
     ) {
         self.recorder = recorder
         self.ciItems = ciItems
         self.feedbackItems = feedbackItems
+        self.diff = diff
+        self.diffError = diffError
+        self.ciError = ciError
+        self.feedbackError = feedbackError
     }
 
     var kind: CodeHostKind { .github }
@@ -268,8 +350,18 @@ private struct FakeCodeHostProvider: CodeHostProvider {
         []
     }
 
+    func reviewDiff(remote: CodeHostRemote, request: ReviewRequest, cwd: URL) async throws -> String {
+        if let diffError {
+            throw diffError
+        }
+        return diff
+    }
+
     func failedCheckEvidence(remote: CodeHostRemote, request: ReviewRequest, cwd: URL) async throws -> [ReviewEvidenceItem] {
-        ciItems
+        if let ciError {
+            throw ciError
+        }
+        return ciItems
     }
 
     func checkEvidenceDetail(
@@ -289,7 +381,10 @@ private struct FakeCodeHostProvider: CodeHostProvider {
     }
 
     func feedbackEvidence(remote: CodeHostRemote, request: ReviewRequest, cwd: URL) async throws -> [ReviewEvidenceItem] {
-        feedbackItems
+        if let feedbackError {
+            throw feedbackError
+        }
+        return feedbackItems
     }
 
     func feedbackEvidenceDetail(
@@ -348,6 +443,18 @@ private actor SuspendedDetailProvider: CodeHostProvider {
     func currentReviewRequest(remote: CodeHostRemote, branch: String, headOwner: String?, baseBranch: String, cwd: URL) async throws -> ReviewRequest? { nil }
     func createReviewRequest(remote: CodeHostRemote, branch: String, headOwner: String?, baseBranch: String, title: String, body: String, isDraft: Bool, cwd: URL) async throws -> URL { remote.webURL }
     func checks(remote: CodeHostRemote, request: ReviewRequest, cwd: URL) async throws -> [ReviewCheck] { [] }
+
+    func reviewDiff(remote: CodeHostRemote, request: ReviewRequest, cwd: URL) async throws -> String {
+        """
+        diff --git a/Sources/App.swift b/Sources/App.swift
+        index 111..222 100644
+        --- a/Sources/App.swift
+        +++ b/Sources/App.swift
+        @@ -1 +1 @@
+        -let old = true
+        +let new = true
+        """
+    }
 
     func failedCheckEvidence(remote: CodeHostRemote, request: ReviewRequest, cwd: URL) async throws -> [ReviewEvidenceItem] {
         [Self.makeCIItem()]

--- a/AlasTests/Integrations/ReviewEvidenceModelTests.swift
+++ b/AlasTests/Integrations/ReviewEvidenceModelTests.swift
@@ -186,6 +186,50 @@ struct ReviewEvidenceModelTests {
         ))
     }
 
+    @Test func inlineFeedbackMappingFallsBackToOriginalPathForNewSideWhenCurrentPathIsMissing() {
+        let renamedFile = DiffReviewFileSummary(
+            path: "Sources/NewApp.swift",
+            namespace: "github-pr",
+            groupID: nil,
+            groupTitle: nil,
+            status: .renamed,
+            additions: 4,
+            deletions: 3,
+            isRenderable: true,
+            originalPath: "Sources/OldApp.swift"
+        )
+        let threads = [
+            ReviewThreadSummary(
+                id: "thread-new-side-original-path",
+                author: "reviewer",
+                body: "Provider reported the original path.",
+                url: URL(string: "https://github.com/discussion/new-original"),
+                isResolved: false,
+                isActionable: true,
+                location: ReviewThreadLocation(
+                    path: "Sources/OldApp.swift",
+                    originalPath: nil,
+                    line: 8,
+                    side: .new,
+                    providerPosition: "new-original"
+                )
+            ),
+        ]
+
+        let feedback = ReviewEvidenceInlineFeedbackMapper.feedbackByFileID(
+            threads: threads,
+            files: [renamedFile],
+            providerName: "GitHub"
+        )
+
+        #expect(feedback[renamedFile.id]?.map(\.id) == ["thread-new-side-original-path"])
+        #expect(feedback[renamedFile.id]?.first?.anchor == DiffReviewInlineFeedbackAnchor(
+            path: "Sources/OldApp.swift",
+            line: 8,
+            side: .new
+        ))
+    }
+
     @Test func modelPublishesInlineFeedbackAfterFilesAndEvidenceLoad() async throws {
         let model = ReviewEvidenceModel(
             snapshot: Self.snapshot(reviewRequest: Self.reviewRequest(threads: [

--- a/AlasTests/Integrations/ReviewEvidenceModelTests.swift
+++ b/AlasTests/Integrations/ReviewEvidenceModelTests.swift
@@ -61,6 +61,48 @@ struct ReviewEvidenceModelTests {
         #expect(model.selectedItem?.id == "check-pending")
     }
 
+    @Test func reviewEvidenceRevisionKeyIncludesThreadLocation() {
+        let baseThread = ReviewThreadSummary(
+            id: "thread-1",
+            author: "reviewer",
+            body: "Please simplify this.",
+            url: URL(string: "https://github.com/discussion"),
+            isResolved: false,
+            isActionable: true,
+            location: ReviewThreadLocation(
+                path: "Sources/App.swift",
+                originalPath: nil,
+                line: 12,
+                side: .new,
+                providerPosition: "12"
+            )
+        )
+        let movedThread = ReviewThreadSummary(
+            id: "thread-1",
+            author: "reviewer",
+            body: "Please simplify this.",
+            url: URL(string: "https://github.com/discussion"),
+            isResolved: false,
+            isActionable: true,
+            location: ReviewThreadLocation(
+                path: "Sources/App.swift",
+                originalPath: nil,
+                line: 18,
+                side: .old,
+                providerPosition: "18"
+            )
+        )
+
+        let baseKey = ReviewEvidenceTabView.reviewEvidenceRevisionKey(
+            for: Self.reviewRequest(threads: [baseThread])
+        )
+        let movedKey = ReviewEvidenceTabView.reviewEvidenceRevisionKey(
+            for: Self.reviewRequest(threads: [movedThread])
+        )
+
+        #expect(baseKey != movedKey)
+    }
+
     @Test func inlineFeedbackMappingUsesLocatedActionableThreads() {
         let files = [
             DiffReviewFileSummary(

--- a/AlasTests/Integrations/ReviewEvidenceModelTests.swift
+++ b/AlasTests/Integrations/ReviewEvidenceModelTests.swift
@@ -186,6 +186,56 @@ struct ReviewEvidenceModelTests {
         ))
     }
 
+    @Test func inlineFeedbackMappingPrefersExactCurrentPathWhenOldSidePathCollidesWithOriginalPath() {
+        let modifiedFile = DiffReviewFileSummary(
+            path: "Sources/App.swift",
+            namespace: "github-pr",
+            groupID: nil,
+            groupTitle: nil,
+            status: .modified,
+            additions: 2,
+            deletions: 2,
+            isRenderable: true
+        )
+        let copiedFromApp = DiffReviewFileSummary(
+            path: "Sources/AppCopy.swift",
+            namespace: "github-pr",
+            groupID: nil,
+            groupTitle: nil,
+            status: .copied,
+            additions: 3,
+            deletions: 1,
+            isRenderable: true,
+            originalPath: "Sources/App.swift"
+        )
+        let threads = [
+            ReviewThreadSummary(
+                id: "thread-old-side-current-path",
+                author: "reviewer",
+                body: "Old side feedback on the modified file.",
+                url: URL(string: "https://github.com/discussion/old-current"),
+                isResolved: false,
+                isActionable: true,
+                location: ReviewThreadLocation(
+                    path: "Sources/App.swift",
+                    originalPath: nil,
+                    line: 5,
+                    side: .old,
+                    providerPosition: "old-current"
+                )
+            ),
+        ]
+
+        let feedback = ReviewEvidenceInlineFeedbackMapper.feedbackByFileID(
+            threads: threads,
+            files: [modifiedFile, copiedFromApp],
+            providerName: "GitHub"
+        )
+
+        #expect(feedback[modifiedFile.id]?.map(\.id) == ["thread-old-side-current-path"])
+        #expect(feedback[copiedFromApp.id] == nil)
+    }
+
     @Test func inlineFeedbackMappingFallsBackToOriginalPathForNewSideWhenCurrentPathIsMissing() {
         let renamedFile = DiffReviewFileSummary(
             path: "Sources/NewApp.swift",
@@ -315,6 +365,46 @@ struct ReviewEvidenceModelTests {
         await model.load()
 
         #expect(model.inlineFeedbackByFileID.isEmpty)
+    }
+
+    @Test func reloadClearsStaleFileSessionAndInlineFeedbackUntilFreshFilesPublish() async throws {
+        let provider = FirstFastThenSuspendedDiffProvider()
+        let model = ReviewEvidenceModel(
+            snapshot: Self.snapshot(reviewRequest: Self.reviewRequest(threads: [
+                ReviewThreadSummary(
+                    id: "thread-1",
+                    author: "reviewer",
+                    body: "Please simplify this.",
+                    url: URL(string: "https://github.com/discussion"),
+                    isResolved: false,
+                    isActionable: true,
+                    location: ReviewThreadLocation(
+                        path: "Sources/App.swift",
+                        originalPath: nil,
+                        line: 1,
+                        side: .new,
+                        providerPosition: "thread-1"
+                    )
+                ),
+            ])),
+            provider: provider,
+            cwd: URL(fileURLWithPath: "/tmp/alas"),
+            initialSection: nil
+        )
+
+        await model.load()
+        let initialFileID = try #require(model.fileSession?.files.first?.id)
+        #expect(model.inlineFeedbackByFileID[initialFileID]?.map(\.id) == ["thread-1"])
+
+        let task = Task { await model.load() }
+        await provider.waitForSecondDiffCall()
+        await provider.waitForSecondEvidenceCalls()
+
+        #expect(model.fileSession == nil)
+        #expect(model.inlineFeedbackByFileID.isEmpty)
+
+        await provider.completeSecondDiff()
+        await task.value
     }
 
     @Test func fileLoaderFailureLeavesEvidenceLoadedAndSetsFileError() async {
@@ -1120,6 +1210,123 @@ private actor SuspendedLoadProvider: CodeHostProvider {
             waiter.resume()
         }
         evidenceWaiters.removeAll()
+    }
+
+    private nonisolated static let diff = """
+    diff --git a/Sources/App.swift b/Sources/App.swift
+    index 111..222 100644
+    --- a/Sources/App.swift
+    +++ b/Sources/App.swift
+    @@ -1 +1 @@
+    -let old = true
+    +let new = true
+    """
+
+    private nonisolated static func makeCIItem() -> ReviewEvidenceItem {
+        ReviewEvidenceItem(
+            id: "ci:test",
+            section: .ci,
+            title: "Tests",
+            subtitle: "CI",
+            status: .failed,
+            providerURL: URL(string: "https://github.com/run")
+        )
+    }
+
+    private nonisolated static func makeFeedbackItem() -> ReviewEvidenceItem {
+        ReviewEvidenceItem(
+            id: "feedback:thread-1",
+            section: .feedback,
+            title: "reviewer",
+            subtitle: "Please simplify this.",
+            status: .actionable,
+            providerURL: URL(string: "https://github.com/discussion")
+        )
+    }
+}
+
+private actor FirstFastThenSuspendedDiffProvider: CodeHostProvider {
+    nonisolated let kind: CodeHostKind = .github
+    nonisolated let capabilities: CodeHostProviderCapabilities = .githubCLI
+
+    private var diffCallCount = 0
+    private var ciCallCount = 0
+    private var feedbackCallCount = 0
+    private var secondDiffContinuation: CheckedContinuation<String, Never>?
+    private var secondDiffWaiters: [CheckedContinuation<Void, Never>] = []
+    private var secondEvidenceWaiters: [CheckedContinuation<Void, Never>] = []
+
+    func waitForSecondDiffCall() async {
+        if diffCallCount >= 2 { return }
+        await withCheckedContinuation { continuation in
+            secondDiffWaiters.append(continuation)
+        }
+    }
+
+    func waitForSecondEvidenceCalls() async {
+        if ciCallCount >= 2 && feedbackCallCount >= 2 { return }
+        await withCheckedContinuation { continuation in
+            secondEvidenceWaiters.append(continuation)
+        }
+    }
+
+    func completeSecondDiff() {
+        secondDiffContinuation?.resume(returning: Self.diff)
+        secondDiffContinuation = nil
+    }
+
+    func isAvailable() async -> Bool { true }
+    func isAuthenticated(remote: CodeHostRemote, cwd: URL) async -> Bool { true }
+    func currentReviewRequest(remote: CodeHostRemote, branch: String, headOwner: String?, baseBranch: String, cwd: URL) async throws -> ReviewRequest? { nil }
+    func createReviewRequest(remote: CodeHostRemote, branch: String, headOwner: String?, baseBranch: String, title: String, body: String, isDraft: Bool, cwd: URL) async throws -> URL { remote.webURL }
+    func checks(remote: CodeHostRemote, request: ReviewRequest, cwd: URL) async throws -> [ReviewCheck] { [] }
+
+    func reviewDiff(remote: CodeHostRemote, request: ReviewRequest, cwd: URL) async throws -> String {
+        diffCallCount += 1
+        if diffCallCount == 2 {
+            resumeSecondDiffWaiters()
+            return await withCheckedContinuation { continuation in
+                secondDiffContinuation = continuation
+            }
+        }
+        return Self.diff
+    }
+
+    func failedCheckEvidence(remote: CodeHostRemote, request: ReviewRequest, cwd: URL) async throws -> [ReviewEvidenceItem] {
+        ciCallCount += 1
+        resumeSecondEvidenceWaitersIfReady()
+        return [Self.makeCIItem()]
+    }
+
+    func feedbackEvidence(remote: CodeHostRemote, request: ReviewRequest, cwd: URL) async throws -> [ReviewEvidenceItem] {
+        feedbackCallCount += 1
+        resumeSecondEvidenceWaitersIfReady()
+        return [Self.makeFeedbackItem()]
+    }
+
+    func checkEvidenceDetail(remote: CodeHostRemote, request: ReviewRequest, item: ReviewEvidenceItem, cwd: URL) async throws -> ReviewEvidenceDetail {
+        ReviewEvidenceDetail(item: item, body: "CI detail", filePath: nil, line: nil, isTruncated: false)
+    }
+
+    func feedbackEvidenceDetail(remote: CodeHostRemote, request: ReviewRequest, item: ReviewEvidenceItem, cwd: URL) async throws -> ReviewEvidenceDetail {
+        ReviewEvidenceDetail(item: item, body: "Feedback detail", filePath: nil, line: nil, isTruncated: false)
+    }
+
+    func rerunFailedChecks(remote: CodeHostRemote, branch: String, headSHA: String, request: ReviewRequest?, cwd: URL) async throws {}
+
+    private func resumeSecondDiffWaiters() {
+        for waiter in secondDiffWaiters {
+            waiter.resume()
+        }
+        secondDiffWaiters.removeAll()
+    }
+
+    private func resumeSecondEvidenceWaitersIfReady() {
+        guard ciCallCount >= 2 && feedbackCallCount >= 2 else { return }
+        for waiter in secondEvidenceWaiters {
+            waiter.resume()
+        }
+        secondEvidenceWaiters.removeAll()
     }
 
     private nonisolated static let diff = """

--- a/AlasTests/Integrations/ReviewEvidenceModelTests.swift
+++ b/AlasTests/Integrations/ReviewEvidenceModelTests.swift
@@ -25,6 +25,42 @@ struct ReviewEvidenceModelTests {
         #expect(counts.feedback == 0)
     }
 
+    @Test func ciActivityEvidenceMapsAllCheckBuckets() {
+        let checks = [
+            Self.check(id: "check-pass", name: "build", workflow: "CI", bucket: .pass),
+            Self.check(id: "check-fail", name: "test", workflow: "CI", bucket: .fail),
+            Self.check(id: "check-pending", name: "lint", workflow: "CI", bucket: .pending),
+            Self.check(id: "check-skipping", name: "docs", workflow: "Docs", bucket: .skipping),
+            Self.check(id: "check-cancel", name: "release", workflow: "Deploy", bucket: .cancel),
+        ]
+
+        let items = ReviewEvidenceCIActivityMapper.items(for: checks)
+
+        #expect(items.map(\.id) == checks.map(\.id))
+        #expect(items.map(\.section) == [.ci, .ci, .ci, .ci, .ci])
+        #expect(items.map(\.title) == ["build", "test", "lint", "docs", "release"])
+        #expect(items.map(\.subtitle) == ["CI", "CI", "CI", "Docs", "Deploy"])
+        #expect(items.map(\.status) == [.passed, .failed, .pending, .unknown, .cancelled])
+        #expect(items.map(\.providerURL) == checks.map(\.detailURL))
+    }
+
+    @Test func modelPublishesPendingChecksFromReviewRequest() async {
+        let pending = Self.check(id: "check-pending", name: "lint", workflow: "CI", bucket: .pending)
+        let model = ReviewEvidenceModel(
+            snapshot: Self.snapshot(reviewRequest: Self.reviewRequest(checks: [pending])),
+            provider: DefaultEvidenceProvider(),
+            cwd: URL(fileURLWithPath: "/tmp/alas"),
+            initialSection: .ci
+        )
+
+        await model.load()
+
+        #expect(model.selectedSection == .ci)
+        #expect(model.ciItems.map(\.id) == ["check-pending"])
+        #expect(model.ciItems.first?.status == .pending)
+        #expect(model.selectedItem?.id == "check-pending")
+    }
+
     @Test func inlineFeedbackMappingUsesLocatedActionableThreads() {
         let files = [
             DiffReviewFileSummary(
@@ -902,7 +938,10 @@ struct ReviewEvidenceModelTests {
         )
     }
 
-    private static func reviewRequest(threads: [ReviewThreadSummary] = []) -> ReviewRequest {
+    private static func reviewRequest(
+        checks: [ReviewCheck] = [],
+        threads: [ReviewThreadSummary] = []
+    ) -> ReviewRequest {
         let remote = Self.remote()
         let request = ReviewRequest(
             remote: remote,
@@ -915,10 +954,27 @@ struct ReviewEvidenceModelTests {
             baseRefName: "main",
             reviewDecision: .changesRequested,
             mergeState: .blocked,
-            checks: [],
+            checks: checks,
             threads: threads
         )
         return request
+    }
+
+    private static func check(
+        id: String,
+        name: String,
+        workflow: String?,
+        bucket: ReviewCheckBucket,
+        detailURL: URL? = URL(string: "https://github.com/check")
+    ) -> ReviewCheck {
+        ReviewCheck(
+            id: id,
+            name: name,
+            workflow: workflow,
+            bucket: bucket,
+            detailURL: detailURL,
+            completedAt: nil
+        )
     }
 
     private static func feedbackItem(id: String, title: String, body: String) -> ReviewEvidenceItem {
@@ -969,6 +1025,62 @@ struct ReviewEvidenceModelTests {
         }
         return predicate()
     }
+}
+
+private struct DefaultEvidenceProvider: CodeHostProvider {
+    var kind: CodeHostKind { .github }
+    var capabilities: CodeHostProviderCapabilities { .readOnly }
+
+    func isAvailable() async -> Bool { true }
+
+    func isAuthenticated(remote: CodeHostRemote, cwd: URL) async -> Bool { true }
+
+    func currentReviewRequest(
+        remote: CodeHostRemote,
+        branch: String,
+        headOwner: String?,
+        baseBranch: String,
+        cwd: URL
+    ) async throws -> ReviewRequest? {
+        nil
+    }
+
+    func createReviewRequest(
+        remote: CodeHostRemote,
+        branch: String,
+        headOwner: String?,
+        baseBranch: String,
+        title: String,
+        body: String,
+        isDraft: Bool,
+        cwd: URL
+    ) async throws -> URL {
+        remote.webURL
+    }
+
+    func checks(remote: CodeHostRemote, request: ReviewRequest, cwd: URL) async throws -> [ReviewCheck] {
+        []
+    }
+
+    func reviewDiff(remote: CodeHostRemote, request: ReviewRequest, cwd: URL) async throws -> String {
+        """
+        diff --git a/Sources/App.swift b/Sources/App.swift
+        index 111..222 100644
+        --- a/Sources/App.swift
+        +++ b/Sources/App.swift
+        @@ -1 +1 @@
+        -let old = true
+        +let new = true
+        """
+    }
+
+    func rerunFailedChecks(
+        remote: CodeHostRemote,
+        branch: String,
+        headSHA: String,
+        request: ReviewRequest?,
+        cwd: URL
+    ) async throws {}
 }
 
 private actor EvidenceProviderRecorder {

--- a/AlasTests/Integrations/ReviewEvidenceModelTests.swift
+++ b/AlasTests/Integrations/ReviewEvidenceModelTests.swift
@@ -25,6 +25,210 @@ struct ReviewEvidenceModelTests {
         #expect(counts.feedback == 0)
     }
 
+    @Test func inlineFeedbackMappingUsesLocatedActionableThreads() {
+        let files = [
+            DiffReviewFileSummary(
+                path: "Sources/App.swift",
+                namespace: "github-pr",
+                groupID: nil,
+                groupTitle: nil,
+                status: .modified,
+                additions: 2,
+                deletions: 1,
+                isRenderable: true
+            ),
+        ]
+        let threads = [
+            ReviewThreadSummary(
+                id: "thread-2",
+                author: "reviewer",
+                body: "Second inline comment.",
+                url: URL(string: "https://github.com/discussion/2"),
+                isResolved: false,
+                isActionable: true,
+                location: ReviewThreadLocation(
+                    path: "Sources/App.swift",
+                    originalPath: nil,
+                    line: 20,
+                    side: .new,
+                    providerPosition: "2"
+                )
+            ),
+            ReviewThreadSummary(
+                id: "thread-1",
+                author: "reviewer",
+                body: "File level comment.",
+                url: URL(string: "https://github.com/discussion/1"),
+                isResolved: false,
+                isActionable: true,
+                location: ReviewThreadLocation(
+                    path: "Sources/App.swift",
+                    originalPath: nil,
+                    line: nil,
+                    side: .new,
+                    providerPosition: "1"
+                )
+            ),
+            ReviewThreadSummary(
+                id: "thread-resolved",
+                author: "reviewer",
+                body: "Resolved comment.",
+                url: nil,
+                isResolved: true,
+                isActionable: true,
+                location: ReviewThreadLocation(
+                    path: "Sources/App.swift",
+                    originalPath: nil,
+                    line: 10,
+                    side: .new,
+                    providerPosition: "resolved"
+                )
+            ),
+        ]
+
+        let feedback = ReviewEvidenceInlineFeedbackMapper.feedbackByFileID(
+            threads: threads,
+            files: files,
+            providerName: "GitHub"
+        )
+
+        let fileFeedback = feedback[files[0].id]
+        #expect(fileFeedback?.map(\.id) == ["thread-1", "thread-2"])
+        #expect(fileFeedback?.first?.providerName == "GitHub")
+        #expect(fileFeedback?.first?.anchor == DiffReviewInlineFeedbackAnchor(
+            path: "Sources/App.swift",
+            line: nil,
+            side: .new
+        ))
+        #expect(fileFeedback?.last?.anchor == DiffReviewInlineFeedbackAnchor(
+            path: "Sources/App.swift",
+            line: 20,
+            side: .new
+        ))
+        #expect(fileFeedback?.last?.evidenceItemID == "thread-2")
+    }
+
+    @Test func inlineFeedbackMappingSkipsMissingLocation() {
+        let files = [
+            DiffReviewFileSummary(
+                path: "Sources/App.swift",
+                namespace: "github-pr",
+                groupID: nil,
+                groupTitle: nil,
+                status: .modified,
+                additions: 2,
+                deletions: 1,
+                isRenderable: true
+            ),
+        ]
+        let threads = [
+            ReviewThreadSummary(
+                id: "thread-without-location",
+                author: "reviewer",
+                body: "Still appears in feedback evidence.",
+                url: URL(string: "https://github.com/discussion/1"),
+                isResolved: false,
+                isActionable: true,
+                location: nil
+            ),
+        ]
+
+        let feedback = ReviewEvidenceInlineFeedbackMapper.feedbackByFileID(
+            threads: threads,
+            files: files,
+            providerName: "GitHub"
+        )
+
+        #expect(feedback.isEmpty)
+    }
+
+    @Test func inlineFeedbackMappingMatchesRenamedOldSideToOriginalPath() {
+        let renamedFile = DiffReviewFileSummary(
+            path: "Sources/NewApp.swift",
+            namespace: "github-pr",
+            groupID: nil,
+            groupTitle: nil,
+            status: .renamed,
+            additions: 4,
+            deletions: 3,
+            isRenderable: true,
+            originalPath: "Sources/OldApp.swift"
+        )
+        let threads = [
+            ReviewThreadSummary(
+                id: "thread-old-side",
+                author: "reviewer",
+                body: "Old side feedback.",
+                url: URL(string: "https://github.com/discussion/old"),
+                isResolved: false,
+                isActionable: true,
+                location: ReviewThreadLocation(
+                    path: "Sources/NewApp.swift",
+                    originalPath: "Sources/OldApp.swift",
+                    line: 12,
+                    side: .old,
+                    providerPosition: "old"
+                )
+            ),
+        ]
+
+        let feedback = ReviewEvidenceInlineFeedbackMapper.feedbackByFileID(
+            threads: threads,
+            files: [renamedFile],
+            providerName: "GitHub"
+        )
+
+        #expect(feedback[renamedFile.id]?.map(\.id) == ["thread-old-side"])
+        #expect(feedback[renamedFile.id]?.first?.anchor == DiffReviewInlineFeedbackAnchor(
+            path: "Sources/OldApp.swift",
+            line: 12,
+            side: .old
+        ))
+    }
+
+    @Test func modelPublishesInlineFeedbackAfterFilesAndEvidenceLoad() async throws {
+        let model = ReviewEvidenceModel(
+            snapshot: Self.snapshot(reviewRequest: Self.reviewRequest(threads: [
+                ReviewThreadSummary(
+                    id: "thread-1",
+                    author: "reviewer",
+                    body: "Please simplify this.",
+                    url: URL(string: "https://github.com/discussion"),
+                    isResolved: false,
+                    isActionable: true,
+                    location: ReviewThreadLocation(
+                        path: "Sources/App.swift",
+                        originalPath: nil,
+                        line: 1,
+                        side: .new,
+                        providerPosition: "thread-1"
+                    )
+                ),
+            ])),
+            provider: FakeCodeHostProvider(),
+            cwd: URL(fileURLWithPath: "/tmp/alas"),
+            initialSection: nil
+        )
+
+        await model.load()
+
+        let fileID = try #require(model.fileSession?.files.first?.id)
+        #expect(model.inlineFeedbackByFileID[fileID]?.map(\.id) == ["thread-1"])
+    }
+
+    @Test func modelClearsInlineFeedbackWithoutReviewRequest() async {
+        let model = ReviewEvidenceModel(
+            snapshot: Self.snapshot(reviewRequest: nil),
+            provider: FakeCodeHostProvider(),
+            cwd: URL(fileURLWithPath: "/tmp/alas"),
+            initialSection: nil
+        )
+
+        await model.load()
+
+        #expect(model.inlineFeedbackByFileID.isEmpty)
+    }
+
     @Test func fileLoaderFailureLeavesEvidenceLoadedAndSetsFileError() async {
         let model = ReviewEvidenceModel(
             snapshot: Self.snapshot(),
@@ -470,7 +674,7 @@ struct ReviewEvidenceModelTests {
         )
     }
 
-    private static func reviewRequest() -> ReviewRequest {
+    private static func reviewRequest(threads: [ReviewThreadSummary] = []) -> ReviewRequest {
         let remote = Self.remote()
         let request = ReviewRequest(
             remote: remote,
@@ -484,7 +688,7 @@ struct ReviewEvidenceModelTests {
             reviewDecision: .changesRequested,
             mergeState: .blocked,
             checks: [],
-            threads: []
+            threads: threads
         )
         return request
     }

--- a/AlasTests/Integrations/ReviewEvidenceModelTests.swift
+++ b/AlasTests/Integrations/ReviewEvidenceModelTests.swift
@@ -59,6 +59,35 @@ struct ReviewEvidenceModelTests {
         #expect(model.feedbackItems.isEmpty)
     }
 
+    @Test func loadedFilesKeepBrowserAvailableWhenEvidenceFails() async {
+        let model = ReviewEvidenceModel(
+            snapshot: Self.snapshot(),
+            provider: FakeCodeHostProvider(ciError: TestError(message: "checks unavailable")),
+            cwd: URL(fileURLWithPath: "/tmp/alas"),
+            initialSection: nil
+        )
+
+        await model.load()
+
+        #expect(model.fileSession != nil)
+        #expect(model.errorMessage == "checks unavailable")
+        #expect(!ReviewEvidenceTabView.shouldShowModelUnavailable(model))
+    }
+
+    @Test func missingReviewRequestKeepsBrowserUnavailable() async {
+        let model = ReviewEvidenceModel(
+            snapshot: Self.snapshot(reviewRequest: nil),
+            provider: FakeCodeHostProvider(),
+            cwd: URL(fileURLWithPath: "/tmp/alas"),
+            initialSection: nil
+        )
+
+        await model.load()
+
+        #expect(model.errorMessage == "Review request not found.")
+        #expect(ReviewEvidenceTabView.shouldShowModelUnavailable(model))
+    }
+
     @Test func evidencePublishesWhileFileLoadIsSuspended() async {
         let provider = SuspendedLoadProvider(suspendDiff: true)
         let model = ReviewEvidenceModel(

--- a/AlasTests/Integrations/ReviewEvidenceModelTests.swift
+++ b/AlasTests/Integrations/ReviewEvidenceModelTests.swift
@@ -74,6 +74,92 @@ struct ReviewEvidenceModelTests {
         #expect(!ReviewEvidenceTabView.shouldShowModelUnavailable(model))
     }
 
+    @Test func filesSectionChoosesFilesContent() {
+        let content = ReviewEvidenceTabView.contentRoute(
+            selectedSection: .files,
+            isLoadingFiles: false,
+            fileErrorMessage: nil,
+            fileSession: Self.loadedSession(),
+            modelErrorMessage: nil
+        )
+
+        #expect(content == .files(.diffSurface))
+    }
+
+    @Test func ciAndFeedbackSectionsChooseEvidenceBrowser() {
+        let ciContent = ReviewEvidenceTabView.contentRoute(
+            selectedSection: .ci,
+            isLoadingFiles: false,
+            fileErrorMessage: nil,
+            fileSession: Self.loadedSession(),
+            modelErrorMessage: nil
+        )
+        let feedbackContent = ReviewEvidenceTabView.contentRoute(
+            selectedSection: .feedback,
+            isLoadingFiles: false,
+            fileErrorMessage: nil,
+            fileSession: Self.loadedSession(),
+            modelErrorMessage: nil
+        )
+
+        #expect(ciContent == .evidenceBrowser)
+        #expect(feedbackContent == .evidenceBrowser)
+    }
+
+    @Test func filesLoadedWithEvidenceErrorStillChoosesFilesContent() {
+        let content = ReviewEvidenceTabView.contentRoute(
+            selectedSection: .files,
+            isLoadingFiles: false,
+            fileErrorMessage: nil,
+            fileSession: Self.loadedSession(),
+            modelErrorMessage: "checks unavailable"
+        )
+
+        #expect(content == .files(.diffSurface))
+    }
+
+    @Test func fileErrorWithoutSessionChoosesFileErrorState() {
+        let content = ReviewEvidenceTabView.contentRoute(
+            selectedSection: .files,
+            isLoadingFiles: false,
+            fileErrorMessage: "diff unavailable",
+            fileSession: nil,
+            modelErrorMessage: nil
+        )
+
+        #expect(content == .files(.error("diff unavailable")))
+    }
+
+    @Test func fileErrorKeepsFilesRouteAvailableWhenEvidenceAlsoFails() async {
+        let model = ReviewEvidenceModel(
+            snapshot: Self.snapshot(),
+            provider: FakeCodeHostProvider(
+                diffError: TestError(message: "diff unavailable"),
+                ciError: TestError(message: "checks unavailable")
+            ),
+            cwd: URL(fileURLWithPath: "/tmp/alas"),
+            initialSection: nil
+        )
+
+        await model.load()
+
+        #expect(model.fileErrorMessage == "diff unavailable")
+        #expect(model.errorMessage == "checks unavailable")
+        #expect(!ReviewEvidenceTabView.shouldShowModelUnavailable(model))
+    }
+
+    @Test func emptyFileSessionChoosesEmptyState() {
+        let content = ReviewEvidenceTabView.contentRoute(
+            selectedSection: .files,
+            isLoadingFiles: false,
+            fileErrorMessage: nil,
+            fileSession: Self.loadedSession(summaries: []),
+            modelErrorMessage: nil
+        )
+
+        #expect(content == .files(.empty))
+    }
+
     @Test func missingReviewRequestKeepsBrowserUnavailable() async {
         let model = ReviewEvidenceModel(
             snapshot: Self.snapshot(reviewRequest: nil),
@@ -336,6 +422,34 @@ struct ReviewEvidenceModelTests {
             subtitle: body,
             status: .actionable,
             providerURL: URL(string: "https://github.com/discussion/\(id)")
+        )
+    }
+
+    private static func loadedSession(
+        summaries: [DiffReviewFileSummary] = [
+            DiffReviewFileSummary(
+                path: "Sources/App.swift",
+                namespace: "github-pr",
+                groupID: nil,
+                groupTitle: nil,
+                status: .modified,
+                additions: 2,
+                deletions: 1,
+                isRenderable: true
+            ),
+        ]
+    ) -> DiffReviewLoadedSession {
+        DiffReviewLoadedSession(
+            files: summaries.map { summary in
+                DiffReviewFileSectionModel(
+                    summary: summary,
+                    parsedDiff: nil,
+                    displayModel: nil,
+                    placeholderMessage: "No diff.",
+                    openFile: nil
+                )
+            },
+            summary: DiffReviewSessionModel(files: summaries, groupsEnabled: false)
         )
     }
 

--- a/AlasTests/Integrations/ReviewRequestDiffLoaderTests.swift
+++ b/AlasTests/Integrations/ReviewRequestDiffLoaderTests.swift
@@ -22,8 +22,8 @@ struct ReviewRequestDiffLoaderTests {
         #expect(session.files[1].summary.originalPath == "Sources/OldName.swift")
         #expect(session.files[2].summary.isRenderable == false)
         #expect(session.files[2].placeholderMessage == "Image changes are not available in this review view yet.")
-        #expect(session.summary.totalAdditions == 3)
-        #expect(session.summary.totalDeletions == 2)
+        #expect(session.summary.totalAdditions == 4)
+        #expect(session.summary.totalDeletions == 3)
     }
 
     @Test func emptyProviderDiffProducesEmptyUngroupedSession() async throws {

--- a/AlasTests/Integrations/ReviewRequestDiffLoaderTests.swift
+++ b/AlasTests/Integrations/ReviewRequestDiffLoaderTests.swift
@@ -60,6 +60,46 @@ struct ReviewRequestDiffLoaderTests {
         #expect(file.placeholderMessage == "Image changes are not available in this review view yet.")
     }
 
+    @Test func noHunkPlaceholderFileWithBSlashSegmentKeepsHeaderPath() async throws {
+        let provider = FakeDiffProvider(diff: """
+        diff --git a/foo b/bar.png b/foo b/bar.png
+        index 111..222 100644
+        """)
+        let loader = ReviewRequestDiffLoader(provider: provider)
+
+        let session = try await loader.load(
+            remote: Self.remote(),
+            request: Self.reviewRequest(),
+            cwd: URL(fileURLWithPath: "/tmp/repo")
+        )
+
+        let file = try #require(session.files.first)
+        #expect(file.summary.path == "foo b/bar.png")
+        #expect(file.summary.isRenderable == false)
+    }
+
+    @Test func quotedPathHeadersDecodeEscapedTab() async throws {
+        let provider = FakeDiffProvider(diff: """
+        diff --git "a/tab\\tfile.swift" "b/tab\\tfile.swift"
+        index 111..222 100644
+        --- "a/tab\\tfile.swift"
+        +++ "b/tab\\tfile.swift"
+        @@ -1 +1 @@
+        -let old = true
+        +let new = true
+        """)
+        let loader = ReviewRequestDiffLoader(provider: provider)
+
+        let session = try await loader.load(
+            remote: Self.remote(),
+            request: Self.reviewRequest(),
+            cwd: URL(fileURLWithPath: "/tmp/repo")
+        )
+
+        let file = try #require(session.files.first)
+        #expect(file.summary.path == "tab\tfile.swift")
+    }
+
     @Test func gitLabNewFileUsesMergeRequestNamespaceAndAddedStatus() async throws {
         let provider = FakeDiffProvider(
             diff: """

--- a/AlasTests/Integrations/ReviewRequestDiffLoaderTests.swift
+++ b/AlasTests/Integrations/ReviewRequestDiffLoaderTests.swift
@@ -41,6 +41,51 @@ struct ReviewRequestDiffLoaderTests {
         #expect(session.summary.groupsEnabled == false)
     }
 
+    @Test func noHunkPlaceholderFileWithSpacesKeepsHeaderPath() async throws {
+        let provider = FakeDiffProvider(diff: """
+        diff --git a/Assets/logo file.png b/Assets/logo file.png
+        index 111..222 100644
+        """)
+        let loader = ReviewRequestDiffLoader(provider: provider)
+
+        let session = try await loader.load(
+            remote: Self.remote(),
+            request: Self.reviewRequest(),
+            cwd: URL(fileURLWithPath: "/tmp/repo")
+        )
+
+        let file = try #require(session.files.first)
+        #expect(file.summary.path == "Assets/logo file.png")
+        #expect(file.summary.isRenderable == false)
+        #expect(file.placeholderMessage == "Image changes are not available in this review view yet.")
+    }
+
+    @Test func gitLabNewFileUsesMergeRequestNamespaceAndAddedStatus() async throws {
+        let provider = FakeDiffProvider(
+            diff: """
+            diff --git a/Sources/NewFile.swift b/Sources/NewFile.swift
+            new file mode 100644
+            index 0000000..1111111
+            --- /dev/null
+            +++ b/Sources/NewFile.swift
+            @@ -0,0 +1 @@
+            +let value = true
+            """,
+            kind: .gitlab
+        )
+        let loader = ReviewRequestDiffLoader(provider: provider)
+
+        let session = try await loader.load(
+            remote: Self.remote(kind: .gitlab),
+            request: Self.reviewRequest(kind: .gitlab),
+            cwd: URL(fileURLWithPath: "/tmp/repo")
+        )
+
+        let file = try #require(session.files.first)
+        #expect(file.summary.namespace == "gitlab-mr")
+        #expect(file.summary.status == .added)
+    }
+
     private static let sampleDiff = """
     diff --git a/Sources/App.swift b/Sources/App.swift
     index 111..222 100644
@@ -70,9 +115,9 @@ struct ReviewRequestDiffLoaderTests {
     +binary new
     """
 
-    private static func remote() -> CodeHostRemote {
+    private static func remote(kind: CodeHostKind = .github) -> CodeHostRemote {
         CodeHostRemote(
-            kind: .github,
+            kind: kind,
             host: "github.com",
             owner: "mrmans0n",
             repository: "alas",
@@ -81,9 +126,9 @@ struct ReviewRequestDiffLoaderTests {
         )
     }
 
-    private static func reviewRequest() -> ReviewRequest {
+    private static func reviewRequest(kind: CodeHostKind = .github) -> ReviewRequest {
         ReviewRequest(
-            remote: remote(),
+            remote: remote(kind: kind),
             number: 516,
             title: "Files first",
             url: URL(string: "https://github.com/mrmans0n/alas/pull/516")!,
@@ -101,7 +146,7 @@ struct ReviewRequestDiffLoaderTests {
 
 private struct FakeDiffProvider: CodeHostProvider {
     let diff: String
-    var kind: CodeHostKind { .github }
+    var kind: CodeHostKind = .github
     func isAvailable() async -> Bool { true }
     func isAuthenticated(remote: CodeHostRemote, cwd: URL) async -> Bool { true }
     func currentReviewRequest(remote: CodeHostRemote, branch: String, headOwner: String?, baseBranch: String, cwd: URL) async throws -> ReviewRequest? { nil }

--- a/AlasTests/Integrations/ReviewRequestDiffLoaderTests.swift
+++ b/AlasTests/Integrations/ReviewRequestDiffLoaderTests.swift
@@ -100,6 +100,32 @@ struct ReviewRequestDiffLoaderTests {
         #expect(file.summary.path == "tab\tfile.swift")
     }
 
+    @Test func quotedRenameHeadersDecodeEscapedPaths() async throws {
+        let provider = FakeDiffProvider(diff: """
+        diff --git "a/old\\tfile.swift" "b/new\\tfile.swift"
+        similarity index 88%
+        rename from "old\\tfile.swift"
+        rename to "new\\tfile.swift"
+        --- "a/old\\tfile.swift"
+        +++ "b/new\\tfile.swift"
+        @@ -1 +1 @@
+        -let oldName = true
+        +let newName = true
+        """)
+        let loader = ReviewRequestDiffLoader(provider: provider)
+
+        let session = try await loader.load(
+            remote: Self.remote(),
+            request: Self.reviewRequest(),
+            cwd: URL(fileURLWithPath: "/tmp/repo")
+        )
+
+        let file = try #require(session.files.first)
+        #expect(file.summary.path == "new\tfile.swift")
+        #expect(file.summary.originalPath == "old\tfile.swift")
+        #expect(file.summary.status == .renamed)
+    }
+
     @Test func gitLabNewFileUsesMergeRequestNamespaceAndAddedStatus() async throws {
         let provider = FakeDiffProvider(
             diff: """

--- a/AlasTests/Integrations/ReviewRequestDiffLoaderTests.swift
+++ b/AlasTests/Integrations/ReviewRequestDiffLoaderTests.swift
@@ -100,6 +100,28 @@ struct ReviewRequestDiffLoaderTests {
         #expect(file.summary.path == "tab\tfile.swift")
     }
 
+    @Test func quotedPathHeadersDecodeUtf8OctalEscapes() async throws {
+        let provider = FakeDiffProvider(diff: """
+        diff --git "a/\\303\\251.swift" "b/\\303\\251.swift"
+        index 111..222 100644
+        --- "a/\\303\\251.swift"
+        +++ "b/\\303\\251.swift"
+        @@ -1 +1 @@
+        -let old = true
+        +let new = true
+        """)
+        let loader = ReviewRequestDiffLoader(provider: provider)
+
+        let session = try await loader.load(
+            remote: Self.remote(),
+            request: Self.reviewRequest(),
+            cwd: URL(fileURLWithPath: "/tmp/repo")
+        )
+
+        let file = try #require(session.files.first)
+        #expect(file.summary.path == "é.swift")
+    }
+
     @Test func quotedRenameHeadersDecodeEscapedPaths() async throws {
         let provider = FakeDiffProvider(diff: """
         diff --git "a/old\\tfile.swift" "b/new\\tfile.swift"

--- a/AlasTests/Integrations/ReviewRequestDiffLoaderTests.swift
+++ b/AlasTests/Integrations/ReviewRequestDiffLoaderTests.swift
@@ -78,6 +78,28 @@ struct ReviewRequestDiffLoaderTests {
         #expect(file.summary.isRenderable == false)
     }
 
+    @Test func unquotedPathHeadersDropTabMetadata() async throws {
+        let provider = FakeDiffProvider(diff: """
+        diff --git a/Foo Bar.swift b/Foo Bar.swift
+        index 111..222 100644
+        --- a/Foo Bar.swift\t2026-06-13 12:00:00
+        +++ b/Foo Bar.swift\t2026-06-13 12:00:01
+        @@ -1 +1 @@
+        -let old = true
+        +let new = true
+        """)
+        let loader = ReviewRequestDiffLoader(provider: provider)
+
+        let session = try await loader.load(
+            remote: Self.remote(),
+            request: Self.reviewRequest(),
+            cwd: URL(fileURLWithPath: "/tmp/repo")
+        )
+
+        let file = try #require(session.files.first)
+        #expect(file.summary.path == "Foo Bar.swift")
+    }
+
     @Test func quotedPathHeadersDecodeEscapedTab() async throws {
         let provider = FakeDiffProvider(diff: """
         diff --git "a/tab\\tfile.swift" "b/tab\\tfile.swift"

--- a/AlasTests/Integrations/ReviewRequestDiffLoaderTests.swift
+++ b/AlasTests/Integrations/ReviewRequestDiffLoaderTests.swift
@@ -1,0 +1,112 @@
+import Foundation
+import Testing
+@testable import Alas
+
+@MainActor
+struct ReviewRequestDiffLoaderTests {
+    @Test func providerUnifiedDiffBuildsReviewSessionInProviderOrder() async throws {
+        let provider = FakeDiffProvider(diff: Self.sampleDiff)
+        let loader = ReviewRequestDiffLoader(provider: provider)
+
+        let session = try await loader.load(
+            remote: Self.remote(),
+            request: Self.reviewRequest(),
+            cwd: URL(fileURLWithPath: "/tmp/repo")
+        )
+
+        #expect(session.files.map(\.summary.path) == ["Sources/App.swift", "Sources/NewName.swift", "Assets/logo.png"])
+        #expect(session.files.map(\.summary.namespace) == ["github-pr", "github-pr", "github-pr"])
+        #expect(session.summary.groupsEnabled == false)
+        #expect(session.files[0].summary.status == .modified)
+        #expect(session.files[1].summary.status == .renamed)
+        #expect(session.files[1].summary.originalPath == "Sources/OldName.swift")
+        #expect(session.files[2].summary.isRenderable == false)
+        #expect(session.files[2].placeholderMessage == "Image changes are not available in this review view yet.")
+        #expect(session.summary.totalAdditions == 3)
+        #expect(session.summary.totalDeletions == 2)
+    }
+
+    @Test func emptyProviderDiffProducesEmptyUngroupedSession() async throws {
+        let provider = FakeDiffProvider(diff: "")
+        let loader = ReviewRequestDiffLoader(provider: provider)
+
+        let session = try await loader.load(
+            remote: Self.remote(),
+            request: Self.reviewRequest(),
+            cwd: URL(fileURLWithPath: "/tmp/repo")
+        )
+
+        #expect(session.files.isEmpty)
+        #expect(session.summary.files.isEmpty)
+        #expect(session.summary.groupsEnabled == false)
+    }
+
+    private static let sampleDiff = """
+    diff --git a/Sources/App.swift b/Sources/App.swift
+    index 111..222 100644
+    --- a/Sources/App.swift
+    +++ b/Sources/App.swift
+    @@ -1,2 +1,3 @@
+     struct App {
+    -    let old = true
+    +    let new = true
+    +    let added = true
+     }
+    diff --git a/Sources/OldName.swift b/Sources/NewName.swift
+    similarity index 88%
+    rename from Sources/OldName.swift
+    rename to Sources/NewName.swift
+    --- a/Sources/OldName.swift
+    +++ b/Sources/NewName.swift
+    @@ -1 +1 @@
+    -let oldName = true
+    +let newName = true
+    diff --git a/Assets/logo.png b/Assets/logo.png
+    index 111..222 100644
+    --- a/Assets/logo.png
+    +++ b/Assets/logo.png
+    @@ -1 +1 @@
+    -binary old
+    +binary new
+    """
+
+    private static func remote() -> CodeHostRemote {
+        CodeHostRemote(
+            kind: .github,
+            host: "github.com",
+            owner: "mrmans0n",
+            repository: "alas",
+            remoteName: "origin",
+            webURL: URL(string: "https://github.com/mrmans0n/alas")!
+        )
+    }
+
+    private static func reviewRequest() -> ReviewRequest {
+        ReviewRequest(
+            remote: remote(),
+            number: 516,
+            title: "Files first",
+            url: URL(string: "https://github.com/mrmans0n/alas/pull/516")!,
+            state: .open,
+            isDraft: false,
+            headRefName: "feature/files",
+            baseRefName: "main",
+            reviewDecision: .unknown,
+            mergeState: .unknown,
+            checks: [],
+            threads: []
+        )
+    }
+}
+
+private struct FakeDiffProvider: CodeHostProvider {
+    let diff: String
+    var kind: CodeHostKind { .github }
+    func isAvailable() async -> Bool { true }
+    func isAuthenticated(remote: CodeHostRemote, cwd: URL) async -> Bool { true }
+    func currentReviewRequest(remote: CodeHostRemote, branch: String, headOwner: String?, baseBranch: String, cwd: URL) async throws -> ReviewRequest? { nil }
+    func createReviewRequest(remote: CodeHostRemote, branch: String, headOwner: String?, baseBranch: String, title: String, body: String, isDraft: Bool, cwd: URL) async throws -> URL { URL(fileURLWithPath: "/tmp/pr") }
+    func checks(remote: CodeHostRemote, request: ReviewRequest, cwd: URL) async throws -> [ReviewCheck] { [] }
+    func reviewDiff(remote: CodeHostRemote, request: ReviewRequest, cwd: URL) async throws -> String { diff }
+    func rerunFailedChecks(remote: CodeHostRemote, branch: String, headSHA: String, request: ReviewRequest?, cwd: URL) async throws {}
+}

--- a/AlasTests/TabsManagerReviewEvidenceTests.swift
+++ b/AlasTests/TabsManagerReviewEvidenceTests.swift
@@ -118,6 +118,28 @@ struct TabsManagerReviewEvidenceTests {
         #expect(!state.matches(Self.snapshot(number: 42, host: "github.example.com")))
     }
 
+    @Test func reviewEvidenceTabStateDefaultsToFilesUnlessInitialSectionIsExplicit() {
+        let defaultState = ReviewEvidenceTabState(
+            worktreeId: "review-evidence-default",
+            snapshot: Self.snapshot(),
+            initialSection: nil
+        )
+        let ciState = ReviewEvidenceTabState(
+            worktreeId: "review-evidence-ci",
+            snapshot: Self.snapshot(),
+            initialSection: .ci
+        )
+        let feedbackState = ReviewEvidenceTabState(
+            worktreeId: "review-evidence-feedback",
+            snapshot: Self.snapshot(),
+            initialSection: .feedback
+        )
+
+        #expect(defaultState.selectedSection == .files)
+        #expect(ciState.selectedSection == .ci)
+        #expect(feedbackState.selectedSection == .feedback)
+    }
+
     @Test func reviewEvidenceTabStateCodableRoundTrips() throws {
         let state = ReviewEvidenceTabState(
             worktreeId: "wt-1",

--- a/AlasTests/TabsManagerReviewEvidenceTests.swift
+++ b/AlasTests/TabsManagerReviewEvidenceTests.swift
@@ -85,6 +85,31 @@ struct TabsManagerReviewEvidenceTests {
         #expect(manager.tabs(forWorktree: worktreeId).count == 1)
     }
 
+    @Test func updatingFilesSelectionClearsPersistedItemID() {
+        let worktreeId = "review-evidence-files-selection"
+        defer { try? FileManager.default.removeItem(at: Paths.tabsFile(forWorktreeId: worktreeId)) }
+        let manager = TabsManager()
+        let opened = manager.openOrFocusReviewEvidence(
+            worktreeId: worktreeId,
+            snapshot: Self.snapshot(),
+            initialSection: .feedback
+        )
+
+        let updated = manager.updateReviewEvidenceSelection(
+            worktreeId: worktreeId,
+            tabId: opened.id,
+            selectedSection: .files,
+            selectedItemID: "thread-1"
+        )
+
+        guard case .reviewEvidence(let state) = updated else {
+            Issue.record("Expected review evidence tab")
+            return
+        }
+        #expect(state.selectedSection == .files)
+        #expect(state.selectedItemID == nil)
+    }
+
     @Test func differentReviewRequestOpensSeparateEvidenceTab() {
         let worktreeId = "review-evidence-separate-request"
         defer { try? FileManager.default.removeItem(at: Paths.tabsFile(forWorktreeId: worktreeId)) }

--- a/AlasTests/WorkspaceLSPManagerStatusTests.swift
+++ b/AlasTests/WorkspaceLSPManagerStatusTests.swift
@@ -547,7 +547,7 @@ struct WorkspaceLSPManagerStatusTests {
             languageId: "swift",
             text: "let unsaved = 2\n"
         )
-        await Task.yield()
+        try? await Task.sleep(nanoseconds: 10_000_000)
         let closeEditor = Task {
             await mgr.closeDocument(worktreeRoot: root, fileURL: fileURL, languageId: "swift")
         }

--- a/docs/superpowers/plans/2026-06-12-pr-details-files-first-review.md
+++ b/docs/superpowers/plans/2026-06-12-pr-details-files-first-review.md
@@ -1,0 +1,981 @@
+# PR Details Files-First Review Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make PR/MR details open to a files-first review surface backed by provider diff output, while preserving CI and feedback evidence sections.
+
+**Architecture:** Add a provider diff capability to `CodeHostProvider`, parse provider unified diff into file-level models with a new `ReviewRequestDiffLoader`, extend `ReviewEvidenceModel` with independent file-session state, then update `ReviewEvidenceTabView` to render `DiffReviewSurface` as the default Files section. CI and Feedback keep the existing evidence list/detail browser and actions.
+
+**Tech Stack:** Swift 5.9+, SwiftUI, AppKit-backed diff renderer, Swift Testing, `gh`/`glab` CLI providers.
+
+---
+
+## File Structure
+
+- Modify `Alas/Sources/Integrations/CodeHost/CodeHostProvider.swift` to add `reviewDiff(remote:request:cwd:)`.
+- Modify `Alas/Sources/Integrations/CodeHost/GitHubCLIProvider.swift` and `Alas/Sources/Integrations/CodeHost/GitLabCLIProvider.swift` to call provider CLI diff commands.
+- Create `Alas/Sources/Integrations/CodeHost/ReviewRequestDiffLoader.swift` for provider unified diff splitting and `DiffReviewLoadedSession` construction.
+- Modify `Alas/Sources/Integrations/CodeHost/ReviewEvidence.swift` to add `.files`.
+- Modify `Alas/Sources/Integrations/CodeHost/ReviewEvidenceModel.swift` to load files independently from CI/feedback evidence.
+- Modify `Alas/Sources/Center/ReviewEvidence/ReviewEvidenceTabView.swift` to render Files, CI, and Feedback sections.
+- Add/modify tests under `AlasTests/Integrations`, `AlasTests`, and `AlasTests/Center` matching the existing test organization.
+- Regenerate `Alas.xcodeproj` after adding source/test files.
+
+---
+
+### Task 1: Provider Diff Capability
+
+**Files:**
+- Modify: `Alas/Sources/Integrations/CodeHost/CodeHostProvider.swift`
+- Modify: `Alas/Sources/Integrations/CodeHost/GitHubCLIProvider.swift`
+- Modify: `Alas/Sources/Integrations/CodeHost/GitLabCLIProvider.swift`
+- Test: `AlasTests/Integrations/GitHubCLIProviderTests.swift`
+- Test: `AlasTests/Integrations/GitLabCLIProviderTests.swift`
+
+- [ ] **Step 1: Write failing GitHub provider test**
+
+Add this test near other command-argument tests in `AlasTests/Integrations/GitHubCLIProviderTests.swift`:
+
+```swift
+@Test func reviewDiffUsesPRDiffCommand() async throws {
+    let runner = FakeRunner(results: [
+        ProcessResult(exitCode: 0, stdout: "diff --git a/A.swift b/A.swift\n", stderr: ""),
+    ])
+    let request = try #require(try GitHubCLIProvider.parsePRList(Self.prListOutput, remote: Self.remote))
+
+    let diff = try await GitHubCLIProvider(runner: runner).reviewDiff(
+        remote: Self.remote,
+        request: request,
+        cwd: Self.cwd
+    )
+
+    #expect(diff == "diff --git a/A.swift b/A.swift\n")
+    #expect(await runner.commands == [
+        FakeRunner.Command(
+            executable: "gh",
+            args: ["pr", "diff", "42", "-R", "mrmans0n/alas"],
+            cwd: Self.cwd
+        ),
+    ])
+}
+
+@Test func reviewDiffSurfacesGitHubCommandFailure() async throws {
+    let runner = FakeRunner(results: [
+        ProcessResult(exitCode: 1, stdout: "", stderr: "not found"),
+    ])
+    let request = try #require(try GitHubCLIProvider.parsePRList(Self.prListOutput, remote: Self.remote))
+
+    await #expect(throws: CodeHostProviderError.commandFailed(command: "gh pr diff", stderr: "not found")) {
+        _ = try await GitHubCLIProvider(runner: runner).reviewDiff(
+            remote: Self.remote,
+            request: request,
+            cwd: Self.cwd
+        )
+    }
+}
+```
+
+- [ ] **Step 2: Write failing GitLab provider test**
+
+Add this test near other command-argument tests in `AlasTests/Integrations/GitLabCLIProviderTests.swift`:
+
+```swift
+@Test func reviewDiffUsesMRDiffCommand() async throws {
+    let runner = FakeRunner(results: [
+        ProcessResult(exitCode: 0, stdout: "diff --git a/A.swift b/A.swift\n", stderr: ""),
+    ])
+    let request = try GitLabCLIProvider.parseMRView(Self.mrViewOutput, remote: Self.remote)
+
+    let diff = try await GitLabCLIProvider(runner: runner).reviewDiff(
+        remote: Self.remote,
+        request: request,
+        cwd: Self.cwd
+    )
+
+    #expect(diff == "diff --git a/A.swift b/A.swift\n")
+    #expect(await runner.commands == [
+        FakeRunner.Command(
+            executable: "glab",
+            args: ["mr", "diff", "44", "-R", "platform/mobile/alas"],
+            cwd: Self.cwd
+        ),
+    ])
+}
+
+@Test func reviewDiffSurfacesGitLabCommandFailure() async throws {
+    let runner = FakeRunner(results: [
+        ProcessResult(exitCode: 1, stdout: "", stderr: "not found"),
+    ])
+    let request = try GitLabCLIProvider.parseMRView(Self.mrViewOutput, remote: Self.remote)
+
+    await #expect(throws: CodeHostProviderError.commandFailed(command: "glab mr diff", stderr: "not found")) {
+        _ = try await GitLabCLIProvider(runner: runner).reviewDiff(
+            remote: Self.remote,
+            request: request,
+            cwd: Self.cwd
+        )
+    }
+}
+```
+
+- [ ] **Step 3: Run focused provider tests red**
+
+Run:
+
+```bash
+xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -only-testing:AlasTests/GitHubCLIProviderTests/reviewDiffUsesPRDiffCommand -only-testing:AlasTests/GitLabCLIProviderTests/reviewDiffUsesMRDiffCommand test
+```
+
+Expected: compile failure because `reviewDiff(remote:request:cwd:)` is not defined.
+
+- [ ] **Step 4: Implement provider capability**
+
+Add to `CodeHostProvider`:
+
+```swift
+func reviewDiff(remote: CodeHostRemote, request: ReviewRequest, cwd: URL) async throws -> String
+```
+
+Add this default implementation in the `CodeHostProvider` extension:
+
+```swift
+func reviewDiff(remote: CodeHostRemote, request: ReviewRequest, cwd: URL) async throws -> String {
+    throw CodeHostProviderError.unsupportedProvider(remote.kind)
+}
+```
+
+Add this method to `GitHubCLIProvider`:
+
+```swift
+func reviewDiff(remote: CodeHostRemote, request: ReviewRequest, cwd: URL) async throws -> String {
+    let result = try await runner.run(
+        "gh",
+        args: ["pr", "diff", "\(request.number)", "-R", remote.repositorySlug],
+        cwd: cwd
+    )
+    guard result.exitCode == 0 else {
+        throw CodeHostProviderError.commandFailed(command: "gh pr diff", stderr: result.stderr)
+    }
+    return result.stdout
+}
+```
+
+Add this method to `GitLabCLIProvider`:
+
+```swift
+func reviewDiff(remote: CodeHostRemote, request: ReviewRequest, cwd: URL) async throws -> String {
+    let result = try await runner.run(
+        "glab",
+        args: ["mr", "diff", "\(request.number)", "-R", remote.repositorySlug],
+        cwd: cwd
+    )
+    guard result.exitCode == 0 else {
+        throw CodeHostProviderError.commandFailed(command: "glab mr diff", stderr: result.stderr)
+    }
+    return result.stdout
+}
+```
+
+- [ ] **Step 5: Run focused provider tests green**
+
+Run:
+
+```bash
+xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -only-testing:AlasTests/GitHubCLIProviderTests -only-testing:AlasTests/GitLabCLIProviderTests test
+```
+
+Expected: provider tests pass.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add Alas/Sources/Integrations/CodeHost/CodeHostProvider.swift Alas/Sources/Integrations/CodeHost/GitHubCLIProvider.swift Alas/Sources/Integrations/CodeHost/GitLabCLIProvider.swift AlasTests/Integrations/GitHubCLIProviderTests.swift AlasTests/Integrations/GitLabCLIProviderTests.swift
+git commit -m "feat(review): fetch provider review diffs"
+```
+
+---
+
+### Task 2: Review Request Diff Loader
+
+**Files:**
+- Create: `Alas/Sources/Integrations/CodeHost/ReviewRequestDiffLoader.swift`
+- Test: `AlasTests/Integrations/ReviewRequestDiffLoaderTests.swift`
+- Modify generated project: `Alas.xcodeproj/project.pbxproj` after `xcodegen`
+
+- [ ] **Step 1: Write failing loader tests**
+
+Create `AlasTests/Integrations/ReviewRequestDiffLoaderTests.swift`:
+
+```swift
+import Foundation
+import Testing
+@testable import Alas
+
+@MainActor
+struct ReviewRequestDiffLoaderTests {
+    @Test func providerUnifiedDiffBuildsReviewSessionInProviderOrder() async throws {
+        let provider = FakeDiffProvider(diff: Self.sampleDiff)
+        let loader = ReviewRequestDiffLoader(provider: provider)
+
+        let session = try await loader.load(
+            remote: Self.remote(),
+            request: Self.reviewRequest(),
+            cwd: URL(fileURLWithPath: "/tmp/repo")
+        )
+
+        #expect(session.files.map(\.summary.path) == ["Sources/App.swift", "Sources/NewName.swift", "Assets/logo.png"])
+        #expect(session.files.map(\.summary.namespace) == ["github-pr", "github-pr", "github-pr"])
+        #expect(session.summary.groupsEnabled == false)
+        #expect(session.files[0].summary.status == .modified)
+        #expect(session.files[1].summary.status == .renamed)
+        #expect(session.files[1].summary.originalPath == "Sources/OldName.swift")
+        #expect(session.files[2].summary.isRenderable == false)
+        #expect(session.files[2].placeholderMessage == "Image changes are not available in this review view yet.")
+        #expect(session.summary.totalAdditions == 3)
+        #expect(session.summary.totalDeletions == 2)
+    }
+
+    @Test func emptyProviderDiffProducesEmptyUngroupedSession() async throws {
+        let provider = FakeDiffProvider(diff: "")
+        let loader = ReviewRequestDiffLoader(provider: provider)
+
+        let session = try await loader.load(
+            remote: Self.remote(),
+            request: Self.reviewRequest(),
+            cwd: URL(fileURLWithPath: "/tmp/repo")
+        )
+
+        #expect(session.files.isEmpty)
+        #expect(session.summary.files.isEmpty)
+        #expect(session.summary.groupsEnabled == false)
+    }
+
+    private static let sampleDiff = """
+    diff --git a/Sources/App.swift b/Sources/App.swift
+    index 111..222 100644
+    --- a/Sources/App.swift
+    +++ b/Sources/App.swift
+    @@ -1,2 +1,3 @@
+     struct App {
+    -    let old = true
+    +    let new = true
+    +    let added = true
+     }
+    diff --git a/Sources/OldName.swift b/Sources/NewName.swift
+    similarity index 88%
+    rename from Sources/OldName.swift
+    rename to Sources/NewName.swift
+    --- a/Sources/OldName.swift
+    +++ b/Sources/NewName.swift
+    @@ -1 +1 @@
+    -let oldName = true
+    +let newName = true
+    diff --git a/Assets/logo.png b/Assets/logo.png
+    index 111..222 100644
+    --- a/Assets/logo.png
+    +++ b/Assets/logo.png
+    @@ -1 +1 @@
+    -binary old
+    +binary new
+    """
+
+    private static func remote() -> CodeHostRemote {
+        CodeHostRemote(
+            kind: .github,
+            host: "github.com",
+            owner: "mrmans0n",
+            repository: "alas",
+            remoteName: "origin",
+            webURL: URL(string: "https://github.com/mrmans0n/alas")!
+        )
+    }
+
+    private static func reviewRequest() -> ReviewRequest {
+        ReviewRequest(
+            remote: remote(),
+            number: 516,
+            title: "Files first",
+            url: URL(string: "https://github.com/mrmans0n/alas/pull/516")!,
+            state: .open,
+            isDraft: false,
+            headRefName: "feature/files",
+            baseRefName: "main",
+            reviewDecision: .unknown,
+            mergeState: .unknown,
+            checks: [],
+            threads: []
+        )
+    }
+}
+
+private struct FakeDiffProvider: CodeHostProvider {
+    let diff: String
+    var kind: CodeHostKind { .github }
+    func isAvailable() async -> Bool { true }
+    func isAuthenticated(remote: CodeHostRemote, cwd: URL) async -> Bool { true }
+    func currentReviewRequest(remote: CodeHostRemote, branch: String, headOwner: String?, baseBranch: String, cwd: URL) async throws -> ReviewRequest? { nil }
+    func createReviewRequest(remote: CodeHostRemote, branch: String, headOwner: String?, baseBranch: String, title: String, body: String, isDraft: Bool, cwd: URL) async throws -> URL { URL(fileURLWithPath: "/tmp/pr") }
+    func checks(remote: CodeHostRemote, request: ReviewRequest, cwd: URL) async throws -> [ReviewCheck] { [] }
+    func reviewDiff(remote: CodeHostRemote, request: ReviewRequest, cwd: URL) async throws -> String { diff }
+    func rerunFailedChecks(remote: CodeHostRemote, branch: String, headSHA: String, request: ReviewRequest?, cwd: URL) async throws {}
+}
+```
+
+- [ ] **Step 2: Run loader tests red**
+
+Run:
+
+```bash
+xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -only-testing:AlasTests/ReviewRequestDiffLoaderTests test
+```
+
+Expected: compile failure because `ReviewRequestDiffLoader` is missing.
+
+- [ ] **Step 3: Implement loader**
+
+Create `Alas/Sources/Integrations/CodeHost/ReviewRequestDiffLoader.swift` with:
+
+```swift
+import Foundation
+
+struct ReviewRequestDiffLoader {
+    let provider: any CodeHostProvider
+
+    init(provider: any CodeHostProvider) {
+        self.provider = provider
+    }
+
+    func load(remote: CodeHostRemote, request: ReviewRequest, cwd: URL) async throws -> DiffReviewLoadedSession {
+        try Task.checkCancellation()
+        let rawDiff = try await provider.reviewDiff(remote: remote, request: request, cwd: cwd)
+        try Task.checkCancellation()
+
+        var sections: [DiffReviewFileSectionModel] = []
+        for file in ProviderDiffSplitter.split(rawDiff) {
+            try Task.checkCancellation()
+            sections.append(try await fileSection(for: file, namespace: namespace(for: request.provider)))
+        }
+
+        return DiffReviewLoadedSession(
+            files: sections,
+            summary: DiffReviewSessionModel(files: sections.map(\.summary), groupsEnabled: false)
+        )
+    }
+
+    private func namespace(for provider: CodeHostKind) -> String {
+        switch provider {
+        case .github: "github-pr"
+        case .gitlab: "gitlab-mr"
+        }
+    }
+
+    private func fileSection(for file: ProviderDiffFile, namespace: String) async throws -> DiffReviewFileSectionModel {
+        let parsedDiff = DiffParser.parse(file.rawDiff)
+        let canRender = !parsedDiff.hunks.isEmpty && !ImageFileType.isSupported(relativePath: file.path)
+        let counts = lineCounts(in: parsedDiff)
+        let summary = DiffReviewFileSummary(
+            path: file.path,
+            namespace: namespace,
+            groupID: nil,
+            groupTitle: nil,
+            status: DiffReviewFileStatus(gitStatus: file.status),
+            additions: counts.additions,
+            deletions: counts.deletions,
+            isRenderable: canRender,
+            originalPath: file.originalPath
+        )
+
+        return DiffReviewFileSectionModel(
+            summary: summary,
+            parsedDiff: parsedDiff,
+            displayModel: canRender ? try await buildDisplayModel(diff: parsedDiff, filePath: file.path) : nil,
+            placeholderMessage: canRender ? nil : placeholderMessage(for: file, parsedDiff: parsedDiff),
+            openFile: nil
+        )
+    }
+
+    private func buildDisplayModel(diff: ParsedDiff, filePath: String) async throws -> DiffDisplayModel {
+        try Task.checkCancellation()
+        let model = await Task.detached(priority: .userInitiated) {
+            DiffDisplayModelBuilder.build(diff: diff, filePath: filePath)
+        }.value
+        try Task.checkCancellation()
+        return model
+    }
+
+    private func lineCounts(in diff: ParsedDiff) -> (additions: Int, deletions: Int) {
+        diff.hunks.reduce(into: (additions: 0, deletions: 0)) { counts, hunk in
+            for line in hunk.lines {
+                switch line.kind {
+                case .add: counts.additions += 1
+                case .delete: counts.deletions += 1
+                case .context: break
+                }
+            }
+        }
+    }
+
+    private func placeholderMessage(for file: ProviderDiffFile, parsedDiff: ParsedDiff) -> String {
+        if ImageFileType.isSupported(relativePath: file.path) {
+            return "Image changes are not available in this review view yet."
+        }
+        if parsedDiff.hunks.isEmpty {
+            return "No text diff is available for this file."
+        }
+        return "This file cannot be rendered in the review view."
+    }
+}
+
+struct ProviderDiffFile: Equatable {
+    let path: String
+    let originalPath: String?
+    let status: String
+    let rawDiff: String
+}
+
+enum ProviderDiffSplitter {
+    static func split(_ rawDiff: String) -> [ProviderDiffFile] {
+        let lines = rawDiff.split(separator: "\n", omittingEmptySubsequences: false).map(String.init)
+        var files: [ProviderDiffFile] = []
+        var current: [String] = []
+
+        func flush() {
+            guard !current.isEmpty, let file = parseFile(current) else {
+                current.removeAll()
+                return
+            }
+            files.append(file)
+            current.removeAll()
+        }
+
+        for line in lines {
+            if line.hasPrefix("diff --git ") {
+                flush()
+            }
+            current.append(line)
+        }
+        flush()
+        return files
+    }
+
+    private static func parseFile(_ lines: [String]) -> ProviderDiffFile? {
+        guard let header = lines.first, header.hasPrefix("diff --git ") else { return nil }
+        let paths = parseDiffGitPaths(header)
+        let renameFrom = lines.first { $0.hasPrefix("rename from ") }.map { String($0.dropFirst("rename from ".count)) }
+        let renameTo = lines.first { $0.hasPrefix("rename to ") }.map { String($0.dropFirst("rename to ".count)) }
+        let deleted = lines.contains { $0.hasPrefix("deleted file mode") }
+        let added = lines.contains { $0.hasPrefix("new file mode") }
+        let path = renameTo ?? paths?.newPath
+        guard let path else { return nil }
+
+        let status: String
+        if renameFrom != nil || renameTo != nil {
+            status = "R"
+        } else if added {
+            status = "A"
+        } else if deleted {
+            status = "D"
+        } else {
+            status = "M"
+        }
+
+        return ProviderDiffFile(
+            path: path,
+            originalPath: renameFrom ?? (deleted ? paths?.oldPath : nil),
+            status: status,
+            rawDiff: lines.joined(separator: "\n")
+        )
+    }
+
+    private static func parseDiffGitPaths(_ header: String) -> (oldPath: String, newPath: String)? {
+        let prefix = "diff --git "
+        guard header.hasPrefix(prefix) else { return nil }
+        let remainder = String(header.dropFirst(prefix.count))
+        let parts = remainder.split(separator: " ", maxSplits: 1).map(String.init)
+        guard parts.count == 2 else { return nil }
+        return (stripGitPrefix(parts[0]), stripGitPrefix(parts[1]))
+    }
+
+    private static func stripGitPrefix(_ path: String) -> String {
+        if path.hasPrefix("a/") || path.hasPrefix("b/") {
+            return String(path.dropFirst(2))
+        }
+        return path
+    }
+}
+```
+
+- [ ] **Step 4: Regenerate project**
+
+Run:
+
+```bash
+xcodegen
+```
+
+Expected: `Alas.xcodeproj/project.pbxproj` includes the new source and test files.
+
+- [ ] **Step 5: Run loader tests green**
+
+Run:
+
+```bash
+xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -only-testing:AlasTests/ReviewRequestDiffLoaderTests test
+```
+
+Expected: loader tests pass.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add Alas.xcodeproj/project.pbxproj Alas/Sources/Integrations/CodeHost/ReviewRequestDiffLoader.swift AlasTests/Integrations/ReviewRequestDiffLoaderTests.swift
+git commit -m "feat(review): build file sessions from provider diffs"
+```
+
+---
+
+### Task 3: Files Section Model State
+
+**Files:**
+- Modify: `Alas/Sources/Integrations/CodeHost/ReviewEvidence.swift`
+- Modify: `Alas/Sources/Integrations/CodeHost/ReviewEvidenceModel.swift`
+- Test: `AlasTests/Integrations/ReviewEvidenceModelTests.swift`
+
+- [ ] **Step 1: Write failing model tests**
+
+Add these tests to `ReviewEvidenceModelTests`:
+
+```swift
+@Test func modelDefaultsToFilesAndLoadsFileSessionIndependently() async {
+    let provider = FakeCodeHostProvider(reviewDiff: """
+    diff --git a/A.swift b/A.swift
+    --- a/A.swift
+    +++ b/A.swift
+    @@ -1 +1,2 @@
+     let a = 1
+    +let b = 2
+    """)
+    let model = ReviewEvidenceModel(
+        snapshot: Self.snapshot(),
+        provider: provider,
+        cwd: URL(fileURLWithPath: "/tmp/alas"),
+        initialSection: nil
+    )
+
+    await model.load()
+
+    #expect(model.selectedSection == .files)
+    #expect(model.fileSession?.summary.files.map(\.path) == ["A.swift"])
+    #expect(model.ciItems.count == 1)
+    #expect(model.feedbackItems.count == 1)
+    #expect(model.fileErrorMessage == nil)
+}
+
+@Test func fileLoadFailureDoesNotEraseEvidenceItems() async {
+    let provider = FakeCodeHostProvider(
+        reviewDiffError: CodeHostProviderError.commandFailed(command: "gh pr diff", stderr: "boom")
+    )
+    let model = ReviewEvidenceModel(
+        snapshot: Self.snapshot(),
+        provider: provider,
+        cwd: URL(fileURLWithPath: "/tmp/alas"),
+        initialSection: nil
+    )
+
+    await model.load()
+
+    #expect(model.selectedSection == .files)
+    #expect(model.fileSession == nil)
+    #expect(model.fileErrorMessage?.contains("gh pr diff failed: boom") == true)
+    #expect(model.ciItems.count == 1)
+    #expect(model.feedbackItems.count == 1)
+}
+
+@Test func restoredCISectionIsPreserved() async {
+    let model = ReviewEvidenceModel(
+        snapshot: Self.snapshot(),
+        provider: FakeCodeHostProvider(),
+        cwd: URL(fileURLWithPath: "/tmp/alas"),
+        initialSection: .ci
+    )
+
+    await model.load()
+
+    #expect(model.selectedSection == .ci)
+    #expect(model.selectedItem?.id == "ci:test")
+}
+```
+
+Update the local `FakeCodeHostProvider` initializer in the same file to accept:
+
+```swift
+let reviewDiff: String
+let reviewDiffError: Error?
+```
+
+with defaults:
+
+```swift
+reviewDiff: String = "",
+reviewDiffError: Error? = nil
+```
+
+and implement:
+
+```swift
+func reviewDiff(remote: CodeHostRemote, request: ReviewRequest, cwd: URL) async throws -> String {
+    if let reviewDiffError { throw reviewDiffError }
+    return reviewDiff
+}
+```
+
+- [ ] **Step 2: Run model tests red**
+
+Run:
+
+```bash
+xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -only-testing:AlasTests/ReviewEvidenceModelTests test
+```
+
+Expected: compile failures for `.files`, `fileSession`, and `fileErrorMessage`.
+
+- [ ] **Step 3: Add files section and model state**
+
+Update `ReviewEvidenceSection`:
+
+```swift
+enum ReviewEvidenceSection: String, Codable, Equatable, Sendable, CaseIterable {
+    case files
+    case ci
+    case feedback
+
+    var displayName: String {
+        switch self {
+        case .files: "Files"
+        case .ci: "CI"
+        case .feedback: "Feedback"
+        }
+    }
+}
+```
+
+Update `ReviewEvidenceModel`:
+
+- `selectedSection` should default to `initialSection ?? .files`.
+- Add:
+
+```swift
+private(set) var fileSession: DiffReviewLoadedSession?
+private(set) var isLoadingFiles = false
+private(set) var fileErrorMessage: String?
+private var selectedFileID: DiffReviewFileID?
+```
+
+- In `load()`, load files and evidence independently:
+
+```swift
+async let loadedFiles: Void = loadFiles(remote: remote, request: request)
+async let loadedEvidence: Void = loadEvidenceLists(remote: remote, request: request)
+_ = await (loadedFiles, loadedEvidence)
+chooseInitialSelection()
+```
+
+Implement `loadFiles(remote:request:)`:
+
+```swift
+private func loadFiles(remote: CodeHostRemote, request: ReviewRequest) async {
+    isLoadingFiles = true
+    fileErrorMessage = nil
+    do {
+        fileSession = try await ReviewRequestDiffLoader(provider: provider).load(
+            remote: remote,
+            request: request,
+            cwd: cwd
+        )
+    } catch {
+        fileSession = nil
+        fileErrorMessage = error.localizedDescription
+    }
+    isLoadingFiles = false
+}
+```
+
+Move the existing CI/feedback loading body into `loadEvidenceLists(remote:request:)`, preserving `ciItems`, `feedbackItems`, `isLoadingList`, and `errorMessage`.
+
+Update `chooseInitialSelection()` so `.files` remains selected when requested/defaulted. Only run item selection logic when selected section is `.ci` or `.feedback`.
+
+Update `items(for:)`:
+
+```swift
+func items(for section: ReviewEvidenceSection) -> [ReviewEvidenceItem] {
+    switch section {
+    case .files:
+        []
+    case .ci:
+        ciItems
+    case .feedback:
+        feedbackItems
+    }
+}
+```
+
+- [ ] **Step 4: Run model tests green**
+
+Run:
+
+```bash
+xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -only-testing:AlasTests/ReviewEvidenceModelTests -only-testing:AlasTests/ReviewRequestDiffLoaderTests test
+```
+
+Expected: model and loader tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Alas/Sources/Integrations/CodeHost/ReviewEvidence.swift Alas/Sources/Integrations/CodeHost/ReviewEvidenceModel.swift AlasTests/Integrations/ReviewEvidenceModelTests.swift
+git commit -m "feat(review): load files-first evidence state"
+```
+
+---
+
+### Task 4: Files-First Review Evidence Tab
+
+**Files:**
+- Modify: `Alas/Sources/Center/ReviewEvidence/ReviewEvidenceTabView.swift`
+- Modify: `Alas/Sources/Center/Tab.swift`
+- Create: `AlasTests/ReviewEvidenceTabViewTests.swift`
+
+- [ ] **Step 1: Write failing view tests**
+
+Create `AlasTests/ReviewEvidenceTabViewTests.swift` with these section/default tests. This avoids brittle SwiftUI reflection while still locking the behavior that the view consumes:
+
+```swift
+import Foundation
+import Testing
+@testable import Alas
+
+struct ReviewEvidenceTabViewTests {
+    @Test func sectionListIncludesFilesFirst() {
+        #expect(ReviewEvidenceSection.allCases.map(\.displayName) == ["Files", "CI", "Feedback"])
+    }
+
+    @Test func tabStateDefaultsToFilesForNewReviewEvidenceTabs() {
+        let snapshot = ReviewLoopSnapshot(
+            local: ReviewLoopLocalState(
+                branchName: "feature/files",
+                headSHA: "abc",
+                baseBranch: "main",
+                hasWorkingTreeChanges: false,
+                hasStagedChanges: false,
+                aheadCommitCount: 1,
+                hasUpstream: true,
+                needsPush: false
+            ),
+            remote: remote(),
+            reviewRequest: request(),
+            providerAvailable: true,
+            providerAuthenticated: true,
+            providerCapabilities: .githubCLI,
+            errorMessage: nil
+        )
+
+        let state = ReviewEvidenceTabState(
+            worktreeId: "worktree-1",
+            snapshot: snapshot,
+            initialSection: nil
+        )
+
+        #expect(state.selectedSection == .files)
+    }
+
+    private static func remote() -> CodeHostRemote {
+        CodeHostRemote(
+            kind: .github,
+            host: "github.com",
+            owner: "mrmans0n",
+            repository: "alas",
+            remoteName: "origin",
+            webURL: URL(string: "https://github.com/mrmans0n/alas")!
+        )
+    }
+
+    private static func request() -> ReviewRequest {
+        ReviewRequest(
+            remote: remote(),
+            number: 516,
+            title: "Files first",
+            url: URL(string: "https://github.com/mrmans0n/alas/pull/516")!,
+            state: .open,
+            isDraft: false,
+            headRefName: "feature/files",
+            baseRefName: "main",
+            reviewDecision: .unknown,
+            mergeState: .unknown,
+            checks: [],
+            threads: []
+        )
+    }
+}
+```
+
+- [ ] **Step 2: Run view/section tests red**
+
+Run:
+
+```bash
+xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -only-testing:AlasTests/ReviewEvidenceTabViewTests test
+```
+
+Expected: compile failure if the new test file is not in the project yet, or failure until `.files` is implemented and ordered first.
+
+- [ ] **Step 3: Render Files section**
+
+In `ReviewEvidenceTabView`:
+
+- Keep `header` unchanged.
+- Keep `statusChips`, detail actions, rerun, copy, and handoff functions unchanged.
+- Update `evidenceBrowser(model:)` so the segmented picker includes Files, CI, Feedback.
+- Replace the body routing with:
+
+```swift
+switch selectedSection {
+case .files:
+    filesPane(model: model)
+case .ci, .feedback:
+    evidencePane(model: model)
+}
+```
+
+Add:
+
+```swift
+@State private var selectedFileID: DiffReviewFileID?
+@State private var railCollapsed = false
+@State private var layoutMode: DiffLayoutMode = .split
+@State private var wrapLines = true
+@State private var showWhitespace = false
+```
+
+Initialize these from `appState.config.diff` using the same binding/save pattern used by `CommitTabView` for commit details. The bindings must persist changes through `appState.saveConfig()`.
+
+Implement `filesPane(model:)`:
+
+```swift
+@ViewBuilder
+private func filesPane(model: ReviewEvidenceModel) -> some View {
+    if model.isLoadingFiles {
+        Spinner()
+            .frame(width: 20, height: 20)
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
+    } else if let session = model.fileSession {
+        DiffReviewSurface(
+            session: session,
+            selectedFileID: $selectedFileID,
+            railCollapsed: $railCollapsed,
+            layoutMode: diffLayoutBinding,
+            wrapLines: diffWrapBinding,
+            showWhitespace: diffWhitespaceBinding,
+            codeFontFamily: appState.config.code.fontFamily,
+            codeFontSize: CGFloat(appState.config.code.fontSize),
+            showsSourceBadges: false,
+            showsRailDisplayControls: true
+        )
+    } else {
+        unavailableState(message: model.fileErrorMessage ?? "No file diff is available for this review request.")
+    }
+}
+```
+
+Extract the existing `HStack` list/detail browser into `evidencePane(model:)` and leave its internals unchanged for `.ci` and `.feedback`.
+
+Update `applySelectedSection(_:,loadDetail:)`:
+
+- If section is `.files`, persist `.files` with `itemID: nil` and do not select evidence item.
+- For `.ci`/`.feedback`, keep current behavior.
+
+Update `emptyText(for:)` to return `"No file diffs"` for `.files`, although `filesPane` handles the Files empty state directly.
+
+- [ ] **Step 4: Regenerate project if a new test file was added**
+
+Run:
+
+```bash
+xcodegen
+```
+
+Expected: project contains `AlasTests/ReviewEvidenceTabViewTests.swift`.
+
+- [ ] **Step 5: Run focused view/model tests green**
+
+Run:
+
+```bash
+xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -only-testing:AlasTests/ReviewEvidenceModelTests -only-testing:AlasTests/ReviewEvidenceTabViewTests test
+```
+
+Expected: focused tests pass.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add Alas.xcodeproj/project.pbxproj Alas/Sources/Center/ReviewEvidence/ReviewEvidenceTabView.swift Alas/Sources/Center/Tab.swift AlasTests/ReviewEvidenceTabViewTests.swift
+git commit -m "feat(review): show files first in PR details"
+```
+
+---
+
+### Task 5: Final Integration Verification
+
+**Files:**
+- No planned source edits unless verification exposes a regression.
+
+- [ ] **Step 1: Run provider and diff-review focused suites**
+
+Run:
+
+```bash
+xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -only-testing:AlasTests/GitHubCLIProviderTests -only-testing:AlasTests/GitLabCLIProviderTests -only-testing:AlasTests/ReviewRequestDiffLoaderTests -only-testing:AlasTests/ReviewEvidenceModelTests -only-testing:AlasTests/DiffReviewSurfaceTests test
+```
+
+Expected: all focused suites pass.
+
+- [ ] **Step 2: Run project generation**
+
+Run:
+
+```bash
+xcodegen
+```
+
+Expected: completes successfully. Commit any legitimate `Alas.xcodeproj/project.pbxproj` updates caused by new files.
+
+- [ ] **Step 3: Run quiet build**
+
+Run:
+
+```bash
+xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -quiet build
+```
+
+Expected: build exits 0.
+
+- [ ] **Step 4: Run full test suite**
+
+Run:
+
+```bash
+xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' test
+```
+
+Expected: full suite exits 0. If it fails, inspect the failing test. Fix regressions caused by this work; if a known unrelated flake fails, rerun that exact test once and report the caveat honestly.
+
+- [ ] **Step 5: Commit verification fixes**
+
+If verification required source changes, stage the exact files changed by those fixes. Example for a view/model hardening fix:
+
+```bash
+git add Alas/Sources/Center/ReviewEvidence/ReviewEvidenceTabView.swift Alas/Sources/Integrations/CodeHost/ReviewEvidenceModel.swift
+git commit -m "fix(review): harden files-first PR details"
+```
+
+If no source changes were needed, do not create an empty commit.

--- a/docs/superpowers/plans/2026-06-13-pr-inline-feedback-ci-activity.md
+++ b/docs/superpowers/plans/2026-06-13-pr-inline-feedback-ci-activity.md
@@ -1,0 +1,1194 @@
+# PR Inline Feedback And CI Activity Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Show provider review feedback inline in PR/MR file diffs and show CI activity rows while checks are pending or running.
+
+**Architecture:** Keep provider-specific parsing in `Integrations/CodeHost`, map provider feedback into generic `DiffReviewInlineFeedback` values, and render those cards inside the shared `DiffReviewSurface`. CI activity uses the already-loaded `ReviewRequest.checks` as the base list, then overlays failed-check details where those logs already exist.
+
+**Tech Stack:** Swift 5.9+, SwiftUI, AppKit-hosted diff panes, Swift Testing, existing `CodeHostProvider`, `ReviewEvidenceModel`, and `DiffReviewSurface`.
+
+---
+
+## File Structure
+
+- Modify `Alas/Sources/Integrations/CodeHost/CodeHostModels.swift`
+  - Add `ReviewThreadLocation` and a `location` field on `ReviewThreadSummary`.
+- Modify `Alas/Sources/Integrations/CodeHost/GitHubCLIProvider.swift`
+  - Request review-thread path/line metadata from GraphQL and parse it.
+- Modify `Alas/Sources/Integrations/CodeHost/GitLabCLIProvider.swift`
+  - Parse discussion note position metadata where `glab` provides it.
+- Modify `Alas/Sources/Integrations/CodeHost/ReviewEvidence.swift`
+  - Add CI activity item construction and inline-feedback mapping helpers.
+- Modify `Alas/Sources/Integrations/CodeHost/ReviewEvidenceModel.swift`
+  - Publish CI activity rows and grouped inline feedback.
+- Modify `Alas/Sources/Center/DiffReview/DiffReviewModels.swift`
+  - Add `DiffReviewInlineFeedback` and anchor models.
+- Modify `Alas/Sources/Center/DiffReview/DiffReviewSurface.swift`
+  - Accept inline feedback grouped by file ID and pass it into file sections.
+- Modify `Alas/Sources/Center/DiffReview/DiffReviewFileSection.swift`
+  - Render file-level and line-near inline feedback cards.
+- Modify `Alas/Sources/Center/ReviewEvidence/ReviewEvidenceTabView.swift`
+  - Pass inline feedback into `DiffReviewSurface` and render CI activity rows in the evidence browser.
+- Tests:
+  - `AlasTests/Integrations/CodeHostProviderTests.swift`
+  - `AlasTests/Integrations/GitHubCLIProviderTests.swift`
+  - `AlasTests/Integrations/GitLabCLIProviderTests.swift`
+  - `AlasTests/Integrations/ReviewEvidenceModelTests.swift`
+  - `AlasTests/DiffReviewSurfaceTests.swift`
+  - `AlasTests/Integrations/ReviewEvidenceTabViewTests.swift`
+
+---
+
+### Task 1: Provider Thread Locations
+
+**Files:**
+- Modify: `Alas/Sources/Integrations/CodeHost/CodeHostModels.swift`
+- Modify: `Alas/Sources/Integrations/CodeHost/GitHubCLIProvider.swift`
+- Modify: `Alas/Sources/Integrations/CodeHost/GitLabCLIProvider.swift`
+- Test: `AlasTests/Integrations/CodeHostProviderTests.swift`
+- Test: `AlasTests/Integrations/GitHubCLIProviderTests.swift`
+- Test: `AlasTests/Integrations/GitLabCLIProviderTests.swift`
+
+- [ ] **Step 1: Add failing model tests for thread location preservation**
+
+Add to `CodeHostProviderTests.defaultEvidenceMethodsUseSummaryData` or a new adjacent test:
+
+```swift
+let location = ReviewThreadLocation(
+    path: "Sources/App.swift",
+    originalPath: nil,
+    line: 42,
+    side: .new,
+    providerPosition: "github-position-1"
+)
+let thread = ReviewThreadSummary(
+    id: "thread-located",
+    author: "reviewer",
+    body: "Inline feedback.",
+    url: URL(string: "https://github.com/thread-located")!,
+    isResolved: false,
+    isActionable: true,
+    location: location
+)
+
+#expect(thread.location?.path == "Sources/App.swift")
+#expect(thread.location?.line == 42)
+#expect(thread.location?.side == .new)
+#expect(thread.location?.providerPosition == "github-position-1")
+```
+
+Expected failure: `ReviewThreadLocation` and `ReviewThreadSummary.location` do not exist.
+
+- [ ] **Step 2: Add failing GitHub parser test**
+
+In `GitHubCLIProviderTests`, add a test using `GitHubCLIProvider.parseReviewThreads` with GraphQL thread JSON that includes:
+
+```json
+{
+  "data": {
+    "repository": {
+      "pullRequest": {
+        "reviewThreads": {
+          "nodes": [
+            {
+              "id": "PRRT_kwDO",
+              "isResolved": false,
+              "isOutdated": false,
+              "path": "Sources/App.swift",
+              "line": 56,
+              "originalLine": null,
+              "diffSide": "RIGHT",
+              "comments": {
+                "nodes": [
+                  {
+                    "id": "PRRC_kwDO",
+                    "body": "Please simplify this.",
+                    "url": "https://github.com/mrmans0n/alas/pull/1#discussion_r1",
+                    "author": { "login": "reviewer" }
+                  }
+                ]
+              }
+            }
+          ],
+          "pageInfo": { "hasNextPage": false, "endCursor": null }
+        }
+      }
+    }
+  }
+}
+```
+
+Assert:
+
+```swift
+let threads = try GitHubCLIProvider.parseReviewThreads(json)
+#expect(threads.first?.location?.path == "Sources/App.swift")
+#expect(threads.first?.location?.line == 56)
+#expect(threads.first?.location?.side == .new)
+```
+
+Expected failure: GitHub parser ignores location fields.
+
+- [ ] **Step 3: Add failing GitLab parser test**
+
+In `GitLabCLIProviderTests`, add a test for `GitLabCLIProvider.parseDiscussions` using note JSON with a position:
+
+```json
+[
+  {
+    "id": "discussion-1",
+    "resolved": false,
+    "notes": [
+      {
+        "id": 100,
+        "body": "This needs a guard.",
+        "system": false,
+        "web_url": "https://gitlab.example.com/group/proj/-/merge_requests/7#note_100",
+        "author": { "username": "reviewer" },
+        "position": {
+          "new_path": "Sources/App.swift",
+          "old_path": "Sources/OldApp.swift",
+          "new_line": 24,
+          "old_line": null
+        }
+      }
+    ]
+  }
+]
+```
+
+Assert:
+
+```swift
+let threads = try GitLabCLIProvider.parseDiscussions(json, requestURL: URL(string: "https://gitlab.example.com/group/proj/-/merge_requests/7")!)
+#expect(threads.first?.location?.path == "Sources/App.swift")
+#expect(threads.first?.location?.originalPath == "Sources/OldApp.swift")
+#expect(threads.first?.location?.line == 24)
+#expect(threads.first?.location?.side == .new)
+```
+
+Expected failure: GitLab note position metadata is not decoded.
+
+- [ ] **Step 4: Implement location models**
+
+In `CodeHostModels.swift`, add:
+
+```swift
+enum ReviewThreadSide: String, Codable, Equatable, Sendable {
+    case old
+    case new
+    case unknown
+}
+
+struct ReviewThreadLocation: Codable, Equatable, Sendable {
+    let path: String
+    let originalPath: String?
+    let line: Int?
+    let side: ReviewThreadSide
+    let providerPosition: String?
+}
+```
+
+Update `ReviewThreadSummary`:
+
+```swift
+struct ReviewThreadSummary: Identifiable, Equatable, Sendable {
+    let id: String
+    let author: String?
+    let body: String
+    let url: URL?
+    let isResolved: Bool
+    let isActionable: Bool
+    let location: ReviewThreadLocation?
+
+    init(
+        id: String,
+        author: String?,
+        body: String,
+        url: URL?,
+        isResolved: Bool,
+        isActionable: Bool,
+        location: ReviewThreadLocation? = nil
+    ) {
+        self.id = id
+        self.author = author
+        self.body = body
+        self.url = url
+        self.isResolved = isResolved
+        self.isActionable = isActionable
+        self.location = location
+    }
+}
+```
+
+The initializer keeps existing call sites compiling.
+
+- [ ] **Step 5: Implement GitHub location parsing**
+
+Update `GitHubCLIProvider.reviewThreadsQuery` to request the thread-level fields:
+
+```graphql
+path
+line
+originalLine
+diffSide
+```
+
+Update the private thread node decodable type with:
+
+```swift
+let path: String?
+let line: Int?
+let originalLine: Int?
+let diffSide: String?
+```
+
+Add a mapper:
+
+```swift
+private static func reviewThreadLocation(from thread: ReviewThreadNode) -> ReviewThreadLocation? {
+    guard let path = normalizedOptionalString(thread.path) else { return nil }
+    let side: ReviewThreadSide
+    let line: Int?
+    switch thread.diffSide?.uppercased() {
+    case "LEFT":
+        side = .old
+        line = thread.originalLine ?? thread.line
+    case "RIGHT":
+        side = .new
+        line = thread.line ?? thread.originalLine
+    default:
+        side = .unknown
+        line = thread.line ?? thread.originalLine
+    }
+    return ReviewThreadLocation(
+        path: path,
+        originalPath: nil,
+        line: line,
+        side: side,
+        providerPosition: thread.id
+    )
+}
+```
+
+Pass `location: reviewThreadLocation(from: thread)` into `ReviewThreadSummary`.
+
+- [ ] **Step 6: Implement GitLab location parsing**
+
+Add `position` to the note decodable type:
+
+```swift
+let position: GitLabNotePosition?
+```
+
+Add:
+
+```swift
+private struct GitLabNotePosition: Decodable {
+    let newPath: String?
+    let oldPath: String?
+    let newLine: Int?
+    let oldLine: Int?
+
+    enum CodingKeys: String, CodingKey {
+        case newPath = "new_path"
+        case oldPath = "old_path"
+        case newLine = "new_line"
+        case oldLine = "old_line"
+    }
+}
+```
+
+Add a mapper:
+
+```swift
+private static func reviewThreadLocation(from note: GitLabNote) -> ReviewThreadLocation? {
+    guard let position = note.position else { return nil }
+    let newPath = normalizedOptionalString(position.newPath)
+    let oldPath = normalizedOptionalString(position.oldPath)
+    guard let path = newPath ?? oldPath else { return nil }
+
+    let side: ReviewThreadSide
+    let line: Int?
+    if let newLine = position.newLine {
+        side = .new
+        line = newLine
+    } else if let oldLine = position.oldLine {
+        side = .old
+        line = oldLine
+    } else {
+        side = .unknown
+        line = nil
+    }
+
+    return ReviewThreadLocation(
+        path: path,
+        originalPath: oldPath,
+        line: line,
+        side: side,
+        providerPosition: String(note.id)
+    )
+}
+```
+
+Pass the location into `ReviewThreadSummary`.
+
+- [ ] **Step 7: Run focused tests**
+
+Run:
+
+```bash
+rtk xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' test \
+  -only-testing:AlasTests/CodeHostProviderTests \
+  -only-testing:AlasTests/GitHubCLIProviderTests \
+  -only-testing:AlasTests/GitLabCLIProviderTests
+```
+
+Expected: the new and existing provider tests pass.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add Alas/Sources/Integrations/CodeHost/CodeHostModels.swift \
+        Alas/Sources/Integrations/CodeHost/GitHubCLIProvider.swift \
+        Alas/Sources/Integrations/CodeHost/GitLabCLIProvider.swift \
+        AlasTests/Integrations/CodeHostProviderTests.swift \
+        AlasTests/Integrations/GitHubCLIProviderTests.swift \
+        AlasTests/Integrations/GitLabCLIProviderTests.swift
+git commit -m "feat(review): preserve provider thread locations"
+```
+
+---
+
+### Task 2: Inline Feedback Models And Mapping
+
+**Files:**
+- Modify: `Alas/Sources/Center/DiffReview/DiffReviewModels.swift`
+- Modify: `Alas/Sources/Integrations/CodeHost/ReviewEvidence.swift`
+- Modify: `Alas/Sources/Integrations/CodeHost/ReviewEvidenceModel.swift`
+- Test: `AlasTests/Integrations/ReviewEvidenceModelTests.swift`
+
+- [ ] **Step 1: Add failing tests for inline feedback mapping**
+
+In `ReviewEvidenceModelTests`, add:
+
+```swift
+@Test func modelBuildsInlineFeedbackForLocatedThreads() async {
+    let request = Self.reviewRequest(threads: [
+        ReviewThreadSummary(
+            id: "thread-1",
+            author: "reviewer",
+            body: "Please simplify this.",
+            url: URL(string: "https://github.com/thread-1")!,
+            isResolved: false,
+            isActionable: true,
+            location: ReviewThreadLocation(
+                path: "Sources/App.swift",
+                originalPath: nil,
+                line: 2,
+                side: .new,
+                providerPosition: "pos-1"
+            )
+        ),
+        ReviewThreadSummary(
+            id: "thread-no-path",
+            author: "reviewer",
+            body: "General note.",
+            url: URL(string: "https://github.com/thread-2")!,
+            isResolved: false,
+            isActionable: true,
+            location: nil
+        ),
+    ])
+    let model = ReviewEvidenceModel(
+        snapshot: Self.snapshot(reviewRequest: request),
+        provider: FakeCodeHostProvider(),
+        cwd: URL(fileURLWithPath: "/tmp/alas"),
+        initialSection: nil
+    )
+
+    await model.load()
+
+    let fileID = DiffReviewFileID(namespace: "github-pr", path: "Sources/App.swift")
+    #expect(model.inlineFeedbackByFileID[fileID]?.map(\.id) == ["thread-1"])
+    #expect(model.feedbackItems.map(\.id).contains("thread-no-path"))
+}
+```
+
+Add:
+
+```swift
+@Test func inlineFeedbackMatchesRenamedOldSideToOriginalPath() async {
+    let request = Self.reviewRequest(threads: [
+        ReviewThreadSummary(
+            id: "thread-old",
+            author: "reviewer",
+            body: "Old side note.",
+            url: URL(string: "https://github.com/thread-old")!,
+            isResolved: false,
+            isActionable: true,
+            location: ReviewThreadLocation(
+                path: "Sources/NewName.swift",
+                originalPath: "Sources/OldName.swift",
+                line: 4,
+                side: .old,
+                providerPosition: "pos-old"
+            )
+        ),
+    ])
+    let summary = DiffReviewFileSummary(
+        path: "Sources/NewName.swift",
+        namespace: "github-pr",
+        groupID: nil,
+        groupTitle: nil,
+        status: .renamed,
+        additions: 1,
+        deletions: 1,
+        isRenderable: true,
+        originalPath: "Sources/OldName.swift"
+    )
+    let inline = ReviewEvidenceInlineFeedbackMapper.feedbackByFileID(
+        threads: request.threads,
+        files: [summary],
+        providerName: request.provider.displayName
+    )
+
+    #expect(inline[summary.id]?.first?.anchor.side == .old)
+    #expect(inline[summary.id]?.first?.anchor.line == 4)
+}
+```
+
+Expected failure: `DiffReviewInlineFeedback`, `inlineFeedbackByFileID`, and `ReviewEvidenceInlineFeedbackMapper` do not exist.
+
+- [ ] **Step 2: Add generic inline feedback models**
+
+In `DiffReviewModels.swift`, add:
+
+```swift
+enum DiffReviewInlineFeedbackSide: String, Codable, Equatable, Sendable {
+    case old
+    case new
+    case unknown
+}
+
+struct DiffReviewInlineFeedbackAnchor: Codable, Equatable, Hashable, Sendable {
+    let path: String
+    let line: Int?
+    let side: DiffReviewInlineFeedbackSide
+
+    var isFileLevel: Bool { line == nil }
+}
+
+struct DiffReviewInlineFeedback: Identifiable, Codable, Equatable, Sendable {
+    let id: String
+    let providerName: String
+    let author: String?
+    let bodyPreview: String
+    let status: ReviewEvidenceStatus
+    let providerURL: URL?
+    let anchor: DiffReviewInlineFeedbackAnchor
+    let evidenceItemID: String
+}
+```
+
+- [ ] **Step 3: Add mapper**
+
+In `ReviewEvidence.swift`, add:
+
+```swift
+enum ReviewEvidenceInlineFeedbackMapper {
+    static func feedbackByFileID(
+        threads: [ReviewThreadSummary],
+        files: [DiffReviewFileSummary],
+        providerName: String
+    ) -> [DiffReviewFileID: [DiffReviewInlineFeedback]] {
+        var output: [DiffReviewFileID: [DiffReviewInlineFeedback]] = [:]
+        for thread in threads where !thread.isResolved && thread.isActionable {
+            guard let location = thread.location else { continue }
+            guard let file = matchingFile(for: location, in: files) else { continue }
+
+            let item = DiffReviewInlineFeedback(
+                id: thread.id,
+                providerName: providerName,
+                author: thread.author,
+                bodyPreview: String(thread.body.prefix(240)),
+                status: .actionable,
+                providerURL: thread.url,
+                anchor: DiffReviewInlineFeedbackAnchor(
+                    path: file.path,
+                    line: location.line,
+                    side: inlineSide(from: location.side)
+                ),
+                evidenceItemID: thread.id
+            )
+            output[file.id, default: []].append(item)
+        }
+
+        return output.mapValues { items in
+            items.sorted {
+                ($0.anchor.line ?? Int.min, $0.id) < ($1.anchor.line ?? Int.min, $1.id)
+            }
+        }
+    }
+
+    private static func matchingFile(
+        for location: ReviewThreadLocation,
+        in files: [DiffReviewFileSummary]
+    ) -> DiffReviewFileSummary? {
+        switch location.side {
+        case .old:
+            return files.first { $0.originalPath == location.originalPath || $0.originalPath == location.path }
+                ?? files.first { $0.path == location.path }
+        case .new, .unknown:
+            return files.first { $0.path == location.path }
+                ?? files.first { $0.originalPath == location.originalPath || $0.originalPath == location.path }
+        }
+    }
+
+    private static func inlineSide(from side: ReviewThreadSide) -> DiffReviewInlineFeedbackSide {
+        switch side {
+        case .old: .old
+        case .new: .new
+        case .unknown: .unknown
+        }
+    }
+}
+```
+
+If Swift requires explicit returns in the switch expression for the local compiler version, use normal `switch` statements with `return`.
+
+- [ ] **Step 4: Publish inline feedback from the model**
+
+In `ReviewEvidenceModel`, add:
+
+```swift
+private(set) var inlineFeedbackByFileID: [DiffReviewFileID: [DiffReviewInlineFeedback]] = [:]
+```
+
+Update evidence/file publishing so inline feedback is recomputed after either `fileSession` or `feedbackItems`/request threads load:
+
+```swift
+private func refreshInlineFeedback() {
+    guard let fileSession,
+          let request = snapshot.reviewRequest
+    else {
+        inlineFeedbackByFileID = [:]
+        return
+    }
+
+    inlineFeedbackByFileID = ReviewEvidenceInlineFeedbackMapper.feedbackByFileID(
+        threads: request.threads,
+        files: fileSession.summary.files,
+        providerName: request.provider.displayName
+    )
+}
+```
+
+Call `refreshInlineFeedback()` after successful `publishFiles` and after successful `publishEvidence`.
+
+- [ ] **Step 5: Run focused tests**
+
+Run:
+
+```bash
+rtk xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' test \
+  -only-testing:AlasTests/ReviewEvidenceModelTests
+```
+
+Expected: `ReviewEvidenceModelTests` pass.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add Alas/Sources/Center/DiffReview/DiffReviewModels.swift \
+        Alas/Sources/Integrations/CodeHost/ReviewEvidence.swift \
+        Alas/Sources/Integrations/CodeHost/ReviewEvidenceModel.swift \
+        AlasTests/Integrations/ReviewEvidenceModelTests.swift
+git commit -m "feat(review): map feedback to diff anchors"
+```
+
+---
+
+### Task 3: Inline Feedback Rendering In Diff Review Surface
+
+**Files:**
+- Modify: `Alas/Sources/Center/DiffReview/DiffReviewSurface.swift`
+- Modify: `Alas/Sources/Center/DiffReview/DiffReviewFileSection.swift`
+- Test: `AlasTests/DiffReviewSurfaceTests.swift`
+
+- [ ] **Step 1: Add failing surface tests**
+
+In `DiffReviewSurfaceTests`, add:
+
+```swift
+@Test func fileSectionRendersFileLevelInlineFeedbackBelowHeader() {
+    let file = DiffReviewFileSectionModel(
+        summary: summary(path: "Sources/App.swift"),
+        parsedDiff: parsedDiff(),
+        displayModel: displayModel(),
+        placeholderMessage: nil,
+        openFile: nil
+    )
+    let feedback = [
+        DiffReviewInlineFeedback(
+            id: "thread-file",
+            providerName: "GitHub",
+            author: "reviewer",
+            bodyPreview: "Please review this file.",
+            status: .actionable,
+            providerURL: URL(string: "https://github.com/thread-file")!,
+            anchor: DiffReviewInlineFeedbackAnchor(path: "Sources/App.swift", line: nil, side: .unknown),
+            evidenceItemID: "thread-file"
+        ),
+    ]
+    var layout = DiffLayoutMode.split
+    var wrap = false
+    var whitespace = false
+
+    let view = DiffReviewFileSection(
+        file: file,
+        inlineFeedback: feedback,
+        layoutMode: Binding(get: { layout }, set: { layout = $0 }),
+        wrapLines: Binding(get: { wrap }, set: { wrap = $0 }),
+        showWhitespace: Binding(get: { whitespace }, set: { whitespace = $0 }),
+        codeFontFamily: "",
+        codeFontSize: 13,
+        showsSourceBadge: false
+    )
+    .environment(\.theme, theme())
+
+    let controller = host(view, width: 900, height: 500)
+
+    #expect(subview(withAccessibilityIdentifier: "diff-review-inline-feedback-thread-file", in: controller.view) != nil)
+    #expect(accessibilityLabel(in: controller.view, containing: "Please review this file.") != nil)
+}
+```
+
+Add:
+
+```swift
+@Test func surfacePassesFeedbackToMatchingFileOnly() {
+    let first = summary(path: "Sources/App.swift")
+    let second = summary(path: "Sources/Other.swift")
+    let session = loadedSession(summaries: [first, second])
+    let feedback = [
+        first.id: [
+            DiffReviewInlineFeedback(
+                id: "thread-app",
+                providerName: "GitHub",
+                author: "reviewer",
+                bodyPreview: "App feedback.",
+                status: .actionable,
+                providerURL: nil,
+                anchor: DiffReviewInlineFeedbackAnchor(path: first.path, line: 2, side: .new),
+                evidenceItemID: "thread-app"
+            ),
+        ],
+    ]
+    var selected = first.id
+    var collapsed = false
+    var layout = DiffLayoutMode.split
+    var wrap = false
+    var whitespace = false
+
+    let view = DiffReviewSurface(
+        session: session,
+        selectedFileID: Binding(get: { selected }, set: { selected = $0 }),
+        railCollapsed: Binding(get: { collapsed }, set: { collapsed = $0 }),
+        layoutMode: Binding(get: { layout }, set: { layout = $0 }),
+        wrapLines: Binding(get: { wrap }, set: { wrap = $0 }),
+        showWhitespace: Binding(get: { whitespace }, set: { whitespace = $0 }),
+        codeFontFamily: "",
+        codeFontSize: 13,
+        inlineFeedbackByFileID: feedback
+    )
+    .environment(\.theme, theme())
+
+    let controller = host(view, width: 1000, height: 700)
+
+    #expect(subview(withAccessibilityIdentifier: "diff-review-inline-feedback-thread-app", in: controller.view) != nil)
+}
+```
+
+Expected failure: initializers do not accept inline feedback and cards do not render.
+
+- [ ] **Step 2: Add surface parameters**
+
+In `DiffReviewSurface`, add:
+
+```swift
+var inlineFeedbackByFileID: [DiffReviewFileID: [DiffReviewInlineFeedback]] = [:]
+```
+
+Pass `inlineFeedbackByFileID[file.id] ?? []` into `DiffReviewFileSection` for rendered sections. Placeholders do not need inline cards in V1.
+
+- [ ] **Step 3: Add file section parameter**
+
+In `DiffReviewFileSection`, add:
+
+```swift
+var inlineFeedback: [DiffReviewInlineFeedback] = []
+```
+
+Update initializers/call sites as needed, relying on the default for existing tests.
+
+- [ ] **Step 4: Render compact feedback cards**
+
+In `DiffReviewFileSection.body`, render file-level cards after `header` and before `content`:
+
+```swift
+VStack(spacing: 0) {
+    header
+    inlineFeedbackStack
+    content
+}
+```
+
+Add:
+
+```swift
+@ViewBuilder
+private var inlineFeedbackStack: some View {
+    let items = inlineFeedback
+    if !items.isEmpty {
+        VStack(alignment: .leading, spacing: 6) {
+            ForEach(items) { item in
+                DiffReviewInlineFeedbackCard(item: item)
+            }
+        }
+        .padding(.horizontal, 14)
+        .padding(.vertical, 10)
+        .background(theme.color("bg-1"))
+        .overlay(Rectangle().fill(theme.color("line")).frame(height: 0.5), alignment: .bottom)
+    }
+}
+```
+
+Add a private card view in `DiffReviewFileSection.swift`:
+
+```swift
+private struct DiffReviewInlineFeedbackCard: View {
+    let item: DiffReviewInlineFeedback
+    @Environment(\.theme) private var theme
+
+    var body: some View {
+        HStack(alignment: .top, spacing: 8) {
+            RoundedRectangle(cornerRadius: 2)
+                .fill(theme.color("accent"))
+                .frame(width: 3)
+            VStack(alignment: .leading, spacing: 4) {
+                HStack(spacing: 6) {
+                    Text(item.providerName)
+                        .font(.system(size: 10, weight: .semibold))
+                        .foregroundColor(theme.color("accent"))
+                    if let author = item.author, !author.isEmpty {
+                        Text(author)
+                            .font(.system(size: 10))
+                            .foregroundColor(theme.color("fg-muted"))
+                    }
+                    if let line = item.anchor.line {
+                        Text("line \(line)")
+                            .font(.system(size: 10))
+                            .foregroundColor(theme.color("fg-faint"))
+                    }
+                }
+                Text(item.bodyPreview)
+                    .font(.system(size: 11.5))
+                    .foregroundColor(theme.color("fg"))
+                    .lineLimit(3)
+            }
+            Spacer(minLength: 0)
+        }
+        .padding(8)
+        .background(theme.color("bg-2"))
+        .clipShape(RoundedRectangle(cornerRadius: 6))
+        .overlay(RoundedRectangle(cornerRadius: 6).stroke(theme.color("line"), lineWidth: 0.5))
+        .background(DiffReviewAccessibilityMarker(identifier: "diff-review-inline-feedback-\(item.id)", label: item.bodyPreview))
+    }
+}
+```
+
+V1 renders cards at file level even when they have line metadata. The model keeps the line metadata for a later precise row-placement pass. This is intentional to avoid destabilizing the AppKit diff body.
+
+- [ ] **Step 5: Run focused tests**
+
+Run:
+
+```bash
+rtk xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' test \
+  -only-testing:AlasTests/DiffReviewSurfaceTests
+```
+
+Expected: `DiffReviewSurfaceTests` pass.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add Alas/Sources/Center/DiffReview/DiffReviewSurface.swift \
+        Alas/Sources/Center/DiffReview/DiffReviewFileSection.swift \
+        AlasTests/DiffReviewSurfaceTests.swift
+git commit -m "feat(diff): show inline review feedback cards"
+```
+
+---
+
+### Task 4: CI Activity Rows
+
+**Files:**
+- Modify: `Alas/Sources/Integrations/CodeHost/ReviewEvidence.swift`
+- Modify: `Alas/Sources/Integrations/CodeHost/CodeHostProvider.swift`
+- Modify: `Alas/Sources/Integrations/CodeHost/GitHubCLIProvider.swift`
+- Modify: `Alas/Sources/Integrations/CodeHost/GitLabCLIProvider.swift`
+- Test: `AlasTests/Integrations/CodeHostProviderTests.swift`
+- Test: `AlasTests/Integrations/ReviewEvidenceModelTests.swift`
+
+- [ ] **Step 1: Add failing tests for CI activity evidence**
+
+In `CodeHostProviderTests.defaultEvidenceMethodsUseSummaryData`, update the expectation from failed-only CI to all checks:
+
+```swift
+#expect(ci.map(\.id) == ["check-passed", "check-1", "check-pending"])
+#expect(ci.map(\.status) == [.passed, .failed, .pending])
+```
+
+Add a focused test:
+
+```swift
+@Test func ciActivityEvidenceMapsAllCheckBuckets() {
+    let checks = [
+        ReviewCheck(id: "pass", name: "build", workflow: "CI", bucket: .pass, detailURL: nil, completedAt: Date()),
+        ReviewCheck(id: "fail", name: "test", workflow: "CI", bucket: .fail, detailURL: nil, completedAt: nil),
+        ReviewCheck(id: "pending", name: "lint", workflow: "CI", bucket: .pending, detailURL: nil, completedAt: nil),
+        ReviewCheck(id: "skip", name: "docs", workflow: "CI", bucket: .skipping, detailURL: nil, completedAt: nil),
+        ReviewCheck(id: "cancel", name: "deploy", workflow: "CI", bucket: .cancel, detailURL: nil, completedAt: nil),
+    ]
+
+    let items = ReviewEvidenceCIActivityMapper.items(for: checks)
+
+    #expect(items.map(\.id) == ["pass", "fail", "pending", "skip", "cancel"])
+    #expect(items.map(\.status) == [.passed, .failed, .pending, .unknown, .cancelled])
+}
+```
+
+Expected failure: mapper does not exist and providers only return failed checks.
+
+- [ ] **Step 2: Implement CI activity mapper**
+
+In `ReviewEvidence.swift`, add:
+
+```swift
+enum ReviewEvidenceCIActivityMapper {
+    static func items(for checks: [ReviewCheck]) -> [ReviewEvidenceItem] {
+        checks.map { check in
+            ReviewEvidenceItem(
+                id: check.id,
+                section: .ci,
+                title: check.name,
+                subtitle: check.workflow,
+                status: status(for: check.bucket),
+                providerURL: check.detailURL
+            )
+        }
+    }
+
+    static func status(for bucket: ReviewCheckBucket) -> ReviewEvidenceStatus {
+        switch bucket {
+        case .pass:
+            return .passed
+        case .fail:
+            return .failed
+        case .pending:
+            return .pending
+        case .cancel:
+            return .cancelled
+        case .skipping, .unknown:
+            return .unknown
+        }
+    }
+}
+```
+
+- [ ] **Step 3: Use mapper in providers**
+
+Update default `CodeHostProvider.failedCheckEvidence`:
+
+```swift
+func failedCheckEvidence(remote: CodeHostRemote, request: ReviewRequest, cwd: URL) async throws -> [ReviewEvidenceItem] {
+    ReviewEvidenceCIActivityMapper.items(for: request.checks)
+}
+```
+
+Update `GitHubCLIProvider.failedCheckEvidence` and `GitLabCLIProvider.failedCheckEvidence` to return `ReviewEvidenceCIActivityMapper.items(for: request.checks)`.
+
+Keep method names unchanged for compatibility; the method now returns CI activity evidence, not only failed rows.
+
+- [ ] **Step 4: Preserve failed check details and generic running details**
+
+Do not change failed-log fetching. In `GitHubCLIProvider.checkEvidenceDetail` and `GitLabCLIProvider.checkEvidenceDetail`, keep the existing logic. For non-failed rows where no run/job ID can be extracted, the current fallback text is acceptable:
+
+```swift
+"Open this check in GitHub to inspect full logs."
+```
+
+and
+
+```swift
+"Open this job in GitLab to inspect full logs."
+```
+
+- [ ] **Step 5: Add model test for running CI rows**
+
+In `ReviewEvidenceModelTests`, update or add:
+
+```swift
+@Test func ciSectionShowsPendingChecksFromRequest() async {
+    let request = Self.reviewRequest(checks: [
+        ReviewCheck(
+            id: "pending-check",
+            name: "build-test",
+            workflow: "Build",
+            bucket: .pending,
+            detailURL: URL(string: "https://github.com/checks/1"),
+            completedAt: nil
+        ),
+    ])
+    let model = ReviewEvidenceModel(
+        snapshot: Self.snapshot(reviewRequest: request),
+        provider: FakeCodeHostProvider(),
+        cwd: URL(fileURLWithPath: "/tmp/alas"),
+        initialSection: .ci
+    )
+
+    await model.load()
+
+    #expect(model.ciItems.map(\.id) == ["pending-check"])
+    #expect(model.ciItems.first?.status == .pending)
+}
+```
+
+Replace the existing `reviewRequest()` helper with this signature and default values:
+
+```swift
+private static func reviewRequest(
+    checks: [ReviewCheck] = [],
+    threads: [ReviewThreadSummary] = []
+) -> ReviewRequest {
+    let remote = Self.remote()
+    return ReviewRequest(
+        remote: remote,
+        number: 428,
+        title: "Review loop",
+        url: URL(string: "https://github.com/mrmans0n/alas/pull/428")!,
+        state: .open,
+        isDraft: false,
+        headRefName: "feature/review-loop",
+        baseRefName: "main",
+        reviewDecision: .changesRequested,
+        mergeState: .blocked,
+        checks: checks,
+        threads: threads
+    )
+}
+```
+
+- [ ] **Step 6: Run focused tests**
+
+Run:
+
+```bash
+rtk xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' test \
+  -only-testing:AlasTests/CodeHostProviderTests \
+  -only-testing:AlasTests/ReviewEvidenceModelTests
+```
+
+Expected: provider and model CI tests pass.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add Alas/Sources/Integrations/CodeHost/ReviewEvidence.swift \
+        Alas/Sources/Integrations/CodeHost/CodeHostProvider.swift \
+        Alas/Sources/Integrations/CodeHost/GitHubCLIProvider.swift \
+        Alas/Sources/Integrations/CodeHost/GitLabCLIProvider.swift \
+        AlasTests/Integrations/CodeHostProviderTests.swift \
+        AlasTests/Integrations/ReviewEvidenceModelTests.swift
+git commit -m "feat(review): show CI activity rows"
+```
+
+---
+
+### Task 5: Wire Inline Feedback And CI Activity Into Review Evidence View
+
+**Files:**
+- Modify: `Alas/Sources/Center/ReviewEvidence/ReviewEvidenceTabView.swift`
+- Test: `AlasTests/Integrations/ReviewEvidenceTabViewTests.swift`
+- Test: `AlasTests/Integrations/ReviewEvidenceModelTests.swift`
+- Test: `AlasTests/DiffReviewSurfaceTests.swift`
+
+- [ ] **Step 1: Add failing view route tests**
+
+In `ReviewEvidenceTabViewTests`, add hosted tests or route-helper tests that assert:
+
+```swift
+#expect(ReviewEvidenceTabView.emptyText(for: .ci, isLoadingList: true, itemCount: 0) == "Loading checks…")
+#expect(ReviewEvidenceTabView.emptyText(for: .ci, isLoadingList: false, itemCount: 0) == "No checks")
+```
+
+If `emptyText` is private, make a small internal static helper:
+
+```swift
+static func emptyText(for section: ReviewEvidenceSection, isLoadingList: Bool, itemCount: Int) -> String
+```
+
+Expected failure: helper does not exist and current CI empty text says `"No failed checks"`.
+
+- [ ] **Step 2: Pass inline feedback into the diff surface**
+
+In `ReviewEvidenceTabView`, update the existing `.files` view branch by adding the inline-feedback argument to the existing `DiffReviewSurface` call. The resulting call must keep the existing bindings and add this final argument:
+
+```swift
+DiffReviewSurface(
+    session: fileSession,
+    selectedFileID: $selectedFileID,
+    railCollapsed: $railCollapsed,
+    layoutMode: diffPreferences.layoutMode,
+    wrapLines: diffPreferences.wrapLines,
+    showWhitespace: diffPreferences.showWhitespace,
+    codeFontFamily: appState.config.appearance.codeFontFamily,
+    codeFontSize: CGFloat(appState.config.appearance.codeFontSize),
+    showsSourceBadges: false,
+    inlineFeedbackByFileID: model.inlineFeedbackByFileID
+)
+```
+
+If the live call site has different local binding names after nearby refactors, keep those existing names and add only `inlineFeedbackByFileID: model.inlineFeedbackByFileID`.
+
+- [ ] **Step 3: Improve CI empty/loading text**
+
+Replace the private empty text helper with:
+
+```swift
+static func emptyText(
+    for section: ReviewEvidenceSection,
+    isLoadingList: Bool,
+    itemCount: Int
+) -> String {
+    switch section {
+    case .files:
+        return "No changed files"
+    case .ci:
+        if isLoadingList && itemCount == 0 { return "Loading checks…" }
+        return "No checks"
+    case .feedback:
+        if isLoadingList && itemCount == 0 { return "Loading feedback…" }
+        return "No feedback"
+    }
+}
+```
+
+Update call sites to pass `model.isLoadingList` and `model.items(for: section).count`.
+
+- [ ] **Step 4: Keep detail actions available**
+
+Do not remove or rewrite these existing actions in `detailPane`:
+
+- rerun failed checks
+- copy context
+- open in provider
+- send to agent
+
+Run a focused grep after editing:
+
+```bash
+rg -n "Rerun Failed|Copy Context|Open|Send" Alas/Sources/Center/ReviewEvidence/ReviewEvidenceTabView.swift
+```
+
+Expected: existing action labels or equivalent button titles remain.
+
+- [ ] **Step 5: Run focused tests**
+
+Run:
+
+```bash
+rtk xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' test \
+  -only-testing:AlasTests/ReviewEvidenceTabViewTests \
+  -only-testing:AlasTests/ReviewEvidenceModelTests \
+  -only-testing:AlasTests/DiffReviewSurfaceTests
+```
+
+Expected: review evidence view/model and diff review surface tests pass.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add Alas/Sources/Center/ReviewEvidence/ReviewEvidenceTabView.swift \
+        AlasTests/Integrations/ReviewEvidenceTabViewTests.swift \
+        AlasTests/Integrations/ReviewEvidenceModelTests.swift \
+        AlasTests/DiffReviewSurfaceTests.swift
+git commit -m "feat(review): surface inline feedback and CI activity"
+```
+
+---
+
+### Task 6: Final Verification
+
+**Files:**
+- No intended source edits.
+
+- [ ] **Step 1: Run project generation**
+
+Run:
+
+```bash
+xcodegen
+```
+
+Expected: command exits 0. If it changes `Alas.xcodeproj/project.pbxproj`, include that generated file in the final commit for the task that introduced new source files.
+
+- [ ] **Step 2: Run focused suites**
+
+Run:
+
+```bash
+rtk xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' test \
+  -only-testing:AlasTests/CodeHostProviderTests \
+  -only-testing:AlasTests/GitHubCLIProviderTests \
+  -only-testing:AlasTests/GitLabCLIProviderTests \
+  -only-testing:AlasTests/ReviewEvidenceModelTests \
+  -only-testing:AlasTests/ReviewEvidenceTabViewTests \
+  -only-testing:AlasTests/DiffReviewSurfaceTests
+```
+
+Expected: focused suites pass.
+
+- [ ] **Step 3: Run quiet build**
+
+Run:
+
+```bash
+rtk xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -quiet build
+```
+
+Expected: build exits 0.
+
+- [ ] **Step 4: Run full suite**
+
+Run:
+
+```bash
+rtk xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' test
+```
+
+Expected: full suite exits 0. If it fails in a known flaky non-review area, rerun the exact failing suite once and report the result honestly.
+
+- [ ] **Step 5: Final status**
+
+Run:
+
+```bash
+git status --short
+git log --oneline -5
+```
+
+Expected: working tree clean and latest commits correspond to this plan.

--- a/docs/superpowers/specs/2026-06-12-pr-details-files-first-review-design.md
+++ b/docs/superpowers/specs/2026-06-12-pr-details-files-first-review-design.md
@@ -1,0 +1,174 @@
+# PR Details Files-First Review Design
+
+## Goal
+
+Make PR/MR details a files-first review experience. The tab should open on the changed files with the same left rail and stacked diff stream used by Review Changes and commit details, while preserving the current CI and feedback evidence workflow as secondary sections.
+
+The target feel is the diffs.com/GitHub/GitLab review flow: changed files are the primary surface, the rail tracks scroll position, and evidence is available without displacing the diff stack.
+
+## Scope
+
+V1 applies to the existing `ReviewEvidenceTabView` opened from the review-loop drawer.
+
+In scope:
+
+- Make **Files** the default section for PR/MR detail tabs.
+- Reuse `DiffReviewSurface` for the file rail, split/stacked controls, wrapping, whitespace, scroll-spy selection, and file stack.
+- Keep **CI** and **Feedback** as secondary sections in the same tab.
+- Preserve existing failed-check and feedback detail behavior, including rerun failed checks, copy context, open in browser, and send to agent.
+- Load provider diffs through the code-host CLI:
+  - GitHub: `gh pr diff <number> -R <owner/repo>`
+  - GitLab: `glab mr diff <number> -R <namespace/project>`
+- Parse provider unified diff output with the existing `DiffParser`.
+- Convert parsed provider diffs into a `DiffReviewLoadedSession`.
+- Keep unsupported files visible as placeholder cards.
+- Preserve provider-aware header identity, status chips, refresh, and open-in-provider action.
+
+Out of scope for V1:
+
+- Inline rendering of existing review threads on diff lines.
+- Posting new review comments from the diff.
+- Resolving remote review threads.
+- Local-ref fallback when provider CLI diff output fails.
+- Image diff rendering inside PR/MR details. Images remain placeholder cards.
+- Progressive streaming of very large provider diffs.
+
+Fast follow:
+
+- Attach existing review threads to stable diff anchors.
+- Let selected lines/ranges be sent to an agent with file and provider context.
+- Add local git-ref fallback for provider CLI diff failures or unavailable CLIs.
+- Add inline review comment drafting and provider submission.
+- Add progressive loading or virtualization if very large PR/MR diffs show performance issues.
+
+## Architecture
+
+Extend the code-host provider abstraction with a read-only diff-loading capability. The provider remains responsible for fetching provider-specific diff text, while shared loaders remain responsible for parsing and building the review session.
+
+New or refactored pieces:
+
+- `CodeHostProvider.reviewDiff(remote:request:cwd:) async throws -> String`
+  - GitHub implementation calls `gh pr diff`.
+  - GitLab implementation calls `glab mr diff`.
+- `ReviewRequestDiffLoader`
+  - Calls the provider diff method.
+  - Parses the unified diff.
+  - Builds `DiffDisplayModel` values off-main.
+  - Produces `DiffReviewLoadedSession`.
+- `ReviewEvidenceModel`
+  - Continues to load CI and feedback evidence.
+  - Gains file-review loading state, selected file state, and a selected section that includes `.files`.
+- `ReviewEvidenceTabView`
+  - Keeps the current header.
+  - Replaces the top-level two-section segmented control with a files-first section control.
+  - Renders `DiffReviewSurface` for `.files`.
+  - Renders the existing evidence list/detail browser for `.ci` and `.feedback`.
+
+The shared `DiffReviewSurface` should not learn about GitHub or GitLab. It receives a generic `DiffReviewLoadedSession` just like Review Changes and commit details.
+
+## Provider Diff Data Flow
+
+Loading a PR/MR details tab follows this flow:
+
+1. `ReviewEvidenceTabView` receives the active `ReviewLoopSnapshot`.
+2. It validates that provider CLI support and authentication are available.
+3. It creates `ReviewEvidenceModel` with the active `ReviewRequest` and provider.
+4. The model loads CI evidence, feedback evidence, and file diffs as independent async work.
+5. The file loader calls `provider.reviewDiff(remote:request:cwd:)`.
+6. The provider returns provider-native unified diff text.
+7. `DiffParser` parses the unified diff into file-level `ParsedDiff` values.
+8. The loader converts each parsed file into a `DiffReviewFileSectionModel`.
+9. `DiffReviewSurface` renders the loaded file session.
+
+The loader should use the parsed diff header to derive path, original path, and status. Counts should be derived from parsed hunk lines so they match what the pane renders.
+
+The loaded session uses a provider-specific namespace, such as `github-pr` or `gitlab-mr`, and disables source grouping. File order should match provider diff order.
+
+## UI Behavior
+
+The tab header remains provider-aware:
+
+- provider name and request number
+- repository slug
+- request title
+- checks, review, and merge chips
+- refresh action
+- open in provider action
+
+Below the header, the section control should include:
+
+- `Files`
+- `CI`
+- `Feedback`
+
+`Files` is selected by default for new tabs. Restored tabs should keep their last selected section when possible.
+
+The Files section:
+
+- Shows `DiffReviewSurface`.
+- Uses a collapsible left file rail.
+- Shows all changed files in a continuous diff stack.
+- Synchronizes rail selection with scroll position.
+- Scrolls to a file when clicked in the rail.
+- Reuses global diff display preferences for split/stacked layout, wrapping, and whitespace.
+- Shows source badges only when they help disambiguate provider/source context. For V1, provider PR/MR files should not show staged/unstaged badges.
+- Does not show `Open File` by default unless the file exists locally and the app can safely open it from the current worktree.
+
+The CI and Feedback sections keep the current evidence browser shape:
+
+- left list of evidence items
+- right detail pane
+- existing detail actions
+- current empty states
+
+If file diff loading fails but evidence loading succeeds, the Files section should show a clear error state while CI and Feedback remain usable.
+
+## Review Thread Handling
+
+V1 does not render review threads inline on diff lines.
+
+Existing actionable feedback stays in the Feedback section. The data model should preserve thread file path and line metadata when providers expose it, but line placement is intentionally deferred. This avoids inaccurate pins for outdated threads, renamed files, or provider-specific diff positions while still leaving a path for inline comments later.
+
+## Testing
+
+Provider tests should cover:
+
+- GitHub calls `gh pr diff <number> -R <owner/repo>`.
+- GitLab calls `glab mr diff <number> -R <namespace/project>`.
+- Non-zero CLI exits surface `CodeHostProviderError.commandFailed`.
+
+Loader tests should cover:
+
+- A provider unified diff becomes a `DiffReviewLoadedSession`.
+- File order follows provider diff order.
+- Added, modified, deleted, and renamed files produce correct summaries.
+- Add/delete counts are derived from parsed hunk lines.
+- Unsupported image files remain visible as placeholders.
+- Display models are built outside SwiftUI body evaluation.
+- Cancellation prevents stale file sessions from being published.
+
+Model tests should cover:
+
+- New models default to `.files`.
+- Restored section selection is preserved when valid.
+- CI and feedback evidence still load and select as before.
+- File diff load errors do not erase loaded CI or feedback evidence.
+- Revision keys include enough request and head metadata to reload when provider diff content can change.
+
+View tests should cover:
+
+- The header remains present.
+- Files section hosts `DiffReviewSurface`.
+- CI and Feedback sections still host the evidence list/detail browser.
+- Existing evidence actions remain visible in detail panes.
+- Rail display controls are available in the Files section.
+
+## Migration Plan
+
+1. Add provider diff capability to GitHub and GitLab providers.
+2. Add `ReviewRequestDiffLoader`.
+3. Extend `ReviewEvidenceSection` with `.files` and update tab state persistence.
+4. Extend `ReviewEvidenceModel` to load file review sessions independently from CI/feedback evidence.
+5. Update `ReviewEvidenceTabView` to make Files the default section and render `DiffReviewSurface`.
+6. Preserve and retest CI/Feedback evidence behavior.
+7. Run focused provider, loader, model, and view tests, then `xcodegen`, quiet build, and the full test suite.

--- a/docs/superpowers/specs/2026-06-13-pr-inline-feedback-ci-activity-design.md
+++ b/docs/superpowers/specs/2026-06-13-pr-inline-feedback-ci-activity-design.md
@@ -1,0 +1,167 @@
+# PR Inline Feedback And CI Activity Design
+
+## Goal
+
+Make PR/MR details feel like a real review surface while preserving the files-first layout from the previous phase.
+
+The Files section should show provider feedback where the reviewer is already looking: inside the diff stack, anchored to the relevant file and line when location data is available. The CI section should show useful activity while checks are pending or running, not only after a failure produces logs.
+
+The target feel remains diffs.com, GitHub/GitLab review, and rudu-style review flows: changed files first, contextual feedback near code, and provider status visible without leaving the review tab.
+
+## Scope
+
+V1 applies to PR/MR review evidence tabs opened from the review-loop drawer.
+
+In scope:
+
+- Keep **Files** as the default PR/MR detail section.
+- Render provider feedback as inline cards in the Files diff stack when a thread can be matched to a file.
+- Anchor feedback cards to the closest supported position:
+  - exact file and new-side line when available
+  - exact file and old-side line when available
+  - file-level card near the file header when the thread has a path but no usable line
+  - Feedback section only when no file path is available
+- Preserve the existing Feedback section as the complete list/detail browser.
+- Preserve existing feedback actions: copy context, open in provider, and send to agent.
+- Extend provider feedback models with optional location metadata.
+- Show running, pending, passed, failed, skipped, and cancelled checks in the CI section.
+- Keep failed-check log/detail actions for failed checks.
+- Add CI activity rows for checks that do not have failure logs yet.
+- Keep this pass display-only for comments: no posting, replying, resolving, or editing remote comments.
+
+Out of scope:
+
+- Creating new provider review comments from selected diff lines.
+- Replying to or resolving provider review threads.
+- Editing or deleting provider comments.
+- Perfect placement for outdated comments whose provider position no longer maps cleanly to the current diff.
+- Live log streaming for running checks.
+- Provider-side review submission flows.
+- Inline comments for local Review Changes or commit detail surfaces.
+
+## Architecture
+
+This phase adds review metadata beside the existing provider diff session instead of making `DiffReviewSurface` provider-aware.
+
+New or refactored pieces:
+
+- `ReviewThreadLocation`
+  - provider file path
+  - optional original path
+  - optional line number
+  - optional side, such as old/new/unknown
+  - optional provider position metadata for future comment actions
+- `ReviewThreadSummary.location`
+  - optional structured location captured by GitHub/GitLab providers when available
+- `DiffReviewInlineFeedback`
+  - generic display model for inline cards inside a diff review file section
+  - contains thread identity, title/body summary, provider URL, severity/actionability state, and source evidence item identity
+- `ReviewEvidenceModel`
+  - maps provider thread summaries into inline feedback grouped by file path
+  - keeps the Feedback evidence list as the canonical complete list
+- `DiffReviewSurface`
+  - accepts optional per-file inline feedback
+  - renders inline cards without knowing about GitHub or GitLab
+- CI evidence model
+  - includes status rows for every known check, not only failed checks with logs
+
+The provider layer remains responsible for extracting provider-specific metadata. The shared diff review layer only sees generic file paths, sides, lines, and display text.
+
+## Inline Feedback Data Flow
+
+Loading a PR/MR details tab follows the existing files-first flow, with feedback enrichment:
+
+1. `ReviewEvidenceModel` loads provider diff files, CI evidence, and feedback evidence independently.
+2. Provider implementations populate `ReviewThreadSummary.location` when the provider exposes file/line data.
+3. The model converts loaded thread summaries into `DiffReviewInlineFeedback` values.
+4. Feedback is grouped by normalized provider file path.
+5. `ReviewEvidenceTabView` passes grouped feedback into `DiffReviewSurface`.
+6. The surface attaches cards to matching file sections:
+   - line-anchored cards render before the nearest matching hunk row when the file display model contains that line
+   - file-level cards render below the file header and above the first hunk
+   - unmatched cards do not disappear; they remain visible in the Feedback section
+
+Path matching should be deterministic and conservative. If both a current path and original path exist for a rename, the current path wins for new-side comments and original path is allowed for old-side comments. If side is unknown, current path wins.
+
+## Inline Feedback UI
+
+Inline cards should be compact and review-oriented:
+
+- subtle bordered card using existing theme tokens
+- provider/source label, such as `GitHub review`
+- thread status/actionability indicator
+- author and short body preview
+- file/line label when known
+- actions matching existing evidence detail actions where available:
+  - open in provider
+  - copy context
+  - send to agent
+
+Cards should not visually dominate the code. They are context markers, not a replacement for the Feedback section. Multiple cards at the same anchor should stack with tight spacing.
+
+Line placement is best-effort in V1. If an exact line is outside the displayed hunks because context is collapsed, the card should attach to the closest visible row in that file rather than forcing the hunk open. Expanding collapsed context can improve placement in a later pass.
+
+## CI Activity Data Flow
+
+The CI section should render from the provider request’s check state immediately.
+
+For every check in the current `ReviewRequest`:
+
+- create a CI activity row with name, status, conclusion, provider URL, and timestamps when available
+- mark running or pending rows with a non-blocking progress indicator
+- keep passed/skipped/cancelled rows visible, but visually quieter than running and failed rows
+- attach existing failed-log evidence detail when a failed check has fetched logs
+
+Failed checks continue to support the existing rerun/copy/send-to-agent actions. Running and pending checks should offer open-in-provider and copy basic context, but not log-specific actions until logs exist.
+
+If checks are still loading and no rows exist yet, the CI section should show a compact loading state rather than the current empty state.
+
+## Error Handling
+
+Inline feedback failures must not hide file diffs. If provider feedback loading fails but file diff loading succeeds, Files still renders the diff stack and the Feedback section shows the existing error state.
+
+CI activity rows should render from whatever check summary is already available. Failure to fetch detailed logs should affect only the failed-check detail pane, not the CI activity list.
+
+If provider location metadata is missing or malformed, the thread remains available in the Feedback section and is omitted from inline placement.
+
+## Testing
+
+Provider/model tests should cover:
+
+- GitHub thread summaries preserve file path, line, side, URL, and provider IDs when available.
+- GitLab thread summaries preserve file path, line, side, URL, and provider IDs when available.
+- Missing location metadata does not drop the feedback evidence item.
+- Renamed-file thread locations match current and original paths deterministically.
+
+Diff review tests should cover:
+
+- `DiffReviewSurface` renders inline feedback cards for matching file sections.
+- File-level feedback appears below the file header.
+- Line-level feedback appears near the matching displayed row.
+- Multiple feedback cards at one anchor remain stable and ordered.
+- Unmatched feedback is not rendered inline.
+- Existing rail click and scroll-spy behavior still works with inline cards present.
+
+CI tests should cover:
+
+- Pending and running checks create visible CI rows.
+- Passing/skipped/cancelled checks create quieter visible rows.
+- Failed checks still show existing failure details and actions.
+- Empty CI state is only shown when there are genuinely no checks and no check loading state.
+- A check-log loading failure does not remove basic check activity rows.
+
+View tests should cover:
+
+- Files section shows inline feedback when feedback and file diffs both load.
+- Feedback section still shows the full evidence list.
+- CI section shows activity while checks are running.
+- Existing copy/open/send-to-agent actions remain available.
+
+## Migration Plan
+
+1. Extend provider feedback location models and tests.
+2. Add generic inline feedback display models and mapping from feedback evidence.
+3. Add inline feedback rendering to the shared diff review surface.
+4. Add CI activity rows for all check statuses while preserving failed-check details.
+5. Update PR/MR review evidence views to pass inline feedback and render CI activity.
+6. Run focused provider, review evidence, diff review, and CI tests, then `xcodegen`, quiet build, and the full test suite.


### PR DESCRIPTION
## Summary
- add Files as the default PR/MR evidence section backed by provider diff loading
- render changed files with the shared diff review surface, file rail, inline feedback cards, and CI activity rows
- preserve CI and Feedback evidence flows while mapping provider thread locations onto diff anchors

## Verification
- xcodegen
- rtk xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -quiet build
- rtk xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' test