### PR TITLE
fix(diff): stacked diff replacement block ordering

### DIFF
--- a/Alas/Sources/Center/Diff/DiffPaneTextDocumentBuilder.swift
+++ b/Alas/Sources/Center/Diff/DiffPaneTextDocumentBuilder.swift
@@ -115,7 +115,9 @@ struct DiffPaneTextDocumentBuilder {
             expandedCollapsedRowIDs: expandedCollapsedRowIDs
         )
 
-        for row in rows {
+        var index = 0
+        while index < rows.count {
+            let row = rows[index]
             if row.kind == .collapsed {
                 gutter.append("", side: .paired)
                 codeColumn.append(
@@ -124,10 +126,16 @@ struct DiffPaneTextDocumentBuilder {
                     tone: .collapsed,
                     sourceLine: nil
                 )
+                index += 1
                 continue
             }
 
-            for line in DiffPaneRowProjection.stackedLines(for: row) {
+            let rowStart = index
+            while index < rows.count, rows[index].kind != .collapsed {
+                index += 1
+            }
+            let lines = DiffPaneRowProjection.stackedLines(for: Array(rows[rowStart..<index]))
+            for (row, line) in lines {
                 gutter.append(marker(for: line, emptyKind: row.kind, side: line.anchor.side), side: line.anchor.side)
                 codeColumn.append(
                     code(
@@ -164,6 +172,15 @@ struct DiffPaneTextDocumentBuilder {
             in: group,
             expandedCollapsedRowIDs: expandedCollapsedRowIDs
         )
+        if layoutMode == .stacked {
+            return buildStackedSingleDocument(
+                rows: rows,
+                fileExtension: fileExtension,
+                font: font,
+                showWhitespace: showWhitespace,
+                theme: theme
+            )
+        }
 
         for row in rows {
             if output.length > 0 {
@@ -175,28 +192,14 @@ struct DiffPaneTextDocumentBuilder {
             case .collapsed:
                 output.append(collapsedLine(row, font: font, theme: theme))
             case .context, .add, .delete, .replacement:
-                switch layoutMode {
-                case .split:
-                    output.append(splitLine(
-                        row,
-                        fileExtension: fileExtension,
-                        font: font,
-                        showWhitespace: showWhitespace,
-                        theme: theme,
-                        splitColumnCharacterWidth: splitColumnCharacterWidth
-                    ))
-                case .stacked:
-                    appendStackedLines(
-                        row,
-                        to: output,
-                        lines: &lines,
-                        fileExtension: fileExtension,
-                        font: font,
-                        showWhitespace: showWhitespace,
-                        theme: theme
-                    )
-                    continue
-                }
+                output.append(splitLine(
+                    row,
+                    fileExtension: fileExtension,
+                    font: font,
+                    showWhitespace: showWhitespace,
+                    theme: theme,
+                    splitColumnCharacterWidth: splitColumnCharacterWidth
+                ))
             }
 
             lines.append(LineMetadata(kind: row.kind, range: NSRange(location: start, length: output.length - start)))
@@ -205,8 +208,51 @@ struct DiffPaneTextDocumentBuilder {
         return Result(attributedString: output, lines: lines)
     }
 
+    private static func buildStackedSingleDocument(
+        rows: [DiffDisplayRow],
+        fileExtension: String,
+        font: NSFont,
+        showWhitespace: Bool,
+        theme: Theme
+    ) -> Result {
+        let output = NSMutableAttributedString()
+        var lines: [LineMetadata] = []
+        var index = 0
+
+        while index < rows.count {
+            let row = rows[index]
+            if output.length > 0 {
+                output.append(NSAttributedString(string: "\n", attributes: baseAttributes(font: font, theme: theme)))
+            }
+
+            if row.kind == .collapsed {
+                let start = output.length
+                output.append(collapsedLine(row, font: font, theme: theme))
+                lines.append(LineMetadata(kind: row.kind, range: NSRange(location: start, length: output.length - start)))
+                index += 1
+                continue
+            }
+
+            let rowStart = index
+            while index < rows.count, rows[index].kind != .collapsed {
+                index += 1
+            }
+            appendStackedLines(
+                DiffPaneRowProjection.stackedLines(for: Array(rows[rowStart..<index])),
+                to: output,
+                lines: &lines,
+                fileExtension: fileExtension,
+                font: font,
+                showWhitespace: showWhitespace,
+                theme: theme
+            )
+        }
+
+        return Result(attributedString: output, lines: lines)
+    }
+
     private static func appendStackedLines(
-        _ row: DiffDisplayRow,
+        _ stackedLines: [(row: DiffDisplayRow, line: DiffDisplayLine)],
         to output: NSMutableAttributedString,
         lines: inout [LineMetadata],
         fileExtension: String,
@@ -214,7 +260,9 @@ struct DiffPaneTextDocumentBuilder {
         showWhitespace: Bool,
         theme: Theme
     ) {
-        for (index, line) in DiffPaneRowProjection.stackedLines(for: row).enumerated() {
+        for (index, entry) in stackedLines.enumerated() {
+            let row = entry.row
+            let line = entry.line
             if index > 0 {
                 output.append(NSAttributedString(string: "\n", attributes: baseAttributes(font: font, theme: theme)))
             }

--- a/Alas/Sources/Center/Diff/DiffPaneView.swift
+++ b/Alas/Sources/Center/Diff/DiffPaneView.swift
@@ -57,6 +57,38 @@ enum DiffPaneRowProjection {
         }
     }
 
+    static func stackedLines(for rows: [DiffDisplayRow]) -> [(row: DiffDisplayRow, line: DiffDisplayLine)] {
+        var output: [(row: DiffDisplayRow, line: DiffDisplayLine)] = []
+        var index = 0
+
+        while index < rows.count {
+            let row = rows[index]
+            guard isChanged(row) else {
+                output.append(contentsOf: stackedLines(for: row).map { (row, $0) })
+                index += 1
+                continue
+            }
+
+            let start = index
+            while index < rows.count, isChanged(rows[index]) {
+                index += 1
+            }
+            let changedRows = Array(rows[start..<index])
+            output.append(contentsOf: changedRows.compactMap { row in
+                row.old.map { (row, $0) }
+            })
+            output.append(contentsOf: changedRows.compactMap { row in
+                row.new.map { (row, $0) }
+            })
+        }
+
+        return output
+    }
+
+    private static func isChanged(_ row: DiffDisplayRow) -> Bool {
+        row.kind == .replacement || row.kind == .delete || row.kind == .add
+    }
+
     static func stackedLines(for row: DiffDisplayRow) -> [DiffDisplayLine] {
         if row.kind == .context {
             if let new = row.new { return [new] }

--- a/AlasTests/DiffPaneViewTests.swift
+++ b/AlasTests/DiffPaneViewTests.swift
@@ -753,6 +753,119 @@ struct DiffPaneViewTests {
         #expect(result.code.lines.contains { $0.kind == .replacement })
     }
 
+    @Test func stackedDocumentGroupsConsecutiveReplacementBlocksBySide() throws {
+        let model = DiffDisplayModelBuilder.build(
+            diff: ParsedDiff(hunks: [
+                ParsedDiff.Hunk(
+                    header: "@@ -1,4 +1,4 @@",
+                    oldStart: 1,
+                    newStart: 1,
+                    lines: [
+                        .init(kind: .context, text: "before", oldNumber: 1, newNumber: 1),
+                        .init(kind: .delete, text: "old one", oldNumber: 2, newNumber: nil),
+                        .init(kind: .delete, text: "old two", oldNumber: 3, newNumber: nil),
+                        .init(kind: .add, text: "new one", oldNumber: nil, newNumber: 2),
+                        .init(kind: .add, text: "new two", oldNumber: nil, newNumber: 3),
+                        .init(kind: .context, text: "after", oldNumber: 4, newNumber: 4),
+                    ]
+                )
+            ]),
+            filePath: "a.swift"
+        )
+        let result = DiffPaneTextDocumentBuilder.buildStacked(
+            group: try #require(model.groups.first),
+            expandedCollapsedRowIDs: [],
+            fileExtension: "swift",
+            font: CenterTypography.resolveCodeFont(family: "", size: 13),
+            showWhitespace: false,
+            theme: theme()
+        )
+
+        #expect(result.code.attributedString.string.components(separatedBy: "\n") == [
+            "before",
+            "old one",
+            "old two",
+            "new one",
+            "new two",
+            "after",
+        ])
+        #expect(result.gutter.string.components(separatedBy: "\n") == ["1", "2", "3", "2", "3", "4"])
+    }
+
+    @Test func stackedDocumentKeepsExtraDeletedLinesWithDeleteBlock() throws {
+        let model = DiffDisplayModelBuilder.build(
+            diff: ParsedDiff(hunks: [
+                ParsedDiff.Hunk(
+                    header: "@@ -1,4 +1,3 @@",
+                    oldStart: 1,
+                    newStart: 1,
+                    lines: [
+                        .init(kind: .context, text: "before", oldNumber: 1, newNumber: 1),
+                        .init(kind: .delete, text: "old one", oldNumber: 2, newNumber: nil),
+                        .init(kind: .delete, text: "old two", oldNumber: 3, newNumber: nil),
+                        .init(kind: .add, text: "new one", oldNumber: nil, newNumber: 2),
+                        .init(kind: .context, text: "after", oldNumber: 4, newNumber: 3),
+                    ]
+                )
+            ]),
+            filePath: "a.swift"
+        )
+        let result = DiffPaneTextDocumentBuilder.buildStacked(
+            group: try #require(model.groups.first),
+            expandedCollapsedRowIDs: [],
+            fileExtension: "swift",
+            font: CenterTypography.resolveCodeFont(family: "", size: 13),
+            showWhitespace: false,
+            theme: theme()
+        )
+
+        #expect(result.code.attributedString.string.components(separatedBy: "\n") == [
+            "before",
+            "old one",
+            "old two",
+            "new one",
+            "after",
+        ])
+        #expect(result.gutter.string.components(separatedBy: "\n") == ["1", "2", "3", "2", "3"])
+    }
+
+    @Test func stackedDocumentKeepsExtraAddedLinesWithAddBlock() throws {
+        let model = DiffDisplayModelBuilder.build(
+            diff: ParsedDiff(hunks: [
+                ParsedDiff.Hunk(
+                    header: "@@ -1,3 +1,4 @@",
+                    oldStart: 1,
+                    newStart: 1,
+                    lines: [
+                        .init(kind: .context, text: "before", oldNumber: 1, newNumber: 1),
+                        .init(kind: .delete, text: "old one", oldNumber: 2, newNumber: nil),
+                        .init(kind: .add, text: "new one", oldNumber: nil, newNumber: 2),
+                        .init(kind: .add, text: "new two", oldNumber: nil, newNumber: 3),
+                        .init(kind: .context, text: "after", oldNumber: 3, newNumber: 4),
+                    ]
+                )
+            ]),
+            filePath: "a.swift"
+        )
+        let result = DiffPaneTextDocumentBuilder.buildStacked(
+            group: try #require(model.groups.first),
+            expandedCollapsedRowIDs: [],
+            fileExtension: "swift",
+            font: CenterTypography.resolveCodeFont(family: "", size: 13),
+            showWhitespace: false,
+            theme: theme()
+        )
+
+        #expect(result.code.attributedString.string.components(separatedBy: "\n") == [
+            "before",
+            "old one",
+            "new one",
+            "new two",
+            "after",
+        ])
+        #expect(result.gutter.string.components(separatedBy: "\n") == ["1", "2", "2", "3", "4"])
+    }
+
     @Test func splitDocumentUsesInvisibleLayoutGlyphsForEmptyCounterparts() throws {
         let model = DiffDisplayModelBuilder.build(
             diff: ParsedDiff(hunks: [


### PR DESCRIPTION
## Summary
- Render contiguous changed rows in stacked diff mode as a delete block followed by an add block.
- Keep split-mode row pairing intact for side-by-side alignment and inline highlights.
- Add regression tests for equal-size replacement blocks and asymmetric delete/add tails.

## Validation
- xcodegen
- xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -quiet build
- xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' test -only-testing:AlasTests/DiffPaneViewTests
- GitHub Actions Build / build-test: success