### PR TITLE
feat(review): Add local review workspace

### DIFF
--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -105,6 +105,7 @@
 		195102F7D680452476D70329 /* GitLabCLIProviderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C371360F83FE318A5B8AEDBF /* GitLabCLIProviderTests.swift */; };
 		1A56FAF2DE8FFB95272EE948 /* ACPQuestionPromptTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 44ACE3DEC81C465524111058 /* ACPQuestionPromptTests.swift */; };
 		1A60F5DDA4E304766FEEC013 /* CodeTextViewAutoPairTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7C3A8A65C6EC8182FD23AE97 /* CodeTextViewAutoPairTests.swift */; };
+		1A6AF8939585038A3303B625 /* ReviewDraftModelsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 67378DD93876E3840E367550 /* ReviewDraftModelsTests.swift */; };
 		1AE5FCAF7D44694876754813 /* HookInstallNudgeResolverTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C54F4827435F746DC54616D0 /* HookInstallNudgeResolverTests.swift */; };
 		1B123A31842DDDB42C6820F1 /* BuildIdentity.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F30C23C9CD0842373F29D1F /* BuildIdentity.swift */; };
 		1B16FCB3621BB868C34334D7 /* ACPStreamingTextTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F16F771D1DD9CAC618459D41 /* ACPStreamingTextTests.swift */; };
@@ -427,6 +428,7 @@
 		6AFE04B669CA654D7733F97E /* AlasCLICommandRouter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1271747193D1594AEA596278 /* AlasCLICommandRouter.swift */; };
 		6B2B0731DBCD5D1BE353FFCB /* AlasGhostty.SurfaceView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02FCDD45C23BAE141549D03F /* AlasGhostty.SurfaceView.swift */; };
 		6B9E188A6C0A39C38D8723BF /* ReviewRequestDraftTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A1A152D4297DBB5B8DFF950 /* ReviewRequestDraftTests.swift */; };
+		6BA64E78F8AB2B8710665FC9 /* ReviewDraftModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = BFA871B5464E4F9D3350851B /* ReviewDraftModels.swift */; };
 		6BF6FE50DAC473322005A036 /* ProjectsManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F5B91F414F99741818BCB17 /* ProjectsManagerTests.swift */; };
 		6C33DC3A21C3223832EA5D28 /* ACPSessionLeaseTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F31E42DEC85081FEA8CA1BC3 /* ACPSessionLeaseTests.swift */; };
 		6C800C9827E75F9F07C67DB9 /* AppConfigTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B78A7E7888D552AFC80BA3AA /* AppConfigTests.swift */; };
@@ -499,6 +501,7 @@
 		7EC95A2AAEFE78B51D9F599A /* ACPPlanSidebarVisibility.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7322805CC904D460A8C53C8 /* ACPPlanSidebarVisibility.swift */; };
 		7FC2A96DE87638A594DD8B61 /* ProcessGitTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5210D5B1E2FD2EF68139506E /* ProcessGitTests.swift */; };
 		7FFC3D96011714F0A131FAB8 /* ACPFileChip.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA6C7434D216D5C43A2FB921 /* ACPFileChip.swift */; };
+		8011EDCDB9E13B454E58F45E /* ReviewDraftCommentStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = B10E5AB5D726C40331681709 /* ReviewDraftCommentStore.swift */; };
 		8035C82C1C3F79801A0F2F39 /* ImageDiffPairKind.swift in Sources */ = {isa = PBXBuildFile; fileRef = 38EAFDB135BDCF0DFF0121B1 /* ImageDiffPairKind.swift */; };
 		804D11E10C7478C00C0F5C40 /* DraftCommitTabStateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EB44F87B415733A4B2F2A990 /* DraftCommitTabStateTests.swift */; };
 		809972779548945B012F8B6C /* ACPConnectingPlaceholder.swift in Sources */ = {isa = PBXBuildFile; fileRef = DFBD2A49431277EB68106AAA /* ACPConnectingPlaceholder.swift */; };
@@ -818,6 +821,7 @@
 		CB27451157E1BF95BE47248A /* GitServiceStagingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6DF0AEE54BDB4FC4FD5E02F4 /* GitServiceStagingTests.swift */; };
 		CB549B27BB0E578776AA7ED0 /* WorktreeServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D36137279CD9028BB6FFED0B /* WorktreeServiceTests.swift */; };
 		CB6D9F5929D97FAB3A264F47 /* AppConfigAgentsCodingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A72E6086ED069AF65F890BBB /* AppConfigAgentsCodingTests.swift */; };
+		CBB3A06686A9CBFE699C08AF /* ReviewDraftCommentStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D36EA68CE127E24991ABD5A6 /* ReviewDraftCommentStoreTests.swift */; };
 		CC30504E2DC245FD23347E33 /* ACPPermissionPolicy.swift in Sources */ = {isa = PBXBuildFile; fileRef = B78414C2E79104BC6218B1F4 /* ACPPermissionPolicy.swift */; };
 		CC531074F02A34E48A1E6133 /* ACPAgentProfilesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A110966FCF7EA47C18BE71A /* ACPAgentProfilesTests.swift */; };
 		CC64E79B9CF4AF1B3CE31261 /* ACPMentionChipAttachment.swift in Sources */ = {isa = PBXBuildFile; fileRef = 329882D757C34246C9848C3A /* ACPMentionChipAttachment.swift */; };
@@ -1445,6 +1449,7 @@
 		66E8A2A1A02BD06F4B782D03 /* Highlighted.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Highlighted.swift; sourceTree = "<group>"; };
 		670C7B064EA079D045F0D0DE /* WorktreeWatcherFilterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorktreeWatcherFilterTests.swift; sourceTree = "<group>"; };
 		6713F5A8712C0962BED1EFEA /* RightPaneStateBaseBranchTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RightPaneStateBaseBranchTests.swift; sourceTree = "<group>"; };
+		67378DD93876E3840E367550 /* ReviewDraftModelsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReviewDraftModelsTests.swift; sourceTree = "<group>"; };
 		6791BB640C39115289BF6D07 /* ACPSetupNudgeBanner.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPSetupNudgeBanner.swift; sourceTree = "<group>"; };
 		679E62B501E0490F48CCA830 /* EditorFindBarView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditorFindBarView.swift; sourceTree = "<group>"; };
 		67E03BF5DB4E6BFF8C2FA6A2 /* ACPPermissionRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPPermissionRequest.swift; sourceTree = "<group>"; };
@@ -1704,6 +1709,7 @@
 		B0D2C54087C4501C3E7793FE /* ChatPane.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatPane.swift; sourceTree = "<group>"; };
 		B0F47561DB37D2ED72B6BE25 /* ReviewLoopDrawerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReviewLoopDrawerTests.swift; sourceTree = "<group>"; };
 		B0FBEABA73057C9F165A66CD /* ReviewEvidenceModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReviewEvidenceModelTests.swift; sourceTree = "<group>"; };
+		B10E5AB5D726C40331681709 /* ReviewDraftCommentStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReviewDraftCommentStore.swift; sourceTree = "<group>"; };
 		B133843C0559BBD6E769ABB8 /* ACPManagerAccessorsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPManagerAccessorsTests.swift; sourceTree = "<group>"; };
 		B15DFCD74150803355CC0A95 /* RightPaneSelectionState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RightPaneSelectionState.swift; sourceTree = "<group>"; };
 		B1615F1953C6FE9D1A30A1A2 /* ACPImageEncoding.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPImageEncoding.swift; sourceTree = "<group>"; };
@@ -1769,6 +1775,7 @@
 		BF3F87CE04B7E98606BF76CA /* CursorInstallerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CursorInstallerTests.swift; sourceTree = "<group>"; };
 		BF72CF0EA2F684D6ED3B43F5 /* ChatFontCatalogTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatFontCatalogTests.swift; sourceTree = "<group>"; };
 		BF7E57BC5EC8A465F26B3642 /* AlasCLIRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlasCLIRequest.swift; sourceTree = "<group>"; };
+		BFA871B5464E4F9D3350851B /* ReviewDraftModels.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReviewDraftModels.swift; sourceTree = "<group>"; };
 		BFD267BE3F08611B376F3CC7 /* EditorConflictBanner.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditorConflictBanner.swift; sourceTree = "<group>"; };
 		BFE0C069E5446132D39C4DE5 /* QueuedPrompt.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QueuedPrompt.swift; sourceTree = "<group>"; };
 		C02B44D8CC0AE48BFA9CD88E /* RemoteProtocolTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteProtocolTests.swift; sourceTree = "<group>"; };
@@ -1857,6 +1864,7 @@
 		D2AD81E0DFE33CE4DACF0ADF /* WorktreeWatcher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorktreeWatcher.swift; sourceTree = "<group>"; };
 		D2F90D03073708AA01531533 /* GitService+Staging.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "GitService+Staging.swift"; sourceTree = "<group>"; };
 		D36137279CD9028BB6FFED0B /* WorktreeServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorktreeServiceTests.swift; sourceTree = "<group>"; };
+		D36EA68CE127E24991ABD5A6 /* ReviewDraftCommentStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReviewDraftCommentStoreTests.swift; sourceTree = "<group>"; };
 		D3DC5DBEC068EB1BFDBB7F59 /* GitEventFilterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GitEventFilterTests.swift; sourceTree = "<group>"; };
 		D3EDEEB00185F9C717205540 /* ACPAutoRunToggle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPAutoRunToggle.swift; sourceTree = "<group>"; };
 		D46B68FD01B15E3EEA09CB79 /* ACPMessages.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPMessages.swift; sourceTree = "<group>"; };
@@ -2385,6 +2393,8 @@
 				CDAE8FBBADF986E1E6585941 /* ReviewChangesModelsTests.swift */,
 				F2C9F8BAEDB1D157E321A328 /* ReviewChangesScrollSpyTests.swift */,
 				FB9E78C70091168556C9669B /* ReviewChangesTabViewTests.swift */,
+				D36EA68CE127E24991ABD5A6 /* ReviewDraftCommentStoreTests.swift */,
+				67378DD93876E3840E367550 /* ReviewDraftModelsTests.swift */,
 				694DDEC8133EFBC33822BC26 /* ReviewLoopHandoffRoutingTests.swift */,
 				54635D583B6B308B75ABCE63 /* RightPaneSelectionStateResolverTests.swift */,
 				6713F5A8712C0962BED1EFEA /* RightPaneStateBaseBranchTests.swift */,
@@ -3003,6 +3013,7 @@
 				42C76CF381570A3B233F79D2 /* ReviewChanges */,
 				22F204D0F6846057D6505326 /* ReviewEvidence */,
 				4AF44827354C470592274005 /* ReviewRequest */,
+				D01AEADFFA32827C6CFC24CB /* ReviewWorkspace */,
 			);
 			path = Center;
 			sourceTree = "<group>";
@@ -3629,6 +3640,15 @@
 				5A1A152D4297DBB5B8DFF950 /* ReviewRequestDraftTests.swift */,
 			);
 			path = Integrations;
+			sourceTree = "<group>";
+		};
+		D01AEADFFA32827C6CFC24CB /* ReviewWorkspace */ = {
+			isa = PBXGroup;
+			children = (
+				B10E5AB5D726C40331681709 /* ReviewDraftCommentStore.swift */,
+				BFA871B5464E4F9D3350851B /* ReviewDraftModels.swift */,
+			);
+			path = ReviewWorkspace;
 			sourceTree = "<group>";
 		};
 		D693E9FFCCA3C968C18E4437 /* ThirdParty */ = {
@@ -4531,6 +4551,8 @@
 				F2385B8730E9D1F47C7FA423 /* ReviewChangesRail.swift in Sources */,
 				5269ED23D9732680EF7F4E16 /* ReviewChangesScrollSpy.swift in Sources */,
 				72EDB798775F24B86E8AD8DA /* ReviewChangesTabView.swift in Sources */,
+				8011EDCDB9E13B454E58F45E /* ReviewDraftCommentStore.swift in Sources */,
+				6BA64E78F8AB2B8710665FC9 /* ReviewDraftModels.swift in Sources */,
 				77CDD88F7C517095DE580B50 /* ReviewEvidence.swift in Sources */,
 				DF93C8550C7A78C2A03CF56A /* ReviewEvidenceModel.swift in Sources */,
 				8617CC447747E25550D93CFF /* ReviewEvidenceTabView.swift in Sources */,
@@ -4984,6 +5006,8 @@
 				13928612F39D3D86ED3313AC /* ReviewChangesModelsTests.swift in Sources */,
 				B13C57CF7090C966143A6840 /* ReviewChangesScrollSpyTests.swift in Sources */,
 				ACDE5C92423E9EFBE50CAEF2 /* ReviewChangesTabViewTests.swift in Sources */,
+				CBB3A06686A9CBFE699C08AF /* ReviewDraftCommentStoreTests.swift in Sources */,
+				1A6AF8939585038A3303B625 /* ReviewDraftModelsTests.swift in Sources */,
 				D1B12A9BA62CBB99E0DB1E28 /* ReviewEvidenceModelTests.swift in Sources */,
 				A05391FF4907AB0870A79C02 /* ReviewEvidenceTests.swift in Sources */,
 				9409E946054E7D837A479137 /* ReviewLoopDrawerTests.swift in Sources */,

--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -913,6 +913,7 @@
 		DF8CAD5714483408B8BD72F7 /* GitService+Discard.swift in Sources */ = {isa = PBXBuildFile; fileRef = 90817EC3BAA727EF6D9FBD97 /* GitService+Discard.swift */; };
 		DF93C8550C7A78C2A03CF56A /* ReviewEvidenceModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7FF257B37B6E9EA4D97C67D4 /* ReviewEvidenceModel.swift */; };
 		E0AA2F46C6E53C547FEB6495 /* ClaudeCodeACPInstallerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4B2FAABB50C8BE2321A1B1DD /* ClaudeCodeACPInstallerTests.swift */; };
+		E0F4EFE612252BDD7F999A70 /* ReviewFeedbackAgentSender.swift in Sources */ = {isa = PBXBuildFile; fileRef = 56E964C72322223859CC6AF8 /* ReviewFeedbackAgentSender.swift */; };
 		E175AE346DFAD0B62827C921 /* ProjectPicker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3CE948F94DB2759E66CD4DEF /* ProjectPicker.swift */; };
 		E1DA1C6BF9D5E157DAF6EE00 /* ClaudeInstallerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6016A3CF87F34222C533D350 /* ClaudeInstallerTests.swift */; };
 		E1E4C11CC5BFF761DF397507 /* ACPToolCallContentTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 54897710493742A6DFD6ABF3 /* ACPToolCallContentTests.swift */; };
@@ -1402,6 +1403,7 @@
 		56780EE994E2CA14A3ABBA7B /* MergeActionGutter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MergeActionGutter.swift; sourceTree = "<group>"; };
 		56BF141F589820AA91674BD0 /* TreeSitterJavaScript */ = {isa = PBXFileReference; lastKnownFileType = folder; name = TreeSitterJavaScript; path = ThirdParty/TreeSitterJavaScript; sourceTree = SOURCE_ROOT; };
 		56D1AC9E1E00C3C5C234382C /* TouchTargetSmokeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TouchTargetSmokeTests.swift; sourceTree = "<group>"; };
+		56E964C72322223859CC6AF8 /* ReviewFeedbackAgentSender.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReviewFeedbackAgentSender.swift; sourceTree = "<group>"; };
 		5733BF1C52BA0FCFB2724D57 /* ACPQueuedBubbleActionMetricsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPQueuedBubbleActionMetricsTests.swift; sourceTree = "<group>"; };
 		576619C2726DFDE8F627AE19 /* CommitsAheadTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommitsAheadTests.swift; sourceTree = "<group>"; };
 		57713D7143CFD53124E0523F /* AlasHookCommand.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlasHookCommand.swift; sourceTree = "<group>"; };
@@ -3661,6 +3663,7 @@
 				B10E5AB5D726C40331681709 /* ReviewDraftCommentStore.swift */,
 				BFA871B5464E4F9D3350851B /* ReviewDraftModels.swift */,
 				C432B6C03738D6ACB4293471 /* ReviewDraftSummaryRail.swift */,
+				56E964C72322223859CC6AF8 /* ReviewFeedbackAgentSender.swift */,
 				B0886F9B3096AC1264E3D337 /* ReviewFeedbackBundle.swift */,
 			);
 			path = ReviewWorkspace;
@@ -4574,6 +4577,7 @@
 				77CDD88F7C517095DE580B50 /* ReviewEvidence.swift in Sources */,
 				DF93C8550C7A78C2A03CF56A /* ReviewEvidenceModel.swift in Sources */,
 				8617CC447747E25550D93CFF /* ReviewEvidenceTabView.swift in Sources */,
+				E0F4EFE612252BDD7F999A70 /* ReviewFeedbackAgentSender.swift in Sources */,
 				D27A85DE79B3B62C6F91174A /* ReviewFeedbackBundle.swift in Sources */,
 				DB29057E7147A0774BC2B835 /* ReviewLoopDrawer.swift in Sources */,
 				877BEC66CEBB5C495536FA20 /* ReviewLoopHandoffBuilder.swift in Sources */,

--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -642,6 +642,7 @@
 		A05391FF4907AB0870A79C02 /* ReviewEvidenceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4B05E0E44B026AE7E8EA3101 /* ReviewEvidenceTests.swift */; };
 		A0B5074B10E732616C917D10 /* DragHandleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1379AD82025AFEABD37EFC42 /* DragHandleTests.swift */; };
 		A0F1E46BC1A9E2CC21805EE7 /* FilesTabFilterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1977C85C3DFD1F232A2755AD /* FilesTabFilterTests.swift */; };
+		A1252F6D967104D2B369CEA8 /* ReviewFeedbackBundleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C84E444E25F7DDBE30FB824 /* ReviewFeedbackBundleTests.swift */; };
 		A139CD869FCFF8F4CFB7E50D /* ACPSyntaxHighlightedText.swift in Sources */ = {isa = PBXBuildFile; fileRef = C72B05E51A4C6FAE18666DBC /* ACPSyntaxHighlightedText.swift */; };
 		A15C8E0D7A942160A74BD68E /* ImageDiffPairResolver.swift in Sources */ = {isa = PBXBuildFile; fileRef = D568D53950A3CA2CD1F4EECB /* ImageDiffPairResolver.swift */; };
 		A19649A790595DF4F48C3824 /* TerminalService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1AFC62A30044F71F0F16C3FB /* TerminalService.swift */; };
@@ -849,12 +850,14 @@
 		D0F4A4F5BF5F1C3C625F11D9 /* Clipboard.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0E6600436B01C75D85C01FFA /* Clipboard.swift */; };
 		D10A8F47A537C1C8969752B1 /* ACPMessageTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8A0A083659269CDD16A6764 /* ACPMessageTests.swift */; };
 		D13AFC98364971915782491C /* ProjectConfigTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B3FF64CC698074BFDE2A36A /* ProjectConfigTests.swift */; };
+		D1826BD546F4C8D2755D8F56 /* ReviewDraftCommentActions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2EC0311F5824C51F14EC4278 /* ReviewDraftCommentActions.swift */; };
 		D1B12A9BA62CBB99E0DB1E28 /* ReviewEvidenceModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0FBEABA73057C9F165A66CD /* ReviewEvidenceModelTests.swift */; };
 		D1C14B54BE27D97E354F448B /* ProcessGitDataTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF741B889D6DC8B1F4EB350F /* ProcessGitDataTests.swift */; };
 		D1F372532A0F9607051020F5 /* HarnessDetectorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F198697EB5305E5ECE97BC61 /* HarnessDetectorTests.swift */; };
 		D1FF11465D1309A56FCFFAF0 /* AppConfigCodeInstallTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8ACFACD788DF2035534F62E /* AppConfigCodeInstallTests.swift */; };
 		D204CCA2E2FE480D2C502186 /* ACPSessionManagerHydrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 472917238C382A8125A84103 /* ACPSessionManagerHydrationTests.swift */; };
 		D27A1F6D7592D6A4BDD9FC4F /* GitIgnoreServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6EB58175A9A39073E9D73F85 /* GitIgnoreServiceTests.swift */; };
+		D27A85DE79B3B62C6F91174A /* ReviewFeedbackBundle.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0886F9B3096AC1264E3D337 /* ReviewFeedbackBundle.swift */; };
 		D28EE6309DBB51EFEDCEAC18 /* ACPSessionManagerLeaseTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 96C13707B79B7A4F4BB2608E /* ACPSessionManagerLeaseTests.swift */; };
 		D2B345D1AEB1D5CEF48354C3 /* HoverHighlightFeatureTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 100091C8ABC3F3FA66C744E9 /* HoverHighlightFeatureTests.swift */; };
 		D2D5D79EE8DE82FC44C2D36A /* CompletionFeature.swift in Sources */ = {isa = PBXBuildFile; fileRef = D510DACCD80A328B2DFABDC0 /* CompletionFeature.swift */; };
@@ -1210,6 +1213,7 @@
 		2BFCE07604D55558B13FC33B /* DiffOpenFileAvailabilityTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiffOpenFileAvailabilityTests.swift; sourceTree = "<group>"; };
 		2BFD4C762D8323B78934ECE7 /* BranchPicker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BranchPicker.swift; sourceTree = "<group>"; };
 		2C2381497E73D74C8C314928 /* AgentRegistryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentRegistryTests.swift; sourceTree = "<group>"; };
+		2C84E444E25F7DDBE30FB824 /* ReviewFeedbackBundleTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReviewFeedbackBundleTests.swift; sourceTree = "<group>"; };
 		2CBAD18141C1A9B654F56982 /* FileTypeIconTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileTypeIconTests.swift; sourceTree = "<group>"; };
 		2CDC00065CA8839DA1AD0E0F /* TrafficLights.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TrafficLights.swift; sourceTree = "<group>"; };
 		2CDDDC4C6146165CA4C7474E /* ACPPlanPillState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPPlanPillState.swift; sourceTree = "<group>"; };
@@ -1220,6 +1224,7 @@
 		2E669FEBE09BC250B477B335 /* ACPLaunchCatalog.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPLaunchCatalog.swift; sourceTree = "<group>"; };
 		2E7E61C3BD4AD4AE3828A6F0 /* InstallSource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InstallSource.swift; sourceTree = "<group>"; };
 		2EB39DE3614B5BEC4D3EBF13 /* ACPSessionLifecycleTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPSessionLifecycleTests.swift; sourceTree = "<group>"; };
+		2EC0311F5824C51F14EC4278 /* ReviewDraftCommentActions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReviewDraftCommentActions.swift; sourceTree = "<group>"; };
 		2EF18448EDA0DCC8B171F11D /* CommitDiffView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommitDiffView.swift; sourceTree = "<group>"; };
 		2F1CBD7C9E0119EC1656C1E2 /* GeminiInstallerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GeminiInstallerTests.swift; sourceTree = "<group>"; };
 		2F5959FF98A5105FF7B17894 /* WorkingTreeChangeGroupTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkingTreeChangeGroupTests.swift; sourceTree = "<group>"; };
@@ -1705,6 +1710,7 @@
 		AE0A6F237480EE72CB8DBE28 /* TitlelessWindowTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TitlelessWindowTests.swift; sourceTree = "<group>"; };
 		AE35206EEBD7E3A35C3421EA /* ACPRecoveryPill.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPRecoveryPill.swift; sourceTree = "<group>"; };
 		AF2F716F911BB20B3E78C40B /* AgentDefinition.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentDefinition.swift; sourceTree = "<group>"; };
+		B0886F9B3096AC1264E3D337 /* ReviewFeedbackBundle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReviewFeedbackBundle.swift; sourceTree = "<group>"; };
 		B0D0ED01C390D1F729993B13 /* MarkdownImageLoaderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MarkdownImageLoaderTests.swift; sourceTree = "<group>"; };
 		B0D2C54087C4501C3E7793FE /* ChatPane.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatPane.swift; sourceTree = "<group>"; };
 		B0F47561DB37D2ED72B6BE25 /* ReviewLoopDrawerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReviewLoopDrawerTests.swift; sourceTree = "<group>"; };
@@ -2395,6 +2401,7 @@
 				FB9E78C70091168556C9669B /* ReviewChangesTabViewTests.swift */,
 				D36EA68CE127E24991ABD5A6 /* ReviewDraftCommentStoreTests.swift */,
 				67378DD93876E3840E367550 /* ReviewDraftModelsTests.swift */,
+				2C84E444E25F7DDBE30FB824 /* ReviewFeedbackBundleTests.swift */,
 				694DDEC8133EFBC33822BC26 /* ReviewLoopHandoffRoutingTests.swift */,
 				54635D583B6B308B75ABCE63 /* RightPaneSelectionStateResolverTests.swift */,
 				6713F5A8712C0962BED1EFEA /* RightPaneStateBaseBranchTests.swift */,
@@ -3645,8 +3652,10 @@
 		D01AEADFFA32827C6CFC24CB /* ReviewWorkspace */ = {
 			isa = PBXGroup;
 			children = (
+				2EC0311F5824C51F14EC4278 /* ReviewDraftCommentActions.swift */,
 				B10E5AB5D726C40331681709 /* ReviewDraftCommentStore.swift */,
 				BFA871B5464E4F9D3350851B /* ReviewDraftModels.swift */,
+				B0886F9B3096AC1264E3D337 /* ReviewFeedbackBundle.swift */,
 			);
 			path = ReviewWorkspace;
 			sourceTree = "<group>";
@@ -4551,11 +4560,13 @@
 				F2385B8730E9D1F47C7FA423 /* ReviewChangesRail.swift in Sources */,
 				5269ED23D9732680EF7F4E16 /* ReviewChangesScrollSpy.swift in Sources */,
 				72EDB798775F24B86E8AD8DA /* ReviewChangesTabView.swift in Sources */,
+				D1826BD546F4C8D2755D8F56 /* ReviewDraftCommentActions.swift in Sources */,
 				8011EDCDB9E13B454E58F45E /* ReviewDraftCommentStore.swift in Sources */,
 				6BA64E78F8AB2B8710665FC9 /* ReviewDraftModels.swift in Sources */,
 				77CDD88F7C517095DE580B50 /* ReviewEvidence.swift in Sources */,
 				DF93C8550C7A78C2A03CF56A /* ReviewEvidenceModel.swift in Sources */,
 				8617CC447747E25550D93CFF /* ReviewEvidenceTabView.swift in Sources */,
+				D27A85DE79B3B62C6F91174A /* ReviewFeedbackBundle.swift in Sources */,
 				DB29057E7147A0774BC2B835 /* ReviewLoopDrawer.swift in Sources */,
 				877BEC66CEBB5C495536FA20 /* ReviewLoopHandoffBuilder.swift in Sources */,
 				F5626F154B2CF446FF3F917B /* ReviewLoopState.swift in Sources */,
@@ -5010,6 +5021,7 @@
 				1A6AF8939585038A3303B625 /* ReviewDraftModelsTests.swift in Sources */,
 				D1B12A9BA62CBB99E0DB1E28 /* ReviewEvidenceModelTests.swift in Sources */,
 				A05391FF4907AB0870A79C02 /* ReviewEvidenceTests.swift in Sources */,
+				A1252F6D967104D2B369CEA8 /* ReviewFeedbackBundleTests.swift in Sources */,
 				9409E946054E7D837A479137 /* ReviewLoopDrawerTests.swift in Sources */,
 				096304FB0EA9B5EC04D76C49 /* ReviewLoopHandoffBuilderTests.swift in Sources */,
 				B82F5295F500E46C381A8D52 /* ReviewLoopHandoffRoutingTests.swift in Sources */,

--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -890,6 +890,7 @@
 		D8E808EF960CA0C10E59D44C /* SemanticVersion.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8E8EB674A5221235F1C7594E /* SemanticVersion.swift */; };
 		D95A7FAF0B955642ED9D7521 /* ACPAuthFailureTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 380D04E9EB0D0ED0C24702DA /* ACPAuthFailureTests.swift */; };
 		D9C26E07021DC6938013FBBE /* RemoteServerError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3000211002A1A433AC8DBB3B /* RemoteServerError.swift */; };
+		D9FD24854A41DF2E9214E078 /* ReviewDraftCommentController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 58BC051640BBB02A2EBF6E4F /* ReviewDraftCommentController.swift */; };
 		DA5ED6D708DD8C0B5563AB4F /* WindowDragHandle.swift in Sources */ = {isa = PBXBuildFile; fileRef = 32D6E47CC4523FDE263C764C /* WindowDragHandle.swift */; };
 		DAA6F5DABE3214693628C730 /* ACPFilesystem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 435D9E527A76820947F426A8 /* ACPFilesystem.swift */; };
 		DABD0B9B7817F4A080512501 /* FilesTabLoadingIndicatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C8541BE5617C7E212CCD034 /* FilesTabLoadingIndicatorTests.swift */; };
@@ -908,6 +909,7 @@
 		DEBA25FCF25D26395BD04F73 /* EditorConflictBanner.swift in Sources */ = {isa = PBXBuildFile; fileRef = BFD267BE3F08611B376F3CC7 /* EditorConflictBanner.swift */; };
 		DEBB0627BD0426369D18CAD4 /* FileSearchDialog.swift in Sources */ = {isa = PBXBuildFile; fileRef = F97EB3FA3E3C1206D76A9668 /* FileSearchDialog.swift */; };
 		DEC1744FA9C8A26294FF0671 /* CompletionEngineTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E0CD4F3AC6DD83BC45459475 /* CompletionEngineTests.swift */; };
+		DF2960A73C07F97DA0A615D4 /* ReviewDraftSummaryRail.swift in Sources */ = {isa = PBXBuildFile; fileRef = C432B6C03738D6ACB4293471 /* ReviewDraftSummaryRail.swift */; };
 		DF8CAD5714483408B8BD72F7 /* GitService+Discard.swift in Sources */ = {isa = PBXBuildFile; fileRef = 90817EC3BAA727EF6D9FBD97 /* GitService+Discard.swift */; };
 		DF93C8550C7A78C2A03CF56A /* ReviewEvidenceModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7FF257B37B6E9EA4D97C67D4 /* ReviewEvidenceModel.swift */; };
 		E0AA2F46C6E53C547FEB6495 /* ClaudeCodeACPInstallerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4B2FAABB50C8BE2321A1B1DD /* ClaudeCodeACPInstallerTests.swift */; };
@@ -1406,6 +1408,7 @@
 		57B7225443DF69C32D25338D /* SpacesPane.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpacesPane.swift; sourceTree = "<group>"; };
 		57DEA304B6038D986A372150 /* BundledFontRegistrar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BundledFontRegistrar.swift; sourceTree = "<group>"; };
 		58B78EE378B0A076C904E2E4 /* TreeSitterLua */ = {isa = PBXFileReference; lastKnownFileType = folder; name = TreeSitterLua; path = ThirdParty/TreeSitterLua; sourceTree = SOURCE_ROOT; };
+		58BC051640BBB02A2EBF6E4F /* ReviewDraftCommentController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReviewDraftCommentController.swift; sourceTree = "<group>"; };
 		59DBB72EE97F0E906442919B /* CommitTabView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommitTabView.swift; sourceTree = "<group>"; };
 		5A1A152D4297DBB5B8DFF950 /* ReviewRequestDraftTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReviewRequestDraftTests.swift; sourceTree = "<group>"; };
 		5A2EFB5253073D6A4A328FE0 /* RemoteConnection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteConnection.swift; sourceTree = "<group>"; };
@@ -1797,6 +1800,7 @@
 		C371360F83FE318A5B8AEDBF /* GitLabCLIProviderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GitLabCLIProviderTests.swift; sourceTree = "<group>"; };
 		C3B53E3E92FA696866F44FDD /* ACPLaunchSpecTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPLaunchSpecTests.swift; sourceTree = "<group>"; };
 		C3BC736DAAD590624B840923 /* ACPSystemNoticeView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPSystemNoticeView.swift; sourceTree = "<group>"; };
+		C432B6C03738D6ACB4293471 /* ReviewDraftSummaryRail.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReviewDraftSummaryRail.swift; sourceTree = "<group>"; };
 		C47AF847BD698EAB373D128B /* ZmxClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ZmxClient.swift; sourceTree = "<group>"; };
 		C48DB0098D71F26ABF594615 /* permission-request.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "permission-request.json"; sourceTree = "<group>"; };
 		C496549308D5C3DD20E988AD /* ACPComposer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPComposer.swift; sourceTree = "<group>"; };
@@ -3653,8 +3657,10 @@
 			isa = PBXGroup;
 			children = (
 				2EC0311F5824C51F14EC4278 /* ReviewDraftCommentActions.swift */,
+				58BC051640BBB02A2EBF6E4F /* ReviewDraftCommentController.swift */,
 				B10E5AB5D726C40331681709 /* ReviewDraftCommentStore.swift */,
 				BFA871B5464E4F9D3350851B /* ReviewDraftModels.swift */,
+				C432B6C03738D6ACB4293471 /* ReviewDraftSummaryRail.swift */,
 				B0886F9B3096AC1264E3D337 /* ReviewFeedbackBundle.swift */,
 			);
 			path = ReviewWorkspace;
@@ -4561,8 +4567,10 @@
 				5269ED23D9732680EF7F4E16 /* ReviewChangesScrollSpy.swift in Sources */,
 				72EDB798775F24B86E8AD8DA /* ReviewChangesTabView.swift in Sources */,
 				D1826BD546F4C8D2755D8F56 /* ReviewDraftCommentActions.swift in Sources */,
+				D9FD24854A41DF2E9214E078 /* ReviewDraftCommentController.swift in Sources */,
 				8011EDCDB9E13B454E58F45E /* ReviewDraftCommentStore.swift in Sources */,
 				6BA64E78F8AB2B8710665FC9 /* ReviewDraftModels.swift in Sources */,
+				DF2960A73C07F97DA0A615D4 /* ReviewDraftSummaryRail.swift in Sources */,
 				77CDD88F7C517095DE580B50 /* ReviewEvidence.swift in Sources */,
 				DF93C8550C7A78C2A03CF56A /* ReviewEvidenceModel.swift in Sources */,
 				8617CC447747E25550D93CFF /* ReviewEvidenceTabView.swift in Sources */,

--- a/Alas/Sources/Center/Commit/CommitTabView.swift
+++ b/Alas/Sources/Center/Commit/CommitTabView.swift
@@ -102,6 +102,11 @@ struct CommitTabView: View {
                     codeFontSize: CGFloat(appState.config.code.fontSize),
                     worktreeId: worktreeId,
                     worktreePath: worktreePath,
+                    reviewDraftSessionID: CommitReviewBody.reviewDraftSessionID(
+                        worktreeID: worktreeId,
+                        repositoryPath: worktreePath,
+                        sha: sha
+                    ),
                     appState: appState
                 )
             } else {
@@ -268,7 +273,15 @@ struct CommitReviewBody: View {
     let codeFontSize: CGFloat
     var worktreeId: String? = nil
     var worktreePath: URL? = nil
+    var reviewDraftSessionID: ReviewDraftSessionID? = nil
     var appState: AppState? = nil
+
+    @State private var reviewSummaryCollapsed = false
+    @State private var draftCommentController: ReviewDraftCommentController?
+    @State private var loadedDraftSessionID: ReviewDraftSessionID?
+    @State private var focusedDraftCommentID: String?
+    @State private var draftCommentScrollCommand: DiffReviewDraftCommentScrollCommand?
+    @State private var draftCommentScrollController = DiffReviewDraftCommentScrollController()
 
     init(
         session: DiffReviewLoadedSession,
@@ -281,6 +294,7 @@ struct CommitReviewBody: View {
         codeFontSize: CGFloat,
         worktreeId: String? = nil,
         worktreePath: URL? = nil,
+        reviewDraftSessionID: ReviewDraftSessionID? = nil,
         appState: AppState? = nil
     ) {
         self.session = session
@@ -293,7 +307,20 @@ struct CommitReviewBody: View {
         self.codeFontSize = codeFontSize
         self.worktreeId = worktreeId
         self.worktreePath = worktreePath
+        self.reviewDraftSessionID = reviewDraftSessionID
         self.appState = appState
+    }
+
+    static func reviewDraftSessionID(
+        worktreeID: String,
+        repositoryPath: URL,
+        sha: String
+    ) -> ReviewDraftSessionID {
+        ReviewDraftSessionID.commit(
+            worktreeID: worktreeID,
+            repositoryPath: repositoryPath,
+            sha: sha
+        )
     }
 
     var body: some View {
@@ -301,6 +328,7 @@ struct CommitReviewBody: View {
             session: session,
             selectedFileID: $selectedFileID,
             railCollapsed: $railCollapsed,
+            reviewSummaryCollapsed: $reviewSummaryCollapsed,
             layoutMode: $layoutMode,
             wrapLines: $wrapLines,
             showWhitespace: $showWhitespace,
@@ -308,8 +336,18 @@ struct CommitReviewBody: View {
             codeFontSize: codeFontSize,
             showsSourceBadges: false,
             showsRailDisplayControls: true,
+            showsDraftSummaryRail: reviewDraftSessionID != nil,
             lspContextForFile: { file in
                 makeLSPContext(relativePath: file.summary.path)
+            },
+            reviewFeedbackTarget: reviewFeedbackTarget,
+            draftCommentsByFileID: ReviewDraftCommentGrouping.commentsByFileID(draftCommentController?.comments ?? []),
+            focusedDraftCommentID: focusedDraftCommentID,
+            draftCommentScrollCommand: draftCommentScrollCommand,
+            draftCommentActions: draftCommentActions(),
+            onSelectDraftComment: selectDraftComment,
+            onSaveDraftComment: { fileID, anchor, body in
+                saveDraftComment(fileID: fileID, anchor: anchor, body: body)
             }
         )
         .accessibilityIdentifier("commit-review-body")
@@ -318,6 +356,22 @@ struct CommitReviewBody: View {
                 identifier: "commit-review-body",
                 label: "Commit review"
             )
+        )
+        .onAppear {
+            loadDraftCommentController()
+        }
+        .onChange(of: reviewDraftSessionID?.rawValue) { _, _ in
+            loadDraftCommentController()
+        }
+    }
+
+    private var reviewFeedbackTarget: ReviewFeedbackTarget? {
+        guard let worktreePath else { return nil }
+        return ReviewFeedbackTarget(
+            title: "Commit Review",
+            repositoryPath: worktreePath.path,
+            providerDescription: nil,
+            sourceDescription: "Commit"
         )
     }
 
@@ -379,6 +433,53 @@ struct CommitReviewBody: View {
                 originatingWorktreeRoot: worktreePath,
                 language: language
             )
+        }
+    }
+
+    private var reviewFeedbackAgentSender: ReviewFeedbackAgentSender? {
+        guard let appState, let worktreeId else { return nil }
+        return ReviewFeedbackAgentSender.production(appState: appState, worktreeID: worktreeId)
+    }
+
+    private func loadDraftCommentController() {
+        guard let sessionID = reviewDraftSessionID else { return }
+        if loadedDraftSessionID != sessionID {
+            draftCommentController = ReviewDraftCommentController(sessionID: sessionID)
+            loadedDraftSessionID = sessionID
+            focusedDraftCommentID = nil
+            draftCommentScrollCommand = nil
+        }
+        do {
+            try draftCommentController?.load()
+        } catch {
+            // The controller keeps the non-blocking error state for the review rail.
+        }
+    }
+
+    private func draftCommentActions() -> ReviewDraftCommentActions {
+        guard let reviewFeedbackAgentSender else {
+            return ReviewDraftCommentActions()
+        }
+        return ReviewDraftWorkspaceActions.make(
+            controller: draftCommentController,
+            sender: reviewFeedbackAgentSender
+        )
+    }
+
+    private func selectDraftComment(_ comment: ReviewDraftComment) {
+        focusedDraftCommentID = comment.id
+        selectedFileID = comment.fileID
+        draftCommentScrollCommand = draftCommentScrollController.command(
+            commentID: comment.id,
+            fileID: comment.fileID
+        )
+    }
+
+    private func saveDraftComment(fileID: DiffReviewFileID, anchor: DiffReviewLineAnchor, body: String) {
+        do {
+            try draftCommentController?.add(anchor: anchor, fileID: fileID, bodyMarkdown: body)
+        } catch {
+            // The controller keeps the non-blocking error state for the review rail.
         }
     }
 }

--- a/Alas/Sources/Center/Commit/CommitTabView.swift
+++ b/Alas/Sources/Center/Commit/CommitTabView.swift
@@ -107,6 +107,7 @@ struct CommitTabView: View {
                         repositoryPath: worktreePath,
                         sha: sha
                     ),
+                    reviewedCommitSHA: sha,
                     appState: appState
                 )
             } else {
@@ -274,6 +275,7 @@ struct CommitReviewBody: View {
     var worktreeId: String? = nil
     var worktreePath: URL? = nil
     var reviewDraftSessionID: ReviewDraftSessionID? = nil
+    var reviewedCommitSHA: String? = nil
     var appState: AppState? = nil
 
     @State private var reviewSummaryCollapsed = false
@@ -295,6 +297,7 @@ struct CommitReviewBody: View {
         worktreeId: String? = nil,
         worktreePath: URL? = nil,
         reviewDraftSessionID: ReviewDraftSessionID? = nil,
+        reviewedCommitSHA: String? = nil,
         appState: AppState? = nil
     ) {
         self.session = session
@@ -308,6 +311,7 @@ struct CommitReviewBody: View {
         self.worktreeId = worktreeId
         self.worktreePath = worktreePath
         self.reviewDraftSessionID = reviewDraftSessionID
+        self.reviewedCommitSHA = reviewedCommitSHA
         self.appState = appState
     }
 
@@ -320,6 +324,18 @@ struct CommitReviewBody: View {
             worktreeID: worktreeID,
             repositoryPath: repositoryPath,
             sha: sha
+        )
+    }
+
+    static func reviewFeedbackTarget(repositoryPath: URL, sha: String?) -> ReviewFeedbackTarget {
+        let trimmedSHA = sha?.trimmingCharacters(in: .whitespacesAndNewlines)
+        let commitDescription = trimmedSHA.flatMap { $0.isEmpty ? nil : $0 }
+        let shortSHA = commitDescription.map { String($0.prefix(10)) }
+        return ReviewFeedbackTarget(
+            title: shortSHA.map { "Commit Review \($0)" } ?? "Commit Review",
+            repositoryPath: repositoryPath.path,
+            providerDescription: nil,
+            sourceDescription: commitDescription.map { "Commit \($0)" } ?? "Commit"
         )
     }
 
@@ -367,12 +383,7 @@ struct CommitReviewBody: View {
 
     private var reviewFeedbackTarget: ReviewFeedbackTarget? {
         guard let worktreePath else { return nil }
-        return ReviewFeedbackTarget(
-            title: "Commit Review",
-            repositoryPath: worktreePath.path,
-            providerDescription: nil,
-            sourceDescription: "Commit"
-        )
+        return Self.reviewFeedbackTarget(repositoryPath: worktreePath, sha: reviewedCommitSHA)
     }
 
     private func makeLSPContext(relativePath: String) -> DiffPaneLSPContext? {

--- a/Alas/Sources/Center/Diff/DiffPaneTextDocumentBuilder.swift
+++ b/Alas/Sources/Center/Diff/DiffPaneTextDocumentBuilder.swift
@@ -75,7 +75,7 @@ struct DiffPaneTextDocumentBuilder {
                 ),
                 kind: row.kind,
                 tone: tone(for: row.old, rowKind: row.kind),
-                sourceLine: row.old
+                sourceLine: reviewSourceLine(row.old, side: .old)
             )
             newColumn.append(
                 code(
@@ -88,7 +88,7 @@ struct DiffPaneTextDocumentBuilder {
                 ),
                 kind: row.kind,
                 tone: tone(for: row.new, rowKind: row.kind),
-                sourceLine: row.new
+                sourceLine: reviewSourceLine(row.new, side: .new)
             )
         }
 
@@ -425,6 +425,29 @@ struct DiffPaneTextDocumentBuilder {
             return ""
         }
         return line.lineNumber.map(String.init) ?? ""
+    }
+
+    private static func reviewSourceLine(_ line: DiffDisplayLine?, side: DiffLineSide) -> DiffDisplayLine? {
+        guard let line else { return nil }
+        guard line.anchor.side != side else { return line }
+
+        let anchor = DiffLineAnchor(
+            filePath: line.anchor.filePath,
+            hunkIndex: line.anchor.hunkIndex,
+            rowIndex: line.anchor.rowIndex,
+            side: side,
+            oldLine: side == .old ? line.anchor.oldLine : nil,
+            newLine: side == .new ? line.anchor.newLine : nil
+        )
+        return DiffDisplayLine(
+            id: "\(anchor.filePath):\(anchor.side.rawValue):\(anchor.oldLine ?? 0):\(anchor.newLine ?? 0)",
+            anchor: anchor,
+            text: line.text,
+            lineNumber: line.lineNumber,
+            kind: line.kind,
+            inlineSpans: line.inlineSpans,
+            noTrailingNewline: line.noTrailingNewline
+        )
     }
 
     private static func tone(for line: DiffDisplayLine?, rowKind: DiffDisplayRow.Kind) -> DiffPaneLineTone {

--- a/Alas/Sources/Center/Diff/DiffPaneTextDocumentView.swift
+++ b/Alas/Sources/Center/Diff/DiffPaneTextDocumentView.swift
@@ -1,6 +1,14 @@
 import AppKit
 import SwiftUI
 
+struct DiffReviewLineAnchor: Equatable, Hashable, Sendable {
+    let path: String
+    let side: DiffReviewInlineFeedbackSide
+    let line: Int
+    let rowIndex: Int
+    let selectedText: String
+}
+
 struct DiffPaneTextDocumentView: NSViewRepresentable {
     let group: DiffDisplayGroup
     let expandedCollapsedRowIDs: Set<String>
@@ -12,6 +20,33 @@ struct DiffPaneTextDocumentView: NSViewRepresentable {
     let codeFontSize: CGFloat
     let theme: Theme
     let lspContext: DiffPaneLSPContext?
+    var onReviewLineSelected: (DiffReviewLineAnchor) -> Void = { _ in }
+
+    init(
+        group: DiffDisplayGroup,
+        expandedCollapsedRowIDs: Set<String>,
+        layoutMode: DiffLayoutMode,
+        wrapLines: Bool,
+        showWhitespace: Bool,
+        fileExtension: String,
+        codeFontFamily: String,
+        codeFontSize: CGFloat,
+        theme: Theme,
+        lspContext: DiffPaneLSPContext?,
+        onReviewLineSelected: @escaping (DiffReviewLineAnchor) -> Void = { _ in }
+    ) {
+        self.group = group
+        self.expandedCollapsedRowIDs = expandedCollapsedRowIDs
+        self.layoutMode = layoutMode
+        self.wrapLines = wrapLines
+        self.showWhitespace = showWhitespace
+        self.fileExtension = fileExtension
+        self.codeFontFamily = codeFontFamily
+        self.codeFontSize = codeFontSize
+        self.theme = theme
+        self.lspContext = lspContext
+        self.onReviewLineSelected = onReviewLineSelected
+    }
 
     func makeNSView(context: Context) -> DiffPaneTextDocumentContainerView {
         DiffPaneTextDocumentContainerView()
@@ -27,7 +62,8 @@ struct DiffPaneTextDocumentView: NSViewRepresentable {
             fileExtension: fileExtension,
             font: CenterTypography.resolveCodeFont(family: codeFontFamily, size: codeFontSize),
             theme: theme,
-            lspContext: lspContext
+            lspContext: lspContext,
+            onReviewLineSelected: onReviewLineSelected
         )
     }
 }
@@ -72,8 +108,13 @@ final class DiffPaneTextDocumentContainerView: NSView {
         fileExtension: String,
         font: NSFont,
         theme: Theme,
-        lspContext: DiffPaneLSPContext?
+        lspContext: DiffPaneLSPContext?,
+        onReviewLineSelected: @escaping (DiffReviewLineAnchor) -> Void = { _ in }
     ) {
+        oldPane.onReviewLineSelected = onReviewLineSelected
+        newPane.onReviewLineSelected = onReviewLineSelected
+        stackedPane.onReviewLineSelected = onReviewLineSelected
+
         let signature = UpdateSignature(
             group: group,
             expandedCollapsedRowIDs: expandedCollapsedRowIDs,
@@ -258,6 +299,7 @@ final class DiffPaneTextScrollView: NSScrollView {
     private var wraps = false
     private var font: NSFont = .monospacedSystemFont(ofSize: 13, weight: .regular)
     private var theme: Theme?
+    var onReviewLineSelected: (DiffReviewLineAnchor) -> Void = { _ in }
 
     var documentHeight: CGFloat {
         if let lastRow = textView.diffRowRects().last {
@@ -292,7 +334,11 @@ final class DiffPaneTextScrollView: NSScrollView {
         documentView = textView
         hasVerticalRuler = true
         rulersVisible = true
-        verticalRulerView = DiffPaneLineNumberRulerView(scrollView: self)
+        let ruler = DiffPaneLineNumberRulerView(scrollView: self)
+        ruler.onReviewLineSelected = { [weak self] anchor in
+            self?.onReviewLineSelected(anchor)
+        }
+        verticalRulerView = ruler
 
         textView.isEditable = false
         textView.isSelectable = true
@@ -761,6 +807,17 @@ final class DiffPaneCodeTextView: NSTextView {
         lspController?.update(context: lspContext, allowedSide: allowedLSPSide)
     }
 
+    func reviewLineAnchor(atRow row: Int) -> DiffReviewLineAnchor? {
+        guard lineMetadata.indices.contains(row) else { return nil }
+        return lineMetadata[row].reviewLineAnchor(rowIndex: row)
+    }
+
+    func reviewLineAnchor(at point: NSPoint) -> DiffReviewLineAnchor? {
+        let rowRects = diffRowRects()
+        guard let row = rowRects.firstIndex(where: { $0.contains(point) }) else { return nil }
+        return reviewLineAnchor(atRow: row)
+    }
+
     private func drawLineBackgrounds(in dirtyRect: NSRect) {
         guard let theme else { return }
         let rowRects = diffRowRects()
@@ -886,6 +943,7 @@ final class DiffPaneLineNumberRulerView: NSRulerView {
     private var lineTones: [DiffPaneLineTone] = []
     private var theme: Theme?
     var rowHeight: CGFloat = 16
+    var onReviewLineSelected: (DiffReviewLineAnchor) -> Void = { _ in }
     private var contentTopInset: CGFloat = 6
     private var boundsObserver: NSObjectProtocol?
 
@@ -920,6 +978,26 @@ final class DiffPaneLineNumberRulerView: NSRulerView {
         self.theme = theme
         updateThickness()
         needsDisplay = true
+    }
+
+    override func mouseDown(with event: NSEvent) {
+        guard let scrollView,
+              let textView = scrollView.documentView as? DiffPaneCodeTextView
+        else {
+            super.mouseDown(with: event)
+            return
+        }
+
+        let point = convert(event.locationInWindow, from: nil)
+        let sourcePoint = NSPoint(
+            x: point.x,
+            y: point.y + scrollView.contentView.bounds.origin.y
+        )
+        guard let anchor = textView.reviewLineAnchor(at: sourcePoint) else {
+            super.mouseDown(with: event)
+            return
+        }
+        onReviewLineSelected(anchor)
     }
 
     override func drawHashMarksAndLabels(in rect: NSRect) {
@@ -1126,5 +1204,33 @@ final class DiffPaneLeadingClipView: NSClipView {
         let maxX = max(documentView.frame.width - bounds.width, 0)
         bounds.origin.x = min(max(bounds.origin.x, 0), maxX)
         return bounds
+    }
+}
+
+private extension DiffPaneTextDocumentBuilder.LineMetadata {
+    func reviewLineAnchor(rowIndex: Int) -> DiffReviewLineAnchor? {
+        guard let sourceLine,
+              let lineNumber = sourceLine.lineNumber
+        else {
+            return nil
+        }
+
+        let side: DiffReviewInlineFeedbackSide
+        switch sourceLine.anchor.side {
+        case .old:
+            side = .old
+        case .new:
+            side = .new
+        case .paired:
+            side = .unknown
+        }
+
+        return DiffReviewLineAnchor(
+            path: sourceLine.anchor.filePath,
+            side: side,
+            line: lineNumber,
+            rowIndex: rowIndex,
+            selectedText: sourceLine.text
+        )
     }
 }

--- a/Alas/Sources/Center/Diff/DiffPaneView.swift
+++ b/Alas/Sources/Center/Diff/DiffPaneView.swift
@@ -115,10 +115,39 @@ struct DiffPaneView: View {
     var showsToolbar: Bool = true
     var verticalScrollMode: DiffPaneVerticalScrollMode = .internalScroll
     var lspContext: DiffPaneLSPContext? = nil
+    var onReviewLineSelected: (DiffReviewLineAnchor) -> Void = { _ in }
     let hunkActions: (ParsedDiff.Hunk) -> DiffPaneHunkActions
 
     @Environment(\.theme) private var theme
     @State private var expandedCollapsedRowIDs: Set<String> = []
+
+    init(
+        model: DiffDisplayModel,
+        fileExtension: String,
+        layoutMode: Binding<DiffLayoutMode>,
+        wrapLines: Binding<Bool>,
+        showWhitespace: Binding<Bool>,
+        codeFontFamily: String,
+        codeFontSize: CGFloat,
+        showsToolbar: Bool = true,
+        verticalScrollMode: DiffPaneVerticalScrollMode = .internalScroll,
+        lspContext: DiffPaneLSPContext? = nil,
+        onReviewLineSelected: @escaping (DiffReviewLineAnchor) -> Void = { _ in },
+        hunkActions: @escaping (ParsedDiff.Hunk) -> DiffPaneHunkActions
+    ) {
+        self.model = model
+        self.fileExtension = fileExtension
+        self._layoutMode = layoutMode
+        self._wrapLines = wrapLines
+        self._showWhitespace = showWhitespace
+        self.codeFontFamily = codeFontFamily
+        self.codeFontSize = codeFontSize
+        self.showsToolbar = showsToolbar
+        self.verticalScrollMode = verticalScrollMode
+        self.lspContext = lspContext
+        self.onReviewLineSelected = onReviewLineSelected
+        self.hunkActions = hunkActions
+    }
 
     var body: some View {
         VStack(spacing: 0) {
@@ -254,7 +283,8 @@ struct DiffPaneView: View {
                 codeFontFamily: codeFontFamily,
                 codeFontSize: codeFontSize,
                 theme: theme,
-                lspContext: lspContext
+                lspContext: lspContext,
+                onReviewLineSelected: onReviewLineSelected
             )
             .fixedSize(horizontal: false, vertical: true)
         }

--- a/Alas/Sources/Center/DiffReview/DiffReviewFileSection.swift
+++ b/Alas/Sources/Center/DiffReview/DiffReviewFileSection.swift
@@ -839,6 +839,8 @@ private struct ReviewDraftCommentCard: View {
     let onSelect: (ReviewDraftComment) -> Void
 
     @Environment(\.theme) private var theme
+    @State private var isEditing = false
+    @State private var editingBody = ""
 
     var body: some View {
         VStack(alignment: .leading, spacing: 6) {
@@ -868,10 +870,21 @@ private struct ReviewDraftCommentCard: View {
                         }
                         .lineLimit(1)
 
-                        Text(DiffReviewInlineFeedbackMarkdown.render(comment.bodyMarkdown))
-                            .font(.system(size: 11.5))
-                            .foregroundColor(theme.color("fg"))
-                            .fixedSize(horizontal: false, vertical: true)
+                        if isEditing {
+                            TextEditor(text: $editingBody)
+                                .font(.system(size: 11.5))
+                                .foregroundColor(theme.color("fg"))
+                                .scrollContentBackground(.hidden)
+                                .frame(minHeight: 72)
+                                .background(theme.color("bg-1"))
+                                .clipShape(RoundedRectangle(cornerRadius: 5))
+                                .accessibilityIdentifier("diff-review-draft-comment-editor-\(comment.id)")
+                        } else {
+                            Text(DiffReviewInlineFeedbackMarkdown.render(comment.bodyMarkdown))
+                                .font(.system(size: 11.5))
+                                .foregroundColor(theme.color("fg"))
+                                .fixedSize(horizontal: false, vertical: true)
+                        }
                     }
                     .frame(maxWidth: .infinity, alignment: .leading)
 
@@ -919,13 +932,24 @@ private struct ReviewDraftCommentCard: View {
             || availability.canResolve
             || availability.canDismiss
             || availability.canCopyPrompt
-            || availability.canSendToAgent
+            || availability.canShowSendToAgent
         {
             HStack(spacing: 6) {
                 Spacer(minLength: 0)
-                if availability.canEdit {
+                if isEditing {
+                    actionButton(id: "save", title: "Save") {
+                        actions.edit(comment, editingBody)
+                        isEditing = false
+                        editingBody = ""
+                    }
+                    actionButton(id: "cancel", title: "Cancel") {
+                        isEditing = false
+                        editingBody = ""
+                    }
+                } else if availability.canEdit {
                     actionButton(id: "edit", title: "Edit") {
-                        actions.edit(comment)
+                        editingBody = comment.bodyMarkdown
+                        isEditing = true
                     }
                 }
                 if availability.canDelete {
@@ -948,12 +972,34 @@ private struct ReviewDraftCommentCard: View {
                         actions.copyPrompt(feedbackBundle)
                     }
                 }
-                if availability.canSendToAgent {
-                    actionButton(id: "send", title: "Send") {
-                        actions.sendToAgent(feedbackBundle)
+                if availability.canShowSendToAgent {
+                    sendToAgentControl(isEnabled: availability.canSendToAgent)
+                }
+            }
+        }
+    }
+
+    @ViewBuilder
+    private func sendToAgentControl(isEnabled: Bool) -> some View {
+        let targets = actions.agentTargets()
+        if targets.count > 1 {
+            Menu("Send") {
+                ForEach(targets) { target in
+                    Button(target.title) {
+                        actions.sendToAgent(feedbackBundle, target)
                     }
                 }
             }
+            .menuStyle(.borderlessButton)
+            .disabled(!isEnabled)
+            .help("Send")
+            .accessibilityIdentifier("diff-review-draft-comment-action-send-\(comment.id)")
+        } else {
+            actionButton(id: "send", title: "Send") {
+                guard let target = targets.first else { return }
+                actions.sendToAgent(feedbackBundle, target)
+            }
+            .disabled(!isEnabled)
         }
     }
 

--- a/Alas/Sources/Center/DiffReview/DiffReviewFileSection.swift
+++ b/Alas/Sources/Center/DiffReview/DiffReviewFileSection.swift
@@ -543,6 +543,21 @@ enum ReviewDraftCommentPlacement {
             return lhs.id < rhs.id
         }
     }
+
+    static func comments(
+        matching keys: [RowKey],
+        in placement: Result,
+        excludingIDs excludedIDs: Set<String> = []
+    ) -> [ReviewDraftComment] {
+        var seenIDs = excludedIDs
+        var comments: [ReviewDraftComment] = []
+        for key in keys {
+            for comment in placement.byRowAnchor[key] ?? [] where seenIDs.insert(comment.id).inserted {
+                comments.append(comment)
+            }
+        }
+        return sorted(comments)
+    }
 }
 
 enum ReviewDraftCommentRowSegmentation {
@@ -571,11 +586,17 @@ enum ReviewDraftCommentRowSegmentation {
         }
         var segments: [Segment] = []
         var bufferedRows: [DiffDisplayRow] = []
+        var emittedCommentIDs: Set<String> = []
 
         for row in group.rows {
             bufferedRows.append(row)
             let keys = ReviewDraftCommentPlacement.allRowKeys(in: row)
-            let comments = ReviewDraftCommentPlacement.sorted(keys.flatMap { placement.byRowAnchor[$0] ?? [] })
+            let comments = ReviewDraftCommentPlacement.comments(
+                matching: keys,
+                in: placement,
+                excludingIDs: emittedCommentIDs
+            )
+            emittedCommentIDs.formUnion(comments.map(\.id))
             let showsComposer = pendingKey.map { keys.contains($0) } ?? false
             guard !comments.isEmpty || showsComposer else { continue }
 

--- a/Alas/Sources/Center/DiffReview/DiffReviewFileSection.swift
+++ b/Alas/Sources/Center/DiffReview/DiffReviewFileSection.swift
@@ -123,6 +123,7 @@ struct DiffReviewFileSection: View {
                         actions: draftCommentActions,
                         onSelect: onSelectDraftComment
                     )
+                    .id(DiffReviewDraftCommentTargetID.targetID(commentID: comment.id, fileID: file.id))
                 }
             }
             .padding(.horizontal, 14)

--- a/Alas/Sources/Center/DiffReview/DiffReviewFileSection.swift
+++ b/Alas/Sources/Center/DiffReview/DiffReviewFileSection.swift
@@ -516,6 +516,9 @@ enum ReviewDraftCommentPlacement {
         if let newLine = row.new?.lineNumber {
             keys.append(RowKey(side: .new, line: newLine))
         }
+        for line in Set([row.old?.lineNumber, row.new?.lineNumber].compactMap(\.self)).sorted() {
+            keys.append(RowKey(side: .unknown, line: line))
+        }
         return keys
     }
 

--- a/Alas/Sources/Center/DiffReview/DiffReviewFileSection.swift
+++ b/Alas/Sources/Center/DiffReview/DiffReviewFileSection.swift
@@ -23,6 +23,7 @@ struct DiffReviewFileSection: View {
     @Environment(\.theme) private var theme
     @State private var pendingDraftAnchor: DiffReviewLineAnchor?
     @State private var pendingDraftBody = ""
+    @State private var expandedCollapsedRowIDs: Set<String> = []
 
     var body: some View {
         VStack(spacing: 0) {
@@ -193,30 +194,7 @@ struct DiffReviewFileSection: View {
                     if let groupFeedback = inlinePlacement.byGroupID[group.id], !groupFeedback.isEmpty {
                         inlineFeedbackStack(groupFeedback, file: file.summary)
                     }
-                    let groupDraftComments = draftComments(for: group, placement: draftPlacement)
-                    if !groupDraftComments.isEmpty {
-                        draftCommentStack(groupDraftComments)
-                    }
-                    if pendingDraftAnchorBelongs(to: group) {
-                        draftComposer
-                    }
-                    DiffPaneView(
-                        model: DiffDisplayModel(filePath: displayModel.filePath, groups: [group]),
-                        fileExtension: LanguageRegistry.highlighterExtension(forPath: file.summary.path),
-                        layoutMode: $layoutMode,
-                        wrapLines: $wrapLines,
-                        showWhitespace: $showWhitespace,
-                        codeFontFamily: codeFontFamily,
-                        codeFontSize: codeFontSize,
-                        showsToolbar: false,
-                        verticalScrollMode: .staticHeight,
-                        lspContext: lspContext,
-                        onReviewLineSelected: { anchor in
-                            pendingDraftAnchor = anchor
-                            pendingDraftBody = ""
-                        },
-                        hunkActions: { _ in DiffPaneHunkActions() }
-                    )
+                    reviewGroup(group, displayModel: displayModel, placement: draftPlacement)
                 }
             }
         } else {
@@ -235,6 +213,111 @@ struct DiffReviewFileSection: View {
                     )
                 )
         }
+    }
+
+    @ViewBuilder
+    private func reviewGroup(
+        _ group: DiffDisplayGroup,
+        displayModel: DiffDisplayModel,
+        placement: ReviewDraftCommentPlacement.Result
+    ) -> some View {
+        let segments = ReviewDraftCommentRowSegmentation.segments(
+            for: group,
+            placement: placement,
+            pendingAnchor: pendingDraftAnchor
+        )
+        if segments.containsLocalAccessories {
+            VStack(alignment: .leading, spacing: 0) {
+                segmentedHunkHeader(group)
+                ForEach(segments.items) { segment in
+                    if !segment.rows.isEmpty {
+                        DiffPaneTextDocumentView(
+                            group: DiffDisplayGroup(
+                                id: segment.id,
+                                header: group.header,
+                                sourceHunk: group.sourceHunk,
+                                rows: segment.rows
+                            ),
+                            expandedCollapsedRowIDs: expandedCollapsedRowIDs,
+                            layoutMode: layoutMode,
+                            wrapLines: wrapLines,
+                            showWhitespace: showWhitespace,
+                            fileExtension: LanguageRegistry.highlighterExtension(forPath: file.summary.path),
+                            codeFontFamily: codeFontFamily,
+                            codeFontSize: codeFontSize,
+                            theme: theme,
+                            lspContext: lspContext,
+                            onReviewLineSelected: { anchor in
+                                pendingDraftAnchor = anchor
+                                pendingDraftBody = ""
+                            }
+                        )
+                        .fixedSize(horizontal: false, vertical: true)
+                    }
+                    if !segment.draftComments.isEmpty {
+                        draftCommentStack(segment.draftComments)
+                    }
+                    if segment.showsComposer {
+                        draftComposer
+                    }
+                }
+            }
+            .background(theme.color("bg-1"))
+            .clipShape(RoundedRectangle(cornerRadius: 7))
+            .overlay(
+                RoundedRectangle(cornerRadius: 7)
+                    .stroke(theme.color("line"), lineWidth: 0.75)
+            )
+            .padding(.bottom, 10)
+        } else {
+            DiffPaneView(
+                model: DiffDisplayModel(filePath: displayModel.filePath, groups: [group]),
+                fileExtension: LanguageRegistry.highlighterExtension(forPath: file.summary.path),
+                layoutMode: $layoutMode,
+                wrapLines: $wrapLines,
+                showWhitespace: $showWhitespace,
+                codeFontFamily: codeFontFamily,
+                codeFontSize: codeFontSize,
+                showsToolbar: false,
+                verticalScrollMode: .staticHeight,
+                lspContext: lspContext,
+                onReviewLineSelected: { anchor in
+                    pendingDraftAnchor = anchor
+                    pendingDraftBody = ""
+                },
+                hunkActions: { _ in DiffPaneHunkActions() }
+            )
+        }
+    }
+
+    private func segmentedHunkHeader(_ group: DiffDisplayGroup) -> some View {
+        HStack(spacing: 8) {
+            Text(group.header)
+                .font(CenterTypography.codeFont(family: codeFontFamily, size: codeFontSize - 1))
+                .foregroundColor(theme.color("fg-muted"))
+                .lineLimit(1)
+            Spacer(minLength: 12)
+            if !DiffCollapsedContextController.collapsedRowIDs(in: group).isEmpty {
+                let expanded = DiffCollapsedContextController.isExpanded(group, expandedIDs: expandedCollapsedRowIDs)
+                Button {
+                    expandedCollapsedRowIDs = DiffCollapsedContextController.toggled(
+                        group,
+                        expandedIDs: expandedCollapsedRowIDs
+                    )
+                } label: {
+                    Image(systemName: expanded ? "minus.square" : "plus.square")
+                        .font(.system(size: 12, weight: .medium))
+                        .foregroundColor(theme.color("fg-muted"))
+                        .frame(width: 22, height: 20)
+                }
+                .buttonStyle(.plain)
+                .help(expanded ? "Collapse context" : "Expand context")
+            }
+        }
+        .padding(.horizontal, 13)
+        .padding(.vertical, 8)
+        .background(theme.color("bg-2"))
+        .overlay(Rectangle().fill(theme.color("line")).frame(height: 0.5), alignment: .bottom)
     }
 
     @ViewBuilder
@@ -300,22 +383,6 @@ struct DiffReviewFileSection: View {
         onSaveDraftComment(pendingDraftAnchor, body)
         self.pendingDraftAnchor = nil
         pendingDraftBody = ""
-    }
-
-    private func pendingDraftAnchorBelongs(to group: DiffDisplayGroup) -> Bool {
-        guard let pendingDraftAnchor else { return false }
-        return ReviewDraftCommentPlacement.visibleRowKeys(in: group).contains(
-            ReviewDraftCommentPlacement.RowKey(side: pendingDraftAnchor.side, line: pendingDraftAnchor.line)
-        )
-    }
-
-    private func draftComments(
-        for group: DiffDisplayGroup,
-        placement: ReviewDraftCommentPlacement.Result
-    ) -> [ReviewDraftComment] {
-        let rowKeys = ReviewDraftCommentPlacement.visibleRowKeys(in: group)
-        let comments = rowKeys.flatMap { placement.byRowAnchor[$0] ?? [] }
-        return ReviewDraftCommentPlacement.sorted(comments)
     }
 
     @ViewBuilder
@@ -400,15 +467,19 @@ enum ReviewDraftCommentPlacement {
 
     static func visibleRowKeys(in group: DiffDisplayGroup) -> [RowKey] {
         group.rows.flatMap { row -> [RowKey] in
-            var keys: [RowKey] = []
-            if let oldLine = row.old?.lineNumber {
-                keys.append(RowKey(side: .old, line: oldLine))
-            }
-            if let newLine = row.new?.lineNumber {
-                keys.append(RowKey(side: .new, line: newLine))
-            }
-            return keys
+            visibleRowKeys(in: row)
         }
+    }
+
+    static func visibleRowKeys(in row: DiffDisplayRow) -> [RowKey] {
+        var keys: [RowKey] = []
+        if let oldLine = row.old?.lineNumber {
+            keys.append(RowKey(side: .old, line: oldLine))
+        }
+        if let newLine = row.new?.lineNumber {
+            keys.append(RowKey(side: .new, line: newLine))
+        }
+        return keys
     }
 
     static func sorted(_ comments: [ReviewDraftComment]) -> [ReviewDraftComment] {
@@ -427,6 +498,62 @@ enum ReviewDraftCommentPlacement {
             }
             return lhs.id < rhs.id
         }
+    }
+}
+
+enum ReviewDraftCommentRowSegmentation {
+    struct Segment: Equatable, Identifiable {
+        let id: String
+        let rows: [DiffDisplayRow]
+        let draftComments: [ReviewDraftComment]
+        let showsComposer: Bool
+    }
+
+    struct Result: Equatable {
+        let items: [Segment]
+
+        var containsLocalAccessories: Bool {
+            items.contains { !$0.draftComments.isEmpty || $0.showsComposer }
+        }
+    }
+
+    static func segments(
+        for group: DiffDisplayGroup,
+        placement: ReviewDraftCommentPlacement.Result,
+        pendingAnchor: DiffReviewLineAnchor?
+    ) -> Result {
+        let pendingKey = pendingAnchor.map {
+            ReviewDraftCommentPlacement.RowKey(side: $0.side, line: $0.line)
+        }
+        var segments: [Segment] = []
+        var bufferedRows: [DiffDisplayRow] = []
+
+        for row in group.rows {
+            bufferedRows.append(row)
+            let keys = ReviewDraftCommentPlacement.visibleRowKeys(in: row)
+            let comments = ReviewDraftCommentPlacement.sorted(keys.flatMap { placement.byRowAnchor[$0] ?? [] })
+            let showsComposer = pendingKey.map { keys.contains($0) } ?? false
+            guard !comments.isEmpty || showsComposer else { continue }
+
+            segments.append(Segment(
+                id: "\(group.id)-segment-\(segments.count)",
+                rows: bufferedRows,
+                draftComments: comments,
+                showsComposer: showsComposer
+            ))
+            bufferedRows = []
+        }
+
+        if !bufferedRows.isEmpty {
+            segments.append(Segment(
+                id: "\(group.id)-segment-\(segments.count)",
+                rows: bufferedRows,
+                draftComments: [],
+                showsComposer: false
+            ))
+        }
+
+        return Result(items: segments)
     }
 }
 

--- a/Alas/Sources/Center/DiffReview/DiffReviewFileSection.swift
+++ b/Alas/Sources/Center/DiffReview/DiffReviewFileSection.swift
@@ -5,6 +5,8 @@ struct DiffReviewFileSection: View {
     var inlineFeedback: [DiffReviewInlineFeedback] = []
     var focusedFeedbackID: String? = nil
     var inlineFeedbackScrollTargetID: String? = nil
+    var draftComments: [ReviewDraftComment] = []
+    var focusedDraftCommentID: String? = nil
     @Binding var layoutMode: DiffLayoutMode
     @Binding var wrapLines: Bool
     @Binding var showWhitespace: Bool
@@ -14,12 +16,18 @@ struct DiffReviewFileSection: View {
     var lspContext: DiffPaneLSPContext? = nil
     var inlineFeedbackActions = DiffReviewInlineFeedbackActions()
     var onSelectInlineFeedback: (DiffReviewInlineFeedback) -> Void = { _ in }
+    var draftCommentActions = ReviewDraftCommentActions()
+    var onSelectDraftComment: (ReviewDraftComment) -> Void = { _ in }
+    var onSaveDraftComment: (DiffReviewLineAnchor, String) -> Void = { _, _ in }
 
     @Environment(\.theme) private var theme
+    @State private var pendingDraftAnchor: DiffReviewLineAnchor?
+    @State private var pendingDraftBody = ""
 
     var body: some View {
         VStack(spacing: 0) {
             header
+            fileLevelDraftCommentStack
             fileLevelInlineFeedbackStack
             content
         }
@@ -92,6 +100,35 @@ struct DiffReviewFileSection: View {
     }
 
     @ViewBuilder
+    private var fileLevelDraftCommentStack: some View {
+        let fileLevel = draftCommentPlacement.fileLevel
+        if !fileLevel.isEmpty {
+            draftCommentStack(fileLevel)
+        }
+    }
+
+    @ViewBuilder
+    private func draftCommentStack(_ comments: [ReviewDraftComment]) -> some View {
+        if !comments.isEmpty {
+            VStack(alignment: .leading, spacing: 6) {
+                ForEach(comments) { comment in
+                    ReviewDraftCommentCard(
+                        comment: comment,
+                        file: file.summary,
+                        isFocused: comment.id == focusedDraftCommentID,
+                        actions: draftCommentActions,
+                        onSelect: onSelectDraftComment
+                    )
+                }
+            }
+            .padding(.horizontal, 14)
+            .padding(.vertical, 10)
+            .background(theme.color("bg-1"))
+            .overlay(Rectangle().fill(theme.color("line")).frame(height: 0.5), alignment: .bottom)
+        }
+    }
+
+    @ViewBuilder
     private var fileLevelInlineFeedbackStack: some View {
         let fileLevel = inlineFeedbackPlacement.fileLevel
         if !fileLevel.isEmpty {
@@ -139,14 +176,29 @@ struct DiffReviewFileSection: View {
         return DiffReviewInlineFeedbackPlacement.position(inlineFeedback, in: displayModel.groups)
     }
 
+    private var draftCommentPlacement: ReviewDraftCommentPlacement.Result {
+        guard let displayModel = file.displayModel else {
+            return ReviewDraftCommentPlacement.position(draftComments, in: [])
+        }
+        return ReviewDraftCommentPlacement.position(draftComments, in: displayModel.groups)
+    }
+
     @ViewBuilder
     private var content: some View {
         if let displayModel = file.displayModel {
-            let placement = inlineFeedbackPlacement
+            let inlinePlacement = inlineFeedbackPlacement
+            let draftPlacement = draftCommentPlacement
             VStack(spacing: 0) {
                 ForEach(displayModel.groups) { group in
-                    if let groupFeedback = placement.byGroupID[group.id], !groupFeedback.isEmpty {
+                    if let groupFeedback = inlinePlacement.byGroupID[group.id], !groupFeedback.isEmpty {
                         inlineFeedbackStack(groupFeedback, file: file.summary)
+                    }
+                    let groupDraftComments = draftComments(for: group, placement: draftPlacement)
+                    if !groupDraftComments.isEmpty {
+                        draftCommentStack(groupDraftComments)
+                    }
+                    if pendingDraftAnchorBelongs(to: group) {
+                        draftComposer
                     }
                     DiffPaneView(
                         model: DiffDisplayModel(filePath: displayModel.filePath, groups: [group]),
@@ -159,6 +211,10 @@ struct DiffReviewFileSection: View {
                         showsToolbar: false,
                         verticalScrollMode: .staticHeight,
                         lspContext: lspContext,
+                        onReviewLineSelected: { anchor in
+                            pendingDraftAnchor = anchor
+                            pendingDraftBody = ""
+                        },
                         hunkActions: { _ in DiffPaneHunkActions() }
                     )
                 }
@@ -179,6 +235,87 @@ struct DiffReviewFileSection: View {
                     )
                 )
         }
+    }
+
+    @ViewBuilder
+    private var draftComposer: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            TextEditor(text: $pendingDraftBody)
+                .font(.system(size: 12))
+                .foregroundColor(theme.color("fg"))
+                .frame(minHeight: 64, maxHeight: 90)
+                .background(theme.color("bg-2"))
+                .clipShape(RoundedRectangle(cornerRadius: 6))
+                .overlay(
+                    RoundedRectangle(cornerRadius: 6)
+                        .stroke(theme.color("line"), lineWidth: 0.5)
+                )
+                .accessibilityIdentifier("diff-review-draft-composer")
+
+            HStack(spacing: 6) {
+                Spacer(minLength: 0)
+                Button("Cancel") {
+                    pendingDraftAnchor = nil
+                    pendingDraftBody = ""
+                }
+                .buttonStyle(.plain)
+                .font(.system(size: 10, weight: .semibold))
+                .foregroundColor(theme.color("fg-muted"))
+                .padding(.horizontal, 8)
+                .frame(height: 24)
+                .background(theme.color("bg-3"))
+                .clipShape(RoundedRectangle(cornerRadius: 5))
+                .accessibilityIdentifier("diff-review-draft-composer-cancel")
+
+                Button("Save") {
+                    savePendingDraft()
+                }
+                .buttonStyle(.plain)
+                .font(.system(size: 10, weight: .semibold))
+                .foregroundColor(theme.color("bg-1"))
+                .padding(.horizontal, 9)
+                .frame(height: 24)
+                .background(theme.color("accent"))
+                .clipShape(RoundedRectangle(cornerRadius: 5))
+                .accessibilityIdentifier("diff-review-draft-composer-save")
+            }
+        }
+        .padding(.horizontal, 14)
+        .padding(.vertical, 10)
+        .background(theme.color("bg-1"))
+        .overlay(Rectangle().fill(theme.color("line")).frame(height: 0.5), alignment: .bottom)
+        .background(
+            DiffReviewAccessibilityMarker(
+                identifier: "diff-review-draft-composer-marker",
+                label: "Draft comment composer"
+            )
+        )
+    }
+
+    private func savePendingDraft() {
+        guard let pendingDraftAnchor else { return }
+        let body = pendingDraftBody.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !body.isEmpty else { return }
+
+        onSaveDraftComment(pendingDraftAnchor, body)
+        self.pendingDraftAnchor = nil
+        pendingDraftBody = ""
+    }
+
+    private func pendingDraftAnchorBelongs(to group: DiffDisplayGroup) -> Bool {
+        guard let pendingDraftAnchor else { return false }
+        return ReviewDraftCommentPlacement.visibleRowKeys(in: group).contains(
+            ReviewDraftCommentPlacement.RowKey(side: pendingDraftAnchor.side, line: pendingDraftAnchor.line)
+        )
+    }
+
+    private func draftComments(
+        for group: DiffDisplayGroup,
+        placement: ReviewDraftCommentPlacement.Result
+    ) -> [ReviewDraftComment] {
+        let rowKeys = ReviewDraftCommentPlacement.visibleRowKeys(in: group)
+        let comments = rowKeys.flatMap { placement.byRowAnchor[$0] ?? [] }
+        return ReviewDraftCommentPlacement.sorted(comments)
     }
 
     @ViewBuilder
@@ -223,6 +360,72 @@ struct DiffReviewFileSection: View {
             theme.color("warn")
         case .modified, .unknown:
             theme.color("fg-dim")
+        }
+    }
+}
+
+enum ReviewDraftCommentPlacement {
+    struct RowKey: Hashable, Equatable {
+        let side: DiffReviewInlineFeedbackSide
+        let line: Int
+    }
+
+    struct Result: Equatable {
+        let fileLevel: [ReviewDraftComment]
+        let byRowAnchor: [RowKey: [ReviewDraftComment]]
+    }
+
+    static func position(
+        _ comments: [ReviewDraftComment],
+        in groups: [DiffDisplayGroup]
+    ) -> Result {
+        let visibleKeys = Set(groups.flatMap(visibleRowKeys))
+        var fileLevel: [ReviewDraftComment] = []
+        var byRowAnchor: [RowKey: [ReviewDraftComment]] = [:]
+
+        for comment in comments where comment.state != .dismissed {
+            let key = RowKey(side: comment.side, line: comment.normalizedLineRange.upperBound)
+            if visibleKeys.contains(key) {
+                byRowAnchor[key, default: []].append(comment)
+            } else {
+                fileLevel.append(comment)
+            }
+        }
+
+        return Result(
+            fileLevel: sorted(fileLevel),
+            byRowAnchor: byRowAnchor.mapValues(sorted)
+        )
+    }
+
+    static func visibleRowKeys(in group: DiffDisplayGroup) -> [RowKey] {
+        group.rows.flatMap { row -> [RowKey] in
+            var keys: [RowKey] = []
+            if let oldLine = row.old?.lineNumber {
+                keys.append(RowKey(side: .old, line: oldLine))
+            }
+            if let newLine = row.new?.lineNumber {
+                keys.append(RowKey(side: .new, line: newLine))
+            }
+            return keys
+        }
+    }
+
+    static func sorted(_ comments: [ReviewDraftComment]) -> [ReviewDraftComment] {
+        comments.sorted { lhs, rhs in
+            if lhs.path != rhs.path {
+                return lhs.path.localizedStandardCompare(rhs.path) == .orderedAscending
+            }
+            if lhs.normalizedLineRange.lowerBound != rhs.normalizedLineRange.lowerBound {
+                return lhs.normalizedLineRange.lowerBound < rhs.normalizedLineRange.lowerBound
+            }
+            if lhs.normalizedLineRange.upperBound != rhs.normalizedLineRange.upperBound {
+                return lhs.normalizedLineRange.upperBound < rhs.normalizedLineRange.upperBound
+            }
+            if lhs.createdAt != rhs.createdAt {
+                return lhs.createdAt < rhs.createdAt
+            }
+            return lhs.id < rhs.id
         }
     }
 }
@@ -288,6 +491,39 @@ enum DiffReviewInlineFeedbackPlacement {
             return row.old?.lineNumber == line
         case .unknown:
             return row.new?.lineNumber == line || row.old?.lineNumber == line
+        }
+    }
+}
+
+enum ReviewDraftCommentDisplayPolicy {
+    static let cardMinimumHeight: CGFloat = 86
+    private static let estimatedBodyCharactersPerLine = 86
+    private static let estimatedBodyLineHeight: CGFloat = 15.5
+    private static let cardNonBodyHeight: CGFloat = 52
+    private static let stackVerticalPadding: CGFloat = 20
+    private static let rowSpacing: CGFloat = 6
+
+    static func estimatedHeight(for comments: [ReviewDraftComment]) -> CGFloat {
+        guard !comments.isEmpty else { return 0 }
+
+        let visibleHeights = comments.reduce(CGFloat(0)) { total, comment in
+            total + estimatedCardHeight(for: comment)
+        }
+        let spacingHeight = CGFloat(max(0, comments.count - 1)) * rowSpacing
+        return stackVerticalPadding + visibleHeights + spacingHeight
+    }
+
+    static func estimatedCardHeight(for comment: ReviewDraftComment) -> CGFloat {
+        let bodyLineCount = estimatedLineCount(for: comment.bodyMarkdown)
+        let bodyHeight = CGFloat(bodyLineCount) * estimatedBodyLineHeight
+
+        return max(cardMinimumHeight, cardNonBodyHeight + bodyHeight)
+    }
+
+    private static func estimatedLineCount(for source: String) -> Int {
+        let logicalLines = source.split(separator: "\n", omittingEmptySubsequences: false)
+        return logicalLines.reduce(0) { total, line in
+            total + max(1, Int(ceil(Double(line.count) / Double(estimatedBodyCharactersPerLine))))
         }
     }
 }
@@ -376,6 +612,194 @@ enum DiffReviewInlineFeedbackMarkdown {
     @MainActor
     static func plainText(_ source: String) -> String {
         NSAttributedString(render(source)).string
+    }
+}
+
+private struct ReviewDraftCommentCard: View {
+    let comment: ReviewDraftComment
+    let file: DiffReviewFileSummary
+    let isFocused: Bool
+    let actions: ReviewDraftCommentActions
+    let onSelect: (ReviewDraftComment) -> Void
+
+    @Environment(\.theme) private var theme
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            Button {
+                onSelect(comment)
+            } label: {
+                HStack(alignment: .top, spacing: 8) {
+                    RoundedRectangle(cornerRadius: 2)
+                        .fill(statusColor)
+                        .frame(width: 3)
+
+                    VStack(alignment: .leading, spacing: 4) {
+                        HStack(spacing: 6) {
+                            Text("Local draft")
+                                .font(.system(size: 10, weight: .semibold))
+                                .foregroundColor(statusColor)
+
+                            Text(lineDescription)
+                                .font(.system(size: 10))
+                                .foregroundColor(theme.color("fg-faint"))
+
+                            if comment.state == .resolved {
+                                Text("resolved")
+                                    .font(.system(size: 10))
+                                    .foregroundColor(theme.color("fg-faint"))
+                            }
+                        }
+                        .lineLimit(1)
+
+                        Text(DiffReviewInlineFeedbackMarkdown.render(comment.bodyMarkdown))
+                            .font(.system(size: 11.5))
+                            .foregroundColor(theme.color("fg"))
+                            .fixedSize(horizontal: false, vertical: true)
+                    }
+                    .frame(maxWidth: .infinity, alignment: .leading)
+
+                    Spacer(minLength: 0)
+                }
+                .contentShape(Rectangle())
+            }
+            .buttonStyle(.plain)
+            .accessibilityIdentifier("diff-review-draft-comment-select-\(comment.id)")
+
+            actionRow
+        }
+        .padding(8)
+        .frame(minHeight: ReviewDraftCommentDisplayPolicy.cardMinimumHeight, alignment: .top)
+        .background(isFocused ? theme.color("accent-soft") : theme.color("bg-2"))
+        .clipShape(RoundedRectangle(cornerRadius: 6))
+        .overlay(
+            RoundedRectangle(cornerRadius: 6)
+                .stroke(isFocused ? theme.color("accent") : statusColor.opacity(0.65), lineWidth: isFocused ? 1 : 0.75)
+        )
+        .background(
+            DiffReviewAccessibilityMarker(
+                identifier: "diff-review-draft-comment-\(comment.id)",
+                label: accessibilityLabel
+            )
+        )
+        .background(focusedMarker)
+    }
+
+    @ViewBuilder
+    private var focusedMarker: some View {
+        if isFocused {
+            DiffReviewAccessibilityMarker(
+                identifier: "diff-review-draft-comment-focused-\(comment.id)",
+                label: accessibilityLabel
+            )
+        }
+    }
+
+    @ViewBuilder
+    private var actionRow: some View {
+        let availability = actions.availability(comment)
+        if availability.canEdit
+            || availability.canDelete
+            || availability.canResolve
+            || availability.canCopyPrompt
+            || availability.canSendToAgent
+        {
+            HStack(spacing: 6) {
+                Spacer(minLength: 0)
+                if availability.canEdit {
+                    actionButton(id: "edit", title: "Edit") {
+                        actions.edit(comment)
+                    }
+                }
+                if availability.canDelete {
+                    actionButton(id: "delete", title: "Delete") {
+                        actions.delete(comment)
+                    }
+                }
+                if availability.canResolve {
+                    actionButton(id: "resolve", title: "Resolve") {
+                        actions.resolve(comment)
+                    }
+                }
+                if availability.canCopyPrompt {
+                    actionButton(id: "copy", title: "Copy") {
+                        actions.copyPrompt(feedbackBundle)
+                    }
+                }
+                if availability.canSendToAgent {
+                    actionButton(id: "send", title: "Send") {
+                        actions.sendToAgent(feedbackBundle)
+                    }
+                }
+            }
+        }
+    }
+
+    private func actionButton(id: String, title: String, action: @escaping () -> Void) -> some View {
+        Button(action: action) {
+            Text(title)
+                .font(.system(size: 10, weight: .semibold))
+                .foregroundColor(theme.color("fg-muted"))
+                .padding(.horizontal, 7)
+                .frame(height: 22)
+                .background(theme.color("bg-3"))
+                .clipShape(RoundedRectangle(cornerRadius: 5))
+        }
+        .buttonStyle(.plain)
+        .help(title)
+        .accessibilityIdentifier("diff-review-draft-comment-\(id)-\(comment.id)")
+        .accessibilityLabel(title)
+        .background(
+            DiffReviewAccessibilityMarker(
+                identifier: "diff-review-draft-comment-action-\(id)-\(comment.id)",
+                label: title
+            )
+        )
+    }
+
+    private var feedbackBundle: ReviewFeedbackBundle {
+        ReviewFeedbackBundle(
+            target: ReviewFeedbackTarget(
+                title: file.path,
+                repositoryPath: nil,
+                providerDescription: nil,
+                sourceDescription: "Local draft comment"
+            ),
+            comments: [comment]
+        )
+    }
+
+    private var lineDescription: String {
+        let range = comment.normalizedLineRange
+        if range.lowerBound == range.upperBound {
+            return "line \(range.lowerBound)"
+        }
+        return "lines \(range.lowerBound)-\(range.upperBound)"
+    }
+
+    private var accessibilityLabel: String {
+        [
+            "Local draft",
+            lineDescription,
+            comment.state == .resolved ? "resolved" : nil,
+            DiffReviewInlineFeedbackMarkdown.plainText(comment.bodyMarkdown),
+        ]
+        .compactMap { part in
+            guard let part, !part.isEmpty else { return nil }
+            return part
+        }
+        .joined(separator: ", ")
+    }
+
+    private var statusColor: Color {
+        switch comment.state {
+        case .active:
+            theme.color("warn")
+        case .resolved:
+            theme.color("add")
+        case .dismissed:
+            theme.color("fg-muted")
+        }
     }
 }
 

--- a/Alas/Sources/Center/DiffReview/DiffReviewFileSection.swift
+++ b/Alas/Sources/Center/DiffReview/DiffReviewFileSection.swift
@@ -473,6 +473,7 @@ enum ReviewDraftCommentPlacement {
     struct Result: Equatable {
         let fileLevel: [ReviewDraftComment]
         let byRowAnchor: [RowKey: [ReviewDraftComment]]
+        let groupIDByCommentID: [String: String]
     }
 
     static func position(
@@ -480,13 +481,18 @@ enum ReviewDraftCommentPlacement {
         in groups: [DiffDisplayGroup]
     ) -> Result {
         let visibleKeys = Set(groups.flatMap(allRowKeys))
+        let groupIDByKey = firstGroupIDByRowKey(in: groups)
         var fileLevel: [ReviewDraftComment] = []
         var byRowAnchor: [RowKey: [ReviewDraftComment]] = [:]
+        var groupIDByCommentID: [String: String] = [:]
 
         for comment in comments where comment.state != .dismissed {
             let key = RowKey(side: comment.side, line: comment.normalizedLineRange.upperBound)
             if visibleKeys.contains(key) {
                 byRowAnchor[key, default: []].append(comment)
+                if let groupID = groupIDByKey[key] {
+                    groupIDByCommentID[comment.id] = groupID
+                }
             } else {
                 fileLevel.append(comment)
             }
@@ -494,8 +500,19 @@ enum ReviewDraftCommentPlacement {
 
         return Result(
             fileLevel: sorted(fileLevel),
-            byRowAnchor: byRowAnchor.mapValues(sorted)
+            byRowAnchor: byRowAnchor.mapValues(sorted),
+            groupIDByCommentID: groupIDByCommentID
         )
+    }
+
+    private static func firstGroupIDByRowKey(in groups: [DiffDisplayGroup]) -> [RowKey: String] {
+        var output: [RowKey: String] = [:]
+        for group in groups {
+            for key in allRowKeys(in: group) where output[key] == nil {
+                output[key] = group.id
+            }
+        }
+        return output
     }
 
     static func visibleRowKeys(in group: DiffDisplayGroup) -> [RowKey] {
@@ -547,12 +564,17 @@ enum ReviewDraftCommentPlacement {
     static func comments(
         matching keys: [RowKey],
         in placement: Result,
+        groupID: String? = nil,
         excludingIDs excludedIDs: Set<String> = []
     ) -> [ReviewDraftComment] {
         var seenIDs = excludedIDs
         var comments: [ReviewDraftComment] = []
         for key in keys {
-            for comment in placement.byRowAnchor[key] ?? [] where seenIDs.insert(comment.id).inserted {
+            for comment in placement.byRowAnchor[key] ?? [] {
+                if let groupID, placement.groupIDByCommentID[comment.id] != groupID {
+                    continue
+                }
+                guard seenIDs.insert(comment.id).inserted else { continue }
                 comments.append(comment)
             }
         }
@@ -594,6 +616,7 @@ enum ReviewDraftCommentRowSegmentation {
             let comments = ReviewDraftCommentPlacement.comments(
                 matching: keys,
                 in: placement,
+                groupID: group.id,
                 excludingIDs: emittedCommentIDs
             )
             emittedCommentIDs.formUnion(comments.map(\.id))

--- a/Alas/Sources/Center/DiffReview/DiffReviewFileSection.swift
+++ b/Alas/Sources/Center/DiffReview/DiffReviewFileSection.swift
@@ -44,6 +44,9 @@ struct DiffReviewFileSection: View {
                 label: file.summary.path
             )
         )
+        .onChange(of: draftCommentDisplaySignature) { _, _ in
+            clearPendingDraft()
+        }
     }
 
     private var header: some View {
@@ -338,8 +341,7 @@ struct DiffReviewFileSection: View {
             HStack(spacing: 6) {
                 Spacer(minLength: 0)
                 Button("Cancel") {
-                    pendingDraftAnchor = nil
-                    pendingDraftBody = ""
+                    clearPendingDraft()
                 }
                 .buttonStyle(.plain)
                 .font(.system(size: 10, weight: .semibold))
@@ -379,10 +381,41 @@ struct DiffReviewFileSection: View {
         guard let pendingDraftAnchor else { return }
         let body = pendingDraftBody.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !body.isEmpty else { return }
+        guard currentDraftRowKeys.contains(ReviewDraftCommentPlacement.RowKey(
+            side: pendingDraftAnchor.side,
+            line: pendingDraftAnchor.line
+        )) else {
+            clearPendingDraft()
+            return
+        }
 
         onSaveDraftComment(pendingDraftAnchor, body)
-        self.pendingDraftAnchor = nil
+        clearPendingDraft()
+    }
+
+    private func clearPendingDraft() {
+        pendingDraftAnchor = nil
         pendingDraftBody = ""
+    }
+
+    private var currentDraftRowKeys: Set<ReviewDraftCommentPlacement.RowKey> {
+        guard let displayModel = file.displayModel else { return [] }
+        return Set(displayModel.groups.flatMap(ReviewDraftCommentPlacement.allRowKeys))
+    }
+
+    private var draftCommentDisplaySignature: String {
+        let groupSignature = file.displayModel?.groups.map { group in
+            let rowSignature = group.rows.map { row in
+                [
+                    row.id,
+                    row.old?.lineNumber.map { "o\($0)" } ?? "o-",
+                    row.new?.lineNumber.map { "n\($0)" } ?? "n-",
+                    "\(row.collapsedRows.count)",
+                ].joined(separator: ":")
+            }.joined(separator: ",")
+            return "\(group.id)[\(rowSignature)]"
+        }.joined(separator: "|") ?? "placeholder"
+        return "\(file.id.rawValue)|\(groupSignature)"
     }
 
     @ViewBuilder
@@ -446,7 +479,7 @@ enum ReviewDraftCommentPlacement {
         _ comments: [ReviewDraftComment],
         in groups: [DiffDisplayGroup]
     ) -> Result {
-        let visibleKeys = Set(groups.flatMap(visibleRowKeys))
+        let visibleKeys = Set(groups.flatMap(allRowKeys))
         var fileLevel: [ReviewDraftComment] = []
         var byRowAnchor: [RowKey: [ReviewDraftComment]] = [:]
 
@@ -471,6 +504,10 @@ enum ReviewDraftCommentPlacement {
         }
     }
 
+    static func allRowKeys(in group: DiffDisplayGroup) -> [RowKey] {
+        group.rows.flatMap(allRowKeys)
+    }
+
     static func visibleRowKeys(in row: DiffDisplayRow) -> [RowKey] {
         var keys: [RowKey] = []
         if let oldLine = row.old?.lineNumber {
@@ -480,6 +517,10 @@ enum ReviewDraftCommentPlacement {
             keys.append(RowKey(side: .new, line: newLine))
         }
         return keys
+    }
+
+    static func allRowKeys(in row: DiffDisplayRow) -> [RowKey] {
+        visibleRowKeys(in: row) + row.collapsedRows.flatMap(allRowKeys)
     }
 
     static func sorted(_ comments: [ReviewDraftComment]) -> [ReviewDraftComment] {
@@ -530,7 +571,7 @@ enum ReviewDraftCommentRowSegmentation {
 
         for row in group.rows {
             bufferedRows.append(row)
-            let keys = ReviewDraftCommentPlacement.visibleRowKeys(in: row)
+            let keys = ReviewDraftCommentPlacement.allRowKeys(in: row)
             let comments = ReviewDraftCommentPlacement.sorted(keys.flatMap { placement.byRowAnchor[$0] ?? [] })
             let showsComposer = pendingKey.map { keys.contains($0) } ?? false
             guard !comments.isEmpty || showsComposer else { continue }

--- a/Alas/Sources/Center/DiffReview/DiffReviewFileSection.swift
+++ b/Alas/Sources/Center/DiffReview/DiffReviewFileSection.swift
@@ -19,6 +19,7 @@ struct DiffReviewFileSection: View {
     var draftCommentActions = ReviewDraftCommentActions()
     var onSelectDraftComment: (ReviewDraftComment) -> Void = { _ in }
     var onSaveDraftComment: (DiffReviewLineAnchor, String) -> Void = { _, _ in }
+    var reviewFeedbackTarget: ReviewFeedbackTarget?
 
     @Environment(\.theme) private var theme
     @State private var pendingDraftAnchor: DiffReviewLineAnchor?
@@ -103,6 +104,18 @@ struct DiffReviewFileSection: View {
         .overlay(Rectangle().fill(theme.color("line")).frame(height: 0.5), alignment: .bottom)
     }
 
+    private var effectiveReviewFeedbackTarget: ReviewFeedbackTarget {
+        if let reviewFeedbackTarget {
+            return reviewFeedbackTarget
+        }
+        return ReviewFeedbackTarget(
+            title: file.summary.path,
+            repositoryPath: nil,
+            providerDescription: nil,
+            sourceDescription: "Local draft comment"
+        )
+    }
+
     @ViewBuilder
     private var fileLevelDraftCommentStack: some View {
         let fileLevel = draftCommentPlacement.fileLevel
@@ -121,6 +134,7 @@ struct DiffReviewFileSection: View {
                         file: file.summary,
                         isFocused: comment.id == focusedDraftCommentID,
                         actions: draftCommentActions,
+                        reviewFeedbackTarget: effectiveReviewFeedbackTarget,
                         onSelect: onSelectDraftComment
                     )
                     .id(DiffReviewDraftCommentTargetID.targetID(commentID: comment.id, fileID: file.id))
@@ -836,6 +850,7 @@ private struct ReviewDraftCommentCard: View {
     let file: DiffReviewFileSummary
     let isFocused: Bool
     let actions: ReviewDraftCommentActions
+    let reviewFeedbackTarget: ReviewFeedbackTarget
     let onSelect: (ReviewDraftComment) -> Void
 
     @Environment(\.theme) private var theme
@@ -1048,12 +1063,7 @@ private struct ReviewDraftCommentCard: View {
 
     private var feedbackBundle: ReviewFeedbackBundle {
         ReviewFeedbackBundle(
-            target: ReviewFeedbackTarget(
-                title: file.path,
-                repositoryPath: nil,
-                providerDescription: nil,
-                sourceDescription: "Local draft comment"
-            ),
+            target: reviewFeedbackTarget,
             comments: [comment]
         )
     }

--- a/Alas/Sources/Center/DiffReview/DiffReviewFileSection.swift
+++ b/Alas/Sources/Center/DiffReview/DiffReviewFileSection.swift
@@ -844,56 +844,18 @@ private struct ReviewDraftCommentCard: View {
 
     var body: some View {
         VStack(alignment: .leading, spacing: 6) {
-            Button {
-                onSelect(comment)
-            } label: {
-                HStack(alignment: .top, spacing: 8) {
-                    RoundedRectangle(cornerRadius: 2)
-                        .fill(statusColor)
-                        .frame(width: 3)
-
-                    VStack(alignment: .leading, spacing: 4) {
-                        HStack(spacing: 6) {
-                            Text("Local draft")
-                                .font(.system(size: 10, weight: .semibold))
-                                .foregroundColor(statusColor)
-
-                            Text(lineDescription)
-                                .font(.system(size: 10))
-                                .foregroundColor(theme.color("fg-faint"))
-
-                            if comment.state == .resolved {
-                                Text("resolved")
-                                    .font(.system(size: 10))
-                                    .foregroundColor(theme.color("fg-faint"))
-                            }
-                        }
-                        .lineLimit(1)
-
-                        if isEditing {
-                            TextEditor(text: $editingBody)
-                                .font(.system(size: 11.5))
-                                .foregroundColor(theme.color("fg"))
-                                .scrollContentBackground(.hidden)
-                                .frame(minHeight: 72)
-                                .background(theme.color("bg-1"))
-                                .clipShape(RoundedRectangle(cornerRadius: 5))
-                                .accessibilityIdentifier("diff-review-draft-comment-editor-\(comment.id)")
-                        } else {
-                            Text(DiffReviewInlineFeedbackMarkdown.render(comment.bodyMarkdown))
-                                .font(.system(size: 11.5))
-                                .foregroundColor(theme.color("fg"))
-                                .fixedSize(horizontal: false, vertical: true)
-                        }
-                    }
-                    .frame(maxWidth: .infinity, alignment: .leading)
-
-                    Spacer(minLength: 0)
+            if isEditing {
+                cardContent
+            } else {
+                Button {
+                    onSelect(comment)
+                } label: {
+                    cardContent
+                        .contentShape(Rectangle())
                 }
-                .contentShape(Rectangle())
+                .buttonStyle(.plain)
+                .accessibilityIdentifier("diff-review-draft-comment-select-\(comment.id)")
             }
-            .buttonStyle(.plain)
-            .accessibilityIdentifier("diff-review-draft-comment-select-\(comment.id)")
 
             actionRow
         }
@@ -912,6 +874,52 @@ private struct ReviewDraftCommentCard: View {
             )
         )
         .background(focusedMarker)
+    }
+
+    private var cardContent: some View {
+        HStack(alignment: .top, spacing: 8) {
+            RoundedRectangle(cornerRadius: 2)
+                .fill(statusColor)
+                .frame(width: 3)
+
+            VStack(alignment: .leading, spacing: 4) {
+                HStack(spacing: 6) {
+                    Text("Local draft")
+                        .font(.system(size: 10, weight: .semibold))
+                        .foregroundColor(statusColor)
+
+                    Text(lineDescription)
+                        .font(.system(size: 10))
+                        .foregroundColor(theme.color("fg-faint"))
+
+                    if comment.state == .resolved {
+                        Text("resolved")
+                            .font(.system(size: 10))
+                            .foregroundColor(theme.color("fg-faint"))
+                    }
+                }
+                .lineLimit(1)
+
+                if isEditing {
+                    TextEditor(text: $editingBody)
+                        .font(.system(size: 11.5))
+                        .foregroundColor(theme.color("fg"))
+                        .scrollContentBackground(.hidden)
+                        .frame(minHeight: 72)
+                        .background(theme.color("bg-1"))
+                        .clipShape(RoundedRectangle(cornerRadius: 5))
+                        .accessibilityIdentifier("diff-review-draft-comment-editor-\(comment.id)")
+                } else {
+                    Text(DiffReviewInlineFeedbackMarkdown.render(comment.bodyMarkdown))
+                        .font(.system(size: 11.5))
+                        .foregroundColor(theme.color("fg"))
+                        .fixedSize(horizontal: false, vertical: true)
+                }
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
+
+            Spacer(minLength: 0)
+        }
     }
 
     @ViewBuilder
@@ -995,25 +1003,30 @@ private struct ReviewDraftCommentCard: View {
             .help("Send")
             .accessibilityIdentifier("diff-review-draft-comment-action-send-\(comment.id)")
         } else {
-            actionButton(id: "send", title: "Send") {
+            actionButton(id: "send", title: "Send", enabled: isEnabled) {
                 guard let target = targets.first else { return }
                 actions.sendToAgent(feedbackBundle, target)
             }
-            .disabled(!isEnabled)
         }
     }
 
-    private func actionButton(id: String, title: String, action: @escaping () -> Void) -> some View {
+    private func actionButton(
+        id: String,
+        title: String,
+        enabled: Bool = true,
+        action: @escaping () -> Void
+    ) -> some View {
         Button(action: action) {
             Text(title)
                 .font(.system(size: 10, weight: .semibold))
-                .foregroundColor(theme.color("fg-muted"))
+                .foregroundColor(enabled ? theme.color("fg-muted") : theme.color("fg-faint"))
                 .padding(.horizontal, 7)
                 .frame(height: 22)
                 .background(theme.color("bg-3"))
                 .clipShape(RoundedRectangle(cornerRadius: 5))
         }
         .buttonStyle(.plain)
+        .disabled(!enabled)
         .help(title)
         .accessibilityIdentifier("diff-review-draft-comment-\(id)-\(comment.id)")
         .accessibilityLabel(title)
@@ -1027,6 +1040,7 @@ private struct ReviewDraftCommentCard: View {
             ReviewDraftCommentActionPressMarker(
                 identifier: "diff-review-draft-comment-action-\(id)-\(comment.id)",
                 label: title,
+                isEnabled: enabled,
                 action: action
             )
         )
@@ -1081,6 +1095,7 @@ private struct ReviewDraftCommentCard: View {
 private struct ReviewDraftCommentActionPressMarker: NSViewRepresentable {
     let identifier: String
     let label: String
+    var isEnabled = true
     let action: () -> Void
 
     func makeNSView(context: Context) -> ReviewDraftCommentActionPressView {
@@ -1088,6 +1103,8 @@ private struct ReviewDraftCommentActionPressMarker: NSViewRepresentable {
         view.setAccessibilityIdentifier(identifier)
         view.setAccessibilityLabel(label)
         view.setAccessibilityRole(.button)
+        view.setAccessibilityEnabled(isEnabled)
+        view.isEnabled = isEnabled
         view.action = action
         return view
     }
@@ -1096,14 +1113,18 @@ private struct ReviewDraftCommentActionPressMarker: NSViewRepresentable {
         view.setAccessibilityIdentifier(identifier)
         view.setAccessibilityLabel(label)
         view.setAccessibilityRole(.button)
+        view.setAccessibilityEnabled(isEnabled)
+        view.isEnabled = isEnabled
         view.action = action
     }
 }
 
 private final class ReviewDraftCommentActionPressView: NSView {
+    var isEnabled = true
     var action: () -> Void = {}
 
     override func accessibilityPerformPress() -> Bool {
+        guard isEnabled else { return false }
         action()
         return true
     }

--- a/Alas/Sources/Center/DiffReview/DiffReviewFileSection.swift
+++ b/Alas/Sources/Center/DiffReview/DiffReviewFileSection.swift
@@ -916,6 +916,7 @@ private struct ReviewDraftCommentCard: View {
         if availability.canEdit
             || availability.canDelete
             || availability.canResolve
+            || availability.canDismiss
             || availability.canCopyPrompt
             || availability.canSendToAgent
         {
@@ -934,6 +935,11 @@ private struct ReviewDraftCommentCard: View {
                 if availability.canResolve {
                     actionButton(id: "resolve", title: "Resolve") {
                         actions.resolve(comment)
+                    }
+                }
+                if availability.canDismiss {
+                    actionButton(id: "dismiss", title: "Dismiss") {
+                        actions.dismiss(comment)
                     }
                 }
                 if availability.canCopyPrompt {
@@ -968,6 +974,13 @@ private struct ReviewDraftCommentCard: View {
             DiffReviewAccessibilityMarker(
                 identifier: "diff-review-draft-comment-action-\(id)-\(comment.id)",
                 label: title
+            )
+        )
+        .background(
+            ReviewDraftCommentActionPressMarker(
+                identifier: "diff-review-draft-comment-action-\(id)-\(comment.id)",
+                label: title,
+                action: action
             )
         )
     }
@@ -1015,6 +1028,37 @@ private struct ReviewDraftCommentCard: View {
         case .dismissed:
             theme.color("fg-muted")
         }
+    }
+}
+
+private struct ReviewDraftCommentActionPressMarker: NSViewRepresentable {
+    let identifier: String
+    let label: String
+    let action: () -> Void
+
+    func makeNSView(context: Context) -> ReviewDraftCommentActionPressView {
+        let view = ReviewDraftCommentActionPressView(frame: .zero)
+        view.setAccessibilityIdentifier(identifier)
+        view.setAccessibilityLabel(label)
+        view.setAccessibilityRole(.button)
+        view.action = action
+        return view
+    }
+
+    func updateNSView(_ view: ReviewDraftCommentActionPressView, context: Context) {
+        view.setAccessibilityIdentifier(identifier)
+        view.setAccessibilityLabel(label)
+        view.setAccessibilityRole(.button)
+        view.action = action
+    }
+}
+
+private final class ReviewDraftCommentActionPressView: NSView {
+    var action: () -> Void = {}
+
+    override func accessibilityPerformPress() -> Bool {
+        action()
+        return true
     }
 }
 

--- a/Alas/Sources/Center/DiffReview/DiffReviewModels.swift
+++ b/Alas/Sources/Center/DiffReview/DiffReviewModels.swift
@@ -8,7 +8,7 @@ struct DiffReviewFileID: Codable, Equatable, Hashable, Identifiable, Sendable {
     var rawValue: String { "\(namespace):\(path)" }
 }
 
-enum DiffReviewInlineFeedbackSide: String, Codable, Equatable, Sendable {
+enum DiffReviewInlineFeedbackSide: String, Codable, Equatable, Hashable, Sendable {
     case old
     case new
     case unknown

--- a/Alas/Sources/Center/DiffReview/DiffReviewModels.swift
+++ b/Alas/Sources/Center/DiffReview/DiffReviewModels.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-struct DiffReviewFileID: Codable, Equatable, Hashable, Identifiable {
+struct DiffReviewFileID: Codable, Equatable, Hashable, Identifiable, Sendable {
     let namespace: String
     let path: String
 

--- a/Alas/Sources/Center/DiffReview/DiffReviewSurface.swift
+++ b/Alas/Sources/Center/DiffReview/DiffReviewSurface.swift
@@ -98,7 +98,7 @@ struct DiffReviewSurface: View {
     }
 
     private var shouldShowReviewSummaryRail: Bool {
-        showsDraftSummaryRail || allDraftComments.contains { $0.state != .dismissed }
+        showsDraftSummaryRail || !allDraftComments.isEmpty
     }
 
     private var reviewFeedbackBundle: ReviewFeedbackBundle {

--- a/Alas/Sources/Center/DiffReview/DiffReviewSurface.swift
+++ b/Alas/Sources/Center/DiffReview/DiffReviewSurface.swift
@@ -12,6 +12,7 @@ struct DiffReviewSurface: View {
     let codeFontSize: CGFloat
     var showsSourceBadges: Bool = true
     var showsRailDisplayControls: Bool = false
+    var showsDraftSummaryRail: Bool = false
     var lspContextForFile: (DiffReviewFileSectionModel) -> DiffPaneLSPContext? = { _ in nil }
     var inlineFeedbackByFileID: [DiffReviewFileID: [DiffReviewInlineFeedback]] = [:]
     var focusedFeedbackID: String? = nil
@@ -45,6 +46,7 @@ struct DiffReviewSurface: View {
         codeFontSize: CGFloat,
         showsSourceBadges: Bool = true,
         showsRailDisplayControls: Bool = false,
+        showsDraftSummaryRail: Bool = false,
         lspContextForFile: @escaping (DiffReviewFileSectionModel) -> DiffPaneLSPContext? = { _ in nil },
         inlineFeedbackByFileID: [DiffReviewFileID: [DiffReviewInlineFeedback]] = [:],
         focusedFeedbackID: String? = nil,
@@ -68,6 +70,7 @@ struct DiffReviewSurface: View {
         self.codeFontSize = codeFontSize
         self.showsSourceBadges = showsSourceBadges
         self.showsRailDisplayControls = showsRailDisplayControls
+        self.showsDraftSummaryRail = showsDraftSummaryRail
         self.lspContextForFile = lspContextForFile
         self.inlineFeedbackByFileID = inlineFeedbackByFileID
         self.focusedFeedbackID = focusedFeedbackID
@@ -95,7 +98,7 @@ struct DiffReviewSurface: View {
     }
 
     private var shouldShowReviewSummaryRail: Bool {
-        allDraftComments.contains { $0.state != .dismissed }
+        showsDraftSummaryRail || allDraftComments.contains { $0.state != .dismissed }
     }
 
     private var reviewFeedbackBundle: ReviewFeedbackBundle {

--- a/Alas/Sources/Center/DiffReview/DiffReviewSurface.swift
+++ b/Alas/Sources/Center/DiffReview/DiffReviewSurface.swift
@@ -280,7 +280,8 @@ struct DiffReviewSurface: View {
                 onSelectDraftComment: onSelectDraftComment,
                 onSaveDraftComment: { anchor, body in
                     onSaveDraftComment(file.id, anchor, body)
-                }
+                },
+                reviewFeedbackTarget: effectiveReviewFeedbackTarget
             )
         } else {
             DiffReviewFileSectionPlaceholder(

--- a/Alas/Sources/Center/DiffReview/DiffReviewSurface.swift
+++ b/Alas/Sources/Center/DiffReview/DiffReviewSurface.swift
@@ -17,6 +17,11 @@ struct DiffReviewSurface: View {
     var inlineFeedbackScrollCommand: DiffReviewInlineFeedbackScrollCommand? = nil
     var inlineFeedbackActions = DiffReviewInlineFeedbackActions()
     var onSelectInlineFeedback: (DiffReviewInlineFeedback) -> Void = { _ in }
+    var draftCommentsByFileID: [DiffReviewFileID: [ReviewDraftComment]] = [:]
+    var focusedDraftCommentID: String? = nil
+    var draftCommentActions = ReviewDraftCommentActions()
+    var onSelectDraftComment: (ReviewDraftComment) -> Void = { _ in }
+    var onSaveDraftComment: (DiffReviewLineAnchor, String) -> Void = { _, _ in }
 
     @Environment(\.theme) private var theme
     @State private var programmaticScroll = DiffReviewProgrammaticScrollController()
@@ -133,12 +138,15 @@ struct DiffReviewSurface: View {
     @ViewBuilder
     private func fileSection(_ file: DiffReviewFileSectionModel, isRendered: Bool) -> some View {
         let inlineFeedback = inlineFeedbackByFileID[file.id] ?? []
+        let draftComments = draftCommentsByFileID[file.id] ?? []
         if isRendered {
             DiffReviewFileSection(
                 file: file,
                 inlineFeedback: inlineFeedback,
                 focusedFeedbackID: focusedFeedbackID,
                 inlineFeedbackScrollTargetID: inlineFeedbackScrollTargetID(for: file.id),
+                draftComments: draftComments,
+                focusedDraftCommentID: focusedDraftCommentID,
                 layoutMode: $layoutMode,
                 wrapLines: $wrapLines,
                 showWhitespace: $showWhitespace,
@@ -147,14 +155,18 @@ struct DiffReviewSurface: View {
                 showsSourceBadge: showsSourceBadges,
                 lspContext: lspContextForFile(file),
                 inlineFeedbackActions: inlineFeedbackActions,
-                onSelectInlineFeedback: onSelectInlineFeedback
+                onSelectInlineFeedback: onSelectInlineFeedback,
+                draftCommentActions: draftCommentActions,
+                onSelectDraftComment: onSelectDraftComment,
+                onSaveDraftComment: onSaveDraftComment
             )
         } else {
             DiffReviewFileSectionPlaceholder(
                 file: file,
                 estimatedHeight: DiffReviewFileSectionHeightEstimator.estimatedHeight(
                     for: file,
-                    inlineFeedback: inlineFeedback
+                    inlineFeedback: inlineFeedback,
+                    draftComments: draftComments
                 ),
                 showsSourceBadge: showsSourceBadges,
                 codeFontFamily: codeFontFamily,
@@ -362,9 +374,20 @@ extension DiffReviewFileSectionHeightEstimator {
         for file: DiffReviewFileSectionModel,
         inlineFeedback: [DiffReviewInlineFeedback]
     ) -> CGFloat {
+        estimatedHeight(for: file, inlineFeedback: inlineFeedback, draftComments: [])
+    }
+
+    static func estimatedHeight(
+        for file: DiffReviewFileSectionModel,
+        inlineFeedback: [DiffReviewInlineFeedback],
+        draftComments: [ReviewDraftComment]
+    ) -> CGFloat {
         guard let displayModel = file.displayModel else {
             return estimatedHeight(for: file)
                 + DiffReviewInlineFeedbackDisplayPolicy.estimatedHeight(for: inlineFeedback)
+                + ReviewDraftCommentDisplayPolicy.estimatedHeight(
+                    for: ReviewDraftCommentPlacement.position(draftComments, in: []).fileLevel
+                )
         }
 
         let placement = DiffReviewInlineFeedbackPlacement.position(inlineFeedback, in: displayModel.groups)
@@ -372,8 +395,17 @@ extension DiffReviewFileSectionHeightEstimator {
         let groupHeights = placement.byGroupID.values.reduce(CGFloat(0)) { total, groupFeedback in
             total + DiffReviewInlineFeedbackDisplayPolicy.estimatedHeight(for: groupFeedback)
         }
+        let draftPlacement = ReviewDraftCommentPlacement.position(draftComments, in: displayModel.groups)
+        let draftFileLevelHeight = ReviewDraftCommentDisplayPolicy.estimatedHeight(for: draftPlacement.fileLevel)
+        let draftGroupHeights = displayModel.groups.reduce(CGFloat(0)) { total, group in
+            let rowKeys = ReviewDraftCommentPlacement.visibleRowKeys(in: group)
+            let groupDraftComments = ReviewDraftCommentPlacement.sorted(
+                rowKeys.flatMap { draftPlacement.byRowAnchor[$0] ?? [] }
+            )
+            return total + ReviewDraftCommentDisplayPolicy.estimatedHeight(for: groupDraftComments)
+        }
 
-        return estimatedHeight(for: file) + fileLevelHeight + groupHeights
+        return estimatedHeight(for: file) + fileLevelHeight + groupHeights + draftFileLevelHeight + draftGroupHeights
     }
 }
 

--- a/Alas/Sources/Center/DiffReview/DiffReviewSurface.swift
+++ b/Alas/Sources/Center/DiffReview/DiffReviewSurface.swift
@@ -4,6 +4,7 @@ struct DiffReviewSurface: View {
     let session: DiffReviewLoadedSession
     @Binding var selectedFileID: DiffReviewFileID?
     @Binding var railCollapsed: Bool
+    @Binding var reviewSummaryCollapsed: Bool
     @Binding var layoutMode: DiffLayoutMode
     @Binding var wrapLines: Bool
     @Binding var showWhitespace: Bool
@@ -32,8 +33,95 @@ struct DiffReviewSurface: View {
 
     private static let scrollCoordinateSpace = "diff-review-scroll"
 
+    init(
+        session: DiffReviewLoadedSession,
+        selectedFileID: Binding<DiffReviewFileID?>,
+        railCollapsed: Binding<Bool>,
+        reviewSummaryCollapsed: Binding<Bool> = .constant(false),
+        layoutMode: Binding<DiffLayoutMode>,
+        wrapLines: Binding<Bool>,
+        showWhitespace: Binding<Bool>,
+        codeFontFamily: String,
+        codeFontSize: CGFloat,
+        showsSourceBadges: Bool = true,
+        showsRailDisplayControls: Bool = false,
+        lspContextForFile: @escaping (DiffReviewFileSectionModel) -> DiffPaneLSPContext? = { _ in nil },
+        inlineFeedbackByFileID: [DiffReviewFileID: [DiffReviewInlineFeedback]] = [:],
+        focusedFeedbackID: String? = nil,
+        inlineFeedbackScrollCommand: DiffReviewInlineFeedbackScrollCommand? = nil,
+        inlineFeedbackActions: DiffReviewInlineFeedbackActions = DiffReviewInlineFeedbackActions(),
+        onSelectInlineFeedback: @escaping (DiffReviewInlineFeedback) -> Void = { _ in },
+        draftCommentsByFileID: [DiffReviewFileID: [ReviewDraftComment]] = [:],
+        focusedDraftCommentID: String? = nil,
+        draftCommentActions: ReviewDraftCommentActions = ReviewDraftCommentActions(),
+        onSelectDraftComment: @escaping (ReviewDraftComment) -> Void = { _ in },
+        onSaveDraftComment: @escaping (DiffReviewLineAnchor, String) -> Void = { _, _ in }
+    ) {
+        self.session = session
+        self._selectedFileID = selectedFileID
+        self._railCollapsed = railCollapsed
+        self._reviewSummaryCollapsed = reviewSummaryCollapsed
+        self._layoutMode = layoutMode
+        self._wrapLines = wrapLines
+        self._showWhitespace = showWhitespace
+        self.codeFontFamily = codeFontFamily
+        self.codeFontSize = codeFontSize
+        self.showsSourceBadges = showsSourceBadges
+        self.showsRailDisplayControls = showsRailDisplayControls
+        self.lspContextForFile = lspContextForFile
+        self.inlineFeedbackByFileID = inlineFeedbackByFileID
+        self.focusedFeedbackID = focusedFeedbackID
+        self.inlineFeedbackScrollCommand = inlineFeedbackScrollCommand
+        self.inlineFeedbackActions = inlineFeedbackActions
+        self.onSelectInlineFeedback = onSelectInlineFeedback
+        self.draftCommentsByFileID = draftCommentsByFileID
+        self.focusedDraftCommentID = focusedDraftCommentID
+        self.draftCommentActions = draftCommentActions
+        self.onSelectDraftComment = onSelectDraftComment
+        self.onSaveDraftComment = onSaveDraftComment
+    }
+
     private var fileIDs: [DiffReviewFileID] {
         session.summary.files.map(\.id)
+    }
+
+    private var allDraftComments: [ReviewDraftComment] {
+        let commentsForSessionFiles = session.summary.files.flatMap { draftCommentsByFileID[$0.id] ?? [] }
+        let sessionFileIDs = Set(session.summary.files.map(\.id))
+        let orphanComments = draftCommentsByFileID
+            .filter { !sessionFileIDs.contains($0.key) }
+            .flatMap(\.value)
+        return ReviewDraftCommentPlacement.sorted(commentsForSessionFiles + orphanComments)
+    }
+
+    private var shouldShowReviewSummaryRail: Bool {
+        allDraftComments.contains { $0.state != .dismissed }
+    }
+
+    private var reviewFeedbackBundle: ReviewFeedbackBundle {
+        ReviewFeedbackBundle(target: reviewFeedbackTarget, comments: allDraftComments)
+    }
+
+    private var reviewFeedbackTarget: ReviewFeedbackTarget {
+        ReviewFeedbackTarget(
+            title: reviewFeedbackTargetTitle,
+            repositoryPath: nil,
+            providerDescription: nil,
+            sourceDescription: reviewFeedbackSourceDescription
+        )
+    }
+
+    private var reviewFeedbackTargetTitle: String {
+        if session.summary.files.count == 1, let path = session.summary.files.first?.path {
+            return path
+        }
+        return "\(session.summary.fileCount) changed \(session.summary.fileCount == 1 ? "file" : "files")"
+    }
+
+    private var reviewFeedbackSourceDescription: String {
+        let sources = Set(session.summary.files.map { $0.groupTitle ?? $0.groupID ?? $0.namespace })
+        let sortedSources = sources.sorted { $0.localizedStandardCompare($1) == .orderedAscending }
+        return sortedSources.isEmpty ? "Diff review" : sortedSources.joined(separator: ", ")
     }
 
     private var fileSetKey: String {
@@ -77,6 +165,16 @@ struct DiffReviewSurface: View {
                 onSelectFile: scrollToFile
             )
             mainReviewStream(session, firstFileID: firstFileID)
+            if shouldShowReviewSummaryRail {
+                ReviewDraftSummaryRail(
+                    comments: allDraftComments,
+                    bundle: reviewFeedbackBundle,
+                    collapsed: $reviewSummaryCollapsed,
+                    focusedDraftCommentID: focusedDraftCommentID,
+                    draftCommentActions: draftCommentActions,
+                    onSelectDraftComment: onSelectDraftComment
+                )
+            }
         }
     }
 

--- a/Alas/Sources/Center/DiffReview/DiffReviewSurface.swift
+++ b/Alas/Sources/Center/DiffReview/DiffReviewSurface.swift
@@ -401,7 +401,8 @@ extension DiffReviewFileSectionHeightEstimator {
             let rowKeys = ReviewDraftCommentPlacement.allRowKeys(in: group)
             let groupDraftComments = ReviewDraftCommentPlacement.comments(
                 matching: rowKeys,
-                in: draftPlacement
+                in: draftPlacement,
+                groupID: group.id
             )
             return total + ReviewDraftCommentDisplayPolicy.estimatedHeight(for: groupDraftComments)
         }

--- a/Alas/Sources/Center/DiffReview/DiffReviewSurface.swift
+++ b/Alas/Sources/Center/DiffReview/DiffReviewSurface.swift
@@ -19,11 +19,13 @@ struct DiffReviewSurface: View {
     var inlineFeedbackScrollCommand: DiffReviewInlineFeedbackScrollCommand? = nil
     var inlineFeedbackActions = DiffReviewInlineFeedbackActions()
     var onSelectInlineFeedback: (DiffReviewInlineFeedback) -> Void = { _ in }
+    var reviewFeedbackTargetOverride: ReviewFeedbackTarget? = nil
     var draftCommentsByFileID: [DiffReviewFileID: [ReviewDraftComment]] = [:]
     var focusedDraftCommentID: String? = nil
+    var draftCommentScrollCommand: DiffReviewDraftCommentScrollCommand? = nil
     var draftCommentActions = ReviewDraftCommentActions()
     var onSelectDraftComment: (ReviewDraftComment) -> Void = { _ in }
-    var onSaveDraftComment: (DiffReviewLineAnchor, String) -> Void = { _, _ in }
+    var onSaveDraftComment: (DiffReviewFileID, DiffReviewLineAnchor, String) -> Void = { _, _, _ in }
 
     @Environment(\.theme) private var theme
     @State private var programmaticScroll = DiffReviewProgrammaticScrollController()
@@ -53,11 +55,13 @@ struct DiffReviewSurface: View {
         inlineFeedbackScrollCommand: DiffReviewInlineFeedbackScrollCommand? = nil,
         inlineFeedbackActions: DiffReviewInlineFeedbackActions = DiffReviewInlineFeedbackActions(),
         onSelectInlineFeedback: @escaping (DiffReviewInlineFeedback) -> Void = { _ in },
+        reviewFeedbackTarget: ReviewFeedbackTarget? = nil,
         draftCommentsByFileID: [DiffReviewFileID: [ReviewDraftComment]] = [:],
         focusedDraftCommentID: String? = nil,
+        draftCommentScrollCommand: DiffReviewDraftCommentScrollCommand? = nil,
         draftCommentActions: ReviewDraftCommentActions = ReviewDraftCommentActions(),
         onSelectDraftComment: @escaping (ReviewDraftComment) -> Void = { _ in },
-        onSaveDraftComment: @escaping (DiffReviewLineAnchor, String) -> Void = { _, _ in }
+        onSaveDraftComment: @escaping (DiffReviewFileID, DiffReviewLineAnchor, String) -> Void = { _, _, _ in }
     ) {
         self.session = session
         self._selectedFileID = selectedFileID
@@ -77,8 +81,10 @@ struct DiffReviewSurface: View {
         self.inlineFeedbackScrollCommand = inlineFeedbackScrollCommand
         self.inlineFeedbackActions = inlineFeedbackActions
         self.onSelectInlineFeedback = onSelectInlineFeedback
+        self.reviewFeedbackTargetOverride = reviewFeedbackTarget
         self.draftCommentsByFileID = draftCommentsByFileID
         self.focusedDraftCommentID = focusedDraftCommentID
+        self.draftCommentScrollCommand = draftCommentScrollCommand
         self.draftCommentActions = draftCommentActions
         self.onSelectDraftComment = onSelectDraftComment
         self.onSaveDraftComment = onSaveDraftComment
@@ -102,11 +108,14 @@ struct DiffReviewSurface: View {
     }
 
     private var reviewFeedbackBundle: ReviewFeedbackBundle {
-        ReviewFeedbackBundle(target: reviewFeedbackTarget, comments: allDraftComments)
+        ReviewFeedbackBundle(target: effectiveReviewFeedbackTarget, comments: allDraftComments)
     }
 
-    private var reviewFeedbackTarget: ReviewFeedbackTarget {
-        ReviewFeedbackTarget(
+    private var effectiveReviewFeedbackTarget: ReviewFeedbackTarget {
+        if let reviewFeedbackTargetOverride {
+            return reviewFeedbackTargetOverride
+        }
+        return ReviewFeedbackTarget(
             title: reviewFeedbackTargetTitle,
             repositoryPath: nil,
             providerDescription: nil,
@@ -222,14 +231,24 @@ struct DiffReviewSurface: View {
                             consumed: command
                         )
                     }
-                    guard let command = inlineFeedbackScrollCommand else { return }
-                    Task { @MainActor in
-                        scrollToInlineFeedback(command, scrollProxy: scrollProxy, animated: false)
+                    if let command = inlineFeedbackScrollCommand {
+                        Task { @MainActor in
+                            scrollToInlineFeedback(command, scrollProxy: scrollProxy, animated: false)
+                        }
+                    }
+                    if let draftCommand = draftCommentScrollCommand {
+                        Task { @MainActor in
+                            scrollToDraftComment(draftCommand, scrollProxy: scrollProxy, animated: false)
+                        }
                     }
                 }
                 .onChange(of: inlineFeedbackScrollCommand) { _, command in
                     guard let command else { return }
                     scrollToInlineFeedback(command, scrollProxy: scrollProxy, animated: true)
+                }
+                .onChange(of: draftCommentScrollCommand) { _, command in
+                    guard let command else { return }
+                    scrollToDraftComment(command, scrollProxy: scrollProxy, animated: true)
                 }
             }
         }
@@ -259,7 +278,9 @@ struct DiffReviewSurface: View {
                 onSelectInlineFeedback: onSelectInlineFeedback,
                 draftCommentActions: draftCommentActions,
                 onSelectDraftComment: onSelectDraftComment,
-                onSaveDraftComment: onSaveDraftComment
+                onSaveDraftComment: { anchor, body in
+                    onSaveDraftComment(file.id, anchor, body)
+                }
             )
         } else {
             DiffReviewFileSectionPlaceholder(
@@ -284,8 +305,31 @@ struct DiffReviewSurface: View {
         return command.feedbackID
     }
 
+    private func draftCommentScrollTargetID(for fileID: DiffReviewFileID) -> String? {
+        guard let command = draftCommentScrollCommand,
+              command.fileID == fileID
+        else { return nil }
+
+        return command.commentID
+    }
+
     private func scrollToInlineFeedback(
         _ command: DiffReviewInlineFeedbackScrollCommand,
+        scrollProxy: ScrollViewProxy,
+        animated: Bool
+    ) {
+        selectedFileID = command.fileID
+        if animated {
+            withAnimation(.easeInOut(duration: 0.18)) {
+                scrollProxy.scrollTo(command.targetID, anchor: .center)
+            }
+        } else {
+            scrollProxy.scrollTo(command.targetID, anchor: .center)
+        }
+    }
+
+    private func scrollToDraftComment(
+        _ command: DiffReviewDraftCommentScrollCommand,
         scrollProxy: ScrollViewProxy,
         animated: Bool
     ) {
@@ -307,7 +351,8 @@ struct DiffReviewSurface: View {
             selectedFileID: selectedFileID,
             programmaticTarget: DiffReviewSurfaceSelectionSync.renderedTargetFileID(
                 fileScrollTarget: programmaticScroll.target,
-                inlineFeedbackScrollCommand: inlineFeedbackScrollCommand
+                inlineFeedbackScrollCommand: inlineFeedbackScrollCommand,
+                draftCommentScrollCommand: draftCommentScrollCommand
             ),
             firstFileID: firstFileID
         )
@@ -351,7 +396,8 @@ struct DiffReviewSurface: View {
             selectedFileID: selectedFileID,
             programmaticTarget: DiffReviewSurfaceSelectionSync.renderedTargetFileID(
                 fileScrollTarget: programmaticScroll.target,
-                inlineFeedbackScrollCommand: inlineFeedbackScrollCommand
+                inlineFeedbackScrollCommand: inlineFeedbackScrollCommand,
+                draftCommentScrollCommand: draftCommentScrollCommand
             ),
             firstFileID: firstFileID
         )
@@ -428,7 +474,19 @@ enum DiffReviewSurfaceSelectionSync {
         fileScrollTarget: DiffReviewFileID?,
         inlineFeedbackScrollCommand: DiffReviewInlineFeedbackScrollCommand?
     ) -> DiffReviewFileID? {
-        inlineFeedbackScrollCommand?.fileID ?? fileScrollTarget
+        renderedTargetFileID(
+            fileScrollTarget: fileScrollTarget,
+            inlineFeedbackScrollCommand: inlineFeedbackScrollCommand,
+            draftCommentScrollCommand: nil
+        )
+    }
+
+    static func renderedTargetFileID(
+        fileScrollTarget: DiffReviewFileID?,
+        inlineFeedbackScrollCommand: DiffReviewInlineFeedbackScrollCommand?,
+        draftCommentScrollCommand: DiffReviewDraftCommentScrollCommand?
+    ) -> DiffReviewFileID? {
+        draftCommentScrollCommand?.fileID ?? inlineFeedbackScrollCommand?.fileID ?? fileScrollTarget
     }
 
     static func synchronize(

--- a/Alas/Sources/Center/DiffReview/DiffReviewSurface.swift
+++ b/Alas/Sources/Center/DiffReview/DiffReviewSurface.swift
@@ -398,7 +398,7 @@ extension DiffReviewFileSectionHeightEstimator {
         let draftPlacement = ReviewDraftCommentPlacement.position(draftComments, in: displayModel.groups)
         let draftFileLevelHeight = ReviewDraftCommentDisplayPolicy.estimatedHeight(for: draftPlacement.fileLevel)
         let draftGroupHeights = displayModel.groups.reduce(CGFloat(0)) { total, group in
-            let rowKeys = ReviewDraftCommentPlacement.visibleRowKeys(in: group)
+            let rowKeys = ReviewDraftCommentPlacement.allRowKeys(in: group)
             let groupDraftComments = ReviewDraftCommentPlacement.sorted(
                 rowKeys.flatMap { draftPlacement.byRowAnchor[$0] ?? [] }
             )

--- a/Alas/Sources/Center/DiffReview/DiffReviewSurface.swift
+++ b/Alas/Sources/Center/DiffReview/DiffReviewSurface.swift
@@ -399,8 +399,9 @@ extension DiffReviewFileSectionHeightEstimator {
         let draftFileLevelHeight = ReviewDraftCommentDisplayPolicy.estimatedHeight(for: draftPlacement.fileLevel)
         let draftGroupHeights = displayModel.groups.reduce(CGFloat(0)) { total, group in
             let rowKeys = ReviewDraftCommentPlacement.allRowKeys(in: group)
-            let groupDraftComments = ReviewDraftCommentPlacement.sorted(
-                rowKeys.flatMap { draftPlacement.byRowAnchor[$0] ?? [] }
+            let groupDraftComments = ReviewDraftCommentPlacement.comments(
+                matching: rowKeys,
+                in: draftPlacement
             )
             return total + ReviewDraftCommentDisplayPolicy.estimatedHeight(for: groupDraftComments)
         }

--- a/Alas/Sources/Center/ReviewChanges/ReviewChangesTabView.swift
+++ b/Alas/Sources/Center/ReviewChanges/ReviewChangesTabView.swift
@@ -70,6 +70,12 @@ struct ReviewChangesTabView: View {
     @State private var loadError: String?
     @State private var selectedFileID: ReviewChangesFileID?
     @State private var railCollapsed = false
+    @State private var reviewSummaryCollapsed = false
+    @State private var draftCommentController: ReviewDraftCommentController?
+    @State private var loadedDraftSessionID: ReviewDraftSessionID?
+    @State private var focusedDraftCommentID: String?
+    @State private var draftCommentScrollCommand: DiffReviewDraftCommentScrollCommand?
+    @State private var draftCommentScrollController = DiffReviewDraftCommentScrollController()
     @State private var activeLoadKey: String?
     @State private var activeLoadID = UUID()
 
@@ -84,6 +90,21 @@ struct ReviewChangesTabView: View {
         .task(id: loadKey) {
             await loadSession()
         }
+        .task(id: reviewDraftSessionID.rawValue) {
+            loadDraftCommentController()
+        }
+    }
+
+    static func reviewDraftSessionID(worktree: Worktree) -> ReviewDraftSessionID {
+        ReviewDraftSessionID.localChanges(
+            worktreeID: worktree.id,
+            worktreePath: worktree.path,
+            scope: .all
+        )
+    }
+
+    private var reviewDraftSessionID: ReviewDraftSessionID {
+        Self.reviewDraftSessionID(worktree: worktree)
     }
 
     private var loadKey: String {
@@ -206,9 +227,26 @@ struct ReviewChangesTabView: View {
             codeFontFamily: appState.config.code.fontFamily,
             codeFontSize: CGFloat(appState.config.code.fontSize),
             showsSourceBadges: true,
+            showsDraftSummaryRail: true,
             lspContextForFile: { file in
                 makeLSPContext(relativePath: file.summary.path)
-            }
+            },
+            reviewFeedbackTarget: reviewFeedbackTarget,
+            draftCommentsByFileID: ReviewDraftCommentGrouping.commentsByFileID(draftCommentController?.comments ?? []),
+            focusedDraftCommentID: focusedDraftCommentID,
+            draftCommentScrollCommand: draftCommentScrollCommand,
+            draftCommentActions: draftCommentActions(),
+            onSelectDraftComment: selectDraftComment,
+            onSaveDraftComment: saveDraftComment
+        )
+    }
+
+    private var reviewFeedbackTarget: ReviewFeedbackTarget {
+        ReviewFeedbackTarget(
+            title: "Review Changes",
+            repositoryPath: worktree.path.path,
+            providerDescription: nil,
+            sourceDescription: "Review Changes"
         )
     }
 
@@ -312,6 +350,7 @@ struct ReviewChangesTabView: View {
             selectedFileID = selectedFileID.flatMap { selected in
                 loaded.summary.files.contains { $0.id == selected } ? selected : loaded.summary.files.first?.id
             } ?? loaded.summary.files.first?.id
+            loadDraftCommentController()
         } catch is CancellationError {
         } catch {
             guard
@@ -324,5 +363,48 @@ struct ReviewChangesTabView: View {
 
     private var diffPreferences: DiffPreferenceBindings {
         DiffPreferenceBindings(appState: appState)
+    }
+
+    private var reviewFeedbackAgentSender: ReviewFeedbackAgentSender {
+        ReviewFeedbackAgentSender.production(appState: appState, worktreeID: worktree.id)
+    }
+
+    private func loadDraftCommentController() {
+        let sessionID = reviewDraftSessionID
+        if loadedDraftSessionID != sessionID {
+            draftCommentController = ReviewDraftCommentController(sessionID: sessionID)
+            loadedDraftSessionID = sessionID
+            focusedDraftCommentID = nil
+            draftCommentScrollCommand = nil
+        }
+        do {
+            try draftCommentController?.load()
+        } catch {
+            // The controller keeps the non-blocking error state for the review rail.
+        }
+    }
+
+    private func draftCommentActions() -> ReviewDraftCommentActions {
+        ReviewDraftWorkspaceActions.make(
+            controller: draftCommentController,
+            sender: reviewFeedbackAgentSender
+        )
+    }
+
+    private func selectDraftComment(_ comment: ReviewDraftComment) {
+        focusedDraftCommentID = comment.id
+        selectedFileID = comment.fileID
+        draftCommentScrollCommand = draftCommentScrollController.command(
+            commentID: comment.id,
+            fileID: comment.fileID
+        )
+    }
+
+    private func saveDraftComment(fileID: DiffReviewFileID, anchor: DiffReviewLineAnchor, body: String) {
+        do {
+            try draftCommentController?.add(anchor: anchor, fileID: fileID, bodyMarkdown: body)
+        } catch {
+            // The controller keeps the non-blocking error state for the review rail.
+        }
     }
 }

--- a/Alas/Sources/Center/ReviewChanges/ReviewChangesTabView.swift
+++ b/Alas/Sources/Center/ReviewChanges/ReviewChangesTabView.swift
@@ -221,6 +221,7 @@ struct ReviewChangesTabView: View {
             session: session,
             selectedFileID: $selectedFileID,
             railCollapsed: $railCollapsed,
+            reviewSummaryCollapsed: $reviewSummaryCollapsed,
             layoutMode: diffPreferences.layoutMode,
             wrapLines: diffPreferences.wrapLines,
             showWhitespace: diffPreferences.showWhitespace,

--- a/Alas/Sources/Center/ReviewEvidence/ReviewEvidenceTabView.swift
+++ b/Alas/Sources/Center/ReviewEvidence/ReviewEvidenceTabView.swift
@@ -85,6 +85,12 @@ struct ReviewEvidenceTabView: View {
     @State private var focusedFeedbackID: String?
     @State private var inlineFeedbackScrollCommand: DiffReviewInlineFeedbackScrollCommand?
     @State private var inlineFeedbackScrollController = DiffReviewInlineFeedbackScrollController()
+    @State private var reviewSummaryCollapsed = false
+    @State private var draftCommentController: ReviewDraftCommentController?
+    @State private var loadedDraftSessionID: ReviewDraftSessionID?
+    @State private var focusedDraftCommentID: String?
+    @State private var draftCommentScrollCommand: DiffReviewDraftCommentScrollCommand?
+    @State private var draftCommentScrollController = DiffReviewDraftCommentScrollController()
 
     @Environment(\.theme) private var theme
 
@@ -184,9 +190,38 @@ struct ReviewEvidenceTabView: View {
         .task(id: loadKey) {
             await loadEvidence()
         }
+        .task(id: reviewDraftSessionID.rawValue) {
+            loadDraftCommentController()
+        }
         .onChange(of: tabState.selectedSection) { _, section in
             applySelectedSection(section, loadDetail: true)
         }
+    }
+
+    static func reviewDraftSessionID(
+        worktreeID: String,
+        provider: CodeHostKind,
+        host: String,
+        repositorySlug: String,
+        number: Int
+    ) -> ReviewDraftSessionID {
+        ReviewDraftSessionID.reviewRequest(
+            worktreeID: worktreeID,
+            provider: provider,
+            host: host,
+            repositorySlug: repositorySlug,
+            number: number
+        )
+    }
+
+    private var reviewDraftSessionID: ReviewDraftSessionID {
+        Self.reviewDraftSessionID(
+            worktreeID: tabState.worktreeId,
+            provider: snapshotProvider,
+            host: snapshot?.remote?.host ?? tabState.url.host ?? "",
+            repositorySlug: snapshot?.remote?.repositorySlug ?? tabState.repositorySlug,
+            number: snapshot?.reviewRequest?.number ?? tabState.number
+        )
     }
 
     @ViewBuilder
@@ -384,6 +419,7 @@ struct ReviewEvidenceTabView: View {
                     session: session,
                     selectedFileID: $selectedFileID,
                     railCollapsed: $railCollapsed,
+                    reviewSummaryCollapsed: $reviewSummaryCollapsed,
                     layoutMode: diffPreferences.layoutMode,
                     wrapLines: diffPreferences.wrapLines,
                     showWhitespace: diffPreferences.showWhitespace,
@@ -391,11 +427,21 @@ struct ReviewEvidenceTabView: View {
                     codeFontSize: CGFloat(appState.config.code.fontSize),
                     showsSourceBadges: true,
                     showsRailDisplayControls: true,
+                    showsDraftSummaryRail: true,
                     inlineFeedbackByFileID: inlineFeedbackByFileID,
                     focusedFeedbackID: focusedFeedbackID,
                     inlineFeedbackScrollCommand: inlineFeedbackScrollCommand,
                     inlineFeedbackActions: inlineFeedbackActions(),
-                    onSelectInlineFeedback: selectInlineFeedback
+                    onSelectInlineFeedback: selectInlineFeedback,
+                    reviewFeedbackTarget: reviewFeedbackTarget,
+                    draftCommentsByFileID: ReviewDraftCommentGrouping.commentsByFileID(draftCommentController?.comments ?? []),
+                    focusedDraftCommentID: focusedDraftCommentID,
+                    draftCommentScrollCommand: draftCommentScrollCommand,
+                    draftCommentActions: draftCommentActions(),
+                    onSelectDraftComment: selectDraftComment,
+                    onSaveDraftComment: { fileID, anchor, body in
+                        saveDraftComment(fileID: fileID, anchor: anchor, body: body)
+                    }
                 )
             } else {
                 filesEmptyState
@@ -620,6 +666,8 @@ struct ReviewEvidenceTabView: View {
         focusedFeedbackID = nil
         inlineFeedbackScrollCommand = nil
         inlineFeedbackScrollController = DiffReviewInlineFeedbackScrollController()
+        focusedDraftCommentID = nil
+        draftCommentScrollCommand = nil
         let loaded = ReviewEvidenceModel(
             snapshot: snapshot,
             provider: provider,
@@ -647,6 +695,7 @@ struct ReviewEvidenceTabView: View {
             selectedItemID = loaded.selectedItemID
         }
         persistSelection(section: selectedSection, itemID: selectedItemID)
+        loadDraftCommentController()
         guard selectedItemID != nil else { return }
         await loaded.loadSelectedDetail()
     }
@@ -851,6 +900,7 @@ struct ReviewEvidenceTabView: View {
 
     private func selectInlineFeedback(_ feedback: DiffReviewInlineFeedback) {
         focusedFeedbackID = feedback.id
+        focusedDraftCommentID = nil
         if let model,
            model.feedbackItems.contains(where: { $0.id == feedback.evidenceItemID }) {
             model.select(itemID: feedback.evidenceItemID, section: .feedback)
@@ -935,6 +985,60 @@ struct ReviewEvidenceTabView: View {
                 )
             }
         )
+    }
+
+    private var reviewFeedbackTarget: ReviewFeedbackTarget {
+        ReviewFeedbackTarget(
+            title: requestTitle,
+            repositoryPath: worktreePath.path,
+            providerDescription: identityTitle,
+            sourceDescription: "Review evidence files"
+        )
+    }
+
+    private var reviewFeedbackAgentSender: ReviewFeedbackAgentSender {
+        ReviewFeedbackAgentSender.production(appState: appState, worktreeID: tabState.worktreeId)
+    }
+
+    private func loadDraftCommentController() {
+        let sessionID = reviewDraftSessionID
+        if loadedDraftSessionID != sessionID {
+            draftCommentController = ReviewDraftCommentController(sessionID: sessionID)
+            loadedDraftSessionID = sessionID
+            focusedDraftCommentID = nil
+            draftCommentScrollCommand = nil
+        }
+        do {
+            try draftCommentController?.load()
+        } catch {
+            // The controller keeps the non-blocking error state for the review rail.
+        }
+    }
+
+    private func draftCommentActions() -> ReviewDraftCommentActions {
+        ReviewDraftWorkspaceActions.make(
+            controller: draftCommentController,
+            sender: reviewFeedbackAgentSender
+        )
+    }
+
+    private func selectDraftComment(_ comment: ReviewDraftComment) {
+        focusedDraftCommentID = comment.id
+        focusedFeedbackID = nil
+        selectedSection = .files
+        selectedFileID = comment.fileID
+        draftCommentScrollCommand = draftCommentScrollController.command(
+            commentID: comment.id,
+            fileID: comment.fileID
+        )
+    }
+
+    private func saveDraftComment(fileID: DiffReviewFileID, anchor: DiffReviewLineAnchor, body: String) {
+        do {
+            try draftCommentController?.add(anchor: anchor, fileID: fileID, bodyMarkdown: body)
+        } catch {
+            // The controller keeps the non-blocking error state for the review rail.
+        }
     }
 
     private func statusDot(for status: ReviewEvidenceStatus) -> some View {

--- a/Alas/Sources/Center/ReviewRequest/DraftReviewRequestTabView.swift
+++ b/Alas/Sources/Center/ReviewRequest/DraftReviewRequestTabView.swift
@@ -20,6 +20,12 @@ struct DraftReviewRequestTabView: View {
     @State private var draftReviewSession: DiffReviewLoadedSession?
     @State private var selectedFileID: DiffReviewFileID?
     @State private var railCollapsed = false
+    @State private var reviewSummaryCollapsed = false
+    @State private var draftCommentController: ReviewDraftCommentController?
+    @State private var loadedDraftSessionID: ReviewDraftSessionID?
+    @State private var focusedDraftCommentID: String?
+    @State private var draftCommentScrollCommand: DiffReviewDraftCommentScrollCommand?
+    @State private var draftCommentScrollController = DiffReviewDraftCommentScrollController()
     @State private var generation: Task<Void, Never>? = nil
 
     @Environment(\.theme) private var theme
@@ -87,9 +93,35 @@ struct DraftReviewRequestTabView: View {
             selectedPath = path
         }
         .task(id: contextKey) { await loadContext() }
+        .task(id: reviewDraftSessionID.rawValue) {
+            loadDraftCommentController()
+        }
         .onDisappear {
             generation?.cancel()
         }
+    }
+
+    static func reviewDraftSessionID(
+        worktreeID: String,
+        repositoryPath: URL,
+        base: String,
+        head: String
+    ) -> ReviewDraftSessionID {
+        ReviewDraftSessionID.draftReviewRequest(
+            worktreeID: worktreeID,
+            repositoryPath: repositoryPath,
+            base: base,
+            head: head
+        )
+    }
+
+    private var reviewDraftSessionID: ReviewDraftSessionID {
+        Self.reviewDraftSessionID(
+            worktreeID: worktreeId,
+            repositoryPath: worktreePath,
+            base: tabState.baseBranch,
+            head: tabState.branchName
+        )
     }
 
     private var reviewRequestEditor: some View {
@@ -389,6 +421,7 @@ struct DraftReviewRequestTabView: View {
                 session: draftReviewSession,
                 selectedFileID: $selectedFileID,
                 railCollapsed: $railCollapsed,
+                reviewSummaryCollapsed: $reviewSummaryCollapsed,
                 layoutMode: diffPreferences.layoutMode,
                 wrapLines: diffPreferences.wrapLines,
                 showWhitespace: diffPreferences.showWhitespace,
@@ -396,8 +429,18 @@ struct DraftReviewRequestTabView: View {
                 codeFontSize: CGFloat(appState.config.code.fontSize),
                 showsSourceBadges: false,
                 showsRailDisplayControls: true,
+                showsDraftSummaryRail: true,
                 lspContextForFile: { file in
                     makeLSPContext(relativePath: file.summary.path)
+                },
+                reviewFeedbackTarget: reviewFeedbackTarget,
+                draftCommentsByFileID: ReviewDraftCommentGrouping.commentsByFileID(draftCommentController?.comments ?? []),
+                focusedDraftCommentID: focusedDraftCommentID,
+                draftCommentScrollCommand: draftCommentScrollCommand,
+                draftCommentActions: draftCommentActions(),
+                onSelectDraftComment: selectDraftComment,
+                onSaveDraftComment: { fileID, anchor, body in
+                    saveDraftComment(fileID: fileID, anchor: anchor, body: body)
                 }
             )
         } else {
@@ -496,6 +539,7 @@ struct DraftReviewRequestTabView: View {
                 session: session
             )
             selectedPath = DraftReviewRequestDiffSessionBuilder.selectedPath(for: selectedFileID)
+            loadDraftCommentController()
             warning = loaded.hasUncommittedChanges
                 ? "Uncommitted changes are present but excluded from this \(tabState.provider.reviewRequestLabel)."
                 : nil
@@ -663,6 +707,61 @@ struct DraftReviewRequestTabView: View {
                 originatingWorktreeRoot: worktreePath,
                 language: language
             )
+        }
+    }
+
+    private var reviewFeedbackTarget: ReviewFeedbackTarget {
+        ReviewFeedbackTarget(
+            title: "Draft \(tabState.provider.reviewRequestLabel)",
+            repositoryPath: worktreePath.path,
+            providerDescription: [
+                tabState.provider.displayName,
+                tabState.repositorySlug,
+            ].filter { !$0.isEmpty }.joined(separator: " "),
+            sourceDescription: "\(tabState.baseBranch) -> \(tabState.branchName)"
+        )
+    }
+
+    private var reviewFeedbackAgentSender: ReviewFeedbackAgentSender {
+        ReviewFeedbackAgentSender.production(appState: appState, worktreeID: worktreeId)
+    }
+
+    private func loadDraftCommentController() {
+        let sessionID = reviewDraftSessionID
+        if loadedDraftSessionID != sessionID {
+            draftCommentController = ReviewDraftCommentController(sessionID: sessionID)
+            loadedDraftSessionID = sessionID
+            focusedDraftCommentID = nil
+            draftCommentScrollCommand = nil
+        }
+        do {
+            try draftCommentController?.load()
+        } catch {
+            // The controller keeps the non-blocking error state for the review rail.
+        }
+    }
+
+    private func draftCommentActions() -> ReviewDraftCommentActions {
+        ReviewDraftWorkspaceActions.make(
+            controller: draftCommentController,
+            sender: reviewFeedbackAgentSender
+        )
+    }
+
+    private func selectDraftComment(_ comment: ReviewDraftComment) {
+        focusedDraftCommentID = comment.id
+        selectedFileID = comment.fileID
+        draftCommentScrollCommand = draftCommentScrollController.command(
+            commentID: comment.id,
+            fileID: comment.fileID
+        )
+    }
+
+    private func saveDraftComment(fileID: DiffReviewFileID, anchor: DiffReviewLineAnchor, body: String) {
+        do {
+            try draftCommentController?.add(anchor: anchor, fileID: fileID, bodyMarkdown: body)
+        } catch {
+            // The controller keeps the non-blocking error state for the review rail.
         }
     }
 }

--- a/Alas/Sources/Center/ReviewWorkspace/ReviewDraftCommentActions.swift
+++ b/Alas/Sources/Center/ReviewWorkspace/ReviewDraftCommentActions.swift
@@ -4,6 +4,7 @@ struct ReviewDraftCommentActionAvailability: Equatable, Sendable {
     var canResolve: Bool
     var canDismiss: Bool
     var canCopyPrompt: Bool
+    var canShowSendToAgent: Bool
     var canSendToAgent: Bool
 
     static let none = ReviewDraftCommentActionAvailability(
@@ -12,6 +13,7 @@ struct ReviewDraftCommentActionAvailability: Equatable, Sendable {
         canResolve: false,
         canDismiss: false,
         canCopyPrompt: false,
+        canShowSendToAgent: false,
         canSendToAgent: false
     )
 }

--- a/Alas/Sources/Center/ReviewWorkspace/ReviewDraftCommentActions.swift
+++ b/Alas/Sources/Center/ReviewWorkspace/ReviewDraftCommentActions.swift
@@ -16,23 +16,23 @@ struct ReviewDraftCommentActionAvailability: Equatable, Sendable {
     )
 }
 
-struct ReviewDraftCommentActions: Sendable {
-    var availability: @Sendable (ReviewDraftComment) -> ReviewDraftCommentActionAvailability
-    var edit: @Sendable (ReviewDraftComment) -> Void
-    var delete: @Sendable (ReviewDraftComment) -> Void
-    var resolve: @Sendable (ReviewDraftComment) -> Void
-    var dismiss: @Sendable (ReviewDraftComment) -> Void
-    var copyPrompt: @Sendable (ReviewFeedbackBundle) -> Void
-    var sendToAgent: @Sendable (ReviewFeedbackBundle) -> Void
+struct ReviewDraftCommentActions {
+    var availability: (ReviewDraftComment) -> ReviewDraftCommentActionAvailability
+    var edit: (ReviewDraftComment) -> Void
+    var delete: (ReviewDraftComment) -> Void
+    var resolve: (ReviewDraftComment) -> Void
+    var dismiss: (ReviewDraftComment) -> Void
+    var copyPrompt: (ReviewFeedbackBundle) -> Void
+    var sendToAgent: (ReviewFeedbackBundle) -> Void
 
     init(
-        availability: @escaping @Sendable (ReviewDraftComment) -> ReviewDraftCommentActionAvailability = { _ in .none },
-        edit: @escaping @Sendable (ReviewDraftComment) -> Void = { _ in },
-        delete: @escaping @Sendable (ReviewDraftComment) -> Void = { _ in },
-        resolve: @escaping @Sendable (ReviewDraftComment) -> Void = { _ in },
-        dismiss: @escaping @Sendable (ReviewDraftComment) -> Void = { _ in },
-        copyPrompt: @escaping @Sendable (ReviewFeedbackBundle) -> Void = { _ in },
-        sendToAgent: @escaping @Sendable (ReviewFeedbackBundle) -> Void = { _ in }
+        availability: @escaping (ReviewDraftComment) -> ReviewDraftCommentActionAvailability = { _ in .none },
+        edit: @escaping (ReviewDraftComment) -> Void = { _ in },
+        delete: @escaping (ReviewDraftComment) -> Void = { _ in },
+        resolve: @escaping (ReviewDraftComment) -> Void = { _ in },
+        dismiss: @escaping (ReviewDraftComment) -> Void = { _ in },
+        copyPrompt: @escaping (ReviewFeedbackBundle) -> Void = { _ in },
+        sendToAgent: @escaping (ReviewFeedbackBundle) -> Void = { _ in }
     ) {
         self.availability = availability
         self.edit = edit

--- a/Alas/Sources/Center/ReviewWorkspace/ReviewDraftCommentActions.swift
+++ b/Alas/Sources/Center/ReviewWorkspace/ReviewDraftCommentActions.swift
@@ -1,0 +1,40 @@
+struct ReviewDraftCommentActionAvailability: Equatable, Sendable {
+    var canEdit: Bool
+    var canDelete: Bool
+    var canResolve: Bool
+    var canCopyPrompt: Bool
+    var canSendToAgent: Bool
+
+    static let none = ReviewDraftCommentActionAvailability(
+        canEdit: false,
+        canDelete: false,
+        canResolve: false,
+        canCopyPrompt: false,
+        canSendToAgent: false
+    )
+}
+
+struct ReviewDraftCommentActions: Sendable {
+    var availability: @Sendable (ReviewDraftComment) -> ReviewDraftCommentActionAvailability
+    var edit: @Sendable (ReviewDraftComment) -> Void
+    var delete: @Sendable (ReviewDraftComment) -> Void
+    var resolve: @Sendable (ReviewDraftComment) -> Void
+    var copyPrompt: @Sendable (ReviewFeedbackBundle) -> Void
+    var sendToAgent: @Sendable (ReviewFeedbackBundle) -> Void
+
+    init(
+        availability: @escaping @Sendable (ReviewDraftComment) -> ReviewDraftCommentActionAvailability = { _ in .none },
+        edit: @escaping @Sendable (ReviewDraftComment) -> Void = { _ in },
+        delete: @escaping @Sendable (ReviewDraftComment) -> Void = { _ in },
+        resolve: @escaping @Sendable (ReviewDraftComment) -> Void = { _ in },
+        copyPrompt: @escaping @Sendable (ReviewFeedbackBundle) -> Void = { _ in },
+        sendToAgent: @escaping @Sendable (ReviewFeedbackBundle) -> Void = { _ in }
+    ) {
+        self.availability = availability
+        self.edit = edit
+        self.delete = delete
+        self.resolve = resolve
+        self.copyPrompt = copyPrompt
+        self.sendToAgent = sendToAgent
+    }
+}

--- a/Alas/Sources/Center/ReviewWorkspace/ReviewDraftCommentActions.swift
+++ b/Alas/Sources/Center/ReviewWorkspace/ReviewDraftCommentActions.swift
@@ -2,6 +2,7 @@ struct ReviewDraftCommentActionAvailability: Equatable, Sendable {
     var canEdit: Bool
     var canDelete: Bool
     var canResolve: Bool
+    var canDismiss: Bool
     var canCopyPrompt: Bool
     var canSendToAgent: Bool
 
@@ -9,6 +10,7 @@ struct ReviewDraftCommentActionAvailability: Equatable, Sendable {
         canEdit: false,
         canDelete: false,
         canResolve: false,
+        canDismiss: false,
         canCopyPrompt: false,
         canSendToAgent: false
     )
@@ -19,6 +21,7 @@ struct ReviewDraftCommentActions: Sendable {
     var edit: @Sendable (ReviewDraftComment) -> Void
     var delete: @Sendable (ReviewDraftComment) -> Void
     var resolve: @Sendable (ReviewDraftComment) -> Void
+    var dismiss: @Sendable (ReviewDraftComment) -> Void
     var copyPrompt: @Sendable (ReviewFeedbackBundle) -> Void
     var sendToAgent: @Sendable (ReviewFeedbackBundle) -> Void
 
@@ -27,6 +30,7 @@ struct ReviewDraftCommentActions: Sendable {
         edit: @escaping @Sendable (ReviewDraftComment) -> Void = { _ in },
         delete: @escaping @Sendable (ReviewDraftComment) -> Void = { _ in },
         resolve: @escaping @Sendable (ReviewDraftComment) -> Void = { _ in },
+        dismiss: @escaping @Sendable (ReviewDraftComment) -> Void = { _ in },
         copyPrompt: @escaping @Sendable (ReviewFeedbackBundle) -> Void = { _ in },
         sendToAgent: @escaping @Sendable (ReviewFeedbackBundle) -> Void = { _ in }
     ) {
@@ -34,6 +38,7 @@ struct ReviewDraftCommentActions: Sendable {
         self.edit = edit
         self.delete = delete
         self.resolve = resolve
+        self.dismiss = dismiss
         self.copyPrompt = copyPrompt
         self.sendToAgent = sendToAgent
     }

--- a/Alas/Sources/Center/ReviewWorkspace/ReviewDraftCommentActions.swift
+++ b/Alas/Sources/Center/ReviewWorkspace/ReviewDraftCommentActions.swift
@@ -20,21 +20,23 @@ struct ReviewDraftCommentActionAvailability: Equatable, Sendable {
 
 struct ReviewDraftCommentActions {
     var availability: (ReviewDraftComment) -> ReviewDraftCommentActionAvailability
-    var edit: (ReviewDraftComment) -> Void
+    var edit: (ReviewDraftComment, String) -> Void
     var delete: (ReviewDraftComment) -> Void
     var resolve: (ReviewDraftComment) -> Void
     var dismiss: (ReviewDraftComment) -> Void
     var copyPrompt: (ReviewFeedbackBundle) -> Void
-    var sendToAgent: (ReviewFeedbackBundle) -> Void
+    var agentTargets: () -> [ReviewFeedbackAgentTarget]
+    var sendToAgent: (ReviewFeedbackBundle, ReviewFeedbackAgentTarget) -> Void
 
     init(
         availability: @escaping (ReviewDraftComment) -> ReviewDraftCommentActionAvailability = { _ in .none },
-        edit: @escaping (ReviewDraftComment) -> Void = { _ in },
+        edit: @escaping (ReviewDraftComment, String) -> Void = { _, _ in },
         delete: @escaping (ReviewDraftComment) -> Void = { _ in },
         resolve: @escaping (ReviewDraftComment) -> Void = { _ in },
         dismiss: @escaping (ReviewDraftComment) -> Void = { _ in },
         copyPrompt: @escaping (ReviewFeedbackBundle) -> Void = { _ in },
-        sendToAgent: @escaping (ReviewFeedbackBundle) -> Void = { _ in }
+        agentTargets: @escaping () -> [ReviewFeedbackAgentTarget] = { [] },
+        sendToAgent: @escaping (ReviewFeedbackBundle, ReviewFeedbackAgentTarget) -> Void = { _, _ in }
     ) {
         self.availability = availability
         self.edit = edit
@@ -42,6 +44,7 @@ struct ReviewDraftCommentActions {
         self.resolve = resolve
         self.dismiss = dismiss
         self.copyPrompt = copyPrompt
+        self.agentTargets = agentTargets
         self.sendToAgent = sendToAgent
     }
 }

--- a/Alas/Sources/Center/ReviewWorkspace/ReviewDraftCommentController.swift
+++ b/Alas/Sources/Center/ReviewWorkspace/ReviewDraftCommentController.swift
@@ -73,6 +73,13 @@ final class ReviewDraftCommentController {
         try saveAndReload(comment)
     }
 
+    func dismiss(commentID: String) throws {
+        guard var comment = comments.first(where: { $0.id == commentID }) else { return }
+        comment.state = .dismissed
+        comment.updatedAt = now()
+        try saveAndReload(comment)
+    }
+
     func delete(commentID: String) throws {
         do {
             try store.delete(commentID: commentID, sessionID: sessionID)

--- a/Alas/Sources/Center/ReviewWorkspace/ReviewDraftCommentController.swift
+++ b/Alas/Sources/Center/ReviewWorkspace/ReviewDraftCommentController.swift
@@ -1,0 +1,97 @@
+import Foundation
+import Observation
+
+@MainActor
+@Observable
+final class ReviewDraftCommentController {
+    private let sessionID: ReviewDraftSessionID
+    private let store: ReviewDraftCommentStore
+    private let now: () -> Date
+
+    private(set) var comments: [ReviewDraftComment] = []
+    var errorMessage: String?
+
+    init(
+        sessionID: ReviewDraftSessionID,
+        store: ReviewDraftCommentStore = .init(),
+        now: @escaping () -> Date = Date.init
+    ) {
+        self.sessionID = sessionID
+        self.store = store
+        self.now = now
+    }
+
+    func load() throws {
+        do {
+            comments = try store.load(sessionID: sessionID)
+            errorMessage = nil
+        } catch {
+            errorMessage = error.localizedDescription
+            throw error
+        }
+    }
+
+    func add(anchor: DiffReviewLineAnchor, fileID: DiffReviewFileID, bodyMarkdown: String) throws {
+        let timestamp = now()
+        let comment = ReviewDraftComment(
+            id: UUID().uuidString,
+            sessionID: sessionID,
+            fileID: fileID,
+            path: anchor.path,
+            originalPath: nil,
+            side: anchor.side,
+            startLine: anchor.line,
+            endLine: nil,
+            selectedText: anchor.selectedText,
+            bodyMarkdown: bodyMarkdown,
+            state: .active,
+            createdAt: timestamp,
+            updatedAt: timestamp
+        )
+
+        do {
+            try store.save(comment)
+            comments = try store.load(sessionID: sessionID)
+            errorMessage = nil
+        } catch {
+            errorMessage = error.localizedDescription
+            throw error
+        }
+    }
+
+    func edit(commentID: String, bodyMarkdown: String) throws {
+        guard var comment = comments.first(where: { $0.id == commentID }) else { return }
+        comment.bodyMarkdown = bodyMarkdown
+        comment.updatedAt = now()
+        try saveAndReload(comment)
+    }
+
+    func resolve(commentID: String) throws {
+        guard var comment = comments.first(where: { $0.id == commentID }) else { return }
+        comment.state = .resolved
+        comment.updatedAt = now()
+        try saveAndReload(comment)
+    }
+
+    func delete(commentID: String) throws {
+        do {
+            try store.delete(commentID: commentID, sessionID: sessionID)
+            comments = try store.load(sessionID: sessionID)
+            errorMessage = nil
+        } catch {
+            errorMessage = error.localizedDescription
+            throw error
+        }
+    }
+
+    private func saveAndReload(_ comment: ReviewDraftComment) throws {
+        do {
+            try store.save(comment)
+            comments = try store.load(sessionID: sessionID)
+            errorMessage = nil
+        } catch {
+            errorMessage = error.localizedDescription
+            throw error
+        }
+    }
+}

--- a/Alas/Sources/Center/ReviewWorkspace/ReviewDraftCommentController.swift
+++ b/Alas/Sources/Center/ReviewWorkspace/ReviewDraftCommentController.swift
@@ -51,7 +51,7 @@ final class ReviewDraftCommentController {
 
         do {
             try store.save(comment)
-            comments = try store.load(sessionID: sessionID)
+            comments = ReviewDraftCommentPlacement.sorted(comments + [comment])
             errorMessage = nil
         } catch {
             errorMessage = error.localizedDescription
@@ -81,22 +81,30 @@ final class ReviewDraftCommentController {
     }
 
     func delete(commentID: String) throws {
+        let previous = comments
+        let updated = comments.filter { $0.id != commentID }
         do {
             try store.delete(commentID: commentID, sessionID: sessionID)
-            comments = try store.load(sessionID: sessionID)
+            comments = updated
             errorMessage = nil
         } catch {
+            comments = previous
             errorMessage = error.localizedDescription
             throw error
         }
     }
 
     private func saveAndReload(_ comment: ReviewDraftComment) throws {
+        let previous = comments
+        let updated = ReviewDraftCommentPlacement.sorted(comments.map { existing in
+            existing.id == comment.id ? comment : existing
+        })
         do {
             try store.save(comment)
-            comments = try store.load(sessionID: sessionID)
+            comments = updated
             errorMessage = nil
         } catch {
+            comments = previous
             errorMessage = error.localizedDescription
             throw error
         }

--- a/Alas/Sources/Center/ReviewWorkspace/ReviewDraftCommentStore.swift
+++ b/Alas/Sources/Center/ReviewWorkspace/ReviewDraftCommentStore.swift
@@ -1,0 +1,68 @@
+import Foundation
+
+struct ReviewDraftCommentStore {
+    private let store: any PersistenceStoreProtocol
+    private let url: URL
+
+    init(store: any PersistenceStoreProtocol = PersistenceStore(), url: URL = Paths.reviewDraftCommentsFile) {
+        self.store = store
+        self.url = url
+    }
+
+    func load(sessionID: ReviewDraftSessionID) throws -> [ReviewDraftComment] {
+        let snapshot = try readSnapshot()
+        return (snapshot.commentsBySessionID[sessionID.rawValue] ?? []).sorted(by: sortComments)
+    }
+
+    func save(_ comment: ReviewDraftComment) throws {
+        var snapshot = try readSnapshot()
+        var comments = snapshot.commentsBySessionID[comment.sessionID.rawValue] ?? []
+
+        if let index = comments.firstIndex(where: { $0.id == comment.id }) {
+            comments[index] = comment
+        } else {
+            comments.append(comment)
+        }
+
+        snapshot.commentsBySessionID[comment.sessionID.rawValue] = comments
+        try store.write(snapshot, to: url)
+    }
+
+    func delete(commentID: String, sessionID: ReviewDraftSessionID) throws {
+        var snapshot = try readSnapshot()
+        var comments = snapshot.commentsBySessionID[sessionID.rawValue] ?? []
+        comments.removeAll { $0.id == commentID }
+
+        if comments.isEmpty {
+            snapshot.commentsBySessionID.removeValue(forKey: sessionID.rawValue)
+        } else {
+            snapshot.commentsBySessionID[sessionID.rawValue] = comments
+        }
+
+        try store.write(snapshot, to: url)
+    }
+
+    func delete(sessionID: ReviewDraftSessionID) throws {
+        var snapshot = try readSnapshot()
+        snapshot.commentsBySessionID.removeValue(forKey: sessionID.rawValue)
+        try store.write(snapshot, to: url)
+    }
+
+    private func readSnapshot() throws -> Snapshot {
+        try store.readIfExists(Snapshot.self, from: url) ?? Snapshot(commentsBySessionID: [:])
+    }
+
+    private func sortComments(_ lhs: ReviewDraftComment, _ rhs: ReviewDraftComment) -> Bool {
+        if lhs.path != rhs.path {
+            return lhs.path.localizedStandardCompare(rhs.path) == .orderedAscending
+        }
+        if lhs.normalizedLineRange.lowerBound != rhs.normalizedLineRange.lowerBound {
+            return lhs.normalizedLineRange.lowerBound < rhs.normalizedLineRange.lowerBound
+        }
+        return lhs.createdAt < rhs.createdAt
+    }
+
+    private struct Snapshot: Codable, Equatable {
+        var commentsBySessionID: [String: [ReviewDraftComment]]
+    }
+}

--- a/Alas/Sources/Center/ReviewWorkspace/ReviewDraftCommentStore.swift
+++ b/Alas/Sources/Center/ReviewWorkspace/ReviewDraftCommentStore.swift
@@ -59,7 +59,13 @@ struct ReviewDraftCommentStore {
         if lhs.normalizedLineRange.lowerBound != rhs.normalizedLineRange.lowerBound {
             return lhs.normalizedLineRange.lowerBound < rhs.normalizedLineRange.lowerBound
         }
-        return lhs.createdAt < rhs.createdAt
+        if lhs.normalizedLineRange.upperBound != rhs.normalizedLineRange.upperBound {
+            return lhs.normalizedLineRange.upperBound < rhs.normalizedLineRange.upperBound
+        }
+        if lhs.createdAt != rhs.createdAt {
+            return lhs.createdAt < rhs.createdAt
+        }
+        return lhs.id < rhs.id
     }
 
     private struct Snapshot: Codable, Equatable {

--- a/Alas/Sources/Center/ReviewWorkspace/ReviewDraftModels.swift
+++ b/Alas/Sources/Center/ReviewWorkspace/ReviewDraftModels.swift
@@ -83,8 +83,6 @@ enum ReviewDraftCommentState: String, Codable, Equatable, Hashable, Sendable {
     case dismissed
 }
 
-extension DiffReviewFileID: @unchecked Sendable {}
-
 struct ReviewDraftComment: Codable, Equatable, Identifiable, Sendable {
     var id: String
     var sessionID: ReviewDraftSessionID

--- a/Alas/Sources/Center/ReviewWorkspace/ReviewDraftModels.swift
+++ b/Alas/Sources/Center/ReviewWorkspace/ReviewDraftModels.swift
@@ -1,0 +1,109 @@
+import Foundation
+
+enum ReviewDraftSourceKind: String, Codable, Equatable, Hashable, Sendable {
+    case localChanges = "local-changes"
+    case commit
+    case draftCommit = "draft-commit"
+    case branch
+    case reviewRequest = "review-request"
+    case draftReviewRequest = "draft-review-request"
+}
+
+enum ReviewDraftLocalChangesScope: String, Codable, Equatable, Hashable, Sendable {
+    case all
+    case unstaged
+    case staged
+}
+
+struct ReviewDraftSessionID: Codable, Equatable, Hashable, Sendable, RawRepresentable {
+    let rawValue: String
+    let sourceKind: ReviewDraftSourceKind
+
+    init(rawValue: String, sourceKind: ReviewDraftSourceKind) {
+        self.rawValue = rawValue
+        self.sourceKind = sourceKind
+    }
+
+    init?(rawValue: String) {
+        let parts = rawValue.split(separator: Self.separator, omittingEmptySubsequences: false).map(String.init)
+        guard let first = parts.first,
+              let sourceKind = ReviewDraftSourceKind(rawValue: first)
+        else { return nil }
+        self.rawValue = rawValue
+        self.sourceKind = sourceKind
+    }
+
+    static func localChanges(worktreeID: String, worktreePath: URL, scope: ReviewDraftLocalChangesScope) -> Self {
+        make(.localChanges, [worktreeID, worktreePath.standardizedFileURL.path, scope.rawValue])
+    }
+
+    static func commit(worktreeID: String, repositoryPath: URL, sha: String) -> Self {
+        make(.commit, [worktreeID, repositoryPath.standardizedFileURL.path, sha])
+    }
+
+    static func draftCommit(worktreeID: String, repositoryPath: URL) -> Self {
+        make(.draftCommit, [worktreeID, repositoryPath.standardizedFileURL.path])
+    }
+
+    static func branch(worktreeID: String, repositoryPath: URL, base: String, head: String) -> Self {
+        make(.branch, [worktreeID, repositoryPath.standardizedFileURL.path, base, head])
+    }
+
+    static func reviewRequest(
+        worktreeID: String,
+        provider: CodeHostKind,
+        host: String,
+        repositorySlug: String,
+        number: Int
+    ) -> Self {
+        make(.reviewRequest, [worktreeID, provider.rawValue, host.lowercased(), repositorySlug, "\(number)"])
+    }
+
+    static func draftReviewRequest(worktreeID: String, repositoryPath: URL, base: String, head: String) -> Self {
+        make(.draftReviewRequest, [worktreeID, repositoryPath.standardizedFileURL.path, base, head])
+    }
+
+    private static let separator: Character = "\u{1f}"
+
+    private static func make(_ kind: ReviewDraftSourceKind, _ fields: [String]) -> Self {
+        let escapedFields = ([kind.rawValue] + fields).map(escape)
+        return ReviewDraftSessionID(rawValue: escapedFields.joined(separator: String(separator)), sourceKind: kind)
+    }
+
+    private static func escape(_ value: String) -> String {
+        value
+            .replacingOccurrences(of: "\\", with: "\\\\")
+            .replacingOccurrences(of: String(separator), with: "\\u001f")
+    }
+}
+
+enum ReviewDraftCommentState: String, Codable, Equatable, Hashable, Sendable {
+    case active
+    case resolved
+    case dismissed
+}
+
+extension DiffReviewFileID: @unchecked Sendable {}
+
+struct ReviewDraftComment: Codable, Equatable, Identifiable, Sendable {
+    var id: String
+    var sessionID: ReviewDraftSessionID
+    var fileID: DiffReviewFileID
+    var path: String
+    var originalPath: String?
+    var side: DiffReviewInlineFeedbackSide
+    var startLine: Int
+    var endLine: Int?
+    var selectedText: String?
+    var bodyMarkdown: String
+    var state: ReviewDraftCommentState
+    var createdAt: Date
+    var updatedAt: Date
+
+    var normalizedLineRange: ClosedRange<Int> {
+        let end = endLine ?? startLine
+        return min(startLine, end)...max(startLine, end)
+    }
+
+    var isActive: Bool { state == .active }
+}

--- a/Alas/Sources/Center/ReviewWorkspace/ReviewDraftSummaryRail.swift
+++ b/Alas/Sources/Center/ReviewWorkspace/ReviewDraftSummaryRail.swift
@@ -36,6 +36,10 @@ struct ReviewDraftSummaryRail: View {
         !bundle.activeComments.isEmpty && visibleComments.contains { draftCommentActions.availability($0).canSendToAgent }
     }
 
+    private var shouldShowSendToAgent: Bool {
+        visibleComments.contains { draftCommentActions.availability($0).canShowSendToAgent }
+    }
+
     var body: some View {
         VStack(spacing: 0) {
             if collapsed {
@@ -84,13 +88,15 @@ struct ReviewDraftSummaryRail: View {
             ) {
                 draftCommentActions.copyPrompt(bundle)
             }
-            collapsedActionButton(
-                id: "review-draft-summary-send-agent",
-                systemName: "paperplane",
-                label: "Send to agent",
-                enabled: canSendToAgent
-            ) {
-                draftCommentActions.sendToAgent(bundle)
+            if shouldShowSendToAgent {
+                collapsedActionButton(
+                    id: "review-draft-summary-send-agent",
+                    systemName: "paperplane",
+                    label: "Send to agent",
+                    enabled: canSendToAgent
+                ) {
+                    draftCommentActions.sendToAgent(bundle)
+                }
             }
             Spacer(minLength: 0)
         }
@@ -135,30 +141,32 @@ struct ReviewDraftSummaryRail: View {
                     }
                 )
 
-                Button {
-                    draftCommentActions.sendToAgent(bundle)
-                } label: {
-                    Image(systemName: "paperplane")
-                        .font(.system(size: 12, weight: .medium))
-                        .foregroundColor(canSendToAgent ? theme.color("fg-muted") : theme.color("fg-faint"))
-                        .frame(width: 28, height: 24)
-                        .background(theme.color("bg-3"))
-                        .clipShape(RoundedRectangle(cornerRadius: 6))
-                }
-                .buttonStyle(.plain)
-                .disabled(!canSendToAgent)
-                .help("Send to agent")
-                .accessibilityIdentifier("review-draft-summary-send-agent")
-                .accessibilityLabel("Send to agent")
-                .background(
-                    ReviewDraftSummaryPressMarker(
-                        identifier: "review-draft-summary-send-agent",
-                        label: "Send to agent",
-                        isEnabled: canSendToAgent
-                    ) {
+                if shouldShowSendToAgent {
+                    Button {
                         draftCommentActions.sendToAgent(bundle)
+                    } label: {
+                        Image(systemName: "paperplane")
+                            .font(.system(size: 12, weight: .medium))
+                            .foregroundColor(canSendToAgent ? theme.color("fg-muted") : theme.color("fg-faint"))
+                            .frame(width: 28, height: 24)
+                            .background(theme.color("bg-3"))
+                            .clipShape(RoundedRectangle(cornerRadius: 6))
                     }
-                )
+                    .buttonStyle(.plain)
+                    .disabled(!canSendToAgent)
+                    .help("Send to agent")
+                    .accessibilityIdentifier("review-draft-summary-send-agent")
+                    .accessibilityLabel("Send to agent")
+                    .background(
+                        ReviewDraftSummaryPressMarker(
+                            identifier: "review-draft-summary-send-agent",
+                            label: "Send to agent",
+                            isEnabled: canSendToAgent
+                        ) {
+                            draftCommentActions.sendToAgent(bundle)
+                        }
+                    )
+                }
 
                 Spacer(minLength: 0)
             }

--- a/Alas/Sources/Center/ReviewWorkspace/ReviewDraftSummaryRail.swift
+++ b/Alas/Sources/Center/ReviewWorkspace/ReviewDraftSummaryRail.swift
@@ -1,0 +1,361 @@
+import AppKit
+import SwiftUI
+
+struct ReviewDraftSummaryRail: View {
+    let comments: [ReviewDraftComment]
+    let bundle: ReviewFeedbackBundle
+    @Binding var collapsed: Bool
+    var focusedDraftCommentID: String?
+    var draftCommentActions = ReviewDraftCommentActions()
+    var onSelectDraftComment: (ReviewDraftComment) -> Void = { _ in }
+
+    @Environment(\.theme) private var theme
+
+    private var visibleComments: [ReviewDraftComment] {
+        ReviewDraftCommentPlacement.sorted(comments.filter { $0.state != .dismissed })
+    }
+
+    private var activeCount: Int {
+        visibleComments.filter(\.isActive).count
+    }
+
+    private var groupedComments: [CommentGroup] {
+        let grouped = Dictionary(grouping: visibleComments, by: \.path)
+        return grouped.keys
+            .sorted { $0.localizedStandardCompare($1) == .orderedAscending }
+            .map { path in
+                CommentGroup(path: path, comments: ReviewDraftCommentPlacement.sorted(grouped[path] ?? []))
+            }
+    }
+
+    private var canCopyPrompt: Bool {
+        !bundle.activeComments.isEmpty && visibleComments.contains { draftCommentActions.availability($0).canCopyPrompt }
+    }
+
+    private var canSendToAgent: Bool {
+        !bundle.activeComments.isEmpty && visibleComments.contains { draftCommentActions.availability($0).canSendToAgent }
+    }
+
+    var body: some View {
+        VStack(spacing: 0) {
+            if collapsed {
+                collapsedBody
+            } else {
+                expandedBody
+            }
+        }
+        .frame(width: collapsed ? 44 : 260)
+        .frame(maxHeight: .infinity, alignment: .top)
+        .background(theme.color("bg-2"))
+        .overlay(Rectangle().fill(theme.color("line")).frame(width: 0.5), alignment: .leading)
+        .accessibilityIdentifier("review-draft-summary-rail")
+        .background(
+            DiffReviewAccessibilityMarker(
+                identifier: "review-draft-summary-rail",
+                label: "Draft review summary"
+            )
+        )
+    }
+
+    private var expandedBody: some View {
+        VStack(spacing: 0) {
+            expandedHeader
+            ScrollView(.vertical) {
+                LazyVStack(alignment: .leading, spacing: 10) {
+                    ForEach(groupedComments) { group in
+                        commentGroup(group)
+                    }
+                }
+                .padding(10)
+            }
+        }
+    }
+
+    private var collapsedBody: some View {
+        VStack(spacing: 8) {
+            collapseButton
+                .padding(.top, 8)
+            activeCountPill(compact: true)
+            Spacer(minLength: 0)
+        }
+    }
+
+    private var expandedHeader: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            HStack(spacing: 8) {
+                VStack(alignment: .leading, spacing: 3) {
+                    Text("Draft review")
+                        .font(.system(size: 12, weight: .semibold))
+                        .foregroundColor(theme.color("fg"))
+                    activeCountPill(compact: false)
+                }
+                Spacer(minLength: 8)
+                collapseButton
+            }
+
+            HStack(spacing: 6) {
+                Button {
+                    draftCommentActions.copyPrompt(bundle)
+                } label: {
+                    Image(systemName: "doc.on.doc")
+                        .font(.system(size: 12, weight: .medium))
+                        .foregroundColor(canCopyPrompt ? theme.color("fg-muted") : theme.color("fg-faint"))
+                        .frame(width: 28, height: 24)
+                        .background(theme.color("bg-3"))
+                        .clipShape(RoundedRectangle(cornerRadius: 6))
+                }
+                .buttonStyle(.plain)
+                .disabled(!canCopyPrompt)
+                .help("Copy prompt")
+                .accessibilityIdentifier("review-draft-summary-copy-prompt")
+                .accessibilityLabel("Copy prompt")
+                .background(
+                    ReviewDraftSummaryPressMarker(
+                        identifier: "review-draft-summary-copy-prompt",
+                        label: "Copy prompt"
+                    ) {
+                        guard canCopyPrompt else { return }
+                        draftCommentActions.copyPrompt(bundle)
+                    }
+                )
+
+                Button {
+                    draftCommentActions.sendToAgent(bundle)
+                } label: {
+                    Image(systemName: "paperplane")
+                        .font(.system(size: 12, weight: .medium))
+                        .foregroundColor(canSendToAgent ? theme.color("fg-muted") : theme.color("fg-faint"))
+                        .frame(width: 28, height: 24)
+                        .background(theme.color("bg-3"))
+                        .clipShape(RoundedRectangle(cornerRadius: 6))
+                }
+                .buttonStyle(.plain)
+                .disabled(!canSendToAgent)
+                .help("Send to agent")
+                .accessibilityIdentifier("review-draft-summary-send-agent")
+                .accessibilityLabel("Send to agent")
+                .background(
+                    ReviewDraftSummaryPressMarker(
+                        identifier: "review-draft-summary-send-agent",
+                        label: "Send to agent"
+                    ) {
+                        guard canSendToAgent else { return }
+                        draftCommentActions.sendToAgent(bundle)
+                    }
+                )
+
+                Spacer(minLength: 0)
+            }
+        }
+        .padding(.horizontal, 12)
+        .padding(.vertical, 10)
+        .background(theme.color("bg-2"))
+        .overlay(Rectangle().fill(theme.color("line")).frame(height: 0.5), alignment: .bottom)
+    }
+
+    private var collapseButton: some View {
+        Button {
+            collapsed.toggle()
+        } label: {
+            Image(systemName: collapsed ? "sidebar.right" : "sidebar.trailing")
+                .font(.system(size: 12, weight: .medium))
+                .foregroundColor(theme.color("fg-muted"))
+                .frame(width: 26, height: 24)
+                .background(theme.color("bg-3"))
+                .clipShape(RoundedRectangle(cornerRadius: 6))
+        }
+        .buttonStyle(.plain)
+        .help(collapsed ? "Expand draft review rail" : "Collapse draft review rail")
+        .accessibilityIdentifier("review-draft-summary-collapse-toggle")
+    }
+
+    private func activeCountPill(compact: Bool) -> some View {
+        Text(compact ? "\(activeCount)" : "\(activeCount) active")
+            .font(.system(size: compact ? 11 : 10.5, weight: .semibold, design: .monospaced))
+            .foregroundColor(activeCount > 0 ? theme.color("warn") : theme.color("fg-faint"))
+            .padding(.horizontal, compact ? 0 : 7)
+            .frame(width: compact ? 26 : nil, height: compact ? 22 : 20)
+            .background((activeCount > 0 ? theme.color("warn") : theme.color("fg-muted")).opacity(0.15))
+            .clipShape(RoundedRectangle(cornerRadius: compact ? 6 : 5))
+            .accessibilityLabel("\(activeCount) active draft comments")
+    }
+
+    private func commentGroup(_ group: CommentGroup) -> some View {
+        VStack(alignment: .leading, spacing: 6) {
+            Text(group.path)
+                .font(.system(size: 10.5, weight: .semibold))
+                .foregroundColor(theme.color("fg-dim"))
+                .lineLimit(1)
+                .truncationMode(.middle)
+
+            ForEach(group.comments) { comment in
+                summaryCard(comment)
+            }
+        }
+    }
+
+    private func summaryCard(_ comment: ReviewDraftComment) -> some View {
+        let availability = draftCommentActions.availability(comment)
+        let isFocused = comment.id == focusedDraftCommentID
+
+        return VStack(alignment: .leading, spacing: 6) {
+            Button {
+                onSelectDraftComment(comment)
+            } label: {
+                VStack(alignment: .leading, spacing: 5) {
+                    HStack(spacing: 6) {
+                        Text(lineDescription(for: comment))
+                            .font(.system(size: 10, weight: .semibold))
+                            .foregroundColor(statusColor(for: comment))
+                        if comment.state == .resolved {
+                            Text("resolved")
+                                .font(.system(size: 10))
+                                .foregroundColor(theme.color("fg-faint"))
+                        }
+                        Spacer(minLength: 0)
+                    }
+
+                    Text(DiffReviewInlineFeedbackMarkdown.render(comment.bodyMarkdown))
+                        .font(.system(size: 11.5))
+                        .foregroundColor(theme.color("fg"))
+                        .lineLimit(4)
+                        .fixedSize(horizontal: false, vertical: true)
+                }
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .contentShape(Rectangle())
+            }
+            .buttonStyle(.plain)
+            .accessibilityIdentifier("review-draft-summary-comment-\(comment.id)")
+            .accessibilityLabel(accessibilityLabel(for: comment))
+
+            if availability.canEdit || availability.canDelete || availability.canResolve {
+                HStack(spacing: 5) {
+                    Spacer(minLength: 0)
+                    if availability.canEdit {
+                        commentActionButton(id: "edit", commentID: comment.id, systemName: "pencil", tooltip: "Edit") {
+                            draftCommentActions.edit(comment)
+                        }
+                    }
+                    if availability.canResolve {
+                        commentActionButton(id: "resolve", commentID: comment.id, systemName: "checkmark", tooltip: "Resolve") {
+                            draftCommentActions.resolve(comment)
+                        }
+                    }
+                    if availability.canDelete {
+                        commentActionButton(id: "delete", commentID: comment.id, systemName: "trash", tooltip: "Delete") {
+                            draftCommentActions.delete(comment)
+                        }
+                    }
+                }
+            }
+        }
+        .padding(8)
+        .background(isFocused ? theme.color("accent-soft") : theme.color("bg-1"))
+        .clipShape(RoundedRectangle(cornerRadius: 6))
+        .overlay(
+            RoundedRectangle(cornerRadius: 6)
+                .stroke(isFocused ? theme.color("accent") : theme.color("line"), lineWidth: isFocused ? 1 : 0.5)
+        )
+        .background(
+            ReviewDraftSummaryPressMarker(
+                identifier: "review-draft-summary-comment-\(comment.id)",
+                label: accessibilityLabel(for: comment)
+            ) {
+                onSelectDraftComment(comment)
+            }
+        )
+    }
+
+    private func commentActionButton(
+        id: String,
+        commentID: String,
+        systemName: String,
+        tooltip: String,
+        action: @escaping () -> Void
+    ) -> some View {
+        Button(action: action) {
+            Image(systemName: systemName)
+                .font(.system(size: 10.5, weight: .medium))
+                .foregroundColor(theme.color("fg-muted"))
+                .frame(width: 22, height: 20)
+                .background(theme.color("bg-3"))
+                .clipShape(RoundedRectangle(cornerRadius: 5))
+        }
+        .buttonStyle(.plain)
+        .help(tooltip)
+        .accessibilityIdentifier("review-draft-summary-\(id)-\(commentID)")
+        .accessibilityLabel(tooltip)
+    }
+
+    private func lineDescription(for comment: ReviewDraftComment) -> String {
+        let range = comment.normalizedLineRange
+        if range.lowerBound == range.upperBound {
+            return "line \(range.lowerBound)"
+        }
+        return "lines \(range.lowerBound)-\(range.upperBound)"
+    }
+
+    private func accessibilityLabel(for comment: ReviewDraftComment) -> String {
+        [
+            "Draft comment",
+            comment.path,
+            lineDescription(for: comment),
+            comment.state == .resolved ? "resolved" : nil,
+            DiffReviewInlineFeedbackMarkdown.plainText(comment.bodyMarkdown),
+        ]
+        .compactMap { part in
+            guard let part, !part.isEmpty else { return nil }
+            return part
+        }
+        .joined(separator: ", ")
+    }
+
+    private func statusColor(for comment: ReviewDraftComment) -> Color {
+        switch comment.state {
+        case .active:
+            theme.color("warn")
+        case .resolved:
+            theme.color("add")
+        case .dismissed:
+            theme.color("fg-muted")
+        }
+    }
+}
+
+private struct CommentGroup: Identifiable {
+    let path: String
+    let comments: [ReviewDraftComment]
+
+    var id: String { path }
+}
+
+private struct ReviewDraftSummaryPressMarker: NSViewRepresentable {
+    let identifier: String
+    let label: String?
+    let action: () -> Void
+
+    func makeNSView(context: Context) -> ReviewDraftSummaryPressView {
+        let view = ReviewDraftSummaryPressView(frame: .zero)
+        view.setAccessibilityIdentifier(identifier)
+        view.setAccessibilityLabel(label)
+        view.setAccessibilityRole(.button)
+        view.action = action
+        return view
+    }
+
+    func updateNSView(_ view: ReviewDraftSummaryPressView, context: Context) {
+        view.setAccessibilityIdentifier(identifier)
+        view.setAccessibilityLabel(label)
+        view.setAccessibilityRole(.button)
+        view.action = action
+    }
+}
+
+private final class ReviewDraftSummaryPressView: NSView {
+    var action: () -> Void = {}
+
+    override func accessibilityPerformPress() -> Bool {
+        action()
+        return true
+    }
+}

--- a/Alas/Sources/Center/ReviewWorkspace/ReviewDraftSummaryRail.swift
+++ b/Alas/Sources/Center/ReviewWorkspace/ReviewDraftSummaryRail.swift
@@ -10,6 +10,8 @@ struct ReviewDraftSummaryRail: View {
     var onSelectDraftComment: (ReviewDraftComment) -> Void = { _ in }
 
     @Environment(\.theme) private var theme
+    @State private var editingCommentID: String?
+    @State private var editingBody = ""
 
     private var visibleComments: [ReviewDraftComment] {
         ReviewDraftCommentPlacement.sorted(comments)
@@ -38,6 +40,10 @@ struct ReviewDraftSummaryRail: View {
 
     private var shouldShowSendToAgent: Bool {
         visibleComments.contains { draftCommentActions.availability($0).canShowSendToAgent }
+    }
+
+    private var agentTargets: [ReviewFeedbackAgentTarget] {
+        draftCommentActions.agentTargets()
     }
 
     var body: some View {
@@ -89,14 +95,7 @@ struct ReviewDraftSummaryRail: View {
                 draftCommentActions.copyPrompt(bundle)
             }
             if shouldShowSendToAgent {
-                collapsedActionButton(
-                    id: "review-draft-summary-send-agent",
-                    systemName: "paperplane",
-                    label: "Send to agent",
-                    enabled: canSendToAgent
-                ) {
-                    draftCommentActions.sendToAgent(bundle)
-                }
+                collapsedSendToAgentControl
             }
             Spacer(minLength: 0)
         }
@@ -142,30 +141,7 @@ struct ReviewDraftSummaryRail: View {
                 )
 
                 if shouldShowSendToAgent {
-                    Button {
-                        draftCommentActions.sendToAgent(bundle)
-                    } label: {
-                        Image(systemName: "paperplane")
-                            .font(.system(size: 12, weight: .medium))
-                            .foregroundColor(canSendToAgent ? theme.color("fg-muted") : theme.color("fg-faint"))
-                            .frame(width: 28, height: 24)
-                            .background(theme.color("bg-3"))
-                            .clipShape(RoundedRectangle(cornerRadius: 6))
-                    }
-                    .buttonStyle(.plain)
-                    .disabled(!canSendToAgent)
-                    .help("Send to agent")
-                    .accessibilityIdentifier("review-draft-summary-send-agent")
-                    .accessibilityLabel("Send to agent")
-                    .background(
-                        ReviewDraftSummaryPressMarker(
-                            identifier: "review-draft-summary-send-agent",
-                            label: "Send to agent",
-                            isEnabled: canSendToAgent
-                        ) {
-                            draftCommentActions.sendToAgent(bundle)
-                        }
-                    )
+                    expandedSendToAgentControl
                 }
 
                 Spacer(minLength: 0)
@@ -234,6 +210,87 @@ struct ReviewDraftSummaryRail: View {
         )
     }
 
+    @ViewBuilder
+    private var collapsedSendToAgentControl: some View {
+        if agentTargets.count > 1 {
+            Menu {
+                ForEach(agentTargets) { target in
+                    Button(target.title) {
+                        draftCommentActions.sendToAgent(bundle, target)
+                    }
+                }
+            } label: {
+                summaryActionIcon(systemName: "paperplane", enabled: canSendToAgent)
+            }
+            .menuStyle(.borderlessButton)
+            .disabled(!canSendToAgent)
+            .help("Send to agent")
+            .accessibilityIdentifier("review-draft-summary-send-agent")
+            .accessibilityLabel("Send to agent")
+        } else {
+            collapsedActionButton(
+                id: "review-draft-summary-send-agent",
+                systemName: "paperplane",
+                label: "Send to agent",
+                enabled: canSendToAgent
+            ) {
+                guard let target = agentTargets.first else { return }
+                draftCommentActions.sendToAgent(bundle, target)
+            }
+        }
+    }
+
+    @ViewBuilder
+    private var expandedSendToAgentControl: some View {
+        if agentTargets.count > 1 {
+            Menu {
+                ForEach(agentTargets) { target in
+                    Button(target.title) {
+                        draftCommentActions.sendToAgent(bundle, target)
+                    }
+                }
+            } label: {
+                summaryActionIcon(systemName: "paperplane", enabled: canSendToAgent)
+            }
+            .menuStyle(.borderlessButton)
+            .disabled(!canSendToAgent)
+            .help("Send to agent")
+            .accessibilityIdentifier("review-draft-summary-send-agent")
+            .accessibilityLabel("Send to agent")
+        } else {
+            Button {
+                guard let target = agentTargets.first else { return }
+                draftCommentActions.sendToAgent(bundle, target)
+            } label: {
+                summaryActionIcon(systemName: "paperplane", enabled: canSendToAgent)
+            }
+            .buttonStyle(.plain)
+            .disabled(!canSendToAgent)
+            .help("Send to agent")
+            .accessibilityIdentifier("review-draft-summary-send-agent")
+            .accessibilityLabel("Send to agent")
+            .background(
+                ReviewDraftSummaryPressMarker(
+                    identifier: "review-draft-summary-send-agent",
+                    label: "Send to agent",
+                    isEnabled: canSendToAgent
+                ) {
+                    guard let target = agentTargets.first else { return }
+                    draftCommentActions.sendToAgent(bundle, target)
+                }
+            )
+        }
+    }
+
+    private func summaryActionIcon(systemName: String, enabled: Bool) -> some View {
+        Image(systemName: systemName)
+            .font(.system(size: 12, weight: .medium))
+            .foregroundColor(enabled ? theme.color("fg-muted") : theme.color("fg-faint"))
+            .frame(width: 28, height: 24)
+            .background(theme.color("bg-3"))
+            .clipShape(RoundedRectangle(cornerRadius: 6))
+    }
+
     private func commentGroup(_ group: CommentGroup) -> some View {
         VStack(alignment: .leading, spacing: 6) {
             Text(group.path)
@@ -269,11 +326,22 @@ struct ReviewDraftSummaryRail: View {
                         Spacer(minLength: 0)
                     }
 
-                    Text(DiffReviewInlineFeedbackMarkdown.render(comment.bodyMarkdown))
-                        .font(.system(size: 11.5))
-                        .foregroundColor(theme.color("fg"))
-                        .lineLimit(4)
-                        .fixedSize(horizontal: false, vertical: true)
+                    if editingCommentID == comment.id {
+                        TextEditor(text: $editingBody)
+                            .font(.system(size: 11.5))
+                            .foregroundColor(theme.color("fg"))
+                            .scrollContentBackground(.hidden)
+                            .frame(minHeight: 62)
+                            .background(theme.color("bg-2"))
+                            .clipShape(RoundedRectangle(cornerRadius: 5))
+                            .accessibilityIdentifier("review-draft-summary-editor-\(comment.id)")
+                    } else {
+                        Text(DiffReviewInlineFeedbackMarkdown.render(comment.bodyMarkdown))
+                            .font(.system(size: 11.5))
+                            .foregroundColor(theme.color("fg"))
+                            .lineLimit(4)
+                            .fixedSize(horizontal: false, vertical: true)
+                    }
                 }
                 .frame(maxWidth: .infinity, alignment: .leading)
                 .contentShape(Rectangle())
@@ -285,9 +353,20 @@ struct ReviewDraftSummaryRail: View {
             if availability.canEdit || availability.canDelete || availability.canResolve || availability.canDismiss {
                 HStack(spacing: 5) {
                     Spacer(minLength: 0)
-                    if availability.canEdit {
+                    if editingCommentID == comment.id {
+                        commentActionButton(id: "save", commentID: comment.id, systemName: "checkmark", tooltip: "Save") {
+                            draftCommentActions.edit(comment, editingBody)
+                            editingCommentID = nil
+                            editingBody = ""
+                        }
+                        commentActionButton(id: "cancel", commentID: comment.id, systemName: "xmark", tooltip: "Cancel") {
+                            editingCommentID = nil
+                            editingBody = ""
+                        }
+                    } else if availability.canEdit {
                         commentActionButton(id: "edit", commentID: comment.id, systemName: "pencil", tooltip: "Edit") {
-                            draftCommentActions.edit(comment)
+                            editingCommentID = comment.id
+                            editingBody = comment.bodyMarkdown
                         }
                     }
                     if availability.canResolve {

--- a/Alas/Sources/Center/ReviewWorkspace/ReviewDraftSummaryRail.swift
+++ b/Alas/Sources/Center/ReviewWorkspace/ReviewDraftSummaryRail.swift
@@ -12,7 +12,7 @@ struct ReviewDraftSummaryRail: View {
     @Environment(\.theme) private var theme
 
     private var visibleComments: [ReviewDraftComment] {
-        ReviewDraftCommentPlacement.sorted(comments.filter { $0.state != .dismissed })
+        ReviewDraftCommentPlacement.sorted(comments)
     }
 
     private var activeCount: Int {
@@ -254,8 +254,8 @@ struct ReviewDraftSummaryRail: View {
                         Text(lineDescription(for: comment))
                             .font(.system(size: 10, weight: .semibold))
                             .foregroundColor(statusColor(for: comment))
-                        if comment.state == .resolved {
-                            Text("resolved")
+                        if let stateLabel = stateLabel(for: comment) {
+                            Text(stateLabel)
                                 .font(.system(size: 10))
                                 .foregroundColor(theme.color("fg-faint"))
                         }
@@ -349,9 +349,9 @@ struct ReviewDraftSummaryRail: View {
     private func lineDescription(for comment: ReviewDraftComment) -> String {
         let range = comment.normalizedLineRange
         if range.lowerBound == range.upperBound {
-            return "line \(range.lowerBound)"
+            return "\(sideLabel(for: comment.side)) line \(range.lowerBound)"
         }
-        return "lines \(range.lowerBound)-\(range.upperBound)"
+        return "\(sideLabel(for: comment.side)) lines \(range.lowerBound)-\(range.upperBound)"
     }
 
     private func accessibilityLabel(for comment: ReviewDraftComment) -> String {
@@ -359,14 +359,36 @@ struct ReviewDraftSummaryRail: View {
             "Draft comment",
             comment.path,
             lineDescription(for: comment),
-            comment.state == .resolved ? "resolved" : nil,
+            stateLabel(for: comment),
             DiffReviewInlineFeedbackMarkdown.plainText(comment.bodyMarkdown),
         ]
         .compactMap { part in
             guard let part, !part.isEmpty else { return nil }
             return part
         }
-        .joined(separator: ", ")
+            .joined(separator: ", ")
+    }
+
+    private func stateLabel(for comment: ReviewDraftComment) -> String? {
+        switch comment.state {
+        case .active:
+            nil
+        case .resolved:
+            "resolved"
+        case .dismissed:
+            "dismissed"
+        }
+    }
+
+    private func sideLabel(for side: DiffReviewInlineFeedbackSide) -> String {
+        switch side {
+        case .old:
+            "old"
+        case .new:
+            "new"
+        case .unknown:
+            "unknown"
+        }
     }
 
     private func statusColor(for comment: ReviewDraftComment) -> Color {

--- a/Alas/Sources/Center/ReviewWorkspace/ReviewDraftSummaryRail.swift
+++ b/Alas/Sources/Center/ReviewWorkspace/ReviewDraftSummaryRail.swift
@@ -275,7 +275,7 @@ struct ReviewDraftSummaryRail: View {
             .accessibilityIdentifier("review-draft-summary-comment-\(comment.id)")
             .accessibilityLabel(accessibilityLabel(for: comment))
 
-            if availability.canEdit || availability.canDelete || availability.canResolve {
+            if availability.canEdit || availability.canDelete || availability.canResolve || availability.canDismiss {
                 HStack(spacing: 5) {
                     Spacer(minLength: 0)
                     if availability.canEdit {
@@ -286,6 +286,11 @@ struct ReviewDraftSummaryRail: View {
                     if availability.canResolve {
                         commentActionButton(id: "resolve", commentID: comment.id, systemName: "checkmark", tooltip: "Resolve") {
                             draftCommentActions.resolve(comment)
+                        }
+                    }
+                    if availability.canDismiss {
+                        commentActionButton(id: "dismiss", commentID: comment.id, systemName: "xmark", tooltip: "Dismiss") {
+                            draftCommentActions.dismiss(comment)
                         }
                     }
                     if availability.canDelete {
@@ -332,6 +337,13 @@ struct ReviewDraftSummaryRail: View {
         .help(tooltip)
         .accessibilityIdentifier("review-draft-summary-\(id)-\(commentID)")
         .accessibilityLabel(tooltip)
+        .background(
+            ReviewDraftSummaryPressMarker(
+                identifier: "review-draft-summary-\(id)-\(commentID)",
+                label: tooltip,
+                action: action
+            )
+        )
     }
 
     private func lineDescription(for comment: ReviewDraftComment) -> String {

--- a/Alas/Sources/Center/ReviewWorkspace/ReviewDraftSummaryRail.swift
+++ b/Alas/Sources/Center/ReviewWorkspace/ReviewDraftSummaryRail.swift
@@ -76,6 +76,22 @@ struct ReviewDraftSummaryRail: View {
             collapseButton
                 .padding(.top, 8)
             activeCountPill(compact: true)
+            collapsedActionButton(
+                id: "review-draft-summary-copy-prompt",
+                systemName: "doc.on.doc",
+                label: "Copy prompt",
+                enabled: canCopyPrompt
+            ) {
+                draftCommentActions.copyPrompt(bundle)
+            }
+            collapsedActionButton(
+                id: "review-draft-summary-send-agent",
+                systemName: "paperplane",
+                label: "Send to agent",
+                enabled: canSendToAgent
+            ) {
+                draftCommentActions.sendToAgent(bundle)
+            }
             Spacer(minLength: 0)
         }
     }
@@ -178,6 +194,37 @@ struct ReviewDraftSummaryRail: View {
             .background((activeCount > 0 ? theme.color("warn") : theme.color("fg-muted")).opacity(0.15))
             .clipShape(RoundedRectangle(cornerRadius: compact ? 6 : 5))
             .accessibilityLabel("\(activeCount) active draft comments")
+    }
+
+    private func collapsedActionButton(
+        id: String,
+        systemName: String,
+        label: String,
+        enabled: Bool,
+        action: @escaping () -> Void
+    ) -> some View {
+        Button {
+            guard enabled else { return }
+            action()
+        } label: {
+            Image(systemName: systemName)
+                .font(.system(size: 11, weight: .medium))
+                .foregroundColor(enabled ? theme.color("fg-muted") : theme.color("fg-faint"))
+                .frame(width: 26, height: 24)
+                .background(theme.color("bg-3"))
+                .clipShape(RoundedRectangle(cornerRadius: 6))
+        }
+        .buttonStyle(.plain)
+        .disabled(!enabled)
+        .help(label)
+        .accessibilityIdentifier(id)
+        .accessibilityLabel(label)
+        .background(
+            ReviewDraftSummaryPressMarker(identifier: id, label: label) {
+                guard enabled else { return }
+                action()
+            }
+        )
     }
 
     private func commentGroup(_ group: CommentGroup) -> some View {

--- a/Alas/Sources/Center/ReviewWorkspace/ReviewDraftSummaryRail.swift
+++ b/Alas/Sources/Center/ReviewWorkspace/ReviewDraftSummaryRail.swift
@@ -128,9 +128,9 @@ struct ReviewDraftSummaryRail: View {
                 .background(
                     ReviewDraftSummaryPressMarker(
                         identifier: "review-draft-summary-copy-prompt",
-                        label: "Copy prompt"
+                        label: "Copy prompt",
+                        isEnabled: canCopyPrompt
                     ) {
-                        guard canCopyPrompt else { return }
                         draftCommentActions.copyPrompt(bundle)
                     }
                 )
@@ -153,9 +153,9 @@ struct ReviewDraftSummaryRail: View {
                 .background(
                     ReviewDraftSummaryPressMarker(
                         identifier: "review-draft-summary-send-agent",
-                        label: "Send to agent"
+                        label: "Send to agent",
+                        isEnabled: canSendToAgent
                     ) {
-                        guard canSendToAgent else { return }
                         draftCommentActions.sendToAgent(bundle)
                     }
                 )
@@ -220,8 +220,7 @@ struct ReviewDraftSummaryRail: View {
         .accessibilityIdentifier(id)
         .accessibilityLabel(label)
         .background(
-            ReviewDraftSummaryPressMarker(identifier: id, label: label) {
-                guard enabled else { return }
+            ReviewDraftSummaryPressMarker(identifier: id, label: label, isEnabled: enabled) {
                 action()
             }
         )
@@ -341,6 +340,7 @@ struct ReviewDraftSummaryRail: View {
             ReviewDraftSummaryPressMarker(
                 identifier: "review-draft-summary-\(id)-\(commentID)",
                 label: tooltip,
+                isEnabled: true,
                 action: action
             )
         )
@@ -413,6 +413,7 @@ private struct CommentGroup: Identifiable {
 private struct ReviewDraftSummaryPressMarker: NSViewRepresentable {
     let identifier: String
     let label: String?
+    var isEnabled = true
     let action: () -> Void
 
     func makeNSView(context: Context) -> ReviewDraftSummaryPressView {
@@ -420,6 +421,8 @@ private struct ReviewDraftSummaryPressMarker: NSViewRepresentable {
         view.setAccessibilityIdentifier(identifier)
         view.setAccessibilityLabel(label)
         view.setAccessibilityRole(.button)
+        view.setAccessibilityEnabled(isEnabled)
+        view.isEnabled = isEnabled
         view.action = action
         return view
     }
@@ -428,14 +431,18 @@ private struct ReviewDraftSummaryPressMarker: NSViewRepresentable {
         view.setAccessibilityIdentifier(identifier)
         view.setAccessibilityLabel(label)
         view.setAccessibilityRole(.button)
+        view.setAccessibilityEnabled(isEnabled)
+        view.isEnabled = isEnabled
         view.action = action
     }
 }
 
 private final class ReviewDraftSummaryPressView: NSView {
+    var isEnabled = true
     var action: () -> Void = {}
 
     override func accessibilityPerformPress() -> Bool {
+        guard isEnabled else { return false }
         action()
         return true
     }

--- a/Alas/Sources/Center/ReviewWorkspace/ReviewDraftSummaryRail.swift
+++ b/Alas/Sources/Center/ReviewWorkspace/ReviewDraftSummaryRail.swift
@@ -310,45 +310,19 @@ struct ReviewDraftSummaryRail: View {
         let isFocused = comment.id == focusedDraftCommentID
 
         return VStack(alignment: .leading, spacing: 6) {
-            Button {
-                onSelectDraftComment(comment)
-            } label: {
-                VStack(alignment: .leading, spacing: 5) {
-                    HStack(spacing: 6) {
-                        Text(lineDescription(for: comment))
-                            .font(.system(size: 10, weight: .semibold))
-                            .foregroundColor(statusColor(for: comment))
-                        if let stateLabel = stateLabel(for: comment) {
-                            Text(stateLabel)
-                                .font(.system(size: 10))
-                                .foregroundColor(theme.color("fg-faint"))
-                        }
-                        Spacer(minLength: 0)
-                    }
-
-                    if editingCommentID == comment.id {
-                        TextEditor(text: $editingBody)
-                            .font(.system(size: 11.5))
-                            .foregroundColor(theme.color("fg"))
-                            .scrollContentBackground(.hidden)
-                            .frame(minHeight: 62)
-                            .background(theme.color("bg-2"))
-                            .clipShape(RoundedRectangle(cornerRadius: 5))
-                            .accessibilityIdentifier("review-draft-summary-editor-\(comment.id)")
-                    } else {
-                        Text(DiffReviewInlineFeedbackMarkdown.render(comment.bodyMarkdown))
-                            .font(.system(size: 11.5))
-                            .foregroundColor(theme.color("fg"))
-                            .lineLimit(4)
-                            .fixedSize(horizontal: false, vertical: true)
-                    }
+            if editingCommentID == comment.id {
+                summaryCardContent(comment)
+            } else {
+                Button {
+                    onSelectDraftComment(comment)
+                } label: {
+                    summaryCardContent(comment)
+                        .contentShape(Rectangle())
                 }
-                .frame(maxWidth: .infinity, alignment: .leading)
-                .contentShape(Rectangle())
+                .buttonStyle(.plain)
+                .accessibilityIdentifier("review-draft-summary-comment-\(comment.id)")
+                .accessibilityLabel(accessibilityLabel(for: comment))
             }
-            .buttonStyle(.plain)
-            .accessibilityIdentifier("review-draft-summary-comment-\(comment.id)")
-            .accessibilityLabel(accessibilityLabel(for: comment))
 
             if availability.canEdit || availability.canDelete || availability.canResolve || availability.canDismiss {
                 HStack(spacing: 5) {
@@ -397,11 +371,46 @@ struct ReviewDraftSummaryRail: View {
         .background(
             ReviewDraftSummaryPressMarker(
                 identifier: "review-draft-summary-comment-\(comment.id)",
-                label: accessibilityLabel(for: comment)
+                label: accessibilityLabel(for: comment),
+                isEnabled: editingCommentID != comment.id
             ) {
                 onSelectDraftComment(comment)
             }
         )
+    }
+
+    private func summaryCardContent(_ comment: ReviewDraftComment) -> some View {
+        VStack(alignment: .leading, spacing: 5) {
+            HStack(spacing: 6) {
+                Text(lineDescription(for: comment))
+                    .font(.system(size: 10, weight: .semibold))
+                    .foregroundColor(statusColor(for: comment))
+                if let stateLabel = stateLabel(for: comment) {
+                    Text(stateLabel)
+                        .font(.system(size: 10))
+                        .foregroundColor(theme.color("fg-faint"))
+                }
+                Spacer(minLength: 0)
+            }
+
+            if editingCommentID == comment.id {
+                TextEditor(text: $editingBody)
+                    .font(.system(size: 11.5))
+                    .foregroundColor(theme.color("fg"))
+                    .scrollContentBackground(.hidden)
+                    .frame(minHeight: 62)
+                    .background(theme.color("bg-2"))
+                    .clipShape(RoundedRectangle(cornerRadius: 5))
+                    .accessibilityIdentifier("review-draft-summary-editor-\(comment.id)")
+            } else {
+                Text(DiffReviewInlineFeedbackMarkdown.render(comment.bodyMarkdown))
+                    .font(.system(size: 11.5))
+                    .foregroundColor(theme.color("fg"))
+                    .lineLimit(4)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
     }
 
     private func commentActionButton(

--- a/Alas/Sources/Center/ReviewWorkspace/ReviewFeedbackAgentSender.swift
+++ b/Alas/Sources/Center/ReviewWorkspace/ReviewFeedbackAgentSender.swift
@@ -103,19 +103,21 @@ enum ReviewDraftWorkspaceActions {
             pasteboard.setString(prompt, forType: .string)
         }
     ) -> ReviewDraftCommentActions {
-        let hasSendTarget = !sender.availableTargets().isEmpty
-
         return ReviewDraftCommentActions(
             availability: { comment in
-                ReviewDraftCommentActionAvailability(
-                    canEdit: false,
+                let hasCurrentSendTarget = !sender.availableTargets().isEmpty
+                return ReviewDraftCommentActionAvailability(
+                    canEdit: comment.isActive,
                     canDelete: true,
                     canResolve: comment.isActive,
                     canDismiss: comment.isActive,
                     canCopyPrompt: comment.isActive,
-                    canShowSendToAgent: hasSendTarget,
-                    canSendToAgent: comment.isActive && hasSendTarget
+                    canShowSendToAgent: hasCurrentSendTarget,
+                    canSendToAgent: comment.isActive && hasCurrentSendTarget
                 )
+            },
+            edit: { comment, bodyMarkdown in
+                try? controller?.edit(commentID: comment.id, bodyMarkdown: bodyMarkdown)
             },
             delete: { comment in
                 try? controller?.delete(commentID: comment.id)
@@ -129,8 +131,10 @@ enum ReviewDraftWorkspaceActions {
             copyPrompt: { bundle in
                 ReviewFeedbackPromptActions.copyPrompt(bundle, pasteboard: pasteboard)
             },
-            sendToAgent: { bundle in
-                guard let target = sender.availableTargets().first else { return }
+            agentTargets: {
+                sender.availableTargets()
+            },
+            sendToAgent: { bundle, target in
                 ReviewFeedbackPromptActions.sendToAgent(bundle, target: target, sender: sender)
             }
         )

--- a/Alas/Sources/Center/ReviewWorkspace/ReviewFeedbackAgentSender.swift
+++ b/Alas/Sources/Center/ReviewWorkspace/ReviewFeedbackAgentSender.swift
@@ -1,0 +1,169 @@
+import AppKit
+import Foundation
+
+enum ReviewDraftCommentGrouping {
+    static func commentsByFileID(_ comments: [ReviewDraftComment]) -> [DiffReviewFileID: [ReviewDraftComment]] {
+        Dictionary(grouping: comments, by: \.fileID)
+    }
+}
+
+enum ReviewFeedbackAgentTarget: Equatable, Identifiable {
+    case newChat(agentID: String, title: String)
+    case existingSession(worktreeID: String, sessionID: String, title: String)
+
+    var id: String {
+        switch self {
+        case .newChat(let agentID, _):
+            return "new:\(agentID)"
+        case .existingSession(let worktreeID, let sessionID, _):
+            return "existing:\(worktreeID):\(sessionID)"
+        }
+    }
+
+    var title: String {
+        switch self {
+        case .newChat(_, let title), .existingSession(_, _, let title):
+            return title
+        }
+    }
+}
+
+@MainActor
+struct ReviewFeedbackAgentSender {
+    var availableTargets: () -> [ReviewFeedbackAgentTarget]
+    var send: (String, ReviewFeedbackAgentTarget) -> Void
+
+    static func production(appState: AppState, worktreeID: String) -> ReviewFeedbackAgentSender {
+        ReviewFeedbackAgentSender(
+            availableTargets: {
+                var targets: [ReviewFeedbackAgentTarget] = []
+                let agentID = appState.config.changes.aiToolId
+                if agentID != "none", appState.agent(id: agentID) != nil {
+                    targets.append(.newChat(agentID: agentID, title: "New chat"))
+                }
+
+                let sessionTargets = appState.tabs.tabs(forWorktree: worktreeID).compactMap { tab -> ReviewFeedbackAgentTarget? in
+                    guard case .acpSession(let state) = tab,
+                          appState.session(for: state.sessionId) != nil,
+                          appState.isWriter(for: state.sessionId)
+                    else { return nil }
+                    return .existingSession(
+                        worktreeID: worktreeID,
+                        sessionID: state.sessionId,
+                        title: state.title.isEmpty ? "Existing chat" : state.title
+                    )
+                }
+                targets.append(contentsOf: sessionTargets)
+                return targets
+            },
+            send: { prompt, target in
+                switch target {
+                case .newChat(let agentID, _):
+                    appState.openNewACPSession(agentID: agentID, initialPrompt: prompt)
+                case .existingSession(_, let sessionID, _):
+                    appState.sendPrompt(for: sessionID, text: prompt, attachments: []) { _ in }
+                }
+            }
+        )
+    }
+}
+
+enum ReviewFeedbackPromptActions {
+    static func copyPrompt(
+        _ bundle: ReviewFeedbackBundle,
+        pasteboard: (String) -> Void = copyReviewPrompt
+    ) {
+        pasteboard(bundle.promptMarkdown())
+    }
+
+    @MainActor
+    static func sendToAgent(
+        _ bundle: ReviewFeedbackBundle,
+        target: ReviewFeedbackAgentTarget,
+        sender: ReviewFeedbackAgentSender
+    ) {
+        sender.send(bundle.promptMarkdown(), target)
+    }
+
+    private static func copyReviewPrompt(_ prompt: String) {
+        let pasteboard = NSPasteboard.general
+        pasteboard.clearContents()
+        pasteboard.setString(prompt, forType: .string)
+    }
+}
+
+@MainActor
+enum ReviewDraftWorkspaceActions {
+    static func make(
+        controller: ReviewDraftCommentController?,
+        sender: ReviewFeedbackAgentSender,
+        pasteboard: @escaping (String) -> Void = { prompt in
+            let pasteboard = NSPasteboard.general
+            pasteboard.clearContents()
+            pasteboard.setString(prompt, forType: .string)
+        }
+    ) -> ReviewDraftCommentActions {
+        let hasSendTarget = !sender.availableTargets().isEmpty
+
+        return ReviewDraftCommentActions(
+            availability: { comment in
+                ReviewDraftCommentActionAvailability(
+                    canEdit: false,
+                    canDelete: true,
+                    canResolve: comment.isActive,
+                    canDismiss: comment.isActive,
+                    canCopyPrompt: comment.isActive,
+                    canSendToAgent: comment.isActive && hasSendTarget
+                )
+            },
+            delete: { comment in
+                try? controller?.delete(commentID: comment.id)
+            },
+            resolve: { comment in
+                try? controller?.resolve(commentID: comment.id)
+            },
+            dismiss: { comment in
+                try? controller?.dismiss(commentID: comment.id)
+            },
+            copyPrompt: { bundle in
+                ReviewFeedbackPromptActions.copyPrompt(bundle, pasteboard: pasteboard)
+            },
+            sendToAgent: { bundle in
+                guard let target = sender.availableTargets().first else { return }
+                ReviewFeedbackPromptActions.sendToAgent(bundle, target: target, sender: sender)
+            }
+        )
+    }
+}
+
+struct DiffReviewDraftCommentScrollCommand: Equatable {
+    let commentID: String
+    let fileID: DiffReviewFileID
+    let generation: Int
+
+    var targetID: DiffReviewDraftCommentTargetID {
+        DiffReviewDraftCommentTargetID.targetID(commentID: commentID, fileID: fileID)
+    }
+}
+
+struct DiffReviewDraftCommentScrollController: Equatable {
+    private(set) var generation = 0
+
+    mutating func command(commentID: String, fileID: DiffReviewFileID) -> DiffReviewDraftCommentScrollCommand {
+        generation += 1
+        return DiffReviewDraftCommentScrollCommand(
+            commentID: commentID,
+            fileID: fileID,
+            generation: generation
+        )
+    }
+}
+
+struct DiffReviewDraftCommentTargetID: Hashable, Equatable {
+    let fileID: DiffReviewFileID
+    let commentID: String
+
+    static func targetID(commentID: String, fileID: DiffReviewFileID) -> DiffReviewDraftCommentTargetID {
+        DiffReviewDraftCommentTargetID(fileID: fileID, commentID: commentID)
+    }
+}

--- a/Alas/Sources/Center/ReviewWorkspace/ReviewFeedbackAgentSender.swift
+++ b/Alas/Sources/Center/ReviewWorkspace/ReviewFeedbackAgentSender.swift
@@ -113,6 +113,7 @@ enum ReviewDraftWorkspaceActions {
                     canResolve: comment.isActive,
                     canDismiss: comment.isActive,
                     canCopyPrompt: comment.isActive,
+                    canShowSendToAgent: hasSendTarget,
                     canSendToAgent: comment.isActive && hasSendTarget
                 )
             },

--- a/Alas/Sources/Center/ReviewWorkspace/ReviewFeedbackBundle.swift
+++ b/Alas/Sources/Center/ReviewWorkspace/ReviewFeedbackBundle.swift
@@ -41,12 +41,21 @@ struct ReviewFeedbackBundle: Equatable, Sendable {
             lines.append("## \(path)")
 
             for comment in comments {
-                lines.append("- `\(path):\(lineDescription(for: comment)) (\(comment.side.rawValue))` — \(singleLineBody(comment.bodyMarkdown))")
+                let bodyLines = markdownBodyLines(comment.bodyMarkdown)
+                if bodyLines.count <= 1 {
+                    let suffix = bodyLines.first.map { " — \($0)" } ?? ""
+                    lines.append("- `\(path):\(lineDescription(for: comment)) (\(comment.side.rawValue))`\(suffix)")
+                } else {
+                    lines.append("- `\(path):\(lineDescription(for: comment)) (\(comment.side.rawValue))`")
+                    lines.append(contentsOf: bodyLines)
+                }
 
-                if let selectedText = comment.selectedText?.trimmingCharacters(in: .whitespacesAndNewlines),
-                   !selectedText.isEmpty {
-                    for selectedLine in selectedText.components(separatedBy: .newlines) {
-                        lines.append("> \(selectedLine)")
+                if let selectedText = comment.selectedText {
+                    let selectedTextForDisplay = selectedText.trimmingCharacters(in: .newlines)
+                    if !selectedTextForDisplay.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+                        for selectedLine in selectedTextForDisplay.components(separatedBy: .newlines) {
+                            lines.append("> \(selectedLine)")
+                        }
                     }
                 }
             }
@@ -81,10 +90,15 @@ struct ReviewFeedbackBundle: Equatable, Sendable {
         return "\(range.lowerBound)-\(range.upperBound)"
     }
 
-    private func singleLineBody(_ body: String) -> String {
-        body.components(separatedBy: .newlines)
-            .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
-            .filter { !$0.isEmpty }
-            .joined(separator: " ")
+    private func markdownBodyLines(_ body: String) -> [String] {
+        let trimmedBody = body.trimmingCharacters(in: .newlines)
+        guard !trimmedBody.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+            return []
+        }
+        let lines = trimmedBody.components(separatedBy: .newlines)
+        if lines.count == 1 {
+            return [lines[0].trimmingCharacters(in: .whitespacesAndNewlines)]
+        }
+        return lines
     }
 }

--- a/Alas/Sources/Center/ReviewWorkspace/ReviewFeedbackBundle.swift
+++ b/Alas/Sources/Center/ReviewWorkspace/ReviewFeedbackBundle.swift
@@ -1,0 +1,90 @@
+import Foundation
+
+struct ReviewFeedbackTarget: Equatable, Sendable {
+    var title: String
+    var repositoryPath: String?
+    var providerDescription: String?
+    var sourceDescription: String
+}
+
+struct ReviewFeedbackBundle: Equatable, Sendable {
+    var target: ReviewFeedbackTarget
+    var comments: [ReviewDraftComment]
+
+    var activeComments: [ReviewDraftComment] {
+        comments.filter(\.isActive)
+    }
+
+    func promptMarkdown() -> String {
+        var lines: [String] = [
+            "Please address each review comment below.",
+            "",
+            "Inspect the referenced files and make the smallest safe changes. Explain what changed. Do not publish remote review comments unless explicitly asked.",
+            "",
+            "Review target: \(target.title)",
+        ]
+
+        if let repositoryPath = target.repositoryPath, !repositoryPath.isEmpty {
+            lines.append("Repository: \(repositoryPath)")
+        }
+
+        lines.append("Source: \(target.sourceDescription)")
+
+        if let providerDescription = target.providerDescription, !providerDescription.isEmpty {
+            lines.append("Provider: \(providerDescription)")
+        }
+
+        let commentsByPath = Dictionary(grouping: sortedActiveComments(), by: \.path)
+        for path in commentsByPath.keys.sorted(by: { $0.localizedStandardCompare($1) == .orderedAscending }) {
+            guard let comments = commentsByPath[path] else { continue }
+            lines.append("")
+            lines.append("## \(path)")
+
+            for comment in comments {
+                lines.append("- `\(path):\(lineDescription(for: comment)) (\(comment.side.rawValue))` — \(singleLineBody(comment.bodyMarkdown))")
+
+                if let selectedText = comment.selectedText?.trimmingCharacters(in: .whitespacesAndNewlines),
+                   !selectedText.isEmpty {
+                    for selectedLine in selectedText.components(separatedBy: .newlines) {
+                        lines.append("> \(selectedLine)")
+                    }
+                }
+            }
+        }
+
+        return lines.joined(separator: "\n")
+    }
+
+    private func sortedActiveComments() -> [ReviewDraftComment] {
+        activeComments.sorted { lhs, rhs in
+            if lhs.path != rhs.path {
+                return lhs.path.localizedStandardCompare(rhs.path) == .orderedAscending
+            }
+            if lhs.normalizedLineRange.lowerBound != rhs.normalizedLineRange.lowerBound {
+                return lhs.normalizedLineRange.lowerBound < rhs.normalizedLineRange.lowerBound
+            }
+            if lhs.normalizedLineRange.upperBound != rhs.normalizedLineRange.upperBound {
+                return lhs.normalizedLineRange.upperBound < rhs.normalizedLineRange.upperBound
+            }
+            if lhs.createdAt != rhs.createdAt {
+                return lhs.createdAt < rhs.createdAt
+            }
+            return lhs.id < rhs.id
+        }
+    }
+
+    private func lineDescription(for comment: ReviewDraftComment) -> String {
+        let range = comment.normalizedLineRange
+        if range.lowerBound == range.upperBound {
+            return "\(range.lowerBound)"
+        }
+        return "\(range.lowerBound)-\(range.upperBound)"
+    }
+
+    private func singleLineBody(_ body: String) -> String {
+        body.components(separatedBy: .newlines)
+            .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+            .filter { !$0.isEmpty }
+            .joined(separator: " ")
+    }
+}

--- a/Alas/Sources/Center/ReviewWorkspace/ReviewFeedbackBundle.swift
+++ b/Alas/Sources/Center/ReviewWorkspace/ReviewFeedbackBundle.swift
@@ -34,19 +34,22 @@ struct ReviewFeedbackBundle: Equatable, Sendable {
             lines.append("Provider: \(providerDescription)")
         }
 
-        let commentsByPath = Dictionary(grouping: sortedActiveComments(), by: \.path)
-        for path in commentsByPath.keys.sorted(by: { $0.localizedStandardCompare($1) == .orderedAscending }) {
-            guard let comments = commentsByPath[path] else { continue }
+        let commentsByFile = Dictionary(grouping: sortedActiveComments(), by: ReviewFeedbackFileContext.init(comment:))
+        let sortedFiles = commentsByFile.keys.sorted()
+        for fileContext in sortedFiles {
+            guard let comments = commentsByFile[fileContext] else { continue }
+            let path = fileContext.path
             lines.append("")
-            lines.append("## \(path)")
+            lines.append("## \(fileContext.heading)")
 
             for comment in comments {
+                let reference = fileContext.reference(for: comment)
                 let bodyLines = markdownBodyLines(comment.bodyMarkdown)
                 if bodyLines.count <= 1 {
                     let suffix = bodyLines.first.map { " — \($0)" } ?? ""
-                    lines.append("- `\(path):\(lineDescription(for: comment)) (\(comment.side.rawValue))`\(suffix)")
+                    lines.append("- `\(reference)`\(suffix)")
                 } else {
-                    lines.append("- `\(path):\(lineDescription(for: comment)) (\(comment.side.rawValue))`")
+                    lines.append("- `\(reference)`")
                     lines.append(contentsOf: bodyLines)
                 }
 
@@ -82,14 +85,6 @@ struct ReviewFeedbackBundle: Equatable, Sendable {
         }
     }
 
-    private func lineDescription(for comment: ReviewDraftComment) -> String {
-        let range = comment.normalizedLineRange
-        if range.lowerBound == range.upperBound {
-            return "\(range.lowerBound)"
-        }
-        return "\(range.lowerBound)-\(range.upperBound)"
-    }
-
     private func markdownBodyLines(_ body: String) -> [String] {
         let trimmedBody = body.trimmingCharacters(in: .newlines)
         guard !trimmedBody.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
@@ -100,5 +95,48 @@ struct ReviewFeedbackBundle: Equatable, Sendable {
             return [lines[0].trimmingCharacters(in: .whitespacesAndNewlines)]
         }
         return lines
+    }
+}
+
+private struct ReviewFeedbackFileContext: Hashable, Comparable {
+    var path: String
+    var namespace: String
+
+    init(comment: ReviewDraftComment) {
+        self.path = comment.path
+        self.namespace = comment.fileID.namespace
+    }
+
+    var heading: String {
+        guard shouldDisplayNamespace else { return path }
+        return "\(path) [\(namespace)]"
+    }
+
+    func reference(for comment: ReviewDraftComment) -> String {
+        let line = ReviewFeedbackFileContext.lineDescription(for: comment)
+        guard shouldDisplayNamespace else {
+            return "\(path):\(line) (\(comment.side.rawValue))"
+        }
+        return "\(path):\(line) (\(comment.side.rawValue), \(namespace))"
+    }
+
+    static func < (lhs: ReviewFeedbackFileContext, rhs: ReviewFeedbackFileContext) -> Bool {
+        let pathOrder = lhs.path.localizedStandardCompare(rhs.path)
+        if pathOrder != .orderedSame {
+            return pathOrder == .orderedAscending
+        }
+        return lhs.namespace.localizedStandardCompare(rhs.namespace) == .orderedAscending
+    }
+
+    private var shouldDisplayNamespace: Bool {
+        !namespace.isEmpty && namespace != "review"
+    }
+
+    private static func lineDescription(for comment: ReviewDraftComment) -> String {
+        let range = comment.normalizedLineRange
+        if range.lowerBound == range.upperBound {
+            return "\(range.lowerBound)"
+        }
+        return "\(range.lowerBound)-\(range.upperBound)"
     }
 }

--- a/Alas/Sources/Persistence/Paths.swift
+++ b/Alas/Sources/Persistence/Paths.swift
@@ -56,6 +56,12 @@ extension Paths {
 }
 
 extension Paths {
+    static var reviewDraftCommentsFile: URL {
+        appSupportRoot.appendingPathComponent("review-draft-comments.json")
+    }
+}
+
+extension Paths {
     static var acpAttachmentsRoot: URL { appSupportRoot.appendingPathComponent("acp-attachments", isDirectory: true) }
 
     static func acpAttachmentsDir(forWorktreeId id: String) -> URL {

--- a/AlasTests/CommitTabViewTests.swift
+++ b/AlasTests/CommitTabViewTests.swift
@@ -21,6 +21,18 @@ struct CommitTabViewTests {
         #expect(sessionID.sourceKind == .commit)
     }
 
+    @Test func commitReviewFeedbackTargetIncludesCommitSHA() {
+        let sha = "abcdef1234567890abcdef1234567890abcdef12"
+        let target = CommitReviewBody.reviewFeedbackTarget(
+            repositoryPath: URL(fileURLWithPath: "/repo"),
+            sha: sha
+        )
+
+        #expect(target.title == "Commit Review abcdef1234")
+        #expect(target.repositoryPath == "/repo")
+        #expect(target.sourceDescription == "Commit \(sha)")
+    }
+
     @Test func commitReviewBodyHostsReviewSurfaceWithoutSourceBadges() {
         let file = summary(path: "Sources/App.swift")
         let session = DiffReviewLoadedSession(

--- a/AlasTests/CommitTabViewTests.swift
+++ b/AlasTests/CommitTabViewTests.swift
@@ -6,6 +6,21 @@ import Testing
 @Suite(.serialized)
 @MainActor
 struct CommitTabViewTests {
+    @Test func commitReviewDraftSessionIDUsesCommitSHA() {
+        let sessionID = CommitReviewBody.reviewDraftSessionID(
+            worktreeID: "wt",
+            repositoryPath: URL(fileURLWithPath: "/repo"),
+            sha: "abc"
+        )
+
+        #expect(sessionID == ReviewDraftSessionID.commit(
+            worktreeID: "wt",
+            repositoryPath: URL(fileURLWithPath: "/repo"),
+            sha: "abc"
+        ))
+        #expect(sessionID.sourceKind == .commit)
+    }
+
     @Test func commitReviewBodyHostsReviewSurfaceWithoutSourceBadges() {
         let file = summary(path: "Sources/App.swift")
         let session = DiffReviewLoadedSession(

--- a/AlasTests/DiffPaneViewTests.swift
+++ b/AlasTests/DiffPaneViewTests.swift
@@ -26,6 +26,24 @@ struct DiffPaneViewTests {
         )
     }
 
+    private func reviewAnchorModel() -> DiffDisplayModel {
+        DiffDisplayModelBuilder.build(
+            diff: ParsedDiff(hunks: [
+                ParsedDiff.Hunk(
+                    header: "@@ -1,2 +1,2 @@",
+                    oldStart: 1,
+                    newStart: 1,
+                    lines: [
+                        .init(kind: .context, text: "let a = 1", oldNumber: 1, newNumber: 1),
+                        .init(kind: .delete, text: "let b = 2", oldNumber: 2, newNumber: nil),
+                        .init(kind: .add, text: "let b = 3", oldNumber: nil, newNumber: 2),
+                    ]
+                )
+            ]),
+            filePath: "Sources/App.swift"
+        )
+    }
+
     private func collapsedContextModel() -> DiffDisplayModel {
         DiffDisplayModelBuilder.build(
             diff: ParsedDiff(hunks: [
@@ -211,6 +229,113 @@ struct DiffPaneViewTests {
         #expect(!selectableText.contains("|"))
         #expect(!selectableText.contains("+2"))
         #expect(!selectableText.contains("-2"))
+    }
+
+    @Test @MainActor func splitTextDocumentExposesSourceLineMetadataForBothSides() throws {
+        var layout = DiffLayoutMode.split
+        var wrap = false
+        var whitespace = false
+        let view = DiffPaneView(
+            model: reviewAnchorModel(),
+            fileExtension: "swift",
+            layoutMode: Binding(get: { layout }, set: { layout = $0 }),
+            wrapLines: Binding(get: { wrap }, set: { wrap = $0 }),
+            showWhitespace: Binding(get: { whitespace }, set: { whitespace = $0 }),
+            codeFontFamily: "",
+            codeFontSize: 13,
+            showsToolbar: false,
+            verticalScrollMode: .staticHeight,
+            hunkActions: { _ in DiffPaneHunkActions() }
+        )
+        .environment(\.theme, theme())
+
+        let controller = NSHostingController(rootView: view)
+        controller.view.frame = NSRect(x: 0, y: 0, width: 900, height: 400)
+        controller.view.layoutSubtreeIfNeeded()
+
+        let codeViews = visibleCodeTextViews(in: controller.view)
+        #expect(codeViews.count == 2)
+        let oldCodeView = try #require(codeViews.first)
+        let newCodeView = try #require(codeViews.last)
+
+        #expect(oldCodeView.reviewLineAnchor(atRow: 0)?.side == .old)
+        #expect(newCodeView.reviewLineAnchor(atRow: 0)?.side == .new)
+
+        let changedAnchor = try #require(newCodeView.reviewLineAnchor(atRow: 1))
+        #expect(changedAnchor.path == "Sources/App.swift")
+        #expect(changedAnchor.side == .new)
+        #expect(changedAnchor.line == 2)
+        #expect(changedAnchor.rowIndex == 1)
+        #expect(changedAnchor.selectedText == "let b = 3")
+    }
+
+    @Test @MainActor func stackedTextDocumentExposesSourceLineMetadataForAddedAndDeletedLines() throws {
+        let view = DiffPaneTextDocumentView(
+            group: try #require(reviewAnchorModel().groups.first),
+            expandedCollapsedRowIDs: [],
+            layoutMode: .stacked,
+            wrapLines: false,
+            showWhitespace: false,
+            fileExtension: "swift",
+            codeFontFamily: "",
+            codeFontSize: 13,
+            theme: theme(),
+            lspContext: nil
+        )
+
+        let controller = NSHostingController(rootView: view)
+        controller.view.frame = NSRect(x: 0, y: 0, width: 520, height: 400)
+        controller.view.layoutSubtreeIfNeeded()
+
+        let codeView = try #require(visibleCodeTextViews(in: controller.view).first)
+        let deletedAnchor = try #require(codeView.reviewLineAnchor(atRow: 1))
+        let addedAnchor = try #require(codeView.reviewLineAnchor(atRow: 2))
+
+        #expect(deletedAnchor.path == "Sources/App.swift")
+        #expect(deletedAnchor.side == .old)
+        #expect(deletedAnchor.line == 2)
+        #expect(deletedAnchor.rowIndex == 1)
+        #expect(deletedAnchor.selectedText == "let b = 2")
+
+        #expect(addedAnchor.path == "Sources/App.swift")
+        #expect(addedAnchor.side == .new)
+        #expect(addedAnchor.line == 2)
+        #expect(addedAnchor.rowIndex == 2)
+        #expect(addedAnchor.selectedText == "let b = 3")
+    }
+
+    @Test @MainActor func rowHitTestingReturnsLocalReviewAnchorForCodePoint() throws {
+        var layout = DiffLayoutMode.split
+        var wrap = false
+        var whitespace = false
+        let view = DiffPaneView(
+            model: reviewAnchorModel(),
+            fileExtension: "swift",
+            layoutMode: Binding(get: { layout }, set: { layout = $0 }),
+            wrapLines: Binding(get: { wrap }, set: { wrap = $0 }),
+            showWhitespace: Binding(get: { whitespace }, set: { whitespace = $0 }),
+            codeFontFamily: "",
+            codeFontSize: 13,
+            showsToolbar: false,
+            verticalScrollMode: .staticHeight,
+            hunkActions: { _ in DiffPaneHunkActions() }
+        )
+        .environment(\.theme, theme())
+
+        let controller = NSHostingController(rootView: view)
+        controller.view.frame = NSRect(x: 0, y: 0, width: 900, height: 400)
+        controller.view.layoutSubtreeIfNeeded()
+
+        let newCodeView = try #require(visibleCodeTextViews(in: controller.view).last)
+        let changedRowRect = try #require(newCodeView.diffRowRects().dropFirst().first)
+        let point = NSPoint(x: changedRowRect.minX + 8, y: changedRowRect.midY)
+
+        let anchor = try #require(newCodeView.reviewLineAnchor(at: point))
+        #expect(anchor.path == "Sources/App.swift")
+        #expect(anchor.line == 2)
+        #expect(anchor.side == .new)
+        #expect(anchor.rowIndex == 1)
+        #expect(anchor.selectedText == "let b = 3")
     }
 
     @Test func splitPaneExposesDiffLineTonesForRailsAndPlaceholders() throws {
@@ -1155,6 +1280,14 @@ struct DiffPaneViewTests {
             return view
         }
         return view.subviews.lazy.compactMap { subview(withAccessibilityIdentifier: identifier, in: $0) }.first
+    }
+
+    private func visibleCodeTextViews(in view: NSView) -> [DiffPaneCodeTextView] {
+        allSubviews(of: view)
+            .compactMap { $0 as? DiffPaneTextScrollView }
+            .filter(isEffectivelyVisible)
+            .sorted { $0.frame.minX < $1.frame.minX }
+            .compactMap { $0.documentView as? DiffPaneCodeTextView }
     }
 
     private func isEffectivelyVisible(_ view: NSView) -> Bool {

--- a/AlasTests/DiffReviewSurfaceTests.swift
+++ b/AlasTests/DiffReviewSurfaceTests.swift
@@ -1180,6 +1180,43 @@ struct DiffReviewSurfaceTests {
         #expect(dismissedID == "draft-dismiss-summary")
     }
 
+    @Test func summaryRailShowsDismissedCommentsWithSideAndStatus() throws {
+        let file = summary(path: "Sources/App.swift")
+        let comment = draftComment(
+            id: "draft-dismissed-visible",
+            fileID: file.id,
+            path: file.path,
+            side: .old,
+            startLine: 7,
+            state: .dismissed
+        )
+        let bundle = ReviewFeedbackBundle(
+            target: ReviewFeedbackTarget(
+                title: "Review Sources/App.swift",
+                repositoryPath: "/repo",
+                providerDescription: nil,
+                sourceDescription: "Local draft comments"
+            ),
+            comments: [comment]
+        )
+        var collapsed = false
+
+        let view = ReviewDraftSummaryRail(
+            comments: [comment],
+            bundle: bundle,
+            collapsed: Binding(get: { collapsed }, set: { collapsed = $0 }),
+            draftCommentActions: ReviewDraftCommentActions(),
+            onSelectDraftComment: { _ in }
+        )
+        .environment(\.theme, theme())
+
+        let controller = host(view, width: 280, height: 500)
+
+        #expect(subview(withAccessibilityIdentifier: "review-draft-summary-comment-draft-dismissed-visible", in: controller.view) != nil)
+        #expect(accessibilityLabel(in: controller.view, containing: "old line 7") != nil)
+        #expect(accessibilityLabel(in: controller.view, containing: "dismissed") != nil)
+    }
+
     @Test func collapsedSummaryRailKeepsFinishActionsAccessible() throws {
         let file = summary(path: "Sources/App.swift")
         let comment = draftComment(id: "draft-collapsed", fileID: file.id, path: file.path, side: .new, startLine: 2)

--- a/AlasTests/DiffReviewSurfaceTests.swift
+++ b/AlasTests/DiffReviewSurfaceTests.swift
@@ -729,6 +729,55 @@ struct DiffReviewSurfaceTests {
         #expect(accessibilityLabel(in: controller.view, containing: "Please revisit this line.") != nil)
     }
 
+    @Test func fileSectionDraftCommentCardCanDismissComment() {
+        let file = DiffReviewFileSectionModel(
+            summary: summary(path: "Sources/App.swift"),
+            parsedDiff: parsedDiff(),
+            displayModel: displayModel(),
+            placeholderMessage: nil,
+            openFile: nil
+        )
+        let comment = draftComment(id: "draft-dismiss-inline", fileID: file.id, path: file.summary.path, side: .new, startLine: 2)
+        var layout = DiffLayoutMode.split
+        var wrap = false
+        var whitespace = false
+        var dismissedID: String?
+        let actions = ReviewDraftCommentActions(
+            availability: { _ in
+                ReviewDraftCommentActionAvailability(
+                    canEdit: false,
+                    canDelete: false,
+                    canResolve: false,
+                    canDismiss: true,
+                    canCopyPrompt: false,
+                    canSendToAgent: false
+                )
+            },
+            dismiss: { dismissedID = $0.id }
+        )
+
+        let view = DiffReviewFileSection(
+            file: file,
+            draftComments: [comment],
+            layoutMode: Binding(get: { layout }, set: { layout = $0 }),
+            wrapLines: Binding(get: { wrap }, set: { wrap = $0 }),
+            showWhitespace: Binding(get: { whitespace }, set: { whitespace = $0 }),
+            codeFontFamily: "",
+            codeFontSize: 13,
+            showsSourceBadge: false,
+            draftCommentActions: actions
+        )
+        .environment(\.theme, theme())
+
+        let controller = host(view, width: 900, height: 500)
+
+        #expect(pressAccessibilityElement(
+            withAccessibilityIdentifier: "diff-review-draft-comment-action-dismiss-draft-dismiss-inline",
+            in: controller.view
+        ))
+        #expect(dismissedID == "draft-dismiss-inline")
+    }
+
     @Test func inlineFeedbackContextFormatterIncludesReviewMetadata() {
         let file = summary(path: "Sources/App.swift")
         let item = DiffReviewInlineFeedback(
@@ -1059,6 +1108,7 @@ struct DiffReviewSurfaceTests {
                     canEdit: false,
                     canDelete: false,
                     canResolve: false,
+                    canDismiss: false,
                     canCopyPrompt: true,
                     canSendToAgent: true
                 )
@@ -1084,6 +1134,52 @@ struct DiffReviewSurfaceTests {
         #expect(recorder.sent == bundle)
     }
 
+    @Test func summaryRailCanDismissDraftComment() throws {
+        let file = summary(path: "Sources/App.swift")
+        let comment = draftComment(id: "draft-dismiss-summary", fileID: file.id, path: file.path, side: .new, startLine: 2)
+        let bundle = ReviewFeedbackBundle(
+            target: ReviewFeedbackTarget(
+                title: "Review Sources/App.swift",
+                repositoryPath: "/repo",
+                providerDescription: nil,
+                sourceDescription: "Local draft comments"
+            ),
+            comments: [comment]
+        )
+        var collapsed = false
+        var dismissedID: String?
+        let actions = ReviewDraftCommentActions(
+            availability: { _ in
+                ReviewDraftCommentActionAvailability(
+                    canEdit: false,
+                    canDelete: false,
+                    canResolve: false,
+                    canDismiss: true,
+                    canCopyPrompt: false,
+                    canSendToAgent: false
+                )
+            },
+            dismiss: { dismissedID = $0.id }
+        )
+
+        let view = ReviewDraftSummaryRail(
+            comments: [comment],
+            bundle: bundle,
+            collapsed: Binding(get: { collapsed }, set: { collapsed = $0 }),
+            draftCommentActions: actions,
+            onSelectDraftComment: { _ in }
+        )
+        .environment(\.theme, theme())
+
+        let controller = host(view, width: 280, height: 500)
+
+        #expect(pressAccessibilityElement(
+            withAccessibilityIdentifier: "review-draft-summary-dismiss-draft-dismiss-summary",
+            in: controller.view
+        ))
+        #expect(dismissedID == "draft-dismiss-summary")
+    }
+
     @Test func collapsedSummaryRailKeepsFinishActionsAccessible() throws {
         let file = summary(path: "Sources/App.swift")
         let comment = draftComment(id: "draft-collapsed", fileID: file.id, path: file.path, side: .new, startLine: 2)
@@ -1104,6 +1200,7 @@ struct DiffReviewSurfaceTests {
                     canEdit: false,
                     canDelete: false,
                     canResolve: false,
+                    canDismiss: false,
                     canCopyPrompt: true,
                     canSendToAgent: true
                 )

--- a/AlasTests/DiffReviewSurfaceTests.swift
+++ b/AlasTests/DiffReviewSurfaceTests.swift
@@ -779,6 +779,64 @@ struct DiffReviewSurfaceTests {
         #expect(dismissedID == "draft-dismiss-inline")
     }
 
+    @Test func fileSectionDraftCommentCardUsesProvidedReviewTargetForPromptActions() {
+        let file = DiffReviewFileSectionModel(
+            summary: summary(path: "Sources/App.swift"),
+            parsedDiff: parsedDiff(),
+            displayModel: displayModel(),
+            placeholderMessage: nil,
+            openFile: nil
+        )
+        let target = ReviewFeedbackTarget(
+            title: "Review working tree",
+            repositoryPath: "/repo",
+            providerDescription: "GitHub #123",
+            sourceDescription: "Review Changes"
+        )
+        let comment = draftComment(id: "draft-target-inline", fileID: file.id, path: file.summary.path, side: .new, startLine: 2)
+        var layout = DiffLayoutMode.split
+        var wrap = false
+        var whitespace = false
+        let recorder = ReviewBundleActionRecorder()
+        let actions = ReviewDraftCommentActions(
+            availability: { _ in
+                ReviewDraftCommentActionAvailability(
+                    canEdit: false,
+                    canDelete: false,
+                    canResolve: false,
+                    canDismiss: false,
+                    canCopyPrompt: true,
+                    canShowSendToAgent: false,
+                    canSendToAgent: false
+                )
+            },
+            copyPrompt: { recorder.copied = $0 }
+        )
+
+        let view = DiffReviewFileSection(
+            file: file,
+            draftComments: [comment],
+            layoutMode: Binding(get: { layout }, set: { layout = $0 }),
+            wrapLines: Binding(get: { wrap }, set: { wrap = $0 }),
+            showWhitespace: Binding(get: { whitespace }, set: { whitespace = $0 }),
+            codeFontFamily: "",
+            codeFontSize: 13,
+            showsSourceBadge: false,
+            draftCommentActions: actions,
+            reviewFeedbackTarget: target
+        )
+        .environment(\.theme, theme())
+
+        let controller = host(view, width: 900, height: 500)
+
+        #expect(pressAccessibilityElement(
+            withAccessibilityIdentifier: "diff-review-draft-comment-action-copy-draft-target-inline",
+            in: controller.view
+        ))
+        #expect(recorder.copied?.target == target)
+        #expect(recorder.copied?.comments == [comment])
+    }
+
     @Test func fileSectionDraftCommentCardDoesNotFireDisabledSendAction() {
         let file = DiffReviewFileSectionModel(
             summary: summary(path: "Sources/App.swift"),

--- a/AlasTests/DiffReviewSurfaceTests.swift
+++ b/AlasTests/DiffReviewSurfaceTests.swift
@@ -779,6 +779,115 @@ struct DiffReviewSurfaceTests {
         #expect(dismissedID == "draft-dismiss-inline")
     }
 
+    @Test func fileSectionDraftCommentCardDoesNotFireDisabledSendAction() {
+        let file = DiffReviewFileSectionModel(
+            summary: summary(path: "Sources/App.swift"),
+            parsedDiff: parsedDiff(),
+            displayModel: displayModel(),
+            placeholderMessage: nil,
+            openFile: nil
+        )
+        let comment = draftComment(
+            id: "draft-disabled-send-inline",
+            fileID: file.id,
+            path: file.summary.path,
+            side: .new,
+            startLine: 2,
+            state: .resolved
+        )
+        var layout = DiffLayoutMode.split
+        var wrap = false
+        var whitespace = false
+        let actions = ReviewDraftCommentActions(
+            availability: { _ in
+                ReviewDraftCommentActionAvailability(
+                    canEdit: false,
+                    canDelete: false,
+                    canResolve: false,
+                    canDismiss: false,
+                    canCopyPrompt: false,
+                    canShowSendToAgent: true,
+                    canSendToAgent: false
+                )
+            },
+            agentTargets: { [.newChat(agentID: "codex", title: "Codex")] },
+            sendToAgent: { _, _ in Issue.record("disabled send action fired") }
+        )
+
+        let view = DiffReviewFileSection(
+            file: file,
+            draftComments: [comment],
+            layoutMode: Binding(get: { layout }, set: { layout = $0 }),
+            wrapLines: Binding(get: { wrap }, set: { wrap = $0 }),
+            showWhitespace: Binding(get: { whitespace }, set: { whitespace = $0 }),
+            codeFontFamily: "",
+            codeFontSize: 13,
+            showsSourceBadge: false,
+            draftCommentActions: actions
+        )
+        .environment(\.theme, theme())
+
+        let controller = host(view, width: 900, height: 500)
+
+        #expect(!pressAccessibilityElement(
+            withAccessibilityIdentifier: "diff-review-draft-comment-action-send-draft-disabled-send-inline",
+            in: controller.view
+        ))
+    }
+
+    @Test func fileSectionDraftCommentEditorDoesNotKeepCardSelectionButtonActive() {
+        let file = DiffReviewFileSectionModel(
+            summary: summary(path: "Sources/App.swift"),
+            parsedDiff: parsedDiff(),
+            displayModel: displayModel(),
+            placeholderMessage: nil,
+            openFile: nil
+        )
+        let comment = draftComment(id: "draft-edit-inline", fileID: file.id, path: file.summary.path, side: .new, startLine: 2)
+        var layout = DiffLayoutMode.split
+        var wrap = false
+        var whitespace = false
+        var selectedID: String?
+        let actions = ReviewDraftCommentActions(
+            availability: { _ in
+                ReviewDraftCommentActionAvailability(
+                    canEdit: true,
+                    canDelete: false,
+                    canResolve: false,
+                    canDismiss: false,
+                    canCopyPrompt: false,
+                    canShowSendToAgent: false,
+                    canSendToAgent: false
+                )
+            }
+        )
+
+        let view = DiffReviewFileSection(
+            file: file,
+            draftComments: [comment],
+            layoutMode: Binding(get: { layout }, set: { layout = $0 }),
+            wrapLines: Binding(get: { wrap }, set: { wrap = $0 }),
+            showWhitespace: Binding(get: { whitespace }, set: { whitespace = $0 }),
+            codeFontFamily: "",
+            codeFontSize: 13,
+            showsSourceBadge: false,
+            draftCommentActions: actions,
+            onSelectDraftComment: { selectedID = $0.id }
+        )
+        .environment(\.theme, theme())
+
+        let controller = host(view, width: 900, height: 500)
+        #expect(pressAccessibilityElement(
+            withAccessibilityIdentifier: "diff-review-draft-comment-action-edit-draft-edit-inline",
+            in: controller.view
+        ))
+        controller.view.layoutSubtreeIfNeeded()
+
+        #expect(subview(withAccessibilityIdentifier: "diff-review-draft-comment-action-save-draft-edit-inline", in: controller.view) != nil)
+        #expect(!pressAccessibilityElement(withAccessibilityIdentifier: "diff-review-draft-comment-select-draft-edit-inline", in: controller.view))
+        #expect(selectedID == nil)
+    }
+
     @Test func inlineFeedbackContextFormatterIncludesReviewMetadata() {
         let file = summary(path: "Sources/App.swift")
         let item = DiffReviewInlineFeedback(
@@ -1252,6 +1361,55 @@ struct DiffReviewSurfaceTests {
             in: controller.view
         ))
         #expect(dismissedID == "draft-dismiss-summary")
+    }
+
+    @Test func summaryRailEditorDoesNotKeepCardSelectionPressActive() throws {
+        let file = summary(path: "Sources/App.swift")
+        let comment = draftComment(id: "draft-edit-summary", fileID: file.id, path: file.path, side: .new, startLine: 2)
+        let bundle = ReviewFeedbackBundle(
+            target: ReviewFeedbackTarget(
+                title: "Review Sources/App.swift",
+                repositoryPath: "/repo",
+                providerDescription: nil,
+                sourceDescription: "Local draft comments"
+            ),
+            comments: [comment]
+        )
+        var collapsed = false
+        var selectedID: String?
+        let actions = ReviewDraftCommentActions(
+            availability: { _ in
+                ReviewDraftCommentActionAvailability(
+                    canEdit: true,
+                    canDelete: false,
+                    canResolve: false,
+                    canDismiss: false,
+                    canCopyPrompt: false,
+                    canShowSendToAgent: false,
+                    canSendToAgent: false
+                )
+            }
+        )
+
+        let view = ReviewDraftSummaryRail(
+            comments: [comment],
+            bundle: bundle,
+            collapsed: Binding(get: { collapsed }, set: { collapsed = $0 }),
+            draftCommentActions: actions,
+            onSelectDraftComment: { selectedID = $0.id }
+        )
+        .environment(\.theme, theme())
+
+        let controller = host(view, width: 280, height: 500)
+        #expect(pressAccessibilityElement(
+            withAccessibilityIdentifier: "review-draft-summary-edit-draft-edit-summary",
+            in: controller.view
+        ))
+        controller.view.layoutSubtreeIfNeeded()
+
+        #expect(subview(withAccessibilityIdentifier: "review-draft-summary-save-draft-edit-summary", in: controller.view) != nil)
+        #expect(!pressAccessibilityElement(withAccessibilityIdentifier: "review-draft-summary-comment-draft-edit-summary", in: controller.view))
+        #expect(selectedID == nil)
     }
 
     @Test func summaryRailShowsDismissedCommentsWithSideAndStatus() throws {

--- a/AlasTests/DiffReviewSurfaceTests.swift
+++ b/AlasTests/DiffReviewSurfaceTests.swift
@@ -1088,6 +1088,37 @@ struct DiffReviewSurfaceTests {
         #expect(subview(withAccessibilityIdentifier: "review-draft-summary-rail", in: controller.view) != nil)
     }
 
+    @Test func surfaceKeepsDraftSummaryRailWhenOnlyDismissedCommentsRemain() throws {
+        let file = summary(path: "Sources/App.swift")
+        let session = loadedSession(summaries: [file])
+        let comment = draftComment(id: "draft-dismissed-only", fileID: file.id, path: file.path, side: .new, startLine: 2, state: .dismissed)
+        var selectedFileID: DiffReviewFileID? = file.id
+        var railCollapsed = false
+        var summaryCollapsed = false
+        var layout = DiffLayoutMode.split
+        var wrap = false
+        var whitespace = false
+
+        let view = DiffReviewSurface(
+            session: session,
+            selectedFileID: Binding(get: { selectedFileID }, set: { selectedFileID = $0 }),
+            railCollapsed: Binding(get: { railCollapsed }, set: { railCollapsed = $0 }),
+            reviewSummaryCollapsed: Binding(get: { summaryCollapsed }, set: { summaryCollapsed = $0 }),
+            layoutMode: Binding(get: { layout }, set: { layout = $0 }),
+            wrapLines: Binding(get: { wrap }, set: { wrap = $0 }),
+            showWhitespace: Binding(get: { whitespace }, set: { whitespace = $0 }),
+            codeFontFamily: "",
+            codeFontSize: 13,
+            draftCommentsByFileID: [file.id: [comment]]
+        )
+        .environment(\.theme, theme())
+
+        let controller = host(view, width: 1200, height: 700)
+
+        #expect(subview(withAccessibilityIdentifier: "review-draft-summary-rail", in: controller.view) != nil)
+        #expect(accessibilityLabel(in: controller.view, containing: "dismissed") != nil)
+    }
+
     @Test func summaryRailUsesProvidedBundleForCopyAndSendActions() throws {
         let file = summary(path: "Sources/App.swift")
         let comment = draftComment(id: "draft-bundle", fileID: file.id, path: file.path, side: .new, startLine: 2)
@@ -1132,6 +1163,40 @@ struct DiffReviewSurfaceTests {
 
         #expect(recorder.copied == bundle)
         #expect(recorder.sent == bundle)
+    }
+
+    @Test func summaryRailDisabledFinishActionsDoNotReportPressed() throws {
+        let file = summary(path: "Sources/App.swift")
+        let comment = draftComment(id: "draft-disabled-actions", fileID: file.id, path: file.path, side: .new, startLine: 2)
+        let bundle = ReviewFeedbackBundle(
+            target: ReviewFeedbackTarget(
+                title: "Review Sources/App.swift",
+                repositoryPath: "/repo",
+                providerDescription: nil,
+                sourceDescription: "Local draft comments"
+            ),
+            comments: [comment]
+        )
+        var collapsed = false
+        let actions = ReviewDraftCommentActions(
+            availability: { _ in .none },
+            copyPrompt: { _ in Issue.record("disabled copy action fired") },
+            sendToAgent: { _ in Issue.record("disabled send action fired") }
+        )
+
+        let view = ReviewDraftSummaryRail(
+            comments: [comment],
+            bundle: bundle,
+            collapsed: Binding(get: { collapsed }, set: { collapsed = $0 }),
+            draftCommentActions: actions,
+            onSelectDraftComment: { _ in }
+        )
+        .environment(\.theme, theme())
+
+        let controller = host(view, width: 280, height: 500)
+
+        #expect(!pressAccessibilityElement(withAccessibilityIdentifier: "review-draft-summary-copy-prompt", in: controller.view))
+        #expect(!pressAccessibilityElement(withAccessibilityIdentifier: "review-draft-summary-send-agent", in: controller.view))
     }
 
     @Test func summaryRailCanDismissDraftComment() throws {

--- a/AlasTests/DiffReviewSurfaceTests.swift
+++ b/AlasTests/DiffReviewSurfaceTests.swift
@@ -1010,6 +1010,35 @@ struct DiffReviewSurfaceTests {
         #expect(selectedDraftID == "draft-summary")
     }
 
+    @Test func surfaceCanShowDraftSummaryRailBeforeCommentsExist() throws {
+        let file = summary(path: "Sources/App.swift")
+        let session = loadedSession(summaries: [file])
+        var selectedFileID: DiffReviewFileID? = file.id
+        var railCollapsed = false
+        var summaryCollapsed = false
+        var layout = DiffLayoutMode.split
+        var wrap = false
+        var whitespace = false
+
+        let view = DiffReviewSurface(
+            session: session,
+            selectedFileID: Binding(get: { selectedFileID }, set: { selectedFileID = $0 }),
+            railCollapsed: Binding(get: { railCollapsed }, set: { railCollapsed = $0 }),
+            reviewSummaryCollapsed: Binding(get: { summaryCollapsed }, set: { summaryCollapsed = $0 }),
+            layoutMode: Binding(get: { layout }, set: { layout = $0 }),
+            wrapLines: Binding(get: { wrap }, set: { wrap = $0 }),
+            showWhitespace: Binding(get: { whitespace }, set: { whitespace = $0 }),
+            codeFontFamily: "",
+            codeFontSize: 13,
+            showsDraftSummaryRail: true
+        )
+        .environment(\.theme, theme())
+
+        let controller = host(view, width: 1200, height: 700)
+
+        #expect(subview(withAccessibilityIdentifier: "review-draft-summary-rail", in: controller.view) != nil)
+    }
+
     @Test func summaryRailUsesProvidedBundleForCopyAndSendActions() throws {
         let file = summary(path: "Sources/App.swift")
         let comment = draftComment(id: "draft-bundle", fileID: file.id, path: file.path, side: .new, startLine: 2)
@@ -1048,6 +1077,51 @@ struct DiffReviewSurfaceTests {
         .environment(\.theme, theme())
 
         let controller = host(view, width: 280, height: 500)
+        #expect(pressAccessibilityElement(withAccessibilityIdentifier: "review-draft-summary-copy-prompt", in: controller.view))
+        #expect(pressAccessibilityElement(withAccessibilityIdentifier: "review-draft-summary-send-agent", in: controller.view))
+
+        #expect(recorder.copied == bundle)
+        #expect(recorder.sent == bundle)
+    }
+
+    @Test func collapsedSummaryRailKeepsFinishActionsAccessible() throws {
+        let file = summary(path: "Sources/App.swift")
+        let comment = draftComment(id: "draft-collapsed", fileID: file.id, path: file.path, side: .new, startLine: 2)
+        let bundle = ReviewFeedbackBundle(
+            target: ReviewFeedbackTarget(
+                title: "Review Sources/App.swift",
+                repositoryPath: "/repo",
+                providerDescription: nil,
+                sourceDescription: "Local draft comments"
+            ),
+            comments: [comment]
+        )
+        var collapsed = true
+        let recorder = ReviewBundleActionRecorder()
+        let actions = ReviewDraftCommentActions(
+            availability: { _ in
+                ReviewDraftCommentActionAvailability(
+                    canEdit: false,
+                    canDelete: false,
+                    canResolve: false,
+                    canCopyPrompt: true,
+                    canSendToAgent: true
+                )
+            },
+            copyPrompt: { recorder.copied = $0 },
+            sendToAgent: { recorder.sent = $0 }
+        )
+
+        let view = ReviewDraftSummaryRail(
+            comments: [comment],
+            bundle: bundle,
+            collapsed: Binding(get: { collapsed }, set: { collapsed = $0 }),
+            draftCommentActions: actions,
+            onSelectDraftComment: { _ in }
+        )
+        .environment(\.theme, theme())
+
+        let controller = host(view, width: 80, height: 500)
         #expect(pressAccessibilityElement(withAccessibilityIdentifier: "review-draft-summary-copy-prompt", in: controller.view))
         #expect(pressAccessibilityElement(withAccessibilityIdentifier: "review-draft-summary-send-agent", in: controller.view))
 

--- a/AlasTests/DiffReviewSurfaceTests.swift
+++ b/AlasTests/DiffReviewSurfaceTests.swift
@@ -971,6 +971,90 @@ struct DiffReviewSurfaceTests {
         #expect(accessibilityLabel(in: controller.view, containing: "App feedback.") != nil)
     }
 
+    @Test func surfaceShowsDraftSummaryRailAndSelectsDraftComment() throws {
+        let file = summary(path: "Sources/App.swift")
+        let session = loadedSession(summaries: [file])
+        let comment = draftComment(id: "draft-summary", fileID: file.id, path: file.path, side: .new, startLine: 2)
+        var selectedFileID: DiffReviewFileID? = file.id
+        var railCollapsed = false
+        var summaryCollapsed = false
+        var layout = DiffLayoutMode.split
+        var wrap = false
+        var whitespace = false
+        var selectedDraftID: String?
+
+        let view = DiffReviewSurface(
+            session: session,
+            selectedFileID: Binding(get: { selectedFileID }, set: { selectedFileID = $0 }),
+            railCollapsed: Binding(get: { railCollapsed }, set: { railCollapsed = $0 }),
+            reviewSummaryCollapsed: Binding(get: { summaryCollapsed }, set: { summaryCollapsed = $0 }),
+            layoutMode: Binding(get: { layout }, set: { layout = $0 }),
+            wrapLines: Binding(get: { wrap }, set: { wrap = $0 }),
+            showWhitespace: Binding(get: { whitespace }, set: { whitespace = $0 }),
+            codeFontFamily: "",
+            codeFontSize: 13,
+            draftCommentsByFileID: [file.id: [comment]],
+            onSelectDraftComment: { selectedDraftID = $0.id }
+        )
+        .environment(\.theme, theme())
+
+        let controller = host(view, width: 1200, height: 700)
+
+        #expect(subview(withAccessibilityIdentifier: "review-draft-summary-rail", in: controller.view) != nil)
+        let pressed = pressAccessibilityElement(
+            withAccessibilityIdentifier: "review-draft-summary-comment-draft-summary",
+            in: controller.view
+        )
+
+        #expect(pressed)
+        #expect(selectedDraftID == "draft-summary")
+    }
+
+    @Test func summaryRailUsesProvidedBundleForCopyAndSendActions() throws {
+        let file = summary(path: "Sources/App.swift")
+        let comment = draftComment(id: "draft-bundle", fileID: file.id, path: file.path, side: .new, startLine: 2)
+        let bundle = ReviewFeedbackBundle(
+            target: ReviewFeedbackTarget(
+                title: "Review Sources/App.swift",
+                repositoryPath: "/repo",
+                providerDescription: nil,
+                sourceDescription: "Local draft comments"
+            ),
+            comments: [comment]
+        )
+        var collapsed = false
+        let recorder = ReviewBundleActionRecorder()
+        let actions = ReviewDraftCommentActions(
+            availability: { _ in
+                ReviewDraftCommentActionAvailability(
+                    canEdit: false,
+                    canDelete: false,
+                    canResolve: false,
+                    canCopyPrompt: true,
+                    canSendToAgent: true
+                )
+            },
+            copyPrompt: { recorder.copied = $0 },
+            sendToAgent: { recorder.sent = $0 }
+        )
+
+        let view = ReviewDraftSummaryRail(
+            comments: [comment],
+            bundle: bundle,
+            collapsed: Binding(get: { collapsed }, set: { collapsed = $0 }),
+            draftCommentActions: actions,
+            onSelectDraftComment: { _ in }
+        )
+        .environment(\.theme, theme())
+
+        let controller = host(view, width: 280, height: 500)
+        #expect(pressAccessibilityElement(withAccessibilityIdentifier: "review-draft-summary-copy-prompt", in: controller.view))
+        #expect(pressAccessibilityElement(withAccessibilityIdentifier: "review-draft-summary-send-agent", in: controller.view))
+
+        #expect(recorder.copied == bundle)
+        #expect(recorder.sent == bundle)
+    }
+
     @Test func selectionSynchronizationClearsEmptySessions() {
         let selected = DiffReviewFileID(namespace: "commit", path: "Stale.swift")
 
@@ -1446,10 +1530,24 @@ struct DiffReviewSurfaceTests {
         return matches
     }
 
+    private func pressAccessibilityElement(withAccessibilityIdentifier identifier: String, in view: NSView) -> Bool {
+        for match in subviews(withAccessibilityIdentifier: identifier, in: view) {
+            if match.accessibilityPerformPress() {
+                return true
+            }
+        }
+        return false
+    }
+
     private func accessibilityLabel(in view: NSView, containing text: String) -> String? {
         if let label = view.accessibilityLabel(), label.contains(text) {
             return label
         }
         return view.subviews.lazy.compactMap { accessibilityLabel(in: $0, containing: text) }.first
     }
+}
+
+private final class ReviewBundleActionRecorder: @unchecked Sendable {
+    var copied: ReviewFeedbackBundle?
+    var sent: ReviewFeedbackBundle?
 }

--- a/AlasTests/DiffReviewSurfaceTests.swift
+++ b/AlasTests/DiffReviewSurfaceTests.swift
@@ -649,6 +649,54 @@ struct DiffReviewSurfaceTests {
         #expect(segments.items.flatMap(\.draftComments).map(\.id) == ["draft-shifted"])
     }
 
+    @Test func localDraftCommentsWithUnknownSideDoNotDuplicateAcrossMatchingHunks() {
+        let firstGroup = DiffDisplayGroup(
+            id: "first-group",
+            header: "@@ -1,1 +2,1 @@",
+            sourceHunk: parsedDiff().hunks[0],
+            rows: [
+                DiffDisplayRow(
+                    id: "first-row",
+                    kind: .context,
+                    old: diffLine(id: "first-old", side: .old, oldLine: 1, text: "one"),
+                    new: diffLine(id: "first-new", side: .new, newLine: 2, text: "two"),
+                    collapsedLineCount: 0
+                ),
+            ]
+        )
+        let secondGroup = DiffDisplayGroup(
+            id: "second-group",
+            header: "@@ -2,1 +3,1 @@",
+            sourceHunk: parsedDiff().hunks[0],
+            rows: [
+                DiffDisplayRow(
+                    id: "second-row",
+                    kind: .context,
+                    old: diffLine(id: "second-old", side: .old, oldLine: 2, text: "two"),
+                    new: diffLine(id: "second-new", side: .new, newLine: 3, text: "three"),
+                    collapsedLineCount: 0
+                ),
+            ]
+        )
+        let comment = draftComment(id: "draft-cross-hunk", path: "A.swift", side: .unknown, startLine: 2)
+        let placement = ReviewDraftCommentPlacement.position([comment], in: [firstGroup, secondGroup])
+
+        let firstSegments = ReviewDraftCommentRowSegmentation.segments(
+            for: firstGroup,
+            placement: placement,
+            pendingAnchor: nil
+        )
+        let secondSegments = ReviewDraftCommentRowSegmentation.segments(
+            for: secondGroup,
+            placement: placement,
+            pendingAnchor: nil
+        )
+
+        #expect(placement.groupIDByCommentID["draft-cross-hunk"] == "first-group")
+        #expect(firstSegments.items.flatMap(\.draftComments).map(\.id) == ["draft-cross-hunk"])
+        #expect(secondSegments.items.flatMap(\.draftComments).isEmpty)
+    }
+
     @Test func fileSectionRendersVisibleLocalDraftCommentCard() {
         let file = DiffReviewFileSectionModel(
             summary: summary(path: "Sources/App.swift"),

--- a/AlasTests/DiffReviewSurfaceTests.swift
+++ b/AlasTests/DiffReviewSurfaceTests.swift
@@ -526,6 +526,76 @@ struct DiffReviewSurfaceTests {
         #expect(segments.items[1].draftComments.map(\.id) == ["draft-second"])
     }
 
+    @Test func localDraftCommentsOnCollapsedRowsAttachToCollapsedParent() throws {
+        let hiddenLine = diffLine(
+            id: "hidden-new",
+            side: .new,
+            newLine: 12,
+            text: "let hidden = true"
+        )
+        let collapsedParent = DiffDisplayRow(
+            id: "collapsed-parent",
+            kind: .collapsed,
+            old: nil,
+            new: nil,
+            collapsedLineCount: 1,
+            collapsedRows: [
+                DiffDisplayRow(
+                    id: "hidden-row",
+                    kind: .context,
+                    old: nil,
+                    new: hiddenLine,
+                    collapsedLineCount: 0
+                ),
+            ]
+        )
+        let group = DiffDisplayGroup(
+            id: "group",
+            header: "@@ -10,3 +10,3 @@",
+            sourceHunk: parsedDiff().hunks[0],
+            rows: [collapsedParent]
+        )
+        let comment = draftComment(id: "draft-collapsed", path: "A.swift", side: .new, startLine: 12)
+
+        let placement = ReviewDraftCommentPlacement.position([comment], in: [group])
+        let segments = ReviewDraftCommentRowSegmentation.segments(
+            for: group,
+            placement: placement,
+            pendingAnchor: nil
+        )
+
+        #expect(placement.fileLevel.isEmpty)
+        #expect(placement.byRowAnchor[ReviewDraftCommentPlacement.RowKey(side: .new, line: 12)]?.map(\.id) == ["draft-collapsed"])
+        #expect(segments.items.count == 1)
+        #expect(segments.items[0].rows.map(\.id) == ["collapsed-parent"])
+        #expect(segments.items[0].draftComments.map(\.id) == ["draft-collapsed"])
+    }
+
+    @Test func draftPlacementIndexesCollapsedChildRows() {
+        let line = diffLine(id: "old-hidden", side: .old, oldLine: 7, text: "let old = true")
+        let row = DiffDisplayRow(
+            id: "collapsed-parent",
+            kind: .collapsed,
+            old: nil,
+            new: nil,
+            collapsedLineCount: 1,
+            collapsedRows: [
+                DiffDisplayRow(
+                    id: "old-hidden-row",
+                    kind: .context,
+                    old: line,
+                    new: nil,
+                    collapsedLineCount: 0
+                ),
+            ]
+        )
+
+        #expect(ReviewDraftCommentPlacement.visibleRowKeys(in: row).isEmpty)
+        #expect(ReviewDraftCommentPlacement.allRowKeys(in: row) == [
+            ReviewDraftCommentPlacement.RowKey(side: .old, line: 7),
+        ])
+    }
+
     @Test func fileSectionRendersVisibleLocalDraftCommentCard() {
         let file = DiffReviewFileSectionModel(
             summary: summary(path: "Sources/App.swift"),
@@ -1142,6 +1212,31 @@ struct DiffReviewSurfaceTests {
             state: state,
             createdAt: Date(timeIntervalSince1970: 1),
             updatedAt: Date(timeIntervalSince1970: 2)
+        )
+    }
+
+    private func diffLine(
+        id: String,
+        side: DiffLineSide,
+        oldLine: Int? = nil,
+        newLine: Int? = nil,
+        text: String
+    ) -> DiffDisplayLine {
+        DiffDisplayLine(
+            id: id,
+            anchor: DiffLineAnchor(
+                filePath: "A.swift",
+                hunkIndex: 0,
+                rowIndex: 0,
+                side: side,
+                oldLine: oldLine,
+                newLine: newLine
+            ),
+            text: text,
+            lineNumber: oldLine ?? newLine,
+            kind: .context,
+            inlineSpans: [],
+            noTrailingNewline: false
         )
     }
 

--- a/AlasTests/DiffReviewSurfaceTests.swift
+++ b/AlasTests/DiffReviewSurfaceTests.swift
@@ -484,6 +484,60 @@ struct DiffReviewSurfaceTests {
         #expect(placement.fileLevel.map(\.id) == ["thread-file", "thread-unmatched"])
     }
 
+    @Test func localDraftCommentsPositionAtExactMatchingRows() throws {
+        let model = displayModel()
+        let comment = draftComment(id: "draft-line", path: "A.swift", side: .new, startLine: 2)
+
+        let placement = ReviewDraftCommentPlacement.position([comment], in: model.groups)
+
+        #expect(
+            placement.byRowAnchor[ReviewDraftCommentPlacement.RowKey(side: .new, line: 2)]?.map(\.id) == ["draft-line"]
+        )
+        #expect(placement.fileLevel.isEmpty)
+    }
+
+    @Test func unmatchedLocalDraftCommentsFallBackToFileLevel() {
+        let model = displayModel()
+        let comment = draftComment(id: "draft-unmatched", path: "A.swift", side: .new, startLine: 99)
+
+        let placement = ReviewDraftCommentPlacement.position([comment], in: model.groups)
+
+        #expect(placement.byRowAnchor.isEmpty)
+        #expect(placement.fileLevel.map(\.id) == ["draft-unmatched"])
+    }
+
+    @Test func fileSectionRendersVisibleLocalDraftCommentCard() {
+        let file = DiffReviewFileSectionModel(
+            summary: summary(path: "Sources/App.swift"),
+            parsedDiff: parsedDiff(),
+            displayModel: displayModel(),
+            placeholderMessage: nil,
+            openFile: nil
+        )
+        let comment = draftComment(id: "draft-visible", fileID: file.id, path: file.summary.path, side: .new, startLine: 2)
+        var layout = DiffLayoutMode.split
+        var wrap = false
+        var whitespace = false
+
+        let view = DiffReviewFileSection(
+            file: file,
+            draftComments: [comment],
+            layoutMode: Binding(get: { layout }, set: { layout = $0 }),
+            wrapLines: Binding(get: { wrap }, set: { wrap = $0 }),
+            showWhitespace: Binding(get: { whitespace }, set: { whitespace = $0 }),
+            codeFontFamily: "",
+            codeFontSize: 13,
+            showsSourceBadge: false
+        )
+        .environment(\.theme, theme())
+
+        let controller = host(view, width: 900, height: 500)
+
+        #expect(subview(withAccessibilityIdentifier: "diff-review-draft-comment-draft-visible", in: controller.view) != nil)
+        #expect(accessibilityLabel(in: controller.view, containing: "Local draft") != nil)
+        #expect(accessibilityLabel(in: controller.view, containing: "Please revisit this line.") != nil)
+    }
+
     @Test func inlineFeedbackContextFormatterIncludesReviewMetadata() {
         let file = summary(path: "Sources/App.swift")
         let item = DiffReviewInlineFeedback(
@@ -942,6 +996,22 @@ struct DiffReviewSurfaceTests {
         )
     }
 
+    @Test func estimatedSectionHeightGrowsWithDraftComments() {
+        let file = DiffReviewFileSectionModel(
+            summary: summary(path: "Sources/App.swift"),
+            parsedDiff: parsedDiff(),
+            displayModel: displayModel(),
+            placeholderMessage: nil,
+            openFile: nil
+        )
+        let comment = draftComment(id: "draft-height", fileID: file.id, path: file.summary.path, side: .new, startLine: 2)
+
+        #expect(
+            DiffReviewFileSectionHeightEstimator.estimatedHeight(for: file, inlineFeedback: [], draftComments: [comment])
+                > DiffReviewFileSectionHeightEstimator.estimatedHeight(for: file, inlineFeedback: [], draftComments: [])
+        )
+    }
+
     @Test func inlineFeedbackCardEstimateUsesDynamicBodyHeight() {
         let short = DiffReviewInlineFeedback(
             id: "short",
@@ -1023,6 +1093,36 @@ struct DiffReviewSurfaceTests {
                 evidenceItemID: "thread-\(index)"
             )
         }
+    }
+
+    private func draftComment(
+        id: String,
+        fileID: DiffReviewFileID = DiffReviewFileID(namespace: "commit", path: "A.swift"),
+        path: String = "A.swift",
+        side: DiffReviewInlineFeedbackSide = .new,
+        startLine: Int,
+        endLine: Int? = nil,
+        state: ReviewDraftCommentState = .active
+    ) -> ReviewDraftComment {
+        ReviewDraftComment(
+            id: id,
+            sessionID: .commit(
+                worktreeID: "wt",
+                repositoryPath: URL(fileURLWithPath: "/repo"),
+                sha: "abc123"
+            ),
+            fileID: fileID,
+            path: path,
+            originalPath: nil,
+            side: side,
+            startLine: startLine,
+            endLine: endLine,
+            selectedText: "let b = 3",
+            bodyMarkdown: "Please revisit this line.",
+            state: state,
+            createdAt: Date(timeIntervalSince1970: 1),
+            updatedAt: Date(timeIntervalSince1970: 2)
+        )
     }
 
     private func summary(

--- a/AlasTests/DiffReviewSurfaceTests.swift
+++ b/AlasTests/DiffReviewSurfaceTests.swift
@@ -616,6 +616,39 @@ struct DiffReviewSurfaceTests {
         #expect(segments.items.first?.draftComments.map(\.id) == ["draft-unknown"])
     }
 
+    @Test func localDraftCommentsWithUnknownSideDoNotDuplicateAcrossShiftedContextRows() {
+        let firstRow = DiffDisplayRow(
+            id: "row-1",
+            kind: .context,
+            old: diffLine(id: "old-1", side: .old, oldLine: 1, text: "one"),
+            new: diffLine(id: "new-2", side: .new, newLine: 2, text: "two"),
+            collapsedLineCount: 0
+        )
+        let secondRow = DiffDisplayRow(
+            id: "row-2",
+            kind: .context,
+            old: diffLine(id: "old-2", side: .old, oldLine: 2, text: "two"),
+            new: diffLine(id: "new-3", side: .new, newLine: 3, text: "three"),
+            collapsedLineCount: 0
+        )
+        let group = DiffDisplayGroup(
+            id: "group",
+            header: "@@ -1,2 +2,2 @@",
+            sourceHunk: parsedDiff().hunks[0],
+            rows: [firstRow, secondRow]
+        )
+        let comment = draftComment(id: "draft-shifted", path: "A.swift", side: .unknown, startLine: 2)
+
+        let placement = ReviewDraftCommentPlacement.position([comment], in: [group])
+        let segments = ReviewDraftCommentRowSegmentation.segments(
+            for: group,
+            placement: placement,
+            pendingAnchor: nil
+        )
+
+        #expect(segments.items.flatMap(\.draftComments).map(\.id) == ["draft-shifted"])
+    }
+
     @Test func fileSectionRendersVisibleLocalDraftCommentCard() {
         let file = DiffReviewFileSectionModel(
             summary: summary(path: "Sources/App.swift"),

--- a/AlasTests/DiffReviewSurfaceTests.swift
+++ b/AlasTests/DiffReviewSurfaceTests.swift
@@ -750,6 +750,7 @@ struct DiffReviewSurfaceTests {
                     canResolve: false,
                     canDismiss: true,
                     canCopyPrompt: false,
+                    canShowSendToAgent: false,
                     canSendToAgent: false
                 )
             },
@@ -1141,6 +1142,7 @@ struct DiffReviewSurfaceTests {
                     canResolve: false,
                     canDismiss: false,
                     canCopyPrompt: true,
+                    canShowSendToAgent: true,
                     canSendToAgent: true
                 )
             },
@@ -1165,7 +1167,7 @@ struct DiffReviewSurfaceTests {
         #expect(recorder.sent == bundle)
     }
 
-    @Test func summaryRailDisabledFinishActionsDoNotReportPressed() throws {
+    @Test func summaryRailHidesSendActionWhenNoAgentTargetExists() throws {
         let file = summary(path: "Sources/App.swift")
         let comment = draftComment(id: "draft-disabled-actions", fileID: file.id, path: file.path, side: .new, startLine: 2)
         let bundle = ReviewFeedbackBundle(
@@ -1181,7 +1183,7 @@ struct DiffReviewSurfaceTests {
         let actions = ReviewDraftCommentActions(
             availability: { _ in .none },
             copyPrompt: { _ in Issue.record("disabled copy action fired") },
-            sendToAgent: { _ in Issue.record("disabled send action fired") }
+            sendToAgent: { _ in Issue.record("hidden send action fired") }
         )
 
         let view = ReviewDraftSummaryRail(
@@ -1196,7 +1198,7 @@ struct DiffReviewSurfaceTests {
         let controller = host(view, width: 280, height: 500)
 
         #expect(!pressAccessibilityElement(withAccessibilityIdentifier: "review-draft-summary-copy-prompt", in: controller.view))
-        #expect(!pressAccessibilityElement(withAccessibilityIdentifier: "review-draft-summary-send-agent", in: controller.view))
+        #expect(subview(withAccessibilityIdentifier: "review-draft-summary-send-agent", in: controller.view) == nil)
     }
 
     @Test func summaryRailCanDismissDraftComment() throws {
@@ -1221,6 +1223,7 @@ struct DiffReviewSurfaceTests {
                     canResolve: false,
                     canDismiss: true,
                     canCopyPrompt: false,
+                    canShowSendToAgent: false,
                     canSendToAgent: false
                 )
             },
@@ -1304,6 +1307,7 @@ struct DiffReviewSurfaceTests {
                     canResolve: false,
                     canDismiss: false,
                     canCopyPrompt: true,
+                    canShowSendToAgent: true,
                     canSendToAgent: true
                 )
             },

--- a/AlasTests/DiffReviewSurfaceTests.swift
+++ b/AlasTests/DiffReviewSurfaceTests.swift
@@ -506,6 +506,26 @@ struct DiffReviewSurfaceTests {
         #expect(placement.fileLevel.map(\.id) == ["draft-unmatched"])
     }
 
+    @Test func localDraftCommentsSegmentSameHunkByExactRow() throws {
+        let model = displayModel()
+        let group = try #require(model.groups.first)
+        let firstLine = draftComment(id: "draft-first", path: "A.swift", side: .new, startLine: 1)
+        let secondLine = draftComment(id: "draft-second", path: "A.swift", side: .new, startLine: 2)
+        let placement = ReviewDraftCommentPlacement.position([secondLine, firstLine], in: model.groups)
+
+        let segments = ReviewDraftCommentRowSegmentation.segments(
+            for: group,
+            placement: placement,
+            pendingAnchor: nil
+        )
+
+        #expect(segments.items.count == 2)
+        #expect(segments.items[0].rows.map(\.id) == [group.rows[0].id])
+        #expect(segments.items[0].draftComments.map(\.id) == ["draft-first"])
+        #expect(segments.items[1].rows.map(\.id) == [group.rows[1].id])
+        #expect(segments.items[1].draftComments.map(\.id) == ["draft-second"])
+    }
+
     @Test func fileSectionRendersVisibleLocalDraftCommentCard() {
         let file = DiffReviewFileSectionModel(
             summary: summary(path: "Sources/App.swift"),

--- a/AlasTests/DiffReviewSurfaceTests.swift
+++ b/AlasTests/DiffReviewSurfaceTests.swift
@@ -1147,7 +1147,11 @@ struct DiffReviewSurfaceTests {
                 )
             },
             copyPrompt: { recorder.copied = $0 },
-            sendToAgent: { recorder.sent = $0 }
+            agentTargets: { [.newChat(agentID: "codex", title: "Codex")] },
+            sendToAgent: { bundle, target in
+                recorder.sent = bundle
+                recorder.sentTarget = target
+            }
         )
 
         let view = ReviewDraftSummaryRail(
@@ -1165,6 +1169,7 @@ struct DiffReviewSurfaceTests {
 
         #expect(recorder.copied == bundle)
         #expect(recorder.sent == bundle)
+        #expect(recorder.sentTarget == .newChat(agentID: "codex", title: "Codex"))
     }
 
     @Test func summaryRailHidesSendActionWhenNoAgentTargetExists() throws {
@@ -1183,7 +1188,8 @@ struct DiffReviewSurfaceTests {
         let actions = ReviewDraftCommentActions(
             availability: { _ in .none },
             copyPrompt: { _ in Issue.record("disabled copy action fired") },
-            sendToAgent: { _ in Issue.record("hidden send action fired") }
+            agentTargets: { [] },
+            sendToAgent: { _, _ in Issue.record("hidden send action fired") }
         )
 
         let view = ReviewDraftSummaryRail(
@@ -1312,7 +1318,11 @@ struct DiffReviewSurfaceTests {
                 )
             },
             copyPrompt: { recorder.copied = $0 },
-            sendToAgent: { recorder.sent = $0 }
+            agentTargets: { [.newChat(agentID: "codex", title: "Codex")] },
+            sendToAgent: { bundle, target in
+                recorder.sent = bundle
+                recorder.sentTarget = target
+            }
         )
 
         let view = ReviewDraftSummaryRail(
@@ -1330,6 +1340,7 @@ struct DiffReviewSurfaceTests {
 
         #expect(recorder.copied == bundle)
         #expect(recorder.sent == bundle)
+        #expect(recorder.sentTarget == .newChat(agentID: "codex", title: "Codex"))
     }
 
     @Test func selectionSynchronizationClearsEmptySessions() {
@@ -1827,4 +1838,5 @@ struct DiffReviewSurfaceTests {
 private final class ReviewBundleActionRecorder: @unchecked Sendable {
     var copied: ReviewFeedbackBundle?
     var sent: ReviewFeedbackBundle?
+    var sentTarget: ReviewFeedbackAgentTarget?
 }

--- a/AlasTests/DiffReviewSurfaceTests.swift
+++ b/AlasTests/DiffReviewSurfaceTests.swift
@@ -593,7 +593,27 @@ struct DiffReviewSurfaceTests {
         #expect(ReviewDraftCommentPlacement.visibleRowKeys(in: row).isEmpty)
         #expect(ReviewDraftCommentPlacement.allRowKeys(in: row) == [
             ReviewDraftCommentPlacement.RowKey(side: .old, line: 7),
+            ReviewDraftCommentPlacement.RowKey(side: .unknown, line: 7),
         ])
+    }
+
+    @Test func localDraftCommentsWithUnknownSideMatchContextRows() throws {
+        let model = displayModel()
+        let comment = draftComment(id: "draft-unknown", path: "A.swift", side: .unknown, startLine: 1)
+
+        let placement = ReviewDraftCommentPlacement.position([comment], in: model.groups)
+        let segments = ReviewDraftCommentRowSegmentation.segments(
+            for: try #require(model.groups.first),
+            placement: placement,
+            pendingAnchor: nil
+        )
+
+        #expect(placement.fileLevel.isEmpty)
+        #expect(
+            placement.byRowAnchor[ReviewDraftCommentPlacement.RowKey(side: .unknown, line: 1)]?.map(\.id)
+                == ["draft-unknown"]
+        )
+        #expect(segments.items.first?.draftComments.map(\.id) == ["draft-unknown"])
     }
 
     @Test func fileSectionRendersVisibleLocalDraftCommentCard() {
@@ -1095,6 +1115,56 @@ struct DiffReviewSurfaceTests {
             openFile: nil
         )
         let comment = draftComment(id: "draft-height", fileID: file.id, path: file.summary.path, side: .new, startLine: 2)
+
+        #expect(
+            DiffReviewFileSectionHeightEstimator.estimatedHeight(for: file, inlineFeedback: [], draftComments: [comment])
+                > DiffReviewFileSectionHeightEstimator.estimatedHeight(for: file, inlineFeedback: [], draftComments: [])
+        )
+    }
+
+    @Test func estimatedSectionHeightGrowsWithDraftCommentsOnCollapsedRows() {
+        let hiddenLine = diffLine(id: "hidden-new", side: .new, newLine: 12, text: "let hidden = true")
+        let collapsedParent = DiffDisplayRow(
+            id: "collapsed-parent",
+            kind: .collapsed,
+            old: nil,
+            new: nil,
+            collapsedLineCount: 1,
+            collapsedRows: [
+                DiffDisplayRow(
+                    id: "hidden-row",
+                    kind: .context,
+                    old: nil,
+                    new: hiddenLine,
+                    collapsedLineCount: 0
+                ),
+            ]
+        )
+        let displayModel = DiffDisplayModel(
+            filePath: "Sources/App.swift",
+            groups: [
+                DiffDisplayGroup(
+                    id: "group",
+                    header: "@@ -10,3 +10,3 @@",
+                    sourceHunk: parsedDiff().hunks[0],
+                    rows: [collapsedParent]
+                ),
+            ]
+        )
+        let file = DiffReviewFileSectionModel(
+            summary: summary(path: "Sources/App.swift"),
+            parsedDiff: parsedDiff(),
+            displayModel: displayModel,
+            placeholderMessage: nil,
+            openFile: nil
+        )
+        let comment = draftComment(
+            id: "draft-collapsed-height",
+            fileID: file.id,
+            path: file.summary.path,
+            side: .new,
+            startLine: 12
+        )
 
         #expect(
             DiffReviewFileSectionHeightEstimator.estimatedHeight(for: file, inlineFeedback: [], draftComments: [comment])

--- a/AlasTests/Integrations/ReviewEvidenceModelTests.swift
+++ b/AlasTests/Integrations/ReviewEvidenceModelTests.swift
@@ -4,6 +4,25 @@ import Testing
 
 @MainActor
 struct ReviewEvidenceModelTests {
+    @Test func reviewEvidenceDraftSessionIDUsesProviderRepositoryAndNumber() {
+        let sessionID = ReviewEvidenceTabView.reviewDraftSessionID(
+            worktreeID: "wt",
+            provider: .github,
+            host: "github.com",
+            repositorySlug: "mrmans0n/alas",
+            number: 520
+        )
+
+        #expect(sessionID == ReviewDraftSessionID.reviewRequest(
+            worktreeID: "wt",
+            provider: .github,
+            host: "github.com",
+            repositorySlug: "mrmans0n/alas",
+            number: 520
+        ))
+        #expect(sessionID.sourceKind == .reviewRequest)
+    }
+
     @Test func defaultLoadSelectsFilesAndLoadsEvidenceWithoutDetailCalls() async {
         let recorder = EvidenceProviderRecorder()
         let model = ReviewEvidenceModel(

--- a/AlasTests/Integrations/ReviewRequestDraftTests.swift
+++ b/AlasTests/Integrations/ReviewRequestDraftTests.swift
@@ -5,6 +5,110 @@ import Testing
 @testable import Alas
 
 struct ReviewRequestDraftTests {
+    @Test func draftReviewRequestDraftSessionIDUsesBaseAndHeadBranches() {
+        let sessionID = DraftReviewRequestTabView.reviewDraftSessionID(
+            worktreeID: "wt",
+            repositoryPath: URL(fileURLWithPath: "/repo"),
+            base: "main",
+            head: "feature"
+        )
+
+        #expect(sessionID == ReviewDraftSessionID.draftReviewRequest(
+            worktreeID: "wt",
+            repositoryPath: URL(fileURLWithPath: "/repo"),
+            base: "main",
+            head: "feature"
+        ))
+        #expect(sessionID.sourceKind == .draftReviewRequest)
+    }
+
+    @Test @MainActor func selectingDraftSummaryCommentFocusesAndSelectsFile() async throws {
+        let path = "Sources/A.swift"
+        let context = ReviewRequestDraftContext(
+            commitSubjects: [],
+            commits: [],
+            changedFiles: [
+                CommitChangedFile(path: path, originalPath: nil, status: "M", add: 1, del: 1),
+            ],
+            diff: Self.modifiedSwiftDiff(path: path),
+            fileDiffsByPath: [path: Self.modifiedSwiftDiff(path: path)],
+            hasUncommittedChanges: false
+        )
+        let session = try await DraftReviewRequestDiffSessionBuilder.build(
+            context: context,
+            worktreePath: URL(fileURLWithPath: "/tmp/alas-tests"),
+            openFileForPath: { _ -> (() -> Void)? in nil }
+        )
+        let fileID = DiffReviewFileID(namespace: "draft-review-request", path: path)
+        let comment = ReviewDraftComment(
+            id: "draft-1",
+            sessionID: .draftReviewRequest(
+                worktreeID: "wt",
+                repositoryPath: URL(fileURLWithPath: "/repo"),
+                base: "main",
+                head: "feature"
+            ),
+            fileID: fileID,
+            path: path,
+            originalPath: nil,
+            side: .new,
+            startLine: 1,
+            endLine: nil,
+            selectedText: "let value = 2",
+            bodyMarkdown: "Prefer a named constant.",
+            state: .active,
+            createdAt: Date(timeIntervalSince1970: 1),
+            updatedAt: Date(timeIntervalSince1970: 1)
+        )
+        var selectedFileID: DiffReviewFileID?
+        var focusedDraftCommentID: String?
+        var draftScrollCommand: DiffReviewDraftCommentScrollCommand?
+        var railCollapsed = false
+        var summaryCollapsed = false
+        var layoutMode = DiffLayoutMode.split
+        var wrapLines = false
+        var showWhitespace = false
+        var scrollController = DiffReviewDraftCommentScrollController()
+
+        func makeView() -> some View {
+            DiffReviewSurface(
+                session: session,
+                selectedFileID: Binding(get: { selectedFileID }, set: { selectedFileID = $0 }),
+                railCollapsed: Binding(get: { railCollapsed }, set: { railCollapsed = $0 }),
+                reviewSummaryCollapsed: Binding(get: { summaryCollapsed }, set: { summaryCollapsed = $0 }),
+                layoutMode: Binding(get: { layoutMode }, set: { layoutMode = $0 }),
+                wrapLines: Binding(get: { wrapLines }, set: { wrapLines = $0 }),
+                showWhitespace: Binding(get: { showWhitespace }, set: { showWhitespace = $0 }),
+                codeFontFamily: "",
+                codeFontSize: 13,
+                showsDraftSummaryRail: true,
+                draftCommentsByFileID: [fileID: [comment]],
+                focusedDraftCommentID: focusedDraftCommentID,
+                draftCommentScrollCommand: draftScrollCommand,
+                onSelectDraftComment: { selected in
+                    focusedDraftCommentID = selected.id
+                    selectedFileID = selected.fileID
+                    draftScrollCommand = scrollController.command(commentID: selected.id, fileID: selected.fileID)
+                }
+            )
+            .environment(\.theme, theme())
+        }
+
+        let controller = host(makeView(), width: 1100, height: 720)
+        await Task.yield()
+        controller.view.layoutSubtreeIfNeeded()
+        #expect(pressAccessibilityElement(withAccessibilityIdentifier: "review-draft-summary-comment-draft-1", in: controller.view))
+        controller.rootView = makeView()
+        await Task.yield()
+        controller.view.layoutSubtreeIfNeeded()
+
+        #expect(selectedFileID == fileID)
+        #expect(focusedDraftCommentID == "draft-1")
+        #expect(draftScrollCommand?.fileID == fileID)
+        #expect(draftScrollCommand?.commentID == "draft-1")
+        #expect(subview(withAccessibilityIdentifier: "diff-review-draft-comment-focused-draft-1", in: controller.view) != nil)
+    }
+
     @Test func draftReviewRequestDiffSessionBuilderCreatesRenderableFileSection() async throws {
         let path = "Sources/A.swift"
         let context = ReviewRequestDraftContext(
@@ -82,7 +186,7 @@ struct ReviewRequestDraftTests {
         let session = try await DraftReviewRequestDiffSessionBuilder.build(
             context: context,
             worktreePath: URL(fileURLWithPath: "/tmp/alas-tests"),
-            openFileForPath: { _ in nil }
+            openFileForPath: { _ -> (() -> Void)? in nil }
         )
         var selectedFileID = DraftReviewRequestDiffSessionBuilder.selectedFileID(for: path)
         var railCollapsed = false
@@ -174,7 +278,7 @@ struct ReviewRequestDraftTests {
         let session = try await DraftReviewRequestDiffSessionBuilder.build(
             context: context,
             worktreePath: URL(fileURLWithPath: "/tmp/alas-tests"),
-            openFileForPath: { _ in nil }
+            openFileForPath: { _ -> (() -> Void)? in nil }
         )
 
         let selected = DraftReviewRequestDiffSessionBuilder.synchronizedSelection(
@@ -200,7 +304,7 @@ struct ReviewRequestDraftTests {
         let session = try await DraftReviewRequestDiffSessionBuilder.build(
             context: context,
             worktreePath: URL(fileURLWithPath: "/tmp/alas-tests"),
-            openFileForPath: { _ in nil }
+            openFileForPath: { _ -> (() -> Void)? in nil }
         )
 
         let selected = DraftReviewRequestDiffSessionBuilder.synchronizedSelection(
@@ -236,7 +340,7 @@ struct ReviewRequestDraftTests {
         let session = try await DraftReviewRequestDiffSessionBuilder.build(
             context: context,
             worktreePath: URL(fileURLWithPath: "/tmp/alas-tests"),
-            openFileForPath: { _ in nil }
+            openFileForPath: { _ -> (() -> Void)? in nil }
         )
 
         #expect(session.files.map(\.summary.path) == [imagePath, textPath])
@@ -442,6 +546,31 @@ struct ReviewRequestDraftTests {
 
     private func allSubviews(of view: NSView) -> [NSView] {
         view.subviews + view.subviews.flatMap { allSubviews(of: $0) }
+    }
+
+    private func subview(withAccessibilityIdentifier identifier: String, in view: NSView) -> NSView? {
+        if view.accessibilityIdentifier() == identifier {
+            return view
+        }
+        return view.subviews.lazy.compactMap { subview(withAccessibilityIdentifier: identifier, in: $0) }.first
+    }
+
+    private func subviews(withAccessibilityIdentifier identifier: String, in view: NSView) -> [NSView] {
+        var matches: [NSView] = []
+        if view.accessibilityIdentifier() == identifier {
+            matches.append(view)
+        }
+        matches.append(contentsOf: view.subviews.flatMap { subviews(withAccessibilityIdentifier: identifier, in: $0) })
+        return matches
+    }
+
+    private func pressAccessibilityElement(withAccessibilityIdentifier identifier: String, in view: NSView) -> Bool {
+        for match in subviews(withAccessibilityIdentifier: identifier, in: view) {
+            if match.accessibilityPerformPress() {
+                return true
+            }
+        }
+        return false
     }
 
     private func isEffectivelyVisible(_ view: NSView) -> Bool {

--- a/AlasTests/ReviewChangesTabViewTests.swift
+++ b/AlasTests/ReviewChangesTabViewTests.swift
@@ -8,6 +8,71 @@ import Testing
 struct ReviewChangesTabViewTests {
     private func theme() -> Theme { try! ThemeStore().current }
 
+    @Test func reviewChangesDraftSessionIDUsesWorktreeAndLocalChangesScope() {
+        let worktree = Worktree(
+            id: "wt-1",
+            projectId: "project-1",
+            name: "main",
+            branch: "main",
+            path: URL(fileURLWithPath: "/repo"),
+            status: .clean,
+            lastActivity: Date(timeIntervalSince1970: 0)
+        )
+
+        let sessionID = ReviewChangesTabView.reviewDraftSessionID(worktree: worktree)
+
+        #expect(sessionID == ReviewDraftSessionID.localChanges(
+            worktreeID: "wt-1",
+            worktreePath: URL(fileURLWithPath: "/repo"),
+            scope: .all
+        ))
+        #expect(sessionID.sourceKind == .localChanges)
+    }
+
+    @Test func copyReviewPromptUsesPromptMarkdown() {
+        var copiedPrompt: String?
+        let bundle = ReviewFeedbackBundle(
+            target: ReviewFeedbackTarget(
+                title: "Working tree",
+                repositoryPath: "/repo",
+                providerDescription: nil,
+                sourceDescription: "Review Changes"
+            ),
+            comments: [
+                draftComment(id: "draft-1", body: "Extract this helper."),
+            ]
+        )
+
+        ReviewFeedbackPromptActions.copyPrompt(bundle, pasteboard: { copiedPrompt = $0 })
+
+        #expect(copiedPrompt == bundle.promptMarkdown())
+    }
+
+    @Test func sendReviewPromptUsesSamePromptMarkdownAndTarget() {
+        let target = ReviewFeedbackAgentTarget.newChat(agentID: "codex", title: "New chat")
+        let sender = ReviewFeedbackAgentSender(
+            availableTargets: { [target] },
+            send: { prompt, selectedTarget in
+                #expect(prompt.contains("Please address each review comment below."))
+                #expect(prompt.contains("Extract this helper."))
+                #expect(selectedTarget == target)
+            }
+        )
+        let bundle = ReviewFeedbackBundle(
+            target: ReviewFeedbackTarget(
+                title: "Working tree",
+                repositoryPath: "/repo",
+                providerDescription: nil,
+                sourceDescription: "Review Changes"
+            ),
+            comments: [
+                draftComment(id: "draft-1", body: "Extract this helper."),
+            ]
+        )
+
+        ReviewFeedbackPromptActions.sendToAgent(bundle, target: target, sender: sender)
+    }
+
     @Test func loadTokenOnlyAcceptsCurrentLoad() {
         let key = "/repo\u{0}review"
         let first = ReviewChangesLoadToken.next(key: key)
@@ -254,6 +319,28 @@ struct ReviewChangesTabViewTests {
             deletions: deletions,
             isRenderable: isRenderable,
             originalPath: originalPath
+        )
+    }
+
+    private func draftComment(id: String, body: String) -> ReviewDraftComment {
+        ReviewDraftComment(
+            id: id,
+            sessionID: .localChanges(
+                worktreeID: "wt-1",
+                worktreePath: URL(fileURLWithPath: "/repo"),
+                scope: .all
+            ),
+            fileID: DiffReviewFileID(namespace: "unstaged", path: "Sources/App.swift"),
+            path: "Sources/App.swift",
+            originalPath: nil,
+            side: .new,
+            startLine: 4,
+            endLine: nil,
+            selectedText: nil,
+            bodyMarkdown: body,
+            state: .active,
+            createdAt: Date(timeIntervalSince1970: 1),
+            updatedAt: Date(timeIntervalSince1970: 1)
         )
     }
 }

--- a/AlasTests/ReviewChangesTabViewTests.swift
+++ b/AlasTests/ReviewChangesTabViewTests.swift
@@ -73,6 +73,78 @@ struct ReviewChangesTabViewTests {
         ReviewFeedbackPromptActions.sendToAgent(bundle, target: target, sender: sender)
     }
 
+    @Test func draftWorkspaceActionsEditCommentThroughController() throws {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        let store = ReviewDraftCommentStore(
+            store: PersistenceStore(),
+            url: directory.appendingPathComponent("review-draft-comments.json")
+        )
+        let session = ReviewDraftSessionID.localChanges(
+            worktreeID: "wt-1",
+            worktreePath: URL(fileURLWithPath: "/repo"),
+            scope: .all
+        )
+        let controller = ReviewDraftCommentController(
+            sessionID: session,
+            store: store,
+            now: { Date(timeIntervalSince1970: 100) }
+        )
+        let sender = ReviewFeedbackAgentSender(
+            availableTargets: { [] },
+            send: { _, _ in Issue.record("send should not be called") }
+        )
+        let anchor = DiffReviewLineAnchor(
+            path: "Sources/App.swift",
+            side: .new,
+            line: 4,
+            rowIndex: 0,
+            selectedText: ""
+        )
+        let fileID = DiffReviewFileID(namespace: "unstaged", path: "Sources/App.swift")
+
+        try controller.load()
+        try controller.add(anchor: anchor, fileID: fileID, bodyMarkdown: "Original")
+        let comment = try #require(controller.comments.first)
+        let actions = ReviewDraftWorkspaceActions.make(controller: controller, sender: sender)
+
+        #expect(actions.availability(comment).canEdit)
+        actions.edit(comment, "Updated body")
+
+        #expect(controller.comments.count == 1)
+        #expect(controller.comments.first?.bodyMarkdown == "Updated body")
+        let savedComments = try store.load(sessionID: session)
+        #expect(savedComments.count == 1)
+        #expect(savedComments.first?.bodyMarkdown == "Updated body")
+    }
+
+    @Test func draftWorkspaceActionsSendToExplicitTargetOnly() {
+        let codex = ReviewFeedbackAgentTarget.newChat(agentID: "codex", title: "Codex")
+        let claude = ReviewFeedbackAgentTarget.newChat(agentID: "claude", title: "Claude")
+        var selectedTarget: ReviewFeedbackAgentTarget?
+        let sender = ReviewFeedbackAgentSender(
+            availableTargets: { [codex, claude] },
+            send: { _, target in selectedTarget = target }
+        )
+        let comment = draftComment(id: "draft-1", body: "Extract this helper.")
+        let bundle = ReviewFeedbackBundle(
+            target: ReviewFeedbackTarget(
+                title: "Working tree",
+                repositoryPath: "/repo",
+                providerDescription: nil,
+                sourceDescription: "Review Changes"
+            ),
+            comments: [comment]
+        )
+        let actions = ReviewDraftWorkspaceActions.make(controller: nil, sender: sender)
+
+        #expect(actions.agentTargets() == [codex, claude])
+        #expect(actions.availability(comment).canShowSendToAgent)
+        actions.sendToAgent(bundle, claude)
+
+        #expect(selectedTarget == claude)
+    }
+
     @Test func loadTokenOnlyAcceptsCurrentLoad() {
         let key = "/repo\u{0}review"
         let first = ReviewChangesLoadToken.next(key: key)

--- a/AlasTests/ReviewDraftCommentStoreTests.swift
+++ b/AlasTests/ReviewDraftCommentStoreTests.swift
@@ -1,0 +1,68 @@
+import Foundation
+import Testing
+@testable import Alas
+
+@Suite("Review draft comment store")
+struct ReviewDraftCommentStoreTests {
+    @Test func savesLoadsAndDeletesCommentsBySession() throws {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        let url = directory.appendingPathComponent("review-draft-comments.json")
+        let store = ReviewDraftCommentStore(store: PersistenceStore(), url: url)
+        let session = ReviewDraftSessionID.localChanges(
+            worktreeID: "wt",
+            worktreePath: URL(fileURLWithPath: "/repo"),
+            scope: .all
+        )
+        let comment = ReviewDraftComment(
+            id: "comment-1",
+            sessionID: session,
+            fileID: DiffReviewFileID(namespace: "unstaged", path: "A.swift"),
+            path: "A.swift",
+            originalPath: nil,
+            side: .new,
+            startLine: 4,
+            endLine: nil,
+            selectedText: "let a = 1",
+            bodyMarkdown: "**Fix** this.",
+            state: .active,
+            createdAt: Date(timeIntervalSince1970: 10),
+            updatedAt: Date(timeIntervalSince1970: 11)
+        )
+
+        try store.save(comment)
+        #expect(try store.load(sessionID: session) == [comment])
+
+        var edited = comment
+        edited.bodyMarkdown = "Updated"
+        edited.state = .resolved
+        edited.updatedAt = Date(timeIntervalSince1970: 12)
+        try store.save(edited)
+        #expect(try store.load(sessionID: session).single?.bodyMarkdown == "Updated")
+        #expect(try store.load(sessionID: session).single?.state == .resolved)
+
+        try store.delete(commentID: "comment-1", sessionID: session)
+        #expect(try store.load(sessionID: session).isEmpty)
+    }
+
+    @Test func brokenStoreFileReturnsEmptySessions() throws {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        let url = directory.appendingPathComponent("review-draft-comments.json")
+        try Data("not json".utf8).write(to: url)
+        let store = ReviewDraftCommentStore(store: PersistenceStore(), url: url)
+        let session = ReviewDraftSessionID.localChanges(
+            worktreeID: "wt",
+            worktreePath: URL(fileURLWithPath: "/repo"),
+            scope: .all
+        )
+
+        #expect(try store.load(sessionID: session).isEmpty)
+        #expect(!FileManager.default.fileExists(atPath: url.path))
+    }
+}
+
+private extension Array {
+    var single: Element? { count == 1 ? first : nil }
+}

--- a/AlasTests/ReviewDraftCommentStoreTests.swift
+++ b/AlasTests/ReviewDraftCommentStoreTests.swift
@@ -61,6 +61,52 @@ struct ReviewDraftCommentStoreTests {
         #expect(try store.load(sessionID: session).isEmpty)
         #expect(!FileManager.default.fileExists(atPath: url.path))
     }
+
+    @Test func loadUsesDeterministicTieBreakersForSameLineComments() throws {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        let url = directory.appendingPathComponent("review-draft-comments.json")
+        let store = ReviewDraftCommentStore(store: PersistenceStore(), url: url)
+        let session = ReviewDraftSessionID.localChanges(
+            worktreeID: "wt",
+            worktreePath: URL(fileURLWithPath: "/repo"),
+            scope: .all
+        )
+        let date = Date(timeIntervalSince1970: 10)
+        let laterRange = makeComment(id: "b", session: session, startLine: 4, endLine: 6, createdAt: date)
+        let earlierRange = makeComment(id: "a", session: session, startLine: 4, endLine: 5, createdAt: date)
+        let sameRangeLaterID = makeComment(id: "c", session: session, startLine: 4, endLine: 5, createdAt: date)
+
+        try store.save(laterRange)
+        try store.save(sameRangeLaterID)
+        try store.save(earlierRange)
+
+        #expect(try store.load(sessionID: session).map(\.id) == ["a", "c", "b"])
+    }
+
+    private func makeComment(
+        id: String,
+        session: ReviewDraftSessionID,
+        startLine: Int,
+        endLine: Int?,
+        createdAt: Date
+    ) -> ReviewDraftComment {
+        ReviewDraftComment(
+            id: id,
+            sessionID: session,
+            fileID: DiffReviewFileID(namespace: "unstaged", path: "A.swift"),
+            path: "A.swift",
+            originalPath: nil,
+            side: .new,
+            startLine: startLine,
+            endLine: endLine,
+            selectedText: nil,
+            bodyMarkdown: "Comment \(id)",
+            state: .active,
+            createdAt: createdAt,
+            updatedAt: createdAt
+        )
+    }
 }
 
 private extension Array {

--- a/AlasTests/ReviewDraftCommentStoreTests.swift
+++ b/AlasTests/ReviewDraftCommentStoreTests.swift
@@ -55,6 +55,10 @@ struct ReviewDraftCommentStoreTests {
         #expect(controller.comments.single?.state == .resolved)
         #expect(try store.load(sessionID: session).single?.state == .resolved)
 
+        try controller.dismiss(commentID: added.id)
+        #expect(controller.comments.single?.state == .dismissed)
+        #expect(try store.load(sessionID: session).single?.state == .dismissed)
+
         try controller.delete(commentID: added.id)
         #expect(controller.comments.isEmpty)
         #expect(try store.load(sessionID: session).isEmpty)

--- a/AlasTests/ReviewDraftCommentStoreTests.swift
+++ b/AlasTests/ReviewDraftCommentStoreTests.swift
@@ -4,6 +4,63 @@ import Testing
 
 @Suite("Review draft comment store")
 struct ReviewDraftCommentStoreTests {
+    @Test @MainActor func controllerAddsEditsDeletesAndResolvesComments() throws {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        let url = directory.appendingPathComponent("review-draft-comments.json")
+        let store = ReviewDraftCommentStore(store: PersistenceStore(), url: url)
+        let session = ReviewDraftSessionID.localChanges(
+            worktreeID: "wt",
+            worktreePath: URL(fileURLWithPath: "/repo"),
+            scope: .all
+        )
+        let controller = ReviewDraftCommentController(
+            sessionID: session,
+            store: store,
+            now: { Date(timeIntervalSince1970: 100) }
+        )
+        let anchor = DiffReviewLineAnchor(
+            path: "Sources/App.swift",
+            side: .new,
+            line: 42,
+            rowIndex: 3,
+            selectedText: "let value = 1"
+        )
+        let fileID = DiffReviewFileID(namespace: "unstaged", path: "Sources/App.swift")
+
+        try controller.load()
+        #expect(controller.comments.isEmpty)
+
+        try controller.add(anchor: anchor, fileID: fileID, bodyMarkdown: "Please revisit this.")
+        let added = try #require(controller.comments.single)
+        #expect(added.sessionID == session)
+        #expect(added.fileID == fileID)
+        #expect(added.path == "Sources/App.swift")
+        #expect(added.originalPath == nil)
+        #expect(added.side == .new)
+        #expect(added.startLine == 42)
+        #expect(added.endLine == nil)
+        #expect(added.selectedText == "let value = 1")
+        #expect(added.bodyMarkdown == "Please revisit this.")
+        #expect(added.state == .active)
+        #expect(added.createdAt == Date(timeIntervalSince1970: 100))
+        #expect(added.updatedAt == Date(timeIntervalSince1970: 100))
+        #expect(try store.load(sessionID: session).single?.id == added.id)
+
+        try controller.edit(commentID: added.id, bodyMarkdown: "Updated")
+        #expect(controller.comments.single?.bodyMarkdown == "Updated")
+        #expect(try store.load(sessionID: session).single?.bodyMarkdown == "Updated")
+
+        try controller.resolve(commentID: added.id)
+        #expect(controller.comments.single?.state == .resolved)
+        #expect(try store.load(sessionID: session).single?.state == .resolved)
+
+        try controller.delete(commentID: added.id)
+        #expect(controller.comments.isEmpty)
+        #expect(try store.load(sessionID: session).isEmpty)
+        #expect(controller.errorMessage == nil)
+    }
+
     @Test func savesLoadsAndDeletesCommentsBySession() throws {
         let directory = FileManager.default.temporaryDirectory
             .appendingPathComponent(UUID().uuidString, isDirectory: true)

--- a/AlasTests/ReviewDraftModelsTests.swift
+++ b/AlasTests/ReviewDraftModelsTests.swift
@@ -1,0 +1,67 @@
+import Foundation
+import Testing
+@testable import Alas
+
+@Suite("Review draft models")
+struct ReviewDraftModelsTests {
+    @Test func localChangesSessionIDIsStableForSameWorktree() {
+        let first = ReviewDraftSessionID.localChanges(
+            worktreeID: "wt-1",
+            worktreePath: URL(fileURLWithPath: "/repo"),
+            scope: .all
+        )
+        let second = ReviewDraftSessionID.localChanges(
+            worktreeID: "wt-1",
+            worktreePath: URL(fileURLWithPath: "/repo"),
+            scope: .all
+        )
+
+        #expect(first == second)
+        #expect(first.rawValue.contains("local-changes"))
+        #expect(first.rawValue.contains("wt-1"))
+    }
+
+    @Test func commitAndProviderSessionsDoNotCollide() {
+        let commit = ReviewDraftSessionID.commit(
+            worktreeID: "wt",
+            repositoryPath: URL(fileURLWithPath: "/repo"),
+            sha: "abc123"
+        )
+        let pr = ReviewDraftSessionID.reviewRequest(
+            worktreeID: "wt",
+            provider: .github,
+            host: "github.com",
+            repositorySlug: "mrmans0n/alas",
+            number: 520
+        )
+
+        #expect(commit != pr)
+        #expect(commit.sourceKind == .commit)
+        #expect(pr.sourceKind == .reviewRequest)
+    }
+
+    @Test func draftCommentRangeNormalizesLineOrder() {
+        let comment = ReviewDraftComment(
+            id: "c1",
+            sessionID: .localChanges(
+                worktreeID: "wt",
+                worktreePath: URL(fileURLWithPath: "/repo"),
+                scope: .all
+            ),
+            fileID: DiffReviewFileID(namespace: "unstaged", path: "Sources/App.swift"),
+            path: "Sources/App.swift",
+            originalPath: nil,
+            side: .new,
+            startLine: 8,
+            endLine: 3,
+            selectedText: "let value = 1",
+            bodyMarkdown: "Please extract this.",
+            state: .active,
+            createdAt: Date(timeIntervalSince1970: 1),
+            updatedAt: Date(timeIntervalSince1970: 2)
+        )
+
+        #expect(comment.normalizedLineRange == 3...8)
+        #expect(comment.isActive)
+    }
+}

--- a/AlasTests/ReviewFeedbackBundleTests.swift
+++ b/AlasTests/ReviewFeedbackBundleTests.swift
@@ -89,6 +89,46 @@ struct ReviewFeedbackBundleTests {
         #expect(prompt.contains("This behavior regressed."))
     }
 
+    @Test func promptDistinguishesSamePathCommentsFromDifferentNamespaces() {
+        let session = ReviewDraftSessionID.localChanges(
+            worktreeID: "wt",
+            worktreePath: URL(fileURLWithPath: "/repo"),
+            scope: .all
+        )
+        let target = ReviewFeedbackTarget(
+            title: "Local changes",
+            repositoryPath: "/repo",
+            providerDescription: nil,
+            sourceDescription: "Review Changes"
+        )
+        let bundle = ReviewFeedbackBundle(target: target, comments: [
+            comment(
+                id: "unstaged",
+                session: session,
+                namespace: "unstaged",
+                path: "Sources/App.swift",
+                line: 4,
+                body: "Fix the working tree edit."
+            ),
+            comment(
+                id: "staged",
+                session: session,
+                namespace: "staged",
+                path: "Sources/App.swift",
+                line: 4,
+                body: "Fix the staged edit."
+            ),
+        ])
+
+        let prompt = bundle.promptMarkdown()
+
+        #expect(prompt.contains("## Sources/App.swift [staged]"))
+        #expect(prompt.contains("## Sources/App.swift [unstaged]"))
+        #expect(prompt.contains("- `Sources/App.swift:4 (new, staged)` — Fix the staged edit."))
+        #expect(prompt.contains("- `Sources/App.swift:4 (new, unstaged)` — Fix the working tree edit."))
+    }
+
+
     @Test func promptPreservesMultilineMarkdownBodies() {
         let session = ReviewDraftSessionID.localChanges(
             worktreeID: "wt",
@@ -166,6 +206,7 @@ struct ReviewFeedbackBundleTests {
     private func comment(
         id: String,
         session: ReviewDraftSessionID,
+        namespace: String = "review",
         path: String,
         side: DiffReviewInlineFeedbackSide = .new,
         line: Int,
@@ -177,7 +218,7 @@ struct ReviewFeedbackBundleTests {
         ReviewDraftComment(
             id: id,
             sessionID: session,
-            fileID: DiffReviewFileID(namespace: "review", path: path),
+            fileID: DiffReviewFileID(namespace: namespace, path: path),
             path: path,
             originalPath: nil,
             side: side,

--- a/AlasTests/ReviewFeedbackBundleTests.swift
+++ b/AlasTests/ReviewFeedbackBundleTests.swift
@@ -89,6 +89,80 @@ struct ReviewFeedbackBundleTests {
         #expect(prompt.contains("This behavior regressed."))
     }
 
+    @Test func promptPreservesMultilineMarkdownBodies() {
+        let session = ReviewDraftSessionID.localChanges(
+            worktreeID: "wt",
+            worktreePath: URL(fileURLWithPath: "/repo"),
+            scope: .all
+        )
+        let target = ReviewFeedbackTarget(
+            title: "Local changes",
+            repositoryPath: nil,
+            providerDescription: nil,
+            sourceDescription: "local changes"
+        )
+        let body = """
+        This needs a guard.
+
+        ```swift
+        if value == nil {
+            return
+        }
+        ```
+        """
+        let bundle = ReviewFeedbackBundle(target: target, comments: [
+            comment(id: "a", session: session, path: "A.swift", line: 4, body: body),
+        ])
+
+        let prompt = bundle.promptMarkdown()
+
+        #expect(prompt.contains("- `A.swift:4 (new)`"))
+        #expect(prompt.contains("""
+        This needs a guard.
+
+        ```swift
+        if value == nil {
+            return
+        }
+        ```
+        """))
+        #expect(!prompt.contains("This needs a guard. ```swift if value == nil"))
+    }
+
+    @Test func promptPreservesSelectedTextIndentation() {
+        let session = ReviewDraftSessionID.localChanges(
+            worktreeID: "wt",
+            worktreePath: URL(fileURLWithPath: "/repo"),
+            scope: .all
+        )
+        let target = ReviewFeedbackTarget(
+            title: "Local changes",
+            repositoryPath: nil,
+            providerDescription: nil,
+            sourceDescription: "local changes"
+        )
+        let selectedText = """
+            if condition {
+                run()
+            }
+        """
+        let bundle = ReviewFeedbackBundle(target: target, comments: [
+            comment(
+                id: "a",
+                session: session,
+                path: "A.swift",
+                line: 4,
+                selectedText: selectedText,
+                body: "Keep indentation."
+            ),
+        ])
+
+        let prompt = bundle.promptMarkdown()
+
+        #expect(prompt.contains(">     if condition {"))
+        #expect(prompt.contains(">         run()"))
+    }
+
     private func comment(
         id: String,
         session: ReviewDraftSessionID,

--- a/AlasTests/ReviewFeedbackBundleTests.swift
+++ b/AlasTests/ReviewFeedbackBundleTests.swift
@@ -128,7 +128,6 @@ struct ReviewFeedbackBundleTests {
         #expect(prompt.contains("- `Sources/App.swift:4 (new, unstaged)` — Fix the working tree edit."))
     }
 
-
     @Test func promptPreservesMultilineMarkdownBodies() {
         let session = ReviewDraftSessionID.localChanges(
             worktreeID: "wt",

--- a/AlasTests/ReviewFeedbackBundleTests.swift
+++ b/AlasTests/ReviewFeedbackBundleTests.swift
@@ -1,0 +1,119 @@
+import Foundation
+import Testing
+@testable import Alas
+
+@Suite("Review feedback bundle")
+struct ReviewFeedbackBundleTests {
+    @Test func promptGroupsActiveCommentsByFileAndLine() throws {
+        let session = ReviewDraftSessionID.commit(
+            worktreeID: "wt",
+            repositoryPath: URL(fileURLWithPath: "/repo"),
+            sha: "abc123"
+        )
+        let target = ReviewFeedbackTarget(
+            title: "Review commit abc123",
+            repositoryPath: "/repo",
+            providerDescription: nil,
+            sourceDescription: "commit abc123"
+        )
+        let bundle = ReviewFeedbackBundle(target: target, comments: [
+            comment(
+                id: "b",
+                session: session,
+                path: "Sources/B.swift",
+                line: 9,
+                body: "Rename this."
+            ),
+            comment(
+                id: "a-resolved",
+                session: session,
+                path: "Sources/A.swift",
+                line: 1,
+                body: "Resolved body.",
+                state: .resolved
+            ),
+            comment(
+                id: "a",
+                session: session,
+                path: "Sources/A.swift",
+                line: 2,
+                body: "Extract helper."
+            ),
+        ])
+
+        let prompt = bundle.promptMarkdown()
+
+        #expect(prompt.contains("Please address each review comment below."))
+        #expect(prompt.contains("Review target: Review commit abc123"))
+        #expect(prompt.contains("Repository: /repo"))
+        #expect(prompt.contains("Source: commit abc123"))
+        #expect(prompt.contains("## Sources/A.swift"))
+        #expect(prompt.contains("## Sources/B.swift"))
+        let aHeader = try #require(prompt.range(of: "## Sources/A.swift")?.lowerBound)
+        let bHeader = try #require(prompt.range(of: "## Sources/B.swift")?.lowerBound)
+        #expect(aHeader < bHeader)
+        #expect(prompt.contains("- `Sources/A.swift:2 (new)` — Extract helper."))
+        #expect(prompt.contains("- `Sources/B.swift:9 (new)` — Rename this."))
+        #expect(!prompt.contains("Resolved body."))
+    }
+
+    @Test func promptIncludesLineRangesAndSelectedText() {
+        let session = ReviewDraftSessionID.localChanges(
+            worktreeID: "wt",
+            worktreePath: URL(fileURLWithPath: "/repo"),
+            scope: .all
+        )
+        let target = ReviewFeedbackTarget(
+            title: "Local changes",
+            repositoryPath: nil,
+            providerDescription: nil,
+            sourceDescription: "local changes"
+        )
+        let bundle = ReviewFeedbackBundle(target: target, comments: [
+            comment(
+                id: "a",
+                session: session,
+                path: "A.swift",
+                side: .old,
+                line: 4,
+                endLine: 6,
+                selectedText: "old code",
+                body: "This behavior regressed."
+            ),
+        ])
+
+        let prompt = bundle.promptMarkdown()
+
+        #expect(prompt.contains("`A.swift:4-6 (old)`"))
+        #expect(prompt.contains("> old code"))
+        #expect(prompt.contains("This behavior regressed."))
+    }
+
+    private func comment(
+        id: String,
+        session: ReviewDraftSessionID,
+        path: String,
+        side: DiffReviewInlineFeedbackSide = .new,
+        line: Int,
+        endLine: Int? = nil,
+        selectedText: String? = nil,
+        body: String,
+        state: ReviewDraftCommentState = .active
+    ) -> ReviewDraftComment {
+        ReviewDraftComment(
+            id: id,
+            sessionID: session,
+            fileID: DiffReviewFileID(namespace: "review", path: path),
+            path: path,
+            originalPath: nil,
+            side: side,
+            startLine: line,
+            endLine: endLine,
+            selectedText: selectedText,
+            bodyMarkdown: body,
+            state: state,
+            createdAt: Date(timeIntervalSince1970: Double(line)),
+            updatedAt: Date(timeIntervalSince1970: Double(line))
+        )
+    }
+}

--- a/docs/superpowers/plans/2026-06-14-local-review-workspace.md
+++ b/docs/superpowers/plans/2026-06-14-local-review-workspace.md
@@ -1,0 +1,1383 @@
+# Local Review Workspace Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add persistent local draft review comments on exact diff lines/ranges, render and manage them in the shared review surface, and bundle them for Copy Prompt / Send Feedback To Agent.
+
+**Architecture:** Introduce a provider-independent local review model and JSON store, then extend the existing `DiffReviewSurface` with local-comment display/action hooks. Keep provider feedback read-only and separate. Add entry-point session IDs for existing diff review sources so local comments persist per repo and review target.
+
+**Tech Stack:** Swift 5.9+, SwiftUI, AppKit `NSTextView` diff renderer, Swift Testing, existing `PersistenceStore`, existing `DiffReviewSurface`, existing ACP session infrastructure.
+
+---
+
+## File Structure
+
+- Create `Alas/Sources/Center/ReviewWorkspace/ReviewDraftModels.swift`
+  - `ReviewDraftSessionID`, `ReviewDraftComment`, local state enums, and source identity helpers.
+- Create `Alas/Sources/Center/ReviewWorkspace/ReviewDraftCommentStore.swift`
+  - JSON-backed persistence using `PersistenceStoreProtocol`.
+- Create `Alas/Sources/Center/ReviewWorkspace/ReviewFeedbackBundle.swift`
+  - ai-review-style prompt formatter and grouping logic.
+- Create `Alas/Sources/Center/ReviewWorkspace/ReviewDraftCommentActions.swift`
+  - action closures and context shared by summary rail and inline cards.
+- Create `Alas/Sources/Center/ReviewWorkspace/ReviewDraftSummaryRail.swift`
+  - right-side local review rail.
+- Modify `Alas/Sources/Persistence/Paths.swift`
+  - add `reviewDraftCommentsFile`.
+- Modify `Alas/Sources/Center/Diff/DiffPaneTextDocumentBuilder.swift`
+  - expose stable source-line metadata needed for exact local comment placement.
+- Modify `Alas/Sources/Center/Diff/DiffPaneTextDocumentView.swift`
+  - expose row hit/selection callbacks and local accessory row metadata.
+- Modify `Alas/Sources/Center/Diff/DiffPaneView.swift`
+  - pass local review interaction hooks into the AppKit body.
+- Modify `Alas/Sources/Center/DiffReview/DiffReviewModels.swift`
+  - add local review state inputs where they belong beside `DiffReviewLoadedSession` and file section models.
+- Modify `Alas/Sources/Center/DiffReview/DiffReviewFileSection.swift`
+  - render local draft comments exactly at row/range anchors and show inline composer.
+- Modify `Alas/Sources/Center/DiffReview/DiffReviewSurface.swift`
+  - add right review rail, draft-comment bindings, scroll/focus support, and placeholder height accounting.
+- Modify `Alas/Sources/Center/ReviewChanges/ReviewChangesTabView.swift`
+  - create/load draft session for local changes and pass local comments/actions into `DiffReviewSurface`.
+- Modify `Alas/Sources/Center/Commit/CommitTabView.swift`
+  - create/load draft session for commit review body.
+- Modify `Alas/Sources/Center/ReviewEvidence/ReviewEvidenceTabView.swift`
+  - create/load draft session for PR/MR Files while leaving provider feedback read-only.
+- Modify `Alas/Sources/Center/ReviewRequest/DraftReviewRequestTabView.swift`
+  - create/load draft session for create-PR branch diff review.
+- Modify `Alas.xcodeproj/project.pbxproj`
+  - regenerate or include new files so clean checkouts build.
+
+Tests:
+
+- Create `AlasTests/ReviewDraftModelsTests.swift`
+- Create `AlasTests/ReviewDraftCommentStoreTests.swift`
+- Create `AlasTests/ReviewFeedbackBundleTests.swift`
+- Extend `AlasTests/DiffReviewSurfaceTests.swift`
+- Extend `AlasTests/DiffPaneViewTests.swift`
+- Extend `AlasTests/ReviewChangesTabViewTests.swift`
+- Extend `AlasTests/CommitTabViewTests.swift`
+- Extend `AlasTests/Integrations/ReviewEvidenceModelTests.swift`
+- Extend `AlasTests/Integrations/ReviewRequestDraftTests.swift`
+
+---
+
+### Task 1: Draft Review Models And Persistence
+
+**Files:**
+- Create: `Alas/Sources/Center/ReviewWorkspace/ReviewDraftModels.swift`
+- Create: `Alas/Sources/Center/ReviewWorkspace/ReviewDraftCommentStore.swift`
+- Modify: `Alas/Sources/Persistence/Paths.swift`
+- Test: `AlasTests/ReviewDraftModelsTests.swift`
+- Test: `AlasTests/ReviewDraftCommentStoreTests.swift`
+
+- [ ] **Step 1: Write model tests for stable session IDs**
+
+Add `AlasTests/ReviewDraftModelsTests.swift`:
+
+```swift
+import Foundation
+import Testing
+
+@Suite("Review draft models")
+struct ReviewDraftModelsTests {
+    @Test func localChangesSessionIDIsStableForSameWorktree() {
+        let first = ReviewDraftSessionID.localChanges(
+            worktreeID: "wt-1",
+            worktreePath: URL(fileURLWithPath: "/repo"),
+            scope: .all
+        )
+        let second = ReviewDraftSessionID.localChanges(
+            worktreeID: "wt-1",
+            worktreePath: URL(fileURLWithPath: "/repo"),
+            scope: .all
+        )
+
+        #expect(first == second)
+        #expect(first.rawValue.contains("local-changes"))
+        #expect(first.rawValue.contains("wt-1"))
+    }
+
+    @Test func commitAndProviderSessionsDoNotCollide() {
+        let commit = ReviewDraftSessionID.commit(
+            worktreeID: "wt",
+            repositoryPath: URL(fileURLWithPath: "/repo"),
+            sha: "abc123"
+        )
+        let pr = ReviewDraftSessionID.reviewRequest(
+            worktreeID: "wt",
+            provider: .github,
+            host: "github.com",
+            repositorySlug: "mrmans0n/alas",
+            number: 520
+        )
+
+        #expect(commit != pr)
+        #expect(commit.sourceKind == .commit)
+        #expect(pr.sourceKind == .reviewRequest)
+    }
+
+    @Test func draftCommentRangeNormalizesLineOrder() {
+        let comment = ReviewDraftComment(
+            id: "c1",
+            sessionID: .localChanges(
+                worktreeID: "wt",
+                worktreePath: URL(fileURLWithPath: "/repo"),
+                scope: .all
+            ),
+            fileID: DiffReviewFileID(namespace: "unstaged", path: "Sources/App.swift"),
+            path: "Sources/App.swift",
+            originalPath: nil,
+            side: .new,
+            startLine: 8,
+            endLine: 3,
+            selectedText: "let value = 1",
+            bodyMarkdown: "Please extract this.",
+            state: .active,
+            createdAt: Date(timeIntervalSince1970: 1),
+            updatedAt: Date(timeIntervalSince1970: 2)
+        )
+
+        #expect(comment.normalizedLineRange == 3...8)
+        #expect(comment.isActive)
+    }
+}
+```
+
+- [ ] **Step 2: Write persistence tests**
+
+Add `AlasTests/ReviewDraftCommentStoreTests.swift`:
+
+```swift
+import Foundation
+import Testing
+
+@Suite("Review draft comment store")
+struct ReviewDraftCommentStoreTests {
+    @Test func savesLoadsAndDeletesCommentsBySession() throws {
+        let directory = try #require(FileManager.default.urls(for: .itemReplacementDirectory, in: .userDomainMask).first)
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        let url = directory.appendingPathComponent("review-draft-comments.json")
+        let store = ReviewDraftCommentStore(store: PersistenceStore(), url: url)
+        let session = ReviewDraftSessionID.localChanges(
+            worktreeID: "wt",
+            worktreePath: URL(fileURLWithPath: "/repo"),
+            scope: .all
+        )
+        let comment = ReviewDraftComment(
+            id: "comment-1",
+            sessionID: session,
+            fileID: DiffReviewFileID(namespace: "unstaged", path: "A.swift"),
+            path: "A.swift",
+            originalPath: nil,
+            side: .new,
+            startLine: 4,
+            endLine: nil,
+            selectedText: "let a = 1",
+            bodyMarkdown: "**Fix** this.",
+            state: .active,
+            createdAt: Date(timeIntervalSince1970: 10),
+            updatedAt: Date(timeIntervalSince1970: 11)
+        )
+
+        try store.save(comment)
+        #expect(try store.load(sessionID: session) == [comment])
+
+        var edited = comment
+        edited.bodyMarkdown = "Updated"
+        edited.state = .resolved
+        edited.updatedAt = Date(timeIntervalSince1970: 12)
+        try store.save(edited)
+        #expect(try store.load(sessionID: session).single?.bodyMarkdown == "Updated")
+        #expect(try store.load(sessionID: session).single?.state == .resolved)
+
+        try store.delete(commentID: "comment-1", sessionID: session)
+        #expect(try store.load(sessionID: session).isEmpty)
+    }
+
+    @Test func brokenStoreFileReturnsEmptySessions() throws {
+        let directory = try #require(FileManager.default.urls(for: .itemReplacementDirectory, in: .userDomainMask).first)
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        let url = directory.appendingPathComponent("review-draft-comments.json")
+        try Data("not json".utf8).write(to: url)
+        let store = ReviewDraftCommentStore(store: PersistenceStore(), url: url)
+        let session = ReviewDraftSessionID.localChanges(
+            worktreeID: "wt",
+            worktreePath: URL(fileURLWithPath: "/repo"),
+            scope: .all
+        )
+
+        #expect(try store.load(sessionID: session).isEmpty)
+        #expect(!FileManager.default.fileExists(atPath: url.path))
+    }
+}
+
+private extension Array {
+    var single: Element? { count == 1 ? first : nil }
+}
+```
+
+- [ ] **Step 3: Run tests red**
+
+Run:
+
+```bash
+rtk xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -only-testing:AlasTests/ReviewDraftModelsTests -only-testing:AlasTests/ReviewDraftCommentStoreTests test
+```
+
+Expected: fails to compile because `ReviewDraftSessionID`, `ReviewDraftComment`, and `ReviewDraftCommentStore` do not exist.
+
+- [ ] **Step 4: Implement models and store**
+
+Create `Alas/Sources/Center/ReviewWorkspace/ReviewDraftModels.swift`:
+
+```swift
+import Foundation
+
+enum ReviewDraftSourceKind: String, Codable, Equatable, Hashable, Sendable {
+    case localChanges = "local-changes"
+    case commit
+    case draftCommit = "draft-commit"
+    case branch
+    case reviewRequest = "review-request"
+    case draftReviewRequest = "draft-review-request"
+}
+
+enum ReviewDraftLocalChangesScope: String, Codable, Equatable, Hashable, Sendable {
+    case all
+    case unstaged
+    case staged
+}
+
+struct ReviewDraftSessionID: Codable, Equatable, Hashable, Sendable, RawRepresentable {
+    let rawValue: String
+    let sourceKind: ReviewDraftSourceKind
+
+    init(rawValue: String, sourceKind: ReviewDraftSourceKind) {
+        self.rawValue = rawValue
+        self.sourceKind = sourceKind
+    }
+
+    init?(rawValue: String) {
+        let parts = rawValue.split(separator: "\u{1f}", omittingEmptySubsequences: false).map(String.init)
+        guard let first = parts.first,
+              let sourceKind = ReviewDraftSourceKind(rawValue: first)
+        else { return nil }
+        self.rawValue = rawValue
+        self.sourceKind = sourceKind
+    }
+
+    static func localChanges(worktreeID: String, worktreePath: URL, scope: ReviewDraftLocalChangesScope) -> Self {
+        make(.localChanges, [worktreeID, worktreePath.standardizedFileURL.path, scope.rawValue])
+    }
+
+    static func commit(worktreeID: String, repositoryPath: URL, sha: String) -> Self {
+        make(.commit, [worktreeID, repositoryPath.standardizedFileURL.path, sha])
+    }
+
+    static func draftCommit(worktreeID: String, repositoryPath: URL) -> Self {
+        make(.draftCommit, [worktreeID, repositoryPath.standardizedFileURL.path])
+    }
+
+    static func branch(worktreeID: String, repositoryPath: URL, base: String, head: String) -> Self {
+        make(.branch, [worktreeID, repositoryPath.standardizedFileURL.path, base, head])
+    }
+
+    static func reviewRequest(worktreeID: String, provider: CodeHostKind, host: String, repositorySlug: String, number: Int) -> Self {
+        make(.reviewRequest, [worktreeID, provider.rawValue, host.lowercased(), repositorySlug, "\(number)"])
+    }
+
+    static func draftReviewRequest(worktreeID: String, repositoryPath: URL, base: String, head: String) -> Self {
+        make(.draftReviewRequest, [worktreeID, repositoryPath.standardizedFileURL.path, base, head])
+    }
+
+    private static func make(_ kind: ReviewDraftSourceKind, _ fields: [String]) -> Self {
+        let escapedFields = ([kind.rawValue] + fields).map(escape)
+        return ReviewDraftSessionID(rawValue: escapedFields.joined(separator: "\u{1f}"), sourceKind: kind)
+    }
+
+    private static func escape(_ value: String) -> String {
+        value
+            .replacingOccurrences(of: "\\", with: "\\\\")
+            .replacingOccurrences(of: "\u{1f}", with: "\\u001f")
+    }
+}
+
+enum ReviewDraftCommentState: String, Codable, Equatable, Hashable, Sendable {
+    case active
+    case resolved
+    case dismissed
+}
+
+struct ReviewDraftComment: Codable, Equatable, Identifiable, Sendable {
+    var id: String
+    var sessionID: ReviewDraftSessionID
+    var fileID: DiffReviewFileID
+    var path: String
+    var originalPath: String?
+    var side: DiffReviewInlineFeedbackSide
+    var startLine: Int
+    var endLine: Int?
+    var selectedText: String?
+    var bodyMarkdown: String
+    var state: ReviewDraftCommentState
+    var createdAt: Date
+    var updatedAt: Date
+
+    var normalizedLineRange: ClosedRange<Int> {
+        let end = endLine ?? startLine
+        return min(startLine, end)...max(startLine, end)
+    }
+
+    var isActive: Bool { state == .active }
+}
+```
+
+Create `Alas/Sources/Center/ReviewWorkspace/ReviewDraftCommentStore.swift`:
+
+```swift
+import Foundation
+
+struct ReviewDraftCommentStore {
+    private var store: any PersistenceStoreProtocol
+    private var url: URL
+
+    init(store: any PersistenceStoreProtocol = PersistenceStore(), url: URL = Paths.reviewDraftCommentsFile) {
+        self.store = store
+        self.url = url
+    }
+
+    func load(sessionID: ReviewDraftSessionID) throws -> [ReviewDraftComment] {
+        let snapshot = try readSnapshot()
+        return (snapshot.commentsBySessionID[sessionID.rawValue] ?? [])
+            .sorted { lhs, rhs in
+                if lhs.path != rhs.path { return lhs.path.localizedStandardCompare(rhs.path) == .orderedAscending }
+                if lhs.normalizedLineRange.lowerBound != rhs.normalizedLineRange.lowerBound {
+                    return lhs.normalizedLineRange.lowerBound < rhs.normalizedLineRange.lowerBound
+                }
+                return lhs.createdAt < rhs.createdAt
+            }
+    }
+
+    func save(_ comment: ReviewDraftComment) throws {
+        var snapshot = try readSnapshot()
+        var comments = snapshot.commentsBySessionID[comment.sessionID.rawValue] ?? []
+        if let index = comments.firstIndex(where: { $0.id == comment.id }) {
+            comments[index] = comment
+        } else {
+            comments.append(comment)
+        }
+        snapshot.commentsBySessionID[comment.sessionID.rawValue] = comments
+        try store.write(snapshot, to: url)
+    }
+
+    func delete(commentID: String, sessionID: ReviewDraftSessionID) throws {
+        var snapshot = try readSnapshot()
+        var comments = snapshot.commentsBySessionID[sessionID.rawValue] ?? []
+        comments.removeAll { $0.id == commentID }
+        if comments.isEmpty {
+            snapshot.commentsBySessionID.removeValue(forKey: sessionID.rawValue)
+        } else {
+            snapshot.commentsBySessionID[sessionID.rawValue] = comments
+        }
+        try store.write(snapshot, to: url)
+    }
+
+    private func readSnapshot() throws -> Snapshot {
+        try store.readIfExists(Snapshot.self, from: url) ?? Snapshot(commentsBySessionID: [:])
+    }
+
+    private struct Snapshot: Codable, Equatable {
+        var commentsBySessionID: [String: [ReviewDraftComment]]
+    }
+}
+```
+
+Modify `Alas/Sources/Persistence/Paths.swift`:
+
+```swift
+static var reviewDraftCommentsFile: URL {
+    appSupportRoot.appendingPathComponent("review-draft-comments.json")
+}
+```
+
+- [ ] **Step 5: Run tests green**
+
+Run:
+
+```bash
+rtk xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -only-testing:AlasTests/ReviewDraftModelsTests -only-testing:AlasTests/ReviewDraftCommentStoreTests test
+```
+
+Expected: both suites pass.
+
+- [ ] **Step 6: Regenerate project and commit**
+
+Run:
+
+```bash
+xcodegen
+rtk xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -only-testing:AlasTests/ReviewDraftModelsTests -only-testing:AlasTests/ReviewDraftCommentStoreTests test
+git add Alas/Sources/Center/ReviewWorkspace/ReviewDraftModels.swift Alas/Sources/Center/ReviewWorkspace/ReviewDraftCommentStore.swift Alas/Sources/Persistence/Paths.swift AlasTests/ReviewDraftModelsTests.swift AlasTests/ReviewDraftCommentStoreTests.swift Alas.xcodeproj/project.pbxproj
+git commit -m "feat(review): add draft comment store"
+```
+
+Expected: commit contains only Task 1 files and generated project references for the new sources/tests.
+
+---
+
+### Task 2: Feedback Bundle Formatter And Draft Actions
+
+**Files:**
+- Create: `Alas/Sources/Center/ReviewWorkspace/ReviewFeedbackBundle.swift`
+- Create: `Alas/Sources/Center/ReviewWorkspace/ReviewDraftCommentActions.swift`
+- Test: `AlasTests/ReviewFeedbackBundleTests.swift`
+
+- [ ] **Step 1: Write formatter tests**
+
+Add `AlasTests/ReviewFeedbackBundleTests.swift`:
+
+```swift
+import Foundation
+import Testing
+
+@Suite("Review feedback bundle")
+struct ReviewFeedbackBundleTests {
+    @Test func promptGroupsActiveCommentsByFileAndLine() {
+        let session = ReviewDraftSessionID.commit(
+            worktreeID: "wt",
+            repositoryPath: URL(fileURLWithPath: "/repo"),
+            sha: "abc123"
+        )
+        let comments = [
+            draftComment(id: "b", session: session, path: "Sources/B.swift", line: 9, body: "Rename this."),
+            draftComment(id: "a", session: session, path: "Sources/A.swift", line: 2, body: "Extract helper."),
+            draftComment(id: "resolved", session: session, path: "Sources/A.swift", line: 1, body: "Ignore", state: .resolved),
+        ]
+        let bundle = ReviewFeedbackBundle(
+            target: ReviewFeedbackTarget(
+                title: "Review commit abc123",
+                repositoryPath: "/repo",
+                providerDescription: nil,
+                sourceDescription: "commit abc123"
+            ),
+            comments: comments
+        )
+
+        let prompt = bundle.promptMarkdown()
+
+        #expect(prompt.contains("Please address each review comment below."))
+        #expect(prompt.contains("Review target: Review commit abc123"))
+        #expect(prompt.contains("Repository: /repo"))
+        #expect(prompt.contains("Source: commit abc123"))
+        #expect(prompt.contains("## Sources/A.swift"))
+        #expect(prompt.contains("- `Sources/A.swift:2 (new)` — Extract helper."))
+        #expect(prompt.contains("## Sources/B.swift"))
+        #expect(prompt.contains("- `Sources/B.swift:9 (new)` — Rename this."))
+        #expect(!prompt.contains("Ignore"))
+    }
+
+    @Test func promptIncludesLineRangesAndSelectedText() {
+        let session = ReviewDraftSessionID.localChanges(
+            worktreeID: "wt",
+            worktreePath: URL(fileURLWithPath: "/repo"),
+            scope: .all
+        )
+        let comment = ReviewDraftComment(
+            id: "range",
+            sessionID: session,
+            fileID: DiffReviewFileID(namespace: "unstaged", path: "A.swift"),
+            path: "A.swift",
+            originalPath: nil,
+            side: .old,
+            startLine: 4,
+            endLine: 6,
+            selectedText: "old code",
+            bodyMarkdown: "This behavior regressed.",
+            state: .active,
+            createdAt: Date(timeIntervalSince1970: 1),
+            updatedAt: Date(timeIntervalSince1970: 1)
+        )
+        let bundle = ReviewFeedbackBundle(
+            target: ReviewFeedbackTarget(title: "Review changes", repositoryPath: nil, providerDescription: nil, sourceDescription: "local changes"),
+            comments: [comment]
+        )
+
+        let prompt = bundle.promptMarkdown()
+
+        #expect(prompt.contains("`A.swift:4-6 (old)`"))
+        #expect(prompt.contains("> old code"))
+        #expect(prompt.contains("This behavior regressed."))
+    }
+
+    private func draftComment(
+        id: String,
+        session: ReviewDraftSessionID,
+        path: String,
+        line: Int,
+        body: String,
+        state: ReviewDraftCommentState = .active
+    ) -> ReviewDraftComment {
+        ReviewDraftComment(
+            id: id,
+            sessionID: session,
+            fileID: DiffReviewFileID(namespace: "review", path: path),
+            path: path,
+            originalPath: nil,
+            side: .new,
+            startLine: line,
+            endLine: nil,
+            selectedText: nil,
+            bodyMarkdown: body,
+            state: state,
+            createdAt: Date(timeIntervalSince1970: Double(line)),
+            updatedAt: Date(timeIntervalSince1970: Double(line))
+        )
+    }
+}
+```
+
+- [ ] **Step 2: Run tests red**
+
+Run:
+
+```bash
+rtk xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -only-testing:AlasTests/ReviewFeedbackBundleTests test
+```
+
+Expected: fails to compile because `ReviewFeedbackBundle` does not exist.
+
+- [ ] **Step 3: Implement formatter and actions**
+
+Create `Alas/Sources/Center/ReviewWorkspace/ReviewFeedbackBundle.swift`:
+
+```swift
+import Foundation
+
+struct ReviewFeedbackTarget: Equatable, Sendable {
+    let title: String
+    let repositoryPath: String?
+    let providerDescription: String?
+    let sourceDescription: String
+}
+
+struct ReviewFeedbackBundle: Equatable, Sendable {
+    let target: ReviewFeedbackTarget
+    let comments: [ReviewDraftComment]
+
+    var activeComments: [ReviewDraftComment] {
+        comments.filter(\.isActive)
+    }
+
+    func promptMarkdown() -> String {
+        var lines: [String] = [
+            "Please address each review comment below.",
+            "",
+            "Inspect the referenced files and make the smallest safe changes. Explain what changed. Do not publish remote review comments unless explicitly asked.",
+            "",
+            "Review target: \(target.title)",
+            "Source: \(target.sourceDescription)",
+        ]
+        if let repositoryPath = target.repositoryPath {
+            lines.append("Repository: \(repositoryPath)")
+        }
+        if let providerDescription = target.providerDescription {
+            lines.append("Provider: \(providerDescription)")
+        }
+
+        let grouped = Dictionary(grouping: activeComments, by: \.path)
+        for path in grouped.keys.sorted(by: { $0.localizedStandardCompare($1) == .orderedAscending }) {
+            lines.append("")
+            lines.append("## \(path)")
+            let fileComments = (grouped[path] ?? []).sorted(by: sortComments)
+            for comment in fileComments {
+                lines.append("- `\(anchorLabel(comment))` — \(singleLine(comment.bodyMarkdown))")
+                if let selectedText = comment.selectedText?.trimmingCharacters(in: .whitespacesAndNewlines), !selectedText.isEmpty {
+                    for line in selectedText.components(separatedBy: .newlines) {
+                        lines.append("> \(line)")
+                    }
+                }
+            }
+        }
+
+        return lines.joined(separator: "\n")
+    }
+
+    private func sortComments(_ lhs: ReviewDraftComment, _ rhs: ReviewDraftComment) -> Bool {
+        if lhs.normalizedLineRange.lowerBound != rhs.normalizedLineRange.lowerBound {
+            return lhs.normalizedLineRange.lowerBound < rhs.normalizedLineRange.lowerBound
+        }
+        return lhs.createdAt < rhs.createdAt
+    }
+
+    private func anchorLabel(_ comment: ReviewDraftComment) -> String {
+        let range = comment.normalizedLineRange
+        let line = range.lowerBound == range.upperBound
+            ? "\(range.lowerBound)"
+            : "\(range.lowerBound)-\(range.upperBound)"
+        return "\(comment.path):\(line) (\(comment.side.rawValue))"
+    }
+
+    private func singleLine(_ text: String) -> String {
+        text.trimmingCharacters(in: .whitespacesAndNewlines)
+            .components(separatedBy: .newlines)
+            .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+            .filter { !$0.isEmpty }
+            .joined(separator: " ")
+    }
+}
+```
+
+Create `Alas/Sources/Center/ReviewWorkspace/ReviewDraftCommentActions.swift`:
+
+```swift
+import Foundation
+
+struct ReviewDraftCommentActionAvailability: Equatable {
+    var canEdit: Bool
+    var canDelete: Bool
+    var canResolve: Bool
+    var canCopyPrompt: Bool
+    var canSendToAgent: Bool
+
+    static let none = ReviewDraftCommentActionAvailability(
+        canEdit: false,
+        canDelete: false,
+        canResolve: false,
+        canCopyPrompt: false,
+        canSendToAgent: false
+    )
+}
+
+struct ReviewDraftCommentActions {
+    var availability: (ReviewDraftComment) -> ReviewDraftCommentActionAvailability = { _ in .none }
+    var edit: (ReviewDraftComment) -> Void = { _ in }
+    var delete: (ReviewDraftComment) -> Void = { _ in }
+    var resolve: (ReviewDraftComment) -> Void = { _ in }
+    var copyPrompt: (ReviewDraftComment) -> Void = { _ in }
+    var sendToAgent: (ReviewDraftComment) -> Void = { _ in }
+}
+```
+
+- [ ] **Step 4: Run tests green and commit**
+
+Run:
+
+```bash
+xcodegen
+rtk xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -only-testing:AlasTests/ReviewFeedbackBundleTests test
+git add Alas/Sources/Center/ReviewWorkspace/ReviewFeedbackBundle.swift Alas/Sources/Center/ReviewWorkspace/ReviewDraftCommentActions.swift AlasTests/ReviewFeedbackBundleTests.swift Alas.xcodeproj/project.pbxproj
+git commit -m "feat(review): format draft feedback bundles"
+```
+
+Expected: focused formatter tests pass.
+
+---
+
+### Task 3: Exact Diff Row Anchors For Local Draft Comments
+
+**Files:**
+- Modify: `Alas/Sources/Center/Diff/DiffPaneTextDocumentBuilder.swift`
+- Modify: `Alas/Sources/Center/Diff/DiffPaneTextDocumentView.swift`
+- Modify: `Alas/Sources/Center/Diff/DiffPaneView.swift`
+- Test: `AlasTests/DiffPaneViewTests.swift`
+
+- [ ] **Step 1: Add row-anchor and hit-test regression tests**
+
+Extend `AlasTests/DiffPaneViewTests.swift` with tests named:
+
+```swift
+@Test @MainActor func splitTextDocumentExposesSourceLineMetadataForBothSides() throws
+@Test @MainActor func stackedTextDocumentExposesSourceLineMetadataForAddedAndDeletedLines() throws
+@Test @MainActor func rowHitTestingReturnsLocalReviewAnchorForCodePoint() throws
+```
+
+Use the existing hosted `DiffPaneView` helpers in the file. The expected behavior:
+
+```swift
+#expect(oldCodeView.reviewLineAnchor(atRow: 0)?.side == .old)
+#expect(newCodeView.reviewLineAnchor(atRow: 0)?.side == .new)
+#expect(newCodeView.reviewLineAnchor(atRow: 0)?.line == 2)
+#expect(stackedCodeView.reviewLineAnchor(atRow: 1)?.side == .new)
+```
+
+For the hit-test test, obtain a point inside a known row rect and expect:
+
+```swift
+let anchor = try #require(codeView.reviewLineAnchor(at: point))
+#expect(anchor.path == "Sources/App.swift")
+#expect(anchor.line == 2)
+#expect(anchor.side == .new)
+```
+
+- [ ] **Step 2: Run tests red**
+
+Run:
+
+```bash
+rtk xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -only-testing:AlasTests/DiffPaneViewTests test
+```
+
+Expected: fails because the review-anchor accessors do not exist.
+
+- [ ] **Step 3: Implement row anchor exposure**
+
+Add a provider-independent local anchor type in `DiffPaneTextDocumentView.swift` or a small sibling file if the type is reused by SwiftUI:
+
+```swift
+struct DiffReviewLineAnchor: Equatable, Hashable {
+    let path: String
+    let side: DiffReviewInlineFeedbackSide
+    let line: Int
+    let rowIndex: Int
+    let selectedText: String
+}
+```
+
+In `DiffPaneTextDocumentBuilder.LineMetadata`, keep using `sourceLine`. Add helpers that convert metadata into `DiffReviewLineAnchor`:
+
+```swift
+extension DiffPaneTextDocumentBuilder.LineMetadata {
+    func reviewAnchor(rowIndex: Int) -> DiffReviewLineAnchor? {
+        guard let sourceLine, let line = sourceLine.lineNumber else { return nil }
+        let side: DiffReviewInlineFeedbackSide
+        switch sourceLine.anchor.side {
+        case .old: side = .old
+        case .new: side = .new
+        case .paired: side = .unknown
+        }
+        return DiffReviewLineAnchor(
+            path: sourceLine.anchor.filePath,
+            side: side,
+            line: line,
+            rowIndex: rowIndex,
+            selectedText: sourceLine.text
+        )
+    }
+}
+```
+
+Expose testing/internal methods on `DiffPaneCodeTextView`:
+
+```swift
+func reviewLineAnchor(atRow row: Int) -> DiffReviewLineAnchor? {
+    guard row >= 0, row < lineMetadata.count else { return nil }
+    return lineMetadata[row].reviewAnchor(rowIndex: row)
+}
+
+func reviewLineAnchor(at point: NSPoint) -> DiffReviewLineAnchor? {
+    let rows = diffRowRects()
+    guard let index = rows.firstIndex(where: { $0.contains(point) }) else { return nil }
+    return reviewLineAnchor(atRow: index)
+}
+```
+
+Keep these `internal` so tests can use them without public API.
+
+- [ ] **Step 4: Add SwiftUI/AppKit selection callback plumbing**
+
+Add optional callbacks to `DiffPaneTextDocumentView` and `DiffPaneView`:
+
+```swift
+var onReviewLineSelected: (DiffReviewLineAnchor) -> Void = { _ in }
+```
+
+Wire the callback from `DiffPaneTextScrollView` when the user clicks the gutter or a modified-click-supported code row. Do not steal native text selection drags from the code text view. The click target for local review selection is the gutter/line-number area first.
+
+- [ ] **Step 5: Run tests green and commit**
+
+Run:
+
+```bash
+rtk xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -only-testing:AlasTests/DiffPaneViewTests test
+git add Alas/Sources/Center/Diff/DiffPaneTextDocumentBuilder.swift Alas/Sources/Center/Diff/DiffPaneTextDocumentView.swift Alas/Sources/Center/Diff/DiffPaneView.swift AlasTests/DiffPaneViewTests.swift
+git commit -m "feat(diff): expose review line anchors"
+```
+
+Expected: `DiffPaneViewTests` pass and existing text selection behavior remains unchanged.
+
+---
+
+### Task 4: Local Draft Comment Placement And Inline Cards
+
+**Files:**
+- Modify: `Alas/Sources/Center/DiffReview/DiffReviewModels.swift`
+- Modify: `Alas/Sources/Center/DiffReview/DiffReviewFileSection.swift`
+- Modify: `Alas/Sources/Center/DiffReview/DiffReviewSurface.swift`
+- Test: `AlasTests/DiffReviewSurfaceTests.swift`
+
+- [ ] **Step 1: Add display model and placement tests**
+
+Extend `AlasTests/DiffReviewSurfaceTests.swift`:
+
+```swift
+@Test func localDraftCommentsPositionAtExactMatchingRows() {
+    let group = makeDisplayGroupWithChangedLines()
+    let session = ReviewDraftSessionID.localChanges(
+        worktreeID: "wt",
+        worktreePath: URL(fileURLWithPath: "/repo"),
+        scope: .all
+    )
+    let comment = ReviewDraftComment(
+        id: "draft-1",
+        sessionID: session,
+        fileID: DiffReviewFileID(namespace: "unstaged", path: "A.swift"),
+        path: "A.swift",
+        originalPath: nil,
+        side: .new,
+        startLine: 2,
+        endLine: nil,
+        selectedText: "let newValue = 1",
+        bodyMarkdown: "Please rename.",
+        state: .active,
+        createdAt: Date(timeIntervalSince1970: 1),
+        updatedAt: Date(timeIntervalSince1970: 1)
+    )
+
+    let placement = ReviewDraftCommentPlacement.position([comment], in: [group])
+
+    #expect(placement.fileLevel.isEmpty)
+    #expect(placement.byRowAnchor.values.flatMap { $0 }.map(\.id) == ["draft-1"])
+}
+
+@Test func unmatchedLocalDraftCommentsFallBackToFileLevel() {
+    let group = makeDisplayGroupWithChangedLines()
+    let comment = makeDraftComment(path: "A.swift", side: .new, line: 99)
+    let placement = ReviewDraftCommentPlacement.position([comment], in: [group])
+
+    #expect(placement.fileLevel.map(\.id) == [comment.id])
+    #expect(placement.byRowAnchor.isEmpty)
+}
+```
+
+Use existing helper patterns from `DiffReviewSurfaceTests` to create `DiffDisplayGroup`.
+
+- [ ] **Step 2: Run tests red**
+
+Run:
+
+```bash
+rtk xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -only-testing:AlasTests/DiffReviewSurfaceTests test
+```
+
+Expected: fails because `ReviewDraftCommentPlacement` and local draft comment inputs do not exist.
+
+- [ ] **Step 3: Implement local comment display and placement**
+
+Add local comment inputs to `DiffReviewSurface`:
+
+```swift
+var draftCommentsByFileID: [DiffReviewFileID: [ReviewDraftComment]] = [:]
+var focusedDraftCommentID: String? = nil
+var draftCommentActions = ReviewDraftCommentActions()
+var onSelectDraftComment: (ReviewDraftComment) -> Void = { _ in }
+var onAddDraftComment: (DiffReviewLineAnchor) -> Void = { _ in }
+```
+
+Add matching inputs to `DiffReviewFileSection`.
+
+Implement `ReviewDraftCommentPlacement` in `DiffReviewFileSection.swift`:
+
+```swift
+enum ReviewDraftCommentPlacement {
+    struct RowKey: Hashable {
+        let side: DiffReviewInlineFeedbackSide
+        let line: Int
+    }
+
+    struct Result: Equatable {
+        let fileLevel: [ReviewDraftComment]
+        let byRowAnchor: [RowKey: [ReviewDraftComment]]
+    }
+
+    static func position(_ comments: [ReviewDraftComment], in groups: [DiffDisplayGroup]) -> Result {
+        var visibleKeys = Set<RowKey>()
+        for group in groups {
+            for row in group.rows {
+                if let old = row.old, let line = old.lineNumber {
+                    visibleKeys.insert(RowKey(side: .old, line: line))
+                }
+                if let new = row.new, let line = new.lineNumber {
+                    visibleKeys.insert(RowKey(side: .new, line: line))
+                }
+            }
+        }
+
+        var fileLevel: [ReviewDraftComment] = []
+        var byRowAnchor: [RowKey: [ReviewDraftComment]] = [:]
+        for comment in comments where comment.state != .dismissed {
+            let key = RowKey(side: comment.side, line: comment.normalizedLineRange.upperBound)
+            if visibleKeys.contains(key) {
+                byRowAnchor[key, default: []].append(comment)
+            } else {
+                fileLevel.append(comment)
+            }
+        }
+        return Result(fileLevel: fileLevel, byRowAnchor: byRowAnchor)
+    }
+}
+```
+
+Render draft comment cards with a distinct local treatment and buttons for edit/delete/resolve/copy/send. Keep provider cards unchanged.
+
+- [ ] **Step 4: Render composer trigger from line selection**
+
+When `DiffPaneView` emits `onReviewLineSelected`, set a local composer state in `DiffReviewFileSection`:
+
+```swift
+@State private var pendingDraftAnchor: DiffReviewLineAnchor?
+```
+
+Render a compact inline composer at the matching row insertion point:
+
+- markdown text editor
+- Save
+- Cancel
+
+Saving calls `onAddDraftComment(anchor)` through a closure that also receives the body text. Use this signature:
+
+```swift
+var onSaveDraftComment: (DiffReviewLineAnchor, String) -> Void = { _, _ in }
+```
+
+- [ ] **Step 5: Update height estimator**
+
+Update `DiffReviewFileSectionHeightEstimator` so placeholders include local draft comment height:
+
+```swift
+static func estimatedHeight(
+    for file: DiffReviewFileSectionModel,
+    inlineFeedback: [DiffReviewInlineFeedback],
+    draftComments: [ReviewDraftComment]
+) -> CGFloat
+```
+
+Use this from `DiffReviewSurface.fileSection`.
+
+- [ ] **Step 6: Run tests and commit**
+
+Run:
+
+```bash
+rtk xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -only-testing:AlasTests/DiffReviewSurfaceTests test
+git add Alas/Sources/Center/DiffReview/DiffReviewModels.swift Alas/Sources/Center/DiffReview/DiffReviewFileSection.swift Alas/Sources/Center/DiffReview/DiffReviewSurface.swift AlasTests/DiffReviewSurfaceTests.swift
+git commit -m "feat(review): render local draft comments"
+```
+
+Expected: surface tests pass and provider feedback tests remain green.
+
+---
+
+### Task 5: Review Summary Rail And Draft Comment State Controller
+
+**Files:**
+- Create: `Alas/Sources/Center/ReviewWorkspace/ReviewDraftSummaryRail.swift`
+- Create: `Alas/Sources/Center/ReviewWorkspace/ReviewDraftCommentController.swift`
+- Modify: `Alas/Sources/Center/DiffReview/DiffReviewSurface.swift`
+- Test: `AlasTests/DiffReviewSurfaceTests.swift`
+- Test: `AlasTests/ReviewDraftCommentStoreTests.swift`
+
+- [ ] **Step 1: Add controller tests**
+
+Extend `AlasTests/ReviewDraftCommentStoreTests.swift`:
+
+```swift
+@Test @MainActor func controllerAddsEditsDeletesAndResolvesComments() throws {
+    let directory = try #require(FileManager.default.urls(for: .itemReplacementDirectory, in: .userDomainMask).first)
+        .appendingPathComponent(UUID().uuidString, isDirectory: true)
+    let store = ReviewDraftCommentStore(store: PersistenceStore(), url: directory.appendingPathComponent("comments.json"))
+    let session = ReviewDraftSessionID.localChanges(
+        worktreeID: "wt",
+        worktreePath: URL(fileURLWithPath: "/repo"),
+        scope: .all
+    )
+    let controller = ReviewDraftCommentController(sessionID: session, store: store, now: { Date(timeIntervalSince1970: 100) })
+
+    try controller.load()
+    let anchor = DiffReviewLineAnchor(path: "A.swift", side: .new, line: 4, rowIndex: 0, selectedText: "let a = 1")
+    try controller.add(anchor: anchor, fileID: DiffReviewFileID(namespace: "unstaged", path: "A.swift"), bodyMarkdown: "Fix naming.")
+    let added = try #require(controller.comments.single)
+    #expect(added.bodyMarkdown == "Fix naming.")
+
+    try controller.edit(commentID: added.id, bodyMarkdown: "Fix naming and tests.")
+    #expect(controller.comments.single?.bodyMarkdown == "Fix naming and tests.")
+
+    try controller.resolve(commentID: added.id)
+    #expect(controller.comments.single?.state == .resolved)
+
+    try controller.delete(commentID: added.id)
+    #expect(controller.comments.isEmpty)
+}
+```
+
+- [ ] **Step 2: Add summary rail hosted test**
+
+Extend `AlasTests/DiffReviewSurfaceTests.swift`:
+
+```swift
+@Test @MainActor func reviewSurfaceShowsLocalDraftSummaryRailAndScrollsToComment() throws {
+    let comment = makeDraftComment(path: "A.swift", side: .new, line: 2)
+    var selectedCommentID: String?
+    let view = DiffReviewSurface(
+        session: loadedSessionWithOneFile(),
+        selectedFileID: .constant(nil),
+        railCollapsed: .constant(false),
+        layoutMode: .constant(.split),
+        wrapLines: .constant(false),
+        showWhitespace: .constant(false),
+        codeFontFamily: "SF Mono",
+        codeFontSize: 12,
+        draftCommentsByFileID: [comment.fileID: [comment]],
+        onSelectDraftComment: { selectedCommentID = $0.id }
+    )
+
+    let host = try ViewHosting.host(view)
+    let button = try #require(host.findButton(accessibilityIdentifier: "review-draft-summary-comment-\(comment.id)"))
+    button.performClick(nil)
+
+    #expect(selectedCommentID == comment.id)
+}
+```
+
+- [ ] **Step 3: Implement controller**
+
+Create `ReviewDraftCommentController` as an `@MainActor @Observable` reference type:
+
+```swift
+@MainActor
+@Observable
+final class ReviewDraftCommentController {
+    private let sessionID: ReviewDraftSessionID
+    private let store: ReviewDraftCommentStore
+    private let now: () -> Date
+    private(set) var comments: [ReviewDraftComment] = []
+    var errorMessage: String?
+
+    init(
+        sessionID: ReviewDraftSessionID,
+        store: ReviewDraftCommentStore = ReviewDraftCommentStore(),
+        now: @escaping () -> Date = Date.init
+    ) {
+        self.sessionID = sessionID
+        self.store = store
+        self.now = now
+    }
+
+    func load() throws {
+        comments = try store.load(sessionID: sessionID)
+        errorMessage = nil
+    }
+
+    func add(anchor: DiffReviewLineAnchor, fileID: DiffReviewFileID, bodyMarkdown: String) throws {
+        let date = now()
+        let comment = ReviewDraftComment(
+            id: UUID().uuidString,
+            sessionID: sessionID,
+            fileID: fileID,
+            path: anchor.path,
+            originalPath: nil,
+            side: anchor.side,
+            startLine: anchor.line,
+            endLine: nil,
+            selectedText: anchor.selectedText,
+            bodyMarkdown: bodyMarkdown,
+            state: .active,
+            createdAt: date,
+            updatedAt: date
+        )
+        var updated = comments
+        updated.append(comment)
+        try persist(updated)
+    }
+
+    func edit(commentID: String, bodyMarkdown: String) throws {
+        var updated = comments
+        guard let index = updated.firstIndex(where: { $0.id == commentID }) else { return }
+        updated[index].bodyMarkdown = bodyMarkdown
+        updated[index].updatedAt = now()
+        try persist(updated)
+    }
+
+    func resolve(commentID: String) throws {
+        var updated = comments
+        guard let index = updated.firstIndex(where: { $0.id == commentID }) else { return }
+        updated[index].state = .resolved
+        updated[index].updatedAt = now()
+        try persist(updated)
+    }
+
+    func delete(commentID: String) throws {
+        var updated = comments
+        updated.removeAll { $0.id == commentID }
+        try store.delete(commentID: commentID, sessionID: sessionID)
+        comments = updated
+        errorMessage = nil
+    }
+
+    private func persist(_ updated: [ReviewDraftComment]) throws {
+        let previous = comments
+        do {
+            for comment in updated {
+                try store.save(comment)
+            }
+            comments = updated
+            errorMessage = nil
+        } catch {
+            comments = previous
+            errorMessage = error.localizedDescription
+            throw error
+        }
+    }
+}
+```
+
+Every mutating method persists through `ReviewDraftCommentStore`. On error, leave the in-memory mutation applied only when persistence succeeded; otherwise keep the previous `comments` array and set `errorMessage`.
+
+- [ ] **Step 4: Implement right summary rail**
+
+Create `ReviewDraftSummaryRail`:
+
+- width 260 expanded
+- width 44 collapsed
+- active count pill
+- grouped-by-file comment list
+- Edit/Delete/Resolve buttons
+- Copy Prompt and Send Feedback To Agent buttons in the rail header/footer
+
+Use accessibility identifiers:
+
+- `review-draft-summary-rail`
+- `review-draft-summary-comment-<commentID>`
+- `review-draft-summary-copy-prompt`
+- `review-draft-summary-send-agent`
+
+- [ ] **Step 5: Wire rail into `DiffReviewSurface`**
+
+Add inputs:
+
+```swift
+@Binding var reviewSummaryCollapsed: Bool
+var draftCommentsByFileID: [DiffReviewFileID: [ReviewDraftComment]] = [:]
+var focusedDraftCommentID: String? = nil
+var draftCommentActions = ReviewDraftCommentActions()
+var onSelectDraftComment: (ReviewDraftComment) -> Void = { _ in }
+```
+
+Render `ReviewDraftSummaryRail` to the right of `mainReviewStream` when there is a draft session. Keep the existing left file rail unchanged.
+
+- [ ] **Step 6: Run tests and commit**
+
+Run:
+
+```bash
+rtk xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -only-testing:AlasTests/DiffReviewSurfaceTests -only-testing:AlasTests/ReviewDraftCommentStoreTests test
+git add Alas/Sources/Center/ReviewWorkspace/ReviewDraftSummaryRail.swift Alas/Sources/Center/ReviewWorkspace/ReviewDraftCommentController.swift Alas/Sources/Center/DiffReview/DiffReviewSurface.swift AlasTests/DiffReviewSurfaceTests.swift AlasTests/ReviewDraftCommentStoreTests.swift
+git commit -m "feat(review): add draft comment summary rail"
+```
+
+Expected: focused suites pass.
+
+---
+
+### Task 6: Entry Point Integration And Agent Handoff
+
+**Files:**
+- Modify: `Alas/Sources/Center/ReviewChanges/ReviewChangesTabView.swift`
+- Modify: `Alas/Sources/Center/Commit/CommitTabView.swift`
+- Modify: `Alas/Sources/Center/ReviewEvidence/ReviewEvidenceTabView.swift`
+- Modify: `Alas/Sources/Center/ReviewRequest/DraftReviewRequestTabView.swift`
+- Modify: `Alas/Sources/Center/DiffReview/DiffReviewSurface.swift`
+- Test: `AlasTests/ReviewChangesTabViewTests.swift`
+- Test: `AlasTests/CommitTabViewTests.swift`
+- Test: `AlasTests/Integrations/ReviewEvidenceModelTests.swift`
+- Test: `AlasTests/Integrations/ReviewRequestDraftTests.swift`
+
+- [ ] **Step 1: Add session-id helper tests at entry points**
+
+Add tests:
+
+```swift
+@Test func reviewChangesDraftSessionIDUsesWorktreeAndLocalChangesScope()
+@Test func commitReviewDraftSessionIDUsesCommitSHA()
+@Test func reviewEvidenceDraftSessionIDUsesProviderRepositoryAndNumber()
+@Test func draftReviewRequestDraftSessionIDUsesBaseAndHeadBranches()
+```
+
+Each test calls a static helper on the relevant view/model:
+
+```swift
+ReviewChangesTabView.reviewDraftSessionID(worktree: worktree)
+CommitReviewBody.reviewDraftSessionID(worktreeID: "wt", repositoryPath: URL(fileURLWithPath: "/repo"), sha: "abc")
+ReviewEvidenceTabView.reviewDraftSessionID(worktreeID: "wt", provider: .github, host: "github.com", repositorySlug: "mrmans0n/alas", number: 520)
+DraftReviewRequestTabView.reviewDraftSessionID(worktreeID: "wt", repositoryPath: URL(fileURLWithPath: "/repo"), base: "main", head: "feature")
+```
+
+- [ ] **Step 2: Add action wiring tests**
+
+Add focused tests that inject fake `ReviewDraftCommentController` or action closures and verify:
+
+- selecting a draft comment in the summary focuses and scrolls to its inline card
+- Copy Prompt receives `ReviewFeedbackBundle.promptMarkdown()`
+- Send Feedback To Agent receives the same prompt text
+
+Use existing hosted-view and helper patterns from the files listed above. Do not start a real ACP process in tests.
+
+- [ ] **Step 3: Run tests red**
+
+Run:
+
+```bash
+rtk xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -only-testing:AlasTests/ReviewChangesTabViewTests -only-testing:AlasTests/CommitTabViewTests -only-testing:AlasTests/ReviewEvidenceModelTests -only-testing:AlasTests/ReviewRequestDraftTests test
+```
+
+Expected: fails because entry-point helpers and action wiring are missing.
+
+- [ ] **Step 4: Wire draft comment controllers**
+
+In each entry point:
+
+- create a `ReviewDraftSessionID`
+- create a `ReviewDraftCommentController`
+- call `load()` when the diff review session loads or appears
+- pass `draftCommentsByFileID`, focused state, summary collapsed binding, and action closures into `DiffReviewSurface`
+
+Use one helper to group comments by `DiffReviewFileID`:
+
+```swift
+enum ReviewDraftCommentGrouping {
+    static func commentsByFileID(_ comments: [ReviewDraftComment]) -> [DiffReviewFileID: [ReviewDraftComment]] {
+        Dictionary(grouping: comments, by: \.fileID)
+    }
+}
+```
+
+- [ ] **Step 5: Implement Copy Prompt**
+
+Build `ReviewFeedbackBundle` from active controller comments and write to `NSPasteboard.general` through a small injectable closure in production views:
+
+```swift
+private func copyReviewPrompt(_ prompt: String) {
+    NSPasteboard.general.clearContents()
+    NSPasteboard.general.setString(prompt, forType: .string)
+}
+```
+
+Tests call the pure bundle helper and an injected pasteboard closure, not the global pasteboard.
+
+- [ ] **Step 6: Implement Send Feedback To Agent target path**
+
+For this phase, route through a deterministic ACP target model:
+
+```swift
+enum ReviewFeedbackAgentTarget: Equatable, Identifiable {
+    case newChat(agentID: String, title: String)
+    case existingSession(worktreeID: String, sessionID: String, title: String)
+
+    var id: String {
+        switch self {
+        case .newChat(let agentID, _):
+            return "new:\(agentID)"
+        case .existingSession(let worktreeID, let sessionID, _):
+            return "existing:\(worktreeID):\(sessionID)"
+        }
+    }
+
+    var title: String {
+        switch self {
+        case .newChat(_, let title), .existingSession(_, _, let title):
+            return title
+        }
+    }
+}
+
+@MainActor
+struct ReviewFeedbackAgentSender {
+    var availableTargets: () -> [ReviewFeedbackAgentTarget]
+    var send: (String, ReviewFeedbackAgentTarget) -> Void
+}
+```
+
+Production target discovery:
+
+- Include `.newChat(agentID: appState.config.changes.aiToolId, title: "New chat")` when `aiToolId != "none"` and the agent exists.
+- Include `.existingSession(worktreeID:sessionID:title:)` for live ACP sessions in the current worktree when `ACPSessionManager.isWriter(for:)` is true.
+- Hide Send Feedback To Agent when the target list is empty.
+
+Production sending:
+
+- `.newChat` calls `appState.openNewACPSession(agentID:initialPrompt:)`.
+- `.existingSession` calls `ACPSessionManager.sendPrompt(for:text:attachments:onResult:)` with empty attachments.
+- Sending never mutates provider feedback or provider review state.
+
+- [ ] **Step 7: Run focused tests and commit**
+
+Run:
+
+```bash
+rtk xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -only-testing:AlasTests/ReviewChangesTabViewTests -only-testing:AlasTests/CommitTabViewTests -only-testing:AlasTests/ReviewEvidenceModelTests -only-testing:AlasTests/ReviewRequestDraftTests test
+git add Alas/Sources/Center/ReviewChanges/ReviewChangesTabView.swift Alas/Sources/Center/Commit/CommitTabView.swift Alas/Sources/Center/ReviewEvidence/ReviewEvidenceTabView.swift Alas/Sources/Center/ReviewRequest/DraftReviewRequestTabView.swift Alas/Sources/Center/DiffReview/DiffReviewSurface.swift AlasTests/ReviewChangesTabViewTests.swift AlasTests/CommitTabViewTests.swift AlasTests/Integrations/ReviewEvidenceModelTests.swift AlasTests/Integrations/ReviewRequestDraftTests.swift
+git commit -m "feat(review): wire draft feedback workspace"
+```
+
+Expected: entry-point tests pass and no provider feedback behavior regresses.
+
+---
+
+### Task 7: Final Integration Verification
+
+**Files:**
+- No planned production files.
+- Modify tests only if final review finds a missing regression.
+
+- [ ] **Step 1: Run focused review suites**
+
+Run:
+
+```bash
+rtk xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -only-testing:AlasTests/ReviewDraftModelsTests -only-testing:AlasTests/ReviewDraftCommentStoreTests -only-testing:AlasTests/ReviewFeedbackBundleTests -only-testing:AlasTests/DiffPaneViewTests -only-testing:AlasTests/DiffReviewSurfaceTests -only-testing:AlasTests/ReviewChangesTabViewTests -only-testing:AlasTests/CommitTabViewTests -only-testing:AlasTests/ReviewEvidenceModelTests -only-testing:AlasTests/ReviewRequestDraftTests test
+```
+
+Expected: all focused suites pass.
+
+- [ ] **Step 2: Run project generation**
+
+Run:
+
+```bash
+xcodegen
+git status --short
+```
+
+Expected: no project diff. If project files changed because a prior task added source/test files without committing the generated reference, stage and commit the generated project file before final review.
+
+- [ ] **Step 3: Run quiet build**
+
+Run:
+
+```bash
+rtk xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -quiet build
+```
+
+Expected: build exits 0.
+
+- [ ] **Step 4: Run full test suite**
+
+Run:
+
+```bash
+rtk xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' test
+```
+
+Expected: full suite exits 0. If an unrelated known flaky test fails, rerun that exact failing suite once and record the result before deciding whether to fix or report it.
+
+- [ ] **Step 5: Final review**
+
+Dispatch a final code-review subagent over the whole branch. It must check:
+
+- local draft comments never mutate provider state
+- provider feedback actions still work
+- exact local placement is stable in split and stacked modes
+- draft comment persistence cannot leak across worktrees or review targets
+- Send Feedback To Agent / Copy Prompt use the same formatter
+
+Expected: reviewer approves or all findings are fixed before completion.

--- a/docs/superpowers/specs/2026-06-14-local-review-workspace-design.md
+++ b/docs/superpowers/specs/2026-06-14-local-review-workspace-design.md
@@ -1,0 +1,263 @@
+# Local Review Workspace Design
+
+## Context
+
+Alas now has a polished diffs.com-style review surface:
+
+- local multi-file review stacks
+- commit and draft/create-PR diff review stacks
+- PR/MR Files with provider feedback, CI activity, and inline feedback actions
+- shared file rail, scroll sync, split/stacked diffs, rich gutters, and feedback
+  cards
+
+The remaining gap with `ai-review` is the local human-review loop: review any
+diff or commit, write draft comments on exact lines, then hand those comments
+back to an agent/chat to address. The remaining gap with rudu is provider write
+actions for GitHub/GitLab review threads. This phase builds the common local
+review workspace first, so provider mutations can later attach to the same
+review-comment model instead of becoming a separate workflow.
+
+## Goals
+
+- Add a first-class Review Workspace for supported diff sources:
+  - working tree and staged changes
+  - commit and draft commit diffs
+  - PR/MR Files
+  - branch/create-PR draft diffs where a `DiffReviewLoadedSession` already
+    exists
+- Let users add local draft comments on exact old/new lines or line ranges.
+- Render local draft comments at the selected row or range in the diff stack.
+- Support editing, deleting, and locally resolving/dismissing draft comments.
+- Persist draft comments per repo and review target.
+- Add a review summary rail/panel for navigating local draft comments.
+- Add a primary **Send Feedback To Agent** action and a secondary **Copy Prompt**
+  action.
+- Keep provider feedback visible and actionable as it is today.
+
+## Non-Goals
+
+- No posting comments to GitHub/GitLab.
+- No replying to or resolving provider threads.
+- No publishing local draft comments as a provider review.
+- No arbitrary patch-file import.
+- No full historical review browser.
+- No exact row-level placement for provider feedback; provider feedback can keep
+  the current conservative hunk-level placement.
+
+## Product Shape
+
+The Review Workspace is the shared review mode for any diff source Alas can
+already load into `DiffReviewSurface`.
+
+The main layout stays familiar:
+
+- collapsible left file rail
+- central stacked file diff stream
+- session-level split/stacked, wrap, and whitespace controls
+- diffs.com-style gutters, row fills, hunk chrome, and feedback cards
+
+New review controls add a local feedback layer:
+
+- selecting a diff line/range opens an inline comment composer
+- saved comments appear exactly at their selected line/range
+- the review summary lists active local comments grouped by file
+- clicking a summary item scrolls to and focuses the inline comment
+- finishing the review sends or copies a structured feedback prompt
+
+The existing provider feedback cards remain separate from local draft comments
+visually and semantically. They may appear in the same diff stack, but their
+actions differ.
+
+## Data Model
+
+Add a local draft-review model:
+
+- `ReviewDraftSessionID`
+  - stable key for workspace/repo identity
+  - source kind: local changes, staged, commit, range, branch, PR, MR, draft PR
+  - source identifier: commit SHA, branch/ref pair, PR/MR provider identity, or
+    local-change token
+- `ReviewDraftComment`
+  - id
+  - session id
+  - file id/path and optional original path
+  - side: old, new, or unknown
+  - start line and optional end line
+  - selected text snapshot when available
+  - markdown body
+  - created/updated timestamps
+  - local state: active, resolved, dismissed
+- `ReviewDraftCommentStore`
+  - persists comments by session id
+  - loads comments when a review source opens
+  - saves on add/edit/delete/state changes
+- `ReviewFeedbackBundle`
+  - groups active draft comments by file and line
+  - includes review target metadata
+  - formats prompt text for Copy and Send To Agent
+
+Provider feedback continues to use `DiffReviewInlineFeedback`. The review
+surface should get a display abstraction that can render both provider feedback
+and local draft comments without erasing their different action sets.
+
+## Diff Interaction
+
+Local draft comments need exact placement. The AppKit-backed diff body already
+has `DiffDisplayLine` and `DiffLineAnchor` metadata. This phase should expose
+the minimum interaction hooks needed by the review workspace:
+
+- identify the old/new side and line anchor under a click or gutter action
+- support range selection through existing/extended diff selection primitives
+- surface a stable insertion target for local comments in split and stacked
+  layouts
+- render comment accessories at the exact selected row/range
+
+The line/range anchor must survive layout-mode changes because it is based on
+file path, side, and line numbers, not visible row indexes.
+
+For V1, the inline composer can be compact:
+
+- markdown text field/editor
+- Save and Cancel
+- optional selected-range summary
+
+Existing provider feedback placement should not be rewritten in this phase.
+
+## Review Summary
+
+The Review Workspace adds a collapsible right-side review summary rail for local
+draft comments. The left rail remains file navigation. The right rail is review
+state and finish actions. Collapsing the summary rail should leave a narrow
+comment-count/finish-action strip so the review state remains visible while
+reading code.
+
+The summary shows:
+
+- active comment count
+- grouped comments by file
+- line/range and side
+- markdown preview
+- resolved/dismissed status where relevant
+
+Actions:
+
+- click to scroll/focus the inline comment
+- edit
+- delete
+- resolve/dismiss locally
+
+Provider feedback remains in its current PR/MR Feedback evidence area and inline
+cards. This phase should not merge provider feedback into the local summary
+unless it can be done without confusing local-vs-remote state.
+
+## Agent Handoff
+
+The primary finish action is **Send Feedback To Agent**. It uses the same
+formatter as **Copy Prompt** and includes:
+
+- review target metadata
+- repository/worktree path when available
+- provider PR/MR metadata when the source is a provider review
+- file paths
+- old/new line or range anchors
+- selected code snapshots when available
+- markdown comment bodies
+
+The prompt should be direct:
+
+> Please address each review comment below. Inspect the referenced files and
+> make the smallest safe changes. Explain what changed. Do not publish remote
+> review comments unless explicitly asked.
+
+Sending should use existing chat/ACP plumbing through an explicit target
+selection step: list existing eligible chat sessions and a `New Chat` option. If
+there are no eligible existing sessions, `New Chat` is the only target. The
+selected target receives the formatted feedback bundle as the next user message.
+`Copy Prompt` stays available as the manual fallback.
+
+## Provider Boundary
+
+Local draft comments are always local in this phase. Even when the review source
+is a PR/MR, saving a local draft comment must not mutate GitHub/GitLab.
+
+Provider feedback actions remain:
+
+- Open
+- Copy
+- Send to Agent
+
+Local draft comment actions are:
+
+- Edit
+- Delete
+- Resolve/Dismiss locally
+- Copy
+- Send to Agent
+
+Future provider-write phases can add:
+
+- publish local draft comments to GitHub/GitLab review
+- reply to provider threads
+- resolve/unresolve provider threads
+- submit provider review decisions
+
+## Entry Points
+
+Add or reuse entry points for:
+
+- `Review Changes` from local changes
+- `Review Commit` from commit/draft commit views
+- `Review PR/MR Files` from PR/MR Files
+- draft/create-PR branch diff review surface
+
+Each entry point should create a `ReviewDraftSessionID` from its source and load
+the same Review Workspace UI with the correct `DiffReviewLoadedSession`.
+
+## Persistence
+
+Draft comments should survive app restart. Persistence should follow the app’s
+existing settings/state storage conventions rather than provider storage.
+
+Required behavior:
+
+- opening the same review target restores draft comments
+- opening a different commit/branch/PR gets a separate session
+- deleting a comment removes it from persistence
+- resolving/dismissing a comment persists that local state
+
+For local working-tree reviews, the session key should be stable enough to
+survive reloads but scoped to the worktree/repo so comments do not leak between
+repos.
+
+## Error Handling
+
+- If a saved comment no longer maps to a visible line, render it in the file’s
+  fallback feedback area with an “unmatched” treatment.
+- If a file no longer exists in the current review target, keep the comment in
+  the summary under an unmatched/deleted file group.
+- If persistence fails, keep comments in memory and show a non-blocking error.
+- If Send To Agent is unavailable, hide or disable it and keep Copy Prompt
+  available.
+- If provider metadata is missing, generate a local-only prompt.
+
+## Testing
+
+Focused tests should cover:
+
+- `ReviewDraftSessionID` stability for each supported source kind
+- persistence round trip for add/edit/delete/resolve
+- local comment exact placement in split and stacked layouts
+- line-range anchors survive split/stacked mode changes
+- unmatched comments fall back without disappearing
+- review summary groups comments by file and scrolls to focused comments
+- prompt bundle formatting matches ai-review-style grouped feedback
+- Copy Prompt and Send To Agent use the same bundle formatter
+- provider feedback cards and actions remain unchanged
+
+Final verification remains:
+
+```bash
+xcodegen
+xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -quiet build
+xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' test
+```


### PR DESCRIPTION
## Summary
- add local draft review comments across review changes, commits, review evidence, and draft review request surfaces
- add draft comment placement, summary rail, editing, resolve/dismiss/delete, copy prompt, and explicit send-to-agent target selection
- wire local review feedback into the shared diff review surface

## Verification
- `xcodegen`
- `xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -quiet build`
- `xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' test`