### PR TITLE
fix(remote): duplicate session summaries

### DIFF
--- a/Alas/Sources/App/AppState.swift
+++ b/Alas/Sources/App/AppState.swift
@@ -3367,7 +3367,9 @@ extension AppState: RemoteSessionsProvider {
     }
 
     func sessionSummaries() async -> [RemoteSessionSummary] {
-        var out: [RemoteSessionSummary] = []
+        var summariesByIdentity: [String: RemoteSessionSummaryCandidate] = [:]
+        var identities: [String] = []
+
         for mgr in acpManagers.values {
             let worktreeSummary: RemoteWorktreeSummary?
             if let resolved = projectAndWorktree(withWorktreeId: mgr.worktreeId) {
@@ -3377,18 +3379,121 @@ extension AppState: RemoteSessionsProvider {
             }
 
             for row in mgr.sessionRows where !row.archived {
+                let liveSession = mgr.liveSession(for: row.id)
+                var effectiveRow = row
+                if let liveRemoteId = liveSession?.remoteSessionId?.trimmingCharacters(in: .whitespacesAndNewlines),
+                   !liveRemoteId.isEmpty {
+                    effectiveRow.remoteSessionId = liveRemoteId
+                }
                 let state = mgr.runners[row.id]?.session.transcript.streamingState
-                out.append(RemoteSessionSummary(
-                    id: row.id,
-                    title: row.title,
-                    agentId: row.agentId,
+                let candidate = RemoteSessionSummaryCandidate(
+                    row: effectiveRow,
                     status: state.map(RemoteSessionGateway.stateString) ?? "idle",
+                    hasRunner: state != nil,
+                    isLive: liveSession != nil,
                     canDrive: mgr.isWriter(for: row.id),
                     worktree: worktreeSummary
-                ))
+                )
+                let identity = remoteSessionListIdentity(worktreeId: mgr.worktreeId, row: effectiveRow)
+                if let existing = summariesByIdentity[identity] {
+                    summariesByIdentity[identity] = existing.merging(candidate)
+                } else {
+                    identities.append(identity)
+                    summariesByIdentity[identity] = candidate
+                }
             }
         }
-        return out
+        return identities.compactMap { summariesByIdentity[$0]?.summary }
+    }
+
+    private func remoteSessionListIdentity(worktreeId: String, row: ACPSessionRow) -> String {
+        if let remoteSessionId = row.remoteSessionId?.trimmingCharacters(in: .whitespacesAndNewlines),
+           !remoteSessionId.isEmpty {
+            return "\(worktreeId)\u{0}\(row.agentId)\u{0}\(remoteSessionId)"
+        }
+        return "\(worktreeId)\u{0}local:\(row.id)"
+    }
+
+    private struct RemoteSessionSummaryCandidate {
+        var operationalRow: ACPSessionRow
+        var displayRow: ACPSessionRow
+        var status: String
+        var hasRunner: Bool
+        var isLive: Bool
+        var canDrive: Bool
+        let worktree: RemoteWorktreeSummary?
+
+        init(
+            row: ACPSessionRow,
+            status: String,
+            hasRunner: Bool,
+            isLive: Bool,
+            canDrive: Bool,
+            worktree: RemoteWorktreeSummary?
+        ) {
+            self.operationalRow = row
+            self.displayRow = row
+            self.status = status
+            self.hasRunner = hasRunner
+            self.isLive = isLive
+            self.canDrive = canDrive
+            self.worktree = worktree
+        }
+
+        var summary: RemoteSessionSummary {
+            RemoteSessionSummary(
+                id: operationalRow.id,
+                title: displayRow.title,
+                agentId: operationalRow.agentId,
+                status: status,
+                canDrive: canDrive,
+                worktree: worktree
+            )
+        }
+
+        func merging(_ other: RemoteSessionSummaryCandidate) -> RemoteSessionSummaryCandidate {
+            var merged = self
+            if other.isBetterOperationalRow(than: merged) {
+                merged.operationalRow = other.operationalRow
+                merged.status = other.status
+                merged.hasRunner = other.hasRunner
+                merged.isLive = other.isLive
+                merged.canDrive = other.canDrive
+            }
+            if Self.isBetterDisplayRow(other.displayRow, than: merged.displayRow) {
+                merged.displayRow = other.displayRow
+            }
+            return merged
+        }
+
+        private func isBetterOperationalRow(than other: RemoteSessionSummaryCandidate) -> Bool {
+            if canDrive != other.canDrive { return canDrive }
+            if hasRunner != other.hasRunner { return hasRunner }
+            if isLive != other.isLive { return isLive }
+            if operationalRow.lastOpenedAt != other.operationalRow.lastOpenedAt {
+                return operationalRow.lastOpenedAt > other.operationalRow.lastOpenedAt
+            }
+            return operationalRow.updatedAt > other.operationalRow.updatedAt
+        }
+
+        private static func isBetterDisplayRow(_ candidate: ACPSessionRow, than current: ACPSessionRow) -> Bool {
+            let candidateScore = displayTitleScore(candidate)
+            let currentScore = displayTitleScore(current)
+            if candidateScore != currentScore { return candidateScore > currentScore }
+            return candidate.updatedAt > current.updatedAt
+        }
+
+        private static func displayTitleScore(_ row: ACPSessionRow) -> Int {
+            let title = row.title.trimmingCharacters(in: .whitespacesAndNewlines)
+            let meaningfulTitle = !title.isEmpty && title != "New session"
+            let sourceScore: Int
+            switch row.titleSource {
+            case .manual: sourceScore = 3
+            case .generated: sourceScore = 2
+            case .placeholder: sourceScore = 1
+            }
+            return (meaningfulTitle ? 100 : 0) + sourceScore
+        }
     }
 
     func session(for id: String) -> ACPSession? {

--- a/AlasTests/Remote/RemoteAppStateAccessTests.swift
+++ b/AlasTests/Remote/RemoteAppStateAccessTests.swift
@@ -95,6 +95,133 @@ struct RemoteAppStateAccessTests {
         }
     }
 
+    @Test func remoteSessionSummariesCollapseRowsForSameRemoteSession() async throws {
+        var cleanupWorktreeId: String?
+        defer {
+            if let cleanupWorktreeId {
+                cleanupRemoteRenameFiles(worktreeId: cleanupWorktreeId)
+            }
+        }
+
+        let state = makeRemoteRenameState()
+        let worktreeId = try #require(state.selectedWorktreeId)
+        cleanupWorktreeId = worktreeId
+        state.openNewACPSession(agentID: "test-agent")
+        let tab = try #require(acpTabs(in: state).first)
+        let manager = try #require(state.acpManager(forWorktreeId: worktreeId))
+        let session = try #require(manager.placeholderSession(id: tab.sessionId))
+        session.remoteSessionId = "remote-shared"
+        try seedStoredSession(
+            id: tab.sessionId,
+            title: "New session",
+            titleSource: .placeholder,
+            in: manager
+        )
+        try seedStoredSession(
+            id: "historical-copy",
+            title: "Actual Remote Title",
+            titleSource: .manual,
+            remoteSessionId: "remote-shared",
+            in: manager
+        )
+
+        let summaries = await state.sessionSummaries()
+
+        #expect(summaries.count == 1)
+        #expect(summaries.first?.id == tab.sessionId)
+        #expect(summaries.first?.title == "Actual Remote Title")
+    }
+
+    @Test func remoteSessionSummariesPreferLivePlaceholderOverStoredDuplicate() async throws {
+        var cleanupWorktreeId: String?
+        defer {
+            if let cleanupWorktreeId {
+                cleanupRemoteRenameFiles(worktreeId: cleanupWorktreeId)
+            }
+        }
+
+        let state = makeRemoteRenameState()
+        let worktreeId = try #require(state.selectedWorktreeId)
+        cleanupWorktreeId = worktreeId
+        state.openNewACPSession(agentID: "test-agent")
+        let tab = try #require(acpTabs(in: state).first)
+        let manager = try #require(state.acpManager(forWorktreeId: worktreeId))
+        let session = try #require(manager.placeholderSession(id: tab.sessionId))
+        session.remoteSessionId = "remote-shared"
+        let mirrorOwner = try ACPSessionManager(
+            worktreeId: worktreeId,
+            worktreePath: "/tmp/mirror-owner",
+            store: ACPSessionStore(path: Paths.acpSessionsDB(forWorktreeId: worktreeId).path),
+            instanceId: "mirror-owner",
+            pid: Int64(getpid())
+        )
+        _ = try #require(mirrorOwner.placeholderSession(id: tab.sessionId))
+        #expect(mirrorOwner.acquireWriterLease(sessionId: tab.sessionId))
+        #expect(manager.isMirror(sessionId: tab.sessionId))
+        defer {
+            mirrorOwner.releaseWriterLease(sessionId: tab.sessionId)
+        }
+        try seedStoredSession(
+            id: tab.sessionId,
+            title: "New session",
+            titleSource: .placeholder,
+            updatedAt: 1,
+            lastOpenedAt: 1,
+            in: manager
+        )
+        try seedStoredSession(
+            id: "historical-copy",
+            title: "Actual Remote Title",
+            titleSource: .manual,
+            remoteSessionId: "remote-shared",
+            updatedAt: 2,
+            lastOpenedAt: 2,
+            in: manager
+        )
+
+        let summaries = await state.sessionSummaries()
+
+        #expect(summaries.count == 1)
+        #expect(summaries.first?.id == tab.sessionId)
+        #expect(summaries.first?.title == "Actual Remote Title")
+    }
+
+    @Test func remoteSessionSummariesKeepDifferentAgentsWithSameRemoteSessionId() async throws {
+        var cleanupWorktreeId: String?
+        defer {
+            if let cleanupWorktreeId {
+                cleanupRemoteRenameFiles(worktreeId: cleanupWorktreeId)
+            }
+        }
+
+        let state = makeRemoteRenameState()
+        let worktreeId = try #require(state.selectedWorktreeId)
+        cleanupWorktreeId = worktreeId
+        state.openNewACPSession(agentID: "test-agent")
+        let manager = try #require(state.acpManager(forWorktreeId: worktreeId))
+        try seedStoredSession(
+            id: "codex-session",
+            agentId: "codex",
+            title: "Codex Session",
+            titleSource: .manual,
+            remoteSessionId: "remote-shared",
+            in: manager
+        )
+        try seedStoredSession(
+            id: "claude-session",
+            agentId: "claude",
+            title: "Claude Session",
+            titleSource: .manual,
+            remoteSessionId: "remote-shared",
+            in: manager
+        )
+
+        let summaries = await state.sessionSummaries()
+
+        #expect(summaries.map(\.id).contains("codex-session"))
+        #expect(summaries.map(\.id).contains("claude-session"))
+    }
+
     @Test func remoteRenameSessionRejectsEmptyAndUnknownSession() throws {
         var cleanupWorktreeId: String?
         defer {
@@ -328,22 +455,28 @@ struct RemoteAppStateAccessTests {
 
     private func seedStoredSession(
         id: String,
+        agentId: String = "test-agent",
         title: String,
+        titleSource: ACPSessionTitleSource = .placeholder,
+        remoteSessionId: String? = nil,
         archived: Bool = false,
+        updatedAt: Int64? = nil,
+        lastOpenedAt: Int64? = nil,
         in manager: ACPSessionManager
     ) throws {
         let now = Int64(Date().timeIntervalSince1970)
         try manager.store.upsertSession(ACPSessionRow(
             id: id,
-            agentId: "test-agent",
+            agentId: agentId,
             title: title,
-            titleSource: .placeholder,
+            titleSource: titleSource,
+            remoteSessionId: remoteSessionId,
             currentModel: nil,
             currentMode: nil,
             autoRun: false,
             createdAt: now,
-            updatedAt: now,
-            lastOpenedAt: now,
+            updatedAt: updatedAt ?? now,
+            lastOpenedAt: lastOpenedAt ?? now,
             archived: archived
         ))
         manager.refreshRecent()


### PR DESCRIPTION
## Summary
- Collapse remote session summaries that point at the same non-empty backend remote session id.
- Preserve a usable local session id for subscribe/hydrate while showing the best available title.
- Add a regression test for the duplicate placeholder/title case.

## Verification
- `xcodegen`
- `xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -quiet build`
- `xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -only-testing:AlasTests/RemoteAppStateAccessTests test`

Full `xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' test` was also run and failed in an unrelated existing test: `WorkspaceLSPManagerStatusTests.swift:563` (`editorCloseBeforeDidOpenRestoresPendingTemporaryDiffText`).