### PR TITLE
Add in-app review sessions

### DIFF
--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -259,6 +259,7 @@
 		3F0D7932AB67DDF711AF1B6F /* DiffDisplayPreferences.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5C96772DABFBCF15691FFB37 /* DiffDisplayPreferences.swift */; };
 		3F54F0437585F96F5774A3BD /* ACPSetupNudgeBanner.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6791BB640C39115289BF6D07 /* ACPSetupNudgeBanner.swift */; };
 		3FCC4EDA31A96BE121F45D44 /* ACPComposerPlaceholderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 85E54E9F53ECFE9C205788F1 /* ACPComposerPlaceholderTests.swift */; };
+		3FD4E84E222D586F7C6D3946 /* TabsManagerReviewSessionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA9D3F3FFE39D7E29827D83D /* TabsManagerReviewSessionTests.swift */; };
 		3FE3D85D5E833DE3A91FD444 /* CopilotInstaller.swift in Sources */ = {isa = PBXBuildFile; fileRef = D64C0B7363363C77718B446C /* CopilotInstaller.swift */; };
 		40450134EBF5CCD5CD667327 /* ChangeSummaryVisibility.swift in Sources */ = {isa = PBXBuildFile; fileRef = 524926F2D16B1AD83FC234AB /* ChangeSummaryVisibility.swift */; };
 		4058A537B8CAE76FE7EFE184 /* ACPSessionHydrationStateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1DC1B975662D135B148443BC /* ACPSessionHydrationStateTests.swift */; };
@@ -326,6 +327,7 @@
 		4EC9752B397FD7FA89459AC1 /* MergeConflictColumnView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8CAB78A2ED0F4B736B089701 /* MergeConflictColumnView.swift */; };
 		4ECFD27396367A9A81D52A0D /* WorktreeRowView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C995611A6313FABE30508248 /* WorktreeRowView.swift */; };
 		4F2BB7482C39B07F5E35E9D1 /* RemoteMessageWireJSON.swift in Sources */ = {isa = PBXBuildFile; fileRef = EBD68C6A69930BE0F9437AAE /* RemoteMessageWireJSON.swift */; };
+		4FE322C88A2B06C317DDA9B5 /* ReviewSessionTabView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 64C593F9F14DD962C9822C64 /* ReviewSessionTabView.swift */; };
 		5026424BC4EA8196D12E6F46 /* BuildIdentityTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0EE31A4EB90FFE45DC46420 /* BuildIdentityTests.swift */; };
 		502B274A6E7E801B76B8564A /* ACPScrollDirectionClassifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7DE5F609BDA1D7CE2DF4A491 /* ACPScrollDirectionClassifier.swift */; };
 		5031D53ED872A86B7C253696 /* MergeConflictToolbar.swift in Sources */ = {isa = PBXBuildFile; fileRef = 91B5694DB75F80C8D7B51E82 /* MergeConflictToolbar.swift */; };
@@ -340,6 +342,7 @@
 		520F19A37512D2FA0D10EB63 /* ReviewChangesLoader.swift in Sources */ = {isa = PBXBuildFile; fileRef = FC084336F2435440CE1E0AFB /* ReviewChangesLoader.swift */; };
 		523568D4D67F61ACA677EE44 /* SubHeader.swift in Sources */ = {isa = PBXBuildFile; fileRef = DDE8B45ECF898B83A616586D /* SubHeader.swift */; };
 		524B70F03B9A934CEEA5FA61 /* LSPClientTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E7F8F6FBCE1218EAB74B608A /* LSPClientTests.swift */; };
+		5255F92036DF00CB48082526 /* ReviewSessionTabViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4120556B9870D6246D0F30A /* ReviewSessionTabViewTests.swift */; };
 		5269ED23D9732680EF7F4E16 /* ReviewChangesScrollSpy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80694744AA6D7E12FEB38A1A /* ReviewChangesScrollSpy.swift */; };
 		528CB7F6FF36C6809DE532B8 /* RemoteNetwork.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC6FA61556FA530605C9FE81 /* RemoteNetwork.swift */; };
 		52A5CDD852333A0C4BDC6995 /* ACPPermissionRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 67E03BF5DB4E6BFF8C2FA6A2 /* ACPPermissionRequest.swift */; };
@@ -1456,6 +1459,7 @@
 		626DBFF220D347A36859AB17 /* ZmxSessionNameTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ZmxSessionNameTests.swift; sourceTree = "<group>"; };
 		638E94907851A6D0B4AB8F52 /* ImageDiffEndToEndTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageDiffEndToEndTests.swift; sourceTree = "<group>"; };
 		639B69601924624FFE573EBA /* ACPSessionRecoveryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPSessionRecoveryTests.swift; sourceTree = "<group>"; };
+		64C593F9F14DD962C9822C64 /* ReviewSessionTabView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReviewSessionTabView.swift; sourceTree = "<group>"; };
 		64CE9A3DB2C89A5B9C970ED3 /* EnvBuilderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EnvBuilderTests.swift; sourceTree = "<group>"; };
 		64E96E26D5F53F217BFD1F49 /* EditorBuffer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditorBuffer.swift; sourceTree = "<group>"; };
 		650B300A5337E2A9149CF083 /* UnionCanvasGeometry.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UnionCanvasGeometry.swift; sourceTree = "<group>"; };
@@ -1773,6 +1777,7 @@
 		B9830BAAE86AA0A20A77731D /* ProcessMemoryProbeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProcessMemoryProbeTests.swift; sourceTree = "<group>"; };
 		BA59378FB8733DBAC67592A3 /* RemotePairingServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemotePairingServiceTests.swift; sourceTree = "<group>"; };
 		BA6C7434D216D5C43A2FB921 /* ACPFileChip.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPFileChip.swift; sourceTree = "<group>"; };
+		BA9D3F3FFE39D7E29827D83D /* TabsManagerReviewSessionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabsManagerReviewSessionTests.swift; sourceTree = "<group>"; };
 		BAE3E5634CC9BA68765EA539 /* ANSIStream.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ANSIStream.swift; sourceTree = "<group>"; };
 		BB6A90FAE1D410744D02A454 /* CommitPromptEditorWindow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommitPromptEditorWindow.swift; sourceTree = "<group>"; };
 		BBBEFD27FD7013D458435779 /* ACPSession.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPSession.swift; sourceTree = "<group>"; };
@@ -2020,6 +2025,7 @@
 		F332906E17C5865856DBB90B /* ACPSessionRunner.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPSessionRunner.swift; sourceTree = "<group>"; };
 		F3678A2904CBBFAC939C9275 /* SettingsGroup.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsGroup.swift; sourceTree = "<group>"; };
 		F3AB3D6DF4A23648F0C45AC5 /* GitServiceCommitEditingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GitServiceCommitEditingTests.swift; sourceTree = "<group>"; };
+		F4120556B9870D6246D0F30A /* ReviewSessionTabViewTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReviewSessionTabViewTests.swift; sourceTree = "<group>"; };
 		F59AAA1AFFBA04A837BCBA13 /* ACPBareURLLinkifierTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPBareURLLinkifierTests.swift; sourceTree = "<group>"; };
 		F5C6A07D7C67D02C8638D8C1 /* LSPMessages.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LSPMessages.swift; sourceTree = "<group>"; };
 		F61EB45499D244E44EB170BC /* MergeBulkResolvePromptEditorWindow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MergeBulkResolvePromptEditorWindow.swift; sourceTree = "<group>"; };
@@ -2424,6 +2430,7 @@
 				ADC27B340A795F13EA4E0765 /* ReviewSessionLoaderTests.swift */,
 				AB8CA584A5F9F1BDE903E8D2 /* ReviewSessionModelsTests.swift */,
 				F63C0C3F29FDD890239300E5 /* ReviewSessionStoreTests.swift */,
+				F4120556B9870D6246D0F30A /* ReviewSessionTabViewTests.swift */,
 				54635D583B6B308B75ABCE63 /* RightPaneSelectionStateResolverTests.swift */,
 				6713F5A8712C0962BED1EFEA /* RightPaneStateBaseBranchTests.swift */,
 				4973BDD06953B7A1EB9A7A66 /* RightPaneStateDiscardPathsTests.swift */,
@@ -2462,6 +2469,7 @@
 				70377E10CD6D08B225BDFABE /* TabsManagerBufferTests.swift */,
 				75610F1E65DB417E5240D649 /* TabsManagerReviewEvidenceTests.swift */,
 				83A8622BA130E8FA339EDCEB /* TabsManagerReviewRequestDraftTests.swift */,
+				BA9D3F3FFE39D7E29827D83D /* TabsManagerReviewSessionTests.swift */,
 				D6A9977C979705A40595FD5E /* TabsManagerTests.swift */,
 				4A777C0D1DB412458D46A628 /* TerminalCLIInjectionTests.swift */,
 				606DD97D8F66AC2B5883F984 /* TerminalIntegrationActionsTests.swift */,
@@ -3683,6 +3691,7 @@
 				2C17465AF6747EDCD8CCE416 /* ReviewSessionLoader.swift */,
 				2F7E37886988A6F285BEA163 /* ReviewSessionModels.swift */,
 				0704EBDA62931ADE79B04F30 /* ReviewSessionStore.swift */,
+				64C593F9F14DD962C9822C64 /* ReviewSessionTabView.swift */,
 			);
 			path = ReviewWorkspace;
 			sourceTree = "<group>";
@@ -4608,6 +4617,7 @@
 				C10DDFA9216B53E3C9527F8C /* ReviewSessionLoader.swift in Sources */,
 				58B2E8C756F6D3CB08FB3B10 /* ReviewSessionModels.swift in Sources */,
 				5723C73E91B9143B73554042 /* ReviewSessionStore.swift in Sources */,
+				4FE322C88A2B06C317DDA9B5 /* ReviewSessionTabView.swift in Sources */,
 				FBAB18AAEFB289EF765564C5 /* RightPaneSelectionState.swift in Sources */,
 				3C57603EA801D8994B0B5525 /* RightPaneState.swift in Sources */,
 				6D5DF06E64DA191F1EE4B057 /* RightPaneStore.swift in Sources */,
@@ -5066,6 +5076,7 @@
 				E6B5EDEA2C41C783ECA67FD9 /* ReviewSessionLoaderTests.swift in Sources */,
 				60F31F7C4A8A69EDE77363FB /* ReviewSessionModelsTests.swift in Sources */,
 				DECBF7BD8E09E75F70340CF3 /* ReviewSessionStoreTests.swift in Sources */,
+				5255F92036DF00CB48082526 /* ReviewSessionTabViewTests.swift in Sources */,
 				C35CB6B466364169DF2616C3 /* RightPaneSelectionStateResolverTests.swift in Sources */,
 				38EB2BAA50A7B7B37DDE2A4C /* RightPaneStateBaseBranchTests.swift in Sources */,
 				21332BF444F30835C0C70AD6 /* RightPaneStateDiscardPathsTests.swift in Sources */,
@@ -5106,6 +5117,7 @@
 				0563F6A02BFFE6B5013D2190 /* TabsManagerBufferTests.swift in Sources */,
 				CFBCD5E3D345BCA65888E7BB /* TabsManagerReviewEvidenceTests.swift in Sources */,
 				418D526733AA6B50A66CCCAF /* TabsManagerReviewRequestDraftTests.swift in Sources */,
+				3FD4E84E222D586F7C6D3946 /* TabsManagerReviewSessionTests.swift in Sources */,
 				E822ADCC0B35087C38FB01A3 /* TabsManagerTests.swift in Sources */,
 				BEFFE99F341935C249CA4943 /* TerminalCLIInjectionTests.swift in Sources */,
 				CAE149AF78F3A62AC985EA2D /* TerminalIntegrationActionsTests.swift in Sources */,

--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -357,6 +357,7 @@
 		56B6EF95B863B557992AE9DA /* ACPAutoRunToggle.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3EDEEB00185F9C717205540 /* ACPAutoRunToggle.swift */; };
 		5711B2BE2D70220A4BED5B2B /* DefinitionFeature.swift in Sources */ = {isa = PBXBuildFile; fileRef = F12340A649892955245BECB7 /* DefinitionFeature.swift */; };
 		57138814D45D03AE10BE9D67 /* ACPPermissionFSTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2B932ED9D5A485AE1545223C /* ACPPermissionFSTests.swift */; };
+		5723C73E91B9143B73554042 /* ReviewSessionStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0704EBDA62931ADE79B04F30 /* ReviewSessionStore.swift */; };
 		575A4296D86E77D00A1E66A7 /* CommitTabViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB3DAB779A962AC2092A2879 /* CommitTabViewTests.swift */; };
 		57A5A3F4F14E75F6C00A2DC0 /* ACPSessionRunnerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B91E5E766925FD6499548CFC /* ACPSessionRunnerTests.swift */; };
 		57C5E087A453B384485B4EE2 /* ChatFontCatalogTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF72CF0EA2F684D6ED3B43F5 /* ChatFontCatalogTests.swift */; };
@@ -366,6 +367,7 @@
 		5846A180EB68D905E9775401 /* GitService+ReviewLoop.swift in Sources */ = {isa = PBXBuildFile; fileRef = 764489A630CC6D79FCE0A26A /* GitService+ReviewLoop.swift */; };
 		588A1EB3D20EB2419A5A03B4 /* ACPStdioQuestionDispatchTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2015944331CE56AEEF534910 /* ACPStdioQuestionDispatchTests.swift */; };
 		58A58A64E7E10EC5A1CC60C5 /* FileDeviceStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = F18E4AD4B92330FB085C821C /* FileDeviceStore.swift */; };
+		58B2E8C756F6D3CB08FB3B10 /* ReviewSessionModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F7E37886988A6F285BEA163 /* ReviewSessionModels.swift */; };
 		58ED3DFB6576F9B3C473D16C /* ACPNewChatEmptyStateView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7294C0B27241ADEB9A95347A /* ACPNewChatEmptyStateView.swift */; };
 		5936DF2636F0B74BEAB33A57 /* DraftAmendPrefillTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB02326DBD7A82431A33C50F /* DraftAmendPrefillTests.swift */; };
 		59765FD789179C1BDC3F1BB9 /* ChangesTreeBuilderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E7D49EBCE99D6F1690646F80 /* ChangesTreeBuilderTests.swift */; };
@@ -395,6 +397,7 @@
 		603D2F40A0368A139822CE80 /* ACPLaunchCatalogTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B29505F108227C8F43822585 /* ACPLaunchCatalogTests.swift */; };
 		604E881461FC839C4233B0AF /* LSPInstaller.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74D394D40BC9060833DD640A /* LSPInstaller.swift */; };
 		6094D26DB816FAD6FD9BE7F9 /* DiffReviewSurface.swift in Sources */ = {isa = PBXBuildFile; fileRef = AD3B3FF5D7B8F892ED1972A8 /* DiffReviewSurface.swift */; };
+		60F31F7C4A8A69EDE77363FB /* ReviewSessionModelsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB8CA584A5F9F1BDE903E8D2 /* ReviewSessionModelsTests.swift */; };
 		610486A9FA350E77D1BF594B /* ACPTerminalTailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CBFD1CE53DE229626220B457 /* ACPTerminalTailView.swift */; };
 		6117C4AD7519BCD82EA0CF56 /* RightPaneTransitionalView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9C165BAAF80F9B4A5949BD39 /* RightPaneTransitionalView.swift */; };
 		6140E9DE848A53A37DFB8890 /* CodexInstallerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F59C2CF9199EC099B1814AC /* CodexInstallerTests.swift */; };
@@ -909,6 +912,7 @@
 		DEBA25FCF25D26395BD04F73 /* EditorConflictBanner.swift in Sources */ = {isa = PBXBuildFile; fileRef = BFD267BE3F08611B376F3CC7 /* EditorConflictBanner.swift */; };
 		DEBB0627BD0426369D18CAD4 /* FileSearchDialog.swift in Sources */ = {isa = PBXBuildFile; fileRef = F97EB3FA3E3C1206D76A9668 /* FileSearchDialog.swift */; };
 		DEC1744FA9C8A26294FF0671 /* CompletionEngineTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E0CD4F3AC6DD83BC45459475 /* CompletionEngineTests.swift */; };
+		DECBF7BD8E09E75F70340CF3 /* ReviewSessionStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F63C0C3F29FDD890239300E5 /* ReviewSessionStoreTests.swift */; };
 		DF2960A73C07F97DA0A615D4 /* ReviewDraftSummaryRail.swift in Sources */ = {isa = PBXBuildFile; fileRef = C432B6C03738D6ACB4293471 /* ReviewDraftSummaryRail.swift */; };
 		DF8CAD5714483408B8BD72F7 /* GitService+Discard.swift in Sources */ = {isa = PBXBuildFile; fileRef = 90817EC3BAA727EF6D9FBD97 /* GitService+Discard.swift */; };
 		DF93C8550C7A78C2A03CF56A /* ReviewEvidenceModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7FF257B37B6E9EA4D97C67D4 /* ReviewEvidenceModel.swift */; };
@@ -1080,6 +1084,7 @@
 		05C9583C0CA5EDE7D2A1B7DF /* ACPDiffGeneratorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPDiffGeneratorTests.swift; sourceTree = "<group>"; };
 		05EE713DD3CACF29F206553C /* ThemeStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThemeStore.swift; sourceTree = "<group>"; };
 		06375E561569DA36EC289C6F /* JSONRPCNewlineFramer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JSONRPCNewlineFramer.swift; sourceTree = "<group>"; };
+		0704EBDA62931ADE79B04F30 /* ReviewSessionStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReviewSessionStore.swift; sourceTree = "<group>"; };
 		074A17527610230DCFBEA13C /* ACPMockClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPMockClient.swift; sourceTree = "<group>"; };
 		07A17183B064CAB5EB5D5C11 /* ReviewRequestPromptEditorWindow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReviewRequestPromptEditorWindow.swift; sourceTree = "<group>"; };
 		07BC4D03723CEB1B6C2F9D15 /* TabActivityIconTintTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabActivityIconTintTests.swift; sourceTree = "<group>"; };
@@ -1232,6 +1237,7 @@
 		2F1CBD7C9E0119EC1656C1E2 /* GeminiInstallerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GeminiInstallerTests.swift; sourceTree = "<group>"; };
 		2F5959FF98A5105FF7B17894 /* WorkingTreeChangeGroupTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkingTreeChangeGroupTests.swift; sourceTree = "<group>"; };
 		2F59C2CF9199EC099B1814AC /* CodexInstallerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CodexInstallerTests.swift; sourceTree = "<group>"; };
+		2F7E37886988A6F285BEA163 /* ReviewSessionModels.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReviewSessionModels.swift; sourceTree = "<group>"; };
 		2F8A28C3DBC50749BB1D2BEA /* HeadReaderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HeadReaderTests.swift; sourceTree = "<group>"; };
 		2FD28E0005DE3A33A974A511 /* libsqlite3.tbd */ = {isa = PBXFileReference; lastKnownFileType = "sourcecode.text-based-dylib-definition"; name = libsqlite3.tbd; path = usr/lib/libsqlite3.tbd; sourceTree = SDKROOT; };
 		3000211002A1A433AC8DBB3B /* RemoteServerError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteServerError.swift; sourceTree = "<group>"; };
@@ -1705,6 +1711,7 @@
 		AAEDACEB27E6AF219054496E /* DialogChrome.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DialogChrome.swift; sourceTree = "<group>"; };
 		AB3DAB779A962AC2092A2879 /* CommitTabViewTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommitTabViewTests.swift; sourceTree = "<group>"; };
 		AB4C1B7737A289066E01C444 /* WorkspaceLSPManagerStatusTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkspaceLSPManagerStatusTests.swift; sourceTree = "<group>"; };
+		AB8CA584A5F9F1BDE903E8D2 /* ReviewSessionModelsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReviewSessionModelsTests.swift; sourceTree = "<group>"; };
 		AB9D4FBF08CBAB59C08BBF1D /* ACPQuestionRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPQuestionRequest.swift; sourceTree = "<group>"; };
 		ACCA6B39E2B172FADFD9E0E6 /* DiffPaneTextDocumentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiffPaneTextDocumentView.swift; sourceTree = "<group>"; };
 		ACFF914E16884DAC97F11C76 /* SearchEmptyState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchEmptyState.swift; sourceTree = "<group>"; };
@@ -2012,6 +2019,7 @@
 		F59AAA1AFFBA04A837BCBA13 /* ACPBareURLLinkifierTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPBareURLLinkifierTests.swift; sourceTree = "<group>"; };
 		F5C6A07D7C67D02C8638D8C1 /* LSPMessages.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LSPMessages.swift; sourceTree = "<group>"; };
 		F61EB45499D244E44EB170BC /* MergeBulkResolvePromptEditorWindow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MergeBulkResolvePromptEditorWindow.swift; sourceTree = "<group>"; };
+		F63C0C3F29FDD890239300E5 /* ReviewSessionStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReviewSessionStoreTests.swift; sourceTree = "<group>"; };
 		F649B493D42787FEA6D8E67B /* DiffReviewScrollSpyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiffReviewScrollSpyTests.swift; sourceTree = "<group>"; };
 		F6883364648BF4B9F5DA131F /* EditorOverlayPanel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditorOverlayPanel.swift; sourceTree = "<group>"; };
 		F68B06E93430D1C7B02F6BB2 /* ACPAuthNudgeBannerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPAuthNudgeBannerTests.swift; sourceTree = "<group>"; };
@@ -2409,6 +2417,8 @@
 				67378DD93876E3840E367550 /* ReviewDraftModelsTests.swift */,
 				2C84E444E25F7DDBE30FB824 /* ReviewFeedbackBundleTests.swift */,
 				694DDEC8133EFBC33822BC26 /* ReviewLoopHandoffRoutingTests.swift */,
+				AB8CA584A5F9F1BDE903E8D2 /* ReviewSessionModelsTests.swift */,
+				F63C0C3F29FDD890239300E5 /* ReviewSessionStoreTests.swift */,
 				54635D583B6B308B75ABCE63 /* RightPaneSelectionStateResolverTests.swift */,
 				6713F5A8712C0962BED1EFEA /* RightPaneStateBaseBranchTests.swift */,
 				4973BDD06953B7A1EB9A7A66 /* RightPaneStateDiscardPathsTests.swift */,
@@ -3665,6 +3675,8 @@
 				C432B6C03738D6ACB4293471 /* ReviewDraftSummaryRail.swift */,
 				56E964C72322223859CC6AF8 /* ReviewFeedbackAgentSender.swift */,
 				B0886F9B3096AC1264E3D337 /* ReviewFeedbackBundle.swift */,
+				2F7E37886988A6F285BEA163 /* ReviewSessionModels.swift */,
+				0704EBDA62931ADE79B04F30 /* ReviewSessionStore.swift */,
 			);
 			path = ReviewWorkspace;
 			sourceTree = "<group>";
@@ -4587,6 +4599,8 @@
 				F04E4353813EB99D4459750F /* ReviewRequestDiffLoader.swift in Sources */,
 				CDA1193EF673BA40A6548B2B /* ReviewRequestDraft.swift in Sources */,
 				2D80BC255AB24FA274617553 /* ReviewRequestPromptEditorWindow.swift in Sources */,
+				58B2E8C756F6D3CB08FB3B10 /* ReviewSessionModels.swift in Sources */,
+				5723C73E91B9143B73554042 /* ReviewSessionStore.swift in Sources */,
 				FBAB18AAEFB289EF765564C5 /* RightPaneSelectionState.swift in Sources */,
 				3C57603EA801D8994B0B5525 /* RightPaneState.swift in Sources */,
 				6D5DF06E64DA191F1EE4B057 /* RightPaneStore.swift in Sources */,
@@ -5042,6 +5056,8 @@
 				518D1D069F821B232469C414 /* ReviewRequestContextBuilderTests.swift in Sources */,
 				21FBAF70DBD55FF57DAB796D /* ReviewRequestDiffLoaderTests.swift in Sources */,
 				6B9E188A6C0A39C38D8723BF /* ReviewRequestDraftTests.swift in Sources */,
+				60F31F7C4A8A69EDE77363FB /* ReviewSessionModelsTests.swift in Sources */,
+				DECBF7BD8E09E75F70340CF3 /* ReviewSessionStoreTests.swift in Sources */,
 				C35CB6B466364169DF2616C3 /* RightPaneSelectionStateResolverTests.swift in Sources */,
 				38EB2BAA50A7B7B37DDE2A4C /* RightPaneStateBaseBranchTests.swift in Sources */,
 				21332BF444F30835C0C70AD6 /* RightPaneStateDiscardPathsTests.swift in Sources */,
@@ -5498,7 +5514,7 @@
 			repositoryURL = "https://github.com/apple/swift-markdown";
 			requirement = {
 				kind = upToNextMajorVersion;
-				minimumVersion = 0.4.0;
+				minimumVersion = 0.8.0;
 			};
 		};
 		CF72A36467D20A160E653761 /* XCRemoteSwiftPackageReference "swift-tree-sitter" */ = {

--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -780,6 +780,7 @@
 		C04150547C17399FA9D7947C /* ACPComposerShell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 906D92F7AD84F313508D9CFD /* ACPComposerShell.swift */; };
 		C0A78F790FB9B52621D5798A /* ImageDiffSideBySideViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC13E4C0AF55A2524341EB36 /* ImageDiffSideBySideViewTests.swift */; };
 		C10B2726FF5606A3786ED3B4 /* TerminalServiceZmxTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 68B6937D50514C34A2C14BE1 /* TerminalServiceZmxTests.swift */; };
+		C10DDFA9216B53E3C9527F8C /* ReviewSessionLoader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C17465AF6747EDCD8CCE416 /* ReviewSessionLoader.swift */; };
 		C12FCCB35EBD486D20EC65D2 /* ACPTranscriptMarkdown.swift in Sources */ = {isa = PBXBuildFile; fileRef = 04B44F1DD775D2543439D508 /* ACPTranscriptMarkdown.swift */; };
 		C179C5202C4BB8D73E7EB701 /* AppIconTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 620C4A708CD1013DE2736A00 /* AppIconTests.swift */; };
 		C1D83EEBE3AF4ABC04B3F7EB /* GitHubCLIProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5D2DA50E978EB0571D6A74C /* GitHubCLIProvider.swift */; };
@@ -949,6 +950,7 @@
 		E5D32C15B08F30DF3B46CA74 /* DiffReviewScrollSpy.swift in Sources */ = {isa = PBXBuildFile; fileRef = D73C433B373577FD515FECD3 /* DiffReviewScrollSpy.swift */; };
 		E681EB5B83BAC199B1ED5E24 /* WorktreeWatcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2AD81E0DFE33CE4DACF0ADF /* WorktreeWatcher.swift */; };
 		E6A429E3423A9A40A9B36C97 /* RepoSelectorEnvironment.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37C7F4710313BA1671A3AED0 /* RepoSelectorEnvironment.swift */; };
+		E6B5EDEA2C41C783ECA67FD9 /* ReviewSessionLoaderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = ADC27B340A795F13EA4E0765 /* ReviewSessionLoaderTests.swift */; };
 		E6C5CD34C39ECF114DC3D4B4 /* WorktreeRowHeightTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C6C27094E7804D975635EB11 /* WorktreeRowHeightTests.swift */; };
 		E6CB573877637461E11CACAF /* InstallRecipe.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F80EA8C6EFF2C0A8F02C62D /* InstallRecipe.swift */; };
 		E6F317EB2FF5522C77B30B62 /* ACPMarkdownText.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE2AC16E9220C05F670BE3EB /* ACPMarkdownText.swift */; };
@@ -1220,6 +1222,7 @@
 		2B9E3F080F847EF069137844 /* ShortcutBinding.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShortcutBinding.swift; sourceTree = "<group>"; };
 		2BFCE07604D55558B13FC33B /* DiffOpenFileAvailabilityTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiffOpenFileAvailabilityTests.swift; sourceTree = "<group>"; };
 		2BFD4C762D8323B78934ECE7 /* BranchPicker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BranchPicker.swift; sourceTree = "<group>"; };
+		2C17465AF6747EDCD8CCE416 /* ReviewSessionLoader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReviewSessionLoader.swift; sourceTree = "<group>"; };
 		2C2381497E73D74C8C314928 /* AgentRegistryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentRegistryTests.swift; sourceTree = "<group>"; };
 		2C84E444E25F7DDBE30FB824 /* ReviewFeedbackBundleTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReviewFeedbackBundleTests.swift; sourceTree = "<group>"; };
 		2CBAD18141C1A9B654F56982 /* FileTypeIconTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileTypeIconTests.swift; sourceTree = "<group>"; };
@@ -1719,6 +1722,7 @@
 		AD3B3FF5D7B8F892ED1972A8 /* DiffReviewSurface.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiffReviewSurface.swift; sourceTree = "<group>"; };
 		AD85FA11903B85EA889596A3 /* ACPAttachmentMimeTypeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPAttachmentMimeTypeTests.swift; sourceTree = "<group>"; };
 		AD920E9E496F1DC3BB894B8B /* DiffPaneLSPTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiffPaneLSPTests.swift; sourceTree = "<group>"; };
+		ADC27B340A795F13EA4E0765 /* ReviewSessionLoaderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReviewSessionLoaderTests.swift; sourceTree = "<group>"; };
 		AE0A6F237480EE72CB8DBE28 /* TitlelessWindowTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TitlelessWindowTests.swift; sourceTree = "<group>"; };
 		AE35206EEBD7E3A35C3421EA /* ACPRecoveryPill.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPRecoveryPill.swift; sourceTree = "<group>"; };
 		AF2F716F911BB20B3E78C40B /* AgentDefinition.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentDefinition.swift; sourceTree = "<group>"; };
@@ -2417,6 +2421,7 @@
 				67378DD93876E3840E367550 /* ReviewDraftModelsTests.swift */,
 				2C84E444E25F7DDBE30FB824 /* ReviewFeedbackBundleTests.swift */,
 				694DDEC8133EFBC33822BC26 /* ReviewLoopHandoffRoutingTests.swift */,
+				ADC27B340A795F13EA4E0765 /* ReviewSessionLoaderTests.swift */,
 				AB8CA584A5F9F1BDE903E8D2 /* ReviewSessionModelsTests.swift */,
 				F63C0C3F29FDD890239300E5 /* ReviewSessionStoreTests.swift */,
 				54635D583B6B308B75ABCE63 /* RightPaneSelectionStateResolverTests.swift */,
@@ -3675,6 +3680,7 @@
 				C432B6C03738D6ACB4293471 /* ReviewDraftSummaryRail.swift */,
 				56E964C72322223859CC6AF8 /* ReviewFeedbackAgentSender.swift */,
 				B0886F9B3096AC1264E3D337 /* ReviewFeedbackBundle.swift */,
+				2C17465AF6747EDCD8CCE416 /* ReviewSessionLoader.swift */,
 				2F7E37886988A6F285BEA163 /* ReviewSessionModels.swift */,
 				0704EBDA62931ADE79B04F30 /* ReviewSessionStore.swift */,
 			);
@@ -4599,6 +4605,7 @@
 				F04E4353813EB99D4459750F /* ReviewRequestDiffLoader.swift in Sources */,
 				CDA1193EF673BA40A6548B2B /* ReviewRequestDraft.swift in Sources */,
 				2D80BC255AB24FA274617553 /* ReviewRequestPromptEditorWindow.swift in Sources */,
+				C10DDFA9216B53E3C9527F8C /* ReviewSessionLoader.swift in Sources */,
 				58B2E8C756F6D3CB08FB3B10 /* ReviewSessionModels.swift in Sources */,
 				5723C73E91B9143B73554042 /* ReviewSessionStore.swift in Sources */,
 				FBAB18AAEFB289EF765564C5 /* RightPaneSelectionState.swift in Sources */,
@@ -5056,6 +5063,7 @@
 				518D1D069F821B232469C414 /* ReviewRequestContextBuilderTests.swift in Sources */,
 				21FBAF70DBD55FF57DAB796D /* ReviewRequestDiffLoaderTests.swift in Sources */,
 				6B9E188A6C0A39C38D8723BF /* ReviewRequestDraftTests.swift in Sources */,
+				E6B5EDEA2C41C783ECA67FD9 /* ReviewSessionLoaderTests.swift in Sources */,
 				60F31F7C4A8A69EDE77363FB /* ReviewSessionModelsTests.swift in Sources */,
 				DECBF7BD8E09E75F70340CF3 /* ReviewSessionStoreTests.swift in Sources */,
 				C35CB6B466364169DF2616C3 /* RightPaneSelectionStateResolverTests.swift in Sources */,

--- a/Alas/Sources/Center/CenterPaneView.swift
+++ b/Alas/Sources/Center/CenterPaneView.swift
@@ -248,6 +248,13 @@ struct CenterPaneView: View {
                             appState: state
                         )
                         .id(reviewState.id)
+                    case .reviewSession(let reviewSessionState):
+                        ReviewSessionTabView(
+                            worktree: worktree,
+                            tabState: reviewSessionState,
+                            appState: state
+                        )
+                        .id(reviewSessionState.id)
                     case .imagePreview(let s):
                         ImagePreviewTabView(worktreePath: worktree.path,
                                              relativePath: s.relativePath,

--- a/Alas/Sources/Center/Commit/CommitTabView.swift
+++ b/Alas/Sources/Center/Commit/CommitTabView.swift
@@ -30,6 +30,22 @@ struct CommitTabView: View {
         DiffPreferenceBindings(appState: appState)
     }
 
+    static func reviewSessionTarget(
+        worktreeID: String,
+        repositoryPath: URL,
+        sha: String,
+        title: String
+    ) -> ReviewSessionTarget {
+        let trimmedTitle = title.trimmingCharacters(in: .whitespacesAndNewlines)
+        let sessionTitle = trimmedTitle.isEmpty ? "Review \(String(sha.prefix(10)))" : "Review \(trimmedTitle)"
+        return ReviewSessionTarget.commit(
+            worktreeID: worktreeID,
+            repositoryPath: repositoryPath,
+            sha: sha,
+            title: sessionTitle
+        )
+    }
+
     var body: some View {
         VStack(spacing: 0) {
             if let details {
@@ -91,25 +107,29 @@ struct CommitTabView: View {
             .frame(maxWidth: .infinity, maxHeight: .infinity)
         case .loaded:
             if let reviewSession {
-                CommitReviewBody(
-                    session: reviewSession,
-                    selectedFileID: $selectedReviewFileID,
-                    railCollapsed: $railCollapsed,
-                    layoutMode: diffPreferences.layoutMode,
-                    wrapLines: diffPreferences.wrapLines,
-                    showWhitespace: diffPreferences.showWhitespace,
-                    codeFontFamily: appState.config.code.fontFamily,
-                    codeFontSize: CGFloat(appState.config.code.fontSize),
-                    worktreeId: worktreeId,
-                    worktreePath: worktreePath,
-                    reviewDraftSessionID: CommitReviewBody.reviewDraftSessionID(
-                        worktreeID: worktreeId,
-                        repositoryPath: worktreePath,
-                        sha: sha
-                    ),
-                    reviewedCommitSHA: sha,
-                    appState: appState
-                )
+                VStack(spacing: 0) {
+                    commitReviewHeader(details: details)
+                    Divider().overlay(theme.color("line"))
+                    CommitReviewBody(
+                        session: reviewSession,
+                        selectedFileID: $selectedReviewFileID,
+                        railCollapsed: $railCollapsed,
+                        layoutMode: diffPreferences.layoutMode,
+                        wrapLines: diffPreferences.wrapLines,
+                        showWhitespace: diffPreferences.showWhitespace,
+                        codeFontFamily: appState.config.code.fontFamily,
+                        codeFontSize: CGFloat(appState.config.code.fontSize),
+                        worktreeId: worktreeId,
+                        worktreePath: worktreePath,
+                        reviewDraftSessionID: CommitReviewBody.reviewDraftSessionID(
+                            worktreeID: worktreeId,
+                            repositoryPath: worktreePath,
+                            sha: sha
+                        ),
+                        reviewedCommitSHA: sha,
+                        appState: appState
+                    )
+                }
             } else {
                 Spinner()
                     .frame(width: 20, height: 20)
@@ -121,6 +141,31 @@ struct CommitTabView: View {
                 .foregroundColor(theme.color("fg-dim"))
                 .frame(maxWidth: .infinity, maxHeight: .infinity)
         }
+    }
+
+    private func commitReviewHeader(details: CommitDetails) -> some View {
+        HStack(spacing: 8) {
+            Text("Commit review")
+                .font(.system(size: 12, weight: .semibold))
+                .foregroundColor(theme.color("fg"))
+            Text(details.info.shortSha)
+                .font(.system(size: 11, design: .monospaced))
+                .foregroundColor(theme.color("fg-dim"))
+            Spacer()
+            AlasButton(title: "Review This Commit", icon: "doc.text.magnifyingglass") {
+                openReviewSession(
+                    target: Self.reviewSessionTarget(
+                        worktreeID: worktreeId,
+                        repositoryPath: worktreePath,
+                        sha: sha,
+                        title: details.info.subject
+                    )
+                )
+            }
+        }
+        .padding(.horizontal, 14)
+        .padding(.vertical, 8)
+        .background(theme.color("bg-2"))
     }
 
     private func loadDetails() async {
@@ -216,6 +261,16 @@ struct CommitTabView: View {
             }
             .joined(separator: "\u{1e}")
         return "\(sha)\u{0}\(details.info.sha)\u{0}\(details.files.count)\u{0}\(fileKey)"
+    }
+
+    @MainActor
+    private func openReviewSession(target: ReviewSessionTarget) {
+        let store = ReviewSessionStore()
+        let now = Date()
+        let record = (try? store.findActive(targetID: target.id))
+            ?? ReviewSessionRecord(id: target.id, target: target, createdAt: now, updatedAt: now)
+        try? store.save(record)
+        appState.tabs.openOrFocusReviewSession(worktreeId: worktreeId, record: record)
     }
 }
 

--- a/Alas/Sources/Center/Commit/CommitTabView.swift
+++ b/Alas/Sources/Center/Commit/CommitTabView.swift
@@ -21,6 +21,7 @@ struct CommitTabView: View {
     @State private var activeReviewID = UUID()
 
     @State private var headerExpanded: Bool = false
+    @State private var reviewSessionLaunchError: String?
 
     @Environment(\.theme) private var theme
     private let git = GitService()
@@ -152,6 +153,13 @@ struct CommitTabView: View {
                 .font(.system(size: 11, design: .monospaced))
                 .foregroundColor(theme.color("fg-dim"))
             Spacer()
+            if let reviewSessionLaunchError {
+                Text(reviewSessionLaunchError)
+                    .font(.system(size: 11))
+                    .foregroundColor(theme.color("del"))
+                    .lineLimit(1)
+                    .truncationMode(.middle)
+            }
             AlasButton(title: "Review This Commit", icon: "doc.text.magnifyingglass") {
                 openReviewSession(
                     target: Self.reviewSessionTarget(
@@ -266,11 +274,16 @@ struct CommitTabView: View {
     @MainActor
     private func openReviewSession(target: ReviewSessionTarget) {
         let store = ReviewSessionStore()
-        let now = Date()
-        let record = (try? store.findActive(targetID: target.id))
-            ?? ReviewSessionRecord(id: target.id, target: target, createdAt: now, updatedAt: now)
-        try? store.save(record)
-        appState.tabs.openOrFocusReviewSession(worktreeId: worktreeId, record: record)
+        ReviewSessionLauncher.openOrFocus(
+            target: target,
+            findActive: { try store.findActive(targetID: $0) },
+            save: { try store.save($0) },
+            open: {
+                reviewSessionLaunchError = nil
+                appState.tabs.openOrFocusReviewSession(worktreeId: worktreeId, record: $0)
+            },
+            onFailure: { reviewSessionLaunchError = $0.localizedDescription }
+        )
     }
 }
 

--- a/Alas/Sources/Center/ReviewChanges/ReviewChangesTabView.swift
+++ b/Alas/Sources/Center/ReviewChanges/ReviewChangesTabView.swift
@@ -59,6 +59,8 @@ struct ReviewChangesLoadKey {
 }
 
 struct ReviewChangesTabView: View {
+    static let reviewSessionLauncherLabel = "Open review session"
+
     let worktree: Worktree
     let tabState: ReviewChangesTabState
     let appState: AppState
@@ -78,6 +80,7 @@ struct ReviewChangesTabView: View {
     @State private var draftCommentScrollController = DiffReviewDraftCommentScrollController()
     @State private var activeLoadKey: String?
     @State private var activeLoadID = UUID()
+    @State private var reviewSessionLaunchError: String?
 
     var body: some View {
         VStack(spacing: 0) {
@@ -159,9 +162,16 @@ struct ReviewChangesTabView: View {
                     .foregroundColor(theme.color("del"))
             }
             Spacer()
+            if let reviewSessionLaunchError {
+                Text(reviewSessionLaunchError)
+                    .font(.system(size: 11))
+                    .foregroundColor(theme.color("del"))
+                    .lineLimit(1)
+                    .truncationMode(.middle)
+            }
             toolbarButton(
                 systemName: "doc.text.magnifyingglass",
-                tooltip: "Review Changes",
+                tooltip: Self.reviewSessionLauncherLabel,
                 isActive: false
             ) {
                 openReviewSession(
@@ -398,11 +408,16 @@ struct ReviewChangesTabView: View {
     @MainActor
     private func openReviewSession(target: ReviewSessionTarget) {
         let store = ReviewSessionStore()
-        let now = Date()
-        let record = (try? store.findActive(targetID: target.id))
-            ?? ReviewSessionRecord(id: target.id, target: target, createdAt: now, updatedAt: now)
-        try? store.save(record)
-        appState.tabs.openOrFocusReviewSession(worktreeId: worktree.id, record: record)
+        ReviewSessionLauncher.openOrFocus(
+            target: target,
+            findActive: { try store.findActive(targetID: $0) },
+            save: { try store.save($0) },
+            open: {
+                reviewSessionLaunchError = nil
+                appState.tabs.openOrFocusReviewSession(worktreeId: worktree.id, record: $0)
+            },
+            onFailure: { reviewSessionLaunchError = $0.localizedDescription }
+        )
     }
 
     private func loadDraftCommentController() {

--- a/Alas/Sources/Center/ReviewChanges/ReviewChangesTabView.swift
+++ b/Alas/Sources/Center/ReviewChanges/ReviewChangesTabView.swift
@@ -103,6 +103,18 @@ struct ReviewChangesTabView: View {
         )
     }
 
+    static func reviewSessionTarget(
+        worktreeID: String,
+        repositoryPath: URL,
+        scope: ReviewDraftLocalChangesScope
+    ) -> ReviewSessionTarget {
+        ReviewSessionTarget.localChanges(
+            worktreeID: worktreeID,
+            repositoryPath: repositoryPath,
+            scope: scope
+        )
+    }
+
     private var reviewDraftSessionID: ReviewDraftSessionID {
         Self.reviewDraftSessionID(worktree: worktree)
     }
@@ -147,6 +159,19 @@ struct ReviewChangesTabView: View {
                     .foregroundColor(theme.color("del"))
             }
             Spacer()
+            toolbarButton(
+                systemName: "doc.text.magnifyingglass",
+                tooltip: "Review Changes",
+                isActive: false
+            ) {
+                openReviewSession(
+                    target: Self.reviewSessionTarget(
+                        worktreeID: worktree.id,
+                        repositoryPath: worktree.path,
+                        scope: .all
+                    )
+                )
+            }
             layoutSwitcher
             toolbarButton(
                 systemName: diffPreferences.wrapLines.wrappedValue ? "text.justify.left" : "text.alignleft",
@@ -368,6 +393,16 @@ struct ReviewChangesTabView: View {
 
     private var reviewFeedbackAgentSender: ReviewFeedbackAgentSender {
         ReviewFeedbackAgentSender.production(appState: appState, worktreeID: worktree.id)
+    }
+
+    @MainActor
+    private func openReviewSession(target: ReviewSessionTarget) {
+        let store = ReviewSessionStore()
+        let now = Date()
+        let record = (try? store.findActive(targetID: target.id))
+            ?? ReviewSessionRecord(id: target.id, target: target, createdAt: now, updatedAt: now)
+        try? store.save(record)
+        appState.tabs.openOrFocusReviewSession(worktreeId: worktree.id, record: record)
     }
 
     private func loadDraftCommentController() {

--- a/Alas/Sources/Center/ReviewEvidence/ReviewEvidenceTabView.swift
+++ b/Alas/Sources/Center/ReviewEvidence/ReviewEvidenceTabView.swift
@@ -271,15 +271,6 @@ struct ReviewEvidenceTabView: View {
             AlasButton(title: "Refresh", icon: "arrow.clockwise") {
                 refreshEvidence()
             }
-            AlasButton(title: reviewRequestReviewTitle, icon: "doc.text.magnifyingglass") {
-                openReviewSession(
-                    target: Self.reviewSessionTarget(
-                        worktreeID: tabState.worktreeId,
-                        repositoryPath: worktreePath,
-                        tabState: tabState
-                    )
-                )
-            }
             if let url = reviewRequestURL {
                 AlasButton(title: snapshotProvider.openReviewRequestTitle, icon: "arrow.up.right.square") {
                     NSWorkspace.shared.open(url)
@@ -289,15 +280,6 @@ struct ReviewEvidenceTabView: View {
         .padding(.horizontal, 14)
         .padding(.vertical, 10)
         .background(theme.color("bg-1"))
-    }
-
-    private var reviewRequestReviewTitle: String {
-        switch snapshotProvider {
-        case .github:
-            return "Review Pull Request"
-        case .gitlab:
-            return "Review Merge Request"
-        }
     }
 
     @ViewBuilder
@@ -1034,16 +1016,6 @@ struct ReviewEvidenceTabView: View {
 
     private var reviewFeedbackAgentSender: ReviewFeedbackAgentSender {
         ReviewFeedbackAgentSender.production(appState: appState, worktreeID: tabState.worktreeId)
-    }
-
-    @MainActor
-    private func openReviewSession(target: ReviewSessionTarget) {
-        let store = ReviewSessionStore()
-        let now = Date()
-        let record = (try? store.findActive(targetID: target.id))
-            ?? ReviewSessionRecord(id: target.id, target: target, createdAt: now, updatedAt: now)
-        try? store.save(record)
-        appState.tabs.openOrFocusReviewSession(worktreeId: tabState.worktreeId, record: record)
     }
 
     private func loadDraftCommentController() {

--- a/Alas/Sources/Center/ReviewEvidence/ReviewEvidenceTabView.swift
+++ b/Alas/Sources/Center/ReviewEvidence/ReviewEvidenceTabView.swift
@@ -214,6 +214,24 @@ struct ReviewEvidenceTabView: View {
         )
     }
 
+    static func reviewSessionTarget(
+        worktreeID: String,
+        repositoryPath: URL,
+        tabState: ReviewEvidenceTabState
+    ) -> ReviewSessionTarget {
+        ReviewSessionTarget.reviewRequest(
+            worktreeID: worktreeID,
+            repositoryPath: repositoryPath,
+            provider: tabState.provider,
+            host: tabState.url.host ?? "",
+            repositorySlug: tabState.repositorySlug,
+            number: tabState.number,
+            url: tabState.url,
+            title: tabState.title.isEmpty ? "\(tabState.provider.displayName) \(tabState.provider.reviewRequestLabel)" : tabState.title,
+            headSHA: nil
+        )
+    }
+
     private var reviewDraftSessionID: ReviewDraftSessionID {
         Self.reviewDraftSessionID(
             worktreeID: tabState.worktreeId,
@@ -253,6 +271,15 @@ struct ReviewEvidenceTabView: View {
             AlasButton(title: "Refresh", icon: "arrow.clockwise") {
                 refreshEvidence()
             }
+            AlasButton(title: reviewRequestReviewTitle, icon: "doc.text.magnifyingglass") {
+                openReviewSession(
+                    target: Self.reviewSessionTarget(
+                        worktreeID: tabState.worktreeId,
+                        repositoryPath: worktreePath,
+                        tabState: tabState
+                    )
+                )
+            }
             if let url = reviewRequestURL {
                 AlasButton(title: snapshotProvider.openReviewRequestTitle, icon: "arrow.up.right.square") {
                     NSWorkspace.shared.open(url)
@@ -262,6 +289,15 @@ struct ReviewEvidenceTabView: View {
         .padding(.horizontal, 14)
         .padding(.vertical, 10)
         .background(theme.color("bg-1"))
+    }
+
+    private var reviewRequestReviewTitle: String {
+        switch snapshotProvider {
+        case .github:
+            return "Review Pull Request"
+        case .gitlab:
+            return "Review Merge Request"
+        }
     }
 
     @ViewBuilder
@@ -998,6 +1034,16 @@ struct ReviewEvidenceTabView: View {
 
     private var reviewFeedbackAgentSender: ReviewFeedbackAgentSender {
         ReviewFeedbackAgentSender.production(appState: appState, worktreeID: tabState.worktreeId)
+    }
+
+    @MainActor
+    private func openReviewSession(target: ReviewSessionTarget) {
+        let store = ReviewSessionStore()
+        let now = Date()
+        let record = (try? store.findActive(targetID: target.id))
+            ?? ReviewSessionRecord(id: target.id, target: target, createdAt: now, updatedAt: now)
+        try? store.save(record)
+        appState.tabs.openOrFocusReviewSession(worktreeId: tabState.worktreeId, record: record)
     }
 
     private func loadDraftCommentController() {

--- a/Alas/Sources/Center/ReviewRequest/DraftReviewRequestTabView.swift
+++ b/Alas/Sources/Center/ReviewRequest/DraftReviewRequestTabView.swift
@@ -132,6 +132,10 @@ struct DraftReviewRequestTabView: View {
         )
     }
 
+    static func canLaunchReviewSession(targetMismatchMessage: String?) -> Bool {
+        targetMismatchMessage == nil
+    }
+
     private var reviewDraftSessionID: ReviewDraftSessionID {
         Self.reviewDraftSessionID(
             worktreeID: worktreeId,
@@ -386,6 +390,10 @@ struct DraftReviewRequestTabView: View {
                     .truncationMode(.middle)
             }
             AlasButton(title: "Review Branch Diff", icon: "doc.text.magnifyingglass") {
+                if let targetMismatchMessage {
+                    reviewSessionLaunchError = targetMismatchMessage
+                    return
+                }
                 openReviewSession(
                     target: Self.reviewSessionTarget(
                         worktreeID: worktreeId,
@@ -394,6 +402,7 @@ struct DraftReviewRequestTabView: View {
                     )
                 )
             }
+            .disabled(!Self.canLaunchReviewSession(targetMismatchMessage: targetMismatchMessage))
         }
         .padding(.horizontal, 14)
         .padding(.vertical, 8)

--- a/Alas/Sources/Center/ReviewRequest/DraftReviewRequestTabView.swift
+++ b/Alas/Sources/Center/ReviewRequest/DraftReviewRequestTabView.swift
@@ -115,6 +115,22 @@ struct DraftReviewRequestTabView: View {
         )
     }
 
+    static func reviewSessionTarget(
+        worktreeID: String,
+        repositoryPath: URL,
+        tabState: DraftReviewRequestTabState
+    ) -> ReviewSessionTarget {
+        ReviewSessionTarget.draftReviewRequest(
+            worktreeID: worktreeID,
+            repositoryPath: repositoryPath,
+            provider: tabState.provider,
+            repositorySlug: tabState.repositorySlug,
+            base: tabState.baseBranch,
+            head: tabState.branchName,
+            headSHA: tabState.headSHA
+        )
+    }
+
     private var reviewDraftSessionID: ReviewDraftSessionID {
         Self.reviewDraftSessionID(
             worktreeID: worktreeId,
@@ -361,6 +377,15 @@ struct DraftReviewRequestTabView: View {
                 }
             }
             Spacer()
+            AlasButton(title: "Review Branch Diff", icon: "doc.text.magnifyingglass") {
+                openReviewSession(
+                    target: Self.reviewSessionTarget(
+                        worktreeID: worktreeId,
+                        repositoryPath: worktreePath,
+                        tabState: tabState
+                    )
+                )
+            }
         }
         .padding(.horizontal, 14)
         .padding(.vertical, 8)
@@ -724,6 +749,16 @@ struct DraftReviewRequestTabView: View {
 
     private var reviewFeedbackAgentSender: ReviewFeedbackAgentSender {
         ReviewFeedbackAgentSender.production(appState: appState, worktreeID: worktreeId)
+    }
+
+    @MainActor
+    private func openReviewSession(target: ReviewSessionTarget) {
+        let store = ReviewSessionStore()
+        let now = Date()
+        let record = (try? store.findActive(targetID: target.id))
+            ?? ReviewSessionRecord(id: target.id, target: target, createdAt: now, updatedAt: now)
+        try? store.save(record)
+        appState.tabs.openOrFocusReviewSession(worktreeId: worktreeId, record: record)
     }
 
     private func loadDraftCommentController() {

--- a/Alas/Sources/Center/ReviewRequest/DraftReviewRequestTabView.swift
+++ b/Alas/Sources/Center/ReviewRequest/DraftReviewRequestTabView.swift
@@ -27,6 +27,7 @@ struct DraftReviewRequestTabView: View {
     @State private var draftCommentScrollCommand: DiffReviewDraftCommentScrollCommand?
     @State private var draftCommentScrollController = DiffReviewDraftCommentScrollController()
     @State private var generation: Task<Void, Never>? = nil
+    @State private var reviewSessionLaunchError: String?
 
     @Environment(\.theme) private var theme
     @FocusState private var focused: Field?
@@ -377,6 +378,13 @@ struct DraftReviewRequestTabView: View {
                 }
             }
             Spacer()
+            if let reviewSessionLaunchError {
+                Text(reviewSessionLaunchError)
+                    .font(.system(size: 11))
+                    .foregroundColor(theme.color("del"))
+                    .lineLimit(1)
+                    .truncationMode(.middle)
+            }
             AlasButton(title: "Review Branch Diff", icon: "doc.text.magnifyingglass") {
                 openReviewSession(
                     target: Self.reviewSessionTarget(
@@ -754,11 +762,16 @@ struct DraftReviewRequestTabView: View {
     @MainActor
     private func openReviewSession(target: ReviewSessionTarget) {
         let store = ReviewSessionStore()
-        let now = Date()
-        let record = (try? store.findActive(targetID: target.id))
-            ?? ReviewSessionRecord(id: target.id, target: target, createdAt: now, updatedAt: now)
-        try? store.save(record)
-        appState.tabs.openOrFocusReviewSession(worktreeId: worktreeId, record: record)
+        ReviewSessionLauncher.openOrFocus(
+            target: target,
+            findActive: { try store.findActive(targetID: $0) },
+            save: { try store.save($0) },
+            open: {
+                reviewSessionLaunchError = nil
+                appState.tabs.openOrFocusReviewSession(worktreeId: worktreeId, record: $0)
+            },
+            onFailure: { reviewSessionLaunchError = $0.localizedDescription }
+        )
     }
 
     private func loadDraftCommentController() {

--- a/Alas/Sources/Center/ReviewWorkspace/ReviewDraftSummaryRail.swift
+++ b/Alas/Sources/Center/ReviewWorkspace/ReviewDraftSummaryRail.swift
@@ -1,6 +1,43 @@
 import AppKit
 import SwiftUI
 
+struct ReviewDraftSummaryRailStatus: Equatable {
+    var handoffs: [ReviewFeedbackHandoff] = []
+    var lastSendError: String?
+
+    init(handoffs: [ReviewFeedbackHandoff] = [], lastSendError: String? = nil) {
+        self.handoffs = handoffs
+        self.lastSendError = lastSendError
+    }
+
+    init(record: ReviewSessionRecord?) {
+        self.handoffs = record?.handoffs ?? []
+        self.lastSendError = record?.lastSendError
+    }
+
+    var latestHandoff: ReviewFeedbackHandoff? {
+        handoffs.max { lhs, rhs in lhs.createdAt < rhs.createdAt }
+    }
+
+    var visibleSendError: String? {
+        guard let lastSendError,
+              !lastSendError.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+        else { return nil }
+        return lastSendError
+    }
+}
+
+private struct ReviewDraftSummaryRailStatusKey: EnvironmentKey {
+    static let defaultValue = ReviewDraftSummaryRailStatus()
+}
+
+extension EnvironmentValues {
+    var reviewDraftSummaryRailStatus: ReviewDraftSummaryRailStatus {
+        get { self[ReviewDraftSummaryRailStatusKey.self] }
+        set { self[ReviewDraftSummaryRailStatusKey.self] = newValue }
+    }
+}
+
 struct ReviewDraftSummaryRail: View {
     let comments: [ReviewDraftComment]
     let bundle: ReviewFeedbackBundle
@@ -10,6 +47,7 @@ struct ReviewDraftSummaryRail: View {
     var onSelectDraftComment: (ReviewDraftComment) -> Void = { _ in }
 
     @Environment(\.theme) private var theme
+    @Environment(\.reviewDraftSummaryRailStatus) private var sendStatus
     @State private var editingCommentID: String?
     @State private var editingBody = ""
 
@@ -146,6 +184,8 @@ struct ReviewDraftSummaryRail: View {
 
                 Spacer(minLength: 0)
             }
+
+            sendStateView
         }
         .padding(.horizontal, 12)
         .padding(.vertical, 10)
@@ -178,6 +218,45 @@ struct ReviewDraftSummaryRail: View {
             .background((activeCount > 0 ? theme.color("warn") : theme.color("fg-muted")).opacity(0.15))
             .clipShape(RoundedRectangle(cornerRadius: compact ? 6 : 5))
             .accessibilityLabel("\(activeCount) active draft comments")
+    }
+
+    @ViewBuilder
+    private var sendStateView: some View {
+        if let error = sendStatus.visibleSendError {
+            Text(error)
+                .font(.system(size: 10.5))
+                .foregroundColor(theme.color("del").opacity(0.75))
+                .lineLimit(2)
+                .fixedSize(horizontal: false, vertical: true)
+                .accessibilityIdentifier("review-draft-summary-send-error")
+                .background(
+                    DiffReviewAccessibilityMarker(
+                        identifier: "review-draft-summary-send-error",
+                        label: error
+                    )
+                )
+        } else if let latestHandoff = sendStatus.latestHandoff {
+            HStack(spacing: 5) {
+                Image(systemName: "checkmark.circle")
+                    .font(.system(size: 10.5, weight: .medium))
+                    .foregroundColor(theme.color("add"))
+                Text("Sent to agent")
+                    .font(.system(size: 10.5, weight: .medium))
+                    .foregroundColor(theme.color("fg-muted"))
+                Text(latestHandoff.createdAt, style: .time)
+                    .font(.system(size: 10.5))
+                    .foregroundColor(theme.color("fg-faint"))
+            }
+            .lineLimit(1)
+            .accessibilityIdentifier("review-draft-summary-send-state")
+            .accessibilityLabel("Sent to agent")
+            .background(
+                DiffReviewAccessibilityMarker(
+                    identifier: "review-draft-summary-send-state",
+                    label: "Sent to agent"
+                )
+            )
+        }
     }
 
     private func collapsedActionButton(

--- a/Alas/Sources/Center/ReviewWorkspace/ReviewFeedbackAgentSender.swift
+++ b/Alas/Sources/Center/ReviewWorkspace/ReviewFeedbackAgentSender.swift
@@ -82,7 +82,41 @@ enum ReviewFeedbackPromptActions {
         target: ReviewFeedbackAgentTarget,
         sender: ReviewFeedbackAgentSender
     ) {
-        sender.send(bundle.promptMarkdown(), target)
+        sendToAgent(
+            bundle,
+            target: target,
+            sender: sender,
+            sessionID: nil,
+            recordHandoff: nil
+        )
+    }
+
+    @MainActor
+    static func sendToAgent(
+        _ bundle: ReviewFeedbackBundle,
+        target: ReviewFeedbackAgentTarget,
+        sender: ReviewFeedbackAgentSender,
+        sessionID: ReviewSessionID?,
+        recordHandoff: ((ReviewFeedbackHandoff) -> Void)?,
+        now: () -> Date = Date.init,
+        makeID: () -> String = { UUID().uuidString }
+    ) {
+        let prompt = bundle.promptMarkdown()
+        sender.send(prompt, target)
+
+        guard let sessionID, let recordHandoff else { return }
+        let commentIDs = bundle.activeComments.map(\.id).sorted()
+        recordHandoff(
+            ReviewFeedbackHandoff(
+                id: makeID(),
+                sessionID: sessionID,
+                commentIDs: commentIDs,
+                target: target,
+                createdAt: now(),
+                promptRevision: ReviewFeedbackHandoff.revisionKey(commentIDs: commentIDs, prompt: prompt),
+                status: .sent
+            )
+        )
     }
 
     private static func copyReviewPrompt(_ prompt: String) {
@@ -97,6 +131,8 @@ enum ReviewDraftWorkspaceActions {
     static func make(
         controller: ReviewDraftCommentController?,
         sender: ReviewFeedbackAgentSender,
+        sessionID: ReviewSessionID? = nil,
+        recordHandoff: ((ReviewFeedbackHandoff) -> Void)? = nil,
         pasteboard: @escaping (String) -> Void = { prompt in
             let pasteboard = NSPasteboard.general
             pasteboard.clearContents()
@@ -135,7 +171,13 @@ enum ReviewDraftWorkspaceActions {
                 sender.availableTargets()
             },
             sendToAgent: { bundle, target in
-                ReviewFeedbackPromptActions.sendToAgent(bundle, target: target, sender: sender)
+                ReviewFeedbackPromptActions.sendToAgent(
+                    bundle,
+                    target: target,
+                    sender: sender,
+                    sessionID: sessionID,
+                    recordHandoff: recordHandoff
+                )
             }
         )
     }

--- a/Alas/Sources/Center/ReviewWorkspace/ReviewFeedbackAgentSender.swift
+++ b/Alas/Sources/Center/ReviewWorkspace/ReviewFeedbackAgentSender.swift
@@ -7,7 +7,7 @@ enum ReviewDraftCommentGrouping {
     }
 }
 
-enum ReviewFeedbackAgentTarget: Equatable, Identifiable {
+enum ReviewFeedbackAgentTarget: Codable, Equatable, Hashable, Identifiable, Sendable {
     case newChat(agentID: String, title: String)
     case existingSession(worktreeID: String, sessionID: String, title: String)
 

--- a/Alas/Sources/Center/ReviewWorkspace/ReviewFeedbackAgentSender.swift
+++ b/Alas/Sources/Center/ReviewWorkspace/ReviewFeedbackAgentSender.swift
@@ -31,7 +31,7 @@ enum ReviewFeedbackAgentTarget: Codable, Equatable, Hashable, Identifiable, Send
 @MainActor
 struct ReviewFeedbackAgentSender {
     var availableTargets: () -> [ReviewFeedbackAgentTarget]
-    var send: (String, ReviewFeedbackAgentTarget) -> Void
+    var send: (String, ReviewFeedbackAgentTarget, @escaping @MainActor (Result<Void, Error>) -> Void) -> Void
 
     static func production(appState: AppState, worktreeID: String) -> ReviewFeedbackAgentSender {
         ReviewFeedbackAgentSender(
@@ -56,15 +56,29 @@ struct ReviewFeedbackAgentSender {
                 targets.append(contentsOf: sessionTargets)
                 return targets
             },
-            send: { prompt, target in
+            send: { prompt, target, completion in
                 switch target {
                 case .newChat(let agentID, _):
                     appState.openNewACPSession(agentID: agentID, initialPrompt: prompt)
+                    completion(.success(()))
                 case .existingSession(_, let sessionID, _):
-                    appState.sendPrompt(for: sessionID, text: prompt, attachments: []) { _ in }
+                    appState.sendPrompt(for: sessionID, text: prompt, attachments: []) { accepted in
+                        completion(accepted ? .success(()) : .failure(ReviewFeedbackAgentSendError.rejected))
+                    }
                 }
             }
         )
+    }
+}
+
+enum ReviewFeedbackAgentSendError: LocalizedError, Equatable {
+    case rejected
+
+    var errorDescription: String? {
+        switch self {
+        case .rejected:
+            "Agent rejected the prompt."
+        }
     }
 }
 
@@ -98,25 +112,31 @@ enum ReviewFeedbackPromptActions {
         sender: ReviewFeedbackAgentSender,
         sessionID: ReviewSessionID?,
         recordHandoff: ((ReviewFeedbackHandoff) -> Void)?,
-        now: () -> Date = Date.init,
-        makeID: () -> String = { UUID().uuidString }
+        recordSendFailure: ((Error) -> Void)? = nil,
+        now: @escaping () -> Date = Date.init,
+        makeID: @escaping () -> String = { UUID().uuidString }
     ) {
         let prompt = bundle.promptMarkdown()
-        sender.send(prompt, target)
-
-        guard let sessionID, let recordHandoff else { return }
-        let commentIDs = bundle.activeComments.map(\.id).sorted()
-        recordHandoff(
-            ReviewFeedbackHandoff(
-                id: makeID(),
-                sessionID: sessionID,
-                commentIDs: commentIDs,
-                target: target,
-                createdAt: now(),
-                promptRevision: ReviewFeedbackHandoff.revisionKey(commentIDs: commentIDs, prompt: prompt),
-                status: .sent
-            )
-        )
+        sender.send(prompt, target) { result in
+            switch result {
+            case .success:
+                guard let sessionID, let recordHandoff else { return }
+                let commentIDs = bundle.activeComments.map(\.id).sorted()
+                recordHandoff(
+                    ReviewFeedbackHandoff(
+                        id: makeID(),
+                        sessionID: sessionID,
+                        commentIDs: commentIDs,
+                        target: target,
+                        createdAt: now(),
+                        promptRevision: ReviewFeedbackHandoff.revisionKey(commentIDs: commentIDs, prompt: prompt),
+                        status: .sent
+                    )
+                )
+            case .failure(let error):
+                recordSendFailure?(error)
+            }
+        }
     }
 
     private static func copyReviewPrompt(_ prompt: String) {
@@ -133,6 +153,7 @@ enum ReviewDraftWorkspaceActions {
         sender: ReviewFeedbackAgentSender,
         sessionID: ReviewSessionID? = nil,
         recordHandoff: ((ReviewFeedbackHandoff) -> Void)? = nil,
+        recordSendFailure: ((Error) -> Void)? = nil,
         pasteboard: @escaping (String) -> Void = { prompt in
             let pasteboard = NSPasteboard.general
             pasteboard.clearContents()
@@ -176,7 +197,8 @@ enum ReviewDraftWorkspaceActions {
                     target: target,
                     sender: sender,
                     sessionID: sessionID,
-                    recordHandoff: recordHandoff
+                    recordHandoff: recordHandoff,
+                    recordSendFailure: recordSendFailure
                 )
             }
         )

--- a/Alas/Sources/Center/ReviewWorkspace/ReviewFeedbackBundle.swift
+++ b/Alas/Sources/Center/ReviewWorkspace/ReviewFeedbackBundle.swift
@@ -5,6 +5,9 @@ struct ReviewFeedbackTarget: Equatable, Sendable {
     var repositoryPath: String?
     var providerDescription: String?
     var sourceDescription: String
+    var sessionDescription: String? = nil
+    var revisionDescription: String? = nil
+    var priorHandoffDescription: String? = nil
 }
 
 struct ReviewFeedbackBundle: Equatable, Sendable {
@@ -29,6 +32,18 @@ struct ReviewFeedbackBundle: Equatable, Sendable {
         }
 
         lines.append("Source: \(target.sourceDescription)")
+
+        if let sessionDescription = target.sessionDescription, !sessionDescription.isEmpty {
+            lines.append(sessionDescription)
+        }
+
+        if let revisionDescription = target.revisionDescription, !revisionDescription.isEmpty {
+            lines.append("Revision: \(revisionDescription)")
+        }
+
+        if let priorHandoffDescription = target.priorHandoffDescription, !priorHandoffDescription.isEmpty {
+            lines.append(priorHandoffDescription)
+        }
 
         if let providerDescription = target.providerDescription, !providerDescription.isEmpty {
             lines.append("Provider: \(providerDescription)")

--- a/Alas/Sources/Center/ReviewWorkspace/ReviewSessionLoader.swift
+++ b/Alas/Sources/Center/ReviewWorkspace/ReviewSessionLoader.swift
@@ -32,6 +32,26 @@ struct ReviewSessionLoader {
         self.draftReviewRequest = draftReviewRequest
     }
 
+    @MainActor
+    static func production(appState: AppState, worktree: Worktree) -> ReviewSessionLoader {
+        _ = appState
+        let changesLoader = ReviewChangesLoader()
+
+        return ReviewSessionLoader(
+            localChanges: { target in
+                let session = try await changesLoader.load(worktreePath: worktree.path)
+                guard case .localChanges(let scope) = target.payload else {
+                    throw ReviewSessionLoaderError.unsupportedTarget
+                }
+                return filterLocalChanges(session, scope: scope)
+            },
+            draftCommit: { _ in
+                let session = try await changesLoader.load(worktreePath: worktree.path)
+                return filterLocalChanges(session, scope: .staged)
+            }
+        )
+    }
+
     func load(target: ReviewSessionTarget) async throws -> ReviewSessionLoadedContext {
         try Task.checkCancellation()
 
@@ -66,6 +86,25 @@ struct ReviewSessionLoader {
                 revisionDescription: target.revisionDescription,
                 priorHandoffDescription: nil
             )
+        )
+    }
+
+    private static func filterLocalChanges(
+        _ session: DiffReviewLoadedSession,
+        scope: ReviewDraftLocalChangesScope
+    ) -> DiffReviewLoadedSession {
+        let files: [DiffReviewFileSectionModel]
+        switch scope {
+        case .all:
+            files = session.files
+        case .unstaged:
+            files = session.files.filter { $0.summary.namespace == ReviewChangesSource.unstaged.rawValue }
+        case .staged:
+            files = session.files.filter { $0.summary.namespace == ReviewChangesSource.staged.rawValue }
+        }
+        return DiffReviewLoadedSession(
+            files: files,
+            summary: DiffReviewSessionModel(files: files.map(\.summary), groupsEnabled: true)
         )
     }
 }

--- a/Alas/Sources/Center/ReviewWorkspace/ReviewSessionLoader.swift
+++ b/Alas/Sources/Center/ReviewWorkspace/ReviewSessionLoader.swift
@@ -34,8 +34,9 @@ struct ReviewSessionLoader {
 
     @MainActor
     static func production(appState: AppState, worktree: Worktree) -> ReviewSessionLoader {
-        _ = appState
         let changesLoader = ReviewChangesLoader()
+        let git = GitService()
+        let commitLoader = CommitReviewLoader(git: git)
 
         return ReviewSessionLoader(
             localChanges: { target in
@@ -48,6 +49,54 @@ struct ReviewSessionLoader {
             draftCommit: { _ in
                 let session = try await changesLoader.load(worktreePath: worktree.path)
                 return filterLocalChanges(session, scope: .staged)
+            },
+            commit: { target in
+                guard case .commit(let sha) = target.payload else {
+                    throw ReviewSessionLoaderError.unsupportedTarget
+                }
+                let details = try await git.commitDetails(at: target.repositoryPath, sha: sha)
+                return try await commitLoader.load(
+                    worktreePath: target.repositoryPath,
+                    sha: sha,
+                    files: details.files,
+                    openFileForPath: { path in
+                        openFileAction(
+                            appState: appState,
+                            worktreeID: target.worktreeID,
+                            worktreePath: target.repositoryPath,
+                            relativePath: path
+                        )
+                    }
+                )
+            },
+            reviewRequest: { _ in
+                throw ReviewSessionLoaderError.unsupportedTarget
+            },
+            draftReviewRequest: { target in
+                guard case .draftReviewRequest(_, _, let base, let head, let headSHA) = target.payload else {
+                    throw ReviewSessionLoaderError.unsupportedTarget
+                }
+                try await validateCurrentHead(
+                    worktreePath: target.repositoryPath,
+                    expectedBranch: head,
+                    expectedSHA: headSHA
+                )
+                let context = try await git.reviewRequestDraftContext(
+                    worktreePath: target.repositoryPath,
+                    baseRef: base
+                )
+                return try await DraftReviewRequestDiffSessionBuilder.build(
+                    context: context,
+                    worktreePath: target.repositoryPath,
+                    openFileForPath: { path in
+                        openFileAction(
+                            appState: appState,
+                            worktreeID: target.worktreeID,
+                            worktreePath: target.repositoryPath,
+                            relativePath: path
+                        )
+                    }
+                )
             }
         )
     }
@@ -87,6 +136,43 @@ struct ReviewSessionLoader {
                 priorHandoffDescription: nil
             )
         )
+    }
+
+    private static func openFileAction(
+        appState: AppState,
+        worktreeID: String,
+        worktreePath: URL,
+        relativePath: String
+    ) -> (() -> Void)? {
+        guard DiffOpenFileAvailability.isAvailable(worktreePath: worktreePath, relativePath: relativePath) else {
+            return nil
+        }
+        return {
+            Task { @MainActor in
+                appState.openFile(relativePath: relativePath, worktreeId: worktreeID)
+            }
+        }
+    }
+
+    private static func validateCurrentHead(
+        worktreePath: URL,
+        expectedBranch: String,
+        expectedSHA: String?
+    ) async throws {
+        let branch = try await Process.git(["rev-parse", "--abbrev-ref", "HEAD"], cwd: worktreePath)
+        guard branch.exitCode == 0 else { throw ReviewSessionLoaderError.unsupportedTarget }
+        let currentBranch = branch.stdout.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard currentBranch == expectedBranch || expectedBranch == "HEAD" else {
+            throw ReviewSessionLoaderError.unsupportedTarget
+        }
+
+        guard let expectedSHA, !expectedSHA.isEmpty else { return }
+        let head = try await Process.git(["rev-parse", "HEAD"], cwd: worktreePath)
+        guard head.exitCode == 0 else { throw ReviewSessionLoaderError.unsupportedTarget }
+        let currentSHA = head.stdout.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard currentSHA == expectedSHA || currentSHA.hasPrefix(expectedSHA) else {
+            throw ReviewSessionLoaderError.unsupportedTarget
+        }
     }
 
     private static func filterLocalChanges(

--- a/Alas/Sources/Center/ReviewWorkspace/ReviewSessionLoader.swift
+++ b/Alas/Sources/Center/ReviewWorkspace/ReviewSessionLoader.swift
@@ -5,6 +5,40 @@ struct ReviewSessionLoadedContext {
     let feedbackTarget: ReviewFeedbackTarget
 }
 
+enum ReviewSessionLauncher {
+    @MainActor
+    @discardableResult
+    static func openOrFocus(
+        target: ReviewSessionTarget,
+        now: () -> Date = Date.init,
+        findActive: (ReviewSessionID) throws -> ReviewSessionRecord?,
+        save: (ReviewSessionRecord) throws -> Void,
+        open: (ReviewSessionRecord) -> Void,
+        onFailure: ((any Error) -> Void)? = nil
+    ) -> Bool {
+        do {
+            if let record = try findActive(target.id) {
+                open(record)
+                return true
+            }
+
+            let createdAt = now()
+            let record = ReviewSessionRecord(
+                id: target.id,
+                target: target,
+                createdAt: createdAt,
+                updatedAt: createdAt
+            )
+            try save(record)
+            open(record)
+            return true
+        } catch {
+            onFailure?(error)
+            return false
+        }
+    }
+}
+
 struct ReviewSessionLoader {
     var localChanges: (ReviewSessionTarget) async throws -> DiffReviewLoadedSession
     var draftCommit: (ReviewSessionTarget) async throws -> DiffReviewLoadedSession

--- a/Alas/Sources/Center/ReviewWorkspace/ReviewSessionLoader.swift
+++ b/Alas/Sources/Center/ReviewWorkspace/ReviewSessionLoader.swift
@@ -1,0 +1,75 @@
+import Foundation
+
+struct ReviewSessionLoadedContext {
+    let session: DiffReviewLoadedSession
+    let feedbackTarget: ReviewFeedbackTarget
+}
+
+struct ReviewSessionLoader {
+    var localChanges: (ReviewSessionTarget) async throws -> DiffReviewLoadedSession
+    var draftCommit: (ReviewSessionTarget) async throws -> DiffReviewLoadedSession
+    var commit: (ReviewSessionTarget) async throws -> DiffReviewLoadedSession
+    var commitRange: (ReviewSessionTarget) async throws -> DiffReviewLoadedSession
+    var branch: (ReviewSessionTarget) async throws -> DiffReviewLoadedSession
+    var reviewRequest: (ReviewSessionTarget) async throws -> DiffReviewLoadedSession
+    var draftReviewRequest: (ReviewSessionTarget) async throws -> DiffReviewLoadedSession
+
+    init(
+        localChanges: @escaping (ReviewSessionTarget) async throws -> DiffReviewLoadedSession = { _ in throw ReviewSessionLoaderError.unsupportedTarget },
+        draftCommit: @escaping (ReviewSessionTarget) async throws -> DiffReviewLoadedSession = { _ in throw ReviewSessionLoaderError.unsupportedTarget },
+        commit: @escaping (ReviewSessionTarget) async throws -> DiffReviewLoadedSession = { _ in throw ReviewSessionLoaderError.unsupportedTarget },
+        commitRange: @escaping (ReviewSessionTarget) async throws -> DiffReviewLoadedSession = { _ in throw ReviewSessionLoaderError.unsupportedTarget },
+        branch: @escaping (ReviewSessionTarget) async throws -> DiffReviewLoadedSession = { _ in throw ReviewSessionLoaderError.unsupportedTarget },
+        reviewRequest: @escaping (ReviewSessionTarget) async throws -> DiffReviewLoadedSession = { _ in throw ReviewSessionLoaderError.unsupportedTarget },
+        draftReviewRequest: @escaping (ReviewSessionTarget) async throws -> DiffReviewLoadedSession = { _ in throw ReviewSessionLoaderError.unsupportedTarget }
+    ) {
+        self.localChanges = localChanges
+        self.draftCommit = draftCommit
+        self.commit = commit
+        self.commitRange = commitRange
+        self.branch = branch
+        self.reviewRequest = reviewRequest
+        self.draftReviewRequest = draftReviewRequest
+    }
+
+    func load(target: ReviewSessionTarget) async throws -> ReviewSessionLoadedContext {
+        try Task.checkCancellation()
+
+        let session: DiffReviewLoadedSession
+        switch target.kind {
+        case .localChanges:
+            session = try await localChanges(target)
+        case .draftCommit:
+            session = try await draftCommit(target)
+        case .commit:
+            session = try await commit(target)
+        case .commitRange:
+            session = try await commitRange(target)
+        case .branch:
+            session = try await branch(target)
+        case .reviewRequest:
+            session = try await reviewRequest(target)
+        case .draftReviewRequest:
+            session = try await draftReviewRequest(target)
+        }
+
+        try Task.checkCancellation()
+
+        return ReviewSessionLoadedContext(
+            session: session,
+            feedbackTarget: ReviewFeedbackTarget(
+                title: target.title,
+                repositoryPath: target.repositoryPath.path,
+                providerDescription: target.providerDescription,
+                sourceDescription: target.sourceDescription,
+                sessionDescription: "Review session: \(target.title)",
+                revisionDescription: target.revisionDescription,
+                priorHandoffDescription: nil
+            )
+        )
+    }
+}
+
+enum ReviewSessionLoaderError: Error, Equatable {
+    case unsupportedTarget
+}

--- a/Alas/Sources/Center/ReviewWorkspace/ReviewSessionModels.swift
+++ b/Alas/Sources/Center/ReviewWorkspace/ReviewSessionModels.swift
@@ -1,3 +1,4 @@
+import CryptoKit
 import Foundation
 
 struct ReviewSessionID: Codable, Equatable, Hashable, RawRepresentable, Sendable {
@@ -302,6 +303,24 @@ struct ReviewFeedbackHandoff: Codable, Equatable, Identifiable, Sendable {
     let createdAt: Date
     let promptRevision: String
     var status: ReviewFeedbackHandoffStatus
+
+    static func revisionKey(commentIDs: [String], prompt: String) -> String {
+        var data = Data()
+        for commentID in commentIDs.sorted() {
+            append(commentID, to: &data)
+        }
+        append(prompt, to: &data)
+        return SHA256.hash(data: data)
+            .map { String(format: "%02x", $0) }
+            .joined()
+    }
+
+    private static func append(_ value: String, to data: inout Data) {
+        let bytes = Array(value.utf8)
+        data.append(contentsOf: "\(bytes.count):".utf8)
+        data.append(contentsOf: bytes)
+        data.append(0)
+    }
 }
 
 struct ReviewSessionRecord: Codable, Equatable, Identifiable, Sendable {

--- a/Alas/Sources/Center/ReviewWorkspace/ReviewSessionModels.swift
+++ b/Alas/Sources/Center/ReviewWorkspace/ReviewSessionModels.swift
@@ -1,0 +1,373 @@
+import Foundation
+
+struct ReviewSessionID: Codable, Equatable, Hashable, RawRepresentable, Sendable {
+    let rawValue: String
+}
+
+enum ReviewSessionTargetKind: String, Codable, Equatable, Hashable, Sendable {
+    case localChanges = "local-changes"
+    case draftCommit = "draft-commit"
+    case commit
+    case commitRange = "commit-range"
+    case branch
+    case reviewRequest = "review-request"
+    case draftReviewRequest = "draft-review-request"
+}
+
+struct ReviewSessionTarget: Codable, Equatable, Hashable, Identifiable, Sendable {
+    let id: ReviewSessionID
+    let kind: ReviewSessionTargetKind
+    let worktreeID: String
+    let repositoryPath: URL
+    let title: String
+    let sourceDescription: String
+    let providerDescription: String?
+    let providerURL: URL?
+    let revisionDescription: String?
+    let draftSessionID: ReviewDraftSessionID
+    let payload: Payload
+
+    static func localChanges(
+        worktreeID: String,
+        repositoryPath: URL,
+        scope: ReviewDraftLocalChangesScope
+    ) -> Self {
+        let path = standardizedPath(repositoryPath)
+        return ReviewSessionTarget(
+            id: makeID(.localChanges, [worktreeID, path, scope.rawValue]),
+            kind: .localChanges,
+            worktreeID: worktreeID,
+            repositoryPath: standardizedURL(repositoryPath),
+            title: "Review \(scope.rawValue) changes",
+            sourceDescription: "Local changes: \(scope.rawValue)",
+            providerDescription: nil,
+            providerURL: nil,
+            revisionDescription: nil,
+            draftSessionID: .localChanges(worktreeID: worktreeID, worktreePath: repositoryPath, scope: scope),
+            payload: .localChanges(scope: scope)
+        )
+    }
+
+    static func draftCommit(worktreeID: String, repositoryPath: URL) -> Self {
+        let path = standardizedPath(repositoryPath)
+        return ReviewSessionTarget(
+            id: makeID(.draftCommit, [worktreeID, path]),
+            kind: .draftCommit,
+            worktreeID: worktreeID,
+            repositoryPath: standardizedURL(repositoryPath),
+            title: "Review draft commit",
+            sourceDescription: "Draft commit",
+            providerDescription: nil,
+            providerURL: nil,
+            revisionDescription: nil,
+            draftSessionID: .draftCommit(worktreeID: worktreeID, repositoryPath: repositoryPath),
+            payload: .draftCommit
+        )
+    }
+
+    static func commit(
+        worktreeID: String,
+        repositoryPath: URL,
+        sha: String,
+        title: String
+    ) -> Self {
+        let path = standardizedPath(repositoryPath)
+        return ReviewSessionTarget(
+            id: makeID(.commit, [worktreeID, path, sha]),
+            kind: .commit,
+            worktreeID: worktreeID,
+            repositoryPath: standardizedURL(repositoryPath),
+            title: title,
+            sourceDescription: "Commit \(sha)",
+            providerDescription: nil,
+            providerURL: nil,
+            revisionDescription: sha,
+            draftSessionID: .commit(worktreeID: worktreeID, repositoryPath: repositoryPath, sha: sha),
+            payload: .commit(sha: sha)
+        )
+    }
+
+    static func commitRange(
+        worktreeID: String,
+        repositoryPath: URL,
+        base: String,
+        head: String,
+        title: String? = nil
+    ) -> Self {
+        let path = standardizedPath(repositoryPath)
+        return ReviewSessionTarget(
+            id: makeID(.commitRange, [worktreeID, path, base, head]),
+            kind: .commitRange,
+            worktreeID: worktreeID,
+            repositoryPath: standardizedURL(repositoryPath),
+            title: title ?? "Review \(base)..\(head)",
+            sourceDescription: "Commit range \(base)..\(head)",
+            providerDescription: nil,
+            providerURL: nil,
+            revisionDescription: "\(base)..\(head)",
+            draftSessionID: .branch(worktreeID: worktreeID, repositoryPath: repositoryPath, base: base, head: head),
+            payload: .commitRange(base: base, head: head)
+        )
+    }
+
+    static func branch(
+        worktreeID: String,
+        repositoryPath: URL,
+        base: String,
+        head: String,
+        title: String? = nil
+    ) -> Self {
+        let path = standardizedPath(repositoryPath)
+        return ReviewSessionTarget(
+            id: makeID(.branch, [worktreeID, path, base, head]),
+            kind: .branch,
+            worktreeID: worktreeID,
+            repositoryPath: standardizedURL(repositoryPath),
+            title: title ?? "Review \(head) against \(base)",
+            sourceDescription: "Branch \(head) against \(base)",
+            providerDescription: nil,
+            providerURL: nil,
+            revisionDescription: "\(base)..\(head)",
+            draftSessionID: .branch(worktreeID: worktreeID, repositoryPath: repositoryPath, base: base, head: head),
+            payload: .branch(base: base, head: head)
+        )
+    }
+
+    static func reviewRequest(
+        worktreeID: String,
+        repositoryPath: URL = URL(fileURLWithPath: ""),
+        provider: CodeHostKind,
+        host: String,
+        repositorySlug: String,
+        number: Int,
+        url: URL,
+        title: String,
+        headSHA: String?
+    ) -> Self {
+        let normalizedHost = host.lowercased()
+        let normalizedSlug = standardizedRepositorySlug(repositorySlug)
+        return ReviewSessionTarget(
+            id: makeID(.reviewRequest, [worktreeID, provider.rawValue, normalizedHost, normalizedSlug, "\(number)"]),
+            kind: .reviewRequest,
+            worktreeID: worktreeID,
+            repositoryPath: standardizedURL(repositoryPath),
+            title: title,
+            sourceDescription: "\(provider.reviewRequestLabel) \(provider.reviewRequestNumberPrefix)\(number)",
+            providerDescription: "\(provider.displayName) \(normalizedSlug) \(provider.reviewRequestNumberPrefix)\(number)",
+            providerURL: url,
+            revisionDescription: headSHA,
+            draftSessionID: .reviewRequest(
+                worktreeID: worktreeID,
+                provider: provider,
+                host: normalizedHost,
+                repositorySlug: normalizedSlug,
+                number: number
+            ),
+            payload: .reviewRequest(
+                provider: provider,
+                host: normalizedHost,
+                repositorySlug: normalizedSlug,
+                number: number,
+                headSHA: headSHA
+            )
+        )
+    }
+
+    static func draftReviewRequest(
+        worktreeID: String,
+        repositoryPath: URL,
+        provider: CodeHostKind,
+        repositorySlug: String,
+        base: String,
+        head: String,
+        headSHA: String?
+    ) -> Self {
+        let path = standardizedPath(repositoryPath)
+        let normalizedSlug = standardizedRepositorySlug(repositorySlug)
+        return ReviewSessionTarget(
+            id: makeID(.draftReviewRequest, [worktreeID, path, provider.rawValue, normalizedSlug, base, head]),
+            kind: .draftReviewRequest,
+            worktreeID: worktreeID,
+            repositoryPath: standardizedURL(repositoryPath),
+            title: "Review draft \(provider.reviewRequestLabel)",
+            sourceDescription: "Draft \(provider.reviewRequestLabel) \(head) against \(base)",
+            providerDescription: "\(provider.displayName) \(normalizedSlug)",
+            providerURL: nil,
+            revisionDescription: headSHA,
+            draftSessionID: .draftReviewRequest(worktreeID: worktreeID, repositoryPath: repositoryPath, base: base, head: head),
+            payload: .draftReviewRequest(
+                provider: provider,
+                repositorySlug: normalizedSlug,
+                base: base,
+                head: head,
+                headSHA: headSHA
+            )
+        )
+    }
+
+    private static let separator: Character = "\u{1f}"
+
+    private static func makeID(_ kind: ReviewSessionTargetKind, _ fields: [String]) -> ReviewSessionID {
+        let values = ([kind.rawValue] + fields).map(escape)
+        return ReviewSessionID(rawValue: values.joined(separator: String(separator)))
+    }
+
+    private static func escape(_ value: String) -> String {
+        value
+            .replacingOccurrences(of: "\\", with: "\\\\")
+            .replacingOccurrences(of: String(separator), with: "\\u001f")
+    }
+
+    private static func standardizedURL(_ url: URL) -> URL {
+        url.standardizedFileURL
+    }
+
+    private static func standardizedPath(_ url: URL) -> String {
+        standardizedURL(url).path
+    }
+
+    private static func standardizedRepositorySlug(_ slug: String) -> String {
+        slug
+            .split(separator: "/", omittingEmptySubsequences: true)
+            .map(String.init)
+            .joined(separator: "/")
+    }
+
+    enum Payload: Codable, Equatable, Hashable, Sendable {
+        case localChanges(scope: ReviewDraftLocalChangesScope)
+        case draftCommit
+        case commit(sha: String)
+        case commitRange(base: String, head: String)
+        case branch(base: String, head: String)
+        case reviewRequest(provider: CodeHostKind, host: String, repositorySlug: String, number: Int, headSHA: String?)
+        case draftReviewRequest(provider: CodeHostKind, repositorySlug: String, base: String, head: String, headSHA: String?)
+
+        func hash(into hasher: inout Hasher) {
+            switch self {
+            case .localChanges(let scope):
+                hasher.combine(0)
+                hasher.combine(scope)
+            case .draftCommit:
+                hasher.combine(1)
+            case .commit(let sha):
+                hasher.combine(2)
+                hasher.combine(sha)
+            case .commitRange(let base, let head):
+                hasher.combine(3)
+                hasher.combine(base)
+                hasher.combine(head)
+            case .branch(let base, let head):
+                hasher.combine(4)
+                hasher.combine(base)
+                hasher.combine(head)
+            case .reviewRequest(let provider, let host, let repositorySlug, let number, let headSHA):
+                hasher.combine(5)
+                hasher.combine(provider.rawValue)
+                hasher.combine(host)
+                hasher.combine(repositorySlug)
+                hasher.combine(number)
+                hasher.combine(headSHA)
+            case .draftReviewRequest(let provider, let repositorySlug, let base, let head, let headSHA):
+                hasher.combine(6)
+                hasher.combine(provider.rawValue)
+                hasher.combine(repositorySlug)
+                hasher.combine(base)
+                hasher.combine(head)
+                hasher.combine(headSHA)
+            }
+        }
+    }
+}
+
+enum ReviewSessionStatus: String, Codable, Equatable, Hashable, Sendable {
+    case active
+    case sent
+    case addressing
+    case addressed
+    case archived
+}
+
+enum ReviewFeedbackHandoffStatus: String, Codable, Equatable, Hashable, Sendable {
+    case sent
+    case failed
+    case addressed
+}
+
+struct ReviewFeedbackHandoff: Codable, Equatable, Identifiable, Sendable {
+    let id: String
+    let sessionID: ReviewSessionID
+    let commentIDs: [String]
+    let target: ReviewFeedbackAgentTarget
+    let createdAt: Date
+    let promptRevision: String
+    var status: ReviewFeedbackHandoffStatus
+}
+
+struct ReviewSessionRecord: Codable, Equatable, Identifiable, Sendable {
+    let id: ReviewSessionID
+    var target: ReviewSessionTarget
+    var selectedFileID: DiffReviewFileID?
+    var focusedCommentID: String?
+    var status: ReviewSessionStatus
+    var handoffs: [ReviewFeedbackHandoff]
+    var lastSendError: String?
+    let createdAt: Date
+    var updatedAt: Date
+
+    init(
+        id: ReviewSessionID,
+        target: ReviewSessionTarget,
+        selectedFileID: DiffReviewFileID? = nil,
+        focusedCommentID: String? = nil,
+        status: ReviewSessionStatus = .active,
+        handoffs: [ReviewFeedbackHandoff] = [],
+        lastSendError: String? = nil,
+        createdAt: Date,
+        updatedAt: Date
+    ) {
+        self.id = id
+        self.target = target
+        self.selectedFileID = selectedFileID
+        self.focusedCommentID = focusedCommentID
+        self.status = status
+        self.handoffs = handoffs
+        self.lastSendError = lastSendError
+        self.createdAt = createdAt
+        self.updatedAt = updatedAt
+    }
+
+    func recording(handoff: ReviewFeedbackHandoff) -> ReviewSessionRecord {
+        var record = self
+        record.handoffs.append(handoff)
+        record.status = handoff.status == .failed ? .active : .sent
+        record.lastSendError = nil
+        record.updatedAt = handoff.createdAt
+        return record
+    }
+
+    func markedAddressed(now: Date) -> ReviewSessionRecord {
+        var record = self
+        record.status = .addressed
+        record.handoffs = record.handoffs.map { handoff in
+            var updated = handoff
+            updated.status = .addressed
+            return updated
+        }
+        record.updatedAt = now
+        return record
+    }
+
+    func selectingFile(_ fileID: DiffReviewFileID?, now: Date) -> ReviewSessionRecord {
+        var record = self
+        record.selectedFileID = fileID
+        record.updatedAt = now
+        return record
+    }
+
+    func focusingComment(_ commentID: String?, now: Date) -> ReviewSessionRecord {
+        var record = self
+        record.focusedCommentID = commentID
+        record.updatedAt = now
+        return record
+    }
+}

--- a/Alas/Sources/Center/ReviewWorkspace/ReviewSessionModels.swift
+++ b/Alas/Sources/Center/ReviewWorkspace/ReviewSessionModels.swift
@@ -135,7 +135,7 @@ struct ReviewSessionTarget: Codable, Equatable, Hashable, Identifiable, Sendable
 
     static func reviewRequest(
         worktreeID: String,
-        repositoryPath: URL = URL(fileURLWithPath: ""),
+        repositoryPath: URL,
         provider: CodeHostKind,
         host: String,
         repositorySlug: String,
@@ -144,10 +144,11 @@ struct ReviewSessionTarget: Codable, Equatable, Hashable, Identifiable, Sendable
         title: String,
         headSHA: String?
     ) -> Self {
+        let path = standardizedPath(repositoryPath)
         let normalizedHost = host.lowercased()
         let normalizedSlug = standardizedRepositorySlug(repositorySlug)
         return ReviewSessionTarget(
-            id: makeID(.reviewRequest, [worktreeID, provider.rawValue, normalizedHost, normalizedSlug, "\(number)"]),
+            id: makeID(.reviewRequest, [worktreeID, path, provider.rawValue, normalizedHost, normalizedSlug, "\(number)"]),
             kind: .reviewRequest,
             worktreeID: worktreeID,
             repositoryPath: standardizedURL(repositoryPath),

--- a/Alas/Sources/Center/ReviewWorkspace/ReviewSessionModels.swift
+++ b/Alas/Sources/Center/ReviewWorkspace/ReviewSessionModels.swift
@@ -187,7 +187,7 @@ struct ReviewSessionTarget: Codable, Equatable, Hashable, Identifiable, Sendable
         let path = standardizedPath(repositoryPath)
         let normalizedSlug = standardizedRepositorySlug(repositorySlug)
         return ReviewSessionTarget(
-            id: makeID(.draftReviewRequest, [worktreeID, path, provider.rawValue, normalizedSlug, base, head]),
+            id: makeID(.draftReviewRequest, [worktreeID, path, provider.rawValue, normalizedSlug, base, head, headSHA ?? ""]),
             kind: .draftReviewRequest,
             worktreeID: worktreeID,
             repositoryPath: standardizedURL(repositoryPath),

--- a/Alas/Sources/Center/ReviewWorkspace/ReviewSessionStore.swift
+++ b/Alas/Sources/Center/ReviewWorkspace/ReviewSessionStore.swift
@@ -1,0 +1,52 @@
+import Foundation
+
+struct ReviewSessionStore {
+    private let store: any PersistenceStoreProtocol
+    private let url: URL
+
+    init(store: any PersistenceStoreProtocol = PersistenceStore(), url: URL = Paths.reviewSessionsFile) {
+        self.store = store
+        self.url = url
+    }
+
+    func load(id: ReviewSessionID) throws -> ReviewSessionRecord? {
+        let snapshot = try readSnapshot()
+        return snapshot.recordsByID[id.rawValue]
+    }
+
+    func list(worktreeID: String) throws -> [ReviewSessionRecord] {
+        let snapshot = try readSnapshot()
+        return snapshot.recordsByID.values
+            .filter { $0.target.worktreeID == worktreeID }
+            .sorted(by: sortSessions)
+    }
+
+    func findActive(targetID: ReviewSessionID) throws -> ReviewSessionRecord? {
+        let snapshot = try readSnapshot()
+        guard let record = snapshot.recordsByID[targetID.rawValue],
+              record.status != .archived
+        else { return nil }
+        return record
+    }
+
+    func save(_ record: ReviewSessionRecord) throws {
+        var snapshot = try readSnapshot()
+        snapshot.recordsByID[record.id.rawValue] = record
+        try store.write(snapshot, to: url)
+    }
+
+    private func readSnapshot() throws -> Snapshot {
+        try store.readIfExists(Snapshot.self, from: url) ?? Snapshot(recordsByID: [:])
+    }
+
+    private func sortSessions(_ lhs: ReviewSessionRecord, _ rhs: ReviewSessionRecord) -> Bool {
+        if lhs.updatedAt != rhs.updatedAt {
+            return lhs.updatedAt > rhs.updatedAt
+        }
+        return lhs.id.rawValue < rhs.id.rawValue
+    }
+
+    private struct Snapshot: Codable, Equatable {
+        var recordsByID: [String: ReviewSessionRecord]
+    }
+}

--- a/Alas/Sources/Center/ReviewWorkspace/ReviewSessionStore.swift
+++ b/Alas/Sources/Center/ReviewWorkspace/ReviewSessionStore.swift
@@ -23,10 +23,10 @@ struct ReviewSessionStore {
 
     func findActive(targetID: ReviewSessionID) throws -> ReviewSessionRecord? {
         let snapshot = try readSnapshot()
-        guard let record = snapshot.recordsByID[targetID.rawValue],
-              record.status != .archived
-        else { return nil }
-        return record
+        return snapshot.recordsByID.values
+            .filter { $0.target.id == targetID && $0.status != .archived }
+            .sorted(by: sortSessions)
+            .first
     }
 
     func save(_ record: ReviewSessionRecord) throws {

--- a/Alas/Sources/Center/ReviewWorkspace/ReviewSessionTabView.swift
+++ b/Alas/Sources/Center/ReviewWorkspace/ReviewSessionTabView.swift
@@ -253,6 +253,7 @@ struct ReviewSessionTabView: View {
             onSelectDraftComment: selectDraftComment,
             onSaveDraftComment: saveDraftComment
         )
+        .environment(\.reviewDraftSummaryRailStatus, ReviewDraftSummaryRailStatus(record: record))
     }
 
     private var layoutModeBinding: Binding<DiffLayoutMode> {
@@ -392,8 +393,32 @@ struct ReviewSessionTabView: View {
     private func draftCommentActions() -> ReviewDraftCommentActions {
         ReviewDraftWorkspaceActions.make(
             controller: draftCommentController,
-            sender: feedbackSender
+            sender: feedbackSender,
+            sessionID: tabState.sessionID,
+            recordHandoff: recordSessionHandoff
         )
+    }
+
+    private func recordSessionHandoff(_ handoff: ReviewFeedbackHandoff) {
+        guard persistsState else {
+            if let current = record {
+                record = current.recording(handoff: handoff)
+            }
+            return
+        }
+
+        do {
+            let current = try sessionStore.load(id: handoff.sessionID) ?? record
+            guard let current else { return }
+            let updated = current.recording(handoff: handoff)
+            try sessionStore.save(updated)
+            record = updated
+        } catch {
+            guard var visibleRecord = record else { return }
+            visibleRecord.lastSendError = error.localizedDescription
+            visibleRecord.updatedAt = now()
+            record = visibleRecord
+        }
     }
 
     private func selectDraftComment(_ comment: ReviewDraftComment) {

--- a/Alas/Sources/Center/ReviewWorkspace/ReviewSessionTabView.swift
+++ b/Alas/Sources/Center/ReviewWorkspace/ReviewSessionTabView.swift
@@ -1,0 +1,408 @@
+import SwiftUI
+
+struct ReviewSessionTabView: View {
+    let worktree: Worktree?
+    let tabState: ReviewSessionTabState
+    let appState: AppState?
+    var sessionStore: ReviewSessionStore
+    var draftCommentStore: ReviewDraftCommentStore
+    var loader: ReviewSessionLoader
+    var feedbackSender: ReviewFeedbackAgentSender
+    var loadsOnAppear: Bool
+    var persistsState: Bool
+    var now: () -> Date
+
+    @Environment(\.theme) private var theme
+    @State private var record: ReviewSessionRecord?
+    @State private var loaded: ReviewSessionLoadedContext?
+    @State private var isLoading = false
+    @State private var loadError: String?
+    @State private var selectedFileID: DiffReviewFileID?
+    @State private var railCollapsed = false
+    @State private var reviewSummaryCollapsed = false
+    @State private var localLayoutMode = DiffLayoutMode.split
+    @State private var localWrapLines = false
+    @State private var localShowWhitespace = false
+    @State private var draftCommentController: ReviewDraftCommentController?
+    @State private var loadedDraftSessionID: ReviewDraftSessionID?
+    @State private var focusedDraftCommentID: String?
+    @State private var draftCommentScrollCommand: DiffReviewDraftCommentScrollCommand?
+    @State private var draftCommentScrollController = DiffReviewDraftCommentScrollController()
+
+    init(worktree: Worktree, tabState: ReviewSessionTabState, appState: AppState) {
+        self.worktree = worktree
+        self.tabState = tabState
+        self.appState = appState
+        self.sessionStore = ReviewSessionStore()
+        self.draftCommentStore = ReviewDraftCommentStore()
+        self.loader = ReviewSessionLoader()
+        self.feedbackSender = ReviewFeedbackAgentSender.production(appState: appState, worktreeID: worktree.id)
+        self.loadsOnAppear = true
+        self.persistsState = true
+        self.now = Date.init
+        self._selectedFileID = State(initialValue: tabState.selectedFileID)
+        self._focusedDraftCommentID = State(initialValue: tabState.focusedCommentID)
+    }
+
+    private init(
+        tabState: ReviewSessionTabState,
+        record: ReviewSessionRecord?,
+        loaded: ReviewSessionLoadedContext?,
+        sessionStore: ReviewSessionStore = ReviewSessionStore(),
+        draftCommentStore: ReviewDraftCommentStore = ReviewDraftCommentStore(),
+        loader: ReviewSessionLoader = ReviewSessionLoader(),
+        feedbackSender: ReviewFeedbackAgentSender,
+        loadsOnAppear: Bool,
+        persistsState: Bool,
+        now: @escaping () -> Date = Date.init
+    ) {
+        self.worktree = nil
+        self.tabState = tabState
+        self.appState = nil
+        self.sessionStore = sessionStore
+        self.draftCommentStore = draftCommentStore
+        self.loader = loader
+        self.feedbackSender = feedbackSender
+        self.loadsOnAppear = loadsOnAppear
+        self.persistsState = persistsState
+        self.now = now
+        self._record = State(initialValue: record)
+        self._loaded = State(initialValue: loaded)
+        self._selectedFileID = State(initialValue: record?.selectedFileID ?? tabState.selectedFileID)
+        self._focusedDraftCommentID = State(initialValue: record?.focusedCommentID ?? tabState.focusedCommentID)
+    }
+
+    static func preview(record: ReviewSessionRecord, loaded: ReviewSessionLoadedContext) -> some View {
+        ReviewSessionTabView(
+            tabState: ReviewSessionTabState(worktreeId: record.target.worktreeID, record: record),
+            record: record,
+            loaded: loaded,
+            feedbackSender: ReviewFeedbackAgentSender(availableTargets: { [] }, send: { _, _ in }),
+            loadsOnAppear: false,
+            persistsState: false
+        )
+    }
+
+    var body: some View {
+        VStack(spacing: 0) {
+            header
+            Divider().overlay(theme.color("line"))
+            content
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .background(theme.color("bg-1"))
+        .task(id: tabState.sessionID.rawValue) {
+            guard loadsOnAppear else { return }
+            await loadReviewSession()
+        }
+        .onChange(of: selectedFileID) { _, fileID in
+            persistSelectedFile(fileID)
+        }
+        .onChange(of: focusedDraftCommentID) { _, commentID in
+            persistFocusedComment(commentID)
+        }
+    }
+
+    private var header: some View {
+        HStack(spacing: 10) {
+            Image(systemName: "text.badge.checkmark")
+                .font(.system(size: 13, weight: .medium))
+                .foregroundColor(theme.color("accent"))
+            VStack(alignment: .leading, spacing: 2) {
+                Text(record?.target.title ?? tabState.title)
+                    .font(.system(size: 13, weight: .semibold))
+                    .foregroundColor(theme.color("fg"))
+                    .lineLimit(1)
+                    .accessibilityLabel(record?.target.title ?? tabState.title)
+                if let sourceDescription = record?.target.sourceDescription {
+                    Text(sourceDescription)
+                        .font(.system(size: 11))
+                        .foregroundColor(theme.color("fg-muted"))
+                        .lineLimit(1)
+                }
+            }
+            Spacer(minLength: 12)
+            if let providerDescription = record?.target.providerDescription {
+                Text(providerDescription)
+                    .font(.system(size: 11, weight: .medium))
+                    .foregroundColor(theme.color("fg-muted"))
+                    .lineLimit(1)
+            }
+        }
+        .padding(.horizontal, 14)
+        .padding(.vertical, 9)
+        .background(theme.color("bg-2"))
+        .background(
+            DiffReviewAccessibilityMarker(
+                identifier: "review-session-title",
+                label: record?.target.title ?? tabState.title
+            )
+        )
+    }
+
+    @ViewBuilder
+    private var content: some View {
+        if isLoading {
+            stateView(title: "Loading review session...", detail: nil, color: theme.color("fg-dim"), showsRetry: false)
+        } else if let loadError {
+            stateView(title: "Could not load review session", detail: loadError, color: theme.color("del"), showsRetry: loadsOnAppear)
+        } else if let loaded, loaded.session.files.isEmpty {
+            stateView(title: "No files to review", detail: "This review session has no file diffs.", color: theme.color("fg-dim"), showsRetry: false)
+        } else if let loaded {
+            reviewSurface(loaded)
+        } else {
+            stateView(title: "No review session loaded", detail: nil, color: theme.color("fg-dim"), showsRetry: false)
+        }
+    }
+
+    private func stateView(title: String, detail: String?, color: Color, showsRetry: Bool) -> some View {
+        VStack(spacing: 10) {
+            Text(title)
+                .font(.system(size: 13, weight: .semibold))
+                .foregroundColor(color)
+            if let detail, !detail.isEmpty {
+                Text(detail)
+                    .font(.system(size: 11))
+                    .foregroundColor(theme.color("fg-muted"))
+                    .multilineTextAlignment(.center)
+            }
+            if showsRetry {
+                Button("Retry") {
+                    Task { await loadReviewSession() }
+                }
+                .buttonStyle(.bordered)
+                .controlSize(.small)
+            }
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .background(theme.color("bg-1"))
+    }
+
+    private func reviewSurface(_ loaded: ReviewSessionLoadedContext) -> some View {
+        DiffReviewSurface(
+            session: loaded.session,
+            selectedFileID: Binding(
+                get: { selectedFileID },
+                set: { selectedFileID = $0 }
+            ),
+            railCollapsed: $railCollapsed,
+            reviewSummaryCollapsed: $reviewSummaryCollapsed,
+            layoutMode: layoutModeBinding,
+            wrapLines: wrapLinesBinding,
+            showWhitespace: showWhitespaceBinding,
+            codeFontFamily: appState?.config.code.fontFamily ?? "",
+            codeFontSize: CGFloat(appState?.config.code.fontSize ?? 13),
+            showsSourceBadges: true,
+            showsRailDisplayControls: true,
+            showsDraftSummaryRail: true,
+            lspContextForFile: makeLSPContext,
+            reviewFeedbackTarget: loaded.feedbackTarget,
+            draftCommentsByFileID: ReviewDraftCommentGrouping.commentsByFileID(draftCommentController?.comments ?? []),
+            focusedDraftCommentID: focusedDraftCommentID,
+            draftCommentScrollCommand: draftCommentScrollCommand,
+            draftCommentActions: draftCommentActions(),
+            onSelectDraftComment: selectDraftComment,
+            onSaveDraftComment: saveDraftComment
+        )
+    }
+
+    private var layoutModeBinding: Binding<DiffLayoutMode> {
+        guard let appState else { return $localLayoutMode }
+        return DiffPreferenceBindings(appState: appState).layoutMode
+    }
+
+    private var wrapLinesBinding: Binding<Bool> {
+        guard let appState else { return $localWrapLines }
+        return DiffPreferenceBindings(appState: appState).wrapLines
+    }
+
+    private var showWhitespaceBinding: Binding<Bool> {
+        guard let appState else { return $localShowWhitespace }
+        return DiffPreferenceBindings(appState: appState).showWhitespace
+    }
+
+    private func makeLSPContext(_ file: DiffReviewFileSectionModel) -> DiffPaneLSPContext? {
+        guard let appState, let worktree else { return nil }
+        let relativePath = file.summary.path
+        let fileURL = worktree.path.appendingPathComponent(relativePath)
+        guard FileManager.default.fileExists(atPath: fileURL.path),
+              let language = appState.lsp.language(forFileExtension: (relativePath as NSString).pathExtension)
+        else {
+            return nil
+        }
+        return DiffPaneLSPContext(
+            worktreeId: worktree.id,
+            worktreeRoot: worktree.path,
+            relativePath: relativePath,
+            language: language,
+            lsp: appState.lsp,
+            openTarget: { url, line, character in
+                openLSPTarget(
+                    url: url,
+                    originatingRelativePath: relativePath,
+                    language: language,
+                    line: line,
+                    character: character
+                )
+            }
+        )
+    }
+
+    private func openLSPTarget(
+        url: URL,
+        originatingRelativePath: String,
+        language: String,
+        line: Int,
+        character: Int
+    ) {
+        guard let appState, let worktree else { return }
+        let prefix = worktree.path.path + "/"
+        if url.path.hasPrefix(prefix) {
+            let relativeTarget = String(url.path.dropFirst(prefix.count))
+            appState.tabs.openEditor(
+                worktreeId: worktree.id,
+                relativePath: relativeTarget,
+                revealLine: line,
+                revealCharacter: character
+            )
+        } else {
+            appState.tabs.openExternalEditor(
+                worktreeId: worktree.id,
+                absoluteURL: url,
+                revealLine: line,
+                revealCharacter: character,
+                originatingRelativePath: originatingRelativePath,
+                originatingWorktreeRoot: worktree.path,
+                language: language
+            )
+        }
+    }
+
+    private func loadReviewSession() async {
+        isLoading = true
+        loadError = nil
+        loaded = nil
+
+        do {
+            guard let storedRecord = try sessionStore.load(id: tabState.sessionID) else {
+                throw ReviewSessionTabError.missingSession(tabState.sessionID)
+            }
+            record = storedRecord
+            selectedFileID = storedRecord.selectedFileID
+            focusedDraftCommentID = storedRecord.focusedCommentID
+            loadDraftCommentController(for: storedRecord)
+
+            let loadedContext = try await loader.load(target: storedRecord.target)
+            loaded = loadedContext
+            selectedFileID = synchronizedSelection(
+                selectedFileID,
+                session: loadedContext.session
+            )
+            isLoading = false
+        } catch is CancellationError {
+            isLoading = false
+        } catch {
+            loadError = error.localizedDescription
+            isLoading = false
+        }
+    }
+
+    private func synchronizedSelection(
+        _ selected: DiffReviewFileID?,
+        session: DiffReviewLoadedSession
+    ) -> DiffReviewFileID? {
+        if let selected, session.summary.files.contains(where: { $0.id == selected }) {
+            return selected
+        }
+        return session.summary.files.first?.id
+    }
+
+    private func loadDraftCommentController(for record: ReviewSessionRecord) {
+        let sessionID = record.target.draftSessionID
+        if loadedDraftSessionID != sessionID {
+            draftCommentController = ReviewDraftCommentController(
+                sessionID: sessionID,
+                store: draftCommentStore
+            )
+            loadedDraftSessionID = sessionID
+            draftCommentScrollCommand = nil
+        }
+        do {
+            try draftCommentController?.load()
+        } catch {
+            // Draft comment load failures stay non-blocking; the controller keeps the error.
+        }
+    }
+
+    private func draftCommentActions() -> ReviewDraftCommentActions {
+        ReviewDraftWorkspaceActions.make(
+            controller: draftCommentController,
+            sender: feedbackSender
+        )
+    }
+
+    private func selectDraftComment(_ comment: ReviewDraftComment) {
+        focusedDraftCommentID = comment.id
+        selectedFileID = comment.fileID
+        draftCommentScrollCommand = draftCommentScrollController.command(
+            commentID: comment.id,
+            fileID: comment.fileID
+        )
+    }
+
+    private func saveDraftComment(fileID: DiffReviewFileID, anchor: DiffReviewLineAnchor, body: String) {
+        do {
+            try draftCommentController?.add(anchor: anchor, fileID: fileID, bodyMarkdown: body)
+        } catch {
+            // Draft comment save failures stay non-blocking; the controller keeps the error.
+        }
+    }
+
+    private func persistSelectedFile(_ fileID: DiffReviewFileID?) {
+        guard let current = record else { return }
+        let updated = current.selectingFile(fileID, now: now())
+        persist(updated)
+        updateTabState { state in
+            state.selectedFileID = fileID
+        }
+    }
+
+    private func persistFocusedComment(_ commentID: String?) {
+        guard let current = record else { return }
+        let updated = current.focusingComment(commentID, now: now())
+        persist(updated)
+        updateTabState { state in
+            state.focusedCommentID = commentID
+        }
+    }
+
+    private func persist(_ updated: ReviewSessionRecord) {
+        record = updated
+        guard persistsState else { return }
+        do {
+            try sessionStore.save(updated)
+        } catch {
+            loadError = error.localizedDescription
+        }
+    }
+
+    private func updateTabState(_ mutate: (inout ReviewSessionTabState) -> Void) {
+        guard persistsState, let appState else { return }
+        _ = appState.tabs.updateReviewSession(
+            worktreeId: tabState.worktreeId,
+            tabId: tabState.id,
+            mutate: mutate
+        )
+    }
+}
+
+private enum ReviewSessionTabError: LocalizedError {
+    case missingSession(ReviewSessionID)
+
+    var errorDescription: String? {
+        switch self {
+        case .missingSession(let id):
+            return "Review session \(id.rawValue) was not found."
+        }
+    }
+}

--- a/Alas/Sources/Center/ReviewWorkspace/ReviewSessionTabView.swift
+++ b/Alas/Sources/Center/ReviewWorkspace/ReviewSessionTabView.swift
@@ -35,7 +35,7 @@ struct ReviewSessionTabView: View {
         self.appState = appState
         self.sessionStore = ReviewSessionStore()
         self.draftCommentStore = ReviewDraftCommentStore()
-        self.loader = ReviewSessionLoader()
+        self.loader = ReviewSessionLoader.production(appState: appState, worktree: worktree)
         self.feedbackSender = ReviewFeedbackAgentSender.production(appState: appState, worktreeID: worktree.id)
         self.loadsOnAppear = true
         self.persistsState = true

--- a/Alas/Sources/Center/ReviewWorkspace/ReviewSessionTabView.swift
+++ b/Alas/Sources/Center/ReviewWorkspace/ReviewSessionTabView.swift
@@ -127,7 +127,7 @@ struct ReviewSessionTabView: View {
             tabState: ReviewSessionTabState(worktreeId: record.target.worktreeID, record: record),
             record: record,
             loaded: loaded,
-            feedbackSender: ReviewFeedbackAgentSender(availableTargets: { [] }, send: { _, _ in }),
+            feedbackSender: ReviewFeedbackAgentSender(availableTargets: { [] }, send: { _, _, _ in }),
             loadsOnAppear: false,
             persistsState: false
         )
@@ -395,29 +395,31 @@ struct ReviewSessionTabView: View {
             controller: draftCommentController,
             sender: feedbackSender,
             sessionID: tabState.sessionID,
-            recordHandoff: recordSessionHandoff
+            recordHandoff: recordSessionHandoff,
+            recordSendFailure: recordSessionSendFailure
         )
     }
 
     private func recordSessionHandoff(_ handoff: ReviewFeedbackHandoff) {
-        guard persistsState else {
-            if let current = record {
-                record = current.recording(handoff: handoff)
-            }
-            return
-        }
+        record = ReviewSessionHandoffPersistence.record(
+            handoff,
+            currentRecord: record,
+            sessionStore: sessionStore,
+            persistsState: persistsState,
+            now: now
+        )
+    }
 
+    private func recordSessionSendFailure(_ error: Error) {
+        guard var current = record else { return }
+        current.lastSendError = "Failed to send to agent: \(error.localizedDescription)"
+        current.updatedAt = now()
+        record = current
+        guard persistsState else { return }
         do {
-            let current = try sessionStore.load(id: handoff.sessionID) ?? record
-            guard let current else { return }
-            let updated = current.recording(handoff: handoff)
-            try sessionStore.save(updated)
-            record = updated
+            try sessionStore.save(current)
         } catch {
-            guard var visibleRecord = record else { return }
-            visibleRecord.lastSendError = error.localizedDescription
-            visibleRecord.updatedAt = now()
-            record = visibleRecord
+            // Visible send failure state is already set; failure to persist that state is non-blocking.
         }
     }
 
@@ -499,6 +501,34 @@ private enum ReviewSessionTabError: LocalizedError {
         switch self {
         case .missingSession(let id):
             return "Review session \(id.rawValue) was not found."
+        }
+    }
+}
+
+enum ReviewSessionHandoffPersistence {
+    @MainActor
+    static func record(
+        _ handoff: ReviewFeedbackHandoff,
+        currentRecord: ReviewSessionRecord?,
+        sessionStore: ReviewSessionStore,
+        persistsState: Bool,
+        now: () -> Date
+    ) -> ReviewSessionRecord? {
+        guard persistsState else {
+            return currentRecord?.recording(handoff: handoff)
+        }
+
+        do {
+            let current = try sessionStore.load(id: handoff.sessionID) ?? currentRecord
+            guard let current else { return nil }
+            let updated = current.recording(handoff: handoff)
+            try sessionStore.save(updated)
+            return updated
+        } catch {
+            guard var visibleRecord = currentRecord else { return nil }
+            visibleRecord.lastSendError = "Sent to agent, but failed to save handoff record: \(error.localizedDescription)"
+            visibleRecord.updatedAt = now()
+            return visibleRecord
         }
     }
 }

--- a/Alas/Sources/Center/ReviewWorkspace/ReviewSessionTabView.swift
+++ b/Alas/Sources/Center/ReviewWorkspace/ReviewSessionTabView.swift
@@ -1,5 +1,53 @@
 import SwiftUI
 
+struct ReviewSessionTabLoadToken: Equatable {
+    private let id = UUID()
+}
+
+struct ReviewSessionTabLoadCoordinator {
+    private(set) var activeToken: ReviewSessionTabLoadToken?
+
+    mutating func begin() -> ReviewSessionTabLoadToken {
+        let token = ReviewSessionTabLoadToken()
+        activeToken = token
+        return token
+    }
+
+    func canPublish(_ token: ReviewSessionTabLoadToken) -> Bool {
+        activeToken == token
+    }
+
+    mutating func finish(_ token: ReviewSessionTabLoadToken) {
+        guard activeToken == token else { return }
+        activeToken = nil
+    }
+}
+
+struct ReviewSessionTabLoadPublication {
+    let record: ReviewSessionRecord
+    let loaded: ReviewSessionLoadedContext
+    let selectedFileID: DiffReviewFileID?
+    let focusedDraftCommentID: String?
+    let shouldPersistSelectionState: Bool
+
+    static func initial(
+        record: ReviewSessionRecord,
+        loaded: ReviewSessionLoadedContext
+    ) -> ReviewSessionTabLoadPublication {
+        let fileIDs = loaded.session.summary.files.map(\.id)
+        return ReviewSessionTabLoadPublication(
+            record: record,
+            loaded: loaded,
+            selectedFileID: DiffReviewSurfaceSelectionSync.synchronizedSelection(
+                current: record.selectedFileID,
+                fileIDs: fileIDs
+            ),
+            focusedDraftCommentID: record.focusedCommentID,
+            shouldPersistSelectionState: false
+        )
+    }
+}
+
 struct ReviewSessionTabView: View {
     let worktree: Worktree?
     let tabState: ReviewSessionTabState
@@ -28,6 +76,8 @@ struct ReviewSessionTabView: View {
     @State private var focusedDraftCommentID: String?
     @State private var draftCommentScrollCommand: DiffReviewDraftCommentScrollCommand?
     @State private var draftCommentScrollController = DiffReviewDraftCommentScrollController()
+    @State private var loadCoordinator = ReviewSessionTabLoadCoordinator()
+    @State private var loadGeneration = 0
 
     init(worktree: Worktree, tabState: ReviewSessionTabState, appState: AppState) {
         self.worktree = worktree
@@ -91,16 +141,15 @@ struct ReviewSessionTabView: View {
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
         .background(theme.color("bg-1"))
-        .task(id: tabState.sessionID.rawValue) {
+        .task(id: loadTaskID) {
             guard loadsOnAppear else { return }
-            await loadReviewSession()
+            let token = beginLoadReviewSession()
+            await loadReviewSession(token: token)
         }
-        .onChange(of: selectedFileID) { _, fileID in
-            persistSelectedFile(fileID)
-        }
-        .onChange(of: focusedDraftCommentID) { _, commentID in
-            persistFocusedComment(commentID)
-        }
+    }
+
+    private var loadTaskID: String {
+        "\(tabState.sessionID.rawValue):\(loadGeneration)"
     }
 
     private var header: some View {
@@ -168,7 +217,7 @@ struct ReviewSessionTabView: View {
             }
             if showsRetry {
                 Button("Retry") {
-                    Task { await loadReviewSession() }
+                    loadGeneration += 1
                 }
                 .buttonStyle(.bordered)
                 .controlSize(.small)
@@ -183,7 +232,7 @@ struct ReviewSessionTabView: View {
             session: loaded.session,
             selectedFileID: Binding(
                 get: { selectedFileID },
-                set: { selectedFileID = $0 }
+                set: { setSelectedFileID($0, persist: true) }
             ),
             railCollapsed: $railCollapsed,
             reviewSummaryCollapsed: $reviewSummaryCollapsed,
@@ -278,43 +327,49 @@ struct ReviewSessionTabView: View {
         }
     }
 
-    private func loadReviewSession() async {
+    private func beginLoadReviewSession() -> ReviewSessionTabLoadToken {
+        let token = loadCoordinator.begin()
         isLoading = true
         loadError = nil
         loaded = nil
+        return token
+    }
 
+    private func loadReviewSession(token: ReviewSessionTabLoadToken) async {
         do {
             guard let storedRecord = try sessionStore.load(id: tabState.sessionID) else {
                 throw ReviewSessionTabError.missingSession(tabState.sessionID)
             }
-            record = storedRecord
-            selectedFileID = storedRecord.selectedFileID
-            focusedDraftCommentID = storedRecord.focusedCommentID
-            loadDraftCommentController(for: storedRecord)
 
             let loadedContext = try await loader.load(target: storedRecord.target)
-            loaded = loadedContext
-            selectedFileID = synchronizedSelection(
-                selectedFileID,
-                session: loadedContext.session
+            guard loadCoordinator.canPublish(token) else { return }
+
+            publishInitialLoad(
+                ReviewSessionTabLoadPublication.initial(
+                    record: storedRecord,
+                    loaded: loadedContext
+                )
             )
+            loadDraftCommentController(for: storedRecord)
             isLoading = false
+            loadCoordinator.finish(token)
         } catch is CancellationError {
+            guard loadCoordinator.canPublish(token) else { return }
             isLoading = false
+            loadCoordinator.finish(token)
         } catch {
+            guard loadCoordinator.canPublish(token) else { return }
             loadError = error.localizedDescription
             isLoading = false
+            loadCoordinator.finish(token)
         }
     }
 
-    private func synchronizedSelection(
-        _ selected: DiffReviewFileID?,
-        session: DiffReviewLoadedSession
-    ) -> DiffReviewFileID? {
-        if let selected, session.summary.files.contains(where: { $0.id == selected }) {
-            return selected
-        }
-        return session.summary.files.first?.id
+    private func publishInitialLoad(_ publication: ReviewSessionTabLoadPublication) {
+        record = publication.record
+        loaded = publication.loaded
+        selectedFileID = publication.selectedFileID
+        focusedDraftCommentID = publication.focusedDraftCommentID
     }
 
     private func loadDraftCommentController(for record: ReviewSessionRecord) {
@@ -342,8 +397,8 @@ struct ReviewSessionTabView: View {
     }
 
     private func selectDraftComment(_ comment: ReviewDraftComment) {
-        focusedDraftCommentID = comment.id
-        selectedFileID = comment.fileID
+        setFocusedDraftCommentID(comment.id, persist: true)
+        setSelectedFileID(comment.fileID, persist: true)
         draftCommentScrollCommand = draftCommentScrollController.command(
             commentID: comment.id,
             fileID: comment.fileID
@@ -358,8 +413,23 @@ struct ReviewSessionTabView: View {
         }
     }
 
+    private func setSelectedFileID(_ fileID: DiffReviewFileID?, persist shouldPersist: Bool) {
+        guard selectedFileID != fileID else { return }
+        selectedFileID = fileID
+        guard shouldPersist else { return }
+        persistSelectedFile(fileID)
+    }
+
+    private func setFocusedDraftCommentID(_ commentID: String?, persist shouldPersist: Bool) {
+        guard focusedDraftCommentID != commentID else { return }
+        focusedDraftCommentID = commentID
+        guard shouldPersist else { return }
+        persistFocusedComment(commentID)
+    }
+
     private func persistSelectedFile(_ fileID: DiffReviewFileID?) {
         guard let current = record else { return }
+        guard current.selectedFileID != fileID else { return }
         let updated = current.selectingFile(fileID, now: now())
         persist(updated)
         updateTabState { state in
@@ -369,6 +439,7 @@ struct ReviewSessionTabView: View {
 
     private func persistFocusedComment(_ commentID: String?) {
         guard let current = record else { return }
+        guard current.focusedCommentID != commentID else { return }
         let updated = current.focusingComment(commentID, now: now())
         persist(updated)
         updateTabState { state in

--- a/Alas/Sources/Center/Tab.swift
+++ b/Alas/Sources/Center/Tab.swift
@@ -12,6 +12,7 @@ enum Tab: Codable, Equatable, Identifiable {
     case draftReviewRequest(DraftReviewRequestTabState)
     case reviewEvidence(ReviewEvidenceTabState)
     case reviewChanges(ReviewChangesTabState)
+    case reviewSession(ReviewSessionTabState)
     case imagePreview(ImagePreviewTabState)
     case mergeConflict(MergeConflictTabState)
     case acpSession(ACPSessionTabState)
@@ -27,6 +28,7 @@ enum Tab: Codable, Equatable, Identifiable {
         case .draftReviewRequest(let s): return s.id
         case .reviewEvidence(let s): return s.id
         case .reviewChanges(let s): return s.id
+        case .reviewSession(let s): return s.id
         case .imagePreview(let s): return s.id
         case .mergeConflict(let s): return s.id
         case .acpSession(let s):   return s.id
@@ -44,6 +46,7 @@ enum Tab: Codable, Equatable, Identifiable {
         case .draftReviewRequest(let s): return s.displayTitle
         case .reviewEvidence(let s): return s.displayTitle
         case .reviewChanges:       return "Review Changes"
+        case .reviewSession(let s): return s.title
         case .imagePreview(let s): return s.title
         case .mergeConflict(let s): return s.title
         case .acpSession(let s):   return s.title
@@ -61,6 +64,7 @@ enum Tab: Codable, Equatable, Identifiable {
         case .draftReviewRequest: return "pull-request"
         case .reviewEvidence: return "doc.text.magnifyingglass"
         case .reviewChanges: return "diff"
+        case .reviewSession: return "text.badge.checkmark"
         case .imagePreview: return "image"
         case .mergeConflict: return "diff"
         case .acpSession:   return "sparkle"
@@ -84,6 +88,24 @@ struct ReviewChangesTabState: Codable, Equatable, Identifiable {
     init(worktreeId: String) {
         self.id = "review-changes:\(worktreeId)"
         self.worktreeId = worktreeId
+    }
+}
+
+struct ReviewSessionTabState: Codable, Equatable, Identifiable {
+    let id: TabID
+    let worktreeId: String
+    let sessionID: ReviewSessionID
+    var title: String
+    var selectedFileID: DiffReviewFileID?
+    var focusedCommentID: String?
+
+    init(worktreeId: String, record: ReviewSessionRecord) {
+        self.id = "review-session:\(record.id.rawValue)"
+        self.worktreeId = worktreeId
+        self.sessionID = record.id
+        self.title = record.target.title
+        self.selectedFileID = record.selectedFileID
+        self.focusedCommentID = record.focusedCommentID
     }
 }
 

--- a/Alas/Sources/Center/TabsManager.swift
+++ b/Alas/Sources/Center/TabsManager.swift
@@ -650,6 +650,46 @@ final class TabsManager {
     }
 
     @discardableResult
+    func openOrFocusReviewSession(worktreeId: String, record: ReviewSessionRecord) -> Tab {
+        let baseState = ReviewSessionTabState(worktreeId: worktreeId, record: record)
+        if var file = byWorktree[worktreeId],
+           let idx = file.tabs.firstIndex(where: { $0.id == baseState.id }),
+           case .reviewSession(var existing) = file.tabs[idx] {
+            existing.title = record.target.title
+            existing.selectedFileID = record.selectedFileID
+            existing.focusedCommentID = record.focusedCommentID
+            let tab = Tab.reviewSession(existing)
+            file.tabs[idx] = tab
+            file.activeTabId = tab.id
+            byWorktree[worktreeId] = file
+            persist(worktreeId)
+            return tab
+        }
+
+        let tab = Tab.reviewSession(baseState)
+        append(tab, to: worktreeId)
+        return tab
+    }
+
+    @discardableResult
+    func updateReviewSession(
+        worktreeId: String,
+        tabId: TabID,
+        mutate: (inout ReviewSessionTabState) -> Void
+    ) -> Tab? {
+        guard var file = byWorktree[worktreeId],
+              let idx = file.tabs.firstIndex(where: { $0.id == tabId }),
+              case .reviewSession(var state) = file.tabs[idx]
+        else { return nil }
+        mutate(&state)
+        let tab = Tab.reviewSession(state)
+        file.tabs[idx] = tab
+        byWorktree[worktreeId] = file
+        persist(worktreeId)
+        return tab
+    }
+
+    @discardableResult
     func openOrFocusDraftCommit(worktreeId: String) -> Tab {
         let baseState = DraftCommitTabState(worktreeId: worktreeId)
         if var file = byWorktree[worktreeId],

--- a/Alas/Sources/Persistence/Paths.swift
+++ b/Alas/Sources/Persistence/Paths.swift
@@ -59,6 +59,10 @@ extension Paths {
     static var reviewDraftCommentsFile: URL {
         appSupportRoot.appendingPathComponent("review-draft-comments.json")
     }
+
+    static var reviewSessionsFile: URL {
+        appSupportRoot.appendingPathComponent("review-sessions.json")
+    }
 }
 
 extension Paths {

--- a/AlasTests/CommitTabViewTests.swift
+++ b/AlasTests/CommitTabViewTests.swift
@@ -21,6 +21,24 @@ struct CommitTabViewTests {
         #expect(sessionID.sourceKind == .commit)
     }
 
+    @Test func commitLauncherBuildsCommitTarget() {
+        let target = CommitTabView.reviewSessionTarget(
+            worktreeID: "wt",
+            repositoryPath: URL(fileURLWithPath: "/repo"),
+            sha: "abcdef1234567890",
+            title: "Add review sessions"
+        )
+
+        #expect(target.kind == .commit)
+        #expect(target.draftSessionID == .commit(
+            worktreeID: "wt",
+            repositoryPath: URL(fileURLWithPath: "/repo"),
+            sha: "abcdef1234567890"
+        ))
+        #expect(target.title == "Review Add review sessions")
+        #expect(target.revisionDescription == "abcdef1234567890")
+    }
+
     @Test func commitReviewFeedbackTargetIncludesCommitSHA() {
         let sha = "abcdef1234567890abcdef1234567890abcdef12"
         let target = CommitReviewBody.reviewFeedbackTarget(

--- a/AlasTests/Integrations/ReviewEvidenceModelTests.swift
+++ b/AlasTests/Integrations/ReviewEvidenceModelTests.swift
@@ -23,6 +23,32 @@ struct ReviewEvidenceModelTests {
         #expect(sessionID.sourceKind == .reviewRequest)
     }
 
+    @Test func reviewEvidenceLauncherBuildsReviewRequestTarget() {
+        let snapshot = Self.snapshot()
+        let tabState = ReviewEvidenceTabState(
+            worktreeId: "wt",
+            snapshot: snapshot,
+            initialSection: .files
+        )
+
+        let target = ReviewEvidenceTabView.reviewSessionTarget(
+            worktreeID: "wt",
+            repositoryPath: URL(fileURLWithPath: "/repo"),
+            tabState: tabState
+        )
+
+        #expect(target.kind == .reviewRequest)
+        #expect(target.draftSessionID == .reviewRequest(
+            worktreeID: "wt",
+            provider: .github,
+            host: "github.com",
+            repositorySlug: "mrmans0n/alas",
+            number: 428
+        ))
+        #expect(target.title == "Review loop")
+        #expect(target.providerURL == URL(string: "https://github.com/mrmans0n/alas/pull/428")!)
+    }
+
     @Test func defaultLoadSelectsFilesAndLoadsEvidenceWithoutDetailCalls() async {
         let recorder = EvidenceProviderRecorder()
         let model = ReviewEvidenceModel(

--- a/AlasTests/Integrations/ReviewRequestDraftTests.swift
+++ b/AlasTests/Integrations/ReviewRequestDraftTests.swift
@@ -45,6 +45,31 @@ struct ReviewRequestDraftTests {
         #expect(target.revisionDescription == "abc123")
     }
 
+    @Test func draftReviewRequestLauncherIncludesHeadSHAInTargetIdentity() {
+        var firstState = DraftReviewRequestTabState(
+            worktreeId: "wt",
+            snapshot: Self.snapshot(needsPush: false, aheadCommitCount: 2)
+        )
+        var secondState = firstState
+        firstState.headSHA = "abc123"
+        secondState.headSHA = "def456"
+
+        let first = DraftReviewRequestTabView.reviewSessionTarget(
+            worktreeID: "wt",
+            repositoryPath: URL(fileURLWithPath: "/repo"),
+            tabState: firstState
+        )
+        let second = DraftReviewRequestTabView.reviewSessionTarget(
+            worktreeID: "wt",
+            repositoryPath: URL(fileURLWithPath: "/repo"),
+            tabState: secondState
+        )
+
+        #expect(first.id != second.id)
+        #expect(first.id.rawValue.contains("abc123"))
+        #expect(second.id.rawValue.contains("def456"))
+    }
+
     @Test @MainActor func selectingDraftSummaryCommentFocusesAndSelectsFile() async throws {
         let path = "Sources/A.swift"
         let context = ReviewRequestDraftContext(

--- a/AlasTests/Integrations/ReviewRequestDraftTests.swift
+++ b/AlasTests/Integrations/ReviewRequestDraftTests.swift
@@ -70,6 +70,13 @@ struct ReviewRequestDraftTests {
         #expect(second.id.rawValue.contains("def456"))
     }
 
+    @Test func draftReviewRequestLauncherIsDisabledForStaleTargets() {
+        #expect(DraftReviewRequestTabView.canLaunchReviewSession(targetMismatchMessage: nil))
+        #expect(!DraftReviewRequestTabView.canLaunchReviewSession(
+            targetMismatchMessage: "Switch back to the original branch state."
+        ))
+    }
+
     @Test @MainActor func selectingDraftSummaryCommentFocusesAndSelectsFile() async throws {
         let path = "Sources/A.swift"
         let context = ReviewRequestDraftContext(

--- a/AlasTests/Integrations/ReviewRequestDraftTests.swift
+++ b/AlasTests/Integrations/ReviewRequestDraftTests.swift
@@ -22,6 +22,29 @@ struct ReviewRequestDraftTests {
         #expect(sessionID.sourceKind == .draftReviewRequest)
     }
 
+    @Test func draftReviewRequestLauncherBuildsBranchDiffTarget() {
+        let tabState = DraftReviewRequestTabState(
+            worktreeId: "wt",
+            snapshot: Self.snapshot(needsPush: false, aheadCommitCount: 2)
+        )
+
+        let target = DraftReviewRequestTabView.reviewSessionTarget(
+            worktreeID: "wt",
+            repositoryPath: URL(fileURLWithPath: "/repo"),
+            tabState: tabState
+        )
+
+        #expect(target.kind == .draftReviewRequest)
+        #expect(target.draftSessionID == .draftReviewRequest(
+            worktreeID: "wt",
+            repositoryPath: URL(fileURLWithPath: "/repo"),
+            base: "origin/main",
+            head: "feature/pr-drafts"
+        ))
+        #expect(target.title == "Review draft PR")
+        #expect(target.revisionDescription == "abc123")
+    }
+
     @Test @MainActor func selectingDraftSummaryCommentFocusesAndSelectsFile() async throws {
         let path = "Sources/A.swift"
         let context = ReviewRequestDraftContext(

--- a/AlasTests/ReviewChangesTabViewTests.swift
+++ b/AlasTests/ReviewChangesTabViewTests.swift
@@ -73,6 +73,61 @@ struct ReviewChangesTabViewTests {
         ReviewFeedbackPromptActions.sendToAgent(bundle, target: target, sender: sender)
     }
 
+    @Test func sendToAgentRecordsSessionHandoff() {
+        var sentPrompt: String?
+        var recorded: ReviewFeedbackHandoff?
+        let target = ReviewFeedbackAgentTarget.existingSession(worktreeID: "wt-1", sessionID: "acp-1", title: "Codex")
+        let sender = ReviewFeedbackAgentSender(
+            availableTargets: { [target] },
+            send: { prompt, _ in sentPrompt = prompt }
+        )
+        let sessionID = ReviewSessionID(rawValue: "session-1")
+        let activeComment = draftComment(id: "c1", body: "Fix it")
+        let dismissedComment = ReviewDraftComment(
+            id: "c2",
+            sessionID: activeComment.sessionID,
+            fileID: activeComment.fileID,
+            path: activeComment.path,
+            originalPath: activeComment.originalPath,
+            side: activeComment.side,
+            startLine: activeComment.startLine,
+            endLine: activeComment.endLine,
+            selectedText: activeComment.selectedText,
+            bodyMarkdown: "Ignore it",
+            state: .dismissed,
+            createdAt: activeComment.createdAt,
+            updatedAt: activeComment.updatedAt
+        )
+        let bundle = ReviewFeedbackBundle(
+            target: ReviewFeedbackTarget(
+                title: "Review",
+                repositoryPath: "/repo",
+                providerDescription: nil,
+                sourceDescription: "Local changes"
+            ),
+            comments: [dismissedComment, activeComment]
+        )
+
+        ReviewFeedbackPromptActions.sendToAgent(
+            bundle,
+            target: target,
+            sender: sender,
+            sessionID: sessionID,
+            recordHandoff: { recorded = $0 },
+            now: { Date(timeIntervalSince1970: 30) },
+            makeID: { "handoff-1" }
+        )
+
+        #expect(sentPrompt?.contains("Fix it") == true)
+        #expect(recorded?.id == "handoff-1")
+        #expect(recorded?.sessionID == sessionID)
+        #expect(recorded?.commentIDs == ["c1"])
+        #expect(recorded?.target == target)
+        #expect(recorded?.createdAt == Date(timeIntervalSince1970: 30))
+        #expect(recorded?.promptRevision == ReviewFeedbackHandoff.revisionKey(commentIDs: ["c1"], prompt: sentPrompt ?? ""))
+        #expect(recorded?.status == .sent)
+    }
+
     @Test func draftWorkspaceActionsEditCommentThroughController() throws {
         let directory = FileManager.default.temporaryDirectory
             .appendingPathComponent(UUID().uuidString, isDirectory: true)

--- a/AlasTests/ReviewChangesTabViewTests.swift
+++ b/AlasTests/ReviewChangesTabViewTests.swift
@@ -29,6 +29,22 @@ struct ReviewChangesTabViewTests {
         #expect(sessionID.sourceKind == .localChanges)
     }
 
+    @Test func reviewChangesLauncherBuildsLocalChangesTarget() {
+        let target = ReviewChangesTabView.reviewSessionTarget(
+            worktreeID: "wt-1",
+            repositoryPath: URL(fileURLWithPath: "/repo"),
+            scope: .all
+        )
+
+        #expect(target.kind == .localChanges)
+        #expect(target.draftSessionID == .localChanges(
+            worktreeID: "wt-1",
+            worktreePath: URL(fileURLWithPath: "/repo"),
+            scope: .all
+        ))
+        #expect(target.title == "Review all changes")
+    }
+
     @Test func copyReviewPromptUsesPromptMarkdown() {
         var copiedPrompt: String?
         let bundle = ReviewFeedbackBundle(

--- a/AlasTests/ReviewChangesTabViewTests.swift
+++ b/AlasTests/ReviewChangesTabViewTests.swift
@@ -52,10 +52,11 @@ struct ReviewChangesTabViewTests {
         let target = ReviewFeedbackAgentTarget.newChat(agentID: "codex", title: "New chat")
         let sender = ReviewFeedbackAgentSender(
             availableTargets: { [target] },
-            send: { prompt, selectedTarget in
+            send: { prompt, selectedTarget, completion in
                 #expect(prompt.contains("Please address each review comment below."))
                 #expect(prompt.contains("Extract this helper."))
                 #expect(selectedTarget == target)
+                completion(.success(()))
             }
         )
         let bundle = ReviewFeedbackBundle(
@@ -79,7 +80,10 @@ struct ReviewChangesTabViewTests {
         let target = ReviewFeedbackAgentTarget.existingSession(worktreeID: "wt-1", sessionID: "acp-1", title: "Codex")
         let sender = ReviewFeedbackAgentSender(
             availableTargets: { [target] },
-            send: { prompt, _ in sentPrompt = prompt }
+            send: { prompt, _, completion in
+                sentPrompt = prompt
+                completion(.success(()))
+            }
         )
         let sessionID = ReviewSessionID(rawValue: "session-1")
         let activeComment = draftComment(id: "c1", body: "Fix it")
@@ -128,6 +132,45 @@ struct ReviewChangesTabViewTests {
         #expect(recorded?.status == .sent)
     }
 
+    @Test func failedSendDoesNotRecordSessionHandoffAndReportsError() {
+        var sentPrompt: String?
+        var recorded: ReviewFeedbackHandoff?
+        var sendError: Error?
+        let target = ReviewFeedbackAgentTarget.existingSession(worktreeID: "wt-1", sessionID: "acp-1", title: "Codex")
+        let sender = ReviewFeedbackAgentSender(
+            availableTargets: { [target] },
+            send: { prompt, _, completion in
+                sentPrompt = prompt
+                completion(.failure(ReviewFeedbackAgentSendError.rejected))
+            }
+        )
+        let sessionID = ReviewSessionID(rawValue: "session-1")
+        let bundle = ReviewFeedbackBundle(
+            target: ReviewFeedbackTarget(
+                title: "Review",
+                repositoryPath: "/repo",
+                providerDescription: nil,
+                sourceDescription: "Local changes"
+            ),
+            comments: [draftComment(id: "c1", body: "Fix it")]
+        )
+
+        ReviewFeedbackPromptActions.sendToAgent(
+            bundle,
+            target: target,
+            sender: sender,
+            sessionID: sessionID,
+            recordHandoff: { recorded = $0 },
+            recordSendFailure: { sendError = $0 },
+            now: { Date(timeIntervalSince1970: 30) },
+            makeID: { "handoff-1" }
+        )
+
+        #expect(sentPrompt?.contains("Fix it") == true)
+        #expect(recorded == nil)
+        #expect((sendError as? ReviewFeedbackAgentSendError) == .rejected)
+    }
+
     @Test func draftWorkspaceActionsEditCommentThroughController() throws {
         let directory = FileManager.default.temporaryDirectory
             .appendingPathComponent(UUID().uuidString, isDirectory: true)
@@ -147,7 +190,7 @@ struct ReviewChangesTabViewTests {
         )
         let sender = ReviewFeedbackAgentSender(
             availableTargets: { [] },
-            send: { _, _ in Issue.record("send should not be called") }
+            send: { _, _, _ in Issue.record("send should not be called") }
         )
         let anchor = DiffReviewLineAnchor(
             path: "Sources/App.swift",
@@ -179,7 +222,10 @@ struct ReviewChangesTabViewTests {
         var selectedTarget: ReviewFeedbackAgentTarget?
         let sender = ReviewFeedbackAgentSender(
             availableTargets: { [codex, claude] },
-            send: { _, target in selectedTarget = target }
+            send: { _, target, completion in
+                selectedTarget = target
+                completion(.success(()))
+            }
         )
         let comment = draftComment(id: "draft-1", body: "Extract this helper.")
         let bundle = ReviewFeedbackBundle(

--- a/AlasTests/ReviewChangesTabViewTests.swift
+++ b/AlasTests/ReviewChangesTabViewTests.swift
@@ -45,6 +45,61 @@ struct ReviewChangesTabViewTests {
         #expect(target.title == "Review all changes")
     }
 
+    @Test func reviewChangesLauncherUsesDistinctActionLabel() {
+        #expect(ReviewChangesTabView.reviewSessionLauncherLabel == "Open review session")
+    }
+
+    @Test func reviewSessionLauncherOpensExistingRecordWithoutSaving() {
+        let target = ReviewChangesTabView.reviewSessionTarget(
+            worktreeID: "wt-1",
+            repositoryPath: URL(fileURLWithPath: "/repo"),
+            scope: .all
+        )
+        let existing = ReviewSessionRecord(
+            id: target.id,
+            target: target,
+            createdAt: Date(timeIntervalSince1970: 1),
+            updatedAt: Date(timeIntervalSince1970: 2)
+        )
+        var savedRecords: [ReviewSessionRecord] = []
+        var openedRecords: [ReviewSessionRecord] = []
+
+        let opened = ReviewSessionLauncher.openOrFocus(
+            target: target,
+            now: { Date(timeIntervalSince1970: 10) },
+            findActive: { _ in existing },
+            save: { savedRecords.append($0) },
+            open: { openedRecords.append($0) }
+        )
+
+        #expect(opened)
+        #expect(savedRecords.isEmpty)
+        #expect(openedRecords == [existing])
+    }
+
+    @Test func reviewSessionLauncherDoesNotOpenNewRecordWhenSaveFails() {
+        let target = ReviewChangesTabView.reviewSessionTarget(
+            worktreeID: "wt-1",
+            repositoryPath: URL(fileURLWithPath: "/repo"),
+            scope: .all
+        )
+        var openedRecords: [ReviewSessionRecord] = []
+        var reportedError: Error?
+
+        let opened = ReviewSessionLauncher.openOrFocus(
+            target: target,
+            now: { Date(timeIntervalSince1970: 10) },
+            findActive: { _ in nil },
+            save: { _ in throw LauncherTestError.saveFailed },
+            open: { openedRecords.append($0) },
+            onFailure: { reportedError = $0 }
+        )
+
+        #expect(!opened)
+        #expect(openedRecords.isEmpty)
+        #expect((reportedError as? LauncherTestError) == .saveFailed)
+    }
+
     @Test func copyReviewPromptUsesPromptMarkdown() {
         var copiedPrompt: String?
         let bundle = ReviewFeedbackBundle(
@@ -531,5 +586,9 @@ struct ReviewChangesTabViewTests {
             createdAt: Date(timeIntervalSince1970: 1),
             updatedAt: Date(timeIntervalSince1970: 1)
         )
+    }
+
+    private enum LauncherTestError: Error, Equatable {
+        case saveFailed
     }
 }

--- a/AlasTests/ReviewFeedbackBundleTests.swift
+++ b/AlasTests/ReviewFeedbackBundleTests.swift
@@ -202,6 +202,39 @@ struct ReviewFeedbackBundleTests {
         #expect(prompt.contains(">         run()"))
     }
 
+    @Test func promptIncludesReviewSessionRevisionAndPreviousHandoff() {
+        let target = ReviewFeedbackTarget(
+            title: "Review deadbeef",
+            repositoryPath: "/repo",
+            providerDescription: nil,
+            sourceDescription: "Commit deadbeef",
+            sessionDescription: "Review session: commit deadbeef",
+            revisionDescription: "deadbeef",
+            priorHandoffDescription: "Previously sent to Codex at 1970-01-01 00:00:30 +0000"
+        )
+        let comment = ReviewDraftComment(
+            id: "c1",
+            sessionID: .commit(worktreeID: "wt-1", repositoryPath: URL(fileURLWithPath: "/repo"), sha: "deadbeef"),
+            fileID: DiffReviewFileID(namespace: "commit", path: "Sources/A.swift"),
+            path: "Sources/A.swift",
+            originalPath: nil,
+            side: .new,
+            startLine: 10,
+            endLine: nil,
+            selectedText: nil,
+            bodyMarkdown: "Fix this",
+            state: .active,
+            createdAt: Date(timeIntervalSince1970: 1),
+            updatedAt: Date(timeIntervalSince1970: 1)
+        )
+
+        let prompt = ReviewFeedbackBundle(target: target, comments: [comment]).promptMarkdown()
+
+        #expect(prompt.contains("Review session: commit deadbeef"))
+        #expect(prompt.contains("Revision: deadbeef"))
+        #expect(prompt.contains("Previously sent to Codex"))
+    }
+
     private func comment(
         id: String,
         session: ReviewDraftSessionID,

--- a/AlasTests/ReviewSessionLoaderTests.swift
+++ b/AlasTests/ReviewSessionLoaderTests.swift
@@ -97,6 +97,119 @@ struct ReviewSessionLoaderTests {
         #expect(loaded.feedbackTarget.sourceDescription == "Commit deadbeef")
     }
 
+    @MainActor
+    @Test func productionLoaderRejectsStoredProviderReviewRequestWithoutSnapshotData() async throws {
+        let repo = FileManager.default.temporaryDirectory
+            .appendingPathComponent("alas-review-session-loader-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: repo, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: repo) }
+        _ = try await Process.git(["init", "-q", "-b", "main"], cwd: repo)
+
+        let worktree = Worktree(
+            id: Worktree.makeId(path: repo),
+            projectId: "project-1",
+            name: "main",
+            branch: "main",
+            path: repo,
+            status: .clean,
+            lastActivity: Date(timeIntervalSince1970: 1)
+        )
+        let target = ReviewSessionTarget.reviewRequest(
+            worktreeID: worktree.id,
+            repositoryPath: repo,
+            provider: .github,
+            host: "github.com",
+            repositorySlug: "mrmans0n/alas",
+            number: 428,
+            url: URL(string: "https://github.com/mrmans0n/alas/pull/428")!,
+            title: "Review loop",
+            headSHA: "abc123"
+        )
+        let loader = ReviewSessionLoader.production(
+            appState: AppState(store: MemoryStore()),
+            worktree: worktree
+        )
+
+        do {
+            _ = try await loader.load(target: target)
+            Issue.record("Expected stored provider review request to be unsupported without snapshot data")
+        } catch let error as ReviewSessionLoaderError {
+            #expect(error == .unsupportedTarget)
+        }
+    }
+
+    @MainActor
+    @Test func productionLoaderRejectsBranchTargetUntilStoredDiffLoadingIsWired() async throws {
+        let repo = FileManager.default.temporaryDirectory
+            .appendingPathComponent("alas-review-session-loader-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: repo, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: repo) }
+        _ = try await Process.git(["init", "-q", "-b", "main"], cwd: repo)
+
+        let worktree = Worktree(
+            id: Worktree.makeId(path: repo),
+            projectId: "project-1",
+            name: "main",
+            branch: "main",
+            path: repo,
+            status: .clean,
+            lastActivity: Date(timeIntervalSince1970: 1)
+        )
+        let target = ReviewSessionTarget.branch(
+            worktreeID: worktree.id,
+            repositoryPath: repo,
+            base: "main",
+            head: "feature"
+        )
+        let loader = ReviewSessionLoader.production(
+            appState: AppState(store: MemoryStore()),
+            worktree: worktree
+        )
+
+        do {
+            _ = try await loader.load(target: target)
+            Issue.record("Expected branch targets to stay unsupported until stored diff loading is wired")
+        } catch let error as ReviewSessionLoaderError {
+            #expect(error == .unsupportedTarget)
+        }
+    }
+
+    @MainActor
+    @Test func productionLoaderRejectsCommitRangeTargetUntilStoredDiffLoadingIsWired() async throws {
+        let repo = FileManager.default.temporaryDirectory
+            .appendingPathComponent("alas-review-session-loader-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: repo, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: repo) }
+        _ = try await Process.git(["init", "-q", "-b", "main"], cwd: repo)
+
+        let worktree = Worktree(
+            id: Worktree.makeId(path: repo),
+            projectId: "project-1",
+            name: "main",
+            branch: "main",
+            path: repo,
+            status: .clean,
+            lastActivity: Date(timeIntervalSince1970: 1)
+        )
+        let target = ReviewSessionTarget.commitRange(
+            worktreeID: worktree.id,
+            repositoryPath: repo,
+            base: "main",
+            head: "HEAD"
+        )
+        let loader = ReviewSessionLoader.production(
+            appState: AppState(store: MemoryStore()),
+            worktree: worktree
+        )
+
+        do {
+            _ = try await loader.load(target: target)
+            Issue.record("Expected commit-range targets to stay unsupported until stored diff loading is wired")
+        } catch let error as ReviewSessionLoaderError {
+            #expect(error == .unsupportedTarget)
+        }
+    }
+
     private struct MemoryStore: PersistenceStoreProtocol {
         func write<T: Encodable>(_ value: T, to url: URL) throws {}
 

--- a/AlasTests/ReviewSessionLoaderTests.swift
+++ b/AlasTests/ReviewSessionLoaderTests.swift
@@ -4,6 +4,46 @@ import Testing
 
 @Suite("Review session loader")
 struct ReviewSessionLoaderTests {
+    @MainActor
+    @Test func productionLoaderLoadsLocalChangesFromWorktree() async throws {
+        let repo = FileManager.default.temporaryDirectory
+            .appendingPathComponent("alas-review-session-loader-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: repo, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: repo) }
+        _ = try await Process.git(["init", "-q", "-b", "main"], cwd: repo)
+
+        let worktree = Worktree(
+            id: Worktree.makeId(path: repo),
+            projectId: "project-1",
+            name: "main",
+            branch: "main",
+            path: repo,
+            status: .clean,
+            lastActivity: Date(timeIntervalSince1970: 1)
+        )
+        let target = ReviewSessionTarget.localChanges(
+            worktreeID: worktree.id,
+            repositoryPath: repo,
+            scope: .all
+        )
+        let loader = ReviewSessionLoader.production(
+            appState: AppState(store: MemoryStore()),
+            worktree: worktree
+        )
+
+        let loaded = try await loader.load(target: target)
+        let draftCommitTarget = ReviewSessionTarget.draftCommit(
+            worktreeID: worktree.id,
+            repositoryPath: repo
+        )
+        let draftCommitLoaded = try await loader.load(target: draftCommitTarget)
+
+        #expect(loaded.session.files.isEmpty)
+        #expect(loaded.feedbackTarget.title == "Review all changes")
+        #expect(draftCommitLoaded.session.files.isEmpty)
+        #expect(draftCommitLoaded.feedbackTarget.title == "Review draft commit")
+    }
+
     @Test func localChangesLoaderBuildsGroupedSessionAndFeedbackTarget() async throws {
         let target = ReviewSessionTarget.localChanges(
             worktreeID: "wt-1",
@@ -55,5 +95,13 @@ struct ReviewSessionLoaderTests {
         let loaded = try await loader.load(target: target)
 
         #expect(loaded.feedbackTarget.sourceDescription == "Commit deadbeef")
+    }
+
+    private struct MemoryStore: PersistenceStoreProtocol {
+        func write<T: Encodable>(_ value: T, to url: URL) throws {}
+
+        func readIfExists<T: Decodable>(_ type: T.Type, from url: URL) throws -> T? {
+            nil
+        }
     }
 }

--- a/AlasTests/ReviewSessionLoaderTests.swift
+++ b/AlasTests/ReviewSessionLoaderTests.swift
@@ -1,0 +1,59 @@
+import Foundation
+import Testing
+@testable import Alas
+
+@Suite("Review session loader")
+struct ReviewSessionLoaderTests {
+    @Test func localChangesLoaderBuildsGroupedSessionAndFeedbackTarget() async throws {
+        let target = ReviewSessionTarget.localChanges(
+            worktreeID: "wt-1",
+            repositoryPath: URL(fileURLWithPath: "/repo"),
+            scope: .all
+        )
+        let loader = ReviewSessionLoader(
+            localChanges: { target in
+                #expect(target.kind == .localChanges)
+                let summary = DiffReviewFileSummary(
+                    path: "Sources/A.swift",
+                    namespace: "unstaged",
+                    groupID: "unstaged",
+                    groupTitle: "Unstaged",
+                    status: .modified,
+                    additions: 1,
+                    deletions: 0,
+                    isRenderable: true
+                )
+                return DiffReviewLoadedSession(
+                    files: [DiffReviewFileSectionModel(summary: summary, parsedDiff: nil, displayModel: nil, placeholderMessage: nil, openFile: nil)],
+                    summary: DiffReviewSessionModel(files: [summary], groupsEnabled: true)
+                )
+            }
+        )
+
+        let loaded = try await loader.load(target: target)
+
+        #expect(loaded.session.summary.fileCount == 1)
+        #expect(loaded.feedbackTarget.title == "Review all changes")
+        #expect(loaded.feedbackTarget.repositoryPath == "/repo")
+        #expect(loaded.feedbackTarget.sourceDescription == "Local changes: all")
+    }
+
+    @Test func commitLoaderBuildsPinnedSourceDescription() async throws {
+        let target = ReviewSessionTarget.commit(
+            worktreeID: "wt-1",
+            repositoryPath: URL(fileURLWithPath: "/repo"),
+            sha: "deadbeef",
+            title: "Review deadbeef"
+        )
+        let loader = ReviewSessionLoader(
+            commit: { target in
+                #expect(target.revisionDescription == "deadbeef")
+                return DiffReviewLoadedSession(files: [], summary: DiffReviewSessionModel(files: [], groupsEnabled: false))
+            }
+        )
+
+        let loaded = try await loader.load(target: target)
+
+        #expect(loaded.feedbackTarget.sourceDescription == "Commit deadbeef")
+    }
+}

--- a/AlasTests/ReviewSessionModelsTests.swift
+++ b/AlasTests/ReviewSessionModelsTests.swift
@@ -86,7 +86,7 @@ struct ReviewSessionModelsTests {
         )
 
         #expect(target.kind == .draftReviewRequest)
-        #expect(target.id.rawValue == "draft-review-request\u{1f}wt-1\u{1f}/repo\u{1f}gitlab\u{1f}mrmans0n/alas\u{1f}main\u{1f}feature")
+        #expect(target.id.rawValue == "draft-review-request\u{1f}wt-1\u{1f}/repo\u{1f}gitlab\u{1f}mrmans0n/alas\u{1f}main\u{1f}feature\u{1f}abc123")
         #expect(target.draftSessionID == .draftReviewRequest(worktreeID: "wt-1", repositoryPath: repositoryPath, base: "main", head: "feature"))
         #expect(target.providerDescription == "GitLab mrmans0n/alas")
         #expect(target.revisionDescription == "abc123")

--- a/AlasTests/ReviewSessionModelsTests.swift
+++ b/AlasTests/ReviewSessionModelsTests.swift
@@ -1,0 +1,144 @@
+import Foundation
+import Testing
+@testable import Alas
+
+@Suite("Review session models")
+struct ReviewSessionModelsTests {
+    @Test func localChangesTargetDerivesStableIDs() {
+        let repositoryPath = URL(fileURLWithPath: "/repo")
+        let target = ReviewSessionTarget.localChanges(
+            worktreeID: "wt-1",
+            repositoryPath: repositoryPath,
+            scope: .unstaged
+        )
+
+        #expect(target.kind == .localChanges)
+        #expect(target.id.rawValue == "local-changes\u{1f}wt-1\u{1f}/repo\u{1f}unstaged")
+        #expect(target.draftSessionID == .localChanges(worktreeID: "wt-1", worktreePath: repositoryPath, scope: .unstaged))
+        #expect(target.title == "Review unstaged changes")
+        #expect(target.sourceDescription == "Local changes: unstaged")
+    }
+
+    @Test func providerTargetIncludesProviderIdentity() {
+        let target = ReviewSessionTarget.reviewRequest(
+            worktreeID: "wt-1",
+            provider: .github,
+            host: "GitHub.com",
+            repositorySlug: "mrmans0n/alas",
+            number: 520,
+            url: URL(string: "https://github.com/mrmans0n/alas/pull/520")!,
+            title: "Use shared surface",
+            headSHA: "abc123"
+        )
+
+        #expect(target.kind == .reviewRequest)
+        #expect(target.id.rawValue.contains("github"))
+        #expect(target.id.rawValue.contains("github.com"))
+        #expect(target.draftSessionID == .reviewRequest(worktreeID: "wt-1", provider: .github, host: "github.com", repositorySlug: "mrmans0n/alas", number: 520))
+        #expect(target.providerDescription == "GitHub mrmans0n/alas #520")
+        #expect(target.revisionDescription == "abc123")
+    }
+
+    @Test func commitStyleTargetsDeriveDraftSessions() {
+        let repositoryPath = URL(fileURLWithPath: "/repo/../repo")
+        let draft = ReviewSessionTarget.draftCommit(worktreeID: "wt-1", repositoryPath: repositoryPath)
+        let commit = ReviewSessionTarget.commit(
+            worktreeID: "wt-1",
+            repositoryPath: repositoryPath,
+            sha: "deadbeef",
+            title: "Review deadbeef"
+        )
+        let range = ReviewSessionTarget.commitRange(
+            worktreeID: "wt-1",
+            repositoryPath: repositoryPath,
+            base: "main",
+            head: "feature"
+        )
+        let branch = ReviewSessionTarget.branch(
+            worktreeID: "wt-1",
+            repositoryPath: repositoryPath,
+            base: "main",
+            head: "feature"
+        )
+
+        #expect(draft.draftSessionID == .draftCommit(worktreeID: "wt-1", repositoryPath: repositoryPath))
+        #expect(commit.draftSessionID == .commit(worktreeID: "wt-1", repositoryPath: repositoryPath, sha: "deadbeef"))
+        #expect(range.draftSessionID == .branch(worktreeID: "wt-1", repositoryPath: repositoryPath, base: "main", head: "feature"))
+        #expect(branch.draftSessionID == .branch(worktreeID: "wt-1", repositoryPath: repositoryPath, base: "main", head: "feature"))
+        #expect(draft.id.rawValue == "draft-commit\u{1f}wt-1\u{1f}/repo")
+        #expect(commit.sourceDescription == "Commit deadbeef")
+        #expect(range.sourceDescription == "Commit range main..feature")
+        #expect(branch.sourceDescription == "Branch feature against main")
+    }
+
+    @Test func draftReviewRequestTargetUsesRepositoryPathDraftID() {
+        let repositoryPath = URL(fileURLWithPath: "/repo")
+        let target = ReviewSessionTarget.draftReviewRequest(
+            worktreeID: "wt-1",
+            repositoryPath: repositoryPath,
+            provider: .gitlab,
+            repositorySlug: "mrmans0n/alas",
+            base: "main",
+            head: "feature",
+            headSHA: "abc123"
+        )
+
+        #expect(target.kind == .draftReviewRequest)
+        #expect(target.id.rawValue == "draft-review-request\u{1f}wt-1\u{1f}/repo\u{1f}gitlab\u{1f}mrmans0n/alas\u{1f}main\u{1f}feature")
+        #expect(target.draftSessionID == .draftReviewRequest(worktreeID: "wt-1", repositoryPath: repositoryPath, base: "main", head: "feature"))
+        #expect(target.providerDescription == "GitLab mrmans0n/alas")
+        #expect(target.revisionDescription == "abc123")
+    }
+
+    @Test func handoffTransitionsToSentAndAddressed() {
+        let record = ReviewSessionRecord(
+            id: ReviewSessionID(rawValue: "session-1"),
+            target: .commit(
+                worktreeID: "wt-1",
+                repositoryPath: URL(fileURLWithPath: "/repo"),
+                sha: "deadbeef",
+                title: "Review deadbeef"
+            ),
+            createdAt: Date(timeIntervalSince1970: 10),
+            updatedAt: Date(timeIntervalSince1970: 20)
+        )
+        let handoff = ReviewFeedbackHandoff(
+            id: "handoff-1",
+            sessionID: record.id,
+            commentIDs: ["c1", "c2"],
+            target: .existingSession(worktreeID: "wt-1", sessionID: "acp-1", title: "Codex"),
+            createdAt: Date(timeIntervalSince1970: 30),
+            promptRevision: "rev-1",
+            status: .sent
+        )
+
+        let withHandoff = record.recording(handoff: handoff)
+        #expect(withHandoff.status == .sent)
+        #expect(withHandoff.updatedAt == Date(timeIntervalSince1970: 30))
+        #expect(withHandoff.handoffs == [handoff])
+        #expect(withHandoff.markedAddressed(now: Date(timeIntervalSince1970: 40)).status == .addressed)
+    }
+
+    @Test func recordSelectionHelpersUpdateStateAndTimestamp() {
+        let target = ReviewSessionTarget.localChanges(
+            worktreeID: "wt-1",
+            repositoryPath: URL(fileURLWithPath: "/repo"),
+            scope: .all
+        )
+        let record = ReviewSessionRecord(
+            id: target.id,
+            target: target,
+            createdAt: Date(timeIntervalSince1970: 10),
+            updatedAt: Date(timeIntervalSince1970: 10)
+        )
+        let fileID = DiffReviewFileID(namespace: "unstaged", path: "Sources/A.swift")
+
+        let selected = record.selectingFile(fileID, now: Date(timeIntervalSince1970: 20))
+        #expect(selected.selectedFileID == fileID)
+        #expect(selected.updatedAt == Date(timeIntervalSince1970: 20))
+
+        let focused = selected.focusingComment("comment-1", now: Date(timeIntervalSince1970: 30))
+        #expect(focused.focusedCommentID == "comment-1")
+        #expect(focused.updatedAt == Date(timeIntervalSince1970: 30))
+    }
+}

--- a/AlasTests/ReviewSessionModelsTests.swift
+++ b/AlasTests/ReviewSessionModelsTests.swift
@@ -20,8 +20,10 @@ struct ReviewSessionModelsTests {
     }
 
     @Test func providerTargetIncludesProviderIdentity() {
+        let repositoryPath = URL(fileURLWithPath: "/repo/../repo")
         let target = ReviewSessionTarget.reviewRequest(
             worktreeID: "wt-1",
+            repositoryPath: repositoryPath,
             provider: .github,
             host: "GitHub.com",
             repositorySlug: "mrmans0n/alas",
@@ -32,8 +34,8 @@ struct ReviewSessionModelsTests {
         )
 
         #expect(target.kind == .reviewRequest)
-        #expect(target.id.rawValue.contains("github"))
-        #expect(target.id.rawValue.contains("github.com"))
+        #expect(target.repositoryPath.path == "/repo")
+        #expect(target.id.rawValue == "review-request\u{1f}wt-1\u{1f}/repo\u{1f}github\u{1f}github.com\u{1f}mrmans0n/alas\u{1f}520")
         #expect(target.draftSessionID == .reviewRequest(worktreeID: "wt-1", provider: .github, host: "github.com", repositorySlug: "mrmans0n/alas", number: 520))
         #expect(target.providerDescription == "GitHub mrmans0n/alas #520")
         #expect(target.revisionDescription == "abc123")

--- a/AlasTests/ReviewSessionModelsTests.swift
+++ b/AlasTests/ReviewSessionModelsTests.swift
@@ -121,6 +121,15 @@ struct ReviewSessionModelsTests {
         #expect(withHandoff.markedAddressed(now: Date(timeIntervalSince1970: 40)).status == .addressed)
     }
 
+    @Test func promptRevisionChangesWhenIncludedCommentsChange() {
+        let first = ReviewFeedbackHandoff.revisionKey(commentIDs: ["b", "a"], prompt: "hello")
+        let second = ReviewFeedbackHandoff.revisionKey(commentIDs: ["a", "b"], prompt: "hello")
+        let third = ReviewFeedbackHandoff.revisionKey(commentIDs: ["a", "b"], prompt: "different")
+
+        #expect(first == second)
+        #expect(first != third)
+    }
+
     @Test func recordSelectionHelpersUpdateStateAndTimestamp() {
         let target = ReviewSessionTarget.localChanges(
             worktreeID: "wt-1",

--- a/AlasTests/ReviewSessionStoreTests.swift
+++ b/AlasTests/ReviewSessionStoreTests.swift
@@ -75,6 +75,30 @@ struct ReviewSessionStoreTests {
         #expect(try store.load(id: target.id)?.status == .archived)
     }
 
+    @Test func findActiveMatchesTargetIDWhenRecordIDDiffers() throws {
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+            .appendingPathComponent("review-sessions.json")
+        let store = ReviewSessionStore(url: url)
+        let target = ReviewSessionTarget.commit(
+            worktreeID: "wt-1",
+            repositoryPath: URL(fileURLWithPath: "/repo"),
+            sha: "abc123",
+            title: "Review abc123"
+        )
+        let record = ReviewSessionRecord(
+            id: ReviewSessionID(rawValue: "session-override"),
+            target: target,
+            createdAt: Date(timeIntervalSince1970: 1),
+            updatedAt: Date(timeIntervalSince1970: 2)
+        )
+
+        try store.save(record)
+
+        #expect(try store.load(id: record.id) == record)
+        #expect(try store.findActive(targetID: target.id) == record)
+    }
+
     private func makeRecord(id: String, worktreeID: String, updatedAt: TimeInterval) -> ReviewSessionRecord {
         let target = ReviewSessionTarget.commit(
             worktreeID: worktreeID,

--- a/AlasTests/ReviewSessionStoreTests.swift
+++ b/AlasTests/ReviewSessionStoreTests.swift
@@ -1,0 +1,92 @@
+import Foundation
+import Testing
+@testable import Alas
+
+@Suite("Review session store")
+struct ReviewSessionStoreTests {
+    @Test func roundTripsSessionRecords() throws {
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+            .appendingPathComponent("review-sessions.json")
+        let store = ReviewSessionStore(url: url)
+        let target = ReviewSessionTarget.commit(
+            worktreeID: "wt-1",
+            repositoryPath: URL(fileURLWithPath: "/repo"),
+            sha: "abc123",
+            title: "Review abc123"
+        )
+        let record = ReviewSessionRecord(
+            id: target.id,
+            target: target,
+            selectedFileID: DiffReviewFileID(namespace: "commit", path: "Sources/A.swift"),
+            focusedCommentID: "comment-1",
+            status: .active,
+            handoffs: [],
+            lastSendError: nil,
+            createdAt: Date(timeIntervalSince1970: 1),
+            updatedAt: Date(timeIntervalSince1970: 2)
+        )
+
+        try store.save(record)
+
+        #expect(try store.load(id: target.id) == record)
+        #expect(try store.findActive(targetID: target.id) == record)
+        #expect(try store.list(worktreeID: "wt-1") == [record])
+    }
+
+    @Test func listSortsByUpdatedAtDescendingWithinWorktree() throws {
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+            .appendingPathComponent("review-sessions.json")
+        let store = ReviewSessionStore(url: url)
+        let older = makeRecord(id: "older", worktreeID: "wt-1", updatedAt: 10)
+        let newer = makeRecord(id: "newer", worktreeID: "wt-1", updatedAt: 20)
+        let otherWorktree = makeRecord(id: "other", worktreeID: "wt-2", updatedAt: 30)
+
+        try store.save(older)
+        try store.save(otherWorktree)
+        try store.save(newer)
+
+        #expect(try store.list(worktreeID: "wt-1").map(\.id.rawValue) == ["newer", "older"])
+    }
+
+    @Test func archiveRemovesSessionFromActiveReuse() throws {
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+            .appendingPathComponent("review-sessions.json")
+        let store = ReviewSessionStore(url: url)
+        let target = ReviewSessionTarget.localChanges(
+            worktreeID: "wt-1",
+            repositoryPath: URL(fileURLWithPath: "/repo"),
+            scope: .all
+        )
+        var record = ReviewSessionRecord(
+            id: target.id,
+            target: target,
+            createdAt: Date(timeIntervalSince1970: 1),
+            updatedAt: Date(timeIntervalSince1970: 1)
+        )
+        try store.save(record)
+
+        record.status = .archived
+        try store.save(record)
+
+        #expect(try store.findActive(targetID: target.id) == nil)
+        #expect(try store.load(id: target.id)?.status == .archived)
+    }
+
+    private func makeRecord(id: String, worktreeID: String, updatedAt: TimeInterval) -> ReviewSessionRecord {
+        let target = ReviewSessionTarget.commit(
+            worktreeID: worktreeID,
+            repositoryPath: URL(fileURLWithPath: "/repo"),
+            sha: id,
+            title: "Review \(id)"
+        )
+        return ReviewSessionRecord(
+            id: ReviewSessionID(rawValue: id),
+            target: target,
+            createdAt: Date(timeIntervalSince1970: 1),
+            updatedAt: Date(timeIntervalSince1970: updatedAt)
+        )
+    }
+}

--- a/AlasTests/ReviewSessionTabViewTests.swift
+++ b/AlasTests/ReviewSessionTabViewTests.swift
@@ -6,6 +6,63 @@ import Testing
 
 @MainActor
 struct ReviewSessionTabViewTests {
+    @Test func initialLoadPublicationDoesNotRequestPersistenceForRestoredSelection() {
+        let selected = DiffReviewFileID(namespace: "unstaged", path: "A.swift")
+        let target = ReviewSessionTarget.localChanges(
+            worktreeID: "wt-1",
+            repositoryPath: URL(fileURLWithPath: "/repo"),
+            scope: .all
+        )
+        let record = ReviewSessionRecord(
+            id: target.id,
+            target: target,
+            selectedFileID: selected,
+            focusedCommentID: "draft-1",
+            createdAt: .init(timeIntervalSince1970: 1),
+            updatedAt: .init(timeIntervalSince1970: 20)
+        )
+        let loaded = ReviewSessionLoadedContext(
+            session: DiffReviewLoadedSession(
+                files: [Self.file(path: "A.swift", namespace: "unstaged")],
+                summary: DiffReviewSessionModel(
+                    files: [Self.summary(path: "A.swift", namespace: "unstaged")],
+                    groupsEnabled: true
+                )
+            ),
+            feedbackTarget: ReviewFeedbackTarget(
+                title: target.title,
+                repositoryPath: "/repo",
+                providerDescription: nil,
+                sourceDescription: target.sourceDescription
+            )
+        )
+
+        let publication = ReviewSessionTabLoadPublication.initial(record: record, loaded: loaded)
+
+        #expect(publication.record.updatedAt == Date(timeIntervalSince1970: 20))
+        #expect(publication.selectedFileID == selected)
+        #expect(publication.focusedDraftCommentID == "draft-1")
+        #expect(!publication.shouldPersistSelectionState)
+    }
+
+    @Test func loadCoordinatorRejectsOlderCompletionAfterNewerLoadStarts() {
+        var coordinator = ReviewSessionTabLoadCoordinator()
+        let older = coordinator.begin()
+        let newer = coordinator.begin()
+        var published = "newer"
+
+        if coordinator.canPublish(older) {
+            published = "older"
+        }
+
+        #expect(!coordinator.canPublish(older))
+        #expect(coordinator.canPublish(newer))
+        #expect(published == "newer")
+
+        coordinator.finish(newer)
+        #expect(!coordinator.canPublish(older))
+    }
+
     @Test func rendersLoadedSessionTitleAndSummaryRail() throws {
         let target = ReviewSessionTarget.localChanges(
             worktreeID: "wt-1",
@@ -69,5 +126,28 @@ struct ReviewSessionTabViewTests {
             return view
         }
         return view.subviews.lazy.compactMap { subview(withAccessibilityIdentifier: identifier, in: $0) }.first
+    }
+
+    private static func summary(path: String, namespace: String) -> DiffReviewFileSummary {
+        DiffReviewFileSummary(
+            path: path,
+            namespace: namespace,
+            groupID: namespace,
+            groupTitle: "Unstaged",
+            status: .modified,
+            additions: 1,
+            deletions: 0,
+            isRenderable: false
+        )
+    }
+
+    private static func file(path: String, namespace: String) -> DiffReviewFileSectionModel {
+        DiffReviewFileSectionModel(
+            summary: summary(path: path, namespace: namespace),
+            parsedDiff: nil,
+            displayModel: nil,
+            placeholderMessage: "No diff",
+            openFile: nil
+        )
     }
 }

--- a/AlasTests/ReviewSessionTabViewTests.swift
+++ b/AlasTests/ReviewSessionTabViewTests.swift
@@ -159,6 +159,64 @@ struct ReviewSessionTabViewTests {
         #expect(recursiveDescription(host).contains("Sent to agent"))
     }
 
+    @Test func handoffPersistenceFailureKeepsSuccessfulSendVisible() throws {
+        let target = ReviewSessionTarget.localChanges(
+            worktreeID: "wt-1",
+            repositoryPath: URL(fileURLWithPath: "/repo"),
+            scope: .all
+        )
+        let handoff = ReviewFeedbackHandoff(
+            id: "handoff-1",
+            sessionID: target.id,
+            commentIDs: ["draft-1"],
+            target: .existingSession(worktreeID: "wt-1", sessionID: "acp-1", title: "Codex"),
+            createdAt: Date(timeIntervalSince1970: 30),
+            promptRevision: "revision-1",
+            status: .sent
+        )
+        let record = ReviewSessionRecord(
+            id: target.id,
+            target: target,
+            createdAt: .init(timeIntervalSince1970: 1),
+            updatedAt: .init(timeIntervalSince1970: 1)
+        )
+        let store = ReviewSessionStore(
+            store: FailingPersistenceStore(error: TestPersistenceError()),
+            url: URL(fileURLWithPath: "/tmp/review-sessions.json")
+        )
+
+        let updated = ReviewSessionHandoffPersistence.record(
+            handoff,
+            currentRecord: record,
+            sessionStore: store,
+            persistsState: true,
+            now: { Date(timeIntervalSince1970: 40) }
+        )
+
+        #expect(updated?.handoffs.isEmpty == true)
+        #expect(updated?.lastSendError == "Sent to agent, but failed to save handoff record: save failed")
+
+        let loaded = ReviewSessionLoadedContext(
+            session: DiffReviewLoadedSession(
+                files: [Self.file(path: "A.swift", namespace: "unstaged")],
+                summary: DiffReviewSessionModel(files: [Self.summary(path: "A.swift", namespace: "unstaged")], groupsEnabled: true)
+            ),
+            feedbackTarget: ReviewFeedbackTarget(
+                title: target.title,
+                repositoryPath: "/repo",
+                providerDescription: nil,
+                sourceDescription: target.sourceDescription
+            )
+        )
+        let view = ReviewSessionTabView.preview(record: try #require(updated), loaded: loaded)
+            .environment(\.theme, try ThemeStore().current)
+
+        let host = NSHostingView(rootView: view.frame(width: 900, height: 700))
+        host.layoutSubtreeIfNeeded()
+
+        #expect(recursiveDescription(host).contains("Sent to agent, but failed to save handoff record: save failed"))
+    }
+
     private func recursiveDescription(_ view: NSView) -> String {
         ([view.accessibilityLabel(), view.accessibilityIdentifier()] + view.subviews.map(recursiveDescription))
             .compactMap { $0 }
@@ -193,5 +251,21 @@ struct ReviewSessionTabViewTests {
             placeholderMessage: "No diff",
             openFile: nil
         )
+    }
+
+    private struct TestPersistenceError: LocalizedError {
+        var errorDescription: String? { "save failed" }
+    }
+
+    private struct FailingPersistenceStore: PersistenceStoreProtocol {
+        let error: Error
+
+        func write<T: Encodable>(_ value: T, to url: URL) throws {
+            throw error
+        }
+
+        func readIfExists<T: Decodable>(_ type: T.Type, from url: URL) throws -> T? {
+            nil
+        }
     }
 }

--- a/AlasTests/ReviewSessionTabViewTests.swift
+++ b/AlasTests/ReviewSessionTabViewTests.swift
@@ -115,6 +115,50 @@ struct ReviewSessionTabViewTests {
         #expect(subview(withAccessibilityIdentifier: "review-draft-summary-rail", in: host) != nil)
     }
 
+    @Test func rendersSentStateForRecordWithHandoff() throws {
+        let target = ReviewSessionTarget.localChanges(
+            worktreeID: "wt-1",
+            repositoryPath: URL(fileURLWithPath: "/repo"),
+            scope: .all
+        )
+        let handoff = ReviewFeedbackHandoff(
+            id: "handoff-1",
+            sessionID: target.id,
+            commentIDs: ["draft-1"],
+            target: .existingSession(worktreeID: "wt-1", sessionID: "acp-1", title: "Codex"),
+            createdAt: Date(timeIntervalSince1970: 30),
+            promptRevision: "revision-1",
+            status: .sent
+        )
+        let record = ReviewSessionRecord(
+            id: target.id,
+            target: target,
+            handoffs: [handoff],
+            createdAt: .init(timeIntervalSince1970: 1),
+            updatedAt: .init(timeIntervalSince1970: 30)
+        )
+        let summary = Self.summary(path: "A.swift", namespace: "unstaged")
+        let loaded = ReviewSessionLoadedContext(
+            session: DiffReviewLoadedSession(
+                files: [Self.file(path: "A.swift", namespace: "unstaged")],
+                summary: DiffReviewSessionModel(files: [summary], groupsEnabled: true)
+            ),
+            feedbackTarget: ReviewFeedbackTarget(
+                title: target.title,
+                repositoryPath: "/repo",
+                providerDescription: nil,
+                sourceDescription: target.sourceDescription
+            )
+        )
+        let view = ReviewSessionTabView.preview(record: record, loaded: loaded)
+            .environment(\.theme, try ThemeStore().current)
+
+        let host = NSHostingView(rootView: view.frame(width: 900, height: 700))
+        host.layoutSubtreeIfNeeded()
+
+        #expect(recursiveDescription(host).contains("Sent to agent"))
+    }
+
     private func recursiveDescription(_ view: NSView) -> String {
         ([view.accessibilityLabel(), view.accessibilityIdentifier()] + view.subviews.map(recursiveDescription))
             .compactMap { $0 }

--- a/AlasTests/ReviewSessionTabViewTests.swift
+++ b/AlasTests/ReviewSessionTabViewTests.swift
@@ -1,0 +1,73 @@
+import AppKit
+import Foundation
+import SwiftUI
+import Testing
+@testable import Alas
+
+@MainActor
+struct ReviewSessionTabViewTests {
+    @Test func rendersLoadedSessionTitleAndSummaryRail() throws {
+        let target = ReviewSessionTarget.localChanges(
+            worktreeID: "wt-1",
+            repositoryPath: URL(fileURLWithPath: "/repo"),
+            scope: .all
+        )
+        let record = ReviewSessionRecord(
+            id: target.id,
+            target: target,
+            createdAt: .init(timeIntervalSince1970: 1),
+            updatedAt: .init(timeIntervalSince1970: 1)
+        )
+        let summary = DiffReviewFileSummary(
+            path: "A.swift",
+            namespace: "unstaged",
+            groupID: "unstaged",
+            groupTitle: "Unstaged",
+            status: .modified,
+            additions: 1,
+            deletions: 0,
+            isRenderable: false
+        )
+        let loaded = ReviewSessionLoadedContext(
+            session: DiffReviewLoadedSession(
+                files: [
+                    DiffReviewFileSectionModel(
+                        summary: summary,
+                        parsedDiff: nil,
+                        displayModel: nil,
+                        placeholderMessage: "No diff",
+                        openFile: nil
+                    ),
+                ],
+                summary: DiffReviewSessionModel(files: [summary], groupsEnabled: true)
+            ),
+            feedbackTarget: ReviewFeedbackTarget(
+                title: target.title,
+                repositoryPath: "/repo",
+                providerDescription: nil,
+                sourceDescription: target.sourceDescription
+            )
+        )
+        let view = ReviewSessionTabView.preview(record: record, loaded: loaded)
+            .environment(\.theme, try ThemeStore().current)
+
+        let host = NSHostingView(rootView: view.frame(width: 900, height: 700))
+        host.layoutSubtreeIfNeeded()
+
+        #expect(recursiveDescription(host).contains("Review all changes"))
+        #expect(subview(withAccessibilityIdentifier: "review-draft-summary-rail", in: host) != nil)
+    }
+
+    private func recursiveDescription(_ view: NSView) -> String {
+        ([view.accessibilityLabel(), view.accessibilityIdentifier()] + view.subviews.map(recursiveDescription))
+            .compactMap { $0 }
+            .joined(separator: "\n")
+    }
+
+    private func subview(withAccessibilityIdentifier identifier: String, in view: NSView) -> NSView? {
+        if view.accessibilityIdentifier() == identifier {
+            return view
+        }
+        return view.subviews.lazy.compactMap { subview(withAccessibilityIdentifier: identifier, in: $0) }.first
+    }
+}

--- a/AlasTests/TabsManagerReviewSessionTests.swift
+++ b/AlasTests/TabsManagerReviewSessionTests.swift
@@ -1,0 +1,57 @@
+import Foundation
+import Testing
+@testable import Alas
+
+@MainActor
+struct TabsManagerReviewSessionTests {
+    @Test func opensOrFocusesReviewSessionForSameTarget() {
+        var manager = TabsManager()
+        let target = ReviewSessionTarget.localChanges(
+            worktreeID: "wt-1",
+            repositoryPath: URL(fileURLWithPath: "/repo"),
+            scope: .all
+        )
+        let record = ReviewSessionRecord(
+            id: target.id,
+            target: target,
+            createdAt: .init(timeIntervalSince1970: 1),
+            updatedAt: .init(timeIntervalSince1970: 1)
+        )
+
+        let first = manager.openOrFocusReviewSession(worktreeId: "wt-1", record: record)
+        let second = manager.openOrFocusReviewSession(worktreeId: "wt-1", record: record)
+
+        #expect(first.id == second.id)
+        #expect(manager.tabs(forWorktree: "wt-1").filter {
+            if case .reviewSession = $0 { return true }
+            return false
+        }.count == 1)
+    }
+
+    @Test func updatesReviewSessionSelection() {
+        var manager = TabsManager()
+        let target = ReviewSessionTarget.commit(
+            worktreeID: "wt-1",
+            repositoryPath: URL(fileURLWithPath: "/repo"),
+            sha: "abc",
+            title: "Review abc"
+        )
+        let record = ReviewSessionRecord(
+            id: target.id,
+            target: target,
+            createdAt: .init(timeIntervalSince1970: 1),
+            updatedAt: .init(timeIntervalSince1970: 1)
+        )
+        let tab = manager.openOrFocusReviewSession(worktreeId: "wt-1", record: record)
+
+        _ = manager.updateReviewSession(worktreeId: "wt-1", tabId: tab.id) { state in
+            state.selectedFileID = DiffReviewFileID(namespace: "commit", path: "A.swift")
+        }
+
+        guard case .reviewSession(let state)? = manager.tabs(forWorktree: "wt-1").first(where: { $0.id == tab.id }) else {
+            Issue.record("Missing review session tab")
+            return
+        }
+        #expect(state.selectedFileID == DiffReviewFileID(namespace: "commit", path: "A.swift"))
+    }
+}

--- a/docs/superpowers/plans/2026-06-15-in-app-review-sessions-agent-handoff.md
+++ b/docs/superpowers/plans/2026-06-15-in-app-review-sessions-agent-handoff.md
@@ -1,0 +1,1130 @@
+# In-App Review Sessions And Agent Handoff Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add persistent in-app review sessions for any reviewable diff target, with local feedback state and native send-to-agent handoff tracking.
+
+**Architecture:** Build a durable review-session layer above the existing `DiffReviewSurface`, `ReviewDraftCommentStore`, and `ReviewFeedbackAgentSender`. Reuse existing diff loaders and draft comment storage; add session records, target identity, handoff history, a review-session tab shell, and launcher entry points.
+
+**Tech Stack:** Swift 5.9+, SwiftUI, Swift Testing, existing JSON persistence through `PersistenceStore`, existing ACP session APIs through `AppState`.
+
+---
+
+## File Map
+
+- Create `Alas/Sources/Center/ReviewWorkspace/ReviewSessionModels.swift`
+  - Owns `ReviewSessionTarget`, `ReviewSessionRecord`, `ReviewSessionStatus`, `ReviewFeedbackHandoff`, and deterministic IDs.
+- Create `Alas/Sources/Center/ReviewWorkspace/ReviewSessionStore.swift`
+  - Persists session records using the same `PersistenceStoreProtocol` style as `ReviewDraftCommentStore`.
+- Modify `Alas/Sources/Persistence/Paths.swift`
+  - Adds `reviewSessionsFile`.
+- Modify `Alas/Sources/Center/ReviewWorkspace/ReviewFeedbackAgentSender.swift`
+  - Makes `ReviewFeedbackAgentTarget` persistable for handoff records.
+- Test `AlasTests/ReviewSessionModelsTests.swift`
+  - Covers target IDs, draft session IDs, prompt metadata, and handoff state.
+- Test `AlasTests/ReviewSessionStoreTests.swift`
+  - Covers persistence round trips, sorted session listing, and reuse lookup.
+- Create `Alas/Sources/Center/ReviewWorkspace/ReviewSessionLoader.swift`
+  - Converts `ReviewSessionTarget` into `DiffReviewLoadedSession` plus `ReviewFeedbackTarget`.
+- Modify existing loaders only where needed to expose pure helper methods:
+  - `Alas/Sources/Center/ReviewChanges/ReviewChangesTabView.swift`
+  - `Alas/Sources/Center/Commit/CommitReviewLoader.swift`
+  - `Alas/Sources/Center/ReviewRequest/DraftReviewRequestDiffSessionBuilder.swift`
+  - `Alas/Sources/Integrations/CodeHost/ReviewRequestDiffLoader.swift`
+- Test `AlasTests/ReviewSessionLoaderTests.swift`
+  - Covers target-to-loader routing with fake clients.
+- Create `Alas/Sources/Center/ReviewWorkspace/ReviewSessionTabView.swift`
+  - Thin SwiftUI shell around `DiffReviewSurface`, summary rail, target header, and send state.
+- Modify `Alas/Sources/Center/Tab.swift`
+  - Adds `case reviewSession(ReviewSessionTabState)`.
+- Modify `Alas/Sources/Center/TabsManager.swift`
+  - Adds `openOrFocusReviewSession` and `updateReviewSession`.
+- Modify `Alas/Sources/Center/CenterPaneView.swift`
+  - Hosts `ReviewSessionTabView`.
+- Test `AlasTests/TabsManagerReviewSessionTests.swift`
+  - Covers open/focus, update, and reuse behavior.
+- Modify launcher surfaces:
+  - `Alas/Sources/Center/ReviewChanges/ReviewChangesTabView.swift`
+  - `Alas/Sources/Center/Commit/CommitTabView.swift`
+  - `Alas/Sources/Center/ReviewEvidence/ReviewEvidenceTabView.swift`
+  - `Alas/Sources/Center/ReviewRequest/DraftReviewRequestTabView.swift`
+- Modify `Alas/Sources/Center/ReviewWorkspace/ReviewFeedbackBundle.swift`
+  - Adds optional session/revision metadata to the prompt.
+- Modify `Alas/Sources/Center/ReviewWorkspace/ReviewFeedbackAgentSender.swift`
+  - Records successful handoffs through the session store after ACP accepts/queues the prompt.
+- Test existing focused suites:
+  - `AlasTests/ReviewFeedbackBundleTests.swift`
+  - `AlasTests/ReviewChangesTabViewTests.swift`
+  - `AlasTests/DiffReviewSurfaceTests.swift`
+
+## Task 1: Review Session Models And Persistence
+
+**Files:**
+- Create: `Alas/Sources/Center/ReviewWorkspace/ReviewSessionModels.swift`
+- Create: `Alas/Sources/Center/ReviewWorkspace/ReviewSessionStore.swift`
+- Modify: `Alas/Sources/Center/ReviewWorkspace/ReviewFeedbackAgentSender.swift`
+- Modify: `Alas/Sources/Persistence/Paths.swift`
+- Test: `AlasTests/ReviewSessionModelsTests.swift`
+- Test: `AlasTests/ReviewSessionStoreTests.swift`
+- Modify after `xcodegen` when new Swift file references are generated: `Alas.xcodeproj/project.pbxproj`
+
+- [ ] **Step 1: Add failing model tests for stable target identity**
+
+Add `AlasTests/ReviewSessionModelsTests.swift`:
+
+```swift
+import Foundation
+import Testing
+
+struct ReviewSessionModelsTests {
+    @Test func localChangesTargetDerivesStableIDs() {
+        let repositoryPath = URL(fileURLWithPath: "/repo")
+        let target = ReviewSessionTarget.localChanges(
+            worktreeID: "wt-1",
+            repositoryPath: repositoryPath,
+            scope: .unstaged
+        )
+
+        #expect(target.kind == .localChanges)
+        #expect(target.id.rawValue == "local-changes\u{1f}wt-1\u{1f}/repo\u{1f}unstaged")
+        #expect(target.draftSessionID == .localChanges(worktreeID: "wt-1", worktreePath: repositoryPath, scope: .unstaged))
+        #expect(target.title == "Review unstaged changes")
+        #expect(target.sourceDescription == "Local changes: unstaged")
+    }
+
+    @Test func providerTargetIncludesProviderIdentity() {
+        let target = ReviewSessionTarget.reviewRequest(
+            worktreeID: "wt-1",
+            provider: .github,
+            host: "GitHub.com",
+            repositorySlug: "mrmans0n/alas",
+            number: 520,
+            url: URL(string: "https://github.com/mrmans0n/alas/pull/520")!,
+            title: "Use shared surface",
+            headSHA: "abc123"
+        )
+
+        #expect(target.kind == .reviewRequest)
+        #expect(target.id.rawValue.contains("github"))
+        #expect(target.id.rawValue.contains("github.com"))
+        #expect(target.draftSessionID == .reviewRequest(worktreeID: "wt-1", provider: .github, host: "github.com", repositorySlug: "mrmans0n/alas", number: 520))
+        #expect(target.providerDescription == "GitHub mrmans0n/alas #520")
+        #expect(target.revisionDescription == "abc123")
+    }
+
+    @Test func handoffTransitionsToSentAndAddressed() {
+        let record = ReviewSessionRecord(
+            id: ReviewSessionID(rawValue: "session-1"),
+            target: .commit(
+                worktreeID: "wt-1",
+                repositoryPath: URL(fileURLWithPath: "/repo"),
+                sha: "deadbeef",
+                title: "Review deadbeef"
+            ),
+            createdAt: Date(timeIntervalSince1970: 10),
+            updatedAt: Date(timeIntervalSince1970: 20)
+        )
+        let handoff = ReviewFeedbackHandoff(
+            id: "handoff-1",
+            sessionID: record.id,
+            commentIDs: ["c1", "c2"],
+            target: .existingSession(worktreeID: "wt-1", sessionID: "acp-1", title: "Codex"),
+            createdAt: Date(timeIntervalSince1970: 30),
+            promptRevision: "rev-1",
+            status: .sent
+        )
+
+        let withHandoff = record.recording(handoff: handoff)
+        #expect(withHandoff.status == .sent)
+        #expect(withHandoff.handoffs == [handoff])
+        #expect(withHandoff.markedAddressed(now: Date(timeIntervalSince1970: 40)).status == .addressed)
+    }
+}
+```
+
+Run: `rtk xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -only-testing:AlasTests/ReviewSessionModelsTests test`
+
+Expected: FAIL because `ReviewSessionTarget`, `ReviewSessionRecord`, and `ReviewFeedbackHandoff` do not exist.
+
+- [ ] **Step 2: Implement review session models**
+
+First modify `ReviewFeedbackAgentTarget` in `Alas/Sources/Center/ReviewWorkspace/ReviewFeedbackAgentSender.swift` so handoff records can be persisted:
+
+```swift
+enum ReviewFeedbackAgentTarget: Codable, Equatable, Hashable, Identifiable, Sendable {
+    case newChat(agentID: String, title: String)
+    case existingSession(worktreeID: String, sessionID: String, title: String)
+}
+```
+
+Create `Alas/Sources/Center/ReviewWorkspace/ReviewSessionModels.swift` with these public-internal types:
+
+```swift
+import Foundation
+
+struct ReviewSessionID: Codable, Equatable, Hashable, RawRepresentable, Sendable {
+    let rawValue: String
+}
+
+enum ReviewSessionTargetKind: String, Codable, Equatable, Hashable, Sendable {
+    case localChanges = "local-changes"
+    case draftCommit = "draft-commit"
+    case commit
+    case commitRange = "commit-range"
+    case branch
+    case reviewRequest = "review-request"
+    case draftReviewRequest = "draft-review-request"
+}
+
+struct ReviewSessionTarget: Codable, Equatable, Hashable, Identifiable, Sendable {
+    let id: ReviewSessionID
+    let kind: ReviewSessionTargetKind
+    let worktreeID: String
+    let repositoryPath: URL
+    let title: String
+    let sourceDescription: String
+    let providerDescription: String?
+    let providerURL: URL?
+    let revisionDescription: String?
+    let draftSessionID: ReviewDraftSessionID
+    let payload: Payload
+
+    enum Payload: Codable, Equatable, Hashable, Sendable {
+        case localChanges(scope: ReviewDraftLocalChangesScope)
+        case draftCommit
+        case commit(sha: String)
+        case commitRange(base: String, head: String)
+        case branch(base: String, head: String)
+        case reviewRequest(provider: CodeHostKind, host: String, repositorySlug: String, number: Int, headSHA: String?)
+        case draftReviewRequest(provider: CodeHostKind, repositorySlug: String, base: String, head: String, headSHA: String?)
+    }
+}
+
+enum ReviewSessionStatus: String, Codable, Equatable, Hashable, Sendable {
+    case active
+    case sent
+    case addressing
+    case addressed
+    case archived
+}
+
+enum ReviewFeedbackHandoffStatus: String, Codable, Equatable, Hashable, Sendable {
+    case sent
+    case failed
+    case addressed
+}
+
+struct ReviewFeedbackHandoff: Codable, Equatable, Identifiable, Sendable {
+    let id: String
+    let sessionID: ReviewSessionID
+    let commentIDs: [String]
+    let target: ReviewFeedbackAgentTarget
+    let createdAt: Date
+    let promptRevision: String
+    var status: ReviewFeedbackHandoffStatus
+}
+
+struct ReviewSessionRecord: Codable, Equatable, Identifiable, Sendable {
+    let id: ReviewSessionID
+    var target: ReviewSessionTarget
+    var selectedFileID: DiffReviewFileID?
+    var focusedCommentID: String?
+    var status: ReviewSessionStatus
+    var handoffs: [ReviewFeedbackHandoff]
+    var lastSendError: String?
+    let createdAt: Date
+    var updatedAt: Date
+}
+```
+
+Add factory methods on `ReviewSessionTarget` for every target listed in the spec. Use `\u{1f}` as the field separator and lowercase provider hosts. Derive `draftSessionID` with the existing `ReviewDraftSessionID` factories.
+
+Add a convenience initializer on `ReviewSessionRecord` with defaults for optional state:
+
+```swift
+init(
+    id: ReviewSessionID,
+    target: ReviewSessionTarget,
+    selectedFileID: DiffReviewFileID? = nil,
+    focusedCommentID: String? = nil,
+    status: ReviewSessionStatus = .active,
+    handoffs: [ReviewFeedbackHandoff] = [],
+    lastSendError: String? = nil,
+    createdAt: Date,
+    updatedAt: Date
+)
+```
+
+Add convenience methods on `ReviewSessionRecord`:
+
+```swift
+func recording(handoff: ReviewFeedbackHandoff) -> ReviewSessionRecord
+func markedAddressed(now: Date) -> ReviewSessionRecord
+func selectingFile(_ fileID: DiffReviewFileID?, now: Date) -> ReviewSessionRecord
+func focusingComment(_ commentID: String?, now: Date) -> ReviewSessionRecord
+```
+
+Run: `rtk xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -only-testing:AlasTests/ReviewSessionModelsTests test`
+
+Expected: PASS.
+
+- [ ] **Step 3: Add failing persistence tests**
+
+Add `AlasTests/ReviewSessionStoreTests.swift`:
+
+```swift
+import Foundation
+import Testing
+
+struct ReviewSessionStoreTests {
+    @Test func roundTripsSessionRecords() throws {
+        let url = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        let store = ReviewSessionStore(url: url)
+        let target = ReviewSessionTarget.commit(
+            worktreeID: "wt-1",
+            repositoryPath: URL(fileURLWithPath: "/repo"),
+            sha: "abc123",
+            title: "Review abc123"
+        )
+        let record = ReviewSessionRecord(
+            id: target.id,
+            target: target,
+            selectedFileID: DiffReviewFileID(namespace: "commit", path: "Sources/A.swift"),
+            focusedCommentID: "comment-1",
+            status: .active,
+            handoffs: [],
+            lastSendError: nil,
+            createdAt: Date(timeIntervalSince1970: 1),
+            updatedAt: Date(timeIntervalSince1970: 2)
+        )
+
+        try store.save(record)
+
+        #expect(try store.load(id: target.id) == record)
+        #expect(try store.findActive(targetID: target.id) == record)
+        #expect(try store.list(worktreeID: "wt-1") == [record])
+    }
+
+    @Test func archiveRemovesSessionFromActiveReuse() throws {
+        let url = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        let store = ReviewSessionStore(url: url)
+        let target = ReviewSessionTarget.localChanges(
+            worktreeID: "wt-1",
+            repositoryPath: URL(fileURLWithPath: "/repo"),
+            scope: .all
+        )
+        var record = ReviewSessionRecord(id: target.id, target: target, createdAt: .init(timeIntervalSince1970: 1), updatedAt: .init(timeIntervalSince1970: 1))
+        try store.save(record)
+
+        record.status = .archived
+        try store.save(record)
+
+        #expect(try store.findActive(targetID: target.id) == nil)
+        #expect(try store.load(id: target.id)?.status == .archived)
+    }
+}
+```
+
+Run: `rtk xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -only-testing:AlasTests/ReviewSessionStoreTests test`
+
+Expected: FAIL because `ReviewSessionStore` and `Paths.reviewSessionsFile` do not exist.
+
+- [ ] **Step 4: Implement persistence**
+
+Modify `Alas/Sources/Persistence/Paths.swift` with:
+
+```swift
+static var reviewSessionsFile: URL {
+    appSupport.appendingPathComponent("review-sessions.json")
+}
+```
+
+Create `Alas/Sources/Center/ReviewWorkspace/ReviewSessionStore.swift` following `ReviewDraftCommentStore`:
+
+```swift
+import Foundation
+
+struct ReviewSessionStore {
+    private let store: any PersistenceStoreProtocol
+    private let url: URL
+
+    init(store: any PersistenceStoreProtocol = PersistenceStore(), url: URL = Paths.reviewSessionsFile) {
+        self.store = store
+        self.url = url
+    }
+
+    func load(id: ReviewSessionID) throws -> ReviewSessionRecord?
+    func list(worktreeID: String) throws -> [ReviewSessionRecord]
+    func findActive(targetID: ReviewSessionID) throws -> ReviewSessionRecord?
+    func save(_ record: ReviewSessionRecord) throws
+}
+```
+
+Store records by `record.id.rawValue`, sort lists by `updatedAt` descending, and treat `.archived` records as not active for reuse.
+
+Run:
+
+```bash
+rtk xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -only-testing:AlasTests/ReviewSessionModelsTests -only-testing:AlasTests/ReviewSessionStoreTests test
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Regenerate project and commit Task 1**
+
+Run:
+
+```bash
+xcodegen
+rtk xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -only-testing:AlasTests/ReviewSessionModelsTests -only-testing:AlasTests/ReviewSessionStoreTests test
+git status --short
+git add Alas/Sources/Center/ReviewWorkspace/ReviewSessionModels.swift Alas/Sources/Center/ReviewWorkspace/ReviewSessionStore.swift Alas/Sources/Center/ReviewWorkspace/ReviewFeedbackAgentSender.swift Alas/Sources/Persistence/Paths.swift AlasTests/ReviewSessionModelsTests.swift AlasTests/ReviewSessionStoreTests.swift Alas.xcodeproj/project.pbxproj
+git commit -m "feat(review): add review session records"
+```
+
+Expected: focused tests pass. If `xcodegen` does not change `Alas.xcodeproj/project.pbxproj`, do not stage it.
+
+## Task 2: Review Session Loader And Prompt Context
+
+**Files:**
+- Create: `Alas/Sources/Center/ReviewWorkspace/ReviewSessionLoader.swift`
+- Modify: `Alas/Sources/Center/ReviewWorkspace/ReviewFeedbackBundle.swift`
+- Test: `AlasTests/ReviewSessionLoaderTests.swift`
+- Test: `AlasTests/ReviewFeedbackBundleTests.swift`
+- Modify after `xcodegen` when new Swift file references are generated: `Alas.xcodeproj/project.pbxproj`
+
+- [ ] **Step 1: Add failing loader tests**
+
+Create `AlasTests/ReviewSessionLoaderTests.swift` with fake clients for commit and local-change sessions:
+
+```swift
+import Foundation
+import Testing
+
+struct ReviewSessionLoaderTests {
+    @Test func localChangesLoaderBuildsGroupedSessionAndFeedbackTarget() async throws {
+        let target = ReviewSessionTarget.localChanges(
+            worktreeID: "wt-1",
+            repositoryPath: URL(fileURLWithPath: "/repo"),
+            scope: .all
+        )
+        let loader = ReviewSessionLoader(
+            localChanges: { target in
+                #expect(target.kind == .localChanges)
+                let summary = DiffReviewFileSummary(
+                    path: "Sources/A.swift",
+                    namespace: "unstaged",
+                    groupID: "unstaged",
+                    groupTitle: "Unstaged",
+                    status: .modified,
+                    additions: 1,
+                    deletions: 0,
+                    isRenderable: true
+                )
+                return DiffReviewLoadedSession(
+                    files: [DiffReviewFileSectionModel(summary: summary, parsedDiff: nil, displayModel: nil, placeholderMessage: nil, openFile: nil)],
+                    summary: DiffReviewSessionModel(files: [summary], groupsEnabled: true)
+                )
+            }
+        )
+
+        let loaded = try await loader.load(target: target)
+
+        #expect(loaded.session.summary.fileCount == 1)
+        #expect(loaded.feedbackTarget.title == "Review unstaged changes")
+        #expect(loaded.feedbackTarget.repositoryPath == "/repo")
+        #expect(loaded.feedbackTarget.sourceDescription == "Local changes: all")
+    }
+
+    @Test func commitLoaderBuildsPinnedSourceDescription() async throws {
+        let target = ReviewSessionTarget.commit(
+            worktreeID: "wt-1",
+            repositoryPath: URL(fileURLWithPath: "/repo"),
+            sha: "deadbeef",
+            title: "Review deadbeef"
+        )
+        let loader = ReviewSessionLoader(
+            commit: { target in
+                #expect(target.revisionDescription == "deadbeef")
+                return DiffReviewLoadedSession(files: [], summary: DiffReviewSessionModel(files: [], groupsEnabled: false))
+            }
+        )
+
+        let loaded = try await loader.load(target: target)
+
+        #expect(loaded.feedbackTarget.sourceDescription == "Commit deadbeef")
+    }
+}
+```
+
+Run: `rtk xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -only-testing:AlasTests/ReviewSessionLoaderTests test`
+
+Expected: FAIL because `ReviewSessionLoader` does not exist.
+
+- [ ] **Step 2: Implement loader shell and injected closures**
+
+Create `Alas/Sources/Center/ReviewWorkspace/ReviewSessionLoader.swift`:
+
+```swift
+import Foundation
+
+struct ReviewSessionLoadedContext {
+    let session: DiffReviewLoadedSession
+    let feedbackTarget: ReviewFeedbackTarget
+}
+
+struct ReviewSessionLoader {
+    var localChanges: (ReviewSessionTarget) async throws -> DiffReviewLoadedSession
+    var draftCommit: (ReviewSessionTarget) async throws -> DiffReviewLoadedSession
+    var commit: (ReviewSessionTarget) async throws -> DiffReviewLoadedSession
+    var commitRange: (ReviewSessionTarget) async throws -> DiffReviewLoadedSession
+    var branch: (ReviewSessionTarget) async throws -> DiffReviewLoadedSession
+    var reviewRequest: (ReviewSessionTarget) async throws -> DiffReviewLoadedSession
+    var draftReviewRequest: (ReviewSessionTarget) async throws -> DiffReviewLoadedSession
+
+    init(
+        localChanges: @escaping (ReviewSessionTarget) async throws -> DiffReviewLoadedSession = { _ in throw ReviewSessionLoaderError.unsupportedTarget },
+        draftCommit: @escaping (ReviewSessionTarget) async throws -> DiffReviewLoadedSession = { _ in throw ReviewSessionLoaderError.unsupportedTarget },
+        commit: @escaping (ReviewSessionTarget) async throws -> DiffReviewLoadedSession = { _ in throw ReviewSessionLoaderError.unsupportedTarget },
+        commitRange: @escaping (ReviewSessionTarget) async throws -> DiffReviewLoadedSession = { _ in throw ReviewSessionLoaderError.unsupportedTarget },
+        branch: @escaping (ReviewSessionTarget) async throws -> DiffReviewLoadedSession = { _ in throw ReviewSessionLoaderError.unsupportedTarget },
+        reviewRequest: @escaping (ReviewSessionTarget) async throws -> DiffReviewLoadedSession = { _ in throw ReviewSessionLoaderError.unsupportedTarget },
+        draftReviewRequest: @escaping (ReviewSessionTarget) async throws -> DiffReviewLoadedSession = { _ in throw ReviewSessionLoaderError.unsupportedTarget }
+    )
+
+    func load(target: ReviewSessionTarget) async throws -> ReviewSessionLoadedContext
+}
+
+enum ReviewSessionLoaderError: Error, Equatable {
+    case unsupportedTarget
+}
+```
+
+Route by `target.kind`, call `Task.checkCancellation()` before and after the selected closure, and build `ReviewFeedbackTarget` from `target.title`, `target.repositoryPath.path`, `target.providerDescription`, and `target.sourceDescription`.
+
+Run: `rtk xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -only-testing:AlasTests/ReviewSessionLoaderTests test`
+
+Expected: PASS.
+
+- [ ] **Step 3: Add failing prompt metadata test**
+
+Extend `AlasTests/ReviewFeedbackBundleTests.swift`:
+
+```swift
+@Test func promptIncludesReviewSessionRevisionAndPreviousHandoff() {
+    let target = ReviewFeedbackTarget(
+        title: "Review deadbeef",
+        repositoryPath: "/repo",
+        providerDescription: nil,
+        sourceDescription: "Commit deadbeef",
+        sessionDescription: "Review session: commit deadbeef",
+        revisionDescription: "deadbeef",
+        priorHandoffDescription: "Previously sent to Codex at 1970-01-01 00:00:30 +0000"
+    )
+    let comment = ReviewDraftComment(
+        id: "c1",
+        sessionID: .commit(worktreeID: "wt-1", repositoryPath: URL(fileURLWithPath: "/repo"), sha: "deadbeef"),
+        fileID: DiffReviewFileID(namespace: "commit", path: "Sources/A.swift"),
+        path: "Sources/A.swift",
+        originalPath: nil,
+        side: .new,
+        startLine: 10,
+        endLine: nil,
+        selectedText: nil,
+        bodyMarkdown: "Fix this",
+        state: .active,
+        createdAt: Date(timeIntervalSince1970: 1),
+        updatedAt: Date(timeIntervalSince1970: 1)
+    )
+
+    let prompt = ReviewFeedbackBundle(target: target, comments: [comment]).promptMarkdown()
+
+    #expect(prompt.contains("Review session: commit deadbeef"))
+    #expect(prompt.contains("Revision: deadbeef"))
+    #expect(prompt.contains("Previously sent to Codex"))
+}
+```
+
+Run: `rtk xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -only-testing:AlasTests/ReviewFeedbackBundleTests test`
+
+Expected: FAIL because `ReviewFeedbackTarget` has no optional session/revision/handoff descriptions.
+
+- [ ] **Step 4: Extend prompt target metadata**
+
+Modify `ReviewFeedbackTarget` in `ReviewFeedbackBundle.swift`:
+
+```swift
+struct ReviewFeedbackTarget: Equatable, Sendable {
+    var title: String
+    var repositoryPath: String?
+    var providerDescription: String?
+    var sourceDescription: String
+    var sessionDescription: String? = nil
+    var revisionDescription: String? = nil
+    var priorHandoffDescription: String? = nil
+}
+```
+
+In `promptMarkdown()`, append non-empty metadata after `Source`:
+
+```swift
+if let sessionDescription, !sessionDescription.isEmpty {
+    lines.append(sessionDescription)
+}
+if let revisionDescription, !revisionDescription.isEmpty {
+    lines.append("Revision: \(revisionDescription)")
+}
+if let priorHandoffDescription, !priorHandoffDescription.isEmpty {
+    lines.append(priorHandoffDescription)
+}
+```
+
+Run:
+
+```bash
+rtk xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -only-testing:AlasTests/ReviewSessionLoaderTests -only-testing:AlasTests/ReviewFeedbackBundleTests test
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Regenerate project and commit Task 2**
+
+Run:
+
+```bash
+xcodegen
+rtk xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -only-testing:AlasTests/ReviewSessionLoaderTests -only-testing:AlasTests/ReviewFeedbackBundleTests test
+git status --short
+git add Alas/Sources/Center/ReviewWorkspace/ReviewSessionLoader.swift Alas/Sources/Center/ReviewWorkspace/ReviewFeedbackBundle.swift AlasTests/ReviewSessionLoaderTests.swift AlasTests/ReviewFeedbackBundleTests.swift Alas.xcodeproj/project.pbxproj
+git commit -m "feat(review): add review session loading context"
+```
+
+Expected: focused tests pass. If `xcodegen` does not change the project, do not stage `Alas.xcodeproj/project.pbxproj`.
+
+## Task 3: Review Session Tab And Tabs Manager
+
+**Files:**
+- Create: `Alas/Sources/Center/ReviewWorkspace/ReviewSessionTabView.swift`
+- Modify: `Alas/Sources/Center/Tab.swift`
+- Modify: `Alas/Sources/Center/TabsManager.swift`
+- Modify: `Alas/Sources/Center/CenterPaneView.swift`
+- Test: `AlasTests/TabsManagerReviewSessionTests.swift`
+- Test: `AlasTests/ReviewSessionTabViewTests.swift`
+- Modify after `xcodegen` when new Swift file references are generated: `Alas.xcodeproj/project.pbxproj`
+
+- [ ] **Step 1: Add failing tab manager tests**
+
+Add `AlasTests/TabsManagerReviewSessionTests.swift`:
+
+```swift
+import Foundation
+import Testing
+
+struct TabsManagerReviewSessionTests {
+    @Test func opensOrFocusesReviewSessionForSameTarget() {
+        var manager = TabsManager()
+        let target = ReviewSessionTarget.localChanges(
+            worktreeID: "wt-1",
+            repositoryPath: URL(fileURLWithPath: "/repo"),
+            scope: .all
+        )
+        let record = ReviewSessionRecord(id: target.id, target: target, createdAt: .init(timeIntervalSince1970: 1), updatedAt: .init(timeIntervalSince1970: 1))
+
+        let first = manager.openOrFocusReviewSession(worktreeId: "wt-1", record: record)
+        let second = manager.openOrFocusReviewSession(worktreeId: "wt-1", record: record)
+
+        #expect(first.id == second.id)
+        #expect(manager.tabs(forWorktree: "wt-1").filter {
+            if case .reviewSession = $0 { return true }
+            return false
+        }.count == 1)
+    }
+
+    @Test func updatesReviewSessionSelection() {
+        var manager = TabsManager()
+        let target = ReviewSessionTarget.commit(
+            worktreeID: "wt-1",
+            repositoryPath: URL(fileURLWithPath: "/repo"),
+            sha: "abc",
+            title: "Review abc"
+        )
+        let record = ReviewSessionRecord(id: target.id, target: target, createdAt: .init(timeIntervalSince1970: 1), updatedAt: .init(timeIntervalSince1970: 1))
+        let tab = manager.openOrFocusReviewSession(worktreeId: "wt-1", record: record)
+
+        _ = manager.updateReviewSession(worktreeId: "wt-1", tabId: tab.id) { state in
+            state.selectedFileID = DiffReviewFileID(namespace: "commit", path: "A.swift")
+        }
+
+        guard case .reviewSession(let state)? = manager.tabs(forWorktree: "wt-1").first(where: { $0.id == tab.id }) else {
+            Issue.record("Missing review session tab")
+            return
+        }
+        #expect(state.selectedFileID == DiffReviewFileID(namespace: "commit", path: "A.swift"))
+    }
+}
+```
+
+Run: `rtk xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -only-testing:AlasTests/TabsManagerReviewSessionTests test`
+
+Expected: FAIL because `Tab.reviewSession` and `ReviewSessionTabState` do not exist.
+
+- [ ] **Step 2: Add tab state and manager APIs**
+
+Modify `Alas/Sources/Center/Tab.swift`:
+
+```swift
+case reviewSession(ReviewSessionTabState)
+```
+
+Add `ReviewSessionTabState`:
+
+```swift
+struct ReviewSessionTabState: Codable, Equatable, Identifiable {
+    let id: TabID
+    let worktreeId: String
+    let sessionID: ReviewSessionID
+    var title: String
+    var selectedFileID: DiffReviewFileID?
+    var focusedCommentID: String?
+
+    init(worktreeId: String, record: ReviewSessionRecord) {
+        self.id = "review-session:\(record.id.rawValue)"
+        self.worktreeId = worktreeId
+        self.sessionID = record.id
+        self.title = record.target.title
+        self.selectedFileID = record.selectedFileID
+        self.focusedCommentID = record.focusedCommentID
+    }
+}
+```
+
+Update `Tab.id`, `Tab.title`, and `Tab.iconName` for `.reviewSession`.
+
+Modify `TabsManager.swift` with:
+
+```swift
+@discardableResult
+func openOrFocusReviewSession(worktreeId: String, record: ReviewSessionRecord) -> Tab
+
+@discardableResult
+func updateReviewSession(
+    worktreeId: String,
+    tabId: TabID,
+    mutate: (inout ReviewSessionTabState) -> Void
+) -> Tab?
+```
+
+Use the existing `openOrFocusDraftReviewRequest` pattern.
+
+Run: `rtk xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -only-testing:AlasTests/TabsManagerReviewSessionTests test`
+
+Expected: PASS.
+
+- [ ] **Step 3: Add failing hosted shell test**
+
+Add `AlasTests/ReviewSessionTabViewTests.swift`:
+
+```swift
+import Foundation
+import Testing
+import SwiftUI
+
+struct ReviewSessionTabViewTests {
+    @MainActor
+    @Test func rendersLoadedSessionTitleAndSummaryRail() throws {
+        let target = ReviewSessionTarget.localChanges(
+            worktreeID: "wt-1",
+            repositoryPath: URL(fileURLWithPath: "/repo"),
+            scope: .all
+        )
+        let record = ReviewSessionRecord(id: target.id, target: target, createdAt: .init(timeIntervalSince1970: 1), updatedAt: .init(timeIntervalSince1970: 1))
+        let summary = DiffReviewFileSummary(
+            path: "A.swift",
+            namespace: "unstaged",
+            groupID: "unstaged",
+            groupTitle: "Unstaged",
+            status: .modified,
+            additions: 1,
+            deletions: 0,
+            isRenderable: false
+        )
+        let loaded = ReviewSessionLoadedContext(
+            session: DiffReviewLoadedSession(
+                files: [DiffReviewFileSectionModel(summary: summary, parsedDiff: nil, displayModel: nil, placeholderMessage: "No diff", openFile: nil)],
+                summary: DiffReviewSessionModel(files: [summary], groupsEnabled: true)
+            ),
+            feedbackTarget: ReviewFeedbackTarget(title: target.title, repositoryPath: "/repo", providerDescription: nil, sourceDescription: target.sourceDescription)
+        )
+        let view = ReviewSessionTabView.preview(record: record, loaded: loaded)
+
+        let host = NSHostingView(rootView: view.frame(width: 900, height: 700))
+        host.layoutSubtreeIfNeeded()
+
+        #expect(host.recursiveDescriptionForTests.contains("Review all changes"))
+    }
+}
+```
+
+Run: `rtk xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -only-testing:AlasTests/ReviewSessionTabViewTests test`
+
+Expected: FAIL because `ReviewSessionTabView` does not exist.
+
+- [ ] **Step 4: Implement review session tab shell**
+
+Create `Alas/Sources/Center/ReviewWorkspace/ReviewSessionTabView.swift`.
+
+The production initializer should accept:
+
+```swift
+struct ReviewSessionTabView: View {
+    let worktree: Worktree
+    let tabState: ReviewSessionTabState
+    let appState: AppState
+}
+```
+
+Implement internal dependencies:
+
+- `ReviewSessionStore()`
+- `ReviewDraftCommentStore()`
+- `ReviewSessionLoader.production(appState:worktree:)`
+- `ReviewFeedbackAgentSender.production(appState:worktreeID:)`
+
+Keep the first implementation thin:
+
+- load `ReviewSessionRecord` by `tabState.sessionID`
+- call `ReviewSessionLoader.load(target:)`
+- render retryable error text on load failure
+- render `DiffReviewSurface(session:selectedFileID:...)` with existing `ReviewDraftWorkspaceActions`
+- render `ReviewDraftSummaryRail` beside the diff surface
+- update `ReviewSessionStore` and `TabsManager.updateReviewSession` when selected file or focused comment changes
+
+Add a `static func preview(record:loaded:) -> some View` only for tests; it should use in-memory closures and no disk writes.
+
+Modify `CenterPaneView.swift` to switch over `.reviewSession(let state)` and host `ReviewSessionTabView`.
+
+Run:
+
+```bash
+rtk xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -only-testing:AlasTests/TabsManagerReviewSessionTests -only-testing:AlasTests/ReviewSessionTabViewTests test
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Regenerate project and commit Task 3**
+
+Run:
+
+```bash
+xcodegen
+rtk xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -only-testing:AlasTests/TabsManagerReviewSessionTests -only-testing:AlasTests/ReviewSessionTabViewTests test
+git status --short
+git add Alas/Sources/Center/ReviewWorkspace/ReviewSessionTabView.swift Alas/Sources/Center/Tab.swift Alas/Sources/Center/TabsManager.swift Alas/Sources/Center/CenterPaneView.swift AlasTests/TabsManagerReviewSessionTests.swift AlasTests/ReviewSessionTabViewTests.swift Alas.xcodeproj/project.pbxproj
+git commit -m "feat(review): add review session tab"
+```
+
+Expected: focused tests pass. Do not stage the project file if unchanged.
+
+## Task 4: Agent Handoff Recording
+
+**Files:**
+- Modify: `Alas/Sources/Center/ReviewWorkspace/ReviewFeedbackAgentSender.swift`
+- Modify: `Alas/Sources/Center/ReviewWorkspace/ReviewDraftSummaryRail.swift`
+- Modify: `Alas/Sources/Center/ReviewWorkspace/ReviewSessionTabView.swift`
+- Test: `AlasTests/ReviewChangesTabViewTests.swift`
+- Test: `AlasTests/ReviewSessionModelsTests.swift`
+- Test: `AlasTests/ReviewSessionTabViewTests.swift`
+
+- [ ] **Step 1: Add failing handoff recording tests**
+
+Extend `AlasTests/ReviewSessionModelsTests.swift`:
+
+```swift
+@Test func promptRevisionChangesWhenIncludedCommentsChange() {
+    let first = ReviewFeedbackHandoff.revisionKey(commentIDs: ["b", "a"], prompt: "hello")
+    let second = ReviewFeedbackHandoff.revisionKey(commentIDs: ["a", "b"], prompt: "hello")
+    let third = ReviewFeedbackHandoff.revisionKey(commentIDs: ["a", "b"], prompt: "different")
+
+    #expect(first == second)
+    #expect(first != third)
+}
+```
+
+Extend `AlasTests/ReviewChangesTabViewTests.swift` or add to `ReviewSessionTabViewTests.swift`:
+
+```swift
+@MainActor
+@Test func sendToAgentRecordsSessionHandoff() {
+    var sentPrompt: String?
+    var recorded: ReviewFeedbackHandoff?
+    let target = ReviewFeedbackAgentTarget.existingSession(worktreeID: "wt-1", sessionID: "acp-1", title: "Codex")
+    let sender = ReviewFeedbackAgentSender(
+        availableTargets: { [target] },
+        send: { prompt, _ in sentPrompt = prompt }
+    )
+    let sessionID = ReviewSessionID(rawValue: "session-1")
+    let comment = ReviewDraftComment(
+        id: "c1",
+        sessionID: .localChanges(worktreeID: "wt-1", worktreePath: URL(fileURLWithPath: "/repo"), scope: .all),
+        fileID: DiffReviewFileID(namespace: "unstaged", path: "A.swift"),
+        path: "A.swift",
+        originalPath: nil,
+        side: .new,
+        startLine: 1,
+        endLine: nil,
+        selectedText: nil,
+        bodyMarkdown: "Fix it",
+        state: .active,
+        createdAt: .init(timeIntervalSince1970: 1),
+        updatedAt: .init(timeIntervalSince1970: 1)
+    )
+    let bundle = ReviewFeedbackBundle(
+        target: ReviewFeedbackTarget(title: "Review", repositoryPath: "/repo", providerDescription: nil, sourceDescription: "Local changes"),
+        comments: [comment]
+    )
+
+    ReviewFeedbackPromptActions.sendToAgent(
+        bundle,
+        target: target,
+        sender: sender,
+        sessionID: sessionID,
+        recordHandoff: { recorded = $0 },
+        now: { Date(timeIntervalSince1970: 30) },
+        makeID: { "handoff-1" }
+    )
+
+    #expect(sentPrompt?.contains("Fix it") == true)
+    #expect(recorded?.id == "handoff-1")
+    #expect(recorded?.sessionID == sessionID)
+    #expect(recorded?.commentIDs == ["c1"])
+    #expect(recorded?.status == .sent)
+}
+```
+
+Run focused tests.
+
+Expected: FAIL because `revisionKey` and the extended send API do not exist.
+
+- [ ] **Step 2: Implement handoff recording API**
+
+Modify `ReviewFeedbackAgentSender.swift`:
+
+- Add `ReviewFeedbackHandoff.revisionKey(commentIDs:prompt:)` in `ReviewSessionModels.swift`.
+- Overload `ReviewFeedbackPromptActions.sendToAgent` with optional session handoff parameters:
+
+```swift
+@MainActor
+static func sendToAgent(
+    _ bundle: ReviewFeedbackBundle,
+    target: ReviewFeedbackAgentTarget,
+    sender: ReviewFeedbackAgentSender,
+    sessionID: ReviewSessionID?,
+    recordHandoff: ((ReviewFeedbackHandoff) -> Void)?,
+    now: () -> Date = Date.init,
+    makeID: () -> String = { UUID().uuidString }
+)
+```
+
+Keep the existing call site API by having the old method call the new one with `nil`.
+
+Record a handoff only after `sender.send(prompt,target)` returns. Include only active comment IDs in sorted order.
+
+In `ReviewSessionTabView`, pass a `recordHandoff` closure that:
+
+- loads the current `ReviewSessionRecord`
+- appends the handoff through `recording(handoff:)`
+- saves the record through `ReviewSessionStore`
+- updates visible record state
+
+Run focused tests.
+
+Expected: PASS.
+
+- [ ] **Step 3: Surface sent state in summary rail**
+
+Add a small visible state to `ReviewDraftSummaryRail`:
+
+- When at least one handoff exists, show `Sent to agent` with the latest handoff time.
+- If `lastSendError` is non-empty, show the error in muted destructive text.
+- Keep existing copy/send controls available.
+
+Add a hosted test in `ReviewSessionTabViewTests` that a preview record with one handoff renders `Sent to agent`.
+
+Run: `rtk xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -only-testing:AlasTests/ReviewSessionTabViewTests -only-testing:AlasTests/ReviewSessionModelsTests -only-testing:AlasTests/ReviewChangesTabViewTests test`
+
+Expected: PASS.
+
+- [ ] **Step 4: Commit Task 4**
+
+Run:
+
+```bash
+git status --short
+git add Alas/Sources/Center/ReviewWorkspace/ReviewFeedbackAgentSender.swift Alas/Sources/Center/ReviewWorkspace/ReviewDraftSummaryRail.swift Alas/Sources/Center/ReviewWorkspace/ReviewSessionTabView.swift Alas/Sources/Center/ReviewWorkspace/ReviewSessionModels.swift AlasTests/ReviewChangesTabViewTests.swift AlasTests/ReviewSessionModelsTests.swift AlasTests/ReviewSessionTabViewTests.swift
+git commit -m "feat(review): record agent handoffs"
+```
+
+Expected: focused tests pass and commit contains only handoff-related changes.
+
+## Task 5: Launcher Entry Points And Production Loader Wiring
+
+**Files:**
+- Modify: `Alas/Sources/Center/ReviewWorkspace/ReviewSessionLoader.swift`
+- Modify: `Alas/Sources/Center/ReviewChanges/ReviewChangesTabView.swift`
+- Modify: `Alas/Sources/Center/Commit/CommitTabView.swift`
+- Modify: `Alas/Sources/Center/ReviewEvidence/ReviewEvidenceTabView.swift`
+- Modify: `Alas/Sources/Center/ReviewRequest/DraftReviewRequestTabView.swift`
+- Test: `AlasTests/ReviewSessionLoaderTests.swift`
+- Test: `AlasTests/ReviewChangesTabViewTests.swift`
+- Test: `AlasTests/CommitTabViewTests.swift`
+- Test: `AlasTests/Integrations/ReviewEvidenceModelTests.swift`
+- Test: `AlasTests/Integrations/ReviewRequestDraftTests.swift`
+
+- [ ] **Step 1: Add failing launcher tests**
+
+Add targeted helper tests where the existing views already expose static helpers:
+
+```swift
+@Test func reviewChangesLauncherBuildsLocalChangesTarget() {
+    let target = ReviewChangesTabView.reviewSessionTarget(
+        worktreeID: "wt-1",
+        repositoryPath: URL(fileURLWithPath: "/repo"),
+        scope: .all
+    )
+
+    #expect(target.draftSessionID == .localChanges(worktreeID: "wt-1", worktreePath: URL(fileURLWithPath: "/repo"), scope: .all))
+    #expect(target.title == "Review all changes")
+}
+```
+
+Add equivalent helper tests for:
+
+- `CommitTabView.reviewSessionTarget(worktreeID:repositoryPath:sha:title:)`
+- `ReviewEvidenceTabView.reviewSessionTarget(worktreeID:tabState:)`
+- `DraftReviewRequestTabView.reviewSessionTarget(worktreeID:repositoryPath:tabState:)`
+
+Run focused suites.
+
+Expected: FAIL because helpers and UI actions do not exist.
+
+- [ ] **Step 2: Add production loader wiring**
+
+Add `ReviewSessionLoader.production(appState:worktree:)`.
+
+The production loader should:
+
+- local changes / draft commit: reuse the existing review changes loading helpers for `DiffReviewLoadedSession`.
+- commit: reuse `CommitReviewLoader`.
+- commit range / branch: use git diff file discovery plus `DiffParser` and `DiffDisplayModelBuilder`, matching the existing draft review request builder pattern.
+- review request: use `ReviewRequestDiffLoader` and provider snapshot data available from `ReviewEvidenceTabView`.
+- draft review request: use `DraftReviewRequestDiffSessionBuilder`.
+
+If an individual target cannot yet be loaded due to missing data at runtime, throw `ReviewSessionLoaderError.unsupportedTarget` and let the tab show the retryable error. Do not silently open an empty session.
+
+Run `ReviewSessionLoaderTests`.
+
+Expected: PASS.
+
+- [ ] **Step 3: Add open/focus helper and launcher buttons**
+
+In each launcher surface, add a static target helper plus a private open method:
+
+```swift
+@MainActor
+private func openReviewSession(target: ReviewSessionTarget) {
+    let store = ReviewSessionStore()
+    let now = Date()
+    let record = (try? store.findActive(targetID: target.id)) ?? ReviewSessionRecord(id: target.id, target: target, createdAt: now, updatedAt: now)
+    try? store.save(record)
+    appState.tabs.openOrFocusReviewSession(worktreeId: worktree.id, record: record)
+}
+```
+
+Use the local state names in each file (`worktree`, `tabState`, `snapshot`, etc.) instead of inventing globals.
+
+Add UI affordances:
+
+- Changes tab toolbar/menu: `Review Changes`
+- Commit tab review header: `Review This Commit`
+- Review Evidence Files/Feedback header: `Review Pull Request` / `Review Merge Request`
+- Draft PR/MR tab diff header: `Review Branch Diff`
+
+Run focused view tests.
+
+Expected: PASS.
+
+- [ ] **Step 4: Commit Task 5**
+
+Run:
+
+```bash
+rtk xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -only-testing:AlasTests/ReviewSessionLoaderTests -only-testing:AlasTests/ReviewChangesTabViewTests -only-testing:AlasTests/CommitTabViewTests -only-testing:AlasTests/Integrations/ReviewEvidenceModelTests -only-testing:AlasTests/Integrations/ReviewRequestDraftTests test
+git status --short
+git add Alas/Sources/Center/ReviewWorkspace/ReviewSessionLoader.swift Alas/Sources/Center/ReviewChanges/ReviewChangesTabView.swift Alas/Sources/Center/Commit/CommitTabView.swift Alas/Sources/Center/ReviewEvidence/ReviewEvidenceTabView.swift Alas/Sources/Center/ReviewRequest/DraftReviewRequestTabView.swift AlasTests/ReviewSessionLoaderTests.swift AlasTests/ReviewChangesTabViewTests.swift AlasTests/CommitTabViewTests.swift AlasTests/Integrations/ReviewEvidenceModelTests.swift AlasTests/Integrations/ReviewRequestDraftTests.swift
+git commit -m "feat(review): launch in-app review sessions"
+```
+
+Expected: focused tests pass and launcher actions compile.
+
+## Task 6: Final Integration Verification
+
+**Files:**
+- No planned source edits. Fix only issues found by verification.
+
+- [ ] **Step 1: Run focused review suites**
+
+Run:
+
+```bash
+rtk xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -only-testing:AlasTests/ReviewSessionModelsTests -only-testing:AlasTests/ReviewSessionStoreTests -only-testing:AlasTests/ReviewSessionLoaderTests -only-testing:AlasTests/ReviewSessionTabViewTests -only-testing:AlasTests/TabsManagerReviewSessionTests -only-testing:AlasTests/DiffReviewSurfaceTests -only-testing:AlasTests/ReviewFeedbackBundleTests test
+```
+
+Expected: PASS.
+
+- [ ] **Step 2: Regenerate project and build**
+
+Run:
+
+```bash
+xcodegen
+xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -quiet build
+```
+
+Expected: both commands exit 0 and no unexpected generated project churn remains.
+
+- [ ] **Step 3: Run full test suite**
+
+Run:
+
+```bash
+xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' test
+```
+
+Expected: PASS. If a known flaky suite fails, rerun that exact suite once and record the result before deciding whether to fix or report.
+
+- [ ] **Step 4: Launch for manual verification**
+
+Run:
+
+```bash
+rtk open -n /Users/nacho/Library/Developer/Xcode/DerivedData/Alas-eupuaczfhmjxxeczlwrweeuqzxqh/Build/Products/Debug/Alas.app
+```
+
+If the DerivedData path differs, locate the newest valid `Alas.app` with `Contents/MacOS/Alas` and launch that path with `rtk open -n`.
+
+Manual checks:
+
+- Open Review Changes, click `Review Changes`, and confirm a review session tab opens.
+- Add a local draft comment, send it to an ACP target, and confirm the summary rail shows sent state.
+- Reopen the same target and confirm the existing session is focused rather than duplicated.
+
+- [ ] **Step 5: Final status**
+
+Run:
+
+```bash
+git status --short
+git log --oneline -6
+```
+
+Expected: clean worktree with all implementation commits present.

--- a/docs/superpowers/specs/2026-06-15-in-app-review-sessions-agent-handoff-design.md
+++ b/docs/superpowers/specs/2026-06-15-in-app-review-sessions-agent-handoff-design.md
@@ -1,0 +1,220 @@
+# In-App Review Sessions And Agent Handoff Design
+
+## Context
+
+Alas now has the core review surface pieces: a diffs.com-like multi-file diff
+surface, local draft comments, inline comment cards, summary rail actions,
+provider PR/MR evidence loading, commit review surfaces, create PR draft
+surfaces, and direct ACP prompt sending.
+
+The remaining gap with `ai-review` is not the visual diff reader anymore. The
+gap is the review workflow: start a review over any useful diff target, keep
+that review as a first-class in-app object, collect human comments, then send
+the resulting feedback to an agent with enough context for the agent to address
+it correctly.
+
+The remaining gap with Rudu is provider mutation: creating/replying/editing and
+resolving GitHub/GitLab review comments. This phase prepares the data model for
+that work, but it does not implement provider mutation.
+
+## Goals
+
+- Add an in-app review session launcher for reviewable diff targets.
+- Make review sessions persistent and resumable inside Alas.
+- Use the existing `DiffReviewSurface` and local draft comments as the review
+  body.
+- Add native "send selected/all feedback to agent" workflows that target Alas
+  ACP sessions directly.
+- Track feedback handoff state so the review UI can distinguish unsent,
+  sent, and addressed feedback.
+- Keep the model ready for future GitHub/GitLab write-backed comments.
+
+## Non-Goals
+
+- Do not add an external `air`-style CLI or blocking `--wait --json` bridge.
+- Do not add agent skills in this phase.
+- Do not implement GitHub/GitLab comment mutation APIs in this phase.
+- Do not replace existing provider evidence loading.
+- Do not change ACP protocol behavior or introduce a second agent transport.
+
+## Review Targets
+
+V1 supports review sessions for targets that already have data loaders or nearby
+loader patterns:
+
+- local working-tree changes, with scope `all`, `unstaged`, or `staged`
+- draft commit / staged changes
+- a single commit
+- a commit range
+- a branch diff, including stack-style branch ranges
+- a provider PR/MR diff loaded through existing review evidence providers
+- a draft PR/MR request context
+
+Each target gets a stable `ReviewSessionTarget` value containing:
+
+- target kind
+- worktree ID
+- repository path
+- provider identity when applicable
+- base/head/revision identifiers when applicable
+- human-readable title and source description
+
+The target stores all revision/context fields needed to build both the diff
+session and the agent handoff prompt without depending on current checkout
+state.
+
+## Review Session State
+
+Add a durable review session record separate from individual draft comments.
+
+A review session owns:
+
+- stable session ID
+- target identity
+- created/updated timestamps
+- selected file
+- display preferences inherited from global diff preferences
+- focused comment ID when one is selected
+- handoff history
+- lightweight status: `active`, `sent`, `addressing`, `addressed`, `archived`
+
+The existing `ReviewDraftSessionID` remains the comment-storage key. The new
+review session record references or derives the relevant `ReviewDraftSessionID`
+for its target. This avoids migrating existing comments while giving Alas a
+place to track session-level state.
+
+Session persistence uses the same app-support/storage style as existing review
+draft comments and ACP sessions. The persisted format is versioned or decodes
+unknown fields safely so provider-backed comments can be added later.
+
+## Launcher UX
+
+Add a review launcher reachable from the places where users already discover
+diffs:
+
+- Changes tab: "Review Changes"
+- Draft Commit tab: "Review Staged Changes"
+- Commit tab: "Review This Commit"
+- commit/range contexts: "Review Range"
+- Review Evidence / PR/MR details: "Review Pull Request" or "Review Merge Request"
+- Create PR/MR draft tab: "Review Branch Diff"
+
+The launcher opens or focuses a review session tab. If an active session already
+exists for the same target, Alas resumes it instead of creating a duplicate
+unless the user explicitly starts a new review.
+
+The review session tab is a thin shell around the shared diff review surface:
+
+- title/header describes the target
+- file rail and diff stack come from `DiffReviewSurface`
+- local draft comments are editable/resolvable/dismissible
+- a feedback summary rail shows active/resolved/sent counts
+- send actions are available from the summary rail and individual comment cards
+
+## Native Agent Handoff
+
+The handoff uses existing ACP session mechanisms directly. No CLI or skill
+bridge is needed.
+
+Supported actions:
+
+- send selected comment to an existing writable ACP session
+- send selected comment to a new ACP session using the configured default agent
+- send all active comments to an existing writable ACP session
+- send all active comments to a new ACP session
+
+The prompt is built from `ReviewFeedbackBundle`, extended to include:
+
+- review session title
+- repository path
+- target kind
+- base/head/revision identifiers
+- provider URL when applicable
+- file path and original path
+- side and line/range
+- selected code snippet
+- comment status
+- whether this feedback was previously sent
+
+When a send succeeds, Alas records a `ReviewFeedbackHandoff` entry:
+
+- handoff ID
+- review session ID
+- comment IDs included
+- ACP session ID or new-session target
+- timestamp
+- prompt hash or revision key
+- status: `sent`, `failed`, `addressed`
+
+V1 marks handoffs as `sent` when the prompt is accepted or queued by ACP. It does
+not infer addressed status from code changes. Addressed state is user-controlled
+through existing resolve/dismiss actions.
+
+## Provider Write Readiness
+
+The model distinguishes local draft comments from future provider-backed
+threads:
+
+- local comments remain mutable locally
+- provider comments will carry provider thread/comment IDs
+- provider comments can have write capabilities: reply, edit, resolve, submit
+- provider write actions can reuse the same visible card/action surfaces
+
+This phase does not call GitHub/GitLab mutation APIs. It uses neutral names like
+review comments, handoffs, and capabilities rather than local-only names where
+the data will become provider backed.
+
+## Error Handling
+
+If a target cannot be loaded, the review session tab shows a retryable error and
+preserves the session record.
+
+If some files cannot render, keep the file in the rail and show the existing
+placeholder behavior.
+
+If there is no available agent target, show copy actions and an unavailable
+send state. Do not hide comments.
+
+If sending to an ACP session fails synchronously, keep the feedback unsent and
+show a small error on the session/summary rail. If ACP accepts the prompt for
+queueing, record the handoff as sent.
+
+If a target revision changes, the review session shows a "target moved" state.
+Provider PR/MR sessions can reload against the new head; immutable commit
+sessions stay pinned.
+
+## Testing
+
+Add focused model tests for:
+
+- target identity stability for local changes, commit, range, branch, provider,
+  and draft PR/MR targets
+- review session persistence round trips
+- review session reuse for the same target
+- handoff records and status transitions
+- prompt context includes target/revision/provider data
+
+Add loader/view tests for:
+
+- launching a local changes review session
+- launching a commit review session pinned to its SHA
+- launching or resuming a provider review session
+- sending all active comments to a mocked ACP target
+- sending one selected comment to a mocked ACP target
+- unavailable send state when no writable ACP target exists
+
+Final verification remains:
+
+```bash
+xcodegen
+xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -quiet build
+xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' test
+```
+
+## Fast Follows
+
+- Provider write actions for GitHub/GitLab comments and review decisions.
+- Review queue keyboard navigation.
+- Exact row-level inline comment insertion inside the AppKit diff body.
+- Automatic addressed-state detection from later diffs.
+- Saved review templates or prompt variants for different agent types.


### PR DESCRIPTION
## Summary
- Add persistent in-app review sessions for local changes, commits, draft commits, and draft PR/MR branch diffs
- Add native ACP handoff recording for review feedback sent to agents
- Wire review session launchers into existing diff review surfaces

## Verification
- `xcodegen`
- `rtk xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -quiet build`
- Full test suite passed locally before rebase; post-rebase quiet build passed