### PR TITLE
fix(editor): find attachment

### DIFF
--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -5498,7 +5498,7 @@
 			repositoryURL = "https://github.com/apple/swift-markdown";
 			requirement = {
 				kind = upToNextMajorVersion;
-				minimumVersion = 0.4.0;
+				minimumVersion = 0.8.0;
 			};
 		};
 		CF72A36467D20A160E653761 /* XCRemoteSwiftPackageReference "swift-tree-sitter" */ = {

--- a/Alas/Sources/Center/EditorTabView.swift
+++ b/Alas/Sources/Center/EditorTabView.swift
@@ -106,7 +106,9 @@ struct EditorTabView: View {
                 originatingRelativePath: originatingRelativePath,
                 fontFamily: appState.config.code.fontFamily,
                 fontSize: appState.config.code.fontSize,
-                showLineNumbers: appState.config.code.showLineNumbers
+                showLineNumbers: appState.config.code.showLineNumbers,
+                onTextViewAttached: { attachFindController(to: $0) },
+                onTextViewDetached: { detachFindController(from: $0) }
             )
         }
         .background(theme.color("bg-1"))
@@ -119,32 +121,6 @@ struct EditorTabView: View {
             findController.textView = nil
             activeTextView = nil
         }
-        .onReceive(NotificationCenter.default.publisher(for: .codeEditorDidAttach)) { notification in
-            guard let info = notification.userInfo,
-                  let notifTabId = info["tabId"] as? TabID,
-                  notifTabId == tabId,
-                  let textView = info["textView"] as? CodeTextView else { return }
-            clearFindHighlights()
-            if activeTextView !== textView {
-                activeTextView?.escapeHandler = fallbackEscapeHandler
-                fallbackEscapeHandler = textView.escapeHandler
-            }
-            activeTextView = textView
-            findController.textView = textView
-            findHighlightRenderer.attach(textView: textView)
-            installEscapeHandler(on: textView)
-            renderFindHighlights()
-        }
-        .onReceive(NotificationCenter.default.publisher(for: .codeEditorDidDetach)) { notification in
-            guard let info = notification.userInfo,
-                  let notifTabId = info["tabId"] as? TabID,
-                  notifTabId == tabId else { return }
-            clearFindHighlights()
-            activeTextView?.escapeHandler = nil
-            fallbackEscapeHandler = nil
-            activeTextView = nil
-            findController.textView = nil
-        }
         .onReceive(NotificationCenter.default.publisher(for: .alasShowFindReplace)) { notification in
             handleFindRequest(notification)
         }
@@ -153,6 +129,28 @@ struct EditorTabView: View {
                   textView === activeTextView else { return }
             handleEditorTextChanged()
         }
+    }
+
+    private func attachFindController(to textView: CodeTextView) {
+        clearFindHighlights()
+        if activeTextView !== textView {
+            activeTextView?.escapeHandler = fallbackEscapeHandler
+            fallbackEscapeHandler = textView.escapeHandler
+        }
+        activeTextView = textView
+        findController.textView = textView
+        findHighlightRenderer.attach(textView: textView)
+        installEscapeHandler(on: textView)
+        refreshFindMatches(selecting: findText.isEmpty ? .none : .nearestFromSelection)
+    }
+
+    private func detachFindController(from textView: CodeTextView?) {
+        if let textView, activeTextView !== textView { return }
+        clearFindHighlights()
+        activeTextView?.escapeHandler = nil
+        fallbackEscapeHandler = nil
+        activeTextView = nil
+        findController.textView = nil
     }
 
     private func handleFindRequest(_ notification: Notification) {

--- a/Alas/Sources/Center/EditorTabView.swift
+++ b/Alas/Sources/Center/EditorTabView.swift
@@ -141,7 +141,9 @@ struct EditorTabView: View {
         findController.textView = textView
         findHighlightRenderer.attach(textView: textView)
         installEscapeHandler(on: textView)
-        refreshFindMatches(selecting: findText.isEmpty ? .none : .nearestFromSelection)
+        let selection: EditorFindController.RefreshSelection =
+            findPresentation == .hidden || findText.isEmpty ? .none : .nearestFromSelection
+        refreshFindMatches(selecting: selection)
     }
 
     private func detachFindController(from textView: CodeTextView?) {

--- a/Alas/Sources/Code/Editor/CodeEditorCoordinator.swift
+++ b/Alas/Sources/Code/Editor/CodeEditorCoordinator.swift
@@ -11,6 +11,9 @@ import Observation
 @MainActor
 final class CodeEditorCoordinator {
     let appState: AppState
+    var onTextViewAttached: ((CodeTextView, TabID) -> Void)?
+    var onTextViewDetached: ((CodeTextView?, TabID?) -> Void)?
+
     private weak var textView: CodeTextView?
     private weak var buffer: EditorBuffer?
     private var layoutManager: NSLayoutManager?
@@ -270,6 +273,7 @@ final class CodeEditorCoordinator {
             object: self,
             userInfo: ["textView": textView, "tabId": tabId]
         )
+        onTextViewAttached?(textView, tabId)
     }
 
     func updateIfNeeded(worktreeId: String, worktreeRoot: URL, relativePath: String, tabId: TabID, revealLine: Int?, revealCharacter: Int?, theme: Theme, externalAbsolutePath: String? = nil, originatingRelativePath: String? = nil) {
@@ -472,6 +476,7 @@ final class CodeEditorCoordinator {
     }
 
     func detach() {
+        let detachedTextView = textView
         // LSP open/close for external buffers is managed by TabsManager
         // (tied to the buffer's cached lifetime), not by the coordinator
         // (which is torn down on every tab switch by SwiftUI's dismantleNSView).
@@ -528,6 +533,7 @@ final class CodeEditorCoordinator {
             object: self,
             userInfo: ["tabId": tabId as Any]
         )
+        onTextViewDetached?(detachedTextView, tabId)
     }
 
     // MARK: - Hover observers

--- a/Alas/Sources/Code/Editor/CodeEditorView.swift
+++ b/Alas/Sources/Code/Editor/CodeEditorView.swift
@@ -28,6 +28,8 @@ struct CodeEditorView: NSViewRepresentable {
     let fontFamily: String
     let fontSize: Int
     let showLineNumbers: Bool
+    var onTextViewAttached: (CodeTextView) -> Void = { _ in }
+    var onTextViewDetached: (CodeTextView?) -> Void = { _ in }
     @Environment(\.theme) var theme
 
     func makeCoordinator() -> CodeEditorCoordinator {
@@ -97,6 +99,7 @@ struct CodeEditorView: NSViewRepresentable {
         scroll.documentView = textView
         configureLineNumberRuler(for: scroll, textView: textView)
 
+        configureLifecycleCallbacks(on: context.coordinator)
         context.coordinator.attach(
             textView: textView,
             buffer: buffer,
@@ -114,6 +117,7 @@ struct CodeEditorView: NSViewRepresentable {
     }
 
     func updateNSView(_ nsView: NSScrollView, context: Context) {
+        configureLifecycleCallbacks(on: context.coordinator)
         context.coordinator.updateIfNeeded(
             worktreeId: worktreeId,
             worktreeRoot: worktreeRoot,
@@ -135,6 +139,22 @@ struct CodeEditorView: NSViewRepresentable {
         // Detach the coordinator from the text view, but DO NOT close the
         // buffer's LSP document or watcher — the buffer outlives this view.
         coordinator.detach()
+    }
+
+    private func configureLifecycleCallbacks(on coordinator: CodeEditorCoordinator) {
+        let expectedTabId = tabId
+        coordinator.onTextViewAttached = { textView, attachedTabId in
+            guard attachedTabId == expectedTabId else { return }
+            DispatchQueue.main.async {
+                onTextViewAttached(textView)
+            }
+        }
+        coordinator.onTextViewDetached = { textView, detachedTabId in
+            guard detachedTabId == nil || detachedTabId == expectedTabId else { return }
+            DispatchQueue.main.async {
+                onTextViewDetached(textView)
+            }
+        }
     }
 
     private func configureLineNumberRuler(for scrollView: NSScrollView, textView: CodeTextView) {

--- a/AlasTests/EditorBufferTests.swift
+++ b/AlasTests/EditorBufferTests.swift
@@ -534,6 +534,47 @@ struct EditorBufferTests {
         #expect(!buffer.storage.layoutManagers.contains { $0 === layoutManager })
     }
 
+    @Test func coordinatorCallsDirectAttachAndDetachCallbacks() throws {
+        let root = tempWorktree()
+        _ = try writeFile(root, "a.txt", "v1\n")
+        let buffer = EditorBuffer(worktreeRoot: root, relativePath: "a.txt")
+        let layoutManager = NSLayoutManager()
+        let textContainer = NSTextContainer(size: NSSize(width: 800, height: 600))
+        layoutManager.addTextContainer(textContainer)
+        let textView = CodeTextView(frame: NSRect(x: 0, y: 0, width: 800, height: 600), textContainer: textContainer)
+        let coordinator = CodeEditorCoordinator(appState: AppState())
+        let theme = try ThemeStore().current
+        var attachedTextView: CodeTextView?
+        var attachedTabId: TabID?
+        var detachedTabId: TabID?
+
+        coordinator.onTextViewAttached = { textView, tabId in
+            attachedTextView = textView
+            attachedTabId = tabId
+        }
+        coordinator.onTextViewDetached = { _, tabId in
+            detachedTabId = tabId
+        }
+
+        coordinator.attach(
+            textView: textView,
+            buffer: buffer,
+            layoutManager: layoutManager,
+            worktreeId: "wt",
+            worktreeRoot: root,
+            tabId: "t",
+            revealLine: nil,
+            revealCharacter: nil,
+            theme: theme
+        )
+        #expect(attachedTextView === textView)
+        #expect(attachedTabId == "t")
+
+        coordinator.detach()
+
+        #expect(detachedTabId == "t")
+    }
+
     @Test func coordinatorAppliesMonospacedFontToLoadedContent() throws {
         // Regression: after rebinding, applyBaseStyle was reading
         // `textView.font` whose getter falls back to the system default font


### PR DESCRIPTION
## Summary
- Bind the center-pane editor find controller through direct `CodeEditorView` lifecycle callbacks instead of same-view attach notifications.
- Refresh find matches as soon as the mounted `CodeTextView` is attached so searches run against the visible editor buffer.
- Add regression coverage for coordinator attach/detach callbacks.

## Root cause
`CodeEditorCoordinator.attach` posted `.codeEditorDidAttach` during `NSViewRepresentable.makeNSView`. The parent `EditorTabView` listened with `.onReceive`, which can miss notifications emitted before the SwiftUI subscription is installed. When that happened, the find controller never received the live `CodeTextView`, so searches reported no matches even though the text was visible.

## Verification
- `xcodegen`
- `xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -quiet build`
- `xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -only-testing:AlasTests/EditorFindControllerTests -only-testing:AlasTests/EditorBufferTests test` (65 tests passed)

Note: full `xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' test` was attempted, but the app-hosted test run hung after several minutes and was interrupted.