### PR TITLE
Smooth diff review scrolling

### DIFF
--- a/Alas/Sources/Center/Diff/DiffPaneTextDocumentView.swift
+++ b/Alas/Sources/Center/Diff/DiffPaneTextDocumentView.swift
@@ -602,6 +602,11 @@ enum DiffPaneLineTone: Equatable {
 }
 
 final class DiffPaneCodeTextView: NSTextView {
+    private struct RowGeometry {
+        let rowRects: [NSRect]
+        let firstLineFragmentRects: [NSRect]
+    }
+
     static func placeholderHatchRect(in rowRect: NSRect) -> NSRect {
         rowRect.insetBy(dx: 0, dy: 1)
     }
@@ -613,11 +618,22 @@ final class DiffPaneCodeTextView: NSTextView {
     private var ownedTextStorage: NSTextStorage?
     private var customTrackingArea: NSTrackingArea?
     private var lspController: DiffPaneLSPController?
+    private var cachedRowGeometry: RowGeometry?
+    private var rowGeometryComputationCount = 0
+
+    var rowGeometryComputationCountForTesting: Int {
+        rowGeometryComputationCount
+    }
 
     var lineTones: [DiffPaneLineTone] = [] {
-        didSet { needsDisplay = true }
+        didSet {
+            invalidateDiffRowGeometry()
+            needsDisplay = true
+        }
     }
-    var lineMetadata: [DiffPaneTextDocumentBuilder.LineMetadata] = []
+    var lineMetadata: [DiffPaneTextDocumentBuilder.LineMetadata] = [] {
+        didSet { invalidateDiffRowGeometry() }
+    }
     var hoverHandler: ((NSPoint) -> Void)?
     var commandClickHandler: ((NSPoint) -> Void)?
     var flagsChangedHandler: ((NSEvent) -> Void)?
@@ -657,6 +673,19 @@ final class DiffPaneCodeTextView: NSTextView {
     override func draw(_ dirtyRect: NSRect) {
         drawLineBackgrounds(in: dirtyRect)
         super.draw(dirtyRect)
+    }
+
+    override func setFrameSize(_ newSize: NSSize) {
+        let oldSize = frame.size
+        super.setFrameSize(newSize)
+        if abs(oldSize.width - newSize.width) > 0.5 {
+            invalidateDiffRowGeometry()
+        }
+    }
+
+    override func didChangeText() {
+        super.didChangeText()
+        invalidateDiffRowGeometry()
     }
 
     override func mouseMoved(with event: NSEvent) {
@@ -701,33 +730,61 @@ final class DiffPaneCodeTextView: NSTextView {
     }
 
     func diffRowRects() -> [NSRect] {
-        guard let layoutManager, let textContainer else { return [] }
+        rowGeometry().rowRects
+    }
+
+    func diffFirstLineFragmentRects() -> [NSRect] {
+        rowGeometry().firstLineFragmentRects
+    }
+
+    func invalidateDiffRowGeometry() {
+        cachedRowGeometry = nil
+    }
+
+    private func rowGeometry() -> RowGeometry {
+        if let cachedRowGeometry {
+            return cachedRowGeometry
+        }
+
+        let computed = computeRowGeometry()
+        cachedRowGeometry = computed
+        rowGeometryComputationCount += 1
+        return computed
+    }
+
+    private func computeRowGeometry() -> RowGeometry {
+        guard let layoutManager, let textContainer else {
+            return RowGeometry(rowRects: [], firstLineFragmentRects: [])
+        }
         layoutManager.ensureLayout(for: textContainer)
         let paragraphRanges = paragraphRanges(lineCount: lineTones.count)
+        let origin = textContainerOrigin
         var nextY = textContainerOrigin.y
-        return paragraphRanges.map { range in
+
+        var rowRects: [NSRect] = []
+        var firstLineFragmentRects: [NSRect] = []
+        rowRects.reserveCapacity(paragraphRanges.count)
+        firstLineFragmentRects.reserveCapacity(paragraphRanges.count)
+
+        for range in paragraphRanges {
             let height = measuredRowHeight(for: range, layoutManager: layoutManager)
-            defer { nextY += height }
-            return NSRect(
+            let rowRect = NSRect(
                 x: 0,
                 y: nextY,
                 width: max(bounds.width, visibleRect.width),
                 height: height
             )
-        }
-    }
-
-    func diffFirstLineFragmentRects() -> [NSRect] {
-        guard let layoutManager, let textContainer else { return [] }
-        layoutManager.ensureLayout(for: textContainer)
-        let origin = textContainerOrigin
-        return paragraphRanges(lineCount: lineTones.count).map { range in
-            firstLineFragmentRect(
+            let firstRect = firstLineFragmentRect(
                 for: range,
                 layoutManager: layoutManager,
                 origin: origin
             )
+            rowRects.append(rowRect)
+            firstLineFragmentRects.append(firstRect)
+            nextY += height
         }
+
+        return RowGeometry(rowRects: rowRects, firstLineFragmentRects: firstLineFragmentRects)
     }
 
     func characterIndex(at point: NSPoint) -> Int? {

--- a/Alas/Sources/Center/DiffReview/DiffReviewScrollSpy.swift
+++ b/Alas/Sources/Center/DiffReview/DiffReviewScrollSpy.swift
@@ -124,6 +124,8 @@ enum DiffReviewScrollCommandConsumption {
 enum DiffReviewRenderWindow {
     private static let leadingScreens: CGFloat = 1.25
     private static let trailingScreens: CGFloat = 2.5
+    private static let retentionLeadingScreens: CGFloat = 3.0
+    private static let retentionTrailingScreens: CGFloat = 4.0
 
     static func renderedFileIDs(
         current: Set<DiffReviewFileID>,
@@ -135,6 +137,12 @@ enum DiffReviewRenderWindow {
     ) -> Set<DiffReviewFileID> {
         var rendered = Set(frames.compactMap { frame -> DiffReviewFileID? in
             guard isNearViewport(frame, viewportHeight: viewportHeight) else { return nil }
+            return frame.id
+        })
+        rendered.formUnion(frames.compactMap { frame -> DiffReviewFileID? in
+            guard current.contains(frame.id),
+                  isWithinRetentionBand(frame, viewportHeight: viewportHeight)
+            else { return nil }
             return frame.id
         })
 
@@ -159,6 +167,13 @@ enum DiffReviewRenderWindow {
         let height = max(viewportHeight, 1)
         let minY = -height * leadingScreens
         let maxY = height * trailingScreens
+        return frame.maxY >= minY && frame.minY <= maxY
+    }
+
+    private static func isWithinRetentionBand(_ frame: DiffReviewSectionFrame, viewportHeight: CGFloat) -> Bool {
+        let height = max(viewportHeight, 1)
+        let minY = -height * retentionLeadingScreens
+        let maxY = height * retentionTrailingScreens
         return frame.maxY >= minY && frame.minY <= maxY
     }
 }

--- a/AlasTests/DiffPaneViewTests.swift
+++ b/AlasTests/DiffPaneViewTests.swift
@@ -1165,6 +1165,48 @@ struct DiffPaneViewTests {
         #expect(codeView.lineMetadata.first?.sourceLine?.anchor.newLine == 3)
     }
 
+    @Test func diffPaneCodeTextViewCachesMeasuredRowGeometry() throws {
+        let font = NSFont.monospacedSystemFont(ofSize: 13, weight: .regular)
+        let text = """
+        let first = 1
+        let second = 2
+        """
+        let document = DiffPaneTextDocumentBuilder.CodeDocument(
+            attributedString: NSAttributedString(string: text, attributes: [.font: font]),
+            lines: [
+                DiffPaneTextDocumentBuilder.LineMetadata(kind: .context, range: NSRange(location: 0, length: 13)),
+                DiffPaneTextDocumentBuilder.LineMetadata(kind: .context, range: NSRange(location: 14, length: 14)),
+            ]
+        )
+        let scrollView = DiffPaneTextScrollView(frame: NSRect(x: 0, y: 0, width: 420, height: 120))
+        let theme = try Theme.loadBundled(id: "cool-slate")
+
+        scrollView.update(
+            document: document,
+            lineLabels: [" 1", " 2"],
+            wraps: true,
+            font: font,
+            theme: theme,
+            lspContext: nil,
+            allowedLSPSide: .new
+        )
+        scrollView.layoutSubtreeIfNeeded()
+
+        let codeView = try #require(scrollView.documentView as? DiffPaneCodeTextView)
+
+        _ = codeView.diffRowRects()
+        _ = codeView.diffRowRects()
+        _ = codeView.diffFirstLineFragmentRects()
+        _ = codeView.diffFirstLineFragmentRects()
+
+        #expect(codeView.rowGeometryComputationCountForTesting == 1)
+
+        codeView.setFrameSize(NSSize(width: 260, height: codeView.frame.height))
+        _ = codeView.diffRowRects()
+
+        #expect(codeView.rowGeometryComputationCountForTesting == 2)
+    }
+
     @Test func diffPaneCodeTextViewResolvesSymbolsFromPoints() throws {
         let textView = DiffPaneCodeTextView(frame: NSRect(x: 0, y: 0, width: 300, height: 80), textContainer: NSTextContainer())
         textView.textStorage?.setAttributedString(NSAttributedString(string: "let value = service.fetch()"))

--- a/AlasTests/DiffReviewSurfaceTests.swift
+++ b/AlasTests/DiffReviewSurfaceTests.swift
@@ -1690,6 +1690,33 @@ struct DiffReviewSurfaceTests {
         #expect(!rendered.contains(far))
     }
 
+    @Test func renderWindowRetainsRecentlyRenderedFilesNearViewport() {
+        let visible = DiffReviewFileID(namespace: "commit", path: "Visible.swift")
+        let justAbove = DiffReviewFileID(namespace: "commit", path: "JustAbove.swift")
+        let justBelow = DiffReviewFileID(namespace: "commit", path: "JustBelow.swift")
+        let far = DiffReviewFileID(namespace: "commit", path: "Far.swift")
+        let frames = [
+            DiffReviewSectionFrame(id: visible, minY: 120, maxY: 420),
+            DiffReviewSectionFrame(id: justAbove, minY: -1_200, maxY: -900),
+            DiffReviewSectionFrame(id: justBelow, minY: 1_600, maxY: 1_900),
+            DiffReviewSectionFrame(id: far, minY: 9_000, maxY: 9_300),
+        ]
+
+        let rendered = DiffReviewRenderWindow.renderedFileIDs(
+            current: [justAbove, justBelow, far],
+            frames: frames,
+            viewportHeight: 500,
+            selectedFileID: nil,
+            programmaticTarget: nil,
+            firstFileID: nil
+        )
+
+        #expect(rendered.contains(visible))
+        #expect(rendered.contains(justAbove))
+        #expect(rendered.contains(justBelow))
+        #expect(!rendered.contains(far))
+    }
+
     @Test func estimatedSectionHeightScalesWithDiffRows() {
         let small = DiffReviewFileSectionModel(
             summary: summary(path: "Sources/Small.swift"),


### PR DESCRIPTION
## Summary
- Cache AppKit diff row geometry so repeated gutter/background drawing does not force fresh TextKit layout during scrolling
- Retain recently rendered review file sections through a wider scroll retirement band to avoid AppKit diff teardown/rebuild churn when reversing direction
- Add focused regressions for row-geometry reuse and render-window retention

## Verification
- `rtk xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -only-testing:AlasTests/DiffReviewSurfaceTests -only-testing:AlasTests/DiffPaneViewTests -quiet test`
- `xcodegen`
- `rtk xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -quiet build`
- `rtk xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' test`