### PR TITLE
fix(editor): stale autocomplete refresh state

### DIFF
--- a/Alas/Sources/Code/LSP/Features/CompletionFeature.swift
+++ b/Alas/Sources/Code/LSP/Features/CompletionFeature.swift
@@ -340,8 +340,11 @@ final class CompletionFeature {
         requestTask?.cancel()
         requestTask = nil
         requestID &+= 1
+        candidates.removeAll()
         prefix = nil
+        selection = 0
         isRefreshing = true
+        closeUI()
     }
 
     private func canAcceptCompletion(prefix: CompletionPrefix, in textView: CodeTextView) -> Bool {
@@ -373,3 +376,43 @@ final class CompletionFeature {
         return true
     }
 }
+
+#if DEBUG
+extension CompletionFeature {
+    struct TestingSnapshot: Equatable {
+        let candidateLabels: [String]
+        let prefix: CompletionPrefix?
+        let selection: Int
+        let isRefreshing: Bool
+    }
+
+    func testingSeedVisibleCandidates(labels: [String], prefix: CompletionPrefix, selection: Int = 0) {
+        candidates = labels.map {
+            CompletionCandidate(
+                label: $0,
+                detail: nil,
+                kind: nil,
+                documentation: nil,
+                sortText: nil,
+                filterText: $0,
+                replacementText: $0,
+                textEdit: nil,
+                additionalTextEdits: [],
+                source: .lsp
+            )
+        }
+        self.prefix = prefix
+        self.selection = min(max(selection, 0), max(candidates.count - 1, 0))
+        isRefreshing = false
+    }
+
+    var testingSnapshot: TestingSnapshot {
+        TestingSnapshot(
+            candidateLabels: candidates.map(\.label),
+            prefix: prefix,
+            selection: selection,
+            isRefreshing: isRefreshing
+        )
+    }
+}
+#endif

--- a/AlasTests/Code/LSP/Features/CompletionFeatureTests.swift
+++ b/AlasTests/Code/LSP/Features/CompletionFeatureTests.swift
@@ -64,6 +64,29 @@ struct CompletionFeatureTests {
         #expect(!CompletionFeature.isMemberAccessTriggerCharacter(nil))
     }
 
+    @Test("refresh clears stale candidates before the next response")
+    func refreshClearsStaleCandidatesBeforeNextResponse() {
+        let textView = makeTextView("open")
+        let feature = CompletionFeature(
+            textView: textView,
+            getClient: { nil },
+            getURI: { "file:///tmp/foo.swift" },
+            isEnabled: { true }
+        )
+        feature.testingSeedVisibleCandidates(
+            labels: ["openAlpha", "openBeta"],
+            prefix: CompletionPrefix(text: "open", range: NSRange(location: 0, length: 4))
+        )
+
+        textView.completionChangeHandler?()
+
+        #expect(feature.testingSnapshot.candidateLabels.isEmpty)
+        #expect(feature.testingSnapshot.prefix == nil)
+        #expect(feature.testingSnapshot.selection == 0)
+        #expect(feature.testingSnapshot.isRefreshing)
+        feature.cancelAndDismiss()
+    }
+
     private func waitForCompletionRequest(events: () -> [String]) async throws {
         let deadline = Date().addingTimeInterval(2)
         while !events().contains("completion"), Date() < deadline {


### PR DESCRIPTION
## Summary
- Clear stale completion candidates when a refresh starts
- Hide the old popup while waiting for the next completion response
- Add a regression test for refresh clearing stale candidates
- Regenerate the Xcode project dependency metadata

## Verification
- xcodegen
- xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -quiet build
- xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' test -only-testing:AlasTests/CompletionFeatureTests

Note: a full local test run was attempted but hung during the broader suite after several minutes; the stuck xcodebuild/test-host processes were terminated.