### PR TITLE
fix(editor): stale editor undo teardown

### DIFF
--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -5498,7 +5498,7 @@
 			repositoryURL = "https://github.com/apple/swift-markdown";
 			requirement = {
 				kind = upToNextMajorVersion;
-				minimumVersion = 0.4.0;
+				minimumVersion = 0.8.0;
 			};
 		};
 		CF72A36467D20A160E653761 /* XCRemoteSwiftPackageReference "swift-tree-sitter" */ = {

--- a/Alas/Sources/Code/Editor/CodeEditorCoordinator.swift
+++ b/Alas/Sources/Code/Editor/CodeEditorCoordinator.swift
@@ -518,6 +518,7 @@ final class CodeEditorCoordinator {
         textView?.increaseFontSizeHandler = nil
         textView?.decreaseFontSizeHandler = nil
         textView?.resetFontSizeHandler = nil
+        textView?.undoManager?.removeAllActions()
         textView = nil
         buffer = nil
         // We deliberately do NOT close the LSP document or stop the file

--- a/AlasTests/EditorBufferTests.swift
+++ b/AlasTests/EditorBufferTests.swift
@@ -909,6 +909,40 @@ struct EditorBufferTests {
 
         #expect(textView.undoManager?.canUndo == false)
     }
+
+    @Test func coordinatorDetachClearsTextViewUndoStack() throws {
+        // Regression: AppKit text undo actions target the NSTextView/TextKit
+        // objects that created them. If SwiftUI tears down the editor while
+        // those actions remain in the responder-chain undo manager, a later
+        // Edit > Undo can send _undoRedoTextOperation: to stale objects.
+        let root = tempWorktree()
+        _ = try writeFile(root, "a.swift", "let a = 1\n")
+        let appState = AppState()
+        let buffer = appState.tabs.buffer(
+            worktreeId: "wt", tabId: "tab-a",
+            worktreeRoot: root, relativePath: "a.swift"
+        )
+        let layoutManager = NSLayoutManager()
+        let textContainer = NSTextContainer(size: NSSize(width: 800, height: 600))
+        layoutManager.addTextContainer(textContainer)
+        let textView = CodeTextView(frame: NSRect(x: 0, y: 0, width: 800, height: 600), textContainer: textContainer)
+        let undoOwner = TestUndoOwner()
+        textView.delegate = undoOwner
+        let coordinator = CodeEditorCoordinator(appState: appState)
+        let theme = try ThemeStore().current
+        coordinator.attach(
+            textView: textView, buffer: buffer, layoutManager: layoutManager,
+            worktreeId: "wt", worktreeRoot: root, tabId: "tab-a",
+            revealLine: nil, revealCharacter: nil, theme: theme
+        )
+
+        textView.undoManager?.registerUndo(withTarget: textView) { _ in }
+        #expect(textView.undoManager?.canUndo == true)
+
+        coordinator.detach()
+
+        #expect(textView.undoManager?.canUndo == false)
+    }
 }
 
 @MainActor


### PR DESCRIPTION
## Summary

Fixes a crash path where AppKit could invoke stale text undo actions after a code editor view was torn down.

## Root cause

The crash report shows `NSUndoManager` invoking AppKit text undo machinery (`_undoRedoTextOperation:`) on the main thread. The editor already clears undo history when rebinding between buffers, but teardown left the responder-chain undo manager intact while SwiftUI dismantled the `CodeTextView` and TextKit objects.

## Changes

- Clear the text view undo manager when `CodeEditorCoordinator.detach()` releases editor handlers and references.
- Add a Swift Testing regression covering coordinator detach with a staged undo action.
- Regenerate the Xcode project with `xcodegen`.

## Verification

- `xcodegen`
- `xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -quiet build`
- `xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' '-only-testing:AlasTests/EditorBufferTests/coordinatorDetachClearsTextViewUndoStack()' test`
- `xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' '-only-testing:AlasTests/EditorBufferTests/coordinatorPathChangeClearsTextViewUndoStack()' test`

Note: an unfiltered `xcodebuild ... test` run was attempted and started executing Swift Testing cases, but it became silent with the test host still alive and was interrupted.