### PR TITLE
feat(diff): add expandable diff context rows

### DIFF
--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -636,6 +636,7 @@
 		9D4F9F5CE9FF51C33E32703C /* ACPMessageWire.swift in Sources */ = {isa = PBXBuildFile; fileRef = D21F30DB5A812E396262A926 /* ACPMessageWire.swift */; };
 		9D6FE5A4589D73A7480CE2B2 /* IndentationHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 35C3F234BEF9CE053CD4DB1E /* IndentationHelper.swift */; };
 		9D99FFFDFB3A256C4960D388 /* ReleaseCheckerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C2E0C7ED63A67D16A79DF4BA /* ReleaseCheckerTests.swift */; };
+		9DDA9F2462746F06A652973A /* DiffContextExpansionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2B9CB2A64E9E16A2DE3A6272 /* DiffContextExpansionTests.swift */; };
 		9DF0D37CE59DF8AAD7172443 /* ACPSetupChecker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3E9864A515B0ED49C68739B6 /* ACPSetupChecker.swift */; };
 		9E302329243407946D47DC91 /* BranchPicker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2BFD4C762D8323B78934ECE7 /* BranchPicker.swift */; };
 		9E349701BA73BBCCCBB135B3 /* DraftCommitTabView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC3CA543A17D1C3DFA70A80C /* DraftCommitTabView.swift */; };
@@ -753,6 +754,7 @@
 		B884D1257E321D543B5BC670 /* ShortcutBindingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2440A9DE95B4F783AA69A355 /* ShortcutBindingTests.swift */; };
 		B8B0B60C8096F691F8401D31 /* TabBarView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BEC7CCBF8463A95EAAE9EBCE /* TabBarView.swift */; };
 		B8BA936481455853CFC3393F /* ANSIStream.swift in Sources */ = {isa = PBXBuildFile; fileRef = BAE3E5634CC9BA68765EA539 /* ANSIStream.swift */; };
+		B8C893DFB0965CB7EB0AFD10 /* DiffContextExpansion.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF71AF50DF50AA4158A96177 /* DiffContextExpansion.swift */; };
 		B8D2EB18303D58777D79CDBA /* SearchResult.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A0FF718D68E15F539577F56 /* SearchResult.swift */; };
 		B94F61E5170AA8102AA2A022 /* DiffPaneLSP.swift in Sources */ = {isa = PBXBuildFile; fileRef = B58BD62080F250E0F0DD057F /* DiffPaneLSP.swift */; };
 		B9BEA46E818C321122713F41 /* EditorFindControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6033DBD8BF13A76978A653A3 /* EditorFindControllerTests.swift */; };
@@ -1222,6 +1224,7 @@
 		2B142F2A747C7F2D96E8BAD1 /* SessionRegistry.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionRegistry.swift; sourceTree = "<group>"; };
 		2B7ADCB7C4178FE036A31214 /* ACPComposerActionButtonMetricsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPComposerActionButtonMetricsTests.swift; sourceTree = "<group>"; };
 		2B932ED9D5A485AE1545223C /* ACPPermissionFSTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPPermissionFSTests.swift; sourceTree = "<group>"; };
+		2B9CB2A64E9E16A2DE3A6272 /* DiffContextExpansionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiffContextExpansionTests.swift; sourceTree = "<group>"; };
 		2B9E3F080F847EF069137844 /* ShortcutBinding.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShortcutBinding.swift; sourceTree = "<group>"; };
 		2BFCE07604D55558B13FC33B /* DiffOpenFileAvailabilityTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiffOpenFileAvailabilityTests.swift; sourceTree = "<group>"; };
 		2BFD4C762D8323B78934ECE7 /* BranchPicker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BranchPicker.swift; sourceTree = "<group>"; };
@@ -2070,6 +2073,7 @@
 		FE66950F2226F1182DCDD39A /* RightPaneView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RightPaneView.swift; sourceTree = "<group>"; };
 		FEB2EC20D23F9A4F50B1A6E3 /* TerminalPane.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TerminalPane.swift; sourceTree = "<group>"; };
 		FEC68B05B719B9235865027F /* ThreePaneSizing.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThreePaneSizing.swift; sourceTree = "<group>"; };
+		FF71AF50DF50AA4158A96177 /* DiffContextExpansion.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiffContextExpansion.swift; sourceTree = "<group>"; };
 		FF741B889D6DC8B1F4EB350F /* ProcessGitDataTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProcessGitDataTests.swift; sourceTree = "<group>"; };
 		FFAFB40F5FACBC726C7E4172 /* ACPAdapterInstaller.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPAdapterInstaller.swift; sourceTree = "<group>"; };
 		FFB1CCDE2E4D85A46E6CFB1A /* GitServiceReviewRequestDraftTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GitServiceReviewRequestDraftTests.swift; sourceTree = "<group>"; };
@@ -2306,6 +2310,7 @@
 				AA98E1DB8D77DE67918D6B9F /* CopilotInstallerTests.swift */,
 				BF3F87CE04B7E98606BF76CA /* CursorInstallerTests.swift */,
 				179A74F3A825DA1EC4C4E0FC /* DebounceTimerTests.swift */,
+				2B9CB2A64E9E16A2DE3A6272 /* DiffContextExpansionTests.swift */,
 				6181842BEA798CB8606F222B /* DiffDisplayModelBuilderTests.swift */,
 				61D4F5B30CE2AA0220A3E45C /* DiffInlineHighlighterTests.swift */,
 				2BFCE07604D55558B13FC33B /* DiffOpenFileAvailabilityTests.swift */,
@@ -3058,6 +3063,7 @@
 			isa = PBXGroup;
 			children = (
 				C50700F7960B44D0116F09C8 /* DiffCodeText.swift */,
+				FF71AF50DF50AA4158A96177 /* DiffContextExpansion.swift */,
 				CF8CB5B1DA091EE7D5DA0436 /* DiffDisplayModel.swift */,
 				00F66827E8BFF9AB51D76A96 /* DiffDisplayModelBuilder.swift */,
 				5C96772DABFBCF15691FFB37 /* DiffDisplayPreferences.swift */,
@@ -4376,6 +4382,7 @@
 				90958414931FC96F766F0C46 /* DiagnosticsFeature.swift in Sources */,
 				9FD539228216762192A02C69 /* DialogChrome.swift in Sources */,
 				38A19A8CE98216F87C522952 /* DiffCodeText.swift in Sources */,
+				B8C893DFB0965CB7EB0AFD10 /* DiffContextExpansion.swift in Sources */,
 				A630ABCDF04C36956349606C /* DiffDisplayModel.swift in Sources */,
 				E8F4E5FAC73026DAC29FDEF7 /* DiffDisplayModelBuilder.swift in Sources */,
 				3F0D7932AB67DDF711AF1B6F /* DiffDisplayPreferences.swift in Sources */,
@@ -4908,6 +4915,7 @@
 				25347EFEF1B5F7F4915DB120 /* DebounceTimerTests.swift in Sources */,
 				7EB64E55CE27886D660C5D0C /* DefinitionSnippetCacheTests.swift in Sources */,
 				BFF99F8FDEA5D05EF4E1EEC3 /* DiagnosticsRangeTests.swift in Sources */,
+				9DDA9F2462746F06A652973A /* DiffContextExpansionTests.swift in Sources */,
 				899FB89D155619CF846C6BDC /* DiffDisplayModelBuilderTests.swift in Sources */,
 				172298A09BC94456A27EFCB7 /* DiffInlineHighlighterTests.swift in Sources */,
 				9927E3934D3CAA9055EF5E44 /* DiffOpenFileAvailabilityTests.swift in Sources */,

--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -248,6 +248,7 @@
 		3D711A767050DB05E4C77548 /* SurfaceViewKeyboardTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF5143046167375A802ED378 /* SurfaceViewKeyboardTests.swift */; };
 		3D98C4F5EE2C0B1203C76752 /* ACPImageChipAttachment.swift in Sources */ = {isa = PBXBuildFile; fileRef = A7FB37A9430467B477E40819 /* ACPImageChipAttachment.swift */; };
 		3DB85FF0D4965BF78AD2B010 /* MergeSidePane.swift in Sources */ = {isa = PBXBuildFile; fileRef = 52C55C85672956E1340B03B1 /* MergeSidePane.swift */; };
+		3DC03A7B9F9959155AE2B60E /* DiffReviewContextProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD6385E6DE02E97B0041616F /* DiffReviewContextProvider.swift */; };
 		3E0A4613EB8F41DA8C182C36 /* FormatOnSaveTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5BEBDB5A6617C62D0F1C0D1 /* FormatOnSaveTests.swift */; };
 		3E0AA46F17D152BFDA52A79D /* NotificationServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C2AEA30B7C74A39A46448AF5 /* NotificationServiceTests.swift */; };
 		3E46667F7AA794E24B04BC7F /* TerminalCLIInjection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 013AF8211B98BD98B65DF632 /* TerminalCLIInjection.swift */; };
@@ -1866,6 +1867,7 @@
 		CC83C13F9F6391F9CE8BF2CA /* MarkdownViewMode.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MarkdownViewMode.swift; sourceTree = "<group>"; };
 		CC958412AAB6B8788171F74A /* ReviewChangesLoaderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReviewChangesLoaderTests.swift; sourceTree = "<group>"; };
 		CD0A56D300AE7380A16F1D42 /* ReviewRequestDiffLoader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReviewRequestDiffLoader.swift; sourceTree = "<group>"; };
+		CD6385E6DE02E97B0041616F /* DiffReviewContextProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiffReviewContextProvider.swift; sourceTree = "<group>"; };
 		CD9289893FA7DC9DB8565353 /* MarkdownParser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MarkdownParser.swift; sourceTree = "<group>"; };
 		CDAE8FBBADF986E1E6585941 /* ReviewChangesModelsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReviewChangesModelsTests.swift; sourceTree = "<group>"; };
 		CDE49D2437D7E6AC9D67F136 /* RemoteSessionGateway.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteSessionGateway.swift; sourceTree = "<group>"; };
@@ -3625,6 +3627,7 @@
 		C96401D17E1C5E3A5F55212E /* DiffReview */ = {
 			isa = PBXGroup;
 			children = (
+				CD6385E6DE02E97B0041616F /* DiffReviewContextProvider.swift */,
 				65B5815D9BE36D3F835B5456 /* DiffReviewFileSection.swift */,
 				E8B46B2287CA16E683490301 /* DiffReviewInlineFeedbackActions.swift */,
 				14D1ECA099BBDCB5BB2EEC67 /* DiffReviewModels.swift */,
@@ -4394,6 +4397,7 @@
 				A971C64CC3136E00C5FC158C /* DiffPaneView.swift in Sources */,
 				02425EBF61592A01B1FCC7D0 /* DiffParser.swift in Sources */,
 				B7067A1BBEB1B1B5B9867BEA /* DiffPreferenceBindings.swift in Sources */,
+				3DC03A7B9F9959155AE2B60E /* DiffReviewContextProvider.swift in Sources */,
 				D6022D340521FC907FD901DE /* DiffReviewFileSection.swift in Sources */,
 				AB4B19ECC0C3D7242ECD42C6 /* DiffReviewInlineFeedbackActions.swift in Sources */,
 				5806E3E41DA735380E33BF76 /* DiffReviewModels.swift in Sources */,

--- a/Alas/Sources/Center/Commit/CommitReviewLoader.swift
+++ b/Alas/Sources/Center/Commit/CommitReviewLoader.swift
@@ -73,7 +73,8 @@ struct CommitReviewLoader {
                 ? try await buildDisplayModel(diff: diff, filePath: file.path)
                 : nil,
             placeholderMessage: canRender ? nil : placeholderMessage(for: file, diff: diff),
-            openFile: openFile
+            openFile: openFile,
+            contextProvider: nil
         )
     }
 

--- a/Alas/Sources/Center/Commit/CommitReviewLoader.swift
+++ b/Alas/Sources/Center/Commit/CommitReviewLoader.swift
@@ -2,6 +2,7 @@ import Foundation
 
 protocol CommitReviewGitClient {
     func diff(worktreePath: URL, sha: String, file: String, originalPath: String?) async throws -> ParsedDiff
+    func commitContextSnapshot(worktreePath: URL, sha: String, file: String, originalPath: String?) async throws -> DiffReviewFileContextSnapshot
 }
 
 extension GitService: CommitReviewGitClient {}
@@ -37,6 +38,8 @@ struct CommitReviewLoader {
             sections.append(try await fileSection(
                 for: file,
                 diff: diff,
+                worktreePath: worktreePath,
+                sha: sha,
                 openFile: openFileForPath(file.path)
             ))
         }
@@ -50,6 +53,8 @@ struct CommitReviewLoader {
     private func fileSection(
         for file: CommitChangedFile,
         diff: ParsedDiff,
+        worktreePath: URL,
+        sha: String,
         openFile: (() -> Void)?
     ) async throws -> DiffReviewFileSectionModel {
         let canRender = !diff.hunks.isEmpty && !ImageFileType.isSupported(relativePath: file.path)
@@ -74,7 +79,14 @@ struct CommitReviewLoader {
                 : nil,
             placeholderMessage: canRender ? nil : placeholderMessage(for: file, diff: diff),
             openFile: openFile,
-            contextProvider: nil
+            contextProvider: DiffReviewContextProvider {
+                try await git.commitContextSnapshot(
+                    worktreePath: worktreePath,
+                    sha: sha,
+                    file: file.path,
+                    originalPath: file.originalPath
+                )
+            }
         )
     }
 

--- a/Alas/Sources/Center/Diff/DiffContextExpansion.swift
+++ b/Alas/Sources/Center/Diff/DiffContextExpansion.swift
@@ -63,7 +63,7 @@ enum DiffContextExpandedDisplayBuilder {
 
     static func derive(
         groups: [DiffDisplayGroup],
-        snapshot: DiffReviewFileContextSnapshot,
+        snapshot: DiffReviewFileContextSnapshot?,
         providerAvailable: Bool,
         expansion: DiffContextExpansionState,
         filePath: String,
@@ -109,16 +109,49 @@ enum DiffContextExpandedDisplayBuilder {
         }
     }
 
+    static func availableLineCount(
+        key: DiffContextExpansionKey,
+        groups: [DiffDisplayGroup],
+        snapshot: DiffReviewFileContextSnapshot?
+    ) -> Int {
+        guard
+            let snapshot,
+            let groupIndex = groups.firstIndex(where: { $0.id == key.groupID })
+        else {
+            return 0
+        }
+        return boundaryRange(
+            for: groups[groupIndex],
+            groupIndex: groupIndex,
+            boundary: key.boundary,
+            groups: groups,
+            snapshot: snapshot
+        ).lineCount
+    }
+
     private static func expansionRows(
         for group: DiffDisplayGroup,
         groupIndex: Int,
         boundary: DiffContextBoundary,
         groups: [DiffDisplayGroup],
-        snapshot: DiffReviewFileContextSnapshot,
+        snapshot: DiffReviewFileContextSnapshot?,
         expansion: DiffContextExpansionState,
         filePath: String,
         chunkSize: Int
     ) -> [DiffDisplayRow] {
+        guard let snapshot else {
+            guard optimisticBoundaryAvailable(
+                for: group,
+                groupIndex: groupIndex,
+                boundary: boundary,
+                groups: groups
+            ) else {
+                return []
+            }
+            let key = DiffContextExpansionKey(groupID: group.id, boundary: boundary)
+            return [expandableRow(group: group, boundary: boundary, remaining: 0, key: key)]
+        }
+
         let range = boundaryRange(
             for: group,
             groupIndex: groupIndex,
@@ -168,6 +201,42 @@ enum DiffContextExpandedDisplayBuilder {
             rows.insert(expandable, at: rows.endIndex)
         }
         return rows
+    }
+
+    private static func optimisticBoundaryAvailable(
+        for group: DiffDisplayGroup,
+        groupIndex: Int,
+        boundary: DiffContextBoundary,
+        groups: [DiffDisplayGroup]
+    ) -> Bool {
+        let currentOld = hunkSideExtent(in: group, side: .old)
+        let currentNew = hunkSideExtent(in: group, side: .new)
+
+        switch boundary {
+        case .above:
+            let previous = groupIndex > 0 ? groups[groupIndex - 1] : nil
+            guard let previous else {
+                return currentOld.lineBefore > 0 || currentNew.lineBefore > 0
+            }
+            let previousOld = hunkSideExtent(in: previous, side: .old)
+            let previousNew = hunkSideExtent(in: previous, side: .new)
+            return optimisticLineCount(start: previousOld.lineAfter, end: currentOld.lineBefore) > 0
+                || optimisticLineCount(start: previousNew.lineAfter, end: currentNew.lineBefore) > 0
+        case .below:
+            guard groupIndex + 1 < groups.count else {
+                return true
+            }
+            let next = groups[groupIndex + 1]
+            let nextOld = hunkSideExtent(in: next, side: .old)
+            let nextNew = hunkSideExtent(in: next, side: .new)
+            return optimisticLineCount(start: currentOld.lineAfter, end: nextOld.lineBefore) > 0
+                || optimisticLineCount(start: currentNew.lineAfter, end: nextNew.lineBefore) > 0
+        }
+    }
+
+    private static func optimisticLineCount(start: Int, end: Int) -> Int {
+        guard start <= end else { return 0 }
+        return end - start + 1
     }
 
     private static func boundaryRange(

--- a/Alas/Sources/Center/Diff/DiffContextExpansion.swift
+++ b/Alas/Sources/Center/Diff/DiffContextExpansion.swift
@@ -10,19 +10,19 @@ struct DiffReviewFileContextSnapshot: Equatable, Sendable {
     let new: DiffReviewFileContextLines
 }
 
-struct DiffContextExpansionState: Equatable {
-    enum Mode: Equatable {
-        case chunk(size: Int)
-        case all
-    }
+enum DiffContextExpansionMode: Equatable {
+    case chunk(size: Int)
+    case all
+}
 
+struct DiffContextExpansionState: Equatable {
     private var expandedLineCounts: [DiffContextExpansionKey: Int] = [:]
 
     func expandedLineCount(for key: DiffContextExpansionKey) -> Int {
         expandedLineCounts[key, default: 0]
     }
 
-    mutating func expand(_ key: DiffContextExpansionKey, available: Int, mode: Mode) {
+    mutating func expand(_ key: DiffContextExpansionKey, available: Int, mode: DiffContextExpansionMode) {
         let available = max(0, available)
         let current = expandedLineCounts[key, default: 0]
         let next: Int

--- a/Alas/Sources/Center/Diff/DiffContextExpansion.swift
+++ b/Alas/Sources/Center/Diff/DiffContextExpansion.swift
@@ -48,6 +48,19 @@ enum DiffContextExpandedDisplayBuilder {
         }
     }
 
+    private struct HunkSideExtent {
+        let start: Int
+        let count: Int
+
+        var lineBefore: Int {
+            count > 0 ? start - 1 : start
+        }
+
+        var lineAfter: Int {
+            start + max(count, 1)
+        }
+    }
+
     static func derive(
         groups: [DiffDisplayGroup],
         snapshot: DiffReviewFileContextSnapshot,
@@ -146,8 +159,7 @@ enum DiffContextExpandedDisplayBuilder {
             group: group,
             boundary: boundary,
             remaining: remaining,
-            key: key,
-            chunkSize: chunkSize
+            key: key
         )
         switch boundary {
         case .above:
@@ -167,89 +179,74 @@ enum DiffContextExpandedDisplayBuilder {
     ) -> BoundaryRange {
         let previous = groupIndex > 0 ? groups[groupIndex - 1] : nil
         let next = groupIndex + 1 < groups.count ? groups[groupIndex + 1] : nil
+        let currentOld = hunkSideExtent(in: group, side: .old)
+        let currentNew = hunkSideExtent(in: group, side: .new)
+        let previousOld = previous.map { hunkSideExtent(in: $0, side: .old) }
+        let previousNew = previous.map { hunkSideExtent(in: $0, side: .new) }
+        let nextOld = next.map { hunkSideExtent(in: $0, side: .old) }
+        let nextNew = next.map { hunkSideExtent(in: $0, side: .new) }
 
         switch boundary {
         case .above:
+            let oldStart = previousOld?.lineAfter ?? 1
+            let newStart = previousNew?.lineAfter ?? 1
             return BoundaryRange(
-                oldStart: startAfterLastLine(in: previous, side: .old),
-                oldCount: aboveCount(
-                    start: startAfterLastLine(in: previous, side: .old),
-                    end: lineBeforeFirstLine(in: group, side: .old),
+                oldStart: oldStart,
+                oldCount: lineCount(
+                    start: oldStart,
+                    end: currentOld.lineBefore,
                     snapshotLines: snapshot.old.lineCount
                 ),
-                newStart: startAfterLastLine(in: previous, side: .new),
-                newCount: aboveCount(
-                    start: startAfterLastLine(in: previous, side: .new),
-                    end: lineBeforeFirstLine(in: group, side: .new),
+                newStart: newStart,
+                newCount: lineCount(
+                    start: newStart,
+                    end: currentNew.lineBefore,
                     snapshotLines: snapshot.new.lineCount
                 )
             )
         case .below:
+            let oldStart = currentOld.lineAfter
+            let newStart = currentNew.lineAfter
             return BoundaryRange(
-                oldStart: lineAfterLastLine(in: group, side: .old),
-                oldCount: belowCount(
-                    start: lineAfterLastLine(in: group, side: .old),
-                    end: lineBeforeFirstLine(in: next, side: .old) ?? snapshot.old.lineCount,
+                oldStart: oldStart,
+                oldCount: lineCount(
+                    start: oldStart,
+                    end: nextOld?.lineBefore ?? snapshot.old.lineCount,
                     snapshotLines: snapshot.old.lineCount
                 ),
-                newStart: lineAfterLastLine(in: group, side: .new),
-                newCount: belowCount(
-                    start: lineAfterLastLine(in: group, side: .new),
-                    end: lineBeforeFirstLine(in: next, side: .new) ?? snapshot.new.lineCount,
+                newStart: newStart,
+                newCount: lineCount(
+                    start: newStart,
+                    end: nextNew?.lineBefore ?? snapshot.new.lineCount,
                     snapshotLines: snapshot.new.lineCount
                 )
             )
         }
     }
 
-    private static func aboveCount(start: Int?, end: Int?, snapshotLines: Int?) -> Int {
-        guard let snapshotLines, let start, let end else { return 0 }
+    private static func lineCount(start: Int, end: Int?, snapshotLines: Int?) -> Int {
+        guard let snapshotLines, let end else { return 0 }
         let clampedStart = max(1, start)
         let clampedEnd = min(end, snapshotLines)
         guard clampedStart <= clampedEnd else { return 0 }
         return clampedEnd - clampedStart + 1
     }
 
-    private static func belowCount(start: Int?, end: Int?, snapshotLines: Int?) -> Int {
-        guard let snapshotLines, let start, let end else { return 0 }
-        let clampedStart = max(1, start)
-        let clampedEnd = min(end, snapshotLines)
-        guard clampedStart <= clampedEnd else { return 0 }
-        return clampedEnd - clampedStart + 1
-    }
-
-    private static func startAfterLastLine(in group: DiffDisplayGroup?, side: DiffLineSide) -> Int? {
-        guard let group else { return 1 }
-        return lastLineNumber(in: group, side: side).map { $0 + 1 }
-    }
-
-    private static func lineBeforeFirstLine(in group: DiffDisplayGroup?, side: DiffLineSide) -> Int? {
-        guard let group else { return nil }
-        return firstLineNumber(in: group, side: side).map { $0 - 1 }
-    }
-
-    private static func lineAfterLastLine(in group: DiffDisplayGroup, side: DiffLineSide) -> Int? {
-        lastLineNumber(in: group, side: side).map { $0 + 1 }
-    }
-
-    private static func firstLineNumber(in group: DiffDisplayGroup, side: DiffLineSide) -> Int? {
-        for row in group.rows {
-            let line = side == .old ? row.old : row.new
-            if let number = line?.lineNumber {
-                return number
-            }
+    private static func hunkSideExtent(in group: DiffDisplayGroup, side: DiffLineSide) -> HunkSideExtent {
+        let start = side == .old ? group.sourceHunk.oldStart : group.sourceHunk.newStart
+        let count = group.sourceHunk.lines.reduce(0) { partial, line in
+            partial + (lineConsumes(line, side: side) ? 1 : 0)
         }
-        return nil
+        return HunkSideExtent(start: start, count: count)
     }
 
-    private static func lastLineNumber(in group: DiffDisplayGroup, side: DiffLineSide) -> Int? {
-        for row in group.rows.reversed() {
-            let line = side == .old ? row.old : row.new
-            if let number = line?.lineNumber {
-                return number
-            }
+    private static func lineConsumes(_ line: ParsedDiff.Hunk.Line, side: DiffLineSide) -> Bool {
+        switch (line.kind, side) {
+        case (.context, .old), (.context, .new), (.delete, .old), (.add, .new):
+            return true
+        case (_, .paired), (.add, .old), (.delete, .new):
+            return false
         }
-        return nil
     }
 
     private static func expandedContextRow(
@@ -308,11 +305,10 @@ enum DiffContextExpandedDisplayBuilder {
         group: DiffDisplayGroup,
         boundary: DiffContextBoundary,
         remaining: Int,
-        key: DiffContextExpansionKey,
-        chunkSize: Int
+        key: DiffContextExpansionKey
     ) -> DiffDisplayRow {
         DiffDisplayRow(
-            id: "\(group.id)-expand-\(boundary.rawValue)-\(remaining)-\(chunkSize)",
+            id: "\(group.id)-expand-\(boundary.rawValue)",
             kind: .expandableContext,
             old: nil,
             new: nil,

--- a/Alas/Sources/Center/Diff/DiffContextExpansion.swift
+++ b/Alas/Sources/Center/Diff/DiffContextExpansion.swift
@@ -196,7 +196,7 @@ enum DiffContextExpandedDisplayBuilder {
         )
         switch boundary {
         case .above:
-            rows.append(expandable)
+            rows.insert(expandable, at: rows.startIndex)
         case .below:
             rows.insert(expandable, at: rows.endIndex)
         }

--- a/Alas/Sources/Center/Diff/DiffContextExpansion.swift
+++ b/Alas/Sources/Center/Diff/DiffContextExpansion.swift
@@ -1,0 +1,397 @@
+import Foundation
+
+enum DiffReviewFileContextLines: Equatable, Sendable {
+    case unavailable
+    case available([String])
+}
+
+struct DiffReviewFileContextSnapshot: Equatable, Sendable {
+    let old: DiffReviewFileContextLines
+    let new: DiffReviewFileContextLines
+}
+
+struct DiffContextExpansionState: Equatable {
+    enum Mode: Equatable {
+        case chunk(size: Int)
+        case all
+    }
+
+    private var expandedLineCounts: [DiffContextExpansionKey: Int] = [:]
+
+    func expandedLineCount(for key: DiffContextExpansionKey) -> Int {
+        expandedLineCounts[key, default: 0]
+    }
+
+    mutating func expand(_ key: DiffContextExpansionKey, available: Int, mode: Mode) {
+        let available = max(0, available)
+        let current = expandedLineCounts[key, default: 0]
+        let next: Int
+        switch mode {
+        case let .chunk(size):
+            next = current + max(0, size)
+        case .all:
+            next = available
+        }
+        expandedLineCounts[key] = min(next, available)
+    }
+}
+
+enum DiffContextExpandedDisplayBuilder {
+    private struct BoundaryRange {
+        let oldStart: Int?
+        let oldCount: Int
+        let newStart: Int?
+        let newCount: Int
+
+        var lineCount: Int {
+            max(oldCount, newCount)
+        }
+    }
+
+    static func derive(
+        groups: [DiffDisplayGroup],
+        snapshot: DiffReviewFileContextSnapshot,
+        providerAvailable: Bool,
+        expansion: DiffContextExpansionState,
+        filePath: String,
+        chunkSize: Int
+    ) -> [DiffDisplayGroup] {
+        groups.enumerated().map { index, group in
+            var rows: [DiffDisplayRow] = []
+
+            if providerAvailable {
+                rows.append(contentsOf: expansionRows(
+                    for: group,
+                    groupIndex: index,
+                    boundary: .above,
+                    groups: groups,
+                    snapshot: snapshot,
+                    expansion: expansion,
+                    filePath: filePath,
+                    chunkSize: chunkSize
+                ))
+            }
+
+            rows.append(contentsOf: group.rows)
+
+            if providerAvailable {
+                rows.append(contentsOf: expansionRows(
+                    for: group,
+                    groupIndex: index,
+                    boundary: .below,
+                    groups: groups,
+                    snapshot: snapshot,
+                    expansion: expansion,
+                    filePath: filePath,
+                    chunkSize: chunkSize
+                ))
+            }
+
+            return DiffDisplayGroup(
+                id: group.id,
+                header: group.header,
+                sourceHunk: group.sourceHunk,
+                rows: rows
+            )
+        }
+    }
+
+    private static func expansionRows(
+        for group: DiffDisplayGroup,
+        groupIndex: Int,
+        boundary: DiffContextBoundary,
+        groups: [DiffDisplayGroup],
+        snapshot: DiffReviewFileContextSnapshot,
+        expansion: DiffContextExpansionState,
+        filePath: String,
+        chunkSize: Int
+    ) -> [DiffDisplayRow] {
+        let range = boundaryRange(
+            for: group,
+            groupIndex: groupIndex,
+            boundary: boundary,
+            groups: groups,
+            snapshot: snapshot
+        )
+        let available = range.lineCount
+        guard available > 0 else { return [] }
+
+        let key = DiffContextExpansionKey(groupID: group.id, boundary: boundary)
+        let expandedCount = min(expansion.expandedLineCount(for: key), available)
+        let remaining = available - expandedCount
+        let offsets: Range<Int>
+        switch boundary {
+        case .above:
+            offsets = (available - expandedCount)..<available
+        case .below:
+            offsets = 0..<expandedCount
+        }
+
+        var rows = offsets.map {
+            expandedContextRow(
+                group: group,
+                groupIndex: groupIndex,
+                boundary: boundary,
+                range: range,
+                offset: $0,
+                totalCount: available,
+                snapshot: snapshot,
+                filePath: filePath
+            )
+        }
+
+        guard remaining > 0 else { return rows }
+
+        let expandable = expandableRow(
+            group: group,
+            boundary: boundary,
+            remaining: remaining,
+            key: key,
+            chunkSize: chunkSize
+        )
+        switch boundary {
+        case .above:
+            rows.append(expandable)
+        case .below:
+            rows.insert(expandable, at: rows.endIndex)
+        }
+        return rows
+    }
+
+    private static func boundaryRange(
+        for group: DiffDisplayGroup,
+        groupIndex: Int,
+        boundary: DiffContextBoundary,
+        groups: [DiffDisplayGroup],
+        snapshot: DiffReviewFileContextSnapshot
+    ) -> BoundaryRange {
+        let previous = groupIndex > 0 ? groups[groupIndex - 1] : nil
+        let next = groupIndex + 1 < groups.count ? groups[groupIndex + 1] : nil
+
+        switch boundary {
+        case .above:
+            return BoundaryRange(
+                oldStart: startAfterLastLine(in: previous, side: .old),
+                oldCount: aboveCount(
+                    start: startAfterLastLine(in: previous, side: .old),
+                    end: lineBeforeFirstLine(in: group, side: .old),
+                    snapshotLines: snapshot.old.lineCount
+                ),
+                newStart: startAfterLastLine(in: previous, side: .new),
+                newCount: aboveCount(
+                    start: startAfterLastLine(in: previous, side: .new),
+                    end: lineBeforeFirstLine(in: group, side: .new),
+                    snapshotLines: snapshot.new.lineCount
+                )
+            )
+        case .below:
+            return BoundaryRange(
+                oldStart: lineAfterLastLine(in: group, side: .old),
+                oldCount: belowCount(
+                    start: lineAfterLastLine(in: group, side: .old),
+                    end: lineBeforeFirstLine(in: next, side: .old) ?? snapshot.old.lineCount,
+                    snapshotLines: snapshot.old.lineCount
+                ),
+                newStart: lineAfterLastLine(in: group, side: .new),
+                newCount: belowCount(
+                    start: lineAfterLastLine(in: group, side: .new),
+                    end: lineBeforeFirstLine(in: next, side: .new) ?? snapshot.new.lineCount,
+                    snapshotLines: snapshot.new.lineCount
+                )
+            )
+        }
+    }
+
+    private static func aboveCount(start: Int?, end: Int?, snapshotLines: Int?) -> Int {
+        guard let snapshotLines, let start, let end else { return 0 }
+        let clampedStart = max(1, start)
+        let clampedEnd = min(end, snapshotLines)
+        guard clampedStart <= clampedEnd else { return 0 }
+        return clampedEnd - clampedStart + 1
+    }
+
+    private static func belowCount(start: Int?, end: Int?, snapshotLines: Int?) -> Int {
+        guard let snapshotLines, let start, let end else { return 0 }
+        let clampedStart = max(1, start)
+        let clampedEnd = min(end, snapshotLines)
+        guard clampedStart <= clampedEnd else { return 0 }
+        return clampedEnd - clampedStart + 1
+    }
+
+    private static func startAfterLastLine(in group: DiffDisplayGroup?, side: DiffLineSide) -> Int? {
+        guard let group else { return 1 }
+        return lastLineNumber(in: group, side: side).map { $0 + 1 }
+    }
+
+    private static func lineBeforeFirstLine(in group: DiffDisplayGroup?, side: DiffLineSide) -> Int? {
+        guard let group else { return nil }
+        return firstLineNumber(in: group, side: side).map { $0 - 1 }
+    }
+
+    private static func lineAfterLastLine(in group: DiffDisplayGroup, side: DiffLineSide) -> Int? {
+        lastLineNumber(in: group, side: side).map { $0 + 1 }
+    }
+
+    private static func firstLineNumber(in group: DiffDisplayGroup, side: DiffLineSide) -> Int? {
+        for row in group.rows {
+            let line = side == .old ? row.old : row.new
+            if let number = line?.lineNumber {
+                return number
+            }
+        }
+        return nil
+    }
+
+    private static func lastLineNumber(in group: DiffDisplayGroup, side: DiffLineSide) -> Int? {
+        for row in group.rows.reversed() {
+            let line = side == .old ? row.old : row.new
+            if let number = line?.lineNumber {
+                return number
+            }
+        }
+        return nil
+    }
+
+    private static func expandedContextRow(
+        group: DiffDisplayGroup,
+        groupIndex: Int,
+        boundary: DiffContextBoundary,
+        range: BoundaryRange,
+        offset: Int,
+        totalCount: Int,
+        snapshot: DiffReviewFileContextSnapshot,
+        filePath: String
+    ) -> DiffDisplayRow {
+        let oldNumber = lineNumber(
+            start: range.oldStart,
+            count: range.oldCount,
+            offset: offset,
+            totalCount: totalCount,
+            boundary: boundary
+        )
+        let newNumber = lineNumber(
+            start: range.newStart,
+            count: range.newCount,
+            offset: offset,
+            totalCount: totalCount,
+            boundary: boundary
+        )
+        let rowIndex = syntheticRowIndex(boundary: boundary, offset: offset)
+        let anchorSide = anchorSide(oldNumber: oldNumber, newNumber: newNumber)
+        let anchor = DiffLineAnchor(
+            filePath: filePath,
+            hunkIndex: groupIndex,
+            rowIndex: rowIndex,
+            side: anchorSide,
+            oldLine: anchorSide == .new ? nil : oldNumber,
+            newLine: anchorSide == .old ? nil : newNumber
+        )
+
+        return DiffDisplayRow(
+            id: "\(group.id)-expanded-\(boundary.rawValue)-\(offset)-\(oldNumber ?? 0)-\(newNumber ?? 0)",
+            kind: .expandedContext,
+            old: displayLine(
+                anchor: anchor,
+                number: oldNumber,
+                text: oldNumber.flatMap { snapshot.old.line(at: $0) }
+            ),
+            new: displayLine(
+                anchor: anchor,
+                number: newNumber,
+                text: newNumber.flatMap { snapshot.new.line(at: $0) }
+            ),
+            collapsedLineCount: 0
+        )
+    }
+
+    private static func expandableRow(
+        group: DiffDisplayGroup,
+        boundary: DiffContextBoundary,
+        remaining: Int,
+        key: DiffContextExpansionKey,
+        chunkSize: Int
+    ) -> DiffDisplayRow {
+        DiffDisplayRow(
+            id: "\(group.id)-expand-\(boundary.rawValue)-\(remaining)-\(chunkSize)",
+            kind: .expandableContext,
+            old: nil,
+            new: nil,
+            collapsedLineCount: remaining,
+            contextExpansion: DiffContextExpansionRow(
+                key: key,
+                boundary: boundary,
+                remainingLineCount: remaining
+            )
+        )
+    }
+
+    private static func displayLine(anchor: DiffLineAnchor, number: Int?, text: String?) -> DiffDisplayLine? {
+        guard let number, let text else { return nil }
+        return DiffDisplayLine(
+            id: "\(anchor.filePath):\(anchor.side.rawValue):\(anchor.oldLine ?? 0):\(anchor.newLine ?? 0):\(number)",
+            anchor: anchor,
+            text: text,
+            lineNumber: number,
+            kind: .context,
+            inlineSpans: [],
+            noTrailingNewline: false
+        )
+    }
+
+    private static func lineNumber(
+        start: Int?,
+        count: Int,
+        offset: Int,
+        totalCount: Int,
+        boundary: DiffContextBoundary
+    ) -> Int? {
+        guard let start, count > 0 else { return nil }
+        switch boundary {
+        case .above:
+            let alignedOffset = offset - (totalCount - count)
+            guard alignedOffset >= 0, alignedOffset < count else { return nil }
+            return start + alignedOffset
+        case .below:
+            guard offset < count else { return nil }
+            return start + offset
+        }
+    }
+
+    private static func syntheticRowIndex(boundary: DiffContextBoundary, offset: Int) -> Int {
+        switch boundary {
+        case .above:
+            return -100_000 + offset
+        case .below:
+            return 100_000 + offset
+        }
+    }
+
+    private static func anchorSide(oldNumber: Int?, newNumber: Int?) -> DiffLineSide {
+        if oldNumber != nil, newNumber != nil {
+            return .paired
+        }
+        return oldNumber == nil ? .new : .old
+    }
+}
+
+private extension DiffReviewFileContextLines {
+    var lineCount: Int? {
+        switch self {
+        case .unavailable:
+            return nil
+        case let .available(lines):
+            return lines.count
+        }
+    }
+
+    func line(at number: Int) -> String? {
+        switch self {
+        case .unavailable:
+            return nil
+        case let .available(lines):
+            let index = number - 1
+            guard lines.indices.contains(index) else { return nil }
+            return lines[index]
+        }
+    }
+}

--- a/Alas/Sources/Center/Diff/DiffContextExpansion.swift
+++ b/Alas/Sources/Center/Diff/DiffContextExpansion.swift
@@ -120,6 +120,9 @@ enum DiffContextExpandedDisplayBuilder {
         else {
             return 0
         }
+        guard ownsBoundary(groupIndex: groupIndex, boundary: key.boundary) else {
+            return 0
+        }
         return boundaryRange(
             for: groups[groupIndex],
             groupIndex: groupIndex,
@@ -139,6 +142,9 @@ enum DiffContextExpandedDisplayBuilder {
         filePath: String,
         chunkSize: Int
     ) -> [DiffDisplayRow] {
+        guard ownsBoundary(groupIndex: groupIndex, boundary: boundary) else {
+            return []
+        }
         guard let snapshot else {
             guard optimisticBoundaryAvailable(
                 for: group,
@@ -201,6 +207,15 @@ enum DiffContextExpandedDisplayBuilder {
             rows.insert(expandable, at: rows.endIndex)
         }
         return rows
+    }
+
+    private static func ownsBoundary(groupIndex: Int, boundary: DiffContextBoundary) -> Bool {
+        switch boundary {
+        case .above:
+            groupIndex == 0
+        case .below:
+            true
+        }
     }
 
     private static func optimisticBoundaryAvailable(

--- a/Alas/Sources/Center/Diff/DiffDisplayModel.swift
+++ b/Alas/Sources/Center/Diff/DiffDisplayModel.swift
@@ -80,6 +80,22 @@ struct DiffDisplayLine: Identifiable, Equatable {
     let noTrailingNewline: Bool
 }
 
+struct DiffContextExpansionKey: Codable, Equatable, Hashable, Sendable {
+    let groupID: String
+    let boundary: DiffContextBoundary
+}
+
+enum DiffContextBoundary: String, Codable, Equatable, Hashable, Sendable {
+    case above
+    case below
+}
+
+struct DiffContextExpansionRow: Codable, Equatable, Hashable, Sendable {
+    let key: DiffContextExpansionKey
+    let boundary: DiffContextBoundary
+    let remainingLineCount: Int
+}
+
 struct DiffDisplayRow: Identifiable, Equatable {
     enum Kind: Equatable {
         case context
@@ -87,6 +103,8 @@ struct DiffDisplayRow: Identifiable, Equatable {
         case delete
         case replacement
         case collapsed
+        case expandedContext
+        case expandableContext
     }
 
     let id: String
@@ -95,6 +113,7 @@ struct DiffDisplayRow: Identifiable, Equatable {
     let new: DiffDisplayLine?
     let collapsedLineCount: Int
     let collapsedRows: [DiffDisplayRow]
+    var contextExpansion: DiffContextExpansionRow?
 
     init(
         id: String,
@@ -102,7 +121,8 @@ struct DiffDisplayRow: Identifiable, Equatable {
         old: DiffDisplayLine?,
         new: DiffDisplayLine?,
         collapsedLineCount: Int,
-        collapsedRows: [DiffDisplayRow] = []
+        collapsedRows: [DiffDisplayRow] = [],
+        contextExpansion: DiffContextExpansionRow? = nil
     ) {
         self.id = id
         self.kind = kind
@@ -110,6 +130,7 @@ struct DiffDisplayRow: Identifiable, Equatable {
         self.new = new
         self.collapsedLineCount = collapsedLineCount
         self.collapsedRows = collapsedRows
+        self.contextExpansion = contextExpansion
     }
 }
 

--- a/Alas/Sources/Center/Diff/DiffPaneTextDocumentBuilder.swift
+++ b/Alas/Sources/Center/Diff/DiffPaneTextDocumentBuilder.swift
@@ -8,6 +8,8 @@ struct DiffPaneTextDocumentBuilder {
         var tone: DiffPaneLineTone? = nil
         var sourceLine: DiffDisplayLine? = nil
         var sourceRange: NSRange? = nil
+        var expansionKey: DiffContextExpansionKey? = nil
+        var expansionBoundary: DiffContextBoundary? = nil
     }
 
     struct CodeDocument {
@@ -50,17 +52,44 @@ struct DiffPaneTextDocumentBuilder {
         )
 
         for row in rows {
+            if row.kind == .expandableContext {
+                oldGutter.append("+", side: .paired)
+                newGutter.append("", side: .paired)
+                oldColumn.append(
+                    expandableContextText(row, font: font, theme: theme),
+                    kind: row.kind,
+                    tone: .collapsed,
+                    sourceLine: nil,
+                    expansion: row.contextExpansion
+                )
+                newColumn.append(
+                    emptyLayoutGlyph(font: font, theme: theme),
+                    kind: row.kind,
+                    tone: .collapsed,
+                    sourceLine: nil,
+                    expansion: row.contextExpansion
+                )
+                continue
+            }
+
             oldGutter.append(marker(for: row.old, emptyKind: row.kind, side: .old), side: .old)
             newGutter.append(marker(for: row.new, emptyKind: row.kind, side: .new), side: .new)
 
-            if row.kind == .collapsed || row.kind == .expandableContext {
+            if row.kind == .collapsed {
                 oldColumn.append(
                     collapsedCodeText(row, font: font, theme: theme),
                     kind: row.kind,
                     tone: .collapsed,
-                    sourceLine: nil
+                    sourceLine: nil,
+                    expansion: row.contextExpansion
                 )
-                newColumn.append(emptyLayoutGlyph(font: font, theme: theme), kind: row.kind, tone: .collapsed, sourceLine: nil)
+                newColumn.append(
+                    emptyLayoutGlyph(font: font, theme: theme),
+                    kind: row.kind,
+                    tone: .collapsed,
+                    sourceLine: nil,
+                    expansion: row.contextExpansion
+                )
                 continue
             }
 
@@ -75,7 +104,8 @@ struct DiffPaneTextDocumentBuilder {
                 ),
                 kind: row.kind,
                 tone: tone(for: row.old, rowKind: row.kind),
-                sourceLine: reviewSourceLine(row.old, side: .old)
+                sourceLine: reviewSourceLine(row.old, side: .old),
+                expansion: row.contextExpansion
             )
             newColumn.append(
                 code(
@@ -88,7 +118,8 @@ struct DiffPaneTextDocumentBuilder {
                 ),
                 kind: row.kind,
                 tone: tone(for: row.new, rowKind: row.kind),
-                sourceLine: reviewSourceLine(row.new, side: .new)
+                sourceLine: reviewSourceLine(row.new, side: .new),
+                expansion: row.contextExpansion
             )
         }
 
@@ -118,13 +149,27 @@ struct DiffPaneTextDocumentBuilder {
         var index = 0
         while index < rows.count {
             let row = rows[index]
-            if row.kind == .collapsed || row.kind == .expandableContext {
+            if row.kind == .expandableContext {
+                gutter.append("+", side: .paired)
+                codeColumn.append(
+                    expandableContextText(row, font: font, theme: theme),
+                    kind: row.kind,
+                    tone: .collapsed,
+                    sourceLine: nil,
+                    expansion: row.contextExpansion
+                )
+                index += 1
+                continue
+            }
+
+            if row.kind == .collapsed {
                 gutter.append("", side: .paired)
                 codeColumn.append(
                     collapsedCodeText(row, font: font, theme: theme),
                     kind: row.kind,
                     tone: .collapsed,
-                    sourceLine: nil
+                    sourceLine: nil,
+                    expansion: row.contextExpansion
                 )
                 index += 1
                 continue
@@ -148,7 +193,8 @@ struct DiffPaneTextDocumentBuilder {
                     ),
                     kind: row.kind,
                     tone: tone(for: line, rowKind: row.kind),
-                    sourceLine: line
+                    sourceLine: line,
+                    expansion: row.contextExpansion
                 )
             }
         }
@@ -189,8 +235,10 @@ struct DiffPaneTextDocumentBuilder {
 
             let start = output.length
             switch row.kind {
-            case .collapsed, .expandableContext:
+            case .collapsed:
                 output.append(collapsedLine(row, font: font, theme: theme))
+            case .expandableContext:
+                output.append(expandableContextLine(row, font: font, theme: theme))
             case .context, .expandedContext, .add, .delete, .replacement:
                 output.append(splitLine(
                     row,
@@ -202,7 +250,12 @@ struct DiffPaneTextDocumentBuilder {
                 ))
             }
 
-            lines.append(LineMetadata(kind: row.kind, range: NSRange(location: start, length: output.length - start)))
+            lines.append(LineMetadata(
+                kind: row.kind,
+                range: NSRange(location: start, length: output.length - start),
+                expansionKey: row.contextExpansion?.key,
+                expansionBoundary: row.contextExpansion?.boundary
+            ))
         }
 
         return Result(attributedString: output, lines: lines)
@@ -227,8 +280,17 @@ struct DiffPaneTextDocumentBuilder {
 
             if row.kind == .collapsed || row.kind == .expandableContext {
                 let start = output.length
-                output.append(collapsedLine(row, font: font, theme: theme))
-                lines.append(LineMetadata(kind: row.kind, range: NSRange(location: start, length: output.length - start)))
+                if row.kind == .expandableContext {
+                    output.append(expandableContextLine(row, font: font, theme: theme))
+                } else {
+                    output.append(collapsedLine(row, font: font, theme: theme))
+                }
+                lines.append(LineMetadata(
+                    kind: row.kind,
+                    range: NSRange(location: start, length: output.length - start),
+                    expansionKey: row.contextExpansion?.key,
+                    expansionBoundary: row.contextExpansion?.boundary
+                ))
                 index += 1
                 continue
             }
@@ -279,7 +341,9 @@ struct DiffPaneTextDocumentBuilder {
                 kind: row.kind,
                 range: NSRange(location: start, length: output.length - start),
                 sourceLine: line,
-                sourceRange: NSRange(location: start + prefixLength, length: (line.text as NSString).length)
+                sourceRange: NSRange(location: start + prefixLength, length: (line.text as NSString).length),
+                expansionKey: row.contextExpansion?.key,
+                expansionBoundary: row.contextExpansion?.boundary
             ))
         }
     }
@@ -358,6 +422,17 @@ struct DiffPaneTextDocumentBuilder {
         )
     }
 
+    private static func expandableContextLine(
+        _ row: DiffDisplayRow,
+        font: NSFont,
+        theme: Theme
+    ) -> NSAttributedString {
+        NSAttributedString(
+            string: "      \(expandableContextLabel(row))",
+            attributes: collapsedTextAttributes(font: font, theme: theme)
+        )
+    }
+
     private static func collapsedCodeText(
         _ row: DiffDisplayRow,
         font: NSFont,
@@ -365,13 +440,36 @@ struct DiffPaneTextDocumentBuilder {
     ) -> NSAttributedString {
         NSAttributedString(
             string: "... \(row.collapsedLineCount) unchanged lines",
-            attributes: [
-                .font: font,
-                .foregroundColor: NSColor(theme.color("fg-dim")),
-                .backgroundColor: NSColor(theme.color("bg-2")),
-                .paragraphStyle: CenterTypography.paragraphStyle(),
-            ]
+            attributes: collapsedTextAttributes(font: font, theme: theme)
         )
+    }
+
+    private static func expandableContextText(
+        _ row: DiffDisplayRow,
+        font: NSFont,
+        theme: Theme
+    ) -> NSAttributedString {
+        NSAttributedString(
+            string: expandableContextLabel(row),
+            attributes: collapsedTextAttributes(font: font, theme: theme)
+        )
+    }
+
+    private static func expandableContextLabel(_ row: DiffDisplayRow) -> String {
+        let boundaryText = row.contextExpansion?.boundary == .below ? "below" : "above"
+        guard row.collapsedLineCount > 0 else {
+            return "Expand context \(boundaryText)"
+        }
+        return "\(row.collapsedLineCount) unchanged lines \(boundaryText)"
+    }
+
+    private static func collapsedTextAttributes(font: NSFont, theme: Theme) -> [NSAttributedString.Key: Any] {
+        [
+            .font: font,
+            .foregroundColor: NSColor(theme.color("fg-dim")),
+            .backgroundColor: NSColor(theme.color("bg-2")),
+            .paragraphStyle: CenterTypography.paragraphStyle(),
+        ]
     }
 
     private static func code(
@@ -586,7 +684,8 @@ private struct ColumnAccumulator {
         _ line: NSAttributedString,
         kind: DiffDisplayRow.Kind,
         tone: DiffPaneLineTone? = nil,
-        sourceLine: DiffDisplayLine? = nil
+        sourceLine: DiffDisplayLine? = nil,
+        expansion: DiffContextExpansionRow? = nil
     ) {
         if output.length > 0 {
             output.append(NSAttributedString(string: "\n", attributes: newlineAttributes))
@@ -598,7 +697,9 @@ private struct ColumnAccumulator {
             range: NSRange(location: start, length: line.length),
             tone: tone,
             sourceLine: sourceLine,
-            sourceRange: sourceLine.map { _ in NSRange(location: start, length: line.length) }
+            sourceRange: sourceLine.map { _ in NSRange(location: start, length: line.length) },
+            expansionKey: expansion?.key,
+            expansionBoundary: expansion?.boundary
         ))
     }
 }

--- a/Alas/Sources/Center/Diff/DiffPaneTextDocumentBuilder.swift
+++ b/Alas/Sources/Center/Diff/DiffPaneTextDocumentBuilder.swift
@@ -53,7 +53,7 @@ struct DiffPaneTextDocumentBuilder {
             oldGutter.append(marker(for: row.old, emptyKind: row.kind, side: .old), side: .old)
             newGutter.append(marker(for: row.new, emptyKind: row.kind, side: .new), side: .new)
 
-            if row.kind == .collapsed {
+            if row.kind == .collapsed || row.kind == .expandableContext {
                 oldColumn.append(
                     collapsedCodeText(row, font: font, theme: theme),
                     kind: row.kind,
@@ -118,7 +118,7 @@ struct DiffPaneTextDocumentBuilder {
         var index = 0
         while index < rows.count {
             let row = rows[index]
-            if row.kind == .collapsed {
+            if row.kind == .collapsed || row.kind == .expandableContext {
                 gutter.append("", side: .paired)
                 codeColumn.append(
                     collapsedCodeText(row, font: font, theme: theme),
@@ -131,7 +131,7 @@ struct DiffPaneTextDocumentBuilder {
             }
 
             let rowStart = index
-            while index < rows.count, rows[index].kind != .collapsed {
+            while index < rows.count, rows[index].kind != .collapsed, rows[index].kind != .expandableContext {
                 index += 1
             }
             let lines = DiffPaneRowProjection.stackedLines(for: Array(rows[rowStart..<index]))
@@ -189,9 +189,9 @@ struct DiffPaneTextDocumentBuilder {
 
             let start = output.length
             switch row.kind {
-            case .collapsed:
+            case .collapsed, .expandableContext:
                 output.append(collapsedLine(row, font: font, theme: theme))
-            case .context, .add, .delete, .replacement:
+            case .context, .expandedContext, .add, .delete, .replacement:
                 output.append(splitLine(
                     row,
                     fileExtension: fileExtension,
@@ -225,7 +225,7 @@ struct DiffPaneTextDocumentBuilder {
                 output.append(NSAttributedString(string: "\n", attributes: baseAttributes(font: font, theme: theme)))
             }
 
-            if row.kind == .collapsed {
+            if row.kind == .collapsed || row.kind == .expandableContext {
                 let start = output.length
                 output.append(collapsedLine(row, font: font, theme: theme))
                 lines.append(LineMetadata(kind: row.kind, range: NSRange(location: start, length: output.length - start)))
@@ -234,7 +234,7 @@ struct DiffPaneTextDocumentBuilder {
             }
 
             let rowStart = index
-            while index < rows.count, rows[index].kind != .collapsed {
+            while index < rows.count, rows[index].kind != .collapsed, rows[index].kind != .expandableContext {
                 index += 1
             }
             appendStackedLines(
@@ -452,7 +452,7 @@ struct DiffPaneTextDocumentBuilder {
 
     private static func tone(for line: DiffDisplayLine?, rowKind: DiffDisplayRow.Kind) -> DiffPaneLineTone {
         guard let line else {
-            return rowKind == .collapsed ? .collapsed : .placeholder
+            return (rowKind == .collapsed || rowKind == .expandableContext) ? .collapsed : .placeholder
         }
         switch line.kind {
         case .add:
@@ -543,9 +543,9 @@ struct DiffPaneTextDocumentBuilder {
             return theme.color("del").opacity(0.12)
         case .replacement:
             return theme.color("mod").opacity(0.10)
-        case .context:
+        case .context, .expandedContext:
             return theme.color("bg-1")
-        case .collapsed:
+        case .collapsed, .expandableContext:
             return theme.color("bg-2")
         }
     }

--- a/Alas/Sources/Center/Diff/DiffPaneTextDocumentView.swift
+++ b/Alas/Sources/Center/Diff/DiffPaneTextDocumentView.swift
@@ -1067,7 +1067,7 @@ final class DiffPaneLineNumberRulerView: NSRulerView {
         let rowRects = diffRowRects()
         guard !rowRects.isEmpty else { return }
 
-        let textHeight = ("8" as NSString).size(withAttributes: labelAttributes(for: "")).height
+        let textHeight = ("8" as NSString).size(withAttributes: labelAttributes(for: "", row: nil)).height
         let labelRects = labelDrawRects()
         for index in visibleRowIndices(in: visible) {
             let label = labels[index]
@@ -1085,7 +1085,7 @@ final class DiffPaneLineNumberRulerView: NSRulerView {
                 width: ruleThickness - horizontalPadding,
                 height: textHeight
             )
-            NSString(string: label).draw(in: drawRect, withAttributes: labelAttributes(for: label))
+            NSString(string: label).draw(in: drawRect, withAttributes: labelAttributes(for: label, row: index))
         }
     }
 
@@ -1098,7 +1098,7 @@ final class DiffPaneLineNumberRulerView: NSRulerView {
     }
 
     func labelDrawRects() -> [NSRect] {
-        let textHeight = ("8" as NSString).size(withAttributes: labelAttributes(for: "")).height
+        let textHeight = ("8" as NSString).size(withAttributes: labelAttributes(for: "", row: nil)).height
         let textLineRects: [NSRect]
         if let textView = scrollView?.documentView as? DiffPaneCodeTextView {
             textLineRects = textView.diffFirstLineFragmentRects()
@@ -1137,6 +1137,10 @@ final class DiffPaneLineNumberRulerView: NSRulerView {
         }
     }
 
+    func labelAttributesForTesting(row: Int) -> [NSAttributedString.Key: Any] {
+        labelAttributes(for: labels.indices.contains(row) ? labels[row] : "", row: row)
+    }
+
     private func observe(scrollView: NSScrollView) {
         scrollView.contentView.postsBoundsChangedNotifications = true
         boundsObserver = NotificationCenter.default.addObserver(
@@ -1154,18 +1158,19 @@ final class DiffPaneLineNumberRulerView: NSRulerView {
             .map(\.count)
             .max() ?? 1
         let sample = String(repeating: "8", count: max(maxDigits, 1)) as NSString
-        let width = ceil(sample.size(withAttributes: labelAttributes(for: "")).width)
+        let width = ceil(sample.size(withAttributes: labelAttributes(for: "", row: nil)).width)
         ruleThickness = max(minimumThickness, width + horizontalPadding * 2)
     }
 
-    private func labelAttributes(for label: String) -> [NSAttributedString.Key: Any] {
+    private func labelAttributes(for label: String, row: Int?) -> [NSAttributedString.Key: Any] {
         let paragraph = NSMutableParagraphStyle()
         paragraph.alignment = .right
         let color: NSColor
         if let theme {
-            if label.hasPrefix("+") {
+            let tone = row.flatMap(labelTone(at:))
+            if tone == .add || (tone == nil && label.hasPrefix("+")) {
                 color = NSColor(theme.color("add"))
-            } else if label.hasPrefix("-") {
+            } else if tone == .delete || (tone == nil && label.hasPrefix("-")) {
                 color = NSColor(theme.color("del"))
             } else {
                 color = NSColor(theme.color("fg-faint"))
@@ -1178,6 +1183,10 @@ final class DiffPaneLineNumberRulerView: NSRulerView {
             .foregroundColor: color,
             .paragraphStyle: paragraph,
         ]
+    }
+
+    private func labelTone(at row: Int) -> DiffPaneLineTone? {
+        lineTones.indices.contains(row) ? lineTones[row] : nil
     }
 
     private func drawRowBackground(index: Int, rowRect: NSRect, theme: Theme) {

--- a/Alas/Sources/Center/Diff/DiffPaneTextDocumentView.swift
+++ b/Alas/Sources/Center/Diff/DiffPaneTextDocumentView.swift
@@ -1,6 +1,8 @@
 import AppKit
 import SwiftUI
 
+private let diffContextExpansionChunkSize = 10
+
 struct DiffReviewLineAnchor: Equatable, Hashable, Sendable {
     let path: String
     let side: DiffReviewInlineFeedbackSide
@@ -314,6 +316,7 @@ final class DiffPaneTextScrollView: NSScrollView {
     var onReviewLineSelected: (DiffReviewLineAnchor) -> Void = { _ in }
     var onContextExpansion: (DiffContextExpansionKey, DiffContextExpansionMode) -> Void = { _, _ in } {
         didSet {
+            textView.contextExpansionHandler = onContextExpansion
             (verticalRulerView as? DiffPaneLineNumberRulerView)?.onContextExpansion = onContextExpansion
         }
     }
@@ -412,6 +415,7 @@ final class DiffPaneTextScrollView: NSScrollView {
         textView.font = font
         textView.lineMetadata = document.lines
         textView.lineTones = lineTones
+        textView.contextExpansionHandler = onContextExpansion
         textView.theme = theme
         textView.lspContext = lspContext
         textView.allowedLSPSide = allowedLSPSide
@@ -660,6 +664,7 @@ final class DiffPaneCodeTextView: NSTextView {
     var commandClickHandler: ((NSPoint) -> Void)?
     var flagsChangedHandler: ((NSEvent) -> Void)?
     var mouseExitedHandler: (() -> Void)?
+    var contextExpansionHandler: (DiffContextExpansionKey, DiffContextExpansionMode) -> Void = { _, _ in }
     var lspContext: DiffPaneLSPContext?
     var allowedLSPSide: DiffLineSide = .new
     var hasLSPContextForTesting: Bool { lspContext != nil }
@@ -716,8 +721,12 @@ final class DiffPaneCodeTextView: NSTextView {
     }
 
     override func mouseDown(with event: NSEvent) {
+        let point = convert(event.locationInWindow, from: nil)
+        if invokeExpansion(at: point, optionKey: event.modifierFlags.contains(.option)) {
+            return
+        }
         if event.modifierFlags.contains(.command), let commandClickHandler {
-            commandClickHandler(convert(event.locationInWindow, from: nil))
+            commandClickHandler(point)
             return
         }
         super.mouseDown(with: event)
@@ -897,6 +906,32 @@ final class DiffPaneCodeTextView: NSTextView {
         return reviewLineAnchor(atRow: row)
     }
 
+    func invokeExpansionForTesting(row: Int, optionKey: Bool) {
+        guard let key = expansionKey(atRow: row) else { return }
+        invokeExpansion(key: key, optionKey: optionKey)
+    }
+
+    private func invokeExpansion(at point: NSPoint, optionKey: Bool) -> Bool {
+        let rowRects = diffRowRects()
+        guard let row = rowRects.firstIndex(where: { $0.contains(point) }),
+              let key = expansionKey(atRow: row)
+        else {
+            return false
+        }
+        invokeExpansion(key: key, optionKey: optionKey)
+        return true
+    }
+
+    private func expansionKey(atRow row: Int) -> DiffContextExpansionKey? {
+        guard lineMetadata.indices.contains(row) else { return nil }
+        return lineMetadata[row].expansionKey
+    }
+
+    private func invokeExpansion(key: DiffContextExpansionKey, optionKey: Bool) {
+        let mode: DiffContextExpansionMode = optionKey ? .all : .chunk(size: diffContextExpansionChunkSize)
+        contextExpansionHandler(key, mode)
+    }
+
     private func drawLineBackgrounds(in dirtyRect: NSRect) {
         guard let theme else { return }
         let rowRects = diffRowRects()
@@ -1030,7 +1065,6 @@ final class DiffPaneLineNumberRulerView: NSRulerView {
 
     private let minimumThickness: CGFloat = 42
     private let horizontalPadding: CGFloat = 8
-    private let defaultExpansionChunkSize = 10
 
     init(scrollView: NSScrollView) {
         super.init(scrollView: scrollView, orientation: .verticalRuler)
@@ -1197,7 +1231,7 @@ final class DiffPaneLineNumberRulerView: NSRulerView {
             return false
         }
 
-        let mode: DiffContextExpansionMode = optionKey ? .all : .chunk(size: defaultExpansionChunkSize)
+        let mode: DiffContextExpansionMode = optionKey ? .all : .chunk(size: diffContextExpansionChunkSize)
         onContextExpansion(key, mode)
         return true
     }

--- a/Alas/Sources/Center/Diff/DiffPaneTextDocumentView.swift
+++ b/Alas/Sources/Center/Diff/DiffPaneTextDocumentView.swift
@@ -21,6 +21,7 @@ struct DiffPaneTextDocumentView: NSViewRepresentable {
     let theme: Theme
     let lspContext: DiffPaneLSPContext?
     var onReviewLineSelected: (DiffReviewLineAnchor) -> Void = { _ in }
+    var onContextExpansion: (DiffContextExpansionKey, DiffContextExpansionMode) -> Void = { _, _ in }
 
     init(
         group: DiffDisplayGroup,
@@ -33,7 +34,8 @@ struct DiffPaneTextDocumentView: NSViewRepresentable {
         codeFontSize: CGFloat,
         theme: Theme,
         lspContext: DiffPaneLSPContext?,
-        onReviewLineSelected: @escaping (DiffReviewLineAnchor) -> Void = { _ in }
+        onReviewLineSelected: @escaping (DiffReviewLineAnchor) -> Void = { _ in },
+        onContextExpansion: @escaping (DiffContextExpansionKey, DiffContextExpansionMode) -> Void = { _, _ in }
     ) {
         self.group = group
         self.expandedCollapsedRowIDs = expandedCollapsedRowIDs
@@ -46,6 +48,7 @@ struct DiffPaneTextDocumentView: NSViewRepresentable {
         self.theme = theme
         self.lspContext = lspContext
         self.onReviewLineSelected = onReviewLineSelected
+        self.onContextExpansion = onContextExpansion
     }
 
     func makeNSView(context: Context) -> DiffPaneTextDocumentContainerView {
@@ -63,7 +66,8 @@ struct DiffPaneTextDocumentView: NSViewRepresentable {
             font: CenterTypography.resolveCodeFont(family: codeFontFamily, size: codeFontSize),
             theme: theme,
             lspContext: lspContext,
-            onReviewLineSelected: onReviewLineSelected
+            onReviewLineSelected: onReviewLineSelected,
+            onContextExpansion: onContextExpansion
         )
     }
 }
@@ -109,11 +113,15 @@ final class DiffPaneTextDocumentContainerView: NSView {
         font: NSFont,
         theme: Theme,
         lspContext: DiffPaneLSPContext?,
-        onReviewLineSelected: @escaping (DiffReviewLineAnchor) -> Void = { _ in }
+        onReviewLineSelected: @escaping (DiffReviewLineAnchor) -> Void = { _ in },
+        onContextExpansion: @escaping (DiffContextExpansionKey, DiffContextExpansionMode) -> Void = { _, _ in }
     ) {
         oldPane.onReviewLineSelected = onReviewLineSelected
         newPane.onReviewLineSelected = onReviewLineSelected
         stackedPane.onReviewLineSelected = onReviewLineSelected
+        oldPane.onContextExpansion = onContextExpansion
+        newPane.onContextExpansion = onContextExpansion
+        stackedPane.onContextExpansion = onContextExpansion
 
         let signature = UpdateSignature(
             group: group,
@@ -155,7 +163,8 @@ final class DiffPaneTextDocumentContainerView: NSView {
                 font: font,
                 theme: theme,
                 lspContext: nil,
-                allowedLSPSide: .new
+                allowedLSPSide: .new,
+                onContextExpansion: onContextExpansion
             )
             newPane.update(
                 document: result.newCode,
@@ -164,7 +173,8 @@ final class DiffPaneTextDocumentContainerView: NSView {
                 font: font,
                 theme: theme,
                 lspContext: lspContext,
-                allowedLSPSide: .new
+                allowedLSPSide: .new,
+                onContextExpansion: onContextExpansion
             )
             stackedPane.clearLSPContext()
             measuredHeight = max(oldPane.documentHeight, newPane.documentHeight)
@@ -184,7 +194,8 @@ final class DiffPaneTextDocumentContainerView: NSView {
                 font: font,
                 theme: theme,
                 lspContext: lspContext,
-                allowedLSPSide: .new
+                allowedLSPSide: .new,
+                onContextExpansion: onContextExpansion
             )
             oldPane.clearLSPContext()
             newPane.clearLSPContext()
@@ -293,6 +304,7 @@ final class DiffPaneTextScrollView: NSScrollView {
     private var lineLabels: [String] = []
     private var rowKinds: [DiffDisplayRow.Kind] = []
     private var lineTones: [DiffPaneLineTone] = []
+    private var expansionKeys: [DiffContextExpansionKey?] = []
     private var baseDocument: DiffPaneTextDocumentBuilder.CodeDocument?
     private var synchronizedRowHeights: [CGFloat] = []
     private var shouldResetHorizontalOrigin = false
@@ -300,6 +312,11 @@ final class DiffPaneTextScrollView: NSScrollView {
     private var font: NSFont = .monospacedSystemFont(ofSize: 13, weight: .regular)
     private var theme: Theme?
     var onReviewLineSelected: (DiffReviewLineAnchor) -> Void = { _ in }
+    var onContextExpansion: (DiffContextExpansionKey, DiffContextExpansionMode) -> Void = { _, _ in } {
+        didSet {
+            (verticalRulerView as? DiffPaneLineNumberRulerView)?.onContextExpansion = onContextExpansion
+        }
+    }
 
     var documentHeight: CGFloat {
         if let lastRow = textView.diffRowRects().last {
@@ -370,7 +387,8 @@ final class DiffPaneTextScrollView: NSScrollView {
         font: NSFont,
         theme: Theme,
         lspContext: DiffPaneLSPContext?,
-        allowedLSPSide: DiffLineSide
+        allowedLSPSide: DiffLineSide,
+        onContextExpansion: @escaping (DiffContextExpansionKey, DiffContextExpansionMode) -> Void = { _, _ in }
     ) {
         self.lineLabels = lineLabels
         self.rowKinds = document.lines.map(\.kind)
@@ -380,12 +398,14 @@ final class DiffPaneTextScrollView: NSScrollView {
                 rowKind: line.kind
             )
         }
+        self.expansionKeys = document.lines.map(\.expansionKey)
         self.baseDocument = document
         self.synchronizedRowHeights = []
         self.shouldResetHorizontalOrigin = true
         self.wraps = wraps
         self.font = font
         self.theme = theme
+        self.onContextExpansion = onContextExpansion
         hasHorizontalScroller = !wraps
 
         textView.textStorage?.setAttributedString(document.attributedString)
@@ -404,7 +424,9 @@ final class DiffPaneTextScrollView: NSScrollView {
                 lineTones: lineTones,
                 rowHeight: lineHeight(),
                 contentTopInset: textView.textContainerInset.height,
-                theme: theme
+                theme: theme,
+                expansionKeys: expansionKeys,
+                onContextExpansion: onContextExpansion
             )
         }
 
@@ -998,14 +1020,17 @@ final class DiffPaneCodeTextView: NSTextView {
 final class DiffPaneLineNumberRulerView: NSRulerView {
     private var labels: [String] = []
     private var lineTones: [DiffPaneLineTone] = []
+    private var expansionKeys: [DiffContextExpansionKey?] = []
     private var theme: Theme?
     var rowHeight: CGFloat = 16
     var onReviewLineSelected: (DiffReviewLineAnchor) -> Void = { _ in }
+    var onContextExpansion: (DiffContextExpansionKey, DiffContextExpansionMode) -> Void = { _, _ in }
     private var contentTopInset: CGFloat = 6
     private var boundsObserver: NSObjectProtocol?
 
     private let minimumThickness: CGFloat = 42
     private let horizontalPadding: CGFloat = 8
+    private let defaultExpansionChunkSize = 10
 
     init(scrollView: NSScrollView) {
         super.init(scrollView: scrollView, orientation: .verticalRuler)
@@ -1026,13 +1051,17 @@ final class DiffPaneLineNumberRulerView: NSRulerView {
         lineTones: [DiffPaneLineTone],
         rowHeight: CGFloat,
         contentTopInset: CGFloat,
-        theme: Theme
+        theme: Theme,
+        expansionKeys: [DiffContextExpansionKey?],
+        onContextExpansion: @escaping (DiffContextExpansionKey, DiffContextExpansionMode) -> Void
     ) {
         self.labels = labels
         self.lineTones = lineTones
         self.rowHeight = rowHeight
         self.contentTopInset = contentTopInset
         self.theme = theme
+        self.expansionKeys = expansionKeys
+        self.onContextExpansion = onContextExpansion
         updateThickness()
         needsDisplay = true
     }
@@ -1050,6 +1079,9 @@ final class DiffPaneLineNumberRulerView: NSRulerView {
             x: point.x,
             y: point.y + scrollView.contentView.bounds.origin.y
         )
+        if let row = rowIndex(at: sourcePoint), invokeExpansion(row: row, optionKey: event.modifierFlags.contains(.option)) {
+            return
+        }
         guard let anchor = textView.reviewLineAnchor(at: sourcePoint) else {
             super.mouseDown(with: event)
             return
@@ -1139,6 +1171,35 @@ final class DiffPaneLineNumberRulerView: NSRulerView {
 
     func labelAttributesForTesting(row: Int) -> [NSAttributedString.Key: Any] {
         labelAttributes(for: labels.indices.contains(row) ? labels[row] : "", row: row)
+    }
+
+    func invokeExpansionForTesting(row: Int, optionKey: Bool) {
+        _ = invokeExpansion(row: row, optionKey: optionKey)
+    }
+
+    func invokeReviewLineSelectionForTesting(row: Int) {
+        guard let textView = scrollView?.documentView as? DiffPaneCodeTextView,
+              let anchor = textView.reviewLineAnchor(atRow: row)
+        else {
+            return
+        }
+        onReviewLineSelected(anchor)
+    }
+
+    private func rowIndex(at point: NSPoint) -> Int? {
+        diffRowRects().firstIndex { $0.contains(point) }
+    }
+
+    private func invokeExpansion(row: Int, optionKey: Bool) -> Bool {
+        guard expansionKeys.indices.contains(row),
+              let key = expansionKeys[row]
+        else {
+            return false
+        }
+
+        let mode: DiffContextExpansionMode = optionKey ? .all : .chunk(size: defaultExpansionChunkSize)
+        onContextExpansion(key, mode)
+        return true
     }
 
     private func observe(scrollView: NSScrollView) {

--- a/Alas/Sources/Center/Diff/DiffPaneTextDocumentView.swift
+++ b/Alas/Sources/Center/Diff/DiffPaneTextDocumentView.swift
@@ -582,9 +582,9 @@ enum DiffPaneLineTone: Equatable {
     case collapsed
 
     init(label: String, rowKind: DiffDisplayRow.Kind) {
-        if rowKind == .collapsed {
+        if rowKind == .collapsed || rowKind == .expandableContext {
             self = .collapsed
-        } else if label.isEmpty, rowKind != .context {
+        } else if label.isEmpty, rowKind != .context, rowKind != .expandedContext {
             self = .placeholder
         } else {
             switch rowKind {
@@ -592,9 +592,9 @@ enum DiffPaneLineTone: Equatable {
                 self = .add
             case .delete:
                 self = .delete
-            case .context, .replacement:
+            case .context, .expandedContext, .replacement:
                 self = .context
-            case .collapsed:
+            case .collapsed, .expandableContext:
                 self = .collapsed
             }
         }

--- a/Alas/Sources/Center/Diff/DiffPaneView.swift
+++ b/Alas/Sources/Center/Diff/DiffPaneView.swift
@@ -90,7 +90,7 @@ enum DiffPaneRowProjection {
     }
 
     static func stackedLines(for row: DiffDisplayRow) -> [DiffDisplayLine] {
-        if row.kind == .context {
+        if row.kind == .context || row.kind == .expandedContext {
             if let new = row.new { return [new] }
             if let old = row.old { return [old] }
             return []

--- a/Alas/Sources/Center/Diff/DiffPaneView.swift
+++ b/Alas/Sources/Center/Diff/DiffPaneView.swift
@@ -116,6 +116,7 @@ struct DiffPaneView: View {
     var verticalScrollMode: DiffPaneVerticalScrollMode = .internalScroll
     var lspContext: DiffPaneLSPContext? = nil
     var onReviewLineSelected: (DiffReviewLineAnchor) -> Void = { _ in }
+    var onContextExpansion: (DiffContextExpansionKey, DiffContextExpansionMode) -> Void = { _, _ in }
     let hunkActions: (ParsedDiff.Hunk) -> DiffPaneHunkActions
 
     @Environment(\.theme) private var theme
@@ -133,6 +134,7 @@ struct DiffPaneView: View {
         verticalScrollMode: DiffPaneVerticalScrollMode = .internalScroll,
         lspContext: DiffPaneLSPContext? = nil,
         onReviewLineSelected: @escaping (DiffReviewLineAnchor) -> Void = { _ in },
+        onContextExpansion: @escaping (DiffContextExpansionKey, DiffContextExpansionMode) -> Void = { _, _ in },
         hunkActions: @escaping (ParsedDiff.Hunk) -> DiffPaneHunkActions
     ) {
         self.model = model
@@ -146,6 +148,7 @@ struct DiffPaneView: View {
         self.verticalScrollMode = verticalScrollMode
         self.lspContext = lspContext
         self.onReviewLineSelected = onReviewLineSelected
+        self.onContextExpansion = onContextExpansion
         self.hunkActions = hunkActions
     }
 
@@ -284,7 +287,8 @@ struct DiffPaneView: View {
                 codeFontSize: codeFontSize,
                 theme: theme,
                 lspContext: lspContext,
-                onReviewLineSelected: onReviewLineSelected
+                onReviewLineSelected: onReviewLineSelected,
+                onContextExpansion: onContextExpansion
             )
             .fixedSize(horizontal: false, vertical: true)
         }

--- a/Alas/Sources/Center/DiffReview/DiffReviewContextProvider.swift
+++ b/Alas/Sources/Center/DiffReview/DiffReviewContextProvider.swift
@@ -1,0 +1,5 @@
+import Foundation
+
+struct DiffReviewContextProvider {
+    let snapshot: @Sendable () async throws -> DiffReviewFileContextSnapshot
+}

--- a/Alas/Sources/Center/DiffReview/DiffReviewContextProvider.swift
+++ b/Alas/Sources/Center/DiffReview/DiffReviewContextProvider.swift
@@ -1,5 +1,14 @@
 import Foundation
 
 struct DiffReviewContextProvider {
+    let id: UUID
     let snapshot: @Sendable () async throws -> DiffReviewFileContextSnapshot
+
+    init(
+        id: UUID = UUID(),
+        snapshot: @escaping @Sendable () async throws -> DiffReviewFileContextSnapshot
+    ) {
+        self.id = id
+        self.snapshot = snapshot
+    }
 }

--- a/Alas/Sources/Center/DiffReview/DiffReviewFileSection.swift
+++ b/Alas/Sources/Center/DiffReview/DiffReviewFileSection.swift
@@ -25,10 +25,16 @@ struct DiffReviewFileSection: View {
     @State private var pendingDraftAnchor: DiffReviewLineAnchor?
     @State private var pendingDraftBody = ""
     @State private var expandedCollapsedRowIDs: Set<String> = []
+    @State private var contextSnapshot: DiffReviewFileContextSnapshot?
+    @State private var contextExpansion = DiffContextExpansionState()
+    @State private var contextLoadTask: Task<Void, Never>?
+    @State private var contextLoadFileID: DiffReviewFileID?
+    @State private var contextLoadError: String?
 
     var body: some View {
         VStack(spacing: 0) {
             header
+            contextLoadErrorRow
             fileLevelDraftCommentStack
             fileLevelInlineFeedbackStack
             content
@@ -47,6 +53,14 @@ struct DiffReviewFileSection: View {
         )
         .onChange(of: draftCommentDisplaySignature) { _, _ in
             clearPendingDraft()
+        }
+        .onChange(of: file.id) { _, _ in
+            resetContextState()
+        }
+        .onDisappear {
+            contextLoadTask?.cancel()
+            contextLoadTask = nil
+            contextLoadFileID = nil
         }
     }
 
@@ -114,6 +128,26 @@ struct DiffReviewFileSection: View {
             providerDescription: nil,
             sourceDescription: "Local draft comment"
         )
+    }
+
+    @ViewBuilder
+    private var contextLoadErrorRow: some View {
+        if let contextLoadError {
+            Text("Could not load surrounding context: \(contextLoadError)")
+                .font(.system(size: 11))
+                .foregroundColor(theme.color("warn"))
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .padding(.horizontal, 14)
+                .padding(.vertical, 8)
+                .background(theme.color("bg-2"))
+                .overlay(Rectangle().fill(theme.color("line")).frame(height: 0.5), alignment: .bottom)
+                .background(
+                    DiffReviewAccessibilityMarker(
+                        identifier: "diff-review-context-error-\(file.id.rawValue)",
+                        label: "Could not load surrounding context: \(contextLoadError)"
+                    )
+                )
+        }
     }
 
     @ViewBuilder
@@ -189,26 +223,38 @@ struct DiffReviewFileSection: View {
     }
 
     private var inlineFeedbackPlacement: DiffReviewInlineFeedbackPlacement.Result {
-        guard let displayModel = file.displayModel else {
+        guard let groups = derivedDisplayGroups else {
             return DiffReviewInlineFeedbackPlacement.Result(fileLevel: inlineFeedback, byGroupID: [:])
         }
-        return DiffReviewInlineFeedbackPlacement.position(inlineFeedback, in: displayModel.groups)
+        return DiffReviewInlineFeedbackPlacement.position(inlineFeedback, in: groups)
     }
 
     private var draftCommentPlacement: ReviewDraftCommentPlacement.Result {
-        guard let displayModel = file.displayModel else {
+        guard let groups = derivedDisplayGroups else {
             return ReviewDraftCommentPlacement.position(draftComments, in: [])
         }
-        return ReviewDraftCommentPlacement.position(draftComments, in: displayModel.groups)
+        return ReviewDraftCommentPlacement.position(draftComments, in: groups)
+    }
+
+    private var derivedDisplayGroups: [DiffDisplayGroup]? {
+        guard let displayModel = file.displayModel else { return nil }
+        return DiffContextExpandedDisplayBuilder.derive(
+            groups: displayModel.groups,
+            snapshot: contextSnapshot,
+            providerAvailable: file.contextProvider != nil,
+            expansion: contextExpansion,
+            filePath: displayModel.filePath,
+            chunkSize: 10
+        )
     }
 
     @ViewBuilder
     private var content: some View {
-        if let displayModel = file.displayModel {
+        if let displayModel = file.displayModel, let groups = derivedDisplayGroups {
             let inlinePlacement = inlineFeedbackPlacement
             let draftPlacement = draftCommentPlacement
             VStack(spacing: 0) {
-                ForEach(displayModel.groups) { group in
+                ForEach(groups) { group in
                     if let groupFeedback = inlinePlacement.byGroupID[group.id], !groupFeedback.isEmpty {
                         inlineFeedbackStack(groupFeedback, file: file.summary)
                     }
@@ -268,7 +314,8 @@ struct DiffReviewFileSection: View {
                             onReviewLineSelected: { anchor in
                                 pendingDraftAnchor = anchor
                                 pendingDraftBody = ""
-                            }
+                            },
+                            onContextExpansion: loadContextAndExpand
                         )
                         .fixedSize(horizontal: false, vertical: true)
                     }
@@ -303,6 +350,7 @@ struct DiffReviewFileSection: View {
                     pendingDraftAnchor = anchor
                     pendingDraftBody = ""
                 },
+                onContextExpansion: loadContextAndExpand,
                 hunkActions: { _ in DiffPaneHunkActions() }
             )
         }
@@ -414,8 +462,8 @@ struct DiffReviewFileSection: View {
     }
 
     private var currentDraftRowKeys: Set<ReviewDraftCommentPlacement.RowKey> {
-        guard let displayModel = file.displayModel else { return [] }
-        return Set(displayModel.groups.flatMap(ReviewDraftCommentPlacement.allRowKeys))
+        guard let groups = derivedDisplayGroups else { return [] }
+        return Set(groups.flatMap(ReviewDraftCommentPlacement.allRowKeys))
     }
 
     private var draftCommentDisplaySignature: String {
@@ -431,6 +479,56 @@ struct DiffReviewFileSection: View {
             return "\(group.id)[\(rowSignature)]"
         }.joined(separator: "|") ?? "placeholder"
         return "\(file.id.rawValue)|\(groupSignature)"
+    }
+
+    private func loadContextAndExpand(_ key: DiffContextExpansionKey, mode: DiffContextExpansionMode) {
+        guard let provider = file.contextProvider else { return }
+        if contextSnapshot != nil {
+            applyContextExpansion(key, mode: mode)
+            return
+        }
+        guard contextLoadTask == nil else { return }
+        let fileID = file.id
+        contextLoadError = nil
+        contextLoadFileID = fileID
+        contextLoadTask = Task {
+            do {
+                let snapshot = try await provider.snapshot()
+                await MainActor.run {
+                    guard contextLoadFileID == fileID else { return }
+                    contextSnapshot = snapshot
+                    contextLoadTask = nil
+                    contextLoadFileID = nil
+                    applyContextExpansion(key, mode: mode)
+                }
+            } catch {
+                await MainActor.run {
+                    guard contextLoadFileID == fileID else { return }
+                    contextLoadError = error.localizedDescription
+                    contextLoadTask = nil
+                    contextLoadFileID = nil
+                }
+            }
+        }
+    }
+
+    private func applyContextExpansion(_ key: DiffContextExpansionKey, mode: DiffContextExpansionMode) {
+        guard let displayModel = file.displayModel else { return }
+        let available = DiffContextExpandedDisplayBuilder.availableLineCount(
+            key: key,
+            groups: displayModel.groups,
+            snapshot: contextSnapshot
+        )
+        contextExpansion.expand(key, available: available, mode: mode)
+    }
+
+    private func resetContextState() {
+        contextLoadTask?.cancel()
+        contextSnapshot = nil
+        contextExpansion = DiffContextExpansionState()
+        contextLoadTask = nil
+        contextLoadFileID = nil
+        contextLoadError = nil
     }
 
     @ViewBuilder

--- a/Alas/Sources/Center/DiffReview/DiffReviewFileSection.swift
+++ b/Alas/Sources/Center/DiffReview/DiffReviewFileSection.swift
@@ -1,5 +1,10 @@
 import SwiftUI
 
+private struct PendingContextExpansion {
+    let key: DiffContextExpansionKey
+    let mode: DiffContextExpansionMode
+}
+
 struct DiffReviewFileSection: View {
     let file: DiffReviewFileSectionModel
     var inlineFeedback: [DiffReviewInlineFeedback] = []
@@ -30,6 +35,7 @@ struct DiffReviewFileSection: View {
     @State private var contextLoadTask: Task<Void, Never>?
     @State private var contextLoadFileID: DiffReviewFileID?
     @State private var contextLoadError: String?
+    @State private var pendingContextExpansions: [PendingContextExpansion] = []
 
     var body: some View {
         VStack(spacing: 0) {
@@ -58,9 +64,7 @@ struct DiffReviewFileSection: View {
             resetContextState()
         }
         .onDisappear {
-            contextLoadTask?.cancel()
-            contextLoadTask = nil
-            contextLoadFileID = nil
+            resetContextState()
         }
     }
 
@@ -487,6 +491,7 @@ struct DiffReviewFileSection: View {
             applyContextExpansion(key, mode: mode)
             return
         }
+        pendingContextExpansions.append(PendingContextExpansion(key: key, mode: mode))
         guard contextLoadTask == nil else { return }
         let fileID = file.id
         contextLoadError = nil
@@ -499,7 +504,11 @@ struct DiffReviewFileSection: View {
                     contextSnapshot = snapshot
                     contextLoadTask = nil
                     contextLoadFileID = nil
-                    applyContextExpansion(key, mode: mode)
+                    let pendingExpansions = pendingContextExpansions
+                    pendingContextExpansions = []
+                    for expansion in pendingExpansions {
+                        applyContextExpansion(expansion.key, mode: expansion.mode)
+                    }
                 }
             } catch {
                 await MainActor.run {
@@ -507,6 +516,7 @@ struct DiffReviewFileSection: View {
                     contextLoadError = error.localizedDescription
                     contextLoadTask = nil
                     contextLoadFileID = nil
+                    pendingContextExpansions = []
                 }
             }
         }
@@ -529,6 +539,7 @@ struct DiffReviewFileSection: View {
         contextLoadTask = nil
         contextLoadFileID = nil
         contextLoadError = nil
+        pendingContextExpansions = []
     }
 
     @ViewBuilder

--- a/Alas/Sources/Center/DiffReview/DiffReviewFileSection.swift
+++ b/Alas/Sources/Center/DiffReview/DiffReviewFileSection.swift
@@ -24,6 +24,7 @@ struct DiffReviewFileSection: View {
     var draftCommentActions = ReviewDraftCommentActions()
     var onSelectDraftComment: (ReviewDraftComment) -> Void = { _ in }
     var onSaveDraftComment: (DiffReviewLineAnchor, String) -> Void = { _, _ in }
+    var onContextExpansionActivated: () -> Void = {}
     var reviewFeedbackTarget: ReviewFeedbackTarget?
 
     @Environment(\.theme) private var theme
@@ -501,6 +502,7 @@ struct DiffReviewFileSection: View {
 
     private func loadContextAndExpand(_ key: DiffContextExpansionKey, mode: DiffContextExpansionMode) {
         guard let provider = file.contextProvider else { return }
+        onContextExpansionActivated()
         if contextSnapshot != nil {
             applyContextExpansion(key, mode: mode)
             return

--- a/Alas/Sources/Center/DiffReview/DiffReviewFileSection.swift
+++ b/Alas/Sources/Center/DiffReview/DiffReviewFileSection.swift
@@ -34,6 +34,7 @@ struct DiffReviewFileSection: View {
     @State private var contextExpansion = DiffContextExpansionState()
     @State private var contextLoadTask: Task<Void, Never>?
     @State private var contextLoadFileID: DiffReviewFileID?
+    @State private var contextLoadSignature: String?
     @State private var contextLoadGeneration = 0
     @State private var contextLoadError: String?
     @State private var pendingContextExpansions: [PendingContextExpansion] = []
@@ -62,6 +63,9 @@ struct DiffReviewFileSection: View {
             clearPendingDraft()
         }
         .onChange(of: file.id) { _, _ in
+            resetContextState()
+        }
+        .onChange(of: contextStateSignature) { _, _ in
             resetContextState()
         }
         .onDisappear {
@@ -471,7 +475,7 @@ struct DiffReviewFileSection: View {
         return Set(groups.flatMap(ReviewDraftCommentPlacement.allRowKeys))
     }
 
-    private var draftCommentDisplaySignature: String {
+    private var displayGroupSignature: String {
         let groupSignature = file.displayModel?.groups.map { group in
             let rowSignature = group.rows.map { row in
                 [
@@ -483,7 +487,19 @@ struct DiffReviewFileSection: View {
             }.joined(separator: ",")
             return "\(group.id)[\(rowSignature)]"
         }.joined(separator: "|") ?? "placeholder"
-        return "\(file.id.rawValue)|\(groupSignature)"
+        return groupSignature
+    }
+
+    private var draftCommentDisplaySignature: String {
+        "\(file.id.rawValue)|\(displayGroupSignature)"
+    }
+
+    private var contextStateSignature: String {
+        [
+            file.id.rawValue,
+            file.contextProvider?.id.uuidString ?? "no-context-provider",
+            displayGroupSignature,
+        ].joined(separator: "|")
     }
 
     private func loadContextAndExpand(_ key: DiffContextExpansionKey, mode: DiffContextExpansionMode) {
@@ -495,19 +511,25 @@ struct DiffReviewFileSection: View {
         pendingContextExpansions.append(PendingContextExpansion(key: key, mode: mode))
         guard contextLoadTask == nil else { return }
         let fileID = file.id
+        let loadSignature = contextStateSignature
         contextLoadGeneration += 1
         let loadGeneration = contextLoadGeneration
         contextLoadError = nil
         contextLoadFileID = fileID
+        contextLoadSignature = loadSignature
         contextLoadTask = Task {
             do {
                 let snapshot = try await provider.snapshot()
                 try Task.checkCancellation()
                 await MainActor.run {
-                    guard contextLoadGeneration == loadGeneration, contextLoadFileID == fileID else { return }
+                    guard contextLoadGeneration == loadGeneration,
+                          contextLoadFileID == fileID,
+                          contextLoadSignature == loadSignature
+                    else { return }
                     contextSnapshot = snapshot
                     contextLoadTask = nil
                     contextLoadFileID = nil
+                    contextLoadSignature = nil
                     let pendingExpansions = pendingContextExpansions
                     pendingContextExpansions = []
                     for expansion in pendingExpansions {
@@ -516,10 +538,14 @@ struct DiffReviewFileSection: View {
                 }
             } catch {
                 await MainActor.run {
-                    guard contextLoadGeneration == loadGeneration, contextLoadFileID == fileID else { return }
+                    guard contextLoadGeneration == loadGeneration,
+                          contextLoadFileID == fileID,
+                          contextLoadSignature == loadSignature
+                    else { return }
                     contextLoadError = error.localizedDescription
                     contextLoadTask = nil
                     contextLoadFileID = nil
+                    contextLoadSignature = nil
                     pendingContextExpansions = []
                 }
             }
@@ -543,6 +569,7 @@ struct DiffReviewFileSection: View {
         contextExpansion = DiffContextExpansionState()
         contextLoadTask = nil
         contextLoadFileID = nil
+        contextLoadSignature = nil
         contextLoadError = nil
         pendingContextExpansions = []
     }

--- a/Alas/Sources/Center/DiffReview/DiffReviewFileSection.swift
+++ b/Alas/Sources/Center/DiffReview/DiffReviewFileSection.swift
@@ -34,6 +34,7 @@ struct DiffReviewFileSection: View {
     @State private var contextExpansion = DiffContextExpansionState()
     @State private var contextLoadTask: Task<Void, Never>?
     @State private var contextLoadFileID: DiffReviewFileID?
+    @State private var contextLoadGeneration = 0
     @State private var contextLoadError: String?
     @State private var pendingContextExpansions: [PendingContextExpansion] = []
 
@@ -494,13 +495,16 @@ struct DiffReviewFileSection: View {
         pendingContextExpansions.append(PendingContextExpansion(key: key, mode: mode))
         guard contextLoadTask == nil else { return }
         let fileID = file.id
+        contextLoadGeneration += 1
+        let loadGeneration = contextLoadGeneration
         contextLoadError = nil
         contextLoadFileID = fileID
         contextLoadTask = Task {
             do {
                 let snapshot = try await provider.snapshot()
+                try Task.checkCancellation()
                 await MainActor.run {
-                    guard contextLoadFileID == fileID else { return }
+                    guard contextLoadGeneration == loadGeneration, contextLoadFileID == fileID else { return }
                     contextSnapshot = snapshot
                     contextLoadTask = nil
                     contextLoadFileID = nil
@@ -512,7 +516,7 @@ struct DiffReviewFileSection: View {
                 }
             } catch {
                 await MainActor.run {
-                    guard contextLoadFileID == fileID else { return }
+                    guard contextLoadGeneration == loadGeneration, contextLoadFileID == fileID else { return }
                     contextLoadError = error.localizedDescription
                     contextLoadTask = nil
                     contextLoadFileID = nil
@@ -534,6 +538,7 @@ struct DiffReviewFileSection: View {
 
     private func resetContextState() {
         contextLoadTask?.cancel()
+        contextLoadGeneration += 1
         contextSnapshot = nil
         contextExpansion = DiffContextExpansionState()
         contextLoadTask = nil

--- a/Alas/Sources/Center/DiffReview/DiffReviewFileSection.swift
+++ b/Alas/Sources/Center/DiffReview/DiffReviewFileSection.swift
@@ -68,9 +68,6 @@ struct DiffReviewFileSection: View {
         .onChange(of: contextStateSignature) { _, _ in
             resetContextState()
         }
-        .onDisappear {
-            resetContextState()
-        }
     }
 
     private var header: some View {

--- a/Alas/Sources/Center/DiffReview/DiffReviewModels.swift
+++ b/Alas/Sources/Center/DiffReview/DiffReviewModels.swift
@@ -179,6 +179,7 @@ struct DiffReviewFileSectionModel: Identifiable {
     let displayModel: DiffDisplayModel?
     let placeholderMessage: String?
     let openFile: (() -> Void)?
+    let contextProvider: DiffReviewContextProvider?
 }
 
 struct DiffReviewSourceGroup: Equatable, Identifiable {

--- a/Alas/Sources/Center/DiffReview/DiffReviewSurface.swift
+++ b/Alas/Sources/Center/DiffReview/DiffReviewSurface.swift
@@ -32,6 +32,7 @@ struct DiffReviewSurface: View {
     @State private var scrollCommandController = DiffReviewScrollCommandController()
     @State private var scrollCommand: DiffReviewScrollCommand?
     @State private var renderedFileIDs: Set<DiffReviewFileID> = []
+    @State private var contextExpandedFileIDs: Set<DiffReviewFileID> = []
     @State private var synchronizedFileSetKey: String?
 
     private static let scrollCoordinateSpace = "diff-review-scroll"
@@ -281,6 +282,9 @@ struct DiffReviewSurface: View {
                 onSaveDraftComment: { anchor, body in
                     onSaveDraftComment(file.id, anchor, body)
                 },
+                onContextExpansionActivated: {
+                    contextExpandedFileIDs.insert(file.id)
+                },
                 reviewFeedbackTarget: effectiveReviewFeedbackTarget
             )
         } else {
@@ -356,7 +360,7 @@ struct DiffReviewSurface: View {
                 draftCommentScrollCommand: draftCommentScrollCommand
             ),
             firstFileID: firstFileID
-        )
+        ).union(contextExpandedFileIDs)
     }
 
     private func sectionFrameReader(for id: DiffReviewFileID) -> some View {
@@ -401,7 +405,7 @@ struct DiffReviewSurface: View {
                 draftCommentScrollCommand: draftCommentScrollCommand
             ),
             firstFileID: firstFileID
-        )
+        ).union(contextExpandedFileIDs)
         guard updated != renderedFileIDs else { return }
 
         renderedFileIDs = updated
@@ -421,6 +425,7 @@ struct DiffReviewSurface: View {
         synchronizedFileSetKey = result.fileSetKey
         programmaticScroll = result.programmaticScroll
         renderedFileIDs = []
+        contextExpandedFileIDs.formIntersection(Set(fileIDs))
         if DiffReviewSurfaceSelectionSync.shouldScrollRestoredSelection(
             previousFileSetKey: previousFileSetKey,
             previousSelection: previousSelection,

--- a/Alas/Sources/Center/ReviewChanges/ReviewChangesLoader.swift
+++ b/Alas/Sources/Center/ReviewChanges/ReviewChangesLoader.swift
@@ -3,6 +3,7 @@ import Foundation
 protocol ReviewChangesGitClient {
     func status(worktreePath: URL) async throws -> [ChangedFile]
     func diff(worktreePath: URL, file: String, staged: Bool, originalPath: String?) async throws -> ParsedDiff
+    func contextSnapshot(worktreePath: URL, file: String, staged: Bool, originalPath: String?) async throws -> DiffReviewFileContextSnapshot
 }
 
 extension GitService: ReviewChangesGitClient {}
@@ -31,7 +32,7 @@ struct ReviewChangesLoader {
             )
             try Task.checkCancellation()
 
-            files.append(try await fileSection(for: change, diff: diff))
+            files.append(try await fileSection(for: change, diff: diff, worktreePath: worktreePath))
         }
 
         return ReviewChangesLoadedSession(
@@ -53,8 +54,9 @@ struct ReviewChangesLoader {
             }
     }
 
-    private func fileSection(for change: ChangedFile, diff: ParsedDiff) async throws -> ReviewChangesFileSectionModel {
+    private func fileSection(for change: ChangedFile, diff: ParsedDiff, worktreePath: URL) async throws -> ReviewChangesFileSectionModel {
         let source = ReviewChangesSource(stage: change.stage)
+        let staged = change.stage == .staged
         let canRender = !diff.hunks.isEmpty && !ImageFileType.isSupported(relativePath: change.path)
         let counts = lineCounts(in: diff)
         let summary = DiffReviewFileSummary(
@@ -76,7 +78,15 @@ struct ReviewChangesLoader {
                 ? try await buildDisplayModel(diff: diff, filePath: change.path)
                 : nil,
             placeholderMessage: canRender ? nil : placeholderMessage(for: change, diff: diff),
-            openFile: nil
+            openFile: nil,
+            contextProvider: DiffReviewContextProvider {
+                try await git.contextSnapshot(
+                    worktreePath: worktreePath,
+                    file: change.path,
+                    staged: staged,
+                    originalPath: change.renameFrom
+                )
+            }
         )
     }
 

--- a/Alas/Sources/Center/ReviewRequest/DraftReviewRequestDiffSessionBuilder.swift
+++ b/Alas/Sources/Center/ReviewRequest/DraftReviewRequestDiffSessionBuilder.swift
@@ -86,7 +86,8 @@ enum DraftReviewRequestDiffSessionBuilder {
                 ? try await buildDisplayModel(diff: diff, filePath: file.path)
                 : nil,
             placeholderMessage: canRender ? nil : placeholderMessage(for: file, diff: diff),
-            openFile: openFile
+            openFile: openFile,
+            contextProvider: nil
         )
     }
 

--- a/Alas/Sources/Center/ReviewRequest/DraftReviewRequestDiffSessionBuilder.swift
+++ b/Alas/Sources/Center/ReviewRequest/DraftReviewRequestDiffSessionBuilder.swift
@@ -6,7 +6,8 @@ enum DraftReviewRequestDiffSessionBuilder {
     static func build(
         context: ReviewRequestDraftContext,
         worktreePath: URL,
-        openFileForPath: @escaping (String) -> (() -> Void)?
+        openFileForPath: @escaping (String) -> (() -> Void)?,
+        contextProviderForPath: @escaping (String, String?) -> DiffReviewContextProvider? = { _, _ in nil }
     ) async throws -> DiffReviewLoadedSession {
         _ = worktreePath
         var sections: [DiffReviewFileSectionModel] = []
@@ -20,7 +21,8 @@ enum DraftReviewRequestDiffSessionBuilder {
             sections.append(try await fileSection(
                 for: file,
                 diff: parsed,
-                openFile: openFileForPath(file.path)
+                openFile: openFileForPath(file.path),
+                contextProvider: contextProviderForPath(file.path, file.originalPath)
             ))
         }
 
@@ -62,7 +64,8 @@ enum DraftReviewRequestDiffSessionBuilder {
     private static func fileSection(
         for file: CommitChangedFile,
         diff: ParsedDiff,
-        openFile: (() -> Void)?
+        openFile: (() -> Void)?,
+        contextProvider: DiffReviewContextProvider?
     ) async throws -> DiffReviewFileSectionModel {
         let isImage = ImageFileType.isSupported(relativePath: file.path)
         let canRender = !diff.hunks.isEmpty && !isImage
@@ -87,7 +90,7 @@ enum DraftReviewRequestDiffSessionBuilder {
                 : nil,
             placeholderMessage: canRender ? nil : placeholderMessage(for: file, diff: diff),
             openFile: openFile,
-            contextProvider: nil
+            contextProvider: contextProvider
         )
     }
 

--- a/Alas/Sources/Center/ReviewRequest/DraftReviewRequestTabView.swift
+++ b/Alas/Sources/Center/ReviewRequest/DraftReviewRequestTabView.swift
@@ -570,6 +570,17 @@ struct DraftReviewRequestTabView: View {
                     ) { path in
                         appState.openFile(relativePath: path, worktreeId: worktreeId)
                     }
+                },
+                contextProviderForPath: { path, originalPath in
+                    DiffReviewContextProvider {
+                        try await GitService().refContextSnapshot(
+                            worktreePath: worktreePath,
+                            baseRef: tabState.baseBranch,
+                            headRef: tabState.headSHA.isEmpty ? "HEAD" : tabState.headSHA,
+                            file: path,
+                            originalPath: originalPath
+                        )
+                    }
                 }
             )
             guard !Task.isCancelled, key == contextKey else { return }

--- a/Alas/Sources/Center/ReviewWorkspace/ReviewSessionLoader.swift
+++ b/Alas/Sources/Center/ReviewWorkspace/ReviewSessionLoader.swift
@@ -129,6 +129,18 @@ struct ReviewSessionLoader {
                             worktreePath: target.repositoryPath,
                             relativePath: path
                         )
+                    },
+                    contextProviderForPath: { path, originalPath in
+                        let resolvedHeadRef = headSHA.flatMap { $0.isEmpty ? nil : $0 } ?? "HEAD"
+                        return DiffReviewContextProvider {
+                            try await GitService().refContextSnapshot(
+                                worktreePath: target.repositoryPath,
+                                baseRef: base,
+                                headRef: resolvedHeadRef,
+                                file: path,
+                                originalPath: originalPath
+                            )
+                        }
                     }
                 )
             }

--- a/Alas/Sources/Git/GitService.swift
+++ b/Alas/Sources/Git/GitService.swift
@@ -206,9 +206,23 @@ extension GitService {
 
     func refContextSnapshot(worktreePath: URL, baseRef: String, headRef: String, file: String, originalPath: String? = nil) async throws -> DiffReviewFileContextSnapshot {
         let oldPath = originalPath?.isEmpty == false ? originalPath! : file
-        let old = try await blobLinesOrUnavailable(worktreePath: worktreePath, ref: baseRef, path: oldPath)
+        let mergeBase = try await mergeBase(worktreePath: worktreePath, baseRef: baseRef, headRef: headRef)
+        let old = try await blobLinesOrUnavailable(worktreePath: worktreePath, ref: mergeBase, path: oldPath)
         let new = try await blobLinesOrUnavailable(worktreePath: worktreePath, ref: headRef, path: file)
         return DiffReviewFileContextSnapshot(old: old, new: new)
+    }
+
+    private func mergeBase(worktreePath: URL, baseRef: String, headRef: String) async throws -> String {
+        let result = try await Process.git(["merge-base", baseRef, headRef], cwd: worktreePath)
+        let stdout = result.stdout.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard result.exitCode == 0, !stdout.isEmpty else {
+            let detail = result.stderr.trimmingCharacters(in: .whitespacesAndNewlines)
+            let message = detail.isEmpty
+                ? "Unable to resolve merge base for \(baseRef) and \(headRef)."
+                : detail
+            throw ProcessError.nonZeroExit(result.exitCode, message)
+        }
+        return stdout
     }
 
     private func firstParentOrEmptyTree(worktreePath: URL, sha: String) async throws -> String {

--- a/Alas/Sources/Git/GitService.swift
+++ b/Alas/Sources/Git/GitService.swift
@@ -207,6 +207,9 @@ extension GitService {
 
     private func worktreeLinesOrUnavailable(worktreePath: URL, path: String) async throws -> DiffReviewFileContextLines {
         let url = worktreePath.appendingPathComponent(path)
+        if let destination = try? FileManager.default.destinationOfSymbolicLink(atPath: url.path) {
+            return .available([destination])
+        }
         do {
             let data = try Data(contentsOf: url)
             return Self.contextLinesOrUnavailable(from: data)

--- a/Alas/Sources/Git/GitService.swift
+++ b/Alas/Sources/Git/GitService.swift
@@ -196,6 +196,41 @@ extension GitService {
         return DiffReviewFileContextSnapshot(old: old, new: new)
     }
 
+    func commitContextSnapshot(worktreePath: URL, sha: String, file: String, originalPath: String? = nil) async throws -> DiffReviewFileContextSnapshot {
+        let oldPath = originalPath?.isEmpty == false ? originalPath! : file
+        let parentSha = try await firstParentOrEmptyTree(worktreePath: worktreePath, sha: sha)
+        let old = try await blobLinesOrUnavailable(worktreePath: worktreePath, ref: parentSha, path: oldPath)
+        let new = try await blobLinesOrUnavailable(worktreePath: worktreePath, ref: sha, path: file)
+        return DiffReviewFileContextSnapshot(old: old, new: new)
+    }
+
+    func refContextSnapshot(worktreePath: URL, baseRef: String, headRef: String, file: String, originalPath: String? = nil) async throws -> DiffReviewFileContextSnapshot {
+        let oldPath = originalPath?.isEmpty == false ? originalPath! : file
+        let old = try await blobLinesOrUnavailable(worktreePath: worktreePath, ref: baseRef, path: oldPath)
+        let new = try await blobLinesOrUnavailable(worktreePath: worktreePath, ref: headRef, path: file)
+        return DiffReviewFileContextSnapshot(old: old, new: new)
+    }
+
+    private func firstParentOrEmptyTree(worktreePath: URL, sha: String) async throws -> String {
+        let parentsResult = try await Process.git(
+            ["rev-list", "--parents", "-n", "1", sha],
+            cwd: worktreePath
+        )
+        guard parentsResult.exitCode == 0 else {
+            throw NSError(
+                domain: "GitService.commitContextSnapshot(sha:file:)",
+                code: Int(parentsResult.exitCode),
+                userInfo: [NSLocalizedDescriptionKey: parentsResult.stderr]
+            )
+        }
+        let parts = parentsResult.stdout.trimmingCharacters(in: .whitespacesAndNewlines)
+            .split(separator: " ", omittingEmptySubsequences: true)
+        if parts.count > 1 {
+            return String(parts[1])
+        }
+        return "4b825dc642cb6eb9a060e54bf8d69288fbee4904"
+    }
+
     private func blobLinesOrUnavailable(worktreePath: URL, ref: String, path: String) async throws -> DiffReviewFileContextLines {
         let blobSpec = ref == ":" ? ":\(path)" : "\(ref):\(path)"
         let result = try await Process.gitData(["show", blobSpec], cwd: worktreePath)

--- a/Alas/Sources/Git/GitService.swift
+++ b/Alas/Sources/Git/GitService.swift
@@ -176,6 +176,61 @@ extension GitService {
         return await Self.parseOffMain(stdout)
     }
 
+    func contextSnapshot(worktreePath: URL, file: String, staged: Bool, originalPath: String? = nil) async throws -> DiffReviewFileContextSnapshot {
+        let oldPath = originalPath?.isEmpty == false ? originalPath! : file
+        let old: DiffReviewFileContextLines
+        let new: DiffReviewFileContextLines
+
+        if staged {
+            if try await hasHead(worktreePath: worktreePath) {
+                old = try await blobLinesOrUnavailable(worktreePath: worktreePath, ref: "HEAD", path: oldPath)
+            } else {
+                old = .available([])
+            }
+            new = try await blobLinesOrUnavailable(worktreePath: worktreePath, ref: ":", path: file)
+        } else {
+            old = try await blobLinesOrUnavailable(worktreePath: worktreePath, ref: ":", path: oldPath)
+            new = try await worktreeLinesOrUnavailable(worktreePath: worktreePath, path: file)
+        }
+
+        return DiffReviewFileContextSnapshot(old: old, new: new)
+    }
+
+    private func blobLinesOrUnavailable(worktreePath: URL, ref: String, path: String) async throws -> DiffReviewFileContextLines {
+        let blobSpec = ref == ":" ? ":\(path)" : "\(ref):\(path)"
+        let result = try await Process.gitData(["show", blobSpec], cwd: worktreePath)
+        guard result.exitCode == 0 else {
+            return .unavailable
+        }
+        return Self.contextLinesOrUnavailable(from: result.stdout)
+    }
+
+    private func worktreeLinesOrUnavailable(worktreePath: URL, path: String) async throws -> DiffReviewFileContextLines {
+        let url = worktreePath.appendingPathComponent(path)
+        do {
+            let data = try Data(contentsOf: url)
+            return Self.contextLinesOrUnavailable(from: data)
+        } catch {
+            return .unavailable
+        }
+    }
+
+    private static func contextLinesOrUnavailable(from data: Data) -> DiffReviewFileContextLines {
+        guard !data.contains(0),
+              let text = String(data: data, encoding: .utf8) else {
+            return .unavailable
+        }
+        return .available(splitContextLines(text))
+    }
+
+    private static func splitContextLines(_ text: String) -> [String] {
+        var lines = text.split(separator: "\n", omittingEmptySubsequences: false).map(String.init)
+        if lines.last == "" {
+            lines.removeLast()
+        }
+        return lines
+    }
+
     /// Parses diff stdout on a detached executor so callers awaited from the
     /// MainActor (SwiftUI `.task`) don't resume on main for tens of thousands
     /// of lines of synchronous string work — that's the freeze users see on

--- a/Alas/Sources/Integrations/CodeHost/ReviewRequestDiffLoader.swift
+++ b/Alas/Sources/Integrations/CodeHost/ReviewRequestDiffLoader.swift
@@ -52,7 +52,8 @@ struct ReviewRequestDiffLoader {
                 ? try await buildDisplayModel(diff: parsed, filePath: section.path)
                 : nil,
             placeholderMessage: canRender ? nil : placeholderMessage(for: section, diff: parsed),
-            openFile: nil
+            openFile: nil,
+            contextProvider: nil
         )
     }
 

--- a/AlasTests/CommitReviewLoaderTests.swift
+++ b/AlasTests/CommitReviewLoaderTests.swift
@@ -151,6 +151,51 @@ struct CommitReviewLoaderTests {
         #expect(withoutOpenFile.files.first?.openFile == nil)
     }
 
+    @Test func attachesContextProviderForCommitFiles() async throws {
+        let snapshot = DiffReviewFileContextSnapshot(
+            old: .available(["old"]),
+            new: .available(["new"])
+        )
+        let git = FakeCommitReviewGitClient(
+            diffs: [
+                "Sources/NewName.swift": diff(lines: [
+                    .init(kind: .delete, text: "old", oldNumber: 1, newNumber: nil),
+                    .init(kind: .add, text: "new", oldNumber: nil, newNumber: 1),
+                ]),
+            ],
+            snapshots: [
+                "abc123:Sources/NewName.swift": snapshot,
+            ]
+        )
+        let loader = CommitReviewLoader(git: git)
+        let worktreePath = URL(fileURLWithPath: "/tmp/repo")
+
+        let session = try await loader.load(
+            worktreePath: worktreePath,
+            sha: "abc123",
+            files: [
+                CommitChangedFile(
+                    path: "Sources/NewName.swift",
+                    originalPath: "Sources/OldName.swift",
+                    status: "R",
+                    add: 1,
+                    del: 1
+                ),
+            ],
+            openFileForPath: { _ in nil }
+        )
+
+        #expect(try await session.files.first?.contextProvider?.snapshot() == snapshot)
+        #expect(git.contextSnapshotRequests == [
+            .init(
+                worktreePath: worktreePath,
+                sha: "abc123",
+                file: "Sources/NewName.swift",
+                originalPath: "Sources/OldName.swift"
+            ),
+        ])
+    }
+
     private func diff(lines: [ParsedDiff.Hunk.Line]) -> ParsedDiff {
         ParsedDiff(hunks: [
             ParsedDiff.Hunk(
@@ -172,15 +217,25 @@ private final class FakeCommitReviewGitClient: CommitReviewGitClient, @unchecked
     }
 
     private let diffs: [String: ParsedDiff]
+    private let snapshots: [String: DiffReviewFileContextSnapshot]
     private let lock = NSLock()
     private var recordedRequests: [Request] = []
+    private var recordedContextSnapshotRequests: [Request] = []
 
-    init(diffs: [String: ParsedDiff]) {
+    init(
+        diffs: [String: ParsedDiff],
+        snapshots: [String: DiffReviewFileContextSnapshot] = [:]
+    ) {
         self.diffs = diffs
+        self.snapshots = snapshots
     }
 
     var requests: [Request] {
         lock.withLock { recordedRequests }
+    }
+
+    var contextSnapshotRequests: [Request] {
+        lock.withLock { recordedContextSnapshotRequests }
     }
 
     func diff(worktreePath: URL, sha: String, file: String, originalPath: String?) async throws -> ParsedDiff {
@@ -193,6 +248,23 @@ private final class FakeCommitReviewGitClient: CommitReviewGitClient, @unchecked
             ))
         }
         return diffs[file, default: ParsedDiff(hunks: [])]
+    }
+
+    func commitContextSnapshot(
+        worktreePath: URL,
+        sha: String,
+        file: String,
+        originalPath: String?
+    ) async throws -> DiffReviewFileContextSnapshot {
+        lock.withLock {
+            recordedContextSnapshotRequests.append(Request(
+                worktreePath: worktreePath,
+                sha: sha,
+                file: file,
+                originalPath: originalPath
+            ))
+        }
+        return snapshots["\(sha):\(file)", default: DiffReviewFileContextSnapshot(old: .unavailable, new: .unavailable)]
     }
 }
 

--- a/AlasTests/CommitTabViewTests.swift
+++ b/AlasTests/CommitTabViewTests.swift
@@ -60,7 +60,8 @@ struct CommitTabViewTests {
                     parsedDiff: nil,
                     displayModel: nil,
                     placeholderMessage: "No diff.",
-                    openFile: nil
+                    openFile: nil,
+                    contextProvider: nil
                 ),
             ],
             summary: DiffReviewSessionModel(files: [file], groupsEnabled: false)

--- a/AlasTests/DiffContextExpansionTests.swift
+++ b/AlasTests/DiffContextExpansionTests.swift
@@ -49,11 +49,13 @@ struct DiffContextExpansionTests {
             filePath: "a.swift",
             chunkSize: 2
         )
-        #expect(expanded[0].rows.prefix(3).map(\.kind) == [.expandedContext, .expandedContext, .expandableContext])
-        #expect(expanded[0].rows[0].old?.lineNumber == 2)
-        #expect(expanded[0].rows[1].old?.lineNumber == 3)
-        #expect(expanded[0].rows[0].new?.lineNumber == 2)
-        #expect(expanded[0].rows[1].new?.lineNumber == 3)
+        #expect(expanded[0].rows.prefix(3).map(\.kind) == [.expandableContext, .expandedContext, .expandedContext])
+        #expect(expanded[0].rows[0].contextExpansion?.boundary == .above)
+        #expect(expanded[0].rows[0].collapsedLineCount == 1)
+        #expect(expanded[0].rows[1].old?.lineNumber == 2)
+        #expect(expanded[0].rows[2].old?.lineNumber == 3)
+        #expect(expanded[0].rows[1].new?.lineNumber == 2)
+        #expect(expanded[0].rows[2].new?.lineNumber == 3)
     }
 
     @Test func optionExpansionRevealsAllBelowBoundary() {

--- a/AlasTests/DiffContextExpansionTests.swift
+++ b/AlasTests/DiffContextExpansionTests.swift
@@ -1,0 +1,119 @@
+import Testing
+@testable import Alas
+
+struct DiffContextExpansionTests {
+    private func group() -> DiffDisplayGroup {
+        let hunk = ParsedDiff.Hunk(
+            header: "@@ -4,3 +4,3 @@",
+            oldStart: 4,
+            newStart: 4,
+            lines: [
+                .init(kind: .context, text: "old/new 4", oldNumber: 4, newNumber: 4),
+                .init(kind: .delete, text: "old 5", oldNumber: 5, newNumber: nil),
+                .init(kind: .add, text: "new 5", oldNumber: nil, newNumber: 5),
+                .init(kind: .context, text: "old/new 6", oldNumber: 6, newNumber: 6),
+            ]
+        )
+        return DiffDisplayModelBuilder.build(diff: ParsedDiff(hunks: [hunk]), filePath: "a.swift").groups[0]
+    }
+
+    private func snapshot() -> DiffReviewFileContextSnapshot {
+        DiffReviewFileContextSnapshot(
+            old: .available((1...10).map { "old \($0)" }),
+            new: .available((1...12).map { "new \($0)" })
+        )
+    }
+
+    @Test func derivesAboveBoundaryAndChunkedRows() throws {
+        let base = group()
+        let snapshot = snapshot()
+        var state = DiffContextExpansionState()
+
+        let initial = DiffContextExpandedDisplayBuilder.derive(
+            groups: [base],
+            snapshot: snapshot,
+            providerAvailable: true,
+            expansion: state,
+            filePath: "a.swift",
+            chunkSize: 2
+        )
+        #expect(initial[0].rows.first?.contextExpansion?.boundary == .above)
+        #expect(initial[0].rows.first?.collapsedLineCount == 3)
+
+        state.expand(.init(groupID: base.id, boundary: .above), available: 3, mode: .chunk(size: 2))
+        let expanded = DiffContextExpandedDisplayBuilder.derive(
+            groups: [base],
+            snapshot: snapshot,
+            providerAvailable: true,
+            expansion: state,
+            filePath: "a.swift",
+            chunkSize: 2
+        )
+        #expect(expanded[0].rows.prefix(3).map(\.kind) == [.expandedContext, .expandedContext, .expandableContext])
+        #expect(expanded[0].rows[0].old?.lineNumber == 2)
+        #expect(expanded[0].rows[1].old?.lineNumber == 3)
+        #expect(expanded[0].rows[0].new?.lineNumber == 2)
+        #expect(expanded[0].rows[1].new?.lineNumber == 3)
+    }
+
+    @Test func optionExpansionRevealsAllBelowBoundary() {
+        let base = group()
+        var state = DiffContextExpansionState()
+        state.expand(.init(groupID: base.id, boundary: .below), available: 6, mode: .all)
+
+        let expanded = DiffContextExpandedDisplayBuilder.derive(
+            groups: [base],
+            snapshot: snapshot(),
+            providerAvailable: true,
+            expansion: state,
+            filePath: "a.swift",
+            chunkSize: 2
+        )
+        let trailing = expanded[0].rows.suffix(6)
+        #expect(trailing.allSatisfy { $0.kind == .expandedContext })
+        #expect(trailing.first?.old?.lineNumber == 7)
+        #expect(trailing.last?.new?.lineNumber == 12)
+        #expect(expanded[0].rows.contains { $0.contextExpansion?.boundary == .below } == false)
+    }
+
+    @Test func expansionStopsAtAdjacentHunkBoundaries() {
+        let first = group()
+        let secondHunk = ParsedDiff.Hunk(header: "@@ -8,1 +8,1 @@", oldStart: 8, newStart: 8, lines: [
+            .init(kind: .context, text: "line 8", oldNumber: 8, newNumber: 8),
+        ])
+        let second = DiffDisplayModelBuilder.build(diff: ParsedDiff(hunks: [secondHunk]), filePath: "a.swift").groups[0]
+        var state = DiffContextExpansionState()
+        state.expand(.init(groupID: first.id, boundary: .below), available: 10, mode: .all)
+
+        let expanded = DiffContextExpandedDisplayBuilder.derive(
+            groups: [first, second],
+            snapshot: snapshot(),
+            providerAvailable: true,
+            expansion: state,
+            filePath: "a.swift",
+            chunkSize: 2
+        )
+
+        let firstTrailingContext = expanded[0].rows.filter { $0.kind == .expandedContext }
+        #expect(firstTrailingContext.map { $0.old?.lineNumber } == [7])
+        #expect(firstTrailingContext.map { $0.new?.lineNumber } == [7])
+    }
+
+    @Test func originalDiffAnchorsStayStableAfterExpansion() throws {
+        let base = group()
+        var state = DiffContextExpansionState()
+        state.expand(.init(groupID: base.id, boundary: .above), available: 3, mode: .all)
+
+        let expanded = DiffContextExpandedDisplayBuilder.derive(
+            groups: [base],
+            snapshot: snapshot(),
+            providerAvailable: true,
+            expansion: state,
+            filePath: "a.swift",
+            chunkSize: 2
+        )
+        let replacement = try #require(expanded[0].rows.first { $0.kind == .replacement })
+        #expect(replacement.old?.anchor == base.rows.first { $0.kind == .replacement }?.old?.anchor)
+        #expect(replacement.new?.anchor == base.rows.first { $0.kind == .replacement }?.new?.anchor)
+    }
+}

--- a/AlasTests/DiffContextExpansionTests.swift
+++ b/AlasTests/DiffContextExpansionTests.swift
@@ -86,6 +86,7 @@ struct DiffContextExpansionTests {
         let second = DiffDisplayModelBuilder.build(diff: ParsedDiff(hunks: [secondHunk]), filePath: "a.swift").groups[0]
         var state = DiffContextExpansionState()
         state.expand(.init(groupID: first.id, boundary: .below), available: 10, mode: .all)
+        state.expand(.init(groupID: second.id, boundary: .above), available: 10, mode: .all)
 
         let expanded = DiffContextExpandedDisplayBuilder.derive(
             groups: [first, second],
@@ -99,6 +100,9 @@ struct DiffContextExpansionTests {
         let firstTrailingContext = expanded[0].rows.filter { $0.kind == .expandedContext }
         #expect(firstTrailingContext.map { $0.old?.lineNumber } == [7])
         #expect(firstTrailingContext.map { $0.new?.lineNumber } == [7])
+        #expect(expanded[1].rows.allSatisfy { $0.contextExpansion?.boundary != .above })
+        let allExpandedLineNumbers = expanded.flatMap(\.rows).compactMap { $0.old?.lineNumber }
+        #expect(allExpandedLineNumbers.filter { $0 == 7 }.count == 1)
     }
 
     @Test func addOnlyExpansionPairsBelowContextBeforeAdjacentHunk() {

--- a/AlasTests/DiffContextExpansionTests.swift
+++ b/AlasTests/DiffContextExpansionTests.swift
@@ -99,6 +99,55 @@ struct DiffContextExpansionTests {
         #expect(firstTrailingContext.map { $0.new?.lineNumber } == [7])
     }
 
+    @Test func addOnlyExpansionPairsBelowContextBeforeAdjacentHunk() {
+        let insertHunk = ParsedDiff.Hunk(header: "@@ -4,0 +5,2 @@", oldStart: 4, newStart: 5, lines: [
+            .init(kind: .add, text: "new 5", oldNumber: nil, newNumber: 5),
+            .init(kind: .add, text: "new 6", oldNumber: nil, newNumber: 6),
+        ])
+        let adjacentHunk = ParsedDiff.Hunk(header: "@@ -7,1 +9,1 @@", oldStart: 7, newStart: 9, lines: [
+            .init(kind: .context, text: "line", oldNumber: 7, newNumber: 9),
+        ])
+        let model = DiffDisplayModelBuilder.build(diff: ParsedDiff(hunks: [insertHunk, adjacentHunk]), filePath: "a.swift")
+        var state = DiffContextExpansionState()
+        state.expand(.init(groupID: model.groups[0].id, boundary: .below), available: 2, mode: .all)
+
+        let expanded = DiffContextExpandedDisplayBuilder.derive(
+            groups: model.groups,
+            snapshot: snapshot(),
+            providerAvailable: true,
+            expansion: state,
+            filePath: "a.swift",
+            chunkSize: 2
+        )
+
+        let insertedTrailingContext = expanded[0].rows.filter { $0.kind == .expandedContext }
+        #expect(insertedTrailingContext.map { $0.old?.lineNumber } == [5, 6])
+        #expect(insertedTrailingContext.map { $0.new?.lineNumber } == [7, 8])
+    }
+
+    @Test func deleteOnlyExpansionPairsAboveContextFromHunkPosition() {
+        let deleteHunk = ParsedDiff.Hunk(header: "@@ -5,2 +4,0 @@", oldStart: 5, newStart: 4, lines: [
+            .init(kind: .delete, text: "old 5", oldNumber: 5, newNumber: nil),
+            .init(kind: .delete, text: "old 6", oldNumber: 6, newNumber: nil),
+        ])
+        let base = DiffDisplayModelBuilder.build(diff: ParsedDiff(hunks: [deleteHunk]), filePath: "a.swift").groups[0]
+        var state = DiffContextExpansionState()
+        state.expand(.init(groupID: base.id, boundary: .above), available: 4, mode: .all)
+
+        let expanded = DiffContextExpandedDisplayBuilder.derive(
+            groups: [base],
+            snapshot: snapshot(),
+            providerAvailable: true,
+            expansion: state,
+            filePath: "a.swift",
+            chunkSize: 2
+        )
+
+        let leadingContext = expanded[0].rows.filter { $0.kind == .expandedContext }
+        #expect(leadingContext.map { $0.old?.lineNumber } == [1, 2, 3, 4])
+        #expect(leadingContext.map { $0.new?.lineNumber } == [1, 2, 3, 4])
+    }
+
     @Test func originalDiffAnchorsStayStableAfterExpansion() throws {
         let base = group()
         var state = DiffContextExpansionState()

--- a/AlasTests/DiffPaneViewTests.swift
+++ b/AlasTests/DiffPaneViewTests.swift
@@ -866,6 +866,41 @@ struct DiffPaneViewTests {
         #expect(DiffPaneCodeTextView.changeRailRect(in: rowRect, tone: .delete) == nil)
     }
 
+    @Test func lineNumberRulerColorsExpandableContextPlusAsBoundaryControl() throws {
+        let theme = theme()
+        let font = CenterTypography.resolveCodeFont(family: "", size: 13)
+        let document = DiffPaneTextDocumentBuilder.CodeDocument(
+            attributedString: NSAttributedString(
+                string: "9 unchanged lines above",
+                attributes: [.font: font]
+            ),
+            lines: [
+                DiffPaneTextDocumentBuilder.LineMetadata(
+                    kind: .expandableContext,
+                    range: NSRange(location: 0, length: 23),
+                    expansionKey: DiffContextExpansionKey(groupID: "hunk-0", boundary: .above),
+                    expansionBoundary: .above
+                ),
+            ]
+        )
+        let scrollView = DiffPaneTextScrollView(frame: NSRect(x: 0, y: 0, width: 220, height: 80))
+        scrollView.update(
+            document: document,
+            lineLabels: ["+"],
+            wraps: false,
+            font: font,
+            theme: theme,
+            lspContext: nil,
+            allowedLSPSide: .old
+        )
+
+        let ruler = try #require(scrollView.verticalRulerView as? DiffPaneLineNumberRulerView)
+        let color = try #require(ruler.labelAttributesForTesting(row: 0)[.foregroundColor] as? NSColor)
+
+        #expect(color == NSColor(theme.color("fg-faint")))
+        #expect(color != NSColor(theme.color("add")))
+    }
+
     @Test func splitDocumentBuildsSeparateCodeAndGutterColumns() throws {
         let result = DiffPaneTextDocumentBuilder.buildSplit(
             group: try #require(model().groups.first),

--- a/AlasTests/DiffPaneViewTests.swift
+++ b/AlasTests/DiffPaneViewTests.swift
@@ -979,6 +979,118 @@ struct DiffPaneViewTests {
         #expect(captured?.1 == .all)
     }
 
+    @Test @MainActor func codeTextViewInvokesExpansionActionForExpandableRows() throws {
+        let theme = theme()
+        let font = CenterTypography.resolveCodeFont(family: "", size: 13)
+        let key = DiffContextExpansionKey(groupID: "hunk-0", boundary: .above)
+        let document = DiffPaneTextDocumentBuilder.CodeDocument(
+            attributedString: NSAttributedString(
+                string: "9 unchanged lines above",
+                attributes: [.font: font]
+            ),
+            lines: [
+                DiffPaneTextDocumentBuilder.LineMetadata(
+                    kind: .expandableContext,
+                    range: NSRange(location: 0, length: 23),
+                    expansionKey: key,
+                    expansionBoundary: .above
+                ),
+            ]
+        )
+        let scrollView = DiffPaneTextScrollView(frame: NSRect(x: 0, y: 0, width: 220, height: 80))
+        let window = NSWindow(contentRect: scrollView.frame, styleMask: [], backing: .buffered, defer: false)
+        window.contentView?.addSubview(scrollView)
+        var captured: (DiffContextExpansionKey, DiffContextExpansionMode)?
+
+        scrollView.update(
+            document: document,
+            lineLabels: ["+"],
+            wraps: false,
+            font: font,
+            theme: theme,
+            lspContext: nil,
+            allowedLSPSide: .old,
+            onContextExpansion: { key, mode in captured = (key, mode) }
+        )
+        scrollView.layoutSubtreeIfNeeded()
+
+        let textView = try #require(scrollView.documentView as? DiffPaneCodeTextView)
+        let rowRect = try #require(textView.diffRowRects().first)
+        let windowPoint = textView.convert(NSPoint(x: rowRect.midX, y: rowRect.midY), to: nil)
+        let event = try #require(NSEvent.mouseEvent(
+            with: .leftMouseDown,
+            location: windowPoint,
+            modifierFlags: [],
+            timestamp: 0,
+            windowNumber: window.windowNumber,
+            context: nil,
+            eventNumber: 0,
+            clickCount: 1,
+            pressure: 1
+        ))
+
+        textView.mouseDown(with: event)
+
+        #expect(captured?.0 == key)
+        #expect(captured?.1 == .chunk(size: 10))
+    }
+
+    @Test @MainActor func codeTextViewOptionClickInvokesFullExpansionForExpandableRows() throws {
+        let theme = theme()
+        let font = CenterTypography.resolveCodeFont(family: "", size: 13)
+        let key = DiffContextExpansionKey(groupID: "hunk-0", boundary: .below)
+        let document = DiffPaneTextDocumentBuilder.CodeDocument(
+            attributedString: NSAttributedString(
+                string: "7 unchanged lines below",
+                attributes: [.font: font]
+            ),
+            lines: [
+                DiffPaneTextDocumentBuilder.LineMetadata(
+                    kind: .expandableContext,
+                    range: NSRange(location: 0, length: 23),
+                    expansionKey: key,
+                    expansionBoundary: .below
+                ),
+            ]
+        )
+        let scrollView = DiffPaneTextScrollView(frame: NSRect(x: 0, y: 0, width: 220, height: 80))
+        let window = NSWindow(contentRect: scrollView.frame, styleMask: [], backing: .buffered, defer: false)
+        window.contentView?.addSubview(scrollView)
+        var captured: (DiffContextExpansionKey, DiffContextExpansionMode)?
+
+        scrollView.update(
+            document: document,
+            lineLabels: ["+"],
+            wraps: false,
+            font: font,
+            theme: theme,
+            lspContext: nil,
+            allowedLSPSide: .new,
+            onContextExpansion: { key, mode in captured = (key, mode) }
+        )
+        scrollView.layoutSubtreeIfNeeded()
+
+        let textView = try #require(scrollView.documentView as? DiffPaneCodeTextView)
+        let rowRect = try #require(textView.diffRowRects().first)
+        let windowPoint = textView.convert(NSPoint(x: rowRect.midX, y: rowRect.midY), to: nil)
+        let event = try #require(NSEvent.mouseEvent(
+            with: .leftMouseDown,
+            location: windowPoint,
+            modifierFlags: .option,
+            timestamp: 0,
+            windowNumber: window.windowNumber,
+            context: nil,
+            eventNumber: 0,
+            clickCount: 1,
+            pressure: 1
+        ))
+
+        textView.mouseDown(with: event)
+
+        #expect(captured?.0 == key)
+        #expect(captured?.1 == .all)
+    }
+
     @Test @MainActor func lineNumberRulerKeepsReviewSelectionForNonExpandableRows() throws {
         let theme = theme()
         let font = CenterTypography.resolveCodeFont(family: "", size: 13)

--- a/AlasTests/DiffPaneViewTests.swift
+++ b/AlasTests/DiffPaneViewTests.swift
@@ -60,6 +60,37 @@ struct DiffPaneViewTests {
         )
     }
 
+    private func expandableContextGroup(
+        boundary: DiffContextBoundary,
+        collapsedLineCount: Int
+    ) -> DiffDisplayGroup {
+        let groupID = "hunk-0"
+        return DiffDisplayGroup(
+            id: groupID,
+            header: "@@ -2,1 +2,1 @@",
+            sourceHunk: ParsedDiff.Hunk(
+                header: "@@ -2,1 +2,1 @@",
+                oldStart: 2,
+                newStart: 2,
+                lines: []
+            ),
+            rows: [
+                DiffDisplayRow(
+                    id: "expand-\(boundary.rawValue)",
+                    kind: .expandableContext,
+                    old: nil,
+                    new: nil,
+                    collapsedLineCount: collapsedLineCount,
+                    contextExpansion: DiffContextExpansionRow(
+                        key: DiffContextExpansionKey(groupID: groupID, boundary: boundary),
+                        boundary: boundary,
+                        remainingLineCount: collapsedLineCount
+                    )
+                ),
+            ]
+        )
+    }
+
     @Test func splitModeHostsRendererWithoutCrashing() {
         var layout = DiffLayoutMode.split
         var wrap = false
@@ -859,6 +890,62 @@ struct DiffPaneViewTests {
         #expect(!result.newCode.attributedString.string.contains("|"))
         #expect(result.oldCode.lines.contains { $0.kind == .replacement })
         #expect(result.newCode.lines.contains { $0.kind == .replacement })
+    }
+
+    @Test func splitDocumentRendersExpandableContextBoundaryRows() throws {
+        let result = DiffPaneTextDocumentBuilder.buildSplit(
+            group: expandableContextGroup(boundary: .above, collapsedLineCount: 9),
+            expandedCollapsedRowIDs: [],
+            fileExtension: "swift",
+            font: CenterTypography.resolveCodeFont(family: "", size: 13),
+            showWhitespace: false,
+            theme: theme()
+        )
+        let key = DiffContextExpansionKey(groupID: "hunk-0", boundary: .above)
+
+        #expect(result.oldGutter.string.components(separatedBy: "\n") == ["+"])
+        #expect(result.newGutter.string.components(separatedBy: "\n") == [""])
+        #expect(result.oldCode.attributedString.string.components(separatedBy: "\n") == ["9 unchanged lines above"])
+        #expect(result.newCode.attributedString.string.components(separatedBy: "\n") == [" "])
+        #expect(result.oldCode.lines.count == result.oldGutter.string.components(separatedBy: "\n").count)
+        #expect(result.newCode.lines.count == result.newGutter.string.components(separatedBy: "\n").count)
+        #expect(result.oldCode.lines.first?.expansionKey == key)
+        #expect(result.oldCode.lines.first?.expansionBoundary == .above)
+        #expect(result.newCode.lines.first?.expansionKey == key)
+        #expect(result.newCode.lines.first?.expansionBoundary == .above)
+    }
+
+    @Test func stackedDocumentRendersExpandableContextBoundaryRows() throws {
+        let result = DiffPaneTextDocumentBuilder.buildStacked(
+            group: expandableContextGroup(boundary: .below, collapsedLineCount: 7),
+            expandedCollapsedRowIDs: [],
+            fileExtension: "swift",
+            font: CenterTypography.resolveCodeFont(family: "", size: 13),
+            showWhitespace: false,
+            theme: theme()
+        )
+
+        #expect(result.gutter.string.components(separatedBy: "\n") == ["+"])
+        #expect(result.code.attributedString.string.components(separatedBy: "\n") == ["7 unchanged lines below"])
+        #expect(result.code.lines.count == result.gutter.string.components(separatedBy: "\n").count)
+        #expect(result.code.lines.first?.expansionKey == DiffContextExpansionKey(groupID: "hunk-0", boundary: .below))
+        #expect(result.code.lines.first?.expansionBoundary == .below)
+    }
+
+    @Test func singleDocumentPreservesExpandableContextMetadata() throws {
+        let result = DiffPaneTextDocumentBuilder.build(
+            group: expandableContextGroup(boundary: .above, collapsedLineCount: 0),
+            expandedCollapsedRowIDs: [],
+            layoutMode: .split,
+            fileExtension: "swift",
+            font: CenterTypography.resolveCodeFont(family: "", size: 13),
+            showWhitespace: false,
+            theme: theme()
+        )
+
+        #expect(result.attributedString.string.contains("Expand context above"))
+        #expect(result.lines.first?.expansionKey == DiffContextExpansionKey(groupID: "hunk-0", boundary: .above))
+        #expect(result.lines.first?.expansionBoundary == .above)
     }
 
     @Test func stackedDocumentBuildsCodeOnlyTextAndSeparateGutter() throws {

--- a/AlasTests/DiffPaneViewTests.swift
+++ b/AlasTests/DiffPaneViewTests.swift
@@ -901,6 +901,148 @@ struct DiffPaneViewTests {
         #expect(color != NSColor(theme.color("add")))
     }
 
+    @Test @MainActor func lineNumberRulerInvokesExpansionActionForExpandableRows() throws {
+        let theme = theme()
+        let font = CenterTypography.resolveCodeFont(family: "", size: 13)
+        let key = DiffContextExpansionKey(groupID: "hunk-0", boundary: .above)
+        let document = DiffPaneTextDocumentBuilder.CodeDocument(
+            attributedString: NSAttributedString(
+                string: "9 unchanged lines above",
+                attributes: [.font: font]
+            ),
+            lines: [
+                DiffPaneTextDocumentBuilder.LineMetadata(
+                    kind: .expandableContext,
+                    range: NSRange(location: 0, length: 23),
+                    expansionKey: key,
+                    expansionBoundary: .above
+                ),
+            ]
+        )
+        let scrollView = DiffPaneTextScrollView(frame: NSRect(x: 0, y: 0, width: 220, height: 80))
+        var captured: (DiffContextExpansionKey, DiffContextExpansionMode)?
+
+        scrollView.update(
+            document: document,
+            lineLabels: ["+"],
+            wraps: false,
+            font: font,
+            theme: theme,
+            lspContext: nil,
+            allowedLSPSide: .old,
+            onContextExpansion: { key, mode in captured = (key, mode) }
+        )
+
+        let ruler = try #require(scrollView.verticalRulerView as? DiffPaneLineNumberRulerView)
+        ruler.invokeExpansionForTesting(row: 0, optionKey: false)
+
+        #expect(captured?.0 == key)
+        #expect(captured?.1 == .chunk(size: 10))
+    }
+
+    @Test @MainActor func lineNumberRulerOptionClickInvokesFullExpansionForExpandableRows() throws {
+        let theme = theme()
+        let font = CenterTypography.resolveCodeFont(family: "", size: 13)
+        let key = DiffContextExpansionKey(groupID: "hunk-0", boundary: .below)
+        let document = DiffPaneTextDocumentBuilder.CodeDocument(
+            attributedString: NSAttributedString(
+                string: "7 unchanged lines below",
+                attributes: [.font: font]
+            ),
+            lines: [
+                DiffPaneTextDocumentBuilder.LineMetadata(
+                    kind: .expandableContext,
+                    range: NSRange(location: 0, length: 23),
+                    expansionKey: key,
+                    expansionBoundary: .below
+                ),
+            ]
+        )
+        let scrollView = DiffPaneTextScrollView(frame: NSRect(x: 0, y: 0, width: 220, height: 80))
+        var captured: (DiffContextExpansionKey, DiffContextExpansionMode)?
+
+        scrollView.update(
+            document: document,
+            lineLabels: ["+"],
+            wraps: false,
+            font: font,
+            theme: theme,
+            lspContext: nil,
+            allowedLSPSide: .new,
+            onContextExpansion: { key, mode in captured = (key, mode) }
+        )
+
+        let ruler = try #require(scrollView.verticalRulerView as? DiffPaneLineNumberRulerView)
+        ruler.invokeExpansionForTesting(row: 0, optionKey: true)
+
+        #expect(captured?.0 == key)
+        #expect(captured?.1 == .all)
+    }
+
+    @Test @MainActor func lineNumberRulerKeepsReviewSelectionForNonExpandableRows() throws {
+        let theme = theme()
+        let font = CenterTypography.resolveCodeFont(family: "", size: 13)
+        let text = "let value = 1"
+        let anchor = DiffReviewLineAnchor(
+            path: "Sources/App.swift",
+            side: .new,
+            line: 12,
+            rowIndex: 0,
+            selectedText: text
+        )
+        let sourceLine = DiffDisplayLine(
+            id: "line-12",
+            anchor: DiffLineAnchor(
+                filePath: anchor.path,
+                hunkIndex: 0,
+                rowIndex: 0,
+                side: .new,
+                oldLine: nil,
+                newLine: anchor.line
+            ),
+            text: text,
+            lineNumber: anchor.line,
+            kind: .context,
+            inlineSpans: [],
+            noTrailingNewline: false
+        )
+        let document = DiffPaneTextDocumentBuilder.CodeDocument(
+            attributedString: NSAttributedString(
+                string: text,
+                attributes: [.font: font]
+            ),
+            lines: [
+                DiffPaneTextDocumentBuilder.LineMetadata(
+                    kind: .context,
+                    range: NSRange(location: 0, length: (text as NSString).length),
+                    sourceLine: sourceLine
+                ),
+            ]
+        )
+        let scrollView = DiffPaneTextScrollView(frame: NSRect(x: 0, y: 0, width: 220, height: 80))
+        var expansionInvocations = 0
+        var selectedAnchor: DiffReviewLineAnchor?
+        scrollView.onReviewLineSelected = { selectedAnchor = $0 }
+
+        scrollView.update(
+            document: document,
+            lineLabels: ["12"],
+            wraps: false,
+            font: font,
+            theme: theme,
+            lspContext: nil,
+            allowedLSPSide: .new,
+            onContextExpansion: { _, _ in expansionInvocations += 1 }
+        )
+
+        let ruler = try #require(scrollView.verticalRulerView as? DiffPaneLineNumberRulerView)
+        ruler.invokeExpansionForTesting(row: 0, optionKey: false)
+        ruler.invokeReviewLineSelectionForTesting(row: 0)
+
+        #expect(expansionInvocations == 0)
+        #expect(selectedAnchor == anchor)
+    }
+
     @Test func splitDocumentBuildsSeparateCodeAndGutterColumns() throws {
         let result = DiffPaneTextDocumentBuilder.buildSplit(
             group: try #require(model().groups.first),

--- a/AlasTests/DiffReviewSurfaceTests.swift
+++ b/AlasTests/DiffReviewSurfaceTests.swift
@@ -106,7 +106,8 @@ struct DiffReviewSurfaceTests {
             parsedDiff: parsedDiff(),
             displayModel: displayModel(),
             placeholderMessage: nil,
-            openFile: {}
+            openFile: {},
+            contextProvider: nil
         )
         var layout = DiffLayoutMode.split
         var wrap = false
@@ -138,7 +139,8 @@ struct DiffReviewSurfaceTests {
             parsedDiff: parsedDiff(),
             displayModel: displayModel(),
             placeholderMessage: nil,
-            openFile: nil
+            openFile: nil,
+            contextProvider: nil
         )
         var layout = DiffLayoutMode.split
         var wrap = false
@@ -179,7 +181,8 @@ struct DiffReviewSurfaceTests {
             parsedDiff: parsedDiff(),
             displayModel: displayModel(),
             placeholderMessage: nil,
-            openFile: nil
+            openFile: nil,
+            contextProvider: nil
         )
         let feedback = [
             DiffReviewInlineFeedback(
@@ -223,7 +226,8 @@ struct DiffReviewSurfaceTests {
             parsedDiff: parsedDiff(),
             displayModel: displayModel(),
             placeholderMessage: nil,
-            openFile: nil
+            openFile: nil,
+            contextProvider: nil
         )
         let feedback = DiffReviewInlineFeedback(
             id: "thread-1",
@@ -283,7 +287,8 @@ struct DiffReviewSurfaceTests {
             parsedDiff: parsedDiff(),
             displayModel: displayModel(),
             placeholderMessage: nil,
-            openFile: nil
+            openFile: nil,
+            contextProvider: nil
         )
         let feedback = inlineFeedbackItems(count: 5, path: file.summary.path, lineAnchored: false)
         var layout = DiffLayoutMode.split
@@ -320,7 +325,8 @@ struct DiffReviewSurfaceTests {
             parsedDiff: parsedDiff(),
             displayModel: displayModel(),
             placeholderMessage: nil,
-            openFile: nil
+            openFile: nil,
+            contextProvider: nil
         )
         let feedback = inlineFeedbackItems(count: 5, path: file.summary.path, lineAnchored: false)
         var layout = DiffLayoutMode.split
@@ -412,7 +418,8 @@ struct DiffReviewSurfaceTests {
             parsedDiff: parsedDiff(),
             displayModel: displayModel(),
             placeholderMessage: nil,
-            openFile: nil
+            openFile: nil,
+            contextProvider: nil
         )
         let feedback = inlineFeedbackItems(count: 5, path: file.summary.path, lineAnchored: false)
         var layout = DiffLayoutMode.split
@@ -703,7 +710,8 @@ struct DiffReviewSurfaceTests {
             parsedDiff: parsedDiff(),
             displayModel: displayModel(),
             placeholderMessage: nil,
-            openFile: nil
+            openFile: nil,
+            contextProvider: nil
         )
         let comment = draftComment(id: "draft-visible", fileID: file.id, path: file.summary.path, side: .new, startLine: 2)
         var layout = DiffLayoutMode.split
@@ -735,7 +743,8 @@ struct DiffReviewSurfaceTests {
             parsedDiff: parsedDiff(),
             displayModel: displayModel(),
             placeholderMessage: nil,
-            openFile: nil
+            openFile: nil,
+            contextProvider: nil
         )
         let comment = draftComment(id: "draft-dismiss-inline", fileID: file.id, path: file.summary.path, side: .new, startLine: 2)
         var layout = DiffLayoutMode.split
@@ -785,7 +794,8 @@ struct DiffReviewSurfaceTests {
             parsedDiff: parsedDiff(),
             displayModel: displayModel(),
             placeholderMessage: nil,
-            openFile: nil
+            openFile: nil,
+            contextProvider: nil
         )
         let target = ReviewFeedbackTarget(
             title: "Review working tree",
@@ -843,7 +853,8 @@ struct DiffReviewSurfaceTests {
             parsedDiff: parsedDiff(),
             displayModel: displayModel(),
             placeholderMessage: nil,
-            openFile: nil
+            openFile: nil,
+            contextProvider: nil
         )
         let comment = draftComment(
             id: "draft-disabled-send-inline",
@@ -899,7 +910,8 @@ struct DiffReviewSurfaceTests {
             parsedDiff: parsedDiff(),
             displayModel: displayModel(),
             placeholderMessage: nil,
-            openFile: nil
+            openFile: nil,
+            contextProvider: nil
         )
         let comment = draftComment(id: "draft-edit-inline", fileID: file.id, path: file.summary.path, side: .new, startLine: 2)
         var layout = DiffLayoutMode.split
@@ -1089,7 +1101,8 @@ struct DiffReviewSurfaceTests {
             parsedDiff: nil,
             displayModel: nil,
             placeholderMessage: "Binary files are not shown.",
-            openFile: nil
+            openFile: nil,
+            contextProvider: nil
         )
         var layout = DiffLayoutMode.split
         var wrap = false
@@ -1723,7 +1736,8 @@ struct DiffReviewSurfaceTests {
             parsedDiff: parsedDiff(),
             displayModel: displayModel(),
             placeholderMessage: nil,
-            openFile: nil
+            openFile: nil,
+            contextProvider: nil
         )
         var largeRows = Array(
             repeating: ParsedDiff.Hunk.Line(kind: .add, text: "let value = 1", oldNumber: nil, newNumber: 1),
@@ -1738,7 +1752,8 @@ struct DiffReviewSurfaceTests {
             parsedDiff: largeDiff,
             displayModel: DiffDisplayModelBuilder.build(diff: largeDiff, filePath: "Sources/Large.swift"),
             placeholderMessage: nil,
-            openFile: nil
+            openFile: nil,
+            contextProvider: nil
         )
 
         #expect(DiffReviewFileSectionHeightEstimator.estimatedHeight(for: large) > DiffReviewFileSectionHeightEstimator.estimatedHeight(for: small))
@@ -1750,7 +1765,8 @@ struct DiffReviewSurfaceTests {
             parsedDiff: parsedDiff(),
             displayModel: displayModel(),
             placeholderMessage: nil,
-            openFile: nil
+            openFile: nil,
+            contextProvider: nil
         )
 
         let noFeedback = DiffReviewFileSectionHeightEstimator.estimatedHeight(for: file, inlineFeedbackCount: 0)
@@ -1769,7 +1785,8 @@ struct DiffReviewSurfaceTests {
             parsedDiff: parsedDiff(),
             displayModel: displayModel(),
             placeholderMessage: nil,
-            openFile: nil
+            openFile: nil,
+            contextProvider: nil
         )
         let shortFeedback = [
             DiffReviewInlineFeedback(
@@ -1808,7 +1825,8 @@ struct DiffReviewSurfaceTests {
             parsedDiff: parsedDiff(),
             displayModel: displayModel(),
             placeholderMessage: nil,
-            openFile: nil
+            openFile: nil,
+            contextProvider: nil
         )
         let comment = draftComment(id: "draft-height", fileID: file.id, path: file.summary.path, side: .new, startLine: 2)
 
@@ -1852,7 +1870,8 @@ struct DiffReviewSurfaceTests {
             parsedDiff: parsedDiff(),
             displayModel: displayModel,
             placeholderMessage: nil,
-            openFile: nil
+            openFile: nil,
+            contextProvider: nil
         )
         let comment = draftComment(
             id: "draft-collapsed-height",
@@ -1921,7 +1940,8 @@ struct DiffReviewSurfaceTests {
                     parsedDiff: nil,
                     displayModel: nil,
                     placeholderMessage: "No diff.",
-                    openFile: nil
+                    openFile: nil,
+                    contextProvider: nil
                 )
             },
             summary: DiffReviewSessionModel(files: summaries, groupsEnabled: false)

--- a/AlasTests/GitServiceTests.swift
+++ b/AlasTests/GitServiceTests.swift
@@ -235,6 +235,11 @@ struct GitServiceTests {
         let sha = try await gitOK(["rev-parse", "HEAD"], cwd: repo)
             .stdout
             .trimmingCharacters(in: .whitespacesAndNewlines)
+        try await gitOK(["checkout", "-q", "main"], cwd: repo)
+        try writeText("main advanced\n", "old.swift", in: repo)
+        try await gitOK(["add", "old.swift"], cwd: repo)
+        try await gitOK(["commit", "-q", "-m", "advance main"], cwd: repo)
+        try await gitOK(["checkout", "-q", "feature/rename"], cwd: repo)
 
         let service = GitService()
         let commitSnapshot = try await service.commitContextSnapshot(

--- a/AlasTests/GitServiceTests.swift
+++ b/AlasTests/GitServiceTests.swift
@@ -220,6 +220,47 @@ struct GitServiceTests {
         ))
     }
 
+    @Test func commitAndRefContextSnapshotsUseOriginalPathForRename() async throws {
+        let repo = try await makeContextSnapshotRepo()
+        defer { try? FileManager.default.removeItem(at: repo) }
+
+        try writeText("old\n", "old.swift", in: repo)
+        try await gitOK(["add", "old.swift"], cwd: repo)
+        try await gitOK(["commit", "-q", "-m", "seed old file"], cwd: repo)
+        try await gitOK(["checkout", "-q", "-b", "feature/rename"], cwd: repo)
+        try await gitOK(["mv", "old.swift", "new.swift"], cwd: repo)
+        try writeText("new\n", "new.swift", in: repo)
+        try await gitOK(["add", "new.swift"], cwd: repo)
+        try await gitOK(["commit", "-q", "-m", "rename file"], cwd: repo)
+        let sha = try await gitOK(["rev-parse", "HEAD"], cwd: repo)
+            .stdout
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+
+        let service = GitService()
+        let commitSnapshot = try await service.commitContextSnapshot(
+            worktreePath: repo,
+            sha: sha,
+            file: "new.swift",
+            originalPath: "old.swift"
+        )
+        #expect(commitSnapshot == DiffReviewFileContextSnapshot(
+            old: .available(["old"]),
+            new: .available(["new"])
+        ))
+
+        let refSnapshot = try await service.refContextSnapshot(
+            worktreePath: repo,
+            baseRef: "main",
+            headRef: "HEAD",
+            file: "new.swift",
+            originalPath: "old.swift"
+        )
+        #expect(refSnapshot == DiffReviewFileContextSnapshot(
+            old: .available(["old"]),
+            new: .available(["new"])
+        ))
+    }
+
     @Test func contextSnapshotReturnsUnavailableForBinaryAndInvalidUTF8() async throws {
         let repo = try await makeContextSnapshotRepo()
         defer { try? FileManager.default.removeItem(at: repo) }

--- a/AlasTests/GitServiceTests.swift
+++ b/AlasTests/GitServiceTests.swift
@@ -18,6 +18,44 @@ struct GitServiceTests {
         return dir
     }
 
+    private func makeContextSnapshotRepo(withInitialCommit: Bool = true) async throws -> URL {
+        let dir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("alas-context-snapshot-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        try await gitOK(["init", "-q", "-b", "main"], cwd: dir)
+        try await gitOK(["config", "user.email", "t@example.com"], cwd: dir)
+        try await gitOK(["config", "user.name", "Test User"], cwd: dir)
+        if withInitialCommit {
+            try await gitOK(["commit", "-q", "--allow-empty", "-m", "init"], cwd: dir)
+        }
+        return dir
+    }
+
+    @discardableResult
+    private func gitOK(_ args: [String], cwd: URL) async throws -> ProcessResult {
+        let result = try await Process.git(args, cwd: cwd)
+        guard result.exitCode == 0 else {
+            throw NSError(
+                domain: "GitServiceTests.gitOK",
+                code: Int(result.exitCode),
+                userInfo: [NSLocalizedDescriptionKey: result.stderr]
+            )
+        }
+        return result
+    }
+
+    private func writeText(_ text: String, _ path: String, in repo: URL) throws {
+        let url = repo.appendingPathComponent(path)
+        try FileManager.default.createDirectory(at: url.deletingLastPathComponent(), withIntermediateDirectories: true)
+        try text.write(to: url, atomically: true, encoding: .utf8)
+    }
+
+    private func writeData(_ data: Data, _ path: String, in repo: URL) throws {
+        let url = repo.appendingPathComponent(path)
+        try FileManager.default.createDirectory(at: url.deletingLastPathComponent(), withIntermediateDirectories: true)
+        try data.write(to: url)
+    }
+
     @Test func validateAcceptsRealRepo() async throws {
         let repo = try await makeRepo()
         defer { try? FileManager.default.removeItem(at: repo) }
@@ -88,6 +126,163 @@ struct GitServiceTests {
         #expect(branches.contains("origin/main"))
         #expect(branches.contains("origin/release/remote-only"))
         #expect(branches.firstIndex(of: "develop")! < branches.firstIndex(of: "origin/main")!)
+    }
+
+    @Test func contextSnapshotSeparatesStagedAndUnstagedRefs() async throws {
+        let repo = try await makeContextSnapshotRepo()
+        defer { try? FileManager.default.removeItem(at: repo) }
+
+        try writeText("base\n", "file.txt", in: repo)
+        try await gitOK(["add", "file.txt"], cwd: repo)
+        try await gitOK(["commit", "-q", "-m", "base"], cwd: repo)
+
+        try writeText("staged\n", "file.txt", in: repo)
+        try await gitOK(["add", "file.txt"], cwd: repo)
+        try writeText("worktree\n", "file.txt", in: repo)
+
+        let service = GitService()
+
+        let staged = try await service.contextSnapshot(worktreePath: repo, file: "file.txt", staged: true)
+        #expect(staged == DiffReviewFileContextSnapshot(
+            old: .available(["base"]),
+            new: .available(["staged"])
+        ))
+
+        let unstaged = try await service.contextSnapshot(worktreePath: repo, file: "file.txt", staged: false)
+        #expect(unstaged == DiffReviewFileContextSnapshot(
+            old: .available(["staged"]),
+            new: .available(["worktree"])
+        ))
+    }
+
+    @Test func contextSnapshotUsesEmptyOldSideForUnbornHeadStagedAdd() async throws {
+        let repo = try await makeContextSnapshotRepo(withInitialCommit: false)
+        defer { try? FileManager.default.removeItem(at: repo) }
+
+        try writeText("new\n", "new.txt", in: repo)
+        try await gitOK(["add", "new.txt"], cwd: repo)
+
+        let snapshot = try await GitService().contextSnapshot(worktreePath: repo, file: "new.txt", staged: true)
+
+        #expect(snapshot == DiffReviewFileContextSnapshot(
+            old: .available([]),
+            new: .available(["new"])
+        ))
+    }
+
+    @Test func contextSnapshotHandlesAddsAndDeletes() async throws {
+        let repo = try await makeContextSnapshotRepo()
+        defer { try? FileManager.default.removeItem(at: repo) }
+
+        try writeText("delete me\n", "deleted.txt", in: repo)
+        try await gitOK(["add", "deleted.txt"], cwd: repo)
+        try await gitOK(["commit", "-q", "-m", "seed deleted file"], cwd: repo)
+
+        try writeText("added\n", "added.txt", in: repo)
+        try await gitOK(["add", "added.txt"], cwd: repo)
+        try FileManager.default.removeItem(at: repo.appendingPathComponent("deleted.txt"))
+
+        let service = GitService()
+        let added = try await service.contextSnapshot(worktreePath: repo, file: "added.txt", staged: true)
+        #expect(added == DiffReviewFileContextSnapshot(
+            old: .unavailable,
+            new: .available(["added"])
+        ))
+
+        let deleted = try await service.contextSnapshot(worktreePath: repo, file: "deleted.txt", staged: false)
+        #expect(deleted == DiffReviewFileContextSnapshot(
+            old: .available(["delete me"]),
+            new: .unavailable
+        ))
+    }
+
+    @Test func contextSnapshotUsesOriginalPathForStagedRename() async throws {
+        let repo = try await makeContextSnapshotRepo()
+        defer { try? FileManager.default.removeItem(at: repo) }
+
+        try writeText("old\n", "old.swift", in: repo)
+        try await gitOK(["add", "old.swift"], cwd: repo)
+        try await gitOK(["commit", "-q", "-m", "seed rename"], cwd: repo)
+        try await gitOK(["mv", "old.swift", "new.swift"], cwd: repo)
+        try writeText("new\n", "new.swift", in: repo)
+        try await gitOK(["add", "new.swift"], cwd: repo)
+
+        let snapshot = try await GitService().contextSnapshot(
+            worktreePath: repo,
+            file: "new.swift",
+            staged: true,
+            originalPath: "old.swift"
+        )
+
+        #expect(snapshot == DiffReviewFileContextSnapshot(
+            old: .available(["old"]),
+            new: .available(["new"])
+        ))
+    }
+
+    @Test func contextSnapshotReturnsUnavailableForBinaryAndInvalidUTF8() async throws {
+        let repo = try await makeContextSnapshotRepo()
+        defer { try? FileManager.default.removeItem(at: repo) }
+
+        try writeText("valid\n", "invalid.txt", in: repo)
+        try await gitOK(["add", "invalid.txt"], cwd: repo)
+        try await gitOK(["commit", "-q", "-m", "seed invalid"], cwd: repo)
+        try writeData(Data([0xC3, 0x28]), "invalid.txt", in: repo)
+
+        try writeData(Data([0x00, 0x01, 0x02]), "binary.dat", in: repo)
+        try await gitOK(["add", "binary.dat"], cwd: repo)
+
+        let service = GitService()
+        let invalid = try await service.contextSnapshot(worktreePath: repo, file: "invalid.txt", staged: false)
+        #expect(invalid == DiffReviewFileContextSnapshot(
+            old: .available(["valid"]),
+            new: .unavailable
+        ))
+
+        let binary = try await service.contextSnapshot(worktreePath: repo, file: "binary.dat", staged: true)
+        #expect(binary == DiffReviewFileContextSnapshot(
+            old: .unavailable,
+            new: .unavailable
+        ))
+    }
+
+    @Test func contextSnapshotDropsOnlyFinalTrailingEmptyLine() async throws {
+        let repo = try await makeContextSnapshotRepo()
+        defer { try? FileManager.default.removeItem(at: repo) }
+
+        try writeText("one\n\nthree\n", "lines.txt", in: repo)
+        try await gitOK(["add", "lines.txt"], cwd: repo)
+
+        let snapshot = try await GitService().contextSnapshot(worktreePath: repo, file: "lines.txt", staged: true)
+
+        #expect(snapshot.new == .available(["one", "", "three"]))
+    }
+
+    @Test func contextSnapshotReadsUnstagedSymlinkAsLinkTarget() async throws {
+        let repo = try await makeContextSnapshotRepo()
+        defer { try? FileManager.default.removeItem(at: repo) }
+
+        try writeText("old target contents\n", "old-target.txt", in: repo)
+        try FileManager.default.createSymbolicLink(
+            atPath: repo.appendingPathComponent("link.txt").path,
+            withDestinationPath: "old-target.txt"
+        )
+        try await gitOK(["add", "old-target.txt", "link.txt"], cwd: repo)
+        try await gitOK(["commit", "-q", "-m", "seed symlink"], cwd: repo)
+
+        try FileManager.default.removeItem(at: repo.appendingPathComponent("link.txt"))
+        try writeText("new target contents should not be read\n", "new-target.txt", in: repo)
+        try FileManager.default.createSymbolicLink(
+            atPath: repo.appendingPathComponent("link.txt").path,
+            withDestinationPath: "new-target.txt"
+        )
+
+        let snapshot = try await GitService().contextSnapshot(worktreePath: repo, file: "link.txt", staged: false)
+
+        #expect(snapshot == DiffReviewFileContextSnapshot(
+            old: .available(["old-target.txt"]),
+            new: .available(["new-target.txt"])
+        ))
     }
 
     @Test func fileTreeIncludesIgnoredAndExcludedRootEntries() async throws {

--- a/AlasTests/Integrations/ReviewEvidenceModelTests.swift
+++ b/AlasTests/Integrations/ReviewEvidenceModelTests.swift
@@ -1250,7 +1250,8 @@ struct ReviewEvidenceModelTests {
                     parsedDiff: nil,
                     displayModel: nil,
                     placeholderMessage: "No diff.",
-                    openFile: nil
+                    openFile: nil,
+                    contextProvider: nil
                 )
             },
             summary: DiffReviewSessionModel(files: summaries, groupsEnabled: false)

--- a/AlasTests/Integrations/ReviewRequestDraftTests.swift
+++ b/AlasTests/Integrations/ReviewRequestDraftTests.swift
@@ -215,6 +215,43 @@ struct ReviewRequestDraftTests {
         #expect(DraftReviewRequestDiffSessionBuilder.synchronizedSelection(selectedPath: "Sources/Missing.swift", session: session) == section.summary.id)
     }
 
+    @Test func draftReviewRequestSessionAttachesContextProvider() async throws {
+        let path = "Sources/App.swift"
+        let originalPath = "Sources/OldApp.swift"
+        let snapshot = DiffReviewFileContextSnapshot(
+            old: .available(["old"]),
+            new: .available(["new"])
+        )
+        let context = ReviewRequestDraftContext(
+            commitSubjects: [],
+            commits: [],
+            changedFiles: [
+                CommitChangedFile(path: path, originalPath: originalPath, status: "R", add: 1, del: 1),
+            ],
+            diff: Self.modifiedSwiftDiff(path: path),
+            fileDiffsByPath: [path: Self.modifiedSwiftDiff(path: path)],
+            hasUncommittedChanges: false
+        )
+        let provider = DiffReviewContextProvider {
+            snapshot
+        }
+        var providerRequests: [(path: String, originalPath: String?)] = []
+
+        let session = try await DraftReviewRequestDiffSessionBuilder.build(
+            context: context,
+            worktreePath: URL(fileURLWithPath: "/tmp/alas-tests"),
+            openFileForPath: { _ -> (() -> Void)? in nil },
+            contextProviderForPath: { path, originalPath in
+                providerRequests.append((path: path, originalPath: originalPath))
+                return provider
+            }
+        )
+
+        #expect(try await session.files.first?.contextProvider?.snapshot() == snapshot)
+        #expect(providerRequests.map(\.path) == [path])
+        #expect(providerRequests.map(\.originalPath) == [originalPath])
+    }
+
     @Test @MainActor func draftReviewRequestDiffParsingRunsOffMainThread() async throws {
         let box = ThreadObservationBox()
 

--- a/AlasTests/ReviewChangesLoaderTests.swift
+++ b/AlasTests/ReviewChangesLoaderTests.swift
@@ -97,6 +97,45 @@ struct ReviewChangesLoaderTests {
         #expect(session.summary.totalDeletions == 3)
     }
 
+    @Test func attachesContextProviderForUnstagedAndStagedFiles() async throws {
+        let git = FakeReviewChangesGitClient(
+            status: [
+                ChangedFile(path: "a.swift", status: "M", stage: .unstaged, add: 1, del: 1, renameFrom: nil),
+                ChangedFile(path: "b.swift", status: "M", stage: .staged, add: 1, del: 1, renameFrom: nil),
+            ],
+            diffs: [
+                .init(path: "a.swift", staged: false): diff(lines: [
+                    .init(kind: .context, text: "a", oldNumber: 1, newNumber: 1),
+                ]),
+                .init(path: "b.swift", staged: true): diff(lines: [
+                    .init(kind: .context, text: "b", oldNumber: 1, newNumber: 1),
+                ]),
+            ],
+            snapshots: [
+                .init(path: "a.swift", staged: false): DiffReviewFileContextSnapshot(
+                    old: .available(["old a"]),
+                    new: .available(["new a"])
+                ),
+                .init(path: "b.swift", staged: true): DiffReviewFileContextSnapshot(
+                    old: .available(["old b"]),
+                    new: .available(["new b"])
+                ),
+            ]
+        )
+        let loader = ReviewChangesLoader(git: git)
+
+        let session = try await loader.load(worktreePath: URL(fileURLWithPath: "/tmp/repo"))
+
+        #expect(try await session.files[0].contextProvider?.snapshot() == DiffReviewFileContextSnapshot(
+            old: .available(["old a"]),
+            new: .available(["new a"])
+        ))
+        #expect(try await session.files[1].contextProvider?.snapshot() == DiffReviewFileContextSnapshot(
+            old: .available(["old b"]),
+            new: .available(["new b"])
+        ))
+    }
+
     @Test func propagatesRenameMetadataToSummary() async throws {
         let git = FakeReviewChangesGitClient(
             status: [
@@ -154,6 +193,7 @@ struct ReviewChangesLoaderTests {
 private struct FakeReviewChangesGitClient: ReviewChangesGitClient {
     var status: [ChangedFile]
     var diffs: [DiffKey: ParsedDiff]
+    var snapshots: [DiffKey: DiffReviewFileContextSnapshot] = [:]
 
     func status(worktreePath: URL) async throws -> [ChangedFile] {
         status
@@ -161,6 +201,13 @@ private struct FakeReviewChangesGitClient: ReviewChangesGitClient {
 
     func diff(worktreePath: URL, file: String, staged: Bool, originalPath: String?) async throws -> ParsedDiff {
         diffs[DiffKey(path: file, staged: staged, originalPath: originalPath), default: ParsedDiff(hunks: [])]
+    }
+
+    func contextSnapshot(worktreePath: URL, file: String, staged: Bool, originalPath: String?) async throws -> DiffReviewFileContextSnapshot {
+        snapshots[DiffKey(path: file, staged: staged, originalPath: originalPath), default: DiffReviewFileContextSnapshot(
+            old: .unavailable,
+            new: .unavailable
+        )]
     }
 }
 

--- a/AlasTests/ReviewChangesLoaderTests.swift
+++ b/AlasTests/ReviewChangesLoaderTests.swift
@@ -98,6 +98,7 @@ struct ReviewChangesLoaderTests {
     }
 
     @Test func attachesContextProviderForUnstagedAndStagedFiles() async throws {
+        let calls = ContextSnapshotCallRecorder()
         let git = FakeReviewChangesGitClient(
             status: [
                 ChangedFile(path: "a.swift", status: "M", stage: .unstaged, add: 1, del: 1, renameFrom: nil),
@@ -120,11 +121,13 @@ struct ReviewChangesLoaderTests {
                     old: .available(["old b"]),
                     new: .available(["new b"])
                 ),
-            ]
+            ],
+            contextSnapshotCalls: calls
         )
         let loader = ReviewChangesLoader(git: git)
+        let worktreePath = URL(fileURLWithPath: "/tmp/repo")
 
-        let session = try await loader.load(worktreePath: URL(fileURLWithPath: "/tmp/repo"))
+        let session = try await loader.load(worktreePath: worktreePath)
 
         #expect(try await session.files[0].contextProvider?.snapshot() == DiffReviewFileContextSnapshot(
             old: .available(["old a"]),
@@ -134,6 +137,10 @@ struct ReviewChangesLoaderTests {
             old: .available(["old b"]),
             new: .available(["new b"])
         ))
+        #expect(await calls.all() == [
+            ContextSnapshotCall(worktreePath: worktreePath, file: "a.swift", staged: false, originalPath: nil),
+            ContextSnapshotCall(worktreePath: worktreePath, file: "b.swift", staged: true, originalPath: nil),
+        ])
     }
 
     @Test func propagatesRenameMetadataToSummary() async throws {
@@ -153,6 +160,37 @@ struct ReviewChangesLoaderTests {
 
         let file = try #require(session.files.first)
         #expect(file.summary.originalPath == "old.swift")
+    }
+
+    @Test func contextProviderPropagatesOriginalPath() async throws {
+        let calls = ContextSnapshotCallRecorder()
+        let git = FakeReviewChangesGitClient(
+            status: [
+                ChangedFile(path: "new.swift", status: "R", stage: .staged, add: 1, del: 1, renameFrom: "old.swift"),
+            ],
+            diffs: [
+                .init(path: "new.swift", staged: true, originalPath: "old.swift"): diff(lines: [
+                    .init(kind: .delete, text: "let oldName = true", oldNumber: 1, newNumber: nil),
+                    .init(kind: .add, text: "let newName = true", oldNumber: nil, newNumber: 1),
+                ]),
+            ],
+            snapshots: [
+                .init(path: "new.swift", staged: true, originalPath: "old.swift"): DiffReviewFileContextSnapshot(
+                    old: .available(["old"]),
+                    new: .available(["new"])
+                ),
+            ],
+            contextSnapshotCalls: calls
+        )
+        let loader = ReviewChangesLoader(git: git)
+        let worktreePath = URL(fileURLWithPath: "/tmp/repo")
+
+        let session = try await loader.load(worktreePath: worktreePath)
+        _ = try await session.files[0].contextProvider?.snapshot()
+
+        #expect(await calls.all() == [
+            ContextSnapshotCall(worktreePath: worktreePath, file: "new.swift", staged: true, originalPath: "old.swift"),
+        ])
     }
 
     @Test func includesOriginalPathWhenLoadingStagedRenameDiff() async throws {
@@ -194,6 +232,7 @@ private struct FakeReviewChangesGitClient: ReviewChangesGitClient {
     var status: [ChangedFile]
     var diffs: [DiffKey: ParsedDiff]
     var snapshots: [DiffKey: DiffReviewFileContextSnapshot] = [:]
+    var contextSnapshotCalls = ContextSnapshotCallRecorder()
 
     func status(worktreePath: URL) async throws -> [ChangedFile] {
         status
@@ -204,11 +243,36 @@ private struct FakeReviewChangesGitClient: ReviewChangesGitClient {
     }
 
     func contextSnapshot(worktreePath: URL, file: String, staged: Bool, originalPath: String?) async throws -> DiffReviewFileContextSnapshot {
-        snapshots[DiffKey(path: file, staged: staged, originalPath: originalPath), default: DiffReviewFileContextSnapshot(
+        await contextSnapshotCalls.record(ContextSnapshotCall(
+            worktreePath: worktreePath,
+            file: file,
+            staged: staged,
+            originalPath: originalPath
+        ))
+        return snapshots[DiffKey(path: file, staged: staged, originalPath: originalPath), default: DiffReviewFileContextSnapshot(
             old: .unavailable,
             new: .unavailable
         )]
     }
+}
+
+private actor ContextSnapshotCallRecorder {
+    private var calls: [ContextSnapshotCall] = []
+
+    func record(_ call: ContextSnapshotCall) {
+        calls.append(call)
+    }
+
+    func all() -> [ContextSnapshotCall] {
+        calls
+    }
+}
+
+private struct ContextSnapshotCall: Equatable, Sendable {
+    let worktreePath: URL
+    let file: String
+    let staged: Bool
+    let originalPath: String?
 }
 
 private struct DiffKey: Hashable {

--- a/AlasTests/ReviewChangesTabViewTests.swift
+++ b/AlasTests/ReviewChangesTabViewTests.swift
@@ -559,6 +559,44 @@ struct ReviewChangesTabViewTests {
         #expect(await probe.loadCount == 1)
     }
 
+    @Test func diffReviewFileSectionIgnoresStaleContextLoadAfterResetForSameFile() async throws {
+        let staleProbe = SuspendedContextProviderProbe()
+        let freshProbe = SuspendedContextProviderProbe()
+        let controller = renderAnyFileSection(file: providerBackedFile(provider: DiffReviewContextProvider {
+            try await staleProbe.snapshot()
+        }))
+        let staleRuler = try #require(allSubviews(of: controller.view).compactMap { $0 as? DiffPaneLineNumberRulerView }.first)
+        staleRuler.invokeExpansionForTesting(row: 0, optionKey: false)
+        try await waitForLoadCount(1, probe: staleProbe)
+
+        controller.rootView = fileSectionView(file: providerBackedFile(path: "Sources/App/BetaView.swift"))
+        controller.view.layoutSubtreeIfNeeded()
+        controller.rootView = fileSectionView(file: providerBackedFile(provider: DiffReviewContextProvider {
+            try await freshProbe.snapshot()
+        }))
+        controller.view.layoutSubtreeIfNeeded()
+
+        let freshRuler = try #require(allSubviews(of: controller.view).compactMap { $0 as? DiffPaneLineNumberRulerView }.first)
+        freshRuler.invokeExpansionForTesting(row: 2, optionKey: false)
+        try await waitForLoadCount(1, probe: freshProbe)
+
+        await staleProbe.resolve(DiffReviewFileContextSnapshot(
+            old: .available((1...8).map { "stale \($0)" }),
+            new: .available((1...8).map { "stale \($0)" })
+        ))
+        try await Task.sleep(nanoseconds: 25_000_000)
+        await freshProbe.resolve(DiffReviewFileContextSnapshot(
+            old: .available((1...8).map { "fresh \($0)" }),
+            new: .available((1...8).map { "fresh \($0)" })
+        ))
+
+        let text = try await waitForRenderedText(in: controller.view, containing: "fresh 5")
+        #expect(text.contains("fresh 8"))
+        #expect(!text.contains("stale"))
+        #expect(await staleProbe.loadCount == 1)
+        #expect(await freshProbe.loadCount == 1)
+    }
+
     @Test func diffReviewFileSectionShowsContextProviderFailure() async throws {
         let controller = renderFileSection(file: providerBackedFile(provider: DiffReviewContextProvider {
             throw ContextProviderTestError.failed
@@ -594,6 +632,7 @@ struct ReviewChangesTabViewTests {
     }
 
     private func providerBackedFile(
+        path: String = "Sources/App/AlphaView.swift",
         provider: DiffReviewContextProvider = DiffReviewContextProvider {
             DiffReviewFileContextSnapshot(
                 old: .available((1...8).map { "old \($0)" }),
@@ -612,7 +651,7 @@ struct ReviewChangesTabViewTests {
         let diff = ParsedDiff(hunks: [hunk])
         return ReviewChangesFileSectionModel(
             summary: reviewSummary(
-                path: "Sources/App/AlphaView.swift",
+                path: path,
                 source: .unstaged,
                 status: .modified,
                 additions: 0,
@@ -620,7 +659,7 @@ struct ReviewChangesTabViewTests {
                 isRenderable: true
             ),
             parsedDiff: diff,
-            displayModel: DiffDisplayModelBuilder.build(diff: diff, filePath: "Sources/App/AlphaView.swift"),
+            displayModel: DiffDisplayModelBuilder.build(diff: diff, filePath: path),
             placeholderMessage: nil,
             openFile: nil,
             contextProvider: provider
@@ -628,6 +667,20 @@ struct ReviewChangesTabViewTests {
     }
 
     private func renderFileSection(file: ReviewChangesFileSectionModel) -> NSHostingController<some View> {
+        let controller = NSHostingController(rootView: fileSectionView(file: file))
+        controller.view.frame = NSRect(x: 0, y: 0, width: 760, height: 400)
+        controller.view.layoutSubtreeIfNeeded()
+        return controller
+    }
+
+    private func renderAnyFileSection(file: ReviewChangesFileSectionModel) -> NSHostingController<AnyView> {
+        let controller = NSHostingController(rootView: fileSectionView(file: file))
+        controller.view.frame = NSRect(x: 0, y: 0, width: 760, height: 400)
+        controller.view.layoutSubtreeIfNeeded()
+        return controller
+    }
+
+    private func fileSectionView(file: ReviewChangesFileSectionModel) -> AnyView {
         var layout = DiffLayoutMode.split
         var wrap = false
         var whitespace = false
@@ -641,11 +694,7 @@ struct ReviewChangesTabViewTests {
             showsSourceBadge: false
         )
         .environment(\.theme, theme())
-
-        let controller = NSHostingController(rootView: view)
-        controller.view.frame = NSRect(x: 0, y: 0, width: 760, height: 400)
-        controller.view.layoutSubtreeIfNeeded()
-        return controller
+        return AnyView(view)
     }
 
     private func renderedText(in view: NSView) -> String {

--- a/AlasTests/ReviewChangesTabViewTests.swift
+++ b/AlasTests/ReviewChangesTabViewTests.swift
@@ -508,6 +508,48 @@ struct ReviewChangesTabViewTests {
         #expect(accessibilityLabel(in: controller.view, containing: "UNSTAGED") != nil)
     }
 
+    @Test func diffReviewFileSectionShowsLazyExpandableContextControlsForProvider() throws {
+        let controller = renderFileSection(file: providerBackedFile())
+
+        let text = renderedText(in: controller.view)
+
+        #expect(text.contains("Expand context above"))
+        #expect(text.contains("Expand context below"))
+    }
+
+    @Test func diffReviewFileSectionLoadsProviderAndRevealsExpandedContextRows() async throws {
+        let probe = ContextProviderProbe(snapshot: DiffReviewFileContextSnapshot(
+            old: .available((1...8).map { "old \($0)" }),
+            new: .available((1...8).map { "new \($0)" })
+        ))
+        let controller = renderFileSection(file: providerBackedFile(provider: DiffReviewContextProvider {
+            try await probe.snapshot()
+        }))
+        let ruler = try #require(allSubviews(of: controller.view).compactMap { $0 as? DiffPaneLineNumberRulerView }.first)
+
+        ruler.invokeExpansionForTesting(row: 0, optionKey: false)
+
+        let text = try await waitForRenderedText(in: controller.view, containing: "old 1")
+        #expect(text.contains("old 2"))
+        #expect(text.contains("old 3"))
+        #expect(await probe.loadCount == 1)
+    }
+
+    @Test func diffReviewFileSectionShowsContextProviderFailure() async throws {
+        let controller = renderFileSection(file: providerBackedFile(provider: DiffReviewContextProvider {
+            throw ContextProviderTestError.failed
+        }))
+        let ruler = try #require(allSubviews(of: controller.view).compactMap { $0 as? DiffPaneLineNumberRulerView }.first)
+
+        ruler.invokeExpansionForTesting(row: 0, optionKey: false)
+
+        let label = try await waitForAccessibilityLabel(
+            in: controller.view,
+            containing: "Could not load surrounding context: provider failed"
+        )
+        #expect(label?.contains("Could not load surrounding context: provider failed") == true)
+    }
+
     private func parsedDiff() -> ParsedDiff {
         ParsedDiff(hunks: [
             ParsedDiff.Hunk(
@@ -525,6 +567,93 @@ struct ReviewChangesTabViewTests {
 
     private func displayModel() -> DiffDisplayModel {
         DiffDisplayModelBuilder.build(diff: parsedDiff(), filePath: "Sources/App/AlphaView.swift")
+    }
+
+    private func providerBackedFile(
+        provider: DiffReviewContextProvider = DiffReviewContextProvider {
+            DiffReviewFileContextSnapshot(
+                old: .available((1...8).map { "old \($0)" }),
+                new: .available((1...8).map { "new \($0)" })
+            )
+        }
+    ) -> ReviewChangesFileSectionModel {
+        let hunk = ParsedDiff.Hunk(
+            header: "@@ -4,1 +4,1 @@",
+            oldStart: 4,
+            newStart: 4,
+            lines: [
+                .init(kind: .context, text: "line 4", oldNumber: 4, newNumber: 4),
+            ]
+        )
+        let diff = ParsedDiff(hunks: [hunk])
+        return ReviewChangesFileSectionModel(
+            summary: reviewSummary(
+                path: "Sources/App/AlphaView.swift",
+                source: .unstaged,
+                status: .modified,
+                additions: 0,
+                deletions: 0,
+                isRenderable: true
+            ),
+            parsedDiff: diff,
+            displayModel: DiffDisplayModelBuilder.build(diff: diff, filePath: "Sources/App/AlphaView.swift"),
+            placeholderMessage: nil,
+            openFile: nil,
+            contextProvider: provider
+        )
+    }
+
+    private func renderFileSection(file: ReviewChangesFileSectionModel) -> NSHostingController<some View> {
+        var layout = DiffLayoutMode.split
+        var wrap = false
+        var whitespace = false
+        let view = DiffReviewFileSection(
+            file: file,
+            layoutMode: Binding(get: { layout }, set: { layout = $0 }),
+            wrapLines: Binding(get: { wrap }, set: { wrap = $0 }),
+            showWhitespace: Binding(get: { whitespace }, set: { whitespace = $0 }),
+            codeFontFamily: "",
+            codeFontSize: 13,
+            showsSourceBadge: false
+        )
+        .environment(\.theme, theme())
+
+        let controller = NSHostingController(rootView: view)
+        controller.view.frame = NSRect(x: 0, y: 0, width: 760, height: 400)
+        controller.view.layoutSubtreeIfNeeded()
+        return controller
+    }
+
+    private func renderedText(in view: NSView) -> String {
+        allSubviews(of: view)
+            .compactMap { ($0 as? NSTextView)?.string }
+            .joined(separator: "\n")
+    }
+
+    private func waitForRenderedText(in view: NSView, containing needle: String) async throws -> String {
+        var latest = renderedText(in: view)
+        for _ in 0..<20 {
+            if latest.contains(needle) {
+                return latest
+            }
+            try await Task.sleep(nanoseconds: 25_000_000)
+            view.layoutSubtreeIfNeeded()
+            latest = renderedText(in: view)
+        }
+        return latest
+    }
+
+    private func waitForAccessibilityLabel(in view: NSView, containing needle: String) async throws -> String? {
+        var latest = accessibilityLabel(in: view, containing: needle)
+        for _ in 0..<20 {
+            if latest != nil {
+                return latest
+            }
+            try await Task.sleep(nanoseconds: 25_000_000)
+            view.layoutSubtreeIfNeeded()
+            latest = accessibilityLabel(in: view, containing: needle)
+        }
+        return latest
     }
 
     private func allSubviews(of view: NSView) -> [NSView] {
@@ -591,5 +720,27 @@ struct ReviewChangesTabViewTests {
 
     private enum LauncherTestError: Error, Equatable {
         case saveFailed
+    }
+
+    private actor ContextProviderProbe {
+        private let snapshotValue: DiffReviewFileContextSnapshot
+        private(set) var loadCount = 0
+
+        init(snapshot: DiffReviewFileContextSnapshot) {
+            self.snapshotValue = snapshot
+        }
+
+        func snapshot() async throws -> DiffReviewFileContextSnapshot {
+            loadCount += 1
+            return snapshotValue
+        }
+    }
+
+    private enum ContextProviderTestError: LocalizedError {
+        case failed
+
+        var errorDescription: String? {
+            "provider failed"
+        }
     }
 }

--- a/AlasTests/ReviewChangesTabViewTests.swift
+++ b/AlasTests/ReviewChangesTabViewTests.swift
@@ -569,8 +569,6 @@ struct ReviewChangesTabViewTests {
         staleRuler.invokeExpansionForTesting(row: 0, optionKey: false)
         try await waitForLoadCount(1, probe: staleProbe)
 
-        controller.rootView = fileSectionView(file: providerBackedFile(path: "Sources/App/BetaView.swift"))
-        controller.view.layoutSubtreeIfNeeded()
         controller.rootView = fileSectionView(file: providerBackedFile(provider: DiffReviewContextProvider {
             try await freshProbe.snapshot()
         }))

--- a/AlasTests/ReviewChangesTabViewTests.swift
+++ b/AlasTests/ReviewChangesTabViewTests.swift
@@ -479,7 +479,8 @@ struct ReviewChangesTabViewTests {
             parsedDiff: parsedDiff(),
             displayModel: displayModel(),
             placeholderMessage: nil,
-            openFile: nil
+            openFile: nil,
+            contextProvider: nil
         )
         var layout = DiffLayoutMode.split
         var wrap = false

--- a/AlasTests/ReviewChangesTabViewTests.swift
+++ b/AlasTests/ReviewChangesTabViewTests.swift
@@ -535,6 +535,30 @@ struct ReviewChangesTabViewTests {
         #expect(await probe.loadCount == 1)
     }
 
+    @Test func diffReviewFileSectionQueuesExpansionClicksWhileProviderLoads() async throws {
+        let probe = SuspendedContextProviderProbe()
+        let controller = renderFileSection(file: providerBackedFile(provider: DiffReviewContextProvider {
+            try await probe.snapshot()
+        }))
+        let ruler = try #require(allSubviews(of: controller.view).compactMap { $0 as? DiffPaneLineNumberRulerView }.first)
+
+        ruler.invokeExpansionForTesting(row: 0, optionKey: false)
+        try await waitForLoadCount(1, probe: probe)
+        ruler.invokeExpansionForTesting(row: 2, optionKey: false)
+        await probe.resolve(DiffReviewFileContextSnapshot(
+            old: .available((1...8).map { "old \($0)" }),
+            new: .available((1...8).map { "new \($0)" })
+        ))
+
+        let text = try await waitForRenderedText(in: controller.view, containing: "old 5")
+        #expect(text.contains("old 1"))
+        #expect(text.contains("old 2"))
+        #expect(text.contains("old 3"))
+        #expect(text.contains("old 5"))
+        #expect(text.contains("old 8"))
+        #expect(await probe.loadCount == 1)
+    }
+
     @Test func diffReviewFileSectionShowsContextProviderFailure() async throws {
         let controller = renderFileSection(file: providerBackedFile(provider: DiffReviewContextProvider {
             throw ContextProviderTestError.failed
@@ -656,6 +680,16 @@ struct ReviewChangesTabViewTests {
         return latest
     }
 
+    private func waitForLoadCount(_ expected: Int, probe: SuspendedContextProviderProbe) async throws {
+        for _ in 0..<20 {
+            if await probe.loadCount == expected {
+                return
+            }
+            try await Task.sleep(nanoseconds: 25_000_000)
+        }
+        #expect(await probe.loadCount == expected)
+    }
+
     private func allSubviews(of view: NSView) -> [NSView] {
         view.subviews + view.subviews.flatMap { allSubviews(of: $0) }
     }
@@ -733,6 +767,23 @@ struct ReviewChangesTabViewTests {
         func snapshot() async throws -> DiffReviewFileContextSnapshot {
             loadCount += 1
             return snapshotValue
+        }
+    }
+
+    private actor SuspendedContextProviderProbe {
+        private var continuation: CheckedContinuation<DiffReviewFileContextSnapshot, Error>?
+        private(set) var loadCount = 0
+
+        func snapshot() async throws -> DiffReviewFileContextSnapshot {
+            loadCount += 1
+            return try await withCheckedThrowingContinuation { continuation in
+                self.continuation = continuation
+            }
+        }
+
+        func resolve(_ snapshot: DiffReviewFileContextSnapshot) {
+            continuation?.resume(returning: snapshot)
+            continuation = nil
         }
     }
 

--- a/AlasTests/ReviewSessionLoaderTests.swift
+++ b/AlasTests/ReviewSessionLoaderTests.swift
@@ -64,7 +64,16 @@ struct ReviewSessionLoaderTests {
                     isRenderable: true
                 )
                 return DiffReviewLoadedSession(
-                    files: [DiffReviewFileSectionModel(summary: summary, parsedDiff: nil, displayModel: nil, placeholderMessage: nil, openFile: nil)],
+                    files: [
+                        DiffReviewFileSectionModel(
+                            summary: summary,
+                            parsedDiff: nil,
+                            displayModel: nil,
+                            placeholderMessage: nil,
+                            openFile: nil,
+                            contextProvider: nil
+                        ),
+                    ],
                     summary: DiffReviewSessionModel(files: [summary], groupsEnabled: true)
                 )
             }

--- a/AlasTests/ReviewSessionTabViewTests.swift
+++ b/AlasTests/ReviewSessionTabViewTests.swift
@@ -93,7 +93,8 @@ struct ReviewSessionTabViewTests {
                         parsedDiff: nil,
                         displayModel: nil,
                         placeholderMessage: "No diff",
-                        openFile: nil
+                        openFile: nil,
+                        contextProvider: nil
                     ),
                 ],
                 summary: DiffReviewSessionModel(files: [summary], groupsEnabled: true)
@@ -249,7 +250,8 @@ struct ReviewSessionTabViewTests {
             parsedDiff: nil,
             displayModel: nil,
             placeholderMessage: "No diff",
-            openFile: nil
+            openFile: nil,
+            contextProvider: nil
         )
     }
 

--- a/docs/superpowers/plans/2026-06-15-diff-context-expansion-plan.md
+++ b/docs/superpowers/plans/2026-06-15-diff-context-expansion-plan.md
@@ -1,0 +1,1442 @@
+# Diff Context Expansion Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add lazy, gutter-first context expansion to the shared Alas diff review surface.
+
+**Architecture:** Keep parsed diffs immutable and derive expanded display rows from a file snapshot plus per-file expansion state. Context providers are optional and lazy, so repository-backed screens can expand outside hunks while imported/provider-only sessions keep existing behavior. The AppKit text/ruler renderer draws the gutter `+` and routes clicks back to SwiftUI state.
+
+**Tech Stack:** Swift 5.9, SwiftUI, AppKit `NSViewRepresentable`, Swift Testing, existing `GitService` and diff display model.
+
+---
+
+## File Structure
+
+- Create `Alas/Sources/Center/Diff/DiffContextExpansion.swift`
+  - Owns expansion keys, state, file snapshots, expansion math, and derived display groups.
+- Modify `Alas/Sources/Center/Diff/DiffDisplayModel.swift`
+  - Adds display metadata for expanded context/boundary rows.
+- Modify `Alas/Sources/Center/Diff/DiffPaneTextDocumentBuilder.swift`
+  - Renders expandable boundary rows and expanded context as neutral context.
+- Modify `Alas/Sources/Center/Diff/DiffPaneTextDocumentView.swift`
+  - Passes row metadata into scroll panes/rulers and handles gutter expansion clicks.
+- Modify `Alas/Sources/Center/Diff/DiffPaneView.swift`
+  - Threads expansion data/actions for non-review embedded diff panes.
+- Modify `Alas/Sources/Center/DiffReview/DiffReviewModels.swift`
+  - Adds optional context provider to `DiffReviewFileSectionModel`.
+- Modify `Alas/Sources/Center/DiffReview/DiffReviewFileSection.swift`
+  - Owns per-file expansion state, lazy snapshot loading, failure display, and derived display groups.
+- Create `Alas/Sources/Center/DiffReview/DiffReviewContextProvider.swift`
+  - Defines provider protocol and provider factories for local changes, commits, and draft review requests.
+- Modify `Alas/Sources/Git/GitService.swift`
+  - Adds reusable text snapshot loading helpers.
+- Modify `Alas/Sources/Center/ReviewChanges/ReviewChangesLoader.swift`
+  - Attaches providers for staged and unstaged local changes.
+- Modify `Alas/Sources/Center/Commit/CommitReviewLoader.swift`
+  - Attaches providers for commit review sessions.
+- Modify `Alas/Sources/Center/ReviewRequest/DraftReviewRequestDiffSessionBuilder.swift`
+  - Attaches providers for draft review request sessions.
+- Add/modify tests:
+  - `AlasTests/DiffContextExpansionTests.swift`
+  - `AlasTests/DiffPaneViewTests.swift`
+  - `AlasTests/ReviewChangesLoaderTests.swift`
+  - `AlasTests/CommitReviewLoaderTests.swift`
+  - `AlasTests/Integrations/ReviewRequestDraftTests.swift`
+
+## Task 1: Expansion Model And Derived Rows
+
+**Files:**
+- Create: `Alas/Sources/Center/Diff/DiffContextExpansion.swift`
+- Modify: `Alas/Sources/Center/Diff/DiffDisplayModel.swift`
+- Test: `AlasTests/DiffContextExpansionTests.swift`
+
+- [ ] **Step 1: Write failing tests for chunked and all-at-once expansion**
+
+Add this file:
+
+```swift
+import Testing
+@testable import Alas
+
+struct DiffContextExpansionTests {
+    private func group() -> DiffDisplayGroup {
+        let hunk = ParsedDiff.Hunk(
+            header: "@@ -4,3 +4,3 @@",
+            oldStart: 4,
+            newStart: 4,
+            lines: [
+                .init(kind: .context, text: "old/new 4", oldNumber: 4, newNumber: 4),
+                .init(kind: .delete, text: "old 5", oldNumber: 5, newNumber: nil),
+                .init(kind: .add, text: "new 5", oldNumber: nil, newNumber: 5),
+                .init(kind: .context, text: "old/new 6", oldNumber: 6, newNumber: 6),
+            ]
+        )
+        return DiffDisplayModelBuilder.build(diff: ParsedDiff(hunks: [hunk]), filePath: "a.swift").groups[0]
+    }
+
+    private func snapshot() -> DiffReviewFileContextSnapshot {
+        DiffReviewFileContextSnapshot(
+            old: .available((1...10).map { "old \($0)" }),
+            new: .available((1...12).map { "new \($0)" })
+        )
+    }
+
+    @Test func derivesAboveBoundaryAndChunkedRows() throws {
+        let base = group()
+        let snapshot = snapshot()
+        var state = DiffContextExpansionState()
+
+        let initial = DiffContextExpandedDisplayBuilder.derive(
+            groups: [base],
+            snapshot: snapshot,
+            providerAvailable: true,
+            expansion: state,
+            filePath: "a.swift",
+            chunkSize: 2
+        )
+        #expect(initial[0].rows.first?.contextExpansion?.boundary == .above)
+        #expect(initial[0].rows.first?.collapsedLineCount == 3)
+
+        state.expand(.init(groupID: base.id, boundary: .above), available: 3, mode: .chunk(size: 2))
+        let expanded = DiffContextExpandedDisplayBuilder.derive(
+            groups: [base],
+            snapshot: snapshot,
+            providerAvailable: true,
+            expansion: state,
+            filePath: "a.swift",
+            chunkSize: 2
+        )
+        #expect(expanded[0].rows.prefix(3).map(\.kind) == [.expandedContext, .expandedContext, .expandableContext])
+        #expect(expanded[0].rows[0].old?.lineNumber == 2)
+        #expect(expanded[0].rows[1].old?.lineNumber == 3)
+        #expect(expanded[0].rows[0].new?.lineNumber == 2)
+        #expect(expanded[0].rows[1].new?.lineNumber == 3)
+    }
+
+    @Test func optionExpansionRevealsAllBelowBoundary() {
+        let base = group()
+        var state = DiffContextExpansionState()
+        state.expand(.init(groupID: base.id, boundary: .below), available: 6, mode: .all)
+
+        let expanded = DiffContextExpandedDisplayBuilder.derive(
+            groups: [base],
+            snapshot: snapshot(),
+            providerAvailable: true,
+            expansion: state,
+            filePath: "a.swift",
+            chunkSize: 2
+        )
+        let trailing = expanded[0].rows.suffix(6)
+        #expect(trailing.allSatisfy { $0.kind == .expandedContext })
+        #expect(trailing.first?.old?.lineNumber == 7)
+        #expect(trailing.last?.new?.lineNumber == 12)
+        #expect(expanded[0].rows.contains { $0.contextExpansion?.boundary == .below } == false)
+    }
+
+    @Test func expansionStopsAtAdjacentHunkBoundaries() {
+        let first = group()
+        let secondHunk = ParsedDiff.Hunk(header: "@@ -8,1 +8,1 @@", oldStart: 8, newStart: 8, lines: [
+            .init(kind: .context, text: "line 8", oldNumber: 8, newNumber: 8),
+        ])
+        let second = DiffDisplayModelBuilder.build(diff: ParsedDiff(hunks: [secondHunk]), filePath: "a.swift").groups[0]
+        var state = DiffContextExpansionState()
+        state.expand(.init(groupID: first.id, boundary: .below), available: 10, mode: .all)
+
+        let expanded = DiffContextExpandedDisplayBuilder.derive(
+            groups: [first, second],
+            snapshot: snapshot(),
+            providerAvailable: true,
+            expansion: state,
+            filePath: "a.swift",
+            chunkSize: 2
+        )
+
+        let firstTrailingContext = expanded[0].rows.filter { $0.kind == .expandedContext }
+        #expect(firstTrailingContext.map { $0.old?.lineNumber } == [7])
+        #expect(firstTrailingContext.map { $0.new?.lineNumber } == [7])
+    }
+
+    @Test func originalDiffAnchorsStayStableAfterExpansion() throws {
+        let base = group()
+        var state = DiffContextExpansionState()
+        state.expand(.init(groupID: base.id, boundary: .above), available: 3, mode: .all)
+
+        let expanded = DiffContextExpandedDisplayBuilder.derive(
+            groups: [base],
+            snapshot: snapshot(),
+            providerAvailable: true,
+            expansion: state,
+            filePath: "a.swift",
+            chunkSize: 2
+        )
+        let replacement = try #require(expanded[0].rows.first { $0.kind == .replacement })
+        #expect(replacement.old?.anchor == base.rows.first { $0.kind == .replacement }?.old?.anchor)
+        #expect(replacement.new?.anchor == base.rows.first { $0.kind == .replacement }?.new?.anchor)
+    }
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run:
+
+```bash
+xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' test -only-testing:AlasTests/DiffContextExpansionTests
+```
+
+Expected: fail to compile because `DiffReviewFileContextSnapshot`, `DiffContextExpansionState`, and `.expandedContext` do not exist.
+
+- [ ] **Step 3: Add row metadata and expansion types**
+
+In `DiffDisplayModel.swift`, extend `DiffDisplayRow.Kind` and add metadata:
+
+```swift
+struct DiffContextExpansionKey: Codable, Equatable, Hashable, Sendable {
+    let groupID: String
+    let boundary: DiffContextBoundary
+}
+
+enum DiffContextBoundary: String, Codable, Equatable, Hashable, Sendable {
+    case above
+    case below
+}
+
+struct DiffContextExpansionRow: Codable, Equatable, Hashable, Sendable {
+    let key: DiffContextExpansionKey
+    let boundary: DiffContextBoundary
+    let remainingLineCount: Int
+}
+
+struct DiffDisplayRow: Identifiable, Equatable {
+    enum Kind: Equatable {
+        case context
+        case add
+        case delete
+        case replacement
+        case collapsed
+        case expandedContext
+        case expandableContext
+    }
+
+    let id: String
+    let kind: Kind
+    let old: DiffDisplayLine?
+    let new: DiffDisplayLine?
+    let collapsedLineCount: Int
+    let collapsedRows: [DiffDisplayRow]
+    var contextExpansion: DiffContextExpansionRow?
+
+    init(
+        id: String,
+        kind: Kind,
+        old: DiffDisplayLine?,
+        new: DiffDisplayLine?,
+        collapsedLineCount: Int,
+        collapsedRows: [DiffDisplayRow] = [],
+        contextExpansion: DiffContextExpansionRow? = nil
+    ) {
+        self.id = id
+        self.kind = kind
+        self.old = old
+        self.new = new
+        self.collapsedLineCount = collapsedLineCount
+        self.collapsedRows = collapsedRows
+        self.contextExpansion = contextExpansion
+    }
+}
+```
+
+- [ ] **Step 4: Add the expansion model**
+
+Create `DiffContextExpansion.swift`:
+
+```swift
+import Foundation
+
+struct DiffReviewFileContextSnapshot: Equatable, Sendable {
+    enum Side: Equatable, Sendable {
+        case unavailable
+        case available([String])
+
+        var lineCount: Int {
+            if case .available(let lines) = self { return lines.count }
+            return 0
+        }
+
+        func line(number: Int) -> String? {
+            guard case .available(let lines) = self,
+                  number >= 1,
+                  number <= lines.count
+            else { return nil }
+            return lines[number - 1]
+        }
+    }
+
+    let old: Side
+    let new: Side
+}
+
+enum DiffContextExpansionMode: Equatable {
+    case chunk(size: Int)
+    case all
+}
+
+struct DiffContextExpansionState: Equatable {
+    private var revealed: [DiffContextExpansionKey: Int] = [:]
+
+    func revealedCount(for key: DiffContextExpansionKey) -> Int {
+        revealed[key, default: 0]
+    }
+
+    mutating func expand(_ key: DiffContextExpansionKey, available: Int, mode: DiffContextExpansionMode) {
+        let current = revealedCount(for: key)
+        let next: Int
+        switch mode {
+        case .chunk(let size):
+            next = min(available, current + max(size, 1))
+        case .all:
+            next = available
+        }
+        revealed[key] = next
+    }
+}
+
+enum DiffContextExpandedDisplayBuilder {
+    static func derive(
+        groups: [DiffDisplayGroup],
+        snapshot: DiffReviewFileContextSnapshot?,
+        providerAvailable: Bool,
+        expansion: DiffContextExpansionState,
+        filePath: String,
+        chunkSize: Int
+    ) -> [DiffDisplayGroup] {
+        guard snapshot != nil || providerAvailable else { return groups }
+        return groups.indices.map { index in
+            let group = groups[index]
+            DiffDisplayGroup(
+                id: group.id,
+                header: group.header,
+                sourceHunk: group.sourceHunk,
+                rows: rows(
+                    for: group,
+                    previous: index > 0 ? groups[index - 1] : nil,
+                    next: index < groups.count - 1 ? groups[index + 1] : nil,
+                    snapshot: snapshot,
+                    providerAvailable: providerAvailable,
+                    expansion: expansion,
+                    filePath: filePath,
+                    chunkSize: chunkSize
+                )
+            )
+        }
+    }
+
+    private static func rows(
+        for group: DiffDisplayGroup,
+        previous: DiffDisplayGroup?,
+        next: DiffDisplayGroup?,
+        snapshot: DiffReviewFileContextSnapshot?,
+        providerAvailable: Bool,
+        expansion: DiffContextExpansionState,
+        filePath: String,
+        chunkSize: Int
+    ) -> [DiffDisplayRow] {
+        boundaryRows(.above, group: group, previous: previous, next: next, snapshot: snapshot, providerAvailable: providerAvailable, expansion: expansion, filePath: filePath, chunkSize: chunkSize)
+            + group.rows
+            + boundaryRows(.below, group: group, previous: previous, next: next, snapshot: snapshot, providerAvailable: providerAvailable, expansion: expansion, filePath: filePath, chunkSize: chunkSize)
+    }
+
+    private static func boundaryRows(
+        _ boundary: DiffContextBoundary,
+        group: DiffDisplayGroup,
+        previous: DiffDisplayGroup?,
+        next: DiffDisplayGroup?,
+        snapshot: DiffReviewFileContextSnapshot?,
+        providerAvailable: Bool,
+        expansion: DiffContextExpansionState,
+        filePath: String,
+        chunkSize: Int
+    ) -> [DiffDisplayRow] {
+        let key = DiffContextExpansionKey(groupID: group.id, boundary: boundary)
+        let available = snapshot.map { availableCount(boundary, group: group, previous: previous, next: next, snapshot: $0) } ?? optimisticAvailableCount(boundary, group: group, previous: previous, next: next, providerAvailable: providerAvailable)
+        guard available > 0 else { return [] }
+        let revealed = min(expansion.revealedCount(for: key), available)
+        var rows = expandedRows(
+            boundary,
+            group: group,
+            previous: previous,
+            next: next,
+            snapshot: snapshot,
+            filePath: filePath,
+            revealed: revealed
+        )
+        let remaining = available - revealed
+        if remaining > 0 {
+            rows.append(DiffDisplayRow(
+                id: "\(group.id)-context-\(boundary.rawValue)-control",
+                kind: .expandableContext,
+                old: nil,
+                new: nil,
+                collapsedLineCount: remaining,
+                contextExpansion: DiffContextExpansionRow(key: key, boundary: boundary, remainingLineCount: remaining)
+            ))
+        }
+        return rows
+    }
+
+    static func availableLineCount(
+        key: DiffContextExpansionKey,
+        groups: [DiffDisplayGroup],
+        snapshot: DiffReviewFileContextSnapshot?
+    ) -> Int {
+        guard let group = groups.first(where: { $0.id == key.groupID }), let snapshot else { return 0 }
+        let index = groups.firstIndex(where: { $0.id == key.groupID })!
+        return availableCount(
+            key.boundary,
+            group: group,
+            previous: index > 0 ? groups[index - 1] : nil,
+            next: index < groups.count - 1 ? groups[index + 1] : nil,
+            snapshot: snapshot
+        )
+    }
+
+    private static func optimisticAvailableCount(
+        _ boundary: DiffContextBoundary,
+        group: DiffDisplayGroup,
+        previous: DiffDisplayGroup?,
+        next: DiffDisplayGroup?,
+        providerAvailable: Bool
+    ) -> Int {
+        guard providerAvailable else { return 0 }
+        switch boundary {
+        case .above:
+            let oldStart = group.sourceHunk.lines.compactMap(\.oldNumber).min() ?? 1
+            let newStart = group.sourceHunk.lines.compactMap(\.newNumber).min() ?? 1
+            let previousOldEnd = previous?.sourceHunk.lines.compactMap(\.oldNumber).max() ?? 0
+            let previousNewEnd = previous?.sourceHunk.lines.compactMap(\.newNumber).max() ?? 0
+            return max(oldStart - previousOldEnd - 1, newStart - previousNewEnd - 1)
+        case .below:
+            if let next {
+                let oldEnd = group.sourceHunk.lines.compactMap(\.oldNumber).max() ?? 0
+                let newEnd = group.sourceHunk.lines.compactMap(\.newNumber).max() ?? 0
+                let nextOldStart = next.sourceHunk.lines.compactMap(\.oldNumber).min() ?? oldEnd + 1
+                let nextNewStart = next.sourceHunk.lines.compactMap(\.newNumber).min() ?? newEnd + 1
+                return max(nextOldStart - oldEnd - 1, nextNewStart - newEnd - 1)
+            }
+            return 1
+        }
+    }
+
+    private static func availableCount(
+        _ boundary: DiffContextBoundary,
+        group: DiffDisplayGroup,
+        previous: DiffDisplayGroup?,
+        next: DiffDisplayGroup?,
+        snapshot: DiffReviewFileContextSnapshot
+    ) -> Int {
+        let oldNumbers = group.sourceHunk.lines.compactMap(\.oldNumber)
+        let newNumbers = group.sourceHunk.lines.compactMap(\.newNumber)
+        switch boundary {
+        case .above:
+            let previousOldEnd = previous?.sourceHunk.lines.compactMap(\.oldNumber).max() ?? 0
+            let previousNewEnd = previous?.sourceHunk.lines.compactMap(\.newNumber).max() ?? 0
+            return max((oldNumbers.min() ?? 1) - previousOldEnd - 1, (newNumbers.min() ?? 1) - previousNewEnd - 1)
+        case .below:
+            let oldEnd = oldNumbers.max() ?? 0
+            let newEnd = newNumbers.max() ?? 0
+            let oldLimit = next?.sourceHunk.lines.compactMap(\.oldNumber).min().map { $0 - 1 } ?? snapshot.old.lineCount
+            let newLimit = next?.sourceHunk.lines.compactMap(\.newNumber).min().map { $0 - 1 } ?? snapshot.new.lineCount
+            return max(oldLimit - oldEnd, newLimit - newEnd)
+        }
+    }
+
+    private static func expandedRows(
+        _ boundary: DiffContextBoundary,
+        group: DiffDisplayGroup,
+        previous: DiffDisplayGroup?,
+        next: DiffDisplayGroup?,
+        snapshot: DiffReviewFileContextSnapshot?,
+        filePath: String,
+        revealed: Int
+    ) -> [DiffDisplayRow] {
+        guard revealed > 0, let snapshot else { return [] }
+        let oldNumbers = group.sourceHunk.lines.compactMap(\.oldNumber)
+        let newNumbers = group.sourceHunk.lines.compactMap(\.newNumber)
+        let oldStart: Int
+        let newStart: Int
+        switch boundary {
+        case .above:
+            oldStart = max(1, (oldNumbers.min() ?? 1) - revealed)
+            newStart = max(1, (newNumbers.min() ?? 1) - revealed)
+        case .below:
+            oldStart = (oldNumbers.max() ?? 0) + 1
+            newStart = (newNumbers.max() ?? 0) + 1
+        }
+
+        return (0..<revealed).map { offset in
+            let oldNumber = oldStart + offset
+            let newNumber = newStart + offset
+            let oldText = snapshot.old.line(number: oldNumber)
+            let newText = snapshot.new.line(number: newNumber)
+            return DiffDisplayRow(
+                id: "\(group.id)-context-\(boundary.rawValue)-\(offset)",
+                kind: .expandedContext,
+                old: oldText.map { displayLine($0, filePath: filePath, group: group, rowIndex: -10_000 - offset, side: .old, lineNumber: oldNumber, pairedNewLine: newText == nil ? nil : newNumber) },
+                new: newText.map { displayLine($0, filePath: filePath, group: group, rowIndex: -10_000 - offset, side: .new, lineNumber: newNumber, pairedOldLine: oldText == nil ? nil : oldNumber) },
+                collapsedLineCount: 0
+            )
+        }
+    }
+
+    private static func displayLine(
+        _ text: String,
+        filePath: String,
+        group: DiffDisplayGroup,
+        rowIndex: Int,
+        side: DiffLineSide,
+        lineNumber: Int,
+        pairedOldLine: Int? = nil,
+        pairedNewLine: Int? = nil
+    ) -> DiffDisplayLine {
+        let anchor = DiffLineAnchor(
+            filePath: filePath,
+            hunkIndex: group.sourceHunk.oldStart,
+            rowIndex: rowIndex,
+            side: side,
+            oldLine: side == .old ? lineNumber : pairedOldLine,
+            newLine: side == .new ? lineNumber : pairedNewLine
+        )
+        return DiffDisplayLine(
+            id: "\(filePath):expanded:\(side.rawValue):\(lineNumber):\(rowIndex)",
+            anchor: anchor,
+            text: text,
+            lineNumber: lineNumber,
+            kind: .context,
+            inlineSpans: [],
+            noTrailingNewline: false
+        )
+    }
+}
+```
+
+- [ ] **Step 5: Update row projection for new row kinds**
+
+In `DiffPaneView.swift`, update changed-row checks:
+
+```swift
+private static func isChanged(_ row: DiffDisplayRow) -> Bool {
+    row.kind == .replacement || row.kind == .delete || row.kind == .add
+}
+
+static func stackedLines(for row: DiffDisplayRow) -> [DiffDisplayLine] {
+    if row.kind == .context || row.kind == .expandedContext {
+        if let new = row.new { return [new] }
+        if let old = row.old { return [old] }
+        return []
+    }
+    return [row.old, row.new].compactMap { $0 }
+}
+```
+
+- [ ] **Step 6: Run model tests**
+
+Run:
+
+```bash
+xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' test -only-testing:AlasTests/DiffContextExpansionTests
+```
+
+Expected: pass.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add Alas/Sources/Center/Diff/DiffContextExpansion.swift Alas/Sources/Center/Diff/DiffDisplayModel.swift Alas/Sources/Center/Diff/DiffPaneView.swift AlasTests/DiffContextExpansionTests.swift
+git commit -m "Add diff context expansion model"
+```
+
+## Task 2: Provider Protocol And Git Snapshot Loading
+
+**Files:**
+- Create: `Alas/Sources/Center/DiffReview/DiffReviewContextProvider.swift`
+- Modify: `Alas/Sources/Git/GitService.swift`
+- Test: `AlasTests/ReviewChangesLoaderTests.swift`
+
+- [ ] **Step 1: Add failing provider tests**
+
+In `ReviewChangesLoaderTests.swift`, extend `FakeReviewChangesGitClient` and add:
+
+```swift
+@Test func attachesContextProviderForUnstagedAndStagedFiles() async throws {
+    let git = FakeReviewChangesGitClient(
+        status: [
+            ChangedFile(path: "a.swift", status: "M", stage: .unstaged, add: 1, del: 1, renameFrom: nil),
+            ChangedFile(path: "b.swift", status: "M", stage: .staged, add: 1, del: 1, renameFrom: nil),
+        ],
+        diffs: [
+            .init(path: "a.swift", staged: false): diff(lines: [.init(kind: .context, text: "a", oldNumber: 1, newNumber: 1)]),
+            .init(path: "b.swift", staged: true): diff(lines: [.init(kind: .context, text: "b", oldNumber: 1, newNumber: 1)]),
+        ],
+        snapshots: [
+            .init(path: "a.swift", staged: false): DiffReviewFileContextSnapshot(old: .available(["old a"]), new: .available(["new a"])),
+            .init(path: "b.swift", staged: true): DiffReviewFileContextSnapshot(old: .available(["old b"]), new: .available(["new b"])),
+        ]
+    )
+    let loader = ReviewChangesLoader(git: git)
+
+    let session = try await loader.load(worktreePath: URL(fileURLWithPath: "/tmp/repo"))
+
+    #expect(try await session.files[0].contextProvider?.snapshot() == DiffReviewFileContextSnapshot(old: .available(["old a"]), new: .available(["new a"])))
+    #expect(try await session.files[1].contextProvider?.snapshot() == DiffReviewFileContextSnapshot(old: .available(["old b"]), new: .available(["new b"])))
+}
+```
+
+Update the fake:
+
+```swift
+private struct FakeReviewChangesGitClient: ReviewChangesGitClient {
+    var status: [ChangedFile]
+    var diffs: [DiffKey: ParsedDiff]
+    var snapshots: [DiffKey: DiffReviewFileContextSnapshot] = [:]
+
+    func status(worktreePath: URL) async throws -> [ChangedFile] { status }
+
+    func diff(worktreePath: URL, file: String, staged: Bool, originalPath: String?) async throws -> ParsedDiff {
+        diffs[DiffKey(path: file, staged: staged, originalPath: originalPath), default: ParsedDiff(hunks: [])]
+    }
+
+    func contextSnapshot(worktreePath: URL, file: String, staged: Bool, originalPath: String?) async throws -> DiffReviewFileContextSnapshot {
+        snapshots[DiffKey(path: file, staged: staged, originalPath: originalPath), default: DiffReviewFileContextSnapshot(old: .unavailable, new: .unavailable)]
+    }
+}
+```
+
+- [ ] **Step 2: Run test to verify failure**
+
+Run:
+
+```bash
+xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' test -only-testing:AlasTests/ReviewChangesLoaderTests/attachesContextProviderForUnstagedAndStagedFiles
+```
+
+Expected: fail to compile because `contextProvider`, `DiffReviewContextProvider`, and `contextSnapshot` do not exist.
+
+- [ ] **Step 3: Add provider protocol and model property**
+
+Create `DiffReviewContextProvider.swift`:
+
+```swift
+import Foundation
+
+struct DiffReviewContextProvider {
+    let snapshot: @Sendable () async throws -> DiffReviewFileContextSnapshot
+}
+```
+
+In `DiffReviewModels.swift`, add to `DiffReviewFileSectionModel`:
+
+```swift
+let contextProvider: DiffReviewContextProvider?
+```
+
+Update every `DiffReviewFileSectionModel(...)` construction to pass `contextProvider: nil` until the next step wires real providers.
+
+- [ ] **Step 4: Extend review changes git client**
+
+In `ReviewChangesLoader.swift`, update the protocol:
+
+```swift
+protocol ReviewChangesGitClient {
+    func status(worktreePath: URL) async throws -> [ChangedFile]
+    func diff(worktreePath: URL, file: String, staged: Bool, originalPath: String?) async throws -> ParsedDiff
+    func contextSnapshot(worktreePath: URL, file: String, staged: Bool, originalPath: String?) async throws -> DiffReviewFileContextSnapshot
+}
+```
+
+Attach the provider in `fileSection` by accepting `worktreePath` and passing:
+
+```swift
+contextProvider: DiffReviewContextProvider {
+    try await git.contextSnapshot(
+        worktreePath: worktreePath,
+        file: change.path,
+        staged: change.stage == .staged,
+        originalPath: change.renameFrom
+    )
+}
+```
+
+- [ ] **Step 5: Implement GitService snapshot helpers**
+
+In `GitService.swift`, add:
+
+```swift
+func contextSnapshot(worktreePath: URL, file: String, staged: Bool, originalPath: String?) async throws -> DiffReviewFileContextSnapshot {
+    if staged {
+        let head = try await hasHead(worktreePath: worktreePath)
+        let oldPath = originalPath ?? file
+        let old = head ? try await blobLinesOrUnavailable(worktreePath: worktreePath, ref: "HEAD", path: oldPath) : .available([])
+        let new = try await blobLinesOrUnavailable(worktreePath: worktreePath, ref: ":", path: file)
+        return DiffReviewFileContextSnapshot(old: old, new: new)
+    }
+
+    let oldPath = originalPath ?? file
+    let old = try await blobLinesOrUnavailable(worktreePath: worktreePath, ref: ":", path: oldPath)
+    let new = try await worktreeLinesOrUnavailable(worktreePath: worktreePath, path: file)
+    return DiffReviewFileContextSnapshot(old: old, new: new)
+}
+
+func commitContextSnapshot(worktreePath: URL, sha: String, file: String, originalPath: String?) async throws -> DiffReviewFileContextSnapshot {
+    let parent = try await firstParentOrEmptyTree(worktreePath: worktreePath, sha: sha)
+    let old = try await blobLinesOrUnavailable(worktreePath: worktreePath, ref: parent, path: originalPath ?? file)
+    let new = try await blobLinesOrUnavailable(worktreePath: worktreePath, ref: sha, path: file)
+    return DiffReviewFileContextSnapshot(old: old, new: new)
+}
+
+func refContextSnapshot(worktreePath: URL, baseRef: String, headRef: String, file: String, originalPath: String?) async throws -> DiffReviewFileContextSnapshot {
+    let old = try await blobLinesOrUnavailable(worktreePath: worktreePath, ref: baseRef, path: originalPath ?? file)
+    let new = try await blobLinesOrUnavailable(worktreePath: worktreePath, ref: headRef, path: file)
+    return DiffReviewFileContextSnapshot(old: old, new: new)
+}
+
+private func firstParentOrEmptyTree(worktreePath: URL, sha: String) async throws -> String {
+    let result = try await Process.git(["rev-list", "--parents", "-n", "1", sha], cwd: worktreePath)
+    guard result.exitCode == 0 else { return "4b825dc642cb6eb9a060e54bf8d69288fbee4904" }
+    let parts = result.stdout.trimmingCharacters(in: .whitespacesAndNewlines).split(separator: " ")
+    return parts.count > 1 ? String(parts[1]) : "4b825dc642cb6eb9a060e54bf8d69288fbee4904"
+}
+
+private func blobLinesOrUnavailable(worktreePath: URL, ref: String, path: String) async throws -> DiffReviewFileContextSnapshot.Side {
+    let spec = ref == ":" ? ":\(path)" : "\(ref):\(path)"
+    let result = try await Process.gitData(["show", spec], cwd: worktreePath)
+    guard result.exitCode == 0, !Self.looksBinary(result.stdout) else { return .unavailable }
+    guard let text = String(data: result.stdout, encoding: .utf8) else { return .unavailable }
+    return .available(Self.splitContextLines(text))
+}
+
+private func worktreeLinesOrUnavailable(worktreePath: URL, path: String) async throws -> DiffReviewFileContextSnapshot.Side {
+    let url = worktreePath.appendingPathComponent(path)
+    let data = try Data(contentsOf: url)
+    guard !Self.looksBinary(data), let text = String(data: data, encoding: .utf8) else { return .unavailable }
+    return .available(Self.splitContextLines(text))
+}
+
+private static func splitContextLines(_ text: String) -> [String] {
+    var lines = text.split(separator: "\n", omittingEmptySubsequences: false).map(String.init)
+    if lines.last == "" { lines.removeLast() }
+    return lines
+}
+```
+
+- [ ] **Step 6: Run provider tests**
+
+Run:
+
+```bash
+xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' test -only-testing:AlasTests/ReviewChangesLoaderTests
+```
+
+Expected: pass.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add Alas/Sources/Center/DiffReview/DiffReviewContextProvider.swift Alas/Sources/Center/DiffReview/DiffReviewModels.swift Alas/Sources/Center/ReviewChanges/ReviewChangesLoader.swift Alas/Sources/Git/GitService.swift AlasTests/ReviewChangesLoaderTests.swift
+git commit -m "Load diff context snapshots lazily"
+```
+
+## Task 3: Commit And Draft Review Request Providers
+
+**Files:**
+- Modify: `Alas/Sources/Center/Commit/CommitReviewLoader.swift`
+- Modify: `Alas/Sources/Center/ReviewRequest/DraftReviewRequestDiffSessionBuilder.swift`
+- Test: `AlasTests/CommitReviewLoaderTests.swift`
+- Test: `AlasTests/Integrations/ReviewRequestDraftTests.swift`
+
+- [ ] **Step 1: Write failing commit provider test**
+
+In `CommitReviewLoaderTests.swift`, add:
+
+```swift
+@Test func attachesContextProviderForCommitFiles() async throws {
+    let diff = ParsedDiff(hunks: [
+        ParsedDiff.Hunk(header: "@@ -1,1 +1,1 @@", oldStart: 1, newStart: 1, lines: [
+            .init(kind: .delete, text: "old", oldNumber: 1, newNumber: nil),
+            .init(kind: .add, text: "new", oldNumber: nil, newNumber: 1),
+        ]),
+    ])
+    let snapshot = DiffReviewFileContextSnapshot(old: .available(["old"]), new: .available(["new"]))
+    let git = FakeCommitReviewGitClient(diffs: ["a.swift": diff], snapshots: ["abc123:a.swift": snapshot])
+    let loader = CommitReviewLoader(git: git)
+
+    let session = try await loader.load(
+        worktreePath: URL(fileURLWithPath: "/tmp/repo"),
+        sha: "abc123",
+        files: [CommitChangedFile(path: "a.swift", status: "M", add: 1, del: 1, originalPath: nil)],
+        openFileForPath: { _ in nil }
+    )
+
+    #expect(try await session.files.first?.contextProvider?.snapshot() == snapshot)
+}
+```
+
+Update the fake to implement:
+
+```swift
+func commitContextSnapshot(worktreePath: URL, sha: String, file: String, originalPath: String?) async throws -> DiffReviewFileContextSnapshot {
+    snapshots["\(sha):\(file)", default: DiffReviewFileContextSnapshot(old: .unavailable, new: .unavailable)]
+}
+```
+
+- [ ] **Step 2: Write failing draft review request provider test**
+
+In `ReviewRequestDraftTests.swift`, add:
+
+```swift
+@Test func draftReviewRequestSessionAttachesContextProvider() async throws {
+    let context = ReviewRequestDraftContext(
+        provider: .github,
+        repositorySlug: "owner/repo",
+        baseBranch: "main",
+        headBranch: "feature",
+        headSHA: "abc123",
+        title: "Title",
+        body: "",
+        changedFiles: [
+            CommitChangedFile(path: "Sources/App.swift", status: "M", add: 1, del: 1, originalPath: nil),
+        ],
+        fileDiffsByPath: [
+            "Sources/App.swift": "@@ -1,1 +1,1 @@\n-old\n+new\n",
+        ],
+        commits: []
+    )
+    let provider = DiffReviewContextProvider {
+        DiffReviewFileContextSnapshot(old: .available(["old"]), new: .available(["new"]))
+    }
+
+    let session = try await DraftReviewRequestDiffSessionBuilder.build(
+        context: context,
+        worktreePath: URL(fileURLWithPath: "/tmp/repo"),
+        openFileForPath: { _ in nil },
+        contextProviderForPath: { path, _ in path == "Sources/App.swift" ? provider : nil }
+    )
+
+    #expect(try await session.files.first?.contextProvider?.snapshot() == DiffReviewFileContextSnapshot(old: .available(["old"]), new: .available(["new"])))
+}
+```
+
+- [ ] **Step 3: Run tests to verify failure**
+
+Run:
+
+```bash
+xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' test -only-testing:AlasTests/CommitReviewLoaderTests/attachesContextProviderForCommitFiles -only-testing:AlasTests/Integrations/ReviewRequestDraftTests/draftReviewRequestSessionAttachesContextProvider
+```
+
+Expected: fail to compile because loader protocols/builders do not expose provider hooks.
+
+- [ ] **Step 4: Extend commit review protocol and loader**
+
+In `CommitReviewLoader.swift`, update:
+
+```swift
+protocol CommitReviewGitClient {
+    func diff(worktreePath: URL, sha: String, file: String, originalPath: String?) async throws -> ParsedDiff
+    func commitContextSnapshot(worktreePath: URL, sha: String, file: String, originalPath: String?) async throws -> DiffReviewFileContextSnapshot
+}
+```
+
+Pass this in `DiffReviewFileSectionModel`:
+
+```swift
+contextProvider: DiffReviewContextProvider {
+    try await git.commitContextSnapshot(
+        worktreePath: worktreePath,
+        sha: sha,
+        file: file.path,
+        originalPath: file.originalPath
+    )
+}
+```
+
+Thread `worktreePath` and `sha` into `fileSection`.
+
+- [ ] **Step 5: Extend draft review request builder**
+
+Change the builder signature:
+
+```swift
+static func build(
+    context: ReviewRequestDraftContext,
+    worktreePath: URL,
+    openFileForPath: @escaping (String) -> (() -> Void)?,
+    contextProviderForPath: @escaping (String, String?) -> DiffReviewContextProvider? = { _, _ in nil }
+) async throws -> DiffReviewLoadedSession
+```
+
+Pass into `fileSection`:
+
+```swift
+contextProvider: contextProviderForPath(file.path, file.originalPath)
+```
+
+In `DraftReviewRequestTabView.swift` and `ReviewSessionLoader.swift`, create the provider:
+
+```swift
+contextProviderForPath: { path, originalPath in
+    DiffReviewContextProvider {
+        try await GitService().refContextSnapshot(
+            worktreePath: worktreePath,
+            baseRef: tabState.baseBranch,
+            headRef: tabState.headSHA.isEmpty ? "HEAD" : tabState.headSHA,
+            file: path,
+            originalPath: originalPath
+        )
+    }
+}
+```
+
+Use `base` and `headSHA ?? "HEAD"` in `ReviewSessionLoader.production` where `tabState` is not in scope.
+
+- [ ] **Step 6: Run targeted tests**
+
+Run:
+
+```bash
+xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' test -only-testing:AlasTests/CommitReviewLoaderTests -only-testing:AlasTests/Integrations/ReviewRequestDraftTests
+```
+
+Expected: pass.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add Alas/Sources/Center/Commit/CommitReviewLoader.swift Alas/Sources/Center/ReviewRequest/DraftReviewRequestDiffSessionBuilder.swift Alas/Sources/Center/ReviewRequest/DraftReviewRequestTabView.swift Alas/Sources/Center/ReviewWorkspace/ReviewSessionLoader.swift AlasTests/CommitReviewLoaderTests.swift AlasTests/Integrations/ReviewRequestDraftTests.swift
+git commit -m "Attach context providers to review sessions"
+```
+
+## Task 4: Render Expansion Boundary Rows In Text Documents
+
+**Files:**
+- Modify: `Alas/Sources/Center/Diff/DiffPaneTextDocumentBuilder.swift`
+- Modify: `Alas/Sources/Center/Diff/DiffPaneTextDocumentView.swift`
+- Test: `AlasTests/DiffPaneViewTests.swift`
+
+- [ ] **Step 1: Add failing document builder expectations**
+
+In `DiffPaneViewTests.swift`, add:
+
+```swift
+@Test @MainActor func expandableContextRowsRenderAsGutterPlusRows() throws {
+    let group = DiffDisplayGroup(
+        id: "hunk-0",
+        header: "@@ -2,1 +2,1 @@",
+        sourceHunk: ParsedDiff.Hunk(header: "@@ -2,1 +2,1 @@", oldStart: 2, newStart: 2, lines: []),
+        rows: [
+            DiffDisplayRow(
+                id: "expand",
+                kind: .expandableContext,
+                old: nil,
+                new: nil,
+                collapsedLineCount: 9,
+                contextExpansion: DiffContextExpansionRow(
+                    key: DiffContextExpansionKey(groupID: "hunk-0", boundary: .above),
+                    boundary: .above,
+                    remainingLineCount: 9
+                )
+            ),
+        ]
+    )
+    let result = DiffPaneTextDocumentBuilder.buildSplit(
+        group: group,
+        expandedCollapsedRowIDs: [],
+        fileExtension: "swift",
+        font: CenterTypography.resolveCodeFont(family: "", size: 13),
+        showWhitespace: false,
+        theme: theme()
+    )
+
+    #expect(result.oldGutter.string.contains("+"))
+    #expect(result.oldCode.attributedString.string.contains("9 unchanged lines above"))
+    #expect(result.oldCode.lines.first?.expansionKey == DiffContextExpansionKey(groupID: "hunk-0", boundary: .above))
+}
+```
+
+- [ ] **Step 2: Run test to verify failure**
+
+Run:
+
+```bash
+xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' test -only-testing:AlasTests/DiffPaneViewTests/expandableContextRowsRenderAsGutterPlusRows
+```
+
+Expected: fail because `LineMetadata.expansionKey` and rendering do not exist.
+
+- [ ] **Step 3: Add expansion metadata to text document lines**
+
+In `DiffPaneTextDocumentBuilder.LineMetadata`, add:
+
+```swift
+var expansionKey: DiffContextExpansionKey? = nil
+var expansionBoundary: DiffContextBoundary? = nil
+```
+
+When appending rows, preserve `row.contextExpansion?.key` and `row.contextExpansion?.boundary`.
+
+- [ ] **Step 4: Render expandable rows**
+
+Update `buildSplit` and `buildStacked` row loops:
+
+```swift
+if row.kind == .expandableContext {
+    let text = expandableContextText(row)
+    oldColumn.append(text, kind: row.kind, tone: .collapsed, sourceLine: nil, expansion: row.contextExpansion)
+    newColumn.append(emptyLayoutGlyph(font: font, theme: theme), kind: row.kind, tone: .collapsed, sourceLine: nil, expansion: row.contextExpansion)
+    oldGutter.append("+", side: .paired)
+    newGutter.append("", side: .paired)
+    continue
+}
+```
+
+Add:
+
+```swift
+private static func expandableContextText(_ row: DiffDisplayRow, font: NSFont, theme: Theme) -> NSAttributedString {
+    let boundary = row.contextExpansion?.boundary == .above ? "above" : "below"
+    let label = row.collapsedLineCount > 0
+        ? "\(row.collapsedLineCount) unchanged lines \(boundary)"
+        : "Expand context \(boundary)"
+    return NSAttributedString(
+        string: label,
+        attributes: [
+            .font: font,
+            .foregroundColor: NSColor(theme.color("fg-dim")),
+            .backgroundColor: NSColor(theme.color("bg-2")),
+            .paragraphStyle: CenterTypography.paragraphStyle(),
+        ]
+    )
+}
+```
+
+Adjust the existing accumulator `append` helper to accept an optional `expansion`.
+
+- [ ] **Step 5: Treat expanded context as normal context for colors**
+
+Update `DiffPaneLineTone.init`:
+
+```swift
+case .expandedContext:
+    self = .context
+case .expandableContext:
+    self = .collapsed
+```
+
+Update any `switch row.kind` in `DiffPaneTextDocumentBuilder` to include `.expandedContext` with `.context` and `.expandableContext` with `.collapsed`.
+
+- [ ] **Step 6: Run rendering tests**
+
+Run:
+
+```bash
+xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' test -only-testing:AlasTests/DiffPaneViewTests
+```
+
+Expected: pass.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add Alas/Sources/Center/Diff/DiffPaneTextDocumentBuilder.swift Alas/Sources/Center/Diff/DiffPaneTextDocumentView.swift AlasTests/DiffPaneViewTests.swift
+git commit -m "Render expandable diff context rows"
+```
+
+## Task 5: Gutter Click Handling
+
+**Files:**
+- Modify: `Alas/Sources/Center/Diff/DiffPaneTextDocumentView.swift`
+- Modify: `Alas/Sources/Center/Diff/DiffPaneView.swift`
+- Test: `AlasTests/DiffPaneViewTests.swift`
+
+- [ ] **Step 1: Add failing gutter interaction test**
+
+In `DiffPaneViewTests.swift`, add:
+
+```swift
+@Test @MainActor func lineNumberRulerInvokesExpansionActionForExpandableRows() throws {
+    let scrollView = DiffPaneTextScrollView(frame: NSRect(x: 0, y: 0, width: 220, height: 80))
+    let key = DiffContextExpansionKey(groupID: "hunk-0", boundary: .above)
+    let font = CenterTypography.resolveCodeFont(family: "", size: 13)
+    let document = DiffPaneTextDocumentBuilder.CodeDocument(
+        attributedString: NSAttributedString(string: "9 unchanged lines above", attributes: [.font: font]),
+        lines: [
+            .init(
+                kind: .expandableContext,
+                range: NSRange(location: 0, length: 23),
+                tone: .collapsed,
+                expansionKey: key,
+                expansionBoundary: .above
+            ),
+        ]
+    )
+    var captured: (DiffContextExpansionKey, DiffContextExpansionMode)?
+
+    scrollView.update(
+        document: document,
+        lineLabels: ["+"],
+        wraps: false,
+        font: font,
+        theme: theme(),
+        lspContext: nil,
+        allowedLSPSide: .new,
+        onContextExpansion: { key, mode in captured = (key, mode) }
+    )
+    let ruler = try #require(scrollView.verticalRulerView as? DiffPaneLineNumberRulerView)
+    ruler.invokeExpansionForTesting(row: 0, optionKey: false)
+
+    #expect(captured?.0 == key)
+    #expect(captured?.1 == .chunk(size: 10))
+}
+```
+
+- [ ] **Step 2: Run test to verify failure**
+
+Run:
+
+```bash
+xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' test -only-testing:AlasTests/DiffPaneViewTests/lineNumberRulerInvokesExpansionActionForExpandableRows
+```
+
+Expected: fail because `onContextExpansion` and `invokeExpansionForTesting` do not exist.
+
+- [ ] **Step 3: Thread expansion actions through the text document view**
+
+Add to `DiffPaneTextDocumentView`:
+
+```swift
+var onContextExpansion: (DiffContextExpansionKey, DiffContextExpansionMode) -> Void = { _, _ in }
+```
+
+Pass it into `DiffPaneTextDocumentContainerView.update`, then to each `DiffPaneTextScrollView.update`.
+
+- [ ] **Step 4: Store expansion metadata in scroll/ruler**
+
+In `DiffPaneTextScrollView`, add:
+
+```swift
+private var expansionKeys: [DiffContextExpansionKey?] = []
+private var onContextExpansion: (DiffContextExpansionKey, DiffContextExpansionMode) -> Void = { _, _ in }
+```
+
+In `update`, assign:
+
+```swift
+self.expansionKeys = document.lines.map(\.expansionKey)
+self.onContextExpansion = onContextExpansion
+```
+
+Pass both to the ruler:
+
+```swift
+ruler.update(..., expansionKeys: expansionKeys, onContextExpansion: onContextExpansion)
+```
+
+- [ ] **Step 5: Handle ruler clicks**
+
+In `DiffPaneLineNumberRulerView`, add:
+
+```swift
+private var expansionKeys: [DiffContextExpansionKey?] = []
+private var onContextExpansion: (DiffContextExpansionKey, DiffContextExpansionMode) -> Void = { _, _ in }
+private let defaultExpansionChunkSize = 10
+```
+
+Update `mouseDown` before review-line selection:
+
+```swift
+let row = rowIndex(at: sourcePoint)
+if let row, expansionKeys.indices.contains(row), let key = expansionKeys[row] {
+    let mode: DiffContextExpansionMode = event.modifierFlags.contains(.option)
+        ? .all
+        : .chunk(size: defaultExpansionChunkSize)
+    onContextExpansion(key, mode)
+    return
+}
+```
+
+Add helpers:
+
+```swift
+private func rowIndex(at point: NSPoint) -> Int? {
+    diffRowRects().firstIndex { $0.contains(point) }
+}
+
+func invokeExpansionForTesting(row: Int, optionKey: Bool) {
+    guard expansionKeys.indices.contains(row), let key = expansionKeys[row] else { return }
+    onContextExpansion(key, optionKey ? .all : .chunk(size: defaultExpansionChunkSize))
+}
+```
+
+- [ ] **Step 6: Run gutter tests**
+
+Run:
+
+```bash
+xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' test -only-testing:AlasTests/DiffPaneViewTests/lineNumberRulerInvokesExpansionActionForExpandableRows
+```
+
+Expected: pass.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add Alas/Sources/Center/Diff/DiffPaneTextDocumentView.swift Alas/Sources/Center/Diff/DiffPaneView.swift AlasTests/DiffPaneViewTests.swift
+git commit -m "Handle gutter context expansion clicks"
+```
+
+## Task 6: Wire Expansion Into DiffReviewFileSection
+
+**Files:**
+- Modify: `Alas/Sources/Center/DiffReview/DiffReviewFileSection.swift`
+- Test: `AlasTests/ReviewChangesTabViewTests.swift`
+
+- [ ] **Step 1: Add failing surface rendering test**
+
+In `ReviewChangesTabViewTests.swift`, add:
+
+```swift
+@Test @MainActor func diffReviewFileSectionShowsLazyExpandableContextControlsForProvider() throws {
+    var layout = DiffLayoutMode.split
+    var wrap = false
+    var whitespace = false
+    let hunk = ParsedDiff.Hunk(header: "@@ -4,1 +4,1 @@", oldStart: 4, newStart: 4, lines: [
+        .init(kind: .context, text: "line 4", oldNumber: 4, newNumber: 4),
+    ])
+    let diff = ParsedDiff(hunks: [hunk])
+    let model = DiffDisplayModelBuilder.build(diff: diff, filePath: "a.swift")
+    let file = DiffReviewFileSectionModel(
+        summary: summary(path: "a.swift", source: .unstaged, status: .modified, additions: 0, deletions: 0),
+        parsedDiff: diff,
+        displayModel: model,
+        placeholderMessage: nil,
+        openFile: nil,
+        contextProvider: DiffReviewContextProvider {
+            DiffReviewFileContextSnapshot(
+                old: .available((1...8).map { "old \($0)" }),
+                new: .available((1...8).map { "new \($0)" })
+            )
+        }
+    )
+
+    let view = DiffReviewFileSection(
+        file: file,
+        layoutMode: Binding(get: { layout }, set: { layout = $0 }),
+        wrapLines: Binding(get: { wrap }, set: { wrap = $0 }),
+        showWhitespace: Binding(get: { whitespace }, set: { whitespace = $0 }),
+        codeFontFamily: "",
+        codeFontSize: 13,
+        showsSourceBadge: false
+    )
+    .environment(\.theme, try! ThemeStore().current)
+
+    let controller = NSHostingController(rootView: view)
+    controller.view.frame = NSRect(x: 0, y: 0, width: 760, height: 400)
+    controller.view.layoutSubtreeIfNeeded()
+
+    let text = allSubviews(of: controller.view)
+        .compactMap { ($0 as? NSTextView)?.string }
+        .joined(separator: "\n")
+    #expect(text.contains("Expand context above"))
+    #expect(text.contains("Expand context below"))
+}
+```
+
+- [ ] **Step 2: Run test to verify failure**
+
+Run:
+
+```bash
+xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' test -only-testing:AlasTests/ReviewChangesTabViewTests/diffReviewFileSectionShowsLazyExpandableContextControlsForProvider
+```
+
+Expected: fail because `DiffReviewFileSection` does not derive optimistic provider-backed boundary controls.
+
+- [ ] **Step 3: Add state and lazy load helper**
+
+In `DiffReviewFileSection`, add:
+
+```swift
+@State private var contextSnapshot: DiffReviewFileContextSnapshot?
+@State private var contextExpansion = DiffContextExpansionState()
+@State private var contextLoadTask: Task<Void, Never>?
+@State private var contextLoadError: String?
+```
+
+Add:
+
+```swift
+private func loadContextAndExpand(_ key: DiffContextExpansionKey, mode: DiffContextExpansionMode) {
+    guard let provider = file.contextProvider else { return }
+    if contextSnapshot != nil {
+        applyContextExpansion(key, mode: mode)
+        return
+    }
+    guard contextLoadTask == nil else { return }
+    contextLoadError = nil
+    contextLoadTask = Task {
+        do {
+            let snapshot = try await provider.snapshot()
+            await MainActor.run {
+                contextSnapshot = snapshot
+                contextLoadTask = nil
+                applyContextExpansion(key, mode: mode)
+            }
+        } catch {
+            await MainActor.run {
+                contextLoadError = error.localizedDescription
+                contextLoadTask = nil
+            }
+        }
+    }
+}
+
+private func applyContextExpansion(_ key: DiffContextExpansionKey, mode: DiffContextExpansionMode) {
+    guard let displayModel = file.displayModel else { return }
+    let available = DiffContextExpandedDisplayBuilder.availableLineCount(
+        key: key,
+        groups: displayModel.groups,
+        snapshot: contextSnapshot
+    )
+    contextExpansion.expand(key, available: available, mode: mode)
+}
+```
+
+Expose `availableLineCount` from `DiffContextExpandedDisplayBuilder`. The first click loads the snapshot and then applies the requested chunk or all-at-once expansion with the exact available line count.
+
+- [ ] **Step 4: Derive groups before rendering**
+
+In `content`, compute:
+
+```swift
+let groups = DiffContextExpandedDisplayBuilder.derive(
+    groups: displayModel.groups,
+    snapshot: contextSnapshot,
+    providerAvailable: file.contextProvider != nil,
+    expansion: contextExpansion,
+    filePath: displayModel.filePath,
+    chunkSize: 10
+)
+```
+
+Use `groups` for placement and rendering. Before the snapshot loads, `providerAvailable: true` creates optimistic `Expand context above/below` rows. After the first successful expansion click, the loaded snapshot gives exact counts and concrete expanded rows.
+
+- [ ] **Step 5: Pass expansion action to text views**
+
+For both `DiffPaneTextDocumentView` and `DiffPaneView`, pass:
+
+```swift
+onContextExpansion: loadContextAndExpand
+```
+
+- [ ] **Step 6: Show load failure**
+
+Below the file header and before content, add:
+
+```swift
+if let contextLoadError {
+    Text("Could not load surrounding context: \(contextLoadError)")
+        .font(.system(size: 11))
+        .foregroundColor(theme.color("warn"))
+        .padding(.horizontal, 14)
+        .padding(.vertical, 8)
+        .background(theme.color("bg-2"))
+}
+```
+
+- [ ] **Step 7: Run file section test**
+
+Run:
+
+```bash
+xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' test -only-testing:AlasTests/ReviewChangesTabViewTests/diffReviewFileSectionShowsLazyExpandableContextControlsForProvider
+```
+
+Expected: pass.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add Alas/Sources/Center/DiffReview/DiffReviewFileSection.swift Alas/Sources/Center/Diff/DiffContextExpansion.swift AlasTests/ReviewChangesTabViewTests.swift
+git commit -m "Wire context expansion into review diffs"
+```
+
+## Task 7: Final Verification And Project Regeneration Check
+
+**Files:**
+- Modify only if `project.yml` or generated project membership requires it.
+
+- [ ] **Step 1: Check whether new source/test files are included by project generation**
+
+Run:
+
+```bash
+xcodegen
+git status --short
+```
+
+Expected: if `Alas.xcodeproj/project.pbxproj` changes, keep it. If it does not change, the project already included the files through generation rules.
+
+- [ ] **Step 2: Run focused tests**
+
+Run:
+
+```bash
+xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' test -only-testing:AlasTests/DiffContextExpansionTests -only-testing:AlasTests/DiffPaneViewTests -only-testing:AlasTests/ReviewChangesLoaderTests -only-testing:AlasTests/CommitReviewLoaderTests -only-testing:AlasTests/Integrations/ReviewRequestDraftTests -only-testing:AlasTests/ReviewChangesTabViewTests
+```
+
+Expected: pass.
+
+- [ ] **Step 3: Run required build**
+
+Run:
+
+```bash
+xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -quiet build
+```
+
+Expected: pass.
+
+- [ ] **Step 4: Run full test suite**
+
+Run:
+
+```bash
+xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' test
+```
+
+Expected: pass.
+
+- [ ] **Step 5: Commit generated project or final fixes**
+
+If `xcodegen` changed the project:
+
+```bash
+git add Alas.xcodeproj/project.pbxproj
+git commit -m "Regenerate Xcode project"
+```
+
+If final verification required code fixes, commit those files with a targeted message:
+
+```bash
+git add <fixed-files>
+git commit -m "Fix diff context expansion verification issues"
+```
+
+- [ ] **Step 6: Final status**
+
+Run:
+
+```bash
+git status --short
+```
+
+Expected: no tracked changes. Ignored `.build/` or `.superpowers/` may remain.

--- a/docs/superpowers/specs/2026-06-15-diff-context-expansion-design.md
+++ b/docs/superpowers/specs/2026-06-15-diff-context-expansion-design.md
@@ -1,0 +1,102 @@
+# Diff Context Expansion Design
+
+## Context
+
+Alas has new diff stack screens built on the shared `DiffReviewSurface` path. The relevant implementation is concentrated around:
+
+- `DiffReviewSurface`
+- `DiffReviewFileSection`
+- `DiffDisplayModel`
+- `DiffDisplayModelBuilder`
+- `DiffPaneTextDocumentView`
+- `ReviewChangesLoader`
+- `CommitReviewLoader`
+- `DraftReviewRequestDiffSessionBuilder`
+
+The current diff display can collapse long unchanged runs that already exist inside a parsed diff hunk. It does not yet fetch or reveal unchanged file lines outside the hunk boundaries. The desired behavior is closer to diffs.com: reviewers can expand context outward from a visible hunk while staying in the review surface.
+
+## Goals
+
+- Add context expansion to all screens that use the shared diff review surface.
+- Use a compact gutter-first control, matching the selected "gutter plus" direction.
+- Reveal a small chunk on normal click and all available context on Option-click.
+- Expand both old and new sides when both snapshots are available.
+- Preserve existing hunk actions, review comment placement, inline feedback placement, and stable anchors for original diff rows.
+- Keep initial review loading fast by fetching file snapshots lazily.
+
+## Non-Goals
+
+- Do not turn the diff review surface into a full file editor.
+- Do not mutate `ParsedDiff.Hunk` to represent expanded context.
+- Do not make provider-only sessions fail when repository snapshots are unavailable.
+- Do not eagerly load full file contents for every changed file.
+
+## UX
+
+Each expandable hunk boundary shows a small `+` affordance in the line-number gutter. The adjacent row can show subdued text such as `24 unchanged lines above` or `31 unchanged lines below`.
+
+Interaction:
+
+- Click: reveal the next context chunk, defaulting to 10 lines.
+- Option-click: reveal all remaining context in that direction.
+- Hover/help: describe the active action, for example `Expand 10 lines` or `Expand all`.
+- When all context in a direction is visible, remove the boundary control for that direction.
+
+Split view expands both old and new side context when both snapshots exist. If only one side exists, such as an added or deleted file, expansion degrades to the available side. Stacked view projects expanded context through the same row-ordering rules used by the existing stacked diff renderer.
+
+Existing collapsed in-hunk context remains supported. Boundary expansion reveals context outside the parsed hunk; collapsed rows inside the parsed hunk keep their current expansion behavior.
+
+## Data Model
+
+`ParsedDiff.Hunk` remains the immutable source of the actual diff. Expansion state lives alongside display construction.
+
+Add a context layer with these responsibilities:
+
+- `DiffReviewContextProvider`: optional async provider attached to a renderable review file.
+- `DiffReviewFileContextSnapshot`: old/new line arrays plus metadata for missing or unavailable sides.
+- `DiffContextExpansionState`: per file, hunk, and boundary state tracking how many lines above and below are currently revealed.
+- Display-row metadata for expanded context rows so they render as neutral context while remaining distinguishable from original diff rows.
+
+Original diff row anchors stay stable. Expanded context rows receive deterministic anchors from real old/new line numbers. They do not alter `sourceHunk`, hunk staging, hunk discard, commit hunk dropping, inline feedback placement, or draft comment placement for original rows.
+
+## Loading And Providers
+
+Providers are optional and lazy. A review file loads its snapshot on first provider-backed expansion and caches it in view state.
+
+Provider sources:
+
+- Unstaged local changes: old side is the index version; new side is the worktree file.
+- Staged local changes: old side is `HEAD` or the empty tree; new side is the index version.
+- Commit review: old side is the first parent or empty tree; new side is the commit.
+- Draft review request: old side is the selected base ref; new side is the validated head SHA or current HEAD used for the draft.
+- Provider/imported sessions without local repository snapshots: provider-backed expansion is unavailable, but already-present collapsed in-hunk context can still expand.
+
+Provider failures are scoped to the file and interaction that triggered them. A failed snapshot load should not break the rest of the review stream. Files known to be binary, missing, or unsupported before rendering should hide expansion controls. If a control was rendered but the lazy snapshot load fails, show a lightweight inline failure for that file.
+
+## Rendering
+
+`DiffReviewFileSection` owns per-file expansion UI state, similar to its existing collapsed-row and draft-composer state. The text renderer stays responsible for drawing rows, line numbers, selection, backgrounds, wrapping, and LSP metadata.
+
+Rendering flow:
+
+1. Build the base `DiffDisplayModel` from `ParsedDiff`.
+2. When expansion state or loaded snapshots change, derive display groups that include expanded boundary context rows.
+3. Pass the derived groups to `DiffPaneTextDocumentView`.
+4. Render the gutter `+` affordance through the least invasive AppKit bridge, either as a row-level gutter control or an extension of the line-number ruler.
+
+Scroll position should remain stable after expansion, especially when revealing lines above the visible viewport.
+
+## Testing
+
+Unit tests should cover:
+
+- Expansion math for above and below hunk boundaries.
+- Chunked expansion versus expand-all.
+- Added, deleted, renamed, and normal modified files.
+- Stable original anchors across expansion.
+- Deterministic anchors for expanded context rows.
+- Provider selection for unstaged, staged, commit, and draft review request contexts.
+- Fallback behavior when no provider exists.
+- Display-row generation for split and stacked layouts.
+
+UI-level tests should cover accessibility identifiers or labels for gutter expansion controls where practical.


### PR DESCRIPTION
## Summary
- Add expandable diff context rows around hunks in review diff screens.
- Lazily load full-file context snapshots for local changes, commit reviews, and draft review request diffs.
- Support gutter and text-row clicks, with Option-click expanding all remaining context.
- Guard async context loads across file, provider, and display replacement.

## Validation
- `rtk xcodegen`
- `rtk xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -quiet build`
- `rtk xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' test`
- Targeted diff expansion and review test suites
- Final focused review pass: no findings