### PR TITLE
feat(review): Add provider review actions

### DIFF
--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -760,6 +760,7 @@
 		B8D2EB18303D58777D79CDBA /* SearchResult.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A0FF718D68E15F539577F56 /* SearchResult.swift */; };
 		B94F61E5170AA8102AA2A022 /* DiffPaneLSP.swift in Sources */ = {isa = PBXBuildFile; fileRef = B58BD62080F250E0F0DD057F /* DiffPaneLSP.swift */; };
 		B9BEA46E818C321122713F41 /* EditorFindControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6033DBD8BF13A76978A653A3 /* EditorFindControllerTests.swift */; };
+		B9D15679A5E813254E1DDCB6 /* ProviderReviewMutationController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6F0AE27D70E34430C71AAF84 /* ProviderReviewMutationController.swift */; };
 		B9F3258E4AE2DB1E7481690A /* SubprocessRunner.swift in Sources */ = {isa = PBXBuildFile; fileRef = E06BA06E4A620EEE773E1672 /* SubprocessRunner.swift */; };
 		BACDEEE3791E66405294B328 /* ACPFirstRunConnectingPolicyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F6EDDD4D22267C26B496A6FF /* ACPFirstRunConnectingPolicyTests.swift */; };
 		BAE4D422FC3950E61FEE1D15 /* AppIntents.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = CA43AA9C8462D579E733B46C /* AppIntents.framework */; };
@@ -1512,6 +1513,7 @@
 		6E8B52175A7F6144B4C52010 /* EditorTabView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditorTabView.swift; sourceTree = "<group>"; };
 		6E8FA892877AE2FDBCD4C747 /* ShortcutResolverTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShortcutResolverTests.swift; sourceTree = "<group>"; };
 		6EB58175A9A39073E9D73F85 /* GitIgnoreServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GitIgnoreServiceTests.swift; sourceTree = "<group>"; };
+		6F0AE27D70E34430C71AAF84 /* ProviderReviewMutationController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProviderReviewMutationController.swift; sourceTree = "<group>"; };
 		6FFE12732C0D83715FC990A9 /* CommitsSectionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommitsSectionView.swift; sourceTree = "<group>"; };
 		7018E992654E19345D8BD723 /* ImageDiffSwipeViewTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageDiffSwipeViewTests.swift; sourceTree = "<group>"; };
 		701F837327D905FAAA0E0AF3 /* ACPConnectionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPConnectionTests.swift; sourceTree = "<group>"; };
@@ -3696,6 +3698,7 @@
 		D01AEADFFA32827C6CFC24CB /* ReviewWorkspace */ = {
 			isa = PBXGroup;
 			children = (
+				6F0AE27D70E34430C71AAF84 /* ProviderReviewMutationController.swift */,
 				2EC0311F5824C51F14EC4278 /* ReviewDraftCommentActions.swift */,
 				58BC051640BBB02A2EBF6E4F /* ReviewDraftCommentController.swift */,
 				B10E5AB5D726C40331681709 /* ReviewDraftCommentStore.swift */,
@@ -4581,6 +4584,7 @@
 				6E69D87B57B23223A48AB6F7 /* ProjectsManager.swift in Sources */,
 				50D7FF67981533B21FCB0890 /* PromptEditorBody.swift in Sources */,
 				2661C51A093174D940CB5733 /* ProviderReviewActions.swift in Sources */,
+				B9D15679A5E813254E1DDCB6 /* ProviderReviewMutationController.swift in Sources */,
 				0FE1A3CCEB283E8780F52076 /* QueuedPrompt.swift in Sources */,
 				3AC6DD00AD2D19FB3A0CCD03 /* RecommendedLanguageCatalog.swift in Sources */,
 				0D8046E333B0DA2B45EE78D4 /* RelativeTime.swift in Sources */,

--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -153,6 +153,7 @@
 		25B94D8823F2A5A2BA4545B5 /* AppStatePersistenceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8C11E3449E4A7B4E69E83C1C /* AppStatePersistenceTests.swift */; };
 		25CD620AE7FFA7DE82937F7E /* Spinner.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7E01930F1D95B8D17BCBAC1 /* Spinner.swift */; };
 		2659BA65A6CABBE800A06AB3 /* tool-call-content-diff.json in Resources */ = {isa = PBXBuildFile; fileRef = 9A187BD52742E8F4A6E52667 /* tool-call-content-diff.json */; };
+		2661C51A093174D940CB5733 /* ProviderReviewActions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F9F77CC231E1131962F5A43 /* ProviderReviewActions.swift */; };
 		26F83C65E75B5F44024FEF1F /* ACPMentionPickerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E941397D0207F68135B3464D /* ACPMentionPickerTests.swift */; };
 		2731B28802538E4FD7CBB0EA /* AgentDefinitionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FAC7D583D292BB6D72670F0A /* AgentDefinitionTests.swift */; };
 		2735F19DF0AD717CA3CF3B23 /* WorktreeServiceCreatedAtTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6BA2F208DBC024A64D0ED065 /* WorktreeServiceCreatedAtTests.swift */; };
@@ -912,6 +913,7 @@
 		DBE7AD7F869B444A7C48E5B2 /* TreeSitterJava in Frameworks */ = {isa = PBXBuildFile; productRef = 33EB43DCB691861654EC147A /* TreeSitterJava */; };
 		DC0989E32F4B7BF023F784D6 /* StartupScriptInstallerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 43DF691FC778F3A71CE20FBB /* StartupScriptInstallerTests.swift */; };
 		DC394B7740FAEBD2F8ACB61F /* LSPMessages.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5C6A07D7C67D02C8638D8C1 /* LSPMessages.swift */; };
+		DC93AED5844A56C6BA012CC3 /* ProviderReviewActionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 327D6F0E386398E6A512ADDF /* ProviderReviewActionsTests.swift */; };
 		DCACB5B624BFFE7C50DA6C61 /* RightPaneStateSyncStatusTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D3505FB870FA22C9C0FDB26 /* RightPaneStateSyncStatusTests.swift */; };
 		DD18C5FF006D18BC66964D94 /* TerminalTabView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 14087D57E96448EEF0B80BD9 /* TerminalTabView.swift */; };
 		DDAA1FF54466B7F5424D315E /* TreeSitterMarkdown in Frameworks */ = {isa = PBXBuildFile; productRef = 49F7F27A9183521F9997AF49 /* TreeSitterMarkdown */; };
@@ -1260,6 +1262,7 @@
 		321866B3EB8CCE337B1D3A58 /* ACPMessage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPMessage.swift; sourceTree = "<group>"; };
 		321E1DBC8C06504AD3EE7D6E /* WorktreeWatcherTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorktreeWatcherTests.swift; sourceTree = "<group>"; };
 		3253B229B757C725B7747249 /* initialize-request.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "initialize-request.json"; sourceTree = "<group>"; };
+		327D6F0E386398E6A512ADDF /* ProviderReviewActionsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProviderReviewActionsTests.swift; sourceTree = "<group>"; };
 		328607AAAAA12EE2206ED5A4 /* LanguageRegistry.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LanguageRegistry.swift; sourceTree = "<group>"; };
 		329882D757C34246C9848C3A /* ACPMentionChipAttachment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPMentionChipAttachment.swift; sourceTree = "<group>"; };
 		32D6E47CC4523FDE263C764C /* WindowDragHandle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WindowDragHandle.swift; sourceTree = "<group>"; };
@@ -1450,6 +1453,7 @@
 		5F30C23C9CD0842373F29D1F /* BuildIdentity.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BuildIdentity.swift; sourceTree = "<group>"; };
 		5F77AE52695B7B19A9F11B89 /* RemotePairingService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemotePairingService.swift; sourceTree = "<group>"; };
 		5F931B1EEA7F04855BAE5A43 /* WorkingTreeStageAllActionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkingTreeStageAllActionTests.swift; sourceTree = "<group>"; };
+		5F9F77CC231E1131962F5A43 /* ProviderReviewActions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProviderReviewActions.swift; sourceTree = "<group>"; };
 		6016A3CF87F34222C533D350 /* ClaudeInstallerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClaudeInstallerTests.swift; sourceTree = "<group>"; };
 		6033DBD8BF13A76978A653A3 /* EditorFindControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditorFindControllerTests.swift; sourceTree = "<group>"; };
 		6048519B4C444FCB46A11E49 /* ACPMessageStableIdTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPMessageStableIdTests.swift; sourceTree = "<group>"; };
@@ -2831,6 +2835,7 @@
 				82E98F9835497D830C12AA8F /* CodeHostRemoteDetector.swift */,
 				B5D2DA50E978EB0571D6A74C /* GitHubCLIProvider.swift */,
 				6C4E2F83F9EAB77B96EBA152 /* GitLabCLIProvider.swift */,
+				5F9F77CC231E1131962F5A43 /* ProviderReviewActions.swift */,
 				FC11F5C6667A6ECB74E066AE /* ReviewEvidence.swift */,
 				7FF257B37B6E9EA4D97C67D4 /* ReviewEvidenceModel.swift */,
 				2D4CC3ED497796474F107EBE /* ReviewLoopDrawer.swift */,
@@ -3674,6 +3679,7 @@
 				DE74A483930F70A0C79CC3E8 /* CodeHostRemoteDetectorTests.swift */,
 				8C28D64372B5B4C734A92533 /* GitHubCLIProviderTests.swift */,
 				C371360F83FE318A5B8AEDBF /* GitLabCLIProviderTests.swift */,
+				327D6F0E386398E6A512ADDF /* ProviderReviewActionsTests.swift */,
 				B0FBEABA73057C9F165A66CD /* ReviewEvidenceModelTests.swift */,
 				4B05E0E44B026AE7E8EA3101 /* ReviewEvidenceTests.swift */,
 				B0F47561DB37D2ED72B6BE25 /* ReviewLoopDrawerTests.swift */,
@@ -4574,6 +4580,7 @@
 				E175AE346DFAD0B62827C921 /* ProjectPicker.swift in Sources */,
 				6E69D87B57B23223A48AB6F7 /* ProjectsManager.swift in Sources */,
 				50D7FF67981533B21FCB0890 /* PromptEditorBody.swift in Sources */,
+				2661C51A093174D940CB5733 /* ProviderReviewActions.swift in Sources */,
 				0FE1A3CCEB283E8780F52076 /* QueuedPrompt.swift in Sources */,
 				3AC6DD00AD2D19FB3A0CCD03 /* RecommendedLanguageCatalog.swift in Sources */,
 				0D8046E333B0DA2B45EE78D4 /* RelativeTime.swift in Sources */,
@@ -5051,6 +5058,7 @@
 				9C20E8B060C753308748CE05 /* ProjectsManagerProjectOrderingTests.swift in Sources */,
 				6BF6FE50DAC473322005A036 /* ProjectsManagerTests.swift in Sources */,
 				66D3CC7109527B2938684292 /* ProjectsManagerWorktreeOrderingTests.swift in Sources */,
+				DC93AED5844A56C6BA012CC3 /* ProviderReviewActionsTests.swift in Sources */,
 				B6580745C7EDF5AA65DB0A86 /* QueuedPromptTests.swift in Sources */,
 				E89811545A8AD0ED03655AA3 /* RecommendedLanguageCatalogTests.swift in Sources */,
 				9D99FFFDFB3A256C4960D388 /* ReleaseCheckerTests.swift in Sources */,

--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -945,6 +945,7 @@
 		E3158A4D8FBD36D06D421D28 /* RepoSelectorRecents.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9CA420C011D4235E47A3FB1B /* RepoSelectorRecents.swift */; };
 		E395C1299D215BA0EC4760E8 /* SpaceConfig.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7963D4DD10B67EB683510FF6 /* SpaceConfig.swift */; };
 		E3B38707284D08326C3183E4 /* FuzzyMatchTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E444D51CB35528C8E5AB150A /* FuzzyMatchTests.swift */; };
+		E3D59DB020583EF3E0EB7171 /* ProviderReviewPublishConfirmationView.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF69D638124D1B4D1C04BD31 /* ProviderReviewPublishConfirmationView.swift */; };
 		E433BB79E6D79DAF4532172A /* Kbd.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16CA8FEE64D73BDEBAF74878 /* Kbd.swift */; };
 		E44EBD2F2F9A398207E55C6D /* ACPTerminal.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0594E7E039B5FC403783C6E8 /* ACPTerminal.swift */; };
 		E468E95C778E0C9BE6F1EDED /* LegacyHookSweep.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4CE0FF00CB2F81000FB09A72 /* LegacyHookSweep.swift */; };
@@ -2018,6 +2019,7 @@
 		EECB91379591DA21D216A894 /* RelativeTime.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RelativeTime.swift; sourceTree = "<group>"; };
 		EECD5B53A23694EF60F63041 /* MergeConflictAgentProposalView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MergeConflictAgentProposalView.swift; sourceTree = "<group>"; };
 		EF5F20AB3B3F7BCEAA56B143 /* SQLiteDatabase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SQLiteDatabase.swift; sourceTree = "<group>"; };
+		EF69D638124D1B4D1C04BD31 /* ProviderReviewPublishConfirmationView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProviderReviewPublishConfirmationView.swift; sourceTree = "<group>"; };
 		EFDB90A7F9E58F4C1A258D23 /* AppStateSpacesTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppStateSpacesTests.swift; sourceTree = "<group>"; };
 		F01FD27D107E0207950F00D3 /* ACPTopPaginationIndicator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPTopPaginationIndicator.swift; sourceTree = "<group>"; };
 		F03C1E46A0853704E9B4449A /* JSONRPCFramerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JSONRPCFramerTests.swift; sourceTree = "<group>"; };
@@ -3699,6 +3701,7 @@
 			isa = PBXGroup;
 			children = (
 				6F0AE27D70E34430C71AAF84 /* ProviderReviewMutationController.swift */,
+				EF69D638124D1B4D1C04BD31 /* ProviderReviewPublishConfirmationView.swift */,
 				2EC0311F5824C51F14EC4278 /* ReviewDraftCommentActions.swift */,
 				58BC051640BBB02A2EBF6E4F /* ReviewDraftCommentController.swift */,
 				B10E5AB5D726C40331681709 /* ReviewDraftCommentStore.swift */,
@@ -4585,6 +4588,7 @@
 				50D7FF67981533B21FCB0890 /* PromptEditorBody.swift in Sources */,
 				2661C51A093174D940CB5733 /* ProviderReviewActions.swift in Sources */,
 				B9D15679A5E813254E1DDCB6 /* ProviderReviewMutationController.swift in Sources */,
+				E3D59DB020583EF3E0EB7171 /* ProviderReviewPublishConfirmationView.swift in Sources */,
 				0FE1A3CCEB283E8780F52076 /* QueuedPrompt.swift in Sources */,
 				3AC6DD00AD2D19FB3A0CCD03 /* RecommendedLanguageCatalog.swift in Sources */,
 				0D8046E333B0DA2B45EE78D4 /* RelativeTime.swift in Sources */,

--- a/Alas/Sources/Center/Commit/CommitTabView.swift
+++ b/Alas/Sources/Center/Commit/CommitTabView.swift
@@ -430,8 +430,8 @@ struct CommitReviewBody: View {
             draftCommentScrollCommand: draftCommentScrollCommand,
             draftCommentActions: draftCommentActions(),
             onSelectDraftComment: selectDraftComment,
-            onSaveDraftComment: { fileID, anchor, body in
-                saveDraftComment(fileID: fileID, anchor: anchor, body: body)
+            onSaveDraftComment: { fileID, originalPath, anchor, body in
+                saveDraftComment(fileID: fileID, originalPath: originalPath, anchor: anchor, body: body)
             }
         )
         .accessibilityIdentifier("commit-review-body")
@@ -554,9 +554,14 @@ struct CommitReviewBody: View {
         )
     }
 
-    private func saveDraftComment(fileID: DiffReviewFileID, anchor: DiffReviewLineAnchor, body: String) {
+    private func saveDraftComment(
+        fileID: DiffReviewFileID,
+        originalPath: String?,
+        anchor: DiffReviewLineAnchor,
+        body: String
+    ) {
         do {
-            try draftCommentController?.add(anchor: anchor, fileID: fileID, bodyMarkdown: body)
+            try draftCommentController?.add(anchor: anchor, fileID: fileID, originalPath: originalPath, bodyMarkdown: body)
         } catch {
             // The controller keeps the non-blocking error state for the review rail.
         }

--- a/Alas/Sources/Center/DiffReview/DiffReviewFileSection.swift
+++ b/Alas/Sources/Center/DiffReview/DiffReviewFileSection.swift
@@ -1308,8 +1308,7 @@ private struct DiffReviewInlineFeedbackCard: View {
     let onSelect: (DiffReviewInlineFeedback) -> Void
 
     @Environment(\.theme) private var theme
-    @State private var isReplying = false
-    @State private var replyBody = ""
+    @State private var replyEditor = DiffReviewInlineFeedbackReplyEditorState()
 
     var body: some View {
         VStack(alignment: .leading, spacing: 6) {
@@ -1387,9 +1386,9 @@ private struct DiffReviewInlineFeedbackCard: View {
     @ViewBuilder
     private var actionRow: some View {
         let availability = actions.availability(item, file)
-        if isReplying {
+        if replyEditor.isReplying {
             VStack(alignment: .leading, spacing: 6) {
-                TextField("Reply", text: $replyBody, axis: .vertical)
+                TextField("Reply", text: $replyEditor.body, axis: .vertical)
                     .textFieldStyle(.plain)
                     .font(.system(size: 11.5))
                     .foregroundColor(theme.color("fg"))
@@ -1401,17 +1400,12 @@ private struct DiffReviewInlineFeedbackCard: View {
                 HStack(spacing: 6) {
                     Spacer(minLength: 0)
                     inlineActionButton(id: "reply-save", title: "Save") {
-                        let body = replyBody.trimmingCharacters(in: .whitespacesAndNewlines)
-                        guard !body.isEmpty else { return }
-                        DiffReviewInlineFeedbackCardInteraction.reply(item, body: body) { feedback, body in
+                        _ = replyEditor.save(item) { feedback, body in
                             actions.replyProvider(feedback, file, body)
                         }
-                        isReplying = false
-                        replyBody = ""
                     }
                     inlineActionButton(id: "reply-cancel", title: "Cancel") {
-                        isReplying = false
-                        replyBody = ""
+                        replyEditor.cancel()
                     }
                 }
             }
@@ -1446,8 +1440,7 @@ private struct DiffReviewInlineFeedbackCard: View {
                 }
                 if availability.canReplyProvider {
                     inlineActionButton(id: "reply", title: "Reply") {
-                        replyBody = ""
-                        isReplying = true
+                        replyEditor.start()
                     }
                 }
                 if availability.canResolveProvider {
@@ -1556,6 +1549,34 @@ enum DiffReviewInlineFeedbackCardInteraction {
         action: (DiffReviewInlineFeedback, String) -> Void
     ) {
         action(item, body)
+    }
+}
+
+struct DiffReviewInlineFeedbackReplyEditorState: Equatable {
+    var isReplying = false
+    var body = ""
+
+    mutating func start() {
+        body = ""
+        isReplying = true
+    }
+
+    mutating func cancel() {
+        body = ""
+        isReplying = false
+    }
+
+    @discardableResult
+    mutating func save(
+        _ item: DiffReviewInlineFeedback,
+        action: (DiffReviewInlineFeedback, String) -> Void
+    ) -> Bool {
+        let trimmed = body.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return false }
+        DiffReviewInlineFeedbackCardInteraction.reply(item, body: trimmed, action: action)
+        body = ""
+        isReplying = false
+        return true
     }
 }
 

--- a/Alas/Sources/Center/DiffReview/DiffReviewFileSection.swift
+++ b/Alas/Sources/Center/DiffReview/DiffReviewFileSection.swift
@@ -1055,6 +1055,15 @@ private struct ReviewDraftCommentCard: View {
                 }
                 .lineLimit(1)
 
+                ForEach(providerStateLabels.indices, id: \.self) { index in
+                    let label = providerStateLabels[index]
+                    Text(label.text)
+                        .font(.system(size: 10))
+                        .foregroundColor(label.color)
+                        .lineLimit(2)
+                        .fixedSize(horizontal: false, vertical: true)
+                }
+
                 if isEditing {
                     TextEditor(text: $editingBody)
                         .font(.system(size: 11.5))
@@ -1241,6 +1250,7 @@ private struct ReviewDraftCommentCard: View {
             "Local draft",
             lineDescription,
             comment.state == .resolved ? "resolved" : nil,
+            providerStateLabels.map(\.text).joined(separator: ", "),
             DiffReviewInlineFeedbackMarkdown.plainText(comment.bodyMarkdown),
         ]
         .compactMap { part in
@@ -1248,6 +1258,17 @@ private struct ReviewDraftCommentCard: View {
             return part
         }
         .joined(separator: ", ")
+    }
+
+    private var providerStateLabels: [(text: String, color: Color)] {
+        var labels: [(text: String, color: Color)] = []
+        if let publish = comment.providerPublish {
+            labels.append(("published to \(publish.provider.displayName)", theme.color("fg-faint")))
+        }
+        if let error = comment.providerError {
+            labels.append(("\(error.provider.displayName) error: \(error.message)", theme.color("warn")))
+        }
+        return labels
     }
 
     private var statusColor: Color {

--- a/Alas/Sources/Center/DiffReview/DiffReviewFileSection.swift
+++ b/Alas/Sources/Center/DiffReview/DiffReviewFileSection.swift
@@ -1308,6 +1308,8 @@ private struct DiffReviewInlineFeedbackCard: View {
     let onSelect: (DiffReviewInlineFeedback) -> Void
 
     @Environment(\.theme) private var theme
+    @State private var isReplying = false
+    @State private var replyBody = ""
 
     var body: some View {
         VStack(alignment: .leading, spacing: 6) {
@@ -1385,7 +1387,40 @@ private struct DiffReviewInlineFeedbackCard: View {
     @ViewBuilder
     private var actionRow: some View {
         let availability = actions.availability(item, file)
-        if availability.canOpenProvider || availability.canCopyContext || availability.canSendToAgent {
+        if isReplying {
+            VStack(alignment: .leading, spacing: 6) {
+                TextField("Reply", text: $replyBody, axis: .vertical)
+                    .textFieldStyle(.plain)
+                    .font(.system(size: 11.5))
+                    .foregroundColor(theme.color("fg"))
+                    .padding(7)
+                    .background(theme.color("bg-1"))
+                    .clipShape(RoundedRectangle(cornerRadius: 5))
+                    .accessibilityIdentifier("diff-review-inline-feedback-reply-\(item.id)")
+
+                HStack(spacing: 6) {
+                    Spacer(minLength: 0)
+                    inlineActionButton(id: "reply-save", title: "Save") {
+                        let body = replyBody.trimmingCharacters(in: .whitespacesAndNewlines)
+                        guard !body.isEmpty else { return }
+                        DiffReviewInlineFeedbackCardInteraction.reply(item, body: body) { feedback, body in
+                            actions.replyProvider(feedback, file, body)
+                        }
+                        isReplying = false
+                        replyBody = ""
+                    }
+                    inlineActionButton(id: "reply-cancel", title: "Cancel") {
+                        isReplying = false
+                        replyBody = ""
+                    }
+                }
+            }
+        } else if availability.canOpenProvider
+            || availability.canCopyContext
+            || availability.canSendToAgent
+            || availability.canReplyProvider
+            || availability.canResolveProvider
+            || availability.canUnresolveProvider {
             HStack(spacing: 6) {
                 Spacer(minLength: 0)
                 if availability.canOpenProvider {
@@ -1407,6 +1442,22 @@ private struct DiffReviewInlineFeedbackCard: View {
                         DiffReviewInlineFeedbackCardInteraction.send(item) { feedback in
                             actions.sendToAgent(feedback, file)
                         }
+                    }
+                }
+                if availability.canReplyProvider {
+                    inlineActionButton(id: "reply", title: "Reply") {
+                        replyBody = ""
+                        isReplying = true
+                    }
+                }
+                if availability.canResolveProvider {
+                    inlineActionButton(id: "resolve", title: "Resolve") {
+                        actions.resolveProvider(item, file)
+                    }
+                }
+                if availability.canUnresolveProvider {
+                    inlineActionButton(id: "unresolve", title: "Unresolve") {
+                        actions.unresolveProvider(item, file)
                     }
                 }
             }
@@ -1431,6 +1482,13 @@ private struct DiffReviewInlineFeedbackCard: View {
             DiffReviewAccessibilityMarker(
                 identifier: "diff-review-inline-feedback-action-\(id)-\(item.id)",
                 label: title
+            )
+        )
+        .background(
+            ReviewDraftCommentActionPressMarker(
+                identifier: "diff-review-inline-feedback-action-\(id)-\(item.id)",
+                label: title,
+                action: action
             )
         )
     }
@@ -1490,6 +1548,14 @@ enum DiffReviewInlineFeedbackCardInteraction {
         action: (DiffReviewInlineFeedback) -> Void
     ) {
         action(item)
+    }
+
+    static func reply(
+        _ item: DiffReviewInlineFeedback,
+        body: String,
+        action: (DiffReviewInlineFeedback, String) -> Void
+    ) {
+        action(item, body)
     }
 }
 

--- a/Alas/Sources/Center/DiffReview/DiffReviewFileSection.swift
+++ b/Alas/Sources/Center/DiffReview/DiffReviewFileSection.swift
@@ -1096,6 +1096,7 @@ private struct ReviewDraftCommentCard: View {
             || availability.canDismiss
             || availability.canCopyPrompt
             || availability.canShowSendToAgent
+            || availability.canPublishProvider
         {
             HStack(spacing: 6) {
                 Spacer(minLength: 0)
@@ -1133,6 +1134,11 @@ private struct ReviewDraftCommentCard: View {
                 if availability.canCopyPrompt {
                     actionButton(id: "copy", title: "Copy") {
                         actions.copyPrompt(feedbackBundle)
+                    }
+                }
+                if availability.canPublishProvider {
+                    actionButton(id: "publish", title: "Publish") {
+                        actions.publishProvider(comment)
                     }
                 }
                 if availability.canShowSendToAgent {
@@ -1183,22 +1189,36 @@ private struct ReviewDraftCommentCard: View {
         .buttonStyle(.plain)
         .disabled(!enabled)
         .help(title)
-        .accessibilityIdentifier("diff-review-draft-comment-\(id)-\(comment.id)")
+        .accessibilityIdentifier(accessibilityIdentifier(forActionID: id))
         .accessibilityLabel(title)
         .background(
             DiffReviewAccessibilityMarker(
-                identifier: "diff-review-draft-comment-action-\(id)-\(comment.id)",
+                identifier: markerIdentifier(forActionID: id),
                 label: title
             )
         )
         .background(
             ReviewDraftCommentActionPressMarker(
-                identifier: "diff-review-draft-comment-action-\(id)-\(comment.id)",
+                identifier: markerIdentifier(forActionID: id),
                 label: title,
                 isEnabled: enabled,
                 action: action
             )
         )
+    }
+
+    private func accessibilityIdentifier(forActionID id: String) -> String {
+        if id == "publish" {
+            return "diff-review-draft-comment-publish-\(comment.id)"
+        }
+        return "diff-review-draft-comment-\(id)-\(comment.id)"
+    }
+
+    private func markerIdentifier(forActionID id: String) -> String {
+        if id == "publish" {
+            return "diff-review-draft-comment-publish-\(comment.id)"
+        }
+        return "diff-review-draft-comment-action-\(id)-\(comment.id)"
     }
 
     private var feedbackBundle: ReviewFeedbackBundle {

--- a/Alas/Sources/Center/DiffReview/DiffReviewInlineFeedbackActions.swift
+++ b/Alas/Sources/Center/DiffReview/DiffReviewInlineFeedbackActions.swift
@@ -36,11 +36,17 @@ struct DiffReviewInlineFeedbackActionAvailability: Equatable {
     var canOpenProvider: Bool
     var canCopyContext: Bool
     var canSendToAgent: Bool
+    var canReplyProvider: Bool = false
+    var canResolveProvider: Bool = false
+    var canUnresolveProvider: Bool = false
 
     static let none = DiffReviewInlineFeedbackActionAvailability(
         canOpenProvider: false,
         canCopyContext: false,
-        canSendToAgent: false
+        canSendToAgent: false,
+        canReplyProvider: false,
+        canResolveProvider: false,
+        canUnresolveProvider: false
     )
 }
 
@@ -49,6 +55,9 @@ struct DiffReviewInlineFeedbackActions {
     var openProvider: (DiffReviewInlineFeedback, DiffReviewFileSummary) -> Void = { _, _ in }
     var copyContext: (DiffReviewInlineFeedback, DiffReviewFileSummary) -> Void = { _, _ in }
     var sendToAgent: (DiffReviewInlineFeedback, DiffReviewFileSummary) -> Void = { _, _ in }
+    var replyProvider: (DiffReviewInlineFeedback, DiffReviewFileSummary, String) -> Void = { _, _, _ in }
+    var resolveProvider: (DiffReviewInlineFeedback, DiffReviewFileSummary) -> Void = { _, _ in }
+    var unresolveProvider: (DiffReviewInlineFeedback, DiffReviewFileSummary) -> Void = { _, _ in }
 }
 
 enum DiffReviewInlineFeedbackContextFormatter {

--- a/Alas/Sources/Center/DiffReview/DiffReviewSurface.swift
+++ b/Alas/Sources/Center/DiffReview/DiffReviewSurface.swift
@@ -25,7 +25,7 @@ struct DiffReviewSurface: View {
     var draftCommentScrollCommand: DiffReviewDraftCommentScrollCommand? = nil
     var draftCommentActions = ReviewDraftCommentActions()
     var onSelectDraftComment: (ReviewDraftComment) -> Void = { _ in }
-    var onSaveDraftComment: (DiffReviewFileID, DiffReviewLineAnchor, String) -> Void = { _, _, _ in }
+    var onSaveDraftComment: (DiffReviewFileID, String?, DiffReviewLineAnchor, String) -> Void = { _, _, _, _ in }
 
     @Environment(\.theme) private var theme
     @State private var programmaticScroll = DiffReviewProgrammaticScrollController()
@@ -62,7 +62,7 @@ struct DiffReviewSurface: View {
         draftCommentScrollCommand: DiffReviewDraftCommentScrollCommand? = nil,
         draftCommentActions: ReviewDraftCommentActions = ReviewDraftCommentActions(),
         onSelectDraftComment: @escaping (ReviewDraftComment) -> Void = { _ in },
-        onSaveDraftComment: @escaping (DiffReviewFileID, DiffReviewLineAnchor, String) -> Void = { _, _, _ in }
+        onSaveDraftComment: @escaping (DiffReviewFileID, String?, DiffReviewLineAnchor, String) -> Void = { _, _, _, _ in }
     ) {
         self.session = session
         self._selectedFileID = selectedFileID
@@ -280,7 +280,7 @@ struct DiffReviewSurface: View {
                 draftCommentActions: draftCommentActions,
                 onSelectDraftComment: onSelectDraftComment,
                 onSaveDraftComment: { anchor, body in
-                    onSaveDraftComment(file.id, anchor, body)
+                    onSaveDraftComment(file.id, file.summary.originalPath, anchor, body)
                 },
                 onContextExpansionActivated: {
                     contextExpandedFileIDs.insert(file.id)

--- a/Alas/Sources/Center/ReviewChanges/ReviewChangesTabView.swift
+++ b/Alas/Sources/Center/ReviewChanges/ReviewChangesTabView.swift
@@ -451,9 +451,14 @@ struct ReviewChangesTabView: View {
         )
     }
 
-    private func saveDraftComment(fileID: DiffReviewFileID, anchor: DiffReviewLineAnchor, body: String) {
+    private func saveDraftComment(
+        fileID: DiffReviewFileID,
+        originalPath: String?,
+        anchor: DiffReviewLineAnchor,
+        body: String
+    ) {
         do {
-            try draftCommentController?.add(anchor: anchor, fileID: fileID, bodyMarkdown: body)
+            try draftCommentController?.add(anchor: anchor, fileID: fileID, originalPath: originalPath, bodyMarkdown: body)
         } catch {
             // The controller keeps the non-blocking error state for the review rail.
         }

--- a/Alas/Sources/Center/ReviewEvidence/ReviewEvidenceTabView.swift
+++ b/Alas/Sources/Center/ReviewEvidence/ReviewEvidenceTabView.swift
@@ -457,8 +457,8 @@ struct ReviewEvidenceTabView: View {
                     draftCommentScrollCommand: draftCommentScrollCommand,
                     draftCommentActions: draftCommentActions(),
                     onSelectDraftComment: selectDraftComment,
-                    onSaveDraftComment: { fileID, anchor, body in
-                        saveDraftComment(fileID: fileID, anchor: anchor, body: body)
+                    onSaveDraftComment: { fileID, originalPath, anchor, body in
+                        saveDraftComment(fileID: fileID, originalPath: originalPath, anchor: anchor, body: body)
                     }
                 )
             } else {
@@ -1051,9 +1051,14 @@ struct ReviewEvidenceTabView: View {
         )
     }
 
-    private func saveDraftComment(fileID: DiffReviewFileID, anchor: DiffReviewLineAnchor, body: String) {
+    private func saveDraftComment(
+        fileID: DiffReviewFileID,
+        originalPath: String?,
+        anchor: DiffReviewLineAnchor,
+        body: String
+    ) {
         do {
-            try draftCommentController?.add(anchor: anchor, fileID: fileID, bodyMarkdown: body)
+            try draftCommentController?.add(anchor: anchor, fileID: fileID, originalPath: originalPath, bodyMarkdown: body)
         } catch {
             // The controller keeps the non-blocking error state for the review rail.
         }

--- a/Alas/Sources/Center/ReviewRequest/DraftReviewRequestTabView.swift
+++ b/Alas/Sources/Center/ReviewRequest/DraftReviewRequestTabView.swift
@@ -481,8 +481,8 @@ struct DraftReviewRequestTabView: View {
                 draftCommentScrollCommand: draftCommentScrollCommand,
                 draftCommentActions: draftCommentActions(),
                 onSelectDraftComment: selectDraftComment,
-                onSaveDraftComment: { fileID, anchor, body in
-                    saveDraftComment(fileID: fileID, anchor: anchor, body: body)
+                onSaveDraftComment: { fileID, originalPath, anchor, body in
+                    saveDraftComment(fileID: fileID, originalPath: originalPath, anchor: anchor, body: body)
                 }
             )
         } else {
@@ -825,9 +825,14 @@ struct DraftReviewRequestTabView: View {
         )
     }
 
-    private func saveDraftComment(fileID: DiffReviewFileID, anchor: DiffReviewLineAnchor, body: String) {
+    private func saveDraftComment(
+        fileID: DiffReviewFileID,
+        originalPath: String?,
+        anchor: DiffReviewLineAnchor,
+        body: String
+    ) {
         do {
-            try draftCommentController?.add(anchor: anchor, fileID: fileID, bodyMarkdown: body)
+            try draftCommentController?.add(anchor: anchor, fileID: fileID, originalPath: originalPath, bodyMarkdown: body)
         } catch {
             // The controller keeps the non-blocking error state for the review rail.
         }

--- a/Alas/Sources/Center/ReviewWorkspace/ProviderReviewMutationController.swift
+++ b/Alas/Sources/Center/ReviewWorkspace/ProviderReviewMutationController.swift
@@ -24,10 +24,11 @@ struct ProviderReviewMutationController {
         cwd: URL,
         localDraftIDs: Set<String>? = nil
     ) async throws -> ProviderReviewPublishResult {
-        let sourceComments = draftController.activeUnpublishedComments.filter { comment in
+        let sourceComments = draftController.comments.filter { comment in
             localDraftIDs?.contains(comment.id) ?? true
         }
-        let comments = sourceComments.compactMap(ProviderReviewDraftComment.init(localDraft:))
+        let comments = ProviderReviewPublishPlanner.publishableDrafts(sourceComments)
+            .compactMap(ProviderReviewDraftComment.init(localDraft:))
         if localDraftIDs != nil, comments.isEmpty {
             throw ProviderReviewMutationControllerError.noPublishableSelectedDrafts
         }
@@ -75,6 +76,48 @@ struct ProviderReviewMutationController {
 
     func mutateThread(_ mutation: ProviderThreadMutation) async throws -> ProviderThreadMutationResult {
         try await provider.mutateReviewThread(mutation)
+    }
+}
+
+enum ProviderReviewPublishPlanner {
+    static func publishableDrafts(_ drafts: [ReviewDraftComment]) -> [ReviewDraftComment] {
+        drafts.filter { unpublishableReason(for: $0) == nil }
+    }
+
+    static func unpublishableMessages(_ drafts: [ReviewDraftComment]) -> [String] {
+        drafts.compactMap { draft in
+            guard let reason = unpublishableReason(for: draft) else { return nil }
+            return "\(draft.path): \(reason)"
+        }
+    }
+
+    private static func unpublishableReason(for draft: ReviewDraftComment) -> String? {
+        if let publish = draft.providerPublish {
+            return "already published to \(publish.provider.displayName)."
+        }
+        if draft.state != .active {
+            return "draft is \(draft.state.providerPublishDescription)."
+        }
+        if draft.side == .unknown || draft.normalizedLineRange.lowerBound <= 0 {
+            return "missing line anchor."
+        }
+        if draft.bodyMarkdown.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+            return "empty comment."
+        }
+        return nil
+    }
+}
+
+private extension ReviewDraftCommentState {
+    var providerPublishDescription: String {
+        switch self {
+        case .active:
+            "active"
+        case .resolved:
+            "resolved"
+        case .dismissed:
+            "dismissed"
+        }
     }
 }
 

--- a/Alas/Sources/Center/ReviewWorkspace/ProviderReviewMutationController.swift
+++ b/Alas/Sources/Center/ReviewWorkspace/ProviderReviewMutationController.swift
@@ -1,0 +1,72 @@
+import Foundation
+
+@MainActor
+struct ProviderReviewMutationController {
+    let provider: any CodeHostProvider
+    let draftController: ReviewDraftCommentController
+    let now: () -> Date
+
+    init(
+        provider: any CodeHostProvider,
+        draftController: ReviewDraftCommentController,
+        now: @escaping () -> Date = Date.init
+    ) {
+        self.provider = provider
+        self.draftController = draftController
+        self.now = now
+    }
+
+    func publishReview(
+        remote: CodeHostRemote,
+        reviewRequest: ReviewRequest,
+        decision: ProviderReviewDecision,
+        summaryBody: String,
+        cwd: URL
+    ) async throws -> ProviderReviewPublishResult {
+        let comments = draftController.activeUnpublishedComments.compactMap(ProviderReviewDraftComment.init(localDraft:))
+        let request = ProviderReviewPublishRequest(
+            remote: remote,
+            reviewRequest: reviewRequest,
+            comments: comments,
+            decision: decision,
+            summaryBody: summaryBody,
+            cwd: cwd
+        )
+
+        let result = try await provider.publishReview(request)
+        let timestamp = now()
+
+        for published in result.published {
+            try draftController.markPublished(
+                commentID: published.localDraftID,
+                publish: ReviewDraftProviderPublish(
+                    provider: remote.kind,
+                    host: remote.host,
+                    repositorySlug: remote.repositorySlug,
+                    reviewNumber: reviewRequest.number,
+                    threadID: published.providerThreadID,
+                    commentID: published.providerCommentID,
+                    url: published.providerURL,
+                    publishedAt: timestamp
+                )
+            )
+        }
+
+        for failed in result.failed {
+            try draftController.recordProviderError(
+                commentID: failed.localDraftID,
+                error: ReviewDraftProviderError(
+                    provider: remote.kind,
+                    message: failed.message,
+                    occurredAt: timestamp
+                )
+            )
+        }
+
+        return result
+    }
+
+    func mutateThread(_ mutation: ProviderThreadMutation) async throws -> ProviderThreadMutationResult {
+        try await provider.mutateReviewThread(mutation)
+    }
+}

--- a/Alas/Sources/Center/ReviewWorkspace/ProviderReviewMutationController.swift
+++ b/Alas/Sources/Center/ReviewWorkspace/ProviderReviewMutationController.swift
@@ -21,9 +21,13 @@ struct ProviderReviewMutationController {
         reviewRequest: ReviewRequest,
         decision: ProviderReviewDecision,
         summaryBody: String,
-        cwd: URL
+        cwd: URL,
+        localDraftIDs: Set<String>? = nil
     ) async throws -> ProviderReviewPublishResult {
-        let comments = draftController.activeUnpublishedComments.compactMap(ProviderReviewDraftComment.init(localDraft:))
+        let sourceComments = draftController.activeUnpublishedComments.filter { comment in
+            localDraftIDs?.contains(comment.id) ?? true
+        }
+        let comments = sourceComments.compactMap(ProviderReviewDraftComment.init(localDraft:))
         let request = ProviderReviewPublishRequest(
             remote: remote,
             reviewRequest: reviewRequest,

--- a/Alas/Sources/Center/ReviewWorkspace/ProviderReviewMutationController.swift
+++ b/Alas/Sources/Center/ReviewWorkspace/ProviderReviewMutationController.swift
@@ -28,6 +28,9 @@ struct ProviderReviewMutationController {
             localDraftIDs?.contains(comment.id) ?? true
         }
         let comments = sourceComments.compactMap(ProviderReviewDraftComment.init(localDraft:))
+        if localDraftIDs != nil, comments.isEmpty {
+            throw ProviderReviewMutationControllerError.noPublishableSelectedDrafts
+        }
         let request = ProviderReviewPublishRequest(
             remote: remote,
             reviewRequest: reviewRequest,
@@ -72,5 +75,16 @@ struct ProviderReviewMutationController {
 
     func mutateThread(_ mutation: ProviderThreadMutation) async throws -> ProviderThreadMutationResult {
         try await provider.mutateReviewThread(mutation)
+    }
+}
+
+enum ProviderReviewMutationControllerError: LocalizedError, Equatable {
+    case noPublishableSelectedDrafts
+
+    var errorDescription: String? {
+        switch self {
+        case .noPublishableSelectedDrafts:
+            return "The selected draft is no longer publishable."
+        }
     }
 }

--- a/Alas/Sources/Center/ReviewWorkspace/ProviderReviewMutationController.swift
+++ b/Alas/Sources/Center/ReviewWorkspace/ProviderReviewMutationController.swift
@@ -32,6 +32,9 @@ struct ProviderReviewMutationController {
         if localDraftIDs != nil, comments.isEmpty {
             throw ProviderReviewMutationControllerError.noPublishableSelectedDrafts
         }
+        if localDraftIDs == nil, decision == .comment, comments.isEmpty {
+            throw ProviderReviewMutationControllerError.noPublishableDraftsForCommentReview
+        }
         let request = ProviderReviewPublishRequest(
             remote: remote,
             reviewRequest: reviewRequest,
@@ -123,11 +126,14 @@ private extension ReviewDraftCommentState {
 
 enum ProviderReviewMutationControllerError: LocalizedError, Equatable {
     case noPublishableSelectedDrafts
+    case noPublishableDraftsForCommentReview
 
     var errorDescription: String? {
         switch self {
         case .noPublishableSelectedDrafts:
             return "The selected draft is no longer publishable."
+        case .noPublishableDraftsForCommentReview:
+            return "There are no publishable draft comments for a comment review."
         }
     }
 }

--- a/Alas/Sources/Center/ReviewWorkspace/ProviderReviewPublishConfirmationView.swift
+++ b/Alas/Sources/Center/ReviewWorkspace/ProviderReviewPublishConfirmationView.swift
@@ -5,6 +5,7 @@ struct ProviderReviewPublishConfirmationView: View {
     let reviewIdentity: String
     let commentCount: Int
     let unpublishableMessages: [String]
+    let allowedDecisions: [ProviderReviewDecision]
     @Binding var selectedDecision: ProviderReviewDecision
     let isPublishing: Bool
     let errorMessage: String?
@@ -24,13 +25,19 @@ struct ProviderReviewPublishConfirmationView: View {
                 .foregroundColor(theme.color("fg-muted"))
 
             Picker("Decision", selection: $selectedDecision) {
-                Text("Comment").tag(ProviderReviewDecision.comment)
-                Text("Approve").tag(ProviderReviewDecision.approve)
-                Text("Request changes").tag(ProviderReviewDecision.requestChanges)
+                ForEach(allowedDecisions, id: \.self) { decision in
+                    Text(decision.displayName).tag(decision)
+                }
             }
             .pickerStyle(.segmented)
             .disabled(isPublishing)
             .accessibilityIdentifier("provider-review-publish-decision")
+            .background(
+                DiffReviewAccessibilityMarker(
+                    identifier: "provider-review-publish-decisions",
+                    label: allowedDecisions.map(\.displayName).joined(separator: ", ")
+                )
+            )
 
             Text(commentCountText)
                 .font(.system(size: 12))
@@ -113,7 +120,22 @@ struct ProviderReviewPublishConfirmationView: View {
     }
 
     private var isConfirmDisabled: Bool {
-        isPublishing || (commentCount == 0 && selectedDecision == .comment)
+        isPublishing
+            || !allowedDecisions.contains(selectedDecision)
+            || (commentCount == 0 && selectedDecision == .comment)
+    }
+}
+
+private extension ProviderReviewDecision {
+    var displayName: String {
+        switch self {
+        case .comment:
+            "Comment"
+        case .approve:
+            "Approve"
+        case .requestChanges:
+            "Request changes"
+        }
     }
 }
 

--- a/Alas/Sources/Center/ReviewWorkspace/ProviderReviewPublishConfirmationView.swift
+++ b/Alas/Sources/Center/ReviewWorkspace/ProviderReviewPublishConfirmationView.swift
@@ -1,0 +1,116 @@
+import SwiftUI
+
+struct ProviderReviewPublishConfirmationView: View {
+    let providerName: String
+    let reviewIdentity: String
+    let commentCount: Int
+    let unpublishableMessages: [String]
+    @Binding var selectedDecision: ProviderReviewDecision
+    let isPublishing: Bool
+    let errorMessage: String?
+    let onCancel: () -> Void
+    let onConfirm: () -> Void
+
+    @Environment(\.theme) private var theme
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            Text("Publish review")
+                .font(.system(size: 15, weight: .semibold))
+                .foregroundColor(theme.color("fg"))
+
+            Text("\(providerName) \(reviewIdentity)")
+                .font(.system(size: 12, weight: .medium))
+                .foregroundColor(theme.color("fg-muted"))
+
+            Picker("Decision", selection: $selectedDecision) {
+                Text("Comment").tag(ProviderReviewDecision.comment)
+                Text("Approve").tag(ProviderReviewDecision.approve)
+                Text("Request changes").tag(ProviderReviewDecision.requestChanges)
+            }
+            .pickerStyle(.segmented)
+            .disabled(isPublishing)
+            .accessibilityIdentifier("provider-review-publish-decision")
+
+            Text(commentCountText)
+                .font(.system(size: 12))
+                .foregroundColor(theme.color("fg"))
+
+            if !unpublishableMessages.isEmpty {
+                VStack(alignment: .leading, spacing: 4) {
+                    Text("Unable to publish")
+                        .font(.system(size: 11, weight: .semibold))
+                        .foregroundColor(theme.color("warn"))
+                    ForEach(unpublishableMessages, id: \.self) { message in
+                        Text(message)
+                            .font(.system(size: 11))
+                            .foregroundColor(theme.color("warn"))
+                            .fixedSize(horizontal: false, vertical: true)
+                            .background(
+                                DiffReviewAccessibilityMarker(
+                                    identifier: "provider-review-publish-unpublishable-\(message.stableAccessibilityIDComponent)",
+                                    label: message
+                                )
+                            )
+                    }
+                }
+                .padding(8)
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .background(theme.color("warn").opacity(0.12))
+                .clipShape(RoundedRectangle(cornerRadius: 6))
+            }
+
+            if let errorMessage, !errorMessage.isEmpty {
+                Text(errorMessage)
+                    .font(.system(size: 11))
+                    .foregroundColor(theme.color("del"))
+                    .fixedSize(horizontal: false, vertical: true)
+                    .background(
+                        DiffReviewAccessibilityMarker(
+                            identifier: "provider-review-publish-error",
+                            label: errorMessage
+                        )
+                    )
+            }
+
+            HStack(spacing: 8) {
+                Spacer()
+                Button("Cancel", action: onCancel)
+                    .disabled(isPublishing)
+                    .accessibilityIdentifier("provider-review-publish-cancel")
+                Button(isPublishing ? "Publishing..." : "Publish", action: onConfirm)
+                    .disabled(isPublishing)
+                    .keyboardShortcut(.defaultAction)
+                    .accessibilityIdentifier("provider-review-publish-confirm")
+            }
+        }
+        .padding(14)
+        .frame(width: 420)
+        .background(theme.color("bg-1"))
+        .clipShape(RoundedRectangle(cornerRadius: 10))
+        .overlay(
+            RoundedRectangle(cornerRadius: 10)
+                .stroke(theme.color("line"), lineWidth: 0.75)
+        )
+        .accessibilityIdentifier("provider-review-publish-confirmation")
+        .background(
+            DiffReviewAccessibilityMarker(
+                identifier: "provider-review-publish-confirmation",
+                label: "Publish review \(providerName) \(reviewIdentity), \(commentCountText)"
+            )
+        )
+    }
+
+    private var commentCountText: String {
+        "\(commentCount) \(commentCount == 1 ? "comment" : "comments")"
+    }
+}
+
+private extension String {
+    var stableAccessibilityIDComponent: String {
+        let allowed = CharacterSet.alphanumerics.union(CharacterSet(charactersIn: "-_"))
+        return unicodeScalars
+            .map { allowed.contains($0) ? Character($0).description : "-" }
+            .joined()
+    }
+}

--- a/Alas/Sources/Center/ReviewWorkspace/ProviderReviewPublishConfirmationView.swift
+++ b/Alas/Sources/Center/ReviewWorkspace/ProviderReviewPublishConfirmationView.swift
@@ -81,7 +81,14 @@ struct ProviderReviewPublishConfirmationView: View {
                 Button(isPublishing ? "Publishing..." : "Publish", action: onConfirm)
                     .disabled(isPublishing)
                     .keyboardShortcut(.defaultAction)
-                    .accessibilityIdentifier("provider-review-publish-confirm")
+                    .background(
+                        ProviderReviewPublishPressMarker(
+                            identifier: "provider-review-publish-confirm",
+                            label: "Publish",
+                            isEnabled: !isPublishing,
+                            action: onConfirm
+                        )
+                    )
             }
         }
         .padding(14)
@@ -103,6 +110,44 @@ struct ProviderReviewPublishConfirmationView: View {
 
     private var commentCountText: String {
         "\(commentCount) \(commentCount == 1 ? "comment" : "comments")"
+    }
+}
+
+private struct ProviderReviewPublishPressMarker: NSViewRepresentable {
+    let identifier: String
+    let label: String
+    let isEnabled: Bool
+    let action: () -> Void
+
+    func makeNSView(context: Context) -> ProviderReviewPublishPressView {
+        let view = ProviderReviewPublishPressView(frame: .zero)
+        view.setAccessibilityIdentifier(identifier)
+        view.setAccessibilityLabel(label)
+        view.setAccessibilityRole(.button)
+        view.setAccessibilityEnabled(isEnabled)
+        view.isEnabled = isEnabled
+        view.action = action
+        return view
+    }
+
+    func updateNSView(_ view: ProviderReviewPublishPressView, context: Context) {
+        view.setAccessibilityIdentifier(identifier)
+        view.setAccessibilityLabel(label)
+        view.setAccessibilityRole(.button)
+        view.setAccessibilityEnabled(isEnabled)
+        view.isEnabled = isEnabled
+        view.action = action
+    }
+}
+
+private final class ProviderReviewPublishPressView: NSView {
+    var isEnabled = true
+    var action: () -> Void = {}
+
+    override func accessibilityPerformPress() -> Bool {
+        guard isEnabled else { return false }
+        action()
+        return true
     }
 }
 

--- a/Alas/Sources/Center/ReviewWorkspace/ProviderReviewPublishConfirmationView.swift
+++ b/Alas/Sources/Center/ReviewWorkspace/ProviderReviewPublishConfirmationView.swift
@@ -79,13 +79,13 @@ struct ProviderReviewPublishConfirmationView: View {
                     .disabled(isPublishing)
                     .accessibilityIdentifier("provider-review-publish-cancel")
                 Button(isPublishing ? "Publishing..." : "Publish", action: onConfirm)
-                    .disabled(isPublishing)
+                    .disabled(isConfirmDisabled)
                     .keyboardShortcut(.defaultAction)
                     .background(
                         ProviderReviewPublishPressMarker(
                             identifier: "provider-review-publish-confirm",
                             label: "Publish",
-                            isEnabled: !isPublishing,
+                            isEnabled: !isConfirmDisabled,
                             action: onConfirm
                         )
                     )
@@ -110,6 +110,10 @@ struct ProviderReviewPublishConfirmationView: View {
 
     private var commentCountText: String {
         "\(commentCount) \(commentCount == 1 ? "comment" : "comments")"
+    }
+
+    private var isConfirmDisabled: Bool {
+        isPublishing || (commentCount == 0 && selectedDecision == .comment)
     }
 }
 

--- a/Alas/Sources/Center/ReviewWorkspace/ProviderReviewPublishConfirmationView.swift
+++ b/Alas/Sources/Center/ReviewWorkspace/ProviderReviewPublishConfirmationView.swift
@@ -7,6 +7,7 @@ struct ProviderReviewPublishConfirmationView: View {
     let unpublishableMessages: [String]
     let allowedDecisions: [ProviderReviewDecision]
     @Binding var selectedDecision: ProviderReviewDecision
+    @Binding var summaryBody: String
     let isPublishing: Bool
     let errorMessage: String?
     let onCancel: () -> Void
@@ -42,6 +43,34 @@ struct ProviderReviewPublishConfirmationView: View {
             Text(commentCountText)
                 .font(.system(size: 12))
                 .foregroundColor(theme.color("fg"))
+
+            if selectedDecision.requiresSummaryBody {
+                VStack(alignment: .leading, spacing: 6) {
+                    Text("Review summary")
+                        .font(.system(size: 11, weight: .semibold))
+                        .foregroundColor(theme.color("fg-muted"))
+                    TextEditor(text: $summaryBody)
+                        .font(.system(size: 12))
+                        .foregroundColor(theme.color("fg"))
+                        .scrollContentBackground(.hidden)
+                        .frame(minHeight: 72)
+                        .padding(6)
+                        .background(theme.color("bg-0"))
+                        .clipShape(RoundedRectangle(cornerRadius: 6))
+                        .overlay(
+                            RoundedRectangle(cornerRadius: 6)
+                                .stroke(theme.color("line"), lineWidth: 0.75)
+                        )
+                        .disabled(isPublishing)
+                        .accessibilityIdentifier("provider-review-publish-summary")
+                }
+                .background(
+                    DiffReviewAccessibilityMarker(
+                        identifier: "provider-review-publish-summary",
+                        label: "Review summary"
+                    )
+                )
+            }
 
             if !unpublishableMessages.isEmpty {
                 VStack(alignment: .leading, spacing: 4) {
@@ -123,6 +152,7 @@ struct ProviderReviewPublishConfirmationView: View {
         isPublishing
             || !allowedDecisions.contains(selectedDecision)
             || (commentCount == 0 && selectedDecision == .comment)
+            || (selectedDecision.requiresSummaryBody && summaryBody.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
     }
 }
 

--- a/Alas/Sources/Center/ReviewWorkspace/ReviewDraftCommentActions.swift
+++ b/Alas/Sources/Center/ReviewWorkspace/ReviewDraftCommentActions.swift
@@ -6,6 +6,27 @@ struct ReviewDraftCommentActionAvailability: Equatable, Sendable {
     var canCopyPrompt: Bool
     var canShowSendToAgent: Bool
     var canSendToAgent: Bool
+    var canPublishProvider: Bool
+
+    init(
+        canEdit: Bool,
+        canDelete: Bool,
+        canResolve: Bool,
+        canDismiss: Bool,
+        canCopyPrompt: Bool,
+        canShowSendToAgent: Bool,
+        canSendToAgent: Bool,
+        canPublishProvider: Bool = false
+    ) {
+        self.canEdit = canEdit
+        self.canDelete = canDelete
+        self.canResolve = canResolve
+        self.canDismiss = canDismiss
+        self.canCopyPrompt = canCopyPrompt
+        self.canShowSendToAgent = canShowSendToAgent
+        self.canSendToAgent = canSendToAgent
+        self.canPublishProvider = canPublishProvider
+    }
 
     static let none = ReviewDraftCommentActionAvailability(
         canEdit: false,
@@ -14,36 +35,46 @@ struct ReviewDraftCommentActionAvailability: Equatable, Sendable {
         canDismiss: false,
         canCopyPrompt: false,
         canShowSendToAgent: false,
-        canSendToAgent: false
+        canSendToAgent: false,
+        canPublishProvider: false
     )
 }
 
 struct ReviewDraftCommentActions {
     var availability: (ReviewDraftComment) -> ReviewDraftCommentActionAvailability
+    var canPublishReview: () -> Bool
     var edit: (ReviewDraftComment, String) -> Void
     var delete: (ReviewDraftComment) -> Void
     var resolve: (ReviewDraftComment) -> Void
     var dismiss: (ReviewDraftComment) -> Void
     var copyPrompt: (ReviewFeedbackBundle) -> Void
+    var publishProvider: (ReviewDraftComment) -> Void
+    var publishReview: () -> Void
     var agentTargets: () -> [ReviewFeedbackAgentTarget]
     var sendToAgent: (ReviewFeedbackBundle, ReviewFeedbackAgentTarget) -> Void
 
     init(
         availability: @escaping (ReviewDraftComment) -> ReviewDraftCommentActionAvailability = { _ in .none },
+        canPublishReview: @escaping () -> Bool = { false },
         edit: @escaping (ReviewDraftComment, String) -> Void = { _, _ in },
         delete: @escaping (ReviewDraftComment) -> Void = { _ in },
         resolve: @escaping (ReviewDraftComment) -> Void = { _ in },
         dismiss: @escaping (ReviewDraftComment) -> Void = { _ in },
         copyPrompt: @escaping (ReviewFeedbackBundle) -> Void = { _ in },
+        publishProvider: @escaping (ReviewDraftComment) -> Void = { _ in },
+        publishReview: @escaping () -> Void = {},
         agentTargets: @escaping () -> [ReviewFeedbackAgentTarget] = { [] },
         sendToAgent: @escaping (ReviewFeedbackBundle, ReviewFeedbackAgentTarget) -> Void = { _, _ in }
     ) {
         self.availability = availability
+        self.canPublishReview = canPublishReview
         self.edit = edit
         self.delete = delete
         self.resolve = resolve
         self.dismiss = dismiss
         self.copyPrompt = copyPrompt
+        self.publishProvider = publishProvider
+        self.publishReview = publishReview
         self.agentTargets = agentTargets
         self.sendToAgent = sendToAgent
     }

--- a/Alas/Sources/Center/ReviewWorkspace/ReviewDraftCommentController.swift
+++ b/Alas/Sources/Center/ReviewWorkspace/ReviewDraftCommentController.swift
@@ -11,6 +11,10 @@ final class ReviewDraftCommentController {
     private(set) var comments: [ReviewDraftComment] = []
     var errorMessage: String?
 
+    var activeUnpublishedComments: [ReviewDraftComment] {
+        comments.filter { $0.state == .active && $0.providerPublish == nil }
+    }
+
     init(
         sessionID: ReviewDraftSessionID,
         store: ReviewDraftCommentStore = .init(),
@@ -76,6 +80,21 @@ final class ReviewDraftCommentController {
     func dismiss(commentID: String) throws {
         guard var comment = comments.first(where: { $0.id == commentID }) else { return }
         comment.state = .dismissed
+        comment.updatedAt = now()
+        try saveAndReload(comment)
+    }
+
+    func markPublished(commentID: String, publish: ReviewDraftProviderPublish) throws {
+        guard var comment = comments.first(where: { $0.id == commentID }) else { return }
+        comment.providerPublish = publish
+        comment.providerError = nil
+        comment.updatedAt = now()
+        try saveAndReload(comment)
+    }
+
+    func recordProviderError(commentID: String, error: ReviewDraftProviderError) throws {
+        guard var comment = comments.first(where: { $0.id == commentID }) else { return }
+        comment.providerError = error
         comment.updatedAt = now()
         try saveAndReload(comment)
     }

--- a/Alas/Sources/Center/ReviewWorkspace/ReviewDraftCommentController.swift
+++ b/Alas/Sources/Center/ReviewWorkspace/ReviewDraftCommentController.swift
@@ -35,14 +35,19 @@ final class ReviewDraftCommentController {
         }
     }
 
-    func add(anchor: DiffReviewLineAnchor, fileID: DiffReviewFileID, bodyMarkdown: String) throws {
+    func add(
+        anchor: DiffReviewLineAnchor,
+        fileID: DiffReviewFileID,
+        originalPath: String? = nil,
+        bodyMarkdown: String
+    ) throws {
         let timestamp = now()
         let comment = ReviewDraftComment(
             id: UUID().uuidString,
             sessionID: sessionID,
             fileID: fileID,
             path: anchor.path,
-            originalPath: nil,
+            originalPath: originalPath,
             side: anchor.side,
             startLine: anchor.line,
             endLine: nil,

--- a/Alas/Sources/Center/ReviewWorkspace/ReviewDraftModels.swift
+++ b/Alas/Sources/Center/ReviewWorkspace/ReviewDraftModels.swift
@@ -83,6 +83,23 @@ enum ReviewDraftCommentState: String, Codable, Equatable, Hashable, Sendable {
     case dismissed
 }
 
+struct ReviewDraftProviderPublish: Codable, Equatable, Sendable {
+    let provider: CodeHostKind
+    let host: String
+    let repositorySlug: String
+    let reviewNumber: Int
+    let threadID: String?
+    let commentID: String?
+    let url: URL?
+    let publishedAt: Date
+}
+
+struct ReviewDraftProviderError: Codable, Equatable, Sendable {
+    let provider: CodeHostKind
+    let message: String
+    let occurredAt: Date
+}
+
 struct ReviewDraftComment: Codable, Equatable, Identifiable, Sendable {
     var id: String
     var sessionID: ReviewDraftSessionID
@@ -97,6 +114,8 @@ struct ReviewDraftComment: Codable, Equatable, Identifiable, Sendable {
     var state: ReviewDraftCommentState
     var createdAt: Date
     var updatedAt: Date
+    var providerPublish: ReviewDraftProviderPublish? = nil
+    var providerError: ReviewDraftProviderError? = nil
 
     var normalizedLineRange: ClosedRange<Int> {
         let end = endLine ?? startLine

--- a/Alas/Sources/Center/ReviewWorkspace/ReviewDraftSummaryRail.swift
+++ b/Alas/Sources/Center/ReviewWorkspace/ReviewDraftSummaryRail.swift
@@ -504,6 +504,12 @@ struct ReviewDraftSummaryRail: View {
                         .font(.system(size: 10))
                         .foregroundColor(theme.color("fg-faint"))
                 }
+                ForEach(providerStateLabels(for: comment).indices, id: \.self) { index in
+                    let label = providerStateLabels(for: comment)[index]
+                    Text(label.text)
+                        .font(.system(size: 10))
+                        .foregroundColor(label.color)
+                }
                 Spacer(minLength: 0)
             }
 
@@ -570,6 +576,7 @@ struct ReviewDraftSummaryRail: View {
             comment.path,
             lineDescription(for: comment),
             stateLabel(for: comment),
+            providerStateLabels(for: comment).map(\.text).joined(separator: ", "),
             DiffReviewInlineFeedbackMarkdown.plainText(comment.bodyMarkdown),
         ]
         .compactMap { part in
@@ -588,6 +595,17 @@ struct ReviewDraftSummaryRail: View {
         case .dismissed:
             "dismissed"
         }
+    }
+
+    private func providerStateLabels(for comment: ReviewDraftComment) -> [(text: String, color: Color)] {
+        var labels: [(text: String, color: Color)] = []
+        if let publish = comment.providerPublish {
+            labels.append(("published to \(publish.provider.displayName)", theme.color("fg-faint")))
+        }
+        if let error = comment.providerError {
+            labels.append(("\(error.provider.displayName) error: \(error.message)", theme.color("warn")))
+        }
+        return labels
     }
 
     private func sideLabel(for side: DiffReviewInlineFeedbackSide) -> String {

--- a/Alas/Sources/Center/ReviewWorkspace/ReviewDraftSummaryRail.swift
+++ b/Alas/Sources/Center/ReviewWorkspace/ReviewDraftSummaryRail.swift
@@ -76,6 +76,10 @@ struct ReviewDraftSummaryRail: View {
         !bundle.activeComments.isEmpty && visibleComments.contains { draftCommentActions.availability($0).canSendToAgent }
     }
 
+    private var canPublishReview: Bool {
+        draftCommentActions.canPublishReview()
+    }
+
     private var shouldShowSendToAgent: Bool {
         visibleComments.contains { draftCommentActions.availability($0).canShowSendToAgent }
     }
@@ -132,6 +136,16 @@ struct ReviewDraftSummaryRail: View {
             ) {
                 draftCommentActions.copyPrompt(bundle)
             }
+            if canPublishReview {
+                collapsedActionButton(
+                    id: "review-draft-summary-publish-review",
+                    systemName: "arrow.up.doc",
+                    label: "Publish review",
+                    enabled: true
+                ) {
+                    draftCommentActions.publishReview()
+                }
+            }
             if shouldShowSendToAgent {
                 collapsedSendToAgentControl
             }
@@ -177,6 +191,27 @@ struct ReviewDraftSummaryRail: View {
                         draftCommentActions.copyPrompt(bundle)
                     }
                 )
+
+                if canPublishReview {
+                    Button {
+                        draftCommentActions.publishReview()
+                    } label: {
+                        summaryActionIcon(systemName: "arrow.up.doc", enabled: true)
+                    }
+                    .buttonStyle(.plain)
+                    .help("Publish review")
+                    .accessibilityIdentifier("review-draft-summary-publish-review")
+                    .accessibilityLabel("Publish review")
+                    .background(
+                        ReviewDraftSummaryPressMarker(
+                            identifier: "review-draft-summary-publish-review",
+                            label: "Publish review",
+                            isEnabled: true
+                        ) {
+                            draftCommentActions.publishReview()
+                        }
+                    )
+                }
 
                 if shouldShowSendToAgent {
                     expandedSendToAgentControl

--- a/Alas/Sources/Center/ReviewWorkspace/ReviewSessionLoader.swift
+++ b/Alas/Sources/Center/ReviewWorkspace/ReviewSessionLoader.swift
@@ -78,7 +78,11 @@ struct ReviewSessionLoader {
     }
 
     @MainActor
-    static func production(appState: AppState, worktree: Worktree) -> ReviewSessionLoader {
+    static func production(
+        appState: AppState,
+        worktree: Worktree,
+        providerRegistry: CodeHostProviderRegistry = .live()
+    ) -> ReviewSessionLoader {
         let changesLoader = ReviewChangesLoader()
         let git = GitService()
         let commitLoader = CommitReviewLoader(git: git)
@@ -114,8 +118,49 @@ struct ReviewSessionLoader {
                     }
                 )
             },
-            reviewRequest: { _ in
-                throw ReviewSessionLoaderError.unsupportedTarget
+            reviewRequest: { target in
+                guard case .reviewRequest(let providerKind, let host, let repositorySlug, let number, _) = target.payload,
+                      let provider = providerRegistry.provider(for: providerKind),
+                      let separatorIndex = repositorySlug.lastIndex(of: "/")
+                else {
+                    throw ReviewSessionLoaderError.unsupportedTarget
+                }
+                let owner = String(repositorySlug[..<separatorIndex])
+                let repository = String(repositorySlug[repositorySlug.index(after: separatorIndex)...])
+                guard !owner.isEmpty, !repository.isEmpty else {
+                    throw ReviewSessionLoaderError.unsupportedTarget
+                }
+                let remote = CodeHostRemote(
+                    kind: providerKind,
+                    host: host,
+                    owner: owner,
+                    repository: repository,
+                    remoteName: "origin",
+                    webURL: target.providerURL ?? URL(string: "https://\(host)/\(repositorySlug)")!
+                )
+                let request = ReviewRequest(
+                    remote: remote,
+                    number: number,
+                    title: target.title,
+                    url: target.providerURL ?? remote.webURL,
+                    state: .open,
+                    isDraft: false,
+                    headRefName: "",
+                    baseRefName: "",
+                    reviewDecision: .unknown,
+                    mergeState: .unknown,
+                    checks: [],
+                    threads: []
+                )
+                let loadedSession = try await ReviewRequestDiffLoader(provider: provider).load(
+                    remote: remote,
+                    request: request,
+                    cwd: target.repositoryPath
+                )
+                return ReviewSessionProviderLoadedSession(
+                    loadedSession: loadedSession,
+                    providerContext: ReviewSessionProviderContext(remote: remote, reviewRequest: request)
+                )
             },
             draftReviewRequest: { target in
                 guard case .draftReviewRequest(_, _, let base, let head, let headSHA) = target.payload else {

--- a/Alas/Sources/Center/ReviewWorkspace/ReviewSessionLoader.swift
+++ b/Alas/Sources/Center/ReviewWorkspace/ReviewSessionLoader.swift
@@ -1,8 +1,19 @@
 import Foundation
 
+struct ReviewSessionProviderContext: Equatable, Sendable {
+    let remote: CodeHostRemote
+    let reviewRequest: ReviewRequest
+}
+
+struct ReviewSessionProviderLoadedSession {
+    let loadedSession: DiffReviewLoadedSession
+    let providerContext: ReviewSessionProviderContext
+}
+
 struct ReviewSessionLoadedContext {
     let session: DiffReviewLoadedSession
     let feedbackTarget: ReviewFeedbackTarget
+    let providerContext: ReviewSessionProviderContext?
 }
 
 enum ReviewSessionLauncher {
@@ -45,7 +56,7 @@ struct ReviewSessionLoader {
     var commit: (ReviewSessionTarget) async throws -> DiffReviewLoadedSession
     var commitRange: (ReviewSessionTarget) async throws -> DiffReviewLoadedSession
     var branch: (ReviewSessionTarget) async throws -> DiffReviewLoadedSession
-    var reviewRequest: (ReviewSessionTarget) async throws -> DiffReviewLoadedSession
+    var reviewRequest: (ReviewSessionTarget) async throws -> ReviewSessionProviderLoadedSession
     var draftReviewRequest: (ReviewSessionTarget) async throws -> DiffReviewLoadedSession
 
     init(
@@ -54,7 +65,7 @@ struct ReviewSessionLoader {
         commit: @escaping (ReviewSessionTarget) async throws -> DiffReviewLoadedSession = { _ in throw ReviewSessionLoaderError.unsupportedTarget },
         commitRange: @escaping (ReviewSessionTarget) async throws -> DiffReviewLoadedSession = { _ in throw ReviewSessionLoaderError.unsupportedTarget },
         branch: @escaping (ReviewSessionTarget) async throws -> DiffReviewLoadedSession = { _ in throw ReviewSessionLoaderError.unsupportedTarget },
-        reviewRequest: @escaping (ReviewSessionTarget) async throws -> DiffReviewLoadedSession = { _ in throw ReviewSessionLoaderError.unsupportedTarget },
+        reviewRequest: @escaping (ReviewSessionTarget) async throws -> ReviewSessionProviderLoadedSession = { _ in throw ReviewSessionLoaderError.unsupportedTarget },
         draftReviewRequest: @escaping (ReviewSessionTarget) async throws -> DiffReviewLoadedSession = { _ in throw ReviewSessionLoaderError.unsupportedTarget }
     ) {
         self.localChanges = localChanges
@@ -151,21 +162,30 @@ struct ReviewSessionLoader {
         try Task.checkCancellation()
 
         let session: DiffReviewLoadedSession
+        let providerContext: ReviewSessionProviderContext?
         switch target.kind {
         case .localChanges:
             session = try await localChanges(target)
+            providerContext = nil
         case .draftCommit:
             session = try await draftCommit(target)
+            providerContext = nil
         case .commit:
             session = try await commit(target)
+            providerContext = nil
         case .commitRange:
             session = try await commitRange(target)
+            providerContext = nil
         case .branch:
             session = try await branch(target)
+            providerContext = nil
         case .reviewRequest:
-            session = try await reviewRequest(target)
+            let loaded = try await reviewRequest(target)
+            session = loaded.loadedSession
+            providerContext = loaded.providerContext
         case .draftReviewRequest:
             session = try await draftReviewRequest(target)
+            providerContext = nil
         }
 
         try Task.checkCancellation()
@@ -180,7 +200,8 @@ struct ReviewSessionLoader {
                 sessionDescription: "Review session: \(target.title)",
                 revisionDescription: target.revisionDescription,
                 priorHandoffDescription: nil
-            )
+            ),
+            providerContext: providerContext
         )
     }
 

--- a/Alas/Sources/Center/ReviewWorkspace/ReviewSessionLoader.swift
+++ b/Alas/Sources/Center/ReviewWorkspace/ReviewSessionLoader.swift
@@ -138,20 +138,7 @@ struct ReviewSessionLoader {
                     remoteName: "origin",
                     webURL: target.providerURL ?? URL(string: "https://\(host)/\(repositorySlug)")!
                 )
-                let request = ReviewRequest(
-                    remote: remote,
-                    number: number,
-                    title: target.title,
-                    url: target.providerURL ?? remote.webURL,
-                    state: .open,
-                    isDraft: false,
-                    headRefName: "",
-                    baseRefName: "",
-                    reviewDecision: .unknown,
-                    mergeState: .unknown,
-                    checks: [],
-                    threads: []
-                )
+                let request = try await provider.reviewRequest(remote: remote, number: number, cwd: target.repositoryPath)
                 let loadedSession = try await ReviewRequestDiffLoader(provider: provider).load(
                     remote: remote,
                     request: request,

--- a/Alas/Sources/Center/ReviewWorkspace/ReviewSessionTabView.swift
+++ b/Alas/Sources/Center/ReviewWorkspace/ReviewSessionTabView.swift
@@ -691,13 +691,21 @@ struct ReviewSessionTabView: View {
             guard let location = thread.location,
                   let file = matcher.file(for: location)
             else { continue }
+            let status: ReviewEvidenceStatus
+            if thread.isResolved {
+                status = .resolved
+            } else if thread.isActionable {
+                status = .actionable
+            } else {
+                status = .unknown
+            }
 
             let feedback = DiffReviewInlineFeedback(
                 id: thread.id,
                 providerName: providerName,
                 author: thread.author,
                 bodyPreview: String(thread.body.prefix(240)),
-                status: thread.isResolved ? .resolved : .actionable,
+                status: status,
                 providerURL: thread.url,
                 anchor: DiffReviewInlineFeedbackAnchor(
                     path: Self.inlineFeedbackAnchorPath(for: location, matchedFile: file),
@@ -752,8 +760,8 @@ struct ReviewSessionTabView: View {
                 canOpenProvider: item.providerURL != nil,
                 canCopyContext: true,
                 canSendToAgent: false,
-                canReplyProvider: capabilities.canReplyToReviewThreads,
-                canResolveProvider: item.status != .resolved && capabilities.canResolveReviewThreads,
+                canReplyProvider: item.status == .actionable && capabilities.canReplyToReviewThreads,
+                canResolveProvider: item.status == .actionable && capabilities.canResolveReviewThreads,
                 canUnresolveProvider: item.status == .resolved && capabilities.canUnresolveReviewThreads
             )
         }
@@ -820,7 +828,7 @@ struct ReviewSessionTabView: View {
             body: item.bodyPreview,
             url: item.providerURL,
             isResolved: item.status == .resolved,
-            isActionable: item.status != .resolved,
+            isActionable: item.status == .actionable,
             location: ReviewThreadLocation(
                 path: item.anchor.path,
                 originalPath: file.originalPath,

--- a/Alas/Sources/Center/ReviewWorkspace/ReviewSessionTabView.swift
+++ b/Alas/Sources/Center/ReviewWorkspace/ReviewSessionTabView.swift
@@ -48,6 +48,14 @@ struct ReviewSessionTabLoadPublication {
     }
 }
 
+struct ProviderReviewPublishConfirmationState: Equatable {
+    let commentID: String?
+    let providerName: String
+    let reviewIdentity: String
+    let commentCount: Int
+    let unpublishableMessages: [String]
+}
+
 struct ReviewSessionTabView: View {
     let worktree: Worktree?
     let tabState: ReviewSessionTabState
@@ -79,6 +87,10 @@ struct ReviewSessionTabView: View {
     @State private var draftCommentScrollController = DiffReviewDraftCommentScrollController()
     @State private var loadCoordinator = ReviewSessionTabLoadCoordinator()
     @State private var loadGeneration = 0
+    @State private var providerPublishConfirmation: ProviderReviewPublishConfirmationState?
+    @State private var selectedProviderDecision = ProviderReviewDecision.comment
+    @State private var isProviderPublishing = false
+    @State private var providerPublishError: String?
 
     init(worktree: Worktree, tabState: ReviewSessionTabState, appState: AppState) {
         self.worktree = worktree
@@ -124,6 +136,15 @@ struct ReviewSessionTabView: View {
         self._loaded = State(initialValue: loaded)
         self._selectedFileID = State(initialValue: record?.selectedFileID ?? tabState.selectedFileID)
         self._focusedDraftCommentID = State(initialValue: record?.focusedCommentID ?? tabState.focusedCommentID)
+        if let record {
+            let controller = ReviewDraftCommentController(
+                sessionID: record.target.draftSessionID,
+                store: draftCommentStore
+            )
+            try? controller.load()
+            self._draftCommentController = State(initialValue: controller)
+            self._loadedDraftSessionID = State(initialValue: record.target.draftSessionID)
+        }
     }
 
     static func preview(record: ReviewSessionRecord, loaded: ReviewSessionLoadedContext) -> some View {
@@ -137,6 +158,24 @@ struct ReviewSessionTabView: View {
         )
     }
 
+    static func testView(
+        record: ReviewSessionRecord,
+        loaded: ReviewSessionLoadedContext,
+        draftCommentStore: ReviewDraftCommentStore = ReviewDraftCommentStore(),
+        provider: any CodeHostProvider
+    ) -> some View {
+        ReviewSessionTabView(
+            tabState: ReviewSessionTabState(worktreeId: record.target.worktreeID, record: record),
+            record: record,
+            loaded: loaded,
+            draftCommentStore: draftCommentStore,
+            feedbackSender: ReviewFeedbackAgentSender(availableTargets: { [] }, send: { _, _, _ in }),
+            providerRegistry: CodeHostProviderRegistry(providers: [provider.kind: provider]),
+            loadsOnAppear: false,
+            persistsState: false
+        )
+    }
+
     var body: some View {
         VStack(spacing: 0) {
             header
@@ -145,6 +184,7 @@ struct ReviewSessionTabView: View {
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
         .background(theme.color("bg-1"))
+        .overlay(providerPublishConfirmationOverlay)
         .task(id: loadTaskID) {
             guard loadsOnAppear else { return }
             let token = beginLoadReviewSession()
@@ -249,11 +289,13 @@ struct ReviewSessionTabView: View {
             showsRailDisplayControls: true,
             showsDraftSummaryRail: true,
             lspContextForFile: makeLSPContext,
+            inlineFeedbackByFileID: inlineFeedbackByFileID(for: loaded),
+            inlineFeedbackActions: inlineFeedbackActions(for: loaded),
             reviewFeedbackTarget: loaded.feedbackTarget,
             draftCommentsByFileID: ReviewDraftCommentGrouping.commentsByFileID(draftCommentController?.comments ?? []),
             focusedDraftCommentID: focusedDraftCommentID,
             draftCommentScrollCommand: draftCommentScrollCommand,
-            draftCommentActions: draftCommentActions(),
+            draftCommentActions: draftCommentActions(for: loaded),
             onSelectDraftComment: selectDraftComment,
             onSaveDraftComment: saveDraftComment
         )
@@ -394,14 +436,30 @@ struct ReviewSessionTabView: View {
         }
     }
 
-    private func draftCommentActions() -> ReviewDraftCommentActions {
-        ReviewDraftWorkspaceActions.make(
+    private func draftCommentActions(for loaded: ReviewSessionLoadedContext) -> ReviewDraftCommentActions {
+        var actions = ReviewDraftWorkspaceActions.make(
             controller: draftCommentController,
             sender: feedbackSender,
             sessionID: tabState.sessionID,
             recordHandoff: recordSessionHandoff,
             recordSendFailure: recordSessionSendFailure
         )
+        let baseAvailability = actions.availability
+        actions.availability = { comment in
+            var availability = baseAvailability(comment)
+            availability.canPublishProvider = canPublishProvider(comment, in: loaded)
+            return availability
+        }
+        actions.canPublishReview = {
+            canPublishProviderReview(in: loaded)
+        }
+        actions.publishProvider = { comment in
+            openProviderPublishConfirmation(commentID: comment.id, loaded: loaded)
+        }
+        actions.publishReview = {
+            openProviderPublishConfirmation(commentID: nil, loaded: loaded)
+        }
+        return actions
     }
 
     private func makeProviderMutationController(for loaded: ReviewSessionLoadedContext) -> ProviderReviewMutationController? {
@@ -410,6 +468,264 @@ struct ReviewSessionTabView: View {
             draftCommentController: draftCommentController,
             providerRegistry: providerRegistry,
             now: now
+        )
+    }
+
+    private func canPublishProvider(_ comment: ReviewDraftComment, in loaded: ReviewSessionLoadedContext) -> Bool {
+        guard loaded.providerContext != nil else { return false }
+        return ProviderReviewDraftComment(localDraft: comment) != nil
+    }
+
+    private func canPublishProviderReview(in loaded: ReviewSessionLoadedContext) -> Bool {
+        guard loaded.providerContext != nil else { return false }
+        return draftCommentController?.activeUnpublishedComments.contains { comment in
+            ProviderReviewDraftComment(localDraft: comment) != nil
+        } ?? false
+    }
+
+    private func openProviderPublishConfirmation(commentID: String?, loaded: ReviewSessionLoadedContext) {
+        guard let providerContext = loaded.providerContext else { return }
+        let comments = providerPublishableComments(commentID: commentID)
+        guard !comments.isEmpty else { return }
+        selectedProviderDecision = .comment
+        providerPublishError = nil
+        providerPublishConfirmation = ProviderReviewPublishConfirmationState(
+            commentID: commentID,
+            providerName: providerContext.remote.kind.displayName,
+            reviewIdentity: providerContext.reviewRequest.displayIdentity,
+            commentCount: comments.count,
+            unpublishableMessages: providerUnpublishableMessages(commentID: commentID)
+        )
+    }
+
+    private func providerPublishableComments(commentID: String?) -> [ReviewDraftComment] {
+        let comments = draftCommentController?.activeUnpublishedComments ?? []
+        let filtered = commentID.map { id in comments.filter { $0.id == id } } ?? comments
+        return filtered.filter { ProviderReviewDraftComment(localDraft: $0) != nil }
+    }
+
+    private func providerUnpublishableMessages(commentID: String?) -> [String] {
+        let comments = draftCommentController?.activeUnpublishedComments ?? []
+        let filtered = commentID.map { id in comments.filter { $0.id == id } } ?? comments
+        return filtered.compactMap { comment in
+            ProviderReviewDraftComment(localDraft: comment) == nil ? "\(comment.path): cannot publish this draft" : nil
+        }
+    }
+
+    @ViewBuilder
+    private var providerPublishConfirmationOverlay: some View {
+        if let providerPublishConfirmation {
+            ZStack {
+                theme.color("bg-0").opacity(0.45)
+                    .ignoresSafeArea()
+                ProviderReviewPublishConfirmationView(
+                    providerName: providerPublishConfirmation.providerName,
+                    reviewIdentity: providerPublishConfirmation.reviewIdentity,
+                    commentCount: providerPublishConfirmation.commentCount,
+                    unpublishableMessages: providerPublishConfirmation.unpublishableMessages,
+                    selectedDecision: $selectedProviderDecision,
+                    isPublishing: isProviderPublishing,
+                    errorMessage: providerPublishError,
+                    onCancel: {
+                        self.providerPublishConfirmation = nil
+                        providerPublishError = nil
+                    },
+                    onConfirm: {
+                        Task { @MainActor in
+                            await confirmProviderPublish()
+                        }
+                    }
+                )
+            }
+        }
+    }
+
+    private func confirmProviderPublish() async {
+        guard providerPublishConfirmation != nil,
+              let loaded,
+              let providerContext = loaded.providerContext,
+              let controller = makeProviderMutationController(for: loaded)
+        else { return }
+
+        isProviderPublishing = true
+        providerPublishError = nil
+        defer { isProviderPublishing = false }
+
+        do {
+            let result = try await controller.publishReview(
+                remote: providerContext.remote,
+                reviewRequest: providerContext.reviewRequest,
+                decision: selectedProviderDecision,
+                summaryBody: "",
+                cwd: record?.target.repositoryPath ?? URL(fileURLWithPath: loaded.feedbackTarget.repositoryPath ?? "/")
+            )
+            replaceProviderReviewRequest(result.refreshedRequest)
+            providerPublishConfirmation = nil
+        } catch {
+            providerPublishError = error.localizedDescription
+        }
+    }
+
+    private func inlineFeedbackByFileID(for loaded: ReviewSessionLoadedContext) -> [DiffReviewFileID: [DiffReviewInlineFeedback]] {
+        guard let providerContext = loaded.providerContext else { return [:] }
+        return Self.inlineFeedbackByFileID(
+            threads: providerContext.reviewRequest.threads,
+            files: loaded.session.summary.files,
+            providerName: providerContext.remote.kind.displayName
+        )
+    }
+
+    static func inlineFeedbackByFileID(
+        threads: [ReviewThreadSummary],
+        files: [DiffReviewFileSummary],
+        providerName: String
+    ) -> [DiffReviewFileID: [DiffReviewInlineFeedback]] {
+        var grouped: [DiffReviewFileID: [DiffReviewInlineFeedback]] = [:]
+        let matcher = ReviewSessionInlineFeedbackFileMatcher(files: files)
+        for thread in threads {
+            guard let location = thread.location,
+                  let file = matcher.file(for: location)
+            else { continue }
+
+            let feedback = DiffReviewInlineFeedback(
+                id: thread.id,
+                providerName: providerName,
+                author: thread.author,
+                bodyPreview: String(thread.body.prefix(240)),
+                status: thread.isResolved ? .resolved : .actionable,
+                providerURL: thread.url,
+                anchor: DiffReviewInlineFeedbackAnchor(
+                    path: Self.inlineFeedbackAnchorPath(for: location, matchedFile: file),
+                    line: location.line,
+                    side: DiffReviewInlineFeedbackSide(location.side)
+                ),
+                evidenceItemID: thread.id
+            )
+            grouped[file.id, default: []].append(feedback)
+        }
+
+        return grouped.mapValues { feedback in
+            feedback.sorted { lhs, rhs in
+                switch (lhs.anchor.line, rhs.anchor.line) {
+                case (nil, nil):
+                    return lhs.id < rhs.id
+                case (nil, _?):
+                    return true
+                case (_?, nil):
+                    return false
+                case (let lhsLine?, let rhsLine?):
+                    if lhsLine != rhsLine {
+                        return lhsLine < rhsLine
+                    }
+                    return lhs.id < rhs.id
+                }
+            }
+        }
+    }
+
+    private static func inlineFeedbackAnchorPath(
+        for location: ReviewThreadLocation,
+        matchedFile file: DiffReviewFileSummary
+    ) -> String {
+        switch location.side {
+        case .old:
+            location.originalPath ?? file.originalPath ?? location.path
+        case .new, .unknown:
+            location.path
+        }
+    }
+
+    private func inlineFeedbackActions(for loaded: ReviewSessionLoadedContext) -> DiffReviewInlineFeedbackActions {
+        var actions = DiffReviewInlineFeedbackActions()
+        actions.availability = { item, _ in
+            guard let providerContext = loaded.providerContext,
+                  let provider = providerRegistry.provider(for: providerContext.remote.kind)
+            else { return .none }
+
+            let capabilities = provider.capabilities
+            return DiffReviewInlineFeedbackActionAvailability(
+                canOpenProvider: item.providerURL != nil,
+                canCopyContext: true,
+                canSendToAgent: false,
+                canReplyProvider: capabilities.canReplyToReviewThreads,
+                canResolveProvider: item.status != .resolved && capabilities.canResolveReviewThreads,
+                canUnresolveProvider: item.status == .resolved && capabilities.canUnresolveReviewThreads
+            )
+        }
+        actions.replyProvider = { item, file, body in
+            Task { await mutateProviderThread(item, file: file, loaded: loaded, kind: .reply, body: body) }
+        }
+        actions.resolveProvider = { item, file in
+            Task { await mutateProviderThread(item, file: file, loaded: loaded, kind: .resolve, body: nil) }
+        }
+        actions.unresolveProvider = { item, file in
+            Task { await mutateProviderThread(item, file: file, loaded: loaded, kind: .unresolve, body: nil) }
+        }
+        return actions
+    }
+
+    private func mutateProviderThread(
+        _ item: DiffReviewInlineFeedback,
+        file: DiffReviewFileSummary,
+        loaded: ReviewSessionLoadedContext,
+        kind: ProviderThreadMutationKind,
+        body: String?
+    ) async {
+        guard let providerContext = loaded.providerContext,
+              let controller = makeProviderMutationController(for: loaded)
+        else { return }
+
+        do {
+            let result = try await controller.mutateThread(
+                ProviderThreadMutation(
+                    remote: providerContext.remote,
+                    reviewRequest: providerContext.reviewRequest,
+                    thread: reviewThreadSummary(item, file: file),
+                    kind: kind,
+                    bodyMarkdown: body,
+                    cwd: record?.target.repositoryPath ?? URL(fileURLWithPath: loaded.feedbackTarget.repositoryPath ?? "/")
+                )
+            )
+            replaceProviderReviewRequest(result.refreshedRequest)
+        } catch {
+            providerPublishError = error.localizedDescription
+        }
+    }
+
+    private func reviewThreadSummary(
+        _ item: DiffReviewInlineFeedback,
+        file: DiffReviewFileSummary
+    ) -> ReviewThreadSummary {
+        ReviewThreadSummary(
+            id: item.id,
+            author: item.author,
+            body: item.bodyPreview,
+            url: item.providerURL,
+            isResolved: item.status == .resolved,
+            isActionable: item.status != .resolved,
+            location: ReviewThreadLocation(
+                path: item.anchor.path,
+                originalPath: file.originalPath,
+                line: item.anchor.line,
+                side: ReviewThreadSide(item.anchor.side),
+                providerPosition: nil
+            ),
+            providerThreadID: item.id,
+            providerCommentID: nil
+        )
+    }
+
+    private func replaceProviderReviewRequest(_ reviewRequest: ReviewRequest) {
+        guard let current = loaded,
+              let providerContext = current.providerContext
+        else { return }
+        loaded = ReviewSessionLoadedContext(
+            session: current.session,
+            feedbackTarget: current.feedbackTarget,
+            providerContext: ReviewSessionProviderContext(
+                remote: providerContext.remote,
+                reviewRequest: reviewRequest
+            )
         )
     }
 
@@ -560,6 +876,76 @@ enum ReviewSessionHandoffPersistence {
             visibleRecord.lastSendError = "Sent to agent, but failed to save handoff record: \(error.localizedDescription)"
             visibleRecord.updatedAt = now()
             return visibleRecord
+        }
+    }
+}
+
+private struct ReviewSessionInlineFeedbackFileMatcher {
+    private let filesByPath: [String: DiffReviewFileSummary]
+    private let filesByOriginalPath: [String: DiffReviewFileSummary]
+
+    init(files: [DiffReviewFileSummary]) {
+        self.filesByPath = Self.uniqueFiles(files) { $0.path }
+        self.filesByOriginalPath = Self.uniqueFiles(
+            files.compactMap { file in file.originalPath == nil ? nil : file },
+            keyedBy: { $0.originalPath }
+        )
+    }
+
+    func file(for location: ReviewThreadLocation) -> DiffReviewFileSummary? {
+        switch location.side {
+        case .new:
+            filesByPath[location.path]
+                ?? location.originalPath.flatMap { filesByOriginalPath[$0] }
+                ?? filesByOriginalPath[location.path]
+        case .old:
+            location.originalPath.flatMap { filesByOriginalPath[$0] }
+                ?? filesByOriginalPath[location.path]
+                ?? filesByPath[location.path]
+        case .unknown:
+            filesByPath[location.path]
+                ?? location.originalPath.flatMap { filesByOriginalPath[$0] }
+                ?? filesByOriginalPath[location.path]
+        }
+    }
+
+    private static func uniqueFiles(
+        _ files: [DiffReviewFileSummary],
+        keyedBy key: (DiffReviewFileSummary) -> String?
+    ) -> [String: DiffReviewFileSummary] {
+        var counts: [String: Int] = [:]
+        var matches: [String: DiffReviewFileSummary] = [:]
+        for file in files {
+            guard let value = key(file), !value.isEmpty else { continue }
+            counts[value, default: 0] += 1
+            matches[value] = file
+        }
+        return matches.filter { counts[$0.key] == 1 }
+    }
+}
+
+private extension DiffReviewInlineFeedbackSide {
+    init(_ side: ReviewThreadSide) {
+        switch side {
+        case .old:
+            self = .old
+        case .new:
+            self = .new
+        case .unknown:
+            self = .unknown
+        }
+    }
+}
+
+private extension ReviewThreadSide {
+    init(_ side: DiffReviewInlineFeedbackSide) {
+        switch side {
+        case .old:
+            self = .old
+        case .new:
+            self = .new
+        case .unknown:
+            self = .unknown
         }
     }
 }

--- a/Alas/Sources/Center/ReviewWorkspace/ReviewSessionTabView.swift
+++ b/Alas/Sources/Center/ReviewWorkspace/ReviewSessionTabView.swift
@@ -90,6 +90,7 @@ struct ReviewSessionTabView: View {
     @State private var loadGeneration = 0
     @State private var providerPublishConfirmation: ProviderReviewPublishConfirmationState?
     @State private var selectedProviderDecision = ProviderReviewDecision.comment
+    @State private var providerReviewSummaryBody = ""
     @State private var isProviderPublishing = false
     @State private var providerPublishError: String?
 
@@ -549,6 +550,7 @@ struct ReviewSessionTabView: View {
         selectedProviderDecision = Self.defaultProviderDecision(
             allowedDecisions: allowedDecisions
         )
+        providerReviewSummaryBody = ""
         providerPublishError = nil
         providerPublishConfirmation = ProviderReviewPublishConfirmationState(
             commentID: commentID,
@@ -611,6 +613,7 @@ struct ReviewSessionTabView: View {
                     unpublishableMessages: providerPublishConfirmation.unpublishableMessages,
                     allowedDecisions: providerPublishConfirmation.allowedDecisions,
                     selectedDecision: $selectedProviderDecision,
+                    summaryBody: $providerReviewSummaryBody,
                     isPublishing: isProviderPublishing,
                     errorMessage: providerPublishError,
                     onCancel: {
@@ -644,12 +647,17 @@ struct ReviewSessionTabView: View {
                 providerPublishError = "\(selectedProviderDecision.displayName) is not supported by this provider."
                 return
             }
+            let summaryBody = providerReviewSummaryBody.trimmingCharacters(in: .whitespacesAndNewlines)
+            if selectedProviderDecision.requiresSummaryBody, summaryBody.isEmpty {
+                providerPublishError = "\(selectedProviderDecision.displayName) requires a review summary."
+                return
+            }
             let selectedDraftIDs = confirmation.commentID.map { Set([$0]) }
             let result = try await controller.publishReview(
                 remote: providerContext.remote,
                 reviewRequest: providerContext.reviewRequest,
                 decision: selectedProviderDecision,
-                summaryBody: "",
+                summaryBody: summaryBody,
                 cwd: record?.target.repositoryPath ?? URL(fileURLWithPath: loaded.feedbackTarget.repositoryPath ?? "/"),
                 localDraftIDs: selectedDraftIDs
             )

--- a/Alas/Sources/Center/ReviewWorkspace/ReviewSessionTabView.swift
+++ b/Alas/Sources/Center/ReviewWorkspace/ReviewSessionTabView.swift
@@ -56,6 +56,7 @@ struct ReviewSessionTabView: View {
     var draftCommentStore: ReviewDraftCommentStore
     var loader: ReviewSessionLoader
     var feedbackSender: ReviewFeedbackAgentSender
+    var providerRegistry: CodeHostProviderRegistry
     var loadsOnAppear: Bool
     var persistsState: Bool
     var now: () -> Date
@@ -87,6 +88,7 @@ struct ReviewSessionTabView: View {
         self.draftCommentStore = ReviewDraftCommentStore()
         self.loader = ReviewSessionLoader.production(appState: appState, worktree: worktree)
         self.feedbackSender = ReviewFeedbackAgentSender.production(appState: appState, worktreeID: worktree.id)
+        self.providerRegistry = .live()
         self.loadsOnAppear = true
         self.persistsState = true
         self.now = Date.init
@@ -102,6 +104,7 @@ struct ReviewSessionTabView: View {
         draftCommentStore: ReviewDraftCommentStore = ReviewDraftCommentStore(),
         loader: ReviewSessionLoader = ReviewSessionLoader(),
         feedbackSender: ReviewFeedbackAgentSender,
+        providerRegistry: CodeHostProviderRegistry = .live(),
         loadsOnAppear: Bool,
         persistsState: Bool,
         now: @escaping () -> Date = Date.init
@@ -113,6 +116,7 @@ struct ReviewSessionTabView: View {
         self.draftCommentStore = draftCommentStore
         self.loader = loader
         self.feedbackSender = feedbackSender
+        self.providerRegistry = providerRegistry
         self.loadsOnAppear = loadsOnAppear
         self.persistsState = persistsState
         self.now = now
@@ -397,6 +401,33 @@ struct ReviewSessionTabView: View {
             sessionID: tabState.sessionID,
             recordHandoff: recordSessionHandoff,
             recordSendFailure: recordSessionSendFailure
+        )
+    }
+
+    private func makeProviderMutationController(for loaded: ReviewSessionLoadedContext) -> ProviderReviewMutationController? {
+        Self.makeProviderMutationController(
+            loaded: loaded,
+            draftCommentController: draftCommentController,
+            providerRegistry: providerRegistry,
+            now: now
+        )
+    }
+
+    static func makeProviderMutationController(
+        loaded: ReviewSessionLoadedContext,
+        draftCommentController: ReviewDraftCommentController?,
+        providerRegistry: CodeHostProviderRegistry,
+        now: @escaping () -> Date
+    ) -> ProviderReviewMutationController? {
+        guard let providerContext = loaded.providerContext,
+              let draftCommentController,
+              let provider = providerRegistry.provider(for: providerContext.remote.kind)
+        else { return nil }
+
+        return ProviderReviewMutationController(
+            provider: provider,
+            draftController: draftCommentController,
+            now: now
         )
     }
 

--- a/Alas/Sources/Center/ReviewWorkspace/ReviewSessionTabView.swift
+++ b/Alas/Sources/Center/ReviewWorkspace/ReviewSessionTabView.swift
@@ -1011,7 +1011,7 @@ enum ReviewSessionHandoffPersistence {
     }
 }
 
-private struct ReviewSessionInlineFeedbackFileMatcher {
+struct ReviewSessionInlineFeedbackFileMatcher {
     private let filesByPath: [String: DiffReviewFileSummary]
     private let filesByOriginalPath: [String: DiffReviewFileSummary]
 
@@ -1026,15 +1026,19 @@ private struct ReviewSessionInlineFeedbackFileMatcher {
     func file(for location: ReviewThreadLocation) -> DiffReviewFileSummary? {
         switch location.side {
         case .new:
-            filesByPath[location.path]
+            return filesByPath[location.path]
                 ?? location.originalPath.flatMap { filesByOriginalPath[$0] }
                 ?? filesByOriginalPath[location.path]
         case .old:
-            location.originalPath.flatMap { filesByOriginalPath[$0] }
+            if let originalPath = location.originalPath, originalPath != location.path {
+                return filesByOriginalPath[originalPath]
+                    ?? filesByPath[location.path]
+                    ?? filesByOriginalPath[location.path]
+            }
+            return filesByPath[location.path]
                 ?? filesByOriginalPath[location.path]
-                ?? filesByPath[location.path]
         case .unknown:
-            filesByPath[location.path]
+            return filesByPath[location.path]
                 ?? location.originalPath.flatMap { filesByOriginalPath[$0] }
                 ?? filesByOriginalPath[location.path]
         }

--- a/Alas/Sources/Center/ReviewWorkspace/ReviewSessionTabView.swift
+++ b/Alas/Sources/Center/ReviewWorkspace/ReviewSessionTabView.swift
@@ -541,6 +541,7 @@ struct ReviewSessionTabView: View {
     }
 
     private func confirmProviderPublish() async {
+        guard !isProviderPublishing else { return }
         guard let confirmation = providerPublishConfirmation,
               let loaded,
               let providerContext = loaded.providerContext,

--- a/Alas/Sources/Center/ReviewWorkspace/ReviewSessionTabView.swift
+++ b/Alas/Sources/Center/ReviewWorkspace/ReviewSessionTabView.swift
@@ -477,16 +477,31 @@ struct ReviewSessionTabView: View {
     }
 
     private func canPublishProviderReview(in loaded: ReviewSessionLoadedContext) -> Bool {
-        guard loaded.providerContext != nil else { return false }
-        return !ProviderReviewPublishPlanner.publishableDrafts(draftCommentController?.comments ?? []).isEmpty
+        guard let providerContext = loaded.providerContext,
+              let provider = providerRegistry.provider(for: providerContext.remote.kind)
+        else { return false }
+        let capabilities = provider.capabilities
+        return capabilities.canPublishReviewComments
+            || capabilities.canApproveReview
+            || capabilities.canRequestChanges
     }
 
     private func openProviderPublishConfirmation(commentID: String?, loaded: ReviewSessionLoadedContext) {
-        guard let providerContext = loaded.providerContext else { return }
+        guard let providerContext = loaded.providerContext,
+              let provider = providerRegistry.provider(for: providerContext.remote.kind)
+        else { return }
         let comments = providerPublishableComments(commentID: commentID)
         let unpublishableMessages = providerUnpublishableMessages(commentID: commentID)
-        guard !comments.isEmpty || !unpublishableMessages.isEmpty else { return }
-        selectedProviderDecision = .comment
+        guard commentID == nil || !comments.isEmpty || !unpublishableMessages.isEmpty else { return }
+        guard !comments.isEmpty
+            || !unpublishableMessages.isEmpty
+            || provider.capabilities.canApproveReview
+            || provider.capabilities.canRequestChanges
+        else { return }
+        selectedProviderDecision = Self.defaultProviderDecision(
+            commentCount: comments.count,
+            capabilities: provider.capabilities
+        )
         providerPublishError = nil
         providerPublishConfirmation = ProviderReviewPublishConfirmationState(
             commentID: commentID,
@@ -495,6 +510,22 @@ struct ReviewSessionTabView: View {
             commentCount: comments.count,
             unpublishableMessages: unpublishableMessages
         )
+    }
+
+    private static func defaultProviderDecision(
+        commentCount: Int,
+        capabilities: CodeHostProviderCapabilities
+    ) -> ProviderReviewDecision {
+        if commentCount > 0 {
+            return .comment
+        }
+        if capabilities.canApproveReview {
+            return .approve
+        }
+        if capabilities.canRequestChanges {
+            return .requestChanges
+        }
+        return .comment
     }
 
     private func providerPublishableComments(commentID: String?) -> [ReviewDraftComment] {

--- a/Alas/Sources/Center/ReviewWorkspace/ReviewSessionTabView.swift
+++ b/Alas/Sources/Center/ReviewWorkspace/ReviewSessionTabView.swift
@@ -822,9 +822,14 @@ struct ReviewSessionTabView: View {
         )
     }
 
-    private func saveDraftComment(fileID: DiffReviewFileID, anchor: DiffReviewLineAnchor, body: String) {
+    private func saveDraftComment(
+        fileID: DiffReviewFileID,
+        originalPath: String?,
+        anchor: DiffReviewLineAnchor,
+        body: String
+    ) {
         do {
-            try draftCommentController?.add(anchor: anchor, fileID: fileID, bodyMarkdown: body)
+            try draftCommentController?.add(anchor: anchor, fileID: fileID, originalPath: originalPath, bodyMarkdown: body)
         } catch {
             // Draft comment save failures stay non-blocking; the controller keeps the error.
         }

--- a/Alas/Sources/Center/ReviewWorkspace/ReviewSessionTabView.swift
+++ b/Alas/Sources/Center/ReviewWorkspace/ReviewSessionTabView.swift
@@ -655,6 +655,18 @@ struct ReviewSessionTabView: View {
         actions.replyProvider = { item, file, body in
             Task { await mutateProviderThread(item, file: file, loaded: loaded, kind: .reply, body: body) }
         }
+        actions.openProvider = { item, _ in
+            guard let url = item.providerURL else { return }
+            NSWorkspace.shared.open(url)
+        }
+        actions.copyContext = { item, file in
+            let pasteboard = NSPasteboard.general
+            pasteboard.clearContents()
+            pasteboard.setString(
+                DiffReviewInlineFeedbackContextFormatter.format(item: item, file: file),
+                forType: .string
+            )
+        }
         actions.resolveProvider = { item, file in
             Task { await mutateProviderThread(item, file: file, loaded: loaded, kind: .resolve, body: nil) }
         }

--- a/Alas/Sources/Center/ReviewWorkspace/ReviewSessionTabView.swift
+++ b/Alas/Sources/Center/ReviewWorkspace/ReviewSessionTabView.swift
@@ -541,7 +541,7 @@ struct ReviewSessionTabView: View {
     }
 
     private func confirmProviderPublish() async {
-        guard providerPublishConfirmation != nil,
+        guard let confirmation = providerPublishConfirmation,
               let loaded,
               let providerContext = loaded.providerContext,
               let controller = makeProviderMutationController(for: loaded)
@@ -552,12 +552,14 @@ struct ReviewSessionTabView: View {
         defer { isProviderPublishing = false }
 
         do {
+            let selectedDraftIDs = confirmation.commentID.map { Set([$0]) }
             let result = try await controller.publishReview(
                 remote: providerContext.remote,
                 reviewRequest: providerContext.reviewRequest,
                 decision: selectedProviderDecision,
                 summaryBody: "",
-                cwd: record?.target.repositoryPath ?? URL(fileURLWithPath: loaded.feedbackTarget.repositoryPath ?? "/")
+                cwd: record?.target.repositoryPath ?? URL(fileURLWithPath: loaded.feedbackTarget.repositoryPath ?? "/"),
+                localDraftIDs: selectedDraftIDs
             )
             replaceProviderReviewRequest(result.refreshedRequest)
             providerPublishConfirmation = nil

--- a/Alas/Sources/Center/ReviewWorkspace/ReviewSessionTabView.swift
+++ b/Alas/Sources/Center/ReviewWorkspace/ReviewSessionTabView.swift
@@ -273,34 +273,76 @@ struct ReviewSessionTabView: View {
     }
 
     private func reviewSurface(_ loaded: ReviewSessionLoadedContext) -> some View {
-        DiffReviewSurface(
-            session: loaded.session,
-            selectedFileID: Binding(
-                get: { selectedFileID },
-                set: { setSelectedFileID($0, persist: true) }
-            ),
-            railCollapsed: $railCollapsed,
-            reviewSummaryCollapsed: $reviewSummaryCollapsed,
-            layoutMode: layoutModeBinding,
-            wrapLines: wrapLinesBinding,
-            showWhitespace: showWhitespaceBinding,
-            codeFontFamily: appState?.config.code.fontFamily ?? "",
-            codeFontSize: CGFloat(appState?.config.code.fontSize ?? 13),
-            showsSourceBadges: true,
-            showsRailDisplayControls: true,
-            showsDraftSummaryRail: true,
-            lspContextForFile: makeLSPContext,
-            inlineFeedbackByFileID: inlineFeedbackByFileID(for: loaded),
-            inlineFeedbackActions: inlineFeedbackActions(for: loaded),
-            reviewFeedbackTarget: loaded.feedbackTarget,
-            draftCommentsByFileID: ReviewDraftCommentGrouping.commentsByFileID(draftCommentController?.comments ?? []),
-            focusedDraftCommentID: focusedDraftCommentID,
-            draftCommentScrollCommand: draftCommentScrollCommand,
-            draftCommentActions: draftCommentActions(for: loaded),
-            onSelectDraftComment: selectDraftComment,
-            onSaveDraftComment: saveDraftComment
+        VStack(spacing: 0) {
+            if let providerPublishError, !providerPublishError.isEmpty {
+                providerErrorBanner(providerPublishError)
+            }
+            DiffReviewSurface(
+                session: loaded.session,
+                selectedFileID: Binding(
+                    get: { selectedFileID },
+                    set: { setSelectedFileID($0, persist: true) }
+                ),
+                railCollapsed: $railCollapsed,
+                reviewSummaryCollapsed: $reviewSummaryCollapsed,
+                layoutMode: layoutModeBinding,
+                wrapLines: wrapLinesBinding,
+                showWhitespace: showWhitespaceBinding,
+                codeFontFamily: appState?.config.code.fontFamily ?? "",
+                codeFontSize: CGFloat(appState?.config.code.fontSize ?? 13),
+                showsSourceBadges: true,
+                showsRailDisplayControls: true,
+                showsDraftSummaryRail: true,
+                lspContextForFile: makeLSPContext,
+                inlineFeedbackByFileID: inlineFeedbackByFileID(for: loaded),
+                inlineFeedbackActions: inlineFeedbackActions(for: loaded),
+                reviewFeedbackTarget: loaded.feedbackTarget,
+                draftCommentsByFileID: ReviewDraftCommentGrouping.commentsByFileID(draftCommentController?.comments ?? []),
+                focusedDraftCommentID: focusedDraftCommentID,
+                draftCommentScrollCommand: draftCommentScrollCommand,
+                draftCommentActions: draftCommentActions(for: loaded),
+                onSelectDraftComment: selectDraftComment,
+                onSaveDraftComment: saveDraftComment
+            )
+            .environment(\.reviewDraftSummaryRailStatus, ReviewDraftSummaryRailStatus(record: record))
+        }
+    }
+
+    private func providerErrorBanner(_ message: String) -> some View {
+        HStack(spacing: 8) {
+            Image(systemName: "exclamationmark.triangle")
+                .font(.system(size: 12, weight: .semibold))
+                .foregroundColor(theme.color("del"))
+            Text(message)
+                .font(.system(size: 11))
+                .foregroundColor(theme.color("fg"))
+                .lineLimit(2)
+            Spacer(minLength: 8)
+            Button {
+                providerPublishError = nil
+            } label: {
+                Image(systemName: "xmark")
+                    .font(.system(size: 11, weight: .semibold))
+            }
+            .buttonStyle(.plain)
+            .foregroundColor(theme.color("fg-muted"))
+            .help("Dismiss")
+            .accessibilityIdentifier("review-session-provider-error-dismiss")
+        }
+        .padding(.horizontal, 12)
+        .padding(.vertical, 8)
+        .background(theme.color("del").opacity(0.08))
+        .overlay(alignment: .bottom) {
+            Rectangle()
+                .fill(theme.color("line"))
+                .frame(height: 1)
+        }
+        .background(
+            DiffReviewAccessibilityMarker(
+                identifier: "review-session-provider-error",
+                label: message
+            )
         )
-        .environment(\.reviewDraftSummaryRailStatus, ReviewDraftSummaryRailStatus(record: record))
     }
 
     private var layoutModeBinding: Binding<DiffLayoutMode> {
@@ -751,6 +793,7 @@ struct ReviewSessionTabView: View {
                 )
             )
             replaceProviderReviewRequest(result.refreshedRequest)
+            providerPublishError = nil
         } catch {
             providerPublishError = error.localizedDescription
         }

--- a/Alas/Sources/Center/ReviewWorkspace/ReviewSessionTabView.swift
+++ b/Alas/Sources/Center/ReviewWorkspace/ReviewSessionTabView.swift
@@ -473,20 +473,19 @@ struct ReviewSessionTabView: View {
 
     private func canPublishProvider(_ comment: ReviewDraftComment, in loaded: ReviewSessionLoadedContext) -> Bool {
         guard loaded.providerContext != nil else { return false }
-        return ProviderReviewDraftComment(localDraft: comment) != nil
+        return !ProviderReviewPublishPlanner.publishableDrafts([comment]).isEmpty
     }
 
     private func canPublishProviderReview(in loaded: ReviewSessionLoadedContext) -> Bool {
         guard loaded.providerContext != nil else { return false }
-        return draftCommentController?.activeUnpublishedComments.contains { comment in
-            ProviderReviewDraftComment(localDraft: comment) != nil
-        } ?? false
+        return !ProviderReviewPublishPlanner.publishableDrafts(draftCommentController?.comments ?? []).isEmpty
     }
 
     private func openProviderPublishConfirmation(commentID: String?, loaded: ReviewSessionLoadedContext) {
         guard let providerContext = loaded.providerContext else { return }
         let comments = providerPublishableComments(commentID: commentID)
-        guard !comments.isEmpty else { return }
+        let unpublishableMessages = providerUnpublishableMessages(commentID: commentID)
+        guard !comments.isEmpty || !unpublishableMessages.isEmpty else { return }
         selectedProviderDecision = .comment
         providerPublishError = nil
         providerPublishConfirmation = ProviderReviewPublishConfirmationState(
@@ -494,22 +493,20 @@ struct ReviewSessionTabView: View {
             providerName: providerContext.remote.kind.displayName,
             reviewIdentity: providerContext.reviewRequest.displayIdentity,
             commentCount: comments.count,
-            unpublishableMessages: providerUnpublishableMessages(commentID: commentID)
+            unpublishableMessages: unpublishableMessages
         )
     }
 
     private func providerPublishableComments(commentID: String?) -> [ReviewDraftComment] {
-        let comments = draftCommentController?.activeUnpublishedComments ?? []
+        let comments = draftCommentController?.comments ?? []
         let filtered = commentID.map { id in comments.filter { $0.id == id } } ?? comments
-        return filtered.filter { ProviderReviewDraftComment(localDraft: $0) != nil }
+        return ProviderReviewPublishPlanner.publishableDrafts(filtered)
     }
 
     private func providerUnpublishableMessages(commentID: String?) -> [String] {
-        let comments = draftCommentController?.activeUnpublishedComments ?? []
+        let comments = draftCommentController?.comments ?? []
         let filtered = commentID.map { id in comments.filter { $0.id == id } } ?? comments
-        return filtered.compactMap { comment in
-            ProviderReviewDraftComment(localDraft: comment) == nil ? "\(comment.path): cannot publish this draft" : nil
-        }
+        return ProviderReviewPublishPlanner.unpublishableMessages(filtered)
     }
 
     @ViewBuilder

--- a/Alas/Sources/Center/ReviewWorkspace/ReviewSessionTabView.swift
+++ b/Alas/Sources/Center/ReviewWorkspace/ReviewSessionTabView.swift
@@ -812,7 +812,7 @@ struct ReviewSessionTabView: View {
                 )
             )
             replaceProviderReviewRequest(result.refreshedRequest)
-            providerPublishError = nil
+            providerPublishError = result.warnings.isEmpty ? nil : result.warnings.joined(separator: "\n")
         } catch {
             providerPublishError = error.localizedDescription
         }

--- a/Alas/Sources/Center/ReviewWorkspace/ReviewSessionTabView.swift
+++ b/Alas/Sources/Center/ReviewWorkspace/ReviewSessionTabView.swift
@@ -54,6 +54,7 @@ struct ProviderReviewPublishConfirmationState: Equatable {
     let reviewIdentity: String
     let commentCount: Int
     let unpublishableMessages: [String]
+    let allowedDecisions: [ProviderReviewDecision]
 }
 
 struct ReviewSessionTabView: View {
@@ -498,9 +499,13 @@ struct ReviewSessionTabView: View {
             || provider.capabilities.canApproveReview
             || provider.capabilities.canRequestChanges
         else { return }
-        selectedProviderDecision = Self.defaultProviderDecision(
+        let allowedDecisions = Self.allowedProviderDecisions(
             commentCount: comments.count,
             capabilities: provider.capabilities
+        )
+        guard !allowedDecisions.isEmpty else { return }
+        selectedProviderDecision = Self.defaultProviderDecision(
+            allowedDecisions: allowedDecisions
         )
         providerPublishError = nil
         providerPublishConfirmation = ProviderReviewPublishConfirmationState(
@@ -508,24 +513,35 @@ struct ReviewSessionTabView: View {
             providerName: providerContext.remote.kind.displayName,
             reviewIdentity: providerContext.reviewRequest.displayIdentity,
             commentCount: comments.count,
-            unpublishableMessages: unpublishableMessages
+            unpublishableMessages: unpublishableMessages,
+            allowedDecisions: allowedDecisions
         )
     }
 
-    private static func defaultProviderDecision(
+    private static func allowedProviderDecisions(
         commentCount: Int,
         capabilities: CodeHostProviderCapabilities
-    ) -> ProviderReviewDecision {
-        if commentCount > 0 {
-            return .comment
+    ) -> [ProviderReviewDecision] {
+        var decisions: [ProviderReviewDecision] = []
+        if commentCount > 0, capabilities.canPublishReviewComments {
+            decisions.append(.comment)
         }
         if capabilities.canApproveReview {
-            return .approve
+            decisions.append(.approve)
         }
         if capabilities.canRequestChanges {
-            return .requestChanges
+            decisions.append(.requestChanges)
         }
-        return .comment
+        return decisions
+    }
+
+    private static func defaultProviderDecision(
+        allowedDecisions: [ProviderReviewDecision]
+    ) -> ProviderReviewDecision {
+        if allowedDecisions.contains(.comment) {
+            return .comment
+        }
+        return allowedDecisions.first ?? .comment
     }
 
     private func providerPublishableComments(commentID: String?) -> [ReviewDraftComment] {
@@ -551,6 +567,7 @@ struct ReviewSessionTabView: View {
                     reviewIdentity: providerPublishConfirmation.reviewIdentity,
                     commentCount: providerPublishConfirmation.commentCount,
                     unpublishableMessages: providerPublishConfirmation.unpublishableMessages,
+                    allowedDecisions: providerPublishConfirmation.allowedDecisions,
                     selectedDecision: $selectedProviderDecision,
                     isPublishing: isProviderPublishing,
                     errorMessage: providerPublishError,
@@ -581,6 +598,10 @@ struct ReviewSessionTabView: View {
         defer { isProviderPublishing = false }
 
         do {
+            guard confirmation.allowedDecisions.contains(selectedProviderDecision) else {
+                providerPublishError = "\(selectedProviderDecision.displayName) is not supported by this provider."
+                return
+            }
             let selectedDraftIDs = confirmation.commentID.map { Set([$0]) }
             let result = try await controller.publishReview(
                 remote: providerContext.remote,
@@ -994,6 +1015,19 @@ private extension ReviewThreadSide {
             self = .new
         case .unknown:
             self = .unknown
+        }
+    }
+}
+
+private extension ProviderReviewDecision {
+    var displayName: String {
+        switch self {
+        case .comment:
+            "Comment"
+        case .approve:
+            "Approve"
+        case .requestChanges:
+            "Request changes"
         }
     }
 }

--- a/Alas/Sources/Center/ReviewWorkspace/ReviewSessionTabView.swift
+++ b/Alas/Sources/Center/ReviewWorkspace/ReviewSessionTabView.swift
@@ -655,6 +655,9 @@ struct ReviewSessionTabView: View {
             )
             replaceProviderReviewRequest(result.refreshedRequest)
             providerPublishConfirmation = nil
+            if !result.warnings.isEmpty {
+                providerPublishError = result.warnings.joined(separator: "\n")
+            }
         } catch {
             providerPublishError = error.localizedDescription
         }

--- a/Alas/Sources/Integrations/CodeHost/CodeHostModels.swift
+++ b/Alas/Sources/Integrations/CodeHost/CodeHostModels.swift
@@ -111,7 +111,7 @@ struct CodeHostProviderCapabilities: Equatable, Sendable {
         canResolveReviewThreads: true,
         canUnresolveReviewThreads: false,
         canApproveReview: true,
-        canRequestChanges: false
+        canRequestChanges: true
     )
 }
 

--- a/Alas/Sources/Integrations/CodeHost/CodeHostModels.swift
+++ b/Alas/Sources/Integrations/CodeHost/CodeHostModels.swift
@@ -109,9 +109,9 @@ struct CodeHostProviderCapabilities: Equatable, Sendable {
         canPublishReviewComments: true,
         canReplyToReviewThreads: true,
         canResolveReviewThreads: true,
-        canUnresolveReviewThreads: true,
+        canUnresolveReviewThreads: false,
         canApproveReview: true,
-        canRequestChanges: true
+        canRequestChanges: false
     )
 }
 

--- a/Alas/Sources/Integrations/CodeHost/CodeHostModels.swift
+++ b/Alas/Sources/Integrations/CodeHost/CodeHostModels.swift
@@ -239,6 +239,23 @@ struct ReviewRequest: Identifiable, Equatable, Sendable {
     var hasActionableFeedback: Bool {
         reviewDecision == .changesRequested || threads.contains { !$0.isResolved && $0.isActionable }
     }
+
+    static func placeholder(remote: CodeHostRemote, number: Int) -> ReviewRequest {
+        ReviewRequest(
+            remote: remote,
+            number: number,
+            title: "",
+            url: remote.webURL,
+            state: .open,
+            isDraft: false,
+            headRefName: "",
+            baseRefName: "",
+            reviewDecision: .unknown,
+            mergeState: .unknown,
+            checks: [],
+            threads: []
+        )
+    }
 }
 
 struct ReviewLoopLocalState: Equatable, Sendable {

--- a/Alas/Sources/Integrations/CodeHost/CodeHostModels.swift
+++ b/Alas/Sources/Integrations/CodeHost/CodeHostModels.swift
@@ -223,6 +223,7 @@ struct ReviewRequest: Identifiable, Equatable, Sendable {
     let isDraft: Bool
     let headRefName: String
     let baseRefName: String
+    let headSHA: String?
     let reviewDecision: ReviewDecision
     let mergeState: ReviewMergeState
     let checks: [ReviewCheck]
@@ -231,6 +232,36 @@ struct ReviewRequest: Identifiable, Equatable, Sendable {
     var provider: CodeHostKind { remote.kind }
 
     var displayIdentity: String { "\(provider.displayName) \(provider.reviewRequestNumberPrefix)\(number)" }
+
+    init(
+        remote: CodeHostRemote,
+        number: Int,
+        title: String,
+        url: URL,
+        state: ReviewRequestState,
+        isDraft: Bool,
+        headRefName: String,
+        baseRefName: String,
+        headSHA: String? = nil,
+        reviewDecision: ReviewDecision,
+        mergeState: ReviewMergeState,
+        checks: [ReviewCheck],
+        threads: [ReviewThreadSummary]
+    ) {
+        self.remote = remote
+        self.number = number
+        self.title = title
+        self.url = url
+        self.state = state
+        self.isDraft = isDraft
+        self.headRefName = headRefName
+        self.baseRefName = baseRefName
+        self.headSHA = headSHA
+        self.reviewDecision = reviewDecision
+        self.mergeState = mergeState
+        self.checks = checks
+        self.threads = threads
+    }
 
     var worstCheckBucket: ReviewCheckBucket? {
         checks.max { $0.bucket.severity < $1.bucket.severity }?.bucket

--- a/Alas/Sources/Integrations/CodeHost/CodeHostModels.swift
+++ b/Alas/Sources/Integrations/CodeHost/CodeHostModels.swift
@@ -49,23 +49,69 @@ struct CodeHostProviderCapabilities: Equatable, Sendable {
     let canCreateReviewRequest: Bool
     let canRerunFailedChecks: Bool
     let canOpenReviewRequest: Bool
+    let canPublishReviewComments: Bool
+    let canReplyToReviewThreads: Bool
+    let canResolveReviewThreads: Bool
+    let canUnresolveReviewThreads: Bool
+    let canApproveReview: Bool
+    let canRequestChanges: Bool
+
+    init(
+        canCreateReviewRequest: Bool,
+        canRerunFailedChecks: Bool,
+        canOpenReviewRequest: Bool,
+        canPublishReviewComments: Bool = false,
+        canReplyToReviewThreads: Bool = false,
+        canResolveReviewThreads: Bool = false,
+        canUnresolveReviewThreads: Bool = false,
+        canApproveReview: Bool = false,
+        canRequestChanges: Bool = false
+    ) {
+        self.canCreateReviewRequest = canCreateReviewRequest
+        self.canRerunFailedChecks = canRerunFailedChecks
+        self.canOpenReviewRequest = canOpenReviewRequest
+        self.canPublishReviewComments = canPublishReviewComments
+        self.canReplyToReviewThreads = canReplyToReviewThreads
+        self.canResolveReviewThreads = canResolveReviewThreads
+        self.canUnresolveReviewThreads = canUnresolveReviewThreads
+        self.canApproveReview = canApproveReview
+        self.canRequestChanges = canRequestChanges
+    }
 
     static let readOnly = CodeHostProviderCapabilities(
         canCreateReviewRequest: false,
         canRerunFailedChecks: false,
-        canOpenReviewRequest: true
+        canOpenReviewRequest: true,
+        canPublishReviewComments: false,
+        canReplyToReviewThreads: false,
+        canResolveReviewThreads: false,
+        canUnresolveReviewThreads: false,
+        canApproveReview: false,
+        canRequestChanges: false
     )
 
     static let githubCLI = CodeHostProviderCapabilities(
         canCreateReviewRequest: true,
         canRerunFailedChecks: true,
-        canOpenReviewRequest: true
+        canOpenReviewRequest: true,
+        canPublishReviewComments: true,
+        canReplyToReviewThreads: true,
+        canResolveReviewThreads: true,
+        canUnresolveReviewThreads: true,
+        canApproveReview: true,
+        canRequestChanges: true
     )
 
     static let gitlabCLI = CodeHostProviderCapabilities(
         canCreateReviewRequest: true,
         canRerunFailedChecks: true,
-        canOpenReviewRequest: true
+        canOpenReviewRequest: true,
+        canPublishReviewComments: true,
+        canReplyToReviewThreads: true,
+        canResolveReviewThreads: true,
+        canUnresolveReviewThreads: true,
+        canApproveReview: true,
+        canRequestChanges: true
     )
 }
 
@@ -141,6 +187,8 @@ struct ReviewThreadSummary: Identifiable, Equatable, Sendable {
     let isResolved: Bool
     let isActionable: Bool
     let location: ReviewThreadLocation?
+    let providerThreadID: String?
+    let providerCommentID: String?
 
     init(
         id: String,
@@ -149,7 +197,9 @@ struct ReviewThreadSummary: Identifiable, Equatable, Sendable {
         url: URL?,
         isResolved: Bool,
         isActionable: Bool,
-        location: ReviewThreadLocation? = nil
+        location: ReviewThreadLocation? = nil,
+        providerThreadID: String? = nil,
+        providerCommentID: String? = nil
     ) {
         self.id = id
         self.author = author
@@ -158,6 +208,8 @@ struct ReviewThreadSummary: Identifiable, Equatable, Sendable {
         self.isResolved = isResolved
         self.isActionable = isActionable
         self.location = location
+        self.providerThreadID = providerThreadID
+        self.providerCommentID = providerCommentID
     }
 }
 

--- a/Alas/Sources/Integrations/CodeHost/CodeHostProvider.swift
+++ b/Alas/Sources/Integrations/CodeHost/CodeHostProvider.swift
@@ -29,12 +29,24 @@ enum CodeHostProviderError: LocalizedError, Equatable {
 }
 
 protocol CodeHostCommandRunning: Sendable {
-    func run(_ executable: String, args: [String], cwd: URL?) async throws -> ProcessResult
+    func run(_ executable: String, args: [String], cwd: URL?, stdin: String?) async throws -> ProcessResult
+}
+
+extension CodeHostCommandRunning {
+    func run(_ executable: String, args: [String], cwd: URL?) async throws -> ProcessResult {
+        try await run(executable, args: args, cwd: cwd, stdin: nil)
+    }
 }
 
 struct ProcessCodeHostCommandRunner: CodeHostCommandRunning {
-    func run(_ executable: String, args: [String], cwd: URL?) async throws -> ProcessResult {
-        try await Process.run("/usr/bin/env", args: [executable] + args, cwd: cwd, env: Process.gitEnv())
+    func run(_ executable: String, args: [String], cwd: URL?, stdin: String?) async throws -> ProcessResult {
+        try await Process.run(
+            "/usr/bin/env",
+            args: [executable] + args,
+            cwd: cwd,
+            env: Process.gitEnv(),
+            stdin: stdin
+        )
     }
 }
 
@@ -84,6 +96,8 @@ protocol CodeHostProvider: Sendable {
         request: ReviewRequest?,
         cwd: URL
     ) async throws
+    func publishReview(_ request: ProviderReviewPublishRequest) async throws -> ProviderReviewPublishResult
+    func mutateReviewThread(_ mutation: ProviderThreadMutation) async throws -> ProviderThreadMutationResult
 }
 
 extension CodeHostProvider {
@@ -148,6 +162,14 @@ extension CodeHostProvider {
             line: nil,
             isTruncated: false
         )
+    }
+
+    func publishReview(_ request: ProviderReviewPublishRequest) async throws -> ProviderReviewPublishResult {
+        throw CodeHostProviderError.unsupportedProvider(request.remote.kind)
+    }
+
+    func mutateReviewThread(_ mutation: ProviderThreadMutation) async throws -> ProviderThreadMutationResult {
+        throw CodeHostProviderError.unsupportedProvider(mutation.remote.kind)
     }
 }
 

--- a/Alas/Sources/Integrations/CodeHost/CodeHostProvider.swift
+++ b/Alas/Sources/Integrations/CodeHost/CodeHostProvider.swift
@@ -63,6 +63,7 @@ protocol CodeHostProvider: Sendable {
         baseBranch: String,
         cwd: URL
     ) async throws -> ReviewRequest?
+    func reviewRequest(remote: CodeHostRemote, number: Int, cwd: URL) async throws -> ReviewRequest
     func createReviewRequest(
         remote: CodeHostRemote,
         branch: String,
@@ -104,6 +105,10 @@ extension CodeHostProvider {
     var capabilities: CodeHostProviderCapabilities { .readOnly }
 
     func reviewDiff(remote: CodeHostRemote, request: ReviewRequest, cwd: URL) async throws -> String {
+        throw CodeHostProviderError.unsupportedProvider(remote.kind)
+    }
+
+    func reviewRequest(remote: CodeHostRemote, number: Int, cwd: URL) async throws -> ReviewRequest {
         throw CodeHostProviderError.unsupportedProvider(remote.kind)
     }
 

--- a/Alas/Sources/Integrations/CodeHost/GitHubCLIProvider.swift
+++ b/Alas/Sources/Integrations/CodeHost/GitHubCLIProvider.swift
@@ -367,7 +367,7 @@ struct GitHubCLIProvider: CodeHostProvider {
             pullRequestId: pullRequestID,
             event: Self.githubReviewEvent(for: request.decision),
             body: request.summaryBody,
-            comments: request.comments.map(Self.githubReviewCommentPayload(for:))
+            threads: request.comments.map(Self.githubReviewThreadPayload(for:))
         )
         let stdin = try Self.graphQLInput(
             query: Self.publishReviewMutation,
@@ -522,6 +522,42 @@ struct GitHubCLIProvider: CodeHostProvider {
         guard let item else {
             return nil
         }
+        guard let url = URL(string: item.url), url.isHTTPOrHTTPS else {
+            throw CodeHostProviderError.malformedOutput("gh pr list returned an invalid URL")
+        }
+
+        return ReviewRequest(
+            remote: remote,
+            number: item.number,
+            title: item.title,
+            url: url,
+            state: mapState(item.state),
+            isDraft: item.isDraft,
+            headRefName: item.headRefName,
+            baseRefName: item.baseRefName,
+            reviewDecision: mapReviewDecision(item.reviewDecision),
+            mergeState: mapMergeState(item.mergeStateStatus),
+            checks: [],
+            threads: []
+        )
+    }
+
+    static func parsePRView(_ json: String, remote: CodeHostRemote) throws -> ReviewRequest {
+        let data = Data(json.utf8)
+        let item: PRListItem
+        do {
+            item = try JSONDecoder().decode(PRListItem.self, from: data)
+        } catch {
+            throw CodeHostProviderError.malformedOutput("Unable to parse gh pr view output")
+        }
+
+        guard let request = try reviewRequest(from: item, remote: remote) else {
+            throw CodeHostProviderError.malformedOutput("gh pr view returned an invalid PR")
+        }
+        return request
+    }
+
+    private static func reviewRequest(from item: PRListItem, remote: CodeHostRemote) throws -> ReviewRequest? {
         guard let url = URL(string: item.url), url.isHTTPOrHTTPS else {
             throw CodeHostProviderError.malformedOutput("gh pr list returned an invalid URL")
         }
@@ -892,16 +928,22 @@ struct GitHubCLIProvider: CodeHostProvider {
     }
 
     private func refreshedReviewRequest(remote: CodeHostRemote, request: ReviewRequest, cwd: URL) async throws -> ReviewRequest {
-        guard let refreshed = try await currentReviewRequest(
-            remote: remote,
-            branch: request.headRefName,
-            headOwner: nil,
-            baseBranch: request.baseRefName,
+        let result = try await runner.run(
+            "gh",
+            args: [
+                "pr", "view", "\(request.number)",
+                "--json", "number,title,url,state,isDraft,headRefName,headRepositoryOwner,baseRefName,reviewDecision,mergeStateStatus",
+                "-R", remote.repositorySlug,
+            ],
             cwd: cwd
-        ) else {
-            throw CodeHostProviderError.malformedOutput("Unable to refresh GitHub PR after review mutation")
+        )
+        guard result.exitCode == 0 else {
+            throw CodeHostProviderError.commandFailed(command: "gh pr view", stderr: result.stderr)
         }
-        return refreshed
+
+        let request = try Self.parsePRView(result.stdout, remote: remote)
+        let threads = (try? await reviewThreads(remote: remote, request: request, cwd: cwd)) ?? []
+        return Self.withThreads(threads, on: request)
     }
 
     static func githubReviewEvent(for decision: ProviderReviewDecision) -> String {
@@ -912,8 +954,8 @@ struct GitHubCLIProvider: CodeHostProvider {
         }
     }
 
-    static func githubReviewCommentPayload(for draft: ProviderReviewDraftComment) -> GitHubReviewDraftCommentPayload {
-        GitHubReviewDraftCommentPayload(
+    static func githubReviewThreadPayload(for draft: ProviderReviewDraftComment) -> GitHubReviewDraftThreadPayload {
+        GitHubReviewDraftThreadPayload(
             path: draft.path,
             body: draft.bodyMarkdown,
             line: draft.lineRange.upperBound,
@@ -1014,7 +1056,7 @@ private struct PullRequestNodePullRequest: Decodable {
     let id: String
 }
 
-struct GitHubReviewDraftCommentPayload: Encodable, Equatable {
+struct GitHubReviewDraftThreadPayload: Encodable, Equatable {
     let path: String
     let body: String
     let line: Int
@@ -1030,7 +1072,7 @@ private struct PublishReviewInput: Encodable {
     let pullRequestId: String
     let event: String
     let body: String
-    let comments: [GitHubReviewDraftCommentPayload]
+    let threads: [GitHubReviewDraftThreadPayload]
 }
 
 private struct PublishReviewResponse: Decodable {

--- a/Alas/Sources/Integrations/CodeHost/GitHubCLIProvider.swift
+++ b/Alas/Sources/Integrations/CodeHost/GitHubCLIProvider.swift
@@ -699,6 +699,7 @@ struct GitHubCLIProvider: CodeHostProvider {
             isDraft: item.isDraft,
             headRefName: item.headRefName,
             baseRefName: item.baseRefName,
+            headSHA: normalizedOptionalString(item.headRefOid),
             reviewDecision: mapReviewDecision(item.reviewDecision),
             mergeState: mapMergeState(item.mergeStateStatus),
             checks: [],

--- a/Alas/Sources/Integrations/CodeHost/GitHubCLIProvider.swift
+++ b/Alas/Sources/Integrations/CodeHost/GitHubCLIProvider.swift
@@ -448,7 +448,7 @@ struct GitHubCLIProvider: CodeHostProvider {
                         commitOID: request.reviewRequest.headSHA,
                         comments: [comment],
                         decision: .comment,
-                        summaryBody: request.summaryBody,
+                        summaryBody: "",
                         cwd: request.cwd
                     )
                     published.append(contentsOf: result.published)

--- a/Alas/Sources/Integrations/CodeHost/GitHubCLIProvider.swift
+++ b/Alas/Sources/Integrations/CodeHost/GitHubCLIProvider.swift
@@ -386,7 +386,7 @@ struct GitHubCLIProvider: CodeHostProvider {
             cwd: request.cwd
         )
 
-        let published = await publishReviewWithFallback(
+        let published = try await publishReviewWithFallback(
             pullRequestID: pullRequestID,
             request: request,
             publishableComments: publishableComments
@@ -415,7 +415,7 @@ struct GitHubCLIProvider: CodeHostProvider {
         pullRequestID: String,
         request: ProviderReviewPublishRequest,
         publishableComments: [ProviderReviewDraftComment]
-    ) async -> (published: [ProviderReviewPublishedComment], failed: [ProviderReviewFailedComment], warnings: [String]) {
+    ) async throws -> (published: [ProviderReviewPublishedComment], failed: [ProviderReviewFailedComment], warnings: [String]) {
         do {
             let published = try await submitReview(
                 remote: request.remote,
@@ -428,6 +428,9 @@ struct GitHubCLIProvider: CodeHostProvider {
             )
             return (published.published, published.failed, published.warnings)
         } catch {
+            guard !publishableComments.isEmpty else {
+                throw error
+            }
             guard Self.shouldRetryPublishIndividually(after: error), publishableComments.count > 1 else {
                 return (
                     [],

--- a/Alas/Sources/Integrations/CodeHost/GitHubCLIProvider.swift
+++ b/Alas/Sources/Integrations/CodeHost/GitHubCLIProvider.swift
@@ -605,12 +605,24 @@ struct GitHubCLIProvider: CodeHostProvider {
             providerURL = nil
         }
 
-        let refreshedRequest = (try? await refreshedReviewRequest(
-            remote: mutation.remote,
-            request: mutation.reviewRequest,
-            cwd: mutation.cwd
-        )) ?? mutation.reviewRequest
-        return ProviderThreadMutationResult(refreshedRequest: refreshedRequest, providerURL: providerURL)
+        let refreshedRequest: ReviewRequest
+        let warnings: [String]
+        do {
+            refreshedRequest = try await refreshedReviewRequest(
+                remote: mutation.remote,
+                request: mutation.reviewRequest,
+                cwd: mutation.cwd
+            )
+            warnings = []
+        } catch {
+            refreshedRequest = mutation.reviewRequest
+            warnings = ["GitHub thread was updated, but Alas could not refresh the PR: \(error.localizedDescription)"]
+        }
+        return ProviderThreadMutationResult(
+            refreshedRequest: refreshedRequest,
+            providerURL: providerURL,
+            warnings: warnings
+        )
     }
 
     func rerunFailedChecks(

--- a/Alas/Sources/Integrations/CodeHost/GitHubCLIProvider.swift
+++ b/Alas/Sources/Integrations/CodeHost/GitHubCLIProvider.swift
@@ -358,6 +358,15 @@ struct GitHubCLIProvider: CodeHostProvider {
     }
 
     func publishReview(_ request: ProviderReviewPublishRequest) async throws -> ProviderReviewPublishResult {
+        let publishableComments = request.comments.filter { $0.side != .unknown }
+        let preflightFailures = request.comments
+            .filter { $0.side == .unknown }
+            .map {
+                ProviderReviewFailedComment(
+                    localDraftID: $0.localDraftID,
+                    message: "GitHub review comments require an old or new side."
+                )
+            }
         let pullRequestID = try await pullRequestNodeID(
             remote: request.remote,
             request: request.reviewRequest,
@@ -367,7 +376,7 @@ struct GitHubCLIProvider: CodeHostProvider {
             pullRequestId: pullRequestID,
             event: Self.githubReviewEvent(for: request.decision),
             body: request.summaryBody,
-            threads: request.comments.map(Self.githubReviewThreadPayload(for:))
+            threads: publishableComments.map(Self.githubReviewThreadPayload(for:))
         )
         let stdin = try Self.graphQLInput(
             query: Self.publishReviewMutation,
@@ -383,7 +392,7 @@ struct GitHubCLIProvider: CodeHostProvider {
             throw CodeHostProviderError.commandFailed(command: "gh api graphql", stderr: result.stderr)
         }
 
-        let published = try Self.parsePublishReviewResult(result.stdout, drafts: request.comments)
+        let published = try Self.parsePublishReviewResult(result.stdout, drafts: publishableComments)
         let refreshedRequest = try await refreshedReviewRequest(
             remote: request.remote,
             request: request.reviewRequest,
@@ -391,7 +400,7 @@ struct GitHubCLIProvider: CodeHostProvider {
         )
         return ProviderReviewPublishResult(
             published: published.published,
-            failed: published.failed,
+            failed: preflightFailures + published.failed,
             refreshedRequest: refreshedRequest,
             warnings: []
         )

--- a/Alas/Sources/Integrations/CodeHost/GitHubCLIProvider.swift
+++ b/Alas/Sources/Integrations/CodeHost/GitHubCLIProvider.swift
@@ -367,6 +367,14 @@ struct GitHubCLIProvider: CodeHostProvider {
                     message: "GitHub review comments require an old or new side."
                 )
             }
+        guard !publishableComments.isEmpty else {
+            return ProviderReviewPublishResult(
+                published: [],
+                failed: preflightFailures,
+                refreshedRequest: request.reviewRequest,
+                warnings: []
+            )
+        }
         let pullRequestID = try await pullRequestNodeID(
             remote: request.remote,
             request: request.reviewRequest,

--- a/Alas/Sources/Integrations/CodeHost/GitHubCLIProvider.swift
+++ b/Alas/Sources/Integrations/CodeHost/GitHubCLIProvider.swift
@@ -367,7 +367,7 @@ struct GitHubCLIProvider: CodeHostProvider {
                     message: "GitHub review comments require an old or new side."
                 )
             }
-        guard !publishableComments.isEmpty else {
+        guard !publishableComments.isEmpty || request.comments.isEmpty else {
             return ProviderReviewPublishResult(
                 published: [],
                 failed: preflightFailures,

--- a/Alas/Sources/Integrations/CodeHost/GitHubCLIProvider.swift
+++ b/Alas/Sources/Integrations/CodeHost/GitHubCLIProvider.swift
@@ -426,7 +426,7 @@ struct GitHubCLIProvider: CodeHostProvider {
                 summaryBody: request.summaryBody,
                 cwd: request.cwd
             )
-            return (published.published, published.failed, [])
+            return (published.published, published.failed, published.warnings)
         } catch {
             guard Self.shouldRetryPublishIndividually(after: error), publishableComments.count > 1 else {
                 return (
@@ -440,6 +440,7 @@ struct GitHubCLIProvider: CodeHostProvider {
 
             var published: [ProviderReviewPublishedComment] = []
             var failed: [ProviderReviewFailedComment] = []
+            var warnings: [String] = []
             for comment in publishableComments {
                 do {
                     let result = try await submitReview(
@@ -453,6 +454,7 @@ struct GitHubCLIProvider: CodeHostProvider {
                     )
                     published.append(contentsOf: result.published)
                     failed.append(contentsOf: result.failed)
+                    warnings.append(contentsOf: result.warnings)
                 } catch {
                     failed.append(ProviderReviewFailedComment(localDraftID: comment.localDraftID, message: error.localizedDescription))
                 }
@@ -460,7 +462,9 @@ struct GitHubCLIProvider: CodeHostProvider {
             return (
                 published,
                 failed,
-                ["GitHub rejected the batch review; Alas retried publishable comments individually without submitting the review decision."]
+                warnings + [
+                    "GitHub rejected the batch review; Alas retried publishable comments individually without submitting the review decision.",
+                ]
             )
         }
     }
@@ -480,7 +484,11 @@ struct GitHubCLIProvider: CodeHostProvider {
         decision: ProviderReviewDecision,
         summaryBody: String,
         cwd: URL
-    ) async throws -> (published: [ProviderReviewPublishedComment], failed: [ProviderReviewFailedComment]) {
+    ) async throws -> (
+        published: [ProviderReviewPublishedComment],
+        failed: [ProviderReviewFailedComment],
+        warnings: [String]
+    ) {
         let input = PublishReviewInput(
             pullRequestId: pullRequestID,
             commitOID: Self.normalizedOptionalString(commitOID),
@@ -767,7 +775,11 @@ struct GitHubCLIProvider: CodeHostProvider {
     static func parsePublishReviewResult(
         _ json: String,
         drafts: [ProviderReviewDraftComment]
-    ) throws -> (published: [ProviderReviewPublishedComment], failed: [ProviderReviewFailedComment]) {
+    ) throws -> (
+        published: [ProviderReviewPublishedComment],
+        failed: [ProviderReviewFailedComment],
+        warnings: [String]
+    ) {
         let data = Data(json.utf8)
         let response: PublishReviewResponse
         do {
@@ -777,7 +789,7 @@ struct GitHubCLIProvider: CodeHostProvider {
         }
 
         let comments = response.data.addPullRequestReview.pullRequestReview.comments.nodes
-        let published = zip(drafts, comments).map { draft, comment in
+        var published = zip(drafts, comments).map { draft, comment in
             ProviderReviewPublishedComment(
                 localDraftID: draft.localDraftID,
                 providerThreadID: normalizedOptionalString(comment.pullRequestReviewThread?.id),
@@ -785,13 +797,29 @@ struct GitHubCLIProvider: CodeHostProvider {
                 providerURL: try? parseOptionalHTTPURL(comment.url, context: "gh publish review returned an invalid URL")
             )
         }
-        let failed = drafts.dropFirst(published.count).map {
-            ProviderReviewFailedComment(
-                localDraftID: $0.localDraftID,
-                message: "GitHub did not return a published comment for this draft."
-            )
+        var warnings: [String] = []
+        let missingDrafts = drafts.dropFirst(published.count)
+        let failed: [ProviderReviewFailedComment]
+        if !missingDrafts.isEmpty, comments.count == 100 {
+            published.append(contentsOf: missingDrafts.map {
+                ProviderReviewPublishedComment(
+                    localDraftID: $0.localDraftID,
+                    providerThreadID: nil,
+                    providerCommentID: nil,
+                    providerURL: nil
+                )
+            })
+            warnings.append("GitHub returned only the first 100 review comments; remaining drafts were marked published without provider comment IDs.")
+            failed = []
+        } else {
+            failed = missingDrafts.map {
+                ProviderReviewFailedComment(
+                    localDraftID: $0.localDraftID,
+                    message: "GitHub did not return a published comment for this draft."
+                )
+            }
         }
-        return (Array(published), Array(failed))
+        return (Array(published), failed, warnings)
     }
 
     static func parseThreadReplyResult(_ json: String) throws -> URL? {

--- a/Alas/Sources/Integrations/CodeHost/GitHubCLIProvider.swift
+++ b/Alas/Sources/Integrations/CodeHost/GitHubCLIProvider.swift
@@ -340,6 +340,7 @@ struct GitHubCLIProvider: CodeHostProvider {
     ) async throws -> ReviewThreadsPage {
         var args = [
             "api", "graphql",
+            "--hostname", remote.host,
             "-f", "query=\(Self.reviewThreadsQuery)",
             "-F", "owner=\(remote.owner)",
             "-F", "repo=\(remote.repository)",
@@ -417,6 +418,7 @@ struct GitHubCLIProvider: CodeHostProvider {
     ) async -> (published: [ProviderReviewPublishedComment], failed: [ProviderReviewFailedComment], warnings: [String]) {
         do {
             let published = try await submitReview(
+                remote: request.remote,
                 pullRequestID: pullRequestID,
                 comments: publishableComments,
                 decision: request.decision,
@@ -440,6 +442,7 @@ struct GitHubCLIProvider: CodeHostProvider {
             for comment in publishableComments {
                 do {
                     let result = try await submitReview(
+                        remote: request.remote,
                         pullRequestID: pullRequestID,
                         comments: [comment],
                         decision: .comment,
@@ -468,6 +471,7 @@ struct GitHubCLIProvider: CodeHostProvider {
     }
 
     private func submitReview(
+        remote: CodeHostRemote,
         pullRequestID: String,
         comments: [ProviderReviewDraftComment],
         decision: ProviderReviewDecision,
@@ -486,7 +490,7 @@ struct GitHubCLIProvider: CodeHostProvider {
         )
         let result = try await runner.run(
             "gh",
-            args: ["api", "graphql", "--input", "-"],
+            args: Self.graphQLAPIStdinArgs(remote: remote),
             cwd: cwd,
             stdin: stdin
         )
@@ -536,7 +540,7 @@ struct GitHubCLIProvider: CodeHostProvider {
             )
             let result = try await runner.run(
                 "gh",
-                args: ["api", "graphql", "--input", "-"],
+                args: Self.graphQLAPIStdinArgs(remote: mutation.remote),
                 cwd: mutation.cwd,
                 stdin: stdin
             )
@@ -551,7 +555,7 @@ struct GitHubCLIProvider: CodeHostProvider {
             )
             let result = try await runner.run(
                 "gh",
-                args: ["api", "graphql", "--input", "-"],
+                args: Self.graphQLAPIStdinArgs(remote: mutation.remote),
                 cwd: mutation.cwd,
                 stdin: stdin
             )
@@ -567,7 +571,7 @@ struct GitHubCLIProvider: CodeHostProvider {
             )
             let result = try await runner.run(
                 "gh",
-                args: ["api", "graphql", "--input", "-"],
+                args: Self.graphQLAPIStdinArgs(remote: mutation.remote),
                 cwd: mutation.cwd,
                 stdin: stdin
             )
@@ -1036,7 +1040,7 @@ struct GitHubCLIProvider: CodeHostProvider {
         )
         let result = try await runner.run(
             "gh",
-            args: ["api", "graphql", "--input", "-"],
+            args: Self.graphQLAPIStdinArgs(remote: remote),
             cwd: cwd,
             stdin: stdin
         )
@@ -1052,6 +1056,10 @@ struct GitHubCLIProvider: CodeHostProvider {
         case .approve: "APPROVE"
         case .requestChanges: "REQUEST_CHANGES"
         }
+    }
+
+    static func graphQLAPIStdinArgs(remote: CodeHostRemote) -> [String] {
+        ["api", "graphql", "--hostname", remote.host, "--input", "-"]
     }
 
     static func githubReviewThreadPayload(for draft: ProviderReviewDraftComment) -> GitHubReviewDraftThreadPayload {

--- a/Alas/Sources/Integrations/CodeHost/GitHubCLIProvider.swift
+++ b/Alas/Sources/Integrations/CodeHost/GitHubCLIProvider.swift
@@ -142,7 +142,7 @@ struct GitHubCLIProvider: CodeHostProvider {
                 "--base", base,
                 "--state", "open",
                 "--limit", "20",
-                "--json", "number,title,url,state,isDraft,headRefName,headRepositoryOwner,baseRefName,reviewDecision,mergeStateStatus",
+                "--json", "number,title,url,state,isDraft,headRefName,headRefOid,headRepositoryOwner,baseRefName,reviewDecision,mergeStateStatus",
                 "-R", remote.repositorySlug,
             ],
             cwd: cwd
@@ -420,6 +420,7 @@ struct GitHubCLIProvider: CodeHostProvider {
             let published = try await submitReview(
                 remote: request.remote,
                 pullRequestID: pullRequestID,
+                commitOID: request.reviewRequest.headSHA,
                 comments: publishableComments,
                 decision: request.decision,
                 summaryBody: request.summaryBody,
@@ -444,6 +445,7 @@ struct GitHubCLIProvider: CodeHostProvider {
                     let result = try await submitReview(
                         remote: request.remote,
                         pullRequestID: pullRequestID,
+                        commitOID: request.reviewRequest.headSHA,
                         comments: [comment],
                         decision: .comment,
                         summaryBody: request.summaryBody,
@@ -473,6 +475,7 @@ struct GitHubCLIProvider: CodeHostProvider {
     private func submitReview(
         remote: CodeHostRemote,
         pullRequestID: String,
+        commitOID: String?,
         comments: [ProviderReviewDraftComment],
         decision: ProviderReviewDecision,
         summaryBody: String,
@@ -480,6 +483,7 @@ struct GitHubCLIProvider: CodeHostProvider {
     ) async throws -> (published: [ProviderReviewPublishedComment], failed: [ProviderReviewFailedComment]) {
         let input = PublishReviewInput(
             pullRequestId: pullRequestID,
+            commitOID: Self.normalizedOptionalString(commitOID),
             event: Self.githubReviewEvent(for: decision),
             body: summaryBody,
             threads: comments.map(Self.githubReviewThreadPayload(for:))
@@ -506,7 +510,7 @@ struct GitHubCLIProvider: CodeHostProvider {
             "gh",
             args: [
                 "pr", "view", "\(request.number)",
-                "--json", "number,title,url,state,isDraft,headRefName,headRepositoryOwner,baseRefName,reviewDecision,mergeStateStatus",
+                "--json", "number,title,url,state,isDraft,headRefName,headRefOid,headRepositoryOwner,baseRefName,reviewDecision,mergeStateStatus",
                 "-R", remote.repositorySlug,
             ],
             cwd: cwd
@@ -658,6 +662,7 @@ struct GitHubCLIProvider: CodeHostProvider {
             isDraft: item.isDraft,
             headRefName: item.headRefName,
             baseRefName: item.baseRefName,
+            headSHA: normalizedOptionalString(item.headRefOid),
             reviewDecision: mapReviewDecision(item.reviewDecision),
             mergeState: mapMergeState(item.mergeStateStatus),
             checks: [],
@@ -1022,6 +1027,7 @@ struct GitHubCLIProvider: CodeHostProvider {
             isDraft: request.isDraft,
             headRefName: request.headRefName,
             baseRefName: request.baseRefName,
+            headSHA: request.headSHA,
             reviewDecision: request.reviewDecision,
             mergeState: request.mergeState,
             checks: request.checks,
@@ -1097,6 +1103,7 @@ private struct PRListItem: Decodable {
     let state: String
     let isDraft: Bool
     let headRefName: String
+    let headRefOid: String?
     let headRepositoryOwner: HeadRepositoryOwner?
     let baseRefName: String
     let reviewDecision: String?
@@ -1180,6 +1187,7 @@ private struct PublishReviewVariables: Encodable {
 
 private struct PublishReviewInput: Encodable {
     let pullRequestId: String
+    let commitOID: String?
     let event: String
     let body: String
     let threads: [GitHubReviewDraftThreadPayload]

--- a/Alas/Sources/Integrations/CodeHost/GitHubCLIProvider.swift
+++ b/Alas/Sources/Integrations/CodeHost/GitHubCLIProvider.swift
@@ -413,7 +413,7 @@ struct GitHubCLIProvider: CodeHostProvider {
             )
             return (published.published, published.failed, [])
         } catch {
-            guard publishableComments.count > 1 else {
+            guard Self.shouldRetryPublishIndividually(after: error), publishableComments.count > 1 else {
                 return (
                     [],
                     publishableComments.map {
@@ -446,6 +446,13 @@ struct GitHubCLIProvider: CodeHostProvider {
                 ["GitHub rejected the batch review; Alas retried publishable comments individually without submitting the review decision."]
             )
         }
+    }
+
+    private static func shouldRetryPublishIndividually(after error: Error) -> Bool {
+        guard case CodeHostProviderError.commandFailed = error else {
+            return false
+        }
+        return true
     }
 
     private func submitReview(

--- a/Alas/Sources/Integrations/CodeHost/GitHubCLIProvider.swift
+++ b/Alas/Sources/Integrations/CodeHost/GitHubCLIProvider.swift
@@ -158,6 +158,10 @@ struct GitHubCLIProvider: CodeHostProvider {
         return Self.withThreads(threads, on: request)
     }
 
+    func reviewRequest(remote: CodeHostRemote, number: Int, cwd: URL) async throws -> ReviewRequest {
+        try await refreshedReviewRequest(remote: remote, request: ReviewRequest.placeholder(remote: remote, number: number), cwd: cwd)
+    }
+
     func createReviewRequest(
         remote: CodeHostRemote,
         branch: String,

--- a/Alas/Sources/Integrations/CodeHost/GitHubCLIProvider.swift
+++ b/Alas/Sources/Integrations/CodeHost/GitHubCLIProvider.swift
@@ -969,7 +969,8 @@ struct GitHubCLIProvider: CodeHostProvider {
             body: draft.bodyMarkdown,
             line: draft.lineRange.upperBound,
             side: draft.side == .old ? "LEFT" : "RIGHT",
-            startLine: draft.lineRange.lowerBound == draft.lineRange.upperBound ? nil : draft.lineRange.lowerBound
+            startLine: draft.lineRange.lowerBound == draft.lineRange.upperBound ? nil : draft.lineRange.lowerBound,
+            startSide: draft.lineRange.lowerBound == draft.lineRange.upperBound ? nil : (draft.side == .old ? "LEFT" : "RIGHT")
         )
     }
 
@@ -1071,6 +1072,7 @@ struct GitHubReviewDraftThreadPayload: Encodable, Equatable {
     let line: Int
     let side: String
     let startLine: Int?
+    let startSide: String?
 }
 
 private struct PublishReviewVariables: Encodable {

--- a/Alas/Sources/Integrations/CodeHost/GitHubCLIProvider.swift
+++ b/Alas/Sources/Integrations/CodeHost/GitHubCLIProvider.swift
@@ -377,7 +377,7 @@ struct GitHubCLIProvider: CodeHostProvider {
                 published: [],
                 failed: preflightFailures,
                 refreshedRequest: request.reviewRequest,
-                warnings: []
+                warnings: Self.skippedDecisionWarnings(decision: request.decision, provider: "GitHub")
             )
         }
         let pullRequestID = try await pullRequestNodeID(
@@ -434,7 +434,7 @@ struct GitHubCLIProvider: CodeHostProvider {
                     publishableComments.map {
                         ProviderReviewFailedComment(localDraftID: $0.localDraftID, message: error.localizedDescription)
                     },
-                    []
+                    Self.skippedDecisionWarnings(decision: request.decision, provider: "GitHub")
                 )
             }
 
@@ -474,6 +474,17 @@ struct GitHubCLIProvider: CodeHostProvider {
             return false
         }
         return true
+    }
+
+    private static func skippedDecisionWarnings(decision: ProviderReviewDecision, provider: String) -> [String] {
+        switch decision {
+        case .comment:
+            []
+        case .approve:
+            ["\(provider) approval review was not submitted because review comments failed to publish."]
+        case .requestChanges:
+            ["\(provider) request changes review was not submitted because review comments failed to publish."]
+        }
     }
 
     private func submitReview(

--- a/Alas/Sources/Integrations/CodeHost/GitHubCLIProvider.swift
+++ b/Alas/Sources/Integrations/CodeHost/GitHubCLIProvider.swift
@@ -3,6 +3,67 @@ import Foundation
 struct GitHubCLIProvider: CodeHostProvider {
     let kind: CodeHostKind = .github
     let capabilities: CodeHostProviderCapabilities = .githubCLI
+    static let pullRequestNodeQuery = """
+    query($owner: String!, $repo: String!, $number: Int!) {
+      repository(owner: $owner, name: $repo) {
+        pullRequest(number: $number) {
+          id
+        }
+      }
+    }
+    """
+
+    static let publishReviewMutation = """
+    mutation($input: AddPullRequestReviewInput!) {
+      addPullRequestReview(input: $input) {
+        pullRequestReview {
+          comments(first: 100) {
+            nodes {
+              id
+              url
+              pullRequestReviewThread {
+                id
+              }
+            }
+          }
+        }
+      }
+    }
+    """
+
+    static let replyReviewThreadMutation = """
+    mutation($input: AddPullRequestReviewThreadReplyInput!) {
+      addPullRequestReviewThreadReply(input: $input) {
+        comment {
+          id
+          url
+        }
+      }
+    }
+    """
+
+    static let resolveReviewThreadMutation = """
+    mutation($input: ResolveReviewThreadInput!) {
+      resolveReviewThread(input: $input) {
+        thread {
+          id
+          isResolved
+        }
+      }
+    }
+    """
+
+    static let unresolveReviewThreadMutation = """
+    mutation($input: UnresolveReviewThreadInput!) {
+      unresolveReviewThread(input: $input) {
+        thread {
+          id
+          isResolved
+        }
+      }
+    }
+    """
+
     static let reviewThreadsQuery = """
     query($owner: String!, $repo: String!, $number: Int!, $cursor: String) {
       repository(owner: $owner, name: $repo) {
@@ -296,6 +357,116 @@ struct GitHubCLIProvider: CodeHostProvider {
         return try Self.parseReviewThreadsPage(result.stdout)
     }
 
+    func publishReview(_ request: ProviderReviewPublishRequest) async throws -> ProviderReviewPublishResult {
+        let pullRequestID = try await pullRequestNodeID(
+            remote: request.remote,
+            request: request.reviewRequest,
+            cwd: request.cwd
+        )
+        let input = PublishReviewInput(
+            pullRequestId: pullRequestID,
+            event: Self.githubReviewEvent(for: request.decision),
+            body: request.summaryBody,
+            comments: request.comments.map(Self.githubReviewCommentPayload(for:))
+        )
+        let stdin = try Self.graphQLInput(
+            query: Self.publishReviewMutation,
+            variables: PublishReviewVariables(input: input)
+        )
+        let result = try await runner.run(
+            "gh",
+            args: ["api", "graphql", "--input", "-"],
+            cwd: request.cwd,
+            stdin: stdin
+        )
+        guard result.exitCode == 0 else {
+            throw CodeHostProviderError.commandFailed(command: "gh api graphql", stderr: result.stderr)
+        }
+
+        let published = try Self.parsePublishReviewResult(result.stdout, drafts: request.comments)
+        let refreshedRequest = try await refreshedReviewRequest(
+            remote: request.remote,
+            request: request.reviewRequest,
+            cwd: request.cwd
+        )
+        return ProviderReviewPublishResult(
+            published: published.published,
+            failed: published.failed,
+            refreshedRequest: refreshedRequest,
+            warnings: []
+        )
+    }
+
+    func mutateReviewThread(_ mutation: ProviderThreadMutation) async throws -> ProviderThreadMutationResult {
+        guard let threadID = Self.normalizedOptionalString(mutation.thread.providerThreadID) else {
+            throw CodeHostProviderError.malformedOutput("GitHub review thread mutation is missing a provider thread ID")
+        }
+
+        let providerURL: URL?
+        switch mutation.kind {
+        case .reply:
+            guard let body = Self.normalizedOptionalString(mutation.bodyMarkdown) else {
+                throw CodeHostProviderError.malformedOutput("GitHub review thread reply requires a non-empty body")
+            }
+            let stdin = try Self.graphQLInput(
+                query: Self.replyReviewThreadMutation,
+                variables: ThreadReplyVariables(input: ThreadReplyInput(
+                    pullRequestReviewThreadId: threadID,
+                    body: body
+                ))
+            )
+            let result = try await runner.run(
+                "gh",
+                args: ["api", "graphql", "--input", "-"],
+                cwd: mutation.cwd,
+                stdin: stdin
+            )
+            guard result.exitCode == 0 else {
+                throw CodeHostProviderError.commandFailed(command: "gh api graphql", stderr: result.stderr)
+            }
+            providerURL = try Self.parseThreadReplyResult(result.stdout)
+        case .resolve:
+            let stdin = try Self.graphQLInput(
+                query: Self.resolveReviewThreadMutation,
+                variables: ThreadStateVariables(input: ThreadStateInput(threadId: threadID))
+            )
+            let result = try await runner.run(
+                "gh",
+                args: ["api", "graphql", "--input", "-"],
+                cwd: mutation.cwd,
+                stdin: stdin
+            )
+            guard result.exitCode == 0 else {
+                throw CodeHostProviderError.commandFailed(command: "gh api graphql", stderr: result.stderr)
+            }
+            try Self.parseThreadStateResult(result.stdout, mutationName: "resolveReviewThread")
+            providerURL = nil
+        case .unresolve:
+            let stdin = try Self.graphQLInput(
+                query: Self.unresolveReviewThreadMutation,
+                variables: ThreadStateVariables(input: ThreadStateInput(threadId: threadID))
+            )
+            let result = try await runner.run(
+                "gh",
+                args: ["api", "graphql", "--input", "-"],
+                cwd: mutation.cwd,
+                stdin: stdin
+            )
+            guard result.exitCode == 0 else {
+                throw CodeHostProviderError.commandFailed(command: "gh api graphql", stderr: result.stderr)
+            }
+            try Self.parseThreadStateResult(result.stdout, mutationName: "unresolveReviewThread")
+            providerURL = nil
+        }
+
+        let refreshedRequest = try await refreshedReviewRequest(
+            remote: mutation.remote,
+            request: mutation.reviewRequest,
+            cwd: mutation.cwd
+        )
+        return ProviderThreadMutationResult(refreshedRequest: refreshedRequest, providerURL: providerURL)
+    }
+
     func rerunFailedChecks(
         remote: CodeHostRemote,
         branch: String,
@@ -412,6 +583,83 @@ struct GitHubCLIProvider: CodeHostProvider {
         try parseReviewThreadsPage(json).threads
     }
 
+    static func parsePullRequestNodeID(_ json: String) throws -> String {
+        let data = Data(json.utf8)
+        do {
+            let response = try JSONDecoder().decode(PullRequestNodeResponse.self, from: data)
+            let id = response.data.repository.pullRequest.id
+            guard !id.isEmpty else {
+                throw CodeHostProviderError.malformedOutput("gh pull request node output is missing a pull request ID")
+            }
+            return id
+        } catch let error as CodeHostProviderError {
+            throw error
+        } catch {
+            throw CodeHostProviderError.malformedOutput("Unable to parse gh pull request node output")
+        }
+    }
+
+    static func parsePublishReviewResult(
+        _ json: String,
+        drafts: [ProviderReviewDraftComment]
+    ) throws -> (published: [ProviderReviewPublishedComment], failed: [ProviderReviewFailedComment]) {
+        let data = Data(json.utf8)
+        let response: PublishReviewResponse
+        do {
+            response = try JSONDecoder().decode(PublishReviewResponse.self, from: data)
+        } catch {
+            throw CodeHostProviderError.malformedOutput("Unable to parse gh publish review output")
+        }
+
+        let comments = response.data.addPullRequestReview.pullRequestReview.comments.nodes
+        let published = zip(drafts, comments).map { draft, comment in
+            ProviderReviewPublishedComment(
+                localDraftID: draft.localDraftID,
+                providerThreadID: normalizedOptionalString(comment.pullRequestReviewThread?.id),
+                providerCommentID: normalizedOptionalString(comment.id),
+                providerURL: try? parseOptionalHTTPURL(comment.url, context: "gh publish review returned an invalid URL")
+            )
+        }
+        let failed = drafts.dropFirst(published.count).map {
+            ProviderReviewFailedComment(
+                localDraftID: $0.localDraftID,
+                message: "GitHub did not return a published comment for this draft."
+            )
+        }
+        return (Array(published), Array(failed))
+    }
+
+    static func parseThreadReplyResult(_ json: String) throws -> URL? {
+        let data = Data(json.utf8)
+        do {
+            let response = try JSONDecoder().decode(ThreadReplyResponse.self, from: data)
+            return try parseOptionalHTTPURL(
+                response.data.addPullRequestReviewThreadReply.comment.url,
+                context: "gh review thread reply returned an invalid URL"
+            )
+        } catch let error as CodeHostProviderError {
+            throw error
+        } catch {
+            throw CodeHostProviderError.malformedOutput("Unable to parse gh review thread reply output")
+        }
+    }
+
+    static func parseThreadStateResult(_ json: String, mutationName: String) throws {
+        let data = Data(json.utf8)
+        do {
+            switch mutationName {
+            case "resolveReviewThread":
+                _ = try JSONDecoder().decode(ResolveThreadStateResponse.self, from: data)
+            case "unresolveReviewThread":
+                _ = try JSONDecoder().decode(UnresolveThreadStateResponse.self, from: data)
+            default:
+                throw CodeHostProviderError.malformedOutput("Unsupported GitHub review thread mutation output")
+            }
+        } catch {
+            throw CodeHostProviderError.malformedOutput("Unable to parse gh \(mutationName) output")
+        }
+    }
+
     static func githubRunID(from url: URL?) -> String? {
         guard let url else { return nil }
         let components = url.pathComponents
@@ -462,7 +710,9 @@ struct GitHubCLIProvider: CodeHostProvider {
                 url: url,
                 isResolved: thread.isResolved,
                 isActionable: !thread.isResolved && !thread.isOutdated,
-                location: reviewThreadLocation(from: thread)
+                location: reviewThreadLocation(from: thread),
+                providerThreadID: thread.id,
+                providerCommentID: normalizedOptionalString(comment.id)
             )
         }
         return ReviewThreadsPage(threads: threads, pageInfo: connection.pageInfo)
@@ -619,6 +869,74 @@ struct GitHubCLIProvider: CodeHostProvider {
             threads: threads
         )
     }
+
+    private func pullRequestNodeID(remote: CodeHostRemote, request: ReviewRequest, cwd: URL) async throws -> String {
+        let stdin = try Self.graphQLInput(
+            query: Self.pullRequestNodeQuery,
+            variables: PullRequestNodeVariables(
+                owner: remote.owner,
+                repo: remote.repository,
+                number: request.number
+            )
+        )
+        let result = try await runner.run(
+            "gh",
+            args: ["api", "graphql", "--input", "-"],
+            cwd: cwd,
+            stdin: stdin
+        )
+        guard result.exitCode == 0 else {
+            throw CodeHostProviderError.commandFailed(command: "gh api graphql", stderr: result.stderr)
+        }
+        return try Self.parsePullRequestNodeID(result.stdout)
+    }
+
+    private func refreshedReviewRequest(remote: CodeHostRemote, request: ReviewRequest, cwd: URL) async throws -> ReviewRequest {
+        guard let refreshed = try await currentReviewRequest(
+            remote: remote,
+            branch: request.headRefName,
+            headOwner: nil,
+            baseBranch: request.baseRefName,
+            cwd: cwd
+        ) else {
+            throw CodeHostProviderError.malformedOutput("Unable to refresh GitHub PR after review mutation")
+        }
+        return refreshed
+    }
+
+    static func githubReviewEvent(for decision: ProviderReviewDecision) -> String {
+        switch decision {
+        case .comment: "COMMENT"
+        case .approve: "APPROVE"
+        case .requestChanges: "REQUEST_CHANGES"
+        }
+    }
+
+    static func githubReviewCommentPayload(for draft: ProviderReviewDraftComment) -> GitHubReviewDraftCommentPayload {
+        GitHubReviewDraftCommentPayload(
+            path: draft.path,
+            body: draft.bodyMarkdown,
+            line: draft.lineRange.upperBound,
+            side: draft.side == .old ? "LEFT" : "RIGHT",
+            startLine: draft.lineRange.lowerBound == draft.lineRange.upperBound ? nil : draft.lineRange.lowerBound
+        )
+    }
+
+    static func graphQLInput<Variables: Encodable>(query: String, variables: Variables) throws -> String {
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.sortedKeys]
+        do {
+            let data = try encoder.encode(GraphQLRequest(query: query, variables: variables))
+            guard let string = String(data: data, encoding: .utf8) else {
+                throw CodeHostProviderError.malformedOutput("Unable to encode gh graphql input")
+            }
+            return string
+        } catch let error as CodeHostProviderError {
+            throw error
+        } catch {
+            throw CodeHostProviderError.malformedOutput("Unable to encode gh graphql input")
+        }
+    }
 }
 
 private struct PRListItem: Decodable {
@@ -667,6 +985,141 @@ private struct CheckItem: Decodable {
 
 private struct RunItem: Decodable {
     let databaseId: Int
+}
+
+private struct GraphQLRequest<Variables: Encodable>: Encodable {
+    let query: String
+    let variables: Variables
+}
+
+private struct PullRequestNodeVariables: Encodable {
+    let owner: String
+    let repo: String
+    let number: Int
+}
+
+private struct PullRequestNodeResponse: Decodable {
+    let data: PullRequestNodeData
+}
+
+private struct PullRequestNodeData: Decodable {
+    let repository: PullRequestNodeRepository
+}
+
+private struct PullRequestNodeRepository: Decodable {
+    let pullRequest: PullRequestNodePullRequest
+}
+
+private struct PullRequestNodePullRequest: Decodable {
+    let id: String
+}
+
+struct GitHubReviewDraftCommentPayload: Encodable, Equatable {
+    let path: String
+    let body: String
+    let line: Int
+    let side: String
+    let startLine: Int?
+}
+
+private struct PublishReviewVariables: Encodable {
+    let input: PublishReviewInput
+}
+
+private struct PublishReviewInput: Encodable {
+    let pullRequestId: String
+    let event: String
+    let body: String
+    let comments: [GitHubReviewDraftCommentPayload]
+}
+
+private struct PublishReviewResponse: Decodable {
+    let data: PublishReviewData
+}
+
+private struct PublishReviewData: Decodable {
+    let addPullRequestReview: AddPullRequestReviewPayload
+}
+
+private struct AddPullRequestReviewPayload: Decodable {
+    let pullRequestReview: PublishedPullRequestReview
+}
+
+private struct PublishedPullRequestReview: Decodable {
+    let comments: PublishedReviewCommentsConnection
+}
+
+private struct PublishedReviewCommentsConnection: Decodable {
+    let nodes: [PublishedReviewCommentNode]
+}
+
+private struct PublishedReviewCommentNode: Decodable {
+    let id: String?
+    let url: String?
+    let pullRequestReviewThread: PublishedReviewThreadNode?
+}
+
+private struct PublishedReviewThreadNode: Decodable {
+    let id: String?
+}
+
+private struct ThreadReplyVariables: Encodable {
+    let input: ThreadReplyInput
+}
+
+private struct ThreadReplyInput: Encodable {
+    let pullRequestReviewThreadId: String
+    let body: String
+}
+
+private struct ThreadReplyResponse: Decodable {
+    let data: ThreadReplyData
+}
+
+private struct ThreadReplyData: Decodable {
+    let addPullRequestReviewThreadReply: AddPullRequestReviewThreadReplyPayload
+}
+
+private struct AddPullRequestReviewThreadReplyPayload: Decodable {
+    let comment: ThreadReplyComment
+}
+
+private struct ThreadReplyComment: Decodable {
+    let id: String?
+    let url: String?
+}
+
+private struct ThreadStateVariables: Encodable {
+    let input: ThreadStateInput
+}
+
+private struct ThreadStateInput: Encodable {
+    let threadId: String
+}
+
+private struct ResolveThreadStateResponse: Decodable {
+    let data: ResolveThreadStateData
+}
+
+private struct ResolveThreadStateData: Decodable {
+    let resolveReviewThread: ThreadStatePayload
+}
+
+private struct UnresolveThreadStateResponse: Decodable {
+    let data: UnresolveThreadStateData
+}
+
+private struct UnresolveThreadStateData: Decodable {
+    let unresolveReviewThread: ThreadStatePayload
+}
+
+private struct ThreadStatePayload: Decodable {
+    let thread: ThreadStateThread
+}
+
+private struct ThreadStateThread: Decodable {
+    let id: String
+    let isResolved: Bool
 }
 
 private struct ReviewThreadsResponse: Decodable {
@@ -739,9 +1192,25 @@ private struct ReviewThreadCommentsConnection: Decodable {
 }
 
 private struct ReviewThreadCommentNode: Decodable {
+    let id: String?
     let body: String
     let url: String?
     let author: ReviewThreadAuthor?
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        self.id = try? container.decode(String.self, forKey: .id)
+        self.body = try container.decode(String.self, forKey: .body)
+        self.url = try? container.decode(String.self, forKey: .url)
+        self.author = try? container.decode(ReviewThreadAuthor.self, forKey: .author)
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case id
+        case body
+        case url
+        case author
+    }
 }
 
 private struct ReviewThreadAuthor: Decodable {

--- a/Alas/Sources/Integrations/CodeHost/GitHubCLIProvider.swift
+++ b/Alas/Sources/Integrations/CodeHost/GitHubCLIProvider.swift
@@ -143,7 +143,7 @@ struct GitHubCLIProvider: CodeHostProvider {
                 "--state", "open",
                 "--limit", "20",
                 "--json", "number,title,url,state,isDraft,headRefName,headRefOid,headRepositoryOwner,baseRefName,reviewDecision,mergeStateStatus",
-                "-R", remote.repositorySlug,
+                "-R", Self.highLevelRepositorySelector(remote: remote),
             ],
             cwd: cwd
         )
@@ -180,7 +180,7 @@ struct GitHubCLIProvider: CodeHostProvider {
             "--head", head,
             "--title", title,
             "--body", body,
-            "-R", remote.repositorySlug,
+            "-R", Self.highLevelRepositorySelector(remote: remote),
         ]
         if isDraft {
             args.append("--draft")
@@ -214,7 +214,7 @@ struct GitHubCLIProvider: CodeHostProvider {
             args: [
                 "pr", "checks", "\(request.number)",
                 "--json", "bucket,completedAt,description,event,link,name,startedAt,state,workflow",
-                "-R", remote.repositorySlug,
+                "-R", Self.highLevelRepositorySelector(remote: remote),
             ],
             cwd: cwd
         )
@@ -231,7 +231,7 @@ struct GitHubCLIProvider: CodeHostProvider {
     func reviewDiff(remote: CodeHostRemote, request: ReviewRequest, cwd: URL) async throws -> String {
         let result = try await runner.run(
             "gh",
-            args: ["pr", "diff", "\(request.number)", "-R", remote.repositorySlug],
+            args: ["pr", "diff", "\(request.number)", "-R", Self.highLevelRepositorySelector(remote: remote)],
             cwd: cwd
         )
         guard result.exitCode == 0 else {
@@ -270,7 +270,7 @@ struct GitHubCLIProvider: CodeHostProvider {
             )
         }
 
-        var args = ["run", "view", runID, "--log-failed", "-R", remote.repositorySlug]
+        var args = ["run", "view", runID, "--log-failed", "-R", Self.highLevelRepositorySelector(remote: remote)]
         if let jobID = Self.githubJobID(from: item.providerURL) {
             args.append(contentsOf: ["--job", jobID])
         }
@@ -519,7 +519,7 @@ struct GitHubCLIProvider: CodeHostProvider {
             args: [
                 "pr", "view", "\(request.number)",
                 "--json", "number,title,url,state,isDraft,headRefName,headRefOid,headRepositoryOwner,baseRefName,reviewDecision,mergeStateStatus",
-                "-R", remote.repositorySlug,
+                "-R", Self.highLevelRepositorySelector(remote: remote),
             ],
             cwd: cwd
         )
@@ -619,7 +619,7 @@ struct GitHubCLIProvider: CodeHostProvider {
                 "--status", "failure",
                 "--limit", "20",
                 "--json", "databaseId,status,conclusion,url",
-                "-R", remote.repositorySlug,
+                "-R", Self.highLevelRepositorySelector(remote: remote),
             ],
             cwd: cwd
         )
@@ -630,7 +630,7 @@ struct GitHubCLIProvider: CodeHostProvider {
         for runID in try Self.parseRunIDs(listResult.stdout) {
             let rerunResult = try await runner.run(
                 "gh",
-                args: ["run", "rerun", "\(runID)", "--failed", "-R", remote.repositorySlug],
+                args: ["run", "rerun", "\(runID)", "--failed", "-R", Self.highLevelRepositorySelector(remote: remote)],
                 cwd: cwd
             )
             guard rerunResult.exitCode == 0 else {
@@ -1095,6 +1095,10 @@ struct GitHubCLIProvider: CodeHostProvider {
 
     static func graphQLAPIStdinArgs(remote: CodeHostRemote) -> [String] {
         ["api", "graphql", "--hostname", remote.host, "--input", "-"]
+    }
+
+    static func highLevelRepositorySelector(remote: CodeHostRemote) -> String {
+        remote.host == "github.com" ? remote.repositorySlug : "\(remote.host)/\(remote.repositorySlug)"
     }
 
     static func githubReviewThreadPayload(for draft: ProviderReviewDraftComment) -> GitHubReviewDraftThreadPayload {

--- a/Alas/Sources/Integrations/CodeHost/GitHubCLIProvider.swift
+++ b/Alas/Sources/Integrations/CodeHost/GitHubCLIProvider.swift
@@ -574,11 +574,11 @@ struct GitHubCLIProvider: CodeHostProvider {
             providerURL = nil
         }
 
-        let refreshedRequest = try await refreshedReviewRequest(
+        let refreshedRequest = (try? await refreshedReviewRequest(
             remote: mutation.remote,
             request: mutation.reviewRequest,
             cwd: mutation.cwd
-        )
+        )) ?? mutation.reviewRequest
         return ProviderThreadMutationResult(refreshedRequest: refreshedRequest, providerURL: providerURL)
     }
 

--- a/Alas/Sources/Integrations/CodeHost/GitHubCLIProvider.swift
+++ b/Alas/Sources/Integrations/CodeHost/GitHubCLIProvider.swift
@@ -372,11 +372,94 @@ struct GitHubCLIProvider: CodeHostProvider {
             request: request.reviewRequest,
             cwd: request.cwd
         )
+
+        let published = await publishReviewWithFallback(
+            pullRequestID: pullRequestID,
+            request: request,
+            publishableComments: publishableComments
+        )
+        var warnings = published.warnings
+        let refreshedRequest: ReviewRequest
+        do {
+            refreshedRequest = try await refreshedReviewRequest(
+                remote: request.remote,
+                request: request.reviewRequest,
+                cwd: request.cwd
+            )
+        } catch {
+            refreshedRequest = request.reviewRequest
+            warnings.append("GitHub review was published, but Alas could not refresh the PR: \(error.localizedDescription)")
+        }
+        return ProviderReviewPublishResult(
+            published: published.published,
+            failed: preflightFailures + published.failed,
+            refreshedRequest: refreshedRequest,
+            warnings: warnings
+        )
+    }
+
+    private func publishReviewWithFallback(
+        pullRequestID: String,
+        request: ProviderReviewPublishRequest,
+        publishableComments: [ProviderReviewDraftComment]
+    ) async -> (published: [ProviderReviewPublishedComment], failed: [ProviderReviewFailedComment], warnings: [String]) {
+        do {
+            let published = try await submitReview(
+                pullRequestID: pullRequestID,
+                comments: publishableComments,
+                decision: request.decision,
+                summaryBody: request.summaryBody,
+                cwd: request.cwd
+            )
+            return (published.published, published.failed, [])
+        } catch {
+            guard publishableComments.count > 1 else {
+                return (
+                    [],
+                    publishableComments.map {
+                        ProviderReviewFailedComment(localDraftID: $0.localDraftID, message: error.localizedDescription)
+                    },
+                    []
+                )
+            }
+
+            var published: [ProviderReviewPublishedComment] = []
+            var failed: [ProviderReviewFailedComment] = []
+            for comment in publishableComments {
+                do {
+                    let result = try await submitReview(
+                        pullRequestID: pullRequestID,
+                        comments: [comment],
+                        decision: .comment,
+                        summaryBody: request.summaryBody,
+                        cwd: request.cwd
+                    )
+                    published.append(contentsOf: result.published)
+                    failed.append(contentsOf: result.failed)
+                } catch {
+                    failed.append(ProviderReviewFailedComment(localDraftID: comment.localDraftID, message: error.localizedDescription))
+                }
+            }
+            return (
+                published,
+                failed,
+                ["GitHub rejected the batch review; Alas retried publishable comments individually without submitting the review decision."]
+            )
+        }
+    }
+
+    private func submitReview(
+        pullRequestID: String,
+        comments: [ProviderReviewDraftComment],
+        decision: ProviderReviewDecision,
+        summaryBody: String,
+        cwd: URL
+    ) async throws -> (published: [ProviderReviewPublishedComment], failed: [ProviderReviewFailedComment]) {
         let input = PublishReviewInput(
             pullRequestId: pullRequestID,
-            event: Self.githubReviewEvent(for: request.decision),
-            body: request.summaryBody,
-            threads: publishableComments.map(Self.githubReviewThreadPayload(for:))
+            event: Self.githubReviewEvent(for: decision),
+            body: summaryBody,
+            threads: comments.map(Self.githubReviewThreadPayload(for:))
         )
         let stdin = try Self.graphQLInput(
             query: Self.publishReviewMutation,
@@ -385,25 +468,33 @@ struct GitHubCLIProvider: CodeHostProvider {
         let result = try await runner.run(
             "gh",
             args: ["api", "graphql", "--input", "-"],
-            cwd: request.cwd,
+            cwd: cwd,
             stdin: stdin
         )
         guard result.exitCode == 0 else {
             throw CodeHostProviderError.commandFailed(command: "gh api graphql", stderr: result.stderr)
         }
 
-        let published = try Self.parsePublishReviewResult(result.stdout, drafts: publishableComments)
-        let refreshedRequest = try await refreshedReviewRequest(
-            remote: request.remote,
-            request: request.reviewRequest,
-            cwd: request.cwd
+        return try Self.parsePublishReviewResult(result.stdout, drafts: comments)
+    }
+
+    private func refreshedReviewRequest(remote: CodeHostRemote, request: ReviewRequest, cwd: URL) async throws -> ReviewRequest {
+        let result = try await runner.run(
+            "gh",
+            args: [
+                "pr", "view", "\(request.number)",
+                "--json", "number,title,url,state,isDraft,headRefName,headRepositoryOwner,baseRefName,reviewDecision,mergeStateStatus",
+                "-R", remote.repositorySlug,
+            ],
+            cwd: cwd
         )
-        return ProviderReviewPublishResult(
-            published: published.published,
-            failed: preflightFailures + published.failed,
-            refreshedRequest: refreshedRequest,
-            warnings: []
-        )
+        guard result.exitCode == 0 else {
+            throw CodeHostProviderError.commandFailed(command: "gh pr view", stderr: result.stderr)
+        }
+
+        let request = try Self.parsePRView(result.stdout, remote: remote)
+        let threads = (try? await reviewThreads(remote: remote, request: request, cwd: cwd)) ?? []
+        return Self.withThreads(threads, on: request)
     }
 
     func mutateReviewThread(_ mutation: ProviderThreadMutation) async throws -> ProviderThreadMutationResult {
@@ -934,25 +1025,6 @@ struct GitHubCLIProvider: CodeHostProvider {
             throw CodeHostProviderError.commandFailed(command: "gh api graphql", stderr: result.stderr)
         }
         return try Self.parsePullRequestNodeID(result.stdout)
-    }
-
-    private func refreshedReviewRequest(remote: CodeHostRemote, request: ReviewRequest, cwd: URL) async throws -> ReviewRequest {
-        let result = try await runner.run(
-            "gh",
-            args: [
-                "pr", "view", "\(request.number)",
-                "--json", "number,title,url,state,isDraft,headRefName,headRepositoryOwner,baseRefName,reviewDecision,mergeStateStatus",
-                "-R", remote.repositorySlug,
-            ],
-            cwd: cwd
-        )
-        guard result.exitCode == 0 else {
-            throw CodeHostProviderError.commandFailed(command: "gh pr view", stderr: result.stderr)
-        }
-
-        let request = try Self.parsePRView(result.stdout, remote: remote)
-        let threads = (try? await reviewThreads(remote: remote, request: request, cwd: cwd)) ?? []
-        return Self.withThreads(threads, on: request)
     }
 
     static func githubReviewEvent(for decision: ProviderReviewDecision) -> String {

--- a/Alas/Sources/Integrations/CodeHost/GitLabCLIProvider.swift
+++ b/Alas/Sources/Integrations/CodeHost/GitLabCLIProvider.swift
@@ -1,3 +1,4 @@
+import CryptoKit
 import Foundation
 
 struct GitLabCLIProvider: CodeHostProvider {
@@ -191,21 +192,28 @@ struct GitLabCLIProvider: CodeHostProvider {
             }
         }
 
-        switch request.decision {
-        case .comment:
-            break
-        case .approve:
-            try await approveMergeRequest(remote: request.remote, request: request.reviewRequest, cwd: request.cwd)
-        case .requestChanges:
-            try await createRequestChangesNote(
-                remote: request.remote,
-                request: request.reviewRequest,
-                body: request.summaryBody,
-                cwd: request.cwd
-            )
+        var warnings: [String] = []
+        do {
+            switch request.decision {
+            case .comment:
+                break
+            case .approve:
+                try await approveMergeRequest(remote: request.remote, request: request.reviewRequest, cwd: request.cwd)
+            case .requestChanges:
+                try await createRequestChangesNote(
+                    remote: request.remote,
+                    request: request.reviewRequest,
+                    body: request.summaryBody,
+                    cwd: request.cwd
+                )
+            }
+        } catch {
+            guard !published.isEmpty else {
+                throw error
+            }
+            warnings.append("GitLab review comments were published, but Alas could not submit the review decision: \(error.localizedDescription)")
         }
 
-        var warnings: [String] = []
         let refreshedRequest: ReviewRequest
         do {
             refreshedRequest = try await refreshedReviewRequest(
@@ -1261,6 +1269,7 @@ private struct GitLabCreateDiscussionPosition: Encodable {
     let newPath: String
     let oldLine: Int?
     let newLine: Int?
+    let lineRange: GitLabCreateDiscussionLineRange?
 
     init(comment: ProviderReviewDraftComment, diffRefs: GitLabDiffRefs) {
         self.baseSHA = diffRefs.baseSHA
@@ -1268,16 +1277,30 @@ private struct GitLabCreateDiscussionPosition: Encodable {
         self.headSHA = diffRefs.headSHA
         self.oldPath = comment.originalPath ?? comment.path
         self.newPath = comment.path
+        let sideType: GitLabCreateDiscussionLineRangePoint.LineType
         switch comment.side {
         case .old:
             self.oldLine = comment.lineRange.upperBound
             self.newLine = nil
+            sideType = .old
         case .new:
             self.oldLine = nil
             self.newLine = comment.lineRange.upperBound
+            sideType = .new
         case .unknown:
             self.oldLine = nil
             self.newLine = nil
+            sideType = .old
+        }
+        if comment.lineRange.lowerBound == comment.lineRange.upperBound {
+            self.lineRange = nil
+        } else {
+            self.lineRange = GitLabCreateDiscussionLineRange(
+                path: sideType == .old ? self.oldPath : self.newPath,
+                type: sideType,
+                startLine: comment.lineRange.lowerBound,
+                endLine: comment.lineRange.upperBound
+            )
         }
     }
 
@@ -1290,6 +1313,60 @@ private struct GitLabCreateDiscussionPosition: Encodable {
         case newPath = "new_path"
         case oldLine = "old_line"
         case newLine = "new_line"
+        case lineRange = "line_range"
+    }
+}
+
+private struct GitLabCreateDiscussionLineRange: Encodable {
+    let start: GitLabCreateDiscussionLineRangePoint
+    let end: GitLabCreateDiscussionLineRangePoint
+
+    init(
+        path: String,
+        type: GitLabCreateDiscussionLineRangePoint.LineType,
+        startLine: Int,
+        endLine: Int
+    ) {
+        self.start = GitLabCreateDiscussionLineRangePoint(path: path, type: type, line: startLine)
+        self.end = GitLabCreateDiscussionLineRangePoint(path: path, type: type, line: endLine)
+    }
+}
+
+private struct GitLabCreateDiscussionLineRangePoint: Encodable {
+    enum LineType: String, Encodable {
+        case old
+        case new
+    }
+
+    let lineCode: String
+    let type: LineType
+    let oldLine: Int?
+    let newLine: Int?
+
+    init(path: String, type: LineType, line: Int) {
+        self.lineCode = "\(Self.sha1Hex(path))_\(line)_\(line)"
+        self.type = type
+        switch type {
+        case .old:
+            self.oldLine = line
+            self.newLine = nil
+        case .new:
+            self.oldLine = nil
+            self.newLine = line
+        }
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case lineCode = "line_code"
+        case type
+        case oldLine = "old_line"
+        case newLine = "new_line"
+    }
+
+    private static func sha1Hex(_ value: String) -> String {
+        Insecure.SHA1.hash(data: Data(value.utf8))
+            .map { String(format: "%02x", $0) }
+            .joined()
     }
 }
 

--- a/Alas/Sources/Integrations/CodeHost/GitLabCLIProvider.swift
+++ b/Alas/Sources/Integrations/CodeHost/GitLabCLIProvider.swift
@@ -1117,6 +1117,7 @@ struct GitLabCLIProvider: CodeHostProvider {
             isDraft: request.isDraft,
             headRefName: request.headRefName,
             baseRefName: request.baseRefName,
+            headSHA: request.headSHA,
             reviewDecision: request.reviewDecision,
             mergeState: request.mergeState,
             checks: checks,

--- a/Alas/Sources/Integrations/CodeHost/GitLabCLIProvider.swift
+++ b/Alas/Sources/Integrations/CodeHost/GitLabCLIProvider.swift
@@ -447,7 +447,7 @@ struct GitLabCLIProvider: CodeHostProvider {
         guard result.exitCode == 0 else {
             throw CodeHostProviderError.commandFailed(command: "glab api merge request versions", stderr: result.stderr)
         }
-        return try Self.parseDiffRefs(result.stdout)
+        return try Self.parseDiffRefs(result.stdout, reviewedHeadSHA: request.headSHA)
     }
 
     private func createDiscussion(
@@ -763,16 +763,27 @@ struct GitLabCLIProvider: CodeHostProvider {
         }
     }
 
-    static func parseDiffRefs(_ json: String) throws -> GitLabDiffRefs {
+    static func parseDiffRefs(_ json: String, reviewedHeadSHA: String? = nil) throws -> GitLabDiffRefs {
         let data = Data(json.utf8)
         let decoder = JSONDecoder()
         do {
-            if let versions = try? decoder.decode([GitLabMRVersion].self, from: data),
-               let refs = versions.first?.diffRefs {
-                return try refs.validated()
+            if let versions = try? decoder.decode([GitLabMRVersion].self, from: data) {
+                guard !versions.isEmpty else {
+                    throw CodeHostProviderError.malformedOutput("glab api merge request versions output is missing diff refs")
+                }
+                if let reviewedHeadSHA = normalizedOptionalString(reviewedHeadSHA) {
+                    guard let refs = versions.first(where: { $0.diffRefs.headSHA == reviewedHeadSHA })?.diffRefs else {
+                        throw CodeHostProviderError.malformedOutput("Unable to find GitLab diff refs for reviewed head SHA.")
+                    }
+                    return try refs.validated()
+                }
+                return try versions[0].diffRefs.validated()
             }
-            let version = try decoder.decode(GitLabMRVersion.self, from: data)
-            return try version.diffRefs.validated()
+            let refs = try decoder.decode(GitLabMRVersion.self, from: data).diffRefs
+            if let reviewedHeadSHA = normalizedOptionalString(reviewedHeadSHA), refs.headSHA != reviewedHeadSHA {
+                throw CodeHostProviderError.malformedOutput("Unable to find GitLab diff refs for reviewed head SHA.")
+            }
+            return try refs.validated()
         } catch let error as CodeHostProviderError {
             throw error
         } catch {

--- a/Alas/Sources/Integrations/CodeHost/GitLabCLIProvider.swift
+++ b/Alas/Sources/Integrations/CodeHost/GitLabCLIProvider.swift
@@ -477,6 +477,10 @@ struct GitLabCLIProvider: CodeHostProvider {
     }
 
     private func approveMergeRequest(remote: CodeHostRemote, request: ReviewRequest, cwd: URL) async throws {
+        guard let headSHA = Self.normalizedOptionalString(request.headSHA) else {
+            throw CodeHostProviderError.malformedOutput("GitLab approval requires the reviewed merge request head SHA.")
+        }
+        let payload = GitLabApproveMergeRequestPayload(sha: headSHA)
         let result = try await runner.run(
             "glab",
             args: [
@@ -484,8 +488,10 @@ struct GitLabCLIProvider: CodeHostProvider {
                 "projects/:id/merge_requests/\(request.number)/approve",
                 "--method", "POST",
                 "--hostname", remote.host,
+                "--input", "-",
             ],
-            cwd: cwd
+            cwd: cwd,
+            stdin: try Self.encodedJSON(payload)
         )
         guard result.exitCode == 0 else {
             throw CodeHostProviderError.commandFailed(command: "glab api merge request approve", stderr: result.stderr)
@@ -898,6 +904,7 @@ struct GitLabCLIProvider: CodeHostProvider {
             isDraft: item.isDraft,
             headRefName: item.sourceBranch,
             baseRefName: item.targetBranch,
+            headSHA: normalizedOptionalString(item.sha),
             reviewDecision: mapReviewDecision(approvalsRequired: item.approvalsRequired, approvalsLeft: item.approvalsLeft),
             mergeState: mapMergeState(detailed: item.detailedMergeStatus, fallback: item.mergeStatus),
             checks: [],
@@ -1121,6 +1128,7 @@ struct GitLabCLIProvider: CodeHostProvider {
 private struct MRListItem: Decodable {
     let id: Int?
     let iid: Int?
+    let sha: String?
     let title: String
     let webURL: String
     let state: String
@@ -1158,6 +1166,7 @@ private struct MRListItem: Decodable {
     private enum CodingKeys: String, CodingKey {
         case id
         case iid
+        case sha
         case title
         case webURL = "web_url"
         case state
@@ -1385,6 +1394,10 @@ private struct GitLabCreateDiscussionLineRangePoint: Encodable {
 
 private struct GitLabBodyPayload: Encodable {
     let body: String
+}
+
+private struct GitLabApproveMergeRequestPayload: Encodable {
+    let sha: String
 }
 
 private struct GitLabResolveDiscussionPayload: Encodable {

--- a/Alas/Sources/Integrations/CodeHost/GitLabCLIProvider.swift
+++ b/Alas/Sources/Integrations/CodeHost/GitLabCLIProvider.swift
@@ -191,6 +191,14 @@ struct GitLabCLIProvider: CodeHostProvider {
                 failed.append(ProviderReviewFailedComment(localDraftID: comment.localDraftID, message: error.localizedDescription))
             }
         }
+        guard request.comments.isEmpty || !published.isEmpty else {
+            return ProviderReviewPublishResult(
+                published: [],
+                failed: failed,
+                refreshedRequest: request.reviewRequest,
+                warnings: []
+            )
+        }
 
         var warnings: [String] = []
         do {

--- a/Alas/Sources/Integrations/CodeHost/GitLabCLIProvider.swift
+++ b/Alas/Sources/Integrations/CodeHost/GitLabCLIProvider.swift
@@ -78,6 +78,10 @@ struct GitLabCLIProvider: CodeHostProvider {
         return Self.withEnrichment(threads: threads, checks: checks, on: detailedRequest)
     }
 
+    func reviewRequest(remote: CodeHostRemote, number: Int, cwd: URL) async throws -> ReviewRequest {
+        try await refreshedReviewRequest(remote: remote, request: ReviewRequest.placeholder(remote: remote, number: number), cwd: cwd)
+    }
+
     func createReviewRequest(
         remote: CodeHostRemote,
         branch: String,
@@ -1352,13 +1356,14 @@ private struct GitLabCreateDiscussionLineRangePoint: Encodable {
     let newLine: Int?
 
     init(path: String, type: LineType, line: Int) {
-        self.lineCode = "\(Self.sha1Hex(path))_\(line)_\(line)"
         self.type = type
         switch type {
         case .old:
+            self.lineCode = "\(Self.sha1Hex(path))_\(line)_0"
             self.oldLine = line
             self.newLine = nil
         case .new:
+            self.lineCode = "\(Self.sha1Hex(path))_0_\(line)"
             self.oldLine = nil
             self.newLine = line
         }

--- a/Alas/Sources/Integrations/CodeHost/GitLabCLIProvider.swift
+++ b/Alas/Sources/Integrations/CodeHost/GitLabCLIProvider.swift
@@ -212,12 +212,7 @@ struct GitLabCLIProvider: CodeHostProvider {
             case .approve:
                 try await approveMergeRequest(remote: request.remote, request: request.reviewRequest, cwd: request.cwd)
             case .requestChanges:
-                try await createRequestChangesNote(
-                    remote: request.remote,
-                    request: request.reviewRequest,
-                    body: request.summaryBody,
-                    cwd: request.cwd
-                )
+                throw CodeHostProviderError.malformedOutput("GitLab request-changes review state is not supported yet.")
             }
         } catch {
             guard !published.isEmpty else {
@@ -273,14 +268,7 @@ struct GitLabCLIProvider: CodeHostProvider {
             )
             providerURL = nil
         case .unresolve:
-            try await setDiscussionResolved(
-                remote: mutation.remote,
-                request: mutation.reviewRequest,
-                discussionID: discussionID,
-                resolved: false,
-                cwd: mutation.cwd
-            )
-            providerURL = nil
+            throw CodeHostProviderError.malformedOutput("GitLab unresolve is not supported until resolved discussions are loaded.")
         }
 
         let refreshedRequest = (try? await refreshedReviewRequest(
@@ -495,30 +483,6 @@ struct GitLabCLIProvider: CodeHostProvider {
         )
         guard result.exitCode == 0 else {
             throw CodeHostProviderError.commandFailed(command: "glab api merge request approve", stderr: result.stderr)
-        }
-    }
-
-    private func createRequestChangesNote(
-        remote: CodeHostRemote,
-        request: ReviewRequest,
-        body: String,
-        cwd: URL
-    ) async throws {
-        let payload = GitLabBodyPayload(body: Self.normalizedOptionalString(body) ?? "Changes requested.")
-        let result = try await runner.run(
-            "glab",
-            args: [
-                "api",
-                "projects/:id/merge_requests/\(request.number)/notes",
-                "--method", "POST",
-                "--hostname", remote.host,
-                "--input", "-",
-            ],
-            cwd: cwd,
-            stdin: try Self.encodedJSON(payload)
-        )
-        guard result.exitCode == 0 else {
-            throw CodeHostProviderError.commandFailed(command: "glab api merge request notes", stderr: result.stderr)
         }
     }
 

--- a/Alas/Sources/Integrations/CodeHost/GitLabCLIProvider.swift
+++ b/Alas/Sources/Integrations/CodeHost/GitLabCLIProvider.swift
@@ -150,6 +150,127 @@ struct GitLabCLIProvider: CodeHostProvider {
         return result.stdout
     }
 
+    func publishReview(_ request: ProviderReviewPublishRequest) async throws -> ProviderReviewPublishResult {
+        let publishableComments = request.comments.filter { $0.side != .unknown }
+        let preflightFailures = request.comments
+            .filter { $0.side == .unknown }
+            .map {
+                ProviderReviewFailedComment(
+                    localDraftID: $0.localDraftID,
+                    message: "GitLab review comments require an old or new side."
+                )
+            }
+        guard !publishableComments.isEmpty || request.comments.isEmpty else {
+            return ProviderReviewPublishResult(
+                published: [],
+                failed: preflightFailures,
+                refreshedRequest: request.reviewRequest,
+                warnings: []
+            )
+        }
+
+        let diffRefs = publishableComments.isEmpty
+            ? nil
+            : try await mergeRequestDiffRefs(remote: request.remote, request: request.reviewRequest, cwd: request.cwd)
+        var published: [ProviderReviewPublishedComment] = []
+        var failed: [ProviderReviewFailedComment] = preflightFailures
+
+        for comment in publishableComments {
+            guard let diffRefs else { break }
+            do {
+                let mapping = try await createDiscussion(
+                    remote: request.remote,
+                    request: request.reviewRequest,
+                    comment: comment,
+                    diffRefs: diffRefs,
+                    cwd: request.cwd
+                )
+                published.append(mapping)
+            } catch {
+                failed.append(ProviderReviewFailedComment(localDraftID: comment.localDraftID, message: error.localizedDescription))
+            }
+        }
+
+        switch request.decision {
+        case .comment:
+            break
+        case .approve:
+            try await approveMergeRequest(remote: request.remote, request: request.reviewRequest, cwd: request.cwd)
+        case .requestChanges:
+            try await createRequestChangesNote(
+                remote: request.remote,
+                request: request.reviewRequest,
+                body: request.summaryBody,
+                cwd: request.cwd
+            )
+        }
+
+        var warnings: [String] = []
+        let refreshedRequest: ReviewRequest
+        do {
+            refreshedRequest = try await refreshedReviewRequest(
+                remote: request.remote,
+                request: request.reviewRequest,
+                cwd: request.cwd
+            )
+        } catch {
+            refreshedRequest = request.reviewRequest
+            warnings.append("GitLab review was published, but Alas could not refresh the MR: \(error.localizedDescription)")
+        }
+        return ProviderReviewPublishResult(
+            published: published,
+            failed: failed,
+            refreshedRequest: refreshedRequest,
+            warnings: warnings
+        )
+    }
+
+    func mutateReviewThread(_ mutation: ProviderThreadMutation) async throws -> ProviderThreadMutationResult {
+        guard let discussionID = Self.normalizedOptionalString(mutation.thread.providerThreadID) else {
+            throw CodeHostProviderError.malformedOutput("GitLab thread mutation requires a discussion id.")
+        }
+
+        let providerURL: URL?
+        switch mutation.kind {
+        case .reply:
+            guard let body = Self.normalizedOptionalString(mutation.bodyMarkdown) else {
+                throw CodeHostProviderError.malformedOutput("GitLab reply requires a non-empty body.")
+            }
+            providerURL = try await createDiscussionNote(
+                remote: mutation.remote,
+                request: mutation.reviewRequest,
+                discussionID: discussionID,
+                body: body,
+                cwd: mutation.cwd
+            )
+        case .resolve:
+            try await setDiscussionResolved(
+                remote: mutation.remote,
+                request: mutation.reviewRequest,
+                discussionID: discussionID,
+                resolved: true,
+                cwd: mutation.cwd
+            )
+            providerURL = nil
+        case .unresolve:
+            try await setDiscussionResolved(
+                remote: mutation.remote,
+                request: mutation.reviewRequest,
+                discussionID: discussionID,
+                resolved: false,
+                cwd: mutation.cwd
+            )
+            providerURL = nil
+        }
+
+        let refreshedRequest = (try? await refreshedReviewRequest(
+            remote: mutation.remote,
+            request: mutation.reviewRequest,
+            cwd: mutation.cwd
+        )) ?? mutation.reviewRequest
+        return ProviderThreadMutationResult(refreshedRequest: refreshedRequest, providerURL: providerURL)
+    }
+
     func failedCheckEvidence(remote: CodeHostRemote, request: ReviewRequest, cwd: URL) async throws -> [ReviewEvidenceItem] {
         ReviewEvidenceCIActivityMapper.items(for: request.checks)
     }
@@ -274,6 +395,155 @@ struct GitLabCLIProvider: CodeHostProvider {
         }
 
         return try Self.parseMRView(result.stdout, remote: remote)
+    }
+
+    private func refreshedReviewRequest(
+        remote: CodeHostRemote,
+        request: ReviewRequest,
+        cwd: URL
+    ) async throws -> ReviewRequest {
+        let refreshed = try await reviewRequestDetails(remote: remote, request: request, cwd: cwd)
+        let threads = (try? await unresolvedDiscussions(remote: remote, request: refreshed, cwd: cwd)) ?? []
+        let checks = (try? await checks(remote: remote, request: refreshed, cwd: cwd)) ?? []
+        return Self.withEnrichment(threads: threads, checks: checks, on: refreshed)
+    }
+
+    private func mergeRequestDiffRefs(
+        remote: CodeHostRemote,
+        request: ReviewRequest,
+        cwd: URL
+    ) async throws -> GitLabDiffRefs {
+        let result = try await runner.run(
+            "glab",
+            args: [
+                "api",
+                "projects/:id/merge_requests/\(request.number)/versions",
+                "--hostname", remote.host,
+                "--output", "json",
+            ],
+            cwd: cwd
+        )
+        guard result.exitCode == 0 else {
+            throw CodeHostProviderError.commandFailed(command: "glab api merge request versions", stderr: result.stderr)
+        }
+        return try Self.parseDiffRefs(result.stdout)
+    }
+
+    private func createDiscussion(
+        remote: CodeHostRemote,
+        request: ReviewRequest,
+        comment: ProviderReviewDraftComment,
+        diffRefs: GitLabDiffRefs,
+        cwd: URL
+    ) async throws -> ProviderReviewPublishedComment {
+        let payload = GitLabCreateDiscussionPayload(comment: comment, diffRefs: diffRefs)
+        let stdin = try Self.encodedJSON(payload)
+        let result = try await runner.run(
+            "glab",
+            args: [
+                "api",
+                "projects/:id/merge_requests/\(request.number)/discussions",
+                "--method", "POST",
+                "--hostname", remote.host,
+                "--input", "-",
+            ],
+            cwd: cwd,
+            stdin: stdin
+        )
+        guard result.exitCode == 0 else {
+            throw CodeHostProviderError.commandFailed(command: "glab api merge request discussions", stderr: result.stderr)
+        }
+        return try Self.parsePublishedDiscussion(result.stdout, localDraftID: comment.localDraftID)
+    }
+
+    private func approveMergeRequest(remote: CodeHostRemote, request: ReviewRequest, cwd: URL) async throws {
+        let result = try await runner.run(
+            "glab",
+            args: [
+                "api",
+                "projects/:id/merge_requests/\(request.number)/approve",
+                "--method", "POST",
+                "--hostname", remote.host,
+            ],
+            cwd: cwd
+        )
+        guard result.exitCode == 0 else {
+            throw CodeHostProviderError.commandFailed(command: "glab api merge request approve", stderr: result.stderr)
+        }
+    }
+
+    private func createRequestChangesNote(
+        remote: CodeHostRemote,
+        request: ReviewRequest,
+        body: String,
+        cwd: URL
+    ) async throws {
+        let payload = GitLabBodyPayload(body: Self.normalizedOptionalString(body) ?? "Changes requested.")
+        let result = try await runner.run(
+            "glab",
+            args: [
+                "api",
+                "projects/:id/merge_requests/\(request.number)/notes",
+                "--method", "POST",
+                "--hostname", remote.host,
+                "--input", "-",
+            ],
+            cwd: cwd,
+            stdin: try Self.encodedJSON(payload)
+        )
+        guard result.exitCode == 0 else {
+            throw CodeHostProviderError.commandFailed(command: "glab api merge request notes", stderr: result.stderr)
+        }
+    }
+
+    @discardableResult
+    private func createDiscussionNote(
+        remote: CodeHostRemote,
+        request: ReviewRequest,
+        discussionID: String,
+        body: String,
+        cwd: URL
+    ) async throws -> URL? {
+        let result = try await runner.run(
+            "glab",
+            args: [
+                "api",
+                "projects/:id/merge_requests/\(request.number)/discussions/\(discussionID)/notes",
+                "--method", "POST",
+                "--hostname", remote.host,
+                "--input", "-",
+            ],
+            cwd: cwd,
+            stdin: try Self.encodedJSON(GitLabBodyPayload(body: body))
+        )
+        guard result.exitCode == 0 else {
+            throw CodeHostProviderError.commandFailed(command: "glab api merge request discussion note", stderr: result.stderr)
+        }
+        return try Self.parseCreatedNoteURL(result.stdout)
+    }
+
+    private func setDiscussionResolved(
+        remote: CodeHostRemote,
+        request: ReviewRequest,
+        discussionID: String,
+        resolved: Bool,
+        cwd: URL
+    ) async throws {
+        let result = try await runner.run(
+            "glab",
+            args: [
+                "api",
+                "projects/:id/merge_requests/\(request.number)/discussions/\(discussionID)",
+                "--method", "PUT",
+                "--hostname", remote.host,
+                "--input", "-",
+            ],
+            cwd: cwd,
+            stdin: try Self.encodedJSON(GitLabResolveDiscussionPayload(resolved: resolved))
+        )
+        guard result.exitCode == 0 else {
+            throw CodeHostProviderError.commandFailed(command: "glab api merge request discussion", stderr: result.stderr)
+        }
     }
 
     private func sourceProjectPathsByID(
@@ -447,9 +717,71 @@ struct GitLabCLIProvider: CodeHostProvider {
                 url: try discussionURL(note: note, requestURL: requestURL),
                 isResolved: discussion.isResolved,
                 isActionable: !discussion.isResolved,
-                location: reviewThreadLocation(from: note)
+                location: reviewThreadLocation(from: note),
+                providerThreadID: discussion.id,
+                providerCommentID: note.id.map(String.init)
             )
         }
+    }
+
+    static func parseDiffRefs(_ json: String) throws -> GitLabDiffRefs {
+        let data = Data(json.utf8)
+        let decoder = JSONDecoder()
+        do {
+            if let versions = try? decoder.decode([GitLabMRVersion].self, from: data),
+               let refs = versions.first?.diffRefs {
+                return try refs.validated()
+            }
+            let version = try decoder.decode(GitLabMRVersion.self, from: data)
+            return try version.diffRefs.validated()
+        } catch let error as CodeHostProviderError {
+            throw error
+        } catch {
+            throw CodeHostProviderError.malformedOutput("Unable to parse glab api merge request versions output")
+        }
+    }
+
+    static func parsePublishedDiscussion(
+        _ json: String,
+        localDraftID: String
+    ) throws -> ProviderReviewPublishedComment {
+        let data = Data(json.utf8)
+        let discussion: GitLabDiscussion
+        do {
+            discussion = try JSONDecoder().decode(GitLabDiscussion.self, from: data)
+        } catch {
+            throw CodeHostProviderError.malformedOutput("Unable to parse glab api merge request discussion output")
+        }
+        let note = discussion.notes.first { !($0.system ?? false) }
+        return ProviderReviewPublishedComment(
+            localDraftID: localDraftID,
+            providerThreadID: discussion.id,
+            providerCommentID: note?.id.map(String.init),
+            providerURL: try note.flatMap {
+                try parseOptionalHTTPURL($0.webURL, context: "glab api merge request discussion returned an invalid URL")
+            }
+        )
+    }
+
+    static func parseCreatedNoteURL(_ json: String) throws -> URL? {
+        let data = Data(json.utf8)
+        let note: GitLabCreatedNote
+        do {
+            note = try JSONDecoder().decode(GitLabCreatedNote.self, from: data)
+        } catch {
+            throw CodeHostProviderError.malformedOutput("Unable to parse glab api merge request discussion note output")
+        }
+        return try parseOptionalHTTPURL(note.webURL, context: "glab api merge request discussion note returned an invalid URL")
+    }
+
+    static func encodedJSON<T: Encodable>(_ value: T) throws -> String {
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.sortedKeys]
+        let data = try encoder.encode(value)
+        guard let string = String(data: data, encoding: .utf8) else {
+            throw CodeHostProviderError.malformedOutput("Unable to encode GitLab API payload")
+        }
+        return string
     }
 
     static func parsePipeline(_ json: String) throws -> [ReviewCheck] {
@@ -883,6 +1215,92 @@ private struct GitLabRetryTarget {
     let pipelineID: Int
 }
 
+struct GitLabDiffRefs: Codable, Equatable {
+    let baseSHA: String
+    let startSHA: String
+    let headSHA: String
+
+    func validated() throws -> GitLabDiffRefs {
+        guard !baseSHA.isEmpty, !startSHA.isEmpty, !headSHA.isEmpty else {
+            throw CodeHostProviderError.malformedOutput("glab api merge request versions output is missing diff refs")
+        }
+        return self
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case baseSHA = "base_sha"
+        case startSHA = "start_sha"
+        case headSHA = "head_sha"
+    }
+}
+
+private struct GitLabMRVersion: Decodable {
+    let diffRefs: GitLabDiffRefs
+
+    private enum CodingKeys: String, CodingKey {
+        case diffRefs = "diff_refs"
+    }
+}
+
+private struct GitLabCreateDiscussionPayload: Encodable {
+    let body: String
+    let position: GitLabCreateDiscussionPosition
+
+    init(comment: ProviderReviewDraftComment, diffRefs: GitLabDiffRefs) {
+        self.body = comment.bodyMarkdown
+        self.position = GitLabCreateDiscussionPosition(comment: comment, diffRefs: diffRefs)
+    }
+}
+
+private struct GitLabCreateDiscussionPosition: Encodable {
+    let positionType = "text"
+    let baseSHA: String
+    let startSHA: String
+    let headSHA: String
+    let oldPath: String
+    let newPath: String
+    let oldLine: Int?
+    let newLine: Int?
+
+    init(comment: ProviderReviewDraftComment, diffRefs: GitLabDiffRefs) {
+        self.baseSHA = diffRefs.baseSHA
+        self.startSHA = diffRefs.startSHA
+        self.headSHA = diffRefs.headSHA
+        self.oldPath = comment.originalPath ?? comment.path
+        self.newPath = comment.path
+        switch comment.side {
+        case .old:
+            self.oldLine = comment.lineRange.upperBound
+            self.newLine = nil
+        case .new:
+            self.oldLine = nil
+            self.newLine = comment.lineRange.upperBound
+        case .unknown:
+            self.oldLine = nil
+            self.newLine = nil
+        }
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case positionType = "position_type"
+        case baseSHA = "base_sha"
+        case startSHA = "start_sha"
+        case headSHA = "head_sha"
+        case oldPath = "old_path"
+        case newPath = "new_path"
+        case oldLine = "old_line"
+        case newLine = "new_line"
+    }
+}
+
+private struct GitLabBodyPayload: Encodable {
+    let body: String
+}
+
+private struct GitLabResolveDiscussionPayload: Encodable {
+    let resolved: Bool
+}
+
 private struct GitLabDiscussion: Decodable {
     let id: String
     let resolved: Bool?
@@ -940,6 +1358,16 @@ private struct GitLabDiscussionNote: Decodable {
 
 private struct GitLabDiscussionAuthor: Decodable {
     let username: String?
+}
+
+private struct GitLabCreatedNote: Decodable {
+    let id: Int?
+    let webURL: String?
+
+    private enum CodingKeys: String, CodingKey {
+        case id
+        case webURL = "web_url"
+    }
 }
 
 private struct GitLabNotePosition: Decodable {

--- a/Alas/Sources/Integrations/CodeHost/GitLabCLIProvider.swift
+++ b/Alas/Sources/Integrations/CodeHost/GitLabCLIProvider.swift
@@ -210,7 +210,11 @@ struct GitLabCLIProvider: CodeHostProvider {
             case .comment:
                 break
             case .approve:
-                try await approveMergeRequest(remote: request.remote, request: request.reviewRequest, cwd: request.cwd)
+                if failed.isEmpty {
+                    try await approveMergeRequest(remote: request.remote, request: request.reviewRequest, cwd: request.cwd)
+                } else {
+                    warnings.append("GitLab approval was not submitted because \(failed.count) review comment(s) failed to publish.")
+                }
             case .requestChanges:
                 throw CodeHostProviderError.malformedOutput("GitLab request-changes review state is not supported yet.")
             }

--- a/Alas/Sources/Integrations/CodeHost/GitLabCLIProvider.swift
+++ b/Alas/Sources/Integrations/CodeHost/GitLabCLIProvider.swift
@@ -425,7 +425,7 @@ struct GitLabCLIProvider: CodeHostProvider {
             "glab",
             args: [
                 "api",
-                "projects/:id/merge_requests/\(request.number)/versions",
+                Self.mergeRequestAPIPath(remote: remote, request: request, suffix: "versions"),
                 "--hostname", remote.host,
                 "--output", "json",
             ],
@@ -450,7 +450,7 @@ struct GitLabCLIProvider: CodeHostProvider {
             "glab",
             args: [
                 "api",
-                "projects/:id/merge_requests/\(request.number)/discussions",
+                Self.mergeRequestAPIPath(remote: remote, request: request, suffix: "discussions"),
                 "--method", "POST",
                 "--hostname", remote.host,
                 "--input", "-",
@@ -473,7 +473,7 @@ struct GitLabCLIProvider: CodeHostProvider {
             "glab",
             args: [
                 "api",
-                "projects/:id/merge_requests/\(request.number)/approve",
+                Self.mergeRequestAPIPath(remote: remote, request: request, suffix: "approve"),
                 "--method", "POST",
                 "--hostname", remote.host,
                 "--input", "-",
@@ -498,7 +498,7 @@ struct GitLabCLIProvider: CodeHostProvider {
             "glab",
             args: [
                 "api",
-                "projects/:id/merge_requests/\(request.number)/discussions/\(discussionID)/notes",
+                Self.mergeRequestAPIPath(remote: remote, request: request, suffix: "discussions/\(discussionID)/notes"),
                 "--method", "POST",
                 "--hostname", remote.host,
                 "--input", "-",
@@ -523,7 +523,7 @@ struct GitLabCLIProvider: CodeHostProvider {
             "glab",
             args: [
                 "api",
-                "projects/:id/merge_requests/\(request.number)/discussions/\(discussionID)",
+                Self.mergeRequestAPIPath(remote: remote, request: request, suffix: "discussions/\(discussionID)"),
                 "--method", "PUT",
                 "--hostname", remote.host,
                 "--input", "-",
@@ -534,6 +534,16 @@ struct GitLabCLIProvider: CodeHostProvider {
         guard result.exitCode == 0 else {
             throw CodeHostProviderError.commandFailed(command: "glab api merge request discussion", stderr: result.stderr)
         }
+    }
+
+    static func mergeRequestAPIPath(remote: CodeHostRemote, request: ReviewRequest, suffix: String) -> String {
+        "projects/\(encodedProjectPath(remote.repositorySlug))/merge_requests/\(request.number)/\(suffix)"
+    }
+
+    static func encodedProjectPath(_ projectPath: String) -> String {
+        var allowed = CharacterSet.urlPathAllowed
+        allowed.remove(charactersIn: "/")
+        return projectPath.addingPercentEncoding(withAllowedCharacters: allowed) ?? projectPath
     }
 
     private func sourceProjectPathsByID(

--- a/Alas/Sources/Integrations/CodeHost/GitLabCLIProvider.swift
+++ b/Alas/Sources/Integrations/CodeHost/GitLabCLIProvider.swift
@@ -284,12 +284,24 @@ struct GitLabCLIProvider: CodeHostProvider {
             throw CodeHostProviderError.malformedOutput("GitLab unresolve is not supported until resolved discussions are loaded.")
         }
 
-        let refreshedRequest = (try? await refreshedReviewRequest(
-            remote: mutation.remote,
-            request: mutation.reviewRequest,
-            cwd: mutation.cwd
-        )) ?? mutation.reviewRequest
-        return ProviderThreadMutationResult(refreshedRequest: refreshedRequest, providerURL: providerURL)
+        let refreshedRequest: ReviewRequest
+        let warnings: [String]
+        do {
+            refreshedRequest = try await refreshedReviewRequest(
+                remote: mutation.remote,
+                request: mutation.reviewRequest,
+                cwd: mutation.cwd
+            )
+            warnings = []
+        } catch {
+            refreshedRequest = mutation.reviewRequest
+            warnings = ["GitLab thread was updated, but Alas could not refresh the MR: \(error.localizedDescription)"]
+        }
+        return ProviderThreadMutationResult(
+            refreshedRequest: refreshedRequest,
+            providerURL: providerURL,
+            warnings: warnings
+        )
     }
 
     func failedCheckEvidence(remote: CodeHostRemote, request: ReviewRequest, cwd: URL) async throws -> [ReviewEvidenceItem] {

--- a/Alas/Sources/Integrations/CodeHost/GitLabCLIProvider.swift
+++ b/Alas/Sources/Integrations/CodeHost/GitLabCLIProvider.swift
@@ -170,7 +170,7 @@ struct GitLabCLIProvider: CodeHostProvider {
                 published: [],
                 failed: preflightFailures,
                 refreshedRequest: request.reviewRequest,
-                warnings: []
+                warnings: Self.skippedDecisionWarnings(decision: request.decision)
             )
         }
 
@@ -200,7 +200,7 @@ struct GitLabCLIProvider: CodeHostProvider {
                 published: [],
                 failed: failed,
                 refreshedRequest: request.reviewRequest,
-                warnings: []
+                warnings: Self.skippedDecisionWarnings(decision: request.decision)
             )
         }
 
@@ -577,6 +577,17 @@ struct GitLabCLIProvider: CodeHostProvider {
 
     static func mergeRequestAPIPath(remote: CodeHostRemote, request: ReviewRequest, suffix: String) -> String {
         "projects/\(encodedProjectPath(remote.repositorySlug))/merge_requests/\(request.number)/\(suffix)"
+    }
+
+    private static func skippedDecisionWarnings(decision: ProviderReviewDecision) -> [String] {
+        switch decision {
+        case .comment:
+            []
+        case .approve:
+            ["GitLab approval was not submitted because review comments failed to publish."]
+        case .requestChanges:
+            ["GitLab request changes note was not submitted because review comments failed to publish."]
+        }
     }
 
     static func encodedProjectPath(_ projectPath: String) -> String {

--- a/Alas/Sources/Integrations/CodeHost/GitLabCLIProvider.swift
+++ b/Alas/Sources/Integrations/CodeHost/GitLabCLIProvider.swift
@@ -1233,6 +1233,22 @@ private struct GitLabMRVersion: Decodable {
 
     private enum CodingKeys: String, CodingKey {
         case diffRefs = "diff_refs"
+        case baseCommitSHA = "base_commit_sha"
+        case startCommitSHA = "start_commit_sha"
+        case headCommitSHA = "head_commit_sha"
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        if let diffRefs = try container.decodeIfPresent(GitLabDiffRefs.self, forKey: .diffRefs) {
+            self.diffRefs = diffRefs
+            return
+        }
+        self.diffRefs = GitLabDiffRefs(
+            baseSHA: try container.decodeIfPresent(String.self, forKey: .baseCommitSHA) ?? "",
+            startSHA: try container.decodeIfPresent(String.self, forKey: .startCommitSHA) ?? "",
+            headSHA: try container.decodeIfPresent(String.self, forKey: .headCommitSHA) ?? ""
+        )
     }
 }
 

--- a/Alas/Sources/Integrations/CodeHost/GitLabCLIProvider.swift
+++ b/Alas/Sources/Integrations/CodeHost/GitLabCLIProvider.swift
@@ -216,7 +216,16 @@ struct GitLabCLIProvider: CodeHostProvider {
                     warnings.append("GitLab approval was not submitted because \(failed.count) review comment(s) failed to publish.")
                 }
             case .requestChanges:
-                throw CodeHostProviderError.malformedOutput("GitLab request-changes review state is not supported yet.")
+                if failed.isEmpty {
+                    try await createMergeRequestNote(
+                        remote: request.remote,
+                        request: request.reviewRequest,
+                        body: request.summaryBody,
+                        cwd: request.cwd
+                    )
+                } else {
+                    warnings.append("GitLab request changes note was not submitted because \(failed.count) review comment(s) failed to publish.")
+                }
             }
         } catch {
             guard !published.isEmpty else {
@@ -487,6 +496,32 @@ struct GitLabCLIProvider: CodeHostProvider {
         )
         guard result.exitCode == 0 else {
             throw CodeHostProviderError.commandFailed(command: "glab api merge request approve", stderr: result.stderr)
+        }
+    }
+
+    private func createMergeRequestNote(
+        remote: CodeHostRemote,
+        request: ReviewRequest,
+        body: String,
+        cwd: URL
+    ) async throws {
+        guard let body = Self.normalizedOptionalString(body) else {
+            throw CodeHostProviderError.malformedOutput("GitLab request changes note requires a non-empty body.")
+        }
+        let result = try await runner.run(
+            "glab",
+            args: [
+                "api",
+                Self.mergeRequestAPIPath(remote: remote, request: request, suffix: "notes"),
+                "--method", "POST",
+                "--hostname", remote.host,
+                "--input", "-",
+            ],
+            cwd: cwd,
+            stdin: try Self.encodedJSON(GitLabBodyPayload(body: body))
+        )
+        guard result.exitCode == 0 else {
+            throw CodeHostProviderError.commandFailed(command: "glab api merge request note", stderr: result.stderr)
         }
     }
 

--- a/Alas/Sources/Integrations/CodeHost/ProviderReviewActions.swift
+++ b/Alas/Sources/Integrations/CodeHost/ProviderReviewActions.swift
@@ -83,4 +83,11 @@ struct ProviderThreadMutation: Equatable, Sendable {
 struct ProviderThreadMutationResult: Equatable, Sendable {
     let refreshedRequest: ReviewRequest
     let providerURL: URL?
+    let warnings: [String]
+
+    init(refreshedRequest: ReviewRequest, providerURL: URL?, warnings: [String] = []) {
+        self.refreshedRequest = refreshedRequest
+        self.providerURL = providerURL
+        self.warnings = warnings
+    }
 }

--- a/Alas/Sources/Integrations/CodeHost/ProviderReviewActions.swift
+++ b/Alas/Sources/Integrations/CodeHost/ProviderReviewActions.swift
@@ -1,0 +1,77 @@
+import Foundation
+
+enum ProviderReviewDecision: String, Codable, Equatable, Sendable {
+    case comment
+    case approve
+    case requestChanges
+}
+
+struct ProviderReviewDraftComment: Codable, Equatable, Identifiable, Sendable {
+    var id: String { localDraftID }
+    let localDraftID: String
+    let path: String
+    let originalPath: String?
+    let side: DiffReviewInlineFeedbackSide
+    let lineRange: ClosedRange<Int>
+    let selectedText: String?
+    let bodyMarkdown: String
+
+    init?(localDraft: ReviewDraftComment) {
+        guard localDraft.state == .active, localDraft.providerPublish == nil else { return nil }
+        self.localDraftID = localDraft.id
+        self.path = localDraft.path
+        self.originalPath = localDraft.originalPath
+        self.side = localDraft.side
+        self.lineRange = localDraft.normalizedLineRange
+        self.selectedText = localDraft.selectedText
+        self.bodyMarkdown = localDraft.bodyMarkdown
+    }
+}
+
+struct ProviderReviewPublishRequest: Equatable, Sendable {
+    let remote: CodeHostRemote
+    let reviewRequest: ReviewRequest
+    let comments: [ProviderReviewDraftComment]
+    let decision: ProviderReviewDecision
+    let summaryBody: String
+    let cwd: URL
+}
+
+struct ProviderReviewPublishedComment: Codable, Equatable, Sendable {
+    let localDraftID: String
+    let providerThreadID: String?
+    let providerCommentID: String?
+    let providerURL: URL?
+}
+
+struct ProviderReviewFailedComment: Codable, Equatable, Sendable {
+    let localDraftID: String
+    let message: String
+}
+
+struct ProviderReviewPublishResult: Equatable, Sendable {
+    let published: [ProviderReviewPublishedComment]
+    let failed: [ProviderReviewFailedComment]
+    let refreshedRequest: ReviewRequest
+    let warnings: [String]
+}
+
+enum ProviderThreadMutationKind: String, Codable, Equatable, Sendable {
+    case reply
+    case resolve
+    case unresolve
+}
+
+struct ProviderThreadMutation: Equatable, Sendable {
+    let remote: CodeHostRemote
+    let reviewRequest: ReviewRequest
+    let thread: ReviewThreadSummary
+    let kind: ProviderThreadMutationKind
+    let bodyMarkdown: String?
+    let cwd: URL
+}
+
+struct ProviderThreadMutationResult: Equatable, Sendable {
+    let refreshedRequest: ReviewRequest
+    let providerURL: URL?
+}

--- a/Alas/Sources/Integrations/CodeHost/ProviderReviewActions.swift
+++ b/Alas/Sources/Integrations/CodeHost/ProviderReviewActions.swift
@@ -4,6 +4,15 @@ enum ProviderReviewDecision: String, Codable, Equatable, Sendable {
     case comment
     case approve
     case requestChanges
+
+    var requiresSummaryBody: Bool {
+        switch self {
+        case .comment, .approve:
+            false
+        case .requestChanges:
+            true
+        }
+    }
 }
 
 struct ProviderReviewDraftComment: Codable, Equatable, Identifiable, Sendable {

--- a/AlasTests/DiffReviewSurfaceTests.swift
+++ b/AlasTests/DiffReviewSurfaceTests.swift
@@ -362,9 +362,14 @@ struct DiffReviewSurfaceTests {
         #expect(pressAccessibilityElement(withAccessibilityIdentifier: "diff-review-inline-feedback-action-unresolve-thread-2", in: controller.view))
         #expect(unresolvedID == "thread-2")
 
-        DiffReviewInlineFeedbackCardInteraction.reply(feedback, body: "Done") { item, body in
+        var replyEditor = DiffReviewInlineFeedbackReplyEditorState()
+        replyEditor.start()
+        #expect(replyEditor.isReplying)
+        replyEditor.body = "  Done  "
+        #expect(replyEditor.save(feedback) { item, body in
             actions.replyProvider(item, file.summary, body)
-        }
+        })
+        #expect(!replyEditor.isReplying)
         #expect(replied?.id == "thread-1")
         #expect(replied?.body == "Done")
     }

--- a/AlasTests/DiffReviewSurfaceTests.swift
+++ b/AlasTests/DiffReviewSurfaceTests.swift
@@ -287,7 +287,8 @@ struct DiffReviewSurfaceTests {
             parsedDiff: parsedDiff(),
             displayModel: displayModel(),
             placeholderMessage: nil,
-            openFile: nil
+            openFile: nil,
+            contextProvider: nil
         )
         let feedback = DiffReviewInlineFeedback(
             id: "thread-1",
@@ -836,7 +837,8 @@ struct DiffReviewSurfaceTests {
             parsedDiff: parsedDiff(),
             displayModel: displayModel(),
             placeholderMessage: nil,
-            openFile: nil
+            openFile: nil,
+            contextProvider: nil
         )
         var published = draftComment(id: "draft-published-inline", fileID: file.id, path: file.summary.path, side: .new, startLine: 2)
         published.providerPublish = ReviewDraftProviderPublish(
@@ -934,7 +936,8 @@ struct DiffReviewSurfaceTests {
             parsedDiff: parsedDiff(),
             displayModel: displayModel(),
             placeholderMessage: nil,
-            openFile: nil
+            openFile: nil,
+            contextProvider: nil
         )
         let comment = draftComment(id: "draft-publish-inline", fileID: file.id, path: file.summary.path, side: .new, startLine: 2)
         var layout = DiffLayoutMode.split

--- a/AlasTests/DiffReviewSurfaceTests.swift
+++ b/AlasTests/DiffReviewSurfaceTests.swift
@@ -830,6 +830,53 @@ struct DiffReviewSurfaceTests {
         #expect(accessibilityLabel(in: controller.view, containing: "Please revisit this line.") != nil)
     }
 
+    @Test func fileSectionDraftCommentCardShowsProviderPublishAndErrorState() {
+        let file = DiffReviewFileSectionModel(
+            summary: summary(path: "Sources/App.swift"),
+            parsedDiff: parsedDiff(),
+            displayModel: displayModel(),
+            placeholderMessage: nil,
+            openFile: nil
+        )
+        var published = draftComment(id: "draft-published-inline", fileID: file.id, path: file.summary.path, side: .new, startLine: 2)
+        published.providerPublish = ReviewDraftProviderPublish(
+            provider: .github,
+            host: "github.com",
+            repositorySlug: "mrmans0n/alas",
+            reviewNumber: 527,
+            threadID: "thread-1",
+            commentID: "comment-1",
+            url: nil,
+            publishedAt: Date(timeIntervalSince1970: 3)
+        )
+        var failed = draftComment(id: "draft-error-inline", fileID: file.id, path: file.summary.path, side: .new, startLine: 2)
+        failed.providerError = ReviewDraftProviderError(
+            provider: .gitlab,
+            message: "Line is no longer commentable.",
+            occurredAt: Date(timeIntervalSince1970: 4)
+        )
+        var layout = DiffLayoutMode.split
+        var wrap = false
+        var whitespace = false
+
+        let view = DiffReviewFileSection(
+            file: file,
+            draftComments: [published, failed],
+            layoutMode: Binding(get: { layout }, set: { layout = $0 }),
+            wrapLines: Binding(get: { wrap }, set: { wrap = $0 }),
+            showWhitespace: Binding(get: { whitespace }, set: { whitespace = $0 }),
+            codeFontFamily: "",
+            codeFontSize: 13,
+            showsSourceBadge: false
+        )
+        .environment(\.theme, theme())
+
+        let controller = host(view, width: 900, height: 620)
+
+        #expect(accessibilityLabel(in: controller.view, containing: "published to GitHub") != nil)
+        #expect(accessibilityLabel(in: controller.view, containing: "GitLab error: Line is no longer commentable.") != nil)
+    }
+
     @Test func fileSectionDraftCommentCardCanDismissComment() {
         let file = DiffReviewFileSectionModel(
             summary: summary(path: "Sources/App.swift"),
@@ -1697,6 +1744,51 @@ struct DiffReviewSurfaceTests {
         #expect(subview(withAccessibilityIdentifier: "review-draft-summary-comment-draft-dismissed-visible", in: controller.view) != nil)
         #expect(accessibilityLabel(in: controller.view, containing: "old line 7") != nil)
         #expect(accessibilityLabel(in: controller.view, containing: "dismissed") != nil)
+    }
+
+    @Test func summaryRailShowsProviderPublishAndErrorState() throws {
+        let file = summary(path: "Sources/App.swift")
+        var published = draftComment(id: "draft-published-summary", fileID: file.id, path: file.path, side: .new, startLine: 2)
+        published.providerPublish = ReviewDraftProviderPublish(
+            provider: .github,
+            host: "github.com",
+            repositorySlug: "mrmans0n/alas",
+            reviewNumber: 527,
+            threadID: "thread-1",
+            commentID: "comment-1",
+            url: nil,
+            publishedAt: Date(timeIntervalSince1970: 3)
+        )
+        var failed = draftComment(id: "draft-error-summary", fileID: file.id, path: file.path, side: .new, startLine: 2)
+        failed.providerError = ReviewDraftProviderError(
+            provider: .gitlab,
+            message: "Line is no longer commentable.",
+            occurredAt: Date(timeIntervalSince1970: 4)
+        )
+        let bundle = ReviewFeedbackBundle(
+            target: ReviewFeedbackTarget(
+                title: "Review Sources/App.swift",
+                repositoryPath: "/repo",
+                providerDescription: nil,
+                sourceDescription: "Local draft comments"
+            ),
+            comments: [published, failed]
+        )
+        var collapsed = false
+
+        let view = ReviewDraftSummaryRail(
+            comments: [published, failed],
+            bundle: bundle,
+            collapsed: Binding(get: { collapsed }, set: { collapsed = $0 }),
+            draftCommentActions: ReviewDraftCommentActions(),
+            onSelectDraftComment: { _ in }
+        )
+        .environment(\.theme, theme())
+
+        let controller = host(view, width: 280, height: 520)
+
+        #expect(accessibilityLabel(in: controller.view, containing: "published to GitHub") != nil)
+        #expect(accessibilityLabel(in: controller.view, containing: "GitLab error: Line is no longer commentable.") != nil)
     }
 
     @Test func collapsedSummaryRailKeepsFinishActionsAccessible() throws {

--- a/AlasTests/DiffReviewSurfaceTests.swift
+++ b/AlasTests/DiffReviewSurfaceTests.swift
@@ -788,6 +788,57 @@ struct DiffReviewSurfaceTests {
         #expect(dismissedID == "draft-dismiss-inline")
     }
 
+    @Test func fileSectionDraftCommentCardCanPublishProviderComment() {
+        let file = DiffReviewFileSectionModel(
+            summary: summary(path: "Sources/App.swift"),
+            parsedDiff: parsedDiff(),
+            displayModel: displayModel(),
+            placeholderMessage: nil,
+            openFile: nil
+        )
+        let comment = draftComment(id: "draft-publish-inline", fileID: file.id, path: file.summary.path, side: .new, startLine: 2)
+        var layout = DiffLayoutMode.split
+        var wrap = false
+        var whitespace = false
+        var publishedID: String?
+        let actions = ReviewDraftCommentActions(
+            availability: { _ in
+                ReviewDraftCommentActionAvailability(
+                    canEdit: false,
+                    canDelete: false,
+                    canResolve: false,
+                    canDismiss: false,
+                    canCopyPrompt: false,
+                    canShowSendToAgent: false,
+                    canSendToAgent: false,
+                    canPublishProvider: true
+                )
+            },
+            publishProvider: { publishedID = $0.id }
+        )
+
+        let view = DiffReviewFileSection(
+            file: file,
+            draftComments: [comment],
+            layoutMode: Binding(get: { layout }, set: { layout = $0 }),
+            wrapLines: Binding(get: { wrap }, set: { wrap = $0 }),
+            showWhitespace: Binding(get: { whitespace }, set: { whitespace = $0 }),
+            codeFontFamily: "",
+            codeFontSize: 13,
+            showsSourceBadge: false,
+            draftCommentActions: actions
+        )
+        .environment(\.theme, theme())
+
+        let controller = host(view, width: 900, height: 500)
+
+        #expect(pressAccessibilityElement(
+            withAccessibilityIdentifier: "diff-review-draft-comment-publish-draft-publish-inline",
+            in: controller.view
+        ))
+        #expect(publishedID == "draft-publish-inline")
+    }
+
     @Test func fileSectionDraftCommentCardUsesProvidedReviewTargetForPromptActions() {
         let file = DiffReviewFileSectionModel(
             summary: summary(path: "Sources/App.swift"),
@@ -1350,6 +1401,41 @@ struct DiffReviewSurfaceTests {
         #expect(recorder.copied == bundle)
         #expect(recorder.sent == bundle)
         #expect(recorder.sentTarget == .newChat(agentID: "codex", title: "Codex"))
+    }
+
+    @Test func summaryRailCanPublishReview() throws {
+        let file = summary(path: "Sources/App.swift")
+        let comment = draftComment(id: "draft-publish-summary", fileID: file.id, path: file.path, side: .new, startLine: 2)
+        let bundle = ReviewFeedbackBundle(
+            target: ReviewFeedbackTarget(
+                title: "Review provider request",
+                repositoryPath: "/repo",
+                providerDescription: "GitHub #527",
+                sourceDescription: "Provider review"
+            ),
+            comments: [comment]
+        )
+        var collapsed = false
+        var didPublish = false
+        let actions = ReviewDraftCommentActions(
+            availability: { _ in .none },
+            canPublishReview: { true },
+            publishReview: { didPublish = true }
+        )
+
+        let view = ReviewDraftSummaryRail(
+            comments: [comment],
+            bundle: bundle,
+            collapsed: Binding(get: { collapsed }, set: { collapsed = $0 }),
+            draftCommentActions: actions,
+            onSelectDraftComment: { _ in }
+        )
+        .environment(\.theme, theme())
+
+        let controller = host(view, width: 280, height: 500)
+
+        #expect(pressAccessibilityElement(withAccessibilityIdentifier: "review-draft-summary-publish-review", in: controller.view))
+        #expect(didPublish)
     }
 
     @Test func summaryRailHidesSendActionWhenNoAgentTargetExists() throws {

--- a/AlasTests/DiffReviewSurfaceTests.swift
+++ b/AlasTests/DiffReviewSurfaceTests.swift
@@ -281,6 +281,94 @@ struct DiffReviewSurfaceTests {
         #expect(subviews(withAccessibilityIdentifier: "diff-review-inline-feedback-copy-thread-1", in: controller.view).count <= 1)
     }
 
+    @Test func providerFeedbackCardShowsReplyResolveAndUnresolveActions() {
+        let file = DiffReviewFileSectionModel(
+            summary: summary(path: "Sources/App.swift"),
+            parsedDiff: parsedDiff(),
+            displayModel: displayModel(),
+            placeholderMessage: nil,
+            openFile: nil
+        )
+        let feedback = DiffReviewInlineFeedback(
+            id: "thread-1",
+            providerName: "GitHub",
+            author: "reviewer",
+            bodyPreview: "Please fix this.",
+            status: .actionable,
+            providerURL: nil,
+            anchor: DiffReviewInlineFeedbackAnchor(path: file.summary.path, line: 2, side: .new),
+            evidenceItemID: "thread-1"
+        )
+        var layout = DiffLayoutMode.split
+        var wrap = false
+        var whitespace = false
+        var resolvedID: String?
+        var unresolvedID: String?
+        var replied: (id: String, body: String)?
+        let actions = DiffReviewInlineFeedbackActions(
+            availability: { item, _ in
+                DiffReviewInlineFeedbackActionAvailability(
+                    canOpenProvider: false,
+                    canCopyContext: false,
+                    canSendToAgent: false,
+                    canReplyProvider: true,
+                    canResolveProvider: item.status != .resolved,
+                    canUnresolveProvider: item.status == .resolved
+                )
+            },
+            replyProvider: { item, _, body in
+                replied = (item.id, body)
+            },
+            resolveProvider: { item, _ in
+                resolvedID = item.id
+            },
+            unresolveProvider: { item, _ in
+                unresolvedID = item.id
+            }
+        )
+
+        let view = DiffReviewFileSection(
+            file: file,
+            inlineFeedback: [
+                feedback,
+                DiffReviewInlineFeedback(
+                    id: "thread-2",
+                    providerName: "GitHub",
+                    author: "reviewer",
+                    bodyPreview: "Resolved thread.",
+                    status: .resolved,
+                    providerURL: nil,
+                    anchor: DiffReviewInlineFeedbackAnchor(path: file.summary.path, line: nil, side: .unknown),
+                    evidenceItemID: "thread-2"
+                ),
+            ],
+            layoutMode: Binding(get: { layout }, set: { layout = $0 }),
+            wrapLines: Binding(get: { wrap }, set: { wrap = $0 }),
+            showWhitespace: Binding(get: { whitespace }, set: { whitespace = $0 }),
+            codeFontFamily: "",
+            codeFontSize: 13,
+            showsSourceBadge: false,
+            inlineFeedbackActions: actions
+        )
+        .environment(\.theme, theme())
+
+        let controller = host(view, width: 900, height: 520)
+
+        #expect(subview(withAccessibilityIdentifier: "diff-review-inline-feedback-action-reply-thread-1", in: controller.view) != nil)
+        #expect(subview(withAccessibilityIdentifier: "diff-review-inline-feedback-action-resolve-thread-1", in: controller.view) != nil)
+        #expect(subview(withAccessibilityIdentifier: "diff-review-inline-feedback-action-unresolve-thread-2", in: controller.view) != nil)
+        #expect(pressAccessibilityElement(withAccessibilityIdentifier: "diff-review-inline-feedback-action-resolve-thread-1", in: controller.view))
+        #expect(resolvedID == "thread-1")
+        #expect(pressAccessibilityElement(withAccessibilityIdentifier: "diff-review-inline-feedback-action-unresolve-thread-2", in: controller.view))
+        #expect(unresolvedID == "thread-2")
+
+        DiffReviewInlineFeedbackCardInteraction.reply(feedback, body: "Done") { item, body in
+            actions.replyProvider(item, file.summary, body)
+        }
+        #expect(replied?.id == "thread-1")
+        #expect(replied?.body == "Done")
+    }
+
     @Test func focusedInlineFeedbackPastDisplayCapRemainsVisibleWithMoreRow() {
         let file = DiffReviewFileSectionModel(
             summary: summary(path: "Sources/App.swift"),

--- a/AlasTests/Integrations/CodeHostModelsTests.swift
+++ b/AlasTests/Integrations/CodeHostModelsTests.swift
@@ -136,6 +136,29 @@ struct CodeHostModelsTests {
         #expect(first.id != second.id)
     }
 
+    @Test func reviewThreadSummaryCarriesProviderThreadIdentity() {
+        let thread = ReviewThreadSummary(
+            id: "thread-1",
+            author: "reviewer",
+            body: "Please fix this.",
+            url: URL(string: "https://provider/thread"),
+            isResolved: false,
+            isActionable: true,
+            location: ReviewThreadLocation(
+                path: "Sources/App.swift",
+                originalPath: nil,
+                line: 42,
+                side: .new,
+                providerPosition: "42"
+            ),
+            providerThreadID: "thread-provider-id",
+            providerCommentID: "comment-provider-id"
+        )
+
+        #expect(thread.providerThreadID == "thread-provider-id")
+        #expect(thread.providerCommentID == "comment-provider-id")
+    }
+
     private func makeReviewRequest(
         remote: CodeHostRemote = CodeHostRemote(
             kind: .github,

--- a/AlasTests/Integrations/GitHubCLIProviderTests.swift
+++ b/AlasTests/Integrations/GitHubCLIProviderTests.swift
@@ -1088,6 +1088,14 @@ struct GitHubCLIProviderTests {
             let executable: String
             let args: [String]
             let cwd: URL?
+            let stdin: String?
+
+            init(executable: String, args: [String], cwd: URL?, stdin: String? = nil) {
+                self.executable = executable
+                self.args = args
+                self.cwd = cwd
+                self.stdin = stdin
+            }
         }
 
         private var results: [ProcessResult]
@@ -1097,8 +1105,8 @@ struct GitHubCLIProviderTests {
             self.results = results
         }
 
-        func run(_ executable: String, args: [String], cwd: URL?) async throws -> ProcessResult {
-            commands.append(Command(executable: executable, args: args, cwd: cwd))
+        func run(_ executable: String, args: [String], cwd: URL?, stdin: String?) async throws -> ProcessResult {
+            commands.append(Command(executable: executable, args: args, cwd: cwd, stdin: stdin))
             guard !results.isEmpty else {
                 return ProcessResult(exitCode: 1, stdout: "", stderr: "unexpected command")
             }

--- a/AlasTests/Integrations/GitHubCLIProviderTests.swift
+++ b/AlasTests/Integrations/GitHubCLIProviderTests.swift
@@ -460,6 +460,43 @@ struct GitHubCLIProviderTests {
         })
     }
 
+    @Test func githubPublishReviewDoesNotFailDraftsPastReturnedCommentWindow() async throws {
+        let drafts = try (1...101).map { index in
+            try Self.makeProviderDraftComment(
+                id: "draft-\(index)",
+                path: "Sources/App.swift",
+                side: .new,
+                startLine: index,
+                endLine: nil,
+                body: "Comment \(index)"
+            )
+        }
+        let runner = FakeRunner(results: [
+            ProcessResult(exitCode: 0, stdout: Self.pullRequestNodeOutput, stderr: ""),
+            ProcessResult(exitCode: 0, stdout: Self.publishReviewMutationOutput(commentCount: 100), stderr: ""),
+            ProcessResult(exitCode: 0, stdout: Self.prViewOutput, stderr: ""),
+            ProcessResult(exitCode: 0, stdout: Self.reviewThreadsOutput, stderr: ""),
+        ])
+        let provider = GitHubCLIProvider(runner: runner)
+
+        let result = try await provider.publishReview(ProviderReviewPublishRequest(
+            remote: Self.remote,
+            reviewRequest: Self.makeRequest(),
+            comments: drafts,
+            decision: .comment,
+            summaryBody: "Review notes.",
+            cwd: Self.cwd
+        ))
+
+        #expect(result.failed.isEmpty)
+        #expect(result.published.map(\.localDraftID) == drafts.map(\.localDraftID))
+        #expect(result.published[99].providerCommentID == "PRRC_comment_100")
+        #expect(result.published[100].providerCommentID == nil)
+        #expect(result.warnings.contains {
+            $0.contains("GitHub returned only the first 100 review comments")
+        })
+    }
+
     @Test func githubPublishReviewDoesNotRetryAfterMalformedSuccessfulBatchResponse() async throws {
         let runner = FakeRunner(results: [
             ProcessResult(exitCode: 0, stdout: Self.pullRequestNodeOutput, stderr: ""),
@@ -1492,6 +1529,13 @@ struct GitHubCLIProviderTests {
     private static let publishReviewMutationOutput = """
     {"data":{"addPullRequestReview":{"pullRequestReview":{"comments":{"nodes":[{"id":"PRRC_comment_1","url":"https://github.com/mrmans0n/alas/pull/42#discussion_r1","pullRequestReviewThread":{"id":"PRRT_thread_1"}}]}}}}}
     """
+
+    private static func publishReviewMutationOutput(commentCount: Int) -> String {
+        let nodes = (1...commentCount).map { index in
+            #"{"id":"PRRC_comment_\#(index)","url":"https://github.com/mrmans0n/alas/pull/42#discussion_r\#(index)","pullRequestReviewThread":{"id":"PRRT_thread_\#(index)"}}"#
+        }.joined(separator: ",")
+        return #"{"data":{"addPullRequestReview":{"pullRequestReview":{"comments":{"nodes":[\#(nodes)]}}}}}"#
+    }
 
     private static let publishReviewMutationWithoutCommentsOutput = """
     {"data":{"addPullRequestReview":{"pullRequestReview":{"comments":{"nodes":[]}}}}}

--- a/AlasTests/Integrations/GitHubCLIProviderTests.swift
+++ b/AlasTests/Integrations/GitHubCLIProviderTests.swift
@@ -500,6 +500,40 @@ struct GitHubCLIProviderTests {
         #expect(result.refreshedRequest.number == 42)
     }
 
+    @Test func githubPublishReviewDoesNotSubmitDecisionWhenNoDraftsArePublishable() async throws {
+        let runner = FakeRunner(results: [])
+        let provider = GitHubCLIProvider(runner: runner)
+
+        let result = try await provider.publishReview(ProviderReviewPublishRequest(
+            remote: Self.remote,
+            reviewRequest: Self.makeRequest(),
+            comments: [
+                Self.makeProviderDraftComment(
+                    id: "draft-unknown",
+                    path: "Sources/App.swift",
+                    side: .unknown,
+                    startLine: 20,
+                    endLine: nil,
+                    body: "This should not submit a review decision."
+                ),
+            ],
+            decision: .requestChanges,
+            summaryBody: "Please update this before merge.",
+            cwd: Self.cwd
+        ))
+
+        let commands = await runner.commands
+        #expect(commands.isEmpty)
+        #expect(result.published.isEmpty)
+        #expect(result.failed == [
+            ProviderReviewFailedComment(
+                localDraftID: "draft-unknown",
+                message: "GitHub review comments require an old or new side."
+            ),
+        ])
+        #expect(result.refreshedRequest.number == 42)
+    }
+
     @Test func githubPublishReviewPreservesMappingsWhenRefreshFails() async throws {
         let runner = FakeRunner(results: [
             ProcessResult(exitCode: 0, stdout: Self.pullRequestNodeOutput, stderr: ""),

--- a/AlasTests/Integrations/GitHubCLIProviderTests.swift
+++ b/AlasTests/Integrations/GitHubCLIProviderTests.swift
@@ -534,6 +534,37 @@ struct GitHubCLIProviderTests {
         #expect(result.refreshedRequest.number == 42)
     }
 
+    @Test func githubPublishReviewSubmitsDecisionWhenNoDraftCommentsExist() async throws {
+        let runner = FakeRunner(results: [
+            ProcessResult(exitCode: 0, stdout: Self.pullRequestNodeOutput, stderr: ""),
+            ProcessResult(exitCode: 0, stdout: Self.publishReviewMutationWithoutCommentsOutput, stderr: ""),
+            ProcessResult(exitCode: 0, stdout: Self.prViewOutput, stderr: ""),
+            ProcessResult(exitCode: 0, stdout: Self.reviewThreadsOutput, stderr: ""),
+        ])
+        let provider = GitHubCLIProvider(runner: runner)
+
+        let result = try await provider.publishReview(ProviderReviewPublishRequest(
+            remote: Self.remote,
+            reviewRequest: Self.makeRequest(),
+            comments: [],
+            decision: .approve,
+            summaryBody: "Looks good.",
+            cwd: Self.cwd
+        ))
+
+        let commands = await runner.commands
+        #expect(commands.count == 4)
+        let publishVariables = try Self.graphQLVariables(from: commands[1].stdin)
+        let publishInput = try #require(publishVariables["input"] as? [String: Any])
+        let publishThreads = try #require(publishInput["threads"] as? [[String: Any]])
+        #expect(publishInput["event"] as? String == "APPROVE")
+        #expect(publishInput["body"] as? String == "Looks good.")
+        #expect(publishThreads.isEmpty)
+        #expect(result.published.isEmpty)
+        #expect(result.failed.isEmpty)
+        #expect(result.refreshedRequest.number == 42)
+    }
+
     @Test func githubPublishReviewPreservesMappingsWhenRefreshFails() async throws {
         let runner = FakeRunner(results: [
             ProcessResult(exitCode: 0, stdout: Self.pullRequestNodeOutput, stderr: ""),
@@ -1395,6 +1426,10 @@ struct GitHubCLIProviderTests {
 
     private static let publishReviewMutationOutput = """
     {"data":{"addPullRequestReview":{"pullRequestReview":{"comments":{"nodes":[{"id":"PRRC_comment_1","url":"https://github.com/mrmans0n/alas/pull/42#discussion_r1","pullRequestReviewThread":{"id":"PRRT_thread_1"}}]}}}}}
+    """
+
+    private static let publishReviewMutationWithoutCommentsOutput = """
+    {"data":{"addPullRequestReview":{"pullRequestReview":{"comments":{"nodes":[]}}}}}
     """
 
     private static let replyMutationOutput = """

--- a/AlasTests/Integrations/GitHubCLIProviderTests.swift
+++ b/AlasTests/Integrations/GitHubCLIProviderTests.swift
@@ -450,6 +450,7 @@ struct GitHubCLIProviderTests {
         let retryInput = try #require(retryVariables["input"] as? [String: Any])
         let retryThreads = try #require(retryInput["threads"] as? [[String: Any]])
         #expect(retryInput["event"] as? String == "COMMENT")
+        #expect(retryInput["body"] as? String == "")
         #expect(retryThreads.count == 1)
         #expect(result.published.map(\.localDraftID) == ["draft-good"])
         #expect(result.failed.map(\.localDraftID) == ["draft-bad"])

--- a/AlasTests/Integrations/GitHubCLIProviderTests.swift
+++ b/AlasTests/Integrations/GitHubCLIProviderTests.swift
@@ -659,6 +659,41 @@ struct GitHubCLIProviderTests {
         #expect(resolveResult.refreshedRequest.number == 42)
     }
 
+    @Test func githubThreadMutationPreservesSuccessfulReplyWhenRefreshFails() async throws {
+        let thread = ReviewThreadSummary(
+            id: "thread-1",
+            author: "reviewer",
+            body: "Please tighten this branch lookup.",
+            url: URL(string: "https://github.com/mrmans0n/alas/pull/42#discussion_r1"),
+            isResolved: false,
+            isActionable: true,
+            providerThreadID: "PRRT_thread_1",
+            providerCommentID: "PRRC_comment_1"
+        )
+        let originalRequest = Self.makeRequest(threads: [thread])
+        let runner = FakeRunner(results: [
+            ProcessResult(exitCode: 0, stdout: Self.replyMutationOutput, stderr: ""),
+            ProcessResult(exitCode: 1, stdout: "", stderr: "temporary API failure"),
+        ])
+        let provider = GitHubCLIProvider(runner: runner)
+
+        let replyResult = try await provider.mutateReviewThread(ProviderThreadMutation(
+            remote: Self.remote,
+            reviewRequest: originalRequest,
+            thread: thread,
+            kind: .reply,
+            bodyMarkdown: "Thanks, fixed.",
+            cwd: Self.cwd
+        ))
+
+        let commands = await runner.commands
+        #expect(commands.count == 2)
+        #expect(commands[0].stdin?.contains("addPullRequestReviewThreadReply") == true)
+        #expect(commands[1].args.first == "pr")
+        #expect(replyResult.providerURL == URL(string: "https://github.com/mrmans0n/alas/pull/42#discussion_r2"))
+        #expect(replyResult.refreshedRequest == originalRequest)
+    }
+
     @Test func reviewThreadsJSONPreservesLocationMetadata() throws {
         let threads = try GitHubCLIProvider.parseReviewThreads(
             """

--- a/AlasTests/Integrations/GitHubCLIProviderTests.swift
+++ b/AlasTests/Integrations/GitHubCLIProviderTests.swift
@@ -448,6 +448,58 @@ struct GitHubCLIProviderTests {
         })
     }
 
+    @Test func githubPublishReviewDoesNotRetryAfterMalformedSuccessfulBatchResponse() async throws {
+        let runner = FakeRunner(results: [
+            ProcessResult(exitCode: 0, stdout: Self.pullRequestNodeOutput, stderr: ""),
+            ProcessResult(exitCode: 0, stdout: #"{"data":{}}"#, stderr: ""),
+            ProcessResult(exitCode: 0, stdout: Self.prViewOutput, stderr: ""),
+            ProcessResult(exitCode: 0, stdout: Self.reviewThreadsOutput, stderr: ""),
+        ])
+        let provider = GitHubCLIProvider(runner: runner)
+
+        let result = try await provider.publishReview(ProviderReviewPublishRequest(
+            remote: Self.remote,
+            reviewRequest: Self.makeRequest(),
+            comments: [
+                Self.makeProviderDraftComment(
+                    id: "draft-1",
+                    path: "Sources/App.swift",
+                    side: .new,
+                    startLine: 12,
+                    endLine: nil,
+                    body: "Please simplify this."
+                ),
+                Self.makeProviderDraftComment(
+                    id: "draft-2",
+                    path: "Sources/Other.swift",
+                    side: .new,
+                    startLine: 99,
+                    endLine: nil,
+                    body: "This anchor is stale."
+                ),
+            ],
+            decision: .requestChanges,
+            summaryBody: "Please update this before merge.",
+            cwd: Self.cwd
+        ))
+
+        let commands = await runner.commands
+        #expect(commands.count == 4)
+        let publishVariables = try Self.graphQLVariables(from: commands[1].stdin)
+        let publishInput = try #require(publishVariables["input"] as? [String: Any])
+        let publishThreads = try #require(publishInput["threads"] as? [[String: Any]])
+        #expect(publishInput["event"] as? String == "REQUEST_CHANGES")
+        #expect(publishThreads.count == 2)
+        #expect(commands[2].args.first == "pr")
+        #expect(result.published.isEmpty)
+        #expect(result.failed.map(\.localDraftID) == ["draft-1", "draft-2"])
+        #expect(result.failed.allSatisfy {
+            $0.message.contains("Unable to parse gh publish review output")
+        })
+        #expect(result.warnings.isEmpty)
+        #expect(result.refreshedRequest.number == 42)
+    }
+
     @Test func githubPublishReviewPreservesMappingsWhenRefreshFails() async throws {
         let runner = FakeRunner(results: [
             ProcessResult(exitCode: 0, stdout: Self.pullRequestNodeOutput, stderr: ""),

--- a/AlasTests/Integrations/GitHubCLIProviderTests.swift
+++ b/AlasTests/Integrations/GitHubCLIProviderTests.swift
@@ -210,6 +210,7 @@ struct GitHubCLIProviderTests {
                 executable: "gh",
                 args: [
                     "api", "graphql",
+                    "--hostname", "github.com",
                     "-f", "query=\(GitHubCLIProvider.reviewThreadsQuery)",
                     "-F", "owner=mrmans0n",
                     "-F", "repo=alas",
@@ -352,8 +353,8 @@ struct GitHubCLIProviderTests {
 
         let commands = await runner.commands
         #expect(commands.count == 4)
-        #expect(commands[0].args == ["api", "graphql", "--input", "-"])
-        #expect(commands[1].args == ["api", "graphql", "--input", "-"])
+        #expect(commands[0].args == ["api", "graphql", "--hostname", "github.com", "--input", "-"])
+        #expect(commands[1].args == ["api", "graphql", "--hostname", "github.com", "--input", "-"])
         #expect(commands[0].stdin?.contains("pullRequest(number: $number)") == true)
         let publishVariables = try Self.graphQLVariables(from: commands[1].stdin)
         let publishInput = try #require(publishVariables["input"] as? [String: Any])
@@ -638,13 +639,13 @@ struct GitHubCLIProviderTests {
         ))
 
         let commands = await runner.commands
-        #expect(commands[0].args == ["api", "graphql", "--input", "-"])
+        #expect(commands[0].args == ["api", "graphql", "--hostname", "github.com", "--input", "-"])
         #expect(commands[1].args == [
             "pr", "view", "42",
             "--json", "number,title,url,state,isDraft,headRefName,headRepositoryOwner,baseRefName,reviewDecision,mergeStateStatus",
             "-R", "mrmans0n/alas",
         ])
-        #expect(commands[3].args == ["api", "graphql", "--input", "-"])
+        #expect(commands[3].args == ["api", "graphql", "--hostname", "github.com", "--input", "-"])
         #expect(commands[4].args == [
             "pr", "view", "42",
             "--json", "number,title,url,state,isDraft,headRefName,headRepositoryOwner,baseRefName,reviewDecision,mergeStateStatus",
@@ -657,6 +658,21 @@ struct GitHubCLIProviderTests {
         #expect(replyResult.providerURL == URL(string: "https://github.com/mrmans0n/alas/pull/42#discussion_r2"))
         #expect(replyResult.refreshedRequest.number == 42)
         #expect(resolveResult.refreshedRequest.number == 42)
+    }
+
+    @Test func githubGraphQLAPIArgsIncludeSelectedRemoteHost() {
+        let enterpriseRemote = CodeHostRemote(
+            kind: .github,
+            host: "github.enterprise.example.com",
+            owner: "platform",
+            repository: "alas",
+            remoteName: "enterprise",
+            webURL: URL(string: "https://github.enterprise.example.com/platform/alas")!
+        )
+
+        #expect(GitHubCLIProvider.graphQLAPIStdinArgs(remote: enterpriseRemote) == [
+            "api", "graphql", "--hostname", "github.enterprise.example.com", "--input", "-",
+        ])
     }
 
     @Test func githubThreadMutationPreservesSuccessfulReplyWhenRefreshFails() async throws {

--- a/AlasTests/Integrations/GitHubCLIProviderTests.swift
+++ b/AlasTests/Integrations/GitHubCLIProviderTests.swift
@@ -788,6 +788,9 @@ struct GitHubCLIProviderTests {
         #expect(commands[1].args.first == "pr")
         #expect(replyResult.providerURL == URL(string: "https://github.com/mrmans0n/alas/pull/42#discussion_r2"))
         #expect(replyResult.refreshedRequest == originalRequest)
+        #expect(replyResult.warnings.contains {
+            $0.contains("GitHub thread was updated, but Alas could not refresh the PR")
+        })
     }
 
     @Test func reviewThreadsJSONPreservesLocationMetadata() throws {

--- a/AlasTests/Integrations/GitHubCLIProviderTests.swift
+++ b/AlasTests/Integrations/GitHubCLIProviderTests.swift
@@ -390,6 +390,98 @@ struct GitHubCLIProviderTests {
         #expect(result.refreshedRequest.threads.count == 2)
     }
 
+    @Test func githubPublishReviewRetriesIndividuallyAfterBatchRejection() async throws {
+        let runner = FakeRunner(results: [
+            ProcessResult(exitCode: 0, stdout: Self.pullRequestNodeOutput, stderr: ""),
+            ProcessResult(exitCode: 1, stdout: "", stderr: "line is not commentable"),
+            ProcessResult(exitCode: 0, stdout: Self.publishReviewMutationOutput, stderr: ""),
+            ProcessResult(exitCode: 1, stdout: "", stderr: "line is not commentable"),
+            ProcessResult(exitCode: 0, stdout: Self.prViewOutput, stderr: ""),
+            ProcessResult(exitCode: 0, stdout: Self.reviewThreadsOutput, stderr: ""),
+        ])
+        let provider = GitHubCLIProvider(runner: runner)
+
+        let result = try await provider.publishReview(ProviderReviewPublishRequest(
+            remote: Self.remote,
+            reviewRequest: Self.makeRequest(),
+            comments: [
+                Self.makeProviderDraftComment(
+                    id: "draft-good",
+                    path: "Sources/App.swift",
+                    side: .new,
+                    startLine: 12,
+                    endLine: nil,
+                    body: "Please simplify this."
+                ),
+                Self.makeProviderDraftComment(
+                    id: "draft-bad",
+                    path: "Sources/Other.swift",
+                    side: .new,
+                    startLine: 99,
+                    endLine: nil,
+                    body: "This anchor is stale."
+                ),
+            ],
+            decision: .requestChanges,
+            summaryBody: "Please update this before merge.",
+            cwd: Self.cwd
+        ))
+
+        let commands = await runner.commands
+        #expect(commands.count == 6)
+        let batchVariables = try Self.graphQLVariables(from: commands[1].stdin)
+        let batchInput = try #require(batchVariables["input"] as? [String: Any])
+        let batchThreads = try #require(batchInput["threads"] as? [[String: Any]])
+        #expect(batchInput["event"] as? String == "REQUEST_CHANGES")
+        #expect(batchThreads.count == 2)
+
+        let retryVariables = try Self.graphQLVariables(from: commands[2].stdin)
+        let retryInput = try #require(retryVariables["input"] as? [String: Any])
+        let retryThreads = try #require(retryInput["threads"] as? [[String: Any]])
+        #expect(retryInput["event"] as? String == "COMMENT")
+        #expect(retryThreads.count == 1)
+        #expect(result.published.map(\.localDraftID) == ["draft-good"])
+        #expect(result.failed.map(\.localDraftID) == ["draft-bad"])
+        #expect(result.failed.first?.message.contains("line is not commentable") == true)
+        #expect(result.warnings.contains {
+            $0.contains("retried publishable comments individually")
+        })
+    }
+
+    @Test func githubPublishReviewPreservesMappingsWhenRefreshFails() async throws {
+        let runner = FakeRunner(results: [
+            ProcessResult(exitCode: 0, stdout: Self.pullRequestNodeOutput, stderr: ""),
+            ProcessResult(exitCode: 0, stdout: Self.publishReviewMutationOutput, stderr: ""),
+            ProcessResult(exitCode: 1, stdout: "", stderr: "temporary API failure"),
+        ])
+        let provider = GitHubCLIProvider(runner: runner)
+
+        let result = try await provider.publishReview(ProviderReviewPublishRequest(
+            remote: Self.remote,
+            reviewRequest: Self.makeRequest(),
+            comments: [
+                Self.makeProviderDraftComment(
+                    id: "draft-1",
+                    path: "Sources/App.swift",
+                    side: .new,
+                    startLine: 12,
+                    endLine: nil,
+                    body: "Please simplify this."
+                ),
+            ],
+            decision: .comment,
+            summaryBody: "Review notes.",
+            cwd: Self.cwd
+        ))
+
+        #expect(result.published.map(\.localDraftID) == ["draft-1"])
+        #expect(result.failed.isEmpty)
+        #expect(result.refreshedRequest == Self.makeRequest())
+        #expect(result.warnings.contains {
+            $0.contains("could not refresh the PR")
+        })
+    }
+
     @Test func githubThreadMutationsUseGraphQLAndRefreshPR() async throws {
         let thread = ReviewThreadSummary(
             id: "thread-1",

--- a/AlasTests/Integrations/GitHubCLIProviderTests.swift
+++ b/AlasTests/Integrations/GitHubCLIProviderTests.swift
@@ -319,7 +319,7 @@ struct GitHubCLIProviderTests {
         let runner = FakeRunner(results: [
             ProcessResult(exitCode: 0, stdout: Self.pullRequestNodeOutput, stderr: ""),
             ProcessResult(exitCode: 0, stdout: Self.publishReviewMutationOutput, stderr: ""),
-            ProcessResult(exitCode: 0, stdout: Self.prListOutput, stderr: ""),
+            ProcessResult(exitCode: 0, stdout: Self.prViewOutput, stderr: ""),
             ProcessResult(exitCode: 0, stdout: Self.reviewThreadsOutput, stderr: ""),
         ])
         let provider = GitHubCLIProvider(runner: runner)
@@ -349,10 +349,19 @@ struct GitHubCLIProviderTests {
         #expect(commands[0].stdin?.contains("pullRequest(number: $number)") == true)
         let publishVariables = try Self.graphQLVariables(from: commands[1].stdin)
         let publishInput = try #require(publishVariables["input"] as? [String: Any])
-        let publishComments = try #require(publishInput["comments"] as? [[String: Any]])
+        let publishThreads = try #require(publishInput["threads"] as? [[String: Any]])
+        #expect(publishInput["comments"] == nil)
         #expect(publishInput["pullRequestId"] as? String == "PR_node_42")
         #expect(publishInput["event"] as? String == "REQUEST_CHANGES")
-        #expect(publishComments.first?["path"] as? String == "Sources/App.swift")
+        #expect(publishThreads.first?["path"] as? String == "Sources/App.swift")
+        #expect(publishThreads.first?["line"] as? Int == 14)
+        #expect(publishThreads.first?["side"] as? String == "RIGHT")
+        #expect(publishThreads.first?["startLine"] as? Int == 12)
+        #expect(commands[2].args == [
+            "pr", "view", "42",
+            "--json", "number,title,url,state,isDraft,headRefName,headRepositoryOwner,baseRefName,reviewDecision,mergeStateStatus",
+            "-R", "mrmans0n/alas",
+        ])
         #expect(result.published == [
             ProviderReviewPublishedComment(
                 localDraftID: "draft-1",
@@ -379,10 +388,10 @@ struct GitHubCLIProviderTests {
         )
         let runner = FakeRunner(results: [
             ProcessResult(exitCode: 0, stdout: Self.replyMutationOutput, stderr: ""),
-            ProcessResult(exitCode: 0, stdout: Self.prListOutput, stderr: ""),
+            ProcessResult(exitCode: 0, stdout: Self.prViewOutput, stderr: ""),
             ProcessResult(exitCode: 0, stdout: Self.reviewThreadsOutput, stderr: ""),
             ProcessResult(exitCode: 0, stdout: Self.resolveThreadMutationOutput, stderr: ""),
-            ProcessResult(exitCode: 0, stdout: Self.prListOutput, stderr: ""),
+            ProcessResult(exitCode: 0, stdout: Self.prViewOutput, stderr: ""),
             ProcessResult(exitCode: 0, stdout: Self.reviewThreadsOutput, stderr: ""),
         ])
         let provider = GitHubCLIProvider(runner: runner)
@@ -406,7 +415,17 @@ struct GitHubCLIProviderTests {
 
         let commands = await runner.commands
         #expect(commands[0].args == ["api", "graphql", "--input", "-"])
+        #expect(commands[1].args == [
+            "pr", "view", "42",
+            "--json", "number,title,url,state,isDraft,headRefName,headRepositoryOwner,baseRefName,reviewDecision,mergeStateStatus",
+            "-R", "mrmans0n/alas",
+        ])
         #expect(commands[3].args == ["api", "graphql", "--input", "-"])
+        #expect(commands[4].args == [
+            "pr", "view", "42",
+            "--json", "number,title,url,state,isDraft,headRefName,headRepositoryOwner,baseRefName,reviewDecision,mergeStateStatus",
+            "-R", "mrmans0n/alas",
+        ])
         #expect(commands[0].stdin?.contains("addPullRequestReviewThreadReply") == true)
         #expect(commands[0].stdin?.contains("\"pullRequestReviewThreadId\":\"PRRT_thread_1\"") == true)
         #expect(commands[3].stdin?.contains("resolveReviewThread") == true)
@@ -1005,6 +1024,20 @@ struct GitHubCLIProviderTests {
         "mergeStateStatus": "CLEAN"
       }
     ]
+    """
+
+    private static let prViewOutput = """
+    {
+      "number": 42,
+      "title": "Add GitHub provider",
+      "url": "https://github.com/mrmans0n/alas/pull/42",
+      "state": "OPEN",
+      "isDraft": false,
+      "headRefName": "feature/github-provider",
+      "baseRefName": "main",
+      "reviewDecision": "APPROVED",
+      "mergeStateStatus": "CLEAN"
+    }
     """
 
     private static let checksOutput = """

--- a/AlasTests/Integrations/GitHubCLIProviderTests.swift
+++ b/AlasTests/Integrations/GitHubCLIProviderTests.swift
@@ -366,6 +366,7 @@ struct GitHubCLIProviderTests {
         #expect(publishThreads.first?["line"] as? Int == 14)
         #expect(publishThreads.first?["side"] as? String == "RIGHT")
         #expect(publishThreads.first?["startLine"] as? Int == 12)
+        #expect(publishThreads.first?["startSide"] as? String == "RIGHT")
         #expect(commands[2].args == [
             "pr", "view", "42",
             "--json", "number,title,url,state,isDraft,headRefName,headRepositoryOwner,baseRefName,reviewDecision,mergeStateStatus",

--- a/AlasTests/Integrations/GitHubCLIProviderTests.swift
+++ b/AlasTests/Integrations/GitHubCLIProviderTests.swift
@@ -616,6 +616,31 @@ struct GitHubCLIProviderTests {
         #expect(result.refreshedRequest.number == 42)
     }
 
+    @Test func githubPublishReviewThrowsDecisionOnlyReviewFailure() async throws {
+        let runner = FakeRunner(results: [
+            ProcessResult(exitCode: 0, stdout: Self.pullRequestNodeOutput, stderr: ""),
+            ProcessResult(exitCode: 1, stdout: "", stderr: "GraphQL: Resource not accessible by integration"),
+        ])
+        let provider = GitHubCLIProvider(runner: runner)
+
+        await #expect(throws: CodeHostProviderError.commandFailed(
+            command: "gh api graphql",
+            stderr: "GraphQL: Resource not accessible by integration"
+        )) {
+            _ = try await provider.publishReview(ProviderReviewPublishRequest(
+                remote: Self.remote,
+                reviewRequest: Self.makeRequest(),
+                comments: [],
+                decision: .approve,
+                summaryBody: "Looks good.",
+                cwd: Self.cwd
+            ))
+        }
+
+        let commands = await runner.commands
+        #expect(commands.count == 2)
+    }
+
     @Test func githubPublishReviewPreservesMappingsWhenRefreshFails() async throws {
         let runner = FakeRunner(results: [
             ProcessResult(exitCode: 0, stdout: Self.pullRequestNodeOutput, stderr: ""),

--- a/AlasTests/Integrations/GitHubCLIProviderTests.swift
+++ b/AlasTests/Integrations/GitHubCLIProviderTests.swift
@@ -723,6 +723,36 @@ struct GitHubCLIProviderTests {
         ])
     }
 
+    @Test func githubRefreshUsesHostQualifiedRepositoryForEnterpriseRemote() async throws {
+        let enterpriseRemote = CodeHostRemote(
+            kind: .github,
+            host: "github.enterprise.example.com",
+            owner: "platform",
+            repository: "alas",
+            remoteName: "enterprise",
+            webURL: URL(string: "https://github.enterprise.example.com/platform/alas")!
+        )
+        let runner = FakeRunner(results: [
+            ProcessResult(exitCode: 0, stdout: Self.prViewOutput, stderr: ""),
+            ProcessResult(exitCode: 0, stdout: Self.reviewThreadsOutput, stderr: ""),
+        ])
+        let provider = GitHubCLIProvider(runner: runner)
+
+        _ = try await provider.reviewRequest(remote: enterpriseRemote, number: 42, cwd: Self.cwd)
+
+        let commands = await runner.commands
+        #expect(commands.count == 2)
+        #expect(commands[0].args == [
+            "pr", "view", "42",
+            "--json", "number,title,url,state,isDraft,headRefName,headRefOid,headRepositoryOwner,baseRefName,reviewDecision,mergeStateStatus",
+            "-R", "github.enterprise.example.com/platform/alas",
+        ])
+        #expect(commands[1].args.prefix(3) == ["api", "graphql", "--hostname"])
+        #expect(commands[1].args.contains("github.enterprise.example.com"))
+        #expect(commands[1].args.contains("owner=platform"))
+        #expect(commands[1].args.contains("repo=alas"))
+    }
+
     @Test func githubThreadMutationPreservesSuccessfulReplyWhenRefreshFails() async throws {
         let thread = ReviewThreadSummary(
             id: "thread-1",

--- a/AlasTests/Integrations/GitHubCLIProviderTests.swift
+++ b/AlasTests/Integrations/GitHubCLIProviderTests.swift
@@ -14,6 +14,7 @@ struct GitHubCLIProviderTests {
                 "state": "OPEN",
                 "isDraft": false,
                 "headRefName": "feature/github-provider",
+                "headRefOid": "head-sha-42",
                 "baseRefName": "main",
                 "reviewDecision": "CHANGES_REQUESTED",
                 "mergeStateStatus": "BLOCKED"
@@ -29,6 +30,7 @@ struct GitHubCLIProviderTests {
         #expect(request.reviewDecision == .changesRequested)
         #expect(request.mergeState == .blocked)
         #expect(request.provider == .github)
+        #expect(request.headSHA == "head-sha-42")
         #expect(request.checks.isEmpty)
         #expect(request.threads.isEmpty)
     }
@@ -201,7 +203,7 @@ struct GitHubCLIProviderTests {
                     "--base", "main",
                     "--state", "open",
                     "--limit", "20",
-                    "--json", "number,title,url,state,isDraft,headRefName,headRepositoryOwner,baseRefName,reviewDecision,mergeStateStatus",
+                    "--json", "number,title,url,state,isDraft,headRefName,headRefOid,headRepositoryOwner,baseRefName,reviewDecision,mergeStateStatus",
                     "-R", "mrmans0n/alas",
                 ],
                 cwd: Self.cwd
@@ -362,6 +364,7 @@ struct GitHubCLIProviderTests {
         #expect(publishInput["comments"] == nil)
         #expect(publishThreads.count == 1)
         #expect(publishInput["pullRequestId"] as? String == "PR_node_42")
+        #expect(publishInput["commitOID"] as? String == "head-sha-42")
         #expect(publishInput["event"] as? String == "REQUEST_CHANGES")
         #expect(publishThreads.first?["path"] as? String == "Sources/App.swift")
         #expect(publishThreads.first?["line"] as? Int == 14)
@@ -370,7 +373,7 @@ struct GitHubCLIProviderTests {
         #expect(publishThreads.first?["startSide"] as? String == "RIGHT")
         #expect(commands[2].args == [
             "pr", "view", "42",
-            "--json", "number,title,url,state,isDraft,headRefName,headRepositoryOwner,baseRefName,reviewDecision,mergeStateStatus",
+            "--json", "number,title,url,state,isDraft,headRefName,headRefOid,headRepositoryOwner,baseRefName,reviewDecision,mergeStateStatus",
             "-R", "mrmans0n/alas",
         ])
         #expect(result.published == [
@@ -642,13 +645,13 @@ struct GitHubCLIProviderTests {
         #expect(commands[0].args == ["api", "graphql", "--hostname", "github.com", "--input", "-"])
         #expect(commands[1].args == [
             "pr", "view", "42",
-            "--json", "number,title,url,state,isDraft,headRefName,headRepositoryOwner,baseRefName,reviewDecision,mergeStateStatus",
+            "--json", "number,title,url,state,isDraft,headRefName,headRefOid,headRepositoryOwner,baseRefName,reviewDecision,mergeStateStatus",
             "-R", "mrmans0n/alas",
         ])
         #expect(commands[3].args == ["api", "graphql", "--hostname", "github.com", "--input", "-"])
         #expect(commands[4].args == [
             "pr", "view", "42",
-            "--json", "number,title,url,state,isDraft,headRefName,headRepositoryOwner,baseRefName,reviewDecision,mergeStateStatus",
+            "--json", "number,title,url,state,isDraft,headRefName,headRefOid,headRepositoryOwner,baseRefName,reviewDecision,mergeStateStatus",
             "-R", "mrmans0n/alas",
         ])
         #expect(commands[0].stdin?.contains("addPullRequestReviewThreadReply") == true)
@@ -1238,6 +1241,7 @@ struct GitHubCLIProviderTests {
             isDraft: false,
             headRefName: "feature/github-provider",
             baseRefName: "main",
+            headSHA: "head-sha-42",
             reviewDecision: reviewDecision,
             mergeState: .clean,
             checks: checks,
@@ -1294,6 +1298,7 @@ struct GitHubCLIProviderTests {
         "state": "OPEN",
         "isDraft": false,
         "headRefName": "feature/github-provider",
+        "headRefOid": "head-sha-42",
         "baseRefName": "main",
         "reviewDecision": "APPROVED",
         "mergeStateStatus": "CLEAN"
@@ -1309,6 +1314,7 @@ struct GitHubCLIProviderTests {
       "state": "OPEN",
       "isDraft": false,
       "headRefName": "feature/github-provider",
+      "headRefOid": "head-sha-42",
       "baseRefName": "main",
       "reviewDecision": "APPROVED",
       "mergeStateStatus": "CLEAN"

--- a/AlasTests/Integrations/GitHubCLIProviderTests.swift
+++ b/AlasTests/Integrations/GitHubCLIProviderTests.swift
@@ -309,8 +309,111 @@ struct GitHubCLIProviderTests {
         #expect(threads[0].url == URL(string: "https://github.com/mrmans0n/alas/pull/42#discussion_r1"))
         #expect(threads[0].isResolved == false)
         #expect(threads[0].isActionable == true)
+        #expect(threads[0].providerThreadID == "thread-1")
+        #expect(threads[0].providerCommentID == "comment-1")
         #expect(threads[1].isResolved == false)
         #expect(threads[1].isActionable == false)
+    }
+
+    @Test func githubPublishReviewUsesGraphQLPayloadAndRefreshesPR() async throws {
+        let runner = FakeRunner(results: [
+            ProcessResult(exitCode: 0, stdout: Self.pullRequestNodeOutput, stderr: ""),
+            ProcessResult(exitCode: 0, stdout: Self.publishReviewMutationOutput, stderr: ""),
+            ProcessResult(exitCode: 0, stdout: Self.prListOutput, stderr: ""),
+            ProcessResult(exitCode: 0, stdout: Self.reviewThreadsOutput, stderr: ""),
+        ])
+        let provider = GitHubCLIProvider(runner: runner)
+
+        let result = try await provider.publishReview(ProviderReviewPublishRequest(
+            remote: Self.remote,
+            reviewRequest: Self.makeRequest(),
+            comments: [
+                Self.makeProviderDraftComment(
+                    id: "draft-1",
+                    path: "Sources/App.swift",
+                    side: .new,
+                    startLine: 12,
+                    endLine: 14,
+                    body: "Please simplify this."
+                ),
+            ],
+            decision: .requestChanges,
+            summaryBody: "Please update this before merge.",
+            cwd: Self.cwd
+        ))
+
+        let commands = await runner.commands
+        #expect(commands.count == 4)
+        #expect(commands[0].args == ["api", "graphql", "--input", "-"])
+        #expect(commands[1].args == ["api", "graphql", "--input", "-"])
+        #expect(commands[0].stdin?.contains("pullRequest(number: $number)") == true)
+        let publishVariables = try Self.graphQLVariables(from: commands[1].stdin)
+        let publishInput = try #require(publishVariables["input"] as? [String: Any])
+        let publishComments = try #require(publishInput["comments"] as? [[String: Any]])
+        #expect(publishInput["pullRequestId"] as? String == "PR_node_42")
+        #expect(publishInput["event"] as? String == "REQUEST_CHANGES")
+        #expect(publishComments.first?["path"] as? String == "Sources/App.swift")
+        #expect(result.published == [
+            ProviderReviewPublishedComment(
+                localDraftID: "draft-1",
+                providerThreadID: "PRRT_thread_1",
+                providerCommentID: "PRRC_comment_1",
+                providerURL: URL(string: "https://github.com/mrmans0n/alas/pull/42#discussion_r1")
+            ),
+        ])
+        #expect(result.failed.isEmpty)
+        #expect(result.refreshedRequest.number == 42)
+        #expect(result.refreshedRequest.threads.count == 2)
+    }
+
+    @Test func githubThreadMutationsUseGraphQLAndRefreshPR() async throws {
+        let thread = ReviewThreadSummary(
+            id: "thread-1",
+            author: "reviewer",
+            body: "Please tighten this branch lookup.",
+            url: URL(string: "https://github.com/mrmans0n/alas/pull/42#discussion_r1"),
+            isResolved: false,
+            isActionable: true,
+            providerThreadID: "PRRT_thread_1",
+            providerCommentID: "PRRC_comment_1"
+        )
+        let runner = FakeRunner(results: [
+            ProcessResult(exitCode: 0, stdout: Self.replyMutationOutput, stderr: ""),
+            ProcessResult(exitCode: 0, stdout: Self.prListOutput, stderr: ""),
+            ProcessResult(exitCode: 0, stdout: Self.reviewThreadsOutput, stderr: ""),
+            ProcessResult(exitCode: 0, stdout: Self.resolveThreadMutationOutput, stderr: ""),
+            ProcessResult(exitCode: 0, stdout: Self.prListOutput, stderr: ""),
+            ProcessResult(exitCode: 0, stdout: Self.reviewThreadsOutput, stderr: ""),
+        ])
+        let provider = GitHubCLIProvider(runner: runner)
+
+        let replyResult = try await provider.mutateReviewThread(ProviderThreadMutation(
+            remote: Self.remote,
+            reviewRequest: Self.makeRequest(threads: [thread]),
+            thread: thread,
+            kind: .reply,
+            bodyMarkdown: "Thanks, fixed.",
+            cwd: Self.cwd
+        ))
+        let resolveResult = try await provider.mutateReviewThread(ProviderThreadMutation(
+            remote: Self.remote,
+            reviewRequest: Self.makeRequest(threads: [thread]),
+            thread: thread,
+            kind: .resolve,
+            bodyMarkdown: nil,
+            cwd: Self.cwd
+        ))
+
+        let commands = await runner.commands
+        #expect(commands[0].args == ["api", "graphql", "--input", "-"])
+        #expect(commands[3].args == ["api", "graphql", "--input", "-"])
+        #expect(commands[0].stdin?.contains("addPullRequestReviewThreadReply") == true)
+        #expect(commands[0].stdin?.contains("\"pullRequestReviewThreadId\":\"PRRT_thread_1\"") == true)
+        #expect(commands[3].stdin?.contains("resolveReviewThread") == true)
+        #expect(commands[3].stdin?.contains("\"threadId\":\"PRRT_thread_1\"") == true)
+        #expect(replyResult.providerURL == URL(string: "https://github.com/mrmans0n/alas/pull/42#discussion_r2"))
+        #expect(replyResult.refreshedRequest.number == 42)
+        #expect(resolveResult.refreshedRequest.number == 42)
     }
 
     @Test func reviewThreadsJSONPreservesLocationMetadata() throws {
@@ -848,6 +951,46 @@ struct GitHubCLIProviderTests {
         )
     }
 
+    private static func makeProviderDraftComment(
+        id: String,
+        path: String,
+        side: DiffReviewInlineFeedbackSide,
+        startLine: Int,
+        endLine: Int?,
+        body: String
+    ) throws -> ProviderReviewDraftComment {
+        let draft = ReviewDraftComment(
+            id: id,
+            sessionID: .reviewRequest(
+                worktreeID: "wt",
+                provider: .github,
+                host: "github.com",
+                repositorySlug: "mrmans0n/alas",
+                number: 42
+            ),
+            fileID: DiffReviewFileID(namespace: "github", path: path),
+            path: path,
+            originalPath: nil,
+            side: side,
+            startLine: startLine,
+            endLine: endLine,
+            selectedText: nil,
+            bodyMarkdown: body,
+            state: .active,
+            createdAt: Date(timeIntervalSince1970: 10),
+            updatedAt: Date(timeIntervalSince1970: 11)
+        )
+        return try #require(ProviderReviewDraftComment(localDraft: draft))
+    }
+
+    private static func graphQLVariables(from stdin: String?) throws -> [String: Any] {
+        let stdin = try #require(stdin)
+        let data = Data(stdin.utf8)
+        let object = try JSONSerialization.jsonObject(with: data)
+        let payload = try #require(object as? [String: Any])
+        return try #require(payload["variables"] as? [String: Any])
+    }
+
     private static let prListOutput = """
     [
       {
@@ -970,6 +1113,7 @@ struct GitHubCLIProviderTests {
                   "comments": {
                     "nodes": [
                       {
+                        "id": "comment-1",
                         "body": "Please tighten this branch lookup.",
                         "url": "https://github.com/mrmans0n/alas/pull/42#discussion_r1",
                         "author": { "login": "reviewer" }
@@ -984,6 +1128,7 @@ struct GitHubCLIProviderTests {
                   "comments": {
                     "nodes": [
                       {
+                        "id": "comment-2",
                         "body": "Old feedback.",
                         "url": "https://github.com/mrmans0n/alas/pull/42#discussion_r2",
                         "author": { "login": "reviewer" }
@@ -998,6 +1143,7 @@ struct GitHubCLIProviderTests {
                   "comments": {
                     "nodes": [
                       {
+                        "id": "comment-3",
                         "body": "",
                         "url": "https://github.com/mrmans0n/alas/pull/42#discussion_r3",
                         "author": { "login": "reviewer" }
@@ -1015,6 +1161,22 @@ struct GitHubCLIProviderTests {
         }
       }
     }
+    """
+
+    private static let pullRequestNodeOutput = """
+    {"data":{"repository":{"pullRequest":{"id":"PR_node_42"}}}}
+    """
+
+    private static let publishReviewMutationOutput = """
+    {"data":{"addPullRequestReview":{"pullRequestReview":{"comments":{"nodes":[{"id":"PRRC_comment_1","url":"https://github.com/mrmans0n/alas/pull/42#discussion_r1","pullRequestReviewThread":{"id":"PRRT_thread_1"}}]}}}}}
+    """
+
+    private static let replyMutationOutput = """
+    {"data":{"addPullRequestReviewThreadReply":{"comment":{"id":"PRRC_reply_1","url":"https://github.com/mrmans0n/alas/pull/42#discussion_r2"}}}}
+    """
+
+    private static let resolveThreadMutationOutput = """
+    {"data":{"resolveReviewThread":{"thread":{"id":"PRRT_thread_1","isResolved":true}}}}
     """
 
     private static let reviewThreadsFirstPageOutput = """

--- a/AlasTests/Integrations/GitHubCLIProviderTests.swift
+++ b/AlasTests/Integrations/GitHubCLIProviderTests.swift
@@ -336,6 +336,14 @@ struct GitHubCLIProviderTests {
                     endLine: 14,
                     body: "Please simplify this."
                 ),
+                Self.makeProviderDraftComment(
+                    id: "draft-unknown",
+                    path: "Sources/App.swift",
+                    side: .unknown,
+                    startLine: 20,
+                    endLine: nil,
+                    body: "This should not be posted to the wrong side."
+                ),
             ],
             decision: .requestChanges,
             summaryBody: "Please update this before merge.",
@@ -351,6 +359,7 @@ struct GitHubCLIProviderTests {
         let publishInput = try #require(publishVariables["input"] as? [String: Any])
         let publishThreads = try #require(publishInput["threads"] as? [[String: Any]])
         #expect(publishInput["comments"] == nil)
+        #expect(publishThreads.count == 1)
         #expect(publishInput["pullRequestId"] as? String == "PR_node_42")
         #expect(publishInput["event"] as? String == "REQUEST_CHANGES")
         #expect(publishThreads.first?["path"] as? String == "Sources/App.swift")
@@ -370,7 +379,12 @@ struct GitHubCLIProviderTests {
                 providerURL: URL(string: "https://github.com/mrmans0n/alas/pull/42#discussion_r1")
             ),
         ])
-        #expect(result.failed.isEmpty)
+        #expect(result.failed == [
+            ProviderReviewFailedComment(
+                localDraftID: "draft-unknown",
+                message: "GitHub review comments require an old or new side."
+            ),
+        ])
         #expect(result.refreshedRequest.number == 42)
         #expect(result.refreshedRequest.threads.count == 2)
     }

--- a/AlasTests/Integrations/GitHubCLIProviderTests.swift
+++ b/AlasTests/Integrations/GitHubCLIProviderTests.swift
@@ -545,7 +545,9 @@ struct GitHubCLIProviderTests {
         #expect(result.failed.allSatisfy {
             $0.message.contains("Unable to parse gh publish review output")
         })
-        #expect(result.warnings.isEmpty)
+        #expect(result.warnings.contains {
+            $0.contains("GitHub request changes review was not submitted")
+        })
         #expect(result.refreshedRequest.number == 42)
     }
 

--- a/AlasTests/Integrations/GitHubCLIProviderTests.swift
+++ b/AlasTests/Integrations/GitHubCLIProviderTests.swift
@@ -35,6 +35,13 @@ struct GitHubCLIProviderTests {
         #expect(request.threads.isEmpty)
     }
 
+    @Test func prViewJSONParsesHeadSHA() throws {
+        let request = try GitHubCLIProvider.parsePRView(Self.prViewOutput, remote: Self.remote)
+
+        #expect(request.number == 42)
+        #expect(request.headSHA == "head-sha-42")
+    }
+
     @Test func checksJSONParsesBucketsURLsDatesAndDistinctIDs() throws {
         let checks = try GitHubCLIProvider.parseChecks(
             """

--- a/AlasTests/Integrations/GitLabCLIProviderTests.swift
+++ b/AlasTests/Integrations/GitLabCLIProviderTests.swift
@@ -1265,6 +1265,9 @@ struct GitLabCLIProviderTests {
 
         #expect(result.providerURL == URL(string: "https://gitlab.example.com/platform/mobile/alas/-/merge_requests/42#note_502"))
         #expect(result.refreshedRequest == Self.makeRequest())
+        #expect(result.warnings.contains {
+            $0.contains("GitLab thread was updated, but Alas could not refresh the MR")
+        })
     }
 
     @Test func currentReviewRequestResolvesSourceProjectIDsBeforeFilteringForkMRs() async throws {

--- a/AlasTests/Integrations/GitLabCLIProviderTests.swift
+++ b/AlasTests/Integrations/GitLabCLIProviderTests.swift
@@ -652,6 +652,7 @@ struct GitLabCLIProviderTests {
         )
 
         #expect(request?.number == 42)
+        #expect(request?.headSHA == "head123")
         #expect(request?.threads.map(\.id) == ["discussion-1", "discussion-2"])
         #expect(request?.hasActionableFeedback == true)
         #expect(await runner.commands.map(\.args.first) == ["mr", "mr", "mr", "ci"])

--- a/AlasTests/Integrations/GitLabCLIProviderTests.swift
+++ b/AlasTests/Integrations/GitLabCLIProviderTests.swift
@@ -852,28 +852,11 @@ struct GitLabCLIProviderTests {
         #expect(lineRangeEnd["line_code"] as? String == "\(Self.gitLabLineCodePathHash("Sources/OldApp.swift"))_14_0")
     }
 
-    @Test func publishReviewRejectsUnsupportedGitLabRequestChangesDecision() async throws {
-        let runner = FakeRunner(results: [])
-
-        await #expect(throws: CodeHostProviderError.malformedOutput("GitLab request-changes review state is not supported yet.")) {
-            _ = try await GitLabCLIProvider(runner: runner).publishReview(ProviderReviewPublishRequest(
-                remote: Self.remote,
-                reviewRequest: Self.makeRequest(),
-                comments: [],
-                decision: .requestChanges,
-                summaryBody: "Please address the inline notes before merging.",
-                cwd: Self.cwd
-            ))
-        }
-
-        let commands = await runner.commands
-        #expect(commands.isEmpty)
-    }
-
-    @Test func publishReviewReportsUnsupportedGitLabRequestChangesAfterPublishingComments() async throws {
+    @Test func publishReviewCreatesStatusNoteForGitLabRequestChanges() async throws {
         let runner = FakeRunner(results: [
             ProcessResult(exitCode: 0, stdout: Self.versionsOutput, stderr: ""),
             ProcessResult(exitCode: 0, stdout: Self.createDiscussionOutput, stderr: ""),
+            ProcessResult(exitCode: 0, stdout: Self.createNoteOutput, stderr: ""),
             ProcessResult(exitCode: 0, stdout: Self.mrViewOutput, stderr: ""),
             ProcessResult(exitCode: 0, stdout: Self.discussionsOutput, stderr: ""),
             ProcessResult(exitCode: 0, stdout: Self.pipelineOutput, stderr: ""),
@@ -890,7 +873,51 @@ struct GitLabCLIProviderTests {
 
         #expect(result.published.map { $0.localDraftID } == ["draft-1"])
         #expect(result.failed.isEmpty)
-        #expect(result.warnings.contains { $0.contains("GitLab request-changes review state is not supported yet.") })
+        #expect(result.warnings.isEmpty)
+
+        let commands = await runner.commands
+        #expect(commands.map { Array($0.args.prefix(2)) } == [
+            ["api", "projects/platform%2Fmobile%2Falas/merge_requests/42/versions"],
+            ["api", "projects/platform%2Fmobile%2Falas/merge_requests/42/discussions"],
+            ["api", "projects/platform%2Fmobile%2Falas/merge_requests/42/notes"],
+            ["mr", "view"],
+            ["mr", "note"],
+            ["ci", "get"],
+        ])
+        let statusNotePayload = try Self.jsonObject(from: commands[2].stdin)
+        #expect(statusNotePayload["body"] as? String == "Please address the inline notes before merging.")
+    }
+
+    @Test func publishReviewCreatesGitLabRequestChangesStatusNoteWithoutDrafts() async throws {
+        let runner = FakeRunner(results: [
+            ProcessResult(exitCode: 0, stdout: Self.createNoteOutput, stderr: ""),
+            ProcessResult(exitCode: 0, stdout: Self.mrViewOutput, stderr: ""),
+            ProcessResult(exitCode: 0, stdout: Self.discussionsOutput, stderr: ""),
+            ProcessResult(exitCode: 0, stdout: Self.pipelineOutput, stderr: ""),
+        ])
+
+        let result = try await GitLabCLIProvider(runner: runner).publishReview(ProviderReviewPublishRequest(
+            remote: Self.remote,
+            reviewRequest: Self.makeRequest(),
+            comments: [],
+            decision: .requestChanges,
+            summaryBody: "Please address the inline notes before merging.",
+            cwd: Self.cwd
+        ))
+
+        #expect(result.published.isEmpty)
+        #expect(result.failed.isEmpty)
+        #expect(result.warnings.isEmpty)
+
+        let commands = await runner.commands
+        #expect(commands.map { Array($0.args.prefix(2)) } == [
+            ["api", "projects/platform%2Fmobile%2Falas/merge_requests/42/notes"],
+            ["mr", "view"],
+            ["mr", "note"],
+            ["ci", "get"],
+        ])
+        let statusNotePayload = try Self.jsonObject(from: commands[0].stdin)
+        #expect(statusNotePayload["body"] as? String == "Please address the inline notes before merging.")
     }
 
     @Test func publishReviewReturnsFailuresWithoutRemoteWriteForUnknownOnlyDrafts() async throws {
@@ -1025,6 +1052,43 @@ struct GitLabCLIProviderTests {
         #expect(result.failed.map(\.localDraftID) == ["draft-2"])
         #expect(result.refreshedRequest.threads.map(\.id) == ["discussion-1", "discussion-2"])
         #expect(result.warnings.contains { $0.contains("approval was not submitted") })
+    }
+
+    @Test func publishReviewDoesNotSubmitGitLabRequestChangesNoteWhenSomeDraftPublishesFail() async throws {
+        let runner = FakeRunner(results: [
+            ProcessResult(exitCode: 0, stdout: Self.versionsOutput, stderr: ""),
+            ProcessResult(exitCode: 0, stdout: Self.createDiscussionOutput, stderr: ""),
+            ProcessResult(exitCode: 1, stdout: "", stderr: "line is not commentable"),
+            ProcessResult(exitCode: 0, stdout: Self.mrViewOutput, stderr: ""),
+            ProcessResult(exitCode: 0, stdout: Self.discussionsOutput, stderr: ""),
+            ProcessResult(exitCode: 0, stdout: Self.pipelineOutput, stderr: ""),
+        ])
+
+        let result = try await GitLabCLIProvider(runner: runner).publishReview(ProviderReviewPublishRequest(
+            remote: Self.remote,
+            reviewRequest: Self.makeRequest(),
+            comments: [
+                try Self.makeProviderDraftComment(localDraftID: "draft-1", side: .new, lineRange: 24...24),
+                try Self.makeProviderDraftComment(localDraftID: "draft-2", side: .new, lineRange: 25...25),
+            ],
+            decision: .requestChanges,
+            summaryBody: "Please address the inline notes before merging.",
+            cwd: Self.cwd
+        ))
+
+        let commands = await runner.commands
+        #expect(commands.map { Array($0.args.prefix(2)) } == [
+            ["api", "projects/platform%2Fmobile%2Falas/merge_requests/42/versions"],
+            ["api", "projects/platform%2Fmobile%2Falas/merge_requests/42/discussions"],
+            ["api", "projects/platform%2Fmobile%2Falas/merge_requests/42/discussions"],
+            ["mr", "view"],
+            ["mr", "note"],
+            ["ci", "get"],
+        ])
+        #expect(result.published.map(\.localDraftID) == ["draft-1"])
+        #expect(result.failed.map(\.localDraftID) == ["draft-2"])
+        #expect(result.refreshedRequest.threads.map(\.id) == ["discussion-1", "discussion-2"])
+        #expect(result.warnings.contains { $0.contains("request changes note was not submitted") })
     }
 
     @Test func threadMutationsUseDiscussionEndpointsAndRefreshMR() async throws {

--- a/AlasTests/Integrations/GitLabCLIProviderTests.swift
+++ b/AlasTests/Integrations/GitLabCLIProviderTests.swift
@@ -990,6 +990,43 @@ struct GitLabCLIProviderTests {
         #expect(result.refreshedRequest == Self.makeRequest())
     }
 
+    @Test func publishReviewDoesNotApproveWhenSomeGitLabDraftPublishesFail() async throws {
+        let runner = FakeRunner(results: [
+            ProcessResult(exitCode: 0, stdout: Self.versionsOutput, stderr: ""),
+            ProcessResult(exitCode: 0, stdout: Self.createDiscussionOutput, stderr: ""),
+            ProcessResult(exitCode: 1, stdout: "", stderr: "line is not commentable"),
+            ProcessResult(exitCode: 0, stdout: Self.mrViewOutput, stderr: ""),
+            ProcessResult(exitCode: 0, stdout: Self.discussionsOutput, stderr: ""),
+            ProcessResult(exitCode: 0, stdout: Self.pipelineOutput, stderr: ""),
+        ])
+
+        let result = try await GitLabCLIProvider(runner: runner).publishReview(ProviderReviewPublishRequest(
+            remote: Self.remote,
+            reviewRequest: Self.makeRequest(),
+            comments: [
+                try Self.makeProviderDraftComment(localDraftID: "draft-1", side: .new, lineRange: 24...24),
+                try Self.makeProviderDraftComment(localDraftID: "draft-2", side: .new, lineRange: 25...25),
+            ],
+            decision: .approve,
+            summaryBody: "Looks good.",
+            cwd: Self.cwd
+        ))
+
+        let commands = await runner.commands
+        #expect(commands.map { Array($0.args.prefix(2)) } == [
+            ["api", "projects/platform%2Fmobile%2Falas/merge_requests/42/versions"],
+            ["api", "projects/platform%2Fmobile%2Falas/merge_requests/42/discussions"],
+            ["api", "projects/platform%2Fmobile%2Falas/merge_requests/42/discussions"],
+            ["mr", "view"],
+            ["mr", "note"],
+            ["ci", "get"],
+        ])
+        #expect(result.published.map(\.localDraftID) == ["draft-1"])
+        #expect(result.failed.map(\.localDraftID) == ["draft-2"])
+        #expect(result.refreshedRequest.threads.map(\.id) == ["discussion-1", "discussion-2"])
+        #expect(result.warnings.contains { $0.contains("approval was not submitted") })
+    }
+
     @Test func threadMutationsUseDiscussionEndpointsAndRefreshMR() async throws {
         let runner = FakeRunner(results: [
             ProcessResult(exitCode: 0, stdout: Self.createNoteOutput, stderr: ""),

--- a/AlasTests/Integrations/GitLabCLIProviderTests.swift
+++ b/AlasTests/Integrations/GitLabCLIProviderTests.swift
@@ -1801,11 +1801,9 @@ struct GitLabCLIProviderTests {
     private static let versionsOutput = """
     [
       {
-        "diff_refs": {
-          "base_sha": "base123",
-          "start_sha": "start123",
-          "head_sha": "head123"
-        }
+        "base_commit_sha": "base123",
+        "start_commit_sha": "start123",
+        "head_commit_sha": "head123"
       }
     ]
     """

--- a/AlasTests/Integrations/GitLabCLIProviderTests.swift
+++ b/AlasTests/Integrations/GitLabCLIProviderTests.swift
@@ -107,6 +107,7 @@ struct GitLabCLIProviderTests {
         #expect(request.isDraft == false)
         #expect(request.headRefName == "feature/gitlab-provider")
         #expect(request.baseRefName == "main")
+        #expect(request.headSHA == "head123")
         #expect(request.reviewDecision == .unknown)
         #expect(request.mergeState == .clean)
         #expect(request.provider == .gitlab)
@@ -118,6 +119,7 @@ struct GitLabCLIProviderTests {
         #expect(request.number == 42)
         #expect(request.title == "Add GitLab provider")
         #expect(request.isDraft == true)
+        #expect(request.headSHA == "head123")
         #expect(request.reviewDecision == .reviewRequired)
         #expect(request.mergeState == .blocked)
     }
@@ -781,6 +783,9 @@ struct GitLabCLIProviderTests {
         ])
         let discussionPayload = try Self.jsonObject(from: commands[1].stdin)
         #expect(discussionPayload["body"] as? String == "Please fix this.")
+        #expect(commands[2].args.suffix(2) == ["--input", "-"])
+        let approvePayload = try Self.jsonObject(from: commands[2].stdin)
+        #expect(approvePayload["sha"] as? String == "head123")
         let position = try #require(discussionPayload["position"] as? [String: Any])
         #expect(position["position_type"] as? String == "text")
         #expect(position["base_sha"] as? String == "base123")
@@ -1578,6 +1583,7 @@ struct GitLabCLIProviderTests {
             isDraft: false,
             headRefName: "feature/gitlab-provider",
             baseRefName: "main",
+            headSHA: "head123",
             reviewDecision: .unknown,
             mergeState: .unknown,
             checks: checks,
@@ -1640,6 +1646,7 @@ struct GitLabCLIProviderTests {
         "draft": false,
         "source_branch": "feature/gitlab-provider",
         "target_branch": "main",
+        "sha": "head123",
         "merge_status": "can_be_merged",
         "detailed_merge_status": "mergeable"
       }
@@ -1655,6 +1662,7 @@ struct GitLabCLIProviderTests {
       "draft": true,
       "source_branch": "feature/gitlab-provider",
       "target_branch": "main",
+      "sha": "head123",
       "merge_status": "cannot_be_merged",
       "detailed_merge_status": "not_approved",
       "approvals_required": 1,

--- a/AlasTests/Integrations/GitLabCLIProviderTests.swift
+++ b/AlasTests/Integrations/GitLabCLIProviderTests.swift
@@ -1063,6 +1063,7 @@ struct GitLabCLIProviderTests {
         #expect(result.failed.map(\.localDraftID) == ["draft-1"])
         #expect(result.failed.first?.message.contains("line is not commentable") == true)
         #expect(result.refreshedRequest == Self.makeRequest())
+        #expect(result.warnings.contains { $0.contains("approval was not submitted") })
     }
 
     @Test func publishReviewDoesNotApproveWhenSomeGitLabDraftPublishesFail() async throws {

--- a/AlasTests/Integrations/GitLabCLIProviderTests.swift
+++ b/AlasTests/Integrations/GitLabCLIProviderTests.swift
@@ -134,11 +134,15 @@ struct GitLabCLIProviderTests {
         #expect(threads[0].url == URL(string: "https://gitlab.example.com/platform/mobile/alas/-/merge_requests/42#note_501"))
         #expect(threads[0].isResolved == false)
         #expect(threads[0].isActionable)
+        #expect(threads[0].providerThreadID == "discussion-1")
+        #expect(threads[0].providerCommentID == "501")
         #expect(threads[1].id == "discussion-2")
         #expect(threads[1].author == "maintainer")
         #expect(threads[1].url == URL(string: "https://gitlab.example.com/platform/mobile/alas/-/merge_requests/42#note_503"))
         #expect(threads[1].isResolved == false)
         #expect(threads[1].isActionable)
+        #expect(threads[1].providerThreadID == "discussion-2")
+        #expect(threads[1].providerCommentID == "503")
     }
 
     @Test func discussionsJSONPreservesLocationMetadata() throws {
@@ -725,6 +729,249 @@ struct GitLabCLIProviderTests {
         }
     }
 
+    @Test func publishReviewCreatesDiscussionsApprovesAndRefreshesMR() async throws {
+        let runner = FakeRunner(results: [
+            ProcessResult(exitCode: 0, stdout: Self.versionsOutput, stderr: ""),
+            ProcessResult(exitCode: 0, stdout: Self.createDiscussionOutput, stderr: ""),
+            ProcessResult(exitCode: 0, stdout: Self.approveOutput, stderr: ""),
+            ProcessResult(exitCode: 0, stdout: Self.mrViewOutput, stderr: ""),
+            ProcessResult(exitCode: 0, stdout: Self.discussionsOutput, stderr: ""),
+            ProcessResult(exitCode: 0, stdout: Self.pipelineOutput, stderr: ""),
+        ])
+        let provider = GitLabCLIProvider(runner: runner)
+
+        let result = try await provider.publishReview(ProviderReviewPublishRequest(
+            remote: Self.remote,
+            reviewRequest: Self.makeRequest(),
+            comments: [
+                try Self.makeProviderDraftComment(
+                    localDraftID: "draft-1",
+                    path: "Sources/App.swift",
+                    originalPath: "Sources/OldApp.swift",
+                    side: .new,
+                    lineRange: 24...24,
+                    bodyMarkdown: "Please fix this."
+                ),
+            ],
+            decision: .approve,
+            summaryBody: "Looks good after this note.",
+            cwd: Self.cwd
+        ))
+
+        #expect(result.published == [
+            ProviderReviewPublishedComment(
+                localDraftID: "draft-1",
+                providerThreadID: "discussion-1",
+                providerCommentID: "501",
+                providerURL: URL(string: "https://gitlab.example.com/platform/mobile/alas/-/merge_requests/42#note_501")
+            ),
+        ])
+        #expect(result.failed.isEmpty)
+        #expect(result.refreshedRequest.threads.map(\.id) == ["discussion-1", "discussion-2"])
+
+        let commands = await runner.commands
+        #expect(commands.map { Array($0.args.prefix(2)) } == [
+            ["api", "projects/:id/merge_requests/42/versions"],
+            ["api", "projects/:id/merge_requests/42/discussions"],
+            ["api", "projects/:id/merge_requests/42/approve"],
+            ["mr", "view"],
+            ["mr", "note"],
+            ["ci", "get"],
+        ])
+        let discussionPayload = try Self.jsonObject(from: commands[1].stdin)
+        #expect(discussionPayload["body"] as? String == "Please fix this.")
+        let position = try #require(discussionPayload["position"] as? [String: Any])
+        #expect(position["position_type"] as? String == "text")
+        #expect(position["base_sha"] as? String == "base123")
+        #expect(position["start_sha"] as? String == "start123")
+        #expect(position["head_sha"] as? String == "head123")
+        #expect(position["old_path"] as? String == "Sources/OldApp.swift")
+        #expect(position["new_path"] as? String == "Sources/App.swift")
+        #expect(position["new_line"] as? Int == 24)
+        #expect(position["old_line"] == nil)
+    }
+
+    @Test func publishReviewCreatesRequestChangesNoteForGitLabDecision() async throws {
+        let runner = FakeRunner(results: [
+            ProcessResult(exitCode: 0, stdout: Self.requestChangesNoteOutput, stderr: ""),
+            ProcessResult(exitCode: 0, stdout: Self.mrViewOutput, stderr: ""),
+            ProcessResult(exitCode: 0, stdout: Self.discussionsOutput, stderr: ""),
+            ProcessResult(exitCode: 0, stdout: Self.pipelineOutput, stderr: ""),
+        ])
+
+        let result = try await GitLabCLIProvider(runner: runner).publishReview(ProviderReviewPublishRequest(
+            remote: Self.remote,
+            reviewRequest: Self.makeRequest(),
+            comments: [],
+            decision: .requestChanges,
+            summaryBody: "Please address the inline notes before merging.",
+            cwd: Self.cwd
+        ))
+
+        #expect(result.published.isEmpty)
+        #expect(result.failed.isEmpty)
+        let commands = await runner.commands
+        #expect(commands.first == FakeRunner.Command(
+            executable: "glab",
+            args: [
+                "api",
+                "projects/:id/merge_requests/42/notes",
+                "--method", "POST",
+                "--hostname", "gitlab.example.com",
+                "--input", "-",
+            ],
+            cwd: Self.cwd,
+            stdin: #"{"body":"Please address the inline notes before merging."}"#
+        ))
+    }
+
+    @Test func publishReviewReturnsFailuresWithoutRemoteWriteForUnknownOnlyDrafts() async throws {
+        let runner = FakeRunner(results: [])
+
+        let result = try await GitLabCLIProvider(runner: runner).publishReview(ProviderReviewPublishRequest(
+            remote: Self.remote,
+            reviewRequest: Self.makeRequest(),
+            comments: [
+                try Self.makeProviderDraftComment(
+                    localDraftID: "draft-1",
+                    side: .unknown,
+                    lineRange: 24...24
+                ),
+            ],
+            decision: .approve,
+            summaryBody: "Looks good.",
+            cwd: Self.cwd
+        ))
+
+        #expect(result.published.isEmpty)
+        #expect(result.failed.map(\.localDraftID) == ["draft-1"])
+        #expect(await runner.commands.isEmpty)
+    }
+
+    @Test func publishReviewPreservesPublishedMappingsWhenRefreshFails() async throws {
+        let runner = FakeRunner(results: [
+            ProcessResult(exitCode: 0, stdout: Self.versionsOutput, stderr: ""),
+            ProcessResult(exitCode: 0, stdout: Self.createDiscussionOutput, stderr: ""),
+            ProcessResult(exitCode: 1, stdout: "", stderr: "refresh failed"),
+        ])
+
+        let result = try await GitLabCLIProvider(runner: runner).publishReview(ProviderReviewPublishRequest(
+            remote: Self.remote,
+            reviewRequest: Self.makeRequest(),
+            comments: [try Self.makeProviderDraftComment(localDraftID: "draft-1", side: .new)],
+            decision: .comment,
+            summaryBody: "",
+            cwd: Self.cwd
+        ))
+
+        #expect(result.published.map(\.localDraftID) == ["draft-1"])
+        #expect(result.refreshedRequest == Self.makeRequest())
+        #expect(result.warnings.first?.contains("could not refresh") == true)
+    }
+
+    @Test func threadMutationsUseDiscussionEndpointsAndRefreshMR() async throws {
+        let runner = FakeRunner(results: [
+            ProcessResult(exitCode: 0, stdout: Self.createNoteOutput, stderr: ""),
+            ProcessResult(exitCode: 0, stdout: Self.mrViewOutput, stderr: ""),
+            ProcessResult(exitCode: 0, stdout: Self.discussionsOutput, stderr: ""),
+            ProcessResult(exitCode: 0, stdout: Self.pipelineOutput, stderr: ""),
+            ProcessResult(exitCode: 0, stdout: Self.resolveDiscussionOutput, stderr: ""),
+            ProcessResult(exitCode: 0, stdout: Self.mrViewOutput, stderr: ""),
+            ProcessResult(exitCode: 0, stdout: Self.discussionsOutput, stderr: ""),
+            ProcessResult(exitCode: 0, stdout: Self.pipelineOutput, stderr: ""),
+            ProcessResult(exitCode: 0, stdout: Self.unresolveDiscussionOutput, stderr: ""),
+            ProcessResult(exitCode: 0, stdout: Self.mrViewOutput, stderr: ""),
+            ProcessResult(exitCode: 0, stdout: Self.discussionsOutput, stderr: ""),
+            ProcessResult(exitCode: 0, stdout: Self.pipelineOutput, stderr: ""),
+        ])
+        let thread = ReviewThreadSummary(
+            id: "discussion-1",
+            author: "reviewer",
+            body: "Please fix this.",
+            url: URL(string: "https://gitlab.example.com/platform/mobile/alas/-/merge_requests/42#note_501"),
+            isResolved: false,
+            isActionable: true,
+            location: nil,
+            providerThreadID: "discussion-1",
+            providerCommentID: "501"
+        )
+        let provider = GitLabCLIProvider(runner: runner)
+
+        let reply = try await provider.mutateReviewThread(ProviderThreadMutation(
+            remote: Self.remote,
+            reviewRequest: Self.makeRequest(),
+            thread: thread,
+            kind: .reply,
+            bodyMarkdown: "Fixed locally.",
+            cwd: Self.cwd
+        ))
+        _ = try await provider.mutateReviewThread(ProviderThreadMutation(
+            remote: Self.remote,
+            reviewRequest: Self.makeRequest(),
+            thread: thread,
+            kind: .resolve,
+            bodyMarkdown: nil,
+            cwd: Self.cwd
+        ))
+        _ = try await provider.mutateReviewThread(ProviderThreadMutation(
+            remote: Self.remote,
+            reviewRequest: Self.makeRequest(),
+            thread: thread,
+            kind: .unresolve,
+            bodyMarkdown: nil,
+            cwd: Self.cwd
+        ))
+
+        #expect(reply.providerURL == URL(string: "https://gitlab.example.com/platform/mobile/alas/-/merge_requests/42#note_502"))
+        let commands = await runner.commands
+        #expect(commands[0].args == [
+            "api",
+            "projects/:id/merge_requests/42/discussions/discussion-1/notes",
+            "--method", "POST",
+            "--hostname", "gitlab.example.com",
+            "--input", "-",
+        ])
+        #expect(commands[4].args == [
+            "api",
+            "projects/:id/merge_requests/42/discussions/discussion-1",
+            "--method", "PUT",
+            "--hostname", "gitlab.example.com",
+            "--input", "-",
+        ])
+        #expect(try Self.jsonObject(from: commands[4].stdin)["resolved"] as? Bool == true)
+        #expect(try Self.jsonObject(from: commands[8].stdin)["resolved"] as? Bool == false)
+    }
+
+    @Test func threadMutationPreservesSuccessfulReplyWhenRefreshFails() async throws {
+        let runner = FakeRunner(results: [
+            ProcessResult(exitCode: 0, stdout: Self.createNoteOutput, stderr: ""),
+            ProcessResult(exitCode: 1, stdout: "", stderr: "refresh failed"),
+        ])
+        let thread = ReviewThreadSummary(
+            id: "discussion-1",
+            author: nil,
+            body: "Body",
+            url: nil,
+            isResolved: false,
+            isActionable: true,
+            location: nil,
+            providerThreadID: "discussion-1",
+            providerCommentID: "501"
+        )
+
+        let result = try await GitLabCLIProvider(runner: runner).mutateReviewThread(ProviderThreadMutation(
+            remote: Self.remote,
+            reviewRequest: Self.makeRequest(),
+            thread: thread,
+            kind: .reply,
+            bodyMarkdown: "Fixed.",
+            cwd: Self.cwd
+        ))
+
+        #expect(result.providerURL == URL(string: "https://gitlab.example.com/platform/mobile/alas/-/merge_requests/42#note_502"))
+        #expect(result.refreshedRequest == Self.makeRequest())
+    }
+
     @Test func currentReviewRequestResolvesSourceProjectIDsBeforeFilteringForkMRs() async throws {
         let runner = FakeRunner(results: [
             ProcessResult(exitCode: 0, stdout: Self.duplicateForkMRListOutput, stderr: ""),
@@ -1230,6 +1477,45 @@ struct GitLabCLIProviderTests {
         )
     }
 
+    private static func makeProviderDraftComment(
+        localDraftID: String = "draft-1",
+        path: String = "Sources/App.swift",
+        originalPath: String? = nil,
+        side: DiffReviewInlineFeedbackSide = .new,
+        lineRange: ClosedRange<Int> = 24...24,
+        selectedText: String? = nil,
+        bodyMarkdown: String = "Please fix this."
+    ) throws -> ProviderReviewDraftComment {
+        let draft = ReviewDraftComment(
+            id: localDraftID,
+            sessionID: .reviewRequest(
+                worktreeID: "wt",
+                provider: .gitlab,
+                host: "gitlab.example.com",
+                repositorySlug: "platform/mobile/alas",
+                number: 42
+            ),
+            fileID: DiffReviewFileID(namespace: "gitlab", path: path),
+            path: path,
+            originalPath: originalPath,
+            side: side,
+            startLine: lineRange.lowerBound,
+            endLine: lineRange.upperBound == lineRange.lowerBound ? nil : lineRange.upperBound,
+            selectedText: selectedText,
+            bodyMarkdown: bodyMarkdown,
+            state: .active,
+            createdAt: Date(timeIntervalSince1970: 10),
+            updatedAt: Date(timeIntervalSince1970: 11)
+        )
+        return try #require(ProviderReviewDraftComment(localDraft: draft))
+    }
+
+    private static func jsonObject(from stdin: String?) throws -> [String: Any] {
+        let stdin = try #require(stdin)
+        let data = Data(stdin.utf8)
+        return try #require(JSONSerialization.jsonObject(with: data) as? [String: Any])
+    }
+
     private static let mrListOutput = """
     [
       {
@@ -1364,6 +1650,70 @@ struct GitLabCLIProviderTests {
         ]
       }
     ]
+    """
+
+    private static let versionsOutput = """
+    [
+      {
+        "diff_refs": {
+          "base_sha": "base123",
+          "start_sha": "start123",
+          "head_sha": "head123"
+        }
+      }
+    ]
+    """
+
+    private static let createDiscussionOutput = """
+    {
+      "id": "discussion-1",
+      "notes": [
+        {
+          "id": 501,
+          "body": "Please fix this.",
+          "system": false,
+          "web_url": "https://gitlab.example.com/platform/mobile/alas/-/merge_requests/42#note_501",
+          "author": { "username": "nacho" }
+        }
+      ]
+    }
+    """
+
+    private static let createNoteOutput = """
+    {
+      "id": 502,
+      "body": "Fixed locally.",
+      "web_url": "https://gitlab.example.com/platform/mobile/alas/-/merge_requests/42#note_502"
+    }
+    """
+
+    private static let requestChangesNoteOutput = """
+    {
+      "id": 601,
+      "body": "Please address the inline notes before merging.",
+      "web_url": "https://gitlab.example.com/platform/mobile/alas/-/merge_requests/42#note_601"
+    }
+    """
+
+    private static let resolveDiscussionOutput = """
+    {
+      "id": "discussion-1",
+      "resolved": true
+    }
+    """
+
+    private static let unresolveDiscussionOutput = """
+    {
+      "id": "discussion-1",
+      "resolved": false
+    }
+    """
+
+    private static let approveOutput = """
+    {
+      "id": 42,
+      "approved": true
+    }
     """
 
     private static let systemOnlyDiscussionsOutput = """

--- a/AlasTests/Integrations/GitLabCLIProviderTests.swift
+++ b/AlasTests/Integrations/GitLabCLIProviderTests.swift
@@ -796,11 +796,54 @@ struct GitLabCLIProviderTests {
         #expect(lineRangeStart["type"] as? String == "new")
         #expect(lineRangeStart["new_line"] as? Int == 24)
         #expect(lineRangeStart["old_line"] == nil)
-        #expect(lineRangeStart["line_code"] as? String == "\(Self.gitLabLineCodePathHash("Sources/App.swift"))_24_24")
+        #expect(lineRangeStart["line_code"] as? String == "\(Self.gitLabLineCodePathHash("Sources/App.swift"))_0_24")
         #expect(lineRangeEnd["type"] as? String == "new")
         #expect(lineRangeEnd["new_line"] as? Int == 26)
         #expect(lineRangeEnd["old_line"] == nil)
-        #expect(lineRangeEnd["line_code"] as? String == "\(Self.gitLabLineCodePathHash("Sources/App.swift"))_26_26")
+        #expect(lineRangeEnd["line_code"] as? String == "\(Self.gitLabLineCodePathHash("Sources/App.swift"))_0_26")
+    }
+
+    @Test func publishReviewUsesZeroNewLineInGitLabDeletedLineRangeCodes() async throws {
+        let runner = FakeRunner(results: [
+            ProcessResult(exitCode: 0, stdout: Self.versionsOutput, stderr: ""),
+            ProcessResult(exitCode: 0, stdout: Self.createDiscussionOutput, stderr: ""),
+            ProcessResult(exitCode: 0, stdout: Self.mrViewOutput, stderr: ""),
+            ProcessResult(exitCode: 0, stdout: Self.discussionsOutput, stderr: ""),
+            ProcessResult(exitCode: 0, stdout: Self.pipelineOutput, stderr: ""),
+        ])
+        let provider = GitLabCLIProvider(runner: runner)
+
+        _ = try await provider.publishReview(ProviderReviewPublishRequest(
+            remote: Self.remote,
+            reviewRequest: Self.makeRequest(),
+            comments: [
+                try Self.makeProviderDraftComment(
+                    localDraftID: "draft-1",
+                    path: "Sources/OldApp.swift",
+                    side: .old,
+                    lineRange: 12...14,
+                    bodyMarkdown: "This removal needs another look."
+                ),
+            ],
+            decision: .comment,
+            summaryBody: "",
+            cwd: Self.cwd
+        ))
+
+        let commands = await runner.commands
+        let discussionPayload = try Self.jsonObject(from: commands[1].stdin)
+        let position = try #require(discussionPayload["position"] as? [String: Any])
+        let lineRange = try #require(position["line_range"] as? [String: Any])
+        let lineRangeStart = try #require(lineRange["start"] as? [String: Any])
+        let lineRangeEnd = try #require(lineRange["end"] as? [String: Any])
+        #expect(lineRangeStart["type"] as? String == "old")
+        #expect(lineRangeStart["old_line"] as? Int == 12)
+        #expect(lineRangeStart["new_line"] == nil)
+        #expect(lineRangeStart["line_code"] as? String == "\(Self.gitLabLineCodePathHash("Sources/OldApp.swift"))_12_0")
+        #expect(lineRangeEnd["type"] as? String == "old")
+        #expect(lineRangeEnd["old_line"] as? Int == 14)
+        #expect(lineRangeEnd["new_line"] == nil)
+        #expect(lineRangeEnd["line_code"] as? String == "\(Self.gitLabLineCodePathHash("Sources/OldApp.swift"))_14_0")
     }
 
     @Test func publishReviewCreatesRequestChangesNoteForGitLabDecision() async throws {

--- a/AlasTests/Integrations/GitLabCLIProviderTests.swift
+++ b/AlasTests/Integrations/GitLabCLIProviderTests.swift
@@ -852,9 +852,28 @@ struct GitLabCLIProviderTests {
         #expect(lineRangeEnd["line_code"] as? String == "\(Self.gitLabLineCodePathHash("Sources/OldApp.swift"))_14_0")
     }
 
-    @Test func publishReviewCreatesRequestChangesNoteForGitLabDecision() async throws {
+    @Test func publishReviewRejectsUnsupportedGitLabRequestChangesDecision() async throws {
+        let runner = FakeRunner(results: [])
+
+        await #expect(throws: CodeHostProviderError.malformedOutput("GitLab request-changes review state is not supported yet.")) {
+            _ = try await GitLabCLIProvider(runner: runner).publishReview(ProviderReviewPublishRequest(
+                remote: Self.remote,
+                reviewRequest: Self.makeRequest(),
+                comments: [],
+                decision: .requestChanges,
+                summaryBody: "Please address the inline notes before merging.",
+                cwd: Self.cwd
+            ))
+        }
+
+        let commands = await runner.commands
+        #expect(commands.isEmpty)
+    }
+
+    @Test func publishReviewReportsUnsupportedGitLabRequestChangesAfterPublishingComments() async throws {
         let runner = FakeRunner(results: [
-            ProcessResult(exitCode: 0, stdout: Self.requestChangesNoteOutput, stderr: ""),
+            ProcessResult(exitCode: 0, stdout: Self.versionsOutput, stderr: ""),
+            ProcessResult(exitCode: 0, stdout: Self.createDiscussionOutput, stderr: ""),
             ProcessResult(exitCode: 0, stdout: Self.mrViewOutput, stderr: ""),
             ProcessResult(exitCode: 0, stdout: Self.discussionsOutput, stderr: ""),
             ProcessResult(exitCode: 0, stdout: Self.pipelineOutput, stderr: ""),
@@ -863,27 +882,15 @@ struct GitLabCLIProviderTests {
         let result = try await GitLabCLIProvider(runner: runner).publishReview(ProviderReviewPublishRequest(
             remote: Self.remote,
             reviewRequest: Self.makeRequest(),
-            comments: [],
+            comments: [try Self.makeProviderDraftComment()],
             decision: .requestChanges,
             summaryBody: "Please address the inline notes before merging.",
             cwd: Self.cwd
         ))
 
-        #expect(result.published.isEmpty)
+        #expect(result.published.map { $0.localDraftID } == ["draft-1"])
         #expect(result.failed.isEmpty)
-        let commands = await runner.commands
-        #expect(commands.first == FakeRunner.Command(
-            executable: "glab",
-            args: [
-                "api",
-                "projects/:id/merge_requests/42/notes",
-                "--method", "POST",
-                "--hostname", "gitlab.example.com",
-                "--input", "-",
-            ],
-            cwd: Self.cwd,
-            stdin: #"{"body":"Please address the inline notes before merging."}"#
-        ))
+        #expect(result.warnings.contains { $0.contains("GitLab request-changes review state is not supported yet.") })
     }
 
     @Test func publishReviewReturnsFailuresWithoutRemoteWriteForUnknownOnlyDrafts() async throws {
@@ -993,10 +1000,6 @@ struct GitLabCLIProviderTests {
             ProcessResult(exitCode: 0, stdout: Self.mrViewOutput, stderr: ""),
             ProcessResult(exitCode: 0, stdout: Self.discussionsOutput, stderr: ""),
             ProcessResult(exitCode: 0, stdout: Self.pipelineOutput, stderr: ""),
-            ProcessResult(exitCode: 0, stdout: Self.unresolveDiscussionOutput, stderr: ""),
-            ProcessResult(exitCode: 0, stdout: Self.mrViewOutput, stderr: ""),
-            ProcessResult(exitCode: 0, stdout: Self.discussionsOutput, stderr: ""),
-            ProcessResult(exitCode: 0, stdout: Self.pipelineOutput, stderr: ""),
         ])
         let thread = ReviewThreadSummary(
             id: "discussion-1",
@@ -1027,14 +1030,6 @@ struct GitLabCLIProviderTests {
             bodyMarkdown: nil,
             cwd: Self.cwd
         ))
-        _ = try await provider.mutateReviewThread(ProviderThreadMutation(
-            remote: Self.remote,
-            reviewRequest: Self.makeRequest(),
-            thread: thread,
-            kind: .unresolve,
-            bodyMarkdown: nil,
-            cwd: Self.cwd
-        ))
 
         #expect(reply.providerURL == URL(string: "https://gitlab.example.com/platform/mobile/alas/-/merge_requests/42#note_502"))
         let commands = await runner.commands
@@ -1053,7 +1048,35 @@ struct GitLabCLIProviderTests {
             "--input", "-",
         ])
         #expect(try Self.jsonObject(from: commands[4].stdin)["resolved"] as? Bool == true)
-        #expect(try Self.jsonObject(from: commands[8].stdin)["resolved"] as? Bool == false)
+    }
+
+    @Test func threadMutationRejectsUnsupportedGitLabUnresolve() async throws {
+        let runner = FakeRunner(results: [])
+        let thread = ReviewThreadSummary(
+            id: "discussion-1",
+            author: "reviewer",
+            body: "Please fix this.",
+            url: nil,
+            isResolved: true,
+            isActionable: true,
+            location: nil,
+            providerThreadID: "discussion-1",
+            providerCommentID: "501"
+        )
+
+        await #expect(throws: CodeHostProviderError.malformedOutput("GitLab unresolve is not supported until resolved discussions are loaded.")) {
+            _ = try await GitLabCLIProvider(runner: runner).mutateReviewThread(ProviderThreadMutation(
+                remote: Self.remote,
+                reviewRequest: Self.makeRequest(),
+                thread: thread,
+                kind: .unresolve,
+                bodyMarkdown: nil,
+                cwd: Self.cwd
+            ))
+        }
+
+        let commands = await runner.commands
+        #expect(commands.isEmpty)
     }
 
     @Test func threadMutationPreservesSuccessfulReplyWhenRefreshFails() async throws {
@@ -1810,25 +1833,10 @@ struct GitLabCLIProviderTests {
     }
     """
 
-    private static let requestChangesNoteOutput = """
-    {
-      "id": 601,
-      "body": "Please address the inline notes before merging.",
-      "web_url": "https://gitlab.example.com/platform/mobile/alas/-/merge_requests/42#note_601"
-    }
-    """
-
     private static let resolveDiscussionOutput = """
     {
       "id": "discussion-1",
       "resolved": true
-    }
-    """
-
-    private static let unresolveDiscussionOutput = """
-    {
-      "id": "discussion-1",
-      "resolved": false
     }
     """
 

--- a/AlasTests/Integrations/GitLabCLIProviderTests.swift
+++ b/AlasTests/Integrations/GitLabCLIProviderTests.swift
@@ -1,3 +1,4 @@
+import CryptoKit
 import Foundation
 import Testing
 @testable import Alas
@@ -749,7 +750,7 @@ struct GitLabCLIProviderTests {
                     path: "Sources/App.swift",
                     originalPath: "Sources/OldApp.swift",
                     side: .new,
-                    lineRange: 24...24,
+                    lineRange: 24...26,
                     bodyMarkdown: "Please fix this."
                 ),
             ],
@@ -787,8 +788,19 @@ struct GitLabCLIProviderTests {
         #expect(position["head_sha"] as? String == "head123")
         #expect(position["old_path"] as? String == "Sources/OldApp.swift")
         #expect(position["new_path"] as? String == "Sources/App.swift")
-        #expect(position["new_line"] as? Int == 24)
+        #expect(position["new_line"] as? Int == 26)
         #expect(position["old_line"] == nil)
+        let lineRange = try #require(position["line_range"] as? [String: Any])
+        let lineRangeStart = try #require(lineRange["start"] as? [String: Any])
+        let lineRangeEnd = try #require(lineRange["end"] as? [String: Any])
+        #expect(lineRangeStart["type"] as? String == "new")
+        #expect(lineRangeStart["new_line"] as? Int == 24)
+        #expect(lineRangeStart["old_line"] == nil)
+        #expect(lineRangeStart["line_code"] as? String == "\(Self.gitLabLineCodePathHash("Sources/App.swift"))_24_24")
+        #expect(lineRangeEnd["type"] as? String == "new")
+        #expect(lineRangeEnd["new_line"] as? Int == 26)
+        #expect(lineRangeEnd["old_line"] == nil)
+        #expect(lineRangeEnd["line_code"] as? String == "\(Self.gitLabLineCodePathHash("Sources/App.swift"))_26_26")
     }
 
     @Test func publishReviewCreatesRequestChangesNoteForGitLabDecision() async throws {
@@ -867,6 +879,33 @@ struct GitLabCLIProviderTests {
         #expect(result.published.map(\.localDraftID) == ["draft-1"])
         #expect(result.refreshedRequest == Self.makeRequest())
         #expect(result.warnings.first?.contains("could not refresh") == true)
+    }
+
+    @Test func publishReviewPreservesPublishedMappingsWhenDecisionFailsAfterDiscussionCreation() async throws {
+        let runner = FakeRunner(results: [
+            ProcessResult(exitCode: 0, stdout: Self.versionsOutput, stderr: ""),
+            ProcessResult(exitCode: 0, stdout: Self.createDiscussionOutput, stderr: ""),
+            ProcessResult(exitCode: 1, stdout: "", stderr: "approval failed"),
+            ProcessResult(exitCode: 0, stdout: Self.mrViewOutput, stderr: ""),
+            ProcessResult(exitCode: 0, stdout: Self.discussionsOutput, stderr: ""),
+            ProcessResult(exitCode: 0, stdout: Self.pipelineOutput, stderr: ""),
+        ])
+
+        let result = try await GitLabCLIProvider(runner: runner).publishReview(ProviderReviewPublishRequest(
+            remote: Self.remote,
+            reviewRequest: Self.makeRequest(),
+            comments: [try Self.makeProviderDraftComment(localDraftID: "draft-1", side: .new)],
+            decision: .approve,
+            summaryBody: "",
+            cwd: Self.cwd
+        ))
+
+        #expect(result.published.map(\.localDraftID) == ["draft-1"])
+        #expect(result.failed.isEmpty)
+        #expect(result.refreshedRequest.threads.map(\.id) == ["discussion-1", "discussion-2"])
+        #expect(result.warnings.contains {
+            $0.contains("could not submit the review decision") && $0.contains("approval failed")
+        })
     }
 
     @Test func threadMutationsUseDiscussionEndpointsAndRefreshMR() async throws {
@@ -1514,6 +1553,12 @@ struct GitLabCLIProviderTests {
         let stdin = try #require(stdin)
         let data = Data(stdin.utf8)
         return try #require(JSONSerialization.jsonObject(with: data) as? [String: Any])
+    }
+
+    private static func gitLabLineCodePathHash(_ path: String) -> String {
+        Insecure.SHA1.hash(data: Data(path.utf8))
+            .map { String(format: "%02x", $0) }
+            .joined()
     }
 
     private static let mrListOutput = """

--- a/AlasTests/Integrations/GitLabCLIProviderTests.swift
+++ b/AlasTests/Integrations/GitLabCLIProviderTests.swift
@@ -775,9 +775,9 @@ struct GitLabCLIProviderTests {
 
         let commands = await runner.commands
         #expect(commands.map { Array($0.args.prefix(2)) } == [
-            ["api", "projects/:id/merge_requests/42/versions"],
-            ["api", "projects/:id/merge_requests/42/discussions"],
-            ["api", "projects/:id/merge_requests/42/approve"],
+            ["api", "projects/platform%2Fmobile%2Falas/merge_requests/42/versions"],
+            ["api", "projects/platform%2Fmobile%2Falas/merge_requests/42/discussions"],
+            ["api", "projects/platform%2Fmobile%2Falas/merge_requests/42/approve"],
             ["mr", "view"],
             ["mr", "note"],
             ["ci", "get"],
@@ -981,8 +981,8 @@ struct GitLabCLIProviderTests {
 
         let commands = await runner.commands
         #expect(commands.map { Array($0.args.prefix(2)) } == [
-            ["api", "projects/:id/merge_requests/42/versions"],
-            ["api", "projects/:id/merge_requests/42/discussions"],
+            ["api", "projects/platform%2Fmobile%2Falas/merge_requests/42/versions"],
+            ["api", "projects/platform%2Fmobile%2Falas/merge_requests/42/discussions"],
         ])
         #expect(result.published.isEmpty)
         #expect(result.failed.map(\.localDraftID) == ["draft-1"])
@@ -1035,19 +1035,27 @@ struct GitLabCLIProviderTests {
         let commands = await runner.commands
         #expect(commands[0].args == [
             "api",
-            "projects/:id/merge_requests/42/discussions/discussion-1/notes",
+            "projects/platform%2Fmobile%2Falas/merge_requests/42/discussions/discussion-1/notes",
             "--method", "POST",
             "--hostname", "gitlab.example.com",
             "--input", "-",
         ])
         #expect(commands[4].args == [
             "api",
-            "projects/:id/merge_requests/42/discussions/discussion-1",
+            "projects/platform%2Fmobile%2Falas/merge_requests/42/discussions/discussion-1",
             "--method", "PUT",
             "--hostname", "gitlab.example.com",
             "--input", "-",
         ])
         #expect(try Self.jsonObject(from: commands[4].stdin)["resolved"] as? Bool == true)
+    }
+
+    @Test func gitLabMergeRequestAPIPathUsesSelectedRemoteProjectPath() {
+        #expect(GitLabCLIProvider.mergeRequestAPIPath(
+            remote: Self.remote,
+            request: Self.makeRequest(),
+            suffix: "discussions"
+        ) == "projects/platform%2Fmobile%2Falas/merge_requests/42/discussions")
     }
 
     @Test func threadMutationRejectsUnsupportedGitLabUnresolve() async throws {

--- a/AlasTests/Integrations/GitLabCLIProviderTests.swift
+++ b/AlasTests/Integrations/GitLabCLIProviderTests.swift
@@ -908,6 +908,32 @@ struct GitLabCLIProviderTests {
         })
     }
 
+    @Test func publishReviewDoesNotSubmitDecisionWhenAllGitLabDraftPublishesFail() async throws {
+        let runner = FakeRunner(results: [
+            ProcessResult(exitCode: 0, stdout: Self.versionsOutput, stderr: ""),
+            ProcessResult(exitCode: 1, stdout: "", stderr: "line is not commentable"),
+        ])
+
+        let result = try await GitLabCLIProvider(runner: runner).publishReview(ProviderReviewPublishRequest(
+            remote: Self.remote,
+            reviewRequest: Self.makeRequest(),
+            comments: [try Self.makeProviderDraftComment(localDraftID: "draft-1", side: .new)],
+            decision: .approve,
+            summaryBody: "Looks good.",
+            cwd: Self.cwd
+        ))
+
+        let commands = await runner.commands
+        #expect(commands.map { Array($0.args.prefix(2)) } == [
+            ["api", "projects/:id/merge_requests/42/versions"],
+            ["api", "projects/:id/merge_requests/42/discussions"],
+        ])
+        #expect(result.published.isEmpty)
+        #expect(result.failed.map(\.localDraftID) == ["draft-1"])
+        #expect(result.failed.first?.message.contains("line is not commentable") == true)
+        #expect(result.refreshedRequest == Self.makeRequest())
+    }
+
     @Test func threadMutationsUseDiscussionEndpointsAndRefreshMR() async throws {
         let runner = FakeRunner(results: [
             ProcessResult(exitCode: 0, stdout: Self.createNoteOutput, stderr: ""),

--- a/AlasTests/Integrations/GitLabCLIProviderTests.swift
+++ b/AlasTests/Integrations/GitLabCLIProviderTests.swift
@@ -852,6 +852,54 @@ struct GitLabCLIProviderTests {
         #expect(lineRangeEnd["line_code"] as? String == "\(Self.gitLabLineCodePathHash("Sources/OldApp.swift"))_14_0")
     }
 
+    @Test func publishReviewSelectsGitLabDiffRefsForReviewedHeadSHA() async throws {
+        let runner = FakeRunner(results: [
+            ProcessResult(exitCode: 0, stdout: Self.versionsWithMultipleHeadsOutput, stderr: ""),
+            ProcessResult(exitCode: 0, stdout: Self.createDiscussionOutput, stderr: ""),
+            ProcessResult(exitCode: 0, stdout: Self.mrViewOutput, stderr: ""),
+            ProcessResult(exitCode: 0, stdout: Self.discussionsOutput, stderr: ""),
+            ProcessResult(exitCode: 0, stdout: Self.pipelineOutput, stderr: ""),
+        ])
+
+        _ = try await GitLabCLIProvider(runner: runner).publishReview(ProviderReviewPublishRequest(
+            remote: Self.remote,
+            reviewRequest: Self.makeRequest(headSHA: "reviewed-head"),
+            comments: [try Self.makeProviderDraftComment()],
+            decision: .comment,
+            summaryBody: "",
+            cwd: Self.cwd
+        ))
+
+        let commands = await runner.commands
+        let discussionPayload = try Self.jsonObject(from: commands[1].stdin)
+        let position = try #require(discussionPayload["position"] as? [String: Any])
+        #expect(position["base_sha"] as? String == "reviewed-base")
+        #expect(position["start_sha"] as? String == "reviewed-start")
+        #expect(position["head_sha"] as? String == "reviewed-head")
+    }
+
+    @Test func publishReviewRejectsGitLabDiffRefsWithoutReviewedHeadSHA() async throws {
+        let runner = FakeRunner(results: [
+            ProcessResult(exitCode: 0, stdout: Self.versionsWithMultipleHeadsOutput, stderr: ""),
+        ])
+
+        await #expect(throws: CodeHostProviderError.malformedOutput("Unable to find GitLab diff refs for reviewed head SHA.")) {
+            _ = try await GitLabCLIProvider(runner: runner).publishReview(ProviderReviewPublishRequest(
+                remote: Self.remote,
+                reviewRequest: Self.makeRequest(headSHA: "missing-head"),
+                comments: [try Self.makeProviderDraftComment()],
+                decision: .comment,
+                summaryBody: "",
+                cwd: Self.cwd
+            ))
+        }
+
+        let commands = await runner.commands
+        #expect(commands.map { Array($0.args.prefix(2)) } == [
+            ["api", "projects/platform%2Fmobile%2Falas/merge_requests/42/versions"],
+        ])
+    }
+
     @Test func publishReviewCreatesStatusNoteForGitLabRequestChanges() async throws {
         let runner = FakeRunner(results: [
             ProcessResult(exitCode: 0, stdout: Self.versionsOutput, stderr: ""),
@@ -1704,6 +1752,7 @@ struct GitLabCLIProviderTests {
     private static let cwd = URL(fileURLWithPath: "/tmp/alas")
 
     private static func makeRequest(
+        headSHA: String = "head123",
         checks: [ReviewCheck] = [],
         threads: [ReviewThreadSummary] = []
     ) -> ReviewRequest {
@@ -1716,7 +1765,7 @@ struct GitLabCLIProviderTests {
             isDraft: false,
             headRefName: "feature/gitlab-provider",
             baseRefName: "main",
-            headSHA: "head123",
+            headSHA: headSHA,
             reviewDecision: .unknown,
             mergeState: .unknown,
             checks: checks,
@@ -1913,6 +1962,21 @@ struct GitLabCLIProviderTests {
         "base_commit_sha": "base123",
         "start_commit_sha": "start123",
         "head_commit_sha": "head123"
+      }
+    ]
+    """
+
+    private static let versionsWithMultipleHeadsOutput = """
+    [
+      {
+        "base_commit_sha": "latest-base",
+        "start_commit_sha": "latest-start",
+        "head_commit_sha": "latest-head"
+      },
+      {
+        "base_commit_sha": "reviewed-base",
+        "start_commit_sha": "reviewed-start",
+        "head_commit_sha": "reviewed-head"
       }
     ]
     """

--- a/AlasTests/Integrations/GitLabCLIProviderTests.swift
+++ b/AlasTests/Integrations/GitLabCLIProviderTests.swift
@@ -1538,6 +1538,14 @@ struct GitLabCLIProviderTests {
             let executable: String
             let args: [String]
             let cwd: URL?
+            let stdin: String?
+
+            init(executable: String, args: [String], cwd: URL?, stdin: String? = nil) {
+                self.executable = executable
+                self.args = args
+                self.cwd = cwd
+                self.stdin = stdin
+            }
         }
 
         private var results: [ProcessResult]
@@ -1547,8 +1555,8 @@ struct GitLabCLIProviderTests {
             self.results = results
         }
 
-        func run(_ executable: String, args: [String], cwd: URL?) async throws -> ProcessResult {
-            commands.append(Command(executable: executable, args: args, cwd: cwd))
+        func run(_ executable: String, args: [String], cwd: URL?, stdin: String?) async throws -> ProcessResult {
+            commands.append(Command(executable: executable, args: args, cwd: cwd, stdin: stdin))
             guard !results.isEmpty else {
                 return ProcessResult(exitCode: 1, stdout: "", stderr: "unexpected command")
             }

--- a/AlasTests/Integrations/ProviderReviewActionsTests.swift
+++ b/AlasTests/Integrations/ProviderReviewActionsTests.swift
@@ -89,7 +89,7 @@ struct ProviderReviewActionsTests {
         #expect(CodeHostProviderCapabilities.gitlabCLI.canResolveReviewThreads)
         #expect(!CodeHostProviderCapabilities.gitlabCLI.canUnresolveReviewThreads)
         #expect(CodeHostProviderCapabilities.gitlabCLI.canApproveReview)
-        #expect(!CodeHostProviderCapabilities.gitlabCLI.canRequestChanges)
+        #expect(CodeHostProviderCapabilities.gitlabCLI.canRequestChanges)
 
         #expect(!CodeHostProviderCapabilities.readOnly.canPublishReviewComments)
         #expect(!CodeHostProviderCapabilities.readOnly.canReplyToReviewThreads)

--- a/AlasTests/Integrations/ProviderReviewActionsTests.swift
+++ b/AlasTests/Integrations/ProviderReviewActionsTests.swift
@@ -87,9 +87,9 @@ struct ProviderReviewActionsTests {
         #expect(CodeHostProviderCapabilities.gitlabCLI.canPublishReviewComments)
         #expect(CodeHostProviderCapabilities.gitlabCLI.canReplyToReviewThreads)
         #expect(CodeHostProviderCapabilities.gitlabCLI.canResolveReviewThreads)
-        #expect(CodeHostProviderCapabilities.gitlabCLI.canUnresolveReviewThreads)
+        #expect(!CodeHostProviderCapabilities.gitlabCLI.canUnresolveReviewThreads)
         #expect(CodeHostProviderCapabilities.gitlabCLI.canApproveReview)
-        #expect(CodeHostProviderCapabilities.gitlabCLI.canRequestChanges)
+        #expect(!CodeHostProviderCapabilities.gitlabCLI.canRequestChanges)
 
         #expect(!CodeHostProviderCapabilities.readOnly.canPublishReviewComments)
         #expect(!CodeHostProviderCapabilities.readOnly.canReplyToReviewThreads)

--- a/AlasTests/Integrations/ProviderReviewActionsTests.swift
+++ b/AlasTests/Integrations/ProviderReviewActionsTests.swift
@@ -1,0 +1,101 @@
+import Foundation
+import Testing
+@testable import Alas
+
+struct ProviderReviewActionsTests {
+    @Test func providerDraftCommentBuildsFromActiveLocalDraft() throws {
+        let session = ReviewDraftSessionID.reviewRequest(
+            worktreeID: "wt",
+            provider: .github,
+            host: "github.com",
+            repositorySlug: "mrmans0n/alas",
+            number: 527
+        )
+        let draft = ReviewDraftComment(
+            id: "draft-1",
+            sessionID: session,
+            fileID: DiffReviewFileID(namespace: "github", path: "Sources/App.swift"),
+            path: "Sources/App.swift",
+            originalPath: nil,
+            side: .new,
+            startLine: 12,
+            endLine: 14,
+            selectedText: "let value = 1",
+            bodyMarkdown: "Please simplify this.",
+            state: .active,
+            createdAt: Date(timeIntervalSince1970: 10),
+            updatedAt: Date(timeIntervalSince1970: 11)
+        )
+
+        let providerDraft = try #require(ProviderReviewDraftComment(localDraft: draft))
+
+        #expect(providerDraft.localDraftID == "draft-1")
+        #expect(providerDraft.path == "Sources/App.swift")
+        #expect(providerDraft.originalPath == nil)
+        #expect(providerDraft.side == .new)
+        #expect(providerDraft.lineRange == 12...14)
+        #expect(providerDraft.selectedText == "let value = 1")
+        #expect(providerDraft.bodyMarkdown == "Please simplify this.")
+    }
+
+    @Test func providerDraftCommentRejectsNonActiveOrPublishedDrafts() {
+        var draft = ReviewDraftComment(
+            id: "draft-1",
+            sessionID: .reviewRequest(
+                worktreeID: "wt",
+                provider: .github,
+                host: "github.com",
+                repositorySlug: "mrmans0n/alas",
+                number: 527
+            ),
+            fileID: DiffReviewFileID(namespace: "github", path: "Sources/App.swift"),
+            path: "Sources/App.swift",
+            originalPath: nil,
+            side: .new,
+            startLine: 12,
+            endLine: nil,
+            selectedText: nil,
+            bodyMarkdown: "Comment",
+            state: .resolved,
+            createdAt: Date(timeIntervalSince1970: 10),
+            updatedAt: Date(timeIntervalSince1970: 11)
+        )
+        #expect(ProviderReviewDraftComment(localDraft: draft) == nil)
+
+        draft.state = .active
+        draft.providerPublish = ReviewDraftProviderPublish(
+            provider: .github,
+            host: "github.com",
+            repositorySlug: "mrmans0n/alas",
+            reviewNumber: 527,
+            threadID: "thread-1",
+            commentID: "comment-1",
+            url: URL(string: "https://github.com/mrmans0n/alas/pull/527#discussion_r1"),
+            publishedAt: Date(timeIntervalSince1970: 20)
+        )
+        #expect(ProviderReviewDraftComment(localDraft: draft) == nil)
+    }
+
+    @Test func providerCapabilitiesExposeWriteActions() {
+        #expect(CodeHostProviderCapabilities.githubCLI.canPublishReviewComments)
+        #expect(CodeHostProviderCapabilities.githubCLI.canReplyToReviewThreads)
+        #expect(CodeHostProviderCapabilities.githubCLI.canResolveReviewThreads)
+        #expect(CodeHostProviderCapabilities.githubCLI.canUnresolveReviewThreads)
+        #expect(CodeHostProviderCapabilities.githubCLI.canApproveReview)
+        #expect(CodeHostProviderCapabilities.githubCLI.canRequestChanges)
+
+        #expect(CodeHostProviderCapabilities.gitlabCLI.canPublishReviewComments)
+        #expect(CodeHostProviderCapabilities.gitlabCLI.canReplyToReviewThreads)
+        #expect(CodeHostProviderCapabilities.gitlabCLI.canResolveReviewThreads)
+        #expect(CodeHostProviderCapabilities.gitlabCLI.canUnresolveReviewThreads)
+        #expect(CodeHostProviderCapabilities.gitlabCLI.canApproveReview)
+        #expect(CodeHostProviderCapabilities.gitlabCLI.canRequestChanges)
+
+        #expect(!CodeHostProviderCapabilities.readOnly.canPublishReviewComments)
+        #expect(!CodeHostProviderCapabilities.readOnly.canReplyToReviewThreads)
+        #expect(!CodeHostProviderCapabilities.readOnly.canResolveReviewThreads)
+        #expect(!CodeHostProviderCapabilities.readOnly.canUnresolveReviewThreads)
+        #expect(!CodeHostProviderCapabilities.readOnly.canApproveReview)
+        #expect(!CodeHostProviderCapabilities.readOnly.canRequestChanges)
+    }
+}

--- a/AlasTests/ReviewDraftCommentStoreTests.swift
+++ b/AlasTests/ReviewDraftCommentStoreTests.swift
@@ -106,6 +106,134 @@ struct ReviewDraftCommentStoreTests {
         #expect(try store.load(sessionID: session).isEmpty)
     }
 
+    @Test @MainActor func controllerMarksDraftPublishedAndRecordsProviderErrors() throws {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        let url = directory.appendingPathComponent("review-draft-comments.json")
+        let store = ReviewDraftCommentStore(store: PersistenceStore(), url: url)
+        let session = ReviewDraftSessionID.reviewRequest(
+            worktreeID: "wt",
+            provider: .github,
+            host: "github.com",
+            repositorySlug: "mrmans0n/alas",
+            number: 527
+        )
+        var now = Date(timeIntervalSince1970: 100)
+        let controller = ReviewDraftCommentController(
+            sessionID: session,
+            store: store,
+            now: { now }
+        )
+        var comment = makeComment(
+            id: "draft-1",
+            session: session,
+            startLine: 4,
+            endLine: nil,
+            createdAt: Date(timeIntervalSince1970: 10)
+        )
+        comment.providerError = ReviewDraftProviderError(
+            provider: .github,
+            message: "old error",
+            occurredAt: Date(timeIntervalSince1970: 20)
+        )
+        let resolved = makeComment(
+            id: "resolved",
+            session: session,
+            startLine: 8,
+            endLine: nil,
+            createdAt: Date(timeIntervalSince1970: 11),
+            state: .resolved
+        )
+        try store.save(comment)
+        try store.save(resolved)
+        try controller.load()
+        controller.errorMessage = "previous"
+        #expect(controller.activeUnpublishedComments.map(\.id) == ["draft-1"])
+
+        let publish = ReviewDraftProviderPublish(
+            provider: .github,
+            host: "github.com",
+            repositorySlug: "mrmans0n/alas",
+            reviewNumber: 527,
+            threadID: "thread-1",
+            commentID: "comment-1",
+            url: URL(string: "https://github.com/mrmans0n/alas/pull/527#discussion_r1"),
+            publishedAt: Date(timeIntervalSince1970: 30)
+        )
+        now = Date(timeIntervalSince1970: 101)
+        try controller.markPublished(commentID: "draft-1", publish: publish)
+
+        let published = try #require(controller.comments.first { $0.id == "draft-1" })
+        #expect(published.providerPublish == publish)
+        #expect(published.providerError == nil)
+        #expect(published.updatedAt == Date(timeIntervalSince1970: 101))
+        #expect(controller.activeUnpublishedComments.isEmpty)
+        #expect(controller.errorMessage == nil)
+        #expect(try store.load(sessionID: session).first { $0.id == "draft-1" }?.providerPublish == publish)
+
+        let error = ReviewDraftProviderError(
+            provider: .github,
+            message: "line is outdated",
+            occurredAt: Date(timeIntervalSince1970: 40)
+        )
+        now = Date(timeIntervalSince1970: 102)
+        try controller.recordProviderError(commentID: "draft-1", error: error)
+
+        let failed = try #require(controller.comments.first { $0.id == "draft-1" })
+        #expect(failed.providerPublish == publish)
+        #expect(failed.providerError == error)
+        #expect(failed.updatedAt == Date(timeIntervalSince1970: 102))
+        #expect(controller.errorMessage == nil)
+        #expect(try store.load(sessionID: session).first { $0.id == "draft-1" }?.providerError == error)
+
+        try controller.markPublished(commentID: "missing", publish: publish)
+        try controller.recordProviderError(commentID: "missing", error: error)
+        #expect(controller.comments.count == 2)
+    }
+
+    @Test func publishedMetadataSurvivesStoreRoundTrip() throws {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        let url = directory.appendingPathComponent("review-draft-comments.json")
+        let store = ReviewDraftCommentStore(store: PersistenceStore(), url: url)
+        let session = ReviewDraftSessionID.reviewRequest(
+            worktreeID: "wt",
+            provider: .github,
+            host: "github.com",
+            repositorySlug: "mrmans0n/alas",
+            number: 527
+        )
+        var published = makeComment(
+            id: "published",
+            session: session,
+            startLine: 12,
+            endLine: nil,
+            createdAt: Date(timeIntervalSince1970: 10)
+        )
+        published.providerPublish = ReviewDraftProviderPublish(
+            provider: .github,
+            host: "github.com",
+            repositorySlug: "mrmans0n/alas",
+            reviewNumber: 527,
+            threadID: "thread-1",
+            commentID: "comment-1",
+            url: URL(string: "https://github.com/mrmans0n/alas/pull/527#discussion_r1"),
+            publishedAt: Date(timeIntervalSince1970: 30)
+        )
+        published.providerError = ReviewDraftProviderError(
+            provider: .github,
+            message: "line is outdated",
+            occurredAt: Date(timeIntervalSince1970: 40)
+        )
+
+        try store.save(published)
+
+        let reloaded = try #require(store.load(sessionID: session).single)
+        #expect(reloaded == published)
+        #expect(reloaded.providerPublish == published.providerPublish)
+        #expect(reloaded.providerError == published.providerError)
+    }
+
     @Test func brokenStoreFileReturnsEmptySessions() throws {
         let directory = FileManager.default.temporaryDirectory
             .appendingPathComponent(UUID().uuidString, isDirectory: true)
@@ -150,7 +278,8 @@ struct ReviewDraftCommentStoreTests {
         session: ReviewDraftSessionID,
         startLine: Int,
         endLine: Int?,
-        createdAt: Date
+        createdAt: Date,
+        state: ReviewDraftCommentState = .active
     ) -> ReviewDraftComment {
         ReviewDraftComment(
             id: id,
@@ -163,7 +292,7 @@ struct ReviewDraftCommentStoreTests {
             endLine: endLine,
             selectedText: nil,
             bodyMarkdown: "Comment \(id)",
-            state: .active,
+            state: state,
             createdAt: createdAt,
             updatedAt: createdAt
         )

--- a/AlasTests/ReviewDraftCommentStoreTests.swift
+++ b/AlasTests/ReviewDraftCommentStoreTests.swift
@@ -65,6 +65,44 @@ struct ReviewDraftCommentStoreTests {
         #expect(controller.errorMessage == nil)
     }
 
+    @Test @MainActor func controllerPersistsOriginalPathForRenamedFileDrafts() throws {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        let url = directory.appendingPathComponent("review-draft-comments.json")
+        let store = ReviewDraftCommentStore(store: PersistenceStore(), url: url)
+        let session = ReviewDraftSessionID.reviewRequest(
+            worktreeID: "wt",
+            provider: .gitlab,
+            host: "gitlab.example.com",
+            repositorySlug: "platform/mobile/alas",
+            number: 42
+        )
+        let controller = ReviewDraftCommentController(
+            sessionID: session,
+            store: store,
+            now: { Date(timeIntervalSince1970: 100) }
+        )
+        let anchor = DiffReviewLineAnchor(
+            path: "Sources/NewApp.swift",
+            side: .old,
+            line: 12,
+            rowIndex: 0,
+            selectedText: "oldValue"
+        )
+        let fileID = DiffReviewFileID(namespace: "gitlab-mr", path: "Sources/NewApp.swift")
+
+        try controller.load()
+        try controller.add(
+            anchor: anchor,
+            fileID: fileID,
+            originalPath: "Sources/OldApp.swift",
+            bodyMarkdown: "Please revisit this removal."
+        )
+
+        #expect(controller.comments.single?.originalPath == "Sources/OldApp.swift")
+        #expect(try store.load(sessionID: session).single?.originalPath == "Sources/OldApp.swift")
+    }
+
     @Test func savesLoadsAndDeletesCommentsBySession() throws {
         let directory = FileManager.default.temporaryDirectory
             .appendingPathComponent(UUID().uuidString, isDirectory: true)

--- a/AlasTests/ReviewDraftModelsTests.swift
+++ b/AlasTests/ReviewDraftModelsTests.swift
@@ -64,4 +64,77 @@ struct ReviewDraftModelsTests {
         #expect(comment.normalizedLineRange == 3...8)
         #expect(comment.isActive)
     }
+
+    @Test func draftCommentDecodesLegacyJSONWithoutProviderFields() throws {
+        let json = """
+        {
+          "id": "legacy",
+          "sessionID": "local-changes\\u001fwt\\u001f/repo\\u001fall",
+          "fileID": {
+            "namespace": "unstaged",
+            "path": "Sources/App.swift"
+          },
+          "path": "Sources/App.swift",
+          "originalPath": null,
+          "side": "new",
+          "startLine": 8,
+          "endLine": null,
+          "selectedText": "let value = 1",
+          "bodyMarkdown": "Please extract this.",
+          "state": "active",
+          "createdAt": 1,
+          "updatedAt": 2
+        }
+        """.data(using: .utf8)!
+
+        let comment = try JSONDecoder().decode(ReviewDraftComment.self, from: json)
+
+        #expect(comment.id == "legacy")
+        #expect(comment.providerPublish == nil)
+        #expect(comment.providerError == nil)
+    }
+
+    @Test func draftCommentRoundTripsProviderPublishAndErrorMetadata() throws {
+        let comment = ReviewDraftComment(
+            id: "published",
+            sessionID: .reviewRequest(
+                worktreeID: "wt",
+                provider: .github,
+                host: "github.com",
+                repositorySlug: "mrmans0n/alas",
+                number: 527
+            ),
+            fileID: DiffReviewFileID(namespace: "github", path: "Sources/App.swift"),
+            path: "Sources/App.swift",
+            originalPath: nil,
+            side: .new,
+            startLine: 8,
+            endLine: nil,
+            selectedText: "let value = 1",
+            bodyMarkdown: "Please extract this.",
+            state: .active,
+            createdAt: Date(timeIntervalSince1970: 1),
+            updatedAt: Date(timeIntervalSince1970: 2),
+            providerPublish: ReviewDraftProviderPublish(
+                provider: .github,
+                host: "github.com",
+                repositorySlug: "mrmans0n/alas",
+                reviewNumber: 527,
+                threadID: "thread-1",
+                commentID: "comment-1",
+                url: URL(string: "https://github.com/mrmans0n/alas/pull/527#discussion_r1"),
+                publishedAt: Date(timeIntervalSince1970: 3)
+            ),
+            providerError: ReviewDraftProviderError(
+                provider: .github,
+                message: "line is outdated",
+                occurredAt: Date(timeIntervalSince1970: 4)
+            )
+        )
+
+        let data = try JSONEncoder().encode(comment)
+        let decoded = try JSONDecoder().decode(ReviewDraftComment.self, from: data)
+
+        #expect(decoded == comment)
+    }
 }

--- a/AlasTests/ReviewSessionLoaderTests.swift
+++ b/AlasTests/ReviewSessionLoaderTests.swift
@@ -165,6 +165,8 @@ struct ReviewSessionLoaderTests {
 
         #expect(loaded.providerContext?.remote.repositorySlug == "mrmans0n/alas")
         #expect(loaded.providerContext?.reviewRequest.number == 428)
+        #expect(loaded.providerContext?.reviewRequest.title == "Provider refreshed title")
+        #expect(loaded.providerContext?.reviewRequest.threads.map(\.id) == ["thread-1"])
         #expect(loaded.session.summary.files.map(\.path) == [summary.path])
         #expect(loaded.session.summary.files.map(\.namespace) == [summary.namespace])
     }
@@ -263,6 +265,34 @@ struct ReviewSessionLoaderTests {
             cwd: URL
         ) async throws -> ReviewRequest? {
             nil
+        }
+        func reviewRequest(remote: CodeHostRemote, number: Int, cwd: URL) async throws -> ReviewRequest {
+            ReviewRequest(
+                remote: remote,
+                number: number,
+                title: "Provider refreshed title",
+                url: URL(string: "https://github.com/mrmans0n/alas/pull/\(number)")!,
+                state: .open,
+                isDraft: false,
+                headRefName: "feature/provider-review",
+                baseRefName: "main",
+                reviewDecision: .unknown,
+                mergeState: .clean,
+                checks: [],
+                threads: [
+                    ReviewThreadSummary(
+                        id: "thread-1",
+                        author: "reviewer",
+                        body: "Please adjust this.",
+                        url: URL(string: "https://github.com/mrmans0n/alas/pull/\(number)#discussion_r1"),
+                        isResolved: false,
+                        isActionable: true,
+                        location: ReviewThreadLocation(path: "Sources/App.swift", originalPath: nil, line: 1, side: .new, providerPosition: nil),
+                        providerThreadID: "thread-provider-1",
+                        providerCommentID: "comment-provider-1"
+                    ),
+                ]
+            )
         }
         func createReviewRequest(
             remote: CodeHostRemote,

--- a/AlasTests/ReviewSessionLoaderTests.swift
+++ b/AlasTests/ReviewSessionLoaderTests.swift
@@ -107,7 +107,7 @@ struct ReviewSessionLoaderTests {
     }
 
     @MainActor
-    @Test func productionLoaderRejectsStoredProviderReviewRequestWithoutSnapshotData() async throws {
+    @Test func productionLoaderLoadsProviderReviewRequestWithProviderContext() async throws {
         let repo = FileManager.default.temporaryDirectory
             .appendingPathComponent("alas-review-session-loader-\(UUID().uuidString)")
         try FileManager.default.createDirectory(at: repo, withIntermediateDirectories: true)
@@ -134,17 +134,39 @@ struct ReviewSessionLoaderTests {
             title: "Review loop",
             headSHA: "abc123"
         )
+        let summary = DiffReviewFileSummary(
+            path: "Sources/App.swift",
+            namespace: "github-pr",
+            groupID: nil,
+            groupTitle: nil,
+            status: .modified,
+            additions: 1,
+            deletions: 0,
+            isRenderable: true
+        )
+        let provider = FakeReviewRequestProvider(
+            diff: """
+            diff --git a/Sources/App.swift b/Sources/App.swift
+            index 1111111..2222222 100644
+            --- a/Sources/App.swift
+            +++ b/Sources/App.swift
+            @@ -1 +1 @@
+            -let old = true
+            +let new = true
+            """
+        )
         let loader = ReviewSessionLoader.production(
             appState: AppState(store: MemoryStore()),
-            worktree: worktree
+            worktree: worktree,
+            providerRegistry: CodeHostProviderRegistry(providers: [.github: provider])
         )
 
-        do {
-            _ = try await loader.load(target: target)
-            Issue.record("Expected stored provider review request to be unsupported without snapshot data")
-        } catch let error as ReviewSessionLoaderError {
-            #expect(error == .unsupportedTarget)
-        }
+        let loaded = try await loader.load(target: target)
+
+        #expect(loaded.providerContext?.remote.repositorySlug == "mrmans0n/alas")
+        #expect(loaded.providerContext?.reviewRequest.number == 428)
+        #expect(loaded.session.summary.files.map(\.path) == [summary.path])
+        #expect(loaded.session.summary.files.map(\.namespace) == [summary.namespace])
     }
 
     @MainActor
@@ -225,5 +247,61 @@ struct ReviewSessionLoaderTests {
         func readIfExists<T: Decodable>(_ type: T.Type, from url: URL) throws -> T? {
             nil
         }
+    }
+
+    private struct FakeReviewRequestProvider: CodeHostProvider {
+        let kind: CodeHostKind = .github
+        let diff: String
+
+        func isAvailable() async -> Bool { true }
+        func isAuthenticated(remote: CodeHostRemote, cwd: URL) async -> Bool { true }
+        func currentReviewRequest(
+            remote: CodeHostRemote,
+            branch: String,
+            headOwner: String?,
+            baseBranch: String,
+            cwd: URL
+        ) async throws -> ReviewRequest? {
+            nil
+        }
+        func createReviewRequest(
+            remote: CodeHostRemote,
+            branch: String,
+            headOwner: String?,
+            baseBranch: String,
+            title: String,
+            body: String,
+            isDraft: Bool,
+            cwd: URL
+        ) async throws -> URL {
+            remote.webURL
+        }
+        func checks(remote: CodeHostRemote, request: ReviewRequest, cwd: URL) async throws -> [ReviewCheck] { [] }
+        func reviewDiff(remote: CodeHostRemote, request: ReviewRequest, cwd: URL) async throws -> String { diff }
+        func failedCheckEvidence(remote: CodeHostRemote, request: ReviewRequest, cwd: URL) async throws -> [ReviewEvidenceItem] { [] }
+        func checkEvidenceDetail(
+            remote: CodeHostRemote,
+            request: ReviewRequest,
+            item: ReviewEvidenceItem,
+            cwd: URL
+        ) async throws -> ReviewEvidenceDetail {
+            throw CodeHostProviderError.malformedOutput("FakeReviewRequestProvider does not provide check evidence details.")
+        }
+        func feedbackEvidence(remote: CodeHostRemote, request: ReviewRequest, cwd: URL) async throws -> [ReviewEvidenceItem] { [] }
+        func feedbackEvidenceDetail(
+            remote: CodeHostRemote,
+            request: ReviewRequest,
+            item: ReviewEvidenceItem,
+            cwd: URL
+        ) async throws -> ReviewEvidenceDetail {
+            throw CodeHostProviderError.malformedOutput("FakeReviewRequestProvider does not provide feedback evidence details.")
+        }
+        func rerunFailedChecks(
+            remote: CodeHostRemote,
+            branch: String,
+            headSHA: String,
+            request: ReviewRequest?,
+            cwd: URL
+        ) async throws {}
     }
 }

--- a/AlasTests/ReviewSessionTabViewTests.swift
+++ b/AlasTests/ReviewSessionTabViewTests.swift
@@ -835,6 +835,49 @@ struct ReviewSessionTabViewTests {
         #expect(subview(withAccessibilityIdentifier: "provider-review-publish-confirm", in: host) != nil)
     }
 
+    @Test func reviewSessionShowsProviderFeedbackOpenAndCopyActions() throws {
+        let thread = ReviewThreadSummary(
+            id: "thread-1",
+            author: "reviewer",
+            body: "Please fix this.",
+            url: URL(string: "https://github.com/mrmans0n/alas/pull/527#discussion_r1"),
+            isResolved: false,
+            isActionable: true,
+            location: ReviewThreadLocation(path: "Sources/App.swift", originalPath: nil, line: 2, side: .new, providerPosition: nil),
+            providerThreadID: "thread-provider-1",
+            providerCommentID: "comment-provider-1"
+        )
+        let request = Self.reviewRequest(provider: .github, threads: [thread])
+        let target = Self.reviewRequestTarget(provider: .github, request: request)
+        let record = ReviewSessionRecord(
+            id: target.id,
+            target: target,
+            createdAt: Date(timeIntervalSince1970: 1),
+            updatedAt: Date(timeIntervalSince1970: 1)
+        )
+        let loaded = Self.loadedReviewRequestContext(provider: .github, request: request)
+        let view = ReviewSessionTabView.testView(
+            record: record,
+            loaded: loaded,
+            provider: RecordingProviderReviewMutator(
+                kind: .github,
+                publishResult: ProviderReviewPublishResult(
+                    published: [],
+                    failed: [],
+                    refreshedRequest: request,
+                    warnings: []
+                )
+            )
+        )
+        .environment(\.theme, try ThemeStore().current)
+
+        let host = NSHostingView(rootView: view.frame(width: 1200, height: 720))
+        host.layoutSubtreeIfNeeded()
+
+        #expect(subview(withAccessibilityIdentifier: "diff-review-inline-feedback-action-open-thread-1", in: host) != nil)
+        #expect(subview(withAccessibilityIdentifier: "diff-review-inline-feedback-action-copy-thread-1", in: host) != nil)
+    }
+
     private func recursiveDescription(_ view: NSView) -> String {
         ([view.accessibilityLabel(), view.accessibilityIdentifier()] + view.subviews.map(recursiveDescription))
             .compactMap { $0 }
@@ -903,7 +946,7 @@ struct ReviewSessionTabViewTests {
         )
     }
 
-    private static func reviewRequest(provider: CodeHostKind) -> ReviewRequest {
+    private static func reviewRequest(provider: CodeHostKind, threads: [ReviewThreadSummary] = []) -> ReviewRequest {
         let remote = Self.remote(kind: provider)
         return ReviewRequest(
             remote: remote,
@@ -917,7 +960,7 @@ struct ReviewSessionTabViewTests {
             reviewDecision: .unknown,
             mergeState: .unknown,
             checks: [],
-            threads: []
+            threads: threads
         )
     }
 
@@ -983,7 +1026,8 @@ struct ReviewSessionTabViewTests {
                         parsedDiff: parsedDiff(),
                         displayModel: displayModel(),
                         placeholderMessage: nil,
-                        openFile: nil
+                        openFile: nil,
+                        contextProvider: nil
                     ),
                 ],
                 summary: DiffReviewSessionModel(files: [summary], groupsEnabled: false)

--- a/AlasTests/ReviewSessionTabViewTests.swift
+++ b/AlasTests/ReviewSessionTabViewTests.swift
@@ -914,6 +914,62 @@ struct ReviewSessionTabViewTests {
         #expect(provider.publishRequests().map(\.decision) == [.approve])
     }
 
+    @Test func reviewSessionShowsProviderPublishWarningsAfterSuccessfulPublish() async throws {
+        let request = Self.reviewRequest(provider: .github)
+        let target = Self.reviewRequestTarget(provider: .github, request: request)
+        let record = ReviewSessionRecord(
+            id: target.id,
+            target: target,
+            createdAt: Date(timeIntervalSince1970: 1),
+            updatedAt: Date(timeIntervalSince1970: 1)
+        )
+        let loaded = Self.loadedReviewRequestContext(provider: .github, request: request)
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("alas-review-session-provider-warning-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let draftStore = ReviewDraftCommentStore(
+            store: PersistenceStore(),
+            url: directory.appendingPathComponent("drafts.json")
+        )
+        let provider = RecordingProviderReviewMutator(
+            kind: .github,
+            publishResult: ProviderReviewPublishResult(
+                published: [],
+                failed: [],
+                refreshedRequest: request,
+                warnings: ["Provider comments were published, but the approval was not submitted."]
+            )
+        )
+        let view = ReviewSessionTabView.testView(
+            record: record,
+            loaded: loaded,
+            draftCommentStore: draftStore,
+            provider: provider
+        )
+        .environment(\.theme, try ThemeStore().current)
+
+        let host = NSHostingView(rootView: view.frame(width: 1200, height: 720))
+        host.layoutSubtreeIfNeeded()
+
+        #expect(pressAccessibilityElement(withAccessibilityIdentifier: "review-draft-summary-publish-review", in: host))
+        RunLoop.current.run(until: Date().addingTimeInterval(0.05))
+        host.layoutSubtreeIfNeeded()
+        #expect(pressAccessibilityElement(withAccessibilityIdentifier: "provider-review-publish-confirm", in: host))
+
+        let deadline = Date().addingTimeInterval(1)
+        while subview(withAccessibilityIdentifier: "review-session-provider-error", in: host) == nil, Date() < deadline {
+            try await Task.sleep(nanoseconds: 10_000_000)
+            RunLoop.current.run(until: Date().addingTimeInterval(0.01))
+            host.layoutSubtreeIfNeeded()
+        }
+
+        let description = recursiveDescription(host)
+        #expect(subview(withAccessibilityIdentifier: "provider-review-publish-confirmation", in: host) == nil)
+        #expect(subview(withAccessibilityIdentifier: "review-session-provider-error", in: host) != nil)
+        #expect(description.contains("approval was not submitted"))
+    }
+
     @Test func reviewSessionShowsProviderFeedbackOpenAndCopyActions() throws {
         let thread = ReviewThreadSummary(
             id: "thread-1",

--- a/AlasTests/ReviewSessionTabViewTests.swift
+++ b/AlasTests/ReviewSessionTabViewTests.swift
@@ -1069,6 +1069,58 @@ struct ReviewSessionTabViewTests {
         #expect(subview(withAccessibilityIdentifier: "diff-review-inline-feedback-action-copy-thread-1", in: host) != nil)
     }
 
+    @Test func reviewSessionKeepsNonActionableProviderFeedbackReadOnly() throws {
+        let thread = ReviewThreadSummary(
+            id: "thread-1",
+            author: "reviewer",
+            body: "This outdated comment should remain visible.",
+            url: URL(string: "https://github.com/mrmans0n/alas/pull/527#discussion_r1"),
+            isResolved: false,
+            isActionable: false,
+            location: ReviewThreadLocation(path: "Sources/App.swift", originalPath: nil, line: 2, side: .new, providerPosition: nil),
+            providerThreadID: "thread-provider-1",
+            providerCommentID: "comment-provider-1"
+        )
+        let request = Self.reviewRequest(provider: .github, threads: [thread])
+        let target = Self.reviewRequestTarget(provider: .github, request: request)
+        let record = ReviewSessionRecord(
+            id: target.id,
+            target: target,
+            createdAt: Date(timeIntervalSince1970: 1),
+            updatedAt: Date(timeIntervalSince1970: 1)
+        )
+        let loaded = Self.loadedReviewRequestContext(provider: .github, request: request)
+        let view = ReviewSessionTabView.testView(
+            record: record,
+            loaded: loaded,
+            provider: RecordingProviderReviewMutator(
+                kind: .github,
+                publishResult: ProviderReviewPublishResult(
+                    published: [],
+                    failed: [],
+                    refreshedRequest: request,
+                    warnings: []
+                )
+            )
+        )
+        .environment(\.theme, try ThemeStore().current)
+
+        let feedback = try #require(ReviewSessionTabView.inlineFeedbackByFileID(
+            threads: [thread],
+            files: [Self.summary(path: "Sources/App.swift", namespace: "github")],
+            providerName: "GitHub"
+        )[DiffReviewFileID(namespace: "github", path: "Sources/App.swift")]?.first)
+        #expect(feedback.status == .unknown)
+
+        let host = NSHostingView(rootView: view.frame(width: 1200, height: 720))
+        host.layoutSubtreeIfNeeded()
+
+        #expect(subview(withAccessibilityIdentifier: "diff-review-inline-feedback-action-open-thread-1", in: host) != nil)
+        #expect(subview(withAccessibilityIdentifier: "diff-review-inline-feedback-action-copy-thread-1", in: host) != nil)
+        #expect(subview(withAccessibilityIdentifier: "diff-review-inline-feedback-action-reply-thread-1", in: host) == nil)
+        #expect(subview(withAccessibilityIdentifier: "diff-review-inline-feedback-action-resolve-thread-1", in: host) == nil)
+    }
+
     @Test func reviewSessionShowsProviderThreadMutationFailureOutsidePublishSheet() async throws {
         let thread = ReviewThreadSummary(
             id: "thread-1",

--- a/AlasTests/ReviewSessionTabViewTests.swift
+++ b/AlasTests/ReviewSessionTabViewTests.swift
@@ -454,6 +454,107 @@ struct ReviewSessionTabViewTests {
         #expect(provider.publishRequests().isEmpty)
     }
 
+    @Test func providerMutationControllerRejectsEmptyCommentReviewWithoutPublishing() async throws {
+        let sessionID = ReviewDraftSessionID.reviewRequest(
+            worktreeID: "wt",
+            provider: .github,
+            host: "github.com",
+            repositorySlug: "mrmans0n/alas",
+            number: 527
+        )
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("alas-provider-empty-comment-review-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: directory) }
+
+        let draftController = ReviewDraftCommentController(
+            sessionID: sessionID,
+            store: ReviewDraftCommentStore(
+                store: PersistenceStore(),
+                url: directory.appendingPathComponent("drafts.json")
+            )
+        )
+        try draftController.load()
+        let request = Self.reviewRequest(provider: .github)
+        let provider = RecordingProviderReviewMutator(
+            kind: .github,
+            publishResult: ProviderReviewPublishResult(
+                published: [],
+                failed: [],
+                refreshedRequest: request,
+                warnings: []
+            )
+        )
+        let controller = ProviderReviewMutationController(
+            provider: provider,
+            draftController: draftController
+        )
+
+        do {
+            _ = try await controller.publishReview(
+                remote: request.remote,
+                reviewRequest: request,
+                decision: .comment,
+                summaryBody: "Review from Alas",
+                cwd: URL(fileURLWithPath: "/repo")
+            )
+            Issue.record("Expected empty comment review publish to throw")
+        } catch let error as ProviderReviewMutationControllerError {
+            #expect(error == .noPublishableDraftsForCommentReview)
+        }
+
+        #expect(provider.publishRequests().isEmpty)
+    }
+
+    @Test func providerMutationControllerAllowsDecisionOnlyApproveWithoutDrafts() async throws {
+        let sessionID = ReviewDraftSessionID.reviewRequest(
+            worktreeID: "wt",
+            provider: .github,
+            host: "github.com",
+            repositorySlug: "mrmans0n/alas",
+            number: 527
+        )
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("alas-provider-decision-only-review-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: directory) }
+
+        let draftController = ReviewDraftCommentController(
+            sessionID: sessionID,
+            store: ReviewDraftCommentStore(
+                store: PersistenceStore(),
+                url: directory.appendingPathComponent("drafts.json")
+            )
+        )
+        try draftController.load()
+        let request = Self.reviewRequest(provider: .github)
+        let provider = RecordingProviderReviewMutator(
+            kind: .github,
+            publishResult: ProviderReviewPublishResult(
+                published: [],
+                failed: [],
+                refreshedRequest: request,
+                warnings: []
+            )
+        )
+        let controller = ProviderReviewMutationController(
+            provider: provider,
+            draftController: draftController
+        )
+
+        _ = try await controller.publishReview(
+            remote: request.remote,
+            reviewRequest: request,
+            decision: .approve,
+            summaryBody: "Looks good.",
+            cwd: URL(fileURLWithPath: "/repo")
+        )
+
+        let publishedRequest = try #require(provider.publishRequests().first)
+        #expect(publishedRequest.comments.isEmpty)
+        #expect(publishedRequest.decision == .approve)
+    }
+
     @Test func providerMutationControllerKeepsFailedDraftsActiveWithError() async throws {
         let sessionID = ReviewDraftSessionID.reviewRequest(
             worktreeID: "wt",

--- a/AlasTests/ReviewSessionTabViewTests.swift
+++ b/AlasTests/ReviewSessionTabViewTests.swift
@@ -957,6 +957,62 @@ struct ReviewSessionTabViewTests {
         #expect(subview(withAccessibilityIdentifier: "diff-review-inline-feedback-action-copy-thread-1", in: host) != nil)
     }
 
+    @Test func reviewSessionShowsProviderThreadMutationFailureOutsidePublishSheet() async throws {
+        let thread = ReviewThreadSummary(
+            id: "thread-1",
+            author: "reviewer",
+            body: "Please fix this.",
+            url: URL(string: "https://github.com/mrmans0n/alas/pull/527#discussion_r1"),
+            isResolved: false,
+            isActionable: true,
+            location: ReviewThreadLocation(path: "Sources/App.swift", originalPath: nil, line: 2, side: .new, providerPosition: nil),
+            providerThreadID: "thread-provider-1",
+            providerCommentID: "comment-provider-1"
+        )
+        let request = Self.reviewRequest(provider: .github, threads: [thread])
+        let target = Self.reviewRequestTarget(provider: .github, request: request)
+        let record = ReviewSessionRecord(
+            id: target.id,
+            target: target,
+            createdAt: Date(timeIntervalSince1970: 1),
+            updatedAt: Date(timeIntervalSince1970: 1)
+        )
+        let loaded = Self.loadedReviewRequestContext(provider: .github, request: request)
+        let view = ReviewSessionTabView.testView(
+            record: record,
+            loaded: loaded,
+            provider: RecordingProviderReviewMutator(
+                kind: .github,
+                publishResult: ProviderReviewPublishResult(
+                    published: [],
+                    failed: [],
+                    refreshedRequest: request,
+                    warnings: []
+                ),
+                mutationError: CodeHostProviderError.malformedOutput("resolve failed")
+            )
+        )
+        .environment(\.theme, try ThemeStore().current)
+
+        let host = NSHostingView(rootView: view.frame(width: 1200, height: 720))
+        host.layoutSubtreeIfNeeded()
+
+        #expect(subview(withAccessibilityIdentifier: "provider-review-publish-confirmation", in: host) == nil)
+        #expect(pressAccessibilityElement(withAccessibilityIdentifier: "diff-review-inline-feedback-action-resolve-thread-1", in: host))
+
+        let deadline = Date().addingTimeInterval(1)
+        while subview(withAccessibilityIdentifier: "review-session-provider-error", in: host) == nil, Date() < deadline {
+            try await Task.sleep(nanoseconds: 10_000_000)
+            RunLoop.current.run(until: Date().addingTimeInterval(0.01))
+            host.layoutSubtreeIfNeeded()
+        }
+
+        let description = recursiveDescription(host)
+        #expect(subview(withAccessibilityIdentifier: "provider-review-publish-confirmation", in: host) == nil)
+        #expect(subview(withAccessibilityIdentifier: "review-session-provider-error", in: host) != nil)
+        #expect(description.contains("resolve failed"))
+    }
+
     private func recursiveDescription(_ view: NSView) -> String {
         ([view.accessibilityLabel(), view.accessibilityIdentifier()] + view.subviews.map(recursiveDescription))
             .compactMap { $0 }
@@ -1206,17 +1262,20 @@ struct ReviewSessionTabViewTests {
         let kind: CodeHostKind
         let capabilities: CodeHostProviderCapabilities
         private let publishResult: ProviderReviewPublishResult
+        private let mutationError: Error?
         private let lock = NSLock()
         private var recordedPublishRequests: [ProviderReviewPublishRequest] = []
 
         init(
             kind: CodeHostKind,
             capabilities: CodeHostProviderCapabilities = .githubCLI,
-            publishResult: ProviderReviewPublishResult
+            publishResult: ProviderReviewPublishResult,
+            mutationError: Error? = nil
         ) {
             self.kind = kind
             self.capabilities = capabilities
             self.publishResult = publishResult
+            self.mutationError = mutationError
         }
 
         func publishRequests() -> [ProviderReviewPublishRequest] {
@@ -1282,7 +1341,10 @@ struct ReviewSessionTabViewTests {
             return publishResult
         }
         func mutateReviewThread(_ mutation: ProviderThreadMutation) async throws -> ProviderThreadMutationResult {
-            ProviderThreadMutationResult(
+            if let mutationError {
+                throw mutationError
+            }
+            return ProviderThreadMutationResult(
                 refreshedRequest: publishResult.refreshedRequest,
                 providerURL: publishResult.refreshedRequest.url
             )

--- a/AlasTests/ReviewSessionTabViewTests.swift
+++ b/AlasTests/ReviewSessionTabViewTests.swift
@@ -725,6 +725,7 @@ struct ReviewSessionTabViewTests {
 
     @Test func providerPublishConfirmationListsProviderDecisionAndCommentCount() throws {
         var selectedDecision = ProviderReviewDecision.comment
+        var summaryBody = ""
         let view = ProviderReviewPublishConfirmationView(
             providerName: "GitHub",
             reviewIdentity: "PR #527",
@@ -732,6 +733,7 @@ struct ReviewSessionTabViewTests {
             unpublishableMessages: ["Sources/Old.swift: line is outdated"],
             allowedDecisions: [.comment, .approve, .requestChanges],
             selectedDecision: Binding(get: { selectedDecision }, set: { selectedDecision = $0 }),
+            summaryBody: Binding(get: { summaryBody }, set: { summaryBody = $0 }),
             isPublishing: false,
             errorMessage: nil,
             onCancel: {},
@@ -752,6 +754,7 @@ struct ReviewSessionTabViewTests {
 
     @Test func providerPublishConfirmationDisablesCommentDecisionWithNoComments() throws {
         var selectedDecision = ProviderReviewDecision.comment
+        var summaryBody = ""
         var didConfirm = false
         let view = ProviderReviewPublishConfirmationView(
             providerName: "GitHub",
@@ -760,6 +763,7 @@ struct ReviewSessionTabViewTests {
             unpublishableMessages: ["Sources/App.swift: already published to GitHub."],
             allowedDecisions: [.comment, .approve, .requestChanges],
             selectedDecision: Binding(get: { selectedDecision }, set: { selectedDecision = $0 }),
+            summaryBody: Binding(get: { summaryBody }, set: { summaryBody = $0 }),
             isPublishing: false,
             errorMessage: nil,
             onCancel: {},
@@ -774,8 +778,59 @@ struct ReviewSessionTabViewTests {
         #expect(!didConfirm)
     }
 
+    @Test func providerPublishConfirmationRequiresSummaryForRequestChanges() throws {
+        var selectedDecision = ProviderReviewDecision.requestChanges
+        var emptySummaryBody = ""
+        var emptyDidConfirm = false
+        let emptyView = ProviderReviewPublishConfirmationView(
+            providerName: "GitHub",
+            reviewIdentity: "PR #527",
+            commentCount: 2,
+            unpublishableMessages: [],
+            allowedDecisions: [.comment, .approve, .requestChanges],
+            selectedDecision: Binding(get: { selectedDecision }, set: { selectedDecision = $0 }),
+            summaryBody: Binding(get: { emptySummaryBody }, set: { emptySummaryBody = $0 }),
+            isPublishing: false,
+            errorMessage: nil,
+            onCancel: {},
+            onConfirm: { emptyDidConfirm = true }
+        )
+        .environment(\.theme, try ThemeStore().current)
+
+        let emptyHost = NSHostingView(rootView: emptyView.frame(width: 420, height: 360))
+        emptyHost.layoutSubtreeIfNeeded()
+
+        #expect(subview(withAccessibilityIdentifier: "provider-review-publish-summary", in: emptyHost) != nil)
+        #expect(!pressAccessibilityElement(withAccessibilityIdentifier: "provider-review-publish-confirm", in: emptyHost))
+        #expect(!emptyDidConfirm)
+
+        var filledSummaryBody = "Please address the inline notes before merging."
+        var filledDidConfirm = false
+        let filledView = ProviderReviewPublishConfirmationView(
+            providerName: "GitHub",
+            reviewIdentity: "PR #527",
+            commentCount: 2,
+            unpublishableMessages: [],
+            allowedDecisions: [.comment, .approve, .requestChanges],
+            selectedDecision: Binding(get: { selectedDecision }, set: { selectedDecision = $0 }),
+            summaryBody: Binding(get: { filledSummaryBody }, set: { filledSummaryBody = $0 }),
+            isPublishing: false,
+            errorMessage: nil,
+            onCancel: {},
+            onConfirm: { filledDidConfirm = true }
+        )
+        .environment(\.theme, try ThemeStore().current)
+
+        let filledHost = NSHostingView(rootView: filledView.frame(width: 420, height: 360))
+        filledHost.layoutSubtreeIfNeeded()
+
+        #expect(pressAccessibilityElement(withAccessibilityIdentifier: "provider-review-publish-confirm", in: filledHost))
+        #expect(filledDidConfirm)
+    }
+
     @Test func providerPublishConfirmationHidesUnsupportedReviewDecisions() throws {
         var selectedDecision = ProviderReviewDecision.comment
+        var summaryBody = ""
         let view = ProviderReviewPublishConfirmationView(
             providerName: "GitLab",
             reviewIdentity: "MR !42",
@@ -783,6 +838,7 @@ struct ReviewSessionTabViewTests {
             unpublishableMessages: [],
             allowedDecisions: [.comment, .approve],
             selectedDecision: Binding(get: { selectedDecision }, set: { selectedDecision = $0 }),
+            summaryBody: Binding(get: { summaryBody }, set: { summaryBody = $0 }),
             isPublishing: false,
             errorMessage: nil,
             onCancel: {},

--- a/AlasTests/ReviewSessionTabViewTests.swift
+++ b/AlasTests/ReviewSessionTabViewTests.swift
@@ -465,6 +465,32 @@ struct ReviewSessionTabViewTests {
         ) == nil)
     }
 
+    @Test func providerPublishConfirmationListsProviderDecisionAndCommentCount() throws {
+        var selectedDecision = ProviderReviewDecision.comment
+        let view = ProviderReviewPublishConfirmationView(
+            providerName: "GitHub",
+            reviewIdentity: "PR #527",
+            commentCount: 2,
+            unpublishableMessages: ["Sources/Old.swift: line is outdated"],
+            selectedDecision: Binding(get: { selectedDecision }, set: { selectedDecision = $0 }),
+            isPublishing: false,
+            errorMessage: nil,
+            onCancel: {},
+            onConfirm: {}
+        )
+        .environment(\.theme, try ThemeStore().current)
+
+        let host = NSHostingView(rootView: view.frame(width: 420, height: 260))
+        host.layoutSubtreeIfNeeded()
+        let description = recursiveDescription(host)
+
+        #expect(description.contains("GitHub"))
+        #expect(description.contains("PR #527"))
+        #expect(description.contains("2 comments"))
+        #expect(description.contains("line is outdated"))
+        #expect(subview(withAccessibilityIdentifier: "provider-review-publish-confirmation", in: host) != nil)
+    }
+
     private func recursiveDescription(_ view: NSView) -> String {
         ([view.accessibilityLabel(), view.accessibilityIdentifier()] + view.subviews.map(recursiveDescription))
             .compactMap { $0 }

--- a/AlasTests/ReviewSessionTabViewTests.swift
+++ b/AlasTests/ReviewSessionTabViewTests.swift
@@ -373,6 +373,59 @@ struct ReviewSessionTabViewTests {
         #expect(publishedRequest.comments.map(\.localDraftID) == [selected.id])
     }
 
+    @Test func providerMutationControllerRejectsStaleSelectedDraftWithoutPublishing() async throws {
+        let sessionID = ReviewDraftSessionID.reviewRequest(
+            worktreeID: "wt",
+            provider: .github,
+            host: "github.com",
+            repositorySlug: "mrmans0n/alas",
+            number: 527
+        )
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("alas-provider-stale-selected-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: directory) }
+
+        let draftController = ReviewDraftCommentController(
+            sessionID: sessionID,
+            store: ReviewDraftCommentStore(
+                store: PersistenceStore(),
+                url: directory.appendingPathComponent("drafts.json")
+            )
+        )
+        try draftController.load()
+        let request = Self.reviewRequest(provider: .github)
+        let provider = RecordingProviderReviewMutator(
+            kind: .github,
+            publishResult: ProviderReviewPublishResult(
+                published: [],
+                failed: [],
+                refreshedRequest: request,
+                warnings: []
+            )
+        )
+        let controller = ProviderReviewMutationController(
+            provider: provider,
+            draftController: draftController
+        )
+
+        do {
+            _ = try await controller.publishReview(
+                remote: request.remote,
+                reviewRequest: request,
+                decision: .comment,
+                summaryBody: "Review from Alas",
+                cwd: URL(fileURLWithPath: "/repo"),
+                localDraftIDs: ["missing-draft"]
+            )
+            Issue.record("Expected stale selected draft publish to throw")
+        } catch let error as ProviderReviewMutationControllerError {
+            #expect(error == .noPublishableSelectedDrafts)
+        }
+
+        #expect(provider.publishRequests().isEmpty)
+    }
+
     @Test func providerMutationControllerKeepsFailedDraftsActiveWithError() async throws {
         let sessionID = ReviewDraftSessionID.reviewRequest(
             worktreeID: "wt",

--- a/AlasTests/ReviewSessionTabViewTests.swift
+++ b/AlasTests/ReviewSessionTabViewTests.swift
@@ -730,6 +730,7 @@ struct ReviewSessionTabViewTests {
             reviewIdentity: "PR #527",
             commentCount: 2,
             unpublishableMessages: ["Sources/Old.swift: line is outdated"],
+            allowedDecisions: [.comment, .approve, .requestChanges],
             selectedDecision: Binding(get: { selectedDecision }, set: { selectedDecision = $0 }),
             isPublishing: false,
             errorMessage: nil,
@@ -757,6 +758,7 @@ struct ReviewSessionTabViewTests {
             reviewIdentity: "PR #527",
             commentCount: 0,
             unpublishableMessages: ["Sources/App.swift: already published to GitHub."],
+            allowedDecisions: [.comment, .approve, .requestChanges],
             selectedDecision: Binding(get: { selectedDecision }, set: { selectedDecision = $0 }),
             isPublishing: false,
             errorMessage: nil,
@@ -770,6 +772,31 @@ struct ReviewSessionTabViewTests {
 
         #expect(!pressAccessibilityElement(withAccessibilityIdentifier: "provider-review-publish-confirm", in: host))
         #expect(!didConfirm)
+    }
+
+    @Test func providerPublishConfirmationHidesUnsupportedReviewDecisions() throws {
+        var selectedDecision = ProviderReviewDecision.comment
+        let view = ProviderReviewPublishConfirmationView(
+            providerName: "GitLab",
+            reviewIdentity: "MR !42",
+            commentCount: 1,
+            unpublishableMessages: [],
+            allowedDecisions: [.comment, .approve],
+            selectedDecision: Binding(get: { selectedDecision }, set: { selectedDecision = $0 }),
+            isPublishing: false,
+            errorMessage: nil,
+            onCancel: {},
+            onConfirm: {}
+        )
+        .environment(\.theme, try ThemeStore().current)
+
+        let host = NSHostingView(rootView: view.frame(width: 420, height: 260))
+        host.layoutSubtreeIfNeeded()
+        let description = recursiveDescription(host)
+
+        #expect(description.contains("Comment"))
+        #expect(description.contains("Approve"))
+        #expect(!description.contains("Request changes"))
     }
 
     @Test func reviewSessionShowsPublishReviewForProviderContextWithDraftsAndOpensPublishConfirmation() async throws {

--- a/AlasTests/ReviewSessionTabViewTests.swift
+++ b/AlasTests/ReviewSessionTabViewTests.swift
@@ -34,7 +34,8 @@ struct ReviewSessionTabViewTests {
                 repositoryPath: "/repo",
                 providerDescription: nil,
                 sourceDescription: target.sourceDescription
-            )
+            ),
+            providerContext: nil
         )
 
         let publication = ReviewSessionTabLoadPublication.initial(record: record, loaded: loaded)
@@ -104,7 +105,8 @@ struct ReviewSessionTabViewTests {
                 repositoryPath: "/repo",
                 providerDescription: nil,
                 sourceDescription: target.sourceDescription
-            )
+            ),
+            providerContext: nil
         )
         let view = ReviewSessionTabView.preview(record: record, loaded: loaded)
             .environment(\.theme, try ThemeStore().current)
@@ -149,7 +151,8 @@ struct ReviewSessionTabViewTests {
                 repositoryPath: "/repo",
                 providerDescription: nil,
                 sourceDescription: target.sourceDescription
-            )
+            ),
+            providerContext: nil
         )
         let view = ReviewSessionTabView.preview(record: record, loaded: loaded)
             .environment(\.theme, try ThemeStore().current)
@@ -207,7 +210,8 @@ struct ReviewSessionTabViewTests {
                 repositoryPath: "/repo",
                 providerDescription: nil,
                 sourceDescription: target.sourceDescription
-            )
+            ),
+            providerContext: nil
         )
         let view = ReviewSessionTabView.preview(record: try #require(updated), loaded: loaded)
             .environment(\.theme, try ThemeStore().current)
@@ -216,6 +220,249 @@ struct ReviewSessionTabViewTests {
         host.layoutSubtreeIfNeeded()
 
         #expect(recursiveDescription(host).contains("Sent to agent, but failed to save handoff record: save failed"))
+    }
+
+    @Test func providerMutationControllerPublishesDraftsAndMarksResults() async throws {
+        let sessionID = ReviewDraftSessionID.reviewRequest(
+            worktreeID: "wt",
+            provider: .github,
+            host: "github.com",
+            repositorySlug: "mrmans0n/alas",
+            number: 527
+        )
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("alas-provider-mutation-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: directory) }
+
+        let store = ReviewDraftCommentStore(
+            store: PersistenceStore(),
+            url: directory.appendingPathComponent("drafts.json")
+        )
+        let draftController = ReviewDraftCommentController(
+            sessionID: sessionID,
+            store: store,
+            now: { Date(timeIntervalSince1970: 200) }
+        )
+        try draftController.load()
+        try draftController.add(
+            anchor: DiffReviewLineAnchor(
+                path: "Sources/App.swift",
+                side: .new,
+                line: 12,
+                rowIndex: 0,
+                selectedText: "let value = 1"
+            ),
+            fileID: DiffReviewFileID(namespace: "github", path: "Sources/App.swift"),
+            bodyMarkdown: "Please fix this."
+        )
+        let added = try #require(draftController.comments.first)
+        let request = Self.reviewRequest(provider: .github)
+        let provider = FakeProviderReviewMutator(
+            kind: .github,
+            result: ProviderReviewPublishResult(
+                published: [
+                    ProviderReviewPublishedComment(
+                        localDraftID: added.id,
+                        providerThreadID: "thread-1",
+                        providerCommentID: "comment-1",
+                        providerURL: URL(string: "https://github.com/mrmans0n/alas/pull/527#discussion_r1")
+                    ),
+                ],
+                failed: [],
+                refreshedRequest: request,
+                warnings: []
+            )
+        )
+        let controller = ProviderReviewMutationController(
+            provider: provider,
+            draftController: draftController,
+            now: { Date(timeIntervalSince1970: 300) }
+        )
+
+        let outcome = try await controller.publishReview(
+            remote: request.remote,
+            reviewRequest: request,
+            decision: .comment,
+            summaryBody: "Review from Alas",
+            cwd: URL(fileURLWithPath: "/repo")
+        )
+
+        #expect(outcome.refreshedRequest.number == 527)
+        let updated = try #require(draftController.comments.first)
+        #expect(updated.providerPublish?.threadID == "thread-1")
+        #expect(updated.providerPublish?.commentID == "comment-1")
+        #expect(updated.providerPublish?.publishedAt == Date(timeIntervalSince1970: 300))
+        #expect(updated.providerPublish?.provider == .github)
+        #expect(updated.providerError == nil)
+    }
+
+    @Test func providerMutationControllerKeepsFailedDraftsActiveWithError() async throws {
+        let sessionID = ReviewDraftSessionID.reviewRequest(
+            worktreeID: "wt",
+            provider: .gitlab,
+            host: "gitlab.example.com",
+            repositorySlug: "platform/alas",
+            number: 42
+        )
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("alas-provider-mutation-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: directory) }
+
+        let store = ReviewDraftCommentStore(
+            store: PersistenceStore(),
+            url: directory.appendingPathComponent("drafts.json")
+        )
+        let draftController = ReviewDraftCommentController(
+            sessionID: sessionID,
+            store: store,
+            now: { Date(timeIntervalSince1970: 200) }
+        )
+        try draftController.load()
+        try draftController.add(
+            anchor: DiffReviewLineAnchor(
+                path: "Sources/App.swift",
+                side: .new,
+                line: 12,
+                rowIndex: 0,
+                selectedText: ""
+            ),
+            fileID: DiffReviewFileID(namespace: "gitlab", path: "Sources/App.swift"),
+            bodyMarkdown: "Please fix this."
+        )
+        let added = try #require(draftController.comments.first)
+        let request = Self.reviewRequest(provider: .gitlab)
+        let provider = FakeProviderReviewMutator(
+            kind: .gitlab,
+            result: ProviderReviewPublishResult(
+                published: [],
+                failed: [
+                    ProviderReviewFailedComment(
+                        localDraftID: added.id,
+                        message: "line is not commentable"
+                    ),
+                ],
+                refreshedRequest: request,
+                warnings: []
+            )
+        )
+        let controller = ProviderReviewMutationController(
+            provider: provider,
+            draftController: draftController,
+            now: { Date(timeIntervalSince1970: 300) }
+        )
+
+        _ = try await controller.publishReview(
+            remote: request.remote,
+            reviewRequest: request,
+            decision: .comment,
+            summaryBody: "Review from Alas",
+            cwd: URL(fileURLWithPath: "/repo")
+        )
+
+        let updated = try #require(draftController.comments.first)
+        #expect(updated.providerPublish == nil)
+        #expect(updated.providerError?.message == "line is not commentable")
+        #expect(updated.providerError?.provider == .gitlab)
+        #expect(updated.providerError?.occurredAt == Date(timeIntervalSince1970: 300))
+        #expect(updated.state == .active)
+    }
+
+    @Test func reviewSessionLoadedContextCarriesProviderContextForProviderSessions() async throws {
+        let request = Self.reviewRequest(provider: .github)
+        let target = ReviewSessionTarget.reviewRequest(
+            worktreeID: "wt-1",
+            repositoryPath: URL(fileURLWithPath: "/repo"),
+            provider: .github,
+            host: "github.com",
+            repositorySlug: "mrmans0n/alas",
+            number: request.number,
+            url: request.url,
+            title: request.title,
+            headSHA: "abc123"
+        )
+        let providerLoaded = ReviewSessionProviderLoadedSession(
+            loadedSession: DiffReviewLoadedSession(files: [], summary: DiffReviewSessionModel(files: [], groupsEnabled: false)),
+            providerContext: ReviewSessionProviderContext(remote: request.remote, reviewRequest: request)
+        )
+        let loader = ReviewSessionLoader(reviewRequest: { target in
+            #expect(target.kind == .reviewRequest)
+            return providerLoaded
+        })
+
+        let loaded = try await loader.load(target: target)
+
+        #expect(loaded.providerContext?.remote == request.remote)
+        #expect(loaded.providerContext?.reviewRequest == request)
+    }
+
+    @Test func providerMutationControllerFactoryRequiresLoadedProviderContext() throws {
+        let request = Self.reviewRequest(provider: .github)
+        let session = DiffReviewLoadedSession(files: [], summary: DiffReviewSessionModel(files: [], groupsEnabled: false))
+        let providerLoaded = ReviewSessionLoadedContext(
+            session: session,
+            feedbackTarget: ReviewFeedbackTarget(
+                title: "Review provider writes",
+                repositoryPath: "/repo",
+                providerDescription: "GitHub mrmans0n/alas #527",
+                sourceDescription: "PR #527"
+            ),
+            providerContext: ReviewSessionProviderContext(remote: request.remote, reviewRequest: request)
+        )
+        let localLoaded = ReviewSessionLoadedContext(
+            session: session,
+            feedbackTarget: ReviewFeedbackTarget(
+                title: "Review all changes",
+                repositoryPath: "/repo",
+                providerDescription: nil,
+                sourceDescription: "Local changes: all"
+            ),
+            providerContext: nil
+        )
+        let draftController = ReviewDraftCommentController(
+            sessionID: .reviewRequest(
+                worktreeID: "wt",
+                provider: .github,
+                host: "github.com",
+                repositorySlug: "mrmans0n/alas",
+                number: 527
+            ),
+            store: ReviewDraftCommentStore(
+                store: PersistenceStore(),
+                url: FileManager.default.temporaryDirectory
+                    .appendingPathComponent("alas-provider-mutation-\(UUID().uuidString).json")
+            )
+        )
+        let provider = FakeProviderReviewMutator(
+            kind: .github,
+            result: ProviderReviewPublishResult(
+                published: [],
+                failed: [],
+                refreshedRequest: request,
+                warnings: []
+            )
+        )
+        let registry = CodeHostProviderRegistry(providers: [.github: provider])
+
+        #expect(ReviewSessionTabView.makeProviderMutationController(
+            loaded: providerLoaded,
+            draftCommentController: draftController,
+            providerRegistry: registry,
+            now: Date.init
+        ) != nil)
+        #expect(ReviewSessionTabView.makeProviderMutationController(
+            loaded: localLoaded,
+            draftCommentController: draftController,
+            providerRegistry: registry,
+            now: Date.init
+        ) == nil)
+        #expect(ReviewSessionTabView.makeProviderMutationController(
+            loaded: providerLoaded,
+            draftCommentController: nil,
+            providerRegistry: registry,
+            now: Date.init
+        ) == nil)
     }
 
     private func recursiveDescription(_ view: NSView) -> String {
@@ -253,6 +500,102 @@ struct ReviewSessionTabViewTests {
             openFile: nil,
             contextProvider: nil
         )
+    }
+
+    private static func remote(kind: CodeHostKind = .github) -> CodeHostRemote {
+        let host = kind == .github ? "github.com" : "gitlab.example.com"
+        let owner = kind == .github ? "mrmans0n" : "platform"
+        return CodeHostRemote(
+            kind: kind,
+            host: host,
+            owner: owner,
+            repository: "alas",
+            remoteName: "origin",
+            webURL: URL(string: "https://\(host)/\(owner)/alas")!
+        )
+    }
+
+    private static func reviewRequest(provider: CodeHostKind) -> ReviewRequest {
+        let remote = Self.remote(kind: provider)
+        return ReviewRequest(
+            remote: remote,
+            number: provider == .github ? 527 : 42,
+            title: "Review provider writes",
+            url: remote.webURL.appendingPathComponent(provider == .github ? "pull/527" : "merge_requests/42"),
+            state: .open,
+            isDraft: false,
+            headRefName: "feature/provider-writes",
+            baseRefName: "main",
+            reviewDecision: .unknown,
+            mergeState: .unknown,
+            checks: [],
+            threads: []
+        )
+    }
+
+    private struct FakeProviderReviewMutator: CodeHostProvider {
+        let kind: CodeHostKind
+        let result: ProviderReviewPublishResult
+
+        func isAvailable() async -> Bool { true }
+        func isAuthenticated(remote: CodeHostRemote, cwd: URL) async -> Bool { true }
+        func currentReviewRequest(
+            remote: CodeHostRemote,
+            branch: String,
+            headOwner: String?,
+            baseBranch: String,
+            cwd: URL
+        ) async throws -> ReviewRequest? {
+            result.refreshedRequest
+        }
+        func createReviewRequest(
+            remote: CodeHostRemote,
+            branch: String,
+            headOwner: String?,
+            baseBranch: String,
+            title: String,
+            body: String,
+            isDraft: Bool,
+            cwd: URL
+        ) async throws -> URL {
+            result.refreshedRequest.url
+        }
+        func checks(remote: CodeHostRemote, request: ReviewRequest, cwd: URL) async throws -> [ReviewCheck] { [] }
+        func reviewDiff(remote: CodeHostRemote, request: ReviewRequest, cwd: URL) async throws -> String { "" }
+        func failedCheckEvidence(remote: CodeHostRemote, request: ReviewRequest, cwd: URL) async throws -> [ReviewEvidenceItem] { [] }
+        func checkEvidenceDetail(
+            remote: CodeHostRemote,
+            request: ReviewRequest,
+            item: ReviewEvidenceItem,
+            cwd: URL
+        ) async throws -> ReviewEvidenceDetail {
+            throw CodeHostProviderError.malformedOutput("FakeProviderReviewMutator does not provide check evidence details.")
+        }
+        func feedbackEvidence(remote: CodeHostRemote, request: ReviewRequest, cwd: URL) async throws -> [ReviewEvidenceItem] { [] }
+        func feedbackEvidenceDetail(
+            remote: CodeHostRemote,
+            request: ReviewRequest,
+            item: ReviewEvidenceItem,
+            cwd: URL
+        ) async throws -> ReviewEvidenceDetail {
+            throw CodeHostProviderError.malformedOutput("FakeProviderReviewMutator does not provide feedback evidence details.")
+        }
+        func rerunFailedChecks(
+            remote: CodeHostRemote,
+            branch: String,
+            headSHA: String,
+            request: ReviewRequest?,
+            cwd: URL
+        ) async throws {}
+        func publishReview(_ request: ProviderReviewPublishRequest) async throws -> ProviderReviewPublishResult {
+            result
+        }
+        func mutateReviewThread(_ mutation: ProviderThreadMutation) async throws -> ProviderThreadMutationResult {
+            ProviderThreadMutationResult(
+                refreshedRequest: result.refreshedRequest,
+                providerURL: result.refreshedRequest.url
+            )
+        }
     }
 
     private struct TestPersistenceError: LocalizedError {

--- a/AlasTests/ReviewSessionTabViewTests.swift
+++ b/AlasTests/ReviewSessionTabViewTests.swift
@@ -5,6 +5,7 @@ import Testing
 @testable import Alas
 
 @MainActor
+@Suite(.serialized)
 struct ReviewSessionTabViewTests {
     @Test func initialLoadPublicationDoesNotRequestPersistenceForRestoredSelection() {
         let selected = DiffReviewFileID(namespace: "unstaged", path: "A.swift")
@@ -491,6 +492,69 @@ struct ReviewSessionTabViewTests {
         #expect(subview(withAccessibilityIdentifier: "provider-review-publish-confirmation", in: host) != nil)
     }
 
+    @Test func reviewSessionShowsPublishReviewForProviderContextWithDraftsAndOpensPublishConfirmation() async throws {
+        let request = Self.reviewRequest(provider: .github)
+        let target = Self.reviewRequestTarget(provider: .github, request: request)
+        let record = ReviewSessionRecord(
+            id: target.id,
+            target: target,
+            createdAt: Date(timeIntervalSince1970: 1),
+            updatedAt: Date(timeIntervalSince1970: 1)
+        )
+        let loaded = Self.loadedReviewRequestContext(provider: .github, request: request)
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("alas-review-session-publish-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let draftStore = ReviewDraftCommentStore(
+            store: PersistenceStore(),
+            url: directory.appendingPathComponent("drafts.json")
+        )
+        let draftController = ReviewDraftCommentController(
+            sessionID: target.draftSessionID,
+            store: draftStore,
+            now: { Date(timeIntervalSince1970: 10) }
+        )
+        try draftController.load()
+        try draftController.add(
+            anchor: DiffReviewLineAnchor(
+                path: "Sources/App.swift",
+                side: .new,
+                line: 2,
+                rowIndex: 0,
+                selectedText: "let b = 3"
+            ),
+            fileID: loaded.session.files[0].id,
+            bodyMarkdown: "Please fix this."
+        )
+        let provider = RecordingProviderReviewMutator(
+            kind: .github,
+            publishResult: ProviderReviewPublishResult(
+                published: [],
+                failed: [],
+                refreshedRequest: request,
+                warnings: []
+            )
+        )
+        let view = ReviewSessionTabView.testView(
+            record: record,
+            loaded: loaded,
+            draftCommentStore: draftStore,
+            provider: provider
+        )
+        .environment(\.theme, try ThemeStore().current)
+
+        let host = NSHostingView(rootView: view.frame(width: 1200, height: 720))
+        host.layoutSubtreeIfNeeded()
+
+        #expect(subview(withAccessibilityIdentifier: "review-draft-summary-publish-review", in: host) != nil)
+        #expect(pressAccessibilityElement(withAccessibilityIdentifier: "review-draft-summary-publish-review", in: host))
+        RunLoop.current.run(until: Date().addingTimeInterval(0.05))
+        host.layoutSubtreeIfNeeded()
+        #expect(subview(withAccessibilityIdentifier: "provider-review-publish-confirmation", in: host) != nil)
+        #expect(subview(withAccessibilityIdentifier: "provider-review-publish-confirm", in: host) != nil)
+    }
+
     private func recursiveDescription(_ view: NSView) -> String {
         ([view.accessibilityLabel(), view.accessibilityIdentifier()] + view.subviews.map(recursiveDescription))
             .compactMap { $0 }
@@ -502,6 +566,24 @@ struct ReviewSessionTabViewTests {
             return view
         }
         return view.subviews.lazy.compactMap { subview(withAccessibilityIdentifier: identifier, in: $0) }.first
+    }
+
+    private func subviews(withAccessibilityIdentifier identifier: String, in view: NSView) -> [NSView] {
+        var matches: [NSView] = []
+        if view.accessibilityIdentifier() == identifier {
+            matches.append(view)
+        }
+        matches.append(contentsOf: view.subviews.flatMap { subviews(withAccessibilityIdentifier: identifier, in: $0) })
+        return matches
+    }
+
+    private func pressAccessibilityElement(withAccessibilityIdentifier identifier: String, in view: NSView) -> Bool {
+        for match in subviews(withAccessibilityIdentifier: identifier, in: view) {
+            if match.accessibilityPerformPress() {
+                return true
+            }
+        }
+        return false
     }
 
     private static func summary(path: String, namespace: String) -> DiffReviewFileSummary {
@@ -557,6 +639,70 @@ struct ReviewSessionTabViewTests {
             checks: [],
             threads: []
         )
+    }
+
+    private static func reviewRequestTarget(provider: CodeHostKind, request: ReviewRequest) -> ReviewSessionTarget {
+        ReviewSessionTarget.reviewRequest(
+            worktreeID: "wt",
+            repositoryPath: URL(fileURLWithPath: "/repo"),
+            provider: provider,
+            host: request.remote.host,
+            repositorySlug: request.remote.repositorySlug,
+            number: request.number,
+            url: request.url,
+            title: request.title,
+            headSHA: "abc123"
+        )
+    }
+
+    private static func loadedReviewRequestContext(provider: CodeHostKind, request: ReviewRequest) -> ReviewSessionLoadedContext {
+        let summary = DiffReviewFileSummary(
+            path: "Sources/App.swift",
+            namespace: provider == .github ? "github-pr" : "gitlab-mr",
+            groupID: nil,
+            groupTitle: nil,
+            status: .modified,
+            additions: 1,
+            deletions: 1,
+            isRenderable: true
+        )
+        return ReviewSessionLoadedContext(
+            session: DiffReviewLoadedSession(
+                files: [
+                    DiffReviewFileSectionModel(
+                        summary: summary,
+                        parsedDiff: parsedDiff(),
+                        displayModel: displayModel(),
+                        placeholderMessage: nil,
+                        openFile: nil
+                    ),
+                ],
+                summary: DiffReviewSessionModel(files: [summary], groupsEnabled: false)
+            ),
+            feedbackTarget: ReviewFeedbackTarget(
+                title: request.title,
+                repositoryPath: "/repo",
+                providerDescription: request.displayIdentity,
+                sourceDescription: request.displayIdentity
+            ),
+            providerContext: ReviewSessionProviderContext(remote: request.remote, reviewRequest: request)
+        )
+    }
+
+    private static func parsedDiff() -> ParsedDiff {
+        DiffParser.parse("""
+        diff --git a/Sources/App.swift b/Sources/App.swift
+        --- a/Sources/App.swift
+        +++ b/Sources/App.swift
+        @@ -1,2 +1,2 @@
+         let a = 1
+        -let b = 2
+        +let b = 3
+        """)
+    }
+
+    private static func displayModel() -> DiffDisplayModel {
+        DiffDisplayModelBuilder.build(diff: parsedDiff(), filePath: "Sources/App.swift")
     }
 
     private struct FakeProviderReviewMutator: CodeHostProvider {
@@ -620,6 +766,93 @@ struct ReviewSessionTabViewTests {
             ProviderThreadMutationResult(
                 refreshedRequest: result.refreshedRequest,
                 providerURL: result.refreshedRequest.url
+            )
+        }
+    }
+
+    private final class RecordingProviderReviewMutator: CodeHostProvider, @unchecked Sendable {
+        let kind: CodeHostKind
+        let capabilities: CodeHostProviderCapabilities
+        private let publishResult: ProviderReviewPublishResult
+        private let lock = NSLock()
+        private var recordedPublishRequests: [ProviderReviewPublishRequest] = []
+
+        init(
+            kind: CodeHostKind,
+            capabilities: CodeHostProviderCapabilities = .githubCLI,
+            publishResult: ProviderReviewPublishResult
+        ) {
+            self.kind = kind
+            self.capabilities = capabilities
+            self.publishResult = publishResult
+        }
+
+        func publishRequests() -> [ProviderReviewPublishRequest] {
+            lock.lock()
+            defer { lock.unlock() }
+            return recordedPublishRequests
+        }
+
+        func isAvailable() async -> Bool { true }
+        func isAuthenticated(remote: CodeHostRemote, cwd: URL) async -> Bool { true }
+        func currentReviewRequest(
+            remote: CodeHostRemote,
+            branch: String,
+            headOwner: String?,
+            baseBranch: String,
+            cwd: URL
+        ) async throws -> ReviewRequest? {
+            publishResult.refreshedRequest
+        }
+        func createReviewRequest(
+            remote: CodeHostRemote,
+            branch: String,
+            headOwner: String?,
+            baseBranch: String,
+            title: String,
+            body: String,
+            isDraft: Bool,
+            cwd: URL
+        ) async throws -> URL {
+            publishResult.refreshedRequest.url
+        }
+        func checks(remote: CodeHostRemote, request: ReviewRequest, cwd: URL) async throws -> [ReviewCheck] { [] }
+        func reviewDiff(remote: CodeHostRemote, request: ReviewRequest, cwd: URL) async throws -> String { "" }
+        func failedCheckEvidence(remote: CodeHostRemote, request: ReviewRequest, cwd: URL) async throws -> [ReviewEvidenceItem] { [] }
+        func checkEvidenceDetail(
+            remote: CodeHostRemote,
+            request: ReviewRequest,
+            item: ReviewEvidenceItem,
+            cwd: URL
+        ) async throws -> ReviewEvidenceDetail {
+            throw CodeHostProviderError.malformedOutput("RecordingProviderReviewMutator does not provide check evidence details.")
+        }
+        func feedbackEvidence(remote: CodeHostRemote, request: ReviewRequest, cwd: URL) async throws -> [ReviewEvidenceItem] { [] }
+        func feedbackEvidenceDetail(
+            remote: CodeHostRemote,
+            request: ReviewRequest,
+            item: ReviewEvidenceItem,
+            cwd: URL
+        ) async throws -> ReviewEvidenceDetail {
+            throw CodeHostProviderError.malformedOutput("RecordingProviderReviewMutator does not provide feedback evidence details.")
+        }
+        func rerunFailedChecks(
+            remote: CodeHostRemote,
+            branch: String,
+            headSHA: String,
+            request: ReviewRequest?,
+            cwd: URL
+        ) async throws {}
+        func publishReview(_ request: ProviderReviewPublishRequest) async throws -> ProviderReviewPublishResult {
+            lock.lock()
+            recordedPublishRequests.append(request)
+            lock.unlock()
+            return publishResult
+        }
+        func mutateReviewThread(_ mutation: ProviderThreadMutation) async throws -> ProviderThreadMutationResult {
+            ProviderThreadMutationResult(
+                refreshedRequest: publishResult.refreshedRequest,
+                providerURL: publishResult.refreshedRequest.url
             )
         }
     }

--- a/AlasTests/ReviewSessionTabViewTests.swift
+++ b/AlasTests/ReviewSessionTabViewTests.swift
@@ -1177,6 +1177,62 @@ struct ReviewSessionTabViewTests {
         #expect(description.contains("resolve failed"))
     }
 
+    @Test func reviewSessionShowsProviderThreadMutationWarningsOutsidePublishSheet() async throws {
+        let thread = ReviewThreadSummary(
+            id: "thread-1",
+            author: "reviewer",
+            body: "Please fix this.",
+            url: URL(string: "https://github.com/mrmans0n/alas/pull/527#discussion_r1"),
+            isResolved: false,
+            isActionable: true,
+            location: ReviewThreadLocation(path: "Sources/App.swift", originalPath: nil, line: 2, side: .new, providerPosition: nil),
+            providerThreadID: "thread-provider-1",
+            providerCommentID: "comment-provider-1"
+        )
+        let request = Self.reviewRequest(provider: .github, threads: [thread])
+        let target = Self.reviewRequestTarget(provider: .github, request: request)
+        let record = ReviewSessionRecord(
+            id: target.id,
+            target: target,
+            createdAt: Date(timeIntervalSince1970: 1),
+            updatedAt: Date(timeIntervalSince1970: 1)
+        )
+        let loaded = Self.loadedReviewRequestContext(provider: .github, request: request)
+        let view = ReviewSessionTabView.testView(
+            record: record,
+            loaded: loaded,
+            provider: RecordingProviderReviewMutator(
+                kind: .github,
+                publishResult: ProviderReviewPublishResult(
+                    published: [],
+                    failed: [],
+                    refreshedRequest: request,
+                    warnings: []
+                ),
+                mutationWarnings: ["GitHub thread was updated, but Alas could not refresh the PR: temporary API failure"]
+            )
+        )
+        .environment(\.theme, try ThemeStore().current)
+
+        let host = NSHostingView(rootView: view.frame(width: 1200, height: 720))
+        host.layoutSubtreeIfNeeded()
+
+        #expect(subview(withAccessibilityIdentifier: "provider-review-publish-confirmation", in: host) == nil)
+        #expect(pressAccessibilityElement(withAccessibilityIdentifier: "diff-review-inline-feedback-action-resolve-thread-1", in: host))
+
+        let deadline = Date().addingTimeInterval(1)
+        while subview(withAccessibilityIdentifier: "review-session-provider-error", in: host) == nil, Date() < deadline {
+            try await Task.sleep(nanoseconds: 10_000_000)
+            RunLoop.current.run(until: Date().addingTimeInterval(0.01))
+            host.layoutSubtreeIfNeeded()
+        }
+
+        let description = recursiveDescription(host)
+        #expect(subview(withAccessibilityIdentifier: "provider-review-publish-confirmation", in: host) == nil)
+        #expect(subview(withAccessibilityIdentifier: "review-session-provider-error", in: host) != nil)
+        #expect(description.contains("could not refresh the PR"))
+    }
+
     private func recursiveDescription(_ view: NSView) -> String {
         ([view.accessibilityLabel(), view.accessibilityIdentifier()] + view.subviews.map(recursiveDescription))
             .compactMap { $0 }
@@ -1427,6 +1483,7 @@ struct ReviewSessionTabViewTests {
         let capabilities: CodeHostProviderCapabilities
         private let publishResult: ProviderReviewPublishResult
         private let mutationError: Error?
+        private let mutationWarnings: [String]
         private let lock = NSLock()
         private var recordedPublishRequests: [ProviderReviewPublishRequest] = []
 
@@ -1434,12 +1491,14 @@ struct ReviewSessionTabViewTests {
             kind: CodeHostKind,
             capabilities: CodeHostProviderCapabilities = .githubCLI,
             publishResult: ProviderReviewPublishResult,
-            mutationError: Error? = nil
+            mutationError: Error? = nil,
+            mutationWarnings: [String] = []
         ) {
             self.kind = kind
             self.capabilities = capabilities
             self.publishResult = publishResult
             self.mutationError = mutationError
+            self.mutationWarnings = mutationWarnings
         }
 
         func publishRequests() -> [ProviderReviewPublishRequest] {
@@ -1510,7 +1569,8 @@ struct ReviewSessionTabViewTests {
             }
             return ProviderThreadMutationResult(
                 refreshedRequest: publishResult.refreshedRequest,
-                providerURL: publishResult.refreshedRequest.url
+                providerURL: publishResult.refreshedRequest.url,
+                warnings: mutationWarnings
             )
         }
     }

--- a/AlasTests/ReviewSessionTabViewTests.swift
+++ b/AlasTests/ReviewSessionTabViewTests.swift
@@ -1233,6 +1233,41 @@ struct ReviewSessionTabViewTests {
         #expect(description.contains("could not refresh the PR"))
     }
 
+    @Test func providerFeedbackMatcherPrefersExactOldSidePathWhenOriginalPathIsMissing() {
+        let modified = DiffReviewFileSummary(
+            path: "Sources/App.swift",
+            namespace: "github-pr",
+            groupID: nil,
+            groupTitle: nil,
+            status: .modified,
+            additions: 1,
+            deletions: 1,
+            isRenderable: true
+        )
+        let copied = DiffReviewFileSummary(
+            path: "Sources/CopiedApp.swift",
+            namespace: "github-pr",
+            groupID: nil,
+            groupTitle: nil,
+            status: .copied,
+            additions: 1,
+            deletions: 0,
+            isRenderable: true,
+            originalPath: "Sources/App.swift"
+        )
+        let matcher = ReviewSessionInlineFeedbackFileMatcher(files: [modified, copied])
+
+        let match = matcher.file(for: ReviewThreadLocation(
+            path: "Sources/App.swift",
+            originalPath: nil,
+            line: 7,
+            side: .old,
+            providerPosition: nil
+        ))
+
+        #expect(match?.path == "Sources/App.swift")
+    }
+
     private func recursiveDescription(_ view: NSView) -> String {
         ([view.accessibilityLabel(), view.accessibilityIdentifier()] + view.subviews.map(recursiveDescription))
             .compactMap { $0 }

--- a/AlasTests/ReviewSessionTabViewTests.swift
+++ b/AlasTests/ReviewSessionTabViewTests.swift
@@ -373,6 +373,34 @@ struct ReviewSessionTabViewTests {
         #expect(publishedRequest.comments.map(\.localDraftID) == [selected.id])
     }
 
+    @Test func providerPublishPlannerIgnoresAlreadyPublishedAndInvalidDrafts() {
+        var published = Self.providerDraftComment(id: "published")
+        published.providerPublish = ReviewDraftProviderPublish(
+            provider: .github,
+            host: "github.com",
+            repositorySlug: "mrmans0n/alas",
+            reviewNumber: 527,
+            threadID: "thread-1",
+            commentID: "comment-1",
+            url: nil,
+            publishedAt: Date(timeIntervalSince1970: 20)
+        )
+        let valid = Self.providerDraftComment(id: "valid")
+        let resolved = Self.providerDraftComment(id: "resolved", state: .resolved)
+        let missingAnchor = Self.providerDraftComment(id: "missing-anchor", side: .unknown)
+        let empty = Self.providerDraftComment(id: "empty", bodyMarkdown: " \n ")
+
+        let comments = [published, valid, resolved, missingAnchor, empty]
+
+        #expect(ProviderReviewPublishPlanner.publishableDrafts(comments).map(\.id) == ["valid"])
+        #expect(ProviderReviewPublishPlanner.unpublishableMessages(comments) == [
+            "Sources/published.swift: already published to GitHub.",
+            "Sources/resolved.swift: draft is resolved.",
+            "Sources/missing-anchor.swift: missing line anchor.",
+            "Sources/empty.swift: empty comment.",
+        ])
+    }
+
     @Test func providerMutationControllerRejectsStaleSelectedDraftWithoutPublishing() async throws {
         let sessionID = ReviewDraftSessionID.reviewRequest(
             worktreeID: "wt",
@@ -620,6 +648,29 @@ struct ReviewSessionTabViewTests {
         #expect(subview(withAccessibilityIdentifier: "provider-review-publish-confirmation", in: host) != nil)
     }
 
+    @Test func providerPublishConfirmationDisablesCommentDecisionWithNoComments() throws {
+        var selectedDecision = ProviderReviewDecision.comment
+        var didConfirm = false
+        let view = ProviderReviewPublishConfirmationView(
+            providerName: "GitHub",
+            reviewIdentity: "PR #527",
+            commentCount: 0,
+            unpublishableMessages: ["Sources/App.swift: already published to GitHub."],
+            selectedDecision: Binding(get: { selectedDecision }, set: { selectedDecision = $0 }),
+            isPublishing: false,
+            errorMessage: nil,
+            onCancel: {},
+            onConfirm: { didConfirm = true }
+        )
+        .environment(\.theme, try ThemeStore().current)
+
+        let host = NSHostingView(rootView: view.frame(width: 420, height: 260))
+        host.layoutSubtreeIfNeeded()
+
+        #expect(!pressAccessibilityElement(withAccessibilityIdentifier: "provider-review-publish-confirm", in: host))
+        #expect(!didConfirm)
+    }
+
     @Test func reviewSessionShowsPublishReviewForProviderContextWithDraftsAndOpensPublishConfirmation() async throws {
         let request = Self.reviewRequest(provider: .github)
         let target = Self.reviewRequestTarget(provider: .github, request: request)
@@ -766,6 +817,35 @@ struct ReviewSessionTabViewTests {
             mergeState: .unknown,
             checks: [],
             threads: []
+        )
+    }
+
+    private static func providerDraftComment(
+        id: String,
+        side: DiffReviewInlineFeedbackSide = .new,
+        state: ReviewDraftCommentState = .active,
+        bodyMarkdown: String = "Please fix this."
+    ) -> ReviewDraftComment {
+        ReviewDraftComment(
+            id: id,
+            sessionID: .reviewRequest(
+                worktreeID: "wt",
+                provider: .github,
+                host: "github.com",
+                repositorySlug: "mrmans0n/alas",
+                number: 527
+            ),
+            fileID: DiffReviewFileID(namespace: "github-pr", path: "Sources/\(id).swift"),
+            path: "Sources/\(id).swift",
+            originalPath: nil,
+            side: side,
+            startLine: 12,
+            endLine: nil,
+            selectedText: "let value = 1",
+            bodyMarkdown: bodyMarkdown,
+            state: state,
+            createdAt: Date(timeIntervalSince1970: 1),
+            updatedAt: Date(timeIntervalSince1970: 2)
         )
     }
 

--- a/AlasTests/ReviewSessionTabViewTests.swift
+++ b/AlasTests/ReviewSessionTabViewTests.swift
@@ -298,6 +298,81 @@ struct ReviewSessionTabViewTests {
         #expect(updated.providerError == nil)
     }
 
+    @Test func providerMutationControllerPublishesOnlySelectedDraftIDs() async throws {
+        let sessionID = ReviewDraftSessionID.reviewRequest(
+            worktreeID: "wt",
+            provider: .github,
+            host: "github.com",
+            repositorySlug: "mrmans0n/alas",
+            number: 527
+        )
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("alas-provider-selected-publish-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: directory) }
+
+        let store = ReviewDraftCommentStore(
+            store: PersistenceStore(),
+            url: directory.appendingPathComponent("drafts.json")
+        )
+        let draftController = ReviewDraftCommentController(
+            sessionID: sessionID,
+            store: store,
+            now: { Date(timeIntervalSince1970: 200) }
+        )
+        try draftController.load()
+        try draftController.add(
+            anchor: DiffReviewLineAnchor(
+                path: "Sources/App.swift",
+                side: .new,
+                line: 12,
+                rowIndex: 0,
+                selectedText: "let value = 1"
+            ),
+            fileID: DiffReviewFileID(namespace: "github", path: "Sources/App.swift"),
+            bodyMarkdown: "Publish this."
+        )
+        let selected = try #require(draftController.comments.first)
+        try draftController.add(
+            anchor: DiffReviewLineAnchor(
+                path: "Sources/Other.swift",
+                side: .new,
+                line: 8,
+                rowIndex: 0,
+                selectedText: "let other = 1"
+            ),
+            fileID: DiffReviewFileID(namespace: "github", path: "Sources/Other.swift"),
+            bodyMarkdown: "Keep local."
+        )
+        let request = Self.reviewRequest(provider: .github)
+        let provider = RecordingProviderReviewMutator(
+            kind: .github,
+            publishResult: ProviderReviewPublishResult(
+                published: [],
+                failed: [],
+                refreshedRequest: request,
+                warnings: []
+            )
+        )
+        let controller = ProviderReviewMutationController(
+            provider: provider,
+            draftController: draftController,
+            now: { Date(timeIntervalSince1970: 300) }
+        )
+
+        _ = try await controller.publishReview(
+            remote: request.remote,
+            reviewRequest: request,
+            decision: .comment,
+            summaryBody: "Review from Alas",
+            cwd: URL(fileURLWithPath: "/repo"),
+            localDraftIDs: [selected.id]
+        )
+
+        let publishedRequest = try #require(provider.publishRequests().first)
+        #expect(publishedRequest.comments.map(\.localDraftID) == [selected.id])
+    }
+
     @Test func providerMutationControllerKeepsFailedDraftsActiveWithError() async throws {
         let sessionID = ReviewDraftSessionID.reviewRequest(
             worktreeID: "wt",

--- a/AlasTests/ReviewSessionTabViewTests.swift
+++ b/AlasTests/ReviewSessionTabViewTests.swift
@@ -835,6 +835,58 @@ struct ReviewSessionTabViewTests {
         #expect(subview(withAccessibilityIdentifier: "provider-review-publish-confirm", in: host) != nil)
     }
 
+    @Test func reviewSessionShowsPublishReviewForProviderContextWithoutDraftsAndOpensPublishConfirmation() async throws {
+        let request = Self.reviewRequest(provider: .github)
+        let target = Self.reviewRequestTarget(provider: .github, request: request)
+        let record = ReviewSessionRecord(
+            id: target.id,
+            target: target,
+            createdAt: Date(timeIntervalSince1970: 1),
+            updatedAt: Date(timeIntervalSince1970: 1)
+        )
+        let loaded = Self.loadedReviewRequestContext(provider: .github, request: request)
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("alas-review-session-decision-only-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let draftStore = ReviewDraftCommentStore(
+            store: PersistenceStore(),
+            url: directory.appendingPathComponent("drafts.json")
+        )
+        let provider = RecordingProviderReviewMutator(
+            kind: .github,
+            publishResult: ProviderReviewPublishResult(
+                published: [],
+                failed: [],
+                refreshedRequest: request,
+                warnings: []
+            )
+        )
+        let view = ReviewSessionTabView.testView(
+            record: record,
+            loaded: loaded,
+            draftCommentStore: draftStore,
+            provider: provider
+        )
+        .environment(\.theme, try ThemeStore().current)
+
+        let host = NSHostingView(rootView: view.frame(width: 1200, height: 720))
+        host.layoutSubtreeIfNeeded()
+
+        #expect(subview(withAccessibilityIdentifier: "review-draft-summary-publish-review", in: host) != nil)
+        #expect(pressAccessibilityElement(withAccessibilityIdentifier: "review-draft-summary-publish-review", in: host))
+        RunLoop.current.run(until: Date().addingTimeInterval(0.05))
+        host.layoutSubtreeIfNeeded()
+        #expect(subview(withAccessibilityIdentifier: "provider-review-publish-confirmation", in: host) != nil)
+        #expect(subview(withAccessibilityIdentifier: "provider-review-publish-confirm", in: host) != nil)
+        #expect(pressAccessibilityElement(withAccessibilityIdentifier: "provider-review-publish-confirm", in: host))
+        let deadline = Date().addingTimeInterval(1)
+        while provider.publishRequests().isEmpty, Date() < deadline {
+            try await Task.sleep(nanoseconds: 10_000_000)
+        }
+        #expect(provider.publishRequests().map(\.decision) == [.approve])
+    }
+
     @Test func reviewSessionShowsProviderFeedbackOpenAndCopyActions() throws {
         let thread = ReviewThreadSummary(
             id: "thread-1",

--- a/docs/superpowers/plans/2026-06-15-provider-review-actions.md
+++ b/docs/superpowers/plans/2026-06-15-provider-review-actions.md
@@ -1,0 +1,2276 @@
+# Provider Review Actions Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Let Alas publish local draft review comments and mutate GitHub/GitLab review threads directly from the existing review workspace.
+
+**Architecture:** Add a provider-neutral write contract beside the existing `CodeHostProvider` read contract, implement it for both `gh` and `glab`, then wire provider publishing through the existing review-session/draft-comment controller. Keep `DiffReviewSurface` provider-neutral; it should render capability-driven actions and delegate all mutations to review-session owned controllers.
+
+**Tech Stack:** Swift 5.9+, SwiftUI, Swift Testing, existing `gh`/`glab` CLI provider infrastructure, existing JSON persistence stores.
+
+---
+
+## Scope Boundaries
+
+This plan implements the approved spec at `docs/superpowers/specs/2026-06-15-provider-review-actions-design.md`.
+
+V1 includes both GitHub and GitLab:
+
+- publish local draft comments to provider PR/MR
+- GitHub comment/approve/request-changes review decisions
+- GitLab discussions, approval endpoint, and request-changes status note
+- reply to provider threads/discussions
+- resolve/unresolve provider threads/discussions
+- refresh provider state after writes
+- persist provider publish metadata and provider errors on local drafts
+- confirmation UI before remote writes
+
+Out of scope:
+
+- editing/deleting remote comments
+- suggestion blocks/apply suggestion
+- pending GitHub reviews created outside Alas
+- offline mutation queue
+- automatic line-comment-to-file-comment fallback
+
+---
+
+## File Map
+
+### Provider Models and Contracts
+
+- Modify `Alas/Sources/Integrations/CodeHost/CodeHostModels.swift`
+  - extend `CodeHostProviderCapabilities`
+  - add `providerThreadID` and `providerCommentID` directly to `ReviewThreadSummary`; keep `ReviewThreadLocation` focused on path/line/side data
+- Create `Alas/Sources/Integrations/CodeHost/ProviderReviewActions.swift`
+  - provider-neutral publish/reply/resolve models
+  - provider action validators and small payload helpers
+- Modify `Alas/Sources/Integrations/CodeHost/CodeHostProvider.swift`
+  - add async write methods with default unsupported implementations
+  - add stdin-capable command runner support for `gh api --input -` and `glab api --input -`
+
+### Provider Implementations
+
+- Modify `Alas/Sources/Integrations/CodeHost/GitHubCLIProvider.swift`
+  - implement publish/reply/resolve/unresolve/review-decision methods
+  - add payload builders as `internal static` helpers for tests
+- Modify `Alas/Sources/Integrations/CodeHost/GitLabCLIProvider.swift`
+  - implement publish/reply/resolve/unresolve/approve/request-changes-note methods
+  - add diff-ref and position payload builders as `internal static` helpers for tests
+
+### Review Workspace State and Controller
+
+- Modify `Alas/Sources/Center/ReviewWorkspace/ReviewDraftModels.swift`
+  - add publish metadata and provider error fields to `ReviewDraftComment`
+- Modify `Alas/Sources/Center/ReviewWorkspace/ReviewDraftCommentStore.swift`
+  - keep round-trip persistence backward compatible
+- Modify `Alas/Sources/Center/ReviewWorkspace/ReviewDraftCommentController.swift`
+  - add `markPublished`, `recordProviderError`, and active publish filtering
+- Create `Alas/Sources/Center/ReviewWorkspace/ProviderReviewMutationController.swift`
+  - owns publish/reply/resolve orchestration, refresh-after-write, and draft-store updates
+
+### UI Actions
+
+- Modify `Alas/Sources/Center/ReviewWorkspace/ReviewDraftCommentActions.swift`
+  - add publish availability/action
+- Modify `Alas/Sources/Center/DiffReview/DiffReviewInlineFeedbackActions.swift`
+  - add reply/resolve/unresolve availability/actions
+- Modify `Alas/Sources/Center/DiffReview/DiffReviewFileSection.swift`
+  - render provider thread actions on feedback cards
+  - render per-draft publish on local draft cards
+- Modify `Alas/Sources/Center/ReviewWorkspace/ReviewDraftSummaryRail.swift`
+  - render `Publish review`
+  - show published/error state in summary rows
+- Create `Alas/Sources/Center/ReviewWorkspace/ProviderReviewPublishConfirmationView.swift`
+  - confirmation UI for decision/comment count/unpublishable drafts
+- Modify `Alas/Sources/Center/ReviewWorkspace/ReviewSessionTabView.swift`
+  - wire controller, confirmation state, publish results, provider-thread actions
+
+### Tests
+
+- Modify `AlasTests/Integrations/CodeHostModelsTests.swift`
+- Create `AlasTests/Integrations/ProviderReviewActionsTests.swift`
+- Modify `AlasTests/Integrations/GitHubCLIProviderTests.swift`
+- Modify `AlasTests/Integrations/GitLabCLIProviderTests.swift`
+- Modify `AlasTests/ReviewDraftModelsTests.swift`
+- Modify `AlasTests/ReviewDraftCommentStoreTests.swift`
+- Modify `AlasTests/ReviewSessionTabViewTests.swift`
+- Modify `AlasTests/DiffReviewSurfaceTests.swift`
+
+Run `xcodegen` after adding new Swift files so `Alas.xcodeproj` references them.
+
+---
+
+## Task 1: Provider Write Models and Capabilities
+
+**Files:**
+
+- Create: `Alas/Sources/Integrations/CodeHost/ProviderReviewActions.swift`
+- Modify: `Alas/Sources/Integrations/CodeHost/CodeHostModels.swift`
+- Modify: `Alas/Sources/Integrations/CodeHost/CodeHostProvider.swift`
+- Test: `AlasTests/Integrations/CodeHostModelsTests.swift`
+- Test: `AlasTests/Integrations/ProviderReviewActionsTests.swift`
+
+- [ ] **Step 1: Write failing model/capability tests**
+
+Add `AlasTests/Integrations/ProviderReviewActionsTests.swift`:
+
+```swift
+import Foundation
+import Testing
+@testable import Alas
+
+struct ProviderReviewActionsTests {
+    @Test func providerDraftCommentBuildsFromActiveLocalDraft() throws {
+        let session = ReviewDraftSessionID.reviewRequest(
+            worktreeID: "wt",
+            provider: .github,
+            host: "github.com",
+            repositorySlug: "mrmans0n/alas",
+            number: 527
+        )
+        let draft = ReviewDraftComment(
+            id: "draft-1",
+            sessionID: session,
+            fileID: DiffReviewFileID(namespace: "github", path: "Sources/App.swift"),
+            path: "Sources/App.swift",
+            originalPath: nil,
+            side: .new,
+            startLine: 12,
+            endLine: 14,
+            selectedText: "let value = 1",
+            bodyMarkdown: "Please simplify this.",
+            state: .active,
+            createdAt: Date(timeIntervalSince1970: 10),
+            updatedAt: Date(timeIntervalSince1970: 11)
+        )
+
+        let providerDraft = try #require(ProviderReviewDraftComment(localDraft: draft))
+
+        #expect(providerDraft.localDraftID == "draft-1")
+        #expect(providerDraft.path == "Sources/App.swift")
+        #expect(providerDraft.side == .new)
+        #expect(providerDraft.lineRange == 12...14)
+        #expect(providerDraft.bodyMarkdown == "Please simplify this.")
+    }
+
+    @Test func providerDraftCommentRejectsNonActiveOrPublishedDrafts() {
+        var draft = ReviewDraftComment(
+            id: "draft-1",
+            sessionID: .reviewRequest(worktreeID: "wt", provider: .github, host: "github.com", repositorySlug: "mrmans0n/alas", number: 527),
+            fileID: DiffReviewFileID(namespace: "github", path: "Sources/App.swift"),
+            path: "Sources/App.swift",
+            originalPath: nil,
+            side: .new,
+            startLine: 12,
+            endLine: nil,
+            selectedText: nil,
+            bodyMarkdown: "Comment",
+            state: .resolved,
+            createdAt: Date(timeIntervalSince1970: 10),
+            updatedAt: Date(timeIntervalSince1970: 11)
+        )
+        #expect(ProviderReviewDraftComment(localDraft: draft) == nil)
+
+        draft.state = .active
+        draft.providerPublish = ReviewDraftProviderPublish(
+            provider: .github,
+            host: "github.com",
+            repositorySlug: "mrmans0n/alas",
+            reviewNumber: 527,
+            threadID: "thread-1",
+            commentID: "comment-1",
+            url: URL(string: "https://github.com/mrmans0n/alas/pull/527#discussion_r1"),
+            publishedAt: Date(timeIntervalSince1970: 20)
+        )
+        #expect(ProviderReviewDraftComment(localDraft: draft) == nil)
+    }
+
+    @Test func providerCapabilitiesExposeWriteActions() {
+        #expect(CodeHostProviderCapabilities.githubCLI.canPublishReviewComments)
+        #expect(CodeHostProviderCapabilities.githubCLI.canReplyToReviewThreads)
+        #expect(CodeHostProviderCapabilities.githubCLI.canResolveReviewThreads)
+        #expect(CodeHostProviderCapabilities.githubCLI.canUnresolveReviewThreads)
+        #expect(CodeHostProviderCapabilities.githubCLI.canApproveReview)
+        #expect(CodeHostProviderCapabilities.githubCLI.canRequestChanges)
+
+        #expect(CodeHostProviderCapabilities.gitlabCLI.canPublishReviewComments)
+        #expect(CodeHostProviderCapabilities.gitlabCLI.canReplyToReviewThreads)
+        #expect(CodeHostProviderCapabilities.gitlabCLI.canResolveReviewThreads)
+        #expect(CodeHostProviderCapabilities.gitlabCLI.canUnresolveReviewThreads)
+        #expect(CodeHostProviderCapabilities.gitlabCLI.canApproveReview)
+        #expect(CodeHostProviderCapabilities.gitlabCLI.canRequestChanges)
+
+        #expect(!CodeHostProviderCapabilities.readOnly.canPublishReviewComments)
+    }
+}
+```
+
+Extend `AlasTests/Integrations/CodeHostModelsTests.swift` with:
+
+```swift
+@Test func reviewThreadSummaryCarriesProviderThreadIdentity() {
+    let thread = ReviewThreadSummary(
+        id: "thread-1",
+        author: "reviewer",
+        body: "Please fix this.",
+        url: URL(string: "https://provider/thread"),
+        isResolved: false,
+        isActionable: true,
+        location: ReviewThreadLocation(
+            path: "Sources/App.swift",
+            originalPath: nil,
+            line: 42,
+            side: .new,
+            providerPosition: "42"
+        ),
+        providerThreadID: "thread-provider-id",
+        providerCommentID: "comment-provider-id"
+    )
+
+    #expect(thread.providerThreadID == "thread-provider-id")
+    #expect(thread.providerCommentID == "comment-provider-id")
+}
+```
+
+- [ ] **Step 2: Run tests to verify failure**
+
+Run:
+
+```bash
+rtk xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -only-testing:AlasTests/ProviderReviewActionsTests -only-testing:AlasTests/CodeHostModelsTests -quiet test
+```
+
+Expected: compile failure for missing `ProviderReviewDraftComment`, `ReviewDraftProviderPublish`, provider capability fields, and `ReviewThreadSummary` identity fields.
+
+- [ ] **Step 3: Add provider write models**
+
+Create `Alas/Sources/Integrations/CodeHost/ProviderReviewActions.swift`:
+
+```swift
+import Foundation
+
+enum ProviderReviewDecision: String, Codable, Equatable, Sendable {
+    case comment
+    case approve
+    case requestChanges
+}
+
+struct ProviderReviewDraftComment: Codable, Equatable, Identifiable, Sendable {
+    var id: String { localDraftID }
+    let localDraftID: String
+    let path: String
+    let originalPath: String?
+    let side: DiffReviewInlineFeedbackSide
+    let lineRange: ClosedRange<Int>
+    let selectedText: String?
+    let bodyMarkdown: String
+
+    init?(localDraft: ReviewDraftComment) {
+        guard localDraft.state == .active, localDraft.providerPublish == nil else { return nil }
+        self.localDraftID = localDraft.id
+        self.path = localDraft.path
+        self.originalPath = localDraft.originalPath
+        self.side = localDraft.side
+        self.lineRange = localDraft.normalizedLineRange
+        self.selectedText = localDraft.selectedText
+        self.bodyMarkdown = localDraft.bodyMarkdown
+    }
+}
+
+struct ProviderReviewPublishRequest: Equatable, Sendable {
+    let remote: CodeHostRemote
+    let reviewRequest: ReviewRequest
+    let comments: [ProviderReviewDraftComment]
+    let decision: ProviderReviewDecision
+    let summaryBody: String
+    let cwd: URL
+}
+
+struct ProviderReviewPublishedComment: Codable, Equatable, Sendable {
+    let localDraftID: String
+    let providerThreadID: String?
+    let providerCommentID: String?
+    let providerURL: URL?
+}
+
+struct ProviderReviewFailedComment: Codable, Equatable, Sendable {
+    let localDraftID: String
+    let message: String
+}
+
+struct ProviderReviewPublishResult: Equatable, Sendable {
+    let published: [ProviderReviewPublishedComment]
+    let failed: [ProviderReviewFailedComment]
+    let refreshedRequest: ReviewRequest
+    let warnings: [String]
+}
+
+enum ProviderThreadMutationKind: String, Codable, Equatable, Sendable {
+    case reply
+    case resolve
+    case unresolve
+}
+
+struct ProviderThreadMutation: Equatable, Sendable {
+    let remote: CodeHostRemote
+    let reviewRequest: ReviewRequest
+    let thread: ReviewThreadSummary
+    let kind: ProviderThreadMutationKind
+    let bodyMarkdown: String?
+    let cwd: URL
+}
+
+struct ProviderThreadMutationResult: Equatable, Sendable {
+    let refreshedRequest: ReviewRequest
+    let providerURL: URL?
+}
+```
+
+- [ ] **Step 4: Extend existing models and provider protocol**
+
+In `ReviewDraftModels.swift`, extend `ReviewDraftComment`:
+
+```swift
+struct ReviewDraftProviderPublish: Codable, Equatable, Sendable {
+    let provider: CodeHostKind
+    let host: String
+    let repositorySlug: String
+    let reviewNumber: Int
+    let threadID: String?
+    let commentID: String?
+    let url: URL?
+    let publishedAt: Date
+}
+
+struct ReviewDraftProviderError: Codable, Equatable, Sendable {
+    let provider: CodeHostKind
+    let message: String
+    let occurredAt: Date
+}
+```
+
+Add fields to `ReviewDraftComment`:
+
+```swift
+var providerPublish: ReviewDraftProviderPublish?
+var providerError: ReviewDraftProviderError?
+```
+
+Update its initializer to default both fields to `nil` so existing call sites keep compiling:
+
+```swift
+providerPublish: ReviewDraftProviderPublish? = nil,
+providerError: ReviewDraftProviderError? = nil
+```
+
+In `CodeHostModels.swift`, extend `CodeHostProviderCapabilities` with booleans:
+
+```swift
+let canPublishReviewComments: Bool
+let canReplyToReviewThreads: Bool
+let canResolveReviewThreads: Bool
+let canUnresolveReviewThreads: Bool
+let canApproveReview: Bool
+let canRequestChanges: Bool
+```
+
+Set `readOnly` to all false. Set `githubCLI` and `gitlabCLI` to all true for those six fields.
+
+Extend `ReviewThreadSummary`:
+
+```swift
+let providerThreadID: String?
+let providerCommentID: String?
+```
+
+Default both to `nil` in the initializer. Keep `id` unchanged for UI identity.
+
+In `CodeHostProvider.swift`, add default unsupported write methods:
+
+```swift
+func publishReview(_ request: ProviderReviewPublishRequest) async throws -> ProviderReviewPublishResult
+func mutateReviewThread(_ mutation: ProviderThreadMutation) async throws -> ProviderThreadMutationResult
+```
+
+Default implementations:
+
+```swift
+func publishReview(_ request: ProviderReviewPublishRequest) async throws -> ProviderReviewPublishResult {
+    throw CodeHostProviderError.unsupportedProvider(request.remote.kind)
+}
+
+func mutateReviewThread(_ mutation: ProviderThreadMutation) async throws -> ProviderThreadMutationResult {
+    throw CodeHostProviderError.unsupportedProvider(mutation.remote.kind)
+}
+```
+
+Extend `CodeHostCommandRunning` so providers can pass JSON to provider CLIs without shell-encoding it into arguments:
+
+```swift
+protocol CodeHostCommandRunning: Sendable {
+    func run(_ executable: String, args: [String], cwd: URL?, stdin: String?) async throws -> ProcessResult
+}
+
+extension CodeHostCommandRunning {
+    func run(_ executable: String, args: [String], cwd: URL?) async throws -> ProcessResult {
+        try await run(executable, args: args, cwd: cwd, stdin: nil)
+    }
+}
+
+struct ProcessCodeHostCommandRunner: CodeHostCommandRunning {
+    func run(_ executable: String, args: [String], cwd: URL?, stdin: String?) async throws -> ProcessResult {
+        try await Process.run(
+            "/usr/bin/env",
+            args: [executable] + args,
+            cwd: cwd,
+            env: Process.gitEnv(),
+            stdin: stdin
+        )
+    }
+}
+```
+
+Update fake runners in provider tests when those tests first need stdin recording:
+
+```swift
+struct Command: Equatable {
+    let executable: String
+    let args: [String]
+    let cwd: URL?
+    let stdin: String?
+
+    init(executable: String, args: [String], cwd: URL?, stdin: String? = nil) {
+        self.executable = executable
+        self.args = args
+        self.cwd = cwd
+        self.stdin = stdin
+    }
+}
+```
+
+and:
+
+```swift
+func run(_ executable: String, args: [String], cwd: URL?, stdin: String?) async throws -> ProcessResult {
+    commands.append(Command(executable: executable, args: args, cwd: cwd, stdin: stdin))
+    guard !results.isEmpty else {
+        throw CodeHostProviderError.commandFailed(command: executable, stderr: "missing fake result")
+    }
+    return results.removeFirst()
+}
+```
+
+- [ ] **Step 5: Run focused tests**
+
+Run:
+
+```bash
+rtk xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -only-testing:AlasTests/ProviderReviewActionsTests -only-testing:AlasTests/CodeHostModelsTests -only-testing:AlasTests/ReviewDraftModelsTests -quiet test
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Regenerate project and commit**
+
+Run:
+
+```bash
+xcodegen
+git status --short
+git add Alas/Sources/Integrations/CodeHost/ProviderReviewActions.swift Alas/Sources/Integrations/CodeHost/CodeHostModels.swift Alas/Sources/Integrations/CodeHost/CodeHostProvider.swift Alas/Sources/Center/ReviewWorkspace/ReviewDraftModels.swift AlasTests/Integrations/ProviderReviewActionsTests.swift AlasTests/Integrations/CodeHostModelsTests.swift AlasTests/ReviewDraftModelsTests.swift Alas.xcodeproj
+git commit -m "feat(review): add provider review action models"
+```
+
+Expected: commit contains only provider model/protocol changes and focused tests.
+
+---
+
+## Task 2: Draft Publish Metadata Persistence
+
+**Files:**
+
+- Modify: `Alas/Sources/Center/ReviewWorkspace/ReviewDraftCommentStore.swift`
+- Modify: `Alas/Sources/Center/ReviewWorkspace/ReviewDraftCommentController.swift`
+- Test: `AlasTests/ReviewDraftCommentStoreTests.swift`
+
+- [ ] **Step 1: Write failing persistence/controller tests**
+
+Add to `ReviewDraftCommentStoreTests`:
+
+```swift
+@Test @MainActor func controllerMarksDraftPublishedAndRecordsProviderErrors() throws {
+    let directory = FileManager.default.temporaryDirectory
+        .appendingPathComponent(UUID().uuidString, isDirectory: true)
+    let url = directory.appendingPathComponent("review-draft-comments.json")
+    let store = ReviewDraftCommentStore(store: PersistenceStore(), url: url)
+    let session = ReviewDraftSessionID.reviewRequest(
+        worktreeID: "wt",
+        provider: .github,
+        host: "github.com",
+        repositorySlug: "mrmans0n/alas",
+        number: 527
+    )
+    let controller = ReviewDraftCommentController(
+        sessionID: session,
+        store: store,
+        now: { Date(timeIntervalSince1970: 100) }
+    )
+    let anchor = DiffReviewLineAnchor(
+        path: "Sources/App.swift",
+        side: .new,
+        line: 42,
+        rowIndex: 0,
+        selectedText: "let value = 1"
+    )
+    let fileID = DiffReviewFileID(namespace: "github", path: "Sources/App.swift")
+
+    try controller.load()
+    try controller.add(anchor: anchor, fileID: fileID, bodyMarkdown: "Please fix this.")
+    let added = try #require(controller.comments.single)
+
+    let publish = ReviewDraftProviderPublish(
+        provider: .github,
+        host: "github.com",
+        repositorySlug: "mrmans0n/alas",
+        reviewNumber: 527,
+        threadID: "thread-1",
+        commentID: "comment-1",
+        url: URL(string: "https://github.com/mrmans0n/alas/pull/527#discussion_r1"),
+        publishedAt: Date(timeIntervalSince1970: 120)
+    )
+    try controller.markPublished(commentID: added.id, publish: publish)
+
+    let published = try #require(controller.comments.single)
+    #expect(published.providerPublish == publish)
+    #expect(published.providerError == nil)
+    #expect(try store.load(sessionID: session).single?.providerPublish == publish)
+
+    try controller.recordProviderError(
+        commentID: added.id,
+        error: ReviewDraftProviderError(provider: .github, message: "line is outdated", occurredAt: Date(timeIntervalSince1970: 130))
+    )
+
+    let errored = try #require(controller.comments.single)
+    #expect(errored.providerPublish == publish)
+    #expect(errored.providerError?.message == "line is outdated")
+}
+
+@Test func publishedMetadataSurvivesStoreRoundTrip() throws {
+    let directory = FileManager.default.temporaryDirectory
+        .appendingPathComponent(UUID().uuidString, isDirectory: true)
+    let url = directory.appendingPathComponent("review-draft-comments.json")
+    let store = ReviewDraftCommentStore(store: PersistenceStore(), url: url)
+    let session = ReviewDraftSessionID.reviewRequest(
+        worktreeID: "wt",
+        provider: .gitlab,
+        host: "gitlab.example.com",
+        repositorySlug: "platform/alas",
+        number: 42
+    )
+    let comment = makeComment(id: "published", session: session, startLine: 8, endLine: nil, createdAt: Date(timeIntervalSince1970: 10))
+        .withProviderPublishForTest(
+            ReviewDraftProviderPublish(
+                provider: .gitlab,
+                host: "gitlab.example.com",
+                repositorySlug: "platform/alas",
+                reviewNumber: 42,
+                threadID: "discussion-1",
+                commentID: "501",
+                url: URL(string: "https://gitlab.example.com/platform/alas/-/merge_requests/42#note_501"),
+                publishedAt: Date(timeIntervalSince1970: 20)
+            )
+        )
+
+    try store.save(comment)
+
+    #expect(try store.load(sessionID: session).single == comment)
+}
+```
+
+Add a private test helper:
+
+```swift
+private extension ReviewDraftComment {
+    func withProviderPublishForTest(_ publish: ReviewDraftProviderPublish) -> ReviewDraftComment {
+        var copy = self
+        copy.providerPublish = publish
+        return copy
+    }
+}
+```
+
+- [ ] **Step 2: Run tests to verify failure**
+
+Run:
+
+```bash
+rtk xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -only-testing:AlasTests/ReviewDraftCommentStoreTests -quiet test
+```
+
+Expected: compile failure for missing controller methods.
+
+- [ ] **Step 3: Implement controller methods**
+
+In `ReviewDraftCommentController.swift`, add:
+
+```swift
+func markPublished(commentID: String, publish: ReviewDraftProviderPublish) throws {
+    guard let index = comments.firstIndex(where: { $0.id == commentID }) else { return }
+    var updated = comments[index]
+    updated.providerPublish = publish
+    updated.providerError = nil
+    updated.updatedAt = now()
+    try store.save(updated)
+    comments[index] = updated
+    errorMessage = nil
+}
+
+func recordProviderError(commentID: String, error: ReviewDraftProviderError) throws {
+    guard let index = comments.firstIndex(where: { $0.id == commentID }) else { return }
+    var updated = comments[index]
+    updated.providerError = error
+    updated.updatedAt = now()
+    try store.save(updated)
+    comments[index] = updated
+    errorMessage = nil
+}
+
+var activeUnpublishedComments: [ReviewDraftComment] {
+    comments.filter { $0.state == .active && $0.providerPublish == nil }
+}
+```
+
+Use the existing private `now` closure already injected into `ReviewDraftCommentController` for both publish and provider-error timestamps.
+
+- [ ] **Step 4: Run focused tests**
+
+Run:
+
+```bash
+rtk xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -only-testing:AlasTests/ReviewDraftCommentStoreTests -quiet test
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+Run:
+
+```bash
+git add Alas/Sources/Center/ReviewWorkspace/ReviewDraftCommentController.swift Alas/Sources/Center/ReviewWorkspace/ReviewDraftCommentStore.swift AlasTests/ReviewDraftCommentStoreTests.swift
+git commit -m "feat(review): persist provider publish metadata"
+```
+
+Expected: commit contains only draft metadata persistence/controller changes and tests.
+
+---
+
+## Task 3: GitHub Provider Mutations
+
+**Files:**
+
+- Modify: `Alas/Sources/Integrations/CodeHost/GitHubCLIProvider.swift`
+- Test: `AlasTests/Integrations/GitHubCLIProviderTests.swift`
+
+- [ ] **Step 1: Write failing GitHub publish/reply/resolve tests**
+
+Add to `GitHubCLIProviderTests`:
+
+```swift
+@Test func githubPublishReviewUsesGraphQLPayloadAndRefreshesPR() async throws {
+    let runner = FakeRunner(results: [
+        ProcessResult(exitCode: 0, stdout: Self.pullRequestNodeOutput, stderr: ""),
+        ProcessResult(exitCode: 0, stdout: Self.publishReviewMutationOutput, stderr: ""),
+        ProcessResult(exitCode: 0, stdout: Self.prListOutput, stderr: ""),
+        ProcessResult(exitCode: 0, stdout: Self.reviewThreadsOutput, stderr: ""),
+    ])
+    let provider = GitHubCLIProvider(runner: runner)
+    let request = ProviderReviewPublishRequest(
+        remote: Self.remote,
+        reviewRequest: Self.reviewRequest,
+        comments: [
+            ProviderReviewDraftComment(
+                localDraftID: "draft-1",
+                path: "Sources/App.swift",
+                originalPath: nil,
+                side: .new,
+                lineRange: 42...42,
+                selectedText: "let value = 1",
+                bodyMarkdown: "Please fix this."
+            )
+        ],
+        decision: .requestChanges,
+        summaryBody: "Requesting changes from Alas.",
+        cwd: Self.cwd
+    )
+
+    let result = try await provider.publishReview(request)
+
+    #expect(result.published.map(\.localDraftID) == ["draft-1"])
+    #expect(result.failed.isEmpty)
+    #expect(result.refreshedRequest.number == 42)
+    let commands = await runner.commands
+    #expect(commands[0].executable == "gh")
+    #expect(commands[0].args == ["api", "graphql", "--input", "-"])
+    #expect(commands[0].stdin?.contains("pullRequest(number:$number){id}") == true)
+    #expect(commands[1].args == ["api", "graphql", "--input", "-"])
+    #expect(commands[1].stdin?.contains("\"event\":\"REQUEST_CHANGES\"") == true)
+    #expect(commands[1].stdin?.contains("\"path\":\"Sources/App.swift\"") == true)
+}
+
+@Test func githubThreadMutationsUseGraphQLAndRefreshPR() async throws {
+    let runner = FakeRunner(results: [
+        ProcessResult(exitCode: 0, stdout: Self.replyMutationOutput, stderr: ""),
+        ProcessResult(exitCode: 0, stdout: Self.prListOutput, stderr: ""),
+        ProcessResult(exitCode: 0, stdout: Self.reviewThreadsOutput, stderr: ""),
+        ProcessResult(exitCode: 0, stdout: Self.resolveThreadMutationOutput, stderr: ""),
+        ProcessResult(exitCode: 0, stdout: Self.prListOutput, stderr: ""),
+        ProcessResult(exitCode: 0, stdout: Self.reviewThreadsOutput, stderr: ""),
+    ])
+    let provider = GitHubCLIProvider(runner: runner)
+    let thread = ReviewThreadSummary(
+        id: "thread-1",
+        author: "reviewer",
+        body: "Please fix this.",
+        url: URL(string: "https://github.com/mrmans0n/alas/pull/42#discussion_r1"),
+        isResolved: false,
+        isActionable: true,
+        location: nil,
+        providerThreadID: "PRRT_thread_1",
+        providerCommentID: "PRRC_comment_1"
+    )
+
+    _ = try await provider.mutateReviewThread(ProviderThreadMutation(
+        remote: Self.remote,
+        reviewRequest: Self.reviewRequest,
+        thread: thread,
+        kind: .reply,
+        bodyMarkdown: "Fixed locally.",
+        cwd: Self.cwd
+    ))
+    _ = try await provider.mutateReviewThread(ProviderThreadMutation(
+        remote: Self.remote,
+        reviewRequest: Self.reviewRequest,
+        thread: thread,
+        kind: .resolve,
+        bodyMarkdown: nil,
+        cwd: Self.cwd
+    ))
+
+    let commands = await runner.commands
+    #expect(commands[0].args.contains(where: { $0.contains("addPullRequestReviewThreadReply") }))
+    #expect(commands[3].args.contains(where: { $0.contains("resolveReviewThread") }))
+}
+```
+
+Add fixtures near existing test fixture constants:
+
+```swift
+static let publishReviewMutationOutput = """
+{"data":{"addPullRequestReview":{"pullRequestReview":{"comments":{"nodes":[{"id":"PRRC_comment_1","url":"https://github.com/mrmans0n/alas/pull/42#discussion_r1","pullRequestReviewThread":{"id":"PRRT_thread_1"}}]}}}}}
+"""
+static let replyMutationOutput = """
+{"data":{"addPullRequestReviewThreadReply":{"comment":{"id":"PRRC_reply_1","url":"https://github.com/mrmans0n/alas/pull/42#discussion_r2"}}}}
+"""
+static let resolveThreadMutationOutput = """
+{"data":{"resolveReviewThread":{"thread":{"id":"PRRT_thread_1","isResolved":true}}}}
+"""
+```
+
+- [ ] **Step 2: Run tests to verify failure**
+
+Run:
+
+```bash
+rtk xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -only-testing:AlasTests/GitHubCLIProviderTests -quiet test
+```
+
+Expected: compile failure for missing provider write implementation or initializer access.
+
+- [ ] **Step 3: Implement GitHub mutations**
+
+In `GitHubCLIProvider.swift`, add:
+
+```swift
+func publishReview(_ request: ProviderReviewPublishRequest) async throws -> ProviderReviewPublishResult {
+    let stdin = try Self.githubReviewInputPayload(
+        pullRequestID: try await pullRequestNodeID(
+            remote: request.remote,
+            number: request.reviewRequest.number,
+            cwd: request.cwd
+        ),
+        decision: request.decision,
+        summaryBody: request.summaryBody,
+        comments: request.comments
+    )
+    let result = try await runner.run(
+        "gh",
+        args: ["api", "graphql", "--input", "-"],
+        cwd: request.cwd,
+        stdin: stdin
+    )
+    guard result.exitCode == 0 else {
+        throw CodeHostProviderError.commandFailed(command: "gh api graphql", stderr: result.stderr)
+    }
+    let published = try Self.parsePublishedReviewComments(result.stdout, originalDrafts: request.comments)
+    let refreshed = try await refreshedReviewRequest(remote: request.remote, request: request.reviewRequest, cwd: request.cwd)
+    return ProviderReviewPublishResult(published: published, failed: [], refreshedRequest: refreshed, warnings: [])
+}
+
+func mutateReviewThread(_ mutation: ProviderThreadMutation) async throws -> ProviderThreadMutationResult {
+    switch mutation.kind {
+    case .reply:
+        guard let threadID = mutation.thread.providerThreadID, let body = mutation.bodyMarkdown, !body.isEmpty else {
+            throw CodeHostProviderError.malformedOutput("GitHub reply requires a provider thread id and non-empty body.")
+        }
+        try await runThreadReply(threadID: threadID, body: body, cwd: mutation.cwd)
+    case .resolve:
+        guard let threadID = mutation.thread.providerThreadID else {
+            throw CodeHostProviderError.malformedOutput("GitHub resolve requires a provider thread id.")
+        }
+        try await runThreadResolution(threadID: threadID, resolve: true, cwd: mutation.cwd)
+    case .unresolve:
+        guard let threadID = mutation.thread.providerThreadID else {
+            throw CodeHostProviderError.malformedOutput("GitHub unresolve requires a provider thread id.")
+        }
+        try await runThreadResolution(threadID: threadID, resolve: false, cwd: mutation.cwd)
+    }
+    let refreshed = try await refreshedReviewRequest(remote: mutation.remote, request: mutation.reviewRequest, cwd: mutation.cwd)
+    return ProviderThreadMutationResult(refreshedRequest: refreshed, providerURL: mutation.thread.url)
+}
+```
+
+Add helper static functions:
+
+```swift
+static func githubReviewEvent(for decision: ProviderReviewDecision) -> String {
+    switch decision {
+    case .comment: "COMMENT"
+    case .approve: "APPROVE"
+    case .requestChanges: "REQUEST_CHANGES"
+    }
+}
+
+static func githubReviewInputPayload(
+    pullRequestID: String,
+    decision: ProviderReviewDecision,
+    summaryBody: String,
+    comments: [ProviderReviewDraftComment]
+) throws -> String {
+    struct Comment: Encodable {
+        let path: String
+        let body: String
+        let line: Int
+        let side: String
+        let startLine: Int?
+    }
+    struct Variables: Encodable {
+        let pullRequestID: String
+        let event: String
+        let body: String
+        let comments: [Comment]
+    }
+    struct Payload: Encodable {
+        let query: String
+        let variables: Variables
+    }
+    let commentPayload = comments.map { comment in
+        Comment(
+            path: comment.path,
+            body: comment.bodyMarkdown,
+            line: comment.lineRange.upperBound,
+            side: comment.side == .old ? "LEFT" : "RIGHT",
+            startLine: comment.lineRange.lowerBound == comment.lineRange.upperBound ? nil : comment.lineRange.lowerBound
+        )
+    }
+    let payload = Payload(
+        query: publishReviewMutation,
+        variables: Variables(
+            pullRequestID: pullRequestID,
+            event: githubReviewEvent(for: decision),
+            body: summaryBody,
+            comments: commentPayload
+        )
+    )
+    let data = try JSONEncoder().encode(payload)
+    return String(decoding: data, as: UTF8.self)
+}
+```
+
+Keep parser/helpers internal static so tests can exercise payload mapping. Use the existing `currentReviewRequest` path to refresh:
+
+```swift
+private func refreshedReviewRequest(remote: CodeHostRemote, request: ReviewRequest, cwd: URL) async throws -> ReviewRequest {
+    let refreshed = try await currentReviewRequest(
+        remote: remote,
+        branch: request.headRefName,
+        headOwner: nil,
+        baseBranch: request.baseRefName,
+        cwd: cwd
+    )
+    return refreshed ?? request
+}
+```
+
+Use this explicit GraphQL flow: first query the PR node id by owner/repo/number, then submit the review with `addPullRequestReview(input:)`. Add this helper in the same task:
+
+```swift
+private func pullRequestNodeID(remote: CodeHostRemote, number: Int, cwd: URL) async throws -> String {
+    let stdin = """
+    {"query":"query($owner:String!,$repo:String!,$number:Int!){repository(owner:$owner,name:$repo){pullRequest(number:$number){id}}}","variables":{"owner":"\(remote.owner)","repo":"\(remote.repository)","number":\(number)}}
+    """
+    let result = try await runner.run("gh", args: ["api", "graphql", "--input", "-"], cwd: cwd, stdin: stdin)
+    guard result.exitCode == 0 else {
+        throw CodeHostProviderError.commandFailed(command: "gh api graphql", stderr: result.stderr)
+    }
+    return try Self.parsePullRequestNodeID(result.stdout)
+}
+```
+
+Update `githubPublishReviewUsesGraphQLPayloadAndRefreshesPR` so `FakeRunner` returns the PR node-id query result before `publishReviewMutationOutput`, and assert the first two commands are:
+
+```swift
+#expect(commands[0].args == ["api", "graphql", "--input", "-"])
+#expect(commands[0].stdin?.contains("pullRequest(number:$number){id}") == true)
+#expect(commands[1].args == ["api", "graphql", "--input", "-"])
+#expect(commands[1].stdin?.contains("\"pullRequestId\":\"PR_node_42\"") == true)
+```
+
+Add fixture:
+
+```swift
+static let pullRequestNodeOutput = """
+{"data":{"repository":{"pullRequest":{"id":"PR_node_42"}}}}
+"""
+```
+
+- [ ] **Step 4: Preserve thread provider IDs during parsing**
+
+When parsing GitHub review threads, set:
+
+```swift
+providerThreadID: node.id
+providerCommentID: firstComment.id
+```
+
+Keep existing `ReviewThreadSummary.id` stable as the same provider thread id or existing id.
+
+- [ ] **Step 5: Run focused tests**
+
+Run:
+
+```bash
+rtk xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -only-testing:AlasTests/GitHubCLIProviderTests -quiet test
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+Run:
+
+```bash
+git add Alas/Sources/Integrations/CodeHost/GitHubCLIProvider.swift AlasTests/Integrations/GitHubCLIProviderTests.swift
+git commit -m "feat(review): add github review mutations"
+```
+
+Expected: commit contains only GitHub provider mutation work and tests.
+
+---
+
+## Task 4: GitLab Provider Mutations
+
+**Files:**
+
+- Modify: `Alas/Sources/Integrations/CodeHost/GitLabCLIProvider.swift`
+- Test: `AlasTests/Integrations/GitLabCLIProviderTests.swift`
+
+- [ ] **Step 1: Write failing GitLab publish/reply/resolve tests**
+
+Add to `GitLabCLIProviderTests`:
+
+```swift
+@Test func gitlabPublishReviewCreatesDiscussionsApprovesAndRefreshesMR() async throws {
+    let runner = FakeRunner(results: [
+        ProcessResult(exitCode: 0, stdout: Self.versionsOutput, stderr: ""),
+        ProcessResult(exitCode: 0, stdout: Self.createDiscussionOutput, stderr: ""),
+        ProcessResult(exitCode: 0, stdout: Self.approveOutput, stderr: ""),
+        ProcessResult(exitCode: 0, stdout: Self.mrViewOutput, stderr: ""),
+        ProcessResult(exitCode: 0, stdout: Self.discussionsOutput, stderr: ""),
+        ProcessResult(exitCode: 0, stdout: Self.pipelineOutput, stderr: ""),
+    ])
+    let provider = GitLabCLIProvider(runner: runner)
+    let request = ProviderReviewPublishRequest(
+        remote: Self.remote,
+        reviewRequest: Self.reviewRequest,
+        comments: [
+            ProviderReviewDraftComment(
+                localDraftID: "draft-1",
+                path: "Sources/App.swift",
+                originalPath: nil,
+                side: .new,
+                lineRange: 24...24,
+                selectedText: nil,
+                bodyMarkdown: "Please fix this."
+            )
+        ],
+        decision: .approve,
+        summaryBody: "Looks good after this note.",
+        cwd: Self.cwd
+    )
+
+    let result = try await provider.publishReview(request)
+
+    #expect(result.published.map(\.localDraftID) == ["draft-1"])
+    let commands = await runner.commands
+    #expect(commands.contains {
+        $0.executable == "glab" && $0.args.prefix(2) == ["api", "projects/:id/merge_requests/42/discussions"]
+    })
+    #expect(commands.contains {
+        $0.executable == "glab" && $0.args.prefix(2) == ["api", "projects/:id/merge_requests/42/approve"]
+    })
+}
+
+@Test func gitlabThreadMutationsUseDiscussionEndpointsAndRefreshMR() async throws {
+    let runner = FakeRunner(results: [
+        ProcessResult(exitCode: 0, stdout: Self.createNoteOutput, stderr: ""),
+        ProcessResult(exitCode: 0, stdout: Self.mrViewOutput, stderr: ""),
+        ProcessResult(exitCode: 0, stdout: Self.discussionsOutput, stderr: ""),
+        ProcessResult(exitCode: 0, stdout: Self.pipelineOutput, stderr: ""),
+        ProcessResult(exitCode: 0, stdout: Self.resolveDiscussionOutput, stderr: ""),
+        ProcessResult(exitCode: 0, stdout: Self.mrViewOutput, stderr: ""),
+        ProcessResult(exitCode: 0, stdout: Self.discussionsOutput, stderr: ""),
+        ProcessResult(exitCode: 0, stdout: Self.pipelineOutput, stderr: ""),
+    ])
+    let provider = GitLabCLIProvider(runner: runner)
+    let thread = ReviewThreadSummary(
+        id: "discussion-1",
+        author: "reviewer",
+        body: "Please fix this.",
+        url: URL(string: "https://gitlab.example.com/platform/mobile/alas/-/merge_requests/42#note_501"),
+        isResolved: false,
+        isActionable: true,
+        location: nil,
+        providerThreadID: "discussion-1",
+        providerCommentID: "501"
+    )
+
+    _ = try await provider.mutateReviewThread(ProviderThreadMutation(
+        remote: Self.remote,
+        reviewRequest: Self.reviewRequest,
+        thread: thread,
+        kind: .reply,
+        bodyMarkdown: "Fixed locally.",
+        cwd: Self.cwd
+    ))
+    _ = try await provider.mutateReviewThread(ProviderThreadMutation(
+        remote: Self.remote,
+        reviewRequest: Self.reviewRequest,
+        thread: thread,
+        kind: .resolve,
+        bodyMarkdown: nil,
+        cwd: Self.cwd
+    ))
+
+    let commands = await runner.commands
+    #expect(commands.contains { $0.args.contains("projects/:id/merge_requests/42/discussions/discussion-1/notes") })
+    #expect(commands.contains { $0.args.contains("projects/:id/merge_requests/42/discussions/discussion-1") })
+}
+```
+
+Add fixtures:
+
+```swift
+static let versionsOutput = """
+{"diff_refs":{"base_sha":"base123","start_sha":"start123","head_sha":"head123"}}
+"""
+static let createDiscussionOutput = """
+{"id":"discussion-1","notes":[{"id":501,"web_url":"https://gitlab.example.com/platform/mobile/alas/-/merge_requests/42#note_501"}]}
+"""
+static let createNoteOutput = """
+{"id":502,"web_url":"https://gitlab.example.com/platform/mobile/alas/-/merge_requests/42#note_502"}
+"""
+static let resolveDiscussionOutput = """
+{"id":"discussion-1","resolved":true}
+"""
+static let approveOutput = """
+{"id":42,"approved":true}
+"""
+```
+
+- [ ] **Step 2: Run tests to verify failure**
+
+Run:
+
+```bash
+rtk xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -only-testing:AlasTests/GitLabCLIProviderTests -quiet test
+```
+
+Expected: compile failure for missing GitLab mutation implementation.
+
+- [ ] **Step 3: Implement GitLab mutations**
+
+In `GitLabCLIProvider.swift`, add:
+
+```swift
+func publishReview(_ request: ProviderReviewPublishRequest) async throws -> ProviderReviewPublishResult {
+    let diffRefs = try await mergeRequestDiffRefs(remote: request.remote, request: request.reviewRequest, cwd: request.cwd)
+    var published: [ProviderReviewPublishedComment] = []
+    var failed: [ProviderReviewFailedComment] = []
+
+    for comment in request.comments {
+        do {
+            let mapping = try await createDiscussion(remote: request.remote, request: request.reviewRequest, comment: comment, diffRefs: diffRefs, cwd: request.cwd)
+            published.append(mapping)
+        } catch {
+            failed.append(ProviderReviewFailedComment(localDraftID: comment.localDraftID, message: error.localizedDescription))
+        }
+    }
+
+    if request.decision == .approve {
+        try await approveMergeRequest(remote: request.remote, request: request.reviewRequest, cwd: request.cwd)
+    } else if request.decision == .requestChanges {
+        try await createRequestChangesNote(remote: request.remote, request: request.reviewRequest, body: request.summaryBody, cwd: request.cwd)
+    }
+
+    let refreshed = try await reviewRequestDetails(remote: request.remote, request: request.reviewRequest, cwd: request.cwd)
+    let threads = (try? await unresolvedDiscussions(remote: request.remote, request: refreshed, cwd: request.cwd)) ?? []
+    let checks = (try? await checks(remote: request.remote, request: refreshed, cwd: request.cwd)) ?? []
+    return ProviderReviewPublishResult(
+        published: published,
+        failed: failed,
+        refreshedRequest: Self.withEnrichment(threads: threads, checks: checks, on: refreshed),
+        warnings: []
+    )
+}
+
+func mutateReviewThread(_ mutation: ProviderThreadMutation) async throws -> ProviderThreadMutationResult {
+    guard let discussionID = mutation.thread.providerThreadID else {
+        throw CodeHostProviderError.malformedOutput("GitLab thread mutation requires a discussion id.")
+    }
+    switch mutation.kind {
+    case .reply:
+        guard let body = mutation.bodyMarkdown, !body.isEmpty else {
+            throw CodeHostProviderError.malformedOutput("GitLab reply requires a non-empty body.")
+        }
+        try await createDiscussionNote(remote: mutation.remote, request: mutation.reviewRequest, discussionID: discussionID, body: body, cwd: mutation.cwd)
+    case .resolve:
+        try await setDiscussionResolved(remote: mutation.remote, request: mutation.reviewRequest, discussionID: discussionID, resolved: true, cwd: mutation.cwd)
+    case .unresolve:
+        try await setDiscussionResolved(remote: mutation.remote, request: mutation.reviewRequest, discussionID: discussionID, resolved: false, cwd: mutation.cwd)
+    }
+
+    let refreshed = try await reviewRequestDetails(remote: mutation.remote, request: mutation.reviewRequest, cwd: mutation.cwd)
+    let threads = (try? await unresolvedDiscussions(remote: mutation.remote, request: refreshed, cwd: mutation.cwd)) ?? []
+    let checks = (try? await checks(remote: mutation.remote, request: refreshed, cwd: mutation.cwd)) ?? []
+    return ProviderThreadMutationResult(
+        refreshedRequest: Self.withEnrichment(threads: threads, checks: checks, on: refreshed),
+        providerURL: mutation.thread.url
+    )
+}
+```
+
+Add helpers:
+
+```swift
+struct GitLabDiffRefs: Equatable {
+    let baseSHA: String
+    let startSHA: String
+    let headSHA: String
+}
+
+static func gitLabPositionPayload(comment: ProviderReviewDraftComment, diffRefs: GitLabDiffRefs) -> [String: String] {
+    var payload = [
+        "position[position_type]": "text",
+        "position[base_sha]": diffRefs.baseSHA,
+        "position[start_sha]": diffRefs.startSHA,
+        "position[head_sha]": diffRefs.headSHA,
+        "position[new_path]": comment.path,
+        "position[old_path]": comment.originalPath ?? comment.path,
+    ]
+    if comment.side == .old {
+        payload["position[old_line]"] = "\(comment.lineRange.upperBound)"
+    } else {
+        payload["position[new_line]"] = "\(comment.lineRange.upperBound)"
+    }
+    return payload
+}
+```
+
+Use `glab api` endpoint strings exactly:
+
+- `projects/:id/merge_requests/<number>/versions`
+- `projects/:id/merge_requests/<number>/discussions`
+- `projects/:id/merge_requests/<number>/discussions/<discussionID>/notes`
+- `projects/:id/merge_requests/<number>/discussions/<discussionID>`
+- `projects/:id/merge_requests/<number>/approve`
+- `projects/:id/merge_requests/<number>/notes`
+
+- [ ] **Step 4: Preserve provider IDs during discussion parsing**
+
+When parsing GitLab discussions, set:
+
+```swift
+providerThreadID: discussion.id
+providerCommentID: firstNonSystemNote.id.map(String.init)
+```
+
+Keep `ReviewThreadSummary.id` as the discussion id.
+
+- [ ] **Step 5: Run focused tests**
+
+Run:
+
+```bash
+rtk xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -only-testing:AlasTests/GitLabCLIProviderTests -quiet test
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+Run:
+
+```bash
+git add Alas/Sources/Integrations/CodeHost/GitLabCLIProvider.swift AlasTests/Integrations/GitLabCLIProviderTests.swift
+git commit -m "feat(review): add gitlab review mutations"
+```
+
+Expected: commit contains only GitLab provider mutation work and tests.
+
+---
+
+## Task 5: Provider Review Mutation Controller
+
+**Files:**
+
+- Create: `Alas/Sources/Center/ReviewWorkspace/ProviderReviewMutationController.swift`
+- Modify: `Alas/Sources/Center/ReviewWorkspace/ReviewSessionTabView.swift`
+- Test: `AlasTests/ReviewSessionTabViewTests.swift`
+
+- [ ] **Step 1: Write failing controller tests**
+
+Add to `ReviewSessionTabViewTests`:
+
+```swift
+@Test @MainActor func providerMutationControllerPublishesDraftsAndMarksResults() async throws {
+    let sessionID = ReviewDraftSessionID.reviewRequest(
+        worktreeID: "wt",
+        provider: .github,
+        host: "github.com",
+        repositorySlug: "mrmans0n/alas",
+        number: 527
+    )
+    let directory = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString, isDirectory: true)
+    let store = ReviewDraftCommentStore(store: PersistenceStore(), url: directory.appendingPathComponent("drafts.json"))
+    let draftController = ReviewDraftCommentController(sessionID: sessionID, store: store, now: { Date(timeIntervalSince1970: 200) })
+    try draftController.load()
+    try draftController.add(
+        anchor: DiffReviewLineAnchor(path: "Sources/App.swift", side: .new, line: 12, rowIndex: 0, selectedText: "let value = 1"),
+        fileID: DiffReviewFileID(namespace: "github", path: "Sources/App.swift"),
+        bodyMarkdown: "Please fix this."
+    )
+    let added = try #require(draftController.comments.single)
+
+    let provider = FakeProviderReviewMutator(
+        result: ProviderReviewPublishResult(
+            published: [
+                ProviderReviewPublishedComment(
+                    localDraftID: added.id,
+                    providerThreadID: "thread-1",
+                    providerCommentID: "comment-1",
+                    providerURL: URL(string: "https://github.com/mrmans0n/alas/pull/527#discussion_r1")
+                )
+            ],
+            failed: [],
+            refreshedRequest: Self.reviewRequest(provider: .github),
+            warnings: []
+        )
+    )
+    let controller = ProviderReviewMutationController(
+        provider: provider,
+        draftController: draftController,
+        now: { Date(timeIntervalSince1970: 300) }
+    )
+
+    let outcome = try await controller.publishReview(
+        remote: Self.remote(kind: .github),
+        reviewRequest: Self.reviewRequest(provider: .github),
+        decision: .comment,
+        summaryBody: "Review from Alas",
+        cwd: URL(fileURLWithPath: "/repo")
+    )
+
+    #expect(outcome.refreshedRequest.number == 527)
+    let updated = try #require(draftController.comments.single)
+    #expect(updated.providerPublish?.threadID == "thread-1")
+    #expect(updated.providerPublish?.publishedAt == Date(timeIntervalSince1970: 300))
+}
+
+@Test @MainActor func providerMutationControllerKeepsFailedDraftsActiveWithError() async throws {
+    let sessionID = ReviewDraftSessionID.reviewRequest(
+        worktreeID: "wt",
+        provider: .gitlab,
+        host: "gitlab.example.com",
+        repositorySlug: "platform/alas",
+        number: 42
+    )
+    let directory = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString, isDirectory: true)
+    let store = ReviewDraftCommentStore(store: PersistenceStore(), url: directory.appendingPathComponent("drafts.json"))
+    let draftController = ReviewDraftCommentController(sessionID: sessionID, store: store, now: { Date(timeIntervalSince1970: 200) })
+    try draftController.load()
+    try draftController.add(
+        anchor: DiffReviewLineAnchor(path: "Sources/App.swift", side: .new, line: 12, rowIndex: 0, selectedText: nil),
+        fileID: DiffReviewFileID(namespace: "gitlab", path: "Sources/App.swift"),
+        bodyMarkdown: "Please fix this."
+    )
+    let added = try #require(draftController.comments.single)
+
+    let provider = FakeProviderReviewMutator(
+        result: ProviderReviewPublishResult(
+            published: [],
+            failed: [ProviderReviewFailedComment(localDraftID: added.id, message: "line is not commentable")],
+            refreshedRequest: Self.reviewRequest(provider: .gitlab),
+            warnings: []
+        )
+    )
+    let controller = ProviderReviewMutationController(
+        provider: provider,
+        draftController: draftController,
+        now: { Date(timeIntervalSince1970: 300) }
+    )
+
+    _ = try await controller.publishReview(
+        remote: Self.remote(kind: .gitlab),
+        reviewRequest: Self.reviewRequest(provider: .gitlab),
+        decision: .comment,
+        summaryBody: "Review from Alas",
+        cwd: URL(fileURLWithPath: "/repo")
+    )
+
+    let updated = try #require(draftController.comments.single)
+    #expect(updated.providerPublish == nil)
+    #expect(updated.providerError?.message == "line is not commentable")
+    #expect(updated.state == .active)
+}
+```
+
+Add a local fake:
+
+```swift
+private struct FakeProviderReviewMutator: CodeHostProvider {
+    let kind: CodeHostKind = .github
+    let result: ProviderReviewPublishResult
+
+    func isAvailable() async -> Bool { true }
+    func isAuthenticated(remote: CodeHostRemote, cwd: URL) async -> Bool { true }
+    func currentReviewRequest(remote: CodeHostRemote, branch: String, headOwner: String?, baseBranch: String, cwd: URL) async throws -> ReviewRequest? { result.refreshedRequest }
+    func createReviewRequest(remote: CodeHostRemote, branch: String, headOwner: String?, baseBranch: String, title: String, body: String, isDraft: Bool, cwd: URL) async throws -> URL { result.refreshedRequest.url }
+    func checks(remote: CodeHostRemote, request: ReviewRequest, cwd: URL) async throws -> [ReviewCheck] { [] }
+    func reviewDiff(remote: CodeHostRemote, request: ReviewRequest, cwd: URL) async throws -> String { "" }
+    func failedCheckEvidence(remote: CodeHostRemote, request: ReviewRequest, cwd: URL) async throws -> [ReviewEvidenceItem] { [] }
+    func checkEvidenceDetail(remote: CodeHostRemote, request: ReviewRequest, item: ReviewEvidenceItem, cwd: URL) async throws -> ReviewEvidenceDetail {
+        throw CodeHostProviderError.malformedOutput("FakeProviderReviewMutator does not provide check evidence details.")
+    }
+    func feedbackEvidence(remote: CodeHostRemote, request: ReviewRequest, cwd: URL) async throws -> [ReviewEvidenceItem] { [] }
+    func feedbackEvidenceDetail(remote: CodeHostRemote, request: ReviewRequest, item: ReviewEvidenceItem, cwd: URL) async throws -> ReviewEvidenceDetail {
+        throw CodeHostProviderError.malformedOutput("FakeProviderReviewMutator does not provide feedback evidence details.")
+    }
+    func rerunFailedChecks(remote: CodeHostRemote, branch: String, headSHA: String, request: ReviewRequest?, cwd: URL) async throws {}
+    func publishReview(_ request: ProviderReviewPublishRequest) async throws -> ProviderReviewPublishResult { result }
+}
+```
+
+- [ ] **Step 2: Run tests to verify failure**
+
+Run:
+
+```bash
+rtk xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -only-testing:AlasTests/ReviewSessionTabViewTests -quiet test
+```
+
+Expected: compile failure for missing `ProviderReviewMutationController`.
+
+- [ ] **Step 3: Implement controller**
+
+Create `ProviderReviewMutationController.swift`:
+
+```swift
+import Foundation
+
+@MainActor
+struct ProviderReviewMutationController {
+    let provider: any CodeHostProvider
+    let draftController: ReviewDraftCommentController
+    let now: () -> Date
+
+    func publishReview(
+        remote: CodeHostRemote,
+        reviewRequest: ReviewRequest,
+        decision: ProviderReviewDecision,
+        summaryBody: String,
+        cwd: URL
+    ) async throws -> ProviderReviewPublishResult {
+        let comments = draftController.activeUnpublishedComments.compactMap(ProviderReviewDraftComment.init(localDraft:))
+        let request = ProviderReviewPublishRequest(
+            remote: remote,
+            reviewRequest: reviewRequest,
+            comments: comments,
+            decision: decision,
+            summaryBody: summaryBody,
+            cwd: cwd
+        )
+
+        let result = try await provider.publishReview(request)
+        for published in result.published {
+            try draftController.markPublished(
+                commentID: published.localDraftID,
+                publish: ReviewDraftProviderPublish(
+                    provider: remote.kind,
+                    host: remote.host,
+                    repositorySlug: remote.repositorySlug,
+                    reviewNumber: reviewRequest.number,
+                    threadID: published.providerThreadID,
+                    commentID: published.providerCommentID,
+                    url: published.providerURL,
+                    publishedAt: now()
+                )
+            )
+        }
+        for failed in result.failed {
+            try draftController.recordProviderError(
+                commentID: failed.localDraftID,
+                error: ReviewDraftProviderError(
+                    provider: remote.kind,
+                    message: failed.message,
+                    occurredAt: now()
+                )
+            )
+        }
+        return result
+    }
+
+    func mutateThread(_ mutation: ProviderThreadMutation) async throws -> ProviderThreadMutationResult {
+        try await provider.mutateReviewThread(mutation)
+    }
+}
+```
+
+- [ ] **Step 4: Wire controller factory in `ReviewSessionTabView` without UI yet**
+
+Add private helper methods in `ReviewSessionTabView`:
+
+```swift
+private func providerForLoadedReviewSession(_ loaded: ReviewSessionLoadedContext) -> (any CodeHostProvider)? {
+    guard let appState else { return nil }
+    guard let request = loaded.session.reviewRequest else { return nil }
+    return appState.codeHostProviders.provider(for: request.provider)
+}
+
+private func makeProviderMutationController(for loaded: ReviewSessionLoadedContext) -> ProviderReviewMutationController? {
+    guard let provider = providerForLoadedReviewSession(loaded),
+          let draftCommentController
+    else { return nil }
+    return ProviderReviewMutationController(
+        provider: provider,
+        draftController: draftCommentController,
+        now: now
+    )
+}
+```
+
+Add explicit provider context to the loaded review-session context in this task. Modify `ReviewSessionLoadedContext`:
+
+```swift
+struct ReviewSessionProviderContext: Equatable, Sendable {
+    let remote: CodeHostRemote
+    let reviewRequest: ReviewRequest
+}
+
+struct ReviewSessionLoadedContext {
+    let session: DiffReviewLoadedSession
+    let feedbackTarget: ReviewFeedbackTarget
+    let providerContext: ReviewSessionProviderContext?
+}
+```
+
+Update `ReviewSessionLoader.load(target:)` so local changes, commits, ranges, branches, and draft PR/MR sessions pass `providerContext: nil`. For `.reviewRequest`, populate `providerContext` from the target payload and the loaded `ReviewRequest` returned by `ReviewRequestDiffLoader`; if the existing loader closure returns only `DiffReviewLoadedSession`, change that closure type to return:
+
+```swift
+struct ReviewSessionProviderLoadedSession {
+    let loadedSession: DiffReviewLoadedSession
+    let providerContext: ReviewSessionProviderContext
+}
+```
+
+and adapt only the `.reviewRequest` production/test loaders.
+
+- [ ] **Step 5: Run focused tests and regenerate project**
+
+Run:
+
+```bash
+xcodegen
+rtk xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -only-testing:AlasTests/ReviewSessionTabViewTests -quiet test
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+Run:
+
+```bash
+git add Alas/Sources/Center/ReviewWorkspace/ProviderReviewMutationController.swift Alas/Sources/Center/ReviewWorkspace/ReviewSessionTabView.swift AlasTests/ReviewSessionTabViewTests.swift Alas.xcodeproj
+git commit -m "feat(review): add provider mutation controller"
+```
+
+Expected: commit contains controller and minimal wiring only.
+
+---
+
+## Task 6: Provider Publish Confirmation UI
+
+**Files:**
+
+- Create: `Alas/Sources/Center/ReviewWorkspace/ProviderReviewPublishConfirmationView.swift`
+- Modify: `Alas/Sources/Center/ReviewWorkspace/ReviewDraftSummaryRail.swift`
+- Modify: `Alas/Sources/Center/ReviewWorkspace/ReviewDraftCommentActions.swift`
+- Modify: `Alas/Sources/Center/DiffReview/DiffReviewFileSection.swift`
+- Test: `AlasTests/DiffReviewSurfaceTests.swift`
+- Test: `AlasTests/ReviewSessionTabViewTests.swift`
+
+- [ ] **Step 1: Write failing UI action tests**
+
+Add to `DiffReviewSurfaceTests`:
+
+```swift
+@Test @MainActor func localDraftCardShowsPublishActionWhenAvailable() throws {
+    let comment = draftComment(
+        id: "draft-publish",
+        fileID: DiffReviewFileID(namespace: "github", path: "Sources/App.swift"),
+        path: "Sources/App.swift",
+        side: .new,
+        startLine: 2
+    )
+    var publishedID: String?
+    var layout = DiffLayoutMode.stacked
+    var wrap = false
+    var whitespace = false
+    var actions = ReviewDraftCommentActions()
+    actions.availability = { _ in
+        ReviewDraftCommentActionAvailability(
+            canEdit: false,
+            canDelete: false,
+            canResolve: false,
+            canDismiss: false,
+            canCopyPrompt: false,
+            canShowSendToAgent: false,
+            canSendToAgent: false,
+            canPublishProvider: true
+        )
+    }
+    actions.publishProvider = { comment in
+        publishedID = comment.id
+    }
+
+    let view = DiffReviewFileSection(
+        file: DiffReviewFileSectionModel(summary: summary(path: "Sources/App.swift"), parsedDiff: parsedDiff(), displayModel: displayModel(), placeholderMessage: nil, openFile: nil),
+        draftComments: [comment],
+        layoutMode: Binding(get: { layout }, set: { layout = $0 }),
+        wrapLines: Binding(get: { wrap }, set: { wrap = $0 }),
+        showWhitespace: Binding(get: { whitespace }, set: { whitespace = $0 }),
+        codeFontFamily: "",
+        codeFontSize: 13,
+        showsSourceBadge: false,
+        draftCommentActions: actions
+    )
+    .environment(\.theme, theme())
+
+    let controller = host(view, width: 900, height: 500)
+    #expect(pressAccessibilityElement(withAccessibilityIdentifier: "diff-review-draft-comment-publish-draft-publish", in: controller.view))
+    #expect(publishedID == "draft-publish")
+}
+```
+
+Add to `ReviewSessionTabViewTests`:
+
+```swift
+@Test @MainActor func publishConfirmationListsProviderDecisionAndCommentCount() {
+    let view = ProviderReviewPublishConfirmationView(
+        providerName: "GitHub",
+        reviewIdentity: "PR #527",
+        commentCount: 2,
+        unpublishableMessages: ["Sources/Old.swift: line is outdated"],
+        selectedDecision: .constant(.comment),
+        isPublishing: false,
+        errorMessage: nil,
+        onCancel: {},
+        onConfirm: {}
+    )
+    .environment(\.theme, theme())
+
+    let controller = host(view, width: 420, height: 260)
+
+    #expect(text(in: controller.view, contains: "GitHub"))
+    #expect(text(in: controller.view, contains: "PR #527"))
+    #expect(text(in: controller.view, contains: "2 comments"))
+    #expect(text(in: controller.view, contains: "line is outdated"))
+}
+```
+
+- [ ] **Step 2: Run tests to verify failure**
+
+Run:
+
+```bash
+rtk xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -only-testing:AlasTests/DiffReviewSurfaceTests -only-testing:AlasTests/ReviewSessionTabViewTests -quiet test
+```
+
+Expected: compile failures for new action availability and confirmation view.
+
+- [ ] **Step 3: Extend draft action API**
+
+In `ReviewDraftCommentActions.swift`, add:
+
+```swift
+var canPublishProvider: Bool
+```
+
+to `ReviewDraftCommentActionAvailability`, defaulting false.
+
+Add action:
+
+```swift
+var publishProvider: (ReviewDraftComment) -> Void = { _ in }
+```
+
+Update all availability construction sites with `canPublishProvider`.
+
+- [ ] **Step 4: Render per-comment publish**
+
+In `ReviewDraftCommentCard.actionRow` inside `DiffReviewFileSection.swift`, add:
+
+```swift
+if availability.canPublishProvider {
+    actionButton(id: "publish", title: "Publish") {
+        actions.publishProvider(comment)
+    }
+}
+```
+
+Ensure the action button accessibility id becomes:
+
+```swift
+"diff-review-draft-comment-publish-\(comment.id)"
+```
+
+by following the existing action button id naming pattern.
+
+- [ ] **Step 5: Create confirmation view**
+
+Create `ProviderReviewPublishConfirmationView.swift`:
+
+```swift
+import SwiftUI
+
+struct ProviderReviewPublishConfirmationView: View {
+    let providerName: String
+    let reviewIdentity: String
+    let commentCount: Int
+    let unpublishableMessages: [String]
+    @Binding var selectedDecision: ProviderReviewDecision
+    let isPublishing: Bool
+    let errorMessage: String?
+    let onCancel: () -> Void
+    let onConfirm: () -> Void
+
+    @Environment(\.theme) private var theme
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            Text("Publish review")
+                .font(.system(size: 15, weight: .semibold))
+                .foregroundColor(theme.color("fg"))
+            Text("\(providerName) \(reviewIdentity)")
+                .font(.system(size: 12, weight: .medium))
+                .foregroundColor(theme.color("fg-muted"))
+            Picker("Decision", selection: $selectedDecision) {
+                Text("Comment").tag(ProviderReviewDecision.comment)
+                Text("Approve").tag(ProviderReviewDecision.approve)
+                Text("Request changes").tag(ProviderReviewDecision.requestChanges)
+            }
+            .pickerStyle(.segmented)
+            Text("\(commentCount) \(commentCount == 1 ? "comment" : "comments")")
+                .font(.system(size: 12))
+                .foregroundColor(theme.color("fg"))
+            if !unpublishableMessages.isEmpty {
+                VStack(alignment: .leading, spacing: 4) {
+                    ForEach(unpublishableMessages, id: \.self) { message in
+                        Text(message)
+                            .font(.system(size: 11))
+                            .foregroundColor(theme.color("warn"))
+                    }
+                }
+            }
+            if let errorMessage {
+                Text(errorMessage)
+                    .font(.system(size: 11))
+                    .foregroundColor(theme.color("del"))
+            }
+            HStack {
+                Spacer()
+                Button("Cancel", action: onCancel)
+                    .disabled(isPublishing)
+                Button(isPublishing ? "Publishing..." : "Publish", action: onConfirm)
+                    .disabled(isPublishing)
+                    .keyboardShortcut(.defaultAction)
+            }
+        }
+        .padding(14)
+        .frame(width: 420)
+        .background(theme.color("bg-1"))
+        .accessibilityIdentifier("provider-review-publish-confirmation")
+    }
+}
+```
+
+- [ ] **Step 6: Add summary rail publish affordance**
+
+In `ReviewDraftSummaryRail.swift`, add a `Publish review` button near copy/send actions when an injected availability flag is true. If a new action container is needed, add it to `ReviewDraftCommentActions`:
+
+```swift
+var publishReview: () -> Void = {}
+var canPublishReview: () -> Bool = { false }
+```
+
+Render with accessibility id:
+
+```swift
+"review-draft-summary-publish-review"
+```
+
+- [ ] **Step 7: Run focused UI tests**
+
+Run:
+
+```bash
+xcodegen
+rtk xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -only-testing:AlasTests/DiffReviewSurfaceTests -only-testing:AlasTests/ReviewSessionTabViewTests -quiet test
+```
+
+Expected: PASS.
+
+- [ ] **Step 8: Commit**
+
+Run:
+
+```bash
+git add Alas/Sources/Center/ReviewWorkspace/ProviderReviewPublishConfirmationView.swift Alas/Sources/Center/ReviewWorkspace/ReviewDraftCommentActions.swift Alas/Sources/Center/ReviewWorkspace/ReviewDraftSummaryRail.swift Alas/Sources/Center/DiffReview/DiffReviewFileSection.swift AlasTests/DiffReviewSurfaceTests.swift AlasTests/ReviewSessionTabViewTests.swift Alas.xcodeproj
+git commit -m "feat(review): add provider publish actions"
+```
+
+Expected: commit contains UI action surfaces and confirmation view only.
+
+---
+
+## Task 7: Review Session Provider Wiring
+
+**Files:**
+
+- Modify: `Alas/Sources/Center/ReviewWorkspace/ReviewSessionTabView.swift`
+- Modify: `Alas/Sources/Center/DiffReview/DiffReviewInlineFeedbackActions.swift`
+- Modify: `Alas/Sources/Center/DiffReview/DiffReviewFileSection.swift`
+- Test: `AlasTests/ReviewSessionTabViewTests.swift`
+- Test: `AlasTests/DiffReviewSurfaceTests.swift`
+
+- [ ] **Step 1: Write failing session wiring tests**
+
+Add to `ReviewSessionTabViewTests`:
+
+```swift
+@Test @MainActor func reviewSessionShowsPublishReviewForProviderContextWithDrafts() throws {
+    let record = reviewRequestRecord(provider: .github)
+    let loaded = loadedReviewRequestContext(provider: .github)
+    let draft = draftComment(id: "draft-1", sessionID: record.target.draftSessionID, fileID: loaded.session.files[0].id)
+    let draftStore = seededDraftStore(comments: [draft])
+
+    let view = ReviewSessionTabView.testView(
+        record: record,
+        loaded: loaded,
+        draftCommentStore: draftStore,
+        provider: FakeProviderReviewMutator(result: ProviderReviewPublishResult(
+            published: [],
+            failed: [],
+            refreshedRequest: reviewRequest(provider: .github),
+            warnings: []
+        ))
+    )
+    .environment(\.theme, theme())
+
+    let controller = host(view, width: 1200, height: 720)
+
+    #expect(subview(withAccessibilityIdentifier: "review-draft-summary-publish-review", in: controller.view) != nil)
+}
+```
+
+Add to `DiffReviewSurfaceTests`:
+
+```swift
+@Test @MainActor func providerFeedbackCardShowsReplyResolveAndUnresolveActions() throws {
+    let unresolved = DiffReviewInlineFeedback(
+        id: "thread-1",
+        providerName: "GitHub",
+        author: "reviewer",
+        bodyPreview: "Please fix this.",
+        status: .actionable,
+        providerURL: nil,
+        anchor: DiffReviewInlineFeedbackAnchor(path: "Sources/App.swift", line: 2, side: .new),
+        evidenceItemID: "thread-1"
+    )
+    var replied = false
+    var resolved = false
+    var actions = DiffReviewInlineFeedbackActions()
+    actions.availability = { _, _ in
+        DiffReviewInlineFeedbackActionAvailability(
+            canOpenProvider: false,
+            canCopyContext: false,
+            canSendToAgent: false,
+            canReplyProvider: true,
+            canResolveProvider: true,
+            canUnresolveProvider: false
+        )
+    }
+    actions.replyProvider = { _, _, body in
+        replied = body == "Done"
+    }
+    actions.resolveProvider = { _, _ in
+        resolved = true
+    }
+
+    let summary = DiffReviewFileSummary(
+        path: "Sources/App.swift",
+        namespace: "github",
+        groupID: nil,
+        groupTitle: nil,
+        status: .modified,
+        additions: 1,
+        deletions: 0,
+        isRenderable: true,
+        originalPath: nil
+    )
+    var layout = DiffLayoutMode.stacked
+    var wrap = false
+    var whitespace = false
+    let view = DiffReviewFileSection(
+        file: DiffReviewFileSectionModel(
+            summary: summary,
+            parsedDiff: parsedDiff(),
+            displayModel: displayModel(),
+            placeholderMessage: nil,
+            openFile: nil
+        ),
+        inlineFeedback: [unresolved],
+        inlineFeedbackActions: actions,
+        layoutMode: Binding(get: { layout }, set: { layout = $0 }),
+        wrapLines: Binding(get: { wrap }, set: { wrap = $0 }),
+        showWhitespace: Binding(get: { whitespace }, set: { whitespace = $0 }),
+        codeFontFamily: "",
+        codeFontSize: 13,
+        showsSourceBadge: false
+    )
+    .environment(\.theme, theme())
+
+    let controller = host(view, width: 900, height: 520)
+
+    #expect(subview(withAccessibilityIdentifier: "diff-review-inline-feedback-action-reply-thread-1", in: controller.view) != nil)
+    #expect(pressAccessibilityElement(withAccessibilityIdentifier: "diff-review-inline-feedback-action-resolve-thread-1", in: controller.view))
+    #expect(resolved)
+    DiffReviewInlineFeedbackCardInteraction.reply(unresolved, body: "Done") { item, body in
+        actions.replyProvider(item, summary, body)
+    }
+    #expect(replied)
+}
+```
+
+- [ ] **Step 2: Run tests to verify failure**
+
+Run:
+
+```bash
+rtk xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -only-testing:AlasTests/ReviewSessionTabViewTests -only-testing:AlasTests/DiffReviewSurfaceTests -quiet test
+```
+
+Expected: compile or assertion failure for missing wiring/actions.
+
+- [ ] **Step 3: Extend inline feedback actions**
+
+In `DiffReviewInlineFeedbackActions.swift`, extend availability:
+
+```swift
+var canReplyProvider: Bool
+var canResolveProvider: Bool
+var canUnresolveProvider: Bool
+```
+
+Add action closures:
+
+```swift
+var replyProvider: (DiffReviewInlineFeedback, DiffReviewFileSummary, String) -> Void = { _, _, _ in }
+var resolveProvider: (DiffReviewInlineFeedback, DiffReviewFileSummary) -> Void = { _, _ in }
+var unresolveProvider: (DiffReviewInlineFeedback, DiffReviewFileSummary) -> Void = { _, _ in }
+```
+
+Update `.none` and all construction sites.
+
+- [ ] **Step 4: Render provider feedback action buttons**
+
+In `DiffReviewInlineFeedbackCard.actionRow`, render:
+
+```swift
+if availability.canReplyProvider {
+    actionButton(id: "reply", title: "Reply") {
+        isReplying = true
+        replyBody = ""
+    }
+}
+if availability.canResolveProvider {
+    actionButton(id: "resolve", title: "Resolve") {
+        actions.resolveProvider(item, file)
+    }
+}
+if availability.canUnresolveProvider {
+    actionButton(id: "unresolve", title: "Unresolve") {
+        actions.unresolveProvider(item, file)
+    }
+}
+```
+
+Add minimal inline reply editor state:
+
+```swift
+@State private var isReplying = false
+@State private var replyBody = ""
+```
+
+When saving:
+
+```swift
+let body = replyBody.trimmingCharacters(in: .whitespacesAndNewlines)
+guard !body.isEmpty else { return }
+actions.replyProvider(item, file, body)
+isReplying = false
+replyBody = ""
+```
+
+Accessibility ids:
+
+- `diff-review-inline-feedback-reply-<id>`
+- `diff-review-inline-feedback-resolve-<id>`
+- `diff-review-inline-feedback-unresolve-<id>`
+- `diff-review-inline-feedback-reply-save-<id>`
+
+- [ ] **Step 5: Wire provider actions in `ReviewSessionTabView`**
+
+Add state:
+
+```swift
+@State private var providerPublishConfirmation: ProviderReviewPublishConfirmationState?
+@State private var providerPublishError: String?
+@State private var isProviderPublishing = false
+@State private var selectedProviderDecision: ProviderReviewDecision = .comment
+```
+
+Add state type near the view:
+
+```swift
+struct ProviderReviewPublishConfirmationState: Equatable {
+    let commentID: String?
+    let providerName: String
+    let reviewIdentity: String
+    let commentCount: Int
+    let unpublishableMessages: [String]
+}
+```
+
+Extend `draftCommentActions()` so:
+
+- `availability.canPublishProvider` is true only for provider sessions, active unpublished drafts, and commentable line anchors.
+- `publishProvider(comment)` opens confirmation for that comment.
+- `canPublishReview()` is true when provider session has active unpublished drafts.
+- `publishReview()` opens confirmation for all active unpublished drafts.
+
+Extend `DiffReviewInlineFeedbackActions` produced by the tab so:
+
+- reply/resolve/unresolve visibility follows provider capabilities and provider thread id presence
+- actions call `ProviderReviewMutationController.mutateThread`
+- after mutation, update `loaded` with the result's refreshed request/session, preserving current selected file
+
+Use an overlay/sheet/popover for `ProviderReviewPublishConfirmationView`. In the confirm callback, call `ProviderReviewMutationController.publishReview`.
+
+- [ ] **Step 6: Refresh loaded session from refreshed provider request**
+
+Add helper:
+
+```swift
+private func applyRefreshedReviewRequest(_ request: ReviewRequest) async {
+    guard var currentLoaded = loaded else { return }
+    currentLoaded = currentLoaded.replacingReviewRequest(request)
+    loaded = currentLoaded
+}
+```
+
+Add replacement helpers for refreshed provider state:
+
+```swift
+extension ReviewSessionLoadedContext {
+    func replacingReviewRequest(_ request: ReviewRequest) -> ReviewSessionLoadedContext {
+        ReviewSessionLoadedContext(
+            session: session.replacingReviewRequest(request),
+            feedbackTarget: feedbackTarget
+        )
+    }
+}
+```
+
+Add equivalent `DiffReviewLoadedSession.replacingReviewRequest`.
+
+- [ ] **Step 7: Run focused tests**
+
+Run:
+
+```bash
+rtk xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -only-testing:AlasTests/ReviewSessionTabViewTests -only-testing:AlasTests/DiffReviewSurfaceTests -quiet test
+```
+
+Expected: PASS.
+
+- [ ] **Step 8: Commit**
+
+Run:
+
+```bash
+git add Alas/Sources/Center/ReviewWorkspace/ReviewSessionTabView.swift Alas/Sources/Center/DiffReview/DiffReviewInlineFeedbackActions.swift Alas/Sources/Center/DiffReview/DiffReviewFileSection.swift AlasTests/ReviewSessionTabViewTests.swift AlasTests/DiffReviewSurfaceTests.swift
+git commit -m "feat(review): wire provider review actions"
+```
+
+Expected: commit contains review-session wiring and provider-feedback UI actions.
+
+---
+
+## Task 8: Publish Filtering, Confirmation Safety, and Error States
+
+**Files:**
+
+- Modify: `Alas/Sources/Center/ReviewWorkspace/ProviderReviewMutationController.swift`
+- Modify: `Alas/Sources/Center/ReviewWorkspace/ReviewDraftSummaryRail.swift`
+- Modify: `Alas/Sources/Center/DiffReview/DiffReviewFileSection.swift`
+- Modify: `Alas/Sources/Center/ReviewWorkspace/ProviderReviewPublishConfirmationView.swift`
+- Test: `AlasTests/ReviewSessionTabViewTests.swift`
+- Test: `AlasTests/DiffReviewSurfaceTests.swift`
+
+- [ ] **Step 1: Write failing safety tests**
+
+Add tests:
+
+```swift
+@Test @MainActor func publishReviewIgnoresAlreadyPublishedDraftsByDefault() throws {
+    let comments = [
+        activeUnpublishedDraft(id: "active"),
+        activePublishedDraft(id: "published")
+    ]
+    let publishable = ProviderReviewPublishPlanner.publishableDrafts(comments)
+    #expect(publishable.map(\.id) == ["active"])
+}
+
+@Test @MainActor func confirmationDisablesPublishWhenNoPublishableCommentsAndDecisionIsComment() {
+    var decision = ProviderReviewDecision.comment
+    var confirmed = false
+    let view = ProviderReviewPublishConfirmationView(
+        providerName: "GitHub",
+        reviewIdentity: "PR #527",
+        commentCount: 0,
+        unpublishableMessages: [],
+        selectedDecision: Binding(get: { decision }, set: { decision = $0 }),
+        isPublishing: false,
+        errorMessage: nil,
+        onCancel: {},
+        onConfirm: { confirmed = true }
+    )
+    .environment(\.theme, theme())
+
+    let controller = host(view, width: 420, height: 260)
+    #expect(!pressAccessibilityElement(withAccessibilityIdentifier: "provider-review-publish-confirm", in: controller.view))
+    #expect(!confirmed)
+}
+```
+
+- [ ] **Step 2: Run tests to verify failure**
+
+Run:
+
+```bash
+rtk xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -only-testing:AlasTests/ReviewSessionTabViewTests -only-testing:AlasTests/DiffReviewSurfaceTests -quiet test
+```
+
+Expected: failure for missing planner and disabled confirmation behavior.
+
+- [ ] **Step 3: Add publish planner**
+
+Create in `ProviderReviewMutationController.swift`:
+
+```swift
+enum ProviderReviewPublishPlanner {
+    static func publishableDrafts(_ comments: [ReviewDraftComment]) -> [ReviewDraftComment] {
+        comments.filter { comment in
+            comment.state == .active
+                && comment.providerPublish == nil
+                && comment.startLine > 0
+                && !comment.bodyMarkdown.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+        }
+    }
+
+    static func unpublishableMessages(_ comments: [ReviewDraftComment]) -> [String] {
+        comments.compactMap { comment in
+            if comment.providerPublish != nil {
+                return "\(comment.path): already published"
+            }
+            if comment.state != .active {
+                return "\(comment.path): not active"
+            }
+            if comment.startLine <= 0 {
+                return "\(comment.path): missing line anchor"
+            }
+            if comment.bodyMarkdown.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+                return "\(comment.path): empty comment"
+            }
+            return nil
+        }
+    }
+}
+```
+
+Use this planner in summary rail and per-comment publish availability.
+
+- [ ] **Step 4: Harden confirmation view**
+
+Add:
+
+```swift
+private var canConfirm: Bool {
+    !isPublishing && (commentCount > 0 || selectedDecision != .comment)
+}
+```
+
+Use `.disabled(!canConfirm)` on the confirm button and add an accessibility marker with id `provider-review-publish-confirm` whose press returns false when disabled.
+
+- [ ] **Step 5: Render published/error state on local draft cards and summary rows**
+
+In local draft cards, display:
+
+- `published` status when `comment.providerPublish != nil`
+- provider error text when `comment.providerError != nil`
+
+Use existing text styles:
+
+```swift
+if let providerPublish = comment.providerPublish {
+    Text("published to \(providerPublish.provider.displayName)")
+}
+if let providerError = comment.providerError {
+    Text(providerError.message)
+        .foregroundColor(theme.color("warn"))
+}
+```
+
+- [ ] **Step 6: Run focused tests**
+
+Run:
+
+```bash
+rtk xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -only-testing:AlasTests/ReviewSessionTabViewTests -only-testing:AlasTests/DiffReviewSurfaceTests -quiet test
+```
+
+Expected: PASS.
+
+- [ ] **Step 7: Commit**
+
+Run:
+
+```bash
+git add Alas/Sources/Center/ReviewWorkspace/ProviderReviewMutationController.swift Alas/Sources/Center/ReviewWorkspace/ReviewDraftSummaryRail.swift Alas/Sources/Center/DiffReview/DiffReviewFileSection.swift Alas/Sources/Center/ReviewWorkspace/ProviderReviewPublishConfirmationView.swift AlasTests/ReviewSessionTabViewTests.swift AlasTests/DiffReviewSurfaceTests.swift
+git commit -m "fix(review): harden provider publish safety"
+```
+
+Expected: commit contains safety filtering/error display only.
+
+---
+
+## Task 9: Final Integration Verification
+
+**Files:**
+
+- Verify all changed files.
+- No new production behavior unless CI/focused tests reveal a bug that must be fixed.
+
+- [ ] **Step 1: Run focused provider/review suites**
+
+Run:
+
+```bash
+rtk xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' \
+  -only-testing:AlasTests/ProviderReviewActionsTests \
+  -only-testing:AlasTests/GitHubCLIProviderTests \
+  -only-testing:AlasTests/GitLabCLIProviderTests \
+  -only-testing:AlasTests/ReviewDraftCommentStoreTests \
+  -only-testing:AlasTests/ReviewSessionTabViewTests \
+  -only-testing:AlasTests/DiffReviewSurfaceTests \
+  -quiet test
+```
+
+Expected: PASS.
+
+- [ ] **Step 2: Run project generation**
+
+Run:
+
+```bash
+xcodegen
+git status --short
+```
+
+Expected: no uncommitted project churn except intended source/test files. If `Alas.xcodeproj` changes due to new files, include it in the relevant commit.
+
+- [ ] **Step 3: Run quiet build**
+
+Run:
+
+```bash
+rtk xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -quiet build
+```
+
+Expected: exit 0.
+
+- [ ] **Step 4: Run full test suite**
+
+Run:
+
+```bash
+rtk xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' test
+```
+
+Expected: exit 0.
+
+- [ ] **Step 5: Final status**
+
+Run:
+
+```bash
+git status --short --branch
+git log --oneline -8
+```
+
+Expected: clean working tree on `nacho/provider-review-actions`, with implementation commits above the design/plan commits.
+
+Do not open or merge a PR automatically unless the user asks for the PR loop.

--- a/docs/superpowers/specs/2026-06-15-provider-review-actions-design.md
+++ b/docs/superpowers/specs/2026-06-15-provider-review-actions-design.md
@@ -1,0 +1,291 @@
+# Provider Review Actions Design
+
+## Context
+
+Alas now has a polished diff review surface, persistent local draft review
+comments, in-app review sessions, and native agent handoff. Those pieces cover
+most of the local `ai-review` workflow. The remaining Rudu-sized gap is provider
+write support: Alas can read GitHub/GitLab review state, but it cannot yet
+participate in the remote review by publishing comments, replying to threads, or
+resolving provider discussions.
+
+This design adds explicit provider review actions for both GitHub and GitLab in
+the same V1. The implementation stays CLI-backed (`gh`, `glab`, plus
+`api`/GraphQL subcommands where needed) so auth, host routing, and enterprise
+configuration remain delegated to the existing provider tools.
+
+## Product Shape
+
+Provider writes layer onto existing review workspaces and PR/MR review surfaces:
+
+1. The user opens a GitHub PR or GitLab MR review session.
+2. The user adds local draft comments on exact lines/ranges as they do today.
+3. The user chooses `Publish review`.
+4. Alas shows a confirmation with provider, PR/MR number, review decision,
+   comment count, and any comments that cannot be published.
+5. Alas writes the comments/review through the provider CLI.
+6. Alas refreshes provider state from the remote source.
+7. Alas marks successfully published local drafts with provider metadata and
+   leaves failed drafts active with an attached warning.
+
+Existing provider feedback cards gain provider-backed actions when the loaded
+thread contains the provider identifiers required by that action:
+
+- Reply
+- Resolve
+- Unresolve
+
+Local drafts never publish automatically. Typing, saving, editing, or sending a
+draft to an agent remains local-only until the user explicitly chooses a publish
+action.
+
+## Provider Model
+
+Add a write-side provider API beside the current read-side `CodeHostProvider`
+methods.
+
+Core model:
+
+- `ProviderReviewDraftComment`
+  - local draft comment id
+  - file path and original path
+  - side: old, new, or unknown
+  - start/end lines
+  - selected text snapshot
+  - Markdown body
+- `ProviderReviewDecision`
+  - `comment`
+  - `approve`
+  - `requestChanges`
+- `ProviderReviewPublishRequest`
+  - remote
+  - review request
+  - comments
+  - decision
+  - summary body
+  - repository cwd
+- `ProviderReviewPublishedComment`
+  - local draft id
+  - provider thread id, required for thread-level publish/resolve actions
+  - provider comment id, optional and stored when returned
+  - provider URL, optional and stored when returned
+- `ProviderReviewPublishResult`
+  - published comment mappings
+  - failed comment results
+  - refreshed `ReviewRequest`
+  - provider warnings
+- `ProviderThreadMutation`
+  - reply
+  - resolve
+  - unresolve
+
+`CodeHostProviderCapabilities` should expose write capabilities explicitly:
+
+- can publish review comments
+- can reply to review threads
+- can resolve review threads
+- can unresolve review threads
+- can approve
+- can request changes
+
+Capabilities can be static where the provider CLI/API support is known and can
+also be filtered at action time when a request lacks enough provider identifiers
+or the thread is outdated.
+
+## GitHub Path
+
+GitHub uses `gh` for auth and host routing.
+
+Implementation rules:
+
+- Use `gh api graphql` for thread resolution and unresolution.
+- Use `gh api` or `gh api graphql` for creating review comments and submitting
+  review decisions.
+- Use one review submission for batch publish. If GitHub rejects one comment in
+  the batch, retry publish for the remaining individually commentable drafts and
+  report the rejected draft as a per-comment failure.
+- Preserve the provider's canonical response: collect provider thread/comment
+  ids and URLs when returned.
+- Map local anchors to GitHub file/line/side fields. If GitHub rejects an exact
+  anchor because the line is outdated or uncommentable, keep that draft local
+  and surface the provider error for that comment.
+- After publish/reply/resolve/unresolve, refresh the PR through the existing
+  provider loading path before reporting success.
+
+GitHub decisions:
+
+- `comment`: publish comments and submit a comment review.
+- `approve`: publish comments if present, then submit approval.
+- `requestChanges`: publish comments if present, then submit request changes.
+
+## GitLab Path
+
+GitLab uses `glab` for auth and host routing.
+
+Implementation rules:
+
+- Use `glab api` for MR discussions and notes because high-level `glab mr`
+  commands do not cover all review-thread mutations cleanly.
+- Create line/range discussions from local drafts using GitLab diff refs and
+  position payloads.
+- Reply to discussions by creating notes.
+- Resolve/unresolve discussion threads using the discussions API. Hide these
+  actions when the loaded thread does not include a discussion id.
+- Use the MR approval endpoint for `approve`. If the endpoint is unavailable or
+  the user lacks permission, surface that provider error and leave local drafts
+  unchanged except for comments that were already published before the approval
+  call.
+- Represent `requestChanges` as publishing draft discussions plus a clear
+  review-status note, because GitLab does not map one-to-one to GitHub review
+  decisions in all tiers/versions.
+- After publish/reply/resolve/unresolve, refresh the MR through the existing
+  provider loading path before reporting success.
+
+If GitLab rejects a position payload, keep the local draft active and attach the
+provider error to that draft. Do not silently fall back to a file-level comment
+unless the user explicitly chooses a later fallback action.
+
+## UI and Safety
+
+Summary rail:
+
+- Show `Publish review` when the session has provider context and active local
+  drafts or a provider decision action.
+- The publish flow presents a confirmation popover/sheet before any remote
+  mutation.
+- Confirmation shows provider, PR/MR number, decision, comment count, and
+  warnings for unpublishable drafts.
+- The user selects `Comment`, `Approve`, or `Request changes`.
+
+Local draft cards:
+
+- Show `Publish` when the draft has provider context and a commentable anchor.
+- Per-comment publish still confirms provider target and action.
+- Successful per-comment publish marks only that draft as published.
+
+Provider feedback cards:
+
+- Show `Reply` when reply is supported for the thread.
+- Show `Resolve` for unresolved threads with a provider thread/discussion id.
+- Show `Unresolve` for resolved threads with a provider thread/discussion id.
+- Mutating actions show a small inline progress/error state and refresh provider
+  state after success.
+
+Published local drafts:
+
+- Local draft comments are not deleted on publish.
+- Each successful draft stores provider metadata: provider kind, remote identity,
+  PR/MR number, provider thread id/comment id, URL, and published timestamp.
+- Failed comments remain active local drafts with an error message.
+- Re-publish actions are hidden for already-published drafts.
+
+## Data Flow
+
+Publish review:
+
+1. UI builds a `ProviderReviewPublishRequest` from the current review session,
+   active local drafts, selected decision, and provider context.
+2. UI asks the provider for unsupported/unpublishable drafts before showing the
+   confirmation.
+3. User confirms.
+4. Provider writes comments/review through `gh` or `glab`.
+5. Provider returns published mappings, failures, warnings, and refreshed
+   request data.
+6. Draft comment store records provider metadata for successful drafts and
+   provider errors for failed drafts.
+7. Review session reloads refreshed provider state and re-renders remote threads.
+
+Thread mutation:
+
+1. User chooses Reply, Resolve, or Unresolve on a provider feedback card.
+2. UI builds a `ProviderThreadMutation` with provider thread/comment ids.
+3. Provider writes through `gh` or `glab`.
+4. Provider refreshes the request state.
+5. UI replaces the stale request state with the refreshed state.
+
+## Error Handling
+
+Provider mutation failures should be specific and recoverable:
+
+- Missing CLI: show install/auth guidance and leave local drafts unchanged.
+- Unauthenticated CLI: show provider auth guidance and leave local drafts
+  unchanged.
+- Unpublishable anchor: leave that draft active and attach the provider error.
+- Partial batch failure: mark successful drafts as published; keep failed drafts
+  active with errors.
+- Refresh failure after successful write: preserve successful provider mappings
+  and show that refresh failed, so the user can manually refresh.
+- Unsupported provider capability: hide the action or show a disabled reason in
+  the confirmation.
+
+No provider write should be retried automatically without another explicit user
+action.
+
+## Scope
+
+V1 includes:
+
+- GitHub and GitLab publish local draft comments.
+- GitHub review decisions: comment, approve, request changes.
+- GitLab publish discussions and call the MR approval endpoint for approve.
+- GitLab request-changes normalization as discussions plus status note.
+- Reply to provider feedback threads.
+- Resolve/unresolve provider threads when the loaded thread has the required
+  provider thread/discussion id.
+- Refresh provider state after writes.
+- Persist published metadata and failed provider errors on local drafts.
+- UI confirmation before every provider write.
+
+Out of scope:
+
+- Provider suggestion blocks and apply-suggestion flows.
+- Editing or deleting remote comments after publish.
+- Importing pending GitHub reviews created outside Alas.
+- Offline provider mutation queue.
+- Arbitrary patch-file provider publishing.
+- Automatic fallback from line comment to file-level comment.
+
+## Testing
+
+Provider tests:
+
+- GitHub command/payload tests for publish, reply, resolve, unresolve, and
+  review decisions.
+- GitLab command/payload tests for discussion creation, reply, resolve,
+  unresolve, approve, and request-changes note.
+- Anchor mapping tests for old, new, unknown, and range anchors.
+- Partial failure tests: successful drafts get provider metadata; failed drafts
+  remain active with errors.
+- Refresh-after-write tests for both providers.
+
+UI tests:
+
+- Publish actions show only when provider context and capabilities allow them.
+- Confirmation lists provider, PR/MR number, decision, comment count, and
+  unpublishable comments.
+- Provider feedback cards expose Reply/Resolve/Unresolve according to
+  capabilities and current thread state.
+- No-write safety: editing or saving local drafts does not call provider APIs.
+
+Persistence tests:
+
+- Published metadata survives store round trip.
+- Provider error state survives store round trip.
+- Already-published drafts do not appear in the default active publish set.
+
+## Implementation Notes
+
+Keep the review surface provider-neutral. GitHub/GitLab details should stay in
+provider implementations and shared provider-write models. The review surface
+should render capabilities and actions, then delegate mutations to a controller
+owned by the review session/provider tab.
+
+The first implementation plan should split the work into:
+
+1. Provider write models and draft metadata.
+2. GitHub provider mutations and tests.
+3. GitLab provider mutations and tests.
+4. Review-session controller and persistence wiring.
+5. UI confirmation/actions.
+6. Refresh/error handling.
+7. Final verification and PR loop.


### PR DESCRIPTION
## Summary
- add provider review action models and provider write capabilities
- implement GitHub and GitLab review publish, reply, resolve, and decision flows through CLI-backed APIs
- wire provider publish/reply/resolve actions into review sessions with confirmation, refresh, persisted publish/error metadata, and safety guards

## Verification
- `rtk xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -only-testing:AlasTests/ProviderReviewActionsTests -only-testing:AlasTests/GitHubCLIProviderTests -only-testing:AlasTests/GitLabCLIProviderTests -only-testing:AlasTests/ReviewDraftCommentStoreTests -only-testing:AlasTests/ReviewSessionTabViewTests -only-testing:AlasTests/DiffReviewSurfaceTests -quiet test`
- `xcodegen`
- `rtk xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -quiet build`
- `rtk xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' test`

Note: one full-suite run hit the existing `ProcessMemoryProbe` sampling flake; that test passed in isolation and the full-suite retry passed.