### PR TITLE
feat(review): improve review request drawer affordance

### DIFF
--- a/Alas/Sources/Icons/Icon.swift
+++ b/Alas/Sources/Icons/Icon.swift
@@ -48,6 +48,7 @@ struct Icon: View {
         case "palette":    return "paintpalette"
         case "keyboard":   return "keyboard"
         case "github":     return "circle.hexagongrid"
+        case "gitlab":     return "triangle"
         case "alert":      return "exclamationmark.triangle"
         case "sparkle":    return "sparkles"
         default:           return name

--- a/Alas/Sources/Integrations/CodeHost/CodeHostModels.swift
+++ b/Alas/Sources/Integrations/CodeHost/CodeHostModels.swift
@@ -25,6 +25,13 @@ enum CodeHostKind: String, Codable, Equatable, Sendable {
         }
     }
 
+    var iconName: String {
+        switch self {
+        case .github: "github"
+        case .gitlab: "gitlab"
+        }
+    }
+
     var createReviewRequestTitle: String {
         "Create \(reviewRequestLabel)"
     }

--- a/Alas/Sources/Integrations/CodeHost/ReviewLoopDrawer.swift
+++ b/Alas/Sources/Integrations/CodeHost/ReviewLoopDrawer.swift
@@ -62,8 +62,28 @@ struct ReviewLoopDrawer: View {
         .padding(.vertical, 7)
         .contentShape(Rectangle())
         .onTapGesture {
-            state.setExpanded(!state.isExpanded)
+            toggleExpanded()
         }
+        .focusable()
+        .onKeyPress(.return) {
+            toggleExpanded()
+            return .handled
+        }
+        .onKeyPress(.space) {
+            toggleExpanded()
+            return .handled
+        }
+        .accessibilityElement(children: .contain)
+        .accessibilityLabel(model.identity)
+        .accessibilityHint(state.isExpanded ? "Collapse review status" : "Expand review status")
+        .accessibilityAddTraits(.isButton)
+        .accessibilityAction {
+            toggleExpanded()
+        }
+    }
+
+    private func toggleExpanded() {
+        state.setExpanded(!state.isExpanded)
     }
 
     private func headerTitle(model: ReviewReadinessModel) -> some View {

--- a/Alas/Sources/Integrations/CodeHost/ReviewLoopDrawer.swift
+++ b/Alas/Sources/Integrations/CodeHost/ReviewLoopDrawer.swift
@@ -77,7 +77,7 @@ struct ReviewLoopDrawer: View {
 
             if let requestNumberTitle = model.requestNumberTitle {
                 Button {
-                    onAction(.inspectReviewEvidence)
+                    onAction(.openReviewRequest)
                 } label: {
                     Text(requestNumberTitle.uppercased())
                         .font(.system(size: 10.5, weight: .semibold))

--- a/Alas/Sources/Integrations/CodeHost/ReviewLoopDrawer.swift
+++ b/Alas/Sources/Integrations/CodeHost/ReviewLoopDrawer.swift
@@ -21,12 +21,7 @@ struct ReviewLoopDrawer: View {
             Rectangle()
                 .fill(toneColor(model.primaryTone).opacity(0.24))
                 .frame(height: 1)
-            Button {
-                state.setExpanded(!state.isExpanded)
-            } label: {
-                collapsedRow(model: model)
-            }
-            .buttonStyle(.plain)
+            collapsedRow(model: model)
 
             if state.isExpanded {
                 expandedBody(model: model)
@@ -46,13 +41,8 @@ struct ReviewLoopDrawer: View {
                 .fill(toneColor(model.primaryTone))
                 .frame(width: 6, height: 6)
                 .shadow(color: toneColor(model.primaryTone).opacity(model.primaryTone == .muted ? 0 : 0.45), radius: 3)
-            Icon(name: "branch", size: 11, color: theme.color("fg-faint"))
-            Text(model.identity.uppercased())
-                .font(.system(size: 10.5, weight: .semibold))
-                .tracking(0.5)
-                .foregroundColor(theme.color("fg-muted"))
-                .lineLimit(1)
-                .truncationMode(.middle)
+            Icon(name: model.providerIconName, size: 11, color: theme.color("fg-faint"))
+            headerTitle(model: model)
 
             if state.isRefreshing {
                 Spinner(lineWidth: 1.4, duration: 0.8)
@@ -71,6 +61,34 @@ struct ReviewLoopDrawer: View {
         .padding(.horizontal, 10)
         .padding(.vertical, 7)
         .contentShape(Rectangle())
+        .onTapGesture {
+            state.setExpanded(!state.isExpanded)
+        }
+    }
+
+    private func headerTitle(model: ReviewReadinessModel) -> some View {
+        HStack(spacing: 3) {
+            Text((model.providerTitle ?? model.identity).uppercased())
+                .font(.system(size: 10.5, weight: .semibold))
+                .tracking(0.5)
+                .foregroundColor(theme.color("fg-muted"))
+                .lineLimit(1)
+                .truncationMode(.middle)
+
+            if let requestNumberTitle = model.requestNumberTitle {
+                Button {
+                    onAction(.inspectReviewEvidence)
+                } label: {
+                    Text(requestNumberTitle.uppercased())
+                        .font(.system(size: 10.5, weight: .semibold))
+                        .tracking(0.5)
+                        .foregroundColor(theme.color("accent"))
+                        .lineLimit(1)
+                }
+                .buttonStyle(.plain)
+                .help("Open \(model.providerTitle ?? "review") \(requestNumberTitle)")
+            }
+        }
     }
 
     private func expandedBody(model: ReviewReadinessModel) -> some View {

--- a/Alas/Sources/Integrations/CodeHost/ReviewReadinessModel.swift
+++ b/Alas/Sources/Integrations/CodeHost/ReviewReadinessModel.swift
@@ -64,6 +64,9 @@ struct ReviewReadinessModel: Equatable, Sendable {
     }
 
     let identity: String
+    let providerIconName: String
+    let providerTitle: String?
+    let requestNumberTitle: String?
     let title: String?
     let chips: [Chip]
     let facts: [Fact]
@@ -73,6 +76,9 @@ struct ReviewReadinessModel: Equatable, Sendable {
     init(snapshot: ReviewLoopSnapshot?, lastError: String?, canOpenAgentHandoff: Bool) {
         guard let snapshot else {
             identity = "Review readiness"
+            providerIconName = "branch"
+            providerTitle = nil
+            requestNumberTitle = nil
             title = nil
             chips = [Chip(id: "loading", title: "Checking", tone: .accent)]
             facts = []
@@ -87,6 +93,9 @@ struct ReviewReadinessModel: Equatable, Sendable {
         let requestLabel = kind?.reviewRequestLabel ?? "review request"
 
         identity = request?.displayIdentity ?? kind?.displayName ?? "Review readiness"
+        providerIconName = kind?.iconName ?? "branch"
+        providerTitle = kind?.displayName
+        requestNumberTitle = request.map { "\($0.provider.reviewRequestNumberPrefix)\($0.number)" }
         title = request?.title
         blockingText = lastError ?? snapshot.errorMessage ?? Self.providerBlockingText(snapshot) ?? Self.localBlockingText(snapshot)
 

--- a/AlasTests/Integrations/CodeHostModelsTests.swift
+++ b/AlasTests/Integrations/CodeHostModelsTests.swift
@@ -18,11 +18,13 @@ struct CodeHostModelsTests {
     @Test func codeHostKindUsesProviderNativeReviewRequestLabels() {
         #expect(CodeHostKind.github.reviewRequestLabel == "PR")
         #expect(CodeHostKind.github.reviewRequestNumberPrefix == "#")
+        #expect(CodeHostKind.github.iconName == "github")
         #expect(CodeHostKind.github.createReviewRequestTitle == "Create PR")
         #expect(CodeHostKind.github.openReviewRequestTitle == "Open PR")
 
         #expect(CodeHostKind.gitlab.reviewRequestLabel == "MR")
         #expect(CodeHostKind.gitlab.reviewRequestNumberPrefix == "!")
+        #expect(CodeHostKind.gitlab.iconName == "gitlab")
         #expect(CodeHostKind.gitlab.createReviewRequestTitle == "Create MR")
         #expect(CodeHostKind.gitlab.openReviewRequestTitle == "Open MR")
     }

--- a/AlasTests/Integrations/ReviewLoopDrawerTests.swift
+++ b/AlasTests/Integrations/ReviewLoopDrawerTests.swift
@@ -12,6 +12,24 @@ struct ReviewLoopDrawerTests {
         )
 
         #expect(model.identity == "GitHub #42")
+        #expect(model.providerIconName == "github")
+        #expect(model.providerTitle == "GitHub")
+        #expect(model.requestNumberTitle == "#42")
+    }
+
+    @Test func readinessIdentityUsesGitLabRequestTokenWhenPresent() {
+        let remote = Self.makeRemote(kind: .gitlab)
+        let request = Self.makeReviewRequest(remote: remote)
+        let model = ReviewReadinessModel(
+            snapshot: Self.makeSnapshot(remote: remote, reviewRequest: request),
+            lastError: nil,
+            canOpenAgentHandoff: true
+        )
+
+        #expect(model.identity == "GitLab !42")
+        #expect(model.providerIconName == "gitlab")
+        #expect(model.providerTitle == "GitLab")
+        #expect(model.requestNumberTitle == "!42")
     }
 
     @Test func githubSnapshotWithoutRequestExposesCreatePR() {


### PR DESCRIPTION
## Summary
- show GitHub/GitLab provider icons in the review request drawer header
- make the PR/MR number token open the in-app review evidence pane
- cover provider icon and request-number model metadata in tests

## Test plan
- xcodegen
- xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -quiet build
- xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' test