### PR TITLE
feat(changes): improve changes preparation entry point

### DIFF
--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -703,6 +703,7 @@
 		ACF240D867C3CCCD59E5A0E6 /* HarnessConfigAutoRunTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4D4F87B7B6F4A6E6ED882F1F /* HarnessConfigAutoRunTests.swift */; };
 		AD311BBE11A5A2751EA0907C /* HoverFeature.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0AF8152B18C9D6290724122F /* HoverFeature.swift */; };
 		ADAE65B8D982CD4411235D32 /* CodeHostRemoteDetector.swift in Sources */ = {isa = PBXBuildFile; fileRef = 82E98F9835497D830C12AA8F /* CodeHostRemoteDetector.swift */; };
+		ADAF74641060B0C04E469AF8 /* ChangesPreparationCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1513AFD842F4CF16F8DEEA31 /* ChangesPreparationCard.swift */; };
 		ADF6D3B634D9CCA17D7884EC /* PiACPInstallerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C6641006D2208E28C46AAB2 /* PiACPInstallerTests.swift */; };
 		AE179E24A9E308150D1FD1D5 /* CommitPromptStatusTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1E40B5F193E3CB5EB5BA945A /* CommitPromptStatusTests.swift */; };
 		AE5BC95F30EE46ED0DE74F23 /* WorkingTreeChangeGroup.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9D32294F9B916DFAFF5E9A6F /* WorkingTreeChangeGroup.swift */; };
@@ -1152,6 +1153,7 @@
 		14907D679267359B3FB8A848 /* TabMergeConflictCodingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabMergeConflictCodingTests.swift; sourceTree = "<group>"; };
 		14CAEDA53AADBCE77C694E7B /* CodeHostModelsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CodeHostModelsTests.swift; sourceTree = "<group>"; };
 		14D1ECA099BBDCB5BB2EEC67 /* DiffReviewModels.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiffReviewModels.swift; sourceTree = "<group>"; };
+		1513AFD842F4CF16F8DEEA31 /* ChangesPreparationCard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChangesPreparationCard.swift; sourceTree = "<group>"; };
 		155B35EBCCE7F2CA1A0E5DE5 /* HarnessService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HarnessService.swift; sourceTree = "<group>"; };
 		15630570F849AC577CA0D379 /* ACPAdapterVersionChecker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPAdapterVersionChecker.swift; sourceTree = "<group>"; };
 		159FE807399835B0821E1CAB /* EnvBuilder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EnvBuilder.swift; sourceTree = "<group>"; };
@@ -2797,6 +2799,7 @@
 				6BAD20759A17B6EFE3AC0C81 /* BranchOpsMenu.swift */,
 				7554DEF788B5448132F2B93F /* BulkConflictResolveReport.swift */,
 				3E10A1919A8DDC6A8DBB8B97 /* ChangedRow.swift */,
+				1513AFD842F4CF16F8DEEA31 /* ChangesPreparationCard.swift */,
 				D54BBE356A720AF00F2A7C56 /* ChangesPreparationModel.swift */,
 				C682FF74C86B77BDCF46CF25 /* ChangesTabView.swift */,
 				3DCEFADD952DB870B8BAB890 /* CommitRow.swift */,
@@ -4341,6 +4344,7 @@
 				40450134EBF5CCD5CD667327 /* ChangeSummaryVisibility.swift in Sources */,
 				8147BF86F2E77D81BE885B8F /* ChangedRow.swift in Sources */,
 				8F5B93A115E4554430ADC0FD /* ChangesPane.swift in Sources */,
+				ADAF74641060B0C04E469AF8 /* ChangesPreparationCard.swift in Sources */,
 				230BD521ACDBA5BB7AA9167D /* ChangesPreparationModel.swift in Sources */,
 				23013D3D2538AC2D1BD3403D /* ChangesTabView.swift in Sources */,
 				D46F8DF1FB66AD0ED92F3DF0 /* ChangesTreeBuilder.swift in Sources */,

--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -140,6 +140,7 @@
 		2281077800674169E69C6C3B /* HoverWindowControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C9032BA9542C617A09EF848 /* HoverWindowControllerTests.swift */; };
 		22FDE2FB05952993DA2D0EB7 /* WorkingTreeSectionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 866CFEB75B7F754485C6BE77 /* WorkingTreeSectionView.swift */; };
 		23013D3D2538AC2D1BD3403D /* ChangesTabView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C682FF74C86B77BDCF46CF25 /* ChangesTabView.swift */; };
+		230BD521ACDBA5BB7AA9167D /* ChangesPreparationModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = D54BBE356A720AF00F2A7C56 /* ChangesPreparationModel.swift */; };
 		238BBB5FC59949CE6ABAFBEF /* ACPCodeBlockHighlighterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 81773A01826A91080F5A2E95 /* ACPCodeBlockHighlighterTests.swift */; };
 		23F92214B30096D070419921 /* ACPQueuedBubbleActionMetricsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5733BF1C52BA0FCFB2724D57 /* ACPQueuedBubbleActionMetricsTests.swift */; };
 		2434A66A45EDF2609BA9F1D3 /* session-update-config-options.json in Resources */ = {isa = PBXBuildFile; fileRef = 97DA8F50DDCDAA15CCEA2004 /* session-update-config-options.json */; };
@@ -1911,6 +1912,7 @@
 		D49B5B544A3432F8D8105268 /* SearchModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchModel.swift; sourceTree = "<group>"; };
 		D510DACCD80A328B2DFABDC0 /* CompletionFeature.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CompletionFeature.swift; sourceTree = "<group>"; };
 		D52FB6333DDC1A21B0959C1B /* ReviewReadinessModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReviewReadinessModelTests.swift; sourceTree = "<group>"; };
+		D54BBE356A720AF00F2A7C56 /* ChangesPreparationModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChangesPreparationModel.swift; sourceTree = "<group>"; };
 		D568D53950A3CA2CD1F4EECB /* ImageDiffPairResolver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageDiffPairResolver.swift; sourceTree = "<group>"; };
 		D5825E49F6DC54DC35132D2F /* MergeConflictTabModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MergeConflictTabModelTests.swift; sourceTree = "<group>"; };
 		D5AA350F5909E28954C623B7 /* ProcessMemoryProbe.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProcessMemoryProbe.swift; sourceTree = "<group>"; };
@@ -2795,6 +2797,7 @@
 				6BAD20759A17B6EFE3AC0C81 /* BranchOpsMenu.swift */,
 				7554DEF788B5448132F2B93F /* BulkConflictResolveReport.swift */,
 				3E10A1919A8DDC6A8DBB8B97 /* ChangedRow.swift */,
+				D54BBE356A720AF00F2A7C56 /* ChangesPreparationModel.swift */,
 				C682FF74C86B77BDCF46CF25 /* ChangesTabView.swift */,
 				3DCEFADD952DB870B8BAB890 /* CommitRow.swift */,
 				6FFE12732C0D83715FC990A9 /* CommitsSectionView.swift */,
@@ -4338,6 +4341,7 @@
 				40450134EBF5CCD5CD667327 /* ChangeSummaryVisibility.swift in Sources */,
 				8147BF86F2E77D81BE885B8F /* ChangedRow.swift in Sources */,
 				8F5B93A115E4554430ADC0FD /* ChangesPane.swift in Sources */,
+				230BD521ACDBA5BB7AA9167D /* ChangesPreparationModel.swift in Sources */,
 				23013D3D2538AC2D1BD3403D /* ChangesTabView.swift in Sources */,
 				D46F8DF1FB66AD0ED92F3DF0 /* ChangesTreeBuilder.swift in Sources */,
 				B7542C247255B91CEC68004F /* ChatFontCatalog.swift in Sources */,

--- a/Alas/Sources/Right/ChangesPreparationCard.swift
+++ b/Alas/Sources/Right/ChangesPreparationCard.swift
@@ -29,13 +29,9 @@ struct ChangesPreparationCard: View {
                 primaryReviewButton(reviewAction)
             }
             if model.draftAction != nil || model.reviewRequestAction != nil {
-                HStack(spacing: 8) {
-                    if let draftAction = model.draftAction {
-                        secondaryDraftButton(draftAction)
-                    }
-                    if let reviewRequestAction = model.reviewRequestAction {
-                        secondaryReviewRequestButton(reviewRequestAction)
-                    }
+                ViewThatFits(in: .horizontal) {
+                    secondaryActionsHorizontal
+                    secondaryActionsVertical
                 }
             }
         }
@@ -74,6 +70,8 @@ struct ChangesPreparationCard: View {
                     Text(action.title)
                         .font(.system(size: 12.5, weight: .semibold))
                         .foregroundColor(theme.color("bg-0"))
+                        .lineLimit(1)
+                        .truncationMode(.tail)
                     Text(ChangesPreparationCardText.reviewStats(
                         fileCount: action.fileCount,
                         additions: action.additions,
@@ -81,7 +79,10 @@ struct ChangesPreparationCard: View {
                     ))
                     .font(.system(size: 11, design: .monospaced))
                     .foregroundColor(theme.color("bg-0").opacity(0.72))
+                    .lineLimit(1)
+                    .truncationMode(.tail)
                 }
+                .frame(maxWidth: .infinity, alignment: .leading)
                 Spacer(minLength: 8)
                 Icon(name: "chev-right", size: 11, color: theme.color("bg-0").opacity(0.72))
             }
@@ -96,6 +97,28 @@ struct ChangesPreparationCard: View {
         )
         .help(action.title)
         .accessibilityIdentifier("changes-preparation-review")
+    }
+
+    private var secondaryActionsHorizontal: some View {
+        HStack(spacing: 8) {
+            if let draftAction = model.draftAction {
+                secondaryDraftButton(draftAction)
+            }
+            if let reviewRequestAction = model.reviewRequestAction {
+                secondaryReviewRequestButton(reviewRequestAction)
+            }
+        }
+    }
+
+    private var secondaryActionsVertical: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            if let draftAction = model.draftAction {
+                secondaryDraftButton(draftAction)
+            }
+            if let reviewRequestAction = model.reviewRequestAction {
+                secondaryReviewRequestButton(reviewRequestAction)
+            }
+        }
     }
 
     private func secondaryDraftButton(_ action: ChangesPreparationModel.DraftAction) -> some View {

--- a/Alas/Sources/Right/ChangesPreparationCard.swift
+++ b/Alas/Sources/Right/ChangesPreparationCard.swift
@@ -1,0 +1,178 @@
+import SwiftUI
+
+enum ChangesPreparationCardText {
+    static func reviewStats(fileCount: Int, additions: Int?, deletions: Int?) -> String {
+        let files = fileCount == 1 ? "1 file" : "\(fileCount) files"
+        guard let additions, let deletions else { return files }
+        return "\(files) · +\(additions) −\(deletions)"
+    }
+
+    static func draftStats(stagedCount: Int, additions: Int, deletions: Int) -> String {
+        guard stagedCount > 0 else { return "0 staged" }
+        let staged = stagedCount == 1 ? "1 staged" : "\(stagedCount) staged"
+        return "\(staged) · +\(additions) −\(deletions)"
+    }
+}
+
+struct ChangesPreparationCard: View {
+    let model: ChangesPreparationModel
+    let onReviewChanges: () -> Void
+    let onDraftCommit: () -> Void
+    let onReviewRequestAction: (ReviewReadinessActionKind) -> Void
+
+    @Environment(\.theme) private var theme
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 9) {
+            header
+            if let reviewAction = model.reviewAction {
+                primaryReviewButton(reviewAction)
+            }
+            if model.draftAction != nil || model.reviewRequestAction != nil {
+                HStack(spacing: 8) {
+                    if let draftAction = model.draftAction {
+                        secondaryDraftButton(draftAction)
+                    }
+                    if let reviewRequestAction = model.reviewRequestAction {
+                        secondaryReviewRequestButton(reviewRequestAction)
+                    }
+                }
+            }
+        }
+        .padding(10)
+        .background(
+            RoundedRectangle(cornerRadius: 8)
+                .fill(theme.color("bg-1"))
+        )
+        .overlay(
+            RoundedRectangle(cornerRadius: 8)
+                .strokeBorder(theme.color("line").opacity(0.75), lineWidth: 0.75)
+        )
+        .padding(.horizontal, 10)
+        .padding(.top, 8)
+        .padding(.bottom, 6)
+        .accessibilityIdentifier("changes-preparation-card")
+    }
+
+    private var header: some View {
+        HStack(spacing: 6) {
+            Icon(name: "diff", size: 11, color: theme.color("fg-faint"))
+            Text("Prepare")
+                .font(.system(size: 10.5, weight: .semibold))
+                .tracking(0.5)
+                .foregroundColor(theme.color("fg-muted"))
+                .textCase(.uppercase)
+            Spacer(minLength: 0)
+        }
+    }
+
+    private func primaryReviewButton(_ action: ChangesPreparationModel.ReviewAction) -> some View {
+        Button(action: onReviewChanges) {
+            HStack(spacing: 9) {
+                Icon(name: "diff", size: 13, color: theme.color("bg-0"))
+                VStack(alignment: .leading, spacing: 2) {
+                    Text(action.title)
+                        .font(.system(size: 12.5, weight: .semibold))
+                        .foregroundColor(theme.color("bg-0"))
+                    Text(ChangesPreparationCardText.reviewStats(
+                        fileCount: action.fileCount,
+                        additions: action.additions,
+                        deletions: action.deletions
+                    ))
+                    .font(.system(size: 11, design: .monospaced))
+                    .foregroundColor(theme.color("bg-0").opacity(0.72))
+                }
+                Spacer(minLength: 8)
+                Icon(name: "chev-right", size: 11, color: theme.color("bg-0").opacity(0.72))
+            }
+            .padding(.horizontal, 10)
+            .frame(minHeight: 44)
+            .contentShape(RoundedRectangle(cornerRadius: 7))
+        }
+        .buttonStyle(.plain)
+        .background(
+            RoundedRectangle(cornerRadius: 7)
+                .fill(theme.color("accent"))
+        )
+        .help(action.title)
+        .accessibilityIdentifier("changes-preparation-review")
+    }
+
+    private func secondaryDraftButton(_ action: ChangesPreparationModel.DraftAction) -> some View {
+        secondaryButton(
+            title: action.title,
+            subtitle: ChangesPreparationCardText.draftStats(
+                stagedCount: action.stagedCount,
+                additions: action.additions,
+                deletions: action.deletions
+            ),
+            iconName: "commit",
+            showsDot: action.hasNonEmptyDraft,
+            isEnabled: true,
+            action: onDraftCommit
+        )
+        .accessibilityIdentifier("changes-preparation-draft")
+    }
+
+    private func secondaryReviewRequestButton(
+        _ action: ChangesPreparationModel.ReviewRequestAction
+    ) -> some View {
+        secondaryButton(
+            title: action.title,
+            subtitle: "Branch review",
+            iconName: action.iconName,
+            showsDot: action.emphasis == .primary,
+            isEnabled: action.isEnabled,
+            action: { onReviewRequestAction(action.kind) }
+        )
+        .accessibilityIdentifier("changes-preparation-review-request")
+    }
+
+    private func secondaryButton(
+        title: String,
+        subtitle: String,
+        iconName: String,
+        showsDot: Bool,
+        isEnabled: Bool,
+        action: @escaping () -> Void
+    ) -> some View {
+        Button(action: action) {
+            HStack(spacing: 8) {
+                Icon(name: iconName, size: 11, color: theme.color("fg-dim"))
+                VStack(alignment: .leading, spacing: 1) {
+                    HStack(spacing: 5) {
+                        Text(title)
+                            .font(.system(size: 11.5, weight: .semibold))
+                            .foregroundColor(theme.color("fg"))
+                            .lineLimit(1)
+                        if showsDot {
+                            Circle()
+                                .fill(theme.color("accent"))
+                                .frame(width: 5, height: 5)
+                        }
+                    }
+                    Text(subtitle)
+                        .font(.system(size: 10.5))
+                        .foregroundColor(theme.color("fg-faint"))
+                        .lineLimit(1)
+                }
+                Spacer(minLength: 4)
+            }
+            .padding(.horizontal, 8)
+            .frame(height: 40)
+            .contentShape(RoundedRectangle(cornerRadius: 6))
+        }
+        .buttonStyle(.plain)
+        .disabled(!isEnabled)
+        .opacity(isEnabled ? 1 : 0.5)
+        .background(
+            RoundedRectangle(cornerRadius: 6)
+                .fill(theme.color("bg-2").opacity(0.72))
+        )
+        .overlay(
+            RoundedRectangle(cornerRadius: 6)
+                .strokeBorder(theme.color("line").opacity(0.65), lineWidth: 0.75)
+        )
+        .help(title)
+    }
+}

--- a/Alas/Sources/Right/ChangesPreparationModel.swift
+++ b/Alas/Sources/Right/ChangesPreparationModel.swift
@@ -1,0 +1,91 @@
+import Foundation
+
+struct ChangesPreparationModel: Equatable {
+    struct ReviewAction: Equatable {
+        let title: String
+        let fileCount: Int
+        let additions: Int?
+        let deletions: Int?
+    }
+
+    struct DraftAction: Equatable {
+        let title: String
+        let stagedCount: Int
+        let additions: Int
+        let deletions: Int
+        let hasNonEmptyDraft: Bool
+    }
+
+    struct ReviewRequestAction: Equatable {
+        let kind: ReviewReadinessActionKind
+        let title: String
+        let isEnabled: Bool
+        let iconName: String
+        let emphasis: ReviewReadinessModel.Action.Emphasis
+    }
+
+    let reviewAction: ReviewAction?
+    let draftAction: DraftAction?
+    let reviewRequestAction: ReviewRequestAction?
+
+    var isVisible: Bool {
+        reviewAction != nil || draftAction != nil || reviewRequestAction != nil
+    }
+
+    init(
+        changes: [ChangedFile],
+        hasDraft: Bool,
+        draftNonEmpty: Bool,
+        readinessActions: [ReviewReadinessModel.Action]
+    ) {
+        if let summary = ReviewChangesTriggerSummary.summary(for: changes) {
+            reviewAction = ReviewAction(
+                title: "Review current changes",
+                fileCount: summary.fileCount,
+                additions: summary.additions,
+                deletions: summary.deletions
+            )
+        } else {
+            reviewAction = nil
+        }
+
+        let stagedChanges = changes.filter { $0.stage == .staged }
+        if !stagedChanges.isEmpty || hasDraft {
+            draftAction = DraftAction(
+                title: hasDraft ? "Open draft" : "Draft commit",
+                stagedCount: stagedChanges.count,
+                additions: stagedChanges.reduce(0) { $0 + $1.add },
+                deletions: stagedChanges.reduce(0) { $0 + $1.del },
+                hasNonEmptyDraft: draftNonEmpty
+            )
+        } else {
+            draftAction = nil
+        }
+
+        reviewRequestAction = Self.compactReviewRequestAction(from: readinessActions)
+    }
+
+    private static func compactReviewRequestAction(
+        from actions: [ReviewReadinessModel.Action]
+    ) -> ReviewRequestAction? {
+        for kind in compactActionPriority {
+            guard let action = actions.first(where: { $0.kind == kind }) else { continue }
+            return ReviewRequestAction(
+                kind: action.kind,
+                title: action.title,
+                isEnabled: action.isEnabled,
+                iconName: action.iconName,
+                emphasis: action.emphasis
+            )
+        }
+        return nil
+    }
+
+    private static let compactActionPriority: [ReviewReadinessActionKind] = [
+        .createReviewRequest,
+        .pushBranch,
+        .openReviewRequest,
+        .inspectReviewEvidence,
+        .refresh,
+    ]
+}

--- a/Alas/Sources/Right/ChangesPreparationModel.swift
+++ b/Alas/Sources/Right/ChangesPreparationModel.swift
@@ -38,20 +38,22 @@ struct ChangesPreparationModel: Equatable {
         draftNonEmpty: Bool,
         readinessActions: [ReviewReadinessModel.Action]
     ) {
+        let builtReviewAction: ReviewAction?
         if let summary = ReviewChangesTriggerSummary.summary(for: changes) {
-            reviewAction = ReviewAction(
+            builtReviewAction = ReviewAction(
                 title: "Review current changes",
                 fileCount: summary.fileCount,
                 additions: summary.additions,
                 deletions: summary.deletions
             )
         } else {
-            reviewAction = nil
+            builtReviewAction = nil
         }
 
         let stagedChanges = changes.filter { $0.stage == .staged }
+        let builtDraftAction: DraftAction?
         if !stagedChanges.isEmpty || hasDraft {
-            draftAction = DraftAction(
+            builtDraftAction = DraftAction(
                 title: hasDraft ? "Open draft" : "Draft commit",
                 stagedCount: stagedChanges.count,
                 additions: stagedChanges.reduce(0) { $0 + $1.add },
@@ -59,10 +61,19 @@ struct ChangesPreparationModel: Equatable {
                 hasNonEmptyDraft: draftNonEmpty
             )
         } else {
-            draftAction = nil
+            builtDraftAction = nil
         }
 
-        reviewRequestAction = Self.compactReviewRequestAction(from: readinessActions)
+        reviewAction = builtReviewAction
+        draftAction = builtDraftAction
+        let builtReviewRequestAction = Self.compactReviewRequestAction(from: readinessActions)
+        if builtReviewRequestAction?.kind == .refresh,
+           builtReviewAction == nil,
+           builtDraftAction == nil {
+            reviewRequestAction = nil
+        } else {
+            reviewRequestAction = builtReviewRequestAction
+        }
     }
 
     private static func compactReviewRequestAction(
@@ -84,8 +95,8 @@ struct ChangesPreparationModel: Equatable {
     private static let compactActionPriority: [ReviewReadinessActionKind] = [
         .createReviewRequest,
         .pushBranch,
-        .openReviewRequest,
         .inspectReviewEvidence,
+        .openReviewRequest,
         .refresh,
     ]
 }

--- a/Alas/Sources/Right/ChangesTabView.swift
+++ b/Alas/Sources/Right/ChangesTabView.swift
@@ -8,16 +8,6 @@ struct ChangesTabView: View {
     let onSelectCommit: (CommitInfo) -> Void
     let onEditCommit: (CommitInfo, String) -> Void
 
-    private var stagedCount: Int {
-        rps.changes.filter { $0.stage == .staged }.count
-    }
-    private var stagedAdd: Int {
-        rps.changes.filter { $0.stage == .staged }.reduce(0) { $0 + $1.add }
-    }
-    private var stagedDel: Int {
-        rps.changes.filter { $0.stage == .staged }.reduce(0) { $0 + $1.del }
-    }
-
     private var conflicts: [ChangedFile] {
         rps.changes.filter { $0.conflict != nil }
     }
@@ -26,8 +16,18 @@ struct ChangesTabView: View {
         rps.changes.filter { $0.conflict == nil }
     }
 
-    private var reviewChangesSummary: ReviewChangesTriggerSummary? {
-        ReviewChangesTriggerSummary.summary(for: rps.changes)
+    private var preparationModel: ChangesPreparationModel {
+        let readiness = ReviewReadinessModel(
+            snapshot: rps.reviewLoop.snapshot,
+            lastError: rps.reviewLoop.lastError,
+            canOpenAgentHandoff: rps.canOpenReviewLoopHandoff(appState: appState)
+        )
+        return ChangesPreparationModel(
+            changes: rps.changes,
+            hasDraft: hasDraftTab,
+            draftNonEmpty: draftNonEmpty,
+            readinessActions: readiness.actions
+        )
     }
 
     var body: some View {
@@ -85,20 +85,14 @@ struct ChangesTabView: View {
                 onDismissBulkReport: { rps.dismissBulkResolveReport() }
             )
 
-            if stagedCount > 0 {
-                DraftCommitTriggerRow(
-                    stagedCount: stagedCount,
-                    stagedAdd: stagedAdd,
-                    stagedDel: stagedDel,
-                    hasDraft: hasDraftTab,
-                    draftNonEmpty: draftNonEmpty,
-                    onOpen: openDraftTab
-                )
-            }
-            if let reviewChangesSummary {
-                ReviewChangesTriggerRow(
-                    summary: reviewChangesSummary,
-                    onOpen: openReviewChangesTab
+            if preparationModel.isVisible {
+                ChangesPreparationCard(
+                    model: preparationModel,
+                    onReviewChanges: openReviewChangesTab,
+                    onDraftCommit: openDraftTab,
+                    onReviewRequestAction: { action in
+                        rps.handleReviewReadinessAction(action, appState: appState)
+                    }
                 )
             }
             WorkingTreeSectionView(
@@ -250,106 +244,5 @@ struct ReviewChangesTriggerSummary: Equatable {
             additions: hasDuplicatePath ? nil : reviewableChanges.reduce(0) { $0 + $1.add },
             deletions: hasDuplicatePath ? nil : reviewableChanges.reduce(0) { $0 + $1.del }
         )
-    }
-}
-
-private struct ReviewChangesTriggerRow: View {
-    let summary: ReviewChangesTriggerSummary
-    let onOpen: () -> Void
-
-    @Environment(\.theme) private var theme
-
-    private var fileLabel: String {
-        summary.fileCount == 1 ? "1 file" : "\(summary.fileCount) files"
-    }
-
-    var body: some View {
-        Button(action: onOpen) {
-            HStack(spacing: 8) {
-                Icon(name: "diff", size: 11, color: theme.color("fg-dim"))
-                Text(fileLabel)
-                    .font(.system(size: 11, design: .monospaced))
-                    .foregroundColor(theme.color("fg-dim"))
-                if let additions = summary.additions, let deletions = summary.deletions {
-                    Text("·")
-                        .font(.system(size: 11))
-                        .foregroundColor(theme.color("fg-faint"))
-                    Text("+\(additions)")
-                        .font(.system(size: 11, design: .monospaced))
-                        .foregroundColor(theme.color("add"))
-                    Text("−\(deletions)")
-                        .font(.system(size: 11, design: .monospaced))
-                        .foregroundColor(theme.color("del"))
-                }
-                Spacer()
-                Text("Review Changes")
-                    .font(.system(size: 11.5, weight: .semibold))
-                    .foregroundColor(theme.color("accent"))
-                Icon(name: "chev-right", size: 10, color: theme.color("fg-faint"))
-            }
-            .padding(.horizontal, 12)
-            .padding(.vertical, 8)
-            .contentShape(Rectangle())
-        }
-        .buttonStyle(.plain)
-        .background(theme.color("bg-1"))
-        .overlay(Divider().opacity(0.5), alignment: .bottom)
-    }
-}
-
-private struct DraftCommitTriggerRow: View {
-    let stagedCount: Int
-    let stagedAdd: Int
-    let stagedDel: Int
-    let hasDraft: Bool
-    let draftNonEmpty: Bool
-    let onOpen: () -> Void
-
-    @Environment(\.theme) private var theme
-
-    private var label: String {
-        hasDraft ? "Open draft" : "Draft commit"
-    }
-
-    var body: some View {
-        Button(action: onOpen) {
-            HStack(spacing: 8) {
-                Icon(name: "commit", size: 11, color: theme.color("fg-dim"))
-                if stagedCount > 0 {
-                    Text("\(stagedCount) staged")
-                        .font(.system(size: 11, design: .monospaced))
-                        .foregroundColor(theme.color("fg-dim"))
-                    Text("·")
-                        .font(.system(size: 11))
-                        .foregroundColor(theme.color("fg-faint"))
-                    Text("+\(stagedAdd)")
-                        .font(.system(size: 11, design: .monospaced))
-                        .foregroundColor(theme.color("add"))
-                    Text("−\(stagedDel)")
-                        .font(.system(size: 11, design: .monospaced))
-                        .foregroundColor(theme.color("del"))
-                } else {
-                    Text("0 staged")
-                        .font(.system(size: 11, design: .monospaced))
-                        .foregroundColor(theme.color("fg-faint"))
-                }
-                Spacer()
-                if hasDraft && draftNonEmpty {
-                    Circle()
-                        .fill(theme.color("accent"))
-                        .frame(width: 5, height: 5)
-                }
-                Text(label)
-                    .font(.system(size: 11.5, weight: .semibold))
-                    .foregroundColor(theme.color("accent"))
-                Icon(name: "chev-right", size: 10, color: theme.color("fg-faint"))
-            }
-            .padding(.horizontal, 12)
-            .padding(.vertical, 8)
-            .contentShape(Rectangle())
-        }
-        .buttonStyle(.plain)
-        .background(theme.color("bg-1"))
-        .overlay(Divider().opacity(0.5), alignment: .bottom)
     }
 }

--- a/AlasTests/ReviewChangesModelsTests.swift
+++ b/AlasTests/ReviewChangesModelsTests.swift
@@ -209,6 +209,117 @@ struct ReviewChangesModelsTests {
             "staged:Sources/App.swift",
         ])
     }
+
+    @Test func preparationModelShowsReviewActionForNonConflictChangesOnly() throws {
+        let changes = [
+            changedFile("conflicted.swift", stage: .unstaged, add: 40, del: 5, conflict: .bothModified),
+            changedFile("Sources/App.swift", stage: .unstaged, add: 8, del: 2),
+        ]
+
+        let model = ChangesPreparationModel(
+            changes: changes,
+            hasDraft: false,
+            draftNonEmpty: false,
+            readinessActions: []
+        )
+
+        #expect(model.isVisible)
+        let review = try #require(model.reviewAction)
+        #expect(review.fileCount == 1)
+        #expect(review.additions == 8)
+        #expect(review.deletions == 2)
+        #expect(review.title == "Review current changes")
+    }
+
+    @Test func preparationModelHidesReviewActionWhenOnlyConflictsExist() {
+        let changes = [
+            changedFile("conflicted.swift", stage: .unstaged, add: 40, del: 5, conflict: .bothModified),
+        ]
+
+        let model = ChangesPreparationModel(
+            changes: changes,
+            hasDraft: false,
+            draftNonEmpty: false,
+            readinessActions: []
+        )
+
+        #expect(model.reviewAction == nil)
+        #expect(!model.isVisible)
+    }
+
+    @Test func preparationModelShowsDraftActionForStagedChanges() throws {
+        let model = ChangesPreparationModel(
+            changes: [
+                changedFile("Sources/App.swift", stage: .staged, add: 3, del: 1),
+                changedFile("Sources/View.swift", stage: .unstaged, add: 9, del: 0),
+            ],
+            hasDraft: false,
+            draftNonEmpty: false,
+            readinessActions: []
+        )
+
+        let draft = try #require(model.draftAction)
+        #expect(draft.title == "Draft commit")
+        #expect(draft.stagedCount == 1)
+        #expect(draft.additions == 3)
+        #expect(draft.deletions == 1)
+        #expect(!draft.hasNonEmptyDraft)
+    }
+
+    @Test func preparationModelShowsExistingDraftWithoutStagedChanges() throws {
+        let model = ChangesPreparationModel(
+            changes: [],
+            hasDraft: true,
+            draftNonEmpty: true,
+            readinessActions: []
+        )
+
+        #expect(model.isVisible)
+        let draft = try #require(model.draftAction)
+        #expect(draft.title == "Open draft")
+        #expect(draft.stagedCount == 0)
+        #expect(draft.additions == 0)
+        #expect(draft.deletions == 0)
+        #expect(draft.hasNonEmptyDraft)
+    }
+
+    @Test func preparationModelSelectsSingleReadinessActionByPriority() throws {
+        let actions = [
+            ReviewReadinessModel.Action(kind: .refresh, title: "Refresh", isEnabled: true),
+            ReviewReadinessModel.Action(kind: .inspectReviewEvidence, title: "Inspect", isEnabled: true),
+            ReviewReadinessModel.Action(kind: .openReviewRequest, title: "Open PR", isEnabled: true),
+            ReviewReadinessModel.Action(kind: .createReviewRequest, title: "Create PR", isEnabled: true),
+        ]
+
+        let model = ChangesPreparationModel(
+            changes: [],
+            hasDraft: false,
+            draftNonEmpty: false,
+            readinessActions: actions
+        )
+
+        let reviewRequest = try #require(model.reviewRequestAction)
+        #expect(reviewRequest.kind == .createReviewRequest)
+        #expect(reviewRequest.title == "Create PR")
+    }
+
+    @Test func preparationModelFallsBackToPushBeforeOpenRequest() throws {
+        let actions = [
+            ReviewReadinessModel.Action(kind: .openReviewRequest, title: "Open PR", isEnabled: true),
+            ReviewReadinessModel.Action(kind: .pushBranch, title: "Push", isEnabled: true),
+        ]
+
+        let model = ChangesPreparationModel(
+            changes: [],
+            hasDraft: false,
+            draftNonEmpty: false,
+            readinessActions: actions
+        )
+
+        let reviewRequest = try #require(model.reviewRequestAction)
+        #expect(reviewRequest.kind == .pushBranch)
+        #expect(reviewRequest.title == "Push")
+    }
 }
 
 private func changedFile(

--- a/AlasTests/ReviewChangesModelsTests.swift
+++ b/AlasTests/ReviewChangesModelsTests.swift
@@ -352,6 +352,25 @@ struct ReviewChangesModelsTests {
         #expect(reviewRequest.kind == .pushBranch)
         #expect(reviewRequest.title == "Push")
     }
+
+    @Test func preparationModelCanBeBuiltFromReadinessModelActions() throws {
+        let readiness = ReviewReadinessModel(
+            snapshot: ReviewChangesReadinessFixtures.makeSnapshot(reviewRequest: nil),
+            lastError: nil,
+            canOpenAgentHandoff: false
+        )
+
+        let model = ChangesPreparationModel(
+            changes: [changedFile("Sources/App.swift", stage: .unstaged, add: 2, del: 1)],
+            hasDraft: false,
+            draftNonEmpty: false,
+            readinessActions: readiness.actions
+        )
+
+        #expect(model.reviewAction?.title == "Review current changes")
+        #expect(model.reviewRequestAction?.kind == .createReviewRequest)
+        #expect(model.reviewRequestAction?.title == "Create PR")
+    }
 }
 
 private func changedFile(
@@ -392,4 +411,36 @@ private func reviewSummary(
         isRenderable: isRenderable,
         originalPath: originalPath
     )
+}
+
+private enum ReviewChangesReadinessFixtures {
+    static func makeSnapshot(reviewRequest: ReviewRequest?) -> ReviewLoopSnapshot {
+        let remote = CodeHostRemote(
+            kind: .github,
+            host: "github.com",
+            owner: "mrmans0n",
+            repository: "alas",
+            remoteName: "origin",
+            webURL: URL(string: "https://github.com/mrmans0n/alas")!
+        )
+        return ReviewLoopSnapshot(
+            local: ReviewLoopLocalState(
+                branchName: "feature/entrypoint",
+                headSHA: "abc123",
+                baseBranch: "main",
+                hasWorkingTreeChanges: true,
+                hasStagedChanges: true,
+                aheadCommitCount: 1,
+                hasUpstream: true,
+                upstreamAheadCommitCount: 0,
+                needsPush: false
+            ),
+            remote: remote,
+            reviewRequest: reviewRequest,
+            providerAvailable: true,
+            providerAuthenticated: true,
+            providerCapabilities: .githubCLI,
+            errorMessage: nil
+        )
+    }
 }

--- a/AlasTests/ReviewChangesModelsTests.swift
+++ b/AlasTests/ReviewChangesModelsTests.swift
@@ -371,6 +371,65 @@ struct ReviewChangesModelsTests {
         #expect(model.reviewRequestAction?.kind == .createReviewRequest)
         #expect(model.reviewRequestAction?.title == "Create PR")
     }
+
+    @Test func preparationModelDoesNotShowStandaloneRefreshWhileReadinessLoads() {
+        let loadingReadiness = ReviewReadinessModel(
+            snapshot: nil,
+            lastError: nil,
+            canOpenAgentHandoff: false
+        )
+
+        let model = ChangesPreparationModel(
+            changes: [],
+            hasDraft: false,
+            draftNonEmpty: false,
+            readinessActions: loadingReadiness.actions
+        )
+
+        #expect(model.reviewRequestAction == nil)
+        #expect(!model.isVisible)
+    }
+
+    @Test func preparationModelKeepsRefreshWhenCardIsVisibleForChanges() throws {
+        let loadingReadiness = ReviewReadinessModel(
+            snapshot: nil,
+            lastError: nil,
+            canOpenAgentHandoff: false
+        )
+
+        let model = ChangesPreparationModel(
+            changes: [changedFile("Sources/App.swift", stage: .unstaged, add: 2, del: 1)],
+            hasDraft: false,
+            draftNonEmpty: false,
+            readinessActions: loadingReadiness.actions
+        )
+
+        #expect(model.isVisible)
+        let action = try #require(model.reviewRequestAction)
+        #expect(action.kind == .refresh)
+    }
+
+    @Test func preparationModelPrefersInspectOverOpenRequestForFailedChecks() throws {
+        let request = ReviewChangesReadinessFixtures.makeReviewRequest(
+            checks: [ReviewChangesReadinessFixtures.makeCheck(bucket: .fail)]
+        )
+        let readiness = ReviewReadinessModel(
+            snapshot: ReviewChangesReadinessFixtures.makeSnapshot(reviewRequest: request),
+            lastError: nil,
+            canOpenAgentHandoff: false
+        )
+
+        let model = ChangesPreparationModel(
+            changes: [],
+            hasDraft: false,
+            draftNonEmpty: false,
+            readinessActions: readiness.actions
+        )
+
+        let action = try #require(model.reviewRequestAction)
+        #expect(action.kind == .inspectReviewEvidence)
+        #expect(action.title == "Inspect")
+    }
 }
 
 private func changedFile(
@@ -415,14 +474,7 @@ private func reviewSummary(
 
 private enum ReviewChangesReadinessFixtures {
     static func makeSnapshot(reviewRequest: ReviewRequest?) -> ReviewLoopSnapshot {
-        let remote = CodeHostRemote(
-            kind: .github,
-            host: "github.com",
-            owner: "mrmans0n",
-            repository: "alas",
-            remoteName: "origin",
-            webURL: URL(string: "https://github.com/mrmans0n/alas")!
-        )
+        let remote = makeRemote()
         return ReviewLoopSnapshot(
             local: ReviewLoopLocalState(
                 branchName: "feature/entrypoint",
@@ -441,6 +493,48 @@ private enum ReviewChangesReadinessFixtures {
             providerAuthenticated: true,
             providerCapabilities: .githubCLI,
             errorMessage: nil
+        )
+    }
+
+    static func makeReviewRequest(
+        remote: CodeHostRemote = makeRemote(),
+        checks: [ReviewCheck] = []
+    ) -> ReviewRequest {
+        ReviewRequest(
+            remote: remote,
+            number: 428,
+            title: "Entry point review",
+            url: remote.webURL.appending(path: "pull/428"),
+            state: .open,
+            isDraft: false,
+            headRefName: "feature/entrypoint",
+            baseRefName: "main",
+            reviewDecision: .reviewRequired,
+            mergeState: .blocked,
+            checks: checks,
+            threads: []
+        )
+    }
+
+    static func makeCheck(bucket: ReviewCheckBucket) -> ReviewCheck {
+        ReviewCheck(
+            id: "ci-tests",
+            name: "Tests",
+            workflow: "CI",
+            bucket: bucket,
+            detailURL: nil,
+            completedAt: nil
+        )
+    }
+
+    private static func makeRemote() -> CodeHostRemote {
+        CodeHostRemote(
+            kind: .github,
+            host: "github.com",
+            owner: "mrmans0n",
+            repository: "alas",
+            remoteName: "origin",
+            webURL: URL(string: "https://github.com/mrmans0n/alas")!
         )
     }
 }

--- a/AlasTests/ReviewChangesModelsTests.swift
+++ b/AlasTests/ReviewChangesModelsTests.swift
@@ -210,6 +210,38 @@ struct ReviewChangesModelsTests {
         ])
     }
 
+    @Test func preparationStatsFormatFileAndLineCounts() {
+        let single = ChangesPreparationCardText.reviewStats(
+            fileCount: 1,
+            additions: 3,
+            deletions: 1
+        )
+        #expect(single == "1 file · +3 −1")
+
+        let duplicatePath = ChangesPreparationCardText.reviewStats(
+            fileCount: 2,
+            additions: nil,
+            deletions: nil
+        )
+        #expect(duplicatePath == "2 files")
+    }
+
+    @Test func preparationStatsFormatDraftCounts() {
+        let staged = ChangesPreparationCardText.draftStats(
+            stagedCount: 2,
+            additions: 9,
+            deletions: 4
+        )
+        #expect(staged == "2 staged · +9 −4")
+
+        let empty = ChangesPreparationCardText.draftStats(
+            stagedCount: 0,
+            additions: 0,
+            deletions: 0
+        )
+        #expect(empty == "0 staged")
+    }
+
     @Test func preparationModelShowsReviewActionForNonConflictChangesOnly() throws {
         let changes = [
             changedFile("conflicted.swift", stage: .unstaged, add: 40, del: 5, conflict: .bothModified),

--- a/docs/superpowers/plans/2026-06-16-changes-preparation-entrypoint.md
+++ b/docs/superpowers/plans/2026-06-16-changes-preparation-entrypoint.md
@@ -1,0 +1,773 @@
+# Changes Preparation Entry Point Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace separate Changes-tab draft/review trigger rows with one coherent preparation card that opens the existing review, draft commit, and PR/MR workflows.
+
+**Architecture:** Add a pure `ChangesPreparationModel` that converts existing Changes tab state into a small set of presentation actions. Add a SwiftUI `ChangesPreparationCard` that renders those actions and calls existing handlers. Wire `ChangesTabView` to render the new card above the working tree while keeping the review-loop drawer as the detailed status surface.
+
+**Tech Stack:** Swift 5.9+, SwiftUI, Swift Testing, existing Alas theme/icons, existing `ReviewReadinessModel` and tab-opening APIs.
+
+---
+
+## File Structure
+
+- Create `Alas/Sources/Right/ChangesPreparationModel.swift`
+  - Owns the pure model for the card: primary review action, draft action, review-request action, stats, labels, and action-priority selection.
+- Create `Alas/Sources/Right/ChangesPreparationCard.swift`
+  - Owns SwiftUI rendering for the preparation card only.
+- Modify `Alas/Sources/Right/ChangesTabView.swift`
+  - Computes `ChangesPreparationModel`.
+  - Replaces `DraftCommitTriggerRow` and `ReviewChangesTriggerRow` with `ChangesPreparationCard`.
+  - Removes obsolete private trigger row views after integration.
+- Modify `AlasTests/ReviewChangesModelsTests.swift`
+  - Adds model tests for card visibility, review/draft action rules, conflicts, and readiness action priority.
+
+The Xcode project is generated. If new source files are not picked up by a build, run `xcodegen` and commit resulting project changes only if `xcodegen` actually changes `Alas.xcodeproj`.
+
+---
+
+### Task 1: Pure Preparation Model
+
+**Files:**
+- Create: `Alas/Sources/Right/ChangesPreparationModel.swift`
+- Modify: `AlasTests/ReviewChangesModelsTests.swift`
+
+- [ ] **Step 1: Add failing model tests**
+
+Append these tests inside `struct ReviewChangesModelsTests` in `AlasTests/ReviewChangesModelsTests.swift`, before the closing `}`:
+
+```swift
+    @Test func preparationModelShowsReviewActionForNonConflictChangesOnly() throws {
+        let changes = [
+            changedFile("conflicted.swift", stage: .unstaged, add: 40, del: 5, conflict: .bothModified),
+            changedFile("Sources/App.swift", stage: .unstaged, add: 8, del: 2),
+        ]
+
+        let model = ChangesPreparationModel(
+            changes: changes,
+            hasDraft: false,
+            draftNonEmpty: false,
+            readinessActions: []
+        )
+
+        #expect(model.isVisible)
+        let review = try #require(model.reviewAction)
+        #expect(review.fileCount == 1)
+        #expect(review.additions == 8)
+        #expect(review.deletions == 2)
+        #expect(review.title == "Review current changes")
+    }
+
+    @Test func preparationModelHidesReviewActionWhenOnlyConflictsExist() {
+        let changes = [
+            changedFile("conflicted.swift", stage: .unstaged, add: 40, del: 5, conflict: .bothModified),
+        ]
+
+        let model = ChangesPreparationModel(
+            changes: changes,
+            hasDraft: false,
+            draftNonEmpty: false,
+            readinessActions: []
+        )
+
+        #expect(model.reviewAction == nil)
+        #expect(!model.isVisible)
+    }
+
+    @Test func preparationModelShowsDraftActionForStagedChanges() throws {
+        let model = ChangesPreparationModel(
+            changes: [
+                changedFile("Sources/App.swift", stage: .staged, add: 3, del: 1),
+                changedFile("Sources/View.swift", stage: .unstaged, add: 9, del: 0),
+            ],
+            hasDraft: false,
+            draftNonEmpty: false,
+            readinessActions: []
+        )
+
+        let draft = try #require(model.draftAction)
+        #expect(draft.title == "Draft commit")
+        #expect(draft.stagedCount == 1)
+        #expect(draft.additions == 3)
+        #expect(draft.deletions == 1)
+        #expect(!draft.hasNonEmptyDraft)
+    }
+
+    @Test func preparationModelShowsExistingDraftWithoutStagedChanges() throws {
+        let model = ChangesPreparationModel(
+            changes: [],
+            hasDraft: true,
+            draftNonEmpty: true,
+            readinessActions: []
+        )
+
+        #expect(model.isVisible)
+        let draft = try #require(model.draftAction)
+        #expect(draft.title == "Open draft")
+        #expect(draft.stagedCount == 0)
+        #expect(draft.additions == 0)
+        #expect(draft.deletions == 0)
+        #expect(draft.hasNonEmptyDraft)
+    }
+
+    @Test func preparationModelSelectsSingleReadinessActionByPriority() throws {
+        let actions = [
+            ReviewReadinessModel.Action(kind: .refresh, title: "Refresh", isEnabled: true),
+            ReviewReadinessModel.Action(kind: .inspectReviewEvidence, title: "Inspect", isEnabled: true),
+            ReviewReadinessModel.Action(kind: .openReviewRequest, title: "Open PR", isEnabled: true),
+            ReviewReadinessModel.Action(kind: .createReviewRequest, title: "Create PR", isEnabled: true),
+        ]
+
+        let model = ChangesPreparationModel(
+            changes: [],
+            hasDraft: false,
+            draftNonEmpty: false,
+            readinessActions: actions
+        )
+
+        let reviewRequest = try #require(model.reviewRequestAction)
+        #expect(reviewRequest.kind == .createReviewRequest)
+        #expect(reviewRequest.title == "Create PR")
+    }
+
+    @Test func preparationModelFallsBackToPushBeforeOpenRequest() throws {
+        let actions = [
+            ReviewReadinessModel.Action(kind: .openReviewRequest, title: "Open PR", isEnabled: true),
+            ReviewReadinessModel.Action(kind: .pushBranch, title: "Push", isEnabled: true),
+        ]
+
+        let model = ChangesPreparationModel(
+            changes: [],
+            hasDraft: false,
+            draftNonEmpty: false,
+            readinessActions: actions
+        )
+
+        let reviewRequest = try #require(model.reviewRequestAction)
+        #expect(reviewRequest.kind == .pushBranch)
+        #expect(reviewRequest.title == "Push")
+    }
+```
+
+- [ ] **Step 2: Run tests and verify they fail**
+
+Run:
+
+```bash
+xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -only-testing:AlasTests/ReviewChangesModelsTests test
+```
+
+Expected: FAIL because `ChangesPreparationModel` does not exist.
+
+- [ ] **Step 3: Add `ChangesPreparationModel`**
+
+Create `Alas/Sources/Right/ChangesPreparationModel.swift`:
+
+```swift
+import Foundation
+
+struct ChangesPreparationModel: Equatable {
+    struct ReviewAction: Equatable {
+        let title: String
+        let fileCount: Int
+        let additions: Int?
+        let deletions: Int?
+    }
+
+    struct DraftAction: Equatable {
+        let title: String
+        let stagedCount: Int
+        let additions: Int
+        let deletions: Int
+        let hasNonEmptyDraft: Bool
+    }
+
+    struct ReviewRequestAction: Equatable {
+        let kind: ReviewReadinessActionKind
+        let title: String
+        let isEnabled: Bool
+        let iconName: String
+        let emphasis: ReviewReadinessModel.Action.Emphasis
+    }
+
+    let reviewAction: ReviewAction?
+    let draftAction: DraftAction?
+    let reviewRequestAction: ReviewRequestAction?
+
+    var isVisible: Bool {
+        reviewAction != nil || draftAction != nil || reviewRequestAction != nil
+    }
+
+    init(
+        changes: [ChangedFile],
+        hasDraft: Bool,
+        draftNonEmpty: Bool,
+        readinessActions: [ReviewReadinessModel.Action]
+    ) {
+        if let summary = ReviewChangesTriggerSummary.summary(for: changes) {
+            reviewAction = ReviewAction(
+                title: "Review current changes",
+                fileCount: summary.fileCount,
+                additions: summary.additions,
+                deletions: summary.deletions
+            )
+        } else {
+            reviewAction = nil
+        }
+
+        let stagedChanges = changes.filter { $0.stage == .staged }
+        if !stagedChanges.isEmpty || hasDraft {
+            draftAction = DraftAction(
+                title: hasDraft ? "Open draft" : "Draft commit",
+                stagedCount: stagedChanges.count,
+                additions: stagedChanges.reduce(0) { $0 + $1.add },
+                deletions: stagedChanges.reduce(0) { $0 + $1.del },
+                hasNonEmptyDraft: draftNonEmpty
+            )
+        } else {
+            draftAction = nil
+        }
+
+        reviewRequestAction = Self.compactReviewRequestAction(from: readinessActions)
+    }
+
+    private static func compactReviewRequestAction(
+        from actions: [ReviewReadinessModel.Action]
+    ) -> ReviewRequestAction? {
+        for kind in compactActionPriority {
+            guard let action = actions.first(where: { $0.kind == kind }) else { continue }
+            return ReviewRequestAction(
+                kind: action.kind,
+                title: action.title,
+                isEnabled: action.isEnabled,
+                iconName: action.iconName,
+                emphasis: action.emphasis
+            )
+        }
+        return nil
+    }
+
+    private static let compactActionPriority: [ReviewReadinessActionKind] = [
+        .createReviewRequest,
+        .pushBranch,
+        .openReviewRequest,
+        .inspectReviewEvidence,
+        .refresh,
+    ]
+}
+```
+
+- [ ] **Step 4: Run model tests and build**
+
+Run:
+
+```bash
+xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -only-testing:AlasTests/ReviewChangesModelsTests test
+xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -quiet build
+```
+
+Expected: both commands exit 0. If the build cannot find the new source file, run `xcodegen` and rerun both commands.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Alas/Sources/Right/ChangesPreparationModel.swift AlasTests/ReviewChangesModelsTests.swift Alas.xcodeproj/project.pbxproj
+git commit -m "feat(changes): model preparation entry points"
+```
+
+If `Alas.xcodeproj/project.pbxproj` is unchanged, omit it from `git add`.
+
+---
+
+### Task 2: Preparation Card View
+
+**Files:**
+- Create: `Alas/Sources/Right/ChangesPreparationCard.swift`
+- Modify: `AlasTests/ReviewChangesModelsTests.swift`
+
+- [ ] **Step 1: Add card formatting tests**
+
+Append these tests inside `struct ReviewChangesModelsTests`:
+
+```swift
+    @Test func preparationStatsFormatFileAndLineCounts() {
+        let single = ChangesPreparationCardText.reviewStats(
+            fileCount: 1,
+            additions: 3,
+            deletions: 1
+        )
+        #expect(single == "1 file · +3 −1")
+
+        let duplicatePath = ChangesPreparationCardText.reviewStats(
+            fileCount: 2,
+            additions: nil,
+            deletions: nil
+        )
+        #expect(duplicatePath == "2 files")
+    }
+
+    @Test func preparationStatsFormatDraftCounts() {
+        let staged = ChangesPreparationCardText.draftStats(
+            stagedCount: 2,
+            additions: 9,
+            deletions: 4
+        )
+        #expect(staged == "2 staged · +9 −4")
+
+        let empty = ChangesPreparationCardText.draftStats(
+            stagedCount: 0,
+            additions: 0,
+            deletions: 0
+        )
+        #expect(empty == "0 staged")
+    }
+```
+
+- [ ] **Step 2: Run tests and verify they fail**
+
+Run:
+
+```bash
+xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -only-testing:AlasTests/ReviewChangesModelsTests test
+```
+
+Expected: FAIL because `ChangesPreparationCardText` does not exist.
+
+- [ ] **Step 3: Add `ChangesPreparationCardText` and `ChangesPreparationCard`**
+
+Create `Alas/Sources/Right/ChangesPreparationCard.swift`:
+
+```swift
+import SwiftUI
+
+enum ChangesPreparationCardText {
+    static func reviewStats(fileCount: Int, additions: Int?, deletions: Int?) -> String {
+        let files = fileCount == 1 ? "1 file" : "\(fileCount) files"
+        guard let additions, let deletions else { return files }
+        return "\(files) · +\(additions) −\(deletions)"
+    }
+
+    static func draftStats(stagedCount: Int, additions: Int, deletions: Int) -> String {
+        guard stagedCount > 0 else { return "0 staged" }
+        let staged = stagedCount == 1 ? "1 staged" : "\(stagedCount) staged"
+        return "\(staged) · +\(additions) −\(deletions)"
+    }
+}
+
+struct ChangesPreparationCard: View {
+    let model: ChangesPreparationModel
+    let onReviewChanges: () -> Void
+    let onDraftCommit: () -> Void
+    let onReviewRequestAction: (ReviewReadinessActionKind) -> Void
+
+    @Environment(\.theme) private var theme
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 9) {
+            header
+            if let reviewAction = model.reviewAction {
+                primaryReviewButton(reviewAction)
+            }
+            if model.draftAction != nil || model.reviewRequestAction != nil {
+                HStack(spacing: 8) {
+                    if let draftAction = model.draftAction {
+                        secondaryDraftButton(draftAction)
+                    }
+                    if let reviewRequestAction = model.reviewRequestAction {
+                        secondaryReviewRequestButton(reviewRequestAction)
+                    }
+                }
+            }
+        }
+        .padding(10)
+        .background(
+            RoundedRectangle(cornerRadius: 8)
+                .fill(theme.color("bg-1"))
+        )
+        .overlay(
+            RoundedRectangle(cornerRadius: 8)
+                .strokeBorder(theme.color("line").opacity(0.75), lineWidth: 0.75)
+        )
+        .padding(.horizontal, 10)
+        .padding(.top, 8)
+        .padding(.bottom, 6)
+        .accessibilityIdentifier("changes-preparation-card")
+    }
+
+    private var header: some View {
+        HStack(spacing: 6) {
+            Icon(name: "diff", size: 11, color: theme.color("fg-faint"))
+            Text("Prepare")
+                .font(.system(size: 10.5, weight: .semibold))
+                .tracking(0.5)
+                .foregroundColor(theme.color("fg-muted"))
+                .textCase(.uppercase)
+            Spacer(minLength: 0)
+        }
+    }
+
+    private func primaryReviewButton(_ action: ChangesPreparationModel.ReviewAction) -> some View {
+        Button(action: onReviewChanges) {
+            HStack(spacing: 9) {
+                Icon(name: "diff", size: 13, color: theme.color("bg-0"))
+                VStack(alignment: .leading, spacing: 2) {
+                    Text(action.title)
+                        .font(.system(size: 12.5, weight: .semibold))
+                        .foregroundColor(theme.color("bg-0"))
+                    Text(ChangesPreparationCardText.reviewStats(
+                        fileCount: action.fileCount,
+                        additions: action.additions,
+                        deletions: action.deletions
+                    ))
+                    .font(.system(size: 11, design: .monospaced))
+                    .foregroundColor(theme.color("bg-0").opacity(0.72))
+                }
+                Spacer(minLength: 8)
+                Icon(name: "chev-right", size: 11, color: theme.color("bg-0").opacity(0.72))
+            }
+            .padding(.horizontal, 10)
+            .frame(minHeight: 44)
+            .contentShape(RoundedRectangle(cornerRadius: 7))
+        }
+        .buttonStyle(.plain)
+        .background(
+            RoundedRectangle(cornerRadius: 7)
+                .fill(theme.color("accent"))
+        )
+        .help(action.title)
+        .accessibilityIdentifier("changes-preparation-review")
+    }
+
+    private func secondaryDraftButton(_ action: ChangesPreparationModel.DraftAction) -> some View {
+        secondaryButton(
+            title: action.title,
+            subtitle: ChangesPreparationCardText.draftStats(
+                stagedCount: action.stagedCount,
+                additions: action.additions,
+                deletions: action.deletions
+            ),
+            iconName: "commit",
+            showsDot: action.hasNonEmptyDraft,
+            isEnabled: true,
+            action: onDraftCommit
+        )
+        .accessibilityIdentifier("changes-preparation-draft")
+    }
+
+    private func secondaryReviewRequestButton(
+        _ action: ChangesPreparationModel.ReviewRequestAction
+    ) -> some View {
+        secondaryButton(
+            title: action.title,
+            subtitle: "Branch review",
+            iconName: action.iconName,
+            showsDot: action.emphasis == .primary,
+            isEnabled: action.isEnabled,
+            action: { onReviewRequestAction(action.kind) }
+        )
+        .accessibilityIdentifier("changes-preparation-review-request")
+    }
+
+    private func secondaryButton(
+        title: String,
+        subtitle: String,
+        iconName: String,
+        showsDot: Bool,
+        isEnabled: Bool,
+        action: @escaping () -> Void
+    ) -> some View {
+        Button(action: action) {
+            HStack(spacing: 8) {
+                Icon(name: iconName, size: 11, color: theme.color("fg-dim"))
+                VStack(alignment: .leading, spacing: 1) {
+                    HStack(spacing: 5) {
+                        Text(title)
+                            .font(.system(size: 11.5, weight: .semibold))
+                            .foregroundColor(theme.color("fg"))
+                            .lineLimit(1)
+                        if showsDot {
+                            Circle()
+                                .fill(theme.color("accent"))
+                                .frame(width: 5, height: 5)
+                        }
+                    }
+                    Text(subtitle)
+                        .font(.system(size: 10.5))
+                        .foregroundColor(theme.color("fg-faint"))
+                        .lineLimit(1)
+                }
+                Spacer(minLength: 4)
+            }
+            .padding(.horizontal, 8)
+            .frame(height: 40)
+            .contentShape(RoundedRectangle(cornerRadius: 6))
+        }
+        .buttonStyle(.plain)
+        .disabled(!isEnabled)
+        .opacity(isEnabled ? 1 : 0.5)
+        .background(
+            RoundedRectangle(cornerRadius: 6)
+                .fill(theme.color("bg-2").opacity(0.72))
+        )
+        .overlay(
+            RoundedRectangle(cornerRadius: 6)
+                .strokeBorder(theme.color("line").opacity(0.65), lineWidth: 0.75)
+        )
+        .help(title)
+    }
+}
+```
+
+- [ ] **Step 4: Run focused tests and build**
+
+Run:
+
+```bash
+xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -only-testing:AlasTests/ReviewChangesModelsTests test
+xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -quiet build
+```
+
+Expected: both commands exit 0. If the build cannot find the new source file, run `xcodegen` and rerun both commands.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Alas/Sources/Right/ChangesPreparationCard.swift AlasTests/ReviewChangesModelsTests.swift Alas.xcodeproj/project.pbxproj
+git commit -m "feat(changes): add preparation card view"
+```
+
+If `Alas.xcodeproj/project.pbxproj` is unchanged, omit it from `git add`.
+
+---
+
+### Task 3: Integrate Card Into Changes Tab
+
+**Files:**
+- Modify: `Alas/Sources/Right/ChangesTabView.swift`
+- Modify: `AlasTests/ReviewChangesModelsTests.swift`
+
+- [ ] **Step 1: Add model construction test for readiness actions**
+
+Append this test inside `struct ReviewChangesModelsTests`:
+
+```swift
+    @Test func preparationModelCanBeBuiltFromReadinessModelActions() throws {
+        let readiness = ReviewReadinessModel(
+            snapshot: ReviewChangesReadinessFixtures.makeSnapshot(reviewRequest: nil),
+            lastError: nil,
+            canOpenAgentHandoff: false
+        )
+
+        let model = ChangesPreparationModel(
+            changes: [changedFile("Sources/App.swift", stage: .unstaged, add: 2, del: 1)],
+            hasDraft: false,
+            draftNonEmpty: false,
+            readinessActions: readiness.actions
+        )
+
+        #expect(model.reviewAction?.title == "Review current changes")
+        #expect(model.reviewRequestAction?.kind == .createReviewRequest)
+        #expect(model.reviewRequestAction?.title == "Create PR")
+    }
+```
+
+Then add this helper after the existing private helpers in `AlasTests/ReviewChangesModelsTests.swift`:
+
+```swift
+private enum ReviewChangesReadinessFixtures {
+    static func makeSnapshot(reviewRequest: ReviewRequest?) -> ReviewLoopSnapshot {
+        let remote = CodeHostRemote(
+            kind: .github,
+            host: "github.com",
+            owner: "mrmans0n",
+            repository: "alas",
+            remoteName: "origin",
+            webURL: URL(string: "https://github.com/mrmans0n/alas")!
+        )
+        return ReviewLoopSnapshot(
+            local: ReviewLoopLocalState(
+                branchName: "feature/entrypoint",
+                headSHA: "abc123",
+                baseBranch: "main",
+                hasWorkingTreeChanges: true,
+                hasStagedChanges: true,
+                aheadCommitCount: 1,
+                hasUpstream: true,
+                upstreamAheadCommitCount: 0,
+                needsPush: false
+            ),
+            remote: remote,
+            reviewRequest: reviewRequest,
+            providerAvailable: true,
+            providerAuthenticated: true,
+            providerCapabilities: .githubCLI,
+            errorMessage: nil
+        )
+    }
+}
+```
+
+- [ ] **Step 2: Run tests and verify they pass before UI integration**
+
+Run:
+
+```bash
+xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -only-testing:AlasTests/ReviewChangesModelsTests test
+```
+
+Expected: PASS. This confirms the model can consume real readiness actions before the view is rewired.
+
+- [ ] **Step 3: Modify `ChangesTabView`**
+
+In `Alas/Sources/Right/ChangesTabView.swift`, replace the old trigger rows:
+
+```swift
+            if stagedCount > 0 {
+                DraftCommitTriggerRow(
+                    stagedCount: stagedCount,
+                    stagedAdd: stagedAdd,
+                    stagedDel: stagedDel,
+                    hasDraft: hasDraftTab,
+                    draftNonEmpty: draftNonEmpty,
+                    onOpen: openDraftTab
+                )
+            }
+            if let reviewChangesSummary {
+                ReviewChangesTriggerRow(
+                    summary: reviewChangesSummary,
+                    onOpen: openReviewChangesTab
+                )
+            }
+```
+
+with:
+
+```swift
+            if preparationModel.isVisible {
+                ChangesPreparationCard(
+                    model: preparationModel,
+                    onReviewChanges: openReviewChangesTab,
+                    onDraftCommit: openDraftTab,
+                    onReviewRequestAction: { action in
+                        rps.handleReviewReadinessAction(action, appState: appState)
+                    }
+                )
+            }
+```
+
+Add this computed model near the existing `reviewChangesSummary` property:
+
+```swift
+    private var preparationModel: ChangesPreparationModel {
+        let readiness = ReviewReadinessModel(
+            snapshot: rps.reviewLoop.snapshot,
+            lastError: rps.reviewLoop.lastError,
+            canOpenAgentHandoff: rps.canOpenReviewLoopHandoff(appState: appState)
+        )
+        return ChangesPreparationModel(
+            changes: rps.changes,
+            hasDraft: hasDraftTab,
+            draftNonEmpty: draftNonEmpty,
+            readinessActions: readiness.actions
+        )
+    }
+```
+
+Remove the now-unused `reviewChangesSummary` computed property from `ChangesTabView`.
+
+Delete the obsolete private view types from the bottom of `ChangesTabView.swift`:
+
+- `private struct ReviewChangesTriggerRow: View`, currently beginning near line
+  256, through its closing brace.
+- `private struct DraftCommitTriggerRow: View`, currently beginning near line
+  300, through its closing brace at the end of the file.
+
+Keep `ReviewChangesTriggerSummary` in `ChangesTabView.swift` for now, because the model and existing tests use it.
+
+- [ ] **Step 4: Run focused tests and build**
+
+Run:
+
+```bash
+xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -only-testing:AlasTests/ReviewChangesModelsTests -only-testing:AlasTests/Integrations/ReviewReadinessModelTests test
+xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -quiet build
+```
+
+Expected: both commands exit 0.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Alas/Sources/Right/ChangesTabView.swift AlasTests/ReviewChangesModelsTests.swift
+git commit -m "feat(changes): surface preparation card"
+```
+
+---
+
+### Task 4: Final Verification and Cleanup
+
+**Files:**
+- Review all changed files from Tasks 1-3.
+
+- [ ] **Step 1: Scan for obsolete trigger-row references**
+
+Run:
+
+```bash
+rg -n "DraftCommitTriggerRow|ReviewChangesTriggerRow|reviewChangesSummary" Alas/Sources AlasTests
+```
+
+Expected: no references to `DraftCommitTriggerRow` or `ReviewChangesTriggerRow`. `ReviewChangesTriggerSummary` references are expected.
+
+- [ ] **Step 2: Regenerate project**
+
+Run:
+
+```bash
+xcodegen
+git status --short
+```
+
+Expected: no `project.yml` changes. If `Alas.xcodeproj/project.pbxproj` changes because new source files were not already present, include it in the final commit.
+
+- [ ] **Step 3: Run focused tests**
+
+Run:
+
+```bash
+xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -only-testing:AlasTests/ReviewChangesModelsTests -only-testing:AlasTests/Integrations/ReviewReadinessModelTests test
+```
+
+Expected: exit 0.
+
+- [ ] **Step 4: Run quiet build**
+
+Run:
+
+```bash
+xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -quiet build
+```
+
+Expected: exit 0.
+
+- [ ] **Step 5: Run full test suite**
+
+Run:
+
+```bash
+xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' test
+```
+
+Expected: exit 0. If a known flaky unrelated test fails, rerun that exact test once and document the result before final reporting.
+
+- [ ] **Step 6: Commit final project cleanup if needed**
+
+If Step 2 changed the generated Xcode project and no task commit already included it:
+
+```bash
+git add Alas.xcodeproj/project.pbxproj
+git commit -m "chore: update generated project"
+```
+
+If no files changed, do not create a commit.

--- a/docs/superpowers/specs/2026-06-16-changes-preparation-entrypoint-design.md
+++ b/docs/superpowers/specs/2026-06-16-changes-preparation-entrypoint-design.md
@@ -1,0 +1,155 @@
+# Changes Preparation Entry Point Design
+
+## Context
+
+The Changes tab currently exposes related destinations as separate, similarly
+weighted rows: draft commit, review changes, and the review-loop drawer. The
+center panes for these workflows are useful and should remain separate, but the
+right-pane entry points feel duplicative because they compete for attention
+instead of presenting one clear preparation hierarchy.
+
+The goal of this pass is to improve how users get from the Changes tab to the
+existing draft commit, local review, and PR/MR review-request workflows. This is
+an entry-point and hierarchy change only; it does not redesign the center panes
+or provider behavior.
+
+## Goals
+
+- Make the Changes tab read as one coherent preparation surface.
+- Keep `DraftCommitTabView`, `ReviewSessionTabView`, and
+  `DraftReviewRequestTabView` as separate center-pane destinations.
+- Replace the separate draft/review trigger rows with one polished preparation
+  card.
+- Make `Review current changes` the primary doorway when reviewable changes
+  exist.
+- Surface one compact PR/MR readiness action using existing review-loop logic.
+- Preserve current staging, discard, conflict, commit-list, and review-loop
+  behavior.
+
+## Non-Goals
+
+- Redesigning draft commit composition.
+- Redesigning the multi-file review tab.
+- Redesigning draft PR/MR creation.
+- Removing the review-loop drawer.
+- Changing provider readiness rules.
+- Adding new provider actions.
+
+## Proposed Hierarchy
+
+Add a single preparation card near the top of the Changes tab, below merge
+operation and conflict UI and above the working-tree file list.
+
+The card contains one primary action:
+
+- `Review current changes`
+
+This opens the existing multi-file review center pane. It shows the number of
+reviewable files and aggregate additions/deletions. It appears only when there
+are reviewable non-conflict changes.
+
+The card also contains compact secondary actions:
+
+- `Draft commit` or `Open draft`
+- `Create PR/MR`, `Push`, `Open PR/MR`, `Inspect`, or `Refresh`
+
+These are not competing top-level rows. They are destination actions inside the
+same preparation card, making the Changes tab hierarchy clearer while preserving
+the current workflow separation.
+
+## Behavior Rules
+
+The preparation card appears when any of the following is true:
+
+- there are reviewable non-conflict file changes
+- there are staged changes
+- there is a live or stashed draft commit
+- the review-loop readiness model exposes one of the compact action kinds
+  listed below
+
+The primary review action appears only when `ReviewChangesTriggerSummary`
+produces a summary for reviewable changes. Conflicts do not count toward this
+summary.
+
+The draft commit action appears when staged changes exist or when a live/stashed
+draft commit exists. Its label is `Draft commit` for a new draft and `Open
+draft` when a draft already exists. If no staged changes exist but a draft
+exists, the action remains visible so users can recover or finish the draft.
+
+The PR/MR action reuses `ReviewReadinessModel.actions` and selects one compact
+action by priority:
+
+1. `createReviewRequest`
+2. `pushBranch`
+3. `openReviewRequest`
+4. `inspectReviewEvidence`
+5. `refresh`
+
+The card must not show multiple PR/MR actions. The existing `ReviewLoopDrawer`
+remains the detailed surface for branch state, chips, facts, and secondary
+review-loop actions.
+
+Conflicts and merge operations continue to take visual priority above the
+preparation card.
+
+## Implementation Shape
+
+Introduce a small pure model named `ChangesPreparationModel`, built from data
+already available to `ChangesTabView`:
+
+- changed files and `ReviewChangesTriggerSummary`
+- staged file count and staged additions/deletions
+- live/stashed draft commit state
+- `ReviewReadinessModel`
+
+The model produces:
+
+- optional primary review action metadata
+- optional draft commit action metadata
+- optional review-request action metadata
+- compact stats and status text for the card
+
+`ChangesTabView` renders a new `ChangesPreparationCard` from that model. The
+card does not directly know about git, provider clients, or tab construction. It
+calls existing handlers supplied by `ChangesTabView`:
+
+- `openReviewChangesTab`
+- `openDraftTab`
+- `rps.handleReviewReadinessAction(_, appState:)`
+
+This keeps provider and branch-readiness policy inside the existing review-loop
+model and state objects.
+
+## Review Loop Drawer
+
+The `ReviewLoopDrawer` stays in place for this pass. It remains the detailed
+branch/review status surface with chips, facts, and secondary actions.
+
+If the preparation card later makes the drawer feel redundant, a follow-up can
+collapse the drawer by default, move selected chips into the card, or turn the
+drawer into an explicit branch review status popover.
+
+## Testing
+
+Focused model tests should cover:
+
+- review action appears only when reviewable non-conflict changes exist
+- draft commit action appears for staged changes
+- draft commit action appears for existing live/stashed drafts even without
+  staged changes
+- review-request action selects the highest-priority readiness action
+- review-request action does not expose multiple readiness actions
+- conflicts are excluded from reviewable change summaries
+
+Hosted UI coverage can stay light. Add a `ChangesPreparationCard` or
+`ChangesTabView` test only if the current test harness makes button ordering and
+handler invocation practical.
+
+## Fast Follow
+
+- Re-evaluate whether the `ReviewLoopDrawer` should collapse by default after
+  the preparation card lands.
+- Consider moving the most important readiness chips into the card once the
+  compact action proves useful.
+- Add keyboard shortcuts for review changes, draft commit, and create/open
+  review request.


### PR DESCRIPTION
## Summary
- Replace separate Changes-tab draft/review trigger rows with one preparation card
- Keep review changes, draft commit, and draft PR/MR flows as separate center panes
- Prioritize the most relevant review-readiness action and suppress refresh-only noise

## Verification
- xcodegen
- xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -only-testing:AlasTests/ReviewChangesModelsTests test
- xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -only-testing:AlasTests/ReviewReadinessModelTests test
- xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -quiet build
- xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' test