### PR TITLE
fix(changes): stale changes snapshot flash

### DIFF
--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -5498,7 +5498,7 @@
 			repositoryURL = "https://github.com/apple/swift-markdown";
 			requirement = {
 				kind = upToNextMajorVersion;
-				minimumVersion = 0.4.0;
+				minimumVersion = 0.8.0;
 			};
 		};
 		CF72A36467D20A160E653761 /* XCRemoteSwiftPackageReference "swift-tree-sitter" */ = {

--- a/Alas/Sources/App/AppState.swift
+++ b/Alas/Sources/App/AppState.swift
@@ -844,6 +844,7 @@ final class AppState {
                 return ""
             }
         }
+        rightPaneStore.invalidateSnapshot(worktreeId: optimisticId)
         let optimistic = Worktree(
             id: optimisticId,
             projectId: projectId,

--- a/Alas/Sources/Right/RightPaneState.swift
+++ b/Alas/Sources/Right/RightPaneState.swift
@@ -11,6 +11,10 @@ final class RightPaneState {
     let worktree: Worktree
     let reviewLoop: ReviewLoopState
     var changes: [ChangedFile] = []
+    private(set) var hasLoadedSnapshot: Bool = false
+    var displayChanges: [ChangedFile] {
+        hasLoadedSnapshot ? changes : []
+    }
     /// Increments whenever `refresh()` publishes a new change list. This
     /// catches same-line unstaged edits whose add/delete totals stay constant.
     private(set) var changesGeneration: Int = 0
@@ -381,6 +385,7 @@ final class RightPaneState {
             self.upstreamRef = resolvedUpstream?.ref
             _ = await mergeRefresh
             self.changes = entries
+            self.hasLoadedSnapshot = true
             self.changesGeneration += 1
             if let lsResult = try? await Process.git(
                 ["ls-files", "-s", "-z"],
@@ -445,6 +450,20 @@ final class RightPaneState {
             // an empty Changes pane when the very first refresh failed.
             logger.error("refresh failed for worktree \(self.worktree.path.path, privacy: .public): \(error.localizedDescription, privacy: .public)")
         }
+    }
+
+    func markSnapshotUnknown() {
+        hasLoadedSnapshot = false
+        changes = []
+        indexFingerprint = ""
+        fileTree = []
+        commits = []
+        olderCommits = []
+        comparisonRef = nil
+        sidebarError = nil
+        pendingDiscard = nil
+        changesGeneration += 1
+        invalidateFileTreeChildLoadsForRefresh()
     }
 
     private func refreshReviewLoop(

--- a/Alas/Sources/Right/RightPaneState.swift
+++ b/Alas/Sources/Right/RightPaneState.swift
@@ -18,6 +18,10 @@ final class RightPaneState {
     /// Increments whenever `refresh()` publishes a new change list. This
     /// catches same-line unstaged edits whose add/delete totals stay constant.
     private(set) var changesGeneration: Int = 0
+    /// Increments whenever cached snapshot data is explicitly invalidated.
+    /// In-flight refreshes capture this before doing async work and must not
+    /// publish if it changed underneath them.
+    private var snapshotInvalidationGeneration: Int = 0
     /// Fingerprint of the staged index contents (concatenated blob SHAs of
     /// staged files). Changes whenever any staged file's contents change,
     /// even when add/del totals are identical. Used by views that need to
@@ -352,6 +356,7 @@ final class RightPaneState {
     @MainActor
     func refresh() async {
         let reviewLoopInspection = reviewLoop.beginLocalInspection()
+        let snapshotGeneration = snapshotInvalidationGeneration
         loading = true
         defer { loading = false }
         invalidateFileTreeChildLoadsForRefresh()
@@ -382,11 +387,8 @@ final class RightPaneState {
             let (commits, ref) = try await c
             let reviewLoopBaseResult = try? await reviewLoopBase
             let resolvedUpstream = try? await upstream
-            self.upstreamRef = resolvedUpstream?.ref
             _ = await mergeRefresh
-            self.changes = entries
-            self.hasLoadedSnapshot = true
-            self.changesGeneration += 1
+            let indexFingerprint: String
             if let lsResult = try? await Process.git(
                 ["ls-files", "-s", "-z"],
                 cwd: worktree.path
@@ -398,19 +400,27 @@ final class RightPaneState {
                     .split(separator: "\0", omittingEmptySubsequences: true)
                     .map(String.init)
                     .sorted()
-                self.indexFingerprint = tokens.joined(separator: "|")
+                indexFingerprint = tokens.joined(separator: "|")
             } else {
-                self.indexFingerprint = ""
+                indexFingerprint = ""
             }
+            let previousBranch = self.currentBranch
+            let previousHeadSHA = self.currentHeadSHA
+            let currentBranch = (try? await br) ?? self.currentBranch
+            let headSHA = (try? await self.git.revParseHEAD(worktreePath: self.worktree.path)) ?? ""
+            guard snapshotGeneration == snapshotInvalidationGeneration else {
+                return
+            }
+            self.upstreamRef = resolvedUpstream?.ref
+            self.changes = entries
+            self.changesGeneration += 1
+            self.indexFingerprint = indexFingerprint
             self.fileTree = tree
             self.commits = commits
             self.comparisonRef = ref
-            let previousBranch = self.currentBranch
-            self.currentBranch = (try? await br) ?? self.currentBranch
-            let previousHeadSHA = self.currentHeadSHA
-            let headSHA = (try? await self.git.revParseHEAD(worktreePath: self.worktree.path)) ?? ""
+            self.currentBranch = currentBranch
             self.currentHeadSHA = headSHA
-            if previousBranch != self.currentBranch || previousHeadSHA != self.currentHeadSHA {
+            if previousBranch != currentBranch || previousHeadSHA != headSHA {
                 // Branch or HEAD changed (checkout, rebase, reset, amend, …).
                 // The behind chips were probed against the OLD branch's base
                 // and upstream — clear them so the header doesn't render
@@ -430,6 +440,7 @@ final class RightPaneState {
                 }
                 didInitDefaultTab = true
             }
+            self.hasLoadedSnapshot = true
             let upstreamBranchName = resolvedUpstream.map {
                 String($0.ref.dropFirst($0.remote.count + 1))
             }
@@ -453,6 +464,7 @@ final class RightPaneState {
     }
 
     func markSnapshotUnknown() {
+        snapshotInvalidationGeneration += 1
         hasLoadedSnapshot = false
         changes = []
         indexFingerprint = ""

--- a/Alas/Sources/Right/RightPaneState.swift
+++ b/Alas/Sources/Right/RightPaneState.swift
@@ -455,6 +455,12 @@ final class RightPaneState {
             )
         } catch {
             reviewLoop.failLocalRefresh(reviewLoopInspection, error: error)
+            guard snapshotGeneration == snapshotInvalidationGeneration else {
+                return
+            }
+            sidebarError = error.localizedDescription
+            hasLoadedSnapshot = true
+            changesGeneration += 1
             // Surface failures via os.Logger so they're visible in Console.app
             // and the unified log. The previous `print` here silently kept
             // `self.changes` at its last successful value, which presented as

--- a/Alas/Sources/Right/RightPaneStore.swift
+++ b/Alas/Sources/Right/RightPaneStore.swift
@@ -95,6 +95,10 @@ final class RightPaneStore {
         await state.refresh()
     }
 
+    func invalidateSnapshot(worktreeId: String) {
+        states[worktreeId]?.markSnapshotUnknown()
+    }
+
     func commitEditorComparisonRef(worktreeId: String) -> String? {
         guard let state = states[worktreeId] else { return nil }
         return state.comparisonRef

--- a/Alas/Sources/Right/RightPaneTransitionalView.swift
+++ b/Alas/Sources/Right/RightPaneTransitionalView.swift
@@ -51,7 +51,7 @@ struct RightPaneTransitionalView: View {
     private var content: some View {
         switch kind {
         case .creating:
-            CreatingSkeletonView(activeTab: activeTab)
+            RightPaneLoadingSkeletonView(activeTab: activeTab)
         case .deleting:
             CompactStateLabel(
                 systemIcon: "trash",
@@ -70,7 +70,7 @@ struct RightPaneTransitionalView: View {
 
 // MARK: - Creating skeleton
 
-private struct CreatingSkeletonView: View {
+struct RightPaneLoadingSkeletonView: View {
     let activeTab: RightPaneTab
 
     var body: some View {

--- a/Alas/Sources/Right/RightPaneView.swift
+++ b/Alas/Sources/Right/RightPaneView.swift
@@ -15,6 +15,7 @@ struct RightPaneView: View {
             baseBranch: state.config.worktrees.baseBranch,
             trackUpstreamForCommits: state.config.changes.trackUpstreamForCommits
         )
+        let displayChanges = rps.displayChanges
         let override = state.config.sidebarChromeOverride(forThemeId: state.themeStore.current.id)
         ZStack {
             SidebarMaterialBackground(
@@ -27,9 +28,9 @@ struct RightPaneView: View {
                         get: { rps.activeTab },
                         set: { rps.activeTab = $0 }
                     ),
-                    changesCount: rps.changes.count,
-                    totalAdd: rps.changes.reduce(0) { $0 + $1.add },
-                    totalDel: rps.changes.reduce(0) { $0 + $1.del },
+                    changesCount: displayChanges.count,
+                    totalAdd: displayChanges.reduce(0) { $0 + $1.add },
+                    totalDel: displayChanges.reduce(0) { $0 + $1.del },
                     onHidePane: {
                         state.config.rightPaneVisible = false
                         state.saveConfig()
@@ -41,33 +42,37 @@ struct RightPaneView: View {
                     }
                 )
 
-                switch rps.activeTab {
-                case .changes:
-                    ChangesTabView(
-                        rps: rps,
-                        appState: state,
-                        onSelect: onSelectChangedFile,
-                        onSelectCommit: onSelectCommit,
-                        onEditCommit: onEditCommit
-                    )
-                case .files:
-                    FilesTabView(
-                        nodes: rps.fileTree,
-                        fileTreeGeneration: rps.fileTreeGeneration,
-                        openPaths: Binding(
-                            get: { rps.openPaths },
-                            set: { rps.openPaths = $0 }
-                        ),
-                        onSelectFile: onSelectTreeFile,
-                        shouldAutoLoadChildren: { path, childrenState in
-                            rps.shouldAutoLoadFileTreeChildren(path: path, childrenState: childrenState)
-                        },
-                        onLoadChildren: { rps.loadFileTreeChildren(path: $0) },
-                        showIgnored: state.config.files.showIgnored,
-                        revealPath: rps.revealPath,
-                        revealTick: rps.revealTick,
-                        onClearReveal: { rps.clearReveal() }
-                    )
+                if rps.hasLoadedSnapshot {
+                    switch rps.activeTab {
+                    case .changes:
+                        ChangesTabView(
+                            rps: rps,
+                            appState: state,
+                            onSelect: onSelectChangedFile,
+                            onSelectCommit: onSelectCommit,
+                            onEditCommit: onEditCommit
+                        )
+                    case .files:
+                        FilesTabView(
+                            nodes: rps.fileTree,
+                            fileTreeGeneration: rps.fileTreeGeneration,
+                            openPaths: Binding(
+                                get: { rps.openPaths },
+                                set: { rps.openPaths = $0 }
+                            ),
+                            onSelectFile: onSelectTreeFile,
+                            shouldAutoLoadChildren: { path, childrenState in
+                                rps.shouldAutoLoadFileTreeChildren(path: path, childrenState: childrenState)
+                            },
+                            onLoadChildren: { rps.loadFileTreeChildren(path: $0) },
+                            showIgnored: state.config.files.showIgnored,
+                            revealPath: rps.revealPath,
+                            revealTick: rps.revealTick,
+                            onClearReveal: { rps.clearReveal() }
+                        )
+                    }
+                } else {
+                    RightPaneLoadingSkeletonView(activeTab: rps.activeTab)
                 }
             }
             .sidebarChromeTheme(textContrast: override.textContrast)

--- a/AlasTests/RightPaneStateBaseBranchTests.swift
+++ b/AlasTests/RightPaneStateBaseBranchTests.swift
@@ -223,4 +223,17 @@ struct RightPaneStateBaseBranchTests {
         #expect(state.changes.isEmpty)
         #expect(store.commitEditorComparisonRef(worktreeId: wt.id) == nil)
     }
+
+    @Test func refreshFailurePublishesLoadedErrorSnapshot() async throws {
+        let tmp = FileManager.default.temporaryDirectory
+            .appendingPathComponent("alas-missing-worktree-\(UUID().uuidString)")
+        let wt = makeWorktree(at: tmp, branch: "main")
+        let state = RightPaneState(worktree: wt, baseBranch: "main")
+
+        await state.refresh()
+
+        #expect(state.hasLoadedSnapshot)
+        #expect(state.sidebarError != nil)
+        #expect(state.displayChanges.isEmpty)
+    }
 }

--- a/AlasTests/RightPaneStateBaseBranchTests.swift
+++ b/AlasTests/RightPaneStateBaseBranchTests.swift
@@ -206,4 +206,21 @@ struct RightPaneStateBaseBranchTests {
 
         #expect(store.commitEditorComparisonRef(worktreeId: wt.id) == "origin/main")
     }
+
+    @Test func invalidatingCachedSnapshotHidesStaleChangesUntilRefreshPublishes() async throws {
+        let tmp = try await createTestRepoWithBranches()
+        defer { try? FileManager.default.removeItem(at: tmp) }
+        try "dirty\n".write(to: tmp.appendingPathComponent("stale.txt"), atomically: true, encoding: .utf8)
+        let wt = makeWorktree(at: tmp, branch: "main")
+        let store = RightPaneStore()
+        let state = store.state(for: wt, baseBranch: "main", trackUpstreamForCommits: false)
+        try await waitUntil { state.hasLoadedSnapshot && !state.displayChanges.isEmpty }
+
+        store.invalidateSnapshot(worktreeId: wt.id)
+
+        #expect(!state.hasLoadedSnapshot)
+        #expect(state.displayChanges.isEmpty)
+        #expect(state.changes.isEmpty)
+        #expect(store.commitEditorComparisonRef(worktreeId: wt.id) == nil)
+    }
 }


### PR DESCRIPTION
## Summary
- Invalidate cached right-pane snapshots when a worktree is created for an existing path/id.
- Render the right-pane loading skeleton until git refresh publishes trusted Changes/Files data.
- Add regression coverage for hiding stale cached changes after invalidation.

## Root cause
The right pane could render directly from a cached `RightPaneState.changes` snapshot while a new worktree refresh was still pending. If a path/id was reused, the UI could briefly show old diff counts and tree rows before `git status` completed.

## Validation
- `xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' test -only-testing:AlasTests/RightPaneStateBaseBranchTests`
- `xcodegen`
- `xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -quiet build`

Note: the full `xcodebuild ... test` command was started locally but hung in the broader terminal/ACP test area after many tests had passed, so it was interrupted.