### PR TITLE
fix(review): improve review pane interactions

### DIFF
--- a/Alas/Sources/Center/Diff/DiffPaneTextDocumentView.swift
+++ b/Alas/Sources/Center/Diff/DiffPaneTextDocumentView.swift
@@ -1057,6 +1057,14 @@ final class DiffPaneLineNumberRulerView: NSRulerView {
     private var lineTones: [DiffPaneLineTone] = []
     private var expansionKeys: [DiffContextExpansionKey?] = []
     private var theme: Theme?
+    private var hoverRowIndex: Int? {
+        didSet {
+            if hoverRowIndex != oldValue {
+                needsDisplay = true
+            }
+        }
+    }
+    private var trackingArea: NSTrackingArea?
     var rowHeight: CGFloat = 16
     var onReviewLineSelected: (DiffReviewLineAnchor) -> Void = { _ in }
     var onContextExpansion: (DiffContextExpansionKey, DiffContextExpansionMode) -> Void = { _, _ in }
@@ -1123,6 +1131,32 @@ final class DiffPaneLineNumberRulerView: NSRulerView {
         onReviewLineSelected(anchor)
     }
 
+    override func mouseMoved(with event: NSEvent) {
+        super.mouseMoved(with: event)
+        updateHoverRow(with: event)
+    }
+
+    override func mouseExited(with event: NSEvent) {
+        super.mouseExited(with: event)
+        hoverRowIndex = nil
+    }
+
+    override func updateTrackingAreas() {
+        super.updateTrackingAreas()
+        if let trackingArea {
+            removeTrackingArea(trackingArea)
+            self.trackingArea = nil
+        }
+        let area = NSTrackingArea(
+            rect: bounds,
+            options: [.mouseMoved, .mouseEnteredAndExited, .activeInActiveApp, .inVisibleRect],
+            owner: self,
+            userInfo: nil
+        )
+        trackingArea = area
+        addTrackingArea(area)
+    }
+
     override func drawHashMarksAndLabels(in rect: NSRect) {
         guard let theme else { return }
         NSColor(theme.color("bg-0")).setFill()
@@ -1152,6 +1186,9 @@ final class DiffPaneLineNumberRulerView: NSRulerView {
                 height: textHeight
             )
             NSString(string: label).draw(in: drawRect, withAttributes: labelAttributes(for: label, row: index))
+            if index == hoverRowIndex, isReviewCommentableRow(index) {
+                drawReviewAffordance(in: rowRect, theme: theme)
+            }
         }
     }
 
@@ -1247,6 +1284,31 @@ final class DiffPaneLineNumberRulerView: NSRulerView {
         }
     }
 
+    private func updateHoverRow(with event: NSEvent) {
+        guard let scrollView else {
+            hoverRowIndex = nil
+            return
+        }
+        let point = convert(event.locationInWindow, from: nil)
+        let sourcePoint = NSPoint(
+            x: point.x,
+            y: point.y + scrollView.contentView.bounds.origin.y
+        )
+        let rowRects = diffRowRects()
+        guard let row = rowRects.firstIndex(where: { $0.contains(sourcePoint) }),
+              isReviewCommentableRow(row)
+        else {
+            hoverRowIndex = nil
+            return
+        }
+        hoverRowIndex = row
+    }
+
+    private func isReviewCommentableRow(_ row: Int) -> Bool {
+        guard let textView = scrollView?.documentView as? DiffPaneCodeTextView else { return false }
+        return textView.reviewLineAnchor(atRow: row) != nil
+    }
+
     private func updateThickness() {
         let maxDigits = labels
             .map { $0.trimmingCharacters(in: CharacterSet(charactersIn: "+- ")) }
@@ -1318,6 +1380,35 @@ final class DiffPaneLineNumberRulerView: NSRulerView {
         }
     }
 
+    private func drawReviewAffordance(in rowRect: NSRect, theme: Theme) {
+        let rect = Self.reviewAffordanceRect(in: rowRect, ruleThickness: ruleThickness)
+        let path = NSBezierPath(roundedRect: rect, xRadius: 8, yRadius: 8)
+        NSColor(theme.color("accent")).setFill()
+        path.fill()
+
+        let attributes: [NSAttributedString.Key: Any] = [
+            .font: NSFont.systemFont(ofSize: 12, weight: .bold),
+            .foregroundColor: NSColor(theme.color("bg-1")),
+        ]
+        let string = "+" as NSString
+        let size = string.size(withAttributes: attributes)
+        let point = NSPoint(
+            x: rect.midX - size.width / 2,
+            y: rect.midY - size.height / 2 - 0.5
+        )
+        string.draw(at: point, withAttributes: attributes)
+    }
+
+    static func reviewAffordanceRect(in rowRect: NSRect, ruleThickness: CGFloat) -> NSRect {
+        let size: CGFloat = 16
+        return NSRect(
+            x: min(rowRect.maxX, ruleThickness) - size - 4,
+            y: rowRect.midY - size / 2,
+            width: size,
+            height: size
+        )
+    }
+
     static func changeRailRect(in rowRect: NSRect, tone: DiffPaneLineTone) -> NSRect? {
         switch tone {
         case .add, .delete:
@@ -1328,6 +1419,9 @@ final class DiffPaneLineNumberRulerView: NSRulerView {
     }
 
     deinit {
+        if let trackingArea {
+            removeTrackingArea(trackingArea)
+        }
         if let boundsObserver {
             NotificationCenter.default.removeObserver(boundsObserver)
         }

--- a/Alas/Sources/Center/DiffReview/DiffReviewFileSection.swift
+++ b/Alas/Sources/Center/DiffReview/DiffReviewFileSection.swift
@@ -1,3 +1,4 @@
+import AppKit
 import SwiftUI
 
 private struct PendingContextExpansion {
@@ -395,18 +396,20 @@ struct DiffReviewFileSection: View {
 
     @ViewBuilder
     private var draftComposer: some View {
-        VStack(alignment: .leading, spacing: 8) {
-            TextEditor(text: $pendingDraftBody)
-                .font(.system(size: 12))
-                .foregroundColor(theme.color("fg"))
-                .frame(minHeight: 64, maxHeight: 90)
-                .background(theme.color("bg-2"))
-                .clipShape(RoundedRectangle(cornerRadius: 6))
-                .overlay(
-                    RoundedRectangle(cornerRadius: 6)
-                        .stroke(theme.color("line"), lineWidth: 0.5)
-                )
-                .accessibilityIdentifier("diff-review-draft-composer")
+        VStack(alignment: .leading, spacing: 10) {
+            ReviewDraftComposerTextEditor(
+                text: $pendingDraftBody,
+                theme: theme,
+                onSave: savePendingDraft,
+                onCancel: clearPendingDraft
+            )
+            .frame(minHeight: 76, maxHeight: 104)
+            .clipShape(RoundedRectangle(cornerRadius: 7))
+            .overlay(
+                RoundedRectangle(cornerRadius: 7)
+                    .stroke(theme.color("accent").opacity(0.65), lineWidth: 0.75)
+            )
+            .accessibilityIdentifier("diff-review-draft-composer")
 
             HStack(spacing: 6) {
                 Spacer(minLength: 0)
@@ -435,8 +438,8 @@ struct DiffReviewFileSection: View {
                 .accessibilityIdentifier("diff-review-draft-composer-save")
             }
         }
-        .padding(.horizontal, 14)
-        .padding(.vertical, 10)
+        .padding(.horizontal, 16)
+        .padding(.vertical, 12)
         .background(theme.color("bg-1"))
         .overlay(Rectangle().fill(theme.color("line")).frame(height: 0.5), alignment: .bottom)
         .background(
@@ -616,6 +619,124 @@ struct DiffReviewFileSection: View {
         case .modified, .unknown:
             theme.color("fg-dim")
         }
+    }
+}
+
+enum ReviewDraftComposerKeyboardAction: Equatable {
+    case save
+    case cancel
+
+    static func resolve(key: String, modifiers: NSEvent.ModifierFlags) -> Self? {
+        let flags = modifiers.intersection(.deviceIndependentFlagsMask)
+        if key == "\r", flags.contains(.command) {
+            return .save
+        }
+        if key == "\u{1b}" {
+            return .cancel
+        }
+        return nil
+    }
+}
+
+private struct ReviewDraftComposerTextEditor: NSViewRepresentable {
+    @Binding var text: String
+    let theme: Theme
+    let onSave: () -> Void
+    let onCancel: () -> Void
+
+    func makeCoordinator() -> Coordinator {
+        Coordinator(self)
+    }
+
+    func makeNSView(context: Context) -> NSScrollView {
+        let scrollView = NSScrollView()
+        scrollView.drawsBackground = false
+        scrollView.borderType = .noBorder
+        scrollView.hasVerticalScroller = true
+        scrollView.hasHorizontalScroller = false
+
+        let textView = ReviewDraftComposerNSTextView()
+        textView.delegate = context.coordinator
+        textView.isEditable = true
+        textView.isSelectable = true
+        textView.isRichText = false
+        textView.allowsUndo = true
+        textView.importsGraphics = false
+        textView.drawsBackground = false
+        textView.textContainerInset = NSSize(width: 10, height: 9)
+        textView.textContainer?.widthTracksTextView = true
+        textView.textContainer?.containerSize = NSSize(
+            width: scrollView.contentSize.width,
+            height: CGFloat.greatestFiniteMagnitude
+        )
+        textView.minSize = NSSize(width: 0, height: 0)
+        textView.maxSize = NSSize(
+            width: CGFloat.greatestFiniteMagnitude,
+            height: CGFloat.greatestFiniteMagnitude
+        )
+        textView.isVerticallyResizable = true
+        textView.isHorizontallyResizable = false
+        textView.autoresizingMask = [.width]
+        textView.string = text
+        textView.onKeyboardAction = context.coordinator.perform
+        scrollView.documentView = textView
+        context.coordinator.textView = textView
+        applyTheme(to: scrollView, textView: textView)
+        return scrollView
+    }
+
+    func updateNSView(_ scrollView: NSScrollView, context: Context) {
+        context.coordinator.parent = self
+        guard let textView = scrollView.documentView as? ReviewDraftComposerNSTextView else { return }
+        if textView.string != text {
+            textView.string = text
+        }
+        textView.onKeyboardAction = context.coordinator.perform
+        applyTheme(to: scrollView, textView: textView)
+    }
+
+    private func applyTheme(to scrollView: NSScrollView, textView: NSTextView) {
+        scrollView.wantsLayer = true
+        scrollView.layer?.backgroundColor = NSColor(theme.color("bg-2")).cgColor
+        textView.font = .systemFont(ofSize: 12)
+        textView.textColor = NSColor(theme.color("fg"))
+        textView.insertionPointColor = NSColor(theme.color("accent"))
+    }
+
+    final class Coordinator: NSObject, NSTextViewDelegate {
+        var parent: ReviewDraftComposerTextEditor
+        weak var textView: NSTextView?
+
+        init(_ parent: ReviewDraftComposerTextEditor) {
+            self.parent = parent
+        }
+
+        func textDidChange(_ notification: Notification) {
+            guard let textView = notification.object as? NSTextView else { return }
+            parent.text = textView.string
+        }
+
+        func perform(_ action: ReviewDraftComposerKeyboardAction) {
+            switch action {
+            case .save:
+                parent.onSave()
+            case .cancel:
+                parent.onCancel()
+            }
+        }
+    }
+}
+
+private final class ReviewDraftComposerNSTextView: NSTextView {
+    var onKeyboardAction: ((ReviewDraftComposerKeyboardAction) -> Void)?
+
+    override func keyDown(with event: NSEvent) {
+        let key = event.charactersIgnoringModifiers ?? event.characters ?? ""
+        if let action = ReviewDraftComposerKeyboardAction.resolve(key: key, modifiers: event.modifierFlags) {
+            onKeyboardAction?(action)
+            return
+        }
+        super.keyDown(with: event)
     }
 }
 
@@ -1065,14 +1186,19 @@ private struct ReviewDraftCommentCard: View {
                 }
 
                 if isEditing {
-                    TextEditor(text: $editingBody)
-                        .font(.system(size: 11.5))
-                        .foregroundColor(theme.color("fg"))
-                        .scrollContentBackground(.hidden)
-                        .frame(minHeight: 72)
-                        .background(theme.color("bg-1"))
-                        .clipShape(RoundedRectangle(cornerRadius: 5))
-                        .accessibilityIdentifier("diff-review-draft-comment-editor-\(comment.id)")
+                    ReviewDraftComposerTextEditor(
+                        text: $editingBody,
+                        theme: theme,
+                        onSave: saveEditingComment,
+                        onCancel: cancelEditingComment
+                    )
+                    .frame(minHeight: 72)
+                    .clipShape(RoundedRectangle(cornerRadius: 6))
+                    .overlay(
+                        RoundedRectangle(cornerRadius: 6)
+                            .stroke(theme.color("line"), lineWidth: 0.75)
+                    )
+                    .accessibilityIdentifier("diff-review-draft-comment-editor-\(comment.id)")
                 } else {
                     Text(DiffReviewInlineFeedbackMarkdown.render(comment.bodyMarkdown))
                         .font(.system(size: 11.5))
@@ -1111,13 +1237,10 @@ private struct ReviewDraftCommentCard: View {
                 Spacer(minLength: 0)
                 if isEditing {
                     actionButton(id: "save", title: "Save") {
-                        actions.edit(comment, editingBody)
-                        isEditing = false
-                        editingBody = ""
+                        saveEditingComment()
                     }
                     actionButton(id: "cancel", title: "Cancel") {
-                        isEditing = false
-                        editingBody = ""
+                        cancelEditingComment()
                     }
                 } else if availability.canEdit {
                     actionButton(id: "edit", title: "Edit") {
@@ -1228,6 +1351,16 @@ private struct ReviewDraftCommentCard: View {
             return "diff-review-draft-comment-publish-\(comment.id)"
         }
         return "diff-review-draft-comment-action-\(id)-\(comment.id)"
+    }
+
+    private func saveEditingComment() {
+        actions.edit(comment, editingBody)
+        cancelEditingComment()
+    }
+
+    private func cancelEditingComment() {
+        isEditing = false
+        editingBody = ""
     }
 
     private var feedbackBundle: ReviewFeedbackBundle {

--- a/Alas/Sources/Center/ReviewChanges/ReviewChangesTabView.swift
+++ b/Alas/Sources/Center/ReviewChanges/ReviewChangesTabView.swift
@@ -58,6 +58,16 @@ struct ReviewChangesLoadKey {
     }
 }
 
+enum ReviewChangesLoadingPresentation {
+    static func showsBlockingLoader(isLoading: Bool, hasSession: Bool) -> Bool {
+        isLoading && !hasSession
+    }
+
+    static func showsRefreshError(loadError: String?, hasSession: Bool) -> Bool {
+        hasSession && loadError != nil
+    }
+}
+
 struct ReviewChangesTabView: View {
     static let reviewSessionLauncherLabel = "Open review session"
 
@@ -132,14 +142,18 @@ struct ReviewChangesTabView: View {
 
     @ViewBuilder
     private var content: some View {
-        if isLoading {
+        if ReviewChangesLoadingPresentation.showsBlockingLoader(isLoading: isLoading, hasSession: session != nil) {
             stateView(title: "Loading changes...", detail: nil, color: theme.color("fg-dim"))
+        } else if let session, session.files.isEmpty {
+            loadedSessionContent {
+                stateView(title: "No changes to review", detail: "This worktree has no staged or unstaged file diffs.", color: theme.color("fg-dim"))
+            }
+        } else if let session {
+            loadedSessionContent {
+                reviewSurface(session)
+            }
         } else if let loadError {
             stateView(title: "Could not load review changes", detail: loadError, color: theme.color("del"))
-        } else if let session, session.files.isEmpty {
-            stateView(title: "No changes to review", detail: "This worktree has no staged or unstaged file diffs.", color: theme.color("fg-dim"))
-        } else if let session {
-            reviewSurface(session)
         } else {
             stateView(title: "No changes loaded", detail: nil, color: theme.color("fg-dim"))
         }
@@ -249,6 +263,42 @@ struct ReviewChangesTabView: View {
         }
         .buttonStyle(.plain)
         .help(tooltip)
+    }
+
+    private func loadedSessionContent<Content: View>(
+        @ViewBuilder content: () -> Content
+    ) -> some View {
+        VStack(spacing: 0) {
+            if ReviewChangesLoadingPresentation.showsRefreshError(loadError: loadError, hasSession: true),
+               let loadError
+            {
+                refreshErrorBanner(message: loadError)
+            }
+            content()
+        }
+    }
+
+    private func refreshErrorBanner(message: String) -> some View {
+        HStack(spacing: 8) {
+            Image(systemName: "exclamationmark.triangle.fill")
+                .font(.system(size: 11, weight: .semibold))
+                .foregroundColor(theme.color("del"))
+            Text("Could not refresh changes")
+                .font(.system(size: 11, weight: .semibold))
+                .foregroundColor(theme.color("fg"))
+            Text(message)
+                .font(.system(size: 11))
+                .foregroundColor(theme.color("fg-muted"))
+                .lineLimit(1)
+                .truncationMode(.middle)
+            Spacer(minLength: 0)
+        }
+        .padding(.horizontal, 12)
+        .frame(height: 30)
+        .background(theme.color("del").opacity(0.12))
+        .overlay(Rectangle().fill(theme.color("line")).frame(height: 0.5), alignment: .bottom)
+        .accessibilityIdentifier("review-changes-refresh-error")
+        .accessibilityLabel("Could not refresh changes. \(message)")
     }
 
     private func reviewSurface(_ session: ReviewChangesLoadedSession) -> some View {
@@ -368,7 +418,6 @@ struct ReviewChangesTabView: View {
         activeLoadID = requestedLoadToken.id
         isLoading = true
         loadError = nil
-        session = nil
         defer {
             if requestedLoadToken.isActive(activeKey: activeLoadKey, activeID: activeLoadID) {
                 isLoading = false

--- a/AlasTests/DiffReviewSurfaceTests.swift
+++ b/AlasTests/DiffReviewSurfaceTests.swift
@@ -879,6 +879,22 @@ struct DiffReviewSurfaceTests {
         #expect(accessibilityLabel(in: controller.view, containing: "GitLab error: Line is no longer commentable.") != nil)
     }
 
+    @Test func draftComposerKeyboardShortcutsMapToSaveAndCancel() {
+        #expect(ReviewDraftComposerKeyboardAction.resolve(key: "\r", modifiers: [.command]) == .save)
+        #expect(ReviewDraftComposerKeyboardAction.resolve(key: "\u{1b}", modifiers: []) == .cancel)
+        #expect(ReviewDraftComposerKeyboardAction.resolve(key: "\r", modifiers: []) == nil)
+    }
+
+    @Test func gutterCommentAffordanceUsesCompactPlusButton() {
+        let rowRect = NSRect(x: 0, y: 10, width: 42, height: 20)
+        let plusRect = DiffPaneLineNumberRulerView.reviewAffordanceRect(in: rowRect, ruleThickness: 42)
+
+        #expect(plusRect.width == 16)
+        #expect(plusRect.height == 16)
+        #expect(plusRect.maxX <= rowRect.maxX - 4)
+        #expect(plusRect.midY == rowRect.midY)
+    }
+
     @Test func fileSectionDraftCommentCardCanDismissComment() {
         let file = DiffReviewFileSectionModel(
             summary: summary(path: "Sources/App.swift"),

--- a/AlasTests/ReviewChangesTabViewTests.swift
+++ b/AlasTests/ReviewChangesTabViewTests.swift
@@ -100,6 +100,18 @@ struct ReviewChangesTabViewTests {
         #expect((reportedError as? LauncherTestError) == .saveFailed)
     }
 
+    @Test func loadingPresentationOnlyBlocksInitialLoad() {
+        #expect(ReviewChangesLoadingPresentation.showsBlockingLoader(isLoading: true, hasSession: false))
+        #expect(!ReviewChangesLoadingPresentation.showsBlockingLoader(isLoading: true, hasSession: true))
+        #expect(!ReviewChangesLoadingPresentation.showsBlockingLoader(isLoading: false, hasSession: false))
+    }
+
+    @Test func loadingPresentationSurfacesRefreshErrorsWithStaleSession() {
+        #expect(ReviewChangesLoadingPresentation.showsRefreshError(loadError: "git failed", hasSession: true))
+        #expect(!ReviewChangesLoadingPresentation.showsRefreshError(loadError: "git failed", hasSession: false))
+        #expect(!ReviewChangesLoadingPresentation.showsRefreshError(loadError: nil, hasSession: true))
+    }
+
     @Test func copyReviewPromptUsesPromptMarkdown() {
         var copiedPrompt: String?
         let bundle = ReviewFeedbackBundle(


### PR DESCRIPTION
## Summary

- keep the existing review diff visible during background reloads so the pane no longer flashes to a full-screen loading state
- restyle the inline draft/edit comment composer and add Cmd+Enter to save plus Escape to cancel
- show a compact plus affordance when hovering commentable diff gutter rows

## Validation

- `xcodegen`
- `xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -quiet build`
- `xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' test`

Full local suite result: 3949 tests in 438 suites passed.