### PR TITLE
feat(sidebar): house glyph for the main worktree row

### DIFF
--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -545,6 +545,7 @@
 		899FB89D155619CF846C6BDC /* DiffDisplayModelBuilderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6181842BEA798CB8606F222B /* DiffDisplayModelBuilderTests.swift */; };
 		89A3BEAA64625C766E73F58E /* ZmxSessionNameTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 626DBFF220D347A36859AB17 /* ZmxSessionNameTests.swift */; };
 		89A5E5AD13431B6C9E16669B /* ImageFileTypeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A300F7033D91C4A0D283F75E /* ImageFileTypeTests.swift */; };
+		89E952C361337F8D9FB279D5 /* IconSymbolTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 705B34DF3EE049FA52E8ECFB /* IconSymbolTests.swift */; };
 		89F58C7178B661EAE0057622 /* ACPTerminalTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7F8802F19E02CED256495755 /* ACPTerminalTests.swift */; };
 		8ACF2EE38E46F72F5466DB01 /* SettingsRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE607EE1ACDE73C1DB0FCA00 /* SettingsRow.swift */; };
 		8B0593FC9BC9E683E0685DD0 /* WorktreeCreateFetchTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3B7BE659F7E386D15047C374 /* WorktreeCreateFetchTests.swift */; };
@@ -1477,6 +1478,7 @@
 		70255847CE81CE85E0117A85 /* ACPMarkdownBlockCache.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPMarkdownBlockCache.swift; sourceTree = "<group>"; };
 		70377E10CD6D08B225BDFABE /* TabsManagerBufferTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabsManagerBufferTests.swift; sourceTree = "<group>"; };
 		705A47F78FEC16C2CA293BAC /* AppConfigSidebarChromeOverridesTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppConfigSidebarChromeOverridesTests.swift; sourceTree = "<group>"; };
+		705B34DF3EE049FA52E8ECFB /* IconSymbolTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IconSymbolTests.swift; sourceTree = "<group>"; };
 		708AB670AB611EFB9D216D7C /* UpdateThrottleTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UpdateThrottleTests.swift; sourceTree = "<group>"; };
 		7094534860369BA79FC5A877 /* session-update-plan.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "session-update-plan.json"; sourceTree = "<group>"; };
 		7095EA2868EF619BA4202BDF /* MergeScrollCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MergeScrollCoordinator.swift; sourceTree = "<group>"; };
@@ -2319,6 +2321,7 @@
 				3F1D8FEB5416139D8B2BA780 /* HoverFeatureRenderingTests.swift */,
 				3C9032BA9542C617A09EF848 /* HoverWindowControllerTests.swift */,
 				FA486F66BE4CEB2A16EB148B /* HunkPatchBuilderTests.swift */,
+				705B34DF3EE049FA52E8ECFB /* IconSymbolTests.swift */,
 				9278ED5964A66871F5299F0C /* ImageDiffDifferenceComputerTests.swift */,
 				638E94907851A6D0B4AB8F52 /* ImageDiffEndToEndTests.swift */,
 				FFE911B77AC087704180BDB5 /* ImageDiffModeApplicabilityTests.swift */,
@@ -4884,6 +4887,7 @@
 				D2B345D1AEB1D5CEF48354C3 /* HoverHighlightFeatureTests.swift in Sources */,
 				2281077800674169E69C6C3B /* HoverWindowControllerTests.swift in Sources */,
 				E31120BCB281A62D767D85BC /* HunkPatchBuilderTests.swift in Sources */,
+				89E952C361337F8D9FB279D5 /* IconSymbolTests.swift in Sources */,
 				3961F6003185B2FC9DFE7E14 /* ImageDiffDifferenceComputerTests.swift in Sources */,
 				474DF7FE50CB6146644B2450 /* ImageDiffEndToEndTests.swift in Sources */,
 				9707DC02317F0E92AB06196B /* ImageDiffModeApplicabilityTests.swift in Sources */,

--- a/Alas/Sources/App/ProjectsManager.swift
+++ b/Alas/Sources/App/ProjectsManager.swift
@@ -457,6 +457,13 @@ final class ProjectsManager {
         return normalized
     }
 
+    /// Whether `worktree` is the project's primary on-disk checkout (the main
+    /// worktree) rather than a feature worktree. Reuses the same path
+    /// comparison the sort logic uses to pin main at position 0.
+    func isMain(_ worktree: Worktree, in project: ProjectConfig) -> Bool {
+        isMainWorktree(worktree, project: project)
+    }
+
     private func isMainWorktree(_ worktree: Worktree, project: ProjectConfig) -> Bool {
         canonical(worktree.path) == canonical(URL(fileURLWithPath: project.path))
     }

--- a/Alas/Sources/Icons/Icon.swift
+++ b/Alas/Sources/Icons/Icon.swift
@@ -28,6 +28,7 @@ struct Icon: View {
     static func symbol(for name: String) -> String {
         switch name {
         case "branch":     return "arrow.triangle.branch"
+        case "home":       return "house"
         case "terminal":   return "terminal"
         case "code":       return "chevron.left.forwardslash.chevron.right"
         case "diff":       return "plus.forwardslash.minus"

--- a/Alas/Sources/Sidebar/RepoGroupView.swift
+++ b/Alas/Sources/Sidebar/RepoGroupView.swift
@@ -13,6 +13,7 @@ struct RepoGroupView: View {
     let worktrees: [Worktree]
     @Binding var collapsed: Bool
     let selectedWorktreeId: String?
+    let isMain: (Worktree) -> Bool
     let operationState: (Worktree) -> WorktreeOperationState?
     let harnessSummary: (String) -> HarnessService.WorktreeHarnessSummary?
     let onSelect: (Worktree) -> Void
@@ -134,6 +135,7 @@ struct RepoGroupView: View {
                         WorktreeRowView(
                             worktree: wt,
                             isSelected: wt.id == selectedWorktreeId,
+                            isMain: isMain(wt),
                             operationState: operationState(wt),
                             harnessSummary: harnessSummary(wt.id),
                             onTap: { onSelect(wt) },

--- a/Alas/Sources/Sidebar/SidebarView.swift
+++ b/Alas/Sources/Sidebar/SidebarView.swift
@@ -44,6 +44,7 @@ struct SidebarView: View {
                                     }
                                 ),
                                 selectedWorktreeId: state.selectedWorktreeId,
+                                isMain: { wt in state.projectsManager.isMain(wt, in: project) },
                                 operationState: { wt in
                                     state.projectsManager.operationState(for: wt.id)
                                 },

--- a/Alas/Sources/Sidebar/WorktreeRowView.swift
+++ b/Alas/Sources/Sidebar/WorktreeRowView.swift
@@ -3,6 +3,7 @@ import SwiftUI
 struct WorktreeRowView: View {
     let worktree: Worktree
     let isSelected: Bool
+    let isMain: Bool
     let operationState: WorktreeOperationState?
     let harnessSummary: HarnessService.WorktreeHarnessSummary?
     let onTap: () -> Void
@@ -60,7 +61,11 @@ struct WorktreeRowView: View {
             }
             VStack(alignment: .leading, spacing: 2) {
                 HStack(spacing: 6) {
-                    Icon(name: "branch", size: 11, color: theme.color("fg-faint"))
+                    Icon(
+                        name: isMain ? "home" : "branch",
+                        size: 11,
+                        color: theme.color(isMain ? "fg-muted" : "fg-faint")
+                    )
                     Text(worktree.branch)
                         .font(.system(size: 12, weight: .medium, design: .monospaced))
                         .foregroundColor(theme.color(isPending ? "fg-faint" : "fg"))

--- a/AlasTests/IconSymbolTests.swift
+++ b/AlasTests/IconSymbolTests.swift
@@ -1,0 +1,12 @@
+import Testing
+@testable import Alas
+
+struct IconSymbolTests {
+    @Test func homeMapsToHouse() {
+        #expect(Icon.symbol(for: "home") == "house")
+    }
+
+    @Test func branchMappingUnchanged() {
+        #expect(Icon.symbol(for: "branch") == "arrow.triangle.branch")
+    }
+}

--- a/AlasTests/ProjectsManagerTests.swift
+++ b/AlasTests/ProjectsManagerTests.swift
@@ -427,4 +427,33 @@ extension ProjectsManagerTests {
         #expect(!mgr.worktrees(projectId: project.id).contains { $0.id == worktree.id })
         #expect(mgr.operationState(for: worktree.id) == nil)
     }
+
+    @Test func isMainTrueForPrimaryCheckout() async throws {
+        let repo = try await makeRepo(name: "ismain-true")
+        defer { try? FileManager.default.removeItem(at: repo) }
+        let mgr = ProjectsManager(persistedProjects: [])
+        let project = try await mgr.addProject(path: repo, displayName: "ismain-true", color: "#5fb7c4")
+        try await mgr.refreshWorktrees(projectId: project.id)
+        let trees = mgr.worktrees(projectId: project.id)
+        #expect(trees.count == 1)
+        #expect(mgr.isMain(trees[0], in: project))
+    }
+
+    @Test func isMainFalseForFeatureWorktree() async throws {
+        let repo = try await makeRepo(name: "ismain-false")
+        defer { try? FileManager.default.removeItem(at: repo) }
+        let mgr = ProjectsManager(persistedProjects: [])
+        let project = try await mgr.addProject(path: repo, displayName: "ismain-false", color: "#c89d6f")
+        let dest = repo.appendingPathComponent("wt-feature")
+        let feature = Worktree(
+            id: Worktree.makeId(path: dest),
+            projectId: project.id,
+            name: "feature",
+            branch: "feature",
+            path: dest,
+            status: .clean,
+            lastActivity: Date()
+        )
+        #expect(!mgr.isMain(feature, in: project))
+    }
 }

--- a/AlasTests/ProjectsManagerTests.swift
+++ b/AlasTests/ProjectsManagerTests.swift
@@ -444,16 +444,20 @@ extension ProjectsManagerTests {
         defer { try? FileManager.default.removeItem(at: repo) }
         let mgr = ProjectsManager(persistedProjects: [])
         let project = try await mgr.addProject(path: repo, displayName: "ismain-false", color: "#c89d6f")
+
+        let svc = WorktreeService()
         let dest = repo.appendingPathComponent("wt-feature")
-        let feature = Worktree(
-            id: Worktree.makeId(path: dest),
-            projectId: project.id,
-            name: "feature",
-            branch: "feature",
-            path: dest,
-            status: .clean,
-            lastActivity: Date()
-        )
-        #expect(!mgr.isMain(feature, in: project))
+        _ = try await svc.add(repoPath: repo, base: "main", branch: "feature-b", destination: dest, projectId: project.id)
+
+        try await mgr.refreshWorktrees(projectId: project.id)
+        let trees = mgr.worktrees(projectId: project.id)
+        #expect(trees.count == 2)
+
+        let repoCanonical = repo.standardizedFileURL.path
+        let mainWorktree = try #require(trees.first { $0.path.standardizedFileURL.path == repoCanonical })
+        let featureWorktree = try #require(trees.first { $0.path.standardizedFileURL.path != repoCanonical })
+
+        #expect(mgr.isMain(mainWorktree, in: project))
+        #expect(!mgr.isMain(featureWorktree, in: project))
     }
 }

--- a/AlasTests/RepoGroupViewLayoutTests.swift
+++ b/AlasTests/RepoGroupViewLayoutTests.swift
@@ -39,6 +39,7 @@ struct RepoGroupViewLayoutTests {
             worktrees: worktrees,
             collapsed: .constant(collapsed),
             selectedWorktreeId: nil,
+            isMain: { _ in false },
             operationState: { _ in nil },
             harnessSummary: { _ in nil },
             onSelect: { _ in },

--- a/AlasTests/WorktreeRowHeightTests.swift
+++ b/AlasTests/WorktreeRowHeightTests.swift
@@ -54,6 +54,7 @@ struct WorktreeRowHeightTests {
         let view = WorktreeRowView(
             worktree: worktree,
             isSelected: false,
+            isMain: false,
             operationState: nil,
             harnessSummary: harnessSummary,
             onTap: {},


### PR DESCRIPTION
## Summary

- The main worktree's sidebar row now shows an outline **house** glyph (SF Symbol `house`, tinted `fg-muted`) instead of the branch glyph (`fg-faint`). Feature worktrees are unchanged.
- The cue marks the worktree's **role** — the primary on-disk checkout — which is independent of whatever branch it has checked out (so it stays correct even when main isn't on `main`, and avoids a redundant "main" label).
- Wiring: `Icon.symbol("home") → "house"`; a public `ProjectsManager.isMain(_:in:)` wraps the existing path-comparison used to pin main at position 0; `SidebarView` → `RepoGroupView` → `WorktreeRowView` thread an `isMain` flag that selects the glyph + tint. No data-model, theme-token, or layout changes.

## Test Plan

- [x] `IconSymbolTests` — `home` resolves to `house`, `branch` unchanged
- [x] `ProjectsManagerTests` — `isMain` true for the primary checkout, false for a real linked feature worktree
- [x] `SidebarVisibilityTests` + layout suites green; app builds clean
- [ ] Visual: main row (position 0) shows the house at `fg-muted`; feature rows still show the branch glyph at `fg-faint`; selection bar / metrics / harness pill unchanged