### PR TITLE
fix(remote): render tool execution metadata

### DIFF
--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -5498,7 +5498,7 @@
 			repositoryURL = "https://github.com/apple/swift-markdown";
 			requirement = {
 				kind = upToNextMajorVersion;
-				minimumVersion = 0.4.0;
+				minimumVersion = 0.8.0;
 			};
 		};
 		CF72A36467D20A160E653761 /* XCRemoteSwiftPackageReference "swift-tree-sitter" */ = {

--- a/Alas/Resources/RemoteWeb/app.js
+++ b/Alas/Resources/RemoteWeb/app.js
@@ -1165,27 +1165,84 @@ function thoughtCard(text) {
 
 function toolCard(tc) {
   const verb = TOOL_VERB[tc.kind] || (tc.kind ? cap(tc.kind) : "Tool");
-  const name = tc.title || (tc.locations && tc.locations[0]) || "";
-  const card = structCard(verb, name && name.toLowerCase() !== verb.toLowerCase() ? name : "",
-                          toolBody(tc), tc.preview);
+  const name = toolDisplayName(tc, verb);
+  const card = structCard(verb, name, toolBody(tc), tc.preview || toolCollapsedPreview(tc));
   const [ch, scls] = TOOL_STATUS[tc.status] || [tc.status || "", "run"];
   card.querySelector(".tool-chev").insertAdjacentElement("beforebegin", el("span", "tool-status " + scls, ch));
   return card;
 }
 
 function toolBody(tc) {
-  if (typeof tc.content === "string" && tc.content) return tc.content;
-  const rows = [
+  const rows = toolMetadataRows(tc);
+  if (typeof tc.content === "string" && tc.content) {
+    return rows.length ? rows.map(([key, value]) => `${key}: ${value}`).join("\n") + "\n\n" + tc.content : tc.content;
+  }
+  if (!rows.length) {
+    if (tc.status === "in_progress" || tc.status === "pending") return "Working…";
+    if (tc.status === "canceled" || tc.status === "cancelled") return "Canceled.";
+    return "Tool invoked.";
+  }
+  return rows.map(([key, value]) => `${key}: ${value}`).join("\n");
+}
+
+function toolDisplayName(tc, verb) {
+  const candidates = [
+    tc.title,
+    Array.isArray(tc.locations) ? tc.locations[0] : "",
+    tc.toolCallId
+  ];
+  const name = candidates.find(v => typeof v === "string" && v.trim().length > 0) || "";
+  return name.toLowerCase() !== verb.toLowerCase() ? name : "";
+}
+
+function toolCollapsedPreview(tc) {
+  const rows = toolMetadataRows(tc);
+  const priority = ["rawInput", "params", "input", "arguments", "locations", "toolCallId"];
+  for (const key of priority) {
+    const row = rows.find(([k]) => k === key);
+    if (row) return `${row[0]}: ${singleLine(row[1])}`;
+  }
+  if (tc.status === "in_progress" || tc.status === "pending") return "Working…";
+  if (tc.status === "completed") return "Completed";
+  if (tc.status === "failed") return "Failed";
+  if (tc.status === "canceled" || tc.status === "cancelled") return "Canceled";
+  return "Tool executed";
+}
+
+function toolMetadataRows(tc) {
+  return [
     ["toolCallId", tc.toolCallId],
     ["title", tc.title],
     ["kind", tc.kind],
     ["status", tc.status],
     ["preview", tc.preview],
+    ["rawInput", valuePreview(tc.rawInput)],
+    ["params", valuePreview(tc.params)],
+    ["input", valuePreview(tc.input)],
+    ["arguments", valuePreview(tc.arguments)],
+    ["rawOutput", valuePreview(tc.rawOutput)],
     ["locations", Array.isArray(tc.locations) ? tc.locations.join("\n") : ""],
     ["terminalIds", Array.isArray(tc.terminalIds) ? tc.terminalIds.join("\n") : ""]
   ].filter(([, value]) => typeof value === "string" && value.length > 0);
-  if (!rows.length) return "Tool invoked.";
-  return rows.map(([key, value]) => `${key}: ${value}`).join("\n");
+}
+
+function valuePreview(value) {
+  if (value === null || value === undefined) return "";
+  if (typeof value === "string") return value;
+  try { return JSON.stringify(value, null, 2); } catch { return String(value); }
+}
+
+function singleLine(value) {
+  return (value || "").replace(/\s+/g, " ").trim();
+}
+
+function toolGlyph(verb) {
+  const v = (verb || "").toLowerCase();
+  if (v === "read") return "□";
+  if (v === "searched") return "⌕";
+  if (v === "ran") return "›";
+  if (v === "edit") return "✎";
+  return "⚙";
 }
 
 function structCard(verb, name, body, preview) {
@@ -1194,6 +1251,7 @@ function structCard(verb, name, body, preview) {
   button.type = "button";
   button.dataset.cardToggle = "true";
   button.setAttribute("aria-expanded", "false");
+  button.append(el("span", "tool-glyph", toolGlyph(verb)));
   button.append(el("span", "tool-verb", verb));
   button.append(el("span", "tool-name", name || ""));
   button.append(el("span", "tool-preview", preview || ""));

--- a/Alas/Resources/RemoteWeb/index.html
+++ b/Alas/Resources/RemoteWeb/index.html
@@ -11,7 +11,7 @@
   <link rel="icon" href="/icon.svg" type="image/svg+xml" />
   <link rel="apple-touch-icon" href="/icon-180.png" />
   <title>Alas Remote</title>
-  <link rel="stylesheet" href="/style.css?v=29" />
+  <link rel="stylesheet" href="/style.css?v=30" />
 </head>
 <body>
   <header id="bar">
@@ -99,7 +99,7 @@
   </div>
   <script src="/marked.min.js?v=28"></script>
   <script src="/purify.min.js?v=28"></script>
-  <script src="/app.js?v=41"></script>
+  <script src="/app.js?v=42"></script>
   <script>
     if ("serviceWorker" in navigator) {
       window.addEventListener("load", () => {

--- a/Alas/Resources/RemoteWeb/style.css
+++ b/Alas/Resources/RemoteWeb/style.css
@@ -107,9 +107,10 @@ h1 { font-size: 22px; font-weight: 700; margin: 12px 4px 10px; }
 /* Tool call / structured card — collapsed by default */
 .m-tool { align-self: stretch; color: var(--fg); background: color-mix(in oklab, var(--bg-1) 60%, transparent); border: 0.5px solid var(--line); border-radius: 8px; margin: 5px 0; overflow: hidden; }
 .m-tool.is-open { border-color: var(--bg-4); }
-.tool-toggle { appearance: none; -webkit-appearance: none; width: 100%; border: none; background: none; color: var(--fg); font: inherit; cursor: pointer; display: flex; align-items: center; gap: 8px; padding: 8px 10px; text-align: left; -webkit-tap-highlight-color: transparent; }
+.tool-toggle { appearance: none; -webkit-appearance: none; width: 100%; min-height: 36px; border: none; background: none; color: var(--fg); font: inherit; cursor: pointer; display: flex; align-items: center; gap: 8px; padding: 8px 10px; text-align: left; -webkit-tap-highlight-color: transparent; }
+.tool-glyph { flex: 0 0 18px; width: 18px; height: 18px; border-radius: 4px; display: inline-flex; align-items: center; justify-content: center; background: color-mix(in oklab, var(--bg-0) 80%, transparent); color: var(--accent); font-family: ui-monospace, monospace; font-size: 12px; font-weight: 700; }
 .tool-verb { flex-shrink: 0; font-size: 10px; font-weight: 700; letter-spacing: .6px; text-transform: uppercase; color: var(--accent); }
-.tool-name { color: var(--fg-muted); font-family: ui-monospace, monospace; font-size: 12px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.tool-name { color: var(--fg-muted); font-family: ui-monospace, monospace; font-size: 12px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; max-width: 42%; }
 .tool-preview { flex: 1; min-width: 0; color: var(--fg-faint); font-family: ui-monospace, monospace; font-size: 11px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
 .tool-status { flex-shrink: 0; margin-left: auto; font-size: 12px; font-weight: 700; }
 .tool-status.ok { color: var(--add); } .tool-status.err { color: var(--del); } .tool-status.run { color: var(--fg-faint); }

--- a/Alas/Resources/RemoteWeb/sw.js
+++ b/Alas/Resources/RemoteWeb/sw.js
@@ -1,9 +1,9 @@
-const CACHE_NAME = "alas-remote-shell-v17";
+const CACHE_NAME = "alas-remote-shell-v18";
 const SHELL_ASSETS = [
   "/",
   "/index.html",
-  "/style.css?v=29",
-  "/app.js?v=41",
+  "/style.css?v=30",
+  "/app.js?v=42",
   "/marked.min.js?v=28",
   "/purify.min.js?v=28",
   "/manifest.webmanifest",

--- a/Alas/Sources/ACP/Session/ACPMessage.swift
+++ b/Alas/Sources/ACP/Session/ACPMessage.swift
@@ -67,6 +67,9 @@ enum ACPMessage: Equatable {
         /// Supported explicit language label from a wrapping markdown fence
         /// that was removed from `content`.
         var contentLanguage: String?
+        /// Compact JSON/string form of the tool input reported by ACP. Kept so
+        /// remote mirrors can show useful params even before output arrives.
+        var rawInput: String?
         var locations: [String]
         /// Terminal IDs referenced by this call's structured content, in
         /// declaration order. The expanded card renders one
@@ -97,7 +100,8 @@ enum ACPMessage: Equatable {
 
         init(toolCallId: String, title: String, kind: String? = nil,
              status: String, content: String = "", preview: String? = nil,
-             contentLanguage: String? = nil, locations: [String] = [], terminalIds: [String] = [])
+             contentLanguage: String? = nil, rawInput: String? = nil,
+             locations: [String] = [], terminalIds: [String] = [])
         {
             self.toolCallId = toolCallId
             self.title = title
@@ -106,6 +110,7 @@ enum ACPMessage: Equatable {
             self.content = content
             self.preview = preview
             self.contentLanguage = contentLanguage
+            self.rawInput = rawInput
             self.locations = locations
             self.terminalIds = terminalIds
         }
@@ -115,7 +120,7 @@ enum ACPMessage: Equatable {
         // session history doesn't go blank after upgrade.
         enum CodingKeys: String, CodingKey {
             case toolCallId, title, kind, status, content, preview,
-                 contentSummary, contentLanguage, locations, terminalIds
+                 contentSummary, contentLanguage, rawInput, locations, terminalIds
         }
         init(from decoder: Decoder) throws {
             let c = try decoder.container(keyedBy: CodingKeys.self)
@@ -127,6 +132,7 @@ enum ACPMessage: Equatable {
             preview = (try? c.decode(String.self, forKey: .preview))
                 ?? (try? c.decode(String.self, forKey: .contentSummary))
             contentLanguage = try? c.decode(String.self, forKey: .contentLanguage)
+            rawInput = try? c.decode(String.self, forKey: .rawInput)
             locations = (try? c.decode([String].self, forKey: .locations)) ?? []
             terminalIds = (try? c.decode([String].self, forKey: .terminalIds)) ?? []
         }
@@ -139,6 +145,7 @@ enum ACPMessage: Equatable {
             try c.encode(content, forKey: .content)
             try c.encodeIfPresent(preview, forKey: .preview)
             try c.encodeIfPresent(contentLanguage, forKey: .contentLanguage)
+            try c.encodeIfPresent(rawInput, forKey: .rawInput)
             try c.encode(locations, forKey: .locations)
             try c.encode(terminalIds, forKey: .terminalIds)
         }
@@ -155,6 +162,7 @@ enum ACPMessage: Equatable {
                 && lhs.content == rhs.content
                 && lhs.preview == rhs.preview
                 && lhs.contentLanguage == rhs.contentLanguage
+                && lhs.rawInput == rhs.rawInput
                 && lhs.locations == rhs.locations
         }
 
@@ -166,6 +174,7 @@ enum ACPMessage: Equatable {
             hasher.combine(content)
             hasher.combine(preview)
             hasher.combine(contentLanguage)
+            hasher.combine(rawInput)
             hasher.combine(locations)
         }
     }

--- a/Alas/Sources/ACP/Session/ACPSession.swift
+++ b/Alas/Sources/ACP/Session/ACPSession.swift
@@ -81,6 +81,7 @@ final class ACPSession: ObservableObject, Identifiable {
     /// persisted session fields instead.
     @Published var firstRunConnectingPhase: ACPFirstRunConnectingPhase?
 
+    private static let metadataPreviewLimit = 4096
     private var contextRecoveryExpiryTask: Task<Void, Never>?
 
     /// Runtime-only marker for a forced queue item parked behind the current
@@ -258,6 +259,7 @@ final class ACPSession: ObservableObject, Identifiable {
                 content: full,
                 preview: Self.previewLine(full),
                 contentLanguage: Self.wrappingFenceLanguage(raw),
+                rawInput: Self.metadataString(payload.rawInput),
                 locations: payload.locations?.map(\.path) ?? [],
                 terminalIds: Self.extractTerminalIds(items))))
             didAppendTranscriptMessage()
@@ -643,6 +645,20 @@ final class ACPSession: ObservableObject, Identifiable {
         let s = String(firstLine).trimmingCharacters(in: .whitespacesAndNewlines)
         guard !s.isEmpty else { return nil }
         return s.count > 80 ? String(s.prefix(80)) + "…" : s
+    }
+
+    private static func metadataString(_ value: AnyCodable?) -> String? {
+        guard let value else { return nil }
+        if let string = value.value as? String { return boundedMetadataPreview(string) }
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.sortedKeys]
+        guard let data = try? encoder.encode(value) else { return nil }
+        return String(data: data, encoding: .utf8).map(boundedMetadataPreview)
+    }
+
+    private static func boundedMetadataPreview(_ string: String) -> String {
+        guard string.count > metadataPreviewLimit else { return string }
+        return String(string.prefix(metadataPreviewLimit)) + "… [truncated]"
     }
 
     private static func extractTerminalIds(_ items: [ACPToolCallContent]) -> [String] {

--- a/Alas/Sources/ACP/Session/ACPSessionByteAccounting.swift
+++ b/Alas/Sources/ACP/Session/ACPSessionByteAccounting.swift
@@ -21,6 +21,7 @@ extension ACPSession {
             case .toolCall(let tc):
                 total &+= UInt64(tc.content.utf8.count)
                 total &+= UInt64(tc.preview?.utf8.count ?? 0)
+                total &+= UInt64(tc.rawInput?.utf8.count ?? 0)
                 total &+= UInt64(tc.title.utf8.count)
                 for path in tc.locations { total &+= UInt64(path.utf8.count) }
             case .fileEdit(_, let edit):

--- a/AlasTests/ACP/Session/ACPSessionTests.swift
+++ b/AlasTests/ACP/Session/ACPSessionTests.swift
@@ -327,6 +327,54 @@ struct ACPSessionTests {
         } else { Issue.record("expected toolCall message") }
     }
 
+    @Test("initial toolCall preserves raw input metadata")
+    func toolCallPreservesRawInput() async {
+        let session = ACPSession(id: "s", agentId: "claude", worktreeId: "w", title: "t")
+        session.apply(.toolCall(.init(
+            toolCallId: "tc-meta",
+            title: "bash",
+            kind: "execute",
+            status: "in_progress",
+            content: nil,
+            locations: nil,
+            rawInput: AnyCodable([
+                "command": AnyCodable("swift test"),
+                "timeout": AnyCodable(120)
+            ]),
+            rawOutput: nil)))
+
+        if case .toolCall(let tc) = session.transcript.messages[0] {
+            #expect(tc.rawInput?.contains(#""command":"swift test""#) == true)
+            #expect(tc.rawInput?.contains(#""timeout":120"#) == true)
+        } else {
+            Issue.record("expected toolCall message")
+        }
+    }
+
+    @Test("initial toolCall stores bounded raw input metadata")
+    func toolCallBoundsRawInput() async {
+        let session = ACPSession(id: "s", agentId: "claude", worktreeId: "w", title: "t")
+        session.apply(.toolCall(.init(
+            toolCallId: "tc-large-meta",
+            title: "write",
+            kind: "edit",
+            status: "in_progress",
+            content: nil,
+            locations: nil,
+            rawInput: AnyCodable([
+                "path": AnyCodable("/tmp/large.txt"),
+                "content": AnyCodable(String(repeating: "x", count: 8_192))
+            ]),
+            rawOutput: nil)))
+
+        if case .toolCall(let tc) = session.transcript.messages[0] {
+            #expect(tc.rawInput?.hasSuffix("… [truncated]") == true)
+            #expect((tc.rawInput?.count ?? 0) <= 4_096 + "… [truncated]".count)
+        } else {
+            Issue.record("expected toolCall message")
+        }
+    }
+
     @Test("diff content flattens to a readable text representation")
     func toolCallUpdateDiff() async {
         let session = ACPSession(id: "s", agentId: "claude", worktreeId: "w", title: "t")

--- a/AlasTests/Remote/RemoteWebAssetTests.swift
+++ b/AlasTests/Remote/RemoteWebAssetTests.swift
@@ -28,15 +28,31 @@ struct RemoteWebAssetTests {
         #expect(!css.contains(".m-tool > summary"))
     }
 
+    @Test func toolCardsAlwaysExposeCollapsedMetadata() throws {
+        let app = try asset("app.js")
+        let css = try asset("style.css")
+
+        #expect(app.contains("function toolCollapsedPreview"))
+        #expect(app.contains("function toolDisplayName"))
+        #expect(app.contains("function toolMetadataRows"))
+        #expect(app.contains(#""toolCallId""#))
+        #expect(app.contains(#""rawInput""#))
+        #expect(app.contains(#""params""#))
+        #expect(app.contains(#"button.append(el("span", "tool-glyph", toolGlyph(verb)))"#))
+        #expect(app.contains(#"preview || toolCollapsedPreview(tc)"#))
+        #expect(css.contains(".tool-glyph"))
+        #expect(css.contains(".tool-toggle"))
+    }
+
     @Test func toolCardMobileFixBustsServiceWorkerAssetCache() throws {
         let html = try asset("index.html")
         let sw = try asset("sw.js")
 
-        #expect(html.contains(#"/app.js?v=41"#))
-        #expect(html.contains(#"/style.css?v=29"#))
-        #expect(sw.contains(#"const CACHE_NAME = "alas-remote-shell-v17";"#))
-        #expect(sw.contains(#""/app.js?v=41""#))
-        #expect(sw.contains(#""/style.css?v=29""#))
+        #expect(html.contains(#"/app.js?v=42"#))
+        #expect(html.contains(#"/style.css?v=30"#))
+        #expect(sw.contains(#"const CACHE_NAME = "alas-remote-shell-v18";"#))
+        #expect(sw.contains(#""/app.js?v=42""#))
+        #expect(sw.contains(#""/style.css?v=30""#))
     }
 
     @Test func remoteBareURLLinkifierPreservesIndentedCodeBlocks() throws {
@@ -67,8 +83,8 @@ struct RemoteWebAssetTests {
         #expect(app.contains(#""clean""#))
         #expect(css.contains(".session-row-card"))
         #expect(css.contains(".session-meta"))
-        #expect(html.contains("/app.js?v=41"))
-        #expect(html.contains("/style.css?v=29"))
+        #expect(html.contains("/app.js?v=42"))
+        #expect(html.contains("/style.css?v=30"))
     }
 
     @Test func remoteWebExposesSessionRenameControls() throws {
@@ -93,8 +109,8 @@ struct RemoteWebAssetTests {
         #expect(css.contains(".session-open"))
         #expect(css.contains("#detail-title"))
         #expect(css.contains(".sheet-input"))
-        #expect(sw.contains(#""/app.js?v=41""#))
-        #expect(sw.contains(#""/style.css?v=29""#))
+        #expect(sw.contains(#""/app.js?v=42""#))
+        #expect(sw.contains(#""/style.css?v=30""#))
     }
 
     @Test func serviceWorkerKeepsControlAndDiagnosticRoutesNetworkOnly() throws {


### PR DESCRIPTION
## Summary

- Render remote web tool calls as visible collapsed cards with tool metadata instead of an empty-looking row.
- Preserve ACP tool `rawInput` on `ACPMessage.ToolCall` so remote mirrors can show params while a tool is running.
- Bust remote web asset caches and add coverage for the renderer and raw input preservation.

## Validation

- `xcodegen`
- `node --check Alas/Resources/RemoteWeb/app.js`
- `git diff --check`
- `xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -quiet build`
- `xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -quiet test`