### PR TITLE
feat(review): support multiline comments

### DIFF
--- a/Alas/Sources/Center/Diff/DiffPaneTextDocumentView.swift
+++ b/Alas/Sources/Center/Diff/DiffPaneTextDocumentView.swift
@@ -7,8 +7,25 @@ struct DiffReviewLineAnchor: Equatable, Hashable, Sendable {
     let path: String
     let side: DiffReviewInlineFeedbackSide
     let line: Int
+    let endLine: Int?
     let rowIndex: Int
     let selectedText: String
+
+    init(
+        path: String,
+        side: DiffReviewInlineFeedbackSide,
+        line: Int,
+        endLine: Int? = nil,
+        rowIndex: Int,
+        selectedText: String
+    ) {
+        self.path = path
+        self.side = side
+        self.line = line
+        self.endLine = endLine
+        self.rowIndex = rowIndex
+        self.selectedText = selectedText
+    }
 }
 
 struct DiffPaneTextDocumentView: NSViewRepresentable {
@@ -900,10 +917,57 @@ final class DiffPaneCodeTextView: NSTextView {
         return lineMetadata[row].reviewLineAnchor(rowIndex: row)
     }
 
+    func reviewLineAnchor(fromRow startRow: Int, toRow endRow: Int) -> DiffReviewLineAnchor? {
+        let lowerRow = min(startRow, endRow)
+        let upperRow = max(startRow, endRow)
+        guard lineMetadata.indices.contains(lowerRow),
+              lineMetadata.indices.contains(upperRow)
+        else { return nil }
+
+        var resolvedAnchors: [DiffReviewLineAnchor] = []
+        for rowIndex in lowerRow...upperRow {
+            let metadata = lineMetadata[rowIndex]
+            if let anchor = metadata.reviewLineAnchor(rowIndex: rowIndex) {
+                resolvedAnchors.append(anchor)
+            } else if metadata.tone != .placeholder {
+                return nil
+            }
+        }
+        guard !resolvedAnchors.isEmpty,
+              let first = resolvedAnchors.first,
+              resolvedAnchors.allSatisfy({ $0.path == first.path })
+        else { return nil }
+        guard resolvedAnchors.count > 1 else { return first }
+
+        let side = resolvedAnchors.allSatisfy({ $0.side == first.side }) ? first.side : .unknown
+        let lineNumbers = resolvedAnchors.flatMap { anchor -> [Int] in
+            if let endLine = anchor.endLine {
+                return [anchor.line, endLine]
+            }
+            return [anchor.line]
+        }
+        guard let startLine = lineNumbers.min(),
+              let endLine = lineNumbers.max()
+        else { return nil }
+
+        return DiffReviewLineAnchor(
+            path: first.path,
+            side: side,
+            line: startLine,
+            endLine: endLine,
+            rowIndex: first.rowIndex,
+            selectedText: resolvedAnchors.map(\.selectedText).joined(separator: "\n")
+        )
+    }
+
     func reviewLineAnchor(at point: NSPoint) -> DiffReviewLineAnchor? {
-        let rowRects = diffRowRects()
-        guard let row = rowRects.firstIndex(where: { $0.contains(point) }) else { return nil }
+        guard let row = reviewLineRow(at: point) else { return nil }
         return reviewLineAnchor(atRow: row)
+    }
+
+    func reviewLineRow(at point: NSPoint) -> Int? {
+        let rowRects = diffRowRects()
+        return rowRects.firstIndex(where: { $0.contains(point) })
     }
 
     func invokeExpansionForTesting(row: Int, optionKey: Bool) {
@@ -1070,6 +1134,8 @@ final class DiffPaneLineNumberRulerView: NSRulerView {
     var onContextExpansion: (DiffContextExpansionKey, DiffContextExpansionMode) -> Void = { _, _ in }
     private var contentTopInset: CGFloat = 6
     private var boundsObserver: NSObjectProtocol?
+    private var selectionStartRow: Int?
+    private var selectionCurrentRow: Int?
 
     private let minimumThickness: CGFloat = 42
     private let horizontalPadding: CGFloat = 8
@@ -1124,10 +1190,52 @@ final class DiffPaneLineNumberRulerView: NSRulerView {
         if let row = rowIndex(at: sourcePoint), invokeExpansion(row: row, optionKey: event.modifierFlags.contains(.option)) {
             return
         }
-        guard let anchor = textView.reviewLineAnchor(at: sourcePoint) else {
+        guard let row = textView.reviewLineRow(at: sourcePoint) else {
             super.mouseDown(with: event)
             return
         }
+
+        selectionStartRow = row
+        selectionCurrentRow = row
+        needsDisplay = true
+    }
+
+    override func mouseDragged(with event: NSEvent) {
+        guard let scrollView,
+              let textView = scrollView.documentView as? DiffPaneCodeTextView,
+              selectionStartRow != nil
+        else {
+            super.mouseDragged(with: event)
+            return
+        }
+
+        let point = convert(event.locationInWindow, from: nil)
+        let sourcePoint = NSPoint(
+            x: point.x,
+            y: point.y + scrollView.contentView.bounds.origin.y
+        )
+        if let row = textView.reviewLineRow(at: sourcePoint), row != selectionCurrentRow {
+            selectionCurrentRow = row
+            needsDisplay = true
+        }
+    }
+
+    override func mouseUp(with event: NSEvent) {
+        defer {
+            selectionStartRow = nil
+            selectionCurrentRow = nil
+            needsDisplay = true
+        }
+        guard let scrollView,
+              let textView = scrollView.documentView as? DiffPaneCodeTextView,
+              let startRow = selectionStartRow,
+              let currentRow = selectionCurrentRow,
+              let anchor = textView.reviewLineAnchor(fromRow: startRow, toRow: currentRow)
+        else {
+            super.mouseUp(with: event)
+            return
+        }
+
         onReviewLineSelected(anchor)
     }
 
@@ -1190,6 +1298,7 @@ final class DiffPaneLineNumberRulerView: NSRulerView {
                 drawReviewAffordance(in: rowRect, theme: theme)
             }
         }
+        drawSelectionOutline(visibleRect: visible, rowRects: rowRects, theme: theme)
     }
 
     func visibleRowIndices(in visibleRect: NSRect) -> [Int] {
@@ -1271,6 +1380,25 @@ final class DiffPaneLineNumberRulerView: NSRulerView {
         let mode: DiffContextExpansionMode = optionKey ? .all : .chunk(size: diffContextExpansionChunkSize)
         onContextExpansion(key, mode)
         return true
+    }
+
+    static func selectionOutlineRect(
+        rowRects: [NSRect],
+        rowRange: ClosedRange<Int>,
+        visibleMinY: CGFloat,
+        ruleThickness: CGFloat
+    ) -> NSRect {
+        let rows = rowRange.compactMap { index in
+            rowRects.indices.contains(index) ? rowRects[index] : nil
+        }
+        guard let first = rows.first else { return .zero }
+        let union = rows.dropFirst().reduce(first) { $0.union($1) }
+        return NSRect(
+            x: 4,
+            y: max(0, union.minY - visibleMinY),
+            width: max(ruleThickness - 8, 1),
+            height: union.height
+        )
     }
 
     private func observe(scrollView: NSScrollView) {
@@ -1409,6 +1537,26 @@ final class DiffPaneLineNumberRulerView: NSRulerView {
         )
     }
 
+    private func drawSelectionOutline(visibleRect: NSRect, rowRects: [NSRect], theme: Theme) {
+        guard let start = selectionStartRow,
+              let current = selectionCurrentRow
+        else { return }
+
+        let rowRange = min(start, current)...max(start, current)
+        let outlineRect = Self.selectionOutlineRect(
+            rowRects: rowRects,
+            rowRange: rowRange,
+            visibleMinY: visibleRect.minY,
+            ruleThickness: ruleThickness
+        )
+        guard outlineRect != .zero else { return }
+
+        NSColor(theme.color("accent")).setStroke()
+        let path = NSBezierPath(roundedRect: outlineRect.insetBy(dx: 0.5, dy: 0.5), xRadius: 5, yRadius: 5)
+        path.lineWidth = 1.5
+        path.stroke()
+    }
+
     static func changeRailRect(in rowRect: NSRect, tone: DiffPaneLineTone) -> NSRect? {
         switch tone {
         case .add, .delete:
@@ -1484,6 +1632,7 @@ private extension DiffPaneTextDocumentBuilder.LineMetadata {
             path: sourceLine.anchor.filePath,
             side: side,
             line: lineNumber,
+            endLine: nil,
             rowIndex: rowIndex,
             selectedText: sourceLine.text
         )

--- a/Alas/Sources/Center/DiffReview/DiffReviewFileSection.swift
+++ b/Alas/Sources/Center/DiffReview/DiffReviewFileSection.swift
@@ -29,6 +29,7 @@ struct DiffReviewFileSection: View {
     var reviewFeedbackTarget: ReviewFeedbackTarget?
 
     @Environment(\.theme) private var theme
+    @StateObject private var copyFeedback = CopyFeedbackState()
     @State private var pendingDraftAnchor: DiffReviewLineAnchor?
     @State private var pendingDraftBody = ""
     @State private var expandedCollapsedRowIDs: Set<String> = []
@@ -40,6 +41,7 @@ struct DiffReviewFileSection: View {
     @State private var contextLoadGeneration = 0
     @State private var contextLoadError: String?
     @State private var pendingContextExpansions: [PendingContextExpansion] = []
+    @FocusState private var draftComposerFocused: Bool
 
     var body: some View {
         VStack(spacing: 0) {
@@ -51,6 +53,7 @@ struct DiffReviewFileSection: View {
         }
         .background(theme.color("bg-1"))
         .clipShape(RoundedRectangle(cornerRadius: 8))
+        .copyFeedbackOverlay(message: copyFeedback.message)
         .overlay(
             RoundedRectangle(cornerRadius: 8)
                 .stroke(theme.color("line"), lineWidth: 0.75)
@@ -61,6 +64,7 @@ struct DiffReviewFileSection: View {
                 label: file.summary.path
             )
         )
+        .background(copyFeedbackMarker)
         .onChange(of: draftCommentDisplaySignature) { _, _ in
             clearPendingDraft()
         }
@@ -69,6 +73,22 @@ struct DiffReviewFileSection: View {
         }
         .onChange(of: contextStateSignature) { _, _ in
             resetContextState()
+        }
+        .onChange(of: pendingDraftAnchor) { _, anchor in
+            guard anchor != nil else { return }
+            Task { @MainActor in
+                draftComposerFocused = true
+            }
+        }
+    }
+
+    @ViewBuilder
+    private var copyFeedbackMarker: some View {
+        if let message = copyFeedback.message {
+            DiffReviewAccessibilityMarker(
+                identifier: "diff-review-copy-feedback-\(file.id.rawValue)",
+                label: message
+            )
         }
     }
 
@@ -138,6 +158,23 @@ struct DiffReviewFileSection: View {
         )
     }
 
+    private var feedbackDraftCommentActions: ReviewDraftCommentActions {
+        ReviewDraftCommentActions(
+            availability: draftCommentActions.availability,
+            edit: draftCommentActions.edit,
+            delete: draftCommentActions.delete,
+            resolve: draftCommentActions.resolve,
+            dismiss: draftCommentActions.dismiss,
+            copyPrompt: { bundle in
+                draftCommentActions.copyPrompt(bundle)
+                copyFeedback.show("Copied prompt")
+            },
+            publishProvider: draftCommentActions.publishProvider,
+            agentTargets: draftCommentActions.agentTargets,
+            sendToAgent: draftCommentActions.sendToAgent
+        )
+    }
+
     @ViewBuilder
     private var contextLoadErrorRow: some View {
         if let contextLoadError {
@@ -175,7 +212,7 @@ struct DiffReviewFileSection: View {
                         comment: comment,
                         file: file.summary,
                         isFocused: comment.id == focusedDraftCommentID,
-                        actions: draftCommentActions,
+                        actions: feedbackDraftCommentActions,
                         reviewFeedbackTarget: effectiveReviewFeedbackTarget,
                         onSelect: onSelectDraftComment
                     )
@@ -400,10 +437,15 @@ struct DiffReviewFileSection: View {
             ReviewDraftComposerTextEditor(
                 text: $pendingDraftBody,
                 theme: theme,
+                isFocused: $draftComposerFocused,
                 onSave: savePendingDraft,
                 onCancel: clearPendingDraft
             )
             .frame(minHeight: 76, maxHeight: 104)
+            .background(focusedComposerMarker)
+            .onAppear {
+                draftComposerFocused = true
+            }
             .clipShape(RoundedRectangle(cornerRadius: 7))
             .overlay(
                 RoundedRectangle(cornerRadius: 7)
@@ -450,13 +492,23 @@ struct DiffReviewFileSection: View {
         )
     }
 
+    @ViewBuilder
+    private var focusedComposerMarker: some View {
+        if draftComposerFocused {
+            DiffReviewAccessibilityMarker(
+                identifier: "diff-review-draft-composer-focused",
+                label: "Draft comment composer focused"
+            )
+        }
+    }
+
     private func savePendingDraft() {
         guard let pendingDraftAnchor else { return }
         let body = pendingDraftBody.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !body.isEmpty else { return }
         guard currentDraftRowKeys.contains(ReviewDraftCommentPlacement.RowKey(
             side: pendingDraftAnchor.side,
-            line: pendingDraftAnchor.line
+            line: pendingDraftAnchor.draftPlacementLine
         )) else {
             clearPendingDraft()
             return
@@ -469,6 +521,7 @@ struct DiffReviewFileSection: View {
     private func clearPendingDraft() {
         pendingDraftAnchor = nil
         pendingDraftBody = ""
+        draftComposerFocused = false
     }
 
     private var currentDraftRowKeys: Set<ReviewDraftCommentPlacement.RowKey> {
@@ -641,6 +694,7 @@ enum ReviewDraftComposerKeyboardAction: Equatable {
 private struct ReviewDraftComposerTextEditor: NSViewRepresentable {
     @Binding var text: String
     let theme: Theme
+    let isFocused: FocusState<Bool>.Binding
     let onSave: () -> Void
     let onCancel: () -> Void
 
@@ -682,6 +736,7 @@ private struct ReviewDraftComposerTextEditor: NSViewRepresentable {
         scrollView.documentView = textView
         context.coordinator.textView = textView
         applyTheme(to: scrollView, textView: textView)
+        requestFocusIfNeeded(textView)
         return scrollView
     }
 
@@ -693,6 +748,7 @@ private struct ReviewDraftComposerTextEditor: NSViewRepresentable {
         }
         textView.onKeyboardAction = context.coordinator.perform
         applyTheme(to: scrollView, textView: textView)
+        requestFocusIfNeeded(textView)
     }
 
     private func applyTheme(to scrollView: NSScrollView, textView: NSTextView) {
@@ -701,6 +757,16 @@ private struct ReviewDraftComposerTextEditor: NSViewRepresentable {
         textView.font = .systemFont(ofSize: 12)
         textView.textColor = NSColor(theme.color("fg"))
         textView.insertionPointColor = NSColor(theme.color("accent"))
+    }
+
+    private func requestFocusIfNeeded(_ textView: NSTextView) {
+        guard isFocused.wrappedValue else { return }
+        DispatchQueue.main.async {
+            guard let window = textView.window,
+                  window.firstResponder !== textView
+            else { return }
+            window.makeFirstResponder(textView)
+        }
     }
 
     final class Coordinator: NSObject, NSTextViewDelegate {
@@ -716,6 +782,15 @@ private struct ReviewDraftComposerTextEditor: NSViewRepresentable {
             parent.text = textView.string
         }
 
+        func textDidBeginEditing(_ notification: Notification) {
+            parent.isFocused.wrappedValue = true
+        }
+
+        func textDidEndEditing(_ notification: Notification) {
+            parent.isFocused.wrappedValue = false
+        }
+
+        @MainActor
         func perform(_ action: ReviewDraftComposerKeyboardAction) {
             switch action {
             case .save:
@@ -728,7 +803,7 @@ private struct ReviewDraftComposerTextEditor: NSViewRepresentable {
 }
 
 private final class ReviewDraftComposerNSTextView: NSTextView {
-    var onKeyboardAction: ((ReviewDraftComposerKeyboardAction) -> Void)?
+    var onKeyboardAction: (@MainActor (ReviewDraftComposerKeyboardAction) -> Void)?
 
     override func keyDown(with event: NSEvent) {
         let key = event.charactersIgnoringModifiers ?? event.characters ?? ""
@@ -880,7 +955,7 @@ enum ReviewDraftCommentRowSegmentation {
         pendingAnchor: DiffReviewLineAnchor?
     ) -> Result {
         let pendingKey = pendingAnchor.map {
-            ReviewDraftCommentPlacement.RowKey(side: $0.side, line: $0.line)
+            ReviewDraftCommentPlacement.RowKey(side: $0.side, line: $0.draftPlacementLine)
         }
         var segments: [Segment] = []
         var bufferedRows: [DiffDisplayRow] = []
@@ -1117,6 +1192,7 @@ private struct ReviewDraftCommentCard: View {
     @Environment(\.theme) private var theme
     @State private var isEditing = false
     @State private var editingBody = ""
+    @FocusState private var editorFocused: Bool
 
     var body: some View {
         VStack(alignment: .leading, spacing: 6) {
@@ -1189,6 +1265,7 @@ private struct ReviewDraftCommentCard: View {
                     ReviewDraftComposerTextEditor(
                         text: $editingBody,
                         theme: theme,
+                        isFocused: $editorFocused,
                         onSave: saveEditingComment,
                         onCancel: cancelEditingComment
                     )
@@ -1246,6 +1323,7 @@ private struct ReviewDraftCommentCard: View {
                     actionButton(id: "edit", title: "Edit") {
                         editingBody = comment.bodyMarkdown
                         isEditing = true
+                        editorFocused = true
                     }
                 }
                 if availability.canDelete {
@@ -1325,7 +1403,7 @@ private struct ReviewDraftCommentCard: View {
         .accessibilityLabel(title)
         .background(
             DiffReviewAccessibilityMarker(
-                identifier: markerIdentifier(forActionID: id),
+                identifier: "\(markerIdentifier(forActionID: id))-label",
                 label: title
             )
         )
@@ -1340,10 +1418,7 @@ private struct ReviewDraftCommentCard: View {
     }
 
     private func accessibilityIdentifier(forActionID id: String) -> String {
-        if id == "publish" {
-            return "diff-review-draft-comment-publish-\(comment.id)"
-        }
-        return "diff-review-draft-comment-\(id)-\(comment.id)"
+        return "diff-review-draft-comment-button-\(id)-\(comment.id)"
     }
 
     private func markerIdentifier(forActionID id: String) -> String {
@@ -1361,6 +1436,7 @@ private struct ReviewDraftCommentCard: View {
     private func cancelEditingComment() {
         isEditing = false
         editingBody = ""
+        editorFocused = false
     }
 
     private var feedbackBundle: ReviewFeedbackBundle {
@@ -1413,6 +1489,12 @@ private struct ReviewDraftCommentCard: View {
         case .dismissed:
             theme.color("fg-muted")
         }
+    }
+}
+
+private extension DiffReviewLineAnchor {
+    var draftPlacementLine: Int {
+        endLine ?? line
     }
 }
 

--- a/Alas/Sources/Center/ReviewWorkspace/ReviewDraftCommentController.swift
+++ b/Alas/Sources/Center/ReviewWorkspace/ReviewDraftCommentController.swift
@@ -50,7 +50,7 @@ final class ReviewDraftCommentController {
             originalPath: originalPath,
             side: anchor.side,
             startLine: anchor.line,
-            endLine: nil,
+            endLine: anchor.endLine,
             selectedText: anchor.selectedText,
             bodyMarkdown: bodyMarkdown,
             state: .active,

--- a/AlasTests/DiffPaneViewTests.swift
+++ b/AlasTests/DiffPaneViewTests.swift
@@ -91,6 +91,25 @@ struct DiffPaneViewTests {
         )
     }
 
+    private func diffLine(id: String, side: DiffLineSide, oldLine: Int? = nil, newLine: Int? = nil, text: String) -> DiffDisplayLine {
+        DiffDisplayLine(
+            id: id,
+            anchor: DiffLineAnchor(
+                filePath: "Sources/App.swift",
+                hunkIndex: 0,
+                rowIndex: 0,
+                side: side,
+                oldLine: oldLine,
+                newLine: newLine
+            ),
+            text: text,
+            lineNumber: oldLine ?? newLine,
+            kind: .context,
+            inlineSpans: [],
+            noTrailingNewline: false
+        )
+    }
+
     @Test func splitModeHostsRendererWithoutCrashing() {
         var layout = DiffLayoutMode.split
         var wrap = false
@@ -335,6 +354,149 @@ struct DiffPaneViewTests {
         #expect(addedAnchor.selectedText == "let b = 3")
     }
 
+    @Test @MainActor func stackedTextDocumentBuildsMultilineReviewAnchor() throws {
+        let view = DiffPaneTextDocumentView(
+            group: try #require(reviewAnchorModel().groups.first),
+            expandedCollapsedRowIDs: [],
+            layoutMode: .stacked,
+            wrapLines: false,
+            showWhitespace: false,
+            fileExtension: "swift",
+            codeFontFamily: "",
+            codeFontSize: 13,
+            theme: theme(),
+            lspContext: nil
+        )
+
+        let controller = NSHostingController(rootView: view)
+        controller.view.frame = NSRect(x: 0, y: 0, width: 520, height: 400)
+        controller.view.layoutSubtreeIfNeeded()
+
+        let codeView = try #require(visibleCodeTextViews(in: controller.view).first)
+        let anchor = try #require(codeView.reviewLineAnchor(fromRow: 1, toRow: 2))
+
+        #expect(anchor.path == "Sources/App.swift")
+        #expect(anchor.side == .unknown)
+        #expect(anchor.line == 2)
+        #expect(anchor.endLine == 2)
+        #expect(anchor.rowIndex == 1)
+        #expect(anchor.selectedText == """
+let b = 2
+let b = 3
+""")
+    }
+
+    @Test @MainActor func multilineReviewAnchorRejectsSkippedRows() throws {
+        let group = DiffDisplayGroup(
+            id: "group",
+            header: "@@ -1,3 +1,3 @@",
+            sourceHunk: ParsedDiff.Hunk(header: "@@ -1,3 +1,3 @@", oldStart: 1, newStart: 1, lines: []),
+            rows: [
+                DiffDisplayRow(
+                    id: "row-1",
+                    kind: .context,
+                    old: nil,
+                    new: diffLine(id: "new-1", side: .new, newLine: 1, text: "let first = true"),
+                    collapsedLineCount: 0
+                ),
+                DiffDisplayRow(
+                    id: "collapsed",
+                    kind: .collapsed,
+                    old: nil,
+                    new: nil,
+                    collapsedLineCount: 3
+                ),
+                DiffDisplayRow(
+                    id: "row-2",
+                    kind: .context,
+                    old: nil,
+                    new: diffLine(id: "new-5", side: .new, newLine: 5, text: "let last = true"),
+                    collapsedLineCount: 0
+                ),
+            ]
+        )
+        let view = DiffPaneTextDocumentView(
+            group: group,
+            expandedCollapsedRowIDs: [],
+            layoutMode: .stacked,
+            wrapLines: false,
+            showWhitespace: false,
+            fileExtension: "swift",
+            codeFontFamily: "",
+            codeFontSize: 13,
+            theme: theme(),
+            lspContext: nil
+        )
+
+        let controller = NSHostingController(rootView: view)
+        controller.view.frame = NSRect(x: 0, y: 0, width: 520, height: 400)
+        controller.view.layoutSubtreeIfNeeded()
+
+        let codeView = try #require(visibleCodeTextViews(in: controller.view).first)
+
+        #expect(codeView.reviewLineAnchor(fromRow: 0, toRow: 2) == nil)
+    }
+
+    @Test @MainActor func splitMultilineReviewAnchorSkipsOppositeSidePlaceholders() throws {
+        let group = DiffDisplayGroup(
+            id: "group",
+            header: "@@ -1,3 +1,2 @@",
+            sourceHunk: ParsedDiff.Hunk(header: "@@ -1,3 +1,2 @@", oldStart: 1, newStart: 1, lines: []),
+            rows: [
+                DiffDisplayRow(
+                    id: "row-1",
+                    kind: .context,
+                    old: diffLine(id: "old-1", side: .old, oldLine: 1, text: "let first = true"),
+                    new: diffLine(id: "new-1", side: .new, newLine: 1, text: "let first = true"),
+                    collapsedLineCount: 0
+                ),
+                DiffDisplayRow(
+                    id: "deleted",
+                    kind: .delete,
+                    old: diffLine(id: "old-2", side: .old, oldLine: 2, text: "let removed = true"),
+                    new: nil,
+                    collapsedLineCount: 0
+                ),
+                DiffDisplayRow(
+                    id: "row-2",
+                    kind: .context,
+                    old: diffLine(id: "old-3", side: .old, oldLine: 3, text: "let second = true"),
+                    new: diffLine(id: "new-2", side: .new, newLine: 2, text: "let second = true"),
+                    collapsedLineCount: 0
+                ),
+            ]
+        )
+        let view = DiffPaneTextDocumentView(
+            group: group,
+            expandedCollapsedRowIDs: [],
+            layoutMode: .split,
+            wrapLines: false,
+            showWhitespace: false,
+            fileExtension: "swift",
+            codeFontFamily: "",
+            codeFontSize: 13,
+            theme: theme(),
+            lspContext: nil
+        )
+
+        let controller = NSHostingController(rootView: view)
+        controller.view.frame = NSRect(x: 0, y: 0, width: 820, height: 400)
+        controller.view.layoutSubtreeIfNeeded()
+
+        let codeViews = visibleCodeTextViews(in: controller.view)
+        let newCodeView = try #require(codeViews.last)
+        let anchor = try #require(newCodeView.reviewLineAnchor(fromRow: 0, toRow: 2))
+
+        #expect(anchor.path == "Sources/App.swift")
+        #expect(anchor.side == .new)
+        #expect(anchor.line == 1)
+        #expect(anchor.endLine == 2)
+        #expect(anchor.selectedText == """
+let first = true
+let second = true
+""")
+    }
+
     @Test @MainActor func rowHitTestingReturnsLocalReviewAnchorForCodePoint() throws {
         var layout = DiffLayoutMode.split
         var wrap = false
@@ -444,6 +606,23 @@ struct DiffPaneViewTests {
                 #expect(abs(codeCenter - labelCenter) < 0.75)
             }
         }
+    }
+
+    @Test func gutterSelectionOutlineWrapsContiguousRows() {
+        let rowRects = [
+            NSRect(x: 0, y: 8, width: 42, height: 18),
+            NSRect(x: 0, y: 26, width: 42, height: 22),
+            NSRect(x: 0, y: 48, width: 42, height: 18),
+        ]
+
+        let outline = DiffPaneLineNumberRulerView.selectionOutlineRect(
+            rowRects: rowRects,
+            rowRange: 0...2,
+            visibleMinY: 10,
+            ruleThickness: 42
+        )
+
+        #expect(outline == NSRect(x: 4, y: 0, width: 34, height: 58))
     }
 
     @Test func diffTextScrollPanesUseLeadingClipViewsAndStartScrolledLeft() throws {

--- a/AlasTests/DiffReviewSurfaceTests.swift
+++ b/AlasTests/DiffReviewSurfaceTests.swift
@@ -627,6 +627,29 @@ struct DiffReviewSurfaceTests {
         #expect(segments.items[1].draftComments.map(\.id) == ["draft-second"])
     }
 
+    @Test func pendingMultilineDraftComposerUsesRangeEndRow() throws {
+        let model = displayModel()
+        let group = try #require(model.groups.first)
+        let pendingAnchor = DiffReviewLineAnchor(
+            path: "A.swift",
+            side: .new,
+            line: 1,
+            endLine: 2,
+            rowIndex: 0,
+            selectedText: "line 1\nline 2"
+        )
+
+        let segments = ReviewDraftCommentRowSegmentation.segments(
+            for: group,
+            placement: ReviewDraftCommentPlacement.position([], in: model.groups),
+            pendingAnchor: pendingAnchor
+        )
+
+        #expect(segments.items.count == 1)
+        #expect(segments.items[0].showsComposer)
+        #expect(segments.items[0].rows.map(\.id) == [group.rows[0].id, group.rows[1].id])
+    }
+
     @Test func localDraftCommentsOnCollapsedRowsAttachToCollapsedParent() throws {
         let hiddenLine = diffLine(
             id: "hidden-new",
@@ -1055,6 +1078,9 @@ struct DiffReviewSurfaceTests {
         ))
         #expect(recorder.copied?.target == target)
         #expect(recorder.copied?.comments == [comment])
+        RunLoop.main.run(until: Date(timeIntervalSinceNow: 0.05))
+        controller.view.layoutSubtreeIfNeeded()
+        #expect(accessibilityLabel(in: controller.view, containing: "Copied prompt") != nil)
     }
 
     @Test func fileSectionDraftCommentCardDoesNotFireDisabledSendAction() {

--- a/AlasTests/ReviewDraftCommentStoreTests.swift
+++ b/AlasTests/ReviewDraftCommentStoreTests.swift
@@ -23,8 +23,13 @@ struct ReviewDraftCommentStoreTests {
             path: "Sources/App.swift",
             side: .new,
             line: 42,
+            endLine: 44,
             rowIndex: 3,
-            selectedText: "let value = 1"
+            selectedText: """
+let value = 1
+let other = 2
+return value + other
+"""
         )
         let fileID = DiffReviewFileID(namespace: "unstaged", path: "Sources/App.swift")
 
@@ -39,8 +44,12 @@ struct ReviewDraftCommentStoreTests {
         #expect(added.originalPath == nil)
         #expect(added.side == .new)
         #expect(added.startLine == 42)
-        #expect(added.endLine == nil)
-        #expect(added.selectedText == "let value = 1")
+        #expect(added.endLine == 44)
+        #expect(added.selectedText == """
+let value = 1
+let other = 2
+return value + other
+""")
         #expect(added.bodyMarkdown == "Please revisit this.")
         #expect(added.state == .active)
         #expect(added.createdAt == Date(timeIntervalSince1970: 100))


### PR DESCRIPTION
## Summary

- Add gutter drag selection for multiline review comments in the review pane.
- Persist selected review ranges through draft comment creation.
- Draw an accent outline around the selected gutter range.
- Add copy feedback for draft comment prompt copy actions.
- Focus the draft composer when a comment is opened.

## Validation

- `xcodegen`
- `xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -quiet build`
- `xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -only-testing:AlasTests/DiffPaneViewTests -only-testing:AlasTests/DiffReviewSurfaceTests -only-testing:AlasTests/ReviewDraftCommentStoreTests test` (109 tests passed)

Full `xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' test` was started locally, but the process stayed active and silent for several minutes and was interrupted to avoid leaving a hung build process running.