### PR TITLE
fix(changes): footer code host icon

### DIFF
--- a/Alas/Sources/Icons/Icon.swift
+++ b/Alas/Sources/Icons/Icon.swift
@@ -18,6 +18,14 @@ struct Icon: View {
                 ))
                 .foregroundColor(resolved)
                 .frame(width: size, height: size)
+        } else if name == "github" {
+            GitHubGlyph()
+                .fill(resolved, style: FillStyle(eoFill: true))
+                .frame(width: size, height: size)
+        } else if name == "gitlab" {
+            GitLabGlyph()
+                .fill(resolved)
+                .frame(width: size, height: size)
         } else {
             Image(systemName: Self.symbol(for: name))
                 .font(.system(size: size))
@@ -25,7 +33,7 @@ struct Icon: View {
         }
     }
 
-    static func symbol(for name: String) -> String {
+    nonisolated static func symbol(for name: String) -> String {
         switch name {
         case "branch":     return "arrow.triangle.branch"
         case "home":       return "house"
@@ -48,11 +56,20 @@ struct Icon: View {
         case "split-down": return "rectangle.split.1x2"
         case "palette":    return "paintpalette"
         case "keyboard":   return "keyboard"
-        case "github":     return "circle.hexagongrid"
-        case "gitlab":     return "triangle"
+        case "github":     return "github"
+        case "gitlab":     return "gitlab"
         case "alert":      return "exclamationmark.triangle"
         case "sparkle":    return "sparkles"
         default:           return name
+        }
+    }
+
+    nonisolated static func rendersCustomGlyph(for name: String) -> Bool {
+        switch name {
+        case "commit", "github", "gitlab":
+            true
+        default:
+            false
         }
     }
 }
@@ -75,5 +92,73 @@ struct CommitGlyph: Shape {
         p.move(to: CGPoint(x: cx, y: rect.minY + 11.5 * unit))
         p.addLine(to: CGPoint(x: cx, y: rect.minY + 14.5 * unit))
         return p
+    }
+}
+
+/// Compact GitHub mark used where SF Symbols has no brand glyph.
+struct GitHubGlyph: Shape {
+    func path(in rect: CGRect) -> Path {
+        let s = min(rect.width, rect.height)
+        let x = rect.midX - s / 2
+        let y = rect.midY - s / 2
+        let unit = s / 16
+
+        func p(_ px: CGFloat, _ py: CGFloat) -> CGPoint {
+            CGPoint(x: x + px * unit, y: y + py * unit)
+        }
+
+        var path = Path()
+        path.addEllipse(in: CGRect(x: x + 1.2 * unit, y: y + 1.2 * unit, width: 13.6 * unit, height: 13.6 * unit))
+
+        var cutout = Path()
+        cutout.move(to: p(5.0, 13.6))
+        cutout.addCurve(to: p(5.4, 11.9), control1: p(5.1, 13.0), control2: p(5.1, 12.4))
+        cutout.addCurve(to: p(3.8, 11.2), control1: p(4.4, 12.0), control2: p(4.0, 11.5))
+        cutout.addCurve(to: p(5.3, 11.2), control1: p(3.9, 10.8), control2: p(4.5, 11.0))
+        cutout.addCurve(to: p(6.5, 10.3), control1: p(5.8, 11.0), control2: p(6.2, 10.7))
+        cutout.addCurve(to: p(3.7, 6.2), control1: p(4.7, 10.1), control2: p(3.7, 9.0))
+        cutout.addCurve(to: p(4.5, 3.9), control1: p(3.7, 5.3), control2: p(4.0, 4.5))
+        cutout.addCurve(to: p(6.8, 4.8), control1: p(4.4, 3.4), control2: p(4.7, 3.1))
+        cutout.addCurve(to: p(9.2, 4.8), control1: p(7.5, 4.6), control2: p(8.5, 4.6))
+        cutout.addCurve(to: p(11.5, 3.9), control1: p(11.3, 3.1), control2: p(11.6, 3.4))
+        cutout.addCurve(to: p(12.3, 6.2), control1: p(12.0, 4.5), control2: p(12.3, 5.3))
+        cutout.addCurve(to: p(9.5, 10.3), control1: p(12.3, 9.0), control2: p(11.3, 10.1))
+        cutout.addCurve(to: p(10.0, 12.0), control1: p(9.9, 10.8), control2: p(10.0, 11.4))
+        cutout.addLine(to: p(10.0, 13.6))
+        cutout.addLine(to: p(5.0, 13.6))
+        cutout.closeSubpath()
+
+        path.addPath(cutout)
+        return path
+    }
+}
+
+/// Compact GitLab mark used where SF Symbols has no brand glyph.
+struct GitLabGlyph: Shape {
+    func path(in rect: CGRect) -> Path {
+        let s = min(rect.width, rect.height)
+        let x = rect.midX - s / 2
+        let y = rect.midY - s / 2
+        let unit = s / 16
+
+        func p(_ px: CGFloat, _ py: CGFloat) -> CGPoint {
+            CGPoint(x: x + px * unit, y: y + py * unit)
+        }
+
+        var path = Path()
+        path.move(to: p(8, 14.2))
+        path.addLine(to: p(2.1, 9.9))
+        path.addCurve(to: p(1.8, 8.8), control1: p(1.8, 9.6), control2: p(1.7, 9.2))
+        path.addLine(to: p(3.2, 3.9))
+        path.addCurve(to: p(4.1, 3.4), control1: p(3.3, 3.4), control2: p(3.9, 3.2))
+        path.addLine(to: p(5.9, 7.2))
+        path.addLine(to: p(10.1, 7.2))
+        path.addLine(to: p(11.9, 3.4))
+        path.addCurve(to: p(12.8, 3.9), control1: p(12.1, 3.2), control2: p(12.7, 3.4))
+        path.addLine(to: p(14.2, 8.8))
+        path.addCurve(to: p(13.9, 9.9), control1: p(14.3, 9.2), control2: p(14.2, 9.6))
+        path.addLine(to: p(8, 14.2))
+        path.closeSubpath()
+        return path
     }
 }

--- a/Alas/Sources/Integrations/CodeHost/ReviewLoopDrawer.swift
+++ b/Alas/Sources/Integrations/CodeHost/ReviewLoopDrawer.swift
@@ -106,6 +106,7 @@ struct ReviewLoopDrawer: View {
                         .lineLimit(1)
                 }
                 .buttonStyle(.plain)
+                .focusEffectDisabled()
                 .help("Open \(model.providerTitle ?? "review") \(requestNumberTitle)")
             }
         }
@@ -249,6 +250,7 @@ private struct ReviewReadinessActionButton: View {
             )
         }
         .buttonStyle(.plain)
+        .focusEffectDisabled()
         .disabled(!action.isEnabled)
         .opacity(action.isEnabled ? 1 : 0.5)
         .help(action.title)

--- a/AlasTests/IconSymbolTests.swift
+++ b/AlasTests/IconSymbolTests.swift
@@ -9,4 +9,11 @@ struct IconSymbolTests {
     @Test func branchMappingUnchanged() {
         #expect(Icon.symbol(for: "branch") == "arrow.triangle.branch")
     }
+
+    @Test func codeHostIconsUseCustomGlyphs() {
+        #expect(Icon.symbol(for: "github") == "github")
+        #expect(Icon.symbol(for: "gitlab") == "gitlab")
+        #expect(Icon.rendersCustomGlyph(for: "github"))
+        #expect(Icon.rendersCustomGlyph(for: "gitlab"))
+    }
 }


### PR DESCRIPTION
## Summary
- Render GitHub/GitLab code-host icons deterministically in the Changes footer.
- Suppress the unwanted focus effect on the compact footer controls while preserving button semantics.
- Add regression coverage for code-host icon routing.

## Validation
- xcodegen
- xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -quiet build
- Focused IconSymbolTests

Full xcodebuild test was attempted earlier but wedged after running a large portion of the suite.