### PR TITLE
fix(acp): preserve ACP chat tail on tab restore

### DIFF
--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -5498,7 +5498,7 @@
 			repositoryURL = "https://github.com/apple/swift-markdown";
 			requirement = {
 				kind = upToNextMajorVersion;
-				minimumVersion = 0.4.0;
+				minimumVersion = 0.8.0;
 			};
 		};
 		CF72A36467D20A160E653761 /* XCRemoteSwiftPackageReference "swift-tree-sitter" */ = {

--- a/Alas/Sources/ACP/UI/ACPMessageList.swift
+++ b/Alas/Sources/ACP/UI/ACPMessageList.swift
@@ -535,7 +535,11 @@ struct ACPMessageList: View {
         // match the legacy observer exactly.
         let currentEventType = NSApp.currentEvent?.type
         let isUserDriven = ACPUserScrollEvent.isUserDriven(currentEventType)
-        let isHeadPaginationDriven = ACPUserScrollEvent.isHeadPaginationDriven(currentEventType)
+        let isHeadPaginationDriven = ACPUserScrollEvent.isHeadPaginationDriven(
+            currentEventType,
+            previousMinY: previousMinY,
+            newMinY: newMinY
+        )
         let decision = ACPScrollDirectionClassifier.decide(
             previousOffsetY: previousMinY,
             newOffsetY: newMinY,
@@ -918,13 +922,19 @@ enum ACPUserScrollEvent {
         }
     }
 
-    static func isHeadPaginationDriven(_ type: NSEvent.EventType?) -> Bool {
+    static func isHeadPaginationDriven(
+        _ type: NSEvent.EventType?,
+        previousMinY: CGFloat? = nil,
+        newMinY: CGFloat? = nil
+    ) -> Bool {
         guard let type else { return false }
         if isUserDriven(type) { return true }
         // Track-click paging arrives as a plain mouse-down. Keep that out of
-        // tail-follow pause detection, but allow it to reveal older rows once
-        // geometry confirms the viewport is already near the transcript head.
-        return type == .leftMouseDown
+        // tail-follow pause detection, and require actual upward geometry
+        // movement so top-row control clicks that only change content height do
+        // not reveal older rows.
+        guard type == .leftMouseDown, let previousMinY, let newMinY else { return false }
+        return newMinY < previousMinY - ACPScrollDirectionClassifier.upwardEpsilon
     }
 }
 

--- a/Alas/Sources/ACP/UI/ACPMessageList.swift
+++ b/Alas/Sources/ACP/UI/ACPMessageList.swift
@@ -538,7 +538,8 @@ struct ACPMessageList: View {
         let isHeadPaginationDriven = ACPUserScrollEvent.isHeadPaginationDriven(
             currentEventType,
             previousMinY: previousMinY,
-            newMinY: newMinY
+            newMinY: newMinY,
+            isScrollbarTrackHit: ACPUserScrollEvent.isScrollbarTrackMouseDown(NSApp.currentEvent)
         )
         let decision = ACPScrollDirectionClassifier.decide(
             previousOffsetY: previousMinY,
@@ -925,16 +926,39 @@ enum ACPUserScrollEvent {
     static func isHeadPaginationDriven(
         _ type: NSEvent.EventType?,
         previousMinY: CGFloat? = nil,
-        newMinY: CGFloat? = nil
+        newMinY: CGFloat? = nil,
+        isScrollbarTrackHit: Bool = false
     ) -> Bool {
         guard let type else { return false }
         if isUserDriven(type) { return true }
         // Track-click paging arrives as a plain mouse-down. Keep that out of
-        // tail-follow pause detection, and require actual upward geometry
-        // movement so top-row control clicks that only change content height do
-        // not reveal older rows.
-        guard type == .leftMouseDown, let previousMinY, let newMinY else { return false }
+        // tail-follow pause detection, and require both scrollbar provenance
+        // and actual upward geometry movement so tab/content clicks cannot
+        // reveal older rows during restore or layout.
+        guard type == .leftMouseDown, isScrollbarTrackHit, let previousMinY, let newMinY else {
+            return false
+        }
         return newMinY < previousMinY - ACPScrollDirectionClassifier.upwardEpsilon
+    }
+
+    static func isScrollbarTrackMouseDown(_ event: NSEvent?) -> Bool {
+        guard let event, event.type == .leftMouseDown, let contentView = event.window?.contentView else {
+            return false
+        }
+        return isScrollbarView(contentView.hitTest(event.locationInWindow))
+    }
+
+    private static func isScrollbarView(_ view: NSView?) -> Bool {
+        var current = view
+        while let view = current {
+            if view is NSScroller { return true }
+            let className = NSStringFromClass(type(of: view)).lowercased()
+            if className.contains("scroller") || className.contains("scrollbar") {
+                return true
+            }
+            current = view.superview
+        }
+        return false
     }
 }
 

--- a/Alas/Sources/ACP/UI/ACPMessageList.swift
+++ b/Alas/Sources/ACP/UI/ACPMessageList.swift
@@ -533,7 +533,9 @@ struct ACPMessageList: View {
     ) {
         // Tail-follow pause/resume — reuse the shared classifier so the rules
         // match the legacy observer exactly.
-        let isUserDriven = ACPUserScrollEvent.isUserDriven(NSApp.currentEvent?.type)
+        let currentEventType = NSApp.currentEvent?.type
+        let isUserDriven = ACPUserScrollEvent.isUserDriven(currentEventType)
+        let isHeadPaginationDriven = ACPUserScrollEvent.isHeadPaginationDriven(currentEventType)
         let decision = ACPScrollDirectionClassifier.decide(
             previousOffsetY: previousMinY,
             newOffsetY: newMinY,
@@ -564,7 +566,7 @@ struct ACPMessageList: View {
         guard Self.shouldStepHeadBackFromGeometry(
             visibleHead: transcript.visibleHead,
             isRestoring: isRestoringTail,
-            isUserDriven: isUserDriven,
+            isHeadPaginationDriven: isHeadPaginationDriven,
             newMinY: newMinY,
             threshold: headStepScrollThreshold
         ) else { return }
@@ -577,13 +579,13 @@ struct ACPMessageList: View {
     nonisolated static func shouldStepHeadBackFromGeometry(
         visibleHead: Int,
         isRestoring: Bool,
-        isUserDriven: Bool,
+        isHeadPaginationDriven: Bool,
         newMinY: CGFloat,
         threshold: CGFloat
     ) -> Bool {
         guard visibleHead > 0 else { return false }
         guard !isRestoring else { return false }
-        guard isUserDriven else { return false }
+        guard isHeadPaginationDriven else { return false }
         guard newMinY < threshold else { return false }
         return true
     }
@@ -914,6 +916,15 @@ enum ACPUserScrollEvent {
         default:
             return false
         }
+    }
+
+    static func isHeadPaginationDriven(_ type: NSEvent.EventType?) -> Bool {
+        guard let type else { return false }
+        if isUserDriven(type) { return true }
+        // Track-click paging arrives as a plain mouse-down. Keep that out of
+        // tail-follow pause detection, but allow it to reveal older rows once
+        // geometry confirms the viewport is already near the transcript head.
+        return type == .leftMouseDown
     }
 }
 

--- a/Alas/Sources/ACP/UI/ACPMessageList.swift
+++ b/Alas/Sources/ACP/UI/ACPMessageList.swift
@@ -533,13 +533,14 @@ struct ACPMessageList: View {
     ) {
         // Tail-follow pause/resume — reuse the shared classifier so the rules
         // match the legacy observer exactly.
+        let isUserDriven = ACPUserScrollEvent.isUserDriven(NSApp.currentEvent?.type)
         let decision = ACPScrollDirectionClassifier.decide(
             previousOffsetY: previousMinY,
             newOffsetY: newMinY,
             viewportHeight: viewportHeight,
             contentHeight: contentHeight,
             isRestoring: isRestoringTail,
-            isUserDriven: ACPUserScrollEvent.isUserDriven(NSApp.currentEvent?.type)
+            isUserDriven: isUserDriven
         )
         switch decision {
         case .userScrolledUp: setFollowsTranscriptTail(false)
@@ -556,15 +557,35 @@ struct ACPMessageList: View {
             scrollToTail(proxy: proxy, animated: false)
             return
         }
-        // Head-step pagination: reveal an older chunk as the viewport nears the
-        // top of the content. When restored to the tail, `newMinY` is large, so
-        // the threshold check alone keeps this from firing prematurely.
-        guard transcript.visibleHead > 0, !isRestoringTail else { return }
-        guard newMinY < headStepScrollThreshold else { return }
+        // Head-step pagination: reveal older messages only while a live scroll
+        // gesture is driving the viewport near the top. Initial post-restore
+        // geometry can briefly report top-like offsets before tail restoration
+        // settles; geometry alone must not page the transcript upward.
+        guard Self.shouldStepHeadBackFromGeometry(
+            visibleHead: transcript.visibleHead,
+            isRestoring: isRestoringTail,
+            isUserDriven: isUserDriven,
+            newMinY: newMinY,
+            threshold: headStepScrollThreshold
+        ) else { return }
         let now = Date()
         guard now.timeIntervalSince(lastHeadStepAt) > headStepDebounceInterval else { return }
         lastHeadStepAt = now
         stepHeadBackPreservingScroll(proxy: proxy)
+    }
+
+    nonisolated static func shouldStepHeadBackFromGeometry(
+        visibleHead: Int,
+        isRestoring: Bool,
+        isUserDriven: Bool,
+        newMinY: CGFloat,
+        threshold: CGFloat
+    ) -> Bool {
+        guard visibleHead > 0 else { return false }
+        guard !isRestoring else { return false }
+        guard isUserDriven else { return false }
+        guard newMinY < threshold else { return false }
+        return true
     }
 
     /// Reveal an older chunk while keeping the viewport anchored to the same

--- a/AlasTests/ACPScrollDirectionClassifierTests.swift
+++ b/AlasTests/ACPScrollDirectionClassifierTests.swift
@@ -7,7 +7,7 @@ struct ACPScrollDirectionClassifierTests {
         #expect(!ACPMessageList.shouldStepHeadBackFromGeometry(
             visibleHead: 70,
             isRestoring: true,
-            isUserDriven: false,
+            isHeadPaginationDriven: false,
             newMinY: 0,
             threshold: 200
         ))
@@ -17,7 +17,7 @@ struct ACPScrollDirectionClassifierTests {
         #expect(!ACPMessageList.shouldStepHeadBackFromGeometry(
             visibleHead: 70,
             isRestoring: false,
-            isUserDriven: false,
+            isHeadPaginationDriven: false,
             newMinY: 0,
             threshold: 200
         ))
@@ -27,7 +27,7 @@ struct ACPScrollDirectionClassifierTests {
         #expect(ACPMessageList.shouldStepHeadBackFromGeometry(
             visibleHead: 70,
             isRestoring: false,
-            isUserDriven: true,
+            isHeadPaginationDriven: true,
             newMinY: 0,
             threshold: 200
         ))

--- a/AlasTests/ACPScrollDirectionClassifierTests.swift
+++ b/AlasTests/ACPScrollDirectionClassifierTests.swift
@@ -3,6 +3,36 @@ import CoreGraphics
 @testable import Alas
 
 struct ACPScrollDirectionClassifierTests {
+    @Test func initialTailRestoreSuppressesHeadPagination() {
+        #expect(!ACPMessageList.shouldStepHeadBackFromGeometry(
+            visibleHead: 70,
+            isRestoring: true,
+            isUserDriven: false,
+            newMinY: 0,
+            threshold: 200
+        ))
+    }
+
+    @Test func delayedInitialGeometryDoesNotStepHeadBackAfterRestore() {
+        #expect(!ACPMessageList.shouldStepHeadBackFromGeometry(
+            visibleHead: 70,
+            isRestoring: false,
+            isUserDriven: false,
+            newMinY: 0,
+            threshold: 200
+        ))
+    }
+
+    @Test func userDrivenTopGeometryAllowsLaterHeadPagination() {
+        #expect(ACPMessageList.shouldStepHeadBackFromGeometry(
+            visibleHead: 70,
+            isRestoring: false,
+            isUserDriven: true,
+            newMinY: 0,
+            threshold: 200
+        ))
+    }
+
     @Test func firstSampleReportsNoChange() {
         let decision = ACPScrollDirectionClassifier.decide(
             previousOffsetY: nil,

--- a/AlasTests/ACPUserScrollEventTests.swift
+++ b/AlasTests/ACPUserScrollEventTests.swift
@@ -29,7 +29,8 @@ struct ACPUserScrollEventTests {
         #expect(ACPUserScrollEvent.isHeadPaginationDriven(
             .leftMouseDown,
             previousMinY: 240,
-            newMinY: 40
+            newMinY: 40,
+            isScrollbarTrackHit: true
         ))
     }
 
@@ -37,12 +38,23 @@ struct ACPUserScrollEventTests {
         #expect(!ACPUserScrollEvent.isHeadPaginationDriven(
             .leftMouseDown,
             previousMinY: 40,
-            newMinY: 40
+            newMinY: 40,
+            isScrollbarTrackHit: true
         ))
         #expect(!ACPUserScrollEvent.isHeadPaginationDriven(
             .leftMouseDown,
             previousMinY: 40,
-            newMinY: 240
+            newMinY: 240,
+            isScrollbarTrackHit: true
+        ))
+    }
+
+    @Test func plainMouseDownAwayFromScrollbarDoesNotDriveHeadPagination() {
+        #expect(!ACPUserScrollEvent.isHeadPaginationDriven(
+            .leftMouseDown,
+            previousMinY: 240,
+            newMinY: 40,
+            isScrollbarTrackHit: false
         ))
     }
 

--- a/AlasTests/ACPUserScrollEventTests.swift
+++ b/AlasTests/ACPUserScrollEventTests.swift
@@ -20,10 +20,13 @@ struct ACPUserScrollEventTests {
         // from clicking a transcript control (expanding/collapsing a card, the
         // copy button) by event type alone. If such a click coincides with a
         // streaming/layout reflow that shifts the clip view upward, treating it
-        // as a scroll would re-latch the false pause this change prevents. Only
-        // the knob drag (leftMouseDragged) counts; track-click paging is a rare
-        // interaction not worth that regression.
+        // as a tail-follow pause would re-latch the false pause this change
+        // prevents. Only the knob drag (leftMouseDragged) counts for that path.
         #expect(!ACPUserScrollEvent.isUserDriven(.leftMouseDown))
+    }
+
+    @Test func trackClickCanDriveHeadPagination() {
+        #expect(ACPUserScrollEvent.isHeadPaginationDriven(.leftMouseDown))
     }
 
     @Test func keyboardIsNotTreatedAsScroll() {
@@ -31,11 +34,15 @@ struct ACPUserScrollEventTests {
         // and currentEvent is app-wide, so keyDown would misattribute composer
         // typing during streaming. It must not count as a user scroll.
         #expect(!ACPUserScrollEvent.isUserDriven(.keyDown))
+        #expect(!ACPUserScrollEvent.isHeadPaginationDriven(.keyDown))
     }
 
     @Test func incidentalEventsAreNotUserDriven() {
         #expect(!ACPUserScrollEvent.isUserDriven(.mouseMoved))
         #expect(!ACPUserScrollEvent.isUserDriven(.leftMouseUp))
         #expect(!ACPUserScrollEvent.isUserDriven(nil))
+        #expect(!ACPUserScrollEvent.isHeadPaginationDriven(.mouseMoved))
+        #expect(!ACPUserScrollEvent.isHeadPaginationDriven(.leftMouseUp))
+        #expect(!ACPUserScrollEvent.isHeadPaginationDriven(nil))
     }
 }

--- a/AlasTests/ACPUserScrollEventTests.swift
+++ b/AlasTests/ACPUserScrollEventTests.swift
@@ -26,7 +26,24 @@ struct ACPUserScrollEventTests {
     }
 
     @Test func trackClickCanDriveHeadPagination() {
-        #expect(ACPUserScrollEvent.isHeadPaginationDriven(.leftMouseDown))
+        #expect(ACPUserScrollEvent.isHeadPaginationDriven(
+            .leftMouseDown,
+            previousMinY: 240,
+            newMinY: 40
+        ))
+    }
+
+    @Test func plainMouseDownWithoutUpwardMovementDoesNotDriveHeadPagination() {
+        #expect(!ACPUserScrollEvent.isHeadPaginationDriven(
+            .leftMouseDown,
+            previousMinY: 40,
+            newMinY: 40
+        ))
+        #expect(!ACPUserScrollEvent.isHeadPaginationDriven(
+            .leftMouseDown,
+            previousMinY: 40,
+            newMinY: 240
+        ))
     }
 
     @Test func keyboardIsNotTreatedAsScroll() {


### PR DESCRIPTION
## Summary
- gate ACP head-step pagination on a live user scroll event so post-restore geometry cannot page the transcript upward
- add regression coverage for immediate restore, delayed non-user geometry after restore, and later user-driven top pagination
- regenerate the Xcode project after `xcodegen`

## Verification
- `xcodegen`
- `xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -quiet build`
- `xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' test -only-testing:AlasTests/ACPScrollDirectionClassifierTests`

## Notes
- A local full `xcodebuild ... test` run was attempted, but it hung again in the pre-existing `ACP terminal routing` area and was interrupted after confirming the test-host process was stuck there. CI should be the full-suite arbiter for this PR.