### PR TITLE
feat(commit): use DiffReviewSurface in draft commit tab

### DIFF
--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -144,6 +144,7 @@
 		238BBB5FC59949CE6ABAFBEF /* ACPCodeBlockHighlighterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 81773A01826A91080F5A2E95 /* ACPCodeBlockHighlighterTests.swift */; };
 		23F92214B30096D070419921 /* ACPQueuedBubbleActionMetricsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5733BF1C52BA0FCFB2724D57 /* ACPQueuedBubbleActionMetricsTests.swift */; };
 		2434A66A45EDF2609BA9F1D3 /* session-update-config-options.json in Resources */ = {isa = PBXBuildFile; fileRef = 97DA8F50DDCDAA15CCEA2004 /* session-update-config-options.json */; };
+		249E943D5C46A84496390B31 /* StagedDiffSelectionBridgingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B3DCDC9F76F91CE1071471C /* StagedDiffSelectionBridgingTests.swift */; };
 		24F8EA15B87C38C319B8A66B /* AlasField.swift in Sources */ = {isa = PBXBuildFile; fileRef = D9E6D61B213F3378243B4A26 /* AlasField.swift */; };
 		250F0E2CB26CC16D2FFDB9DD /* DiffSelectableTextView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 23FECFF5D8673A3A8E7A1431 /* DiffSelectableTextView.swift */; };
 		25311FAD068B5590F459CED9 /* ACPChatLayout.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6D8E02BB3FEB3C71AEEBBE6F /* ACPChatLayout.swift */; };
@@ -330,6 +331,7 @@
 		4EC9752B397FD7FA89459AC1 /* MergeConflictColumnView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8CAB78A2ED0F4B736B089701 /* MergeConflictColumnView.swift */; };
 		4ECFD27396367A9A81D52A0D /* WorktreeRowView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C995611A6313FABE30508248 /* WorktreeRowView.swift */; };
 		4F2BB7482C39B07F5E35E9D1 /* RemoteMessageWireJSON.swift in Sources */ = {isa = PBXBuildFile; fileRef = EBD68C6A69930BE0F9437AAE /* RemoteMessageWireJSON.swift */; };
+		4FD9E5FFB4C75850CF7B2FE7 /* StagedDiffLoaderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 99CD99C81057F377C5E249B7 /* StagedDiffLoaderTests.swift */; };
 		4FE322C88A2B06C317DDA9B5 /* ReviewSessionTabView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 64C593F9F14DD962C9822C64 /* ReviewSessionTabView.swift */; };
 		5026424BC4EA8196D12E6F46 /* BuildIdentityTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0EE31A4EB90FFE45DC46420 /* BuildIdentityTests.swift */; };
 		502B274A6E7E801B76B8564A /* ACPScrollDirectionClassifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7DE5F609BDA1D7CE2DF4A491 /* ACPScrollDirectionClassifier.swift */; };
@@ -523,6 +525,7 @@
 		82544FFCF9960E0BA0FD2C7F /* ProcessMemoryProbeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9830BAAE86AA0A20A77731D /* ProcessMemoryProbeTests.swift */; };
 		82D3560952F0B800F56377D7 /* AgentHookInstallNudgeBanner.swift in Sources */ = {isa = PBXBuildFile; fileRef = 18CA47D5E0D1BF962CF45ABE /* AgentHookInstallNudgeBanner.swift */; };
 		82E9F713C1BFF433E540314C /* AgentLogoView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6F6E707551671670D8CBA38 /* AgentLogoView.swift */; };
+		82F5A171BDDFE0A5E0BD587A /* DiffReviewStagedMutationActionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E0F10B6B1311831E53DA45C0 /* DiffReviewStagedMutationActionsTests.swift */; };
 		8312A5067AD6E0143FA83023 /* JSONRPCStdioTransport.swift in Sources */ = {isa = PBXBuildFile; fileRef = 65A1EB96EBED0DEDCA5CD094 /* JSONRPCStdioTransport.swift */; };
 		832BDA6FD48E68F76E46D786 /* ACPSessionQueueAPITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0B057D23BD5B72E06E790C5B /* ACPSessionQueueAPITests.swift */; };
 		8352A6C0D7AE371907E50217 /* TreeSitterPython in Frameworks */ = {isa = PBXBuildFile; productRef = 7D55FFC5D9F65DAD0178FB0E /* TreeSitterPython */; };
@@ -651,6 +654,7 @@
 		A03338AC85E6EC8201D56F95 /* TreeSitterGo in Frameworks */ = {isa = PBXBuildFile; productRef = DB0D87DDDAD70492540E6906 /* TreeSitterGo */; };
 		A050BAECF89694B0D613C5D2 /* EditorBuffer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 64E96E26D5F53F217BFD1F49 /* EditorBuffer.swift */; };
 		A05391FF4907AB0870A79C02 /* ReviewEvidenceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4B05E0E44B026AE7E8EA3101 /* ReviewEvidenceTests.swift */; };
+		A06C59805BCD9D3200896932 /* StagedDiffLoader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3B2FEDAAF927CDC9E4D19551 /* StagedDiffLoader.swift */; };
 		A0B5074B10E732616C917D10 /* DragHandleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1379AD82025AFEABD37EFC42 /* DragHandleTests.swift */; };
 		A0F1E46BC1A9E2CC21805EE7 /* FilesTabFilterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1977C85C3DFD1F232A2755AD /* FilesTabFilterTests.swift */; };
 		A1252F6D967104D2B369CEA8 /* ReviewFeedbackBundleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C84E444E25F7DDBE30FB824 /* ReviewFeedbackBundleTests.swift */; };
@@ -1313,6 +1317,7 @@
 		3A110966FCF7EA47C18BE71A /* ACPAgentProfilesTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPAgentProfilesTests.swift; sourceTree = "<group>"; };
 		3A8A5932B664C88F20BF00CA /* AppStateCreateWorktreeLaunchSurfaceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppStateCreateWorktreeLaunchSurfaceTests.swift; sourceTree = "<group>"; };
 		3ABD3A575FAEC381A5744BFA /* FileTreeBuilderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileTreeBuilderTests.swift; sourceTree = "<group>"; };
+		3B2FEDAAF927CDC9E4D19551 /* StagedDiffLoader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StagedDiffLoader.swift; sourceTree = "<group>"; };
 		3B7BE659F7E386D15047C374 /* WorktreeCreateFetchTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorktreeCreateFetchTests.swift; sourceTree = "<group>"; };
 		3BE23A4881B60D7F16A4ACA5 /* GhosttyConfigBuilderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GhosttyConfigBuilderTests.swift; sourceTree = "<group>"; };
 		3BF2F213480B30034B25B2B8 /* AgentRunError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentRunError.swift; sourceTree = "<group>"; };
@@ -1674,11 +1679,13 @@
 		987FAB1E4DB4B81D5D0902B1 /* AppConfigMarkdownTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppConfigMarkdownTests.swift; sourceTree = "<group>"; };
 		98A00D845A8B82E27B7D2352 /* SidebarVisibilityTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SidebarVisibilityTests.swift; sourceTree = "<group>"; };
 		98A7F35818C95A567DDA586A /* ACPSelectChipTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPSelectChipTests.swift; sourceTree = "<group>"; };
+		99CD99C81057F377C5E249B7 /* StagedDiffLoaderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StagedDiffLoaderTests.swift; sourceTree = "<group>"; };
 		9A06D96DE3FEBF63E7A157DD /* HunkPatchBuilder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HunkPatchBuilder.swift; sourceTree = "<group>"; };
 		9A187BD52742E8F4A6E52667 /* tool-call-content-diff.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "tool-call-content-diff.json"; sourceTree = "<group>"; };
 		9A2292E8F8E3D91440BE88FC /* ACPSessionTerminalRoutingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPSessionTerminalRoutingTests.swift; sourceTree = "<group>"; };
 		9A40BDC5115B641AB26220D9 /* ZmxSunPathBudget.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ZmxSunPathBudget.swift; sourceTree = "<group>"; };
 		9B15F58AFF7BC19419935C05 /* PendingDiscard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PendingDiscard.swift; sourceTree = "<group>"; };
+		9B3DCDC9F76F91CE1071471C /* StagedDiffSelectionBridgingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StagedDiffSelectionBridgingTests.swift; sourceTree = "<group>"; };
 		9C165BAAF80F9B4A5949BD39 /* RightPaneTransitionalView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RightPaneTransitionalView.swift; sourceTree = "<group>"; };
 		9C45A26ADB0D1CCFBB5BEAE8 /* TerminalSession.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TerminalSession.swift; sourceTree = "<group>"; };
 		9CA420C011D4235E47A3FB1B /* RepoSelectorRecents.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RepoSelectorRecents.swift; sourceTree = "<group>"; };
@@ -1961,6 +1968,7 @@
 		E0CD4F3AC6DD83BC45459475 /* CompletionEngineTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CompletionEngineTests.swift; sourceTree = "<group>"; };
 		E0E1BF90CB3BE5BFDFA2EC7C /* ACPSessionStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPSessionStore.swift; sourceTree = "<group>"; };
 		E0E5107A10052A150DD8DE02 /* ZmxSunPathBudgetTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ZmxSunPathBudgetTests.swift; sourceTree = "<group>"; };
+		E0F10B6B1311831E53DA45C0 /* DiffReviewStagedMutationActionsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiffReviewStagedMutationActionsTests.swift; sourceTree = "<group>"; };
 		E15A32659EEBFA80F816CE31 /* SymbolsFeatureTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SymbolsFeatureTests.swift; sourceTree = "<group>"; };
 		E16C4F54FB3E390F80208DA1 /* AdvancedPane.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AdvancedPane.swift; sourceTree = "<group>"; };
 		E1703FC5CD7DF16F4450E274 /* DiffParser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiffParser.swift; sourceTree = "<group>"; };
@@ -2335,6 +2343,7 @@
 				EE26221DC8E8837FFEB87474 /* DiffParserTests.swift */,
 				A172B476A5BF7E4016431E6A /* DiffReviewModelsTests.swift */,
 				F649B493D42787FEA6D8E67B /* DiffReviewScrollSpyTests.swift */,
+				E0F10B6B1311831E53DA45C0 /* DiffReviewStagedMutationActionsTests.swift */,
 				312DC027D433B496FD010F85 /* DiffReviewSurfaceTests.swift */,
 				C34ED0F4DB5FB6620993ECFC /* DiffSelectableTextTests.swift */,
 				FB02326DBD7A82431A33C50F /* DraftAmendPrefillTests.swift */,
@@ -2479,6 +2488,8 @@
 				28777B087266D8AE174BA233 /* SpaceEmojiPickerSelectionTests.swift */,
 				E7D9230E4E0DD70D689F40DD /* SpacePagerIndicatorTests.swift */,
 				CEA8BA11A167DA43E22E7D2D /* SpacesManagerTests.swift */,
+				99CD99C81057F377C5E249B7 /* StagedDiffLoaderTests.swift */,
+				9B3DCDC9F76F91CE1071471C /* StagedDiffSelectionBridgingTests.swift */,
 				43DF691FC778F3A71CE20FBB /* StartupScriptInstallerTests.swift */,
 				9D3C76F2F0F6BCE4023A9D7F /* StartupScriptResolverTests.swift */,
 				DBA6A9F78C8E8CDF6D170BDD /* StatusParserTests.swift */,
@@ -3826,6 +3837,7 @@
 				59DBB72EE97F0E906442919B /* CommitTabView.swift */,
 				71F9CE2A0C76E75E95A641AE /* DraftAmendPrefill.swift */,
 				BC3CA543A17D1C3DFA70A80C /* DraftCommitTabView.swift */,
+				3B2FEDAAF927CDC9E4D19551 /* StagedDiffLoader.swift */,
 			);
 			path = Commit;
 			sourceTree = "<group>";
@@ -4701,6 +4713,7 @@
 				7D0897F6872ABAC08F09281E /* SpacesPane.swift in Sources */,
 				25CD620AE7FFA7DE82937F7E /* Spinner.swift in Sources */,
 				6256EAEB315812ED4F4E9107 /* StageChip.swift in Sources */,
+				A06C59805BCD9D3200896932 /* StagedDiffLoader.swift in Sources */,
 				514C75877C1C3B1D19BB5BD5 /* StartupScriptInstaller.swift in Sources */,
 				899E7B2794DD3F2114B38AFC /* StartupScriptResolver.swift in Sources */,
 				EDC5F3C0F2964AC78C832F87 /* StatusParser.swift in Sources */,
@@ -4954,6 +4967,7 @@
 				0CF488290CC525EA7C11A43C /* DiffParserTests.swift in Sources */,
 				59AF95D3DFDFE7736051EF4A /* DiffReviewModelsTests.swift in Sources */,
 				14D70126BAF735B2A66A23C5 /* DiffReviewScrollSpyTests.swift in Sources */,
+				82F5A171BDDFE0A5E0BD587A /* DiffReviewStagedMutationActionsTests.swift in Sources */,
 				8FFF1CF8720587ADC3FFA688 /* DiffReviewSurfaceTests.swift in Sources */,
 				10F83C7DA89B3BF168E47310 /* DiffSelectableTextTests.swift in Sources */,
 				5936DF2636F0B74BEAB33A57 /* DraftAmendPrefillTests.swift in Sources */,
@@ -5144,6 +5158,8 @@
 				FE5846F4401C702264817399 /* SpaceEmojiPickerSelectionTests.swift in Sources */,
 				E4FA8142AB5FF2AA63BF6DA1 /* SpacePagerIndicatorTests.swift in Sources */,
 				D87EC73A848929FFB819888C /* SpacesManagerTests.swift in Sources */,
+				4FD9E5FFB4C75850CF7B2FE7 /* StagedDiffLoaderTests.swift in Sources */,
+				249E943D5C46A84496390B31 /* StagedDiffSelectionBridgingTests.swift in Sources */,
 				DC0989E32F4B7BF023F784D6 /* StartupScriptInstallerTests.swift in Sources */,
 				771CD72B94194370E783F7DD /* StartupScriptResolverTests.swift in Sources */,
 				FE1517EC14DCB1C29528C865 /* StatusParserTests.swift in Sources */,

--- a/Alas/Sources/Center/Commit/DraftCommitTabView.swift
+++ b/Alas/Sources/Center/Commit/DraftCommitTabView.swift
@@ -77,7 +77,7 @@ struct DraftCommitTabView: View {
                     unstageHunk(path: model.summary.path, hunk: hunk)
                 },
                 isHunkUnstageEnabled: { hunk in
-                    !busy && model.summary.status == .modified && !hunk.lines.isEmpty
+                    !busy && model.summary.gitStatus == "M" && !hunk.lines.isEmpty
                 }
             )
             return m

--- a/Alas/Sources/Center/Commit/DraftCommitTabView.swift
+++ b/Alas/Sources/Center/Commit/DraftCommitTabView.swift
@@ -162,6 +162,11 @@ struct DraftCommitTabView: View {
                 showsRailDisplayControls: true,
                 allowsDraftCommentCreation: false
             )
+        } else if error != nil, hasStaged {
+            Text("Staged changes could not be loaded.")
+                .multilineTextAlignment(.center)
+                .foregroundColor(theme.color("fg-dim"))
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
         } else {
             Text("No staged changes yet.\nStage files from the sidebar to start a commit.")
                 .multilineTextAlignment(.center)

--- a/Alas/Sources/Center/Commit/DraftCommitTabView.swift
+++ b/Alas/Sources/Center/Commit/DraftCommitTabView.swift
@@ -9,16 +9,8 @@ struct DraftCommitTabView: View {
     @State private var subject: String = ""
     @State private var bodyText: String = ""
     @State private var amend: Bool = false
-    @State private var selectedPath: String?
-    @State private var stagedFiles: [CommitChangedFile] = []
-    @State private var diff: ParsedDiff = ParsedDiff(hunks: [])
-    @State private var displayModel: DiffDisplayModel?
-    @State private var displayModelKey: String?
     @State private var busy = false
     @State private var error: String?
-    @State private var loadingFiles = false
-    @State private var loadingDiff = false
-    @State private var activeDiffKey: String?
     @State private var amendPrefilled: Bool = false
     @State private var amendPrefilledSubject: String = ""
     @State private var amendPrefilledBody: String = ""
@@ -26,10 +18,14 @@ struct DraftCommitTabView: View {
     @State private var canAmend: Bool = true
     @State private var generation: Task<Void, Never>? = nil
 
+    @State private var stagedSession: DiffReviewLoadedSession?
+    @State private var selectedFileID: DiffReviewFileID?
+    @State private var loadingSession = false
+    @State private var railCollapsed = false
+
     @Environment(\.theme) private var theme
     private let git = GitService()
 
-    private static let minPaneWidth: CGFloat = 140
     private var diffPreferences: DiffPreferenceBindings {
         DiffPreferenceBindings(appState: appState)
     }
@@ -38,7 +34,7 @@ struct DraftCommitTabView: View {
         subject.trimmingCharacters(in: .whitespacesAndNewlines)
     }
 
-    private var hasStaged: Bool { !stagedFiles.isEmpty }
+    private var hasStaged: Bool { (stagedSession?.summary.fileCount ?? 0) > 0 }
     private var canCommit: Bool { hasStaged && !trimmedSubject.isEmpty && !busy }
 
     /// A key that changes whenever the staged set changes in the sidebar.
@@ -56,14 +52,34 @@ struct DraftCommitTabView: View {
         return "\(rps.changes.count):\(staged):\(rps.indexFingerprint)"
     }
 
-    private var diffKey: String { "\(stagedKey):\(selectedPath ?? "")" }
-
     /// Drives `refreshCanAmend()` re-firing when HEAD changes (e.g. an
     /// external commit on an unborn branch should enable Amend without
     /// needing a tab reopen). The value itself doesn't matter, only that
     /// it shifts when HEAD does.
     private var amendProbeKey: String {
         appState.rightPaneStore.activeState(worktreeId: worktreeId)?.currentHeadSHA ?? ""
+    }
+
+    // Computed property that overlays mutation actions onto the loaded session.
+    // Reads `busy` fresh on each render so closures always see current value.
+    private var sessionWithActions: DiffReviewLoadedSession? {
+        guard let session = stagedSession else { return nil }
+        let filesWithActions = session.files.map { model in
+            var m = model
+            m.stagedMutationActions = DiffReviewStagedMutationActions(
+                unstageFile: {
+                    unstageFileByPaths(path: model.summary.path, originalPath: model.summary.originalPath)
+                },
+                unstageHunk: { hunk in
+                    unstageHunk(path: model.summary.path, hunk: hunk)
+                },
+                isHunkUnstageEnabled: { hunk in
+                    !busy && model.summary.status == .modified && !hunk.lines.isEmpty
+                }
+            )
+            return m
+        }
+        return DiffReviewLoadedSession(files: filesWithActions, summary: session.summary)
     }
 
     var body: some View {
@@ -102,7 +118,7 @@ struct DraftCommitTabView: View {
                     .padding(.top, 4)
                     .frame(maxWidth: .infinity, alignment: .leading)
             }
-            splitBody
+            stagedDiffBody
         }
         .onAppear { hydrateFromTabState() }
         // Re-probe HEAD existence whenever the right-pane state observes a
@@ -119,59 +135,34 @@ struct DraftCommitTabView: View {
                 clearAmendPrefillIfUnchanged()
             }
         }
-        .onChange(of: selectedPath) { _, new in persist(selectedPath: new) }
-        .task(id: stagedKey) { await loadStaged() }
-        .task(id: diffKey) { await loadDiff() }
+        .onChange(of: selectedFileID) { _, new in persist(selectedPath: new?.path) }
+        .task(id: stagedKey) { await loadStagedSession() }
     }
 
     @ViewBuilder
-    private var splitBody: some View {
-        GeometryReader { proxy in
-            let total = proxy.size.width
-            let ratio = max(0.15, min(0.7, appState.config.commitDetailSplitRatio))
-            let leftWidth = max(Self.minPaneWidth, total * ratio)
-            HStack(spacing: 0) {
-                CommitFilesListView(
-                    files: stagedFiles,
-                    selectedPath: $selectedPath,
-                    onDropFile: { file in unstageFile(file) },
-                    dropFileEnabled: { _ in !busy }
-                )
-                .frame(width: leftWidth)
-                DragHandle(axis: .horizontal, onDrag: { delta in
-                    guard total > 0 else { return }
-                    let newWidth = max(Self.minPaneWidth, min(total - Self.minPaneWidth, leftWidth + delta))
-                    appState.config.commitDetailSplitRatio = newWidth / total
-                    appState.saveConfig()
-                })
-                if hasStaged, let path = selectedPath,
-                   let file = stagedFiles.first(where: { $0.path == path }) {
-                    let selectedDisplayModel = displayModelKey == diffKey ? displayModel : nil
-                    CommitDiffView(
-                        worktreePath: worktreePath,
-                        sha: "INDEX",
-                        file: file,
-                        path: path,
-                        diff: diff,
-                        displayModel: selectedDisplayModel,
-                        loading: loadingDiff,
-                        error: nil,
-                        codeFontFamily: appState.config.code.fontFamily,
-                        codeFontSize: CGFloat(appState.config.code.fontSize),
-                        layoutMode: diffPreferences.layoutMode,
-                        wrapLines: diffPreferences.wrapLines,
-                        showWhitespace: diffPreferences.showWhitespace,
-                        onOpenFile: nil,
-                        onDropHunk: { hunk in unstageHunk(path: path, hunk: hunk) },
-                        dropHunkEnabled: { file, hunk in !busy && file.status == "M" && !hunk.lines.isEmpty }
-                    )
-                } else {
-                    Text(hasStaged ? "Select a file" : "No staged changes yet.\nStage files from the sidebar to start a commit.")
-                        .multilineTextAlignment(.center)
-                        .foregroundColor(theme.color("fg-dim"))
-                        .frame(maxWidth: .infinity, maxHeight: .infinity)
-                }
-            }
+    private var stagedDiffBody: some View {
+        if loadingSession && stagedSession == nil {
+            ProgressView()
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
+        } else if let session = sessionWithActions, !session.files.isEmpty {
+            DiffReviewSurface(
+                session: session,
+                selectedFileID: $selectedFileID,
+                railCollapsed: $railCollapsed,
+                reviewSummaryCollapsed: .constant(false),
+                layoutMode: diffPreferences.layoutMode,
+                wrapLines: diffPreferences.wrapLines,
+                showWhitespace: diffPreferences.showWhitespace,
+                codeFontFamily: appState.config.code.fontFamily,
+                codeFontSize: CGFloat(appState.config.code.fontSize),
+                showsSourceBadges: false,
+                showsRailDisplayControls: true
+            )
+        } else {
+            Text("No staged changes yet.\nStage files from the sidebar to start a commit.")
+                .multilineTextAlignment(.center)
+                .foregroundColor(theme.color("fg-dim"))
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
         }
     }
 
@@ -179,7 +170,7 @@ struct DraftCommitTabView: View {
         subject = tabState.subject
         bodyText = tabState.bodyText
         amend = tabState.amend
-        selectedPath = tabState.selectedPath
+        selectedFileID = tabState.selectedPath.map { DiffReviewFileID(namespace: "staged", path: $0) }
     }
 
     private func persist(subject: String? = nil, body: String? = nil, amend: Bool? = nil, selectedPath: String?? = nil) {
@@ -301,78 +292,53 @@ struct DraftCommitTabView: View {
         }
     }
 
-    private func loadStaged() async {
-        loadingFiles = true
-        defer { loadingFiles = false }
-        do {
-            let files = try await git.stagedChangedFiles(at: worktreePath)
-            guard !Task.isCancelled else { return }
-            stagedFiles = files
-            if let sel = selectedPath, !files.contains(where: { $0.path == sel }) {
-                selectedPath = files.first?.path
-            } else if selectedPath == nil {
-                selectedPath = files.first?.path
-            }
-        } catch {
-            self.error = (error as NSError).localizedDescription
-        }
-    }
-
-    private func loadDiff() async {
-        guard let path = selectedPath,
-              let stagedFile = stagedFiles.first(where: { $0.path == path }) else {
-            diff = ParsedDiff(hunks: [])
-            displayModel = nil
-            displayModelKey = nil
-            activeDiffKey = nil
-            return
-        }
-        let requestedKey = "\(stagedKey):\(path)"
-        activeDiffKey = requestedKey
-        loadingDiff = true
-        displayModel = nil
-        displayModelKey = nil
+    @MainActor
+    private func loadStagedSession() async {
+        let token = stagedKey
+        loadingSession = true
+        error = nil
         defer {
-            if activeDiffKey == requestedKey { loadingDiff = false }
+            if stagedKey == token { loadingSession = false }
         }
         do {
-            let loaded = try await git.diff(
-                worktreePath: worktreePath,
-                file: path,
-                staged: true,
-                originalPath: stagedFile.originalPath
-            )
-            guard !Task.isCancelled, activeDiffKey == requestedKey else { return }
-            let loadedModel = await Task.detached(priority: .userInitiated) {
-                DiffDisplayModelBuilder.build(diff: loaded, filePath: path)
-            }.value
-            guard !Task.isCancelled, activeDiffKey == requestedKey else { return }
-            diff = loaded
-            displayModel = loadedModel
-            displayModelKey = requestedKey
+            let session = try await StagedDiffLoader().load(worktreePath: worktreePath)
+            guard !Task.isCancelled, stagedKey == token else { return }
+            stagedSession = session
+            synchronizeSelection(with: session)
+        } catch is CancellationError {
+            // ignore
         } catch {
-            guard !Task.isCancelled, activeDiffKey == requestedKey else { return }
+            guard stagedKey == token else { return }
             self.error = (error as NSError).localizedDescription
         }
     }
 
-    private func unstageFile(_ file: CommitChangedFile) {
+    private func synchronizeSelection(with session: DiffReviewLoadedSession) {
+        let fileIDs = session.files.map { $0.summary.id }
+        if let sel = selectedFileID, fileIDs.contains(sel) {
+            // keep current selection
+        } else if let first = fileIDs.first {
+            selectedFileID = first
+            persist(selectedPath: first.path)
+        } else {
+            selectedFileID = nil
+            persist(selectedPath: nil)
+        }
+    }
+
+    private func unstageFileByPaths(path: String, originalPath: String?) {
         guard !busy else { return }
         busy = true
         error = nil
         Task { @MainActor in
             defer { busy = false }
             do {
-                // For staged renames git needs both the old and the new
-                // path; passing only `file.path` leaves the old-path
-                // deletion staged. `originalPath` is non-nil for R/C entries.
-                var paths = [file.path]
-                if let original = file.originalPath, !original.isEmpty {
+                var paths = [path]
+                if let original = originalPath, !original.isEmpty {
                     paths.append(original)
                 }
                 try await git.unstage(worktreePath: worktreePath, files: paths)
-                await loadStaged()
-                await loadDiff()
+                await loadStagedSession()
                 await appState.rightPaneStore.refresh(worktreeId: worktreeId)
             } catch {
                 self.error = (error as NSError).localizedDescription
@@ -388,8 +354,7 @@ struct DraftCommitTabView: View {
             defer { busy = false }
             do {
                 try await git.unstageHunk(worktreePath: worktreePath, path: path, hunk: hunk)
-                await loadStaged()
-                await loadDiff()
+                await loadStagedSession()
                 await appState.rightPaneStore.refresh(worktreeId: worktreeId)
             } catch {
                 self.error = (error as NSError).localizedDescription

--- a/Alas/Sources/Center/Commit/DraftCommitTabView.swift
+++ b/Alas/Sources/Center/Commit/DraftCommitTabView.swift
@@ -313,6 +313,7 @@ struct DraftCommitTabView: View {
             // ignore
         } catch {
             guard stagedKey == token else { return }
+            stagedSession = nil
             self.error = (error as NSError).localizedDescription
         }
     }

--- a/Alas/Sources/Center/Commit/DraftCommitTabView.swift
+++ b/Alas/Sources/Center/Commit/DraftCommitTabView.swift
@@ -34,7 +34,10 @@ struct DraftCommitTabView: View {
         subject.trimmingCharacters(in: .whitespacesAndNewlines)
     }
 
-    private var hasStaged: Bool { (stagedSession?.summary.fileCount ?? 0) > 0 }
+    private var hasStaged: Bool {
+        guard let rps = appState.rightPaneStore.activeState(worktreeId: worktreeId) else { return false }
+        return rps.changes.contains { $0.stage == .staged }
+    }
     private var canCommit: Bool { hasStaged && !trimmedSubject.isEmpty && !busy }
 
     /// A key that changes whenever the staged set changes in the sidebar.
@@ -156,7 +159,8 @@ struct DraftCommitTabView: View {
                 codeFontFamily: appState.config.code.fontFamily,
                 codeFontSize: CGFloat(appState.config.code.fontSize),
                 showsSourceBadges: false,
-                showsRailDisplayControls: true
+                showsRailDisplayControls: true,
+                allowsDraftCommentCreation: false
             )
         } else {
             Text("No staged changes yet.\nStage files from the sidebar to start a commit.")

--- a/Alas/Sources/Center/Commit/StagedDiffLoader.swift
+++ b/Alas/Sources/Center/Commit/StagedDiffLoader.swift
@@ -52,7 +52,8 @@ struct StagedDiffLoader {
             additions: counts.additions,
             deletions: counts.deletions,
             isRenderable: canRender,
-            originalPath: file.originalPath
+            originalPath: file.originalPath,
+            gitStatus: file.status
         )
 
         return DiffReviewFileSectionModel(

--- a/Alas/Sources/Center/Commit/StagedDiffLoader.swift
+++ b/Alas/Sources/Center/Commit/StagedDiffLoader.swift
@@ -1,0 +1,103 @@
+import Foundation
+
+protocol StagedDiffGitClient {
+    func stagedChangedFiles(at worktreePath: URL) async throws -> [CommitChangedFile]
+    func diff(worktreePath: URL, file: String, staged: Bool, originalPath: String?) async throws -> ParsedDiff
+}
+
+extension GitService: StagedDiffGitClient {}
+
+struct StagedDiffLoader {
+    let git: StagedDiffGitClient
+
+    init(git: StagedDiffGitClient = GitService()) {
+        self.git = git
+    }
+
+    @MainActor
+    func load(worktreePath: URL) async throws -> DiffReviewLoadedSession {
+        try Task.checkCancellation()
+        let stagedFiles = try await git.stagedChangedFiles(at: worktreePath)
+        try Task.checkCancellation()
+
+        var sections: [DiffReviewFileSectionModel] = []
+        for file in stagedFiles {
+            try Task.checkCancellation()
+            let diff = try await git.diff(
+                worktreePath: worktreePath,
+                file: file.path,
+                staged: true,
+                originalPath: file.originalPath
+            )
+            try Task.checkCancellation()
+
+            sections.append(try await fileSection(for: file, diff: diff))
+        }
+
+        return DiffReviewLoadedSession(
+            files: sections,
+            summary: DiffReviewSessionModel(files: sections.map(\.summary), groupsEnabled: false)
+        )
+    }
+
+    private func fileSection(for file: CommitChangedFile, diff: ParsedDiff) async throws -> DiffReviewFileSectionModel {
+        let canRender = !diff.hunks.isEmpty && !ImageFileType.isSupported(relativePath: file.path)
+        let counts = lineCounts(in: diff)
+        let summary = DiffReviewFileSummary(
+            path: file.path,
+            namespace: "staged",
+            groupID: nil,
+            groupTitle: nil,
+            status: DiffReviewFileStatus(gitStatus: file.status),
+            additions: counts.additions,
+            deletions: counts.deletions,
+            isRenderable: canRender,
+            originalPath: file.originalPath
+        )
+
+        return DiffReviewFileSectionModel(
+            summary: summary,
+            parsedDiff: diff,
+            displayModel: canRender
+                ? try await buildDisplayModel(diff: diff, filePath: file.path)
+                : nil,
+            placeholderMessage: canRender ? nil : placeholderMessage(for: file, diff: diff),
+            openFile: nil,
+            contextProvider: nil
+        )
+    }
+
+    private func buildDisplayModel(diff: ParsedDiff, filePath: String) async throws -> DiffDisplayModel {
+        try Task.checkCancellation()
+        let model = await Task.detached(priority: .userInitiated) {
+            DiffDisplayModelBuilder.build(diff: diff, filePath: filePath)
+        }.value
+        try Task.checkCancellation()
+        return model
+    }
+
+    private func lineCounts(in diff: ParsedDiff) -> (additions: Int, deletions: Int) {
+        diff.hunks.reduce(into: (additions: 0, deletions: 0)) { counts, hunk in
+            for line in hunk.lines {
+                switch line.kind {
+                case .add:
+                    counts.additions += 1
+                case .delete:
+                    counts.deletions += 1
+                case .context:
+                    break
+                }
+            }
+        }
+    }
+
+    private func placeholderMessage(for file: CommitChangedFile, diff: ParsedDiff) -> String {
+        if ImageFileType.isSupported(relativePath: file.path) {
+            return "Image changes are not available in this review view yet."
+        }
+        if diff.hunks.isEmpty {
+            return "No text diff is available for this file."
+        }
+        return "This file cannot be rendered in the review view."
+    }
+}

--- a/Alas/Sources/Center/Diff/DiffPaneTextDocumentView.swift
+++ b/Alas/Sources/Center/Diff/DiffPaneTextDocumentView.swift
@@ -39,6 +39,7 @@ struct DiffPaneTextDocumentView: NSViewRepresentable {
     let codeFontSize: CGFloat
     let theme: Theme
     let lspContext: DiffPaneLSPContext?
+    var allowsReviewLineSelection: Bool = true
     var onReviewLineSelected: (DiffReviewLineAnchor) -> Void = { _ in }
     var onContextExpansion: (DiffContextExpansionKey, DiffContextExpansionMode) -> Void = { _, _ in }
 
@@ -53,6 +54,7 @@ struct DiffPaneTextDocumentView: NSViewRepresentable {
         codeFontSize: CGFloat,
         theme: Theme,
         lspContext: DiffPaneLSPContext?,
+        allowsReviewLineSelection: Bool = true,
         onReviewLineSelected: @escaping (DiffReviewLineAnchor) -> Void = { _ in },
         onContextExpansion: @escaping (DiffContextExpansionKey, DiffContextExpansionMode) -> Void = { _, _ in }
     ) {
@@ -66,6 +68,7 @@ struct DiffPaneTextDocumentView: NSViewRepresentable {
         self.codeFontSize = codeFontSize
         self.theme = theme
         self.lspContext = lspContext
+        self.allowsReviewLineSelection = allowsReviewLineSelection
         self.onReviewLineSelected = onReviewLineSelected
         self.onContextExpansion = onContextExpansion
     }
@@ -85,6 +88,7 @@ struct DiffPaneTextDocumentView: NSViewRepresentable {
             font: CenterTypography.resolveCodeFont(family: codeFontFamily, size: codeFontSize),
             theme: theme,
             lspContext: lspContext,
+            allowsReviewLineSelection: allowsReviewLineSelection,
             onReviewLineSelected: onReviewLineSelected,
             onContextExpansion: onContextExpansion
         )
@@ -132,9 +136,13 @@ final class DiffPaneTextDocumentContainerView: NSView {
         font: NSFont,
         theme: Theme,
         lspContext: DiffPaneLSPContext?,
+        allowsReviewLineSelection: Bool = true,
         onReviewLineSelected: @escaping (DiffReviewLineAnchor) -> Void = { _ in },
         onContextExpansion: @escaping (DiffContextExpansionKey, DiffContextExpansionMode) -> Void = { _, _ in }
     ) {
+        oldPane.allowsReviewLineSelection = allowsReviewLineSelection
+        newPane.allowsReviewLineSelection = allowsReviewLineSelection
+        stackedPane.allowsReviewLineSelection = allowsReviewLineSelection
         oldPane.onReviewLineSelected = onReviewLineSelected
         newPane.onReviewLineSelected = onReviewLineSelected
         stackedPane.onReviewLineSelected = onReviewLineSelected
@@ -330,6 +338,11 @@ final class DiffPaneTextScrollView: NSScrollView {
     private var wraps = false
     private var font: NSFont = .monospacedSystemFont(ofSize: 13, weight: .regular)
     private var theme: Theme?
+    var allowsReviewLineSelection: Bool = true {
+        didSet {
+            (verticalRulerView as? DiffPaneLineNumberRulerView)?.allowsReviewLineSelection = allowsReviewLineSelection
+        }
+    }
     var onReviewLineSelected: (DiffReviewLineAnchor) -> Void = { _ in }
     var onContextExpansion: (DiffContextExpansionKey, DiffContextExpansionMode) -> Void = { _, _ in } {
         didSet {
@@ -1130,6 +1143,7 @@ final class DiffPaneLineNumberRulerView: NSRulerView {
     }
     private var trackingArea: NSTrackingArea?
     var rowHeight: CGFloat = 16
+    var allowsReviewLineSelection: Bool = true
     var onReviewLineSelected: (DiffReviewLineAnchor) -> Void = { _ in }
     var onContextExpansion: (DiffContextExpansionKey, DiffContextExpansionMode) -> Void = { _, _ in }
     private var contentTopInset: CGFloat = 6
@@ -1190,7 +1204,7 @@ final class DiffPaneLineNumberRulerView: NSRulerView {
         if let row = rowIndex(at: sourcePoint), invokeExpansion(row: row, optionKey: event.modifierFlags.contains(.option)) {
             return
         }
-        guard let row = textView.reviewLineRow(at: sourcePoint) else {
+        guard allowsReviewLineSelection, let row = textView.reviewLineRow(at: sourcePoint) else {
             super.mouseDown(with: event)
             return
         }
@@ -1433,6 +1447,7 @@ final class DiffPaneLineNumberRulerView: NSRulerView {
     }
 
     private func isReviewCommentableRow(_ row: Int) -> Bool {
+        guard allowsReviewLineSelection else { return false }
         guard let textView = scrollView?.documentView as? DiffPaneCodeTextView else { return false }
         return textView.reviewLineAnchor(atRow: row) != nil
     }

--- a/Alas/Sources/Center/Diff/DiffPaneView.swift
+++ b/Alas/Sources/Center/Diff/DiffPaneView.swift
@@ -115,6 +115,7 @@ struct DiffPaneView: View {
     var showsToolbar: Bool = true
     var verticalScrollMode: DiffPaneVerticalScrollMode = .internalScroll
     var lspContext: DiffPaneLSPContext? = nil
+    var allowsReviewLineSelection: Bool = true
     var onReviewLineSelected: (DiffReviewLineAnchor) -> Void = { _ in }
     var onContextExpansion: (DiffContextExpansionKey, DiffContextExpansionMode) -> Void = { _, _ in }
     let hunkActions: (ParsedDiff.Hunk) -> DiffPaneHunkActions
@@ -133,6 +134,7 @@ struct DiffPaneView: View {
         showsToolbar: Bool = true,
         verticalScrollMode: DiffPaneVerticalScrollMode = .internalScroll,
         lspContext: DiffPaneLSPContext? = nil,
+        allowsReviewLineSelection: Bool = true,
         onReviewLineSelected: @escaping (DiffReviewLineAnchor) -> Void = { _ in },
         onContextExpansion: @escaping (DiffContextExpansionKey, DiffContextExpansionMode) -> Void = { _, _ in },
         hunkActions: @escaping (ParsedDiff.Hunk) -> DiffPaneHunkActions
@@ -147,6 +149,7 @@ struct DiffPaneView: View {
         self.showsToolbar = showsToolbar
         self.verticalScrollMode = verticalScrollMode
         self.lspContext = lspContext
+        self.allowsReviewLineSelection = allowsReviewLineSelection
         self.onReviewLineSelected = onReviewLineSelected
         self.onContextExpansion = onContextExpansion
         self.hunkActions = hunkActions
@@ -287,6 +290,7 @@ struct DiffPaneView: View {
                 codeFontSize: codeFontSize,
                 theme: theme,
                 lspContext: lspContext,
+                allowsReviewLineSelection: allowsReviewLineSelection,
                 onReviewLineSelected: onReviewLineSelected,
                 onContextExpansion: onContextExpansion
             )

--- a/Alas/Sources/Center/DiffReview/DiffReviewFileSection.swift
+++ b/Alas/Sources/Center/DiffReview/DiffReviewFileSection.swift
@@ -25,6 +25,7 @@ struct DiffReviewFileSection: View {
     var draftCommentActions = ReviewDraftCommentActions()
     var onSelectDraftComment: (ReviewDraftComment) -> Void = { _ in }
     var onSaveDraftComment: (DiffReviewLineAnchor, String) -> Void = { _, _ in }
+    var allowsDraftCommentCreation: Bool = true
     var onContextExpansionActivated: () -> Void = {}
     var reviewFeedbackTarget: ReviewFeedbackTarget?
 
@@ -369,10 +370,10 @@ struct DiffReviewFileSection: View {
                             codeFontSize: codeFontSize,
                             theme: theme,
                             lspContext: lspContext,
-                            onReviewLineSelected: { anchor in
+                            onReviewLineSelected: allowsDraftCommentCreation ? { anchor in
                                 pendingDraftAnchor = anchor
                                 pendingDraftBody = ""
-                            },
+                            } : { _ in },
                             onContextExpansion: loadContextAndExpand
                         )
                         .fixedSize(horizontal: false, vertical: true)
@@ -404,10 +405,10 @@ struct DiffReviewFileSection: View {
                 showsToolbar: false,
                 verticalScrollMode: .staticHeight,
                 lspContext: lspContext,
-                onReviewLineSelected: { anchor in
+                onReviewLineSelected: allowsDraftCommentCreation ? { anchor in
                     pendingDraftAnchor = anchor
                     pendingDraftBody = ""
-                },
+                } : { _ in },
                 onContextExpansion: loadContextAndExpand,
                 hunkActions: { hunk in
                     let enabled = file.stagedMutationActions?.isHunkUnstageEnabled?(hunk) ?? false

--- a/Alas/Sources/Center/DiffReview/DiffReviewFileSection.swift
+++ b/Alas/Sources/Center/DiffReview/DiffReviewFileSection.swift
@@ -370,10 +370,11 @@ struct DiffReviewFileSection: View {
                             codeFontSize: codeFontSize,
                             theme: theme,
                             lspContext: lspContext,
-                            onReviewLineSelected: allowsDraftCommentCreation ? { anchor in
+                            allowsReviewLineSelection: allowsDraftCommentCreation,
+                            onReviewLineSelected: { anchor in
                                 pendingDraftAnchor = anchor
                                 pendingDraftBody = ""
-                            } : { _ in },
+                            },
                             onContextExpansion: loadContextAndExpand
                         )
                         .fixedSize(horizontal: false, vertical: true)
@@ -405,10 +406,11 @@ struct DiffReviewFileSection: View {
                 showsToolbar: false,
                 verticalScrollMode: .staticHeight,
                 lspContext: lspContext,
-                onReviewLineSelected: allowsDraftCommentCreation ? { anchor in
+                allowsReviewLineSelection: allowsDraftCommentCreation,
+                onReviewLineSelected: { anchor in
                     pendingDraftAnchor = anchor
                     pendingDraftBody = ""
-                } : { _ in },
+                },
                 onContextExpansion: loadContextAndExpand,
                 hunkActions: { hunk in
                     let enabled = file.stagedMutationActions?.isHunkUnstageEnabled?(hunk) ?? false

--- a/Alas/Sources/Center/DiffReview/DiffReviewFileSection.swift
+++ b/Alas/Sources/Center/DiffReview/DiffReviewFileSection.swift
@@ -139,6 +139,19 @@ struct DiffReviewFileSection: View {
                 .accessibilityIdentifier("diff-review-open-file-\(file.id.rawValue)")
                 .accessibilityLabel(openFileTitle)
             }
+            if let unstageFile = file.stagedMutationActions?.unstageFile {
+                Button("Unstage") {
+                    unstageFile()
+                }
+                .buttonStyle(.plain)
+                .font(.system(size: 11, weight: .semibold))
+                .foregroundColor(theme.color("fg-muted"))
+                .padding(.horizontal, 8)
+                .frame(height: 24)
+                .background(theme.color("bg-3"))
+                .clipShape(RoundedRectangle(cornerRadius: 6))
+                .accessibilityIdentifier("diff-review-unstage-file-\(file.id.rawValue)")
+            }
         }
         .padding(.horizontal, 14)
         .padding(.vertical, 10)
@@ -396,7 +409,12 @@ struct DiffReviewFileSection: View {
                     pendingDraftBody = ""
                 },
                 onContextExpansion: loadContextAndExpand,
-                hunkActions: { _ in DiffPaneHunkActions() }
+                hunkActions: { hunk in
+                    let enabled = file.stagedMutationActions?.isHunkUnstageEnabled?(hunk) ?? false
+                    return DiffPaneHunkActions(
+                        dropFromCommit: enabled ? { file.stagedMutationActions?.unstageHunk?(hunk) } : nil
+                    )
+                }
             )
         }
     }

--- a/Alas/Sources/Center/DiffReview/DiffReviewModels.swift
+++ b/Alas/Sources/Center/DiffReview/DiffReviewModels.swift
@@ -171,6 +171,12 @@ struct DiffReviewFileSummary: Codable, Equatable, Identifiable {
     }
 }
 
+struct DiffReviewStagedMutationActions {
+    var unstageFile: (() -> Void)? = nil
+    var unstageHunk: ((ParsedDiff.Hunk) -> Void)? = nil
+    var isHunkUnstageEnabled: ((ParsedDiff.Hunk) -> Bool)? = nil
+}
+
 struct DiffReviewFileSectionModel: Identifiable {
     var id: DiffReviewFileID { summary.id }
 
@@ -180,6 +186,7 @@ struct DiffReviewFileSectionModel: Identifiable {
     let placeholderMessage: String?
     let openFile: (() -> Void)?
     let contextProvider: DiffReviewContextProvider?
+    var stagedMutationActions: DiffReviewStagedMutationActions? = nil
 }
 
 struct DiffReviewSourceGroup: Equatable, Identifiable {

--- a/Alas/Sources/Center/DiffReview/DiffReviewModels.swift
+++ b/Alas/Sources/Center/DiffReview/DiffReviewModels.swift
@@ -94,6 +94,7 @@ struct DiffReviewFileSummary: Codable, Equatable, Identifiable {
     let deletions: Int
     let isRenderable: Bool
     var originalPath: String? = nil
+    var gitStatus: String? = nil
 
     init(
         path: String,
@@ -104,7 +105,8 @@ struct DiffReviewFileSummary: Codable, Equatable, Identifiable {
         additions: Int,
         deletions: Int,
         isRenderable: Bool,
-        originalPath: String? = nil
+        originalPath: String? = nil,
+        gitStatus: String? = nil
     ) {
         self.id = DiffReviewFileID(namespace: namespace, path: path)
         self.path = path
@@ -116,6 +118,7 @@ struct DiffReviewFileSummary: Codable, Equatable, Identifiable {
         self.deletions = deletions
         self.isRenderable = isRenderable
         self.originalPath = originalPath
+        self.gitStatus = gitStatus
     }
 
     enum CodingKeys: String, CodingKey {

--- a/Alas/Sources/Center/DiffReview/DiffReviewSurface.swift
+++ b/Alas/Sources/Center/DiffReview/DiffReviewSurface.swift
@@ -13,6 +13,7 @@ struct DiffReviewSurface: View {
     var showsSourceBadges: Bool = true
     var showsRailDisplayControls: Bool = false
     var showsDraftSummaryRail: Bool = false
+    var allowsDraftCommentCreation: Bool = true
     var lspContextForFile: (DiffReviewFileSectionModel) -> DiffPaneLSPContext? = { _ in nil }
     var inlineFeedbackByFileID: [DiffReviewFileID: [DiffReviewInlineFeedback]] = [:]
     var focusedFeedbackID: String? = nil
@@ -50,6 +51,7 @@ struct DiffReviewSurface: View {
         showsSourceBadges: Bool = true,
         showsRailDisplayControls: Bool = false,
         showsDraftSummaryRail: Bool = false,
+        allowsDraftCommentCreation: Bool = true,
         lspContextForFile: @escaping (DiffReviewFileSectionModel) -> DiffPaneLSPContext? = { _ in nil },
         inlineFeedbackByFileID: [DiffReviewFileID: [DiffReviewInlineFeedback]] = [:],
         focusedFeedbackID: String? = nil,
@@ -76,6 +78,7 @@ struct DiffReviewSurface: View {
         self.showsSourceBadges = showsSourceBadges
         self.showsRailDisplayControls = showsRailDisplayControls
         self.showsDraftSummaryRail = showsDraftSummaryRail
+        self.allowsDraftCommentCreation = allowsDraftCommentCreation
         self.lspContextForFile = lspContextForFile
         self.inlineFeedbackByFileID = inlineFeedbackByFileID
         self.focusedFeedbackID = focusedFeedbackID
@@ -282,6 +285,7 @@ struct DiffReviewSurface: View {
                 onSaveDraftComment: { anchor, body in
                     onSaveDraftComment(file.id, file.summary.originalPath, anchor, body)
                 },
+                allowsDraftCommentCreation: allowsDraftCommentCreation,
                 onContextExpansionActivated: {
                     contextExpandedFileIDs.insert(file.id)
                 },

--- a/Alas/Sources/Center/DiffReview/DiffReviewSurface.swift
+++ b/Alas/Sources/Center/DiffReview/DiffReviewSurface.swift
@@ -633,6 +633,19 @@ private struct DiffReviewFileSectionPlaceholder: View {
                 Text("-\(file.summary.deletions)")
                     .foregroundColor(theme.color("del"))
             }
+            if let unstageFile = file.stagedMutationActions?.unstageFile {
+                Button("Unstage") {
+                    unstageFile()
+                }
+                .buttonStyle(.plain)
+                .font(.system(size: 11, weight: .semibold))
+                .foregroundColor(theme.color("fg-muted"))
+                .padding(.horizontal, 8)
+                .frame(height: 24)
+                .background(theme.color("bg-3"))
+                .clipShape(RoundedRectangle(cornerRadius: 6))
+                .accessibilityIdentifier("diff-review-unstage-file-\(file.id.rawValue)")
+            }
         }
         .font(.system(size: 11, weight: .medium, design: .monospaced))
         .padding(.horizontal, 14)

--- a/AlasTests/DiffReviewStagedMutationActionsTests.swift
+++ b/AlasTests/DiffReviewStagedMutationActionsTests.swift
@@ -19,7 +19,8 @@ struct DiffReviewStagedMutationActionsTests {
             parsedDiff: nil,
             displayModel: nil,
             placeholderMessage: nil,
-            openFile: nil
+            openFile: nil,
+            contextProvider: nil
         )
 
         #expect(model.stagedMutationActions == nil)

--- a/AlasTests/DiffReviewStagedMutationActionsTests.swift
+++ b/AlasTests/DiffReviewStagedMutationActionsTests.swift
@@ -1,0 +1,83 @@
+import Testing
+import Foundation
+@testable import Alas
+
+struct DiffReviewStagedMutationActionsTests {
+    @Test func defaultFileSectionModelHasNilStagedActions() {
+        let summary = DiffReviewFileSummary(
+            path: "Sources/App.swift",
+            namespace: "staged",
+            groupID: nil,
+            groupTitle: nil,
+            status: .modified,
+            additions: 1,
+            deletions: 0,
+            isRenderable: true
+        )
+        let model = DiffReviewFileSectionModel(
+            summary: summary,
+            parsedDiff: nil,
+            displayModel: nil,
+            placeholderMessage: nil,
+            openFile: nil
+        )
+
+        #expect(model.stagedMutationActions == nil)
+    }
+
+    @Test func nilActionsAreNonCrashing() {
+        var actions = DiffReviewStagedMutationActions()
+        actions.unstageFile = nil
+        actions.unstageHunk = nil
+        actions.isHunkUnstageEnabled = nil
+
+        // Calling the nil closures with optional chaining should not crash
+        actions.unstageFile?()
+        let hunk = ParsedDiff.Hunk(
+            header: "@@ -1,1 +1,1 @@",
+            oldStart: 1,
+            newStart: 1,
+            lines: [
+                .init(kind: .add, text: "let x = 1", oldNumber: nil, newNumber: 1),
+            ]
+        )
+        actions.unstageHunk?(hunk)
+
+        // Reaching here means no crash occurred
+        #expect(true)
+    }
+
+    @Test func hunkUnstageEnabledRuleMatchesSpec() {
+        // Rule: enabled when !busy && status == .modified && !hunk.lines.isEmpty
+        let emptyHunk = ParsedDiff.Hunk(
+            header: "@@ -0,0 +0,0 @@",
+            oldStart: 0,
+            newStart: 0,
+            lines: []
+        )
+        let nonEmptyHunk = ParsedDiff.Hunk(
+            header: "@@ -1,1 +1,1 @@",
+            oldStart: 1,
+            newStart: 1,
+            lines: [
+                .init(kind: .add, text: "let x = 1", oldNumber: nil, newNumber: 1),
+            ]
+        )
+
+        func isEnabled(busy: Bool, status: DiffReviewFileStatus, hunk: ParsedDiff.Hunk) -> Bool {
+            !busy && status == .modified && !hunk.lines.isEmpty
+        }
+
+        // busy=true → false
+        #expect(isEnabled(busy: true, status: .modified, hunk: nonEmptyHunk) == false)
+
+        // busy=false, status=.modified, lines not empty → true
+        #expect(isEnabled(busy: false, status: .modified, hunk: nonEmptyHunk) == true)
+
+        // busy=false, status=.added → false
+        #expect(isEnabled(busy: false, status: .added, hunk: nonEmptyHunk) == false)
+
+        // busy=false, status=.modified, lines empty → false
+        #expect(isEnabled(busy: false, status: .modified, hunk: emptyHunk) == false)
+    }
+}

--- a/AlasTests/StagedDiffLoaderTests.swift
+++ b/AlasTests/StagedDiffLoaderTests.swift
@@ -1,0 +1,255 @@
+import Foundation
+import Testing
+@testable import Alas
+
+struct StagedDiffLoaderTests {
+    @Test func loadsSessionWithStagedNamespace() async throws {
+        let git = MockStagedDiffGitClient(
+            files: [
+                CommitChangedFile(path: "Sources/App.swift", originalPath: nil, status: "M", add: 1, del: 0),
+            ],
+            diffs: [
+                "Sources/App.swift": diff(lines: [
+                    .init(kind: .add, text: "let x = 1", oldNumber: nil, newNumber: 1),
+                ]),
+            ]
+        )
+        let loader = StagedDiffLoader(git: git)
+
+        let session = try await loader.load(worktreePath: URL(fileURLWithPath: "/tmp/repo"))
+
+        #expect(session.files.map(\.summary.namespace) == ["staged"])
+        #expect(session.summary.files.map(\.namespace) == ["staged"])
+    }
+
+    @Test func countsAdditionsAndDeletions() async throws {
+        let git = MockStagedDiffGitClient(
+            files: [
+                CommitChangedFile(path: "Sources/App.swift", originalPath: nil, status: "M", add: 99, del: 99),
+            ],
+            diffs: [
+                "Sources/App.swift": diff(lines: [
+                    .init(kind: .context, text: "let a = 0", oldNumber: 1, newNumber: 1),
+                    .init(kind: .delete, text: "let b = 1", oldNumber: 2, newNumber: nil),
+                    .init(kind: .delete, text: "let c = 2", oldNumber: 3, newNumber: nil),
+                    .init(kind: .add, text: "let b = 10", oldNumber: nil, newNumber: 2),
+                ]),
+            ]
+        )
+        let loader = StagedDiffLoader(git: git)
+
+        let session = try await loader.load(worktreePath: URL(fileURLWithPath: "/tmp/repo"))
+
+        let file = try #require(session.files.first)
+        #expect(file.summary.additions == 1)
+        #expect(file.summary.deletions == 2)
+        #expect(session.summary.totalAdditions == 1)
+        #expect(session.summary.totalDeletions == 2)
+    }
+
+    @Test func forwardsOriginalPathForRenames() async throws {
+        let git = MockStagedDiffGitClient(
+            files: [
+                CommitChangedFile(path: "Sources/NewName.swift", originalPath: "Sources/OldName.swift", status: "R", add: 1, del: 1),
+            ],
+            diffs: [
+                "Sources/NewName.swift": diff(lines: [
+                    .init(kind: .add, text: "let renamed = true", oldNumber: nil, newNumber: 1),
+                ]),
+            ]
+        )
+        let loader = StagedDiffLoader(git: git)
+
+        let session = try await loader.load(worktreePath: URL(fileURLWithPath: "/tmp/repo"))
+
+        #expect(git.diffRequests.map(\.originalPath) == ["Sources/OldName.swift"])
+        let file = try #require(session.files.first)
+        #expect(file.summary.originalPath == "Sources/OldName.swift")
+    }
+
+    @Test func marksImageFilesAsNotRenderable() async throws {
+        let git = MockStagedDiffGitClient(
+            files: [
+                CommitChangedFile(path: "Assets/logo.png", originalPath: nil, status: "M", add: 0, del: 0),
+            ],
+            diffs: [
+                "Assets/logo.png": diff(lines: [
+                    .init(kind: .delete, text: "binary old", oldNumber: 1, newNumber: nil),
+                    .init(kind: .add, text: "binary new", oldNumber: nil, newNumber: 1),
+                ]),
+            ]
+        )
+        let loader = StagedDiffLoader(git: git)
+
+        let session = try await loader.load(worktreePath: URL(fileURLWithPath: "/tmp/repo"))
+
+        let file = try #require(session.files.first)
+        #expect(file.summary.isRenderable == false)
+        #expect(file.displayModel == nil)
+        #expect(file.placeholderMessage == "Image changes are not available in this review view yet.")
+    }
+
+    @Test func marksEmptyDiffAsNotRenderable() async throws {
+        let git = MockStagedDiffGitClient(
+            files: [
+                CommitChangedFile(path: "README.md", originalPath: nil, status: "M", add: 0, del: 0),
+            ],
+            diffs: [
+                "README.md": ParsedDiff(hunks: []),
+            ]
+        )
+        let loader = StagedDiffLoader(git: git)
+
+        let session = try await loader.load(worktreePath: URL(fileURLWithPath: "/tmp/repo"))
+
+        let file = try #require(session.files.first)
+        #expect(file.summary.isRenderable == false)
+        #expect(file.displayModel == nil)
+        #expect(file.placeholderMessage == "No text diff is available for this file.")
+    }
+
+    @Test func marksTextDiffAsRenderable() async throws {
+        let git = MockStagedDiffGitClient(
+            files: [
+                CommitChangedFile(path: "Sources/App.swift", originalPath: nil, status: "M", add: 1, del: 0),
+            ],
+            diffs: [
+                "Sources/App.swift": diff(lines: [
+                    .init(kind: .add, text: "let value = 1", oldNumber: nil, newNumber: 1),
+                ]),
+            ]
+        )
+        let loader = StagedDiffLoader(git: git)
+
+        let session = try await loader.load(worktreePath: URL(fileURLWithPath: "/tmp/repo"))
+
+        let file = try #require(session.files.first)
+        #expect(file.summary.isRenderable == true)
+        #expect(file.displayModel != nil)
+        #expect(file.placeholderMessage == nil)
+    }
+
+    @Test func buildsDiffReviewLoadedSessionWithGroupsDisabled() async throws {
+        let git = MockStagedDiffGitClient(
+            files: [
+                CommitChangedFile(path: "Sources/App.swift", originalPath: nil, status: "M", add: 1, del: 0),
+                CommitChangedFile(path: "Sources/Other.swift", originalPath: nil, status: "A", add: 5, del: 0),
+            ],
+            diffs: [
+                "Sources/App.swift": diff(lines: [
+                    .init(kind: .add, text: "let a = 1", oldNumber: nil, newNumber: 1),
+                ]),
+                "Sources/Other.swift": diff(lines: [
+                    .init(kind: .add, text: "let b = 2", oldNumber: nil, newNumber: 1),
+                ]),
+            ]
+        )
+        let loader = StagedDiffLoader(git: git)
+
+        let session = try await loader.load(worktreePath: URL(fileURLWithPath: "/tmp/repo"))
+
+        #expect(session.summary.groupsEnabled == false)
+        #expect(session.summary.groups.isEmpty)
+    }
+
+    @Test func abortsOnCancellation() async throws {
+        let git = BlockingStagedDiffGitClient()
+        let loader = StagedDiffLoader(git: git)
+        let worktreePath = URL(fileURLWithPath: "/tmp/repo")
+
+        let task = Task { @MainActor in
+            try await loader.load(worktreePath: worktreePath)
+        }
+        task.cancel()
+
+        do {
+            _ = try await task.value
+            Issue.record("Expected CancellationError but load succeeded")
+        } catch is CancellationError {
+            // Expected: task was cancelled
+        } catch {
+            // Also acceptable: the task may propagate cancellation as a
+            // CancellationError wrapped by the Swift concurrency runtime.
+        }
+
+        // The mock should not have been called (or called minimally) since
+        // cancellation is checked before the first async call.
+        #expect(git.callCount <= 1)
+    }
+
+    // MARK: - Helpers
+
+    private func diff(lines: [ParsedDiff.Hunk.Line]) -> ParsedDiff {
+        ParsedDiff(hunks: [
+            ParsedDiff.Hunk(
+                header: "@@ -1,\(lines.count) +1,\(lines.count) @@",
+                oldStart: 1,
+                newStart: 1,
+                lines: lines
+            ),
+        ])
+    }
+}
+
+// MARK: - MockStagedDiffGitClient
+
+private final class MockStagedDiffGitClient: StagedDiffGitClient, @unchecked Sendable {
+    struct DiffRequest: Equatable {
+        let worktreePath: URL
+        let file: String
+        let staged: Bool
+        let originalPath: String?
+    }
+
+    private let stagedFiles: [CommitChangedFile]
+    private let diffs: [String: ParsedDiff]
+    private let lock = NSLock()
+    private var recordedDiffRequests: [DiffRequest] = []
+
+    init(files: [CommitChangedFile], diffs: [String: ParsedDiff]) {
+        self.stagedFiles = files
+        self.diffs = diffs
+    }
+
+    var diffRequests: [DiffRequest] {
+        lock.withLock { recordedDiffRequests }
+    }
+
+    func stagedChangedFiles(at worktreePath: URL) async throws -> [CommitChangedFile] {
+        stagedFiles
+    }
+
+    func diff(worktreePath: URL, file: String, staged: Bool, originalPath: String?) async throws -> ParsedDiff {
+        lock.withLock {
+            recordedDiffRequests.append(DiffRequest(
+                worktreePath: worktreePath,
+                file: file,
+                staged: staged,
+                originalPath: originalPath
+            ))
+        }
+        return diffs[file, default: ParsedDiff(hunks: [])]
+    }
+}
+
+// MARK: - BlockingStagedDiffGitClient
+
+/// A mock that records how many times `stagedChangedFiles` is called;
+/// used to verify cancellation short-circuits the load.
+private final class BlockingStagedDiffGitClient: StagedDiffGitClient, @unchecked Sendable {
+    private let lock = NSLock()
+    private var _callCount = 0
+
+    var callCount: Int { lock.withLock { _callCount } }
+
+    func stagedChangedFiles(at worktreePath: URL) async throws -> [CommitChangedFile] {
+        lock.withLock { _callCount += 1 }
+        try Task.checkCancellation()
+        return []
+    }
+
+    func diff(worktreePath: URL, file: String, staged: Bool, originalPath: String?) async throws -> ParsedDiff {
+        try Task.checkCancellation()
+        return ParsedDiff(hunks: [])
+    }
+}

--- a/AlasTests/StagedDiffSelectionBridgingTests.swift
+++ b/AlasTests/StagedDiffSelectionBridgingTests.swift
@@ -1,0 +1,34 @@
+import Testing
+import Foundation
+@testable import Alas
+
+struct StagedDiffSelectionBridgingTests {
+    @Test func restoredPathMapsToStagedFileID() {
+        let fileID = DiffReviewFileID(namespace: "staged", path: "foo.swift")
+        #expect(fileID.rawValue == "staged:foo.swift")
+    }
+
+    @Test func selectionFallsToFirstFileWhenRemovedFromSession() {
+        let first = DiffReviewFileID(namespace: "staged", path: "Sources/First.swift")
+        let second = DiffReviewFileID(namespace: "staged", path: "Sources/Second.swift")
+        let removedID = DiffReviewFileID(namespace: "staged", path: "Sources/Removed.swift")
+
+        let result = DiffReviewSurfaceSelectionSync.synchronizedSelection(
+            current: removedID,
+            fileIDs: [first, second]
+        )
+
+        #expect(result == first)
+    }
+
+    @Test func selectionClearsWhenNoFilesRemain() {
+        let staleID = DiffReviewFileID(namespace: "staged", path: "Sources/Stale.swift")
+
+        let result = DiffReviewSurfaceSelectionSync.synchronizedSelection(
+            current: staleID,
+            fileIDs: []
+        )
+
+        #expect(result == nil)
+    }
+}

--- a/docs/superpowers/specs/2026-06-17-draft-commit-stacked-diffs-design.md
+++ b/docs/superpowers/specs/2026-06-17-draft-commit-stacked-diffs-design.md
@@ -1,0 +1,107 @@
+# Draft Commit Stacked Diffs Design
+
+## Goal
+
+Use the shared file rail and stacked/split all-files diff surface in the draft commit tab. The commit message composer stays unchanged at the top of the pane. Only the lower staged-file review area changes.
+
+## Current State
+
+`DraftCommitTabView` currently renders staged files with `CommitFilesListView` on the left and a single selected `CommitDiffView` on the right. This differs from Review Changes and commit review tabs, which use `DiffReviewSurface` for the file rail, scroll-synced all-files diff, and shared split/stacked display controls.
+
+The existing draft commit behavior also supports:
+
+- persisting subject, body, amend mode, and selected staged path in `DraftCommitTabState`
+- refreshing when the right-pane staged change fingerprint changes
+- unstaging a full staged file
+- unstaging an eligible staged hunk
+- refreshing the right pane after staging mutations
+
+Those behaviors must remain intact.
+
+## Proposed Approach
+
+Add a small staged-diff loading path for the draft commit tab and render its result through `DiffReviewSurface`.
+
+The loader should be focused on staged/index diffs. It will:
+
+- load staged files with `GitService.stagedChangedFiles(at:)`
+- load each file diff with `GitService.diff(worktreePath:file:staged:originalPath:)`
+- build `DiffReviewFileSectionModel` values with a staged namespace
+- build text display models for renderable non-image diffs
+- provide placeholders for files that the shared review surface cannot render
+- attach staged mutation actions needed by the draft commit pane
+
+`DraftCommitTabView` will keep `CommitMessageEditorView` and amend warning UI as-is. Below that, it will render:
+
+- a loading state while staged diff sections are loading
+- the existing empty copy when no staged changes exist
+- an error state when staged files or staged diffs fail to load
+- `DiffReviewSurface` when staged sections are available
+
+The shared surface will use the app-wide diff preferences through `DiffPreferenceBindings`, preserving existing behavior for split/stacked layout, line wrapping, and whitespace display.
+
+## Selection
+
+The draft tab currently persists `selectedPath`. The new surface uses `DiffReviewFileID`. The tab should bridge the two:
+
+- when hydrating tab state, turn the stored selected path into `DiffReviewFileID(namespace: "staged", path: selectedPath)`
+- when the user selects a file through the rail or scroll-synced surface, persist `selectedFileID?.path`
+- when a staged refresh removes the selected file, fall back to the first staged file and persist that path
+- when no staged files remain, clear the selected path
+
+This preserves tab restoration without changing the serialized tab model.
+
+## Actions
+
+The draft commit pane must continue to support unstaging staged content.
+
+Full-file unstage remains equivalent to the current `unstageFile(_:)` behavior, including passing both the new and original path for staged renames or copies when `originalPath` is present.
+
+Hunk unstage remains available only when the file and hunk are eligible under the current rule:
+
+- the draft tab is not busy
+- the file status is `M`
+- the hunk has at least one line
+
+The shared file section needs an action surface for draft-commit staged mutations. This can be implemented as a small optional action model on `DiffReviewFileSectionModel` or `DiffReviewFileSection`, scoped to file-level and hunk-level actions. Other review surfaces should keep their current default behavior when these actions are absent.
+
+## Data Flow
+
+1. `stagedKey` changes when the right-pane staged change fingerprint changes.
+2. `DraftCommitTabView` starts a staged review session load.
+3. The loader builds a `DiffReviewLoadedSession` from staged files and staged diffs.
+4. The tab synchronizes `selectedFileID` with the loaded file set and persisted `selectedPath`.
+5. `DiffReviewSurface` renders the file rail and all staged file sections.
+6. File or hunk unstage actions call the existing git operations.
+7. After mutation, the tab reloads the staged session and refreshes the right pane.
+
+## Error Handling
+
+Loading errors should set the draft tab error and show a lower-pane error state without clearing the composer. Staging mutation errors should reuse the existing error display in `CommitMessageEditorView`.
+
+Cancelled or stale loads must not overwrite newer staged sessions. Use the same active-key pattern already present in the tab or the load-token pattern used by `ReviewChangesTabView`.
+
+## Testing
+
+Add focused Swift Testing coverage where practical:
+
+- staged loader builds a `DiffReviewLoadedSession` with staged namespace, counts, original paths, and renderability
+- selected path to selected file ID bridging handles restoration, removal, and empty staged sets
+- optional file/hunk action defaults do not affect other `DiffReviewSurface` consumers
+- hunk unstage availability matches the current draft commit rule
+
+Run the project verification commands after implementation:
+
+```bash
+xcodegen
+xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -quiet build
+xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' test
+```
+
+## Out of Scope
+
+- changing the commit message composer layout
+- changing amend prefill or amend warning behavior
+- adding review draft comments to the draft commit tab
+- adding image diff support to the shared review surface
+- changing `DraftCommitTabState` serialization


### PR DESCRIPTION
## Summary

- Replaces the old `CommitFilesListView` + `CommitDiffView` split pane in the draft commit tab with the shared `DiffReviewSurface`, giving it the file rail, scroll-synced all-files diff view, and split/stacked display controls
- Adds `StagedDiffLoader` to load staged index diffs into a `DiffReviewLoadedSession` (namespace `"staged"`, groups disabled)
- Adds optional `DiffReviewStagedMutationActions` to `DiffReviewFileSectionModel` so the draft commit surface can wire file- and hunk-level unstage — other consumers default to `nil` and see no behaviour change
- Bridges `DraftCommitTabState.selectedPath` ↔ `DiffReviewFileID(namespace: "staged")` to preserve tab restoration without changing serialization
- Uses a load-token pattern to prevent stale session overwrites; `sessionWithActions` computed property ensures `busy` is always read fresh at closure invocation time

## Test Plan

- [ ] Staged files appear in the file rail with correct add/delete counts
- [ ] Selecting a file in the rail scrolls the diff stream to that file
- [ ] Split/stacked layout controls work as in Review Changes tab
- [ ] Unstage button in file section header unstages the whole file
- [ ] Hunk unstage is available for modified files and disabled for added/deleted
- [ ] Tab restores to the previously selected file after re-opening
- [ ] Committing from the draft commit tab still works correctly
- [ ] Amend mode and AI commit message generation are unaffected
- [ ] `StagedDiffLoaderTests`, `StagedDiffSelectionBridgingTests`, `DiffReviewStagedMutationActionsTests` all pass