### PR TITLE
feat(review): prioritise open chats in send-to-agent dropdown

### DIFF
--- a/Alas/Sources/Center/DiffReview/DiffReviewFileSection.swift
+++ b/Alas/Sources/Center/DiffReview/DiffReviewFileSection.swift
@@ -1384,7 +1384,17 @@ private struct ReviewDraftCommentCard: View {
         let targets = actions.agentTargets()
         if targets.count > 1 {
             Menu("Send") {
-                ForEach(targets) { target in
+                let existingTargets = targets.filter { !$0.isNewChat }
+                let newChatTargets = targets.filter { $0.isNewChat }
+                ForEach(existingTargets) { target in
+                    Button(target.title) {
+                        actions.sendToAgent(feedbackBundle, target)
+                    }
+                }
+                if !existingTargets.isEmpty, !newChatTargets.isEmpty {
+                    Divider()
+                }
+                ForEach(newChatTargets) { target in
                     Button(target.title) {
                         actions.sendToAgent(feedbackBundle, target)
                     }

--- a/Alas/Sources/Center/ReviewWorkspace/ReviewDraftSummaryRail.swift
+++ b/Alas/Sources/Center/ReviewWorkspace/ReviewDraftSummaryRail.swift
@@ -328,7 +328,17 @@ struct ReviewDraftSummaryRail: View {
     private var collapsedSendToAgentControl: some View {
         if agentTargets.count > 1 {
             Menu {
-                ForEach(agentTargets) { target in
+                let existingTargets = agentTargets.filter { !$0.isNewChat }
+                let newChatTargets = agentTargets.filter { $0.isNewChat }
+                ForEach(existingTargets) { target in
+                    Button(target.title) {
+                        draftCommentActions.sendToAgent(bundle, target)
+                    }
+                }
+                if !existingTargets.isEmpty, !newChatTargets.isEmpty {
+                    Divider()
+                }
+                ForEach(newChatTargets) { target in
                     Button(target.title) {
                         draftCommentActions.sendToAgent(bundle, target)
                     }
@@ -358,7 +368,17 @@ struct ReviewDraftSummaryRail: View {
     private var expandedSendToAgentControl: some View {
         if agentTargets.count > 1 {
             Menu {
-                ForEach(agentTargets) { target in
+                let existingTargets = agentTargets.filter { !$0.isNewChat }
+                let newChatTargets = agentTargets.filter { $0.isNewChat }
+                ForEach(existingTargets) { target in
+                    Button(target.title) {
+                        draftCommentActions.sendToAgent(bundle, target)
+                    }
+                }
+                if !existingTargets.isEmpty, !newChatTargets.isEmpty {
+                    Divider()
+                }
+                ForEach(newChatTargets) { target in
                     Button(target.title) {
                         draftCommentActions.sendToAgent(bundle, target)
                     }

--- a/Alas/Sources/Center/ReviewWorkspace/ReviewFeedbackAgentSender.swift
+++ b/Alas/Sources/Center/ReviewWorkspace/ReviewFeedbackAgentSender.swift
@@ -26,6 +26,11 @@ enum ReviewFeedbackAgentTarget: Codable, Equatable, Hashable, Identifiable, Send
             return title
         }
     }
+
+    var isNewChat: Bool {
+        if case .newChat = self { return true }
+        return false
+    }
 }
 
 @MainActor
@@ -37,10 +42,6 @@ struct ReviewFeedbackAgentSender {
         ReviewFeedbackAgentSender(
             availableTargets: {
                 var targets: [ReviewFeedbackAgentTarget] = []
-                let agentID = appState.config.changes.aiToolId
-                if agentID != "none", appState.agent(id: agentID) != nil {
-                    targets.append(.newChat(agentID: agentID, title: "New chat"))
-                }
 
                 let sessionTargets = appState.tabs.tabs(forWorktree: worktreeID).compactMap { tab -> ReviewFeedbackAgentTarget? in
                     guard case .acpSession(let state) = tab,
@@ -54,6 +55,11 @@ struct ReviewFeedbackAgentSender {
                     )
                 }
                 targets.append(contentsOf: sessionTargets)
+
+                let agentID = appState.config.changes.aiToolId
+                if agentID != "none", appState.agent(id: agentID) != nil {
+                    targets.append(.newChat(agentID: agentID, title: "New chat"))
+                }
                 return targets
             },
             send: { prompt, target, completion in


### PR DESCRIPTION
<!-- gg:managed:start -->
Existing sessions in the same worktree now appear first, with a
divider separating them from the "New chat" option at the bottom.
Removes the ambiguity between an existing session titled "New session"
and the create-new-chat action.
<!-- gg:managed:end -->