### PR TITLE
feat(diff): render markdown in feedback comment cards

### DIFF
--- a/Alas/Sources/ACP/UI/ACPMarkdownText.swift
+++ b/Alas/Sources/ACP/UI/ACPMarkdownText.swift
@@ -14,6 +14,7 @@ struct ACPMarkdownText: View {
     let raw: String
     var cache: ACPMarkdownBlockCache? = nil
     var typography: ACPChatTypography = .default
+    var showsCodeBlockCopyButton: Bool = true
     @Environment(\.theme) private var theme
 
     var body: some View {
@@ -69,7 +70,7 @@ struct ACPMarkdownText: View {
                 Spacer(minLength: 0)
             }
         case .code(let lang, let body):
-            CodeBlockView(language: lang, code: body, typography: typography)
+            CodeBlockView(language: lang, code: body, typography: typography, showsCopyButton: showsCodeBlockCopyButton)
         case .table(let header, let rows):
             tableView(header: header, rows: rows)
         }
@@ -334,6 +335,7 @@ private struct CodeBlockView: View {
     let language: String?
     let code: String
     let typography: ACPChatTypography
+    var showsCopyButton: Bool = true
     @Environment(\.theme) private var theme
     @State private var copied = false
 
@@ -372,7 +374,9 @@ private struct CodeBlockView: View {
                 Color.clear.frame(height: 1)
             }
             Spacer(minLength: 0)
-            copyButton
+            if showsCopyButton {
+                copyButton
+            }
         }
         .padding(.horizontal, 10).padding(.vertical, 6)
         .frame(maxWidth: .infinity)

--- a/Alas/Sources/Center/DiffReview/DiffReviewFileSection.swift
+++ b/Alas/Sources/Center/DiffReview/DiffReviewFileSection.swift
@@ -1194,7 +1194,7 @@ enum DiffReviewInlineFeedbackMarkdown {
     private static let typography = ACPChatTypography(fontFamily: "", fontSize: 11)
 
     static func view(_ source: String) -> some View {
-        ACPMarkdownText(raw: source, typography: typography)
+        ACPMarkdownText(raw: source, typography: typography, showsCodeBlockCopyButton: false)
     }
 
     @MainActor
@@ -1300,7 +1300,6 @@ private struct ReviewDraftCommentCard: View {
                     .accessibilityIdentifier("diff-review-draft-comment-editor-\(comment.id)")
                 } else {
                     DiffReviewInlineFeedbackMarkdown.view(comment.bodyMarkdown)
-                        .allowsHitTesting(false)
                 }
             }
             .frame(maxWidth: .infinity, alignment: .leading)
@@ -1607,7 +1606,6 @@ private struct DiffReviewInlineFeedbackCard: View {
                         .lineLimit(1)
 
                         DiffReviewInlineFeedbackMarkdown.view(item.bodyPreview)
-                            .allowsHitTesting(false)
                     }
                     .frame(maxWidth: .infinity, alignment: .leading)
 

--- a/Alas/Sources/Center/DiffReview/DiffReviewFileSection.swift
+++ b/Alas/Sources/Center/DiffReview/DiffReviewFileSection.swift
@@ -1300,6 +1300,7 @@ private struct ReviewDraftCommentCard: View {
                     .accessibilityIdentifier("diff-review-draft-comment-editor-\(comment.id)")
                 } else {
                     DiffReviewInlineFeedbackMarkdown.view(comment.bodyMarkdown)
+                        .allowsHitTesting(false)
                 }
             }
             .frame(maxWidth: .infinity, alignment: .leading)
@@ -1606,6 +1607,7 @@ private struct DiffReviewInlineFeedbackCard: View {
                         .lineLimit(1)
 
                         DiffReviewInlineFeedbackMarkdown.view(item.bodyPreview)
+                            .allowsHitTesting(false)
                     }
                     .frame(maxWidth: .infinity, alignment: .leading)
 

--- a/Alas/Sources/Center/DiffReview/DiffReviewFileSection.swift
+++ b/Alas/Sources/Center/DiffReview/DiffReviewFileSection.swift
@@ -1199,7 +1199,16 @@ enum DiffReviewInlineFeedbackMarkdown {
 
     @MainActor
     static func plainText(_ source: String) -> String {
-        NSAttributedString(ACPMarkdownText.inlineMarkdown(source)).string
+        ACPMarkdownText.parse(source).compactMap { block -> String? in
+            switch block {
+            case .heading(_, let text), .paragraph(let text), .quote(let text):
+                return NSAttributedString(ACPMarkdownText.inlineMarkdown(text)).string
+            case .code(_, let body):
+                return body
+            case .table(let header, let rows):
+                return ([header] + rows).map { $0.joined(separator: " ") }.joined(separator: " ")
+            }
+        }.joined(separator: " ")
     }
 }
 

--- a/Alas/Sources/Center/DiffReview/DiffReviewFileSection.swift
+++ b/Alas/Sources/Center/DiffReview/DiffReviewFileSection.swift
@@ -1191,14 +1191,15 @@ enum DiffReviewInlineFeedbackDisplayPolicy {
 }
 
 enum DiffReviewInlineFeedbackMarkdown {
-    @MainActor
-    static func render(_ source: String) -> AttributedString {
-        ACPMarkdownText.inlineMarkdown(source)
+    private static let typography = ACPChatTypography(fontFamily: "", fontSize: 11)
+
+    static func view(_ source: String) -> some View {
+        ACPMarkdownText(raw: source, typography: typography)
     }
 
     @MainActor
     static func plainText(_ source: String) -> String {
-        NSAttributedString(render(source)).string
+        NSAttributedString(ACPMarkdownText.inlineMarkdown(source)).string
     }
 }
 
@@ -1298,10 +1299,7 @@ private struct ReviewDraftCommentCard: View {
                     )
                     .accessibilityIdentifier("diff-review-draft-comment-editor-\(comment.id)")
                 } else {
-                    Text(DiffReviewInlineFeedbackMarkdown.render(comment.bodyMarkdown))
-                        .font(.system(size: 11.5))
-                        .foregroundColor(theme.color("fg"))
-                        .fixedSize(horizontal: false, vertical: true)
+                    DiffReviewInlineFeedbackMarkdown.view(comment.bodyMarkdown)
                 }
             }
             .frame(maxWidth: .infinity, alignment: .leading)
@@ -1607,10 +1605,7 @@ private struct DiffReviewInlineFeedbackCard: View {
                         }
                         .lineLimit(1)
 
-                        Text(DiffReviewInlineFeedbackMarkdown.render(item.bodyPreview))
-                            .font(.system(size: 11.5))
-                            .foregroundColor(theme.color("fg"))
-                            .fixedSize(horizontal: false, vertical: true)
+                        DiffReviewInlineFeedbackMarkdown.view(item.bodyPreview)
                     }
                     .frame(maxWidth: .infinity, alignment: .leading)
 

--- a/Alas/Sources/Center/ReviewWorkspace/ReviewDraftSummaryRail.swift
+++ b/Alas/Sources/Center/ReviewWorkspace/ReviewDraftSummaryRail.swift
@@ -544,7 +544,6 @@ struct ReviewDraftSummaryRail: View {
                     .accessibilityIdentifier("review-draft-summary-editor-\(comment.id)")
             } else {
                 DiffReviewInlineFeedbackMarkdown.view(comment.bodyMarkdown)
-                    .allowsHitTesting(false)
             }
         }
         .frame(maxWidth: .infinity, alignment: .leading)

--- a/Alas/Sources/Center/ReviewWorkspace/ReviewDraftSummaryRail.swift
+++ b/Alas/Sources/Center/ReviewWorkspace/ReviewDraftSummaryRail.swift
@@ -544,6 +544,8 @@ struct ReviewDraftSummaryRail: View {
                     .accessibilityIdentifier("review-draft-summary-editor-\(comment.id)")
             } else {
                 DiffReviewInlineFeedbackMarkdown.view(comment.bodyMarkdown)
+                    .frame(maxHeight: 80, alignment: .top)
+                    .clipped()
             }
         }
         .frame(maxWidth: .infinity, alignment: .leading)

--- a/Alas/Sources/Center/ReviewWorkspace/ReviewDraftSummaryRail.swift
+++ b/Alas/Sources/Center/ReviewWorkspace/ReviewDraftSummaryRail.swift
@@ -544,6 +544,7 @@ struct ReviewDraftSummaryRail: View {
                     .accessibilityIdentifier("review-draft-summary-editor-\(comment.id)")
             } else {
                 DiffReviewInlineFeedbackMarkdown.view(comment.bodyMarkdown)
+                    .allowsHitTesting(false)
             }
         }
         .frame(maxWidth: .infinity, alignment: .leading)

--- a/Alas/Sources/Center/ReviewWorkspace/ReviewDraftSummaryRail.swift
+++ b/Alas/Sources/Center/ReviewWorkspace/ReviewDraftSummaryRail.swift
@@ -543,11 +543,7 @@ struct ReviewDraftSummaryRail: View {
                     .clipShape(RoundedRectangle(cornerRadius: 5))
                     .accessibilityIdentifier("review-draft-summary-editor-\(comment.id)")
             } else {
-                Text(DiffReviewInlineFeedbackMarkdown.render(comment.bodyMarkdown))
-                    .font(.system(size: 11.5))
-                    .foregroundColor(theme.color("fg"))
-                    .lineLimit(4)
-                    .fixedSize(horizontal: false, vertical: true)
+                DiffReviewInlineFeedbackMarkdown.view(comment.bodyMarkdown)
             }
         }
         .frame(maxWidth: .infinity, alignment: .leading)

--- a/AlasTests/DiffReviewSurfaceTests.swift
+++ b/AlasTests/DiffReviewSurfaceTests.swift
@@ -1267,7 +1267,7 @@ struct DiffReviewSurfaceTests {
     @MainActor
     @Test func inlineFeedbackMarkdownRendersCommonReviewMarkup() throws {
         let rendered = NSAttributedString(
-            DiffReviewInlineFeedbackMarkdown.render("Use **bold** and `configId`, then see [docs](https://example.com/docs).")
+            ACPMarkdownText.inlineMarkdown("Use **bold** and `configId`, then see [docs](https://example.com/docs).")
         )
 
         #expect(rendered.string == "Use bold and configId, then see docs.")


### PR DESCRIPTION
## Summary

- Replace `DiffReviewInlineFeedbackMarkdown.render()` (inline-only `AttributedString` via `ACPMarkdownText.inlineMarkdown`) with a `view()` method returning `ACPMarkdownText` at 11pt typography
- Diff inline feedback cards (`DiffReviewInlineFeedbackCard`, `ReviewDraftCommentCard`) now render full block-level markdown: headings, code blocks, blockquotes, tables, and inline formatting
- Feedback rail (`ReviewDraftSummaryRail`) also upgraded; the previous `lineLimit(4)` is dropped since the rail lives inside a `ScrollView`

## Test plan

- [ ] Open a PR with inline review comments that contain markdown (code fences, bold, headings) — verify they render correctly in the diff view
- [ ] Open a PR with local draft comments containing markdown — verify block-level rendering in both the inline card and the summary rail
- [ ] Verify accessibility labels still work (plainText path is unchanged)
- [ ] Check that plain-text comments (no markdown) still render correctly