### PR TITLE
feat(worktree): Increase worktree remove timeout to 90 seconds

### DIFF
--- a/Alas/Sources/Git/WorktreeService.swift
+++ b/Alas/Sources/Git/WorktreeService.swift
@@ -233,10 +233,10 @@ struct WorktreeService {
     ) async throws {
         var args = ["worktree", "remove", worktree.path.path]
         if force { args.append("--force") }
-        var result = try await Process.git(args, cwd: repoPath)
+        var result = try await Process.git(args, cwd: repoPath, timeout: 90)
         if result.exitCode != 0 {
             if Self.looksLikeMissingLFS(result.stderr) {
-                result = try await Process.git(Self.lfsFilterOverride + args, cwd: repoPath)
+                result = try await Process.git(Self.lfsFilterOverride + args, cwd: repoPath, timeout: 90)
             }
             if !force,
                result.exitCode != 0,
@@ -244,7 +244,8 @@ struct WorktreeService {
                try await canForceRemoveAfterMissingLFS(worktree.path) {
                 result = try await Process.git(
                     Self.lfsFilterOverride + ["worktree", "remove", worktree.path.path, "--force"],
-                    cwd: repoPath
+                    cwd: repoPath,
+                    timeout: 90
                 )
             }
         }


### PR DESCRIPTION
## Summary

- Increase the timeout for `git worktree remove` operations from the default 30 seconds to 90 seconds in `WorktreeService.remove(...)`.

## Test plan

- [x] `xcodegen` regenerated the project successfully.
- [x] `xcodebuild build` passed (exit 0, warnings only).
- [x] Focused `xcodebuild test -only-testing:AlasTests/WorktreeServiceTests` passed: 32/32 tests.
- [x] No test updates were needed — the existing suite does not assert on timeout values.