### PR TITLE
feat(remote): highlight active remote sessions

### DIFF
--- a/Alas/Resources/RemoteWeb/app.js
+++ b/Alas/Resources/RemoteWeb/app.js
@@ -207,14 +207,24 @@ function handle(msg) {
 function renderSessions(sessions) {
   const list = $("session-list"); list.innerHTML = "";
   sessionTitles = new Map(sessions.map(s => [s.id, s.title]));
-  sessions.forEach(s => list.appendChild(renderSessionRow(s)));
+  sortedSessions(sessions).forEach(s => list.appendChild(renderSessionRow(s)));
   if (currentSession) setDetailTitle(currentSession);
+}
+
+function sortedSessions(sessions) {
+  return [...sessions].sort((a, b) => Number(sessionIsActive(b)) - Number(sessionIsActive(a)));
+}
+
+function sessionIsActive(session) {
+  return session.isActive !== false;
 }
 
 function renderSessionRow(s) {
   const row = document.createElement("div");
   row.dataset.sessionId = s.id;
   row.className = "session-row";
+  const active = sessionIsActive(s);
+  row.classList.add(active ? "session-row-active" : "session-row-inactive");
 
   const open = document.createElement("button");
   open.type = "button";
@@ -223,8 +233,9 @@ function renderSessionRow(s) {
 
   const head = el("div", "session-head");
   const title = el("span", "session-title", s.title);
+  const state = el("span", active ? "session-state session-state-active" : "session-state session-state-inactive", active ? "Active" : "Closed");
   const status = el("span", "status", s.status);
-  head.append(title, status);
+  head.append(title, state, status);
   open.append(head);
 
   const rename = el("button", "rename-btn", "✎");

--- a/Alas/Resources/RemoteWeb/index.html
+++ b/Alas/Resources/RemoteWeb/index.html
@@ -11,7 +11,7 @@
   <link rel="icon" href="/icon.svg" type="image/svg+xml" />
   <link rel="apple-touch-icon" href="/icon-180.png" />
   <title>Alas Remote</title>
-  <link rel="stylesheet" href="/style.css?v=31" />
+  <link rel="stylesheet" href="/style.css?v=32" />
 </head>
 <body>
   <header id="bar">
@@ -118,7 +118,7 @@
   </div>
   <script src="/marked.min.js?v=28"></script>
   <script src="/purify.min.js?v=28"></script>
-  <script src="/app.js?v=46"></script>
+  <script src="/app.js?v=47"></script>
   <script>
     if ("serviceWorker" in navigator) {
       window.addEventListener("load", () => {

--- a/Alas/Resources/RemoteWeb/style.css
+++ b/Alas/Resources/RemoteWeb/style.css
@@ -60,10 +60,20 @@ h1 { font-size: 22px; font-weight: 700; margin: 12px 4px 10px; }
 .session-open { flex: 1; min-width: 0; border: none; background: none; color: inherit; font: inherit; text-align: left; padding: 0; cursor: pointer; -webkit-tap-highlight-color: transparent; }
 .session-open:focus-visible { outline: 1.5px solid var(--accent); outline-offset: 2px; }
 .session-row-card { padding: 12px; border: 0.5px solid var(--line); border-radius: 10px; background: color-mix(in oklab, var(--bg-2) 54%, transparent); }
+.session-row-active.session-row-card { border-color: color-mix(in oklab, var(--accent) 45%, var(--line)); background: color-mix(in oklab, var(--bg-3) 70%, transparent); box-shadow: inset 3px 0 0 color-mix(in oklab, var(--accent) 78%, transparent); }
+.session-row-inactive { opacity: 0.58; }
+.session-row-inactive.session-row-card { background: color-mix(in oklab, var(--bg-2) 30%, transparent); }
 .session-row-card:has(.session-open:active) { background: var(--bg-3); }
 .session-head { display: flex; align-items: center; gap: 8px; min-width: 0; }
 .session-title { flex: 1; min-width: 0; font-size: 15px; font-weight: 650; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.session-state { flex: 0 0 auto; display: inline-flex; align-items: center; gap: 4px; padding: 2px 6px; border-radius: 999px; font-size: 10.5px; font-weight: 700; line-height: 1.2; white-space: nowrap; }
+.session-state::before { content: ""; width: 6px; height: 6px; border-radius: 50%; flex: 0 0 auto; }
+.session-state-active { color: var(--fg); background: color-mix(in oklab, var(--accent) 20%, transparent); border: 0.5px solid color-mix(in oklab, var(--accent) 48%, transparent); }
+.session-state-active::before { background: var(--add); box-shadow: 0 0 7px color-mix(in oklab, var(--add) 75%, transparent); }
+.session-state-inactive { color: var(--fg-dim); background: color-mix(in oklab, var(--bg-3) 45%, transparent); border: 0.5px solid var(--line-soft); }
+.session-state-inactive::before { background: var(--fg-faint); }
 .session-row .status { color: var(--accent); font-size: 11px; flex-shrink: 0; white-space: nowrap; }
+.session-row-inactive .status { color: var(--fg-dim); }
 .session-worktree { margin-top: 6px; color: var(--fg-muted); font-size: 12px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
 .session-meta { margin-top: 9px; display: flex; flex-wrap: wrap; gap: 8px; color: var(--fg-dim); font-size: 11px; line-height: 1.3; }
 .session-meta span { min-width: 0; }
@@ -73,6 +83,7 @@ h1 { font-size: 22px; font-weight: 700; margin: 12px 4px 10px; }
 .meta-conflict { color: oklch(0.82 0.13 90); }
 .session-row-minimal { justify-content: space-between; align-items: center; gap: 10px; padding: 15px 10px; border-bottom: 0.5px solid var(--line-soft); background: none; }
 .session-row-minimal .session-head { flex: 1; }
+.session-row-active.session-row-minimal { background: color-mix(in oklab, var(--accent) 8%, transparent); }
 .session-row-minimal:has(.session-open:active) { background: var(--bg-2); }
 #back { background: none; border: none; color: var(--accent); font-size: 15px; padding: 4px 2px; margin: -4px 0; cursor: pointer; -webkit-tap-highlight-color: transparent; }
 .rename-btn { flex: 0 0 auto; width: 30px; height: 30px; border: none; border-radius: 50%; display: inline-flex; align-items: center; justify-content: center; background: color-mix(in oklab, var(--bg-3) 64%, transparent); color: var(--fg-muted); font-size: 15px; cursor: pointer; -webkit-tap-highlight-color: transparent; }

--- a/Alas/Resources/RemoteWeb/sw.js
+++ b/Alas/Resources/RemoteWeb/sw.js
@@ -1,9 +1,9 @@
-const CACHE_NAME = "alas-remote-shell-v22";
+const CACHE_NAME = "alas-remote-shell-v23";
 const SHELL_ASSETS = [
   "/",
   "/index.html",
-  "/style.css?v=31",
-  "/app.js?v=46",
+  "/style.css?v=32",
+  "/app.js?v=47",
   "/marked.min.js?v=28",
   "/purify.min.js?v=28",
   "/manifest.webmanifest",

--- a/Alas/Sources/App/AppState.swift
+++ b/Alas/Sources/App/AppState.swift
@@ -3481,7 +3481,7 @@ extension AppState: RemoteSessionsProvider {
                     row: effectiveRow,
                     status: state.map(RemoteSessionGateway.stateString) ?? "idle",
                     hasRunner: state != nil,
-                    isLive: liveSession != nil,
+                    isActive: hasOpenACPSessionTab(worktreeId: mgr.worktreeId, sessionId: row.id),
                     canDrive: mgr.isWriter(for: row.id),
                     worktree: worktreeSummary
                 )
@@ -3497,6 +3497,15 @@ extension AppState: RemoteSessionsProvider {
         return identities.compactMap { summariesByIdentity[$0]?.summary }
     }
 
+    private func hasOpenACPSessionTab(worktreeId: String, sessionId: ACPSession.ID) -> Bool {
+        tabs.tabs(forWorktree: worktreeId).contains { tab in
+            if case .acpSession(let state) = tab {
+                return state.sessionId == sessionId
+            }
+            return false
+        }
+    }
+
     private func remoteSessionListIdentity(worktreeId: String, row: ACPSessionRow) -> String {
         if let remoteSessionId = row.remoteSessionId?.trimmingCharacters(in: .whitespacesAndNewlines),
            !remoteSessionId.isEmpty {
@@ -3510,7 +3519,7 @@ extension AppState: RemoteSessionsProvider {
         var displayRow: ACPSessionRow
         var status: String
         var hasRunner: Bool
-        var isLive: Bool
+        var isActive: Bool
         var canDrive: Bool
         let worktree: RemoteWorktreeSummary?
 
@@ -3518,7 +3527,7 @@ extension AppState: RemoteSessionsProvider {
             row: ACPSessionRow,
             status: String,
             hasRunner: Bool,
-            isLive: Bool,
+            isActive: Bool,
             canDrive: Bool,
             worktree: RemoteWorktreeSummary?
         ) {
@@ -3526,7 +3535,7 @@ extension AppState: RemoteSessionsProvider {
             self.displayRow = row
             self.status = status
             self.hasRunner = hasRunner
-            self.isLive = isLive
+            self.isActive = isActive
             self.canDrive = canDrive
             self.worktree = worktree
         }
@@ -3538,6 +3547,7 @@ extension AppState: RemoteSessionsProvider {
                 agentId: operationalRow.agentId,
                 status: status,
                 canDrive: canDrive,
+                isActive: isActive,
                 worktree: worktree
             )
         }
@@ -3548,7 +3558,7 @@ extension AppState: RemoteSessionsProvider {
                 merged.operationalRow = other.operationalRow
                 merged.status = other.status
                 merged.hasRunner = other.hasRunner
-                merged.isLive = other.isLive
+                merged.isActive = other.isActive
                 merged.canDrive = other.canDrive
             }
             if Self.isBetterDisplayRow(other.displayRow, than: merged.displayRow) {
@@ -3560,7 +3570,7 @@ extension AppState: RemoteSessionsProvider {
         private func isBetterOperationalRow(than other: RemoteSessionSummaryCandidate) -> Bool {
             if canDrive != other.canDrive { return canDrive }
             if hasRunner != other.hasRunner { return hasRunner }
-            if isLive != other.isLive { return isLive }
+            if isActive != other.isActive { return isActive }
             if operationalRow.lastOpenedAt != other.operationalRow.lastOpenedAt {
                 return operationalRow.lastOpenedAt > other.operationalRow.lastOpenedAt
             }

--- a/Alas/Sources/Remote/Protocol/RemoteMessageWireJSON.swift
+++ b/Alas/Sources/Remote/Protocol/RemoteMessageWireJSON.swift
@@ -50,12 +50,13 @@ enum RemoteCreateSessionResult: Equatable, Sendable {
     case failure(String)
 }
 
-struct RemoteSessionSummary: Codable, Equatable, Sendable {
+struct RemoteSessionSummary: Equatable, Sendable {
     let id: String
     let title: String
     let agentId: String
     let status: String       // "idle" | "streaming" | "awaitingPermission" | "awaitingInput"
     let canDrive: Bool       // this remote-host instance currently holds the writer lease
+    let isActive: Bool       // still backed by an open Alas tab
     let worktree: RemoteWorktreeSummary?
 
     init(
@@ -64,6 +65,7 @@ struct RemoteSessionSummary: Codable, Equatable, Sendable {
         agentId: String,
         status: String,
         canDrive: Bool,
+        isActive: Bool = true,
         worktree: RemoteWorktreeSummary? = nil
     ) {
         self.id = id
@@ -71,7 +73,38 @@ struct RemoteSessionSummary: Codable, Equatable, Sendable {
         self.agentId = agentId
         self.status = status
         self.canDrive = canDrive
+        self.isActive = isActive
         self.worktree = worktree
+    }
+}
+
+extension RemoteSessionSummary: Codable {
+    private enum CodingKeys: String, CodingKey {
+        case id, title, agentId, status, canDrive, isActive, worktree
+    }
+
+    init(from decoder: Decoder) throws {
+        let c = try decoder.container(keyedBy: CodingKeys.self)
+        self.init(
+            id: try c.decode(String.self, forKey: .id),
+            title: try c.decode(String.self, forKey: .title),
+            agentId: try c.decode(String.self, forKey: .agentId),
+            status: try c.decode(String.self, forKey: .status),
+            canDrive: try c.decode(Bool.self, forKey: .canDrive),
+            isActive: try c.decodeIfPresent(Bool.self, forKey: .isActive) ?? true,
+            worktree: try c.decodeIfPresent(RemoteWorktreeSummary.self, forKey: .worktree)
+        )
+    }
+
+    func encode(to encoder: Encoder) throws {
+        var c = encoder.container(keyedBy: CodingKeys.self)
+        try c.encode(id, forKey: .id)
+        try c.encode(title, forKey: .title)
+        try c.encode(agentId, forKey: .agentId)
+        try c.encode(status, forKey: .status)
+        try c.encode(canDrive, forKey: .canDrive)
+        try c.encode(isActive, forKey: .isActive)
+        try c.encodeIfPresent(worktree, forKey: .worktree)
     }
 }
 

--- a/AlasTests/Remote/RemoteAppStateAccessTests.swift
+++ b/AlasTests/Remote/RemoteAppStateAccessTests.swift
@@ -139,6 +139,33 @@ struct RemoteAppStateAccessTests {
         #expect(summaries.count == 1)
         #expect(summaries.first?.id == tab.sessionId)
         #expect(summaries.first?.title == "Actual Remote Title")
+        #expect(summaries.first?.isActive == true)
+    }
+
+    @Test func remoteSessionSummariesMarkStoredRowsWithoutTabsInactive() async throws {
+        var cleanupWorktreeId: String?
+        defer {
+            if let cleanupWorktreeId {
+                cleanupRemoteRenameFiles(worktreeId: cleanupWorktreeId)
+            }
+        }
+
+        let state = makeRemoteRenameState()
+        let worktreeId = try #require(state.selectedWorktreeId)
+        cleanupWorktreeId = worktreeId
+        state.openNewACPSession(agentID: "test-agent")
+        let manager = try #require(state.acpManager(forWorktreeId: worktreeId))
+        try seedStoredSession(
+            id: "historical-\(UUID().uuidString)",
+            title: "Historical",
+            titleSource: .manual,
+            in: manager
+        )
+
+        let summaries = await state.sessionSummaries()
+        let historical = try #require(summaries.first { $0.title == "Historical" })
+
+        #expect(!historical.isActive)
     }
 
     @Test func remoteSessionSummariesPreferLivePlaceholderOverStoredDuplicate() async throws {
@@ -257,7 +284,7 @@ struct RemoteAppStateAccessTests {
         }
     }
 
-    @Test func remoteRenameSessionUpdatesNonLiveRecentSession() throws {
+    @Test func remoteRenameSessionUpdatesNonLiveRecentSession() async throws {
         var cleanupWorktreeId: String?
         defer {
             if let cleanupWorktreeId {
@@ -281,6 +308,8 @@ struct RemoteAppStateAccessTests {
             let session = try #require(manager.liveSession(for: sessionId))
             #expect(session.title == "Recent Remote")
             #expect(session.titleSource == .manual)
+            let summaries = await state.sessionSummaries()
+            #expect(summaries.first(where: { $0.id == sessionId })?.isActive == false)
         }
         do {
             let store = try ACPSessionStore(path: Paths.acpSessionsDB(forWorktreeId: worktreeId).path)

--- a/AlasTests/Remote/RemoteProtocolTests.swift
+++ b/AlasTests/Remote/RemoteProtocolTests.swift
@@ -63,7 +63,8 @@ struct RemoteProtocolTests {
             title: "Build feature",
             agentId: "claude",
             status: "idle",
-            canDrive: true
+            canDrive: true,
+            isActive: false
         )
         #expect(try roundTrip(summary) == summary)
     }
@@ -178,6 +179,13 @@ struct RemoteProtocolTests {
         let json = #"{"id":"s1","title":"T","agentId":"codex","status":"idle","canDrive":false}"#
         let decoded = try JSONDecoder().decode(RemoteSessionSummary.self, from: Data(json.utf8))
         #expect(decoded == RemoteSessionSummary(id: "s1", title: "T", agentId: "codex", status: "idle", canDrive: false))
+        #expect(decoded.isActive)
+    }
+
+    @Test func sessionSummaryDecodesInactivePayload() throws {
+        let json = #"{"id":"s1","title":"T","agentId":"codex","status":"idle","canDrive":false,"isActive":false}"#
+        let decoded = try JSONDecoder().decode(RemoteSessionSummary.self, from: Data(json.utf8))
+        #expect(decoded == RemoteSessionSummary(id: "s1", title: "T", agentId: "codex", status: "idle", canDrive: false, isActive: false))
     }
 
     @Test func transcriptDeltaRoundTrips() throws {

--- a/AlasTests/Remote/RemoteSessionGatewayTests.swift
+++ b/AlasTests/Remote/RemoteSessionGatewayTests.swift
@@ -191,6 +191,25 @@ struct RemoteSessionGatewayTests {
         #expect(sent == [.sessionList(sessions: provider.summaries)])
     }
 
+    @Test func listSessionsPreservesIsActiveFlag() async {
+        let provider = FakeSessionsProvider()
+        let active = RemoteSessionSummary(id: "active", title: "Active", agentId: "claude", status: "idle", canDrive: true, isActive: true)
+        let inactive = RemoteSessionSummary(id: "inactive", title: "Inactive", agentId: "codex", status: "idle", canDrive: false, isActive: false)
+        provider.summaries = [active, inactive]
+        var sent: [RemoteServerMessage] = []
+        let gw = RemoteSessionGateway(provider: provider) { sent.append($0) }
+        await gw.handle(.listSessions)
+        await Task.yield()
+        #expect(provider.sessionSummariesCallCount == 1)
+        guard case .sessionList(let sessions)? = sent.first else {
+            Issue.record("expected sessionList, got \(sent)")
+            return
+        }
+        #expect(sessions.count == 2)
+        #expect(sessions.first { $0.id == "active" }?.isActive == true)
+        #expect(sessions.first { $0.id == "inactive" }?.isActive == false)
+    }
+
     @Test func listWorktreesEmitsWorktreeList() async {
         let provider = FakeSessionsProvider()
         provider.worktrees = [

--- a/AlasTests/Remote/RemoteWebAssetTests.swift
+++ b/AlasTests/Remote/RemoteWebAssetTests.swift
@@ -48,11 +48,11 @@ struct RemoteWebAssetTests {
         let html = try asset("index.html")
         let sw = try asset("sw.js")
 
-        #expect(html.contains(#"/app.js?v=46"#))
-        #expect(html.contains(#"/style.css?v=31"#))
-        #expect(sw.contains(#"const CACHE_NAME = "alas-remote-shell-v22";"#))
-        #expect(sw.contains(#""/app.js?v=46""#))
-        #expect(sw.contains(#""/style.css?v=31""#))
+        #expect(html.contains(#"/app.js?v=47"#))
+        #expect(html.contains(#"/style.css?v=32"#))
+        #expect(sw.contains(#"const CACHE_NAME = "alas-remote-shell-v23";"#))
+        #expect(sw.contains(#""/app.js?v=47""#))
+        #expect(sw.contains(#""/style.css?v=32""#))
     }
 
     @Test func remoteBareURLLinkifierPreservesIndentedCodeBlocks() throws {
@@ -79,12 +79,22 @@ struct RemoteWebAssetTests {
 
         #expect(app.contains("function sessionMetaParts"))
         #expect(app.contains("function renderSessionRow"))
+        #expect(app.contains("function sortedSessions"))
+        #expect(app.contains("function sessionIsActive"))
+        #expect(app.contains(#""session-row-active""#))
+        #expect(app.contains(#""session-row-inactive""#))
+        #expect(app.contains(#""Active""#))
+        #expect(app.contains(#""Closed""#))
         #expect(app.contains(#""changes unavailable""#))
         #expect(app.contains(#""clean""#))
         #expect(css.contains(".session-row-card"))
+        #expect(css.contains(".session-row-active"))
+        #expect(css.contains(".session-row-inactive"))
+        #expect(css.contains(".session-state-active"))
+        #expect(css.contains(".session-state-inactive"))
         #expect(css.contains(".session-meta"))
-        #expect(html.contains("/app.js?v=46"))
-        #expect(html.contains("/style.css?v=31"))
+        #expect(html.contains("/app.js?v=47"))
+        #expect(html.contains("/style.css?v=32"))
     }
 
     @Test func remoteWebExposesSessionRenameControls() throws {
@@ -109,8 +119,8 @@ struct RemoteWebAssetTests {
         #expect(css.contains(".session-open"))
         #expect(css.contains("#detail-title"))
         #expect(css.contains(".sheet-input"))
-        #expect(sw.contains(#""/app.js?v=46""#))
-        #expect(sw.contains(#""/style.css?v=31""#))
+        #expect(sw.contains(#""/app.js?v=47""#))
+        #expect(sw.contains(#""/style.css?v=32""#))
     }
 
     @Test func remoteWebIncludesNewSessionControls() throws {


### PR DESCRIPTION
Adds an isActive flag to RemoteSessionSummary so the remote web UI can visually separate sessions backed by an open Alas ACP tab from those that are closed/inactive.

Changes:
- Server-side: AppState.sessionSummaries() now checks TabsManager for an open tab matching each session id.
- Wire protocol: backward-compatible RemoteSessionSummary.isActive (decodes missing as true).
- Web client: active sessions sort first, get a card accent and Active chip; inactive sessions are dimmed and labelled Closed.
- Tests for server classification, wire round-tripping, gateway pass-through, and web assets.

Closes #1205