### PR TITLE
fix(editor): stale markdown preview tab content

### DIFF
--- a/Alas/Sources/Code/Markdown/MarkdownTabView.swift
+++ b/Alas/Sources/Code/Markdown/MarkdownTabView.swift
@@ -14,8 +14,17 @@ struct MarkdownTabView: View {
     let onRevealInFiles: (String) -> Void
     @Environment(\.theme) var theme
 
-    @State private var renderResult: MarkdownRenderResult?
+    @State private var renderCache = MarkdownPreviewCache<MarkdownRenderResult>()
     @State private var debounceTask: Task<Void, Never>?
+
+    private var renderIdentity: MarkdownRenderIdentity {
+        MarkdownRenderIdentity(
+            worktreePath: worktreePath.standardizedFileURL.path,
+            tabId: tabId,
+            relativePath: relativePath,
+            externalAbsolutePath: externalAbsolutePath
+        )
+    }
 
     private var resolvedMode: MarkdownViewMode {
         appState.tabs.editorTabState(worktreeId: worktreeId, tabId: tabId)?.markdownViewMode
@@ -75,6 +84,10 @@ struct MarkdownTabView: View {
                 .accessibilityHidden(true)
         }
         .onAppear { scheduleRender(immediate: true) }
+        .onChange(of: renderIdentity) { _, _ in
+            invalidateRender()
+            scheduleRender(immediate: true)
+        }
         .onChange(of: buffer.editGeneration) { _, _ in scheduleRender(immediate: false) }
         // Re-render when the live theme or code font settings change — the
         // renderer captures those when invoked, so a stale `renderResult`
@@ -145,7 +158,7 @@ struct MarkdownTabView: View {
 
     @ViewBuilder
     private var preview: some View {
-        if let renderResult {
+        if let renderResult = renderCache.value(for: renderIdentity) {
             MarkdownPreviewView(result: renderResult, onLinkClick: handleLinkClick)
         } else {
             Color.clear.onAppear { scheduleRender(immediate: true) }
@@ -206,6 +219,8 @@ struct MarkdownTabView: View {
             return
         }
         debounceTask?.cancel()
+        let renderIdentity = self.renderIdentity
+        renderCache.beginRender(for: renderIdentity)
         let buffer = self.buffer
         let theme = self.theme
         let fontFamily = appState.config.code.fontFamily
@@ -231,8 +246,13 @@ struct MarkdownTabView: View {
                 worktreeRoot: worktreeRootOrNil
             )
             if Task.isCancelled { return }
-            renderResult = result
+            renderCache.storeCompletedRender(result, for: renderIdentity)
         }
+    }
+
+    private func invalidateRender() {
+        debounceTask?.cancel()
+        renderCache.invalidate()
     }
 
     private func handleLinkClick(_ url: URL) {
@@ -297,4 +317,41 @@ struct MarkdownTabView: View {
 
 extension Notification.Name {
     static let markdownScrollToAnchor = Notification.Name("io.nlopez.alas.markdown.scrollToAnchor")
+}
+
+struct MarkdownRenderIdentity: Equatable, Sendable {
+    let worktreePath: String
+    let tabId: TabID
+    let relativePath: String
+    let externalAbsolutePath: String?
+}
+
+struct MarkdownPreviewCache<Value> {
+    private var activeRenderIdentity: MarkdownRenderIdentity?
+    private var identity: MarkdownRenderIdentity?
+    private var value: Value?
+
+    init() {}
+
+    func value(for currentIdentity: MarkdownRenderIdentity) -> Value? {
+        identity == currentIdentity ? value : nil
+    }
+
+    mutating func beginRender(for identity: MarkdownRenderIdentity) {
+        activeRenderIdentity = identity
+    }
+
+    @discardableResult
+    mutating func storeCompletedRender(_ value: Value, for identity: MarkdownRenderIdentity) -> Bool {
+        guard activeRenderIdentity == identity else { return false }
+        self.identity = identity
+        self.value = value
+        return true
+    }
+
+    mutating func invalidate() {
+        activeRenderIdentity = nil
+        identity = nil
+        value = nil
+    }
 }

--- a/AlasTests/MarkdownViewModeTests.swift
+++ b/AlasTests/MarkdownViewModeTests.swift
@@ -15,4 +15,86 @@ struct MarkdownViewModeTests {
         #expect(MarkdownViewMode.split.rawValue == "split")
         #expect(MarkdownViewMode.preview.rawValue == "preview")
     }
+
+    @Test func previewCacheReturnsValueOnlyForMatchingIdentity() {
+        let first = MarkdownRenderIdentity(
+            worktreePath: "/repo",
+            tabId: "tab-1",
+            relativePath: "README.md",
+            externalAbsolutePath: nil
+        )
+        let second = MarkdownRenderIdentity(
+            worktreePath: "/repo",
+            tabId: "tab-2",
+            relativePath: "README.md",
+            externalAbsolutePath: nil
+        )
+        var cache = MarkdownPreviewCache<String>()
+
+        cache.beginRender(for: first)
+        cache.storeCompletedRender("first preview", for: first)
+
+        #expect(cache.value(for: first) == "first preview")
+        #expect(cache.value(for: second) == nil)
+    }
+
+    @Test func previewCacheHidesStaleFileContentForReusedMarkdownViewSlot() {
+        let readme = MarkdownRenderIdentity(
+            worktreePath: "/repo",
+            tabId: "readme-tab",
+            relativePath: "README.md",
+            externalAbsolutePath: nil
+        )
+        let changelog = MarkdownRenderIdentity(
+            worktreePath: "/repo",
+            tabId: "changelog-tab",
+            relativePath: "CHANGELOG.md",
+            externalAbsolutePath: nil
+        )
+        var cache = MarkdownPreviewCache<String>()
+
+        cache.beginRender(for: readme)
+        cache.storeCompletedRender("readme preview", for: readme)
+
+        #expect(cache.value(for: changelog) == nil)
+    }
+
+    @Test func previewCacheRejectsLateRenderCompletionAfterIdentityChanges() {
+        let readme = MarkdownRenderIdentity(
+            worktreePath: "/repo",
+            tabId: "readme-tab",
+            relativePath: "README.md",
+            externalAbsolutePath: nil
+        )
+        let changelog = MarkdownRenderIdentity(
+            worktreePath: "/repo",
+            tabId: "changelog-tab",
+            relativePath: "CHANGELOG.md",
+            externalAbsolutePath: nil
+        )
+        var cache = MarkdownPreviewCache<String>()
+
+        cache.beginRender(for: readme)
+        cache.beginRender(for: changelog)
+
+        #expect(cache.storeCompletedRender("readme preview", for: readme) == false)
+        #expect(cache.value(for: readme) == nil)
+        #expect(cache.value(for: changelog) == nil)
+    }
+
+    @Test func previewCacheInvalidateClearsStoredValue() {
+        let identity = MarkdownRenderIdentity(
+            worktreePath: "/repo",
+            tabId: "tab-1",
+            relativePath: "README.md",
+            externalAbsolutePath: nil
+        )
+        var cache = MarkdownPreviewCache<String>()
+
+        cache.beginRender(for: identity)
+        cache.storeCompletedRender("preview", for: identity)
+        cache.invalidate()
+
+        #expect(cache.value(for: identity) == nil)
+    }
 }


### PR DESCRIPTION
## Summary
- Key markdown preview render results by worktree/tab/path identity so preview-only tabs cannot reuse stale content from a previous SwiftUI view slot.
- Invalidate and re-render immediately when the active markdown render identity changes.
- Reject late async render completions after another markdown tab has become active.
- Add unit coverage for the markdown preview cache identity invariant, including stale slot reuse and late completion behavior.

## Verification
- Manual: reproduced the original issue with multiple preview-only markdown tabs in the traveler repo, then confirmed switching tabs updates preview content immediately after the fix.
- Passed: `xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -only-testing:AlasTests/MarkdownViewModeTests test`
- Passed: `xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -quiet build`
- Passed: `git diff --check`
- Attempted: `xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' test`; interrupted after ~25 minutes with the run stuck at existing `ContentSearcherTests.findsMatchesAcrossFiles()`. Sample captured locally at `/tmp/alas-full-test-hang-sample.txt`.

Note: `xcodegen` was not run because `project.yml` was unchanged and tests were added to an existing project file already present in `Alas.xcodeproj`.