### PR TITLE
feat(diff): keep diff whitespace hidden by default

### DIFF
--- a/Alas/Sources/Center/Commit/CommitEditorTabView.swift
+++ b/Alas/Sources/Center/Commit/CommitEditorTabView.swift
@@ -25,13 +25,14 @@ struct CommitEditorTabView: View {
     @State private var error: String?
     @State private var pendingDropFile: PendingCommitFileDrop?
     @State private var pendingDropHunk: PendingCommitHunkDrop?
+    @State private var showWhitespace = false
 
     @Environment(\.theme) private var theme
     private let git = GitService()
 
     private static let minPaneWidth: CGFloat = 140
     private var diffPreferences: DiffPreferenceBindings {
-        DiffPreferenceBindings(appState: appState)
+        DiffPreferenceBindings(appState: appState, showWhitespace: $showWhitespace)
     }
 
     private var dirty: Bool {

--- a/Alas/Sources/Center/Commit/CommitTabView.swift
+++ b/Alas/Sources/Center/Commit/CommitTabView.swift
@@ -22,13 +22,14 @@ struct CommitTabView: View {
 
     @State private var headerExpanded: Bool = false
     @State private var reviewSessionLaunchError: String?
+    @State private var showWhitespace = false
 
     @Environment(\.theme) private var theme
     private let git = GitService()
     private let reviewLoader = CommitReviewLoader()
 
     private var diffPreferences: DiffPreferenceBindings {
-        DiffPreferenceBindings(appState: appState)
+        DiffPreferenceBindings(appState: appState, showWhitespace: $showWhitespace)
     }
 
     static func reviewSessionTarget(

--- a/Alas/Sources/Center/Commit/DraftCommitTabView.swift
+++ b/Alas/Sources/Center/Commit/DraftCommitTabView.swift
@@ -22,12 +22,13 @@ struct DraftCommitTabView: View {
     @State private var selectedFileID: DiffReviewFileID?
     @State private var loadingSession = false
     @State private var railCollapsed = false
+    @State private var showWhitespace = false
 
     @Environment(\.theme) private var theme
     private let git = GitService()
 
     private var diffPreferences: DiffPreferenceBindings {
-        DiffPreferenceBindings(appState: appState)
+        DiffPreferenceBindings(appState: appState, showWhitespace: $showWhitespace)
     }
 
     private var trimmedSubject: String {

--- a/Alas/Sources/Center/Diff/DiffPreferenceBindings.swift
+++ b/Alas/Sources/Center/Diff/DiffPreferenceBindings.swift
@@ -2,6 +2,12 @@ import SwiftUI
 
 struct DiffPreferenceBindings {
     let appState: AppState
+    private let showWhitespaceStorage: Binding<Bool>
+
+    init(appState: AppState, showWhitespace: Binding<Bool>) {
+        self.appState = appState
+        self.showWhitespaceStorage = showWhitespace
+    }
 
     var layoutMode: Binding<DiffLayoutMode> {
         Binding(
@@ -26,13 +32,6 @@ struct DiffPreferenceBindings {
     }
 
     var showWhitespace: Binding<Bool> {
-        Binding(
-            get: { appState.config.changes.diffShowWhitespace },
-            set: { newValue in
-                guard appState.config.changes.diffShowWhitespace != newValue else { return }
-                appState.config.changes.diffShowWhitespace = newValue
-                appState.saveConfig()
-            }
-        )
+        showWhitespaceStorage
     }
 }

--- a/Alas/Sources/Center/DiffTabView.swift
+++ b/Alas/Sources/Center/DiffTabView.swift
@@ -43,6 +43,7 @@ struct DiffTabView: View {
     @State private var pendingDraftAnchor: DiffReviewLineAnchor?
     @State private var pendingDraftBody = ""
     @State private var reviewExpandedCollapsedRowIDs: Set<String> = []
+    @State private var showWhitespace = false
     @FocusState private var draftComposerFocused: Bool
 
     private let git = GitService()
@@ -161,7 +162,7 @@ struct DiffTabView: View {
     }
 
     private var diffPreferences: DiffPreferenceBindings {
-        DiffPreferenceBindings(appState: appState)
+        DiffPreferenceBindings(appState: appState, showWhitespace: $showWhitespace)
     }
 
     private var lspContext: DiffPaneLSPContext? {

--- a/Alas/Sources/Center/Review/ReviewTabView.swift
+++ b/Alas/Sources/Center/Review/ReviewTabView.swift
@@ -23,6 +23,7 @@ struct ReviewTabView: View {
     @State private var errorMessage: String? = nil
     @State private var pendingReview: PendingReview?
     @State private var showVerdictSheet = false
+    @State private var showWhitespace = false
 
     var body: some View {
         VStack(spacing: 0) {
@@ -582,7 +583,7 @@ struct ReviewTabView: View {
     }
 
     private var diffPreferences: DiffPreferenceBindings {
-        DiffPreferenceBindings(appState: appState)
+        DiffPreferenceBindings(appState: appState, showWhitespace: $showWhitespace)
     }
 
     // MARK: - Verdict submission

--- a/Alas/Sources/Center/ReviewChanges/ReviewChangesTabView.swift
+++ b/Alas/Sources/Center/ReviewChanges/ReviewChangesTabView.swift
@@ -91,6 +91,7 @@ struct ReviewChangesTabView: View {
     @State private var activeLoadKey: String?
     @State private var activeLoadID = UUID()
     @State private var reviewSessionLaunchError: String?
+    @State private var showWhitespace = false
 
     var body: some View {
         VStack(spacing: 0) {
@@ -447,7 +448,7 @@ struct ReviewChangesTabView: View {
     }
 
     private var diffPreferences: DiffPreferenceBindings {
-        DiffPreferenceBindings(appState: appState)
+        DiffPreferenceBindings(appState: appState, showWhitespace: $showWhitespace)
     }
 
     private var reviewFeedbackAgentSender: ReviewFeedbackAgentSender {

--- a/Alas/Sources/Center/ReviewRequest/DraftReviewRequestTabView.swift
+++ b/Alas/Sources/Center/ReviewRequest/DraftReviewRequestTabView.swift
@@ -28,6 +28,7 @@ struct DraftReviewRequestTabView: View {
     @State private var draftCommentScrollController = DiffReviewDraftCommentScrollController()
     @State private var generation: Task<Void, Never>? = nil
     @State private var reviewSessionLaunchError: String?
+    @State private var showWhitespace = false
 
     @Environment(\.theme) private var theme
     @FocusState private var focused: Field?
@@ -73,7 +74,7 @@ struct DraftReviewRequestTabView: View {
     }
 
     private var diffPreferences: DiffPreferenceBindings {
-        DiffPreferenceBindings(appState: appState)
+        DiffPreferenceBindings(appState: appState, showWhitespace: $showWhitespace)
     }
 
     var body: some View {

--- a/Alas/Sources/Center/ReviewWorkspace/ReviewSessionTabView.swift
+++ b/Alas/Sources/Center/ReviewWorkspace/ReviewSessionTabView.swift
@@ -348,17 +348,16 @@ struct ReviewSessionTabView: View {
 
     private var layoutModeBinding: Binding<DiffLayoutMode> {
         guard let appState else { return $localLayoutMode }
-        return DiffPreferenceBindings(appState: appState).layoutMode
+        return DiffPreferenceBindings(appState: appState, showWhitespace: $localShowWhitespace).layoutMode
     }
 
     private var wrapLinesBinding: Binding<Bool> {
         guard let appState else { return $localWrapLines }
-        return DiffPreferenceBindings(appState: appState).wrapLines
+        return DiffPreferenceBindings(appState: appState, showWhitespace: $localShowWhitespace).wrapLines
     }
 
     private var showWhitespaceBinding: Binding<Bool> {
-        guard let appState else { return $localShowWhitespace }
-        return DiffPreferenceBindings(appState: appState).showWhitespace
+        $localShowWhitespace
     }
 
     private func makeLSPContext(_ file: DiffReviewFileSectionModel) -> DiffPaneLSPContext? {

--- a/AlasTests/DiffPaneViewTests.swift
+++ b/AlasTests/DiffPaneViewTests.swift
@@ -842,20 +842,31 @@ let second = true
         #expect(scrollView.contentView.frame.minX >= rulerWidth - 0.5)
     }
 
-    @Test func diffPreferenceBindingsPersistChanges() {
+    @Test func diffPreferenceBindingsPersistLayoutAndWrapButKeepWhitespaceLocal() {
         let appState = AppState()
         appState.config.changes.diffLayoutMode = .split
         appState.config.changes.diffWrapLines = false
-        appState.config.changes.diffShowWhitespace = false
+        appState.config.changes.diffShowWhitespace = true
+        var firstWhitespace = false
+        var secondWhitespace = false
 
-        let bindings = DiffPreferenceBindings(appState: appState)
-        bindings.layoutMode.wrappedValue = .stacked
-        bindings.wrapLines.wrappedValue = true
-        bindings.showWhitespace.wrappedValue = true
+        let first = DiffPreferenceBindings(
+            appState: appState,
+            showWhitespace: Binding(get: { firstWhitespace }, set: { firstWhitespace = $0 })
+        )
+        first.layoutMode.wrappedValue = .stacked
+        first.wrapLines.wrappedValue = true
+        first.showWhitespace.wrappedValue = true
+        let second = DiffPreferenceBindings(
+            appState: appState,
+            showWhitespace: Binding(get: { secondWhitespace }, set: { secondWhitespace = $0 })
+        )
 
         #expect(appState.config.changes.diffLayoutMode == .stacked)
         #expect(appState.config.changes.diffWrapLines == true)
         #expect(appState.config.changes.diffShowWhitespace == true)
+        #expect(first.showWhitespace.wrappedValue == true)
+        #expect(second.showWhitespace.wrappedValue == false)
     }
 
     @Test func collapsedContextControllerTogglesHiddenRows() throws {


### PR DESCRIPTION
## Summary
- keep the diff whitespace/paragraph toggle as local per-screen state
- leave layout and wrap preferences persisted
- add regression coverage for local whitespace defaults

## Verification
- `rtk xcodegen`
- `rtk xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -quiet build`
- `rtk xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -only-testing:AlasTests/DiffPaneViewTests test`

Full `rtk xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' test` was run twice and both runs failed only in `GitHubCLIProviderVerdictTests.startReviewFetchesPRNodeIDThenCallsAddPullRequestReview` with `headSHA unavailable`; that test passed in isolation.