### PR TITLE
fix(remote): web tool rows on mobile

### DIFF
--- a/Alas/Resources/RemoteWeb/app.js
+++ b/Alas/Resources/RemoteWeb/app.js
@@ -1532,6 +1532,13 @@ function singleLine(value) {
   return (value || "").replace(/\s+/g, " ").trim();
 }
 
+function handleCardToggleKeydown(event) {
+  if (event.key !== "Enter" && event.key !== " ") return;
+  event.preventDefault();
+  const card = event.currentTarget.closest(".m-collapsible");
+  if (card) setCardOpen(card, !card.classList.contains("is-open"));
+}
+
 function toolGlyph(verb) {
   const v = (verb || "").toLowerCase();
   if (v === "read") return "□";
@@ -1543,20 +1550,22 @@ function toolGlyph(verb) {
 
 function structCard(verb, name, body, preview) {
   const d = el("div", "msg m-tool m-collapsible");
-  const button = el("button", "tool-toggle");
-  button.type = "button";
-  button.dataset.cardToggle = "true";
-  button.setAttribute("aria-expanded", "false");
-  button.append(el("span", "tool-glyph", toolGlyph(verb)));
-  button.append(el("span", "tool-verb", verb));
-  button.append(el("span", "tool-name", name || ""));
-  button.append(el("span", "tool-preview", preview || ""));
-  button.append(el("span", "tool-chev", "⌄"));
+  const toggle = el("div", "tool-toggle");
+  toggle.dataset.cardToggle = "true";
+  toggle.setAttribute("role", "button");
+  toggle.setAttribute("aria-expanded", "false");
+  toggle.tabIndex = 0;
+  toggle.append(el("span", "tool-glyph", toolGlyph(verb)));
+  toggle.append(el("span", "tool-verb", verb));
+  toggle.append(el("span", "tool-name", name || ""));
+  toggle.append(el("span", "tool-preview", preview || ""));
+  toggle.append(el("span", "tool-chev", "⌄"));
   const content = el("pre", "tool-body", body || "");
   content.dataset.cardBody = "true";
   content.hidden = true;
-  button.onclick = () => setCardOpen(d, !d.classList.contains("is-open"));
-  d.append(button, content);
+  toggle.onclick = () => setCardOpen(d, !d.classList.contains("is-open"));
+  toggle.onkeydown = handleCardToggleKeydown;
+  d.append(toggle, content);
   return d;
 }
 

--- a/Alas/Resources/RemoteWeb/index.html
+++ b/Alas/Resources/RemoteWeb/index.html
@@ -11,7 +11,7 @@
   <link rel="icon" href="/icon.svg" type="image/svg+xml" />
   <link rel="apple-touch-icon" href="/icon-180.png" />
   <title>Alas Remote</title>
-  <link rel="stylesheet" href="/style.css?v=32" />
+  <link rel="stylesheet" href="/style.css?v=33" />
 </head>
 <body>
   <header id="bar">
@@ -118,7 +118,7 @@
   </div>
   <script src="/marked.min.js?v=28"></script>
   <script src="/purify.min.js?v=28"></script>
-  <script src="/app.js?v=47"></script>
+  <script src="/app.js?v=48"></script>
   <script>
     if ("serviceWorker" in navigator) {
       window.addEventListener("load", () => {

--- a/Alas/Resources/RemoteWeb/style.css
+++ b/Alas/Resources/RemoteWeb/style.css
@@ -129,6 +129,7 @@ h1 { font-size: 22px; font-weight: 700; margin: 12px 4px 10px; }
 .m-tool { align-self: stretch; color: var(--fg); background: color-mix(in oklab, var(--bg-1) 60%, transparent); border: 0.5px solid var(--line); border-radius: 8px; margin: 5px 0; overflow: hidden; }
 .m-tool.is-open { border-color: var(--bg-4); }
 .tool-toggle { appearance: none; -webkit-appearance: none; width: 100%; min-height: 36px; border: none; background: none; color: var(--fg); font: inherit; cursor: pointer; display: flex; align-items: center; gap: 8px; padding: 8px 10px; text-align: left; -webkit-tap-highlight-color: transparent; }
+.tool-toggle:focus-visible { outline: 1.5px solid var(--accent); outline-offset: -2px; }
 .tool-glyph { flex: 0 0 18px; width: 18px; height: 18px; border-radius: 4px; display: inline-flex; align-items: center; justify-content: center; background: color-mix(in oklab, var(--bg-0) 80%, transparent); color: var(--accent); font-family: ui-monospace, monospace; font-size: 12px; font-weight: 700; }
 .tool-verb { flex-shrink: 0; font-size: 10px; font-weight: 700; letter-spacing: .6px; text-transform: uppercase; color: var(--accent); }
 .tool-name { color: var(--fg-muted); font-family: ui-monospace, monospace; font-size: 12px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; max-width: 42%; }

--- a/Alas/Resources/RemoteWeb/sw.js
+++ b/Alas/Resources/RemoteWeb/sw.js
@@ -1,9 +1,9 @@
-const CACHE_NAME = "alas-remote-shell-v23";
+const CACHE_NAME = "alas-remote-shell-v24";
 const SHELL_ASSETS = [
   "/",
   "/index.html",
-  "/style.css?v=32",
-  "/app.js?v=47",
+  "/style.css?v=33",
+  "/app.js?v=48",
   "/marked.min.js?v=28",
   "/purify.min.js?v=28",
   "/manifest.webmanifest",

--- a/AlasTests/Remote/RemoteWebAssetTests.swift
+++ b/AlasTests/Remote/RemoteWebAssetTests.swift
@@ -38,7 +38,7 @@ struct RemoteWebAssetTests {
         #expect(app.contains(#""toolCallId""#))
         #expect(app.contains(#""rawInput""#))
         #expect(app.contains(#""params""#))
-        #expect(app.contains(#"button.append(el("span", "tool-glyph", toolGlyph(verb)))"#))
+        #expect(app.contains(#"toggle.append(el("span", "tool-glyph", toolGlyph(verb)))"#))
         #expect(app.contains(#"preview || toolCollapsedPreview(tc)"#))
         #expect(css.contains(".tool-glyph"))
         #expect(css.contains(".tool-toggle"))
@@ -48,11 +48,28 @@ struct RemoteWebAssetTests {
         let html = try asset("index.html")
         let sw = try asset("sw.js")
 
-        #expect(html.contains(#"/app.js?v=47"#))
-        #expect(html.contains(#"/style.css?v=32"#))
-        #expect(sw.contains(#"const CACHE_NAME = "alas-remote-shell-v23";"#))
-        #expect(sw.contains(#""/app.js?v=47""#))
-        #expect(sw.contains(#""/style.css?v=32""#))
+        #expect(html.contains(#"/app.js?v=48"#))
+        #expect(html.contains(#"/style.css?v=33"#))
+        #expect(sw.contains(#"const CACHE_NAME = "alas-remote-shell-v24";"#))
+        #expect(sw.contains(#""/app.js?v=48""#))
+        #expect(sw.contains(#""/style.css?v=33""#))
+    }
+
+    @Test func remoteWebToolRowsAvoidNativeButtonRenderingOnMobileSafari() throws {
+        let app = try asset("app.js")
+        let html = try asset("index.html")
+        let sw = try asset("sw.js")
+
+        #expect(app.contains(#"const toggle = el("div", "tool-toggle")"#))
+        #expect(app.contains(#"toggle.setAttribute("role", "button")"#))
+        #expect(app.contains("toggle.tabIndex = 0"))
+        #expect(app.contains("function handleCardToggleKeydown"))
+        #expect(!app.contains(#"const button = el("button", "tool-toggle")"#))
+        #expect(html.contains(#"/app.js?v=48"#))
+        #expect(html.contains(#"/style.css?v=33"#))
+        #expect(sw.contains(#"const CACHE_NAME = "alas-remote-shell-v24";"#))
+        #expect(sw.contains(#""/app.js?v=48""#))
+        #expect(sw.contains(#""/style.css?v=33""#))
     }
 
     @Test func remoteBareURLLinkifierPreservesIndentedCodeBlocks() throws {
@@ -93,8 +110,8 @@ struct RemoteWebAssetTests {
         #expect(css.contains(".session-state-active"))
         #expect(css.contains(".session-state-inactive"))
         #expect(css.contains(".session-meta"))
-        #expect(html.contains("/app.js?v=47"))
-        #expect(html.contains("/style.css?v=32"))
+        #expect(html.contains("/app.js?v=48"))
+        #expect(html.contains("/style.css?v=33"))
     }
 
     @Test func remoteWebExposesSessionRenameControls() throws {
@@ -119,8 +136,8 @@ struct RemoteWebAssetTests {
         #expect(css.contains(".session-open"))
         #expect(css.contains("#detail-title"))
         #expect(css.contains(".sheet-input"))
-        #expect(sw.contains(#""/app.js?v=47""#))
-        #expect(sw.contains(#""/style.css?v=32""#))
+        #expect(sw.contains(#""/app.js?v=48""#))
+        #expect(sw.contains(#""/style.css?v=33""#))
     }
 
     @Test func remoteWebIncludesNewSessionControls() throws {


### PR DESCRIPTION
## Summary
- Render remote web tool rows with an ARIA button div instead of a native button to avoid mobile Safari dropping the collapsed row contents.
- Bump remote web JS/CSS cache keys so clients load the updated renderer.
- Add a remote web asset regression test for the mobile tool-row renderer.

## Verification
- `node --check Alas/Resources/RemoteWeb/app.js`
- `xcodegen`
- `git diff --check`
- `xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -quiet build`
- `xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' test -only-testing:AlasTests/RemoteWebAssetTests`
- Full `xcodebuild ... test` was run and failed with the existing order-dependent `GitHubCLIProviderVerdictTests/startReviewFetchesPRNodeIDThenCallsAddPullRequestReview()` `headSHA unavailable`; rerunning that single test passed.