### PR TITLE
fix(review): show tail of truncated CI logs and link to full run

### DIFF
--- a/Alas/Sources/Integrations/CodeHost/ReviewEvidence.swift
+++ b/Alas/Sources/Integrations/CodeHost/ReviewEvidence.swift
@@ -71,10 +71,14 @@ struct ReviewEvidenceDetail: Codable, Equatable, Sendable {
             )
         }
 
-        let prefixLength = max(0, maxLength - marker.count)
+        let suffixLength = max(0, maxLength - marker.count)
+        var truncatedBody = marker + String(body.suffix(suffixLength))
+        if let url = item.providerURL {
+            truncatedBody += "\n\n[Open full log in browser.](\(url.absoluteString))"
+        }
         return ReviewEvidenceDetail(
             item: item,
-            body: String(body.prefix(prefixLength)) + marker,
+            body: truncatedBody,
             filePath: filePath,
             line: line,
             isTruncated: true

--- a/AlasTests/Integrations/ReviewEvidenceTests.swift
+++ b/AlasTests/Integrations/ReviewEvidenceTests.swift
@@ -10,7 +10,7 @@ struct ReviewEvidenceTests {
             title: "test",
             subtitle: "CI",
             status: .failed,
-            providerURL: URL(string: "https://github.com/mrmans0n/alas/actions/runs/1/job/2")
+            providerURL: nil
         )
 
         let detail = ReviewEvidenceDetail.truncated(
@@ -21,8 +21,81 @@ struct ReviewEvidenceTests {
             maxLength: 4_000
         )
 
+        #expect(detail.body.hasPrefix("\n\n[Log truncated by Alas.]"))
         #expect(detail.body.count == 4_000)
-        #expect(detail.body.hasSuffix("\n\n[Log truncated by Alas.]"))
+        #expect(detail.isTruncated)
+    }
+
+    @Test func logDetailTruncatedTailIncludesFailure() {
+        let item = ReviewEvidenceItem(
+            id: "ci:test",
+            section: .ci,
+            title: "test",
+            subtitle: "CI",
+            status: .failed,
+            providerURL: URL(string: "https://github.com/mrmans0n/alas/actions/runs/1/job/2")
+        )
+
+        let head = String(repeating: "x", count: 8_000)
+        let tail = "BUILD FAILED: tests did not pass."
+        let detail = ReviewEvidenceDetail.truncated(
+            item: item,
+            body: head + "\n" + tail,
+            filePath: nil,
+            line: nil,
+            maxLength: 4_000
+        )
+
+        #expect(detail.body.hasPrefix("\n\n[Log truncated by Alas.]"))
+        #expect(detail.body.contains(tail))
+        #expect(!detail.body.contains(head))
+        #expect(detail.body.contains("[Open full log in browser.](https://github.com/mrmans0n/alas/actions/runs/1/job/2)"))
+        #expect(detail.isTruncated)
+    }
+
+    @Test func truncatedCILogWithProviderURLIncludesOpenLink() {
+        let url = URL(string: "https://github.com/mrmans0n/alas/actions/runs/1/job/2")!
+        let item = ReviewEvidenceItem(
+            id: "ci:test",
+            section: .ci,
+            title: "test",
+            subtitle: "CI",
+            status: .failed,
+            providerURL: url
+        )
+
+        let detail = ReviewEvidenceDetail.truncated(
+            item: item,
+            body: String(repeating: "x", count: 12_000),
+            filePath: nil,
+            line: nil,
+            maxLength: 4_000
+        )
+
+        #expect(detail.body.hasPrefix("\n\n[Log truncated by Alas.]"))
+        #expect(detail.body.hasSuffix("[Open full log in browser.](\(url.absoluteString))"))
+        #expect(detail.isTruncated)
+    }
+
+    @Test func truncatedCILogWithoutProviderURLOmitsOpenLink() {
+        let item = ReviewEvidenceItem(
+            id: "ci:test",
+            section: .ci,
+            title: "test",
+            subtitle: "CI",
+            status: .failed,
+            providerURL: nil
+        )
+
+        let detail = ReviewEvidenceDetail.truncated(
+            item: item,
+            body: String(repeating: "x", count: 12_000),
+            filePath: nil,
+            line: nil,
+            maxLength: 4_000
+        )
+
+        #expect(!detail.body.contains("Open full log in browser"))
         #expect(detail.isTruncated)
     }
 


### PR DESCRIPTION
CI evidence was keeping the prefix of long logs, which hides the failure at the end. This switches the truncated view to the suffix so the actual failure is visible, and appends a clickable Markdown link to open the full log in the browser when a provider URL is available.