### PR TITLE
feat(ui): add hover tooltips to all icon-only buttons

### DIFF
--- a/Alas/Sources/Center/Review/DiffInlineCommentCard.swift
+++ b/Alas/Sources/Center/Review/DiffInlineCommentCard.swift
@@ -272,6 +272,7 @@ struct DiffInlineCommentCard: View {
                                 .foregroundColor(.secondary)
                         }
                         .buttonStyle(.plain)
+                        .help("Edit comment")
                     }
                     if comment.viewerCanDelete {
                         Button {
@@ -282,6 +283,7 @@ struct DiffInlineCommentCard: View {
                                 .foregroundColor(.secondary)
                         }
                         .buttonStyle(.plain)
+                        .help("Delete comment")
                     }
                 }
                 Text(comment.body)

--- a/Alas/Sources/Code/LSP/Install/InstallSplitButton.swift
+++ b/Alas/Sources/Code/LSP/Install/InstallSplitButton.swift
@@ -69,6 +69,7 @@ struct InstallSplitButton: View {
         .menuIndicator(.hidden)
         .fixedSize()
         .disabled(busy)
+        .help("Choose installer")
     }
 
     private func runPrimary() {

--- a/Alas/Sources/Right/Commit/AiSplitButton.swift
+++ b/Alas/Sources/Right/Commit/AiSplitButton.swift
@@ -70,6 +70,7 @@ struct AiSplitButton: View {
             .menuStyle(.borderlessButton)
             .menuIndicator(.hidden)
             .fixedSize()
+            .help("Select AI agent")
         }
         .clipShape(RoundedRectangle(cornerRadius: 4))
     }

--- a/Alas/Sources/Right/RightPaneTabBar.swift
+++ b/Alas/Sources/Right/RightPaneTabBar.swift
@@ -33,7 +33,7 @@ struct RightPaneTabBar: View {
 
             Spacer(minLength: 8)
             trailing
-            ToolbarBtn(icon: "sidebar.right", action: onHidePane)
+            ToolbarBtn(icon: "sidebar.right", tooltip: "Hide changes pane", action: onHidePane)
         }
         .padding(.horizontal, 10).padding(.vertical, 6)
         .overlay(Divider().opacity(0.5), alignment: .bottom)

--- a/Alas/Sources/Settings/SpacesPane.swift
+++ b/Alas/Sources/Settings/SpacesPane.swift
@@ -75,10 +75,10 @@ private struct SpaceSettingsRow: View {
                     applyChanges()
                 }
                 .accessibilityLabel("Space icon for \(space.name)")
-                SpaceRowIconButton(icon: "checkmark", action: applyChanges)
+                SpaceRowIconButton(icon: "checkmark", tooltip: "Apply changes", action: applyChanges)
                     .disabled(!hasDraftChanges)
                     .accessibilityLabel("Apply changes to \(space.name) space")
-                SpaceRowIconButton(icon: "trash") {
+                SpaceRowIconButton(icon: "trash", tooltip: "Delete space") {
                     isConfirmingDelete = true
                 }
                 .disabled(!canDelete)
@@ -124,6 +124,7 @@ private struct SpaceSettingsRow: View {
 
 private struct SpaceRowIconButton: View {
     let icon: String
+    let tooltip: String
     let action: () -> Void
     @Environment(\.theme) var theme
 
@@ -139,6 +140,7 @@ private struct SpaceRowIconButton: View {
                 .clipShape(RoundedRectangle(cornerRadius: 6))
         }
         .buttonStyle(.plain)
+        .help(tooltip)
     }
 }
 

--- a/Alas/Sources/Sidebar/SidebarHeaderView.swift
+++ b/Alas/Sources/Sidebar/SidebarHeaderView.swift
@@ -11,10 +11,10 @@ struct SidebarHeaderView: View {
             TrafficLights()
             Spacer()
             HStack(alignment: .center, spacing: 2) {
-                ToolbarBtn(icon: "search", action: onSearch)
-                ToolbarBtn(icon: "folder-plus", action: onAddProject)
-                ToolbarBtn(icon: "gear", action: onSettings)
-                ToolbarBtn(icon: "sidebar.left", action: onHideSidebar)
+                ToolbarBtn(icon: "search", tooltip: "Search", action: onSearch)
+                ToolbarBtn(icon: "folder-plus", tooltip: "Add repository", action: onAddProject)
+                ToolbarBtn(icon: "gear", tooltip: "Settings", action: onSettings)
+                ToolbarBtn(icon: "sidebar.left", tooltip: "Hide sidebar", action: onHideSidebar)
             }
         }
         .padding(.horizontal, 12)
@@ -25,6 +25,7 @@ struct SidebarHeaderView: View {
 
 struct ToolbarBtn: View {
     let icon: String
+    let tooltip: String
     let action: () -> Void
     @Environment(\.theme) var theme
     @State private var hovering = false
@@ -38,5 +39,6 @@ struct ToolbarBtn: View {
         }
         .buttonStyle(.plain)
         .onHover { hovering = $0 }
+        .help(tooltip)
     }
 }


### PR DESCRIPTION
<!-- gg:managed:start -->
Add .help() to ToolbarBtn (sidebar + right pane hide buttons), the AI
agent selector caret in AiSplitButton and InstallSplitButton, the
checkmark/trash in SpacesPane, and the pencil/trash in
DiffInlineCommentCard. ToolbarBtn and SpaceRowIconButton gained a
tooltip parameter so call-sites declare intent explicitly.
<!-- gg:managed:end -->