### PR TITLE
feat(changes): review action loading states

### DIFF
--- a/Alas/Sources/Integrations/CodeHost/ReviewLoopDrawer.swift
+++ b/Alas/Sources/Integrations/CodeHost/ReviewLoopDrawer.swift
@@ -11,7 +11,8 @@ struct ReviewLoopDrawer: View {
         ReviewReadinessModel(
             snapshot: state.snapshot,
             lastError: state.lastError,
-            canOpenAgentHandoff: canOpenAgentHandoff
+            canOpenAgentHandoff: canOpenAgentHandoff,
+            inFlightAction: state.inFlightAction
         )
     }
 
@@ -107,6 +108,8 @@ struct ReviewLoopDrawer: View {
                 }
                 .buttonStyle(.plain)
                 .focusEffectDisabled()
+                .disabled(state.inFlightAction != nil)
+                .opacity(state.inFlightAction == nil ? 1 : 0.5)
                 .help("Open \(model.providerTitle ?? "review") \(requestNumberTitle)")
             }
         }
@@ -234,7 +237,13 @@ private struct ReviewReadinessActionButton: View {
     var body: some View {
         Button(action: onAction) {
             HStack(spacing: 6) {
-                Icon(name: action.iconName, size: iconSize, color: foreground)
+                if action.isInFlight {
+                    Spinner(lineWidth: 1.5, duration: 0.7)
+                        .frame(width: iconSize, height: iconSize)
+                        .accessibilityHidden(true)
+                } else {
+                    Icon(name: action.iconName, size: iconSize, color: foreground)
+                }
                 Text(action.title)
                     .font(.system(size: 11.5, weight: .semibold))
                     .lineLimit(1)
@@ -252,7 +261,7 @@ private struct ReviewReadinessActionButton: View {
         .buttonStyle(.plain)
         .focusEffectDisabled()
         .disabled(!action.isEnabled)
-        .opacity(action.isEnabled ? 1 : 0.5)
+        .opacity(action.isEnabled || action.isInFlight ? 1 : 0.5)
         .help(action.title)
     }
 

--- a/Alas/Sources/Integrations/CodeHost/ReviewLoopState.swift
+++ b/Alas/Sources/Integrations/CodeHost/ReviewLoopState.swift
@@ -18,6 +18,7 @@ final class ReviewLoopState {
     private(set) var isRefreshing: Bool = false
     private(set) var isExpanded: Bool = false
     private(set) var lastError: String?
+    private(set) var inFlightAction: ReviewReadinessActionKind?
 
     init(
         worktreePath: URL,
@@ -60,6 +61,17 @@ final class ReviewLoopState {
                 errorMessage: snapshot?.errorMessage
             )
         }
+    }
+
+    func beginAction(_ action: ReviewReadinessActionKind) -> Bool {
+        guard inFlightAction == nil else { return false }
+        inFlightAction = action
+        return true
+    }
+
+    func endAction(_ action: ReviewReadinessActionKind) {
+        guard inFlightAction == action else { return }
+        inFlightAction = nil
     }
 
     func beginLocalInspection() -> ReviewLoopRefreshAttempt {

--- a/Alas/Sources/Integrations/CodeHost/ReviewReadinessModel.swift
+++ b/Alas/Sources/Integrations/CodeHost/ReviewReadinessModel.swift
@@ -36,6 +36,19 @@ struct ReviewReadinessModel: Equatable, Sendable {
         let kind: ReviewReadinessActionKind
         let title: String
         let isEnabled: Bool
+        let isInFlight: Bool
+
+        init(
+            kind: ReviewReadinessActionKind,
+            title: String,
+            isEnabled: Bool,
+            isInFlight: Bool = false
+        ) {
+            self.kind = kind
+            self.title = title
+            self.isEnabled = isEnabled
+            self.isInFlight = isInFlight
+        }
 
         var id: ReviewReadinessActionKind { kind }
 
@@ -73,7 +86,12 @@ struct ReviewReadinessModel: Equatable, Sendable {
     let actions: [Action]
     let blockingText: String?
 
-    init(snapshot: ReviewLoopSnapshot?, lastError: String?, canOpenAgentHandoff: Bool) {
+    init(
+        snapshot: ReviewLoopSnapshot?,
+        lastError: String?,
+        canOpenAgentHandoff: Bool,
+        inFlightAction: ReviewReadinessActionKind? = nil
+    ) {
         guard let snapshot else {
             identity = "Review readiness"
             providerIconName = "branch"
@@ -82,7 +100,10 @@ struct ReviewReadinessModel: Equatable, Sendable {
             title = nil
             chips = [Chip(id: "loading", title: "Checking", tone: .accent)]
             facts = []
-            actions = [Action(kind: .refresh, title: "Refresh", isEnabled: true)]
+            actions = Self.actions(
+                [Action(kind: .refresh, title: "Refresh", isEnabled: true)],
+                applying: inFlightAction
+            )
             blockingText = lastError ?? "Review state is still loading."
             return
         }
@@ -102,16 +123,37 @@ struct ReviewReadinessModel: Equatable, Sendable {
         facts = Self.makeFacts(snapshot: snapshot, requestLabel: requestLabel)
         if lastError != nil || snapshot.errorMessage != nil {
             chips = [Chip(id: "error", title: "Needs attention", tone: .warning)]
-            actions = [Action(kind: .refresh, title: "Refresh", isEnabled: true)]
+            actions = Self.actions(
+                [Action(kind: .refresh, title: "Refresh", isEnabled: true)],
+                applying: inFlightAction
+            )
             return
         }
 
         chips = Self.makeChips(snapshot: snapshot, requestLabel: requestLabel)
-        actions = Self.makeActions(
-            snapshot: snapshot,
-            requestLabel: requestLabel,
-            canOpenAgentHandoff: canOpenAgentHandoff
+        actions = Self.actions(
+            Self.makeActions(
+                snapshot: snapshot,
+                requestLabel: requestLabel,
+                canOpenAgentHandoff: canOpenAgentHandoff
+            ),
+            applying: inFlightAction
         )
+    }
+
+    private static func actions(
+        _ actions: [Action],
+        applying inFlightAction: ReviewReadinessActionKind?
+    ) -> [Action] {
+        guard let inFlightAction else { return actions }
+        return actions.map { action in
+            Action(
+                kind: action.kind,
+                title: action.title,
+                isEnabled: false,
+                isInFlight: action.kind == inFlightAction
+            )
+        }
     }
 
     private static func providerBlockingText(_ snapshot: ReviewLoopSnapshot) -> String? {

--- a/Alas/Sources/Right/ChangesPreparationCard.swift
+++ b/Alas/Sources/Right/ChangesPreparationCard.swift
@@ -146,6 +146,7 @@ struct ChangesPreparationCard: View {
             iconName: action.iconName,
             showsDot: action.emphasis == .primary,
             isEnabled: action.isEnabled,
+            isInFlight: action.isInFlight,
             action: { onReviewRequestAction(action.kind) }
         )
         .accessibilityIdentifier("changes-preparation-review-request")
@@ -157,11 +158,18 @@ struct ChangesPreparationCard: View {
         iconName: String,
         showsDot: Bool,
         isEnabled: Bool,
+        isInFlight: Bool = false,
         action: @escaping () -> Void
     ) -> some View {
         Button(action: action) {
             HStack(spacing: 8) {
-                Icon(name: iconName, size: 11, color: theme.color("fg-dim"))
+                if isInFlight {
+                    Spinner(lineWidth: 1.5, duration: 0.7)
+                        .frame(width: 11, height: 11)
+                        .accessibilityHidden(true)
+                } else {
+                    Icon(name: iconName, size: 11, color: theme.color("fg-dim"))
+                }
                 VStack(alignment: .leading, spacing: 1) {
                     HStack(spacing: 5) {
                         Text(title)
@@ -187,7 +195,7 @@ struct ChangesPreparationCard: View {
         }
         .buttonStyle(.plain)
         .disabled(!isEnabled)
-        .opacity(isEnabled ? 1 : 0.5)
+        .opacity(isEnabled || isInFlight ? 1 : 0.5)
         .background(
             RoundedRectangle(cornerRadius: 6)
                 .fill(theme.color("bg-2").opacity(0.72))

--- a/Alas/Sources/Right/ChangesPreparationModel.swift
+++ b/Alas/Sources/Right/ChangesPreparationModel.swift
@@ -20,6 +20,7 @@ struct ChangesPreparationModel: Equatable {
         let kind: ReviewReadinessActionKind
         let title: String
         let isEnabled: Bool
+        let isInFlight: Bool
         let iconName: String
         let emphasis: ReviewReadinessModel.Action.Emphasis
     }
@@ -79,12 +80,24 @@ struct ChangesPreparationModel: Equatable {
     private static func compactReviewRequestAction(
         from actions: [ReviewReadinessModel.Action]
     ) -> ReviewRequestAction? {
+        if let action = actions.first(where: { $0.isInFlight }) {
+            return ReviewRequestAction(
+                kind: action.kind,
+                title: action.title,
+                isEnabled: action.isEnabled,
+                isInFlight: action.isInFlight,
+                iconName: action.iconName,
+                emphasis: action.emphasis
+            )
+        }
+
         for kind in compactActionPriority {
             guard let action = actions.first(where: { $0.kind == kind }) else { continue }
             return ReviewRequestAction(
                 kind: action.kind,
                 title: action.title,
                 isEnabled: action.isEnabled,
+                isInFlight: action.isInFlight,
                 iconName: action.iconName,
                 emphasis: action.emphasis
             )

--- a/Alas/Sources/Right/ChangesTabView.swift
+++ b/Alas/Sources/Right/ChangesTabView.swift
@@ -20,7 +20,8 @@ struct ChangesTabView: View {
         let readiness = ReviewReadinessModel(
             snapshot: rps.reviewLoop.snapshot,
             lastError: rps.reviewLoop.lastError,
-            canOpenAgentHandoff: rps.canOpenReviewLoopHandoff(appState: appState)
+            canOpenAgentHandoff: rps.canOpenReviewLoopHandoff(appState: appState),
+            inFlightAction: rps.reviewLoop.inFlightAction
         )
         return ChangesPreparationModel(
             changes: rps.changes,

--- a/Alas/Sources/Right/RightPaneState.swift
+++ b/Alas/Sources/Right/RightPaneState.swift
@@ -249,9 +249,15 @@ final class RightPaneState {
     }
 
     func handleReviewReadinessAction(_ action: ReviewReadinessActionKind, appState: AppState) {
+        guard reviewLoop.inFlightAction == nil else { return }
+
         switch action {
         case .refresh:
-            Task { @MainActor in await refresh() }
+            guard reviewLoop.beginAction(action) else { return }
+            Task { @MainActor in
+                defer { reviewLoop.endAction(action) }
+                await refresh()
+            }
         case .openReviewRequest:
             openReviewLoopProviderPage()
         case .openAgentHandoff:
@@ -267,7 +273,9 @@ final class RightPaneState {
             )
         case .pushBranch, .forcePushBranch:
             guard let snapshot = reviewLoop.snapshot else { return }
+            guard reviewLoop.beginAction(action) else { return }
             Task { @MainActor in
+                defer { reviewLoop.endAction(action) }
                 do {
                     let result = try await Process.git(
                         Self.reviewLoopPushArguments(
@@ -290,7 +298,9 @@ final class RightPaneState {
             appState.tabs.openOrFocusDraftReviewRequest(worktreeId: worktree.id, snapshot: snapshot)
         case .rerunFailedChecks:
             guard let snapshot = reviewLoop.snapshot else { return }
+            guard reviewLoop.beginAction(action) else { return }
             Task { @MainActor in
+                defer { reviewLoop.endAction(action) }
                 if await reviewLoop.rerunFailedChecks(snapshot: snapshot) {
                     await refresh()
                 }

--- a/AlasTests/Integrations/ReviewLoopStateTests.swift
+++ b/AlasTests/Integrations/ReviewLoopStateTests.swift
@@ -5,6 +5,23 @@ import Testing
 @MainActor
 @Suite(.serialized)
 struct ReviewLoopStateTests {
+    @Test func inFlightActionRejectsConcurrentReviewActions() {
+        let state = ReviewLoopState(
+            worktreePath: URL(fileURLWithPath: "/tmp/alas-review-loop"),
+            baseBranch: "main"
+        )
+
+        #expect(state.beginAction(.pushBranch))
+        #expect(state.inFlightAction == .pushBranch)
+        #expect(!state.beginAction(.rerunFailedChecks))
+
+        state.endAction(.rerunFailedChecks)
+        #expect(state.inFlightAction == .pushBranch)
+
+        state.endAction(.pushBranch)
+        #expect(state.inFlightAction == nil)
+    }
+
     @Test func refreshBuildsInstallProviderActionWhenProviderIsMissing() async throws {
         let local = Self.makeLocal()
         let state = ReviewLoopState(

--- a/AlasTests/Integrations/ReviewReadinessModelTests.swift
+++ b/AlasTests/Integrations/ReviewReadinessModelTests.swift
@@ -30,6 +30,20 @@ struct ReviewReadinessModelTests {
         #expect(!model.actions.map(\.kind).contains(.createReviewRequest))
     }
 
+    @Test func inFlightActionDisablesReadinessActionsAndMarksRunningAction() throws {
+        let model = ReviewReadinessModel(
+            snapshot: Self.makeSnapshot(local: Self.makeLocal(needsPush: true), reviewRequest: nil),
+            lastError: nil,
+            canOpenAgentHandoff: false,
+            inFlightAction: .pushBranch
+        )
+
+        let push = try #require(model.actions.first { $0.kind == .pushBranch })
+        #expect(push.isInFlight)
+        #expect(!push.isEnabled)
+        #expect(model.actions.allSatisfy { !$0.isEnabled })
+    }
+
     @Test func divergedBranchExposesForcePushInsteadOfNormalPush() {
         let model = ReviewReadinessModel(
             snapshot: Self.makeSnapshot(local: Self.makeLocal(needsPush: true, upstreamAheadCommitCount: 3), reviewRequest: nil),

--- a/AlasTests/ReviewChangesModelsTests.swift
+++ b/AlasTests/ReviewChangesModelsTests.swift
@@ -353,6 +353,57 @@ struct ReviewChangesModelsTests {
         #expect(reviewRequest.title == "Push")
     }
 
+    @Test func preparationModelPreservesInFlightReviewRequestAction() throws {
+        let actions = [
+            ReviewReadinessModel.Action(
+                kind: .pushBranch,
+                title: "Push",
+                isEnabled: false,
+                isInFlight: true
+            ),
+        ]
+
+        let model = ChangesPreparationModel(
+            changes: [],
+            hasDraft: false,
+            draftNonEmpty: false,
+            readinessActions: actions
+        )
+
+        let reviewRequest = try #require(model.reviewRequestAction)
+        #expect(reviewRequest.kind == .pushBranch)
+        #expect(!reviewRequest.isEnabled)
+        #expect(reviewRequest.isInFlight)
+    }
+
+    @Test func preparationModelPrioritizesInFlightActionOverCompactPriority() throws {
+        let actions = [
+            ReviewReadinessModel.Action(
+                kind: .rerunFailedChecks,
+                title: "Rerun",
+                isEnabled: false,
+                isInFlight: true
+            ),
+            ReviewReadinessModel.Action(
+                kind: .inspectReviewEvidence,
+                title: "Inspect",
+                isEnabled: false
+            ),
+        ]
+
+        let model = ChangesPreparationModel(
+            changes: [],
+            hasDraft: false,
+            draftNonEmpty: false,
+            readinessActions: actions
+        )
+
+        let reviewRequest = try #require(model.reviewRequestAction)
+        #expect(reviewRequest.kind == .rerunFailedChecks)
+        #expect(reviewRequest.title == "Rerun")
+        #expect(reviewRequest.isInFlight)
+    }
+
     @Test func preparationModelCanBeBuiltFromReadinessModelActions() throws {
         let readiness = ReviewReadinessModel(
             snapshot: ReviewChangesReadinessFixtures.makeSnapshot(reviewRequest: nil),

--- a/AlasTests/RightPaneStateReviewLoopPushTests.swift
+++ b/AlasTests/RightPaneStateReviewLoopPushTests.swift
@@ -34,6 +34,29 @@ struct RightPaneStateReviewLoopPushTests {
         })
     }
 
+    @Test func createReviewRequestActionNoopsWhileReviewActionIsInFlight() {
+        let worktreeId = "wt-review-request-draft-action-in-flight"
+        defer { try? FileManager.default.removeItem(at: Paths.tabsFile(forWorktreeId: worktreeId)) }
+        let appState = AppState(store: MemoryStore())
+        let worktree = Worktree(
+            id: worktreeId,
+            projectId: "p1",
+            name: "feature/pr-drafts",
+            branch: "feature/pr-drafts",
+            path: URL(fileURLWithPath: "/tmp/repo"),
+            status: .clean,
+            lastActivity: Date(timeIntervalSince1970: 0)
+        )
+        let state = RightPaneState(worktree: worktree, baseBranch: "main")
+        state.reviewLoop.setSnapshotForTests(Self.makeSnapshot())
+        #expect(state.reviewLoop.beginAction(.pushBranch))
+
+        state.handleReviewReadinessAction(.createReviewRequest, appState: appState)
+
+        #expect(appState.tabs.tabs(forWorktree: worktreeId).isEmpty)
+        #expect(state.reviewLoop.inFlightAction == .pushBranch)
+    }
+
     @Test func inspectReviewEvidenceActionNoopsWithoutReviewRequest() {
         let worktreeId = "wt-review-evidence-no-request"
         defer { try? FileManager.default.removeItem(at: Paths.tabsFile(forWorktreeId: worktreeId)) }


### PR DESCRIPTION
## Summary

- Track in-flight GitHub/GitLab review actions from the Changes tab so duplicate async operations are rejected.
- Show spinner/disabled state for running review actions in both the review drawer and the Prepare card.
- Preserve the in-flight action state through the readiness and preparation models, including compact-card Rerun state and non-list action rejection.

## Root Cause

The review drawer had a refresh spinner, but individual async actions such as Push and Rerun did not carry action-level loading state. The same action stayed visually idle and clickable while the underlying operation was still running.

## Validation

- `xcodegen`
- `xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -quiet build`
- Focused test run: `xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' test -only-testing:AlasTests/ReviewReadinessModelTests -only-testing:AlasTests/ReviewChangesModelsTests -only-testing:AlasTests/ReviewLoopStateTests/inFlightActionRejectsConcurrentReviewActions -only-testing:AlasTests/RightPaneStateReviewLoopPushTests` (55 tests)

Note: full `xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' test` was attempted before the final amend, but Xcode hung in test runner/log finalization after a long quiet period and was interrupted.