### PR TITLE
feat(updates): inline self-update from the update available sheet

### DIFF
--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -761,6 +761,7 @@
 		B7067A1BBEB1B1B5B9867BEA /* DiffPreferenceBindings.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F8435ABAF423A6F5BC28E4C /* DiffPreferenceBindings.swift */; };
 		B7542C247255B91CEC68004F /* ChatFontCatalog.swift in Sources */ = {isa = PBXBuildFile; fileRef = F2AC43D07BE4012DB52A2D1B /* ChatFontCatalog.swift */; };
 		B76AD708A9FD54304F84366A /* ImageFileType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B3F942D660C7ABA8542C77D /* ImageFileType.swift */; };
+		B785053315764F42E3601F15 /* UpdateProgressSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6FF766C79A3F9F004A513D4D /* UpdateProgressSheet.swift */; };
 		B79D01EECD92181B710D2648 /* CommitInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C01FBF2EE3668E6772CEB1D /* CommitInfo.swift */; };
 		B7D79703ABCAFBC04A0091E5 /* VisualEffectView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D97EF761C70A3AF83C00879A /* VisualEffectView.swift */; };
 		B7F78A0034B7EC38072C1116 /* AlasGhosttySmokeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 69CE1F098A251F24BC352816 /* AlasGhosttySmokeTests.swift */; };
@@ -1547,6 +1548,7 @@
 		6E8FA892877AE2FDBCD4C747 /* ShortcutResolverTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShortcutResolverTests.swift; sourceTree = "<group>"; };
 		6EB58175A9A39073E9D73F85 /* GitIgnoreServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GitIgnoreServiceTests.swift; sourceTree = "<group>"; };
 		6F0AE27D70E34430C71AAF84 /* ProviderReviewMutationController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProviderReviewMutationController.swift; sourceTree = "<group>"; };
+		6FF766C79A3F9F004A513D4D /* UpdateProgressSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UpdateProgressSheet.swift; sourceTree = "<group>"; };
 		6FFE12732C0D83715FC990A9 /* CommitsSectionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommitsSectionView.swift; sourceTree = "<group>"; };
 		7018E992654E19345D8BD723 /* ImageDiffSwipeViewTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageDiffSwipeViewTests.swift; sourceTree = "<group>"; };
 		701F837327D905FAAA0E0AF3 /* ACPConnectionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPConnectionTests.swift; sourceTree = "<group>"; };
@@ -3390,6 +3392,7 @@
 				8E8EB674A5221235F1C7594E /* SemanticVersion.swift */,
 				0CC074B85082A8BB30EEAFA5 /* UpdateAvailableSheet.swift */,
 				2763F93ADFDCDF6B31D16475 /* UpdateController.swift */,
+				6FF766C79A3F9F004A513D4D /* UpdateProgressSheet.swift */,
 				FE09B83A747269494B206F23 /* UpdateThrottle.swift */,
 			);
 			path = Updates;
@@ -4828,6 +4831,7 @@
 				443F48C0A1AF36BFAB8B61E8 /* UnionCanvasGeometry.swift in Sources */,
 				E1EEC0425D8F30D85CDB35EE /* UpdateAvailableSheet.swift in Sources */,
 				C4466064F783E6667C5FD25D /* UpdateController.swift in Sources */,
+				B785053315764F42E3601F15 /* UpdateProgressSheet.swift in Sources */,
 				EE06DE97F2DCEFAD2B48B05C /* UpdateThrottle.swift in Sources */,
 				C245DDADA1D81810E9302134 /* VerdictSheet.swift in Sources */,
 				B7D79703ABCAFBC04A0091E5 /* VisualEffectView.swift in Sources */,

--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -197,6 +197,7 @@
 		2ED82820F76F5032E4339926 /* ZmxClientTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4B3300F31455EE1BDF7BDE15 /* ZmxClientTests.swift */; };
 		2F110275F3EC46505EF4DA48 /* SettingsSaveNormalizationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9346272D3AF9A7D78067C96F /* SettingsSaveNormalizationTests.swift */; };
 		2FAA421AF3C23D27A864FDCA /* AgentBuiltins.swift in Sources */ = {isa = PBXBuildFile; fileRef = 93F451C90EC9036CA8A7A04C /* AgentBuiltins.swift */; };
+		2FAAA60EF431D109D842428F /* SelfUpdaterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EBDEF50915BACBD0C3EE36AE /* SelfUpdaterTests.swift */; };
 		2FE10FC44BD9CDBD0C969374 /* MergeBulkResolvePromptEditorWindow.swift in Sources */ = {isa = PBXBuildFile; fileRef = F61EB45499D244E44EB170BC /* MergeBulkResolvePromptEditorWindow.swift */; };
 		303E16565ECF8BDDC7A28AF1 /* ACPTopPaginationIndicator.swift in Sources */ = {isa = PBXBuildFile; fileRef = F01FD27D107E0207950F00D3 /* ACPTopPaginationIndicator.swift */; };
 		30A1BE2F8E2777CFF6460486 /* ACPConnectionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 701F837327D905FAAA0E0AF3 /* ACPConnectionTests.swift */; };
@@ -935,6 +936,7 @@
 		DD18C5FF006D18BC66964D94 /* TerminalTabView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 14087D57E96448EEF0B80BD9 /* TerminalTabView.swift */; };
 		DDAA1FF54466B7F5424D315E /* TreeSitterMarkdown in Frameworks */ = {isa = PBXBuildFile; productRef = 49F7F27A9183521F9997AF49 /* TreeSitterMarkdown */; };
 		DE41CB04CDC89D09346494A5 /* LineEndingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EB52B59655B85764D85CFB7F /* LineEndingTests.swift */; };
+		DE431266B60826A2EA3736DF /* LineBuffer.swift in Sources */ = {isa = PBXBuildFile; fileRef = C954F77AD0867F7FD39A5ED7 /* LineBuffer.swift */; };
 		DEBA25FCF25D26395BD04F73 /* EditorConflictBanner.swift in Sources */ = {isa = PBXBuildFile; fileRef = BFD267BE3F08611B376F3CC7 /* EditorConflictBanner.swift */; };
 		DEBB0627BD0426369D18CAD4 /* FileSearchDialog.swift in Sources */ = {isa = PBXBuildFile; fileRef = F97EB3FA3E3C1206D76A9668 /* FileSearchDialog.swift */; };
 		DEC1744FA9C8A26294FF0671 /* CompletionEngineTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E0CD4F3AC6DD83BC45459475 /* CompletionEngineTests.swift */; };
@@ -1049,6 +1051,7 @@
 		FB51C37DBD897B3A690DCDC3 /* ACPNewChatEmptyStateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0CE3F0637B3CA27B1D87080 /* ACPNewChatEmptyStateTests.swift */; };
 		FB5FD89FC2800E173FC31E7A /* ACPAuthFailure.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2DCB7DA8B6EA8CF8B98EA267 /* ACPAuthFailure.swift */; };
 		FB6FF6C91476DEE43E512E30 /* RemoteServer.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1EACA79C819C9FBE68F9D84 /* RemoteServer.swift */; };
+		FB9BAF6C82A1750E41594DB7 /* SelfUpdater.swift in Sources */ = {isa = PBXBuildFile; fileRef = 69CF2E2BF116094A9FEE3F8D /* SelfUpdater.swift */; };
 		FBAB18AAEFB289EF765564C5 /* RightPaneSelectionState.swift in Sources */ = {isa = PBXBuildFile; fileRef = B15DFCD74150803355CC0A95 /* RightPaneSelectionState.swift */; };
 		FBEC59B1FD0C1DDDB6CE3100 /* RemoteNetworkTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2AF8084388AF564A1907548C /* RemoteNetworkTests.swift */; };
 		FC9BC95960AE236F82D69E0B /* ACPQuestionPrompt.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4306DE43C5ADCC65310C1169 /* ACPQuestionPrompt.swift */; };
@@ -1520,6 +1523,7 @@
 		699EA14937A07B8DDD57F401 /* OutdatedThreadsDrawer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OutdatedThreadsDrawer.swift; sourceTree = "<group>"; };
 		69B7FA3997B6A60397B56CD4 /* MergeConflictBinaryView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MergeConflictBinaryView.swift; sourceTree = "<group>"; };
 		69CE1F098A251F24BC352816 /* AlasGhosttySmokeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlasGhosttySmokeTests.swift; sourceTree = "<group>"; };
+		69CF2E2BF116094A9FEE3F8D /* SelfUpdater.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SelfUpdater.swift; sourceTree = "<group>"; };
 		69FCCEC91C40EBC896CF9089 /* AppStateOverlayTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppStateOverlayTests.swift; sourceTree = "<group>"; };
 		6A190D4B29B35C457AA9829F /* SettingsBinding.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsBinding.swift; sourceTree = "<group>"; };
 		6AF335AB8B3061C889A348B3 /* CommitDetails.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommitDetails.swift; sourceTree = "<group>"; };
@@ -1888,6 +1892,7 @@
 		C8A0A083659269CDD16A6764 /* ACPMessageTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPMessageTests.swift; sourceTree = "<group>"; };
 		C8A5CD97B6A04929595B0A9D /* CommitReviewLoaderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommitReviewLoaderTests.swift; sourceTree = "<group>"; };
 		C9126D442E8CDB093FA36BA5 /* RemoteServerPane.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteServerPane.swift; sourceTree = "<group>"; };
+		C954F77AD0867F7FD39A5ED7 /* LineBuffer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LineBuffer.swift; sourceTree = "<group>"; };
 		C96C5E43E973803E6FD1528C /* CodeHostModels.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CodeHostModels.swift; sourceTree = "<group>"; };
 		C995611A6313FABE30508248 /* WorktreeRowView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorktreeRowView.swift; sourceTree = "<group>"; };
 		C9E480C05A2AA6FF8863B7C5 /* AgentEditView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentEditView.swift; sourceTree = "<group>"; };
@@ -2038,6 +2043,7 @@
 		EBBFE202A6AB6F0EFB46EB5D /* MergeConflictTextStorage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MergeConflictTextStorage.swift; sourceTree = "<group>"; };
 		EBCC34174A7CEFA72099DDFD /* AppConfigFilesTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppConfigFilesTests.swift; sourceTree = "<group>"; };
 		EBD68C6A69930BE0F9437AAE /* RemoteMessageWireJSON.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteMessageWireJSON.swift; sourceTree = "<group>"; };
+		EBDEF50915BACBD0C3EE36AE /* SelfUpdaterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SelfUpdaterTests.swift; sourceTree = "<group>"; };
 		EBF4DE84207D33D518DD7D3E /* ACPSessionByteAccounting.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPSessionByteAccounting.swift; sourceTree = "<group>"; };
 		EC01D9A0927AF9DD7524CEB7 /* LanguageServerConfigMasonPrefill.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LanguageServerConfigMasonPrefill.swift; sourceTree = "<group>"; };
 		EC2BB41ECA8AEAB278294B8A /* ACPPlanSidebar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPPlanSidebar.swift; sourceTree = "<group>"; };
@@ -2566,6 +2572,7 @@
 				073D86784AF420D20A2149BB /* Remote */,
 				34382081666B7E8A95C0DA37 /* Settings */,
 				5FA3F5C4A99F2C74080DA0EF /* SQLiteKit */,
+				B637910FC726CC3C2C8983C1 /* Updates */,
 			);
 			path = AlasTests;
 			sourceTree = "<group>";
@@ -2776,6 +2783,7 @@
 				1B7FB431695F35CED973CDD2 /* Dialogs */,
 				2DC32361E466DA20E974D106 /* Git */,
 				B4091CAB7D0E176C8D1E112C /* Harness */,
+				E25B7A3465E9FC8D717EAE2A /* Helpers */,
 				F96AD5C7794128224DD2020B /* Icons */,
 				8E450763881EC336B91FA7E8 /* Integrations */,
 				660ED497D947CDC4ACC61892 /* JSONRPC */,
@@ -3378,6 +3386,7 @@
 				2E7E61C3BD4AD4AE3828A6F0 /* InstallSource.swift */,
 				9FF99EC1C513C5D76D690BC2 /* ReleaseChecker.swift */,
 				35004DC60214F616FA84ED8B /* ReleaseInfo.swift */,
+				69CF2E2BF116094A9FEE3F8D /* SelfUpdater.swift */,
 				8E8EB674A5221235F1C7594E /* SemanticVersion.swift */,
 				0CC074B85082A8BB30EEAFA5 /* UpdateAvailableSheet.swift */,
 				2763F93ADFDCDF6B31D16475 /* UpdateController.swift */,
@@ -3580,6 +3589,14 @@
 				932EA49288A0444FB8BB9CE3 /* PiInstaller.swift */,
 			);
 			path = Harness;
+			sourceTree = "<group>";
+		};
+		B637910FC726CC3C2C8983C1 /* Updates */ = {
+			isa = PBXGroup;
+			children = (
+				EBDEF50915BACBD0C3EE36AE /* SelfUpdaterTests.swift */,
+			);
+			path = Updates;
 			sourceTree = "<group>";
 		};
 		B746CC368DA0E9BE09E7C3A7 /* Install */ = {
@@ -3837,6 +3854,14 @@
 				650B300A5337E2A9149CF083 /* UnionCanvasGeometry.swift */,
 			);
 			path = ImageDiff;
+			sourceTree = "<group>";
+		};
+		E25B7A3465E9FC8D717EAE2A /* Helpers */ = {
+			isa = PBXGroup;
+			children = (
+				C954F77AD0867F7FD39A5ED7 /* LineBuffer.swift */,
+			);
+			path = Helpers;
 			sourceTree = "<group>";
 		};
 		E25BFA956432F729835EA7E3 /* Commit */ = {
@@ -4604,6 +4629,7 @@
 				84C505BF196A3BDA23C80235 /* LanguageServerConfigMasonPrefill.swift in Sources */,
 				C45F78462F404C64D02C413B /* LanguageServerRegistry.swift in Sources */,
 				E468E95C778E0C9BE6F1EDED /* LegacyHookSweep.swift in Sources */,
+				DE431266B60826A2EA3736DF /* LineBuffer.swift in Sources */,
 				6866301B0A6F1F7488819B98 /* LineEnding.swift in Sources */,
 				2C96C81EBF3C4B0951FA2A57 /* MarkdownFileType.swift in Sources */,
 				B3BA844FBD11333E74A05655 /* MarkdownImageLoader.swift in Sources */,
@@ -4749,6 +4775,7 @@
 				3285F4B6AB6DB5A59AE66CF5 /* SearchScope.swift in Sources */,
 				02B055E21896C1C14D2D980D /* SectionHeader.swift in Sources */,
 				D05BDEF0D8651A9C2BD8C857 /* Seg.swift in Sources */,
+				FB9BAF6C82A1750E41594DB7 /* SelfUpdater.swift in Sources */,
 				D8E808EF960CA0C10E59D44C /* SemanticVersion.swift in Sources */,
 				9C394F07FDB8E398A034B778 /* SessionRegistry.swift in Sources */,
 				2C4EDD06B2D26DCBB18DC2D1 /* SettingsBinding.swift in Sources */,
@@ -5208,6 +5235,7 @@
 				4EC689B454508C1ED77C5FB4 /* RightPaneVisibilityTests.swift in Sources */,
 				B05D6011E0FDB7AA1B016844 /* SQLiteDatabaseTests.swift in Sources */,
 				3D5FC516052D2F06781A3F6E /* SearchModelTests.swift in Sources */,
+				2FAAA60EF431D109D842428F /* SelfUpdaterTests.swift in Sources */,
 				2B4CBD06D1568EBC1BD327E0 /* SemanticVersionTests.swift in Sources */,
 				2F110275F3EC46505EF4DA48 /* SettingsSaveNormalizationTests.swift in Sources */,
 				2D6004EEFF10BA1E2B1357B9 /* SettingsSectionTests.swift in Sources */,

--- a/Alas/Sources/App/AppState.swift
+++ b/Alas/Sources/App/AppState.swift
@@ -347,6 +347,10 @@ final class AppState {
 
     let selfUpdater = SelfUpdater()
     var presentUpdateProgress = false
+    /// Set when the user taps Update in the update sheet; the progress sheet
+    /// is presented from the update sheet's `onDismiss` so the two sheets don't
+    /// conflict while the first one is still animating out.
+    var pendingSelfUpdate = false
 
     private(set) var installerHost: InstallerHost = .detect()
 

--- a/Alas/Sources/App/AppState.swift
+++ b/Alas/Sources/App/AppState.swift
@@ -342,6 +342,12 @@ final class AppState {
     // MARK: - LSP installer
 
     let lspInstaller = LSPInstaller()
+
+    // MARK: - Self updater
+
+    let selfUpdater = SelfUpdater()
+    var presentUpdateProgress = false
+
     private(set) var installerHost: InstallerHost = .detect()
 
     /// Re-detect installers after an install completes so that, e.g., installing

--- a/Alas/Sources/App/RootView.swift
+++ b/Alas/Sources/App/RootView.swift
@@ -197,8 +197,21 @@ struct RootView: View {
             UpdateAvailableSheet(
                 info: info,
                 source: state.updates.track == .nightly ? .direct : state.updates.source,
-                onDismiss: { state.updates.presentedUpdate = nil }
+                onDismiss: { state.updates.presentedUpdate = nil },
+                onRunUpdate: {
+                    state.updates.presentedUpdate = nil
+                    state.presentUpdateProgress = true
+                    Task {
+                        try? await state.selfUpdater.start(command: .homebrew)
+                    }
+                }
             )
+            .environment(\.theme, state.themeStore.current)
+        }
+        .sheet(isPresented: $state.presentUpdateProgress) {
+            UpdateProgressSheet(updater: state.selfUpdater) {
+                state.presentUpdateProgress = false
+            }
             .environment(\.theme, state.themeStore.current)
         }
         .task {

--- a/Alas/Sources/App/RootView.swift
+++ b/Alas/Sources/App/RootView.swift
@@ -193,17 +193,21 @@ struct RootView: View {
         .sheet(item: Binding(
             get: { state.updates.presentedUpdate },
             set: { state.updates.presentedUpdate = $0 }
-        )) { info in
+        ), onDismiss: {
+            guard state.pendingSelfUpdate else { return }
+            state.pendingSelfUpdate = false
+            state.presentUpdateProgress = true
+            Task {
+                try? await state.selfUpdater.start(command: .homebrew)
+            }
+        }) { info in
             UpdateAvailableSheet(
                 info: info,
                 source: state.updates.track == .nightly ? .direct : state.updates.source,
                 onDismiss: { state.updates.presentedUpdate = nil },
                 onRunUpdate: {
+                    state.pendingSelfUpdate = true
                     state.updates.presentedUpdate = nil
-                    state.presentUpdateProgress = true
-                    Task {
-                        try? await state.selfUpdater.start(command: .homebrew)
-                    }
                 }
             )
             .environment(\.theme, state.themeStore.current)

--- a/Alas/Sources/Code/LSP/Install/LSPInstaller.swift
+++ b/Alas/Sources/Code/LSP/Install/LSPInstaller.swift
@@ -297,32 +297,3 @@ final class LSPInstaller {
 
 struct InstallerBusy: Error {}
 
-/// Accumulates partial reads and yields complete lines. Trailing newline-less
-/// content is held until either more data arrives or `flush()` is called.
-private final class LineBuffer: @unchecked Sendable {
-    private let lock = NSLock()
-    private var pending: String = ""
-
-    func feed(_ chunk: String) -> [String] {
-        lock.lock()
-        defer { lock.unlock() }
-        pending += chunk
-        var out: [String] = []
-        while let newlineRange = pending.range(of: "\n") {
-            var line = String(pending[..<newlineRange.lowerBound])
-            if line.hasSuffix("\r") { line.removeLast() }
-            out.append(line)
-            pending.removeSubrange(pending.startIndex...newlineRange.lowerBound)
-        }
-        return out
-    }
-
-    func flush() -> String? {
-        lock.lock()
-        defer { lock.unlock() }
-        if pending.isEmpty { return nil }
-        let tail = pending
-        pending = ""
-        return tail
-    }
-}

--- a/Alas/Sources/Code/LSP/Install/LSPInstaller.swift
+++ b/Alas/Sources/Code/LSP/Install/LSPInstaller.swift
@@ -296,4 +296,3 @@ final class LSPInstaller {
 }
 
 struct InstallerBusy: Error {}
-

--- a/Alas/Sources/Helpers/LineBuffer.swift
+++ b/Alas/Sources/Helpers/LineBuffer.swift
@@ -1,0 +1,31 @@
+import Foundation
+
+/// Accumulates partial reads and yields complete lines. Trailing newline-less
+/// content is held until either more data arrives or `flush()` is called.
+final class LineBuffer: @unchecked Sendable {
+    private let lock = NSLock()
+    private var pending: String = ""
+
+    func feed(_ chunk: String) -> [String] {
+        lock.lock()
+        defer { lock.unlock() }
+        pending += chunk
+        var out: [String] = []
+        while let newlineRange = pending.range(of: "\n") {
+            var line = String(pending[..<newlineRange.lowerBound])
+            if line.hasSuffix("\r") { line.removeLast() }
+            out.append(line)
+            pending.removeSubrange(pending.startIndex...newlineRange.lowerBound)
+        }
+        return out
+    }
+
+    func flush() -> String? {
+        lock.lock()
+        defer { lock.unlock() }
+        if pending.isEmpty { return nil }
+        let tail = pending
+        pending = ""
+        return tail
+    }
+}

--- a/Alas/Sources/Updates/SelfUpdater.swift
+++ b/Alas/Sources/Updates/SelfUpdater.swift
@@ -43,6 +43,11 @@ final class SelfUpdater {
     private var currentProcess: Process?
     private var watchdog: Task<Void, Never>?
     private var cancelRequested = false
+    /// Identity token for the currently-tracked update. Incremented on every
+    /// spawn and on every `reset()`. The readability/termination handlers only
+    /// mutate state/logs if this still matches the spawn-time value —
+    /// otherwise a stale handler from a killed process could corrupt a new run.
+    private var generation: Int = 0
 
     /// Start the update. Requires `.idle`; otherwise throws.
     func start(command: SelfUpdateCommand) async throws {
@@ -89,6 +94,7 @@ final class SelfUpdater {
         watchdog?.cancel()
         watchdog = nil
         cancelRequested = false
+        generation &+= 1
     }
 
     /// Test seam: spawn a command directly without going through `start`.
@@ -122,6 +128,9 @@ final class SelfUpdater {
         let stdinPipe = Pipe()
         process.standardInput = stdinPipe
 
+        generation &+= 1
+        let myGeneration = generation
+
         let buffer = LineBuffer()
         pipe.fileHandleForReading.readabilityHandler = { [weak self] handle in
             let data = handle.availableData
@@ -133,7 +142,8 @@ final class SelfUpdater {
             let lines = buffer.feed(chunk)
             if lines.isEmpty { return }
             Task { @MainActor [weak self] in
-                self?.logLines.append(contentsOf: lines)
+                guard let self, self.generation == myGeneration else { return }
+                self.logLines.append(contentsOf: lines)
             }
         }
 
@@ -149,6 +159,7 @@ final class SelfUpdater {
             let finalTrailing = buffer.flush()
             Task { @MainActor [weak self] in
                 guard let self else { return }
+                guard self.generation == myGeneration else { return }
                 if !finalLines.isEmpty {
                     self.logLines.append(contentsOf: finalLines)
                 }

--- a/Alas/Sources/Updates/SelfUpdater.swift
+++ b/Alas/Sources/Updates/SelfUpdater.swift
@@ -1,0 +1,199 @@
+import Foundation
+import Observation
+
+/// Command shape for a self-update operation. For now this is always
+/// `brew upgrade --cask alas`, but wrapping it makes `SelfUpdater` testable
+/// and avoids scattering the command across views.
+struct SelfUpdateCommand: Equatable, Sendable {
+    let executable: String
+    let arguments: [String]
+
+    static let homebrew = SelfUpdateCommand(
+        executable: "/opt/homebrew/bin/brew",
+        arguments: ["upgrade", "--cask", "alas"]
+    )
+
+    var displayCommandLine: String {
+        ((executable as NSString).lastPathComponent as String) + " " + arguments.joined(separator: " ")
+    }
+}
+
+@Observable
+@MainActor
+final class SelfUpdater {
+    enum State: Equatable, Sendable {
+        case idle
+        case running(commandLine: String)
+        case finished(exitCode: Int32)
+        case cancelled
+        case failed(message: String)
+    }
+
+    private(set) var state: State = .idle
+    private(set) var logLines: [String] = []
+
+    private var currentProcess: Process?
+    private var watchdog: Task<Void, Never>?
+    private var cancelRequested = false
+
+    /// Start the update. Requires `.idle`; otherwise throws.
+    func start(command: SelfUpdateCommand) async throws {
+        guard state == .idle else {
+            throw SelfUpdaterBusy()
+        }
+        await _spawn(
+            executable: command.executable,
+            arguments: command.arguments,
+            commandLineForDisplay: command.displayCommandLine
+        )
+    }
+
+    func cancel() {
+        guard case .running = state, let process = currentProcess else { return }
+        cancelRequested = true
+        kill(process.processIdentifier, SIGINT)
+        watchdog?.cancel()
+        watchdog = Task { [weak self] in
+            try? await Task.sleep(nanoseconds: 2_000_000_000)
+            guard let self else { return }
+            await MainActor.run {
+                if case .running = self.state, let proc = self.currentProcess, proc.isRunning {
+                    proc.terminate()
+                }
+            }
+            try? await Task.sleep(nanoseconds: 3_000_000_000)
+            await MainActor.run {
+                if case .running = self.state, let proc = self.currentProcess, proc.isRunning {
+                    kill(proc.processIdentifier, SIGKILL)
+                }
+            }
+        }
+    }
+
+    func reset() {
+        if case .running = state, let proc = currentProcess, proc.isRunning {
+            cancelRequested = true
+            kill(proc.processIdentifier, SIGKILL)
+        }
+        state = .idle
+        logLines = []
+        currentProcess = nil
+        watchdog?.cancel()
+        watchdog = nil
+        cancelRequested = false
+    }
+
+    /// Test seam: spawn a command directly without going through `start`.
+    func runForTesting(executable: String, arguments: [String]) async {
+        precondition(state == .idle, "runForTesting requires idle state")
+        await _spawn(
+            executable: executable,
+            arguments: arguments,
+            commandLineForDisplay: ([executable] + arguments).joined(separator: " ")
+        )
+    }
+
+    // MARK: - Private spawn
+
+    private func _spawn(
+        executable: String,
+        arguments: [String],
+        commandLineForDisplay: String
+    ) async {
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: executable)
+        process.arguments = arguments
+
+        var env = ProcessInfo.processInfo.environment
+        env["PATH"] = augmentedPATH(base: env["PATH"])
+        process.environment = env
+
+        let pipe = Pipe()
+        process.standardOutput = pipe
+        process.standardError = pipe
+        let stdinPipe = Pipe()
+        process.standardInput = stdinPipe
+
+        let buffer = LineBuffer()
+        pipe.fileHandleForReading.readabilityHandler = { [weak self] handle in
+            let data = handle.availableData
+            if data.isEmpty {
+                handle.readabilityHandler = nil
+                return
+            }
+            let chunk = String(decoding: data, as: UTF8.self)
+            let lines = buffer.feed(chunk)
+            if lines.isEmpty { return }
+            Task { @MainActor [weak self] in
+                self?.logLines.append(contentsOf: lines)
+            }
+        }
+
+        process.terminationHandler = { [weak self, buffer, pipe] proc in
+            pipe.fileHandleForReading.readabilityHandler = nil
+            let finalData = (try? pipe.fileHandleForReading.readToEnd()) ?? Data()
+            let finalLines: [String]
+            if let chunk = String(data: finalData, encoding: .utf8), !chunk.isEmpty {
+                finalLines = buffer.feed(chunk)
+            } else {
+                finalLines = []
+            }
+            let finalTrailing = buffer.flush()
+            Task { @MainActor [weak self] in
+                guard let self else { return }
+                if !finalLines.isEmpty {
+                    self.logLines.append(contentsOf: finalLines)
+                }
+                if let trailing = finalTrailing, !trailing.isEmpty {
+                    self.logLines.append(trailing)
+                }
+                self.currentProcess = nil
+                self.watchdog?.cancel()
+                self.watchdog = nil
+                defer { self.cancelRequested = false }
+                if case .running = self.state {
+                    if proc.terminationStatus == 0 {
+                        self.state = .finished(exitCode: 0)
+                    } else if self.cancelRequested || proc.terminationReason == .uncaughtSignal {
+                        self.state = .cancelled
+                    } else {
+                        self.state = .finished(exitCode: proc.terminationStatus)
+                    }
+                }
+            }
+        }
+
+        state = .running(commandLine: commandLineForDisplay)
+        logLines = []
+        currentProcess = process
+
+        do {
+            try process.run()
+        } catch {
+            state = .failed(message: String(describing: error))
+            currentProcess = nil
+            return
+        }
+
+        try? stdinPipe.fileHandleForReading.close()
+        try? stdinPipe.fileHandleForWriting.close()
+        try? pipe.fileHandleForWriting.close()
+    }
+
+    private func augmentedPATH(base: String?) -> String {
+        let basePath = base ?? ""
+        let additional = InstallerHost.defaultAdditionalPathDirectories()
+        var seen = Set<String>()
+        var parts: [String] = []
+        for dir in basePath.split(separator: ":", omittingEmptySubsequences: true).map(String.init)
+        where seen.insert(dir).inserted {
+            parts.append(dir)
+        }
+        for dir in additional where !dir.isEmpty && seen.insert(dir).inserted {
+            parts.append(dir)
+        }
+        return parts.joined(separator: ":")
+    }
+}
+
+struct SelfUpdaterBusy: Error {}

--- a/Alas/Sources/Updates/SelfUpdater.swift
+++ b/Alas/Sources/Updates/SelfUpdater.swift
@@ -8,10 +8,18 @@ struct SelfUpdateCommand: Equatable, Sendable {
     let executable: String
     let arguments: [String]
 
-    static let homebrew = SelfUpdateCommand(
-        executable: "/opt/homebrew/bin/brew",
-        arguments: ["upgrade", "--cask", "alas"]
-    )
+    /// Detects the `brew` executable on the host's PATH so the upgrade
+    /// works on both Apple Silicon (`/opt/homebrew/bin/brew`) and Intel
+    /// (`/usr/local/bin/brew`) Macs. Falls back to the Apple Silicon default
+    /// if brew cannot be found.
+    static var homebrew: SelfUpdateCommand {
+        let host = InstallerHost.detect()
+        let executable = host.detected[.brew]?.executable ?? "/opt/homebrew/bin/brew"
+        return SelfUpdateCommand(
+            executable: executable,
+            arguments: ["upgrade", "--cask", "alas"]
+        )
+    }
 
     var displayCommandLine: String {
         ((executable as NSString).lastPathComponent as String) + " " + arguments.joined(separator: " ")

--- a/Alas/Sources/Updates/UpdateAvailableSheet.swift
+++ b/Alas/Sources/Updates/UpdateAvailableSheet.swift
@@ -7,6 +7,7 @@ struct UpdateAvailableSheet: View {
     let info: ReleaseInfo
     let source: InstallSource
     let onDismiss: () -> Void
+    let onRunUpdate: () -> Void
     @Environment(\.theme) var theme
 
     private let brewCommand = "brew upgrade --cask alas"
@@ -79,7 +80,8 @@ struct UpdateAvailableSheet: View {
                 AlasButton(title: "Copy", style: .subtle) { Clipboard.copy(brewCommand) }
                 Spacer()
                 AlasButton(title: "View Release", style: .subtle) { NSWorkspace.shared.open(info.htmlURL) }
-                AlasButton(title: "Later", style: .primary, action: onDismiss)
+                AlasButton(title: "Update", style: .primary, action: onRunUpdate)
+                AlasButton(title: "Later", style: .subtle, action: onDismiss)
             case .direct:
                 AlasButton(title: viewReleaseLabel, style: .subtle) { NSWorkspace.shared.open(info.htmlURL) }
                 Spacer()

--- a/Alas/Sources/Updates/UpdateProgressSheet.swift
+++ b/Alas/Sources/Updates/UpdateProgressSheet.swift
@@ -1,0 +1,127 @@
+import SwiftUI
+
+struct UpdateProgressSheet: View {
+    @Bindable var updater: SelfUpdater
+    let onDone: () -> Void
+    @Environment(\.theme) var theme
+
+    private var titleText: String {
+        switch updater.state {
+        case .idle:
+            return "Update Alas"
+        case .running:
+            return "Updating Alas…"
+        case .finished(let exitCode):
+            return exitCode == 0 ? "Update downloaded" : "Update failed"
+        case .cancelled:
+            return "Update cancelled"
+        case .failed:
+            return "Could not start update"
+        }
+    }
+
+    private var commandLine: String {
+        if case .running(let cl) = updater.state { return cl }
+        return ""
+    }
+
+    private var isRunning: Bool {
+        if case .running = updater.state { return true }
+        return false
+    }
+
+    private var isSuccess: Bool {
+        if case .finished(0) = updater.state { return true }
+        return false
+    }
+
+    private var isFailure: Bool {
+        switch updater.state {
+        case .finished(let exitCode) where exitCode != 0:
+            return true
+        case .failed, .cancelled:
+            return true
+        default:
+            return false
+        }
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            Text(titleText)
+                .font(.system(size: 16, weight: .semibold))
+                .padding(.bottom, 8)
+
+            if !commandLine.isEmpty {
+                Text(commandLine)
+                    .font(.system(size: 12, design: .monospaced))
+                    .foregroundColor(theme.color("fg-dim"))
+                    .padding(8)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .background(theme.color("bg-0"))
+                    .overlay(RoundedRectangle(cornerRadius: 6)
+                        .strokeBorder(theme.color("line"), lineWidth: 0.5))
+                    .padding(.bottom, 12)
+            }
+
+            if isSuccess {
+                Text("Quit and reopen Alas to start the new version.")
+                    .font(.system(size: 12))
+                    .foregroundColor(theme.color("fg"))
+                    .padding(.bottom, 12)
+            } else if isFailure {
+                Text("You can also run the command manually in a terminal.")
+                    .font(.system(size: 12))
+                    .foregroundColor(theme.color("fg-dim"))
+                    .padding(.bottom, 12)
+            }
+
+            ScrollViewReader { proxy in
+                ScrollView {
+                    VStack(alignment: .leading, spacing: 1) {
+                        ForEach(Array(updater.logLines.enumerated()), id: \.offset) { idx, line in
+                            Text(line.isEmpty ? " " : line)
+                                .font(.system(size: 11.5, design: .monospaced))
+                                .frame(maxWidth: .infinity, alignment: .leading)
+                                .id(idx)
+                        }
+                    }
+                    .padding(8)
+                }
+                .frame(height: 280)
+                .background(theme.color("bg-0"))
+                .overlay(RoundedRectangle(cornerRadius: 6)
+                    .strokeBorder(theme.color("line"), lineWidth: 0.5))
+                .onChange(of: updater.logLines.count) { _, newCount in
+                    guard newCount > 0 else { return }
+                    proxy.scrollTo(newCount - 1, anchor: .bottom)
+                }
+            }
+
+            HStack(spacing: 8) {
+                Spacer()
+                if isRunning {
+                    AlasButton(title: "Cancel", style: .subtle) {
+                        updater.cancel()
+                    }
+                } else {
+                    AlasButton(title: "Close", style: .subtle) {
+                        updater.reset()
+                        onDone()
+                    }
+                    if isSuccess {
+                        AlasButton(title: "Done", style: .primary) {
+                            updater.reset()
+                            onDone()
+                        }
+                    }
+                }
+            }
+            .padding(.top, 16)
+        }
+        .padding(24)
+        .frame(width: 600)
+        .background(theme.color("bg-1"))
+        .interactiveDismissDisabled(true)
+    }
+}

--- a/AlasTests/Updates/SelfUpdaterTests.swift
+++ b/AlasTests/Updates/SelfUpdaterTests.swift
@@ -1,0 +1,103 @@
+import Foundation
+import Testing
+@testable import Alas
+
+@Suite("SelfUpdater")
+struct SelfUpdaterTests {
+    @Test("echo transitions idle → running → finished(0)")
+    @MainActor
+    func echoSucceeds() async throws {
+        let updater = SelfUpdater()
+        await updater.runForTesting(executable: "/bin/echo", arguments: ["updated"])
+
+        for _ in 0..<50 {
+            if case .finished = updater.state { break }
+            try await Task.sleep(nanoseconds: 50_000_000)
+        }
+
+        if case .finished(let code) = updater.state {
+            #expect(code == 0)
+        } else {
+            Issue.record("expected finished, got \(updater.state)")
+        }
+        #expect(updater.logLines.joined(separator: "\n").contains("updated"))
+    }
+
+    @Test("cancel transitions running → cancelled")
+    @MainActor
+    func cancelRunning() async throws {
+        let updater = SelfUpdater()
+        await updater.runForTesting(executable: "/bin/sleep", arguments: ["30"])
+
+        for _ in 0..<50 {
+            if case .running = updater.state { break }
+            try await Task.sleep(nanoseconds: 50_000_000)
+        }
+        if case .running = updater.state { } else {
+            Issue.record("expected running state, got \(updater.state)")
+            return
+        }
+
+        updater.cancel()
+
+        for _ in 0..<200 {
+            if case .cancelled = updater.state { return }
+            if case .failed = updater.state { return }
+            try await Task.sleep(nanoseconds: 50_000_000)
+        }
+        Issue.record("update did not cancel within timeout, state = \(updater.state)")
+    }
+
+    @Test("missing executable transitions to .failed")
+    @MainActor
+    func missingExecutableFails() async {
+        let updater = SelfUpdater()
+        await updater.runForTesting(executable: "/bin/does-not-exist", arguments: [])
+        if case .failed = updater.state {
+            // expected
+        } else {
+            Issue.record("expected .failed state, got \(updater.state)")
+        }
+    }
+
+    @Test("reset returns state to idle")
+    @MainActor
+    func resetClears() async {
+        let updater = SelfUpdater()
+        await updater.runForTesting(executable: "/bin/echo", arguments: ["x"])
+        for _ in 0..<50 {
+            if case .finished = updater.state { break }
+            try? await Task.sleep(nanoseconds: 50_000_000)
+        }
+
+        updater.reset()
+        #expect(updater.state == .idle)
+        #expect(updater.logLines.isEmpty)
+    }
+
+    @Test("start while running throws SelfUpdaterBusy")
+    @MainActor
+    func startWhileRunningThrows() async throws {
+        let updater = SelfUpdater()
+        await updater.runForTesting(executable: "/bin/sleep", arguments: ["10"])
+        for _ in 0..<50 {
+            if case .running = updater.state { break }
+            try await Task.sleep(nanoseconds: 50_000_000)
+        }
+
+        do {
+            try await updater.start(command: .homebrew)
+            Issue.record("expected SelfUpdaterBusy to be thrown")
+        } catch is SelfUpdaterBusy {
+            // expected
+        } catch {
+            Issue.record("expected SelfUpdaterBusy, got \(error)")
+        }
+
+        updater.cancel()
+        for _ in 0..<200 {
+            if case .cancelled = updater.state { break }
+            try? await Task.sleep(nanoseconds: 50_000_000)
+        }
+    }
+}

--- a/AlasTests/Updates/SelfUpdaterTests.swift
+++ b/AlasTests/Updates/SelfUpdaterTests.swift
@@ -4,6 +4,13 @@ import Testing
 
 @Suite("SelfUpdater")
 struct SelfUpdaterTests {
+    @Test("homebrew command has correct arguments and display line")
+    func homebrewCommandShape() {
+        let command = SelfUpdateCommand.homebrew
+        #expect(command.arguments == ["upgrade", "--cask", "alas"])
+        #expect(command.displayCommandLine == "brew upgrade --cask alas")
+    }
+
     @Test("echo transitions idle → running → finished(0)")
     @MainActor
     func echoSucceeds() async throws {

--- a/docs/plans/2026-06-18-inline-self-update-implementation-plan.md
+++ b/docs/plans/2026-06-18-inline-self-update-implementation-plan.md
@@ -1,0 +1,601 @@
+# Inline self-update implementation plan
+
+> **REQUIRED SUB-SKILL:** Use the executing-plans skill to implement this plan task-by-task.
+
+**Goal:** Add an inline “Update” button to `UpdateAvailableSheet` for Homebrew installs that runs `brew upgrade --cask alas` in a progress/log sheet, reusing the existing `LSPInstallProgressSheet` pattern.
+
+**Architecture:** A new `@MainActor @Observable` `SelfUpdater` model spawns and streams `brew` output; a new `UpdateProgressSheet` presents it; `UpdateAvailableSheet` and `RootView` are wired to start and dismiss the flow. `.direct` installs remain unchanged.
+
+**Tech Stack:** Swift 5.9, SwiftUI, Swift Testing, `Foundation.Process`.
+
+---
+
+## Task 1: Create `SelfUpdater` model
+
+**Files:**
+- Create: `Alas/Sources/Updates/SelfUpdater.swift`
+- Test: `AlasTests/Updates/SelfUpdaterTests.swift` (create directory)
+
+**Step 1: Write the failing test**
+
+```swift
+import Foundation
+import Testing
+@testable import Alas
+
+@Suite("SelfUpdater")
+struct SelfUpdaterTests {
+    @Test("echo transitions idle → running → finished(0)")
+    @MainActor
+    func echoSucceeds() async throws {
+        let updater = SelfUpdater()
+        await updater.runForTesting(executable: "/bin/echo", arguments: ["updated"])
+
+        for _ in 0..<50 {
+            if case .finished = updater.state { break }
+            try await Task.sleep(nanoseconds: 50_000_000)
+        }
+
+        if case .finished(let code) = updater.state {
+            #expect(code == 0)
+        } else {
+            Issue.record("expected finished, got \(updater.state)")
+        }
+        #expect(updater.logLines.joined(separator: "\n").contains("updated"))
+    }
+}
+```
+
+**Step 2: Run test to verify it fails**
+
+Run:
+```bash
+cd /Users/nacho/.alas/.worktrees/alas/nacho-update-button/.worktrees/self-update
+xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' \
+  -only-testing AlasTests/SelfUpdaterTests/echoSucceeds test -quiet 2>&1 | tail -20
+```
+
+Expected: FAIL with `Cannot find 'SelfUpdater' in scope`.
+
+**Step 3: Write minimal implementation**
+
+```swift
+import Foundation
+import Observation
+
+/// Command shape for a self-update operation. For now this is always
+/// `brew upgrade --cask alas`, but wrapping it makes `SelfUpdater` testable
+/// and avoids scattering the command across views.
+struct SelfUpdateCommand: Equatable, Sendable {
+    let executable: String
+    let arguments: [String]
+
+    static let homebrew = SelfUpdateCommand(
+        executable: "/opt/homebrew/bin/brew",
+        arguments: ["upgrade", "--cask", "alas"]
+    )
+
+    var displayCommandLine: String {
+        ((executable as NSString).lastPathComponent as String) + " " + arguments.joined(separator: " ")
+    }
+}
+
+@Observable
+@MainActor
+final class SelfUpdater {
+    enum State: Equatable, Sendable {
+        case idle
+        case running(commandLine: String)
+        case finished(exitCode: Int32)
+        case cancelled
+        case failed(message: String)
+    }
+
+    private(set) var state: State = .idle
+    private(set) var logLines: [String] = []
+
+    private var currentProcess: Process?
+    private var watchdog: Task<Void, Never>?
+    private var cancelRequested = false
+
+    /// Start the update. Requires `.idle`; otherwise throws.
+    func start(command: SelfUpdateCommand) async throws {
+        guard state == .idle else {
+            throw SelfUpdaterBusy()
+        }
+        await _spawn(
+            executable: command.executable,
+            arguments: command.arguments,
+            commandLineForDisplay: command.displayCommandLine
+        )
+    }
+
+    func cancel() {
+        guard case .running = state, let process = currentProcess else { return }
+        cancelRequested = true
+        kill(process.processIdentifier, SIGINT)
+        watchdog?.cancel()
+        watchdog = Task { [weak self] in
+            try? await Task.sleep(nanoseconds: 2_000_000_000)
+            guard let self else { return }
+            await MainActor.run {
+                if case .running = self.state, let proc = self.currentProcess, proc.isRunning {
+                    proc.terminate()
+                }
+            }
+            try? await Task.sleep(nanoseconds: 3_000_000_000)
+            await MainActor.run {
+                if case .running = self.state, let proc = self.currentProcess, proc.isRunning {
+                    kill(proc.processIdentifier, SIGKILL)
+                }
+            }
+        }
+    }
+
+    func reset() {
+        if case .running = state, let proc = currentProcess, proc.isRunning {
+            cancelRequested = true
+            kill(proc.processIdentifier, SIGKILL)
+        }
+        state = .idle
+        logLines = []
+        currentProcess = nil
+        watchdog?.cancel()
+        watchdog = nil
+        cancelRequested = false
+    }
+
+    /// Test seam: spawn a command directly without going through `start`.
+    func runForTesting(executable: String, arguments: [String]) async {
+        precondition(state == .idle, "runForTesting requires idle state")
+        await _spawn(
+            executable: executable,
+            arguments: arguments,
+            commandLineForDisplay: ([executable] + arguments).joined(separator: " ")
+        )
+    }
+
+    // MARK: - Private spawn
+
+    private func _spawn(
+        executable: String,
+        arguments: [String],
+        commandLineForDisplay: String
+    ) async {
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: executable)
+        process.arguments = arguments
+
+        var env = ProcessInfo.processInfo.environment
+        env["PATH"] = augmentedPATH(base: env["PATH"])
+        process.environment = env
+
+        let pipe = Pipe()
+        process.standardOutput = pipe
+        process.standardError = pipe
+        let stdinPipe = Pipe()
+        process.standardInput = stdinPipe
+
+        let buffer = LineBuffer()
+        pipe.fileHandleForReading.readabilityHandler = { [weak self] handle in
+            let data = handle.availableData
+            if data.isEmpty {
+                handle.readabilityHandler = nil
+                return
+            }
+            let chunk = String(decoding: data, as: UTF8.self)
+            let lines = buffer.feed(chunk)
+            if lines.isEmpty { return }
+            Task { @MainActor [weak self] in
+                self?.logLines.append(contentsOf: lines)
+            }
+        }
+
+        process.terminationHandler = { [weak self, buffer, pipe] proc in
+            pipe.fileHandleForReading.readabilityHandler = nil
+            let finalData = (try? pipe.fileHandleForReading.readToEnd()) ?? Data()
+            let finalLines: [String]
+            if let chunk = String(data: finalData, encoding: .utf8), !chunk.isEmpty {
+                finalLines = buffer.feed(chunk)
+            } else {
+                finalLines = []
+            }
+            let finalTrailing = buffer.flush()
+            Task { @MainActor [weak self] in
+                guard let self else { return }
+                if !finalLines.isEmpty {
+                    self.logLines.append(contentsOf: finalLines)
+                }
+                if let trailing = finalTrailing, !trailing.isEmpty {
+                    self.logLines.append(trailing)
+                }
+                self.currentProcess = nil
+                self.watchdog?.cancel()
+                self.watchdog = nil
+                defer { self.cancelRequested = false }
+                if case .running = self.state {
+                    if proc.terminationStatus == 0 {
+                        self.state = .finished(exitCode: 0)
+                    } else if self.cancelRequested || proc.terminationReason == .uncaughtSignal {
+                        self.state = .cancelled
+                    } else {
+                        self.state = .finished(exitCode: proc.terminationStatus)
+                    }
+                }
+            }
+        }
+
+        state = .running(commandLine: commandLineForDisplay)
+        logLines = []
+        currentProcess = process
+
+        do {
+            try process.run()
+        } catch {
+            state = .failed(message: String(describing: error))
+            currentProcess = nil
+            return
+        }
+
+        try? stdinPipe.fileHandleForReading.close()
+        try? stdinPipe.fileHandleForWriting.close()
+        try? pipe.fileHandleForWriting.close()
+    }
+
+    private func augmentedPATH(base: String?) -> String {
+        let basePath = base ?? ""
+        let additional = InstallerHost.defaultAdditionalPathDirectories()
+        var seen = Set<String>()
+        var parts: [String] = []
+        for dir in basePath.split(separator: ":", omittingEmptySubsequences: true).map(String.init)
+        where seen.insert(dir).inserted {
+            parts.append(dir)
+        }
+        for dir in additional where !dir.isEmpty && seen.insert(dir).inserted {
+            parts.append(dir)
+        }
+        return parts.joined(separator: ":")
+    }
+}
+
+struct SelfUpdaterBusy: Error {}
+```
+
+Note: `LineBuffer` is already private inside `LSPInstaller.swift`. Either move it to a shared location (`Alas/Sources/Helpers/LineBuffer.swift`) or duplicate it. For this plan, **move it to a shared file** in Task 1 so both models can use it.
+
+**Step 4: Move `LineBuffer` to shared location**
+
+- Create `Alas/Sources/Helpers/LineBuffer.swift` with the existing `LineBuffer` code, removing it from `LSPInstaller.swift`.
+- Update `LSPInstaller.swift` to reference the shared `LineBuffer` (no behavior change).
+
+**Step 5: Run test to verify it passes**
+
+Run the same `xcodebuild -only-testing AlasTests/SelfUpdaterTests/echoSucceeds` command.
+
+Expected: PASS.
+
+**Step 6: Add remaining tests**
+
+Add to `AlasTests/Updates/SelfUpdaterTests.swift`:
+- `cancelRunning()` — `/bin/sleep 30`, cancel, assert `.cancelled`.
+- `missingExecutableFails()` — `/bin/does-not-exist`, assert `.failed`.
+- `resetClears()` — run `/bin/echo`, wait for `.finished`, call `reset()`, assert `.idle` and empty logs.
+- `startWhileRunningThrows()` — run `/bin/sleep 10`, then call `start` and assert `SelfUpdaterBusy`.
+
+Run all `SelfUpdaterTests` with:
+```bash
+xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' \
+  -only-testing AlasTests/SelfUpdaterTests test -quiet 2>&1 | tail -20
+```
+
+Expected: all PASS.
+
+**Step 7: Commit**
+
+```bash
+git add Alas/Sources/Updates/SelfUpdater.swift \
+           Alas/Sources/Helpers/LineBuffer.swift \
+           Alas/Sources/Code/LSP/Install/LSPInstaller.swift \
+           AlasTests/Updates/SelfUpdaterTests.swift
+git commit -m "feat(updates): add SelfUpdater model for inline brew upgrades"
+```
+
+---
+
+## Task 2: Create `UpdateProgressSheet`
+
+**Files:**
+- Create: `Alas/Sources/Updates/UpdateProgressSheet.swift`
+- Modify: `Alas/Sources/Updates/UpdateAvailableSheet.swift:1-107` (add `onRunUpdate`)
+
+**Step 1: Write the sheet view**
+
+```swift
+import SwiftUI
+
+struct UpdateProgressSheet: View {
+    @Bindable var updater: SelfUpdater
+    let onDone: () -> Void
+    @Environment(\.theme) var theme
+
+    private var titleText: String {
+        switch updater.state {
+        case .idle:
+            return "Update Alas"
+        case .running:
+            return "Updating Alas…"
+        case .finished(let exitCode):
+            return exitCode == 0 ? "Update downloaded" : "Update failed"
+        case .cancelled:
+            return "Update cancelled"
+        case .failed:
+            return "Could not start update"
+        }
+    }
+
+    private var commandLine: String {
+        if case .running(let cl) = updater.state { return cl }
+        return ""
+    }
+
+    private var isRunning: Bool {
+        if case .running = updater.state { return true }
+        return false
+    }
+
+    private var isSuccess: Bool {
+        if case .finished(0) = updater.state { return true }
+        return false
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            Text(titleText)
+                .font(.system(size: 16, weight: .semibold))
+                .padding(.bottom, 8)
+
+            if !commandLine.isEmpty {
+                Text(commandLine)
+                    .font(.system(size: 12, design: .monospaced))
+                    .foregroundColor(theme.color("fg-dim"))
+                    .padding(8)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .background(theme.color("bg-0"))
+                    .overlay(RoundedRectangle(cornerRadius: 6)
+                        .strokeBorder(theme.color("line"), lineWidth: 0.5))
+                    .padding(.bottom, 12)
+            }
+
+            if isSuccess {
+                Text("Quit and reopen Alas to start the new version.")
+                    .font(.system(size: 12))
+                    .foregroundColor(theme.color("fg"))
+                    .padding(.bottom, 12)
+            }
+
+            ScrollViewReader { proxy in
+                ScrollView {
+                    VStack(alignment: .leading, spacing: 1) {
+                        ForEach(Array(updater.logLines.enumerated()), id: \.offset) { idx, line in
+                            Text(line.isEmpty ? " " : line)
+                                .font(.system(size: 11.5, design: .monospaced))
+                                .frame(maxWidth: .infinity, alignment: .leading)
+                                .id(idx)
+                        }
+                    }
+                    .padding(8)
+                }
+                .frame(height: 280)
+                .background(theme.color("bg-0"))
+                .overlay(RoundedRectangle(cornerRadius: 6)
+                    .strokeBorder(theme.color("line"), lineWidth: 0.5))
+                .onChange(of: updater.logLines.count) { _, newCount in
+                    guard newCount > 0 else { return }
+                    proxy.scrollTo(newCount - 1, anchor: .bottom)
+                }
+            }
+
+            HStack(spacing: 8) {
+                Spacer()
+                if isRunning {
+                    AlasButton(title: "Cancel", style: .subtle) {
+                        updater.cancel()
+                    }
+                } else {
+                    AlasButton(title: "Close", style: .subtle) {
+                        updater.reset()
+                        onDone()
+                    }
+                    if isSuccess {
+                        AlasButton(title: "Done", style: .primary) {
+                            updater.reset()
+                            onDone()
+                        }
+                    }
+                }
+            }
+            .padding(.top, 16)
+        }
+        .padding(24)
+        .frame(width: 600)
+        .background(theme.color("bg-1"))
+        .interactiveDismissDisabled(true)
+    }
+}
+```
+
+**Step 2: Add `onRunUpdate` to `UpdateAvailableSheet`**
+
+Modify `UpdateAvailableSheet`:
+
+```swift
+struct UpdateAvailableSheet: View {
+    let info: ReleaseInfo
+    let source: InstallSource
+    let onDismiss: () -> Void
+    let onRunUpdate: () -> Void
+    ...
+
+    @ViewBuilder private var actionRow: some View {
+        HStack(spacing: 8) {
+            switch source {
+            case .homebrew:
+                Text(brewCommand)
+                    .font(.system(size: 11.5, design: .monospaced))
+                    .foregroundColor(theme.color("fg"))
+                    .textSelection(.enabled)
+                AlasButton(title: "Copy", style: .subtle) { Clipboard.copy(brewCommand) }
+                Spacer()
+                AlasButton(title: "View Release", style: .subtle) { NSWorkspace.shared.open(info.htmlURL) }
+                AlasButton(title: "Update", style: .primary, action: onRunUpdate)
+                AlasButton(title: "Later", style: .subtle, action: onDismiss)
+            case .direct:
+                ...
+            }
+        }
+        ...
+    }
+}
+```
+
+**Step 3: Build to catch compile errors**
+
+```bash
+xcodegen
+xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -quiet build 2>&1 | tail -20
+```
+
+Expected: build succeeds.
+
+**Step 4: Commit**
+
+```bash
+git add Alas/Sources/Updates/UpdateProgressSheet.swift \
+           Alas/Sources/Updates/UpdateAvailableSheet.swift
+git commit -m "feat(updates): add UpdateProgressSheet and Update button"
+```
+
+---
+
+## Task 3: Wire `SelfUpdater` into `AppState` and `RootView`
+
+**Files:**
+- Modify: `Alas/Sources/App/AppState.swift:344-345`
+- Modify: `Alas/Sources/App/RootView.swift:197-210`
+
+**Step 1: Add `SelfUpdater` to `AppState`**
+
+Near `let lspInstaller = LSPInstaller()` add:
+
+```swift
+    // MARK: - Self updater
+
+    let selfUpdater = SelfUpdater()
+    var presentUpdateProgress = false
+```
+
+**Step 2: Wire sheets in `RootView`**
+
+Replace the existing `.sheet(...)` for updates with:
+
+```swift
+        .sheet(item: Binding(
+            get: { state.updates.presentedUpdate },
+            set: { state.updates.presentedUpdate = $0 }
+        )) { info in
+            UpdateAvailableSheet(
+                info: info,
+                source: state.updates.track == .nightly ? .direct : state.updates.source,
+                onDismiss: { state.updates.presentedUpdate = nil },
+                onRunUpdate: {
+                    state.updates.presentedUpdate = nil
+                    state.presentUpdateProgress = true
+                    Task {
+                        try? await state.selfUpdater.start(command: .homebrew)
+                    }
+                }
+            )
+            .environment(\.theme, state.themeStore.current)
+        }
+        .sheet(isPresented: $state.presentUpdateProgress) {
+            UpdateProgressSheet(updater: state.selfUpdater) {
+                state.presentUpdateProgress = false
+            }
+            .environment(\.theme, state.themeStore.current)
+        }
+```
+
+Note: `state.presentUpdateProgress` must be bindable. Since `AppState` is `@Observable`, `$state.presentUpdateProgress` works directly.
+
+**Step 3: Build and run targeted tests**
+
+```bash
+xcodegen
+xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -quiet build 2>&1 | tail -20
+```
+
+Expected: build succeeds.
+
+**Step 4: Commit**
+
+```bash
+git add Alas/Sources/App/AppState.swift \
+           Alas/Sources/App/RootView.swift
+git commit -m "feat(updates): wire UpdateProgressSheet into AppState and RootView"
+```
+
+---
+
+## Task 4: Run full tests and manual verification
+
+**Step 1: Run full test suite**
+
+```bash
+xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' test -quiet 2>&1 | tail -30
+```
+
+Expected: all tests pass. If the baseline suite times out again, run targeted tests:
+
+```bash
+xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' \
+  -only-testing AlasTests/SelfUpdaterTests \
+  -only-testing AlasTests/ReleaseCheckerTests \
+  -only-testing AlasTests/UpdateThrottleTests test -quiet 2>&1 | tail -20
+```
+
+**Step 2: Manual verification**
+
+Temporarily lower the current version in `project.yml`:
+
+```yaml
+info:
+  properties:
+    CFBundleShortVersionString: "0.8.3"
+```
+
+Run `xcodegen` and build a local copy. Launch it, then use the menu item “Check for Updates…”. The sheet should appear with an **Update** button. Click it and confirm:
+- A progress sheet opens.
+- `brew upgrade --cask alas` runs and prints logs.
+- It exits 0 (or “Already up-to-date”).
+- The app remains running.
+
+Revert the version change afterward.
+
+**Step 3: Commit any final fixes**
+
+```bash
+git commit -m "fix(updates): address review feedback / test failures" # if needed
+```
+
+---
+
+## Done criteria
+
+- [ ] `SelfUpdater` exists, tested, and can run/cancel/reset a subprocess.
+- [ ] `LineBuffer` is shared between `LSPInstaller` and `SelfUpdater`.
+- [ ] `UpdateProgressSheet` exists and mirrors `LSPInstallProgressSheet` style.
+- [ ] `UpdateAvailableSheet` shows an **Update** button for Homebrew installs.
+- [ ] Clicking **Update** dismisses the info sheet and presents the progress sheet.
+- [ ] `brew upgrade --cask alas` runs inline and streams output.
+- [ ] Full test suite passes (or targeted update tests pass if baseline suite is flaky).
+- [ ] Manual verification confirms the flow works end-to-end.

--- a/docs/plans/2026-06-18-update-sheet-self-update-design.md
+++ b/docs/plans/2026-06-18-update-sheet-self-update-design.md
@@ -1,0 +1,128 @@
+# Inline self-update from the update available sheet
+
+## Goal
+
+When Alas detects a newer release and the running copy was installed via Homebrew, the update sheet should offer an **inline “Update” button** that runs `brew upgrade --cask alas` as a subprocess inside a progress/log sheet. This matches the existing `LSPInstallProgressSheet` pattern and lets users upgrade without leaving the app.
+
+## Background
+
+- The current `UpdateAvailableSheet` shows `brew upgrade --cask alas` as a read-only, copyable command for Homebrew installs.
+- `LSPInstallProgressSheet` + `LSPInstaller` already demonstrate how to spawn a subprocess, stream stdout/stderr, and present live logs inside a sheet.
+- The Alas cask (`mrmans0n/homebrew-tap/Casks/alas.rb`) has no `quit`/`signal` uninstall stanzas and no `on_upgrade` directive, so Homebrew will **not** terminate the running app during the upgrade.
+- On macOS, deleting a running app bundle generally succeeds: the running executable stays memory-mapped until it exits. The next Alas launch uses the new bundle.
+
+## Non-goals
+
+- No automatic app relaunch after a successful update.
+- No support for direct-download installs (those keep the existing View Release / Download / Later buttons).
+- No long-running background update service.
+
+## Components
+
+### `SelfUpdater`
+
+A new `@MainActor @Observable` model in the `Updates` module.
+
+```swift
+enum State: Equatable, Sendable {
+    case idle
+    case running(commandLine: String)
+    case finished(exitCode: Int32)
+    case cancelled
+    case failed(message: String)
+}
+```
+
+- `private(set) var state: State`
+- `private(set) var logLines: [String]`
+- `func start(command: BrewCommand)` — starts `brew` as a subprocess.
+- `func cancel()` — SIGINT → SIGTERM → SIGKILL escalation, identical to `LSPInstaller`.
+- `func reset()` — hard kill + clear state, used when the sheet is dismissed mid-run.
+
+`BrewCommand` is a small struct holding the executable and full argv; for now it is always `brew upgrade --cask alas`, but wrapping it keeps `SelfUpdater` testable and avoids magic strings in the view.
+
+The spawn implementation reuses the `Process` + `Pipe` + `LineBuffer` pattern from `LSPInstaller`. Because `SelfUpdater` only ever runs one update per app launch, the generation-token concurrency guard can be simplified or omitted; cancellation/reset still protects against stale `terminationHandler` callbacks by tracking the current `Process` instance.
+
+### `UpdateProgressSheet`
+
+A new view in the `Updates` module, structurally similar to `LSPInstallProgressSheet` but smaller:
+
+- Title changes with `SelfUpdater.State`.
+- A read-only monospaced command line when running.
+- A live log scroll view.
+- Buttons:
+  - Running: **Cancel**.
+  - Finished/cancelled/failed: **Close**.
+  - Success (exit code 0): optionally **Done** to match `LSPInstallProgressSheet`, with the same dismissal semantics so the caller can re-check if needed.
+
+On success, a short explanation is shown:
+> “Update downloaded. Quit and reopen Alas to start the new version.”
+
+### `UpdateAvailableSheet` changes
+
+For `.homebrew` installs the action row becomes:
+- Read-only command: `brew upgrade --cask alas`
+- **Update** (primary) — triggers the progress sheet
+- **Copy** — copies the command to the clipboard
+- **Later** — dismisses
+
+The sheet gains a new closure: `let onRunUpdate: () -> Void`.
+
+### `RootView` changes
+
+The current `.sheet(item: $state.updateController.presentedUpdate)` presents `UpdateAvailableSheet`. We keep that sheet as the entry point, but add a second sheet layer triggered from the update sheet:
+
+```swift
+UpdateAvailableSheet(
+    info: info,
+    source: state.updateController.source,
+    onDismiss: { state.updateController.presentedUpdate = nil },
+    onRunUpdate: { state.presentUpdateProgress = true }
+)
+.sheet(isPresented: $state.presentUpdateProgress) {
+    UpdateProgressSheet(updater: state.selfUpdater) {
+        state.presentUpdateProgress = false
+        // Optionally clear presentedUpdate so the update sheet doesn't come back until next check.
+    }
+}
+```
+
+`AppState` owns the new `SelfUpdater` instance.
+
+### `AppState` changes
+
+- Add `let selfUpdater = SelfUpdater()` next to `lspInstaller`.
+- Add `@Published var presentUpdateProgress: Bool = false` or a similar presentation flag.
+
+## Error handling and edge cases
+
+| Scenario | Behavior |
+|---|---|
+| `brew` not on PATH | `process.run()` fails → `.failed(message:)` |
+| Network or cask error | `brew` exits non-zero → `.finished(exitCode: nonzero)` |
+| User clicks Cancel | SIGINT, then escalate to SIGTERM/SIGKILL → `.cancelled` |
+| Sheet closed mid-run | `reset()` kills the process and clears state |
+| Second update check while one is running | Button disabled via `state == .idle` guard |
+| Successful exit code 0 | Show the quit/reopen explanation; do not auto-quit |
+
+Because Alas keeps running after the bundle is replaced, we do **not** try to verify the new version from inside the process. The success message is phrased defensively.
+
+## Testing
+
+- Unit tests for `SelfUpdater` using a test seam (`_spawnForTesting`) with `/bin/echo` and `/bin/sleep`, mirroring `LSPInstaller` tests:
+  - state transitions from `.idle` to `.running` to `.finished(0)`
+  - log lines are captured
+  - cancellation transitions to `.cancelled`
+  - reset kills a running process
+- UI tests are not required; the sheet layout is straightforward and covered by SwiftUI previews if convenient.
+
+## Verification plan
+
+1. Run `xcodegen`.
+2. Run `xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' build`.
+3. Run `xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' test`.
+4. Manual test: temporarily lower the hardcoded/current version, trigger “Check for Updates…”, and click **Update**. Confirm `brew upgrade --cask alas` runs to completion and the app remains usable.
+
+## Open questions
+
+- Should the update sheet stay dismissed after a successful update, or re-appear on the next manual check until Alas is relaunched? Proposed: dismiss it after Update is clicked; on next check it will report up-to-date for the running version.


### PR DESCRIPTION
## Summary

When Alas is installed via Homebrew and a newer release is available, the update sheet now offers an **Update** button that runs `brew upgrade --cask alas` directly inside a progress/log sheet. This mirrors the existing LSP installation flow and removes the need for users to copy the command and run it manually.

- Added `SelfUpdater` (`@MainActor @Observable`) that spawns `brew`, streams stdout/stderr, and supports cancel/reset.
- Extracted `LineBuffer` from `LSPInstaller.swift` into `Alas/Sources/Helpers/LineBuffer.swift` so both subprocess runners share it.
- Added `UpdateProgressSheet` with live logs, a read-only command line, and Cancel/Close/Done actions.
- Updated `UpdateAvailableSheet` so Homebrew installs show **Update** (primary), **Copy**, and **Later**.
- Wired the flow through `AppState` and `RootView`; clicking Update dismisses the info sheet and presents the progress sheet.

## Notes

- Direct-download installs keep the existing View Release / Download / Later buttons.
- The Alas cask has no `quit`/`signal` stanzas, so Homebrew replaces the bundle while the running app stays memory-mapped. The success message tells users to quit and reopen Alas to start the new version.
- `SelfUpdateCommand.homebrew` detects `brew` on PATH, so it works on both Apple Silicon and Intel Macs.

## Test Plan

- [x] `xcodebuild build` passes.
- [x] `SelfUpdaterTests` (6 tests), `LSPInstallerTests` (15 tests), `ReleaseCheckerTests` (13 tests), and `UpdateThrottleTests` (5 tests) all pass (39 total).
- [ ] Manual test: temporarily lower the app version, trigger "Check for Updates…", and verify the Update button runs `brew upgrade --cask alas` to completion.