### PR TITLE
fix(acp): repoint Codex adapter to @agentclientprotocol/codex-acp

### DIFF
--- a/Alas/Sources/ACP/Adapter/ACPLaunchCatalog.swift
+++ b/Alas/Sources/ACP/Adapter/ACPLaunchCatalog.swift
@@ -52,8 +52,12 @@ enum ACPLaunchCatalog {
             supportsModelSelection: true,
             supportsModeSelection: true),
 
-        // Codex CLI (OpenAI) has no native ACP support. The Zed adapter
-        // `@zed-industries/codex-acp` bridges Codex to ACP over stdio.
+        // Codex CLI (OpenAI) has no native ACP support; an adapter bridges
+        // Codex to ACP over stdio. The package moved orgs — same story as
+        // claude above: `@zed-industries/codex-acp` is stale and does NOT
+        // emit `usage_update`, while `@agentclientprotocol/codex-acp` (active)
+        // does, so the context-window indicator only lights up on the latter.
+        // The binary on PATH is still `codex-acp`.
         // Requires OPENAI_API_KEY or CODEX_API_KEY in the environment.
         ACPLaunchSpec(
             agentID: "codex",
@@ -62,7 +66,7 @@ enum ACPLaunchCatalog {
             extraEnv: [:],
             setupCheck: .binaryOnPathOrNpmPackage(
                 binary: "codex-acp",
-                npmPackage: "@zed-industries/codex-acp"),
+                npmPackage: "@agentclientprotocol/codex-acp"),
             supportsModelSelection: false,
             supportsModeSelection: false),
 

--- a/Alas/Sources/ACP/Adapter/ACPLaunchCatalog.swift
+++ b/Alas/Sources/ACP/Adapter/ACPLaunchCatalog.swift
@@ -57,16 +57,19 @@ enum ACPLaunchCatalog {
         // claude above: `@zed-industries/codex-acp` is stale and does NOT
         // emit `usage_update`, while `@agentclientprotocol/codex-acp` (active)
         // does, so the context-window indicator only lights up on the latter.
-        // The binary on PATH is still `codex-acp`.
+        // The binary on PATH is still `codex-acp` in both packages — which is
+        // exactly why the setup check is `.npxPackage` (gate on the specific
+        // global package) rather than `.binaryOnPathOrNpmPackage`: a
+        // binary-on-PATH check would pass on a stale `@zed-industries/codex-acp`
+        // install and skip the migration, leaving `usage_update` unavailable.
+        // (The claude rename above didn't need this — its binary name changed.)
         // Requires OPENAI_API_KEY or CODEX_API_KEY in the environment.
         ACPLaunchSpec(
             agentID: "codex",
             command: "codex-acp",
             arguments: [],
             extraEnv: [:],
-            setupCheck: .binaryOnPathOrNpmPackage(
-                binary: "codex-acp",
-                npmPackage: "@agentclientprotocol/codex-acp"),
+            setupCheck: .npxPackage(name: "@agentclientprotocol/codex-acp"),
             supportsModelSelection: false,
             supportsModeSelection: false),
 

--- a/Alas/Sources/ACP/Adapter/CodexACPInstaller.swift
+++ b/Alas/Sources/ACP/Adapter/CodexACPInstaller.swift
@@ -14,6 +14,11 @@ struct CodexACPInstaller: ACPAdapterInstaller {
     }
 
     func install() async throws {
+        // The stale `@zed-industries/codex-acp` declares the same global
+        // `codex-acp` bin; npm (v7+) refuses to clobber another package's bin
+        // and fails with EEXIST. Remove the old package first — best-effort,
+        // since it may not be present — then install the active fork.
+        _ = try? await runner("npm", ["uninstall", "-g", "@zed-industries/codex-acp"])
         let (status, stderr) = try await runner("npm", ["install", "-g", "@agentclientprotocol/codex-acp"])
         if status != 0 { throw ACPInstallError.nonZeroExit(status, stderr: stderr) }
     }

--- a/Alas/Sources/ACP/Adapter/CodexACPInstaller.swift
+++ b/Alas/Sources/ACP/Adapter/CodexACPInstaller.swift
@@ -12,11 +12,11 @@ struct CodexACPInstaller: ACPAdapterInstaller {
         await ACPSetupChecker(env: ProcessInfo.processInfo.environment)
             .evaluate(.binaryOnPathOrNpmPackage(
                 binary: "codex-acp",
-                npmPackage: "@zed-industries/codex-acp"))
+                npmPackage: "@agentclientprotocol/codex-acp"))
     }
 
     func install() async throws {
-        let (status, stderr) = try await runner("npm", ["install", "-g", "@zed-industries/codex-acp"])
+        let (status, stderr) = try await runner("npm", ["install", "-g", "@agentclientprotocol/codex-acp"])
         if status != 0 { throw ACPInstallError.nonZeroExit(status, stderr: stderr) }
     }
 }

--- a/Alas/Sources/ACP/Adapter/CodexACPInstaller.swift
+++ b/Alas/Sources/ACP/Adapter/CodexACPInstaller.swift
@@ -10,9 +10,7 @@ struct CodexACPInstaller: ACPAdapterInstaller {
 
     func installState() async -> ACPSetupResult {
         await ACPSetupChecker(env: ProcessInfo.processInfo.environment)
-            .evaluate(.binaryOnPathOrNpmPackage(
-                binary: "codex-acp",
-                npmPackage: "@agentclientprotocol/codex-acp"))
+            .evaluate(.npxPackage(name: "@agentclientprotocol/codex-acp"))
     }
 
     func install() async throws {

--- a/AlasTests/ACP/Adapter/ACPLaunchSpecNpmPackageTests.swift
+++ b/AlasTests/ACP/Adapter/ACPLaunchSpecNpmPackageTests.swift
@@ -49,7 +49,7 @@ struct ACPLaunchSpecNpmPackageTests {
     func catalogCoverage() {
         let byID = Dictionary(uniqueKeysWithValues: ACPLaunchCatalog.specs.map { ($0.agentID, $0) })
         #expect(byID["claude"]?.npmPackageName == "@agentclientprotocol/claude-agent-acp")
-        #expect(byID["codex"]?.npmPackageName == "@zed-industries/codex-acp")
+        #expect(byID["codex"]?.npmPackageName == "@agentclientprotocol/codex-acp")
         #expect(byID["pi"]?.npmPackageName == "pi-acp")
     }
 }

--- a/AlasTests/ACP/Adapter/ACPSetupCheckerTests.swift
+++ b/AlasTests/ACP/Adapter/ACPSetupCheckerTests.swift
@@ -39,4 +39,26 @@ struct ACPSetupCheckerTests {
         let r = await checker.evaluate(.binaryOnPath(name: "codex-acp"))
         #expect(r == .ready)
     }
+
+    // Regression: the codex setup check must NOT be satisfied by a stale
+    // `codex-acp` binary alone. Both the old `@zed-industries/codex-acp` and
+    // the active `@agentclientprotocol/codex-acp` fork ship that binary name,
+    // so gating on the binary would skip migrating users off the package that
+    // lacks `usage_update`. The catalog uses `.npxPackage` to force migration.
+    @Test("codex setup check requires the package, not just a codex-acp binary on PATH")
+    func codexSetupCheckIsPackageSpecific() async throws {
+        let executable = try makeExecutable(named: "codex-acp")
+        defer { try? FileManager.default.removeItem(at: executable.deletingLastPathComponent()) }
+
+        let codexCheck = try #require(ACPLaunchCatalog.spec(for: "codex")?.setupCheck)
+        // PATH carries the fake `codex-acp` but no `npm`, so global-package
+        // resolution deterministically fails — isolating binary-vs-package.
+        let checker = ACPSetupChecker(
+            env: ["PATH": executable.deletingLastPathComponent().path],
+            additionalPathDirectories: [])
+        let r = await checker.evaluate(codexCheck)
+        if case .missing = r {} else {
+            Issue.record("expected .missing — a codex-acp binary alone must not satisfy the codex check")
+        }
+    }
 }

--- a/AlasTests/ACP/Adapter/CodexACPInstallerTests.swift
+++ b/AlasTests/ACP/Adapter/CodexACPInstallerTests.swift
@@ -4,17 +4,18 @@ import Testing
 
 @Suite("CodexACPInstaller")
 struct CodexACPInstallerTests {
-    @Test("install runs `npm install -g @agentclientprotocol/codex-acp`")
+    @Test("install removes the stale package, then installs the active fork")
     func install() async {
-        var capturedCommand: [String] = []
+        var calls: [[String]] = []
         let installer = CodexACPInstaller(runner: { cmd, args in
-            capturedCommand = [cmd] + args
+            calls.append([cmd] + args)
             return (status: 0, stderr: "")
         })
         try? await installer.install()
-        #expect(capturedCommand.contains("npm"))
-        #expect(capturedCommand.contains("install"))
-        #expect(capturedCommand.contains("-g"))
-        #expect(capturedCommand.contains("@agentclientprotocol/codex-acp"))
+        // Uninstall the old package first (avoids npm EEXIST on the shared
+        // `codex-acp` bin), then install the active fork.
+        #expect(calls.count == 2)
+        #expect(calls.first == ["npm", "uninstall", "-g", "@zed-industries/codex-acp"])
+        #expect(calls.last == ["npm", "install", "-g", "@agentclientprotocol/codex-acp"])
     }
 }

--- a/AlasTests/ACP/Adapter/CodexACPInstallerTests.swift
+++ b/AlasTests/ACP/Adapter/CodexACPInstallerTests.swift
@@ -4,7 +4,7 @@ import Testing
 
 @Suite("CodexACPInstaller")
 struct CodexACPInstallerTests {
-    @Test("install runs `npm install -g @zed-industries/codex-acp`")
+    @Test("install runs `npm install -g @agentclientprotocol/codex-acp`")
     func install() async {
         var capturedCommand: [String] = []
         let installer = CodexACPInstaller(runner: { cmd, args in
@@ -15,6 +15,6 @@ struct CodexACPInstallerTests {
         #expect(capturedCommand.contains("npm"))
         #expect(capturedCommand.contains("install"))
         #expect(capturedCommand.contains("-g"))
-        #expect(capturedCommand.contains("@zed-industries/codex-acp"))
+        #expect(capturedCommand.contains("@agentclientprotocol/codex-acp"))
     }
 }


### PR DESCRIPTION
Repoints the Codex ACP adapter from `@zed-industries/codex-acp` (stale, no `usage_update`) to the active `@agentclientprotocol/codex-acp` fork, which emits `{ "sessionUpdate": "usage_update", "used", "size" }`. This makes the context-window indicator (#560) light up for Codex.

Same org-rename already handled for the Claude adapter (see the comment at `ACPLaunchCatalog.swift`).

### Changes
- `ACPLaunchCatalog.swift` — codex `npmPackage` → `@agentclientprotocol/codex-acp` (+ comment explaining the move). Command/binary stay `codex-acp` (the new package's `bin` is unchanged).
- `CodexACPInstaller.swift` — setup check + `npm install -g` target updated to the active package (otherwise the in-app installer would keep installing the stale one).
- Tests updated: `ACPLaunchSpecNpmPackageTests` (catalog coverage) and `CodexACPInstallerTests` (install command). 6/6 affected tests pass.

### Out of scope
- Per-turn `PromptResponse.usage` breakdown (still open upstream in codex-acp).
- Model/mode-selection flags left as-is (`false`) — no behavior change here.

Closes #561
