### PR TITLE
fix(changes): hide prepare action when tab has no worktree changes

### DIFF
--- a/Alas/Sources/Right/ChangesPreparationModel.swift
+++ b/Alas/Sources/Right/ChangesPreparationModel.swift
@@ -38,6 +38,7 @@ struct ChangesPreparationModel: Equatable {
         hasDraft: Bool,
         draftNonEmpty: Bool,
         aheadCommitCount: Int = 0,
+        local: ReviewLoopLocalState? = nil,
         readinessActions: [ReviewReadinessModel.Action]
     ) {
         let builtReviewAction: ReviewAction?
@@ -69,14 +70,18 @@ struct ChangesPreparationModel: Equatable {
         reviewAction = builtReviewAction
         draftAction = builtDraftAction
         let builtReviewRequestAction = Self.compactReviewRequestAction(from: readinessActions)
+        let effectiveAheadCommitCount = local?.aheadCommitCount ?? aheadCommitCount
         if builtReviewRequestAction?.kind == .refresh,
+           builtReviewRequestAction?.isInFlight != true,
            builtReviewAction == nil,
-           builtDraftAction == nil {
+           builtDraftAction == nil,
+           effectiveAheadCommitCount == 0 {
             reviewRequestAction = nil
         } else if builtReviewRequestAction?.kind == .pushBranch,
-                  aheadCommitCount == 0,
-                  builtReviewAction == nil,
-                  builtDraftAction == nil {
+                   builtReviewRequestAction?.isInFlight != true,
+                   effectiveAheadCommitCount == 0,
+                   builtReviewAction == nil,
+                   builtDraftAction == nil {
             reviewRequestAction = nil
         } else {
             reviewRequestAction = builtReviewRequestAction

--- a/Alas/Sources/Right/ChangesPreparationModel.swift
+++ b/Alas/Sources/Right/ChangesPreparationModel.swift
@@ -79,7 +79,7 @@ struct ChangesPreparationModel: Equatable {
             reviewRequestAction = nil
         } else if builtReviewRequestAction?.kind == .pushBranch,
                    builtReviewRequestAction?.isInFlight != true,
-                   effectiveAheadCommitCount == 0,
+                   local?.needsPush == false,
                    builtReviewAction == nil,
                    builtDraftAction == nil {
             reviewRequestAction = nil

--- a/Alas/Sources/Right/ChangesPreparationModel.swift
+++ b/Alas/Sources/Right/ChangesPreparationModel.swift
@@ -37,6 +37,7 @@ struct ChangesPreparationModel: Equatable {
         changes: [ChangedFile],
         hasDraft: Bool,
         draftNonEmpty: Bool,
+        aheadCommitCount: Int = 0,
         readinessActions: [ReviewReadinessModel.Action]
     ) {
         let builtReviewAction: ReviewAction?
@@ -53,7 +54,7 @@ struct ChangesPreparationModel: Equatable {
 
         let stagedChanges = changes.filter { $0.stage == .staged }
         let builtDraftAction: DraftAction?
-        if !stagedChanges.isEmpty || hasDraft {
+        if !stagedChanges.isEmpty || (hasDraft && draftNonEmpty) {
             builtDraftAction = DraftAction(
                 title: hasDraft ? "Open draft" : "Draft commit",
                 stagedCount: stagedChanges.count,
@@ -71,6 +72,11 @@ struct ChangesPreparationModel: Equatable {
         if builtReviewRequestAction?.kind == .refresh,
            builtReviewAction == nil,
            builtDraftAction == nil {
+            reviewRequestAction = nil
+        } else if builtReviewRequestAction?.kind == .pushBranch,
+                  aheadCommitCount == 0,
+                  builtReviewAction == nil,
+                  builtDraftAction == nil {
             reviewRequestAction = nil
         } else {
             reviewRequestAction = builtReviewRequestAction

--- a/Alas/Sources/Right/ChangesTabView.swift
+++ b/Alas/Sources/Right/ChangesTabView.swift
@@ -27,6 +27,7 @@ struct ChangesTabView: View {
             changes: rps.changes,
             hasDraft: hasDraftTab,
             draftNonEmpty: draftNonEmpty,
+            aheadCommitCount: rps.commits.count,
             readinessActions: readiness.actions
         )
     }

--- a/Alas/Sources/Right/ChangesTabView.swift
+++ b/Alas/Sources/Right/ChangesTabView.swift
@@ -28,6 +28,7 @@ struct ChangesTabView: View {
             hasDraft: hasDraftTab,
             draftNonEmpty: draftNonEmpty,
             aheadCommitCount: rps.commits.count,
+            local: rps.reviewLoop.snapshot?.local,
             readinessActions: readiness.actions
         )
     }

--- a/AlasTests/ReviewChangesModelsTests.swift
+++ b/AlasTests/ReviewChangesModelsTests.swift
@@ -318,6 +318,116 @@ struct ReviewChangesModelsTests {
         #expect(model.isVisible)
     }
 
+    @Test func preparationModelHidesPushWhenLocalStateReportsNoCommitsEvenIfNeedsPushIsTrue() {
+        let actions = [
+            ReviewReadinessModel.Action(kind: .pushBranch, title: "Push", isEnabled: true),
+        ]
+        let local = ReviewLoopLocalState(
+            branchName: "feature",
+            headSHA: "abc123",
+            baseBranch: "main",
+            hasWorkingTreeChanges: false,
+            hasStagedChanges: false,
+            aheadCommitCount: 0,
+            hasUpstream: true,
+            needsPush: true
+        )
+
+        let model = ChangesPreparationModel(
+            changes: [],
+            hasDraft: false,
+            draftNonEmpty: false,
+            aheadCommitCount: 0,
+            local: local,
+            readinessActions: actions
+        )
+
+        #expect(model.reviewAction == nil)
+        #expect(model.draftAction == nil)
+        #expect(model.reviewRequestAction == nil)
+        #expect(!model.isVisible)
+    }
+
+    @Test func preparationModelShowsPushUsingLocalStateCommitCount() throws {
+        let actions = [
+            ReviewReadinessModel.Action(kind: .pushBranch, title: "Push", isEnabled: true),
+        ]
+        let local = ReviewLoopLocalState(
+            branchName: "feature",
+            headSHA: "abc123",
+            baseBranch: "main",
+            hasWorkingTreeChanges: false,
+            hasStagedChanges: false,
+            aheadCommitCount: 2,
+            hasUpstream: true,
+            needsPush: true
+        )
+
+        let model = ChangesPreparationModel(
+            changes: [],
+            hasDraft: false,
+            draftNonEmpty: false,
+            aheadCommitCount: 0,
+            local: local,
+            readinessActions: actions
+        )
+
+        #expect(model.reviewAction == nil)
+        #expect(model.draftAction == nil)
+        let request = try #require(model.reviewRequestAction)
+        #expect(request.kind == .pushBranch)
+        #expect(request.title == "Push")
+        #expect(model.isVisible)
+    }
+
+    @Test func preparationModelHidesWhenCleanUsingLocalState() {
+        let local = ReviewLoopLocalState(
+            branchName: "feature",
+            headSHA: "abc123",
+            baseBranch: "main",
+            hasWorkingTreeChanges: false,
+            hasStagedChanges: false,
+            aheadCommitCount: 0,
+            hasUpstream: true,
+            needsPush: false
+        )
+
+        let model = ChangesPreparationModel(
+            changes: [],
+            hasDraft: false,
+            draftNonEmpty: false,
+            aheadCommitCount: 0,
+            local: local,
+            readinessActions: []
+        )
+
+        #expect(model.reviewAction == nil)
+        #expect(model.draftAction == nil)
+        #expect(model.reviewRequestAction == nil)
+        #expect(!model.isVisible)
+    }
+
+    @Test func preparationModelFallsBackToAheadCommitCountParameterWhenLocalStateIsAbsent() throws {
+        let actions = [
+            ReviewReadinessModel.Action(kind: .pushBranch, title: "Push", isEnabled: true),
+        ]
+
+        let model = ChangesPreparationModel(
+            changes: [],
+            hasDraft: false,
+            draftNonEmpty: false,
+            aheadCommitCount: 1,
+            readinessActions: actions
+        )
+
+        #expect(model.reviewAction == nil)
+        #expect(model.draftAction == nil)
+        let request = try #require(model.reviewRequestAction)
+        #expect(request.kind == .pushBranch)
+        #expect(request.title == "Push")
+        #expect(model.isVisible)
+    }
+
     @Test func preparationModelHidesDraftWhenWorktreeIsCleanAndNoDraftTabExists() {
         let model = ChangesPreparationModel(
             changes: [],

--- a/AlasTests/ReviewChangesModelsTests.swift
+++ b/AlasTests/ReviewChangesModelsTests.swift
@@ -279,15 +279,27 @@ struct ReviewChangesModelsTests {
         #expect(!model.isVisible)
     }
 
-    @Test func preparationModelHidesWhenWorktreeIsClean() {
+    @Test func preparationModelHidesPushWhenNeedsPushIsFalse() {
         let actions = [
             ReviewReadinessModel.Action(kind: .pushBranch, title: "Push", isEnabled: true),
         ]
+        let local = ReviewLoopLocalState(
+            branchName: "feature",
+            headSHA: "abc123",
+            baseBranch: "main",
+            hasWorkingTreeChanges: false,
+            hasStagedChanges: false,
+            aheadCommitCount: 0,
+            hasUpstream: true,
+            needsPush: false
+        )
 
         let model = ChangesPreparationModel(
             changes: [],
             hasDraft: false,
             draftNonEmpty: false,
+            aheadCommitCount: 0,
+            local: local,
             readinessActions: actions
         )
 
@@ -318,7 +330,7 @@ struct ReviewChangesModelsTests {
         #expect(model.isVisible)
     }
 
-    @Test func preparationModelHidesPushWhenLocalStateReportsNoCommitsEvenIfNeedsPushIsTrue() {
+    @Test func preparationModelShowsPushWhenNeedsPushIsTrueEvenIfAheadOfBaseIsZero() throws {
         let actions = [
             ReviewReadinessModel.Action(kind: .pushBranch, title: "Push", isEnabled: true),
         ]
@@ -344,8 +356,10 @@ struct ReviewChangesModelsTests {
 
         #expect(model.reviewAction == nil)
         #expect(model.draftAction == nil)
-        #expect(model.reviewRequestAction == nil)
-        #expect(!model.isVisible)
+        let request = try #require(model.reviewRequestAction)
+        #expect(request.kind == .pushBranch)
+        #expect(request.title == "Push")
+        #expect(model.isVisible)
     }
 
     @Test func preparationModelShowsPushUsingLocalStateCommitCount() throws {

--- a/AlasTests/ReviewChangesModelsTests.swift
+++ b/AlasTests/ReviewChangesModelsTests.swift
@@ -279,6 +279,85 @@ struct ReviewChangesModelsTests {
         #expect(!model.isVisible)
     }
 
+    @Test func preparationModelHidesWhenWorktreeIsClean() {
+        let actions = [
+            ReviewReadinessModel.Action(kind: .pushBranch, title: "Push", isEnabled: true),
+        ]
+
+        let model = ChangesPreparationModel(
+            changes: [],
+            hasDraft: false,
+            draftNonEmpty: false,
+            readinessActions: actions
+        )
+
+        #expect(model.reviewAction == nil)
+        #expect(model.draftAction == nil)
+        #expect(model.reviewRequestAction == nil)
+        #expect(!model.isVisible)
+    }
+
+    @Test func preparationModelShowsPushWhenUnpushedCommitsExistEvenWithoutChanges() throws {
+        let actions = [
+            ReviewReadinessModel.Action(kind: .pushBranch, title: "Push", isEnabled: true),
+        ]
+
+        let model = ChangesPreparationModel(
+            changes: [],
+            hasDraft: false,
+            draftNonEmpty: false,
+            aheadCommitCount: 1,
+            readinessActions: actions
+        )
+
+        #expect(model.reviewAction == nil)
+        #expect(model.draftAction == nil)
+        let request = try #require(model.reviewRequestAction)
+        #expect(request.kind == .pushBranch)
+        #expect(request.title == "Push")
+        #expect(model.isVisible)
+    }
+
+    @Test func preparationModelHidesDraftWhenWorktreeIsCleanAndNoDraftTabExists() {
+        let model = ChangesPreparationModel(
+            changes: [],
+            hasDraft: false,
+            draftNonEmpty: false,
+            readinessActions: []
+        )
+
+        #expect(model.draftAction == nil)
+        #expect(!model.isVisible)
+    }
+
+    @Test func preparationModelStillHidesWhenEmptyDraftTabExistsAndWorktreeIsClean() {
+        let model = ChangesPreparationModel(
+            changes: [],
+            hasDraft: true,
+            draftNonEmpty: false,
+            readinessActions: []
+        )
+
+        #expect(model.draftAction == nil)
+        #expect(model.reviewAction == nil)
+        #expect(model.reviewRequestAction == nil)
+        #expect(!model.isVisible)
+    }
+
+    @Test func preparationModelShowsDraftWhenDraftTabHasContentAndWorktreeIsClean() throws {
+        let model = ChangesPreparationModel(
+            changes: [],
+            hasDraft: true,
+            draftNonEmpty: true,
+            readinessActions: []
+        )
+
+        #expect(model.isVisible)
+        let draft = try #require(model.draftAction)
+        #expect(draft.title == "Open draft")
+        #expect(draft.hasNonEmptyDraft)
+    }
+
     @Test func preparationModelShowsDraftActionForStagedChanges() throws {
         let model = ChangesPreparationModel(
             changes: [
@@ -345,6 +424,7 @@ struct ReviewChangesModelsTests {
             changes: [],
             hasDraft: false,
             draftNonEmpty: false,
+            aheadCommitCount: 1,
             readinessActions: actions
         )
 


### PR DESCRIPTION
## Summary
- Hide the Changes tab Prepare card when there are no reviewable worktree changes, no non-empty draft, and no commits ahead.
- Use ReviewLoopLocalState.aheadCommitCount as the authoritative push signal when available.
- Preserve in-flight readiness actions so progress feedback remains visible.

## Validation
- xcodebuild -project Alas.xcodeproj -scheme Alas -only-testing:AlasTests/ReviewChangesModelsTests test