### PR TITLE
fix(lsp): dismiss diff-pane hover and definition popovers on scroll

### DIFF
--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -8,7 +8,6 @@
 
 /* Begin PBXBuildFile section */
 		004A8BA5B9353F67AAA3AE83 /* NotificationService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2975A1465CA308E9766521F2 /* NotificationService.swift */; };
-		0092774787CA4537B01FF285 /* ACPUsageUpdateDecodeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 413EF1A16EEB4933B3A7BE0B /* ACPUsageUpdateDecodeTests.swift */; };
 		01568CB821D2E938C51BBCAB /* ACPHarnessBridgeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A5A3E6B2F9AC2CBB1CDA78E /* ACPHarnessBridgeTests.swift */; };
 		01C919A6F3868980D51539DD /* ACPInitializeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9DF8B5E766D2B3649D2555ED /* ACPInitializeTests.swift */; };
 		01CBEF6793755D3D9B000BC1 /* CodeLanguageDetailViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E91A6AFCC9B3AEFB43D8946F /* CodeLanguageDetailViewTests.swift */; };
@@ -56,6 +55,7 @@
 		0D65F2B699E6B0CF0915D25D /* ImageDiffMode.swift in Sources */ = {isa = PBXBuildFile; fileRef = 09007B6E90DE89B7215A5D44 /* ImageDiffMode.swift */; };
 		0D8046E333B0DA2B45EE78D4 /* RelativeTime.swift in Sources */ = {isa = PBXBuildFile; fileRef = EECB91379591DA21D216A894 /* RelativeTime.swift */; };
 		0DA68649E5F3C0018C4309DA /* UpdateThrottleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 708AB670AB611EFB9D216D7C /* UpdateThrottleTests.swift */; };
+		0DFC9AB26DDCC406CEAA3825 /* ACPContextUsageButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AD22187C951174C9ECEC4C4 /* ACPContextUsageButton.swift */; };
 		0E2D69C181ECD5233770BC01 /* AgentRunnerParseTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E267334F2224961856D20BD8 /* AgentRunnerParseTests.swift */; };
 		0E892EAAAC4EBA733BC441F2 /* MergeRegionVisualLayout.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0FF6BFD0A460F0E723F796E /* MergeRegionVisualLayout.swift */; };
 		0EB3B61ECD46CCF450E717BF /* EditorOverlayPanelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 208C9ABAF59F523D2DDC2F2A /* EditorOverlayPanelTests.swift */; };
@@ -125,6 +125,7 @@
 		1E775E7F3C9F47C676C61B09 /* SwiftTreeSitter in Frameworks */ = {isa = PBXBuildFile; productRef = F1A519F1F3F2B01C1D2E13A7 /* SwiftTreeSitter */; };
 		1EBF9B83C26B9518AF70D2F3 /* EditorTabStateMarkdownCodableTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E98FAFF3AE36A17EE6AD029C /* EditorTabStateMarkdownCodableTests.swift */; };
 		1ECA2C8485DB484C5C687F3D /* OpenCodeInstallerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 292B5DA9EC17ED07588C48FD /* OpenCodeInstallerTests.swift */; };
+		1ED78A36E993D85D0DD1E3CC /* ACPSessionUsageTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF05DF16587C5A48A9E04B2A /* ACPSessionUsageTests.swift */; };
 		1F5AA7624BE0459338EE0EEC /* DragHandle.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7D398D06BDFFA5EDC24D3E6A /* DragHandle.swift */; };
 		1F84796DE0ABC832C0303B27 /* ACPSessionStoreDedupTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FADFC82400385AD76A200A2B /* ACPSessionStoreDedupTests.swift */; };
 		1F89B774F2DC7DD818AD4E5B /* ACPSessionRunner.swift in Sources */ = {isa = PBXBuildFile; fileRef = F332906E17C5865856DBB90B /* ACPSessionRunner.swift */; };
@@ -203,6 +204,7 @@
 		303E16565ECF8BDDC7A28AF1 /* ACPTopPaginationIndicator.swift in Sources */ = {isa = PBXBuildFile; fileRef = F01FD27D107E0207950F00D3 /* ACPTopPaginationIndicator.swift */; };
 		30A1BE2F8E2777CFF6460486 /* ACPConnectionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 701F837327D905FAAA0E0AF3 /* ACPConnectionTests.swift */; };
 		312DB6016C040DE52CD365E8 /* ACPToolbar.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6DE88BE229FD6C1DF35F7EA /* ACPToolbar.swift */; };
+		316ABEA3944051EA41569FDC /* ACPContextRingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = ECD9419E685AD7EED286006B /* ACPContextRingTests.swift */; };
 		32660CEE9955165AE3CCDFBE /* InstallerHostTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 364507D55CD5D73CD44819E7 /* InstallerHostTests.swift */; };
 		32674DB95F2B62C00FC0AAA2 /* RemoteProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = E4A54DD8080E3395C8E7049E /* RemoteProtocol.swift */; };
 		32727E2775753CDBF02D4660 /* TreeSitterDockerfile in Frameworks */ = {isa = PBXBuildFile; productRef = B0B462D196CBF339A0F9B651 /* TreeSitterDockerfile */; };
@@ -295,6 +297,7 @@
 		433EC05E13C676C1C2EB6888 /* ACPLaunchCatalog.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E669FEBE09BC250B477B335 /* ACPLaunchCatalog.swift */; };
 		43CB2A054DED7568A583822E /* ACPGeminiE2ETests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C204307EE573512D731B8307 /* ACPGeminiE2ETests.swift */; };
 		43EC5CF874B360B9092691A5 /* OKLCHTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0E9F9769B8C6EC2F87092F1B /* OKLCHTests.swift */; };
+		441EC5990D107F1059F377F3 /* ACPUsageUpdateDecodeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BE51418F7A0C3D24A60464C7 /* ACPUsageUpdateDecodeTests.swift */; };
 		4421A9D1E7481B49701B3131 /* mason-lsps.json in Resources */ = {isa = PBXBuildFile; fileRef = F0D567F7F894902AD192D220 /* mason-lsps.json */; };
 		443F48C0A1AF36BFAB8B61E8 /* UnionCanvasGeometry.swift in Sources */ = {isa = PBXBuildFile; fileRef = 650B300A5337E2A9149CF083 /* UnionCanvasGeometry.swift */; };
 		449C7E4A63455D01633B791A /* PendingDiscard.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B15F58AFF7BC19419935C05 /* PendingDiscard.swift */; };
@@ -456,8 +459,6 @@
 		6E0481CC3B5D8676A6E8BE69 /* ACPMarkdownLiveStylerImageChipTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7F4B57FBB6E595E5DF1C6F93 /* ACPMarkdownLiveStylerImageChipTests.swift */; };
 		6E52521BCD52ED8DB496E74B /* CompletionDocumentationRendererTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF41C5BD384265499AEEE4CF /* CompletionDocumentationRendererTests.swift */; };
 		6E66AD13D1763D61F619F3D1 /* ACPAuthNudgeBanner.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE2AD8D0539591C434F51418 /* ACPAuthNudgeBanner.swift */; };
-		A786EE6F5E2E49B29812C5F3 /* ACPContextRing.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4643E5259F9E4A0B865AAA8F /* ACPContextRing.swift */; };
-		F4D62F428DD64FBAB495D426 /* ACPContextUsageButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 67136799356D4536826AFDA9 /* ACPContextUsageButton.swift */; };
 		6E69D87B57B23223A48AB6F7 /* ProjectsManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7FFC9539E615699AC90A7412 /* ProjectsManager.swift */; };
 		6EA7BCF9318AC459144B47FB /* ReviewChangesModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21C7D51D781D8191004C6C90 /* ReviewChangesModels.swift */; };
 		6ED129AC9B6798F76F7D3A51 /* FileTypeIconTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CBAD18141C1A9B654F56982 /* FileTypeIconTests.swift */; };
@@ -467,7 +468,6 @@
 		6FDE6E6F5087E811451A6AD8 /* DiffInlineHighlighter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6561C6DA70F49EDBC69BA854 /* DiffInlineHighlighter.swift */; };
 		7028C08DE3F176175CA1FC20 /* MergeConflictResolvedEmptyView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0914F0E19514D1DF89C74B41 /* MergeConflictResolvedEmptyView.swift */; };
 		702EC5CB48F37FC8B6F27FA4 /* ACPSelectChipTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 98A7F35818C95A567DDA586A /* ACPSelectChipTests.swift */; };
-		26CE81971B5647B2A97D6167 /* ACPContextRingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 69FD24431EE74A949E158A85 /* ACPContextRingTests.swift */; };
 		709F5006202FA86C750BBB69 /* IndentationMode.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3D105CB2C185958ED23164D1 /* IndentationMode.swift */; };
 		70F0096BEEECA74B24A3BF70 /* session-update-config-option.json in Resources */ = {isa = PBXBuildFile; fileRef = 0C5373F76231F229D3F96AF3 /* session-update-config-option.json */; };
 		70FCC2B12AE446728EE7CF8D /* LSPTransport.swift in Sources */ = {isa = PBXBuildFile; fileRef = 38499AFE31188908546EE222 /* LSPTransport.swift */; };
@@ -649,6 +649,7 @@
 		9C78AF82EA26A9928865C5C6 /* ACPSessionManagerAttachRestoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8D36A8AF55F212B9F32A944 /* ACPSessionManagerAttachRestoreTests.swift */; };
 		9C9EC609F3ED8EFF1151D611 /* JSONRPCFramerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F03C1E46A0853704E9B4449A /* JSONRPCFramerTests.swift */; };
 		9CCB74669051D30EF12FE306 /* AlasGhostty.App.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2119507B66D09AF3DF347280 /* AlasGhostty.App.swift */; };
+		9CF654B4AB74CC1A9FBCE55F /* ACPContextRing.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF522B02666DB6AC4C82339E /* ACPContextRing.swift */; };
 		9CF6B43A0B19392A597A53EC /* ACPComposerActionButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = E69452CB123EB0AABB632F03 /* ACPComposerActionButton.swift */; };
 		9D1939E70B46881CCDDC389C /* RightPaneStateReviewLoopPushTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B84EFAC9F0FCF459416920B6 /* RightPaneStateReviewLoopPushTests.swift */; };
 		9D2E53FB0A57BC38C146EA5E /* WorktreeLaunchSurface.swift in Sources */ = {isa = PBXBuildFile; fileRef = 941BC60920D6A87164610273 /* WorktreeLaunchSurface.swift */; };
@@ -663,7 +664,6 @@
 		9E4B32E154B18BD2285F0D34 /* CommitDiffView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2EF18448EDA0DCC8B171F11D /* CommitDiffView.swift */; };
 		9ED684E261871342BA6DFAC9 /* MergeWordDiffTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 72970A1D2817539DB5243058 /* MergeWordDiffTests.swift */; };
 		9FD539228216762192A02C69 /* DialogChrome.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAEDACEB27E6AF219054496E /* DialogChrome.swift */; };
-		63D271D787074F6B83FAD7EF /* ACPSessionUsageTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9E7F5BCA47843BBA78B2B7A /* ACPSessionUsageTests.swift */; };
 		9FDF577BDD6D5C47635229DE /* ACPSessionByteAccountingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 52B5F3FFF8AEF13BC48DCFBD /* ACPSessionByteAccountingTests.swift */; };
 		A03338AC85E6EC8201D56F95 /* TreeSitterGo in Frameworks */ = {isa = PBXBuildFile; productRef = DB0D87DDDAD70492540E6906 /* TreeSitterGo */; };
 		A050BAECF89694B0D613C5D2 /* EditorBuffer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 64E96E26D5F53F217BFD1F49 /* EditorBuffer.swift */; };
@@ -1168,7 +1168,6 @@
 		120D10644A278775A9AE1990 /* ImageDiffViewTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageDiffViewTests.swift; sourceTree = "<group>"; };
 		1271747193D1594AEA596278 /* AlasCLICommandRouter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlasCLICommandRouter.swift; sourceTree = "<group>"; };
 		1281A3235F08DC8A95D015A9 /* ACPSessionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPSessionTests.swift; sourceTree = "<group>"; };
-		A9E7F5BCA47843BBA78B2B7A /* ACPSessionUsageTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPSessionUsageTests.swift; sourceTree = "<group>"; };
 		12E1AD3C6506DA5E6BFF4864 /* ImagePreviewTabView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImagePreviewTabView.swift; sourceTree = "<group>"; };
 		12F5FD1C6AEC80509D52C724 /* FontFamilyPicker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FontFamilyPicker.swift; sourceTree = "<group>"; };
 		134EE8D2BC31085A504D27D8 /* InstallNudgeResolverTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InstallNudgeResolverTests.swift; sourceTree = "<group>"; };
@@ -1370,7 +1369,6 @@
 		410A42B1C46E68965FD36793 /* ShortcutChip.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShortcutChip.swift; sourceTree = "<group>"; };
 		412B2AF1B68E3B56DE21EB91 /* DiagnosticsRangeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiagnosticsRangeTests.swift; sourceTree = "<group>"; };
 		413CE0B0BBC96D412D048B1D /* .gitkeep */ = {isa = PBXFileReference; path = .gitkeep; sourceTree = "<group>"; };
-		413EF1A16EEB4933B3A7BE0B /* ACPUsageUpdateDecodeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPUsageUpdateDecodeTests.swift; sourceTree = "<group>"; };
 		417CDD7CCA0D0A86E9EE281F /* CenterSelectionState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CenterSelectionState.swift; sourceTree = "<group>"; };
 		41995BCAEF1E2B356E499333 /* ReviewChangesFileSection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReviewChangesFileSection.swift; sourceTree = "<group>"; };
 		419EF533C4D29448483045DA /* ACPChangeNotifier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPChangeNotifier.swift; sourceTree = "<group>"; };
@@ -1559,7 +1557,6 @@
 		6FFE12732C0D83715FC990A9 /* CommitsSectionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommitsSectionView.swift; sourceTree = "<group>"; };
 		7018E992654E19345D8BD723 /* ImageDiffSwipeViewTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageDiffSwipeViewTests.swift; sourceTree = "<group>"; };
 		701F837327D905FAAA0E0AF3 /* ACPConnectionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPConnectionTests.swift; sourceTree = "<group>"; };
-		69FD24431EE74A949E158A85 /* ACPContextRingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPContextRingTests.swift; sourceTree = "<group>"; };
 		70255847CE81CE85E0117A85 /* ACPMarkdownBlockCache.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPMarkdownBlockCache.swift; sourceTree = "<group>"; };
 		70377E10CD6D08B225BDFABE /* TabsManagerBufferTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabsManagerBufferTests.swift; sourceTree = "<group>"; };
 		705A47F78FEC16C2CA293BAC /* AppConfigSidebarChromeOverridesTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppConfigSidebarChromeOverridesTests.swift; sourceTree = "<group>"; };
@@ -1652,6 +1649,7 @@
 		8942D0F47DBCFFB3549EE775 /* ShortcutReservations.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShortcutReservations.swift; sourceTree = "<group>"; };
 		89B23F35BE6FD53B74DD84ED /* ZmxSessionName.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ZmxSessionName.swift; sourceTree = "<group>"; };
 		89C4AE9D01CA02A9689AAE8B /* CompletionWindowControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CompletionWindowControllerTests.swift; sourceTree = "<group>"; };
+		8AD22187C951174C9ECEC4C4 /* ACPContextUsageButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPContextUsageButton.swift; sourceTree = "<group>"; };
 		8B4BB6C10F3718F7D0A50BAE /* ACPFirstRunConnectingPolicy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPFirstRunConnectingPolicy.swift; sourceTree = "<group>"; };
 		8B94010802299E6AC5597E85 /* WorktreeCodableTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorktreeCodableTests.swift; sourceTree = "<group>"; };
 		8BCE20FA56461E66A58A7AA2 /* MemorySnapshot.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MemorySnapshot.swift; sourceTree = "<group>"; };
@@ -1785,7 +1783,9 @@
 		ADC27B340A795F13EA4E0765 /* ReviewSessionLoaderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReviewSessionLoaderTests.swift; sourceTree = "<group>"; };
 		AE0A6F237480EE72CB8DBE28 /* TitlelessWindowTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TitlelessWindowTests.swift; sourceTree = "<group>"; };
 		AE35206EEBD7E3A35C3421EA /* ACPRecoveryPill.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPRecoveryPill.swift; sourceTree = "<group>"; };
+		AF05DF16587C5A48A9E04B2A /* ACPSessionUsageTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPSessionUsageTests.swift; sourceTree = "<group>"; };
 		AF2F716F911BB20B3E78C40B /* AgentDefinition.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentDefinition.swift; sourceTree = "<group>"; };
+		AF522B02666DB6AC4C82339E /* ACPContextRing.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPContextRing.swift; sourceTree = "<group>"; };
 		B0886F9B3096AC1264E3D337 /* ReviewFeedbackBundle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReviewFeedbackBundle.swift; sourceTree = "<group>"; };
 		B0D0ED01C390D1F729993B13 /* MarkdownImageLoaderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MarkdownImageLoaderTests.swift; sourceTree = "<group>"; };
 		B0D2C54087C4501C3E7793FE /* ChatPane.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatPane.swift; sourceTree = "<group>"; };
@@ -1849,6 +1849,7 @@
 		BDABED76CD2A552B1781D3F4 /* EditorLSPStatusBadge.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditorLSPStatusBadge.swift; sourceTree = "<group>"; };
 		BDD799D0EC22F74A3DCB7F09 /* DeletingWorktreeView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeletingWorktreeView.swift; sourceTree = "<group>"; };
 		BDEA5E54A30636928F5D3B3E /* GitIgnoreService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GitIgnoreService.swift; sourceTree = "<group>"; };
+		BE51418F7A0C3D24A60464C7 /* ACPUsageUpdateDecodeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPUsageUpdateDecodeTests.swift; sourceTree = "<group>"; };
 		BE7AEB9E8D83B610E291BAE1 /* ContentSearcher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentSearcher.swift; sourceTree = "<group>"; };
 		BE809DBC1E614321EE793D00 /* WorkspaceLSPManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkspaceLSPManager.swift; sourceTree = "<group>"; };
 		BEBCF3820A017BBF33B0AB07 /* ACPProtocolVersion.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPProtocolVersion.swift; sourceTree = "<group>"; };
@@ -1927,8 +1928,6 @@
 		CDAE8FBBADF986E1E6585941 /* ReviewChangesModelsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReviewChangesModelsTests.swift; sourceTree = "<group>"; };
 		CDE49D2437D7E6AC9D67F136 /* RemoteSessionGateway.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteSessionGateway.swift; sourceTree = "<group>"; };
 		CE2AD8D0539591C434F51418 /* ACPAuthNudgeBanner.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPAuthNudgeBanner.swift; sourceTree = "<group>"; };
-		4643E5259F9E4A0B865AAA8F /* ACPContextRing.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPContextRing.swift; sourceTree = "<group>"; };
-		67136799356D4536826AFDA9 /* ACPContextUsageButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPContextUsageButton.swift; sourceTree = "<group>"; };
 		CE3FA58107EA372581313A5F /* MergeView3WayLayoutTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MergeView3WayLayoutTests.swift; sourceTree = "<group>"; };
 		CE6CCD7F7273667B5D67F821 /* SearchScope.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchScope.swift; sourceTree = "<group>"; };
 		CEA8BA11A167DA43E22E7D2D /* SpacesManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpacesManagerTests.swift; sourceTree = "<group>"; };
@@ -2064,6 +2063,7 @@
 		EC7FA2ABE27A4CC2EB0BCA18 /* ACPTranscriptCurrentPlanTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPTranscriptCurrentPlanTests.swift; sourceTree = "<group>"; };
 		EC9F12CC9A1AA0A56CF7BA3A /* AppConfigTerminalTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppConfigTerminalTests.swift; sourceTree = "<group>"; };
 		ECB537B70B998A15B81BCBF7 /* CodeTextViewIndentationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CodeTextViewIndentationTests.swift; sourceTree = "<group>"; };
+		ECD9419E685AD7EED286006B /* ACPContextRingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPContextRingTests.swift; sourceTree = "<group>"; };
 		ECFB48AF581F74C564ACBCF5 /* CompletionDocumentationRenderer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CompletionDocumentationRenderer.swift; sourceTree = "<group>"; };
 		EDABAB5EEE4C15A78B5429E6 /* ComposerActionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ComposerActionTests.swift; sourceTree = "<group>"; };
 		EE0C0029F439C282D474ED77 /* ACPFileWriter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPFileWriter.swift; sourceTree = "<group>"; };
@@ -2648,7 +2648,7 @@
 				2015944331CE56AEEF534910 /* ACPStdioQuestionDispatchTests.swift */,
 				01DB2EFD475B2D7D5D75B06A /* ACPStdioTerminalDispatchTests.swift */,
 				54897710493742A6DFD6ABF3 /* ACPToolCallContentTests.swift */,
-				413EF1A16EEB4933B3A7BE0B /* ACPUsageUpdateDecodeTests.swift */,
+				BE51418F7A0C3D24A60464C7 /* ACPUsageUpdateDecodeTests.swift */,
 				4E340D23D2484C570F8E4B7F /* FakeJSONRPCTransport.swift */,
 			);
 			path = Protocol;
@@ -2963,7 +2963,7 @@
 				B9454F0214E21F91473C96F6 /* ACPComposerDraftBridgeTests.swift */,
 				A637073E5D65DAA4E0CF6EA4 /* ACPComposerImageExtractTests.swift */,
 				85E54E9F53ECFE9C205788F1 /* ACPComposerPlaceholderTests.swift */,
-				69FD24431EE74A949E158A85 /* ACPContextRingTests.swift */,
+				ECD9419E685AD7EED286006B /* ACPContextRingTests.swift */,
 				DC76F9150CC29A324D785C29 /* ACPDelayedHoverVisibilityTests.swift */,
 				F6EDDD4D22267C26B496A6FF /* ACPFirstRunConnectingPolicyTests.swift */,
 				FDE53456308778DF77B18AF4 /* ACPImageEncodingTests.swift */,
@@ -3244,8 +3244,8 @@
 				2B0206F856D9639147D0A4BF /* ACPComposerActions.swift */,
 				906D92F7AD84F313508D9CFD /* ACPComposerShell.swift */,
 				DFBD2A49431277EB68106AAA /* ACPConnectingPlaceholder.swift */,
-				4643E5259F9E4A0B865AAA8F /* ACPContextRing.swift */,
-				67136799356D4536826AFDA9 /* ACPContextUsageButton.swift */,
+				AF522B02666DB6AC4C82339E /* ACPContextRing.swift */,
+				8AD22187C951174C9ECEC4C4 /* ACPContextUsageButton.swift */,
 				BA6C7434D216D5C43A2FB921 /* ACPFileChip.swift */,
 				29D7631D754795D16E946440 /* ACPFileEditCard.swift */,
 				8B4BB6C10F3718F7D0A50BAE /* ACPFirstRunConnectingPolicy.swift */,
@@ -3528,8 +3528,8 @@
 				F0A443685B2A3322208D51AE /* ACPSessionStoreTests.swift */,
 				9A2292E8F8E3D91440BE88FC /* ACPSessionTerminalRoutingTests.swift */,
 				1281A3235F08DC8A95D015A9 /* ACPSessionTests.swift */,
-				A9E7F5BCA47843BBA78B2B7A /* ACPSessionUsageTests.swift */,
 				2777D1596E51D8DCA8E7ABA3 /* ACPSessionToolCallTruncationTests.swift */,
+				AF05DF16587C5A48A9E04B2A /* ACPSessionUsageTests.swift */,
 				EAA78FF7BA562DC4423AC35D /* ACPSessionVisibleQueueTests.swift */,
 				F16F771D1DD9CAC618459D41 /* ACPStreamingTextTests.swift */,
 				26E8DE57F9A8D5230BCB7A2C /* ACPSubmitIntentTests.swift */,
@@ -4320,9 +4320,9 @@
 				C04150547C17399FA9D7947C /* ACPComposerShell.swift in Sources */,
 				1298147855092677E3184AC2 /* ACPConfigOption.swift in Sources */,
 				809972779548945B012F8B6C /* ACPConnectingPlaceholder.swift in Sources */,
-				A786EE6F5E2E49B29812C5F3 /* ACPContextRing.swift in Sources */,
-				F4D62F428DD64FBAB495D426 /* ACPContextUsageButton.swift in Sources */,
 				C7EC6D85810513194F831F13 /* ACPConnection.swift in Sources */,
+				9CF654B4AB74CC1A9FBCE55F /* ACPContextRing.swift in Sources */,
+				0DFC9AB26DDCC406CEAA3825 /* ACPContextUsageButton.swift in Sources */,
 				2A19A7B4B392979989E25EC0 /* ACPDiffGenerator.swift in Sources */,
 				7FFC3D96011714F0A131FAB8 /* ACPFileChip.swift in Sources */,
 				DB305015BF666EEE0F9C7BAB /* ACPFileEditCard.swift in Sources */,
@@ -4895,8 +4895,8 @@
 				3FCC4EDA31A96BE121F45D44 /* ACPComposerPlaceholderTests.swift in Sources */,
 				FB2AE30704F39C0BDA83F3CC /* ACPConfigOptionTests.swift in Sources */,
 				30A1BE2F8E2777CFF6460486 /* ACPConnectionTests.swift in Sources */,
-				26CE81971B5647B2A97D6167 /* ACPContextRingTests.swift in Sources */,
 				839AF384DDFF728207769920 /* ACPContentBlockImageTests.swift in Sources */,
+				316ABEA3944051EA41569FDC /* ACPContextRingTests.swift in Sources */,
 				DADDDA3FA289B52415EF4379 /* ACPDelayedHoverVisibilityTests.swift in Sources */,
 				47789166FA5C563AE2F550ED /* ACPDiffGeneratorTests.swift in Sources */,
 				B4C4E13CFE986FC20DC12808 /* ACPFileWriterTests.swift in Sources */,
@@ -4956,9 +4956,9 @@
 				08DF3AC4BA50775940371445 /* ACPSessionStoreTests.swift in Sources */,
 				48AD9728403D96C9C5958AC6 /* ACPSessionTerminalRoutingTests.swift in Sources */,
 				B472D692A8D8D1C664EAC467 /* ACPSessionTests.swift in Sources */,
-				63D271D787074F6B83FAD7EF /* ACPSessionUsageTests.swift in Sources */,
 				960593EAB0380436038D1400 /* ACPSessionToolCallTruncationTests.swift in Sources */,
 				33376EB37508D556E2385D33 /* ACPSessionUpdateTests.swift in Sources */,
+				1ED78A36E993D85D0DD1E3CC /* ACPSessionUsageTests.swift in Sources */,
 				A4476A509577896F9DADE5CB /* ACPSessionVisibleQueueTests.swift in Sources */,
 				AC2574A26E931F0881F560C6 /* ACPSetupCheckerTests.swift in Sources */,
 				07BB2B329992BA535053BB80 /* ACPSetupNudgeBannerModeTests.swift in Sources */,
@@ -4970,12 +4970,12 @@
 				11827C40372D7209868161C0 /* ACPTerminalHostTests.swift in Sources */,
 				89F58C7178B661EAE0057622 /* ACPTerminalTests.swift in Sources */,
 				E1E4C11CC5BFF761DF397507 /* ACPToolCallContentTests.swift in Sources */,
-				0092774787CA4537B01FF285 /* ACPUsageUpdateDecodeTests.swift in Sources */,
 				4B8BD1280C2DFF3CE1FD3C4B /* ACPTranscriptCurrentPlanTests.swift in Sources */,
 				A8EE9207A828D4D1BAF1C1C1 /* ACPTranscriptLatestPlanTests.swift in Sources */,
 				F1C4DD0D3A95ED5301EE2AC9 /* ACPTranscriptMarkdownCacheEvictionTests.swift in Sources */,
 				6682233134C258D81E22D7AD /* ACPTranscriptMarkdownTests.swift in Sources */,
 				A3F27DE52BAC71EFFA69938A /* ACPTranscriptWindowTests.swift in Sources */,
+				441EC5990D107F1059F377F3 /* ACPUsageUpdateDecodeTests.swift in Sources */,
 				83A76F6425CD1406DA85B0E9 /* ACPUserScrollEventTests.swift in Sources */,
 				E30832C33A680645C481826F /* ANSIStreamTests.swift in Sources */,
 				162A6ABEAE92BB3AD1511567 /* AdvancedSettingsVisibilityTests.swift in Sources */,

--- a/Alas/Sources/Center/Diff/DiffPaneLSP.swift
+++ b/Alas/Sources/Center/Diff/DiffPaneLSP.swift
@@ -165,6 +165,7 @@ final class DiffPaneLSPController {
     /// can stay stuck on screen until the user scrolls back to the symbol.
     func notifyScrolled() {
         hideHover()
+        cancelDefinitionRequests()
         definitionPopover?.close()
         definitionPopover = nil
     }
@@ -533,6 +534,12 @@ final class DiffPaneLSPController {
         hoverTask?.cancel()
         definitionTask?.cancel()
         hoverTask = nil
+        definitionTask = nil
+    }
+
+    private func cancelDefinitionRequests() {
+        definitionRequestID &+= 1
+        definitionTask?.cancel()
         definitionTask = nil
     }
 

--- a/Alas/Sources/Center/Diff/DiffPaneLSP.swift
+++ b/Alas/Sources/Center/Diff/DiffPaneLSP.swift
@@ -158,6 +158,17 @@ final class DiffPaneLSPController {
     private var definitionRequestID: UInt64 = 0
     private var hoverSymbolRange: NSRange?
 
+    /// Dismisses any visible hover panel and definition popover. Called when
+    /// the enclosing diff pane scrolls, because the symbol anchor the popovers
+    /// were anchored to may have moved or left the visible area. Without this,
+    /// a hover panel (which is a child window anchored to screen coordinates)
+    /// can stay stuck on screen until the user scrolls back to the symbol.
+    func notifyScrolled() {
+        hideHover()
+        definitionPopover?.close()
+        definitionPopover = nil
+    }
+
     init(textView: DiffPaneCodeTextView) {
         self.textView = textView
         textView.hoverHandler = { [weak self] point in
@@ -302,6 +313,14 @@ final class DiffPaneLSPController {
         context: DiffPaneLSPContext
     ) async -> Bool {
         await matchesCurrentSource(match, context: context)
+    }
+
+    var isHoverVisibleForTesting: Bool { hoverWindowController.isVisible }
+    var isDefinitionPopoverShownForTesting: Bool { definitionPopover != nil }
+
+    func showDefinitionPopoverForTesting(_ popover: NSPopover) {
+        definitionPopover?.close()
+        definitionPopover = popover
     }
 
     private func matchesCurrentSource(

--- a/Alas/Sources/Center/Diff/DiffPaneTextDocumentView.swift
+++ b/Alas/Sources/Center/Diff/DiffPaneTextDocumentView.swift
@@ -852,7 +852,7 @@ final class DiffPaneCodeTextView: NSTextView {
     var hasLSPContextForTesting: Bool { lspContext != nil }
     var allowedLSPSideForTesting: DiffLineSide { allowedLSPSide }
     private var scrollBoundsObservers: [NSObjectProtocol] = []
-    private var observedScrollViews: [NSScrollView] = []
+    private var observedScrollViewIDs: [ObjectIdentifier] = []
     private var scheduledRebindWorkItem: DispatchWorkItem?
 
     var theme: Theme? {
@@ -1121,7 +1121,8 @@ final class DiffPaneCodeTextView: NSTextView {
         // scroll direction that actually moves the symbol away. Rebind on every
         // update so we always observe every ancestor scroll view.
         let scrollViews = ancestorScrollViews()
-        guard scrollViews != observedScrollViews else { return }
+        let scrollViewIDs = scrollViews.map(ObjectIdentifier.init)
+        guard scrollViewIDs != observedScrollViewIDs else { return }
         removeScrollBoundsObserver()
         for scrollView in scrollViews {
             let clipView = scrollView.contentView
@@ -1137,7 +1138,7 @@ final class DiffPaneCodeTextView: NSTextView {
             }
             scrollBoundsObservers.append(token)
         }
-        observedScrollViews = scrollViews
+        observedScrollViewIDs = scrollViewIDs
     }
 
     private func ancestorScrollViews() -> [NSScrollView] {
@@ -1157,7 +1158,7 @@ final class DiffPaneCodeTextView: NSTextView {
             NotificationCenter.default.removeObserver(token)
         }
         scrollBoundsObservers.removeAll()
-        observedScrollViews.removeAll()
+        observedScrollViewIDs.removeAll()
     }
 
     func reviewLineAnchor(atRow row: Int) -> DiffReviewLineAnchor? {

--- a/Alas/Sources/Center/Diff/DiffPaneTextDocumentView.swift
+++ b/Alas/Sources/Center/Diff/DiffPaneTextDocumentView.swift
@@ -851,6 +851,7 @@ final class DiffPaneCodeTextView: NSTextView {
     var allowedLSPSide: DiffLineSide = .new
     var hasLSPContextForTesting: Bool { lspContext != nil }
     var allowedLSPSideForTesting: DiffLineSide { allowedLSPSide }
+    private var scrollBoundsObserver: NSObjectProtocol?
     var theme: Theme? {
         didSet { needsDisplay = true }
     }
@@ -874,7 +875,11 @@ final class DiffPaneCodeTextView: NSTextView {
 
     deinit {
         let lspController = lspController
+        let observer = scrollBoundsObserver
         Task { @MainActor in
+            if let observer {
+                NotificationCenter.default.removeObserver(observer)
+            }
             lspController?.tearDown()
         }
     }
@@ -1069,12 +1074,37 @@ final class DiffPaneCodeTextView: NSTextView {
         guard let lspContext else {
             lspController?.tearDown()
             lspController = nil
+            removeScrollBoundsObserver()
             return
         }
         if lspController == nil {
             lspController = DiffPaneLSPController(textView: self)
+            installScrollBoundsObserver()
         }
         lspController?.update(context: lspContext, allowedSide: allowedLSPSide)
+    }
+
+    private func installScrollBoundsObserver() {
+        guard scrollBoundsObserver == nil,
+              let scrollView = enclosingScrollView else { return }
+        let clipView = scrollView.contentView
+        clipView.postsBoundsChangedNotifications = true
+        scrollBoundsObserver = NotificationCenter.default.addObserver(
+            forName: NSView.boundsDidChangeNotification,
+            object: clipView,
+            queue: .main
+        ) { [weak self] _ in
+            MainActor.assumeIsolated {
+                self?.lspController?.notifyScrolled()
+            }
+        }
+    }
+
+    private func removeScrollBoundsObserver() {
+        if let token = scrollBoundsObserver {
+            NotificationCenter.default.removeObserver(token)
+        }
+        scrollBoundsObserver = nil
     }
 
     func reviewLineAnchor(atRow row: Int) -> DiffReviewLineAnchor? {

--- a/Alas/Sources/Center/Diff/DiffPaneTextDocumentView.swift
+++ b/Alas/Sources/Center/Diff/DiffPaneTextDocumentView.swift
@@ -853,6 +853,8 @@ final class DiffPaneCodeTextView: NSTextView {
     var allowedLSPSideForTesting: DiffLineSide { allowedLSPSide }
     private var scrollBoundsObservers: [NSObjectProtocol] = []
     private var observedScrollViews: [NSScrollView] = []
+    private var scheduledRebindWorkItem: DispatchWorkItem?
+
     var theme: Theme? {
         didSet { needsDisplay = true }
     }
@@ -877,12 +879,33 @@ final class DiffPaneCodeTextView: NSTextView {
     deinit {
         let lspController = lspController
         let observers = scrollBoundsObservers
+        let workItem = scheduledRebindWorkItem
         Task { @MainActor in
             for observer in observers {
                 NotificationCenter.default.removeObserver(observer)
             }
+            workItem?.cancel()
             lspController?.tearDown()
         }
+    }
+
+    override func viewDidMoveToWindow() {
+        super.viewDidMoveToWindow()
+        scheduleDeferredRebind()
+    }
+
+    override func viewDidMoveToSuperview() {
+        super.viewDidMoveToSuperview()
+        scheduleDeferredRebind()
+    }
+
+    private func scheduleDeferredRebind() {
+        scheduledRebindWorkItem?.cancel()
+        let workItem = DispatchWorkItem { [weak self] in
+            self?.installScrollBoundsObserver()
+        }
+        scheduledRebindWorkItem = workItem
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.1, execute: workItem)
     }
 
     override func draw(_ dirtyRect: NSRect) {
@@ -1076,6 +1099,7 @@ final class DiffPaneCodeTextView: NSTextView {
             lspController?.tearDown()
             lspController = nil
             removeScrollBoundsObserver()
+            scheduledRebindWorkItem?.cancel()
             return
         }
         if lspController == nil {
@@ -1085,6 +1109,7 @@ final class DiffPaneCodeTextView: NSTextView {
         // text view to the outer vertical `ScrollView` after the first mount,
         // so the outermost ancestor scroll view can change over time.
         installScrollBoundsObserver()
+        scheduleDeferredRebind()
         lspController?.update(context: lspContext, allowedSide: allowedLSPSide)
     }
 

--- a/Alas/Sources/Center/Diff/DiffPaneTextDocumentView.swift
+++ b/Alas/Sources/Center/Diff/DiffPaneTextDocumentView.swift
@@ -851,7 +851,8 @@ final class DiffPaneCodeTextView: NSTextView {
     var allowedLSPSide: DiffLineSide = .new
     var hasLSPContextForTesting: Bool { lspContext != nil }
     var allowedLSPSideForTesting: DiffLineSide { allowedLSPSide }
-    private var scrollBoundsObserver: NSObjectProtocol?
+    private var scrollBoundsObservers: [NSObjectProtocol] = []
+    private var observedScrollViews: [NSScrollView] = []
     var theme: Theme? {
         didSet { needsDisplay = true }
     }
@@ -875,9 +876,9 @@ final class DiffPaneCodeTextView: NSTextView {
 
     deinit {
         let lspController = lspController
-        let observer = scrollBoundsObserver
+        let observers = scrollBoundsObservers
         Task { @MainActor in
-            if let observer {
+            for observer in observers {
                 NotificationCenter.default.removeObserver(observer)
             }
             lspController?.tearDown()
@@ -1079,32 +1080,59 @@ final class DiffPaneCodeTextView: NSTextView {
         }
         if lspController == nil {
             lspController = DiffPaneLSPController(textView: self)
-            installScrollBoundsObserver()
         }
+        // Rebind the scroll observer on every update. SwiftUI may attach the
+        // text view to the outer vertical `ScrollView` after the first mount,
+        // so the outermost ancestor scroll view can change over time.
+        installScrollBoundsObserver()
         lspController?.update(context: lspContext, allowedSide: allowedLSPSide)
     }
 
     private func installScrollBoundsObserver() {
-        guard scrollBoundsObserver == nil,
-              let scrollView = enclosingScrollView else { return }
-        let clipView = scrollView.contentView
-        clipView.postsBoundsChangedNotifications = true
-        scrollBoundsObserver = NotificationCenter.default.addObserver(
-            forName: NSView.boundsDidChangeNotification,
-            object: clipView,
-            queue: .main
-        ) { [weak self] _ in
-            MainActor.assumeIsolated {
-                self?.lspController?.notifyScrolled()
+        // The diff pane has two scrolling layers: each `DiffPaneTextScrollView`
+        // handles horizontal scrolling of a code pane, and in internal-scroll
+        // mode a SwiftUI `ScrollView(.vertical)` wraps the hunk cards as an
+        // ancestor `NSScrollView`. Observing only one of them can miss the
+        // scroll direction that actually moves the symbol away. Rebind on every
+        // update so we always observe every ancestor scroll view.
+        let scrollViews = ancestorScrollViews()
+        guard scrollViews != observedScrollViews else { return }
+        removeScrollBoundsObserver()
+        for scrollView in scrollViews {
+            let clipView = scrollView.contentView
+            clipView.postsBoundsChangedNotifications = true
+            let token = NotificationCenter.default.addObserver(
+                forName: NSView.boundsDidChangeNotification,
+                object: clipView,
+                queue: .main
+            ) { [weak self] _ in
+                MainActor.assumeIsolated {
+                    self?.lspController?.notifyScrolled()
+                }
             }
+            scrollBoundsObservers.append(token)
         }
+        observedScrollViews = scrollViews
+    }
+
+    private func ancestorScrollViews() -> [NSScrollView] {
+        var scrollViews: [NSScrollView] = []
+        var current: NSView? = self
+        while let view = current {
+            if let scrollView = view as? NSScrollView {
+                scrollViews.append(scrollView)
+            }
+            current = view.superview
+        }
+        return scrollViews
     }
 
     private func removeScrollBoundsObserver() {
-        if let token = scrollBoundsObserver {
+        for token in scrollBoundsObservers {
             NotificationCenter.default.removeObserver(token)
         }
-        scrollBoundsObserver = nil
+        scrollBoundsObservers.removeAll()
+        observedScrollViews.removeAll()
     }
 
     func reviewLineAnchor(atRow row: Int) -> DiffReviewLineAnchor? {

--- a/Alas/Sources/Code/Editor/CodeEditorCoordinator.swift
+++ b/Alas/Sources/Code/Editor/CodeEditorCoordinator.swift
@@ -551,6 +551,7 @@ final class CodeEditorCoordinator {
                 queue: .main
             ) { [weak self] _ in
                 self?.hover?.notifyScrolled()
+                self?.definition?.notifyScrolled()
             }
             hoverObservers.append(token)
         }
@@ -561,6 +562,7 @@ final class CodeEditorCoordinator {
             queue: .main
         ) { [weak self] _ in
             self?.hover?.notifyCaretChanged()
+            self?.definition?.notifyCaretChanged()
         }
         hoverObservers.append(selectionToken)
 
@@ -577,6 +579,7 @@ final class CodeEditorCoordinator {
                   let window = note.object as? NSWindow,
                   window === self.textView?.window else { return }
             self.hover?.notifyWindowResized()
+            self.definition?.notifyWindowResized()
         }
         hoverObservers.append(resizeToken)
 

--- a/Alas/Sources/Code/LSP/Features/DefinitionFeature.swift
+++ b/Alas/Sources/Code/LSP/Features/DefinitionFeature.swift
@@ -30,6 +30,10 @@ final class DefinitionFeature {
         textView.commandClickHandler = { [weak self] p in self?.onClick(at: p) }
     }
 
+    func notifyScrolled() { popover?.close() }
+    func notifyCaretChanged() { popover?.close() }
+    func notifyWindowResized() { popover?.close() }
+
     private func onClick(at point: NSPoint) {
         popover?.close()
         guard let textView, let client = getClient(), let uri = getURI() else { return }

--- a/Alas/Sources/Code/LSP/Features/DefinitionFeature.swift
+++ b/Alas/Sources/Code/LSP/Features/DefinitionFeature.swift
@@ -30,9 +30,16 @@ final class DefinitionFeature {
         textView.commandClickHandler = { [weak self] p in self?.onClick(at: p) }
     }
 
-    func notifyScrolled() { popover?.close() }
-    func notifyCaretChanged() { popover?.close() }
-    func notifyWindowResized() { popover?.close() }
+    func notifyScrolled() { dismiss() }
+    func notifyCaretChanged() { dismiss() }
+    func notifyWindowResized() { dismiss() }
+
+    private func dismiss() {
+        requestID += 1
+        inFlight?.cancel()
+        inFlight = nil
+        popover?.close()
+    }
 
     private func onClick(at point: NSPoint) {
         popover?.close()

--- a/AlasTests/DiffPaneLSPTests.swift
+++ b/AlasTests/DiffPaneLSPTests.swift
@@ -366,6 +366,44 @@ struct DiffPaneLSPLineMapTests {
     }
 
     @MainActor
+    @Test func notifyScrolledDismissesHoverAndDefinitionPopover() throws {
+        let textView = DiffPaneCodeTextView(
+            frame: NSRect(x: 0, y: 0, width: 300, height: 80),
+            textContainer: NSTextContainer()
+        )
+        let renderedLine = DiffDisplayLine(
+            id: "file:new:0:0",
+            anchor: DiffLineAnchor(filePath: "Sources/App.swift", hunkIndex: 0, rowIndex: 0, side: .new, oldLine: nil, newLine: 1),
+            text: "let value = 1",
+            lineNumber: 1,
+            kind: .add,
+            inlineSpans: [],
+            noTrailingNewline: false
+        )
+        textView.lineMetadata = [
+            DiffPaneTextDocumentBuilder.LineMetadata(
+                kind: .add,
+                range: NSRange(location: 0, length: 13),
+                tone: .add,
+                sourceLine: renderedLine
+            ),
+        ]
+        textView.theme = try! ThemeStore().current
+        let controller = DiffPaneLSPController(textView: textView)
+        controller.update(context: nil, allowedSide: .new)
+
+        let popover = NSPopover()
+        controller.showDefinitionPopoverForTesting(popover)
+        #expect(controller.isDefinitionPopoverShownForTesting)
+
+        controller.notifyScrolled()
+
+        #expect(!controller.isDefinitionPopoverShownForTesting)
+        #expect(!controller.isHoverVisibleForTesting)
+        controller.tearDown()
+    }
+
+    @MainActor
     @Test func controllerRejectsSourceLineShiftedByOpenEditorBuffer() async throws {
         let root = FileManager.default.temporaryDirectory.appendingPathComponent("alas-lsp-dirty-editor-\(UUID().uuidString)")
         let source = root.appendingPathComponent("Sources/App.swift")


### PR DESCRIPTION
## Summary

- Fixes a bug where LSP hover panels and the definition picker in the commit-details diff pane stayed visible after the user scrolled away from the underlying symbol.
- Adds `notifyScrolled()` to `DiffPaneLSPController` and wires it to the enclosing scroll view's `boundsDidChange` notification.
- Extends the same scroll/caret/resize dismissal to the editor's `DefinitionFeature` so the editor definition picker can't get stuck either.
- Adds a unit test verifying `notifyScrolled()` dismisses both the hover panel and the definition popover.
