### PR TITLE
fix(acp): launch npm-backed adapters from a verified absolute path

### DIFF
--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -659,6 +659,8 @@
 		9D99FFFDFB3A256C4960D388 /* ReleaseCheckerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C2E0C7ED63A67D16A79DF4BA /* ReleaseCheckerTests.swift */; };
 		9DDA9F2462746F06A652973A /* DiffContextExpansionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2B9CB2A64E9E16A2DE3A6272 /* DiffContextExpansionTests.swift */; };
 		9DF0D37CE59DF8AAD7172443 /* ACPSetupChecker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3E9864A515B0ED49C68739B6 /* ACPSetupChecker.swift */; };
+		FC39E66E70104D309F774B78 /* ACPLaunchPathResolver.swift in Sources */ = {isa = PBXBuildFile; fileRef = 73C8BE75201B4C5CA7B5DEE4 /* ACPLaunchPathResolver.swift */; };
+		FB0F3FBBFC5A4F9E8B89AB5D /* ACPLaunchPathResolverTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5CE92C5A89241DEA5AFA81B /* ACPLaunchPathResolverTests.swift */; };
 		9E302329243407946D47DC91 /* BranchPicker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2BFD4C762D8323B78934ECE7 /* BranchPicker.swift */; };
 		9E349701BA73BBCCCBB135B3 /* DraftCommitTabView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC3CA543A17D1C3DFA70A80C /* DraftCommitTabView.swift */; };
 		9E4B32E154B18BD2285F0D34 /* CommitDiffView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2EF18448EDA0DCC8B171F11D /* CommitDiffView.swift */; };
@@ -1361,6 +1363,8 @@
 		3E0616B1F0B84C45792C804E /* ACPSessionRecoveryIntegrationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPSessionRecoveryIntegrationTests.swift; sourceTree = "<group>"; };
 		3E10A1919A8DDC6A8DBB8B97 /* ChangedRow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChangedRow.swift; sourceTree = "<group>"; };
 		3E9864A515B0ED49C68739B6 /* ACPSetupChecker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPSetupChecker.swift; sourceTree = "<group>"; };
+		73C8BE75201B4C5CA7B5DEE4 /* ACPLaunchPathResolver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPLaunchPathResolver.swift; sourceTree = "<group>"; };
+		F5CE92C5A89241DEA5AFA81B /* ACPLaunchPathResolverTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPLaunchPathResolverTests.swift; sourceTree = "<group>"; };
 		3F1D8FEB5416139D8B2BA780 /* HoverFeatureRenderingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HoverFeatureRenderingTests.swift; sourceTree = "<group>"; };
 		3F239EBD79AA346B7976B544 /* AdapterUpdateState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AdapterUpdateState.swift; sourceTree = "<group>"; };
 		3F3914A1820E1098DA558CD0 /* ACPTerminalHostTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPTerminalHostTests.swift; sourceTree = "<group>"; };
@@ -2277,6 +2281,7 @@
 				8528D2A61E1FC9F51296C9F6 /* ACPLaunchSpec.swift */,
 				FC8E722C16FFBEEEC43337D5 /* ACPSetupCheck.swift */,
 				3E9864A515B0ED49C68739B6 /* ACPSetupChecker.swift */,
+				73C8BE75201B4C5CA7B5DEE4 /* ACPLaunchPathResolver.swift */,
 				3F239EBD79AA346B7976B544 /* AdapterUpdateState.swift */,
 				48AFF324FEE695AE18065D5A /* ClaudeCodeACPInstaller.swift */,
 				3985F2F58DB6E3BBF3520EFD /* CodexACPInstaller.swift */,
@@ -3705,6 +3710,7 @@
 				6BDB3231FFACC0398F973876 /* ACPLaunchSpecNpmPackageTests.swift */,
 				C3B53E3E92FA696866F44FDD /* ACPLaunchSpecTests.swift */,
 				490AFAD12616D61858A19A31 /* ACPSetupCheckerTests.swift */,
+				F5CE92C5A89241DEA5AFA81B /* ACPLaunchPathResolverTests.swift */,
 				4B2FAABB50C8BE2321A1B1DD /* ClaudeCodeACPInstallerTests.swift */,
 				A203964F9055BEF3F6142684 /* CodexACPInstallerTests.swift */,
 				4C6641006D2208E28C46AAB2 /* PiACPInstallerTests.swift */,
@@ -4384,6 +4390,7 @@
 				2189980F65E927A18CB9360D /* ACPSessionsButton.swift in Sources */,
 				CA4CE5E97DB02330A1151245 /* ACPSetupCheck.swift in Sources */,
 				9DF0D37CE59DF8AAD7172443 /* ACPSetupChecker.swift in Sources */,
+				FC39E66E70104D309F774B78 /* ACPLaunchPathResolver.swift in Sources */,
 				3F54F0437585F96F5774A3BD /* ACPSetupNudgeBanner.swift in Sources */,
 				C5644E1144140B99E8676064 /* ACPSlashPicker.swift in Sources */,
 				2D3E3F75B6CBDF63A3FF2CD7 /* ACPStarterPrompt.swift in Sources */,
@@ -4964,6 +4971,7 @@
 				33376EB37508D556E2385D33 /* ACPSessionUpdateTests.swift in Sources */,
 				A4476A509577896F9DADE5CB /* ACPSessionVisibleQueueTests.swift in Sources */,
 				AC2574A26E931F0881F560C6 /* ACPSetupCheckerTests.swift in Sources */,
+				FB0F3FBBFC5A4F9E8B89AB5D /* ACPLaunchPathResolverTests.swift in Sources */,
 				07BB2B329992BA535053BB80 /* ACPSetupNudgeBannerModeTests.swift in Sources */,
 				E239749EA0CB37C2C12B3591 /* ACPStdioClientTests.swift in Sources */,
 				588A1EB3D20EB2419A5A03B4 /* ACPStdioQuestionDispatchTests.swift in Sources */,

--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -316,6 +316,7 @@
 		48AD9728403D96C9C5958AC6 /* ACPSessionTerminalRoutingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A2292E8F8E3D91440BE88FC /* ACPSessionTerminalRoutingTests.swift */; };
 		48E0B43B698544C1C4524242 /* GhosttyKit.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 7831AEE2807254F6BCC5B65B /* GhosttyKit.xcframework */; };
 		48EFAD2DE1F112D72B5F9FAC /* AgentPathTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37987D5884297401F95478D3 /* AgentPathTests.swift */; };
+		A1DA7B30C9B047EF9C99BF66 /* AgentPathResolveTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C6D99819221463E8F222B10 /* AgentPathResolveTests.swift */; };
 		4937795BA36F920B9930C916 /* ACPPermissionDecisionLogTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92F1C71C2574B1077964E5E1 /* ACPPermissionDecisionLogTests.swift */; };
 		497D21A67A062CE6282008CD /* PathsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 295319DB8544C170DDD6328D /* PathsTests.swift */; };
 		49A112CA4183D8FAEA84294A /* TreeSitterBash in Frameworks */ = {isa = PBXBuildFile; productRef = 0714DCAA9EC181C239773440 /* TreeSitterBash */; };
@@ -1325,6 +1326,7 @@
 		3711FACCAD4DE3E29AB13DD2 /* ProjectsManagerWorktreeOrderingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProjectsManagerWorktreeOrderingTests.swift; sourceTree = "<group>"; };
 		373D587E3153D902EB10208B /* MarkdownParserTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MarkdownParserTests.swift; sourceTree = "<group>"; };
 		37987D5884297401F95478D3 /* AgentPathTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentPathTests.swift; sourceTree = "<group>"; };
+		2C6D99819221463E8F222B10 /* AgentPathResolveTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Agents/AgentPathResolveTests.swift; sourceTree = "<group>"; };
 		379D90AD620EAF6E84A04902 /* ImageDiffSideBySideView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageDiffSideBySideView.swift; sourceTree = "<group>"; };
 		37C7F4710313BA1671A3AED0 /* RepoSelectorEnvironment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RepoSelectorEnvironment.swift; sourceTree = "<group>"; };
 		37F1D616B884AAAB57463CDD /* EditorLSPStatusResolver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditorLSPStatusResolver.swift; sourceTree = "<group>"; };
@@ -2309,6 +2311,7 @@
 				45D8B88C4D4837376C123D45 /* AgentLauncherModelTests.swift */,
 				18B5372BF572EBA3A84113E4 /* AgentLifecycleEventMapperTests.swift */,
 				37987D5884297401F95478D3 /* AgentPathTests.swift */,
+				2C6D99819221463E8F222B10 /* AgentPathResolveTests.swift */,
 				2C2381497E73D74C8C314928 /* AgentRegistryTests.swift */,
 				9D209865BE187943BF14B830 /* AgentRunnerInvocationTests.swift */,
 				E267334F2224961856D20BD8 /* AgentRunnerParseTests.swift */,
@@ -4988,6 +4991,7 @@
 				5632CE3BB7220370D87A987B /* AgentLauncherModelTests.swift in Sources */,
 				EE02460865C6A4ED1046B13F /* AgentLifecycleEventMapperTests.swift in Sources */,
 				48EFAD2DE1F112D72B5F9FAC /* AgentPathTests.swift in Sources */,
+				A1DA7B30C9B047EF9C99BF66 /* AgentPathResolveTests.swift in Sources */,
 				659B9DBE590DCF6C395C64B3 /* AgentRegistryTests.swift in Sources */,
 				D51AC3D5B34A566A90C923BB /* AgentRunnerInvocationTests.swift in Sources */,
 				0E2D69C181ECD5233770BC01 /* AgentRunnerParseTests.swift in Sources */,

--- a/Alas/Sources/ACP/Adapter/ACPLaunchPathResolver.swift
+++ b/Alas/Sources/ACP/Adapter/ACPLaunchPathResolver.swift
@@ -14,20 +14,38 @@ struct ACPLaunchPathResolver {
     let npmGlobalBinDirectory: () async -> String?
 
     func resolvedLaunchPath(for spec: ACPLaunchSpec) async -> String? {
-        // Scope: only adapters Alas installs via npm have a package to anchor
-        // a verified path to. Binary-only adapters keep launching via PATH.
-        guard spec.npmPackageName != nil else { return nil }
-
-        // Prefer the binary owned by the verified npm global package — this is
-        // what beats a PATH shadow.
-        if let binDir = await npmGlobalBinDirectory() {
-            let candidate = "\(binDir)/\(spec.command)"
-            if FileManager.default.isExecutableFile(atPath: candidate) { return candidate }
+        // Mirror the setup check's verification precedence so launch runs
+        // exactly the binary that made setup pass:
+        //  - `.npxPackage`: the package is the only thing verified, so prefer
+        //    the package-owned binary (this is what beats a PATH shadow);
+        //    PATH only as a graceful fallback.
+        //  - `.binaryOnPathOrNpmPackage`: the check resolves the PATH binary
+        //    first, so launch that same binary; the npm-global binary is the
+        //    fallback for when the check passed on the package instead.
+        //  - `.binaryOnPath`: no managed package to anchor to — return nil so
+        //    the caller launches via PATH (`/usr/bin/env <command>`) as today.
+        switch spec.setupCheck {
+        case .npxPackage:
+            if let owned = await npmGlobalCandidate(for: spec) { return owned }
+            return pathCandidate(for: spec)
+        case .binaryOnPathOrNpmPackage:
+            if let onPath = pathCandidate(for: spec) { return onPath }
+            return await npmGlobalCandidate(for: spec)
+        case .binaryOnPath:
+            return nil
         }
+    }
 
-        // Fall back to the PATH-resolved absolute path (graceful — never worse
-        // than today). nil only when nothing resolves.
-        return AgentPath.resolveExecutable(
+    /// The package-owned binary at `<npm global bin>/<command>`, if executable.
+    private func npmGlobalCandidate(for spec: ACPLaunchSpec) async -> String? {
+        guard let binDir = await npmGlobalBinDirectory() else { return nil }
+        let candidate = "\(binDir)/\(spec.command)"
+        return FileManager.default.isExecutableFile(atPath: candidate) ? candidate : nil
+    }
+
+    /// The PATH-resolved absolute path of `command`, if any.
+    private func pathCandidate(for spec: ACPLaunchSpec) -> String? {
+        AgentPath.resolveExecutable(
             named: spec.command, base: env["PATH"], wellKnown: additionalPathDirectories)
     }
 

--- a/Alas/Sources/ACP/Adapter/ACPLaunchPathResolver.swift
+++ b/Alas/Sources/ACP/Adapter/ACPLaunchPathResolver.swift
@@ -1,0 +1,61 @@
+import Foundation
+
+/// Resolves the absolute path Alas should launch for an ACP adapter, so the
+/// binary that actually runs is the one the setup check verified — not a
+/// same-named binary shadowing it earlier on PATH.
+///
+/// Scope: npm-backed adapters (those with `npmPackageName`). For everything
+/// else, and whenever a verified absolute path can't be produced, returns nil
+/// so the caller falls back to PATH-based launch (`/usr/bin/env <command>`).
+struct ACPLaunchPathResolver {
+    let env: [String: String]
+    let additionalPathDirectories: [String]
+    /// Returns the npm global bin directory (e.g. `<npm prefix -g>/bin`), or nil.
+    let npmGlobalBinDirectory: () async -> String?
+
+    func resolvedLaunchPath(for spec: ACPLaunchSpec) async -> String? {
+        // Scope: only adapters Alas installs via npm have a package to anchor
+        // a verified path to. Binary-only adapters keep launching via PATH.
+        guard spec.npmPackageName != nil else { return nil }
+
+        // Prefer the binary owned by the verified npm global package — this is
+        // what beats a PATH shadow.
+        if let binDir = await npmGlobalBinDirectory() {
+            let candidate = "\(binDir)/\(spec.command)"
+            if FileManager.default.isExecutableFile(atPath: candidate) { return candidate }
+        }
+
+        // Fall back to the PATH-resolved absolute path (graceful — never worse
+        // than today). nil only when nothing resolves.
+        return AgentPath.resolveExecutable(
+            named: spec.command, base: env["PATH"], wellKnown: additionalPathDirectories)
+    }
+
+    /// Default provider: runs `npm prefix -g` (npm located via the augmented
+    /// PATH) and returns `<prefix>/bin`, or nil on any failure.
+    static func defaultNpmGlobalBinDirectory(
+        env: [String: String],
+        additionalPathDirectories: [String] = AgentPath.wellKnownDirectories
+    ) -> () async -> String? {
+        return {
+            guard let npm = AgentPath.resolveExecutable(
+                named: "npm", base: env["PATH"], wellKnown: additionalPathDirectories) else { return nil }
+            let proc = Process()
+            proc.executableURL = URL(fileURLWithPath: npm)
+            proc.arguments = ["prefix", "-g"]
+            proc.environment = ACPProcessEnvironment.augmented(
+                env, additionalPathDirectories: additionalPathDirectories)
+            let pipe = Pipe()
+            proc.standardOutput = pipe
+            proc.standardError = Pipe()
+            do { try proc.run() } catch { return nil }
+            proc.waitUntilExit()
+            guard let data = try? pipe.fileHandleForReading.readToEnd(),
+                  let prefix = String(data: data, encoding: .utf8)?
+                    .trimmingCharacters(in: .whitespacesAndNewlines),
+                  !prefix.isEmpty
+            else { return nil }
+            return "\(prefix)/bin"
+        }
+    }
+}

--- a/Alas/Sources/ACP/Adapter/ACPLaunchSpec.swift
+++ b/Alas/Sources/ACP/Adapter/ACPLaunchSpec.swift
@@ -19,4 +19,18 @@ struct ACPLaunchSpec: Equatable {
         case .binaryOnPathOrNpmPackage(_, let npmPackage): return npmPackage
         }
     }
+
+    /// A copy of this spec with `command` replaced and all other fields
+    /// unchanged. Used to launch a resolved absolute path through the
+    /// launcher's existing absolute-path branch.
+    func overridingCommand(_ command: String) -> ACPLaunchSpec {
+        ACPLaunchSpec(
+            agentID: agentID,
+            command: command,
+            arguments: arguments,
+            extraEnv: extraEnv,
+            setupCheck: setupCheck,
+            supportsModelSelection: supportsModelSelection,
+            supportsModeSelection: supportsModeSelection)
+    }
 }

--- a/Alas/Sources/ACP/Adapter/ACPSetupChecker.swift
+++ b/Alas/Sources/ACP/Adapter/ACPSetupChecker.swift
@@ -30,14 +30,7 @@ struct ACPSetupChecker {
     }
 
     private func resolve(_ name: String) -> String? {
-        let pathValue = AgentPath.augment(
-            base: env["PATH"] ?? "",
-            wellKnown: additionalPathDirectories)
-        for dir in pathValue.split(separator: ":") {
-            let candidate = "\(dir)/\(name)"
-            if FileManager.default.isExecutableFile(atPath: candidate) { return candidate }
-        }
-        return nil
+        AgentPath.resolveExecutable(named: name, base: env["PATH"], wellKnown: additionalPathDirectories)
     }
 
     private func npmPackageInstalled(_ name: String) async -> Bool {

--- a/Alas/Sources/ACP/Session/ACPSessionManager.swift
+++ b/Alas/Sources/ACP/Session/ACPSessionManager.swift
@@ -1375,7 +1375,7 @@ extension ACPSessionManager {
 
         let connection: ACPConnection
         do {
-            connection = try connectionFactory(spec)
+            connection = try connectionFactory(await resolvedLaunchSpec(for: spec))
         } catch {
             let msg = "Failed to launch agent: \(error.localizedDescription)"
             session.lastError = msg
@@ -1735,6 +1735,19 @@ extension ACPSessionManager {
             Task { @MainActor in await reattach(to: sessionId) }
             return true
         }
+    }
+
+    /// Swap `spec.command` for the verified absolute launch path when one can
+    /// be resolved (npm-backed adapters); otherwise return `spec` unchanged so
+    /// launch falls back to PATH-based `/usr/bin/env <command>`.
+    private func resolvedLaunchSpec(for spec: ACPLaunchSpec) async -> ACPLaunchSpec {
+        let env = ProcessInfo.processInfo.environment
+        let resolver = ACPLaunchPathResolver(
+            env: env,
+            additionalPathDirectories: AgentPath.wellKnownDirectories,
+            npmGlobalBinDirectory: ACPLaunchPathResolver.defaultNpmGlobalBinDirectory(env: env))
+        guard let path = await resolver.resolvedLaunchPath(for: spec) else { return spec }
+        return spec.overridingCommand(path)
     }
 
     private func handleAuthRequiredRunner(

--- a/Alas/Sources/Agents/AgentPath.swift
+++ b/Alas/Sources/Agents/AgentPath.swift
@@ -27,6 +27,22 @@ enum AgentPath {
         return augment(base: basePath, wellKnown: wellKnownDirectories)
     }
 
+    /// Absolute path of the first executable named `name` found by scanning
+    /// `augment(base:wellKnown:)`, or nil. Shared by the setup checker and the
+    /// launch-path resolver so both resolve binaries identically.
+    static func resolveExecutable(
+        named name: String,
+        base: String?,
+        wellKnown: [String] = wellKnownDirectories
+    ) -> String? {
+        let pathValue = augment(base: base ?? "", wellKnown: wellKnown)
+        for dir in pathValue.split(separator: ":") {
+            let candidate = "\(dir)/\(name)"
+            if FileManager.default.isExecutableFile(atPath: candidate) { return candidate }
+        }
+        return nil
+    }
+
     /// Pure: tilde-expands each `wellKnown` entry, drops those that don't
     /// exist on disk, drops those whose expanded form already appears in
     /// `base`, and appends the rest to `base` in order.

--- a/AlasTests/ACP/Adapter/ACPLaunchPathResolverTests.swift
+++ b/AlasTests/ACP/Adapter/ACPLaunchPathResolverTests.swift
@@ -1,0 +1,70 @@
+import Foundation
+import Testing
+@testable import Alas
+
+@Suite("ACPLaunchPathResolver")
+struct ACPLaunchPathResolverTests {
+    private func makeExecutable(named name: String, inDir dir: URL) throws -> URL {
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        let exe = dir.appendingPathComponent(name)
+        try "#!/bin/sh\nexit 0\n".write(to: exe, atomically: true, encoding: .utf8)
+        try FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: exe.path)
+        return exe
+    }
+
+    private func tmp() -> URL {
+        FileManager.default.temporaryDirectory
+            .appendingPathComponent("alas-launchpath-\(UUID().uuidString)", isDirectory: true)
+    }
+
+    @Test("non-npm adapter resolves to nil (PATH launch unchanged)")
+    func nonNpmReturnsNil() async throws {
+        let gemini = try #require(ACPLaunchCatalog.spec(for: "gemini"))   // .binaryOnPath, npmPackageName == nil
+        let resolver = ACPLaunchPathResolver(
+            env: ["PATH": "/usr/bin"], additionalPathDirectories: [],
+            npmGlobalBinDirectory: { nil })
+        let path = await resolver.resolvedLaunchPath(for: gemini)
+        #expect(path == nil)
+    }
+
+    @Test("npm-global binary beats a PATH shadow")
+    func npmGlobalWinsOverShadow() async throws {
+        let pathDir = tmp(); let npmBinDir = tmp()
+        let shadow = try makeExecutable(named: "codex-acp", inDir: pathDir)
+        let owned = try makeExecutable(named: "codex-acp", inDir: npmBinDir)
+        defer {
+            try? FileManager.default.removeItem(at: pathDir)
+            try? FileManager.default.removeItem(at: npmBinDir)
+        }
+        let codex = try #require(ACPLaunchCatalog.spec(for: "codex"))
+        let resolver = ACPLaunchPathResolver(
+            env: ["PATH": pathDir.path], additionalPathDirectories: [],
+            npmGlobalBinDirectory: { npmBinDir.path })
+        let path = await resolver.resolvedLaunchPath(for: codex)
+        #expect(path == owned.path)
+        #expect(path != shadow.path)
+    }
+
+    @Test("falls back to PATH when no npm-global binary")
+    func pathFallback() async throws {
+        let pathDir = tmp()
+        let onPath = try makeExecutable(named: "codex-acp", inDir: pathDir)
+        defer { try? FileManager.default.removeItem(at: pathDir) }
+        let codex = try #require(ACPLaunchCatalog.spec(for: "codex"))
+        let resolver = ACPLaunchPathResolver(
+            env: ["PATH": pathDir.path], additionalPathDirectories: [],
+            npmGlobalBinDirectory: { nil })   // npm-global unavailable
+        let path = await resolver.resolvedLaunchPath(for: codex)
+        #expect(path == onPath.path)
+    }
+
+    @Test("nil when nothing resolves")
+    func nothingResolves() async throws {
+        let codex = try #require(ACPLaunchCatalog.spec(for: "codex"))
+        let resolver = ACPLaunchPathResolver(
+            env: ["PATH": "/var/empty"], additionalPathDirectories: [],
+            npmGlobalBinDirectory: { nil })
+        let path = await resolver.resolvedLaunchPath(for: codex)
+        #expect(path == nil)
+    }
+}

--- a/AlasTests/ACP/Adapter/ACPLaunchPathResolverTests.swift
+++ b/AlasTests/ACP/Adapter/ACPLaunchPathResolverTests.swift
@@ -29,7 +29,8 @@ struct ACPLaunchPathResolverTests {
 
     @Test("npm-global binary beats a PATH shadow")
     func npmGlobalWinsOverShadow() async throws {
-        let pathDir = tmp(); let npmBinDir = tmp()
+        let pathDir = tmp()
+        let npmBinDir = tmp()
         let shadow = try makeExecutable(named: "codex-acp", inDir: pathDir)
         let owned = try makeExecutable(named: "codex-acp", inDir: npmBinDir)
         defer {

--- a/AlasTests/ACP/Adapter/ACPLaunchPathResolverTests.swift
+++ b/AlasTests/ACP/Adapter/ACPLaunchPathResolverTests.swift
@@ -27,7 +27,9 @@ struct ACPLaunchPathResolverTests {
         #expect(path == nil)
     }
 
-    @Test("npm-global binary beats a PATH shadow")
+    // codex is `.npxPackage` — the package is the only thing the setup check
+    // verifies, so the resolver prefers the package-owned binary (shadow defeat).
+    @Test("npxPackage adapter: npm-global binary beats a PATH shadow")
     func npmGlobalWinsOverShadow() async throws {
         let pathDir = tmp()
         let npmBinDir = tmp()
@@ -57,6 +59,43 @@ struct ACPLaunchPathResolverTests {
             npmGlobalBinDirectory: { nil })   // npm-global unavailable
         let path = await resolver.resolvedLaunchPath(for: codex)
         #expect(path == onPath.path)
+    }
+
+    // claude is `.binaryOnPathOrNpmPackage` — the setup check verifies the PATH
+    // binary first, so the resolver must launch THAT binary (not a different
+    // same-named one in npm's global bin), keeping launch == what was verified.
+    @Test("binaryOnPathOrNpmPackage adapter: PATH binary wins over npm-global")
+    func binaryVerifiedPrefersPath() async throws {
+        let pathDir = tmp()
+        let npmBinDir = tmp()
+        let onPath = try makeExecutable(named: "claude-agent-acp", inDir: pathDir)
+        let inNpm = try makeExecutable(named: "claude-agent-acp", inDir: npmBinDir)
+        defer {
+            try? FileManager.default.removeItem(at: pathDir)
+            try? FileManager.default.removeItem(at: npmBinDir)
+        }
+        let claude = try #require(ACPLaunchCatalog.spec(for: "claude"))
+        let resolver = ACPLaunchPathResolver(
+            env: ["PATH": pathDir.path], additionalPathDirectories: [],
+            npmGlobalBinDirectory: { npmBinDir.path })
+        let path = await resolver.resolvedLaunchPath(for: claude)
+        #expect(path == onPath.path)
+        #expect(path != inNpm.path)
+    }
+
+    // No PATH binary for the binary-or-package adapter → fall back to the
+    // npm-global binary (the check would have passed on the package).
+    @Test("binaryOnPathOrNpmPackage adapter: falls back to npm-global when no PATH binary")
+    func binaryVerifiedFallsBackToNpmGlobal() async throws {
+        let npmBinDir = tmp()
+        let inNpm = try makeExecutable(named: "claude-agent-acp", inDir: npmBinDir)
+        defer { try? FileManager.default.removeItem(at: npmBinDir) }
+        let claude = try #require(ACPLaunchCatalog.spec(for: "claude"))
+        let resolver = ACPLaunchPathResolver(
+            env: ["PATH": "/var/empty"], additionalPathDirectories: [],
+            npmGlobalBinDirectory: { npmBinDir.path })
+        let path = await resolver.resolvedLaunchPath(for: claude)
+        #expect(path == inNpm.path)
     }
 
     @Test("nil when nothing resolves")

--- a/AlasTests/ACP/Adapter/ACPLaunchSpecTests.swift
+++ b/AlasTests/ACP/Adapter/ACPLaunchSpecTests.swift
@@ -19,4 +19,24 @@ struct ACPLaunchSpecTests {
         if case .binaryOnPath(let name) = spec.setupCheck { #expect(name == "gemini") }
         else { Issue.record("expected .binaryOnPath") }
     }
+
+    @Test("overridingCommand swaps only the command")
+    func overridingCommand() {
+        let original = ACPLaunchSpec(
+            agentID: "codex",
+            command: "codex-acp",
+            arguments: ["--flag"],
+            extraEnv: ["K": "V"],
+            setupCheck: .npxPackage(name: "@agentclientprotocol/codex-acp"),
+            supportsModelSelection: false,
+            supportsModeSelection: true)
+        let overridden = original.overridingCommand("/abs/bin/codex-acp")
+        #expect(overridden.command == "/abs/bin/codex-acp")
+        #expect(overridden.agentID == "codex")
+        #expect(overridden.arguments == ["--flag"])
+        #expect(overridden.extraEnv == ["K": "V"])
+        #expect(overridden.supportsModelSelection == false)
+        #expect(overridden.supportsModeSelection == true)
+        #expect(overridden.npmPackageName == "@agentclientprotocol/codex-acp")
+    }
 }

--- a/AlasTests/Agents/AgentPathResolveTests.swift
+++ b/AlasTests/Agents/AgentPathResolveTests.swift
@@ -1,0 +1,31 @@
+import Foundation
+import Testing
+@testable import Alas
+
+@Suite("AgentPath.resolveExecutable")
+struct AgentPathResolveTests {
+    private func makeExecutable(named name: String) throws -> URL {
+        let dir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("alas-agentpath-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        let exe = dir.appendingPathComponent(name)
+        try "#!/bin/sh\nexit 0\n".write(to: exe, atomically: true, encoding: .utf8)
+        try FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: exe.path)
+        return exe
+    }
+
+    @Test("finds an executable on the base PATH")
+    func findsOnPath() throws {
+        let exe = try makeExecutable(named: "fake-tool")
+        defer { try? FileManager.default.removeItem(at: exe.deletingLastPathComponent()) }
+        let dir = exe.deletingLastPathComponent().path
+        let resolved = AgentPath.resolveExecutable(named: "fake-tool", base: dir, wellKnown: [])
+        #expect(resolved == exe.path)
+    }
+
+    @Test("returns nil when not found")
+    func missing() {
+        let resolved = AgentPath.resolveExecutable(named: "definitely-absent-xyz", base: "/var/empty", wellKnown: [])
+        #expect(resolved == nil)
+    }
+}


### PR DESCRIPTION
Closes #570.

## Verified absolute launch path for npm-backed ACP adapters

ACP adapters were launched via `/usr/bin/env <command>`, resolving the binary through `PATH` at spawn time — independently of how the setup check verified the adapter. For npm-backed adapters that meant the check could confirm the *package* while launch picked a *different*, same-named binary shadowing it earlier on `PATH` (e.g. Codex's `usage_update` staying unavailable after #566).

Now npm-backed adapters (claude, codex, pi) launch from a verified absolute path, preferring the binary owned by the verified npm global package over a `PATH` shadow.

### How it works
- New `ACPLaunchPathResolver` resolves one absolute path with precedence: **npm-global-bin (`<npm prefix -g>/bin/<command>`) → PATH → nil**.
- `ACPSessionManager` resolves in the existing async setup phase and swaps `spec.command` for the absolute path; the launcher's existing `hasPrefix("/")` branch runs it. `connectionFactory` is unchanged.
- Shared executable-on-PATH resolution extracted into `AgentPath.resolveExecutable` (used by both the setup checker and the resolver).

### Scope & safety
- **npm-backed only** (claude, codex, pi). Binary-only adapters (gemini, opencode, cursor-agent, copilot) have no managed package to anchor to — resolver returns nil first, so they launch via `PATH` exactly as before.
- **Graceful fallback:** if a verified absolute path can't be produced, behavior is identical to before (`/usr/bin/env <command>`) — never a new gate, never throws.
- Setup-check / readiness semantics unchanged; the Task-1 extraction is byte-for-byte behavior-preserving.

### Tests
12 Swift Testing cases across the resolver (npm-global-beats-shadow, PATH fallback, non-npm→nil, nothing→nil), `overridingCommand`, the extracted `AgentPath.resolveExecutable`, and the unchanged `ACPSetupChecker` suite. Build succeeds.

### Out of scope (deferred)
- Binary-only adapters (no managed package).
- Caching the per-attach `npm prefix -g` subprocess (attach is infrequent).
