### PR TITLE
fix(changes): disable focus ring on review status footer

### DIFF
--- a/Alas/Sources/Integrations/CodeHost/ReviewLoopDrawer.swift
+++ b/Alas/Sources/Integrations/CodeHost/ReviewLoopDrawer.swift
@@ -66,6 +66,7 @@ struct ReviewLoopDrawer: View {
             toggleExpanded()
         }
         .focusable()
+        .focusEffectDisabled()
         .onKeyPress(.return) {
             toggleExpanded()
             return .handled


### PR DESCRIPTION
Removes the blue keyboard focus outline from the Changes tab footer by making the collapsed review status row non-focusable.