### PR TITLE
fix: SwiftUI row identity

### DIFF
--- a/Alas/Sources/ACP/UI/ACPMentionPicker.swift
+++ b/Alas/Sources/ACP/UI/ACPMentionPicker.swift
@@ -76,7 +76,7 @@ struct ACPMentionPickerView: View {
                             .foregroundStyle(theme.color("fg-faint"))
                             .padding(.horizontal, 10).padding(.vertical, 10)
                     } else {
-                        ForEach(Array(ranked.enumerated()), id: \.offset) { idx, file in
+                        ForEach(Array(ranked.enumerated()), id: \.element) { idx, file in
                             row(idx: idx, file: file).id(idx)
                         }
                     }

--- a/Alas/Sources/ACP/UI/ACPMessageList.swift
+++ b/Alas/Sources/ACP/UI/ACPMessageList.swift
@@ -190,7 +190,7 @@ struct ACPMessageList: View {
                     .frame(maxWidth: .infinity, alignment: .center)
                     .modifier(ACPScrollTargetLayoutTracking())
                 }
-                .coordinateSpace(name: scrollSpaceName)
+                .coordinateSpace(.named(scrollSpaceName))
                 .modifier(ACPTranscriptScrollTracking(
                     isRestoring: { isRestoringTail },
                     onResolveScrollView: { scrollViewRef.scrollView = $0 },

--- a/Alas/Sources/ACP/UI/ACPSelectChip.swift
+++ b/Alas/Sources/ACP/UI/ACPSelectChip.swift
@@ -181,7 +181,7 @@ private struct DropdownPanel: View {
             ScrollViewReader { proxy in
                 ScrollView {
                     LazyVStack(alignment: .leading, spacing: 1) {
-                        ForEach(Array(filtered.enumerated()), id: \.offset) { idx, item in
+                        ForEach(Array(filtered.enumerated()), id: \.element.id) { idx, item in
                             row(idx: idx, item: item)
                                 .id(idx)
                         }

--- a/Alas/Sources/ACP/UI/ACPSlashPicker.swift
+++ b/Alas/Sources/ACP/UI/ACPSlashPicker.swift
@@ -103,7 +103,7 @@ struct ACPSlashPickerView: View {
                             .frame(maxWidth: .infinity, alignment: .leading)
                             .padding(.horizontal, 10).padding(.vertical, 6)
                     } else {
-                        ForEach(Array(items.enumerated()), id: \.offset) { idx, s in
+                        ForEach(Array(items.enumerated()), id: \.element) { idx, s in
                             row(s, isSelected: idx == model.selectedIndex)
                                 .id(idx)
                                 .contentShape(Rectangle())

--- a/Alas/Sources/Agents/AgentLauncherDialog.swift
+++ b/Alas/Sources/Agents/AgentLauncherDialog.swift
@@ -152,7 +152,7 @@ struct AgentLauncherDialog: View {
                     if agents.isEmpty {
                         emptyState
                     } else {
-                        ForEach(Array(agents.enumerated()), id: \.offset) { idx, agent in
+                        ForEach(Array(agents.enumerated()), id: \.element.id) { idx, agent in
                             AgentLauncherRow(
                                 agent: agent,
                                 isSelected: idx == appState.agentLauncher.selectedIndex,

--- a/Alas/Sources/Center/DiffReview/DiffReviewSurface.swift
+++ b/Alas/Sources/Center/DiffReview/DiffReviewSurface.swift
@@ -242,7 +242,7 @@ struct DiffReviewSurface: View {
                     }
                     .padding(16)
                 }
-                .coordinateSpace(name: Self.scrollCoordinateSpace)
+                .coordinateSpace(.named(Self.scrollCoordinateSpace))
                 .onPreferenceChange(DiffReviewSectionFramePreferenceKey.self) { frames in
                     updateSelectedFileFromScroll(frames: frames, viewportHeight: viewport.size.height)
                     updateRenderedFileIDs(

--- a/Alas/Sources/Center/TabActivityPulse.swift
+++ b/Alas/Sources/Center/TabActivityPulse.swift
@@ -13,7 +13,7 @@ struct TabActivityPulse: ViewModifier {
             .animation(breathingAnimation, value: animatedOpacity)
             .animation(.spring(duration: 0.3), value: pulseTrigger)
             .onAppear { appeared = true }
-            .onChange(of: activityState) { newState in
+            .onChange(of: activityState) { _, newState in
                 if newState != previousState && newState != nil && newState != .idle {
                     pulseTrigger = true
                     DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) {

--- a/Alas/Sources/Center/TerminalTabView.swift
+++ b/Alas/Sources/Center/TerminalTabView.swift
@@ -26,7 +26,7 @@ struct TerminalTabView: View {
                 TerminalRecoverPlaceholder(state: state, worktreeId: worktreeId, tabId: tabId)
             }
         }
-        .coordinateSpace(name: tabCoordinateSpace)
+        .coordinateSpace(.named(tabCoordinateSpace))
         .onPreferenceChange(LeafFramesKey.self) { frames in
             state.terminalLeafFrames[tabId] = frames
         }

--- a/Alas/Sources/Code/Editor/EditorFindBarView.swift
+++ b/Alas/Sources/Code/Editor/EditorFindBarView.swift
@@ -37,7 +37,7 @@ struct EditorFindBarView: View {
                     .frame(minWidth: 36, idealWidth: showsReplace ? 120 : 180, maxWidth: .infinity)
                     .layoutPriority(2)
                     .onSubmit { onFind(.next) }
-                    .onChange(of: findText) { _ in
+                    .onChange(of: findText) {
                         onFindChanged()
                     }
             }

--- a/Alas/Sources/Code/LSP/Features/CompletionPopup.swift
+++ b/Alas/Sources/Code/LSP/Features/CompletionPopup.swift
@@ -23,7 +23,7 @@ struct CompletionPopup: View {
             ScrollViewReader { proxy in
                 ScrollView {
                     LazyVStack(alignment: .leading, spacing: 0) {
-                        ForEach(Array(rows.enumerated()), id: \.offset) { index, row in
+                        ForEach(Array(rows.enumerated()), id: \.element.id) { index, row in
                             rowView(row)
                                 .id(index)
                                 .background(index == selection ? Color.accentColor.opacity(0.24) : Color.clear)

--- a/Alas/Sources/Code/LSP/Features/DefinitionPicker.swift
+++ b/Alas/Sources/Code/LSP/Features/DefinitionPicker.swift
@@ -25,7 +25,7 @@ struct DefinitionPicker: View {
                 .padding(.bottom, 6)
             ScrollView {
                 VStack(alignment: .leading, spacing: 0) {
-                    ForEach(Array(entries.enumerated()), id: \.offset) { idx, entry in
+                    ForEach(Array(entries.enumerated()), id: \.element.id) { idx, entry in
                         row(idx: idx, entry: entry)
                             .background(idx == selection ? Color.accentColor.opacity(0.18) : Color.clear)
                             .contentShape(Rectangle())

--- a/Alas/Sources/Dialogs/RepoSelector/RepoSelectorDialog.swift
+++ b/Alas/Sources/Dialogs/RepoSelector/RepoSelectorDialog.swift
@@ -90,30 +90,31 @@ struct RepoSelectorDialog: View {
     private var rowList: some View {
         let env = environment()
         let rows = appState.repoSelector.rows(environment: env)
+        let renderedRows = rows.enumerated().map { RepoSelectorRenderedRow(index: $0.offset, row: $0.element) }
         let projectsById = Dictionary(uniqueKeysWithValues: appState.projects.map { ($0.id, $0) })
         return ScrollViewReader { proxy in
             ScrollView {
                 LazyVStack(alignment: .leading, spacing: 0) {
-                    ForEach(Array(rows.enumerated()), id: \.offset) { idx, row in
+                    ForEach(renderedRows) { renderedRow in
                         RepoSelectorRowView(
-                            row: row,
-                            isSelected: idx == appState.repoSelector.selectedIndex,
+                            row: renderedRow.row,
+                            isSelected: renderedRow.index == appState.repoSelector.selectedIndex,
                             projectsById: projectsById,
                             onTap: {
                                 // Snap selection to the clicked row before
                                 // activating so a tap without a preceding hover
                                 // can't fire the stale keyboard selection.
-                                appState.repoSelector.setSelectedIndex(idx, in: rows)
+                                appState.repoSelector.setSelectedIndex(renderedRow.index, in: rows)
                                 activate(rows: rows)
                             },
                             onHover: {
                                 let current = NSEvent.mouseLocation
                                 if lastHoverLocation == current { return }
                                 lastHoverLocation = current
-                                appState.repoSelector.setSelectedIndex(idx, in: rows)
+                                appState.repoSelector.setSelectedIndex(renderedRow.index, in: rows)
                             }
                         )
-                        .id(idx)
+                        .id(renderedRow.index)
                     }
                 }
                 .padding(.vertical, 4)

--- a/Alas/Sources/Dialogs/RepoSelector/RepoSelectorRow.swift
+++ b/Alas/Sources/Dialogs/RepoSelector/RepoSelectorRow.swift
@@ -28,4 +28,32 @@ enum RepoSelectorRow: Equatable {
         default: return true
         }
     }
+
+    var stableId: String {
+        switch self {
+        case .worktree(let worktree, _, _):
+            return "worktree:\(worktree.id)"
+        case .action(.newProject):
+            return "action:new-project"
+        case .action(.newWorktreeForRepo(let projectId)):
+            return "action:new-worktree:\(projectId)"
+        case .emptyHint(.noProjects):
+            return "empty:no-projects"
+        case .recentHeader:
+            return "header:recent"
+        case .projectHeader(let projectId):
+            return "header:project:\(projectId)"
+        case .actionsHeader:
+            return "header:actions"
+        }
+    }
+}
+
+struct RepoSelectorRenderedRow: Identifiable, Equatable {
+    let index: Int
+    let row: RepoSelectorRow
+
+    var id: String {
+        "\(index):\(row.stableId)"
+    }
 }

--- a/Alas/Sources/Search/Views/ContentResultGroup.swift
+++ b/Alas/Sources/Search/Views/ContentResultGroup.swift
@@ -13,7 +13,7 @@ struct ContentResultGroupView: View {
     var body: some View {
         VStack(alignment: .leading, spacing: 0) {
             header
-            ForEach(Array(group.hits.enumerated()), id: \.offset) { offset, hit in
+            ForEach(Array(group.hits.enumerated()), id: \.element.id) { offset, hit in
                 let absIndex = baseIndex + offset
                 hitRow(hit: hit, absIndex: absIndex, isSelected: absIndex == selectedIndex)
                     // Match the scroll-target id used by file rows so the

--- a/Alas/Sources/Search/Views/FileSearchDialog.swift
+++ b/Alas/Sources/Search/Views/FileSearchDialog.swift
@@ -61,7 +61,7 @@ struct FileSearchDialog: View {
                     LazyVStack(alignment: .leading, spacing: 0) {
                         switch model.kind {
                         case .files:
-                            ForEach(Array(model.results.fileResults.enumerated()), id: \.offset) { idx, r in
+                            ForEach(Array(model.results.fileResults.enumerated()), id: \.element.id) { idx, r in
                                 FileResultRow(
                                     result: r,
                                     isSelected: idx == model.selectedIndex,

--- a/Alas/Sources/Settings/CodeLanguageDetailView.swift
+++ b/Alas/Sources/Settings/CodeLanguageDetailView.swift
@@ -1,7 +1,7 @@
 import SwiftUI
 
 struct CodeLanguageDetailView: View {
-    @State var entry: LanguageServerConfig
+    @State private var entry: LanguageServerConfig
     let isNew: Bool
     let onSave: (LanguageServerConfig, [InstallRecipe]?) -> Void
     let onCancel: () -> Void

--- a/AlasTests/RepoSelectorModelTests.swift
+++ b/AlasTests/RepoSelectorModelTests.swift
@@ -627,4 +627,35 @@ struct RepoSelectorModelTests {
         #expect(opened)
         #expect(model.isOpen == false)
     }
+
+    @Test func rowStableIDsComeFromRowSemanticsNotPosition() {
+        let worktreeRow = RepoSelectorRow.worktree(
+            worktree("w1", projectId: "p1"),
+            indices: [0, 1],
+            isCurrent: false
+        )
+
+        #expect(worktreeRow.stableId == "worktree:w1")
+        #expect(RepoSelectorRow.projectHeader(projectId: "p1").stableId == "header:project:p1")
+        #expect(RepoSelectorRow.action(.newWorktreeForRepo(projectId: "p1")).stableId == "action:new-worktree:p1")
+        #expect(RepoSelectorRow.action(.newProject).stableId == "action:new-project")
+        #expect(RepoSelectorRow.emptyHint(.noProjects).stableId == "empty:no-projects")
+        #expect(RepoSelectorRow.recentHeader.stableId == "header:recent")
+        #expect(RepoSelectorRow.actionsHeader.stableId == "header:actions")
+    }
+
+    @Test func renderedRowIDsDisambiguateDuplicateSemanticRows() {
+        let worktreeRow = RepoSelectorRow.worktree(
+            worktree("w1", projectId: "p1"),
+            indices: [],
+            isCurrent: false
+        )
+
+        let recentInstance = RepoSelectorRenderedRow(index: 1, row: worktreeRow)
+        let projectInstance = RepoSelectorRenderedRow(index: 3, row: worktreeRow)
+
+        #expect(recentInstance.id == "1:worktree:w1")
+        #expect(projectInstance.id == "3:worktree:w1")
+        #expect(recentInstance.id != projectInstance.id)
+    }
 }


### PR DESCRIPTION
## Summary
- Use stable row identity for dynamic SwiftUI pickers and search/launcher lists while preserving index-based scroll targets.
- Add semantic repo selector row IDs with a focused regression test.
- Modernize a few SwiftUI API call sites and make the language detail draft state private.

## Validation
- `xcodegen`
- `rtk xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -quiet build`
- `rtk xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -only-testing:AlasTests/RepoSelectorModelTests test`

Note: full `rtk xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' test` was attempted but interrupted after running silently for several minutes.