### PR TITLE
feat(review): worktree review scope selector (commit / range / branch)

### DIFF
--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -827,6 +827,7 @@
 		C35CB6B466364169DF2616C3 /* RightPaneSelectionStateResolverTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 54635D583B6B308B75ABCE63 /* RightPaneSelectionStateResolverTests.swift */; };
 		C3840EDD0105467D0678B69C /* AppConfigSidebarChromeOverridesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 705A47F78FEC16C2CA293BAC /* AppConfigSidebarChromeOverridesTests.swift */; };
 		C3B1121E68B4F36F1540C2E1 /* CommitReviewLoaderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8A5CD97B6A04929595B0A9D /* CommitReviewLoaderTests.swift */; };
+		48ABA14A0DC85CE19301F993 /* RangeReviewLoaderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB83B0E479082F170CE86195 /* RangeReviewLoaderTests.swift */; };
 		C3E59948BD9108C1BD3243AD /* RemoteServerPane.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9126D442E8CDB093FA36BA5 /* RemoteServerPane.swift */; };
 		C4466064F783E6667C5FD25D /* UpdateController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2763F93ADFDCDF6B31D16475 /* UpdateController.swift */; };
 		C45F78462F404C64D02C413B /* LanguageServerRegistry.swift in Sources */ = {isa = PBXBuildFile; fileRef = 09D238B1262EB2BC6AFCF621 /* LanguageServerRegistry.swift */; };
@@ -1047,6 +1048,7 @@
 		F6C5274BCA0B3068C6C2D36A /* ZmxSunPathBudgetTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E0E5107A10052A150DD8DE02 /* ZmxSunPathBudgetTests.swift */; };
 		F6CC80D1E8D2D36251C83A1D /* ShellEnvResolver.swift in Sources */ = {isa = PBXBuildFile; fileRef = DFEE7C5318AA6D04095403B2 /* ShellEnvResolver.swift */; };
 		F72AFDC819B805B3F1FFFB9A /* CommitReviewLoader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7A240CD3EF074300828A1214 /* CommitReviewLoader.swift */; };
+		C10C84F0932EBACE12F5CEEC /* RangeReviewLoader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 364374946AF8C3330B3515E5 /* RangeReviewLoader.swift */; };
 		F73063B2384B650C227BD09E /* ACPHistorySidebar.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2C5BD0110EB8EDE7BB4ED93 /* ACPHistorySidebar.swift */; };
 		F8143610563C28604A23B89A /* CenterSelectionStateResolverTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 71A2A074CEB9C9BA2AD34DD7 /* CenterSelectionStateResolverTests.swift */; };
 		F855DEEEE005795EC6B13544 /* AlasFieldTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 169FC38D03727F34855EB521 /* AlasFieldTests.swift */; };
@@ -1605,6 +1607,7 @@
 		79DDEA496740F5B0B5EE808B /* Process+Git.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Process+Git.swift"; sourceTree = "<group>"; };
 		79F544A8DC56D0D4166E0A4F /* CommitContextBuilderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommitContextBuilderTests.swift; sourceTree = "<group>"; };
 		7A240CD3EF074300828A1214 /* CommitReviewLoader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommitReviewLoader.swift; sourceTree = "<group>"; };
+		364374946AF8C3330B3515E5 /* RangeReviewLoader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RangeReviewLoader.swift; sourceTree = "<group>"; };
 		7B22D5EBE7EDAC07C943C91D /* WebSocketFrame.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebSocketFrame.swift; sourceTree = "<group>"; };
 		7BF6F2D792F7DFAE3DA8E597 /* ThemeEnvironment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThemeEnvironment.swift; sourceTree = "<group>"; };
 		7C38FA009B7044E9DC5480A7 /* ACPSessionsButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPSessionsButton.swift; sourceTree = "<group>"; };
@@ -1910,6 +1913,7 @@
 		C7E76CA315A7B08E09A80AA8 /* AlasGhostty.Surface.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlasGhostty.Surface.swift; sourceTree = "<group>"; };
 		C8A0A083659269CDD16A6764 /* ACPMessageTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPMessageTests.swift; sourceTree = "<group>"; };
 		C8A5CD97B6A04929595B0A9D /* CommitReviewLoaderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommitReviewLoaderTests.swift; sourceTree = "<group>"; };
+		AB83B0E479082F170CE86195 /* RangeReviewLoaderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RangeReviewLoaderTests.swift; sourceTree = "<group>"; };
 		C9126D442E8CDB093FA36BA5 /* RemoteServerPane.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteServerPane.swift; sourceTree = "<group>"; };
 		C954F77AD0867F7FD39A5ED7 /* LineBuffer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LineBuffer.swift; sourceTree = "<group>"; };
 		C96C5E43E973803E6FD1528C /* CodeHostModels.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CodeHostModels.swift; sourceTree = "<group>"; };
@@ -2374,6 +2378,7 @@
 				95DA6BFFE45ED25669869C76 /* CommitMessageEditorViewTests.swift */,
 				1E40B5F193E3CB5EB5BA945A /* CommitPromptStatusTests.swift */,
 				C8A5CD97B6A04929595B0A9D /* CommitReviewLoaderTests.swift */,
+				AB83B0E479082F170CE86195 /* RangeReviewLoaderTests.swift */,
 				6D46BDE72E52818061452ECB /* CommitRowTests.swift */,
 				576619C2726DFDE8F627AE19 /* CommitsAheadTests.swift */,
 				8673293AD419AA36F7DF02A9 /* CommitsOlderTests.swift */,
@@ -3828,6 +3833,7 @@
 				C432B6C03738D6ACB4293471 /* ReviewDraftSummaryRail.swift */,
 				56E964C72322223859CC6AF8 /* ReviewFeedbackAgentSender.swift */,
 				B0886F9B3096AC1264E3D337 /* ReviewFeedbackBundle.swift */,
+				364374946AF8C3330B3515E5 /* RangeReviewLoader.swift */,
 				2C17465AF6747EDCD8CCE416 /* ReviewSessionLoader.swift */,
 				2F7E37886988A6F285BEA163 /* ReviewSessionModels.swift */,
 				0704EBDA62931ADE79B04F30 /* ReviewSessionStore.swift */,
@@ -4788,6 +4794,7 @@
 				F04E4353813EB99D4459750F /* ReviewRequestDiffLoader.swift in Sources */,
 				CDA1193EF673BA40A6548B2B /* ReviewRequestDraft.swift in Sources */,
 				2D80BC255AB24FA274617553 /* ReviewRequestPromptEditorWindow.swift in Sources */,
+				C10C84F0932EBACE12F5CEEC /* RangeReviewLoader.swift in Sources */,
 				C10DDFA9216B53E3C9527F8C /* ReviewSessionLoader.swift in Sources */,
 				58B2E8C756F6D3CB08FB3B10 /* ReviewSessionModels.swift in Sources */,
 				5723C73E91B9143B73554042 /* ReviewSessionStore.swift in Sources */,
@@ -5074,6 +5081,7 @@
 				7D087329E7B873B1E7A1CE89 /* CommitMessageEditorViewTests.swift in Sources */,
 				AE179E24A9E308150D1FD1D5 /* CommitPromptStatusTests.swift in Sources */,
 				C3B1121E68B4F36F1540C2E1 /* CommitReviewLoaderTests.swift in Sources */,
+				48ABA14A0DC85CE19301F993 /* RangeReviewLoaderTests.swift in Sources */,
 				B35BD3304D3A9EC5BABBC56E /* CommitRowTests.swift in Sources */,
 				363F31C705CF7D17162E2CF6 /* CommitTabStateTests.swift in Sources */,
 				575A4296D86E77D00A1E66A7 /* CommitTabViewTests.swift in Sources */,

--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -482,6 +482,7 @@
 		72EDB798775F24B86E8AD8DA /* ReviewChangesTabView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5DA887927D32EBA2252792D9 /* ReviewChangesTabView.swift */; };
 		226ECB00035048CB9E24759B /* ReviewScopeSelection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8DA9AD41D12A4064ADCED502 /* ReviewScopeSelection.swift */; };
 		138A8F3E573344159631F8B2 /* ReviewScopeSelectionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F1A3183CD904C6682F24561 /* ReviewScopeSelectionTests.swift */; };
+		A3C7F21B8E4D5091BC6E3A27 /* ReviewScopePicker.swift in Sources */ = {isa = PBXBuildFile; fileRef = B2D9E4A17F3C860D4E1F5B88 /* ReviewScopePicker.swift */; };
 		730DA64B474FF176336B9E0B /* SettingsNavView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 515B67124EA11DDCC29B6E36 /* SettingsNavView.swift */; };
 		7324AD398C5F4168C067F4B0 /* CodeEditorLineNumberRulerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 76B767602C3F8E5909A44B7C /* CodeEditorLineNumberRulerView.swift */; };
 		73480309CF2CBA78879268DD /* BlockedNudgeBanner.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C860C82F92CF8B7CC58FF4D /* BlockedNudgeBanner.swift */; };
@@ -1494,6 +1495,7 @@
 		5D486FD440D802AEC65D1555 /* MarkdownFileType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MarkdownFileType.swift; sourceTree = "<group>"; };
 		5DA887927D32EBA2252792D9 /* ReviewChangesTabView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReviewChangesTabView.swift; sourceTree = "<group>"; };
 		8DA9AD41D12A4064ADCED502 /* ReviewScopeSelection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReviewScopeSelection.swift; sourceTree = "<group>"; };
+		B2D9E4A17F3C860D4E1F5B88 /* ReviewScopePicker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReviewScopePicker.swift; sourceTree = "<group>"; };
 		4F1A3183CD904C6682F24561 /* ReviewScopeSelectionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReviewScopeSelectionTests.swift; sourceTree = "<group>"; };
 		5DC558BE723378DCC7AA5B55 /* ACPChatTypography.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPChatTypography.swift; sourceTree = "<group>"; };
 		5DD723B8C15EF2413C5D935D /* BlockedLanguageServerNudgeResolver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BlockedLanguageServerNudgeResolver.swift; sourceTree = "<group>"; };
@@ -2916,6 +2918,7 @@
 				80694744AA6D7E12FEB38A1A /* ReviewChangesScrollSpy.swift */,
 				5DA887927D32EBA2252792D9 /* ReviewChangesTabView.swift */,
 				8DA9AD41D12A4064ADCED502 /* ReviewScopeSelection.swift */,
+				B2D9E4A17F3C860D4E1F5B88 /* ReviewScopePicker.swift */,
 			);
 			path = ReviewChanges;
 			sourceTree = "<group>";
@@ -4784,6 +4787,7 @@
 				5269ED23D9732680EF7F4E16 /* ReviewChangesScrollSpy.swift in Sources */,
 				72EDB798775F24B86E8AD8DA /* ReviewChangesTabView.swift in Sources */,
 				226ECB00035048CB9E24759B /* ReviewScopeSelection.swift in Sources */,
+				A3C7F21B8E4D5091BC6E3A27 /* ReviewScopePicker.swift in Sources */,
 				D1826BD546F4C8D2755D8F56 /* ReviewDraftCommentActions.swift in Sources */,
 				D9FD24854A41DF2E9214E078 /* ReviewDraftCommentController.swift in Sources */,
 				8011EDCDB9E13B454E58F45E /* ReviewDraftCommentStore.swift in Sources */,

--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -480,6 +480,8 @@
 		725EDB42BF126786D99E359A /* CursorModelVariants.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87F9063CCA0DA839EB342993 /* CursorModelVariants.swift */; };
 		72CF403FFD14D75FC0DD15E3 /* MergeView3WayLayoutTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE3FA58107EA372581313A5F /* MergeView3WayLayoutTests.swift */; };
 		72EDB798775F24B86E8AD8DA /* ReviewChangesTabView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5DA887927D32EBA2252792D9 /* ReviewChangesTabView.swift */; };
+		226ECB00035048CB9E24759B /* ReviewScopeSelection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8DA9AD41D12A4064ADCED502 /* ReviewScopeSelection.swift */; };
+		138A8F3E573344159631F8B2 /* ReviewScopeSelectionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F1A3183CD904C6682F24561 /* ReviewScopeSelectionTests.swift */; };
 		730DA64B474FF176336B9E0B /* SettingsNavView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 515B67124EA11DDCC29B6E36 /* SettingsNavView.swift */; };
 		7324AD398C5F4168C067F4B0 /* CodeEditorLineNumberRulerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 76B767602C3F8E5909A44B7C /* CodeEditorLineNumberRulerView.swift */; };
 		73480309CF2CBA78879268DD /* BlockedNudgeBanner.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C860C82F92CF8B7CC58FF4D /* BlockedNudgeBanner.swift */; };
@@ -1491,6 +1493,8 @@
 		5CC16D06302D9AD3C9F0BE3C /* TreeSitterHighlighter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TreeSitterHighlighter.swift; sourceTree = "<group>"; };
 		5D486FD440D802AEC65D1555 /* MarkdownFileType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MarkdownFileType.swift; sourceTree = "<group>"; };
 		5DA887927D32EBA2252792D9 /* ReviewChangesTabView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReviewChangesTabView.swift; sourceTree = "<group>"; };
+		8DA9AD41D12A4064ADCED502 /* ReviewScopeSelection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReviewScopeSelection.swift; sourceTree = "<group>"; };
+		4F1A3183CD904C6682F24561 /* ReviewScopeSelectionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReviewScopeSelectionTests.swift; sourceTree = "<group>"; };
 		5DC558BE723378DCC7AA5B55 /* ACPChatTypography.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPChatTypography.swift; sourceTree = "<group>"; };
 		5DD723B8C15EF2413C5D935D /* BlockedLanguageServerNudgeResolver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BlockedLanguageServerNudgeResolver.swift; sourceTree = "<group>"; };
 		5E21106B4804D62C1D3C7F62 /* AlasGhostty.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlasGhostty.swift; sourceTree = "<group>"; };
@@ -2511,6 +2515,7 @@
 				CDAE8FBBADF986E1E6585941 /* ReviewChangesModelsTests.swift */,
 				F2C9F8BAEDB1D157E321A328 /* ReviewChangesScrollSpyTests.swift */,
 				FB9E78C70091168556C9669B /* ReviewChangesTabViewTests.swift */,
+				4F1A3183CD904C6682F24561 /* ReviewScopeSelectionTests.swift */,
 				D36EA68CE127E24991ABD5A6 /* ReviewDraftCommentStoreTests.swift */,
 				67378DD93876E3840E367550 /* ReviewDraftModelsTests.swift */,
 				2C84E444E25F7DDBE30FB824 /* ReviewFeedbackBundleTests.swift */,
@@ -2910,6 +2915,7 @@
 				09C9EEDB5A71C5FAE2D0E42B /* ReviewChangesRail.swift */,
 				80694744AA6D7E12FEB38A1A /* ReviewChangesScrollSpy.swift */,
 				5DA887927D32EBA2252792D9 /* ReviewChangesTabView.swift */,
+				8DA9AD41D12A4064ADCED502 /* ReviewScopeSelection.swift */,
 			);
 			path = ReviewChanges;
 			sourceTree = "<group>";
@@ -4777,6 +4783,7 @@
 				F2385B8730E9D1F47C7FA423 /* ReviewChangesRail.swift in Sources */,
 				5269ED23D9732680EF7F4E16 /* ReviewChangesScrollSpy.swift in Sources */,
 				72EDB798775F24B86E8AD8DA /* ReviewChangesTabView.swift in Sources */,
+				226ECB00035048CB9E24759B /* ReviewScopeSelection.swift in Sources */,
 				D1826BD546F4C8D2755D8F56 /* ReviewDraftCommentActions.swift in Sources */,
 				D9FD24854A41DF2E9214E078 /* ReviewDraftCommentController.swift in Sources */,
 				8011EDCDB9E13B454E58F45E /* ReviewDraftCommentStore.swift in Sources */,
@@ -5261,6 +5268,7 @@
 				13928612F39D3D86ED3313AC /* ReviewChangesModelsTests.swift in Sources */,
 				B13C57CF7090C966143A6840 /* ReviewChangesScrollSpyTests.swift in Sources */,
 				ACDE5C92423E9EFBE50CAEF2 /* ReviewChangesTabViewTests.swift in Sources */,
+				138A8F3E573344159631F8B2 /* ReviewScopeSelectionTests.swift in Sources */,
 				CBB3A06686A9CBFE699C08AF /* ReviewDraftCommentStoreTests.swift in Sources */,
 				1A6AF8939585038A3303B625 /* ReviewDraftModelsTests.swift in Sources */,
 				A05391FF4907AB0870A79C02 /* ReviewEvidenceTests.swift in Sources */,

--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -416,6 +416,7 @@
 		603D2F40A0368A139822CE80 /* ACPLaunchCatalogTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B29505F108227C8F43822585 /* ACPLaunchCatalogTests.swift */; };
 		604E881461FC839C4233B0AF /* LSPInstaller.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74D394D40BC9060833DD640A /* LSPInstaller.swift */; };
 		6094D26DB816FAD6FD9BE7F9 /* DiffReviewSurface.swift in Sources */ = {isa = PBXBuildFile; fileRef = AD3B3FF5D7B8F892ED1972A8 /* DiffReviewSurface.swift */; };
+		60A1B2C3D4E5F6A7B8C9D0E1 /* ReviewSessionTargetTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA1122334455667788990011 /* ReviewSessionTargetTests.swift */; };
 		60F31F7C4A8A69EDE77363FB /* ReviewSessionModelsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB8CA584A5F9F1BDE903E8D2 /* ReviewSessionModelsTests.swift */; };
 		610486A9FA350E77D1BF594B /* ACPTerminalTailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CBFD1CE53DE229626220B457 /* ACPTerminalTailView.swift */; };
 		6117C4AD7519BCD82EA0CF56 /* RightPaneTransitionalView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9C165BAAF80F9B4A5949BD39 /* RightPaneTransitionalView.swift */; };
@@ -1778,6 +1779,7 @@
 		AAEDACEB27E6AF219054496E /* DialogChrome.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DialogChrome.swift; sourceTree = "<group>"; };
 		AB3DAB779A962AC2092A2879 /* CommitTabViewTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommitTabViewTests.swift; sourceTree = "<group>"; };
 		AB4C1B7737A289066E01C444 /* WorkspaceLSPManagerStatusTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkspaceLSPManagerStatusTests.swift; sourceTree = "<group>"; };
+		AA1122334455667788990011 /* ReviewSessionTargetTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReviewSessionTargetTests.swift; sourceTree = "<group>"; };
 		AB8CA584A5F9F1BDE903E8D2 /* ReviewSessionModelsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReviewSessionModelsTests.swift; sourceTree = "<group>"; };
 		AB9D4FBF08CBAB59C08BBF1D /* ACPQuestionRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPQuestionRequest.swift; sourceTree = "<group>"; };
 		ACCA6B39E2B172FADFD9E0E6 /* DiffPaneTextDocumentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiffPaneTextDocumentView.swift; sourceTree = "<group>"; };
@@ -2509,6 +2511,7 @@
 				2C84E444E25F7DDBE30FB824 /* ReviewFeedbackBundleTests.swift */,
 				694DDEC8133EFBC33822BC26 /* ReviewLoopHandoffRoutingTests.swift */,
 				ADC27B340A795F13EA4E0765 /* ReviewSessionLoaderTests.swift */,
+				AA1122334455667788990011 /* ReviewSessionTargetTests.swift */,
 				AB8CA584A5F9F1BDE903E8D2 /* ReviewSessionModelsTests.swift */,
 				F63C0C3F29FDD890239300E5 /* ReviewSessionStoreTests.swift */,
 				F4120556B9870D6246D0F30A /* ReviewSessionTabViewTests.swift */,
@@ -5263,6 +5266,7 @@
 				21FBAF70DBD55FF57DAB796D /* ReviewRequestDiffLoaderTests.swift in Sources */,
 				6B9E188A6C0A39C38D8723BF /* ReviewRequestDraftTests.swift in Sources */,
 				E6B5EDEA2C41C783ECA67FD9 /* ReviewSessionLoaderTests.swift in Sources */,
+				60A1B2C3D4E5F6A7B8C9D0E1 /* ReviewSessionTargetTests.swift in Sources */,
 				60F31F7C4A8A69EDE77363FB /* ReviewSessionModelsTests.swift in Sources */,
 				DECBF7BD8E09E75F70340CF3 /* ReviewSessionStoreTests.swift in Sources */,
 				5255F92036DF00CB48082526 /* ReviewSessionTabViewTests.swift in Sources */,

--- a/Alas/Sources/Center/ReviewChanges/ReviewChangesTabView.swift
+++ b/Alas/Sources/Center/ReviewChanges/ReviewChangesTabView.swift
@@ -94,7 +94,6 @@ struct ReviewChangesTabView: View {
     @State private var showWhitespace = false
     @State private var showScopePicker = false
     @State private var scopeBranches: [String] = []
-    @State private var scopeHeadSHA: String?
 
     var body: some View {
         VStack(spacing: 0) {
@@ -116,26 +115,34 @@ struct ReviewChangesTabView: View {
                 branches: scopeBranches,
                 onSelect: { choice in
                     showScopePicker = false
-                    openReviewSession(
-                        target: ReviewScopeSelection.target(
-                            for: choice,
-                            worktreeID: worktree.id,
-                            repositoryPath: worktree.path,
-                            headSHA: scopeHeadSHA
+                    // Resolve HEAD at selection time so a branch target always
+                    // reflects the current revision (the worktree may have moved
+                    // since the picker opened).
+                    Task { @MainActor in
+                        let headSHA: String?
+                        if case .branch = choice {
+                            headSHA = try? await GitService().headSHA(at: worktree.path)
+                        } else {
+                            headSHA = nil
+                        }
+                        openReviewSession(
+                            target: ReviewScopeSelection.target(
+                                for: choice,
+                                worktreeID: worktree.id,
+                                repositoryPath: worktree.path,
+                                headSHA: headSHA
+                            )
                         )
-                    )
+                    }
                 },
                 onCancel: { showScopePicker = false }
             )
         }
         .task(id: showScopePicker) {
+            // Refetch every time the picker opens so the branch list reflects
+            // branches created/checked out since the last open.
             guard showScopePicker else { return }
-            if scopeBranches.isEmpty {
-                scopeBranches = (try? await GitService().branches(at: worktree.path)) ?? []
-            }
-            if scopeHeadSHA == nil {
-                scopeHeadSHA = try? await GitService().headSHA(at: worktree.path)
-            }
+            scopeBranches = (try? await GitService().branches(at: worktree.path)) ?? []
         }
     }
 

--- a/Alas/Sources/Center/ReviewChanges/ReviewChangesTabView.swift
+++ b/Alas/Sources/Center/ReviewChanges/ReviewChangesTabView.swift
@@ -94,6 +94,7 @@ struct ReviewChangesTabView: View {
     @State private var showWhitespace = false
     @State private var showScopePicker = false
     @State private var scopeBranches: [String] = []
+    @State private var scopeHeadSHA: String?
 
     var body: some View {
         VStack(spacing: 0) {
@@ -119,7 +120,8 @@ struct ReviewChangesTabView: View {
                         target: ReviewScopeSelection.target(
                             for: choice,
                             worktreeID: worktree.id,
-                            repositoryPath: worktree.path
+                            repositoryPath: worktree.path,
+                            headSHA: scopeHeadSHA
                         )
                     )
                 },
@@ -127,8 +129,13 @@ struct ReviewChangesTabView: View {
             )
         }
         .task(id: showScopePicker) {
-            guard showScopePicker, scopeBranches.isEmpty else { return }
-            scopeBranches = (try? await GitService().branches(at: worktree.path)) ?? []
+            guard showScopePicker else { return }
+            if scopeBranches.isEmpty {
+                scopeBranches = (try? await GitService().branches(at: worktree.path)) ?? []
+            }
+            if scopeHeadSHA == nil {
+                scopeHeadSHA = try? await GitService().headSHA(at: worktree.path)
+            }
         }
     }
 

--- a/Alas/Sources/Center/ReviewChanges/ReviewChangesTabView.swift
+++ b/Alas/Sources/Center/ReviewChanges/ReviewChangesTabView.swift
@@ -119,18 +119,20 @@ struct ReviewChangesTabView: View {
                     // reflects the current revision (the worktree may have moved
                     // since the picker opened).
                     Task { @MainActor in
-                        let headSHA: String?
-                        if case .branch = choice {
-                            headSHA = try? await GitService().headSHA(at: worktree.path)
-                        } else {
-                            headSHA = nil
+                        var headSHA: String?
+                        var branchBaseSHA: String?
+                        if case .branch(let name) = choice {
+                            let git = GitService()
+                            headSHA = try? await git.headSHA(at: worktree.path)
+                            branchBaseSHA = try? await git.resolveRevision(at: worktree.path, ref: name)
                         }
                         openReviewSession(
                             target: ReviewScopeSelection.target(
                                 for: choice,
                                 worktreeID: worktree.id,
                                 repositoryPath: worktree.path,
-                                headSHA: headSHA
+                                headSHA: headSHA,
+                                branchBaseSHA: branchBaseSHA
                             )
                         )
                     }

--- a/Alas/Sources/Center/ReviewChanges/ReviewChangesTabView.swift
+++ b/Alas/Sources/Center/ReviewChanges/ReviewChangesTabView.swift
@@ -92,6 +92,8 @@ struct ReviewChangesTabView: View {
     @State private var activeLoadID = UUID()
     @State private var reviewSessionLaunchError: String?
     @State private var showWhitespace = false
+    @State private var showScopePicker = false
+    @State private var scopeBranches: [String] = []
 
     var body: some View {
         VStack(spacing: 0) {
@@ -106,6 +108,27 @@ struct ReviewChangesTabView: View {
         }
         .task(id: reviewDraftSessionID.rawValue) {
             loadDraftCommentController()
+        }
+        .sheet(isPresented: $showScopePicker) {
+            ReviewScopePicker(
+                commits: scopeCommits,
+                branches: scopeBranches,
+                onSelect: { choice in
+                    showScopePicker = false
+                    openReviewSession(
+                        target: ReviewScopeSelection.target(
+                            for: choice,
+                            worktreeID: worktree.id,
+                            repositoryPath: worktree.path
+                        )
+                    )
+                },
+                onCancel: { showScopePicker = false }
+            )
+        }
+        .task(id: showScopePicker) {
+            guard showScopePicker, scopeBranches.isEmpty else { return }
+            scopeBranches = (try? await GitService().branches(at: worktree.path)) ?? []
         }
     }
 
@@ -139,6 +162,10 @@ struct ReviewChangesTabView: View {
             worktreePath: worktree.path,
             rightPaneState: appState.rightPaneStore.activeState(worktreeId: worktree.id)
         )
+    }
+
+    private var scopeCommits: [CommitInfo] {
+        appState.rightPaneStore.activeState(worktreeId: worktree.id)?.commits ?? []
     }
 
     @ViewBuilder
@@ -183,6 +210,13 @@ struct ReviewChangesTabView: View {
                     .foregroundColor(theme.color("del"))
                     .lineLimit(1)
                     .truncationMode(.middle)
+            }
+            toolbarButton(
+                systemName: "scope",
+                tooltip: "Choose review scope",
+                isActive: showScopePicker
+            ) {
+                showScopePicker = true
             }
             toolbarButton(
                 systemName: "doc.text.magnifyingglass",

--- a/Alas/Sources/Center/ReviewChanges/ReviewScopePicker.swift
+++ b/Alas/Sources/Center/ReviewChanges/ReviewScopePicker.swift
@@ -1,0 +1,173 @@
+import SwiftUI
+
+struct ReviewScopePicker: View {
+    enum Tab: String, CaseIterable, Identifiable {
+        case commits = "Commits"
+        case branches = "Branches"
+        var id: String { rawValue }
+    }
+
+    let commits: [CommitInfo]
+    let branches: [String]
+    let onSelect: (ReviewScopeChoice) -> Void
+    let onCancel: () -> Void
+
+    @Environment(\.theme) private var theme
+    @State private var tab: Tab = .commits
+    @State private var query: String = ""
+    @State private var rangeAnchor: CommitInfo?
+
+    private var filtered: [CommitInfo] {
+        ReviewScopeSelection.filteredCommits(commits, query: query)
+    }
+
+    var body: some View {
+        VStack(spacing: 0) {
+            header
+            Divider().overlay(theme.color("line"))
+            switch tab {
+            case .commits: commitsList
+            case .branches: branchesList
+            }
+        }
+        .frame(width: 560, height: 480)
+        .background(theme.color("bg-1"))
+    }
+
+    private var header: some View {
+        VStack(spacing: 8) {
+            HStack {
+                Text("Review scope")
+                    .font(.system(size: 13, weight: .semibold))
+                    .foregroundColor(theme.color("fg"))
+                Spacer()
+                Button("Working tree") { onSelect(.workingTree) }
+                    .buttonStyle(.plain)
+                    .foregroundColor(theme.color("accent"))
+                Button(action: onCancel) {
+                    Image(systemName: "xmark")
+                }
+                .buttonStyle(.plain)
+                .foregroundColor(theme.color("fg-muted"))
+            }
+            Picker("", selection: $tab) {
+                ForEach(Tab.allCases) { Text($0.rawValue).tag($0) }
+            }
+            .pickerStyle(.segmented)
+            .labelsHidden()
+            if tab == .commits {
+                TextField("Filter commits…", text: $query)
+                    .textFieldStyle(.roundedBorder)
+                if let anchor = rangeAnchor {
+                    HStack(spacing: 6) {
+                        Image(systemName: "smallcircle.filled.circle")
+                        Text("Range start: \(anchor.shortSha) — pick the end commit")
+                            .font(.system(size: 11))
+                        Spacer()
+                        Button("Clear") { rangeAnchor = nil }
+                            .buttonStyle(.plain)
+                    }
+                    .foregroundColor(theme.color("accent"))
+                }
+            }
+        }
+        .padding(12)
+        .background(theme.color("bg-2"))
+    }
+
+    private var commitsList: some View {
+        ScrollView {
+            LazyVStack(spacing: 0) {
+                ForEach(filtered) { commit in
+                    commitRow(commit)
+                    Divider().overlay(theme.color("line").opacity(0.5))
+                }
+            }
+        }
+    }
+
+    private func commitRow(_ commit: CommitInfo) -> some View {
+        let inRange = rangeAnchor.map { isBetween(commit, $0) } ?? false
+        return HStack(spacing: 10) {
+            Button {
+                rangeAnchor = (rangeAnchor?.id == commit.id) ? nil : commit
+            } label: {
+                Image(systemName: rangeAnchor?.id == commit.id
+                    ? "smallcircle.filled.circle.fill"
+                    : "smallcircle.filled.circle")
+                    .foregroundColor(rangeAnchor?.id == commit.id
+                        ? theme.color("accent")
+                        : theme.color("fg-muted"))
+            }
+            .buttonStyle(.plain)
+            .help("Set as range start")
+
+            Button {
+                select(commit)
+            } label: {
+                VStack(alignment: .leading, spacing: 2) {
+                    Text(commit.subject)
+                        .font(.system(size: 12, weight: .medium))
+                        .foregroundColor(theme.color("fg"))
+                        .lineLimit(1)
+                    Text("\(commit.shortSha) · \(commit.author)")
+                        .font(.system(size: 10))
+                        .foregroundColor(theme.color("fg-dim"))
+                }
+                .frame(maxWidth: .infinity, alignment: .leading)
+            }
+            .buttonStyle(.plain)
+        }
+        .padding(.horizontal, 12)
+        .padding(.vertical, 8)
+        .background(inRange ? theme.color("accent-soft") : Color.clear)
+    }
+
+    private func select(_ commit: CommitInfo) {
+        if let anchor = rangeAnchor, anchor.id != commit.id {
+            let (older, newer) = orderByPosition(anchor, commit)
+            onSelect(.range(older: older, newer: newer))
+        } else {
+            onSelect(.commit(commit))
+        }
+    }
+
+    // Commits arrive newest-first (git log order). "older" = larger index.
+    private func orderByPosition(_ a: CommitInfo, _ b: CommitInfo) -> (older: CommitInfo, newer: CommitInfo) {
+        let ia = commits.firstIndex(of: a) ?? 0
+        let ib = commits.firstIndex(of: b) ?? 0
+        return ia > ib ? (a, b) : (b, a)
+    }
+
+    private func isBetween(_ commit: CommitInfo, _ anchor: CommitInfo) -> Bool {
+        guard let ic = commits.firstIndex(of: commit),
+              let ia = commits.firstIndex(of: anchor)
+        else { return false }
+        return (min(ia, ic) ... max(ia, ic)).contains(ic)
+    }
+
+    private var branchesList: some View {
+        ScrollView {
+            LazyVStack(spacing: 0) {
+                ForEach(branches, id: \.self) { name in
+                    Button {
+                        onSelect(.branch(name: name))
+                    } label: {
+                        HStack {
+                            Image(systemName: "arrow.triangle.branch")
+                                .foregroundColor(theme.color("fg-muted"))
+                            Text(name)
+                                .font(.system(size: 12))
+                                .foregroundColor(theme.color("fg"))
+                            Spacer()
+                        }
+                        .padding(.horizontal, 12)
+                        .padding(.vertical, 9)
+                    }
+                    .buttonStyle(.plain)
+                    Divider().overlay(theme.color("line").opacity(0.5))
+                }
+            }
+        }
+    }
+}

--- a/Alas/Sources/Center/ReviewChanges/ReviewScopePicker.swift
+++ b/Alas/Sources/Center/ReviewChanges/ReviewScopePicker.swift
@@ -124,18 +124,22 @@ struct ReviewScopePicker: View {
     }
 
     private func select(_ commit: CommitInfo) {
-        if let anchor = rangeAnchor, anchor.id != commit.id {
-            let (older, newer) = orderByPosition(anchor, commit)
-            onSelect(.range(older: older, newer: newer))
+        if let anchor = rangeAnchor, anchor.id != commit.id,
+           let ordered = orderByPosition(anchor, commit) {
+            onSelect(.range(older: ordered.older, newer: ordered.newer))
         } else {
             onSelect(.commit(commit))
         }
     }
 
     // Commits arrive newest-first (git log order). "older" = larger index.
-    private func orderByPosition(_ a: CommitInfo, _ b: CommitInfo) -> (older: CommitInfo, newer: CommitInfo) {
-        let ia = commits.firstIndex(of: a) ?? 0
-        let ib = commits.firstIndex(of: b) ?? 0
+    // Returns nil if either commit is no longer in the list (e.g. a stale
+    // anchor after a refresh), so the caller can fall back to a single-commit
+    // selection rather than emit an arbitrarily ordered range.
+    private func orderByPosition(_ a: CommitInfo, _ b: CommitInfo) -> (older: CommitInfo, newer: CommitInfo)? {
+        guard let ia = commits.firstIndex(of: a),
+              let ib = commits.firstIndex(of: b)
+        else { return nil }
         return ia > ib ? (a, b) : (b, a)
     }
 

--- a/Alas/Sources/Center/ReviewChanges/ReviewScopeSelection.swift
+++ b/Alas/Sources/Center/ReviewChanges/ReviewScopeSelection.swift
@@ -12,7 +12,8 @@ enum ReviewScopeSelection {
         for choice: ReviewScopeChoice,
         worktreeID: String,
         repositoryPath: URL,
-        headSHA: String? = nil
+        headSHA: String? = nil,
+        branchBaseSHA: String? = nil
     ) -> ReviewSessionTarget {
         switch choice {
         case .workingTree:
@@ -33,10 +34,13 @@ enum ReviewScopeSelection {
                 title: "Review \(older.shortSha)…\(newer.shortSha)"
             )
         case .branch(let name):
+            // Pin both endpoints to immutable SHAs when resolved, so a stored
+            // review keeps the same merge base even if the branch advances.
+            // The branch name is retained only for the display title.
             return .branch(
                 worktreeID: worktreeID,
                 repositoryPath: repositoryPath,
-                base: name,
+                base: branchBaseSHA ?? name,
                 head: headSHA ?? "HEAD",
                 title: "Review HEAD against \(name)"
             )

--- a/Alas/Sources/Center/ReviewChanges/ReviewScopeSelection.swift
+++ b/Alas/Sources/Center/ReviewChanges/ReviewScopeSelection.swift
@@ -1,0 +1,56 @@
+import Foundation
+
+enum ReviewScopeChoice: Equatable {
+    case workingTree
+    case commit(CommitInfo)
+    case range(older: CommitInfo, newer: CommitInfo)
+    case branch(name: String)
+}
+
+enum ReviewScopeSelection {
+    static func target(
+        for choice: ReviewScopeChoice,
+        worktreeID: String,
+        repositoryPath: URL
+    ) -> ReviewSessionTarget {
+        switch choice {
+        case .workingTree:
+            return .localChanges(worktreeID: worktreeID, repositoryPath: repositoryPath, scope: .all)
+        case .commit(let info):
+            return .commit(
+                worktreeID: worktreeID,
+                repositoryPath: repositoryPath,
+                sha: info.sha,
+                title: "\(info.shortSha) \(info.subject)"
+            )
+        case .range(let older, let newer):
+            return .commitRange(
+                worktreeID: worktreeID,
+                repositoryPath: repositoryPath,
+                base: "\(older.sha)^",
+                head: newer.sha,
+                title: "Review \(older.shortSha)…\(newer.shortSha)"
+            )
+        case .branch(let name):
+            return .branch(
+                worktreeID: worktreeID,
+                repositoryPath: repositoryPath,
+                base: name,
+                head: "HEAD",
+                title: "Review HEAD against \(name)"
+            )
+        }
+    }
+
+    static func filteredCommits(_ commits: [CommitInfo], query: String) -> [CommitInfo] {
+        let trimmed = query.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return commits }
+        let needle = trimmed.lowercased()
+        return commits.filter { commit in
+            commit.sha.lowercased().contains(needle)
+                || commit.shortSha.lowercased().contains(needle)
+                || commit.subject.lowercased().contains(needle)
+                || commit.author.lowercased().contains(needle)
+        }
+    }
+}

--- a/Alas/Sources/Center/ReviewChanges/ReviewScopeSelection.swift
+++ b/Alas/Sources/Center/ReviewChanges/ReviewScopeSelection.swift
@@ -11,7 +11,8 @@ enum ReviewScopeSelection {
     static func target(
         for choice: ReviewScopeChoice,
         worktreeID: String,
-        repositoryPath: URL
+        repositoryPath: URL,
+        headSHA: String? = nil
     ) -> ReviewSessionTarget {
         switch choice {
         case .workingTree:
@@ -36,7 +37,7 @@ enum ReviewScopeSelection {
                 worktreeID: worktreeID,
                 repositoryPath: repositoryPath,
                 base: name,
-                head: "HEAD",
+                head: headSHA ?? "HEAD",
                 title: "Review HEAD against \(name)"
             )
         }

--- a/Alas/Sources/Center/ReviewWorkspace/RangeReviewLoader.swift
+++ b/Alas/Sources/Center/ReviewWorkspace/RangeReviewLoader.swift
@@ -1,0 +1,138 @@
+import Foundation
+
+protocol RangeReviewGitClient {
+    func rangeDiff(worktreePath: URL, base: String, head: String, threeDot: Bool, file: String, originalPath: String?) async throws -> ParsedDiff
+    func rangeContextSnapshot(worktreePath: URL, base: String, head: String, threeDot: Bool, file: String, originalPath: String?) async throws -> DiffReviewFileContextSnapshot
+}
+
+extension GitService: RangeReviewGitClient {
+    func rangeContextSnapshot(worktreePath: URL, base: String, head: String, threeDot: Bool, file: String, originalPath: String?) async throws -> DiffReviewFileContextSnapshot {
+        try await refContextSnapshot(
+            worktreePath: worktreePath,
+            baseRef: base,
+            headRef: head,
+            file: file,
+            originalPath: originalPath,
+            useMergeBase: threeDot
+        )
+    }
+}
+
+struct RangeReviewLoader {
+    let git: RangeReviewGitClient
+
+    init(git: RangeReviewGitClient = GitService()) {
+        self.git = git
+    }
+
+    func load(
+        worktreePath: URL,
+        base: String,
+        head: String,
+        threeDot: Bool,
+        files: [CommitChangedFile],
+        openFileForPath: @escaping (String) -> (() -> Void)?
+    ) async throws -> DiffReviewLoadedSession {
+        var sections: [DiffReviewFileSectionModel] = []
+
+        for file in files {
+            try Task.checkCancellation()
+            let diff = try await git.rangeDiff(
+                worktreePath: worktreePath,
+                base: base, head: head, threeDot: threeDot,
+                file: file.path, originalPath: file.originalPath
+            )
+            try Task.checkCancellation()
+
+            sections.append(try await fileSection(
+                for: file,
+                diff: diff,
+                worktreePath: worktreePath,
+                base: base,
+                head: head,
+                threeDot: threeDot,
+                openFile: openFileForPath(file.path)
+            ))
+        }
+
+        return DiffReviewLoadedSession(
+            files: sections,
+            summary: DiffReviewSessionModel(files: sections.map(\.summary), groupsEnabled: false)
+        )
+    }
+
+    private func fileSection(
+        for file: CommitChangedFile,
+        diff: ParsedDiff,
+        worktreePath: URL,
+        base: String,
+        head: String,
+        threeDot: Bool,
+        openFile: (() -> Void)?
+    ) async throws -> DiffReviewFileSectionModel {
+        let canRender = !diff.hunks.isEmpty && !ImageFileType.isSupported(relativePath: file.path)
+        let counts = lineCounts(in: diff)
+        let summary = DiffReviewFileSummary(
+            path: file.path,
+            namespace: "range",
+            groupID: nil,
+            groupTitle: nil,
+            status: DiffReviewFileStatus(gitStatus: file.status),
+            additions: counts.additions,
+            deletions: counts.deletions,
+            isRenderable: canRender,
+            originalPath: file.originalPath
+        )
+
+        return DiffReviewFileSectionModel(
+            summary: summary,
+            parsedDiff: diff,
+            displayModel: canRender
+                ? try await buildDisplayModel(diff: diff, filePath: file.path)
+                : nil,
+            placeholderMessage: canRender ? nil : placeholderMessage(for: file, diff: diff),
+            openFile: openFile,
+            contextProvider: DiffReviewContextProvider {
+                try await git.rangeContextSnapshot(
+                    worktreePath: worktreePath,
+                    base: base, head: head, threeDot: threeDot,
+                    file: file.path, originalPath: file.originalPath
+                )
+            }
+        )
+    }
+
+    private func buildDisplayModel(diff: ParsedDiff, filePath: String) async throws -> DiffDisplayModel {
+        try Task.checkCancellation()
+        let model = await Task.detached(priority: .userInitiated) {
+            DiffDisplayModelBuilder.build(diff: diff, filePath: filePath)
+        }.value
+        try Task.checkCancellation()
+        return model
+    }
+
+    private func lineCounts(in diff: ParsedDiff) -> (additions: Int, deletions: Int) {
+        diff.hunks.reduce(into: (additions: 0, deletions: 0)) { counts, hunk in
+            for line in hunk.lines {
+                switch line.kind {
+                case .add:
+                    counts.additions += 1
+                case .delete:
+                    counts.deletions += 1
+                case .context:
+                    break
+                }
+            }
+        }
+    }
+
+    private func placeholderMessage(for file: CommitChangedFile, diff: ParsedDiff) -> String {
+        if ImageFileType.isSupported(relativePath: file.path) {
+            return "Image changes are not available in this review view yet."
+        }
+        if diff.hunks.isEmpty {
+            return "No text diff is available for this file."
+        }
+        return "This file cannot be rendered in the review view."
+    }
+}

--- a/Alas/Sources/Center/ReviewWorkspace/ReviewDraftModels.swift
+++ b/Alas/Sources/Center/ReviewWorkspace/ReviewDraftModels.swift
@@ -3,6 +3,7 @@ import Foundation
 enum ReviewDraftSourceKind: String, Codable, Equatable, Hashable, Sendable {
     case localChanges = "local-changes"
     case commit
+    case commitRange = "commit-range"
     case draftCommit = "draft-commit"
     case branch
     case reviewRequest = "review-request"
@@ -39,6 +40,10 @@ struct ReviewDraftSessionID: Codable, Equatable, Hashable, Sendable, RawRepresen
 
     static func commit(worktreeID: String, repositoryPath: URL, sha: String) -> Self {
         make(.commit, [worktreeID, repositoryPath.standardizedFileURL.path, sha])
+    }
+
+    static func commitRange(worktreeID: String, repositoryPath: URL, base: String, head: String) -> Self {
+        make(.commitRange, [worktreeID, repositoryPath.standardizedFileURL.path, base, head])
     }
 
     static func draftCommit(worktreeID: String, repositoryPath: URL) -> Self {

--- a/Alas/Sources/Center/ReviewWorkspace/ReviewSessionLoader.swift
+++ b/Alas/Sources/Center/ReviewWorkspace/ReviewSessionLoader.swift
@@ -86,6 +86,7 @@ struct ReviewSessionLoader {
         let changesLoader = ReviewChangesLoader()
         let git = GitService()
         let commitLoader = CommitReviewLoader(git: git)
+        let rangeLoader = RangeReviewLoader(git: git)
 
         return ReviewSessionLoader(
             localChanges: { target in
@@ -115,6 +116,34 @@ struct ReviewSessionLoader {
                             worktreePath: target.repositoryPath,
                             relativePath: path
                         )
+                    }
+                )
+            },
+            commitRange: { target in
+                guard case .commitRange(let base, let head) = target.payload else {
+                    throw ReviewSessionLoaderError.unsupportedTarget
+                }
+                let files = try await git.rangeChangedFiles(at: target.repositoryPath, base: base, head: head, threeDot: false)
+                return try await rangeLoader.load(
+                    worktreePath: target.repositoryPath,
+                    base: base, head: head, threeDot: false,
+                    files: files,
+                    openFileForPath: { path in
+                        openFileAction(appState: appState, worktreeID: target.worktreeID, worktreePath: target.repositoryPath, relativePath: path)
+                    }
+                )
+            },
+            branch: { target in
+                guard case .branch(let base, let head) = target.payload else {
+                    throw ReviewSessionLoaderError.unsupportedTarget
+                }
+                let files = try await git.rangeChangedFiles(at: target.repositoryPath, base: base, head: head, threeDot: true)
+                return try await rangeLoader.load(
+                    worktreePath: target.repositoryPath,
+                    base: base, head: head, threeDot: true,
+                    files: files,
+                    openFileForPath: { path in
+                        openFileAction(appState: appState, worktreeID: target.worktreeID, worktreePath: target.repositoryPath, relativePath: path)
                     }
                 )
             },

--- a/Alas/Sources/Center/ReviewWorkspace/ReviewSessionModels.swift
+++ b/Alas/Sources/Center/ReviewWorkspace/ReviewSessionModels.swift
@@ -106,7 +106,7 @@ struct ReviewSessionTarget: Codable, Equatable, Hashable, Identifiable, Sendable
             providerDescription: nil,
             providerURL: nil,
             revisionDescription: "\(base)..\(head)",
-            draftSessionID: .branch(worktreeID: worktreeID, repositoryPath: repositoryPath, base: base, head: head),
+            draftSessionID: .commitRange(worktreeID: worktreeID, repositoryPath: repositoryPath, base: base, head: head),
             payload: .commitRange(base: base, head: head)
         )
     }

--- a/Alas/Sources/Git/GitService.swift
+++ b/Alas/Sources/Git/GitService.swift
@@ -747,87 +747,7 @@ extension GitService {
         // single invocation, so we run them separately and merge the results.
         let emptyTreeSha = "4b825dc642cb6eb9a060e54bf8d69288fbee4904"
         let leftTree = parents.isEmpty ? emptyTreeSha : "\(sha)^1"
-        let rightTree = sha
-
-        // `-c core.quotePath=false` keeps non-ASCII / special characters in
-        // paths emitted as raw UTF-8 instead of git's default backslash-
-        // octal quoting (e.g. `"caf\303\251.txt"`). Without it, the parsed
-        // path is the quoted text — the file list shows the escaped name,
-        // the numstat↔name-status merge misses (key mismatch), and a later
-        // `git diff -- <quoted-path>` finds nothing on disk.
-        async let numstatResult = Process.git(
-            ["-c", "core.quotePath=false",
-             "diff-tree", "--no-commit-id", "-r", "-M", "-C", "--no-color", "--numstat", leftTree, rightTree],
-            cwd: worktree
-        )
-        async let nameStatusResult = Process.git(
-            ["-c", "core.quotePath=false",
-             "diff-tree", "--no-commit-id", "-r", "-M", "-C", "--no-color", "--name-status", leftTree, rightTree],
-            cwd: worktree
-        )
-        let numstatOut = try await numstatResult
-        let nameStatusOut = try await nameStatusResult
-
-        guard numstatOut.exitCode == 0 else {
-            throw NSError(domain: "GitService.commitDetails", code: Int(numstatOut.exitCode),
-                          userInfo: [NSLocalizedDescriptionKey: numstatOut.stderr])
-        }
-        guard nameStatusOut.exitCode == 0 else {
-            throw NSError(domain: "GitService.commitDetails", code: Int(nameStatusOut.exitCode),
-                          userInfo: [NSLocalizedDescriptionKey: nameStatusOut.stderr])
-        }
-
-        var addByPath: [String: Int] = [:]
-        var delByPath: [String: Int] = [:]
-        var statusByPath: [String: String] = [:]
-        var originalByPath: [String: String] = [:]
-        var ordered: [String] = []
-        var orderedSet: Set<String> = []
-
-        // Parse numstat: "adds \t dels \t path"
-        // With -M/-C, git emits renames as a combined path field in one of two forms:
-        //   simple: "old.txt => new.txt"
-        //   brace:  "prefix/{old => new}/suffix"
-        // Normalize to the new path before keying so the dict aligns with name-status.
-        for line in numstatOut.stdout.split(separator: "\n", omittingEmptySubsequences: true) {
-            let parts = line.split(separator: "\t", omittingEmptySubsequences: false).map(String.init)
-            guard parts.count >= 3 else { continue }
-            let addStr = parts[0]
-            let delStr = parts[1]
-            let path = Self.numstatNewPath(parts[2])
-            addByPath[path] = (addStr == "-") ? 0 : (Int(addStr) ?? 0)
-            delByPath[path] = (delStr == "-") ? 0 : (Int(delStr) ?? 0)
-        }
-
-        // Parse name-status: "status[score?] \t [old \t] new"
-        for line in nameStatusOut.stdout.split(separator: "\n", omittingEmptySubsequences: true) {
-            let parts = line.split(separator: "\t", omittingEmptySubsequences: false).map(String.init)
-            guard parts.count >= 2 else { continue }
-            let statusLetter = String(parts[0].prefix(1))
-            let newPath: String
-            let oldPath: String?
-            if statusLetter == "R" || statusLetter == "C" {
-                guard parts.count >= 3 else { continue }
-                newPath = parts[2]
-                oldPath = parts[1]
-            } else {
-                newPath = parts[1]
-                oldPath = nil
-            }
-            statusByPath[newPath] = statusLetter
-            if let oldPath { originalByPath[newPath] = oldPath }
-            if orderedSet.insert(newPath).inserted { ordered.append(newPath) }
-        }
-
-        let files: [CommitChangedFile] = ordered.map { path in
-            CommitChangedFile(
-                path: path,
-                originalPath: originalByPath[path],
-                status: statusByPath[path] ?? "M",
-                add: addByPath[path] ?? 0,
-                del: delByPath[path] ?? 0
-            )
-        }
+        let files = try await changedFiles(worktree: worktree, leftTree: leftTree, rightTree: sha)
 
         let info = CommitInfo(
             sha: fullSha,
@@ -849,6 +769,89 @@ extension GitService {
             parents: parents,
             files: files
         )
+    }
+
+    /// Lists changed files between two trees using the two diff-tree passes
+    /// (numstat + name-status) merged into ordered `CommitChangedFile`s. Shared
+    /// by `commitDetails` and `rangeChangedFiles`.
+    private func changedFiles(worktree: URL, leftTree: String, rightTree: String) async throws -> [CommitChangedFile] {
+        async let numstatResult = Process.git(
+            ["-c", "core.quotePath=false",
+             "diff-tree", "--no-commit-id", "-r", "-M", "-C", "--no-color", "--numstat", leftTree, rightTree],
+            cwd: worktree
+        )
+        async let nameStatusResult = Process.git(
+            ["-c", "core.quotePath=false",
+             "diff-tree", "--no-commit-id", "-r", "-M", "-C", "--no-color", "--name-status", leftTree, rightTree],
+            cwd: worktree
+        )
+        let numstatOut = try await numstatResult
+        let nameStatusOut = try await nameStatusResult
+
+        guard numstatOut.exitCode == 0 else {
+            throw NSError(domain: "GitService.changedFiles", code: Int(numstatOut.exitCode),
+                          userInfo: [NSLocalizedDescriptionKey: numstatOut.stderr])
+        }
+        guard nameStatusOut.exitCode == 0 else {
+            throw NSError(domain: "GitService.changedFiles", code: Int(nameStatusOut.exitCode),
+                          userInfo: [NSLocalizedDescriptionKey: nameStatusOut.stderr])
+        }
+
+        var addByPath: [String: Int] = [:]
+        var delByPath: [String: Int] = [:]
+        var statusByPath: [String: String] = [:]
+        var originalByPath: [String: String] = [:]
+        var ordered: [String] = []
+        var orderedSet: Set<String> = []
+
+        for line in numstatOut.stdout.split(separator: "\n", omittingEmptySubsequences: true) {
+            let parts = line.split(separator: "\t", omittingEmptySubsequences: false).map(String.init)
+            guard parts.count >= 3 else { continue }
+            let addStr = parts[0]
+            let delStr = parts[1]
+            let path = Self.numstatNewPath(parts[2])
+            addByPath[path] = (addStr == "-") ? 0 : (Int(addStr) ?? 0)
+            delByPath[path] = (delStr == "-") ? 0 : (Int(delStr) ?? 0)
+        }
+
+        for line in nameStatusOut.stdout.split(separator: "\n", omittingEmptySubsequences: true) {
+            let parts = line.split(separator: "\t", omittingEmptySubsequences: false).map(String.init)
+            guard parts.count >= 2 else { continue }
+            let statusLetter = String(parts[0].prefix(1))
+            let newPath: String
+            let oldPath: String?
+            if statusLetter == "R" || statusLetter == "C" {
+                guard parts.count >= 3 else { continue }
+                newPath = parts[2]
+                oldPath = parts[1]
+            } else {
+                newPath = parts[1]
+                oldPath = nil
+            }
+            statusByPath[newPath] = statusLetter
+            if let oldPath { originalByPath[newPath] = oldPath }
+            if orderedSet.insert(newPath).inserted { ordered.append(newPath) }
+        }
+
+        return ordered.map { path in
+            CommitChangedFile(
+                path: path,
+                originalPath: originalByPath[path],
+                status: statusByPath[path] ?? "M",
+                add: addByPath[path] ?? 0,
+                del: delByPath[path] ?? 0
+            )
+        }
+    }
+
+    /// Lists changed files for a commit range. Two-dot (`threeDot == false`)
+    /// compares `base` directly against `head`; three-dot uses the merge-base of
+    /// `base` and `head` as the left tree (branch-comparison semantics).
+    func rangeChangedFiles(at worktree: URL, base: String, head: String, threeDot: Bool) async throws -> [CommitChangedFile] {
+        let leftTree = threeDot
+            ? try await mergeBase(worktreePath: worktree, baseRef: base, headRef: head)
+            : base
+        return try await changedFiles(worktree: worktree, leftTree: leftTree, rightTree: head)
     }
 
     /// Given a numstat path field that may describe a rename via `old => new`

--- a/Alas/Sources/Git/GitService.swift
+++ b/Alas/Sources/Git/GitService.swift
@@ -1348,6 +1348,19 @@ extension GitService {
         return result.stdout.trimmingCharacters(in: .whitespacesAndNewlines)
     }
 
+    /// Resolves an arbitrary revision (branch name, ref, or SHA) to its commit
+    /// SHA. Used to pin a branch-comparison base to an immutable revision so a
+    /// stored review keeps the same merge base even if the branch advances.
+    func resolveRevision(at worktree: URL, ref: String) async throws -> String {
+        let result = try await Process.git(["rev-parse", "--verify", "\(ref)^{commit}"], cwd: worktree)
+        let resolved = result.stdout.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard result.exitCode == 0, !resolved.isEmpty else {
+            throw NSError(domain: "GitService.resolveRevision", code: Int(result.exitCode),
+                          userInfo: [NSLocalizedDescriptionKey: result.stderr])
+        }
+        return resolved
+    }
+
     /// Resolves the base ref to compare against for a given worktree.
     /// Returns nil when neither `origin/<base>`, `refs/remotes/<base>`, nor local `<base>` exists.
     /// `remote == nil` means "no fetch path; use the local ref as-is".

--- a/Alas/Sources/Git/GitService.swift
+++ b/Alas/Sources/Git/GitService.swift
@@ -204,10 +204,12 @@ extension GitService {
         return DiffReviewFileContextSnapshot(old: old, new: new)
     }
 
-    func refContextSnapshot(worktreePath: URL, baseRef: String, headRef: String, file: String, originalPath: String? = nil) async throws -> DiffReviewFileContextSnapshot {
+    func refContextSnapshot(worktreePath: URL, baseRef: String, headRef: String, file: String, originalPath: String? = nil, useMergeBase: Bool = true) async throws -> DiffReviewFileContextSnapshot {
         let oldPath = originalPath?.isEmpty == false ? originalPath! : file
-        let mergeBase = try await mergeBase(worktreePath: worktreePath, baseRef: baseRef, headRef: headRef)
-        let old = try await blobLinesOrUnavailable(worktreePath: worktreePath, ref: mergeBase, path: oldPath)
+        let oldRef = useMergeBase
+            ? try await mergeBase(worktreePath: worktreePath, baseRef: baseRef, headRef: headRef)
+            : baseRef
+        let old = try await blobLinesOrUnavailable(worktreePath: worktreePath, ref: oldRef, path: oldPath)
         let new = try await blobLinesOrUnavailable(worktreePath: worktreePath, ref: headRef, path: file)
         return DiffReviewFileContextSnapshot(old: old, new: new)
     }
@@ -342,6 +344,31 @@ extension GitService {
         guard result.exitCode == 0 else {
             throw NSError(
                 domain: "GitService.diff(sha:file:)",
+                code: Int(result.exitCode),
+                userInfo: [NSLocalizedDescriptionKey: result.stderr]
+            )
+        }
+        let stdout = result.stdout
+        return await Task.detached(priority: .userInitiated) {
+            DiffParser.parse(Self.sliceDiffForFile(stdout, file: file))
+        }.value
+    }
+
+    /// Per-file diff for a commit range. Two-dot (`threeDot == false`) diffs
+    /// `base` against `head`; three-dot diffs the merge-base of `base`/`head`
+    /// against `head`. Mirrors `diff(worktreePath:sha:file:)`: the multi-file
+    /// output (copies) is sliced down to the requested file before parsing.
+    func rangeDiff(worktreePath: URL, base: String, head: String, threeDot: Bool, file: String, originalPath: String? = nil) async throws -> ParsedDiff {
+        let leftTree = threeDot
+            ? try await mergeBase(worktreePath: worktreePath, baseRef: base, headRef: head)
+            : base
+        var args: [String] = ["-c", "core.quotePath=false",
+                              "diff", "--no-color", "-M", "-C", leftTree, head, "--", file]
+        if let originalPath { args.append(originalPath) }
+        let result = try await Process.git(args, cwd: worktreePath)
+        guard result.exitCode == 0 else {
+            throw NSError(
+                domain: "GitService.rangeDiff",
                 code: Int(result.exitCode),
                 userInfo: [NSLocalizedDescriptionKey: result.stderr]
             )

--- a/Alas/Sources/Git/GitService.swift
+++ b/Alas/Sources/Git/GitService.swift
@@ -217,11 +217,35 @@ extension GitService {
     /// Resolves the left tree for a two-dot range base. The base is constructed
     /// as "<sha>^"; for a root commit that parent does not exist, so fall back to
     /// the canonical empty tree (matching diff(worktreePath:sha:file:)).
+    ///
+    /// The empty-tree fallback is limited to the *proven* root-commit case: the
+    /// commit itself must resolve and have no parents. Any other resolution
+    /// failure (a stale or invalid base) is thrown, so we never silently diff
+    /// against the empty tree and report every file in `head` as newly added.
     private func resolveTwoDotLeftTree(worktreePath: URL, base: String) async throws -> String {
         let result = try await Process.git(["rev-parse", "--verify", "--quiet", base], cwd: worktreePath)
         let resolved = result.stdout.trimmingCharacters(in: .whitespacesAndNewlines)
         if result.exitCode == 0, !resolved.isEmpty { return resolved }
-        return "4b825dc642cb6eb9a060e54bf8d69288fbee4904"
+
+        // `base` did not resolve. Only treat it as the empty tree when it is a
+        // genuine root-commit parent ("<root>^"): the commit-ish must resolve
+        // and report no parents. Otherwise the base is stale/invalid — throw.
+        if base.hasSuffix("^") {
+            let commitish = String(base.dropLast())
+            let parents = try await Process.git(["rev-list", "--parents", "-n", "1", commitish], cwd: worktreePath)
+            let tokens = parents.stdout
+                .trimmingCharacters(in: .whitespacesAndNewlines)
+                .split(separator: " ", omittingEmptySubsequences: true)
+            if parents.exitCode == 0, tokens.count == 1 {
+                return "4b825dc642cb6eb9a060e54bf8d69288fbee4904"
+            }
+        }
+
+        throw NSError(
+            domain: "GitService.resolveTwoDotLeftTree",
+            code: Int(result.exitCode),
+            userInfo: [NSLocalizedDescriptionKey: "Could not resolve range base \"\(base)\": \(result.stderr.trimmingCharacters(in: .whitespacesAndNewlines))"]
+        )
     }
 
     private func mergeBase(worktreePath: URL, baseRef: String, headRef: String) async throws -> String {

--- a/Alas/Sources/Git/GitService.swift
+++ b/Alas/Sources/Git/GitService.swift
@@ -214,6 +214,16 @@ extension GitService {
         return DiffReviewFileContextSnapshot(old: old, new: new)
     }
 
+    /// Resolves the left tree for a two-dot range base. The base is constructed
+    /// as "<sha>^"; for a root commit that parent does not exist, so fall back to
+    /// the canonical empty tree (matching diff(worktreePath:sha:file:)).
+    private func resolveTwoDotLeftTree(worktreePath: URL, base: String) async throws -> String {
+        let result = try await Process.git(["rev-parse", "--verify", "--quiet", base], cwd: worktreePath)
+        let resolved = result.stdout.trimmingCharacters(in: .whitespacesAndNewlines)
+        if result.exitCode == 0, !resolved.isEmpty { return resolved }
+        return "4b825dc642cb6eb9a060e54bf8d69288fbee4904"
+    }
+
     private func mergeBase(worktreePath: URL, baseRef: String, headRef: String) async throws -> String {
         let result = try await Process.git(["merge-base", baseRef, headRef], cwd: worktreePath)
         let stdout = result.stdout.trimmingCharacters(in: .whitespacesAndNewlines)
@@ -361,7 +371,7 @@ extension GitService {
     func rangeDiff(worktreePath: URL, base: String, head: String, threeDot: Bool, file: String, originalPath: String? = nil) async throws -> ParsedDiff {
         let leftTree = threeDot
             ? try await mergeBase(worktreePath: worktreePath, baseRef: base, headRef: head)
-            : base
+            : try await resolveTwoDotLeftTree(worktreePath: worktreePath, base: base)
         var args: [String] = ["-c", "core.quotePath=false",
                               "diff", "--no-color", "-M", "-C", leftTree, head, "--", file]
         if let originalPath { args.append(originalPath) }
@@ -877,7 +887,7 @@ extension GitService {
     func rangeChangedFiles(at worktree: URL, base: String, head: String, threeDot: Bool) async throws -> [CommitChangedFile] {
         let leftTree = threeDot
             ? try await mergeBase(worktreePath: worktree, baseRef: base, headRef: head)
-            : base
+            : try await resolveTwoDotLeftTree(worktreePath: worktree, base: base)
         return try await changedFiles(worktree: worktree, leftTree: leftTree, rightTree: head)
     }
 
@@ -1300,6 +1310,16 @@ extension GitService {
         )
         guard result.exitCode == 0 else {
             throw ProcessError.nonZeroExit(result.exitCode, result.stderr)
+        }
+        return result.stdout.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    /// Returns the full SHA of the current HEAD commit for the given worktree.
+    func headSHA(at worktree: URL) async throws -> String {
+        let result = try await Process.git(["rev-parse", "HEAD"], cwd: worktree)
+        guard result.exitCode == 0 else {
+            throw NSError(domain: "GitService.headSHA", code: Int(result.exitCode),
+                          userInfo: [NSLocalizedDescriptionKey: result.stderr])
         }
         return result.stdout.trimmingCharacters(in: .whitespacesAndNewlines)
     }

--- a/AlasTests/GitServiceTests.swift
+++ b/AlasTests/GitServiceTests.swift
@@ -685,4 +685,21 @@ struct GitServiceTests {
         let sha = try await svc.revParseHEAD(worktreePath: repo)
         #expect(sha.count == 40)
     }
+
+    @Test func rangeChangedFilesListsTwoDotFilesInRange() async throws {
+        let repo = try await makeContextSnapshotRepo()
+        try writeText("a\n", "a.txt", in: repo)
+        try await gitOK(["add", "."], cwd: repo)
+        try await gitOK(["commit", "-q", "-m", "base"], cwd: repo)
+        let base = try await gitOK(["rev-parse", "HEAD"], cwd: repo).stdout.trimmingCharacters(in: .whitespacesAndNewlines)
+        try writeText("a\nb\n", "a.txt", in: repo)
+        try writeText("n\n", "new.txt", in: repo)
+        try await gitOK(["add", "."], cwd: repo)
+        try await gitOK(["commit", "-q", "-m", "head"], cwd: repo)
+        let head = try await gitOK(["rev-parse", "HEAD"], cwd: repo).stdout.trimmingCharacters(in: .whitespacesAndNewlines)
+
+        let files = try await GitService().rangeChangedFiles(at: repo, base: base, head: head, threeDot: false)
+
+        #expect(Set(files.map(\.path)) == ["a.txt", "new.txt"])
+    }
 }

--- a/AlasTests/GitServiceTests.swift
+++ b/AlasTests/GitServiceTests.swift
@@ -817,4 +817,21 @@ struct GitServiceTests {
         #expect(svcSHA == gitSHA)
         #expect(svcSHA.count == 40)
     }
+
+    @Test func resolveRevisionResolvesBranchNameToSHA() async throws {
+        let repo = try await makeContextSnapshotRepo()
+        defer { try? FileManager.default.removeItem(at: repo) }
+        try writeText("a\n", "a.txt", in: repo)
+        try await gitOK(["add", "."], cwd: repo)
+        try await gitOK(["commit", "-q", "-m", "c"], cwd: repo)
+
+        let branchSHA = try await gitOK(["rev-parse", "main"], cwd: repo)
+            .stdout.trimmingCharacters(in: .whitespacesAndNewlines)
+        let resolved = try await GitService().resolveRevision(at: repo, ref: "main")
+        #expect(resolved == branchSHA)
+
+        await #expect(throws: (any Error).self) {
+            _ = try await GitService().resolveRevision(at: repo, ref: "no-such-branch")
+        }
+    }
 }

--- a/AlasTests/GitServiceTests.swift
+++ b/AlasTests/GitServiceTests.swift
@@ -719,4 +719,77 @@ struct GitServiceTests {
 
         #expect(Set(files.map(\.path)) == ["a.txt", "new.txt"])
     }
+
+    // MARK: - Root-commit range tests (Fix 1)
+
+    @Test func rangeChangedFilesHandlesRootCommitParentBase() async throws {
+        // Repo with a SINGLE root commit. base = "<rootSHA>^" (no parent).
+        // rangeChangedFiles must not throw and must treat the missing parent
+        // as the canonical empty tree, so all files in the root commit appear.
+        let repo = FileManager.default.temporaryDirectory
+            .appendingPathComponent("alas-root-range-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: repo, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: repo) }
+
+        try await gitOK(["init", "-q", "-b", "main"], cwd: repo)
+        try await gitOK(["config", "user.email", "t@example.com"], cwd: repo)
+        try await gitOK(["config", "user.name", "Test User"], cwd: repo)
+        try writeText("hello\n", "hello.txt", in: repo)
+        try await gitOK(["add", "."], cwd: repo)
+        try await gitOK(["commit", "-q", "-m", "root"], cwd: repo)
+        let rootSHA = try await gitOK(["rev-parse", "HEAD"], cwd: repo)
+            .stdout.trimmingCharacters(in: .whitespacesAndNewlines)
+
+        let files = try await GitService().rangeChangedFiles(
+            at: repo,
+            base: "\(rootSHA)^",
+            head: rootSHA,
+            threeDot: false
+        )
+
+        #expect(files.map(\.path).contains("hello.txt"))
+    }
+
+    @Test func rangeDiffHandlesRootCommitParentBase() async throws {
+        // Same single-commit repo; rangeDiff must return non-empty hunks
+        // for the file introduced in the root commit.
+        let repo = FileManager.default.temporaryDirectory
+            .appendingPathComponent("alas-root-rdiff-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: repo, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: repo) }
+
+        try await gitOK(["init", "-q", "-b", "main"], cwd: repo)
+        try await gitOK(["config", "user.email", "t@example.com"], cwd: repo)
+        try await gitOK(["config", "user.name", "Test User"], cwd: repo)
+        try writeText("world\n", "world.txt", in: repo)
+        try await gitOK(["add", "."], cwd: repo)
+        try await gitOK(["commit", "-q", "-m", "root"], cwd: repo)
+        let rootSHA = try await gitOK(["rev-parse", "HEAD"], cwd: repo)
+            .stdout.trimmingCharacters(in: .whitespacesAndNewlines)
+
+        let diff = try await GitService().rangeDiff(
+            worktreePath: repo,
+            base: "\(rootSHA)^",
+            head: rootSHA,
+            threeDot: false,
+            file: "world.txt",
+            originalPath: nil
+        )
+
+        #expect(!diff.hunks.isEmpty)
+    }
+
+    // MARK: - headSHA test (Fix 2)
+
+    @Test func headSHAReturnsCurrentHEAD() async throws {
+        let repo = try await makeContextSnapshotRepo()
+        defer { try? FileManager.default.removeItem(at: repo) }
+
+        let gitSHA = try await gitOK(["rev-parse", "HEAD"], cwd: repo)
+            .stdout.trimmingCharacters(in: .whitespacesAndNewlines)
+        let svcSHA = try await GitService().headSHA(at: repo)
+
+        #expect(svcSHA == gitSHA)
+        #expect(svcSHA.count == 40)
+    }
 }

--- a/AlasTests/GitServiceTests.swift
+++ b/AlasTests/GitServiceTests.swift
@@ -779,6 +779,31 @@ struct GitServiceTests {
         #expect(!diff.hunks.isEmpty)
     }
 
+    @Test func rangeChangedFilesThrowsForStaleNonRootBase() async throws {
+        // A non-root base that no longer resolves (e.g. a stale SHA after a
+        // rebase) must throw rather than silently diffing against the empty
+        // tree and reporting every file in head as newly added.
+        let repo = try await makeContextSnapshotRepo()
+        defer { try? FileManager.default.removeItem(at: repo) }
+        try writeText("a\n", "a.txt", in: repo)
+        try await gitOK(["add", "."], cwd: repo)
+        try await gitOK(["commit", "-q", "-m", "head"], cwd: repo)
+        let head = try await gitOK(["rev-parse", "HEAD"], cwd: repo)
+            .stdout.trimmingCharacters(in: .whitespacesAndNewlines)
+
+        // "<bogus-sha>^" — the commit-ish does not resolve, so this is not a
+        // proven root commit and must not fall back to the empty tree.
+        let staleBase = "deadbeefdeadbeefdeadbeefdeadbeefdeadbeef^"
+        await #expect(throws: (any Error).self) {
+            _ = try await GitService().rangeChangedFiles(
+                at: repo,
+                base: staleBase,
+                head: head,
+                threeDot: false
+            )
+        }
+    }
+
     // MARK: - headSHA test (Fix 2)
 
     @Test func headSHAReturnsCurrentHEAD() async throws {

--- a/AlasTests/GitServiceTests.swift
+++ b/AlasTests/GitServiceTests.swift
@@ -686,6 +686,23 @@ struct GitServiceTests {
         #expect(sha.count == 40)
     }
 
+    @Test func rangeDiffReturnsHunksForChangedFile() async throws {
+        let repo = try await makeContextSnapshotRepo()
+        try writeText("a\n", "a.txt", in: repo)
+        try await gitOK(["add", "."], cwd: repo)
+        try await gitOK(["commit", "-q", "-m", "base"], cwd: repo)
+        let base = try await gitOK(["rev-parse", "HEAD"], cwd: repo).stdout.trimmingCharacters(in: .whitespacesAndNewlines)
+        try writeText("a\nb\n", "a.txt", in: repo)
+        try await gitOK(["add", "."], cwd: repo)
+        try await gitOK(["commit", "-q", "-m", "head"], cwd: repo)
+        let head = try await gitOK(["rev-parse", "HEAD"], cwd: repo).stdout.trimmingCharacters(in: .whitespacesAndNewlines)
+
+        let diff = try await GitService().rangeDiff(worktreePath: repo, base: base, head: head, threeDot: false, file: "a.txt", originalPath: nil)
+
+        #expect(!diff.hunks.isEmpty)
+        #expect(diff.hunks.contains { hunk in hunk.lines.contains { $0.kind == .add && $0.text == "b" } })
+    }
+
     @Test func rangeChangedFilesListsTwoDotFilesInRange() async throws {
         let repo = try await makeContextSnapshotRepo()
         try writeText("a\n", "a.txt", in: repo)

--- a/AlasTests/RangeReviewLoaderTests.swift
+++ b/AlasTests/RangeReviewLoaderTests.swift
@@ -1,0 +1,50 @@
+import Foundation
+import Testing
+@testable import Alas
+
+struct RangeReviewLoaderTests {
+    @Test func loadsRangeFilesInOrderIntoUngroupedSession() async throws {
+        let git = FakeRangeReviewGitClient(diffs: [
+            "z.swift": diff(lines: [.init(kind: .add, text: "let z = true", oldNumber: nil, newNumber: 1)]),
+            "a.swift": diff(lines: [.init(kind: .delete, text: "let a = false", oldNumber: 1, newNumber: nil)]),
+        ])
+        let loader = RangeReviewLoader(git: git)
+
+        let session = try await loader.load(
+            worktreePath: URL(fileURLWithPath: "/tmp/repo"),
+            base: "aaa", head: "bbb", threeDot: false,
+            files: [
+                CommitChangedFile(path: "z.swift", originalPath: nil, status: "A", add: 1, del: 0),
+                CommitChangedFile(path: "a.swift", originalPath: nil, status: "D", add: 0, del: 1),
+            ],
+            openFileForPath: { _ in nil }
+        )
+
+        #expect(session.files.map(\.summary.path) == ["z.swift", "a.swift"])
+        #expect(session.summary.groupsEnabled == false)
+    }
+
+    private func diff(lines: [ParsedDiff.Hunk.Line]) -> ParsedDiff {
+        ParsedDiff(hunks: [
+            ParsedDiff.Hunk(
+                header: "@@ -1,\(lines.count) +1,\(lines.count) @@",
+                oldStart: 1,
+                newStart: 1,
+                lines: lines
+            ),
+        ])
+    }
+}
+
+private final class FakeRangeReviewGitClient: RangeReviewGitClient, @unchecked Sendable {
+    private let diffs: [String: ParsedDiff]
+    init(diffs: [String: ParsedDiff]) { self.diffs = diffs }
+
+    func rangeDiff(worktreePath: URL, base: String, head: String, threeDot: Bool, file: String, originalPath: String?) async throws -> ParsedDiff {
+        diffs[file, default: ParsedDiff(hunks: [])]
+    }
+
+    func rangeContextSnapshot(worktreePath: URL, base: String, head: String, threeDot: Bool, file: String, originalPath: String?) async throws -> DiffReviewFileContextSnapshot {
+        DiffReviewFileContextSnapshot(old: .unavailable, new: .unavailable)
+    }
+}

--- a/AlasTests/RangeReviewLoaderTests.swift
+++ b/AlasTests/RangeReviewLoaderTests.swift
@@ -22,6 +22,35 @@ struct RangeReviewLoaderTests {
 
         #expect(session.files.map(\.summary.path) == ["z.swift", "a.swift"])
         #expect(session.summary.groupsEnabled == false)
+        #expect(session.files.map(\.summary.namespace) == ["range", "range"])
+        #expect(session.files.map(\.summary.status) == [.added, .deleted])
+    }
+
+    @Test func derivesCountsFromParsedDiffInsteadOfCommitFileStats() async throws {
+        let git = FakeRangeReviewGitClient(diffs: [
+            "Sources/App.swift": diff(lines: [
+                .init(kind: .context, text: "struct App {}", oldNumber: 1, newNumber: 1),
+                .init(kind: .delete, text: "let old = 1", oldNumber: 2, newNumber: nil),
+                .init(kind: .delete, text: "let older = 0", oldNumber: 3, newNumber: nil),
+                .init(kind: .add, text: "let new = 1", oldNumber: nil, newNumber: 2),
+            ]),
+        ])
+        let loader = RangeReviewLoader(git: git)
+
+        let session = try await loader.load(
+            worktreePath: URL(fileURLWithPath: "/tmp/repo"),
+            base: "aaa", head: "bbb", threeDot: false,
+            files: [
+                CommitChangedFile(path: "Sources/App.swift", originalPath: nil, status: "M", add: 999, del: 888),
+            ],
+            openFileForPath: { _ in nil }
+        )
+
+        let file = try #require(session.files.first)
+        #expect(file.summary.additions == 1)
+        #expect(file.summary.deletions == 2)
+        #expect(session.summary.totalAdditions == 1)
+        #expect(session.summary.totalDeletions == 2)
     }
 
     private func diff(lines: [ParsedDiff.Hunk.Line]) -> ParsedDiff {

--- a/AlasTests/ReviewScopeSelectionTests.swift
+++ b/AlasTests/ReviewScopeSelectionTests.swift
@@ -41,6 +41,42 @@ struct ReviewScopeSelectionTests {
         #expect(target.payload == .branch(base: "main", head: "abc1234abc1234abc1234abc1234abc1234abc1234"))
     }
 
+    @Test func branchWithBranchBaseSHAPinsBase() {
+        let target = ReviewScopeSelection.target(
+            for: .branch(name: "main"),
+            worktreeID: "wt",
+            repositoryPath: path,
+            headSHA: "abc1234abc1234abc1234abc1234abc1234abc1234",
+            branchBaseSHA: "def5678def5678def5678def5678def5678def567"
+        )
+        #expect(target.kind == .branch)
+        #expect(target.payload == .branch(
+            base: "def5678def5678def5678def5678def5678def567",
+            head: "abc1234abc1234abc1234abc1234abc1234abc1234"
+        ))
+        // The branch name is retained only for display.
+        #expect(target.title == "Review HEAD against main")
+    }
+
+    @Test func branchTargetIDVariesWithBranchBaseSHA() {
+        let targetA = ReviewScopeSelection.target(
+            for: .branch(name: "main"),
+            worktreeID: "wt",
+            repositoryPath: path,
+            headSHA: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+            branchBaseSHA: "1111111111111111111111111111111111111111"
+        )
+        let targetB = ReviewScopeSelection.target(
+            for: .branch(name: "main"),
+            worktreeID: "wt",
+            repositoryPath: path,
+            headSHA: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+            branchBaseSHA: "2222222222222222222222222222222222222222"
+        )
+        #expect(targetA.id != targetB.id)
+        #expect(targetA.draftSessionID != targetB.draftSessionID)
+    }
+
     @Test func branchTargetIDVariesWithHeadSHA() {
         let targetA = ReviewScopeSelection.target(
             for: .branch(name: "main"),

--- a/AlasTests/ReviewScopeSelectionTests.swift
+++ b/AlasTests/ReviewScopeSelectionTests.swift
@@ -1,0 +1,39 @@
+import Foundation
+import Testing
+@testable import Alas
+
+struct ReviewScopeSelectionTests {
+    private let path = URL(fileURLWithPath: "/tmp/repo")
+
+    private func info(_ sha: String, _ subject: String) -> CommitInfo {
+        CommitInfo(sha: sha, shortSha: String(sha.prefix(7)), author: "A", authorInitials: "A",
+                   date: Date(timeIntervalSince1970: 0), subject: subject, conventionalTag: nil,
+                   filesChanged: 0, insertions: 0, deletions: 0)
+    }
+
+    @Test func workingTreeBuildsLocalChangesTarget() {
+        let target = ReviewScopeSelection.target(for: .workingTree, worktreeID: "wt", repositoryPath: path)
+        #expect(target.kind == .localChanges)
+    }
+
+    @Test func rangeBuildsParentBaseAndNewerHead() {
+        let older = info("aaaaaaa1", "first")
+        let newer = info("bbbbbbb2", "second")
+        let target = ReviewScopeSelection.target(for: .range(older: older, newer: newer), worktreeID: "wt", repositoryPath: path)
+        #expect(target.kind == .commitRange)
+        #expect(target.payload == .commitRange(base: "aaaaaaa1^", head: "bbbbbbb2"))
+    }
+
+    @Test func branchBuildsThreeDotAgainstHead() {
+        let target = ReviewScopeSelection.target(for: .branch(name: "main"), worktreeID: "wt", repositoryPath: path)
+        #expect(target.kind == .branch)
+        #expect(target.payload == .branch(base: "main", head: "HEAD"))
+    }
+
+    @Test func filterMatchesShaSubjectAndIsCaseInsensitive() {
+        let commits = [info("abc1234", "Fix login"), info("def5678", "Add export")]
+        #expect(ReviewScopeSelection.filteredCommits(commits, query: "").map(\.sha) == ["abc1234", "def5678"])
+        #expect(ReviewScopeSelection.filteredCommits(commits, query: "export").map(\.sha) == ["def5678"])
+        #expect(ReviewScopeSelection.filteredCommits(commits, query: "ABC12").map(\.sha) == ["abc1234"])
+    }
+}

--- a/AlasTests/ReviewScopeSelectionTests.swift
+++ b/AlasTests/ReviewScopeSelectionTests.swift
@@ -30,6 +30,34 @@ struct ReviewScopeSelectionTests {
         #expect(target.payload == .branch(base: "main", head: "HEAD"))
     }
 
+    @Test func branchWithHeadSHAEmbedsConcreteSHA() {
+        let target = ReviewScopeSelection.target(
+            for: .branch(name: "main"),
+            worktreeID: "wt",
+            repositoryPath: path,
+            headSHA: "abc1234abc1234abc1234abc1234abc1234abc1234"
+        )
+        #expect(target.kind == .branch)
+        #expect(target.payload == .branch(base: "main", head: "abc1234abc1234abc1234abc1234abc1234abc1234"))
+    }
+
+    @Test func branchTargetIDVariesWithHeadSHA() {
+        let targetA = ReviewScopeSelection.target(
+            for: .branch(name: "main"),
+            worktreeID: "wt",
+            repositoryPath: path,
+            headSHA: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+        )
+        let targetB = ReviewScopeSelection.target(
+            for: .branch(name: "main"),
+            worktreeID: "wt",
+            repositoryPath: path,
+            headSHA: "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+        )
+        #expect(targetA.id != targetB.id)
+        #expect(targetA.draftSessionID != targetB.draftSessionID)
+    }
+
     @Test func filterMatchesShaSubjectAndIsCaseInsensitive() {
         let commits = [info("abc1234", "Fix login"), info("def5678", "Add export")]
         #expect(ReviewScopeSelection.filteredCommits(commits, query: "").map(\.sha) == ["abc1234", "def5678"])

--- a/AlasTests/ReviewSessionLoaderTests.swift
+++ b/AlasTests/ReviewSessionLoaderTests.swift
@@ -171,75 +171,23 @@ struct ReviewSessionLoaderTests {
         #expect(loaded.session.summary.files.map(\.namespace) == [summary.namespace])
     }
 
-    @MainActor
-    @Test func productionLoaderRejectsBranchTargetUntilStoredDiffLoadingIsWired() async throws {
-        let repo = FileManager.default.temporaryDirectory
-            .appendingPathComponent("alas-review-session-loader-\(UUID().uuidString)")
-        try FileManager.default.createDirectory(at: repo, withIntermediateDirectories: true)
-        defer { try? FileManager.default.removeItem(at: repo) }
-        _ = try await Process.git(["init", "-q", "-b", "main"], cwd: repo)
+    @Test func routesCommitRangeTargetToInjectedLoader() async throws {
+        let path = URL(fileURLWithPath: "/tmp/repo")
+        let expected = DiffReviewLoadedSession(files: [], summary: DiffReviewSessionModel(files: [], groupsEnabled: false))
+        let loader = ReviewSessionLoader(commitRange: { _ in expected })
+        let target = ReviewSessionTarget.commitRange(worktreeID: "wt", repositoryPath: path, base: "aaa", head: "bbb")
 
-        let worktree = Worktree(
-            id: Worktree.makeId(path: repo),
-            projectId: "project-1",
-            name: "main",
-            branch: "main",
-            path: repo,
-            status: .clean,
-            lastActivity: Date(timeIntervalSince1970: 1)
-        )
-        let target = ReviewSessionTarget.branch(
-            worktreeID: worktree.id,
-            repositoryPath: repo,
-            base: "main",
-            head: "feature"
-        )
-        let loader = ReviewSessionLoader.production(
-            appState: AppState(store: MemoryStore()),
-            worktree: worktree
-        )
+        let context = try await loader.load(target: target)
 
-        do {
-            _ = try await loader.load(target: target)
-            Issue.record("Expected branch targets to stay unsupported until stored diff loading is wired")
-        } catch let error as ReviewSessionLoaderError {
-            #expect(error == .unsupportedTarget)
-        }
+        #expect(context.session.files.isEmpty)
     }
 
-    @MainActor
-    @Test func productionLoaderRejectsCommitRangeTargetUntilStoredDiffLoadingIsWired() async throws {
-        let repo = FileManager.default.temporaryDirectory
-            .appendingPathComponent("alas-review-session-loader-\(UUID().uuidString)")
-        try FileManager.default.createDirectory(at: repo, withIntermediateDirectories: true)
-        defer { try? FileManager.default.removeItem(at: repo) }
-        _ = try await Process.git(["init", "-q", "-b", "main"], cwd: repo)
-
-        let worktree = Worktree(
-            id: Worktree.makeId(path: repo),
-            projectId: "project-1",
-            name: "main",
-            branch: "main",
-            path: repo,
-            status: .clean,
-            lastActivity: Date(timeIntervalSince1970: 1)
-        )
-        let target = ReviewSessionTarget.commitRange(
-            worktreeID: worktree.id,
-            repositoryPath: repo,
-            base: "main",
-            head: "HEAD"
-        )
-        let loader = ReviewSessionLoader.production(
-            appState: AppState(store: MemoryStore()),
-            worktree: worktree
-        )
-
-        do {
+    @Test func defaultBranchLoaderThrowsUnsupportedTarget() async throws {
+        let path = URL(fileURLWithPath: "/tmp/repo")
+        let loader = ReviewSessionLoader()
+        let target = ReviewSessionTarget.branch(worktreeID: "wt", repositoryPath: path, base: "main", head: "HEAD")
+        await #expect(throws: ReviewSessionLoaderError.unsupportedTarget) {
             _ = try await loader.load(target: target)
-            Issue.record("Expected commit-range targets to stay unsupported until stored diff loading is wired")
-        } catch let error as ReviewSessionLoaderError {
-            #expect(error == .unsupportedTarget)
         }
     }
 

--- a/AlasTests/ReviewSessionModelsTests.swift
+++ b/AlasTests/ReviewSessionModelsTests.swift
@@ -65,7 +65,7 @@ struct ReviewSessionModelsTests {
 
         #expect(draft.draftSessionID == .draftCommit(worktreeID: "wt-1", repositoryPath: repositoryPath))
         #expect(commit.draftSessionID == .commit(worktreeID: "wt-1", repositoryPath: repositoryPath, sha: "deadbeef"))
-        #expect(range.draftSessionID == .branch(worktreeID: "wt-1", repositoryPath: repositoryPath, base: "main", head: "feature"))
+        #expect(range.draftSessionID == .commitRange(worktreeID: "wt-1", repositoryPath: repositoryPath, base: "main", head: "feature"))
         #expect(branch.draftSessionID == .branch(worktreeID: "wt-1", repositoryPath: repositoryPath, base: "main", head: "feature"))
         #expect(draft.id.rawValue == "draft-commit\u{1f}wt-1\u{1f}/repo")
         #expect(commit.sourceDescription == "Commit deadbeef")

--- a/AlasTests/ReviewSessionTargetTests.swift
+++ b/AlasTests/ReviewSessionTargetTests.swift
@@ -1,0 +1,17 @@
+import Foundation
+import Testing
+@testable import Alas
+
+struct ReviewSessionTargetTests {
+    @Test func commitRangeAndBranchHaveDistinctDraftSessionIDsForSameEndpoints() {
+        let path = URL(fileURLWithPath: "/tmp/repo")
+        let range = ReviewSessionTarget.commitRange(worktreeID: "wt", repositoryPath: path, base: "aaa", head: "bbb")
+        let branch = ReviewSessionTarget.branch(worktreeID: "wt", repositoryPath: path, base: "aaa", head: "bbb")
+        let commit = ReviewSessionTarget.commit(worktreeID: "wt", repositoryPath: path, sha: "aaa", title: "t")
+
+        #expect(range.draftSessionID != branch.draftSessionID)
+        #expect(range.draftSessionID != commit.draftSessionID)
+        #expect(branch.draftSessionID != commit.draftSessionID)
+        #expect(range.draftSessionID.sourceKind == .commitRange)
+    }
+}


### PR DESCRIPTION
## Worktree review scope selector

Adds a scope picker to the Review Changes pane so you can review more than just the working tree: pick a **single commit**, a **commit range** (net two-dot diff), or a **branch** (three-dot merge-base diff) — each opening a persistent, per-target review session. "Working tree" stays the default.

Inspired by `mrmans0n/ai-review`'s commit selector, adapted to Alas's existing target-driven review-session workspace.

### How it works

The feature reuses the existing `ReviewSessionLoader` → `ReviewSessionTabView` workspace, which already routes by `ReviewSessionTarget.kind` and persists per target. Two previously-stubbed loaders (`commitRange`, `branch`) are now implemented; the rest is the picker UI and its entry point.

- A **scope button** in the Review Changes toolbar opens a modal **`ReviewScopePicker`** (Commits tab with single-select + range-anchor, Branches tab, and a Working tree option).
- **`ReviewScopeSelection`** (pure, unit-tested) maps a choice to a `ReviewSessionTarget`. Range maps an inclusive `older…newer` selection to `base = "<older.sha>^"`, `head = newer.sha`.
- **`RangeReviewLoader`** + new `GitService` plumbing (`rangeChangedFiles`, `rangeDiff`, two-dot `refContextSnapshot`) produce the diff sections. Two-dot for ranges, three-dot (merge-base) for branches.
- Each scope keeps its own draft-comment session, so comments persist per scope. Fixed a latent collision where commit ranges shared a branch's draft session id.

### Tests

- `GitService` range methods (ephemeral-repo tests): two-dot file listing and per-file range diff.
- `RangeReviewLoader`: ungrouped session building, counts derived from the parsed diff.
- `ReviewSessionLoader`: `.commitRange`/`.branch` routing; default stubs still throw.
- `ReviewScopeSelection`: all four target mappings + case-insensitive commit filter.
- Distinct draft session ids for `.commit` / `.commitRange` / `.branch` on identical endpoints.

### Follow-ups (non-blocking)

- The branch picker lists the current branch, which yields an empty (`branch...HEAD`) diff — could be filtered out.
- `branch` target's `revisionDescription` shows `base..head` (two-dot) though the diff is three-dot — cosmetic.
- `scopeBranches` isn't reset on worktree switch if the tab view is reused.
