### PR TITLE
feat(review): Improve finish inspect pane

### DIFF
--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -87,6 +87,7 @@
 		14775ED3C1BC3A084B2147C1 /* HeadReader.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB2EB554CB6AF797545DB95D /* HeadReader.swift */; };
 		14BC25FE7259A545420F28AA /* ComposerAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE5FDAB31C577FC38CE53032 /* ComposerAction.swift */; };
 		14D70126BAF735B2A66A23C5 /* DiffReviewScrollSpyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F649B493D42787FEA6D8E67B /* DiffReviewScrollSpyTests.swift */; };
+		14DC8D8191E6E39E8741108D /* ReviewTabViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9CAED428443C9A7FE55E9A31 /* ReviewTabViewTests.swift */; };
 		162363BDA6BC54B372C77B91 /* ACPMarkdownTextBareURLTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8718406234B8C879B9D0CAB1 /* ACPMarkdownTextBareURLTests.swift */; };
 		162A6ABEAE92BB3AD1511567 /* AdvancedSettingsVisibilityTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1CD33324CA36118FCEA2BE2 /* AdvancedSettingsVisibilityTests.swift */; };
 		165300DDFFB445D8AAE7A5E5 /* MarkdownFileTypeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 19C327BB65463E878DDCDA5E /* MarkdownFileTypeTests.swift */; };
@@ -1726,6 +1727,7 @@
 		9C165BAAF80F9B4A5949BD39 /* RightPaneTransitionalView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RightPaneTransitionalView.swift; sourceTree = "<group>"; };
 		9C45A26ADB0D1CCFBB5BEAE8 /* TerminalSession.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TerminalSession.swift; sourceTree = "<group>"; };
 		9CA420C011D4235E47A3FB1B /* RepoSelectorRecents.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RepoSelectorRecents.swift; sourceTree = "<group>"; };
+		9CAED428443C9A7FE55E9A31 /* ReviewTabViewTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReviewTabViewTests.swift; sourceTree = "<group>"; };
 		9D209865BE187943BF14B830 /* AgentRunnerInvocationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentRunnerInvocationTests.swift; sourceTree = "<group>"; };
 		9D32294F9B916DFAFF5E9A6F /* WorkingTreeChangeGroup.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkingTreeChangeGroup.swift; sourceTree = "<group>"; };
 		9D3C76F2F0F6BCE4023A9D7F /* StartupScriptResolverTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StartupScriptResolverTests.swift; sourceTree = "<group>"; };
@@ -3509,6 +3511,7 @@
 			isa = PBXGroup;
 			children = (
 				D43F393A27EF521D4A73B050 /* PendingReviewTests.swift */,
+				9CAED428443C9A7FE55E9A31 /* ReviewTabViewTests.swift */,
 			);
 			path = Review;
 			sourceTree = "<group>";
@@ -5266,6 +5269,7 @@
 				60F31F7C4A8A69EDE77363FB /* ReviewSessionModelsTests.swift in Sources */,
 				DECBF7BD8E09E75F70340CF3 /* ReviewSessionStoreTests.swift in Sources */,
 				5255F92036DF00CB48082526 /* ReviewSessionTabViewTests.swift in Sources */,
+				14DC8D8191E6E39E8741108D /* ReviewTabViewTests.swift in Sources */,
 				1ACB56B9AA0EC3C1C2AF5E18 /* ReviewThreadWriteTests.swift in Sources */,
 				C35CB6B466364169DF2616C3 /* RightPaneSelectionStateResolverTests.swift in Sources */,
 				38EB2BAA50A7B7B37DDE2A4C /* RightPaneStateBaseBranchTests.swift in Sources */,

--- a/Alas/Sources/Center/Review/PendingReviewTray.swift
+++ b/Alas/Sources/Center/Review/PendingReviewTray.swift
@@ -1,39 +1,90 @@
 import SwiftUI
 
-struct PendingReviewTray: View {
+struct PendingReviewRail: View {
     @Bindable var pendingReview: PendingReview
+    @Binding var collapsed: Bool
     var onFinish: () -> Void = {}
 
     @Environment(\.theme) private var theme
 
     var body: some View {
         VStack(alignment: .leading, spacing: 0) {
-            trayHeader
-            Divider()
-            commentList
-            Divider()
-            finishButton
+            if collapsed {
+                collapsedBody
+            } else {
+                expandedBody
+            }
         }
-        .frame(width: 280)
+        .frame(width: collapsed ? 44 : 280)
+        .frame(maxHeight: .infinity, alignment: .top)
         .background(theme.color("bg-2"))
-        .clipShape(RoundedRectangle(cornerRadius: 10))
-        .overlay(
-            RoundedRectangle(cornerRadius: 10)
-                .stroke(theme.color("line"), lineWidth: 0.75)
-        )
-        .shadow(color: .black.opacity(0.15), radius: 12, x: 0, y: 4)
-        .padding(12)
+        .overlay(Rectangle().fill(theme.color("line")).frame(width: 0.5), alignment: .leading)
+        .accessibilityIdentifier("pending-review-rail")
     }
 
-    private var trayHeader: some View {
+    private var expandedBody: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            railHeader
+            Divider().overlay(theme.color("line"))
+            commentList
+            Spacer(minLength: 0)
+            Divider().overlay(theme.color("line"))
+            finishButton
+        }
+    }
+
+    private var collapsedBody: some View {
+        VStack(spacing: 8) {
+            collapseButton
+                .padding(.top, 8)
+            Text("\(pendingReview.staged.count)")
+                .font(.system(size: 11, weight: .semibold, design: .monospaced))
+                .foregroundColor(theme.color("warn"))
+                .frame(width: 26, height: 22)
+                .background(theme.color("warn").opacity(0.15))
+                .clipShape(RoundedRectangle(cornerRadius: 6))
+                .accessibilityLabel("\(pendingReview.staged.count) pending review comments")
+            Button {
+                onFinish()
+            } label: {
+                Image(systemName: "arrow.up.doc")
+                    .font(.system(size: 11, weight: .medium))
+                    .foregroundColor(theme.color("fg-muted"))
+                    .frame(width: 26, height: 24)
+                    .background(theme.color("bg-3"))
+                    .clipShape(RoundedRectangle(cornerRadius: 6))
+            }
+            .buttonStyle(.plain)
+            .help("Finish review")
+            Spacer(minLength: 0)
+        }
+    }
+
+    private var railHeader: some View {
         HStack {
             Text("Review (\(pendingReview.staged.count) comment\(pendingReview.staged.count == 1 ? "" : "s"))")
                 .font(.system(size: 12, weight: .semibold))
                 .foregroundColor(theme.color("fg"))
             Spacer(minLength: 0)
+            collapseButton
         }
         .padding(.horizontal, 12)
         .padding(.vertical, 8)
+    }
+
+    private var collapseButton: some View {
+        Button {
+            collapsed.toggle()
+        } label: {
+            Image(systemName: collapsed ? "sidebar.right" : "sidebar.trailing")
+                .font(.system(size: 12, weight: .medium))
+                .foregroundColor(theme.color("fg-muted"))
+                .frame(width: 26, height: 24)
+                .background(theme.color("bg-3"))
+                .clipShape(RoundedRectangle(cornerRadius: 6))
+        }
+        .buttonStyle(.plain)
+        .help(collapsed ? "Expand review rail" : "Collapse review rail")
     }
 
     private var commentList: some View {
@@ -46,7 +97,6 @@ struct PendingReviewTray: View {
             .padding(.horizontal, 12)
             .padding(.vertical, 8)
         }
-        .frame(maxHeight: 200)
     }
 
     private func commentRow(_ comment: StagedComment) -> some View {

--- a/Alas/Sources/Center/Review/ReviewTabView.swift
+++ b/Alas/Sources/Center/Review/ReviewTabView.swift
@@ -1,6 +1,22 @@
 import AppKit
 import SwiftUI
 
+enum ReviewTabLoadingPresentation {
+    static func showsBlockingLoader(isLoading: Bool, hasSession: Bool) -> Bool {
+        isLoading && !hasSession
+    }
+}
+
+enum ReviewTabPendingReviewPresentation {
+    static func showsRail(stagedCount: Int) -> Bool {
+        stagedCount > 0
+    }
+
+    static func showsToolbarFinishButton(canSubmitReview: Bool, hasPendingReviewScope: Bool) -> Bool {
+        canSubmitReview && hasPendingReviewScope
+    }
+}
+
 struct ReviewTabView: View {
     let worktree: Worktree
     let tabState: ReviewPRTabState
@@ -22,6 +38,7 @@ struct ReviewTabView: View {
     @State private var isWriting = false
     @State private var errorMessage: String? = nil
     @State private var pendingReview: PendingReview?
+    @State private var pendingReviewRailCollapsed = false
     @State private var showVerdictSheet = false
     @State private var showWhitespace = false
 
@@ -49,13 +66,6 @@ struct ReviewTabView: View {
                     .padding(.bottom, 12)
                     .transition(.move(edge: .bottom).combined(with: .opacity))
                     .animation(.easeInOut(duration: 0.2), value: errorMessage)
-            }
-        }
-        .overlay(alignment: .bottomTrailing) {
-            if let pr = pendingReview {
-                PendingReviewTray(pendingReview: pr) {
-                    showVerdictSheet = true
-                }
             }
         }
         .sheet(isPresented: $showVerdictSheet) {
@@ -131,16 +141,34 @@ struct ReviewTabView: View {
 
     @ViewBuilder
     private var content: some View {
-        if isLoading {
+        if ReviewTabLoadingPresentation.showsBlockingLoader(isLoading: isLoading, hasSession: session != nil) {
             stateView(title: "Loading changes...", detail: nil, color: theme.color("fg-dim"))
-        } else if let loadError {
-            stateView(title: "Could not load review changes", detail: loadError, color: theme.color("del"))
         } else if let session, session.files.isEmpty {
             stateView(title: "No changes to review", detail: "This worktree has no staged or unstaged file diffs.", color: theme.color("fg-dim"))
         } else if let session {
-            reviewSurface(session)
+            loadedReviewContent {
+                reviewSurface(session)
+            }
+        } else if let loadError {
+            stateView(title: "Could not load review changes", detail: loadError, color: theme.color("del"))
         } else {
             stateView(title: "No changes loaded", detail: nil, color: theme.color("fg-dim"))
+        }
+    }
+
+    private func loadedReviewContent<Content: View>(@ViewBuilder content: () -> Content) -> some View {
+        HStack(spacing: 0) {
+            content()
+
+            if let pendingReview,
+               ReviewTabPendingReviewPresentation.showsRail(stagedCount: pendingReview.staged.count) {
+                PendingReviewRail(
+                    pendingReview: pendingReview,
+                    collapsed: $pendingReviewRailCollapsed
+                ) {
+                    showVerdictSheet = true
+                }
+            }
         }
     }
 
@@ -172,6 +200,18 @@ struct ReviewTabView: View {
                 }
             }
             Spacer()
+            if ReviewTabPendingReviewPresentation.showsToolbarFinishButton(
+                canSubmitReview: capabilities.canSubmitReview,
+                hasPendingReviewScope: pendingReview != nil
+            ) {
+                toolbarButton(
+                    systemName: "arrow.up.doc",
+                    tooltip: "Finish review",
+                    isActive: (pendingReview?.staged.isEmpty == false)
+                ) {
+                    showVerdictSheet = true
+                }
+            }
             layoutSwitcher
             toolbarButton(
                 systemName: diffPreferences.wrapLines.wrappedValue ? "text.justify.left" : "text.alignleft",
@@ -532,7 +572,6 @@ struct ReviewTabView: View {
         activeLoadID = requestedLoadToken.id
         isLoading = true
         loadError = nil
-        session = nil
         defer {
             if requestedLoadToken.isActive(activeKey: activeLoadKey, activeID: activeLoadID) {
                 isLoading = false

--- a/Alas/Sources/Center/Review/ReviewTabView.swift
+++ b/Alas/Sources/Center/Review/ReviewTabView.swift
@@ -5,6 +5,10 @@ enum ReviewTabLoadingPresentation {
     static func showsBlockingLoader(isLoading: Bool, hasSession: Bool) -> Bool {
         isLoading && !hasSession
     }
+
+    static func showsLoadError(loadError: String?, isLoading: Bool, hasSession: Bool) -> Bool {
+        loadError != nil && !showsBlockingLoader(isLoading: isLoading, hasSession: hasSession)
+    }
 }
 
 enum ReviewTabPendingReviewPresentation {
@@ -143,14 +147,15 @@ struct ReviewTabView: View {
     private var content: some View {
         if ReviewTabLoadingPresentation.showsBlockingLoader(isLoading: isLoading, hasSession: session != nil) {
             stateView(title: "Loading changes...", detail: nil, color: theme.color("fg-dim"))
+        } else if ReviewTabLoadingPresentation.showsLoadError(loadError: loadError, isLoading: isLoading, hasSession: session != nil),
+                  let loadError {
+            stateView(title: "Could not load review changes", detail: loadError, color: theme.color("del"))
         } else if let session, session.files.isEmpty {
             stateView(title: "No changes to review", detail: "This worktree has no staged or unstaged file diffs.", color: theme.color("fg-dim"))
         } else if let session {
             loadedReviewContent {
                 reviewSurface(session)
             }
-        } else if let loadError {
-            stateView(title: "Could not load review changes", detail: loadError, color: theme.color("del"))
         } else {
             stateView(title: "No changes loaded", detail: nil, color: theme.color("fg-dim"))
         }

--- a/Alas/Sources/Center/Review/ReviewTabView.swift
+++ b/Alas/Sources/Center/Review/ReviewTabView.swift
@@ -12,8 +12,8 @@ enum ReviewTabLoadingPresentation {
 }
 
 enum ReviewTabPendingReviewPresentation {
-    static func showsRail(stagedCount: Int) -> Bool {
-        stagedCount > 0
+    static func showsRail(stagedCount: Int, loadedFileCount: Int?) -> Bool {
+        loadedFileCount != nil && stagedCount > 0
     }
 
     static func showsToolbarFinishButton(canSubmitReview: Bool, hasPendingReviewScope: Bool) -> Bool {
@@ -151,9 +151,11 @@ struct ReviewTabView: View {
                   let loadError {
             stateView(title: "Could not load review changes", detail: loadError, color: theme.color("del"))
         } else if let session, session.files.isEmpty {
-            stateView(title: "No changes to review", detail: "This worktree has no staged or unstaged file diffs.", color: theme.color("fg-dim"))
+            loadedReviewContent(fileCount: session.files.count) {
+                stateView(title: "No changes to review", detail: "This worktree has no staged or unstaged file diffs.", color: theme.color("fg-dim"))
+            }
         } else if let session {
-            loadedReviewContent {
+            loadedReviewContent(fileCount: session.files.count) {
                 reviewSurface(session)
             }
         } else {
@@ -161,12 +163,15 @@ struct ReviewTabView: View {
         }
     }
 
-    private func loadedReviewContent<Content: View>(@ViewBuilder content: () -> Content) -> some View {
+    private func loadedReviewContent<Content: View>(fileCount: Int, @ViewBuilder content: () -> Content) -> some View {
         HStack(spacing: 0) {
             content()
 
             if let pendingReview,
-               ReviewTabPendingReviewPresentation.showsRail(stagedCount: pendingReview.staged.count) {
+               ReviewTabPendingReviewPresentation.showsRail(
+                   stagedCount: pendingReview.staged.count,
+                   loadedFileCount: fileCount
+               ) {
                 PendingReviewRail(
                     pendingReview: pendingReview,
                     collapsed: $pendingReviewRailCollapsed

--- a/Alas/Sources/Center/Review/VerdictSheet.swift
+++ b/Alas/Sources/Center/Review/VerdictSheet.swift
@@ -28,7 +28,9 @@ struct VerdictSheet: View {
                     .foregroundColor(theme.color("fg-dim"))
                 TextEditor(text: $summaryBody)
                     .font(.system(size: 12))
+                    .scrollContentBackground(.hidden)
                     .frame(minHeight: 80)
+                    .background(theme.color("bg-1"))
                     .overlay(
                         RoundedRectangle(cornerRadius: 6)
                             .stroke(theme.color("line"), lineWidth: 0.75)
@@ -52,6 +54,8 @@ struct VerdictSheet: View {
         }
         .padding(20)
         .frame(width: 380)
+        .background(theme.color("bg-2"))
+        .presentationBackground(theme.color("bg-2"))
     }
 
     private var verdictPicker: some View {

--- a/AlasTests/Center/Review/ReviewTabViewTests.swift
+++ b/AlasTests/Center/Review/ReviewTabViewTests.swift
@@ -1,0 +1,30 @@
+import Testing
+@testable import Alas
+
+struct ReviewTabViewTests {
+    @Test func loadingPresentationKeepsLoadedSessionVisibleDuringRefresh() {
+        #expect(ReviewTabLoadingPresentation.showsBlockingLoader(isLoading: true, hasSession: false))
+        #expect(!ReviewTabLoadingPresentation.showsBlockingLoader(isLoading: true, hasSession: true))
+        #expect(!ReviewTabLoadingPresentation.showsBlockingLoader(isLoading: false, hasSession: true))
+    }
+
+    @Test func pendingReviewRailOnlyShowsForStagedComments() {
+        #expect(!ReviewTabPendingReviewPresentation.showsRail(stagedCount: 0))
+        #expect(ReviewTabPendingReviewPresentation.showsRail(stagedCount: 1))
+    }
+
+    @Test func finishReviewToolbarButtonRequiresSubmitCapabilityAndPendingReviewScope() {
+        #expect(ReviewTabPendingReviewPresentation.showsToolbarFinishButton(
+            canSubmitReview: true,
+            hasPendingReviewScope: true
+        ))
+        #expect(!ReviewTabPendingReviewPresentation.showsToolbarFinishButton(
+            canSubmitReview: false,
+            hasPendingReviewScope: true
+        ))
+        #expect(!ReviewTabPendingReviewPresentation.showsToolbarFinishButton(
+            canSubmitReview: true,
+            hasPendingReviewScope: false
+        ))
+    }
+}

--- a/AlasTests/Center/Review/ReviewTabViewTests.swift
+++ b/AlasTests/Center/Review/ReviewTabViewTests.swift
@@ -27,8 +27,10 @@ struct ReviewTabViewTests {
     }
 
     @Test func pendingReviewRailOnlyShowsForStagedComments() {
-        #expect(!ReviewTabPendingReviewPresentation.showsRail(stagedCount: 0))
-        #expect(ReviewTabPendingReviewPresentation.showsRail(stagedCount: 1))
+        #expect(!ReviewTabPendingReviewPresentation.showsRail(stagedCount: 0, loadedFileCount: 0))
+        #expect(ReviewTabPendingReviewPresentation.showsRail(stagedCount: 1, loadedFileCount: 0))
+        #expect(ReviewTabPendingReviewPresentation.showsRail(stagedCount: 1, loadedFileCount: 3))
+        #expect(!ReviewTabPendingReviewPresentation.showsRail(stagedCount: 1, loadedFileCount: nil))
     }
 
     @Test func finishReviewToolbarButtonRequiresSubmitCapabilityAndPendingReviewScope() {

--- a/AlasTests/Center/Review/ReviewTabViewTests.swift
+++ b/AlasTests/Center/Review/ReviewTabViewTests.swift
@@ -8,6 +8,24 @@ struct ReviewTabViewTests {
         #expect(!ReviewTabLoadingPresentation.showsBlockingLoader(isLoading: false, hasSession: true))
     }
 
+    @Test func loadErrorPresentationReplacesStaleLoadedSessionAfterRefreshFailure() {
+        #expect(ReviewTabLoadingPresentation.showsLoadError(
+            loadError: "failed",
+            isLoading: false,
+            hasSession: true
+        ))
+        #expect(!ReviewTabLoadingPresentation.showsLoadError(
+            loadError: "failed",
+            isLoading: true,
+            hasSession: false
+        ))
+        #expect(!ReviewTabLoadingPresentation.showsLoadError(
+            loadError: nil,
+            isLoading: false,
+            hasSession: true
+        ))
+    }
+
     @Test func pendingReviewRailOnlyShowsForStagedComments() {
         #expect(!ReviewTabPendingReviewPresentation.showsRail(stagedCount: 0))
         #expect(ReviewTabPendingReviewPresentation.showsRail(stagedCount: 1))

--- a/AlasTests/Integrations/GitHubCLIProviderVerdictTests.swift
+++ b/AlasTests/Integrations/GitHubCLIProviderVerdictTests.swift
@@ -38,6 +38,7 @@ struct GitHubCLIProviderVerdictTests {
         let reviewQueryArg = try #require(reviewCmd.args.first { $0.hasPrefix("query=") })
         #expect(reviewQueryArg.contains("addPullRequestReview"))
         #expect(reviewCmd.args.contains("prId=pr-node-42"))
+        #expect(reviewCmd.args.contains("commitOID=head-sha-42"))
     }
 
     // MARK: - addReviewComment
@@ -172,6 +173,7 @@ struct GitHubCLIProviderVerdictTests {
             isDraft: false,
             headRefName: "feature/github-provider",
             baseRefName: "main",
+            headSHA: "head-sha-42",
             reviewDecision: .approved,
             mergeState: .clean,
             checks: [],


### PR DESCRIPTION
## Summary
- move pending review comments from a floating overlay into an inline collapsible rail
- keep Finish Review available from the inspect toolbar for zero-comment approvals
- theme the finish-review sheet background consistently and avoid blocking reload flashes

## Verification
- xcodegen
- xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -quiet build
- xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' test
- git diff --check