### PR TITLE
feat(acp): context ring tooltip and click target

### DIFF
--- a/Alas/Sources/ACP/UI/ACPContextRing.swift
+++ b/Alas/Sources/ACP/UI/ACPContextRing.swift
@@ -39,15 +39,21 @@ func formatContextTokens(_ n: Int) -> String {
 func contextPercent(ratio: Double) -> Int { Int((ratio * 100).rounded()) }
 
 /// Thin progress ring. `ratio` is expected pre-clamped (see `contextRatio`).
+///
+/// - `help`: optional tooltip shown on hover.
+/// - `action`: optional tap/click handler; when provided the ring becomes a
+///   plain button with a hit area that exactly matches the ring frame.
 struct ACPContextRing: View {
     let ratio: Double
     var diameter: CGFloat = 16
     var lineWidth: CGFloat = 2.5
+    var help: String? = nil
+    var action: (() -> Void)? = nil
 
     @Environment(\.theme) private var theme
 
     var body: some View {
-        ZStack {
+        let ring = ZStack {
             Circle()
                 .stroke(theme.color("line"), lineWidth: lineWidth)
             Circle()
@@ -58,5 +64,32 @@ struct ACPContextRing: View {
         }
         .frame(width: diameter, height: diameter)
         .animation(.easeOut(duration: 0.25), value: ratio)
+
+        labeledRing(ring)
+    }
+
+    @ViewBuilder
+    private func labeledRing(_ ring: some View) -> some View {
+        if let help {
+            ring.help(help)
+                .optionalButton(action: action)
+        } else {
+            ring
+                .optionalButton(action: action)
+        }
+    }
+}
+
+extension View {
+    @ViewBuilder
+    fileprivate func optionalButton(action: (() -> Void)?) -> some View {
+        if let action {
+            Button(action: action) {
+                self
+            }
+            .buttonStyle(.plain)
+        } else {
+            self
+        }
     }
 }

--- a/Alas/Sources/ACP/UI/ACPContextUsageButton.swift
+++ b/Alas/Sources/ACP/UI/ACPContextUsageButton.swift
@@ -12,11 +12,11 @@ struct ACPContextUsageButton: View {
     var body: some View {
         if let usage {
             let ratio = contextRatio(used: usage.used, size: usage.size)
-            Button { showDetails.toggle() } label: {
-                ACPContextRing(ratio: ratio)
-            }
-            .buttonStyle(.plain)
-            .help("Context: \(contextPercent(ratio: ratio))% used")
+            ACPContextRing(
+                ratio: ratio,
+                help: "Context window: \(contextPercent(ratio: ratio))% in use",
+                action: { showDetails.toggle() }
+            )
             .popover(isPresented: $showDetails, arrowEdge: .top) {
                 details(usage: usage, ratio: ratio)
             }

--- a/AlasTests/ACP/UI/ACPContextRingTests.swift
+++ b/AlasTests/ACP/UI/ACPContextRingTests.swift
@@ -57,8 +57,9 @@ struct ACPContextRingTests {
         #expect(contextUsageTooltip(ratio: 1.0) == "Context window: 100% in use")
     }
 
-    @Test("ring stays non-interactive when action is nil")
-    func ringWithoutActionIsNonInteractive() {
+    @Test("ring body evaluates on the main actor")
+    @MainActor
+    func ringBodyEvaluates() {
         let view = ACPContextRing(ratio: 0.5)
         _ = view.body
     }

--- a/AlasTests/ACP/UI/ACPContextRingTests.swift
+++ b/AlasTests/ACP/UI/ACPContextRingTests.swift
@@ -42,4 +42,24 @@ struct ACPContextRingTests {
         #expect(contextPercent(ratio: 0.0) == 0)
         #expect(contextPercent(ratio: 1.0) == 100)
     }
+
+    private func contextUsageTooltip(ratio: Double) -> String {
+        "Context window: \(contextPercent(ratio: ratio))% in use"
+    }
+
+    @Test("tooltip string matches requested wording")
+    func tooltipWording() {
+        #expect(contextUsageTooltip(ratio: 0.0) == "Context window: 0% in use")
+        #expect(contextUsageTooltip(ratio: 0.265) == "Context window: 27% in use")
+        #expect(contextUsageTooltip(ratio: 0.80) == "Context window: 80% in use")
+        #expect(contextUsageTooltip(ratio: 0.949) == "Context window: 95% in use")
+        #expect(contextUsageTooltip(ratio: 0.951) == "Context window: 95% in use")
+        #expect(contextUsageTooltip(ratio: 1.0) == "Context window: 100% in use")
+    }
+
+    @Test("ring stays non-interactive when action is nil")
+    func ringWithoutActionIsNonInteractive() {
+        let view = ACPContextRing(ratio: 0.5)
+        _ = view.body
+    }
 }


### PR DESCRIPTION
Shows the exact context-window percentage on hover and makes the ring itself clickable to open the usage details popover.