### PR TITLE
feat(search): reveal content search matches in editor

### DIFF
--- a/Alas/Sources/App/AppState.swift
+++ b/Alas/Sources/App/AppState.swift
@@ -2475,7 +2475,9 @@ final class AppState {
             focusGlobalWorktree(id: worktree.id, projectId: worktree.projectId)
         }
 
-        if ImageFileType.isSupported(relativePath: relativePath) {
+        let hasRevealTarget = revealLine != nil || revealCharacter != nil
+        if ImageFileType.isSupported(relativePath: relativePath),
+           !hasRevealTarget || !ImageFileType.isTextBacked(relativePath: relativePath) {
             _ = tabs.openImagePreview(worktreeId: worktree.id, relativePath: relativePath)
             return
         }

--- a/Alas/Sources/Center/CenterPaneView.swift
+++ b/Alas/Sources/Center/CenterPaneView.swift
@@ -149,6 +149,7 @@ struct CenterPaneView: View {
                                             originatingRelativePath: s.originatingRelativePath,
                                             revealLine: s.revealLine,
                                             revealCharacter: s.revealCharacter,
+                                            revealRevision: s.revealRevision,
                                             appState: state,
                                             onRevealInFiles: { path in state.revealInFiles(worktreeId: worktree.id, path: path) })
                         } else {
@@ -158,6 +159,7 @@ struct CenterPaneView: View {
                                           tabId: s.id,
                                           revealLine: s.revealLine,
                                           revealCharacter: s.revealCharacter,
+                                          revealRevision: s.revealRevision,
                                           appState: state,
                                           externalAbsolutePath: s.externalAbsolutePath,
                                           originatingRelativePath: s.originatingRelativePath,

--- a/Alas/Sources/Center/EditorTabView.swift
+++ b/Alas/Sources/Center/EditorTabView.swift
@@ -43,6 +43,7 @@ struct EditorTabView: View {
     let tabId: TabID
     let revealLine: Int?
     let revealCharacter: Int?
+    let revealRevision: Int?
     let appState: AppState
     let externalAbsolutePath: String?
     let originatingRelativePath: String?
@@ -101,6 +102,7 @@ struct EditorTabView: View {
                 tabId: tabId,
                 revealLine: revealLine,
                 revealCharacter: revealCharacter,
+                revealRevision: revealRevision,
                 appState: appState,
                 externalAbsolutePath: externalAbsolutePath,
                 originatingRelativePath: originatingRelativePath,

--- a/Alas/Sources/Center/ImageFileType.swift
+++ b/Alas/Sources/Center/ImageFileType.swift
@@ -20,6 +20,10 @@ enum ImageFileType {
         return supportedExtensions.contains(ext)
     }
 
+    static func isTextBacked(relativePath: String) -> Bool {
+        fileExtension(relativePath: relativePath) == "svg"
+    }
+
     static func fileExtension(relativePath: String) -> String? {
         let ext = (relativePath as NSString).pathExtension
             .trimmingCharacters(in: .whitespacesAndNewlines)

--- a/Alas/Sources/Center/Tab.swift
+++ b/Alas/Sources/Center/Tab.swift
@@ -339,6 +339,7 @@ struct EditorTabState: Codable, Equatable, Identifiable {
     var relativePath: String   // relative to worktree root; empty when external
     var revealLine: Int? = nil       // 0-based, optional reveal hint set by go-to-definition
     var revealCharacter: Int? = nil  // 0-based UTF-16
+    var revealRevision: Int? = nil   // increments for each explicit reveal request
     var externalAbsolutePath: String? = nil  // set when navigating to a file outside the worktree
     /// The worktree-relative path of the in-worktree file the user was
     /// viewing when they ⌘-clicked to open this external tab. Persisted so

--- a/Alas/Sources/Center/TabsManager.swift
+++ b/Alas/Sources/Center/TabsManager.swift
@@ -433,6 +433,8 @@ final class TabsManager {
         revealLine: Int?,
         revealCharacter: Int?
     ) -> Tab {
+        let shouldRevealInMarkdownEditor = (revealLine != nil || revealCharacter != nil)
+            && MarkdownFileType.isMarkdown(relativePath: relativePath)
         if var file = byWorktree[worktreeId],
            let idx = file.tabs.firstIndex(where: {
                if case .editor(let s) = $0 { return s.relativePath == relativePath }
@@ -441,6 +443,12 @@ final class TabsManager {
             if case .editor(var s) = file.tabs[idx] {
                 s.revealLine = revealLine
                 s.revealCharacter = revealCharacter
+                if revealLine != nil || revealCharacter != nil {
+                    s.revealRevision = (s.revealRevision ?? 0) &+ 1
+                }
+                if shouldRevealInMarkdownEditor {
+                    s.markdownViewMode = .editor
+                }
                 file.tabs[idx] = .editor(s)
                 file.activeTabId = s.id
                 byWorktree[worktreeId] = file
@@ -449,13 +457,16 @@ final class TabsManager {
             }
         }
         let title = (relativePath as NSString).lastPathComponent
-        let state = EditorTabState(
+        var state = EditorTabState(
             id: UUID().uuidString,
             title: title,
             relativePath: relativePath,
             revealLine: revealLine,
             revealCharacter: revealCharacter
         )
+        if shouldRevealInMarkdownEditor {
+            state.markdownViewMode = .editor
+        }
         let tab = Tab.editor(state)
         append(tab, to: worktreeId)
         return tab
@@ -494,6 +505,9 @@ final class TabsManager {
                 let originChanged = (s.originatingRelativePath != originatingRelativePath)
                 s.revealLine = revealLine
                 s.revealCharacter = revealCharacter
+                if revealLine != nil || revealCharacter != nil {
+                    s.revealRevision = (s.revealRevision ?? 0) &+ 1
+                }
                 s.originatingRelativePath = originatingRelativePath   // refresh the origin
                 file.tabs[idx] = .editor(s)
                 file.activeTabId = s.id

--- a/Alas/Sources/Code/Editor/CodeEditorCoordinator.swift
+++ b/Alas/Sources/Code/Editor/CodeEditorCoordinator.swift
@@ -28,7 +28,9 @@ final class CodeEditorCoordinator {
     private var currentTheme: Theme?
     private var currentFontFamily: String?
     private var currentFontSize: CGFloat?
-    private var lastAppliedReveal: (tabId: TabID, line: Int, character: Int)?
+    private var lastAppliedReveal: (tabId: TabID, line: Int, character: Int, revision: Int)?
+    private var revealHighlightTask: Task<Void, Never>?
+    private var revealHighlightRange: NSRange?
     private var currentExternalAbsolutePath: String?
     private var currentOriginatingWorktreeRoot: URL?
     private var currentOriginatingRelativePath: String?
@@ -74,7 +76,7 @@ final class CodeEditorCoordinator {
         self.appState = appState
     }
 
-    func attach(textView: CodeTextView, buffer: EditorBuffer, layoutManager: NSLayoutManager, worktreeId: String, worktreeRoot: URL, tabId: TabID, revealLine: Int?, revealCharacter: Int?, theme: Theme, externalAbsolutePath: String? = nil, originatingRelativePath: String? = nil) {
+    func attach(textView: CodeTextView, buffer: EditorBuffer, layoutManager: NSLayoutManager, worktreeId: String, worktreeRoot: URL, tabId: TabID, revealLine: Int?, revealCharacter: Int?, revealRevision: Int? = nil, theme: Theme, externalAbsolutePath: String? = nil, originatingRelativePath: String? = nil) {
         self.textView = textView
         self.layoutManager = layoutManager
         self.currentWorktreeId = worktreeId
@@ -266,7 +268,7 @@ final class CodeEditorCoordinator {
             appState.tabs.ensureExternalLSPOpen(tabId: tabId)
         }
 
-        applyRevealIfNeeded(tabId: tabId, line: revealLine, character: revealCharacter)
+        applyRevealIfNeeded(tabId: tabId, line: revealLine, character: revealCharacter, revision: revealRevision)
 
         NotificationCenter.default.post(
             name: .codeEditorDidAttach,
@@ -276,7 +278,7 @@ final class CodeEditorCoordinator {
         onTextViewAttached?(textView, tabId)
     }
 
-    func updateIfNeeded(worktreeId: String, worktreeRoot: URL, relativePath: String, tabId: TabID, revealLine: Int?, revealCharacter: Int?, theme: Theme, externalAbsolutePath: String? = nil, originatingRelativePath: String? = nil) {
+    func updateIfNeeded(worktreeId: String, worktreeRoot: URL, relativePath: String, tabId: TabID, revealLine: Int?, revealCharacter: Int?, revealRevision: Int? = nil, theme: Theme, externalAbsolutePath: String? = nil, originatingRelativePath: String? = nil) {
         // Re-query the registry every time so a registry change (e.g. a
         // server gets installed) still flips this comparison and triggers a
         // rebind. When the same tab is being re-evaluated and has an
@@ -319,6 +321,7 @@ final class CodeEditorCoordinator {
         }
 
         if pathChanged {
+            clearRevealHighlight()
             hoverHighlight?.cancelAndClear()
             completion?.cancelAndDismiss()
             didChangeTask?.cancel()
@@ -402,7 +405,7 @@ final class CodeEditorCoordinator {
             runHighlight(theme: theme)
         }
 
-        applyRevealIfNeeded(tabId: tabId, line: revealLine, character: revealCharacter)
+        applyRevealIfNeeded(tabId: tabId, line: revealLine, character: revealCharacter, revision: revealRevision)
     }
 
     /// Wire the coordinator and the text view to `buffer`. If a previous
@@ -878,13 +881,14 @@ final class CodeEditorCoordinator {
     /// so SwiftUI re-renders that re-pass the same hints don't keep stealing
     /// the user's scroll position. After applying, asks the TabsManager to
     /// clear the hint so it isn't replayed on relaunch.
-    private func applyRevealIfNeeded(tabId: TabID, line: Int?, character: Int?) {
+    private func applyRevealIfNeeded(tabId: TabID, line: Int?, character: Int?, revision: Int?) {
         guard let line, let character else {
             lastAppliedReveal = nil
             return
         }
+        let revision = revision ?? 0
         if let last = lastAppliedReveal,
-           last.tabId == tabId, last.line == line, last.character == character {
+           last.tabId == tabId, last.line == line, last.character == character, last.revision == revision {
             return
         }
         guard let textView, let buffer else { return }
@@ -902,9 +906,56 @@ final class CodeEditorCoordinator {
         let range = NSRange(location: target, length: 0)
         textView.setSelectedRange(range)
         textView.scrollRangeToVisible(range)
-        lastAppliedReveal = (tabId: tabId, line: line, character: character)
+        highlightRevealLine(containing: target, in: nsString, textView: textView)
+        lastAppliedReveal = (tabId: tabId, line: line, character: character, revision: revision)
         if let wid = currentWorktreeId {
             appState.tabs.consumeReveal(worktreeId: wid, tabId: tabId)
         }
+    }
+
+    private func highlightRevealLine(containing target: Int, in nsString: NSString, textView: CodeTextView) {
+        guard nsString.length > 0,
+              let layoutManager = textView.layoutManager else { return }
+        clearRevealHighlight()
+
+        let clampedTarget = min(max(0, target), max(0, nsString.length - 1))
+        let lineRange = nsString.lineRange(for: NSRange(location: clampedTarget, length: 0))
+        guard lineRange.location != NSNotFound, lineRange.length > 0 else { return }
+
+        let color = NSColor.systemYellow.withAlphaComponent(0.9)
+        layoutManager.addTemporaryAttribute(.underlineStyle, value: NSUnderlineStyle.thick.rawValue, forCharacterRange: lineRange)
+        layoutManager.addTemporaryAttribute(.underlineColor, value: color, forCharacterRange: lineRange)
+        revealHighlightRange = lineRange
+        revealHighlightTask = Task { [weak self, weak textView] in
+            try? await Task.sleep(for: .seconds(7))
+            guard !Task.isCancelled else { return }
+            await MainActor.run {
+                guard let self, let textView, self.textView === textView else { return }
+                self.clearRevealHighlight()
+            }
+        }
+    }
+
+    private func clearRevealHighlight() {
+        revealHighlightTask?.cancel()
+        revealHighlightTask = nil
+        guard let range = revealHighlightRange,
+              let textView,
+              let layoutManager = textView.layoutManager else {
+            revealHighlightRange = nil
+            return
+        }
+        let textLength = (textView.string as NSString).length
+        if range.location < textLength {
+            let clampedRange = NSRange(
+                location: range.location,
+                length: min(range.length, textLength - range.location)
+            )
+            if clampedRange.length > 0 {
+                layoutManager.removeTemporaryAttribute(.underlineStyle, forCharacterRange: clampedRange)
+                layoutManager.removeTemporaryAttribute(.underlineColor, forCharacterRange: clampedRange)
+            }
+        }
+        revealHighlightRange = nil
     }
 }

--- a/Alas/Sources/Code/Editor/CodeEditorView.swift
+++ b/Alas/Sources/Code/Editor/CodeEditorView.swift
@@ -14,6 +14,7 @@ struct CodeEditorView: NSViewRepresentable {
     let tabId: TabID
     let revealLine: Int?
     let revealCharacter: Int?
+    let revealRevision: Int?
     let appState: AppState
     let externalAbsolutePath: String?
     /// The worktree-relative path of the in-worktree file from which the
@@ -109,6 +110,7 @@ struct CodeEditorView: NSViewRepresentable {
             tabId: tabId,
             revealLine: revealLine,
             revealCharacter: revealCharacter,
+            revealRevision: revealRevision,
             theme: theme,
             externalAbsolutePath: externalAbsolutePath,
             originatingRelativePath: originatingRelativePath
@@ -125,6 +127,7 @@ struct CodeEditorView: NSViewRepresentable {
             tabId: tabId,
             revealLine: revealLine,
             revealCharacter: revealCharacter,
+            revealRevision: revealRevision,
             theme: theme,
             externalAbsolutePath: externalAbsolutePath,
             originatingRelativePath: originatingRelativePath

--- a/Alas/Sources/Code/Markdown/MarkdownTabView.swift
+++ b/Alas/Sources/Code/Markdown/MarkdownTabView.swift
@@ -10,6 +10,7 @@ struct MarkdownTabView: View {
     let originatingRelativePath: String?
     let revealLine: Int?
     let revealCharacter: Int?
+    let revealRevision: Int?
     @Bindable var appState: AppState
     let onRevealInFiles: (String) -> Void
     @Environment(\.theme) var theme
@@ -147,6 +148,7 @@ struct MarkdownTabView: View {
             tabId: tabId,
             revealLine: revealLine,
             revealCharacter: revealCharacter,
+            revealRevision: revealRevision,
             appState: appState,
             externalAbsolutePath: externalAbsolutePath,
             originatingRelativePath: originatingRelativePath,

--- a/Alas/Sources/Search/ContentSearcher.swift
+++ b/Alas/Sources/Search/ContentSearcher.swift
@@ -219,6 +219,7 @@ final class ContentSearcher: Sendable {
         let endColByte = (first?["end"] as? Int) ?? colByte
         let rawSnippet = lineBlob.trimmingCharacters(in: .newlines)
         let column = charOffset(forByteOffset: colByte, in: rawSnippet).map { $0 + 1 } ?? (colByte + 1)
+        let revealColumn = utf16Offset(forByteOffset: colByte, in: rawSnippet).map { $0 + 1 } ?? column
 
         // `--max-columns=400` doesn't apply in `--json` mode (per rg --help).
         // For a single very long line — minified JS, generated JSON, lockfiles —
@@ -237,6 +238,7 @@ final class ContentSearcher: Sendable {
             relativePath: pathBlob,
             line: lineNumber,
             column: column,
+            revealColumn: revealColumn,
             snippet: trimmedSnippet,
             matchCharRange: charRange
         )
@@ -250,6 +252,15 @@ final class ContentSearcher: Sendable {
         let utf8Index = s.utf8.index(s.utf8.startIndex, offsetBy: bytes)
         guard let charIndex = utf8Index.samePosition(in: s) else { return nil }
         return s.distance(from: s.startIndex, to: charIndex)
+    }
+
+    /// Convert a UTF-8 byte offset into the UTF-16 offset expected by
+    /// NSTextStorage/NSString-based editor APIs.
+    private func utf16Offset(forByteOffset bytes: Int, in s: String) -> Int? {
+        guard bytes >= 0, bytes <= s.utf8.count else { return nil }
+        let utf8Index = s.utf8.index(s.utf8.startIndex, offsetBy: bytes)
+        guard let utf16Index = utf8Index.samePosition(in: s.utf16) else { return nil }
+        return s.utf16.distance(from: s.utf16.startIndex, to: utf16Index)
     }
 
     /// Bound a snippet to ~400 characters, centered on the matched range.

--- a/Alas/Sources/Search/SearchResult.swift
+++ b/Alas/Sources/Search/SearchResult.swift
@@ -35,6 +35,7 @@ struct ContentSearchHit: Identifiable, Equatable, Sendable {
     let relativePath: String
     let line: Int
     let column: Int
+    let revealColumn: Int?
     let snippet: String
     /// Character (grapheme) offsets into `snippet` of the matched run, or
     /// nil if the offsets don't align with character boundaries. Producers
@@ -44,6 +45,8 @@ struct ContentSearchHit: Identifiable, Equatable, Sendable {
 
     var id: String { "\(worktreeId):\(relativePath):\(line):\(column)" }
     var groupKey: String { "\(worktreeId):\(relativePath)" }
+    var revealLine: Int { max(0, line - 1) }
+    var revealCharacter: Int { max(0, (revealColumn ?? column) - 1) }
 }
 
 struct ContentSearchGroup: Identifiable, Equatable, Sendable {

--- a/Alas/Sources/Search/Views/FileSearchDialog.swift
+++ b/Alas/Sources/Search/Views/FileSearchDialog.swift
@@ -109,7 +109,12 @@ struct FileSearchDialog: View {
     }
 
     private func openContent(_ hit: ContentSearchHit) {
-        appState.openFile(relativePath: hit.relativePath, worktreeId: hit.worktreeId)
+        appState.openFile(
+            relativePath: hit.relativePath,
+            worktreeId: hit.worktreeId,
+            revealLine: hit.revealLine,
+            revealCharacter: hit.revealCharacter
+        )
         close()
     }
 

--- a/AlasTests/AppStateTabAvailabilityTests.swift
+++ b/AlasTests/AppStateTabAvailabilityTests.swift
@@ -188,6 +188,69 @@ struct AppStateTabAvailabilityTests {
         #expect(!state.hasActiveEditorTab)
     }
 
+    @Test func openFileWithRevealBypassesImagePreviewForSearchableSvg() async throws {
+        let repo = try await makeRepo(name: "svg-reveal")
+        defer { try? FileManager.default.removeItem(at: repo) }
+
+        let state = AppState()
+        let project = try await state.projectsManager.addProject(
+            path: repo, displayName: "test", color: "#000000"
+        )
+        try await state.projectsManager.refreshWorktrees(projectId: project.id)
+        let trees = state.projectsManager.worktrees(projectId: project.id)
+        #expect(trees.count == 1)
+        state.selectedWorktreeId = trees[0].id
+
+        state.openFile(relativePath: "Assets/icon.svg", worktreeId: trees[0].id)
+        if case .imagePreview = state.activeTab {
+            // Expected path for normal image opens.
+        } else {
+            Issue.record("expected image preview tab")
+        }
+
+        state.openFile(
+            relativePath: "Assets/icon.svg",
+            worktreeId: trees[0].id,
+            revealLine: 4,
+            revealCharacter: 2
+        )
+
+        if case .editor(let tab) = state.activeTab {
+            #expect(tab.relativePath == "Assets/icon.svg")
+            #expect(tab.revealLine == 4)
+            #expect(tab.revealCharacter == 2)
+        } else {
+            Issue.record("expected editor tab")
+        }
+    }
+
+    @Test func openFileWithRevealKeepsBinaryImagesInPreview() async throws {
+        let repo = try await makeRepo(name: "binary-image-reveal")
+        defer { try? FileManager.default.removeItem(at: repo) }
+
+        let state = AppState()
+        let project = try await state.projectsManager.addProject(
+            path: repo, displayName: "test", color: "#000000"
+        )
+        try await state.projectsManager.refreshWorktrees(projectId: project.id)
+        let trees = state.projectsManager.worktrees(projectId: project.id)
+        #expect(trees.count == 1)
+        state.selectedWorktreeId = trees[0].id
+
+        state.openFile(
+            relativePath: "Assets/logo.png",
+            worktreeId: trees[0].id,
+            revealLine: 12,
+            revealCharacter: 4
+        )
+
+        if case .imagePreview(let tab) = state.activeTab {
+            #expect(tab.relativePath == "Assets/logo.png")
+        } else {
+            Issue.record("expected image preview tab")
+        }
+    }
+
     @Test func hasAnyDirtyEditorTabFalseWhenEmpty() {
         let state = AppState()
         #expect(!state.hasAnyDirtyEditorTab)

--- a/AlasTests/ContentSearcherTests.swift
+++ b/AlasTests/ContentSearcherTests.swift
@@ -103,7 +103,7 @@ struct ContentSearcherTests {
     @Test func columnsUseCharacterOffsetsForNonASCIIPrefixes() async throws {
         try #require(rgAvailable())
         let repo = try await makeRepo(files: [
-            ("a.txt", "éneedle\n"),
+            ("a.txt", "😀needle\n"),
         ])
         defer { try? FileManager.default.removeItem(at: repo) }
 
@@ -120,8 +120,35 @@ struct ContentSearcherTests {
 
         let hit = try #require(hits.first)
         #expect(hit.column == 2)
-        #expect(hit.snippet == "éneedle")
+        #expect(hit.revealColumn == 3)
+        #expect(hit.revealCharacter == 2)
+        #expect(hit.snippet == "😀needle")
         #expect(hit.matchCharRange == 1..<7)
+    }
+
+    @Test func revealColumnsUseUTF16OffsetsInsideExtendedGraphemeClusters() async throws {
+        try #require(rgAvailable())
+        let repo = try await makeRepo(files: [
+            ("a.txt", "🇺🇸needle\n"),
+        ])
+        defer { try? FileManager.default.removeItem(at: repo) }
+
+        let cs = ContentSearcher()
+        var hits: [ContentSearchHit] = []
+        for try await h in cs.search(
+            query: "🇸",
+            options: SearchContentOptions(),
+            worktrees: [SearchWorktree(
+                id: "w1", projectId: "p1", displayName: "w",
+                absolutePath: repo
+            )]
+        ) { hits.append(h) }
+
+        let hit = try #require(hits.first)
+        #expect(hit.revealColumn == 3)
+        #expect(hit.revealCharacter == 2)
+        #expect(hit.snippet == "🇺🇸needle")
+        #expect(hit.matchCharRange == nil)
     }
 }
 

--- a/AlasTests/EditorBufferTests.swift
+++ b/AlasTests/EditorBufferTests.swift
@@ -681,6 +681,129 @@ struct EditorBufferTests {
         #expect(fontB?.isFixedPitch == true)
     }
 
+    @Test func coordinatorReappliesSameRevealTargetWhenRevisionChanges() throws {
+        let root = tempWorktree()
+        _ = try writeFile(root, "a.swift", "line one\nline two\nline three\n")
+        let appState = AppState()
+        appState.config.code.fontFamily = "Menlo"
+        let buffer = appState.tabs.buffer(
+            worktreeId: "wt",
+            tabId: "tab-a",
+            worktreeRoot: root,
+            relativePath: "a.swift"
+        )
+        let layoutManager = NSLayoutManager()
+        let textContainer = NSTextContainer(size: NSSize(width: 800, height: 600))
+        layoutManager.addTextContainer(textContainer)
+        let textView = CodeTextView(frame: NSRect(x: 0, y: 0, width: 800, height: 600), textContainer: textContainer)
+        let coordinator = CodeEditorCoordinator(appState: appState)
+        let theme = try ThemeStore().current
+
+        coordinator.attach(
+            textView: textView,
+            buffer: buffer,
+            layoutManager: layoutManager,
+            worktreeId: "wt",
+            worktreeRoot: root,
+            tabId: "tab-a",
+            revealLine: 1,
+            revealCharacter: 0,
+            revealRevision: 0,
+            theme: theme
+        )
+
+        let revealedSelection = textView.selectedRange()
+        #expect(revealedSelection.location > 0)
+
+        textView.setSelectedRange(NSRange(location: 0, length: 0))
+        let findHighlightColor = NSColor.systemBlue
+        layoutManager.addTemporaryAttribute(
+            .backgroundColor,
+            value: findHighlightColor,
+            forCharacterRange: NSRange(location: revealedSelection.location, length: 4)
+        )
+        coordinator.updateIfNeeded(
+            worktreeId: "wt",
+            worktreeRoot: root,
+            relativePath: "a.swift",
+            tabId: "tab-a",
+            revealLine: 1,
+            revealCharacter: 0,
+            revealRevision: 0,
+            theme: theme
+        )
+        #expect(textView.selectedRange().location == 0)
+
+        coordinator.updateIfNeeded(
+            worktreeId: "wt",
+            worktreeRoot: root,
+            relativePath: "a.swift",
+            tabId: "tab-a",
+            revealLine: 1,
+            revealCharacter: 0,
+            revealRevision: 1,
+            theme: theme
+        )
+        #expect(textView.selectedRange() == revealedSelection)
+        let preservedBackground = layoutManager.temporaryAttribute(
+            .backgroundColor,
+            atCharacterIndex: revealedSelection.location,
+            effectiveRange: nil
+        ) as? NSColor
+        #expect(preservedBackground == findHighlightColor)
+    }
+
+    @Test func coordinatorClampsStaleRevealHighlightRangeAfterEdit() throws {
+        let root = tempWorktree()
+        _ = try writeFile(root, "a.swift", "line one\nline two\nline three\n")
+        let appState = AppState()
+        appState.config.code.fontFamily = "Menlo"
+        let buffer = appState.tabs.buffer(
+            worktreeId: "wt",
+            tabId: "tab-a",
+            worktreeRoot: root,
+            relativePath: "a.swift"
+        )
+        let layoutManager = NSLayoutManager()
+        let textContainer = NSTextContainer(size: NSSize(width: 800, height: 600))
+        layoutManager.addTextContainer(textContainer)
+        let textView = CodeTextView(frame: NSRect(x: 0, y: 0, width: 800, height: 600), textContainer: textContainer)
+        let coordinator = CodeEditorCoordinator(appState: appState)
+        let theme = try ThemeStore().current
+
+        coordinator.attach(
+            textView: textView,
+            buffer: buffer,
+            layoutManager: layoutManager,
+            worktreeId: "wt",
+            worktreeRoot: root,
+            tabId: "tab-a",
+            revealLine: 1,
+            revealCharacter: 0,
+            revealRevision: 0,
+            theme: theme
+        )
+        #expect(textView.selectedRange().location > 0)
+
+        buffer.storage.replaceCharacters(
+            in: NSRange(location: 0, length: buffer.storage.length),
+            with: "x\n"
+        )
+
+        coordinator.updateIfNeeded(
+            worktreeId: "wt",
+            worktreeRoot: root,
+            relativePath: "a.swift",
+            tabId: "tab-a",
+            revealLine: 0,
+            revealCharacter: 0,
+            revealRevision: 1,
+            theme: theme
+        )
+
+        #expect(textView.selectedRange() == NSRange(location: 0, length: 0))
+    }
+
     @Test func coordinatorRebindsActiveExternalEditorWhenLanguageAppears() throws {
         let root = tempWorktree()
         let externalURL = FileManager.default.temporaryDirectory

--- a/AlasTests/ImageFileTypeTests.swift
+++ b/AlasTests/ImageFileTypeTests.swift
@@ -11,6 +11,13 @@ struct ImageFileTypeTests {
         #expect(ImageFileType.isSupported(relativePath: "Assets/icon.svg"))
     }
 
+    @Test func recognizesOnlySvgAsTextBackedImage() {
+        #expect(ImageFileType.isTextBacked(relativePath: "Assets/icon.svg"))
+        #expect(ImageFileType.isTextBacked(relativePath: "Assets/icon.SVG"))
+        #expect(!ImageFileType.isTextBacked(relativePath: "Assets/logo.png"))
+        #expect(!ImageFileType.isTextBacked(relativePath: "photo.jpeg"))
+    }
+
     @Test func rejectsNonImagePaths() {
         #expect(!ImageFileType.isSupported(relativePath: "Sources/AppState.swift"))
         #expect(!ImageFileType.isSupported(relativePath: "README.md"))

--- a/AlasTests/SearchModelTests.swift
+++ b/AlasTests/SearchModelTests.swift
@@ -4,6 +4,54 @@ import Foundation
 
 @MainActor
 struct SearchModelTests {
+    @Test func contentSearchHitRevealTargetUsesZeroBasedEditorCoordinates() {
+        let hit = ContentSearchHit(
+            worktreeId: "wt",
+            projectId: "project",
+            relativePath: "Sources/App.swift",
+            line: 12,
+            column: 4,
+            revealColumn: nil,
+            snippet: "    let value = true",
+            matchCharRange: nil
+        )
+
+        #expect(hit.revealLine == 11)
+        #expect(hit.revealCharacter == 3)
+    }
+
+    @Test func contentSearchHitRevealTargetUsesUtf16RevealColumnWhenAvailable() {
+        let hit = ContentSearchHit(
+            worktreeId: "wt",
+            projectId: "project",
+            relativePath: "Sources/App.swift",
+            line: 1,
+            column: 2,
+            revealColumn: 3,
+            snippet: "😀needle",
+            matchCharRange: nil
+        )
+
+        #expect(hit.column == 2)
+        #expect(hit.revealCharacter == 2)
+    }
+
+    @Test func contentSearchHitRevealTargetClampsInvalidCoordinatesToFileStart() {
+        let hit = ContentSearchHit(
+            worktreeId: "wt",
+            projectId: "project",
+            relativePath: "Sources/App.swift",
+            line: 0,
+            column: 0,
+            revealColumn: nil,
+            snippet: "",
+            matchCharRange: nil
+        )
+
+        #expect(hit.revealLine == 0)
+        #expect(hit.revealCharacter == 0)
+    }
+
     /// Returns a finished AsyncThrowingStream with no elements.
     private func emptyContentStream() -> AsyncThrowingStream<ContentSearchHit, Error> {
         AsyncThrowingStream { $0.finish() }
@@ -214,6 +262,7 @@ extension SearchModelTests {
                 relativePath: path,
                 line: line,
                 column: 1,
+                revealColumn: nil,
                 snippet: "some snippet",
                 matchCharRange: nil
             )
@@ -259,7 +308,8 @@ extension SearchModelTests {
             ContentSearchHit(
                 worktreeId: "a", projectId: "p1",
                 relativePath: "f\(i).rs",
-                line: 1, column: 1, snippet: "x", matchCharRange: nil
+                line: 1, column: 1, revealColumn: nil,
+                snippet: "x", matchCharRange: nil
             )
         }
         let env = makeEnv(
@@ -294,7 +344,8 @@ extension SearchModelTests {
             ContentSearchHit(
                 worktreeId: "a", projectId: "p1",
                 relativePath: i.isMultiple(of: 2) ? "a.rs" : "b.rs",
-                line: i + 1, column: 1, snippet: "x", matchCharRange: nil
+                line: i + 1, column: 1, revealColumn: nil,
+                snippet: "x", matchCharRange: nil
             )
         }
         let env = makeEnv(
@@ -405,7 +456,7 @@ extension SearchModelTests {
         let hit = ContentSearchHit(
             worktreeId: "a", projectId: "p1",
             relativePath: "x.rs", line: 1, column: 1,
-            snippet: "match", matchCharRange: nil
+            revealColumn: nil, snippet: "match", matchCharRange: nil
         )
         let env = makeEnv(
             worktrees: [wt("a")],

--- a/AlasTests/TabsManagerTests.swift
+++ b/AlasTests/TabsManagerTests.swift
@@ -284,6 +284,65 @@ struct TabsManagerTests {
         #expect(back.isExternal)
     }
 
+    @Test func openEditorIncrementsRevealRevisionWhenRevealingExistingTab() {
+        let worktreeId = "tabs-manager-editor-reveal-revision"
+        defer { try? FileManager.default.removeItem(at: Paths.tabsFile(forWorktreeId: worktreeId)) }
+        let mgr = TabsManager()
+
+        let first = mgr.openEditor(
+            worktreeId: worktreeId,
+            relativePath: "Sources/App.swift",
+            revealLine: 10,
+            revealCharacter: 0
+        )
+        let second = mgr.openEditor(
+            worktreeId: worktreeId,
+            relativePath: "Sources/App.swift",
+            revealLine: 10,
+            revealCharacter: 0
+        )
+
+        #expect(first.id == second.id)
+        if case .editor(let s) = second {
+            #expect(s.revealRevision == 1)
+        } else {
+            Issue.record("expected editor tab")
+        }
+    }
+
+    @Test func openEditorForcesMarkdownEditorModeWhenRevealing() {
+        let worktreeId = "tabs-manager-markdown-reveal-mode"
+        defer { try? FileManager.default.removeItem(at: Paths.tabsFile(forWorktreeId: worktreeId)) }
+        let mgr = TabsManager()
+
+        let first = mgr.openEditor(
+            worktreeId: worktreeId,
+            relativePath: "README.md",
+            revealLine: nil,
+            revealCharacter: nil
+        )
+        if case .editor(let s) = first {
+            mgr.setMarkdownViewMode(worktreeId: worktreeId, tabId: s.id, mode: .preview)
+        } else {
+            Issue.record("expected editor tab")
+        }
+
+        let revealed = mgr.openEditor(
+            worktreeId: worktreeId,
+            relativePath: "README.md",
+            revealLine: 3,
+            revealCharacter: 0
+        )
+
+        if case .editor(let s) = revealed {
+            #expect(s.markdownViewMode == .editor)
+            #expect(s.revealLine == 3)
+            #expect(s.revealCharacter == 0)
+        } else {
+            Issue.record("expected editor tab")
+        }
+    }
+
     @Test func openExternalEditorAppendsAndActivates() {
         let worktreeId = "tabs-manager-open-external"
         defer { try? FileManager.default.removeItem(at: Paths.tabsFile(forWorktreeId: worktreeId)) }
@@ -383,6 +442,23 @@ struct TabsManagerTests {
         if case .editor(let s) = second {
             #expect(s.revealLine == 5)
             #expect(s.revealCharacter == 2)
+        }
+    }
+
+    @Test func openExternalEditorIncrementsRevealRevisionWhenRevealingExistingTab() {
+        let worktreeId = "tabs-manager-external-reveal-revision"
+        defer { try? FileManager.default.removeItem(at: Paths.tabsFile(forWorktreeId: worktreeId)) }
+        let mgr = TabsManager()
+        let url = URL(fileURLWithPath: "/usr/include/foo.h")
+
+        let first = mgr.openExternalEditor(worktreeId: worktreeId, absoluteURL: url, revealLine: 1, revealCharacter: 0)
+        let second = mgr.openExternalEditor(worktreeId: worktreeId, absoluteURL: url, revealLine: 1, revealCharacter: 0)
+
+        #expect(first.id == second.id)
+        if case .editor(let s) = second {
+            #expect(s.revealRevision == 1)
+        } else {
+            Issue.record("expected editor tab")
         }
     }
 


### PR DESCRIPTION
## Summary
- Route content-search selections through the editor reveal path using editor-safe UTF-16 line and column coordinates, including matches inside extended grapheme clusters.
- Temporarily mark the revealed editor line without clobbering active find-result background highlights, and clamp cleanup ranges after edits.
- Add a reveal revision so selecting the same already-open search hit scrolls and highlights again.
- Force Markdown reveal hits into editor mode so preview-only tabs can consume the reveal.
- Bypass image preview only for text-backed image reveal requests, so searchable SVG hits open in the editor while binary image links keep the image preview.
- Cover the ripgrep coordinate parsing, AppState SVG/binary image reveal routing, image type classification, tab reveal revision, Markdown reveal mode, coordinator repeated-reveal, stale underline cleanup, and find-highlight coexistence behavior in focused tests.

## Validation
- `swiftformat Alas AlasTests --lint --reporter github-actions-log`
- `xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -only-testing:AlasTests/AppStateTabAvailabilityTests -only-testing:AlasTests/ImageFileTypeTests -only-testing:AlasTests/ContentSearcherTests -only-testing:AlasTests/EditorBufferTests -only-testing:AlasTests/TabsManagerTests -only-testing:AlasTests/SearchModelTests -quiet test`
- `xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -quiet build`

## Notes
- A full local `xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' test` run was attempted before commit, but it stopped producing output for several minutes and had to be terminated rather than left running.