### PR TITLE
feat(search): bundle fff for file search

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4,3 +4,6 @@
 [submodule "ThirdParty/zmx"]
 	path = ThirdParty/zmx
 	url = https://github.com/neurosnap/zmx
+[submodule "ThirdParty/fff"]
+	path = ThirdParty/fff
+	url = https://github.com/dmtrKovalenko/fff

--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -82,6 +82,7 @@
 		12035048B950CE0197604F89 /* GitService.swift in Sources */ = {isa = PBXBuildFile; fileRef = B7CE7B4DAFDB65A79308FB63 /* GitService.swift */; };
 		1298147855092677E3184AC2 /* ACPConfigOption.swift in Sources */ = {isa = PBXBuildFile; fileRef = 88C6356C759B509DD81EDEBB /* ACPConfigOption.swift */; };
 		133597E7D43CFE746EF4EF2B /* RepoGroupViewLayoutTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01675626CE431DD5867636BF /* RepoGroupViewLayoutTests.swift */; };
+		1339BE8F736D53991DDD19CD /* FileSearchBackend.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5D68E2007F0370A6C4E7DBC7 /* FileSearchBackend.swift */; };
 		13928612F39D3D86ED3313AC /* ReviewChangesModelsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CDAE8FBBADF986E1E6585941 /* ReviewChangesModelsTests.swift */; };
 		139F45EE390C27342C5DD734 /* CenterPaneView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8685E5E5AC7A77D6D27A847 /* CenterPaneView.swift */; };
 		13E762EA8D84EFE6F0228806 /* AgentTerminalLaunchTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11C3EC94DBE871DFC45C7D25 /* AgentTerminalLaunchTests.swift */; };
@@ -1499,6 +1500,7 @@
 		5C96772DABFBCF15691FFB37 /* DiffDisplayPreferences.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiffDisplayPreferences.swift; sourceTree = "<group>"; };
 		5CC16D06302D9AD3C9F0BE3C /* TreeSitterHighlighter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TreeSitterHighlighter.swift; sourceTree = "<group>"; };
 		5D486FD440D802AEC65D1555 /* MarkdownFileType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MarkdownFileType.swift; sourceTree = "<group>"; };
+		5D68E2007F0370A6C4E7DBC7 /* FileSearchBackend.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileSearchBackend.swift; sourceTree = "<group>"; };
 		5DA887927D32EBA2252792D9 /* ReviewChangesTabView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReviewChangesTabView.swift; sourceTree = "<group>"; };
 		5DC558BE723378DCC7AA5B55 /* ACPChatTypography.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPChatTypography.swift; sourceTree = "<group>"; };
 		5DD723B8C15EF2413C5D935D /* BlockedLanguageServerNudgeResolver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BlockedLanguageServerNudgeResolver.swift; sourceTree = "<group>"; };
@@ -3457,6 +3459,7 @@
 			children = (
 				BE7AEB9E8D83B610E291BAE1 /* ContentSearcher.swift */,
 				E1D1797A096A39AE6CB5EA00 /* FileIndex.swift */,
+				5D68E2007F0370A6C4E7DBC7 /* FileSearchBackend.swift */,
 				96E7159EED1183F784104B4F /* FuzzyMatch.swift */,
 				4261E417947C1A21E77C1587 /* GitStatusCache.swift */,
 				36B06AE8BA5FBDEAD4586616 /* SearchKind.swift */,
@@ -4137,6 +4140,7 @@
 			buildPhases = (
 				A6E0A5F2849F1349828C2EEF /* Build GhosttyKit */,
 				2A52B3AA269E67D4B89E4A6B /* Build zmx */,
+				4609384BD7FA0393B4CE182E /* Build fff */,
 				16AE5D200CA779AE0410E1B1 /* Sources */,
 				BD47E15DBE895A60942DDB48 /* Resources */,
 				65B162623B36E39612A379EA /* Frameworks */,
@@ -4315,6 +4319,25 @@
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "\"${SRCROOT}/scripts/embed-ghostty-resources.sh\"";
+		};
+		4609384BD7FA0393B4CE182E /* Build fff */ = {
+			isa = PBXShellScriptBuildPhase;
+			alwaysOutOfDate = 1;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+			);
+			name = "Build fff";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${SRCROOT}/scripts/build-fff.sh\"";
 		};
 		A6E0A5F2849F1349828C2EEF /* Build GhosttyKit */ = {
 			isa = PBXShellScriptBuildPhase;
@@ -4613,6 +4636,7 @@
 				58A58A64E7E10EC5A1CC60C5 /* FileDeviceStore.swift in Sources */,
 				3B82344338BD29F6B8B6D8EC /* FileIndex.swift in Sources */,
 				E29D10B84F406C38E2F4C457 /* FileResultRow.swift in Sources */,
+				1339BE8F736D53991DDD19CD /* FileSearchBackend.swift in Sources */,
 				DEBB0627BD0426369D18CAD4 /* FileSearchDialog.swift in Sources */,
 				4B2031FB61782327D5279F98 /* FileTreeBuilder.swift in Sources */,
 				64ADA6AFE69C52F121A163E1 /* FileTypeIconView.swift in Sources */,
@@ -5530,12 +5554,11 @@
 					"$(inherited)",
 					"\".build/ghostty\"",
 				);
+				HEADER_SEARCH_PATHS = "$(inherited) $(SRCROOT)/.build/fff/include";
 				INFOPLIST_FILE = Alas/Resources/Info.plist;
-				LD_RUNPATH_SEARCH_PATHS = (
-					"$(inherited)",
-					"@executable_path/../Frameworks",
-				);
-				OTHER_LDFLAGS = "$(inherited) -lc++";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks";
+				LIBRARY_SEARCH_PATHS = "$(inherited) $(SRCROOT)/.build/fff/$(CURRENT_ARCH)/install/lib $(SRCROOT)/.build/fff/universal/install/lib";
+				OTHER_LDFLAGS = "$(inherited) -lc++ -lfff_c";
 				PRODUCT_BUNDLE_IDENTIFIER = io.nlopez.alas;
 				PRODUCT_NAME = Alas;
 				SDKROOT = macosx;
@@ -5548,11 +5571,9 @@
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				COMBINE_HIDPI_IMAGES = YES;
 				GENERATE_INFOPLIST_FILE = YES;
-				LD_RUNPATH_SEARCH_PATHS = (
-					"$(inherited)",
-					"@executable_path/../Frameworks",
-					"@loader_path/../Frameworks",
-				);
+				HEADER_SEARCH_PATHS = "$(inherited) $(SRCROOT)/.build/fff/include";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @loader_path/../Frameworks @executable_path/../Frameworks";
+				LIBRARY_SEARCH_PATHS = "$(inherited) $(SRCROOT)/.build/fff/$(CURRENT_ARCH)/install/lib $(SRCROOT)/.build/fff/universal/install/lib";
 				PRODUCT_BUNDLE_IDENTIFIER = io.nlopez.alas.tests;
 				SDKROOT = macosx;
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Alas.app/Contents/MacOS/Alas";
@@ -5572,12 +5593,11 @@
 					"$(inherited)",
 					"\".build/ghostty\"",
 				);
+				HEADER_SEARCH_PATHS = "$(inherited) $(SRCROOT)/.build/fff/include";
 				INFOPLIST_FILE = Alas/Resources/Info.plist;
-				LD_RUNPATH_SEARCH_PATHS = (
-					"$(inherited)",
-					"@executable_path/../Frameworks",
-				);
-				OTHER_LDFLAGS = "$(inherited) -lc++";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks";
+				LIBRARY_SEARCH_PATHS = "$(inherited) $(SRCROOT)/.build/fff/$(CURRENT_ARCH)/install/lib $(SRCROOT)/.build/fff/universal/install/lib";
+				OTHER_LDFLAGS = "$(inherited) -lc++ -lfff_c";
 				PRODUCT_BUNDLE_IDENTIFIER = io.nlopez.alas;
 				PRODUCT_NAME = Alas;
 				SDKROOT = macosx;
@@ -5590,11 +5610,9 @@
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				COMBINE_HIDPI_IMAGES = YES;
 				GENERATE_INFOPLIST_FILE = YES;
-				LD_RUNPATH_SEARCH_PATHS = (
-					"$(inherited)",
-					"@executable_path/../Frameworks",
-					"@loader_path/../Frameworks",
-				);
+				HEADER_SEARCH_PATHS = "$(inherited) $(SRCROOT)/.build/fff/include";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @loader_path/../Frameworks @executable_path/../Frameworks";
+				LIBRARY_SEARCH_PATHS = "$(inherited) $(SRCROOT)/.build/fff/$(CURRENT_ARCH)/install/lib $(SRCROOT)/.build/fff/universal/install/lib";
 				PRODUCT_BUNDLE_IDENTIFIER = io.nlopez.alas.tests;
 				SDKROOT = macosx;
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Alas.app/Contents/MacOS/Alas";

--- a/Alas/Sources/App/AppState.swift
+++ b/Alas/Sources/App/AppState.swift
@@ -2419,11 +2419,12 @@ final class AppState {
     }
 
     private func makeSearchEnvironment() -> SearchEnvironment {
+        let fileSearchBackend = FffFileSearchBackend()
         // Invariant: the two synchronous closures below are only invoked
         // from `SearchModel`, which is `@MainActor` — so `assumeIsolated`
         // is sound. If a future caller invokes them off-main this will
         // trap; keep them on main or convert to async.
-        SearchEnvironment(
+        return SearchEnvironment(
             currentWorktreeId: { [weak self] in
                 MainActor.assumeIsolated { self?.selectedWorktreeId }
             },
@@ -2449,6 +2450,9 @@ final class AppState {
             },
             statuses: { [statusCache] wt in
                 try await statusCache.statuses(forWorktreePath: wt.absolutePath)
+            },
+            fileSearch: { query, wt in
+                try await fileSearchBackend.search(query: query, worktree: wt, limit: 50)
             },
             contentSearch: { [contentSearcher = ContentSearcher()] query, options, targets in
                 contentSearcher.search(query: query, options: options, worktrees: targets)

--- a/Alas/Sources/Search/FileSearchBackend.swift
+++ b/Alas/Sources/Search/FileSearchBackend.swift
@@ -1,0 +1,144 @@
+import Foundation
+
+#if canImport(FffC)
+import FffC
+#endif
+
+/// Result shape returned by an optional indexed file-search backend.
+/// SearchModel owns decoration with worktree/project ids and git status.
+struct FileSearchBackendResult: Equatable, Sendable {
+    let relativePath: String
+    let score: Double
+    let matchIndices: [Int]
+}
+
+/// Optional bridge to fff's Rust-backed C API.
+///
+/// The actor compiles without the vendored `FffC` module and returns `nil`,
+/// which tells `SearchModel` to keep using the existing Swift file scorer.
+/// Adding the bundled Rust library should only need to provide a `FffC`
+/// module map plus the linked dynamic/static library; production wiring can
+/// stay pointed at this actor.
+actor FffFileSearchBackend {
+#if canImport(FffC)
+    private struct InstanceHandle: @unchecked Sendable {
+        let raw: UnsafeMutableRawPointer
+    }
+
+    private var handles: [String: InstanceHandle] = [:]
+#endif
+
+    deinit {
+#if canImport(FffC)
+        for handle in handles.values {
+            fff_destroy(handle.raw)
+        }
+#endif
+    }
+
+    func search(query: String, worktree: SearchWorktree, limit: Int) async throws -> [FileSearchBackendResult]? {
+#if canImport(FffC)
+        guard canSearchWithFff(query: query) else {
+            return nil
+        }
+        let handle = try instance(for: worktree)
+        guard isInitialScanReady(handle) else {
+            return nil
+        }
+        guard let envelope = fff_search(handle, query, nil, 0, 0, UInt32(limit), 0, 0) else {
+            return nil
+        }
+        defer { fff_free_result(envelope) }
+        guard envelope.pointee.success, let rawSearchResult = envelope.pointee.handle else {
+            return nil
+        }
+
+        let searchResult = rawSearchResult.assumingMemoryBound(to: FffSearchResult.self)
+        defer { fff_free_search_result(searchResult) }
+
+        let count = Int(searchResult.pointee.count)
+        var results: [FileSearchBackendResult] = []
+        results.reserveCapacity(count)
+
+        for index in 0..<count {
+            guard
+                let item = fff_search_result_get_item(searchResult, UInt32(index)),
+                let pathCString = fff_file_item_get_relative_path(item)
+            else { continue }
+            let relativePath = String(cString: pathCString)
+            let scorePointer = fff_search_result_get_score(searchResult, UInt32(index))
+            let score = scorePointer.map { Double($0.pointee.total) } ?? 0
+            let matchIndices = FuzzyMatch.score(query: query, target: relativePath)?.indices ?? []
+            results.append(FileSearchBackendResult(
+                relativePath: relativePath,
+                score: score,
+                matchIndices: matchIndices
+            ))
+        }
+        return results
+#else
+        _ = query
+        _ = worktree
+        _ = limit
+        return nil
+#endif
+    }
+
+#if canImport(FffC)
+    private func instance(for worktree: SearchWorktree) throws -> UnsafeMutableRawPointer {
+        let key = worktree.absolutePath.path
+        if let handle = handles[key] {
+            return handle.raw
+        }
+
+        let handle = try key.withCString { basePath in
+            var options = FffCreateOptions(
+                version: UInt32(FFF_CREATE_OPTIONS_VERSION),
+                base_path: basePath,
+                frecency_db_path: nil,
+                history_db_path: nil,
+                enable_mmap_cache: false,
+                enable_content_indexing: false,
+                watch: true,
+                ai_mode: false,
+                log_file_path: nil,
+                log_level: nil,
+                cache_budget_max_files: 0,
+                cache_budget_max_bytes: 0,
+                cache_budget_max_file_size: 0,
+                enable_fs_root_scanning: false,
+                enable_home_dir_scanning: false
+            )
+            guard let envelope = fff_create_instance_with(&options) else {
+                throw FffFileSearchBackendError.createFailed(nil)
+            }
+            defer { fff_free_result(envelope) }
+            guard envelope.pointee.success, let handle = envelope.pointee.handle else {
+                let message = envelope.pointee.error.map { String(cString: $0) }
+                throw FffFileSearchBackendError.createFailed(message)
+            }
+            return handle
+        }
+        handles[key] = InstanceHandle(raw: handle)
+        return handle
+    }
+
+    private func isInitialScanReady(_ handle: UnsafeMutableRawPointer) -> Bool {
+        guard let envelope = fff_wait_for_scan(handle, 0) else {
+            return false
+        }
+        defer { fff_free_result(envelope) }
+        return envelope.pointee.success && envelope.pointee.int_value != 0
+    }
+
+    private func canSearchWithFff(query: String) -> Bool {
+        query
+            .split(whereSeparator: { $0.isWhitespace })
+            .contains { $0.count >= 2 }
+    }
+#endif
+}
+
+enum FffFileSearchBackendError: Error, Equatable {
+    case createFailed(String?)
+}

--- a/Alas/Sources/Search/SearchModel.swift
+++ b/Alas/Sources/Search/SearchModel.swift
@@ -17,6 +17,7 @@ struct SearchEnvironment: Sendable {
     var allWorktrees: @Sendable () -> [SearchWorktree]
     var entries: @Sendable (SearchWorktree) async throws -> [FileIndex.Entry]
     var statuses: @Sendable (SearchWorktree) async throws -> [String: GitStatusBadge]
+    var fileSearch: @Sendable (String, SearchWorktree) async throws -> [FileSearchBackendResult]?
     var contentSearch: @Sendable (
         String, SearchContentOptions, [SearchWorktree]
     ) -> AsyncThrowingStream<ContentSearchHit, Error>
@@ -200,10 +201,27 @@ final class SearchModel {
         var sinceCancelCheck = 0
         for wt in targets {
             do {
-                async let entriesTask = env.entries(wt)
                 async let statusTask = env.statuses(wt)
-                let entries = try await entriesTask
+                async let candidateRowsTask = fileSearchCandidateRows(query: query, worktree: wt)
+
+                let candidateRows = try await candidateRowsTask
                 let statuses = (try? await statusTask) ?? [:]
+                if case let .backend(backendRows) = candidateRows {
+                    appendBackendRows(backendRows, worktree: wt, statuses: statuses, into: &rows)
+                    try await appendBackendOmittedFallbackRows(
+                        query: query,
+                        backendRows: backendRows,
+                        worktree: wt,
+                        statuses: statuses,
+                        into: &rows,
+                        sinceCancelCheck: &sinceCancelCheck
+                    )
+                    continue
+                }
+
+                guard case let .entries(entries) = candidateRows else {
+                    continue
+                }
                 if Task.isCancelled { return }
 
                 for entry in entries {
@@ -273,6 +291,90 @@ final class SearchModel {
                 ? nil
                 : "Couldn't read files for \(failures.joined(separator: ", "))"
         )
+    }
+
+    private func appendBackendRows(
+        _ backendRows: [FileSearchBackendResult],
+        worktree wt: SearchWorktree,
+        statuses: [String: GitStatusBadge],
+        into rows: inout [FileSearchResult]
+    ) {
+        rows.append(contentsOf: backendRows.map { row in
+            let ext = (row.relativePath as NSString).pathExtension.lowercased()
+            return FileSearchResult(
+                worktreeId: wt.id,
+                projectId: wt.projectId,
+                relativePath: row.relativePath,
+                ext: ext,
+                statusBadge: statuses[row.relativePath],
+                matchIndices: row.matchIndices,
+                score: row.score + (statuses[row.relativePath] != nil ? 2 : 0)
+            )
+        })
+    }
+
+    private func appendBackendOmittedFallbackRows(
+        query: String,
+        backendRows: [FileSearchBackendResult],
+        worktree wt: SearchWorktree,
+        statuses: [String: GitStatusBadge],
+        into rows: inout [FileSearchResult],
+        sinceCancelCheck: inout Int
+    ) async throws {
+        let backendPaths = Set(backendRows.map(\.relativePath))
+        let entries = try await env.entries(wt)
+        for entry in entries where !backendPaths.contains(entry.relativePath) {
+            sinceCancelCheck &+= 1
+            if sinceCancelCheck >= 256 {
+                sinceCancelCheck = 0
+                if Task.isCancelled { return }
+            }
+
+            let badge = statuses[entry.relativePath]
+            if query.isEmpty {
+                rows.append(FileSearchResult(
+                    worktreeId: wt.id,
+                    projectId: wt.projectId,
+                    relativePath: entry.relativePath,
+                    ext: entry.ext,
+                    statusBadge: badge,
+                    matchIndices: [],
+                    score: badge != nil ? 100 : 0
+                ))
+            } else if let match = FuzzyMatch.score(query: query, target: entry.relativePath) {
+                let slash = entry.relativePath.lastIndex(of: "/")
+                let prefixLen = slash.map { entry.relativePath.distance(from: entry.relativePath.startIndex, to: $0) + 1 } ?? 0
+                let inName = match.indices.allSatisfy { $0 >= prefixLen }
+                rows.append(FileSearchResult(
+                    worktreeId: wt.id,
+                    projectId: wt.projectId,
+                    relativePath: entry.relativePath,
+                    ext: entry.ext,
+                    statusBadge: badge,
+                    matchIndices: match.indices,
+                    score: match.score + (inName ? 8 : 0) + (badge != nil ? 2 : 0)
+                ))
+            }
+        }
+    }
+
+    private enum FileSearchCandidateRows {
+        case backend([FileSearchBackendResult])
+        case entries([FileIndex.Entry])
+    }
+
+    private func fileSearchCandidateRows(query: String, worktree wt: SearchWorktree) async throws -> FileSearchCandidateRows {
+        if Self.canUseFileSearchBackend(query: query),
+           let backendRows = try? await env.fileSearch(query, wt) {
+            return .backend(backendRows)
+        }
+        return .entries(try await env.entries(wt))
+    }
+
+    private static func canUseFileSearchBackend(query: String) -> Bool {
+        query
+            .split(whereSeparator: { $0.isWhitespace })
+            .contains { $0.count >= 2 }
     }
 
     private func runContentSearch(query: String, targets: [SearchWorktree]) async {

--- a/AlasTests/SearchModelTests.swift
+++ b/AlasTests/SearchModelTests.swift
@@ -13,6 +13,7 @@ struct SearchModelTests {
         worktrees: [SearchWorktree] = [],
         files: [String: [FileIndex.Entry]] = [:],
         statuses: [String: [String: GitStatusBadge]] = [:],
+        fileSearch: (@Sendable (String, SearchWorktree) async throws -> [FileSearchBackendResult]?)? = nil,
         contentSearch: (@Sendable (String, SearchContentOptions, [SearchWorktree]) -> AsyncThrowingStream<ContentSearchHit, Error>)? = nil
     ) -> SearchEnvironment {
         SearchEnvironment(
@@ -20,6 +21,7 @@ struct SearchModelTests {
             allWorktrees: { worktrees },
             entries: { wt in files[wt.id] ?? [] },
             statuses: { wt in statuses[wt.id] ?? [:] },
+            fileSearch: fileSearch ?? { _, _ in nil },
             contentSearch: contentSearch ?? { _, _, _ in AsyncThrowingStream { $0.finish() } }
         )
     }
@@ -46,6 +48,7 @@ struct SearchModelTests {
             allWorktrees: { [] },
             entries: { _ in [] },
             statuses: { _ in [:] },
+            fileSearch: { _, _ in nil },
             contentSearch: { _, _, _ in AsyncThrowingStream { $0.finish() } }
         )
         let model2 = SearchModel(environment: env)
@@ -84,6 +87,122 @@ struct SearchModelTests {
         #expect(paths.contains("tab_bar.rs"))
         #expect(paths.contains("tab_drag.rs"))
         #expect(!paths.contains("main.rs"))
+    }
+
+    @Test func fileSearchUsesBackendResultsWhenAvailable() async {
+        let env = makeEnv(
+            worktrees: [wt("a")],
+            files: ["a": [
+                .init(relativePath: "fallback_only.rs", ext: "rs"),
+            ]],
+            statuses: ["a": [
+                "src/backend_result.swift": .modified,
+            ]],
+            fileSearch: { query, _ in
+                guard query == "backend" else { return nil }
+                return [
+                    FileSearchBackendResult(
+                        relativePath: "src/backend_result.swift",
+                        score: 42,
+                        matchIndices: [4, 5, 6]
+                    ),
+                ]
+            }
+        )
+        let model = SearchModel(environment: env)
+        model.open()
+        model.query = "backend"
+        await model.waitForIdle()
+
+        #expect(model.results.fileResults.map(\.relativePath) == ["src/backend_result.swift"])
+        #expect(model.results.fileResults.first?.statusBadge == .modified)
+        #expect(model.results.fileResults.first?.score == 44)
+        #expect(model.results.fileResults.first?.matchIndices == [4, 5, 6])
+    }
+
+    @Test func fileSearchMergesDeletedFallbackRowsWithBackendResults() async {
+        let env = makeEnv(
+            worktrees: [wt("a")],
+            files: ["a": [
+                .init(relativePath: "old_file.swift", ext: "swift"),
+                .init(relativePath: "other_file.swift", ext: "swift"),
+            ]],
+            statuses: ["a": [
+                "old_file.swift": .deleted,
+                "other_file.swift": .modified,
+            ]],
+            fileSearch: { query, _ in
+                guard query == "old" else { return nil }
+                return []
+            }
+        )
+        let model = SearchModel(environment: env)
+        model.open()
+        model.query = "old"
+        await model.waitForIdle()
+
+        #expect(model.results.fileResults.map(\.relativePath) == ["old_file.swift"])
+        #expect(model.results.fileResults.first?.statusBadge == .deleted)
+    }
+
+    @Test func fileSearchMergesTrackedFallbackRowsOmittedByBackend() async {
+        let env = makeEnv(
+            worktrees: [wt("a")],
+            files: ["a": [
+                .init(relativePath: "ignored/tracked_file.swift", ext: "swift"),
+                .init(relativePath: "src/other_file.swift", ext: "swift"),
+            ]],
+            fileSearch: { query, _ in
+                guard query == "tracked" else { return nil }
+                return []
+            }
+        )
+        let model = SearchModel(environment: env)
+        model.open()
+        model.query = "tracked"
+        await model.waitForIdle()
+
+        #expect(model.results.fileResults.map(\.relativePath) == ["ignored/tracked_file.swift"])
+        #expect(model.results.fileResults.first?.statusBadge == nil)
+    }
+
+    @Test func fileSearchFallsBackWhenBackendIsNotReady() async {
+        let env = makeEnv(
+            worktrees: [wt("a")],
+            files: ["a": [
+                .init(relativePath: "src/fallback_result.swift", ext: "swift"),
+            ]],
+            fileSearch: { _, _ in nil }
+        )
+        let model = SearchModel(environment: env)
+        model.open()
+        model.query = "fallback"
+        await model.waitForIdle()
+
+        #expect(model.results.fileResults.map(\.relativePath) == ["src/fallback_result.swift"])
+    }
+
+    @Test func fileSearchKeepsSingleCharacterQueryOnSwiftScorer() async {
+        let env = makeEnv(
+            worktrees: [wt("a")],
+            files: ["a": [
+                .init(relativePath: "src/apple.swift", ext: "swift"),
+                .init(relativePath: "src/zoom.swift", ext: "swift"),
+            ]],
+            fileSearch: { _, _ in [
+                FileSearchBackendResult(
+                    relativePath: "src/backend_result.swift",
+                    score: 100,
+                    matchIndices: []
+                ),
+            ] }
+        )
+        let model = SearchModel(environment: env)
+        model.open()
+        model.query = "a"
+        await model.waitForIdle()
+
+        #expect(model.results.fileResults.map(\.relativePath) == ["src/apple.swift"])
     }
 
     @Test func selectionClampsOnResultShrink() async {

--- a/project.yml
+++ b/project.yml
@@ -203,13 +203,19 @@ targets:
         ENABLE_HARDENED_RUNTIME: YES
         CODE_SIGN_STYLE: Automatic
         CODE_SIGN_IDENTITY: "-"
-        OTHER_LDFLAGS: $(inherited) -lc++
+        HEADER_SEARCH_PATHS: $(inherited) $(SRCROOT)/.build/fff/include
+        LIBRARY_SEARCH_PATHS: $(inherited) $(SRCROOT)/.build/fff/$(CURRENT_ARCH)/install/lib $(SRCROOT)/.build/fff/universal/install/lib
+        LD_RUNPATH_SEARCH_PATHS: $(inherited) @executable_path/../Frameworks
+        OTHER_LDFLAGS: $(inherited) -lc++ -lfff_c
     preBuildScripts:
       - name: Build GhosttyKit
         script: '"${SRCROOT}/scripts/build-ghostty.sh"'
         basedOnDependencyAnalysis: false
       - name: Build zmx
         script: '"${SRCROOT}/scripts/build-zmx.sh"'
+        basedOnDependencyAnalysis: false
+      - name: Build fff
+        script: '"${SRCROOT}/scripts/build-fff.sh"'
         basedOnDependencyAnalysis: false
     postBuildScripts:
       - name: Embed Ghostty Resources
@@ -233,6 +239,9 @@ targets:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: io.nlopez.alas.tests
         GENERATE_INFOPLIST_FILE: YES
+        HEADER_SEARCH_PATHS: $(inherited) $(SRCROOT)/.build/fff/include
+        LIBRARY_SEARCH_PATHS: $(inherited) $(SRCROOT)/.build/fff/$(CURRENT_ARCH)/install/lib $(SRCROOT)/.build/fff/universal/install/lib
+        LD_RUNPATH_SEARCH_PATHS: $(inherited) @loader_path/../Frameworks @executable_path/../Frameworks
         TEST_HOST: $(BUILT_PRODUCTS_DIR)/Alas.app/Contents/MacOS/Alas
         BUNDLE_LOADER: $(TEST_HOST)
 

--- a/scripts/build-fff.sh
+++ b/scripts/build-fff.sh
@@ -1,0 +1,91 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [ -n "${HOME:-}" ]; then
+    export PATH="/opt/homebrew/bin:/usr/local/bin:${HOME}/.cargo/bin:${PATH}"
+else
+    export PATH="/opt/homebrew/bin:/usr/local/bin:${PATH}"
+fi
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+script_path="${script_dir}/$(basename "${BASH_SOURCE[0]}")"
+srcroot="${SRCROOT:-$(cd "${script_dir}/.." && pwd)}"
+fff_src="${srcroot}/ThirdParty/fff"
+
+if [ -z "${ALAS_FFF_TARGET_ARCH:-}" ] && [ "${CURRENT_ARCH:-}" = "undefined_arch" ]; then
+    target_arch="universal"
+else
+    target_arch="${ALAS_FFF_TARGET_ARCH:-${CURRENT_ARCH:-$(uname -m)}}"
+fi
+
+build_root="${srcroot}/.build/fff/${target_arch}"
+install_root="${build_root}/install"
+lib_dir="${install_root}/lib"
+lib_output="${lib_dir}/libfff_c.dylib"
+include_root="${srcroot}/.build/fff/include"
+
+die() {
+    echo "build-fff.sh: error: $*" >&2
+    exit 1
+}
+
+if [ "${target_arch}" = "universal" ]; then
+    mkdir -p "${lib_dir}"
+    for slice in arm64 x86_64; do
+        env ALAS_FFF_TARGET_ARCH="${slice}" CURRENT_ARCH="" bash "${script_path}"
+    done
+
+    arm64_slice="${srcroot}/.build/fff/arm64/install/lib/libfff_c.dylib"
+    x86_64_slice="${srcroot}/.build/fff/x86_64/install/lib/libfff_c.dylib"
+    [ -f "${arm64_slice}" ] || die "missing arm64 fff dylib at ${arm64_slice}"
+    [ -f "${x86_64_slice}" ] || die "missing x86_64 fff dylib at ${x86_64_slice}"
+
+    lipo -create "${arm64_slice}" "${x86_64_slice}" -output "${lib_output}"
+    install_name_tool -id @rpath/libfff_c.dylib "${lib_output}"
+    echo "build-fff.sh: produced universal ${lib_output}"
+    exit 0
+fi
+
+[ -d "${fff_src}/.git" ] || [ -f "${fff_src}/.git" ] || die "submodule missing: ${fff_src}"
+command -v cargo >/dev/null 2>&1 || die "cargo not found. Install Rust or ensure cargo is on PATH"
+
+case "${target_arch}" in
+    arm64) cargo_target="aarch64-apple-darwin" ;;
+    x86_64) cargo_target="x86_64-apple-darwin" ;;
+    *) die "unsupported target_arch '${target_arch}'" ;;
+esac
+
+mkdir -p "${lib_dir}" "${include_root}"
+
+if command -v rustup >/dev/null 2>&1; then
+    if ! rustup target list --installed | grep -qx "${cargo_target}"; then
+        rustup target add "${cargo_target}"
+    fi
+fi
+
+(
+    cd "${fff_src}"
+    MACOSX_DEPLOYMENT_TARGET="${MACOSX_DEPLOYMENT_TARGET:-14.0}" \
+        cargo build \
+            --package fff-c \
+            --release \
+            --target "${cargo_target}" \
+            --target-dir "${build_root}/cargo-target"
+)
+
+cargo_output="${build_root}/cargo-target/${cargo_target}/release/libfff_c.dylib"
+[ -f "${cargo_output}" ] || die "cargo did not produce ${cargo_output}"
+
+rsync -a "${cargo_output}" "${lib_output}"
+install_name_tool -id @rpath/libfff_c.dylib "${lib_output}"
+
+rsync -a "${fff_src}/crates/fff-c/include/fff.h" "${include_root}/fff.h"
+cat > "${include_root}/module.modulemap" <<'MODULEMAP'
+module FffC [system] {
+    header "fff.h"
+    link "fff_c"
+    export *
+}
+MODULEMAP
+
+echo "build-fff.sh: built ${lib_output}"

--- a/scripts/embed-ghostty-resources.sh
+++ b/scripts/embed-ghostty-resources.sh
@@ -45,3 +45,26 @@ else
     echo "embed-ghostty-resources.sh: error: zmx binary not found or not executable at ${zmx_source}" >&2
     exit 1
 fi
+
+# fff search backend dylib. Selection mirrors build-fff.sh.
+if [ -n "${ALAS_FFF_TARGET_ARCH:-}" ]; then
+    fff_arch="${ALAS_FFF_TARGET_ARCH}"
+elif [ "${CURRENT_ARCH:-}" = "undefined_arch" ]; then
+    fff_arch="universal"
+else
+    fff_arch="${CURRENT_ARCH:-$(uname -m)}"
+fi
+
+fff_source="${SRCROOT}/.build/fff/${fff_arch}/install/lib/libfff_c.dylib"
+fff_destination_dir="${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}"
+fff_destination="${fff_destination_dir}/libfff_c.dylib"
+
+if [ ! -f "${fff_source}" ]; then
+    echo "embed-ghostty-resources.sh: error: fff dylib not found at ${fff_source}" >&2
+    exit 1
+fi
+
+mkdir -p "${fff_destination_dir}"
+rsync -a "${fff_source}" "${fff_destination}"
+install_name_tool -id @rpath/libfff_c.dylib "${fff_destination}"
+codesign --force --sign - "${fff_destination}" >/dev/null


### PR DESCRIPTION
## Summary

Bundles `dmtrKovalenko/fff` as a submodule and builds its C dylib from Xcode so file search can use the native fff index when available.

## Changes

- Add `ThirdParty/fff` and `scripts/build-fff.sh` for arm64, x86_64, and universal dylib builds; `rustup` is used opportunistically to install missing targets when available, but plain Cargo toolchains can still build native targets.
- Link the app and test target against `libfff_c` via `project.yml` and embed/sign the dylib with the existing resource script.
- Add a Swift `FffFileSearchBackend` and wire `SearchModel` to use it for eligible non-empty file searches, falling back to the existing Swift fuzzy scorer while fff is still scanning or for short queries fff does not filter.
- Preserve git-backed rows that fff omits by merging fallback matches from the file index, including deleted tracked files and tracked files under ignored paths.
- Add SearchModel coverage for backend-provided results, backend-omitted fallback merging, deleted-file fallback merging, not-ready fallback, and one-character query fallback.

## Validation

- `xcodegen`
- `xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -quiet build`
- `xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' test`

Full local suite: 4,277 tests in 465 suites passed.