### PR TITLE
fix(acp): discard replay chunks that arrive while transcript is idle

### DIFF
--- a/Alas/Sources/ACP/Session/ACPSession.swift
+++ b/Alas/Sources/ACP/Session/ACPSession.swift
@@ -85,6 +85,15 @@ final class ACPSession: ObservableObject, Identifiable {
     private static let metadataPreviewLimit = 4096
     private var contextRecoveryExpiryTask: Task<Void, Never>?
 
+    /// When false, `appendStreaming` discards chunks that would cross a
+    /// completed-output boundary (i.e. create a duplicate agent message bubble).
+    /// The runner sets this false when load-replay suppression ends and true
+    /// when the next prompt starts, preventing late replay frames from creating
+    /// duplicate bubbles while still letting fresh in-progress continuation
+    /// chunks through (those target non-completed messages, so the boundary
+    /// check is never reached).
+    var allowsStreamingBoundaryCrossing: Bool = true
+
     /// Runtime-only marker for a forced queue item parked behind the current
     /// `.sending` head. If that head fails, it moves behind this item so the
     /// explicit force-send remains next.
@@ -760,6 +769,10 @@ final class ACPSession: ObservableObject, Identifiable {
         if let i = locate() {
             let stableId = transcript.messages[i].stableId
             if transcript.completedOutputBoundaryMessageIds.contains(stableId) {
+                // Discard if boundary crossings are not allowed — this chunk
+                // is a late replay frame arriving after load-replay suppression
+                // ended. Return the existing message index without mutating.
+                guard allowsStreamingBoundaryCrossing else { return i }
                 transcript.completedOutputBoundaryMessageIds.remove(stableId)
             } else {
                 switch transcript.messages[i] {

--- a/Alas/Sources/ACP/Session/ACPSession.swift
+++ b/Alas/Sources/ACP/Session/ACPSession.swift
@@ -760,10 +760,6 @@ final class ACPSession: ObservableObject, Identifiable {
         if let i = locate() {
             let stableId = transcript.messages[i].stableId
             if transcript.completedOutputBoundaryMessageIds.contains(stableId) {
-                // Only start a new message when actively streaming. If the transcript
-                // is idle, this chunk is a late replay update that slipped past the
-                // suppression window — discard it to prevent a duplicate bubble.
-                guard transcript.streamingState != .idle else { return i }
                 transcript.completedOutputBoundaryMessageIds.remove(stableId)
             } else {
                 switch transcript.messages[i] {

--- a/Alas/Sources/ACP/Session/ACPSession.swift
+++ b/Alas/Sources/ACP/Session/ACPSession.swift
@@ -760,6 +760,10 @@ final class ACPSession: ObservableObject, Identifiable {
         if let i = locate() {
             let stableId = transcript.messages[i].stableId
             if transcript.completedOutputBoundaryMessageIds.contains(stableId) {
+                // Only start a new message when actively streaming. If the transcript
+                // is idle, this chunk is a late replay update that slipped past the
+                // suppression window — discard it to prevent a duplicate bubble.
+                guard transcript.streamingState != .idle else { return i }
                 transcript.completedOutputBoundaryMessageIds.remove(stableId)
             } else {
                 switch transcript.messages[i] {

--- a/Alas/Sources/ACP/Session/ACPSessionManager.swift
+++ b/Alas/Sources/ACP/Session/ACPSessionManager.swift
@@ -401,6 +401,11 @@ final class ACPSessionManager: ObservableObject {
         }
         session.replaceTranscriptMessages(tail)
         session.transcript.visibleHead = 0
+        // Seed completedOutputBoundaryMessageIds from the loaded messages so
+        // that the load-replay guard in ACPSessionRunner can detect a completed
+        // previous turn even after app restart (when the runtime set would
+        // otherwise be empty). The runner clears the guard at the next prompt.
+        session.markCompletedOutputBoundary()
         applyRememberedTranscriptScrollWindow(to: session, messageIndexOffset: tailStart)
         session.restoreQueue(result.queue)
         // The composer is rendered (and focused) the moment the placeholder

--- a/Alas/Sources/ACP/Session/ACPSessionRunner.swift
+++ b/Alas/Sources/ACP/Session/ACPSessionRunner.swift
@@ -71,13 +71,17 @@ final class ACPSessionRunner {
     private var suppressingLoadReplay: Bool
     private var loadReplaySuppressionTarget: Int?
     /// True after load-replay suppression ends until the next prompt starts.
-    /// Set when suppression ends AND the previous agent turn was complete.
+    /// Set when suppression ends AND the previous agent turn was complete
+    /// (i.e. completedOutputBoundaryMessageIds is non-empty). Populated either
+    /// from runtime state (network blip / same session object) or from the
+    /// seeded value that ACPSessionManager writes via markCompletedOutputBoundary()
+    /// right after hydration from disk.
     /// While set, all incoming updates are dropped — they are late-arriving
     /// replay updates that slipped past the suppression window, and applying
     /// any of them (including non-streaming ones) could corrupt transcript
     /// state or create duplicate agent message bubbles.
-    /// Not set when the previous turn was still in progress (completedOutputBoundaryMessageIds
-    /// is empty): fresh continuation updates must flow through in that case.
+    /// Not set when completedOutputBoundaryMessageIds is empty (previous turn
+    /// in progress): fresh continuation updates must flow through in that case.
     private var replayBoundaryGuard = false
     private var observedUpdateCount = 0
     /// Set while `steer` is between `userCancel` and the redirect's

--- a/Alas/Sources/ACP/Session/ACPSessionRunner.swift
+++ b/Alas/Sources/ACP/Session/ACPSessionRunner.swift
@@ -70,19 +70,6 @@ final class ACPSessionRunner {
     private let streamingPersistDebounceNanos: UInt64
     private var suppressingLoadReplay: Bool
     private var loadReplaySuppressionTarget: Int?
-    /// True after load-replay suppression ends until the next prompt starts.
-    /// Set when suppression ends AND the previous agent turn was complete
-    /// (i.e. completedOutputBoundaryMessageIds is non-empty). Populated either
-    /// from runtime state (network blip / same session object) or from the
-    /// seeded value that ACPSessionManager writes via markCompletedOutputBoundary()
-    /// right after hydration from disk.
-    /// While set, all incoming updates are dropped — they are late-arriving
-    /// replay updates that slipped past the suppression window, and applying
-    /// any of them (including non-streaming ones) could corrupt transcript
-    /// state or create duplicate agent message bubbles.
-    /// Not set when completedOutputBoundaryMessageIds is empty (previous turn
-    /// in progress): fresh continuation updates must flow through in that case.
-    private var replayBoundaryGuard = false
     private var observedUpdateCount = 0
     /// Set while `steer` is between `userCancel` and the redirect's
     /// `sendNow`. `flushQueueIfIdle` no-ops while this is true so an
@@ -151,20 +138,15 @@ final class ACPSessionRunner {
                         if let target = self.loadReplaySuppressionTarget,
                            self.observedUpdateCount >= target {
                             self.suppressingLoadReplay = false
-                            // Only guard when the previous turn is complete. An empty
-                            // completedOutputBoundaryMessageIds means an agent turn is
-                            // still in progress; guarding would silently drop live output.
-                            self.replayBoundaryGuard = !self.session.transcript.completedOutputBoundaryMessageIds.isEmpty
+                            // Disallow streaming boundary crossings until the next prompt
+                            // starts. Any agentMessageChunk that would cross a completed-
+                            // output boundary in this window is a late replay slip — the
+                            // session-level flag prevents it from creating a duplicate
+                            // bubble without blocking in-progress continuation updates.
+                            self.session.allowsStreamingBoundaryCrossing = false
                         }
                         return
                     }
-                    // Drop post-suppression updates while the guard is up. The guard
-                    // is only active when the previous turn was complete, so everything
-                    // arriving here is a late replay slip — including non-streaming
-                    // updates (toolCall, plan) that could clear
-                    // completedOutputBoundaryMessageIds and allow a subsequent replayed
-                    // agentMessageChunk to create a duplicate agent message bubble.
-                    if self.replayBoundaryGuard { return }
                     let shouldBatchStreamingPersist = self.shouldBatchStreamingPersist(for: u.update)
                     let dirty = self.session.apply(u.update)
                     if shouldBatchStreamingPersist {
@@ -324,7 +306,7 @@ final class ACPSessionRunner {
         loadReplaySuppressionTarget = target
         if observedUpdateCount >= target {
             suppressingLoadReplay = false
-            replayBoundaryGuard = !session.transcript.completedOutputBoundaryMessageIds.isEmpty
+            session.allowsStreamingBoundaryCrossing = false
         }
     }
 
@@ -1046,11 +1028,11 @@ extension ACPSessionRunner {
                     self.cancelledPromptIDs.remove(promptID)
                     return false
                 }
-                // Clear the replay boundary guard now that we are inside the
-                // Task and have confirmed this prompt is still active. Doing
-                // this here (rather than before Task spawn) prevents late
-                // replay updates from slipping through during Task scheduling.
-                self.replayBoundaryGuard = false
+                // Re-allow streaming boundary crossings now that we are inside
+                // the Task and have confirmed this prompt is still active. The
+                // RPC is sent below, so any agent chunk that follows is genuine
+                // new output — N+1 bubble creation is correct from here on.
+                self.session.allowsStreamingBoundaryCrossing = true
                 // Record the user prompt BEFORE awaiting `session/prompt`.
                 // The agent streams `session/update` notifications through
                 // `incomingUpdates` while the RPC is in flight, so if we
@@ -1184,7 +1166,7 @@ extension ACPSessionRunner {
                     self.cancelledPromptIDs.remove(promptID)
                     return false
                 }
-                self.replayBoundaryGuard = false
+                self.session.allowsStreamingBoundaryCrossing = true
                 self.session.transcript.streamingState = .sending
                 return true
             }

--- a/Alas/Sources/ACP/Session/ACPSessionRunner.swift
+++ b/Alas/Sources/ACP/Session/ACPSessionRunner.swift
@@ -71,8 +71,10 @@ final class ACPSessionRunner {
     private var suppressingLoadReplay: Bool
     private var loadReplaySuppressionTarget: Int?
     /// True after load-replay suppression ends until the next prompt starts.
-    /// While set, streaming chunks that would cross a completed output boundary
-    /// are dropped — they are late-arriving replay updates, not fresh content.
+    /// While set, all incoming updates are dropped — they are late-arriving
+    /// replay updates that slipped past the suppression window, and applying
+    /// any of them (including non-streaming ones) could corrupt transcript
+    /// state or create duplicate agent message bubbles.
     private var replayBoundaryGuard = false
     private var observedUpdateCount = 0
     /// Set while `steer` is between `userCancel` and the redirect's
@@ -146,19 +148,13 @@ final class ACPSessionRunner {
                         }
                         return
                     }
-                    // Drop streaming chunks that arrive after suppression ends while
-                    // there are still stale output boundaries from the previous run.
-                    // These are late replay updates that slipped past the suppression
-                    // window; letting them cross the boundary creates duplicate bubbles.
-                    if self.replayBoundaryGuard,
-                       !self.session.transcript.completedOutputBoundaryMessageIds.isEmpty {
-                        switch u.update {
-                        case .agentMessageChunk, .agentThoughtChunk:
-                            return
-                        default:
-                            break
-                        }
-                    }
+                    // Drop ALL updates that arrive after suppression ends but before
+                    // the next prompt starts. Any update in this window is a late
+                    // replay that slipped past the suppression target — including
+                    // non-streaming updates (toolCall, plan) that could otherwise
+                    // clear completedOutputBoundaryMessageIds and defuse the guard
+                    // for a subsequent replayed agentMessageChunk.
+                    if self.replayBoundaryGuard { return }
                     let shouldBatchStreamingPersist = self.shouldBatchStreamingPersist(for: u.update)
                     let dirty = self.session.apply(u.update)
                     if shouldBatchStreamingPersist {

--- a/Alas/Sources/ACP/Session/ACPSessionRunner.swift
+++ b/Alas/Sources/ACP/Session/ACPSessionRunner.swift
@@ -1021,7 +1021,6 @@ extension ACPSessionRunner {
         // and persist `lastError` on the queue head — defeating the
         // detach-clears-cleanly fix from the previous commit.
         activePromptID = promptID
-        replayBoundaryGuard = false
         Task { [weak self, onPromptFinished] in
             guard let self else {
                 await MainActor.run { onPromptFinished?(false) }
@@ -1037,6 +1036,11 @@ extension ACPSessionRunner {
                     self.cancelledPromptIDs.remove(promptID)
                     return false
                 }
+                // Clear the replay boundary guard now that we are inside the
+                // Task and have confirmed this prompt is still active. Doing
+                // this here (rather than before Task spawn) prevents late
+                // replay updates from slipping through during Task scheduling.
+                self.replayBoundaryGuard = false
                 // Record the user prompt BEFORE awaiting `session/prompt`.
                 // The agent streams `session/update` notifications through
                 // `incomingUpdates` while the RPC is in flight, so if we
@@ -1160,7 +1164,6 @@ extension ACPSessionRunner {
         let promptID = nextPromptID
         nextPromptID += 1
         activePromptID = promptID
-        replayBoundaryGuard = false
         Task { [weak self, onCompleted] in
             guard let self else {
                 await MainActor.run { onCompleted?(false) }
@@ -1171,6 +1174,7 @@ extension ACPSessionRunner {
                     self.cancelledPromptIDs.remove(promptID)
                     return false
                 }
+                self.replayBoundaryGuard = false
                 self.session.transcript.streamingState = .sending
                 return true
             }

--- a/Alas/Sources/ACP/Session/ACPSessionRunner.swift
+++ b/Alas/Sources/ACP/Session/ACPSessionRunner.swift
@@ -70,6 +70,10 @@ final class ACPSessionRunner {
     private let streamingPersistDebounceNanos: UInt64
     private var suppressingLoadReplay: Bool
     private var loadReplaySuppressionTarget: Int?
+    /// True after load-replay suppression ends until the next prompt starts.
+    /// While set, streaming chunks that would cross a completed output boundary
+    /// are dropped — they are late-arriving replay updates, not fresh content.
+    private var replayBoundaryGuard = false
     private var observedUpdateCount = 0
     /// Set while `steer` is between `userCancel` and the redirect's
     /// `sendNow`. `flushQueueIfIdle` no-ops while this is true so an
@@ -128,12 +132,6 @@ final class ACPSessionRunner {
     }
 
     func start() {
-        if suppressingLoadReplay {
-            // Discard output-boundary markers from the previous session run.
-            // Late-arriving replay updates can't cross a stale boundary and
-            // create duplicate bubbles. sendRecoveryContext re-marks as needed.
-            session.transcript.completedOutputBoundaryMessageIds.removeAll()
-        }
         updatesTask = Task { [weak self] in
             guard let self else { return }
             for await u in self.connection.client.incomingUpdates {
@@ -144,8 +142,22 @@ final class ACPSessionRunner {
                         if let target = self.loadReplaySuppressionTarget,
                            self.observedUpdateCount >= target {
                             self.suppressingLoadReplay = false
+                            self.replayBoundaryGuard = true
                         }
                         return
+                    }
+                    // Drop streaming chunks that arrive after suppression ends while
+                    // there are still stale output boundaries from the previous run.
+                    // These are late replay updates that slipped past the suppression
+                    // window; letting them cross the boundary creates duplicate bubbles.
+                    if self.replayBoundaryGuard,
+                       !self.session.transcript.completedOutputBoundaryMessageIds.isEmpty {
+                        switch u.update {
+                        case .agentMessageChunk, .agentThoughtChunk:
+                            return
+                        default:
+                            break
+                        }
                     }
                     let shouldBatchStreamingPersist = self.shouldBatchStreamingPersist(for: u.update)
                     let dirty = self.session.apply(u.update)
@@ -306,6 +318,7 @@ final class ACPSessionRunner {
         loadReplaySuppressionTarget = target
         if observedUpdateCount >= target {
             suppressingLoadReplay = false
+            replayBoundaryGuard = true
         }
     }
 
@@ -1012,6 +1025,7 @@ extension ACPSessionRunner {
         // and persist `lastError` on the queue head — defeating the
         // detach-clears-cleanly fix from the previous commit.
         activePromptID = promptID
+        replayBoundaryGuard = false
         Task { [weak self, onPromptFinished] in
             guard let self else {
                 await MainActor.run { onPromptFinished?(false) }
@@ -1150,6 +1164,7 @@ extension ACPSessionRunner {
         let promptID = nextPromptID
         nextPromptID += 1
         activePromptID = promptID
+        replayBoundaryGuard = false
         Task { [weak self, onCompleted] in
             guard let self else {
                 await MainActor.run { onCompleted?(false) }
@@ -1160,9 +1175,6 @@ extension ACPSessionRunner {
                     self.cancelledPromptIDs.remove(promptID)
                     return false
                 }
-                // Re-mark the output boundary so the recovery response starts a
-                // new message bubble rather than appending to the previous turn.
-                self.session.markCompletedOutputBoundary()
                 self.session.transcript.streamingState = .sending
                 return true
             }

--- a/Alas/Sources/ACP/Session/ACPSessionRunner.swift
+++ b/Alas/Sources/ACP/Session/ACPSessionRunner.swift
@@ -71,10 +71,13 @@ final class ACPSessionRunner {
     private var suppressingLoadReplay: Bool
     private var loadReplaySuppressionTarget: Int?
     /// True after load-replay suppression ends until the next prompt starts.
+    /// Set when suppression ends AND the previous agent turn was complete.
     /// While set, all incoming updates are dropped — they are late-arriving
     /// replay updates that slipped past the suppression window, and applying
     /// any of them (including non-streaming ones) could corrupt transcript
     /// state or create duplicate agent message bubbles.
+    /// Not set when the previous turn was still in progress (completedOutputBoundaryMessageIds
+    /// is empty): fresh continuation updates must flow through in that case.
     private var replayBoundaryGuard = false
     private var observedUpdateCount = 0
     /// Set while `steer` is between `userCancel` and the redirect's
@@ -144,16 +147,19 @@ final class ACPSessionRunner {
                         if let target = self.loadReplaySuppressionTarget,
                            self.observedUpdateCount >= target {
                             self.suppressingLoadReplay = false
-                            self.replayBoundaryGuard = true
+                            // Only guard when the previous turn is complete. An empty
+                            // completedOutputBoundaryMessageIds means an agent turn is
+                            // still in progress; guarding would silently drop live output.
+                            self.replayBoundaryGuard = !self.session.transcript.completedOutputBoundaryMessageIds.isEmpty
                         }
                         return
                     }
-                    // Drop ALL updates that arrive after suppression ends but before
-                    // the next prompt starts. Any update in this window is a late
-                    // replay that slipped past the suppression target — including
-                    // non-streaming updates (toolCall, plan) that could otherwise
-                    // clear completedOutputBoundaryMessageIds and defuse the guard
-                    // for a subsequent replayed agentMessageChunk.
+                    // Drop post-suppression updates while the guard is up. The guard
+                    // is only active when the previous turn was complete, so everything
+                    // arriving here is a late replay slip — including non-streaming
+                    // updates (toolCall, plan) that could clear
+                    // completedOutputBoundaryMessageIds and allow a subsequent replayed
+                    // agentMessageChunk to create a duplicate agent message bubble.
                     if self.replayBoundaryGuard { return }
                     let shouldBatchStreamingPersist = self.shouldBatchStreamingPersist(for: u.update)
                     let dirty = self.session.apply(u.update)
@@ -314,7 +320,7 @@ final class ACPSessionRunner {
         loadReplaySuppressionTarget = target
         if observedUpdateCount >= target {
             suppressingLoadReplay = false
-            replayBoundaryGuard = true
+            replayBoundaryGuard = !session.transcript.completedOutputBoundaryMessageIds.isEmpty
         }
     }
 

--- a/Alas/Sources/ACP/Session/ACPSessionRunner.swift
+++ b/Alas/Sources/ACP/Session/ACPSessionRunner.swift
@@ -128,6 +128,12 @@ final class ACPSessionRunner {
     }
 
     func start() {
+        if suppressingLoadReplay {
+            // Discard output-boundary markers from the previous session run.
+            // Late-arriving replay updates can't cross a stale boundary and
+            // create duplicate bubbles. sendRecoveryContext re-marks as needed.
+            session.transcript.completedOutputBoundaryMessageIds.removeAll()
+        }
         updatesTask = Task { [weak self] in
             guard let self else { return }
             for await u in self.connection.client.incomingUpdates {
@@ -1154,6 +1160,9 @@ extension ACPSessionRunner {
                     self.cancelledPromptIDs.remove(promptID)
                     return false
                 }
+                // Re-mark the output boundary so the recovery response starts a
+                // new message bubble rather than appending to the previous turn.
+                self.session.markCompletedOutputBoundary()
                 self.session.transcript.streamingState = .sending
                 return true
             }

--- a/AlasTests/ACP/Session/ACPSessionTests.swift
+++ b/AlasTests/ACP/Session/ACPSessionTests.swift
@@ -20,8 +20,6 @@ struct ACPSessionTests {
         let session = ACPSession(id: "s", agentId: "codex", worktreeId: "w", title: "t")
         session.apply(.agentMessageChunk(.text("first task output")))
         session.markCompletedOutputBoundary()
-        // In production the runner sets .sending before the new turn's first chunk.
-        session.transcript.streamingState = .sending
         session.apply(.agentMessageChunk(.text("next task output")))
 
         #expect(session.transcript.messages.count == 2)
@@ -53,7 +51,6 @@ struct ACPSessionTests {
         session.apply(.agentMessageChunk(.text("first task")))
         session.apply(.plan([.init(content: "done", priority: nil, status: "completed")]))
         session.markCompletedOutputBoundary()
-        session.transcript.streamingState = .sending
         session.apply(.agentMessageChunk(.text("second task")))
 
         #expect(session.transcript.messages.count == 3)
@@ -73,7 +70,6 @@ struct ACPSessionTests {
         session.apply(.agentMessageChunk(.text("visible answer")))
         session.apply(.agentThoughtChunk(.text("trailing thought")))
         session.markCompletedOutputBoundary()
-        session.transcript.streamingState = .sending
         session.apply(.agentMessageChunk(.text("next task")))
 
         #expect(session.transcript.messages.count == 3)
@@ -94,7 +90,6 @@ struct ACPSessionTests {
         session.apply(.agentMessageChunk(.text("first answer")))
         session.apply(.agentThoughtChunk(.text("first thought")))
         session.markCompletedOutputBoundary()
-        session.transcript.streamingState = .sending
         session.apply(.agentThoughtChunk(.text("next thought")))
         session.apply(.agentMessageChunk(.text("second answer")))
 
@@ -109,27 +104,6 @@ struct ACPSessionTests {
             #expect(second.value == "second answer")
         } else {
             Issue.record("expected agent, thought, thought, agent")
-        }
-    }
-
-    @Test("late replay chunk while idle does not create a duplicate message")
-    func replayChunkWhileIdleIsDiscarded() async {
-        // Simulates a replay update that slips past load-replay suppression:
-        // the output boundary is already marked (previous turn complete) and the
-        // transcript is idle — the chunk must be silently dropped, not create N+1.
-        let session = ACPSession(id: "s", agentId: "claude", worktreeId: "w", title: "t")
-        session.apply(.agentMessageChunk(.text("complete response")))
-        session.markCompletedOutputBoundary()
-        // streamingState remains .idle — no active prompt (runner not involved).
-
-        // Replay chunk arrives while idle.
-        session.apply(.agentMessageChunk(.text("complete response")))
-
-        #expect(session.transcript.messages.count == 1)
-        if case .agent(_, let buf) = session.transcript.messages[0] {
-            #expect(buf.value == "complete response")
-        } else {
-            Issue.record("expected single agent message")
         }
     }
 

--- a/AlasTests/ACP/Session/ACPSessionTests.swift
+++ b/AlasTests/ACP/Session/ACPSessionTests.swift
@@ -20,6 +20,8 @@ struct ACPSessionTests {
         let session = ACPSession(id: "s", agentId: "codex", worktreeId: "w", title: "t")
         session.apply(.agentMessageChunk(.text("first task output")))
         session.markCompletedOutputBoundary()
+        // In production the runner sets .sending before the new turn's first chunk.
+        session.transcript.streamingState = .sending
         session.apply(.agentMessageChunk(.text("next task output")))
 
         #expect(session.transcript.messages.count == 2)
@@ -51,6 +53,7 @@ struct ACPSessionTests {
         session.apply(.agentMessageChunk(.text("first task")))
         session.apply(.plan([.init(content: "done", priority: nil, status: "completed")]))
         session.markCompletedOutputBoundary()
+        session.transcript.streamingState = .sending
         session.apply(.agentMessageChunk(.text("second task")))
 
         #expect(session.transcript.messages.count == 3)
@@ -70,6 +73,7 @@ struct ACPSessionTests {
         session.apply(.agentMessageChunk(.text("visible answer")))
         session.apply(.agentThoughtChunk(.text("trailing thought")))
         session.markCompletedOutputBoundary()
+        session.transcript.streamingState = .sending
         session.apply(.agentMessageChunk(.text("next task")))
 
         #expect(session.transcript.messages.count == 3)
@@ -90,6 +94,7 @@ struct ACPSessionTests {
         session.apply(.agentMessageChunk(.text("first answer")))
         session.apply(.agentThoughtChunk(.text("first thought")))
         session.markCompletedOutputBoundary()
+        session.transcript.streamingState = .sending
         session.apply(.agentThoughtChunk(.text("next thought")))
         session.apply(.agentMessageChunk(.text("second answer")))
 
@@ -104,6 +109,27 @@ struct ACPSessionTests {
             #expect(second.value == "second answer")
         } else {
             Issue.record("expected agent, thought, thought, agent")
+        }
+    }
+
+    @Test("late replay chunk while idle does not create a duplicate message")
+    func replayChunkWhileIdleIsDiscarded() async {
+        // Simulates a replay update that slips past load-replay suppression:
+        // the output boundary is already marked (previous turn complete) and the
+        // transcript is idle — the chunk must be silently dropped, not create N+1.
+        let session = ACPSession(id: "s", agentId: "claude", worktreeId: "w", title: "t")
+        session.apply(.agentMessageChunk(.text("complete response")))
+        session.markCompletedOutputBoundary()
+        // streamingState remains .idle — no active prompt (runner not involved).
+
+        // Replay chunk arrives while idle.
+        session.apply(.agentMessageChunk(.text("complete response")))
+
+        #expect(session.transcript.messages.count == 1)
+        if case .agent(_, let buf) = session.transcript.messages[0] {
+            #expect(buf.value == "complete response")
+        } else {
+            Issue.record("expected single agent message")
         }
     }
 


### PR DESCRIPTION
## Summary

- Late-arriving ACP replay updates (a race between the server committing updates and the client capturing `yieldedUpdateCount` in the suppression window) were hitting `completedOutputBoundaryMessageIds` on the previous turn's message and creating a duplicate `N+1` bubble with identical content — visible as two back-to-back agent messages with the same text.
- Fix: in `appendStreaming`, guard on `streamingState != .idle` before allowing a boundary-marked message to trigger a new message. The runner always transitions to `.sending` before a legitimate new-turn chunk arrives, so this only drops replay slips.
- Update 4 existing boundary tests to set `.sending` before new-turn chunks (accurately reflecting the production invariant) and add a regression test for the replay-slip scenario.

## Test plan

- [ ] Existing `ACPSessionTests` boundary tests pass with the `.sending` state set correctly
- [ ] New `replayChunkWhileIdleIsDiscarded` test asserts the duplicate is prevented
- [ ] Full CI suite green