### PR TITLE
feat(changes): stage/unstage folders via checkbox in working tree

### DIFF
--- a/Alas/Sources/Right/WorkingTreeSectionView.swift
+++ b/Alas/Sources/Right/WorkingTreeSectionView.swift
@@ -128,6 +128,7 @@ struct WorkingTreeSectionView: View {
             let folderGroups = groups.groups(under: node.path)
             let stagedEntries = folderGroups.flatMap(\.stagedEntries)
             let unstagedEntries = folderGroups.flatMap(\.unstagedEntries)
+            let folderState = folderStageState(staged: stagedEntries, unstaged: unstagedEntries)
             let folderUntracked = isUntrackedSubtree(node, groupsByPath: groupsByPath)
             return AnyView(
                 Group {
@@ -141,6 +142,12 @@ struct WorkingTreeSectionView: View {
                         HStack(spacing: 6) {
                             Icon(name: open ? "chev-down" : "chev-right", size: 10, color: theme.color("fg-faint"))
                                 .frame(width: 14, height: 14)
+                            StageChip(state: stageChipState(for: folderState)) {
+                                switch folderState {
+                                case .staged:           onUnstageAll?(stagedEntries)
+                                case .mixed, .unstaged: onStageAll?(unstagedEntries)
+                                }
+                            }
                             FolderIconView(
                                 name: node.name,
                                 path: node.path,
@@ -236,6 +243,17 @@ struct WorkingTreeSectionView: View {
         case .mixed, .unstaged:
             guard !group.unstagedEntries.isEmpty else { return nil }
             return { onStageAll?(group.unstagedEntries) }
+        }
+    }
+
+    private func folderStageState(
+        staged: [ChangedFile],
+        unstaged: [ChangedFile]
+    ) -> WorkingTreeStageState {
+        switch (staged.isEmpty, unstaged.isEmpty) {
+        case (false, false): return .mixed
+        case (false, true):  return .staged
+        default:             return .unstaged
         }
     }
 


### PR DESCRIPTION
## What

Folder rows in the **Working tree** section of the Changes tab now have a stage/unstage checkbox at their left, matching the file rows (and the behavior of git UIs like lazygit).

Ticking a folder stages every changed file under it; unticking unstages them. The checkbox is tri-state:

- `+` — everything under the folder is unstaged
- `✓` — everything under the folder is staged
- `−` — mixed (some staged, some not); clicking stages the remaining unstaged entries

## How

Single-file change in `WorkingTreeSectionView.swift`:

- Added a `folderStageState(staged:unstaged:)` helper that derives the folder's aggregate tri-state from the entries already collected under it.
- Rendered a `StageChip` in the folder header row, right after the chevron (the chevron stays the leftmost collapse affordance; the checkbox sits in the same column as the child files').
- Clicking reuses the existing `onStageAll` / `onUnstageAll` callbacks and `groups.groups(under:)`, so a tick stages/unstages the whole subtree. No model or git-plumbing changes; renames and conflicts flow through the same paths already used by file rows.

The chip is a nested `Button` inside the folder's collapse `Button` — the same nesting file rows already use — so clicking the checkbox toggles staging without expanding/collapsing the folder.