### PR TITLE
fix(diff): gutter alignment

### DIFF
--- a/Alas/Sources/Center/Diff/DiffPaneTextDocumentBuilder.swift
+++ b/Alas/Sources/Center/Diff/DiffPaneTextDocumentBuilder.swift
@@ -484,14 +484,13 @@ struct DiffPaneTextDocumentBuilder {
         guard row.collapsedLineCount > 0 else {
             return "Expand context \(boundaryText)"
         }
-        return "\(row.collapsedLineCount) unchanged lines \(boundaryText)"
+        return "Expand \(row.collapsedLineCount) unchanged lines \(boundaryText)"
     }
 
     private static func collapsedTextAttributes(font: NSFont, theme: Theme) -> [NSAttributedString.Key: Any] {
         [
             .font: font,
             .foregroundColor: NSColor(theme.color("fg-dim")),
-            .backgroundColor: NSColor(theme.color("bg-2")),
             .paragraphStyle: CenterTypography.paragraphStyle(),
         ]
     }

--- a/Alas/Sources/Center/Diff/DiffPaneTextDocumentView.swift
+++ b/Alas/Sources/Center/Diff/DiffPaneTextDocumentView.swift
@@ -1005,7 +1005,7 @@ final class DiffPaneCodeTextView: NSTextView {
         layoutManager.ensureLayout(for: textContainer)
         let paragraphRanges = paragraphRanges(lineCount: lineTones.count)
         let origin = textContainerOrigin
-        var nextY = textContainerOrigin.y
+        var fallbackY = textContainerOrigin.y
 
         var rowRects: [NSRect] = []
         var firstLineFragmentRects: [NSRect] = []
@@ -1013,12 +1013,11 @@ final class DiffPaneCodeTextView: NSTextView {
         firstLineFragmentRects.reserveCapacity(paragraphRanges.count)
 
         for range in paragraphRanges {
-            let height = measuredRowHeight(for: range, layoutManager: layoutManager)
-            let rowRect = NSRect(
-                x: 0,
-                y: nextY,
-                width: max(bounds.width, visibleRect.width),
-                height: height
+            let rowRect = measuredRowRect(
+                for: range,
+                layoutManager: layoutManager,
+                origin: origin,
+                fallbackY: fallbackY
             )
             let firstRect = firstLineFragmentRect(
                 for: range,
@@ -1027,7 +1026,7 @@ final class DiffPaneCodeTextView: NSTextView {
             )
             rowRects.append(rowRect)
             firstLineFragmentRects.append(firstRect)
-            nextY += height
+            fallbackY = rowRect.maxY
         }
 
         return RowGeometry(rowRects: rowRects, firstLineFragmentRects: firstLineFragmentRects)
@@ -1290,6 +1289,8 @@ final class DiffPaneCodeTextView: NSTextView {
             rowRect.fill()
             if tone == .placeholder {
                 drawPlaceholderHatch(in: rowRect, theme: theme)
+            } else if lineMetadata.indices.contains(index), lineMetadata[index].kind == .expandableContext {
+                drawExpandableContextPill(row: index, in: rowRect, theme: theme)
             }
         }
     }
@@ -1316,19 +1317,36 @@ final class DiffPaneCodeTextView: NSTextView {
         return ranges
     }
 
-    private func measuredRowHeight(for range: NSRange, layoutManager: NSLayoutManager) -> CGFloat {
+    private func measuredRowRect(
+        for range: NSRange,
+        layoutManager: NSLayoutManager,
+        origin: NSPoint,
+        fallbackY: CGFloat
+    ) -> NSRect {
         let defaultHeight = layoutManager.defaultLineHeight(for: font ?? .monospacedSystemFont(ofSize: 13, weight: .regular))
-        guard range.length > 0 else { return defaultHeight }
+        let fallback = NSRect(
+            x: 0,
+            y: fallbackY,
+            width: max(bounds.width, visibleRect.width),
+            height: defaultHeight
+        )
+        guard range.length > 0 else { return fallback }
 
         let glyphRange = layoutManager.glyphRange(forCharacterRange: range, actualCharacterRange: nil)
-        guard glyphRange.length > 0 else { return defaultHeight }
+        guard glyphRange.length > 0 else { return fallback }
 
         var rowRect = NSRect.null
         layoutManager.enumerateLineFragments(forGlyphRange: glyphRange) { lineFragmentRect, _, _, _, _ in
             rowRect = rowRect.union(lineFragmentRect)
         }
-        guard !rowRect.isNull else { return defaultHeight }
-        return max(ceil(rowRect.height), defaultHeight)
+        guard !rowRect.isNull else { return fallback }
+
+        return NSRect(
+            x: 0,
+            y: rowRect.minY + origin.y,
+            width: max(bounds.width, visibleRect.width),
+            height: max(rowRect.height, defaultHeight)
+        )
     }
 
     private func firstLineFragmentRect(
@@ -1393,6 +1411,39 @@ final class DiffPaneCodeTextView: NSTextView {
         }
         path.lineWidth = 1
         NSColor(theme.color("line")).withAlphaComponent(0.35).setStroke()
+        path.stroke()
+    }
+
+    private func drawExpandableContextPill(row: Int, in rowRect: NSRect, theme: Theme) {
+        guard lineMetadata.indices.contains(row),
+              let layoutManager,
+              let textContainer
+        else {
+            return
+        }
+
+        let range = lineMetadata[row].range
+        guard range.length > 0 else { return }
+
+        let glyphRange = layoutManager.glyphRange(forCharacterRange: range, actualCharacterRange: nil)
+        guard glyphRange.length > 0 else { return }
+
+        let textRect = layoutManager.boundingRect(forGlyphRange: glyphRange, in: textContainer)
+            .offsetBy(dx: textContainerOrigin.x, dy: textContainerOrigin.y)
+        guard !textRect.isEmpty else { return }
+
+        let pillHeight = min(max(textRect.height + 6, 18), max(rowRect.height - 4, 1))
+        let pillRect = NSRect(
+            x: textRect.minX - 10,
+            y: rowRect.midY - pillHeight / 2,
+            width: textRect.width + 20,
+            height: pillHeight
+        )
+        let path = NSBezierPath(roundedRect: pillRect, xRadius: pillHeight / 2, yRadius: pillHeight / 2)
+        NSColor(theme.color("bg-1")).withAlphaComponent(0.72).setFill()
+        path.fill()
+        NSColor(theme.color("line")).withAlphaComponent(0.55).setStroke()
+        path.lineWidth = 1
         path.stroke()
     }
 }

--- a/AlasTests/DiffPaneViewTests.swift
+++ b/AlasTests/DiffPaneViewTests.swift
@@ -608,6 +608,47 @@ let second = true
         }
     }
 
+    @Test func longGutterRowsStayAlignedWithActualCodeLineFragments() throws {
+        let theme = theme()
+        let font = NSFont.monospacedSystemFont(ofSize: 13, weight: .regular)
+        let lines = (1...80).map { "let value\($0) = \($0)" }
+        let text = lines.joined(separator: "\n")
+        var location = 0
+        let metadata = lines.map { line in
+            defer { location += (line as NSString).length + 1 }
+            return DiffPaneTextDocumentBuilder.LineMetadata(
+                kind: .context,
+                range: NSRange(location: location, length: (line as NSString).length)
+            )
+        }
+        let document = DiffPaneTextDocumentBuilder.CodeDocument(
+            attributedString: NSAttributedString(string: text, attributes: [.font: font]),
+            lines: metadata
+        )
+        let scrollView = DiffPaneTextScrollView(frame: NSRect(x: 0, y: 0, width: 420, height: 360))
+
+        scrollView.update(
+            document: document,
+            lineLabels: lines.indices.map { "\($0 + 1)" },
+            wraps: false,
+            font: font,
+            theme: theme,
+            lspContext: nil,
+            allowedLSPSide: .new
+        )
+        scrollView.layoutSubtreeIfNeeded()
+
+        let codeView = try #require(scrollView.documentView as? DiffPaneCodeTextView)
+        let rowRects = codeView.diffRowRects()
+        let firstLineRects = codeView.diffFirstLineFragmentRects()
+
+        #expect(rowRects.count == lines.count)
+        #expect(firstLineRects.count == lines.count)
+        for index in lines.indices {
+            #expect(abs(rowRects[index].midY - firstLineRects[index].midY) < 0.75)
+        }
+    }
+
     @Test func gutterSelectionOutlineWrapsContiguousRows() {
         let rowRects = [
             NSRect(x: 0, y: 8, width: 42, height: 18),
@@ -1384,7 +1425,7 @@ let second = true
 
         #expect(result.oldGutter.string.components(separatedBy: "\n") == ["+"])
         #expect(result.newGutter.string.components(separatedBy: "\n") == [""])
-        #expect(result.oldCode.attributedString.string.components(separatedBy: "\n") == ["9 unchanged lines above"])
+        #expect(result.oldCode.attributedString.string.components(separatedBy: "\n") == ["Expand 9 unchanged lines above"])
         #expect(result.newCode.attributedString.string.components(separatedBy: "\n") == [" "])
         #expect(result.oldCode.lines.count == result.oldGutter.string.components(separatedBy: "\n").count)
         #expect(result.newCode.lines.count == result.newGutter.string.components(separatedBy: "\n").count)
@@ -1405,7 +1446,7 @@ let second = true
         )
 
         #expect(result.gutter.string.components(separatedBy: "\n") == ["+"])
-        #expect(result.code.attributedString.string.components(separatedBy: "\n") == ["7 unchanged lines below"])
+        #expect(result.code.attributedString.string.components(separatedBy: "\n") == ["Expand 7 unchanged lines below"])
         #expect(result.code.lines.count == result.gutter.string.components(separatedBy: "\n").count)
         #expect(result.code.lines.first?.expansionKey == DiffContextExpansionKey(groupID: "hunk-0", boundary: .below))
         #expect(result.code.lines.first?.expansionBoundary == .below)


### PR DESCRIPTION
## Summary
- Align diff gutter row geometry with AppKit text layout so long chunks do not drift.
- Polish expandable context rows as explicit rounded controls with clearer labels.
- Add a regression test for long-row gutter/code alignment.

## Test plan
- xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -only-testing:AlasTests/DiffPaneViewTests test