### PR TITLE
feat(editor): Highlight inline find matches in editor

### DIFF
--- a/Alas/Sources/Center/EditorTabView.swift
+++ b/Alas/Sources/Center/EditorTabView.swift
@@ -340,7 +340,8 @@ struct EditorTabView: View {
         findHighlightRenderer.render(
             matches: findController.matches,
             activeIndex: findController.activeMatchIndex,
-            color: NSColor.systemYellow.withAlphaComponent(0.28)
+            inactiveColor: NSColor.systemYellow.withAlphaComponent(0.28),
+            activeColor: NSColor.systemOrange.withAlphaComponent(0.38)
         )
     }
 

--- a/Alas/Sources/Code/Editor/EditorFindController.swift
+++ b/Alas/Sources/Code/Editor/EditorFindController.swift
@@ -247,10 +247,15 @@ final class EditorFindController {
 
         let text = textView.string as NSString
         let activeLocation = activeMatchIndex.flatMap { matches.indices.contains($0) ? matches[$0].location : nil }
+        let selectedRange = textView.selectedRange()
         matches = collectMatches(in: text)
         matchCount = matches.count
-        activeMatchIndex = activeLocation.flatMap { location in
-            matches.firstIndex { $0.location == location }
+        if rangeIsMatch(selectedRange, in: text) {
+            activeMatchIndex = matches.firstIndex { $0 == selectedRange }
+        } else {
+            activeMatchIndex = activeLocation.flatMap { location in
+                matches.firstIndex { $0.location == location }
+            }
         }
         return matchCount
     }

--- a/Alas/Sources/Code/Editor/EditorFindHighlightRenderer.swift
+++ b/Alas/Sources/Code/Editor/EditorFindHighlightRenderer.swift
@@ -18,14 +18,12 @@ final class EditorFindHighlightRenderer {
         }
 
         let textLength = (textView.string as NSString).length
-        guard textLength > 0 else { return }
-        layoutManager.removeTemporaryAttribute(
-            .backgroundColor,
-            forCharacterRange: NSRange(location: 0, length: textLength)
-        )
+        for range in markedRanges(layoutManager: layoutManager, textLength: textLength).reversed() {
+            clearMarkedRange(range, layoutManager: layoutManager)
+        }
     }
 
-    func render(matches: [NSRange], activeIndex: Int?, color: NSColor) {
+    func render(matches: [NSRange], activeIndex: Int?, inactiveColor: NSColor, activeColor: NSColor) {
         clear()
 
         guard let textView,
@@ -34,13 +32,94 @@ final class EditorFindHighlightRenderer {
 
         let textLength = (textView.string as NSString).length
         for (index, range) in matches.enumerated() {
-            guard index != activeIndex,
-                  range.location != NSNotFound,
-                  range.location >= 0,
-                  range.length > 0,
-                  NSMaxRange(range) <= textLength else { continue }
+            guard isRenderable(range: range, textLength: textLength) else { continue }
 
-            layoutManager.addTemporaryAttribute(.backgroundColor, value: color, forCharacterRange: range)
+            let color = index == activeIndex ? activeColor : inactiveColor
+            addFindBackground(color, for: range, layoutManager: layoutManager)
         }
     }
+
+    private func isRenderable(range: NSRange, textLength: Int) -> Bool {
+        guard range.location != NSNotFound,
+              range.location >= 0,
+              range.length > 0,
+              textLength > 0 else { return false }
+
+        return NSMaxRange(range) <= textLength
+    }
+
+    private func addFindBackground(_ color: NSColor, for range: NSRange, layoutManager: NSLayoutManager) {
+        var location = range.location
+        let end = NSMaxRange(range)
+        while location < end {
+            var effectiveRange = NSRange(location: location, length: end - location)
+            let previousBackground = layoutManager.temporaryAttribute(
+                .backgroundColor,
+                atCharacterIndex: location,
+                effectiveRange: &effectiveRange
+            )
+            let segment = effectiveRange.intersection(range) ?? NSRange(location: location, length: end - location)
+            guard segment.length > 0 else { break }
+
+            layoutManager.addTemporaryAttribute(
+                .editorFindPreviousBackgroundColor,
+                value: previousBackground ?? NSNull(),
+                forCharacterRange: segment
+            )
+            layoutManager.addTemporaryAttribute(.editorFindHighlightMarker, value: true, forCharacterRange: segment)
+            layoutManager.addTemporaryAttribute(.backgroundColor, value: color, forCharacterRange: segment)
+            location = NSMaxRange(segment)
+        }
+    }
+
+    private func markedRanges(layoutManager: NSLayoutManager, textLength: Int) -> [NSRange] {
+        guard textLength > 0 else { return [] }
+
+        var ranges: [NSRange] = []
+        var location = 0
+        while location < textLength {
+            var effectiveRange = NSRange(location: location, length: textLength - location)
+            let marker = layoutManager.temporaryAttribute(
+                .editorFindHighlightMarker,
+                atCharacterIndex: location,
+                effectiveRange: &effectiveRange
+            )
+            guard effectiveRange.length > 0 else { break }
+
+            if marker != nil {
+                ranges.append(effectiveRange)
+            }
+            location = NSMaxRange(effectiveRange)
+        }
+        return ranges
+    }
+
+    private func clearMarkedRange(_ range: NSRange, layoutManager: NSLayoutManager) {
+        var location = range.location
+        let end = NSMaxRange(range)
+        while location < end {
+            var effectiveRange = NSRange(location: location, length: end - location)
+            let previousBackground = layoutManager.temporaryAttribute(
+                .editorFindPreviousBackgroundColor,
+                atCharacterIndex: location,
+                effectiveRange: &effectiveRange
+            )
+            let segment = effectiveRange.intersection(range) ?? NSRange(location: location, length: end - location)
+            guard segment.length > 0 else { break }
+
+            layoutManager.removeTemporaryAttribute(.backgroundColor, forCharacterRange: segment)
+            if let color = previousBackground as? NSColor {
+                layoutManager.addTemporaryAttribute(.backgroundColor, value: color, forCharacterRange: segment)
+            }
+
+            layoutManager.removeTemporaryAttribute(.editorFindPreviousBackgroundColor, forCharacterRange: segment)
+            layoutManager.removeTemporaryAttribute(.editorFindHighlightMarker, forCharacterRange: segment)
+            location = NSMaxRange(segment)
+        }
+    }
+}
+
+private extension NSAttributedString.Key {
+    static let editorFindHighlightMarker = NSAttributedString.Key("alas.editorFindHighlightMarker")
+    static let editorFindPreviousBackgroundColor = NSAttributedString.Key("alas.editorFindPreviousBackgroundColor")
 }

--- a/AlasTests/EditorFindControllerTests.swift
+++ b/AlasTests/EditorFindControllerTests.swift
@@ -17,6 +17,14 @@ struct EditorFindControllerTests {
         return textView
     }
 
+    private func temporaryBackgroundColor(in textView: CodeTextView, at location: Int) -> NSColor? {
+        textView.layoutManager?.temporaryAttribute(
+            .backgroundColor,
+            atCharacterIndex: location,
+            effectiveRange: nil
+        ) as? NSColor
+    }
+
     @Test func replaceCurrentUpdatesText() {
         let textView = makeTextView("hello world")
         let controller = EditorFindController()
@@ -124,6 +132,23 @@ struct EditorFindControllerTests {
 
         #expect(count == 3)
         #expect(controller.matchCount == 3)
+    }
+
+    @Test func countMatchesPreservesActiveMatchFromCurrentSelectionAfterTextShifts() {
+        let textView = makeTextView("cat dog cat")
+        let controller = EditorFindController()
+        controller.textView = textView
+        controller.findString = "cat"
+        controller.refreshMatches(selecting: .first)
+        #expect(controller.selectNext() == true)
+
+        textView.textStorage?.replaceCharacters(in: NSRange(location: 0, length: 0), with: "big ")
+        textView.setSelectedRange(NSRange(location: 12, length: 3))
+        let count = controller.countMatches()
+
+        #expect(count == 2)
+        #expect(controller.matches.map(\.location) == [4, 12])
+        #expect(controller.activeMatchIndex == 1)
     }
 
     @Test func defaultSearchIsCaseInsensitive() {
@@ -341,5 +366,137 @@ struct EditorFindControllerTests {
 
         #expect(controller.replaceAll() == 0)
         #expect(textView.string == "hello hello")
+    }
+
+    @Test func findHighlightRendererPaintsActiveAndInactiveMatchesDifferently() {
+        let textView = makeTextView("cat dog cat dog cat")
+        let renderer = EditorFindHighlightRenderer()
+        let inactiveColor = NSColor.systemYellow.withAlphaComponent(0.28)
+        let activeColor = NSColor.systemOrange.withAlphaComponent(0.38)
+
+        renderer.attach(textView: textView)
+        renderer.render(
+            matches: [
+                NSRange(location: 0, length: 3),
+                NSRange(location: 8, length: 3),
+                NSRange(location: 16, length: 3),
+            ],
+            activeIndex: 1,
+            inactiveColor: inactiveColor,
+            activeColor: activeColor
+        )
+
+        #expect(temporaryBackgroundColor(in: textView, at: 0) == inactiveColor)
+        #expect(temporaryBackgroundColor(in: textView, at: 8) == activeColor)
+        #expect(temporaryBackgroundColor(in: textView, at: 16) == inactiveColor)
+    }
+
+    @Test func findHighlightRendererClearRemovesOnlyFindOwnedBackgrounds() {
+        let textView = makeTextView("cat dog cat dog")
+        let renderer = EditorFindHighlightRenderer()
+        let unrelatedColor = NSColor.systemBlue
+        let inactiveColor = NSColor.systemYellow.withAlphaComponent(0.28)
+        let activeColor = NSColor.systemOrange.withAlphaComponent(0.38)
+
+        textView.layoutManager?.addTemporaryAttribute(
+            .backgroundColor,
+            value: unrelatedColor,
+            forCharacterRange: NSRange(location: 4, length: 3)
+        )
+
+        renderer.attach(textView: textView)
+        renderer.render(
+            matches: [
+                NSRange(location: 0, length: 3),
+                NSRange(location: 8, length: 3),
+            ],
+            activeIndex: nil,
+            inactiveColor: inactiveColor,
+            activeColor: activeColor
+        )
+
+        renderer.clear()
+
+        #expect(temporaryBackgroundColor(in: textView, at: 0) == nil)
+        #expect(temporaryBackgroundColor(in: textView, at: 4) == unrelatedColor)
+    }
+
+    @Test func findHighlightRendererClearRestoresOverlappingTemporaryBackgrounds() {
+        let textView = makeTextView("cat dog cat")
+        let renderer = EditorFindHighlightRenderer()
+        let unrelatedColor = NSColor.systemBlue
+        let inactiveColor = NSColor.systemYellow.withAlphaComponent(0.28)
+        let activeColor = NSColor.systemOrange.withAlphaComponent(0.38)
+
+        textView.layoutManager?.addTemporaryAttribute(
+            .backgroundColor,
+            value: unrelatedColor,
+            forCharacterRange: NSRange(location: 2, length: 4)
+        )
+
+        renderer.attach(textView: textView)
+        renderer.render(
+            matches: [NSRange(location: 0, length: 7)],
+            activeIndex: nil,
+            inactiveColor: inactiveColor,
+            activeColor: activeColor
+        )
+        #expect(temporaryBackgroundColor(in: textView, at: 0) == inactiveColor)
+        #expect(temporaryBackgroundColor(in: textView, at: 3) == inactiveColor)
+        #expect(temporaryBackgroundColor(in: textView, at: 6) == inactiveColor)
+
+        renderer.clear()
+
+        #expect(temporaryBackgroundColor(in: textView, at: 0) == nil)
+        #expect(temporaryBackgroundColor(in: textView, at: 2) == unrelatedColor)
+        #expect(temporaryBackgroundColor(in: textView, at: 5) == unrelatedColor)
+        #expect(temporaryBackgroundColor(in: textView, at: 6) == nil)
+    }
+
+    @Test func findHighlightRendererClearRemovesHighlightsShiftedByTextEdits() {
+        let textView = makeTextView("prefix cat")
+        let renderer = EditorFindHighlightRenderer()
+        let inactiveColor = NSColor.systemYellow.withAlphaComponent(0.28)
+        let activeColor = NSColor.systemOrange.withAlphaComponent(0.38)
+
+        renderer.attach(textView: textView)
+        renderer.render(
+            matches: [NSRange(location: 7, length: 3)],
+            activeIndex: 0,
+            inactiveColor: inactiveColor,
+            activeColor: activeColor
+        )
+        #expect(temporaryBackgroundColor(in: textView, at: 7) == activeColor)
+
+        textView.textStorage?.replaceCharacters(in: NSRange(location: 0, length: 7), with: "")
+        #expect(temporaryBackgroundColor(in: textView, at: 0) == activeColor)
+
+        renderer.clear()
+
+        #expect(temporaryBackgroundColor(in: textView, at: 0) == nil)
+    }
+
+    @Test func findHighlightRendererIgnoresInvalidRanges() {
+        let textView = makeTextView("cat")
+        let renderer = EditorFindHighlightRenderer()
+        let inactiveColor = NSColor.systemYellow.withAlphaComponent(0.28)
+        let activeColor = NSColor.systemOrange.withAlphaComponent(0.38)
+
+        renderer.attach(textView: textView)
+        renderer.render(
+            matches: [
+                NSRange(location: 0, length: 1),
+                NSRange(location: 1, length: 99),
+                NSRange(location: 99, length: 3),
+                NSRange(location: 1, length: 0),
+                NSRange(location: NSNotFound, length: 1),
+            ],
+            activeIndex: 0,
+            inactiveColor: inactiveColor,
+            activeColor: activeColor
+        )
+
+        #expect(temporaryBackgroundColor(in: textView, at: 0) == activeColor)
+        #expect(temporaryBackgroundColor(in: textView, at: 1) == nil)
     }
 }

--- a/docs/superpowers/specs/2026-06-19-editor-inline-find-active-highlight-design.md
+++ b/docs/superpowers/specs/2026-06-19-editor-inline-find-active-highlight-design.md
@@ -1,0 +1,110 @@
+# Editor Inline Find Active Highlight Design
+
+## Context
+
+Alas already has a custom inline editor find/replace flow for `Cmd-F` and
+related find commands. The current implementation computes all matches in
+`EditorFindController`, selects the active match in the `CodeTextView`, and
+uses `EditorFindHighlightRenderer` to paint non-active matches with temporary
+background attributes.
+
+The active match is currently skipped by the renderer because it is represented
+by the native `NSTextView` selection. That makes the current match less
+visually consistent with other editors when focus is in the find field or when
+the selection appearance is subtle.
+
+## Goal
+
+While inline find or replace mode is open, every current match should be
+visually marked in the editor. The active/current match should be distinct from
+the inactive matches, following the standard behavior in editors such as VS
+Code, IntelliJ, and Zed.
+
+The highlighting should clear when:
+
+- The find/replace UI closes.
+- The query becomes empty.
+- The query has no matches.
+- The editor tab detaches or disappears.
+
+## Non-Goals
+
+- Do not change match finding semantics.
+- Do not change replace behavior.
+- Do not introduce minimap, scrollbar, or overview-ruler markers.
+- Do not reuse the content-search reveal behavior directly, because reveal
+  highlights whole lines temporarily while inline find needs exact match ranges
+  for as long as find mode is open.
+- Do not customize global AppKit selection colors.
+
+## Design
+
+`EditorFindController` remains the source of truth for:
+
+- The current find string.
+- Case sensitivity.
+- The non-overlapping match ranges.
+- The active match index.
+- The native text selection and scroll-to-visible behavior.
+
+`EditorFindHighlightRenderer` should render both inactive and active matches
+using temporary layout-manager attributes. It should no longer skip the active
+range entirely. Instead, it should apply:
+
+- A muted warm background to inactive match ranges.
+- A stronger warm background to the active match range.
+
+The active native selection remains in place. It still drives replacement,
+keyboard navigation, caret behavior, and scroll position. The temporary active
+highlight is an additional visual marker, not a replacement for selection.
+
+The first implementation should use background colors only. Exact-range
+underlines or outlines are a separate follow-up and are out of scope for this
+change.
+
+## Data Flow
+
+1. `EditorTabView` receives a find command and shows the find or replace bar.
+2. `EditorFindController.refreshMatches` computes `matches` and optionally
+   selects an active match.
+3. `EditorTabView.updateFindStatus` updates status text and calls
+   `renderFindHighlights`.
+4. `EditorFindHighlightRenderer.render` clears stale find-owned temporary
+   attributes, then paints inactive and active match ranges.
+5. Navigation changes the active index through `EditorFindController`, then
+   re-renders highlights.
+6. Closing find mode, empty queries, no-match state, tab detach, and tab
+   disappearance call `clearFindHighlights`.
+
+## Edge Cases
+
+- Invalid or stale ranges should be ignored during rendering. This mirrors the
+  current renderer behavior and avoids temporary-attribute operations outside
+  the current text length.
+- Empty matches are ignored.
+- When document text changes while find is open, `EditorTabView` already
+  recounts matches through `handleEditorTextChanged`; the renderer should
+  simply render the refreshed ranges.
+- Temporary find highlighting should not remove unrelated temporary attributes
+  more broadly than necessary. The current renderer removes `.backgroundColor`
+  across the document for find cleanup; this change should keep cleanup limited
+  to the background attributes used for find highlights.
+
+## Testing
+
+Add focused tests around the renderer and existing find controller integration:
+
+- Rendering includes the active match instead of skipping it.
+- Inactive matches and the active match receive different temporary visual
+  attributes.
+- Clearing find highlights removes the temporary attributes used by the
+  renderer.
+- Existing find controller navigation and replace tests continue to pass.
+
+Run focused verification:
+
+```bash
+xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -only-testing:AlasTests/EditorFindControllerTests -only-testing:AlasTests/EditorBufferTests -quiet test
+swiftformat Alas AlasTests --lint --reporter github-actions-log
+xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -quiet build
+```


### PR DESCRIPTION
## Summary
- Highlight every inline editor find match while search mode is active, with a distinct active-match color.
- Track find-owned temporary highlight attributes so cleanup follows text edits and restores overlapping temporary backgrounds.
- Preserve the active match from the current editor selection when matches are recounted after edits.

## Local Validation
- `swiftformat Alas/Sources/Code/Editor/EditorFindHighlightRenderer.swift Alas/Sources/Code/Editor/EditorFindController.swift Alas/Sources/Center/EditorTabView.swift AlasTests/EditorFindControllerTests.swift --lint --reporter github-actions-log`
- `xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -only-testing:AlasTests/EditorFindControllerTests -only-testing:AlasTests/EditorBufferTests -quiet test`

## Review
- Spec compliance review passed.
- Focused quality review passed.
- Final code review passed.

## Notes
- Full-suite coverage is left to CI for this PR.