### PR TITLE
feat(files): compact single-child directory chains

### DIFF
--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -679,6 +679,7 @@
 		A06C59805BCD9D3200896932 /* StagedDiffLoader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3B2FEDAAF927CDC9E4D19551 /* StagedDiffLoader.swift */; };
 		A0B5074B10E732616C917D10 /* DragHandleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1379AD82025AFEABD37EFC42 /* DragHandleTests.swift */; };
 		A0F1E46BC1A9E2CC21805EE7 /* FilesTabFilterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1977C85C3DFD1F232A2755AD /* FilesTabFilterTests.swift */; };
+			87FB4EA6D3524EF48AE139F8 /* FilesTabCompactChainTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B296C473B653492BA22CA625 /* FilesTabCompactChainTests.swift */; };
 		A1252F6D967104D2B369CEA8 /* ReviewFeedbackBundleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C84E444E25F7DDBE30FB824 /* ReviewFeedbackBundleTests.swift */; };
 		A139CD869FCFF8F4CFB7E50D /* ACPSyntaxHighlightedText.swift in Sources */ = {isa = PBXBuildFile; fileRef = C72B05E51A4C6FAE18666DBC /* ACPSyntaxHighlightedText.swift */; };
 		A15C8E0D7A942160A74BD68E /* ImageDiffPairResolver.swift in Sources */ = {isa = PBXBuildFile; fileRef = D568D53950A3CA2CD1F4EECB /* ImageDiffPairResolver.swift */; };
@@ -1209,6 +1210,7 @@
 		18B5372BF572EBA3A84113E4 /* AgentLifecycleEventMapperTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentLifecycleEventMapperTests.swift; sourceTree = "<group>"; };
 		18CA47D5E0D1BF962CF45ABE /* AgentHookInstallNudgeBanner.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentHookInstallNudgeBanner.swift; sourceTree = "<group>"; };
 		1977C85C3DFD1F232A2755AD /* FilesTabFilterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FilesTabFilterTests.swift; sourceTree = "<group>"; };
+			B296C473B653492BA22CA625 /* FilesTabCompactChainTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FilesTabCompactChainTests.swift; sourceTree = "<group>"; };
 		19C327BB65463E878DDCDA5E /* MarkdownFileTypeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MarkdownFileTypeTests.swift; sourceTree = "<group>"; };
 		1A17A797374500E1FDD2382C /* PersistenceStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PersistenceStore.swift; sourceTree = "<group>"; };
 		1A5A3E6B2F9AC2CBB1CDA78E /* ACPHarnessBridgeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPHarnessBridgeTests.swift; sourceTree = "<group>"; };
@@ -2433,6 +2435,7 @@
 				25493E3B18A1AB94EA6985C3 /* EventHolder.swift */,
 				3855FBA3E4444960418639E9 /* FileIndexTests.swift */,
 				1977C85C3DFD1F232A2755AD /* FilesTabFilterTests.swift */,
+						B296C473B653492BA22CA625 /* FilesTabCompactChainTests.swift */,
 				0C8541BE5617C7E212CCD034 /* FilesTabLoadingIndicatorTests.swift */,
 				3ABD3A575FAEC381A5744BFA /* FileTreeBuilderTests.swift */,
 				2CBAD18141C1A9B654F56982 /* FileTypeIconTests.swift */,
@@ -5178,6 +5181,7 @@
 				D85B5032B8F2A71AFF5A13B6 /* FileTreeBuilderTests.swift in Sources */,
 				6ED129AC9B6798F76F7D3A51 /* FileTypeIconTests.swift in Sources */,
 				A0F1E46BC1A9E2CC21805EE7 /* FilesTabFilterTests.swift in Sources */,
+						87FB4EA6D3524EF48AE139F8 /* FilesTabCompactChainTests.swift in Sources */,
 				DABD0B9B7817F4A080512501 /* FilesTabLoadingIndicatorTests.swift in Sources */,
 				F6442CEA8D80C6845ABF0A63 /* FocusDirectionTests.swift in Sources */,
 				3E0A4613EB8F41DA8C182C36 /* FormatOnSaveTests.swift in Sources */,

--- a/Alas/Sources/Right/FilesTabView.swift
+++ b/Alas/Sources/Right/FilesTabView.swift
@@ -70,17 +70,19 @@ struct FilesTabView: View {
 
     private func renderNode(_ node: FileTreeNode, depth: Int) -> AnyView {
         if node.kind == .dir {
-            let open = openPaths.contains(node.path)
-            let canExpand = !node.isSubmodule
+            let chain = Self.compactChain(from: node)
+            let terminal = chain.terminal
+            let open = openPaths.contains(terminal.path)
+            let canExpand = !terminal.isSubmodule
             return AnyView(
                 Group {
                     Button {
                         guard canExpand else { return }
                         if open {
-                            openPaths.remove(node.path)
+                            for p in chain.chainPaths { openPaths.remove(p) }
                         } else {
-                            openPaths.insert(node.path)
-                            onLoadChildren(node.path)
+                            for p in chain.chainPaths { openPaths.insert(p) }
+                            onLoadChildren(terminal.path)
                         }
                     } label: {
                         HStack(spacing: 6) {
@@ -91,62 +93,62 @@ struct FilesTabView: View {
                                 Color.clear.frame(width: 14, height: 14)
                             }
                             FolderIconView(
-                                name: node.name,
-                                path: node.path,
+                                name: terminal.name,
+                                path: terminal.path,
                                 open: open,
-                                fallbackColor: folderColor(for: node, open: open)
+                                fallbackColor: folderColor(for: terminal, open: open)
                             )
-                            Text(node.name)
+                            Text(chain.displayName)
                                 .font(.system(size: 11.5, design: .monospaced))
-                                .foregroundColor(rowForeground(for: node))
+                                .foregroundColor(rowForeground(for: terminal))
                                 .lineLimit(1)
                                 .truncationMode(.middle)
                             Spacer()
-                            if node.isSubmodule {
+                            if terminal.isSubmodule {
                                 submodulePill
                             }
-                            if let badge = node.badge {
+                            if let badge = terminal.badge {
                                 StatusBadge(status: badge)
                             }
-                            if isOffGit(node) {
-                                visibilityPill(node)
+                            if isOffGit(terminal) {
+                                visibilityPill(terminal)
                             }
-                            if Self.showsInlineLoadingIndicator(for: node, open: open, canExpand: canExpand) {
+                            if Self.showsInlineLoadingIndicator(for: terminal, open: open, canExpand: canExpand) {
                                 Spinner(lineWidth: 1.5, duration: 0.7)
                                     .frame(width: 12, height: 12)
-                                    .accessibilityLabel("Loading \(node.name)")
+                                    .accessibilityLabel("Loading \(terminal.name)")
                             }
                         }
                         .padding(.leading, CGFloat(12 + depth * 14))
                         .padding(.trailing, 12)
                         .padding(.vertical, 4)
                         .frame(maxWidth: .infinity, alignment: .leading)
-                        .opacity(isOffGit(node) ? 0.72 : 1.0)
+                        .opacity(isOffGit(terminal) ? 0.72 : 1.0)
                         .overlay(alignment: .leading) {
-                            if isOffGit(node) {
+                            if isOffGit(terminal) {
                                 ghostRail(depth: depth)
                             }
                         }
                         .contentShape(Rectangle())
-                        .background(node.path == revealPath ? theme.color("bg-hover") : Color.clear)
-                        .id(node.id)
+                        .background(terminal.path == revealPath ? theme.color("bg-hover") : Color.clear)
+                        .id("dir:\(terminal.path)")
                     }
                     .buttonStyle(.plain)
                     if open && canExpand {
-                        switch node.childrenState {
+                        switch terminal.childrenState {
                         case .loading, .loaded:
-                            renderChildren(of: node, depth: depth + 1)
+                            renderChildren(of: terminal, depth: depth + 1)
                         case .failed:
                             treeMessage("Could not load children", depth: depth + 1)
-                            renderChildren(of: node, depth: depth + 1)
+                            renderChildren(of: terminal, depth: depth + 1)
                         case .notLoaded:
                             EmptyView()
                         }
                     }
                 }
-                .task(id: loadTaskID(for: node, open: open)) {
-                    if shouldAutoLoadChildren(for: node, open: open) {
-                        onLoadChildren(node.path)
+                .task(id: loadTaskID(for: terminal, open: open)) {
+                    if shouldAutoLoadChildren(for: terminal, open: open) {
+                        onLoadChildren(terminal.path)
                     }
                 }
             )

--- a/Alas/Sources/Right/FilesTabView.swift
+++ b/Alas/Sources/Right/FilesTabView.swift
@@ -256,7 +256,8 @@ struct FilesTabView: View {
                 let children = current.children,
                 children.count == 1,
                 children[0].kind == .dir,
-                !children[0].isSubmodule
+                !children[0].isSubmodule,
+                children[0].childrenState == .loaded
             else { break }
             let next = children[0]
             displayParts.append(next.name)

--- a/Alas/Sources/Right/FilesTabView.swift
+++ b/Alas/Sources/Right/FilesTabView.swift
@@ -81,8 +81,10 @@ struct FilesTabView: View {
                         if open {
                             for p in chain.chainPaths { openPaths.remove(p) }
                         } else {
-                            for p in chain.chainPaths { openPaths.insert(p) }
-                            onLoadChildren(terminal.path)
+                            for p in chain.chainPaths {
+                                openPaths.insert(p)
+                                onLoadChildren(p)
+                            }
                         }
                     } label: {
                         HStack(spacing: 6) {

--- a/Alas/Sources/Right/FilesTabView.swift
+++ b/Alas/Sources/Right/FilesTabView.swift
@@ -266,7 +266,8 @@ struct FilesTabView: View {
                 children.count == 1,
                 children[0].kind == .dir,
                 !children[0].isSubmodule,
-                children[0].childrenState == .loaded
+                children[0].childrenState == .loaded,
+                children[0].visibility == current.visibility
             else { break }
             let next = children[0]
             displayParts.append(next.name)

--- a/Alas/Sources/Right/FilesTabView.swift
+++ b/Alas/Sources/Right/FilesTabView.swift
@@ -155,7 +155,7 @@ struct FilesTabView: View {
                 }
                 .task(id: loadTaskID(for: terminal, open: open)) {
                     if shouldAutoLoadChildren(for: terminal, open: open) {
-                        onLoadChildren(terminal.path)
+                        for p in chain.chainPaths { onLoadChildren(p) }
                     }
                 }
             )

--- a/Alas/Sources/Right/FilesTabView.swift
+++ b/Alas/Sources/Right/FilesTabView.swift
@@ -132,8 +132,13 @@ struct FilesTabView: View {
                             }
                         }
                         .contentShape(Rectangle())
-                        .background(terminal.path == revealPath ? theme.color("bg-hover") : Color.clear)
+                        .background(chain.chainPaths.contains(revealPath ?? "") ? theme.color("bg-hover") : Color.clear)
                         .id("dir:\(terminal.path)")
+                        .overlay(alignment: .top) {
+                            ForEach(chain.chainPaths.dropLast(), id: \.self) { p in
+                                Color.clear.frame(width: 0, height: 0).id("dir:\(p)")
+                            }
+                        }
                     }
                     .buttonStyle(.plain)
                     if open && canExpand {

--- a/Alas/Sources/Right/FilesTabView.swift
+++ b/Alas/Sources/Right/FilesTabView.swift
@@ -242,6 +242,30 @@ struct FilesTabView: View {
         path.split(separator: "/").last.map(String.init) ?? path
     }
 
+    nonisolated static func compactChain(
+        from node: FileTreeNode
+    ) -> (displayName: String, chainPaths: [String], terminal: FileTreeNode) {
+        var displayParts = [node.name]
+        var chainPaths = [node.path]
+        var current = node
+        while true {
+            guard
+                current.kind == .dir,
+                !current.isSubmodule,
+                current.childrenState == .loaded,
+                let children = current.children,
+                children.count == 1,
+                children[0].kind == .dir,
+                !children[0].isSubmodule
+            else { break }
+            let next = children[0]
+            displayParts.append(next.name)
+            chainPaths.append(next.path)
+            current = next
+        }
+        return (displayParts.joined(separator: "/"), chainPaths, current)
+    }
+
     private func isOffGit(_ node: FileTreeNode) -> Bool {
         node.visibility == .ignored || node.visibility == .excluded
     }

--- a/AlasTests/FilesTabCompactChainTests.swift
+++ b/AlasTests/FilesTabCompactChainTests.swift
@@ -1,0 +1,130 @@
+import Testing
+@testable import Alas
+
+struct FilesTabCompactChainTests {
+    // MARK: - Helpers
+
+    private func dir(
+        name: String,
+        path: String,
+        children: [FileTreeNode]? = nil,
+        childrenState: DirectoryChildrenState = .loaded,
+        isSubmodule: Bool = false
+    ) -> FileTreeNode {
+        FileTreeNode(
+            name: name,
+            path: path,
+            kind: .dir,
+            children: children,
+            badge: nil,
+            childrenState: childrenState,
+            isSubmodule: isSubmodule
+        )
+    }
+
+    private func file(name: String, path: String) -> FileTreeNode {
+        FileTreeNode(name: name, path: path, kind: .file, children: nil, badge: nil)
+    }
+
+    // MARK: - Tests
+
+    @Test func fileNodeReturnsItself() {
+        let node = file(name: "App.swift", path: "App.swift")
+        let result = FilesTabView.compactChain(from: node)
+        #expect(result.displayName == "App.swift")
+        #expect(result.chainPaths == ["App.swift"])
+        #expect(result.terminal.path == "App.swift")
+    }
+
+    @Test func dirWithNoChildrenReturnsItself() {
+        let node = dir(name: "src", path: "src", children: [])
+        let result = FilesTabView.compactChain(from: node)
+        #expect(result.displayName == "src")
+        #expect(result.chainPaths == ["src"])
+        #expect(result.terminal.path == "src")
+    }
+
+    @Test func dirWithTwoChildrenReturnsItself() {
+        let node = dir(name: "src", path: "src", children: [
+            dir(name: "main", path: "src/main"),
+            dir(name: "test", path: "src/test")
+        ])
+        let result = FilesTabView.compactChain(from: node)
+        #expect(result.displayName == "src")
+        #expect(result.chainPaths == ["src"])
+        #expect(result.terminal.path == "src")
+    }
+
+    @Test func dirWithOneFileChildReturnsItself() {
+        let node = dir(name: "src", path: "src", children: [
+            file(name: "main.swift", path: "src/main.swift")
+        ])
+        let result = FilesTabView.compactChain(from: node)
+        #expect(result.displayName == "src")
+        #expect(result.chainPaths == ["src"])
+        #expect(result.terminal.path == "src")
+    }
+
+    @Test func singleChildDirChainDepth1() {
+        let node = dir(name: "src", path: "src", children: [
+            dir(name: "main", path: "src/main", children: [
+                file(name: "App.swift", path: "src/main/App.swift")
+            ])
+        ])
+        let result = FilesTabView.compactChain(from: node)
+        #expect(result.displayName == "src/main")
+        #expect(result.chainPaths == ["src", "src/main"])
+        #expect(result.terminal.path == "src/main")
+    }
+
+    @Test func singleChildDirChainDepth3() {
+        let leaf = dir(name: "example", path: "src/main/java/example", children: [
+            file(name: "Main.java", path: "src/main/java/example/Main.java")
+        ])
+        let java = dir(name: "java", path: "src/main/java", children: [leaf])
+        let main = dir(name: "main", path: "src/main", children: [java])
+        let src = dir(name: "src", path: "src", children: [main])
+        let result = FilesTabView.compactChain(from: src)
+        #expect(result.displayName == "src/main/java/example")
+        #expect(result.chainPaths == ["src", "src/main", "src/main/java", "src/main/java/example"])
+        #expect(result.terminal.path == "src/main/java/example")
+    }
+
+    @Test func chainStopsAtNotLoadedChild() {
+        let node = dir(name: "src", path: "src", children: [
+            dir(name: "main", path: "src/main", childrenState: .notLoaded)
+        ])
+        let result = FilesTabView.compactChain(from: node)
+        #expect(result.displayName == "src")
+        #expect(result.chainPaths == ["src"])
+        #expect(result.terminal.path == "src")
+    }
+
+    @Test func chainStopsAtLoadingChild() {
+        let node = dir(name: "src", path: "src", children: [
+            dir(name: "main", path: "src/main", childrenState: .loading)
+        ])
+        let result = FilesTabView.compactChain(from: node)
+        #expect(result.displayName == "src")
+        #expect(result.chainPaths == ["src"])
+        #expect(result.terminal.path == "src")
+    }
+
+    @Test func submoduleDirIsNotCompacted() {
+        let node = dir(name: "vendor", path: "vendor", isSubmodule: true)
+        let result = FilesTabView.compactChain(from: node)
+        #expect(result.displayName == "vendor")
+        #expect(result.chainPaths == ["vendor"])
+        #expect(result.terminal.path == "vendor")
+    }
+
+    @Test func chainStopsBeforeSubmoduleChild() {
+        let node = dir(name: "src", path: "src", children: [
+            dir(name: "sub", path: "src/sub", isSubmodule: true)
+        ])
+        let result = FilesTabView.compactChain(from: node)
+        #expect(result.displayName == "src")
+        #expect(result.chainPaths == ["src"])
+        #expect(result.terminal.path == "src")
+    }
+}

--- a/AlasTests/FilesTabCompactChainTests.swift
+++ b/AlasTests/FilesTabCompactChainTests.swift
@@ -9,6 +9,7 @@ struct FilesTabCompactChainTests {
         path: String,
         children: [FileTreeNode]? = nil,
         childrenState: DirectoryChildrenState = .loaded,
+        visibility: FileVisibility = .tracked,
         isSubmodule: Bool = false
     ) -> FileTreeNode {
         FileTreeNode(
@@ -17,6 +18,7 @@ struct FilesTabCompactChainTests {
             kind: .dir,
             children: children,
             badge: nil,
+            visibility: visibility,
             childrenState: childrenState,
             isSubmodule: isSubmodule
         )
@@ -126,5 +128,29 @@ struct FilesTabCompactChainTests {
         #expect(result.displayName == "src")
         #expect(result.chainPaths == ["src"])
         #expect(result.terminal.path == "src")
+    }
+
+    @Test func chainStopsAtVisibilityBoundary() {
+        let node = dir(name: "ignored", path: "ignored", children: [
+            dir(name: "tracked", path: "ignored/tracked", children: [
+                file(name: "App.swift", path: "ignored/tracked/App.swift")
+            ])
+        ], visibility: .ignored)
+        let result = FilesTabView.compactChain(from: node)
+        #expect(result.displayName == "ignored")
+        #expect(result.chainPaths == ["ignored"])
+        #expect(result.terminal.path == "ignored")
+    }
+
+    @Test func chainContinuesWithSameVisibility() {
+        let node = dir(name: "ignored", path: "ignored", children: [
+            dir(name: "child", path: "ignored/child", children: [
+                file(name: "cache.log", path: "ignored/child/cache.log")
+            ], visibility: .ignored)
+        ], visibility: .ignored)
+        let result = FilesTabView.compactChain(from: node)
+        #expect(result.displayName == "ignored/child")
+        #expect(result.chainPaths == ["ignored", "ignored/child"])
+        #expect(result.terminal.path == "ignored/child")
     }
 }


### PR DESCRIPTION
## Summary

- Adds `compactChain(from:)` to `FilesTabView` — detects single-child directory chains at render time and merges them into one row (e.g. `src/main/java/com/example`)
- Updates `renderNode` to use the compact chain: displays joined path label, toggles all chain paths together on click, uses terminal node for badges/pills/children
- Chain stops gracefully at: 2+ children, file children, unloaded dirs, or submodules — these show as normal rows

## Test Plan

- [x] 10 unit tests covering all `compactChain` boundary conditions (`FilesTabCompactChainTests`)
- [x] Existing FilesTab, FileTreeBuilder tests all pass
- [ ] Manual: open a project with deep single-child dirs (e.g. Java/Kotlin src tree) and verify chains collapse