### PR TITLE
feat(commands): add terminal worktree and review commands

### DIFF
--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -682,6 +682,7 @@
 		A0B5074B10E732616C917D10 /* DragHandleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1379AD82025AFEABD37EFC42 /* DragHandleTests.swift */; };
 		A0F1E46BC1A9E2CC21805EE7 /* FilesTabFilterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1977C85C3DFD1F232A2755AD /* FilesTabFilterTests.swift */; };
 		A1252F6D967104D2B369CEA8 /* ReviewFeedbackBundleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C84E444E25F7DDBE30FB824 /* ReviewFeedbackBundleTests.swift */; };
+		A127B7AA4E95BEF74927FBDE /* WorktreePathTemplateRendererTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 71196F28AFF66FFA70E008D6 /* WorktreePathTemplateRendererTests.swift */; };
 		A139CD869FCFF8F4CFB7E50D /* ACPSyntaxHighlightedText.swift in Sources */ = {isa = PBXBuildFile; fileRef = C72B05E51A4C6FAE18666DBC /* ACPSyntaxHighlightedText.swift */; };
 		A15C8E0D7A942160A74BD68E /* ImageDiffPairResolver.swift in Sources */ = {isa = PBXBuildFile; fileRef = D568D53950A3CA2CD1F4EECB /* ImageDiffPairResolver.swift */; };
 		A19649A790595DF4F48C3824 /* TerminalService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1AFC62A30044F71F0F16C3FB /* TerminalService.swift */; };
@@ -1035,6 +1036,7 @@
 		EF276F4856AA2E82C2ECDC7E /* CodeHostModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = C96C5E43E973803E6FD1528C /* CodeHostModels.swift */; };
 		F04E4353813EB99D4459750F /* ReviewRequestDiffLoader.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD0A56D300AE7380A16F1D42 /* ReviewRequestDiffLoader.swift */; };
 		F078F588859E4B2E906D704A /* AlasToggle.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1841997CCBDB9611576B930C /* AlasToggle.swift */; };
+		F098EBE9088B2EE1DAAF1BFD /* WorktreePathTemplateRenderer.swift in Sources */ = {isa = PBXBuildFile; fileRef = DCD333CD0765908F6657E824 /* WorktreePathTemplateRenderer.swift */; };
 		F0CB2589DDF3082F6996A117 /* ACPPlanSidebarVisibilityTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 96A230290E0029D45CA1B907 /* ACPPlanSidebarVisibilityTests.swift */; };
 		F1299CAAD4DBF766CC56CB8F /* OpenSessions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4068B3E83F9A82C2E3F8A6A1 /* OpenSessions.swift */; };
 		F18EB035A8972F21D23F3810 /* SearchFooter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 39DFD138FE855D8CFC464847 /* SearchFooter.swift */; };
@@ -1588,6 +1590,7 @@
 		708AB670AB611EFB9D216D7C /* UpdateThrottleTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UpdateThrottleTests.swift; sourceTree = "<group>"; };
 		7094534860369BA79FC5A877 /* session-update-plan.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "session-update-plan.json"; sourceTree = "<group>"; };
 		7095EA2868EF619BA4202BDF /* MergeScrollCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MergeScrollCoordinator.swift; sourceTree = "<group>"; };
+		71196F28AFF66FFA70E008D6 /* WorktreePathTemplateRendererTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorktreePathTemplateRendererTests.swift; sourceTree = "<group>"; };
 		711F3E7BD099EDADEA0802FD /* NewWorktreeDialog.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NewWorktreeDialog.swift; sourceTree = "<group>"; };
 		71A2A074CEB9C9BA2AD34DD7 /* CenterSelectionStateResolverTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CenterSelectionStateResolverTests.swift; sourceTree = "<group>"; };
 		71BFAD7D324EEAE4DA5D402E /* TerminalTabStateCodableTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TerminalTabStateCodableTests.swift; sourceTree = "<group>"; };
@@ -2018,6 +2021,7 @@
 		DC3692D5EB4BCA66AB702D43 /* ACPAgentProfiles.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPAgentProfiles.swift; sourceTree = "<group>"; };
 		DC73B8AC6AC57FB3A3253F40 /* ReviewScopeSelectionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReviewScopeSelectionTests.swift; sourceTree = "<group>"; };
 		DC76F9150CC29A324D785C29 /* ACPDelayedHoverVisibilityTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPDelayedHoverVisibilityTests.swift; sourceTree = "<group>"; };
+		DCD333CD0765908F6657E824 /* WorktreePathTemplateRenderer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorktreePathTemplateRenderer.swift; sourceTree = "<group>"; };
 		DD1F34E025D235A5CECCE36E /* ACPSessionUpdate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPSessionUpdate.swift; sourceTree = "<group>"; };
 		DDE8B45ECF898B83A616586D /* SubHeader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SubHeader.swift; sourceTree = "<group>"; };
 		DE2AC16E9220C05F670BE3EB /* ACPMarkdownText.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPMarkdownText.swift; sourceTree = "<group>"; };
@@ -2601,6 +2605,7 @@
 				AB4C1B7737A289066E01C444 /* WorkspaceLSPManagerStatusTests.swift */,
 				8B94010802299E6AC5597E85 /* WorktreeCodableTests.swift */,
 				3B7BE659F7E386D15047C374 /* WorktreeCreateFetchTests.swift */,
+				71196F28AFF66FFA70E008D6 /* WorktreePathTemplateRendererTests.swift */,
 				C6C27094E7804D975635EB11 /* WorktreeRowHeightTests.swift */,
 				6BA2F208DBC024A64D0ED065 /* WorktreeServiceCreatedAtTests.swift */,
 				D36137279CD9028BB6FFED0B /* WorktreeServiceTests.swift */,
@@ -4095,6 +4100,7 @@
 				69024633944E9FFF6DA76FAE /* RootView.swift */,
 				51B868809675C4110044C92E /* SpacesManager.swift */,
 				941BC60920D6A87164610273 /* WorktreeLaunchSurface.swift */,
+				DCD333CD0765908F6657E824 /* WorktreePathTemplateRenderer.swift */,
 				F211897D927000B71316F28A /* WindowChrome */,
 			);
 			path = App;
@@ -4940,6 +4946,7 @@
 				22FDE2FB05952993DA2D0EB7 /* WorkingTreeSectionView.swift in Sources */,
 				8E2FB28D4C7681611BC67537 /* WorkspaceLSPManager.swift in Sources */,
 				9D2E53FB0A57BC38C146EA5E /* WorktreeLaunchSurface.swift in Sources */,
+				F098EBE9088B2EE1DAAF1BFD /* WorktreePathTemplateRenderer.swift in Sources */,
 				4ECFD27396367A9A81D52A0D /* WorktreeRowView.swift in Sources */,
 				9A3EB3ACA3AB366431C904EB /* WorktreeService.swift in Sources */,
 				E681EB5B83BAC199B1ED5E24 /* WorktreeWatcher.swift in Sources */,
@@ -5399,6 +5406,7 @@
 				BE70DBB10DB7106860886AD7 /* WorkspaceLSPManagerStatusTests.swift in Sources */,
 				B34227BF866AFDACB3194333 /* WorktreeCodableTests.swift in Sources */,
 				8B0593FC9BC9E683E0685DD0 /* WorktreeCreateFetchTests.swift in Sources */,
+				A127B7AA4E95BEF74927FBDE /* WorktreePathTemplateRendererTests.swift in Sources */,
 				E6C5CD34C39ECF114DC3D4B4 /* WorktreeRowHeightTests.swift in Sources */,
 				2735F19DF0AD717CA3CF3B23 /* WorktreeServiceCreatedAtTests.swift in Sources */,
 				CB549B27BB0E578776AA7ED0 /* WorktreeServiceTests.swift in Sources */,

--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -8,6 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		004A8BA5B9353F67AAA3AE83 /* NotificationService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2975A1465CA308E9766521F2 /* NotificationService.swift */; };
+		00D95534280A5CED2356D06D /* AlasCLIWorktreeResolver.swift in Sources */ = {isa = PBXBuildFile; fileRef = 457858DB2CF0B558A1A490BC /* AlasCLIWorktreeResolver.swift */; };
 		01568CB821D2E938C51BBCAB /* ACPHarnessBridgeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A5A3E6B2F9AC2CBB1CDA78E /* ACPHarnessBridgeTests.swift */; };
 		01C919A6F3868980D51539DD /* ACPInitializeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9DF8B5E766D2B3649D2555ED /* ACPInitializeTests.swift */; };
 		01CBEF6793755D3D9B000BC1 /* CodeLanguageDetailViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E91A6AFCC9B3AEFB43D8946F /* CodeLanguageDetailViewTests.swift */; };
@@ -315,6 +316,7 @@
 		474DF7FE50CB6146644B2450 /* ImageDiffEndToEndTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 638E94907851A6D0B4AB8F52 /* ImageDiffEndToEndTests.swift */; };
 		476CE4945CF013F76A96AFC6 /* MergeConflictTabState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2A69F4742D3C251A59F400B8 /* MergeConflictTabState.swift */; };
 		47789166FA5C563AE2F550ED /* ACPDiffGeneratorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 05C9583C0CA5EDE7D2A1B7DF /* ACPDiffGeneratorTests.swift */; };
+		4780D23AF088EC5923A17102 /* AlasCLIWorktreeResolverTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 311B7CA55176621C35DE3E92 /* AlasCLIWorktreeResolverTests.swift */; };
 		4781661414034F09EA02E0BC /* CommitsOlderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8673293AD419AA36F7DF02A9 /* CommitsOlderTests.swift */; };
 		478863759224A2278123B7B9 /* GitServiceStagedTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C2CA853E91C240B7B5551859 /* GitServiceStagedTests.swift */; };
 		48040D7ABD4A23B3947E945F /* ACPThoughtView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0FB91182CAC794B0BEDD222D /* ACPThoughtView.swift */; };
@@ -1305,6 +1307,7 @@
 		3066B2C18213B0105D32213F /* RemoteConfigTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteConfigTests.swift; sourceTree = "<group>"; };
 		30CBB25BA2F2C558713FB0E4 /* CodeEditorCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CodeEditorCoordinator.swift; sourceTree = "<group>"; };
 		3111744632DAC342A40DB62A /* ACPAdapterUpdateBannerDecider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPAdapterUpdateBannerDecider.swift; sourceTree = "<group>"; };
+		311B7CA55176621C35DE3E92 /* AlasCLIWorktreeResolverTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlasCLIWorktreeResolverTests.swift; sourceTree = "<group>"; };
 		312DC027D433B496FD010F85 /* DiffReviewSurfaceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiffReviewSurfaceTests.swift; sourceTree = "<group>"; };
 		31CE012ED93AA22C257FEB8A /* MergeConflictBinaryDetectionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MergeConflictBinaryDetectionTests.swift; sourceTree = "<group>"; };
 		31F3A80227DD4A52C4752722 /* CompletionWindowController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CompletionWindowController.swift; sourceTree = "<group>"; };
@@ -1403,6 +1406,7 @@
 		45413FEBB779051893272FC7 /* CommitPrimaryAction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommitPrimaryAction.swift; sourceTree = "<group>"; };
 		45513A6B9EAA4E9744502597 /* AppConfigShortcutsCodingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppConfigShortcutsCodingTests.swift; sourceTree = "<group>"; };
 		4575017544CD7603B3AB9069 /* GitEventFilter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GitEventFilter.swift; sourceTree = "<group>"; };
+		457858DB2CF0B558A1A490BC /* AlasCLIWorktreeResolver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlasCLIWorktreeResolver.swift; sourceTree = "<group>"; };
 		45D7C5464CA7B663A9A7BBFF /* ACPSessionStoreCRUDTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPSessionStoreCRUDTests.swift; sourceTree = "<group>"; };
 		45D8B88C4D4837376C123D45 /* AgentLauncherModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentLauncherModelTests.swift; sourceTree = "<group>"; };
 		45EABFDF5380D8D48B15312C /* ACPHarnessBridge.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPHarnessBridge.swift; sourceTree = "<group>"; };
@@ -2343,6 +2347,7 @@
 				11C3EC94DBE871DFC45C7D25 /* AgentTerminalLaunchTests.swift */,
 				1FDD958CF56AA9AD319F6C6C /* AlasCLICommandRouterTests.swift */,
 				FA730D3A9214ED3ECD15C0ED /* AlasCLIRequestTests.swift */,
+				311B7CA55176621C35DE3E92 /* AlasCLIWorktreeResolverTests.swift */,
 				169FC38D03727F34855EB521 /* AlasFieldTests.swift */,
 				69CE1F098A251F24BC352816 /* AlasGhosttySmokeTests.swift */,
 				A77AA40A1700F0AF21335876 /* AlasHookCommandTests.swift */,
@@ -4079,6 +4084,7 @@
 			children = (
 				7E39F15B0B7395FB81D2C9D0 /* AlasApp.swift */,
 				1271747193D1594AEA596278 /* AlasCLICommandRouter.swift */,
+				457858DB2CF0B558A1A490BC /* AlasCLIWorktreeResolver.swift */,
 				942B0DCA09E1297D9380C58C /* AppQuitAction.swift */,
 				17C2AC0F8B3A1B75239995AC /* AppState.swift */,
 				57DEA304B6038D986A372150 /* BundledFontRegistrar.swift */,
@@ -4497,6 +4503,7 @@
 				5D3E7C2D040B58D0C9D1C0E8 /* AlasButton.swift in Sources */,
 				6AFE04B669CA654D7733F97E /* AlasCLICommandRouter.swift in Sources */,
 				29806D50EECB300991471A7C /* AlasCLIRequest.swift in Sources */,
+				00D95534280A5CED2356D06D /* AlasCLIWorktreeResolver.swift in Sources */,
 				24F8EA15B87C38C319B8A66B /* AlasField.swift in Sources */,
 				9CCB74669051D30EF12FE306 /* AlasGhostty.App.swift in Sources */,
 				8744A1DB40A1EC0D01D4C895 /* AlasGhostty.Config.swift in Sources */,
@@ -5070,6 +5077,7 @@
 				C653712419D5B5A78AA53E84 /* AgentsPaneTests.swift in Sources */,
 				026C8FB815E41D31C8E9421B /* AlasCLICommandRouterTests.swift in Sources */,
 				8F4B6B83968BE4C1E6D0D912 /* AlasCLIRequestTests.swift in Sources */,
+				4780D23AF088EC5923A17102 /* AlasCLIWorktreeResolverTests.swift in Sources */,
 				F855DEEEE005795EC6B13544 /* AlasFieldTests.swift in Sources */,
 				B7F78A0034B7EC38072C1116 /* AlasGhosttySmokeTests.swift in Sources */,
 				281C65FD7F2B509B963B74ED /* AlasHookCommandTests.swift in Sources */,

--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -889,6 +889,7 @@
 		CDEE1CFA85DF21346B05C2E2 /* Icon.swift in Sources */ = {isa = PBXBuildFile; fileRef = 29313DDC46A0CCA2FA42CDE9 /* Icon.swift */; };
 		CE24C8CA495726CD294FD223 /* CommitsSectionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6FFE12732C0D83715FC990A9 /* CommitsSectionView.swift */; };
 		CE43461FCD815780370E90D8 /* SearchKind.swift in Sources */ = {isa = PBXBuildFile; fileRef = 36B06AE8BA5FBDEAD4586616 /* SearchKind.swift */; };
+		CEEDAC1603DF2F3BD9223238 /* AlasCLIReviewTargetResolverTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA0482EAA16C6A9987C16EE8 /* AlasCLIReviewTargetResolverTests.swift */; };
 		CF105C488C01331534C65D88 /* MergeConflictBinaryView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 69B7FA3997B6A60397B56CD4 /* MergeConflictBinaryView.swift */; };
 		CF12433D8F30CEA05088FFB0 /* CodeTextViewIndentationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = ECB537B70B998A15B81BCBF7 /* CodeTextViewIndentationTests.swift */; };
 		CF2AD9C6F30BC02C040902A8 /* ShortcutResolverTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6E8FA892877AE2FDBCD4C747 /* ShortcutResolverTests.swift */; };
@@ -951,6 +952,7 @@
 		DBE7AD7F869B444A7C48E5B2 /* TreeSitterJava in Frameworks */ = {isa = PBXBuildFile; productRef = 33EB43DCB691861654EC147A /* TreeSitterJava */; };
 		DC0989E32F4B7BF023F784D6 /* StartupScriptInstallerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 43DF691FC778F3A71CE20FBB /* StartupScriptInstallerTests.swift */; };
 		DC394B7740FAEBD2F8ACB61F /* LSPMessages.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5C6A07D7C67D02C8638D8C1 /* LSPMessages.swift */; };
+		DC8458FA4C5FCC854BB46B96 /* AlasCLIReviewTargetResolver.swift in Sources */ = {isa = PBXBuildFile; fileRef = 430FCE70CDAB35CB0594CF44 /* AlasCLIReviewTargetResolver.swift */; };
 		DC93AED5844A56C6BA012CC3 /* ProviderReviewActionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 327D6F0E386398E6A512ADDF /* ProviderReviewActionsTests.swift */; };
 		DCACB5B624BFFE7C50DA6C61 /* RightPaneStateSyncStatusTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D3505FB870FA22C9C0FDB26 /* RightPaneStateSyncStatusTests.swift */; };
 		DD18C5FF006D18BC66964D94 /* TerminalTabView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 14087D57E96448EEF0B80BD9 /* TerminalTabView.swift */; };
@@ -1398,6 +1400,7 @@
 		4246F7A17DCEC4D2A669BC43 /* ImageDiffDifferenceView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageDiffDifferenceView.swift; sourceTree = "<group>"; };
 		4261E417947C1A21E77C1587 /* GitStatusCache.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GitStatusCache.swift; sourceTree = "<group>"; };
 		4306DE43C5ADCC65310C1169 /* ACPQuestionPrompt.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPQuestionPrompt.swift; sourceTree = "<group>"; };
+		430FCE70CDAB35CB0594CF44 /* AlasCLIReviewTargetResolver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlasCLIReviewTargetResolver.swift; sourceTree = "<group>"; };
 		435D9E527A76820947F426A8 /* ACPFilesystem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPFilesystem.swift; sourceTree = "<group>"; };
 		436E8992D7373486BA25D290 /* CodeTextViewCompletionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CodeTextViewCompletionTests.swift; sourceTree = "<group>"; };
 		43DF691FC778F3A71CE20FBB /* StartupScriptInstallerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StartupScriptInstallerTests.swift; sourceTree = "<group>"; };
@@ -2144,6 +2147,7 @@
 		F97EB3FA3E3C1206D76A9668 /* FileSearchDialog.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileSearchDialog.swift; sourceTree = "<group>"; };
 		F9CA43B30C70A80245BE99CE /* HarnessServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HarnessServiceTests.swift; sourceTree = "<group>"; };
 		F9F85B92952C963DCF136315 /* HarnessDetector.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HarnessDetector.swift; sourceTree = "<group>"; };
+		FA0482EAA16C6A9987C16EE8 /* AlasCLIReviewTargetResolverTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlasCLIReviewTargetResolverTests.swift; sourceTree = "<group>"; };
 		FA1EC032FDD03ED4A86B96A8 /* SettingsWindow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsWindow.swift; sourceTree = "<group>"; };
 		FA486F66BE4CEB2A16EB148B /* HunkPatchBuilderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HunkPatchBuilderTests.swift; sourceTree = "<group>"; };
 		FA730D3A9214ED3ECD15C0ED /* AlasCLIRequestTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlasCLIRequestTests.swift; sourceTree = "<group>"; };
@@ -2351,6 +2355,7 @@
 				11C3EC94DBE871DFC45C7D25 /* AgentTerminalLaunchTests.swift */,
 				1FDD958CF56AA9AD319F6C6C /* AlasCLICommandRouterTests.swift */,
 				FA730D3A9214ED3ECD15C0ED /* AlasCLIRequestTests.swift */,
+				FA0482EAA16C6A9987C16EE8 /* AlasCLIReviewTargetResolverTests.swift */,
 				311B7CA55176621C35DE3E92 /* AlasCLIWorktreeResolverTests.swift */,
 				169FC38D03727F34855EB521 /* AlasFieldTests.swift */,
 				69CE1F098A251F24BC352816 /* AlasGhosttySmokeTests.swift */,
@@ -4089,6 +4094,7 @@
 			children = (
 				7E39F15B0B7395FB81D2C9D0 /* AlasApp.swift */,
 				1271747193D1594AEA596278 /* AlasCLICommandRouter.swift */,
+				430FCE70CDAB35CB0594CF44 /* AlasCLIReviewTargetResolver.swift */,
 				457858DB2CF0B558A1A490BC /* AlasCLIWorktreeResolver.swift */,
 				942B0DCA09E1297D9380C58C /* AppQuitAction.swift */,
 				17C2AC0F8B3A1B75239995AC /* AppState.swift */,
@@ -4509,6 +4515,7 @@
 				5D3E7C2D040B58D0C9D1C0E8 /* AlasButton.swift in Sources */,
 				6AFE04B669CA654D7733F97E /* AlasCLICommandRouter.swift in Sources */,
 				29806D50EECB300991471A7C /* AlasCLIRequest.swift in Sources */,
+				DC8458FA4C5FCC854BB46B96 /* AlasCLIReviewTargetResolver.swift in Sources */,
 				00D95534280A5CED2356D06D /* AlasCLIWorktreeResolver.swift in Sources */,
 				24F8EA15B87C38C319B8A66B /* AlasField.swift in Sources */,
 				9CCB74669051D30EF12FE306 /* AlasGhostty.App.swift in Sources */,
@@ -5084,6 +5091,7 @@
 				C653712419D5B5A78AA53E84 /* AgentsPaneTests.swift in Sources */,
 				026C8FB815E41D31C8E9421B /* AlasCLICommandRouterTests.swift in Sources */,
 				8F4B6B83968BE4C1E6D0D912 /* AlasCLIRequestTests.swift in Sources */,
+				CEEDAC1603DF2F3BD9223238 /* AlasCLIReviewTargetResolverTests.swift in Sources */,
 				4780D23AF088EC5923A17102 /* AlasCLIWorktreeResolverTests.swift in Sources */,
 				F855DEEEE005795EC6B13544 /* AlasFieldTests.swift in Sources */,
 				B7F78A0034B7EC38072C1116 /* AlasGhosttySmokeTests.swift in Sources */,

--- a/Alas/Sources/App/AlasCLICommandRouter.swift
+++ b/Alas/Sources/App/AlasCLICommandRouter.swift
@@ -15,7 +15,7 @@ struct AlasCLICommandRouter {
     var activateApp: () -> Void
 
     func handle(_ request: AlasCLIRequest) -> AlasCLIResponse {
-        guard request.command == .open else {
+        guard case .open = request.command else {
             return .error("Unsupported command.")
         }
         guard let originWorktreeId = sessionWorktreeId(request.sessionId),

--- a/Alas/Sources/App/AlasCLICommandRouter.swift
+++ b/Alas/Sources/App/AlasCLICommandRouter.swift
@@ -12,20 +12,39 @@ struct AlasCLICommandRouter {
     var visibleWorktrees: () -> [Worktree]
     var openRelativeFile: (String, String) -> Void
     var openExternalFile: (URL, String) -> Void
+    var focusWorktree: (Worktree) -> Void = { _ in }
+    var createWorktree: (Worktree, String, String?) async -> AlasCLIResponse = { _, _, _ in
+        .error("Creating worktrees from the terminal is not available yet.")
+    }
+    var deleteWorktree: (Worktree, Bool, Bool) async -> AlasCLIResponse = { _, _, _ in
+        .error("Deleting worktrees from the terminal is not available yet.")
+    }
+    var openReviewChanges: (Worktree) -> Void = { _ in }
+    var openProviderReview: (Worktree, String) async -> AlasCLIResponse = { _, _ in
+        .error("Opening provider reviews from the terminal is not available yet.")
+    }
     var activateApp: () -> Void
 
-    func handle(_ request: AlasCLIRequest) -> AlasCLIResponse {
-        guard case .open = request.command else {
-            return .error("Unsupported command.")
-        }
+    func handle(_ request: AlasCLIRequest) async -> AlasCLIResponse {
         guard let originWorktreeId = sessionWorktreeId(request.sessionId),
-              originatingWorktree(originWorktreeId) != nil else {
+              let origin = originatingWorktree(originWorktreeId) else {
             return .error("Unknown Alas terminal session.")
         }
 
+        switch request.command {
+        case .open(let paths):
+            return handleOpen(paths: paths, originWorktreeId: originWorktreeId)
+        case .worktree(let command):
+            return await handleWorktree(command, origin: origin)
+        case .review(let command):
+            return await handleReview(command, origin: origin)
+        }
+    }
+
+    private func handleOpen(paths: [String], originWorktreeId: String) -> AlasCLIResponse {
         var errors: [String] = []
         var openedAny = false
-        for rawPath in request.paths {
+        for rawPath in paths {
             let url = URL(fileURLWithPath: rawPath).standardizedFileURL
             guard fileExists(at: url) else {
                 errors.append("\(url.path) does not exist.")
@@ -48,6 +67,47 @@ struct AlasCLICommandRouter {
             activateApp()
         }
         return errors.isEmpty ? .ok : .error(errors.joined(separator: " "))
+    }
+
+    private func handleWorktree(_ command: AlasCLIRequest.WorktreeCommand, origin: Worktree) async -> AlasCLIResponse {
+        let projectWorktrees = visibleWorktrees().filter { $0.projectId == origin.projectId }
+        switch command {
+        case .list:
+            return .text(AlasCLIWorktreeResolver.rows(worktrees: projectWorktrees, currentWorktreeId: origin.id))
+        case .switch(let target):
+            switch AlasCLIWorktreeResolver.resolve(target: target, worktrees: projectWorktrees) {
+            case .matched(let worktree):
+                focusWorktree(worktree)
+                activateApp()
+                return .ok
+            case .missing(let target):
+                return .error("unknown worktree \"\(target)\"")
+            case .ambiguous(let labels):
+                return .error("ambiguous worktree \"\(target)\"; matches: \(labels.joined(separator: ", "))")
+            }
+        case .new(let branch, let base):
+            return await createWorktree(origin, branch, base)
+        case .delete(let target, let force, let keepBranch):
+            switch AlasCLIWorktreeResolver.resolve(target: target, worktrees: projectWorktrees) {
+            case .matched(let worktree):
+                return await deleteWorktree(worktree, force, keepBranch)
+            case .missing(let target):
+                return .error("unknown worktree \"\(target)\"")
+            case .ambiguous(let labels):
+                return .error("ambiguous worktree \"\(target)\"; matches: \(labels.joined(separator: ", "))")
+            }
+        }
+    }
+
+    private func handleReview(_ command: AlasCLIRequest.ReviewCommand, origin: Worktree) async -> AlasCLIResponse {
+        switch command {
+        case .localChanges:
+            openReviewChanges(origin)
+            activateApp()
+            return .ok
+        case .provider(let target):
+            return await openProviderReview(origin, target)
+        }
     }
 
     private func containingWorktree(for url: URL) -> (worktree: Worktree, relativePath: String)? {

--- a/Alas/Sources/App/AlasCLIReviewTargetResolver.swift
+++ b/Alas/Sources/App/AlasCLIReviewTargetResolver.swift
@@ -1,0 +1,46 @@
+import Foundation
+
+enum AlasCLIReviewTargetResolver {
+    enum Target: Equatable {
+        case number(Int)
+        case url(host: String, repositorySlug: String, number: Int)
+    }
+
+    static func parse(_ raw: String) -> Target? {
+        let trimmed = raw.trimmingCharacters(in: .whitespacesAndNewlines)
+        if let number = Int(trimmed), number > 0 {
+            return .number(number)
+        }
+        guard let components = URLComponents(string: trimmed),
+              let host = components.host?.lowercased() else {
+            return nil
+        }
+        let parts = components.path.split(separator: "/").map(String.init)
+        if host == "github.com",
+           let pullIndex = parts.firstIndex(of: "pull"),
+           pullIndex >= 2,
+           pullIndex + 1 < parts.count,
+           let number = Int(parts[pullIndex + 1]),
+           number > 0 {
+            return .url(
+                host: host,
+                repositorySlug: parts[..<pullIndex].joined(separator: "/"),
+                number: number
+            )
+        }
+        if host == "gitlab.com" || host.split(separator: ".").first == "gitlab",
+           let mergeIndex = parts.firstIndex(of: "merge_requests"),
+           mergeIndex >= 2,
+           mergeIndex + 1 < parts.count,
+           let number = Int(parts[mergeIndex + 1]),
+           number > 0 {
+            let slugParts = parts[..<mergeIndex].filter { $0 != "-" }
+            return .url(
+                host: host,
+                repositorySlug: slugParts.joined(separator: "/"),
+                number: number
+            )
+        }
+        return nil
+    }
+}

--- a/Alas/Sources/App/AlasCLIWorktreeResolver.swift
+++ b/Alas/Sources/App/AlasCLIWorktreeResolver.swift
@@ -1,0 +1,60 @@
+import Foundation
+
+enum AlasCLIWorktreeResolver {
+    enum Result: Equatable {
+        case matched(Worktree)
+        case missing(String)
+        case ambiguous([String])
+    }
+
+    static func rows(worktrees: [Worktree], currentWorktreeId: String) -> [String] {
+        let labels = worktrees.map(\.branch)
+        let width = max(labels.map(\.count).max() ?? 0, 1) + 4
+        return worktrees.map { worktree in
+            let marker = worktree.id == currentWorktreeId ? "*" : " "
+            let label = worktree.branch.padding(toLength: width, withPad: " ", startingAt: 0)
+            return "\(marker) \(label)\(worktree.path.path)"
+        }
+    }
+
+    static func resolve(target: String, worktrees: [Worktree]) -> Result {
+        let trimmed = target.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return .missing(trimmed) }
+
+        let exactBranch = worktrees.filter { $0.branch == trimmed || $0.name == trimmed }
+        if exactBranch.count == 1 { return .matched(exactBranch[0]) }
+        if exactBranch.count > 1 { return .ambiguous(labels(for: exactBranch)) }
+
+        let exactBasename = worktrees.filter { $0.path.lastPathComponent == trimmed }
+        if exactBasename.count == 1 { return .matched(exactBasename[0]) }
+        if exactBasename.count > 1 { return .ambiguous(labels(for: exactBasename)) }
+
+        let prefixMatches = worktrees.filter {
+            $0.branch.hasPrefix(trimmed)
+                || $0.name.hasPrefix(trimmed)
+                || $0.path.lastPathComponent.hasPrefix(trimmed)
+        }
+        if prefixMatches.count == 1 { return .matched(prefixMatches[0]) }
+        if prefixMatches.count > 1 { return .ambiguous(labels(for: prefixMatches)) }
+
+        return .missing(trimmed)
+    }
+
+    private static func labels(for worktrees: [Worktree]) -> [String] {
+        let baseLabels = worktrees.map(baseLabel)
+        let duplicateLabels = Set(
+            Dictionary(grouping: baseLabels, by: { $0 })
+                .filter { $0.value.count > 1 }
+                .keys
+        )
+
+        return zip(worktrees, baseLabels).map { worktree, label in
+            duplicateLabels.contains(label) ? "\(label) (\(worktree.path.path))" : label
+        }
+        .sorted()
+    }
+
+    private static func baseLabel(for worktree: Worktree) -> String {
+        worktree.branch.isEmpty ? worktree.path.lastPathComponent : worktree.branch
+    }
+}

--- a/Alas/Sources/App/AppState.swift
+++ b/Alas/Sources/App/AppState.swift
@@ -1559,6 +1559,10 @@ final class AppState {
             openReviewChanges: { [weak self] worktree in
                 _ = self?.openReviewChangesTab(for: worktree)
             },
+            openProviderReview: { [weak self] worktree, target in
+                guard let self else { return .error("Alas is not available.") }
+                return await self.cliOpenProviderReview(worktree: worktree, target: target)
+            },
             activateApp: {
                 NSApp.activate(ignoringOtherApps: true)
             }
@@ -2895,6 +2899,83 @@ final class AppState {
             }
         }
         return .ok
+    }
+
+    @MainActor
+    func cliOpenProviderReview(worktree: Worktree, target: String) async -> AlasCLIResponse {
+        guard let parsed = AlasCLIReviewTargetResolver.parse(target) else {
+            return .error("unsupported review URL")
+        }
+
+        do {
+            let providerRegistry = CodeHostProviderRegistry.live()
+            let remotes = try await GitService().remotes(worktreePath: worktree.path)
+            let supportedRemotes = CodeHostRemoteDetector.detectAll(
+                from: remotes,
+                supportedKinds: providerRegistry.supportedKinds
+            )
+            guard !supportedRemotes.isEmpty else {
+                return .error("no code host remote found for this worktree")
+            }
+
+            let remote: CodeHostRemote
+            let number: Int
+            switch parsed {
+            case .number(let value):
+                remote = supportedRemotes[0]
+                number = value
+            case .url(let host, let repositorySlug, let value):
+                guard let matchingRemote = supportedRemotes.first(where: {
+                    $0.host == host && $0.repositorySlug.lowercased() == repositorySlug.lowercased()
+                }) else {
+                    return .error("review URL does not match this worktree's remote")
+                }
+                remote = matchingRemote
+                number = value
+            }
+
+            guard let provider = providerRegistry.provider(for: remote.kind) else {
+                return .error("\(remote.kind.displayName) is not supported yet.")
+            }
+            let request = try await provider.reviewRequest(remote: remote, number: number, cwd: worktree.path)
+            let reviewTarget = ReviewSessionTarget.reviewRequest(
+                worktreeID: worktree.id,
+                repositoryPath: worktree.path,
+                provider: request.provider,
+                host: request.remote.host,
+                repositorySlug: request.remote.repositorySlug,
+                number: request.number,
+                url: request.url,
+                title: request.title,
+                headSHA: request.headSHA
+            )
+            let store = ReviewSessionStore()
+            let opened = ReviewSessionLauncher.openOrFocus(
+                target: reviewTarget,
+                findActive: { try store.findActive(targetID: $0) },
+                save: { try store.save($0) },
+                open: { [weak self] record in
+                    _ = self?.tabs.openOrFocusReviewSession(worktreeId: worktree.id, record: record)
+                }
+            )
+            guard opened else {
+                return .error("could not open review session")
+            }
+            focusGlobalWorktree(id: worktree.id, projectId: worktree.projectId)
+            NSApp.activate(ignoringOtherApps: true)
+            return .ok
+        } catch {
+            return .error(Self.describeCLIError(error))
+        }
+    }
+
+    nonisolated private static func describeCLIError(_ error: any Error) -> String {
+        if let localized = error as? LocalizedError,
+           let description = localized.errorDescription,
+           !description.isEmpty {
+            return description
+        }
+        return String(describing: error)
     }
 
     /// Runs the git removal off the main actor, then resumes on MainActor

--- a/Alas/Sources/App/AppState.swift
+++ b/Alas/Sources/App/AppState.swift
@@ -1407,19 +1407,8 @@ final class AppState {
             )
         }
         harness.socketServer.onCLIRequest = { [weak self] request in
-            await MainActor.run {
-                guard let self else { return .error("Alas is not available.") }
-                let router = self.makeCLICommandRouter { [weak self] sessionId in
-                    if let s = self?.terminal.registry.session(for: sessionId) {
-                        return s.worktreeId
-                    }
-                    // Fall back to persisted-tab scan so `alas open` etc.
-                    // still resolve a worktree for zmx-persisted leaves
-                    // whose `TerminalSession` hasn't been restored yet.
-                    return self?.persistedLeafLocation(leafId: sessionId)?.worktreeId
-                }
-                return router.handle(request)
-            }
+            guard let self else { return .error("Alas is not available.") }
+            return await self.handleCLIRequest(request)
         }
         harness.onClickThrough = { [weak self] projectId, worktreeId, sessionId in
             self?.activateHarnessSession(
@@ -1434,6 +1423,20 @@ final class AppState {
         // to call here: it reads live managers lazily, so no session state is
         // required at this point.
         syncRemoteServer()
+    }
+
+    @MainActor
+    private func handleCLIRequest(_ request: AlasCLIRequest) async -> AlasCLIResponse {
+        let router = makeCLICommandRouter { [weak self] sessionId in
+            if let s = self?.terminal.registry.session(for: sessionId) {
+                return s.worktreeId
+            }
+            // Fall back to persisted-tab scan so `alas open` etc.
+            // still resolve a worktree for zmx-persisted leaves
+            // whose `TerminalSession` hasn't been restored yet.
+            return self?.persistedLeafLocation(leafId: sessionId)?.worktreeId
+        }
+        return await router.handle(request)
     }
 
     /// Linear scan of persisted terminal tabs for the (projectId, worktreeId)
@@ -1506,6 +1509,12 @@ final class AppState {
                    let worktree = self.worktree(withId: worktreeId) {
                     self.focusGlobalWorktree(id: worktreeId, projectId: worktree.projectId)
                 }
+            },
+            focusWorktree: { [weak self] worktree in
+                self?.focusGlobalWorktree(id: worktree.id, projectId: worktree.projectId)
+            },
+            openReviewChanges: { [weak self] worktree in
+                _ = self?.openReviewChangesTab(for: worktree)
             },
             activateApp: {
                 NSApp.activate(ignoringOtherApps: true)

--- a/Alas/Sources/App/AppState.swift
+++ b/Alas/Sources/App/AppState.swift
@@ -2923,9 +2923,19 @@ final class AppState {
         do {
             let providerRegistry = CodeHostProviderRegistry.live()
             let remotes = try await GitService().remotes(worktreePath: worktree.path)
+            let baseBranch = rightPaneStore.state(
+                for: worktree,
+                baseBranch: config.worktrees.baseBranch,
+                trackUpstreamForCommits: config.changes.trackUpstreamForCommits
+            ).baseBranch
+            let preferredRemoteName = CodeHostRemoteDetector.preferredRemoteName(
+                forBaseBranch: baseBranch,
+                remotes: remotes
+            )
             let supportedRemotes = CodeHostRemoteDetector.detectAll(
                 from: remotes,
-                supportedKinds: providerRegistry.supportedKinds
+                supportedKinds: providerRegistry.supportedKinds,
+                preferredRemoteName: preferredRemoteName
             )
             guard !supportedRemotes.isEmpty else {
                 return .error("no code host remote found for this worktree")

--- a/Alas/Sources/App/AppState.swift
+++ b/Alas/Sources/App/AppState.swift
@@ -980,9 +980,20 @@ final class AppState {
         if FileManager.default.fileExists(atPath: destination.path) {
             return .error("A worktree already exists at this path.")
         }
+        let resolvedBase: String
+        if let base {
+            resolvedBase = base
+        } else {
+            let availableBranches = (try? await GitService().branches(at: URL(fileURLWithPath: project.path))) ?? []
+            resolvedBase = NewWorktreeDialog.preferredBaseBranch(
+                availableBranches: availableBranches,
+                configuredDefault: config.worktrees.baseBranch
+            )
+        }
+
         let id = createWorktree(
             projectId: project.id,
-            base: base ?? config.worktrees.baseBranch,
+            base: resolvedBase,
             branch: branch,
             destination: destination,
             runStartup: true,
@@ -1557,7 +1568,9 @@ final class AppState {
                 return await self.cliDeleteWorktree(worktree, force: force, keepBranch: keepBranch)
             },
             openReviewChanges: { [weak self] worktree in
-                _ = self?.openReviewChangesTab(for: worktree)
+                guard let self else { return }
+                self.focusGlobalWorktree(id: worktree.id, projectId: worktree.projectId)
+                _ = self.openReviewChangesTab(for: worktree)
             },
             openProviderReview: { [weak self] worktree, target in
                 guard let self else { return .error("Alas is not available.") }

--- a/Alas/Sources/App/AppState.swift
+++ b/Alas/Sources/App/AppState.swift
@@ -959,6 +959,41 @@ final class AppState {
         return optimistic.id
     }
 
+    @MainActor
+    func cliCreateWorktree(origin: Worktree, branch: String, base: String?) async -> AlasCLIResponse {
+        guard let project = projects.first(where: { $0.id == origin.projectId }) else {
+            return .error("The current worktree's project is no longer available.")
+        }
+        switch GitNameValidator.validateBranchName(branch) {
+        case .valid:
+            break
+        case .invalid(let message):
+            return .error("invalid branch name: \(message)")
+        }
+
+        let destination = WorktreePathTemplateRenderer.render(
+            template: config.worktrees.pathTemplate,
+            worktreeRoot: config.worktrees.rootPath,
+            repoName: project.name,
+            branch: branch
+        )
+        if FileManager.default.fileExists(atPath: destination.path) {
+            return .error("A worktree already exists at this path.")
+        }
+        let id = createWorktree(
+            projectId: project.id,
+            base: base ?? config.worktrees.baseBranch,
+            branch: branch,
+            destination: destination,
+            runStartup: true,
+            launchSurface: .none
+        )
+        guard !id.isEmpty else {
+            return .error("A worktree already exists at this path.")
+        }
+        return .text(["creating \(branch) at \(destination.path)"])
+    }
+
     func agentStartupCommand(for agent: AgentDefinition, project: ProjectConfig) -> String {
         var argv = [agent.resolvedBinary]
         if let extra = agent.extraTerminalArgs, !extra.isEmpty {
@@ -1512,6 +1547,14 @@ final class AppState {
             },
             focusWorktree: { [weak self] worktree in
                 self?.focusGlobalWorktree(id: worktree.id, projectId: worktree.projectId)
+            },
+            createWorktree: { [weak self] origin, branch, base in
+                guard let self else { return .error("Alas is not available.") }
+                return await self.cliCreateWorktree(origin: origin, branch: branch, base: base)
+            },
+            deleteWorktree: { [weak self] worktree, force, keepBranch in
+                guard let self else { return .error("Alas is not available.") }
+                return await self.cliDeleteWorktree(worktree, force: force, keepBranch: keepBranch)
             },
             openReviewChanges: { [weak self] worktree in
                 _ = self?.openReviewChangesTab(for: worktree)
@@ -2797,6 +2840,61 @@ final class AppState {
                 removedIndex: removedIndex
             )
         }
+    }
+
+    @MainActor
+    func cliDeleteWorktree(_ worktree: Worktree, force: Bool, keepBranch: Bool) async -> AlasCLIResponse {
+        if pendingForceDeleteWorktree?.id == worktree.id {
+            pendingForceDeleteWorktree = nil
+        }
+        if projectsManager.operationState(for: worktree.id) == .deleting {
+            return .ok
+        }
+        let dirty = dirtyEditorTabIds(worktreeId: worktree.id)
+        if !dirty.isEmpty && !force {
+            return .error("worktree has unsaved editor changes; save them or rerun with --force to delete")
+        }
+        guard let project = projects.first(where: { $0.id == worktree.projectId }) else {
+            return .error("Could not find the project for this worktree.")
+        }
+        if !force {
+            let preflight = await Self.performDeletePreflight(worktreePath: worktree.path)
+            if preflight.requiresForce {
+                if preflight.reasons.contains(.dirty) {
+                    return .error("worktree has local changes; rerun with --force to delete")
+                }
+                if preflight.reasons.contains(.containsInitializedSubmodules) {
+                    return .error("worktree contains initialized submodules; rerun with --force to delete")
+                }
+                return .error("worktree requires force delete; rerun with --force to delete")
+            }
+        }
+
+        let repoPath = URL(fileURLWithPath: project.path)
+        let deleteBranch = Self.resolveDeleteBranchIfMerged(
+            globalDeleteOnRemove: config.worktrees.deleteBranchOnRemove,
+            keepBranch: keepBranch
+        )
+        let siblingsBefore = projectsManager.visibleWorktrees(projectId: worktree.projectId)
+        let removedIndex = siblingsBefore.firstIndex(where: { $0.id == worktree.id }) ?? 0
+        projectsManager.setOperationState(id: worktree.id, state: .deleting)
+        Task { @MainActor in
+            await performDeleteWorktree(
+                worktree: worktree,
+                repoPath: repoPath,
+                deleteBranchIfMerged: deleteBranch,
+                force: force,
+                removedIndex: removedIndex
+            )
+            if pendingForceDeleteWorktree?.id == worktree.id {
+                pendingForceDeleteWorktree = nil
+                projectsManager.setOperationState(
+                    id: worktree.id,
+                    state: .deleteFailed(message: "worktree requires force delete; rerun with --force to delete")
+                )
+            }
+        }
+        return .ok
     }
 
     /// Runs the git removal off the main actor, then resumes on MainActor

--- a/Alas/Sources/App/WorktreePathTemplateRenderer.swift
+++ b/Alas/Sources/App/WorktreePathTemplateRenderer.swift
@@ -1,0 +1,22 @@
+import Foundation
+
+enum WorktreePathTemplateRenderer {
+    static func render(
+        template: String,
+        worktreeRoot: String,
+        repoName: String,
+        branch: String,
+        userName: String = NSUserName(),
+        date: Date = Date()
+    ) -> URL {
+        let repo = repoName.split(separator: "/").last.map(String.init) ?? "repo"
+        let timestamp = ISO8601DateFormatter().string(from: date)
+        let rendered = template
+            .replacingOccurrences(of: "{worktreeRoot}", with: worktreeRoot)
+            .replacingOccurrences(of: "{repo}", with: repo)
+            .replacingOccurrences(of: "{branch}", with: branch.replacingOccurrences(of: "/", with: "-"))
+            .replacingOccurrences(of: "{user}", with: userName)
+            .replacingOccurrences(of: "{ts}", with: timestamp)
+        return URL(fileURLWithPath: (rendered as NSString).expandingTildeInPath)
+    }
+}

--- a/Alas/Sources/Dialogs/NewWorktreeDialog.swift
+++ b/Alas/Sources/Dialogs/NewWorktreeDialog.swift
@@ -166,13 +166,12 @@ struct NewWorktreeDialog: View {
 
     private var renderedPath: String {
         guard let project = state.projects.first(where: { $0.id == projectId }) else { return "" }
-        let template = state.config.worktrees.pathTemplate
-            .replacingOccurrences(of: "{worktreeRoot}", with: state.config.worktrees.rootPath)
-            .replacingOccurrences(of: "{repo}", with: project.name.split(separator: "/").last.map(String.init) ?? "repo")
-            .replacingOccurrences(of: "{branch}", with: branch.replacingOccurrences(of: "/", with: "-"))
-            .replacingOccurrences(of: "{user}", with: NSUserName())
-            .replacingOccurrences(of: "{ts}", with: ISO8601DateFormatter().string(from: Date()))
-        return (template as NSString).expandingTildeInPath
+        return WorktreePathTemplateRenderer.render(
+            template: state.config.worktrees.pathTemplate,
+            worktreeRoot: state.config.worktrees.rootPath,
+            repoName: project.name,
+            branch: branch
+        ).path
     }
 
     private func loadBranchesForSelectedProject() {

--- a/Alas/Sources/Harness/AlasCLIRequest.swift
+++ b/Alas/Sources/Harness/AlasCLIRequest.swift
@@ -10,24 +10,67 @@ enum AlasCLIRequestError: Error, Equatable {
 }
 
 struct AlasCLIRequest: Equatable {
-    enum Command: String, Equatable {
-        case open
+    enum Command: Equatable {
+        case open(paths: [String])
+        case worktree(WorktreeCommand)
+        case review(ReviewCommand)
+    }
+
+    enum WorktreeCommand: Equatable {
+        case list
+        case `switch`(target: String)
+        case new(branch: String, base: String?)
+        case delete(target: String, force: Bool, keepBranch: Bool)
+    }
+
+    enum ReviewCommand: Equatable {
+        case localChanges
+        case provider(target: String)
     }
 
     let version: Int
-    let command: Command
     let sessionId: String
-    let paths: [String]
+    let command: Command
+
+    var paths: [String] {
+        guard case .open(let paths) = command else { return [] }
+        return paths
+    }
 
     private struct Raw: Decodable {
         var v: Int?
         var kind: String?
         var command: String?
+        var subcommand: String?
         var session_id: String?
         var paths: [String]?
+        var target: String?
+        var branch: String?
+        var base: String?
+        var force: Bool?
+        var keep_branch: Bool?
     }
 
     static func decode(from data: Data) throws -> AlasCLIRequest {
+        func requiredNonEmpty(_ value: String?) throws -> String {
+            guard let value else { throw AlasCLIRequestError.malformed }
+            let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
+            guard !trimmed.isEmpty else { throw AlasCLIRequestError.malformed }
+            return trimmed
+        }
+
+        func validatedAbsolutePaths(_ paths: [String]?) throws -> [String] {
+            guard let paths,
+                  !paths.isEmpty,
+                  paths.allSatisfy({
+                      let trimmed = $0.trimmingCharacters(in: .whitespacesAndNewlines)
+                      return !trimmed.isEmpty && URL(fileURLWithPath: trimmed).path == trimmed && trimmed.hasPrefix("/")
+                  }) else {
+                throw AlasCLIRequestError.missingPaths
+            }
+            return paths
+        }
+
         let raw: Raw
         do {
             raw = try JSONDecoder().decode(Raw.self, from: data)
@@ -36,28 +79,49 @@ struct AlasCLIRequest: Equatable {
         }
         guard raw.kind == "cli" else { throw AlasCLIRequestError.unsupportedKind }
         guard raw.v == 1 else { throw AlasCLIRequestError.unsupportedVersion }
-        guard let commandString = raw.command,
-              let command = Command(rawValue: commandString) else {
-            throw AlasCLIRequestError.unsupportedCommand
-        }
         guard let sessionId = raw.session_id,
               !sessionId.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
             throw AlasCLIRequestError.missingSession
         }
-        guard let paths = raw.paths,
-              !paths.isEmpty,
-              paths.allSatisfy({
-                  let trimmed = $0.trimmingCharacters(in: .whitespacesAndNewlines)
-                  return !trimmed.isEmpty && URL(fileURLWithPath: trimmed).path == trimmed && trimmed.hasPrefix("/")
-              }) else {
-            throw AlasCLIRequestError.missingPaths
+
+        let command: Command
+        switch raw.command {
+        case "open":
+            command = .open(paths: try validatedAbsolutePaths(raw.paths))
+        case "wt":
+            switch raw.subcommand {
+            case "list":
+                command = .worktree(.list)
+            case "switch":
+                command = .worktree(.switch(target: try requiredNonEmpty(raw.target)))
+            case "new":
+                command = .worktree(.new(branch: try requiredNonEmpty(raw.branch), base: raw.base?.nilIfBlank))
+            case "delete":
+                command = .worktree(.delete(
+                    target: try requiredNonEmpty(raw.target),
+                    force: raw.force ?? false,
+                    keepBranch: raw.keep_branch ?? false
+                ))
+            default:
+                throw AlasCLIRequestError.unsupportedCommand
+            }
+        case "review":
+            if let target = raw.target?.nilIfBlank {
+                command = .review(.provider(target: target))
+            } else {
+                command = .review(.localChanges)
+            }
+        default:
+            throw AlasCLIRequestError.unsupportedCommand
         }
-        return AlasCLIRequest(version: 1, command: command, sessionId: sessionId, paths: paths)
+
+        return AlasCLIRequest(version: 1, sessionId: sessionId, command: command)
     }
 }
 
 enum AlasCLIResponse: Equatable {
     case ok
+    case text([String])
     case error(String)
 
     func encode() throws -> Data {
@@ -65,9 +129,18 @@ enum AlasCLIResponse: Equatable {
         switch self {
         case .ok:
             object = ["ok": true]
+        case .text(let lines):
+            object = ["ok": true, "lines": lines]
         case .error(let message):
             object = ["ok": false, "error": message]
         }
         return try JSONSerialization.data(withJSONObject: object)
+    }
+}
+
+private extension String {
+    var nilIfBlank: String? {
+        let trimmed = trimmingCharacters(in: .whitespacesAndNewlines)
+        return trimmed.isEmpty ? nil : trimmed
     }
 }

--- a/Alas/Sources/Integrations/CodeHost/CodeHostRemoteDetector.swift
+++ b/Alas/Sources/Integrations/CodeHost/CodeHostRemoteDetector.swift
@@ -18,6 +18,10 @@ struct GitRemote: Equatable, Sendable {
 }
 
 enum CodeHostRemoteDetector {
+    static func preferredRemoteName(forBaseBranch baseBranch: String, remotes: [GitRemote]) -> String? {
+        remotes.first { baseBranch.hasPrefix("\($0.name)/") }?.name
+    }
+
     static func detect(
         from remotes: [GitRemote],
         supportedKinds: Set<CodeHostKind>? = nil,

--- a/Alas/Sources/Integrations/CodeHost/CodeHostRemoteDetector.swift
+++ b/Alas/Sources/Integrations/CodeHost/CodeHostRemoteDetector.swift
@@ -23,6 +23,18 @@ enum CodeHostRemoteDetector {
         supportedKinds: Set<CodeHostKind>? = nil,
         preferredRemoteName: String? = nil
     ) -> CodeHostRemote? {
+        detectAll(
+            from: remotes,
+            supportedKinds: supportedKinds,
+            preferredRemoteName: preferredRemoteName
+        ).first
+    }
+
+    static func detectAll(
+        from remotes: [GitRemote],
+        supportedKinds: Set<CodeHostKind>? = nil,
+        preferredRemoteName: String? = nil
+    ) -> [CodeHostRemote] {
         remotes
             .filter { $0.direction == .fetch }
             .sorted { lhs, rhs in
@@ -33,9 +45,7 @@ enum CodeHostRemoteDetector {
                 }
                 return lhs.name < rhs.name
             }
-            .lazy
             .compactMap { parse(remote: $0, supportedKinds: supportedKinds) }
-            .first
     }
 
     private static func priority(for remoteName: String, preferredRemoteName: String?) -> Int {

--- a/Alas/Sources/Integrations/CodeHost/ReviewLoopState.swift
+++ b/Alas/Sources/Integrations/CodeHost/ReviewLoopState.swift
@@ -167,7 +167,10 @@ final class ReviewLoopState {
         }
 
         let supportedKinds = providerRegistry.supportedKinds
-        let preferredRemoteName = Self.preferredRemoteName(for: baseLocal.baseBranch, remotes: remotes)
+        let preferredRemoteName = CodeHostRemoteDetector.preferredRemoteName(
+            forBaseBranch: baseLocal.baseBranch,
+            remotes: remotes
+        )
         guard let remote = CodeHostRemoteDetector.detect(
             from: remotes,
             supportedKinds: supportedKinds.isEmpty ? nil : supportedKinds,
@@ -361,10 +364,6 @@ final class ReviewLoopState {
 
     private func isCurrentRefresh(_ generation: Int) -> Bool {
         generation == refreshGeneration
-    }
-
-    private static func preferredRemoteName(for baseBranch: String, remotes: [GitRemote]) -> String? {
-        remotes.first { baseBranch.hasPrefix("\($0.name)/") }?.name
     }
 
     private static func withHeadRemote(

--- a/Alas/Sources/Terminal/TerminalCLIInjection.swift
+++ b/Alas/Sources/Terminal/TerminalCLIInjection.swift
@@ -13,45 +13,243 @@ enum TerminalCLIInjection {
           exit 2
         fi
 
-        case "${1:-}" in
-          open)
-            shift
-            if [ "$#" -eq 0 ]; then
-              printf '%s\n' 'usage: alas open <path> [path...]' >&2
-              exit 2
-            fi
-            response=$(/usr/bin/python3 - "$ALAS_SESSION_ID" "$@" <<'PY' | /usr/bin/nc -U -w1 "$ALAS_SOCKET_PATH" 2>/dev/null
+        usage_all() {
+          printf '%s\n' 'usage: alas open <path> [path...]' >&2
+          printf '%s\n' 'usage: alas wt list' >&2
+          printf '%s\n' 'usage: alas wt switch <name-or-branch>' >&2
+          printf '%s\n' 'usage: alas wt new <branch> [--base <ref>]' >&2
+          printf '%s\n' 'usage: alas wt delete <name-or-branch> [--force] [--keep-branch]' >&2
+          printf '%s\n' 'usage: alas review [pr-number-or-url]' >&2
+        }
+
+        usage_open() {
+          printf '%s\n' 'usage: alas open <path> [path...]' >&2
+        }
+
+        usage_wt_list() {
+          printf '%s\n' 'usage: alas wt list' >&2
+        }
+
+        usage_wt_switch() {
+          printf '%s\n' 'usage: alas wt switch <name-or-branch>' >&2
+        }
+
+        usage_wt_new() {
+          printf '%s\n' 'usage: alas wt new <branch> [--base <ref>]' >&2
+        }
+
+        usage_wt_delete() {
+          printf '%s\n' 'usage: alas wt delete <name-or-branch> [--force] [--keep-branch]' >&2
+        }
+
+        usage_review() {
+          printf '%s\n' 'usage: alas review [pr-number-or-url]' >&2
+        }
+
+        build_request() {
+          /usr/bin/python3 - "$@" <<'PY'
         import json, os, sys
+
         session_id = sys.argv[1]
-        base = os.environ.get("PWD") or os.getcwd()
-        def resolve(path):
-            if os.path.isabs(path):
-                return os.path.abspath(path)
-            return os.path.abspath(os.path.join(base, path))
-        paths = [resolve(path) for path in sys.argv[2:]]
-        print(json.dumps({"v": 1, "kind": "cli", "command": "open", "session_id": session_id, "paths": paths}))
+        command = sys.argv[2]
+        payload = {"v": 1, "kind": "cli", "command": command, "session_id": session_id}
+
+        if command == "open":
+            base = os.environ.get("PWD") or os.getcwd()
+
+            def resolve(path):
+                if os.path.isabs(path):
+                    return os.path.abspath(path)
+                return os.path.abspath(os.path.join(base, path))
+
+            payload["paths"] = [resolve(path) for path in sys.argv[3:]]
+        elif command == "wt":
+            subcommand = sys.argv[3]
+            payload["subcommand"] = subcommand
+            if subcommand == "switch":
+                payload["target"] = sys.argv[4]
+            elif subcommand == "new":
+                payload["branch"] = sys.argv[4]
+                if len(sys.argv) > 5 and sys.argv[5]:
+                    payload["base"] = sys.argv[5]
+            elif subcommand == "delete":
+                payload["target"] = sys.argv[4]
+                payload["force"] = sys.argv[5] == "1"
+                payload["keep_branch"] = sys.argv[6] == "1"
+        elif command == "review":
+            if len(sys.argv) > 3:
+                payload["target"] = sys.argv[3]
+        else:
+            raise SystemExit(1)
+
+        print(json.dumps(payload))
         PY
-        )
-            alas_status=$?
-            if [ "$alas_status" -ne 0 ]; then
-              printf '%s\n' 'alas: could not reach Alas' >&2
-              exit "$alas_status"
-            fi
-            /usr/bin/python3 - "$response" <<'PY'
+        }
+
+        send_request() {
+          response=$(printf '%s\n' "$1" | /usr/bin/nc -U -w1 "$ALAS_SOCKET_PATH" 2>/dev/null)
+          alas_status=$?
+          if [ "$alas_status" -ne 0 ]; then
+            printf '%s\n' 'alas: could not reach Alas' >&2
+            exit "$alas_status"
+          fi
+          /usr/bin/python3 - "$response" <<'PY'
         import json, sys
+
         try:
             response = json.loads(sys.argv[1] or "{}")
         except Exception:
             print("alas: malformed response from Alas", file=sys.stderr)
             sys.exit(1)
+
         if response.get("ok") is True:
+            lines = response.get("lines") or []
+            if isinstance(lines, list):
+                for line in lines:
+                    print(str(line))
             sys.exit(0)
+
         print("alas: " + str(response.get("error") or "request failed"), file=sys.stderr)
         sys.exit(1)
         PY
+        }
+
+        case "${1:-}" in
+          open)
+            shift
+            if [ "$#" -eq 0 ]; then
+              usage_open
+              exit 2
+            fi
+            request=$(build_request "$ALAS_SESSION_ID" "open" "$@") || exit 1
+            send_request "$request"
+            ;;
+          wt)
+            shift
+            case "${1:-}" in
+              list)
+                shift
+                if [ "$#" -ne 0 ]; then
+                  usage_wt_list
+                  exit 2
+                fi
+                request=$(build_request "$ALAS_SESSION_ID" "wt" "list") || exit 1
+                send_request "$request"
+                ;;
+              switch)
+                shift
+                if [ "$#" -ne 1 ]; then
+                  usage_wt_switch
+                  exit 2
+                fi
+                request=$(build_request "$ALAS_SESSION_ID" "wt" "switch" "$1") || exit 1
+                send_request "$request"
+                ;;
+              new)
+                shift
+                if [ "$#" -lt 1 ]; then
+                  usage_wt_new
+                  exit 2
+                fi
+                case "$1" in
+                  --*)
+                    usage_wt_new
+                    exit 2
+                    ;;
+                esac
+                branch=$1
+                base=
+                shift
+                while [ "$#" -gt 0 ]; do
+                  case "$1" in
+                    --base)
+                      shift
+                      if [ "$#" -eq 0 ]; then
+                        usage_wt_new
+                        exit 2
+                      fi
+                      case "$1" in
+                        --*)
+                          usage_wt_new
+                          exit 2
+                          ;;
+                      esac
+                      base=$1
+                      shift
+                      ;;
+                    --*)
+                      usage_wt_new
+                      exit 2
+                      ;;
+                    *)
+                      usage_wt_new
+                      exit 2
+                      ;;
+                  esac
+                done
+                request=$(build_request "$ALAS_SESSION_ID" "wt" "new" "$branch" "$base") || exit 1
+                send_request "$request"
+                ;;
+              delete)
+                shift
+                if [ "$#" -lt 1 ]; then
+                  usage_wt_delete
+                  exit 2
+                fi
+                case "$1" in
+                  --*)
+                    usage_wt_delete
+                    exit 2
+                    ;;
+                esac
+                target=$1
+                force=0
+                keep_branch=0
+                shift
+                while [ "$#" -gt 0 ]; do
+                  case "$1" in
+                    --force)
+                      force=1
+                      shift
+                      ;;
+                    --keep-branch)
+                      keep_branch=1
+                      shift
+                      ;;
+                    --*)
+                      usage_wt_delete
+                      exit 2
+                      ;;
+                    *)
+                      usage_wt_delete
+                      exit 2
+                      ;;
+                  esac
+                done
+                request=$(build_request "$ALAS_SESSION_ID" "wt" "delete" "$target" "$force" "$keep_branch") || exit 1
+                send_request "$request"
+                ;;
+              *)
+                usage_all
+                exit 2
+                ;;
+            esac
+            ;;
+          review)
+            shift
+            if [ "$#" -gt 1 ]; then
+              usage_review
+              exit 2
+            fi
+            if [ "$#" -eq 0 ]; then
+              request=$(build_request "$ALAS_SESSION_ID" "review") || exit 1
+            else
+              request=$(build_request "$ALAS_SESSION_ID" "review" "$1") || exit 1
+            fi
+            send_request "$request"
             ;;
           *)
-            printf '%s\n' 'usage: alas open <path> [path...]' >&2
+            usage_all
             exit 2
             ;;
         esac

--- a/Alas/Sources/Terminal/TerminalCLIInjection.swift
+++ b/Alas/Sources/Terminal/TerminalCLIInjection.swift
@@ -189,7 +189,7 @@ enum TerminalCLIInjection {
                   esac
                 done
                 request=$(build_request "$ALAS_SESSION_ID" "wt" "new" "$branch" "$base") || exit 1
-                send_request "$request"
+                send_request "$request" 30
                 ;;
               delete)
                 shift
@@ -228,7 +228,7 @@ enum TerminalCLIInjection {
                   esac
                 done
                 request=$(build_request "$ALAS_SESSION_ID" "wt" "delete" "$target" "$force" "$keep_branch") || exit 1
-                send_request "$request"
+                send_request "$request" 30
                 ;;
               *)
                 usage_all

--- a/Alas/Sources/Terminal/TerminalCLIInjection.swift
+++ b/Alas/Sources/Terminal/TerminalCLIInjection.swift
@@ -87,7 +87,8 @@ enum TerminalCLIInjection {
         }
 
         send_request() {
-          response=$(printf '%s\n' "$1" | /usr/bin/nc -U -w1 "$ALAS_SOCKET_PATH" 2>/dev/null)
+          timeout="${2:-1}"
+          response=$(printf '%s\n' "$1" | /usr/bin/nc -U -w "$timeout" "$ALAS_SOCKET_PATH" 2>/dev/null)
           alas_status=$?
           if [ "$alas_status" -ne 0 ]; then
             printf '%s\n' 'alas: could not reach Alas' >&2
@@ -243,10 +244,11 @@ enum TerminalCLIInjection {
             fi
             if [ "$#" -eq 0 ]; then
               request=$(build_request "$ALAS_SESSION_ID" "review") || exit 1
+              send_request "$request"
             else
               request=$(build_request "$ALAS_SESSION_ID" "review" "$1") || exit 1
+              send_request "$request" 30
             fi
-            send_request "$request"
             ;;
           *)
             usage_all

--- a/AlasTests/AlasCLICommandRouterTests.swift
+++ b/AlasTests/AlasCLICommandRouterTests.swift
@@ -13,7 +13,7 @@ struct AlasCLICommandRouterTests {
         return url
     }
 
-    @Test func opensInWorktreeFileByRelativePath() throws {
+    @Test func opensInWorktreeFileByRelativePath() async throws {
         let root = try makeFile("repo/a.txt").deletingLastPathComponent()
         let worktree = Worktree(
             id: "wt1", projectId: "p1", name: "main", branch: "main",
@@ -30,7 +30,7 @@ struct AlasCLICommandRouterTests {
             activateApp: {}
         )
 
-        let response = router.handle(.init(version: 1, sessionId: "s1", command: .open(paths: [root.appendingPathComponent("a.txt").path])))
+        let response = await router.handle(.init(version: 1, sessionId: "s1", command: .open(paths: [root.appendingPathComponent("a.txt").path])))
 
         #expect(response == .ok)
         #expect(opened.count == 1)
@@ -38,7 +38,7 @@ struct AlasCLICommandRouterTests {
         #expect(opened[0].relativePath == "a.txt")
     }
 
-    @Test func opensNestedWorktreeFileInMostSpecificVisibleWorktree() throws {
+    @Test func opensNestedWorktreeFileInMostSpecificVisibleWorktree() async throws {
         let root = try makeFile("repo/packages/tool/file.txt")
             .deletingLastPathComponent()
             .deletingLastPathComponent()
@@ -63,7 +63,7 @@ struct AlasCLICommandRouterTests {
             activateApp: {}
         )
 
-        let response = router.handle(.init(version: 1, sessionId: "s1", command: .open(paths: [nestedRoot.appendingPathComponent("file.txt").path])))
+        let response = await router.handle(.init(version: 1, sessionId: "s1", command: .open(paths: [nestedRoot.appendingPathComponent("file.txt").path])))
 
         #expect(response == .ok)
         #expect(opened.count == 1)
@@ -71,7 +71,7 @@ struct AlasCLICommandRouterTests {
         #expect(opened[0].relativePath == "file.txt")
     }
 
-    @Test func opensSymlinkedLogicalWorktreePathByRelativePath() throws {
+    @Test func opensSymlinkedLogicalWorktreePathByRelativePath() async throws {
         let realRoot = try makeFile("repo/Sources/App.swift")
             .deletingLastPathComponent()
             .deletingLastPathComponent()
@@ -93,7 +93,7 @@ struct AlasCLICommandRouterTests {
             activateApp: {}
         )
 
-        let response = router.handle(.init(version: 1, sessionId: "s1", command: .open(paths: [logicalFile.path])))
+        let response = await router.handle(.init(version: 1, sessionId: "s1", command: .open(paths: [logicalFile.path])))
 
         #expect(response == .ok)
         #expect(opened.count == 1)
@@ -101,7 +101,7 @@ struct AlasCLICommandRouterTests {
         #expect(opened[0].relativePath == "Sources/App.swift")
     }
 
-    @Test func opensCaseVariantWorktreePathByRelativePathOnCaseInsensitiveVolumes() throws {
+    @Test func opensCaseVariantWorktreePathByRelativePathOnCaseInsensitiveVolumes() async throws {
         let realRoot = try makeFile("repo/Sources/App.swift")
             .deletingLastPathComponent()
             .deletingLastPathComponent()
@@ -125,7 +125,7 @@ struct AlasCLICommandRouterTests {
             activateApp: {}
         )
 
-        let response = router.handle(.init(version: 1, sessionId: "s1", command: .open(paths: [caseVariantFile.path])))
+        let response = await router.handle(.init(version: 1, sessionId: "s1", command: .open(paths: [caseVariantFile.path])))
 
         #expect(response == .ok)
         #expect(opened.count == 1)
@@ -133,7 +133,7 @@ struct AlasCLICommandRouterTests {
         #expect(opened[0].relativePath == "Sources/App.swift")
     }
 
-    @Test func opensExternalFileOwnedByOriginatingWorktree() throws {
+    @Test func opensExternalFileOwnedByOriginatingWorktree() async throws {
         let root = try makeFile("repo/a.txt").deletingLastPathComponent()
         let external = try makeFile("external/note.txt")
         let worktree = Worktree(
@@ -151,7 +151,7 @@ struct AlasCLICommandRouterTests {
             activateApp: {}
         )
 
-        let response = router.handle(.init(version: 1, sessionId: "s1", command: .open(paths: [external.path])))
+        let response = await router.handle(.init(version: 1, sessionId: "s1", command: .open(paths: [external.path])))
 
         #expect(response == .ok)
         #expect(externalOpens.count == 1)
@@ -159,7 +159,7 @@ struct AlasCLICommandRouterTests {
         #expect(externalOpens[0].url.standardizedFileURL.path == external.standardizedFileURL.path)
     }
 
-    @Test func rejectsUnsafePrefixMatch() throws {
+    @Test func rejectsUnsafePrefixMatch() async throws {
         let repo = try makeFile("repo/a.txt").deletingLastPathComponent()
         let sibling = repo.deletingLastPathComponent().appendingPathComponent(repo.lastPathComponent + "-copy")
         try FileManager.default.createDirectory(at: sibling, withIntermediateDirectories: true)
@@ -180,13 +180,13 @@ struct AlasCLICommandRouterTests {
             activateApp: {}
         )
 
-        let response = router.handle(.init(version: 1, sessionId: "s1", command: .open(paths: [siblingFile.path])))
+        let response = await router.handle(.init(version: 1, sessionId: "s1", command: .open(paths: [siblingFile.path])))
 
         #expect(response == .ok)
         #expect(externalCount == 1)
     }
 
-    @Test func rejectsMissingFilesAndDirectories() throws {
+    @Test func rejectsMissingFilesAndDirectories() async throws {
         let root = try makeFile("repo/a.txt").deletingLastPathComponent()
         let worktree = Worktree(
             id: "wt1", projectId: "p1", name: "main", branch: "main",
@@ -201,8 +201,8 @@ struct AlasCLICommandRouterTests {
             activateApp: {}
         )
 
-        let missing = router.handle(.init(version: 1, sessionId: "s1", command: .open(paths: [root.appendingPathComponent("missing.txt").path])))
-        let directory = router.handle(.init(version: 1, sessionId: "s1", command: .open(paths: [root.path])))
+        let missing = await router.handle(.init(version: 1, sessionId: "s1", command: .open(paths: [root.appendingPathComponent("missing.txt").path])))
+        let directory = await router.handle(.init(version: 1, sessionId: "s1", command: .open(paths: [root.path])))
 
         guard case .error(let missingMessage) = missing else {
             Issue.record("expected missing file error")
@@ -216,7 +216,7 @@ struct AlasCLICommandRouterTests {
         #expect(directoryMessage.contains("is a directory"))
     }
 
-    @Test func returnsCombinedErrorForMissingFilesAndDirectoriesInOneRequest() throws {
+    @Test func returnsCombinedErrorForMissingFilesAndDirectoriesInOneRequest() async throws {
         let root = try makeFile("repo/a.txt").deletingLastPathComponent()
         let worktree = Worktree(
             id: "wt1", projectId: "p1", name: "main", branch: "main",
@@ -233,7 +233,7 @@ struct AlasCLICommandRouterTests {
             activateApp: { Issue.record("expected no activation") }
         )
 
-        let response = router.handle(.init(version: 1, sessionId: "s1", command: .open(paths: [missingPath, root.path])))
+        let response = await router.handle(.init(version: 1, sessionId: "s1", command: .open(paths: [missingPath, root.path])))
 
         guard case .error(let message) = response else {
             Issue.record("expected combined error")
@@ -243,7 +243,7 @@ struct AlasCLICommandRouterTests {
         #expect(message.contains("\(root.path) is a directory."))
     }
 
-    @Test func activatesAfterSuccessfulOpen() throws {
+    @Test func activatesAfterSuccessfulOpen() async throws {
         let root = try makeFile("repo/a.txt").deletingLastPathComponent()
         let worktree = Worktree(
             id: "wt1", projectId: "p1", name: "main", branch: "main",
@@ -260,13 +260,13 @@ struct AlasCLICommandRouterTests {
             activateApp: { activationCount += 1 }
         )
 
-        let response = router.handle(.init(version: 1, sessionId: "s1", command: .open(paths: [root.appendingPathComponent("a.txt").path])))
+        let response = await router.handle(.init(version: 1, sessionId: "s1", command: .open(paths: [root.appendingPathComponent("a.txt").path])))
 
         #expect(response == .ok)
         #expect(activationCount == 1)
     }
 
-    @Test func doesNotActivateWhenAllPathsFail() throws {
+    @Test func doesNotActivateWhenAllPathsFail() async throws {
         let root = try makeFile("repo/a.txt").deletingLastPathComponent()
         let worktree = Worktree(
             id: "wt1", projectId: "p1", name: "main", branch: "main",
@@ -283,12 +283,12 @@ struct AlasCLICommandRouterTests {
             activateApp: { activationCount += 1 }
         )
 
-        _ = router.handle(.init(version: 1, sessionId: "s1", command: .open(paths: [root.appendingPathComponent("missing.txt").path, root.path])))
+        _ = await router.handle(.init(version: 1, sessionId: "s1", command: .open(paths: [root.appendingPathComponent("missing.txt").path, root.path])))
 
         #expect(activationCount == 0)
     }
 
-    @Test func activatesOnceForMultiFileRequest() throws {
+    @Test func activatesOnceForMultiFileRequest() async throws {
         let first = try makeFile("repo/a.txt")
         let root = first.deletingLastPathComponent()
         let second = root.appendingPathComponent("b.txt")
@@ -308,9 +308,168 @@ struct AlasCLICommandRouterTests {
             activateApp: { activationCount += 1 }
         )
 
-        let response = router.handle(.init(version: 1, sessionId: "s1", command: .open(paths: [first.path, second.path])))
+        let response = await router.handle(.init(version: 1, sessionId: "s1", command: .open(paths: [first.path, second.path])))
 
         #expect(response == .ok)
         #expect(activationCount == 1)
+    }
+
+    @Test func listsCurrentProjectWorktrees() async throws {
+        let current = Self.worktree(branch: "main", path: "/tmp/repo", projectId: "p1")
+        let other = Self.worktree(branch: "feature/review", path: "/tmp/review", projectId: "p1")
+        let differentProject = Self.worktree(branch: "main", path: "/tmp/other", projectId: "p2")
+        let router = Self.router(origin: current, visibleWorktrees: [current, other, differentProject])
+
+        let response = await router.handle(.init(version: 1, sessionId: "s1", command: .worktree(.list)))
+
+        #expect(response == .text(AlasCLIWorktreeResolver.rows(worktrees: [current, other], currentWorktreeId: current.id)))
+    }
+
+    @Test func switchesMatchedWorktree() async throws {
+        let current = Self.worktree(branch: "main", path: "/tmp/repo", projectId: "p1")
+        let target = Self.worktree(branch: "feature/review", path: "/tmp/review", projectId: "p1")
+        var focused: (id: String, projectId: String)?
+        var activationCount = 0
+        let router = Self.router(
+            origin: current,
+            visibleWorktrees: [current, target],
+            focusWorktree: { focused = ($0.id, $0.projectId) },
+            activateApp: { activationCount += 1 }
+        )
+
+        let response = await router.handle(.init(version: 1, sessionId: "s1", command: .worktree(.switch(target: "feature"))))
+
+        #expect(response == .ok)
+        #expect(focused?.id == target.id)
+        #expect(focused?.projectId == "p1")
+        #expect(activationCount == 1)
+    }
+
+    @Test func returnsWorktreeResolutionErrors() async throws {
+        let current = Self.worktree(branch: "main", path: "/tmp/repo", projectId: "p1")
+        let first = Self.worktree(branch: "feature/a", path: "/tmp/a", projectId: "p1")
+        let second = Self.worktree(branch: "feature/b", path: "/tmp/b", projectId: "p1")
+        let router = Self.router(origin: current, visibleWorktrees: [current, first, second])
+
+        let missing = await router.handle(.init(version: 1, sessionId: "s1", command: .worktree(.switch(target: "missing"))))
+        let ambiguous = await router.handle(.init(version: 1, sessionId: "s1", command: .worktree(.delete(target: "feature", force: false, keepBranch: false))))
+
+        #expect(missing == .error("unknown worktree \"missing\""))
+        #expect(ambiguous == .error("ambiguous worktree \"feature\"; matches: feature/a, feature/b"))
+    }
+
+    @Test func createsNewWorktreeFromOrigin() async throws {
+        let current = Self.worktree(branch: "main", path: "/tmp/repo", projectId: "p1")
+        var created: (origin: Worktree, branch: String, base: String?)?
+        let router = Self.router(
+            origin: current,
+            visibleWorktrees: [current],
+            createWorktree: { origin, branch, base in
+                created = (origin, branch, base)
+                return .text(["created"])
+            }
+        )
+
+        let response = await router.handle(.init(version: 1, sessionId: "s1", command: .worktree(.new(branch: "feature/cli", base: "main"))))
+
+        #expect(response == .text(["created"]))
+        #expect(created?.origin == current)
+        #expect(created?.branch == "feature/cli")
+        #expect(created?.base == "main")
+    }
+
+    @Test func deletesMatchedWorktree() async throws {
+        let current = Self.worktree(branch: "main", path: "/tmp/repo", projectId: "p1")
+        let target = Self.worktree(branch: "feature/review", path: "/tmp/review", projectId: "p1")
+        var deleted: (worktree: Worktree, force: Bool, keepBranch: Bool)?
+        let router = Self.router(
+            origin: current,
+            visibleWorktrees: [current, target],
+            deleteWorktree: { worktree, force, keepBranch in
+                deleted = (worktree, force, keepBranch)
+                return .ok
+            }
+        )
+
+        let response = await router.handle(.init(version: 1, sessionId: "s1", command: .worktree(.delete(target: "feature", force: true, keepBranch: true))))
+
+        #expect(response == .ok)
+        #expect(deleted?.worktree == target)
+        #expect(deleted?.force == true)
+        #expect(deleted?.keepBranch == true)
+    }
+
+    @Test func opensLocalReviewChanges() async throws {
+        let current = Self.worktree(branch: "main", path: "/tmp/repo", projectId: "p1")
+        var opened: String?
+        var activationCount = 0
+        let router = Self.router(
+            origin: current,
+            visibleWorktrees: [current],
+            openReviewChanges: { opened = $0.id },
+            activateApp: { activationCount += 1 }
+        )
+
+        let response = await router.handle(.init(version: 1, sessionId: "s1", command: .review(.localChanges)))
+
+        #expect(response == .ok)
+        #expect(opened == current.id)
+        #expect(activationCount == 1)
+    }
+
+    @Test func opensProviderReviewFromOrigin() async throws {
+        let current = Self.worktree(branch: "main", path: "/tmp/repo", projectId: "p1")
+        var opened: (origin: Worktree, target: String)?
+        let router = Self.router(
+            origin: current,
+            visibleWorktrees: [current],
+            openProviderReview: { origin, target in
+                opened = (origin, target)
+                return .ok
+            }
+        )
+
+        let response = await router.handle(.init(version: 1, sessionId: "s1", command: .review(.provider(target: "123"))))
+
+        #expect(response == .ok)
+        #expect(opened?.origin == current)
+        #expect(opened?.target == "123")
+    }
+
+    private static func router(
+        origin: Worktree,
+        visibleWorktrees: [Worktree],
+        focusWorktree: @escaping (Worktree) -> Void = { _ in },
+        createWorktree: @escaping (Worktree, String, String?) async -> AlasCLIResponse = { _, _, _ in .ok },
+        deleteWorktree: @escaping (Worktree, Bool, Bool) async -> AlasCLIResponse = { _, _, _ in .ok },
+        openReviewChanges: @escaping (Worktree) -> Void = { _ in },
+        openProviderReview: @escaping (Worktree, String) async -> AlasCLIResponse = { _, _ in .ok },
+        activateApp: @escaping () -> Void = {}
+    ) -> AlasCLICommandRouter {
+        AlasCLICommandRouter(
+            sessionWorktreeId: { $0 == "s1" ? origin.id : nil },
+            originatingWorktree: { $0 == origin.id ? origin : nil },
+            visibleWorktrees: { visibleWorktrees },
+            openRelativeFile: { _, _ in Issue.record("expected no relative file open") },
+            openExternalFile: { _, _ in Issue.record("expected no external file open") },
+            focusWorktree: focusWorktree,
+            createWorktree: createWorktree,
+            deleteWorktree: deleteWorktree,
+            openReviewChanges: openReviewChanges,
+            openProviderReview: openProviderReview,
+            activateApp: activateApp
+        )
+    }
+
+    private static func worktree(branch: String, path: String, projectId: String) -> Worktree {
+        Worktree(
+            id: Worktree.makeId(path: URL(fileURLWithPath: path)),
+            projectId: projectId,
+            name: branch,
+            branch: branch,
+            path: URL(fileURLWithPath: path),
+            status: .clean,
+            lastActivity: Date()
+        )
     }
 }

--- a/AlasTests/AlasCLICommandRouterTests.swift
+++ b/AlasTests/AlasCLICommandRouterTests.swift
@@ -30,7 +30,7 @@ struct AlasCLICommandRouterTests {
             activateApp: {}
         )
 
-        let response = router.handle(.init(version: 1, command: .open, sessionId: "s1", paths: [root.appendingPathComponent("a.txt").path]))
+        let response = router.handle(.init(version: 1, sessionId: "s1", command: .open(paths: [root.appendingPathComponent("a.txt").path])))
 
         #expect(response == .ok)
         #expect(opened.count == 1)
@@ -63,7 +63,7 @@ struct AlasCLICommandRouterTests {
             activateApp: {}
         )
 
-        let response = router.handle(.init(version: 1, command: .open, sessionId: "s1", paths: [nestedRoot.appendingPathComponent("file.txt").path]))
+        let response = router.handle(.init(version: 1, sessionId: "s1", command: .open(paths: [nestedRoot.appendingPathComponent("file.txt").path])))
 
         #expect(response == .ok)
         #expect(opened.count == 1)
@@ -93,7 +93,7 @@ struct AlasCLICommandRouterTests {
             activateApp: {}
         )
 
-        let response = router.handle(.init(version: 1, command: .open, sessionId: "s1", paths: [logicalFile.path]))
+        let response = router.handle(.init(version: 1, sessionId: "s1", command: .open(paths: [logicalFile.path])))
 
         #expect(response == .ok)
         #expect(opened.count == 1)
@@ -125,7 +125,7 @@ struct AlasCLICommandRouterTests {
             activateApp: {}
         )
 
-        let response = router.handle(.init(version: 1, command: .open, sessionId: "s1", paths: [caseVariantFile.path]))
+        let response = router.handle(.init(version: 1, sessionId: "s1", command: .open(paths: [caseVariantFile.path])))
 
         #expect(response == .ok)
         #expect(opened.count == 1)
@@ -151,7 +151,7 @@ struct AlasCLICommandRouterTests {
             activateApp: {}
         )
 
-        let response = router.handle(.init(version: 1, command: .open, sessionId: "s1", paths: [external.path]))
+        let response = router.handle(.init(version: 1, sessionId: "s1", command: .open(paths: [external.path])))
 
         #expect(response == .ok)
         #expect(externalOpens.count == 1)
@@ -180,7 +180,7 @@ struct AlasCLICommandRouterTests {
             activateApp: {}
         )
 
-        let response = router.handle(.init(version: 1, command: .open, sessionId: "s1", paths: [siblingFile.path]))
+        let response = router.handle(.init(version: 1, sessionId: "s1", command: .open(paths: [siblingFile.path])))
 
         #expect(response == .ok)
         #expect(externalCount == 1)
@@ -201,8 +201,8 @@ struct AlasCLICommandRouterTests {
             activateApp: {}
         )
 
-        let missing = router.handle(.init(version: 1, command: .open, sessionId: "s1", paths: [root.appendingPathComponent("missing.txt").path]))
-        let directory = router.handle(.init(version: 1, command: .open, sessionId: "s1", paths: [root.path]))
+        let missing = router.handle(.init(version: 1, sessionId: "s1", command: .open(paths: [root.appendingPathComponent("missing.txt").path])))
+        let directory = router.handle(.init(version: 1, sessionId: "s1", command: .open(paths: [root.path])))
 
         guard case .error(let missingMessage) = missing else {
             Issue.record("expected missing file error")
@@ -233,7 +233,7 @@ struct AlasCLICommandRouterTests {
             activateApp: { Issue.record("expected no activation") }
         )
 
-        let response = router.handle(.init(version: 1, command: .open, sessionId: "s1", paths: [missingPath, root.path]))
+        let response = router.handle(.init(version: 1, sessionId: "s1", command: .open(paths: [missingPath, root.path])))
 
         guard case .error(let message) = response else {
             Issue.record("expected combined error")
@@ -260,7 +260,7 @@ struct AlasCLICommandRouterTests {
             activateApp: { activationCount += 1 }
         )
 
-        let response = router.handle(.init(version: 1, command: .open, sessionId: "s1", paths: [root.appendingPathComponent("a.txt").path]))
+        let response = router.handle(.init(version: 1, sessionId: "s1", command: .open(paths: [root.appendingPathComponent("a.txt").path])))
 
         #expect(response == .ok)
         #expect(activationCount == 1)
@@ -283,7 +283,7 @@ struct AlasCLICommandRouterTests {
             activateApp: { activationCount += 1 }
         )
 
-        _ = router.handle(.init(version: 1, command: .open, sessionId: "s1", paths: [root.appendingPathComponent("missing.txt").path, root.path]))
+        _ = router.handle(.init(version: 1, sessionId: "s1", command: .open(paths: [root.appendingPathComponent("missing.txt").path, root.path])))
 
         #expect(activationCount == 0)
     }
@@ -308,7 +308,7 @@ struct AlasCLICommandRouterTests {
             activateApp: { activationCount += 1 }
         )
 
-        let response = router.handle(.init(version: 1, command: .open, sessionId: "s1", paths: [first.path, second.path]))
+        let response = router.handle(.init(version: 1, sessionId: "s1", command: .open(paths: [first.path, second.path])))
 
         #expect(response == .ok)
         #expect(activationCount == 1)

--- a/AlasTests/AlasCLIRequestTests.swift
+++ b/AlasTests/AlasCLIRequestTests.swift
@@ -8,10 +8,50 @@ struct AlasCLIRequestTests {
 
         let request = try AlasCLIRequest.decode(from: Data(json.utf8))
 
-        #expect(request.version == 1)
-        #expect(request.command == .open)
-        #expect(request.sessionId == "s1")
-        #expect(request.paths == ["/tmp/a.txt", "/tmp/b.txt"])
+        #expect(request == AlasCLIRequest(version: 1, sessionId: "s1", command: .open(paths: ["/tmp/a.txt", "/tmp/b.txt"])))
+    }
+
+    @Test func decodesWorktreeListRequest() throws {
+        let json = #"{"v":1,"kind":"cli","command":"wt","subcommand":"list","session_id":"s1"}"#
+        let request = try AlasCLIRequest.decode(from: Data(json.utf8))
+        #expect(request == AlasCLIRequest(version: 1, sessionId: "s1", command: .worktree(.list)))
+    }
+
+    @Test func decodesWorktreeSwitchRequest() throws {
+        let json = #"{"v":1,"kind":"cli","command":"wt","subcommand":"switch","session_id":"s1","target":"feature/review"}"#
+        let request = try AlasCLIRequest.decode(from: Data(json.utf8))
+        #expect(request == AlasCLIRequest(version: 1, sessionId: "s1", command: .worktree(.switch(target: "feature/review"))))
+    }
+
+    @Test func decodesWorktreeNewRequestWithBase() throws {
+        let json = #"{"v":1,"kind":"cli","command":"wt","subcommand":"new","session_id":"s1","branch":"feature/review","base":"main"}"#
+        let request = try AlasCLIRequest.decode(from: Data(json.utf8))
+        #expect(request == AlasCLIRequest(version: 1, sessionId: "s1", command: .worktree(.new(branch: "feature/review", base: "main"))))
+    }
+
+    @Test func decodesWorktreeDeleteRequestWithFlags() throws {
+        let json = #"{"v":1,"kind":"cli","command":"wt","subcommand":"delete","session_id":"s1","target":"feature/review","force":true,"keep_branch":true}"#
+        let request = try AlasCLIRequest.decode(from: Data(json.utf8))
+        #expect(request == AlasCLIRequest(version: 1, sessionId: "s1", command: .worktree(.delete(target: "feature/review", force: true, keepBranch: true))))
+    }
+
+    @Test func decodesLocalReviewRequest() throws {
+        let json = #"{"v":1,"kind":"cli","command":"review","session_id":"s1"}"#
+        let request = try AlasCLIRequest.decode(from: Data(json.utf8))
+        #expect(request == AlasCLIRequest(version: 1, sessionId: "s1", command: .review(.localChanges)))
+    }
+
+    @Test func decodesProviderReviewRequest() throws {
+        let json = #"{"v":1,"kind":"cli","command":"review","session_id":"s1","target":"123"}"#
+        let request = try AlasCLIRequest.decode(from: Data(json.utf8))
+        #expect(request == AlasCLIRequest(version: 1, sessionId: "s1", command: .review(.provider(target: "123"))))
+    }
+
+    @Test func rejectsMissingWorktreeTarget() throws {
+        let json = #"{"v":1,"kind":"cli","command":"wt","subcommand":"switch","session_id":"s1"}"#
+        #expect(throws: AlasCLIRequestError.self) {
+            try AlasCLIRequest.decode(from: Data(json.utf8))
+        }
     }
 
     @Test func rejectsNonCLIKind() throws {
@@ -45,5 +85,11 @@ struct AlasCLIRequestTests {
         #expect(ok.contains(#""ok":true"#) || ok.contains(#""ok": true"#))
         #expect(error.contains(#""ok":false"#) || error.contains(#""ok": false"#))
         #expect(error.contains("No file."))
+    }
+
+    @Test func encodesTextResponse() throws {
+        let encoded = String(data: try AlasCLIResponse.text(["a", "b"]).encode(), encoding: .utf8) ?? ""
+        #expect(encoded.contains(#""ok":true"#))
+        #expect(encoded.contains(#""lines":["a","b"]"#))
     }
 }

--- a/AlasTests/AlasCLIReviewTargetResolverTests.swift
+++ b/AlasTests/AlasCLIReviewTargetResolverTests.swift
@@ -1,0 +1,37 @@
+import Testing
+@testable import Alas
+
+struct AlasCLIReviewTargetResolverTests {
+    @Test func parsesBareNumber() {
+        #expect(AlasCLIReviewTargetResolver.parse("123") == .number(123))
+    }
+
+    @Test func rejectsNonPositiveBareNumbers() {
+        #expect(AlasCLIReviewTargetResolver.parse("0") == nil)
+        #expect(AlasCLIReviewTargetResolver.parse("-1") == nil)
+    }
+
+    @Test func rejectsNonPositiveURLNumbers() {
+        #expect(AlasCLIReviewTargetResolver.parse("https://github.com/mrmans0n/alas/pull/0") == nil)
+        #expect(AlasCLIReviewTargetResolver.parse("https://gitlab.com/group/project/-/merge_requests/-1") == nil)
+    }
+
+    @Test func parsesGitHubPullURL() {
+        let parsed = AlasCLIReviewTargetResolver.parse("https://github.com/mrmans0n/alas/pull/580")
+        #expect(parsed == .url(host: "github.com", repositorySlug: "mrmans0n/alas", number: 580))
+    }
+
+    @Test func parsesGitLabMergeRequestURL() {
+        let parsed = AlasCLIReviewTargetResolver.parse("https://gitlab.com/group/project/-/merge_requests/42")
+        #expect(parsed == .url(host: "gitlab.com", repositorySlug: "group/project", number: 42))
+    }
+
+    @Test func rejectsUnsupportedURL() {
+        #expect(AlasCLIReviewTargetResolver.parse("https://example.com/review/1") == nil)
+    }
+
+    @Test func rejectsMalformedProviderURL() {
+        #expect(AlasCLIReviewTargetResolver.parse("https://github.com/mrmans0n/pull/580") == nil)
+        #expect(AlasCLIReviewTargetResolver.parse("https://gitlab.com/group/project/-/merge_requests/not-a-number") == nil)
+    }
+}

--- a/AlasTests/AlasCLIWorktreeResolverTests.swift
+++ b/AlasTests/AlasCLIWorktreeResolverTests.swift
@@ -1,0 +1,64 @@
+import Foundation
+import Testing
+@testable import Alas
+
+@MainActor
+struct AlasCLIWorktreeResolverTests {
+    @Test func rowsMarkCurrentWorktree() {
+        let current = Self.worktree(branch: "main", path: "/tmp/repo")
+        let other = Self.worktree(branch: "feature/review", path: "/tmp/repo-feature")
+        let rows = AlasCLIWorktreeResolver.rows(worktrees: [current, other], currentWorktreeId: current.id)
+        #expect(rows == ["* main                 /tmp/repo", "  feature/review       /tmp/repo-feature"])
+    }
+
+    @Test func exactBranchMatchWins() {
+        let main = Self.worktree(branch: "main", path: "/tmp/main")
+        let match = Self.worktree(branch: "feature/review", path: "/tmp/review")
+        let result = AlasCLIWorktreeResolver.resolve(target: "feature/review", worktrees: [main, match])
+        #expect(result == .matched(match))
+    }
+
+    @Test func exactNameMatchWinsBeforeBasename() {
+        let nameMatch = Self.worktree(name: "review", branch: "feature/review", path: "/tmp/name-match")
+        let basenameMatch = Self.worktree(branch: "other", path: "/tmp/review")
+        let result = AlasCLIWorktreeResolver.resolve(target: "review", worktrees: [basenameMatch, nameMatch])
+        #expect(result == .matched(nameMatch))
+    }
+
+    @Test func basenameMatchWorks() {
+        let match = Self.worktree(branch: "other", path: "/tmp/repo-feature")
+        let result = AlasCLIWorktreeResolver.resolve(target: "repo-feature", worktrees: [match])
+        #expect(result == .matched(match))
+    }
+
+    @Test func ambiguousPrefixListsCandidates() {
+        let b = Self.worktree(branch: "feat/b", path: "/tmp/b")
+        let a = Self.worktree(branch: "feat/a", path: "/tmp/a")
+        let result = AlasCLIWorktreeResolver.resolve(target: "feat", worktrees: [b, a])
+        #expect(result == .ambiguous(["feat/a", "feat/b"]))
+    }
+
+    @Test func ambiguousDuplicateLabelsIncludePaths() {
+        let b = Self.worktree(branch: "main", path: "/tmp/repo-b")
+        let a = Self.worktree(branch: "main", path: "/tmp/repo-a")
+        let result = AlasCLIWorktreeResolver.resolve(target: "main", worktrees: [b, a])
+        #expect(result == .ambiguous(["main (/tmp/repo-a)", "main (/tmp/repo-b)"]))
+    }
+
+    @Test func emptyTargetIsMissing() {
+        let result = AlasCLIWorktreeResolver.resolve(target: "   ", worktrees: [])
+        #expect(result == .missing(""))
+    }
+
+    private static func worktree(name: String? = nil, branch: String, path: String) -> Worktree {
+        Worktree(
+            id: Worktree.makeId(path: URL(fileURLWithPath: path)),
+            projectId: "project",
+            name: name ?? branch,
+            branch: branch,
+            path: URL(fileURLWithPath: path),
+            status: .clean,
+            lastActivity: Date()
+        )
+    }
+}

--- a/AlasTests/AlasCLIWorktreeResolverTests.swift
+++ b/AlasTests/AlasCLIWorktreeResolverTests.swift
@@ -8,7 +8,7 @@ struct AlasCLIWorktreeResolverTests {
         let current = Self.worktree(branch: "main", path: "/tmp/repo")
         let other = Self.worktree(branch: "feature/review", path: "/tmp/repo-feature")
         let rows = AlasCLIWorktreeResolver.rows(worktrees: [current, other], currentWorktreeId: current.id)
-        #expect(rows == ["* main                 /tmp/repo", "  feature/review       /tmp/repo-feature"])
+        #expect(rows == ["* main              /tmp/repo", "  feature/review    /tmp/repo-feature"])
     }
 
     @Test func exactBranchMatchWins() {

--- a/AlasTests/AppStateCLIRoutingTests.swift
+++ b/AlasTests/AppStateCLIRoutingTests.swift
@@ -5,17 +5,20 @@ import Testing
 @Suite(.serialized)
 @MainActor
 struct AppStateCLIRoutingTests {
-    private func makeRepo(name: String) async throws -> URL {
+    private func makeRepo(name: String, initialBranch: String = "main") async throws -> URL {
         let dir = FileManager.default.temporaryDirectory
             .appendingPathComponent("alas-cli-appstate-\(name)-\(UUID().uuidString)")
         try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
-        _ = try await Process.git(["init", "-q", "-b", "main"], cwd: dir)
+        _ = try await Process.git(["init", "-q", "-b", initialBranch], cwd: dir)
         _ = try await Process.git(["commit", "-q", "--allow-empty", "-m", "init"], cwd: dir)
         return dir
     }
 
-    private func makeStateWithWorktree(name: String) async throws -> (AppState, ProjectConfig, Worktree) {
-        let repo = try await makeRepo(name: name)
+    private func makeStateWithWorktree(
+        name: String,
+        initialBranch: String = "main"
+    ) async throws -> (AppState, ProjectConfig, Worktree) {
+        let repo = try await makeRepo(name: name, initialBranch: initialBranch)
         let state = AppState()
         let project = try await state.projectsManager.addProject(path: repo, displayName: "test", color: "#000000")
         try await state.projectsManager.refreshWorktrees(projectId: project.id)
@@ -485,6 +488,29 @@ struct AppStateCLIRoutingTests {
         })
     }
 
+    @Test func cliReviewFocusesOriginatingWorktreeBeforeOpeningReviewChanges() async throws {
+        let (state, project, main) = try await makeStateWithWorktree(name: "review-focus")
+        let otherPath = main.path.deletingLastPathComponent().appendingPathComponent("review-focus-other")
+        defer {
+            try? FileManager.default.removeItem(at: main.path)
+            try? FileManager.default.removeItem(at: otherPath)
+        }
+        _ = try await Process.git(["worktree", "add", "-q", "-b", "review-focus-other", otherPath.path, "main"], cwd: main.path)
+        try await state.projectsManager.refreshWorktrees(projectId: project.id)
+        let other = try #require(state.projectsManager.worktrees(projectId: project.id).first { $0.branch == "review-focus-other" })
+        state.selectedWorktreeId = other.id
+
+        let router = state.makeCLICommandRouter(sessionWorktreeLookup: { _ in main.id })
+        let response = await router.handle(.init(version: 1, sessionId: "s1", command: .review(.localChanges)))
+
+        #expect(response == .ok)
+        #expect(state.selectedWorktreeId == main.id)
+        #expect(state.tabs.tabs(forWorktree: main.id).contains {
+            if case .reviewChanges = $0 { return true }
+            return false
+        })
+    }
+
     @Test func cliReviewProviderRejectsUnsupportedTargetBeforeRemoteLookup() async throws {
         let (state, _, worktree) = try await makeStateWithWorktree(name: "review-provider-invalid")
         defer { try? FileManager.default.removeItem(at: worktree.path) }
@@ -579,6 +605,38 @@ struct AppStateCLIRoutingTests {
         let response = await router.handle(.init(version: 1, sessionId: "s1", command: .worktree(.new(branch: "already-there", base: "main"))))
 
         #expect(response == .error("A worktree already exists at this path."))
+    }
+
+    @Test func cliWorktreeNewUsesDialogPreferredBaseWhenBaseIsOmitted() async throws {
+        let (state, project, main) = try await makeStateWithWorktree(name: "new-default-base", initialBranch: "master")
+        let destinationRoot = main.path.deletingLastPathComponent()
+        let createdPath = destinationRoot.appendingPathComponent("from-master")
+        defer {
+            try? FileManager.default.removeItem(at: main.path)
+            try? FileManager.default.removeItem(at: createdPath)
+        }
+        state.config.worktrees.rootPath = destinationRoot.path
+        state.config.worktrees.pathTemplate = "{worktreeRoot}/{branch}"
+        state.config.worktrees.baseBranch = "stale-default"
+
+        let router = state.makeCLICommandRouter(sessionWorktreeLookup: { _ in main.id })
+        let response = await router.handle(.init(version: 1, sessionId: "s1", command: .worktree(.new(branch: "from-master", base: nil))))
+
+        let canonicalCreatedPath = createdPath
+            .deletingLastPathComponent()
+            .resolvingSymlinksInPath()
+            .appendingPathComponent(createdPath.lastPathComponent)
+        let createdId = Worktree.makeId(path: canonicalCreatedPath)
+        #expect(response == .text(["creating from-master at \(createdPath.path)"]))
+        for _ in 0..<100 {
+            if state.projectsManager.worktrees(projectId: project.id).contains(where: { $0.id == createdId }) &&
+                state.projectsManager.operationState(for: createdId) == nil {
+                break
+            }
+            try? await Task.sleep(for: .milliseconds(50))
+        }
+        #expect(state.projectsManager.operationState(for: createdId) == nil)
+        #expect(state.projectsManager.worktrees(projectId: project.id).contains { $0.id == createdId })
     }
 
     @Test func cliWorktreeDeleteMarksMatchedWorktreeDeleting() async throws {

--- a/AlasTests/AppStateCLIRoutingTests.swift
+++ b/AlasTests/AppStateCLIRoutingTests.swift
@@ -449,4 +449,169 @@ struct AppStateCLIRoutingTests {
             return false
         })
     }
+
+    @Test func cliWorktreeSwitchFocusesMatchedWorktree() async throws {
+        let (state, project, main) = try await makeStateWithWorktree(name: "switch")
+        defer { try? FileManager.default.removeItem(at: main.path) }
+        let other = Worktree(
+            id: "other",
+            projectId: project.id,
+            name: "feature/review",
+            branch: "feature/review",
+            path: main.path.deletingLastPathComponent().appendingPathComponent("other"),
+            status: .clean,
+            lastActivity: Date()
+        )
+        state.projectsManager.insertOptimisticWorktree(other)
+
+        let router = state.makeCLICommandRouter(sessionWorktreeLookup: { _ in main.id })
+        let response = await router.handle(.init(version: 1, sessionId: "s1", command: .worktree(.switch(target: "feature"))))
+
+        #expect(response == .ok)
+        #expect(state.selectedWorktreeId == other.id)
+    }
+
+    @Test func cliReviewOpensReviewChangesTab() async throws {
+        let (state, _, worktree) = try await makeStateWithWorktree(name: "review")
+        defer { try? FileManager.default.removeItem(at: worktree.path) }
+
+        let router = state.makeCLICommandRouter(sessionWorktreeLookup: { _ in worktree.id })
+        let response = await router.handle(.init(version: 1, sessionId: "s1", command: .review(.localChanges)))
+
+        #expect(response == .ok)
+        #expect(state.tabs.tabs(forWorktree: worktree.id).contains {
+            if case .reviewChanges = $0 { return true }
+            return false
+        })
+    }
+
+    @Test func cliWorktreeNewStartsCreation() async throws {
+        let (state, project, main) = try await makeStateWithWorktree(name: "new")
+        let destinationRoot = main.path.deletingLastPathComponent()
+        let createdPath = destinationRoot.appendingPathComponent("test-feature-cli")
+        defer {
+            try? FileManager.default.removeItem(at: main.path)
+            try? FileManager.default.removeItem(at: createdPath)
+        }
+        state.config.worktrees.rootPath = main.path.deletingLastPathComponent().path
+        state.config.worktrees.pathTemplate = "{worktreeRoot}/{repo}-{branch}"
+
+        let router = state.makeCLICommandRouter(sessionWorktreeLookup: { _ in main.id })
+        let response = await router.handle(.init(version: 1, sessionId: "s1", command: .worktree(.new(branch: "feature/cli", base: "missing-base"))))
+
+        let destination = WorktreePathTemplateRenderer.render(
+            template: state.config.worktrees.pathTemplate,
+            worktreeRoot: state.config.worktrees.rootPath,
+            repoName: project.name,
+            branch: "feature/cli"
+        )
+        let canonicalDestination = destination
+            .deletingLastPathComponent()
+            .resolvingSymlinksInPath()
+            .appendingPathComponent(destination.lastPathComponent)
+        let createdId = Worktree.makeId(path: canonicalDestination)
+        #expect(response == .text(["creating feature/cli at \(destination.path)"]))
+        #expect(state.projectsManager.operationState(for: createdId) == .creating)
+        #expect(state.projectsManager.worktrees(projectId: project.id).contains { $0.id == createdId })
+    }
+
+    @Test func cliWorktreeNewRejectsExistingDestination() async throws {
+        let (state, project, main) = try await makeStateWithWorktree(name: "new-existing")
+        defer { try? FileManager.default.removeItem(at: main.path) }
+        state.config.worktrees.rootPath = main.path.deletingLastPathComponent().path
+        state.config.worktrees.pathTemplate = "{worktreeRoot}/{branch}"
+        let existingBranch = main.path.lastPathComponent
+
+        let router = state.makeCLICommandRouter(sessionWorktreeLookup: { _ in main.id })
+        let response = await router.handle(.init(version: 1, sessionId: "s1", command: .worktree(.new(branch: existingBranch, base: "main"))))
+
+        #expect(response == .error("A worktree already exists at this path."))
+        #expect(state.projectsManager.worktrees(projectId: project.id).filter { $0.id == main.id }.count == 1)
+    }
+
+    @Test func cliWorktreeNewRejectsExistingDirectoryOnDisk() async throws {
+        let (state, _, main) = try await makeStateWithWorktree(name: "new-existing-dir")
+        let existingPath = main.path.deletingLastPathComponent().appendingPathComponent("already-there")
+        defer {
+            try? FileManager.default.removeItem(at: main.path)
+            try? FileManager.default.removeItem(at: existingPath)
+        }
+        try FileManager.default.createDirectory(at: existingPath, withIntermediateDirectories: true)
+        state.config.worktrees.rootPath = main.path.deletingLastPathComponent().path
+        state.config.worktrees.pathTemplate = "{worktreeRoot}/{branch}"
+
+        let router = state.makeCLICommandRouter(sessionWorktreeLookup: { _ in main.id })
+        let response = await router.handle(.init(version: 1, sessionId: "s1", command: .worktree(.new(branch: "already-there", base: "main"))))
+
+        #expect(response == .error("A worktree already exists at this path."))
+    }
+
+    @Test func cliWorktreeDeleteMarksMatchedWorktreeDeleting() async throws {
+        let (state, project, main) = try await makeStateWithWorktree(name: "delete")
+        let worktreePath = main.path.deletingLastPathComponent().appendingPathComponent("delete-target")
+        defer {
+            try? FileManager.default.removeItem(at: main.path)
+            try? FileManager.default.removeItem(at: worktreePath)
+        }
+        _ = try await Process.git(["worktree", "add", "-q", "-b", "delete-target", worktreePath.path, "main"], cwd: main.path)
+        try await state.projectsManager.refreshWorktrees(projectId: project.id)
+        let target = try #require(state.projectsManager.worktrees(projectId: project.id).first { $0.branch == "delete-target" })
+
+        let router = state.makeCLICommandRouter(sessionWorktreeLookup: { _ in main.id })
+        let response = await router.handle(.init(version: 1, sessionId: "s1", command: .worktree(.delete(target: "delete-target", force: false, keepBranch: true))))
+
+        #expect(response == .ok)
+        #expect(state.projectsManager.operationState(for: target.id) == .deleting)
+    }
+
+    @Test func cliWorktreeDeleteIsIdempotentWhileDeleting() async throws {
+        let (state, project, main) = try await makeStateWithWorktree(name: "delete-idempotent")
+        let target = Worktree(
+            id: "deleting-target",
+            projectId: project.id,
+            name: "feature/delete",
+            branch: "feature/delete",
+            path: main.path.deletingLastPathComponent().appendingPathComponent("deleting-target"),
+            status: .clean,
+            lastActivity: Date()
+        )
+        defer { try? FileManager.default.removeItem(at: main.path) }
+        state.projectsManager.insertOptimisticWorktree(target)
+        state.projectsManager.setOperationState(id: target.id, state: .deleting)
+
+        let router = state.makeCLICommandRouter(sessionWorktreeLookup: { _ in main.id })
+        let response = await router.handle(.init(version: 1, sessionId: "s1", command: .worktree(.delete(target: "feature/delete", force: true, keepBranch: true))))
+
+        #expect(response == .ok)
+        #expect(state.projectsManager.operationState(for: target.id) == .deleting)
+    }
+
+    @Test func cliWorktreeDeleteForceClearsStalePendingForceState() async throws {
+        let (state, project, main) = try await makeStateWithWorktree(name: "delete-force")
+        let worktreePath = main.path.deletingLastPathComponent().appendingPathComponent("delete-force-target")
+        defer {
+            try? FileManager.default.removeItem(at: main.path)
+            try? FileManager.default.removeItem(at: worktreePath)
+        }
+        _ = try await Process.git(["worktree", "add", "-q", "-b", "delete-force-target", worktreePath.path, "main"], cwd: main.path)
+        try await state.projectsManager.refreshWorktrees(projectId: project.id)
+        let target = try #require(state.projectsManager.worktrees(projectId: project.id).first { $0.branch == "delete-force-target" })
+        state.pendingForceDeleteWorktree = AppState.PendingForceDeleteWorktree(
+            id: target.id,
+            branch: target.branch,
+            projectId: target.projectId,
+            repoPath: main.path,
+            worktreePath: target.path,
+            deleteBranchIfMerged: false,
+            removedIndex: 1,
+            reason: .dirty
+        )
+
+        let router = state.makeCLICommandRouter(sessionWorktreeLookup: { _ in main.id })
+        let response = await router.handle(.init(version: 1, sessionId: "s1", command: .worktree(.delete(target: "delete-force-target", force: true, keepBranch: true))))
+
+        #expect(response == .ok)
+        #expect(state.pendingForceDeleteWorktree == nil)
+        #expect(state.projectsManager.operationState(for: target.id) == .deleting)
+    }
 }

--- a/AlasTests/AppStateCLIRoutingTests.swift
+++ b/AlasTests/AppStateCLIRoutingTests.swift
@@ -485,6 +485,41 @@ struct AppStateCLIRoutingTests {
         })
     }
 
+    @Test func cliReviewProviderRejectsUnsupportedTargetBeforeRemoteLookup() async throws {
+        let (state, _, worktree) = try await makeStateWithWorktree(name: "review-provider-invalid")
+        defer { try? FileManager.default.removeItem(at: worktree.path) }
+
+        let router = state.makeCLICommandRouter(sessionWorktreeLookup: { _ in worktree.id })
+        let response = await router.handle(.init(version: 1, sessionId: "s1", command: .review(.provider(target: "not-a-review"))))
+
+        #expect(response == .error("unsupported review URL"))
+    }
+
+    @Test func cliReviewProviderReturnsErrorWhenNoCodeHostRemoteExists() async throws {
+        let (state, _, worktree) = try await makeStateWithWorktree(name: "review-provider-no-remote")
+        defer { try? FileManager.default.removeItem(at: worktree.path) }
+
+        let router = state.makeCLICommandRouter(sessionWorktreeLookup: { _ in worktree.id })
+        let response = await router.handle(.init(version: 1, sessionId: "s1", command: .review(.provider(target: "123"))))
+
+        #expect(response == .error("no code host remote found for this worktree"))
+    }
+
+    @Test func cliReviewProviderRejectsURLThatDoesNotMatchAnyCodeHostRemote() async throws {
+        let (state, _, worktree) = try await makeStateWithWorktree(name: "review-provider-mismatch")
+        defer { try? FileManager.default.removeItem(at: worktree.path) }
+        _ = try await Process.git(["remote", "add", "origin", "https://github.com/nacho/alas.git"], cwd: worktree.path)
+
+        let router = state.makeCLICommandRouter(sessionWorktreeLookup: { _ in worktree.id })
+        let response = await router.handle(.init(
+            version: 1,
+            sessionId: "s1",
+            command: .review(.provider(target: "https://github.com/mrmans0n/alas/pull/580"))
+        ))
+
+        #expect(response == .error("review URL does not match this worktree's remote"))
+    }
+
     @Test func cliWorktreeNewStartsCreation() async throws {
         let (state, project, main) = try await makeStateWithWorktree(name: "new")
         let destinationRoot = main.path.deletingLastPathComponent()

--- a/AlasTests/AppStateCLIRoutingTests.swift
+++ b/AlasTests/AppStateCLIRoutingTests.swift
@@ -38,7 +38,7 @@ struct AppStateCLIRoutingTests {
         let router = state.makeCLICommandRouter(sessionWorktreeLookup: { sessionId in
             sessionId == "s1" ? worktree.id : nil
         })
-        let response = router.handle(.init(version: 1, sessionId: "s1", command: .open(paths: [file.path])))
+        let response = await router.handle(.init(version: 1, sessionId: "s1", command: .open(paths: [file.path])))
 
         #expect(response == .ok)
         #expect(state.tabs.tabs(forWorktree: worktree.id).contains {
@@ -436,7 +436,7 @@ struct AppStateCLIRoutingTests {
         let router = state.makeCLICommandRouter(sessionWorktreeLookup: { sessionId in
             sessionId == "s1" ? worktree.id : nil
         })
-        let response = router.handle(.init(version: 1, sessionId: "s1", command: .open(paths: [externalFile.path])))
+        let response = await router.handle(.init(version: 1, sessionId: "s1", command: .open(paths: [externalFile.path])))
 
         #expect(response == .ok)
         #expect(state.selectedWorktreeId == worktree.id)

--- a/AlasTests/AppStateCLIRoutingTests.swift
+++ b/AlasTests/AppStateCLIRoutingTests.swift
@@ -38,7 +38,7 @@ struct AppStateCLIRoutingTests {
         let router = state.makeCLICommandRouter(sessionWorktreeLookup: { sessionId in
             sessionId == "s1" ? worktree.id : nil
         })
-        let response = router.handle(.init(version: 1, command: .open, sessionId: "s1", paths: [file.path]))
+        let response = router.handle(.init(version: 1, sessionId: "s1", command: .open(paths: [file.path])))
 
         #expect(response == .ok)
         #expect(state.tabs.tabs(forWorktree: worktree.id).contains {
@@ -69,7 +69,7 @@ struct AppStateCLIRoutingTests {
         state.startHarness()
 
         let handler = try #require(state.harness.socketServer.onCLIRequest)
-        let response = await handler(.init(version: 1, command: .open, sessionId: "s1", paths: [file.path]))
+        let response = await handler(.init(version: 1, sessionId: "s1", command: .open(paths: [file.path])))
 
         #expect(response == .ok)
         #expect(state.tabs.tabs(forWorktree: worktree.id).contains {
@@ -436,7 +436,7 @@ struct AppStateCLIRoutingTests {
         let router = state.makeCLICommandRouter(sessionWorktreeLookup: { sessionId in
             sessionId == "s1" ? worktree.id : nil
         })
-        let response = router.handle(.init(version: 1, command: .open, sessionId: "s1", paths: [externalFile.path]))
+        let response = router.handle(.init(version: 1, sessionId: "s1", command: .open(paths: [externalFile.path])))
 
         #expect(response == .ok)
         #expect(state.selectedWorktreeId == worktree.id)

--- a/AlasTests/Integrations/CodeHostRemoteDetectorTests.swift
+++ b/AlasTests/Integrations/CodeHostRemoteDetectorTests.swift
@@ -109,6 +109,26 @@ struct CodeHostRemoteDetectorTests {
         #expect(remotes.map(\.repositorySlug) == ["nacho/alas", "mrmans0n/alas"])
     }
 
+    @Test func detectAllUsesBaseBranchPreferredRemoteBeforeOrigin() {
+        let gitRemotes = [
+            GitRemote(name: "origin", url: "https://github.com/nacho/alas.git"),
+            GitRemote(name: "upstream", url: "https://github.com/mrmans0n/alas.git"),
+        ]
+        let preferredRemoteName = CodeHostRemoteDetector.preferredRemoteName(
+            forBaseBranch: "upstream/main",
+            remotes: gitRemotes
+        )
+
+        let remotes = CodeHostRemoteDetector.detectAll(
+            from: gitRemotes,
+            preferredRemoteName: preferredRemoteName
+        )
+
+        #expect(preferredRemoteName == "upstream")
+        #expect(remotes.map(\.remoteName) == ["upstream", "origin"])
+        #expect(remotes.map(\.repositorySlug) == ["mrmans0n/alas", "nacho/alas"])
+    }
+
     @Test func preferredRemoteOverridesOrigin() {
         let remote = CodeHostRemoteDetector.detect(
             from: [

--- a/AlasTests/Integrations/CodeHostRemoteDetectorTests.swift
+++ b/AlasTests/Integrations/CodeHostRemoteDetectorTests.swift
@@ -99,6 +99,16 @@ struct CodeHostRemoteDetectorTests {
         #expect(remote?.repository == "alas")
     }
 
+    @Test func detectAllReturnsOriginFirstThenOtherSupportedRemotes() {
+        let remotes = CodeHostRemoteDetector.detectAll(from: [
+            GitRemote(name: "upstream", url: "https://github.com/mrmans0n/alas.git"),
+            GitRemote(name: "origin", url: "https://github.com/nacho/alas.git"),
+        ])
+
+        #expect(remotes.map(\.remoteName) == ["origin", "upstream"])
+        #expect(remotes.map(\.repositorySlug) == ["nacho/alas", "mrmans0n/alas"])
+    }
+
     @Test func preferredRemoteOverridesOrigin() {
         let remote = CodeHostRemoteDetector.detect(
             from: [

--- a/AlasTests/TerminalCLIInjectionTests.swift
+++ b/AlasTests/TerminalCLIInjectionTests.swift
@@ -23,7 +23,7 @@ struct TerminalCLIInjectionTests {
         #expect(script.contains(#"build_request "$ALAS_SESSION_ID" "wt" "new" "$branch" "$base""#))
         #expect(script.contains(#"build_request "$ALAS_SESSION_ID" "wt" "delete" "$target" "$force" "$keep_branch""#))
         #expect(script.contains(#"build_request "$ALAS_SESSION_ID" "review""#))
-        #expect(script.contains(#"send_request "$request" 30"#))
+        #expect(script.components(separatedBy: #"send_request "$request" 30"#).count == 4)
         #expect(script.contains(#""keep_branch""#))
     }
 

--- a/AlasTests/TerminalCLIInjectionTests.swift
+++ b/AlasTests/TerminalCLIInjectionTests.swift
@@ -124,7 +124,10 @@ struct TerminalCLIInjectionTests {
         #expect(process.terminationStatus == 0)
         #expect(stdoutText == "")
         #expect(stderrText == "")
-        #expect(request?.command == .open)
+        if case .open = request?.command {
+        } else {
+            Issue.record("expected open command")
+        }
         #expect(request?.sessionId == "test-session")
         #expect(request?.paths == ["\(logicalDir)/dir with spaces/file.txt"])
     }

--- a/AlasTests/TerminalCLIInjectionTests.swift
+++ b/AlasTests/TerminalCLIInjectionTests.swift
@@ -12,7 +12,7 @@ struct TerminalCLIInjectionTests {
         #expect(script.contains(#""kind": "cli""#))
         #expect(script.contains(#""command": command"#))
         #expect(script.contains("os.path.abspath"))
-        #expect(script.contains("/usr/bin/nc -U -w1"))
+        #expect(script.contains(#"/usr/bin/nc -U -w "$timeout""#))
     }
 
     @Test func executableScriptSendsWorktreeAndReviewRequests() {
@@ -23,6 +23,7 @@ struct TerminalCLIInjectionTests {
         #expect(script.contains(#"build_request "$ALAS_SESSION_ID" "wt" "new" "$branch" "$base""#))
         #expect(script.contains(#"build_request "$ALAS_SESSION_ID" "wt" "delete" "$target" "$force" "$keep_branch""#))
         #expect(script.contains(#"build_request "$ALAS_SESSION_ID" "review""#))
+        #expect(script.contains(#"send_request "$request" 30"#))
         #expect(script.contains(#""keep_branch""#))
     }
 

--- a/AlasTests/TerminalCLIInjectionTests.swift
+++ b/AlasTests/TerminalCLIInjectionTests.swift
@@ -10,9 +10,20 @@ struct TerminalCLIInjectionTests {
         #expect(script.contains("ALAS_SOCKET_PATH"))
         #expect(script.contains("ALAS_SESSION_ID"))
         #expect(script.contains(#""kind": "cli""#))
-        #expect(script.contains(#""command": "open""#))
+        #expect(script.contains(#""command": command"#))
         #expect(script.contains("os.path.abspath"))
         #expect(script.contains("/usr/bin/nc -U -w1"))
+    }
+
+    @Test func executableScriptSendsWorktreeAndReviewRequests() {
+        let script = TerminalCLIInjection.executableScript()
+
+        #expect(script.contains(#"build_request "$ALAS_SESSION_ID" "wt" "list""#))
+        #expect(script.contains(#"build_request "$ALAS_SESSION_ID" "wt" "switch" "$1""#))
+        #expect(script.contains(#"build_request "$ALAS_SESSION_ID" "wt" "new" "$branch" "$base""#))
+        #expect(script.contains(#"build_request "$ALAS_SESSION_ID" "wt" "delete" "$target" "$force" "$keep_branch""#))
+        #expect(script.contains(#"build_request "$ALAS_SESSION_ID" "review""#))
+        #expect(script.contains(#""keep_branch""#))
     }
 
     @Test func aoExecutableScriptExecsAlasOpen() {
@@ -67,14 +78,64 @@ struct TerminalCLIInjectionTests {
     }
 
     @Test func bashExecutableSendsOpenRequestFromLogicalPWD() async throws {
-        try await assertExecutableSendsOpenRequestFromLogicalPWD(shell: "/bin/bash")
+        try await assertExecutableRequest(
+            shell: "/bin/bash",
+            commandLine: #"cd "$ALAS_LOGICAL_DIR"; alas open "dir with spaces/file.txt""#
+        ) { request in
+            if case .open(let paths) = request.command {
+                #expect(paths.count == 1)
+                #expect(paths.first?.hasSuffix("/logical/dir with spaces/file.txt") == true)
+            } else {
+                Issue.record("expected open command")
+            }
+        }
     }
 
     @Test func zshExecutableSendsOpenRequestFromLogicalPWD() async throws {
-        try await assertExecutableSendsOpenRequestFromLogicalPWD(shell: "/bin/zsh")
+        try await assertExecutableRequest(
+            shell: "/bin/zsh",
+            commandLine: #"cd "$ALAS_LOGICAL_DIR"; alas open "dir with spaces/file.txt""#
+        ) { request in
+            if case .open(let paths) = request.command {
+                #expect(paths.count == 1)
+                #expect(paths.first?.hasSuffix("/logical/dir with spaces/file.txt") == true)
+            } else {
+                Issue.record("expected open command")
+            }
+        }
     }
 
-    private func assertExecutableSendsOpenRequestFromLogicalPWD(shell: String) async throws {
+    @Test func bashExecutableSendsWorktreeListRequest() async throws {
+        try await assertExecutableRequest(shell: "/bin/bash", commandLine: "alas wt list") { request in
+            #expect(request.command == .worktree(.list))
+        }
+    }
+
+    @Test func zshExecutableSendsReviewProviderRequest() async throws {
+        try await assertExecutableRequest(shell: "/bin/zsh", commandLine: "alas review 123") { request in
+            #expect(request.command == .review(.provider(target: "123")))
+        }
+    }
+
+    @Test func executablePrintsResponseLines() async throws {
+        try await assertExecutableRequest(
+            shell: "/bin/bash",
+            commandLine: "alas wt list",
+            response: .text(["* main    /tmp/repo", "  feature /tmp/repo-feature"]),
+            expectedStdout: "* main    /tmp/repo\n  feature /tmp/repo-feature\n"
+        ) { request in
+            #expect(request.command == .worktree(.list))
+        }
+    }
+
+    private func assertExecutableRequest(
+        shell: String,
+        commandLine: String,
+        response: AlasCLIResponse = .ok,
+        expectedStdout: String = "",
+        expectedStderr: String = "",
+        verify: @escaping (AlasCLIRequest) -> Void
+    ) async throws {
         let root = "/tmp/alas-cli-injection-\(UUID().uuidString)"
         let realDir = "\(root)/real"
         let logicalDir = "\(root)/logical"
@@ -94,14 +155,15 @@ struct TerminalCLIInjectionTests {
             func current() -> AlasCLIRequest? { request }
         }
         let holder = Holder()
+        let response = response
         server.onCLIRequest = { request in
             await holder.set(request)
-            return .ok
+            return response
         }
 
         let process = Process()
         process.executableURL = URL(fileURLWithPath: shell)
-        process.arguments = ["-c", #"cd "$ALAS_LOGICAL_DIR"; alas open "dir with spaces/file.txt""#]
+        process.arguments = ["-c", commandLine]
         process.currentDirectoryURL = URL(fileURLWithPath: root, isDirectory: true)
         var env = ProcessInfo.processInfo.environment
         env["PATH"] = "\(binDir.path):\(env["PATH"] ?? "")"
@@ -122,13 +184,13 @@ struct TerminalCLIInjectionTests {
         let request = await holder.current()
 
         #expect(process.terminationStatus == 0)
-        #expect(stdoutText == "")
-        #expect(stderrText == "")
-        if case .open = request?.command {
+        #expect(stdoutText == expectedStdout)
+        #expect(stderrText == expectedStderr)
+        if let request {
+            verify(request)
         } else {
-            Issue.record("expected open command")
+            Issue.record("expected CLI request")
         }
         #expect(request?.sessionId == "test-session")
-        #expect(request?.paths == ["\(logicalDir)/dir with spaces/file.txt"])
     }
 }

--- a/AlasTests/WorktreePathTemplateRendererTests.swift
+++ b/AlasTests/WorktreePathTemplateRendererTests.swift
@@ -1,0 +1,32 @@
+import Foundation
+import Testing
+@testable import Alas
+
+struct WorktreePathTemplateRendererTests {
+    @Test func rendersConfiguredTemplate() {
+        let rendered = WorktreePathTemplateRenderer.render(
+            template: "{worktreeRoot}/{repo}-{branch}-{user}-{ts}",
+            worktreeRoot: "/tmp/worktrees",
+            repoName: "mrmans0n/alas",
+            branch: "feature/review-cli",
+            userName: "nacho",
+            date: Date(timeIntervalSince1970: 0)
+        )
+
+        #expect(rendered.path == "/tmp/worktrees/alas-feature-review-cli-nacho-1970-01-01T00:00:00Z")
+    }
+
+    @Test func expandsTildeInRenderedPath() {
+        let rendered = WorktreePathTemplateRenderer.render(
+            template: "~/worktrees/{repo}/{branch}",
+            worktreeRoot: "/unused",
+            repoName: "alas",
+            branch: "main",
+            userName: "nacho",
+            date: Date(timeIntervalSince1970: 0)
+        )
+
+        #expect(!rendered.path.hasPrefix("~"))
+        #expect(rendered.path.hasSuffix("/worktrees/alas/main"))
+    }
+}

--- a/README.md
+++ b/README.md
@@ -36,7 +36,8 @@ agent session, and diff side-by-side.
 
 - **Parallel worktrees, one window.** Every repo lives in the sidebar with its
   linked worktrees underneath. Switching is instant; terminal sessions, tabs, and
-  scroll positions persist per worktree.
+  scroll positions persist per worktree. Built-in `alas` terminal commands open
+  files, switch/create/delete worktrees, and jump into local or provider reviews.
 
   ![Terminal pane with a live agent run and per-worktree changes](art/alas-terminal.png)
 

--- a/docs/manual-test.md
+++ b/docs/manual-test.md
@@ -214,14 +214,23 @@ Run from a real worktree with at least one Swift file and one CRLF text file.
 - **Big file responsiveness.** Open a 5 k-line file, type rapidly. No visible flicker. Diagnostics catch up within ~1 s of pause.
 - **Save failure.** `chmod 555` the parent directory, edit, ⌘S. The conflict-banner area shows "Couldn't save: …". Restore perms, ⌘S succeeds.
 
-## `ao` alias
+## Terminal Commands
 
 Inside an Alas-spawned terminal:
 
+- `type alas` reports the script path under Alas's per-user bin dir.
+- `alas open README.md` opens the file in the editor.
+- `alas wt list` prints the visible worktrees and marks the current one.
+- `alas wt switch <name-or-branch>` focuses the matching worktree.
+- `alas wt new manual-test-branch --base main` starts worktree creation and shows progress in the sidebar.
+- On a disposable worktree, `alas wt delete <name-or-branch>` starts deletion; dirty worktrees are rejected unless rerun with `--force`.
+- `alas review` opens the local Changes review tab.
+- In a GitHub- or GitLab-backed worktree, `alas review <number-or-url>` opens the provider PR/MR review session.
 - `type ao` reports the script path under Alas's per-user bin dir (same directory as `alas`).
 - `ao README.md` opens the file in the editor (identical behavior to `alas open README.md`).
 - `ao` with no arguments prints `usage: alas open <path> [path...]` and exits with a non-zero status.
 - Launching a terminal **outside** Alas, `type ao` reports `ao: not found` (or the shell's equivalent).
+- Launching a terminal **outside** Alas, `type alas` reports `alas: not found` (or the shell's equivalent).
 
 ## Review Loop Drawer
 

--- a/docs/superpowers/specs/2026-06-19-terminal-worktree-review-commands-design.md
+++ b/docs/superpowers/specs/2026-06-19-terminal-worktree-review-commands-design.md
@@ -1,0 +1,203 @@
+# Terminal Worktree And Review Commands Design
+
+## Context
+
+Alas currently injects two commands into Alas-owned terminal sessions:
+
+- `alas open <path> [path...]`
+- `ao <path> [path...]`, a shortcut for `alas open`
+
+The injected `alas` command is terminal-only. It requires `ALAS_SOCKET_PATH` and
+`ALAS_SESSION_ID`, sends a JSON request to the running app over the existing
+socket, and lets Swift resolve the request against the originating terminal
+session. This keeps command behavior scoped to the active Alas worktree instead
+of creating a second workspace model in shell.
+
+This design extends that model with worktree and review commands.
+
+## Goals
+
+- Add terminal commands for common worktree actions: list, switch, create, and
+  delete.
+- Add terminal commands for opening the current worktree's review surfaces.
+- Keep commands available only inside Alas terminals for this pass.
+- Keep Swift as the source of truth for projects, visible worktrees, tabs,
+  review sessions, and safety checks.
+- Preserve `alas open` and `ao` behavior.
+
+## Non-Goals
+
+- Running these commands from arbitrary external shells.
+- Replacing `git worktree` as a standalone CLI.
+- Adding agent launch/resume commands in this pass.
+- Starting review-loop automation, publishing reviews, or posting comments from
+  `alas review`.
+- Adding archive/hidden-worktree management to the first CLI surface.
+
+## Command Surface
+
+```sh
+alas open <path> [path...]
+alas wt list
+alas wt switch <name-or-branch>
+alas wt new <branch> [--base <ref>]
+alas wt delete <name-or-branch> [--force] [--keep-branch]
+alas review
+alas review <pr-number-or-url>
+```
+
+`ao` remains an alias for `alas open`.
+
+## Architecture
+
+The injected shell script remains a thin request builder. It validates that the
+command is running inside an Alas terminal, resolves shell-relative path
+arguments where needed, sends a typed JSON request to the app socket, formats
+simple command output, and exits with the status implied by the app response.
+
+The app-side `AlasCLICommandRouter` becomes a small dispatcher instead of an
+`open`-only handler. Each request still carries `session_id`, and the router
+uses the same session-to-worktree lookup already used by `alas open`. If the
+session cannot be mapped to a worktree, the command fails with a clear error.
+
+All project/worktree/review decisions stay in Swift. The shell script should not
+inspect Git state directly, mutate worktrees, or infer app state beyond argv and
+environment variables.
+
+## Worktree Commands
+
+### `alas wt list`
+
+Lists visible worktrees in the originating worktree's current project. The
+output should be compact and useful in a terminal:
+
+```text
+* main                 /path/to/repo
+  feature/review-cli   /path/to/repo-feature-review-cli
+```
+
+The current/originating worktree is marked with `*`. Hidden or archived
+worktrees are not included in the first version.
+
+### `alas wt switch <name-or-branch>`
+
+Focuses an existing visible worktree in the current project and activates Alas.
+
+Matching order:
+
+1. Exact branch/name match.
+2. Exact path basename match.
+3. Unique prefix/fuzzy match.
+
+If no worktree matches, the command returns an error. If multiple worktrees
+match, the command returns an ambiguity error listing the candidates. The
+command does not create a worktree implicitly.
+
+### `alas wt new <branch> [--base <ref>]`
+
+Starts the existing app-owned worktree creation flow and focuses the optimistic
+worktree row when creation is accepted. The destination path follows the same
+convention the app uses for worktrees created from the UI.
+
+If `--base` is omitted, the command uses the same default base behavior as the
+UI creation path for the originating worktree. If `--base` is present, it is
+passed through to the existing worktree creation service as the base ref.
+
+On success, the command may print the accepted branch/path. Creation errors
+come from the app's existing validation and Git error handling.
+
+### `alas wt delete <name-or-branch> [--force] [--keep-branch]`
+
+Deletes a visible worktree matched by the same resolver as `wt switch`.
+
+The command reuses the existing delete flow and preflight safety rules. Without
+`--force`, dirty worktrees or worktrees with initialized submodules fail with a
+message explaining why force is needed. With `--force`, the delete request maps
+to the app's forced delete path. `--keep-branch` maps to the existing
+branch-retention option.
+
+The command is intentionally named `delete`, not `remove`, to keep the action
+plain and explicit.
+
+## Review Commands
+
+### `alas review`
+
+Opens or focuses the current worktree's Review Changes tab. This is equivalent
+to using the existing app action from the selected worktree. It activates Alas
+and leaves the terminal session intact.
+
+### `alas review <pr-number-or-url>`
+
+Opens a provider-backed review session for the originating worktree.
+
+For a bare number, Alas resolves it as a pull request or merge request number
+for the current worktree's configured code host remote. For a URL, Alas infers
+the provider and review target from the URL when the provider supports it.
+
+If no code host remote can be resolved, or the URL/provider is unsupported, the
+command returns a terminal-readable error. It should not fall back to opening a
+browser, because the command's purpose is to open an Alas review surface.
+
+The command uses the existing review session/store/launcher path. It does not
+start review-loop automation, publish comments, submit verdicts, or mutate code
+host state.
+
+## Responses And Output
+
+The app response should grow beyond the current simple `{ "ok": true }` shape so
+commands can return structured payloads.
+
+Suggested response cases:
+
+- success with no output
+- success with text lines
+- success with structured worktree rows for `wt list`
+- failure with a single message
+
+The shell wrapper formats command output to stdout and prints errors to stderr.
+Action commands can stay quiet on success unless they naturally produce useful
+confirmation, such as `wt new`.
+
+Examples:
+
+```text
+alas: unknown worktree "foo"
+alas: ambiguous worktree "feat"; matches: feat/a, feat/b
+alas: worktree has local changes; rerun with --force to delete
+alas: no code host remote found for this worktree
+alas: unsupported review URL
+```
+
+Exit codes remain simple:
+
+- `0` for successful commands.
+- `1` for app-level request failures.
+- `2` for usage errors or commands run outside Alas terminals.
+
+## Testing
+
+Focused tests should cover:
+
+- Request decoding for all new commands and flags.
+- Shell script command parsing, usage output, and socket request shape.
+- `ao` continuing to delegate to `alas open`.
+- Router dispatch for `open`, `wt`, and `review` commands.
+- Worktree list formatting and current-worktree marking.
+- Worktree matching behavior: exact branch/name, path basename, unique prefix,
+  unknown target, and ambiguity.
+- `wt switch` app-state wiring and app activation.
+- `wt new` argument mapping to the existing create-worktree path.
+- `wt delete` preflight failure, `--force`, and `--keep-branch` mapping.
+- `review` without arguments opening/focusing Review Changes.
+- `review <number-or-url>` routing into provider-backed review session loading.
+- Terminal-only failure behavior when required environment variables are absent.
+
+## Future Extensions
+
+- External-shell support once app instance routing and repository discovery are
+  designed.
+- Agent commands, likely under a separate grouped namespace.
+- Hidden/archived worktree listing and restore commands.
+- Review-loop automation commands, if they can map cleanly onto existing review
+  readiness state without surprising side effects.


### PR DESCRIPTION
## Summary
- Expand the injected `alas` terminal command beyond `open` with `wt list`, `wt switch`, `wt new`, `wt delete`, and `review` commands.
- Route command semantics through Swift/AppState so terminal commands reuse Alas worktree and review surfaces instead of duplicating git/provider behavior in shell.
- Add shared worktree path-template rendering, worktree target resolution, provider review target parsing, and terminal command docs.

## Validation
- `rtk xcodegen`
- `ALAS_FFF_TARGET_ARCH=arm64 rtk xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS,arch=arm64' -only-testing:AlasTests/AlasCLIWorktreeResolverTests test`
- `ALAS_FFF_TARGET_ARCH=arm64 rtk xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS,arch=arm64' -only-testing:AlasTests/AlasCLIRequestTests -only-testing:AlasTests/TerminalCLIInjectionTests -only-testing:AlasTests/AlasCLICommandRouterTests -only-testing:AlasTests/AlasCLIWorktreeResolverTests -only-testing:AlasTests/WorktreePathTemplateRendererTests -only-testing:AlasTests/NewWorktreeDialogTests -only-testing:AlasTests/AppStateCLIRoutingTests -only-testing:AlasTests/AlasCLIReviewTargetResolverTests -only-testing:AlasTests/Integrations/CodeHostRemoteDetectorTests test`

Full suite is intentionally left to CI because the local laptop is resource constrained.