### PR TITLE
fix(editor): pin initial horizontal viewport

### DIFF
--- a/Alas/Sources/Code/Editor/CodeEditorView.swift
+++ b/Alas/Sources/Code/Editor/CodeEditorView.swift
@@ -1,6 +1,44 @@
 import SwiftUI
 import AppKit
 
+/// `NSClipView` subclass that prevents AppKit from placing the document before
+/// the leading edge during initial layout, while preserving normal horizontal
+/// scrolling for long lines.
+final class CodeEditorLeadingClipView: NSClipView {
+    override func scroll(to newOrigin: NSPoint) {
+        super.scroll(to: pinnedOrigin(for: newOrigin))
+    }
+
+    override func setBoundsOrigin(_ newOrigin: NSPoint) {
+        super.setBoundsOrigin(pinnedOrigin(for: newOrigin))
+    }
+
+    override func constrainBoundsRect(_ proposedBounds: NSRect) -> NSRect {
+        var bounds = super.constrainBoundsRect(proposedBounds)
+        guard enclosingScrollView?.hasHorizontalScroller == true else {
+            bounds.origin.x = 0
+            return bounds
+        }
+        guard let documentView else {
+            bounds.origin.x = 0
+            return bounds
+        }
+
+        let maxX = max(documentView.frame.width - bounds.width, 0)
+        bounds.origin.x = min(max(bounds.origin.x, 0), maxX)
+        return bounds
+    }
+
+    private func pinnedOrigin(for origin: NSPoint) -> NSPoint {
+        guard enclosingScrollView?.hasHorizontalScroller == true, origin.x < 0 else {
+            return origin
+        }
+        var pinned = origin
+        pinned.x = 0
+        return pinned
+    }
+}
+
 /// `NSViewRepresentable` that wraps an `NSScrollView` containing a
 /// `CodeTextView`. Read-only, monospaced, no soft-wrap. The coordinator
 /// (`CodeEditorCoordinator`) owns load/highlight/LSP wiring — the view
@@ -45,6 +83,7 @@ struct CodeEditorView: NSViewRepresentable {
         scroll.autohidesScrollers = false
         scroll.drawsBackground = true
         scroll.backgroundColor = NSColor(theme.color("bg-1"))
+        scroll.contentView = CodeEditorLeadingClipView(frame: .zero)
 
         let buffer: EditorBuffer
         if let abs = externalAbsolutePath {

--- a/AlasTests/EditorBufferTests.swift
+++ b/AlasTests/EditorBufferTests.swift
@@ -1031,6 +1031,49 @@ struct EditorBufferTests {
         #expect(onDisk == "x\n")
     }
 
+    @Test func codeEditorLeadingClipViewPinsNegativeHorizontalOriginToZero() {
+        let scroll = NSScrollView(frame: NSRect(x: 0, y: 0, width: 500, height: 400))
+        scroll.contentView = CodeEditorLeadingClipView(frame: .zero)
+        scroll.hasVerticalScroller = true
+        scroll.hasHorizontalScroller = true
+        scroll.borderType = .noBorder
+        scroll.autohidesScrollers = false
+
+        let text = CodeTextView(frame: NSRect(x: 0, y: 0, width: 1000, height: 300), textContainer: nil)
+        text.isHorizontallyResizable = true
+        text.isVerticallyResizable = true
+        text.autoresizingMask = []
+        text.string = "hello world\n"
+        scroll.documentView = text
+
+        scroll.contentView.scroll(to: NSPoint(x: -50, y: 0))
+        #expect(scroll.contentView.bounds.origin.x == 0)
+
+        scroll.contentView.setBoundsOrigin(NSPoint(x: -100, y: 0))
+        #expect(scroll.contentView.bounds.origin.x == 0)
+
+        scroll.contentView.scroll(to: NSPoint(x: 50, y: 0))
+        #expect(scroll.contentView.bounds.origin.x == 50)
+
+        scroll.contentView.setBoundsOrigin(NSPoint(x: 100, y: 0))
+        #expect(scroll.contentView.bounds.origin.x == 100)
+
+        let leadingConstrained = scroll.contentView.constrainBoundsRect(
+            NSRect(x: -25, y: 0, width: 500, height: 400)
+        )
+        #expect(leadingConstrained.origin.x == 0)
+
+        let validConstrained = scroll.contentView.constrainBoundsRect(
+            NSRect(x: 75, y: 0, width: 500, height: 400)
+        )
+        #expect(validConstrained.origin.x == 75)
+
+        let trailingConstrained = scroll.contentView.constrainBoundsRect(
+            NSRect(x: 750, y: 0, width: 500, height: 400)
+        )
+        #expect(trailingConstrained.origin.x == 500)
+    }
+
     @Test func coordinatorPathChangeClearsTextViewUndoStack() throws {
         // Regression: NSTextView's undoManager survives across tab swaps
         // because CenterPaneView reuses the same text view. Without an


### PR DESCRIPTION
## Summary
- Pin the code editor clip view back to the leading edge when AppKit proposes a negative horizontal origin during initial layout.
- Clamp final clip bounds in `constrainBoundsRect(_:)` while preserving normal positive horizontal scrolling for long lines.
- Add a regression test covering scroll, bounds-origin, and constrained-bounds behavior.

## Validation
- `xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' build`
- `xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' test -only-testing:AlasTests/EditorBufferTests`

Note: a full local `xcodebuild ... test` run was attempted after the first review fix but stayed silent for about nine minutes and was interrupted; the focused editor suite passed after each review fix.