### PR TITLE
Disable comment affordances in read-only commit diffs

### DIFF
--- a/Alas/Sources/Center/Commit/CommitDiffView.swift
+++ b/Alas/Sources/Center/Commit/CommitDiffView.swift
@@ -174,6 +174,7 @@ struct CommitDiffView: View {
                 showsToolbar: false,
                 verticalScrollMode: .internalScroll,
                 lspContext: nil,
+                allowsReviewLineSelection: false,
                 hunkActions: { hunk in
                     DiffPaneHunkActions(
                         dropFromCommit: dropHunkEnabled(file, hunk) ? { onDropHunk?(hunk) } : nil

--- a/Alas/Sources/Center/Commit/CommitTabView.swift
+++ b/Alas/Sources/Center/Commit/CommitTabView.swift
@@ -422,6 +422,7 @@ struct CommitReviewBody: View {
             showsSourceBadges: false,
             showsRailDisplayControls: true,
             showsDraftSummaryRail: reviewDraftSessionID != nil,
+            allowsDraftCommentCreation: reviewDraftSessionID != nil,
             lspContextForFile: { file in
                 makeLSPContext(relativePath: file.summary.path)
             },

--- a/Alas/Sources/Center/DiffReview/DiffReviewFileSection.swift
+++ b/Alas/Sources/Center/DiffReview/DiffReviewFileSection.swift
@@ -87,7 +87,7 @@ struct DiffReviewFileSection: View {
             resetContextState()
         }
         .onChange(of: pendingDraftAnchor) { _, anchor in
-            guard anchor != nil else { return }
+            guard allowsDraftCommentCreation, anchor != nil else { return }
             Task { @MainActor in
                 draftComposerFocused = true
             }
@@ -362,7 +362,8 @@ struct DiffReviewFileSection: View {
         let segments = ReviewDraftCommentRowSegmentation.segments(
             for: group,
             placement: placement,
-            pendingAnchor: pendingDraftAnchor
+            pendingAnchor: pendingDraftAnchor,
+            canCreateDraftComment: allowsDraftCommentCreation
         )
         if segments.containsLocalAccessories {
             VStack(alignment: .leading, spacing: 0) {
@@ -517,6 +518,15 @@ struct DiffReviewFileSection: View {
 
     @ViewBuilder
     private var draftComposer: some View {
+        if !allowsDraftCommentCreation {
+            EmptyView()
+        } else {
+            draftComposerBody
+        }
+    }
+
+    @ViewBuilder
+    private var draftComposerBody: some View {
         VStack(alignment: .leading, spacing: 10) {
             ReviewDraftComposerTextEditor(
                 text: $pendingDraftBody,
@@ -1036,7 +1046,8 @@ enum ReviewDraftCommentRowSegmentation {
     static func segments(
         for group: DiffDisplayGroup,
         placement: ReviewDraftCommentPlacement.Result,
-        pendingAnchor: DiffReviewLineAnchor?
+        pendingAnchor: DiffReviewLineAnchor?,
+        canCreateDraftComment: Bool = true
     ) -> Result {
         let pendingKey = pendingAnchor.map {
             ReviewDraftCommentPlacement.RowKey(side: $0.side, line: $0.draftPlacementLine)
@@ -1055,7 +1066,7 @@ enum ReviewDraftCommentRowSegmentation {
                 excludingIDs: emittedCommentIDs
             )
             emittedCommentIDs.formUnion(comments.map(\.id))
-            let showsComposer = pendingKey.map { keys.contains($0) } ?? false
+            let showsComposer = canCreateDraftComment && (pendingKey.map { keys.contains($0) } ?? false)
             guard !comments.isEmpty || showsComposer else { continue }
 
             segments.append(Segment(

--- a/AlasTests/DiffReviewSurfaceTests.swift
+++ b/AlasTests/DiffReviewSurfaceTests.swift
@@ -93,6 +93,46 @@ struct DiffReviewSurfaceTests {
         #expect(DiffReviewRailSelectedRowStyle.contentLeadingPadding == 6)
     }
 
+    @Test func fileSectionHidesReviewAffordanceWhenDraftCommentCreationIsDisabled() {
+        let file = DiffReviewFileSectionModel(
+            summary: summary(
+                path: "Sources/App/AlphaView.swift",
+                namespace: "commit",
+                groupID: "commit",
+                groupTitle: "Commit",
+                additions: 1,
+                deletions: 1
+            ),
+            parsedDiff: parsedDiff(),
+            displayModel: displayModel(),
+            placeholderMessage: nil,
+            openFile: nil,
+            contextProvider: nil
+        )
+        var layout = DiffLayoutMode.split
+        var wrap = false
+        var whitespace = false
+
+        let view = DiffReviewFileSection(
+            file: file,
+            layoutMode: Binding(get: { layout }, set: { layout = $0 }),
+            wrapLines: Binding(get: { wrap }, set: { wrap = $0 }),
+            showWhitespace: Binding(get: { whitespace }, set: { whitespace = $0 }),
+            codeFontFamily: "",
+            codeFontSize: 13,
+            showsSourceBadge: false,
+            allowsDraftCommentCreation: false
+        )
+        .environment(\.theme, theme())
+
+        let controller = host(view, width: 900, height: 500)
+        let rulers = allSubviews(of: controller.view).compactMap { $0 as? DiffPaneLineNumberRulerView }
+        #expect(!rulers.isEmpty)
+        for ruler in rulers {
+            #expect(!ruler.allowsReviewLineSelection)
+        }
+    }
+
     @Test func fileSectionEmbedsDiffPaneWithoutToolbarAndShowsOpenFile() {
         let file = DiffReviewFileSectionModel(
             summary: summary(

--- a/AlasTests/DiffSelectableTextTests.swift
+++ b/AlasTests/DiffSelectableTextTests.swift
@@ -462,6 +462,35 @@ struct Foo {
         #expect(distanceFromTop < 140)
     }
 
+    @Test func commitDiffViewDisablesReviewLineSelection() throws {
+        let diff = ParsedDiff(hunks: [sampleHunk()])
+        let view = CommitDiffView(
+            worktreePath: URL(fileURLWithPath: "/tmp/repo"),
+            sha: "abc123",
+            file: sampleFile(),
+            path: "Sources/App.swift",
+            diff: diff,
+            displayModel: sampleDisplayModel(),
+            loading: false,
+            error: nil,
+            codeFontFamily: "",
+            codeFontSize: 13,
+            layoutMode: .constant(.split),
+            wrapLines: .constant(false),
+            showWhitespace: .constant(false),
+            onOpenFile: nil
+        )
+            .environment(\.theme, currentTheme())
+
+        let controller = NSHostingController(rootView: view)
+        controller.view.frame = NSRect(x: 0, y: 0, width: 900, height: 500)
+        controller.view.layoutSubtreeIfNeeded()
+
+        let rulers = allSubviews(of: controller.view).compactMap { $0 as? DiffPaneLineNumberRulerView }
+        #expect(!rulers.isEmpty)
+        #expect(rulers.allSatisfy { !$0.allowsReviewLineSelection })
+    }
+
     @Test func commitDiffViewEmptyHunksRendersWithoutCrashing() {
         let view = CommitDiffView(
             worktreePath: URL(fileURLWithPath: "/tmp"),


### PR DESCRIPTION
## Summary
- disable review line selection in old commit edit diffs
- gate draft comment creation affordances on whether a review draft session exists
- add coverage for read-only diff surfaces hiding comment affordances

## Verification
- xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' build
- xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' test