### PR TITLE
feat(changes): pull from upstream

### DIFF
--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -498,6 +498,7 @@
 		74B3955E1F94E39BED58EB7F /* HTTPRequestParserTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 001E204C8DBD41063D806ECA /* HTTPRequestParserTests.swift */; };
 		74CCD3B95116C51EB43F5CFA /* TreeSitterSwift in Frameworks */ = {isa = PBXBuildFile; productRef = 77EF95AD63DDA8DB0504087B /* TreeSitterSwift */; };
 		74E1B2C42F77908AA597EF45 /* OKLCH.swift in Sources */ = {isa = PBXBuildFile; fileRef = 73A34259DE8E978943E8BE16 /* OKLCH.swift */; };
+		74F193BC4B2A1BD5AD58C6DA /* GitService+Pull.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B9583B34B9AAD4454C558E5 /* GitService+Pull.swift */; };
 		7556121D51C54458FCAFED2A /* ACPProtocolVersion.swift in Sources */ = {isa = PBXBuildFile; fileRef = BEBCF3820A017BBF33B0AB07 /* ACPProtocolVersion.swift */; };
 		75B5EE5F1761CF5C830F0549 /* TitlelessWindowTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE0A6F237480EE72CB8DBE28 /* TitlelessWindowTests.swift */; };
 		7602FDB0353222613CD39FFE /* FileIndexTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3855FBA3E4444960418639E9 /* FileIndexTests.swift */; };
@@ -792,6 +793,7 @@
 		B884D1257E321D543B5BC670 /* ShortcutBindingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2440A9DE95B4F783AA69A355 /* ShortcutBindingTests.swift */; };
 		B8B0B60C8096F691F8401D31 /* TabBarView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BEC7CCBF8463A95EAAE9EBCE /* TabBarView.swift */; };
 		B8BA936481455853CFC3393F /* ANSIStream.swift in Sources */ = {isa = PBXBuildFile; fileRef = BAE3E5634CC9BA68765EA539 /* ANSIStream.swift */; };
+		B8BF059C5C2090AFBB56A5BC /* GitServicePullTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1BB00E2F151520DC02B80BD4 /* GitServicePullTests.swift */; };
 		B8C893DFB0965CB7EB0AFD10 /* DiffContextExpansion.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF71AF50DF50AA4158A96177 /* DiffContextExpansion.swift */; };
 		B8D2EB18303D58777D79CDBA /* SearchResult.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A0FF718D68E15F539577F56 /* SearchResult.swift */; };
 		B94F61E5170AA8102AA2A022 /* DiffPaneLSP.swift in Sources */ = {isa = PBXBuildFile; fileRef = B58BD62080F250E0F0DD057F /* DiffPaneLSP.swift */; };
@@ -1222,6 +1224,7 @@
 		1A61DF43677282D4CA21769A /* CommitPromptStatus.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommitPromptStatus.swift; sourceTree = "<group>"; };
 		1AFC62A30044F71F0F16C3FB /* TerminalService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TerminalService.swift; sourceTree = "<group>"; };
 		1B0785F1FFC8008C74009584 /* session-update-available-models.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "session-update-available-models.json"; sourceTree = "<group>"; };
+		1BB00E2F151520DC02B80BD4 /* GitServicePullTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GitServicePullTests.swift; sourceTree = "<group>"; };
 		1D3505FB870FA22C9C0FDB26 /* RightPaneStateSyncStatusTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RightPaneStateSyncStatusTests.swift; sourceTree = "<group>"; };
 		1D4A5200C6EBB6434DD6B8BD /* ShortcutReservationsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShortcutReservationsTests.swift; sourceTree = "<group>"; };
 		1DC1B975662D135B148443BC /* ACPSessionHydrationStateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPSessionHydrationStateTests.swift; sourceTree = "<group>"; };
@@ -1505,6 +1508,7 @@
 		5AA5809066E33EB30E09E0D8 /* RemoteWebAssetTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteWebAssetTests.swift; sourceTree = "<group>"; };
 		5B3FF64CC698074BFDE2A36A /* ProjectConfigTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProjectConfigTests.swift; sourceTree = "<group>"; };
 		5B72D621D704CB5B2CCA82C6 /* RemoteAppStateAccessTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteAppStateAccessTests.swift; sourceTree = "<group>"; };
+		5B9583B34B9AAD4454C558E5 /* GitService+Pull.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "GitService+Pull.swift"; sourceTree = "<group>"; };
 		5BAC89A6B9D5DC926AC18E13 /* MergeConflictTabView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MergeConflictTabView.swift; sourceTree = "<group>"; };
 		5BB6172AE118D2F9A40FD534 /* AgentsPane.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentsPane.swift; sourceTree = "<group>"; };
 		5C8BF1EC24E449A302A1E25C /* CopyFeedbackState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CopyFeedbackState.swift; sourceTree = "<group>"; };
@@ -2467,6 +2471,7 @@
 				F936C036893FC70AD506FDD4 /* GitServiceDiscardTests.swift */,
 				38F5019E0550FA05436EFC74 /* GitServiceHeadMessageTests.swift */,
 				B9749FB435319F01F9E70D08 /* GitServiceMergeTests.swift */,
+				1BB00E2F151520DC02B80BD4 /* GitServicePullTests.swift */,
 				FFB1CCDE2E4D85A46E6CFB1A /* GitServiceReviewRequestDraftTests.swift */,
 				C2CA853E91C240B7B5551859 /* GitServiceStagedTests.swift */,
 				6DF0AEE54BDB4FC4FD5E02F4 /* GitServiceStagingTests.swift */,
@@ -2729,6 +2734,7 @@
 				B7CE7B4DAFDB65A79308FB63 /* GitService.swift */,
 				7F4A17C42833BE6190A45AF3 /* GitService+CommitEditing.swift */,
 				90817EC3BAA727EF6D9FBD97 /* GitService+Discard.swift */,
+				5B9583B34B9AAD4454C558E5 /* GitService+Pull.swift */,
 				764489A630CC6D79FCE0A26A /* GitService+ReviewLoop.swift */,
 				0EE97D2D6875CD6A1DBF4DE9 /* GitService+ReviewRequestDraft.swift */,
 				D2F90D03073708AA01531533 /* GitService+Staging.swift */,
@@ -4683,6 +4689,7 @@
 				6FA1659F464BE9C03C90F787 /* GitService+CommitEditing.swift in Sources */,
 				DF8CAD5714483408B8BD72F7 /* GitService+Discard.swift in Sources */,
 				E703B4895A0337310A17FED6 /* GitService+ImageDiff.swift in Sources */,
+				74F193BC4B2A1BD5AD58C6DA /* GitService+Pull.swift in Sources */,
 				5846A180EB68D905E9775401 /* GitService+ReviewLoop.swift in Sources */,
 				C70D6BEC5321C16B70301CBF /* GitService+ReviewRequestDraft.swift in Sources */,
 				0A480D9D7CE5BB837D7BCA13 /* GitService+Staging.swift in Sources */,
@@ -5226,6 +5233,7 @@
 				2C520D1FB289610CEB70BDB6 /* GitServiceDiscardTests.swift in Sources */,
 				1B197F39E826079635F843EB /* GitServiceHeadMessageTests.swift in Sources */,
 				7BD8965290B1F007B0E99BCF /* GitServiceMergeTests.swift in Sources */,
+				B8BF059C5C2090AFBB56A5BC /* GitServicePullTests.swift in Sources */,
 				4D9A57C74B314FA3570B0406 /* GitServiceReviewRequestDraftTests.swift in Sources */,
 				478863759224A2278123B7B9 /* GitServiceStagedTests.swift in Sources */,
 				CB27451157E1BF95BE47248A /* GitServiceStagingTests.swift in Sources */,

--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -1063,6 +1063,7 @@
 		F66BDC777D0BFDE306E8880A /* ACPTabView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B832ED19AC178DAD77C78D37 /* ACPTabView.swift */; };
 		F6C5274BCA0B3068C6C2D36A /* ZmxSunPathBudgetTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E0E5107A10052A150DD8DE02 /* ZmxSunPathBudgetTests.swift */; };
 		F6CC80D1E8D2D36251C83A1D /* ShellEnvResolver.swift in Sources */ = {isa = PBXBuildFile; fileRef = DFEE7C5318AA6D04095403B2 /* ShellEnvResolver.swift */; };
+		F71446E57FF4879C9A9B0686 /* RightPaneStatePullTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 25B1ED890A8A45244572D8A3 /* RightPaneStatePullTests.swift */; };
 		F72AFDC819B805B3F1FFFB9A /* CommitReviewLoader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7A240CD3EF074300828A1214 /* CommitReviewLoader.swift */; };
 		F73063B2384B650C227BD09E /* ACPHistorySidebar.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2C5BD0110EB8EDE7BB4ED93 /* ACPHistorySidebar.swift */; };
 		F8143610563C28604A23B89A /* CenterSelectionStateResolverTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 71A2A074CEB9C9BA2AD34DD7 /* CenterSelectionStateResolverTests.swift */; };
@@ -1257,6 +1258,7 @@
 		2468AD293C8215FAF390C907 /* ACPMessageWireTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPMessageWireTests.swift; sourceTree = "<group>"; };
 		25493E3B18A1AB94EA6985C3 /* EventHolder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EventHolder.swift; sourceTree = "<group>"; };
 		256257983A4B1E1E674DF5B8 /* MergeRegionVisualLayoutTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MergeRegionVisualLayoutTests.swift; sourceTree = "<group>"; };
+		25B1ED890A8A45244572D8A3 /* RightPaneStatePullTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RightPaneStatePullTests.swift; sourceTree = "<group>"; };
 		25C1AD69581AAE3D34624F23 /* AgentAutoLaunch.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentAutoLaunch.swift; sourceTree = "<group>"; };
 		25CBAF6618B6D11EC3B9CC76 /* InstallNudgeResolver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InstallNudgeResolver.swift; sourceTree = "<group>"; };
 		25DBE942154BD154F2D10B9D /* SidebarHeaderViewTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SidebarHeaderViewTests.swift; sourceTree = "<group>"; };
@@ -2565,6 +2567,7 @@
 				3D10596B1B9B854DB81DAF6A /* RightPaneStateDiscardTests.swift */,
 				5A85E1D1600F487D359F363F /* RightPaneStateFileTreeTests.swift */,
 				B3C89163A30EA4D278E86959 /* RightPaneStateLoadOlderTests.swift */,
+				25B1ED890A8A45244572D8A3 /* RightPaneStatePullTests.swift */,
 				B84EFAC9F0FCF459416920B6 /* RightPaneStateReviewLoopPushTests.swift */,
 				1D3505FB870FA22C9C0FDB26 /* RightPaneStateSyncStatusTests.swift */,
 				0AAF2B901624C0629A1E3357 /* RightPaneStateUnstagePathsTests.swift */,
@@ -5368,6 +5371,7 @@
 				8104F4F1DFD11BC5758545E9 /* RightPaneStateDiscardTests.swift in Sources */,
 				35A0942B075D267EBB9A4484 /* RightPaneStateFileTreeTests.swift in Sources */,
 				FDB1BD021ED0D2C7247E42D5 /* RightPaneStateLoadOlderTests.swift in Sources */,
+				F71446E57FF4879C9A9B0686 /* RightPaneStatePullTests.swift in Sources */,
 				9D1939E70B46881CCDDC389C /* RightPaneStateReviewLoopPushTests.swift in Sources */,
 				DCACB5B624BFFE7C50DA6C61 /* RightPaneStateSyncStatusTests.swift in Sources */,
 				57D04CD70E3A716B81F58FF8 /* RightPaneStateUnstagePathsTests.swift in Sources */,

--- a/Alas/Sources/Git/GitService+Pull.swift
+++ b/Alas/Sources/Git/GitService+Pull.swift
@@ -1,0 +1,38 @@
+import Foundation
+
+extension GitService {
+    /// Pulls the current branch's upstream by fetching it fresh and rebasing
+    /// onto the updated remote-tracking ref. Fast-forwards when there are no
+    /// local commits to replay; otherwise replays them. Conflicts surface as a
+    /// `.conflict` result (the worktree is left mid-rebase), classified the
+    /// same way as `rebase(onto:)`. Throws `PullError.noUpstream` when the
+    /// current branch has no upstream tracking ref.
+    func pull(worktreePath: URL) async throws -> MergeResult {
+        guard let upstream = try await resolveUpstreamRef(worktreePath: worktreePath) else {
+            throw PullError.noUpstream
+        }
+        // Upstream ref looks like "origin/<branch>"; strip the validated
+        // "<remote>/" prefix to recover the branch name (same derivation as
+        // `remoteForFetch`, but reusing `resolveUpstreamRef`'s already-validated
+        // `remote` so it can't mis-split). Fetch it fresh, bypassing the
+        // throttle the status probe uses.
+        let branchName = String(upstream.ref.dropFirst(upstream.remote.count + 1))
+        try await fetchRef(
+            worktreePath: worktreePath,
+            remote: upstream.remote,
+            branch: branchName
+        )
+        return try await rebase(worktreePath: worktreePath, onto: upstream.ref)
+    }
+}
+
+enum PullError: LocalizedError, Equatable {
+    case noUpstream
+
+    var errorDescription: String? {
+        switch self {
+        case .noUpstream:
+            return "This branch has no upstream to pull from."
+        }
+    }
+}

--- a/Alas/Sources/Right/BranchOpsMenu.swift
+++ b/Alas/Sources/Right/BranchOpsMenu.swift
@@ -20,6 +20,8 @@ struct BranchOpsMenu: View {
         Menu {
             Button("Merge branch into this worktree…") { openMergePicker() }
             Button("Rebase this worktree onto…")      { openRebasePicker() }
+            Divider()
+            Button("Fetch now") { rps.fetchNow() }
         } label: {
             Image(systemName: "arrow.triangle.merge")
                 .font(.system(size: 11, weight: .semibold))

--- a/Alas/Sources/Right/CommitsSectionView.swift
+++ b/Alas/Sources/Right/CommitsSectionView.swift
@@ -27,6 +27,8 @@ struct BehindChip: View {
     /// When set, the chip becomes a button that runs this action (used by the
     /// upstream chip to trigger a pull). When nil, the chip is a plain pill.
     var onTap: (() -> Void)? = nil
+    /// Remote tracking ref shown in the action tooltip (e.g. "origin/main").
+    var ref: String? = nil
 
     @Environment(\.theme) private var theme
     @State private var hovering = false
@@ -42,12 +44,14 @@ struct BehindChip: View {
         if let onTap {
             // The actionable chip owns the tooltip ("Pull …"); the call site
             // does not add its own `.help`, which would otherwise shadow this.
+            let refSuffix = ref.map { " from \($0)" } ?? ""
             Button(action: onTap) { pill(highlighted: hovering) }
                 .buttonStyle(.plain)
                 .disabled(inFlight)
                 .onHover { hovering = $0 }
+                .onChange(of: inFlight) { _, nowInFlight in if nowInFlight { hovering = false } }
                 .pointingHandCursor()
-                .help("Pull \(count) commit\(count == 1 ? "" : "s") (rebase)")
+                .help("Pull \(count) commit\(count == 1 ? "" : "s")\(refSuffix) (rebase)")
         } else {
             pill(highlighted: false)
         }
@@ -119,7 +123,8 @@ struct CommitsSectionView: View {
                             label: "remote",
                             role: .upstream,
                             inFlight: rps.pullInFlight,
-                            onTap: { rps.pull() }
+                            onTap: { rps.pull() },
+                            ref: s.ref
                         )
                         .disabled(rps.pullInFlight || rps.mergeOp.current != nil)
                     }

--- a/Alas/Sources/Right/CommitsSectionView.swift
+++ b/Alas/Sources/Right/CommitsSectionView.swift
@@ -22,8 +22,14 @@ struct BehindChip: View {
     let count: Int
     let label: String
     let role: Role
+    /// Spinner shown while a pull triggered by this chip is in flight.
+    var inFlight: Bool = false
+    /// When set, the chip becomes a button that runs this action (used by the
+    /// upstream chip to trigger a pull). When nil, the chip is a plain pill.
+    var onTap: (() -> Void)? = nil
 
     @Environment(\.theme) private var theme
+    @State private var hovering = false
 
     /// Pure text composition: `↓N label` (e.g. "↓3 main"). `↓` reads as
     /// "commits to pull in."
@@ -31,15 +37,39 @@ struct BehindChip: View {
         "↓\(count) \(label)"
     }
 
+    @ViewBuilder
     var body: some View {
+        if let onTap {
+            // The actionable chip owns the tooltip ("Pull …"); the call site
+            // does not add its own `.help`, which would otherwise shadow this.
+            Button(action: onTap) { pill(highlighted: hovering) }
+                .buttonStyle(.plain)
+                .disabled(inFlight)
+                .onHover { hovering = $0 }
+                .pointingHandCursor()
+                .help("Pull \(count) commit\(count == 1 ? "" : "s") (rebase)")
+        } else {
+            pill(highlighted: false)
+        }
+    }
+
+    /// Hover styling is passed in explicitly so the non-interactive (base)
+    /// chip can never inherit it.
+    private func pill(highlighted: Bool) -> some View {
         let tint = theme.color(role.colorToken)
-        return Text(Self.displayText(count: count, label: label))
-            .font(.system(size: 9.5, weight: .semibold))
-            .foregroundColor(tint)
-            .lineLimit(1)
-            .padding(.horizontal, 6).padding(.vertical, 1)
-            .background(tint.opacity(0.12))
-            .clipShape(Capsule())
+        return HStack(spacing: 4) {
+            if inFlight {
+                Spinner(lineWidth: 1.2, duration: 0.7)
+                    .frame(width: 9, height: 9)
+            }
+            Text(Self.displayText(count: count, label: label))
+                .font(.system(size: 9.5, weight: .semibold))
+                .lineLimit(1)
+        }
+        .foregroundColor(highlighted ? tint.opacity(0.8) : tint)
+        .padding(.horizontal, 6).padding(.vertical, 1)
+        .background(tint.opacity(highlighted ? 0.2 : 0.12))
+        .clipShape(Capsule())
     }
 }
 
@@ -84,8 +114,14 @@ struct CommitsSectionView: View {
                             .help("\(s.count) behind \(s.ref)")
                     }
                     if let s = behindUpstream {
-                        BehindChip(count: s.count, label: "remote", role: .upstream)
-                            .help("\(s.count) behind \(s.ref)")
+                        BehindChip(
+                            count: s.count,
+                            label: "remote",
+                            role: .upstream,
+                            inFlight: rps.pullInFlight,
+                            onTap: { rps.pull() }
+                        )
+                        .disabled(rps.pullInFlight || rps.mergeOp.current != nil)
                     }
                     BaseBranchSelector(
                         baseBranch: $baseBranch,

--- a/Alas/Sources/Right/RightPaneState.swift
+++ b/Alas/Sources/Right/RightPaneState.swift
@@ -36,6 +36,9 @@ final class RightPaneState {
     /// a future inline strip — for now, set this and rely on existing
     /// log output for diagnosability.
     var sidebarError: String? = nil
+    /// True while a `pull()` is running; drives the upstream chip's spinner
+    /// and disables re-entry. Only `pull()` mutates it.
+    private(set) var pullInFlight: Bool = false
     var fileTree: [FileTreeNode] = []
     var loading: Bool = false
     var openPaths: Set<String> = []   // expanded directories in the tree
@@ -958,13 +961,20 @@ final class RightPaneState {
     /// than 30s. Errors are logged but never surfaced; chips reflect the
     /// last successful probe (or stay hidden if none has succeeded yet).
     @MainActor
-    func refreshSyncStatus() async {
-        await refreshBehindBase()
-        await refreshBehindUpstream()
+    func refreshSyncStatus(force: Bool = false) async {
+        await refreshBehindBase(force: force)
+        await refreshBehindUpstream(force: force)
+    }
+
+    /// Force an immediate fetch + recompute of the behind chips, bypassing the
+    /// 30s probe throttle. Backs the "Fetch now" menu item.
+    @MainActor
+    func fetchNow() {
+        Task { @MainActor in await self.refreshSyncStatus(force: true) }
     }
 
     @MainActor
-    private func refreshBehindBase() async {
+    private func refreshBehindBase(force: Bool = false) async {
         do {
             guard let resolved = try await git.resolveBaseRef(
                 worktreePath: worktree.path,
@@ -976,7 +986,7 @@ final class RightPaneState {
             }
             if let remote = resolved.remote {
                 let last = behindBase?.probedAt ?? .distantPast
-                if Date().timeIntervalSince(last) > 30 {
+                if force || Date().timeIntervalSince(last) > 30 {
                     do {
                         try await git.fetchRef(
                             worktreePath: worktree.path,
@@ -998,7 +1008,7 @@ final class RightPaneState {
     }
 
     @MainActor
-    private func refreshBehindUpstream() async {
+    private func refreshBehindUpstream(force: Bool = false) async {
         do {
             guard let upstream = try await git.resolveUpstreamRef(
                 worktreePath: worktree.path
@@ -1012,7 +1022,7 @@ final class RightPaneState {
             // is what we fetch.
             let branchName = String(upstream.ref.dropFirst(upstream.remote.count + 1))
             let last = behindUpstream?.probedAt ?? .distantPast
-            if Date().timeIntervalSince(last) > 30 {
+            if force || Date().timeIntervalSince(last) > 30 {
                 do {
                     try await git.fetchRef(
                         worktreePath: worktree.path,
@@ -1111,6 +1121,33 @@ final class RightPaneState {
                 handleOperationResult(result)
             } catch {
                 logger.error("cherry-pick failed: \(error.localizedDescription, privacy: .public)")
+            }
+        }
+    }
+
+    /// Pull the current branch's upstream (fetch + rebase onto it). Surfaces
+    /// conflicts through the existing `OperationCard` via `refresh()` +
+    /// `handleOperationResult`. No-ops when there is no upstream, when an
+    /// operation is already in flight, or when a pull is already running.
+    @MainActor
+    func pull() {
+        guard behindUpstream != nil, mergeOp.current == nil, !pullInFlight else { return }
+        sidebarError = nil
+        pullInFlight = true
+        Task { @MainActor in
+            defer { pullInFlight = false }
+            do {
+                let result = try await git.pull(worktreePath: worktree.path)
+                await refresh()
+                // Force the behind chips to reflect the post-pull state now
+                // rather than waiting out the 30s probe throttle.
+                await refreshSyncStatus(force: true)
+                handleOperationResult(result)
+            } catch {
+                // Unlike the pure rebase/merge siblings, surface the failure to
+                // the user: a pull is the only signal they have that it ran.
+                sidebarError = error.localizedDescription
+                logger.error("pull failed: \(error.localizedDescription, privacy: .public)")
             }
         }
     }

--- a/Alas/Sources/Right/RightPaneState.swift
+++ b/Alas/Sources/Right/RightPaneState.swift
@@ -1127,11 +1127,14 @@ final class RightPaneState {
 
     /// Pull the current branch's upstream (fetch + rebase onto it). Surfaces
     /// conflicts through the existing `OperationCard` via `refresh()` +
-    /// `handleOperationResult`. No-ops when there is no upstream, when an
-    /// operation is already in flight, or when a pull is already running.
+    /// `handleOperationResult`. No-ops unless the upstream chip is actually
+    /// showing (behind by >0, attached HEAD), and when an operation is already
+    /// in flight or a pull is already running. Gating on `showBehindUpstreamChip`
+    /// keeps the action's safety with the action rather than relying on the
+    /// view to hide the chip.
     @MainActor
     func pull() {
-        guard behindUpstream != nil, mergeOp.current == nil, !pullInFlight else { return }
+        guard showBehindUpstreamChip, mergeOp.current == nil, !pullInFlight else { return }
         sidebarError = nil
         pullInFlight = true
         Task { @MainActor in

--- a/Alas/Sources/Right/RightPaneState.swift
+++ b/Alas/Sources/Right/RightPaneState.swift
@@ -39,6 +39,7 @@ final class RightPaneState {
     /// True while a `pull()` is running; drives the upstream chip's spinner
     /// and disables re-entry. Only `pull()` mutates it.
     private(set) var pullInFlight: Bool = false
+    private var fetchInFlight: Bool = false
     var fileTree: [FileTreeNode] = []
     var loading: Bool = false
     var openPaths: Set<String> = []   // expanded directories in the tree
@@ -970,7 +971,12 @@ final class RightPaneState {
     /// 30s probe throttle. Backs the "Fetch now" menu item.
     @MainActor
     func fetchNow() {
-        Task { @MainActor in await self.refreshSyncStatus(force: true) }
+        guard !fetchInFlight, !pullInFlight else { return }
+        fetchInFlight = true
+        Task { @MainActor in
+            defer { fetchInFlight = false }
+            await self.refreshSyncStatus(force: true)
+        }
     }
 
     @MainActor
@@ -1142,10 +1148,13 @@ final class RightPaneState {
             do {
                 let result = try await git.pull(worktreePath: worktree.path)
                 await refresh()
-                // Force the behind chips to reflect the post-pull state now
-                // rather than waiting out the 30s probe throttle.
-                await refreshSyncStatus(force: true)
+                // pull() already fetched upstream; skip the redundant network
+                // fetch and just recount against the already-fresh tracking ref.
+                await refreshSyncStatus()
                 handleOperationResult(result)
+                if case .error(let message) = result {
+                    sidebarError = message
+                }
             } catch {
                 // Unlike the pure rebase/merge siblings, surface the failure to
                 // the user: a pull is the only signal they have that it ran.

--- a/AlasTests/GitServicePullTests.swift
+++ b/AlasTests/GitServicePullTests.swift
@@ -1,0 +1,127 @@
+import Testing
+import Foundation
+@testable import Alas
+
+@Suite(.serialized)
+struct GitServicePullTests {
+    /// Bare remote + a clone checked out on `main` tracking `origin/main`.
+    /// Returns the consumer clone and the remote (both must be cleaned up).
+    fileprivate static func makeCloneOnMain() async throws -> (clone: URL, remote: URL) {
+        let remote = FileManager.default.temporaryDirectory
+            .appendingPathComponent("alas-pull-rmt-\(UUID().uuidString)")
+        let seed = FileManager.default.temporaryDirectory
+            .appendingPathComponent("alas-pull-seed-\(UUID().uuidString)")
+        defer { try? FileManager.default.removeItem(at: seed) }
+        _ = try await Process.git(["init", "--bare", "-q", remote.path], cwd: nil)
+        _ = try await Process.git(["clone", "-q", remote.path, seed.path], cwd: nil)
+        _ = try await Process.git(["config", "user.email", "s@e"], cwd: seed)
+        _ = try await Process.git(["config", "user.name", "s"], cwd: seed)
+        _ = try await Process.git(["config", "commit.gpgsign", "false"], cwd: seed)
+        _ = try await Process.git(["checkout", "-q", "-b", "main"], cwd: seed)
+        try "base\n".write(to: seed.appendingPathComponent("a.txt"), atomically: true, encoding: .utf8)
+        _ = try await Process.git(["add", "a.txt"], cwd: seed)
+        _ = try await Process.git(["commit", "-q", "-m", "base"], cwd: seed)
+        _ = try await Process.git(["push", "-q", "-u", "origin", "main"], cwd: seed)
+        _ = try await Process.git(["--git-dir", remote.path, "symbolic-ref", "HEAD", "refs/heads/main"], cwd: nil)
+
+        let clone = FileManager.default.temporaryDirectory
+            .appendingPathComponent("alas-pull-clone-\(UUID().uuidString)")
+        _ = try await Process.git(["clone", "-q", remote.path, clone.path], cwd: nil)
+        _ = try await Process.git(["config", "user.email", "c@e"], cwd: clone)
+        _ = try await Process.git(["config", "user.name", "c"], cwd: clone)
+        _ = try await Process.git(["config", "commit.gpgsign", "false"], cwd: clone)
+        return (clone, remote)
+    }
+
+    /// Pushes one more commit to `origin/main` from a throwaway clone so the
+    /// primary clone falls behind its upstream. `modify` controls the change.
+    fileprivate static func pushToRemoteMain(_ remote: URL, file: String, contents: String, message: String) async throws {
+        let tmp = FileManager.default.temporaryDirectory
+            .appendingPathComponent("alas-pull-push-\(UUID().uuidString)")
+        defer { try? FileManager.default.removeItem(at: tmp) }
+        _ = try await Process.git(["clone", "-q", remote.path, tmp.path], cwd: nil)
+        _ = try await Process.git(["config", "user.email", "x@e"], cwd: tmp)
+        _ = try await Process.git(["config", "user.name", "x"], cwd: tmp)
+        _ = try await Process.git(["config", "commit.gpgsign", "false"], cwd: tmp)
+        try contents.write(to: tmp.appendingPathComponent(file), atomically: true, encoding: .utf8)
+        _ = try await Process.git(["add", file], cwd: tmp)
+        _ = try await Process.git(["commit", "-q", "-m", message], cwd: tmp)
+        _ = try await Process.git(["push", "-q", "origin", "main"], cwd: tmp)
+    }
+
+    private static func headSHA(_ repo: URL, _ ref: String) async throws -> String {
+        try await Process.git(["rev-parse", ref], cwd: repo).stdout
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    @Test func pullFastForwardsWhenNoLocalCommits() async throws {
+        let (clone, remote) = try await Self.makeCloneOnMain()
+        defer {
+            try? FileManager.default.removeItem(at: clone)
+            try? FileManager.default.removeItem(at: remote)
+        }
+        try await Self.pushToRemoteMain(remote, file: "b.txt", contents: "new\n", message: "remote-1")
+
+        let svc = GitService()
+        let result = try await svc.pull(worktreePath: clone)
+        #expect(result == .clean)
+        let head = try await Self.headSHA(clone, "HEAD")
+        let upstream = try await Self.headSHA(clone, "origin/main")
+        #expect(head == upstream)
+    }
+
+    @Test func pullRebasesLocalCommitsWhenDivergedCleanly() async throws {
+        let (clone, remote) = try await Self.makeCloneOnMain()
+        defer {
+            try? FileManager.default.removeItem(at: clone)
+            try? FileManager.default.removeItem(at: remote)
+        }
+        // Local commit touching a different file than the remote one.
+        try "local\n".write(to: clone.appendingPathComponent("local.txt"), atomically: true, encoding: .utf8)
+        _ = try await Process.git(["add", "local.txt"], cwd: clone)
+        _ = try await Process.git(["commit", "-q", "-m", "local-1"], cwd: clone)
+        try await Self.pushToRemoteMain(remote, file: "b.txt", contents: "new\n", message: "remote-1")
+
+        let svc = GitService()
+        let result = try await svc.pull(worktreePath: clone)
+        #expect(result == .clean)
+        // Both the remote file and the replayed local file exist.
+        #expect(FileManager.default.fileExists(atPath: clone.appendingPathComponent("b.txt").path))
+        #expect(FileManager.default.fileExists(atPath: clone.appendingPathComponent("local.txt").path))
+    }
+
+    @Test func pullReturnsConflictWhenDivergedConflicting() async throws {
+        let (clone, remote) = try await Self.makeCloneOnMain()
+        defer {
+            try? FileManager.default.removeItem(at: clone)
+            try? FileManager.default.removeItem(at: remote)
+        }
+        // Local commit and remote commit modify the SAME line of a.txt.
+        try "local change\n".write(to: clone.appendingPathComponent("a.txt"), atomically: true, encoding: .utf8)
+        _ = try await Process.git(["commit", "-q", "-am", "local edit"], cwd: clone)
+        try await Self.pushToRemoteMain(remote, file: "a.txt", contents: "remote change\n", message: "remote edit")
+
+        let svc = GitService()
+        let result = try await svc.pull(worktreePath: clone)
+        guard case .conflict(let files) = result else {
+            Issue.record("expected .conflict, got \(result)")
+            return
+        }
+        #expect(files.contains(where: { $0.path == "a.txt" }))
+    }
+
+    @Test func pullThrowsWhenNoUpstream() async throws {
+        let (clone, remote) = try await Self.makeCloneOnMain()
+        defer {
+            try? FileManager.default.removeItem(at: clone)
+            try? FileManager.default.removeItem(at: remote)
+        }
+        // A fresh local branch with no upstream tracking ref.
+        _ = try await Process.git(["checkout", "-q", "-b", "no-upstream"], cwd: clone)
+
+        let svc = GitService()
+        await #expect(throws: PullError.noUpstream) {
+            _ = try await svc.pull(worktreePath: clone)
+        }
+    }
+}

--- a/AlasTests/RightPaneStatePullTests.swift
+++ b/AlasTests/RightPaneStatePullTests.swift
@@ -1,0 +1,166 @@
+import Testing
+import Foundation
+@testable import Alas
+
+@MainActor
+@Suite(.serialized)
+struct RightPaneStatePullTests {
+    private func makeWorktree(at path: URL, branch: String) -> Worktree {
+        Worktree(
+            id: Worktree.makeId(path: path),
+            projectId: "test-project",
+            name: branch,
+            branch: branch,
+            path: path,
+            status: .clean,
+            lastActivity: Date()
+        )
+    }
+
+    /// Bare remote + clone on `main` tracking `origin/main`, already one
+    /// commit behind (a throwaway clone pushed `remote-1`).
+    private func makeCloneBehindUpstream(conflicting: Bool) async throws -> (clone: URL, remote: URL) {
+        let remote = FileManager.default.temporaryDirectory
+            .appendingPathComponent("alas-rpspull-rmt-\(UUID().uuidString)")
+        let seed = FileManager.default.temporaryDirectory
+            .appendingPathComponent("alas-rpspull-seed-\(UUID().uuidString)")
+        defer { try? FileManager.default.removeItem(at: seed) }
+        _ = try await Process.git(["init", "--bare", "-q", remote.path], cwd: nil)
+        _ = try await Process.git(["clone", "-q", remote.path, seed.path], cwd: nil)
+        _ = try await Process.git(["config", "user.email", "s@e"], cwd: seed)
+        _ = try await Process.git(["config", "user.name", "s"], cwd: seed)
+        _ = try await Process.git(["config", "commit.gpgsign", "false"], cwd: seed)
+        _ = try await Process.git(["checkout", "-q", "-b", "main"], cwd: seed)
+        try "base\n".write(to: seed.appendingPathComponent("a.txt"), atomically: true, encoding: .utf8)
+        _ = try await Process.git(["add", "a.txt"], cwd: seed)
+        _ = try await Process.git(["commit", "-q", "-m", "base"], cwd: seed)
+        _ = try await Process.git(["push", "-q", "-u", "origin", "main"], cwd: seed)
+        _ = try await Process.git(["--git-dir", remote.path, "symbolic-ref", "HEAD", "refs/heads/main"], cwd: nil)
+
+        let clone = FileManager.default.temporaryDirectory
+            .appendingPathComponent("alas-rpspull-clone-\(UUID().uuidString)")
+        _ = try await Process.git(["clone", "-q", remote.path, clone.path], cwd: nil)
+        _ = try await Process.git(["config", "user.email", "c@e"], cwd: clone)
+        _ = try await Process.git(["config", "user.name", "c"], cwd: clone)
+        _ = try await Process.git(["config", "commit.gpgsign", "false"], cwd: clone)
+
+        if conflicting {
+            try "local change\n".write(to: clone.appendingPathComponent("a.txt"), atomically: true, encoding: .utf8)
+            _ = try await Process.git(["commit", "-q", "-am", "local edit"], cwd: clone)
+        }
+
+        // Throwaway clone pushes a commit to origin/main.
+        let tmp = FileManager.default.temporaryDirectory
+            .appendingPathComponent("alas-rpspull-push-\(UUID().uuidString)")
+        defer { try? FileManager.default.removeItem(at: tmp) }
+        _ = try await Process.git(["clone", "-q", remote.path, tmp.path], cwd: nil)
+        _ = try await Process.git(["config", "user.email", "x@e"], cwd: tmp)
+        _ = try await Process.git(["config", "user.name", "x"], cwd: tmp)
+        _ = try await Process.git(["config", "commit.gpgsign", "false"], cwd: tmp)
+        let pushFile = conflicting ? "a.txt" : "b.txt"
+        try "remote change\n".write(to: tmp.appendingPathComponent(pushFile), atomically: true, encoding: .utf8)
+        _ = try await Process.git(["add", pushFile], cwd: tmp)
+        _ = try await Process.git(["commit", "-q", "-m", "remote-1"], cwd: tmp)
+        _ = try await Process.git(["push", "-q", "origin", "main"], cwd: tmp)
+
+        return (clone, remote)
+    }
+
+    /// Polls `condition` on the main actor up to ~5s, returning as soon as it
+    /// holds. Avoids fixed sleeps that flake under load.
+    private func wait(until condition: () -> Bool) async throws {
+        for _ in 0..<50 {
+            if condition() { return }
+            try await Task.sleep(nanoseconds: 100_000_000)
+        }
+    }
+
+    @Test func pullNoOpsWhenNoUpstream() async throws {
+        let repo = FileManager.default.temporaryDirectory
+            .appendingPathComponent("alas-rpspull-nu-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: repo, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: repo) }
+        _ = try await Process.git(["init", "-q", "-b", "feature"], cwd: repo)
+        _ = try await Process.git(["config", "user.email", "t@e"], cwd: repo)
+        _ = try await Process.git(["config", "user.name", "t"], cwd: repo)
+        _ = try await Process.git(["commit", "-q", "--allow-empty", "-m", "x"], cwd: repo)
+
+        let state = RightPaneState(worktree: makeWorktree(at: repo, branch: "feature"), baseBranch: "main")
+        // Probe sync status first so behindUpstream is nil *because the branch
+        // has no upstream*, not merely because it was never fetched.
+        await state.refreshSyncStatus()
+        #expect(state.behindUpstream == nil)
+        state.pull()
+        #expect(state.pullInFlight == false)
+    }
+
+    @Test func pullFastForwardsAndClearsInFlight() async throws {
+        let (clone, remote) = try await makeCloneBehindUpstream(conflicting: false)
+        defer {
+            try? FileManager.default.removeItem(at: clone)
+            try? FileManager.default.removeItem(at: remote)
+        }
+        let state = RightPaneState(worktree: makeWorktree(at: clone, branch: "main"), baseBranch: "main")
+        await state.refresh()
+        try await wait { state.behindUpstream?.count == 1 }
+        #expect(state.behindUpstream?.count == 1)
+
+        state.pull()
+        try await wait { !state.pullInFlight }
+
+        let head = try await Process.git(["rev-parse", "HEAD"], cwd: clone).stdout
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        let upstream = try await Process.git(["rev-parse", "origin/main"], cwd: clone).stdout
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        #expect(head == upstream)
+        #expect(state.pullInFlight == false)
+        #expect(state.mergeOp.current == nil)
+    }
+
+    @Test func pullRoutesConflictIntoMergeOp() async throws {
+        let (clone, remote) = try await makeCloneBehindUpstream(conflicting: true)
+        defer {
+            try? FileManager.default.removeItem(at: clone)
+            try? FileManager.default.removeItem(at: remote)
+        }
+        let state = RightPaneState(worktree: makeWorktree(at: clone, branch: "main"), baseBranch: "main")
+        await state.refresh()
+        try await wait { state.behindUpstream?.count == 1 }
+
+        state.pull()
+        try await wait { !state.pullInFlight }
+
+        #expect(state.pullInFlight == false)
+        guard case .rebase = state.mergeOp.current else {
+            Issue.record("expected rebase-in-progress, got \(String(describing: state.mergeOp.current))")
+            return
+        }
+    }
+
+    @Test func forcedRefreshBypassesThrottleAndUpdatesBehindUpstream() async throws {
+        let (clone, remote) = try await makeCloneBehindUpstream(conflicting: false)
+        defer {
+            try? FileManager.default.removeItem(at: clone)
+            try? FileManager.default.removeItem(at: remote)
+        }
+        let state = RightPaneState(worktree: makeWorktree(at: clone, branch: "main"), baseBranch: "main")
+        // Simulate a very recent probe so the 30s throttle would skip fetches
+        // for both the upstream chip AND the base chip (which also resolves to
+        // origin/main here and would otherwise side-channel the fetch).
+        let recentDate = Date()
+        state.behindBase = GitService.BehindStatus(
+            ref: "origin/main", sha: "deadbeef", count: 0, probedAt: recentDate
+        )
+        state.behindUpstream = GitService.BehindStatus(
+            ref: "origin/main", sha: "deadbeef", count: 0, probedAt: recentDate
+        )
+
+        // Non-forced: throttle skips the fetch, so the stale ref still reads 0.
+        await state.refreshSyncStatus()
+        #expect(state.behindUpstream?.count == 0)
+
+        // Forced: fetches now, sees the upstream commit → behind by 1.
+        await state.refreshSyncStatus(force: true)
+        #expect(state.behindUpstream?.count == 1)
+    }
+}


### PR DESCRIPTION
## Summary

- Adds `GitService.pull(worktreePath:)` — resolves upstream, fetches fresh, rebases onto it (`PullError.noUpstream` when no tracking ref)
- Adds `pull()` + `fetchNow()` on `RightPaneState`, with `pullInFlight` state and `refreshSyncStatus(force:)` to bypass the 30s throttle post-pull
- Makes the upstream "↓N" chip in the Commits header tappable: clicking it pulls, shows a spinner while in flight, and routes conflicts into the existing `OperationCard` machinery
- Adds "Fetch now" to the `BranchOpsMenu` gear menu

## Test plan

- [ ] `AlasTests/GitServicePullTests` — 4 tests covering fast-forward, rebase, conflict, and no-upstream cases
- [ ] `AlasTests/RightPaneStatePullTests` — 4 tests covering no-op guard, fast-forward, conflict routing, and throttle bypass
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)