### PR TITLE
fix(chat): streamed sentence spacing and cache fff builds

### DIFF
--- a/Alas/Sources/ACP/Session/ACPSession.swift
+++ b/Alas/Sources/ACP/Session/ACPSession.swift
@@ -824,6 +824,9 @@ final class ACPSession: ObservableObject, Identifiable {
         // `example.com.` split before `Path`), which we also leave alone.
         let scalars = previous.unicodeScalars
         var i = scalars.index(before: scalars.endIndex) // the punctuation
+        // No word before the punctuation (chunk is just "." or "!" etc.) —
+        // nothing to validate, treat as no separator.
+        guard i > scalars.startIndex else { return "" }
         scalars.formIndex(before: &i) // first char of the word run
         var hasSlash = false
         var hasColon = false

--- a/Alas/Sources/ACP/Session/ACPSession.swift
+++ b/Alas/Sources/ACP/Session/ACPSession.swift
@@ -777,7 +777,7 @@ final class ACPSession: ObservableObject, Identifiable {
             } else {
                 switch transcript.messages[i] {
                 case .agent(_, let buf), .thought(_, let buf):
-                    buf.append(addition)
+                    buf.append(Self.streamingSeparator(between: buf.value, and: addition) + addition)
                     transcript.streamingTick &+= 1
                     return i
                 default:
@@ -788,6 +788,27 @@ final class ACPSession: ObservableObject, Identifiable {
         transcript.messages.append(makeNew())
         didAppendTranscriptMessage()
         return transcript.messages.count - 1
+    }
+    /// Returns the separator (if any) to insert between two streaming
+    /// chunks before appending `next` to `previous`. Adapters sometimes
+    /// split their stream at a sentence boundary and drop the trailing
+    /// whitespace, so a chunk ending in `.` is followed by one starting
+    /// with an uppercase letter — `append` with no separator would glue
+    /// them as `completed.Running`, mashing two sentences together. When
+    /// we detect that boundary (`[.!?]` then `[A-Z][a-z]`), inject a
+    /// newline so the second sentence starts on its own line.
+    private static func streamingSeparator(between previous: String, and next: String) -> String {
+        guard let last = previous.last, let first = next.first else { return "" }
+        if last.isWhitespace || first.isWhitespace { return "" }
+        if last == "." || last == "!" || last == "?" {
+            if let firstUpper = first.asciiValue,
+               firstUpper >= 0x41 && firstUpper <= 0x5A,
+               let secondScalar = next.unicodeScalars.dropFirst().first,
+               secondScalar.value >= 0x61 && secondScalar.value <= 0x7A {
+                return "\n"
+            }
+        }
+        return ""
     }
     /// Returns the index of the matching tool call, or nil if no match.
     private func updateToolCall(id: String, _ mutate: (inout ACPMessage.ToolCall) -> Void) -> Int? {

--- a/Alas/Sources/ACP/Session/ACPSession.swift
+++ b/Alas/Sources/ACP/Session/ACPSession.swift
@@ -795,20 +795,54 @@ final class ACPSession: ObservableObject, Identifiable {
     /// whitespace, so a chunk ending in `.` is followed by one starting
     /// with an uppercase letter — `append` with no separator would glue
     /// them as `completed.Running`, mashing two sentences together. When
-    /// we detect that boundary (`[.!?]` then `[A-Z][a-z]`), inject a
-    /// newline so the second sentence starts on its own line.
+    /// we detect that boundary, inject a newline so the second sentence
+    /// starts on its own line.
+    ///
+    /// To avoid corrupting identifiers / URLs / paths that happen to be
+    /// split across chunks (`Foo.` + `Bar`, `example.com.` + `Path`), we
+    /// require the word immediately before the punctuation to be all
+    /// lowercase (a real English word ending a sentence, not a CamelCase
+    /// token) and not look like the tail of a URL or path (no `/` or `://`
+    /// in the run of non-whitespace preceding the punctuation).
     private static func streamingSeparator(between previous: String, and next: String) -> String {
         guard let last = previous.last, let first = next.first else { return "" }
         if last.isWhitespace || first.isWhitespace { return "" }
-        if last == "." || last == "!" || last == "?" {
-            if let firstUpper = first.asciiValue,
-               firstUpper >= 0x41 && firstUpper <= 0x5A,
-               let secondScalar = next.unicodeScalars.dropFirst().first,
-               secondScalar.value >= 0x61 && secondScalar.value <= 0x7A {
-                return "\n"
-            }
+        guard last == "." || last == "!" || last == "?" else { return "" }
+        // Next chunk must start with an uppercase letter followed by a
+        // lowercase one (start of a new sentence, not an all-caps acronym
+        // like `API`).
+        guard let firstUpper = first.asciiValue,
+              firstUpper >= 0x41 && firstUpper <= 0x5A,
+              let secondScalar = next.unicodeScalars.dropFirst().first,
+              secondScalar.value >= 0x61 && secondScalar.value <= 0x7A
+        else { return "" }
+        // Walk back from the punctuation over the preceding run of
+        // non-whitespace. The word immediately before the punctuation must
+        // be all lowercase ASCII letters — this excludes CamelCase tokens
+        // like `Foo` in `Foo.Bar` and acronyms like `SHA` in `head SHA.Git`.
+        // A `/` or `://` in that run signals a URL/path tail (e.g.
+        // `example.com.` split before `Path`), which we also leave alone.
+        let scalars = previous.unicodeScalars
+        var i = scalars.index(before: scalars.endIndex) // the punctuation
+        scalars.formIndex(before: &i) // first char of the word run
+        var hasSlash = false
+        var hasColon = false
+        var wordChars: [UInt32] = []
+        while i >= scalars.startIndex {
+            let s = scalars[i]
+            if s.value == 0x20 || (s.value >= 0x09 && s.value <= 0x0D) { break }
+            wordChars.append(s.value)
+            if s == "/" { hasSlash = true }
+            if s == ":" { hasColon = true }
+            scalars.formIndex(before: &i)
         }
-        return ""
+        // A `/` or `:` in the preceding run signals a URL/path tail
+        // (e.g. `example.com.` split before `Path`); leave it alone.
+        if hasSlash || hasColon { return "" }
+        guard !wordChars.isEmpty, wordChars.allSatisfy({ v in
+            v >= 0x61 && v <= 0x7A
+        }) else { return "" }
+        return "\n"
     }
     /// Returns the index of the matching tool call, or nil if no match.
     private func updateToolCall(id: String, _ mutate: (inout ACPMessage.ToolCall) -> Void) -> Int? {

--- a/Alas/Sources/ACP/Session/ACPSession.swift
+++ b/Alas/Sources/ACP/Session/ACPSession.swift
@@ -831,9 +831,13 @@ final class ACPSession: ObservableObject, Identifiable {
         var hasSlash = false
         var hasColon = false
         var wordChars: [UInt32] = []
+        var precededByWhitespace = false
         while i >= scalars.startIndex {
             let s = scalars[i]
-            if s.value == 0x20 || (s.value >= 0x09 && s.value <= 0x0D) { break }
+            if s.value == 0x20 || (s.value >= 0x09 && s.value <= 0x0D) {
+                precededByWhitespace = true
+                break
+            }
             wordChars.append(s.value)
             if s == "/" { hasSlash = true }
             if s == ":" { hasColon = true }
@@ -843,7 +847,12 @@ final class ACPSession: ObservableObject, Identifiable {
         // A `/` or `:` in the preceding run signals a URL/path tail
         // (e.g. `example.com.` split before `Path`); leave it alone.
         if hasSlash || hasColon { return "" }
-        guard !wordChars.isEmpty, wordChars.allSatisfy({ v in
+        // The word must be all lowercase ASCII letters. Require it to be
+        // preceded by whitespace so a qualified identifier whose left
+        // segment is lowercase (`package.Type`, `self.Value`) doesn't get
+        // a newline injected — a sentence-ending word in prose is always
+        // preceded by a space, a code identifier usually isn't.
+        guard precededByWhitespace, !wordChars.isEmpty, wordChars.allSatisfy({ v in
             v >= 0x61 && v <= 0x7A
         }) else { return "" }
         return "\n"

--- a/Alas/Sources/ACP/Session/ACPSession.swift
+++ b/Alas/Sources/ACP/Session/ACPSession.swift
@@ -834,6 +834,7 @@ final class ACPSession: ObservableObject, Identifiable {
             wordChars.append(s.value)
             if s == "/" { hasSlash = true }
             if s == ":" { hasColon = true }
+            if i == scalars.startIndex { break }
             scalars.formIndex(before: &i)
         }
         // A `/` or `:` in the preceding run signals a URL/path tail

--- a/AlasTests/ACP/Session/ACPSessionTests.swift
+++ b/AlasTests/ACP/Session/ACPSessionTests.swift
@@ -39,16 +39,22 @@ struct ACPSessionTests {
     @Test("agent chunks with ! or ? boundary also get a newline separator")
     func chunksSplitAtPunctuationGetNewline() async {
         let session = ACPSession(id: "s", agentId: "claude", worktreeId: "w", title: "t")
-        session.apply(.agentMessageChunk(.text("Done!Next")))
+        // Lowercase word before `!` → separator applies.
+        session.apply(.agentMessageChunk(.text("done!")))
+        session.apply(.agentMessageChunk(.text("Next task")))
         if case .agent(_, let buf) = session.transcript.messages[0] {
-            #expect(buf.value == "Done!Next")
+            #expect(buf.value == "done!\nNext task")
         } else { Issue.record("expected single agent message") }
-        // Two separate chunks: "Done!" + "Next"
-        let session2 = ACPSession(id: "s2", agentId: "claude", worktreeId: "w", title: "t")
-        session2.apply(.agentMessageChunk(.text("Done!")))
-        session2.apply(.agentMessageChunk(.text("Next task")))
-        if case .agent(_, let buf) = session2.transcript.messages[0] {
-            #expect(buf.value == "Done!\nNext task")
+    }
+
+    @Test("agent chunks with capitalized word before punctuation do not get a newline")
+    func chunksWithCapitalizedWordNoSeparator() async {
+        let session = ACPSession(id: "s", agentId: "claude", worktreeId: "w", title: "t")
+        // `Foo` is CamelCase → no separator (protects identifiers).
+        session.apply(.agentMessageChunk(.text("Foo.")))
+        session.apply(.agentMessageChunk(.text("Bar")))
+        if case .agent(_, let buf) = session.transcript.messages[0] {
+            #expect(buf.value == "Foo.Bar")
         } else { Issue.record("expected single agent message") }
     }
 
@@ -60,6 +66,17 @@ struct ACPSessionTests {
         // "API" — first char 'A' (upper), second char 'P' (upper, not [a-z]) → no separator
         if case .agent(_, let buf) = session.transcript.messages[0] {
             #expect(buf.value == "See the API docs.API")
+        } else { Issue.record("expected single agent message") }
+    }
+
+    @Test("agent chunks split at a URL tail do not get a newline")
+    func chunksSplitAtURLNoSeparator() async {
+        let session = ACPSession(id: "s", agentId: "claude", worktreeId: "w", title: "t")
+        session.apply(.agentMessageChunk(.text("See https://example.com.")))
+        session.apply(.agentMessageChunk(.text("Path")))
+        // `com.` is preceded by `/` (URL tail) → no separator.
+        if case .agent(_, let buf) = session.transcript.messages[0] {
+            #expect(buf.value == "See https://example.com.Path")
         } else { Issue.record("expected single agent message") }
     }
 

--- a/AlasTests/ACP/Session/ACPSessionTests.swift
+++ b/AlasTests/ACP/Session/ACPSessionTests.swift
@@ -58,6 +58,18 @@ struct ACPSessionTests {
         } else { Issue.record("expected single agent message") }
     }
 
+    @Test("single-character punctuation chunk does not crash and adds no separator")
+    func chunksWithSingleCharPunctuationNoCrash() async {
+        let session = ACPSession(id: "s", agentId: "claude", worktreeId: "w", title: "t")
+        // A chunk that is just "." followed by "Next" must not trap when
+        // walking back past the punctuation and must not inject a newline.
+        session.apply(.agentMessageChunk(.text(".")))
+        session.apply(.agentMessageChunk(.text("Next task")))
+        if case .agent(_, let buf) = session.transcript.messages[0] {
+            #expect(buf.value == ".Next task")
+        } else { Issue.record("expected single agent message") }
+    }
+
     @Test("agent chunks with all-caps acronym after period do not get a newline")
     func chunksWithAcronymNoSeparator() async {
         let session = ACPSession(id: "s", agentId: "claude", worktreeId: "w", title: "t")

--- a/AlasTests/ACP/Session/ACPSessionTests.swift
+++ b/AlasTests/ACP/Session/ACPSessionTests.swift
@@ -39,11 +39,11 @@ struct ACPSessionTests {
     @Test("agent chunks with ! or ? boundary also get a newline separator")
     func chunksSplitAtPunctuationGetNewline() async {
         let session = ACPSession(id: "s", agentId: "claude", worktreeId: "w", title: "t")
-        // Lowercase word before `!` → separator applies.
-        session.apply(.agentMessageChunk(.text("done!")))
+        // Lowercase word before `!` with preceding whitespace → separator.
+        session.apply(.agentMessageChunk(.text("All done!")))
         session.apply(.agentMessageChunk(.text("Next task")))
         if case .agent(_, let buf) = session.transcript.messages[0] {
-            #expect(buf.value == "done!\nNext task")
+            #expect(buf.value == "All done!\nNext task")
         } else { Issue.record("expected single agent message") }
     }
 
@@ -67,6 +67,18 @@ struct ACPSessionTests {
         session.apply(.agentMessageChunk(.text("Next task")))
         if case .agent(_, let buf) = session.transcript.messages[0] {
             #expect(buf.value == ".Next task")
+        } else { Issue.record("expected single agent message") }
+    }
+
+    @Test("qualified identifier with lowercase left segment gets no separator")
+    func chunksWithQualifiedIdentifierNoSeparator() async {
+        let session = ACPSession(id: "s", agentId: "claude", worktreeId: "w", title: "t")
+        // `package.` + `Type` — lowercase word but no preceding whitespace
+        // (qualified identifier at chunk start) → no separator.
+        session.apply(.agentMessageChunk(.text("package.")))
+        session.apply(.agentMessageChunk(.text("Type")))
+        if case .agent(_, let buf) = session.transcript.messages[0] {
+            #expect(buf.value == "package.Type")
         } else { Issue.record("expected single agent message") }
     }
 

--- a/AlasTests/ACP/Session/ACPSessionTests.swift
+++ b/AlasTests/ACP/Session/ACPSessionTests.swift
@@ -15,6 +15,65 @@ struct ACPSessionTests {
         else { Issue.record("expected single agent message") }
     }
 
+    @Test("agent chunks split at a sentence boundary get a newline separator")
+    func chunksSplitAtSentenceGetNewline() async {
+        let session = ACPSession(id: "s", agentId: "claude", worktreeId: "w", title: "t")
+        session.apply(.agentMessageChunk(.text("Compacting completed.")))
+        session.apply(.agentMessageChunk(.text("Running the pull tests.")))
+        #expect(session.transcript.messages.count == 1)
+        if case .agent(_, let buf) = session.transcript.messages[0] {
+            #expect(buf.value == "Compacting completed.\nRunning the pull tests.")
+        } else { Issue.record("expected single agent message") }
+    }
+
+    @Test("agent chunks already separated by whitespace are not double-spaced")
+    func chunksWithExistingWhitespaceNoExtraSeparator() async {
+        let session = ACPSession(id: "s", agentId: "claude", worktreeId: "w", title: "t")
+        session.apply(.agentMessageChunk(.text("line one\n")))
+        session.apply(.agentMessageChunk(.text("line two")))
+        if case .agent(_, let buf) = session.transcript.messages[0] {
+            #expect(buf.value == "line one\nline two")
+        } else { Issue.record("expected single agent message") }
+    }
+
+    @Test("agent chunks with ! or ? boundary also get a newline separator")
+    func chunksSplitAtPunctuationGetNewline() async {
+        let session = ACPSession(id: "s", agentId: "claude", worktreeId: "w", title: "t")
+        session.apply(.agentMessageChunk(.text("Done!Next")))
+        if case .agent(_, let buf) = session.transcript.messages[0] {
+            #expect(buf.value == "Done!Next")
+        } else { Issue.record("expected single agent message") }
+        // Two separate chunks: "Done!" + "Next"
+        let session2 = ACPSession(id: "s2", agentId: "claude", worktreeId: "w", title: "t")
+        session2.apply(.agentMessageChunk(.text("Done!")))
+        session2.apply(.agentMessageChunk(.text("Next task")))
+        if case .agent(_, let buf) = session2.transcript.messages[0] {
+            #expect(buf.value == "Done!\nNext task")
+        } else { Issue.record("expected single agent message") }
+    }
+
+    @Test("agent chunks with all-caps acronym after period do not get a newline")
+    func chunksWithAcronymNoSeparator() async {
+        let session = ACPSession(id: "s", agentId: "claude", worktreeId: "w", title: "t")
+        session.apply(.agentMessageChunk(.text("See the API docs.")))
+        session.apply(.agentMessageChunk(.text("API")))
+        // "API" — first char 'A' (upper), second char 'P' (upper, not [a-z]) → no separator
+        if case .agent(_, let buf) = session.transcript.messages[0] {
+            #expect(buf.value == "See the API docs.API")
+        } else { Issue.record("expected single agent message") }
+    }
+
+    @Test("thought chunks split at a sentence boundary get a newline separator")
+    func thoughtChunksSplitAtSentenceGetNewline() async {
+        let session = ACPSession(id: "s", agentId: "claude", worktreeId: "w", title: "t")
+        session.apply(.agentThoughtChunk(.text("First thought.")))
+        session.apply(.agentThoughtChunk(.text("Second thought.")))
+        #expect(session.transcript.messages.count == 1)
+        if case .thought(_, let buf) = session.transcript.messages[0] {
+            #expect(buf.value == "First thought.\nSecond thought.")
+        } else { Issue.record("expected single thought message") }
+    }
+
     @Test("agent chunks after a completed output boundary start a new message")
     func completedOutputBoundaryStartsNewMessage() async {
         let session = ACPSession(id: "s", agentId: "codex", worktreeId: "w", title: "t")

--- a/scripts/build-fff.sh
+++ b/scripts/build-fff.sh
@@ -23,27 +23,40 @@ install_root="${build_root}/install"
 lib_dir="${install_root}/lib"
 lib_output="${lib_dir}/libfff_c.dylib"
 include_root="${srcroot}/.build/fff/include"
+fingerprint_path="${build_root}/fingerprint"
 
 die() {
     echo "build-fff.sh: error: $*" >&2
     exit 1
 }
 
-# Fast path: if the expected dylib for this arch already exists, skip the
-# cargo build. The Xcode build phase runs this script on every build
-# (`alwaysOutOfDate = 1`), but a cargo build from scratch takes ~40s, so
-# reusing a previously produced dylib keeps incremental Xcode builds fast.
-# The dylib is only regenerated when the fff submodule changes; a stale
-# dylib would be caught by the lipo step in the universal build path below.
-if [ "${target_arch}" = "universal" ]; then
-    arm64_slice="${srcroot}/.build/fff/arm64/install/lib/libfff_c.dylib"
-    x86_64_slice="${srcroot}/.build/fff/x86_64/install/lib/libfff_c.dylib"
-    if [ -f "${lib_output}" ] && [ -f "${arm64_slice}" ] && [ -f "${x86_64_slice}" ]; then
-        echo "build-fff.sh: fast path — universal ${lib_output} exists"
-        exit 0
-    fi
-elif [ -f "${lib_output}" ]; then
-    echo "build-fff.sh: fast path — ${lib_output} exists"
+# Fingerprint over the fff submodule (HEAD + working-tree dirt), target
+# arch, and this script's content hash. A stale `.build/fff` from a
+# previous submodule checkout is invalidated by the SHA change.
+fff_sha="$(git -C "${fff_src}" rev-parse HEAD 2>/dev/null || echo "")"
+fff_dirt="$(
+    {
+        git -C "${fff_src}" diff --no-ext-diff --no-color HEAD -- . 2>/dev/null | shasum -a 256
+        while IFS= read -r -d '' untracked; do
+            printf '%s\0' "${untracked}"
+            shasum -a 256 "${fff_src}/${untracked}" 2>/dev/null | awk '{print $1}'
+        done < <(git -C "${fff_src}" ls-files --others --exclude-standard -z 2>/dev/null | LC_ALL=C sort -z) \
+            | shasum -a 256
+    } | shasum -a 256 | awk '{print $1}'
+)"
+script_id="$(shasum -a 256 "${script_path}" 2>/dev/null | awk '{print $1}')"
+fingerprint="$(printf '%s\n%s\n%s\n%s\n' "${fff_sha}" "${fff_dirt}" "${target_arch}" "${script_id}" | shasum -a 256 | awk '{print $1}')"
+
+# Fast path: if the expected dylib for this arch already exists AND the
+# fingerprint matches, skip the cargo build. The Xcode build phase runs
+# this script on every build (`alwaysOutOfDate = 1`), but a cargo build
+# from scratch takes ~40s, so reusing a previously produced dylib keeps
+# incremental Xcode builds fast. The fingerprint pins the dylib to a
+# specific submodule SHA + script version so a checkout change forces a
+# rebuild rather than linking a stale artifact.
+if [ -f "${lib_output}" ] && [ -f "${fingerprint_path}" ] \
+   && [ "$(cat "${fingerprint_path}")" = "${fingerprint}" ]; then
+    echo "build-fff.sh: fast path — ${lib_output} up to date (fingerprint ${fingerprint:0:12})"
     exit 0
 fi
 
@@ -60,6 +73,7 @@ if [ "${target_arch}" = "universal" ]; then
 
     lipo -create "${arm64_slice}" "${x86_64_slice}" -output "${lib_output}"
     install_name_tool -id @rpath/libfff_c.dylib "${lib_output}"
+    printf '%s\n' "${fingerprint}" > "${fingerprint_path}"
     echo "build-fff.sh: produced universal ${lib_output}"
     exit 0
 fi
@@ -96,6 +110,7 @@ cargo_output="${build_root}/cargo-target/${cargo_target}/release/libfff_c.dylib"
 
 rsync -a "${cargo_output}" "${lib_output}"
 install_name_tool -id @rpath/libfff_c.dylib "${lib_output}"
+printf '%s\n' "${fingerprint}" > "${fingerprint_path}"
 
 rsync -a "${fff_src}/crates/fff-c/include/fff.h" "${include_root}/fff.h"
 cat > "${include_root}/module.modulemap" <<'MODULEMAP'

--- a/scripts/build-fff.sh
+++ b/scripts/build-fff.sh
@@ -54,7 +54,15 @@ fingerprint="$(printf '%s\n%s\n%s\n%s\n' "${fff_sha}" "${fff_dirt}" "${target_ar
 # incremental Xcode builds fast. The fingerprint pins the dylib to a
 # specific submodule SHA + script version so a checkout change forces a
 # rebuild rather than linking a stale artifact.
-if [ -f "${lib_output}" ] && [ -f "${fingerprint_path}" ] \
+#
+# The shared include dir (fff.h, module.modulemap) is also required — a
+# partial clean that removed the headers while leaving the dylib would
+# otherwise make the Swift compile fail with a missing header on a fast
+# path that skipped regenerating it.
+if [ -f "${lib_output}" ] \
+   && [ -f "${fingerprint_path}" ] \
+   && [ -f "${include_root}/fff.h" ] \
+   && [ -f "${include_root}/module.modulemap" ] \
    && [ "$(cat "${fingerprint_path}")" = "${fingerprint}" ]; then
     echo "build-fff.sh: fast path — ${lib_output} up to date (fingerprint ${fingerprint:0:12})"
     exit 0

--- a/scripts/build-fff.sh
+++ b/scripts/build-fff.sh
@@ -29,6 +29,24 @@ die() {
     exit 1
 }
 
+# Fast path: if the expected dylib for this arch already exists, skip the
+# cargo build. The Xcode build phase runs this script on every build
+# (`alwaysOutOfDate = 1`), but a cargo build from scratch takes ~40s, so
+# reusing a previously produced dylib keeps incremental Xcode builds fast.
+# The dylib is only regenerated when the fff submodule changes; a stale
+# dylib would be caught by the lipo step in the universal build path below.
+if [ "${target_arch}" = "universal" ]; then
+    arm64_slice="${srcroot}/.build/fff/arm64/install/lib/libfff_c.dylib"
+    x86_64_slice="${srcroot}/.build/fff/x86_64/install/lib/libfff_c.dylib"
+    if [ -f "${lib_output}" ] && [ -f "${arm64_slice}" ] && [ -f "${x86_64_slice}" ]; then
+        echo "build-fff.sh: fast path — universal ${lib_output} exists"
+        exit 0
+    fi
+elif [ -f "${lib_output}" ]; then
+    echo "build-fff.sh: fast path — ${lib_output} exists"
+    exit 0
+fi
+
 if [ "${target_arch}" = "universal" ]; then
     mkdir -p "${lib_dir}"
     for slice in arm64 x86_64; do

--- a/scripts/build-fff.sh
+++ b/scripts/build-fff.sh
@@ -110,7 +110,6 @@ cargo_output="${build_root}/cargo-target/${cargo_target}/release/libfff_c.dylib"
 
 rsync -a "${cargo_output}" "${lib_output}"
 install_name_tool -id @rpath/libfff_c.dylib "${lib_output}"
-printf '%s\n' "${fingerprint}" > "${fingerprint_path}"
 
 rsync -a "${fff_src}/crates/fff-c/include/fff.h" "${include_root}/fff.h"
 cat > "${include_root}/module.modulemap" <<'MODULEMAP'
@@ -120,5 +119,10 @@ module FffC [system] {
     export *
 }
 MODULEMAP
+
+# Write the fingerprint last so a partial interruption (between dylib
+# install and header copy, or a failed header/modulemap write) leaves
+# an absent or mismatched fingerprint rather than a stale-valid one.
+printf '%s\n' "${fingerprint}" > "${fingerprint_path}"
 
 echo "build-fff.sh: built ${lib_output}"


### PR DESCRIPTION
Avoid mashing adjacent streamed sentences together when adapters split chunks
at punctuation, while preserving existing whitespace and acronym cases.

Skip repeated fff cargo builds when the expected dylib artifacts are already
present so incremental Xcode builds do less redundant work.