### PR TITLE
fix(changes): Expand commit row actions

### DIFF
--- a/Alas/Sources/Git/CommitInfo.swift
+++ b/Alas/Sources/Git/CommitInfo.swift
@@ -8,10 +8,40 @@ struct CommitInfo: Identifiable, Hashable {
     let authorInitials: String
     let date: Date
     let subject: String      // already stripped of conventional prefix
+    let rawSubject: String
+    let body: String
     let conventionalTag: String?
     let filesChanged: Int
     let insertions: Int
     let deletions: Int
+
+    init(
+        sha: String,
+        shortSha: String,
+        author: String,
+        authorInitials: String,
+        date: Date,
+        subject: String,
+        rawSubject: String? = nil,
+        body: String = "",
+        conventionalTag: String?,
+        filesChanged: Int,
+        insertions: Int,
+        deletions: Int
+    ) {
+        self.sha = sha
+        self.shortSha = shortSha
+        self.author = author
+        self.authorInitials = authorInitials
+        self.date = date
+        self.subject = subject
+        self.rawSubject = rawSubject ?? subject
+        self.body = body
+        self.conventionalTag = conventionalTag
+        self.filesChanged = filesChanged
+        self.insertions = insertions
+        self.deletions = deletions
+    }
 }
 
 extension CommitInfo {
@@ -55,5 +85,11 @@ extension CommitInfo {
             .prefix(2)
             .compactMap { $0.first.map { String($0).uppercased() } }
         return parts.isEmpty ? "?" : parts.joined()
+    }
+
+    var fullMessage: String {
+        let trimmedBody = body.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmedBody.isEmpty else { return rawSubject }
+        return "\(rawSubject)\n\n\(trimmedBody)"
     }
 }

--- a/Alas/Sources/Git/GitService.swift
+++ b/Alas/Sources/Git/GitService.swift
@@ -817,6 +817,8 @@ extension GitService {
             authorInitials: CommitInfo.initials(for: author),
             date: date,
             subject: subject,
+            rawSubject: rawSubject,
+            body: body,
             conventionalTag: tag,
             filesChanged: files.count,
             insertions: files.reduce(0) { $0 + $1.add },
@@ -1150,16 +1152,17 @@ extension GitService {
         }
 
         // %x1f = ASCII 0x1f (unit separator), %x1e = 0x1e (record
-        // separator). Avoids collisions with any text in messages.
+        // separator), %x1d = 0x1d (group separator). Avoids collisions with
+        // most message text while keeping the body separate from numstat rows.
         //
         // Place %x1e at the START of each commit's format line (using
         // tformat: so git appends a LF after each record). Splitting on
         // \x1e then yields one empty leading piece followed by one piece
         // per commit, each containing:
-        //   <sha>\x1f<short>\x1f<author-name>\x1f<author-iso-date>\x1f<subject>\n
+        //   <sha>\x1f<short>\x1f<author-name>\x1f<author-iso-date>\x1f<subject>\x1f<body>\x1d
         //   \n                        ← blank separator between header and numstat
         //   <numstat lines: "A\tD\tpath" each>
-        let format = "%x1e%H%x1f%h%x1f%an%x1f%aI%x1f%s"
+        let format = "%x1e%H%x1f%h%x1f%an%x1f%aI%x1f%s%x1f%b%x1d"
         let log = try await Process.git(
             ["log", "\(comparisonRef)..HEAD", "--pretty=tformat:\(format)", "--numstat"],
             cwd: worktree
@@ -1179,15 +1182,18 @@ extension GitService {
         for record in records {
             let trimmed = record.trimmingCharacters(in: .whitespacesAndNewlines)
             guard !trimmed.isEmpty else { continue }
-            let lines = trimmed.split(separator: "\n", omittingEmptySubsequences: false)
-            guard let headerLine = lines.first else { continue }
-            let fields = headerLine.split(separator: "\u{1f}", maxSplits: 4, omittingEmptySubsequences: false)
-            guard fields.count == 5 else { continue }
+            let sections = trimmed.split(separator: "\u{1d}", maxSplits: 1, omittingEmptySubsequences: false)
+            guard let headerLine = sections.first else { continue }
+            let numstatText = sections.count > 1 ? String(sections[1]) : ""
+            let lines = numstatText.split(separator: "\n", omittingEmptySubsequences: false)
+            let fields = headerLine.split(separator: "\u{1f}", maxSplits: 5, omittingEmptySubsequences: false)
+            guard fields.count == 6 else { continue }
             let sha = String(fields[0])
             let short = String(fields[1])
             let author = String(fields[2])
             let dateStr = String(fields[3])
             let rawSubject = String(fields[4])
+            let body = String(fields[5]).trimmingCharacters(in: .whitespacesAndNewlines)
             let date = isoFormatter.date(from: dateStr) ?? Date(timeIntervalSince1970: 0)
             let (tag, subject) = CommitInfo.parseConventional(subject: rawSubject)
 
@@ -1214,6 +1220,8 @@ extension GitService {
                 authorInitials: CommitInfo.initials(for: author),
                 date: date,
                 subject: subject,
+                rawSubject: rawSubject,
+                body: body,
                 conventionalTag: tag,
                 filesChanged: filesChanged,
                 insertions: adds,
@@ -1231,7 +1239,7 @@ extension GitService {
     /// `CommitInfo` shape and the divider/dimming lives in the view layer.
     func commitsOlder(worktreePath: URL, beforeSha: String, count: Int) async throws -> [CommitInfo] {
         let range = "\(beforeSha)^"
-        let format = "%x1e%H%x1f%h%x1f%an%x1f%aI%x1f%s"
+        let format = "%x1e%H%x1f%h%x1f%an%x1f%aI%x1f%s%x1f%b%x1d"
         let log = try await Process.git(
             ["log", range, "-n", String(count), "--first-parent",
              "--pretty=tformat:\(format)", "--numstat"],
@@ -1256,15 +1264,18 @@ extension GitService {
         for record in records {
             let trimmed = record.trimmingCharacters(in: .whitespacesAndNewlines)
             guard !trimmed.isEmpty else { continue }
-            let lines = trimmed.split(separator: "\n", omittingEmptySubsequences: false)
-            guard let headerLine = lines.first else { continue }
-            let fields = headerLine.split(separator: "\u{1f}", maxSplits: 4, omittingEmptySubsequences: false)
-            guard fields.count == 5 else { continue }
+            let sections = trimmed.split(separator: "\u{1d}", maxSplits: 1, omittingEmptySubsequences: false)
+            guard let headerLine = sections.first else { continue }
+            let numstatText = sections.count > 1 ? String(sections[1]) : ""
+            let lines = numstatText.split(separator: "\n", omittingEmptySubsequences: false)
+            let fields = headerLine.split(separator: "\u{1f}", maxSplits: 5, omittingEmptySubsequences: false)
+            guard fields.count == 6 else { continue }
             let sha = String(fields[0])
             let short = String(fields[1])
             let author = String(fields[2])
             let dateStr = String(fields[3])
             let rawSubject = String(fields[4])
+            let body = String(fields[5]).trimmingCharacters(in: .whitespacesAndNewlines)
             let date = isoFormatter.date(from: dateStr) ?? Date(timeIntervalSince1970: 0)
             let (tag, subject) = CommitInfo.parseConventional(subject: rawSubject)
 
@@ -1288,6 +1299,8 @@ extension GitService {
                 authorInitials: CommitInfo.initials(for: author),
                 date: date,
                 subject: subject,
+                rawSubject: rawSubject,
+                body: body,
                 conventionalTag: tag,
                 filesChanged: filesChanged,
                 insertions: adds,
@@ -1598,6 +1611,17 @@ extension GitService {
             return .cherryPick(sha: sha, summary: summary)
         }
 
+        let revertHead = gitDir.appendingPathComponent("REVERT_HEAD")
+        if FileManager.default.fileExists(atPath: revertHead.path) {
+            let sha = (try? String(contentsOf: revertHead, encoding: .utf8))?
+                .trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+            let summary = (try? await Process.git(
+                ["log", "-1", "--pretty=%s", sha],
+                cwd: worktreePath
+            ).stdout.trimmingCharacters(in: .whitespacesAndNewlines)) ?? sha
+            return .revert(sha: sha, summary: summary)
+        }
+
         let mergeHead = gitDir.appendingPathComponent("MERGE_HEAD")
         if FileManager.default.fileExists(atPath: mergeHead.path) {
             // Try to read MERGE_MSG for the source-branch name (`merge branch 'X'`).
@@ -1867,6 +1891,21 @@ extension GitService {
         )
     }
 
+    func revert(worktreePath: URL, sha: String) async throws -> MergeResult {
+        let parents = try await parentCount(worktreePath: worktreePath, sha: sha)
+        var args: [String] = ["-c", "merge.conflictStyle=zdiff3", "revert", "--no-edit"]
+        if parents >= 2 {
+            args.append(contentsOf: ["-m", "1"])
+        }
+        args.append(sha)
+        let result = try await Process.git(args, cwd: worktreePath)
+        return try await classifyOperationResult(
+            worktreePath: worktreePath,
+            exitCode: result.exitCode,
+            stderr: result.stderr
+        )
+    }
+
     /// Number of parent commits for `sha`. Returns 1 for a normal commit, 2+ for a merge.
     private func parentCount(worktreePath: URL, sha: String) async throws -> Int {
         let result = try await Process.git(
@@ -1952,6 +1991,7 @@ extension GitService {
         case .merge:      subcommand = "merge"
         case .rebase:     subcommand = "rebase"
         case .cherryPick: subcommand = "cherry-pick"
+        case .revert:     subcommand = "revert"
         }
         let result = try await Process.git(
             ["-c", "merge.conflictStyle=zdiff3", "-c", "core.editor=true", subcommand, "--continue"],
@@ -1971,6 +2011,7 @@ extension GitService {
         case .merge:      subcommand = "merge"
         case .rebase:     subcommand = "rebase"
         case .cherryPick: subcommand = "cherry-pick"
+        case .revert:     subcommand = "revert"
         }
         let result = try await Process.git([subcommand, "--abort"], cwd: worktreePath)
         guard result.exitCode == 0 else {
@@ -1985,6 +2026,7 @@ extension GitService {
         switch op {
         case .rebase:     subcommand = "rebase"
         case .cherryPick: subcommand = "cherry-pick"
+        case .revert:     subcommand = "revert"
         case .merge:      throw OperationError.skipNotSupported
         }
         let result = try await Process.git(

--- a/Alas/Sources/Git/GitTypes.swift
+++ b/Alas/Sources/Git/GitTypes.swift
@@ -150,8 +150,8 @@ struct ConflictedFile: Equatable {
 }
 
 /// An in-progress conflict-producing operation. Detected by the presence
-/// of marker files inside `.git`: `MERGE_HEAD`, `rebase-merge/`, or
-/// `CHERRY_PICK_HEAD`.
+/// of marker files inside `.git`: `MERGE_HEAD`, `rebase-merge/`,
+/// `CHERRY_PICK_HEAD`, or `REVERT_HEAD`.
 enum MergeOperation: Equatable {
     /// Merging another branch into the current one.
     /// - sourceBranch: the branch being merged in (read from MERGE_MSG / MERGE_HEAD ref)
@@ -164,6 +164,10 @@ enum MergeOperation: Equatable {
     /// Cherry-picking a single commit. `sha` and the first line of the
     /// commit message are exposed for the operation card.
     case cherryPick(sha: String, summary: String)
+
+    /// Reverting a single commit. `sha` and the first line of the commit
+    /// message are exposed for the operation card.
+    case revert(sha: String, summary: String)
 }
 
 struct RebasePlan: Equatable {

--- a/Alas/Sources/Integrations/CodeHost/CodeHostModels.swift
+++ b/Alas/Sources/Integrations/CodeHost/CodeHostModels.swift
@@ -50,6 +50,15 @@ struct CodeHostRemote: Equatable, Sendable {
     let webURL: URL
 
     var repositorySlug: String { "\(owner)/\(repository)" }
+
+    func commitURL(sha: String) -> URL {
+        switch kind {
+        case .github:
+            return webURL.appendingPathComponent("commit").appendingPathComponent(sha)
+        case .gitlab:
+            return webURL.appendingPathComponent("-").appendingPathComponent("commit").appendingPathComponent(sha)
+        }
+    }
 }
 
 struct CodeHostProviderCapabilities: Equatable, Sendable {

--- a/Alas/Sources/Right/CommitRow.swift
+++ b/Alas/Sources/Right/CommitRow.swift
@@ -6,13 +6,17 @@ struct CommitRow: View {
     var isHistorical: Bool = false
     let onSelect: () -> Void
     let onCopySHA: () -> Void
+    var onCopyMessage: (() -> Void)? = nil
+    var onOpenRemote: (() -> Void)? = nil
     var onEdit: (() -> Void)? = nil
     var onCherryPick: (() -> Void)? = nil
+    var onRevert: (() -> Void)? = nil
 
     @Environment(\.theme) private var theme
     @StateObject private var copyFeedback = CopyFeedbackState()
     @State private var shaHovering = false
     @State private var pendingCherryPick = false
+    @State private var pendingRevert = false
 
     var body: some View {
         Button(action: onSelect) {
@@ -37,9 +41,17 @@ struct CommitRow: View {
                 Divider()
             }
             Button("Copy Commit SHA") { copySHA() }
+            Button("Copy Commit Message") { copyMessage() }
+            if let onOpenRemote {
+                Button("Open Commit on Remote") { onOpenRemote() }
+            }
             if onCherryPick != nil {
                 Divider()
                 Button("Cherry-pick…") { pendingCherryPick = true }
+            }
+            if onRevert != nil {
+                Divider()
+                Button("Revert Commit…", role: .destructive) { pendingRevert = true }
             }
         }
         .confirmationDialog(
@@ -53,6 +65,18 @@ struct CommitRow: View {
             Button("Cancel", role: .cancel) {}
         } message: {
             Text("Apply this commit to the current branch.")
+        }
+        .confirmationDialog(
+            "Revert commit?",
+            isPresented: $pendingRevert,
+            titleVisibility: .visible
+        ) {
+            Button("Revert \(String(commit.sha.prefix(7)))", role: .destructive) {
+                onRevert?()
+            }
+            Button("Cancel", role: .cancel) {}
+        } message: {
+            Text("Create a new commit that reverses this commit.")
         }
     }
 
@@ -183,5 +207,14 @@ struct CommitRow: View {
     private func copySHA() {
         onCopySHA()
         copyFeedback.show("Copied SHA")
+    }
+
+    private func copyMessage() {
+        if let onCopyMessage {
+            onCopyMessage()
+        } else {
+            Clipboard.copy(commit.fullMessage)
+        }
+        copyFeedback.show("Copied message")
     }
 }

--- a/Alas/Sources/Right/CommitsSectionView.swift
+++ b/Alas/Sources/Right/CommitsSectionView.swift
@@ -1,3 +1,4 @@
+import AppKit
 import SwiftUI
 
 /// Small pill shown in the Commits section header trailing slot when the
@@ -117,8 +118,11 @@ struct CommitsSectionView: View {
                     isLast: idx == commits.count - 1 && olderCommits.isEmpty,
                     onSelect: { onSelect(commit) },
                     onCopySHA: { onCopySHA(commit) },
+                    onCopyMessage: { Clipboard.copy(commit.fullMessage) },
+                    onOpenRemote: rps.commitsNeedPush ? nil : openRemoteAction(for: commit, remote: rps.primaryCommitRemote),
                     onEdit: { onEdit(commit) },
-                    onCherryPick: { rps.runCherryPick(sha: commit.sha) }
+                    onCherryPick: { rps.runCherryPick(sha: commit.sha) },
+                    onRevert: { rps.runRevert(sha: commit.sha) }
                 )
             }
         } else if olderCommits.isEmpty {
@@ -140,7 +144,10 @@ struct CommitsSectionView: View {
                     isHistorical: comparisonRef != nil,
                     onSelect: { onSelect(commit) },
                     onCopySHA: { onCopySHA(commit) },
-                    onCherryPick: { rps.runCherryPick(sha: commit.sha) }
+                    onCopyMessage: { Clipboard.copy(commit.fullMessage) },
+                    onOpenRemote: openRemoteAction(for: commit, remote: rps.commitRemote),
+                    onCherryPick: { rps.runCherryPick(sha: commit.sha) },
+                    onRevert: { rps.runRevert(sha: commit.sha) }
                 )
             }
         }
@@ -173,6 +180,13 @@ struct CommitsSectionView: View {
         }
         .padding(.horizontal, 12)
         .padding(.vertical, 6)
+    }
+
+    private func openRemoteAction(for commit: CommitInfo, remote: CodeHostRemote?) -> (() -> Void)? {
+        guard let url = remote?.commitURL(sha: commit.sha) else { return nil }
+        return {
+            NSWorkspace.shared.open(url)
+        }
     }
 
     @ViewBuilder

--- a/Alas/Sources/Right/OperationCard.swift
+++ b/Alas/Sources/Right/OperationCard.swift
@@ -43,6 +43,7 @@ struct OperationCard: View {
         case .merge:      return "Merging"
         case .rebase:     return "Rebasing"
         case .cherryPick: return "Cherry-picking"
+        case .revert:     return "Reverting"
         }
     }
 
@@ -64,7 +65,8 @@ struct OperationCard: View {
             case let (src?, nil):   return "\(src) · \(position)"
             default:                return position
             }
-        case .cherryPick(let sha, let summary):
+        case .cherryPick(let sha, let summary),
+             .revert(let sha, let summary):
             return "\(String(sha.prefix(7))) · \(summary)"
         }
     }

--- a/Alas/Sources/Right/RightPaneState.swift
+++ b/Alas/Sources/Right/RightPaneState.swift
@@ -69,6 +69,16 @@ final class RightPaneState {
     var behindBase: GitService.BehindStatus? = nil
     var behindUpstream: GitService.BehindStatus? = nil
 
+    /// Hosted remote used for commit browser links in the Commits section.
+    /// Nil when the worktree has no recognized GitHub/GitLab fetch remote.
+    var commitRemote: CodeHostRemote? = nil
+    /// Hosted remote used for primary/ahead commit rows. This follows the
+    /// current branch's upstream remote, not the comparison/base remote.
+    var primaryCommitRemote: CodeHostRemote? = nil
+    /// True until the current branch is known to have no commits ahead of its
+    /// upstream. Used to avoid remote links for local-only primary commit rows.
+    var commitsNeedPush: Bool = true
+
     /// Live branch name, refreshed on each `refresh()`. The `worktree.branch`
     /// snapshot captured at construction goes stale after a `git checkout`
     /// inside the same worktree, so the chip predicates read this instead.
@@ -382,12 +392,14 @@ final class RightPaneState {
             )
             async let br = git.currentBranch(worktreePath: worktree.path)
             async let upstream = git.resolveUpstreamRef(worktreePath: worktree.path)
+            async let remotesProbe = git.remotes(worktreePath: worktree.path)
             async let mergeRefresh: Void = mergeOp.refresh()
             let entries = try await s
             let tree = try await git.fileTree(worktreePath: worktree.path, statusEntries: entries)
             let (commits, ref) = try await c
             let reviewLoopBaseResult = try? await reviewLoopBase
             let resolvedUpstream = try? await upstream
+            let remotes = (try? await remotesProbe) ?? []
             _ = await mergeRefresh
             let indexFingerprint: String
             if let lsResult = try? await Process.git(
@@ -419,6 +431,22 @@ final class RightPaneState {
             self.fileTree = tree
             self.commits = commits
             self.comparisonRef = ref
+            let preferredCommitRemoteRef = ref ?? baseBranch
+            self.commitRemote = CodeHostRemoteDetector.detect(
+                from: remotes,
+                preferredRemoteName: CodeHostRemoteDetector.preferredRemoteName(
+                    forBaseBranch: preferredCommitRemoteRef,
+                    remotes: remotes
+                )
+            )
+            if let upstreamRemoteName = resolvedUpstream?.remote {
+                self.primaryCommitRemote = CodeHostRemoteDetector.detectAll(
+                    from: remotes,
+                    preferredRemoteName: upstreamRemoteName
+                ).first { $0.remoteName == upstreamRemoteName }
+            } else {
+                self.primaryCommitRemote = nil
+            }
             self.currentBranch = currentBranch
             self.currentHeadSHA = headSHA
             if previousBranch != currentBranch || previousHeadSHA != headSHA {
@@ -479,6 +507,9 @@ final class RightPaneState {
         commits = []
         olderCommits = []
         comparisonRef = nil
+        commitRemote = nil
+        primaryCommitRemote = nil
+        commitsNeedPush = true
         sidebarError = nil
         pendingDiscard = nil
         changesGeneration += 1
@@ -498,6 +529,7 @@ final class RightPaneState {
         async let upstreamAheadProbe = git.upstreamAheadCommitCount(worktreePath: worktree.path)
         let needsPush = (try? await needsPushProbe) ?? true
         let upstreamAheadCommitCount = (try? await upstreamAheadProbe) ?? 0
+        self.commitsNeedPush = needsPush
         let local = ReviewLoopLocalState(
             branchName: currentBranch,
             headSHA: headSHA,
@@ -1111,6 +1143,19 @@ final class RightPaneState {
                 handleOperationResult(result)
             } catch {
                 logger.error("cherry-pick failed: \(error.localizedDescription, privacy: .public)")
+            }
+        }
+    }
+
+    @MainActor
+    func runRevert(sha: String) {
+        Task { @MainActor in
+            do {
+                let result = try await git.revert(worktreePath: worktree.path, sha: sha)
+                await refresh()
+                handleOperationResult(result)
+            } catch {
+                logger.error("revert failed: \(error.localizedDescription, privacy: .public)")
             }
         }
     }

--- a/AlasTests/CommitInfoTests.swift
+++ b/AlasTests/CommitInfoTests.swift
@@ -1,4 +1,5 @@
 import Testing
+import Foundation
 @testable import Alas
 
 struct CommitInfoTests {
@@ -84,6 +85,44 @@ struct CommitInfoTests {
         let (tag, stripped) = CommitInfo.parseConventional(subject: "polish: refine commit chips")
         #expect(tag == "polish")
         #expect(stripped == "refine commit chips")
+    }
+
+    @Test func fullMessageIncludesRawSubjectAndTrimmedBody() {
+        let commit = CommitInfo(
+            sha: "abcdef1234567890",
+            shortSha: "abcdef1",
+            author: "Test User",
+            authorInitials: "TU",
+            date: Date(timeIntervalSince1970: 0),
+            subject: "refine commit chips",
+            rawSubject: "polish: refine commit chips",
+            body: "\nMore context.\n\n",
+            conventionalTag: "polish",
+            filesChanged: 0,
+            insertions: 0,
+            deletions: 0
+        )
+
+        #expect(commit.fullMessage == "polish: refine commit chips\n\nMore context.")
+    }
+
+    @Test func fullMessageFallsBackToRawSubjectWhenBodyIsEmpty() {
+        let commit = CommitInfo(
+            sha: "abcdef1234567890",
+            shortSha: "abcdef1",
+            author: "Test User",
+            authorInitials: "TU",
+            date: Date(timeIntervalSince1970: 0),
+            subject: "refine commit chips",
+            rawSubject: "polish: refine commit chips",
+            body: " \n ",
+            conventionalTag: "polish",
+            filesChanged: 0,
+            insertions: 0,
+            deletions: 0
+        )
+
+        #expect(commit.fullMessage == "polish: refine commit chips")
     }
 
     @Test func initialsEmpty() {

--- a/AlasTests/GitServiceMergeTests.swift
+++ b/AlasTests/GitServiceMergeTests.swift
@@ -102,6 +102,31 @@ struct GitServiceMergeTests {
         #expect(sha.hasPrefix(featureSha.prefix(7)))
     }
 
+    @Test func mergeStateDetectsRevertInProgress() async throws {
+        let repo = try await Self.makeRepo()
+        defer { try? FileManager.default.removeItem(at: repo) }
+
+        try Self.writeFile(repo, "a.txt", "base\n")
+        _ = try await Process.git(["add", "a.txt"], cwd: repo)
+        _ = try await Process.git(["commit", "-q", "-m", "base"], cwd: repo)
+        try Self.writeFile(repo, "a.txt", "target\n")
+        _ = try await Process.git(["commit", "-q", "-am", "target change"], cwd: repo)
+        let targetSha = try await Process.git(["rev-parse", "HEAD"], cwd: repo).stdout
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        try Self.writeFile(repo, "a.txt", "current\n")
+        _ = try await Process.git(["commit", "-q", "-am", "current change"], cwd: repo)
+
+        _ = try await Process.git(["revert", "--no-edit", targetSha], cwd: repo)
+
+        let svc = GitService()
+        let state = try await svc.mergeState(worktreePath: repo)
+        guard case .revert(let sha, _) = state else {
+            Issue.record("expected .revert state, got \(String(describing: state))")
+            return
+        }
+        #expect(sha.hasPrefix(targetSha.prefix(7)))
+    }
+
     @Test func conflictedFileReadsAllThreeSides() async throws {
         let repo = try await Self.makeRepo()
         defer { try? FileManager.default.removeItem(at: repo) }

--- a/AlasTests/GitServiceTests.swift
+++ b/AlasTests/GitServiceTests.swift
@@ -128,6 +128,32 @@ struct GitServiceTests {
         #expect(branches.firstIndex(of: "develop")! < branches.firstIndex(of: "origin/main")!)
     }
 
+    @Test func revertCreatesCleanRevertCommit() async throws {
+        let repo = try await makeContextSnapshotRepo()
+        defer { try? FileManager.default.removeItem(at: repo) }
+
+        try writeText("before\n", "file.txt", in: repo)
+        try await gitOK(["add", "file.txt"], cwd: repo)
+        try await gitOK(["commit", "-q", "-m", "seed file"], cwd: repo)
+
+        try writeText("after\n", "file.txt", in: repo)
+        try await gitOK(["add", "file.txt"], cwd: repo)
+        try await gitOK(["commit", "-q", "-m", "change file"], cwd: repo)
+        let sha = try await gitOK(["rev-parse", "HEAD"], cwd: repo)
+            .stdout
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+
+        let result = try await GitService().revert(worktreePath: repo, sha: sha)
+
+        #expect(result == .clean)
+        let content = try String(contentsOf: repo.appendingPathComponent("file.txt"), encoding: .utf8)
+        #expect(content == "before\n")
+        let subject = try await gitOK(["log", "-1", "--pretty=%s"], cwd: repo)
+            .stdout
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        #expect(subject == #"Revert "change file""#)
+    }
+
     @Test func contextSnapshotSeparatesStagedAndUnstagedRefs() async throws {
         let repo = try await makeContextSnapshotRepo()
         defer { try? FileManager.default.removeItem(at: repo) }

--- a/AlasTests/Integrations/CodeHostRemoteDetectorTests.swift
+++ b/AlasTests/Integrations/CodeHostRemoteDetectorTests.swift
@@ -159,4 +159,30 @@ struct CodeHostRemoteDetectorTests {
 
         #expect(remote == nil)
     }
+
+    @Test func commitURLUsesGitHubCommitPath() {
+        let remote = CodeHostRemote(
+            kind: .github,
+            host: "github.com",
+            owner: "mrmans0n",
+            repository: "alas",
+            remoteName: "origin",
+            webURL: URL(string: "https://github.com/mrmans0n/alas")!
+        )
+
+        #expect(remote.commitURL(sha: "abcdef123") == URL(string: "https://github.com/mrmans0n/alas/commit/abcdef123"))
+    }
+
+    @Test func commitURLUsesGitLabCommitPath() {
+        let remote = CodeHostRemote(
+            kind: .gitlab,
+            host: "gitlab.example.com",
+            owner: "platform/mobile",
+            repository: "alas",
+            remoteName: "origin",
+            webURL: URL(string: "https://gitlab.example.com/platform/mobile/alas")!
+        )
+
+        #expect(remote.commitURL(sha: "abcdef123") == URL(string: "https://gitlab.example.com/platform/mobile/alas/-/commit/abcdef123"))
+    }
 }

--- a/AlasTests/RightPaneStateBaseBranchTests.swift
+++ b/AlasTests/RightPaneStateBaseBranchTests.swift
@@ -79,6 +79,54 @@ struct RightPaneStateBaseBranchTests {
         return (worktree, root)
     }
 
+    private func createTestRepoWithForkAndUpstream() async throws -> URL {
+        let tmp = FileManager.default.temporaryDirectory
+            .appendingPathComponent("alas-base-branch-fork-upstream-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: tmp, withIntermediateDirectories: true)
+        _ = try await Process.git(["init", "-q", "-b", "main"], cwd: tmp)
+        _ = try await Process.git(["config", "user.email", "t@e"], cwd: tmp)
+        _ = try await Process.git(["config", "user.name", "t"], cwd: tmp)
+        try "base\n".write(to: tmp.appendingPathComponent("a.txt"), atomically: true, encoding: .utf8)
+        _ = try await Process.git(["add", "."], cwd: tmp)
+        _ = try await Process.git(["commit", "-q", "-m", "base"], cwd: tmp)
+        _ = try await Process.git(["remote", "add", "origin", "https://github.com/nacho/alas.git"], cwd: tmp)
+        _ = try await Process.git(["remote", "add", "upstream", "https://github.com/mrmans0n/alas.git"], cwd: tmp)
+        let baseSha = try await Process.git(["rev-parse", "HEAD"], cwd: tmp)
+            .stdout.trimmingCharacters(in: .whitespacesAndNewlines)
+        _ = try await Process.git(["update-ref", "refs/remotes/origin/main", baseSha], cwd: tmp)
+        _ = try await Process.git(["update-ref", "refs/remotes/upstream/main", baseSha], cwd: tmp)
+        _ = try await Process.git(["checkout", "-q", "-b", "feature"], cwd: tmp)
+        _ = try await Process.git(["branch", "--set-upstream-to=upstream/main", "feature"], cwd: tmp)
+        try "feature\n".write(to: tmp.appendingPathComponent("a.txt"), atomically: true, encoding: .utf8)
+        _ = try await Process.git(["commit", "-q", "-am", "feature work"], cwd: tmp)
+        return tmp
+    }
+
+    private func createTestRepoWithUnsupportedTrackedRemote() async throws -> URL {
+        let tmp = FileManager.default.temporaryDirectory
+            .appendingPathComponent("alas-base-branch-unsupported-upstream-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: tmp, withIntermediateDirectories: true)
+        _ = try await Process.git(["init", "-q", "-b", "main"], cwd: tmp)
+        _ = try await Process.git(["config", "user.email", "t@e"], cwd: tmp)
+        _ = try await Process.git(["config", "user.name", "t"], cwd: tmp)
+        try "base\n".write(to: tmp.appendingPathComponent("a.txt"), atomically: true, encoding: .utf8)
+        _ = try await Process.git(["add", "."], cwd: tmp)
+        _ = try await Process.git(["commit", "-q", "-m", "base"], cwd: tmp)
+        _ = try await Process.git(["remote", "add", "origin", "https://github.com/nacho/alas.git"], cwd: tmp)
+        _ = try await Process.git(["remote", "add", "internal", "../internal.git"], cwd: tmp)
+        let baseSha = try await Process.git(["rev-parse", "HEAD"], cwd: tmp)
+            .stdout.trimmingCharacters(in: .whitespacesAndNewlines)
+        _ = try await Process.git(["update-ref", "refs/remotes/origin/main", baseSha], cwd: tmp)
+        _ = try await Process.git(["checkout", "-q", "-b", "feature"], cwd: tmp)
+        try "feature\n".write(to: tmp.appendingPathComponent("a.txt"), atomically: true, encoding: .utf8)
+        _ = try await Process.git(["commit", "-q", "-am", "feature work"], cwd: tmp)
+        let featureSha = try await Process.git(["rev-parse", "HEAD"], cwd: tmp)
+            .stdout.trimmingCharacters(in: .whitespacesAndNewlines)
+        _ = try await Process.git(["update-ref", "refs/remotes/internal/feature", featureSha], cwd: tmp)
+        _ = try await Process.git(["branch", "--set-upstream-to=internal/feature", "feature"], cwd: tmp)
+        return tmp
+    }
+
     private func waitUntil(_ condition: @escaping @MainActor () -> Bool) async throws {
         for _ in 0..<100 {
             if condition() { return }
@@ -157,6 +205,34 @@ struct RightPaneStateBaseBranchTests {
         await state.refresh()
 
         #expect(state.comparisonRef == "origin/feature")
+    }
+
+    @Test func refreshUsesComparisonRefRemoteForCommitLinks() async throws {
+        let repo = try await createTestRepoWithForkAndUpstream()
+        defer { try? FileManager.default.removeItem(at: repo) }
+        let wt = makeWorktree(at: repo, branch: "feature")
+        let state = RightPaneState(worktree: wt, baseBranch: "main")
+        state.trackUpstreamForCommits = true
+
+        await state.refresh()
+
+        #expect(state.comparisonRef == "upstream/main")
+        #expect(state.commitRemote?.remoteName == "upstream")
+        #expect(state.commitRemote?.repositorySlug == "mrmans0n/alas")
+    }
+
+    @Test func refreshDoesNotFallbackPrimaryCommitRemoteFromUnsupportedUpstream() async throws {
+        let repo = try await createTestRepoWithUnsupportedTrackedRemote()
+        defer { try? FileManager.default.removeItem(at: repo) }
+        let wt = makeWorktree(at: repo, branch: "feature")
+        let state = RightPaneState(worktree: wt, baseBranch: "main")
+
+        await state.refresh()
+
+        #expect(state.upstreamRef == "internal/feature")
+        #expect(!state.commitsNeedPush)
+        #expect(state.commitRemote?.remoteName == "origin")
+        #expect(state.primaryCommitRemote == nil)
     }
 
     @Test func storeRefreshesWhenConfigMatchesClearedOverride() async throws {


### PR DESCRIPTION
## Summary
- add commit row context menu actions for copying the full commit message, opening commits on a supported remote, and reverting commits behind confirmation
- add `GitService.revert` and `REVERT_HEAD` operation handling so revert conflicts flow through the existing operation card
- preserve raw commit subject/body in commit list models and add GitHub/GitLab commit URL helpers

Closes #588.

## Validation
- `rtk git diff --check`

## Notes
- Local Xcode verification could not complete in this environment. A fresh GhosttyKit build failed because the Metal toolchain component is missing, and later Xcode build/test invocations became silent for several minutes and were interrupted after restoring a cached framework.