### PR TITLE
feat(markdown): Render inline markdown badges

### DIFF
--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -576,6 +576,7 @@
 		8824EFBA6EA3673F13244C6D /* MergeSingleResolvePromptEditorWindow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 749E3289E4C70DA7E4DD80E6 /* MergeSingleResolvePromptEditorWindow.swift */; };
 		884F7EB87029E537B923191E /* DefinitionPicker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 781B8F6F0A3085FEBFC615C2 /* DefinitionPicker.swift */; };
 		88A139C7B3C3C9F20EF5945A /* ACPChangeNotifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = 419EF533C4D29448483045DA /* ACPChangeNotifier.swift */; };
+		88C1A4EBC12F7F7BA7FE9B06 /* ACPMarkdownInlineTextView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84A01D6512394EF1C41782AD /* ACPMarkdownInlineTextView.swift */; };
 		8915EF49F1031BD55C419625 /* GeminiInstallerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F1CBD7C9E0119EC1656C1E2 /* GeminiInstallerTests.swift */; };
 		8927B4E929B4180F5B8984F1 /* ACPTranscript.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0B0317FF3C6E6D3F149FB4F5 /* ACPTranscript.swift */; };
 		8950201500394191D7D981D2 /* MarkdownRenderer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8EF52FE71B7FB41328859734 /* MarkdownRenderer.swift */; };
@@ -1666,6 +1667,7 @@
 		82F696636690652C48CE87D9 /* AlasGhostty.Config.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlasGhostty.Config.swift; sourceTree = "<group>"; };
 		835D847AD52A2CEB36DD5022 /* LegacyHookSweepTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LegacyHookSweepTests.swift; sourceTree = "<group>"; };
 		83A8622BA130E8FA339EDCEB /* TabsManagerReviewRequestDraftTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabsManagerReviewRequestDraftTests.swift; sourceTree = "<group>"; };
+		84A01D6512394EF1C41782AD /* ACPMarkdownInlineTextView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPMarkdownInlineTextView.swift; sourceTree = "<group>"; };
 		84E56989C04A4A478D68084C /* ACPMarkdownBlockCacheTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPMarkdownBlockCacheTests.swift; sourceTree = "<group>"; };
 		8526C9DB63760BDD2CE998BD /* fs-write.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "fs-write.json"; sourceTree = "<group>"; };
 		8528D2A61E1FC9F51296C9F6 /* ACPLaunchSpec.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPLaunchSpec.swift; sourceTree = "<group>"; };
@@ -3322,6 +3324,7 @@
 				A5E1462C85D0E49127BCED81 /* ACPImageThumbnail.swift */,
 				70255847CE81CE85E0117A85 /* ACPMarkdownBlockCache.swift */,
 				DC3814D8B30EBB9991F3388A /* ACPMarkdownInlineRenderer.swift */,
+				84A01D6512394EF1C41782AD /* ACPMarkdownInlineTextView.swift */,
 				2AE565966DD010FDFD7DFF50 /* ACPMarkdownLiveStyler.swift */,
 				DE2AC16E9220C05F670BE3EB /* ACPMarkdownText.swift */,
 				329882D757C34246C9848C3A /* ACPMentionChipAttachment.swift */,
@@ -4436,6 +4439,7 @@
 				542C76AF3A21CBD6B2838CEE /* ACPLaunchSpec.swift in Sources */,
 				B1665774383C03F0C0765A43 /* ACPMarkdownBlockCache.swift in Sources */,
 				7ABF2BE84D6677FE5BCC8ED1 /* ACPMarkdownInlineRenderer.swift in Sources */,
+				88C1A4EBC12F7F7BA7FE9B06 /* ACPMarkdownInlineTextView.swift in Sources */,
 				6AE129E340CA74CC26B34B66 /* ACPMarkdownLiveStyler.swift in Sources */,
 				E6F317EB2FF5522C77B30B62 /* ACPMarkdownText.swift in Sources */,
 				CC64E79B9CF4AF1B3CE31261 /* ACPMentionChipAttachment.swift in Sources */,

--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -511,6 +511,7 @@
 		7A0D3E122F34EF1A2A04984F /* EnvBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 159FE807399835B0821E1CAB /* EnvBuilder.swift */; };
 		7A2C912B677A34391361B720 /* AdvancedSettingsVisibility.swift in Sources */ = {isa = PBXBuildFile; fileRef = 94B123596E047E4CE0FAFE3E /* AdvancedSettingsVisibility.swift */; };
 		7A816022DD913BC76F5EBA7F /* InstallNudgeResolverTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 134EE8D2BC31085A504D27D8 /* InstallNudgeResolverTests.swift */; };
+		7ABF2BE84D6677FE5BCC8ED1 /* ACPMarkdownInlineRenderer.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC3814D8B30EBB9991F3388A /* ACPMarkdownInlineRenderer.swift */; };
 		7ACFA19EA43966431D906F55 /* TreeSitterPHP in Frameworks */ = {isa = PBXBuildFile; productRef = 78020033FC689A2BCDF51DED /* TreeSitterPHP */; };
 		7B25B1405BFDE5570B267213 /* NumstatParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = C6CA79B71B4AA72697392702 /* NumstatParser.swift */; };
 		7B309C87C042B3A18AB31D0F /* SearchModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = D49B5B544A3432F8D8105268 /* SearchModel.swift */; };
@@ -808,6 +809,7 @@
 		BC98C2BCDB4F6C88C66117A6 /* InlineErrorStrip.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7206BC51596AE2A57D8B28B /* InlineErrorStrip.swift */; };
 		BD1CDAECF2D1928C95796F63 /* ACPSessionStoreQueueTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03D901BF4399752A3FC658F8 /* ACPSessionStoreQueueTests.swift */; };
 		BD8E82E61D1E23931FE69C1D /* SidebarVisibilityTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 98A00D845A8B82E27B7D2352 /* SidebarVisibilityTests.swift */; };
+		BDA40E9BFA15217CDED5B2F0 /* ACPMarkdownInlineRendererTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50F0FBAC37A6C6A46C8D426E /* ACPMarkdownInlineRendererTests.swift */; };
 		BDBAA6601CA3FD8A5562E637 /* AppStateFocusMainWorktreeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11DB4509E8835E63F9532E43 /* AppStateFocusMainWorktreeTests.swift */; };
 		BDEA5736B570C77CF4C965F5 /* DiffInlineAnnotationCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1503D1CB549B39E499EFAB8 /* DiffInlineAnnotationCard.swift */; };
 		BE4E46595AF10611CE0B1C6B /* TabActivityPulse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8CFED7F76987C01213CB68A9 /* TabActivityPulse.swift */; };
@@ -1460,6 +1462,7 @@
 		500B60003934104E2CA5A895 /* ReviewTabView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReviewTabView.swift; sourceTree = "<group>"; };
 		50737099AA490FAC6BD9F612 /* TextEditCoordinatesTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TextEditCoordinatesTests.swift; sourceTree = "<group>"; };
 		50B0831638833C386E5CC9E8 /* CompletionEngine.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CompletionEngine.swift; sourceTree = "<group>"; };
+		50F0FBAC37A6C6A46C8D426E /* ACPMarkdownInlineRendererTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPMarkdownInlineRendererTests.swift; sourceTree = "<group>"; };
 		515B67124EA11DDCC29B6E36 /* SettingsNavView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsNavView.swift; sourceTree = "<group>"; };
 		519CFB3707E8DDBDECD6C5D1 /* Alas.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Alas.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		51B868809675C4110044C92E /* SpacesManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpacesManager.swift; sourceTree = "<group>"; };
@@ -2024,6 +2027,7 @@
 		DBA6A9F78C8E8CDF6D170BDD /* StatusParserTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StatusParserTests.swift; sourceTree = "<group>"; };
 		DC3328C0EF905A8AC6F6F34D /* MarkdownViewModeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MarkdownViewModeTests.swift; sourceTree = "<group>"; };
 		DC3692D5EB4BCA66AB702D43 /* ACPAgentProfiles.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPAgentProfiles.swift; sourceTree = "<group>"; };
+		DC3814D8B30EBB9991F3388A /* ACPMarkdownInlineRenderer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPMarkdownInlineRenderer.swift; sourceTree = "<group>"; };
 		DC73B8AC6AC57FB3A3253F40 /* ReviewScopeSelectionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReviewScopeSelectionTests.swift; sourceTree = "<group>"; };
 		DC76F9150CC29A324D785C29 /* ACPDelayedHoverVisibilityTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPDelayedHoverVisibilityTests.swift; sourceTree = "<group>"; };
 		DCD333CD0765908F6657E824 /* WorktreePathTemplateRenderer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorktreePathTemplateRenderer.swift; sourceTree = "<group>"; };
@@ -3029,6 +3033,7 @@
 				FDE53456308778DF77B18AF4 /* ACPImageEncodingTests.swift */,
 				A53358B7D4D68BE2471187D4 /* ACPImageStagingTests.swift */,
 				84E56989C04A4A478D68084C /* ACPMarkdownBlockCacheTests.swift */,
+				50F0FBAC37A6C6A46C8D426E /* ACPMarkdownInlineRendererTests.swift */,
 				7F4B57FBB6E595E5DF1C6F93 /* ACPMarkdownLiveStylerImageChipTests.swift */,
 				8718406234B8C879B9D0CAB1 /* ACPMarkdownTextBareURLTests.swift */,
 				E941397D0207F68135B3464D /* ACPMentionPickerTests.swift */,
@@ -3316,6 +3321,7 @@
 				98796FD86FE05979A2BCBCF3 /* ACPImageStaging.swift */,
 				A5E1462C85D0E49127BCED81 /* ACPImageThumbnail.swift */,
 				70255847CE81CE85E0117A85 /* ACPMarkdownBlockCache.swift */,
+				DC3814D8B30EBB9991F3388A /* ACPMarkdownInlineRenderer.swift */,
 				2AE565966DD010FDFD7DFF50 /* ACPMarkdownLiveStyler.swift */,
 				DE2AC16E9220C05F670BE3EB /* ACPMarkdownText.swift */,
 				329882D757C34246C9848C3A /* ACPMentionChipAttachment.swift */,
@@ -4429,6 +4435,7 @@
 				5789FC76BEC6965E56C2DF3C /* ACPLaunchPathResolver.swift in Sources */,
 				542C76AF3A21CBD6B2838CEE /* ACPLaunchSpec.swift in Sources */,
 				B1665774383C03F0C0765A43 /* ACPMarkdownBlockCache.swift in Sources */,
+				7ABF2BE84D6677FE5BCC8ED1 /* ACPMarkdownInlineRenderer.swift in Sources */,
 				6AE129E340CA74CC26B34B66 /* ACPMarkdownLiveStyler.swift in Sources */,
 				E6F317EB2FF5522C77B30B62 /* ACPMarkdownText.swift in Sources */,
 				CC64E79B9CF4AF1B3CE31261 /* ACPMentionChipAttachment.swift in Sources */,
@@ -5010,6 +5017,7 @@
 				7433DB9396574A02DBF9953D /* ACPLaunchSpecTests.swift in Sources */,
 				965621529CB4BD82DD646B76 /* ACPManagerAccessorsTests.swift in Sources */,
 				21A94ADFA16F85C7ACAB4DA1 /* ACPMarkdownBlockCacheTests.swift in Sources */,
+				BDA40E9BFA15217CDED5B2F0 /* ACPMarkdownInlineRendererTests.swift in Sources */,
 				6E0481CC3B5D8676A6E8BE69 /* ACPMarkdownLiveStylerImageChipTests.swift in Sources */,
 				162363BDA6BC54B372C77B91 /* ACPMarkdownTextBareURLTests.swift in Sources */,
 				26F83C65E75B5F44024FEF1F /* ACPMentionPickerTests.swift in Sources */,

--- a/Alas/Sources/ACP/UI/ACPMarkdownInlineRenderer.swift
+++ b/Alas/Sources/ACP/UI/ACPMarkdownInlineRenderer.swift
@@ -369,8 +369,12 @@ enum ACPMarkdownInlineRenderer {
                 }
 
                 if !isSubscript,
-                   source[index...].hasPrefix("<sub>"),
-                   let closeRange = source.range(of: "</sub>", range: source.index(index, offsetBy: 5)..<source.endIndex) {
+                   hasSubscriptOpenTag(in: source, at: index),
+                   let closeRange = source.range(
+                       of: "</sub>",
+                       options: [.caseInsensitive],
+                       range: source.index(index, offsetBy: 5)..<source.endIndex
+                   ) {
                     let marker = makeSubscriptMarker()
                     output += marker.start
                     output += render(String(source[source.index(index, offsetBy: 5)..<closeRange.lowerBound]), isSubscript: true)
@@ -397,6 +401,13 @@ enum ACPMarkdownInlineRenderer {
                 index = source.index(after: index)
             }
             return output
+        }
+
+        private func hasSubscriptOpenTag(in source: String, at index: String.Index) -> Bool {
+            guard let end = source.index(index, offsetBy: 5, limitedBy: source.endIndex) else {
+                return false
+            }
+            return source[index..<end].caseInsensitiveCompare("<sub>") == .orderedSame
         }
 
         mutating private func makeImagePlaceholder() -> String {

--- a/Alas/Sources/ACP/UI/ACPMarkdownInlineRenderer.swift
+++ b/Alas/Sources/ACP/UI/ACPMarkdownInlineRenderer.swift
@@ -109,6 +109,23 @@ enum ACPMarkdownInlineRenderer {
         return attachment
     }
 
+    static func loadedImageString(
+        for image: NSImage,
+        isSubscript: Bool,
+        attributes: [NSAttributedString.Key: Any]
+    ) -> NSAttributedString {
+        let attributed = NSMutableAttributedString(
+            attributedString: NSAttributedString(
+                attachment: loadedImageAttachment(for: image, isSubscript: isSubscript)
+            )
+        )
+        var inheritedAttributes = attributes
+        inheritedAttributes.removeValue(forKey: .attachment)
+        inheritedAttributes.removeValue(forKey: .acpMarkdownInlineRemoteImage)
+        attributed.addAttributes(inheritedAttributes, range: NSRange(location: 0, length: attributed.length))
+        return attributed
+    }
+
     private static func removingSubscriptMarkers(
         from source: String,
         markers: [ACPMarkdownSubscriptMarker]

--- a/Alas/Sources/ACP/UI/ACPMarkdownInlineRenderer.swift
+++ b/Alas/Sources/ACP/UI/ACPMarkdownInlineRenderer.swift
@@ -1,0 +1,328 @@
+import AppKit
+import Foundation
+import SwiftUI
+
+struct ACPMarkdownInlineRenderPlan: Equatable {
+    let markdownSource: String
+    let images: [ACPMarkdownInlineImage]
+    let subscriptMarkers: [ACPMarkdownSubscriptMarker]
+}
+
+struct ACPMarkdownInlineImage: Equatable {
+    let placeholder: String
+    let alt: String
+    let source: String
+    let isSubscript: Bool
+}
+
+struct ACPMarkdownSubscriptMarker: Equatable {
+    let start: String
+    let end: String
+}
+
+enum ACPMarkdownInlineRole: Equatable {
+    case body
+    case heading(level: Int)
+    case quote
+    case tableCell(isHeader: Bool)
+}
+
+@MainActor
+enum ACPMarkdownInlineRenderer {
+    static let badgeMaxSize = CGSize(width: 120, height: 18)
+    static let normalImageMaxSize = CGSize(width: 240, height: 80)
+
+    private static let privateUsePrefix = "\u{E000}"
+    private static let privateUseSuffix = "\u{E001}"
+
+    static func makePlan(_ source: String) -> ACPMarkdownInlineRenderPlan {
+        var builder = PlanBuilder()
+        let markdownSource = builder.render(source, isSubscript: false)
+        return ACPMarkdownInlineRenderPlan(
+            markdownSource: markdownSource,
+            images: builder.images,
+            subscriptMarkers: builder.subscriptMarkers
+        )
+    }
+
+    static func plainText(_ source: String) -> String {
+        let plan = makePlan(source)
+        var text = plan.markdownSource
+        for image in plan.images {
+            text = text.replacingOccurrences(of: image.placeholder, with: image.alt)
+        }
+        text = removingSubscriptMarkers(from: text, markers: plan.subscriptMarkers)
+        return NSAttributedString(ACPMarkdownText.inlineMarkdown(text)).string
+    }
+
+    static func makeAttributedString(
+        source: String,
+        theme: Theme,
+        typography: ACPChatTypography,
+        role: ACPMarkdownInlineRole
+    ) -> NSMutableAttributedString {
+        let plan = makePlan(source)
+        let attributed = NSMutableAttributedString(ACPMarkdownText.inlineMarkdown(plan.markdownSource))
+        applyBaseAttributes(to: attributed, theme: theme, typography: typography, role: role)
+        applySubscriptRanges(to: attributed, markers: plan.subscriptMarkers, typography: typography, role: role)
+        replaceImages(in: attributed, images: plan.images)
+        return attributed
+    }
+
+    private static func removingSubscriptMarkers(
+        from source: String,
+        markers: [ACPMarkdownSubscriptMarker]
+    ) -> String {
+        var text = source
+        for marker in markers {
+            text = text.replacingOccurrences(of: marker.start, with: "")
+            text = text.replacingOccurrences(of: marker.end, with: "")
+        }
+        return text
+    }
+
+    private static func applyBaseAttributes(
+        to attributed: NSMutableAttributedString,
+        theme: Theme,
+        typography: ACPChatTypography,
+        role: ACPMarkdownInlineRole
+    ) {
+        guard attributed.length > 0 else { return }
+        let fullRange = NSRange(location: 0, length: attributed.length)
+        attributed.addAttribute(.foregroundColor, value: foregroundColor(theme: theme, role: role), range: fullRange)
+        attributed.enumerateAttributes(in: fullRange) { attributes, range, _ in
+            let font = font(for: attributes, typography: typography, size: fontSize(typography: typography, role: role), role: role)
+            attributed.addAttribute(.font, value: font, range: range)
+        }
+    }
+
+    private static func applySubscriptRanges(
+        to attributed: NSMutableAttributedString,
+        markers: [ACPMarkdownSubscriptMarker],
+        typography: ACPChatTypography,
+        role: ACPMarkdownInlineRole
+    ) {
+        for marker in markers.reversed() {
+            let nsString = attributed.string as NSString
+            let startRange = nsString.range(of: marker.start)
+            let endRange = nsString.range(of: marker.end)
+            guard startRange.location != NSNotFound,
+                  endRange.location != NSNotFound,
+                  startRange.location < endRange.location
+            else { continue }
+
+            attributed.deleteCharacters(in: endRange)
+            attributed.deleteCharacters(in: startRange)
+
+            let contentLocation = startRange.location
+            let contentLength = endRange.location - startRange.location - startRange.length
+            guard contentLength > 0 else { continue }
+            let contentRange = NSRange(location: contentLocation, length: contentLength)
+            let subscriptSize = max(7, fontSize(typography: typography, role: role) * 0.82)
+
+            attributed.enumerateAttributes(in: contentRange) { attributes, range, _ in
+                let font = font(for: attributes, typography: typography, size: subscriptSize, role: role)
+                attributed.addAttribute(.font, value: font, range: range)
+            }
+            attributed.addAttribute(.baselineOffset, value: -max(1, subscriptSize * 0.22), range: contentRange)
+        }
+    }
+
+    private static func replaceImages(
+        in attributed: NSMutableAttributedString,
+        images: [ACPMarkdownInlineImage]
+    ) {
+        for image in images {
+            let range = (attributed.string as NSString).range(of: image.placeholder)
+            guard range.location != NSNotFound else { continue }
+            attributed.replaceCharacters(in: range, with: NSAttributedString(attachment: attachment(for: image)))
+        }
+    }
+
+    private static func attachment(for image: ACPMarkdownInlineImage) -> NSTextAttachment {
+        let attachment = NSTextAttachment()
+        let maxSize = image.isSubscript ? badgeMaxSize : normalImageMaxSize
+        attachment.bounds = NSRect(x: 0, y: -2, width: maxSize.width, height: maxSize.height)
+        return attachment
+    }
+
+    private static func fontSize(typography: ACPChatTypography, role: ACPMarkdownInlineRole) -> CGFloat {
+        switch role {
+        case .body:
+            return typography.paragraphSize
+        case .heading(let level):
+            return typography.headingSize(level: level)
+        case .quote:
+            return typography.quoteSize
+        case .tableCell(let isHeader):
+            return isHeader ? typography.tableHeaderSize : typography.tableBodySize
+        }
+    }
+
+    private static func foregroundColor(theme: Theme, role: ACPMarkdownInlineRole) -> NSColor {
+        switch role {
+        case .quote:
+            return NSColor(theme.color("fg-muted"))
+        case .tableCell(let isHeader):
+            return NSColor(theme.color(isHeader ? "fg-muted" : "fg"))
+        case .body, .heading:
+            return NSColor(theme.color("fg"))
+        }
+    }
+
+    private static func font(
+        for attributes: [NSAttributedString.Key: Any],
+        typography: ACPChatTypography,
+        size: CGFloat,
+        role: ACPMarkdownInlineRole
+    ) -> NSFont {
+        let traits = fontTraits(from: attributes, fallbackRole: role)
+        if isInlineCode(attributes) {
+            return codeFont(size: max(8, size - 1), traits: traits)
+        }
+        return typography.appKitFont(size: size, traits: traits)
+    }
+
+    private static func codeFont(size: CGFloat, traits: NSFontTraitMask) -> NSFont {
+        var font = NSFont.monospacedSystemFont(
+            ofSize: size,
+            weight: traits.contains(.boldFontMask) ? .bold : .regular
+        )
+        if traits.contains(.italicFontMask) {
+            font = NSFontManager.shared.convert(font, toHaveTrait: .italicFontMask)
+        }
+        return font
+    }
+
+    private static func fontTraits(
+        from attributes: [NSAttributedString.Key: Any],
+        fallbackRole role: ACPMarkdownInlineRole
+    ) -> NSFontTraitMask {
+        var traits: NSFontTraitMask = []
+        let font = attributes[.font] as? NSFont
+        if font?.fontDescriptor.symbolicTraits.contains(.bold) == true {
+            traits.insert(.boldFontMask)
+        }
+        if font?.fontDescriptor.symbolicTraits.contains(.italic) == true {
+            traits.insert(.italicFontMask)
+        }
+        if let intent = attributes[NSAttributedString.Key("NSInlinePresentationIntent")] as? Int {
+            if intent & 2 != 0 {
+                traits.insert(.boldFontMask)
+            }
+            if intent & 1 != 0 {
+                traits.insert(.italicFontMask)
+            }
+        }
+        switch role {
+        case .heading:
+            traits.insert(.boldFontMask)
+        case .quote:
+            traits.insert(.italicFontMask)
+        case .tableCell(let isHeader) where isHeader:
+            traits.insert(.boldFontMask)
+        case .body, .tableCell:
+            break
+        }
+        return traits
+    }
+
+    private static func isInlineCode(_ attributes: [NSAttributedString.Key: Any]) -> Bool {
+        guard let intent = attributes[NSAttributedString.Key("NSInlinePresentationIntent")] as? Int else {
+            return false
+        }
+        return intent & 4 != 0
+    }
+
+    private struct PlanBuilder {
+        var images: [ACPMarkdownInlineImage] = []
+        var subscriptMarkers: [ACPMarkdownSubscriptMarker] = []
+
+        mutating func render(_ source: String, isSubscript: Bool) -> String {
+            var output = ""
+            var index = source.startIndex
+            while index < source.endIndex {
+                if let codeEnd = inlineCodeEnd(in: source, at: index) {
+                    output.append(contentsOf: source[index...codeEnd])
+                    index = source.index(after: codeEnd)
+                    continue
+                }
+
+                if !isSubscript,
+                   source[index...].hasPrefix("<sub>"),
+                   let closeRange = source.range(of: "</sub>", range: source.index(index, offsetBy: 5)..<source.endIndex) {
+                    let marker = makeSubscriptMarker()
+                    output += marker.start
+                    output += render(String(source[source.index(index, offsetBy: 5)..<closeRange.lowerBound]), isSubscript: true)
+                    output += marker.end
+                    subscriptMarkers.append(marker)
+                    index = closeRange.upperBound
+                    continue
+                }
+
+                if let match = imageMatch(in: source, at: index) {
+                    let placeholder = makeImagePlaceholder()
+                    images.append(ACPMarkdownInlineImage(
+                        placeholder: placeholder,
+                        alt: match.alt,
+                        source: match.source,
+                        isSubscript: isSubscript
+                    ))
+                    output += placeholder
+                    index = match.end
+                    continue
+                }
+
+                output.append(source[index])
+                index = source.index(after: index)
+            }
+            return output
+        }
+
+        mutating private func makeImagePlaceholder() -> String {
+            "\(privateUsePrefix)ACPIMG\(images.count)\(privateUseSuffix)"
+        }
+
+        mutating private func makeSubscriptMarker() -> ACPMarkdownSubscriptMarker {
+            let id = subscriptMarkers.count
+            return ACPMarkdownSubscriptMarker(
+                start: "\(privateUsePrefix)ACPSUB\(id)S\(privateUseSuffix)",
+                end: "\(privateUsePrefix)ACPSUB\(id)E\(privateUseSuffix)"
+            )
+        }
+
+        private func inlineCodeEnd(in source: String, at index: String.Index) -> String.Index? {
+            guard source[index] == "`" else { return nil }
+            let tickCount = source[index...].prefix(while: { $0 == "`" }).count
+            var search = source.index(index, offsetBy: tickCount)
+            while search < source.endIndex {
+                guard source[search] == "`" else {
+                    search = source.index(after: search)
+                    continue
+                }
+                let closeCount = source[search...].prefix(while: { $0 == "`" }).count
+                if closeCount == tickCount {
+                    return source.index(search, offsetBy: tickCount - 1)
+                }
+                search = source.index(search, offsetBy: closeCount)
+            }
+            return nil
+        }
+
+        private func imageMatch(in source: String, at index: String.Index) -> (alt: String, source: String, end: String.Index)? {
+            guard source[index...].hasPrefix("![") else { return nil }
+            let altStart = source.index(index, offsetBy: 2)
+            guard let altEnd = source[altStart...].firstIndex(of: "]"),
+                  source.index(after: altEnd) < source.endIndex,
+                  source[source.index(after: altEnd)] == "("
+            else { return nil }
+            let sourceStart = source.index(altEnd, offsetBy: 2)
+            guard let sourceEnd = source[sourceStart...].firstIndex(of: ")") else { return nil }
+            return (
+                alt: String(source[altStart..<altEnd]),
+                source: String(source[sourceStart..<sourceEnd]),
+                end: source.index(after: sourceEnd)
+            )
+        }
+    }
+}

--- a/Alas/Sources/ACP/UI/ACPMarkdownInlineRenderer.swift
+++ b/Alas/Sources/ACP/UI/ACPMarkdownInlineRenderer.swift
@@ -15,6 +15,17 @@ struct ACPMarkdownInlineImage: Equatable {
     let isSubscript: Bool
 }
 
+enum ACPMarkdownInlineImageSourceKind: Equatable {
+    case remote
+    case local
+    case invalid
+}
+
+struct ACPMarkdownInlineRemoteImage: Equatable {
+    let image: ACPMarkdownInlineImage
+    let url: URL
+}
+
 struct ACPMarkdownSubscriptMarker: Equatable {
     let start: String
     let end: String
@@ -34,6 +45,17 @@ enum ACPMarkdownInlineRenderer {
 
     private static let privateUsePrefix = "\u{E000}"
     private static let privateUseSuffix = "\u{E001}"
+
+    static func imageSourceKind(_ source: String) -> ACPMarkdownInlineImageSourceKind {
+        switch MarkdownImageLoader.classify(source) {
+        case .remote:
+            return .remote
+        case .local:
+            return .local
+        case .invalid:
+            return .invalid
+        }
+    }
 
     static func displaySize(original: CGSize, isSubscript: Bool) -> CGSize {
         let cap = isSubscript ? badgeMaxSize : normalImageMaxSize
@@ -75,8 +97,16 @@ enum ACPMarkdownInlineRenderer {
         let attributed = NSMutableAttributedString(ACPMarkdownText.inlineMarkdown(plan.markdownSource))
         applyBaseAttributes(to: attributed, theme: theme, typography: typography, role: role)
         applySubscriptRanges(to: attributed, markers: plan.subscriptMarkers, typography: typography, role: role)
-        replaceImages(in: attributed, images: plan.images)
+        replaceImages(in: attributed, images: plan.images, theme: theme)
         return attributed
+    }
+
+    static func loadedImageAttachment(for image: NSImage, isSubscript: Bool) -> NSTextAttachment {
+        let displaySize = displaySize(original: image.size, isSubscript: isSubscript)
+        let attachment = NSTextAttachment()
+        attachment.image = resizedImage(image, to: displaySize)
+        attachment.bounds = NSRect(x: 0, y: -2, width: displaySize.width, height: displaySize.height)
+        return attachment
     }
 
     private static func removingSubscriptMarkers(
@@ -140,12 +170,27 @@ enum ACPMarkdownInlineRenderer {
 
     private static func replaceImages(
         in attributed: NSMutableAttributedString,
-        images: [ACPMarkdownInlineImage]
+        images: [ACPMarkdownInlineImage],
+        theme: Theme
     ) {
         for image in images {
             let range = (attributed.string as NSString).range(of: image.placeholder)
             guard range.location != NSNotFound else { continue }
-            attributed.replaceCharacters(in: range, with: NSAttributedString(attachment: attachment(for: image)))
+            let inheritedAttributes = range.location < attributed.length
+                ? attributed.attributes(at: range.location, effectiveRange: nil)
+                : [:]
+            let fallbackAttributes = mutedAttributes(from: inheritedAttributes, theme: theme)
+            let replacement: NSAttributedString
+            switch MarkdownImageLoader.classify(image.source) {
+            case .remote(let url):
+                replacement = remotePlaceholderString(
+                    for: ACPMarkdownInlineRemoteImage(image: image, url: url),
+                    attributes: fallbackAttributes
+                )
+            case .local, .invalid:
+                replacement = mutedAltString(for: image, attributes: fallbackAttributes)
+            }
+            attributed.replaceCharacters(in: range, with: replacement)
         }
     }
 
@@ -154,6 +199,54 @@ enum ACPMarkdownInlineRenderer {
         let maxSize = image.isSubscript ? badgeMaxSize : normalImageMaxSize
         attachment.bounds = NSRect(x: 0, y: -2, width: maxSize.width, height: maxSize.height)
         return attachment
+    }
+
+    private static func remotePlaceholderString(
+        for remoteImage: ACPMarkdownInlineRemoteImage,
+        attributes: [NSAttributedString.Key: Any]
+    ) -> NSAttributedString {
+        let attributed = NSMutableAttributedString(
+            attributedString: NSAttributedString(attachment: attachment(for: remoteImage.image))
+        )
+        let range = NSRange(location: 0, length: attributed.length)
+        attributed.addAttributes(attributes, range: range)
+        attributed.addAttribute(.acpMarkdownInlineRemoteImage, value: remoteImage, range: range)
+        return attributed
+    }
+
+    static func mutedAltString(
+        for image: ACPMarkdownInlineImage,
+        attributes: [NSAttributedString.Key: Any]
+    ) -> NSAttributedString {
+        guard !image.alt.isEmpty else { return NSAttributedString() }
+        var attributes = attributes
+        attributes.removeValue(forKey: .attachment)
+        attributes.removeValue(forKey: .acpMarkdownInlineRemoteImage)
+        return NSAttributedString(string: image.alt, attributes: attributes)
+    }
+
+    private static func mutedAttributes(
+        from attributes: [NSAttributedString.Key: Any],
+        theme: Theme
+    ) -> [NSAttributedString.Key: Any] {
+        var result = attributes
+        result[.foregroundColor] = NSColor(theme.color("fg-muted"))
+        result.removeValue(forKey: .attachment)
+        result.removeValue(forKey: .acpMarkdownInlineRemoteImage)
+        return result
+    }
+
+    private static func resizedImage(_ image: NSImage, to size: CGSize) -> NSImage {
+        let resized = NSImage(size: size)
+        resized.lockFocus()
+        image.draw(
+            in: NSRect(origin: .zero, size: size),
+            from: NSRect(origin: .zero, size: image.size),
+            operation: .copy,
+            fraction: 1
+        )
+        resized.unlockFocus()
+        return resized
     }
 
     private static func fontSize(typography: ACPChatTypography, role: ACPMarkdownInlineRole) -> CGFloat {

--- a/Alas/Sources/ACP/UI/ACPMarkdownInlineRenderer.swift
+++ b/Alas/Sources/ACP/UI/ACPMarkdownInlineRenderer.swift
@@ -35,6 +35,16 @@ enum ACPMarkdownInlineRenderer {
     private static let privateUsePrefix = "\u{E000}"
     private static let privateUseSuffix = "\u{E001}"
 
+    static func displaySize(original: CGSize, isSubscript: Bool) -> CGSize {
+        let cap = isSubscript ? badgeMaxSize : normalImageMaxSize
+        guard original.width > 0, original.height > 0 else { return cap }
+        let scale = min(cap.width / original.width, cap.height / original.height, 1)
+        return CGSize(
+            width: max(1, floor(original.width * scale)),
+            height: max(1, floor(original.height * scale))
+        )
+    }
+
     static func makePlan(_ source: String) -> ACPMarkdownInlineRenderPlan {
         var builder = PlanBuilder()
         let markdownSource = builder.render(source, isSubscript: false)

--- a/Alas/Sources/ACP/UI/ACPMarkdownInlineTextView.swift
+++ b/Alas/Sources/ACP/UI/ACPMarkdownInlineTextView.swift
@@ -50,14 +50,124 @@ struct ACPMarkdownInlineTextView: NSViewRepresentable {
     final class Coordinator {
         private let imageLoader = MarkdownImageLoader()
         private var generation = 0
+        private var inFlightImageURLs: Set<URL> = []
+        private var currentRemoteImageTargets: [URL: RemoteImageRenderTargets] = [:]
 
         func loadRemoteImages(in textView: NSTextView, attributedString: NSAttributedString) {
             generation += 1
-            _ = imageLoader
-            _ = textView
-            _ = attributedString
+            let renderGeneration = generation
+            let fullRange = NSRange(location: 0, length: attributedString.length)
+            var collectedTargets: [URL: [RemoteImageTarget]] = [:]
+
+            attributedString.enumerateAttribute(.acpMarkdownInlineRemoteImage, in: fullRange) { value, range, _ in
+                guard let remoteImage = value as? ACPMarkdownInlineRemoteImage else { return }
+                let fallbackAttributes = attributedString.attributes(at: range.location, effectiveRange: nil)
+                let target = RemoteImageTarget(remoteImage: remoteImage, fallbackAttributes: fallbackAttributes)
+                collectedTargets[remoteImage.url, default: []].append(target)
+            }
+
+            currentRemoteImageTargets = collectedTargets.mapValues {
+                RemoteImageRenderTargets(generation: renderGeneration, targets: $0)
+            }
+
+            for url in collectedTargets.keys {
+                guard !inFlightImageURLs.contains(url) else { continue }
+
+                if let cached = imageLoader.loadRemote(url: url, completion: { [weak self, weak textView] image in
+                    guard let self else { return }
+                    self.inFlightImageURLs.remove(url)
+                    guard let textView else { return }
+                    self.applyLoadedImage(image, for: url, in: textView)
+                }) {
+                    applyLoadedImage(cached, for: url, in: textView)
+                } else {
+                    inFlightImageURLs.insert(url)
+                }
+            }
+        }
+
+        private func applyLoadedImage(
+            _ loadedImage: NSImage?,
+            for url: URL,
+            in textView: NSTextView
+        ) {
+            guard let renderTargets = currentRemoteImageTargets[url],
+                  generation == renderTargets.generation
+            else { return }
+
+            var didReplace = false
+            for target in renderTargets.targets {
+                didReplace = applyLoadedImage(
+                    loadedImage,
+                    to: target,
+                    in: textView
+                ) || didReplace
+            }
+
+            guard didReplace else { return }
+            if let textContainer = textView.textContainer {
+                textView.layoutManager?.ensureLayout(for: textContainer)
+            }
+            textView.invalidateIntrinsicContentSize()
+        }
+
+        private func applyLoadedImage(
+            _ loadedImage: NSImage?,
+            to target: RemoteImageTarget,
+            in textView: NSTextView
+        ) -> Bool {
+            let remoteImage = target.remoteImage
+            guard let storage = textView.textStorage,
+                  let range = range(of: remoteImage, in: storage)
+            else { return false }
+
+            let replacement: NSAttributedString
+            if let loadedImage {
+                let attachment = ACPMarkdownInlineRenderer.loadedImageAttachment(
+                    for: loadedImage,
+                    isSubscript: remoteImage.image.isSubscript
+                )
+                replacement = NSAttributedString(attachment: attachment)
+            } else {
+                replacement = ACPMarkdownInlineRenderer.mutedAltString(
+                    for: remoteImage.image,
+                    attributes: target.fallbackAttributes
+                )
+            }
+            storage.replaceCharacters(in: range, with: replacement)
+            return true
+        }
+
+        private struct RemoteImageRenderTargets {
+            let generation: Int
+            let targets: [RemoteImageTarget]
+        }
+
+        private struct RemoteImageTarget {
+            let remoteImage: ACPMarkdownInlineRemoteImage
+            let fallbackAttributes: [NSAttributedString.Key: Any]
+        }
+
+        private func range(
+            of remoteImage: ACPMarkdownInlineRemoteImage,
+            in storage: NSTextStorage
+        ) -> NSRange? {
+            let fullRange = NSRange(location: 0, length: storage.length)
+            var foundRange: NSRange?
+            storage.enumerateAttribute(.acpMarkdownInlineRemoteImage, in: fullRange) { value, range, stop in
+                guard let candidate = value as? ACPMarkdownInlineRemoteImage,
+                      candidate == remoteImage
+                else { return }
+                foundRange = range
+                stop.pointee = true
+            }
+            return foundRange
         }
     }
+}
+
+extension NSAttributedString.Key {
+    static let acpMarkdownInlineRemoteImage = NSAttributedString.Key("ACPMarkdownInlineRemoteImage")
 }
 
 private final class ACPMarkdownInlineNSTextView: NSTextView {

--- a/Alas/Sources/ACP/UI/ACPMarkdownInlineTextView.swift
+++ b/Alas/Sources/ACP/UI/ACPMarkdownInlineTextView.swift
@@ -130,11 +130,11 @@ struct ACPMarkdownInlineTextView: NSViewRepresentable {
 
             let replacement: NSAttributedString
             if let loadedImage {
-                let attachment = ACPMarkdownInlineRenderer.loadedImageAttachment(
+                replacement = ACPMarkdownInlineRenderer.loadedImageString(
                     for: loadedImage,
-                    isSubscript: remoteImage.image.isSubscript
+                    isSubscript: remoteImage.image.isSubscript,
+                    attributes: target.fallbackAttributes
                 )
-                replacement = NSAttributedString(attachment: attachment)
             } else {
                 replacement = ACPMarkdownInlineRenderer.mutedAltString(
                     for: remoteImage.image,

--- a/Alas/Sources/ACP/UI/ACPMarkdownInlineTextView.swift
+++ b/Alas/Sources/ACP/UI/ACPMarkdownInlineTextView.swift
@@ -1,0 +1,81 @@
+import SwiftUI
+import AppKit
+
+struct ACPMarkdownInlineTextView: NSViewRepresentable {
+    private static let defaultFittingWidth: CGFloat = 240
+    private static let minimumFittingWidth: CGFloat = 80
+
+    let source: String
+    let typography: ACPChatTypography
+    let role: ACPMarkdownInlineRole
+    let theme: Theme
+
+    func makeCoordinator() -> Coordinator {
+        Coordinator()
+    }
+
+    func makeNSView(context: Context) -> NSTextView {
+        let textView = ACPMarkdownInlineNSTextView()
+        textView.isEditable = false
+        textView.isSelectable = true
+        textView.drawsBackground = false
+        textView.isVerticallyResizable = true
+        textView.isHorizontallyResizable = false
+        textView.textContainerInset = .zero
+        textView.textContainer?.lineFragmentPadding = 0
+        textView.textContainer?.widthTracksTextView = true
+        textView.backgroundColor = .clear
+        return textView
+    }
+
+    func updateNSView(_ textView: NSTextView, context: Context) {
+        let rendered = ACPMarkdownInlineRenderer.makeAttributedString(
+            source: source,
+            theme: theme,
+            typography: typography,
+            role: role
+        )
+        textView.textStorage?.setAttributedString(rendered)
+        context.coordinator.loadRemoteImages(in: textView, attributedString: rendered)
+    }
+
+    func sizeThatFits(_ proposal: ProposedViewSize, nsView: NSTextView, context: Context) -> CGSize? {
+        let fallbackWidth = nsView.bounds.width > 1 ? nsView.bounds.width : Self.defaultFittingWidth
+        let width = max(Self.minimumFittingWidth, proposal.width ?? fallbackWidth)
+        return (nsView as? ACPMarkdownInlineNSTextView)?.fittingSize(for: width)
+            ?? CGSize(width: width, height: nsView.intrinsicContentSize.height)
+    }
+
+    @MainActor
+    final class Coordinator {
+        private let imageLoader = MarkdownImageLoader()
+        private var generation = 0
+
+        func loadRemoteImages(in textView: NSTextView, attributedString: NSAttributedString) {
+            generation += 1
+            _ = imageLoader
+            _ = textView
+            _ = attributedString
+        }
+    }
+}
+
+private final class ACPMarkdownInlineNSTextView: NSTextView {
+    private let minimumFittingWidth: CGFloat = 80
+
+    func fittingSize(for width: CGFloat) -> CGSize {
+        let fittingWidth = max(minimumFittingWidth, width)
+        guard let textContainer, let layoutManager else {
+            return CGSize(width: fittingWidth, height: 0)
+        }
+
+        textContainer.containerSize = CGSize(width: fittingWidth, height: .greatestFiniteMagnitude)
+        layoutManager.ensureLayout(for: textContainer)
+        let used = layoutManager.usedRect(for: textContainer)
+        return CGSize(width: fittingWidth, height: ceil(used.height))
+    }
+
+    override var intrinsicContentSize: NSSize {
+        fittingSize(for: bounds.width)
+    }
+}

--- a/Alas/Sources/ACP/UI/ACPMarkdownInlineTextView.swift
+++ b/Alas/Sources/ACP/UI/ACPMarkdownInlineTextView.swift
@@ -2,7 +2,6 @@ import SwiftUI
 import AppKit
 
 struct ACPMarkdownInlineTextView: NSViewRepresentable {
-    private static let defaultFittingWidth: CGFloat = 240
     private static let minimumFittingWidth: CGFloat = 80
 
     let source: String
@@ -40,10 +39,18 @@ struct ACPMarkdownInlineTextView: NSViewRepresentable {
     }
 
     func sizeThatFits(_ proposal: ProposedViewSize, nsView: NSTextView, context: Context) -> CGSize? {
-        let fallbackWidth = nsView.bounds.width > 1 ? nsView.bounds.width : Self.defaultFittingWidth
-        let width = max(Self.minimumFittingWidth, proposal.width ?? fallbackWidth)
-        return (nsView as? ACPMarkdownInlineNSTextView)?.fittingSize(for: width)
-            ?? CGSize(width: width, height: nsView.intrinsicContentSize.height)
+        guard let inlineTextView = nsView as? ACPMarkdownInlineNSTextView else {
+            let fallbackWidth = max(Self.minimumFittingWidth, proposal.width ?? nsView.bounds.width)
+            return CGSize(width: fallbackWidth, height: nsView.intrinsicContentSize.height)
+        }
+
+        if let proposedWidth = proposal.width {
+            return inlineTextView.fittingSize(for: proposedWidth)
+        }
+        if nsView.bounds.width > 1 {
+            return inlineTextView.fittingSize(for: nsView.bounds.width)
+        }
+        return inlineTextView.naturalFittingSize()
     }
 
     @MainActor
@@ -172,6 +179,7 @@ extension NSAttributedString.Key {
 
 private final class ACPMarkdownInlineNSTextView: NSTextView {
     private let minimumFittingWidth: CGFloat = 80
+    private let maximumNaturalFittingWidth: CGFloat = 10_000
 
     func fittingSize(for width: CGFloat) -> CGSize {
         let fittingWidth = max(minimumFittingWidth, width)
@@ -185,7 +193,21 @@ private final class ACPMarkdownInlineNSTextView: NSTextView {
         return CGSize(width: fittingWidth, height: ceil(used.height))
     }
 
+    func naturalFittingSize() -> CGSize {
+        guard let textContainer, let layoutManager else {
+            return CGSize(width: minimumFittingWidth, height: 0)
+        }
+
+        textContainer.containerSize = CGSize(width: maximumNaturalFittingWidth, height: .greatestFiniteMagnitude)
+        layoutManager.ensureLayout(for: textContainer)
+        let used = layoutManager.usedRect(for: textContainer)
+        return CGSize(
+            width: max(minimumFittingWidth, ceil(used.width)),
+            height: ceil(used.height)
+        )
+    }
+
     override var intrinsicContentSize: NSSize {
-        fittingSize(for: bounds.width)
+        bounds.width > 1 ? fittingSize(for: bounds.width) : naturalFittingSize()
     }
 }

--- a/Alas/Sources/ACP/UI/ACPMarkdownText.swift
+++ b/Alas/Sources/ACP/UI/ACPMarkdownText.swift
@@ -38,35 +38,17 @@ struct ACPMarkdownText: View {
     private func view(for block: Block) -> some View {
         switch block {
         case .heading(let level, let text):
-            Text(ACPMarkdownText.inlineMarkdown(text))
-                .font(typography.swiftUIFont(
-                    size: typography.headingSize(level: level),
-                    weight: .bold,
-                    traits: .boldFontMask
-                ))
-                .foregroundStyle(theme.color("fg"))
-                .textSelection(.enabled)
+            ACPMarkdownInlineTextView(source: text, typography: typography, role: .heading(level: level), theme: theme)
                 .padding(.top, level == 1 ? 4 : 2)
         case .paragraph(let text):
-            Text(ACPMarkdownText.inlineMarkdown(text))
-                .font(typography.swiftUIFont(size: typography.paragraphSize))
-                .foregroundStyle(theme.color("fg"))
-                .lineSpacing(3)
-                .textSelection(.enabled)
+            ACPMarkdownInlineTextView(source: text, typography: typography, role: .body, theme: theme)
                 .frame(maxWidth: .infinity, alignment: .leading)
         case .quote(let text):
             HStack(alignment: .top, spacing: 10) {
                 Rectangle()
                     .fill(theme.color("accent").opacity(0.55))
                     .frame(width: 2)
-                Text(ACPMarkdownText.inlineMarkdown(text))
-                    .font(typography.swiftUIFont(
-                        size: typography.quoteSize,
-                        traits: .italicFontMask
-                    ))
-                    .foregroundStyle(theme.color("fg-muted"))
-                    .lineSpacing(2)
-                    .textSelection(.enabled)
+                ACPMarkdownInlineTextView(source: text, typography: typography, role: .quote, theme: theme)
                 Spacer(minLength: 0)
             }
         case .code(let lang, let body):
@@ -99,13 +81,12 @@ struct ACPMarkdownText: View {
         HStack(alignment: .top, spacing: 0) {
             ForEach(0..<columnCount, id: \.self) { i in
                 let value = i < cells.count ? cells[i] : ""
-                Text(ACPMarkdownText.inlineMarkdown(value))
-                    .font(typography.swiftUIFont(
-                        size: isHeader ? typography.tableHeaderSize : typography.tableBodySize,
-                        weight: isHeader ? .semibold : .regular,
-                        traits: isHeader ? .boldFontMask : []
-                    ))
-                    .foregroundStyle(isHeader ? theme.color("fg-muted") : theme.color("fg"))
+                ACPMarkdownInlineTextView(
+                    source: value,
+                    typography: typography,
+                    role: .tableCell(isHeader: isHeader),
+                    theme: theme
+                )
                     .frame(minWidth: 80, alignment: .leading)
                     .padding(.horizontal, 10).padding(.vertical, 6)
                 if i < columnCount - 1 {

--- a/Alas/Sources/ACP/UI/ACPMarkdownText.swift
+++ b/Alas/Sources/ACP/UI/ACPMarkdownText.swift
@@ -40,6 +40,7 @@ struct ACPMarkdownText: View {
         case .heading(let level, let text):
             ACPMarkdownInlineTextView(source: text, typography: typography, role: .heading(level: level), theme: theme)
                 .padding(.top, level == 1 ? 4 : 2)
+                .frame(maxWidth: .infinity, alignment: .leading)
         case .paragraph(let text):
             ACPMarkdownInlineTextView(source: text, typography: typography, role: .body, theme: theme)
                 .frame(maxWidth: .infinity, alignment: .leading)
@@ -49,6 +50,7 @@ struct ACPMarkdownText: View {
                     .fill(theme.color("accent").opacity(0.55))
                     .frame(width: 2)
                 ACPMarkdownInlineTextView(source: text, typography: typography, role: .quote, theme: theme)
+                    .frame(maxWidth: .infinity, alignment: .leading)
                 Spacer(minLength: 0)
             }
         case .code(let lang, let body):

--- a/Alas/Sources/Center/DiffReview/DiffReviewFileSection.swift
+++ b/Alas/Sources/Center/DiffReview/DiffReviewFileSection.swift
@@ -1269,7 +1269,9 @@ enum DiffReviewInlineFeedbackMarkdown {
             case .code(_, let body):
                 return body
             case .table(let header, let rows):
-                return ([header] + rows).map { $0.joined(separator: " ") }.joined(separator: " ")
+                return ([header] + rows).map { row in
+                    row.map { ACPMarkdownInlineRenderer.plainText($0) }.joined(separator: " ")
+                }.joined(separator: " ")
             }
         }.joined(separator: " ")
     }

--- a/Alas/Sources/Center/DiffReview/DiffReviewFileSection.swift
+++ b/Alas/Sources/Center/DiffReview/DiffReviewFileSection.swift
@@ -1265,7 +1265,7 @@ enum DiffReviewInlineFeedbackMarkdown {
         ACPMarkdownText.parse(source).compactMap { block -> String? in
             switch block {
             case .heading(_, let text), .paragraph(let text), .quote(let text):
-                return NSAttributedString(ACPMarkdownText.inlineMarkdown(text)).string
+                return ACPMarkdownInlineRenderer.plainText(text)
             case .code(_, let body):
                 return body
             case .table(let header, let rows):

--- a/AlasTests/ACP/UI/ACPMarkdownInlineRendererTests.swift
+++ b/AlasTests/ACP/UI/ACPMarkdownInlineRendererTests.swift
@@ -73,6 +73,18 @@ struct ACPMarkdownInlineRendererTests {
         #expect(plain == "Before small after")
     }
 
+    @Test("subscript tags are case-insensitive")
+    func subscriptTagsAreCaseInsensitive() throws {
+        let plain = ACPMarkdownInlineRenderer.plainText("Before <SUB>small</SUB> after")
+        #expect(plain == "Before small after")
+
+        let plan = ACPMarkdownInlineRenderer.makePlan(
+            "<SUB>![P3 Badge](https://img.shields.io/badge/P3-lightgrey?style=flat)</SUB>"
+        )
+        let image = try #require(plan.images.first)
+        #expect(image.isSubscript)
+    }
+
     @Test("malformed subscript remains visible")
     func malformedSubscriptRemainsVisible() {
         let plain = ACPMarkdownInlineRenderer.plainText("Before <sub>small after")

--- a/AlasTests/ACP/UI/ACPMarkdownInlineRendererTests.swift
+++ b/AlasTests/ACP/UI/ACPMarkdownInlineRendererTests.swift
@@ -6,6 +6,36 @@ import Testing
 @MainActor
 @Suite("ACP markdown inline renderer")
 struct ACPMarkdownInlineRendererTests {
+    @Test("badge image size is capped with aspect ratio")
+    func badgeImageSizeIsCapped() {
+        let size = ACPMarkdownInlineRenderer.displaySize(
+            original: CGSize(width: 300, height: 60),
+            isSubscript: true
+        )
+        #expect(size.width == 90)
+        #expect(size.height == 18)
+    }
+
+    @Test("normal inline image size is capped")
+    func normalInlineImageSizeIsCapped() {
+        let size = ACPMarkdownInlineRenderer.displaySize(
+            original: CGSize(width: 600, height: 300),
+            isSubscript: false
+        )
+        #expect(size.width == 160)
+        #expect(size.height == 80)
+    }
+
+    @Test("display size keeps minimum pixel dimension")
+    func displaySizeKeepsMinimumPixelDimension() {
+        let size = ACPMarkdownInlineRenderer.displaySize(
+            original: CGSize(width: 100_000, height: 1),
+            isSubscript: true
+        )
+        #expect(size.width >= 1)
+        #expect(size.height >= 1)
+    }
+
     @Test("badge markup produces placeholder and metadata")
     func badgeMarkupProducesPlaceholderAndMetadata() throws {
         let plan = ACPMarkdownInlineRenderer.makePlan(

--- a/AlasTests/ACP/UI/ACPMarkdownInlineRendererTests.swift
+++ b/AlasTests/ACP/UI/ACPMarkdownInlineRendererTests.swift
@@ -1,0 +1,85 @@
+import AppKit
+import Foundation
+import Testing
+@testable import Alas
+
+@MainActor
+@Suite("ACP markdown inline renderer")
+struct ACPMarkdownInlineRendererTests {
+    @Test("badge markup produces placeholder and metadata")
+    func badgeMarkupProducesPlaceholderAndMetadata() throws {
+        let plan = ACPMarkdownInlineRenderer.makePlan(
+            "**<sub>![P2 Badge](https://img.shields.io/badge/P2-yellow?style=flat)</sub> Preserve streamed text**"
+        )
+        let image = try #require(plan.images.first)
+
+        #expect(plan.markdownSource.contains(image.placeholder))
+        #expect(image.alt == "P2 Badge")
+        #expect(image.source == "https://img.shields.io/badge/P2-yellow?style=flat")
+        #expect(image.isSubscript)
+        #expect(plan.markdownSource.hasPrefix("**"))
+        #expect(plan.markdownSource.hasSuffix("**"))
+    }
+
+    @Test("subscript text strips tags")
+    func subscriptTextStripsTags() {
+        let plain = ACPMarkdownInlineRenderer.plainText("Before <sub>small</sub> after")
+        #expect(plain == "Before small after")
+    }
+
+    @Test("malformed subscript remains visible")
+    func malformedSubscriptRemainsVisible() {
+        let plain = ACPMarkdownInlineRenderer.plainText("Before <sub>small after")
+        #expect(plain == "Before <sub>small after")
+    }
+
+    @Test("inline code image syntax stays text")
+    func inlineCodeImageSyntaxStaysText() {
+        let plan = ACPMarkdownInlineRenderer.makePlan("Use `![alt](https://example.com/a.png)` literally")
+        #expect(plan.images.isEmpty)
+        #expect(ACPMarkdownInlineRenderer.plainText("Use `![alt](https://example.com/a.png)` literally")
+            .contains("![alt](https://example.com/a.png)"))
+    }
+
+    @Test("bold can span badge placeholder")
+    func boldCanSpanBadgePlaceholder() throws {
+        let attributed = ACPMarkdownInlineRenderer.makeAttributedString(
+            source: "**<sub>![P2 Badge](https://img.shields.io/badge/P2-yellow?style=flat)</sub> Preserve streamed text**",
+            theme: try Theme.loadBundled(id: "cool-slate"),
+            typography: ACPChatTypography(fontFamily: "", fontSize: 11),
+            role: .body
+        )
+        let textRange = (attributed.string as NSString).range(of: "Preserve streamed text")
+        try #require(textRange.location != NSNotFound)
+        let font = attributed.attribute(.font, at: textRange.location, effectiveRange: nil) as? NSFont
+        #expect(font?.fontDescriptor.symbolicTraits.contains(.bold) == true)
+    }
+
+    @Test("subscript text receives baseline offset")
+    func subscriptTextReceivesBaselineOffset() throws {
+        let attributed = ACPMarkdownInlineRenderer.makeAttributedString(
+            source: "Before <sub>small</sub> after",
+            theme: try Theme.loadBundled(id: "cool-slate"),
+            typography: ACPChatTypography(fontFamily: "", fontSize: 11),
+            role: .body
+        )
+        let range = (attributed.string as NSString).range(of: "small")
+        try #require(range.location != NSNotFound)
+        let baseline = attributed.attribute(.baselineOffset, at: range.location, effectiveRange: nil) as? CGFloat
+        #expect((baseline ?? 0) < 0)
+    }
+
+    @Test("inline code receives fixed pitch font")
+    func inlineCodeReceivesFixedPitchFont() throws {
+        let attributed = ACPMarkdownInlineRenderer.makeAttributedString(
+            source: "Use `configId` now",
+            theme: try Theme.loadBundled(id: "cool-slate"),
+            typography: ACPChatTypography(fontFamily: "", fontSize: 11),
+            role: .body
+        )
+        let range = (attributed.string as NSString).range(of: "configId")
+        try #require(range.location != NSNotFound)
+        let font = attributed.attribute(.font, at: range.location, effectiveRange: nil) as? NSFont
+        #expect(font?.isFixedPitch == true)
+    }
+}

--- a/AlasTests/ACP/UI/ACPMarkdownInlineRendererTests.swift
+++ b/AlasTests/ACP/UI/ACPMarkdownInlineRendererTests.swift
@@ -128,4 +128,31 @@ struct ACPMarkdownInlineRendererTests {
         let font = attributed.attribute(.font, at: range.location, effectiveRange: nil) as? NSFont
         #expect(font?.isFixedPitch == true)
     }
+
+    @Test("loaded image replacement preserves inherited link")
+    func loadedImageReplacementPreservesInheritedLink() throws {
+        let url = try #require(URL(string: "https://review.example"))
+        let remoteImage = ACPMarkdownInlineRemoteImage(
+            image: ACPMarkdownInlineImage(
+                placeholder: "\u{E000}ALAS_IMG_0\u{E001}",
+                alt: "P2",
+                source: "https://img.shields.io/badge/P2-yellow?style=flat",
+                isSubscript: true
+            ),
+            url: try #require(URL(string: "https://img.shields.io/badge/P2-yellow?style=flat"))
+        )
+
+        let image = NSImage(size: CGSize(width: 32, height: 16))
+        let replacement = ACPMarkdownInlineRenderer.loadedImageString(
+            for: image,
+            isSubscript: true,
+            attributes: [
+                .link: url,
+                .acpMarkdownInlineRemoteImage: remoteImage,
+            ]
+        )
+
+        #expect(replacement.attribute(.link, at: 0, effectiveRange: nil) as? URL == url)
+        #expect(replacement.attribute(.acpMarkdownInlineRemoteImage, at: 0, effectiveRange: nil) == nil)
+    }
 }

--- a/AlasTests/ACP/UI/ACPMarkdownInlineRendererTests.swift
+++ b/AlasTests/ACP/UI/ACPMarkdownInlineRendererTests.swift
@@ -36,6 +36,22 @@ struct ACPMarkdownInlineRendererTests {
         #expect(size.height >= 1)
     }
 
+    @Test("remote image sources are renderable")
+    func remoteImageSourcesAreRenderable() {
+        let image = ACPMarkdownInlineImage(
+            placeholder: "\u{E000}ALAS_IMG_0\u{E000}",
+            alt: "P2 Badge",
+            source: "https://img.shields.io/badge/P2-yellow?style=flat",
+            isSubscript: true
+        )
+        #expect(ACPMarkdownInlineRenderer.imageSourceKind(image.source) == .remote)
+    }
+
+    @Test("local image sources fall back without base directory")
+    func localImageSourcesFallbackWithoutBaseDirectory() {
+        #expect(ACPMarkdownInlineRenderer.imageSourceKind("assets/badge.png") == .local)
+    }
+
     @Test("badge markup produces placeholder and metadata")
     func badgeMarkupProducesPlaceholderAndMetadata() throws {
         let plan = ACPMarkdownInlineRenderer.makePlan(

--- a/AlasTests/DiffReviewSurfaceTests.swift
+++ b/AlasTests/DiffReviewSurfaceTests.swift
@@ -1294,6 +1294,19 @@ struct DiffReviewSurfaceTests {
         #expect(plain == "P2 Badge Preserve streamed text")
     }
 
+    @MainActor
+    @Test func inlineFeedbackMarkdownPlainTextNormalizesTableCells() {
+        let plain = DiffReviewInlineFeedbackMarkdown.plainText(
+            """
+            | Priority | Message |
+            | --- | --- |
+            | <sub>![P2 Badge](https://img.shields.io/badge/P2-yellow?style=flat)</sub> | **Fix** this |
+            """
+        )
+
+        #expect(plain == "Priority Message P2 Badge Fix this")
+    }
+
     @Test func textDocumentViewClearsInactivePaneLSPContextWhenLayoutChanges() {
         let manager = WorkspaceLSPManager(registry: LanguageServerRegistry(userDefined: []))
         let context = DiffPaneLSPContext(

--- a/AlasTests/DiffReviewSurfaceTests.swift
+++ b/AlasTests/DiffReviewSurfaceTests.swift
@@ -1285,6 +1285,15 @@ struct DiffReviewSurfaceTests {
         #expect(plain == "Use bold and configId.")
     }
 
+    @MainActor
+    @Test func inlineFeedbackMarkdownPlainTextUsesImageAltAndStripsSubscript() {
+        let plain = DiffReviewInlineFeedbackMarkdown.plainText(
+            "**<sub>![P2 Badge](https://img.shields.io/badge/P2-yellow?style=flat)</sub> Preserve streamed text**"
+        )
+
+        #expect(plain == "P2 Badge Preserve streamed text")
+    }
+
     @Test func textDocumentViewClearsInactivePaneLSPContextWhenLayoutChanges() {
         let manager = WorkspaceLSPManager(registry: LanguageServerRegistry(userDefined: []))
         let context = DiffPaneLSPContext(

--- a/docs/superpowers/specs/2026-06-21-inline-markdown-badges-design.md
+++ b/docs/superpowers/specs/2026-06-21-inline-markdown-badges-design.md
@@ -1,0 +1,101 @@
+# Inline Markdown Badges Design
+
+## Goal
+
+Review feedback and ACP chat surfaces should render GitHub-style badge markup such as:
+
+```markdown
+**<sub>![P2 Badge](https://img.shields.io/badge/P2-yellow?style=flat)</sub> Preserve streamed text**
+```
+
+The rendered output should show the badge image inline, apply emphasis to surrounding text, and treat `<sub>...</sub>` as small lowered inline content instead of visible raw HTML. The behavior should apply to all native SwiftUI surfaces that already use `ACPMarkdownText`, including:
+
+- ACP chat messages
+- queued message previews
+- inline review feedback cards
+- draft review summaries
+
+The normal markdown file preview should keep using `MarkdownRenderer`; it already supports inline local and remote markdown images.
+
+## Non-Goals
+
+- Full HTML rendering in chat or review comments.
+- Arbitrary HTML attributes, nested block HTML, scripts, or custom elements.
+- Image support inside fenced code blocks.
+- Remote web transcript parity in this change.
+- Pixel-perfect GitHub markdown layout.
+
+## Rendering Model
+
+`ACPMarkdownText` remains the shared native SwiftUI markdown entry point for chat and review feedback. Its block parser continues to own headings, paragraphs, blockquotes, tables, and fenced code blocks. Inline rendering changes from one `Text(AttributedString)` per inline string to a lightweight inline run model.
+
+The inline model should recognize:
+
+- plain markdown spans rendered through the existing `AttributedString(markdown:)` path
+- markdown images of the form `![alt](src)`
+- `<sub>...</sub>` spans
+
+Runs are rendered in order inside wrapping SwiftUI layouts. Text runs keep the current typography, foreground color, selection behavior, bare URL linkification, and inline markdown behavior. Image runs render as inline `Image(nsImage:)` views when an image can be loaded and render the alt text as muted text when the image cannot be loaded.
+
+## Subscript Support
+
+Only paired lowercase or uppercase `sub` tags are recognized:
+
+```html
+<sub>content</sub>
+```
+
+The parser treats the tag itself as syntax and recursively parses the content as inline markdown. Subscript content should render with:
+
+- a smaller font scale
+- a lowered baseline for text
+- compact image bounds for badges
+
+Unknown or malformed HTML remains visible as text. This keeps the feature narrow and avoids pretending to support broader HTML.
+
+## Image Loading
+
+Remote `http` and `https` images are loaded with the existing `MarkdownImageLoader` cache. While loading, the run shows a bounded placeholder sized like a compact badge. If loading fails, the run falls back to alt text.
+
+Sizing should be conservative:
+
+- normal inline images are capped to a modest width and line-friendly height
+- images inside `<sub>` are capped to badge scale
+- aspect ratio is preserved
+
+Local image paths may be supported only when the caller can provide a safe base directory. Existing ACP and review feedback calls do not have a markdown document directory, so local images should fall back to alt text there rather than guessing.
+
+## Review Feedback Integration
+
+`DiffReviewInlineFeedbackMarkdown.view(_:)` should continue delegating to `ACPMarkdownText`. The fix should not introduce a separate review markdown renderer.
+
+`DiffReviewInlineFeedbackMarkdown.plainText(_:)` should preserve accessible/searchable text by converting images to alt text and stripping recognized `<sub>` tags. Existing code block, table, heading, paragraph, and quote plain-text behavior should remain.
+
+## Normal Markdown Preview
+
+`MarkdownRenderer` should not be replaced. It already handles markdown image nodes, local image resolution, remote image placeholders, and async remote image patching. The implementation may add targeted tests for `<sub>` behavior if `swift-markdown` exposes inline HTML nodes in that renderer, but the badge fix should be driven by the ACP/review renderer.
+
+## Error Handling
+
+Rendering must never blank a message because inline parsing failed. Any parser failure should fall back to the original source text for that span.
+
+Remote image failures are non-fatal. Failed images render as alt text when present, or as an empty compact placeholder only if no alt text exists.
+
+## Testing
+
+Swift tests should cover:
+
+- `**<sub>![P2 Badge](https://img.shields.io/badge/P2-yellow?style=flat)</sub> Preserve streamed text**` produces an image run plus visible text.
+- `<sub>small</sub>` renders visible text without raw HTML tags.
+- malformed subscript markup remains visible instead of being dropped.
+- image fallback preserves alt text.
+- existing inline markdown links, bare URL linkification, inline code, and emphasis still work.
+- `DiffReviewInlineFeedbackMarkdown.plainText(...)` emits image alt text and strips recognized `sub` tags.
+
+Where direct SwiftUI view inspection is impractical, keep parsing and run construction in small pure helpers so tests can assert the run model directly.
+
+## Risks
+
+- Replacing `Text(AttributedString)` with composed inline views can affect wrapping and selection. The implementation should keep the run renderer compact and verify representative review comments visually.
+- Remote image loading can create layout shifts. Placeholder and final image bounds should be stable.
+- HTML parsing can sprawl. The parser should support only the explicit `<sub>...</sub>` case and leave other HTML alone.


### PR DESCRIPTION
## Summary

Adds support for rendering inline markdown badge images and `<sub>` markup in ACP markdown surfaces, including feedback messages and review summaries.

## Changes

- Render inline markdown through an AppKit-backed inline text view so headings, paragraphs, quotes, and table cells can display image attachments.
- Parse markdown images and `<sub>` spans before handing text to the existing inline markdown path.
- Load remote badge/image URLs asynchronously with alt-text fallbacks for unsupported or failed sources.
- Preserve badge alt text in review feedback plain-text summaries, including table cells.
- Add focused tests for inline badge parsing, sizing, alt fallback, and review summary text.

## Validation

- `rtk xcodegen`
- `rtk xcrun swiftc -parse Alas/Sources/ACP/UI/ACPMarkdownInlineTextView.swift Alas/Sources/ACP/UI/ACPMarkdownText.swift Alas/Sources/Center/DiffReview/DiffReviewFileSection.swift AlasTests/DiffReviewSurfaceTests.swift`
- `rtk git diff --check`

Full local `xcodebuild` verification is currently blocked on this machine because `.build/ghostty/GhosttyKit.xcframework/Info.plist` is missing and rebuilding GhosttyKit requires the Xcode Metal Toolchain (`xcodebuild -downloadComponent MetalToolchain`).