### PR TITLE
fix(acp): filter model dropdown by name and id

### DIFF
--- a/Alas/Sources/ACP/UI/ACPComposerShell.swift
+++ b/Alas/Sources/ACP/UI/ACPComposerShell.swift
@@ -365,7 +365,8 @@ struct ACPComposer: View {
                     ?? spec.currentId
                     ?? "Model",
              placeholder: "Model",
-             accent: theme.color("syntax-keyword"))
+             accent: theme.color("syntax-keyword"),
+             searchDescriptions: false)
     }
 
     private func parameterChip(_ parameter: ACPParameterChip) -> some View {
@@ -411,7 +412,8 @@ struct ACPComposer: View {
     private func chip(spec: ChipSpec,
                       label: String,
                       placeholder: String,
-                      accent: Color) -> some View {
+                      accent: Color,
+                      searchDescriptions: Bool = true) -> some View {
         ACPSelectChip(
             label: label,
             placeholder: placeholder,
@@ -420,6 +422,7 @@ struct ACPComposer: View {
                 ACPSelectChip.Item(id: $0.id, name: $0.name, description: $0.description)
             },
             selectedId: spec.currentId,
+            searchDescriptions: searchDescriptions,
             onSelect: { item in apply(spec: spec, selectedId: item.id) }
         )
     }

--- a/Alas/Sources/ACP/UI/ACPSelectChip.swift
+++ b/Alas/Sources/ACP/UI/ACPSelectChip.swift
@@ -66,6 +66,18 @@ struct ACPSelectChip: View {
         }
     }
 
+    /// Case-insensitive substring filter used by the dropdown. Matches on
+    /// `name` and `id` only; descriptions are displayed but not searched, so
+    /// numeric snippets in descriptions do not pollute model results.
+    static func filteredItems(_ items: [Item], query: String) -> [Item] {
+        let q = query.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        if q.isEmpty { return items }
+        return items.filter {
+            $0.name.lowercased().contains(q)
+                || $0.id.lowercased().contains(q)
+        }
+    }
+
     static func labelForeground(accent: Color, theme: Theme) -> Color {
         if theme.darkMode {
             return Color.blend(accent, .white, t: 0.55)
@@ -163,13 +175,7 @@ private struct DropdownPanel: View {
     private var showSearch: Bool { items.count > 5 }
 
     private var filtered: [ACPSelectChip.Item] {
-        let q = query.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
-        if q.isEmpty { return items }
-        return items.filter {
-            $0.name.lowercased().contains(q)
-                || $0.id.lowercased().contains(q)
-                || ($0.description?.lowercased().contains(q) ?? false)
-        }
+        ACPSelectChip.filteredItems(items, query: query)
     }
 
     var body: some View {

--- a/Alas/Sources/ACP/UI/ACPSelectChip.swift
+++ b/Alas/Sources/ACP/UI/ACPSelectChip.swift
@@ -17,6 +17,7 @@ struct ACPSelectChip: View {
     let accent: Color
     let items: [Item]
     let selectedId: String?
+    let searchDescriptions: Bool
     let onSelect: (Item) -> Void
 
     @Environment(\.theme) private var theme
@@ -57,6 +58,7 @@ struct ACPSelectChip: View {
                 items: items,
                 selectedId: selectedId,
                 accent: accent,
+                searchDescriptions: searchDescriptions,
                 onSelect: { item in
                     onSelect(item)
                     showPopover = false
@@ -66,15 +68,16 @@ struct ACPSelectChip: View {
         }
     }
 
-    /// Case-insensitive substring filter used by the dropdown. Matches on
-    /// `name` and `id` only; descriptions are displayed but not searched, so
-    /// numeric snippets in descriptions do not pollute model results.
-    static func filteredItems(_ items: [Item], query: String) -> [Item] {
+    /// Case-insensitive substring filter used by the dropdown. Model pickers
+    /// disable description matching so numeric snippets in descriptions do
+    /// not pollute model results.
+    static func filteredItems(_ items: [Item], query: String, searchDescriptions: Bool = true) -> [Item] {
         let q = query.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
         if q.isEmpty { return items }
         return items.filter {
             $0.name.lowercased().contains(q)
                 || $0.id.lowercased().contains(q)
+                || (searchDescriptions && ($0.description?.lowercased().contains(q) ?? false))
         }
     }
 
@@ -159,6 +162,7 @@ private struct DropdownPanel: View {
     let items: [ACPSelectChip.Item]
     let selectedId: String?
     let accent: Color
+    let searchDescriptions: Bool
     let onSelect: (ACPSelectChip.Item) -> Void
 
     @Environment(\.theme) private var theme
@@ -175,7 +179,7 @@ private struct DropdownPanel: View {
     private var showSearch: Bool { items.count > 5 }
 
     private var filtered: [ACPSelectChip.Item] {
-        ACPSelectChip.filteredItems(items, query: query)
+        ACPSelectChip.filteredItems(items, query: query, searchDescriptions: searchDescriptions)
     }
 
     var body: some View {

--- a/AlasTests/ACP/UI/ACPSelectChipTests.swift
+++ b/AlasTests/ACP/UI/ACPSelectChipTests.swift
@@ -108,8 +108,8 @@ struct ACPSelectChipTests {
 
     // MARK: - DropdownPanel filtering
 
-    @Test("filters model options by name/id but not description substrings")
-    func filteringIgnoresDescriptionSubstrings() {
+    @Test("can exclude description substrings for model filtering")
+    func filteringCanIgnoreDescriptionSubstrings() {
         let items = [
             ACPSelectChip.Item(id: "kimi-2.7", name: "kimi-2.7", description: nil),
             ACPSelectChip.Item(id: "claude-opus", name: "Claude Opus", description: "2.7M context"),
@@ -117,9 +117,21 @@ struct ACPSelectChipTests {
             ACPSelectChip.Item(id: "gpt-4", name: "GPT-4", description: "2.7M parameters"),
         ]
 
-        let result = ACPSelectChip.filteredItems(items, query: "2.7")
+        let result = ACPSelectChip.filteredItems(items, query: "2.7", searchDescriptions: false)
 
         #expect(result.map(\.id) == ["kimi-2.7"])
+    }
+
+    @Test("default filtering includes description substrings for non-model chips")
+    func defaultFilteringIncludesDescriptionSubstrings() {
+        let items = [
+            ACPSelectChip.Item(id: "standard", name: "Standard", description: "No background processing"),
+            ACPSelectChip.Item(id: "fast", name: "Fast", description: "Lower reasoning effort"),
+        ]
+
+        let result = ACPSelectChip.filteredItems(items, query: "reasoning")
+
+        #expect(result.map(\.id) == ["fast"])
     }
 
     @Test("empty query returns all items in order")

--- a/AlasTests/ACP/UI/ACPSelectChipTests.swift
+++ b/AlasTests/ACP/UI/ACPSelectChipTests.swift
@@ -105,4 +105,60 @@ struct ACPSelectChipTests {
         }
         return 0.2126 * channel(c.red) + 0.7152 * channel(c.green) + 0.0722 * channel(c.blue)
     }
+
+    // MARK: - DropdownPanel filtering
+
+    @Test("filters model options by name/id but not description substrings")
+    func filteringIgnoresDescriptionSubstrings() {
+        let items = [
+            ACPSelectChip.Item(id: "kimi-2.7", name: "kimi-2.7", description: nil),
+            ACPSelectChip.Item(id: "claude-opus", name: "Claude Opus", description: "2.7M context"),
+            ACPSelectChip.Item(id: "gemini-2.5", name: "Gemini 2.5", description: "2.7M context"),
+            ACPSelectChip.Item(id: "gpt-4", name: "GPT-4", description: "2.7M parameters"),
+        ]
+
+        let result = ACPSelectChip.filteredItems(items, query: "2.7")
+
+        #expect(result.map(\.id) == ["kimi-2.7"])
+    }
+
+    @Test("empty query returns all items in order")
+    func emptyQueryReturnsAllItems() {
+        let items = [
+            ACPSelectChip.Item(id: "a", name: "Alpha", description: nil),
+            ACPSelectChip.Item(id: "b", name: "Beta", description: nil),
+        ]
+
+        #expect(ACPSelectChip.filteredItems(items, query: "").map(\.id) == ["a", "b"])
+    }
+
+    @Test("filters case-insensitively by name and id")
+    func filteringIsCaseInsensitive() {
+        let items = [
+            ACPSelectChip.Item(id: "kimi-2.7", name: "Kimi 2.7", description: nil),
+            ACPSelectChip.Item(id: "GPT-4", name: "gpt-4", description: nil),
+        ]
+
+        #expect(ACPSelectChip.filteredItems(items, query: "KIMI").map(\.id) == ["kimi-2.7"])
+        #expect(ACPSelectChip.filteredItems(items, query: "2.7").map(\.id) == ["kimi-2.7"])
+    }
+
+    @Test("matching by id still works when name differs")
+    func filteringMatchesById() {
+        let items = [
+            ACPSelectChip.Item(id: "kimi-2.7", name: "Kimi K2", description: nil),
+            ACPSelectChip.Item(id: "gemini-2.5", name: "Gemini 2.5", description: nil),
+        ]
+
+        #expect(ACPSelectChip.filteredItems(items, query: "kimi-2.7").map(\.id) == ["kimi-2.7"])
+    }
+
+    @Test("trims whitespace from query before filtering")
+    func filteringTrimsWhitespace() {
+        let items = [
+            ACPSelectChip.Item(id: "kimi-2.7", name: "kimi-2.7", description: nil),
+        ]
+
+        #expect(ACPSelectChip.filteredItems(items, query: "  2.7  ").map(\.id) == ["kimi-2.7"])
+    }
 }


### PR DESCRIPTION
## Summary
- filter ACP select dropdown search by model name and id only
- keep descriptions visible but exclude them from matching to avoid numeric false positives
- add focused Swift Testing coverage for dropdown filtering

## Verification
- xcodegen
- xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -quiet build
- xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -quiet test (interrupted locally after stalling; CI will verify)