### PR TITLE
feat(review): surface GitHub feedback in the inspect summary rail

### DIFF
--- a/Alas/Sources/Center/DiffReview/DiffReviewSurface.swift
+++ b/Alas/Sources/Center/DiffReview/DiffReviewSurface.swift
@@ -219,7 +219,10 @@ struct DiffReviewSurface: View {
                     collapsed: $reviewSummaryCollapsed,
                     focusedDraftCommentID: focusedDraftCommentID,
                     draftCommentActions: draftCommentActions,
-                    onSelectDraftComment: onSelectDraftComment
+                    onSelectDraftComment: onSelectDraftComment,
+                    inlineFeedbackByFileID: inlineFeedbackByFileID,
+                    focusedFeedbackID: focusedFeedbackID,
+                    onSelectInlineFeedback: onSelectInlineFeedback
                 )
             }
         }

--- a/Alas/Sources/Center/ReviewWorkspace/ReviewDraftSummaryRail.swift
+++ b/Alas/Sources/Center/ReviewWorkspace/ReviewDraftSummaryRail.swift
@@ -45,6 +45,9 @@ struct ReviewDraftSummaryRail: View {
     var focusedDraftCommentID: String?
     var draftCommentActions = ReviewDraftCommentActions()
     var onSelectDraftComment: (ReviewDraftComment) -> Void = { _ in }
+    var inlineFeedbackByFileID: [DiffReviewFileID: [DiffReviewInlineFeedback]] = [:]
+    var focusedFeedbackID: String?
+    var onSelectInlineFeedback: (DiffReviewInlineFeedback) -> Void = { _ in }
 
     @Environment(\.theme) private var theme
     @Environment(\.reviewDraftSummaryRailStatus) private var sendStatus
@@ -66,6 +69,17 @@ struct ReviewDraftSummaryRail: View {
             .map { path in
                 CommentGroup(path: path, comments: ReviewDraftCommentPlacement.sorted(grouped[path] ?? []))
             }
+    }
+
+    private var feedbackGroups: [FeedbackGroup] {
+        inlineFeedbackByFileID
+            .filter { !$0.value.isEmpty }
+            .map { FeedbackGroup(fileID: $0.key, items: $0.value) }
+            .sorted { $0.path.localizedStandardCompare($1.path) == .orderedAscending }
+    }
+
+    private var hasFeedback: Bool {
+        feedbackGroups.contains { !$0.items.isEmpty }
     }
 
     private var canCopyPrompt: Bool {
@@ -113,9 +127,14 @@ struct ReviewDraftSummaryRail: View {
         VStack(spacing: 0) {
             expandedHeader
             ScrollView(.vertical) {
-                LazyVStack(alignment: .leading, spacing: 10) {
-                    ForEach(groupedComments) { group in
-                        commentGroup(group)
+                VStack(alignment: .leading, spacing: 10) {
+                    LazyVStack(alignment: .leading, spacing: 10) {
+                        ForEach(groupedComments) { group in
+                            commentGroup(group)
+                        }
+                    }
+                    if hasFeedback {
+                        feedbackSection
                     }
                 }
                 .padding(10)
@@ -439,6 +458,110 @@ struct ReviewDraftSummaryRail: View {
         }
     }
 
+    @ViewBuilder
+    private var feedbackSection: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            Text("GitHub feedback")
+                .font(.system(size: 12, weight: .semibold))
+                .foregroundColor(theme.color("fg"))
+                .accessibilityIdentifier("review-summary-feedback-header")
+                .background(
+                    DiffReviewAccessibilityMarker(
+                        identifier: "review-summary-feedback-header",
+                        label: "GitHub feedback"
+                    )
+                )
+            ForEach(feedbackGroups) { group in
+                feedbackGroupView(group)
+            }
+        }
+        .padding(.top, 4)
+        .frame(maxWidth: .infinity, alignment: .leading)
+    }
+
+    private func feedbackGroupView(_ group: FeedbackGroup) -> some View {
+        VStack(alignment: .leading, spacing: 6) {
+            Text(group.path)
+                .font(.system(size: 10.5, weight: .semibold))
+                .foregroundColor(theme.color("fg-dim"))
+                .lineLimit(1)
+                .truncationMode(.middle)
+            ForEach(group.items) { item in
+                feedbackCard(item)
+            }
+        }
+    }
+
+    private func feedbackCard(_ item: DiffReviewInlineFeedback) -> some View {
+        let isFocused = item.id == focusedFeedbackID
+        return Button {
+            onSelectInlineFeedback(item)
+        } label: {
+            feedbackCardContent(item)
+                .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+        .accessibilityIdentifier("review-summary-feedback-\(item.id)")
+        .accessibilityLabel(feedbackAccessibilityLabel(for: item))
+        .padding(8)
+        .background(isFocused ? theme.color("accent-soft") : theme.color("bg-1"))
+        .clipShape(RoundedRectangle(cornerRadius: 6))
+        .overlay(
+            RoundedRectangle(cornerRadius: 6)
+                .stroke(isFocused ? theme.color("accent") : theme.color("line"), lineWidth: isFocused ? 1 : 0.5)
+        )
+        .background(
+            ReviewDraftSummaryPressMarker(
+                identifier: "review-summary-feedback-\(item.id)",
+                label: feedbackAccessibilityLabel(for: item),
+                isEnabled: true
+            ) {
+                onSelectInlineFeedback(item)
+            }
+        )
+    }
+
+    private func feedbackCardContent(_ item: DiffReviewInlineFeedback) -> some View {
+        VStack(alignment: .leading, spacing: 5) {
+            HStack(spacing: 6) {
+                Text(item.providerName)
+                    .font(.system(size: 10, weight: .semibold))
+                    .foregroundColor(theme.color("accent"))
+                if let author = item.author, !author.isEmpty {
+                    Text(author)
+                        .font(.system(size: 10))
+                        .foregroundColor(theme.color("fg-muted"))
+                }
+                if let line = item.anchor.line {
+                    Text("line \(line)")
+                        .font(.system(size: 10))
+                        .foregroundColor(theme.color("fg-faint"))
+                }
+                Spacer(minLength: 0)
+            }
+            .lineLimit(1)
+
+            DiffReviewInlineFeedbackMarkdown.view(item.bodyPreview)
+                .frame(maxHeight: 80, alignment: .top)
+                .clipped()
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+    }
+
+    private func feedbackAccessibilityLabel(for item: DiffReviewInlineFeedback) -> String {
+        [
+            item.providerName,
+            item.author,
+            item.anchor.line.map { "line \($0)" },
+            DiffReviewInlineFeedbackMarkdown.plainText(item.bodyPreview),
+        ]
+        .compactMap { part in
+            guard let part, !part.isEmpty else { return nil }
+            return part
+        }
+        .joined(separator: ", ")
+    }
+
     private func summaryCard(_ comment: ReviewDraftComment) -> some View {
         let availability = draftCommentActions.availability(comment)
         let isFocused = comment.id == focusedDraftCommentID
@@ -654,6 +777,14 @@ private struct CommentGroup: Identifiable {
     let comments: [ReviewDraftComment]
 
     var id: String { path }
+}
+
+private struct FeedbackGroup: Identifiable {
+    let fileID: DiffReviewFileID
+    let items: [DiffReviewInlineFeedback]
+
+    var id: String { fileID.id }
+    var path: String { fileID.path }
 }
 
 private struct ReviewDraftSummaryPressMarker: NSViewRepresentable {

--- a/Alas/Sources/Center/ReviewWorkspace/ReviewDraftSummaryRail.swift
+++ b/Alas/Sources/Center/ReviewWorkspace/ReviewDraftSummaryRail.swift
@@ -79,7 +79,7 @@ struct ReviewDraftSummaryRail: View {
     }
 
     private var hasFeedback: Bool {
-        feedbackGroups.contains { !$0.items.isEmpty }
+        !feedbackGroups.isEmpty
     }
 
     private var canCopyPrompt: Bool {

--- a/Alas/Sources/Center/ReviewWorkspace/ReviewSessionTabView.swift
+++ b/Alas/Sources/Center/ReviewWorkspace/ReviewSessionTabView.swift
@@ -86,6 +86,9 @@ struct ReviewSessionTabView: View {
     @State private var focusedDraftCommentID: String?
     @State private var draftCommentScrollCommand: DiffReviewDraftCommentScrollCommand?
     @State private var draftCommentScrollController = DiffReviewDraftCommentScrollController()
+    @State private var focusedFeedbackID: String?
+    @State private var inlineFeedbackScrollCommand: DiffReviewInlineFeedbackScrollCommand?
+    @State private var inlineFeedbackScrollController = DiffReviewInlineFeedbackScrollController()
     @State private var loadCoordinator = ReviewSessionTabLoadCoordinator()
     @State private var loadGeneration = 0
     @State private var providerPublishConfirmation: ProviderReviewPublishConfirmationState?
@@ -296,7 +299,10 @@ struct ReviewSessionTabView: View {
                 showsDraftSummaryRail: true,
                 lspContextForFile: makeLSPContext,
                 inlineFeedbackByFileID: inlineFeedbackByFileID(for: loaded),
+                focusedFeedbackID: focusedFeedbackID,
+                inlineFeedbackScrollCommand: inlineFeedbackScrollCommand,
                 inlineFeedbackActions: inlineFeedbackActions(for: loaded),
+                onSelectInlineFeedback: selectInlineFeedback,
                 reviewFeedbackTarget: loaded.feedbackTarget,
                 draftCommentsByFileID: ReviewDraftCommentGrouping.commentsByFileID(draftCommentController?.comments ?? []),
                 focusedDraftCommentID: focusedDraftCommentID,
@@ -740,6 +746,15 @@ struct ReviewSessionTabView: View {
         }
     }
 
+    static func fileID(
+        forFeedbackID feedbackID: String,
+        in grouped: [DiffReviewFileID: [DiffReviewInlineFeedback]]
+    ) -> DiffReviewFileID? {
+        grouped.first { _, items in
+            items.contains { $0.id == feedbackID }
+        }?.key
+    }
+
     private func inlineFeedbackActions(for loaded: ReviewSessionLoadedContext) -> DiffReviewInlineFeedbackActions {
         var actions = DiffReviewInlineFeedbackActions()
         actions.availability = { item, _ in
@@ -894,6 +909,18 @@ struct ReviewSessionTabView: View {
         draftCommentScrollCommand = draftCommentScrollController.command(
             commentID: comment.id,
             fileID: comment.fileID
+        )
+    }
+
+    private func selectInlineFeedback(_ item: DiffReviewInlineFeedback) {
+        guard let loaded else { return }
+        let grouped = inlineFeedbackByFileID(for: loaded)
+        guard let fileID = Self.fileID(forFeedbackID: item.id, in: grouped) else { return }
+        focusedFeedbackID = item.id
+        setSelectedFileID(fileID, persist: true)
+        inlineFeedbackScrollCommand = inlineFeedbackScrollController.command(
+            feedbackID: item.id,
+            fileID: fileID
         )
     }
 

--- a/AlasTests/DiffReviewSurfaceTests.swift
+++ b/AlasTests/DiffReviewSurfaceTests.swift
@@ -2291,6 +2291,46 @@ struct DiffReviewSurfaceTests {
         #expect(subview(withAccessibilityIdentifier: "review-summary-feedback-header", in: controller.view) == nil)
     }
 
+    @Test func surfaceForwardsInlineFeedbackToSummaryRail() throws {
+        let file = summary(path: "Sources/App.swift")
+        let session = loadedSession(summaries: [file])
+        let feedback = DiffReviewInlineFeedback(
+            id: "thread-1",
+            providerName: "GitHub",
+            author: "reviewer",
+            bodyPreview: "Please fix this.",
+            status: .actionable,
+            providerURL: nil,
+            anchor: DiffReviewInlineFeedbackAnchor(path: file.path, line: 2, side: .new),
+            evidenceItemID: "thread-1"
+        )
+        var selectedFileID: DiffReviewFileID? = file.id
+        var railCollapsed = false
+        var summaryCollapsed = false
+        var layout = DiffLayoutMode.split
+        var wrap = false
+        var whitespace = false
+
+        let view = DiffReviewSurface(
+            session: session,
+            selectedFileID: Binding(get: { selectedFileID }, set: { selectedFileID = $0 }),
+            railCollapsed: Binding(get: { railCollapsed }, set: { railCollapsed = $0 }),
+            reviewSummaryCollapsed: Binding(get: { summaryCollapsed }, set: { summaryCollapsed = $0 }),
+            layoutMode: Binding(get: { layout }, set: { layout = $0 }),
+            wrapLines: Binding(get: { wrap }, set: { wrap = $0 }),
+            showWhitespace: Binding(get: { whitespace }, set: { whitespace = $0 }),
+            codeFontFamily: "",
+            codeFontSize: 13,
+            showsDraftSummaryRail: true,
+            inlineFeedbackByFileID: [file.id: [feedback]]
+        )
+        .environment(\.theme, theme())
+
+        let controller = host(view, width: 1200, height: 700)
+
+        #expect(subview(withAccessibilityIdentifier: "review-summary-feedback-thread-1", in: controller.view) != nil)
+    }
+
     private func parsedDiff() -> ParsedDiff {
         ParsedDiff(hunks: [
             ParsedDiff.Hunk(

--- a/AlasTests/DiffReviewSurfaceTests.swift
+++ b/AlasTests/DiffReviewSurfaceTests.swift
@@ -2233,6 +2233,64 @@ struct DiffReviewSurfaceTests {
         #expect(DiffReviewInlineFeedbackDisplayPolicy.estimatedCardHeight(for: short) >= DiffReviewInlineFeedbackDisplayPolicy.cardMinimumHeight)
     }
 
+    @Test func summaryRailRendersGitHubFeedbackSection() {
+        let fileID = DiffReviewFileID(namespace: "github", path: "Sources/App.swift")
+        let feedback = DiffReviewInlineFeedback(
+            id: "thread-1",
+            providerName: "GitHub",
+            author: "reviewer",
+            bodyPreview: "Please fix this.",
+            status: .actionable,
+            providerURL: nil,
+            anchor: DiffReviewInlineFeedbackAnchor(path: "Sources/App.swift", line: 2, side: .new),
+            evidenceItemID: "thread-1"
+        )
+        var collapsed = false
+        let view = ReviewDraftSummaryRail(
+            comments: [],
+            bundle: ReviewFeedbackBundle(
+                target: ReviewFeedbackTarget(
+                    title: "PR",
+                    repositoryPath: nil,
+                    providerDescription: nil,
+                    sourceDescription: "Diff review"
+                ),
+                comments: []
+            ),
+            collapsed: Binding(get: { collapsed }, set: { collapsed = $0 }),
+            inlineFeedbackByFileID: [fileID: [feedback]]
+        )
+        .environment(\.theme, theme())
+
+        let controller = host(view, width: 320, height: 500)
+
+        #expect(subview(withAccessibilityIdentifier: "review-summary-feedback-header", in: controller.view) != nil)
+        #expect(subview(withAccessibilityIdentifier: "review-summary-feedback-thread-1", in: controller.view) != nil)
+        #expect(accessibilityLabel(in: controller.view, containing: "Please fix this.") != nil)
+    }
+
+    @Test func summaryRailOmitsGitHubFeedbackSectionWhenEmpty() {
+        var collapsed = false
+        let view = ReviewDraftSummaryRail(
+            comments: [],
+            bundle: ReviewFeedbackBundle(
+                target: ReviewFeedbackTarget(
+                    title: "PR",
+                    repositoryPath: nil,
+                    providerDescription: nil,
+                    sourceDescription: "Diff review"
+                ),
+                comments: []
+            ),
+            collapsed: Binding(get: { collapsed }, set: { collapsed = $0 })
+        )
+        .environment(\.theme, theme())
+
+        let controller = host(view, width: 320, height: 500)
+
+        #expect(subview(withAccessibilityIdentifier: "review-summary-feedback-header", in: controller.view) == nil)
+    }
+
     private func parsedDiff() -> ParsedDiff {
         ParsedDiff(hunks: [
             ParsedDiff.Hunk(

--- a/AlasTests/ReviewSessionTabViewTests.swift
+++ b/AlasTests/ReviewSessionTabViewTests.swift
@@ -1233,6 +1233,84 @@ struct ReviewSessionTabViewTests {
         #expect(description.contains("could not refresh the PR"))
     }
 
+    @Test func fileIDLookupFindsFeedbackOwningFile() {
+        let fileA = DiffReviewFileID(namespace: "github", path: "A.swift")
+        let fileB = DiffReviewFileID(namespace: "github", path: "B.swift")
+        func feedback(_ id: String, path: String) -> DiffReviewInlineFeedback {
+            DiffReviewInlineFeedback(
+                id: id,
+                providerName: "GitHub",
+                author: "reviewer",
+                bodyPreview: "body",
+                status: .actionable,
+                providerURL: nil,
+                anchor: DiffReviewInlineFeedbackAnchor(path: path, line: 1, side: .new),
+                evidenceItemID: id
+            )
+        }
+        let grouped: [DiffReviewFileID: [DiffReviewInlineFeedback]] = [
+            fileA: [feedback("fb-a", path: "A.swift")],
+            fileB: [feedback("fb-b", path: "B.swift")],
+        ]
+
+        #expect(ReviewSessionTabView.fileID(forFeedbackID: "fb-b", in: grouped) == fileB)
+        #expect(ReviewSessionTabView.fileID(forFeedbackID: "missing", in: grouped) == nil)
+    }
+
+    @Test func selectingGitHubFeedbackInRailFocusesItInDiff() throws {
+        let thread = ReviewThreadSummary(
+            id: "thread-1",
+            author: "reviewer",
+            body: "Please fix this.",
+            url: URL(string: "https://github.com/mrmans0n/alas/pull/527#discussion_r1"),
+            isResolved: false,
+            isActionable: true,
+            location: ReviewThreadLocation(path: "Sources/App.swift", originalPath: nil, line: 2, side: .new, providerPosition: nil),
+            providerThreadID: "thread-provider-1",
+            providerCommentID: "comment-provider-1"
+        )
+        let request = Self.reviewRequest(provider: .github, threads: [thread])
+        let target = Self.reviewRequestTarget(provider: .github, request: request)
+        let record = ReviewSessionRecord(
+            id: target.id,
+            target: target,
+            createdAt: Date(timeIntervalSince1970: 1),
+            updatedAt: Date(timeIntervalSince1970: 1)
+        )
+        let loaded = Self.loadedReviewRequestContext(provider: .github, request: request)
+        let view = ReviewSessionTabView.testView(
+            record: record,
+            loaded: loaded,
+            provider: RecordingProviderReviewMutator(
+                kind: .github,
+                publishResult: ProviderReviewPublishResult(
+                    published: [],
+                    failed: [],
+                    refreshedRequest: request,
+                    warnings: []
+                )
+            )
+        )
+        .environment(\.theme, try ThemeStore().current)
+
+        let host = NSHostingView(rootView: view.frame(width: 1200, height: 720))
+        host.layoutSubtreeIfNeeded()
+
+        #expect(subview(withAccessibilityIdentifier: "review-summary-feedback-thread-1", in: host) != nil)
+        #expect(subview(withAccessibilityIdentifier: "diff-review-inline-feedback-focused-thread-1", in: host) == nil)
+
+        #expect(pressAccessibilityElement(withAccessibilityIdentifier: "review-summary-feedback-thread-1", in: host))
+
+        let deadline = Date().addingTimeInterval(1)
+        while subview(withAccessibilityIdentifier: "diff-review-inline-feedback-focused-thread-1", in: host) == nil,
+              Date() < deadline {
+            RunLoop.current.run(until: Date().addingTimeInterval(0.01))
+            host.layoutSubtreeIfNeeded()
+        }
+
+        #expect(subview(withAccessibilityIdentifier: "diff-review-inline-feedback-focused-thread-1", in: host) != nil)
+    }
+
     @Test func providerFeedbackMatcherPrefersExactOldSidePathWhenOriginalPathIsMissing() {
         let modified = DiffReviewFileSummary(
             path: "Sources/App.swift",


### PR DESCRIPTION
## What & why

In the inspect pane, the review summary rail only aggregated **our own draft comments**. GitHub feedback from other reviewers rendered inline in the diff but wasn't listed in the rail, and clicking it did nothing — because `ReviewSessionTabView` never wired the inline-feedback selection callback into `DiffReviewSurface`. This makes the rail a single at-a-glance list of *all* feedback, ours and others', with click-to-scroll for every item.

## Changes

- **`ReviewDraftSummaryRail`** — adds a read-only **"GitHub feedback"** section below "Draft review", grouped by file, same card visual language. Cards are navigation-only (no action row; Open/Copy/Reply/Resolve stay on the inline diff cards). Section is hidden when there's no feedback.
- **`DiffReviewSurface`** — forwards its existing inline-feedback inputs (`inlineFeedbackByFileID`, `focusedFeedbackID`, `onSelectInlineFeedback`) into the rail. Purely additive — other surfaces that pass no inline feedback are unchanged.
- **`ReviewSessionTabView`** — wires selection end-to-end: in-memory `focusedFeedbackID`, a scroll command, and a `selectInlineFeedback` handler mirroring the existing `selectDraftComment` (focus + select file + scroll). This is the actual fix.

`focusedFeedbackID` is intentionally in-memory `@State` only (not persisted, unlike `focusedDraftCommentID`).

## Tests

- `ReviewDraftSummaryRail`: renders the GitHub section grouped by file; omits it when empty.
- `DiffReviewSurface`: forwards inline feedback into the rail.
- `ReviewSessionTabView`: unit test for the feedback→file lookup; end-to-end test that presses a rail feedback card and asserts the diff's focus marker appears.

101 tests pass across `ReviewSessionTabViewTests` + `DiffReviewSurfaceTests`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
