### PR TITLE
feat(changes): Add changed-file HEAD snapshot and history actions

### DIFF
--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -21,6 +21,7 @@
 		02B055E21896C1C14D2D980D /* SectionHeader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 934BCC470703CF2DF2303357 /* SectionHeader.swift */; };
 		02D2512D2B9128E93C7DF6D5 /* NewProjectDialog.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC6599EB47850D1E13ACF0EB /* NewProjectDialog.swift */; };
 		02DF9E0F3A3C1BE39026AF28 /* DraftReviewRequestTabView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 79624D3718BCE5CC605F0D6D /* DraftReviewRequestTabView.swift */; };
+		0312A898BD7777ABD4B2D14F /* ReadonlyTextView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6F4D0EAA4C7CB45617BDD3FE /* ReadonlyTextView.swift */; };
 		03F3504B261E9E6C79C80DD5 /* TreeSitterHCL in Frameworks */ = {isa = PBXBuildFile; productRef = E5B5088DE61D8706D3F358F9 /* TreeSitterHCL */; };
 		0407824F9DA8EEFC5B5EEA8A /* InstallerHost.swift in Sources */ = {isa = PBXBuildFile; fileRef = C506EF972D34E2F937D4FEEC /* InstallerHost.swift */; };
 		043D6A4860C1336134311DD3 /* tool-call-content-terminal.json in Resources */ = {isa = PBXBuildFile; fileRef = D60051A6C7BEE35773F3FBB9 /* tool-call-content-terminal.json */; };
@@ -453,6 +454,7 @@
 		6A5D19016FE0100CD54D24B2 /* MarkdownImageLoaderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0D0ED01C390D1F729993B13 /* MarkdownImageLoaderTests.swift */; };
 		6A639AFB741004AA32C9D81A /* TabActivityPulseTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7DD2CA21EC45168D6E43564 /* TabActivityPulseTests.swift */; };
 		6AA812880B9E28C4AE9A6BFC /* GitHubCLIProviderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8C28D64372B5B4C734A92533 /* GitHubCLIProviderTests.swift */; };
+		6AB631ACAD28A187F15282AB /* FileSnapshotTabView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D28AEE8E4821977FDAF13960 /* FileSnapshotTabView.swift */; };
 		6AD85D472EF03EAE992D65D0 /* session-new-response.json in Resources */ = {isa = PBXBuildFile; fileRef = E7C070765F0474DF1C4ACEF0 /* session-new-response.json */; };
 		6AE129E340CA74CC26B34B66 /* ACPMarkdownLiveStyler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2AE565966DD010FDFD7DFF50 /* ACPMarkdownLiveStyler.swift */; };
 		6AFE04B669CA654D7733F97E /* AlasCLICommandRouter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1271747193D1594AEA596278 /* AlasCLICommandRouter.swift */; };
@@ -1594,6 +1596,7 @@
 		6E8FA892877AE2FDBCD4C747 /* ShortcutResolverTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShortcutResolverTests.swift; sourceTree = "<group>"; };
 		6EB58175A9A39073E9D73F85 /* GitIgnoreServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GitIgnoreServiceTests.swift; sourceTree = "<group>"; };
 		6F0AE27D70E34430C71AAF84 /* ProviderReviewMutationController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProviderReviewMutationController.swift; sourceTree = "<group>"; };
+		6F4D0EAA4C7CB45617BDD3FE /* ReadonlyTextView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReadonlyTextView.swift; sourceTree = "<group>"; };
 		6FF766C79A3F9F004A513D4D /* UpdateProgressSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UpdateProgressSheet.swift; sourceTree = "<group>"; };
 		6FFE12732C0D83715FC990A9 /* CommitsSectionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommitsSectionView.swift; sourceTree = "<group>"; };
 		7018E992654E19345D8BD723 /* ImageDiffSwipeViewTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageDiffSwipeViewTests.swift; sourceTree = "<group>"; };
@@ -1995,6 +1998,7 @@
 		D1CD33324CA36118FCEA2BE2 /* AdvancedSettingsVisibilityTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AdvancedSettingsVisibilityTests.swift; sourceTree = "<group>"; };
 		D1EACA79C819C9FBE68F9D84 /* RemoteServer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteServer.swift; sourceTree = "<group>"; };
 		D21F30DB5A812E396262A926 /* ACPMessageWire.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPMessageWire.swift; sourceTree = "<group>"; };
+		D28AEE8E4821977FDAF13960 /* FileSnapshotTabView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileSnapshotTabView.swift; sourceTree = "<group>"; };
 		D2935EB661338757C478CD86 /* SurfaceViewShortcutTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SurfaceViewShortcutTests.swift; sourceTree = "<group>"; };
 		D2AD81E0DFE33CE4DACF0ADF /* WorktreeWatcher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorktreeWatcher.swift; sourceTree = "<group>"; };
 		D2F90D03073708AA01531533 /* GitService+Staging.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "GitService+Staging.swift"; sourceTree = "<group>"; };
@@ -3190,6 +3194,7 @@
 				F15E14D45EC3926768DE5BD1 /* DiffTabView.swift */,
 				6E8B52175A7F6144B4C52010 /* EditorTabView.swift */,
 				008E982C8526670670425AB8 /* EmptyTabView.swift */,
+				D28AEE8E4821977FDAF13960 /* FileSnapshotTabView.swift */,
 				6B3F942D660C7ABA8542C77D /* ImageFileType.swift */,
 				12E1AD3C6506DA5E6BFF4864 /* ImagePreviewTabView.swift */,
 				90D74C28EB7B8C3CBC53994D /* MergeAgent.swift */,
@@ -3204,6 +3209,7 @@
 				5BAC89A6B9D5DC926AC18E13 /* MergeConflictTabView.swift */,
 				EBBFE202A6AB6F0EFB46EB5D /* MergeConflictTextStorage.swift */,
 				91B5694DB75F80C8D7B51E82 /* MergeConflictToolbar.swift */,
+				6F4D0EAA4C7CB45617BDD3FE /* ReadonlyTextView.swift */,
 				B27595490B7D883CF5D9FFD5 /* Tab.swift */,
 				8CFED7F76987C01213CB68A9 /* TabActivityPulse.swift */,
 				BEC7CCBF8463A95EAAE9EBCE /* TabBarView.swift */,
@@ -4681,6 +4687,7 @@
 				E29D10B84F406C38E2F4C457 /* FileResultRow.swift in Sources */,
 				1339BE8F736D53991DDD19CD /* FileSearchBackend.swift in Sources */,
 				DEBB0627BD0426369D18CAD4 /* FileSearchDialog.swift in Sources */,
+				6AB631ACAD28A187F15282AB /* FileSnapshotTabView.swift in Sources */,
 				4B2031FB61782327D5279F98 /* FileTreeBuilder.swift in Sources */,
 				64ADA6AFE69C52F121A163E1 /* FileTypeIconView.swift in Sources */,
 				9782C5866410EFE13E670AFF /* FilesTabView.swift in Sources */,
@@ -4833,6 +4840,7 @@
 				E3D59DB020583EF3E0EB7171 /* ProviderReviewPublishConfirmationView.swift in Sources */,
 				0FE1A3CCEB283E8780F52076 /* QueuedPrompt.swift in Sources */,
 				0657FD1930271CA4C1F698DD /* RangeReviewLoader.swift in Sources */,
+				0312A898BD7777ABD4B2D14F /* ReadonlyTextView.swift in Sources */,
 				3AC6DD00AD2D19FB3A0CCD03 /* RecommendedLanguageCatalog.swift in Sources */,
 				0D8046E333B0DA2B45EE78D4 /* RelativeTime.swift in Sources */,
 				5FA0FC131F06178797420608 /* ReleaseChecker.swift in Sources */,

--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -978,6 +978,7 @@
 		E0AA2F46C6E53C547FEB6495 /* ClaudeCodeACPInstallerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4B2FAABB50C8BE2321A1B1DD /* ClaudeCodeACPInstallerTests.swift */; };
 		E0F4EFE612252BDD7F999A70 /* ReviewFeedbackAgentSender.swift in Sources */ = {isa = PBXBuildFile; fileRef = 56E964C72322223859CC6AF8 /* ReviewFeedbackAgentSender.swift */; };
 		E175AE346DFAD0B62827C921 /* ProjectPicker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3CE948F94DB2759E66CD4DEF /* ProjectPicker.swift */; };
+		E1D9EF82D0A80D3E2036CAD6 /* FileHistoryTabView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A526016296D5A07C2422BC19 /* FileHistoryTabView.swift */; };
 		E1DA1C6BF9D5E157DAF6EE00 /* ClaudeInstallerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6016A3CF87F34222C533D350 /* ClaudeInstallerTests.swift */; };
 		E1E4C11CC5BFF761DF397507 /* ACPToolCallContentTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 54897710493742A6DFD6ABF3 /* ACPToolCallContentTests.swift */; };
 		E1EEC0425D8F30D85CDB35EE /* UpdateAvailableSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CC074B85082A8BB30EEAFA5 /* UpdateAvailableSheet.swift */; };
@@ -1794,6 +1795,7 @@
 		A42BB90D7C9A270876F470EB /* FocusDirectionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FocusDirectionTests.swift; sourceTree = "<group>"; };
 		A47981117B0CDB5F71DECD64 /* ACPComposerDraft.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPComposerDraft.swift; sourceTree = "<group>"; };
 		A5069EF396F2CB8E81B2AD11 /* ACPTranscriptMarkdownTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPTranscriptMarkdownTests.swift; sourceTree = "<group>"; };
+		A526016296D5A07C2422BC19 /* FileHistoryTabView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileHistoryTabView.swift; sourceTree = "<group>"; };
 		A52FE6A88564AD523AC577CC /* CodeTextViewMultiCursorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CodeTextViewMultiCursorTests.swift; sourceTree = "<group>"; };
 		A53358B7D4D68BE2471187D4 /* ACPImageStagingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPImageStagingTests.swift; sourceTree = "<group>"; };
 		A5848B9AAD7985BF7BFB87F6 /* MergeConflictAnnotationStrip.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MergeConflictAnnotationStrip.swift; sourceTree = "<group>"; };
@@ -3194,6 +3196,7 @@
 				F15E14D45EC3926768DE5BD1 /* DiffTabView.swift */,
 				6E8B52175A7F6144B4C52010 /* EditorTabView.swift */,
 				008E982C8526670670425AB8 /* EmptyTabView.swift */,
+				A526016296D5A07C2422BC19 /* FileHistoryTabView.swift */,
 				D28AEE8E4821977FDAF13960 /* FileSnapshotTabView.swift */,
 				6B3F942D660C7ABA8542C77D /* ImageFileType.swift */,
 				12E1AD3C6506DA5E6BFF4864 /* ImagePreviewTabView.swift */,
@@ -4683,6 +4686,7 @@
 				950C937884477417569DC20B /* EmptyTabView.swift in Sources */,
 				7A0D3E122F34EF1A2A04984F /* EnvBuilder.swift in Sources */,
 				58A58A64E7E10EC5A1CC60C5 /* FileDeviceStore.swift in Sources */,
+				E1D9EF82D0A80D3E2036CAD6 /* FileHistoryTabView.swift in Sources */,
 				3B82344338BD29F6B8B6D8EC /* FileIndex.swift in Sources */,
 				E29D10B84F406C38E2F4C457 /* FileResultRow.swift in Sources */,
 				1339BE8F736D53991DDD19CD /* FileSearchBackend.swift in Sources */,

--- a/Alas/Sources/App/AppState.swift
+++ b/Alas/Sources/App/AppState.swift
@@ -3587,24 +3587,44 @@ final class AppState {
         tabs.append(acpSession: state, to: worktree.id)
     }
 
-    /// Open a diff tab for the given worktree-relative path.
-    /// Reuses an existing unstaged diff tab for the same path if one is already open.
-    func openDiffTab(forFileInWorktree worktree: Worktree, relativePath: String) {
+    /// Open a diff tab for the given worktree-relative path and comparison mode.
+    /// Reuses an existing matching diff tab for the same path if one is already open.
+    func openDiffTab(
+        forFileInWorktree worktree: Worktree,
+        relativePath: String,
+        staged: Bool = false,
+        originalPath: String? = nil,
+        compareWithHEAD: Bool = false
+    ) {
         let worktreeId = worktree.id
-        let staged = false
         let existing = tabs.tabs(forWorktree: worktreeId).first { tab in
-            if case .diff(let s) = tab { return s.relativePath == relativePath && s.staged == staged }
+            if case .diff(let s) = tab {
+                return s.relativePath == relativePath
+                    && s.staged == staged
+                    && s.originalPath == originalPath
+                    && s.compareWithHEAD == compareWithHEAD
+            }
             return false
         }
         if let existing {
             tabs.activate(worktreeId: worktreeId, tabId: existing.id)
         } else {
-            let title = (relativePath as NSString).lastPathComponent
+            let basename = (relativePath as NSString).lastPathComponent
+            let title: String
+            if compareWithHEAD {
+                title = "\(basename) vs HEAD"
+            } else if staged {
+                title = "\(basename) (staged)"
+            } else {
+                title = basename
+            }
             let tab = tabs.appendDiff(
                 worktreeId: worktreeId,
                 title: title,
                 relativePath: relativePath,
-                staged: staged
+                staged: staged,
+                originalPath: originalPath,
+                compareWithHEAD: compareWithHEAD
             )
             tabs.activate(worktreeId: worktreeId, tabId: tab.id)
         }
@@ -3627,6 +3647,26 @@ final class AppState {
             let tab = tabs.appendCommit(worktreeId: worktree.id, sha: commit.sha, title: title)
             tabs.activate(worktreeId: worktree.id, tabId: tab.id)
         }
+    }
+
+    func openFileSnapshotAtHEAD(relativePath: String, worktreeId: String) {
+        guard let worktree = worktree(withId: worktreeId) else { return }
+        guard !projectsManager.isWorktreeHidden(projectId: worktree.projectId, path: worktree.path) else { return }
+        if selectedWorktreeId != worktree.id {
+            focusGlobalWorktree(id: worktree.id, projectId: worktree.projectId)
+        }
+        let tab = tabs.openOrFocusFileSnapshot(worktreeId: worktree.id, relativePath: relativePath, ref: "HEAD")
+        tabs.activate(worktreeId: worktree.id, tabId: tab.id)
+    }
+
+    func openFileHistory(relativePath: String, worktreeId: String) {
+        guard let worktree = worktree(withId: worktreeId) else { return }
+        guard !projectsManager.isWorktreeHidden(projectId: worktree.projectId, path: worktree.path) else { return }
+        if selectedWorktreeId != worktree.id {
+            focusGlobalWorktree(id: worktree.id, projectId: worktree.projectId)
+        }
+        let tab = tabs.openOrFocusFileHistory(worktreeId: worktree.id, relativePath: relativePath)
+        tabs.activate(worktreeId: worktree.id, tabId: tab.id)
     }
 }
 

--- a/Alas/Sources/App/AppState.swift
+++ b/Alas/Sources/App/AppState.swift
@@ -3609,6 +3609,25 @@ final class AppState {
             tabs.activate(worktreeId: worktreeId, tabId: tab.id)
         }
     }
+
+    func openCommitTab(worktreeId: String, commit: CommitInfo) {
+        guard let worktree = worktree(withId: worktreeId) else { return }
+        if selectedWorktreeId != worktree.id {
+            focusGlobalWorktree(id: worktree.id, projectId: worktree.projectId)
+        }
+
+        let existing = tabs.tabs(forWorktree: worktree.id).first { tab in
+            if case .commit(let state) = tab { return state.sha == commit.sha }
+            return false
+        }
+        if let existing {
+            tabs.activate(worktreeId: worktree.id, tabId: existing.id)
+        } else {
+            let title = "\(commit.shortSha) \(commit.conventionalTag.map { "\($0): \(commit.subject)" } ?? commit.subject)"
+            let tab = tabs.appendCommit(worktreeId: worktree.id, sha: commit.sha, title: title)
+            tabs.activate(worktreeId: worktree.id, tabId: tab.id)
+        }
+    }
 }
 
 // MARK: - RemoteSessionsProvider

--- a/Alas/Sources/App/RootView.swift
+++ b/Alas/Sources/App/RootView.swift
@@ -80,7 +80,12 @@ struct RootView: View {
                                     state: state,
                                     worktree: wt,
                                     onSelectChangedFile: { file in
-                                        openOrFocusDiff(worktree: wt, path: file.path, staged: file.stage == .staged)
+                                        openOrFocusDiff(
+                                            worktree: wt,
+                                            path: file.path,
+                                            staged: file.stage == .staged,
+                                            originalPath: file.renameFrom
+                                        )
                                     },
                                     onSelectTreeFile: { node in
                                         openOrFocusEditor(worktree: wt, path: node.path)
@@ -290,29 +295,19 @@ struct RootView: View {
         return nil
     }
 
-    private func openOrFocusDiff(worktree: Worktree, path: String, staged: Bool) {
+    private func openOrFocusDiff(worktree: Worktree, path: String, staged: Bool, originalPath: String?) {
         if ImageFileType.isSupported(relativePath: path) {
             state.openFile(relativePath: path, worktreeId: worktree.id)
             return
         }
 
-        let existing = state.tabs.tabs(forWorktree: worktree.id).first { tab in
-            if case .diff(let s) = tab { return s.relativePath == path && s.staged == staged } else { return false }
-        }
-        if let existing {
-            state.tabs.activate(worktreeId: worktree.id, tabId: existing.id)
-        } else {
-            let title = staged
-                ? "\((path as NSString).lastPathComponent) (staged)"
-                : (path as NSString).lastPathComponent
-            let tab = state.tabs.appendDiff(
-                worktreeId: worktree.id,
-                title: title,
-                relativePath: path,
-                staged: staged
-            )
-            state.tabs.activate(worktreeId: worktree.id, tabId: tab.id)
-        }
+        state.openDiffTab(
+            forFileInWorktree: worktree,
+            relativePath: path,
+            staged: staged,
+            originalPath: originalPath,
+            compareWithHEAD: false
+        )
     }
 
     private func openOrFocusEditor(worktree: Worktree, path: String) {

--- a/Alas/Sources/Center/CenterPaneView.swift
+++ b/Alas/Sources/Center/CenterPaneView.swift
@@ -268,6 +268,8 @@ struct CenterPaneView: View {
                             tabState: s
                         )
                         .id(s.id)
+                    case .fileSnapshot, .fileHistory:
+                        EmptyView()
                     case .acpSession(let s):
                         ACPTabView(sessionId: s.sessionId, state: state, worktree: worktree)
                             .id(s.id)

--- a/Alas/Sources/Center/CenterPaneView.swift
+++ b/Alas/Sources/Center/CenterPaneView.swift
@@ -178,6 +178,8 @@ struct CenterPaneView: View {
                             worktreePath: worktree.path,
                             relativePath: s.relativePath,
                             staged: s.staged,
+                            originalPath: s.originalPath,
+                            compareWithHEAD: s.compareWithHEAD,
                             worktreeId: worktree.id,
                             appState: state,
                             codeFontFamily: state.config.code.fontFamily,

--- a/Alas/Sources/Center/CenterPaneView.swift
+++ b/Alas/Sources/Center/CenterPaneView.swift
@@ -268,7 +268,14 @@ struct CenterPaneView: View {
                             tabState: s
                         )
                         .id(s.id)
-                    case .fileSnapshot, .fileHistory:
+                    case .fileSnapshot(let s):
+                        FileSnapshotTabView(
+                            worktreePath: worktree.path,
+                            state: s,
+                            codeFontFamily: state.config.code.fontFamily,
+                            codeFontSize: CGFloat(state.config.code.fontSize)
+                        )
+                    case .fileHistory:
                         EmptyView()
                     case .acpSession(let s):
                         ACPTabView(sessionId: s.sessionId, state: state, worktree: worktree)

--- a/Alas/Sources/Center/CenterPaneView.swift
+++ b/Alas/Sources/Center/CenterPaneView.swift
@@ -275,8 +275,13 @@ struct CenterPaneView: View {
                             codeFontFamily: state.config.code.fontFamily,
                             codeFontSize: CGFloat(state.config.code.fontSize)
                         )
-                    case .fileHistory:
-                        EmptyView()
+                    case .fileHistory(let s):
+                        FileHistoryTabView(
+                            worktreePath: worktree.path,
+                            state: s,
+                            onSelectCommit: { state.openCommitTab(worktreeId: worktree.id, commit: $0) },
+                            onCopySHA: { Clipboard.copy($0.sha) }
+                        )
                     case .acpSession(let s):
                         ACPTabView(sessionId: s.sessionId, state: state, worktree: worktree)
                             .id(s.id)

--- a/Alas/Sources/Center/DiffTabView.swift
+++ b/Alas/Sources/Center/DiffTabView.swift
@@ -17,6 +17,8 @@ struct DiffTabView: View {
     let worktreePath: URL
     let relativePath: String
     let staged: Bool
+    let originalPath: String?
+    let compareWithHEAD: Bool
     let worktreeId: String
     let appState: AppState
     var codeFontFamily: String = ""
@@ -82,18 +84,27 @@ struct DiffTabView: View {
     }
 
     private var imageLoadKey: String {
-        "img:\(worktreePath.path)\u{0}\(relativePath)\u{0}\(staged)"
+        "img:\(worktreePath.path)\u{0}\(relativePath)\u{0}\(staged)\u{0}\(originalPath ?? "")\u{0}\(compareWithHEAD)"
     }
 
     private func loadImagePair() async {
         imagePairLoaded = false
         imagePair = nil
         do {
-            let pair = try await git.imageDiffPair(
-                worktreePath: worktreePath,
-                relativePath: relativePath,
-                staged: staged
-            )
+            let pair: ImageDiffPair
+            if compareWithHEAD {
+                pair = try await git.imageDiffPairAgainstHEAD(
+                    worktreePath: worktreePath,
+                    relativePath: relativePath,
+                    originalPath: originalPath
+                )
+            } else {
+                pair = try await git.imageDiffPair(
+                    worktreePath: worktreePath,
+                    relativePath: relativePath,
+                    staged: staged
+                )
+            }
             guard !Task.isCancelled else { return }
             imagePair = pair
         } catch {
@@ -158,7 +169,7 @@ struct DiffTabView: View {
     }
 
     private var loadKey: String {
-        "\(worktreePath.path)\u{0}\(relativePath)\u{0}\(staged)"
+        "\(worktreePath.path)\u{0}\(relativePath)\u{0}\(staged)\u{0}\(originalPath ?? "")\u{0}\(compareWithHEAD)"
     }
 
     private var diffPreferences: DiffPreferenceBindings {
@@ -228,7 +239,14 @@ struct DiffTabView: View {
             Text((relativePath as NSString).lastPathComponent)
                 .font(CenterTypography.codeFont(family: codeFontFamily, size: codeFontSize))
                 .foregroundColor(theme.color("fg"))
-            if staged {
+            if compareWithHEAD {
+                Text("HEAD")
+                    .font(.system(size: 9.5, weight: .semibold))
+                    .padding(.horizontal, 5).padding(.vertical, 1)
+                    .background(theme.color("accent").opacity(0.16))
+                    .foregroundColor(theme.color("accent"))
+                    .clipShape(RoundedRectangle(cornerRadius: 3))
+            } else if staged {
                 Text("STAGED")
                     .font(.system(size: 9.5, weight: .semibold))
                     .padding(.horizontal, 5).padding(.vertical, 1)
@@ -252,7 +270,7 @@ struct DiffTabView: View {
                 if let onOpenFile {
                     AlasButton(title: "Open File", style: .subtle, action: onOpenFile)
                 }
-                if let onRequestDiscardFile {
+                if let onRequestDiscardFile, !compareWithHEAD {
                     AlasButton(title: "Discard Changes...", style: .subtle, action: onRequestDiscardFile)
                 }
             }
@@ -276,7 +294,21 @@ struct DiffTabView: View {
         clearPendingDraft()
 
         do {
-            let loadedDiff = try await git.diff(worktreePath: worktreePath, file: relativePath, staged: staged)
+            let loadedDiff: ParsedDiff
+            if compareWithHEAD {
+                loadedDiff = try await git.diffAgainstHEAD(
+                    worktreePath: worktreePath,
+                    file: relativePath,
+                    originalPath: originalPath
+                )
+            } else {
+                loadedDiff = try await git.diff(
+                    worktreePath: worktreePath,
+                    file: relativePath,
+                    staged: staged,
+                    originalPath: originalPath
+                )
+            }
             guard isActiveLoad(requestedLoadToken) else { return }
 
             let loadedDisplayModel = await Task.detached(priority: .userInitiated) {
@@ -372,6 +404,7 @@ struct DiffTabView: View {
     }
 
     private func stagedHunkActions(hunk: ParsedDiff.Hunk) -> (stage: (() -> Void)?, discard: (() -> Void)?) {
+        if compareWithHEAD { return (nil, nil) }
         // Staged view: no per-hunk actions for now (out of scope).
         if staged { return (nil, nil) }
         // Unstaged tracked, file exists: stage + discard.
@@ -423,7 +456,8 @@ struct DiffTabView: View {
     // MARK: - Local review
 
     private var fileID: DiffReviewFileID {
-        DiffReviewFileID(namespace: staged ? "staged" : "unstaged", path: relativePath)
+        let namespace = compareWithHEAD ? "head" : (staged ? "staged" : "unstaged")
+        return DiffReviewFileID(namespace: namespace, path: relativePath)
     }
 
     private var draftSessionID: ReviewDraftSessionID {
@@ -439,14 +473,16 @@ struct DiffTabView: View {
             title: (relativePath as NSString).lastPathComponent,
             repositoryPath: worktreePath.path,
             providerDescription: nil,
-            sourceDescription: staged ? "Staged changes" : "Unstaged changes"
+            sourceDescription: compareWithHEAD
+                ? "Changes since HEAD"
+                : staged ? "Staged changes" : "Unstaged changes"
         )
     }
 
     private var fileSummary: DiffReviewFileSummary {
         DiffReviewFileSummary(
             path: relativePath,
-            namespace: staged ? "staged" : "unstaged",
+            namespace: compareWithHEAD ? "head" : (staged ? "staged" : "unstaged"),
             groupID: nil,
             groupTitle: nil,
             status: .modified,

--- a/Alas/Sources/Center/FileHistoryTabView.swift
+++ b/Alas/Sources/Center/FileHistoryTabView.swift
@@ -1,0 +1,128 @@
+import SwiftUI
+
+struct FileHistoryTabView: View {
+    let worktreePath: URL
+    let state: FileHistoryTabState
+    let onSelectCommit: (CommitInfo) -> Void
+    let onCopySHA: (CommitInfo) -> Void
+
+    @Environment(\.theme) private var theme
+    @State private var commits: [CommitInfo] = []
+    @State private var loaded = false
+    @State private var error: String?
+    private let git = GitService()
+
+    var body: some View {
+        VStack(spacing: 0) {
+            header
+            content
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
+        .background(theme.color("bg-1"))
+        .task(id: loadKey) { await load() }
+    }
+
+    private var loadKey: String {
+        "\(worktreePath.path)\u{0}\(state.relativePath)"
+    }
+
+    private var header: some View {
+        HStack(spacing: 10) {
+            Text((state.relativePath as NSString).lastPathComponent)
+                .font(.system(size: 13, weight: .semibold))
+                .foregroundColor(theme.color("fg"))
+
+            Text("History")
+                .font(.system(size: 9.5, weight: .semibold))
+                .padding(.horizontal, 5)
+                .padding(.vertical, 1)
+                .background(theme.color("accent").opacity(0.14))
+                .foregroundColor(theme.color("accent"))
+                .clipShape(RoundedRectangle(cornerRadius: 3))
+
+            if !directoryPath.isEmpty {
+                Text("·")
+                    .foregroundColor(theme.color("fg-faint"))
+                Text(directoryPath)
+                    .font(.system(size: 11))
+                    .foregroundColor(theme.color("fg-dim"))
+                    .lineLimit(1)
+                    .truncationMode(.middle)
+            }
+
+            Spacer()
+        }
+        .padding(.horizontal, 16)
+        .padding(.vertical, 10)
+        .background(theme.color("bg-2"))
+    }
+
+    private var directoryPath: String {
+        (state.relativePath as NSString).deletingLastPathComponent
+    }
+
+    @ViewBuilder
+    private var content: some View {
+        if let error {
+            VStack(spacing: 8) {
+                Text("Could not load file history")
+                    .font(.system(size: 13, weight: .semibold))
+                    .foregroundColor(theme.color("del"))
+                Text(error)
+                    .font(.system(size: 11))
+                    .foregroundColor(theme.color("fg-dim"))
+                    .multilineTextAlignment(.center)
+                    .lineLimit(4)
+                AlasButton(title: "Retry", style: .subtle) {
+                    Task { await load() }
+                }
+            }
+            .padding(24)
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
+        } else if !loaded {
+            Spinner()
+                .frame(width: 20, height: 20)
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
+        } else if commits.isEmpty {
+            Text("No committed history for \(state.relativePath)")
+                .font(.system(size: 13))
+                .foregroundColor(theme.color("fg-dim"))
+                .padding()
+                .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
+        } else {
+            ScrollView {
+                LazyVStack(spacing: 0) {
+                    ForEach(Array(commits.enumerated()), id: \.element.id) { index, commit in
+                        CommitRow(
+                            commit: commit,
+                            isLast: index == commits.count - 1,
+                            onSelect: { onSelectCommit(commit) },
+                            onCopySHA: { onCopySHA(commit) }
+                        )
+                    }
+                }
+                .padding(.top, 10)
+            }
+        }
+    }
+
+    private func load() async {
+        loaded = false
+        error = nil
+        do {
+            let history = try await git.fileHistory(
+                worktreePath: worktreePath,
+                relativePath: state.relativePath,
+                limit: 200
+            )
+            guard !Task.isCancelled else { return }
+            commits = history
+            loaded = true
+        } catch {
+            guard !Task.isCancelled else { return }
+            commits = []
+            self.error = (error as NSError).localizedDescription
+            loaded = true
+        }
+    }
+}

--- a/Alas/Sources/Center/FileSnapshotTabView.swift
+++ b/Alas/Sources/Center/FileSnapshotTabView.swift
@@ -1,0 +1,106 @@
+import AppKit
+import SwiftUI
+
+struct FileSnapshotTabView: View {
+    let worktreePath: URL
+    let state: FileSnapshotTabState
+    var codeFontFamily: String = ""
+    var codeFontSize: CGFloat = 13
+
+    @Environment(\.theme) private var theme
+    @State private var result: HeadBlobTextResult?
+    @State private var error: String?
+    private let git = GitService()
+
+    var body: some View {
+        VStack(spacing: 0) {
+            header
+            content
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
+        .background(theme.color("bg-1"))
+        .task(id: loadKey) { await load() }
+    }
+
+    private var loadKey: String { "\(worktreePath.path)\u{0}\(state.ref)\u{0}\(state.relativePath)" }
+
+    private var header: some View {
+        HStack(spacing: 12) {
+            Text((state.relativePath as NSString).lastPathComponent)
+                .font(CenterTypography.codeFont(family: codeFontFamily, size: codeFontSize))
+                .foregroundColor(theme.color("fg"))
+
+            Text(state.ref)
+                .font(.system(size: 9.5, weight: .semibold))
+                .padding(.horizontal, 5)
+                .padding(.vertical, 1)
+                .background(theme.color("info").opacity(0.18))
+                .foregroundColor(theme.color("info"))
+                .clipShape(RoundedRectangle(cornerRadius: 3))
+
+            Text("·")
+                .foregroundColor(theme.color("fg-faint"))
+
+            Text((state.relativePath as NSString).deletingLastPathComponent)
+                .font(.system(size: codeFontSize - 1.5))
+                .foregroundColor(theme.color("fg-dim"))
+
+            Spacer()
+        }
+        .padding(.horizontal, 16)
+        .padding(.vertical, 10)
+        .background(theme.color("bg-2"))
+    }
+
+    @ViewBuilder
+    private var content: some View {
+        if let error {
+            Text(error)
+                .font(CenterTypography.codeFont(family: codeFontFamily, size: codeFontSize - 2))
+                .foregroundColor(theme.color("del"))
+                .padding()
+        } else if let result {
+            switch result {
+            case .available(let text):
+                ReadonlyTextView(
+                    text: text,
+                    font: CenterTypography.resolveCodeFont(family: codeFontFamily, size: codeFontSize),
+                    textColor: NSColor(theme.color("fg")),
+                    backgroundColor: .clear
+                )
+            case .missing:
+                emptyText("No HEAD version for \(state.relativePath)")
+            case .undisplayable:
+                emptyText("HEAD version is not displayable as text")
+            }
+        } else {
+            Spinner()
+                .frame(width: 16, height: 16)
+                .padding()
+        }
+    }
+
+    private func emptyText(_ text: String) -> some View {
+        Text(text)
+            .font(CenterTypography.codeFont(family: codeFontFamily, size: codeFontSize - 1))
+            .foregroundColor(theme.color("fg-dim"))
+            .padding()
+            .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
+    }
+
+    private func load() async {
+        result = nil
+        error = nil
+        do {
+            let loaded = try await git.headBlobText(
+                worktreePath: worktreePath,
+                relativePath: state.relativePath
+            )
+            guard !Task.isCancelled else { return }
+            result = loaded
+        } catch {
+            guard !Task.isCancelled else { return }
+            self.error = error.localizedDescription
+        }
+    }
+}

--- a/Alas/Sources/Center/ImageDiff/GitService+ImageDiff.swift
+++ b/Alas/Sources/Center/ImageDiff/GitService+ImageDiff.swift
@@ -146,6 +146,44 @@ extension GitService {
         )
     }
 
+    func imageDiffPairAgainstHEAD(
+        worktreePath: URL,
+        relativePath: String,
+        originalPath: String? = nil
+    ) async throws -> ImageDiffPair {
+        let headPath = originalPath ?? relativePath
+        let fileURL = worktreePath.appendingPathComponent(relativePath)
+        let fileExistsOnDisk = FileManager.default.fileExists(atPath: fileURL.path)
+
+        let before = try await loadBlobImage(
+            worktreePath: worktreePath,
+            ref: "HEAD",
+            path: headPath
+        )
+        let after = fileExistsOnDisk ? NSImage(contentsOf: fileURL) : nil
+        let oldPath = originalPath ?? (before != nil && relativePath != headPath ? headPath : nil)
+        let kind: ImageDiffPairKind
+        switch (before != nil, after != nil, oldPath != nil) {
+        case (false, true, _):
+            kind = .added
+        case (true, false, _):
+            kind = .deleted
+        case (true, true, true):
+            kind = .renamed
+        default:
+            kind = .modified
+        }
+
+        return ImageDiffPair(
+            before: before,
+            after: after,
+            oldPath: oldPath,
+            kind: kind,
+            beforeFrameCount: frameCount(for: before),
+            afterFrameCount: frameCount(for: after)
+        )
+    }
+
     /// Internal: `git show <ref>:<path>` → `NSImage`. `ref == ""` means
     /// the index (i.e. `:path`).
     fileprivate func loadBlobImage(

--- a/Alas/Sources/Center/ReadonlyTextView.swift
+++ b/Alas/Sources/Center/ReadonlyTextView.swift
@@ -1,0 +1,61 @@
+import AppKit
+import SwiftUI
+
+struct ReadonlyTextView: NSViewRepresentable {
+    let text: String
+    let font: NSFont
+    let textColor: NSColor
+    let backgroundColor: NSColor
+
+    func makeNSView(context: Context) -> NSScrollView {
+        let scroll = NSScrollView()
+        scroll.hasVerticalScroller = true
+        scroll.hasHorizontalScroller = true
+        scroll.autohidesScrollers = true
+        scroll.borderType = .noBorder
+        scroll.drawsBackground = false
+        scroll.backgroundColor = backgroundColor
+
+        let textView = NSTextView()
+        textView.isEditable = false
+        textView.isSelectable = true
+        textView.isRichText = false
+        textView.importsGraphics = false
+        textView.isAutomaticQuoteSubstitutionEnabled = false
+        textView.isAutomaticDashSubstitutionEnabled = false
+        textView.isAutomaticTextReplacementEnabled = false
+        textView.isAutomaticSpellingCorrectionEnabled = false
+        textView.isVerticallyResizable = true
+        textView.isHorizontallyResizable = true
+        textView.textContainer?.widthTracksTextView = false
+        textView.textContainer?.containerSize = NSSize(
+            width: CGFloat.greatestFiniteMagnitude,
+            height: CGFloat.greatestFiniteMagnitude
+        )
+        textView.autoresizingMask = [.width]
+        textView.drawsBackground = false
+        textView.backgroundColor = backgroundColor
+        textView.textContainerInset = NSSize(width: 12, height: 10)
+
+        scroll.documentView = textView
+        return scroll
+    }
+
+    func updateNSView(_ scroll: NSScrollView, context: Context) {
+        scroll.backgroundColor = backgroundColor
+        guard let textView = scroll.documentView as? NSTextView else { return }
+        textView.backgroundColor = backgroundColor
+
+        let attributes: [NSAttributedString.Key: Any] = [
+            .font: font,
+            .foregroundColor: textColor,
+            .paragraphStyle: CenterTypography.paragraphStyle()
+        ]
+        if textView.string != text {
+            textView.textStorage?.setAttributedString(NSAttributedString(string: text, attributes: attributes))
+        } else {
+            textView.textStorage?.setAttributes(attributes, range: NSRange(location: 0, length: textView.string.utf16.count))
+        }
+        textView.typingAttributes = attributes
+    }
+}

--- a/Alas/Sources/Center/Tab.swift
+++ b/Alas/Sources/Center/Tab.swift
@@ -16,6 +16,8 @@ enum Tab: Codable, Equatable, Identifiable {
     case mergeConflict(MergeConflictTabState)
     case acpSession(ACPSessionTabState)
     case reviewPR(ReviewPRTabState)
+    case fileSnapshot(FileSnapshotTabState)
+    case fileHistory(FileHistoryTabState)
 
     var id: TabID {
         switch self {
@@ -32,6 +34,8 @@ enum Tab: Codable, Equatable, Identifiable {
         case .mergeConflict(let s): return s.id
         case .acpSession(let s):   return s.id
         case .reviewPR(let s):     return s.id
+        case .fileSnapshot(let s): return s.id
+        case .fileHistory(let s):  return s.id
         }
     }
 
@@ -50,6 +54,8 @@ enum Tab: Codable, Equatable, Identifiable {
         case .mergeConflict(let s): return s.title
         case .acpSession(let s):   return s.title
         case .reviewPR(let s):     return s.displayTitle
+        case .fileSnapshot(let s): return s.title
+        case .fileHistory(let s):  return s.title
         }
     }
 
@@ -68,6 +74,8 @@ enum Tab: Codable, Equatable, Identifiable {
         case .mergeConflict: return "diff"
         case .acpSession:   return "sparkle"
         case .reviewPR:     return "list.bullet.rectangle.portrait.fill"
+        case .fileSnapshot: return "doc.text.magnifyingglass"
+        case .fileHistory:  return "clock.arrow.circlepath"
         }
     }
 
@@ -76,8 +84,40 @@ enum Tab: Codable, Equatable, Identifiable {
         case .editor(let s):       return s.isExternal ? nil : s.relativePath
         case .imagePreview(let s): return s.relativePath
         case .mergeConflict(let s): return s.relativePath
+        case .fileSnapshot(let s): return s.relativePath
+        case .fileHistory(let s):  return s.relativePath
         default:                   return nil
         }
+    }
+}
+
+struct FileSnapshotTabState: Codable, Equatable, Identifiable {
+    let id: TabID
+    let worktreeId: String
+    let relativePath: String
+    let ref: String
+    var title: String
+
+    init(worktreeId: String, relativePath: String, ref: String = "HEAD") {
+        self.worktreeId = worktreeId
+        self.relativePath = relativePath
+        self.ref = ref
+        self.title = "\((relativePath as NSString).lastPathComponent) @ \(ref)"
+        self.id = "file-snapshot:\(worktreeId):\(ref):\(relativePath)"
+    }
+}
+
+struct FileHistoryTabState: Codable, Equatable, Identifiable {
+    let id: TabID
+    let worktreeId: String
+    let relativePath: String
+    var title: String
+
+    init(worktreeId: String, relativePath: String) {
+        self.worktreeId = worktreeId
+        self.relativePath = relativePath
+        self.title = "\((relativePath as NSString).lastPathComponent) History"
+        self.id = "file-history:\(worktreeId):\(relativePath)"
     }
 }
 

--- a/Alas/Sources/Center/Tab.swift
+++ b/Alas/Sources/Center/Tab.swift
@@ -402,16 +402,27 @@ struct DiffTabState: Codable, Equatable, Identifiable {
     var title: String
     var relativePath: String
     var staged: Bool = false
+    var originalPath: String? = nil
+    var compareWithHEAD: Bool = false
 
-    init(id: TabID, title: String, relativePath: String, staged: Bool = false) {
+    init(
+        id: TabID,
+        title: String,
+        relativePath: String,
+        staged: Bool = false,
+        originalPath: String? = nil,
+        compareWithHEAD: Bool = false
+    ) {
         self.id = id
         self.title = title
         self.relativePath = relativePath
         self.staged = staged
+        self.originalPath = originalPath
+        self.compareWithHEAD = compareWithHEAD
     }
 
     private enum CodingKeys: String, CodingKey {
-        case id, title, relativePath, staged
+        case id, title, relativePath, staged, originalPath, compareWithHEAD
     }
 
     init(from decoder: Decoder) throws {
@@ -420,6 +431,8 @@ struct DiffTabState: Codable, Equatable, Identifiable {
         title = try container.decode(String.self, forKey: .title)
         relativePath = try container.decode(String.self, forKey: .relativePath)
         staged = try container.decodeIfPresent(Bool.self, forKey: .staged) ?? false
+        originalPath = try container.decodeIfPresent(String.self, forKey: .originalPath)
+        compareWithHEAD = try container.decodeIfPresent(Bool.self, forKey: .compareWithHEAD) ?? false
     }
 }
 

--- a/Alas/Sources/Center/TabsManager.swift
+++ b/Alas/Sources/Center/TabsManager.swift
@@ -681,6 +681,30 @@ final class TabsManager {
     }
 
     @discardableResult
+    func openOrFocusFileSnapshot(worktreeId: String, relativePath: String, ref: String = "HEAD") -> Tab {
+        let state = FileSnapshotTabState(worktreeId: worktreeId, relativePath: relativePath, ref: ref)
+        if tabs(forWorktree: worktreeId).contains(where: { $0.id == state.id }) {
+            activate(worktreeId: worktreeId, tabId: state.id)
+            return tabs(forWorktree: worktreeId).first(where: { $0.id == state.id }) ?? .fileSnapshot(state)
+        }
+        let tab = Tab.fileSnapshot(state)
+        append(tab, to: worktreeId)
+        return tab
+    }
+
+    @discardableResult
+    func openOrFocusFileHistory(worktreeId: String, relativePath: String) -> Tab {
+        let state = FileHistoryTabState(worktreeId: worktreeId, relativePath: relativePath)
+        if tabs(forWorktree: worktreeId).contains(where: { $0.id == state.id }) {
+            activate(worktreeId: worktreeId, tabId: state.id)
+            return tabs(forWorktree: worktreeId).first(where: { $0.id == state.id }) ?? .fileHistory(state)
+        }
+        let tab = Tab.fileHistory(state)
+        append(tab, to: worktreeId)
+        return tab
+    }
+
+    @discardableResult
     func openOrFocusReviewSession(worktreeId: String, record: ReviewSessionRecord) -> Tab {
         let baseState = ReviewSessionTabState(worktreeId: worktreeId, record: record)
         if var file = byWorktree[worktreeId],

--- a/Alas/Sources/Center/TabsManager.swift
+++ b/Alas/Sources/Center/TabsManager.swift
@@ -604,8 +604,22 @@ final class TabsManager {
     }
 
     @discardableResult
-    func appendDiff(worktreeId: String, title: String, relativePath: String, staged: Bool = false) -> Tab {
-        let state = DiffTabState(id: UUID().uuidString, title: title, relativePath: relativePath, staged: staged)
+    func appendDiff(
+        worktreeId: String,
+        title: String,
+        relativePath: String,
+        staged: Bool = false,
+        originalPath: String? = nil,
+        compareWithHEAD: Bool = false
+    ) -> Tab {
+        let state = DiffTabState(
+            id: UUID().uuidString,
+            title: title,
+            relativePath: relativePath,
+            staged: staged,
+            originalPath: originalPath,
+            compareWithHEAD: compareWithHEAD
+        )
         let tab = Tab.diff(state)
         append(tab, to: worktreeId)
         return tab

--- a/Alas/Sources/Git/GitService.swift
+++ b/Alas/Sources/Git/GitService.swift
@@ -195,6 +195,46 @@ extension GitService {
         return await Self.parseOffMain(stdout)
     }
 
+    func diffAgainstHEAD(worktreePath: URL, file: String, originalPath: String? = nil) async throws -> ParsedDiff {
+        let head = try await hasHead(worktreePath: worktreePath)
+        if !head {
+            let fileURL = worktreePath.appendingPathComponent(file)
+            guard FileManager.default.fileExists(atPath: fileURL.path) else {
+                return ParsedDiff(hunks: [])
+            }
+            let result = try await Process.git(
+                ["diff", "--no-color", "--no-index", "--", "/dev/null", file],
+                cwd: worktreePath
+            )
+            guard result.exitCode <= 1 else { return ParsedDiff(hunks: []) }
+            return await Self.parseOffMain(result.stdout)
+        }
+
+        let headPath = originalPath?.isEmpty == false ? originalPath! : file
+        let headBlob = try await Process.gitData(
+            ["show", "HEAD:\(headPath)"],
+            cwd: worktreePath
+        )
+        if headBlob.exitCode != 0 {
+            let result = try await Process.git(
+                ["diff", "--no-color", "--no-index", "--", "/dev/null", file],
+                cwd: worktreePath
+            )
+            guard result.exitCode <= 1 else { return ParsedDiff(hunks: []) }
+            return await Self.parseOffMain(result.stdout)
+        }
+
+        var args = ["diff", "--no-color", "-M", "-C"]
+        args.append("HEAD")
+        args.append("--")
+        args.append(file)
+        if let originalPath, !originalPath.isEmpty {
+            args.append(originalPath)
+        }
+        let result = try await Process.git(args, cwd: worktreePath)
+        return await Self.parseOffMain(result.stdout)
+    }
+
     func contextSnapshot(worktreePath: URL, file: String, staged: Bool, originalPath: String? = nil) async throws -> DiffReviewFileContextSnapshot {
         let oldPath = originalPath?.isEmpty == false ? originalPath! : file
         let old: DiffReviewFileContextLines

--- a/Alas/Sources/Git/GitService.swift
+++ b/Alas/Sources/Git/GitService.swift
@@ -63,6 +63,12 @@ private struct BranchListError: LocalizedError {
     }
 }
 
+enum HeadBlobTextResult: Equatable, Sendable {
+    case available(String)
+    case missing
+    case undisplayable
+}
+
 extension GitService {
     /// Whether the repo has any commits yet. `git diff HEAD` and friends
     /// fail with `bad revision 'HEAD'` on unborn branches; callers swap to
@@ -73,6 +79,19 @@ extension GitService {
             cwd: worktreePath
         )
         return result.exitCode == 0
+    }
+
+    func headBlobText(worktreePath: URL, relativePath: String) async throws -> HeadBlobTextResult {
+        let result = try await Process.gitData(["show", "HEAD:\(relativePath)"], cwd: worktreePath)
+        guard result.exitCode == 0 else {
+            return .missing
+        }
+        guard !result.stdout.contains(0),
+              let text = String(data: result.stdout, encoding: .utf8)
+        else {
+            return .undisplayable
+        }
+        return .available(text)
     }
 
     func status(worktreePath: URL) async throws -> [ChangedFile] {
@@ -1301,6 +1320,77 @@ extension GitService {
                 subject: subject,
                 rawSubject: rawSubject,
                 body: body,
+                conventionalTag: tag,
+                filesChanged: filesChanged,
+                insertions: adds,
+                deletions: dels
+            ))
+        }
+        return commits
+    }
+
+    func fileHistory(worktreePath: URL, relativePath: String, limit: Int = 200) async throws -> [CommitInfo] {
+        let boundedLimit = max(1, limit)
+        let format = "%x1e%H%x1f%h%x1f%an%x1f%aI%x1f%s"
+        let log = try await Process.git(
+            ["log", "--follow", "-n", String(boundedLimit),
+             "--pretty=tformat:\(format)", "--numstat", "--", relativePath],
+            cwd: worktreePath
+        )
+        guard log.exitCode == 0 else {
+            throw NSError(
+                domain: "GitService.fileHistory",
+                code: Int(log.exitCode),
+                userInfo: [NSLocalizedDescriptionKey: log.stderr.isEmpty ? "git log failed" : log.stderr]
+            )
+        }
+        return Self.parseFileHistoryCommitInfoRecords(log.stdout)
+    }
+
+    private static func parseFileHistoryCommitInfoRecords(_ stdout: String) -> [CommitInfo] {
+        let records = stdout
+            .split(separator: "\u{1e}", omittingEmptySubsequences: true)
+            .map { String($0) }
+
+        let isoFormatter = ISO8601DateFormatter()
+        isoFormatter.formatOptions = [.withInternetDateTime]
+
+        var commits: [CommitInfo] = []
+        for record in records {
+            let trimmed = record.trimmingCharacters(in: .whitespacesAndNewlines)
+            guard !trimmed.isEmpty else { continue }
+            let lines = trimmed.split(separator: "\n", omittingEmptySubsequences: false)
+            guard let headerLine = lines.first else { continue }
+            let fields = headerLine.split(separator: "\u{1f}", maxSplits: 4, omittingEmptySubsequences: false)
+            guard fields.count == 5 else { continue }
+            let sha = String(fields[0])
+            let short = String(fields[1])
+            let author = String(fields[2])
+            let dateStr = String(fields[3])
+            let rawSubject = String(fields[4])
+            let date = isoFormatter.date(from: dateStr) ?? Date(timeIntervalSince1970: 0)
+            let (tag, subject) = CommitInfo.parseConventional(subject: rawSubject)
+
+            var filesChanged = 0
+            var adds = 0
+            var dels = 0
+            for line in lines.dropFirst() {
+                let trimmedLine = line.trimmingCharacters(in: .whitespaces)
+                if trimmedLine.isEmpty { continue }
+                let parts = trimmedLine.split(separator: "\t", omittingEmptySubsequences: false)
+                guard parts.count >= 3 else { continue }
+                filesChanged += 1
+                if let a = Int(parts[0]) { adds += a }
+                if let d = Int(parts[1]) { dels += d }
+            }
+
+            commits.append(CommitInfo(
+                sha: sha,
+                shortSha: short,
+                author: author,
+                authorInitials: CommitInfo.initials(for: author),
+                date: date,
+                subject: subject,
                 conventionalTag: tag,
                 filesChanged: filesChanged,
                 insertions: adds,

--- a/Alas/Sources/Right/ChangedRow.swift
+++ b/Alas/Sources/Right/ChangedRow.swift
@@ -15,8 +15,12 @@ struct ChangedRow: View {
     var onCopyFull:       (() -> Void)? = nil
     var onRevealInFinder: (() -> Void)? = nil
     var onCopyDiff:       (() -> Void)? = nil
+    var onViewAtHEAD:     (() -> Void)? = nil
+    var onCompareWithHEAD: (() -> Void)? = nil
+    var onFileHistory:    (() -> Void)? = nil
     var onDiscard:        (() -> Void)? = nil
     var openFileEnabled:  Bool = true
+    var viewAtHEADEnabled: Bool = true
     var ignoreMenu:       AnyView? = nil
     @Environment(\.theme) var theme
 
@@ -51,6 +55,12 @@ struct ChangedRow: View {
         .contextMenu {
             Button("Open File") { onOpenFile?() }
                 .disabled(!openFileEnabled || onOpenFile == nil)
+            Button("View at HEAD") { onViewAtHEAD?() }
+                .disabled(!viewAtHEADEnabled || onViewAtHEAD == nil)
+            Button("Compare with HEAD") { onCompareWithHEAD?() }
+                .disabled(onCompareWithHEAD == nil)
+            Button("File History") { onFileHistory?() }
+                .disabled(onFileHistory == nil)
             Button("Copy Relative Path") { onCopyRelative?() }
             Button("Copy Full Path") { onCopyFull?() }
             Button("Reveal in Finder") { onRevealInFinder?() }

--- a/Alas/Sources/Right/ChangesTabView.swift
+++ b/Alas/Sources/Right/ChangesTabView.swift
@@ -126,6 +126,26 @@ struct ChangesTabView: View {
                 onCopyDiff: { file in
                     rps.copyDiff(for: file.path, renameFrom: file.renameFrom)
                 },
+                onViewAtHEAD: { file in
+                    appState.openFileSnapshotAtHEAD(
+                        relativePath: file.renameFrom ?? file.path,
+                        worktreeId: rps.worktree.id
+                    )
+                },
+                onCompareWithHEAD: { file in
+                    appState.openDiffTab(
+                        forFileInWorktree: rps.worktree,
+                        relativePath: file.path,
+                        originalPath: file.renameFrom,
+                        compareWithHEAD: true
+                    )
+                },
+                onFileHistory: { file in
+                    appState.openFileHistory(
+                        relativePath: file.renameFrom ?? file.path,
+                        worktreeId: rps.worktree.id
+                    )
+                },
                 onDiscardFile: { file in rps.requestDiscardFile(path: file.path) },
                 isOpenFileEnabled: { file in
                     DiffOpenFileAvailability.isAvailable(

--- a/Alas/Sources/Right/WorkingTreeSectionView.swift
+++ b/Alas/Sources/Right/WorkingTreeSectionView.swift
@@ -14,6 +14,9 @@ struct WorkingTreeSectionView: View {
     var onCopyFull:        ((ChangedFile) -> Void)? = nil
     var onRevealInFinder:  ((ChangedFile) -> Void)? = nil
     var onCopyDiff:        ((ChangedFile) -> Void)? = nil
+    var onViewAtHEAD:      ((ChangedFile) -> Void)? = nil
+    var onCompareWithHEAD: ((ChangedFile) -> Void)? = nil
+    var onFileHistory:     ((ChangedFile) -> Void)? = nil
     var onDiscardFile:     ((ChangedFile) -> Void)? = nil
     var isOpenFileEnabled: ((ChangedFile) -> Bool)? = nil
 
@@ -86,6 +89,13 @@ struct WorkingTreeSectionView: View {
     /// is required.
     private func isUntracked(_ file: ChangedFile) -> Bool {
         file.status == "A" && file.stage == .unstaged
+    }
+
+    private func hasHeadVersion(_ group: WorkingTreeChangeGroup) -> Bool {
+        if group.entries.contains(where: { $0.status == "D" || $0.status == "R" }) {
+            return true
+        }
+        return !group.entries.contains { $0.status == "A" }
     }
 
     /// True when every ChangedFile reachable through `node` is untracked.
@@ -209,6 +219,7 @@ struct WorkingTreeSectionView: View {
                 : nil
             let canStage = !group.unstagedEntries.isEmpty
             let canUnstage = !group.stagedEntries.isEmpty
+            let headPathEntry = group.entries.first { $0.renameFrom != nil } ?? file
             return AnyView(
                 ChangedRow(
                     file: file,
@@ -225,8 +236,12 @@ struct WorkingTreeSectionView: View {
                     onCopyFull: onCopyFull.map { fn in { fn(file) } },
                     onRevealInFinder: onRevealInFinder.map { fn in { fn(file) } },
                     onCopyDiff: onCopyDiff.map { fn in { fn(file) } },
+                    onViewAtHEAD: onViewAtHEAD.map { fn in { fn(headPathEntry) } },
+                    onCompareWithHEAD: onCompareWithHEAD.map { fn in { fn(headPathEntry) } },
+                    onFileHistory: onFileHistory.map { fn in { fn(headPathEntry) } },
                     onDiscard: onDiscardFile.map { fn in { fn(file) } },
                     openFileEnabled: isOpenFileEnabled?(file) ?? true,
+                    viewAtHEADEnabled: hasHeadVersion(group),
                     ignoreMenu: ignore
                 )
             )

--- a/AlasTests/GitServiceTests.swift
+++ b/AlasTests/GitServiceTests.swift
@@ -56,6 +56,12 @@ struct GitServiceTests {
         try data.write(to: url)
     }
 
+    private func commitFile(_ repo: URL, path: String, contents: String, message: String) async throws {
+        try writeText(contents, path, in: repo)
+        try await gitOK(["add", path], cwd: repo)
+        try await gitOK(["commit", "-q", "-m", message], cwd: repo)
+    }
+
     @Test func validateAcceptsRealRepo() async throws {
         let repo = try await makeRepo()
         defer { try? FileManager.default.removeItem(at: repo) }
@@ -152,6 +158,52 @@ struct GitServiceTests {
             .stdout
             .trimmingCharacters(in: .whitespacesAndNewlines)
         #expect(subject == #"Revert "change file""#)
+    }
+
+    @Test func headBlobTextReturnsCommittedText() async throws {
+        let repo = try await makeContextSnapshotRepo(withInitialCommit: false)
+        defer { try? FileManager.default.removeItem(at: repo) }
+        try writeText("hello\n", "a.txt", in: repo)
+        try await gitOK(["add", "a.txt"], cwd: repo)
+        try await gitOK(["commit", "-q", "-m", "add a"], cwd: repo)
+
+        let result = try await GitService().headBlobText(worktreePath: repo, relativePath: "a.txt")
+
+        #expect(result == .available("hello\n"))
+    }
+
+    @Test func headBlobTextReportsMissingPath() async throws {
+        let repo = try await makeContextSnapshotRepo()
+        defer { try? FileManager.default.removeItem(at: repo) }
+
+        let result = try await GitService().headBlobText(worktreePath: repo, relativePath: "missing.txt")
+
+        #expect(result == .missing)
+    }
+
+    @Test func headBlobTextReportsBinaryAsUndisplayable() async throws {
+        let repo = try await makeContextSnapshotRepo()
+        defer { try? FileManager.default.removeItem(at: repo) }
+        try writeData(Data([0, 1, 2, 3]), "blob.bin", in: repo)
+        try await gitOK(["add", "blob.bin"], cwd: repo)
+        try await gitOK(["commit", "-q", "-m", "add binary"], cwd: repo)
+
+        let result = try await GitService().headBlobText(worktreePath: repo, relativePath: "blob.bin")
+
+        #expect(result == .undisplayable)
+    }
+
+    @Test func fileHistoryReturnsCommitsTouchingPathNewestFirst() async throws {
+        let repo = try await makeContextSnapshotRepo()
+        defer { try? FileManager.default.removeItem(at: repo) }
+        try await commitFile(repo, path: "a.txt", contents: "one\n", message: "add a")
+        try await commitFile(repo, path: "b.txt", contents: "other\n", message: "add b")
+        try await commitFile(repo, path: "a.txt", contents: "two\n", message: "update a")
+
+        let commits = try await GitService().fileHistory(worktreePath: repo, relativePath: "a.txt", limit: 200)
+
+        #expect(commits.map(\.subject) == ["update a", "add a"])
+        #expect(commits.allSatisfy { $0.filesChanged >= 1 })
     }
 
     @Test func contextSnapshotSeparatesStagedAndUnstagedRefs() async throws {

--- a/AlasTests/GitServiceTests.swift
+++ b/AlasTests/GitServiceTests.swift
@@ -206,6 +206,37 @@ struct GitServiceTests {
         #expect(commits.allSatisfy { $0.filesChanged >= 1 })
     }
 
+    @Test func diffAgainstHEADIncludesStagedAndUnstagedChanges() async throws {
+        let repo = try await makeContextSnapshotRepo()
+        defer { try? FileManager.default.removeItem(at: repo) }
+        try writeText("base\n", "file.txt", in: repo)
+        try await gitOK(["add", "file.txt"], cwd: repo)
+        try await gitOK(["commit", "-q", "-m", "base"], cwd: repo)
+
+        try writeText("base\nstaged\n", "file.txt", in: repo)
+        try await gitOK(["add", "file.txt"], cwd: repo)
+        try writeText("base\nstaged\nunstaged\n", "file.txt", in: repo)
+
+        let diff = try await GitService().diffAgainstHEAD(worktreePath: repo, file: "file.txt")
+
+        #expect(diff.hunks.contains { hunk in hunk.lines.contains { $0.kind == .add && $0.text == "staged" } })
+        #expect(diff.hunks.contains { hunk in hunk.lines.contains { $0.kind == .add && $0.text == "unstaged" } })
+    }
+
+    @Test func diffAgainstHEADShowsStagedDeletion() async throws {
+        let repo = try await makeContextSnapshotRepo()
+        defer { try? FileManager.default.removeItem(at: repo) }
+        try writeText("delete me\n", "deleted.txt", in: repo)
+        try await gitOK(["add", "deleted.txt"], cwd: repo)
+        try await gitOK(["commit", "-q", "-m", "base"], cwd: repo)
+        try FileManager.default.removeItem(at: repo.appendingPathComponent("deleted.txt"))
+        try await gitOK(["rm", "--cached", "deleted.txt"], cwd: repo)
+
+        let diff = try await GitService().diffAgainstHEAD(worktreePath: repo, file: "deleted.txt")
+
+        #expect(diff.hunks.contains { hunk in hunk.lines.contains { $0.kind == .delete && $0.text == "delete me" } })
+    }
+
     @Test func contextSnapshotSeparatesStagedAndUnstagedRefs() async throws {
         let repo = try await makeContextSnapshotRepo()
         defer { try? FileManager.default.removeItem(at: repo) }

--- a/AlasTests/TabsManagerTests.swift
+++ b/AlasTests/TabsManagerTests.swift
@@ -242,6 +242,36 @@ struct TabsManagerTests {
         #expect(first.title == "Review Changes")
     }
 
+    @Test func openOrFocusFileSnapshotReusesWorktreePathRefTab() {
+        let worktreeId = "tabs-manager-file-snapshot-\(UUID().uuidString)"
+        defer { try? FileManager.default.removeItem(at: Paths.tabsFile(forWorktreeId: worktreeId)) }
+        let manager = TabsManager()
+        let first = manager.openOrFocusFileSnapshot(worktreeId: worktreeId, relativePath: "a.txt", ref: "HEAD")
+        let other = manager.appendTerminal(worktreeId: worktreeId, title: "other", sessionId: "s")
+        manager.activate(worktreeId: worktreeId, tabId: other.id)
+
+        let second = manager.openOrFocusFileSnapshot(worktreeId: worktreeId, relativePath: "a.txt", ref: "HEAD")
+
+        #expect(first.id == second.id)
+        #expect(manager.tabs(forWorktree: worktreeId).count == 2)
+        #expect(manager.activeTabId(forWorktree: worktreeId) == first.id)
+    }
+
+    @Test func openOrFocusFileHistoryReusesWorktreePathTab() {
+        let worktreeId = "tabs-manager-file-history-\(UUID().uuidString)"
+        defer { try? FileManager.default.removeItem(at: Paths.tabsFile(forWorktreeId: worktreeId)) }
+        let manager = TabsManager()
+        let first = manager.openOrFocusFileHistory(worktreeId: worktreeId, relativePath: "a.txt")
+        let other = manager.appendTerminal(worktreeId: worktreeId, title: "other", sessionId: "s")
+        manager.activate(worktreeId: worktreeId, tabId: other.id)
+
+        let second = manager.openOrFocusFileHistory(worktreeId: worktreeId, relativePath: "a.txt")
+
+        #expect(first.id == second.id)
+        #expect(manager.tabs(forWorktree: worktreeId).count == 2)
+        #expect(manager.activeTabId(forWorktree: worktreeId) == first.id)
+    }
+
     @Test func reviewChangesTabStateRoundTrips() throws {
         let state = ReviewChangesTabState(worktreeId: "wt")
         let tab = Tab.reviewChanges(state)

--- a/AlasTests/TabsManagerTests.swift
+++ b/AlasTests/TabsManagerTests.swift
@@ -217,6 +217,8 @@ struct TabsManagerTests {
         let decoded = try JSONDecoder().decode(DiffTabState.self, from: json)
         #expect(decoded.relativePath == "a.txt")
         #expect(decoded.staged == false)
+        #expect(decoded.originalPath == nil)
+        #expect(decoded.compareWithHEAD == false)
     }
 
     @Test func diffTabStateRoundTripsStagedFlag() throws {
@@ -225,6 +227,21 @@ struct TabsManagerTests {
         let decoded = try JSONDecoder().decode(DiffTabState.self, from: data)
         #expect(decoded == state)
         #expect(decoded.staged)
+    }
+
+    @Test func diffTabStateRoundTripsHeadComparisonFields() throws {
+        let state = DiffTabState(
+            id: "d",
+            title: "new.txt vs HEAD",
+            relativePath: "new.txt",
+            originalPath: "old.txt",
+            compareWithHEAD: true
+        )
+        let data = try JSONEncoder().encode(state)
+        let decoded = try JSONDecoder().decode(DiffTabState.self, from: data)
+        #expect(decoded == state)
+        #expect(decoded.originalPath == "old.txt")
+        #expect(decoded.compareWithHEAD)
     }
 
     @Test func openOrFocusReviewChangesCreatesStableWorktreeScopedTab() {

--- a/docs/superpowers/plans/2026-06-21-changed-file-head-history.md
+++ b/docs/superpowers/plans/2026-06-21-changed-file-head-history.md
@@ -1,0 +1,723 @@
+# Changed File HEAD View and History Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add changed-file context-menu actions for viewing a file at `HEAD`, comparing it with `HEAD`, and opening path-scoped file history.
+
+**Architecture:** Add two focused center-pane tab types: a read-only `HEAD` snapshot tab and a file-history tab. Reuse the existing unstaged `DiffTabView` for compare-with-HEAD and existing commit tabs for history row selection. Keep Git access in `GitService`, tab identity in `TabsManager`, and menu wiring in the right-pane changed-file views.
+
+**Tech Stack:** Swift 5.9, SwiftUI, Swift Testing, existing `Process.git` / `Process.gitData`, existing `TabsManager`, `CommitInfo`, `CommitRow`, and `DiffTabView`.
+
+---
+
+## File Structure
+
+- Modify `Alas/Sources/Git/GitService.swift`
+  - Add `HeadBlobTextResult`.
+  - Add `headBlobText(worktreePath:relativePath:)`.
+  - Add `fileHistory(worktreePath:relativePath:limit:)`.
+- Modify `Alas/Sources/Center/Tab.swift`
+  - Add `fileSnapshot` and `fileHistory` tab cases.
+  - Add `FileSnapshotTabState` and `FileHistoryTabState`.
+- Modify `Alas/Sources/Center/TabsManager.swift`
+  - Add open-or-focus helpers for the new tab cases.
+- Create `Alas/Sources/Center/FileSnapshotTabView.swift`
+  - Load and render `HEAD:<path>` read-only text/error states.
+- Create `Alas/Sources/Center/ReadonlyTextView.swift` if no reusable whole-file selectable text view exists.
+  - Render selectable, non-editable monospace text for the snapshot tab.
+- Create `Alas/Sources/Center/FileHistoryTabView.swift`
+  - Load and render path-scoped commits, selecting rows into existing commit tabs.
+- Modify `Alas/Sources/Center/CenterPaneView.swift`
+  - Render the two new tab cases.
+- Modify `Alas/Sources/App/AppState.swift`
+  - Add app-level helpers that focus the worktree and delegate to `TabsManager`.
+- Modify `Alas/Sources/Right/ChangedRow.swift`
+  - Add menu items and enabled flags.
+- Modify `Alas/Sources/Right/WorkingTreeSectionView.swift`
+  - Thread callbacks and calculate `View at HEAD` availability.
+- Modify `Alas/Sources/Right/ChangesTabView.swift`
+  - Wire callbacks to `AppState` and existing diff tab behavior.
+- Tests:
+  - Modify `AlasTests/TabsManagerTests.swift`.
+  - Modify `AlasTests/GitServiceTests.swift`.
+
+---
+
+### Task 1: GitService HEAD Blob and File History
+
+**Files:**
+- Modify: `Alas/Sources/Git/GitService.swift`
+- Test: `AlasTests/GitServiceTests.swift`
+
+- [ ] **Step 1: Write failing tests for HEAD blob states**
+
+Add tests that create a temporary git repo, commit a text file, then verify:
+
+```swift
+@Test func headBlobTextReturnsCommittedText() async throws {
+    let repo = try makeTempRepo()
+    try await gitOK(["init"], cwd: repo)
+    try await gitOK(["config", "user.email", "you@example.com"], cwd: repo)
+    try await gitOK(["config", "user.name", "You"], cwd: repo)
+    try "hello\n".write(to: repo.appendingPathComponent("a.txt"), atomically: true, encoding: .utf8)
+    try await gitOK(["add", "a.txt"], cwd: repo)
+    try await gitOK(["commit", "-m", "add a"], cwd: repo)
+
+    let result = try await GitService().headBlobText(worktreePath: repo, relativePath: "a.txt")
+
+    #expect(result == .available("hello\n"))
+}
+
+@Test func headBlobTextReportsMissingPath() async throws {
+    let repo = try makeTempRepo()
+    try await seedRepoWithInitialCommit(repo)
+
+    let result = try await GitService().headBlobText(worktreePath: repo, relativePath: "missing.txt")
+
+    #expect(result == .missing)
+}
+
+@Test func headBlobTextReportsBinaryAsUndisplayable() async throws {
+    let repo = try makeTempRepo()
+    try await seedRepoWithInitialCommit(repo)
+    try Data([0, 1, 2, 3]).write(to: repo.appendingPathComponent("blob.bin"))
+    try await gitOK(["add", "blob.bin"], cwd: repo)
+    try await gitOK(["commit", "-m", "add binary"], cwd: repo)
+
+    let result = try await GitService().headBlobText(worktreePath: repo, relativePath: "blob.bin")
+
+    #expect(result == .undisplayable)
+}
+```
+
+Use existing test helpers in `GitServiceTests.swift` if present instead of duplicating setup helpers.
+
+- [ ] **Step 2: Run tests and verify they fail**
+
+Run:
+
+```bash
+xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -only-testing:AlasTests/GitServiceTests test
+```
+
+Expected: FAIL because `HeadBlobTextResult` and `headBlobText` do not exist.
+
+- [ ] **Step 3: Implement `HeadBlobTextResult` and `headBlobText`**
+
+Add near other GitService helper types:
+
+```swift
+enum HeadBlobTextResult: Equatable, Sendable {
+    case available(String)
+    case missing
+    case undisplayable
+}
+```
+
+Add a public helper in `GitService`:
+
+```swift
+func headBlobText(worktreePath: URL, relativePath: String) async throws -> HeadBlobTextResult {
+    let result = try await Process.gitData(["show", "HEAD:\(relativePath)"], cwd: worktreePath)
+    guard result.exitCode == 0 else {
+        return .missing
+    }
+    guard !result.stdout.contains(0),
+          let text = String(data: result.stdout, encoding: .utf8)
+    else {
+        return .undisplayable
+    }
+    return .available(text)
+}
+```
+
+If implementation reveals `Process.gitData` names stdout differently, adapt to the existing result shape.
+
+- [ ] **Step 4: Write failing tests for file history**
+
+Add a test that commits `a.txt`, commits unrelated `b.txt`, commits `a.txt` again, then verifies `fileHistory(..., relativePath: "a.txt", limit: 200)` returns only the two `a.txt` commits in newest-first order.
+
+```swift
+@Test func fileHistoryReturnsCommitsTouchingPathNewestFirst() async throws {
+    let repo = try makeTempRepo()
+    try await seedRepoWithInitialCommit(repo)
+    try await commitFile(repo, path: "a.txt", contents: "one\n", message: "add a")
+    try await commitFile(repo, path: "b.txt", contents: "other\n", message: "add b")
+    try await commitFile(repo, path: "a.txt", contents: "two\n", message: "update a")
+
+    let commits = try await GitService().fileHistory(worktreePath: repo, relativePath: "a.txt", limit: 200)
+
+    #expect(commits.map(\.subject) == ["update a", "add a"])
+    #expect(commits.allSatisfy { $0.filesChanged >= 1 })
+}
+```
+
+- [ ] **Step 5: Run tests and verify they fail**
+
+Run the same GitService test command.
+
+Expected: FAIL because `fileHistory` does not exist.
+
+- [ ] **Step 6: Implement `fileHistory` with a shared parser shape**
+
+Use the same record separator format as `commitsAhead` / `commitsOlder`:
+
+```swift
+func fileHistory(worktreePath: URL, relativePath: String, limit: Int = 200) async throws -> [CommitInfo] {
+    let boundedLimit = max(1, limit)
+    let format = "%x1e%H%x1f%h%x1f%an%x1f%aI%x1f%s"
+    let log = try await Process.git(
+        ["log", "--follow", "-n", String(boundedLimit), "--pretty=tformat:\(format)", "--numstat", "--", relativePath],
+        cwd: worktreePath
+    )
+    guard log.exitCode == 0 else {
+        throw NSError(
+            domain: "GitService.fileHistory",
+            code: Int(log.exitCode),
+            userInfo: [NSLocalizedDescriptionKey: log.stderr.isEmpty ? "git log failed" : log.stderr]
+        )
+    }
+    return Self.parseFileHistoryCommitInfoRecords(log.stdout)
+}
+```
+
+Add `private static func parseFileHistoryCommitInfoRecords(_ stdout: String) -> [CommitInfo]` that mirrors the `commitsAhead` / `commitsOlder` parsing shape: split on `\u{1e}`, parse header fields separated by `\u{1f}`, parse ISO dates, run `CommitInfo.parseConventional(subject:)`, and count `--numstat` rows for files/insertions/deletions. Refactor duplicate parsing from existing methods only if it stays small and local; otherwise keep this private parser for the new helper to avoid unrelated churn.
+
+- [ ] **Step 7: Run GitService tests**
+
+Run:
+
+```bash
+xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -only-testing:AlasTests/GitServiceTests test
+```
+
+Expected: PASS for the new tests.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add Alas/Sources/Git/GitService.swift AlasTests/GitServiceTests.swift
+git commit -m "feat(git): add file snapshot and history helpers"
+```
+
+---
+
+### Task 2: Tab State and Open-or-Focus Helpers
+
+**Files:**
+- Modify: `Alas/Sources/Center/Tab.swift`
+- Modify: `Alas/Sources/Center/TabsManager.swift`
+- Test: `AlasTests/TabsManagerTests.swift`
+
+- [ ] **Step 1: Write failing tab identity tests**
+
+Add tests:
+
+```swift
+@Test func openOrFocusFileSnapshotReusesWorktreePathRefTab() {
+    let manager = TabsManager()
+    let first = manager.openOrFocusFileSnapshot(worktreeId: "wt", relativePath: "a.txt", ref: "HEAD")
+    let second = manager.openOrFocusFileSnapshot(worktreeId: "wt", relativePath: "a.txt", ref: "HEAD")
+
+    #expect(first.id == second.id)
+    #expect(manager.tabs(forWorktree: "wt").count == 1)
+}
+
+@Test func openOrFocusFileHistoryReusesWorktreePathTab() {
+    let manager = TabsManager()
+    let first = manager.openOrFocusFileHistory(worktreeId: "wt", relativePath: "a.txt")
+    let second = manager.openOrFocusFileHistory(worktreeId: "wt", relativePath: "a.txt")
+
+    #expect(first.id == second.id)
+    #expect(manager.tabs(forWorktree: "wt").count == 1)
+}
+```
+
+- [ ] **Step 2: Run tests and verify they fail**
+
+Run:
+
+```bash
+xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -only-testing:AlasTests/TabsManagerTests test
+```
+
+Expected: FAIL because tab cases and helpers do not exist.
+
+- [ ] **Step 3: Add tab cases and states**
+
+In `Tab`, add:
+
+```swift
+case fileSnapshot(FileSnapshotTabState)
+case fileHistory(FileHistoryTabState)
+```
+
+Update `id`, `title`, `iconName`, and `relativeFilePath` switches.
+
+Add states:
+
+```swift
+struct FileSnapshotTabState: Codable, Equatable, Identifiable {
+    let id: TabID
+    let worktreeId: String
+    let relativePath: String
+    let ref: String
+    var title: String
+
+    init(worktreeId: String, relativePath: String, ref: String = "HEAD") {
+        self.worktreeId = worktreeId
+        self.relativePath = relativePath
+        self.ref = ref
+        self.title = "\((relativePath as NSString).lastPathComponent) @ \(ref)"
+        self.id = "file-snapshot:\(worktreeId):\(ref):\(relativePath)"
+    }
+}
+
+struct FileHistoryTabState: Codable, Equatable, Identifiable {
+    let id: TabID
+    let worktreeId: String
+    let relativePath: String
+    var title: String
+
+    init(worktreeId: String, relativePath: String) {
+        self.worktreeId = worktreeId
+        self.relativePath = relativePath
+        self.title = "\((relativePath as NSString).lastPathComponent) History"
+        self.id = "file-history:\(worktreeId):\(relativePath)"
+    }
+}
+```
+
+- [ ] **Step 4: Add `TabsManager` open-or-focus helpers**
+
+Add:
+
+```swift
+@discardableResult
+func openOrFocusFileSnapshot(worktreeId: String, relativePath: String, ref: String = "HEAD") -> Tab {
+    let state = FileSnapshotTabState(worktreeId: worktreeId, relativePath: relativePath, ref: ref)
+    if tabs(forWorktree: worktreeId).contains(where: { $0.id == state.id }) {
+        activate(worktreeId: worktreeId, tabId: state.id)
+        return tabs(forWorktree: worktreeId).first(where: { $0.id == state.id }) ?? .fileSnapshot(state)
+    }
+    let tab = Tab.fileSnapshot(state)
+    append(tab, to: worktreeId)
+    return tab
+}
+
+@discardableResult
+func openOrFocusFileHistory(worktreeId: String, relativePath: String) -> Tab {
+    let state = FileHistoryTabState(worktreeId: worktreeId, relativePath: relativePath)
+    if tabs(forWorktree: worktreeId).contains(where: { $0.id == state.id }) {
+        activate(worktreeId: worktreeId, tabId: state.id)
+        return tabs(forWorktree: worktreeId).first(where: { $0.id == state.id }) ?? .fileHistory(state)
+    }
+    let tab = Tab.fileHistory(state)
+    append(tab, to: worktreeId)
+    return tab
+}
+```
+
+Prefer a small private helper if existing `TabsManager` has a reuse pattern nearby.
+
+- [ ] **Step 5: Run tab tests**
+
+Run the TabsManager test command.
+
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add Alas/Sources/Center/Tab.swift Alas/Sources/Center/TabsManager.swift AlasTests/TabsManagerTests.swift
+git commit -m "feat(tabs): add file snapshot and history tabs"
+```
+
+---
+
+### Task 3: File Snapshot Tab View
+
+**Files:**
+- Create: `Alas/Sources/Center/FileSnapshotTabView.swift`
+- Create: `Alas/Sources/Center/ReadonlyTextView.swift` if needed.
+- Modify: `Alas/Sources/Center/CenterPaneView.swift`
+
+- [ ] **Step 1: Add a minimal compile target view**
+
+Create `FileSnapshotTabView`:
+
+```swift
+import SwiftUI
+
+struct FileSnapshotTabView: View {
+    let worktreePath: URL
+    let state: FileSnapshotTabState
+    var codeFontFamily: String = ""
+    var codeFontSize: CGFloat = 13
+
+    @Environment(\.theme) private var theme
+    @State private var result: HeadBlobTextResult?
+    @State private var error: String?
+    private let git = GitService()
+
+    var body: some View {
+        VStack(spacing: 0) {
+            header
+            content
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
+        .background(theme.color("bg-1"))
+        .task(id: loadKey) { await load() }
+    }
+
+    private var loadKey: String { "\(worktreePath.path)\u{0}\(state.ref)\u{0}\(state.relativePath)" }
+}
+```
+
+- [ ] **Step 2: Implement header, content, and loading**
+
+Add a header with filename, `HEAD`, and directory path. Content states:
+
+```swift
+@ViewBuilder
+private var content: some View {
+    if let error {
+        Text(error)
+            .font(CenterTypography.codeFont(family: codeFontFamily, size: codeFontSize - 2))
+            .foregroundColor(theme.color("del"))
+            .padding()
+    } else if let result {
+        switch result {
+        case .available(let text):
+            ReadonlyTextView(
+                text: text,
+                font: CenterTypography.resolveCodeFont(family: codeFontFamily, size: codeFontSize),
+                textColor: NSColor.labelColor,
+                backgroundColor: .clear
+            )
+        case .missing:
+            emptyText("No HEAD version for \(state.relativePath)")
+        case .undisplayable:
+            emptyText("HEAD version is not displayable as text")
+        }
+    } else {
+        Spinner()
+            .frame(width: 16, height: 16)
+            .padding()
+    }
+}
+```
+
+Implement `ReadonlyTextView` as an `NSViewRepresentable` wrapping `NSScrollView` + `NSTextView` with `isEditable = false`, `isSelectable = true`, no rich text, and no background. If an equivalent reusable whole-file selectable text view already exists, use it instead.
+
+- [ ] **Step 3: Wire into `CenterPaneView`**
+
+Add a `case .fileSnapshot(let s)` branch:
+
+```swift
+case .fileSnapshot(let s):
+    FileSnapshotTabView(
+        worktreePath: worktree.path,
+        state: s,
+        codeFontFamily: state.config.code.fontFamily,
+        codeFontSize: CGFloat(state.config.code.fontSize)
+    )
+```
+
+- [ ] **Step 4: Regenerate project and build**
+
+Run:
+
+```bash
+xcodegen
+xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -quiet build
+```
+
+Expected: project generation succeeds and build succeeds. If `Alas.xcodeproj/project.pbxproj` changes because new Swift files were added, include that generated project change in the task commit.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Alas/Sources/Center/FileSnapshotTabView.swift Alas/Sources/Center/CenterPaneView.swift Alas.xcodeproj/project.pbxproj
+git add Alas/Sources/Center/ReadonlyTextView.swift # only if this file was created
+git commit -m "feat(center): add file snapshot tab view"
+```
+
+---
+
+### Task 4: File History Tab View
+
+**Files:**
+- Create: `Alas/Sources/Center/FileHistoryTabView.swift`
+- Modify: `Alas/Sources/Center/CenterPaneView.swift`
+- Modify: `Alas/Sources/App/AppState.swift`
+
+- [ ] **Step 1: Add AppState commit-opening helper if needed**
+
+Find existing private helpers such as `openOrFocusCommit(worktree:commit:)` in `RootView.swift`. If not globally available, add an `AppState` helper:
+
+```swift
+func openCommitTab(worktreeId: String, commit: CommitInfo) {
+    guard let worktree = worktree(withId: worktreeId) else { return }
+    if selectedWorktreeId != worktree.id {
+        focusGlobalWorktree(id: worktree.id, projectId: worktree.projectId)
+    }
+    let existing = tabs.tabs(forWorktree: worktree.id).first { tab in
+        if case .commit(let s) = tab { return s.sha == commit.sha }
+        return false
+    }
+    if let existing {
+        tabs.activate(worktreeId: worktree.id, tabId: existing.id)
+    } else {
+        let tab = tabs.appendCommit(worktreeId: worktree.id, sha: commit.sha, title: commit.shortSha)
+        tabs.activate(worktreeId: worktree.id, tabId: tab.id)
+    }
+}
+```
+
+Reuse an existing public helper if one already exists.
+
+- [ ] **Step 2: Create `FileHistoryTabView`**
+
+Create a SwiftUI view that loads `GitService.fileHistory(worktreePath:relativePath:limit: 200)` and renders:
+
+```swift
+struct FileHistoryTabView: View {
+    let worktreePath: URL
+    let state: FileHistoryTabState
+    let onSelectCommit: (CommitInfo) -> Void
+    let onCopySHA: (CommitInfo) -> Void
+
+    @Environment(\.theme) private var theme
+    @State private var commits: [CommitInfo] = []
+    @State private var loaded = false
+    @State private var error: String?
+    private let git = GitService()
+
+    var body: some View {
+        VStack(spacing: 0) {
+            header
+            content
+        }
+        .background(theme.color("bg-1"))
+        .task(id: loadKey) { await load() }
+    }
+}
+```
+
+Use `CommitRow` for rows:
+
+```swift
+ForEach(Array(commits.enumerated()), id: \.element.id) { index, commit in
+    CommitRow(
+        commit: commit,
+        isLast: index == commits.count - 1,
+        onSelect: { onSelectCommit(commit) },
+        onCopySHA: { onCopySHA(commit) }
+    )
+}
+```
+
+- [ ] **Step 3: Wire into `CenterPaneView`**
+
+Add:
+
+```swift
+case .fileHistory(let s):
+    FileHistoryTabView(
+        worktreePath: worktree.path,
+        state: s,
+        onSelectCommit: { state.openCommitTab(worktreeId: worktree.id, commit: $0) },
+        onCopySHA: { Clipboard.copy($0.sha) }
+    )
+```
+
+- [ ] **Step 4: Regenerate project and build**
+
+Run:
+
+```bash
+xcodegen
+xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -quiet build
+```
+
+Expected: project generation succeeds and build succeeds. If `Alas.xcodeproj/project.pbxproj` changes because the new Swift file was added, include that generated project change in the task commit.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Alas/Sources/Center/FileHistoryTabView.swift Alas/Sources/Center/CenterPaneView.swift Alas/Sources/App/AppState.swift Alas.xcodeproj/project.pbxproj
+git commit -m "feat(center): add file history tab view"
+```
+
+---
+
+### Task 5: Context Menu Wiring
+
+**Files:**
+- Modify: `Alas/Sources/App/AppState.swift`
+- Modify: `Alas/Sources/Right/ChangedRow.swift`
+- Modify: `Alas/Sources/Right/WorkingTreeSectionView.swift`
+- Modify: `Alas/Sources/Right/ChangesTabView.swift`
+- Optional Test: small callback plumbing tests if existing right-pane tests can cover this cheaply.
+
+- [ ] **Step 1: Add AppState helpers for snapshot/history**
+
+Add:
+
+```swift
+func openFileSnapshotAtHEAD(relativePath: String, worktreeId: String) {
+    guard let worktree = worktree(withId: worktreeId) else { return }
+    guard !projectsManager.isWorktreeHidden(projectId: worktree.projectId, path: worktree.path) else { return }
+    if selectedWorktreeId != worktree.id {
+        focusGlobalWorktree(id: worktree.id, projectId: worktree.projectId)
+    }
+    _ = tabs.openOrFocusFileSnapshot(worktreeId: worktree.id, relativePath: relativePath, ref: "HEAD")
+}
+
+func openFileHistory(relativePath: String, worktreeId: String) {
+    guard let worktree = worktree(withId: worktreeId) else { return }
+    guard !projectsManager.isWorktreeHidden(projectId: worktree.projectId, path: worktree.path) else { return }
+    if selectedWorktreeId != worktree.id {
+        focusGlobalWorktree(id: worktree.id, projectId: worktree.projectId)
+    }
+    _ = tabs.openOrFocusFileHistory(worktreeId: worktree.id, relativePath: relativePath)
+}
+```
+
+- [ ] **Step 2: Add `ChangedRow` callbacks and menu items**
+
+Add properties:
+
+```swift
+var onViewAtHEAD: (() -> Void)? = nil
+var onCompareWithHEAD: (() -> Void)? = nil
+var onFileHistory: (() -> Void)? = nil
+var viewAtHEADEnabled: Bool = true
+```
+
+Add menu items near `Open File`:
+
+```swift
+Button("View at HEAD") { onViewAtHEAD?() }
+    .disabled(!viewAtHEADEnabled || onViewAtHEAD == nil)
+Button("Compare with HEAD") { onCompareWithHEAD?() }
+    .disabled(onCompareWithHEAD == nil)
+Button("File History") { onFileHistory?() }
+    .disabled(onFileHistory == nil)
+```
+
+- [ ] **Step 3: Thread callbacks through `WorkingTreeSectionView`**
+
+Add properties:
+
+```swift
+var onViewAtHEAD: ((ChangedFile) -> Void)? = nil
+var onCompareWithHEAD: ((ChangedFile) -> Void)? = nil
+var onFileHistory: ((ChangedFile) -> Void)? = nil
+```
+
+When constructing `ChangedRow`, pass mapped closures and:
+
+```swift
+viewAtHEADEnabled: !isUntracked(file)
+```
+
+Use an availability helper instead of only `isUntracked(file)`:
+
+```swift
+private func hasHeadVersion(_ file: ChangedFile) -> Bool {
+    file.status != "A"
+}
+```
+
+This disables unstaged untracked adds and staged adds, both of which have no `HEAD:<path>` blob. It keeps tracked deletes enabled, which is the important deleted-file case from the spec.
+
+- [ ] **Step 4: Wire from `ChangesTabView`**
+
+In `WorkingTreeSectionView(...)` add:
+
+```swift
+onViewAtHEAD: { file in
+    appState.openFileSnapshotAtHEAD(relativePath: file.path, worktreeId: rps.worktree.id)
+},
+onCompareWithHEAD: { file in
+    appState.openDiffTab(forFileInWorktree: rps.worktree, relativePath: file.path)
+},
+onFileHistory: { file in
+    appState.openFileHistory(relativePath: file.path, worktreeId: rps.worktree.id)
+},
+```
+
+- [ ] **Step 5: Build**
+
+Run:
+
+```bash
+xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -quiet build
+```
+
+Expected: build succeeds.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add Alas/Sources/App/AppState.swift Alas/Sources/Right/ChangedRow.swift Alas/Sources/Right/WorkingTreeSectionView.swift Alas/Sources/Right/ChangesTabView.swift
+git commit -m "feat(changes): add file history context actions"
+```
+
+---
+
+### Task 6: Final Verification
+
+**Files:**
+- No planned edits unless verification finds a defect.
+
+- [ ] **Step 1: Run focused tests**
+
+Run:
+
+```bash
+xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -only-testing:AlasTests/GitServiceTests -only-testing:AlasTests/TabsManagerTests test
+```
+
+Expected: PASS.
+
+- [ ] **Step 2: Run required project build**
+
+Run:
+
+```bash
+xcodegen
+xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -quiet build
+```
+
+Expected: project generation succeeds and build succeeds.
+
+- [ ] **Step 3: Run required project tests**
+
+Run:
+
+```bash
+xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' test
+```
+
+Expected: PASS.
+
+- [ ] **Step 4: Manual smoke test**
+
+In the app, use a worktree with:
+
+- Modified tracked file: `View at HEAD`, `Compare with HEAD`, and `File History` all open the expected tabs.
+- Deleted tracked file: `View at HEAD` opens committed content and `Open File` remains unavailable.
+- Added untracked file: `View at HEAD` is disabled and `File History` opens empty history.
+- Renamed tracked file: `File History` follows prior path where Git detects the rename.
+
+- [ ] **Step 5: Final commit if verification fixes were needed**
+
+If Step 1-4 required follow-up fixes:
+
+```bash
+git add <changed-files>
+git commit -m "fix(changes): polish file history actions"
+```

--- a/docs/superpowers/specs/2026-06-21-changed-file-head-history-design.md
+++ b/docs/superpowers/specs/2026-06-21-changed-file-head-history-design.md
@@ -1,0 +1,105 @@
+# Changed File HEAD View and History Design
+
+## Goal
+
+Add three changed-file context menu actions:
+
+- `View at HEAD`: open the committed `HEAD:<path>` content as a read-only tab.
+- `Compare with HEAD`: open or focus the existing working-tree diff tab for the file.
+- `File History`: open a path-scoped commit history tab.
+
+This covers the common right-click workflow for comparing a dirty file with its committed version and reviewing prior changes to that file.
+
+## Scope
+
+In scope:
+
+- File-level context menu items in `ChangedRow`.
+- Callback plumbing through `WorkingTreeSectionView` and `ChangesTabView`.
+- New tab state and views for a read-only HEAD snapshot and file history.
+- Git helpers for reading `HEAD:<path>` and listing commits that touched a path.
+- Tests for tab identity, GitService parsing, and callback/menu wiring where practical.
+
+Out of scope:
+
+- Blame / annotate.
+- Folder history.
+- Editing historical or HEAD snapshot content.
+- Replacing the existing diff tab UI.
+
+## User Experience
+
+The changed-file context menu gains:
+
+- `Open File`
+- `View at HEAD`
+- `Compare with HEAD`
+- `File History`
+- existing copy/reveal/diff/stage/discard/ignore actions
+
+`View at HEAD` opens a read-only center tab titled like `filename @ HEAD`. The tab renders text with the same editor typography and syntax highlighting path where practical, but does not create an editable `EditorBuffer`. If the file is absent at `HEAD` or is not UTF-8 text, the tab shows a small empty/error state.
+
+`Compare with HEAD` opens or focuses the current unstaged `DiffTabView` for the path. This makes the action explicit in the context menu while reusing existing diff behavior.
+
+`File History` opens a center tab titled like `filename History`. It lists commits returned by `git log --follow -- <path>` newest-first using the existing `CommitRow` presentation. Selecting a row opens the existing commit tab for that SHA. Empty history and git failures show inline states inside the tab.
+
+## Architecture
+
+Add two new tab cases:
+
+- `Tab.fileSnapshot(FileSnapshotTabState)`
+- `Tab.fileHistory(FileHistoryTabState)`
+
+The snapshot tab state contains `worktreeId`, `relativePath`, `ref` initially fixed to `HEAD`, and a stable ID keyed by all three. The history tab state contains `worktreeId` and `relativePath`, with a stable ID keyed by both. `TabsManager` gets open-or-focus helpers for both cases so repeated context-menu actions focus existing tabs.
+
+Add center views:
+
+- `FileSnapshotTabView`
+- `FileHistoryTabView`
+
+`CenterPaneView` renders the new tab cases. Snapshot loading happens in the snapshot view with `GitService.headBlobText(...)`. History loading happens in the history view with `GitService.fileHistory(...)`. Both views keep loading/error state local and reload when their tab key changes.
+
+## Git Behavior
+
+Add public GitService helpers:
+
+- `headBlobText(worktreePath:relativePath:) async throws -> HeadBlobTextResult`
+- `fileHistory(worktreePath:relativePath:limit:) async throws -> [CommitInfo]`
+
+`HeadBlobTextResult` distinguishes `.available(String)`, `.missing`, and `.undisplayable` so the view can show the correct empty state. `headBlobText` uses `git show HEAD:<path>` via `Process.gitData`, returns `.missing` for absent blobs, returns `.undisplayable` for binary or non-UTF-8 content, and throws only for unexpected process failures that should surface as an error state.
+
+`fileHistory` uses a single `git log --follow -n 200 --pretty=tformat:... --numstat -- <path>` pass and parses into the existing `CommitInfo` model. Rename following is handled by Git. The first version uses this fixed 200-commit limit without pagination.
+
+Paths are passed as pathspecs after `--` and never interpolated into shell commands.
+
+## Error Handling
+
+`View at HEAD` is disabled for untracked added files. If a tracked file is deleted in the working tree, the action remains available because `HEAD:<path>` is exactly what the user wants.
+
+Snapshot states:
+
+- Loading: spinner.
+- Missing at HEAD: `No HEAD version for <path>`.
+- Binary or non-UTF-8: `HEAD version is not displayable as text`.
+- Git error: concise error strip.
+
+History states:
+
+- Loading: spinner.
+- Empty: `No history for <path>`.
+- Git error: concise error strip with retry by re-opening or automatic task reload.
+
+## Testing
+
+Add focused tests:
+
+- `TabsManagerTests`: snapshot and history tabs reuse existing tab IDs for the same worktree/path/ref and create distinct tabs for distinct paths.
+- `GitServiceTests` or a dedicated file: `headBlobText` returns `.available` with committed text, returns `.missing` for paths missing at HEAD, returns `.undisplayable` for binary content, and `fileHistory` returns only commits touching the path.
+- `ChangedRow` / `WorkingTreeSectionView` callback tests if the existing test harness supports SwiftUI context-menu inspection; otherwise cover callback plumbing with small model-level tests and rely on compile-time integration.
+
+Manual verification:
+
+- Modified tracked file: all three actions work.
+- Deleted tracked file: `View at HEAD` works; `Open File` stays unavailable if the working-tree file is gone.
+- Added untracked file: `View at HEAD` is disabled; `File History` shows empty history.
+- Renamed file: history follows prior path where Git can detect the rename.


### PR DESCRIPTION
## Summary

Adds changed-file context menu actions for:

- viewing the file content at `HEAD` in a read-only snapshot tab
- comparing the current file state with `HEAD`
- opening path-scoped file history

The implementation adds Git helpers, tab state and open-or-focus helpers, snapshot/history center-pane views, and right-pane menu wiring. `Compare with HEAD` uses an explicit HEAD comparison mode so mixed staged/unstaged files show the combined current state, while read-only comparison diffs suppress mutation hunk actions.

## Verification

- `xcodegen` succeeded
- `git diff --check HEAD~5 HEAD` succeeded
- `xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -quiet build` is blocked in this worktree because `ThirdParty/zmx` is missing
- `ALAS_ZMX_OPTIONAL=1 xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -quiet build` then blocks because `ThirdParty/fff` is missing
- `xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' test` is blocked by the same missing `ThirdParty/zmx` build phase