### PR TITLE
fix(changes): unify git menu ellipsis, destructive roles, and confirmation patterns

### DIFF
--- a/Alas/Sources/Right/ChangedRow.swift
+++ b/Alas/Sources/Right/ChangedRow.swift
@@ -77,7 +77,7 @@ struct ChangedRow: View {
             } else if onStage != nil {
                 Button(file.stage == .staged ? "Unstage" : "Stage") { onStage?() }
             }
-            Button("Discard Changes...") { onDiscard?() }
+            Button("Discard Changes…", role: .destructive) { onDiscard?() }
             if let ignoreMenu {
                 Divider()
                 ignoreMenu

--- a/Alas/Sources/Right/CommitRow.swift
+++ b/Alas/Sources/Right/CommitRow.swift
@@ -15,9 +15,7 @@ struct CommitRow: View {
     @Environment(\.theme) private var theme
     @StateObject private var copyFeedback = CopyFeedbackState()
     @State private var shaHovering = false
-    @State private var pendingCherryPick = false
     @State private var pendingRevert = false
-
     var body: some View {
         Button(action: onSelect) {
             HStack(alignment: .top, spacing: 8) {
@@ -37,7 +35,7 @@ struct CommitRow: View {
         .copyFeedbackOverlay(message: copyFeedback.message)
         .contextMenu {
             if let onEdit {
-                Button("Edit Commit...") { onEdit() }
+                Button("Edit Commit…") { onEdit() }
                 Divider()
             }
             Button("Copy Commit SHA") { copySHA() }
@@ -47,24 +45,12 @@ struct CommitRow: View {
             }
             if onCherryPick != nil {
                 Divider()
-                Button("Cherry-pick…") { pendingCherryPick = true }
+                Button("Cherry-pick…") { onCherryPick?() }
             }
             if onRevert != nil {
                 Divider()
                 Button("Revert Commit…", role: .destructive) { pendingRevert = true }
             }
-        }
-        .confirmationDialog(
-            "Cherry-pick commit?",
-            isPresented: $pendingCherryPick,
-            titleVisibility: .visible
-        ) {
-            Button("Cherry-pick \(String(commit.sha.prefix(7)))", role: .destructive) {
-                onCherryPick?()
-            }
-            Button("Cancel", role: .cancel) {}
-        } message: {
-            Text("Apply this commit to the current branch.")
         }
         .confirmationDialog(
             "Revert commit?",

--- a/Alas/Sources/Right/CommitsSectionView.swift
+++ b/Alas/Sources/Right/CommitsSectionView.swift
@@ -153,7 +153,7 @@ struct CommitsSectionView: View {
     private var expandedBody: some View {
         // 1. Worktree commits ("your work") OR today's empty placeholder.
         if !commits.isEmpty {
-            ForEach(Array(commits.enumerated()), id: \.element.id) { idx, commit in
+                ForEach(Array(commits.enumerated()), id: \.element.id) { idx, commit in
                 CommitRow(
                     commit: commit,
                     isLast: idx == commits.count - 1 && olderCommits.isEmpty,
@@ -162,7 +162,7 @@ struct CommitsSectionView: View {
                     onCopyMessage: { Clipboard.copy(commit.fullMessage) },
                     onOpenRemote: rps.commitsNeedPush ? nil : openRemoteAction(for: commit, remote: rps.primaryCommitRemote),
                     onEdit: { onEdit(commit) },
-                    onCherryPick: { rps.runCherryPick(sha: commit.sha) },
+                    onCherryPick: { rps.requestCherryPick(sha: commit.sha) },
                     onRevert: { rps.runRevert(sha: commit.sha) }
                 )
             }
@@ -178,7 +178,7 @@ struct CommitsSectionView: View {
 
         // 3. Older commits — dimmed when comparisonRef exists, plain when not.
         if !olderCommits.isEmpty {
-            ForEach(Array(olderCommits.enumerated()), id: \.element.id) { idx, commit in
+                ForEach(Array(olderCommits.enumerated()), id: \.element.id) { idx, commit in
                 CommitRow(
                     commit: commit,
                     isLast: idx == olderCommits.count - 1,
@@ -187,7 +187,7 @@ struct CommitsSectionView: View {
                     onCopySHA: { onCopySHA(commit) },
                     onCopyMessage: { Clipboard.copy(commit.fullMessage) },
                     onOpenRemote: openRemoteAction(for: commit, remote: rps.commitRemote),
-                    onCherryPick: { rps.runCherryPick(sha: commit.sha) },
+                    onCherryPick: { rps.requestCherryPick(sha: commit.sha) },
                     onRevert: { rps.runRevert(sha: commit.sha) }
                 )
             }

--- a/Alas/Sources/Right/RightPaneState.swift
+++ b/Alas/Sources/Right/RightPaneState.swift
@@ -121,6 +121,7 @@ final class RightPaneState {
     var trackUpstreamForCommits: Bool = false
 
     var pendingDiscard: PendingDiscard? = nil
+    var pendingCherryPickSHA: String? = nil
 
     /// True while the workspace-level agent invocation is running.
     /// Surfaced in the Conflicts section header as a spinner; the
@@ -838,6 +839,20 @@ final class RightPaneState {
 
     func cancelDiscard() {
         pendingDiscard = nil
+    }
+
+    func requestCherryPick(sha: String) {
+        pendingCherryPickSHA = sha
+    }
+
+    func cancelCherryPick() {
+        pendingCherryPickSHA = nil
+    }
+
+    func confirmCherryPick() {
+        guard let sha = pendingCherryPickSHA else { return }
+        pendingCherryPickSHA = nil
+        runCherryPick(sha: sha)
     }
 
     @MainActor

--- a/Alas/Sources/Right/RightPaneView.swift
+++ b/Alas/Sources/Right/RightPaneView.swift
@@ -118,5 +118,24 @@ struct RightPaneView: View {
                 Text(PendingDiscard.alertMessage(for: p))
             }
         )
+        .alert(
+            "Cherry-pick commit?",
+            isPresented: Binding(
+                get: { rps.pendingCherryPickSHA != nil },
+                set: { if !$0 { rps.cancelCherryPick() } }
+            ),
+            presenting: rps.pendingCherryPickSHA,
+            actions: { sha in
+                Button("Cherry-pick \(sha.prefix(7))") {
+                    rps.confirmCherryPick()
+                }
+                Button("Cancel", role: .cancel) {
+                    rps.cancelCherryPick()
+                }
+            },
+            message: { _ in
+                Text("Apply this commit to the current branch.")
+            }
+        )
     }
 }

--- a/Alas/Sources/Right/WorkingTreeSectionView.swift
+++ b/Alas/Sources/Right/WorkingTreeSectionView.swift
@@ -67,7 +67,7 @@ struct WorkingTreeSectionView: View {
                 if !changes.isEmpty {
                     Divider()
                 }
-                Button("Discard all working tree changes...") {
+                Button("Discard all working tree changes…", role: .destructive) {
                     onDiscardAll?()
                 }
                 .disabled(changes.isEmpty)
@@ -192,7 +192,7 @@ struct WorkingTreeSectionView: View {
                         if !stagedEntries.isEmpty || !unstagedEntries.isEmpty {
                             Divider()
                         }
-                        Button("Discard Changes...") {
+                        Button("Discard Changes…", role: .destructive) {
                             onDiscardFolder?(node.path)
                         }
                         if folderUntracked {


### PR DESCRIPTION
Closes #592

A consistency pass across the Changes-tab git menus:

- **Ellipsis style**: standardize on the real ellipsis character (U+2026) for all menu actions.
- **Destructive-role semantics**: mark all Discard actions as destructive, and remove the destructive role from the additive Cherry-pick action.
- **Confirmation patterns**: route Cherry-pick through RightPaneState using the same pending-state + alert pattern already used for Discard, replacing the inline confirmationDialog in CommitRow.

## Verification

- Local Swift build passes; full test suite is blocked on this laptop by a pre-existing Rust x86_64-apple-darwin toolchain issue in the fff build phase, so CI is the authoritative verifier.
