### PR TITLE
feat(trees): Remove folder chevrons from file trees

### DIFF
--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -238,6 +238,7 @@
 		38B6857CDB7D094A46F653E2 /* ACPSessionByteAccounting.swift in Sources */ = {isa = PBXBuildFile; fileRef = EBF4DE84207D33D518DD7D3E /* ACPSessionByteAccounting.swift */; };
 		38DCAD9DA4B9418906700A25 /* MergeView3Way.swift in Sources */ = {isa = PBXBuildFile; fileRef = 695C887147631ACF1FA73C3F /* MergeView3Way.swift */; };
 		38EB2BAA50A7B7B37DDE2A4C /* RightPaneStateBaseBranchTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6713F5A8712C0962BED1EFEA /* RightPaneStateBaseBranchTests.swift */; };
+		3910AEED9AC1888582616BEA /* FileTreeRowIndentationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 431BECA1461B76DF86BBFBDF /* FileTreeRowIndentationTests.swift */; };
 		395276FB3018E0B9E68A7D81 /* ACPMockClientTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11BA9F25CB0A6A2BFDB390EE /* ACPMockClientTests.swift */; };
 		395BC74AF07FD44D67DBE579 /* EditorOverlayPanel.swift in Sources */ = {isa = PBXBuildFile; fileRef = F6883364648BF4B9F5DA131F /* EditorOverlayPanel.swift */; };
 		3961F6003185B2FC9DFE7E14 /* ImageDiffDifferenceComputerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9278ED5964A66871F5299F0C /* ImageDiffDifferenceComputerTests.swift */; };
@@ -1414,6 +1415,7 @@
 		4261E417947C1A21E77C1587 /* GitStatusCache.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GitStatusCache.swift; sourceTree = "<group>"; };
 		4306DE43C5ADCC65310C1169 /* ACPQuestionPrompt.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPQuestionPrompt.swift; sourceTree = "<group>"; };
 		430FCE70CDAB35CB0594CF44 /* AlasCLIReviewTargetResolver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlasCLIReviewTargetResolver.swift; sourceTree = "<group>"; };
+		431BECA1461B76DF86BBFBDF /* FileTreeRowIndentationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileTreeRowIndentationTests.swift; sourceTree = "<group>"; };
 		435D9E527A76820947F426A8 /* ACPFilesystem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPFilesystem.swift; sourceTree = "<group>"; };
 		436E8992D7373486BA25D290 /* CodeTextViewCompletionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CodeTextViewCompletionTests.swift; sourceTree = "<group>"; };
 		43DF691FC778F3A71CE20FBB /* StartupScriptInstallerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StartupScriptInstallerTests.swift; sourceTree = "<group>"; };
@@ -2470,6 +2472,7 @@
 				1977C85C3DFD1F232A2755AD /* FilesTabFilterTests.swift */,
 				0C8541BE5617C7E212CCD034 /* FilesTabLoadingIndicatorTests.swift */,
 				3ABD3A575FAEC381A5744BFA /* FileTreeBuilderTests.swift */,
+				431BECA1461B76DF86BBFBDF /* FileTreeRowIndentationTests.swift */,
 				2CBAD18141C1A9B654F56982 /* FileTypeIconTests.swift */,
 				A42BB90D7C9A270876F470EB /* FocusDirectionTests.swift */,
 				B5BEBDB5A6617C62D0F1C0D1 /* FormatOnSaveTests.swift */,
@@ -5236,6 +5239,7 @@
 				8514D39E901232E7C7343C26 /* FakeJSONRPCTransport.swift in Sources */,
 				7602FDB0353222613CD39FFE /* FileIndexTests.swift in Sources */,
 				D85B5032B8F2A71AFF5A13B6 /* FileTreeBuilderTests.swift in Sources */,
+				3910AEED9AC1888582616BEA /* FileTreeRowIndentationTests.swift in Sources */,
 				6ED129AC9B6798F76F7D3A51 /* FileTypeIconTests.swift in Sources */,
 				61D309EDA409B06C83D52CEE /* FilesTabCompactChainTests.swift in Sources */,
 				A0F1E46BC1A9E2CC21805EE7 /* FilesTabFilterTests.swift in Sources */,

--- a/Alas/Sources/Right/ChangedRow.swift
+++ b/Alas/Sources/Right/ChangedRow.swift
@@ -24,6 +24,10 @@ struct ChangedRow: View {
     var ignoreMenu:       AnyView? = nil
     @Environment(\.theme) var theme
 
+    nonisolated static func rowLeadingPadding(depth: Int) -> CGFloat {
+        12 + CGFloat(depth * 14)
+    }
+
     var body: some View {
         let basename = file.path.split(separator: "/").last.map(String.init) ?? file.path
         let add = displayAdd ?? file.add
@@ -45,7 +49,7 @@ struct ChangedRow: View {
                 StatusBadge(status: file.status)
             }
             .font(.system(size: 11, design: .monospaced))
-            .padding(.leading, CGFloat(12 + (depth == 0 ? 0 : depth * 14 + 14)))
+            .padding(.leading, Self.rowLeadingPadding(depth: depth))
             .padding(.trailing, 12)
             .padding(.vertical, 4)
             .frame(maxWidth: .infinity, alignment: .leading)

--- a/Alas/Sources/Right/FilesTabView.swift
+++ b/Alas/Sources/Right/FilesTabView.swift
@@ -14,6 +14,14 @@ struct FilesTabView: View {
 
     @Environment(\.theme) private var theme
 
+    nonisolated static func rowLeadingPadding(depth: Int) -> CGFloat {
+        12 + CGFloat(depth * 14)
+    }
+
+    nonisolated static func messageLeadingPadding(depth: Int) -> CGFloat {
+        rowLeadingPadding(depth: depth)
+    }
+
     var body: some View {
         ScrollViewReader { proxy in
             VStack(spacing: 0) {
@@ -88,12 +96,6 @@ struct FilesTabView: View {
                         }
                     } label: {
                         HStack(spacing: 6) {
-                            if canExpand {
-                                Icon(name: open ? "chev-down" : "chev-right", size: 10, color: theme.color("fg-faint"))
-                                    .frame(width: 14, height: 14)
-                            } else {
-                                Color.clear.frame(width: 14, height: 14)
-                            }
                             FolderIconView(
                                 name: terminal.name,
                                 path: terminal.path,
@@ -121,7 +123,7 @@ struct FilesTabView: View {
                                     .accessibilityLabel("Loading \(terminal.name)")
                             }
                         }
-                        .padding(.leading, CGFloat(12 + depth * 14))
+                        .padding(.leading, Self.rowLeadingPadding(depth: depth))
                         .padding(.trailing, 12)
                         .padding(.vertical, 4)
                         .frame(maxWidth: .infinity, alignment: .leading)
@@ -177,7 +179,7 @@ struct FilesTabView: View {
                             StatusBadge(status: badge)
                         }
                     }
-                    .padding(.leading, CGFloat(12 + depth * 14 + 14))
+                    .padding(.leading, Self.rowLeadingPadding(depth: depth))
                     .padding(.trailing, 12)
                     .padding(.vertical, 4)
                     .frame(maxWidth: .infinity, alignment: .leading)
@@ -324,7 +326,7 @@ struct FilesTabView: View {
         Text(text)
             .font(.system(size: 11, design: .monospaced))
             .foregroundColor(theme.color("fg-faint"))
-            .padding(.leading, CGFloat(12 + depth * 14 + 14))
+            .padding(.leading, Self.messageLeadingPadding(depth: depth))
             .padding(.trailing, 12)
             .padding(.vertical, 4)
             .frame(maxWidth: .infinity, alignment: .leading)

--- a/Alas/Sources/Right/WorkingTreeSectionView.swift
+++ b/Alas/Sources/Right/WorkingTreeSectionView.swift
@@ -29,6 +29,11 @@ struct WorkingTreeSectionView: View {
     private var changeGroups: [WorkingTreeChangeGroup] {
         WorkingTreeChangeGroup.group(files: changes)
     }
+
+    nonisolated static func directoryRowLeadingPadding(depth: Int) -> CGFloat {
+        12 + CGFloat(depth * 14)
+    }
+
     private var totalAdd: Int { changeGroups.reduce(0) { $0 + $1.add } }
     private var totalDel: Int { changeGroups.reduce(0) { $0 + $1.del } }
 
@@ -150,8 +155,6 @@ struct WorkingTreeSectionView: View {
                         }
                     } label: {
                         HStack(spacing: 6) {
-                            Icon(name: open ? "chev-down" : "chev-right", size: 10, color: theme.color("fg-faint"))
-                                .frame(width: 14, height: 14)
                             StageChip(state: stageChipState(for: folderState)) {
                                 switch folderState {
                                 case .staged:           onUnstageAll?(stagedEntries)
@@ -171,7 +174,7 @@ struct WorkingTreeSectionView: View {
                                 .truncationMode(.middle)
                             Spacer()
                         }
-                        .padding(.leading, CGFloat(12 + depth * 14))
+                        .padding(.leading, Self.directoryRowLeadingPadding(depth: depth))
                         .padding(.trailing, 12)
                         .padding(.vertical, 4)
                         .frame(maxWidth: .infinity, alignment: .leading)

--- a/AlasTests/FileTreeRowIndentationTests.swift
+++ b/AlasTests/FileTreeRowIndentationTests.swift
@@ -1,0 +1,18 @@
+import SwiftUI
+import Testing
+@testable import Alas
+
+struct FileTreeRowIndentationTests {
+    @Test func filesTabRowsUseOneIndentStepPerDepth() {
+        #expect(FilesTabView.rowLeadingPadding(depth: 0) == 12)
+        #expect(FilesTabView.rowLeadingPadding(depth: 1) == 26)
+        #expect(FilesTabView.messageLeadingPadding(depth: 1) == 26)
+    }
+
+    @Test func workingTreeRowsUseOneIndentStepPerDepth() {
+        #expect(WorkingTreeSectionView.directoryRowLeadingPadding(depth: 0) == 12)
+        #expect(WorkingTreeSectionView.directoryRowLeadingPadding(depth: 1) == 26)
+        #expect(ChangedRow.rowLeadingPadding(depth: 0) == 12)
+        #expect(ChangedRow.rowLeadingPadding(depth: 1) == 26)
+    }
+}


### PR DESCRIPTION
## Summary
- Remove folder disclosure chevrons from Files and Working tree rows
- Align file, folder, and tree-message indentation to a single depth step
- Add focused indentation regression coverage

## Verification
- `rtk xcodegen`
- `ALAS_FFF_TARGET_ARCH=arm64 rtk xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS,arch=arm64' -only-testing:AlasTests/FileTreeRowIndentationTests test`