### PR TITLE
fix(editor): preserve horizontal offset when revealing files

### DIFF
--- a/Alas/Sources/Code/Editor/CodeEditorCoordinator.swift
+++ b/Alas/Sources/Code/Editor/CodeEditorCoordinator.swift
@@ -905,12 +905,27 @@ final class CodeEditorCoordinator {
         let target = min(charIndex + character, nsString.length)
         let range = NSRange(location: target, length: 0)
         textView.setSelectedRange(range)
-        textView.scrollRangeToVisible(range)
+        scrollRangeToVisiblePreservingHorizontalOffset(range, in: textView)
         highlightRevealLine(containing: target, in: nsString, textView: textView)
         lastAppliedReveal = (tabId: tabId, line: line, character: character, revision: revision)
         if let wid = currentWorktreeId {
             appState.tabs.consumeReveal(worktreeId: wid, tabId: tabId)
         }
+    }
+
+    private func scrollRangeToVisiblePreservingHorizontalOffset(_ range: NSRange, in textView: CodeTextView) {
+        guard let scrollView = textView.enclosingScrollView else {
+            textView.scrollRangeToVisible(range)
+            return
+        }
+
+        let clipView = scrollView.contentView
+        let originalX = clipView.bounds.origin.x
+        textView.scrollRangeToVisible(range)
+
+        guard clipView.bounds.origin.x != originalX else { return }
+        clipView.scroll(to: NSPoint(x: originalX, y: clipView.bounds.origin.y))
+        scrollView.reflectScrolledClipView(clipView)
     }
 
     private func highlightRevealLine(containing target: Int, in nsString: NSString, textView: CodeTextView) {

--- a/AlasTests/EditorBufferTests.swift
+++ b/AlasTests/EditorBufferTests.swift
@@ -753,6 +753,64 @@ struct EditorBufferTests {
         #expect(preservedBackground == findHighlightColor)
     }
 
+    @Test func coordinatorRevealKeepsEditorHorizontallyAtLeadingEdge() throws {
+        let root = tempWorktree()
+        let prefix = String(repeating: "0123456789 ", count: 40)
+        _ = try writeFile(root, "a.swift", "short\n\(prefix)target\n")
+        let appState = AppState()
+        appState.config.code.fontFamily = "Menlo"
+        let buffer = appState.tabs.buffer(
+            worktreeId: "wt",
+            tabId: "tab-a",
+            worktreeRoot: root,
+            relativePath: "a.swift"
+        )
+        let scrollView = NSScrollView(frame: NSRect(x: 0, y: 0, width: 220, height: 120))
+        scrollView.hasVerticalScroller = true
+        scrollView.hasHorizontalScroller = true
+        scrollView.autohidesScrollers = false
+        let layoutManager = NSLayoutManager()
+        let textContainer = NSTextContainer(size: NSSize(
+            width: CGFloat.greatestFiniteMagnitude,
+            height: CGFloat.greatestFiniteMagnitude
+        ))
+        textContainer.widthTracksTextView = false
+        textContainer.heightTracksTextView = false
+        layoutManager.addTextContainer(textContainer)
+        let textView = CodeTextView(
+            frame: NSRect(x: 0, y: 0, width: 220, height: 120),
+            textContainer: textContainer
+        )
+        textView.minSize = NSSize(width: 0, height: 0)
+        textView.maxSize = NSSize(
+            width: CGFloat.greatestFiniteMagnitude,
+            height: CGFloat.greatestFiniteMagnitude
+        )
+        textView.isHorizontallyResizable = true
+        textView.isVerticallyResizable = true
+        textView.autoresizingMask = []
+        scrollView.documentView = textView
+        scrollView.layoutSubtreeIfNeeded()
+        let coordinator = CodeEditorCoordinator(appState: appState)
+        let theme = try ThemeStore().current
+
+        coordinator.attach(
+            textView: textView,
+            buffer: buffer,
+            layoutManager: layoutManager,
+            worktreeId: "wt",
+            worktreeRoot: root,
+            tabId: "tab-a",
+            revealLine: 1,
+            revealCharacter: prefix.utf16.count,
+            revealRevision: 0,
+            theme: theme
+        )
+
+        #expect(textView.selectedRange().location > prefix.utf16.count)
+        #expect(scrollView.contentView.bounds.origin.x == 0)
+    }
+
     @Test func coordinatorClampsStaleRevealHighlightRangeAfterEdit() throws {
         let root = tempWorktree()
         _ = try writeFile(root, "a.swift", "line one\nline two\nline three\n")


### PR DESCRIPTION
## Summary
- Preserve the editor scroll view's existing horizontal offset when applying reveal targets.
- Add a regression test for opening/revealing a far-right match without losing the leading edge.

## Testing
- `rtk xcodebuild -project Alas.xcodeproj -scheme Alas -destination platform=macOS,arch=arm64 -only-testing AlasTests/EditorBufferTests/coordinatorRevealKeepsEditorHorizontallyAtLeadingEdge CURRENT_ARCH=arm64 ARCHS=arm64 ONLY_ACTIVE_ARCH=YES test -quiet`