### PR TITLE
feat(changes): Add stash support to Changes tab

### DIFF
--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -494,6 +494,7 @@
 		7324AD398C5F4168C067F4B0 /* CodeEditorLineNumberRulerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 76B767602C3F8E5909A44B7C /* CodeEditorLineNumberRulerView.swift */; };
 		73480309CF2CBA78879268DD /* BlockedNudgeBanner.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C860C82F92CF8B7CC58FF4D /* BlockedNudgeBanner.swift */; };
 		735B86E1E8F8F593049937BB /* ReviewSessionTargetTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C3C11FFC65FA56B722E2E7D /* ReviewSessionTargetTests.swift */; };
+		7374C72F780CEE12E81997B9 /* StashDiffTabView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E373805AEFD068B97BC33A82 /* StashDiffTabView.swift */; };
 		7377F6BACEEA621425E54FBC /* TreeSitterTOML in Frameworks */ = {isa = PBXBuildFile; productRef = 69EF3147FDD8F28F8D65D4FC /* TreeSitterTOML */; };
 		737EC7C9A35C9ED61ED67B83 /* RepoSelectorModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 220514C66CF29B6FD04EAB0B /* RepoSelectorModelTests.swift */; };
 		7433DB9396574A02DBF9953D /* ACPLaunchSpecTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3B53E3E92FA696866F44FDD /* ACPLaunchSpecTests.swift */; };
@@ -2080,6 +2081,7 @@
 		E288FF8FA00AC18E1CDD3CA2 /* NewWorktreeDialogTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NewWorktreeDialogTests.swift; sourceTree = "<group>"; };
 		E2C5BD0110EB8EDE7BB4ED93 /* ACPHistorySidebar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPHistorySidebar.swift; sourceTree = "<group>"; };
 		E2D5632302DE981B0BD36273 /* ACPSelectChipMetricsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPSelectChipMetricsTests.swift; sourceTree = "<group>"; };
+		E373805AEFD068B97BC33A82 /* StashDiffTabView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StashDiffTabView.swift; sourceTree = "<group>"; };
 		E43F9F04AF6A6FF0A4D328F4 /* CommitHeaderViewTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommitHeaderViewTests.swift; sourceTree = "<group>"; };
 		E444D51CB35528C8E5AB150A /* FuzzyMatchTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FuzzyMatchTests.swift; sourceTree = "<group>"; };
 		E49006251DFBE67CCD0C4008 /* ACPMentionPicker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPMentionPicker.swift; sourceTree = "<group>"; };
@@ -3219,6 +3221,7 @@
 				EBBFE202A6AB6F0EFB46EB5D /* MergeConflictTextStorage.swift */,
 				91B5694DB75F80C8D7B51E82 /* MergeConflictToolbar.swift */,
 				6F4D0EAA4C7CB45617BDD3FE /* ReadonlyTextView.swift */,
+				E373805AEFD068B97BC33A82 /* StashDiffTabView.swift */,
 				B27595490B7D883CF5D9FFD5 /* Tab.swift */,
 				8CFED7F76987C01213CB68A9 /* TabActivityPulse.swift */,
 				BEC7CCBF8463A95EAAE9EBCE /* TabBarView.swift */,
@@ -4959,6 +4962,7 @@
 				A06C59805BCD9D3200896932 /* StagedDiffLoader.swift in Sources */,
 				514C75877C1C3B1D19BB5BD5 /* StartupScriptInstaller.swift in Sources */,
 				899E7B2794DD3F2114B38AFC /* StartupScriptResolver.swift in Sources */,
+				7374C72F780CEE12E81997B9 /* StashDiffTabView.swift in Sources */,
 				EDC5F3C0F2964AC78C832F87 /* StatusParser.swift in Sources */,
 				523568D4D67F61ACA677EE44 /* SubHeader.swift in Sources */,
 				B9F3258E4AE2DB1E7481690A /* SubprocessRunner.swift in Sources */,

--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -284,6 +284,7 @@
 		40D9FD39D36ADE353B9971E8 /* MergeRegionVisualLayoutTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 256257983A4B1E1E674DF5B8 /* MergeRegionVisualLayoutTests.swift */; };
 		4107D595F9EBF8A1FC69E101 /* EditorFindRequestTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EB950CFAAADD11E84E783E1F /* EditorFindRequestTests.swift */; };
 		412F8D73E3E5CD7F57CD799A /* CompletionWindowController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 31F3A80227DD4A52C4752722 /* CompletionWindowController.swift */; };
+		4135B5BC24856ED442E39069 /* GitServiceStashTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1B218326D14AA360C7476D43 /* GitServiceStashTests.swift */; };
 		4151B68B1CF0A947AEC4C00A /* ACPAuthNudgeBannerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F68B06E93430D1C7B02F6BB2 /* ACPAuthNudgeBannerTests.swift */; };
 		4153DAD75F27395D2D385BED /* LanguageServerAvailabilityTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A8CC42BD54479E057902D392 /* LanguageServerAvailabilityTests.swift */; };
 		418D526733AA6B50A66CCCAF /* TabsManagerReviewRequestDraftTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 83A8622BA130E8FA339EDCEB /* TabsManagerReviewRequestDraftTests.swift */; };
@@ -629,6 +630,7 @@
 		9422B6F8F6C1E3E64B259712 /* LanguageServerRegistryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 345CFF4DBE5794DEBF43F996 /* LanguageServerRegistryTests.swift */; };
 		94354D17B0FEF3F0046B452A /* ACPMessage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 321866B3EB8CCE337B1D3A58 /* ACPMessage.swift */; };
 		94B884D1DB09DB562A0DCC20 /* DiffInlineCommentModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22CF502ECFD2763E52CB022F /* DiffInlineCommentModel.swift */; };
+		94FE17D9014F666C293EEFBE /* GitService+Stash.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8F3F67549BDACF73DFC2E477 /* GitService+Stash.swift */; };
 		950C937884477417569DC20B /* EmptyTabView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 008E982C8526670670425AB8 /* EmptyTabView.swift */; };
 		9547580C9DFECD838C120B90 /* DiffReviewRenderEligibility.swift in Sources */ = {isa = PBXBuildFile; fileRef = 389D0EB957CCC8447DB9C4FE /* DiffReviewRenderEligibility.swift */; };
 		956B221EC4FF3A18C713A64F /* AppStateTabAvailabilityTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 279D43D7F43C40A004A2C4AC /* AppStateTabAvailabilityTests.swift */; };
@@ -1231,6 +1233,7 @@
 		1A61DF43677282D4CA21769A /* CommitPromptStatus.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommitPromptStatus.swift; sourceTree = "<group>"; };
 		1AFC62A30044F71F0F16C3FB /* TerminalService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TerminalService.swift; sourceTree = "<group>"; };
 		1B0785F1FFC8008C74009584 /* session-update-available-models.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "session-update-available-models.json"; sourceTree = "<group>"; };
+		1B218326D14AA360C7476D43 /* GitServiceStashTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GitServiceStashTests.swift; sourceTree = "<group>"; };
 		1BB00E2F151520DC02B80BD4 /* GitServicePullTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GitServicePullTests.swift; sourceTree = "<group>"; };
 		1D3505FB870FA22C9C0FDB26 /* RightPaneStateSyncStatusTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RightPaneStateSyncStatusTests.swift; sourceTree = "<group>"; };
 		1D4A5200C6EBB6434DD6B8BD /* ShortcutReservationsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShortcutReservationsTests.swift; sourceTree = "<group>"; };
@@ -1713,6 +1716,7 @@
 		8EC619ECA68DC50B9C56CC33 /* SidebarView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SidebarView.swift; sourceTree = "<group>"; };
 		8EDED937A8E8340D6E685A6E /* GitNameValidatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GitNameValidatorTests.swift; sourceTree = "<group>"; };
 		8EF52FE71B7FB41328859734 /* MarkdownRenderer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MarkdownRenderer.swift; sourceTree = "<group>"; };
+		8F3F67549BDACF73DFC2E477 /* GitService+Stash.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "GitService+Stash.swift"; sourceTree = "<group>"; };
 		906D92F7AD84F313508D9CFD /* ACPComposerShell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPComposerShell.swift; sourceTree = "<group>"; };
 		90762AFB51B237B783D4190C /* ACPChatLayoutTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPChatLayoutTests.swift; sourceTree = "<group>"; };
 		90817EC3BAA727EF6D9FBD97 /* GitService+Discard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "GitService+Discard.swift"; sourceTree = "<group>"; };
@@ -2489,6 +2493,7 @@
 				FFB1CCDE2E4D85A46E6CFB1A /* GitServiceReviewRequestDraftTests.swift */,
 				C2CA853E91C240B7B5551859 /* GitServiceStagedTests.swift */,
 				6DF0AEE54BDB4FC4FD5E02F4 /* GitServiceStagingTests.swift */,
+				1B218326D14AA360C7476D43 /* GitServiceStashTests.swift */,
 				039741E1CCAEF9770D5DEE08 /* GitServiceTests.swift */,
 				FE2CDF03A998BADF20163D5A /* GitServiceUpstreamTests.swift */,
 				B86E7E91F81AA92ED7108D82 /* GitStatusCacheTests.swift */,
@@ -2753,6 +2758,7 @@
 				764489A630CC6D79FCE0A26A /* GitService+ReviewLoop.swift */,
 				0EE97D2D6875CD6A1DBF4DE9 /* GitService+ReviewRequestDraft.swift */,
 				D2F90D03073708AA01531533 /* GitService+Staging.swift */,
+				8F3F67549BDACF73DFC2E477 /* GitService+Stash.swift */,
 				27A92711BC1D9A78D8A80561 /* GitTypes.swift */,
 				CB2EB554CB6AF797545DB95D /* HeadReader.swift */,
 				9A06D96DE3FEBF63E7A157DD /* HunkPatchBuilder.swift */,
@@ -4718,6 +4724,7 @@
 				5846A180EB68D905E9775401 /* GitService+ReviewLoop.swift in Sources */,
 				C70D6BEC5321C16B70301CBF /* GitService+ReviewRequestDraft.swift in Sources */,
 				0A480D9D7CE5BB837D7BCA13 /* GitService+Staging.swift in Sources */,
+				94FE17D9014F666C293EEFBE /* GitService+Stash.swift in Sources */,
 				12035048B950CE0197604F89 /* GitService.swift in Sources */,
 				676C9F2E4246D5E383F83F72 /* GitStatusCache.swift in Sources */,
 				7DFE8DCEA8A4BABF51F54215 /* GitTypes.swift in Sources */,
@@ -5264,6 +5271,7 @@
 				4D9A57C74B314FA3570B0406 /* GitServiceReviewRequestDraftTests.swift in Sources */,
 				478863759224A2278123B7B9 /* GitServiceStagedTests.swift in Sources */,
 				CB27451157E1BF95BE47248A /* GitServiceStagingTests.swift in Sources */,
+				4135B5BC24856ED442E39069 /* GitServiceStashTests.swift in Sources */,
 				E8CCFE313DFCCA35BE8F93D7 /* GitServiceTests.swift in Sources */,
 				1748C3645E9B769F371F69E6 /* GitServiceUpstreamTests.swift in Sources */,
 				A2298208242B45155BA07BCD /* GitStatusCacheTests.swift in Sources */,

--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -964,6 +964,7 @@
 		DC0989E32F4B7BF023F784D6 /* StartupScriptInstallerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 43DF691FC778F3A71CE20FBB /* StartupScriptInstallerTests.swift */; };
 		DC394B7740FAEBD2F8ACB61F /* LSPMessages.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5C6A07D7C67D02C8638D8C1 /* LSPMessages.swift */; };
 		DC8458FA4C5FCC854BB46B96 /* AlasCLIReviewTargetResolver.swift in Sources */ = {isa = PBXBuildFile; fileRef = 430FCE70CDAB35CB0594CF44 /* AlasCLIReviewTargetResolver.swift */; };
+		DC86127564ACE3337640D0AD /* PendingStashDrop.swift in Sources */ = {isa = PBXBuildFile; fileRef = F748F06725644571785BF658 /* PendingStashDrop.swift */; };
 		DC93AED5844A56C6BA012CC3 /* ProviderReviewActionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 327D6F0E386398E6A512ADDF /* ProviderReviewActionsTests.swift */; };
 		DCACB5B624BFFE7C50DA6C61 /* RightPaneStateSyncStatusTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D3505FB870FA22C9C0FDB26 /* RightPaneStateSyncStatusTests.swift */; };
 		DD18C5FF006D18BC66964D94 /* TerminalTabView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 14087D57E96448EEF0B80BD9 /* TerminalTabView.swift */; };
@@ -1103,6 +1104,7 @@
 		FE5846F4401C702264817399 /* SpaceEmojiPickerSelectionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 28777B087266D8AE174BA233 /* SpaceEmojiPickerSelectionTests.swift */; };
 		FE5F2F9B468D045194B9443B /* ACPChatTypography.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5DC558BE723378DCC7AA5B55 /* ACPChatTypography.swift */; };
 		FF23739CD41997C6DD44E18B /* ACPFileWriter.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE0C0029F439C282D474ED77 /* ACPFileWriter.swift */; };
+		FF34E8DF7CDAECF80934F3A0 /* PendingStashDropTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F66CF7F86AACAAEA759C8A1B /* PendingStashDropTests.swift */; };
 		FF4707BB143F25062DD3BC43 /* AgentAutoLaunchTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 36F875ED8D44E6C298588E60 /* AgentAutoLaunchTests.swift */; };
 		FF7DDFC667CE2E3964B51FA5 /* LSPInstallProgressSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2379C3F8504AD2EE73130AC4 /* LSPInstallProgressSheet.swift */; };
 		FFC747D542D806E6CF6FCD03 /* CompletionPopup.swift in Sources */ = {isa = PBXBuildFile; fileRef = 348D2E5F6030BB9F2BDEFA26 /* CompletionPopup.swift */; };
@@ -2162,10 +2164,12 @@
 		F61EB45499D244E44EB170BC /* MergeBulkResolvePromptEditorWindow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MergeBulkResolvePromptEditorWindow.swift; sourceTree = "<group>"; };
 		F63C0C3F29FDD890239300E5 /* ReviewSessionStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReviewSessionStoreTests.swift; sourceTree = "<group>"; };
 		F649B493D42787FEA6D8E67B /* DiffReviewScrollSpyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiffReviewScrollSpyTests.swift; sourceTree = "<group>"; };
+		F66CF7F86AACAAEA759C8A1B /* PendingStashDropTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PendingStashDropTests.swift; sourceTree = "<group>"; };
 		F6883364648BF4B9F5DA131F /* EditorOverlayPanel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditorOverlayPanel.swift; sourceTree = "<group>"; };
 		F68B06E93430D1C7B02F6BB2 /* ACPAuthNudgeBannerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPAuthNudgeBannerTests.swift; sourceTree = "<group>"; };
 		F6EDDD4D22267C26B496A6FF /* ACPFirstRunConnectingPolicyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPFirstRunConnectingPolicyTests.swift; sourceTree = "<group>"; };
 		F721FB733081A583D4053DDA /* FileTypeIconView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileTypeIconView.swift; sourceTree = "<group>"; };
+		F748F06725644571785BF658 /* PendingStashDrop.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PendingStashDrop.swift; sourceTree = "<group>"; };
 		F787781F8DE2077B7B679C07 /* RepoSelectorRowView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RepoSelectorRowView.swift; sourceTree = "<group>"; };
 		F8685E5E5AC7A77D6D27A847 /* CenterPaneView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CenterPaneView.swift; sourceTree = "<group>"; };
 		F8D36A8AF55F212B9F32A944 /* ACPSessionManagerAttachRestoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPSessionManagerAttachRestoreTests.swift; sourceTree = "<group>"; };
@@ -2547,6 +2551,7 @@
 				16C9E59E3987C1D3C9989D91 /* PaneTreeTests.swift */,
 				295319DB8544C170DDD6328D /* PathsTests.swift */,
 				856607304A9F2409EF40BD5F /* PendingDiscardTests.swift */,
+				F66CF7F86AACAAEA759C8A1B /* PendingStashDropTests.swift */,
 				7EAE4B623CC10B4544E8D17A /* PersistenceStoreTests.swift */,
 				4749A35B3BEF89C8E7B92CD7 /* PiInstallerTests.swift */,
 				FF741B889D6DC8B1F4EB350F /* ProcessGitDataTests.swift */,
@@ -2950,6 +2955,7 @@
 				542B9A0D90AC20BBCA6073F8 /* MergeOperationState.swift */,
 				4941BFBEEEAF9DE9E1752548 /* OperationCard.swift */,
 				9B15F58AFF7BC19419935C05 /* PendingDiscard.swift */,
+				F748F06725644571785BF658 /* PendingStashDrop.swift */,
 				91C1705E68E97111E85D83F3 /* RightPaneState.swift */,
 				795056B6AD803D2B555FC866 /* RightPaneStore.swift */,
 				4B4ADD529F9B64DAD2994E0B /* RightPaneTabBar.swift */,
@@ -4837,6 +4843,7 @@
 				449C7E4A63455D01633B791A /* PendingDiscard.swift in Sources */,
 				F9FED997CCAD027FBBE36C1D /* PendingReview.swift in Sources */,
 				E3C34254BA474878AEC6683D /* PendingReviewTray.swift in Sources */,
+				DC86127564ACE3337640D0AD /* PendingStashDrop.swift in Sources */,
 				671F28D6A18DD75EB912596B /* PersistenceStore.swift in Sources */,
 				E99E4DB46496707E7A3F044A /* PiACPInstaller.swift in Sources */,
 				5E687CE659E83EF3B71CA86F /* PiInstaller.swift in Sources */,
@@ -5344,6 +5351,7 @@
 				497D21A67A062CE6282008CD /* PathsTests.swift in Sources */,
 				11B4AA1D032F054C666DD7F4 /* PendingDiscardTests.swift in Sources */,
 				8D43C0AEB98BC9F3F5A08CC5 /* PendingReviewTests.swift in Sources */,
+				FF34E8DF7CDAECF80934F3A0 /* PendingStashDropTests.swift in Sources */,
 				EE4E9C47863C4306F0D88A2F /* PersistenceStoreTests.swift in Sources */,
 				ADF6D3B634D9CCA17D7884EC /* PiACPInstallerTests.swift in Sources */,
 				04EC051D5AEE99A4841B29C7 /* PiInstallerTests.swift in Sources */,

--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -255,6 +255,7 @@
 		3BB7766DF1D9BF15098432F5 /* CommitDetails.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6AF335AB8B3061C889A348B3 /* CommitDetails.swift */; };
 		3C30C1EAE4786BB1BE42F994 /* ACPToolCallCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC3CF39EE3E5E2AB9B0968B3 /* ACPToolCallCard.swift */; };
 		3C57603EA801D8994B0B5525 /* RightPaneState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 91C1705E68E97111E85D83F3 /* RightPaneState.swift */; };
+		3C5797EAA86E4D493E1EEED8 /* ParkChangesSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 13B7B0E241FE2BEAE4623BA1 /* ParkChangesSheet.swift */; };
 		3C5E243B78F3461F75AB02A8 /* CodeTextViewCompletionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 436E8992D7373486BA25D290 /* CodeTextViewCompletionTests.swift */; };
 		3C8FAA4464E4D928F1DC6C91 /* session-new-response-with-config-options.json in Resources */ = {isa = PBXBuildFile; fileRef = E8A63557B4F06AA00761B547 /* session-new-response-with-config-options.json */; };
 		3CD81DD1B1FF8C1EA849237C /* TerminalSession.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9C45A26ADB0D1CCFBB5BEAE8 /* TerminalSession.swift */; };
@@ -278,6 +279,7 @@
 		3FCC4EDA31A96BE121F45D44 /* ACPComposerPlaceholderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 85E54E9F53ECFE9C205788F1 /* ACPComposerPlaceholderTests.swift */; };
 		3FD4E84E222D586F7C6D3946 /* TabsManagerReviewSessionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA9D3F3FFE39D7E29827D83D /* TabsManagerReviewSessionTests.swift */; };
 		3FE3D85D5E833DE3A91FD444 /* CopilotInstaller.swift in Sources */ = {isa = PBXBuildFile; fileRef = D64C0B7363363C77718B446C /* CopilotInstaller.swift */; };
+		40345C2068BFBF42B5C629B0 /* StashesSectionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40E8D8B829B3A7B0327CAFA1 /* StashesSectionView.swift */; };
 		40450134EBF5CCD5CD667327 /* ChangeSummaryVisibility.swift in Sources */ = {isa = PBXBuildFile; fileRef = 524926F2D16B1AD83FC234AB /* ChangeSummaryVisibility.swift */; };
 		4058A537B8CAE76FE7EFE184 /* ACPSessionHydrationStateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1DC1B975662D135B148443BC /* ACPSessionHydrationStateTests.swift */; };
 		40A21E55EB86B5F3D42AEFF2 /* InlineDiffView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 531DB20F5FBC0D8240778FE6 /* InlineDiffView.swift */; };
@@ -1209,6 +1211,7 @@
 		1379AD82025AFEABD37EFC42 /* DragHandleTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DragHandleTests.swift; sourceTree = "<group>"; };
 		137E9C84D7F32E747F0AF4C0 /* GatekeeperAssessorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GatekeeperAssessorTests.swift; sourceTree = "<group>"; };
 		137F79BD0DEB96B6F756ABD4 /* JSONHookSettingsFile.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JSONHookSettingsFile.swift; sourceTree = "<group>"; };
+		13B7B0E241FE2BEAE4623BA1 /* ParkChangesSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ParkChangesSheet.swift; sourceTree = "<group>"; };
 		14087D57E96448EEF0B80BD9 /* TerminalTabView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TerminalTabView.swift; sourceTree = "<group>"; };
 		14907D679267359B3FB8A848 /* TabMergeConflictCodingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabMergeConflictCodingTests.swift; sourceTree = "<group>"; };
 		14CAEDA53AADBCE77C694E7B /* CodeHostModelsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CodeHostModelsTests.swift; sourceTree = "<group>"; };
@@ -1409,6 +1412,7 @@
 		4068B3E83F9A82C2E3F8A6A1 /* OpenSessions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OpenSessions.swift; sourceTree = "<group>"; };
 		4069925EE709DD18AEA810B3 /* ShortcutResolver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShortcutResolver.swift; sourceTree = "<group>"; };
 		408F9FF672160D96B1C22648 /* FilesTabCompactChainTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FilesTabCompactChainTests.swift; sourceTree = "<group>"; };
+		40E8D8B829B3A7B0327CAFA1 /* StashesSectionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StashesSectionView.swift; sourceTree = "<group>"; };
 		410A42B1C46E68965FD36793 /* ShortcutChip.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShortcutChip.swift; sourceTree = "<group>"; };
 		412B2AF1B68E3B56DE21EB91 /* DiagnosticsRangeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiagnosticsRangeTests.swift; sourceTree = "<group>"; };
 		413CE0B0BBC96D412D048B1D /* .gitkeep */ = {isa = PBXFileReference; path = .gitkeep; sourceTree = "<group>"; };
@@ -2954,6 +2958,7 @@
 				F721FB733081A583D4053DDA /* FileTypeIconView.swift */,
 				542B9A0D90AC20BBCA6073F8 /* MergeOperationState.swift */,
 				4941BFBEEEAF9DE9E1752548 /* OperationCard.swift */,
+				13B7B0E241FE2BEAE4623BA1 /* ParkChangesSheet.swift */,
 				9B15F58AFF7BC19419935C05 /* PendingDiscard.swift */,
 				F748F06725644571785BF658 /* PendingStashDrop.swift */,
 				91C1705E68E97111E85D83F3 /* RightPaneState.swift */,
@@ -2962,6 +2967,7 @@
 				9C165BAAF80F9B4A5949BD39 /* RightPaneTransitionalView.swift */,
 				FE66950F2226F1182DCDD39A /* RightPaneView.swift */,
 				934BCC470703CF2DF2303357 /* SectionHeader.swift */,
+				40E8D8B829B3A7B0327CAFA1 /* StashesSectionView.swift */,
 				DDE8B45ECF898B83A616586D /* SubHeader.swift */,
 				9D32294F9B916DFAFF5E9A6F /* WorkingTreeChangeGroup.swift */,
 				866CFEB75B7F754485C6BE77 /* WorkingTreeSectionView.swift */,
@@ -4839,6 +4845,7 @@
 				082582F4BBA9DCFF0EAB9588 /* OperationCard.swift in Sources */,
 				ACB0AD03C9DFD88A431E6BC5 /* OutdatedThreadsDrawer.swift in Sources */,
 				86718F7E55531B8E4356D7D1 /* PaneTree.swift in Sources */,
+				3C5797EAA86E4D493E1EEED8 /* ParkChangesSheet.swift in Sources */,
 				78D25A04EAE26A0F3021A057 /* Paths.swift in Sources */,
 				449C7E4A63455D01633B791A /* PendingDiscard.swift in Sources */,
 				F9FED997CCAD027FBBE36C1D /* PendingReview.swift in Sources */,
@@ -4970,6 +4977,7 @@
 				514C75877C1C3B1D19BB5BD5 /* StartupScriptInstaller.swift in Sources */,
 				899E7B2794DD3F2114B38AFC /* StartupScriptResolver.swift in Sources */,
 				7374C72F780CEE12E81997B9 /* StashDiffTabView.swift in Sources */,
+				40345C2068BFBF42B5C629B0 /* StashesSectionView.swift in Sources */,
 				EDC5F3C0F2964AC78C832F87 /* StatusParser.swift in Sources */,
 				523568D4D67F61ACA677EE44 /* SubHeader.swift in Sources */,
 				B9F3258E4AE2DB1E7481690A /* SubprocessRunner.swift in Sources */,

--- a/Alas/Sources/App/AppState.swift
+++ b/Alas/Sources/App/AppState.swift
@@ -3634,7 +3634,9 @@ final class AppState {
         let worktreeId = worktree.id
         let existing = tabs.tabs(forWorktree: worktreeId).first { tab in
             if case .stashDiff(let state) = tab {
-                return state.stash.ref == stash.ref && state.file.path == file.path
+                return state.stash.ref == stash.ref
+                    && state.stash.sha == stash.sha
+                    && state.file.path == file.path
             }
             return false
         }

--- a/Alas/Sources/App/AppState.swift
+++ b/Alas/Sources/App/AppState.swift
@@ -3630,6 +3630,22 @@ final class AppState {
         }
     }
 
+    func openStashDiffTab(worktree: Worktree, stash: GitStash, file: GitStashFile) {
+        let worktreeId = worktree.id
+        let existing = tabs.tabs(forWorktree: worktreeId).first { tab in
+            if case .stashDiff(let state) = tab {
+                return state.stash.ref == stash.ref && state.file.path == file.path
+            }
+            return false
+        }
+        if let existing {
+            tabs.activate(worktreeId: worktreeId, tabId: existing.id)
+            return
+        }
+        let tab = tabs.appendStashDiff(worktreeId: worktreeId, stash: stash, file: file)
+        tabs.activate(worktreeId: worktreeId, tabId: tab.id)
+    }
+
     func openCommitTab(worktreeId: String, commit: CommitInfo) {
         guard let worktree = worktree(withId: worktreeId) else { return }
         if selectedWorktreeId != worktree.id {

--- a/Alas/Sources/Center/CenterPaneView.swift
+++ b/Alas/Sources/Center/CenterPaneView.swift
@@ -191,6 +191,14 @@ struct CenterPaneView: View {
                                 rps.requestDiscardFile(path: s.relativePath)
                             }
                         )
+                    case .stashDiff(let s):
+                        StashDiffTabView(
+                            worktreePath: worktree.path,
+                            state: s,
+                            codeFontFamily: state.config.code.fontFamily,
+                            codeFontSize: CGFloat(state.config.code.fontSize)
+                        )
+                        .id(s.id)
                     case .commit(let s):
                         CommitTabView(
                             worktreePath: worktree.path,

--- a/Alas/Sources/Center/StashDiffTabView.swift
+++ b/Alas/Sources/Center/StashDiffTabView.swift
@@ -1,0 +1,103 @@
+import SwiftUI
+
+struct StashDiffTabView: View {
+    let worktreePath: URL
+    let state: StashDiffTabState
+    var codeFontFamily: String = ""
+    var codeFontSize: CGFloat = 13
+
+    @Environment(\.theme) private var theme
+    @State private var loaded = false
+    @State private var error: String?
+    @State private var displayModel: DiffDisplayModel?
+    @State private var layoutMode: DiffLayoutMode = .split
+    @State private var wrapLines = false
+    @State private var showWhitespace = false
+
+    private let git = GitService()
+
+    var body: some View {
+        VStack(spacing: 0) {
+            header
+            if let error {
+                Text(error)
+                    .font(CenterTypography.codeFont(family: codeFontFamily, size: codeFontSize - 2))
+                    .foregroundColor(theme.color("del"))
+                    .padding(.horizontal, 14)
+                    .padding(.vertical, 6)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .background(theme.color("bg-2"))
+            }
+            if !loaded {
+                Spinner()
+                    .frame(width: 16, height: 16)
+                    .padding()
+            } else if let displayModel {
+                DiffPaneView(
+                    model: displayModel,
+                    fileExtension: (state.file.path as NSString).pathExtension,
+                    layoutMode: $layoutMode,
+                    wrapLines: $wrapLines,
+                    showWhitespace: $showWhitespace,
+                    codeFontFamily: codeFontFamily,
+                    codeFontSize: codeFontSize,
+                    allowsReviewLineSelection: false,
+                    hunkActions: { _ in DiffPaneHunkActions() }
+                )
+            } else {
+                Text("No changes for \(state.file.path)")
+                    .foregroundColor(theme.color("fg-dim"))
+                    .padding()
+            }
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
+        .background(theme.color("bg-1"))
+        .task(id: "\(state.stash.ref)\u{0}\(state.file.path)") { await load() }
+    }
+
+    private var header: some View {
+        HStack(spacing: 10) {
+            Text((state.file.path as NSString).lastPathComponent)
+                .font(CenterTypography.codeFont(family: codeFontFamily, size: codeFontSize))
+                .foregroundColor(theme.color("fg"))
+            Text(state.stash.ref)
+                .font(.system(size: 9.5, weight: .semibold))
+                .padding(.horizontal, 5)
+                .padding(.vertical, 1)
+                .background(theme.color("accent").opacity(0.16))
+                .foregroundColor(theme.color("accent"))
+                .clipShape(RoundedRectangle(cornerRadius: 3))
+            Text("·").foregroundColor(theme.color("fg-faint"))
+            Text((state.file.path as NSString).deletingLastPathComponent)
+                .font(.system(size: codeFontSize - 1.5))
+                .foregroundColor(theme.color("fg-dim"))
+                .lineLimit(1)
+                .truncationMode(.middle)
+            Spacer()
+        }
+        .padding(.horizontal, 14)
+        .padding(.vertical, 8)
+        .background(theme.color("bg-2"))
+        .overlay(Divider().opacity(0.5), alignment: .bottom)
+    }
+
+    private func load() async {
+        loaded = false
+        error = nil
+        displayModel = nil
+        do {
+            let diff = try await git.stashDiff(worktreePath: worktreePath, stash: state.stash, file: state.file)
+            guard !Task.isCancelled else { return }
+            let model = await Task.detached(priority: .userInitiated) {
+                DiffDisplayModelBuilder.build(diff: diff, filePath: state.file.path)
+            }.value
+            guard !Task.isCancelled else { return }
+            displayModel = diff.hunks.isEmpty ? nil : model
+            loaded = true
+        } catch {
+            guard !Task.isCancelled else { return }
+            self.error = error.localizedDescription
+            loaded = true
+        }
+    }
+}

--- a/Alas/Sources/Center/Tab.swift
+++ b/Alas/Sources/Center/Tab.swift
@@ -6,6 +6,7 @@ enum Tab: Codable, Equatable, Identifiable {
     case terminal(TerminalTabState)
     case editor(EditorTabState)
     case diff(DiffTabState)
+    case stashDiff(StashDiffTabState)
     case commit(CommitTabState)
     case commitEditor(CommitEditorTabState)
     case draftCommit(DraftCommitTabState)
@@ -24,6 +25,7 @@ enum Tab: Codable, Equatable, Identifiable {
         case .terminal(let s):     return s.id
         case .editor(let s):       return s.id
         case .diff(let s):         return s.id
+        case .stashDiff(let s):    return s.id
         case .commit(let s):       return s.id
         case .commitEditor(let s): return s.id
         case .draftCommit(let s):  return s.id
@@ -44,6 +46,7 @@ enum Tab: Codable, Equatable, Identifiable {
         case .terminal(let s):     return s.title
         case .editor(let s):       return s.title
         case .diff(let s):         return s.title
+        case .stashDiff(let s):    return s.title
         case .commit(let s):       return s.title
         case .commitEditor(let s): return s.title
         case .draftCommit:         return "Draft commit"
@@ -64,6 +67,7 @@ enum Tab: Codable, Equatable, Identifiable {
         case .terminal:     return "terminal"
         case .editor:       return "code"
         case .diff:         return "diff"
+        case .stashDiff:    return "archivebox"
         case .commit:       return "commit"
         case .commitEditor: return "commit"
         case .draftCommit:  return "commit"
@@ -82,6 +86,7 @@ enum Tab: Codable, Equatable, Identifiable {
     var relativeFilePath: String? {
         switch self {
         case .editor(let s):       return s.isExternal ? nil : s.relativePath
+        case .stashDiff(let s):    return s.file.path
         case .imagePreview(let s): return s.relativePath
         case .mergeConflict(let s): return s.relativePath
         case .fileSnapshot(let s): return s.relativePath
@@ -433,6 +438,22 @@ struct DiffTabState: Codable, Equatable, Identifiable {
         staged = try container.decodeIfPresent(Bool.self, forKey: .staged) ?? false
         originalPath = try container.decodeIfPresent(String.self, forKey: .originalPath)
         compareWithHEAD = try container.decodeIfPresent(Bool.self, forKey: .compareWithHEAD) ?? false
+    }
+}
+
+struct StashDiffTabState: Codable, Equatable, Identifiable {
+    let id: TabID
+    let worktreeId: String
+    let stash: GitStash
+    let file: GitStashFile
+    let title: String
+
+    init(worktreeId: String, stash: GitStash, file: GitStashFile) {
+        self.worktreeId = worktreeId
+        self.stash = stash
+        self.file = file
+        self.title = "\((file.path as NSString).lastPathComponent) @ \(stash.ref)"
+        self.id = "stash-diff:\(worktreeId):\(stash.ref):\(file.path)"
     }
 }
 

--- a/Alas/Sources/Center/Tab.swift
+++ b/Alas/Sources/Center/Tab.swift
@@ -453,7 +453,7 @@ struct StashDiffTabState: Codable, Equatable, Identifiable {
         self.stash = stash
         self.file = file
         self.title = "\((file.path as NSString).lastPathComponent) @ \(stash.ref)"
-        self.id = "stash-diff:\(worktreeId):\(stash.ref):\(file.path)"
+        self.id = "stash-diff:\(worktreeId):\(stash.ref):\(stash.sha):\(file.path)"
     }
 }
 

--- a/Alas/Sources/Center/TabsManager.swift
+++ b/Alas/Sources/Center/TabsManager.swift
@@ -626,6 +626,14 @@ final class TabsManager {
     }
 
     @discardableResult
+    func appendStashDiff(worktreeId: String, stash: GitStash, file: GitStashFile) -> Tab {
+        let state = StashDiffTabState(worktreeId: worktreeId, stash: stash, file: file)
+        let tab = Tab.stashDiff(state)
+        append(tab, to: worktreeId)
+        return tab
+    }
+
+    @discardableResult
     func appendCommit(worktreeId: String, sha: String, title: String) -> Tab {
         let state = CommitTabState(worktreeId: worktreeId, sha: sha, title: title)
         let tab = Tab.commit(state)

--- a/Alas/Sources/Git/GitService+Stash.swift
+++ b/Alas/Sources/Git/GitService+Stash.swift
@@ -147,16 +147,15 @@ extension GitService {
     }
 
     func stashDiff(worktreePath: URL, stash: GitStash, file: GitStashFile) async throws -> ParsedDiff {
-        try await verifyStashIdentity(worktreePath: worktreePath, stash: stash)
-
         let pathspecs = [file.oldPath, file.path].compactMap(\.self)
+        let stashRevision = stash.sha
         var result = try await Process.git(
-            ["diff", "--no-ext-diff", "--no-color", "--find-renames", "\(stash.ref)^1", stash.ref, "--"] + pathspecs,
+            ["diff", "--no-ext-diff", "--no-color", "--find-renames", "\(stashRevision)^1", stashRevision, "--"] + pathspecs,
             cwd: worktreePath
         )
         if result.exitCode == 0, result.stdout.isEmpty {
             result = try await Process.git(
-                ["show", "--format=", "--no-ext-diff", "--no-color", "\(stash.ref)^3", "--", file.path],
+                ["show", "--format=", "--no-ext-diff", "--no-color", "\(stashRevision)^3", "--", file.path],
                 cwd: worktreePath
             )
         }

--- a/Alas/Sources/Git/GitService+Stash.swift
+++ b/Alas/Sources/Git/GitService+Stash.swift
@@ -1,0 +1,65 @@
+import Foundation
+
+struct GitStash: Codable, Equatable, Identifiable, Sendable {
+    var id: String { ref }
+
+    let ref: String
+    let subject: String
+    let relativeTime: String
+    let sha: String
+}
+
+struct GitStashFile: Codable, Equatable, Identifiable, Sendable {
+    var id: String { path }
+
+    let path: String
+    let status: String
+    let add: Int
+    let del: Int
+}
+
+enum StashOperationResult: Equatable, Sendable {
+    case clean
+    case conflict(message: String)
+    case error(message: String)
+}
+
+extension GitService {
+    static func parseStashList(_ output: String) -> [GitStash] {
+        output
+            .split(separator: "\n", omittingEmptySubsequences: true)
+            .compactMap { line -> GitStash? in
+                let parts = line.split(separator: "\u{1f}", omittingEmptySubsequences: false).map(String.init)
+                guard parts.count == 4 else { return nil }
+
+                let ref = parts[0].trimmingCharacters(in: .whitespacesAndNewlines)
+                guard !ref.isEmpty else { return nil }
+
+                return GitStash(
+                    ref: ref,
+                    subject: parts[1].trimmingCharacters(in: .whitespacesAndNewlines),
+                    relativeTime: parts[2].trimmingCharacters(in: .whitespacesAndNewlines),
+                    sha: parts[3].trimmingCharacters(in: .whitespacesAndNewlines)
+                )
+            }
+    }
+
+    static func parseStashFiles(numstat: String, nameStatus: String) -> [GitStashFile] {
+        let counts = NumstatParser.parse(numstat)
+
+        return nameStatus
+            .split(separator: "\n", omittingEmptySubsequences: true)
+            .compactMap { rawLine -> GitStashFile? in
+                let parts = rawLine.split(separator: "\t", omittingEmptySubsequences: false).map(String.init)
+                guard parts.count >= 2 else { return nil }
+
+                let rawStatus = parts[0]
+                let status = String(rawStatus.prefix(1))
+                let path = parts.count >= 3 ? parts[2] : parts[1]
+                let fallback = NumstatParser.destinationPath(from: path)
+                let count = counts[path] ?? counts[fallback] ?? (add: 0, del: 0)
+
+                return GitStashFile(path: path, status: status, add: count.add, del: count.del)
+            }
+    }
+}

--- a/Alas/Sources/Git/GitService+Stash.swift
+++ b/Alas/Sources/Git/GitService+Stash.swift
@@ -88,6 +88,8 @@ extension GitService {
     }
 
     func stashFiles(worktreePath: URL, stash: GitStash) async throws -> [GitStashFile] {
+        try await verifyStashIdentity(worktreePath: worktreePath, stash: stash)
+
         let numstat = try await Process.git(
             ["stash", "show", "--include-untracked", "--numstat", "--format=", stash.ref],
             cwd: worktreePath
@@ -108,6 +110,8 @@ extension GitService {
     }
 
     func stashDiff(worktreePath: URL, stash: GitStash, file: GitStashFile) async throws -> ParsedDiff {
+        try await verifyStashIdentity(worktreePath: worktreePath, stash: stash)
+
         var result = try await Process.git(
             ["diff", "--no-ext-diff", "--no-color", "\(stash.ref)^1", stash.ref, "--", file.path],
             cwd: worktreePath
@@ -128,16 +132,19 @@ extension GitService {
     }
 
     func applyStash(worktreePath: URL, stash: GitStash) async throws -> StashOperationResult {
+        try await verifyStashIdentity(worktreePath: worktreePath, stash: stash)
         let result = try await Process.git(["stash", "apply", stash.ref], cwd: worktreePath)
         return Self.stashOperationResult(result, fallback: "Could not apply stash.")
     }
 
     func popStash(worktreePath: URL, stash: GitStash) async throws -> StashOperationResult {
+        try await verifyStashIdentity(worktreePath: worktreePath, stash: stash)
         let result = try await Process.git(["stash", "pop", stash.ref], cwd: worktreePath)
         return Self.stashOperationResult(result, fallback: "Could not pop stash.")
     }
 
     func dropStash(worktreePath: URL, stash: GitStash) async throws {
+        try await verifyStashIdentity(worktreePath: worktreePath, stash: stash)
         let result = try await Process.git(["stash", "drop", stash.ref], cwd: worktreePath)
         guard result.exitCode == 0 else {
             throw GitStashError.stderr(result.stderr, fallback: "Could not drop stash.")
@@ -157,16 +164,31 @@ extension GitService {
         }
         return .error(message: message)
     }
+
+    private func verifyStashIdentity(worktreePath: URL, stash: GitStash) async throws {
+        let result = try await Process.git(["rev-parse", "--verify", stash.ref], cwd: worktreePath)
+        guard result.exitCode == 0 else {
+            throw GitStashError.stderr(result.stderr, fallback: "\(stash.ref) is no longer available.")
+        }
+
+        let actualSHA = result.stdout.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard actualSHA == stash.sha else {
+            throw GitStashError.staleRef(ref: stash.ref, expectedSHA: stash.sha, actualSHA: actualSHA)
+        }
+    }
 }
 
 private enum GitStashError: LocalizedError {
     case stderr(String, fallback: String)
+    case staleRef(ref: String, expectedSHA: String, actualSHA: String)
 
     var errorDescription: String? {
         switch self {
         case .stderr(let stderr, let fallback):
             let message = stderr.trimmingCharacters(in: .whitespacesAndNewlines)
             return message.isEmpty ? fallback : message
+        case .staleRef(let ref, let expectedSHA, let actualSHA):
+            return "\(ref) changed before the operation could run. Expected \(expectedSHA), found \(actualSHA). Refresh and try again."
         }
     }
 }

--- a/Alas/Sources/Git/GitService+Stash.swift
+++ b/Alas/Sources/Git/GitService+Stash.swift
@@ -62,4 +62,111 @@ extension GitService {
                 return GitStashFile(path: path, status: status, add: count.add, del: count.del)
             }
     }
+
+    func stashes(worktreePath: URL) async throws -> [GitStash] {
+        let result = try await Process.git(
+            ["stash", "list", "--format=%gd%x1f%gs%x1f%cr%x1f%H"],
+            cwd: worktreePath
+        )
+        guard result.exitCode == 0 else {
+            throw GitStashError.stderr(result.stderr, fallback: "Could not list stashes.")
+        }
+        return Self.parseStashList(result.stdout)
+    }
+
+    func pushStash(worktreePath: URL, message: String, includeUntracked: Bool) async throws -> StashOperationResult {
+        var args = ["stash", "push"]
+        if includeUntracked { args.append("--include-untracked") }
+
+        let trimmed = message.trimmingCharacters(in: .whitespacesAndNewlines)
+        if !trimmed.isEmpty {
+            args.append(contentsOf: ["--message", trimmed])
+        }
+
+        let result = try await Process.git(args, cwd: worktreePath)
+        return Self.stashOperationResult(result, fallback: "Could not park changes.")
+    }
+
+    func stashFiles(worktreePath: URL, stash: GitStash) async throws -> [GitStashFile] {
+        let numstat = try await Process.git(
+            ["stash", "show", "--include-untracked", "--numstat", "--format=", stash.ref],
+            cwd: worktreePath
+        )
+        guard numstat.exitCode == 0 else {
+            throw GitStashError.stderr(numstat.stderr, fallback: "Could not load stash files.")
+        }
+
+        let nameStatus = try await Process.git(
+            ["stash", "show", "--include-untracked", "--name-status", "--format=", stash.ref],
+            cwd: worktreePath
+        )
+        guard nameStatus.exitCode == 0 else {
+            throw GitStashError.stderr(nameStatus.stderr, fallback: "Could not load stash files.")
+        }
+
+        return Self.parseStashFiles(numstat: numstat.stdout, nameStatus: nameStatus.stdout)
+    }
+
+    func stashDiff(worktreePath: URL, stash: GitStash, file: GitStashFile) async throws -> ParsedDiff {
+        var result = try await Process.git(
+            ["diff", "--no-ext-diff", "--no-color", "\(stash.ref)^1", stash.ref, "--", file.path],
+            cwd: worktreePath
+        )
+        if result.exitCode == 0, result.stdout.isEmpty {
+            result = try await Process.git(
+                ["show", "--format=", "--no-ext-diff", "--no-color", "\(stash.ref)^3", "--", file.path],
+                cwd: worktreePath
+            )
+        }
+        guard result.exitCode == 0 else {
+            throw GitStashError.stderr(result.stderr, fallback: "Could not load stash diff.")
+        }
+
+        return await Task.detached(priority: .userInitiated) {
+            DiffParser.parse(result.stdout)
+        }.value
+    }
+
+    func applyStash(worktreePath: URL, stash: GitStash) async throws -> StashOperationResult {
+        let result = try await Process.git(["stash", "apply", stash.ref], cwd: worktreePath)
+        return Self.stashOperationResult(result, fallback: "Could not apply stash.")
+    }
+
+    func popStash(worktreePath: URL, stash: GitStash) async throws -> StashOperationResult {
+        let result = try await Process.git(["stash", "pop", stash.ref], cwd: worktreePath)
+        return Self.stashOperationResult(result, fallback: "Could not pop stash.")
+    }
+
+    func dropStash(worktreePath: URL, stash: GitStash) async throws {
+        let result = try await Process.git(["stash", "drop", stash.ref], cwd: worktreePath)
+        guard result.exitCode == 0 else {
+            throw GitStashError.stderr(result.stderr, fallback: "Could not drop stash.")
+        }
+    }
+
+    private static func stashOperationResult(_ result: ProcessResult, fallback: String) -> StashOperationResult {
+        if result.exitCode == 0 { return .clean }
+
+        let output = [result.stderr, result.stdout]
+            .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+            .filter { !$0.isEmpty }
+            .joined(separator: "\n")
+        let message = output.isEmpty ? fallback : output
+        if message.localizedCaseInsensitiveContains("conflict") {
+            return .conflict(message: message)
+        }
+        return .error(message: message)
+    }
+}
+
+private enum GitStashError: LocalizedError {
+    case stderr(String, fallback: String)
+
+    var errorDescription: String? {
+        switch self {
+        case .stderr(let stderr, let fallback):
+            let message = stderr.trimmingCharacters(in: .whitespacesAndNewlines)
+            return message.isEmpty ? fallback : message
+        }
+    }
 }

--- a/Alas/Sources/Git/GitService+Stash.swift
+++ b/Alas/Sources/Git/GitService+Stash.swift
@@ -16,6 +16,28 @@ struct GitStashFile: Codable, Equatable, Identifiable, Sendable {
     let status: String
     let add: Int
     let del: Int
+    let oldPath: String?
+
+    init(path: String, status: String, add: Int, del: Int, oldPath: String? = nil) {
+        self.path = path
+        self.status = status
+        self.add = add
+        self.del = del
+        self.oldPath = oldPath
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case path, status, add, del, oldPath
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        path = try container.decode(String.self, forKey: .path)
+        status = try container.decode(String.self, forKey: .status)
+        add = try container.decode(Int.self, forKey: .add)
+        del = try container.decode(Int.self, forKey: .del)
+        oldPath = try container.decodeIfPresent(String.self, forKey: .oldPath)
+    }
 }
 
 enum StashOperationResult: Equatable, Sendable {
@@ -56,10 +78,11 @@ extension GitService {
                 let rawStatus = parts[0]
                 let status = String(rawStatus.prefix(1))
                 let path = parts.count >= 3 ? parts[2] : parts[1]
+                let oldPath = parts.count >= 3 ? parts[1] : nil
                 let fallback = NumstatParser.destinationPath(from: path)
                 let count = counts[path] ?? counts[fallback] ?? (add: 0, del: 0)
 
-                return GitStashFile(path: path, status: status, add: count.add, del: count.del)
+                return GitStashFile(path: path, status: status, add: count.add, del: count.del, oldPath: oldPath)
             }
     }
 
@@ -91,7 +114,7 @@ extension GitService {
         try await verifyStashIdentity(worktreePath: worktreePath, stash: stash)
 
         let numstat = try await Process.git(
-            ["stash", "show", "--include-untracked", "--numstat", "--format=", stash.ref],
+            ["diff", "--numstat", "--find-renames", "\(stash.ref)^1", stash.ref],
             cwd: worktreePath
         )
         guard numstat.exitCode == 0 else {
@@ -99,21 +122,36 @@ extension GitService {
         }
 
         let nameStatus = try await Process.git(
-            ["stash", "show", "--include-untracked", "--name-status", "--format=", stash.ref],
+            ["diff", "--name-status", "--find-renames", "\(stash.ref)^1", stash.ref],
             cwd: worktreePath
         )
         guard nameStatus.exitCode == 0 else {
             throw GitStashError.stderr(nameStatus.stderr, fallback: "Could not load stash files.")
         }
 
-        return Self.parseStashFiles(numstat: numstat.stdout, nameStatus: nameStatus.stdout)
+        async let untrackedNumstatProbe = Process.git(
+            ["show", "--format=", "--numstat", "\(stash.ref)^3"],
+            cwd: worktreePath
+        )
+        async let untrackedNameStatusProbe = Process.git(
+            ["show", "--format=", "--name-status", "\(stash.ref)^3"],
+            cwd: worktreePath
+        )
+        let untrackedNumstat = try? await untrackedNumstatProbe
+        let untrackedNameStatus = try? await untrackedNameStatusProbe
+
+        return Self.parseStashFiles(
+            numstat: numstat.stdout + (untrackedNumstat?.exitCode == 0 ? untrackedNumstat?.stdout ?? "" : ""),
+            nameStatus: nameStatus.stdout + (untrackedNameStatus?.exitCode == 0 ? untrackedNameStatus?.stdout ?? "" : "")
+        )
     }
 
     func stashDiff(worktreePath: URL, stash: GitStash, file: GitStashFile) async throws -> ParsedDiff {
         try await verifyStashIdentity(worktreePath: worktreePath, stash: stash)
 
+        let pathspecs = [file.oldPath, file.path].compactMap(\.self)
         var result = try await Process.git(
-            ["diff", "--no-ext-diff", "--no-color", "\(stash.ref)^1", stash.ref, "--", file.path],
+            ["diff", "--no-ext-diff", "--no-color", "--find-renames", "\(stash.ref)^1", stash.ref, "--"] + pathspecs,
             cwd: worktreePath
         )
         if result.exitCode == 0, result.stdout.isEmpty {

--- a/Alas/Sources/Right/ChangesTabView.swift
+++ b/Alas/Sources/Right/ChangesTabView.swift
@@ -147,12 +147,29 @@ struct ChangesTabView: View {
                     )
                 },
                 onDiscardFile: { file in rps.requestDiscardFile(path: file.path) },
+                onParkChanges: { rps.requestParkChanges() },
+                parkChangesDisabled: rps.mergeOp.current != nil || rps.stashOperationInFlight,
                 isOpenFileEnabled: { file in
                     DiffOpenFileAvailability.isAvailable(
                         worktreePath: rps.worktree.path,
                         relativePath: file.path
                     )
                 }
+            )
+            StashesSectionView(
+                stashes: rps.stashes,
+                filesByRef: rps.stashFilesByRef,
+                loadingRefs: rps.loadingStashRefs,
+                expanded: $rps.stashesExpanded,
+                expandedRefs: rps.expandedStashRefs,
+                onToggleSection: { rps.stashesExpanded.toggle() },
+                onToggleStash: { rps.toggleStashExpanded($0) },
+                onSelectFile: { stash, file in
+                    appState.openStashDiffTab(worktree: rps.worktree, stash: stash, file: file)
+                },
+                onApply: { rps.applyStash($0) },
+                onPop: { rps.popStash($0) },
+                onDrop: { rps.requestDropStash($0) }
             )
             Divider().opacity(0.4)
             CommitsSectionView(

--- a/Alas/Sources/Right/ParkChangesSheet.swift
+++ b/Alas/Sources/Right/ParkChangesSheet.swift
@@ -1,0 +1,41 @@
+import SwiftUI
+
+struct ParkChangesSheet: View {
+    let onPark: (String, Bool) -> Void
+    let onCancel: () -> Void
+
+    @Environment(\.theme) private var theme
+    @State private var message = ""
+    @State private var includeUntracked = false
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            Text("Park Changes")
+                .font(.system(size: 14, weight: .semibold))
+                .foregroundColor(theme.color("fg"))
+            Text("Move current working-tree changes into a git stash.")
+                .font(.system(size: 11))
+                .foregroundColor(theme.color("fg-muted"))
+            AlasField(
+                text: $message,
+                placeholder: "Optional message",
+                focusOnAppear: true,
+                onSubmit: { onPark(message, includeUntracked) }
+            )
+            Toggle("Include untracked files", isOn: $includeUntracked)
+                .toggleStyle(.checkbox)
+                .font(.system(size: 12))
+            HStack {
+                Spacer()
+                Button("Cancel", action: onCancel)
+                Button("Park Changes") {
+                    onPark(message, includeUntracked)
+                }
+                .keyboardShortcut(.defaultAction)
+            }
+        }
+        .padding(16)
+        .frame(width: 360)
+        .background(theme.color("bg-2"))
+    }
+}

--- a/Alas/Sources/Right/PendingStashDrop.swift
+++ b/Alas/Sources/Right/PendingStashDrop.swift
@@ -1,0 +1,19 @@
+import Foundation
+
+struct PendingStashDrop: Equatable {
+    let stash: GitStash
+
+    static func alertTitle(for pending: PendingStashDrop) -> String {
+        "Drop \(pending.stash.ref)?"
+    }
+
+    static func alertMessage(for pending: PendingStashDrop) -> String {
+        "This permanently deletes \"\(pending.stash.subject)\" from the stash list. This cannot be undone."
+    }
+}
+
+extension PendingStashDrop {
+    static let placeholder = PendingStashDrop(
+        stash: GitStash(ref: "stash@{0}", subject: "stash", relativeTime: "", sha: "")
+    )
+}

--- a/Alas/Sources/Right/RightPaneState.swift
+++ b/Alas/Sources/Right/RightPaneState.swift
@@ -441,10 +441,8 @@ final class RightPaneState {
             }
             self.upstreamRef = resolvedUpstream?.ref
             self.changes = entries
+            self.reconcileStashCaches(with: stashes)
             self.stashes = stashes
-            let validStashRefs = Set(stashes.map(\.ref))
-            self.expandedStashRefs.formIntersection(validStashRefs)
-            self.stashFilesByRef = self.stashFilesByRef.filter { validStashRefs.contains($0.key) }
             self.changesGeneration += 1
             self.indexFingerprint = indexFingerprint
             self.fileTree = tree
@@ -961,7 +959,7 @@ final class RightPaneState {
             do {
                 let files = try await self.git.stashFiles(worktreePath: self.worktree.path, stash: stash)
                 guard snapshotGeneration == self.snapshotInvalidationGeneration else { return }
-                guard self.stashes.contains(where: { $0.ref == stash.ref }) else { return }
+                guard self.stashes.contains(where: { $0.ref == stash.ref && $0.sha == stash.sha }) else { return }
                 self.stashFilesByRef[stash.ref] = files
             } catch {
                 guard snapshotGeneration == self.snapshotInvalidationGeneration else { return }
@@ -1006,6 +1004,17 @@ final class RightPaneState {
                 self.sidebarError = error.localizedDescription
             }
         }
+    }
+
+    func reconcileStashCaches(with newStashes: [GitStash]) {
+        let previousSHAsByRef = Dictionary(uniqueKeysWithValues: stashes.map { ($0.ref, $0.sha) })
+        let newSHAsByRef = Dictionary(uniqueKeysWithValues: newStashes.map { ($0.ref, $0.sha) })
+        let stableRefs = Set(newSHAsByRef.compactMap { ref, sha in
+            previousSHAsByRef[ref] == sha ? ref : nil
+        })
+
+        expandedStashRefs.formIntersection(stableRefs)
+        stashFilesByRef = stashFilesByRef.filter { stableRefs.contains($0.key) }
     }
 
     private func runStashOperation(_ operation: @escaping @MainActor () async throws -> StashOperationResult) {

--- a/Alas/Sources/Right/RightPaneState.swift
+++ b/Alas/Sources/Right/RightPaneState.swift
@@ -11,6 +11,14 @@ final class RightPaneState {
     let worktree: Worktree
     let reviewLoop: ReviewLoopState
     var changes: [ChangedFile] = []
+    var stashes: [GitStash] = []
+    var stashesExpanded: Bool = true
+    var expandedStashRefs: Set<String> = []
+    var stashFilesByRef: [String: [GitStashFile]] = [:]
+    var loadingStashRefs: Set<String> = []
+    var pendingParkChanges: Bool = false
+    var pendingStashDrop: PendingStashDrop? = nil
+    private(set) var stashOperationInFlight: Bool = false
     private(set) var hasLoadedSnapshot: Bool = false
     var displayChanges: [ChangedFile] {
         hasLoadedSnapshot ? changes : []
@@ -398,6 +406,7 @@ final class RightPaneState {
             async let br = git.currentBranch(worktreePath: worktree.path)
             async let upstream = git.resolveUpstreamRef(worktreePath: worktree.path)
             async let remotesProbe = git.remotes(worktreePath: worktree.path)
+            async let stashProbe = git.stashes(worktreePath: worktree.path)
             async let mergeRefresh: Void = mergeOp.refresh()
             let entries = try await s
             let tree = try await git.fileTree(worktreePath: worktree.path, statusEntries: entries)
@@ -405,6 +414,7 @@ final class RightPaneState {
             let reviewLoopBaseResult = try? await reviewLoopBase
             let resolvedUpstream = try? await upstream
             let remotes = (try? await remotesProbe) ?? []
+            let stashes = (try? await stashProbe) ?? []
             _ = await mergeRefresh
             let indexFingerprint: String
             if let lsResult = try? await Process.git(
@@ -431,6 +441,10 @@ final class RightPaneState {
             }
             self.upstreamRef = resolvedUpstream?.ref
             self.changes = entries
+            self.stashes = stashes
+            let validStashRefs = Set(stashes.map(\.ref))
+            self.expandedStashRefs.formIntersection(validStashRefs)
+            self.stashFilesByRef = self.stashFilesByRef.filter { validStashRefs.contains($0.key) }
             self.changesGeneration += 1
             self.indexFingerprint = indexFingerprint
             self.fileTree = tree
@@ -507,6 +521,13 @@ final class RightPaneState {
         snapshotInvalidationGeneration += 1
         hasLoadedSnapshot = false
         changes = []
+        stashes = []
+        expandedStashRefs = []
+        stashFilesByRef = [:]
+        loadingStashRefs = []
+        pendingParkChanges = false
+        pendingStashDrop = nil
+        stashOperationInFlight = false
         indexFingerprint = ""
         fileTree = []
         commits = []
@@ -889,6 +910,126 @@ final class RightPaneState {
         let cleanPaths = paths.filter { !remainingChangedPaths.contains($0) }
         if !cleanPaths.isEmpty {
             closeDiffTabs?(cleanPaths)
+        }
+    }
+
+    func requestParkChanges() {
+        guard !changes.isEmpty, mergeOp.current == nil, !stashOperationInFlight else { return }
+        pendingParkChanges = true
+    }
+
+    func cancelParkChanges() {
+        pendingParkChanges = false
+    }
+
+    func parkChanges(message: String, includeUntracked: Bool) {
+        guard pendingParkChanges, !stashOperationInFlight else { return }
+        pendingParkChanges = false
+        stashOperationInFlight = true
+        sidebarError = nil
+        Task { @MainActor in
+            defer { self.stashOperationInFlight = false }
+            do {
+                let result = try await self.git.pushStash(
+                    worktreePath: self.worktree.path,
+                    message: message,
+                    includeUntracked: includeUntracked
+                )
+                await self.refresh()
+                self.handleStashOperationResult(result)
+            } catch {
+                self.sidebarError = error.localizedDescription
+            }
+        }
+    }
+
+    func toggleStashExpanded(_ stash: GitStash) {
+        if expandedStashRefs.contains(stash.ref) {
+            expandedStashRefs.remove(stash.ref)
+        } else {
+            expandedStashRefs.insert(stash.ref)
+            loadFiles(for: stash)
+        }
+    }
+
+    func loadFiles(for stash: GitStash) {
+        guard stashFilesByRef[stash.ref] == nil, !loadingStashRefs.contains(stash.ref) else { return }
+        let snapshotGeneration = snapshotInvalidationGeneration
+        loadingStashRefs.insert(stash.ref)
+        Task { @MainActor in
+            defer { self.loadingStashRefs.remove(stash.ref) }
+            do {
+                let files = try await self.git.stashFiles(worktreePath: self.worktree.path, stash: stash)
+                guard snapshotGeneration == self.snapshotInvalidationGeneration else { return }
+                guard self.stashes.contains(where: { $0.ref == stash.ref }) else { return }
+                self.stashFilesByRef[stash.ref] = files
+            } catch {
+                guard snapshotGeneration == self.snapshotInvalidationGeneration else { return }
+                self.sidebarError = error.localizedDescription
+            }
+        }
+    }
+
+    func applyStash(_ stash: GitStash) {
+        runStashOperation {
+            try await self.git.applyStash(worktreePath: self.worktree.path, stash: stash)
+        }
+    }
+
+    func popStash(_ stash: GitStash) {
+        runStashOperation {
+            try await self.git.popStash(worktreePath: self.worktree.path, stash: stash)
+        }
+    }
+
+    func requestDropStash(_ stash: GitStash) {
+        pendingStashDrop = PendingStashDrop(stash: stash)
+    }
+
+    func cancelDropStash() {
+        pendingStashDrop = nil
+    }
+
+    func confirmDropStash(_ pending: PendingStashDrop) {
+        if pendingStashDrop == pending {
+            pendingStashDrop = nil
+        }
+        guard !stashOperationInFlight else { return }
+        stashOperationInFlight = true
+        sidebarError = nil
+        Task { @MainActor in
+            defer { self.stashOperationInFlight = false }
+            do {
+                try await self.git.dropStash(worktreePath: self.worktree.path, stash: pending.stash)
+                await self.refresh()
+            } catch {
+                self.sidebarError = error.localizedDescription
+            }
+        }
+    }
+
+    private func runStashOperation(_ operation: @escaping @MainActor () async throws -> StashOperationResult) {
+        guard !stashOperationInFlight else { return }
+        stashOperationInFlight = true
+        sidebarError = nil
+        Task { @MainActor in
+            defer { self.stashOperationInFlight = false }
+            do {
+                let result = try await operation()
+                await self.refresh()
+                self.handleStashOperationResult(result)
+            } catch {
+                self.sidebarError = error.localizedDescription
+            }
+        }
+    }
+
+    private func handleStashOperationResult(_ result: StashOperationResult) {
+        switch result {
+        case .clean:
+            return
+        case .conflict(let message), .error(let message):
+            sidebarError = message
         }
     }
 

--- a/Alas/Sources/Right/RightPaneView.swift
+++ b/Alas/Sources/Right/RightPaneView.swift
@@ -137,5 +137,37 @@ struct RightPaneView: View {
                 Text("Apply this commit to the current branch.")
             }
         )
+        .sheet(
+            isPresented: Binding(
+                get: { rps.pendingParkChanges },
+                set: { if !$0 { rps.cancelParkChanges() } }
+            )
+        ) {
+            ParkChangesSheet(
+                onPark: { message, includeUntracked in
+                    rps.parkChanges(message: message, includeUntracked: includeUntracked)
+                },
+                onCancel: { rps.cancelParkChanges() }
+            )
+        }
+        .alert(
+            PendingStashDrop.alertTitle(for: rps.pendingStashDrop ?? .placeholder),
+            isPresented: Binding(
+                get: { rps.pendingStashDrop != nil },
+                set: { if !$0 { rps.cancelDropStash() } }
+            ),
+            presenting: rps.pendingStashDrop,
+            actions: { pending in
+                Button("Drop", role: .destructive) {
+                    rps.confirmDropStash(pending)
+                }
+                Button("Cancel", role: .cancel) {
+                    rps.cancelDropStash()
+                }
+            },
+            message: { pending in
+                Text(PendingStashDrop.alertMessage(for: pending))
+            }
+        )
     }
 }

--- a/Alas/Sources/Right/StashesSectionView.swift
+++ b/Alas/Sources/Right/StashesSectionView.swift
@@ -1,0 +1,141 @@
+import SwiftUI
+
+struct StashesSectionView: View {
+    let stashes: [GitStash]
+    let filesByRef: [String: [GitStashFile]]
+    let loadingRefs: Set<String>
+    @Binding var expanded: Bool
+    let expandedRefs: Set<String>
+    let onToggleSection: () -> Void
+    let onToggleStash: (GitStash) -> Void
+    let onSelectFile: (GitStash, GitStashFile) -> Void
+    let onApply: (GitStash) -> Void
+    let onPop: (GitStash) -> Void
+    let onDrop: (GitStash) -> Void
+
+    @Environment(\.theme) private var theme
+
+    var body: some View {
+        if !stashes.isEmpty {
+            Section {
+                if expanded {
+                    ForEach(stashes) { stash in
+                        stashRow(stash)
+                    }
+                }
+            } header: {
+                SectionHeader(
+                    title: "Stashes",
+                    count: stashes.count,
+                    expanded: expanded,
+                    onToggle: onToggleSection
+                )
+            }
+        }
+    }
+
+    @ViewBuilder
+    private func stashRow(_ stash: GitStash) -> some View {
+        let open = expandedRefs.contains(stash.ref)
+        Button {
+            onToggleStash(stash)
+        } label: {
+            HStack(spacing: 6) {
+                Icon(name: open ? "chev-down" : "chev-right", size: 10, color: theme.color("fg-faint"))
+                    .frame(width: 14, height: 14)
+                Text(stash.subject.isEmpty ? stash.ref : stash.subject)
+                    .font(.system(size: 11.5))
+                    .foregroundColor(theme.color("fg"))
+                    .lineLimit(1)
+                    .truncationMode(.middle)
+                Text(stash.ref)
+                    .font(.system(size: 10, design: .monospaced))
+                    .foregroundColor(theme.color("fg-faint"))
+                Spacer()
+                if loadingRefs.contains(stash.ref) {
+                    Spinner(lineWidth: 1.2, duration: 0.7)
+                        .frame(width: 10, height: 10)
+                }
+                Menu {
+                    Button("Apply") { onApply(stash) }
+                    Button("Pop") { onPop(stash) }
+                    Divider()
+                    Button("Drop…", role: .destructive) { onDrop(stash) }
+                } label: {
+                    Image(systemName: "ellipsis")
+                        .font(.system(size: 12, weight: .semibold))
+                        .foregroundColor(theme.color("fg-muted"))
+                }
+                .menuStyle(.borderlessButton)
+                .menuIndicator(.hidden)
+                .fixedSize()
+                .help("Stash actions")
+            }
+            .padding(.horizontal, 12)
+            .padding(.vertical, 5)
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+        .contextMenu {
+            Button("Apply") { onApply(stash) }
+            Button("Pop") { onPop(stash) }
+            Divider()
+            Button("Drop…", role: .destructive) { onDrop(stash) }
+        }
+        if open {
+            expandedFiles(for: stash)
+        }
+    }
+
+    @ViewBuilder
+    private func expandedFiles(for stash: GitStash) -> some View {
+        let files = filesByRef[stash.ref] ?? []
+        if loadingRefs.contains(stash.ref) && files.isEmpty {
+            HStack(spacing: 6) {
+                Spinner(lineWidth: 1.2, duration: 0.7)
+                    .frame(width: 10, height: 10)
+                Text("Loading stash files…")
+                    .font(.system(size: 11))
+                    .foregroundColor(theme.color("fg-faint"))
+            }
+            .padding(.leading, 32)
+            .padding(.vertical, 6)
+        } else if files.isEmpty {
+            Text("no files")
+                .font(.system(size: 11))
+                .foregroundColor(theme.color("fg-faint"))
+                .padding(.leading, 32)
+                .padding(.vertical, 6)
+        } else {
+            ForEach(files) { file in
+                Button {
+                    onSelectFile(stash, file)
+                } label: {
+                    HStack(spacing: 6) {
+                        FileTypeIconView(filename: (file.path as NSString).lastPathComponent, size: 16)
+                        Text((file.path as NSString).lastPathComponent)
+                            .font(.system(size: 11.5, design: .monospaced))
+                            .lineLimit(1)
+                            .truncationMode(.middle)
+                        Spacer()
+                        if file.add > 0 {
+                            Text("+\(file.add)")
+                                .foregroundColor(theme.color("add"))
+                        }
+                        if file.del > 0 {
+                            Text("-\(file.del)")
+                                .foregroundColor(theme.color("del"))
+                        }
+                        StatusBadge(status: file.status)
+                    }
+                    .font(.system(size: 11, design: .monospaced))
+                    .padding(.leading, 32)
+                    .padding(.trailing, 12)
+                    .padding(.vertical, 4)
+                    .contentShape(Rectangle())
+                }
+                .buttonStyle(.plain)
+            }
+        }
+    }
+}

--- a/Alas/Sources/Right/WorkingTreeSectionView.swift
+++ b/Alas/Sources/Right/WorkingTreeSectionView.swift
@@ -18,6 +18,8 @@ struct WorkingTreeSectionView: View {
     var onCompareWithHEAD: ((ChangedFile) -> Void)? = nil
     var onFileHistory:     ((ChangedFile) -> Void)? = nil
     var onDiscardFile:     ((ChangedFile) -> Void)? = nil
+    var onParkChanges:     (() -> Void)? = nil
+    var parkChangesDisabled: Bool = false
     var isOpenFileEnabled: ((ChangedFile) -> Bool)? = nil
 
     @Environment(\.theme) private var theme
@@ -65,6 +67,10 @@ struct WorkingTreeSectionView: View {
                     }
                 }
                 if !changes.isEmpty {
+                    Button("Park Changes…") {
+                        onParkChanges?()
+                    }
+                    .disabled(parkChangesDisabled || changes.isEmpty || onParkChanges == nil)
                     Divider()
                 }
                 Button("Discard all working tree changes…", role: .destructive) {

--- a/AlasTests/AppStateTabAvailabilityTests.swift
+++ b/AlasTests/AppStateTabAvailabilityTests.swift
@@ -91,6 +91,31 @@ struct AppStateTabAvailabilityTests {
         #expect(!state.hasActiveCodeEditorTab)
     }
 
+    @Test func openStashDiffTabDoesNotReuseTabForDifferentStashSha() {
+        let state = AppState()
+        let worktree = Worktree(
+            id: "wt-stash",
+            projectId: "project",
+            name: "main",
+            branch: "main",
+            path: URL(fileURLWithPath: "/tmp/repo"),
+            status: .clean,
+            lastActivity: Date()
+        )
+        let file = GitStashFile(path: "Sources/App.swift", status: "M", add: 2, del: 1)
+        let oldStash = GitStash(ref: "stash@{0}", subject: "old", relativeTime: "1 minute ago", sha: "old-sha")
+        let newStash = GitStash(ref: "stash@{0}", subject: "new", relativeTime: "now", sha: "new-sha")
+
+        state.openStashDiffTab(worktree: worktree, stash: oldStash, file: file)
+        state.openStashDiffTab(worktree: worktree, stash: newStash, file: file)
+
+        let tabs = state.tabs.tabs(forWorktree: worktree.id).compactMap { tab -> StashDiffTabState? in
+            if case .stashDiff(let stashDiff) = tab { return stashDiff }
+            return nil
+        }
+        #expect(tabs.map(\.stash.sha) == ["old-sha", "new-sha"])
+    }
+
     @Test func hasActiveCodeEditorTabFalseForExternalMarkdownEditor() async throws {
         let repo = try await makeRepo(name: "external-markdown-editor")
         defer { try? FileManager.default.removeItem(at: repo) }

--- a/AlasTests/GitServiceStashTests.swift
+++ b/AlasTests/GitServiceStashTests.swift
@@ -157,6 +157,27 @@ struct GitServiceStashTests {
         #expect(try await service.stashes(worktreePath: repo).isEmpty)
     }
 
+    @Test func dropStashRejectsRefThatNowPointsAtDifferentSha() async throws {
+        let repo = try await makeRepo()
+        defer { try? FileManager.default.removeItem(at: repo) }
+
+        let service = GitService()
+        try "base\nold stash\n".write(to: repo.appendingPathComponent("file.txt"), atomically: true, encoding: .utf8)
+        _ = try await service.pushStash(worktreePath: repo, message: "old", includeUntracked: false)
+        let staleRef = try #require(try await service.stashes(worktreePath: repo).first)
+
+        try "base\nnew stash\n".write(to: repo.appendingPathComponent("file.txt"), atomically: true, encoding: .utf8)
+        _ = try await service.pushStash(worktreePath: repo, message: "new", includeUntracked: false)
+
+        await #expect(throws: (any Error).self) {
+            try await service.dropStash(worktreePath: repo, stash: staleRef)
+        }
+        let stashes = try await service.stashes(worktreePath: repo)
+        #expect(stashes.count == 2)
+        #expect(stashes[0].subject.contains("new"))
+        #expect(stashes[1].subject.contains("old"))
+    }
+
     @Test func applyStashReportsConflictsFromGitStdout() async throws {
         let repo = try await makeRepo()
         defer { try? FileManager.default.removeItem(at: repo) }

--- a/AlasTests/GitServiceStashTests.swift
+++ b/AlasTests/GitServiceStashTests.swift
@@ -85,7 +85,7 @@ struct GitServiceStashTests {
         let files = GitService.parseStashFiles(numstat: numstat, nameStatus: nameStatus)
 
         #expect(files == [
-            GitStashFile(path: "Sources/New.swift", status: "R", add: 1, del: 2),
+            GitStashFile(path: "Sources/New.swift", status: "R", add: 1, del: 2, oldPath: "Sources/Old.swift"),
         ])
     }
 
@@ -96,7 +96,7 @@ struct GitServiceStashTests {
         let files = GitService.parseStashFiles(numstat: numstat, nameStatus: nameStatus)
 
         #expect(files == [
-            GitStashFile(path: "Sources/New.swift", status: "R", add: 1, del: 2),
+            GitStashFile(path: "Sources/New.swift", status: "R", add: 1, del: 2, oldPath: "Sources/Old.swift"),
         ])
     }
 
@@ -133,6 +133,28 @@ struct GitServiceStashTests {
         #expect(file == GitStashFile(path: "new.txt", status: "A", add: 1, del: 0))
         let diff = try await service.stashDiff(worktreePath: repo, stash: stash, file: file)
         #expect(diff.hunks.contains { hunk in hunk.lines.contains { $0.kind == .add && $0.text == "new" } })
+    }
+
+    @Test func stashDiffForRenameIncludesChangedLinesFromOriginalPath() async throws {
+        let repo = try await makeRepo()
+        defer { try? FileManager.default.removeItem(at: repo) }
+        try "one\ntwo\nthree\nfour\nfive\n".write(to: repo.appendingPathComponent("old.txt"), atomically: true, encoding: .utf8)
+        try await gitOK(["add", "old.txt"], cwd: repo)
+        try await gitOK(["commit", "-q", "-m", "add old"], cwd: repo)
+        try await gitOK(["mv", "old.txt", "new.txt"], cwd: repo)
+        try "one\nchanged\nthree\nfour\nfive\n".write(to: repo.appendingPathComponent("new.txt"), atomically: true, encoding: .utf8)
+
+        let service = GitService()
+        _ = try await service.pushStash(worktreePath: repo, message: "rename", includeUntracked: false)
+        let stash = try #require(try await service.stashes(worktreePath: repo).first)
+        let file = try #require(try await service.stashFiles(worktreePath: repo, stash: stash).first)
+
+        #expect(file == GitStashFile(path: "new.txt", status: "R", add: 1, del: 1, oldPath: "old.txt"))
+        let diff = try await service.stashDiff(worktreePath: repo, stash: stash, file: file)
+        #expect(diff.hunks.contains { hunk in
+            hunk.lines.contains { $0.kind == .delete && $0.text == "two" }
+                && hunk.lines.contains { $0.kind == .add && $0.text == "changed" }
+        })
     }
 
     @Test func applyPopAndDropStash() async throws {

--- a/AlasTests/GitServiceStashTests.swift
+++ b/AlasTests/GitServiceStashTests.swift
@@ -1,0 +1,76 @@
+import Foundation
+import Testing
+@testable import Alas
+
+@Suite(.serialized)
+struct GitServiceStashTests {
+    @Test func parseStashListPreservesRefSubjectRelativeTimeAndSha() {
+        let output = """
+        stash@{0}\u{1f}WIP on main: abc123 update parser\u{1f}2 hours ago\u{1f}1111111111111111111111111111111111111111
+        stash@{1}\u{1f}custom message\u{1f}3 days ago\u{1f}2222222222222222222222222222222222222222
+
+        """
+
+        let stashes = GitService.parseStashList(output)
+
+        #expect(stashes == [
+            GitStash(
+                ref: "stash@{0}",
+                subject: "WIP on main: abc123 update parser",
+                relativeTime: "2 hours ago",
+                sha: "1111111111111111111111111111111111111111"
+            ),
+            GitStash(
+                ref: "stash@{1}",
+                subject: "custom message",
+                relativeTime: "3 days ago",
+                sha: "2222222222222222222222222222222222222222"
+            ),
+        ])
+    }
+
+    @Test func parseStashFilesMergesNumstatAndNameStatus() {
+        let numstat = """
+        12\t3\tSources/App.swift
+        -\t-\tAssets/icon.png
+        4\t0\tSources/New.swift
+
+        """
+        let nameStatus = """
+        M\tSources/App.swift
+        M\tAssets/icon.png
+        A\tSources/New.swift
+
+        """
+
+        let files = GitService.parseStashFiles(numstat: numstat, nameStatus: nameStatus)
+
+        #expect(files == [
+            GitStashFile(path: "Sources/App.swift", status: "M", add: 12, del: 3),
+            GitStashFile(path: "Assets/icon.png", status: "M", add: 0, del: 0),
+            GitStashFile(path: "Sources/New.swift", status: "A", add: 4, del: 0),
+        ])
+    }
+
+    @Test func parseStashFilesHandlesRenamesUsingNewPath() {
+        let numstat = "1\t2\tSources/Old.swift => Sources/New.swift\n"
+        let nameStatus = "R100\tSources/Old.swift\tSources/New.swift\n"
+
+        let files = GitService.parseStashFiles(numstat: numstat, nameStatus: nameStatus)
+
+        #expect(files == [
+            GitStashFile(path: "Sources/New.swift", status: "R", add: 1, del: 2),
+        ])
+    }
+
+    @Test func parseStashFilesHandlesBraceRenameNumstatUsingNewPath() {
+        let numstat = "1\t2\tSources/{Old.swift => New.swift}\n"
+        let nameStatus = "R100\tSources/Old.swift\tSources/New.swift\n"
+
+        let files = GitService.parseStashFiles(numstat: numstat, nameStatus: nameStatus)
+
+        #expect(files == [
+            GitStashFile(path: "Sources/New.swift", status: "R", add: 1, del: 2),
+        ])
+    }
+}

--- a/AlasTests/GitServiceStashTests.swift
+++ b/AlasTests/GitServiceStashTests.swift
@@ -157,6 +157,26 @@ struct GitServiceStashTests {
         })
     }
 
+    @Test func stashDiffLoadsCapturedShaAfterRefMoves() async throws {
+        let repo = try await makeRepo()
+        defer { try? FileManager.default.removeItem(at: repo) }
+
+        let service = GitService()
+        try "base\nold stash\n".write(to: repo.appendingPathComponent("file.txt"), atomically: true, encoding: .utf8)
+        _ = try await service.pushStash(worktreePath: repo, message: "old", includeUntracked: false)
+        let oldStash = try #require(try await service.stashes(worktreePath: repo).first)
+        let oldFile = try #require(try await service.stashFiles(worktreePath: repo, stash: oldStash).first)
+
+        try "base\nnew stash\n".write(to: repo.appendingPathComponent("file.txt"), atomically: true, encoding: .utf8)
+        _ = try await service.pushStash(worktreePath: repo, message: "new", includeUntracked: false)
+
+        let diff = try await service.stashDiff(worktreePath: repo, stash: oldStash, file: oldFile)
+
+        #expect(diff.hunks.contains { hunk in
+            hunk.lines.contains { $0.kind == .add && $0.text == "old stash" }
+        })
+    }
+
     @Test func applyPopAndDropStash() async throws {
         let repo = try await makeRepo()
         defer { try? FileManager.default.removeItem(at: repo) }

--- a/AlasTests/GitServiceStashTests.swift
+++ b/AlasTests/GitServiceStashTests.swift
@@ -4,6 +4,32 @@ import Testing
 
 @Suite(.serialized)
 struct GitServiceStashTests {
+    private func makeRepo() async throws -> URL {
+        let dir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("alas-stash-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        try await gitOK(["init", "-q", "-b", "main"], cwd: dir)
+        try await gitOK(["config", "user.email", "t@example.com"], cwd: dir)
+        try await gitOK(["config", "user.name", "Test User"], cwd: dir)
+        try "base\n".write(to: dir.appendingPathComponent("file.txt"), atomically: true, encoding: .utf8)
+        try await gitOK(["add", "file.txt"], cwd: dir)
+        try await gitOK(["commit", "-q", "-m", "base"], cwd: dir)
+        return dir
+    }
+
+    @discardableResult
+    private func gitOK(_ args: [String], cwd: URL) async throws -> ProcessResult {
+        let result = try await Process.git(args, cwd: cwd)
+        guard result.exitCode == 0 else {
+            throw NSError(
+                domain: "GitServiceStashTests.gitOK",
+                code: Int(result.exitCode),
+                userInfo: [NSLocalizedDescriptionKey: result.stderr]
+            )
+        }
+        return result
+    }
+
     @Test func parseStashListPreservesRefSubjectRelativeTimeAndSha() {
         let output = """
         stash@{0}\u{1f}WIP on main: abc123 update parser\u{1f}2 hours ago\u{1f}1111111111111111111111111111111111111111
@@ -72,5 +98,81 @@ struct GitServiceStashTests {
         #expect(files == [
             GitStashFile(path: "Sources/New.swift", status: "R", add: 1, del: 2),
         ])
+    }
+
+    @Test func pushListFilesAndDiffStash() async throws {
+        let repo = try await makeRepo()
+        defer { try? FileManager.default.removeItem(at: repo) }
+        try "base\nchanged\n".write(to: repo.appendingPathComponent("file.txt"), atomically: true, encoding: .utf8)
+
+        let service = GitService()
+        let result = try await service.pushStash(worktreePath: repo, message: "parser cleanup", includeUntracked: false)
+
+        #expect(result == .clean)
+        let stashes = try await service.stashes(worktreePath: repo)
+        #expect(stashes.count == 1)
+        #expect(stashes[0].subject.contains("parser cleanup"))
+        let files = try await service.stashFiles(worktreePath: repo, stash: stashes[0])
+        #expect(files == [GitStashFile(path: "file.txt", status: "M", add: 1, del: 0)])
+        let diff = try await service.stashDiff(worktreePath: repo, stash: stashes[0], file: files[0])
+        #expect(diff.hunks.contains { hunk in hunk.lines.contains { $0.kind == .add && $0.text == "changed" } })
+    }
+
+    @Test func pushStashCanIncludeUntrackedFiles() async throws {
+        let repo = try await makeRepo()
+        defer { try? FileManager.default.removeItem(at: repo) }
+        try "new\n".write(to: repo.appendingPathComponent("new.txt"), atomically: true, encoding: .utf8)
+
+        let service = GitService()
+        let result = try await service.pushStash(worktreePath: repo, message: "", includeUntracked: true)
+
+        #expect(result == .clean)
+        let stash = try #require(try await service.stashes(worktreePath: repo).first)
+        let files = try await service.stashFiles(worktreePath: repo, stash: stash)
+        let file = try #require(files.first { $0.path == "new.txt" })
+        #expect(file == GitStashFile(path: "new.txt", status: "A", add: 1, del: 0))
+        let diff = try await service.stashDiff(worktreePath: repo, stash: stash, file: file)
+        #expect(diff.hunks.contains { hunk in hunk.lines.contains { $0.kind == .add && $0.text == "new" } })
+    }
+
+    @Test func applyPopAndDropStash() async throws {
+        let repo = try await makeRepo()
+        defer { try? FileManager.default.removeItem(at: repo) }
+        try "base\nchanged\n".write(to: repo.appendingPathComponent("file.txt"), atomically: true, encoding: .utf8)
+
+        let service = GitService()
+        _ = try await service.pushStash(worktreePath: repo, message: "apply me", includeUntracked: false)
+        var stash = try #require(try await service.stashes(worktreePath: repo).first)
+
+        #expect(try await service.applyStash(worktreePath: repo, stash: stash) == .clean)
+        #expect(try String(contentsOf: repo.appendingPathComponent("file.txt"), encoding: .utf8) == "base\nchanged\n")
+        try await gitOK(["checkout", "--", "file.txt"], cwd: repo)
+
+        #expect(try await service.popStash(worktreePath: repo, stash: stash) == .clean)
+        #expect(try await service.stashes(worktreePath: repo).isEmpty)
+
+        _ = try await service.pushStash(worktreePath: repo, message: "drop me", includeUntracked: false)
+        stash = try #require(try await service.stashes(worktreePath: repo).first)
+        try await service.dropStash(worktreePath: repo, stash: stash)
+        #expect(try await service.stashes(worktreePath: repo).isEmpty)
+    }
+
+    @Test func applyStashReportsConflictsFromGitStdout() async throws {
+        let repo = try await makeRepo()
+        defer { try? FileManager.default.removeItem(at: repo) }
+        try "stash\n".write(to: repo.appendingPathComponent("file.txt"), atomically: true, encoding: .utf8)
+
+        let service = GitService()
+        _ = try await service.pushStash(worktreePath: repo, message: "conflict me", includeUntracked: false)
+        let stash = try #require(try await service.stashes(worktreePath: repo).first)
+        try "other\n".write(to: repo.appendingPathComponent("file.txt"), atomically: true, encoding: .utf8)
+        try await gitOK(["add", "file.txt"], cwd: repo)
+        try await gitOK(["commit", "-q", "-m", "other"], cwd: repo)
+
+        guard case .conflict(let message) = try await service.applyStash(worktreePath: repo, stash: stash) else {
+            Issue.record("Expected applyStash to report a conflict.")
+            return
+        }
+        #expect(message.contains("CONFLICT"))
     }
 }

--- a/AlasTests/PendingStashDropTests.swift
+++ b/AlasTests/PendingStashDropTests.swift
@@ -1,0 +1,12 @@
+import Testing
+@testable import Alas
+
+struct PendingStashDropTests {
+    @Test func alertCopyUsesStashRefAndSubject() {
+        let stash = GitStash(ref: "stash@{0}", subject: "parser cleanup", relativeTime: "2 hours ago", sha: "abc")
+        let pending = PendingStashDrop(stash: stash)
+
+        #expect(PendingStashDrop.alertTitle(for: pending) == "Drop stash@{0}?")
+        #expect(PendingStashDrop.alertMessage(for: pending) == "This permanently deletes \"parser cleanup\" from the stash list. This cannot be undone.")
+    }
+}

--- a/AlasTests/PendingStashDropTests.swift
+++ b/AlasTests/PendingStashDropTests.swift
@@ -1,6 +1,8 @@
 import Testing
+import Foundation
 @testable import Alas
 
+@MainActor
 struct PendingStashDropTests {
     @Test func alertCopyUsesStashRefAndSubject() {
         let stash = GitStash(ref: "stash@{0}", subject: "parser cleanup", relativeTime: "2 hours ago", sha: "abc")
@@ -8,5 +10,34 @@ struct PendingStashDropTests {
 
         #expect(PendingStashDrop.alertTitle(for: pending) == "Drop stash@{0}?")
         #expect(PendingStashDrop.alertMessage(for: pending) == "This permanently deletes \"parser cleanup\" from the stash list. This cannot be undone.")
+    }
+
+    @Test func reconcileStashesClearsCachedFilesWhenRefPointsAtDifferentSha() {
+        let state = RightPaneState(
+            worktree: Worktree(
+                id: "wt",
+                projectId: "project",
+                name: "main",
+                branch: "main",
+                path: URL(fileURLWithPath: "/tmp/repo"),
+                status: .clean,
+                lastActivity: Date()
+            ),
+            baseBranch: "main"
+        )
+        state.stashFilesByRef = [
+            "stash@{0}": [GitStashFile(path: "old.txt", status: "M", add: 1, del: 0)],
+        ]
+        state.expandedStashRefs = ["stash@{0}"]
+        state.stashes = [
+            GitStash(ref: "stash@{0}", subject: "old", relativeTime: "1 minute ago", sha: "old-sha"),
+        ]
+
+        state.reconcileStashCaches(with: [
+            GitStash(ref: "stash@{0}", subject: "new", relativeTime: "now", sha: "new-sha"),
+        ])
+
+        #expect(state.stashFilesByRef.isEmpty)
+        #expect(state.expandedStashRefs.isEmpty)
     }
 }

--- a/AlasTests/TabsManagerTests.swift
+++ b/AlasTests/TabsManagerTests.swift
@@ -1056,10 +1056,25 @@ struct TabsManagerPaneTests {
             Issue.record("Expected stashDiff tab")
             return
         }
-        #expect(state.id == "stash-diff:wt1:stash@{0}:Sources/App.swift")
+        #expect(state.id == "stash-diff:wt1:stash@{0}:abc:Sources/App.swift")
         #expect(state.title == "App.swift @ stash@{0}")
         #expect(state.stash == stash)
         #expect(state.file == file)
+    }
+
+    @Test func appendStashDiffIncludesShaInTabIdentity() {
+        let worktreeId = "wt1"
+        defer { try? FileManager.default.removeItem(at: Paths.tabsFile(forWorktreeId: worktreeId)) }
+        let mgr = TabsManager()
+        let oldStash = GitStash(ref: "stash@{0}", subject: "old", relativeTime: "1 minute ago", sha: "old-sha")
+        let newStash = GitStash(ref: "stash@{0}", subject: "new", relativeTime: "now", sha: "new-sha")
+        let file = GitStashFile(path: "Sources/App.swift", status: "M", add: 2, del: 1)
+
+        let oldTab = mgr.appendStashDiff(worktreeId: worktreeId, stash: oldStash, file: file)
+        let newTab = mgr.appendStashDiff(worktreeId: worktreeId, stash: newStash, file: file)
+
+        #expect(oldTab.id != newTab.id)
+        #expect(mgr.tabs(forWorktree: worktreeId).count == 2)
     }
 }
 

--- a/AlasTests/TabsManagerTests.swift
+++ b/AlasTests/TabsManagerTests.swift
@@ -1042,6 +1042,25 @@ struct TabsManagerPaneTests {
         #expect(l.lastCwd == "/tmp/work",
                 "lastCwd should be preserved across session replacement")
     }
+
+    @Test func appendStashDiffCreatesStableReadOnlyPreviewTab() {
+        let worktreeId = "wt1"
+        defer { try? FileManager.default.removeItem(at: Paths.tabsFile(forWorktreeId: worktreeId)) }
+        let mgr = TabsManager()
+        let stash = GitStash(ref: "stash@{0}", subject: "parser cleanup", relativeTime: "now", sha: "abc")
+        let file = GitStashFile(path: "Sources/App.swift", status: "M", add: 2, del: 1)
+
+        let tab = mgr.appendStashDiff(worktreeId: worktreeId, stash: stash, file: file)
+
+        guard case .stashDiff(let state) = tab else {
+            Issue.record("Expected stashDiff tab")
+            return
+        }
+        #expect(state.id == "stash-diff:wt1:stash@{0}:Sources/App.swift")
+        #expect(state.title == "App.swift @ stash@{0}")
+        #expect(state.stash == stash)
+        #expect(state.file == file)
+    }
 }
 
 // MARK: - Terminal runtime titles

--- a/docs/superpowers/plans/2026-06-22-stashes-ui-implementation.md
+++ b/docs/superpowers/plans/2026-06-22-stashes-ui-implementation.md
@@ -1,0 +1,1357 @@
+# Stashes UI Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add v1 git stash support to the Changes tab: Park Changes, list stashes, preview stash diffs, apply, pop, and drop.
+
+**Architecture:** Keep stash command execution in `GitService`, coordination in `RightPaneState`, and rendering in focused SwiftUI views under `Alas/Sources/Right`. Stash file preview opens a dedicated center tab backed by existing diff display primitives so preview remains read-only and never mutates the live worktree.
+
+**Tech Stack:** Swift 5.9+, SwiftUI, Swift Testing (`import Testing`), git CLI through existing `Process.git`, existing `DiffParser`/`DiffDisplayModelBuilder`/`DiffPaneView`.
+
+---
+
+## File Structure
+
+- Create `Alas/Sources/Git/GitService+Stash.swift`
+  - Defines `GitStash`, `GitStashFile`, `StashOperationResult`, parser helpers, and stash git commands.
+- Create `AlasTests/GitServiceStashTests.swift`
+  - Unit and integration coverage for stash parsing and command behavior.
+- Modify `Alas/Sources/Center/Tab.swift`
+  - Adds `StashDiffTabState` and `Tab.stashDiff`.
+- Modify `Alas/Sources/Center/TabsManager.swift`
+  - Adds `appendStashDiff`.
+- Modify `Alas/Sources/App/AppState.swift`
+  - Adds `openStashDiffTab`.
+- Modify `Alas/Sources/Center/CenterPaneView.swift`
+  - Renders `StashDiffTabView`.
+- Create `Alas/Sources/Center/StashDiffTabView.swift`
+  - Loads a stash file diff and renders it read-only.
+- Create `Alas/Sources/Right/PendingStashDrop.swift`
+  - Encapsulates drop confirmation copy.
+- Create `AlasTests/PendingStashDropTests.swift`
+  - Covers destructive confirmation strings.
+- Modify `Alas/Sources/Right/RightPaneState.swift`
+  - Adds stash state, refresh loading, park/apply/pop/drop operations, and pending sheet/drop state.
+- Modify `Alas/Sources/Right/WorkingTreeSectionView.swift`
+  - Adds **Park Changes...** menu entry.
+- Create `Alas/Sources/Right/ParkChangesSheet.swift`
+  - Sheet for optional message and include-untracked checkbox.
+- Create `Alas/Sources/Right/StashesSectionView.swift`
+  - Collapsible Stashes section with menu-first row actions.
+- Modify `Alas/Sources/Right/ChangesTabView.swift`
+  - Places Stashes between Working tree and Commits and wires preview/actions.
+- Modify `Alas/Sources/Right/RightPaneView.swift`
+  - Hosts `ParkChangesSheet` and drop confirmation.
+- Add or extend focused view/model tests under `AlasTests`.
+
+## Task 1: Git Stash Models And Parsers
+
+**Files:**
+- Create: `Alas/Sources/Git/GitService+Stash.swift`
+- Create: `AlasTests/GitServiceStashTests.swift`
+
+- [ ] **Step 1: Write failing parser tests**
+
+Add `AlasTests/GitServiceStashTests.swift`:
+
+```swift
+import Foundation
+import Testing
+@testable import Alas
+
+@Suite(.serialized)
+struct GitServiceStashTests {
+    @Test func parseStashListPreservesRefSubjectRelativeTimeAndSha() {
+        let output = """
+        stash@{0}\u{1f}WIP on main: abc123 update parser\u{1f}2 hours ago\u{1f}1111111111111111111111111111111111111111
+        stash@{1}\u{1f}custom message\u{1f}3 days ago\u{1f}2222222222222222222222222222222222222222
+
+        """
+
+        let stashes = GitService.parseStashList(output)
+
+        #expect(stashes == [
+            GitStash(
+                ref: "stash@{0}",
+                subject: "WIP on main: abc123 update parser",
+                relativeTime: "2 hours ago",
+                sha: "1111111111111111111111111111111111111111"
+            ),
+            GitStash(
+                ref: "stash@{1}",
+                subject: "custom message",
+                relativeTime: "3 days ago",
+                sha: "2222222222222222222222222222222222222222"
+            ),
+        ])
+    }
+
+    @Test func parseStashFilesMergesNumstatAndNameStatus() {
+        let numstat = """
+        12\t3\tSources/App.swift
+        -\t-\tAssets/icon.png
+        4\t0\tSources/New.swift
+
+        """
+        let nameStatus = """
+        M\tSources/App.swift
+        M\tAssets/icon.png
+        A\tSources/New.swift
+
+        """
+
+        let files = GitService.parseStashFiles(numstat: numstat, nameStatus: nameStatus)
+
+        #expect(files == [
+            GitStashFile(path: "Sources/App.swift", status: "M", add: 12, del: 3),
+            GitStashFile(path: "Assets/icon.png", status: "M", add: 0, del: 0),
+            GitStashFile(path: "Sources/New.swift", status: "A", add: 4, del: 0),
+        ])
+    }
+
+    @Test func parseStashFilesHandlesRenamesUsingNewPath() {
+        let numstat = "1\t2\tSources/Old.swift => Sources/New.swift\n"
+        let nameStatus = "R100\tSources/Old.swift\tSources/New.swift\n"
+
+        let files = GitService.parseStashFiles(numstat: numstat, nameStatus: nameStatus)
+
+        #expect(files == [
+            GitStashFile(path: "Sources/New.swift", status: "R", add: 1, del: 2),
+        ])
+    }
+}
+```
+
+- [ ] **Step 2: Run tests and verify they fail**
+
+Run:
+
+```bash
+xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -only-testing:AlasTests/GitServiceStashTests test
+```
+
+Expected: compile fails because `GitStash`, `GitStashFile`, `parseStashList`, and `parseStashFiles` do not exist.
+
+- [ ] **Step 3: Add stash models and parser helpers**
+
+Create `Alas/Sources/Git/GitService+Stash.swift`:
+
+```swift
+import Foundation
+
+struct GitStash: Codable, Equatable, Identifiable, Sendable {
+    var id: String { ref }
+    let ref: String
+    let subject: String
+    let relativeTime: String
+    let sha: String
+}
+
+struct GitStashFile: Codable, Equatable, Identifiable, Sendable {
+    var id: String { path }
+    let path: String
+    let status: String
+    let add: Int
+    let del: Int
+}
+
+enum StashOperationResult: Equatable, Sendable {
+    case clean
+    case conflict(message: String)
+    case error(message: String)
+}
+
+extension GitService {
+    static func parseStashList(_ output: String) -> [GitStash] {
+        output
+            .split(separator: "\n", omittingEmptySubsequences: true)
+            .compactMap { line -> GitStash? in
+                let parts = line.split(separator: "\u{1f}", omittingEmptySubsequences: false).map(String.init)
+                guard parts.count == 4 else { return nil }
+                let ref = parts[0].trimmingCharacters(in: .whitespacesAndNewlines)
+                guard !ref.isEmpty else { return nil }
+                return GitStash(
+                    ref: ref,
+                    subject: parts[1].trimmingCharacters(in: .whitespacesAndNewlines),
+                    relativeTime: parts[2].trimmingCharacters(in: .whitespacesAndNewlines),
+                    sha: parts[3].trimmingCharacters(in: .whitespacesAndNewlines)
+                )
+            }
+    }
+
+    static func parseStashFiles(numstat: String, nameStatus: String) -> [GitStashFile] {
+        let counts = parseStashNumstat(numstat)
+        return nameStatus
+            .split(separator: "\n", omittingEmptySubsequences: true)
+            .compactMap { rawLine -> GitStashFile? in
+                let parts = rawLine.split(separator: "\t", omittingEmptySubsequences: false).map(String.init)
+                guard parts.count >= 2 else { return nil }
+                let rawStatus = parts[0]
+                let status = String(rawStatus.prefix(1))
+                let path = parts.count >= 3 ? parts[2] : parts[1]
+                let fallback = normalizeStashNumstatPath(path)
+                let count = counts[path] ?? counts[fallback] ?? (add: 0, del: 0)
+                return GitStashFile(path: path, status: status, add: count.add, del: count.del)
+            }
+    }
+
+    private static func parseStashNumstat(_ output: String) -> [String: (add: Int, del: Int)] {
+        var result: [String: (add: Int, del: Int)] = [:]
+        for rawLine in output.split(separator: "\n", omittingEmptySubsequences: true) {
+            let parts = rawLine.split(separator: "\t", omittingEmptySubsequences: false).map(String.init)
+            guard parts.count >= 3 else { continue }
+            let add = Int(parts[0]) ?? 0
+            let del = Int(parts[1]) ?? 0
+            let path = normalizeStashNumstatPath(parts[2])
+            result[path] = (add, del)
+        }
+        return result
+    }
+
+    private static func normalizeStashNumstatPath(_ path: String) -> String {
+        guard path.contains(" => ") else { return path }
+        guard let suffix = path.split(separator: "=>", maxSplits: 1, omittingEmptySubsequences: false).last else {
+            return path
+        }
+        return suffix
+            .replacingOccurrences(of: "}", with: "")
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+}
+```
+
+- [ ] **Step 4: Run parser tests and verify they pass**
+
+Run:
+
+```bash
+xcodegen
+xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -only-testing:AlasTests/GitServiceStashTests test
+```
+
+Expected: parser tests pass.
+
+- [ ] **Step 5: Commit parser work**
+
+```bash
+git add Alas/Sources/Git/GitService+Stash.swift AlasTests/GitServiceStashTests.swift Alas.xcodeproj/project.pbxproj
+git commit -m "feat(changes): add stash parsers"
+```
+
+## Task 2: Git Stash Commands
+
+**Files:**
+- Modify: `Alas/Sources/Git/GitService+Stash.swift`
+- Modify: `AlasTests/GitServiceStashTests.swift`
+
+- [ ] **Step 1: Add failing integration tests for stash commands**
+
+Append these tests inside `GitServiceStashTests`:
+
+```swift
+private func makeRepo() async throws -> URL {
+    let dir = FileManager.default.temporaryDirectory
+        .appendingPathComponent("alas-stash-\(UUID().uuidString)")
+    try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+    try await gitOK(["init", "-q", "-b", "main"], cwd: dir)
+    try await gitOK(["config", "user.email", "t@example.com"], cwd: dir)
+    try await gitOK(["config", "user.name", "Test User"], cwd: dir)
+    try "base\n".write(to: dir.appendingPathComponent("file.txt"), atomically: true, encoding: .utf8)
+    try await gitOK(["add", "file.txt"], cwd: dir)
+    try await gitOK(["commit", "-q", "-m", "base"], cwd: dir)
+    return dir
+}
+
+@discardableResult
+private func gitOK(_ args: [String], cwd: URL) async throws -> ProcessResult {
+    let result = try await Process.git(args, cwd: cwd)
+    guard result.exitCode == 0 else {
+        throw NSError(
+            domain: "GitServiceStashTests.gitOK",
+            code: Int(result.exitCode),
+            userInfo: [NSLocalizedDescriptionKey: result.stderr]
+        )
+    }
+    return result
+}
+
+@Test func pushListFilesAndDiffStash() async throws {
+    let repo = try await makeRepo()
+    defer { try? FileManager.default.removeItem(at: repo) }
+    try "base\nchanged\n".write(to: repo.appendingPathComponent("file.txt"), atomically: true, encoding: .utf8)
+
+    let service = GitService()
+    let result = try await service.pushStash(worktreePath: repo, message: "parser cleanup", includeUntracked: false)
+
+    #expect(result == .clean)
+    let stashes = try await service.stashes(worktreePath: repo)
+    #expect(stashes.count == 1)
+    #expect(stashes[0].subject.contains("parser cleanup"))
+    let files = try await service.stashFiles(worktreePath: repo, stash: stashes[0])
+    #expect(files == [GitStashFile(path: "file.txt", status: "M", add: 1, del: 0)])
+    let diff = try await service.stashDiff(worktreePath: repo, stash: stashes[0], file: files[0])
+    #expect(diff.hunks.contains { hunk in hunk.lines.contains { $0.kind == .add && $0.text == "changed" } })
+}
+
+@Test func pushStashCanIncludeUntrackedFiles() async throws {
+    let repo = try await makeRepo()
+    defer { try? FileManager.default.removeItem(at: repo) }
+    try "new\n".write(to: repo.appendingPathComponent("new.txt"), atomically: true, encoding: .utf8)
+
+    let service = GitService()
+    let result = try await service.pushStash(worktreePath: repo, message: "", includeUntracked: true)
+
+    #expect(result == .clean)
+    let files = try await service.stashFiles(worktreePath: repo, stash: try #require(try await service.stashes(worktreePath: repo).first))
+    #expect(files.contains(GitStashFile(path: "new.txt", status: "A", add: 1, del: 0)))
+}
+
+@Test func applyPopAndDropStash() async throws {
+    let repo = try await makeRepo()
+    defer { try? FileManager.default.removeItem(at: repo) }
+    try "base\nchanged\n".write(to: repo.appendingPathComponent("file.txt"), atomically: true, encoding: .utf8)
+
+    let service = GitService()
+    _ = try await service.pushStash(worktreePath: repo, message: "apply me", includeUntracked: false)
+    var stash = try #require(try await service.stashes(worktreePath: repo).first)
+
+    #expect(try await service.applyStash(worktreePath: repo, stash: stash) == .clean)
+    #expect(try String(contentsOf: repo.appendingPathComponent("file.txt"), encoding: .utf8) == "base\nchanged\n")
+    try await gitOK(["checkout", "--", "file.txt"], cwd: repo)
+
+    #expect(try await service.popStash(worktreePath: repo, stash: stash) == .clean)
+    #expect(try await service.stashes(worktreePath: repo).isEmpty)
+
+    _ = try await service.pushStash(worktreePath: repo, message: "drop me", includeUntracked: false)
+    stash = try #require(try await service.stashes(worktreePath: repo).first)
+    try await service.dropStash(worktreePath: repo, stash: stash)
+    #expect(try await service.stashes(worktreePath: repo).isEmpty)
+}
+```
+
+- [ ] **Step 2: Run tests and verify they fail**
+
+Run:
+
+```bash
+xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -only-testing:AlasTests/GitServiceStashTests test
+```
+
+Expected: compile fails because stash command methods do not exist.
+
+- [ ] **Step 3: Implement stash command methods**
+
+Append to the `extension GitService` in `Alas/Sources/Git/GitService+Stash.swift`:
+
+```swift
+func stashes(worktreePath: URL) async throws -> [GitStash] {
+    let result = try await Process.git(
+        ["stash", "list", "--format=%gd%x1f%gs%x1f%cr%x1f%H"],
+        cwd: worktreePath
+    )
+    guard result.exitCode == 0 else { throw GitStashError.stderr(result.stderr, fallback: "Could not list stashes.") }
+    return Self.parseStashList(result.stdout)
+}
+
+func pushStash(worktreePath: URL, message: String, includeUntracked: Bool) async throws -> StashOperationResult {
+    var args = ["stash", "push"]
+    if includeUntracked { args.append("--include-untracked") }
+    let trimmed = message.trimmingCharacters(in: .whitespacesAndNewlines)
+    if !trimmed.isEmpty {
+        args.append(contentsOf: ["--message", trimmed])
+    }
+    let result = try await Process.git(args, cwd: worktreePath)
+    return Self.stashOperationResult(result, fallback: "Could not park changes.")
+}
+
+func stashFiles(worktreePath: URL, stash: GitStash) async throws -> [GitStashFile] {
+    let numstat = try await Process.git(
+        ["stash", "show", "--include-untracked", "--numstat", "--format=", stash.ref],
+        cwd: worktreePath
+    )
+    guard numstat.exitCode == 0 else {
+        throw GitStashError.stderr(numstat.stderr, fallback: "Could not load stash files.")
+    }
+    let nameStatus = try await Process.git(
+        ["stash", "show", "--include-untracked", "--name-status", "--format=", stash.ref],
+        cwd: worktreePath
+    )
+    guard nameStatus.exitCode == 0 else {
+        throw GitStashError.stderr(nameStatus.stderr, fallback: "Could not load stash files.")
+    }
+    return Self.parseStashFiles(numstat: numstat.stdout, nameStatus: nameStatus.stdout)
+}
+
+func stashDiff(worktreePath: URL, stash: GitStash, file: GitStashFile) async throws -> ParsedDiff {
+    let result = try await Process.git(
+        ["stash", "show", "--include-untracked", "--patch", "--format=", "--no-ext-diff", "--no-color", stash.ref, "--", file.path],
+        cwd: worktreePath
+    )
+    guard result.exitCode == 0 else {
+        throw GitStashError.stderr(result.stderr, fallback: "Could not load stash diff.")
+    }
+    return await Task.detached(priority: .userInitiated) {
+        DiffParser.parse(result.stdout)
+    }.value
+}
+
+func applyStash(worktreePath: URL, stash: GitStash) async throws -> StashOperationResult {
+    let result = try await Process.git(["stash", "apply", stash.ref], cwd: worktreePath)
+    return Self.stashOperationResult(result, fallback: "Could not apply stash.")
+}
+
+func popStash(worktreePath: URL, stash: GitStash) async throws -> StashOperationResult {
+    let result = try await Process.git(["stash", "pop", stash.ref], cwd: worktreePath)
+    return Self.stashOperationResult(result, fallback: "Could not pop stash.")
+}
+
+func dropStash(worktreePath: URL, stash: GitStash) async throws {
+    let result = try await Process.git(["stash", "drop", stash.ref], cwd: worktreePath)
+    guard result.exitCode == 0 else {
+        throw GitStashError.stderr(result.stderr, fallback: "Could not drop stash.")
+    }
+}
+
+private static func stashOperationResult(_ result: ProcessResult, fallback: String) -> StashOperationResult {
+    if result.exitCode == 0 { return .clean }
+    let message = result.stderr.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+        ? fallback
+        : result.stderr.trimmingCharacters(in: .whitespacesAndNewlines)
+    if message.localizedCaseInsensitiveContains("conflict") {
+        return .conflict(message: message)
+    }
+    return .error(message: message)
+}
+```
+
+Add this private error type at the bottom of the file:
+
+```swift
+private enum GitStashError: LocalizedError {
+    case stderr(String, fallback: String)
+
+    var errorDescription: String? {
+        switch self {
+        case .stderr(let stderr, let fallback):
+            let message = stderr.trimmingCharacters(in: .whitespacesAndNewlines)
+            return message.isEmpty ? fallback : message
+        }
+    }
+}
+```
+
+- [ ] **Step 4: Run stash command tests**
+
+Run:
+
+```bash
+xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -only-testing:AlasTests/GitServiceStashTests test
+```
+
+Expected: all stash tests pass.
+
+- [ ] **Step 5: Commit command work**
+
+```bash
+git add Alas/Sources/Git/GitService+Stash.swift AlasTests/GitServiceStashTests.swift
+git commit -m "feat(changes): add stash git operations"
+```
+
+## Task 3: Stash Diff Center Tab
+
+**Files:**
+- Modify: `Alas/Sources/Center/Tab.swift`
+- Modify: `Alas/Sources/Center/TabsManager.swift`
+- Modify: `Alas/Sources/App/AppState.swift`
+- Modify: `Alas/Sources/Center/CenterPaneView.swift`
+- Create: `Alas/Sources/Center/StashDiffTabView.swift`
+- Modify: `AlasTests/TabsManagerTests.swift`
+
+- [ ] **Step 1: Write failing tab manager test**
+
+Append to `AlasTests/TabsManagerTests.swift`:
+
+```swift
+@Test func appendStashDiffCreatesStableReadOnlyPreviewTab() {
+    let mgr = TabsManager()
+    let worktreeId = "wt1"
+    let stash = GitStash(ref: "stash@{0}", subject: "parser cleanup", relativeTime: "now", sha: "abc")
+    let file = GitStashFile(path: "Sources/App.swift", status: "M", add: 2, del: 1)
+
+    let tab = mgr.appendStashDiff(worktreeId: worktreeId, stash: stash, file: file)
+
+    guard case .stashDiff(let state) = tab else {
+        Issue.record("Expected stashDiff tab")
+        return
+    }
+    #expect(state.id == "stash-diff:wt1:stash@{0}:Sources/App.swift")
+    #expect(state.title == "App.swift @ stash@{0}")
+    #expect(state.stash == stash)
+    #expect(state.file == file)
+}
+```
+
+- [ ] **Step 2: Run test and verify it fails**
+
+Run:
+
+```bash
+xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -only-testing:AlasTests/TabsManagerTests/appendStashDiffCreatesStableReadOnlyPreviewTab test
+```
+
+Expected: compile fails because `stashDiff` tab support does not exist.
+
+- [ ] **Step 3: Add tab state and enum case**
+
+In `Alas/Sources/Center/Tab.swift`, add `case stashDiff(StashDiffTabState)` to `Tab`, then update `id`, `title`, `iconName`, and `relativeFilePath` switches:
+
+```swift
+case stashDiff(StashDiffTabState)
+```
+
+```swift
+case .stashDiff(let s): return s.id
+```
+
+```swift
+case .stashDiff(let s): return s.title
+```
+
+```swift
+case .stashDiff: return "archivebox"
+```
+
+```swift
+case .stashDiff(let s): return s.file.path
+```
+
+Add this state near `DiffTabState`:
+
+```swift
+struct StashDiffTabState: Codable, Equatable, Identifiable {
+    let id: TabID
+    let worktreeId: String
+    let stash: GitStash
+    let file: GitStashFile
+    let title: String
+
+    init(worktreeId: String, stash: GitStash, file: GitStashFile) {
+        self.worktreeId = worktreeId
+        self.stash = stash
+        self.file = file
+        self.title = "\((file.path as NSString).lastPathComponent) @ \(stash.ref)"
+        self.id = "stash-diff:\(worktreeId):\(stash.ref):\(file.path)"
+    }
+}
+```
+
+Because `Tab` is `Codable`, ensure the compiler synthesizes successfully after adding the case. `TabsFile.FailableTab` already skips unknown cases for older persisted files.
+
+- [ ] **Step 4: Add append and open helpers**
+
+In `Alas/Sources/Center/TabsManager.swift`, add:
+
+```swift
+@discardableResult
+func appendStashDiff(worktreeId: String, stash: GitStash, file: GitStashFile) -> Tab {
+    let state = StashDiffTabState(worktreeId: worktreeId, stash: stash, file: file)
+    let tab = Tab.stashDiff(state)
+    append(tab, to: worktreeId)
+    return tab
+}
+```
+
+In `Alas/Sources/App/AppState.swift`, add near `openDiffTab`:
+
+```swift
+func openStashDiffTab(worktree: Worktree, stash: GitStash, file: GitStashFile) {
+    let worktreeId = worktree.id
+    let existing = tabs.tabs(forWorktree: worktreeId).first { tab in
+        if case .stashDiff(let state) = tab {
+            return state.stash.ref == stash.ref && state.file.path == file.path
+        }
+        return false
+    }
+    if let existing {
+        tabs.activate(worktreeId: worktreeId, tabId: existing.id)
+        return
+    }
+    let tab = tabs.appendStashDiff(worktreeId: worktreeId, stash: stash, file: file)
+    tabs.activate(worktreeId: worktreeId, tabId: tab.id)
+}
+```
+
+- [ ] **Step 5: Create stash diff tab view**
+
+Create `Alas/Sources/Center/StashDiffTabView.swift`:
+
+```swift
+import SwiftUI
+
+struct StashDiffTabView: View {
+    let worktreePath: URL
+    let state: StashDiffTabState
+    var codeFontFamily: String = ""
+    var codeFontSize: CGFloat = 13
+
+    @Environment(\.theme) private var theme
+    @State private var loaded = false
+    @State private var error: String?
+    @State private var displayModel: DiffDisplayModel?
+    @State private var layoutMode: DiffLayoutMode = .split
+    @State private var wrapLines = false
+    @State private var showWhitespace = false
+
+    private let git = GitService()
+
+    var body: some View {
+        VStack(spacing: 0) {
+            header
+            if let error {
+                Text(error)
+                    .font(CenterTypography.codeFont(family: codeFontFamily, size: codeFontSize - 2))
+                    .foregroundColor(theme.color("del"))
+                    .padding(.horizontal, 14)
+                    .padding(.vertical, 6)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .background(theme.color("bg-2"))
+            }
+            if !loaded {
+                Spinner()
+                    .frame(width: 16, height: 16)
+                    .padding()
+            } else if let displayModel {
+                DiffPaneView(
+                    model: displayModel,
+                    fileExtension: (state.file.path as NSString).pathExtension,
+                    layoutMode: $layoutMode,
+                    wrapLines: $wrapLines,
+                    showWhitespace: $showWhitespace,
+                    codeFontFamily: codeFontFamily,
+                    codeFontSize: codeFontSize,
+                    allowsReviewLineSelection: false,
+                    hunkActions: { _ in DiffPaneHunkActions() }
+                )
+            } else {
+                Text("No changes for \(state.file.path)")
+                    .foregroundColor(theme.color("fg-dim"))
+                    .padding()
+            }
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
+        .background(theme.color("bg-1"))
+        .task(id: "\(state.stash.ref)\u{0}\(state.file.path)") { await load() }
+    }
+
+    private var header: some View {
+        HStack(spacing: 10) {
+            Text((state.file.path as NSString).lastPathComponent)
+                .font(CenterTypography.codeFont(family: codeFontFamily, size: codeFontSize))
+                .foregroundColor(theme.color("fg"))
+            Text(state.stash.ref)
+                .font(.system(size: 9.5, weight: .semibold))
+                .padding(.horizontal, 5)
+                .padding(.vertical, 1)
+                .background(theme.color("accent").opacity(0.16))
+                .foregroundColor(theme.color("accent"))
+                .clipShape(RoundedRectangle(cornerRadius: 3))
+            Text("·").foregroundColor(theme.color("fg-faint"))
+            Text((state.file.path as NSString).deletingLastPathComponent)
+                .font(.system(size: codeFontSize - 1.5))
+                .foregroundColor(theme.color("fg-dim"))
+                .lineLimit(1)
+                .truncationMode(.middle)
+            Spacer()
+        }
+        .padding(.horizontal, 14)
+        .padding(.vertical, 8)
+        .background(theme.color("bg-2"))
+        .overlay(Divider().opacity(0.5), alignment: .bottom)
+    }
+
+    private func load() async {
+        loaded = false
+        error = nil
+        displayModel = nil
+        do {
+            let diff = try await git.stashDiff(worktreePath: worktreePath, stash: state.stash, file: state.file)
+            guard !Task.isCancelled else { return }
+            let model = await Task.detached(priority: .userInitiated) {
+                DiffDisplayModelBuilder.build(diff: diff, filePath: state.file.path)
+            }.value
+            guard !Task.isCancelled else { return }
+            displayModel = diff.hunks.isEmpty ? nil : model
+            loaded = true
+        } catch {
+            guard !Task.isCancelled else { return }
+            self.error = error.localizedDescription
+            loaded = true
+        }
+    }
+}
+```
+
+- [ ] **Step 6: Render stash diff tab in center pane**
+
+In `Alas/Sources/Center/CenterPaneView.swift`, add a switch case:
+
+```swift
+case .stashDiff(let s):
+    StashDiffTabView(
+        worktreePath: worktree.path,
+        state: s,
+        codeFontFamily: state.config.code.fontFamily,
+        codeFontSize: CGFloat(state.config.code.fontSize)
+    )
+    .id(s.id)
+```
+
+- [ ] **Step 7: Run tab tests**
+
+Run:
+
+```bash
+xcodegen
+xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -only-testing:AlasTests/TabsManagerTests/appendStashDiffCreatesStableReadOnlyPreviewTab test
+```
+
+Expected: test passes.
+
+- [ ] **Step 8: Commit stash preview tab**
+
+```bash
+git add Alas/Sources/Center/Tab.swift Alas/Sources/Center/TabsManager.swift Alas/Sources/App/AppState.swift Alas/Sources/Center/CenterPaneView.swift Alas/Sources/Center/StashDiffTabView.swift AlasTests/TabsManagerTests.swift Alas.xcodeproj/project.pbxproj
+git commit -m "feat(changes): add stash diff preview tab"
+```
+
+## Task 4: RightPaneState Stash Coordination
+
+**Files:**
+- Create: `Alas/Sources/Right/PendingStashDrop.swift`
+- Create: `AlasTests/PendingStashDropTests.swift`
+- Modify: `Alas/Sources/Right/RightPaneState.swift`
+
+- [ ] **Step 1: Write failing drop copy tests**
+
+Create `AlasTests/PendingStashDropTests.swift`:
+
+```swift
+import Testing
+@testable import Alas
+
+struct PendingStashDropTests {
+    @Test func alertCopyUsesStashRefAndSubject() {
+        let stash = GitStash(ref: "stash@{0}", subject: "parser cleanup", relativeTime: "2 hours ago", sha: "abc")
+        let pending = PendingStashDrop(stash: stash)
+
+        #expect(PendingStashDrop.alertTitle(for: pending) == "Drop stash@{0}?")
+        #expect(PendingStashDrop.alertMessage(for: pending) == "This permanently deletes \"parser cleanup\" from the stash list. This cannot be undone.")
+    }
+}
+```
+
+- [ ] **Step 2: Run test and verify it fails**
+
+Run:
+
+```bash
+xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -only-testing:AlasTests/PendingStashDropTests test
+```
+
+Expected: compile fails because `PendingStashDrop` does not exist.
+
+- [ ] **Step 3: Add pending drop model**
+
+Create `Alas/Sources/Right/PendingStashDrop.swift`:
+
+```swift
+struct PendingStashDrop: Equatable {
+    let stash: GitStash
+
+    static func alertTitle(for pending: PendingStashDrop) -> String {
+        "Drop \(pending.stash.ref)?"
+    }
+
+    static func alertMessage(for pending: PendingStashDrop) -> String {
+        "This permanently deletes \"\(pending.stash.subject)\" from the stash list. This cannot be undone."
+    }
+}
+
+extension PendingStashDrop {
+    static let placeholder = PendingStashDrop(
+        stash: GitStash(ref: "stash@{0}", subject: "stash", relativeTime: "", sha: "")
+    )
+}
+```
+
+- [ ] **Step 4: Add stash state to RightPaneState**
+
+In `Alas/Sources/Right/RightPaneState.swift`, add stored properties near existing Changes tab state:
+
+```swift
+var stashes: [GitStash] = []
+var stashesExpanded: Bool = true
+var expandedStashRefs: Set<String> = []
+var stashFilesByRef: [String: [GitStashFile]] = [:]
+var loadingStashRefs: Set<String> = []
+var pendingParkChanges: Bool = false
+var pendingStashDrop: PendingStashDrop? = nil
+private(set) var stashOperationInFlight: Bool = false
+```
+
+In `markSnapshotUnknown()`, clear stash state:
+
+```swift
+stashes = []
+expandedStashRefs = []
+stashFilesByRef = [:]
+loadingStashRefs = []
+pendingParkChanges = false
+pendingStashDrop = nil
+stashOperationInFlight = false
+```
+
+- [ ] **Step 5: Load stashes during refresh**
+
+In `refresh()`, add this async load next to the other git loads:
+
+```swift
+async let stashProbe = git.stashes(worktreePath: worktree.path)
+```
+
+After `entries` and before publishing state, resolve:
+
+```swift
+let stashes = (try? await stashProbe) ?? []
+```
+
+When publishing state, add:
+
+```swift
+self.stashes = stashes
+let validRefs = Set(stashes.map(\.ref))
+self.expandedStashRefs.formIntersection(validRefs)
+self.stashFilesByRef = self.stashFilesByRef.filter { validRefs.contains($0.key) }
+```
+
+- [ ] **Step 6: Add park/apply/pop/drop methods**
+
+Add these methods before the merge operation section:
+
+```swift
+func requestParkChanges() {
+    guard !changes.isEmpty, mergeOp.current == nil, !stashOperationInFlight else { return }
+    pendingParkChanges = true
+}
+
+func cancelParkChanges() {
+    pendingParkChanges = false
+}
+
+func parkChanges(message: String, includeUntracked: Bool) {
+    guard pendingParkChanges, !stashOperationInFlight else { return }
+    pendingParkChanges = false
+    stashOperationInFlight = true
+    sidebarError = nil
+    Task { @MainActor in
+        defer { self.stashOperationInFlight = false }
+        do {
+            let result = try await self.git.pushStash(
+                worktreePath: self.worktree.path,
+                message: message,
+                includeUntracked: includeUntracked
+            )
+            await self.refresh()
+            self.handleStashOperationResult(result)
+        } catch {
+            self.sidebarError = error.localizedDescription
+        }
+    }
+}
+
+func toggleStashExpanded(_ stash: GitStash) {
+    if expandedStashRefs.contains(stash.ref) {
+        expandedStashRefs.remove(stash.ref)
+    } else {
+        expandedStashRefs.insert(stash.ref)
+        loadFiles(for: stash)
+    }
+}
+
+func loadFiles(for stash: GitStash) {
+    guard stashFilesByRef[stash.ref] == nil, !loadingStashRefs.contains(stash.ref) else { return }
+    loadingStashRefs.insert(stash.ref)
+    Task { @MainActor in
+        defer { self.loadingStashRefs.remove(stash.ref) }
+        do {
+            self.stashFilesByRef[stash.ref] = try await self.git.stashFiles(worktreePath: self.worktree.path, stash: stash)
+        } catch {
+            self.sidebarError = error.localizedDescription
+        }
+    }
+}
+
+func applyStash(_ stash: GitStash) {
+    runStashOperation { try await self.git.applyStash(worktreePath: self.worktree.path, stash: stash) }
+}
+
+func popStash(_ stash: GitStash) {
+    runStashOperation { try await self.git.popStash(worktreePath: self.worktree.path, stash: stash) }
+}
+
+func requestDropStash(_ stash: GitStash) {
+    pendingStashDrop = PendingStashDrop(stash: stash)
+}
+
+func cancelDropStash() {
+    pendingStashDrop = nil
+}
+
+func confirmDropStash(_ pending: PendingStashDrop) {
+    if pendingStashDrop == pending { pendingStashDrop = nil }
+    guard !stashOperationInFlight else { return }
+    stashOperationInFlight = true
+    sidebarError = nil
+    Task { @MainActor in
+        defer { self.stashOperationInFlight = false }
+        do {
+            try await self.git.dropStash(worktreePath: self.worktree.path, stash: pending.stash)
+            await self.refresh()
+        } catch {
+            self.sidebarError = error.localizedDescription
+        }
+    }
+}
+
+private func runStashOperation(_ operation: @escaping () async throws -> StashOperationResult) {
+    guard !stashOperationInFlight else { return }
+    stashOperationInFlight = true
+    sidebarError = nil
+    Task { @MainActor in
+        defer { self.stashOperationInFlight = false }
+        do {
+            let result = try await operation()
+            await self.refresh()
+            self.handleStashOperationResult(result)
+        } catch {
+            self.sidebarError = error.localizedDescription
+        }
+    }
+}
+
+private func handleStashOperationResult(_ result: StashOperationResult) {
+    switch result {
+    case .clean:
+        return
+    case .conflict(let message), .error(let message):
+        sidebarError = message
+    }
+}
+```
+
+- [ ] **Step 7: Run drop tests**
+
+Run:
+
+```bash
+xcodegen
+xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -only-testing:AlasTests/PendingStashDropTests test
+```
+
+Expected: tests pass.
+
+- [ ] **Step 8: Commit state coordination**
+
+```bash
+git add Alas/Sources/Right/PendingStashDrop.swift Alas/Sources/Right/RightPaneState.swift AlasTests/PendingStashDropTests.swift Alas.xcodeproj/project.pbxproj
+git commit -m "feat(changes): coordinate stash operations"
+```
+
+## Task 5: Right Pane Stash UI
+
+**Files:**
+- Modify: `Alas/Sources/Right/WorkingTreeSectionView.swift`
+- Create: `Alas/Sources/Right/ParkChangesSheet.swift`
+- Create: `Alas/Sources/Right/StashesSectionView.swift`
+- Modify: `Alas/Sources/Right/ChangesTabView.swift`
+- Modify: `Alas/Sources/Right/RightPaneView.swift`
+
+- [ ] **Step 1: Add Park Changes callback to WorkingTreeSectionView**
+
+In `WorkingTreeSectionView`, add this property:
+
+```swift
+var onParkChanges: (() -> Void)? = nil
+var parkChangesDisabled: Bool = false
+```
+
+Add this menu item in the section header context menu before the discard divider:
+
+```swift
+Button("Park Changes…") {
+    onParkChanges?()
+}
+.disabled(parkChangesDisabled || changes.isEmpty || onParkChanges == nil)
+```
+
+- [ ] **Step 2: Create ParkChangesSheet**
+
+Create `Alas/Sources/Right/ParkChangesSheet.swift`:
+
+```swift
+import SwiftUI
+
+struct ParkChangesSheet: View {
+    let onPark: (String, Bool) -> Void
+    let onCancel: () -> Void
+
+    @Environment(\.theme) private var theme
+    @State private var message = ""
+    @State private var includeUntracked = false
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            Text("Park Changes")
+                .font(.system(size: 14, weight: .semibold))
+                .foregroundColor(theme.color("fg"))
+            Text("Move current working-tree changes into a git stash.")
+                .font(.system(size: 11))
+                .foregroundColor(theme.color("fg-muted"))
+            AlasField(
+                text: $message,
+                placeholder: "Optional message",
+                focusOnAppear: true,
+                onSubmit: { onPark(message, includeUntracked) }
+            )
+            Toggle("Include untracked files", isOn: $includeUntracked)
+                .toggleStyle(.checkbox)
+                .font(.system(size: 12))
+            HStack {
+                Spacer()
+                Button("Cancel", action: onCancel)
+                Button("Park Changes") {
+                    onPark(message, includeUntracked)
+                }
+                .keyboardShortcut(.defaultAction)
+            }
+        }
+        .padding(16)
+        .frame(width: 360)
+        .background(theme.color("bg-2"))
+    }
+}
+```
+
+- [ ] **Step 3: Create StashesSectionView**
+
+Create `Alas/Sources/Right/StashesSectionView.swift`:
+
+```swift
+import SwiftUI
+
+struct StashesSectionView: View {
+    let stashes: [GitStash]
+    let filesByRef: [String: [GitStashFile]]
+    let loadingRefs: Set<String>
+    @Binding var expanded: Bool
+    let expandedRefs: Set<String>
+    let onToggleSection: () -> Void
+    let onToggleStash: (GitStash) -> Void
+    let onSelectFile: (GitStash, GitStashFile) -> Void
+    let onApply: (GitStash) -> Void
+    let onPop: (GitStash) -> Void
+    let onDrop: (GitStash) -> Void
+
+    @Environment(\.theme) private var theme
+
+    var body: some View {
+        if !stashes.isEmpty {
+            Section {
+                if expanded {
+                    ForEach(stashes) { stash in
+                        stashRow(stash)
+                    }
+                }
+            } header: {
+                SectionHeader(
+                    title: "Stashes",
+                    count: stashes.count,
+                    expanded: expanded,
+                    onToggle: onToggleSection
+                )
+            }
+        }
+    }
+
+    @ViewBuilder
+    private func stashRow(_ stash: GitStash) -> some View {
+        let open = expandedRefs.contains(stash.ref)
+        Button {
+            onToggleStash(stash)
+        } label: {
+            HStack(spacing: 6) {
+                Icon(name: open ? "chev-down" : "chev-right", size: 10, color: theme.color("fg-faint"))
+                    .frame(width: 14, height: 14)
+                Text(stash.subject.isEmpty ? stash.ref : stash.subject)
+                    .font(.system(size: 11.5))
+                    .foregroundColor(theme.color("fg"))
+                    .lineLimit(1)
+                    .truncationMode(.middle)
+                Text(stash.ref)
+                    .font(.system(size: 10, design: .monospaced))
+                    .foregroundColor(theme.color("fg-faint"))
+                Spacer()
+                if loadingRefs.contains(stash.ref) {
+                    Spinner(lineWidth: 1.2, duration: 0.7)
+                        .frame(width: 10, height: 10)
+                }
+                Menu {
+                    Button("Apply") { onApply(stash) }
+                    Button("Pop") { onPop(stash) }
+                    Divider()
+                    Button("Drop…", role: .destructive) { onDrop(stash) }
+                } label: {
+                    Image(systemName: "ellipsis")
+                        .font(.system(size: 12, weight: .semibold))
+                        .foregroundColor(theme.color("fg-muted"))
+                }
+                .menuStyle(.borderlessButton)
+                .menuIndicator(.hidden)
+                .fixedSize()
+                .help("Stash actions")
+            }
+            .padding(.horizontal, 12)
+            .padding(.vertical, 5)
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+        .contextMenu {
+            Button("Apply") { onApply(stash) }
+            Button("Pop") { onPop(stash) }
+            Divider()
+            Button("Drop…", role: .destructive) { onDrop(stash) }
+        }
+        if open {
+            expandedFiles(for: stash)
+        }
+    }
+
+    @ViewBuilder
+    private func expandedFiles(for stash: GitStash) -> some View {
+        let files = filesByRef[stash.ref] ?? []
+        if loadingRefs.contains(stash.ref) && files.isEmpty {
+            HStack(spacing: 6) {
+                Spinner(lineWidth: 1.2, duration: 0.7).frame(width: 10, height: 10)
+                Text("Loading stash files…")
+                    .font(.system(size: 11))
+                    .foregroundColor(theme.color("fg-faint"))
+            }
+            .padding(.leading, 32)
+            .padding(.vertical, 6)
+        } else if files.isEmpty {
+            Text("no files")
+                .font(.system(size: 11))
+                .foregroundColor(theme.color("fg-faint"))
+                .padding(.leading, 32)
+                .padding(.vertical, 6)
+        } else {
+            ForEach(files) { file in
+                Button {
+                    onSelectFile(stash, file)
+                } label: {
+                    HStack(spacing: 6) {
+                        FileTypeIconView(filename: (file.path as NSString).lastPathComponent, size: 16)
+                        Text((file.path as NSString).lastPathComponent)
+                            .font(.system(size: 11.5, design: .monospaced))
+                            .lineLimit(1)
+                            .truncationMode(.middle)
+                        Spacer()
+                        if file.add > 0 { Text("+\(file.add)").foregroundColor(theme.color("add")) }
+                        if file.del > 0 { Text("−\(file.del)").foregroundColor(theme.color("del")) }
+                        StatusBadge(status: file.status)
+                    }
+                    .font(.system(size: 11, design: .monospaced))
+                    .padding(.leading, 32)
+                    .padding(.trailing, 12)
+                    .padding(.vertical, 4)
+                    .contentShape(Rectangle())
+                }
+                .buttonStyle(.plain)
+            }
+        }
+    }
+}
+```
+
+- [ ] **Step 4: Wire Stashes into ChangesTabView**
+
+In the `WorkingTreeSectionView` call in `ChangesTabView`, add:
+
+```swift
+onParkChanges: { rps.requestParkChanges() },
+parkChangesDisabled: rps.mergeOp.current != nil || rps.stashOperationInFlight,
+```
+
+After the `WorkingTreeSectionView` block and before the divider before commits, insert:
+
+```swift
+StashesSectionView(
+    stashes: rps.stashes,
+    filesByRef: rps.stashFilesByRef,
+    loadingRefs: rps.loadingStashRefs,
+    expanded: $rps.stashesExpanded,
+    expandedRefs: rps.expandedStashRefs,
+    onToggleSection: { rps.stashesExpanded.toggle() },
+    onToggleStash: { rps.toggleStashExpanded($0) },
+    onSelectFile: { stash, file in
+        appState.openStashDiffTab(worktree: rps.worktree, stash: stash, file: file)
+    },
+    onApply: { rps.applyStash($0) },
+    onPop: { rps.popStash($0) },
+    onDrop: { rps.requestDropStash($0) }
+)
+```
+
+- [ ] **Step 5: Host sheet and drop alert in RightPaneView**
+
+In `RightPaneView`, after the existing alerts, add:
+
+```swift
+.sheet(
+    isPresented: Binding(
+        get: { rps.pendingParkChanges },
+        set: { if !$0 { rps.cancelParkChanges() } }
+    )
+) {
+    ParkChangesSheet(
+        onPark: { message, includeUntracked in
+            rps.parkChanges(message: message, includeUntracked: includeUntracked)
+        },
+        onCancel: { rps.cancelParkChanges() }
+    )
+}
+.alert(
+    PendingStashDrop.alertTitle(for: rps.pendingStashDrop ?? .placeholder),
+    isPresented: Binding(
+        get: { rps.pendingStashDrop != nil },
+        set: { if !$0 { rps.cancelDropStash() } }
+    ),
+    presenting: rps.pendingStashDrop,
+    actions: { pending in
+        Button("Drop", role: .destructive) {
+            rps.confirmDropStash(pending)
+        }
+        Button("Cancel", role: .cancel) {
+            rps.cancelDropStash()
+        }
+    },
+    message: { pending in
+        Text(PendingStashDrop.alertMessage(for: pending))
+    }
+)
+```
+
+- [ ] **Step 6: Run a targeted build**
+
+Run:
+
+```bash
+xcodegen
+xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -quiet build
+```
+
+Expected: build succeeds.
+
+- [ ] **Step 7: Commit right-pane UI**
+
+```bash
+git add Alas/Sources/Right/WorkingTreeSectionView.swift Alas/Sources/Right/ParkChangesSheet.swift Alas/Sources/Right/StashesSectionView.swift Alas/Sources/Right/ChangesTabView.swift Alas/Sources/Right/RightPaneView.swift Alas.xcodeproj/project.pbxproj
+git commit -m "feat(changes): surface stashes in changes tab"
+```
+
+## Task 6: Verification And Polish
+
+**Files:**
+- Modify files from prior tasks only when verification finds compile or behavior gaps.
+
+- [ ] **Step 1: Run focused tests**
+
+Run:
+
+```bash
+xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -only-testing:AlasTests/GitServiceStashTests -only-testing:AlasTests/PendingStashDropTests -only-testing:AlasTests/TabsManagerTests test
+```
+
+Expected: all selected tests pass.
+
+- [ ] **Step 2: Run full build**
+
+Run:
+
+```bash
+xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -quiet build
+```
+
+Expected: build succeeds with no Swift errors.
+
+- [ ] **Step 3: Run full test suite**
+
+Run:
+
+```bash
+xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' test
+```
+
+Expected: all tests pass.
+
+- [ ] **Step 4: Manual verification in a temporary repository**
+
+Use Alas UI against a small repo and verify:
+
+```bash
+mkdir /tmp/alas-stash-manual
+cd /tmp/alas-stash-manual
+git init -b main
+git config user.email t@example.com
+git config user.name "Test User"
+printf "base\n" > file.txt
+git add file.txt
+git commit -m base
+printf "base\nchanged\n" > file.txt
+printf "new\n" > new.txt
+```
+
+Expected UI results:
+
+- Working tree menu shows **Park Changes...**.
+- Park sheet accepts an empty message.
+- Include untracked files parks `new.txt`.
+- Stashes section appears below Working tree.
+- Expanding a stash lists `file.txt` and `new.txt`.
+- Selecting `file.txt` opens a read-only stash diff tab.
+- Apply keeps the stash.
+- Pop removes the stash when apply succeeds.
+- Drop asks for confirmation and removes the stash.
+
+- [ ] **Step 5: Final commit for verification fixes**
+
+If verification required edits:
+
+```bash
+git add Alas/Sources AlasTests
+git commit -m "fix(changes): polish stash ui"
+```
+
+If verification required no edits, do not create an empty commit.
+
+## Final Verification
+
+Before claiming implementation complete, run:
+
+```bash
+xcodegen
+xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -quiet build
+xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' test
+```
+
+Expected: `xcodegen` completes, build succeeds, and the full test suite passes.

--- a/docs/superpowers/specs/2026-06-22-stashes-ui-design.md
+++ b/docs/superpowers/specs/2026-06-22-stashes-ui-design.md
@@ -1,0 +1,120 @@
+# Stashes UI Design
+
+## Context
+
+Issue [#587](https://github.com/mrmans0n/alas/issues/587) asks for git stash support in the Changes tab: park current work-in-progress, optionally include untracked files, list existing stashes with preview, and support apply, pop, and drop. Branch creation from a stash is useful but is deferred from the first pass.
+
+The design follows the existing right-pane Changes architecture. `ChangesTabView` controls section order, `WorkingTreeSectionView` owns the Working tree header menu, `RightPaneState` coordinates sidebar operations and refreshes, and `GitService` owns git command execution and parsing.
+
+## User Flow
+
+The feature uses "Park Changes..." for the action and "Stashes" for the list section.
+
+The Working tree section header menu gains a **Park Changes...** item. Selecting it opens a small sheet with:
+
+- an optional message field
+- an **Include untracked files** checkbox
+- a **Park Changes** primary action
+
+An empty message is allowed. When the user parks changes, Alas runs `git stash push`, refreshes the right-pane state, and shows the newly created stash in the Stashes section.
+
+The **Stashes** section appears directly below Working tree and above Commits when at least one stash exists. It is hidden when there are no stashes in the first version. This keeps clean repositories quiet while making parked work visible next to current work.
+
+Clicking a stash row expands it inline. The expanded row shows a compact file summary and aggregate additions/deletions. Clicking a file opens a stash diff preview in the center pane. Row actions live in the row menu and context menu:
+
+- **Apply**
+- **Pop**
+- **Drop...**
+
+`Drop...` requires confirmation. **Create Branch from Stash...** is not included in v1.
+
+## UI Structure
+
+`WorkingTreeSectionView` gets an optional `onParkChanges` callback and adds **Park Changes...** to the section header menu. The action is disabled when there are no working-tree changes or when a merge/rebase/cherry-pick operation is active.
+
+`ChangesTabView` renders the right-pane sections in this order:
+
+1. operation and error surfaces
+2. conflicts
+3. preparation card
+4. Working tree
+5. Stashes
+6. Commits
+
+`StashesSectionView` is a new collapsible section using the existing `SectionHeader` pattern. It owns only presentation state: section expansion, row expansion, row menus, and rendering stash file rows.
+
+`ParkChangesSheet` is a small SwiftUI sheet for the message and untracked-files option. It is hosted from `RightPaneView`, matching the existing ownership of right-pane confirmations that must remain available even if the child Changes view changes. The sheet state is driven by `RightPaneState`.
+
+## State And Operations
+
+`RightPaneState` owns stash state and operations:
+
+- `stashes: [GitStash]`
+- `stashesExpanded`
+- expanded stash identity
+- pending park sheet state
+- pending drop confirmation state
+- `parkChanges(message:includeUntracked:)`
+- `applyStash(_:)`
+- `popStash(_:)`
+- `requestDropStash(_:)`
+- `confirmDropStash(_:)`
+
+Stash operations follow the existing sidebar operation rhythm: clear `sidebarError`, run git work asynchronously, refresh, then surface failures through `sidebarError`.
+
+## Git Service
+
+`GitService` adds stash primitives:
+
+- list stashes
+- push current changes with optional message and optional untracked files
+- load file summary for a stash
+- load diff for a stash file
+- apply stash
+- pop stash
+- drop stash
+
+Use `git stash push` rather than legacy `git stash save`. If the message is empty, omit the message argument and let Git generate its normal stash message. If **Include untracked files** is checked, pass `--include-untracked`.
+
+List parsing should preserve stable stash references such as `stash@{0}` and the user-visible subject. File summaries should use Git output intended for parsing, such as name-status and numstat data, instead of scraping porcelain text.
+
+## Diff Preview
+
+The expanded stash row lists files changed by the stash. Selecting a file opens a stash-specific diff preview in the center pane.
+
+Use a stash-specific center selection and loader backed by the existing diff display primitives. This keeps the preview read-only and avoids pretending the stash file is part of the live working tree.
+
+The preview must show the stash contents without applying the stash to the working tree.
+
+## Error Handling
+
+Failed park/apply/pop/drop operations surface stderr or a localized fallback in `sidebarError`.
+
+Apply and pop can produce conflicts. In that case Alas refreshes the working tree so conflicted files appear in Working tree. If Git returns a useful message, it should be shown in `sidebarError`. The stash remains intact for `apply`; for `pop`, Git normally keeps the stash when the apply step fails.
+
+Drop requires confirmation because it deletes the stash entry.
+
+## Testing
+
+Add focused tests around the risky boundaries:
+
+- `GitService` parsing tests for stash list output.
+- `GitService` parsing tests for stash file summary output.
+- `RightPaneState` tests for pending park/drop state and operation refresh behavior using injected git-operation seams already available in tests, or narrower state tests if direct git injection is not available.
+- View or model tests for Stashes section visibility, menu labels, and confirmation copy.
+
+Manual verification should cover:
+
+- park tracked changes with no message
+- park tracked changes with a message
+- park including untracked files
+- list and expand stashes
+- preview a stash file diff
+- apply a stash
+- pop a stash
+- drop a stash after confirmation
+- apply/pop conflict behavior
+
+## Deferred
+
+`git stash branch` / **Create Branch from Stash...** is deferred. It adds branch naming, checkout side effects, and additional failure states that are not needed for the first usable version.


### PR DESCRIPTION
## Summary
- Add git stash models, parsing, and operations for push/list/files/diff/apply/pop/drop.
- Add read-only stash diff tabs and right-pane stash coordination state.
- Surface Park Changes, Stashes, inline file previews, apply/pop/drop, and drop confirmation in the Changes tab.

## Test Plan
- `xcodegen`
- `xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -quiet build`
- `xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -only-testing:AlasTests/GitServiceStashTests -only-testing:AlasTests/PendingStashDropTests -only-testing:AlasTests/TabsManagerTests test`
- `xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' test`