### PR TITLE
fix(editor): keep line-number gutter clear at leading edge

### DIFF
--- a/Alas/Sources/Code/Editor/CodeEditorView.swift
+++ b/Alas/Sources/Code/Editor/CodeEditorView.swift
@@ -15,27 +15,66 @@ final class CodeEditorLeadingClipView: NSClipView {
 
     override func constrainBoundsRect(_ proposedBounds: NSRect) -> NSRect {
         var bounds = super.constrainBoundsRect(proposedBounds)
-        guard enclosingScrollView?.hasHorizontalScroller == true else {
-            bounds.origin.x = 0
-            return bounds
-        }
-        guard let documentView else {
-            bounds.origin.x = 0
+        let leadingX = leadingBoundsOriginX
+        guard enclosingScrollView?.hasHorizontalScroller == true,
+              let documentView else {
+            bounds.origin.x = leadingX
             return bounds
         }
 
-        let maxX = max(documentView.frame.width - bounds.width, 0)
-        bounds.origin.x = min(max(bounds.origin.x, 0), maxX)
+        let maxX = max(documentView.frame.width - bounds.width, leadingX)
+        bounds.origin.x = resolvedOriginX(
+            proposed: proposedBounds.origin.x,
+            clamped: bounds.origin.x,
+            leadingX: leadingX,
+            maxX: maxX
+        )
         return bounds
     }
 
     private func pinnedOrigin(for origin: NSPoint) -> NSPoint {
-        guard enclosingScrollView?.hasHorizontalScroller == true, origin.x < 0 else {
-            return origin
-        }
-        var pinned = origin
-        pinned.x = 0
-        return pinned
+        guard enclosingScrollView?.hasHorizontalScroller == true else { return origin }
+        let leadingX = leadingBoundsOriginX
+        // Only enforce the leading edge here; `constrainBoundsRect` (which
+        // `super.scroll`/`setBoundsOrigin` funnel through) applies the upper
+        // bound and the gutter-reset handling.
+        let resolved = resolvedOriginX(
+            proposed: origin.x,
+            clamped: max(origin.x, leadingX),
+            leadingX: leadingX,
+            maxX: .greatestFiniteMagnitude
+        )
+        return resolved == origin.x ? origin : NSPoint(x: resolved, y: origin.y)
+    }
+
+    /// Resolves a proposed horizontal origin against the gutter-adjusted leading
+    /// edge (`leadingX`, e.g. `-rulerThickness`).
+    ///
+    /// AppKit's layout and frame-change passes repeatedly propose `x == 0` — they
+    /// treat `0` as the leading edge, unaware the line-number gutter shifts the
+    /// true leading to `leadingX`. Whichever pass runs last would otherwise win,
+    /// so the first characters of a line intermittently end up hidden under the
+    /// gutter. Snapping *only* that exact `0` reset to `leadingX` fixes the race
+    /// deterministically while leaving every other origin to clamp normally — so
+    /// incremental scrolling from the leading edge (`leadingX + delta`) is
+    /// preserved rather than discarded.
+    private func resolvedOriginX(proposed: CGFloat, clamped: CGFloat, leadingX: CGFloat, maxX: CGFloat) -> CGFloat {
+        if leadingX < 0, proposed == 0 { return leadingX }
+        return min(max(clamped, leadingX), maxX)
+    }
+
+    /// The leading-most horizontal bounds origin. A left-side vertical ruler
+    /// (the line-number gutter) makes AppKit shift the clip's bounds origin
+    /// negative by the ruler's reserved thickness so the document content
+    /// clears the gutter. The true leading edge is therefore `-rulerThickness`,
+    /// not `0` — clamping to `0` hides the first characters of every line under
+    /// the gutter with no way to scroll them back into view.
+    private var leadingBoundsOriginX: CGFloat {
+        guard let scrollView = enclosingScrollView,
+              scrollView.rulersVisible,
+              let ruler = scrollView.verticalRulerView,
+              ruler.orientation == .verticalRuler else { return 0 }
+        return -ruler.requiredThickness
     }
 }
 

--- a/Alas/Sources/Code/Editor/CodeEditorView.swift
+++ b/Alas/Sources/Code/Editor/CodeEditorView.swift
@@ -5,11 +5,15 @@ import AppKit
 /// the leading edge during initial layout, while preserving normal horizontal
 /// scrolling for long lines.
 final class CodeEditorLeadingClipView: NSClipView {
+    private var preservesNextExplicitZeroOrigin = false
+
     override func scroll(to newOrigin: NSPoint) {
+        defer { preservesNextExplicitZeroOrigin = false }
         super.scroll(to: pinnedOrigin(for: newOrigin))
     }
 
     override func setBoundsOrigin(_ newOrigin: NSPoint) {
+        defer { preservesNextExplicitZeroOrigin = false }
         super.setBoundsOrigin(pinnedOrigin(for: newOrigin))
     }
 
@@ -35,6 +39,10 @@ final class CodeEditorLeadingClipView: NSClipView {
     private func pinnedOrigin(for origin: NSPoint) -> NSPoint {
         guard enclosingScrollView?.hasHorizontalScroller == true else { return origin }
         let leadingX = leadingBoundsOriginX
+        if leadingX < 0, origin.x == 0 {
+            preservesNextExplicitZeroOrigin = true
+            return origin
+        }
         // Only enforce the leading edge here; `constrainBoundsRect` (which
         // `super.scroll`/`setBoundsOrigin` funnel through) applies the upper
         // bound and the gutter-reset handling.
@@ -54,12 +62,21 @@ final class CodeEditorLeadingClipView: NSClipView {
     /// treat `0` as the leading edge, unaware the line-number gutter shifts the
     /// true leading to `leadingX`. Whichever pass runs last would otherwise win,
     /// so the first characters of a line intermittently end up hidden under the
-    /// gutter. Snapping *only* that exact `0` reset to `leadingX` fixes the race
-    /// deterministically while leaving every other origin to clamp normally — so
-    /// incremental scrolling from the leading edge (`leadingX + delta`) is
-    /// preserved rather than discarded.
+    /// gutter. Snapping layout-only `0` resets to `leadingX` fixes the race while
+    /// still preserving an explicit scroll/scrollbar move that lands exactly on
+    /// zero.
     private func resolvedOriginX(proposed: CGFloat, clamped: CGFloat, leadingX: CGFloat, maxX: CGFloat) -> CGFloat {
-        if leadingX < 0, proposed == 0 { return leadingX }
+        guard leadingX < 0 else { return min(max(clamped, leadingX), maxX) }
+
+        if proposed == 0 {
+            if preservesNextExplicitZeroOrigin {
+                preservesNextExplicitZeroOrigin = false
+                return min(max(clamped, leadingX), maxX)
+            }
+            return leadingX
+        }
+
+        preservesNextExplicitZeroOrigin = false
         return min(max(clamped, leadingX), maxX)
     }
 

--- a/AlasTests/EditorBufferTests.swift
+++ b/AlasTests/EditorBufferTests.swift
@@ -895,6 +895,18 @@ struct EditorBufferTests {
         )
         #expect(incremental.origin.x == expectedLeadingX + 5)
 
+        // Exact zero is a valid user-driven scroll position. Starting at the
+        // negative gutter edge and landing exactly on zero must not be mistaken
+        // for AppKit's layout reset above.
+        subject.contentView.scroll(to: NSPoint(x: expectedLeadingX, y: 0))
+        subject.contentView.scroll(to: NSPoint(x: 0, y: 0))
+        subject.reflectScrolledClipView(subject.contentView)
+        #expect(subject.contentView.bounds.origin.x == 0)
+
+        subject.contentView.setBoundsOrigin(NSPoint(x: expectedLeadingX, y: 0))
+        subject.contentView.setBoundsOrigin(NSPoint(x: 0, y: 0))
+        #expect(subject.contentView.bounds.origin.x == 0)
+
         // Positive origins scroll long lines normally.
         let positive = subject.contentView.constrainBoundsRect(
             NSRect(x: 30, y: 0, width: clipW, height: subject.contentView.bounds.height)

--- a/AlasTests/EditorBufferTests.swift
+++ b/AlasTests/EditorBufferTests.swift
@@ -811,6 +811,97 @@ struct EditorBufferTests {
         #expect(scrollView.contentView.bounds.origin.x == 0)
     }
 
+    /// Regression for the gutter clipping the leading characters of every line:
+    /// AppKit shifts the clip's bounds origin to `-rulerThickness` so document
+    /// content clears a left-side vertical ruler. `CodeEditorLeadingClipView`
+    /// must honor that negative leading origin instead of pinning it to 0,
+    /// otherwise the first ~6 characters hide under the line-number gutter with
+    /// no way to scroll them back. Uses a plain `NSClipView` as the oracle for
+    /// the correct ruler-aware leading position.
+    @Test func codeEditorLeadingClipViewKeepsRulerGutterClear() throws {
+        let theme = try ThemeStore().current
+
+        func makeScroll(custom: Bool) -> NSScrollView {
+            let scrollView = NSScrollView(frame: NSRect(x: 0, y: 0, width: 400, height: 300))
+            scrollView.hasVerticalScroller = true
+            scrollView.hasHorizontalScroller = true
+            scrollView.autohidesScrollers = false
+            if custom {
+                scrollView.contentView = CodeEditorLeadingClipView(frame: .zero)
+            }
+            let layoutManager = NSLayoutManager()
+            let textContainer = NSTextContainer(size: NSSize(
+                width: CGFloat.greatestFiniteMagnitude,
+                height: CGFloat.greatestFiniteMagnitude
+            ))
+            textContainer.widthTracksTextView = false
+            textContainer.heightTracksTextView = false
+            layoutManager.addTextContainer(textContainer)
+            let textView = CodeTextView(frame: NSRect(x: 0, y: 0, width: 400, height: 300), textContainer: textContainer)
+            textView.minSize = NSSize(width: 0, height: 0)
+            textView.maxSize = NSSize(width: CGFloat.greatestFiniteMagnitude, height: CGFloat.greatestFiniteMagnitude)
+            textView.isHorizontallyResizable = true
+            textView.isVerticallyResizable = true
+            textView.autoresizingMask = []
+            // A line long enough that the document is wider than the viewport.
+            textView.string = String(repeating: "x", count: 4000)
+            scrollView.documentView = textView
+            let ruler = CodeEditorLineNumberRulerView(scrollView: scrollView, textView: textView, theme: theme)
+            scrollView.verticalRulerView = ruler
+            scrollView.hasVerticalRuler = true
+            scrollView.rulersVisible = true
+            scrollView.tile()
+            scrollView.layoutSubtreeIfNeeded()
+            return scrollView
+        }
+
+        // A plain NSClipView rests at a negative leading origin (it reserves the
+        // gutter by shifting bounds left by the ruler thickness). This confirms
+        // the correct leading edge is negative, not 0.
+        let oracle = makeScroll(custom: false)
+        #expect(oracle.contentView.bounds.origin.x < 0)
+
+        // The custom clip must reach that same negative leading edge when the
+        // user scrolls fully left — not clamp it to 0 and hide the gutter-width
+        // of leading characters.
+        let subject = makeScroll(custom: true)
+        let expectedLeadingX = -(subject.verticalRulerView?.requiredThickness ?? 0)
+        #expect(expectedLeadingX < 0)
+        subject.contentView.scroll(to: NSPoint(x: -10_000, y: 0))
+        subject.reflectScrolledClipView(subject.contentView)
+        #expect(subject.contentView.bounds.origin.x == expectedLeadingX)
+
+        // Force a document genuinely wider than the viewport so a horizontal
+        // scroll range exists (headless text layout won't grow the text view on
+        // its own). The clip width is unchanged by a document resize.
+        let clipW = subject.contentView.bounds.width
+        subject.documentView?.setFrameSize(NSSize(width: clipW + 4000, height: 300))
+
+        // The actual production failure: AppKit's layout/frame-change passes
+        // propose x == 0 (treating 0 as the leading edge, unaware of the gutter
+        // offset). That exact reset must settle at the true leading edge,
+        // otherwise the leading characters race under the gutter.
+        let constrainedZero = subject.contentView.constrainBoundsRect(
+            NSRect(x: 0, y: 0, width: clipW, height: subject.contentView.bounds.height)
+        )
+        #expect(constrainedZero.origin.x == expectedLeadingX)
+
+        // Regression for the codex P2: an incremental scroll right from the
+        // leading edge (leadingX + delta) must be preserved, not collapsed back
+        // to the leading edge — otherwise the user can't start scrolling until a
+        // single event jumps the whole gutter width.
+        let incremental = subject.contentView.constrainBoundsRect(
+            NSRect(x: expectedLeadingX + 5, y: 0, width: clipW, height: subject.contentView.bounds.height)
+        )
+        #expect(incremental.origin.x == expectedLeadingX + 5)
+
+        // Positive origins scroll long lines normally.
+        let positive = subject.contentView.constrainBoundsRect(
+            NSRect(x: 30, y: 0, width: clipW, height: subject.contentView.bounds.height)
+        )
+        #expect(positive.origin.x == 30)
+    }
+
     @Test func coordinatorClampsStaleRevealHighlightRangeAfterEdit() throws {
         let root = tempWorktree()
         _ = try writeFile(root, "a.swift", "line one\nline two\nline three\n")

--- a/AlasTests/EditorBufferTests.swift
+++ b/AlasTests/EditorBufferTests.swift
@@ -886,9 +886,9 @@ struct EditorBufferTests {
         )
         #expect(constrainedZero.origin.x == expectedLeadingX)
 
-        // Regression for the codex P2: an incremental scroll right from the
-        // leading edge (leadingX + delta) must be preserved, not collapsed back
-        // to the leading edge — otherwise the user can't start scrolling until a
+        // Regression: an incremental scroll right from the leading edge
+        // (leadingX + delta) must be preserved, not collapsed back to the
+        // leading edge — otherwise the user can't start scrolling until a
         // single event jumps the whole gutter width.
         let incremental = subject.contentView.constrainBoundsRect(
             NSRect(x: expectedLeadingX + 5, y: 0, width: clipW, height: subject.contentView.bounds.height)


### PR DESCRIPTION
Respect AppKit's negative clip origin when a vertical ruler reserves
space for line numbers, so fully-left editor scrolls no longer hide
the first characters under the gutter.