### PR TITLE
fix(editor): clip line-number gutter to scroll view bounds

### DIFF
--- a/Alas/Sources/Code/Editor/CodeEditorView.swift
+++ b/Alas/Sources/Code/Editor/CodeEditorView.swift
@@ -83,6 +83,12 @@ struct CodeEditorView: NSViewRepresentable {
         scroll.autohidesScrollers = false
         scroll.drawsBackground = true
         scroll.backgroundColor = NSColor(theme.color("bg-1"))
+        // Since the macOS 14 SDK `clipsToBounds` defaults to `false`, so the
+        // scroll view no longer clips its subviews. Without this, the vertical
+        // ruler's responsive-scrolling overdraw paints line numbers above the
+        // scroll view's top edge, bleeding over the breadcrumb header that sits
+        // directly above the editor in the enclosing SwiftUI VStack.
+        scroll.clipsToBounds = true
         scroll.contentView = CodeEditorLeadingClipView(frame: .zero)
 
         let buffer: EditorBuffer


### PR DESCRIPTION
## Problem

When scrolling through a file in the editor, the gutter line numbers bleed up over the breadcrumb/header bar (file name + mode toggles). It gets worse during scroll momentum animation.

## Root cause

The app targets the macOS 15 SDK, and since the **macOS 14 SDK `NSView.clipsToBounds` defaults to `false`** — views no longer clip their subviews to bounds automatically. The editor's `NSScrollView` therefore didn't clip its vertical line-number ruler. During AppKit's responsive-scrolling overdraw (rows pre-rendered beyond the visible region for smooth momentum scrolling), the ruler painted line numbers *above* the scroll view's top edge. Since the breadcrumb and editor are sibling views in a SwiftUI `VStack` (breadcrumb drawn first, editor after), that overdraw landed on top of the breadcrumb.

## Fix

Set `scroll.clipsToBounds = true` in `CodeEditorView.makeNSView` so the scroll view clips its ruler and content to its own bounds.