### PR TITLE
feat(tabs): Make tab bar scroll overflow tabs

### DIFF
--- a/Alas/Sources/Center/TabBarView.swift
+++ b/Alas/Sources/Center/TabBarView.swift
@@ -50,52 +50,58 @@ struct TabBarView: View {
                 ToolbarIconButton(iconName: "sidebar.left", tooltip: "Show sidebar", action: onRevealSidebar)
                     .padding(.trailing, 8)
             }
-            ForEach(Array(tabs.enumerated()), id: \.element.id) { idx, tab in
-                TabButton(
-                    titleLookup: titleLookup,
-                    tab: tab,
-                    active: tab.id == activeId,
-                    showClose: true,
-                    harnessInfo: harnessLookup(tab.id),
-                    dirty: dirtyLookup(tab.id),
-                    transcript: transcriptLookup(tab.id),
-                    acpAgent: acpAgentLookup(tab.id),
-                    onActivate: { onActivate(tab.id) },
-                    onClose: { onClose(tab.id) }
-                )
-                .draggable(tab.id)
-                .dropDestination(for: TabID.self) { ids, _ in
-                    guard let draggedId = ids.first, draggedId != tab.id else { return false }
-                    onMove(draggedId, tab.id)
-                    return true
+            ScrollView(.horizontal, showsIndicators: false) {
+                HStack(spacing: 0) {
+                    ForEach(Array(tabs.enumerated()), id: \.element.id) { idx, tab in
+                        TabButton(
+                            titleLookup: titleLookup,
+                            tab: tab,
+                            active: tab.id == activeId,
+                            showClose: true,
+                            harnessInfo: harnessLookup(tab.id),
+                            dirty: dirtyLookup(tab.id),
+                            transcript: transcriptLookup(tab.id),
+                            acpAgent: acpAgentLookup(tab.id),
+                            onActivate: { onActivate(tab.id) },
+                            onClose: { onClose(tab.id) }
+                        )
+                        .draggable(tab.id)
+                        .dropDestination(for: TabID.self) { ids, _ in
+                            guard let draggedId = ids.first, draggedId != tab.id else { return false }
+                            onMove(draggedId, tab.id)
+                            return true
+                        }
+                        .contextMenu {
+                            if case .terminal = tab {
+                                Button("Rename…") { onRenameTerminal(tab.id) }
+                                Divider()
+                            }
+                            if case .acpSession = tab {
+                                Button("Rename…") { onRenameACPSession(tab.id) }
+                                Button("Copy Session as Markdown") { onCopyACPSession(tab.id) }
+                                Button("Save Session as Markdown…") { onExportACPSession(tab.id) }
+                                Divider()
+                            }
+                            Button("Close") { onClose(tab.id) }
+                            Button("Close Other Tabs") { onCloseOthers(tab.id) }
+                                .disabled(tabs.count <= 1)
+                            Button("Close All Tabs") { onCloseAll() }
+                            Button("Close Tabs to the Left") { onCloseToLeft(tab.id) }
+                                .disabled(idx == 0)
+                            Button("Close Tabs to the Right") { onCloseToRight(tab.id) }
+                                .disabled(idx == tabs.count - 1)
+                            Divider()
+                            if tab.relativeFilePath != nil {
+                                Button("Copy Path") { onCopyPath(tab.id) }
+                                Button("Copy Relative Path") { onCopyRelativePath(tab.id) }
+                            }
+                        }
+                    }
                 }
-                .contextMenu {
-                    if case .terminal = tab {
-                        Button("Rename…") { onRenameTerminal(tab.id) }
-                        Divider()
-                    }
-                    if case .acpSession = tab {
-                        Button("Rename…") { onRenameACPSession(tab.id) }
-                        Button("Copy Session as Markdown") { onCopyACPSession(tab.id) }
-                        Button("Save Session as Markdown…") { onExportACPSession(tab.id) }
-                        Divider()
-                    }
-                    Button("Close") { onClose(tab.id) }
-                    Button("Close Other Tabs") { onCloseOthers(tab.id) }
-                        .disabled(tabs.count <= 1)
-                    Button("Close All Tabs") { onCloseAll() }
-                    Button("Close Tabs to the Left") { onCloseToLeft(tab.id) }
-                        .disabled(idx == 0)
-                    Button("Close Tabs to the Right") { onCloseToRight(tab.id) }
-                        .disabled(idx == tabs.count - 1)
-                    Divider()
-                    if tab.relativeFilePath != nil {
-                        Button("Copy Path") { onCopyPath(tab.id) }
-                        Button("Copy Relative Path") { onCopyRelativePath(tab.id) }
-                    }
-                }
+                .fixedSize(horizontal: true, vertical: false)
             }
-            Spacer()
+            .background(AccessibilityMarkerView(identifier: "tab-overflow-scroll"))
+            .frame(maxWidth: .infinity, alignment: .leading)
             if isTerminalActive {
                 ToolbarIconButton(iconName: "split", tooltip: "Split Right (⌘D)") {
                     NotificationCenter.default.post(name: .alasSplitRight, object: nil)
@@ -129,6 +135,20 @@ struct TabBarView: View {
         .background(theme.color("bg-2"))
         .overlay(Divider().opacity(0.5), alignment: .bottom)
         .windowDragHandle()
+    }
+}
+
+private struct AccessibilityMarkerView: NSViewRepresentable {
+    let identifier: String
+
+    func makeNSView(context: Context) -> NSView {
+        let view = NSView(frame: .zero)
+        view.setAccessibilityIdentifier(identifier)
+        return view
+    }
+
+    func updateNSView(_ nsView: NSView, context: Context) {
+        nsView.setAccessibilityIdentifier(identifier)
     }
 }
 

--- a/Alas/Sources/Center/TabBarView.swift
+++ b/Alas/Sources/Center/TabBarView.swift
@@ -34,6 +34,7 @@ struct TabBarView: View {
     let transcriptLookup: (TabID) -> ACPTranscript?
     var acpAgentLookup: (TabID) -> AgentDefinition? = { _ in nil }
     @Environment(\.theme) var theme
+    @State private var tabStripContentWidth: CGFloat = 0
 
     private var isTerminalActive: Bool {
         guard let activeId, let active = tabs.first(where: { $0.id == activeId }) else { return false }
@@ -50,58 +51,88 @@ struct TabBarView: View {
                 ToolbarIconButton(iconName: "sidebar.left", tooltip: "Show sidebar", action: onRevealSidebar)
                     .padding(.trailing, 8)
             }
-            ScrollView(.horizontal, showsIndicators: false) {
-                HStack(spacing: 0) {
-                    ForEach(Array(tabs.enumerated()), id: \.element.id) { idx, tab in
-                        TabButton(
-                            titleLookup: titleLookup,
-                            tab: tab,
-                            active: tab.id == activeId,
-                            showClose: true,
-                            harnessInfo: harnessLookup(tab.id),
-                            dirty: dirtyLookup(tab.id),
-                            transcript: transcriptLookup(tab.id),
-                            acpAgent: acpAgentLookup(tab.id),
-                            onActivate: { onActivate(tab.id) },
-                            onClose: { onClose(tab.id) }
+            GeometryReader { geometry in
+                let stripWidth = min(
+                    max(tabStripContentWidth, 1),
+                    max(geometry.size.width, 1)
+                )
+                ScrollViewReader { scrollProxy in
+                    ScrollView(.horizontal, showsIndicators: false) {
+                        HStack(spacing: 0) {
+                            ForEach(Array(tabs.enumerated()), id: \.element.id) { idx, tab in
+                                TabButton(
+                                    titleLookup: titleLookup,
+                                    tab: tab,
+                                    active: tab.id == activeId,
+                                    showClose: true,
+                                    harnessInfo: harnessLookup(tab.id),
+                                    dirty: dirtyLookup(tab.id),
+                                    transcript: transcriptLookup(tab.id),
+                                    acpAgent: acpAgentLookup(tab.id),
+                                    onActivate: { onActivate(tab.id) },
+                                    onClose: { onClose(tab.id) }
+                                )
+                                .id(tab.id)
+                                .draggable(tab.id)
+                                .dropDestination(for: TabID.self) { ids, _ in
+                                    guard let draggedId = ids.first, draggedId != tab.id else { return false }
+                                    onMove(draggedId, tab.id)
+                                    return true
+                                }
+                                .contextMenu {
+                                    if case .terminal = tab {
+                                        Button("Rename…") { onRenameTerminal(tab.id) }
+                                        Divider()
+                                    }
+                                    if case .acpSession = tab {
+                                        Button("Rename…") { onRenameACPSession(tab.id) }
+                                        Button("Copy Session as Markdown") { onCopyACPSession(tab.id) }
+                                        Button("Save Session as Markdown…") { onExportACPSession(tab.id) }
+                                        Divider()
+                                    }
+                                    Button("Close") { onClose(tab.id) }
+                                    Button("Close Other Tabs") { onCloseOthers(tab.id) }
+                                        .disabled(tabs.count <= 1)
+                                    Button("Close All Tabs") { onCloseAll() }
+                                    Button("Close Tabs to the Left") { onCloseToLeft(tab.id) }
+                                        .disabled(idx == 0)
+                                    Button("Close Tabs to the Right") { onCloseToRight(tab.id) }
+                                        .disabled(idx == tabs.count - 1)
+                                    Divider()
+                                    if tab.relativeFilePath != nil {
+                                        Button("Copy Path") { onCopyPath(tab.id) }
+                                        Button("Copy Relative Path") { onCopyRelativePath(tab.id) }
+                                    }
+                                }
+                            }
+                        }
+                        .fixedSize(horizontal: true, vertical: false)
+                        .background(
+                            GeometryReader { contentGeometry in
+                                Color.clear.preference(
+                                    key: TabStripContentWidthKey.self,
+                                    value: contentGeometry.size.width
+                                )
+                            }
                         )
-                        .draggable(tab.id)
-                        .dropDestination(for: TabID.self) { ids, _ in
-                            guard let draggedId = ids.first, draggedId != tab.id else { return false }
-                            onMove(draggedId, tab.id)
-                            return true
-                        }
-                        .contextMenu {
-                            if case .terminal = tab {
-                                Button("Rename…") { onRenameTerminal(tab.id) }
-                                Divider()
-                            }
-                            if case .acpSession = tab {
-                                Button("Rename…") { onRenameACPSession(tab.id) }
-                                Button("Copy Session as Markdown") { onCopyACPSession(tab.id) }
-                                Button("Save Session as Markdown…") { onExportACPSession(tab.id) }
-                                Divider()
-                            }
-                            Button("Close") { onClose(tab.id) }
-                            Button("Close Other Tabs") { onCloseOthers(tab.id) }
-                                .disabled(tabs.count <= 1)
-                            Button("Close All Tabs") { onCloseAll() }
-                            Button("Close Tabs to the Left") { onCloseToLeft(tab.id) }
-                                .disabled(idx == 0)
-                            Button("Close Tabs to the Right") { onCloseToRight(tab.id) }
-                                .disabled(idx == tabs.count - 1)
-                            Divider()
-                            if tab.relativeFilePath != nil {
-                                Button("Copy Path") { onCopyPath(tab.id) }
-                                Button("Copy Relative Path") { onCopyRelativePath(tab.id) }
-                            }
-                        }
+                    }
+                    .background(AccessibilityMarkerView(identifier: "tab-overflow-scroll"))
+                    .frame(width: stripWidth, alignment: .leading)
+                    .onAppear {
+                        scrollActiveTab(using: scrollProxy, animated: false)
+                    }
+                    .onChange(of: activeId) { _, _ in
+                        scrollActiveTab(using: scrollProxy, animated: true)
+                    }
+                    .onChange(of: tabs.map(\.id)) { _, _ in
+                        scrollActiveTab(using: scrollProxy, animated: true)
                     }
                 }
-                .fixedSize(horizontal: true, vertical: false)
+                .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .leading)
             }
-            .background(AccessibilityMarkerView(identifier: "tab-overflow-scroll"))
-            .frame(maxWidth: .infinity, alignment: .leading)
+            .onPreferenceChange(TabStripContentWidthKey.self) { tabStripContentWidth = $0 }
+            .frame(maxWidth: .infinity, maxHeight: 34, alignment: .leading)
+            .windowDragHandle()
             if isTerminalActive {
                 ToolbarIconButton(iconName: "split", tooltip: "Split Right (⌘D)") {
                     NotificationCenter.default.post(name: .alasSplitRight, object: nil)
@@ -135,6 +166,25 @@ struct TabBarView: View {
         .background(theme.color("bg-2"))
         .overlay(Divider().opacity(0.5), alignment: .bottom)
         .windowDragHandle()
+    }
+
+    private func scrollActiveTab(using proxy: ScrollViewProxy, animated: Bool) {
+        guard let activeId else { return }
+        if animated {
+            withAnimation(.easeOut(duration: 0.12)) {
+                proxy.scrollTo(activeId, anchor: .center)
+            }
+        } else {
+            proxy.scrollTo(activeId, anchor: .center)
+        }
+    }
+}
+
+private struct TabStripContentWidthKey: PreferenceKey {
+    static var defaultValue: CGFloat = 0
+
+    static func reduce(value: inout CGFloat, nextValue: () -> CGFloat) {
+        value = nextValue()
     }
 }
 

--- a/Alas/Sources/Center/TabBarView.swift
+++ b/Alas/Sources/Center/TabBarView.swift
@@ -200,6 +200,8 @@ private struct AccessibilityMarkerView: NSViewRepresentable {
 }
 
 private struct TabButton: View {
+    private static let maxTitleWidth: CGFloat = 220
+
     let titleLookup: (TabID) -> String?
     let tab: Tab
     let active: Bool
@@ -230,6 +232,8 @@ private struct TabButton: View {
                 .font(.system(size: 11.5))
                 .foregroundColor(active ? theme.color("fg") : theme.color("fg-dim"))
                 .lineLimit(1)
+                .truncationMode(.middle)
+                .frame(maxWidth: Self.maxTitleWidth, alignment: .leading)
             if case .editor(let state) = tab, state.isExternal {
                 Image(systemName: "lock.fill")
                     .font(.system(size: 9))

--- a/Alas/Sources/Center/TabBarView.swift
+++ b/Alas/Sources/Center/TabBarView.swift
@@ -124,9 +124,6 @@ struct TabBarView: View {
                     .onChange(of: activeId) { _, _ in
                         scrollActiveTab(using: scrollProxy, animated: true)
                     }
-                    .onChange(of: tabs.map(\.id)) { _, _ in
-                        scrollActiveTab(using: scrollProxy, animated: true)
-                    }
                 }
                 .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .leading)
             }

--- a/AlasTests/TouchTargetSmokeTests.swift
+++ b/AlasTests/TouchTargetSmokeTests.swift
@@ -78,6 +78,60 @@ struct TouchTargetSmokeTests {
         #expect(controller.view != nil)
     }
 
+    @Test func tabBarViewHostsOverflowingTabsInMarkedScrollView() {
+        let tabs = (1...12).map { index in
+            Tab.editor(EditorTabState(
+                id: "t\(index)",
+                title: "VeryLongFileName\(index).swift",
+                relativePath: "Sources/VeryLongFileName\(index).swift",
+                revealLine: nil,
+                revealCharacter: nil,
+                externalAbsolutePath: nil,
+                originatingRelativePath: nil,
+                markdownViewMode: nil,
+                markdownSplitFraction: nil
+            ))
+        }
+        let view = TabBarView(
+            tabs: tabs,
+            activeId: tabs.first?.id,
+            harnessLookup: { _ in nil },
+            dirtyLookup: { _ in false },
+            onActivate: { _ in },
+            onClose: { _ in },
+            onCloseOthers: { _ in },
+            onCloseAll: { },
+            onCloseToLeft: { _ in },
+            onCloseToRight: { _ in },
+            onCopyPath: { _ in },
+            onCopyRelativePath: { _ in },
+            onRenameTerminal: { _ in },
+            onRenameACPSession: { _ in },
+            onCopyACPSession: { _ in },
+            onExportACPSession: { _ in },
+            onNewTerminal: { },
+            enabledAgents: [],
+            onLaunchAgent: { _ in },
+            onLaunchACPSession: { _ in },
+            acpAgents: [],
+            onRevealRightSidebar: { },
+            rightSidebarHidden: false,
+            onRevealSidebar: { },
+            sidebarHidden: false,
+            onMove: { _, _ in },
+            titleLookup: { _ in nil },
+            transcriptLookup: { _ in nil }
+        )
+        .environment(\.theme, currentTheme())
+        let controller = NSHostingController(rootView: view)
+        controller.view.frame = NSRect(x: 0, y: 0, width: 520, height: 34)
+        controller.view.layoutSubtreeIfNeeded()
+
+        #expect(allSubviews(of: controller.view).contains {
+            $0.accessibilityIdentifier() == "tab-overflow-scroll"
+        })
+    }
+
     @Test func agentMenuSectionTitlesUseCurrentLabels() {
         #expect(TabBarView.terminalAgentMenuSectionTitle == "Terminal")
         #expect(TabBarView.acpAgentMenuSectionTitle == "ACP Chat")
@@ -272,5 +326,9 @@ struct TouchTargetSmokeTests {
         let controller = NSHostingController(rootView: view)
         controller.view.layoutSubtreeIfNeeded()
         #expect(controller.view != nil)
+    }
+
+    private func allSubviews(of view: NSView) -> [NSView] {
+        view.subviews + view.subviews.flatMap { allSubviews(of: $0) }
     }
 }


### PR DESCRIPTION
## Summary
- Keep trailing tab bar controls pinned while the tab strip owns available center space
- Make overflowing tabs horizontally scroll in place instead of compressing sidebar columns
- Add a focused smoke test marker for tab overflow hosting

## Checks
- `xcodegen`
- `ALAS_FFF_TARGET_ARCH=arm64 xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS,arch=arm64' -quiet build`
- `ALAS_FFF_TARGET_ARCH=arm64 xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS,arch=arm64' test -only-testing:AlasTests/TouchTargetSmokeTests`