### PR TITLE
fix(review): render inline thread comments as markdown

### DIFF
--- a/Alas/Sources/Center/Review/DiffInlineCommentCard.swift
+++ b/Alas/Sources/Center/Review/DiffInlineCommentCard.swift
@@ -286,10 +286,14 @@ struct DiffInlineCommentCard: View {
                         .help("Delete comment")
                     }
                 }
-                Text(comment.body)
-                    .font(.system(size: 11))
-                    .foregroundColor(.primary)
+                DiffReviewInlineFeedbackMarkdown.view(comment.body)
                     .fixedSize(horizontal: false, vertical: true)
+                    .background(
+                        DiffReviewAccessibilityMarker(
+                            identifier: "diff-inline-comment-markdown-\(comment.id)",
+                            label: DiffReviewInlineFeedbackMarkdown.plainText(comment.body)
+                        )
+                    )
             }
             .frame(maxWidth: .infinity, alignment: .leading)
         }

--- a/AlasTests/ACP/UI/ACPMarkdownInlineRendererTests.swift
+++ b/AlasTests/ACP/UI/ACPMarkdownInlineRendererTests.swift
@@ -1,5 +1,6 @@
 import AppKit
 import Foundation
+import SwiftUI
 import Testing
 @testable import Alas
 
@@ -166,5 +167,67 @@ struct ACPMarkdownInlineRendererTests {
 
         #expect(replacement.attribute(.link, at: 0, effectiveRange: nil) as? URL == url)
         #expect(replacement.attribute(.acpMarkdownInlineRemoteImage, at: 0, effectiveRange: nil) == nil)
+    }
+
+    @Test("inline provider thread comments render markdown body")
+    func inlineProviderThreadCommentRendersMarkdownBody() throws {
+        let comment = DiffInlineComment(
+            id: "comment-1",
+            author: "reviewer",
+            body: """
+            **<sub>![P2 Badge](https://img.shields.io/badge/P2-yellow?style=flat)</sub> Preserve small horizontal scroll deltas**
+
+            Use `leadingX` instead of **resetting** each event.
+            """
+        )
+        let thread = DiffInlineCommentThread(
+            id: "thread-1",
+            filePath: "Sources/App.swift",
+            newLine: 2,
+            isResolved: false,
+            isOutdated: false,
+            comments: [comment]
+        )
+
+        let host = NSHostingView(
+            rootView: DiffInlineCommentCard(thread: thread)
+                .environment(\.theme, try Theme.loadBundled(id: "cool-slate"))
+                .frame(width: 620, height: 260)
+        )
+        host.frame = NSRect(x: 0, y: 0, width: 620, height: 260)
+        host.layoutSubtreeIfNeeded()
+
+        #expect(subview(withAccessibilityIdentifier: "diff-inline-comment-markdown-comment-1", in: host) != nil)
+
+        let renderedBody = allSubviews(of: host)
+            .compactMap { $0 as? NSTextView }
+            .map(\.string)
+            .joined(separator: "\n")
+
+        #expect(renderedBody.contains("Preserve small horizontal scroll deltas"))
+        #expect(renderedBody.contains("Use leadingX instead of resetting each event."))
+        #expect(!renderedBody.contains("**"))
+        #expect(!renderedBody.contains("<sub>"))
+        #expect(!renderedBody.contains("`leadingX`"))
+        #expect(accessibilityLabel(in: host, containing: "**<sub>") == nil)
+        #expect(accessibilityLabel(in: host, containing: "`leadingX`") == nil)
+    }
+
+    private func allSubviews(of view: NSView) -> [NSView] {
+        view.subviews + view.subviews.flatMap { allSubviews(of: $0) }
+    }
+
+    private func subview(withAccessibilityIdentifier identifier: String, in view: NSView) -> NSView? {
+        if view.accessibilityIdentifier() == identifier {
+            return view
+        }
+        return view.subviews.lazy.compactMap { subview(withAccessibilityIdentifier: identifier, in: $0) }.first
+    }
+
+    private func accessibilityLabel(in view: NSView, containing text: String) -> String? {
+        if let label = view.accessibilityLabel(), label.contains(text) {
+            return label
+        }
+        return view.subviews.lazy.compactMap { accessibilityLabel(in: $0, containing: text) }.first
     }
 }


### PR DESCRIPTION
## Summary

- Render expanded provider inline thread comments through the shared markdown renderer.
- Add focused coverage for badge, bold, and inline-code markdown in provider thread comment cards.

## Root cause

Expanded inline provider comments used a raw `Text(comment.body)` view, while the other review feedback surfaces use the markdown renderer. That left markdown delimiters and HTML badge wrappers visible in the Inspect tab.

## Validation

- `xcodegen`
- `ALAS_FFF_TARGET_ARCH=arm64 rtk xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS,arch=arm64' test -only-testing:AlasTests/ACPMarkdownInlineRendererTests`
- `ALAS_FFF_TARGET_ARCH=arm64 rtk xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS,arch=arm64' -quiet build`

Note: `ALAS_FFF_TARGET_ARCH=arm64` was used locally because the universal fff build path picked up Homebrew cargo without the x86_64 Rust stdlib. CI should use its normal setup.