### PR TITLE
fix(tabs): stop tab strip collapsing to a 1px sliver

### DIFF
--- a/Alas/Sources/Center/TabBarView.swift
+++ b/Alas/Sources/Center/TabBarView.swift
@@ -34,7 +34,6 @@ struct TabBarView: View {
     let transcriptLookup: (TabID) -> ACPTranscript?
     var acpAgentLookup: (TabID) -> AgentDefinition? = { _ in nil }
     @Environment(\.theme) var theme
-    @State private var tabStripContentWidth: CGFloat = 0
 
     private var isTerminalActive: Bool {
         guard let activeId, let active = tabs.first(where: { $0.id == activeId }) else { return false }
@@ -51,83 +50,65 @@ struct TabBarView: View {
                 ToolbarIconButton(iconName: "sidebar.left", tooltip: "Show sidebar", action: onRevealSidebar)
                     .padding(.trailing, 8)
             }
-            GeometryReader { geometry in
-                let stripWidth = min(
-                    max(tabStripContentWidth, 1),
-                    max(geometry.size.width, 1)
-                )
-                ScrollViewReader { scrollProxy in
-                    ScrollView(.horizontal, showsIndicators: false) {
-                        HStack(spacing: 0) {
-                            ForEach(Array(tabs.enumerated()), id: \.element.id) { idx, tab in
-                                TabButton(
-                                    titleLookup: titleLookup,
-                                    tab: tab,
-                                    active: tab.id == activeId,
-                                    showClose: true,
-                                    harnessInfo: harnessLookup(tab.id),
-                                    dirty: dirtyLookup(tab.id),
-                                    transcript: transcriptLookup(tab.id),
-                                    acpAgent: acpAgentLookup(tab.id),
-                                    onActivate: { onActivate(tab.id) },
-                                    onClose: { onClose(tab.id) }
-                                )
-                                .id(tab.id)
-                                .draggable(tab.id)
-                                .dropDestination(for: TabID.self) { ids, _ in
-                                    guard let draggedId = ids.first, draggedId != tab.id else { return false }
-                                    onMove(draggedId, tab.id)
-                                    return true
-                                }
-                                .contextMenu {
-                                    if case .terminal = tab {
-                                        Button("Rename…") { onRenameTerminal(tab.id) }
-                                        Divider()
-                                    }
-                                    if case .acpSession = tab {
-                                        Button("Rename…") { onRenameACPSession(tab.id) }
-                                        Button("Copy Session as Markdown") { onCopyACPSession(tab.id) }
-                                        Button("Save Session as Markdown…") { onExportACPSession(tab.id) }
-                                        Divider()
-                                    }
-                                    Button("Close") { onClose(tab.id) }
-                                    Button("Close Other Tabs") { onCloseOthers(tab.id) }
-                                        .disabled(tabs.count <= 1)
-                                    Button("Close All Tabs") { onCloseAll() }
-                                    Button("Close Tabs to the Left") { onCloseToLeft(tab.id) }
-                                        .disabled(idx == 0)
-                                    Button("Close Tabs to the Right") { onCloseToRight(tab.id) }
-                                        .disabled(idx == tabs.count - 1)
+            ScrollViewReader { scrollProxy in
+                ScrollView(.horizontal, showsIndicators: false) {
+                    HStack(spacing: 0) {
+                        ForEach(Array(tabs.enumerated()), id: \.element.id) { idx, tab in
+                            TabButton(
+                                titleLookup: titleLookup,
+                                tab: tab,
+                                active: tab.id == activeId,
+                                showClose: true,
+                                harnessInfo: harnessLookup(tab.id),
+                                dirty: dirtyLookup(tab.id),
+                                transcript: transcriptLookup(tab.id),
+                                acpAgent: acpAgentLookup(tab.id),
+                                onActivate: { onActivate(tab.id) },
+                                onClose: { onClose(tab.id) }
+                            )
+                            .id(tab.id)
+                            .draggable(tab.id)
+                            .dropDestination(for: TabID.self) { ids, _ in
+                                guard let draggedId = ids.first, draggedId != tab.id else { return false }
+                                onMove(draggedId, tab.id)
+                                return true
+                            }
+                            .contextMenu {
+                                if case .terminal = tab {
+                                    Button("Rename…") { onRenameTerminal(tab.id) }
                                     Divider()
-                                    if tab.relativeFilePath != nil {
-                                        Button("Copy Path") { onCopyPath(tab.id) }
-                                        Button("Copy Relative Path") { onCopyRelativePath(tab.id) }
-                                    }
+                                }
+                                if case .acpSession = tab {
+                                    Button("Rename…") { onRenameACPSession(tab.id) }
+                                    Button("Copy Session as Markdown") { onCopyACPSession(tab.id) }
+                                    Button("Save Session as Markdown…") { onExportACPSession(tab.id) }
+                                    Divider()
+                                }
+                                Button("Close") { onClose(tab.id) }
+                                Button("Close Other Tabs") { onCloseOthers(tab.id) }
+                                    .disabled(tabs.count <= 1)
+                                Button("Close All Tabs") { onCloseAll() }
+                                Button("Close Tabs to the Left") { onCloseToLeft(tab.id) }
+                                    .disabled(idx == 0)
+                                Button("Close Tabs to the Right") { onCloseToRight(tab.id) }
+                                    .disabled(idx == tabs.count - 1)
+                                Divider()
+                                if tab.relativeFilePath != nil {
+                                    Button("Copy Path") { onCopyPath(tab.id) }
+                                    Button("Copy Relative Path") { onCopyRelativePath(tab.id) }
                                 }
                             }
                         }
-                        .fixedSize(horizontal: true, vertical: false)
-                        .background(
-                            GeometryReader { contentGeometry in
-                                Color.clear.preference(
-                                    key: TabStripContentWidthKey.self,
-                                    value: contentGeometry.size.width
-                                )
-                            }
-                        )
-                    }
-                    .background(AccessibilityMarkerView(identifier: "tab-overflow-scroll"))
-                    .frame(width: stripWidth, alignment: .leading)
-                    .onAppear {
-                        scrollActiveTab(using: scrollProxy, animated: false)
-                    }
-                    .onChange(of: activeId) { _, _ in
-                        scrollActiveTab(using: scrollProxy, animated: true)
                     }
                 }
-                .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .leading)
+                .background(AccessibilityMarkerView(identifier: "tab-overflow-scroll"))
+                .onAppear {
+                    scrollActiveTab(using: scrollProxy, animated: false)
+                }
+                .onChange(of: activeId) { _, _ in
+                    scrollActiveTab(using: scrollProxy, animated: true)
+                }
             }
-            .onPreferenceChange(TabStripContentWidthKey.self) { tabStripContentWidth = $0 }
             .frame(maxWidth: .infinity, maxHeight: 34, alignment: .leading)
             .windowDragHandle()
             if isTerminalActive {
@@ -174,14 +155,6 @@ struct TabBarView: View {
         } else {
             proxy.scrollTo(activeId, anchor: .center)
         }
-    }
-}
-
-private struct TabStripContentWidthKey: PreferenceKey {
-    static var defaultValue: CGFloat = 0
-
-    static func reduce(value: inout CGFloat, nextValue: () -> CGFloat) {
-        value = nextValue()
     }
 }
 


### PR DESCRIPTION
## Problem

On 0.8.8 the center tab bar collapses to a **1–2px sliver on the left** — the tabs are effectively invisible, with empty space and only the `+` / agent controls visible on the right.

Root cause is the tab-strip sizing introduced in #608. It sizes the strip with:

```swift
let stripWidth = min(max(tabStripContentWidth, 1), max(geometry.size.width, 1))
…
.frame(width: stripWidth, alignment: .leading)
```

where `tabStripContentWidth` is fed from a `GeometryReader` **preference measured on the strip's own content**, inside a `ScrollView` whose width is itself `stripWidth`. That self-referential measurement never settles: the measured width stays ~0, so `stripWidth` pins to `1` and the whole strip renders 1px wide.

## Fix

Replace the `GeometryReader` / `stripWidth` / preference machinery with a **plain horizontal `ScrollView`**. A horizontal `ScrollView` already fills the available width and scrolls its content — no manual width measurement is needed. Net **−27 lines**.

Unchanged: active-tab auto-scroll (`scrollActiveTab`), drag-to-reorder, the per-tab context menu, the accessibility marker, and the per-tab title width cap (`maxTitleWidth` + middle truncation) from #608.

## Verification

- Built a faithful standalone repro of #608's exact layout → tabs collapse to a sliver (reproduces the report). Swapping in the plain `ScrollView` → tabs render correctly, overflow scrolls, trailing controls stay pinned.
- Whole-module build succeeds; the real app launches and renders tabs correctly (no collapse).

Supersedes the tab-strip sizing from #608.