### PR TITLE
feat(acp): Support boolean ACP config options

### DIFF
--- a/Alas/Sources/ACP/Protocol/ACPConfigOption.swift
+++ b/Alas/Sources/ACP/Protocol/ACPConfigOption.swift
@@ -1,16 +1,50 @@
 import Foundation
 
+enum ACPConfigValue: Codable, Equatable, Hashable {
+    case string(String)
+    case boolean(Bool)
+
+    init(from decoder: Decoder) throws {
+        let c = try decoder.singleValueContainer()
+        if let b = try? c.decode(Bool.self) {
+            self = .boolean(b)
+            return
+        }
+        self = .string(try c.decode(String.self))
+    }
+
+    func encode(to encoder: Encoder) throws {
+        var c = encoder.singleValueContainer()
+        switch self {
+        case .string(let value):
+            try c.encode(value)
+        case .boolean(let value):
+            try c.encode(value)
+        }
+    }
+}
+
 /// Per-session configurable option advertised by the agent in
 /// `session/new`. Wire format follows
 /// https://agentclientprotocol.com/protocol/session-config-options —
-/// we only render select-style options today.
+/// select options are rendered as chips, boolean options as toggles.
 struct ACPConfigOption: Codable, Equatable, Identifiable, Hashable {
     let id: String
     let name: String
-    let type: String           // "select" today; other shapes accepted but rendered as empty
+    let type: String           // "select" or negotiated "boolean"; other shapes ignored
     let category: String?      // e.g. "ThoughtLevel" — used as a routing hint
-    let currentValue: String?
+    let currentValue: ACPConfigValue?
     let options: [ACPConfigOptionItem]
+
+    var currentStringValue: String? {
+        guard case .string(let value) = currentValue else { return nil }
+        return value
+    }
+
+    var currentBoolValue: Bool? {
+        guard case .boolean(let value) = currentValue else { return nil }
+        return value
+    }
 
     enum CodingKeys: String, CodingKey {
         case id, name, type, category, currentValue, options
@@ -22,12 +56,24 @@ struct ACPConfigOption: Codable, Equatable, Identifiable, Hashable {
         name = try c.decode(String.self, forKey: .name)
         type = (try? c.decode(String.self, forKey: .type)) ?? "select"
         category = try? c.decode(String.self, forKey: .category)
-        currentValue = try? c.decode(String.self, forKey: .currentValue)
+        currentValue = try? c.decode(ACPConfigValue.self, forKey: .currentValue)
         options = (try? c.decode([ACPConfigOptionItem].self, forKey: .options)) ?? []
     }
 
     init(id: String, name: String, type: String = "select",
          category: String? = nil, currentValue: String? = nil,
+         options: [ACPConfigOptionItem] = []) {
+        self.init(
+            id: id,
+            name: name,
+            type: type,
+            category: category,
+            currentValue: currentValue.map(ACPConfigValue.string),
+            options: options)
+    }
+
+    init(id: String, name: String, type: String = "select",
+         category: String? = nil, currentValue: ACPConfigValue?,
          options: [ACPConfigOptionItem] = []) {
         self.id = id
         self.name = name
@@ -50,7 +96,7 @@ struct ACPConfigOption: Codable, Equatable, Identifiable, Hashable {
     static func mergingSuccessfulSetResponse(
         _ configOptions: [ACPConfigOption],
         configId: String,
-        selectedValue: String,
+        selectedValue: ACPConfigValue,
         currentConfigOptions: [ACPConfigOption]
     ) -> [ACPConfigOption]? {
         guard currentConfigOptions.first(where: { $0.id == configId })?.currentValue == selectedValue else {
@@ -107,7 +153,37 @@ struct ACPConfigOptionItem: Codable, Equatable, Identifiable, Hashable {
 struct ACPSessionSetConfigOptionParams: Codable, Equatable {
     let sessionId: String
     let configId: String
-    let value: String
+    let value: ACPConfigValue
+
+    enum CodingKeys: String, CodingKey {
+        case sessionId, configId, type, value
+    }
+
+    init(sessionId: String, configId: String, value: ACPConfigValue) {
+        self.sessionId = sessionId
+        self.configId = configId
+        self.value = value
+    }
+
+    init(from decoder: Decoder) throws {
+        let c = try decoder.container(keyedBy: CodingKeys.self)
+        sessionId = try c.decode(String.self, forKey: .sessionId)
+        configId = try c.decode(String.self, forKey: .configId)
+        value = try c.decode(ACPConfigValue.self, forKey: .value)
+    }
+
+    func encode(to encoder: Encoder) throws {
+        var c = encoder.container(keyedBy: CodingKeys.self)
+        try c.encode(sessionId, forKey: .sessionId)
+        try c.encode(configId, forKey: .configId)
+        switch value {
+        case .string:
+            try c.encode("id", forKey: .type)
+        case .boolean:
+            try c.encode("boolean", forKey: .type)
+        }
+        try c.encode(value, forKey: .value)
+    }
 }
 
 /// Result of `session/set_config_option`. The agent returns the complete

--- a/Alas/Sources/ACP/Protocol/ACPConnection.swift
+++ b/Alas/Sources/ACP/Protocol/ACPConnection.swift
@@ -79,9 +79,14 @@ final class ACPConnection: @unchecked Sendable {
     /// implementations) in which case the caller's optimistic local update
     /// stands; on a full echo the caller should overwrite local state so
     /// dependent options stay in sync.
-    func setConfigOption(sessionId: String, configId: String, value: String) async throws -> [ACPConfigOption] {
+    func setConfigOption(sessionId: String,
+                         configId: String,
+                         value: ACPConfigValue) async throws -> [ACPConfigOption] {
         let resp = try await client.send(ACPRequest(method: "session/set_config_option",
-                                                    params: ACPSessionSetConfigOptionParams(sessionId: sessionId, configId: configId, value: value)))
+                                                    params: ACPSessionSetConfigOptionParams(
+                                                        sessionId: sessionId,
+                                                        configId: configId,
+                                                        value: value)))
         let result = try? JSONDecoder().decode(ACPSessionSetConfigOptionResult.self, from: resp.body)
         return result?.configOptions ?? []
     }

--- a/Alas/Sources/ACP/Protocol/ACPMessages.swift
+++ b/Alas/Sources/ACP/Protocol/ACPMessages.swift
@@ -57,22 +57,25 @@ struct ACPClientCapabilities: Codable, Equatable {
     /// and only invoke `terminal/*` methods when it is true (ACP spec).
     let terminal: Bool
     let auth: ACPAuthCapabilities
+    let session: ACPSessionCapabilities
     let meta: ACPClientCapabilitiesMeta
 
     init(
         fs: ACPFsCapabilities,
         terminal: Bool,
         auth: ACPAuthCapabilities = .init(terminal: true),
+        session: ACPSessionCapabilities = .booleanConfigOptions,
         meta: ACPClientCapabilitiesMeta = .terminalAuth
     ) {
         self.fs = fs
         self.terminal = terminal
         self.auth = auth
+        self.session = session
         self.meta = meta
     }
 
     enum CodingKeys: String, CodingKey {
-        case fs, terminal, auth
+        case fs, terminal, auth, session
         case meta = "_meta"
     }
 
@@ -82,6 +85,8 @@ struct ACPClientCapabilities: Codable, Equatable {
         terminal = try c.decode(Bool.self, forKey: .terminal)
         auth = try c.decodeIfPresent(ACPAuthCapabilities.self, forKey: .auth)
             ?? .init(terminal: false)
+        session = try c.decodeIfPresent(ACPSessionCapabilities.self, forKey: .session)
+            ?? .init(configOptions: .init(boolean: nil))
         meta = try c.decodeIfPresent(ACPClientCapabilitiesMeta.self, forKey: .meta)
             ?? .init(terminalAuth: false)
     }
@@ -91,6 +96,33 @@ struct ACPClientCapabilities: Codable, Equatable {
         let writeTextFile: Bool
     }
 }
+
+struct ACPSessionCapabilities: Codable, Equatable {
+    static let booleanConfigOptions = ACPSessionCapabilities(
+        configOptions: .init(boolean: .init()))
+
+    let configOptions: ConfigOptions
+
+    init(configOptions: ConfigOptions = .init(boolean: nil)) {
+        self.configOptions = configOptions
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case configOptions
+    }
+
+    init(from decoder: Decoder) throws {
+        let c = try decoder.container(keyedBy: CodingKeys.self)
+        configOptions = try c.decodeIfPresent(ConfigOptions.self, forKey: .configOptions)
+            ?? .init(boolean: nil)
+    }
+
+    struct ConfigOptions: Codable, Equatable {
+        let boolean: EmptyObject?
+    }
+}
+
+struct EmptyObject: Codable, Equatable {}
 
 struct ACPAuthCapabilities: Codable, Equatable {
     let terminal: Bool

--- a/Alas/Sources/ACP/Session/ACPChipState.swift
+++ b/Alas/Sources/ACP/Session/ACPChipState.swift
@@ -145,8 +145,7 @@ extension ACPChipState {
 
     private static func selectOption(id: String,
                                      in configOptions: [ACPConfigOption]) -> ChipSpec? {
-        guard let opt = configOptions.first(where: { $0.id == id }),
-              opt.type == "select", !opt.options.isEmpty else {
+        guard let opt = configOptions.first(where: { $0.id == id && isUsableSelectOption($0) }) else {
             return nil
         }
         return ChipSpec(
@@ -154,7 +153,7 @@ extension ACPChipState {
             options: opt.options.map {
                 ChipSpec.Item(id: $0.id, name: $0.name, description: $0.description)
             },
-            currentId: opt.currentValue)
+            currentId: opt.currentStringValue)
     }
 
     /// Finds a configOption that advertises itself for the given category
@@ -167,10 +166,15 @@ extension ACPChipState {
         in options: [ACPConfigOption]
     ) -> ChipSpec? {
         guard let opt = options.first(where: {
+            guard isUsableSelectOption($0) else { return false }
             guard let c = $0.category else { return false }
             return categoryMatches(c, category)
         }) else { return nil }
         return selectOption(id: opt.id, in: options)
+    }
+
+    private static func isUsableSelectOption(_ option: ACPConfigOption) -> Bool {
+        option.type == "select" && !option.options.isEmpty
     }
 
     private static func parameterChips(
@@ -194,7 +198,7 @@ extension ACPChipState {
                     options: opt.options.map {
                         ChipSpec.Item(id: $0.id, name: $0.name, description: $0.description)
                     },
-                    currentId: opt.currentValue))
+                    currentId: opt.currentStringValue))
         }
     }
 

--- a/Alas/Sources/ACP/UI/ACPComposerShell.swift
+++ b/Alas/Sources/ACP/UI/ACPComposerShell.swift
@@ -176,6 +176,9 @@ struct ACPComposer: View {
                 ForEach(session.chipState.parameters) { parameter in
                     parameterChip(parameter)
                 }
+                ForEach(booleanConfigOptions) { option in
+                    booleanConfigToggle(option)
+                }
                 if let mode = session.chipState.mode {
                     modeChip(mode)
                 }
@@ -397,6 +400,25 @@ struct ACPComposer: View {
         Color(.sRGB, red: 0.48, green: 0.82, blue: 0.42, opacity: 1)
     }
 
+    private var booleanConfigOptions: [ACPConfigOption] {
+        session.availableConfigOptions.filter {
+            $0.type == "boolean" && $0.currentBoolValue != nil
+        }
+    }
+
+    private func booleanConfigToggle(_ option: ACPConfigOption) -> some View {
+        Toggle(isOn: Binding(
+            get: { option.currentBoolValue ?? false },
+            set: { apply(configOptionId: option.id, value: .boolean($0)) }
+        )) {
+            Text(option.name.isEmpty ? option.id : option.name)
+                .font(.system(size: 11, weight: .medium))
+        }
+        .toggleStyle(.switch)
+        .controlSize(.small)
+        .help(option.name.isEmpty ? option.id : option.name)
+    }
+
     private func iconChipLabel(icon: String, spec: ChipSpec, fallback: String) -> String {
         "\(icon) \(selectedName(spec: spec, fallback: fallback))"
     }
@@ -452,7 +474,7 @@ struct ACPComposer: View {
                 let old = session.availableConfigOptions[idx]
                 session.availableConfigOptions[idx] = ACPConfigOption(
                     id: old.id, name: old.name, type: old.type,
-                    category: old.category, currentValue: selectedId,
+                    category: old.category, currentValue: .string(selectedId),
                     options: old.options)
             }
         }
@@ -471,18 +493,52 @@ struct ACPComposer: View {
                 // value for the option just set. Keep the successful selection
                 // for that option while still accepting dependent updates.
                 if let updated = try? await runner.connection.setConfigOption(
-                    sessionId: remoteId, configId: id, value: selectedId),
+                    sessionId: remoteId,
+                    configId: id,
+                    value: .string(selectedId)),
                    !updated.isEmpty {
                     guard let merged = ACPConfigOption.mergingSuccessfulSetResponse(
                         updated,
                         configId: id,
-                        selectedValue: selectedId,
+                        selectedValue: .string(selectedId),
                         currentConfigOptions: session.availableConfigOptions) else {
                         return
                     }
                     session.availableConfigOptions = merged
                     manager.persist(session)
                 }
+            }
+        }
+    }
+
+    private func apply(configOptionId id: String, value: ACPConfigValue) {
+        let sid = session.id
+        let remoteId = session.remoteSessionId ?? sid
+        if let idx = session.availableConfigOptions.firstIndex(where: { $0.id == id }) {
+            let old = session.availableConfigOptions[idx]
+            session.availableConfigOptions[idx] = ACPConfigOption(
+                id: old.id, name: old.name, type: old.type,
+                category: old.category, currentValue: value,
+                options: old.options)
+        }
+        manager.persist(session)
+
+        Task { @MainActor in
+            guard let runner = manager.runners[sid] else { return }
+            if let updated = try? await runner.connection.setConfigOption(
+                sessionId: remoteId,
+                configId: id,
+                value: value),
+               !updated.isEmpty {
+                guard let merged = ACPConfigOption.mergingSuccessfulSetResponse(
+                    updated,
+                    configId: id,
+                    selectedValue: value,
+                    currentConfigOptions: session.availableConfigOptions) else {
+                    return
+                }
+                session.availableConfigOptions = merged
+                manager.persist(session)
             }
         }
     }

--- a/Alas/Sources/Agents/ACPAgentProfiles.swift
+++ b/Alas/Sources/Agents/ACPAgentProfiles.swift
@@ -68,13 +68,22 @@ enum ACPAgentProfiles {
     static func heuristicThinkingId(from options: [ACPConfigOption]) -> String? {
         let knownIds: Set<String> = ["effort", "reasoning_effort", "thinking", "thinking_level"]
         let thoughtCategories: Set<String> = ["thought_level", "ThoughtLevel"]
-        if let byId = options.first(where: { knownIds.contains($0.id) }) { return byId.id }
+        if let byId = options.first(where: {
+            knownIds.contains($0.id) && isUsableSelectOption($0)
+        }) {
+            return byId.id
+        }
         if let byCategory = options.first(where: {
+            guard isUsableSelectOption($0) else { return false }
             guard let c = $0.category else { return false }
             return thoughtCategories.contains(c)
         }) {
             return byCategory.id
         }
         return nil
+    }
+
+    private static func isUsableSelectOption(_ option: ACPConfigOption) -> Bool {
+        option.type == "select" && !option.options.isEmpty
     }
 }

--- a/AlasTests/ACP/Protocol/ACPConfigOptionTests.swift
+++ b/AlasTests/ACP/Protocol/ACPConfigOptionTests.swift
@@ -25,7 +25,7 @@ struct ACPConfigOptionTests {
         #expect(opt.name == "Effort")
         #expect(opt.type == "select")
         #expect(opt.category == "ThoughtLevel")
-        #expect(opt.currentValue == "medium")
+        #expect(opt.currentValue == .string("medium"))
         #expect(opt.options.count == 3)
         #expect(opt.options[2].description == "Use more reasoning")
     }
@@ -60,14 +60,50 @@ struct ACPConfigOptionTests {
         #expect(opt.options.isEmpty)
     }
 
+    @Test("boolean config option decodes a boolean current value")
+    func decodeBooleanCurrentValue() throws {
+        let json = """
+        {
+          "id": "fast-mode",
+          "name": "Fast mode",
+          "type": "boolean",
+          "category": "model_config",
+          "currentValue": true
+        }
+        """.data(using: .utf8)!
+
+        let opt = try JSONDecoder().decode(ACPConfigOption.self, from: json)
+
+        #expect(opt.type == "boolean")
+        #expect(opt.currentValue == .boolean(true))
+        #expect(opt.currentStringValue == nil)
+        #expect(opt.currentBoolValue == true)
+    }
+
     @Test("encodes setConfigOption params")
     func encodeSetParams() throws {
-        let params = ACPSessionSetConfigOptionParams(sessionId: "s", configId: "effort", value: "high")
+        let params = ACPSessionSetConfigOptionParams(
+            sessionId: "s", configId: "effort", value: .string("high"))
         let data = try JSONEncoder().encode(params)
-        let s = String(data: data, encoding: .utf8)!
-        #expect(s.contains("\"sessionId\":\"s\""))
-        #expect(s.contains("\"configId\":\"effort\""))
-        #expect(s.contains("\"value\":\"high\""))
+        let json = try #require(JSONSerialization.jsonObject(with: data) as? [String: Any])
+
+        #expect(json["sessionId"] as? String == "s")
+        #expect(json["configId"] as? String == "effort")
+        #expect(json["type"] as? String == "id")
+        #expect(json["value"] as? String == "high")
+    }
+
+    @Test("encodes boolean setConfigOption params")
+    func encodeBooleanSetParams() throws {
+        let params = ACPSessionSetConfigOptionParams(
+            sessionId: "s", configId: "fast-mode", value: .boolean(false))
+        let data = try JSONEncoder().encode(params)
+        let json = try #require(JSONSerialization.jsonObject(with: data) as? [String: Any])
+
+        #expect(json["sessionId"] as? String == "s")
+        #expect(json["configId"] as? String == "fast-mode")
+        #expect(json["type"] as? String == "boolean")
+        #expect(json["value"] as? Bool == false)
     }
 
     @Test("successful set response preserves the selected config value")
@@ -91,12 +127,12 @@ struct ACPConfigOptionTests {
         let merged = try #require(ACPConfigOption.mergingSuccessfulSetResponse(
             [staleFast, refreshedContext],
             configId: "fast",
-            selectedValue: "true",
+            selectedValue: .string("true"),
             currentConfigOptions: [currentFast, refreshedContext]))
 
         #expect(merged.map(\.id) == ["fast", "context"])
-        #expect(merged.first(where: { $0.id == "fast" })?.currentValue == "true")
-        #expect(merged.first(where: { $0.id == "context" })?.currentValue == "1m")
+        #expect(merged.first(where: { $0.id == "fast" })?.currentValue == .string("true"))
+        #expect(merged.first(where: { $0.id == "context" })?.currentValue == .string("1m"))
     }
 
     @Test("stale set response is ignored after a newer local selection")
@@ -114,9 +150,25 @@ struct ACPConfigOptionTests {
         let merged = ACPConfigOption.mergingSuccessfulSetResponse(
             [oldResponse],
             configId: "fast",
-            selectedValue: "true",
+            selectedValue: .string("true"),
             currentConfigOptions: [currentFast])
 
         #expect(merged == nil)
+    }
+
+    @Test("successful boolean set response preserves the selected config value")
+    func mergeSuccessfulBooleanSetResponsePreservesSelectedValue() throws {
+        let staleFast = ACPConfigOption(
+            id: "fast-mode", name: "Fast mode", type: "boolean", currentValue: .boolean(false))
+        let currentFast = ACPConfigOption(
+            id: "fast-mode", name: "Fast mode", type: "boolean", currentValue: .boolean(true))
+
+        let merged = try #require(ACPConfigOption.mergingSuccessfulSetResponse(
+            [staleFast],
+            configId: "fast-mode",
+            selectedValue: .boolean(true),
+            currentConfigOptions: [currentFast]))
+
+        #expect(merged.first?.currentValue == .boolean(true))
     }
 }

--- a/AlasTests/ACP/Protocol/ACPConnectionTests.swift
+++ b/AlasTests/ACP/Protocol/ACPConnectionTests.swift
@@ -106,7 +106,7 @@ struct ACPConnectionTests {
         }
 
         let conn = ACPConnection(client: mock)
-        _ = try await conn.setConfigOption(sessionId: "sess-1", configId: "effort", value: "high")
+        _ = try await conn.setConfigOption(sessionId: "sess-1", configId: "effort", value: .string("high"))
 
         let req = try #require(mock.sent.last)
         #expect(req.method == "session/set_config_option")
@@ -114,7 +114,7 @@ struct ACPConnectionTests {
         let params = try #require(req.params as? ACPSessionSetConfigOptionParams)
         #expect(params.sessionId == "sess-1")
         #expect(params.configId == "effort")
-        #expect(params.value == "high")
+        #expect(params.value == .string("high"))
     }
 
     @Test("setConfigOption returns refreshed configOptions from response")
@@ -130,9 +130,9 @@ struct ACPConnectionTests {
         }
 
         let conn = ACPConnection(client: mock)
-        let result = try await conn.setConfigOption(sessionId: "s", configId: "effort", value: "high")
+        let result = try await conn.setConfigOption(sessionId: "s", configId: "effort", value: .string("high"))
         #expect(result.count == 1)
-        #expect(result[0].currentValue == "high")
+        #expect(result[0].currentValue == .string("high"))
         #expect(result[0].options.count == 2)
     }
 
@@ -141,7 +141,7 @@ struct ACPConnectionTests {
         let mock = ACPMockClient()
         mock.script(method: "session/set_config_option") { _ in Data() }
         let conn = ACPConnection(client: mock)
-        let result = try await conn.setConfigOption(sessionId: "s", configId: "effort", value: "high")
+        let result = try await conn.setConfigOption(sessionId: "s", configId: "effort", value: .string("high"))
         #expect(result.isEmpty)
     }
 }

--- a/AlasTests/ACP/Protocol/ACPInitializeTests.swift
+++ b/AlasTests/ACP/Protocol/ACPInitializeTests.swift
@@ -39,6 +39,52 @@ struct ACPInitializeTests {
         #expect(env.params?.clientCapabilities.meta.terminalAuth == false)
     }
 
+    @Test("decoding empty session capabilities does not imply boolean config support")
+    func decodeEmptySessionCapabilities() throws {
+        let data = Data("""
+        {
+          "jsonrpc": "2.0",
+          "id": 1,
+          "method": "initialize",
+          "params": {
+            "protocolVersion": 1,
+            "clientCapabilities": {
+              "fs": { "readTextFile": true, "writeTextFile": true },
+              "terminal": true,
+              "session": {}
+            }
+          }
+        }
+        """.utf8)
+
+        let env = try JSONDecoder().decode(JSONRPCEnvelope<ACPInitializeParams>.self, from: data)
+
+        #expect(env.params?.clientCapabilities.session.configOptions.boolean == nil)
+    }
+
+    @Test("decoding null configOptions does not imply boolean config support")
+    func decodeNullSessionConfigOptions() throws {
+        let data = Data("""
+        {
+          "jsonrpc": "2.0",
+          "id": 1,
+          "method": "initialize",
+          "params": {
+            "protocolVersion": 1,
+            "clientCapabilities": {
+              "fs": { "readTextFile": true, "writeTextFile": true },
+              "terminal": true,
+              "session": { "configOptions": null }
+            }
+          }
+        }
+        """.utf8)
+
+        let env = try JSONDecoder().decode(JSONRPCEnvelope<ACPInitializeParams>.self, from: data)
+
+        #expect(env.params?.clientCapabilities.session.configOptions.boolean == nil)
+    }
+
     @Test("initialize request advertises terminal auth capabilities")
     func initializeRequestAdvertisesAuth() throws {
         let params = ACPInitializeParams(
@@ -64,6 +110,9 @@ struct ACPInitializeTests {
         #expect(auth["terminal"] as? Bool == true)
         #expect(meta["terminal-auth"] as? Bool == true)
         #expect(meta["parameterizedModelPicker"] as? Bool == true)
+        let session = try #require(capabilities["session"] as? [String: Any])
+        let configOptions = try #require(session["configOptions"] as? [String: Any])
+        #expect(configOptions["boolean"] as? [String: Any] != nil)
         #expect(capabilities["terminal"] as? Bool == true)
         let fs = try #require(capabilities["fs"] as? [String: Any])
         #expect(fs["readTextFile"] as? Bool == true)

--- a/AlasTests/ACP/Protocol/ACPSessionLifecycleTests.swift
+++ b/AlasTests/ACP/Protocol/ACPSessionLifecycleTests.swift
@@ -32,7 +32,7 @@ struct ACPSessionLifecycleTests {
         let r = try #require(env.result)
         #expect(r.configOptions.count == 1)
         #expect(r.configOptions[0].id == "effort")
-        #expect(r.configOptions[0].currentValue == "medium")
+        #expect(r.configOptions[0].currentValue == .string("medium"))
         #expect(r.configOptions[0].options.count == 3)
     }
 

--- a/AlasTests/ACP/Protocol/ACPSessionUpdateTests.swift
+++ b/AlasTests/ACP/Protocol/ACPSessionUpdateTests.swift
@@ -58,7 +58,7 @@ struct ACPSessionUpdateTests {
         if case .sessionConfigOptionsUpdate(let opts) = env.params!.update {
             #expect(opts.count == 1)
             #expect(opts[0].id == "effort")
-            #expect(opts[0].currentValue == "high")
+            #expect(opts[0].currentValue == .string("high"))
         } else { Issue.record("expected sessionConfigOptionsUpdate") }
     }
 

--- a/AlasTests/ACP/Session/ACPChipStateTests.swift
+++ b/AlasTests/ACP/Session/ACPChipStateTests.swift
@@ -20,6 +20,13 @@ struct ACPChipStateTests {
             options: options.map { ACPConfigOptionItem(id: $0.0, name: $0.1) })
     }
 
+    private func booleanOption(_ id: String,
+                               current: Bool,
+                               category: String? = nil) -> ACPConfigOption {
+        ACPConfigOption(id: id, name: id.capitalized, type: "boolean",
+                        category: category, currentValue: .boolean(current))
+    }
+
     @Test("claude: modes -> Mode chip, effort configOption -> Thinking chip")
     func claudeFullHouse() {
         let state = ACPChipState.normalize(
@@ -135,6 +142,27 @@ struct ACPChipStateTests {
         if case .configOption(let id)? = state.models?.source {
             #expect(id == "preset")
         } else { Issue.record("expected configOption source for model chip") }
+    }
+
+    @Test("canonical category lookup skips boolean options")
+    func canonicalCategorySkipsBooleanOptions() {
+        let state = ACPChipState.normalize(
+            agentId: "future-agent",
+            availableModels: [],
+            currentModel: nil,
+            availableModes: [],
+            currentMode: nil,
+            configOptions: [
+                booleanOption("fast_model", current: false, category: "model"),
+                configOption("preset",
+                             current: "sonnet",
+                             options: [("opus","Opus"),("sonnet","Sonnet")],
+                             category: "model"),
+            ])
+        #expect(state.models?.currentId == "sonnet")
+        if case .configOption(let id)? = state.models?.source {
+            #expect(id == "preset")
+        } else { Issue.record("expected select configOption source for model chip") }
     }
 
     @Test("Mode chip sources from category=mode configOption when present")

--- a/AlasTests/ACP/Session/ACPSessionTests.swift
+++ b/AlasTests/ACP/Session/ACPSessionTests.swift
@@ -374,7 +374,7 @@ struct ACPSessionTests {
                                   options: [ACPConfigOptionItem(id: "high", name: "High")])
         session.apply(.sessionConfigOptionsUpdate([opt]))
         #expect(session.availableConfigOptions.count == 1)
-        #expect(session.availableConfigOptions[0].currentValue == "high")
+        #expect(session.availableConfigOptions[0].currentValue == .string("high"))
     }
 
     @Test("chipState reflects current ACPSession fields")

--- a/AlasTests/ACPAgentProfilesTests.swift
+++ b/AlasTests/ACPAgentProfilesTests.swift
@@ -53,6 +53,18 @@ struct ACPAgentProfilesTests {
         #expect(ACPAgentProfiles.heuristicThinkingId(from: opts) == "effort")
     }
 
+    @Test("heuristic skips boolean known id and picks selectable thought category")
+    func heuristicSkipsBooleanKnownId() {
+        let opts = [
+            ACPConfigOption(id: "effort", name: "Effort", type: "boolean",
+                            currentValue: .boolean(false)),
+            ACPConfigOption(id: "reasoning", name: "Reasoning", category: "thought_level",
+                            currentValue: "high",
+                            options: [ACPConfigOptionItem(id: "high", name: "High")]),
+        ]
+        #expect(ACPAgentProfiles.heuristicThinkingId(from: opts) == "reasoning")
+    }
+
     @Test("heuristic picks ThoughtLevel-category option when no known id")
     func heuristicByCategory() {
         let opts = [


### PR DESCRIPTION
## Summary

Adds native boolean ACP config option support so current Claude/Codex ACP adapters can expose Fast mode as a toggle instead of a select fallback.

## Changes

- Decode and encode ACP config values as either strings or booleans.
- Advertise `clientCapabilities.session.configOptions.boolean` during ACP initialize.
- Keep existing select config chips on string values.
- Render boolean config options as composer toggles and send boolean values through `session/set_config_option`.
- Update protocol/session tests for typed config values.

## Validation

- `xcodegen`
- `ALAS_FFF_TARGET_ARCH=arm64 rtk xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS,arch=arm64' -quiet build`
- `ALAS_FFF_TARGET_ARCH=arm64 rtk xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS,arch=arm64' -only-testing:AlasTests/ACPConfigOptionTests -only-testing:AlasTests/ACPConnectionTests -only-testing:AlasTests/ACPInitializeTests -only-testing:AlasTests/ACPSessionLifecycleTests -only-testing:AlasTests/ACPSessionUpdateTests -only-testing:AlasTests/ACPSessionTests -only-testing:AlasTests/ACPChipStateTests test`

Full local `xcodebuild ... test` was attempted but stayed silent for roughly 10 minutes and was interrupted; affected ACP suites were run explicitly.