### PR TITLE
fix(acp): make context ring fully clickable

### DIFF
--- a/Alas/Sources/ACP/UI/ACPContextRing.swift
+++ b/Alas/Sources/ACP/UI/ACPContextRing.swift
@@ -64,6 +64,7 @@ struct ACPContextRing: View {
         }
         .frame(width: diameter, height: diameter)
         .animation(.easeOut(duration: 0.25), value: ratio)
+        .contentShape(Circle())
 
         labeledRing(ring)
     }


### PR DESCRIPTION
## Summary

In the ACP chat pane composer footer, the context-usage ring was only clickable on the ring's stroke itself — clicking the transparent interior of the circle did nothing. It now behaves like the adjacent image and auto-run buttons, where the whole control area responds to clicks.

## Root cause

`ACPContextRing`'s button label was composed of two *stroked* `Circle` shapes with no fill and no `contentShape`. SwiftUI hit-tests only the opaque drawn pixels, so only the ~2.5pt stroke registered clicks. The image/auto-run buttons don't have this issue because each has a filled `RoundedRectangle` background behind a fixed frame, making the whole rectangle opaque and hittable.

## Fix

Add `.contentShape(Circle())` to the ring so the entire disc (interior included) is a hit region. This also makes the existing doc comment ("a hit area that exactly matches the ring frame") actually true.

🤖 Generated with [Claude Code](https://claude.com/claude-code)