### PR TITLE
fix(acp): Make fast mode a composer button

### DIFF
--- a/Alas/Sources/ACP/Session/ACPChipState.swift
+++ b/Alas/Sources/ACP/Session/ACPChipState.swift
@@ -22,7 +22,7 @@ struct ACPParameterChip: Identifiable, Equatable {
 enum ACPParameterChipPresentation: Equatable {
     case standard
     case cursorContextWindow
-    case cursorFast
+    case fastMode
 }
 
 /// A single chip's data, plus a tag remembering where it came from so the
@@ -206,6 +206,10 @@ extension ACPChipState {
         for option: ACPConfigOption,
         agentId: String
     ) -> ACPParameterChipPresentation {
+        if isFastModeConfigOption(option) {
+            return .fastMode
+        }
+
         guard agentId == "cursor-agent" else { return .standard }
 
         let id = option.id.lowercased()
@@ -213,10 +217,19 @@ extension ACPChipState {
         if id == "context" || id == "context_window" || name == "context window" {
             return .cursorContextWindow
         }
-        if id == "fast" || name == "fast" {
-            return .cursorFast
-        }
         return .standard
+    }
+
+    static func isFastModeConfigOption(_ option: ACPConfigOption) -> Bool {
+        let id = normalizedFastModeToken(option.id)
+        let name = normalizedFastModeToken(option.name)
+        return id == "fast" || id == "fastmode" || name == "fast" || name == "fastmode"
+    }
+
+    private static func normalizedFastModeToken(_ value: String) -> String {
+        value
+            .lowercased()
+            .filter { $0.isLetter || $0.isNumber }
     }
 
     private static func configOptionId(from spec: ChipSpec?) -> String? {

--- a/Alas/Sources/ACP/UI/ACPComposerShell.swift
+++ b/Alas/Sources/ACP/UI/ACPComposerShell.swift
@@ -15,6 +15,41 @@ enum ACPComposerControlPresentation {
             ? "Fast mode is ON — click to disable"
             : "Click to enable fast mode"
     }
+
+    static func canRenderFastModeButton(for spec: ChipSpec) -> Bool {
+        fastModeToggleTarget(for: spec) != nil
+    }
+
+    static func fastModeToggleTarget(for spec: ChipSpec) -> String? {
+        if isFastModeEnabled(spec) {
+            return spec.options.first(where: { isFastModeOff(id: $0.id, name: $0.name) })?.id
+        }
+        return spec.options.first(where: { isFastModeOn(id: $0.id, name: $0.name) })?.id
+    }
+
+    static func isFastModeEnabled(_ spec: ChipSpec) -> Bool {
+        guard let currentId = spec.currentId else { return false }
+        if let item = spec.options.first(where: { $0.id == currentId }) {
+            return isFastModeOn(id: item.id, name: item.name)
+        }
+        return isFastModeOn(id: currentId, name: currentId)
+    }
+
+    private static func isFastModeOn(id: String, name: String) -> Bool {
+        let tokens = [normalizedFastModeValue(id), normalizedFastModeValue(name)]
+        return tokens.contains { ["true", "on", "enabled", "yes", "1", "fast"].contains($0) }
+    }
+
+    private static func isFastModeOff(id: String, name: String) -> Bool {
+        let tokens = [normalizedFastModeValue(id), normalizedFastModeValue(name)]
+        return tokens.contains { ["false", "off", "disabled", "no", "0", "standard"].contains($0) }
+    }
+
+    private static func normalizedFastModeValue(_ value: String) -> String {
+        value
+            .lowercased()
+            .filter { $0.isLetter || $0.isNumber }
+    }
 }
 
 enum ACPComposerPlacement: Equatable {
@@ -414,7 +449,10 @@ struct ACPComposer: View {
     }
 
     private var fastModeParameter: ACPParameterChip? {
-        session.chipState.parameters.first { $0.presentation == .fastMode }
+        session.chipState.parameters.first {
+            $0.presentation == .fastMode
+                && ACPComposerControlPresentation.canRenderFastModeButton(for: $0.spec)
+        }
     }
 
     private var fastModeBooleanOption: ACPConfigOption? {
@@ -426,38 +464,18 @@ struct ACPComposer: View {
     }
 
     private var parameterChips: [ACPParameterChip] {
-        session.chipState.parameters.filter { $0.presentation != .fastMode }
+        session.chipState.parameters.filter {
+            $0.presentation != .fastMode
+                || !ACPComposerControlPresentation.canRenderFastModeButton(for: $0.spec)
+        }
     }
 
     private func fastModeToggleTarget(for spec: ChipSpec) -> String? {
-        if isFastModeEnabled(spec) {
-            return spec.options.first(where: { isFastModeOff(id: $0.id, name: $0.name) })?.id
-        }
-        return spec.options.first(where: { isFastModeOn(id: $0.id, name: $0.name) })?.id
+        ACPComposerControlPresentation.fastModeToggleTarget(for: spec)
     }
 
     private func isFastModeEnabled(_ spec: ChipSpec) -> Bool {
-        guard let currentId = spec.currentId else { return false }
-        if let item = spec.options.first(where: { $0.id == currentId }) {
-            return isFastModeOn(id: item.id, name: item.name)
-        }
-        return isFastModeOn(id: currentId, name: currentId)
-    }
-
-    private func isFastModeOn(id: String, name: String) -> Bool {
-        let tokens = [normalizedFastModeValue(id), normalizedFastModeValue(name)]
-        return tokens.contains { ["true", "on", "enabled", "yes", "1", "fast"].contains($0) }
-    }
-
-    private func isFastModeOff(id: String, name: String) -> Bool {
-        let tokens = [normalizedFastModeValue(id), normalizedFastModeValue(name)]
-        return tokens.contains { ["false", "off", "disabled", "no", "0", "standard"].contains($0) }
-    }
-
-    private func normalizedFastModeValue(_ value: String) -> String {
-        value
-            .lowercased()
-            .filter { $0.isLetter || $0.isNumber }
+        ACPComposerControlPresentation.isFastModeEnabled(spec)
     }
 
     private func fastModeBg(_ spec: ChipSpec) -> Color {
@@ -525,7 +543,10 @@ struct ACPComposer: View {
                  placeholder: parameter.label,
                  accent: cursorContextAccent)
         case .fastMode:
-            EmptyView()
+            chip(spec: parameter.spec,
+                 label: chipLabel(prefix: parameter.label, spec: parameter.spec),
+                 placeholder: parameter.label,
+                 accent: cursorFastAccent)
         case .standard:
             chip(spec: parameter.spec,
                  label: chipLabel(prefix: parameter.label, spec: parameter.spec),

--- a/Alas/Sources/ACP/UI/ACPComposerShell.swift
+++ b/Alas/Sources/ACP/UI/ACPComposerShell.swift
@@ -17,14 +17,12 @@ enum ACPComposerControlPresentation {
     }
 
     static func canRenderFastModeButton(for spec: ChipSpec) -> Bool {
-        fastModeToggleTarget(for: spec) != nil
+        isFastModeToggleSelect(spec) && rawFastModeToggleTarget(for: spec) != nil
     }
 
     static func fastModeToggleTarget(for spec: ChipSpec) -> String? {
-        if isFastModeEnabled(spec) {
-            return spec.options.first(where: { isFastModeOff(id: $0.id, name: $0.name) })?.id
-        }
-        return spec.options.first(where: { isFastModeOn(id: $0.id, name: $0.name) })?.id
+        guard isFastModeToggleSelect(spec) else { return nil }
+        return rawFastModeToggleTarget(for: spec)
     }
 
     static func isFastModeEnabled(_ spec: ChipSpec) -> Bool {
@@ -33,6 +31,31 @@ enum ACPComposerControlPresentation {
             return isFastModeOn(id: item.id, name: item.name)
         }
         return isFastModeOn(id: currentId, name: currentId)
+    }
+
+    private static func isFastModeToggleSelect(_ spec: ChipSpec) -> Bool {
+        guard !spec.options.isEmpty else { return false }
+
+        var hasOnOption = false
+        var hasOffOption = false
+        for option in spec.options {
+            if isFastModeOn(id: option.id, name: option.name) {
+                hasOnOption = true
+            } else if isFastModeOff(id: option.id, name: option.name) {
+                hasOffOption = true
+            } else {
+                return false
+            }
+        }
+
+        return hasOnOption && hasOffOption
+    }
+
+    private static func rawFastModeToggleTarget(for spec: ChipSpec) -> String? {
+        if isFastModeEnabled(spec) {
+            return spec.options.first(where: { isFastModeOff(id: $0.id, name: $0.name) })?.id
+        }
+        return spec.options.first(where: { isFastModeOn(id: $0.id, name: $0.name) })?.id
     }
 
     private static func isFastModeOn(id: String, name: String) -> Bool {

--- a/Alas/Sources/ACP/UI/ACPComposerShell.swift
+++ b/Alas/Sources/ACP/UI/ACPComposerShell.swift
@@ -1,5 +1,22 @@
 import SwiftUI
 
+enum ACPComposerControlPresentation {
+    static func fastModeIconName(isEnabled: Bool) -> String {
+        isEnabled ? "bolt.fill" : "bolt"
+    }
+
+    static func autoRunIconName(isEnabled: Bool) -> String {
+        isEnabled ? "play.fill" : "play"
+    }
+
+    static func fastModeHelp(isEnabled: Bool, canToggle: Bool) -> String {
+        guard canToggle else { return "Fast mode cannot be changed" }
+        return isEnabled
+            ? "Fast mode is ON — click to disable"
+            : "Click to enable fast mode"
+    }
+}
+
 enum ACPComposerPlacement: Equatable {
     case bottom
     case inFlow
@@ -169,11 +186,16 @@ struct ACPComposer: View {
                 ACPContextUsageButton(usage: session.contextUsage,
                                       modelName: session.currentModelDisplayName)
                 attachButton
+                if let fastMode = fastModeParameter {
+                    selectFastModeToggle(fastMode)
+                } else if let fastMode = fastModeBooleanOption {
+                    booleanFastModeToggle(fastMode)
+                }
                 autoRunToggle
                 if let thinking = session.chipState.thinking {
                     thinkingChip(thinking)
                 }
-                ForEach(session.chipState.parameters) { parameter in
+                ForEach(parameterChips) { parameter in
                     parameterChip(parameter)
                 }
                 ForEach(booleanConfigOptions) { option in
@@ -270,7 +292,7 @@ struct ACPComposer: View {
             session.autoRunEnabled.toggle()
             manager.persist(session)
         } label: {
-            Image(systemName: session.autoRunEnabled ? "bolt.fill" : "bolt")
+            Image(systemName: ACPComposerControlPresentation.autoRunIconName(isEnabled: session.autoRunEnabled))
                 .font(.system(size: 12, weight: .bold))
                 .foregroundStyle(autoRunFg)
                 .frame(width: 28, height: 24)
@@ -346,6 +368,128 @@ struct ACPComposer: View {
         .help("Attach an image")
     }
 
+    private func selectFastModeToggle(_ parameter: ACPParameterChip) -> some View {
+        Button {
+            guard let targetId = fastModeToggleTarget(for: parameter.spec) else { return }
+            apply(spec: parameter.spec, selectedId: targetId)
+        } label: {
+            fastModeIcon(isEnabled: isFastModeEnabled(parameter.spec))
+        }
+        .buttonStyle(.plain)
+        .accessibilityLabel("Fast mode")
+        .disabled(fastModeToggleTarget(for: parameter.spec) == nil)
+        .opacity(fastModeToggleTarget(for: parameter.spec) == nil ? 0.5 : 1.0)
+        .help(fastModeHelp(isEnabled: isFastModeEnabled(parameter.spec),
+                           canToggle: fastModeToggleTarget(for: parameter.spec) != nil))
+    }
+
+    private func booleanFastModeToggle(_ option: ACPConfigOption) -> some View {
+        let isEnabled = option.currentBoolValue ?? false
+        return Button {
+            apply(configOptionId: option.id, value: .boolean(!isEnabled))
+        } label: {
+            fastModeIcon(isEnabled: isEnabled)
+        }
+        .buttonStyle(.plain)
+        .accessibilityLabel("Fast mode")
+        .help(fastModeHelp(isEnabled: isEnabled, canToggle: true))
+    }
+
+    private func fastModeIcon(isEnabled: Bool) -> some View {
+        Image(systemName: ACPComposerControlPresentation.fastModeIconName(isEnabled: isEnabled))
+            .font(.system(size: 12, weight: .bold))
+            .foregroundStyle(fastModeFg(isEnabled: isEnabled))
+            .frame(width: 28, height: 24)
+            .background(
+                RoundedRectangle(cornerRadius: 6).fill(fastModeBg(isEnabled: isEnabled))
+            )
+            .overlay(
+                RoundedRectangle(cornerRadius: 6)
+                    .strokeBorder(fastModeBorder(isEnabled: isEnabled), lineWidth: 0.75)
+            )
+    }
+
+    private func fastModeHelp(isEnabled: Bool, canToggle: Bool) -> String {
+        ACPComposerControlPresentation.fastModeHelp(isEnabled: isEnabled, canToggle: canToggle)
+    }
+
+    private var fastModeParameter: ACPParameterChip? {
+        session.chipState.parameters.first { $0.presentation == .fastMode }
+    }
+
+    private var fastModeBooleanOption: ACPConfigOption? {
+        session.availableConfigOptions.first {
+            $0.type == "boolean"
+                && $0.currentBoolValue != nil
+                && ACPChipState.isFastModeConfigOption($0)
+        }
+    }
+
+    private var parameterChips: [ACPParameterChip] {
+        session.chipState.parameters.filter { $0.presentation != .fastMode }
+    }
+
+    private func fastModeToggleTarget(for spec: ChipSpec) -> String? {
+        if isFastModeEnabled(spec) {
+            return spec.options.first(where: { isFastModeOff(id: $0.id, name: $0.name) })?.id
+        }
+        return spec.options.first(where: { isFastModeOn(id: $0.id, name: $0.name) })?.id
+    }
+
+    private func isFastModeEnabled(_ spec: ChipSpec) -> Bool {
+        guard let currentId = spec.currentId else { return false }
+        if let item = spec.options.first(where: { $0.id == currentId }) {
+            return isFastModeOn(id: item.id, name: item.name)
+        }
+        return isFastModeOn(id: currentId, name: currentId)
+    }
+
+    private func isFastModeOn(id: String, name: String) -> Bool {
+        let tokens = [normalizedFastModeValue(id), normalizedFastModeValue(name)]
+        return tokens.contains { ["true", "on", "enabled", "yes", "1", "fast"].contains($0) }
+    }
+
+    private func isFastModeOff(id: String, name: String) -> Bool {
+        let tokens = [normalizedFastModeValue(id), normalizedFastModeValue(name)]
+        return tokens.contains { ["false", "off", "disabled", "no", "0", "standard"].contains($0) }
+    }
+
+    private func normalizedFastModeValue(_ value: String) -> String {
+        value
+            .lowercased()
+            .filter { $0.isLetter || $0.isNumber }
+    }
+
+    private func fastModeBg(_ spec: ChipSpec) -> Color {
+        fastModeBg(isEnabled: isFastModeEnabled(spec))
+    }
+
+    private func fastModeBg(isEnabled: Bool) -> Color {
+        isEnabled
+            ? cursorFastAccent.opacity(0.20)
+            : theme.color("bg-3").opacity(0.7)
+    }
+
+    private func fastModeBorder(_ spec: ChipSpec) -> Color {
+        fastModeBorder(isEnabled: isFastModeEnabled(spec))
+    }
+
+    private func fastModeBorder(isEnabled: Bool) -> Color {
+        isEnabled
+            ? cursorFastAccent.opacity(0.55)
+            : theme.color("line")
+    }
+
+    private func fastModeFg(_ spec: ChipSpec) -> Color {
+        fastModeFg(isEnabled: isFastModeEnabled(spec))
+    }
+
+    private func fastModeFg(isEnabled: Bool) -> Color {
+        isEnabled
+            ? Color.blend(cursorFastAccent, .white, t: 0.45)
+            : theme.color("fg-muted")
+    }
+
     // MARK: - Chip builders driven by ACPChipState
 
     private func modeChip(_ spec: ChipSpec) -> some View {
@@ -372,6 +516,7 @@ struct ACPComposer: View {
              searchDescriptions: false)
     }
 
+    @ViewBuilder
     private func parameterChip(_ parameter: ACPParameterChip) -> some View {
         switch parameter.presentation {
         case .cursorContextWindow:
@@ -379,11 +524,8 @@ struct ACPComposer: View {
                  label: iconChipLabel(icon: "🪟", spec: parameter.spec, fallback: parameter.label),
                  placeholder: parameter.label,
                  accent: cursorContextAccent)
-        case .cursorFast:
-            chip(spec: parameter.spec,
-                 label: iconChipLabel(icon: "🚀", spec: parameter.spec, fallback: parameter.label),
-                 placeholder: parameter.label,
-                 accent: cursorFastAccent)
+        case .fastMode:
+            EmptyView()
         case .standard:
             chip(spec: parameter.spec,
                  label: chipLabel(prefix: parameter.label, spec: parameter.spec),
@@ -403,6 +545,7 @@ struct ACPComposer: View {
     private var booleanConfigOptions: [ACPConfigOption] {
         session.availableConfigOptions.filter {
             $0.type == "boolean" && $0.currentBoolValue != nil
+                && !ACPChipState.isFastModeConfigOption($0)
         }
     }
 

--- a/AlasTests/ACP/Session/ACPChipStateTests.swift
+++ b/AlasTests/ACP/Session/ACPChipStateTests.swift
@@ -411,11 +411,21 @@ extension ACPChipStateTests {
                 ChipSpec.Item(id: "fast", name: "Fast", description: nil),
             ],
             currentId: "fast")
+        let slowNormalFast = ChipSpec(
+            source: .configOption(id: "fast"),
+            options: [
+                ChipSpec.Item(id: "slow", name: "Slow", description: nil),
+                ChipSpec.Item(id: "normal", name: "Normal", description: nil),
+                ChipSpec.Item(id: "fast", name: "Fast", description: nil),
+            ],
+            currentId: "slow")
 
         #expect(ACPComposerControlPresentation.fastModeToggleTarget(for: offOn) == "fast")
         #expect(ACPComposerControlPresentation.canRenderFastModeButton(for: offOn))
         #expect(ACPComposerControlPresentation.fastModeToggleTarget(for: normalFast) == nil)
         #expect(!ACPComposerControlPresentation.canRenderFastModeButton(for: normalFast))
+        #expect(ACPComposerControlPresentation.fastModeToggleTarget(for: slowNormalFast) == nil)
+        #expect(!ACPComposerControlPresentation.canRenderFastModeButton(for: slowNormalFast))
     }
 
     @Test("cursor-agent: no brackets -> no synthesized chips")

--- a/AlasTests/ACP/Session/ACPChipStateTests.swift
+++ b/AlasTests/ACP/Session/ACPChipStateTests.swift
@@ -300,11 +300,11 @@ extension ACPChipStateTests {
         #expect(state.thinking?.options.map { $0.name } == ["None", "Low", "Medium", "High", "Extra High"])
         #expect(state.parameters.map { $0.label } == ["Context", "Fast"])
         #expect(state.parameters.map { $0.spec.currentId } == ["272k", "false"])
-        #expect(state.parameters.map { $0.presentation } == [.cursorContextWindow, .cursorFast])
+        #expect(state.parameters.map { $0.presentation } == [.cursorContextWindow, .fastMode])
     }
 
-    @Test("non-cursor agent: context and fast remain generic parameters")
-    func nonCursorContextAndFastRemainGeneric() {
+    @Test("agents with fast select options expose a fast mode parameter")
+    func agentsWithFastSelectOptionsExposeFastModeParameter() {
         let state = ACPChipState.normalize(
             agentId: "future-agent",
             availableModels: [],
@@ -320,7 +320,79 @@ extension ACPChipStateTests {
                              options: [("false", "Off"), ("true", "On")]),
             ])
 
-        #expect(state.parameters.map { $0.presentation } == [.standard, .standard])
+        #expect(state.parameters.map { $0.presentation } == [.standard, .fastMode])
+    }
+
+    @Test("fast mode detection accepts common config option spellings")
+    func fastModeDetectionAcceptsCommonSpellings() {
+        let state = ACPChipState.normalize(
+            agentId: "claude",
+            availableModels: [],
+            currentModel: nil,
+            availableModes: [],
+            currentMode: nil,
+            configOptions: [
+                ACPConfigOption(
+                    id: "fast-mode",
+                    name: "Fast mode",
+                    type: "select",
+                    currentValue: "off",
+                    options: [
+                        ACPConfigOptionItem(id: "off", name: "Off"),
+                        ACPConfigOptionItem(id: "on", name: "On"),
+                    ]),
+            ])
+
+        #expect(state.parameters.first?.presentation == .fastMode)
+    }
+
+    @Test("fast mode detection ignores unrelated fast model selectors")
+    func fastModeDetectionIgnoresUnrelatedFastModelSelectors() {
+        let state = ACPChipState.normalize(
+            agentId: "codex",
+            availableModels: [],
+            currentModel: nil,
+            availableModes: [],
+            currentMode: nil,
+            configOptions: [
+                configOption("fast_model",
+                             current: "enabled",
+                             options: [("disabled", "Disabled"), ("enabled", "Enabled")]),
+            ])
+
+        #expect(state.parameters.first?.presentation == .standard)
+    }
+
+    @Test("fast mode detection recognizes boolean options")
+    func fastModeDetectionRecognizesBooleanOptions() {
+        let fastMode = ACPConfigOption(
+            id: "fast-mode",
+            name: "Fast mode",
+            type: "boolean",
+            currentValue: .boolean(false))
+        let fastModel = ACPConfigOption(
+            id: "fast_model",
+            name: "Fast model",
+            type: "boolean",
+            currentValue: .boolean(false))
+
+        #expect(ACPChipState.isFastModeConfigOption(fastMode))
+        #expect(!ACPChipState.isFastModeConfigOption(fastModel))
+    }
+
+    @Test("composer fast and auto-run controls use distinct icon semantics")
+    func composerControlIconSemantics() {
+        #expect(ACPComposerControlPresentation.fastModeIconName(isEnabled: false) == "bolt")
+        #expect(ACPComposerControlPresentation.fastModeIconName(isEnabled: true) == "bolt.fill")
+        #expect(ACPComposerControlPresentation.autoRunIconName(isEnabled: false) == "play")
+        #expect(ACPComposerControlPresentation.autoRunIconName(isEnabled: true) == "play.fill")
+    }
+
+    @Test("composer fast mode help explains the hover action")
+    func composerFastModeHelpExplainsHoverAction() {
+        #expect(ACPComposerControlPresentation.fastModeHelp(isEnabled: false, canToggle: true) == "Click to enable fast mode")
+        #expect(ACPComposerControlPresentation.fastModeHelp(isEnabled: true, canToggle: true) == "Fast mode is ON — click to disable")
+        #expect(ACPComposerControlPresentation.fastModeHelp(isEnabled: false, canToggle: false) == "Fast mode cannot be changed")
     }
 
     @Test("cursor-agent: no brackets -> no synthesized chips")

--- a/AlasTests/ACP/Session/ACPChipStateTests.swift
+++ b/AlasTests/ACP/Session/ACPChipStateTests.swift
@@ -395,6 +395,29 @@ extension ACPChipStateTests {
         #expect(ACPComposerControlPresentation.fastModeHelp(isEnabled: false, canToggle: false) == "Fast mode cannot be changed")
     }
 
+    @Test("composer fast mode select toggles only when both directions are known")
+    func composerFastModeSelectToggleAvailability() {
+        let offOn = ChipSpec(
+            source: .configOption(id: "fast"),
+            options: [
+                ChipSpec.Item(id: "off", name: "Off", description: nil),
+                ChipSpec.Item(id: "fast", name: "Fast", description: nil),
+            ],
+            currentId: "off")
+        let normalFast = ChipSpec(
+            source: .configOption(id: "fast"),
+            options: [
+                ChipSpec.Item(id: "normal", name: "Normal", description: nil),
+                ChipSpec.Item(id: "fast", name: "Fast", description: nil),
+            ],
+            currentId: "fast")
+
+        #expect(ACPComposerControlPresentation.fastModeToggleTarget(for: offOn) == "fast")
+        #expect(ACPComposerControlPresentation.canRenderFastModeButton(for: offOn))
+        #expect(ACPComposerControlPresentation.fastModeToggleTarget(for: normalFast) == nil)
+        #expect(!ACPComposerControlPresentation.canRenderFastModeButton(for: normalFast))
+    }
+
     @Test("cursor-agent: no brackets -> no synthesized chips")
     func cursorNoBracketsNoOverlay() {
         let state = ACPChipState.normalize(


### PR DESCRIPTION
## Summary
- Render fast mode as a compact composer button instead of a generic chip or switch
- Use lightning for Fast mode and play for Auto-run
- Add hover help text and tests for fast-mode detection and control presentation

## Validation
- ALAS_FFF_TARGET_ARCH=arm64 xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS,arch=arm64' -only-testing:AlasTests/ACPChipStateTests test\n- ALAS_FFF_TARGET_ARCH=arm64 xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS,arch=arm64' -quiet build\n- git diff --check