### PR TITLE
feat(acp): Support ACP message IDs

### DIFF
--- a/Alas/Sources/ACP/Protocol/ACPSessionUpdate.swift
+++ b/Alas/Sources/ACP/Protocol/ACPSessionUpdate.swift
@@ -6,9 +6,9 @@ struct ACPSessionUpdateParams: Codable, Equatable {
 }
 
 enum ACPSessionUpdate: Codable, Equatable {
-    case userMessageChunk(ACPContentBlock)
-    case agentMessageChunk(ACPContentBlock)
-    case agentThoughtChunk(ACPContentBlock)
+    case userMessageChunk(ACPTextChunk)
+    case agentMessageChunk(ACPTextChunk)
+    case agentThoughtChunk(ACPTextChunk)
     case toolCall(ACPToolCallPayload)
     case toolCallUpdate(ACPToolCallUpdate)
     case plan([ACPPlanEntry])
@@ -20,6 +20,18 @@ enum ACPSessionUpdate: Codable, Equatable {
     case usageUpdate(ACPUsageInfo)
     case unknown(String)
 
+    static func userMessageChunk(_ content: ACPContentBlock) -> ACPSessionUpdate {
+        .userMessageChunk(.init(content: content))
+    }
+
+    static func agentMessageChunk(_ content: ACPContentBlock) -> ACPSessionUpdate {
+        .agentMessageChunk(.init(content: content))
+    }
+
+    static func agentThoughtChunk(_ content: ACPContentBlock) -> ACPSessionUpdate {
+        .agentThoughtChunk(.init(content: content))
+    }
+
     private enum Keys: String, CodingKey {
         case sessionUpdate, content, availableModels, modeId, modelId,
              entries, availableCommands, configOptions
@@ -29,9 +41,9 @@ enum ACPSessionUpdate: Codable, Equatable {
         let c = try decoder.container(keyedBy: Keys.self)
         let kind = try c.decode(String.self, forKey: .sessionUpdate)
         switch kind {
-        case "user_message_chunk":   self = .userMessageChunk(try c.decode(ACPContentBlock.self, forKey: .content))
-        case "agent_message_chunk":  self = .agentMessageChunk(try c.decode(ACPContentBlock.self, forKey: .content))
-        case "agent_thought_chunk":  self = .agentThoughtChunk(try c.decode(ACPContentBlock.self, forKey: .content))
+        case "user_message_chunk":   self = .userMessageChunk(try ACPTextChunk(from: decoder))
+        case "agent_message_chunk":  self = .agentMessageChunk(try ACPTextChunk(from: decoder))
+        case "agent_thought_chunk":  self = .agentThoughtChunk(try ACPTextChunk(from: decoder))
         case "tool_call":
             self = .toolCall(try ACPToolCallPayload(from: decoder))
         case "tool_call_update":
@@ -77,11 +89,11 @@ enum ACPSessionUpdate: Codable, Equatable {
         var c = encoder.container(keyedBy: Keys.self)
         switch self {
         case .userMessageChunk(let b):  try c.encode("user_message_chunk", forKey: .sessionUpdate)
-        try c.encode(b, forKey: .content)
+        try b.encodeFields(to: encoder)
         case .agentMessageChunk(let b): try c.encode("agent_message_chunk", forKey: .sessionUpdate)
-        try c.encode(b, forKey: .content)
+        try b.encodeFields(to: encoder)
         case .agentThoughtChunk(let b): try c.encode("agent_thought_chunk", forKey: .sessionUpdate)
-        try c.encode(b, forKey: .content)
+        try b.encodeFields(to: encoder)
         case .plan(let e):              try c.encode("plan", forKey: .sessionUpdate)
         try c.encode(e, forKey: .entries)
         case .availableModelsUpdate(let m): try c.encode("available_models_update", forKey: .sessionUpdate)
@@ -97,6 +109,26 @@ enum ACPSessionUpdate: Codable, Equatable {
         case .availableCommandsUpdate: break // not produced by us
         case .toolCall, .toolCallUpdate, .usageUpdate, .unknown: break
         }
+    }
+}
+
+struct ACPTextChunk: Codable, Equatable {
+    let messageId: String?
+    let content: ACPContentBlock
+
+    init(messageId: String? = nil, content: ACPContentBlock) {
+        self.messageId = messageId
+        self.content = content
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case messageId, content
+    }
+
+    func encodeFields(to encoder: Encoder) throws {
+        var c = encoder.container(keyedBy: CodingKeys.self)
+        try c.encodeIfPresent(messageId, forKey: .messageId)
+        try c.encode(content, forKey: .content)
     }
 }
 

--- a/Alas/Sources/ACP/Session/ACPMessage.swift
+++ b/Alas/Sources/ACP/Session/ACPMessage.swift
@@ -24,10 +24,11 @@ enum ACPMessage: Equatable {
     var stableId: String {
         switch self {
         case .user(let id, let messageId, _, _):
-            return messageId ?? id.uuidString
-        case .agent(let id, let messageId, _),
-             .thought(let id, let messageId, _):
-            return messageId ?? id.uuidString
+            return messageId.map { "acp-user:\($0)" } ?? id.uuidString
+        case .agent(let id, let messageId, _):
+            return messageId.map { "acp-agent:\($0)" } ?? id.uuidString
+        case .thought(let id, let messageId, _):
+            return messageId.map { "acp-thought:\($0)" } ?? id.uuidString
         case .fileEdit(let id, _),
              .plan(let id, _),
              .systemNotice(let id, _):

--- a/Alas/Sources/ACP/Session/ACPMessage.swift
+++ b/Alas/Sources/ACP/Session/ACPMessage.swift
@@ -1,20 +1,34 @@
 import Foundation
 
 enum ACPMessage: Equatable {
-    case user(id: UUID, text: String, attachments: [Attachment])
-    case agent(id: UUID, StreamingText)
-    case thought(id: UUID, StreamingText)
+    case user(id: UUID, messageId: String?, text: String, attachments: [Attachment])
+    case agent(id: UUID, messageId: String?, StreamingText)
+    case thought(id: UUID, messageId: String?, StreamingText)
     case toolCall(ToolCall)
     case fileEdit(id: UUID, FileEdit)
     case plan(id: UUID, [PlanItem])
     case systemNotice(id: UUID, text: String)
 
+    static func user(id: UUID, text: String, attachments: [Attachment]) -> ACPMessage {
+        .user(id: id, messageId: nil, text: text, attachments: attachments)
+    }
+
+    static func agent(id: UUID, _ text: StreamingText) -> ACPMessage {
+        .agent(id: id, messageId: nil, text)
+    }
+
+    static func thought(id: UUID, _ text: StreamingText) -> ACPMessage {
+        .thought(id: id, messageId: nil, text)
+    }
+
     var stableId: String {
         switch self {
-        case .user(let id, _, _),
-             .agent(let id, _),
-             .thought(let id, _),
-             .fileEdit(let id, _),
+        case .user(let id, let messageId, _, _):
+            return messageId ?? id.uuidString
+        case .agent(let id, let messageId, _),
+             .thought(let id, let messageId, _):
+            return messageId ?? id.uuidString
+        case .fileEdit(let id, _),
              .plan(let id, _),
              .systemNotice(let id, _):
             return id.uuidString
@@ -224,9 +238,9 @@ enum ACPMessageCodec {
     @MainActor
     static func encode(_ m: ACPMessage) throws -> Data {
         switch m {
-        case .user(_, let text, let atts): return try encoder.encode(UserPayload(text: text, attachments: atts))
-        case .agent(_, let buf):            return try encoder.encode(TextPayload(text: buf.value))
-        case .thought(_, let buf):          return try encoder.encode(TextPayload(text: buf.value))
+        case .user(_, let messageId, let text, let atts): return try encoder.encode(UserPayload(messageId: messageId, text: text, attachments: atts))
+        case .agent(_, let messageId, let buf):            return try encoder.encode(TextPayload(messageId: messageId, text: buf.value))
+        case .thought(_, let messageId, let buf):          return try encoder.encode(TextPayload(messageId: messageId, text: buf.value))
         case .toolCall(let tc):             return try encoder.encode(tc)
         case .fileEdit(_, let fe):          return try encoder.encode(fe)
         case .plan(_, let items):           return try encoder.encode(PlanPayload(items: items))
@@ -239,11 +253,13 @@ enum ACPMessageCodec {
         switch kind {
         case "user":
             let p = try JSONDecoder().decode(UserPayload.self, from: payload)
-            return .user(id: UUID(), text: p.text, attachments: p.attachments)
+            return .user(id: UUID(), messageId: p.messageId, text: p.text, attachments: p.attachments)
         case "agent":
-            return .agent(id: UUID(), StreamingText(try JSONDecoder().decode(TextPayload.self, from: payload).text))
+            let p = try JSONDecoder().decode(TextPayload.self, from: payload)
+            return .agent(id: UUID(), messageId: p.messageId, StreamingText(p.text))
         case "thought":
-            return .thought(id: UUID(), StreamingText(try JSONDecoder().decode(TextPayload.self, from: payload).text))
+            let p = try JSONDecoder().decode(TextPayload.self, from: payload)
+            return .thought(id: UUID(), messageId: p.messageId, StreamingText(p.text))
         case "tool_call":
             return .toolCall(try JSONDecoder().decode(ACPMessage.ToolCall.self, from: payload))
         case "file_edit":
@@ -257,8 +273,25 @@ enum ACPMessageCodec {
         }
     }
 
-    private struct TextPayload: Codable { let text: String }
-    private struct UserPayload: Codable { let text: String
-    let attachments: [ACPMessage.Attachment] }
+    private struct TextPayload: Codable {
+        let messageId: String?
+        let text: String
+
+        init(messageId: String? = nil, text: String) {
+            self.messageId = messageId
+            self.text = text
+        }
+    }
+    private struct UserPayload: Codable {
+        let messageId: String?
+        let text: String
+        let attachments: [ACPMessage.Attachment]
+
+        init(messageId: String? = nil, text: String, attachments: [ACPMessage.Attachment]) {
+            self.messageId = messageId
+            self.text = text
+            self.attachments = attachments
+        }
+    }
     private struct PlanPayload: Codable { let items: [ACPMessage.PlanItem] }
 }

--- a/Alas/Sources/ACP/Session/ACPMessageWire.swift
+++ b/Alas/Sources/ACP/Session/ACPMessageWire.swift
@@ -6,9 +6,9 @@ import Foundation
 /// converts each variant into a full `ACPMessage`, which is the only
 /// place we allocate `StreamingText` (a `@MainActor` class).
 enum ACPMessageWire: Sendable {
-    case user(text: String, attachments: [ACPMessage.Attachment])
-    case agent(text: String)
-    case thought(text: String)
+    case user(messageId: String?, text: String, attachments: [ACPMessage.Attachment])
+    case agent(messageId: String?, text: String)
+    case thought(messageId: String?, text: String)
     case toolCall(ACPMessage.ToolCall)
     case fileEdit(ACPMessage.FileEdit)
     case plan([ACPMessage.PlanItem])
@@ -30,11 +30,13 @@ enum ACPMessageWire: Sendable {
         switch kind {
         case "user":
             let p = try decoder.decode(UserPayload.self, from: payload)
-            return .user(text: p.text, attachments: p.attachments)
+            return .user(messageId: p.messageId, text: p.text, attachments: p.attachments)
         case "agent":
-            return .agent(text: try decoder.decode(TextPayload.self, from: payload).text)
+            let p = try decoder.decode(TextPayload.self, from: payload)
+            return .agent(messageId: p.messageId, text: p.text)
         case "thought":
-            return .thought(text: try decoder.decode(TextPayload.self, from: payload).text)
+            let p = try decoder.decode(TextPayload.self, from: payload)
+            return .thought(messageId: p.messageId, text: p.text)
         case "tool_call":
             return .toolCall(try decoder.decode(ACPMessage.ToolCall.self, from: payload))
         case "file_edit":
@@ -53,12 +55,12 @@ enum ACPMessageWire: Sendable {
     @MainActor
     func toMessage() -> ACPMessage {
         switch self {
-        case .user(let text, let attachments):
-            return .user(id: UUID(), text: text, attachments: attachments)
-        case .agent(let text):
-            return .agent(id: UUID(), StreamingText(text))
-        case .thought(let text):
-            return .thought(id: UUID(), StreamingText(text))
+        case .user(let messageId, let text, let attachments):
+            return .user(id: UUID(), messageId: messageId, text: text, attachments: attachments)
+        case .agent(let messageId, let text):
+            return .agent(id: UUID(), messageId: messageId, StreamingText(text))
+        case .thought(let messageId, let text):
+            return .thought(id: UUID(), messageId: messageId, StreamingText(text))
         case .toolCall(let tc):
             return .toolCall(tc)
         case .fileEdit(let fe):
@@ -70,8 +72,12 @@ enum ACPMessageWire: Sendable {
         }
     }
 
-    private struct TextPayload: Decodable { let text: String }
+    private struct TextPayload: Decodable {
+        let messageId: String?
+        let text: String
+    }
     private struct UserPayload: Decodable {
+        let messageId: String?
         let text: String
         let attachments: [ACPMessage.Attachment]
     }

--- a/Alas/Sources/ACP/Session/ACPSession.swift
+++ b/Alas/Sources/ACP/Session/ACPSession.swift
@@ -919,7 +919,8 @@ final class ACPSession: ObservableObject, Identifiable {
         guard !text.isEmpty || !attachments.isEmpty else { return nil }
         return transcript.messages.indices.reversed().first { index in
             if case .user(let id, let messageId, let existing, let existingAttachments) = transcript.messages[index] {
-                guard messageId == nil else { return false }
+                guard messageId == nil,
+                      !legacyUserChunkMessageIds.contains(id) else { return false }
                 if !text.isEmpty {
                     return existing.hasPrefix(text)
                         || (reconciledLegacyLocalUserPromptIds.contains(id) && existing.contains(text))

--- a/Alas/Sources/ACP/Session/ACPSession.swift
+++ b/Alas/Sources/ACP/Session/ACPSession.swift
@@ -809,6 +809,10 @@ final class ACPSession: ObservableObject, Identifiable {
         if let i = located,
            case .user(let id, let existingMessageId, let text, let attachments) = transcript.messages[i] {
             let mergedAttachments = Self.mergingAttachments(attachments, newAttachments)
+            let mergedText = text + Self.streamingSeparator(between: text, and: addition) + addition
+            if text == mergedText && attachments == mergedAttachments {
+                return i
+            }
             let isLiveUserChunk = existingMessageId.map {
                 liveUserChunkMessageIds.contains($0)
             } == true
@@ -831,7 +835,7 @@ final class ACPSession: ObservableObject, Identifiable {
             transcript.messages[i] = .user(
                 id: id,
                 messageId: existingMessageId,
-                text: text + Self.streamingSeparator(between: text, and: addition) + addition,
+                text: mergedText,
                 attachments: mergedAttachments)
             if let existingMessageId {
                 liveUserChunkMessageIds.insert(existingMessageId)
@@ -980,7 +984,9 @@ final class ACPSession: ObservableObject, Identifiable {
         if let i = located {
             let stableId = transcript.messages[i].stableId
             let crossesCompletedBoundary = transcript.completedOutputBoundaryMessageIds.contains(stableId)
-            if messageId != nil, !allowsStreamingBoundaryCrossing {
+            if messageId != nil,
+               !allowsStreamingBoundaryCrossing,
+               (crossesCompletedBoundary || hasUserAfterMessage(at: i)) {
                 return i
             }
             if crossesCompletedBoundary {
@@ -1008,6 +1014,19 @@ final class ACPSession: ObservableObject, Identifiable {
         didAppendTranscriptMessage()
         return transcript.messages.count - 1
     }
+
+    private func hasUserAfterMessage(at index: Int) -> Bool {
+        guard transcript.messages.indices.contains(index), index < transcript.messages.index(before: transcript.messages.endIndex) else {
+            return false
+        }
+        return transcript.messages[(index + 1)...].contains { message in
+            if case .user = message {
+                return true
+            }
+            return false
+        }
+    }
+
     /// Returns the separator (if any) to insert between two streaming
     /// chunks before appending `next` to `previous`. Adapters sometimes
     /// split their stream at a sentence boundary and drop the trailing

--- a/Alas/Sources/ACP/Session/ACPSession.swift
+++ b/Alas/Sources/ACP/Session/ACPSession.swift
@@ -815,14 +815,7 @@ final class ACPSession: ObservableObject, Identifiable {
             return i
         }
 
-        guard !addition.isEmpty else {
-            transcript.messages.append(.user(id: UUID(), messageId: messageId, text: addition, attachments: newAttachments))
-            didAppendTranscriptMessage()
-            transcript.completedOutputBoundaryMessageIds.removeAll()
-            return transcript.messages.count - 1
-        }
-
-        if let i = lastEchoedLocalUserPromptIndex(matching: addition),
+        if let i = lastEchoedLocalUserPromptIndex(matching: addition, attachments: newAttachments),
            case .user(let id, let existingMessageId, let text, let attachments) = transcript.messages[i] {
             if existingMessageId == nil {
                 if let messageId {
@@ -840,6 +833,13 @@ final class ACPSession: ObservableObject, Identifiable {
             return i
         }
 
+        guard !addition.isEmpty else {
+            transcript.messages.append(.user(id: UUID(), messageId: messageId, text: addition, attachments: newAttachments))
+            didAppendTranscriptMessage()
+            transcript.completedOutputBoundaryMessageIds.removeAll()
+            return transcript.messages.count - 1
+        }
+
         transcript.messages.append(.user(id: UUID(), messageId: messageId, text: addition, attachments: newAttachments))
         didAppendTranscriptMessage()
         transcript.completedOutputBoundaryMessageIds.removeAll()
@@ -855,13 +855,16 @@ final class ACPSession: ObservableObject, Identifiable {
         }
     }
 
-    private func lastEchoedLocalUserPromptIndex(matching text: String) -> Int? {
-        guard !text.isEmpty else { return nil }
+    private func lastEchoedLocalUserPromptIndex(matching text: String, attachments: [ACPMessage.Attachment]) -> Int? {
+        guard !text.isEmpty || !attachments.isEmpty else { return nil }
         return transcript.messages.indices.reversed().first { index in
-            if case .user(let id, let messageId, let existing, _) = transcript.messages[index] {
-                return messageId == nil
-                    && (existing.hasPrefix(text)
-                        || (reconciledLegacyLocalUserPromptIds.contains(id) && existing.contains(text)))
+            if case .user(let id, let messageId, let existing, let existingAttachments) = transcript.messages[index] {
+                guard messageId == nil else { return false }
+                if !text.isEmpty {
+                    return existing.hasPrefix(text)
+                        || (reconciledLegacyLocalUserPromptIds.contains(id) && existing.contains(text))
+                }
+                return attachments.allSatisfy { existingAttachments.contains($0) }
             }
             return false
         }

--- a/Alas/Sources/ACP/Session/ACPSession.swift
+++ b/Alas/Sources/ACP/Session/ACPSession.swift
@@ -798,7 +798,7 @@ final class ACPSession: ObservableObject, Identifiable {
         let located = messageId.flatMap { messageIndex(messageId: $0, kind: .user) }
         if let i = located,
            case .user(let id, let existingMessageId, let text, let attachments) = transcript.messages[i] {
-            let mergedAttachments = attachments + newAttachments
+            let mergedAttachments = Self.mergingAttachments(attachments, newAttachments)
             let isReconciledEchoChunk = existingMessageId.map {
                 !addition.isEmpty && reconciledLocalUserPromptMessageIds.contains($0) && text.contains(addition)
             } == true && newAttachments.isEmpty
@@ -830,7 +830,7 @@ final class ACPSession: ObservableObject, Identifiable {
                         id: id,
                         messageId: messageId,
                         text: text,
-                        attachments: attachments + newAttachments)
+                        attachments: Self.mergingAttachments(attachments, newAttachments))
                     reconciledLocalUserPromptMessageIds.insert(messageId)
                     transcript.streamingTick &+= 1
                 } else {
@@ -844,6 +844,15 @@ final class ACPSession: ObservableObject, Identifiable {
         didAppendTranscriptMessage()
         transcript.completedOutputBoundaryMessageIds.removeAll()
         return transcript.messages.count - 1
+    }
+
+    private static func mergingAttachments(_ existing: [ACPMessage.Attachment],
+                                           _ additions: [ACPMessage.Attachment]) -> [ACPMessage.Attachment] {
+        additions.reduce(into: existing) { result, attachment in
+            if !result.contains(attachment) {
+                result.append(attachment)
+            }
+        }
     }
 
     private func lastEchoedLocalUserPromptIndex(matching text: String) -> Int? {

--- a/Alas/Sources/ACP/Session/ACPSession.swift
+++ b/Alas/Sources/ACP/Session/ACPSession.swift
@@ -157,9 +157,9 @@ final class ACPSession: ObservableObject, Identifiable {
     var hasConversationTranscript: Bool {
         transcript.messages.contains { message in
             switch message {
-            case .user(_, let text, _):
+            case .user(_, _, let text, _):
                 return !text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
-            case .agent(_, let buffer):
+            case .agent(_, _, let buffer):
                 return !buffer.value.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
             default:
                 return false
@@ -218,7 +218,7 @@ final class ACPSession: ObservableObject, Identifiable {
     }
 
     func recordUserPrompt(text: String, attachments: [ACPMessage.Attachment]) {
-        transcript.messages.append(.user(id: UUID(), text: text, attachments: attachments))
+        transcript.messages.append(.user(id: UUID(), messageId: nil, text: text, attachments: attachments))
         didAppendTranscriptMessage()
         transcript.completedOutputBoundaryMessageIds.removeAll()
         if titleSource == .placeholder {
@@ -244,23 +244,29 @@ final class ACPSession: ObservableObject, Identifiable {
     @discardableResult
     func apply(_ update: ACPSessionUpdate) -> Set<Int> {
         switch update {
-        case .agentMessageChunk(let block):
+        case .agentMessageChunk(let chunk):
             clearRestoredContextRecoveryStatus()
-            let txt = text(of: block)
-            let i = appendStreaming(text: txt, locate: { lastAgent() },
-                                    makeNew: { .agent(id: UUID(), StreamingText(txt)) })
+            let txt = text(of: chunk.content)
+            let i = appendStreaming(
+                text: txt,
+                messageId: chunk.messageId,
+                locateByMessageId: { id in messageIndex(messageId: id, kind: .agent) },
+                locateLegacy: { lastAgent() },
+                makeNew: { .agent(id: UUID(), messageId: chunk.messageId, StreamingText(txt)) })
             return [i]
-        case .userMessageChunk(let block):
-            // Agents rarely emit these; treat as informational.
-            transcript.messages.append(.systemNotice(id: UUID(), text: text(of: block)))
-            didAppendTranscriptMessage()
-            transcript.completedOutputBoundaryMessageIds.removeAll()
-            return [transcript.messages.count - 1]
-        case .agentThoughtChunk(let block):
+        case .userMessageChunk(let chunk):
+            let txt = text(of: chunk.content)
+            let i = appendUserChunk(text: txt, messageId: chunk.messageId)
+            return [i]
+        case .agentThoughtChunk(let chunk):
             clearRestoredContextRecoveryStatus()
-            let txt = text(of: block)
-            let i = appendStreaming(text: txt, locate: { lastThought() },
-                                    makeNew: { .thought(id: UUID(), StreamingText(txt)) })
+            let txt = text(of: chunk.content)
+            let i = appendStreaming(
+                text: txt,
+                messageId: chunk.messageId,
+                locateByMessageId: { id in messageIndex(messageId: id, kind: .thought) },
+                locateLegacy: { lastThought() },
+                makeNew: { .thought(id: UUID(), messageId: chunk.messageId, StreamingText(txt)) })
             return [i]
         case .toolCall(let payload):
             clearRestoredContextRecoveryStatus()
@@ -762,11 +768,57 @@ final class ACPSession: ObservableObject, Identifiable {
         }
         return nil
     }
+
+    private enum TextMessageKind {
+        case user
+        case agent
+        case thought
+    }
+
+    private func messageIndex(messageId: String, kind: TextMessageKind) -> Int? {
+        transcript.messages.firstIndex { message in
+            switch (kind, message) {
+            case (.user, .user(_, let existing, _, _)),
+                 (.agent, .agent(_, let existing, _)),
+                 (.thought, .thought(_, let existing, _)):
+                return existing == messageId
+            default:
+                return false
+            }
+        }
+    }
+
+    private func appendUserChunk(text addition: String, messageId: String?) -> Int {
+        let located = messageId.flatMap { messageIndex(messageId: $0, kind: .user) }
+        if let i = located,
+           case .user(let id, let existingMessageId, let text, let attachments) = transcript.messages[i] {
+            transcript.messages[i] = .user(
+                id: id,
+                messageId: existingMessageId,
+                text: text + Self.streamingSeparator(between: text, and: addition) + addition,
+                attachments: attachments)
+            transcript.streamingTick &+= 1
+            return i
+        }
+
+        transcript.messages.append(.user(id: UUID(), messageId: messageId, text: addition, attachments: []))
+        didAppendTranscriptMessage()
+        transcript.completedOutputBoundaryMessageIds.removeAll()
+        return transcript.messages.count - 1
+    }
+
     /// Returns the index of the message that was appended or mutated.
     private func appendStreaming(text addition: String,
-                                locate: () -> Int?,
+                                messageId: String?,
+                                locateByMessageId: (String) -> Int?,
+                                locateLegacy: () -> Int?,
                                 makeNew: () -> ACPMessage) -> Int {
-        if let i = locate() {
+        let located = if let messageId {
+            locateByMessageId(messageId)
+        } else {
+            locateLegacy()
+        }
+        if let i = located {
             let stableId = transcript.messages[i].stableId
             if transcript.completedOutputBoundaryMessageIds.contains(stableId) {
                 // Discard if boundary crossings are not allowed — this chunk
@@ -776,7 +828,7 @@ final class ACPSession: ObservableObject, Identifiable {
                 transcript.completedOutputBoundaryMessageIds.remove(stableId)
             } else {
                 switch transcript.messages[i] {
-                case .agent(_, let buf), .thought(_, let buf):
+                case .agent(_, _, let buf), .thought(_, _, let buf):
                     buf.append(Self.streamingSeparator(between: buf.value, and: addition) + addition)
                     transcript.streamingTick &+= 1
                     return i

--- a/Alas/Sources/ACP/Session/ACPSession.swift
+++ b/Alas/Sources/ACP/Session/ACPSession.swift
@@ -885,7 +885,8 @@ final class ACPSession: ObservableObject, Identifiable {
             return nil
         }
 
-        guard !addition.isEmpty else {
+        if addition.isEmpty {
+            guard !newAttachments.isEmpty else { return nil }
             let id = UUID()
             transcript.messages.append(.user(id: id, messageId: messageId, text: addition, attachments: newAttachments))
             if let messageId {

--- a/Alas/Sources/ACP/Session/ACPSession.swift
+++ b/Alas/Sources/ACP/Session/ACPSession.swift
@@ -257,6 +257,7 @@ final class ACPSession: ObservableObject, Identifiable {
                 messageId: chunk.messageId,
                 locateByMessageId: { id in messageIndex(messageId: id, kind: .agent) },
                 locateLegacy: { lastAgent() },
+                isLikelyReplay: { text in messageExists(kind: .agent, containing: text) },
                 makeNew: { .agent(id: UUID(), messageId: chunk.messageId, StreamingText(txt)) }) else {
                 return []
             }
@@ -278,6 +279,7 @@ final class ACPSession: ObservableObject, Identifiable {
                 messageId: chunk.messageId,
                 locateByMessageId: { id in messageIndex(messageId: id, kind: .thought) },
                 locateLegacy: { lastThought() },
+                isLikelyReplay: { text in messageExists(kind: .thought, containing: text) },
                 makeNew: { .thought(id: UUID(), messageId: chunk.messageId, StreamingText(txt)) }) else {
                 return []
             }
@@ -873,7 +875,9 @@ final class ACPSession: ObservableObject, Identifiable {
             return i
         }
 
-        if messageId != nil, !allowsStreamingBoundaryCrossing {
+        if messageId != nil,
+           !allowsStreamingBoundaryCrossing,
+           userMessageExists(containing: addition, attachments: newAttachments) {
             return nil
         }
 
@@ -937,11 +941,36 @@ final class ACPSession: ObservableObject, Identifiable {
         }
     }
 
+    private func messageExists(kind: TextMessageKind, containing text: String) -> Bool {
+        guard !text.isEmpty else { return false }
+        return transcript.messages.contains { message in
+            switch (kind, message) {
+            case (.agent, .agent(_, _, let existing)),
+                 (.thought, .thought(_, _, let existing)):
+                return existing.value.contains(text)
+            default:
+                return false
+            }
+        }
+    }
+
+    private func userMessageExists(containing text: String, attachments: [ACPMessage.Attachment]) -> Bool {
+        guard !text.isEmpty || !attachments.isEmpty else { return false }
+        return transcript.messages.contains { message in
+            guard case .user(_, _, let existing, let existingAttachments) = message else { return false }
+            if !text.isEmpty, existing.contains(text) {
+                return true
+            }
+            return !attachments.isEmpty && attachments.allSatisfy { existingAttachments.contains($0) }
+        }
+    }
+
     /// Returns the index of the message that was appended or mutated.
     private func appendStreaming(text addition: String,
                                  messageId: String?,
                                  locateByMessageId: (String) -> Int?,
                                  locateLegacy: () -> Int?,
+                                 isLikelyReplay: (String) -> Bool,
                                  makeNew: () -> ACPMessage) -> Int? {
         let located = if let messageId {
             locateByMessageId(messageId)
@@ -972,7 +1001,7 @@ final class ACPSession: ObservableObject, Identifiable {
                 }
             }
         }
-        if messageId != nil, !allowsStreamingBoundaryCrossing {
+        if messageId != nil, !allowsStreamingBoundaryCrossing, isLikelyReplay(addition) {
             return nil
         }
         transcript.messages.append(makeNew())

--- a/Alas/Sources/ACP/Session/ACPSession.swift
+++ b/Alas/Sources/ACP/Session/ACPSession.swift
@@ -263,10 +263,12 @@ final class ACPSession: ObservableObject, Identifiable {
             return [i]
         case .userMessageChunk(let chunk):
             let txt = text(of: chunk.content)
-            let i = appendUserChunk(
+            guard let i = appendUserChunk(
                 text: txt,
                 attachments: ACPSessionRunner.attachments(of: [chunk.content]),
-                messageId: chunk.messageId)
+                messageId: chunk.messageId) else {
+                return []
+            }
             return [i]
         case .agentThoughtChunk(let chunk):
             clearRestoredContextRecoveryStatus()
@@ -800,7 +802,7 @@ final class ACPSession: ObservableObject, Identifiable {
         }
     }
 
-    private func appendUserChunk(text addition: String, attachments newAttachments: [ACPMessage.Attachment], messageId: String?) -> Int {
+    private func appendUserChunk(text addition: String, attachments newAttachments: [ACPMessage.Attachment], messageId: String?) -> Int? {
         let located = messageId.flatMap { messageIndex(messageId: $0, kind: .user) }
         if let i = located,
            case .user(let id, let existingMessageId, let text, let attachments) = transcript.messages[i] {
@@ -869,6 +871,10 @@ final class ACPSession: ObservableObject, Identifiable {
                 attachments: mergedAttachments)
             transcript.streamingTick &+= 1
             return i
+        }
+
+        if messageId != nil, !allowsStreamingBoundaryCrossing {
+            return nil
         }
 
         guard !addition.isEmpty else {

--- a/Alas/Sources/ACP/Session/ACPSession.swift
+++ b/Alas/Sources/ACP/Session/ACPSession.swift
@@ -94,6 +94,8 @@ final class ACPSession: ObservableObject, Identifiable {
     /// check is never reached).
     var allowsStreamingBoundaryCrossing: Bool = true
 
+    private var reconciledLocalUserPromptMessageIds: Set<String> = []
+
     /// Runtime-only marker for a forced queue item parked behind the current
     /// `.sending` head. If that head fails, it moves behind this item so the
     /// explicit force-send remains next.
@@ -792,7 +794,11 @@ final class ACPSession: ObservableObject, Identifiable {
         let located = messageId.flatMap { messageIndex(messageId: $0, kind: .user) }
         if let i = located,
            case .user(let id, let existingMessageId, let text, let attachments) = transcript.messages[i] {
-            if text == addition {
+            let isReconciledEchoChunk = existingMessageId.map {
+                reconciledLocalUserPromptMessageIds.contains($0) && text.contains(addition)
+            } == true
+            if text == addition
+                || isReconciledEchoChunk {
                 return i
             }
             transcript.messages[i] = .user(
@@ -806,12 +812,13 @@ final class ACPSession: ObservableObject, Identifiable {
 
         if let i = lastEchoedLocalUserPromptIndex(matching: addition),
            case .user(let id, let existingMessageId, let text, let attachments) = transcript.messages[i] {
-            if existingMessageId == nil, messageId != nil {
+            if existingMessageId == nil, let messageId {
                 transcript.messages[i] = .user(
                     id: id,
                     messageId: messageId,
                     text: text,
                     attachments: attachments)
+                reconciledLocalUserPromptMessageIds.insert(messageId)
                 transcript.streamingTick &+= 1
             }
             return i
@@ -826,7 +833,7 @@ final class ACPSession: ObservableObject, Identifiable {
     private func lastEchoedLocalUserPromptIndex(matching text: String) -> Int? {
         transcript.messages.indices.reversed().first { index in
             if case .user(_, let messageId, let existing, _) = transcript.messages[index] {
-                return messageId == nil && existing == text
+                return messageId == nil && existing.hasPrefix(text)
             }
             return false
         }

--- a/Alas/Sources/ACP/Session/ACPSession.swift
+++ b/Alas/Sources/ACP/Session/ACPSession.swift
@@ -792,6 +792,9 @@ final class ACPSession: ObservableObject, Identifiable {
         let located = messageId.flatMap { messageIndex(messageId: $0, kind: .user) }
         if let i = located,
            case .user(let id, let existingMessageId, let text, let attachments) = transcript.messages[i] {
+            if text == addition {
+                return i
+            }
             transcript.messages[i] = .user(
                 id: id,
                 messageId: existingMessageId,
@@ -801,10 +804,32 @@ final class ACPSession: ObservableObject, Identifiable {
             return i
         }
 
+        if let i = lastEchoedLocalUserPromptIndex(matching: addition),
+           case .user(let id, let existingMessageId, let text, let attachments) = transcript.messages[i] {
+            if existingMessageId == nil, messageId != nil {
+                transcript.messages[i] = .user(
+                    id: id,
+                    messageId: messageId,
+                    text: text,
+                    attachments: attachments)
+                transcript.streamingTick &+= 1
+            }
+            return i
+        }
+
         transcript.messages.append(.user(id: UUID(), messageId: messageId, text: addition, attachments: []))
         didAppendTranscriptMessage()
         transcript.completedOutputBoundaryMessageIds.removeAll()
         return transcript.messages.count - 1
+    }
+
+    private func lastEchoedLocalUserPromptIndex(matching text: String) -> Int? {
+        transcript.messages.indices.reversed().first { index in
+            if case .user(_, let messageId, let existing, _) = transcript.messages[index] {
+                return messageId == nil && existing == text
+            }
+            return false
+        }
     }
 
     /// Returns the index of the message that was appended or mutated.

--- a/Alas/Sources/ACP/Session/ACPSession.swift
+++ b/Alas/Sources/ACP/Session/ACPSession.swift
@@ -940,6 +940,9 @@ final class ACPSession: ObservableObject, Identifiable {
         if let i = located {
             let stableId = transcript.messages[i].stableId
             let crossesCompletedBoundary = transcript.completedOutputBoundaryMessageIds.contains(stableId)
+            if messageId != nil, !allowsStreamingBoundaryCrossing {
+                return i
+            }
             if crossesCompletedBoundary {
                 // Discard if boundary crossings are not allowed — this chunk
                 // is a late replay frame arriving after load-replay suppression

--- a/Alas/Sources/ACP/Session/ACPSession.swift
+++ b/Alas/Sources/ACP/Session/ACPSession.swift
@@ -259,7 +259,10 @@ final class ACPSession: ObservableObject, Identifiable {
             return [i]
         case .userMessageChunk(let chunk):
             let txt = text(of: chunk.content)
-            let i = appendUserChunk(text: txt, messageId: chunk.messageId)
+            let i = appendUserChunk(
+                text: txt,
+                attachments: ACPSessionRunner.attachments(of: [chunk.content]),
+                messageId: chunk.messageId)
             return [i]
         case .agentThoughtChunk(let chunk):
             clearRestoredContextRecoveryStatus()
@@ -791,14 +794,15 @@ final class ACPSession: ObservableObject, Identifiable {
         }
     }
 
-    private func appendUserChunk(text addition: String, messageId: String?) -> Int {
+    private func appendUserChunk(text addition: String, attachments newAttachments: [ACPMessage.Attachment], messageId: String?) -> Int {
         let located = messageId.flatMap { messageIndex(messageId: $0, kind: .user) }
         if let i = located,
            case .user(let id, let existingMessageId, let text, let attachments) = transcript.messages[i] {
+            let mergedAttachments = attachments + newAttachments
             let isReconciledEchoChunk = existingMessageId.map {
-                reconciledLocalUserPromptMessageIds.contains($0) && text.contains(addition)
-            } == true
-            if text == addition
+                !addition.isEmpty && reconciledLocalUserPromptMessageIds.contains($0) && text.contains(addition)
+            } == true && newAttachments.isEmpty
+            if (text == addition && attachments == mergedAttachments)
                 || isReconciledEchoChunk {
                 return i
             }
@@ -806,9 +810,16 @@ final class ACPSession: ObservableObject, Identifiable {
                 id: id,
                 messageId: existingMessageId,
                 text: text + Self.streamingSeparator(between: text, and: addition) + addition,
-                attachments: attachments)
+                attachments: mergedAttachments)
             transcript.streamingTick &+= 1
             return i
+        }
+
+        guard !addition.isEmpty else {
+            transcript.messages.append(.user(id: UUID(), messageId: messageId, text: addition, attachments: newAttachments))
+            didAppendTranscriptMessage()
+            transcript.completedOutputBoundaryMessageIds.removeAll()
+            return transcript.messages.count - 1
         }
 
         if let i = lastEchoedLocalUserPromptIndex(matching: addition),
@@ -819,7 +830,7 @@ final class ACPSession: ObservableObject, Identifiable {
                         id: id,
                         messageId: messageId,
                         text: text,
-                        attachments: attachments)
+                        attachments: attachments + newAttachments)
                     reconciledLocalUserPromptMessageIds.insert(messageId)
                     transcript.streamingTick &+= 1
                 } else {
@@ -829,14 +840,15 @@ final class ACPSession: ObservableObject, Identifiable {
             return i
         }
 
-        transcript.messages.append(.user(id: UUID(), messageId: messageId, text: addition, attachments: []))
+        transcript.messages.append(.user(id: UUID(), messageId: messageId, text: addition, attachments: newAttachments))
         didAppendTranscriptMessage()
         transcript.completedOutputBoundaryMessageIds.removeAll()
         return transcript.messages.count - 1
     }
 
     private func lastEchoedLocalUserPromptIndex(matching text: String) -> Int? {
-        transcript.messages.indices.reversed().first { index in
+        guard !text.isEmpty else { return nil }
+        return transcript.messages.indices.reversed().first { index in
             if case .user(let id, let messageId, let existing, _) = transcript.messages[index] {
                 return messageId == nil
                     && (existing.hasPrefix(text)

--- a/Alas/Sources/ACP/Session/ACPSession.swift
+++ b/Alas/Sources/ACP/Session/ACPSession.swift
@@ -252,12 +252,14 @@ final class ACPSession: ObservableObject, Identifiable {
         case .agentMessageChunk(let chunk):
             clearRestoredContextRecoveryStatus()
             let txt = text(of: chunk.content)
-            let i = appendStreaming(
+            guard let i = appendStreaming(
                 text: txt,
                 messageId: chunk.messageId,
                 locateByMessageId: { id in messageIndex(messageId: id, kind: .agent) },
                 locateLegacy: { lastAgent() },
-                makeNew: { .agent(id: UUID(), messageId: chunk.messageId, StreamingText(txt)) })
+                makeNew: { .agent(id: UUID(), messageId: chunk.messageId, StreamingText(txt)) }) else {
+                return []
+            }
             return [i]
         case .userMessageChunk(let chunk):
             let txt = text(of: chunk.content)
@@ -269,12 +271,14 @@ final class ACPSession: ObservableObject, Identifiable {
         case .agentThoughtChunk(let chunk):
             clearRestoredContextRecoveryStatus()
             let txt = text(of: chunk.content)
-            let i = appendStreaming(
+            guard let i = appendStreaming(
                 text: txt,
                 messageId: chunk.messageId,
                 locateByMessageId: { id in messageIndex(messageId: id, kind: .thought) },
                 locateLegacy: { lastThought() },
-                makeNew: { .thought(id: UUID(), messageId: chunk.messageId, StreamingText(txt)) })
+                makeNew: { .thought(id: UUID(), messageId: chunk.messageId, StreamingText(txt)) }) else {
+                return []
+            }
             return [i]
         case .toolCall(let payload):
             clearRestoredContextRecoveryStatus()
@@ -928,10 +932,10 @@ final class ACPSession: ObservableObject, Identifiable {
 
     /// Returns the index of the message that was appended or mutated.
     private func appendStreaming(text addition: String,
-                                messageId: String?,
-                                locateByMessageId: (String) -> Int?,
-                                locateLegacy: () -> Int?,
-                                makeNew: () -> ACPMessage) -> Int {
+                                 messageId: String?,
+                                 locateByMessageId: (String) -> Int?,
+                                 locateLegacy: () -> Int?,
+                                 makeNew: () -> ACPMessage) -> Int? {
         let located = if let messageId {
             locateByMessageId(messageId)
         } else {
@@ -960,6 +964,9 @@ final class ACPSession: ObservableObject, Identifiable {
                     break
                 }
             }
+        }
+        if messageId != nil, !allowsStreamingBoundaryCrossing {
+            return nil
         }
         transcript.messages.append(makeNew())
         didAppendTranscriptMessage()

--- a/Alas/Sources/ACP/Session/ACPSession.swift
+++ b/Alas/Sources/ACP/Session/ACPSession.swift
@@ -800,7 +800,9 @@ final class ACPSession: ObservableObject, Identifiable {
            case .user(let id, let existingMessageId, let text, let attachments) = transcript.messages[i] {
             let mergedAttachments = Self.mergingAttachments(attachments, newAttachments)
             let isReconciledEchoChunk = existingMessageId.map {
-                !addition.isEmpty && reconciledLocalUserPromptMessageIds.contains($0) && text.contains(addition)
+                !addition.isEmpty
+                    && text.contains(addition)
+                    && (reconciledLocalUserPromptMessageIds.contains($0) || text != addition)
             } == true && newAttachments.isEmpty
             if (text == addition && attachments == mergedAttachments)
                 || isReconciledEchoChunk {

--- a/Alas/Sources/ACP/Session/ACPSession.swift
+++ b/Alas/Sources/ACP/Session/ACPSession.swift
@@ -95,6 +95,7 @@ final class ACPSession: ObservableObject, Identifiable {
     var allowsStreamingBoundaryCrossing: Bool = true
 
     private var reconciledLocalUserPromptMessageIds: Set<String> = []
+    private var reconciledLegacyLocalUserPromptIds: Set<UUID> = []
 
     /// Runtime-only marker for a forced queue item parked behind the current
     /// `.sending` head. If that head fails, it moves behind this item so the
@@ -812,14 +813,18 @@ final class ACPSession: ObservableObject, Identifiable {
 
         if let i = lastEchoedLocalUserPromptIndex(matching: addition),
            case .user(let id, let existingMessageId, let text, let attachments) = transcript.messages[i] {
-            if existingMessageId == nil, let messageId {
-                transcript.messages[i] = .user(
-                    id: id,
-                    messageId: messageId,
-                    text: text,
-                    attachments: attachments)
-                reconciledLocalUserPromptMessageIds.insert(messageId)
-                transcript.streamingTick &+= 1
+            if existingMessageId == nil {
+                if let messageId {
+                    transcript.messages[i] = .user(
+                        id: id,
+                        messageId: messageId,
+                        text: text,
+                        attachments: attachments)
+                    reconciledLocalUserPromptMessageIds.insert(messageId)
+                    transcript.streamingTick &+= 1
+                } else {
+                    reconciledLegacyLocalUserPromptIds.insert(id)
+                }
             }
             return i
         }
@@ -832,8 +837,10 @@ final class ACPSession: ObservableObject, Identifiable {
 
     private func lastEchoedLocalUserPromptIndex(matching text: String) -> Int? {
         transcript.messages.indices.reversed().first { index in
-            if case .user(_, let messageId, let existing, _) = transcript.messages[index] {
-                return messageId == nil && existing.hasPrefix(text)
+            if case .user(let id, let messageId, let existing, _) = transcript.messages[index] {
+                return messageId == nil
+                    && (existing.hasPrefix(text)
+                        || (reconciledLegacyLocalUserPromptIds.contains(id) && existing.contains(text)))
             }
             return false
         }
@@ -852,13 +859,15 @@ final class ACPSession: ObservableObject, Identifiable {
         }
         if let i = located {
             let stableId = transcript.messages[i].stableId
-            if transcript.completedOutputBoundaryMessageIds.contains(stableId) {
+            let crossesCompletedBoundary = transcript.completedOutputBoundaryMessageIds.contains(stableId)
+            if crossesCompletedBoundary {
                 // Discard if boundary crossings are not allowed — this chunk
                 // is a late replay frame arriving after load-replay suppression
                 // ended. Return the existing message index without mutating.
                 guard allowsStreamingBoundaryCrossing else { return i }
                 transcript.completedOutputBoundaryMessageIds.remove(stableId)
-            } else {
+            }
+            if !crossesCompletedBoundary || messageId != nil {
                 switch transcript.messages[i] {
                 case .agent(_, _, let buf), .thought(_, _, let buf):
                     buf.append(Self.streamingSeparator(between: buf.value, and: addition) + addition)

--- a/Alas/Sources/ACP/Session/ACPSession.swift
+++ b/Alas/Sources/ACP/Session/ACPSession.swift
@@ -96,6 +96,7 @@ final class ACPSession: ObservableObject, Identifiable {
 
     private var reconciledLocalUserPromptMessageIds: Set<String> = []
     private var reconciledLegacyLocalUserPromptIds: Set<UUID> = []
+    private var legacyUserChunkMessageIds: Set<UUID> = []
 
     /// Runtime-only marker for a forced queue item parked behind the current
     /// `.sending` head. If that head fails, it moves behind this item so the
@@ -835,14 +836,39 @@ final class ACPSession: ObservableObject, Identifiable {
             return i
         }
 
+        if messageId == nil,
+           let i = lastLegacyUserChunkIndex(),
+           case .user(let id, let existingMessageId, let text, let attachments) = transcript.messages[i] {
+            let mergedText = text + Self.streamingSeparator(between: text, and: addition) + addition
+            let mergedAttachments = Self.mergingAttachments(attachments, newAttachments)
+            if text == mergedText && attachments == mergedAttachments {
+                return i
+            }
+            transcript.messages[i] = .user(
+                id: id,
+                messageId: existingMessageId,
+                text: mergedText,
+                attachments: mergedAttachments)
+            transcript.streamingTick &+= 1
+            return i
+        }
+
         guard !addition.isEmpty else {
-            transcript.messages.append(.user(id: UUID(), messageId: messageId, text: addition, attachments: newAttachments))
+            let id = UUID()
+            transcript.messages.append(.user(id: id, messageId: messageId, text: addition, attachments: newAttachments))
+            if messageId == nil {
+                legacyUserChunkMessageIds.insert(id)
+            }
             didAppendTranscriptMessage()
             transcript.completedOutputBoundaryMessageIds.removeAll()
             return transcript.messages.count - 1
         }
 
-        transcript.messages.append(.user(id: UUID(), messageId: messageId, text: addition, attachments: newAttachments))
+        let id = UUID()
+        transcript.messages.append(.user(id: id, messageId: messageId, text: addition, attachments: newAttachments))
+        if messageId == nil {
+            legacyUserChunkMessageIds.insert(id)
+        }
         didAppendTranscriptMessage()
         transcript.completedOutputBoundaryMessageIds.removeAll()
         return transcript.messages.count - 1
@@ -855,6 +881,16 @@ final class ACPSession: ObservableObject, Identifiable {
                 result.append(attachment)
             }
         }
+    }
+
+    private func lastLegacyUserChunkIndex() -> Int? {
+        guard let index = transcript.messages.indices.last else { return nil }
+        if case .user(let id, let messageId, _, _) = transcript.messages[index],
+           messageId == nil,
+           legacyUserChunkMessageIds.contains(id) {
+            return index
+        }
+        return nil
     }
 
     private func lastEchoedLocalUserPromptIndex(matching text: String, attachments: [ACPMessage.Attachment]) -> Int? {

--- a/Alas/Sources/ACP/Session/ACPSession.swift
+++ b/Alas/Sources/ACP/Session/ACPSession.swift
@@ -96,6 +96,7 @@ final class ACPSession: ObservableObject, Identifiable {
 
     private var reconciledLocalUserPromptMessageIds: Set<String> = []
     private var reconciledLegacyLocalUserPromptIds: Set<UUID> = []
+    private var liveUserChunkMessageIds: Set<String> = []
     private var legacyUserChunkMessageIds: Set<UUID> = []
 
     /// Runtime-only marker for a forced queue item parked behind the current
@@ -800,12 +801,22 @@ final class ACPSession: ObservableObject, Identifiable {
         if let i = located,
            case .user(let id, let existingMessageId, let text, let attachments) = transcript.messages[i] {
             let mergedAttachments = Self.mergingAttachments(attachments, newAttachments)
+            let isLiveUserChunk = existingMessageId.map {
+                liveUserChunkMessageIds.contains($0)
+            } == true
             let isReconciledEchoChunk = existingMessageId.map {
                 !addition.isEmpty
                     && text.contains(addition)
-                    && (reconciledLocalUserPromptMessageIds.contains($0) || text != addition)
+                    && reconciledLocalUserPromptMessageIds.contains($0)
             } == true && newAttachments.isEmpty
-            if (text == addition && attachments == mergedAttachments)
+            let isHydratedReplayChunk = existingMessageId.map {
+                !addition.isEmpty
+                    && text.contains(addition)
+                    && !reconciledLocalUserPromptMessageIds.contains($0)
+                    && !liveUserChunkMessageIds.contains($0)
+            } == true && newAttachments.isEmpty
+            if (!isLiveUserChunk && text == addition && attachments == mergedAttachments)
+                || isHydratedReplayChunk
                 || isReconciledEchoChunk {
                 return i
             }
@@ -814,6 +825,9 @@ final class ACPSession: ObservableObject, Identifiable {
                 messageId: existingMessageId,
                 text: text + Self.streamingSeparator(between: text, and: addition) + addition,
                 attachments: mergedAttachments)
+            if let existingMessageId {
+                liveUserChunkMessageIds.insert(existingMessageId)
+            }
             transcript.streamingTick &+= 1
             return i
         }
@@ -856,7 +870,9 @@ final class ACPSession: ObservableObject, Identifiable {
         guard !addition.isEmpty else {
             let id = UUID()
             transcript.messages.append(.user(id: id, messageId: messageId, text: addition, attachments: newAttachments))
-            if messageId == nil {
+            if let messageId {
+                liveUserChunkMessageIds.insert(messageId)
+            } else {
                 legacyUserChunkMessageIds.insert(id)
             }
             didAppendTranscriptMessage()
@@ -866,7 +882,9 @@ final class ACPSession: ObservableObject, Identifiable {
 
         let id = UUID()
         transcript.messages.append(.user(id: id, messageId: messageId, text: addition, attachments: newAttachments))
-        if messageId == nil {
+        if let messageId {
+            liveUserChunkMessageIds.insert(messageId)
+        } else {
             legacyUserChunkMessageIds.insert(id)
         }
         didAppendTranscriptMessage()

--- a/Alas/Sources/ACP/Session/ACPSessionByteAccounting.swift
+++ b/Alas/Sources/ACP/Session/ACPSessionByteAccounting.swift
@@ -10,13 +10,13 @@ extension ACPSession {
         var total: UInt64 = 0
         for m in transcript.messages {
             switch m {
-            case .user(_, let text, let atts):
+            case .user(_, _, let text, let atts):
                 total &+= UInt64(text.utf8.count)
                 for a in atts {
                     total &+= UInt64(a.uri.utf8.count)
                     total &+= UInt64(a.name?.utf8.count ?? 0)
                 }
-            case .agent(_, let buf), .thought(_, let buf):
+            case .agent(_, _, let buf), .thought(_, _, let buf):
                 total &+= UInt64(buf.value.utf8.count)
             case .toolCall(let tc):
                 total &+= UInt64(tc.content.utf8.count)

--- a/Alas/Sources/ACP/Session/ACPSessionManager.swift
+++ b/Alas/Sources/ACP/Session/ACPSessionManager.swift
@@ -457,9 +457,9 @@ final class ACPSessionManager: ObservableObject {
     private static func wireMessagesHaveConversation(_ wires: [ACPMessageWire]) -> Bool {
         wires.contains { wire in
             switch wire {
-            case let .user(text, _):
+            case let .user(_, text, _):
                 return !text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
-            case let .agent(text):
+            case let .agent(_, text):
                 return !text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
             default:
                 return false

--- a/Alas/Sources/ACP/Session/ACPTranscriptMarkdown.swift
+++ b/Alas/Sources/ACP/Session/ACPTranscriptMarkdown.swift
@@ -22,9 +22,9 @@ enum ACPTranscriptMarkdown {
         var sections: [String] = ["# \(headerTitle(title))"]
         for message in messages {
             switch message {
-            case .user(_, let text, _):
+            case .user(_, _, let text, _):
                 sections.append("## You\n\n\(serializedBody(text))")
-            case .agent(_, let buffer):
+            case .agent(_, _, let buffer):
                 sections.append("## \(agentHeading)\n\n\(serializedBody(buffer.value))")
             default:
                 continue
@@ -37,8 +37,8 @@ enum ACPTranscriptMarkdown {
     @MainActor
     static func messageBody(_ message: ACPMessage) -> String? {
         switch message {
-        case .user(_, let text, _): return serializedBody(text)
-        case .agent(_, let buffer): return serializedBody(buffer.value)
+        case .user(_, _, let text, _): return serializedBody(text)
+        case .agent(_, _, let buffer): return serializedBody(buffer.value)
         default: return nil
         }
     }

--- a/Alas/Sources/ACP/UI/ACPMessageList.swift
+++ b/Alas/Sources/ACP/UI/ACPMessageList.swift
@@ -82,7 +82,7 @@ struct ACPMessageList: View {
         if let last = transcript.messages.last {
             hasher.combine(last.kind)
             switch last {
-            case .agent(_, let buf), .thought(_, let buf):
+            case .agent(_, _, let buf), .thought(_, _, let buf):
                 hasher.combine(buf.value.count)
             case .systemNotice(_, let t):
                 hasher.combine(t.count)
@@ -94,7 +94,7 @@ struct ACPMessageList: View {
                 hasher.combine(e.removed)
             case .plan:
                 break
-            case .user(_, let t, _):
+            case .user(_, _, let t, _):
                 hasher.combine(t.count)
             }
         }
@@ -734,7 +734,7 @@ struct ACPMessageList: View {
     @ViewBuilder
     private func row(for m: ACPMessage) -> some View {
         switch m {
-        case .user(_, let text, let attachments):
+        case .user(_, _, let text, let attachments):
             ACPMessageGutter(markdown: { text }) {
                 UserMessageRow(
                     text: text,
@@ -743,16 +743,16 @@ struct ACPMessageList: View {
                     typography: typography
                 )
             }
-        case .agent(let id, let buf):
+        case .agent(_, _, let buf):
             ACPMessageGutter(markdown: { buf.value }) {
                 AgentMessageRow(
-                    messageId: id.uuidString,
+                    messageId: Self.markdownCacheMessageId(for: m),
                     transcript: transcript,
                     buffer: buf,
                     typography: typography
                 )
             }
-        case .thought(_, let buf):
+        case .thought(_, _, let buf):
             ACPThoughtView(buffer: buf)
         case .toolCall(let tc):
             ACPToolCallCard(
@@ -768,6 +768,10 @@ struct ACPMessageList: View {
         case .systemNotice(_, let text):
             ACPSystemNoticeView(text: text)
         }
+    }
+
+    static func markdownCacheMessageId(for message: ACPMessage) -> String {
+        message.stableId
     }
 }
 

--- a/Alas/Sources/Remote/Gateway/RemoteSessionGateway.swift
+++ b/Alas/Sources/Remote/Gateway/RemoteSessionGateway.swift
@@ -462,7 +462,7 @@ final class RemoteSessionGateway {
     static func toWire(_ message: ACPMessage, index: Int) -> RemoteWireMessage {
         let sid = "m\(index)"
         switch message {
-        case .user(_, let text, let attachments):
+        case .user(_, _, let text, let attachments):
             // The wire carries user text only; surface attachments as a labelled
             // placeholder so an image-only prompt isn't a blank bubble on the
             // phone (we don't serve the image bytes to the client in v1).
@@ -470,9 +470,9 @@ final class RemoteSessionGateway {
             if !text.isEmpty { parts.append(text) }
             parts.append(contentsOf: attachments.map { "🖼 \($0.name ?? "Image")" })
             return .init(stableId: sid, kind: "user", text: parts.joined(separator: "\n\n"), json: nil)
-        case .agent(_, let streaming):
+        case .agent(_, _, let streaming):
             return .init(stableId: sid, kind: "agent", text: streaming.value, json: nil)
-        case .thought(_, let streaming):
+        case .thought(_, _, let streaming):
             return .init(stableId: sid, kind: "thought", text: streaming.value, json: nil)
         case .systemNotice(_, let text):
             return .init(stableId: sid, kind: "systemNotice", text: text, json: nil)

--- a/AlasTests/ACP/E2E/ACPGeminiE2ETests.swift
+++ b/AlasTests/ACP/E2E/ACPGeminiE2ETests.swift
@@ -21,7 +21,8 @@ struct ACPGeminiE2ETests {
         let got = await withTimeout(seconds: 30) { () async -> String? in
             var collected = ""
             for await u in client.incomingUpdates {
-                if case .agentMessageChunk(.text(let s)) = u.update {
+                if case .agentMessageChunk(let chunk) = u.update,
+                   case .text(let s) = chunk.content {
                     collected += s
                     if collected.count > 3 { return collected }
                 }

--- a/AlasTests/ACP/Protocol/ACPSessionUpdateTests.swift
+++ b/AlasTests/ACP/Protocol/ACPSessionUpdateTests.swift
@@ -7,9 +7,36 @@ struct ACPSessionUpdateTests {
     @Test("decodes agent message chunk")
     func agentChunk() throws {
         let env = try decode("session-update-agent-chunk")
-        if case .agentMessageChunk(let block) = env.params!.update {
-            if case .text(let s) = block { #expect(s == "hello ") } else { Issue.record("expected text") }
+        if case .agentMessageChunk(let chunk) = env.params!.update {
+            if case .text(let s) = chunk.content { #expect(s == "hello ") } else { Issue.record("expected text") }
         } else { Issue.record("expected agentMessageChunk") }
+    }
+
+    @Test("decodes messageId on text chunks")
+    func textChunkMessageId() throws {
+        let json = """
+        {
+          "jsonrpc": "2.0",
+          "method": "session/update",
+          "params": {
+            "sessionId": "s1",
+            "update": {
+              "sessionUpdate": "agent_message_chunk",
+              "messageId": "msg-agent-1",
+              "content": { "type": "text", "text": "hello" }
+            }
+          }
+        }
+        """
+        let env = try JSONDecoder().decode(
+            JSONRPCEnvelope<ACPSessionUpdateParams>.self,
+            from: Data(json.utf8))
+        if case .agentMessageChunk(let chunk) = env.params!.update {
+            #expect(chunk.messageId == "msg-agent-1")
+            #expect(chunk.content == .text("hello"))
+        } else {
+            Issue.record("expected agentMessageChunk")
+        }
     }
 
     @Test("decodes tool call (initial)")

--- a/AlasTests/ACP/Protocol/ACPStdioClientTests.swift
+++ b/AlasTests/ACP/Protocol/ACPStdioClientTests.swift
@@ -48,7 +48,7 @@ struct ACPStdioClientTests {
             for await u in client.incomingUpdates { return u.update }
             return nil
         }()
-        if case .agentMessageChunk(let block) = firstUpdate, case .text(let t) = block {
+        if case .agentMessageChunk(let chunk) = firstUpdate, case .text(let t) = chunk.content {
             #expect(t == "hi")
         } else { Issue.record("expected agent_message_chunk 'hi'") }
         await client.shutdown()

--- a/AlasTests/ACP/Session/ACPMessageStableIdTests.swift
+++ b/AlasTests/ACP/Session/ACPMessageStableIdTests.swift
@@ -107,6 +107,27 @@ struct ACPMessageStableIdTests {
         }
     }
 
+    @Test("echoed user chunks do not duplicate local prompt attachments")
+    func echoedUserChunksDoNotDuplicateLocalPromptAttachments() async {
+        let s = ACPSession(id: "s", agentId: "claude", worktreeId: "w", title: "t")
+        let attachment = ACPMessage.Attachment(uri: "file:///tmp/example.swift", name: "example.swift")
+        s.recordUserPrompt(text: "see this", attachments: [attachment])
+
+        s.apply(.userMessageChunk(.init(messageId: "user-1", content: .text("see this"))))
+        s.apply(.userMessageChunk(.init(
+            messageId: "user-1",
+            content: .resourceLink(uri: "file:///tmp/example.swift", name: "example.swift"))))
+
+        #expect(s.transcript.messages.map(\.stableId) == ["acp-user:user-1"])
+        if case .user(_, let messageId, let text, let attachments) = s.transcript.messages[0] {
+            #expect(messageId == "user-1")
+            #expect(text == "see this")
+            #expect(attachments == [attachment])
+        } else {
+            Issue.record("expected user message")
+        }
+    }
+
     @Test("ACP messageIds are namespaced by text row kind")
     func messageIdStableIdsAreNamespaced() async {
         let user = ACPMessage.user(id: UUID(), messageId: "same", text: "u", attachments: [])

--- a/AlasTests/ACP/Session/ACPMessageStableIdTests.swift
+++ b/AlasTests/ACP/Session/ACPMessageStableIdTests.swift
@@ -119,6 +119,16 @@ struct ACPMessageStableIdTests {
         }
     }
 
+    @Test("empty user chunk without attachments does not append")
+    func emptyUserChunkWithoutAttachmentsDoesNotAppend() async {
+        let s = ACPSession(id: "s", agentId: "claude", worktreeId: "w", title: "t")
+
+        let changed = s.apply(.userMessageChunk(.text("")))
+
+        #expect(changed.isEmpty)
+        #expect(s.transcript.messages.isEmpty)
+    }
+
     @Test("mixed user chunks with messageId keep text and attachments together")
     func mixedUserChunksKeepTextAndAttachmentsTogether() async {
         let s = ACPSession(id: "s", agentId: "claude", worktreeId: "w", title: "t")

--- a/AlasTests/ACP/Session/ACPMessageStableIdTests.swift
+++ b/AlasTests/ACP/Session/ACPMessageStableIdTests.swift
@@ -32,7 +32,7 @@ struct ACPMessageStableIdTests {
         s.apply(.agentMessageChunk(.init(messageId: "agent-1", content: .text(" world"))))
 
         #expect(s.transcript.messages.count == 2)
-        #expect(s.transcript.messages[0].stableId == "agent-1")
+        #expect(s.transcript.messages[0].stableId == "acp-agent:agent-1")
         if case .agent(_, _, let text) = s.transcript.messages[0] {
             #expect(text.value == "hello world")
         } else {
@@ -46,7 +46,7 @@ struct ACPMessageStableIdTests {
         s.apply(.agentMessageChunk(.init(messageId: "agent-1", content: .text("one"))))
         s.apply(.agentMessageChunk(.init(messageId: "agent-2", content: .text("two"))))
 
-        #expect(s.transcript.messages.map(\.stableId) == ["agent-1", "agent-2"])
+        #expect(s.transcript.messages.map(\.stableId) == ["acp-agent:agent-1", "acp-agent:agent-2"])
     }
 
     @Test("user chunks with messageId use it as stable id and append by id")
@@ -56,10 +56,57 @@ struct ACPMessageStableIdTests {
         s.apply(.agentMessageChunk(.init(messageId: "agent-1", content: .text("reply"))))
         s.apply(.userMessageChunk(.init(messageId: "user-1", content: .text(" world"))))
 
-        #expect(s.transcript.messages.map(\.stableId) == ["user-1", "agent-1"])
+        #expect(s.transcript.messages.map(\.stableId) == ["acp-user:user-1", "acp-agent:agent-1"])
         if case .user(_, _, let text, let attachments) = s.transcript.messages[0] {
             #expect(text == "hello world")
             #expect(attachments.isEmpty)
+        } else {
+            Issue.record("expected user message")
+        }
+    }
+
+    @Test("ACP messageIds are namespaced by text row kind")
+    func messageIdStableIdsAreNamespaced() async {
+        let user = ACPMessage.user(id: UUID(), messageId: "same", text: "u", attachments: [])
+        let agent = ACPMessage.agent(id: UUID(), messageId: "same", StreamingText("a"))
+        let thought = ACPMessage.thought(id: UUID(), messageId: "same", StreamingText("t"))
+
+        #expect(user.stableId == "acp-user:same")
+        #expect(agent.stableId == "acp-agent:same")
+        #expect(thought.stableId == "acp-thought:same")
+    }
+
+    @Test("user_message_chunk echo updates local prompt instead of duplicating")
+    func userMessageChunkEchoUpdatesLocalPrompt() async {
+        let s = ACPSession(id: "s", agentId: "claude", worktreeId: "w", title: "t")
+        s.recordUserPrompt(text: "hello", attachments: [])
+
+        let changed = s.apply(.userMessageChunk(.init(messageId: "user-1", content: .text("hello"))))
+
+        #expect(changed == [0])
+        #expect(s.transcript.messages.count == 1)
+        #expect(s.transcript.messages[0].stableId == "acp-user:user-1")
+        if case .user(_, let messageId, let text, let attachments) = s.transcript.messages[0] {
+            #expect(messageId == "user-1")
+            #expect(text == "hello")
+            #expect(attachments.isEmpty)
+        } else {
+            Issue.record("expected user message")
+        }
+    }
+
+    @Test("legacy user_message_chunk echo without messageId does not duplicate local prompt")
+    func legacyUserMessageChunkEchoDoesNotDuplicateLocalPrompt() async {
+        let s = ACPSession(id: "s", agentId: "claude", worktreeId: "w", title: "t")
+        s.recordUserPrompt(text: "hello", attachments: [])
+
+        let changed = s.apply(.userMessageChunk(.text("hello")))
+
+        #expect(changed == [0])
+        #expect(s.transcript.messages.count == 1)
+        if case .user(_, let messageId, let text, _) = s.transcript.messages[0] {
+            #expect(messageId == nil)
+            #expect(text == "hello")
         } else {
             Issue.record("expected user message")
         }

--- a/AlasTests/ACP/Session/ACPMessageStableIdTests.swift
+++ b/AlasTests/ACP/Session/ACPMessageStableIdTests.swift
@@ -133,6 +133,25 @@ struct ACPMessageStableIdTests {
         }
     }
 
+    @Test("legacy chunked user_message_chunk echo without messageId does not duplicate local prompt")
+    func legacyChunkedUserMessageChunkEchoDoesNotDuplicateLocalPrompt() async {
+        let s = ACPSession(id: "s", agentId: "claude", worktreeId: "w", title: "t")
+        s.recordUserPrompt(text: "hello world", attachments: [])
+
+        let firstChanged = s.apply(.userMessageChunk(.text("hello ")))
+        let secondChanged = s.apply(.userMessageChunk(.text("world")))
+
+        #expect(firstChanged == [0])
+        #expect(secondChanged == [0])
+        #expect(s.transcript.messages.count == 1)
+        if case .user(_, let messageId, let text, _) = s.transcript.messages[0] {
+            #expect(messageId == nil)
+            #expect(text == "hello world")
+        } else {
+            Issue.record("expected user message")
+        }
+    }
+
     @Test("toolCall row stable id matches its toolCallId")
     func toolCallId() async {
         let s = ACPSession(id: "s", agentId: "claude", worktreeId: "w", title: "t")

--- a/AlasTests/ACP/Session/ACPMessageStableIdTests.swift
+++ b/AlasTests/ACP/Session/ACPMessageStableIdTests.swift
@@ -24,6 +24,47 @@ struct ACPMessageStableIdTests {
         #expect(s.transcript.messages[0].stableId == id1)
     }
 
+    @Test("agent chunks with messageId use it as stable id and append by id")
+    func agentChunksUseMessageId() async {
+        let s = ACPSession(id: "s", agentId: "claude", worktreeId: "w", title: "t")
+        s.apply(.agentMessageChunk(.init(messageId: "agent-1", content: .text("hello"))))
+        s.apply(.agentThoughtChunk(.init(messageId: "thought-1", content: .text("thinking"))))
+        s.apply(.agentMessageChunk(.init(messageId: "agent-1", content: .text(" world"))))
+
+        #expect(s.transcript.messages.count == 2)
+        #expect(s.transcript.messages[0].stableId == "agent-1")
+        if case .agent(_, _, let text) = s.transcript.messages[0] {
+            #expect(text.value == "hello world")
+        } else {
+            Issue.record("expected agent message")
+        }
+    }
+
+    @Test("different messageIds create separate transcript rows")
+    func differentMessageIdsCreateRows() async {
+        let s = ACPSession(id: "s", agentId: "claude", worktreeId: "w", title: "t")
+        s.apply(.agentMessageChunk(.init(messageId: "agent-1", content: .text("one"))))
+        s.apply(.agentMessageChunk(.init(messageId: "agent-2", content: .text("two"))))
+
+        #expect(s.transcript.messages.map(\.stableId) == ["agent-1", "agent-2"])
+    }
+
+    @Test("user chunks with messageId use it as stable id and append by id")
+    func userChunksUseMessageId() async {
+        let s = ACPSession(id: "s", agentId: "claude", worktreeId: "w", title: "t")
+        s.apply(.userMessageChunk(.init(messageId: "user-1", content: .text("hello"))))
+        s.apply(.agentMessageChunk(.init(messageId: "agent-1", content: .text("reply"))))
+        s.apply(.userMessageChunk(.init(messageId: "user-1", content: .text(" world"))))
+
+        #expect(s.transcript.messages.map(\.stableId) == ["user-1", "agent-1"])
+        if case .user(_, _, let text, let attachments) = s.transcript.messages[0] {
+            #expect(text == "hello world")
+            #expect(attachments.isEmpty)
+        } else {
+            Issue.record("expected user message")
+        }
+    }
+
     @Test("toolCall row stable id matches its toolCallId")
     func toolCallId() async {
         let s = ACPSession(id: "s", agentId: "claude", worktreeId: "w", title: "t")

--- a/AlasTests/ACP/Session/ACPMessageStableIdTests.swift
+++ b/AlasTests/ACP/Session/ACPMessageStableIdTests.swift
@@ -65,6 +65,24 @@ struct ACPMessageStableIdTests {
         }
     }
 
+    @Test("replayed user_message_chunk does not duplicate hydrated user text")
+    func replayedUserMessageChunkDoesNotDuplicateHydratedUserText() async {
+        let s = ACPSession(id: "s", agentId: "claude", worktreeId: "w", title: "t")
+        s.apply(.userMessageChunk(.init(messageId: "user-1", content: .text("hello world"))))
+
+        let changed = s.apply(.userMessageChunk(.init(messageId: "user-1", content: .text("hello "))))
+
+        #expect(changed == [0])
+        #expect(s.transcript.messages.map(\.stableId) == ["acp-user:user-1"])
+        if case .user(_, let messageId, let text, let attachments) = s.transcript.messages[0] {
+            #expect(messageId == "user-1")
+            #expect(text == "hello world")
+            #expect(attachments.isEmpty)
+        } else {
+            Issue.record("expected user message")
+        }
+    }
+
     @Test("user chunks with resource links preserve attachments")
     func userResourceChunksPreserveAttachments() async {
         let s = ACPSession(id: "s", agentId: "claude", worktreeId: "w", title: "t")

--- a/AlasTests/ACP/Session/ACPMessageStableIdTests.swift
+++ b/AlasTests/ACP/Session/ACPMessageStableIdTests.swift
@@ -257,6 +257,28 @@ struct ACPMessageStableIdTests {
         }
     }
 
+    @Test("legacy user_message_chunk blocks merge adjacent text and attachments")
+    func legacyUserMessageChunksMergeAdjacentTextAndAttachments() async {
+        let s = ACPSession(id: "s", agentId: "claude", worktreeId: "w", title: "t")
+        let attachment = ACPMessage.Attachment(uri: "file:///tmp/example.swift", name: "example.swift")
+
+        let firstChanged = s.apply(.userMessageChunk(.text("see ")))
+        let secondChanged = s.apply(.userMessageChunk(.init(
+            messageId: nil,
+            content: .resourceLink(uri: "file:///tmp/example.swift", name: "example.swift"))))
+
+        #expect(firstChanged == [0])
+        #expect(secondChanged == [0])
+        #expect(s.transcript.messages.count == 1)
+        if case .user(_, let messageId, let text, let attachments) = s.transcript.messages[0] {
+            #expect(messageId == nil)
+            #expect(text == "see ")
+            #expect(attachments == [attachment])
+        } else {
+            Issue.record("expected user message")
+        }
+    }
+
     @Test("toolCall row stable id matches its toolCallId")
     func toolCallId() async {
         let s = ACPSession(id: "s", agentId: "claude", worktreeId: "w", title: "t")

--- a/AlasTests/ACP/Session/ACPMessageStableIdTests.swift
+++ b/AlasTests/ACP/Session/ACPMessageStableIdTests.swift
@@ -95,6 +95,27 @@ struct ACPMessageStableIdTests {
         }
     }
 
+    @Test("chunked user_message_chunk echo updates local prompt instead of duplicating")
+    func chunkedUserMessageChunkEchoUpdatesLocalPrompt() async {
+        let s = ACPSession(id: "s", agentId: "claude", worktreeId: "w", title: "t")
+        s.recordUserPrompt(text: "hello world", attachments: [])
+
+        let firstChanged = s.apply(.userMessageChunk(.init(messageId: "user-1", content: .text("hello "))))
+        let secondChanged = s.apply(.userMessageChunk(.init(messageId: "user-1", content: .text("world"))))
+
+        #expect(firstChanged == [0])
+        #expect(secondChanged == [0])
+        #expect(s.transcript.messages.count == 1)
+        #expect(s.transcript.messages[0].stableId == "acp-user:user-1")
+        if case .user(_, let messageId, let text, let attachments) = s.transcript.messages[0] {
+            #expect(messageId == "user-1")
+            #expect(text == "hello world")
+            #expect(attachments.isEmpty)
+        } else {
+            Issue.record("expected user message")
+        }
+    }
+
     @Test("legacy user_message_chunk echo without messageId does not duplicate local prompt")
     func legacyUserMessageChunkEchoDoesNotDuplicateLocalPrompt() async {
         let s = ACPSession(id: "s", agentId: "claude", worktreeId: "w", title: "t")

--- a/AlasTests/ACP/Session/ACPMessageStableIdTests.swift
+++ b/AlasTests/ACP/Session/ACPMessageStableIdTests.swift
@@ -186,6 +186,34 @@ struct ACPMessageStableIdTests {
         }
     }
 
+    @Test("attachment-only replay does not mark hydrated user row as live")
+    func attachmentOnlyReplayDoesNotMarkHydratedUserRowAsLive() async {
+        let s = ACPSession(id: "s", agentId: "claude", worktreeId: "w", title: "t")
+        let attachment = ACPMessage.Attachment(
+            uri: "file:///tmp/screenshot.jpg",
+            name: "screenshot.jpg",
+            mimeType: "image/jpeg")
+        s.transcript.messages = [
+            .user(id: UUID(), messageId: "user-1", text: "see this", attachments: [attachment])
+        ]
+
+        let attachmentChanged = s.apply(.userMessageChunk(.init(
+            messageId: "user-1",
+            content: .image(data: nil, uri: "file:///tmp/screenshot.jpg", mimeType: "image/jpeg"))))
+        let textChanged = s.apply(.userMessageChunk(.init(messageId: "user-1", content: .text("see this"))))
+
+        #expect(attachmentChanged == [0])
+        #expect(textChanged == [0])
+        #expect(s.transcript.messages.map(\.stableId) == ["acp-user:user-1"])
+        if case .user(_, let messageId, let text, let attachments) = s.transcript.messages[0] {
+            #expect(messageId == "user-1")
+            #expect(text == "see this")
+            #expect(attachments == [attachment])
+        } else {
+            Issue.record("expected user message")
+        }
+    }
+
     @Test("ACP messageIds are namespaced by text row kind")
     func messageIdStableIdsAreNamespaced() async {
         let user = ACPMessage.user(id: UUID(), messageId: "same", text: "u", attachments: [])

--- a/AlasTests/ACP/Session/ACPMessageStableIdTests.swift
+++ b/AlasTests/ACP/Session/ACPMessageStableIdTests.swift
@@ -65,10 +65,26 @@ struct ACPMessageStableIdTests {
         }
     }
 
+    @Test("repeated user chunks with messageId are preserved")
+    func repeatedUserChunksWithMessageIdArePreserved() async {
+        let s = ACPSession(id: "s", agentId: "claude", worktreeId: "w", title: "t")
+        s.apply(.userMessageChunk(.init(messageId: "user-1", content: .text("a"))))
+        s.apply(.userMessageChunk(.init(messageId: "user-1", content: .text("a"))))
+        s.apply(.userMessageChunk(.init(messageId: "user-1", content: .text("a"))))
+
+        #expect(s.transcript.messages.map(\.stableId) == ["acp-user:user-1"])
+        if case .user(_, _, let text, let attachments) = s.transcript.messages[0] {
+            #expect(text == "aaa")
+            #expect(attachments.isEmpty)
+        } else {
+            Issue.record("expected user message")
+        }
+    }
+
     @Test("replayed user_message_chunk does not duplicate hydrated user text")
     func replayedUserMessageChunkDoesNotDuplicateHydratedUserText() async {
         let s = ACPSession(id: "s", agentId: "claude", worktreeId: "w", title: "t")
-        s.apply(.userMessageChunk(.init(messageId: "user-1", content: .text("hello world"))))
+        s.transcript.messages = [.user(id: UUID(), messageId: "user-1", text: "hello world", attachments: [])]
 
         let changed = s.apply(.userMessageChunk(.init(messageId: "user-1", content: .text("hello "))))
 

--- a/AlasTests/ACP/Session/ACPMessageStableIdTests.swift
+++ b/AlasTests/ACP/Session/ACPMessageStableIdTests.swift
@@ -295,6 +295,25 @@ struct ACPMessageStableIdTests {
         }
     }
 
+    @Test("repeated legacy user_message_chunk text is preserved")
+    func repeatedLegacyUserMessageChunkTextIsPreserved() async {
+        let s = ACPSession(id: "s", agentId: "claude", worktreeId: "w", title: "t")
+
+        let firstChanged = s.apply(.userMessageChunk(.text("ha")))
+        let secondChanged = s.apply(.userMessageChunk(.text("ha")))
+
+        #expect(firstChanged == [0])
+        #expect(secondChanged == [0])
+        #expect(s.transcript.messages.count == 1)
+        if case .user(_, let messageId, let text, let attachments) = s.transcript.messages[0] {
+            #expect(messageId == nil)
+            #expect(text == "haha")
+            #expect(attachments.isEmpty)
+        } else {
+            Issue.record("expected user message")
+        }
+    }
+
     @Test("toolCall row stable id matches its toolCallId")
     func toolCallId() async {
         let s = ACPSession(id: "s", agentId: "claude", worktreeId: "w", title: "t")

--- a/AlasTests/ACP/Session/ACPMessageStableIdTests.swift
+++ b/AlasTests/ACP/Session/ACPMessageStableIdTests.swift
@@ -65,6 +65,48 @@ struct ACPMessageStableIdTests {
         }
     }
 
+    @Test("user chunks with resource links preserve attachments")
+    func userResourceChunksPreserveAttachments() async {
+        let s = ACPSession(id: "s", agentId: "claude", worktreeId: "w", title: "t")
+
+        s.apply(.userMessageChunk(.init(
+            messageId: "user-1",
+            content: .resourceLink(uri: "file:///tmp/example.swift", name: "example.swift"))))
+
+        #expect(s.transcript.messages.map(\.stableId) == ["acp-user:user-1"])
+        if case .user(_, let messageId, let text, let attachments) = s.transcript.messages[0] {
+            #expect(messageId == "user-1")
+            #expect(text == "")
+            #expect(attachments == [
+                ACPMessage.Attachment(uri: "file:///tmp/example.swift", name: "example.swift")
+            ])
+        } else {
+            Issue.record("expected user message")
+        }
+    }
+
+    @Test("mixed user chunks with messageId keep text and attachments together")
+    func mixedUserChunksKeepTextAndAttachmentsTogether() async {
+        let s = ACPSession(id: "s", agentId: "claude", worktreeId: "w", title: "t")
+
+        s.apply(.userMessageChunk(.init(messageId: "user-1", content: .text("see "))))
+        s.apply(.userMessageChunk(.init(
+            messageId: "user-1",
+            content: .image(data: nil, uri: "file:///tmp/screenshot.jpg", mimeType: "image/jpeg"))))
+        s.apply(.userMessageChunk(.init(messageId: "user-1", content: .text("please"))))
+
+        #expect(s.transcript.messages.map(\.stableId) == ["acp-user:user-1"])
+        if case .user(_, let messageId, let text, let attachments) = s.transcript.messages[0] {
+            #expect(messageId == "user-1")
+            #expect(text == "see please")
+            #expect(attachments == [
+                ACPMessage.Attachment(uri: "file:///tmp/screenshot.jpg", name: "screenshot.jpg", mimeType: "image/jpeg")
+            ])
+        } else {
+            Issue.record("expected user message")
+        }
+    }
+
     @Test("ACP messageIds are namespaced by text row kind")
     func messageIdStableIdsAreNamespaced() async {
         let user = ACPMessage.user(id: UUID(), messageId: "same", text: "u", attachments: [])

--- a/AlasTests/ACP/Session/ACPMessageStableIdTests.swift
+++ b/AlasTests/ACP/Session/ACPMessageStableIdTests.swift
@@ -128,6 +128,30 @@ struct ACPMessageStableIdTests {
         }
     }
 
+    @Test("attachment-only user_message_chunk echo updates local prompt instead of duplicating")
+    func attachmentOnlyUserMessageChunkEchoUpdatesLocalPrompt() async {
+        let s = ACPSession(id: "s", agentId: "claude", worktreeId: "w", title: "t")
+        let attachment = ACPMessage.Attachment(
+            uri: "file:///tmp/screenshot.jpg",
+            name: "screenshot.jpg",
+            mimeType: "image/jpeg")
+        s.recordUserPrompt(text: "", attachments: [attachment])
+
+        let changed = s.apply(.userMessageChunk(.init(
+            messageId: "user-1",
+            content: .image(data: nil, uri: "file:///tmp/screenshot.jpg", mimeType: "image/jpeg"))))
+
+        #expect(changed == [0])
+        #expect(s.transcript.messages.map(\.stableId) == ["acp-user:user-1"])
+        if case .user(_, let messageId, let text, let attachments) = s.transcript.messages[0] {
+            #expect(messageId == "user-1")
+            #expect(text == "")
+            #expect(attachments == [attachment])
+        } else {
+            Issue.record("expected user message")
+        }
+    }
+
     @Test("ACP messageIds are namespaced by text row kind")
     func messageIdStableIdsAreNamespaced() async {
         let user = ACPMessage.user(id: UUID(), messageId: "same", text: "u", attachments: [])

--- a/AlasTests/ACP/Session/ACPMessageTests.swift
+++ b/AlasTests/ACP/Session/ACPMessageTests.swift
@@ -28,7 +28,7 @@ struct ACPMessageTests {
             return
         }
         #expect(messageId == "agent-1")
-        #expect(back.stableId == "agent-1")
+        #expect(back.stableId == "acp-agent:agent-1")
         #expect(buf.value == "world")
     }
     @Test("tool call round-trips")

--- a/AlasTests/ACP/Session/ACPMessageTests.swift
+++ b/AlasTests/ACP/Session/ACPMessageTests.swift
@@ -10,7 +10,7 @@ struct ACPMessageTests {
         let m = ACPMessage.user(id: UUID(), text: "hello", attachments: [.init(uri: "file:///a.swift", name: "a.swift")])
         let payload = try ACPMessageCodec.encode(m)
         let back = try ACPMessageCodec.decode(kind: m.kind, payload: payload)
-        guard case .user(_, let text, let atts) = back else {
+        guard case .user(_, _, let text, let atts) = back else {
             Issue.record("expected user message")
             return
         }
@@ -20,13 +20,15 @@ struct ACPMessageTests {
     }
     @Test("agent message round-trips")
     func agentRoundtrip() throws {
-        let m = ACPMessage.agent(id: UUID(), StreamingText("world"))
+        let m = ACPMessage.agent(id: UUID(), messageId: "agent-1", StreamingText("world"))
         let payload = try ACPMessageCodec.encode(m)
         let back = try ACPMessageCodec.decode(kind: m.kind, payload: payload)
-        guard case .agent(_, let buf) = back else {
+        guard case .agent(_, let messageId, let buf) = back else {
             Issue.record("expected agent message")
             return
         }
+        #expect(messageId == "agent-1")
+        #expect(back.stableId == "agent-1")
         #expect(buf.value == "world")
     }
     @Test("tool call round-trips")

--- a/AlasTests/ACP/Session/ACPMessageWireTests.swift
+++ b/AlasTests/ACP/Session/ACPMessageWireTests.swift
@@ -13,7 +13,7 @@ struct ACPMessageWireTests {
             attachments: [.init(uri: "file:///x.txt", name: "x.txt")])
         let payload = try ACPMessageCodec.encode(original)
         let wire = try ACPMessageWire.decode(kind: "user", payload: payload)
-        guard case let .user(text, attachments) = wire else {
+        guard case let .user(_, text, attachments) = wire else {
             #expect(Bool(false), "expected .user, got \(wire)")
             return
         }
@@ -23,14 +23,16 @@ struct ACPMessageWireTests {
 
     @Test("decode round-trips agent text")
     func agentRoundTrip() throws {
-        let original: ACPMessage = .agent(id: UUID(), StreamingText("agent prose"))
+        let original: ACPMessage = .agent(id: UUID(), messageId: "agent-1", StreamingText("agent prose"))
         let payload = try ACPMessageCodec.encode(original)
         let wire = try ACPMessageWire.decode(kind: "agent", payload: payload)
-        guard case let .agent(text) = wire else {
+        guard case let .agent(messageId, text) = wire else {
             #expect(Bool(false), "expected .agent, got \(wire)")
             return
         }
+        #expect(messageId == "agent-1")
         #expect(text == "agent prose")
+        #expect(wire.toMessage().stableId == "agent-1")
     }
 
     @Test("decode round-trips tool call")
@@ -84,11 +86,11 @@ struct ACPMessageWireTests {
 
     @Test("toMessage produces ACPMessage with fresh ids")
     func toMessage() throws {
-        let wire: ACPMessageWire = .agent(text: "x")
+        let wire: ACPMessageWire = .agent(messageId: nil, text: "x")
         let m1 = wire.toMessage()
         let m2 = wire.toMessage()
         // Same wire, different UUIDs each call (matches existing decode behavior).
-        guard case let .agent(id1, _) = m1, case let .agent(id2, _) = m2 else {
+        guard case let .agent(id1, _, _) = m1, case let .agent(id2, _, _) = m2 else {
             #expect(Bool(false))
             return
         }

--- a/AlasTests/ACP/Session/ACPMessageWireTests.swift
+++ b/AlasTests/ACP/Session/ACPMessageWireTests.swift
@@ -32,7 +32,7 @@ struct ACPMessageWireTests {
         }
         #expect(messageId == "agent-1")
         #expect(text == "agent prose")
-        #expect(wire.toMessage().stableId == "agent-1")
+        #expect(wire.toMessage().stableId == "acp-agent:agent-1")
     }
 
     @Test("decode round-trips tool call")

--- a/AlasTests/ACP/Session/ACPSessionManagerAttachRestoreTests.swift
+++ b/AlasTests/ACP/Session/ACPSessionManagerAttachRestoreTests.swift
@@ -97,7 +97,7 @@ struct ACPSessionManagerAttachRestoreTests {
         #expect(client.sent.map(\.method) == ["initialize", "session/load"])
         #expect(session.transcript.messages.count == 3)
         #expect(try store.loadMessages(sessionId: "local").count == 3)
-        guard case .user(_, let text, let attachments) = session.transcript.messages[0] else {
+        guard case .user(_, _, let text, let attachments) = session.transcript.messages[0] else {
             Issue.record("Expected hydrated user message to remain first")
             return
         }
@@ -108,7 +108,7 @@ struct ACPSessionManagerAttachRestoreTests {
 
         client.emit(.init(sessionId: "remote-restored", update: .agentMessageChunk(.text("live follow-up"))))
         try await waitUntil { session.transcript.messages.count == 4 }
-        guard case .agent(_, let liveText) = session.transcript.messages[3] else {
+        guard case .agent(_, _, let liveText) = session.transcript.messages[3] else {
             Issue.record("Expected post-load live update to be applied")
             return
         }
@@ -238,7 +238,7 @@ struct ACPSessionManagerAttachRestoreTests {
         await manager.attach(to: session.id, freshlyCreated: true)
         try await waitUntil { session.transcript.messages.count == 1 }
 
-        guard case .agent(_, let text) = session.transcript.messages[0] else {
+        guard case .agent(_, _, let text) = session.transcript.messages[0] else {
             Issue.record("Expected fresh session update to be applied")
             return
         }
@@ -277,7 +277,7 @@ struct ACPSessionManagerAttachRestoreTests {
                 && session.queue.isEmpty
         }
         #expect(session.transcript.messages.count == 2)
-        guard case .user(_, let text, _) = session.transcript.messages[1] else {
+        guard case .user(_, _, let text, _) = session.transcript.messages[1] else {
             Issue.record("Expected queued prompt to append after hydrated transcript")
             return
         }

--- a/AlasTests/ACP/Session/ACPSessionManagerHydrationTests.swift
+++ b/AlasTests/ACP/Session/ACPSessionManagerHydrationTests.swift
@@ -66,7 +66,7 @@ struct ACPSessionManagerHydrationTests {
 
         #expect(s.hydrationState == .ready)
         #expect(s.transcript.messages.count == 1)
-        if case .user(_, let text, _) = s.transcript.messages.first! {
+        if case .user(_, _, let text, _) = s.transcript.messages.first! {
             #expect(text == "hi")
         } else {
             #expect(Bool(false), "expected user message")
@@ -195,12 +195,12 @@ struct ACPSessionManagerHydrationTests {
         #expect(s.hydrationState == .ready)
         #expect(s.transcript.messages.count == ACPTranscript.tailWindow)
         #expect(s.transcript.visibleHead == 0)
-        if case .user(_, let text, _) = s.transcript.messages.first {
+        if case .user(_, _, let text, _) = s.transcript.messages.first {
             #expect(text == "m70")
         } else {
             #expect(Bool(false), "expected first visible message to be .user m70")
         }
-        if case .user(_, let text, _) = s.transcript.messages.last {
+        if case .user(_, _, let text, _) = s.transcript.messages.last {
             #expect(text == "m99")
         } else {
             #expect(Bool(false), "expected last visible message to be .user m99")
@@ -211,17 +211,17 @@ struct ACPSessionManagerHydrationTests {
         await mgr.awaitBackfill(id: "s")
         #expect(s.transcript.messages.count == 100)
         #expect(s.transcript.visibleHead == 100 - ACPTranscript.tailWindow)
-        if case .user(_, let text, _) = s.transcript.messages.first {
+        if case .user(_, _, let text, _) = s.transcript.messages.first {
             #expect(text == "m0")
         } else {
             #expect(Bool(false), "expected first message to be .user m0 after backfill")
         }
-        if case .user(_, let text, _) = s.transcript.messages[s.transcript.visibleHead] {
+        if case .user(_, _, let text, _) = s.transcript.messages[s.transcript.visibleHead] {
             #expect(text == "m70")
         } else {
             #expect(Bool(false), "expected message at visibleHead to be .user m70")
         }
-        if case .user(_, let text, _) = s.transcript.messages.last {
+        if case .user(_, _, let text, _) = s.transcript.messages.last {
             #expect(text == "m99")
         } else {
             #expect(Bool(false), "expected last message to be .user m99 after backfill")
@@ -257,7 +257,7 @@ struct ACPSessionManagerHydrationTests {
 
         #expect(s.transcript.messages.count == ACPTranscript.tailWindow)
         #expect(s.transcript.visibleHead == 0)
-        if case .user(_, let text, _) = s.transcript.messages[s.transcript.visibleHead] {
+        if case .user(_, _, let text, _) = s.transcript.messages[s.transcript.visibleHead] {
             #expect(text == "m70")
         } else {
             #expect(Bool(false), "expected first tail message before backfill")
@@ -267,7 +267,7 @@ struct ACPSessionManagerHydrationTests {
 
         #expect(s.transcript.messages.count == 100)
         #expect(s.transcript.visibleHead == 5)
-        if case .user(_, let text, _) = s.transcript.messages[s.transcript.visibleHead] {
+        if case .user(_, _, let text, _) = s.transcript.messages[s.transcript.visibleHead] {
             #expect(text == "m5")
         } else {
             #expect(Bool(false), "expected remembered absolute index after backfill")
@@ -312,7 +312,7 @@ struct ACPSessionManagerHydrationTests {
         await mgr.hydrateIfNeeded(id: "s")
         await mgr.awaitBackfill(id: "s")
 
-        if case .user(_, let text, _) = reopened.transcript.messages[reopened.transcript.visibleHead] {
+        if case .user(_, _, let text, _) = reopened.transcript.messages[reopened.transcript.visibleHead] {
             #expect(text == "m40")
         } else {
             #expect(Bool(false), "expected remembered anchor row to be a user message")

--- a/AlasTests/ACP/Session/ACPSessionRecoveryIntegrationTests.swift
+++ b/AlasTests/ACP/Session/ACPSessionRecoveryIntegrationTests.swift
@@ -73,7 +73,7 @@ struct ACPSessionRecoveryIntegrationTests {
 
         #expect(session.hydrationState == .ready)
         #expect(session.transcript.messages.count == 1)
-        if case .user(_, let text, _) = session.transcript.messages.first! {
+        if case .user(_, _, let text, _) = session.transcript.messages.first! {
             #expect(text == "persisted hello")
         } else {
             Issue.record("expected hydrated transcript head to be a user message")

--- a/AlasTests/ACP/Session/ACPSessionRunnerQueueTests.swift
+++ b/AlasTests/ACP/Session/ACPSessionRunnerQueueTests.swift
@@ -267,7 +267,7 @@ struct ACPSessionRunnerQueueTests {
         #expect(session.queue[0].transcriptRecorded == true)
         var userTexts: [String] = []
         for msg in session.transcript.messages {
-            if case .user(_, let text, _) = msg { userTexts.append(text) }
+            if case .user(_, _, let text, _) = msg { userTexts.append(text) }
         }
         #expect(userTexts == ["queued-q"])
     }
@@ -352,7 +352,7 @@ struct ACPSessionRunnerQueueTests {
         #expect(prompts.count == 1)
         var userTexts: [String] = []
         for msg in session.transcript.messages {
-            if case .user(_, let text, _) = msg { userTexts.append(text) }
+            if case .user(_, _, let text, _) = msg { userTexts.append(text) }
         }
         #expect(userTexts == ["selected"])
         #expect(session.queue.isEmpty)
@@ -381,7 +381,7 @@ struct ACPSessionRunnerQueueTests {
         #expect(prompts.count == 1)
         var userTexts: [String] = []
         for msg in session.transcript.messages {
-            if case .user(_, let text, _) = msg { userTexts.append(text) }
+            if case .user(_, _, let text, _) = msg { userTexts.append(text) }
         }
         #expect(userTexts == ["selected"])
     }

--- a/AlasTests/ACP/Session/ACPSessionRunnerTests.swift
+++ b/AlasTests/ACP/Session/ACPSessionRunnerTests.swift
@@ -207,7 +207,7 @@ struct ACPSessionRunnerTests {
         client.emitReserved(.agentMessageChunk(.text(" second")))
         try await waitUntil {
             guard session.transcript.messages.count == 2,
-                  case .agent(_, let buffer) = session.transcript.messages[1]
+                  case .agent(_, _, let buffer) = session.transcript.messages[1]
             else { return false }
             return buffer.value == "first second"
                 && session.transcript.completedOutputBoundaryMessageIds == [session.transcript.messages[1].stableId]
@@ -215,8 +215,8 @@ struct ACPSessionRunnerTests {
 
         client.emitFresh(.agentMessageChunk(.text("next task")))
         try await waitUntil { session.transcript.messages.count == 3 }
-        if case .agent(_, let first) = session.transcript.messages[1],
-           case .agent(_, let second) = session.transcript.messages[2] {
+        if case .agent(_, _, let first) = session.transcript.messages[1],
+           case .agent(_, _, let second) = session.transcript.messages[2] {
             #expect(first.value == "first second")
             #expect(second.value == "next task")
         } else {
@@ -265,9 +265,9 @@ struct ACPSessionRunnerTests {
                 && session.transcript.messages.count >= 3
         }
 
-        if case .user(_, let firstUser, _) = session.transcript.messages[0],
-           case .agent(_, let firstAnswer) = session.transcript.messages[1],
-           case .user(_, let secondUser, _) = session.transcript.messages[2] {
+        if case .user(_, _, let firstUser, _) = session.transcript.messages[0],
+           case .agent(_, _, let firstAnswer) = session.transcript.messages[1],
+           case .user(_, _, let secondUser, _) = session.transcript.messages[2] {
             #expect(firstUser == "hello")
             #expect(firstAnswer.value == "first second")
             #expect(secondUser == "next")
@@ -528,7 +528,7 @@ struct ACPSessionRunnerTests {
         let rows = try store.loadMessages(sessionId: "s")
         let agentRow = try #require(rows.first(where: { $0.kind == "agent" }))
         let decoded = try ACPMessageCodec.decode(kind: agentRow.kind, payload: agentRow.payload)
-        guard case .agent(_, let text) = decoded else {
+        guard case .agent(_, _, let text) = decoded else {
             Issue.record("expected persisted agent message")
             return
         }
@@ -630,7 +630,7 @@ struct ACPSessionRunnerTests {
         let rows = try store.loadMessages(sessionId: sid)
         let agentRow = try #require(rows.first(where: { $0.kind == "agent" }))
         let decoded = try ACPMessageCodec.decode(kind: agentRow.kind, payload: agentRow.payload)
-        guard case .agent(_, let text) = decoded else {
+        guard case .agent(_, _, let text) = decoded else {
             Issue.record("expected persisted agent message")
             return
         }
@@ -683,7 +683,7 @@ struct ACPSessionRunnerTests {
         let rows = try store.loadMessages(sessionId: sid)
         let agentRow = try #require(rows.first(where: { $0.kind == "agent" }))
         let decoded = try ACPMessageCodec.decode(kind: agentRow.kind, payload: agentRow.payload)
-        guard case .agent(_, let text) = decoded else {
+        guard case .agent(_, _, let text) = decoded else {
             Issue.record("expected persisted agent message")
             return
         }
@@ -741,7 +741,7 @@ struct ACPSessionRunnerTests {
         let rows = try store.loadMessages(sessionId: sid)
         let agentRow = try #require(rows.first(where: { $0.kind == "agent" }))
         let decoded = try ACPMessageCodec.decode(kind: agentRow.kind, payload: agentRow.payload)
-        guard case .agent(_, let text) = decoded else {
+        guard case .agent(_, _, let text) = decoded else {
             Issue.record("expected persisted agent message")
             return
         }

--- a/AlasTests/ACP/Session/ACPSessionTests.swift
+++ b/AlasTests/ACP/Session/ACPSessionTests.swift
@@ -216,6 +216,33 @@ struct ACPSessionTests {
         }
     }
 
+    @Test("post-load live chunk with existing messageId updates in-progress output")
+    func postLoadLiveExistingMessageIdChunkUpdatesInProgressOutput() async {
+        let session = ACPSession(id: "s", agentId: "codex", worktreeId: "w", title: "t")
+        session.transcript.messages = [
+            .agent(id: UUID(), messageId: "agent-1", StreamingText("first")),
+            .toolCall(.init(
+                toolCallId: "tool-1",
+                title: "Read file",
+                kind: "read",
+                status: "completed",
+                content: "done"
+            ))
+        ]
+        session.allowsStreamingBoundaryCrossing = false
+
+        let changed = session.apply(.agentMessageChunk(.init(messageId: "agent-1", content: .text(" follow-up"))))
+
+        #expect(changed == [0])
+        #expect(session.transcript.messages.count == 2)
+        if case .agent(_, let messageId, let text) = session.transcript.messages[0] {
+            #expect(messageId == "agent-1")
+            #expect(text.value == "first follow-up")
+        } else {
+            Issue.record("expected agent message")
+        }
+    }
+
     @Test("late replay user chunk with unknown messageId does not append prompt")
     func lateReplayUnknownUserMessageIdChunkDoesNotAppendPrompt() async {
         let session = ACPSession(id: "s", agentId: "codex", worktreeId: "w", title: "t")

--- a/AlasTests/ACP/Session/ACPSessionTests.swift
+++ b/AlasTests/ACP/Session/ACPSessionTests.swift
@@ -188,6 +188,34 @@ struct ACPSessionTests {
         }
     }
 
+    @Test("post-load live chunk with new messageId appends output")
+    func postLoadLiveMessageIdChunkAppendsOutput() async {
+        let session = ACPSession(id: "s", agentId: "codex", worktreeId: "w", title: "t")
+        session.transcript.messages = [
+            .user(id: UUID(), messageId: nil, text: "look at this", attachments: []),
+            .agent(id: UUID(), messageId: nil, StreamingText("the image looks good")),
+            .toolCall(.init(
+                toolCallId: "tool-1",
+                title: "Read file",
+                kind: "read",
+                status: "completed",
+                content: "done"
+            ))
+        ]
+        session.allowsStreamingBoundaryCrossing = false
+
+        let changed = session.apply(.agentMessageChunk(.init(messageId: "agent-live-1", content: .text("live follow-up"))))
+
+        #expect(changed == [3])
+        #expect(session.transcript.messages.count == 4)
+        if case .agent(_, let messageId, let text) = session.transcript.messages[3] {
+            #expect(messageId == "agent-live-1")
+            #expect(text.value == "live follow-up")
+        } else {
+            Issue.record("expected agent message")
+        }
+    }
+
     @Test("late replay user chunk with unknown messageId does not append prompt")
     func lateReplayUnknownUserMessageIdChunkDoesNotAppendPrompt() async {
         let session = ACPSession(id: "s", agentId: "codex", worktreeId: "w", title: "t")

--- a/AlasTests/ACP/Session/ACPSessionTests.swift
+++ b/AlasTests/ACP/Session/ACPSessionTests.swift
@@ -168,6 +168,26 @@ struct ACPSessionTests {
         }
     }
 
+    @Test("late replay chunk with unknown messageId does not append output")
+    func lateReplayUnknownMessageIdChunkDoesNotAppendOutput() async {
+        let session = ACPSession(id: "s", agentId: "codex", worktreeId: "w", title: "t")
+        session.transcript.messages = [
+            .agent(id: UUID(), messageId: "agent-1", StreamingText("earlier answer")),
+            .user(id: UUID(), messageId: "user-1", text: "next prompt", attachments: [])
+        ]
+        session.allowsStreamingBoundaryCrossing = false
+
+        let changed = session.apply(.agentMessageChunk(.init(messageId: "regenerated-agent-1", content: .text("earlier answer"))))
+
+        #expect(changed.isEmpty)
+        #expect(session.transcript.messages.count == 2)
+        if case .agent(_, _, let text) = session.transcript.messages[0] {
+            #expect(text.value == "earlier answer")
+        } else {
+            Issue.record("expected agent message")
+        }
+    }
+
     @Test("completed output boundary does not alter existing message text")
     func completedOutputBoundaryDoesNotAddBlankLines() async {
         let session = ACPSession(id: "s", agentId: "codex", worktreeId: "w", title: "t")

--- a/AlasTests/ACP/Session/ACPSessionTests.swift
+++ b/AlasTests/ACP/Session/ACPSessionTests.swift
@@ -11,7 +11,7 @@ struct ACPSessionTests {
         session.apply(.agentMessageChunk(.text("hello ")))
         session.apply(.agentMessageChunk(.text("world")))
         #expect(session.transcript.messages.count == 1)
-        if case .agent(_, let buf) = session.transcript.messages[0] { #expect(buf.value == "hello world") }
+        if case .agent(_, _, let buf) = session.transcript.messages[0] { #expect(buf.value == "hello world") }
         else { Issue.record("expected single agent message") }
     }
 
@@ -21,7 +21,7 @@ struct ACPSessionTests {
         session.apply(.agentMessageChunk(.text("Compacting completed.")))
         session.apply(.agentMessageChunk(.text("Running the pull tests.")))
         #expect(session.transcript.messages.count == 1)
-        if case .agent(_, let buf) = session.transcript.messages[0] {
+        if case .agent(_, _, let buf) = session.transcript.messages[0] {
             #expect(buf.value == "Compacting completed.\nRunning the pull tests.")
         } else { Issue.record("expected single agent message") }
     }
@@ -31,7 +31,7 @@ struct ACPSessionTests {
         let session = ACPSession(id: "s", agentId: "claude", worktreeId: "w", title: "t")
         session.apply(.agentMessageChunk(.text("line one\n")))
         session.apply(.agentMessageChunk(.text("line two")))
-        if case .agent(_, let buf) = session.transcript.messages[0] {
+        if case .agent(_, _, let buf) = session.transcript.messages[0] {
             #expect(buf.value == "line one\nline two")
         } else { Issue.record("expected single agent message") }
     }
@@ -42,7 +42,7 @@ struct ACPSessionTests {
         // Lowercase word before `!` with preceding whitespace → separator.
         session.apply(.agentMessageChunk(.text("All done!")))
         session.apply(.agentMessageChunk(.text("Next task")))
-        if case .agent(_, let buf) = session.transcript.messages[0] {
+        if case .agent(_, _, let buf) = session.transcript.messages[0] {
             #expect(buf.value == "All done!\nNext task")
         } else { Issue.record("expected single agent message") }
     }
@@ -53,7 +53,7 @@ struct ACPSessionTests {
         // `Foo` is CamelCase → no separator (protects identifiers).
         session.apply(.agentMessageChunk(.text("Foo.")))
         session.apply(.agentMessageChunk(.text("Bar")))
-        if case .agent(_, let buf) = session.transcript.messages[0] {
+        if case .agent(_, _, let buf) = session.transcript.messages[0] {
             #expect(buf.value == "Foo.Bar")
         } else { Issue.record("expected single agent message") }
     }
@@ -65,7 +65,7 @@ struct ACPSessionTests {
         // walking back past the punctuation and must not inject a newline.
         session.apply(.agentMessageChunk(.text(".")))
         session.apply(.agentMessageChunk(.text("Next task")))
-        if case .agent(_, let buf) = session.transcript.messages[0] {
+        if case .agent(_, _, let buf) = session.transcript.messages[0] {
             #expect(buf.value == ".Next task")
         } else { Issue.record("expected single agent message") }
     }
@@ -77,7 +77,7 @@ struct ACPSessionTests {
         // (qualified identifier at chunk start) → no separator.
         session.apply(.agentMessageChunk(.text("package.")))
         session.apply(.agentMessageChunk(.text("Type")))
-        if case .agent(_, let buf) = session.transcript.messages[0] {
+        if case .agent(_, _, let buf) = session.transcript.messages[0] {
             #expect(buf.value == "package.Type")
         } else { Issue.record("expected single agent message") }
     }
@@ -88,7 +88,7 @@ struct ACPSessionTests {
         session.apply(.agentMessageChunk(.text("See the API docs.")))
         session.apply(.agentMessageChunk(.text("API")))
         // "API" — first char 'A' (upper), second char 'P' (upper, not [a-z]) → no separator
-        if case .agent(_, let buf) = session.transcript.messages[0] {
+        if case .agent(_, _, let buf) = session.transcript.messages[0] {
             #expect(buf.value == "See the API docs.API")
         } else { Issue.record("expected single agent message") }
     }
@@ -99,7 +99,7 @@ struct ACPSessionTests {
         session.apply(.agentMessageChunk(.text("See https://example.com.")))
         session.apply(.agentMessageChunk(.text("Path")))
         // `com.` is preceded by `/` (URL tail) → no separator.
-        if case .agent(_, let buf) = session.transcript.messages[0] {
+        if case .agent(_, _, let buf) = session.transcript.messages[0] {
             #expect(buf.value == "See https://example.com.Path")
         } else { Issue.record("expected single agent message") }
     }
@@ -110,7 +110,7 @@ struct ACPSessionTests {
         session.apply(.agentThoughtChunk(.text("First thought.")))
         session.apply(.agentThoughtChunk(.text("Second thought.")))
         #expect(session.transcript.messages.count == 1)
-        if case .thought(_, let buf) = session.transcript.messages[0] {
+        if case .thought(_, _, let buf) = session.transcript.messages[0] {
             #expect(buf.value == "First thought.\nSecond thought.")
         } else { Issue.record("expected single thought message") }
     }
@@ -123,8 +123,8 @@ struct ACPSessionTests {
         session.apply(.agentMessageChunk(.text("next task output")))
 
         #expect(session.transcript.messages.count == 2)
-        if case .agent(_, let first) = session.transcript.messages[0],
-           case .agent(_, let second) = session.transcript.messages[1] {
+        if case .agent(_, _, let first) = session.transcript.messages[0],
+           case .agent(_, _, let second) = session.transcript.messages[1] {
             #expect(first.value == "first task output")
             #expect(second.value == "next task output")
         } else {
@@ -138,7 +138,7 @@ struct ACPSessionTests {
         session.apply(.agentMessageChunk(.text("line one\nline two")))
         session.markCompletedOutputBoundary()
 
-        if case .agent(_, let buf) = session.transcript.messages[0] {
+        if case .agent(_, _, let buf) = session.transcript.messages[0] {
             #expect(buf.value == "line one\nline two")
         } else {
             Issue.record("expected agent message")
@@ -154,9 +154,9 @@ struct ACPSessionTests {
         session.apply(.agentMessageChunk(.text("second task")))
 
         #expect(session.transcript.messages.count == 3)
-        if case .agent(_, let first) = session.transcript.messages[0],
+        if case .agent(_, _, let first) = session.transcript.messages[0],
            case .plan = session.transcript.messages[1],
-           case .agent(_, let second) = session.transcript.messages[2] {
+           case .agent(_, _, let second) = session.transcript.messages[2] {
             #expect(first.value == "first task")
             #expect(second.value == "second task")
         } else {
@@ -173,9 +173,9 @@ struct ACPSessionTests {
         session.apply(.agentMessageChunk(.text("next task")))
 
         #expect(session.transcript.messages.count == 3)
-        if case .agent(_, let first) = session.transcript.messages[0],
-           case .thought(_, let thought) = session.transcript.messages[1],
-           case .agent(_, let second) = session.transcript.messages[2] {
+        if case .agent(_, _, let first) = session.transcript.messages[0],
+           case .thought(_, _, let thought) = session.transcript.messages[1],
+           case .agent(_, _, let second) = session.transcript.messages[2] {
             #expect(first.value == "visible answer")
             #expect(thought.value == "trailing thought")
             #expect(second.value == "next task")
@@ -194,10 +194,10 @@ struct ACPSessionTests {
         session.apply(.agentMessageChunk(.text("second answer")))
 
         #expect(session.transcript.messages.count == 4)
-        if case .agent(_, let first) = session.transcript.messages[0],
-           case .thought(_, let firstThought) = session.transcript.messages[1],
-           case .thought(_, let secondThought) = session.transcript.messages[2],
-           case .agent(_, let second) = session.transcript.messages[3] {
+        if case .agent(_, _, let first) = session.transcript.messages[0],
+           case .thought(_, _, let firstThought) = session.transcript.messages[1],
+           case .thought(_, _, let secondThought) = session.transcript.messages[2],
+           case .agent(_, _, let second) = session.transcript.messages[3] {
             #expect(first.value == "first answer")
             #expect(firstThought.value == "first thought")
             #expect(secondThought.value == "next thought")
@@ -212,7 +212,7 @@ struct ACPSessionTests {
         let session = ACPSession(id: "s", agentId: "claude", worktreeId: "w", title: "t")
         session.recordUserPrompt(text: "hi", attachments: [])
         #expect(session.transcript.messages.count == 1)
-        if case .user(_, let text, _) = session.transcript.messages[0] { #expect(text == "hi") }
+        if case .user(_, _, let text, _) = session.transcript.messages[0] { #expect(text == "hi") }
         else { Issue.record("expected user message") }
     }
 

--- a/AlasTests/ACP/Session/ACPSessionTests.swift
+++ b/AlasTests/ACP/Session/ACPSessionTests.swift
@@ -148,6 +148,26 @@ struct ACPSessionTests {
         }
     }
 
+    @Test("late replay chunk with messageId does not mutate hydrated output")
+    func lateReplayMessageIdChunkDoesNotMutateHydratedOutput() async {
+        let session = ACPSession(id: "s", agentId: "codex", worktreeId: "w", title: "t")
+        session.transcript.messages = [
+            .agent(id: UUID(), messageId: "agent-1", StreamingText("earlier answer")),
+            .user(id: UUID(), messageId: "user-1", text: "next prompt", attachments: [])
+        ]
+        session.allowsStreamingBoundaryCrossing = false
+
+        let changed = session.apply(.agentMessageChunk(.init(messageId: "agent-1", content: .text(" replay"))))
+
+        #expect(changed == [0])
+        #expect(session.transcript.messages.count == 2)
+        if case .agent(_, _, let text) = session.transcript.messages[0] {
+            #expect(text.value == "earlier answer")
+        } else {
+            Issue.record("expected agent message")
+        }
+    }
+
     @Test("completed output boundary does not alter existing message text")
     func completedOutputBoundaryDoesNotAddBlankLines() async {
         let session = ACPSession(id: "s", agentId: "codex", worktreeId: "w", title: "t")

--- a/AlasTests/ACP/Session/ACPSessionTests.swift
+++ b/AlasTests/ACP/Session/ACPSessionTests.swift
@@ -132,6 +132,22 @@ struct ACPSessionTests {
         }
     }
 
+    @Test("agent chunks with messageId after a completed output boundary update the same message")
+    func messageIdChunkAfterCompletedOutputBoundaryUpdatesMessage() async {
+        let session = ACPSession(id: "s", agentId: "codex", worktreeId: "w", title: "t")
+        session.apply(.agentMessageChunk(.init(messageId: "agent-1", content: .text("first"))))
+        session.markCompletedOutputBoundary()
+        session.apply(.agentMessageChunk(.init(messageId: "agent-1", content: .text(" task output"))))
+
+        #expect(session.transcript.messages.count == 1)
+        #expect(session.transcript.messages[0].stableId == "acp-agent:agent-1")
+        if case .agent(_, _, let text) = session.transcript.messages[0] {
+            #expect(text.value == "first task output")
+        } else {
+            Issue.record("expected agent message")
+        }
+    }
+
     @Test("completed output boundary does not alter existing message text")
     func completedOutputBoundaryDoesNotAddBlankLines() async {
         let session = ACPSession(id: "s", agentId: "codex", worktreeId: "w", title: "t")

--- a/AlasTests/ACP/Session/ACPSessionTests.swift
+++ b/AlasTests/ACP/Session/ACPSessionTests.swift
@@ -188,6 +188,27 @@ struct ACPSessionTests {
         }
     }
 
+    @Test("late replay user chunk with unknown messageId does not append prompt")
+    func lateReplayUnknownUserMessageIdChunkDoesNotAppendPrompt() async {
+        let session = ACPSession(id: "s", agentId: "codex", worktreeId: "w", title: "t")
+        session.transcript.messages = [
+            .user(id: UUID(), messageId: "user-1", text: "earlier prompt", attachments: []),
+            .agent(id: UUID(), messageId: "agent-1", StreamingText("earlier answer"))
+        ]
+        session.allowsStreamingBoundaryCrossing = false
+
+        let changed = session.apply(.userMessageChunk(.init(messageId: "regenerated-user-1", content: .text("earlier prompt"))))
+
+        #expect(changed.isEmpty)
+        #expect(session.transcript.messages.count == 2)
+        if case .user(_, _, let text, let attachments) = session.transcript.messages[0] {
+            #expect(text == "earlier prompt")
+            #expect(attachments.isEmpty)
+        } else {
+            Issue.record("expected user message")
+        }
+    }
+
     @Test("completed output boundary does not alter existing message text")
     func completedOutputBoundaryDoesNotAddBlankLines() async {
         let session = ACPSession(id: "s", agentId: "codex", worktreeId: "w", title: "t")

--- a/AlasTests/ACP/Session/ACPTranscriptMarkdownCacheEvictionTests.swift
+++ b/AlasTests/ACP/Session/ACPTranscriptMarkdownCacheEvictionTests.swift
@@ -27,6 +27,13 @@ struct ACPTranscriptMarkdownCacheEvictionTests {
         }
     }
 
+    @Test("agent rows with ACP messageId use stable id for markdown cache")
+    func agentMessageIdCacheKey() {
+        let message = ACPMessage.agent(id: UUID(), messageId: "agent-1", StreamingText("hello"))
+
+        #expect(ACPMessageList.markdownCacheMessageId(for: message) == "agent-1")
+    }
+
     @Test("setVisibleHead is idempotent at the same value")
     func idempotent() {
         let t = ACPTranscript()

--- a/AlasTests/ACP/Session/ACPTranscriptMarkdownCacheEvictionTests.swift
+++ b/AlasTests/ACP/Session/ACPTranscriptMarkdownCacheEvictionTests.swift
@@ -31,7 +31,7 @@ struct ACPTranscriptMarkdownCacheEvictionTests {
     func agentMessageIdCacheKey() {
         let message = ACPMessage.agent(id: UUID(), messageId: "agent-1", StreamingText("hello"))
 
-        #expect(ACPMessageList.markdownCacheMessageId(for: message) == "agent-1")
+        #expect(ACPMessageList.markdownCacheMessageId(for: message) == "acp-agent:agent-1")
     }
 
     @Test("setVisibleHead is idempotent at the same value")


### PR DESCRIPTION
## Summary
- Add optional ACP messageId support to text chunk updates.
- Preserve adapter-provided message IDs through transcript persistence and hydration.
- Group live text chunks by messageId while retaining legacy chunk grouping fallback.
- Use stable message identity for agent markdown cache keys.

## Validation
- ALAS_FFF_TARGET_ARCH=arm64 xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS,arch=arm64' test -only-testing:AlasTests/ACPSessionUpdateTests -only-testing:AlasTests/ACPMessageStableIdTests -only-testing:AlasTests/ACPMessageTests -only-testing:AlasTests/ACPMessageWireTests -only-testing:AlasTests/ACPSessionTests -only-testing:AlasTests/ACPSessionManagerHydrationTests -only-testing:AlasTests/ACPTranscriptMarkdownCacheEvictionTests

Closes #612