### PR TITLE
fix(acp): clear stranded transcript-restore spinner when steered

### DIFF
--- a/Alas/Sources/ACP/Session/ACPSessionRunner.swift
+++ b/Alas/Sources/ACP/Session/ACPSessionRunner.swift
@@ -1180,30 +1180,32 @@ extension ACPSessionRunner {
                 await MainActor.run {
                     let wasCancelled = self.cancelledPromptIDs.remove(promptID) != nil
                     let isActivePrompt = self.activePromptID == promptID
-                    let hasNewerActivePrompt = self.activePromptID != nil && !isActivePrompt
                     if isActivePrompt {
                         self.activePromptID = nil
                         if self.deferCompletedOutputBoundaryUntilUpdatesDrain() {
                             self.flushQueueIfIdle()
                         }
                     }
-                    if !hasNewerActivePrompt {
-                        onCompleted?(isActivePrompt && !wasCancelled)
-                    }
+                    // Always resolve the recovery status, even when a newer
+                    // prompt (e.g. the user steered) has taken over the
+                    // transport. Unlike `sendNow`, whose completion legitimately
+                    // hands UI state to its successor turn, this callback is the
+                    // ONLY thing that clears the "Restoring…" spinner — skipping
+                    // it on supersession strands the spinner forever.
+                    onCompleted?(isActivePrompt && !wasCancelled)
                 }
             } catch {
                 await MainActor.run {
                     _ = self.cancelledPromptIDs.remove(promptID)
                     let isActivePrompt = self.activePromptID == promptID
-                    let hasNewerActivePrompt = self.activePromptID != nil && !isActivePrompt
                     if isActivePrompt {
                         self.flushStreamingPersist()
                         self.activePromptID = nil
                         self.session.transcript.streamingState = .idle
                     }
-                    if !hasNewerActivePrompt {
-                        onCompleted?(false)
-                    }
+                    // See the success path above: the recovery status must
+                    // resolve regardless of supersession or the spinner strands.
+                    onCompleted?(false)
                 }
             }
         }

--- a/AlasTests/ACP/Session/ACPSessionManagerAttachRestoreTests.swift
+++ b/AlasTests/ACP/Session/ACPSessionManagerAttachRestoreTests.swift
@@ -957,6 +957,60 @@ struct ACPSessionManagerAttachRestoreTests {
         #expect(second.prompt == [.text("normal prompt")])
     }
 
+    @Test("recovery context superseded by a steer clears the restoring status")
+    func recoveryContextSupersededBySteerClearsStatus() async throws {
+        let store = try ACPSessionStore(path: tmpStorePath())
+        try store.upsertSession(row(remoteSessionId: "remote-new"))
+        try appendMessage(
+            .user(id: UUID(), text: "What changed?", attachments: []),
+            to: store,
+            seq: 0
+        )
+        let client = ACPMockClient()
+        let recoveryGate = PromptGate()
+        let steerGate = PromptGate()
+        let promptCount = PromptCounter()
+        scriptInitialize(client)
+        scriptSessionResult(client, method: "session/load", sessionId: "remote-new")
+        // Gate the first (recovery) prompt so it stays in flight while the
+        // user steers, and hold the steer's replacement prompt so it still
+        // owns the transport when the recovery RPC finally returns.
+        client.scriptAsync(method: "session/prompt") { _ in
+            switch await promptCount.next() {
+            case 1: await recoveryGate.waitInPrompt()
+            case 2: await steerGate.waitInPrompt()
+            default: break
+            }
+            return Data("null".utf8)
+        }
+        let manager = manager(store: store, client: client)
+
+        let session = try #require(manager.placeholderSession(id: "local"))
+        await manager.hydrateIfNeeded(id: "local")
+        await manager.attach(to: session.id, freshlyCreated: false)
+        let runner = try #require(manager.runners[session.id])
+        session.contextRestoreWarning = .init(
+            message: "Agent context could not be restored.",
+            canSendTranscript: true
+        )
+
+        #expect(manager.sendTranscriptAsContext(sessionId: session.id, agentName: "Agent"))
+        #expect(session.contextRecoveryStatus == .sendingTranscript)
+        try await waitUntilAsync { await recoveryGate.hasEntered }
+
+        // User steers a new prompt while the recovery context is still in
+        // flight — the steer's replacement prompt takes over the transport.
+        runner.steer(blocks: [.text("actually do this instead")])
+        try await waitUntilAsync { await steerGate.hasEntered }
+
+        // The recovery RPC now returns, superseded by the steer. The
+        // "Restoring…" spinner must resolve rather than strand forever.
+        await recoveryGate.release()
+        try await waitUntil { session.contextRecoveryStatus != .sendingTranscript }
+
+        await steerGate.release()
+    }
+
     @Test("transcript context prompt requires conversation")
     func transcriptContextPromptRequiresConversation() async throws {
         let store = try ACPSessionStore(path: tmpStorePath())
@@ -1224,6 +1278,15 @@ struct ACPSessionManagerAttachRestoreTests {
             released = true
             continuation?.resume()
             continuation = nil
+        }
+    }
+
+    private actor PromptCounter {
+        private var count = 0
+
+        func next() -> Int {
+            count += 1
+            return count
         }
     }
 }


### PR DESCRIPTION
## Problem

After restoring a session from transcript, the "Restoring model context from transcript…" spinner sometimes never goes away.

## Root cause

The `.sendingTranscript` recovery status is cleared **only** by the completion callback wired in `ACPSessionManager.sendTranscriptAsContext`. But `ACPSessionRunner.sendRecoveryContext` skipped that callback entirely whenever a newer prompt had taken over the transport (`hasNewerActivePrompt`). When the user **steers** a new prompt while the recovery context is still in flight (the composer even shows "⌥↵ to steer"), the steer installs a newer `activePromptID`, the recovery callback never fires, and the spinner strands forever. It's a race between the recovery RPC completing and the steer's replacement prompt installing itself — hence "sometimes."

The `!hasNewerActivePrompt` guard is correct for `sendNow` (a superseded turn legitimately hands its UI state to the successor), but wrong for the recovery status, which has no successor to hand off to and must always resolve.

## Fix

In `sendRecoveryContext`, always invoke `onCompleted` (both success and error paths). The callback only touches recovery status / warning / persistence — never streaming or queue state — so it can't stomp the newer prompt. Under a steer the recovery prompt is marked cancelled, so the status now resolves to `.failed` (actionable, with Retry, and keeps the recovery-pending flag so it retries later) instead of a phantom spinner.

## Test

`recoveryContextSupersededBySteerClearsStatus` deterministically gates the recovery prompt in flight, steers a replacement that takes over the transport, then releases the recovery RPC and asserts the status leaves `.sendingTranscript`. It times out before the fix and passes after. The full attach-restore suite (30 tests) and the runner/lease suites (59 tests) pass.
