### PR TITLE
fix(markdown): Render subscript tags in markdown previewsx

### DIFF
--- a/Alas/Sources/ACP/UI/ACPMarkdownInlineRenderer.swift
+++ b/Alas/Sources/ACP/UI/ACPMarkdownInlineRenderer.swift
@@ -369,15 +369,15 @@ enum ACPMarkdownInlineRenderer {
                 }
 
                 if !isSubscript,
-                   hasSubscriptOpenTag(in: source, at: index),
+                   let subscriptContentStart = subscriptOpenTagEnd(in: source, at: index),
                    let closeRange = source.range(
                        of: "</sub>",
                        options: [.caseInsensitive],
-                       range: source.index(index, offsetBy: 5)..<source.endIndex
+                       range: subscriptContentStart..<source.endIndex
                    ) {
                     let marker = makeSubscriptMarker()
                     output += marker.start
-                    output += render(String(source[source.index(index, offsetBy: 5)..<closeRange.lowerBound]), isSubscript: true)
+                    output += render(String(source[subscriptContentStart..<closeRange.lowerBound]), isSubscript: true)
                     output += marker.end
                     subscriptMarkers.append(marker)
                     index = closeRange.upperBound
@@ -403,11 +403,26 @@ enum ACPMarkdownInlineRenderer {
             return output
         }
 
-        private func hasSubscriptOpenTag(in source: String, at index: String.Index) -> Bool {
-            guard let end = source.index(index, offsetBy: 5, limitedBy: source.endIndex) else {
-                return false
+        private func subscriptOpenTagEnd(in source: String, at index: String.Index) -> String.Index? {
+            guard source[index...].hasPrefix("<"),
+                  let nameEnd = source.index(index, offsetBy: 4, limitedBy: source.endIndex),
+                  source[index..<nameEnd].caseInsensitiveCompare("<sub") == .orderedSame
+            else {
+                return nil
             }
-            return source[index..<end].caseInsensitiveCompare("<sub>") == .orderedSame
+
+            guard nameEnd < source.endIndex else { return nil }
+            let next = source[nameEnd]
+            guard next == ">" || next.isWhitespace else { return nil }
+
+            var cursor = nameEnd
+            while cursor < source.endIndex {
+                if source[cursor] == ">" {
+                    return source.index(after: cursor)
+                }
+                cursor = source.index(after: cursor)
+            }
+            return nil
         }
 
         mutating private func makeImagePlaceholder() -> String {

--- a/AlasTests/ACP/UI/ACPMarkdownInlineRendererTests.swift
+++ b/AlasTests/ACP/UI/ACPMarkdownInlineRendererTests.swift
@@ -86,6 +86,20 @@ struct ACPMarkdownInlineRendererTests {
         #expect(image.isSubscript)
     }
 
+    @Test("subscript opening tag may include attributes")
+    func subscriptOpeningTagMayIncludeAttributes() throws {
+        let plain = ACPMarkdownInlineRenderer.plainText("Before <sub class=\"priority\">P2</sub> after")
+        #expect(plain == "Before P2 after")
+
+        let plan = ACPMarkdownInlineRenderer.makePlan(
+            "<sub class=\"priority\">![P2 Badge](https://img.shields.io/badge/P2-yellow?style=flat)</sub>"
+        )
+        let image = try #require(plan.images.first)
+        #expect(image.isSubscript)
+        #expect(plan.markdownSource.contains("<sub") == false)
+        #expect(plan.markdownSource.contains("</sub>") == false)
+    }
+
     @Test("malformed subscript remains visible")
     func malformedSubscriptRemainsVisible() {
         let plain = ACPMarkdownInlineRenderer.plainText("Before <sub>small after")


### PR DESCRIPTION
## Summary
- render HTML subscript wrappers with attributes in the shared ACP markdown inline renderer
- preserve subscript badge/image handling while removing visible wrapper tags
- add regression coverage for attributed subscript tags

## Validation
- xcodegen
- ALAS_FFF_TARGET_ARCH=arm64 xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS,arch=arm64' -only-testing:AlasTests/ACPMarkdownInlineRendererTests test
- ALAS_FFF_TARGET_ARCH=arm64 xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS,arch=arm64' -quiet build