### PR TITLE
feat(acp): ACP session info title updates

### DIFF
--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -311,6 +311,7 @@
 		4421A9D1E7481B49701B3131 /* mason-lsps.json in Resources */ = {isa = PBXBuildFile; fileRef = F0D567F7F894902AD192D220 /* mason-lsps.json */; };
 		443F48C0A1AF36BFAB8B61E8 /* UnionCanvasGeometry.swift in Sources */ = {isa = PBXBuildFile; fileRef = 650B300A5337E2A9149CF083 /* UnionCanvasGeometry.swift */; };
 		449C7E4A63455D01633B791A /* PendingDiscard.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B15F58AFF7BC19419935C05 /* PendingDiscard.swift */; };
+		45290287102551CF8726F0EF /* ACPSessionInfoUpdateDecodeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 68AC15742E7423AE2F3A203A /* ACPSessionInfoUpdateDecodeTests.swift */; };
 		4565825A901B119DCD1037ED /* SymbolsFeature.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0DDCB33A74DC088022E5BD5F /* SymbolsFeature.swift */; };
 		45B14EFA547AACAB5539504B /* ThreePaneSizing.swift in Sources */ = {isa = PBXBuildFile; fileRef = FEC68B05B719B9235865027F /* ThreePaneSizing.swift */; };
 		45B3616A459480A78A5004E8 /* ImageDiffPair.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0934F7BB22E33263B63925B7 /* ImageDiffPair.swift */; };
@@ -1578,6 +1579,7 @@
 		679E62B501E0490F48CCA830 /* EditorFindBarView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditorFindBarView.swift; sourceTree = "<group>"; };
 		67E03BF5DB4E6BFF8C2FA6A2 /* ACPPermissionRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPPermissionRequest.swift; sourceTree = "<group>"; };
 		6821B71680094791995C4975 /* ShortcutsPane.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShortcutsPane.swift; sourceTree = "<group>"; };
+		68AC15742E7423AE2F3A203A /* ACPSessionInfoUpdateDecodeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPSessionInfoUpdateDecodeTests.swift; sourceTree = "<group>"; };
 		68B6937D50514C34A2C14BE1 /* TerminalServiceZmxTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TerminalServiceZmxTests.swift; sourceTree = "<group>"; };
 		69024633944E9FFF6DA76FAE /* RootView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RootView.swift; sourceTree = "<group>"; };
 		694DDEC8133EFBC33822BC26 /* ReviewLoopHandoffRoutingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReviewLoopHandoffRoutingTests.swift; sourceTree = "<group>"; };
@@ -2739,6 +2741,7 @@
 				11BA9F25CB0A6A2BFDB390EE /* ACPMockClientTests.swift */,
 				2B932ED9D5A485AE1545223C /* ACPPermissionFSTests.swift */,
 				C2D7EA3F2B69C0A8D2F8F8A5 /* ACPPromptCapabilitiesTests.swift */,
+				68AC15742E7423AE2F3A203A /* ACPSessionInfoUpdateDecodeTests.swift */,
 				2EB39DE3614B5BEC4D3EBF13 /* ACPSessionLifecycleTests.swift */,
 				A5D62D907375A5CBAED1E698 /* ACPSessionUpdateTests.swift */,
 				5302E56E1C16EDECDB45CB20 /* ACPStdioClientTests.swift */,
@@ -5098,6 +5101,7 @@
 				9FDF577BDD6D5C47635229DE /* ACPSessionByteAccountingTests.swift in Sources */,
 				4058A537B8CAE76FE7EFE184 /* ACPSessionHydrationStateTests.swift in Sources */,
 				D45D14487117192F9E5D7F0E /* ACPSessionHydratorTests.swift in Sources */,
+				45290287102551CF8726F0EF /* ACPSessionInfoUpdateDecodeTests.swift in Sources */,
 				6C33DC3A21C3223832EA5D28 /* ACPSessionLeaseTests.swift in Sources */,
 				C51451EC8E103EB5FEF82EFE /* ACPSessionLifecycleTests.swift in Sources */,
 				9C78AF82EA26A9928865C5C6 /* ACPSessionManagerAttachRestoreTests.swift in Sources */,

--- a/Alas/Sources/ACP/Protocol/ACPSessionUpdate.swift
+++ b/Alas/Sources/ACP/Protocol/ACPSessionUpdate.swift
@@ -99,7 +99,14 @@ enum ACPSessionUpdate: Codable, Equatable {
             try c.encode(opts, forKey: .configOptions)
         case .sessionInfoUpdate(let info):
             try c.encode("session_info_update", forKey: .sessionUpdate)
-            try c.encodeIfPresent(info.title, forKey: .title)
+            switch info.title {
+            case .absent:
+                break
+            case .null:
+                try c.encodeNil(forKey: .title)
+            case .value(let title):
+                try c.encode(title, forKey: .title)
+            }
             try c.encodeIfPresent(info.updatedAt, forKey: .updatedAt)
         case .availableCommandsUpdate: break // not produced by us
         case .toolCall, .toolCallUpdate, .usageUpdate, .unknown: break
@@ -167,19 +174,51 @@ struct ACPUsageInfo: Codable, Equatable {
 }
 
 struct ACPSessionInfoUpdate: Codable, Equatable {
-    let title: String?
+    let title: ACPStringFieldUpdate
     let updatedAt: String?
 
     private enum CodingKeys: String, CodingKey { case title, updatedAt }
 
-    init(title: String?, updatedAt: String?) {
+    init(title: ACPStringFieldUpdate = .absent, updatedAt: String?) {
         self.title = title
+        self.updatedAt = updatedAt
+    }
+
+    init(title: String?, updatedAt: String?) {
+        self.title = title.map(ACPStringFieldUpdate.value) ?? .absent
         self.updatedAt = updatedAt
     }
 
     init(from decoder: Decoder) throws {
         let c = try decoder.container(keyedBy: CodingKeys.self)
-        title = try? c.decodeIfPresent(String.self, forKey: .title)
+        if !c.contains(.title) {
+            title = .absent
+        } else if (try? c.decodeNil(forKey: .title)) == true {
+            title = .null
+        } else if let value = try? c.decode(String.self, forKey: .title) {
+            title = .value(value)
+        } else {
+            title = .absent
+        }
         updatedAt = try? c.decodeIfPresent(String.self, forKey: .updatedAt)
     }
+
+    func encode(to encoder: Encoder) throws {
+        var c = encoder.container(keyedBy: CodingKeys.self)
+        switch title {
+        case .absent:
+            break
+        case .null:
+            try c.encodeNil(forKey: .title)
+        case .value(let title):
+            try c.encode(title, forKey: .title)
+        }
+        try c.encodeIfPresent(updatedAt, forKey: .updatedAt)
+    }
+}
+
+enum ACPStringFieldUpdate: Equatable {
+    case absent
+    case null
+    case value(String)
 }

--- a/Alas/Sources/ACP/Protocol/ACPSessionUpdate.swift
+++ b/Alas/Sources/ACP/Protocol/ACPSessionUpdate.swift
@@ -18,11 +18,12 @@ enum ACPSessionUpdate: Codable, Equatable {
     case sessionConfigOptionsUpdate([ACPConfigOption])
     case availableCommandsUpdate([ACPPromptSuggestion])
     case usageUpdate(ACPUsageInfo)
+    case sessionInfoUpdate(ACPSessionInfoUpdate)
     case unknown(String)
 
     private enum Keys: String, CodingKey {
         case sessionUpdate, content, availableModels, modeId, modelId,
-             entries, availableCommands, configOptions
+             entries, availableCommands, configOptions, title, updatedAt
     }
 
     init(from decoder: Decoder) throws {
@@ -59,6 +60,8 @@ enum ACPSessionUpdate: Codable, Equatable {
             })
         case "usage_update":
             self = .usageUpdate(try ACPUsageInfo(from: decoder))
+        case "session_info_update":
+            self = .sessionInfoUpdate(try ACPSessionInfoUpdate(from: decoder))
         default:
             self = .unknown(kind)
         }
@@ -94,6 +97,10 @@ enum ACPSessionUpdate: Codable, Equatable {
         case .sessionConfigOptionsUpdate(let opts):
             try c.encode("session_config_options_update", forKey: .sessionUpdate)
             try c.encode(opts, forKey: .configOptions)
+        case .sessionInfoUpdate(let info):
+            try c.encode("session_info_update", forKey: .sessionUpdate)
+            try c.encodeIfPresent(info.title, forKey: .title)
+            try c.encodeIfPresent(info.updatedAt, forKey: .updatedAt)
         case .availableCommandsUpdate: break // not produced by us
         case .toolCall, .toolCallUpdate, .usageUpdate, .unknown: break
         }
@@ -156,5 +163,23 @@ struct ACPUsageInfo: Codable, Equatable {
         used = try c.decode(Int.self, forKey: .used)
         size = try c.decode(Int.self, forKey: .size)
         cost = try? c.decodeIfPresent(Cost.self, forKey: .cost)
+    }
+}
+
+struct ACPSessionInfoUpdate: Codable, Equatable {
+    let title: String?
+    let updatedAt: String?
+
+    private enum CodingKeys: String, CodingKey { case title, updatedAt }
+
+    init(title: String?, updatedAt: String?) {
+        self.title = title
+        self.updatedAt = updatedAt
+    }
+
+    init(from decoder: Decoder) throws {
+        let c = try decoder.container(keyedBy: CodingKeys.self)
+        title = try? c.decodeIfPresent(String.self, forKey: .title)
+        updatedAt = try? c.decodeIfPresent(String.self, forKey: .updatedAt)
     }
 }

--- a/Alas/Sources/ACP/Session/ACPSession.swift
+++ b/Alas/Sources/ACP/Session/ACPSession.swift
@@ -340,6 +340,8 @@ final class ACPSession: ObservableObject, Identifiable {
             // size <= 0 is unusable (divide-by-zero); treat as "no data".
             contextUsage = (info.size > 0) ? info : nil
             return []
+        case .sessionInfoUpdate:
+            return []
         case .unknown:
             return []
         }

--- a/Alas/Sources/ACP/Session/ACPSessionManager.swift
+++ b/Alas/Sources/ACP/Session/ACPSessionManager.swift
@@ -27,6 +27,7 @@ final class ACPSessionManager: ObservableObject {
     /// the runner falls back to disk in that case. Lets agent reads see
     /// the user's unsaved edits rather than stale disk bytes.
     let onLiveBufferRead: ((String) -> String?)?
+    private let onSessionTitleUpdated: ((ACPSession.ID, String) -> Void)?
     @Published private(set) var sessions: [ACPSession.ID: ACPSession] = [:]
     @Published private(set) var recent: [ACPSessionRow] = []
     private(set) var runners: [ACPSession.ID: ACPSessionRunner] = [:]
@@ -198,6 +199,7 @@ final class ACPSessionManager: ObservableObject {
          hydratorPath: String? = nil,
          onDirtyCheck: ((String) -> Bool)? = nil,
          onLiveBufferRead: ((String) -> String?)? = nil,
+         onSessionTitleUpdated: ((ACPSession.ID, String) -> Void)? = nil,
          changeNotifier: ACPChangeNotifier? = nil,
          setupEvaluator: ACPSetupEvaluator? = nil,
          connectionFactory: ACPConnectionFactory? = nil)
@@ -209,6 +211,7 @@ final class ACPSessionManager: ObservableObject {
         self.store = store
         self.onDirtyCheck = onDirtyCheck
         self.onLiveBufferRead = onLiveBufferRead
+        self.onSessionTitleUpdated = onSessionTitleUpdated
         self.changeNotifier = changeNotifier ?? DarwinChangeNotifier(worktreeId: worktreeId)
         self.hydrator = hydratorPath.flatMap { try? ACPSessionHydrator(path: $0) }
         self.setupEvaluator = setupEvaluator ?? { spec in
@@ -1434,6 +1437,11 @@ extension ACPSessionManager {
                                               )
                                           },
                                           onPersist: { [weak self] in self?.changeNotifier.post() },
+                                          onSessionTitleUpdated: { [weak self] title in
+                                              self?.refreshRecent()
+                                              self?.onSessionTitleUpdated?(sessionId, title)
+                                              self?.changeNotifier.post()
+                                          },
                                           onResumeTranscriptTail: { [weak self] in
                                               self?.rememberTranscriptScrollAnchor(
                                                 sessionId: sessionId,

--- a/Alas/Sources/ACP/Session/ACPSessionManager.swift
+++ b/Alas/Sources/ACP/Session/ACPSessionManager.swift
@@ -1250,6 +1250,9 @@ extension ACPSessionManager {
     /// by-index mutation avoids violating those invariants.
     func refreshMirror(sessionId: ACPSession.ID) async {
         guard let session = sessions[sessionId] else { return }
+        if let row = try? store.loadSession(id: sessionId) {
+            syncMirrorSessionMetadata(row, to: session)
+        }
         // Always sync the queue — it can change (drain/clear) with no new
         // transcript rows, so this must run before any early-return below.
         let queue = (try? store.loadQueue(sessionId: sessionId)) ?? []
@@ -1272,6 +1275,22 @@ extension ACPSessionManager {
             session.transcript.resetWindowToTail()
         } else {
             applyRememberedTranscriptScrollWindow(to: session)
+        }
+    }
+
+    private func syncMirrorSessionMetadata(_ row: ACPSessionRow, to session: ACPSession) {
+        let titleChanged = session.title != row.title || session.titleSource != row.titleSource
+        session.title = row.title
+        session.titleSource = row.titleSource
+        session.currentModel = row.currentModel
+        session.currentMode = row.currentMode
+        session.autoRunEnabled = row.autoRun
+        if session.remoteSessionId == nil || session.remoteSessionId == row.remoteSessionId {
+            session.remoteSessionId = row.remoteSessionId
+        }
+        recent = (try? store.recentSessions()) ?? []
+        if titleChanged {
+            onSessionTitleUpdated?(row.id, row.title)
         }
     }
 }

--- a/Alas/Sources/ACP/Session/ACPSessionRunner.swift
+++ b/Alas/Sources/ACP/Session/ACPSessionRunner.swift
@@ -43,6 +43,7 @@ final class ACPSessionRunner {
     private let ownerInstanceId: String?
     private let onAuthRequired: ((ACPSessionRunner, String) async -> Void)?
     private let onPersist: (() -> Void)?
+    private let onSessionTitleUpdated: ((String) -> Void)?
     private var updatesTask: Task<Void, Never>?
     private var permissionsTask: Task<Void, Never>?
     private var questionsTask: Task<Void, Never>?
@@ -92,6 +93,7 @@ final class ACPSessionRunner {
          onLiveBufferRead: ((String) -> String?)? = nil,
          onAuthRequired: ((ACPSessionRunner, String) async -> Void)? = nil,
          onPersist: (() -> Void)? = nil,
+         onSessionTitleUpdated: ((String) -> Void)? = nil,
          onResumeTranscriptTail: (() -> Void)? = nil,
          streamingPersistDebounceNanos: UInt64 = 250_000_000,
          ownerInstanceId: String? = nil)
@@ -105,6 +107,7 @@ final class ACPSessionRunner {
         self.ownerInstanceId = ownerInstanceId
         self.onAuthRequired = onAuthRequired
         self.onPersist = onPersist
+        self.onSessionTitleUpdated = onSessionTitleUpdated
         self.streamingPersistDebounceNanos = streamingPersistDebounceNanos
         self.suppressingLoadReplay = suppressingLoadReplay
         self.onDirtyCheck = onDirtyCheck
@@ -147,13 +150,18 @@ final class ACPSessionRunner {
                         }
                         return
                     }
-                    let shouldBatchStreamingPersist = self.shouldBatchStreamingPersist(for: u.update)
-                    let dirty = self.session.apply(u.update)
-                    if shouldBatchStreamingPersist {
-                        self.scheduleStreamingPersist(dirty)
-                    } else {
+                    if case .sessionInfoUpdate(let info) = u.update {
                         self.flushStreamingPersist()
-                        self.persistIndices(dirty)
+                        self.applySessionInfoTitle(info)
+                    } else {
+                        let shouldBatchStreamingPersist = self.shouldBatchStreamingPersist(for: u.update)
+                        let dirty = self.session.apply(u.update)
+                        if shouldBatchStreamingPersist {
+                            self.scheduleStreamingPersist(dirty)
+                        } else {
+                            self.flushStreamingPersist()
+                            self.persistIndices(dirty)
+                        }
                     }
                     if self.applyPendingCompletedOutputBoundaryIfReady() {
                         self.flushQueueIfIdle()
@@ -514,6 +522,32 @@ final class ACPSessionRunner {
             }
             return
         }
+    }
+
+    func applySessionInfoTitle(_ info: ACPSessionInfoUpdate) {
+        guard holdsLeaseForWrite() else { return }
+        guard let rawTitle = info.title else { return }
+        let trimmed = rawTitle.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return }
+        guard session.titleSource != .manual else { return }
+
+        let now = Int64(Date().timeIntervalSince1970)
+        guard (try? store.updateGeneratedTitleIfNotManual(
+            id: sessionId,
+            title: trimmed,
+            updatedAt: now
+        )) == true else {
+            guard let row = try? store.loadSession(id: sessionId) else { return }
+            if row.titleSource == .manual {
+                session.title = row.title
+                session.titleSource = row.titleSource
+            }
+            return
+        }
+
+        session.title = trimmed
+        session.titleSource = .generated
+        onSessionTitleUpdated?(trimmed)
     }
 
     /// Returns `absolutePath` relative to the runner's worktree, or

--- a/Alas/Sources/ACP/Session/ACPSessionRunner.swift
+++ b/Alas/Sources/ACP/Session/ACPSessionRunner.swift
@@ -1304,7 +1304,7 @@ extension ACPSessionRunner {
         case .userMessageChunk, .toolCall, .plan, .availableModelsUpdate,
              .currentModeUpdate, .currentModelUpdate,
              .sessionConfigOptionsUpdate, .availableCommandsUpdate,
-             .usageUpdate, .unknown:
+             .usageUpdate, .sessionInfoUpdate, .unknown:
             return false
         }
     }

--- a/Alas/Sources/ACP/Session/ACPSessionRunner.swift
+++ b/Alas/Sources/ACP/Session/ACPSessionRunner.swift
@@ -137,6 +137,14 @@ final class ACPSessionRunner {
                 await MainActor.run {
                     self.observedUpdateCount += 1
                     self.appliedUpdateCount += 1
+                    let handledSessionInfoUpdate: Bool
+                    if case .sessionInfoUpdate(let info) = u.update {
+                        self.flushStreamingPersist()
+                        self.applySessionInfoTitle(info)
+                        handledSessionInfoUpdate = true
+                    } else {
+                        handledSessionInfoUpdate = false
+                    }
                     if self.suppressingLoadReplay {
                         if let target = self.loadReplaySuppressionTarget,
                            self.observedUpdateCount >= target {
@@ -150,10 +158,7 @@ final class ACPSessionRunner {
                         }
                         return
                     }
-                    if case .sessionInfoUpdate(let info) = u.update {
-                        self.flushStreamingPersist()
-                        self.applySessionInfoTitle(info)
-                    } else {
+                    if !handledSessionInfoUpdate {
                         let shouldBatchStreamingPersist = self.shouldBatchStreamingPersist(for: u.update)
                         let dirty = self.session.apply(u.update)
                         if shouldBatchStreamingPersist {

--- a/Alas/Sources/ACP/Session/ACPSessionRunner.swift
+++ b/Alas/Sources/ACP/Session/ACPSessionRunner.swift
@@ -526,7 +526,17 @@ final class ACPSessionRunner {
 
     func applySessionInfoTitle(_ info: ACPSessionInfoUpdate) {
         guard holdsLeaseForWrite() else { return }
-        guard let rawTitle = info.title else { return }
+        switch info.title {
+        case .absent:
+            return
+        case .null:
+            clearSessionInfoTitle()
+        case .value(let rawTitle):
+            applySessionInfoTitleValue(rawTitle)
+        }
+    }
+
+    private func applySessionInfoTitleValue(_ rawTitle: String) {
         let trimmed = rawTitle.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !trimmed.isEmpty else { return }
         guard session.titleSource != .manual else { return }
@@ -548,6 +558,27 @@ final class ACPSessionRunner {
         session.title = trimmed
         session.titleSource = .generated
         onSessionTitleUpdated?(trimmed)
+    }
+
+    private func clearSessionInfoTitle() {
+        guard session.titleSource != .manual else { return }
+
+        let now = Int64(Date().timeIntervalSince1970)
+        guard (try? store.clearGeneratedTitleIfNotManual(
+            id: sessionId,
+            updatedAt: now
+        )) == true else {
+            guard let row = try? store.loadSession(id: sessionId) else { return }
+            if row.titleSource == .manual {
+                session.title = row.title
+                session.titleSource = row.titleSource
+            }
+            return
+        }
+
+        session.title = "New session"
+        session.titleSource = .placeholder
+        onSessionTitleUpdated?("New session")
     }
 
     /// Returns `absolutePath` relative to the runner's worktree, or

--- a/Alas/Sources/ACP/Session/ACPSessionStore.swift
+++ b/Alas/Sources/ACP/Session/ACPSessionStore.swift
@@ -302,6 +302,15 @@ extension ACPSessionStore {
                          ACPSessionTitleSource.placeholder.rawValue]) > 0
     }
 
+    func updateGeneratedTitleIfNotManual(id: String, title: String, updatedAt: Int64) throws -> Bool {
+        try db.execChanges("""
+        UPDATE sessions
+        SET title = ?, title_source = ?, updated_at = ?
+        WHERE id = ? AND archived = 0 AND title_source != ?
+        """, bindings: [title, ACPSessionTitleSource.generated.rawValue, updatedAt, id,
+                         ACPSessionTitleSource.manual.rawValue]) > 0
+    }
+
     func appendMessage(sessionId: String, id: String, kind: String, seq: Int64, payload: Data, createdAt: Int64) throws {
         try db.exec("""
         INSERT INTO messages (id, session_id, kind, seq, payload, created_at)

--- a/Alas/Sources/ACP/Session/ACPSessionStore.swift
+++ b/Alas/Sources/ACP/Session/ACPSessionStore.swift
@@ -311,6 +311,15 @@ extension ACPSessionStore {
                          ACPSessionTitleSource.manual.rawValue]) > 0
     }
 
+    func clearGeneratedTitleIfNotManual(id: String, updatedAt: Int64) throws -> Bool {
+        try db.execChanges("""
+        UPDATE sessions
+        SET title = ?, title_source = ?, updated_at = ?
+        WHERE id = ? AND archived = 0 AND title_source != ?
+        """, bindings: ["New session", ACPSessionTitleSource.placeholder.rawValue, updatedAt, id,
+                         ACPSessionTitleSource.manual.rawValue]) > 0
+    }
+
     func appendMessage(sessionId: String, id: String, kind: String, seq: Int64, payload: Data, createdAt: Int64) throws {
         try db.exec("""
         INSERT INTO messages (id, session_id, kind, seq, payload, created_at)

--- a/Alas/Sources/App/AppState.swift
+++ b/Alas/Sources/App/AppState.swift
@@ -3413,6 +3413,13 @@ final class AppState {
                 },
                 onLiveBufferRead: { [weak self] path in
                     self?.editorLiveBufferText(for: path, worktreeId: worktree.id)
+                },
+                onSessionTitleUpdated: { [weak self] sessionId, title in
+                    _ = self?.tabs.renameACPSessionTabs(
+                        worktreeId: worktree.id,
+                        sessionId: sessionId,
+                        title: title
+                    )
                 }
             )
             acpManagers[worktree.id] = mgr

--- a/AlasTests/ACP/Protocol/ACPSessionInfoUpdateDecodeTests.swift
+++ b/AlasTests/ACP/Protocol/ACPSessionInfoUpdateDecodeTests.swift
@@ -28,7 +28,19 @@ struct ACPSessionInfoUpdateDecodeTests {
         """)
 
         #expect(update == .sessionInfoUpdate(.init(
-            title: nil,
+            title: .absent,
+            updatedAt: "2026-06-25T12:34:56Z"
+        )))
+    }
+
+    @Test("decodes null title as an explicit clear")
+    func nullTitle() throws {
+        let update = try decode("""
+        {"sessionId":"s1","update":{"sessionUpdate":"session_info_update","title":null,"updatedAt":"2026-06-25T12:34:56Z"}}
+        """)
+
+        #expect(update == .sessionInfoUpdate(.init(
+            title: .null,
             updatedAt: "2026-06-25T12:34:56Z"
         )))
     }
@@ -40,7 +52,7 @@ struct ACPSessionInfoUpdateDecodeTests {
         """)
 
         #expect(update == .sessionInfoUpdate(.init(
-            title: nil,
+            title: .absent,
             updatedAt: "2026-06-25T12:34:56Z"
         )))
     }

--- a/AlasTests/ACP/Protocol/ACPSessionInfoUpdateDecodeTests.swift
+++ b/AlasTests/ACP/Protocol/ACPSessionInfoUpdateDecodeTests.swift
@@ -1,0 +1,56 @@
+import Foundation
+import Testing
+@testable import Alas
+
+@Suite("ACP session_info_update decode")
+struct ACPSessionInfoUpdateDecodeTests {
+    private func decode(_ json: String) throws -> ACPSessionUpdate {
+        let data = Data(json.utf8)
+        return try JSONDecoder().decode(ACPSessionUpdateParams.self, from: data).update
+    }
+
+    @Test("decodes title and updatedAt")
+    func full() throws {
+        let update = try decode("""
+        {"sessionId":"s1","update":{"sessionUpdate":"session_info_update","title":"Implement login","updatedAt":"2026-06-25T12:34:56Z"}}
+        """)
+
+        #expect(update == .sessionInfoUpdate(.init(
+            title: "Implement login",
+            updatedAt: "2026-06-25T12:34:56Z"
+        )))
+    }
+
+    @Test("decodes absent title")
+    func noTitle() throws {
+        let update = try decode("""
+        {"sessionId":"s1","update":{"sessionUpdate":"session_info_update","updatedAt":"2026-06-25T12:34:56Z"}}
+        """)
+
+        #expect(update == .sessionInfoUpdate(.init(
+            title: nil,
+            updatedAt: "2026-06-25T12:34:56Z"
+        )))
+    }
+
+    @Test("malformed title decodes as nil")
+    func malformedTitle() throws {
+        let update = try decode("""
+        {"sessionId":"s1","update":{"sessionUpdate":"session_info_update","title":{"bad":true},"updatedAt":"2026-06-25T12:34:56Z"}}
+        """)
+
+        #expect(update == .sessionInfoUpdate(.init(
+            title: nil,
+            updatedAt: "2026-06-25T12:34:56Z"
+        )))
+    }
+
+    @Test("unknown update remains unknown")
+    func unknownStillUnknown() throws {
+        let update = try decode("""
+        {"sessionId":"s1","update":{"sessionUpdate":"future_update","title":"Ignored"}}
+        """)
+
+        #expect(update == .unknown("future_update"))
+    }
+}

--- a/AlasTests/ACP/Session/ACPSessionManagerAttachRestoreTests.swift
+++ b/AlasTests/ACP/Session/ACPSessionManagerAttachRestoreTests.swift
@@ -126,6 +126,54 @@ struct ACPSessionManagerAttachRestoreTests {
         }
     }
 
+    @Test("mirror refresh syncs generated title metadata")
+    func mirrorRefreshSyncsGeneratedTitleMetadata() async throws {
+        let store = try ACPSessionStore(path: tmpStorePath())
+        try store.upsertSession(.init(
+            id: "local",
+            agentId: "claude",
+            title: "Old generated",
+            titleSource: ACPSessionTitleSource.generated,
+            remoteSessionId: "remote-old",
+            currentModel: nil,
+            currentMode: nil,
+            autoRun: false,
+            createdAt: 0,
+            updatedAt: 0,
+            lastOpenedAt: 0,
+            archived: false
+        ))
+        var titleCallbacks: [(ACPSession.ID, String)] = []
+        let manager = ACPSessionManager(
+            worktreeId: "wt",
+            worktreePath: "/tmp/wt",
+            store: store,
+            onSessionTitleUpdated: { titleCallbacks.append(($0, $1)) },
+            setupEvaluator: { _ in .ready },
+            connectionFactory: { _ in ACPConnection(client: ACPMockClient()) }
+        )
+
+        let session = try #require(manager.placeholderSession(id: "local"))
+        await manager.hydrateIfNeeded(id: "local")
+        #expect(session.title == "Old generated")
+        #expect(session.titleSource == ACPSessionTitleSource.generated)
+
+        #expect(try store.updateGeneratedTitleIfNotManual(
+            id: "local",
+            title: "Adapter Title",
+            updatedAt: 10
+        ))
+
+        await manager.refreshMirror(sessionId: "local")
+
+        #expect(session.title == "Adapter Title")
+        #expect(session.titleSource == .generated)
+        #expect(manager.recent.first?.title == "Adapter Title")
+        #expect(titleCallbacks.count == 1)
+        #expect(titleCallbacks.first?.0 == "local")
+        #expect(titleCallbacks.first?.1 == "Adapter Title")
+    }
+
     @Test("fresh attach exposes initializing phase while initialize is pending")
     func freshAttachExposesInitializingPhaseWhileInitializeIsPending() async throws {
         let store = try ACPSessionStore(path: tmpStorePath())

--- a/AlasTests/ACP/Session/ACPSessionRunnerTests.swift
+++ b/AlasTests/ACP/Session/ACPSessionRunnerTests.swift
@@ -663,6 +663,64 @@ struct ACPSessionRunnerTests {
         #expect(row.titleSource == .placeholder)
     }
 
+    @Test("session_info_update applies during load replay suppression")
+    func sessionInfoUpdateAppliesDuringLoadReplaySuppression() async throws {
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("rn-title-replay-\(UUID().uuidString).sqlite")
+        let store = try ACPSessionStore(path: url.path)
+        try store.upsertSession(.init(
+            id: "s",
+            agentId: "claude",
+            title: "Old generated",
+            titleSource: .generated,
+            currentModel: nil,
+            currentMode: nil,
+            autoRun: false,
+            createdAt: 1,
+            updatedAt: 2,
+            lastOpenedAt: 3,
+            archived: false
+        ))
+
+        var callbackTitles: [String] = []
+        let mock = ACPMockClient()
+        let session = ACPSession(
+            id: "s",
+            agentId: "claude",
+            worktreeId: "wt",
+            title: "Old generated",
+            titleSource: .generated
+        )
+        let runner = ACPSessionRunner(
+            session: session,
+            connection: ACPConnection(client: mock),
+            store: store,
+            sessionId: "s",
+            worktreePath: FileManager.default.temporaryDirectory.path,
+            suppressingLoadReplay: true,
+            onSessionTitleUpdated: { callbackTitles.append($0) }
+        )
+        runner.start()
+        defer { runner.stop() }
+
+        mock.emit(.init(
+            sessionId: "s",
+            update: .sessionInfoUpdate(.init(title: "Replayed Adapter Title", updatedAt: nil))
+        ))
+        mock.emit(.init(sessionId: "s", update: .agentMessageChunk(.text("replayed"))))
+
+        try await waitUntil {
+            session.title == "Replayed Adapter Title"
+                && session.titleSource == .generated
+                && callbackTitles == ["Replayed Adapter Title"]
+        }
+
+        let row = try #require(try store.loadSession(id: "s"))
+        #expect(row.title == "Replayed Adapter Title")
+        #expect(row.titleSource == .generated)
+        #expect(session.transcript.messages.isEmpty)
+    }
+
     @Test("streaming chunks are persisted in a batch when streaming ends")
     func streamingChunksPersistAsBatchOnIdle() async throws {
         let url = FileManager.default.temporaryDirectory.appendingPathComponent("rn-\(UUID()).sqlite")

--- a/AlasTests/ACP/Session/ACPSessionRunnerTests.swift
+++ b/AlasTests/ACP/Session/ACPSessionRunnerTests.swift
@@ -608,6 +608,61 @@ struct ACPSessionRunnerTests {
         #expect(row.title == "t")
     }
 
+    @Test("session_info_update null title clears generated title")
+    func sessionInfoUpdateNullTitleClearsGeneratedTitle() async throws {
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("rn-title-clear-\(UUID().uuidString).sqlite")
+        let store = try ACPSessionStore(path: url.path)
+        try store.upsertSession(.init(
+            id: "s",
+            agentId: "claude",
+            title: "Generated title",
+            titleSource: .generated,
+            currentModel: nil,
+            currentMode: nil,
+            autoRun: false,
+            createdAt: 1,
+            updatedAt: 2,
+            lastOpenedAt: 3,
+            archived: false
+        ))
+
+        var callbackTitles: [String] = []
+        let mock = ACPMockClient()
+        let session = ACPSession(
+            id: "s",
+            agentId: "claude",
+            worktreeId: "wt",
+            title: "Generated title",
+            titleSource: .generated
+        )
+        let runner = ACPSessionRunner(
+            session: session,
+            connection: ACPConnection(client: mock),
+            store: store,
+            sessionId: "s",
+            worktreePath: FileManager.default.temporaryDirectory.path,
+            onSessionTitleUpdated: { callbackTitles.append($0) }
+        )
+        runner.start()
+        defer { runner.stop() }
+
+        mock.emit(.init(
+            sessionId: "s",
+            update: .sessionInfoUpdate(.init(title: .null, updatedAt: nil))
+        ))
+
+        try await waitUntil {
+            session.title == "New session"
+                && session.titleSource == .placeholder
+                && callbackTitles == ["New session"]
+        }
+
+        let row = try #require(try store.loadSession(id: "s"))
+        #expect(row.title == "New session")
+        #expect(row.titleSource == .placeholder)
+    }
+
     @Test("streaming chunks are persisted in a batch when streaming ends")
     func streamingChunksPersistAsBatchOnIdle() async throws {
         let url = FileManager.default.temporaryDirectory.appendingPathComponent("rn-\(UUID()).sqlite")

--- a/AlasTests/ACP/Session/ACPSessionRunnerTests.swift
+++ b/AlasTests/ACP/Session/ACPSessionRunnerTests.swift
@@ -481,6 +481,133 @@ struct ACPSessionRunnerTests {
         #expect(rows[0].kind == "agent")
     }
 
+    @Test("session_info_update updates live session and persistence")
+    func sessionInfoUpdateRenamesGeneratedSession() async throws {
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("rn-title-\(UUID().uuidString).sqlite")
+        let store = try ACPSessionStore(path: url.path)
+        try store.upsertSession(.init(
+            id: "s",
+            agentId: "claude",
+            title: "Old generated",
+            titleSource: .generated,
+            currentModel: nil,
+            currentMode: nil,
+            autoRun: false,
+            createdAt: 1,
+            updatedAt: 2,
+            lastOpenedAt: 3,
+            archived: false
+        ))
+
+        var callbackTitles: [String] = []
+        let mock = ACPMockClient()
+        let session = ACPSession(
+            id: "s",
+            agentId: "claude",
+            worktreeId: "wt",
+            title: "Old generated",
+            titleSource: .generated
+        )
+        let runner = ACPSessionRunner(
+            session: session,
+            connection: ACPConnection(client: mock),
+            store: store,
+            sessionId: "s",
+            worktreePath: FileManager.default.temporaryDirectory.path,
+            onSessionTitleUpdated: { callbackTitles.append($0) }
+        )
+        runner.start()
+        defer { runner.stop() }
+
+        mock.emit(.init(
+            sessionId: "s",
+            update: .sessionInfoUpdate(.init(title: "  Adapter Title  ", updatedAt: "2026-06-25T12:34:56Z"))
+        ))
+
+        try await waitUntil {
+            session.title == "Adapter Title"
+                && session.titleSource == .generated
+                && callbackTitles == ["Adapter Title"]
+        }
+
+        let row = try #require(try store.loadSession(id: "s"))
+        #expect(row.title == "Adapter Title")
+        #expect(row.titleSource == .generated)
+    }
+
+    @Test("session_info_update preserves manual title")
+    func sessionInfoUpdatePreservesManualTitle() async throws {
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("rn-title-manual-\(UUID().uuidString).sqlite")
+        let store = try ACPSessionStore(path: url.path)
+        try store.upsertSession(.init(
+            id: "s",
+            agentId: "claude",
+            title: "User Title",
+            titleSource: .manual,
+            currentModel: nil,
+            currentMode: nil,
+            autoRun: false,
+            createdAt: 1,
+            updatedAt: 2,
+            lastOpenedAt: 3,
+            archived: false
+        ))
+
+        var callbackTitles: [String] = []
+        let mock = ACPMockClient()
+        let session = ACPSession(
+            id: "s",
+            agentId: "claude",
+            worktreeId: "wt",
+            title: "User Title",
+            titleSource: .manual
+        )
+        let runner = ACPSessionRunner(
+            session: session,
+            connection: ACPConnection(client: mock),
+            store: store,
+            sessionId: "s",
+            worktreePath: FileManager.default.temporaryDirectory.path,
+            onSessionTitleUpdated: { callbackTitles.append($0) }
+        )
+        runner.start()
+        defer { runner.stop() }
+
+        mock.emit(.init(
+            sessionId: "s",
+            update: .sessionInfoUpdate(.init(title: "Adapter Title", updatedAt: nil))
+        ))
+
+        try await Task.sleep(nanoseconds: 50_000_000)
+
+        let row = try #require(try store.loadSession(id: "s"))
+        #expect(session.title == "User Title")
+        #expect(session.titleSource == .manual)
+        #expect(row.title == "User Title")
+        #expect(row.titleSource == .manual)
+        #expect(callbackTitles.isEmpty)
+    }
+
+    @Test("session_info_update ignores empty title")
+    func sessionInfoUpdateIgnoresEmptyTitle() async throws {
+        let (runner, mock) = try makeRunner()
+        runner.start()
+        defer { runner.stop() }
+
+        mock.emit(.init(
+            sessionId: "s",
+            update: .sessionInfoUpdate(.init(title: "   \n ", updatedAt: nil))
+        ))
+
+        try await Task.sleep(nanoseconds: 50_000_000)
+
+        let row = try #require(try runner.store.loadSession(id: "s"))
+        #expect(runner.session.title == "t")
+        #expect(row.title == "t")
+    }
+
     @Test("streaming chunks are persisted in a batch when streaming ends")
     func streamingChunksPersistAsBatchOnIdle() async throws {
         let url = FileManager.default.temporaryDirectory.appendingPathComponent("rn-\(UUID()).sqlite")

--- a/AlasTests/ACP/Session/ACPSessionStoreCRUDTests.swift
+++ b/AlasTests/ACP/Session/ACPSessionStoreCRUDTests.swift
@@ -208,6 +208,112 @@ struct ACPSessionStoreCRUDTests {
         #expect(manual.titleSource == .manual)
     }
 
+    @Test("session info title update changes placeholder and generated rows")
+    func sessionInfoTitleUpdateChangesNonManualRows() throws {
+        let store = try tmp()
+        try store.upsertSession(.init(
+            id: "placeholder",
+            agentId: "claude",
+            title: "New session",
+            titleSource: .placeholder,
+            currentModel: nil,
+            currentMode: nil,
+            autoRun: false,
+            createdAt: 1,
+            updatedAt: 2,
+            lastOpenedAt: 3,
+            archived: false
+        ))
+        try store.upsertSession(.init(
+            id: "generated",
+            agentId: "claude",
+            title: "Old generated",
+            titleSource: .generated,
+            currentModel: nil,
+            currentMode: nil,
+            autoRun: false,
+            createdAt: 1,
+            updatedAt: 2,
+            lastOpenedAt: 3,
+            archived: false
+        ))
+
+        let placeholderChanged = try store.updateGeneratedTitleIfNotManual(
+            id: "placeholder",
+            title: "Adapter Title",
+            updatedAt: 10
+        )
+        let generatedChanged = try store.updateGeneratedTitleIfNotManual(
+            id: "generated",
+            title: "Better Adapter Title",
+            updatedAt: 11
+        )
+
+        let placeholder = try #require(try store.loadSession(id: "placeholder"))
+        let generated = try #require(try store.loadSession(id: "generated"))
+        #expect(placeholderChanged)
+        #expect(placeholder.title == "Adapter Title")
+        #expect(placeholder.titleSource == .generated)
+        #expect(placeholder.updatedAt == 10)
+        #expect(generatedChanged)
+        #expect(generated.title == "Better Adapter Title")
+        #expect(generated.titleSource == .generated)
+        #expect(generated.updatedAt == 11)
+    }
+
+    @Test("session info title update refuses manual and archived rows")
+    func sessionInfoTitleUpdateRefusesManualAndArchivedRows() throws {
+        let store = try tmp()
+        try store.upsertSession(.init(
+            id: "manual",
+            agentId: "claude",
+            title: "User Title",
+            titleSource: .manual,
+            currentModel: nil,
+            currentMode: nil,
+            autoRun: false,
+            createdAt: 1,
+            updatedAt: 2,
+            lastOpenedAt: 3,
+            archived: false
+        ))
+        try store.upsertSession(.init(
+            id: "archived",
+            agentId: "claude",
+            title: "Archived Title",
+            titleSource: .generated,
+            currentModel: nil,
+            currentMode: nil,
+            autoRun: false,
+            createdAt: 1,
+            updatedAt: 2,
+            lastOpenedAt: 3,
+            archived: true
+        ))
+
+        let manualChanged = try store.updateGeneratedTitleIfNotManual(
+            id: "manual",
+            title: "Adapter Title",
+            updatedAt: 10
+        )
+        let archivedChanged = try store.updateGeneratedTitleIfNotManual(
+            id: "archived",
+            title: "Adapter Title",
+            updatedAt: 10
+        )
+
+        let manual = try #require(try store.loadSession(id: "manual"))
+        let archived = try #require(try store.loadSession(id: "archived"))
+        #expect(!manualChanged)
+        #expect(manual.title == "User Title")
+        #expect(manual.titleSource == .manual)
+        #expect(manual.updatedAt == 2)
+        #expect(!archivedChanged)
+        #expect(archived.title == "Archived Title")
+        #expect(archived.titleSource == .generated)
+        #expect(archived.updatedAt == 2)
+    }
+
     @Test("context recovery pending is stored separately from metadata upserts")
     func contextRecoveryPendingRoundTrip() throws {
         let store = try tmp()

--- a/docs/superpowers/specs/2026-07-03-acp-session-info-update-title-design.md
+++ b/docs/superpowers/specs/2026-07-03-acp-session-info-update-title-design.md
@@ -1,0 +1,155 @@
+# ACP Session Info Update Title Design
+
+## Context
+
+Claude's ACP adapter emits `session/update` notifications with
+`sessionUpdate: "session_info_update"` near turn end. The payload may include a
+generated session `title` and `updatedAt`.
+
+Alas currently generates a provisional ACP session title from the first user
+prompt and tracks title ownership with `ACPSessionTitleSource`:
+
+- `.placeholder` for "New session"
+- `.generated` for app-generated titles
+- `.manual` for user-renamed sessions
+
+Issue #613 requires Alas to decode the adapter notification and adopt the title
+only while the user has not manually renamed the session.
+
+## Goals
+
+- Decode ACP `session_info_update` notifications with optional `title` and
+  `updatedAt`.
+- Apply non-empty adapter titles to sessions whose title source is not
+  `.manual`.
+- Persist accepted titles and mark them as `.generated`.
+- Update matching ACP tab fallback titles so reopened tabs use the generated
+  title.
+- Ignore missing, empty, whitespace-only, archived, and manual-protected title
+  updates.
+
+## Non-Goals
+
+- Do not parse or trust remote `updatedAt` for local persistence ordering.
+  Decode it for protocol completeness, but keep using local persistence
+  timestamps.
+- Do not change manual rename behavior.
+- Do not refactor ACP update routing beyond the title notification path.
+
+## Protocol Model
+
+Add an `ACPSessionInfoUpdate` payload with:
+
+- `title: String?`
+- `updatedAt: String?`
+
+Extend `ACPSessionUpdate` with:
+
+- `.sessionInfoUpdate(ACPSessionInfoUpdate)`
+
+Decode wire updates where `sessionUpdate == "session_info_update"`. Missing
+`title` is valid and decodes successfully. Malformed title values decode as
+`nil` so the notification is ignored instead of dropping the whole update.
+
+Encoding mirrors the payload for test symmetry, even though Alas does not emit
+this notification.
+
+## Runtime Behavior
+
+Handle `.sessionInfoUpdate` in `ACPSessionRunner`, alongside other incoming ACP
+updates. The runner already owns update consumption, write-lease checks, and
+session-row persistence.
+
+When a notification arrives:
+
+1. Return without changing state if `title` is nil.
+2. Trim whitespace and newlines.
+3. Return without changing state if the trimmed title is empty.
+4. Return without changing state if `session.titleSource == .manual`.
+5. Attempt to persist the title with a store helper guarded by
+   `title_source != 'manual'` and `archived = 0`.
+6. On successful persistence, set the live session title to the trimmed title
+   and set `titleSource = .generated`.
+7. Call `onSessionTitleUpdated(trimmed)` so app-level glue can rename matching
+   ACP tabs.
+8. If persistence refuses the update because the stored row is now manual,
+   reload the stored row and restore the live session title/source.
+
+This allows adapter titles to replace both `.placeholder` and existing
+`.generated` titles, including the first-prompt fallback title. It never
+overwrites `.manual`.
+
+## Persistence
+
+Add this `ACPSessionStore` helper:
+
+```swift
+func updateGeneratedTitleIfNotManual(id: String, title: String, updatedAt: Int64) throws -> Bool
+```
+
+The SQL update should:
+
+- set `title = ?`
+- set `title_source = 'generated'`
+- set `updated_at = ?`
+- match `id = ?`
+- require `archived = 0`
+- require `title_source != 'manual'`
+
+Keep the existing placeholder-only helper for the first-prompt fallback so that
+local prompt-derived titles still only replace untouched placeholders.
+
+## Tab Synchronization
+
+Open tab rendering already prefers a live `ACPSession.title` through
+`titleLookup`, falling back to `ACPSessionTabState.title`. Accepted adapter
+titles must also update matching stored ACP tabs so fallback titles remain
+correct after app restart or session eviction.
+
+Keep `TabsManager` out of ACP session internals. Add an
+`onSessionTitleUpdated: (ACPSession.ID, String) -> Void` callback to
+`ACPSessionManager`, pass it into each `ACPSessionRunner` as a runner-local
+`onSessionTitleUpdated: (String) -> Void`, and let app-level wiring call:
+
+```swift
+tabs.renameACPSessionTabs(worktreeId: manager.worktreeId,
+                          sessionId: session.id,
+                          title: trimmed)
+```
+
+The callback should also refresh recent session rows so sidebars and remote
+session lists can observe the updated title.
+
+## Error Handling
+
+- Missing title: ignore.
+- Whitespace-only title: ignore.
+- Manual live title: ignore without touching storage.
+- Manual stored title discovered during persistence: restore the live title and
+  source from storage.
+- Archived session: persistence returns false; do not update live title or tabs.
+- Unknown ACP update kinds continue to decode as `.unknown`.
+
+No user-facing error is needed. These notifications are opportunistic metadata.
+
+## Tests
+
+Add focused Swift Testing coverage:
+
+- Protocol decode:
+  - decodes title and `updatedAt`
+  - decodes when title is absent
+  - keeps unknown update handling unchanged
+- Store:
+  - updates `.placeholder` rows to `.generated`
+  - updates `.generated` rows to `.generated`
+  - refuses `.manual`
+  - refuses archived rows
+- Runner integration:
+  - `ACPMockClient` `session_info_update` updates live title and persistence
+  - generated title can replace first-prompt generated title
+  - manual title is preserved
+  - empty/whitespace title is ignored
+
+Run relevant ACP protocol/session tests first, then the normal project build and
+test commands when moving from implementation to completion.


### PR DESCRIPTION
## Summary
- Decode ACP `session_info_update` notifications and model generated title metadata.
- Persist accepted generated titles without overwriting manually titled sessions.
- Sync accepted generated ACP titles through session runners, recents, and open tabs.

## Test Plan
- `ALAS_FFF_TARGET_ARCH=arm64 xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -only-testing:AlasTests/ACPSessionInfoUpdateDecodeTests test`
- `ALAS_FFF_TARGET_ARCH=arm64 xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -only-testing:AlasTests/ACPSessionStoreCRUDTests test`
- `ALAS_FFF_TARGET_ARCH=arm64 xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -only-testing:AlasTests/ACPSessionRunnerTests test`

Full suite intentionally left to CI because this local machine is resource constrained.

## Notes
- Local unmodified universal fff build path is still affected by Homebrew Rust missing usable `x86_64-apple-darwin` std/core; targeted checks used the native `arm64` fff override.
- 
closes #613 