### PR TITLE
fix(updater): cask trust

### DIFF
--- a/Alas/Sources/Updates/SelfUpdater.swift
+++ b/Alas/Sources/Updates/SelfUpdater.swift
@@ -1,10 +1,11 @@
 import Foundation
 import Observation
 
-/// Command shape for a self-update operation. For now this is always
-/// `brew upgrade --cask alas`, but wrapping it makes `SelfUpdater` testable
-/// and avoids scattering the command across views.
+/// Command shape for a self-update operation. Wrapping the Homebrew command
+/// makes `SelfUpdater` testable and avoids scattering it across views.
 struct SelfUpdateCommand: Equatable, Sendable {
+    static let alasHomebrewCask = "mrmans0n/tap/alas"
+
     let executable: String
     let arguments: [String]
 
@@ -17,7 +18,7 @@ struct SelfUpdateCommand: Equatable, Sendable {
         let executable = host.detected[.brew]?.executable ?? "/opt/homebrew/bin/brew"
         return SelfUpdateCommand(
             executable: executable,
-            arguments: ["upgrade", "--cask", "alas"]
+            arguments: ["upgrade", "--cask", alasHomebrewCask]
         )
     }
 

--- a/Alas/Sources/Updates/UpdateAvailableSheet.swift
+++ b/Alas/Sources/Updates/UpdateAvailableSheet.swift
@@ -10,7 +10,7 @@ struct UpdateAvailableSheet: View {
     let onRunUpdate: () -> Void
     @Environment(\.theme) var theme
 
-    private let brewCommand = "brew upgrade --cask alas"
+    private let brewCommand = SelfUpdateCommand.homebrew.displayCommandLine
 
     private var subtitleText: String {
         switch info {

--- a/AlasTests/Updates/SelfUpdaterTests.swift
+++ b/AlasTests/Updates/SelfUpdaterTests.swift
@@ -7,8 +7,8 @@ struct SelfUpdaterTests {
     @Test("homebrew command has correct arguments and display line")
     func homebrewCommandShape() {
         let command = SelfUpdateCommand.homebrew
-        #expect(command.arguments == ["upgrade", "--cask", "alas"])
-        #expect(command.displayCommandLine == "brew upgrade --cask alas")
+        #expect(command.arguments == ["upgrade", "--cask", "mrmans0n/tap/alas"])
+        #expect(command.displayCommandLine == "brew upgrade --cask mrmans0n/tap/alas")
     }
 
     @Test("echo transitions idle → running → finished(0)")


### PR DESCRIPTION
## Summary

- Qualify the Homebrew updater cask as `mrmans0n/tap/alas`.
- Update `SelfUpdaterTests` to lock in the new command shape.

## Why

Homebrew's newer tap trust checks can reject loading the third-party `alas` cask when the updater invokes the unqualified token. Passing the fully qualified cask name makes the update command an explicit selection of the tap cask without mutating the user's trust store.

## Validation

- `rtk brew upgrade --cask mrmans0n/tap/alas --dry-run`
- `rtk env ALAS_FFF_TARGET_ARCH=arm64 xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS,arch=arm64' -quiet build`
- `rtk env ALAS_FFF_TARGET_ARCH=arm64 xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS,arch=arm64' -only-testing:AlasTests/SelfUpdaterTests test`

Full local test suite was intentionally not run on this resource-constrained machine; CI should cover the broader matrix.