### PR TITLE
fix(acp): audit and harden JSON-RPC cancellation teardown

### DIFF
--- a/Alas/Sources/ACP/Protocol/ACPStdioClient.swift
+++ b/Alas/Sources/ACP/Protocol/ACPStdioClient.swift
@@ -224,9 +224,13 @@ final class ACPStdioClient: ACPClient, @unchecked Sendable {
                 try transport.send(body)
             } catch {
                 stateLock.lock()
-                pending.removeValue(forKey: id)
+                // If a concurrent drainPending (shutdown()/`.exited`) already
+                // removed and resumed this entry, `removeValue` returns nil
+                // here — in that case `cont` has already been resumed and we
+                // must not resume it again (that would trap).
+                let stillPending = pending.removeValue(forKey: id) != nil
                 stateLock.unlock()
-                cont.resume(throwing: error)
+                if stillPending { cont.resume(throwing: error) }
             }
         }
         return ACPResponse(body: data)
@@ -322,6 +326,10 @@ final class ACPStdioClient: ACPClient, @unchecked Sendable {
     /// Resumes and clears every pending outbound continuation exactly once.
     /// Safe to call from both `shutdown()` and the `.exited` handler; the
     /// second caller is a no-op (double-resuming a CheckedContinuation traps).
+    /// This can also race a concurrent `send(_:)` whose `transport.send`
+    /// subsequently throws for the same `id`; `send(_:)` guards against
+    /// double-resuming in that case by only resuming if its own
+    /// `pending.removeValue` still found the entry.
     private func drainPending(with error: Error) {
         stateLock.lock()
         if didDrainPending {

--- a/Alas/Sources/ACP/Protocol/ACPStdioClient.swift
+++ b/Alas/Sources/ACP/Protocol/ACPStdioClient.swift
@@ -25,6 +25,7 @@ final class ACPStdioClient: ACPClient, @unchecked Sendable {
     private var nextId: Int = 0
     private var _yieldedUpdateCount = 0
     private var pending: [JSONRPCID: CheckedContinuation<Data, Error>] = [:]
+    private var didDrainPending = false
     private var dispatchTask: Task<Void, Never>?
 
     init(executable: URL, arguments: [String], environment: [String: String]?) throws {
@@ -117,11 +118,7 @@ final class ACPStdioClient: ACPClient, @unchecked Sendable {
         case .stderr(let data):
             stderrCont.yield(data)
         case .exited:
-            stateLock.lock()
-            let snapshot = pending
-            pending.removeAll()
-            stateLock.unlock()
-            for (_, cont) in snapshot { cont.resume(throwing: ACPClientError.notRunning) }
+            drainPending(with: ACPClientError.notRunning)
             updatesCont.finish()
             permsCont.finish()
             questionsCont.finish()
@@ -216,6 +213,11 @@ final class ACPStdioClient: ACPClient, @unchecked Sendable {
         let body = try Self.encode(envelopeFor: request, id: id)
         let data: Data = try await withCheckedThrowingContinuation { (cont: CheckedContinuation<Data, Error>) in
             stateLock.lock()
+            if didDrainPending {
+                stateLock.unlock()
+                cont.resume(throwing: ACPClientError.notRunning)
+                return
+            }
             pending[id] = cont
             stateLock.unlock()
             do {
@@ -317,7 +319,24 @@ final class ACPStdioClient: ACPClient, @unchecked Sendable {
         } catch {}
     }
 
+    /// Resumes and clears every pending outbound continuation exactly once.
+    /// Safe to call from both `shutdown()` and the `.exited` handler; the
+    /// second caller is a no-op (double-resuming a CheckedContinuation traps).
+    private func drainPending(with error: Error) {
+        stateLock.lock()
+        if didDrainPending {
+            stateLock.unlock()
+            return
+        }
+        didDrainPending = true
+        let snapshot = pending
+        pending.removeAll()
+        stateLock.unlock()
+        for (_, cont) in snapshot { cont.resume(throwing: error) }
+    }
+
     func shutdown() async {
+        drainPending(with: ACPClientError.notRunning)
         transport.terminate()
         dispatchTask?.cancel()
     }

--- a/Alas/Sources/ACP/Session/ACPSessionRunner.swift
+++ b/Alas/Sources/ACP/Session/ACPSessionRunner.swift
@@ -318,6 +318,10 @@ final class ACPSessionRunner {
         filesTask?.cancel()
         terminalsTask?.cancel()
         resolvePendingQuestion(.init(outcome: .cancelled), restorePreviousState: false)
+        // A detach/takeover can land while a permission prompt is parked.
+        // userCancel() already resolves it; stop() must too, or the policy's
+        // continuation is stranded when we tear the connection down.
+        policy.userCancelled()
         // Kill agent-spawned subprocesses now. ACPSessionManager keeps
         // the ACPSession cached after detach, so the session's deinit-
         // time killAll() won't fire on tab close — without this an

--- a/AlasTests/ACP/Protocol/ACPStdioClientTests.swift
+++ b/AlasTests/ACP/Protocol/ACPStdioClientTests.swift
@@ -57,8 +57,17 @@ struct ACPStdioClientTests {
     private final class ResultBox<T>: @unchecked Sendable {
         private let lock = NSLock()
         private var value: T?
-        func set(_ v: T) { lock.lock(); value = v; lock.unlock() }
-        func get() -> T? { lock.lock(); defer { lock.unlock() }; return value }
+        func set(_ v: T) {
+            lock.lock()
+            value = v
+            lock.unlock()
+        }
+
+        func get() -> T? {
+            lock.lock()
+            defer { lock.unlock() }
+            return value
+        }
     }
 
     /// Runs `work` in a detached task and returns its result, or nil if it

--- a/AlasTests/ACP/Protocol/ACPStdioClientTests.swift
+++ b/AlasTests/ACP/Protocol/ACPStdioClientTests.swift
@@ -54,18 +54,31 @@ struct ACPStdioClientTests {
         await client.shutdown()
     }
 
-    /// Runs `work`, but returns nil if it doesn't finish within `timeout`.
-    private func firstToFinish<T: Sendable>(
-        _ timeout: Duration,
+    private final class ResultBox<T>: @unchecked Sendable {
+        private let lock = NSLock()
+        private var value: T?
+        func set(_ v: T) { lock.lock(); value = v; lock.unlock() }
+        func get() -> T? { lock.lock(); defer { lock.unlock() }; return value }
+    }
+
+    /// Runs `work` in a detached task and returns its result, or nil if it
+    /// does not finish within roughly `steps * step`. A work item that never
+    /// completes (e.g. a parked continuation on a regressed drain) is
+    /// abandoned rather than awaited, so a regression surfaces as a bounded
+    /// nil result instead of hanging the whole test run.
+    private func boundedResult<T: Sendable>(
+        steps: Int = 150,
+        step: Duration = .milliseconds(20),
         _ work: @escaping @Sendable () async -> T
     ) async -> T? {
-        await withTaskGroup(of: T?.self) { group in
-            group.addTask { await work() }
-            group.addTask { try? await Task.sleep(for: timeout); return nil }
-            let result = await group.next() ?? nil
-            group.cancelAll()
-            return result
+        let box = ResultBox<T>()
+        let task = Task.detached { box.set(await work()) }
+        for _ in 0..<steps {
+            if let v = box.get() { return v }
+            try? await Task.sleep(for: step)
         }
+        task.cancel()
+        return box.get()
     }
 
     @Test("shutdown resumes an in-flight request even when the transport never emits .exited")
@@ -76,7 +89,7 @@ struct ACPStdioClientTests {
         try? client.start()
 
         // Fire a request the fake never answers; shutdown must unblock it.
-        async let threw = firstToFinish(.seconds(3)) { () -> Bool in
+        async let threw = boundedResult { () -> Bool in
             do {
                 _ = try await client.send(ACPRequest(
                     method: "session/prompt",
@@ -98,7 +111,7 @@ struct ACPStdioClientTests {
         let client = ACPStdioClient.makeForTesting(transport: transport)
         try? client.start()
 
-        async let threw = firstToFinish(.seconds(3)) { () -> Bool in
+        async let threw = boundedResult { () -> Bool in
             do {
                 _ = try await client.send(ACPRequest(
                     method: "session/prompt",
@@ -121,7 +134,7 @@ struct ACPStdioClientTests {
         try? client.start()
         let connection = ACPConnection(client: client)
 
-        async let threw = firstToFinish(.seconds(3)) { () -> Bool in
+        async let threw = boundedResult { () -> Bool in
             do {
                 try await connection.prompt(sessionId: "s", blocks: [])
                 return false

--- a/AlasTests/ACP/Protocol/ACPStdioClientTests.swift
+++ b/AlasTests/ACP/Protocol/ACPStdioClientTests.swift
@@ -53,4 +53,84 @@ struct ACPStdioClientTests {
         } else { Issue.record("expected agent_message_chunk 'hi'") }
         await client.shutdown()
     }
+
+    /// Runs `work`, but returns nil if it doesn't finish within `timeout`.
+    private func firstToFinish<T: Sendable>(
+        _ timeout: Duration,
+        _ work: @escaping @Sendable () async -> T
+    ) async -> T? {
+        await withTaskGroup(of: T?.self) { group in
+            group.addTask { await work() }
+            group.addTask { try? await Task.sleep(for: timeout); return nil }
+            let result = await group.next() ?? nil
+            group.cancelAll()
+            return result
+        }
+    }
+
+    @Test("shutdown resumes an in-flight request even when the transport never emits .exited")
+    func shutdownDrainsPendingWithoutExit() async {
+        let transport = FakeJSONRPCTransport()
+        transport.emitExitOnTerminate = false // real-transport behaviour: no synchronous .exited
+        let client = ACPStdioClient.makeForTesting(transport: transport)
+        try? client.start()
+
+        // Fire a request the fake never answers; shutdown must unblock it.
+        async let threw = firstToFinish(.seconds(3)) { () -> Bool in
+            do {
+                _ = try await client.send(ACPRequest(
+                    method: "session/prompt",
+                    params: ACPSessionPromptParams(sessionId: "s", prompt: [])))
+                return false
+            } catch {
+                return true
+            }
+        }
+        try? await Task.sleep(for: .milliseconds(100)) // let send() register in `pending`
+        await client.shutdown()
+
+        #expect(await threw == true)
+    }
+
+    @Test("shutdown drain is idempotent with a transport that also emits .exited")
+    func shutdownDrainIsIdempotent() async {
+        let transport = FakeJSONRPCTransport() // emitExitOnTerminate defaults to true
+        let client = ACPStdioClient.makeForTesting(transport: transport)
+        try? client.start()
+
+        async let threw = firstToFinish(.seconds(3)) { () -> Bool in
+            do {
+                _ = try await client.send(ACPRequest(
+                    method: "session/prompt",
+                    params: ACPSessionPromptParams(sessionId: "s", prompt: [])))
+                return false
+            } catch { return true }
+        }
+        try? await Task.sleep(for: .milliseconds(100))
+        await client.shutdown()
+        // If the .exited handler re-resumed the same continuation the process
+        // would have already trapped; reaching this line means it did not.
+        #expect(await threw == true)
+    }
+
+    @Test("ACPConnection.shutdown unwinds an in-flight prompt")
+    func connectionShutdownUnwindsPrompt() async {
+        let transport = FakeJSONRPCTransport()
+        transport.emitExitOnTerminate = false
+        let client = ACPStdioClient.makeForTesting(transport: transport)
+        try? client.start()
+        let connection = ACPConnection(client: client)
+
+        async let threw = firstToFinish(.seconds(3)) { () -> Bool in
+            do {
+                try await connection.prompt(sessionId: "s", blocks: [])
+                return false
+            } catch {
+                return true
+            }
+        }
+        try? await Task.sleep(for: .milliseconds(100))
+        await connection.shutdown()
+        #expect(await threw == true)
+    }
 }

--- a/AlasTests/ACP/Protocol/FakeJSONRPCTransport.swift
+++ b/AlasTests/ACP/Protocol/FakeJSONRPCTransport.swift
@@ -23,8 +23,15 @@ final class FakeJSONRPCTransport: JSONRPCStdioTransporting, @unchecked Sendable 
         sentFrames.append(data)
     }
 
+    /// When false, `terminate()` does not synthesise an `.exited` event —
+    /// mirroring the real `JSONRPCStdioTransport`, whose SIGTERM is async and
+    /// whose `.exited` is delivered later (or never, for a wedged adapter).
+    var emitExitOnTerminate = true
+
     func terminate() {
-        cont.yield(.exited(0))
+        if emitExitOnTerminate {
+            cont.yield(.exited(0))
+        }
         cont.finish()
     }
 

--- a/AlasTests/ACP/Session/ACPSessionRunnerTests.swift
+++ b/AlasTests/ACP/Session/ACPSessionRunnerTests.swift
@@ -637,6 +637,34 @@ struct ACPSessionRunnerTests {
         #expect(text.value == "hello world")
     }
 
+    @Test("stop() resolves a parked permission continuation as cancelled")
+    func stopResolvesParkedPermission() async throws {
+        let (runner, _) = try makeRunner()
+
+        // Park a permission decision: autoRun is off and nothing is logged,
+        // so evaluate() binds to the UI and suspends on its continuation.
+        let toolCall = ACPPermissionToolCall(
+            toolCallId: "call_1", title: nil, kind: nil, status: nil,
+            content: nil, locations: nil, rawInput: nil, rawOutput: nil)
+        let params = ACPPermissionRequestParams(
+            sessionId: "s",
+            toolCall: toolCall,
+            options: [ACPPermissionOption(optionId: "allow", name: "Allow", kind: "allow_once"),
+                      ACPPermissionOption(optionId: "reject", name: "Reject", kind: "reject_once")])
+        async let decision = runner.policy.evaluate(
+            scopeKey: "scope",
+            options: params.options,
+            params: params)
+
+        // Give evaluate() a beat to register its continuation.
+        try? await Task.sleep(for: .milliseconds(100))
+
+        runner.stop()
+
+        let response = await decision
+        #expect(response.outcome == .cancelled)
+    }
+
     @Test("takeover flush excludes chunks received after lease loss")
     func takeoverFlushExcludesChunksReceivedAfterLeaseLoss() async throws {
         let url = FileManager.default.temporaryDirectory.appendingPathComponent("rn-\(UUID()).sqlite")


### PR DESCRIPTION
## Summary

Audit and fix of ACP JSON-RPC request-cancellation handling. Alas is the ACP client; `session/cancel` was already sent correctly. The audit found the real gaps were teardown continuation hygiene — pending continuations that could be left suspended, hanging callers and leaking the runner object graph.

Fixes #614.

## Findings addressed

- **Deterministic pending-drain on shutdown.** `ACPStdioClient.shutdown()` only drained its outbound `pending` request map via the transport's `.exited` event, which dispatch-task cancellation could race away — leaving an in-flight `session/prompt` continuation unresumed and leaking the runner → session → connection graph. `shutdown()` now drains `pending` itself via a drain-once `drainPending(with:)` helper (guarded by `stateLock` + a `didDrainPending` flag), with the `.exited` handler kept idempotent. `send()` gains a fast-fail guard after drain and only resumes on transport-send failure if it still owned the pending entry (removes a double-resume → process-trap window).
- **Permission-continuation cleanup on runner stop.** `ACPSessionRunner.stop()` now calls `policy.userCancelled()`, so a detach/takeover landing while a permission prompt is parked can't strand `ACPPermissionPolicy.pendingContinuation` (previously only `userCancel()` resolved it).

## Audit conclusions (acceptance criteria)

- **No extra ACP cancellation notifications needed for abandoned in-flight requests.** User cancel already sends `session/cancel`; every other teardown path (`detach`, `stop`, takeover/`standDown`) calls `connection.shutdown()`, which SIGTERMs the adapter process, so adapter-side work is reaped by process death. The defect was our own continuations not being freed, not missing messages.
- **No RPC timeout added** — a timer is a fragile proxy for a teardown-correctness bug and would risk false-killing legitimately long `session/prompt` turns; deterministic drain-on-teardown fixes it properly.
- SIGKILL escalation in `terminate()` left out of scope (process-lifecycle, distinct from JSON-RPC cancellation).

## Tests

- `FakeJSONRPCTransport` gains an `emitExitOnTerminate` knob so a test can mimic the real async-SIGTERM transport (the synchronous `.exited` previously masked the bug).
- New regression tests: shutdown drains an in-flight request without `.exited`; drain is idempotent with a transport that also emits `.exited`; `ACPConnection.shutdown()` unwinds an in-flight prompt; `stop()` resolves a parked permission continuation as cancelled.
- A `boundedResult` test helper abandons (rather than awaits) a hung task so a future regression fails fast instead of hanging the run.

Focused suites pass locally (`ACPStdioClientTests` 4/4, `ACPSessionRunnerTests` 32/32); full suite runs in CI.
