### PR TITLE
test(acp): cover superseded transcript restore status

### DIFF
--- a/AlasTests/ACP/Session/ACPSessionManagerAttachRestoreTests.swift
+++ b/AlasTests/ACP/Session/ACPSessionManagerAttachRestoreTests.swift
@@ -1059,6 +1059,53 @@ struct ACPSessionManagerAttachRestoreTests {
         await steerGate.release()
     }
 
+    @Test("recovery context superseded by a newer prompt clears the restoring status")
+    func recoveryContextSupersededByNewerPromptClearsStatus() async throws {
+        let store = try ACPSessionStore(path: tmpStorePath())
+        try store.upsertSession(row(remoteSessionId: "remote-new"))
+        try appendMessage(
+            .user(id: UUID(), text: "What changed?", attachments: []),
+            to: store,
+            seq: 0
+        )
+        let client = ACPMockClient()
+        let recoveryGate = PromptGate()
+        let newerPromptGate = PromptGate()
+        let promptCount = PromptCounter()
+        scriptInitialize(client)
+        scriptSessionResult(client, method: "session/load", sessionId: "remote-new")
+        client.scriptAsync(method: "session/prompt") { _ in
+            switch await promptCount.next() {
+            case 1: await recoveryGate.waitInPrompt()
+            case 2: await newerPromptGate.waitInPrompt()
+            default: break
+            }
+            return Data("null".utf8)
+        }
+        let manager = manager(store: store, client: client)
+
+        let session = try #require(manager.placeholderSession(id: "local"))
+        await manager.hydrateIfNeeded(id: "local")
+        await manager.attach(to: session.id, freshlyCreated: false)
+        let runner = try #require(manager.runners[session.id])
+        session.contextRestoreWarning = .init(
+            message: "Agent context could not be restored.",
+            canSendTranscript: true
+        )
+
+        #expect(manager.sendTranscriptAsContext(sessionId: session.id, agentName: "Agent"))
+        #expect(session.contextRecoveryStatus == .sendingTranscript)
+        try await waitUntilAsync { await recoveryGate.hasEntered }
+
+        runner.sendNow(blocks: [.text("actually do this instead")], queuedItemId: nil)
+        try await waitUntilAsync { await newerPromptGate.hasEntered }
+
+        await recoveryGate.release()
+        try await waitUntil { session.contextRecoveryStatus != .sendingTranscript }
+
+        await newerPromptGate.release()
+    }
+
     @Test("transcript context prompt requires conversation")
     func transcriptContextPromptRequiresConversation() async throws {
         let store = try ACPSessionStore(path: tmpStorePath())
@@ -1300,6 +1347,15 @@ struct ACPSessionManagerAttachRestoreTests {
         }
     }
 
+    private actor PromptCounter {
+        private var count = 0
+
+        func next() -> Int {
+            count += 1
+            return count
+        }
+    }
+
     private actor AuthPromptFailureGate {
         private var entered = false
         private var released = false
@@ -1326,15 +1382,6 @@ struct ACPSessionManagerAttachRestoreTests {
             released = true
             continuation?.resume()
             continuation = nil
-        }
-    }
-
-    private actor PromptCounter {
-        private var count = 0
-
-        func next() -> Int {
-            count += 1
-            return count
         }
     }
 }


### PR DESCRIPTION
## Summary

- Add a regression test for transcript recovery being superseded by a newer prompt while the restore status is still `sendingTranscript`.
- Keep PR #620's production behavior covered for a broader supersession path, not just steer.

## Context

After rebasing onto current `main`, the production callback fix from PR #620 is already present. This PR keeps the additional regression coverage that reproduces the status-clearing invariant directly: recovery completion must resolve even when another prompt owns the transport.

## Validation

- `env ALAS_FFF_TARGET_ARCH=arm64 rtk xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS,arch=arm64' -only-testing:AlasTests/ACPSessionManagerAttachRestoreTests test`