### PR TITLE
fix(remote): make config sheet scrollable when model list overflows

### DIFF
--- a/Alas/Resources/RemoteWeb/index.html
+++ b/Alas/Resources/RemoteWeb/index.html
@@ -11,7 +11,7 @@
   <link rel="icon" href="/icon.svg" type="image/svg+xml" />
   <link rel="apple-touch-icon" href="/icon-180.png" />
   <title>Alas Remote</title>
-  <link rel="stylesheet" href="/style.css?v=33" />
+  <link rel="stylesheet" href="/style.css?v=34" />
 </head>
 <body>
   <header id="bar">
@@ -67,18 +67,20 @@
   </div>
   <div id="cfg" class="sheet hidden">
     <div class="sheet-card">
-      <div id="cfg-model-section">
-        <p class="sheet-title">Model</p>
-        <div id="cfg-models"></div>
+      <div id="cfg-scroll">
+        <div id="cfg-model-section">
+          <p class="sheet-title">Model</p>
+          <div id="cfg-models"></div>
+        </div>
+        <div id="cfg-mode-section">
+          <p class="sheet-title">Mode</p>
+          <div id="cfg-modes"></div>
+        </div>
+        <label id="cfg-autorun-row">
+          <span>Auto-run tools</span>
+          <input id="cfg-autorun" type="checkbox" />
+        </label>
       </div>
-      <div id="cfg-mode-section">
-        <p class="sheet-title">Mode</p>
-        <div id="cfg-modes"></div>
-      </div>
-      <label id="cfg-autorun-row">
-        <span>Auto-run tools</span>
-        <input id="cfg-autorun" type="checkbox" />
-      </label>
       <button id="cfg-close" class="sheet-close">Close</button>
     </div>
   </div>

--- a/Alas/Resources/RemoteWeb/style.css
+++ b/Alas/Resources/RemoteWeb/style.css
@@ -169,6 +169,9 @@ h1 { font-size: 22px; font-weight: 700; margin: 12px 4px 10px; }
 #attach:active, #config:active { color: var(--fg-muted); }
 
 /* Config sheet (⚙) — reuses .option-btn / .is-selected for the radio lists. */
+#cfg .sheet-card { max-height: min(85vh, 640px); display: flex; flex-direction: column; }
+#cfg-scroll { min-height: 0; overflow-y: auto; -webkit-overflow-scrolling: touch; }
+#cfg-close { flex: 0 0 auto; }
 #cfg-model-section, #cfg-mode-section { margin-bottom: 14px; }
 #cfg-autorun-row { display: flex; align-items: center; justify-content: space-between; gap: 12px; padding: 12px 14px; margin: 6px 0; border: 1px solid var(--bg-4); border-radius: 10px; background: var(--bg-1); color: var(--fg); font-size: 15px; cursor: pointer; }
 #cfg-autorun { width: 20px; height: 20px; accent-color: var(--accent); cursor: pointer; }

--- a/Alas/Resources/RemoteWeb/sw.js
+++ b/Alas/Resources/RemoteWeb/sw.js
@@ -1,8 +1,8 @@
-const CACHE_NAME = "alas-remote-shell-v24";
+const CACHE_NAME = "alas-remote-shell-v25";
 const SHELL_ASSETS = [
   "/",
   "/index.html",
-  "/style.css?v=33",
+  "/style.css?v=34",
   "/app.js?v=48",
   "/marked.min.js?v=28",
   "/purify.min.js?v=28",

--- a/AlasTests/Remote/RemoteWebAssetTests.swift
+++ b/AlasTests/Remote/RemoteWebAssetTests.swift
@@ -49,10 +49,10 @@ struct RemoteWebAssetTests {
         let sw = try asset("sw.js")
 
         #expect(html.contains(#"/app.js?v=48"#))
-        #expect(html.contains(#"/style.css?v=33"#))
-        #expect(sw.contains(#"const CACHE_NAME = "alas-remote-shell-v24";"#))
+        #expect(html.contains(#"/style.css?v=34"#))
+        #expect(sw.contains(#"const CACHE_NAME = "alas-remote-shell-v25";"#))
         #expect(sw.contains(#""/app.js?v=48""#))
-        #expect(sw.contains(#""/style.css?v=33""#))
+        #expect(sw.contains(#""/style.css?v=34""#))
     }
 
     @Test func remoteWebToolRowsAvoidNativeButtonRenderingOnMobileSafari() throws {
@@ -66,10 +66,10 @@ struct RemoteWebAssetTests {
         #expect(app.contains("function handleCardToggleKeydown"))
         #expect(!app.contains(#"const button = el("button", "tool-toggle")"#))
         #expect(html.contains(#"/app.js?v=48"#))
-        #expect(html.contains(#"/style.css?v=33"#))
-        #expect(sw.contains(#"const CACHE_NAME = "alas-remote-shell-v24";"#))
+        #expect(html.contains(#"/style.css?v=34"#))
+        #expect(sw.contains(#"const CACHE_NAME = "alas-remote-shell-v25";"#))
         #expect(sw.contains(#""/app.js?v=48""#))
-        #expect(sw.contains(#""/style.css?v=33""#))
+        #expect(sw.contains(#""/style.css?v=34""#))
     }
 
     @Test func remoteBareURLLinkifierPreservesIndentedCodeBlocks() throws {
@@ -111,7 +111,7 @@ struct RemoteWebAssetTests {
         #expect(css.contains(".session-state-inactive"))
         #expect(css.contains(".session-meta"))
         #expect(html.contains("/app.js?v=48"))
-        #expect(html.contains("/style.css?v=33"))
+        #expect(html.contains("/style.css?v=34"))
     }
 
     @Test func remoteWebExposesSessionRenameControls() throws {
@@ -137,7 +137,20 @@ struct RemoteWebAssetTests {
         #expect(css.contains("#detail-title"))
         #expect(css.contains(".sheet-input"))
         #expect(sw.contains(#""/app.js?v=48""#))
-        #expect(sw.contains(#""/style.css?v=33""#))
+        #expect(sw.contains(#""/style.css?v=34""#))
+    }
+
+    @Test func configSheetScrollsWhenModelListOverflows() throws {
+        let html = try asset("index.html")
+        let css = try asset("style.css")
+
+        // The config sheet content lives in a dedicated scroll region so that a
+        // long model list stays reachable instead of overflowing off the top of
+        // the viewport (the sheet is anchored to the bottom via align-items: flex-end).
+        #expect(html.contains(#"<div id="cfg-scroll">"#))
+        #expect(css.contains("#cfg .sheet-card { max-height: min(85vh, 640px); display: flex; flex-direction: column; }"))
+        #expect(css.contains("#cfg-scroll { min-height: 0; overflow-y: auto; -webkit-overflow-scrolling: touch; }"))
+        #expect(css.contains("#cfg-close { flex: 0 0 auto; }"))
     }
 
     @Test func remoteWebIncludesNewSessionControls() throws {


### PR DESCRIPTION
## Problem

In the remote web app chat screen, opening the gear/cogwheel (config) sheet showed a bottom sheet whose card was anchored to the bottom of the viewport (`.sheet` uses `align-items: flex-end`) but had no height cap and no scroll container. When the model list is long, the card overflowed off the **top** of the screen, so the newest models (rendered at the top) were unreachable — there was no way to scroll up to them.

## Fix

Wrap the config sheet content (model + mode + auto-run) in a dedicated, height-capped scroll region with the Close button pinned below it, mirroring the existing new-session (`.create-sheet`) pattern already used elsewhere in the same stylesheet:

- `#cfg .sheet-card` becomes a height-capped flex column (`max-height: min(85vh, 640px)`).
- `#cfg-scroll` gets `min-height: 0; overflow-y: auto` so a long list scrolls internally instead of pushing content off-screen.
- `#cfg-close` stays pinned (`flex: 0 0 auto`).

Bumped the `style.css` cache-buster (`v=33` → `v=34`) and the service-worker cache name (`v24` → `v25`) so clients pick up the new stylesheet, and updated the asset-version tests accordingly.

## Tests

Added `configSheetScrollsWhenModelListOverflows` to `RemoteWebAssetTests` locking in the scroll-region markup and CSS, and updated the existing cache-buster assertions.