### PR TITLE
feat(acp): Enrich ACP transcript event handling

### DIFF
--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -72,6 +72,7 @@
 		10557FBC430EEAB1196D9575 /* AgentDetector.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2071DA26A16E9A4A5AC5B3C3 /* AgentDetector.swift */; };
 		106120CBE8107E0AC4EA353A /* ProcessKiller.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F3A345F0B643467352DB5F3 /* ProcessKiller.swift */; };
 		1066AF44E2FCA9B1B2DDE9D7 /* EditorTabView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6E8B52175A7F6144B4C52010 /* EditorTabView.swift */; };
+		10C27B7147AF2D41AD109E9A /* session-update-session-info-goal.json in Resources */ = {isa = PBXBuildFile; fileRef = 2D751485790AD46EBC15A979 /* session-update-session-info-goal.json */; };
 		10F83C7DA89B3BF168E47310 /* DiffSelectableTextTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C34ED0F4DB5FB6620993ECFC /* DiffSelectableTextTests.swift */; };
 		111516874CEE27D789DF61E9 /* ReviewChangesFileSection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 41995BCAEF1E2B356E499333 /* ReviewChangesFileSection.swift */; };
 		11315A703B2F9C4CBB3CABD3 /* CommitRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3DCEFADD952DB870B8BAB890 /* CommitRow.swift */; };
@@ -123,6 +124,7 @@
 		1B7A283F7F585BA8D67C1959 /* ACPSteerUndoToast.swift in Sources */ = {isa = PBXBuildFile; fileRef = C741E646CFDECE0AF9520265 /* ACPSteerUndoToast.swift */; };
 		1B9CC3C13E96290B391E7C26 /* ImagePreviewTabView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 12E1AD3C6506DA5E6BFF4864 /* ImagePreviewTabView.swift */; };
 		1BC03FAEA1E89F3A74A98DE4 /* AppConfigShortcutsCodingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45513A6B9EAA4E9744502597 /* AppConfigShortcutsCodingTests.swift */; };
+		1C2C949642E10060172AB1BA /* ACPToolCallPresentationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B77D7A400059AFD189D1CA5A /* ACPToolCallPresentationTests.swift */; };
 		1C5D64F032EAD5EA28B2482B /* ACPComposerActions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2B0206F856D9639147D0A4BF /* ACPComposerActions.swift */; };
 		1D66F354E7488D0CDAC39BE2 /* TreeSitterRuby in Frameworks */ = {isa = PBXBuildFile; productRef = 352A452EE3387A4D9C8DBAD9 /* TreeSitterRuby */; };
 		1DCE55DBA4A9DC466D817D22 /* ProjectConfig.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD77FB052C8B5A937B14A4AE /* ProjectConfig.swift */; };
@@ -325,6 +327,7 @@
 		4780D23AF088EC5923A17102 /* AlasCLIWorktreeResolverTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 311B7CA55176621C35DE3E92 /* AlasCLIWorktreeResolverTests.swift */; };
 		4781661414034F09EA02E0BC /* CommitsOlderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8673293AD419AA36F7DF02A9 /* CommitsOlderTests.swift */; };
 		478863759224A2278123B7B9 /* GitServiceStagedTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C2CA853E91C240B7B5551859 /* GitServiceStagedTests.swift */; };
+		47906F46D5F1337F696C54C5 /* session-update-tool-call-update-meta.json in Resources */ = {isa = PBXBuildFile; fileRef = 274681651A972F6771B1930C /* session-update-tool-call-update-meta.json */; };
 		48040D7ABD4A23B3947E945F /* ACPThoughtView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0FB91182CAC794B0BEDD222D /* ACPThoughtView.swift */; };
 		481DEBE64E91C54A81185D09 /* ACPAdapterVersionCheckerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5EF6536F169B7C7B2C339B1C /* ACPAdapterVersionCheckerTests.swift */; };
 		4896E5C8D1D4A5C0EC7473BF /* fs-write.json in Resources */ = {isa = PBXBuildFile; fileRef = 8526C9DB63760BDD2CE998BD /* fs-write.json */; };
@@ -381,6 +384,7 @@
 		5585C223E2CB23CD8650A5DC /* MergeActionGutter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 56780EE994E2CA14A3ABBA7B /* MergeActionGutter.swift */; };
 		55A6D67E063518A3A757EE18 /* GeminiInstaller.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD0EBA9DC694E3F11300FC6C /* GeminiInstaller.swift */; };
 		55C7881F382ACCEBCDB7D157 /* AgentsPane.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5BB6172AE118D2F9A40FD534 /* AgentsPane.swift */; };
+		55F30DD1D8943C46FD4D1608 /* session-update-tool-call-meta.json in Resources */ = {isa = PBXBuildFile; fileRef = 3E3ADEB5299C3FFB091D55EE /* session-update-tool-call-meta.json */; };
 		5632CE3BB7220370D87A987B /* AgentLauncherModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45D8B88C4D4837376C123D45 /* AgentLauncherModelTests.swift */; };
 		5685074AFE30889AAC69EB8D /* ThreePaneLayout.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5377288BFD5A1B410E141C54 /* ThreePaneLayout.swift */; };
 		56891962450BF0BF596A428A /* TreeSitterKotlin in Frameworks */ = {isa = PBXBuildFile; productRef = 69B81D6B7546F6A8AF3207E9 /* TreeSitterKotlin */; };
@@ -640,6 +644,7 @@
 		9547580C9DFECD838C120B90 /* DiffReviewRenderEligibility.swift in Sources */ = {isa = PBXBuildFile; fileRef = 389D0EB957CCC8447DB9C4FE /* DiffReviewRenderEligibility.swift */; };
 		956B221EC4FF3A18C713A64F /* AppStateTabAvailabilityTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 279D43D7F43C40A004A2C4AC /* AppStateTabAvailabilityTests.swift */; };
 		960593EAB0380436038D1400 /* ACPSessionToolCallTruncationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2777D1596E51D8DCA8E7ABA3 /* ACPSessionToolCallTruncationTests.swift */; };
+		962361DC40B0707AB7CA6E75 /* session-update-tool-call-update-no-meta.json in Resources */ = {isa = PBXBuildFile; fileRef = 30BAC172C16C360F917B6EED /* session-update-tool-call-update-no-meta.json */; };
 		9624AE35A36692177C9EBD38 /* ACPSubmitIntent.swift in Sources */ = {isa = PBXBuildFile; fileRef = A655F5AA40CA10A7685794F7 /* ACPSubmitIntent.swift */; };
 		9654335704CB69BA7216DD63 /* ReviewLoopStateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3939B27EA8D7A562048E5932 /* ReviewLoopStateTests.swift */; };
 		965621529CB4BD82DD646B76 /* ACPManagerAccessorsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B133843C0559BBD6E769ABB8 /* ACPManagerAccessorsTests.swift */; };
@@ -682,6 +687,7 @@
 		9D99FFFDFB3A256C4960D388 /* ReleaseCheckerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C2E0C7ED63A67D16A79DF4BA /* ReleaseCheckerTests.swift */; };
 		9DDA9F2462746F06A652973A /* DiffContextExpansionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2B9CB2A64E9E16A2DE3A6272 /* DiffContextExpansionTests.swift */; };
 		9DF0D37CE59DF8AAD7172443 /* ACPSetupChecker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3E9864A515B0ED49C68739B6 /* ACPSetupChecker.swift */; };
+		9E07DADE0CA5E18F49602D73 /* session-update-session-info-no-meta.json in Resources */ = {isa = PBXBuildFile; fileRef = AEAF044BC36E6083CC1529BE /* session-update-session-info-no-meta.json */; };
 		9E302329243407946D47DC91 /* BranchPicker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2BFD4C762D8323B78934ECE7 /* BranchPicker.swift */; };
 		9E349701BA73BBCCCBB135B3 /* DraftCommitTabView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC3CA543A17D1C3DFA70A80C /* DraftCommitTabView.swift */; };
 		9E4B32E154B18BD2285F0D34 /* CommitDiffView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2EF18448EDA0DCC8B171F11D /* CommitDiffView.swift */; };
@@ -753,6 +759,7 @@
 		AE179E24A9E308150D1FD1D5 /* CommitPromptStatusTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1E40B5F193E3CB5EB5BA945A /* CommitPromptStatusTests.swift */; };
 		AE5BC95F30EE46ED0DE74F23 /* WorkingTreeChangeGroup.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9D32294F9B916DFAFF5E9A6F /* WorkingTreeChangeGroup.swift */; };
 		AEB565CDE2F5AEAE088A1A79 /* ACPChatLayoutTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 90762AFB51B237B783D4190C /* ACPChatLayoutTests.swift */; };
+		AF071864CA8C882F74753E39 /* ACPToolCallPresentation.swift in Sources */ = {isa = PBXBuildFile; fileRef = D710BC995453481F445E2ECF /* ACPToolCallPresentation.swift */; };
 		AF2263B61D95A8BFF0972E93 /* AgentHookEvent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 136BDA12046FB352E183D6A4 /* AgentHookEvent.swift */; };
 		AFD24C0A5D5625A1843751C1 /* ACPFirstRunConnectingPhase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 73539FDFE4BDBD4D3B4DE546 /* ACPFirstRunConnectingPhase.swift */; };
 		B055F47062645975A500E2EF /* ACPPlanPill.swift in Sources */ = {isa = PBXBuildFile; fileRef = B7AAAEB5A9C69FC459AAD70B /* ACPPlanPill.swift */; };
@@ -1283,6 +1290,7 @@
 		269CE27A6F4F2E663EDF9052 /* GitNameValidator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GitNameValidator.swift; sourceTree = "<group>"; };
 		26E8DE57F9A8D5230BCB7A2C /* ACPSubmitIntentTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPSubmitIntentTests.swift; sourceTree = "<group>"; };
 		271F79A165CAA8617C1EAA4E /* GitTypesTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GitTypesTests.swift; sourceTree = "<group>"; };
+		274681651A972F6771B1930C /* session-update-tool-call-update-meta.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "session-update-tool-call-update-meta.json"; sourceTree = "<group>"; };
 		2763F93ADFDCDF6B31D16475 /* UpdateController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UpdateController.swift; sourceTree = "<group>"; };
 		2777D1596E51D8DCA8E7ABA3 /* ACPSessionToolCallTruncationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPSessionToolCallTruncationTests.swift; sourceTree = "<group>"; };
 		279D43D7F43C40A004A2C4AC /* AppStateTabAvailabilityTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppStateTabAvailabilityTests.swift; sourceTree = "<group>"; };
@@ -1315,6 +1323,7 @@
 		2CDDDC4C6146165CA4C7474E /* ACPPlanPillState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPPlanPillState.swift; sourceTree = "<group>"; };
 		2CFB62547E5E1FD480BD0322 /* ACPChangeNotifierTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPChangeNotifierTests.swift; sourceTree = "<group>"; };
 		2D4CC3ED497796474F107EBE /* ReviewLoopDrawer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReviewLoopDrawer.swift; sourceTree = "<group>"; };
+		2D751485790AD46EBC15A979 /* session-update-session-info-goal.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "session-update-session-info-goal.json"; sourceTree = "<group>"; };
 		2D904085EDE14D7C09A6BC9A /* AgentPathResolveTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentPathResolveTests.swift; sourceTree = "<group>"; };
 		2D911D138AF8A0E99191C862 /* ACPLaunchPathResolverTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPLaunchPathResolverTests.swift; sourceTree = "<group>"; };
 		2DCB7DA8B6EA8CF8B98EA267 /* ACPAuthFailure.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPAuthFailure.swift; sourceTree = "<group>"; };
@@ -1332,6 +1341,7 @@
 		2FD28E0005DE3A33A974A511 /* libsqlite3.tbd */ = {isa = PBXFileReference; lastKnownFileType = "sourcecode.text-based-dylib-definition"; name = libsqlite3.tbd; path = usr/lib/libsqlite3.tbd; sourceTree = SDKROOT; };
 		3000211002A1A433AC8DBB3B /* RemoteServerError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteServerError.swift; sourceTree = "<group>"; };
 		3066B2C18213B0105D32213F /* RemoteConfigTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteConfigTests.swift; sourceTree = "<group>"; };
+		30BAC172C16C360F917B6EED /* session-update-tool-call-update-no-meta.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "session-update-tool-call-update-no-meta.json"; sourceTree = "<group>"; };
 		30CBB25BA2F2C558713FB0E4 /* CodeEditorCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CodeEditorCoordinator.swift; sourceTree = "<group>"; };
 		3111744632DAC342A40DB62A /* ACPAdapterUpdateBannerDecider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPAdapterUpdateBannerDecider.swift; sourceTree = "<group>"; };
 		311B7CA55176621C35DE3E92 /* AlasCLIWorktreeResolverTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlasCLIWorktreeResolverTests.swift; sourceTree = "<group>"; };
@@ -1404,6 +1414,7 @@
 		3DCFA45F98F080043C4D664A /* ACPSessionManagerPlanSidebarLayoutTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPSessionManagerPlanSidebarLayoutTests.swift; sourceTree = "<group>"; };
 		3E0616B1F0B84C45792C804E /* ACPSessionRecoveryIntegrationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPSessionRecoveryIntegrationTests.swift; sourceTree = "<group>"; };
 		3E10A1919A8DDC6A8DBB8B97 /* ChangedRow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChangedRow.swift; sourceTree = "<group>"; };
+		3E3ADEB5299C3FFB091D55EE /* session-update-tool-call-meta.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "session-update-tool-call-meta.json"; sourceTree = "<group>"; };
 		3E9864A515B0ED49C68739B6 /* ACPSetupChecker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPSetupChecker.swift; sourceTree = "<group>"; };
 		3F1D8FEB5416139D8B2BA780 /* HoverFeatureRenderingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HoverFeatureRenderingTests.swift; sourceTree = "<group>"; };
 		3F239EBD79AA346B7976B544 /* AdapterUpdateState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AdapterUpdateState.swift; sourceTree = "<group>"; };
@@ -1849,6 +1860,7 @@
 		ADC27B340A795F13EA4E0765 /* ReviewSessionLoaderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReviewSessionLoaderTests.swift; sourceTree = "<group>"; };
 		AE0A6F237480EE72CB8DBE28 /* TitlelessWindowTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TitlelessWindowTests.swift; sourceTree = "<group>"; };
 		AE35206EEBD7E3A35C3421EA /* ACPRecoveryPill.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPRecoveryPill.swift; sourceTree = "<group>"; };
+		AEAF044BC36E6083CC1529BE /* session-update-session-info-no-meta.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "session-update-session-info-no-meta.json"; sourceTree = "<group>"; };
 		AF05DF16587C5A48A9E04B2A /* ACPSessionUsageTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPSessionUsageTests.swift; sourceTree = "<group>"; };
 		AF2F716F911BB20B3E78C40B /* AgentDefinition.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentDefinition.swift; sourceTree = "<group>"; };
 		AF522B02666DB6AC4C82339E /* ACPContextRing.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPContextRing.swift; sourceTree = "<group>"; };
@@ -1882,6 +1894,7 @@
 		B70ED4990428C46B69784970 /* ThemeSidebarContrastTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThemeSidebarContrastTests.swift; sourceTree = "<group>"; };
 		B71D8A91D3A2BD4A522DD9AD /* ACPDiffGenerator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPDiffGenerator.swift; sourceTree = "<group>"; };
 		B77927262BEAF31E39CE6698 /* RecommendedLanguageCatalogTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecommendedLanguageCatalogTests.swift; sourceTree = "<group>"; };
+		B77D7A400059AFD189D1CA5A /* ACPToolCallPresentationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPToolCallPresentationTests.swift; sourceTree = "<group>"; };
 		B78414C2E79104BC6218B1F4 /* ACPPermissionPolicy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPPermissionPolicy.swift; sourceTree = "<group>"; };
 		B78A7E7888D552AFC80BA3AA /* AppConfigTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppConfigTests.swift; sourceTree = "<group>"; };
 		B7AAAEB5A9C69FC459AAD70B /* ACPPlanPill.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPPlanPill.swift; sourceTree = "<group>"; };
@@ -2039,6 +2052,7 @@
 		D64C0B7363363C77718B446C /* CopilotInstaller.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CopilotInstaller.swift; sourceTree = "<group>"; };
 		D65BEFA85B6671FDE505A30D /* CommitMessageEditorView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommitMessageEditorView.swift; sourceTree = "<group>"; };
 		D6A9977C979705A40595FD5E /* TabsManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabsManagerTests.swift; sourceTree = "<group>"; };
+		D710BC995453481F445E2ECF /* ACPToolCallPresentation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPToolCallPresentation.swift; sourceTree = "<group>"; };
 		D7268D601058775FE02B6B06 /* CommitEditorTabView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommitEditorTabView.swift; sourceTree = "<group>"; };
 		D7322805CC904D460A8C53C8 /* ACPPlanSidebarVisibility.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPPlanSidebarVisibility.swift; sourceTree = "<group>"; };
 		D73C433B373577FD515FECD3 /* DiffReviewScrollSpy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiffReviewScrollSpy.swift; sourceTree = "<group>"; };
@@ -3089,6 +3103,7 @@
 				E2D5632302DE981B0BD36273 /* ACPSelectChipMetricsTests.swift */,
 				98A7F35818C95A567DDA586A /* ACPSelectChipTests.swift */,
 				0AB6FA9F258818E8B464CB0A /* ACPSetupNudgeBannerModeTests.swift */,
+				B77D7A400059AFD189D1CA5A /* ACPToolCallPresentationTests.swift */,
 				EDABAB5EEE4C15A78B5429E6 /* ComposerActionTests.swift */,
 			);
 			path = UI;
@@ -3402,6 +3417,7 @@
 				0FB91182CAC794B0BEDD222D /* ACPThoughtView.swift */,
 				E6DE88BE229FD6C1DF35F7EA /* ACPToolbar.swift */,
 				CC3CF39EE3E5E2AB9B0968B3 /* ACPToolCallCard.swift */,
+				D710BC995453481F445E2ECF /* ACPToolCallPresentation.swift */,
 				F01FD27D107E0207950F00D3 /* ACPTopPaginationIndicator.swift */,
 				FE5FDAB31C577FC38CE53032 /* ComposerAction.swift */,
 				531DB20F5FBC0D8240778FE6 /* InlineDiffView.swift */,
@@ -3477,6 +3493,11 @@
 				97DA8F50DDCDAA15CCEA2004 /* session-update-config-options.json */,
 				02347E4D2EA79A5CB8DF82DC /* session-update-current-model.json */,
 				7094534860369BA79FC5A877 /* session-update-plan.json */,
+				2D751485790AD46EBC15A979 /* session-update-session-info-goal.json */,
+				AEAF044BC36E6083CC1529BE /* session-update-session-info-no-meta.json */,
+				3E3ADEB5299C3FFB091D55EE /* session-update-tool-call-meta.json */,
+				274681651A972F6771B1930C /* session-update-tool-call-update-meta.json */,
+				30BAC172C16C360F917B6EED /* session-update-tool-call-update-no-meta.json */,
 				21FCF9A0DD5C474C9E5EC50A /* session-update-tool-call.json */,
 				F0641A41FC56C8F251D0C2BC /* tool-call-content-blocks.json */,
 				9A187BD52742E8F4A6E52667 /* tool-call-content-diff.json */,
@@ -4334,6 +4355,11 @@
 				2434A66A45EDF2609BA9F1D3 /* session-update-config-options.json in Resources */,
 				BF0A3B3A162F31E86DB13404 /* session-update-current-model.json in Resources */,
 				85C7E65296AB9500FF52060A /* session-update-plan.json in Resources */,
+				10C27B7147AF2D41AD109E9A /* session-update-session-info-goal.json in Resources */,
+				9E07DADE0CA5E18F49602D73 /* session-update-session-info-no-meta.json in Resources */,
+				55F30DD1D8943C46FD4D1608 /* session-update-tool-call-meta.json in Resources */,
+				47906F46D5F1337F696C54C5 /* session-update-tool-call-update-meta.json in Resources */,
+				962361DC40B0707AB7CA6E75 /* session-update-tool-call-update-no-meta.json in Resources */,
 				4262F32CB96356E13E3F6608 /* session-update-tool-call.json in Resources */,
 				B834ADF0BB988121361AF334 /* tool-call-content-blocks.json in Resources */,
 				2659BA65A6CABBE800A06AB3 /* tool-call-content-diff.json in Resources */,
@@ -4542,6 +4568,7 @@
 				610486A9FA350E77D1BF594B /* ACPTerminalTailView.swift in Sources */,
 				48040D7ABD4A23B3947E945F /* ACPThoughtView.swift in Sources */,
 				3C30C1EAE4786BB1BE42F994 /* ACPToolCallCard.swift in Sources */,
+				AF071864CA8C882F74753E39 /* ACPToolCallPresentation.swift in Sources */,
 				312DB6016C040DE52CD365E8 /* ACPToolbar.swift in Sources */,
 				303E16565ECF8BDDC7A28AF1 /* ACPTopPaginationIndicator.swift in Sources */,
 				8927B4E929B4180F5B8984F1 /* ACPTranscript.swift in Sources */,
@@ -5135,6 +5162,7 @@
 				11827C40372D7209868161C0 /* ACPTerminalHostTests.swift in Sources */,
 				89F58C7178B661EAE0057622 /* ACPTerminalTests.swift in Sources */,
 				E1E4C11CC5BFF761DF397507 /* ACPToolCallContentTests.swift in Sources */,
+				1C2C949642E10060172AB1BA /* ACPToolCallPresentationTests.swift in Sources */,
 				4B8BD1280C2DFF3CE1FD3C4B /* ACPTranscriptCurrentPlanTests.swift in Sources */,
 				A8EE9207A828D4D1BAF1C1C1 /* ACPTranscriptLatestPlanTests.swift in Sources */,
 				F1C4DD0D3A95ED5301EE2AC9 /* ACPTranscriptMarkdownCacheEvictionTests.swift in Sources */,

--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -154,6 +154,7 @@
 		230BD521ACDBA5BB7AA9167D /* ChangesPreparationModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = D54BBE356A720AF00F2A7C56 /* ChangesPreparationModel.swift */; };
 		238BBB5FC59949CE6ABAFBEF /* ACPCodeBlockHighlighterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 81773A01826A91080F5A2E95 /* ACPCodeBlockHighlighterTests.swift */; };
 		23F92214B30096D070419921 /* ACPQueuedBubbleActionMetricsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5733BF1C52BA0FCFB2724D57 /* ACPQueuedBubbleActionMetricsTests.swift */; };
+		241C661965785076CB3442DA /* ACPGoalPill.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4FAB28A45A3606C316044F3 /* ACPGoalPill.swift */; };
 		2434A66A45EDF2609BA9F1D3 /* session-update-config-options.json in Resources */ = {isa = PBXBuildFile; fileRef = 97DA8F50DDCDAA15CCEA2004 /* session-update-config-options.json */; };
 		249E943D5C46A84496390B31 /* StagedDiffSelectionBridgingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B3DCDC9F76F91CE1071471C /* StagedDiffSelectionBridgingTests.swift */; };
 		24F8EA15B87C38C319B8A66B /* AlasField.swift in Sources */ = {isa = PBXBuildFile; fileRef = D9E6D61B213F3378243B4A26 /* AlasField.swift */; };
@@ -567,6 +568,7 @@
 		839AF384DDFF728207769920 /* ACPContentBlockImageTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4D4DEBF2A9CFDCFDAD288499 /* ACPContentBlockImageTests.swift */; };
 		83A76F6425CD1406DA85B0E9 /* ACPUserScrollEventTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0535D92433898E76670B9FF0 /* ACPUserScrollEventTests.swift */; };
 		84103C99FE430DB2B36982D1 /* OpenSessionsSection.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE35A47BA74E306A4699B27D /* OpenSessionsSection.swift */; };
+		84AFBFC844DF35AF5D37445B /* ACPGoalPillTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BA7FA6A8011D88FDFEE30A0 /* ACPGoalPillTests.swift */; };
 		84C505BF196A3BDA23C80235 /* LanguageServerConfigMasonPrefill.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC01D9A0927AF9DD7524CEB7 /* LanguageServerConfigMasonPrefill.swift */; };
 		84E96EB0EF4267784462B866 /* ACPComposerImageExtractTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A637073E5D65DAA4E0CF6EA4 /* ACPComposerImageExtractTests.swift */; };
 		850D54DB270088190BA20A13 /* DiffInlineCommentCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4526714086C04ED5B472C90 /* DiffInlineCommentCard.swift */; };
@@ -1724,6 +1726,7 @@
 		8AD22187C951174C9ECEC4C4 /* ACPContextUsageButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPContextUsageButton.swift; sourceTree = "<group>"; };
 		8B4BB6C10F3718F7D0A50BAE /* ACPFirstRunConnectingPolicy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPFirstRunConnectingPolicy.swift; sourceTree = "<group>"; };
 		8B94010802299E6AC5597E85 /* WorktreeCodableTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorktreeCodableTests.swift; sourceTree = "<group>"; };
+		8BA7FA6A8011D88FDFEE30A0 /* ACPGoalPillTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPGoalPillTests.swift; sourceTree = "<group>"; };
 		8BCE20FA56461E66A58A7AA2 /* MemorySnapshot.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MemorySnapshot.swift; sourceTree = "<group>"; };
 		8C11E3449E4A7B4E69E83C1C /* AppStatePersistenceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppStatePersistenceTests.swift; sourceTree = "<group>"; };
 		8C245764E69F92CBB8D31BF6 /* GatekeeperRemediator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GatekeeperRemediator.swift; sourceTree = "<group>"; };
@@ -2040,6 +2043,7 @@
 		D43F393A27EF521D4A73B050 /* PendingReviewTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PendingReviewTests.swift; sourceTree = "<group>"; };
 		D46B68FD01B15E3EEA09CB79 /* ACPMessages.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPMessages.swift; sourceTree = "<group>"; };
 		D49B5B544A3432F8D8105268 /* SearchModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchModel.swift; sourceTree = "<group>"; };
+		D4FAB28A45A3606C316044F3 /* ACPGoalPill.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPGoalPill.swift; sourceTree = "<group>"; };
 		D510DACCD80A328B2DFABDC0 /* CompletionFeature.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CompletionFeature.swift; sourceTree = "<group>"; };
 		D52FB6333DDC1A21B0959C1B /* ReviewReadinessModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReviewReadinessModelTests.swift; sourceTree = "<group>"; };
 		D54BBE356A720AF00F2A7C56 /* ChangesPreparationModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChangesPreparationModel.swift; sourceTree = "<group>"; };
@@ -3087,6 +3091,7 @@
 				ECD9419E685AD7EED286006B /* ACPContextRingTests.swift */,
 				DC76F9150CC29A324D785C29 /* ACPDelayedHoverVisibilityTests.swift */,
 				F6EDDD4D22267C26B496A6FF /* ACPFirstRunConnectingPolicyTests.swift */,
+				8BA7FA6A8011D88FDFEE30A0 /* ACPGoalPillTests.swift */,
 				FDE53456308778DF77B18AF4 /* ACPImageEncodingTests.swift */,
 				A53358B7D4D68BE2471187D4 /* ACPImageStagingTests.swift */,
 				84E56989C04A4A478D68084C /* ACPMarkdownBlockCacheTests.swift */,
@@ -3377,6 +3382,7 @@
 				29D7631D754795D16E946440 /* ACPFileEditCard.swift */,
 				8B4BB6C10F3718F7D0A50BAE /* ACPFirstRunConnectingPolicy.swift */,
 				737A9A3D11EA28582CA5D061 /* ACPFirstRunConnectingView.swift */,
+				D4FAB28A45A3606C316044F3 /* ACPGoalPill.swift */,
 				E2C5BD0110EB8EDE7BB4ED93 /* ACPHistorySidebar.swift */,
 				A7FB37A9430467B477E40819 /* ACPImageChipAttachment.swift */,
 				B1615F1953C6FE9D1A30A1A2 /* ACPImageEncoding.swift */,
@@ -4499,6 +4505,7 @@
 				AFD24C0A5D5625A1843751C1 /* ACPFirstRunConnectingPhase.swift in Sources */,
 				9AC7E08307DA010181E2DE58 /* ACPFirstRunConnectingPolicy.swift in Sources */,
 				62055BD147E504C658B93E20 /* ACPFirstRunConnectingView.swift in Sources */,
+				241C661965785076CB3442DA /* ACPGoalPill.swift in Sources */,
 				4E352BDC87A204DE2912F54F /* ACPHarnessBridge.swift in Sources */,
 				F73063B2384B650C227BD09E /* ACPHistorySidebar.swift in Sources */,
 				3D98C4F5EE2C0B1203C76752 /* ACPImageChipAttachment.swift in Sources */,
@@ -5091,6 +5098,7 @@
 				B4C4E13CFE986FC20DC12808 /* ACPFileWriterTests.swift in Sources */,
 				BACDEEE3791E66405294B328 /* ACPFirstRunConnectingPolicyTests.swift in Sources */,
 				43CB2A054DED7568A583822E /* ACPGeminiE2ETests.swift in Sources */,
+				84AFBFC844DF35AF5D37445B /* ACPGoalPillTests.swift in Sources */,
 				01568CB821D2E938C51BBCAB /* ACPHarnessBridgeTests.swift in Sources */,
 				46E3CCB2AC426BD5F8CB55DC /* ACPImageBlocksTests.swift in Sources */,
 				28F42E0137436A3B5F72CB85 /* ACPImageEncodingTests.swift in Sources */,

--- a/Alas/Sources/ACP/Protocol/ACPMessages.swift
+++ b/Alas/Sources/ACP/Protocol/ACPMessages.swift
@@ -405,6 +405,15 @@ struct AnyCodable: Codable, Equatable, Hashable, @unchecked Sendable {
     private static func canonicalize(_ value: Any) -> CanonicalValue {
         if let value = value as? AnyCodable { return value.canonicalValue }
         if value is NSNull { return .null }
+        if let value = value as? NSNumber {
+            if CFGetTypeID(value) == CFBooleanGetTypeID() {
+                return .bool(value.boolValue)
+            }
+            if CFNumberIsFloatType(value) {
+                return .double(value.doubleValue)
+            }
+            return .int(value.intValue)
+        }
         if let value = value as? Bool { return .bool(value) }
         if let value = value as? Int { return .int(value) }
         if let value = value as? Double { return .double(value) }

--- a/Alas/Sources/ACP/Protocol/ACPMessages.swift
+++ b/Alas/Sources/ACP/Protocol/ACPMessages.swift
@@ -332,9 +332,116 @@ struct ACPInitializeResult: Codable, Equatable {
 }
 
 /// Type-erased Codable used for `JSONRPCError.data` and `_meta` fields.
-struct AnyCodable: Codable, Equatable {
+/// It only carries values that are JSON-compatible and safe to move across
+/// actor boundaries as immutable payload data.
+struct AnyCodable: Codable, Equatable, Hashable, @unchecked Sendable {
     let value: Any
     init(_ value: Any) { self.value = value }
+
+    private enum CanonicalValue: Equatable, Hashable, Encodable {
+        case null
+        case bool(Bool)
+        case int(Int)
+        case double(Double)
+        case string(String)
+        case array([CanonicalValue])
+        case object([CanonicalObjectMember])
+
+        func encode(to encoder: Encoder) throws {
+            switch self {
+            case .null:
+                var c = encoder.singleValueContainer()
+                try c.encodeNil()
+            case .bool(let value):
+                var c = encoder.singleValueContainer()
+                try c.encode(value)
+            case .int(let value):
+                var c = encoder.singleValueContainer()
+                try c.encode(value)
+            case .double(let value):
+                var c = encoder.singleValueContainer()
+                try c.encode(value)
+            case .string(let value):
+                var c = encoder.singleValueContainer()
+                try c.encode(value)
+            case .array(let values):
+                var c = encoder.unkeyedContainer()
+                for value in values { try c.encode(value) }
+            case .object(let members):
+                var c = encoder.container(keyedBy: CanonicalObjectCodingKey.self)
+                for member in members {
+                    try c.encode(member.value, forKey: .init(member.key))
+                }
+            }
+        }
+    }
+
+    private struct CanonicalObjectCodingKey: CodingKey {
+        let stringValue: String
+        let intValue: Int? = nil
+
+        init(_ stringValue: String) {
+            self.stringValue = stringValue
+        }
+
+        init?(stringValue: String) {
+            self.stringValue = stringValue
+        }
+
+        init?(intValue: Int) {
+            return nil
+        }
+    }
+
+    private struct CanonicalObjectMember: Equatable, Hashable {
+        let key: String
+        let value: CanonicalValue
+    }
+
+    private var canonicalValue: CanonicalValue {
+        return AnyCodable.canonicalize(value)
+    }
+
+    private static func canonicalize(_ value: Any) -> CanonicalValue {
+        if let value = value as? AnyCodable { return value.canonicalValue }
+        if value is NSNull { return .null }
+        if let value = value as? Bool { return .bool(value) }
+        if let value = value as? Int { return .int(value) }
+        if let value = value as? Double { return .double(value) }
+        if let value = value as? String { return .string(value) }
+        if let value = value as? [AnyCodable] {
+            return .array(value.map { $0.canonicalValue })
+        }
+        if let value = value as? [String: AnyCodable] {
+            return .object(value
+                .sorted(by: { $0.key < $1.key })
+                .map { key, value in
+                    CanonicalObjectMember(key: key, value: value.canonicalValue)
+                })
+        }
+        if let value = value as? [Any] {
+            return .array(value.map { AnyCodable.canonicalize($0) })
+        }
+        if let value = value as? NSArray {
+            return .array(value.map { AnyCodable.canonicalize($0) })
+        }
+        if let value = value as? [String: Any] {
+            return .object(value
+                .sorted(by: { $0.key < $1.key })
+                .map { key, value in
+                    CanonicalObjectMember(key: key, value: AnyCodable.canonicalize(value))
+                })
+        }
+        if let value = value as? NSDictionary {
+            var members: [CanonicalObjectMember] = []
+            for (rawKey, rawValue) in value {
+                guard let key = rawKey as? String else { return .null }
+                members.append(CanonicalObjectMember(key: key, value: canonicalize(rawValue)))
+            }
+            return .object(members.sorted(by: { $0.key < $1.key }))
+        }
+        return .null
+    }
 
     init(from decoder: Decoder) throws {
         let c = try decoder.singleValueContainer()
@@ -356,20 +463,15 @@ struct AnyCodable: Codable, Equatable {
     }
     func encode(to encoder: Encoder) throws {
         var c = encoder.singleValueContainer()
-        switch value {
-        case is NSNull: try c.encodeNil()
-        case let v as Bool: try c.encode(v)
-        case let v as Int: try c.encode(v)
-        case let v as Double: try c.encode(v)
-        case let v as String: try c.encode(v)
-        case let v as [AnyCodable]: try c.encode(v)
-        case let v as [String: AnyCodable]: try c.encode(v)
-        default: try c.encodeNil()
-        }
+        try c.encode(canonicalValue)
     }
 
     static func == (lhs: AnyCodable, rhs: AnyCodable) -> Bool {
-        String(describing: lhs.value) == String(describing: rhs.value)
+        lhs.canonicalValue == rhs.canonicalValue
+    }
+
+    func hash(into hasher: inout Hasher) {
+        hasher.combine(canonicalValue)
     }
 }
 

--- a/Alas/Sources/ACP/Protocol/ACPMessages.swift
+++ b/Alas/Sources/ACP/Protocol/ACPMessages.swift
@@ -1,3 +1,4 @@
+import CoreFoundation
 import Foundation
 
 /// A generic JSON-RPC 2.0 envelope. Shared by every ACP wire type.

--- a/Alas/Sources/ACP/Protocol/ACPMessages.swift
+++ b/Alas/Sources/ACP/Protocol/ACPMessages.swift
@@ -407,10 +407,11 @@ struct AnyCodable: Codable, Equatable, Hashable, @unchecked Sendable {
         if let value = value as? AnyCodable { return value.canonicalValue }
         if value is NSNull { return .null }
         if let value = value as? NSNumber {
-            if CFGetTypeID(value) == CFBooleanGetTypeID() {
+            let cfValue = value as CFNumber
+            if CFGetTypeID(cfValue) == CFBooleanGetTypeID() {
                 return .bool(value.boolValue)
             }
-            if CFNumberIsFloatType(value) {
+            if CFNumberIsFloatType(cfValue) {
                 return .double(value.doubleValue)
             }
             return .int(value.intValue)

--- a/Alas/Sources/ACP/Protocol/ACPSessionUpdate.swift
+++ b/Alas/Sources/ACP/Protocol/ACPSessionUpdate.swift
@@ -35,16 +35,19 @@ enum ACPSessionUpdate: Codable, Equatable {
 
     private enum Keys: String, CodingKey {
         case sessionUpdate, content, availableModels, modeId, modelId,
-             entries, availableCommands, configOptions, title, updatedAt
+             entries, availableCommands, configOptions
     }
 
     init(from decoder: Decoder) throws {
         let c = try decoder.container(keyedBy: Keys.self)
         let kind = try c.decode(String.self, forKey: .sessionUpdate)
         switch kind {
-        case "user_message_chunk":   self = .userMessageChunk(try ACPTextChunk(from: decoder))
-        case "agent_message_chunk":  self = .agentMessageChunk(try ACPTextChunk(from: decoder))
-        case "agent_thought_chunk":  self = .agentThoughtChunk(try ACPTextChunk(from: decoder))
+        case "user_message_chunk":
+            self = .userMessageChunk(try ACPTextChunk(from: decoder))
+        case "agent_message_chunk":
+            self = .agentMessageChunk(try ACPTextChunk(from: decoder))
+        case "agent_thought_chunk":
+            self = .agentThoughtChunk(try ACPTextChunk(from: decoder))
         case "tool_call":
             self = .toolCall(try ACPToolCallPayload(from: decoder))
         case "tool_call_update":
@@ -91,18 +94,24 @@ enum ACPSessionUpdate: Codable, Equatable {
         // Encoding not required for v1 (we only receive these). Implement when needed.
         var c = encoder.container(keyedBy: Keys.self)
         switch self {
-        case .userMessageChunk(let b):  try c.encode("user_message_chunk", forKey: .sessionUpdate)
-        try b.encodeFields(to: encoder)
-        case .agentMessageChunk(let b): try c.encode("agent_message_chunk", forKey: .sessionUpdate)
-        try b.encodeFields(to: encoder)
-        case .agentThoughtChunk(let b): try c.encode("agent_thought_chunk", forKey: .sessionUpdate)
-        try b.encodeFields(to: encoder)
-        case .plan(let e):              try c.encode("plan", forKey: .sessionUpdate)
-        try c.encode(e, forKey: .entries)
-        case .availableModelsUpdate(let m): try c.encode("available_models_update", forKey: .sessionUpdate)
-        try c.encode(m, forKey: .availableModels)
-        case .currentModeUpdate(let m):     try c.encode("current_mode_update", forKey: .sessionUpdate)
-        try c.encode(m, forKey: .modeId)
+        case .userMessageChunk(let b):
+            try c.encode("user_message_chunk", forKey: .sessionUpdate)
+            try b.encodeFields(to: encoder)
+        case .agentMessageChunk(let b):
+            try c.encode("agent_message_chunk", forKey: .sessionUpdate)
+            try b.encodeFields(to: encoder)
+        case .agentThoughtChunk(let b):
+            try c.encode("agent_thought_chunk", forKey: .sessionUpdate)
+            try b.encodeFields(to: encoder)
+        case .plan(let e):
+            try c.encode("plan", forKey: .sessionUpdate)
+            try c.encode(e, forKey: .entries)
+        case .availableModelsUpdate(let m):
+            try c.encode("available_models_update", forKey: .sessionUpdate)
+            try c.encode(m, forKey: .availableModels)
+        case .currentModeUpdate(let m):
+            try c.encode("current_mode_update", forKey: .sessionUpdate)
+            try c.encode(m, forKey: .modeId)
         case .currentModelUpdate(let m):
             try c.encode("current_model_update", forKey: .sessionUpdate)
             try c.encode(m, forKey: .modelId)
@@ -111,17 +120,11 @@ enum ACPSessionUpdate: Codable, Equatable {
             try c.encode(opts, forKey: .configOptions)
         case .sessionInfoUpdate(let info):
             try c.encode("session_info_update", forKey: .sessionUpdate)
-            switch info.title {
-            case .absent:
-                break
-            case .null:
-                try c.encodeNil(forKey: .title)
-            case .value(let title):
-                try c.encode(title, forKey: .title)
-            }
-            try c.encodeIfPresent(info.updatedAt, forKey: .updatedAt)
-        case .availableCommandsUpdate: break // not produced by us
-        case .toolCall, .toolCallUpdate, .usageUpdate, .unknown: break
+            try info.encodeFields(to: encoder)
+        case .availableCommandsUpdate:
+            break
+        case .toolCall, .toolCallUpdate, .usageUpdate, .unknown:
+            break
         }
     }
 }
@@ -146,6 +149,72 @@ struct ACPTextChunk: Codable, Equatable {
     }
 }
 
+struct ACPSessionInfoUpdate: Codable, Equatable {
+    let title: ACPStringFieldUpdate
+    let updatedAt: String?
+    let metadata: AnyCodable?
+
+    private enum CodingKeys: String, CodingKey {
+        case title, updatedAt
+        case metadata = "_meta"
+    }
+
+    init(
+        title: ACPStringFieldUpdate = .absent,
+        updatedAt: String? = nil,
+        metadata: AnyCodable? = nil
+    ) {
+        self.title = title
+        self.updatedAt = updatedAt
+        self.metadata = metadata
+    }
+
+    init(title: String?, updatedAt: String? = nil, metadata: AnyCodable? = nil) {
+        self.title = title.map(ACPStringFieldUpdate.value) ?? .absent
+        self.updatedAt = updatedAt
+        self.metadata = metadata
+    }
+
+    init(from decoder: Decoder) throws {
+        let c = try decoder.container(keyedBy: CodingKeys.self)
+        if !c.contains(.title) {
+            title = .absent
+        } else if (try? c.decodeNil(forKey: .title)) == true {
+            title = .null
+        } else if let value = try? c.decode(String.self, forKey: .title) {
+            title = .value(value)
+        } else {
+            title = .absent
+        }
+        updatedAt = try? c.decodeIfPresent(String.self, forKey: .updatedAt)
+        metadata = try? c.decodeIfPresent(AnyCodable.self, forKey: .metadata)
+    }
+
+    func encode(to encoder: Encoder) throws {
+        try encodeFields(to: encoder)
+    }
+
+    func encodeFields(to encoder: Encoder) throws {
+        var c = encoder.container(keyedBy: CodingKeys.self)
+        switch title {
+        case .absent:
+            break
+        case .null:
+            try c.encodeNil(forKey: .title)
+        case .value(let title):
+            try c.encode(title, forKey: .title)
+        }
+        try c.encodeIfPresent(updatedAt, forKey: .updatedAt)
+        try c.encodeIfPresent(metadata, forKey: .metadata)
+    }
+}
+
+enum ACPStringFieldUpdate: Equatable {
+    case absent
+    case null
+    case value(String)
+}
+
 struct ACPToolCallPayload: Codable, Equatable {
     let toolCallId: String
     let title: String
@@ -155,13 +224,70 @@ struct ACPToolCallPayload: Codable, Equatable {
     let locations: [ACPToolLocation]?
     let rawInput: AnyCodable?
     let rawOutput: AnyCodable?
+    let metadata: AnyCodable?
+
+    private enum CodingKeys: String, CodingKey {
+        case toolCallId, title, kind, status, content, locations, rawInput, rawOutput
+        case metadata = "_meta"
+    }
+
+    init(
+        toolCallId: String,
+        title: String,
+        kind: String?,
+        status: String,
+        content: [ACPToolCallContent]? = nil,
+        locations: [ACPToolLocation]? = nil,
+        rawInput: AnyCodable? = nil,
+        rawOutput: AnyCodable? = nil,
+        metadata: AnyCodable? = nil
+    ) {
+        self.toolCallId = toolCallId
+        self.title = title
+        self.kind = kind
+        self.status = status
+        self.content = content
+        self.locations = locations
+        self.rawInput = rawInput
+        self.rawOutput = rawOutput
+        self.metadata = metadata
+    }
 }
 
 struct ACPToolCallUpdate: Codable, Equatable {
     let toolCallId: String
+    let title: String?
     let status: String?
+    let locations: [ACPToolLocation]?
     let content: [ACPToolCallContent]?
     let rawOutput: AnyCodable?
+    let rawInput: AnyCodable?
+    let metadata: AnyCodable?
+
+    private enum CodingKeys: String, CodingKey {
+        case toolCallId, title, status, locations, content, rawInput, rawOutput
+        case metadata = "_meta"
+    }
+
+    init(
+        toolCallId: String,
+        status: String? = nil,
+        content: [ACPToolCallContent]? = nil,
+        rawOutput: AnyCodable? = nil,
+        title: String? = nil,
+        locations: [ACPToolLocation]? = nil,
+        rawInput: AnyCodable? = nil,
+        metadata: AnyCodable? = nil
+    ) {
+        self.toolCallId = toolCallId
+        self.title = title
+        self.status = status
+        self.locations = locations
+        self.content = content
+        self.rawOutput = rawOutput
+        self.rawInput = rawInput
+        self.metadata = metadata
+    }
 }
 
 struct ACPToolLocation: Codable, Equatable {
@@ -203,54 +329,4 @@ struct ACPUsageInfo: Codable, Equatable {
         size = try c.decode(Int.self, forKey: .size)
         cost = try? c.decodeIfPresent(Cost.self, forKey: .cost)
     }
-}
-
-struct ACPSessionInfoUpdate: Codable, Equatable {
-    let title: ACPStringFieldUpdate
-    let updatedAt: String?
-
-    private enum CodingKeys: String, CodingKey { case title, updatedAt }
-
-    init(title: ACPStringFieldUpdate = .absent, updatedAt: String?) {
-        self.title = title
-        self.updatedAt = updatedAt
-    }
-
-    init(title: String?, updatedAt: String?) {
-        self.title = title.map(ACPStringFieldUpdate.value) ?? .absent
-        self.updatedAt = updatedAt
-    }
-
-    init(from decoder: Decoder) throws {
-        let c = try decoder.container(keyedBy: CodingKeys.self)
-        if !c.contains(.title) {
-            title = .absent
-        } else if (try? c.decodeNil(forKey: .title)) == true {
-            title = .null
-        } else if let value = try? c.decode(String.self, forKey: .title) {
-            title = .value(value)
-        } else {
-            title = .absent
-        }
-        updatedAt = try? c.decodeIfPresent(String.self, forKey: .updatedAt)
-    }
-
-    func encode(to encoder: Encoder) throws {
-        var c = encoder.container(keyedBy: CodingKeys.self)
-        switch title {
-        case .absent:
-            break
-        case .null:
-            try c.encodeNil(forKey: .title)
-        case .value(let title):
-            try c.encode(title, forKey: .title)
-        }
-        try c.encodeIfPresent(updatedAt, forKey: .updatedAt)
-    }
-}
-
-enum ACPStringFieldUpdate: Equatable {
-    case absent
-    case null
-    case value(String)
 }

--- a/Alas/Sources/ACP/Session/ACPMessage.swift
+++ b/Alas/Sources/ACP/Session/ACPMessage.swift
@@ -66,6 +66,50 @@ enum ACPMessage: Equatable {
         }
     }
 
+    struct ToolCallAsset: Codable, Equatable, Hashable, Sendable {
+        enum Kind: String, Codable, Equatable, Hashable, Sendable {
+            case image
+            case resource
+        }
+
+        let kind: Kind
+        let data: String?
+        let uri: String?
+        let mimeType: String?
+        let name: String?
+
+        init(
+            kind: Kind,
+            data: String? = nil,
+            uri: String? = nil,
+            mimeType: String? = nil,
+            name: String? = nil
+        ) {
+            self.kind = kind
+            self.data = data
+            self.uri = uri
+            self.mimeType = mimeType
+            self.name = name
+        }
+
+        static func image(
+            data: String? = nil,
+            uri: String? = nil,
+            mimeType: String? = nil,
+            name: String? = nil
+        ) -> ToolCallAsset {
+            .init(kind: .image, data: data, uri: uri, mimeType: mimeType, name: name)
+        }
+
+        static func resource(
+            uri: String,
+            name: String?,
+            mimeType: String? = nil
+        ) -> ToolCallAsset {
+            .init(kind: .resource, uri: uri, mimeType: mimeType, name: name)
+        }
+    }
+
     struct ToolCall: Codable, Equatable, Hashable, Sendable {
         let toolCallId: String
         var title: String
@@ -85,6 +129,13 @@ enum ACPMessage: Equatable {
         /// Compact JSON/string form of the tool input reported by ACP. Kept so
         /// remote mirrors can show useful params even before output arrives.
         var rawInput: String?
+        /// Compact JSON/string form of the tool output reported by ACP.
+        var rawOutput: String?
+        /// Structured metadata emitted by protocol payloads. Persisted for
+        /// richer rendering and replay.
+        var metadata: AnyCodable?
+        /// Preserved assets produced with the tool call.
+        var assets: [ToolCallAsset]
         var locations: [String]
         /// Terminal IDs referenced by this call's structured content, in
         /// declaration order. The expanded card renders one
@@ -114,19 +165,24 @@ enum ACPMessage: Equatable {
         }
 
         init(toolCallId: String, title: String, kind: String? = nil,
-             status: String, content: String = "", preview: String? = nil,
+             status: String, content: String? = nil, preview: String? = nil,
              contentLanguage: String? = nil, rawInput: String? = nil,
-             locations: [String] = [], terminalIds: [String] = [])
+             rawOutput: String? = nil, metadata: AnyCodable? = nil,
+             assets: [ToolCallAsset] = [],
+             locations: [String]? = nil, terminalIds: [String] = [])
         {
             self.toolCallId = toolCallId
             self.title = title
             self.kind = kind
             self.status = status
-            self.content = content
+            self.content = content ?? ""
             self.preview = preview
             self.contentLanguage = contentLanguage
             self.rawInput = rawInput
-            self.locations = locations
+            self.rawOutput = rawOutput
+            self.metadata = metadata
+            self.assets = assets
+            self.locations = locations ?? []
             self.terminalIds = terminalIds
         }
 
@@ -135,7 +191,8 @@ enum ACPMessage: Equatable {
         // session history doesn't go blank after upgrade.
         enum CodingKeys: String, CodingKey {
             case toolCallId, title, kind, status, content, preview,
-                 contentSummary, contentLanguage, rawInput, locations, terminalIds
+                 contentSummary, contentLanguage, rawInput, rawOutput, metadata,
+                 assets, locations, terminalIds
         }
         init(from decoder: Decoder) throws {
             let c = try decoder.container(keyedBy: CodingKeys.self)
@@ -148,6 +205,9 @@ enum ACPMessage: Equatable {
                 ?? (try? c.decode(String.self, forKey: .contentSummary))
             contentLanguage = try? c.decode(String.self, forKey: .contentLanguage)
             rawInput = try? c.decode(String.self, forKey: .rawInput)
+            rawOutput = try? c.decode(String.self, forKey: .rawOutput)
+            metadata = try? c.decode(AnyCodable.self, forKey: .metadata)
+            assets = (try? c.decode([ToolCallAsset].self, forKey: .assets)) ?? []
             locations = (try? c.decode([String].self, forKey: .locations)) ?? []
             terminalIds = (try? c.decode([String].self, forKey: .terminalIds)) ?? []
         }
@@ -161,6 +221,9 @@ enum ACPMessage: Equatable {
             try c.encodeIfPresent(preview, forKey: .preview)
             try c.encodeIfPresent(contentLanguage, forKey: .contentLanguage)
             try c.encodeIfPresent(rawInput, forKey: .rawInput)
+            try c.encodeIfPresent(rawOutput, forKey: .rawOutput)
+            try c.encodeIfPresent(metadata, forKey: .metadata)
+            try c.encode(assets, forKey: .assets)
             try c.encode(locations, forKey: .locations)
             try c.encode(terminalIds, forKey: .terminalIds)
         }
@@ -178,7 +241,11 @@ enum ACPMessage: Equatable {
                 && lhs.preview == rhs.preview
                 && lhs.contentLanguage == rhs.contentLanguage
                 && lhs.rawInput == rhs.rawInput
+                && lhs.rawOutput == rhs.rawOutput
+                && lhs.metadata == rhs.metadata
+                && lhs.assets == rhs.assets
                 && lhs.locations == rhs.locations
+                && lhs.terminalIds == rhs.terminalIds
         }
 
         func hash(into hasher: inout Hasher) {
@@ -190,7 +257,11 @@ enum ACPMessage: Equatable {
             hasher.combine(preview)
             hasher.combine(contentLanguage)
             hasher.combine(rawInput)
+            hasher.combine(rawOutput)
+            hasher.combine(metadata)
+            hasher.combine(assets)
             hasher.combine(locations)
+            hasher.combine(terminalIds)
         }
     }
 

--- a/Alas/Sources/ACP/Session/ACPSession.swift
+++ b/Alas/Sources/ACP/Session/ACPSession.swift
@@ -321,48 +321,12 @@ final class ACPSession: ObservableObject, Identifiable {
             return [transcript.messages.count - 1]
         case .toolCallUpdate(let u):
             clearRestoredContextRecoveryStatus()
-            var appliedMetadata: AnyCodable?
-            var metadataTerminalIds: [String] = []
-            var rawOutputAssets: [ACPMessage.ToolCallAsset] = []
             let touched = updateToolCall(id: u.toolCallId) { tc in
-                if let title = u.title { tc.title = title }
-                if let s = u.status { tc.status = s }
-                if let locations = u.locations { tc.locations = locations.map(\.path) }
-                if let rawInput = u.rawInput { tc.rawInput = Self.metadataString(rawInput) }
-                if let rawOutput = u.rawOutput {
-                    tc.rawOutput = Self.metadataString(rawOutput)
-                    rawOutputAssets = Self.extractRawOutputAssets(rawOutput)
-                    tc.assets = Self.mergeAssets(tc.assets, rawOutputAssets)
-                }
-                if let metadata = u.metadata {
-                    tc.metadata = Self.mergeMetadata(tc.metadata, metadata)
-                    appliedMetadata = metadata
-                    metadataTerminalIds = Self.extractMetadataTerminalIds(metadata)
-                    tc.terminalIds = Self.mergeTerminalIds(tc.terminalIds, metadataTerminalIds)
-                }
-                if let c = u.content {
-                    // ACP content updates are full replacement snapshots,
-                    // so terminalIds tracks the *current* content — assign
-                    // unconditionally, including the empty case, so a
-                    // text/diff-only final update doesn't leave a stale
-                    // terminal tail rendering in the card.
-                    let raw = Self.flatten(c)
-                    let full = Self.stripWrappingFence(raw,
-                                                      isFinal: Self.isFinalStatus(tc.status))
-                    tc.content = full
-                    tc.isContentTruncated = false
-                    tc.preview = Self.previewLine(full)
-                    tc.contentLanguage = Self.wrappingFenceLanguage(raw)
-                    tc.terminalIds = Self.mergeTerminalIds(
-                        Self.extractTerminalIds(c),
-                        Self.extractMetadataTerminalIds(tc.metadata))
-                    let preservedRawOutputAssets = rawOutputAssets.isEmpty
-                        ? Self.extractStoredRawOutputAssets(tc.rawOutput, existingAssets: tc.assets)
-                        : rawOutputAssets
-                    tc.assets = Self.mergeAssets(Self.extractAssets(c), preservedRawOutputAssets)
-                }
+                applyToolCallUpdateFields(u, to: &tc)
             }
-            applyToolCallMetadata(appliedMetadata)
+            if touched != nil {
+                applyToolCallMetadata(u.metadata)
+            }
             return touched.map { [$0] } ?? []
         case .sessionInfoUpdate(let info):
             applySessionInfoUpdate(info)
@@ -422,16 +386,50 @@ final class ACPSession: ObservableObject, Identifiable {
             }) != nil else { return }
             applyToolCallMetadata(metadata)
         case .toolCallUpdate(let update):
-            guard let metadata = update.metadata else { return }
             guard updateToolCall(id: update.toolCallId, { tc in
-                tc.metadata = Self.mergeMetadata(tc.metadata, metadata)
-                tc.terminalIds = Self.mergeTerminalIds(
-                    tc.terminalIds,
-                    Self.extractMetadataTerminalIds(metadata))
+                applyToolCallUpdateFields(update, to: &tc)
             }) != nil else { return }
-            applyToolCallMetadata(metadata)
+            applyToolCallMetadata(update.metadata)
         default:
             break
+        }
+    }
+
+    private func applyToolCallUpdateFields(
+        _ update: ACPToolCallUpdate,
+        to tc: inout ACPMessage.ToolCall
+    ) {
+        var rawOutputAssets: [ACPMessage.ToolCallAsset] = []
+        if let title = update.title { tc.title = title }
+        if let status = update.status { tc.status = status }
+        if let locations = update.locations { tc.locations = locations.map(\.path) }
+        if let rawInput = update.rawInput { tc.rawInput = Self.metadataString(rawInput) }
+        if let rawOutput = update.rawOutput {
+            tc.rawOutput = Self.metadataString(rawOutput)
+            rawOutputAssets = Self.extractRawOutputAssets(rawOutput)
+            tc.assets = Self.mergeAssets(tc.assets, rawOutputAssets)
+        }
+        if let metadata = update.metadata {
+            tc.metadata = Self.mergeMetadata(tc.metadata, metadata)
+            tc.terminalIds = Self.mergeTerminalIds(
+                tc.terminalIds,
+                Self.extractMetadataTerminalIds(metadata))
+        }
+        if let content = update.content {
+            let raw = Self.flatten(content)
+            let full = Self.stripWrappingFence(raw,
+                                               isFinal: Self.isFinalStatus(tc.status))
+            tc.content = full
+            tc.isContentTruncated = false
+            tc.preview = Self.previewLine(full)
+            tc.contentLanguage = Self.wrappingFenceLanguage(raw)
+            tc.terminalIds = Self.mergeTerminalIds(
+                Self.extractTerminalIds(content),
+                Self.extractMetadataTerminalIds(tc.metadata))
+            let preservedRawOutputAssets = rawOutputAssets.isEmpty
+                ? Self.extractStoredRawOutputAssets(tc.rawOutput, existingAssets: tc.assets)
+                : rawOutputAssets
+            tc.assets = Self.mergeAssets(Self.extractAssets(content), preservedRawOutputAssets)
         }
     }
 
@@ -1023,12 +1021,23 @@ final class ACPSession: ObservableObject, Identifiable {
             }
             if let uri = asset.uri, rawOutput.contains(uri) { return true }
             if let uri = asset.uri,
-               dataImageMimeType(uri) != nil,
-               rawOutput.contains(String(uri.prefix(128))) {
+               Self.rawOutputContainsStableURIPrefix(rawOutput, uri: uri) {
                 return true
             }
             return false
         }
+    }
+
+    private static func rawOutputContainsStableURIPrefix(_ rawOutput: String, uri: String) -> Bool {
+        guard uri.count >= 128 else { return false }
+        if dataImageMimeType(uri) != nil {
+            return rawOutput.contains(String(uri.prefix(128)))
+        }
+        guard let components = URLComponents(string: uri),
+              components.scheme != nil,
+              components.host != nil
+        else { return false }
+        return rawOutput.contains(String(uri.prefix(128)))
     }
 
     private static func assetName(from uri: String?) -> String? {

--- a/Alas/Sources/ACP/Session/ACPSession.swift
+++ b/Alas/Sources/ACP/Session/ACPSession.swift
@@ -346,7 +346,9 @@ final class ACPSession: ObservableObject, Identifiable {
                     tc.content = full
                     tc.preview = Self.previewLine(full)
                     tc.contentLanguage = Self.wrappingFenceLanguage(raw)
-                    tc.terminalIds = Self.mergeTerminalIds(Self.extractTerminalIds(c), metadataTerminalIds)
+                    tc.terminalIds = Self.mergeTerminalIds(
+                        Self.extractTerminalIds(c),
+                        Self.extractMetadataTerminalIds(tc.metadata))
                     tc.assets = Self.extractAssets(c)
                 }
             }

--- a/Alas/Sources/ACP/Session/ACPSession.swift
+++ b/Alas/Sources/ACP/Session/ACPSession.swift
@@ -409,6 +409,31 @@ final class ACPSession: ObservableObject, Identifiable {
         }
     }
 
+    func applySuppressedReplaySideEffects(_ update: ACPSessionUpdate) {
+        switch update {
+        case .toolCall(let payload):
+            guard let metadata = payload.metadata else { return }
+            guard updateToolCall(id: payload.toolCallId, { tc in
+                tc.metadata = Self.mergeMetadata(tc.metadata, metadata)
+                tc.terminalIds = Self.mergeTerminalIds(
+                    tc.terminalIds,
+                    Self.extractMetadataTerminalIds(metadata))
+            }) != nil else { return }
+            applyToolCallMetadata(metadata)
+        case .toolCallUpdate(let update):
+            guard let metadata = update.metadata else { return }
+            guard updateToolCall(id: update.toolCallId, { tc in
+                tc.metadata = Self.mergeMetadata(tc.metadata, metadata)
+                tc.terminalIds = Self.mergeTerminalIds(
+                    tc.terminalIds,
+                    Self.extractMetadataTerminalIds(metadata))
+            }) != nil else { return }
+            applyToolCallMetadata(metadata)
+        default:
+            break
+        }
+    }
+
     func markContextRecoveryRestored(expiryNanoseconds: UInt64 = 30_000_000_000) {
         contextRecoveryExpiryTask?.cancel()
         contextRecoveryStatus = .restored
@@ -996,6 +1021,11 @@ final class ACPSession: ObservableObject, Identifiable {
                 return true
             }
             if let uri = asset.uri, rawOutput.contains(uri) { return true }
+            if let uri = asset.uri,
+               dataImageMimeType(uri) != nil,
+               rawOutput.contains(String(uri.prefix(128))) {
+                return true
+            }
             return false
         }
     }

--- a/Alas/Sources/ACP/Session/ACPSession.swift
+++ b/Alas/Sources/ACP/Session/ACPSession.swift
@@ -475,7 +475,7 @@ final class ACPSession: ObservableObject, Identifiable {
             tc.metadata = Self.mergeMetadata(tc.metadata, metadata)
             tc.terminalIds = Self.mergeTerminalIds(
                 tc.terminalIds,
-                Self.extractMetadataTerminalIds(metadata))
+                Self.extractMetadataTerminalIds(metadata, includeExit: update.content == nil))
         }
         if let content = update.content {
             if !canReplaceSnapshot {
@@ -1123,6 +1123,7 @@ final class ACPSession: ObservableObject, Identifiable {
         let lower = rawOutput.lowercased()
         guard lower.contains("\"b64_json\"")
             || lower.contains("data:image/")
+            || lower.contains("\"data\"")
             || lower.contains("\"url\"")
             || lower.contains("\"mimetype\"")
             || lower.contains("\"mime_type\"")

--- a/Alas/Sources/ACP/Session/ACPSession.swift
+++ b/Alas/Sources/ACP/Session/ACPSession.swift
@@ -876,29 +876,38 @@ final class ACPSession: ObservableObject, Identifiable {
 
     private func applyGoalMetadata(_ metadata: AnyCodable?) {
         guard let metadata,
-              let root = metadata.value as? [String: AnyCodable]
+              let root = Self.metadataObject(metadata)
         else { return }
 
         if let goal = root["goal"] {
-            currentGoal = Self.goalState(from: goal)
-        } else if let codex = root["codex"]?.value as? [String: AnyCodable],
+            applyGoalValue(goal)
+        } else if let codex = Self.metadataObject(root["codex"]),
                   let goal = codex["goal"] {
-            currentGoal = Self.goalState(from: goal)
+            applyGoalValue(goal)
         }
     }
 
-    private static func goalState(from value: AnyCodable) -> ACPGoalState? {
-        if value.value is NSNull { return nil }
-        guard let goal = value.value as? [String: AnyCodable],
-              let objective = goal["objective"]?.value as? String
-        else { return nil }
-        let trimmedObjective = objective.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard !trimmedObjective.isEmpty else { return nil }
+    private func applyGoalValue(_ value: AnyCodable) {
+        if value.value is NSNull {
+            currentGoal = nil
+            return
+        }
+        guard let goal = Self.metadataObject(value) else { return }
 
-        return ACPGoalState(
-            objective: trimmedObjective,
-            status: goal["status"]?.value as? String,
-            tokenBudget: goal["tokenBudget"]?.value as? Int)
+        let objective: String
+        if let rawObjective = Self.metadataScalarString(goal["objective"])?.trimmingCharacters(in: .whitespacesAndNewlines),
+           !rawObjective.isEmpty {
+            objective = rawObjective
+        } else if let existing = currentGoal {
+            objective = existing.objective
+        } else {
+            return
+        }
+
+        currentGoal = ACPGoalState(
+            objective: objective,
+            status: goal.keys.contains("status") ? Self.metadataScalarString(goal["status"]) : currentGoal?.status,
+            tokenBudget: goal.keys.contains("tokenBudget") ? Self.metadataInt(goal["tokenBudget"]) : currentGoal?.tokenBudget)
     }
 
     /// Best-effort strip of a single pair of markdown code fences that

--- a/Alas/Sources/ACP/Session/ACPSession.swift
+++ b/Alas/Sources/ACP/Session/ACPSession.swift
@@ -894,10 +894,20 @@ final class ACPSession: ObservableObject, Identifiable {
                 assets.append(.image(data: data, mimeType: "image/png"))
             }
             let rawData = metadataScalarString(object["data"])
-            let consumedDataImage = rawData.flatMap(dataImageMimeType) != nil
+            let mimeDataType = rawOutputMimeType(object)
+            let consumedDataImage: Bool
             if let data = rawData,
                let mimeType = dataImageMimeType(data) {
                 assets.append(.image(data: data, mimeType: mimeType))
+                consumedDataImage = true
+            } else if let data = rawData,
+                      let mimeType = mimeDataType,
+                      mimeType.lowercased().hasPrefix("image/"),
+                      !data.isEmpty {
+                assets.append(.image(data: data, mimeType: mimeType))
+                consumedDataImage = true
+            } else {
+                consumedDataImage = false
             }
             if let uri = metadataScalarString(object["url"]),
                rawOutputURLLooksLikeImage(uri, in: object) {
@@ -974,9 +984,18 @@ final class ACPSession: ObservableObject, Identifiable {
         guard lower.contains("\"b64_json\"")
             || lower.contains("data:image/")
             || lower.contains("\"url\"")
+            || lower.contains("\"mimetype\"")
+            || lower.contains("\"mime_type\"")
         else { return [] }
         return existingAssets.filter { asset in
-            asset.kind == .image && (asset.data != nil || asset.uri != nil)
+            guard asset.kind == .image else { return false }
+            if let data = asset.data,
+               !data.isEmpty,
+               rawOutput.contains(String(data.prefix(128))) {
+                return true
+            }
+            if let uri = asset.uri, rawOutput.contains(uri) { return true }
+            return false
         }
     }
 

--- a/Alas/Sources/ACP/Session/ACPSession.swift
+++ b/Alas/Sources/ACP/Session/ACPSession.swift
@@ -387,8 +387,6 @@ final class ACPSession: ObservableObject, Identifiable {
             // size <= 0 is unusable (divide-by-zero); treat as "no data".
             contextUsage = (info.size > 0) ? info : nil
             return []
-        case .sessionInfoUpdate:
-            return []
         case .unknown:
             return []
         }
@@ -821,11 +819,20 @@ final class ACPSession: ObservableObject, Identifiable {
     }
 
     private func applySessionInfoUpdate(_ info: ACPSessionInfoUpdate) {
-        if let title = info.title?.trimmingCharacters(in: .whitespacesAndNewlines),
-           !title.isEmpty,
-           titleSource != .manual {
-            self.title = title
-            titleSource = .generated
+        switch info.title {
+        case .absent:
+            break
+        case .null:
+            if titleSource != .manual {
+                title = "New session"
+                titleSource = .placeholder
+            }
+        case .value(let rawTitle):
+            let trimmed = rawTitle.trimmingCharacters(in: .whitespacesAndNewlines)
+            if !trimmed.isEmpty, titleSource != .manual {
+                title = trimmed
+                titleSource = .generated
+            }
         }
         applyGoalMetadata(info.metadata)
     }

--- a/Alas/Sources/ACP/Session/ACPSession.swift
+++ b/Alas/Sources/ACP/Session/ACPSession.swift
@@ -384,7 +384,7 @@ final class ACPSession: ObservableObject, Identifiable {
             return [touched]
         case .toolCallUpdate(let update):
             guard let touched = updateToolCall(id: update.toolCallId, { tc in
-                Self.applyToolCallUpdateFields(update, to: &tc)
+                Self.applyToolCallUpdateFields(update, to: &tc, allowFinalSnapshotReplacement: false)
             }) else { return [] }
             applyToolCallMetadata(update.metadata)
             return [touched]
@@ -443,13 +443,15 @@ final class ACPSession: ObservableObject, Identifiable {
 
     private static func applyToolCallUpdateFields(
         _ update: ACPToolCallUpdate,
-        to tc: inout ACPMessage.ToolCall
+        to tc: inout ACPMessage.ToolCall,
+        allowFinalSnapshotReplacement: Bool = true
     ) {
+        let canReplaceSnapshot = allowFinalSnapshotReplacement || !Self.isFinalStatus(tc.status)
         var rawOutputAssets: [ACPMessage.ToolCallAsset] = []
-        if let title = update.title { tc.title = title }
-        if let status = update.status { tc.status = status }
-        if let locations = update.locations { tc.locations = locations.map(\.path) }
-        if let rawInput = update.rawInput { tc.rawInput = Self.metadataString(rawInput) }
+        if canReplaceSnapshot, let title = update.title { tc.title = title }
+        if canReplaceSnapshot, let status = update.status { tc.status = status }
+        if canReplaceSnapshot, let locations = update.locations { tc.locations = locations.map(\.path) }
+        if canReplaceSnapshot, let rawInput = update.rawInput { tc.rawInput = Self.metadataString(rawInput) }
         if let rawOutput = update.rawOutput {
             tc.rawOutput = Self.metadataString(rawOutput)
             rawOutputAssets = Self.extractRawOutputAssets(rawOutput)
@@ -462,6 +464,10 @@ final class ACPSession: ObservableObject, Identifiable {
                 Self.extractMetadataTerminalIds(metadata))
         }
         if let content = update.content {
+            if !canReplaceSnapshot {
+                tc.assets = Self.mergeAssets(tc.assets, Self.extractAssets(content))
+                return
+            }
             let raw = Self.flatten(content)
             let full = Self.stripWrappingFence(raw,
                                                isFinal: Self.isFinalStatus(tc.status))

--- a/Alas/Sources/ACP/Session/ACPSession.swift
+++ b/Alas/Sources/ACP/Session/ACPSession.swift
@@ -355,7 +355,10 @@ final class ACPSession: ObservableObject, Identifiable {
                     tc.terminalIds = Self.mergeTerminalIds(
                         Self.extractTerminalIds(c),
                         Self.extractMetadataTerminalIds(tc.metadata))
-                    tc.assets = Self.mergeAssets(Self.extractAssets(c), rawOutputAssets)
+                    let preservedRawOutputAssets = rawOutputAssets.isEmpty
+                        ? Self.extractStoredRawOutputAssets(tc.rawOutput, existingAssets: tc.assets)
+                        : rawOutputAssets
+                    tc.assets = Self.mergeAssets(Self.extractAssets(c), preservedRawOutputAssets)
                 }
             }
             applyToolCallMetadata(appliedMetadata)
@@ -914,6 +917,10 @@ final class ACPSession: ObservableObject, Identifiable {
         if let string = metadataScalarString(value),
            let mimeType = dataImageMimeType(string) {
             assets.append(.image(data: string, mimeType: mimeType))
+        } else if let string = metadataScalarString(value),
+                  let data = string.data(using: .utf8),
+                  let json = try? JSONSerialization.jsonObject(with: data) {
+            collectRawOutputAssets(AnyCodable(json), into: &assets)
         }
     }
 
@@ -923,6 +930,22 @@ final class ACPSession: ObservableObject, Identifiable {
               let semicolon = trimmed.firstIndex(of: ";")
         else { return nil }
         return String(trimmed[..<semicolon].dropFirst("data:".count))
+    }
+
+    private static func extractStoredRawOutputAssets(
+        _ rawOutput: String?,
+        existingAssets: [ACPMessage.ToolCallAsset]
+    ) -> [ACPMessage.ToolCallAsset] {
+        guard let rawOutput else { return [] }
+        let parsedAssets = extractRawOutputAssets(AnyCodable(rawOutput))
+        if !parsedAssets.isEmpty { return parsedAssets }
+
+        let lower = rawOutput.lowercased()
+        guard lower.contains("\"b64_json\"") || lower.contains("data:image/") else { return [] }
+        return existingAssets.filter { asset in
+            asset.kind == .image
+                && (asset.data != nil || asset.uri?.lowercased().hasPrefix("data:image/") == true)
+        }
     }
 
     private static func assetName(from uri: String?) -> String? {

--- a/Alas/Sources/ACP/Session/ACPSession.swift
+++ b/Alas/Sources/ACP/Session/ACPSession.swift
@@ -350,6 +350,7 @@ final class ACPSession: ObservableObject, Identifiable {
                     let full = Self.stripWrappingFence(raw,
                                                       isFinal: Self.isFinalStatus(tc.status))
                     tc.content = full
+                    tc.isContentTruncated = false
                     tc.preview = Self.previewLine(full)
                     tc.contentLanguage = Self.wrappingFenceLanguage(raw)
                     tc.terminalIds = Self.mergeTerminalIds(

--- a/Alas/Sources/ACP/Session/ACPSession.swift
+++ b/Alas/Sources/ACP/Session/ACPSession.swift
@@ -899,9 +899,19 @@ final class ACPSession: ObservableObject, Identifiable {
                let mimeType = dataImageMimeType(data) {
                 assets.append(.image(data: data, mimeType: mimeType))
             }
+            if let uri = metadataScalarString(object["url"]),
+               rawOutputURLLooksLikeImage(uri, in: object) {
+                assets.append(.image(
+                    data: nil,
+                    uri: uri,
+                    mimeType: rawOutputMimeType(object),
+                    name: assetName(from: uri)))
+            }
 
             for (key, child) in object
-                where key != "b64_json" && !(key == "data" && consumedDataImage) {
+                where key != "b64_json"
+                    && key != "url"
+                    && !(key == "data" && consumedDataImage) {
                 collectRawOutputAssets(child, into: &assets)
             }
             return
@@ -932,6 +942,26 @@ final class ACPSession: ObservableObject, Identifiable {
         return String(trimmed[..<semicolon].dropFirst("data:".count))
     }
 
+    private static func rawOutputURLLooksLikeImage(_ uri: String, in object: [String: AnyCodable]) -> Bool {
+        if rawOutputMimeType(object)?.lowercased().hasPrefix("image/") == true { return true }
+        if metadataScalarString(object["type"])?.lowercased() == "image" { return true }
+        if object["revised_prompt"] != nil { return true }
+        let pathExtension = URL(string: uri)?.pathExtension.lowercased()
+            ?? URL(fileURLWithPath: uri).pathExtension.lowercased()
+        switch pathExtension {
+        case "png", "jpg", "jpeg", "gif", "heic", "heif", "tiff", "webp":
+            return true
+        default:
+            return false
+        }
+    }
+
+    private static func rawOutputMimeType(_ object: [String: AnyCodable]) -> String? {
+        metadataScalarString(object["mimeType"])
+            ?? metadataScalarString(object["mime_type"])
+            ?? metadataScalarString(object["mimetype"])
+    }
+
     private static func extractStoredRawOutputAssets(
         _ rawOutput: String?,
         existingAssets: [ACPMessage.ToolCallAsset]
@@ -941,10 +971,12 @@ final class ACPSession: ObservableObject, Identifiable {
         if !parsedAssets.isEmpty { return parsedAssets }
 
         let lower = rawOutput.lowercased()
-        guard lower.contains("\"b64_json\"") || lower.contains("data:image/") else { return [] }
+        guard lower.contains("\"b64_json\"")
+            || lower.contains("data:image/")
+            || lower.contains("\"url\"")
+        else { return [] }
         return existingAssets.filter { asset in
-            asset.kind == .image
-                && (asset.data != nil || asset.uri?.lowercased().hasPrefix("data:image/") == true)
+            asset.kind == .image && (asset.data != nil || asset.uri != nil)
         }
     }
 

--- a/Alas/Sources/ACP/Session/ACPSession.swift
+++ b/Alas/Sources/ACP/Session/ACPSession.swift
@@ -914,7 +914,7 @@ final class ACPSession: ObservableObject, Identifiable {
                 assets.append(.image(
                     data: nil,
                     uri: uri,
-                    mimeType: rawOutputMimeType(object),
+                    mimeType: dataImageMimeType(uri) ?? rawOutputMimeType(object),
                     name: assetName(from: uri)))
             }
 
@@ -953,6 +953,7 @@ final class ACPSession: ObservableObject, Identifiable {
     }
 
     private static func rawOutputURLLooksLikeImage(_ uri: String, in object: [String: AnyCodable]) -> Bool {
+        if dataImageMimeType(uri) != nil { return true }
         if rawOutputMimeType(object)?.lowercased().hasPrefix("image/") == true { return true }
         if metadataScalarString(object["type"])?.lowercased() == "image" { return true }
         if object["revised_prompt"] != nil { return true }

--- a/Alas/Sources/ACP/Session/ACPSession.swift
+++ b/Alas/Sources/ACP/Session/ACPSession.swift
@@ -397,14 +397,16 @@ final class ACPSession: ObservableObject, Identifiable {
         _ payload: ACPToolCallPayload,
         to tc: inout ACPMessage.ToolCall
     ) {
-        let canReplaceSnapshot = !Self.isFinalStatus(tc.status) || Self.isFinalStatus(payload.status)
-        tc.title = payload.title
-        tc.kind = payload.kind
+        let canReplaceSnapshot = !Self.isFinalStatus(tc.status)
+        if canReplaceSnapshot {
+            tc.title = payload.title
+            tc.kind = payload.kind
+        }
         if canReplaceSnapshot {
             tc.status = payload.status
         }
-        if let locations = payload.locations { tc.locations = locations.map(\.path) }
-        if let rawInput = payload.rawInput { tc.rawInput = Self.metadataString(rawInput) }
+        if canReplaceSnapshot, let locations = payload.locations { tc.locations = locations.map(\.path) }
+        if canReplaceSnapshot, let rawInput = payload.rawInput { tc.rawInput = Self.metadataString(rawInput) }
         var rawOutputAssets: [ACPMessage.ToolCallAsset] = []
         if let rawOutput = payload.rawOutput {
             tc.rawOutput = Self.metadataString(rawOutput)
@@ -415,10 +417,14 @@ final class ACPSession: ObservableObject, Identifiable {
             tc.metadata = Self.mergeMetadata(tc.metadata, metadata)
             tc.terminalIds = Self.mergeTerminalIds(
                 tc.terminalIds,
-                Self.extractMetadataTerminalIds(metadata))
+            Self.extractMetadataTerminalIds(metadata))
         }
 
-        guard canReplaceSnapshot, let items = payload.content else { return }
+        guard let items = payload.content else { return }
+        if !canReplaceSnapshot {
+            tc.assets = Self.mergeAssets(tc.assets, Self.extractAssets(items))
+            return
+        }
         let raw = Self.flatten(items)
         let full = Self.stripWrappingFence(raw,
                                            isFinal: Self.isFinalStatus(payload.status))

--- a/Alas/Sources/ACP/Session/ACPSession.swift
+++ b/Alas/Sources/ACP/Session/ACPSession.swift
@@ -733,7 +733,7 @@ final class ACPSession: ObservableObject, Identifiable {
 
     private static func extractMetadataTerminalIds(_ metadata: AnyCodable?) -> [String] {
         guard let root = Self.metadataObject(metadata) else { return [] }
-        let fields = ["terminal_info", "terminal_output", "terminal_output_delta", "terminal_exit"]
+        let fields = ["terminal_info", "terminal_output", "terminal_output_delta"]
         return fields.compactMap { field in
             guard let object = Self.metadataObject(root[field]) else { return nil }
             return Self.metadataScalarString(object["terminal_id"])

--- a/Alas/Sources/ACP/Session/ACPSession.swift
+++ b/Alas/Sources/ACP/Session/ACPSession.swift
@@ -300,7 +300,7 @@ final class ACPSession: ObservableObject, Identifiable {
                                                isFinal: Self.isFinalStatus(payload.status))
             let terminalIds = Self.mergeTerminalIds(
                 Self.extractTerminalIds(items),
-                Self.extractMetadataTerminalIds(payload.metadata))
+                Self.extractMetadataTerminalIds(payload.metadata, includeExit: payload.content == nil))
             let rawOutputAssets = Self.extractRawOutputAssets(payload.rawOutput)
             transcript.messages.append(.toolCall(.init(
                 toolCallId: payload.toolCallId,
@@ -431,11 +431,11 @@ final class ACPSession: ObservableObject, Identifiable {
 
         guard let items = payload.content else { return }
         if !canReplaceSnapshot {
+            tc.terminalIds = Self.mergeTerminalIds(
+                tc.terminalIds,
+                Self.extractTerminalIds(items))
             if Self.isFinalStatus(payload.status) {
                 tc.assets = Self.mergeAssets(tc.assets, Self.extractAssets(items))
-                tc.terminalIds = Self.mergeTerminalIds(
-                    tc.terminalIds,
-                    Self.extractTerminalIds(items))
             }
             return
         }

--- a/Alas/Sources/ACP/Session/ACPSession.swift
+++ b/Alas/Sources/ACP/Session/ACPSession.swift
@@ -374,20 +374,22 @@ final class ACPSession: ObservableObject, Identifiable {
         }
     }
 
-    func applySuppressedReplaySideEffects(_ update: ACPSessionUpdate) {
+    func applySuppressedReplaySideEffects(_ update: ACPSessionUpdate) -> Set<Int> {
         switch update {
         case .toolCall(let payload):
-            guard updateToolCall(id: payload.toolCallId, { tc in
+            guard let touched = updateToolCall(id: payload.toolCallId, { tc in
                 Self.applyToolCallPayloadFields(payload, to: &tc)
-            }) != nil else { return }
+            }) else { return [] }
             applyToolCallMetadata(payload.metadata)
+            return [touched]
         case .toolCallUpdate(let update):
-            guard updateToolCall(id: update.toolCallId, { tc in
+            guard let touched = updateToolCall(id: update.toolCallId, { tc in
                 Self.applyToolCallUpdateFields(update, to: &tc)
-            }) != nil else { return }
+            }) else { return [] }
             applyToolCallMetadata(update.metadata)
+            return [touched]
         default:
-            break
+            return []
         }
     }
 
@@ -395,9 +397,12 @@ final class ACPSession: ObservableObject, Identifiable {
         _ payload: ACPToolCallPayload,
         to tc: inout ACPMessage.ToolCall
     ) {
+        let canReplaceSnapshot = !Self.isFinalStatus(tc.status) || Self.isFinalStatus(payload.status)
         tc.title = payload.title
         tc.kind = payload.kind
-        tc.status = payload.status
+        if canReplaceSnapshot {
+            tc.status = payload.status
+        }
         if let locations = payload.locations { tc.locations = locations.map(\.path) }
         if let rawInput = payload.rawInput { tc.rawInput = Self.metadataString(rawInput) }
         var rawOutputAssets: [ACPMessage.ToolCallAsset] = []
@@ -406,12 +411,14 @@ final class ACPSession: ObservableObject, Identifiable {
             rawOutputAssets = Self.extractRawOutputAssets(rawOutput)
             tc.assets = Self.mergeAssets(tc.assets, rawOutputAssets)
         }
-        tc.metadata = Self.mergeMetadata(tc.metadata, payload.metadata)
-        tc.terminalIds = Self.mergeTerminalIds(
-            tc.terminalIds,
-            Self.extractMetadataTerminalIds(tc.metadata))
+        if let metadata = payload.metadata {
+            tc.metadata = Self.mergeMetadata(tc.metadata, metadata)
+            tc.terminalIds = Self.mergeTerminalIds(
+                tc.terminalIds,
+                Self.extractMetadataTerminalIds(metadata))
+        }
 
-        guard let items = payload.content else { return }
+        guard canReplaceSnapshot, let items = payload.content else { return }
         let raw = Self.flatten(items)
         let full = Self.stripWrappingFence(raw,
                                            isFinal: Self.isFinalStatus(payload.status))

--- a/Alas/Sources/ACP/Session/ACPSession.swift
+++ b/Alas/Sources/ACP/Session/ACPSession.swift
@@ -478,6 +478,9 @@ final class ACPSession: ObservableObject, Identifiable {
             if !canReplaceSnapshot {
                 if let status = update.status, Self.isFinalStatus(status) {
                     tc.assets = Self.mergeAssets(tc.assets, Self.extractAssets(content))
+                    tc.terminalIds = Self.mergeTerminalIds(
+                        tc.terminalIds,
+                        Self.extractTerminalIds(content))
                 }
                 return
             }

--- a/Alas/Sources/ACP/Session/ACPSession.swift
+++ b/Alas/Sources/ACP/Session/ACPSession.swift
@@ -300,6 +300,7 @@ final class ACPSession: ObservableObject, Identifiable {
             let terminalIds = Self.mergeTerminalIds(
                 Self.extractTerminalIds(items),
                 Self.extractMetadataTerminalIds(payload.metadata))
+            let rawOutputAssets = Self.extractRawOutputAssets(payload.rawOutput)
             transcript.messages.append(.toolCall(.init(
                 toolCallId: payload.toolCallId,
                 title: payload.title,
@@ -311,7 +312,7 @@ final class ACPSession: ObservableObject, Identifiable {
                 rawInput: Self.metadataString(payload.rawInput),
                 rawOutput: Self.metadataString(payload.rawOutput),
                 metadata: payload.metadata,
-                assets: Self.extractAssets(items),
+                assets: Self.mergeAssets(Self.extractAssets(items), rawOutputAssets),
                 locations: payload.locations?.map(\.path) ?? [],
                 terminalIds: terminalIds)))
             didAppendTranscriptMessage()
@@ -322,12 +323,17 @@ final class ACPSession: ObservableObject, Identifiable {
             clearRestoredContextRecoveryStatus()
             var appliedMetadata: AnyCodable?
             var metadataTerminalIds: [String] = []
+            var rawOutputAssets: [ACPMessage.ToolCallAsset] = []
             let touched = updateToolCall(id: u.toolCallId) { tc in
                 if let title = u.title { tc.title = title }
                 if let s = u.status { tc.status = s }
                 if let locations = u.locations { tc.locations = locations.map(\.path) }
                 if let rawInput = u.rawInput { tc.rawInput = Self.metadataString(rawInput) }
-                if let rawOutput = u.rawOutput { tc.rawOutput = Self.metadataString(rawOutput) }
+                if let rawOutput = u.rawOutput {
+                    tc.rawOutput = Self.metadataString(rawOutput)
+                    rawOutputAssets = Self.extractRawOutputAssets(rawOutput)
+                    tc.assets = Self.mergeAssets(tc.assets, rawOutputAssets)
+                }
                 if let metadata = u.metadata {
                     tc.metadata = Self.mergeMetadata(tc.metadata, metadata)
                     appliedMetadata = metadata
@@ -349,7 +355,7 @@ final class ACPSession: ObservableObject, Identifiable {
                     tc.terminalIds = Self.mergeTerminalIds(
                         Self.extractTerminalIds(c),
                         Self.extractMetadataTerminalIds(tc.metadata))
-                    tc.assets = Self.extractAssets(c)
+                    tc.assets = Self.mergeAssets(Self.extractAssets(c), rawOutputAssets)
                 }
             }
             applyToolCallMetadata(appliedMetadata)
@@ -829,8 +835,30 @@ final class ACPSession: ObservableObject, Identifiable {
         return nil
     }
 
+    private static func metadataArray(_ value: AnyCodable?) -> [AnyCodable]? {
+        if let array = value?.value as? [AnyCodable] { return array }
+        if let array = value?.value as? [Any] {
+            return array.map { raw in
+                (raw as? AnyCodable) ?? AnyCodable(raw)
+            }
+        }
+        return nil
+    }
+
     private static func extractTerminalIds(_ items: [ACPToolCallContent]) -> [String] {
         items.compactMap { if case .terminal(let id) = $0 { return id } else { return nil } }
+    }
+
+    private static func mergeAssets(
+        _ primary: [ACPMessage.ToolCallAsset],
+        _ secondary: [ACPMessage.ToolCallAsset]
+    ) -> [ACPMessage.ToolCallAsset] {
+        var seen = Set<ACPMessage.ToolCallAsset>()
+        var merged: [ACPMessage.ToolCallAsset] = []
+        for asset in primary + secondary where seen.insert(asset).inserted {
+            merged.append(asset)
+        }
+        return merged
     }
 
     private static func extractAssets(_ items: [ACPToolCallContent]) -> [ACPMessage.ToolCallAsset] {
@@ -847,6 +875,54 @@ final class ACPSession: ObservableObject, Identifiable {
                 return nil
             }
         }
+    }
+
+    private static func extractRawOutputAssets(_ value: AnyCodable?) -> [ACPMessage.ToolCallAsset] {
+        var assets: [ACPMessage.ToolCallAsset] = []
+        collectRawOutputAssets(value, into: &assets)
+        return mergeAssets([], assets)
+    }
+
+    private static func collectRawOutputAssets(_ value: AnyCodable?, into assets: inout [ACPMessage.ToolCallAsset]) {
+        guard let value else { return }
+
+        if let object = metadataObject(value) {
+            if let data = metadataScalarString(object["b64_json"]), !data.isEmpty {
+                assets.append(.image(data: data, mimeType: "image/png"))
+            }
+            let rawData = metadataScalarString(object["data"])
+            let consumedDataImage = rawData.flatMap(dataImageMimeType) != nil
+            if let data = rawData,
+               let mimeType = dataImageMimeType(data) {
+                assets.append(.image(data: data, mimeType: mimeType))
+            }
+
+            for (key, child) in object
+                where key != "b64_json" && !(key == "data" && consumedDataImage) {
+                collectRawOutputAssets(child, into: &assets)
+            }
+            return
+        }
+
+        if let array = metadataArray(value) {
+            for child in array {
+                collectRawOutputAssets(child, into: &assets)
+            }
+            return
+        }
+
+        if let string = metadataScalarString(value),
+           let mimeType = dataImageMimeType(string) {
+            assets.append(.image(data: string, mimeType: mimeType))
+        }
+    }
+
+    private static func dataImageMimeType(_ value: String) -> String? {
+        let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard trimmed.lowercased().hasPrefix("data:image/"),
+              let semicolon = trimmed.firstIndex(of: ";")
+        else { return nil }
+        return String(trimmed[..<semicolon].dropFirst("data:".count))
     }
 
     private static func assetName(from uri: String?) -> String? {

--- a/Alas/Sources/ACP/Session/ACPSession.swift
+++ b/Alas/Sources/ACP/Session/ACPSession.swift
@@ -380,13 +380,13 @@ final class ACPSession: ObservableObject, Identifiable {
             guard let touched = updateToolCall(id: payload.toolCallId, { tc in
                 Self.applyToolCallPayloadFields(payload, to: &tc)
             }) else { return [] }
-            applyToolCallMetadata(payload.metadata)
+            applyToolCallMetadata(payload.metadata, replaying: true)
             return [touched]
         case .toolCallUpdate(let update):
             guard let touched = updateToolCall(id: update.toolCallId, { tc in
                 Self.applyToolCallUpdateFields(update, to: &tc, allowFinalSnapshotReplacement: false)
             }) else { return [] }
-            applyToolCallMetadata(update.metadata)
+            applyToolCallMetadata(update.metadata, replaying: true)
             return [touched]
         default:
             return []
@@ -422,7 +422,9 @@ final class ACPSession: ObservableObject, Identifiable {
 
         guard let items = payload.content else { return }
         if !canReplaceSnapshot {
-            tc.assets = Self.mergeAssets(tc.assets, Self.extractAssets(items))
+            if Self.isFinalStatus(payload.status) {
+                tc.assets = Self.mergeAssets(tc.assets, Self.extractAssets(items))
+            }
             return
         }
         let raw = Self.flatten(items)
@@ -434,7 +436,7 @@ final class ACPSession: ObservableObject, Identifiable {
         tc.contentLanguage = Self.wrappingFenceLanguage(raw)
         tc.terminalIds = Self.mergeTerminalIds(
             Self.extractTerminalIds(items),
-            Self.extractMetadataTerminalIds(tc.metadata))
+            Self.extractMetadataTerminalIds(tc.metadata, includeExit: false))
         let preservedRawOutputAssets = rawOutputAssets.isEmpty
             ? Self.extractStoredRawOutputAssets(tc.rawOutput, existingAssets: tc.assets)
             : rawOutputAssets
@@ -465,7 +467,9 @@ final class ACPSession: ObservableObject, Identifiable {
         }
         if let content = update.content {
             if !canReplaceSnapshot {
-                tc.assets = Self.mergeAssets(tc.assets, Self.extractAssets(content))
+                if let status = update.status, Self.isFinalStatus(status) {
+                    tc.assets = Self.mergeAssets(tc.assets, Self.extractAssets(content))
+                }
                 return
             }
             let raw = Self.flatten(content)
@@ -477,7 +481,7 @@ final class ACPSession: ObservableObject, Identifiable {
             tc.contentLanguage = Self.wrappingFenceLanguage(raw)
             tc.terminalIds = Self.mergeTerminalIds(
                 Self.extractTerminalIds(content),
-                Self.extractMetadataTerminalIds(tc.metadata))
+                Self.extractMetadataTerminalIds(tc.metadata, includeExit: false))
             let preservedRawOutputAssets = rawOutputAssets.isEmpty
                 ? Self.extractStoredRawOutputAssets(tc.rawOutput, existingAssets: tc.assets)
                 : rawOutputAssets
@@ -818,9 +822,11 @@ final class ACPSession: ObservableObject, Identifiable {
         return merged
     }
 
-    private static func extractMetadataTerminalIds(_ metadata: AnyCodable?) -> [String] {
+    private static func extractMetadataTerminalIds(_ metadata: AnyCodable?, includeExit: Bool = true) -> [String] {
         guard let root = Self.metadataObject(metadata) else { return [] }
-        let fields = ["terminal_info", "terminal_output", "terminal_output_delta"]
+        let fields = includeExit
+            ? ["terminal_info", "terminal_output", "terminal_output_delta", "terminal_exit"]
+            : ["terminal_info", "terminal_output", "terminal_output_delta"]
         return fields.compactMap { field in
             guard let object = Self.metadataObject(root[field]) else { return nil }
             return Self.metadataScalarString(object["terminal_id"])
@@ -852,41 +858,52 @@ final class ACPSession: ObservableObject, Identifiable {
         return String(string.prefix(metadataPreviewLimit)) + "… [truncated]"
     }
 
-    private func applyToolCallMetadata(_ metadata: AnyCodable?) {
+    private func applyToolCallMetadata(_ metadata: AnyCodable?, replaying: Bool = false) {
         guard let root = Self.metadataObject(metadata) else { return }
+        let replayExistingTerminalIds = replaying
+            ? Set(Self.extractMetadataTerminalIds(metadata).filter { terminalHost.terminal(id: $0) != nil })
+            : []
 
         if let info = Self.metadataObject(root["terminal_info"]),
            let terminalId = Self.metadataScalarString(info["terminal_id"]) {
-            terminalHost.recordMetadataTerminalInfo(
-                terminalId: terminalId,
-                cwd: Self.metadataScalarString(info["cwd"]))
+            if !replayExistingTerminalIds.contains(terminalId) {
+                terminalHost.recordMetadataTerminalInfo(
+                    terminalId: terminalId,
+                    cwd: Self.metadataScalarString(info["cwd"]))
+            }
         }
 
         if let output = Self.metadataObject(root["terminal_output"]),
            let terminalId = Self.metadataScalarString(output["terminal_id"]),
            let text = Self.metadataScalarString(output["data"]) {
-            terminalHost.appendMetadataOutput(
-                terminalId: terminalId,
-                data: Data(text.utf8),
-                replace: true)
+            if !replayExistingTerminalIds.contains(terminalId) {
+                terminalHost.appendMetadataOutput(
+                    terminalId: terminalId,
+                    data: Data(text.utf8),
+                    replace: true)
+            }
         }
 
         if let delta = Self.metadataObject(root["terminal_output_delta"]),
            let terminalId = Self.metadataScalarString(delta["terminal_id"]),
            let text = Self.metadataScalarString(delta["data"]) {
-            terminalHost.appendMetadataOutput(
-                terminalId: terminalId,
-                data: Data(text.utf8),
-                replace: false)
+            if !replayExistingTerminalIds.contains(terminalId) {
+                terminalHost.appendMetadataOutput(
+                    terminalId: terminalId,
+                    data: Data(text.utf8),
+                    replace: false)
+            }
         }
 
         if let exit = Self.metadataObject(root["terminal_exit"]),
            let terminalId = Self.metadataScalarString(exit["terminal_id"]) {
-            terminalHost.recordMetadataExit(
-                terminalId: terminalId,
-                exitStatus: ACPTerminalExitStatus(
-                    exitCode: Self.metadataInt(exit["exit_code"]),
-                    signal: Self.metadataScalarString(exit["signal"])))
+            if !replayExistingTerminalIds.contains(terminalId) {
+                terminalHost.recordMetadataExit(
+                    terminalId: terminalId,
+                    exitStatus: ACPTerminalExitStatus(
+                        exitCode: Self.metadataInt(exit["exit_code"]),
+                        signal: Self.metadataScalarString(exit["signal"])))
+            }
         }
     }
 

--- a/Alas/Sources/ACP/Session/ACPSession.swift
+++ b/Alas/Sources/ACP/Session/ACPSession.swift
@@ -377,14 +377,10 @@ final class ACPSession: ObservableObject, Identifiable {
     func applySuppressedReplaySideEffects(_ update: ACPSessionUpdate) {
         switch update {
         case .toolCall(let payload):
-            guard let metadata = payload.metadata else { return }
             guard updateToolCall(id: payload.toolCallId, { tc in
-                tc.metadata = Self.mergeMetadata(tc.metadata, metadata)
-                tc.terminalIds = Self.mergeTerminalIds(
-                    tc.terminalIds,
-                    Self.extractMetadataTerminalIds(metadata))
+                applyToolCallPayloadFields(payload, to: &tc)
             }) != nil else { return }
-            applyToolCallMetadata(metadata)
+            applyToolCallMetadata(payload.metadata)
         case .toolCallUpdate(let update):
             guard updateToolCall(id: update.toolCallId, { tc in
                 applyToolCallUpdateFields(update, to: &tc)
@@ -393,6 +389,43 @@ final class ACPSession: ObservableObject, Identifiable {
         default:
             break
         }
+    }
+
+    private func applyToolCallPayloadFields(
+        _ payload: ACPToolCallPayload,
+        to tc: inout ACPMessage.ToolCall
+    ) {
+        tc.title = payload.title
+        tc.kind = payload.kind
+        tc.status = payload.status
+        if let locations = payload.locations { tc.locations = locations.map(\.path) }
+        if let rawInput = payload.rawInput { tc.rawInput = Self.metadataString(rawInput) }
+        var rawOutputAssets: [ACPMessage.ToolCallAsset] = []
+        if let rawOutput = payload.rawOutput {
+            tc.rawOutput = Self.metadataString(rawOutput)
+            rawOutputAssets = Self.extractRawOutputAssets(rawOutput)
+            tc.assets = Self.mergeAssets(tc.assets, rawOutputAssets)
+        }
+        tc.metadata = Self.mergeMetadata(tc.metadata, payload.metadata)
+        tc.terminalIds = Self.mergeTerminalIds(
+            tc.terminalIds,
+            Self.extractMetadataTerminalIds(tc.metadata))
+
+        guard let items = payload.content else { return }
+        let raw = Self.flatten(items)
+        let full = Self.stripWrappingFence(raw,
+                                           isFinal: Self.isFinalStatus(payload.status))
+        tc.content = full
+        tc.isContentTruncated = false
+        tc.preview = Self.previewLine(full)
+        tc.contentLanguage = Self.wrappingFenceLanguage(raw)
+        tc.terminalIds = Self.mergeTerminalIds(
+            Self.extractTerminalIds(items),
+            Self.extractMetadataTerminalIds(tc.metadata))
+        let preservedRawOutputAssets = rawOutputAssets.isEmpty
+            ? Self.extractStoredRawOutputAssets(tc.rawOutput, existingAssets: tc.assets)
+            : rawOutputAssets
+        tc.assets = Self.mergeAssets(Self.extractAssets(items), preservedRawOutputAssets)
     }
 
     private func applyToolCallUpdateFields(

--- a/Alas/Sources/ACP/Session/ACPSession.swift
+++ b/Alas/Sources/ACP/Session/ACPSession.swift
@@ -433,6 +433,9 @@ final class ACPSession: ObservableObject, Identifiable {
         if !canReplaceSnapshot {
             if Self.isFinalStatus(payload.status) {
                 tc.assets = Self.mergeAssets(tc.assets, Self.extractAssets(items))
+                tc.terminalIds = Self.mergeTerminalIds(
+                    tc.terminalIds,
+                    Self.extractTerminalIds(items))
             }
             return
         }

--- a/Alas/Sources/ACP/Session/ACPSession.swift
+++ b/Alas/Sources/ACP/Session/ACPSession.swift
@@ -885,7 +885,11 @@ final class ACPSession: ObservableObject, Identifiable {
         if let output = Self.metadataObject(root["terminal_output"]),
            let terminalId = Self.metadataScalarString(output["terminal_id"]),
            let text = Self.metadataScalarString(output["data"]) {
-            if shouldApplyMetadataTerminalSideEffect(terminalId: terminalId, replaying: replaying) {
+            if shouldApplyMetadataTerminalSideEffect(
+                terminalId: terminalId,
+                replaying: replaying,
+                replace: true
+            ) {
                 terminalHost.appendMetadataOutput(
                     terminalId: terminalId,
                     data: Data(text.utf8),
@@ -896,7 +900,11 @@ final class ACPSession: ObservableObject, Identifiable {
         if let delta = Self.metadataObject(root["terminal_output_delta"]),
            let terminalId = Self.metadataScalarString(delta["terminal_id"]),
            let text = Self.metadataScalarString(delta["data"]) {
-            if shouldApplyMetadataTerminalSideEffect(terminalId: terminalId, replaying: replaying) {
+            if shouldApplyMetadataTerminalSideEffect(
+                terminalId: terminalId,
+                replaying: replaying,
+                replace: false
+            ) {
                 terminalHost.appendMetadataOutput(
                     terminalId: terminalId,
                     data: Data(text.utf8),
@@ -916,8 +924,13 @@ final class ACPSession: ObservableObject, Identifiable {
         }
     }
 
-    private func shouldApplyMetadataTerminalSideEffect(terminalId: String, replaying: Bool) -> Bool {
+    private func shouldApplyMetadataTerminalSideEffect(
+        terminalId: String,
+        replaying: Bool,
+        replace: Bool = false
+    ) -> Bool {
         guard replaying else { return true }
+        if replace { return true }
         if replayCreatedMetadataTerminalIds.contains(terminalId) { return true }
         if let terminal = terminalHost.terminal(id: terminalId),
            !terminal.buffer.isEmpty || terminal.exitStatus != nil {

--- a/Alas/Sources/ACP/Session/ACPSession.swift
+++ b/Alas/Sources/ACP/Session/ACPSession.swift
@@ -324,6 +324,8 @@ final class ACPSession: ObservableObject, Identifiable {
                 }
             }
             return touched.map { [$0] } ?? []
+        case .sessionInfoUpdate:
+            return []
         case .plan(let entries):
             clearRestoredContextRecoveryStatus()
             let items = entries.map { ACPMessage.PlanItem(content: $0.content, status: $0.status) }

--- a/Alas/Sources/ACP/Session/ACPSession.swift
+++ b/Alas/Sources/ACP/Session/ACPSession.swift
@@ -313,16 +313,21 @@ final class ACPSession: ObservableObject, Identifiable {
                 terminalIds: Self.extractTerminalIds(items))))
             didAppendTranscriptMessage()
             transcript.completedOutputBoundaryMessageIds.removeAll()
+            applyToolCallMetadata(payload.metadata)
             return [transcript.messages.count - 1]
         case .toolCallUpdate(let u):
             clearRestoredContextRecoveryStatus()
+            var appliedMetadata: AnyCodable?
             let touched = updateToolCall(id: u.toolCallId) { tc in
                 if let title = u.title { tc.title = title }
                 if let s = u.status { tc.status = s }
                 if let locations = u.locations { tc.locations = locations.map(\.path) }
                 if let rawInput = u.rawInput { tc.rawInput = Self.metadataString(rawInput) }
                 if let rawOutput = u.rawOutput { tc.rawOutput = Self.metadataString(rawOutput) }
-                if let metadata = u.metadata { tc.metadata = metadata }
+                if let metadata = u.metadata {
+                    tc.metadata = metadata
+                    appliedMetadata = metadata
+                }
                 if let c = u.content {
                     // ACP content updates are full replacement snapshots,
                     // so terminalIds tracks the *current* content — assign
@@ -339,6 +344,7 @@ final class ACPSession: ObservableObject, Identifiable {
                     tc.assets = Self.extractAssets(c)
                 }
             }
+            applyToolCallMetadata(appliedMetadata)
             return touched.map { [$0] } ?? []
         case .sessionInfoUpdate(let info):
             applySessionInfoUpdate(info)
@@ -724,6 +730,68 @@ final class ACPSession: ObservableObject, Identifiable {
     private static func boundedMetadataPreview(_ string: String) -> String {
         guard string.count > metadataPreviewLimit else { return string }
         return String(string.prefix(metadataPreviewLimit)) + "… [truncated]"
+    }
+
+    private func applyToolCallMetadata(_ metadata: AnyCodable?) {
+        guard let root = Self.metadataObject(metadata) else { return }
+
+        if let info = Self.metadataObject(root["terminal_info"]),
+           let terminalId = Self.metadataScalarString(info["terminal_id"]) {
+            terminalHost.recordMetadataTerminalInfo(
+                terminalId: terminalId,
+                cwd: Self.metadataScalarString(info["cwd"]))
+        }
+
+        if let output = Self.metadataObject(root["terminal_output"]),
+           let terminalId = Self.metadataScalarString(output["terminal_id"]),
+           let text = Self.metadataScalarString(output["data"]) {
+            terminalHost.appendMetadataOutput(
+                terminalId: terminalId,
+                data: Data(text.utf8),
+                replace: true)
+        }
+
+        if let delta = Self.metadataObject(root["terminal_output_delta"]),
+           let terminalId = Self.metadataScalarString(delta["terminal_id"]),
+           let text = Self.metadataScalarString(delta["data"]) {
+            terminalHost.appendMetadataOutput(
+                terminalId: terminalId,
+                data: Data(text.utf8),
+                replace: false)
+        }
+
+        if let exit = Self.metadataObject(root["terminal_exit"]),
+           let terminalId = Self.metadataScalarString(exit["terminal_id"]) {
+            terminalHost.recordMetadataExit(
+                terminalId: terminalId,
+                exitStatus: ACPTerminalExitStatus(
+                    exitCode: Self.metadataInt(exit["exit_code"]),
+                    signal: Self.metadataScalarString(exit["signal"])))
+        }
+    }
+
+    private static func metadataObject(_ value: AnyCodable?) -> [String: AnyCodable]? {
+        if let dict = value?.value as? [String: AnyCodable] { return dict }
+        if let dict = value?.value as? [String: Any] {
+            return dict.mapValues { raw in
+                (raw as? AnyCodable) ?? AnyCodable(raw)
+            }
+        }
+        return nil
+    }
+
+    private static func metadataScalarString(_ value: AnyCodable?) -> String? {
+        guard let raw = value?.value, !(raw is NSNull) else { return nil }
+        return raw as? String
+    }
+
+    private static func metadataInt(_ value: AnyCodable?) -> Int? {
+        guard let raw = value?.value, !(raw is NSNull) else { return nil }
+        if let int = raw as? Int { return int }
+        if let double = raw as? Double, double.rounded(.towardZero) == double {
+            return Int(double)
+        }
+        return nil
     }
 
     private static func extractTerminalIds(_ items: [ACPToolCallContent]) -> [String] {

--- a/Alas/Sources/ACP/Session/ACPSession.swift
+++ b/Alas/Sources/ACP/Session/ACPSession.swift
@@ -877,8 +877,10 @@ final class ACPSession: ObservableObject, Identifiable {
               let root = metadata.value as? [String: AnyCodable]
         else { return }
 
-        if let codex = root["codex"]?.value as? [String: AnyCodable],
-           let goal = codex["goal"] {
+        if let goal = root["goal"] {
+            currentGoal = Self.goalState(from: goal)
+        } else if let codex = root["codex"]?.value as? [String: AnyCodable],
+                  let goal = codex["goal"] {
             currentGoal = Self.goalState(from: goal)
         }
     }

--- a/Alas/Sources/ACP/Session/ACPSession.swift
+++ b/Alas/Sources/ACP/Session/ACPSession.swift
@@ -105,6 +105,7 @@ final class ACPSession: ObservableObject, Identifiable {
     private var reconciledLegacyLocalUserPromptIds: Set<UUID> = []
     private var liveUserChunkMessageIds: Set<String> = []
     private var legacyUserChunkMessageIds: Set<UUID> = []
+    private var replayCreatedMetadataTerminalIds: Set<String> = []
 
     /// Runtime-only marker for a forced queue item parked behind the current
     /// `.sending` head. If that head fails, it moves behind this item so the
@@ -393,6 +394,14 @@ final class ACPSession: ObservableObject, Identifiable {
         }
     }
 
+    func beginSuppressedReplaySideEffects() {
+        replayCreatedMetadataTerminalIds.removeAll()
+    }
+
+    func endSuppressedReplaySideEffects() {
+        replayCreatedMetadataTerminalIds.removeAll()
+    }
+
     private static func applyToolCallPayloadFields(
         _ payload: ACPToolCallPayload,
         to tc: inout ACPMessage.ToolCall
@@ -417,7 +426,7 @@ final class ACPSession: ObservableObject, Identifiable {
             tc.metadata = Self.mergeMetadata(tc.metadata, metadata)
             tc.terminalIds = Self.mergeTerminalIds(
                 tc.terminalIds,
-            Self.extractMetadataTerminalIds(metadata))
+                Self.extractMetadataTerminalIds(metadata, includeExit: payload.content == nil))
         }
 
         guard let items = payload.content else { return }
@@ -860,13 +869,10 @@ final class ACPSession: ObservableObject, Identifiable {
 
     private func applyToolCallMetadata(_ metadata: AnyCodable?, replaying: Bool = false) {
         guard let root = Self.metadataObject(metadata) else { return }
-        let replayExistingTerminalIds = replaying
-            ? Set(Self.extractMetadataTerminalIds(metadata).filter { terminalHost.terminal(id: $0) != nil })
-            : []
 
         if let info = Self.metadataObject(root["terminal_info"]),
            let terminalId = Self.metadataScalarString(info["terminal_id"]) {
-            if !replayExistingTerminalIds.contains(terminalId) {
+            if shouldApplyMetadataTerminalSideEffect(terminalId: terminalId, replaying: replaying) {
                 terminalHost.recordMetadataTerminalInfo(
                     terminalId: terminalId,
                     cwd: Self.metadataScalarString(info["cwd"]))
@@ -876,7 +882,7 @@ final class ACPSession: ObservableObject, Identifiable {
         if let output = Self.metadataObject(root["terminal_output"]),
            let terminalId = Self.metadataScalarString(output["terminal_id"]),
            let text = Self.metadataScalarString(output["data"]) {
-            if !replayExistingTerminalIds.contains(terminalId) {
+            if shouldApplyMetadataTerminalSideEffect(terminalId: terminalId, replaying: replaying) {
                 terminalHost.appendMetadataOutput(
                     terminalId: terminalId,
                     data: Data(text.utf8),
@@ -887,7 +893,7 @@ final class ACPSession: ObservableObject, Identifiable {
         if let delta = Self.metadataObject(root["terminal_output_delta"]),
            let terminalId = Self.metadataScalarString(delta["terminal_id"]),
            let text = Self.metadataScalarString(delta["data"]) {
-            if !replayExistingTerminalIds.contains(terminalId) {
+            if shouldApplyMetadataTerminalSideEffect(terminalId: terminalId, replaying: replaying) {
                 terminalHost.appendMetadataOutput(
                     terminalId: terminalId,
                     data: Data(text.utf8),
@@ -897,7 +903,7 @@ final class ACPSession: ObservableObject, Identifiable {
 
         if let exit = Self.metadataObject(root["terminal_exit"]),
            let terminalId = Self.metadataScalarString(exit["terminal_id"]) {
-            if !replayExistingTerminalIds.contains(terminalId) {
+            if shouldApplyMetadataTerminalSideEffect(terminalId: terminalId, replaying: replaying) {
                 terminalHost.recordMetadataExit(
                     terminalId: terminalId,
                     exitStatus: ACPTerminalExitStatus(
@@ -905,6 +911,17 @@ final class ACPSession: ObservableObject, Identifiable {
                         signal: Self.metadataScalarString(exit["signal"])))
             }
         }
+    }
+
+    private func shouldApplyMetadataTerminalSideEffect(terminalId: String, replaying: Bool) -> Bool {
+        guard replaying else { return true }
+        if replayCreatedMetadataTerminalIds.contains(terminalId) { return true }
+        if let terminal = terminalHost.terminal(id: terminalId),
+           !terminal.buffer.isEmpty || terminal.exitStatus != nil {
+            return false
+        }
+        replayCreatedMetadataTerminalIds.insert(terminalId)
+        return true
     }
 
     private static func metadataObject(_ value: AnyCodable?) -> [String: AnyCodable]? {

--- a/Alas/Sources/ACP/Session/ACPSession.swift
+++ b/Alas/Sources/ACP/Session/ACPSession.swift
@@ -1002,6 +1002,9 @@ final class ACPSession: ObservableObject, Identifiable {
 
     private static func assetName(from uri: String?) -> String? {
         guard let uri, !uri.isEmpty else { return nil }
+        if uri.trimmingCharacters(in: .whitespacesAndNewlines).lowercased().hasPrefix("data:") {
+            return nil
+        }
         return URL(string: uri)?.lastPathComponent
             ?? URL(fileURLWithPath: uri).lastPathComponent
     }

--- a/Alas/Sources/ACP/Session/ACPSession.swift
+++ b/Alas/Sources/ACP/Session/ACPSession.swift
@@ -22,6 +22,12 @@ enum ACPSessionTitleSource: String, Codable {
     case manual
 }
 
+struct ACPGoalState: Equatable, Hashable, Sendable {
+    let objective: String
+    let status: String?
+    let tokenBudget: Int?
+}
+
 @MainActor
 final class ACPSession: ObservableObject, Identifiable {
     typealias ID = String
@@ -43,6 +49,7 @@ final class ACPSession: ObservableObject, Identifiable {
     @Published var currentModel: String?
     @Published var contextUsage: ACPUsageInfo?
     @Published var currentMode: String?
+    @Published var currentGoal: ACPGoalState?
     @Published var promptSuggestions: [ACPPromptSuggestion] = []
     @Published var autoRunEnabled: Bool = false
     @Published var setupState: SetupState = .checking
@@ -299,6 +306,9 @@ final class ACPSession: ObservableObject, Identifiable {
                 preview: Self.previewLine(full),
                 contentLanguage: Self.wrappingFenceLanguage(raw),
                 rawInput: Self.metadataString(payload.rawInput),
+                rawOutput: Self.metadataString(payload.rawOutput),
+                metadata: payload.metadata,
+                assets: Self.extractAssets(items),
                 locations: payload.locations?.map(\.path) ?? [],
                 terminalIds: Self.extractTerminalIds(items))))
             didAppendTranscriptMessage()
@@ -307,7 +317,12 @@ final class ACPSession: ObservableObject, Identifiable {
         case .toolCallUpdate(let u):
             clearRestoredContextRecoveryStatus()
             let touched = updateToolCall(id: u.toolCallId) { tc in
+                if let title = u.title { tc.title = title }
                 if let s = u.status { tc.status = s }
+                if let locations = u.locations { tc.locations = locations.map(\.path) }
+                if let rawInput = u.rawInput { tc.rawInput = Self.metadataString(rawInput) }
+                if let rawOutput = u.rawOutput { tc.rawOutput = Self.metadataString(rawOutput) }
+                if let metadata = u.metadata { tc.metadata = metadata }
                 if let c = u.content {
                     // ACP content updates are full replacement snapshots,
                     // so terminalIds tracks the *current* content — assign
@@ -321,10 +336,12 @@ final class ACPSession: ObservableObject, Identifiable {
                     tc.preview = Self.previewLine(full)
                     tc.contentLanguage = Self.wrappingFenceLanguage(raw)
                     tc.terminalIds = Self.extractTerminalIds(c)
+                    tc.assets = Self.extractAssets(c)
                 }
             }
             return touched.map { [$0] } ?? []
-        case .sessionInfoUpdate:
+        case .sessionInfoUpdate(let info):
+            applySessionInfoUpdate(info)
             return []
         case .plan(let entries):
             clearRestoredContextRecoveryStatus()
@@ -644,12 +661,13 @@ final class ACPSession: ObservableObject, Identifiable {
             switch item {
             case .content(.text(let s)):
                 out.append(s)
-            case .content(.resourceLink(let uri, let name)):
-                out.append("[\(name ?? uri)]")
-            case .content(.image):
-                out.append("[image]")
-            case .content(.resource(let uri, _, _)):
-                out.append("[\(URL(string: uri)?.lastPathComponent ?? uri)]")
+            case .content(.resourceLink), .content(.image):
+                // Asset blocks are preserved on `ToolCall.assets`; including
+                // text placeholders here corrupts wrapped prose/code output
+                // when an update contains both text and assets.
+                continue
+            case .content(.resource(_, _, let text)):
+                out.append(text)
             case .diff(let path, let old, let new):
                 var lines: [String] = ["--- \(path)"]
                 if let old, !old.isEmpty {
@@ -710,6 +728,63 @@ final class ACPSession: ObservableObject, Identifiable {
 
     private static func extractTerminalIds(_ items: [ACPToolCallContent]) -> [String] {
         items.compactMap { if case .terminal(let id) = $0 { return id } else { return nil } }
+    }
+
+    private static func extractAssets(_ items: [ACPToolCallContent]) -> [ACPMessage.ToolCallAsset] {
+        items.compactMap { item in
+            guard case .content(let block) = item else { return nil }
+            switch block {
+            case .image(let data, let uri, let mime):
+                return .image(data: data, uri: uri, mimeType: mime, name: Self.assetName(from: uri))
+            case .resourceLink(let uri, let name):
+                return .resource(uri: uri, name: name)
+            case .resource(let uri, let mime, _):
+                return .resource(uri: uri, name: Self.assetName(from: uri), mimeType: mime)
+            case .text:
+                return nil
+            }
+        }
+    }
+
+    private static func assetName(from uri: String?) -> String? {
+        guard let uri, !uri.isEmpty else { return nil }
+        return URL(string: uri)?.lastPathComponent
+            ?? URL(fileURLWithPath: uri).lastPathComponent
+    }
+
+    private func applySessionInfoUpdate(_ info: ACPSessionInfoUpdate) {
+        if let title = info.title?.trimmingCharacters(in: .whitespacesAndNewlines),
+           !title.isEmpty,
+           titleSource != .manual {
+            self.title = title
+            titleSource = .generated
+        }
+        applyGoalMetadata(info.metadata)
+    }
+
+    private func applyGoalMetadata(_ metadata: AnyCodable?) {
+        guard let metadata,
+              let root = metadata.value as? [String: AnyCodable]
+        else { return }
+
+        if let codex = root["codex"]?.value as? [String: AnyCodable],
+           let goal = codex["goal"] {
+            currentGoal = Self.goalState(from: goal)
+        }
+    }
+
+    private static func goalState(from value: AnyCodable) -> ACPGoalState? {
+        if value.value is NSNull { return nil }
+        guard let goal = value.value as? [String: AnyCodable],
+              let objective = goal["objective"]?.value as? String
+        else { return nil }
+        let trimmedObjective = objective.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmedObjective.isEmpty else { return nil }
+
+        return ACPGoalState(
+            objective: trimmedObjective,
+            status: goal["status"]?.value as? String,
+            tokenBudget: goal["tokenBudget"]?.value as? Int)
     }
 
     /// Best-effort strip of a single pair of markdown code fences that

--- a/Alas/Sources/ACP/Session/ACPSession.swift
+++ b/Alas/Sources/ACP/Session/ACPSession.swift
@@ -417,7 +417,7 @@ final class ACPSession: ObservableObject, Identifiable {
         if canReplaceSnapshot, let locations = payload.locations { tc.locations = locations.map(\.path) }
         if canReplaceSnapshot, let rawInput = payload.rawInput { tc.rawInput = Self.metadataString(rawInput) }
         var rawOutputAssets: [ACPMessage.ToolCallAsset] = []
-        if let rawOutput = payload.rawOutput {
+        if (canReplaceSnapshot || Self.isFinalStatus(payload.status)), let rawOutput = payload.rawOutput {
             tc.rawOutput = Self.metadataString(rawOutput)
             rawOutputAssets = Self.extractRawOutputAssets(rawOutput)
             tc.assets = Self.mergeAssets(tc.assets, rawOutputAssets)
@@ -466,7 +466,7 @@ final class ACPSession: ObservableObject, Identifiable {
         if canReplaceSnapshot, let status = update.status { tc.status = status }
         if canReplaceSnapshot, let locations = update.locations { tc.locations = locations.map(\.path) }
         if canReplaceSnapshot, let rawInput = update.rawInput { tc.rawInput = Self.metadataString(rawInput) }
-        if let rawOutput = update.rawOutput {
+        if (canReplaceSnapshot || update.status.map(Self.isFinalStatus) == true), let rawOutput = update.rawOutput {
             tc.rawOutput = Self.metadataString(rawOutput)
             rawOutputAssets = Self.extractRawOutputAssets(rawOutput)
             tc.assets = Self.mergeAssets(tc.assets, rawOutputAssets)

--- a/Alas/Sources/ACP/Session/ACPSession.swift
+++ b/Alas/Sources/ACP/Session/ACPSession.swift
@@ -322,7 +322,7 @@ final class ACPSession: ObservableObject, Identifiable {
         case .toolCallUpdate(let u):
             clearRestoredContextRecoveryStatus()
             let touched = updateToolCall(id: u.toolCallId) { tc in
-                applyToolCallUpdateFields(u, to: &tc)
+                Self.applyToolCallUpdateFields(u, to: &tc)
             }
             if touched != nil {
                 applyToolCallMetadata(u.metadata)
@@ -378,12 +378,12 @@ final class ACPSession: ObservableObject, Identifiable {
         switch update {
         case .toolCall(let payload):
             guard updateToolCall(id: payload.toolCallId, { tc in
-                applyToolCallPayloadFields(payload, to: &tc)
+                Self.applyToolCallPayloadFields(payload, to: &tc)
             }) != nil else { return }
             applyToolCallMetadata(payload.metadata)
         case .toolCallUpdate(let update):
             guard updateToolCall(id: update.toolCallId, { tc in
-                applyToolCallUpdateFields(update, to: &tc)
+                Self.applyToolCallUpdateFields(update, to: &tc)
             }) != nil else { return }
             applyToolCallMetadata(update.metadata)
         default:
@@ -391,7 +391,7 @@ final class ACPSession: ObservableObject, Identifiable {
         }
     }
 
-    private func applyToolCallPayloadFields(
+    private static func applyToolCallPayloadFields(
         _ payload: ACPToolCallPayload,
         to tc: inout ACPMessage.ToolCall
     ) {
@@ -428,7 +428,7 @@ final class ACPSession: ObservableObject, Identifiable {
         tc.assets = Self.mergeAssets(Self.extractAssets(items), preservedRawOutputAssets)
     }
 
-    private func applyToolCallUpdateFields(
+    private static func applyToolCallUpdateFields(
         _ update: ACPToolCallUpdate,
         to tc: inout ACPMessage.ToolCall
     ) {

--- a/Alas/Sources/ACP/Session/ACPSession.swift
+++ b/Alas/Sources/ACP/Session/ACPSession.swift
@@ -297,6 +297,9 @@ final class ACPSession: ObservableObject, Identifiable {
             let raw = Self.flatten(items)
             let full = Self.stripWrappingFence(raw,
                                                isFinal: Self.isFinalStatus(payload.status))
+            let terminalIds = Self.mergeTerminalIds(
+                Self.extractTerminalIds(items),
+                Self.extractMetadataTerminalIds(payload.metadata))
             transcript.messages.append(.toolCall(.init(
                 toolCallId: payload.toolCallId,
                 title: payload.title,
@@ -310,7 +313,7 @@ final class ACPSession: ObservableObject, Identifiable {
                 metadata: payload.metadata,
                 assets: Self.extractAssets(items),
                 locations: payload.locations?.map(\.path) ?? [],
-                terminalIds: Self.extractTerminalIds(items))))
+                terminalIds: terminalIds)))
             didAppendTranscriptMessage()
             transcript.completedOutputBoundaryMessageIds.removeAll()
             applyToolCallMetadata(payload.metadata)
@@ -318,6 +321,7 @@ final class ACPSession: ObservableObject, Identifiable {
         case .toolCallUpdate(let u):
             clearRestoredContextRecoveryStatus()
             var appliedMetadata: AnyCodable?
+            var metadataTerminalIds: [String] = []
             let touched = updateToolCall(id: u.toolCallId) { tc in
                 if let title = u.title { tc.title = title }
                 if let s = u.status { tc.status = s }
@@ -327,6 +331,8 @@ final class ACPSession: ObservableObject, Identifiable {
                 if let metadata = u.metadata {
                     tc.metadata = metadata
                     appliedMetadata = metadata
+                    metadataTerminalIds = Self.extractMetadataTerminalIds(metadata)
+                    tc.terminalIds = Self.mergeTerminalIds(tc.terminalIds, metadataTerminalIds)
                 }
                 if let c = u.content {
                     // ACP content updates are full replacement snapshots,
@@ -340,7 +346,7 @@ final class ACPSession: ObservableObject, Identifiable {
                     tc.content = full
                     tc.preview = Self.previewLine(full)
                     tc.contentLanguage = Self.wrappingFenceLanguage(raw)
-                    tc.terminalIds = Self.extractTerminalIds(c)
+                    tc.terminalIds = Self.mergeTerminalIds(Self.extractTerminalIds(c), metadataTerminalIds)
                     tc.assets = Self.extractAssets(c)
                 }
             }
@@ -714,6 +720,24 @@ final class ACPSession: ObservableObject, Identifiable {
         let s = String(firstLine).trimmingCharacters(in: .whitespacesAndNewlines)
         guard !s.isEmpty else { return nil }
         return s.count > 80 ? String(s.prefix(80)) + "…" : s
+    }
+
+    private static func mergeTerminalIds(_ primary: [String], _ secondary: [String]) -> [String] {
+        var seen = Set<String>()
+        var merged: [String] = []
+        for terminalId in primary + secondary where seen.insert(terminalId).inserted {
+            merged.append(terminalId)
+        }
+        return merged
+    }
+
+    private static func extractMetadataTerminalIds(_ metadata: AnyCodable?) -> [String] {
+        guard let root = Self.metadataObject(metadata) else { return [] }
+        let fields = ["terminal_info", "terminal_output", "terminal_output_delta", "terminal_exit"]
+        return fields.compactMap { field in
+            guard let object = Self.metadataObject(root[field]) else { return nil }
+            return Self.metadataScalarString(object["terminal_id"])
+        }
     }
 
     private static func metadataString(_ value: AnyCodable?) -> String? {

--- a/Alas/Sources/ACP/Session/ACPSession.swift
+++ b/Alas/Sources/ACP/Session/ACPSession.swift
@@ -903,7 +903,7 @@ final class ACPSession: ObservableObject, Identifiable {
 
         if let exit = Self.metadataObject(root["terminal_exit"]),
            let terminalId = Self.metadataScalarString(exit["terminal_id"]) {
-            if shouldApplyMetadataTerminalSideEffect(terminalId: terminalId, replaying: replaying) {
+            if shouldApplyMetadataTerminalExitSideEffect(terminalId: terminalId, replaying: replaying) {
                 terminalHost.recordMetadataExit(
                     terminalId: terminalId,
                     exitStatus: ACPTerminalExitStatus(
@@ -919,6 +919,16 @@ final class ACPSession: ObservableObject, Identifiable {
         if let terminal = terminalHost.terminal(id: terminalId),
            !terminal.buffer.isEmpty || terminal.exitStatus != nil {
             return false
+        }
+        replayCreatedMetadataTerminalIds.insert(terminalId)
+        return true
+    }
+
+    private func shouldApplyMetadataTerminalExitSideEffect(terminalId: String, replaying: Bool) -> Bool {
+        guard replaying else { return true }
+        if replayCreatedMetadataTerminalIds.contains(terminalId) { return true }
+        if let terminal = terminalHost.terminal(id: terminalId) {
+            return terminal.exitStatus == nil
         }
         replayCreatedMetadataTerminalIds.insert(terminalId)
         return true

--- a/Alas/Sources/ACP/Session/ACPSession.swift
+++ b/Alas/Sources/ACP/Session/ACPSession.swift
@@ -329,7 +329,7 @@ final class ACPSession: ObservableObject, Identifiable {
                 if let rawInput = u.rawInput { tc.rawInput = Self.metadataString(rawInput) }
                 if let rawOutput = u.rawOutput { tc.rawOutput = Self.metadataString(rawOutput) }
                 if let metadata = u.metadata {
-                    tc.metadata = metadata
+                    tc.metadata = Self.mergeMetadata(tc.metadata, metadata)
                     appliedMetadata = metadata
                     metadataTerminalIds = Self.extractMetadataTerminalIds(metadata)
                     tc.terminalIds = Self.mergeTerminalIds(tc.terminalIds, metadataTerminalIds)
@@ -738,6 +738,17 @@ final class ACPSession: ObservableObject, Identifiable {
             guard let object = Self.metadataObject(root[field]) else { return nil }
             return Self.metadataScalarString(object["terminal_id"])
         }
+    }
+
+    private static func mergeMetadata(_ existing: AnyCodable?, _ update: AnyCodable) -> AnyCodable {
+        guard var merged = Self.metadataObject(existing),
+              let updateObject = Self.metadataObject(update) else {
+            return update
+        }
+        for (key, value) in updateObject {
+            merged[key] = value
+        }
+        return AnyCodable(merged)
     }
 
     private static func metadataString(_ value: AnyCodable?) -> String? {

--- a/Alas/Sources/ACP/Session/ACPSessionRunner.swift
+++ b/Alas/Sources/ACP/Session/ACPSessionRunner.swift
@@ -1491,7 +1491,7 @@ extension ACPSessionRunner {
         let now = Int64(Date().timeIntervalSince1970)
         for i in indices.sorted() {
             guard i >= 0, i < messages.count else { continue }
-            let m = messages[i]
+            let m = messageForPersistence(messages[i])
             guard let payload = try? ACPMessageCodec.encode(m) else { continue }
             let id = "msg-\(sessionId)-\(i)"
             if i < persistedMessageCount {
@@ -1510,6 +1510,20 @@ extension ACPSessionRunner {
         }
         onPersist?()
         return true
+    }
+
+    private func messageForPersistence(_ message: ACPMessage) -> ACPMessage {
+        guard case .toolCall(var toolCall) = message,
+              toolCall.isContentTruncated,
+              let storedContent = try? store.loadToolCallContent(
+                sessionId: sessionId,
+                toolCallId: toolCall.toolCallId
+              )
+        else {
+            return message
+        }
+        toolCall.content = storedContent
+        return .toolCall(toolCall)
     }
 
     /// Persist messages from the apply() boundary. Three cases:

--- a/Alas/Sources/ACP/Session/ACPSessionRunner.swift
+++ b/Alas/Sources/ACP/Session/ACPSessionRunner.swift
@@ -146,6 +146,9 @@ final class ACPSessionRunner {
                         preAppliedSessionInfoDirty = nil
                     }
                     if self.suppressingLoadReplay {
+                        if preAppliedSessionInfoDirty == nil {
+                            self.session.applySuppressedReplaySideEffects(u.update)
+                        }
                         if let target = self.loadReplaySuppressionTarget,
                            self.observedUpdateCount >= target {
                             self.suppressingLoadReplay = false

--- a/Alas/Sources/ACP/Session/ACPSessionRunner.swift
+++ b/Alas/Sources/ACP/Session/ACPSessionRunner.swift
@@ -1378,7 +1378,7 @@ extension ACPSessionRunner {
         case .userMessageChunk, .toolCall, .plan, .availableModelsUpdate,
              .currentModeUpdate, .currentModelUpdate, .sessionInfoUpdate,
              .sessionConfigOptionsUpdate, .availableCommandsUpdate,
-             .usageUpdate, .sessionInfoUpdate, .unknown:
+             .usageUpdate, .unknown:
             return false
         }
     }

--- a/Alas/Sources/ACP/Session/ACPSessionRunner.swift
+++ b/Alas/Sources/ACP/Session/ACPSessionRunner.swift
@@ -137,13 +137,13 @@ final class ACPSessionRunner {
                 await MainActor.run {
                     self.observedUpdateCount += 1
                     self.appliedUpdateCount += 1
-                    let handledSessionInfoUpdate: Bool
+                    let preAppliedSessionInfoDirty: Set<Int>?
                     if case .sessionInfoUpdate(let info) = u.update {
                         self.flushStreamingPersist()
+                        preAppliedSessionInfoDirty = self.session.apply(u.update)
                         self.applySessionInfoTitle(info)
-                        handledSessionInfoUpdate = true
                     } else {
-                        handledSessionInfoUpdate = false
+                        preAppliedSessionInfoDirty = nil
                     }
                     if self.suppressingLoadReplay {
                         if let target = self.loadReplaySuppressionTarget,
@@ -158,7 +158,9 @@ final class ACPSessionRunner {
                         }
                         return
                     }
-                    if !handledSessionInfoUpdate {
+                    if let dirty = preAppliedSessionInfoDirty {
+                        self.persistIndices(dirty)
+                    } else {
                         let shouldBatchStreamingPersist = self.shouldBatchStreamingPersist(for: u.update)
                         let dirty = self.session.apply(u.update)
                         if shouldBatchStreamingPersist {

--- a/Alas/Sources/ACP/Session/ACPSessionRunner.swift
+++ b/Alas/Sources/ACP/Session/ACPSessionRunner.swift
@@ -1376,7 +1376,7 @@ extension ACPSessionRunner {
         case .agentMessageChunk, .agentThoughtChunk, .toolCallUpdate:
             return true
         case .userMessageChunk, .toolCall, .plan, .availableModelsUpdate,
-             .currentModeUpdate, .currentModelUpdate,
+             .currentModeUpdate, .currentModelUpdate, .sessionInfoUpdate,
              .sessionConfigOptionsUpdate, .availableCommandsUpdate,
              .usageUpdate, .sessionInfoUpdate, .unknown:
             return false

--- a/Alas/Sources/ACP/Session/ACPSessionRunner.swift
+++ b/Alas/Sources/ACP/Session/ACPSessionRunner.swift
@@ -146,9 +146,9 @@ final class ACPSessionRunner {
                         preAppliedSessionInfoDirty = nil
                     }
                     if self.suppressingLoadReplay {
-                        if preAppliedSessionInfoDirty == nil {
-                            self.session.applySuppressedReplaySideEffects(u.update)
-                        }
+                        let dirty = preAppliedSessionInfoDirty
+                            ?? self.session.applySuppressedReplaySideEffects(u.update)
+                        self.persistIndices(dirty)
                         if let target = self.loadReplaySuppressionTarget,
                            self.observedUpdateCount >= target {
                             self.suppressingLoadReplay = false

--- a/Alas/Sources/ACP/Session/ACPSessionRunner.swift
+++ b/Alas/Sources/ACP/Session/ACPSessionRunner.swift
@@ -1440,7 +1440,7 @@ extension ACPSessionRunner {
         let messages = session.transcript.messages
         for i in indices {
             guard i >= 0, i < messages.count else { continue }
-            let message = messages[i]
+            let message = messageForPersistence(messages[i])
             guard let payload = try? ACPMessageCodec.encode(message) else { continue }
             let id = "msg-\(sessionId)-\(i)"
             let basePayload = i < persistedMessageCount ? try? store.loadMessagePayload(id: id) : nil

--- a/Alas/Sources/ACP/Session/ACPSessionRunner.swift
+++ b/Alas/Sources/ACP/Session/ACPSessionRunner.swift
@@ -110,6 +110,9 @@ final class ACPSessionRunner {
         self.onSessionTitleUpdated = onSessionTitleUpdated
         self.streamingPersistDebounceNanos = streamingPersistDebounceNanos
         self.suppressingLoadReplay = suppressingLoadReplay
+        if suppressingLoadReplay {
+            session.beginSuppressedReplaySideEffects()
+        }
         self.onDirtyCheck = onDirtyCheck
         self.onLiveBufferRead = onLiveBufferRead
         self.onResumeTranscriptTail = onResumeTranscriptTail
@@ -152,6 +155,7 @@ final class ACPSessionRunner {
                         if let target = self.loadReplaySuppressionTarget,
                            self.observedUpdateCount >= target {
                             self.suppressingLoadReplay = false
+                            self.session.endSuppressedReplaySideEffects()
                             // Disallow streaming boundary crossings until the next prompt
                             // starts. Any agentMessageChunk that would cross a completed-
                             // output boundary in this window is a late replay slip — the
@@ -324,6 +328,7 @@ final class ACPSessionRunner {
         loadReplaySuppressionTarget = target
         if observedUpdateCount >= target {
             suppressingLoadReplay = false
+            session.endSuppressedReplaySideEffects()
             session.allowsStreamingBoundaryCrossing = false
         }
     }

--- a/Alas/Sources/ACP/Terminal/ACPTerminal.swift
+++ b/Alas/Sources/ACP/Terminal/ACPTerminal.swift
@@ -16,6 +16,7 @@ final class ACPTerminal: ObservableObject {
     let createdAt: Date
     let outputByteLimit: Int
 
+    @Published private(set) var cwd: String?
     @Published private(set) var buffer: Data = Data()
     @Published private(set) var truncated: Bool = false
     @Published private(set) var exitStatus: ACPTerminalExitStatus?
@@ -24,9 +25,11 @@ final class ACPTerminal: ObservableObject {
     /// the UI render the retained buffer.
     private(set) var released: Bool = false
     var onExit: (() -> Void)?
+    var isProcessBacked: Bool { process != nil }
+    var isMetadataBacked: Bool { process == nil }
 
-    private let process: Process
-    private let pipe: Pipe
+    private let process: Process?
+    private let pipe: Pipe?
     private var exitWaiters: [CheckedContinuation<ACPTerminalExitStatus, Never>] = []
     /// True once the readability handler has observed an empty chunk —
     /// the canonical EOF signal. `handleExit` polls this before
@@ -64,6 +67,7 @@ final class ACPTerminal: ObservableObject {
     {
         self.id = id
         self.createdAt = Date()
+        self.cwd = cwd
         // Cap against the internal buffer so an agent can't ask us to
         // return more than we ever retain. Floor at 1 so callers that
         // pass 0 or negative don't trip divide-by-zero / nonsense math
@@ -72,8 +76,10 @@ final class ACPTerminal: ObservableObject {
         // tail). Per ACP `outputByteLimit` contract.
         self.outputByteLimit = max(1, min(outputByteLimit, Self.internalBufferCap))
 
-        self.process = Process()
-        self.pipe = Pipe()
+        let process = Process()
+        let pipe = Pipe()
+        self.process = process
+        self.pipe = pipe
         // Spawn via /usr/bin/env so bare commands (npm, cargo, etc.) are
         // resolved against PATH. Foundation's Process only looks at the
         // exact URL otherwise, which would fail every non-absolute command
@@ -132,6 +138,15 @@ final class ACPTerminal: ObservableObject {
         _ = setpgid(process.processIdentifier, process.processIdentifier)
     }
 
+    init(metadataId id: String, cwd: String?, outputByteLimit: Int = 65_536) {
+        self.id = id
+        self.createdAt = Date()
+        self.cwd = cwd
+        self.outputByteLimit = max(1, min(outputByteLimit, Self.internalBufferCap))
+        self.process = nil
+        self.pipe = nil
+    }
+
     func waitForExit() async -> ACPTerminalExitStatus {
         if let s = exitStatus { return s }
         return await withCheckedContinuation { cont in
@@ -140,6 +155,7 @@ final class ACPTerminal: ObservableObject {
     }
 
     func kill() {
+        guard let process else { return }
         let pid = process.processIdentifier
         // `pid > 0` guards against signalling pid 0 (our own group)
         // when the process never launched. We intentionally do NOT
@@ -188,6 +204,7 @@ final class ACPTerminal: ObservableObject {
     }
 
     private func startDescendantTracker() {
+        guard let process else { return }
         descendantTracker = Task { @MainActor [weak self] in
             // Walk the live process tree every second while the root is
             // alive, accumulating every descendant we observe. The last
@@ -197,13 +214,14 @@ final class ACPTerminal: ObservableObject {
             while !Task.isCancelled {
                 guard let self else { return }
                 self.refreshOrphanSet()
-                if !self.process.isRunning { return }
+                if !process.isRunning { return }
                 try? await Task.sleep(nanoseconds: 1_000_000_000)
             }
         }
     }
 
     private func refreshOrphanSet() {
+        guard let process else { return }
         let pid = process.processIdentifier
         guard pid > 0 else { return }
         for d in Self.collectDescendants(of: pid) {
@@ -292,6 +310,33 @@ final class ACPTerminal: ObservableObject {
     func release() {
         released = true
         kill()
+    }
+
+    func updateMetadataCwd(_ cwd: String?) {
+        guard !isProcessBacked else { return }
+        self.cwd = cwd
+    }
+
+    func appendMetadataOutput(_ data: Data, replace: Bool) {
+        guard !isProcessBacked else { return }
+        if replace {
+            buffer.removeAll(keepingCapacity: true)
+            truncated = false
+        }
+        appendChunk(data)
+    }
+
+    func finishMetadata(exitStatus status: ACPTerminalExitStatus) {
+        guard !isProcessBacked else { return }
+        if exitStatus != nil {
+            exitStatus = status
+            return
+        }
+        exitStatus = status
+        onExit?()
+        let waiters = exitWaiters
+        exitWaiters.removeAll()
+        for c in waiters { c.resume(returning: status) }
     }
 
     /// Returns the last `byteLimit` bytes of the buffer as ANSI-stripped
@@ -392,6 +437,7 @@ final class ACPTerminal: ObservableObject {
     }
 
     private func handleExit(status: ACPTerminalExitStatus) async {
+        guard let pipe else { return }
         descendantTracker?.cancel()
         // Close the parent-side write end so the read end can EOF after
         // the kernel buffer drains. `Pipe()` retains both ends; if we

--- a/Alas/Sources/ACP/Terminal/ACPTerminalHost.swift
+++ b/Alas/Sources/ACP/Terminal/ACPTerminalHost.swift
@@ -28,12 +28,12 @@ final class ACPTerminalHost: ObservableObject {
     /// surface a `notFound` to the agent. Matches the ACP rule that a
     /// released id can no longer be used with `terminal/*` methods.
     private func liveTerminal(_ id: String) -> ACPTerminal? {
-        guard let term = terminals[id], !term.released else { return nil }
+        guard let term = terminals[id], !term.released, term.isProcessBacked else { return nil }
         return term
     }
 
     func create(_ p: ACPTerminalCreateParams) throws -> ACPTerminalCreateResult {
-        let liveCount = terminals.values.filter { $0.exitStatus == nil }.count
+        let liveCount = terminals.values.filter { $0.isProcessBacked && $0.exitStatus == nil }.count
         if liveCount >= Self.maxLiveTerminals {
             throw ACPTerminalHostError.tooManyTerminals
         }
@@ -57,6 +57,20 @@ final class ACPTerminalHost: ObservableObject {
         } catch {
             throw ACPTerminalHostError.spawnFailed(error.localizedDescription)
         }
+    }
+
+    func recordMetadataTerminalInfo(terminalId: String, cwd: String?) {
+        _ = metadataTerminal(terminalId: terminalId, cwd: cwd)
+    }
+
+    func appendMetadataOutput(terminalId: String, data: Data, replace: Bool) {
+        metadataTerminal(terminalId: terminalId, cwd: nil)
+            .appendMetadataOutput(data, replace: replace)
+    }
+
+    func recordMetadataExit(terminalId: String, exitStatus: ACPTerminalExitStatus) {
+        metadataTerminal(terminalId: terminalId, cwd: nil)
+            .finishMetadata(exitStatus: exitStatus)
     }
 
     func output(_ p: ACPTerminalOutputParams) throws -> ACPTerminalOutputResult {
@@ -124,6 +138,23 @@ final class ACPTerminalHost: ObservableObject {
         var out = sessionEnv
         for v in overlay ?? [] { out[v.name] = v.value }
         return out
+    }
+
+    private func metadataTerminal(terminalId: String, cwd: String?) -> ACPTerminal {
+        if let term = terminals[terminalId] {
+            if cwd != nil { term.updateMetadataCwd(cwd) }
+            return term
+        }
+
+        let term = ACPTerminal(
+            metadataId: terminalId,
+            cwd: cwd ?? sessionCwd,
+            outputByteLimit: 65_536)
+        term.onExit = { [weak self] in
+            self?.pruneFinishedTerminals()
+        }
+        terminals[terminalId] = term
+        return term
     }
 
     private func pruneFinishedTerminals() {

--- a/Alas/Sources/ACP/Terminal/ACPTerminalHost.swift
+++ b/Alas/Sources/ACP/Terminal/ACPTerminalHost.swift
@@ -10,6 +10,7 @@ enum ACPTerminalHostError: Error, Equatable {
 final class ACPTerminalHost: ObservableObject {
     static let maxLiveTerminals = 32
     static let maxRetainedFinishedTerminals = 64
+    static let maxMetadataTerminals = 64
 
     private(set) var sessionCwd: String
     private(set) var sessionEnv: [String: String]
@@ -154,6 +155,7 @@ final class ACPTerminalHost: ObservableObject {
             self?.pruneFinishedTerminals()
         }
         terminals[terminalId] = term
+        pruneMetadataTerminals()
         return term
     }
 
@@ -164,6 +166,17 @@ final class ACPTerminalHost: ObservableObject {
         let overflow = finished.count - Self.maxRetainedFinishedTerminals
         guard overflow > 0 else { return }
         for term in finished.prefix(overflow) {
+            terminals.removeValue(forKey: term.id)
+        }
+    }
+
+    private func pruneMetadataTerminals() {
+        let unfinishedMetadata = terminals.values
+            .filter { !$0.isProcessBacked && $0.exitStatus == nil }
+            .sorted { $0.createdAt < $1.createdAt }
+        let overflow = unfinishedMetadata.count - Self.maxMetadataTerminals
+        guard overflow > 0 else { return }
+        for term in unfinishedMetadata.prefix(overflow) {
             terminals.removeValue(forKey: term.id)
         }
     }

--- a/Alas/Sources/ACP/Terminal/ACPTerminalHost.swift
+++ b/Alas/Sources/ACP/Terminal/ACPTerminalHost.swift
@@ -152,7 +152,7 @@ final class ACPTerminalHost: ObservableObject {
             cwd: cwd ?? sessionCwd,
             outputByteLimit: 65_536)
         term.onExit = { [weak self] in
-            self?.pruneFinishedTerminals()
+            self?.pruneMetadataTerminals()
         }
         terminals[terminalId] = term
         pruneMetadataTerminals()
@@ -161,7 +161,7 @@ final class ACPTerminalHost: ObservableObject {
 
     private func pruneFinishedTerminals() {
         let finished = terminals.values
-            .filter { $0.exitStatus != nil }
+            .filter { $0.isProcessBacked && $0.exitStatus != nil }
             .sorted { $0.createdAt < $1.createdAt }
         let overflow = finished.count - Self.maxRetainedFinishedTerminals
         guard overflow > 0 else { return }
@@ -171,12 +171,12 @@ final class ACPTerminalHost: ObservableObject {
     }
 
     private func pruneMetadataTerminals() {
-        let unfinishedMetadata = terminals.values
-            .filter { !$0.isProcessBacked && $0.exitStatus == nil }
+        let metadata = terminals.values
+            .filter { !$0.isProcessBacked }
             .sorted { $0.createdAt < $1.createdAt }
-        let overflow = unfinishedMetadata.count - Self.maxMetadataTerminals
+        let overflow = metadata.count - Self.maxMetadataTerminals
         guard overflow > 0 else { return }
-        for term in unfinishedMetadata.prefix(overflow) {
+        for term in metadata.prefix(overflow) {
             terminals.removeValue(forKey: term.id)
         }
     }

--- a/Alas/Sources/ACP/UI/ACPGoalPill.swift
+++ b/Alas/Sources/ACP/UI/ACPGoalPill.swift
@@ -1,0 +1,59 @@
+import Foundation
+import SwiftUI
+
+struct ACPGoalPill: View {
+    let goal: ACPGoalState
+    @Environment(\.theme) private var theme
+
+    var body: some View {
+        HStack(spacing: 6) {
+            Image(systemName: "target")
+                .font(.system(size: 10, weight: .semibold))
+                .foregroundStyle(theme.color("accent"))
+            Text(Self.summary(goal))
+                .font(.system(size: 11, weight: .medium))
+                .foregroundStyle(theme.color("fg"))
+                .lineLimit(1)
+                .truncationMode(.tail)
+        }
+        .padding(.horizontal, 10)
+        .frame(height: 22)
+        .background(
+            RoundedRectangle(cornerRadius: 11, style: .continuous)
+                .fill(theme.color("bg-1"))
+        )
+        .overlay(
+            RoundedRectangle(cornerRadius: 11, style: .continuous)
+                .strokeBorder(theme.color("line"), lineWidth: 0.5)
+        )
+        .help(Self.summary(goal))
+        .transition(.opacity)
+    }
+
+    static func summary(_ goal: ACPGoalState) -> String {
+        var parts = ["Goal: \(truncatedObjective(goal.objective))"]
+        if let status = goal.status?.replacingOccurrences(of: "_", with: " "),
+           !status.isEmpty {
+            parts.append(status)
+        }
+        if let tokenBudget = goal.tokenBudget {
+            parts.append(formattedTokenBudget(tokenBudget))
+        }
+        return parts.joined(separator: " · ")
+    }
+
+    private static func truncatedObjective(_ objective: String) -> String {
+        guard objective.count > 60 else { return objective }
+        return "\(objective.prefix(60))…"
+    }
+
+    private static func formattedTokenBudget(_ tokenBudget: Int) -> String {
+        guard tokenBudget >= 1_000 else { return "\(tokenBudget)" }
+        let thousands = Double(tokenBudget) / 1_000
+        let rounded = (thousands * 10).rounded() / 10
+        if rounded == rounded.rounded() {
+            return "\(Int(rounded))k"
+        }
+        return String(format: "%.1fk", rounded)
+    }
+}

--- a/Alas/Sources/ACP/UI/ACPMessageList.swift
+++ b/Alas/Sources/ACP/UI/ACPMessageList.swift
@@ -9,6 +9,7 @@ struct ACPMessageList: View {
     let onOpenDiff: (String) -> Void
     let onOpenTranscriptLink: (URL) -> Bool
     let policy: ACPPermissionPolicy?
+    let trustedImageRoot: URL?
     let scopeKey: String
     let onQuestionResponse: (ACPQuestionResponse) -> Void
     /// Callbacks invoked by the pending bubbles + header. The host wires
@@ -757,6 +758,7 @@ struct ACPMessageList: View {
         case .toolCall(let tc):
             ACPToolCallCard(
                 toolCall: tc,
+                trustedImageRoot: trustedImageRoot,
                 loadFullContent: tc.isContentTruncated
                     ? { [tcid = tc.toolCallId] in onLoadFullToolCallContent(tcid) }
                     : nil)

--- a/Alas/Sources/ACP/UI/ACPTabView.swift
+++ b/Alas/Sources/ACP/UI/ACPTabView.swift
@@ -254,6 +254,7 @@ private struct ACPSessionView: View {
                                 // lives) — otherwise the user's click can't resolve the
                                 // pending permission request.
                                 policy: manager.runners[sessionId]?.policy,
+                                trustedImageRoot: worktree.path,
                                 scopeKey: scopeKey(for: session.transcript.pendingPermission),
                                 onQuestionResponse: { response in
                                     manager.runners[sessionId]?.answerQuestion(response)

--- a/Alas/Sources/ACP/UI/ACPToolCallCard.swift
+++ b/Alas/Sources/ACP/UI/ACPToolCallCard.swift
@@ -7,6 +7,7 @@ import AppKit
 /// renders an animated spinner instead of a static glyph.
 struct ACPToolCallCard: View {
     let toolCall: ACPMessage.ToolCall
+    var trustedImageRoot: URL? = nil
     /// Closure that returns the full persisted `content` for the tool call
     /// whose in-memory `content` was truncated when its row left the render
     /// window. Invoked the first time the card expands; the result is cached
@@ -141,7 +142,7 @@ struct ACPToolCallCard: View {
     private var assetBody: some View {
         VStack(alignment: .leading, spacing: 8) {
             ForEach(Array(toolCall.assets.enumerated()), id: \.offset) { entry in
-                ACPToolCallAssetView(asset: entry.element)
+                ACPToolCallAssetView(asset: entry.element, trustedImageRoot: trustedImageRoot)
             }
         }
         .padding(.horizontal, 12).padding(.vertical, 10)
@@ -198,12 +199,13 @@ struct ACPToolCallCard: View {
 
 private struct ACPToolCallAssetView: View {
     let asset: ACPMessage.ToolCallAsset
+    let trustedImageRoot: URL?
     @Environment(\.theme) private var theme
 
     var body: some View {
         switch asset.kind {
         case .image:
-            if let image = asset.loadedImage {
+            if let image = asset.loadedImage(trustedRoot: trustedImageRoot) {
                 imageThumbnail(image)
                     .help(asset.displayText)
             } else {
@@ -260,7 +262,7 @@ private struct ACPToolCallAssetView: View {
 }
 
 private extension ACPMessage.ToolCallAsset {
-    var loadedImage: NSImage? {
+    func loadedImage(trustedRoot: URL?) -> NSImage? {
         if let data, let decoded = Self.decodeBase64ImageData(data), let image = NSImage(data: decoded) {
             return image
         }
@@ -270,7 +272,8 @@ private extension ACPMessage.ToolCallAsset {
            let image = NSImage(data: decoded) {
             return image
         }
-        return nil
+        guard let url = Self.trustedLocalURL(from: uri, trustedRoot: trustedRoot) else { return nil }
+        return NSImage(contentsOf: url)
     }
 
     var displayTitle: String {
@@ -307,6 +310,25 @@ private extension ACPMessage.ToolCallAsset {
             base64 = trimmed
         }
         return Data(base64Encoded: base64, options: .ignoreUnknownCharacters)
+    }
+
+    private static func trustedLocalURL(from value: String, trustedRoot: URL?) -> URL? {
+        guard let trustedRoot else { return nil }
+        let candidate: URL
+        if let url = URL(string: value), let scheme = url.scheme {
+            guard scheme.lowercased() == "file" else { return nil }
+            candidate = url
+        } else if value.hasPrefix("/") {
+            candidate = URL(fileURLWithPath: value)
+        } else {
+            candidate = URL(fileURLWithPath: value, relativeTo: trustedRoot)
+        }
+        let root = trustedRoot.resolvingSymlinksInPath().standardizedFileURL
+        let resolved = candidate.resolvingSymlinksInPath().standardizedFileURL
+        let rootPath = root.path
+        let rootPrefix = rootPath.hasSuffix("/") ? rootPath : rootPath + "/"
+        guard resolved.path == rootPath || resolved.path.hasPrefix(rootPrefix) else { return nil }
+        return resolved
     }
 
     private static func displayURL(from value: String) -> URL? {

--- a/Alas/Sources/ACP/UI/ACPToolCallCard.swift
+++ b/Alas/Sources/ACP/UI/ACPToolCallCard.swift
@@ -270,8 +270,7 @@ private extension ACPMessage.ToolCallAsset {
            let image = NSImage(data: decoded) {
             return image
         }
-        guard let url = Self.localURL(from: uri) else { return nil }
-        return NSImage(contentsOf: url)
+        return nil
     }
 
     var displayTitle: String {
@@ -308,20 +307,6 @@ private extension ACPMessage.ToolCallAsset {
             base64 = trimmed
         }
         return Data(base64Encoded: base64, options: .ignoreUnknownCharacters)
-    }
-
-    private static func localURL(from value: String) -> URL? {
-        if let url = URL(string: value), let scheme = url.scheme {
-            switch scheme.lowercased() {
-            case "file":
-                return url
-            case "data":
-                return nil
-            default:
-                return nil
-            }
-        }
-        return URL(fileURLWithPath: value)
     }
 
     private static func displayURL(from value: String) -> URL? {

--- a/Alas/Sources/ACP/UI/ACPToolCallCard.swift
+++ b/Alas/Sources/ACP/UI/ACPToolCallCard.swift
@@ -297,6 +297,9 @@ extension ACPMessage.ToolCallAsset {
             return name
         }
         if let uri = nonEmpty(uri) {
+            if Self.isDataURI(uri) {
+                return kind == .image ? "Image" : "Resource"
+            }
             if let url = Self.displayURL(from: uri), !url.lastPathComponent.isEmpty {
                 return url.lastPathComponent
             }
@@ -307,6 +310,7 @@ extension ACPMessage.ToolCallAsset {
 
     var displayDetail: String? {
         guard let uri = nonEmpty(uri), uri != displayTitle else { return nil }
+        guard !Self.isDataURI(uri) else { return nil }
         return uri
     }
 
@@ -326,6 +330,12 @@ extension ACPMessage.ToolCallAsset {
             base64 = trimmed
         }
         return Data(base64Encoded: base64, options: .ignoreUnknownCharacters)
+    }
+
+    private static func isDataURI(_ value: String) -> Bool {
+        value.trimmingCharacters(in: .whitespacesAndNewlines)
+            .lowercased()
+            .hasPrefix("data:")
     }
 
     private static func trustedLocalURL(from value: String, trustedRoot: URL?) -> URL? {

--- a/Alas/Sources/ACP/UI/ACPToolCallCard.swift
+++ b/Alas/Sources/ACP/UI/ACPToolCallCard.swift
@@ -266,7 +266,7 @@ private struct ACPToolCallAssetView: View {
     }
 }
 
-private extension ACPMessage.ToolCallAsset {
+extension ACPMessage.ToolCallAsset {
     var looksLikeImage: Bool {
         if mimeType?.lowercased().hasPrefix("image/") == true { return true }
         guard let candidate = nonEmpty(uri) ?? nonEmpty(name) else { return false }
@@ -337,7 +337,7 @@ private extension ACPMessage.ToolCallAsset {
         } else if value.hasPrefix("/") {
             candidate = URL(fileURLWithPath: value)
         } else {
-            candidate = URL(fileURLWithPath: value, relativeTo: trustedRoot)
+            candidate = trustedRoot.appendingPathComponent(value)
         }
         let root = trustedRoot.resolvingSymlinksInPath().standardizedFileURL
         let resolved = candidate.resolvingSymlinksInPath().standardizedFileURL

--- a/Alas/Sources/ACP/UI/ACPToolCallCard.swift
+++ b/Alas/Sources/ACP/UI/ACPToolCallCard.swift
@@ -1,4 +1,5 @@
 import SwiftUI
+import AppKit
 
 /// Read / Search / Run / Edit tool invocation. Collapsed by default to
 /// one row showing verb + target + status; expanded shows the tool's
@@ -91,7 +92,7 @@ struct ACPToolCallCard: View {
     @ViewBuilder
     private var expandedBody: some View {
         VStack(alignment: .leading, spacing: 0) {
-            if displayContent.isEmpty && toolCall.terminalIds.isEmpty {
+            if !hasExpandedOutput {
                 HStack(spacing: 6) {
                     if toolCall.status == "in_progress" || toolCall.status == "pending" {
                         Spinner(lineWidth: 1.5, duration: 0.7).frame(width: 10, height: 10)
@@ -121,6 +122,9 @@ struct ACPToolCallCard: View {
                     }
                     .background(theme.color("bg-0").opacity(0.55))
                 }
+                if !toolCall.assets.isEmpty {
+                    assetBody
+                }
                 if let host = terminalHost {
                     ForEach(toolCall.terminalIds, id: \.self) { tid in
                         ACPTerminalTailView(terminalId: tid, host: host)
@@ -128,6 +132,20 @@ struct ACPToolCallCard: View {
                 }
             }
         }
+    }
+
+    private var hasExpandedOutput: Bool {
+        !displayContent.isEmpty || !toolCall.assets.isEmpty || !toolCall.terminalIds.isEmpty
+    }
+
+    private var assetBody: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            ForEach(Array(toolCall.assets.enumerated()), id: \.offset) { entry in
+                ACPToolCallAssetView(asset: entry.element)
+            }
+        }
+        .padding(.horizontal, 12).padding(.vertical, 10)
+        .background(theme.color("bg-0").opacity(0.55))
     }
 
     @ViewBuilder
@@ -175,6 +193,147 @@ struct ACPToolCallCard: View {
                 .foregroundStyle(theme.color("accent"))
         }
         .frame(width: 18, height: 18)
+    }
+}
+
+private struct ACPToolCallAssetView: View {
+    let asset: ACPMessage.ToolCallAsset
+    @Environment(\.theme) private var theme
+
+    var body: some View {
+        switch asset.kind {
+        case .image:
+            if let image = asset.loadedImage {
+                imageThumbnail(image)
+                    .help(asset.displayText)
+            } else {
+                compactRow(iconSystemName: "photo", title: asset.displayTitle, detail: asset.displayDetail)
+            }
+        case .resource:
+            compactRow(iconSystemName: "doc.text", title: asset.displayTitle, detail: asset.displayDetail)
+        }
+    }
+
+    private func imageThumbnail(_ image: NSImage) -> some View {
+        ZStack {
+            RoundedRectangle(cornerRadius: 8)
+                .fill(theme.color("bg-1").opacity(0.7))
+            Image(nsImage: image)
+                .resizable()
+                .scaledToFit()
+                .padding(6)
+        }
+            .frame(width: 160, height: 120)
+            .overlay(RoundedRectangle(cornerRadius: 8).strokeBorder(.white.opacity(0.15), lineWidth: 0.5))
+    }
+
+    private func compactRow(iconSystemName: String, title: String, detail: String?) -> some View {
+        HStack(spacing: 8) {
+            Image(systemName: iconSystemName)
+                .font(.system(size: 12))
+                .foregroundStyle(theme.color("accent"))
+                .frame(width: 18, height: 18)
+
+            VStack(alignment: .leading, spacing: 2) {
+                Text(title)
+                    .font(.system(size: 11.5, weight: .semibold))
+                    .foregroundStyle(theme.color("fg"))
+                    .lineLimit(1)
+                    .truncationMode(.middle)
+                if let detail {
+                    Text(detail)
+                        .font(.system(size: 10.5))
+                        .foregroundStyle(theme.color("fg-faint"))
+                        .lineLimit(1)
+                        .truncationMode(.middle)
+                }
+            }
+
+            Spacer(minLength: 0)
+        }
+        .padding(.horizontal, 8).padding(.vertical, 7)
+        .background(theme.color("bg-1").opacity(0.7))
+        .clipShape(RoundedRectangle(cornerRadius: 6))
+        .overlay(RoundedRectangle(cornerRadius: 6).strokeBorder(theme.color("line-soft"), lineWidth: 0.5))
+        .help(asset.displayText)
+    }
+}
+
+private extension ACPMessage.ToolCallAsset {
+    var loadedImage: NSImage? {
+        if let data, let decoded = Self.decodeBase64ImageData(data), let image = NSImage(data: decoded) {
+            return image
+        }
+        guard let uri = nonEmpty(uri) else { return nil }
+        if uri.lowercased().hasPrefix("data:"),
+           let decoded = Self.decodeBase64ImageData(uri),
+           let image = NSImage(data: decoded) {
+            return image
+        }
+        guard let url = Self.localURL(from: uri) else { return nil }
+        return NSImage(contentsOf: url)
+    }
+
+    var displayTitle: String {
+        if let name = nonEmpty(name) {
+            return name
+        }
+        if let uri = nonEmpty(uri) {
+            if let url = Self.displayURL(from: uri), !url.lastPathComponent.isEmpty {
+                return url.lastPathComponent
+            }
+            return uri
+        }
+        return kind == .image ? "Image" : "Resource"
+    }
+
+    var displayDetail: String? {
+        guard let uri = nonEmpty(uri), uri != displayTitle else { return nil }
+        return uri
+    }
+
+    var displayText: String {
+        if let detail = displayDetail {
+            return "\(displayTitle) \(detail)"
+        }
+        return displayTitle
+    }
+
+    private static func decodeBase64ImageData(_ value: String) -> Data? {
+        let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
+        let base64: String
+        if let marker = trimmed.range(of: "base64,", options: .caseInsensitive) {
+            base64 = String(trimmed[marker.upperBound...])
+        } else {
+            base64 = trimmed
+        }
+        return Data(base64Encoded: base64, options: .ignoreUnknownCharacters)
+    }
+
+    private static func localURL(from value: String) -> URL? {
+        if let url = URL(string: value), let scheme = url.scheme {
+            switch scheme.lowercased() {
+            case "file":
+                return url
+            case "data":
+                return nil
+            default:
+                return nil
+            }
+        }
+        return URL(fileURLWithPath: value)
+    }
+
+    private static func displayURL(from value: String) -> URL? {
+        if let url = URL(string: value), url.scheme != nil { return url }
+        return URL(fileURLWithPath: value)
+    }
+
+    private func nonEmpty(_ value: String?) -> String? {
+        guard let trimmed = value?.trimmingCharacters(in: .whitespacesAndNewlines), !trimmed.isEmpty else {
+            return nil
+        }
+        return trimmed
     }
 }
 

--- a/Alas/Sources/ACP/UI/ACPToolCallCard.swift
+++ b/Alas/Sources/ACP/UI/ACPToolCallCard.swift
@@ -31,12 +31,12 @@ struct ACPToolCallCard: View {
             } label: {
                 HStack(spacing: 8) {
                     glyph
-                    Text(verb)
+                    Text(presentation.label)
                         .font(.system(size: 10.5, weight: .semibold))
                         .tracking(0.6)
                         .textCase(.uppercase)
                         .foregroundStyle(theme.color("fg-faint"))
-                    if !toolCall.title.isEmpty && toolCall.title.lowercased() != verb.lowercased() {
+                    if !toolCall.title.isEmpty && toolCall.title.lowercased() != presentation.label.lowercased() {
                         FileChip(path: toolCall.title, lines: nil, iconSystemName: nil)
                     }
                     if let first = toolCall.locations.first {
@@ -161,24 +161,8 @@ struct ACPToolCallCard: View {
         expanded ? theme.color("bg-4") : theme.color("line")
     }
 
-    private var verb: String {
-        switch toolCall.kind {
-        case "read":          return "Read"
-        case "search":        return "Searched"
-        case "execute","run": return "Ran"
-        case "edit":          return "Edit"
-        default:              return toolCall.kind?.capitalized ?? "Tool"
-        }
-    }
-
-    private var iconSystemName: String {
-        switch toolCall.kind {
-        case "read":          return "doc.text"
-        case "search":        return "magnifyingglass"
-        case "execute","run": return "terminal"
-        case "edit":          return "pencil"
-        default:              return "gearshape"
-        }
+    private var presentation: ACPToolCallPresentation {
+        ACPToolCallPresentation.resolve(toolCall)
     }
 
     @ViewBuilder
@@ -186,7 +170,7 @@ struct ACPToolCallCard: View {
         ZStack {
             RoundedRectangle(cornerRadius: 4)
                 .fill(theme.color("bg-0").opacity(0.8))
-            Image(systemName: iconSystemName)
+            Image(systemName: presentation.iconSystemName)
                 .font(.system(size: 10))
                 .foregroundStyle(theme.color("accent"))
         }

--- a/Alas/Sources/ACP/UI/ACPToolCallCard.swift
+++ b/Alas/Sources/ACP/UI/ACPToolCallCard.swift
@@ -212,7 +212,12 @@ private struct ACPToolCallAssetView: View {
                 compactRow(iconSystemName: "photo", title: asset.displayTitle, detail: asset.displayDetail)
             }
         case .resource:
-            compactRow(iconSystemName: "doc.text", title: asset.displayTitle, detail: asset.displayDetail)
+            if asset.looksLikeImage, let image = asset.loadedImage(trustedRoot: trustedImageRoot) {
+                imageThumbnail(image)
+                    .help(asset.displayText)
+            } else {
+                compactRow(iconSystemName: "doc.text", title: asset.displayTitle, detail: asset.displayDetail)
+            }
         }
     }
 
@@ -262,6 +267,17 @@ private struct ACPToolCallAssetView: View {
 }
 
 private extension ACPMessage.ToolCallAsset {
+    var looksLikeImage: Bool {
+        if mimeType?.lowercased().hasPrefix("image/") == true { return true }
+        guard let candidate = nonEmpty(uri) ?? nonEmpty(name) else { return false }
+        switch URL(fileURLWithPath: candidate).pathExtension.lowercased() {
+        case "png", "jpg", "jpeg", "gif", "heic", "heif", "tiff", "webp":
+            return true
+        default:
+            return false
+        }
+    }
+
     func loadedImage(trustedRoot: URL?) -> NSImage? {
         if let data, let decoded = Self.decodeBase64ImageData(data), let image = NSImage(data: decoded) {
             return image

--- a/Alas/Sources/ACP/UI/ACPToolCallPresentation.swift
+++ b/Alas/Sources/ACP/UI/ACPToolCallPresentation.swift
@@ -1,0 +1,145 @@
+import Foundation
+
+struct ACPToolCallPresentation: Equatable, Sendable {
+    enum Style: Equatable, Sendable {
+        case generic
+        case webSearch
+        case image
+        case mcp
+        case review
+    }
+
+    let label: String
+    let iconSystemName: String
+    let style: Style
+
+    static func resolve(_ toolCall: ACPMessage.ToolCall) -> ACPToolCallPresentation {
+        let title = toolCall.title.trimmingCharacters(in: .whitespacesAndNewlines)
+        let lowerTitle = title.lowercased()
+        let kind = toolCall.kind?.lowercased()
+
+        if kind == "search" {
+            if lowerTitle.hasPrefix("web search") {
+                return .init(label: "Web Search", iconSystemName: "globe", style: .webSearch)
+            }
+            if lowerTitle.hasPrefix("open page") {
+                return .init(label: "Opened Page", iconSystemName: "safari", style: .webSearch)
+            }
+            if lowerTitle.hasPrefix("find in page") {
+                return .init(label: "Find", iconSystemName: "text.magnifyingglass", style: .webSearch)
+            }
+        }
+
+        if lowerTitle.hasPrefix("image generation"),
+           toolCall.hasImageAsset || rawOutputLooksLikeImageResult(toolCall.rawOutput) {
+            return .init(label: "Image", iconSystemName: "photo", style: .image)
+        }
+
+        if kind == "read", toolCall.referencesImage {
+            return .init(label: "Viewed Image", iconSystemName: "photo.on.rectangle", style: .image)
+        }
+
+        if toolCall.isMCPToolCall || lowerTitle.hasPrefix("mcp.") || lowerTitle.hasPrefix("mcp__") {
+            return .init(
+                label: "MCP",
+                iconSystemName: "point.3.connected.trianglepath.dotted",
+                style: .mcp
+            )
+        }
+
+        if kind == "think" || lowerTitle == "guardian review" {
+            return .init(label: "Review", iconSystemName: "checkmark.shield", style: .review)
+        }
+
+        switch kind {
+        case "read":
+            return .init(label: "Read", iconSystemName: "doc.text", style: .generic)
+        case "search":
+            return .init(label: "Searched", iconSystemName: "magnifyingglass", style: .generic)
+        case "execute", "run":
+            return .init(label: "Ran", iconSystemName: "terminal", style: .generic)
+        case "edit":
+            return .init(label: "Edit", iconSystemName: "pencil", style: .generic)
+        default:
+            return .init(label: toolCall.kind?.capitalized ?? "Tool", iconSystemName: "gearshape", style: .generic)
+        }
+    }
+
+    private static func rawOutputLooksLikeImageResult(_ rawOutput: String?) -> Bool {
+        guard let rawOutput else { return false }
+        let lower = rawOutput.lowercased()
+        return lower.contains("\"type\":\"image\"")
+            || lower.contains("\"type\": \"image\"")
+            || lower.contains("\"mimetype\":\"image/")
+            || lower.contains("\"mimetype\": \"image/")
+            || lower.contains("\"mime_type\":\"image/")
+            || lower.contains("\"mime_type\": \"image/")
+            || lower.contains("\"b64_json\"")
+            || lower.contains("\"revised_prompt\"")
+            || lower.contains("data:image/")
+    }
+}
+
+private extension ACPMessage.ToolCall {
+    var hasImageAsset: Bool {
+        assets.contains { $0.isImageReference }
+    }
+
+    var referencesImage: Bool {
+        hasImageAsset
+            || imagePath(title)
+            || locations.contains(where: imagePath)
+    }
+
+    var isMCPToolCall: Bool {
+        guard let root = metadataObject(metadata) else { return false }
+        return boolValue(root["is_mcp_tool_call"]) == true
+    }
+}
+
+private extension ACPMessage.ToolCallAsset {
+    var isImageReference: Bool {
+        kind == .image
+            || mimeType?.lowercased().hasPrefix("image/") == true
+            || uri.map(imagePath) == true
+            || name.map(imagePath) == true
+    }
+}
+
+private func metadataObject(_ value: AnyCodable?) -> [String: AnyCodable]? {
+    if let dict = value?.value as? [String: AnyCodable] { return dict }
+    if let dict = value?.value as? [String: Any] {
+        return dict.mapValues { raw in
+            (raw as? AnyCodable) ?? AnyCodable(raw)
+        }
+    }
+    if let dict = value?.value as? NSDictionary {
+        var result: [String: AnyCodable] = [:]
+        for (rawKey, rawValue) in dict {
+            guard let key = rawKey as? String else { continue }
+            result[key] = (rawValue as? AnyCodable) ?? AnyCodable(rawValue)
+        }
+        return result
+    }
+    return nil
+}
+
+private func boolValue(_ value: AnyCodable?) -> Bool? {
+    guard let raw = value?.value, !(raw is NSNull) else { return nil }
+    if let bool = raw as? Bool { return bool }
+    if let string = raw as? String {
+        switch string.lowercased() {
+        case "true": return true
+        case "false": return false
+        default: return nil
+        }
+    }
+    return nil
+}
+
+private func imagePath(_ value: String) -> Bool {
+    let lower = value.lowercased()
+    return [".png", ".jpg", ".jpeg", ".gif", ".webp", ".heic", ".heif", ".tiff", ".bmp"].contains {
+        lower.hasSuffix($0) || lower.contains("\($0)?")
+    }
+}

--- a/Alas/Sources/ACP/UI/ACPToolbar.swift
+++ b/Alas/Sources/ACP/UI/ACPToolbar.swift
@@ -20,6 +20,9 @@ struct ACPToolbar: View {
                 agentLookup: agentLookup
             )
             ACPRecoveryPill(session: session)
+            if let currentGoal = session.currentGoal {
+                ACPGoalPill(goal: currentGoal)
+            }
             ACPPlanPill(
                 transcript: session.transcript,
                 sidebarUserMinimized: planSidebarUserMinimized,

--- a/Alas/Sources/Remote/Gateway/RemoteSessionGateway.swift
+++ b/Alas/Sources/Remote/Gateway/RemoteSessionGateway.swift
@@ -504,7 +504,7 @@ final class RemoteSessionGateway {
     private static func remoteAssetURI(_ uri: String?) -> String? {
         guard let uri else { return nil }
         let normalized = uri.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
-        return normalized.hasPrefix("data:image/") ? nil : uri
+        return normalized.hasPrefix("data:") ? nil : uri
     }
 
     private static func encodeJSON<T: Encodable>(_ value: T) -> String? {

--- a/Alas/Sources/Remote/Gateway/RemoteSessionGateway.swift
+++ b/Alas/Sources/Remote/Gateway/RemoteSessionGateway.swift
@@ -493,12 +493,17 @@ final class RemoteSessionGateway {
             ACPMessage.ToolCallAsset(
                 kind: asset.kind,
                 data: nil,
-                uri: asset.uri,
+                uri: Self.remoteAssetURI(asset.uri),
                 mimeType: asset.mimeType,
                 name: asset.name
             )
         }
         return remote
+    }
+
+    private static func remoteAssetURI(_ uri: String?) -> String? {
+        guard let uri else { return nil }
+        return uri.lowercased().hasPrefix("data:image/") ? nil : uri
     }
 
     private static func encodeJSON<T: Encodable>(_ value: T) -> String? {

--- a/Alas/Sources/Remote/Gateway/RemoteSessionGateway.swift
+++ b/Alas/Sources/Remote/Gateway/RemoteSessionGateway.swift
@@ -477,12 +477,26 @@ final class RemoteSessionGateway {
         case .systemNotice(_, let text):
             return .init(stableId: sid, kind: "systemNotice", text: text, json: nil)
         case .toolCall(let call):
-            return .init(stableId: sid, kind: "toolCall", text: nil, json: Self.encodeJSON(call))
+            return .init(stableId: sid, kind: "toolCall", text: nil, json: Self.encodeJSON(remoteToolCall(call)))
         case .fileEdit(_, let edit):
             return .init(stableId: sid, kind: "fileEdit", text: nil, json: Self.encodeJSON(edit))
         case .plan(_, let items):
             return .init(stableId: sid, kind: "plan", text: nil, json: Self.encodeJSON(items))
         }
+    }
+
+    private static func remoteToolCall(_ call: ACPMessage.ToolCall) -> ACPMessage.ToolCall {
+        var remote = call
+        remote.assets = call.assets.map { asset in
+            ACPMessage.ToolCallAsset(
+                kind: asset.kind,
+                data: nil,
+                uri: asset.uri,
+                mimeType: asset.mimeType,
+                name: asset.name
+            )
+        }
+        return remote
     }
 
     private static func encodeJSON<T: Encodable>(_ value: T) -> String? {

--- a/Alas/Sources/Remote/Gateway/RemoteSessionGateway.swift
+++ b/Alas/Sources/Remote/Gateway/RemoteSessionGateway.swift
@@ -503,7 +503,8 @@ final class RemoteSessionGateway {
 
     private static func remoteAssetURI(_ uri: String?) -> String? {
         guard let uri else { return nil }
-        return uri.lowercased().hasPrefix("data:image/") ? nil : uri
+        let normalized = uri.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        return normalized.hasPrefix("data:image/") ? nil : uri
     }
 
     private static func encodeJSON<T: Encodable>(_ value: T) -> String? {

--- a/Alas/Sources/Remote/Gateway/RemoteSessionGateway.swift
+++ b/Alas/Sources/Remote/Gateway/RemoteSessionGateway.swift
@@ -487,6 +487,8 @@ final class RemoteSessionGateway {
 
     private static func remoteToolCall(_ call: ACPMessage.ToolCall) -> ACPMessage.ToolCall {
         var remote = call
+        remote.rawOutput = nil
+        remote.metadata = nil
         remote.assets = call.assets.map { asset in
             ACPMessage.ToolCallAsset(
                 kind: asset.kind,

--- a/AlasTests/ACP/Fixtures/session-update-session-info-goal.json
+++ b/AlasTests/ACP/Fixtures/session-update-session-info-goal.json
@@ -1,0 +1,12 @@
+{"jsonrpc":"2.0","method":"session/update","params":{
+  "sessionId":"s",
+  "update":{"sessionUpdate":"session_info_update","title":"Investigate ACP events","_meta":{
+    "codex":{
+      "goal":{
+        "objective":"Surface richer ACP events",
+        "status":"in_progress",
+        "tokenBudget":12000
+      }
+    }
+  }}
+}}

--- a/AlasTests/ACP/Fixtures/session-update-session-info-no-meta.json
+++ b/AlasTests/ACP/Fixtures/session-update-session-info-no-meta.json
@@ -1,0 +1,4 @@
+{"jsonrpc":"2.0","method":"session/update","params":{
+  "sessionId":"s",
+  "update":{"sessionUpdate":"session_info_update","title":"Title only"}
+}}

--- a/AlasTests/ACP/Fixtures/session-update-tool-call-meta.json
+++ b/AlasTests/ACP/Fixtures/session-update-tool-call-meta.json
@@ -1,0 +1,9 @@
+{"jsonrpc":"2.0","method":"session/update","params":{
+  "sessionId":"s",
+  "update":{"sessionUpdate":"tool_call","toolCallId":"cmd-1","title":"swift test","kind":"execute","status":"in_progress","content":[{"type":"terminal","terminalId":"cmd-1"}],"rawInput":{"command":"swift test","cwd":"/repo"},"_meta":{
+    "terminal_info":{
+      "terminal_id":"cmd-1",
+      "cwd":"/repo"
+    }
+  }}
+}}

--- a/AlasTests/ACP/Fixtures/session-update-tool-call-update-meta.json
+++ b/AlasTests/ACP/Fixtures/session-update-tool-call-update-meta.json
@@ -1,0 +1,14 @@
+{"jsonrpc":"2.0","method":"session/update","params":{
+  "sessionId":"s",
+  "update":{"sessionUpdate":"tool_call_update","toolCallId":"cmd-1","title":"swift test --filter ACP","status":"completed","locations":[{"path":"AlasTests/ACP/Session/ACPSessionTests.swift","line":12}],"rawInput":{"command":"swift test --filter ACP"},"rawOutput":{"exit_code":0},"_meta":{
+    "terminal_output_delta":{
+      "terminal_id":"cmd-1",
+      "data":"ok\n"
+    },
+    "terminal_exit":{
+      "terminal_id":"cmd-1",
+      "exit_code":0,
+      "signal":null
+    }
+  }}
+}}

--- a/AlasTests/ACP/Fixtures/session-update-tool-call-update-no-meta.json
+++ b/AlasTests/ACP/Fixtures/session-update-tool-call-update-no-meta.json
@@ -1,0 +1,4 @@
+{"jsonrpc":"2.0","method":"session/update","params":{
+  "sessionId":"s",
+  "update":{"sessionUpdate":"tool_call_update","toolCallId":"cmd-legacy","title":"read_file","status":"completed","locations":[{"path":"AlasTests/ACP/Protocol/ACPSessionUpdateTests.swift","line":7}],"content":[{"type":"content","content":{"type":"text","text":"legacy output"}}],"rawInput":{"path":"/legacy/file.swift"},"rawOutput":{"exit_code":0}}
+}}

--- a/AlasTests/ACP/Protocol/ACPSessionUpdateTests.swift
+++ b/AlasTests/ACP/Protocol/ACPSessionUpdateTests.swift
@@ -61,7 +61,7 @@ struct ACPSessionUpdateTests {
             Issue.record("expected sessionInfoUpdate")
             return
         }
-        #expect(info.title == "Investigate ACP events")
+        #expect(info.title == .value("Investigate ACP events"))
         let meta = try #require(info.metadata?.value as? [String: AnyCodable])
         let codex = try #require(meta["codex"]?.value as? [String: AnyCodable])
         let goal = try #require(codex["goal"]?.value as? [String: AnyCodable])
@@ -77,7 +77,7 @@ struct ACPSessionUpdateTests {
             Issue.record("expected sessionInfoUpdate")
             return
         }
-        #expect(info.title == "Title only")
+        #expect(info.title == .value("Title only"))
         #expect(info.metadata == nil)
     }
 

--- a/AlasTests/ACP/Protocol/ACPSessionUpdateTests.swift
+++ b/AlasTests/ACP/Protocol/ACPSessionUpdateTests.swift
@@ -46,11 +46,98 @@ struct ACPSessionUpdateTests {
             #expect(tc.toolCallId == "tc-1")
             #expect(tc.title == "read_file")
             #expect(tc.status == "in_progress")
+            #expect(tc.metadata == nil)
             #expect(tc.content?.count == 1)
             if case .content(.text(let s)) = tc.content?.first {
                 #expect(s == "reading…")
             } else { Issue.record("expected wrapped text content") }
         } else { Issue.record("expected toolCall") }
+    }
+
+    @Test("decodes session_info_update with metadata")
+    func sessionInfoUpdate() throws {
+        let env = try decode("session-update-session-info-goal")
+        guard case .sessionInfoUpdate(let info) = env.params!.update else {
+            Issue.record("expected sessionInfoUpdate")
+            return
+        }
+        #expect(info.title == "Investigate ACP events")
+        let meta = try #require(info.metadata?.value as? [String: AnyCodable])
+        let codex = try #require(meta["codex"]?.value as? [String: AnyCodable])
+        let goal = try #require(codex["goal"]?.value as? [String: AnyCodable])
+        #expect(goal["objective"]?.value as? String == "Surface richer ACP events")
+        #expect(goal["status"]?.value as? String == "in_progress")
+        #expect(goal["tokenBudget"]?.value as? Int == 12000)
+    }
+
+    @Test("decodes session_info_update without metadata")
+    func sessionInfoUpdateWithoutMetadata() throws {
+        let env = try decode("session-update-session-info-no-meta")
+        guard case .sessionInfoUpdate(let info) = env.params!.update else {
+            Issue.record("expected sessionInfoUpdate")
+            return
+        }
+        #expect(info.title == "Title only")
+        #expect(info.metadata == nil)
+    }
+
+    @Test("decodes tool call metadata")
+    func toolCallMetadata() throws {
+        let env = try decode("session-update-tool-call-meta")
+        guard case .toolCall(let tc) = env.params!.update else {
+            Issue.record("expected toolCall")
+            return
+        }
+        #expect(tc.toolCallId == "cmd-1")
+        #expect(tc.metadata != nil)
+        let meta = try #require(tc.metadata?.value as? [String: AnyCodable])
+        let terminalInfo = try #require(meta["terminal_info"]?.value as? [String: AnyCodable])
+        #expect(terminalInfo["terminal_id"]?.value as? String == "cmd-1")
+        #expect(terminalInfo["cwd"]?.value as? String == "/repo")
+    }
+
+    @Test("decodes tool call update metadata and mutable fields")
+    func toolCallUpdateMetadata() throws {
+        let env = try decode("session-update-tool-call-update-meta")
+        guard case .toolCallUpdate(let update) = env.params!.update else {
+            Issue.record("expected toolCallUpdate")
+            return
+        }
+        #expect(update.toolCallId == "cmd-1")
+        #expect(update.title == "swift test --filter ACP")
+        #expect(update.locations?.first?.path == "AlasTests/ACP/Session/ACPSessionTests.swift")
+        #expect(update.locations?.first?.line == 12)
+        let rawInput = try #require(update.rawInput?.value as? [String: AnyCodable])
+        #expect(rawInput["command"]?.value as? String == "swift test --filter ACP")
+        let rawOutput = try #require(update.rawOutput?.value as? [String: AnyCodable])
+        #expect(rawOutput["exit_code"]?.value as? Int == 0)
+        let meta = try #require(update.metadata?.value as? [String: AnyCodable])
+        let outputDelta = try #require(meta["terminal_output_delta"]?.value as? [String: AnyCodable])
+        #expect(outputDelta["terminal_id"]?.value as? String == "cmd-1")
+        #expect(outputDelta["data"]?.value as? String == "ok\n")
+        let terminalExit = try #require(meta["terminal_exit"]?.value as? [String: AnyCodable])
+        #expect(terminalExit["terminal_id"]?.value as? String == "cmd-1")
+        #expect(terminalExit["exit_code"]?.value as? Int == 0)
+        let signal = terminalExit["signal"]?.value
+        #expect(signal == nil || signal is NSNull)
+    }
+
+    @Test("decodes legacy tool call update without metadata")
+    func toolCallUpdateNoMetadata() throws {
+        let env = try decode("session-update-tool-call-update-no-meta")
+        guard case .toolCallUpdate(let update) = env.params!.update else {
+            Issue.record("expected toolCallUpdate")
+            return
+        }
+        #expect(update.toolCallId == "cmd-legacy")
+        #expect(update.title == "read_file")
+        #expect(update.status == "completed")
+        #expect(update.locations?.first?.path == "AlasTests/ACP/Protocol/ACPSessionUpdateTests.swift")
+        #expect(update.locations?.first?.line == 7)
+        #expect(update.content?.count == 1)
+        #expect(update.rawInput != nil)
+        #expect(update.rawOutput != nil)
+        #expect(update.metadata == nil)
     }
 
     @Test("decodes plan update")

--- a/AlasTests/ACP/Session/ACPMessageTests.swift
+++ b/AlasTests/ACP/Session/ACPMessageTests.swift
@@ -204,6 +204,19 @@ struct ACPMessageTests {
         #expect(a != b)
     }
 
+    @Test("AnyCodable preserves numeric NSNumbers")
+    func anyCodablePreservesNumericNSNumbers() throws {
+        let value = AnyCodable([
+            "exit_code": NSNumber(value: 1),
+            "ok": NSNumber(value: true)
+        ])
+
+        let payload = try JSONEncoder().encode(value)
+        let json = try #require(String(data: payload, encoding: .utf8))
+        #expect(json.contains(#""exit_code":1"#))
+        #expect(json.contains(#""ok":true"#))
+    }
+
     @Test("tool call equality differs on rawOutput")
     func toolCallRawOutputAffectsEquality() throws {
         let a = ACPMessage.ToolCall(

--- a/AlasTests/ACP/Session/ACPMessageTests.swift
+++ b/AlasTests/ACP/Session/ACPMessageTests.swift
@@ -41,6 +41,214 @@ struct ACPMessageTests {
         let back = try ACPMessageCodec.decode(kind: m.kind, payload: payload)
         #expect(back == m)
     }
+
+    @Test("tool call enriched fields round-trip")
+    func toolCallEnrichedRoundtrip() throws {
+        let metadata = AnyCodable([
+            "is_mcp_tool_call": AnyCodable(true),
+            "tool": AnyCodable("read_file")
+        ])
+        let assets: [ACPMessage.ToolCallAsset] = [
+            .image(
+                data: "aGVsbG8=",
+                uri: "file:///tmp/screenshot.png",
+                mimeType: "image/png",
+                name: "screenshot.png"
+            ),
+            .resource(uri: "file:///tmp/result.txt", name: nil, mimeType: "text/plain"),
+            .resource(uri: "file:///tmp/result-named.txt", name: "result.txt", mimeType: "text/plain")
+        ]
+        let m = ACPMessage.toolCall(.init(
+            toolCallId: "tc-2",
+            title: "read_file",
+            kind: "read",
+            status: "completed",
+            content: "response text",
+            preview: "response text",
+            rawInput: #"{\"command\":\"read_file\"}"#,
+            rawOutput: #"{\"status\":\"ok\"}"#,
+            metadata: metadata,
+            assets: assets,
+            locations: ["file://x"],
+            terminalIds: ["term-1"]))
+        let payload = try ACPMessageCodec.encode(m)
+        let back = try ACPMessageCodec.decode(kind: m.kind, payload: payload)
+        #expect(back == m)
+    }
+
+    @Test("legacy contentSummary decode keeps backward-compatible preview")
+    func toolCallLegacyContentSummary() throws {
+        let payload = """
+        {
+          "toolCallId": "tc-legacy-summary",
+          "title": "read_file",
+          "kind": "read",
+          "status": "completed",
+          "content": "raw output",
+          "contentSummary": "legacy summary",
+          "locations": ["/x"]
+        }
+        """.data(using: .utf8)!
+        let back = try ACPMessageCodec.decode(kind: "tool_call", payload: payload)
+        guard case .toolCall(let tc) = back else {
+            Issue.record("expected toolCall")
+            return
+        }
+        #expect(tc.preview == "legacy summary")
+        #expect(tc.rawOutput == nil)
+        #expect(tc.metadata == nil)
+        #expect(tc.assets == [])
+    }
+
+    @Test("tool call equality differs on terminalIds")
+    func toolCallTerminalIdAffectsEquality() throws {
+        let a = ACPMessage.ToolCall(
+            toolCallId: "tc-1", title: "read", kind: "read",
+            status: "completed", content: "output", preview: "output",
+            terminalIds: ["term-a"])
+        let b = ACPMessage.ToolCall(
+            toolCallId: "tc-1", title: "read", kind: "read",
+            status: "completed", content: "output", preview: "output",
+            terminalIds: ["term-b"])
+        #expect(a != b)
+    }
+
+    @Test("tool call equality and hash align for same metadata")
+    func toolCallMetadataEqualityAndHash() throws {
+        let metadata = AnyCodable(["is_mcp_tool_call": AnyCodable(true)])
+        let a = ACPMessage.ToolCall(
+            toolCallId: "tc-2", title: "read", kind: "read",
+            status: "completed", content: "output", preview: "output",
+            rawOutput: #"{\"ok\":true}"#,
+            metadata: metadata)
+        let b = ACPMessage.ToolCall(
+            toolCallId: "tc-2", title: "read", kind: "read",
+            status: "completed", content: "output", preview: "output",
+            rawOutput: #"{\"ok\":true}"#,
+            metadata: metadata)
+        #expect(a == b)
+
+        var ha = Hasher()
+        a.hash(into: &ha)
+        var hb = Hasher()
+        b.hash(into: &hb)
+        #expect(ha.finalize() == hb.finalize())
+    }
+
+    @Test("tool call metadata order does not affect equality or hash")
+    func toolCallMetadataDictionaryOrderIsDeterministic() throws {
+        var first: [String: AnyCodable] = [:]
+        first["first"] = AnyCodable("value")
+        first["second"] = AnyCodable(99)
+
+        var second: [String: AnyCodable] = [:]
+        second["second"] = AnyCodable(99)
+        second["first"] = AnyCodable("value")
+
+        #expect(AnyCodable(first) == AnyCodable(second))
+
+        let a = ACPMessage.ToolCall(
+            toolCallId: "tc-order", title: "read", kind: "read",
+            status: "completed", content: "output", preview: "output",
+            metadata: AnyCodable(first))
+        let b = ACPMessage.ToolCall(
+            toolCallId: "tc-order", title: "read", kind: "read",
+            status: "completed", content: "output", preview: "output",
+            metadata: AnyCodable(second))
+        #expect(a == b)
+
+        var ha = Hasher()
+        a.hash(into: &ha)
+        var hb = Hasher()
+        b.hash(into: &hb)
+        #expect(ha.finalize() == hb.finalize())
+    }
+
+    @Test("AnyCodable supports raw Swift dictionary literals")
+    func anyCodableSupportsRawSwiftDictionaries() throws {
+        let prewrapped: [String: AnyCodable] = [
+            "tool": AnyCodable("read"),
+            "is_mcp_tool_call": AnyCodable(true),
+            "args": AnyCodable([AnyCodable(1), AnyCodable("two"), AnyCodable(["nested": AnyCodable(false)])])
+        ]
+        let a = AnyCodable(prewrapped)
+        let b = AnyCodable(["is_mcp_tool_call": true, "args": [1, "two", ["nested": false]], "tool": "read"])
+        #expect(a == b)
+
+        var ha = Hasher()
+        a.hash(into: &ha)
+        var hb = Hasher()
+        b.hash(into: &hb)
+        #expect(ha.finalize() == hb.finalize())
+
+        let payload = try JSONEncoder().encode(a)
+        let decoded = try JSONDecoder().decode(AnyCodable.self, from: payload)
+        #expect(decoded == a)
+        #expect(decoded == b)
+
+        let arrayPayload = try JSONEncoder().encode(AnyCodable([1, "two", ["nested": false]]))
+        let decodedArray = try JSONDecoder().decode(AnyCodable.self, from: arrayPayload)
+        #expect(decodedArray == AnyCodable([1, "two", ["nested": false]]))
+
+        var hc = Hasher()
+        a.hash(into: &hc)
+        var hd = Hasher()
+        decoded.hash(into: &hd)
+        #expect(hc.finalize() == hd.finalize())
+    }
+
+    @Test("AnyCodable keeps distinct dictionaries from comparing equal")
+    func anyCodableDistinctDictionariesAreDistinct() throws {
+        let a = AnyCodable(["a": 1, "b": 2])
+        let b = AnyCodable(["a": 1, "b": 3])
+        #expect(a != b)
+    }
+
+    @Test("tool call equality differs on rawOutput")
+    func toolCallRawOutputAffectsEquality() throws {
+        let a = ACPMessage.ToolCall(
+            toolCallId: "tc-3", title: "read", kind: "read",
+            status: "completed", content: "output", preview: "output",
+            rawOutput: #"{\"ok\":true}"#)
+        let b = ACPMessage.ToolCall(
+            toolCallId: "tc-3", title: "read", kind: "read",
+            status: "completed", content: "output", preview: "output",
+            rawOutput: #"{\"ok\":false}"#)
+        #expect(a != b)
+    }
+
+    @Test("tool call equality differs on assets")
+    func toolCallAssetsAffectEquality() throws {
+        let a = ACPMessage.ToolCall(
+            toolCallId: "tc-4", title: "read", kind: "read",
+            status: "completed", content: "output", preview: "output",
+            assets: [.image(data: "aGVsbG8=", uri: "file:///a.png", mimeType: "image/png", name: "a.png")])
+        let b = ACPMessage.ToolCall(
+            toolCallId: "tc-4", title: "read", kind: "read",
+            status: "completed", content: "output", preview: "output",
+            assets: [.resource(uri: "file:///a.txt", name: "a.txt")])
+        #expect(a != b)
+    }
+
+    @Test("tool call truncation flag is excluded from equality and hashing")
+    func toolCallTruncatedFlagExcludedFromEqualityAndHash() throws {
+        var a = ACPMessage.ToolCall(
+            toolCallId: "tc-5", title: "read", kind: "read",
+            status: "completed", content: "output", preview: "output")
+        var b = ACPMessage.ToolCall(
+            toolCallId: "tc-5", title: "read", kind: "read",
+            status: "completed", content: "output", preview: "output")
+        b.isContentTruncated = true
+
+        #expect(a == b)
+
+        var ha = Hasher()
+        a.hash(into: &ha)
+        var hb = Hasher()
+        b.hash(into: &hb)
+        #expect(ha.finalize() == hb.finalize())
+    }
+
     @Test("file edit round-trips")
     func editRoundtrip() throws {
         let m = ACPMessage.fileEdit(id: UUID(), .init(

--- a/AlasTests/ACP/Session/ACPMessageWireTests.swift
+++ b/AlasTests/ACP/Session/ACPMessageWireTests.swift
@@ -52,8 +52,8 @@ struct ACPMessageWireTests {
         #expect(decoded == tc)
     }
 
-    @Test("tool call decodes missing content language as nil")
-    func toolCallMissingContentLanguageDecodesAsNil() throws {
+    @Test("tool call decodes missing enriched fields as nil/empty")
+    func toolCallMissingEnrichedFieldsDecodeAsDefault() throws {
         let payload = """
         {
           "toolCallId": "tc1",
@@ -62,8 +62,7 @@ struct ACPMessageWireTests {
           "status": "completed",
           "content": "abc",
           "preview": "abc",
-          "locations": ["/a"],
-          "terminalIds": []
+          "locations": ["/a"]
         }
         """.data(using: .utf8)!
         let wire = try ACPMessageWire.decode(kind: "tool_call", payload: payload)
@@ -72,6 +71,66 @@ struct ACPMessageWireTests {
             return
         }
         #expect(decoded.contentLanguage == nil)
+        #expect(decoded.rawOutput == nil)
+        #expect(decoded.metadata == nil)
+        #expect(decoded.assets == [])
+        #expect(decoded.terminalIds.isEmpty)
+    }
+
+    @Test("tool call decodes enriched fields from wire payload")
+    func toolCallWireDecodesEnrichedFields() throws {
+        let payload = """
+        {
+          "toolCallId": "tc2",
+          "title": "read",
+          "kind": "fs.read",
+          "status": "completed",
+          "content": "raw",
+          "preview": "raw",
+          "contentLanguage": "plaintext",
+          "rawInput": "{\\\"command\\\":\\\"read_file\\\"}",
+          "rawOutput": "{\\\"status\\\":\\\"ok\\\"}",
+          "metadata": {
+            "is_mcp_tool_call": true
+          },
+          "assets": [
+            {
+              "kind": "image",
+              "data": "aGVsbG8=",
+              "uri": "file:///tmp/screenshot.png",
+              "mimeType": "image/png",
+              "name": "screenshot.png"
+            },
+            {
+              "kind": "resource",
+              "uri": "file:///tmp/resource.txt",
+              "mimeType": "text/plain",
+              "name": "resource.txt"
+            }
+          ],
+          "locations": ["/a", "/b"],
+          "terminalIds": ["term-1", "term-2"]
+        }
+        """.data(using: .utf8)!
+
+        let wire = try ACPMessageWire.decode(kind: "tool_call", payload: payload)
+        guard case let .toolCall(decoded) = wire else {
+            #expect(Bool(false), "expected .toolCall, got \(wire)")
+            return
+        }
+
+        #expect(decoded.contentLanguage == "plaintext")
+        #expect(decoded.rawInput == #"{\"command\":\"read_file\"}")
+        #expect(decoded.rawOutput == #"{\"status\":\"ok\"}")
+        #expect(decoded.metadata?.value as? [String: AnyCodable] != nil)
+        #expect((decoded.metadata?.value as? [String: AnyCodable])?["is_mcp_tool_call"]?.value as? Bool == true)
+        #expect(decoded.assets.count == 2)
+        #expect(decoded.assets[0].kind == .image)
+        #expect(decoded.assets[0].name == "screenshot.png")
+        #expect(decoded.assets[1].kind == .resource)
+        #expect(decoded.assets[1].name == "resource.txt")
+        #expect(decoded.locations == ["/a", "/b"])
+        #expect(decoded.terminalIds == ["term-1", "term-2"])
     }
 
     @Test("unknown kind decodes to system notice")

--- a/AlasTests/ACP/Session/ACPMessageWireTests.swift
+++ b/AlasTests/ACP/Session/ACPMessageWireTests.swift
@@ -120,8 +120,8 @@ struct ACPMessageWireTests {
         }
 
         #expect(decoded.contentLanguage == "plaintext")
-        #expect(decoded.rawInput == #"{\"command\":\"read_file\"}")
-        #expect(decoded.rawOutput == #"{\"status\":\"ok\"}")
+        #expect(decoded.rawInput == #"{"command":"read_file"}"#)
+        #expect(decoded.rawOutput == #"{"status":"ok"}"#)
         #expect(decoded.metadata?.value as? [String: AnyCodable] != nil)
         #expect((decoded.metadata?.value as? [String: AnyCodable])?["is_mcp_tool_call"]?.value as? Bool == true)
         #expect(decoded.assets.count == 2)

--- a/AlasTests/ACP/Session/ACPSessionRunnerTests.swift
+++ b/AlasTests/ACP/Session/ACPSessionRunnerTests.swift
@@ -1352,6 +1352,56 @@ struct ACPSessionRunnerTests {
         #expect(persisted.terminalIds == ["term-1"])
     }
 
+    @Test("persistIndices stores replacement tool content after truncation")
+    func persistIndicesStoresReplacementToolContentAfterTruncation() throws {
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("rn-persist-replacement-tool-\(UUID().uuidString).sqlite")
+        let store = try ACPSessionStore(path: url.path)
+        try store.upsertSession(.init(id: "s", agentId: "claude", title: "t",
+            currentModel: nil, currentMode: nil, autoRun: false,
+            createdAt: 0, updatedAt: 0, lastOpenedAt: 0, archived: false))
+
+        let mock = ACPMockClient()
+        let session = ACPSession(id: "s", agentId: "claude", worktreeId: "wt", title: "t")
+        let runner = ACPSessionRunner(
+            session: session,
+            connection: ACPConnection(client: mock),
+            store: store,
+            sessionId: "s",
+            worktreePath: FileManager.default.temporaryDirectory.path
+        )
+
+        let originalContent = String(repeating: "old-content-line\n", count: 400)
+        let replacementContent = String(repeating: "new-content-line\n", count: 350)
+        let original = ACPMessage.toolCall(.init(
+            toolCallId: "tool-1",
+            title: "Run",
+            kind: "execute",
+            status: "completed",
+            content: originalContent
+        ))
+        session.replaceTranscriptMessages([original])
+        runner.persistIndices([0])
+
+        session.transcript.setVisibleHead(1)
+        let dirty = session.apply(.toolCallUpdate(.init(
+            toolCallId: "tool-1",
+            status: "completed",
+            content: [.content(.text(replacementContent))]
+        )))
+        runner.persistIndices(dirty)
+
+        let rows = try store.loadMessages(sessionId: "s")
+        let row = try #require(rows.first(where: { $0.kind == "tool_call" }))
+        let decoded = try ACPMessageCodec.decode(kind: row.kind, payload: row.payload)
+        guard case .toolCall(let persisted) = decoded else {
+            Issue.record("expected persisted tool call")
+            return
+        }
+        #expect(persisted.content == replacementContent)
+        #expect(persisted.isContentTruncated == false)
+    }
+
     @Test("persistIndices updates deterministic row kind that appeared after runner initialization")
     func persistIndicesUpdatesLateDeterministicRowCollisionKind() throws {
         let url = FileManager.default.temporaryDirectory

--- a/AlasTests/ACP/Session/ACPSessionRunnerTests.swift
+++ b/AlasTests/ACP/Session/ACPSessionRunnerTests.swift
@@ -881,7 +881,88 @@ struct ACPSessionRunnerTests {
 
         #expect(session.transcript.messages.count == 1)
         if case .toolCall(let tc) = session.transcript.messages[0] {
-            #expect(tc.content == "[image]")
+            #expect(tc.content == "")
+            #expect(tc.rawOutput?.contains(#""b64_json":"raw-output-data""#) == true)
+            #expect(tc.assets == [
+                ACPMessage.ToolCallAsset.image(data: "content-image-data", mimeType: "image/png"),
+                ACPMessage.ToolCallAsset.image(data: "raw-output-data", mimeType: "image/png")
+            ])
+        } else {
+            Issue.record("expected restored toolCall message")
+        }
+    }
+
+    @Test("initial tool image enrichments apply during load replay suppression")
+    func initialToolImageEnrichmentsApplyDuringLoadReplaySuppression() async throws {
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("rn-tool-initial-image-replay-\(UUID().uuidString).sqlite")
+        let store = try ACPSessionStore(path: url.path)
+        try store.upsertSession(.init(
+            id: "s",
+            agentId: "codex",
+            title: "t",
+            currentModel: nil,
+            currentMode: nil,
+            autoRun: false,
+            createdAt: 1,
+            updatedAt: 2,
+            lastOpenedAt: 3,
+            archived: false
+        ))
+
+        let mock = ACPMockClient()
+        let session = ACPSession(id: "s", agentId: "codex", worktreeId: "wt", title: "t")
+        session.apply(.toolCall(.init(
+            toolCallId: "tc-initial-image-replay",
+            title: "Image generation",
+            kind: "other",
+            status: "in_progress",
+            content: nil,
+            locations: nil,
+            rawInput: nil,
+            rawOutput: nil)))
+        let runner = ACPSessionRunner(
+            session: session,
+            connection: ACPConnection(client: mock),
+            store: store,
+            sessionId: "s",
+            worktreePath: FileManager.default.temporaryDirectory.path,
+            suppressingLoadReplay: true
+        )
+        runner.start()
+        defer { runner.stop() }
+
+        mock.emit(.init(
+            sessionId: "s",
+            update: .toolCall(.init(
+                toolCallId: "tc-initial-image-replay",
+                title: "Image generation",
+                kind: "other",
+                status: "completed",
+                content: [
+                    .content(.image(data: "content-image-data", uri: nil, mimeType: "image/png"))
+                ],
+                locations: nil,
+                rawInput: nil,
+                rawOutput: AnyCodable([
+                    "data": AnyCodable([
+                        AnyCodable([
+                            "b64_json": AnyCodable("raw-output-data")
+                        ])
+                    ])
+                ])))))
+        mock.emit(.init(sessionId: "s", update: .agentMessageChunk(.text("suppressed replay"))))
+
+        try await waitUntil {
+            guard case .toolCall(let tc) = session.transcript.messages.first else { return false }
+            return tc.status == "completed"
+                && tc.assets.contains(.image(data: "content-image-data", mimeType: "image/png"))
+                && tc.assets.contains(.image(data: "raw-output-data", mimeType: "image/png"))
+        }
+
+        #expect(session.transcript.messages.count == 1)
+        if case .toolCall(let tc) = session.transcript.messages[0] {
+            #expect(tc.content == "")
             #expect(tc.rawOutput?.contains(#""b64_json":"raw-output-data""#) == true)
             #expect(tc.assets == [
                 ACPMessage.ToolCallAsset.image(data: "content-image-data", mimeType: "image/png"),

--- a/AlasTests/ACP/Session/ACPSessionRunnerTests.swift
+++ b/AlasTests/ACP/Session/ACPSessionRunnerTests.swift
@@ -1292,6 +1292,66 @@ struct ACPSessionRunnerTests {
         #expect(posts >= 1)
     }
 
+    @Test("persistIndices preserves stored full tool content after metadata-only update")
+    func persistIndicesPreservesStoredFullToolContentAfterMetadataOnlyUpdate() throws {
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("rn-persist-truncated-tool-\(UUID().uuidString).sqlite")
+        let store = try ACPSessionStore(path: url.path)
+        try store.upsertSession(.init(id: "s", agentId: "claude", title: "t",
+            currentModel: nil, currentMode: nil, autoRun: false,
+            createdAt: 0, updatedAt: 0, lastOpenedAt: 0, archived: false))
+
+        let mock = ACPMockClient()
+        let session = ACPSession(id: "s", agentId: "claude", worktreeId: "wt", title: "t")
+        let runner = ACPSessionRunner(
+            session: session,
+            connection: ACPConnection(client: mock),
+            store: store,
+            sessionId: "s",
+            worktreePath: FileManager.default.temporaryDirectory.path
+        )
+
+        let fullContent = String(repeating: "full-content-line\n", count: 400)
+        let original = ACPMessage.toolCall(.init(
+            toolCallId: "tool-1",
+            title: "Run",
+            kind: "execute",
+            status: "completed",
+            content: fullContent
+        ))
+        session.replaceTranscriptMessages([original])
+        runner.persistIndices([0])
+
+        session.transcript.setVisibleHead(1)
+        guard case .toolCall(let truncated) = session.transcript.messages[0] else {
+            Issue.record("expected tool call")
+            return
+        }
+        #expect(truncated.isContentTruncated)
+        #expect(truncated.content.count < fullContent.count)
+
+        let dirty = session.apply(.toolCallUpdate(.init(
+            toolCallId: "tool-1",
+            metadata: AnyCodable([
+                "terminal_output_delta": AnyCodable([
+                    "terminal_id": AnyCodable("term-1"),
+                    "data": AnyCodable("tail\n")
+                ])
+            ])
+        )))
+        runner.persistIndices(dirty)
+
+        let rows = try store.loadMessages(sessionId: "s")
+        let row = try #require(rows.first(where: { $0.kind == "tool_call" }))
+        let decoded = try ACPMessageCodec.decode(kind: row.kind, payload: row.payload)
+        guard case .toolCall(let persisted) = decoded else {
+            Issue.record("expected persisted tool call")
+            return
+        }
+        #expect(persisted.content == fullContent)
+        #expect(persisted.terminalIds == ["term-1"])
+    }
+
     @Test("persistIndices updates deterministic row kind that appeared after runner initialization")
     func persistIndicesUpdatesLateDeterministicRowCollisionKind() throws {
         let url = FileManager.default.temporaryDirectory

--- a/AlasTests/ACP/Session/ACPSessionRunnerTests.swift
+++ b/AlasTests/ACP/Session/ACPSessionRunnerTests.swift
@@ -971,6 +971,15 @@ struct ACPSessionRunnerTests {
         } else {
             Issue.record("expected restored toolCall message")
         }
+
+        try await waitUntil {
+            guard let row = try? store.loadMessages(sessionId: "s").first,
+                  let decoded = try? ACPMessageCodec.decode(kind: row.kind, payload: row.payload),
+                  case .toolCall(let persisted) = decoded
+            else { return false }
+            return persisted.assets.contains(.image(data: "content-image-data", mimeType: "image/png"))
+                && persisted.assets.contains(.image(data: "raw-output-data", mimeType: "image/png"))
+        }
     }
 
     @Test("streaming chunks are persisted in a batch when streaming ends")

--- a/AlasTests/ACP/Session/ACPSessionRunnerTests.swift
+++ b/AlasTests/ACP/Session/ACPSessionRunnerTests.swift
@@ -536,6 +536,36 @@ struct ACPSessionRunnerTests {
         #expect(row.titleSource == .generated)
     }
 
+    @Test("session_info_update metadata updates live goal")
+    func sessionInfoUpdateMetadataUpdatesLiveGoal() async throws {
+        let (runner, mock) = try makeRunner()
+        runner.start()
+        defer { runner.stop() }
+
+        mock.emit(.init(
+            sessionId: "s",
+            update: .sessionInfoUpdate(.init(
+                title: .absent,
+                metadata: AnyCodable([
+                    "codex": AnyCodable([
+                        "goal": AnyCodable([
+                            "objective": AnyCodable("Surface richer ACP events"),
+                            "status": AnyCodable("in_progress"),
+                            "tokenBudget": AnyCodable(12_000)
+                        ])
+                    ])
+                ])
+            ))
+        ))
+
+        try await waitUntil {
+            runner.session.currentGoal?.objective == "Surface richer ACP events"
+        }
+        let goal = try #require(runner.session.currentGoal)
+        #expect(goal.status == "in_progress")
+        #expect(goal.tokenBudget == 12_000)
+    }
+
     @Test("session_info_update preserves manual title")
     func sessionInfoUpdatePreservesManualTitle() async throws {
         let url = FileManager.default.temporaryDirectory

--- a/AlasTests/ACP/Session/ACPSessionRunnerTests.swift
+++ b/AlasTests/ACP/Session/ACPSessionRunnerTests.swift
@@ -815,6 +815,83 @@ struct ACPSessionRunnerTests {
         }
     }
 
+    @Test("tool image enrichments apply during load replay suppression")
+    func toolImageEnrichmentsApplyDuringLoadReplaySuppression() async throws {
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("rn-tool-image-replay-\(UUID().uuidString).sqlite")
+        let store = try ACPSessionStore(path: url.path)
+        try store.upsertSession(.init(
+            id: "s",
+            agentId: "codex",
+            title: "t",
+            currentModel: nil,
+            currentMode: nil,
+            autoRun: false,
+            createdAt: 1,
+            updatedAt: 2,
+            lastOpenedAt: 3,
+            archived: false
+        ))
+
+        let mock = ACPMockClient()
+        let session = ACPSession(id: "s", agentId: "codex", worktreeId: "wt", title: "t")
+        session.apply(.toolCall(.init(
+            toolCallId: "tc-image-replay",
+            title: "Image generation",
+            kind: "other",
+            status: "in_progress",
+            content: nil,
+            locations: nil,
+            rawInput: nil,
+            rawOutput: nil)))
+        let runner = ACPSessionRunner(
+            session: session,
+            connection: ACPConnection(client: mock),
+            store: store,
+            sessionId: "s",
+            worktreePath: FileManager.default.temporaryDirectory.path,
+            suppressingLoadReplay: true
+        )
+        runner.start()
+        defer { runner.stop() }
+
+        mock.emit(.init(
+            sessionId: "s",
+            update: .toolCallUpdate(.init(
+                toolCallId: "tc-image-replay",
+                status: "completed",
+                content: [
+                    .content(.image(data: "content-image-data", uri: nil, mimeType: "image/png"))
+                ],
+                rawOutput: AnyCodable([
+                    "data": AnyCodable([
+                        AnyCodable([
+                            "b64_json": AnyCodable("raw-output-data")
+                        ])
+                    ])
+                ])))))
+        mock.emit(.init(sessionId: "s", update: .agentMessageChunk(.text("suppressed replay"))))
+
+        try await waitUntil {
+            guard case .toolCall(let tc) = session.transcript.messages.first else { return false }
+            return tc.status == "completed"
+                && tc.assets.contains(.image(data: "content-image-data", mimeType: "image/png"))
+                && tc.assets.contains(.image(data: "raw-output-data", mimeType: "image/png"))
+        }
+
+        #expect(session.transcript.messages.count == 1)
+        if case .toolCall(let tc) = session.transcript.messages[0] {
+            #expect(tc.content == "[image]")
+            #expect(tc.rawOutput?.contains(#""b64_json":"raw-output-data""#) == true)
+            #expect(tc.assets == [
+                ACPMessage.ToolCallAsset.image(data: "content-image-data", mimeType: "image/png"),
+                ACPMessage.ToolCallAsset.image(data: "raw-output-data", mimeType: "image/png")
+            ])
+        } else {
+            Issue.record("expected restored toolCall message")
+        }
+    }
+
     @Test("streaming chunks are persisted in a batch when streaming ends")
     func streamingChunksPersistAsBatchOnIdle() async throws {
         let url = FileManager.default.temporaryDirectory.appendingPathComponent("rn-\(UUID()).sqlite")

--- a/AlasTests/ACP/Session/ACPSessionRunnerTests.swift
+++ b/AlasTests/ACP/Session/ACPSessionRunnerTests.swift
@@ -751,6 +751,70 @@ struct ACPSessionRunnerTests {
         #expect(session.transcript.messages.isEmpty)
     }
 
+    @Test("tool metadata side effects apply during load replay suppression")
+    func toolMetadataSideEffectsApplyDuringLoadReplaySuppression() async throws {
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("rn-tool-replay-\(UUID().uuidString).sqlite")
+        let store = try ACPSessionStore(path: url.path)
+        try store.upsertSession(.init(
+            id: "s",
+            agentId: "claude",
+            title: "t",
+            currentModel: nil,
+            currentMode: nil,
+            autoRun: false,
+            createdAt: 1,
+            updatedAt: 2,
+            lastOpenedAt: 3,
+            archived: false
+        ))
+
+        let mock = ACPMockClient()
+        let session = ACPSession(id: "s", agentId: "claude", worktreeId: "wt", title: "t")
+        session.apply(.toolCall(.init(
+            toolCallId: "tc-replay",
+            title: "Run command",
+            kind: "execute",
+            status: "in_progress",
+            content: nil,
+            locations: nil,
+            rawInput: nil,
+            rawOutput: nil)))
+        let runner = ACPSessionRunner(
+            session: session,
+            connection: ACPConnection(client: mock),
+            store: store,
+            sessionId: "s",
+            worktreePath: FileManager.default.temporaryDirectory.path,
+            suppressingLoadReplay: true
+        )
+        runner.start()
+        defer { runner.stop() }
+
+        mock.emit(.init(
+            sessionId: "s",
+            update: .toolCallUpdate(.init(
+                toolCallId: "tc-replay",
+                metadata: AnyCodable([
+                    "terminal_output_delta": AnyCodable([
+                        "terminal_id": AnyCodable("term-replay"),
+                        "data": AnyCodable("replayed output\n")
+                    ])
+                ])))))
+        mock.emit(.init(sessionId: "s", update: .agentMessageChunk(.text("suppressed replay"))))
+
+        try await waitUntil {
+            session.terminalHost.terminal(id: "term-replay")?.snapshot(byteLimit: 1024).text == "replayed output\n"
+        }
+
+        #expect(session.transcript.messages.count == 1)
+        if case .toolCall(let tc) = session.transcript.messages[0] {
+            #expect(tc.terminalIds == ["term-replay"])
+        } else {
+            Issue.record("expected restored toolCall message")
+        }
+    }
+
     @Test("streaming chunks are persisted in a batch when streaming ends")
     func streamingChunksPersistAsBatchOnIdle() async throws {
         let url = FileManager.default.temporaryDirectory.appendingPathComponent("rn-\(UUID()).sqlite")

--- a/AlasTests/ACP/Session/ACPSessionRunnerTests.swift
+++ b/AlasTests/ACP/Session/ACPSessionRunnerTests.swift
@@ -1138,6 +1138,87 @@ struct ACPSessionRunnerTests {
         #expect(text.value == "hello world")
     }
 
+    @Test("takeover snapshot preserves stored full tool content")
+    func takeoverSnapshotPreservesStoredFullToolContent() async throws {
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("rn-takeover-tool-snapshot-\(UUID().uuidString).sqlite")
+        let store = try ACPSessionStore(path: url.path)
+        let sid = "s"
+        try store.upsertSession(.init(id: sid, agentId: "claude", title: "t",
+            currentModel: nil, currentMode: nil, autoRun: false,
+            createdAt: 0, updatedAt: 0, lastOpenedAt: 0, archived: false))
+        let now = Int64(Date().timeIntervalSince1970)
+        try store.seizeLease(sessionId: sid, instanceId: "ME", pid: Int64(getpid()), now: now)
+
+        let mock = StreamingBatchACPClient()
+        let session = ACPSession(id: sid, agentId: "claude", worktreeId: "wt", title: "t")
+        session.agentState = .ready
+        let runner = ACPSessionRunner(
+            session: session,
+            connection: ACPConnection(client: mock),
+            store: store,
+            sessionId: sid,
+            worktreePath: FileManager.default.temporaryDirectory.path,
+            streamingPersistDebounceNanos: 5_000_000_000,
+            ownerInstanceId: "ME"
+        )
+
+        let fullContent = String(repeating: "full-content-line\n", count: 400)
+        let original = ACPMessage.toolCall(.init(
+            toolCallId: "tool-1",
+            title: "Run",
+            kind: "execute",
+            status: "completed",
+            content: fullContent
+        ))
+        session.replaceTranscriptMessages([original])
+        runner.persistIndices([0])
+        session.transcript.setVisibleHead(1)
+        guard case .toolCall(let truncated) = session.transcript.messages[0] else {
+            Issue.record("expected tool call")
+            return
+        }
+        #expect(truncated.isContentTruncated)
+        #expect(truncated.content.count < fullContent.count)
+
+        runner.start()
+        let completed = Task {
+            await withCheckedContinuation { continuation in
+                runner.send(text: "start", attachments: []) { succeeded in
+                    continuation.resume(returning: succeeded)
+                }
+            }
+        }
+
+        await mock.waitForChunks()
+        mock.emitToolCallUpdate(.init(
+            toolCallId: "tool-1",
+            metadata: AnyCodable([
+                "terminal_output_delta": AnyCodable([
+                    "terminal_id": AnyCodable("term-1"),
+                    "data": AnyCodable("tail\n")
+                ])
+            ])
+        ))
+        try await Task.sleep(nanoseconds: 50_000_000)
+        try store.seizeLease(sessionId: sid, instanceId: "OTHER", pid: Int64(getpid()), now: now)
+        mock.emitUsageUpdate()
+        try await Task.sleep(nanoseconds: 50_000_000)
+        runner.stop()
+        await mock.finishPrompt()
+        _ = await completed.value
+
+        let rows = try store.loadMessages(sessionId: sid)
+        let row = try #require(rows.first(where: { $0.kind == "tool_call" }))
+        let decoded = try ACPMessageCodec.decode(kind: row.kind, payload: row.payload)
+        guard case .toolCall(let persisted) = decoded else {
+            Issue.record("expected persisted tool call")
+            return
+        }
+        #expect(persisted.content == fullContent)
+        #expect(persisted.terminalIds == ["term-1"])
+    }
+
     @Test("stop() resolves a parked permission continuation as cancelled")
     func stopResolvesParkedPermission() async throws {
         let (runner, _) = try makeRunner()
@@ -2030,6 +2111,10 @@ private final class StreamingBatchACPClient: ACPClient {
 
     func emitAgentChunk(_ text: String) {
         updatesCont.yield(.init(sessionId: "s", update: .agentMessageChunk(.text(text))))
+    }
+
+    func emitToolCallUpdate(_ update: ACPToolCallUpdate) {
+        updatesCont.yield(.init(sessionId: "s", update: .toolCallUpdate(update)))
     }
 
     func notify(_ request: ACPRequest) async throws {}

--- a/AlasTests/ACP/Session/ACPSessionTests.swift
+++ b/AlasTests/ACP/Session/ACPSessionTests.swift
@@ -1141,9 +1141,8 @@ struct ACPSessionTests {
             #expect(tc.kind == "read")
             #expect(tc.status == "completed")
             #expect(tc.content == "final output")
-            #expect(tc.assets == [
-                ACPMessage.ToolCallAsset.image(data: "raw-output-data", mimeType: "image/png")
-            ])
+            #expect(tc.rawOutput == nil)
+            #expect(tc.assets == [])
         } else {
             Issue.record("expected toolCall message")
         }
@@ -1196,9 +1195,8 @@ struct ACPSessionTests {
             #expect(tc.terminalIds == ["term-replay"])
             let metadata = try #require(tc.metadata?.value as? [String: AnyCodable])
             #expect(metadata["terminal_output_delta"] != nil)
-            #expect(tc.assets == [
-                ACPMessage.ToolCallAsset.image(data: "raw-output-data", mimeType: "image/png")
-            ])
+            #expect(tc.rawOutput == nil)
+            #expect(tc.assets == [])
         } else {
             Issue.record("expected toolCall message")
         }

--- a/AlasTests/ACP/Session/ACPSessionTests.swift
+++ b/AlasTests/ACP/Session/ACPSessionTests.swift
@@ -774,6 +774,43 @@ struct ACPSessionTests {
         }
     }
 
+    @Test("image-only toolCall content is preserved as assets without preview")
+    func imageOnlyToolCallContentPreservesAssetsWithoutPreview() async {
+        let session = ACPSession(id: "s", agentId: "claude", worktreeId: "w", title: "t")
+
+        session.apply(.toolCall(.init(
+            toolCallId: "tc-image-only",
+            title: "screenshot",
+            kind: "read",
+            status: "completed",
+            content: [
+                .content(.image(data: "base64-data", uri: "/tmp/result.png", mimeType: "image/png")),
+                .content(.image(data: nil, uri: "file:///tmp/second-result.jpg", mimeType: "image/jpeg"))
+            ],
+            locations: nil,
+            rawInput: nil,
+            rawOutput: nil)))
+
+        if case .toolCall(let tc) = session.transcript.messages[0] {
+            #expect(tc.content == "")
+            #expect(tc.preview == nil)
+            #expect(tc.assets == [
+                ACPMessage.ToolCallAsset.image(
+                    data: "base64-data",
+                    uri: "/tmp/result.png",
+                    mimeType: "image/png",
+                    name: "result.png"),
+                ACPMessage.ToolCallAsset.image(
+                    data: nil,
+                    uri: "file:///tmp/second-result.jpg",
+                    mimeType: "image/jpeg",
+                    name: "second-result.jpg")
+            ])
+        } else {
+            Issue.record("expected toolCall message")
+        }
+    }
+
     @Test("tool call metadata routes terminal output and exit")
     func toolCallMetadataRoutesTerminalOutputAndExit() async throws {
         let session = ACPSession(id: "s", agentId: "codex", worktreeId: "w", title: "t")

--- a/AlasTests/ACP/Session/ACPSessionTests.swift
+++ b/AlasTests/ACP/Session/ACPSessionTests.swift
@@ -509,6 +509,84 @@ struct ACPSessionTests {
         #expect(session.availableConfigOptions[0].currentValue == .string("high"))
     }
 
+    @Test("session info applies title and goal")
+    func sessionInfoAppliesTitleAndGoal() async throws {
+        let session = ACPSession(id: "s", agentId: "codex", worktreeId: "w", title: "Old title")
+        session.apply(.sessionInfoUpdate(.init(
+            title: "Investigate ACP events",
+            metadata: AnyCodable([
+                "codex": AnyCodable([
+                    "goal": AnyCodable([
+                        "objective": AnyCodable("Surface richer ACP events"),
+                        "status": AnyCodable("in_progress"),
+                        "tokenBudget": AnyCodable(12_000)
+                    ])
+                ])
+            ]))))
+
+        let goal = try #require(session.currentGoal)
+        #expect(session.title == "Investigate ACP events")
+        #expect(session.titleSource == .generated)
+        #expect(goal.objective == "Surface richer ACP events")
+        #expect(goal.status == "in_progress")
+        #expect(goal.tokenBudget == 12_000)
+    }
+
+    @Test("session info clears goal on null goal")
+    func sessionInfoClearsGoalOnNullGoal() async {
+        let session = ACPSession(id: "s", agentId: "codex", worktreeId: "w", title: "t")
+        session.apply(.sessionInfoUpdate(.init(
+            title: nil,
+            metadata: AnyCodable([
+                "codex": AnyCodable([
+                    "goal": AnyCodable([
+                        "objective": AnyCodable("Keep me"),
+                        "status": AnyCodable("in_progress")
+                    ])
+                ])
+            ]))))
+
+        session.apply(.sessionInfoUpdate(.init(
+            title: nil,
+            metadata: AnyCodable([
+                "codex": AnyCodable([
+                    "goal": AnyCodable(NSNull())
+                ])
+            ]))))
+
+        #expect(session.currentGoal == nil)
+    }
+
+    @Test("session info without goal leaves existing goal unchanged")
+    func sessionInfoWithoutGoalLeavesExistingGoalUnchanged() async throws {
+        let session = ACPSession(id: "s", agentId: "codex", worktreeId: "w", title: "Old title")
+        session.apply(.sessionInfoUpdate(.init(
+            title: nil,
+            metadata: AnyCodable([
+                "codex": AnyCodable([
+                    "goal": AnyCodable([
+                        "objective": AnyCodable("Original goal"),
+                        "status": AnyCodable("in_progress"),
+                        "tokenBudget": AnyCodable(200)
+                    ])
+                ])
+            ]))))
+
+        session.apply(.sessionInfoUpdate(.init(
+            title: "Only title changed",
+            metadata: AnyCodable([
+                "codex": AnyCodable([
+                    "unrelated": AnyCodable(true)
+                ])
+            ]))))
+
+        let goal = try #require(session.currentGoal)
+        #expect(session.title == "Only title changed")
+        #expect(goal.objective == "Original goal")
+        #expect(goal.status == "in_progress")
+        #expect(goal.tokenBudget == 200)
+    }
+
     @Test("chipState reflects current ACPSession fields")
     func chipStateRecomputed() async {
         let session = ACPSession(id: "s", agentId: "claude", worktreeId: "w", title: "t")
@@ -602,6 +680,126 @@ struct ACPSessionTests {
         if case .toolCall(let tc) = session.transcript.messages[0] {
             #expect(tc.rawInput?.hasSuffix("… [truncated]") == true)
             #expect((tc.rawInput?.count ?? 0) <= 4_096 + "… [truncated]".count)
+        } else {
+            Issue.record("expected toolCall message")
+        }
+    }
+
+    @Test("toolCallUpdate mutates enriched fields")
+    func toolCallUpdateMutatesEnrichedFields() async {
+        let session = ACPSession(id: "s", agentId: "claude", worktreeId: "w", title: "t")
+        let metadata = AnyCodable([
+            "terminal_exit": AnyCodable([
+                "terminal_id": AnyCodable("term-1"),
+                "exit_code": AnyCodable(0)
+            ])
+        ])
+
+        session.apply(.toolCall(.init(
+            toolCallId: "tc-enriched",
+            title: "running",
+            kind: "execute",
+            status: "in_progress",
+            content: [
+                .terminal(terminalId: "stale-term"),
+                .content(.resourceLink(uri: "file:///tmp/stale.txt", name: "stale.txt"))
+            ],
+            locations: nil,
+            rawInput: nil,
+            rawOutput: nil)))
+
+        session.apply(.toolCallUpdate(.init(
+            toolCallId: "tc-enriched",
+            status: "completed",
+            content: [
+                .content(.text("```swift\nlet ok = true\n```")),
+                .content(.image(data: "image-data", uri: "file:///tmp/result.png", mimeType: "image/png"))
+            ],
+            rawOutput: AnyCodable(["exit_code": AnyCodable(0)]),
+            title: "swift test --filter ACP",
+            locations: [ACPToolLocation(path: "AlasTests/ACP/Session/ACPSessionTests.swift", line: 12)],
+            rawInput: AnyCodable(["command": AnyCodable("swift test --filter ACP")]),
+            metadata: metadata)))
+
+        if case .toolCall(let tc) = session.transcript.messages[0] {
+            #expect(tc.title == "swift test --filter ACP")
+            #expect(tc.status == "completed")
+            #expect(tc.content == "let ok = true")
+            #expect(tc.preview == "let ok = true")
+            #expect(tc.contentLanguage == "swift")
+            #expect(tc.locations == ["AlasTests/ACP/Session/ACPSessionTests.swift"])
+            #expect(tc.rawInput?.contains(#""command":"swift test --filter ACP""#) == true)
+            #expect(tc.rawOutput?.contains(#""exit_code":0"#) == true)
+            #expect(tc.metadata == metadata)
+            #expect(tc.terminalIds.isEmpty)
+            #expect(tc.assets == [
+                ACPMessage.ToolCallAsset.image(
+                    data: "image-data",
+                    uri: "file:///tmp/result.png",
+                    mimeType: "image/png",
+                    name: "result.png")
+            ])
+        } else {
+            Issue.record("expected toolCall message")
+        }
+    }
+
+    @Test("initial toolCall stores raw output and metadata")
+    func initialToolCallStoresRawOutputAndMetadata() async {
+        let session = ACPSession(id: "s", agentId: "claude", worktreeId: "w", title: "t")
+        let metadata = AnyCodable([
+            "is_mcp_tool_call": AnyCodable(true),
+            "tool": AnyCodable("screenshot")
+        ])
+
+        session.apply(.toolCall(.init(
+            toolCallId: "tc-output",
+            title: "screenshot",
+            kind: "read",
+            status: "completed",
+            content: [.content(.image(data: "base64-data", uri: nil, mimeType: "image/png"))],
+            locations: nil,
+            rawInput: nil,
+            rawOutput: AnyCodable(["status": AnyCodable("ok")]),
+            metadata: metadata)))
+
+        if case .toolCall(let tc) = session.transcript.messages[0] {
+            #expect(tc.rawOutput?.contains(#""status":"ok""#) == true)
+            #expect(tc.metadata == metadata)
+            #expect(tc.assets == [
+                ACPMessage.ToolCallAsset.image(data: "base64-data", uri: nil, mimeType: "image/png")
+            ])
+        } else {
+            Issue.record("expected toolCall message")
+        }
+    }
+
+    @Test("toolCall content preserves embedded resource text and asset")
+    func toolCallPreservesEmbeddedResourceTextAndAsset() async {
+        let session = ACPSession(id: "s", agentId: "claude", worktreeId: "w", title: "t")
+
+        session.apply(.toolCall(.init(
+            toolCallId: "tc-resource",
+            title: "read resource",
+            kind: "read",
+            status: "completed",
+            content: [.content(.resource(
+                uri: "file:///tmp/File.swift",
+                mimeType: "text/plain",
+                text: "let value = 1\n"
+            ))],
+            locations: nil,
+            rawInput: nil,
+            rawOutput: nil)))
+
+        if case .toolCall(let tc) = session.transcript.messages[0] {
+            #expect(tc.content == "let value = 1\n")
+            #expect(tc.assets == [
+                ACPMessage.ToolCallAsset.resource(
+                    uri: "file:///tmp/File.swift",
+                    name: "File.swift",
+                    mimeType: "text/plain")
+            ])
         } else {
             Issue.record("expected toolCall message")
         }

--- a/AlasTests/ACP/Session/ACPSessionTests.swift
+++ b/AlasTests/ACP/Session/ACPSessionTests.swift
@@ -532,6 +532,25 @@ struct ACPSessionTests {
         #expect(goal.tokenBudget == 12_000)
     }
 
+    @Test("session info applies top-level goal metadata")
+    func sessionInfoAppliesTopLevelGoalMetadata() async throws {
+        let session = ACPSession(id: "s", agentId: "bridge", worktreeId: "w", title: "t")
+        session.apply(.sessionInfoUpdate(.init(
+            title: nil,
+            metadata: AnyCodable([
+                "goal": AnyCodable([
+                    "objective": AnyCodable("Surface generic ACP events"),
+                    "status": AnyCodable("in_progress"),
+                    "tokenBudget": AnyCodable(500)
+                ])
+            ]))))
+
+        let goal = try #require(session.currentGoal)
+        #expect(goal.objective == "Surface generic ACP events")
+        #expect(goal.status == "in_progress")
+        #expect(goal.tokenBudget == 500)
+    }
+
     @Test("session info clears goal on null goal")
     func sessionInfoClearsGoalOnNullGoal() async {
         let session = ACPSession(id: "s", agentId: "codex", worktreeId: "w", title: "t")

--- a/AlasTests/ACP/Session/ACPSessionTests.swift
+++ b/AlasTests/ACP/Session/ACPSessionTests.swift
@@ -1199,6 +1199,40 @@ struct ACPSessionTests {
         }
     }
 
+    @Test("suppressed final tool payload replay preserves terminal ids from content")
+    func suppressedFinalToolPayloadReplayPreservesTerminalIdsFromContent() async {
+        let session = ACPSession(id: "s", agentId: "bridge", worktreeId: "w", title: "t")
+
+        session.apply(.toolCall(.init(
+            toolCallId: "tc-final-payload-replay-terminal",
+            title: "Final command",
+            kind: "execute",
+            status: "completed",
+            content: [.content(.text("final output"))],
+            locations: nil,
+            rawInput: nil,
+            rawOutput: nil)))
+
+        let touched = session.applySuppressedReplaySideEffects(.toolCall(.init(
+            toolCallId: "tc-final-payload-replay-terminal",
+            title: "Initial command",
+            kind: "execute",
+            status: "completed",
+            content: [.terminal(terminalId: "term-final-payload-replay")],
+            locations: nil,
+            rawInput: nil,
+            rawOutput: nil)))
+
+        #expect(touched == [0])
+        if case .toolCall(let tc) = session.transcript.messages[0] {
+            #expect(tc.title == "Final command")
+            #expect(tc.content == "final output")
+            #expect(tc.terminalIds == ["term-final-payload-replay"])
+        } else {
+            Issue.record("expected toolCall message")
+        }
+    }
+
     @Test("content update does not preserve stale content image assets")
     func contentUpdateDoesNotPreserveStaleContentImageAssets() async {
         let session = ACPSession(id: "s", agentId: "codex", worktreeId: "w", title: "t")

--- a/AlasTests/ACP/Session/ACPSessionTests.swift
+++ b/AlasTests/ACP/Session/ACPSessionTests.swift
@@ -1030,6 +1030,47 @@ struct ACPSessionTests {
         }
     }
 
+    @Test("raw output long image URL asset survives later content update")
+    func rawOutputLongImageURLAssetSurvivesLaterContentUpdate() async {
+        let session = ACPSession(id: "s", agentId: "bridge", worktreeId: "w", title: "t")
+        let imageURL = "https://example.com/generated.png?signature=" + String(repeating: "A", count: 5_000)
+
+        session.apply(.toolCall(.init(
+            toolCallId: "tc-raw-long-url-update",
+            title: "Image generation",
+            kind: "other",
+            status: "in_progress",
+            content: nil,
+            locations: nil,
+            rawInput: nil,
+            rawOutput: AnyCodable([
+                "data": AnyCodable([
+                    AnyCodable([
+                        "url": AnyCodable(imageURL)
+                    ])
+                ])
+            ]))))
+        session.apply(.toolCallUpdate(.init(
+            toolCallId: "tc-raw-long-url-update",
+            status: "completed",
+            content: [.content(.text("final output"))],
+            rawOutput: nil)))
+
+        if case .toolCall(let tc) = session.transcript.messages[0] {
+            #expect(tc.content == "final output")
+            #expect(tc.rawOutput?.contains("[truncated]") == true)
+            #expect(tc.assets == [
+                ACPMessage.ToolCallAsset.image(
+                    data: nil,
+                    uri: imageURL,
+                    mimeType: nil,
+                    name: "generated.png")
+            ])
+        } else {
+            Issue.record("expected toolCall message")
+        }
+    }
+
     @Test("content update does not preserve stale content image assets")
     func contentUpdateDoesNotPreserveStaleContentImageAssets() async {
         let session = ACPSession(id: "s", agentId: "codex", worktreeId: "w", title: "t")

--- a/AlasTests/ACP/Session/ACPSessionTests.swift
+++ b/AlasTests/ACP/Session/ACPSessionTests.swift
@@ -1425,6 +1425,45 @@ struct ACPSessionTests {
         #expect(term.snapshot(byteLimit: 1024).text == "building\n")
     }
 
+    @Test("suppressed replay replacement terminal output refreshes existing buffer")
+    func suppressedReplayReplacementTerminalOutputRefreshesExistingBuffer() async throws {
+        let session = ACPSession(id: "s", agentId: "codex", worktreeId: "w", title: "t")
+        session.apply(.toolCall(.init(
+            toolCallId: "cmd-replay-terminal-snapshot",
+            title: "swift test",
+            kind: "execute",
+            status: "in_progress",
+            content: nil,
+            locations: nil,
+            rawInput: nil,
+            rawOutput: nil)))
+        session.apply(.toolCallUpdate(.init(
+            toolCallId: "cmd-replay-terminal-snapshot",
+            status: "in_progress",
+            rawOutput: nil,
+            metadata: AnyCodable([
+                "terminal_output_delta": AnyCodable([
+                    "terminal_id": AnyCodable("term-replay-terminal-snapshot"),
+                    "data": AnyCodable("partial\n")
+                ])
+            ]))))
+
+        session.beginSuppressedReplaySideEffects()
+        session.applySuppressedReplaySideEffects(.toolCallUpdate(.init(
+            toolCallId: "cmd-replay-terminal-snapshot",
+            status: "completed",
+            rawOutput: nil,
+            metadata: AnyCodable([
+                "terminal_output": AnyCodable([
+                    "terminal_id": AnyCodable("term-replay-terminal-snapshot"),
+                    "data": AnyCodable("partial\ncomplete\n")
+                ])
+            ]))))
+
+        let term = try #require(session.terminalHost.terminal(id: "term-replay-terminal-snapshot"))
+        #expect(term.snapshot(byteLimit: 1024).text == "partial\ncomplete\n")
+    }
+
     @Test("suppressed replay rebuilds terminal metadata across replay frames")
     func suppressedReplayRebuildsTerminalMetadataAcrossReplayFrames() async throws {
         let session = ACPSession(id: "s", agentId: "codex", worktreeId: "w", title: "t")

--- a/AlasTests/ACP/Session/ACPSessionTests.swift
+++ b/AlasTests/ACP/Session/ACPSessionTests.swift
@@ -989,6 +989,47 @@ struct ACPSessionTests {
         }
     }
 
+    @Test("raw output data URI asset survives later content update")
+    func rawOutputDataURIAssetSurvivesLaterContentUpdate() async {
+        let session = ACPSession(id: "s", agentId: "bridge", worktreeId: "w", title: "t")
+        let dataURI = "data:image/png;base64," + String(repeating: "A", count: 5_000)
+
+        session.apply(.toolCall(.init(
+            toolCallId: "tc-raw-data-uri-update",
+            title: "Image generation",
+            kind: "other",
+            status: "in_progress",
+            content: nil,
+            locations: nil,
+            rawInput: nil,
+            rawOutput: AnyCodable([
+                "data": AnyCodable([
+                    AnyCodable([
+                        "url": AnyCodable(dataURI)
+                    ])
+                ])
+            ]))))
+        session.apply(.toolCallUpdate(.init(
+            toolCallId: "tc-raw-data-uri-update",
+            status: "completed",
+            content: [.content(.text("final output"))],
+            rawOutput: nil)))
+
+        if case .toolCall(let tc) = session.transcript.messages[0] {
+            #expect(tc.content == "final output")
+            #expect(tc.rawOutput?.contains("[truncated]") == true)
+            #expect(tc.assets == [
+                ACPMessage.ToolCallAsset.image(
+                    data: nil,
+                    uri: dataURI,
+                    mimeType: "image/png",
+                    name: nil)
+            ])
+        } else {
+            Issue.record("expected toolCall message")
+        }
+    }
+
     @Test("content update does not preserve stale content image assets")
     func contentUpdateDoesNotPreserveStaleContentImageAssets() async {
         let session = ACPSession(id: "s", agentId: "codex", worktreeId: "w", title: "t")

--- a/AlasTests/ACP/Session/ACPSessionTests.swift
+++ b/AlasTests/ACP/Session/ACPSessionTests.swift
@@ -1115,6 +1115,61 @@ struct ACPSessionTests {
         }
     }
 
+    @Test("suppressed tool update replay does not downgrade completed output")
+    func suppressedToolUpdateReplayDoesNotDowngradeCompletedOutput() async throws {
+        let session = ACPSession(id: "s", agentId: "bridge", worktreeId: "w", title: "t")
+
+        session.apply(.toolCall(.init(
+            toolCallId: "tc-update-replay-downgrade",
+            title: "Final command",
+            kind: "execute",
+            status: "completed",
+            content: [.content(.text("final output"))],
+            locations: [.init(path: "Sources/Final.swift", line: 10)],
+            rawInput: AnyCodable(["command": AnyCodable("swift test")]),
+            rawOutput: nil)))
+
+        let touched = session.applySuppressedReplaySideEffects(.toolCallUpdate(.init(
+            toolCallId: "tc-update-replay-downgrade",
+            status: "in_progress",
+            content: [.content(.text("partial output"))],
+            rawOutput: AnyCodable([
+                "data": AnyCodable([
+                    AnyCodable([
+                        "b64_json": AnyCodable("raw-output-data")
+                    ])
+                ])
+            ]),
+            title: "Initial command",
+            locations: [.init(path: "Sources/Stale.swift", line: 1)],
+            rawInput: AnyCodable(["command": AnyCodable("stale")]),
+            metadata: AnyCodable([
+                "terminal_output_delta": AnyCodable([
+                    "terminal_id": AnyCodable("term-replay"),
+                    "data": AnyCodable("delta")
+                ])
+            ]))))
+
+        #expect(touched == [0])
+        if case .toolCall(let tc) = session.transcript.messages[0] {
+            #expect(tc.title == "Final command")
+            #expect(tc.kind == "execute")
+            #expect(tc.status == "completed")
+            #expect(tc.content == "final output")
+            #expect(tc.locations == ["Sources/Final.swift"])
+            #expect(tc.rawInput?.contains("swift test") == true)
+            #expect(tc.rawInput?.contains("stale") == false)
+            #expect(tc.terminalIds == ["term-replay"])
+            let metadata = try #require(tc.metadata?.value as? [String: AnyCodable])
+            #expect(metadata["terminal_output_delta"] != nil)
+            #expect(tc.assets == [
+                ACPMessage.ToolCallAsset.image(data: "raw-output-data", mimeType: "image/png")
+            ])
+        } else {
+            Issue.record("expected toolCall message")
+        }
+    }
+
     @Test("content update does not preserve stale content image assets")
     func contentUpdateDoesNotPreserveStaleContentImageAssets() async {
         let session = ACPSession(id: "s", agentId: "codex", worktreeId: "w", title: "t")

--- a/AlasTests/ACP/Session/ACPSessionTests.swift
+++ b/AlasTests/ACP/Session/ACPSessionTests.swift
@@ -1071,6 +1071,48 @@ struct ACPSessionTests {
         }
     }
 
+    @Test("suppressed initial tool replay does not downgrade completed output")
+    func suppressedInitialToolReplayDoesNotDowngradeCompletedOutput() async {
+        let session = ACPSession(id: "s", agentId: "bridge", worktreeId: "w", title: "t")
+
+        session.apply(.toolCall(.init(
+            toolCallId: "tc-replay-downgrade",
+            title: "Image generation",
+            kind: "other",
+            status: "completed",
+            content: [.content(.text("final output"))],
+            locations: nil,
+            rawInput: nil,
+            rawOutput: nil)))
+
+        let touched = session.applySuppressedReplaySideEffects(.toolCall(.init(
+            toolCallId: "tc-replay-downgrade",
+            title: "Image generation",
+            kind: "other",
+            status: "in_progress",
+            content: [.content(.text("partial output"))],
+            locations: nil,
+            rawInput: nil,
+            rawOutput: AnyCodable([
+                "data": AnyCodable([
+                    AnyCodable([
+                        "b64_json": AnyCodable("raw-output-data")
+                    ])
+                ])
+            ]))))
+
+        #expect(touched == [0])
+        if case .toolCall(let tc) = session.transcript.messages[0] {
+            #expect(tc.status == "completed")
+            #expect(tc.content == "final output")
+            #expect(tc.assets == [
+                ACPMessage.ToolCallAsset.image(data: "raw-output-data", mimeType: "image/png")
+            ])
+        } else {
+            Issue.record("expected toolCall message")
+        }
+    }
+
     @Test("content update does not preserve stale content image assets")
     func contentUpdateDoesNotPreserveStaleContentImageAssets() async {
         let session = ACPSession(id: "s", agentId: "codex", worktreeId: "w", title: "t")

--- a/AlasTests/ACP/Session/ACPSessionTests.swift
+++ b/AlasTests/ACP/Session/ACPSessionTests.swift
@@ -851,6 +851,41 @@ struct ACPSessionTests {
         #expect(term.exitStatus == ACPTerminalExitStatus(exitCode: 0, signal: nil))
     }
 
+    @Test("metadata-only terminal output attaches terminal id to tool call")
+    func metadataOnlyTerminalOutputAttachesTerminalIdToToolCall() async throws {
+        let session = ACPSession(id: "s", agentId: "codex", worktreeId: "w", title: "t")
+
+        session.apply(.toolCall(.init(
+            toolCallId: "cmd-meta-only",
+            title: "swift test",
+            kind: "execute",
+            status: "in_progress",
+            content: nil,
+            locations: nil,
+            rawInput: nil,
+            rawOutput: nil)))
+        session.apply(.toolCallUpdate(.init(
+            toolCallId: "cmd-meta-only",
+            status: "completed",
+            rawOutput: nil,
+            metadata: AnyCodable([
+                "terminal_output_delta": AnyCodable([
+                    "terminal_id": AnyCodable("cmd-meta-only"),
+                    "data": AnyCodable("ok\n")
+                ])
+            ]))))
+
+        let message = try #require(session.transcript.messages.first)
+        guard case .toolCall(let toolCall) = message else {
+            Issue.record("expected toolCall message")
+            return
+        }
+        #expect(toolCall.terminalIds == ["cmd-meta-only"])
+
+        let term = try #require(session.terminalHost.terminal(id: "cmd-meta-only"))
+        #expect(term.snapshot(byteLimit: 1024).text == "ok\n")
+    }
+
     @Test("terminal_output metadata replaces previous deltas")
     func terminalOutputMetadataReplacesPreviousDeltas() async throws {
         let session = ACPSession(id: "s", agentId: "codex", worktreeId: "w", title: "t")

--- a/AlasTests/ACP/Session/ACPSessionTests.swift
+++ b/AlasTests/ACP/Session/ACPSessionTests.swift
@@ -891,6 +891,32 @@ struct ACPSessionTests {
         }
     }
 
+    @Test("raw output bare image data result is preserved as an asset")
+    func rawOutputBareImageDataResultPreservesAsset() async {
+        let session = ACPSession(id: "s", agentId: "bridge", worktreeId: "w", title: "t")
+
+        session.apply(.toolCall(.init(
+            toolCallId: "tc-raw-image-data",
+            title: "Image generation",
+            kind: "other",
+            status: "completed",
+            content: nil,
+            locations: nil,
+            rawInput: nil,
+            rawOutput: AnyCodable([
+                "data": AnyCodable("base64-data"),
+                "mime_type": AnyCodable("image/png")
+            ]))))
+
+        if case .toolCall(let tc) = session.transcript.messages[0] {
+            #expect(tc.assets == [
+                ACPMessage.ToolCallAsset.image(data: "base64-data", mimeType: "image/png")
+            ])
+        } else {
+            Issue.record("expected toolCall message")
+        }
+    }
+
     @Test("raw output image asset survives later content update")
     func rawOutputImageAssetSurvivesLaterContentUpdate() async {
         let session = ACPSession(id: "s", agentId: "codex", worktreeId: "w", title: "t")
@@ -924,6 +950,50 @@ struct ACPSessionTests {
             #expect(tc.content == "final output")
             #expect(tc.assets == [
                 ACPMessage.ToolCallAsset.image(data: "base64-data", mimeType: "image/png")
+            ])
+        } else {
+            Issue.record("expected toolCall message")
+        }
+    }
+
+    @Test("content update does not preserve stale content image assets")
+    func contentUpdateDoesNotPreserveStaleContentImageAssets() async {
+        let session = ACPSession(id: "s", agentId: "codex", worktreeId: "w", title: "t")
+
+        session.apply(.toolCall(.init(
+            toolCallId: "tc-stale-content-image",
+            title: "Image generation",
+            kind: "other",
+            status: "in_progress",
+            content: [.content(.image(data: "stale-data", uri: nil, mimeType: "image/png"))],
+            locations: nil,
+            rawInput: nil,
+            rawOutput: nil)))
+        session.apply(.toolCallUpdate(.init(
+            toolCallId: "tc-stale-content-image",
+            status: "in_progress",
+            rawOutput: AnyCodable([
+                "data": AnyCodable([
+                    AnyCodable([
+                        "url": AnyCodable("https://example.com/generated"),
+                        "revised_prompt": AnyCodable("A useful screenshot")
+                    ])
+                ])
+            ]))))
+        session.apply(.toolCallUpdate(.init(
+            toolCallId: "tc-stale-content-image",
+            status: "completed",
+            content: [.content(.text("final output"))],
+            rawOutput: nil)))
+
+        if case .toolCall(let tc) = session.transcript.messages[0] {
+            #expect(tc.content == "final output")
+            #expect(tc.assets == [
+                ACPMessage.ToolCallAsset.image(
+                    data: nil,
+                    uri: "https://example.com/generated",
+                    mimeType: nil,
+                    name: "generated")
             ])
         } else {
             Issue.record("expected toolCall message")

--- a/AlasTests/ACP/Session/ACPSessionTests.swift
+++ b/AlasTests/ACP/Session/ACPSessionTests.swift
@@ -891,6 +891,39 @@ struct ACPSessionTests {
         }
     }
 
+    @Test("raw output data URI URL result is preserved as an asset")
+    func rawOutputDataURIURLResultPreservesAsset() async {
+        let session = ACPSession(id: "s", agentId: "bridge", worktreeId: "w", title: "t")
+
+        session.apply(.toolCall(.init(
+            toolCallId: "tc-raw-data-uri-url",
+            title: "Image generation",
+            kind: "other",
+            status: "completed",
+            content: nil,
+            locations: nil,
+            rawInput: nil,
+            rawOutput: AnyCodable([
+                "data": AnyCodable([
+                    AnyCodable([
+                        "url": AnyCodable("data:image/png;base64,base64-data")
+                    ])
+                ])
+            ]))))
+
+        if case .toolCall(let tc) = session.transcript.messages[0] {
+            #expect(tc.assets == [
+                ACPMessage.ToolCallAsset.image(
+                    data: nil,
+                    uri: "data:image/png;base64,base64-data",
+                    mimeType: "image/png",
+                    name: nil)
+            ])
+        } else {
+            Issue.record("expected toolCall message")
+        }
+    }
+
     @Test("raw output bare image data result is preserved as an asset")
     func rawOutputBareImageDataResultPreservesAsset() async {
         let session = ACPSession(id: "s", agentId: "bridge", worktreeId: "w", title: "t")

--- a/AlasTests/ACP/Session/ACPSessionTests.swift
+++ b/AlasTests/ACP/Session/ACPSessionTests.swift
@@ -1071,6 +1071,40 @@ struct ACPSessionTests {
         }
     }
 
+    @Test("raw output long bare image data asset survives later content update")
+    func rawOutputLongBareImageDataAssetSurvivesLaterContentUpdate() async {
+        let session = ACPSession(id: "s", agentId: "bridge", worktreeId: "w", title: "t")
+        let imageData = String(repeating: "A", count: 5_000)
+
+        session.apply(.toolCall(.init(
+            toolCallId: "tc-raw-long-image-data-update",
+            title: "Image generation",
+            kind: "other",
+            status: "in_progress",
+            content: nil,
+            locations: nil,
+            rawInput: nil,
+            rawOutput: AnyCodable([
+                "data": AnyCodable(imageData),
+                "mime_type": AnyCodable("image/png")
+            ]))))
+        session.apply(.toolCallUpdate(.init(
+            toolCallId: "tc-raw-long-image-data-update",
+            status: "completed",
+            content: [.content(.text("final output"))],
+            rawOutput: nil)))
+
+        if case .toolCall(let tc) = session.transcript.messages[0] {
+            #expect(tc.content == "final output")
+            #expect(tc.rawOutput?.contains("[truncated]") == true)
+            #expect(tc.assets == [
+                ACPMessage.ToolCallAsset.image(data: imageData, mimeType: "image/png")
+            ])
+        } else {
+            Issue.record("expected toolCall message")
+        }
+    }
+
     @Test("suppressed initial tool replay does not downgrade completed output")
     func suppressedInitialToolReplayDoesNotDowngradeCompletedOutput() async {
         let session = ACPSession(id: "s", agentId: "bridge", worktreeId: "w", title: "t")
@@ -1713,6 +1747,43 @@ struct ACPSessionTests {
         #expect(toolCall.terminalIds == [])
 
         let term = try #require(session.terminalHost.terminal(id: "term-payload-exit-only"))
+        #expect(term.exitStatus == ACPTerminalExitStatus(exitCode: 0, signal: nil))
+    }
+
+    @Test("suppressed replay update content excludes exit-only terminal id")
+    func suppressedReplayUpdateContentExcludesExitOnlyTerminalId() async throws {
+        let session = ACPSession(id: "s", agentId: "codex", worktreeId: "w", title: "t")
+
+        session.apply(.toolCall(.init(
+            toolCallId: "cmd-update-exit-content",
+            title: "swift test",
+            kind: "execute",
+            status: "completed",
+            content: [.content(.text("final output"))],
+            locations: nil,
+            rawInput: nil,
+            rawOutput: nil)))
+        session.beginSuppressedReplaySideEffects()
+        session.applySuppressedReplaySideEffects(.toolCallUpdate(.init(
+            toolCallId: "cmd-update-exit-content",
+            status: "completed",
+            content: [.content(.text("final output"))],
+            rawOutput: nil,
+            metadata: AnyCodable([
+                "terminal_exit": AnyCodable([
+                    "terminal_id": AnyCodable("term-update-exit-only"),
+                    "exit_code": AnyCodable(0)
+                ])
+            ]))))
+
+        let message = try #require(session.transcript.messages.first)
+        guard case .toolCall(let toolCall) = message else {
+            Issue.record("expected toolCall message")
+            return
+        }
+        #expect(toolCall.terminalIds == [])
+
+        let term = try #require(session.terminalHost.terminal(id: "term-update-exit-only"))
         #expect(term.exitStatus == ACPTerminalExitStatus(exitCode: 0, signal: nil))
     }
 

--- a/AlasTests/ACP/Session/ACPSessionTests.swift
+++ b/AlasTests/ACP/Session/ACPSessionTests.swift
@@ -1070,6 +1070,34 @@ struct ACPSessionTests {
         } else { Issue.record("expected toolCall message") }
     }
 
+    @Test("terminal exit metadata does not reattach cleared terminalIds")
+    func terminalExitMetadataDoesNotReattachClearedTerminalIds() async throws {
+        let session = ACPSession(id: "s", agentId: "claude", worktreeId: "w", title: "t")
+        session.apply(.toolCall(.init(
+            toolCallId: "tc-exit-clear", title: "run", kind: "execute", status: "in_progress",
+            content: [.terminal(terminalId: "term-exit")],
+            locations: nil, rawInput: nil, rawOutput: nil)))
+        session.apply(.toolCallUpdate(.init(
+            toolCallId: "tc-exit-clear",
+            status: "completed",
+            content: [.content(.text("final output"))],
+            rawOutput: nil,
+            metadata: AnyCodable([
+                "terminal_exit": AnyCodable([
+                    "terminal_id": AnyCodable("term-exit"),
+                    "exit_code": AnyCodable(0)
+                ])
+            ]))))
+
+        if case .toolCall(let tc) = session.transcript.messages[0] {
+            #expect(tc.terminalIds.isEmpty)
+            #expect(tc.content == "final output")
+        } else { Issue.record("expected toolCall message") }
+
+        let term = try #require(session.terminalHost.terminal(id: "term-exit"))
+        #expect(term.exitStatus == ACPTerminalExitStatus(exitCode: 0, signal: nil))
+    }
+
     @Test("completed toolCall strips wrapping markdown fences")
     func toolCallStripsBothFences() async {
         let session = ACPSession(id: "s", agentId: "claude", worktreeId: "w", title: "t")

--- a/AlasTests/ACP/Session/ACPSessionTests.swift
+++ b/AlasTests/ACP/Session/ACPSessionTests.swift
@@ -1077,8 +1077,8 @@ struct ACPSessionTests {
 
         session.apply(.toolCall(.init(
             toolCallId: "tc-replay-downgrade",
-            title: "Image generation",
-            kind: "other",
+            title: "Final image generation",
+            kind: "read",
             status: "completed",
             content: [.content(.text("final output"))],
             locations: nil,
@@ -1087,7 +1087,7 @@ struct ACPSessionTests {
 
         let touched = session.applySuppressedReplaySideEffects(.toolCall(.init(
             toolCallId: "tc-replay-downgrade",
-            title: "Image generation",
+            title: "Initial tool",
             kind: "other",
             status: "in_progress",
             content: [.content(.text("partial output"))],
@@ -1103,6 +1103,8 @@ struct ACPSessionTests {
 
         #expect(touched == [0])
         if case .toolCall(let tc) = session.transcript.messages[0] {
+            #expect(tc.title == "Final image generation")
+            #expect(tc.kind == "read")
             #expect(tc.status == "completed")
             #expect(tc.content == "final output")
             #expect(tc.assets == [

--- a/AlasTests/ACP/Session/ACPSessionTests.swift
+++ b/AlasTests/ACP/Session/ACPSessionTests.swift
@@ -606,6 +606,38 @@ struct ACPSessionTests {
         #expect(goal.tokenBudget == 200)
     }
 
+    @Test("session info partial goal metadata updates existing goal")
+    func sessionInfoPartialGoalMetadataUpdatesExistingGoal() async throws {
+        let session = ACPSession(id: "s", agentId: "codex", worktreeId: "w", title: "t")
+        session.apply(.sessionInfoUpdate(.init(
+            title: nil,
+            metadata: AnyCodable([
+                "codex": AnyCodable([
+                    "goal": AnyCodable([
+                        "objective": AnyCodable("Original goal"),
+                        "status": AnyCodable("in_progress"),
+                        "tokenBudget": AnyCodable(200)
+                    ])
+                ])
+            ]))))
+
+        session.apply(.sessionInfoUpdate(.init(
+            title: nil,
+            metadata: AnyCodable([
+                "codex": AnyCodable([
+                    "goal": AnyCodable([
+                        "status": AnyCodable("completed"),
+                        "tokenBudget": AnyCodable(300)
+                    ])
+                ])
+            ]))))
+
+        let goal = try #require(session.currentGoal)
+        #expect(goal.objective == "Original goal")
+        #expect(goal.status == "completed")
+        #expect(goal.tokenBudget == 300)
+    }
+
     @Test("chipState reflects current ACPSession fields")
     func chipStateRecomputed() async {
         let session = ACPSession(id: "s", agentId: "claude", worktreeId: "w", title: "t")

--- a/AlasTests/ACP/Session/ACPSessionTests.swift
+++ b/AlasTests/ACP/Session/ACPSessionTests.swift
@@ -774,6 +774,45 @@ struct ACPSessionTests {
         }
     }
 
+    @Test("toolCallUpdate merges metadata with existing tool metadata")
+    func toolCallUpdateMergesMetadataWithExistingToolMetadata() async throws {
+        let session = ACPSession(id: "s", agentId: "claude", worktreeId: "w", title: "t")
+
+        session.apply(.toolCall(.init(
+            toolCallId: "tc-metadata",
+            title: "mcp tool",
+            kind: "other",
+            status: "in_progress",
+            content: nil,
+            locations: nil,
+            rawInput: nil,
+            rawOutput: nil,
+            metadata: AnyCodable([
+                "is_mcp_tool_call": AnyCodable(true),
+                "tool": AnyCodable("screenshot")
+            ]))))
+        session.apply(.toolCallUpdate(.init(
+            toolCallId: "tc-metadata",
+            status: "in_progress",
+            rawOutput: nil,
+            metadata: AnyCodable([
+                "terminal_output_delta": AnyCodable([
+                    "terminal_id": AnyCodable("term-metadata"),
+                    "data": AnyCodable("ok\n")
+                ])
+            ]))))
+
+        guard case .toolCall(let tc) = session.transcript.messages[0] else {
+            Issue.record("expected toolCall message")
+            return
+        }
+        let metadata = try #require(tc.metadata?.value as? [String: AnyCodable])
+        #expect(metadata["is_mcp_tool_call"]?.value as? Bool == true)
+        #expect(metadata["tool"]?.value as? String == "screenshot")
+        let delta = try #require(metadata["terminal_output_delta"]?.value as? [String: AnyCodable])
+        #expect(delta["terminal_id"]?.value as? String == "term-metadata")
+    }
+
     @Test("image-only toolCall content is preserved as assets without preview")
     func imageOnlyToolCallContentPreservesAssetsWithoutPreview() async {
         let session = ACPSession(id: "s", agentId: "claude", worktreeId: "w", title: "t")

--- a/AlasTests/ACP/Session/ACPSessionTests.swift
+++ b/AlasTests/ACP/Session/ACPSessionTests.swift
@@ -944,6 +944,47 @@ struct ACPSessionTests {
         #expect(term.snapshot(byteLimit: 1024).text == "ok\n")
     }
 
+    @Test("metadata terminal id survives later content-only update")
+    func metadataTerminalIdSurvivesLaterContentOnlyUpdate() async throws {
+        let session = ACPSession(id: "s", agentId: "codex", worktreeId: "w", title: "t")
+
+        session.apply(.toolCall(.init(
+            toolCallId: "cmd-meta-then-content",
+            title: "swift test",
+            kind: "execute",
+            status: "in_progress",
+            content: nil,
+            locations: nil,
+            rawInput: nil,
+            rawOutput: nil)))
+        session.apply(.toolCallUpdate(.init(
+            toolCallId: "cmd-meta-then-content",
+            status: "in_progress",
+            rawOutput: nil,
+            metadata: AnyCodable([
+                "terminal_output_delta": AnyCodable([
+                    "terminal_id": AnyCodable("term-meta-then-content"),
+                    "data": AnyCodable("building\n")
+                ])
+            ]))))
+        session.apply(.toolCallUpdate(.init(
+            toolCallId: "cmd-meta-then-content",
+            status: "completed",
+            content: [.content(.text("final output"))],
+            rawOutput: nil)))
+
+        let message = try #require(session.transcript.messages.first)
+        guard case .toolCall(let toolCall) = message else {
+            Issue.record("expected toolCall message")
+            return
+        }
+        #expect(toolCall.terminalIds == ["term-meta-then-content"])
+        #expect(toolCall.content == "final output")
+
+        let term = try #require(session.terminalHost.terminal(id: "term-meta-then-content"))
+        #expect(term.snapshot(byteLimit: 1024).text == "building\n")
+    }
+
     @Test("terminal_output metadata replaces previous deltas")
     func terminalOutputMetadataReplacesPreviousDeltas() async throws {
         let session = ACPSession(id: "s", agentId: "codex", worktreeId: "w", title: "t")

--- a/AlasTests/ACP/Session/ACPSessionTests.swift
+++ b/AlasTests/ACP/Session/ACPSessionTests.swift
@@ -1447,6 +1447,56 @@ struct ACPSessionTests {
         #expect(term.exitStatus == ACPTerminalExitStatus(exitCode: 0, signal: nil))
     }
 
+    @Test("suppressed replay preserves exit for buffered metadata terminal")
+    func suppressedReplayPreservesExitForBufferedMetadataTerminal() async throws {
+        let session = ACPSession(id: "s", agentId: "codex", worktreeId: "w", title: "t")
+        session.apply(.toolCall(.init(
+            toolCallId: "cmd-replay-buffered-exit",
+            title: "swift test",
+            kind: "execute",
+            status: "in_progress",
+            content: nil,
+            locations: nil,
+            rawInput: nil,
+            rawOutput: nil)))
+        session.apply(.toolCallUpdate(.init(
+            toolCallId: "cmd-replay-buffered-exit",
+            status: "in_progress",
+            rawOutput: nil,
+            metadata: AnyCodable([
+                "terminal_output_delta": AnyCodable([
+                    "terminal_id": AnyCodable("term-replay-buffered-exit"),
+                    "data": AnyCodable("building\n")
+                ])
+            ]))))
+
+        session.beginSuppressedReplaySideEffects()
+        session.applySuppressedReplaySideEffects(.toolCallUpdate(.init(
+            toolCallId: "cmd-replay-buffered-exit",
+            status: "in_progress",
+            rawOutput: nil,
+            metadata: AnyCodable([
+                "terminal_output_delta": AnyCodable([
+                    "terminal_id": AnyCodable("term-replay-buffered-exit"),
+                    "data": AnyCodable("building\n")
+                ])
+            ]))))
+        session.applySuppressedReplaySideEffects(.toolCallUpdate(.init(
+            toolCallId: "cmd-replay-buffered-exit",
+            status: "completed",
+            rawOutput: nil,
+            metadata: AnyCodable([
+                "terminal_exit": AnyCodable([
+                    "terminal_id": AnyCodable("term-replay-buffered-exit"),
+                    "exit_code": AnyCodable(0)
+                ])
+            ]))))
+
+        let term = try #require(session.terminalHost.terminal(id: "term-replay-buffered-exit"))
+        #expect(term.snapshot(byteLimit: 1024).text == "building\n")
+        #expect(term.exitStatus == ACPTerminalExitStatus(exitCode: 0, signal: nil))
+    }
+
     @Test("metadata terminal id survives later content-only update")
     func metadataTerminalIdSurvivesLaterContentOnlyUpdate() async throws {
         let session = ACPSession(id: "s", agentId: "codex", worktreeId: "w", title: "t")

--- a/AlasTests/ACP/Session/ACPSessionTests.swift
+++ b/AlasTests/ACP/Session/ACPSessionTests.swift
@@ -1389,10 +1389,62 @@ struct ACPSessionTests {
             rawInput: nil,
             rawOutput: nil)))
         session.apply(update)
+        session.beginSuppressedReplaySideEffects()
         session.applySuppressedReplaySideEffects(update)
 
         let term = try #require(session.terminalHost.terminal(id: "term-replay-terminal"))
         #expect(term.snapshot(byteLimit: 1024).text == "building\n")
+    }
+
+    @Test("suppressed replay rebuilds terminal metadata across replay frames")
+    func suppressedReplayRebuildsTerminalMetadataAcrossReplayFrames() async throws {
+        let session = ACPSession(id: "s", agentId: "codex", worktreeId: "w", title: "t")
+        session.apply(.toolCall(.init(
+            toolCallId: "cmd-replay-frames",
+            title: "swift test",
+            kind: "execute",
+            status: "in_progress",
+            content: nil,
+            locations: nil,
+            rawInput: nil,
+            rawOutput: nil)))
+
+        session.beginSuppressedReplaySideEffects()
+        session.applySuppressedReplaySideEffects(.toolCallUpdate(.init(
+            toolCallId: "cmd-replay-frames",
+            status: "in_progress",
+            rawOutput: nil,
+            metadata: AnyCodable([
+                "terminal_info": AnyCodable([
+                    "terminal_id": AnyCodable("term-replay-frames"),
+                    "cwd": AnyCodable("/tmp/project")
+                ])
+            ]))))
+        session.applySuppressedReplaySideEffects(.toolCallUpdate(.init(
+            toolCallId: "cmd-replay-frames",
+            status: "in_progress",
+            rawOutput: nil,
+            metadata: AnyCodable([
+                "terminal_output_delta": AnyCodable([
+                    "terminal_id": AnyCodable("term-replay-frames"),
+                    "data": AnyCodable("building\n")
+                ])
+            ]))))
+        session.applySuppressedReplaySideEffects(.toolCallUpdate(.init(
+            toolCallId: "cmd-replay-frames",
+            status: "completed",
+            rawOutput: nil,
+            metadata: AnyCodable([
+                "terminal_exit": AnyCodable([
+                    "terminal_id": AnyCodable("term-replay-frames"),
+                    "exit_code": AnyCodable(0)
+                ])
+            ]))))
+
+        let term = try #require(session.terminalHost.terminal(id: "term-replay-frames"))
+        #expect(term.cwd == "/tmp/project")
+        #expect(term.snapshot(byteLimit: 1024).text == "building\n")
+        #expect(term.exitStatus == ACPTerminalExitStatus(exitCode: 0, signal: nil))
     }
 
     @Test("metadata terminal id survives later content-only update")
@@ -1469,6 +1521,47 @@ struct ACPSessionTests {
 
         let term = try #require(session.terminalHost.terminal(id: "term-exit-only"))
         #expect(term.exitStatus == ACPTerminalExitStatus(exitCode: 1, signal: nil))
+    }
+
+    @Test("suppressed replay payload content excludes exit-only terminal id")
+    func suppressedReplayPayloadContentExcludesExitOnlyTerminalId() async throws {
+        let session = ACPSession(id: "s", agentId: "codex", worktreeId: "w", title: "t")
+
+        session.apply(.toolCall(.init(
+            toolCallId: "cmd-payload-exit-content",
+            title: "swift test",
+            kind: "execute",
+            status: "completed",
+            content: [.content(.text("final output"))],
+            locations: nil,
+            rawInput: nil,
+            rawOutput: nil)))
+        session.beginSuppressedReplaySideEffects()
+        session.applySuppressedReplaySideEffects(.toolCall(.init(
+            toolCallId: "cmd-payload-exit-content",
+            title: "swift test",
+            kind: "execute",
+            status: "completed",
+            content: [.content(.text("final output"))],
+            locations: nil,
+            rawInput: nil,
+            rawOutput: nil,
+            metadata: AnyCodable([
+                "terminal_exit": AnyCodable([
+                    "terminal_id": AnyCodable("term-payload-exit-only"),
+                    "exit_code": AnyCodable(0)
+                ])
+            ]))))
+
+        let message = try #require(session.transcript.messages.first)
+        guard case .toolCall(let toolCall) = message else {
+            Issue.record("expected toolCall message")
+            return
+        }
+        #expect(toolCall.terminalIds == [])
+
+        let term = try #require(session.terminalHost.terminal(id: "term-payload-exit-only"))
+        #expect(term.exitStatus == ACPTerminalExitStatus(exitCode: 0, signal: nil))
     }
 
     @Test("terminal_output metadata replaces previous deltas")

--- a/AlasTests/ACP/Session/ACPSessionTests.swift
+++ b/AlasTests/ACP/Session/ACPSessionTests.swift
@@ -1267,6 +1267,40 @@ struct ACPSessionTests {
         }
     }
 
+    @Test("suppressed in-progress tool payload replay preserves terminal ids from content")
+    func suppressedInProgressToolPayloadReplayPreservesTerminalIdsFromContent() async {
+        let session = ACPSession(id: "s", agentId: "bridge", worktreeId: "w", title: "t")
+
+        session.apply(.toolCall(.init(
+            toolCallId: "tc-in-progress-payload-replay-terminal",
+            title: "Final command",
+            kind: "execute",
+            status: "completed",
+            content: [.content(.text("final output"))],
+            locations: nil,
+            rawInput: nil,
+            rawOutput: nil)))
+
+        let touched = session.applySuppressedReplaySideEffects(.toolCall(.init(
+            toolCallId: "tc-in-progress-payload-replay-terminal",
+            title: "Initial command",
+            kind: "execute",
+            status: "in_progress",
+            content: [.terminal(terminalId: "term-in-progress-payload-replay")],
+            locations: nil,
+            rawInput: nil,
+            rawOutput: nil)))
+
+        #expect(touched == [0])
+        if case .toolCall(let tc) = session.transcript.messages[0] {
+            #expect(tc.title == "Final command")
+            #expect(tc.content == "final output")
+            #expect(tc.terminalIds == ["term-in-progress-payload-replay"])
+        } else {
+            Issue.record("expected toolCall message")
+        }
+    }
+
     @Test("content update does not preserve stale content image assets")
     func contentUpdateDoesNotPreserveStaleContentImageAssets() async {
         let session = ACPSession(id: "s", agentId: "codex", worktreeId: "w", title: "t")
@@ -1948,6 +1982,34 @@ struct ACPSessionTests {
             #expect(tc.terminalIds == ["term-99"])
             #expect(tc.content == "")
         } else { Issue.record("expected toolCall message") }
+    }
+
+    @Test("initial toolCall content excludes exit-only terminal id")
+    func toolCallInitialContentExcludesExitOnlyTerminalId() async throws {
+        let session = ACPSession(id: "s", agentId: "bridge", worktreeId: "w", title: "t")
+        session.apply(.toolCall(.init(
+            toolCallId: "tc-initial-exit-content",
+            title: "run",
+            kind: "execute",
+            status: "completed",
+            content: [.content(.text("final output"))],
+            locations: nil,
+            rawInput: nil,
+            rawOutput: nil,
+            metadata: AnyCodable([
+                "terminal_exit": AnyCodable([
+                    "terminal_id": AnyCodable("term-initial-exit-only"),
+                    "exit_code": AnyCodable(0)
+                ])
+            ]))))
+
+        if case .toolCall(let tc) = session.transcript.messages[0] {
+            #expect(tc.terminalIds.isEmpty)
+            #expect(tc.content == "final output")
+        } else { Issue.record("expected toolCall message") }
+
+        let term = try #require(session.terminalHost.terminal(id: "term-initial-exit-only"))
+        #expect(term.exitStatus == ACPTerminalExitStatus(exitCode: 0, signal: nil))
     }
 
     @Test("toolCallUpdate clears stale terminalIds when content has no terminals")

--- a/AlasTests/ACP/Session/ACPSessionTests.swift
+++ b/AlasTests/ACP/Session/ACPSessionTests.swift
@@ -1170,6 +1170,35 @@ struct ACPSessionTests {
         }
     }
 
+    @Test("suppressed final tool replay preserves terminal ids from content")
+    func suppressedFinalToolReplayPreservesTerminalIdsFromContent() async {
+        let session = ACPSession(id: "s", agentId: "bridge", worktreeId: "w", title: "t")
+
+        session.apply(.toolCall(.init(
+            toolCallId: "tc-final-replay-terminal",
+            title: "Final command",
+            kind: "execute",
+            status: "completed",
+            content: [.content(.text("final output"))],
+            locations: nil,
+            rawInput: nil,
+            rawOutput: nil)))
+
+        let touched = session.applySuppressedReplaySideEffects(.toolCallUpdate(.init(
+            toolCallId: "tc-final-replay-terminal",
+            status: "completed",
+            content: [.terminal(terminalId: "term-final-replay")],
+            rawOutput: nil)))
+
+        #expect(touched == [0])
+        if case .toolCall(let tc) = session.transcript.messages[0] {
+            #expect(tc.content == "final output")
+            #expect(tc.terminalIds == ["term-final-replay"])
+        } else {
+            Issue.record("expected toolCall message")
+        }
+    }
+
     @Test("content update does not preserve stale content image assets")
     func contentUpdateDoesNotPreserveStaleContentImageAssets() async {
         let session = ACPSession(id: "s", agentId: "codex", worktreeId: "w", title: "t")

--- a/AlasTests/ACP/Session/ACPSessionTests.swift
+++ b/AlasTests/ACP/Session/ACPSessionTests.swift
@@ -774,6 +774,131 @@ struct ACPSessionTests {
         }
     }
 
+    @Test("tool call metadata routes terminal output and exit")
+    func toolCallMetadataRoutesTerminalOutputAndExit() async throws {
+        let session = ACPSession(id: "s", agentId: "codex", worktreeId: "w", title: "t")
+
+        session.apply(.toolCall(.init(
+            toolCallId: "cmd-meta",
+            title: "swift test",
+            kind: "execute",
+            status: "in_progress",
+            content: [.terminal(terminalId: "cmd-meta")],
+            locations: nil,
+            rawInput: nil,
+            rawOutput: nil,
+            metadata: AnyCodable([
+                "terminal_info": AnyCodable([
+                    "terminal_id": AnyCodable("cmd-meta"),
+                    "cwd": AnyCodable("/repo")
+                ])
+            ]))))
+        session.apply(.toolCallUpdate(.init(
+            toolCallId: "cmd-meta",
+            status: "completed",
+            rawOutput: nil,
+            metadata: AnyCodable([
+                "terminal_output_delta": AnyCodable([
+                    "terminal_id": AnyCodable("cmd-meta"),
+                    "data": AnyCodable("ok\n")
+                ]),
+                "terminal_exit": AnyCodable([
+                    "terminal_id": AnyCodable("cmd-meta"),
+                    "exit_code": AnyCodable(0),
+                    "signal": AnyCodable(NSNull())
+                ])
+            ]))))
+
+        let term = try #require(session.terminalHost.terminal(id: "cmd-meta"))
+        #expect(term.snapshot(byteLimit: 1024).text == "ok\n")
+        #expect(term.exitStatus == ACPTerminalExitStatus(exitCode: 0, signal: nil))
+    }
+
+    @Test("terminal_output metadata replaces previous deltas")
+    func terminalOutputMetadataReplacesPreviousDeltas() async throws {
+        let session = ACPSession(id: "s", agentId: "codex", worktreeId: "w", title: "t")
+
+        session.apply(.toolCall(.init(
+            toolCallId: "cmd-replace",
+            title: "swift test",
+            kind: "execute",
+            status: "in_progress",
+            content: [.terminal(terminalId: "cmd-replace")],
+            locations: nil,
+            rawInput: nil,
+            rawOutput: nil)))
+        session.apply(.toolCallUpdate(.init(
+            toolCallId: "cmd-replace",
+            status: "in_progress",
+            rawOutput: nil,
+            metadata: AnyCodable([
+                "terminal_output_delta": AnyCodable([
+                    "terminal_id": AnyCodable("cmd-replace"),
+                    "data": AnyCodable("stale\n")
+                ])
+            ]))))
+        session.apply(.toolCallUpdate(.init(
+            toolCallId: "cmd-replace",
+            status: "completed",
+            rawOutput: nil,
+            metadata: AnyCodable([
+                "terminal_output": AnyCodable([
+                    "terminal_id": AnyCodable("cmd-replace"),
+                    "data": AnyCodable("fresh\n")
+                ])
+            ]))))
+
+        let term = try #require(session.terminalHost.terminal(id: "cmd-replace"))
+        #expect(term.snapshot(byteLimit: 1024).text == "fresh\n")
+    }
+
+    @Test("terminal metadata accepts raw Swift dictionaries")
+    func terminalMetadataAcceptsRawSwiftDictionaries() async throws {
+        let session = ACPSession(id: "s", agentId: "codex", worktreeId: "w", title: "t")
+
+        session.apply(.toolCall(.init(
+            toolCallId: "cmd-raw-meta",
+            title: "swift test",
+            kind: "execute",
+            status: "in_progress",
+            content: [.terminal(terminalId: "cmd-raw-meta")],
+            locations: nil,
+            rawInput: nil,
+            rawOutput: nil)))
+        session.apply(.toolCallUpdate(.init(
+            toolCallId: "cmd-raw-meta",
+            status: "completed",
+            rawOutput: nil,
+            metadata: AnyCodable([
+                "terminal_output_delta": [
+                    "terminal_id": "cmd-raw-meta",
+                    "data": "raw\n"
+                ]
+            ]))))
+
+        let term = try #require(session.terminalHost.terminal(id: "cmd-raw-meta"))
+        #expect(term.snapshot(byteLimit: 1024).text == "raw\n")
+    }
+
+    @Test("unknown tool call metadata does not create detached terminal")
+    func unknownToolCallMetadataDoesNotCreateDetachedTerminal() async {
+        let session = ACPSession(id: "s", agentId: "codex", worktreeId: "w", title: "t")
+
+        let touched = session.apply(.toolCallUpdate(.init(
+            toolCallId: "missing",
+            status: "completed",
+            rawOutput: nil,
+            metadata: AnyCodable([
+                "terminal_output_delta": AnyCodable([
+                    "terminal_id": AnyCodable("missing"),
+                    "data": AnyCodable("orphan\n")
+                ])
+            ]))))
+
+        #expect(touched.isEmpty)
+        #expect(session.terminalHost.terminal(id: "missing") == nil)
+    }
+
     @Test("toolCall content preserves embedded resource text and asset")
     func toolCallPreservesEmbeddedResourceTextAndAsset() async {
         let session = ACPSession(id: "s", agentId: "claude", worktreeId: "w", title: "t")

--- a/AlasTests/ACP/Session/ACPSessionTests.swift
+++ b/AlasTests/ACP/Session/ACPSessionTests.swift
@@ -857,6 +857,45 @@ struct ACPSessionTests {
         }
     }
 
+    @Test("raw output image asset survives later content update")
+    func rawOutputImageAssetSurvivesLaterContentUpdate() async {
+        let session = ACPSession(id: "s", agentId: "codex", worktreeId: "w", title: "t")
+
+        session.apply(.toolCall(.init(
+            toolCallId: "tc-raw-image-update",
+            title: "Image generation",
+            kind: "other",
+            status: "in_progress",
+            content: nil,
+            locations: nil,
+            rawInput: nil,
+            rawOutput: nil)))
+        session.apply(.toolCallUpdate(.init(
+            toolCallId: "tc-raw-image-update",
+            status: "in_progress",
+            rawOutput: AnyCodable([
+                "data": AnyCodable([
+                    AnyCodable([
+                        "b64_json": AnyCodable("base64-data")
+                    ])
+                ])
+            ]))))
+        session.apply(.toolCallUpdate(.init(
+            toolCallId: "tc-raw-image-update",
+            status: "completed",
+            content: [.content(.text("final output"))],
+            rawOutput: nil)))
+
+        if case .toolCall(let tc) = session.transcript.messages[0] {
+            #expect(tc.content == "final output")
+            #expect(tc.assets == [
+                ACPMessage.ToolCallAsset.image(data: "base64-data", mimeType: "image/png")
+            ])
+        } else {
+            Issue.record("expected toolCall message")
+        }
+    }
+
     @Test("toolCallUpdate merges metadata with existing tool metadata")
     func toolCallUpdateMergesMetadataWithExistingToolMetadata() async throws {
         let session = ACPSession(id: "s", agentId: "claude", worktreeId: "w", title: "t")

--- a/AlasTests/ACP/Session/ACPSessionTests.swift
+++ b/AlasTests/ACP/Session/ACPSessionTests.swift
@@ -857,6 +857,40 @@ struct ACPSessionTests {
         }
     }
 
+    @Test("raw output image URL result is preserved as an asset")
+    func rawOutputImageURLResultPreservesAsset() async {
+        let session = ACPSession(id: "s", agentId: "codex", worktreeId: "w", title: "t")
+
+        session.apply(.toolCall(.init(
+            toolCallId: "tc-raw-image-url",
+            title: "Image generation",
+            kind: "other",
+            status: "completed",
+            content: nil,
+            locations: nil,
+            rawInput: nil,
+            rawOutput: AnyCodable([
+                "data": AnyCodable([
+                    AnyCodable([
+                        "url": AnyCodable("https://example.com/generated"),
+                        "revised_prompt": AnyCodable("A useful screenshot")
+                    ])
+                ])
+            ]))))
+
+        if case .toolCall(let tc) = session.transcript.messages[0] {
+            #expect(tc.assets == [
+                ACPMessage.ToolCallAsset.image(
+                    data: nil,
+                    uri: "https://example.com/generated",
+                    mimeType: nil,
+                    name: "generated")
+            ])
+        } else {
+            Issue.record("expected toolCall message")
+        }
+    }
+
     @Test("raw output image asset survives later content update")
     func rawOutputImageAssetSurvivesLaterContentUpdate() async {
         let session = ACPSession(id: "s", agentId: "codex", worktreeId: "w", title: "t")

--- a/AlasTests/ACP/Session/ACPSessionTests.swift
+++ b/AlasTests/ACP/Session/ACPSessionTests.swift
@@ -825,6 +825,38 @@ struct ACPSessionTests {
         }
     }
 
+    @Test("raw output image result is preserved as an asset")
+    func rawOutputImageResultPreservesAsset() async {
+        let session = ACPSession(id: "s", agentId: "codex", worktreeId: "w", title: "t")
+
+        session.apply(.toolCall(.init(
+            toolCallId: "tc-raw-image",
+            title: "Image generation",
+            kind: "other",
+            status: "completed",
+            content: nil,
+            locations: nil,
+            rawInput: nil,
+            rawOutput: AnyCodable([
+                "created": AnyCodable(1),
+                "data": AnyCodable([
+                    AnyCodable([
+                        "b64_json": AnyCodable("base64-data"),
+                        "revised_prompt": AnyCodable("A useful screenshot")
+                    ])
+                ])
+            ]))))
+
+        if case .toolCall(let tc) = session.transcript.messages[0] {
+            #expect(tc.rawOutput?.contains(#""b64_json":"base64-data""#) == true)
+            #expect(tc.assets == [
+                ACPMessage.ToolCallAsset.image(data: "base64-data", mimeType: "image/png")
+            ])
+        } else {
+            Issue.record("expected toolCall message")
+        }
+    }
+
     @Test("toolCallUpdate merges metadata with existing tool metadata")
     func toolCallUpdateMergesMetadataWithExistingToolMetadata() async throws {
         let session = ACPSession(id: "s", agentId: "claude", worktreeId: "w", title: "t")

--- a/AlasTests/ACP/Session/ACPSessionTests.swift
+++ b/AlasTests/ACP/Session/ACPSessionTests.swift
@@ -1132,7 +1132,7 @@ struct ACPSessionTests {
         let touched = session.applySuppressedReplaySideEffects(.toolCallUpdate(.init(
             toolCallId: "tc-update-replay-downgrade",
             status: "in_progress",
-            content: [.content(.text("partial output"))],
+            content: [.content(.image(data: "stale-content-data", uri: nil, mimeType: "image/png"))],
             rawOutput: AnyCodable([
                 "data": AnyCodable([
                     AnyCodable([
@@ -1365,6 +1365,36 @@ struct ACPSessionTests {
         #expect(term.snapshot(byteLimit: 1024).text == "ok\n")
     }
 
+    @Test("suppressed replay does not duplicate existing terminal metadata output")
+    func suppressedReplayDoesNotDuplicateExistingTerminalMetadataOutput() async throws {
+        let session = ACPSession(id: "s", agentId: "codex", worktreeId: "w", title: "t")
+        let update = ACPSessionUpdate.toolCallUpdate(.init(
+            toolCallId: "cmd-replay-terminal",
+            status: "in_progress",
+            rawOutput: nil,
+            metadata: AnyCodable([
+                "terminal_output_delta": AnyCodable([
+                    "terminal_id": AnyCodable("term-replay-terminal"),
+                    "data": AnyCodable("building\n")
+                ])
+            ])))
+
+        session.apply(.toolCall(.init(
+            toolCallId: "cmd-replay-terminal",
+            title: "swift test",
+            kind: "execute",
+            status: "in_progress",
+            content: nil,
+            locations: nil,
+            rawInput: nil,
+            rawOutput: nil)))
+        session.apply(update)
+        session.applySuppressedReplaySideEffects(update)
+
+        let term = try #require(session.terminalHost.terminal(id: "term-replay-terminal"))
+        #expect(term.snapshot(byteLimit: 1024).text == "building\n")
+    }
+
     @Test("metadata terminal id survives later content-only update")
     func metadataTerminalIdSurvivesLaterContentOnlyUpdate() async throws {
         let session = ACPSession(id: "s", agentId: "codex", worktreeId: "w", title: "t")
@@ -1404,6 +1434,41 @@ struct ACPSessionTests {
 
         let term = try #require(session.terminalHost.terminal(id: "term-meta-then-content"))
         #expect(term.snapshot(byteLimit: 1024).text == "building\n")
+    }
+
+    @Test("terminal exit metadata-only update attaches terminal id to tool call")
+    func terminalExitMetadataOnlyUpdateAttachesTerminalIdToToolCall() async throws {
+        let session = ACPSession(id: "s", agentId: "codex", worktreeId: "w", title: "t")
+
+        session.apply(.toolCall(.init(
+            toolCallId: "cmd-exit-only",
+            title: "swift test",
+            kind: "execute",
+            status: "in_progress",
+            content: nil,
+            locations: nil,
+            rawInput: nil,
+            rawOutput: nil)))
+        session.apply(.toolCallUpdate(.init(
+            toolCallId: "cmd-exit-only",
+            status: "completed",
+            rawOutput: nil,
+            metadata: AnyCodable([
+                "terminal_exit": AnyCodable([
+                    "terminal_id": AnyCodable("term-exit-only"),
+                    "exit_code": AnyCodable(1)
+                ])
+            ]))))
+
+        let message = try #require(session.transcript.messages.first)
+        guard case .toolCall(let toolCall) = message else {
+            Issue.record("expected toolCall message")
+            return
+        }
+        #expect(toolCall.terminalIds == ["term-exit-only"])
+
+        let term = try #require(session.terminalHost.terminal(id: "term-exit-only"))
+        #expect(term.exitStatus == ACPTerminalExitStatus(exitCode: 1, signal: nil))
     }
 
     @Test("terminal_output metadata replaces previous deltas")

--- a/AlasTests/ACP/Terminal/ACPTerminalHostTests.swift
+++ b/AlasTests/ACP/Terminal/ACPTerminalHostTests.swift
@@ -187,6 +187,30 @@ struct ACPTerminalHostTests {
         #expect(host.terminal(id: "meta-\(ACPTerminalHost.maxMetadataTerminals)") != nil)
     }
 
+    @Test("finished metadata terminal retention does not prune process terminals")
+    func finishedMetadataTerminalRetentionDoesNotPruneProcessTerminals() async throws {
+        let host = ACPTerminalHost(sessionCwd: "/tmp", sessionEnv: [:])
+        let process = try host.create(.init(
+            sessionId: "s",
+            command: "/bin/echo",
+            args: ["process-output"],
+            env: nil,
+            cwd: nil,
+            outputByteLimit: nil
+        ))
+        _ = await host.terminal(id: process.terminalId)?.waitForExit()
+
+        for i in 0 ... ACPTerminalHost.maxMetadataTerminals {
+            host.recordMetadataExit(
+                terminalId: "meta-finished-\(i)",
+                exitStatus: ACPTerminalExitStatus(exitCode: 0, signal: nil))
+        }
+
+        #expect(host.terminal(id: process.terminalId) != nil)
+        #expect(host.terminal(id: "meta-finished-0") == nil)
+        #expect(host.terminal(id: "meta-finished-\(ACPTerminalHost.maxMetadataTerminals)") != nil)
+    }
+
     #if DEBUG
     @Test("retained byte estimate includes terminal buffers")
     func retainedByteEstimateIncludesTerminalBuffers() async throws {

--- a/AlasTests/ACP/Terminal/ACPTerminalHostTests.swift
+++ b/AlasTests/ACP/Terminal/ACPTerminalHostTests.swift
@@ -172,6 +172,21 @@ struct ACPTerminalHostTests {
         #expect(host.terminals.count == ACPTerminalHost.maxRetainedFinishedTerminals)
     }
 
+    @Test("unfinished metadata terminal retention is capped")
+    func unfinishedMetadataTerminalRetentionIsCapped() throws {
+        let host = ACPTerminalHost(sessionCwd: "/tmp", sessionEnv: [:])
+        for i in 0 ... ACPTerminalHost.maxMetadataTerminals {
+            host.appendMetadataOutput(
+                terminalId: "meta-\(i)",
+                data: Data("output-\(i)\n".utf8),
+                replace: false)
+        }
+
+        #expect(host.terminals.count == ACPTerminalHost.maxMetadataTerminals)
+        #expect(host.terminal(id: "meta-0") == nil)
+        #expect(host.terminal(id: "meta-\(ACPTerminalHost.maxMetadataTerminals)") != nil)
+    }
+
     #if DEBUG
     @Test("retained byte estimate includes terminal buffers")
     func retainedByteEstimateIncludesTerminalBuffers() async throws {

--- a/AlasTests/ACP/Terminal/ACPTerminalHostTests.swift
+++ b/AlasTests/ACP/Terminal/ACPTerminalHostTests.swift
@@ -26,6 +26,53 @@ struct ACPTerminalHostTests {
         }
     }
 
+    @Test("metadata terminal appends output and records exit")
+    func metadataTerminalAppendsOutputAndExit() async throws {
+        let host = ACPTerminalHost(sessionCwd: "/tmp", sessionEnv: [:])
+
+        host.recordMetadataTerminalInfo(terminalId: "meta-1", cwd: "/repo")
+        host.appendMetadataOutput(
+            terminalId: "meta-1",
+            data: Data("first\nsecond\n".utf8),
+            replace: false)
+        host.recordMetadataExit(
+            terminalId: "meta-1",
+            exitStatus: ACPTerminalExitStatus(exitCode: 7, signal: nil))
+
+        let term = try #require(host.terminal(id: "meta-1"))
+        #expect(term.snapshot(byteLimit: 1024).text == "first\nsecond\n")
+        #expect(term.exitStatus == ACPTerminalExitStatus(exitCode: 7, signal: nil))
+        #expect(throws: ACPTerminalHostError.notFound("meta-1")) {
+            _ = try host.output(.init(sessionId: "s", terminalId: "meta-1"))
+        }
+        await #expect(throws: ACPTerminalHostError.notFound("meta-1")) {
+            _ = try await host.waitForExit(.init(sessionId: "s", terminalId: "meta-1"))
+        }
+        #expect(throws: ACPTerminalHostError.notFound("meta-1")) {
+            try host.kill(.init(sessionId: "s", terminalId: "meta-1"))
+        }
+        #expect(throws: ACPTerminalHostError.notFound("meta-1")) {
+            try host.release(.init(sessionId: "s", terminalId: "meta-1"))
+        }
+    }
+
+    @Test("metadata terminal replacement overwrites output")
+    func metadataTerminalReplacementOverwritesOutput() throws {
+        let host = ACPTerminalHost(sessionCwd: "/tmp", sessionEnv: [:])
+
+        host.appendMetadataOutput(
+            terminalId: "meta-2",
+            data: Data("stale\n".utf8),
+            replace: false)
+        host.appendMetadataOutput(
+            terminalId: "meta-2",
+            data: Data("fresh\n".utf8),
+            replace: true)
+
+        let term = try #require(host.terminal(id: "meta-2"))
+        #expect(term.snapshot(byteLimit: 1024).text == "fresh\n")
+    }
+
     @Test("release retains the entry but invalidates the id for protocol calls")
     func releaseRetainsForUI() async throws {
         let host = ACPTerminalHost(sessionCwd: "/tmp", sessionEnv: [:])

--- a/AlasTests/ACP/UI/ACPGoalPillTests.swift
+++ b/AlasTests/ACP/UI/ACPGoalPillTests.swift
@@ -1,0 +1,46 @@
+import Foundation
+import Testing
+@testable import Alas
+
+@Suite("ACPGoalPill")
+struct ACPGoalPillTests {
+    @Test("summary includes objective, normalized status, and rounded token budget")
+    func summaryWithStatusAndBudget() {
+        let goal = ACPGoalState(
+            objective: "Surface richer events",
+            status: "in_progress",
+            tokenBudget: 12_000
+        )
+
+        #expect(ACPGoalPill.summary(goal) == "Goal: Surface richer events · in progress · 12k")
+    }
+
+    @Test("summary truncates long objectives")
+    func summaryTruncatesLongObjective() {
+        let objective = String(repeating: "a", count: 61)
+        let goal = ACPGoalState(objective: objective, status: "in_progress", tokenBudget: nil)
+
+        #expect(ACPGoalPill.summary(goal) == "Goal: \(String(repeating: "a", count: 60))… · in progress")
+    }
+
+    @Test("summary omits nil status")
+    func summaryOmitsNilStatus() {
+        let goal = ACPGoalState(objective: "Ship transcript UI", status: nil, tokenBudget: 8_000)
+
+        #expect(ACPGoalPill.summary(goal) == "Goal: Ship transcript UI · 8k")
+    }
+
+    @Test("summary keeps one decimal for non-round token budgets")
+    func summaryFormatsNonRoundTokenBudget() {
+        let goal = ACPGoalState(objective: "Ship transcript UI", status: "done", tokenBudget: 12_500)
+
+        #expect(ACPGoalPill.summary(goal) == "Goal: Ship transcript UI · done · 12.5k")
+    }
+
+    @Test("summary keeps sub-thousand token budgets numeric")
+    func summaryFormatsSmallTokenBudget() {
+        let goal = ACPGoalState(objective: "Ship transcript UI", status: "done", tokenBudget: 999)
+
+        #expect(ACPGoalPill.summary(goal) == "Goal: Ship transcript UI · done · 999")
+    }
+}

--- a/AlasTests/ACP/UI/ACPToolCallPresentationTests.swift
+++ b/AlasTests/ACP/UI/ACPToolCallPresentationTests.swift
@@ -1,0 +1,177 @@
+import Foundation
+import Testing
+@testable import Alas
+
+@Suite("ACPToolCallPresentation")
+struct ACPToolCallPresentationTests {
+    @Test("web search title maps to web search presentation")
+    func webSearchPresentation() {
+        let presentation = ACPToolCallPresentation.resolve(toolCall(
+            title: "Web search: Swift Testing",
+            kind: "search"
+        ))
+
+        #expect(presentation.label == "Web Search")
+        #expect(presentation.iconSystemName == "globe")
+        #expect(presentation.style == .webSearch)
+    }
+
+    @Test("open page title maps to opened page presentation")
+    func openPagePresentation() {
+        let presentation = ACPToolCallPresentation.resolve(toolCall(
+            title: "Open page https://example.com",
+            kind: "search"
+        ))
+
+        #expect(presentation.label == "Opened Page")
+        #expect(presentation.iconSystemName == "safari")
+        #expect(presentation.style == .webSearch)
+    }
+
+    @Test("find in page title maps to find presentation")
+    func findInPagePresentation() {
+        let presentation = ACPToolCallPresentation.resolve(toolCall(
+            title: "Find in page installation",
+            kind: "search"
+        ))
+
+        #expect(presentation.label == "Find")
+        #expect(presentation.iconSystemName == "text.magnifyingglass")
+        #expect(presentation.style == .webSearch)
+    }
+
+    @Test("image generation title with image asset maps to image presentation")
+    func imageGenerationPresentation() {
+        let presentation = ACPToolCallPresentation.resolve(toolCall(
+            title: "Image generation",
+            assets: [.image(data: "iVBORw0KGgo=", mimeType: "image/png")]
+        ))
+
+        #expect(presentation.label == "Image")
+        #expect(presentation.iconSystemName == "photo")
+        #expect(presentation.style == .image)
+    }
+
+    @Test("image generation title with image raw output maps to image presentation")
+    func imageGenerationRawOutputPresentation() {
+        let presentation = ACPToolCallPresentation.resolve(toolCall(
+            title: "Image generation",
+            rawOutput: #"{"b64_json":"iVBORw0KGgo="}"#
+        ))
+
+        #expect(presentation.label == "Image")
+        #expect(presentation.iconSystemName == "photo")
+        #expect(presentation.style == .image)
+    }
+
+    @Test("read tool with image path maps to viewed image presentation")
+    func viewedImagePresentation() {
+        let presentation = ACPToolCallPresentation.resolve(toolCall(
+            title: "read_image",
+            kind: "read",
+            assets: [.resource(uri: "file:///tmp/screenshot.png", name: "screenshot.png", mimeType: "image/png")]
+        ))
+
+        #expect(presentation.label == "Viewed Image")
+        #expect(presentation.iconSystemName == "photo.on.rectangle")
+        #expect(presentation.style == .image)
+    }
+
+    @Test("MCP metadata maps to MCP presentation")
+    func mcpMetadataPresentation() {
+        let presentation = ACPToolCallPresentation.resolve(toolCall(
+            title: "read_file",
+            metadata: AnyCodable(["is_mcp_tool_call": true])
+        ))
+
+        #expect(presentation.label == "MCP")
+        #expect(presentation.iconSystemName == "point.3.connected.trianglepath.dotted")
+        #expect(presentation.style == .mcp)
+    }
+
+    @Test("MCP title prefix maps to MCP presentation")
+    func mcpTitlePresentation() {
+        let presentation = ACPToolCallPresentation.resolve(toolCall(
+            title: "mcp__filesystem__read_file"
+        ))
+
+        #expect(presentation.label == "MCP")
+        #expect(presentation.iconSystemName == "point.3.connected.trianglepath.dotted")
+        #expect(presentation.style == .mcp)
+    }
+
+    @Test("guardian review title maps to review presentation")
+    func guardianReviewPresentation() {
+        let presentation = ACPToolCallPresentation.resolve(toolCall(
+            title: "Guardian Review"
+        ))
+
+        #expect(presentation.label == "Review")
+        #expect(presentation.iconSystemName == "checkmark.shield")
+        #expect(presentation.style == .review)
+    }
+
+    @Test("think kind maps to review presentation")
+    func thinkKindPresentation() {
+        let presentation = ACPToolCallPresentation.resolve(toolCall(
+            title: "Reasoning",
+            kind: "think"
+        ))
+
+        #expect(presentation.label == "Review")
+        #expect(presentation.iconSystemName == "checkmark.shield")
+        #expect(presentation.style == .review)
+    }
+
+    @Test("execute kind keeps existing run fallback")
+    func executeFallbackPresentation() {
+        let presentation = ACPToolCallPresentation.resolve(toolCall(
+            title: "bash",
+            kind: "execute"
+        ))
+
+        #expect(presentation.label == "Ran")
+        #expect(presentation.iconSystemName == "terminal")
+        #expect(presentation.style == .generic)
+    }
+
+    @Test("generic fallbacks keep existing labels")
+    func genericFallbackPresentation() {
+        let cases: [(kind: String?, label: String, icon: String)] = [
+            ("read", "Read", "doc.text"),
+            ("search", "Searched", "magnifyingglass"),
+            ("run", "Ran", "terminal"),
+            ("edit", "Edit", "pencil"),
+            (nil, "Tool", "gearshape")
+        ]
+
+        for item in cases {
+            let presentation = ACPToolCallPresentation.resolve(toolCall(
+                title: item.label,
+                kind: item.kind
+            ))
+
+            #expect(presentation.label == item.label)
+            #expect(presentation.iconSystemName == item.icon)
+            #expect(presentation.style == .generic)
+        }
+    }
+
+    private func toolCall(
+        title: String,
+        kind: String? = nil,
+        rawOutput: String? = nil,
+        metadata: AnyCodable? = nil,
+        assets: [ACPMessage.ToolCallAsset] = []
+    ) -> ACPMessage.ToolCall {
+        ACPMessage.ToolCall(
+            toolCallId: UUID().uuidString,
+            title: title,
+            kind: kind,
+            status: "completed",
+            rawOutput: rawOutput,
+            metadata: metadata,
+            assets: assets
+        )
+    }
+}

--- a/AlasTests/ACP/UI/ACPToolCallPresentationTests.swift
+++ b/AlasTests/ACP/UI/ACPToolCallPresentationTests.swift
@@ -65,6 +65,19 @@ struct ACPToolCallPresentationTests {
         #expect(presentation.style == .image)
     }
 
+    @Test("image data URI assets do not expose URI as display text")
+    func imageDataURIAssetDisplayText() {
+        let asset = ACPMessage.ToolCallAsset.image(
+            data: nil,
+            uri: " \ndata:image/png;base64,\(String(repeating: "A", count: 128))",
+            mimeType: "image/png",
+            name: nil)
+
+        #expect(asset.displayTitle == "Image")
+        #expect(asset.displayDetail == nil)
+        #expect(asset.displayText == "Image")
+    }
+
     @Test("read tool with image path maps to viewed image presentation")
     func viewedImagePresentation() {
         let presentation = ACPToolCallPresentation.resolve(toolCall(

--- a/AlasTests/ACP/UI/ACPToolCallPresentationTests.swift
+++ b/AlasTests/ACP/UI/ACPToolCallPresentationTests.swift
@@ -1,3 +1,4 @@
+import AppKit
 import Foundation
 import Testing
 @testable import Alas
@@ -157,6 +158,31 @@ struct ACPToolCallPresentationTests {
         }
     }
 
+    @Test("relative image resource loads under trusted root")
+    func relativeImageResourceLoadsUnderTrustedRoot() throws {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("acp-tool-asset-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let imageURL = root
+            .appendingPathComponent("screenshots", isDirectory: true)
+            .appendingPathComponent("out.png")
+        try FileManager.default.createDirectory(
+            at: imageURL.deletingLastPathComponent(),
+            withIntermediateDirectories: true)
+        try writePNG(width: 12, height: 8, to: imageURL)
+
+        let asset = ACPMessage.ToolCallAsset.resource(
+            uri: "screenshots/out.png",
+            name: "out.png",
+            mimeType: "image/png")
+
+        let image = try #require(asset.loadedImage(trustedRoot: root))
+        #expect(image.size.width > 0)
+        #expect(image.size.height > 0)
+    }
+
     private func toolCall(
         title: String,
         kind: String? = nil,
@@ -173,5 +199,26 @@ struct ACPToolCallPresentationTests {
             metadata: metadata,
             assets: assets
         )
+    }
+
+    private func writePNG(width: Int, height: Int, to url: URL) throws {
+        let rep = try #require(NSBitmapImageRep(
+            bitmapDataPlanes: nil,
+            pixelsWide: width,
+            pixelsHigh: height,
+            bitsPerSample: 8,
+            samplesPerPixel: 4,
+            hasAlpha: true,
+            isPlanar: false,
+            colorSpaceName: .deviceRGB,
+            bytesPerRow: 0,
+            bitsPerPixel: 0))
+        NSGraphicsContext.saveGraphicsState()
+        NSGraphicsContext.current = NSGraphicsContext(bitmapImageRep: rep)
+        NSColor.red.setFill()
+        NSRect(x: 0, y: 0, width: width, height: height).fill()
+        NSGraphicsContext.restoreGraphicsState()
+        let png = try #require(rep.representation(using: .png, properties: [:]))
+        try png.write(to: url)
     }
 }

--- a/AlasTests/Remote/RemoteSessionGatewayTests.swift
+++ b/AlasTests/Remote/RemoteSessionGatewayTests.swift
@@ -827,7 +827,7 @@ struct RemoteSessionGatewayTests {
                 ),
                 .image(
                     data: nil,
-                    uri: "data:image/png;base64,inline-uri-data",
+                    uri: " \ndata:image/png;base64,inline-uri-data",
                     mimeType: "image/png",
                     name: "inline-uri.png"
                 )

--- a/AlasTests/Remote/RemoteSessionGatewayTests.swift
+++ b/AlasTests/Remote/RemoteSessionGatewayTests.swift
@@ -863,10 +863,11 @@ struct RemoteSessionGatewayTests {
                 mimeType: "image/png",
                 name: "inline-uri.png"
             ),
-            .resource(
+            .init(
+                kind: .resource,
                 uri: nil,
-                name: "inline-resource.json",
-                mimeType: "application/json"
+                mimeType: "application/json",
+                name: "inline-resource.json"
             )
         ])
     }

--- a/AlasTests/Remote/RemoteSessionGatewayTests.swift
+++ b/AlasTests/Remote/RemoteSessionGatewayTests.swift
@@ -830,6 +830,11 @@ struct RemoteSessionGatewayTests {
                     uri: " \ndata:image/png;base64,inline-uri-data",
                     mimeType: "image/png",
                     name: "inline-uri.png"
+                ),
+                .resource(
+                    uri: "data:application/json;base64,inline-resource-data",
+                    name: "inline-resource.json",
+                    mimeType: "application/json"
                 )
             ]))
 
@@ -837,6 +842,7 @@ struct RemoteSessionGatewayTests {
         let json = try #require(wire.json)
         #expect(!json.contains("base64-image-data"))
         #expect(!json.contains("inline-uri-data"))
+        #expect(!json.contains("inline-resource-data"))
         #expect(!json.contains("raw-output-base64"))
         #expect(!json.contains("large terminal output"))
 
@@ -856,6 +862,11 @@ struct RemoteSessionGatewayTests {
                 uri: nil,
                 mimeType: "image/png",
                 name: "inline-uri.png"
+            ),
+            .resource(
+                uri: nil,
+                name: "inline-resource.json",
+                mimeType: "application/json"
             )
         ])
     }

--- a/AlasTests/Remote/RemoteSessionGatewayTests.swift
+++ b/AlasTests/Remote/RemoteSessionGatewayTests.swift
@@ -811,6 +811,13 @@ struct RemoteSessionGatewayTests {
             status: "completed",
             content: "",
             preview: nil,
+            rawOutput: #"{"b64_json":"raw-output-base64"}"#,
+            metadata: AnyCodable([
+                "terminal_output_delta": AnyCodable([
+                    "terminal_id": AnyCodable("term-remote"),
+                    "data": AnyCodable("large terminal output")
+                ])
+            ]),
             assets: [
                 .image(
                     data: "base64-image-data",
@@ -823,9 +830,13 @@ struct RemoteSessionGatewayTests {
         let wire = RemoteSessionGateway.toWire(msg, index: 0)
         let json = try #require(wire.json)
         #expect(!json.contains("base64-image-data"))
+        #expect(!json.contains("raw-output-base64"))
+        #expect(!json.contains("large terminal output"))
 
         let payload = try #require(json.data(using: .utf8))
         let decoded = try JSONDecoder().decode(ACPMessage.ToolCall.self, from: payload)
+        #expect(decoded.rawOutput == nil)
+        #expect(decoded.metadata == nil)
         #expect(decoded.assets == [
             .image(
                 data: nil,

--- a/AlasTests/Remote/RemoteSessionGatewayTests.swift
+++ b/AlasTests/Remote/RemoteSessionGatewayTests.swift
@@ -803,6 +803,39 @@ struct RemoteSessionGatewayTests {
         #expect((wire.text ?? "").isEmpty == false)
     }
 
+    @Test func toolCallWireOmitsInlineAssetData() throws {
+        let msg = ACPMessage.toolCall(.init(
+            toolCallId: "tc-image",
+            title: "Image generation",
+            kind: "other",
+            status: "completed",
+            content: "",
+            preview: nil,
+            assets: [
+                .image(
+                    data: "base64-image-data",
+                    uri: "file:///tmp/shot.png",
+                    mimeType: "image/png",
+                    name: "shot.png"
+                )
+            ]))
+
+        let wire = RemoteSessionGateway.toWire(msg, index: 0)
+        let json = try #require(wire.json)
+        #expect(!json.contains("base64-image-data"))
+
+        let payload = try #require(json.data(using: .utf8))
+        let decoded = try JSONDecoder().decode(ACPMessage.ToolCall.self, from: payload)
+        #expect(decoded.assets == [
+            .image(
+                data: nil,
+                uri: "file:///tmp/shot.png",
+                mimeType: "image/png",
+                name: "shot.png"
+            )
+        ])
+    }
+
     @Test func tooManyAttachmentsRejected() async {
         // Count cap (parity with ACPComposer.maxImagesPerMessage) — a single
         // prompt can't write an unbounded number of tiny files.

--- a/AlasTests/Remote/RemoteSessionGatewayTests.swift
+++ b/AlasTests/Remote/RemoteSessionGatewayTests.swift
@@ -824,12 +824,19 @@ struct RemoteSessionGatewayTests {
                     uri: "file:///tmp/shot.png",
                     mimeType: "image/png",
                     name: "shot.png"
+                ),
+                .image(
+                    data: nil,
+                    uri: "data:image/png;base64,inline-uri-data",
+                    mimeType: "image/png",
+                    name: "inline-uri.png"
                 )
             ]))
 
         let wire = RemoteSessionGateway.toWire(msg, index: 0)
         let json = try #require(wire.json)
         #expect(!json.contains("base64-image-data"))
+        #expect(!json.contains("inline-uri-data"))
         #expect(!json.contains("raw-output-base64"))
         #expect(!json.contains("large terminal output"))
 
@@ -843,6 +850,12 @@ struct RemoteSessionGatewayTests {
                 uri: "file:///tmp/shot.png",
                 mimeType: "image/png",
                 name: "shot.png"
+            ),
+            .image(
+                data: nil,
+                uri: nil,
+                mimeType: "image/png",
+                name: "inline-uri.png"
             )
         ])
     }

--- a/docs/superpowers/plans/2026-07-03-acp-transcript-event-enrichment.md
+++ b/docs/superpowers/plans/2026-07-03-acp-transcript-event-enrichment.md
@@ -1,0 +1,1577 @@
+# ACP Transcript Event Enrichment Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Preserve richer ACP session/tool metadata and render Codex-style enriched transcript events through generic ACP presentation paths.
+
+**Architecture:** Decode enriched protocol fields first, then make `ACPSession.apply(_:)` the only place that maps them into runtime state and transcript rows. Keep UI polish in focused presentation/rendering helpers so `ACPToolCallCard` consumes classified display data instead of growing provider-specific branches.
+
+**Tech Stack:** Swift 5.9+, SwiftUI, Combine, Swift Testing, existing ACP JSON-RPC protocol models, existing `ACPTerminalHost`/`ACPTerminalTailView` transcript UI.
+
+---
+
+## File Structure
+
+- Modify `Alas/Sources/ACP/Protocol/ACPSessionUpdate.swift`
+  - Decode `session_info_update`.
+  - Preserve `_meta` on tool-call create/update payloads.
+  - Decode update-time `title`, `locations`, `rawInput`, and `rawOutput`.
+- Modify `Alas/Sources/ACP/Protocol/ACPMessages.swift`
+  - Keep `AnyCodable` as the metadata transport used by enriched session and tool-call updates.
+  - Preserve image/resource block data already decoded by `ACPContentBlock`.
+- Modify `Alas/Sources/ACP/Session/ACPMessage.swift`
+  - Extend `ACPMessage.ToolCall` with `rawOutput`, `metadata`, and preserved content assets.
+  - Keep decoding backward-compatible for persisted rows.
+- Modify `Alas/Sources/ACP/Session/ACPSession.swift`
+  - Add `ACPGoalState`.
+  - Apply session info updates to title/goal.
+  - Apply enriched tool-call update fields.
+  - Route terminal metadata into retained terminal buffers.
+- Modify `Alas/Sources/ACP/Terminal/ACPTerminal.swift`
+  - Add a lightweight initializer for metadata-backed terminal rows.
+  - Add methods to append metadata output and publish terminal exit without a spawned process.
+- Modify `Alas/Sources/ACP/Terminal/ACPTerminalHost.swift`
+  - Add APIs for metadata-created terminal buffers.
+- Create `Alas/Sources/ACP/UI/ACPToolCallPresentation.swift`
+  - Classify generic ACP tool-call rows for display.
+- Modify `Alas/Sources/ACP/UI/ACPToolCallCard.swift`
+  - Use `ACPToolCallPresentation`.
+  - Render image/resource assets in expanded cards.
+- Create `Alas/Sources/ACP/UI/ACPGoalPill.swift`
+  - Compact goal indicator for toolbar/header.
+- Modify `Alas/Sources/ACP/UI/ACPToolbar.swift`
+  - Render `ACPGoalPill` when `session.currentGoal` exists.
+- Add/modify tests:
+  - `AlasTests/ACP/Protocol/ACPSessionUpdateTests.swift`
+  - `AlasTests/ACP/Session/ACPSessionTests.swift`
+  - `AlasTests/ACP/Session/ACPMessageTests.swift`
+  - `AlasTests/ACP/Terminal/ACPTerminalHostTests.swift`
+  - Create `AlasTests/ACP/UI/ACPToolCallPresentationTests.swift`
+  - Create fixtures under `AlasTests/ACP/Fixtures/`
+
+---
+
+### Task 1: Decode enriched ACP session updates
+
+**Files:**
+- Modify: `Alas/Sources/ACP/Protocol/ACPSessionUpdate.swift`
+- Modify: `AlasTests/ACP/Protocol/ACPSessionUpdateTests.swift`
+- Create: `AlasTests/ACP/Fixtures/session-update-session-info-goal.json`
+- Create: `AlasTests/ACP/Fixtures/session-update-tool-call-meta.json`
+- Create: `AlasTests/ACP/Fixtures/session-update-tool-call-update-meta.json`
+
+- [ ] **Step 1: Add failing protocol fixtures**
+
+Create `AlasTests/ACP/Fixtures/session-update-session-info-goal.json`:
+
+```json
+{
+  "jsonrpc": "2.0",
+  "method": "session/update",
+  "params": {
+    "sessionId": "s",
+    "update": {
+      "sessionUpdate": "session_info_update",
+      "title": "Investigate ACP events",
+      "_meta": {
+        "codex": {
+          "goal": {
+            "objective": "Surface richer ACP events",
+            "status": "in_progress",
+            "tokenBudget": 12000
+          }
+        }
+      }
+    }
+  }
+}
+```
+
+Create `AlasTests/ACP/Fixtures/session-update-tool-call-meta.json`:
+
+```json
+{
+  "jsonrpc": "2.0",
+  "method": "session/update",
+  "params": {
+    "sessionId": "s",
+    "update": {
+      "sessionUpdate": "tool_call",
+      "toolCallId": "cmd-1",
+      "title": "swift test",
+      "kind": "execute",
+      "status": "in_progress",
+      "content": [{ "type": "terminal", "terminalId": "cmd-1" }],
+      "rawInput": { "command": "swift test", "cwd": "/repo" },
+      "_meta": {
+        "terminal_info": {
+          "terminal_id": "cmd-1",
+          "cwd": "/repo"
+        }
+      }
+    }
+  }
+}
+```
+
+Create `AlasTests/ACP/Fixtures/session-update-tool-call-update-meta.json`:
+
+```json
+{
+  "jsonrpc": "2.0",
+  "method": "session/update",
+  "params": {
+    "sessionId": "s",
+    "update": {
+      "sessionUpdate": "tool_call_update",
+      "toolCallId": "cmd-1",
+      "title": "swift test --filter ACP",
+      "status": "completed",
+      "locations": [{ "path": "AlasTests/ACP/Session/ACPSessionTests.swift", "line": 12 }],
+      "rawInput": { "command": "swift test --filter ACP" },
+      "rawOutput": { "exit_code": 0 },
+      "_meta": {
+        "terminal_output_delta": {
+          "terminal_id": "cmd-1",
+          "data": "ok\n"
+        },
+        "terminal_exit": {
+          "terminal_id": "cmd-1",
+          "exit_code": 0,
+          "signal": null
+        }
+      }
+    }
+  }
+}
+```
+
+- [ ] **Step 2: Add failing decode tests**
+
+Append tests to `AlasTests/ACP/Protocol/ACPSessionUpdateTests.swift`:
+
+```swift
+@Test("decodes session_info_update with metadata")
+func sessionInfoUpdate() throws {
+    let env = try decode("session-update-session-info-goal")
+    guard case .sessionInfoUpdate(let info) = env.params!.update else {
+        Issue.record("expected sessionInfoUpdate")
+        return
+    }
+    #expect(info.title == "Investigate ACP events")
+    let meta = try #require(info.metadata?.value as? [String: AnyCodable])
+    let codex = try #require(meta["codex"]?.value as? [String: AnyCodable])
+    let goal = try #require(codex["goal"]?.value as? [String: AnyCodable])
+    #expect(goal["objective"]?.value as? String == "Surface richer ACP events")
+    #expect(goal["status"]?.value as? String == "in_progress")
+    #expect(goal["tokenBudget"]?.value as? Int == 12000)
+}
+
+@Test("decodes tool call metadata")
+func toolCallMetadata() throws {
+    let env = try decode("session-update-tool-call-meta")
+    guard case .toolCall(let tc) = env.params!.update else {
+        Issue.record("expected toolCall")
+        return
+    }
+    #expect(tc.toolCallId == "cmd-1")
+    #expect(tc.metadata != nil)
+    let meta = try #require(tc.metadata?.value as? [String: AnyCodable])
+    let terminalInfo = try #require(meta["terminal_info"]?.value as? [String: AnyCodable])
+    #expect(terminalInfo["terminal_id"]?.value as? String == "cmd-1")
+    #expect(terminalInfo["cwd"]?.value as? String == "/repo")
+}
+
+@Test("decodes tool call update metadata and mutable fields")
+func toolCallUpdateMetadata() throws {
+    let env = try decode("session-update-tool-call-update-meta")
+    guard case .toolCallUpdate(let update) = env.params!.update else {
+        Issue.record("expected toolCallUpdate")
+        return
+    }
+    #expect(update.toolCallId == "cmd-1")
+    #expect(update.title == "swift test --filter ACP")
+    #expect(update.locations?.first?.path == "AlasTests/ACP/Session/ACPSessionTests.swift")
+    #expect(update.rawInput != nil)
+    #expect(update.rawOutput != nil)
+    #expect(update.metadata != nil)
+}
+```
+
+- [ ] **Step 3: Run tests to verify failure**
+
+Run:
+
+```bash
+rtk xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -only-testing:AlasTests/ACPSessionUpdateTests test
+```
+
+Expected: FAIL because `ACPSessionUpdate.sessionInfoUpdate`, `metadata`, and update-time fields do not exist.
+
+- [ ] **Step 4: Implement protocol decoding**
+
+Update `Alas/Sources/ACP/Protocol/ACPSessionUpdate.swift`:
+
+```swift
+enum ACPSessionUpdate: Codable, Equatable {
+    case userMessageChunk(ACPContentBlock)
+    case agentMessageChunk(ACPContentBlock)
+    case agentThoughtChunk(ACPContentBlock)
+    case toolCall(ACPToolCallPayload)
+    case toolCallUpdate(ACPToolCallUpdate)
+    case plan([ACPPlanEntry])
+    case availableModelsUpdate([ACPModelInfo])
+    case currentModeUpdate(modeId: String)
+    case currentModelUpdate(modelId: String)
+    case sessionConfigOptionsUpdate([ACPConfigOption])
+    case availableCommandsUpdate([ACPPromptSuggestion])
+    case usageUpdate(ACPUsageInfo)
+    case sessionInfoUpdate(ACPSessionInfoUpdate)
+    case unknown(String)
+
+    private enum Keys: String, CodingKey {
+        case sessionUpdate, content, availableModels, modeId, modelId,
+             entries, availableCommands, configOptions
+    }
+}
+```
+
+Add the decode case:
+
+```swift
+case "session_info_update":
+    self = .sessionInfoUpdate(try ACPSessionInfoUpdate(from: decoder))
+```
+
+Add encode fallthrough:
+
+```swift
+case .sessionInfoUpdate:
+    break
+```
+
+Add new protocol type:
+
+```swift
+struct ACPSessionInfoUpdate: Codable, Equatable {
+    let title: String?
+    let metadata: AnyCodable?
+
+    private enum CodingKeys: String, CodingKey {
+        case title
+        case metadata = "_meta"
+    }
+}
+```
+
+Update tool-call payloads:
+
+```swift
+struct ACPToolCallPayload: Codable, Equatable {
+    let toolCallId: String
+    let title: String
+    let kind: String?
+    let status: String
+    let content: [ACPToolCallContent]?
+    let locations: [ACPToolLocation]?
+    let rawInput: AnyCodable?
+    let rawOutput: AnyCodable?
+    let metadata: AnyCodable?
+
+    private enum CodingKeys: String, CodingKey {
+        case toolCallId, title, kind, status, content, locations, rawInput, rawOutput
+        case metadata = "_meta"
+    }
+}
+
+struct ACPToolCallUpdate: Codable, Equatable {
+    let toolCallId: String
+    let title: String?
+    let status: String?
+    let content: [ACPToolCallContent]?
+    let locations: [ACPToolLocation]?
+    let rawInput: AnyCodable?
+    let rawOutput: AnyCodable?
+    let metadata: AnyCodable?
+
+    private enum CodingKeys: String, CodingKey {
+        case toolCallId, title, status, content, locations, rawInput, rawOutput
+        case metadata = "_meta"
+    }
+}
+```
+
+- [ ] **Step 5: Run tests to verify pass**
+
+Run:
+
+```bash
+rtk xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -only-testing:AlasTests/ACPSessionUpdateTests test
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+rtk git add Alas/Sources/ACP/Protocol/ACPSessionUpdate.swift AlasTests/ACP/Protocol/ACPSessionUpdateTests.swift AlasTests/ACP/Fixtures/session-update-session-info-goal.json AlasTests/ACP/Fixtures/session-update-tool-call-meta.json AlasTests/ACP/Fixtures/session-update-tool-call-update-meta.json
+rtk git commit -m "feat(acp): decode enriched session updates"
+```
+
+---
+
+### Task 2: Persist enriched tool-call fields
+
+**Files:**
+- Modify: `Alas/Sources/ACP/Session/ACPMessage.swift`
+- Modify: `AlasTests/ACP/Session/ACPMessageTests.swift`
+- Modify: `AlasTests/ACP/Session/ACPMessageWireTests.swift`
+
+- [ ] **Step 1: Add failing round-trip tests**
+
+Add to `AlasTests/ACP/Session/ACPMessageTests.swift`:
+
+```swift
+@Test("tool call round-trips enriched fields")
+func toolCallEnrichedRoundtrip() throws {
+    let metadata = AnyCodable([
+        "is_mcp_tool_call": AnyCodable(true),
+        "terminal_info": AnyCodable([
+            "terminal_id": AnyCodable("term-1"),
+            "cwd": AnyCodable("/repo")
+        ])
+    ])
+    let rawOutput = #"{"exit_code":0}"#
+    let assets = [
+        ACPMessage.ToolCallAsset.image(data: "abc123", uri: "/tmp/out.png", mimeType: "image/png", name: "out.png"),
+        ACPMessage.ToolCallAsset.resource(uri: "/tmp/out.png", name: "out.png", mimeType: "image/png")
+    ]
+    let original = ACPMessage.toolCall(.init(
+        toolCallId: "tc-enriched",
+        title: "Image generation",
+        kind: "other",
+        status: "completed",
+        content: "Revised prompt: a small icon",
+        preview: "Revised prompt",
+        contentLanguage: nil,
+        rawInput: #"{"prompt":"icon"}"#,
+        rawOutput: rawOutput,
+        metadata: metadata,
+        locations: ["/tmp/out.png"],
+        terminalIds: ["term-1"],
+        assets: assets
+    ))
+
+    let payload = try ACPMessageCodec.encode(original)
+    let decoded = try ACPMessageCodec.decode(kind: original.kind, payload: payload)
+    #expect(decoded == original)
+}
+```
+
+Add to `AlasTests/ACP/Session/ACPMessageWireTests.swift`:
+
+```swift
+@Test("tool call missing enriched fields decodes with defaults")
+func toolCallMissingEnrichedFieldsDecodeAsDefaults() throws {
+    let payload = """
+    {
+      "toolCallId": "tc1",
+      "title": "read",
+      "kind": "fs.read",
+      "status": "completed",
+      "content": "abc",
+      "preview": "abc",
+      "locations": ["/a"],
+      "terminalIds": []
+    }
+    """.data(using: .utf8)!
+    let wire = try ACPMessageWire.decode(kind: "tool_call", payload: payload)
+    guard case let .toolCall(decoded) = wire else {
+        Issue.record("expected .toolCall")
+        return
+    }
+    #expect(decoded.rawOutput == nil)
+    #expect(decoded.metadata == nil)
+    #expect(decoded.assets.isEmpty)
+}
+```
+
+- [ ] **Step 2: Run tests to verify failure**
+
+Run:
+
+```bash
+rtk xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -only-testing:AlasTests/ACPMessageTests -only-testing:AlasTests/ACPMessageWireTests test
+```
+
+Expected: FAIL because `rawOutput`, `metadata`, and `ToolCallAsset` do not exist.
+
+- [ ] **Step 3: Extend `ACPMessage.ToolCall`**
+
+In `Alas/Sources/ACP/Session/ACPMessage.swift`, add nested asset type:
+
+```swift
+struct ToolCallAsset: Codable, Equatable, Hashable, Sendable {
+    enum Kind: String, Codable, Equatable, Hashable, Sendable {
+        case image
+        case resource
+    }
+
+    let kind: Kind
+    let data: String?
+    let uri: String?
+    let mimeType: String?
+    let name: String?
+
+    static func image(data: String?, uri: String?, mimeType: String?, name: String?) -> Self {
+        Self(kind: .image, data: data, uri: uri, mimeType: mimeType, name: name)
+    }
+
+    static func resource(uri: String, name: String?, mimeType: String?) -> Self {
+        Self(kind: .resource, data: nil, uri: uri, mimeType: mimeType, name: name)
+    }
+}
+```
+
+Extend `ToolCall` stored properties and initializer:
+
+```swift
+var rawOutput: String?
+var metadata: AnyCodable?
+var assets: [ToolCallAsset]
+
+init(toolCallId: String, title: String, kind: String? = nil,
+     status: String, content: String = "", preview: String? = nil,
+     contentLanguage: String? = nil, rawInput: String? = nil,
+     rawOutput: String? = nil, metadata: AnyCodable? = nil,
+     locations: [String] = [], terminalIds: [String] = [],
+     assets: [ToolCallAsset] = [])
+{
+    self.toolCallId = toolCallId
+    self.title = title
+    self.kind = kind
+    self.status = status
+    self.content = content
+    self.preview = preview
+    self.contentLanguage = contentLanguage
+    self.rawInput = rawInput
+    self.rawOutput = rawOutput
+    self.metadata = metadata
+    self.locations = locations
+    self.terminalIds = terminalIds
+    self.assets = assets
+}
+```
+
+Update `CodingKeys`:
+
+```swift
+case toolCallId, title, kind, status, content, preview,
+     contentSummary, contentLanguage, rawInput, rawOutput,
+     metadata, locations, terminalIds, assets
+```
+
+Update decode:
+
+```swift
+rawOutput = try? c.decode(String.self, forKey: .rawOutput)
+metadata = try? c.decode(AnyCodable.self, forKey: .metadata)
+assets = (try? c.decode([ToolCallAsset].self, forKey: .assets)) ?? []
+```
+
+Update encode:
+
+```swift
+try c.encodeIfPresent(rawOutput, forKey: .rawOutput)
+try c.encodeIfPresent(metadata, forKey: .metadata)
+try c.encode(assets, forKey: .assets)
+```
+
+Update equality and hash to include `rawOutput`, `metadata`, `assets`, and `terminalIds`.
+
+- [ ] **Step 4: Run tests to verify pass**
+
+Run:
+
+```bash
+rtk xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -only-testing:AlasTests/ACPMessageTests -only-testing:AlasTests/ACPMessageWireTests test
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+rtk git add Alas/Sources/ACP/Session/ACPMessage.swift AlasTests/ACP/Session/ACPMessageTests.swift AlasTests/ACP/Session/ACPMessageWireTests.swift
+rtk git commit -m "feat(acp): persist enriched tool calls"
+```
+
+---
+
+### Task 3: Apply session info, goal, and enriched tool-call updates
+
+**Files:**
+- Modify: `Alas/Sources/ACP/Session/ACPSession.swift`
+- Modify: `AlasTests/ACP/Session/ACPSessionTests.swift`
+
+- [ ] **Step 1: Add failing session-apply tests**
+
+Add to `AlasTests/ACP/Session/ACPSessionTests.swift`:
+
+```swift
+@Test("session info update applies title and goal")
+func sessionInfoAppliesTitleAndGoal() async {
+    let session = ACPSession(id: "s", agentId: "codex", worktreeId: "w", title: "Old")
+    let metadata = AnyCodable([
+        "codex": AnyCodable([
+            "goal": AnyCodable([
+                "objective": AnyCodable("Ship ACP enrichment"),
+                "status": AnyCodable("in_progress"),
+                "tokenBudget": AnyCodable(8000)
+            ])
+        ])
+    ])
+
+    let dirty = session.apply(.sessionInfoUpdate(.init(title: "New title", metadata: metadata)))
+
+    #expect(dirty.isEmpty)
+    #expect(session.title == "New title")
+    #expect(session.currentGoal?.objective == "Ship ACP enrichment")
+    #expect(session.currentGoal?.status == "in_progress")
+    #expect(session.currentGoal?.tokenBudget == 8000)
+}
+
+@Test("session info update clears goal when metadata goal is null")
+func sessionInfoClearsGoal() async {
+    let session = ACPSession(id: "s", agentId: "codex", worktreeId: "w", title: "Title")
+    session.currentGoal = .init(objective: "Old goal", status: "in_progress", tokenBudget: nil)
+    let metadata = AnyCodable([
+        "codex": AnyCodable([
+            "goal": AnyCodable(NSNull())
+        ])
+    ])
+
+    _ = session.apply(.sessionInfoUpdate(.init(title: nil, metadata: metadata)))
+
+    #expect(session.currentGoal == nil)
+}
+
+@Test("tool call update mutates enriched fields")
+func toolCallUpdateMutatesEnrichedFields() async {
+    let session = ACPSession(id: "s", agentId: "codex", worktreeId: "w", title: "t")
+    session.apply(.toolCall(.init(
+        toolCallId: "tc",
+        title: "old",
+        kind: "execute",
+        status: "in_progress",
+        content: nil,
+        locations: nil,
+        rawInput: nil,
+        rawOutput: nil,
+        metadata: nil
+    )))
+
+    let touched = session.apply(.toolCallUpdate(.init(
+        toolCallId: "tc",
+        title: "new title",
+        status: "completed",
+        content: [.content(.text("done"))],
+        locations: [.init(path: "Sources/App.swift", line: 4)],
+        rawInput: AnyCodable(["command": AnyCodable("swift test")]),
+        rawOutput: AnyCodable(["exit_code": AnyCodable(0)]),
+        metadata: AnyCodable(["is_mcp_tool_call": AnyCodable(true)])
+    )))
+
+    #expect(touched == [0])
+    guard case .toolCall(let tc) = session.transcript.messages[0] else {
+        Issue.record("expected tool call")
+        return
+    }
+    #expect(tc.title == "new title")
+    #expect(tc.status == "completed")
+    #expect(tc.content == "done")
+    #expect(tc.locations == ["Sources/App.swift"])
+    #expect(tc.rawInput?.contains("swift test") == true)
+    #expect(tc.rawOutput?.contains(#""exit_code":0"#) == true)
+    #expect(tc.metadata != nil)
+}
+```
+
+- [ ] **Step 2: Run tests to verify failure**
+
+Run:
+
+```bash
+rtk xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -only-testing:AlasTests/ACPSessionTests test
+```
+
+Expected: FAIL because `ACPGoalState`, `currentGoal`, and enriched apply behavior do not exist.
+
+- [ ] **Step 3: Implement goal state and apply behavior**
+
+In `Alas/Sources/ACP/Session/ACPSession.swift`, add near session published state:
+
+```swift
+@Published var currentGoal: ACPGoalState?
+```
+
+Add near `ACPSession` nested types or file scope:
+
+```swift
+struct ACPGoalState: Equatable, Hashable {
+    let objective: String
+    let status: String
+    let tokenBudget: Int?
+}
+```
+
+Add `apply` case:
+
+```swift
+case .sessionInfoUpdate(let info):
+    if let title = info.title?.trimmingCharacters(in: .whitespacesAndNewlines),
+       !title.isEmpty,
+       titleSource != .manual {
+        self.title = title
+        self.titleSource = .generated
+    }
+    applyGoalMetadata(info.metadata)
+    return []
+```
+
+Update `.toolCall` creation:
+
+```swift
+rawInput: Self.metadataString(payload.rawInput),
+rawOutput: Self.metadataString(payload.rawOutput),
+metadata: payload.metadata,
+locations: payload.locations?.map(\.path) ?? [],
+terminalIds: Self.extractTerminalIds(items),
+assets: Self.extractAssets(items)
+```
+
+Update `.toolCallUpdate` mutation:
+
+```swift
+if let title = u.title { tc.title = title }
+if let s = u.status { tc.status = s }
+if let locations = u.locations { tc.locations = locations.map(\.path) }
+if let rawInput = u.rawInput { tc.rawInput = Self.metadataString(rawInput) }
+if let rawOutput = u.rawOutput { tc.rawOutput = Self.metadataString(rawOutput) }
+if let metadata = u.metadata { tc.metadata = metadata }
+if let c = u.content {
+    let raw = Self.flatten(c)
+    let full = Self.stripWrappingFence(raw, isFinal: Self.isFinalStatus(tc.status))
+    tc.content = full
+    tc.preview = Self.previewLine(full)
+    tc.contentLanguage = Self.wrappingFenceLanguage(raw)
+    tc.terminalIds = Self.extractTerminalIds(c)
+    tc.assets = Self.extractAssets(c)
+}
+```
+
+Add helpers:
+
+```swift
+private func applyGoalMetadata(_ metadata: AnyCodable?) {
+    guard let dict = metadata?.value as? [String: AnyCodable] else { return }
+    if let directGoal = dict["goal"] {
+        currentGoal = Self.goalState(from: directGoal)
+        return
+    }
+    if let codex = dict["codex"]?.value as? [String: AnyCodable],
+       let goal = codex["goal"] {
+        currentGoal = Self.goalState(from: goal)
+    }
+}
+
+private static func goalState(from value: AnyCodable) -> ACPGoalState? {
+    if value.value is NSNull { return nil }
+    guard let dict = value.value as? [String: AnyCodable],
+          let objective = dict["objective"]?.value as? String,
+          let status = dict["status"]?.value as? String
+    else { return nil }
+    let trimmed = objective.trimmingCharacters(in: .whitespacesAndNewlines)
+    guard !trimmed.isEmpty else { return nil }
+    return ACPGoalState(
+        objective: trimmed,
+        status: status,
+        tokenBudget: dict["tokenBudget"]?.value as? Int
+    )
+}
+
+private static func extractAssets(_ items: [ACPToolCallContent]) -> [ACPMessage.ToolCallAsset] {
+    items.compactMap { item in
+        switch item {
+        case .content(.image(let data, let uri, let mimeType)):
+            return .image(data: data, uri: uri, mimeType: mimeType, name: uri.map { URL(fileURLWithPath: $0).lastPathComponent })
+        case .content(.resourceLink(let uri, let name)):
+            return .resource(uri: uri, name: name, mimeType: nil)
+        case .content(.resource(let uri, let mimeType, _)):
+            return .resource(uri: uri, name: URL(fileURLWithPath: uri).lastPathComponent, mimeType: mimeType)
+        default:
+            return nil
+        }
+    }
+}
+```
+
+- [ ] **Step 4: Run tests to verify pass**
+
+Run:
+
+```bash
+rtk xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -only-testing:AlasTests/ACPSessionTests test
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+rtk git add Alas/Sources/ACP/Session/ACPSession.swift AlasTests/ACP/Session/ACPSessionTests.swift
+rtk git commit -m "feat(acp): apply enriched session metadata"
+```
+
+---
+
+### Task 4: Route terminal output metadata into retained terminal buffers
+
+**Files:**
+- Modify: `Alas/Sources/ACP/Terminal/ACPTerminal.swift`
+- Modify: `Alas/Sources/ACP/Terminal/ACPTerminalHost.swift`
+- Modify: `Alas/Sources/ACP/Session/ACPSession.swift`
+- Modify: `AlasTests/ACP/Terminal/ACPTerminalHostTests.swift`
+- Modify: `AlasTests/ACP/Session/ACPSessionTests.swift`
+
+- [ ] **Step 1: Add failing terminal host tests**
+
+Add to `AlasTests/ACP/Terminal/ACPTerminalHostTests.swift`:
+
+```swift
+@MainActor
+@Test("metadata terminal buffers append output and publish exit")
+func metadataTerminalBuffers() async throws {
+    let host = ACPTerminalHost(sessionCwd: "/repo", sessionEnv: [:])
+
+    host.recordMetadataTerminalInfo(terminalId: "term-1", cwd: "/repo/sub")
+    host.appendMetadataOutput(terminalId: "term-1", data: Data("hello".utf8), replace: false)
+    host.appendMetadataOutput(terminalId: "term-1", data: Data(" world".utf8), replace: false)
+    host.recordMetadataExit(terminalId: "term-1", exitStatus: .init(exitCode: 0, signal: nil))
+
+    let term = try #require(host.terminal(id: "term-1"))
+    #expect(String(data: term.buffer, encoding: .utf8) == "hello world")
+    #expect(term.exitStatus == .init(exitCode: 0, signal: nil))
+    #expect(term.outputByteLimit == ACPTerminal.internalBufferCap)
+}
+
+@MainActor
+@Test("metadata terminal replacement overwrites output")
+func metadataTerminalReplacementOverwritesOutput() async throws {
+    let host = ACPTerminalHost(sessionCwd: "/repo", sessionEnv: [:])
+
+    host.appendMetadataOutput(terminalId: "term-1", data: Data("old".utf8), replace: false)
+    host.appendMetadataOutput(terminalId: "term-1", data: Data("new".utf8), replace: true)
+
+    let term = try #require(host.terminal(id: "term-1"))
+    #expect(String(data: term.buffer, encoding: .utf8) == "new")
+}
+```
+
+- [ ] **Step 2: Add failing session metadata routing test**
+
+Add to `AlasTests/ACP/Session/ACPSessionTests.swift`:
+
+```swift
+@Test("tool call metadata routes terminal output and exit")
+func toolCallMetadataRoutesTerminalOutput() async throws {
+    let session = ACPSession(id: "s", agentId: "codex", worktreeId: "w", title: "t")
+    session.apply(.toolCall(.init(
+        toolCallId: "cmd-1",
+        title: "swift test",
+        kind: "execute",
+        status: "in_progress",
+        content: [.terminal(terminalId: "cmd-1")],
+        locations: nil,
+        rawInput: nil,
+        rawOutput: nil,
+        metadata: AnyCodable([
+            "terminal_info": AnyCodable([
+                "terminal_id": AnyCodable("cmd-1"),
+                "cwd": AnyCodable("/repo")
+            ])
+        ])
+    )))
+    session.apply(.toolCallUpdate(.init(
+        toolCallId: "cmd-1",
+        title: nil,
+        status: "completed",
+        content: nil,
+        locations: nil,
+        rawInput: nil,
+        rawOutput: nil,
+        metadata: AnyCodable([
+            "terminal_output_delta": AnyCodable([
+                "terminal_id": AnyCodable("cmd-1"),
+                "data": AnyCodable("ok\n")
+            ]),
+            "terminal_exit": AnyCodable([
+                "terminal_id": AnyCodable("cmd-1"),
+                "exit_code": AnyCodable(0),
+                "signal": AnyCodable(NSNull())
+            ])
+        ])
+    )))
+
+    let term = try #require(session.terminalHost.terminal(id: "cmd-1"))
+    #expect(String(data: term.buffer, encoding: .utf8) == "ok\n")
+    #expect(term.exitStatus == .init(exitCode: 0, signal: nil))
+}
+```
+
+- [ ] **Step 3: Run tests to verify failure**
+
+Run:
+
+```bash
+rtk xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -only-testing:AlasTests/ACPTerminalHostTests -only-testing:AlasTests/ACPSessionTests/toolCallMetadataRoutesTerminalOutput test
+```
+
+Expected: FAIL because metadata-backed terminal APIs do not exist.
+
+- [ ] **Step 4: Add metadata terminal support**
+
+In `Alas/Sources/ACP/Terminal/ACPTerminal.swift`, add a metadata initializer and mutation methods. Because existing process-backed stored properties are non-optional, make `process` and `pipe` optional and guard process-only operations.
+
+Change properties:
+
+```swift
+private let process: Process?
+private let pipe: Pipe?
+```
+
+Set them in the existing initializer:
+
+```swift
+self.process = Process()
+self.pipe = Pipe()
+guard let process, let pipe else { fatalError("process terminal requires process and pipe") }
+```
+
+Add metadata initializer:
+
+```swift
+init(metadataId id: String, cwd: String?, outputByteLimit: Int = ACPTerminal.internalBufferCap) {
+    self.id = id
+    self.createdAt = Date()
+    self.outputByteLimit = max(1, min(outputByteLimit, Self.internalBufferCap))
+    self.process = nil
+    self.pipe = nil
+}
+```
+
+Add methods:
+
+```swift
+func appendMetadataOutput(_ data: Data, replace: Bool) {
+    if replace {
+        buffer.removeAll(keepingCapacity: true)
+        truncated = false
+    }
+    appendChunk(data)
+}
+
+func finishMetadata(exitStatus status: ACPTerminalExitStatus) {
+    guard exitStatus == nil else { return }
+    exitStatus = status
+    for waiter in exitWaiters {
+        waiter.resume(returning: status)
+    }
+    exitWaiters.removeAll()
+    onExit?()
+}
+```
+
+Update `kill()` to no-op for metadata terminals:
+
+```swift
+guard let process else { return }
+```
+
+- [ ] **Step 5: Add host APIs**
+
+In `Alas/Sources/ACP/Terminal/ACPTerminalHost.swift`, add:
+
+```swift
+func recordMetadataTerminalInfo(terminalId: String, cwd: String?) {
+    _ = metadataTerminal(id: terminalId, cwd: cwd)
+}
+
+func appendMetadataOutput(terminalId: String, data: Data, replace: Bool) {
+    let term = metadataTerminal(id: terminalId, cwd: nil)
+    term.appendMetadataOutput(data, replace: replace)
+}
+
+func recordMetadataExit(terminalId: String, exitStatus: ACPTerminalExitStatus) {
+    let term = metadataTerminal(id: terminalId, cwd: nil)
+    term.finishMetadata(exitStatus: exitStatus)
+    pruneFinishedTerminals()
+}
+
+private func metadataTerminal(id: String, cwd: String?) -> ACPTerminal {
+    if let existing = terminals[id] { return existing }
+    let term = ACPTerminal(metadataId: id, cwd: cwd)
+    term.onExit = { [weak self] in self?.pruneFinishedTerminals() }
+    terminals[id] = term
+    return term
+}
+```
+
+- [ ] **Step 6: Route metadata in session apply**
+
+In `Alas/Sources/ACP/Session/ACPSession.swift`, call after creating/updating tool calls:
+
+```swift
+applyToolCallMetadata(payload.metadata)
+```
+
+and:
+
+```swift
+if let metadata = u.metadata {
+    tc.metadata = metadata
+    applyToolCallMetadata(metadata)
+}
+```
+
+Add helper:
+
+```swift
+private func applyToolCallMetadata(_ metadata: AnyCodable?) {
+    guard let dict = metadata?.value as? [String: AnyCodable] else { return }
+    if let info = dict["terminal_info"]?.value as? [String: AnyCodable],
+       let id = info["terminal_id"]?.value as? String {
+        terminalHost.recordMetadataTerminalInfo(
+            terminalId: id,
+            cwd: info["cwd"]?.value as? String
+        )
+    }
+    if let output = dict["terminal_output"]?.value as? [String: AnyCodable],
+       let id = output["terminal_id"]?.value as? String,
+       let data = output["data"]?.value as? String {
+        terminalHost.appendMetadataOutput(terminalId: id, data: Data(data.utf8), replace: true)
+    }
+    if let output = dict["terminal_output_delta"]?.value as? [String: AnyCodable],
+       let id = output["terminal_id"]?.value as? String,
+       let data = output["data"]?.value as? String {
+        terminalHost.appendMetadataOutput(terminalId: id, data: Data(data.utf8), replace: false)
+    }
+    if let exit = dict["terminal_exit"]?.value as? [String: AnyCodable],
+       let id = exit["terminal_id"]?.value as? String {
+        let status = ACPTerminalExitStatus(
+            exitCode: exit["exit_code"]?.value as? Int,
+            signal: exit["signal"]?.value as? String
+        )
+        terminalHost.recordMetadataExit(terminalId: id, exitStatus: status)
+    }
+}
+```
+
+- [ ] **Step 7: Run tests to verify pass**
+
+Run:
+
+```bash
+rtk xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -only-testing:AlasTests/ACPTerminalHostTests -only-testing:AlasTests/ACPSessionTests test
+```
+
+Expected: PASS.
+
+- [ ] **Step 8: Commit**
+
+```bash
+rtk git add Alas/Sources/ACP/Terminal/ACPTerminal.swift Alas/Sources/ACP/Terminal/ACPTerminalHost.swift Alas/Sources/ACP/Session/ACPSession.swift AlasTests/ACP/Terminal/ACPTerminalHostTests.swift AlasTests/ACP/Session/ACPSessionTests.swift
+rtk git commit -m "feat(acp): render terminal metadata output"
+```
+
+---
+
+### Task 5: Add bridge-neutral tool-call presentation resolver
+
+**Files:**
+- Create: `Alas/Sources/ACP/UI/ACPToolCallPresentation.swift`
+- Modify: `Alas/Sources/ACP/UI/ACPToolCallCard.swift`
+- Create: `AlasTests/ACP/UI/ACPToolCallPresentationTests.swift`
+
+- [ ] **Step 1: Add failing presentation tests**
+
+Create `AlasTests/ACP/UI/ACPToolCallPresentationTests.swift`:
+
+```swift
+import Foundation
+import Testing
+@testable import Alas
+
+@Suite("ACPToolCallPresentation")
+struct ACPToolCallPresentationTests {
+    @Test("classifies web search")
+    func webSearch() {
+        let tc = ACPMessage.ToolCall(toolCallId: "web", title: "Web search: swift testing", kind: "search", status: "completed")
+        let presentation = ACPToolCallPresentation.resolve(tc)
+        #expect(presentation.label == "Web Search")
+        #expect(presentation.iconSystemName == "globe")
+        #expect(presentation.style == .webSearch)
+    }
+
+    @Test("classifies open page")
+    func openPage() {
+        let tc = ACPMessage.ToolCall(toolCallId: "open", title: "Open page: https://example.com", kind: "search", status: "completed")
+        let presentation = ACPToolCallPresentation.resolve(tc)
+        #expect(presentation.label == "Opened Page")
+        #expect(presentation.iconSystemName == "safari")
+        #expect(presentation.style == .webSearch)
+    }
+
+    @Test("classifies image generation")
+    func imageGeneration() {
+        let tc = ACPMessage.ToolCall(
+            toolCallId: "img",
+            title: "Image generation",
+            kind: "other",
+            status: "completed",
+            assets: [.image(data: "abc", uri: "/tmp/out.png", mimeType: "image/png", name: "out.png")]
+        )
+        let presentation = ACPToolCallPresentation.resolve(tc)
+        #expect(presentation.label == "Image")
+        #expect(presentation.iconSystemName == "photo")
+        #expect(presentation.style == .image)
+    }
+
+    @Test("classifies image view")
+    func imageView() {
+        let tc = ACPMessage.ToolCall(
+            toolCallId: "view",
+            title: "View Image /tmp/out.png",
+            kind: "read",
+            status: "completed",
+            assets: [.resource(uri: "/tmp/out.png", name: "out.png", mimeType: "image/png")]
+        )
+        let presentation = ACPToolCallPresentation.resolve(tc)
+        #expect(presentation.label == "Viewed Image")
+        #expect(presentation.style == .image)
+    }
+
+    @Test("classifies MCP calls")
+    func mcpCall() {
+        let tc = ACPMessage.ToolCall(
+            toolCallId: "mcp",
+            title: "mcp.github.fetch_issue",
+            kind: "execute",
+            status: "completed",
+            metadata: AnyCodable(["is_mcp_tool_call": AnyCodable(true)])
+        )
+        let presentation = ACPToolCallPresentation.resolve(tc)
+        #expect(presentation.label == "MCP")
+        #expect(presentation.iconSystemName == "point.3.connected.trianglepath.dotted")
+        #expect(presentation.style == .mcp)
+    }
+
+    @Test("classifies review thinking")
+    func guardianReview() {
+        let tc = ACPMessage.ToolCall(toolCallId: "review", title: "Guardian Review", kind: "think", status: "completed")
+        let presentation = ACPToolCallPresentation.resolve(tc)
+        #expect(presentation.label == "Review")
+        #expect(presentation.iconSystemName == "checkmark.shield")
+        #expect(presentation.style == .review)
+    }
+
+    @Test("keeps existing execute fallback")
+    func executeFallback() {
+        let tc = ACPMessage.ToolCall(toolCallId: "run", title: "swift test", kind: "execute", status: "completed")
+        let presentation = ACPToolCallPresentation.resolve(tc)
+        #expect(presentation.label == "Ran")
+        #expect(presentation.iconSystemName == "terminal")
+        #expect(presentation.style == .generic)
+    }
+}
+```
+
+- [ ] **Step 2: Run tests to verify failure**
+
+Run:
+
+```bash
+rtk xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -only-testing:AlasTests/ACPToolCallPresentationTests test
+```
+
+Expected: FAIL because `ACPToolCallPresentation` does not exist.
+
+- [ ] **Step 3: Implement resolver**
+
+Create `Alas/Sources/ACP/UI/ACPToolCallPresentation.swift`:
+
+```swift
+import Foundation
+
+struct ACPToolCallPresentation: Equatable {
+    enum Style: Equatable {
+        case generic
+        case webSearch
+        case image
+        case mcp
+        case review
+    }
+
+    let label: String
+    let iconSystemName: String
+    let style: Style
+
+    static func resolve(_ toolCall: ACPMessage.ToolCall) -> Self {
+        let title = toolCall.title
+        let lowerTitle = title.lowercased()
+        let lowerKind = toolCall.kind?.lowercased()
+
+        if lowerKind == "search", lowerTitle.hasPrefix("web search") {
+            return .init(label: "Web Search", iconSystemName: "globe", style: .webSearch)
+        }
+        if lowerKind == "search", lowerTitle.hasPrefix("open page") {
+            return .init(label: "Opened Page", iconSystemName: "safari", style: .webSearch)
+        }
+        if lowerKind == "search", lowerTitle.hasPrefix("find in page") {
+            return .init(label: "Find", iconSystemName: "text.magnifyingglass", style: .webSearch)
+        }
+        if lowerTitle == "image generation", toolCall.assets.contains(where: { $0.kind == .image }) || toolCall.rawOutput?.contains("result") == true {
+            return .init(label: "Image", iconSystemName: "photo", style: .image)
+        }
+        if lowerKind == "read", toolCall.assets.contains(where: { asset in
+            asset.kind == .image || asset.mimeType?.hasPrefix("image/") == true || asset.uri.map(isImagePath) == true
+        }) {
+            return .init(label: "Viewed Image", iconSystemName: "photo.on.rectangle", style: .image)
+        }
+        if isMCP(toolCall) {
+            return .init(label: "MCP", iconSystemName: "point.3.connected.trianglepath.dotted", style: .mcp)
+        }
+        if lowerKind == "think" || lowerTitle == "guardian review" {
+            return .init(label: "Review", iconSystemName: "checkmark.shield", style: .review)
+        }
+
+        switch lowerKind {
+        case "read":
+            return .init(label: "Read", iconSystemName: "doc.text", style: .generic)
+        case "search":
+            return .init(label: "Searched", iconSystemName: "magnifyingglass", style: .generic)
+        case "execute", "run":
+            return .init(label: "Ran", iconSystemName: "terminal", style: .generic)
+        case "edit":
+            return .init(label: "Edit", iconSystemName: "pencil", style: .generic)
+        default:
+            return .init(label: toolCall.kind?.capitalized ?? "Tool", iconSystemName: "gearshape", style: .generic)
+        }
+    }
+
+    private static func isMCP(_ toolCall: ACPMessage.ToolCall) -> Bool {
+        if toolCall.title.hasPrefix("mcp.") || toolCall.title.hasPrefix("mcp__") {
+            return true
+        }
+        guard let metadata = toolCall.metadata?.value as? [String: AnyCodable] else { return false }
+        return metadata["is_mcp_tool_call"]?.value as? Bool == true
+    }
+
+    private static func isImagePath(_ path: String) -> Bool {
+        let ext = URL(fileURLWithPath: path).pathExtension.lowercased()
+        return ["png", "jpg", "jpeg", "gif", "webp", "heic", "tiff", "bmp"].contains(ext)
+    }
+}
+```
+
+- [ ] **Step 4: Update `ACPToolCallCard` to use resolver**
+
+In `Alas/Sources/ACP/UI/ACPToolCallCard.swift`, add:
+
+```swift
+private var presentation: ACPToolCallPresentation {
+    ACPToolCallPresentation.resolve(toolCall)
+}
+```
+
+Change label text:
+
+```swift
+Text(presentation.label)
+```
+
+Change `iconSystemName` to:
+
+```swift
+private var iconSystemName: String {
+    presentation.iconSystemName
+}
+```
+
+Remove or stop using the old `verb` switch. When checking whether to render the title chip, compare against `presentation.label`:
+
+```swift
+if !toolCall.title.isEmpty && toolCall.title.lowercased() != presentation.label.lowercased() {
+    FileChip(path: toolCall.title, lines: nil, iconSystemName: nil)
+}
+```
+
+- [ ] **Step 5: Run tests to verify pass**
+
+Run:
+
+```bash
+rtk xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -only-testing:AlasTests/ACPToolCallPresentationTests test
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+rtk git add Alas/Sources/ACP/UI/ACPToolCallPresentation.swift Alas/Sources/ACP/UI/ACPToolCallCard.swift AlasTests/ACP/UI/ACPToolCallPresentationTests.swift
+rtk git commit -m "feat(acp): classify tool call presentation"
+```
+
+---
+
+### Task 6: Render image assets in tool-call cards
+
+**Files:**
+- Modify: `Alas/Sources/ACP/UI/ACPToolCallCard.swift`
+- Modify: `AlasTests/ACP/Session/ACPSessionTests.swift`
+
+- [ ] **Step 1: Add failing image preservation test**
+
+Add to `AlasTests/ACP/Session/ACPSessionTests.swift`:
+
+```swift
+@Test("tool call image content is preserved as an asset")
+func toolCallImageContentPreserved() async {
+    let session = ACPSession(id: "s", agentId: "codex", worktreeId: "w", title: "t")
+
+    session.apply(.toolCall(.init(
+        toolCallId: "img",
+        title: "Image generation",
+        kind: "other",
+        status: "completed",
+        content: [.content(.image(data: "base64-image", uri: "/tmp/out.png", mimeType: "image/png"))],
+        locations: nil,
+        rawInput: nil,
+        rawOutput: nil,
+        metadata: nil
+    )))
+
+    guard case .toolCall(let tc) = session.transcript.messages[0] else {
+        Issue.record("expected tool call")
+        return
+    }
+    #expect(tc.assets == [.image(data: "base64-image", uri: "/tmp/out.png", mimeType: "image/png", name: "out.png")])
+    #expect(tc.preview == nil)
+}
+```
+
+- [ ] **Step 2: Run test to verify current behavior**
+
+Run:
+
+```bash
+rtk xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -only-testing:AlasTests/ACPSessionTests/toolCallImageContentPreserved test
+```
+
+Expected: PASS if Task 3 already extracts assets; FAIL if the image asset extraction still needs adjustment. If it fails because the generated `name` is wrong for absolute paths, update `extractAssets(_:)` to use `URL(fileURLWithPath: uri).lastPathComponent`.
+
+- [ ] **Step 3: Add image rendering helpers**
+
+In `Alas/Sources/ACP/UI/ACPToolCallCard.swift`, add to `expandedBody` after text content and before terminal tails:
+
+```swift
+if !toolCall.assets.isEmpty {
+    ToolCallAssetsView(assets: toolCall.assets)
+}
+```
+
+Add local views at the bottom of the file:
+
+```swift
+private struct ToolCallAssetsView: View {
+    let assets: [ACPMessage.ToolCallAsset]
+    @Environment(\.theme) private var theme
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            ForEach(Array(assets.enumerated()), id: \.offset) { _, asset in
+                switch asset.kind {
+                case .image:
+                    ToolCallImageAssetView(asset: asset)
+                case .resource:
+                    HStack(spacing: 6) {
+                        Image(systemName: "doc")
+                        Text(asset.name ?? asset.uri ?? "Resource")
+                            .lineLimit(1)
+                            .truncationMode(.middle)
+                    }
+                    .font(.system(size: 11))
+                    .foregroundStyle(theme.color("fg-muted"))
+                }
+            }
+        }
+        .padding(.horizontal, 12)
+        .padding(.vertical, 10)
+        .background(theme.color("bg-0").opacity(0.55))
+    }
+}
+
+private struct ToolCallImageAssetView: View {
+    let asset: ACPMessage.ToolCallAsset
+    @Environment(\.theme) private var theme
+
+    var body: some View {
+        if let image = image {
+            Image(nsImage: image)
+                .resizable()
+                .scaledToFit()
+                .frame(maxWidth: 360, maxHeight: 260, alignment: .leading)
+                .clipShape(RoundedRectangle(cornerRadius: 6))
+                .overlay(RoundedRectangle(cornerRadius: 6).strokeBorder(theme.color("line"), lineWidth: 0.5))
+        } else {
+            HStack(spacing: 6) {
+                Image(systemName: "photo")
+                Text(asset.name ?? asset.uri ?? "Image unavailable")
+                    .lineLimit(1)
+                    .truncationMode(.middle)
+            }
+            .font(.system(size: 11))
+            .foregroundStyle(theme.color("fg-faint"))
+        }
+    }
+
+    private var image: NSImage? {
+        if let data = asset.data,
+           let decoded = Data(base64Encoded: data),
+           let nsImage = NSImage(data: decoded) {
+            return nsImage
+        }
+        if let uri = asset.uri {
+            let url = URL(fileURLWithPath: uri)
+            return NSImage(contentsOf: url)
+        }
+        return nil
+    }
+}
+```
+
+- [ ] **Step 4: Build targeted UI code**
+
+Run:
+
+```bash
+rtk xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -quiet build
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+rtk git add Alas/Sources/ACP/UI/ACPToolCallCard.swift AlasTests/ACP/Session/ACPSessionTests.swift
+rtk git commit -m "feat(acp): render tool call image assets"
+```
+
+---
+
+### Task 7: Surface current goal in the ACP toolbar
+
+**Files:**
+- Create: `Alas/Sources/ACP/UI/ACPGoalPill.swift`
+- Modify: `Alas/Sources/ACP/UI/ACPToolbar.swift`
+- Create: `AlasTests/ACP/UI/ACPGoalPillTests.swift`
+
+- [ ] **Step 1: Add failing copy tests**
+
+Create `AlasTests/ACP/UI/ACPGoalPillTests.swift`:
+
+```swift
+import Testing
+@testable import Alas
+
+@Suite("ACPGoalPill")
+struct ACPGoalPillTests {
+    @Test("summarizes goal with status and budget")
+    func summaryWithStatusAndBudget() {
+        let goal = ACPGoalState(objective: "Surface richer events", status: "in_progress", tokenBudget: 12000)
+        #expect(ACPGoalPill.summary(goal) == "Goal: Surface richer events · in progress · 12k")
+    }
+
+    @Test("truncates long objective")
+    func summaryTruncatesLongObjective() {
+        let goal = ACPGoalState(objective: String(repeating: "x", count: 90), status: "completed", tokenBudget: nil)
+        #expect(ACPGoalPill.summary(goal).hasPrefix("Goal: \(String(repeating: "x", count: 60))…"))
+        #expect(ACPGoalPill.summary(goal).hasSuffix("completed"))
+    }
+}
+```
+
+- [ ] **Step 2: Run tests to verify failure**
+
+Run:
+
+```bash
+rtk xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -only-testing:AlasTests/ACPGoalPillTests test
+```
+
+Expected: FAIL because `ACPGoalPill` does not exist.
+
+- [ ] **Step 3: Implement goal pill**
+
+Create `Alas/Sources/ACP/UI/ACPGoalPill.swift`:
+
+```swift
+import SwiftUI
+
+struct ACPGoalPill: View {
+    let goal: ACPGoalState
+    @Environment(\.theme) private var theme
+
+    var body: some View {
+        HStack(spacing: 5) {
+            Image(systemName: "target")
+                .font(.system(size: 10, weight: .semibold))
+            Text(Self.summary(goal))
+                .font(.system(size: 11, weight: .medium))
+                .lineLimit(1)
+                .truncationMode(.tail)
+        }
+        .foregroundStyle(theme.color("fg-muted"))
+        .padding(.horizontal, 8)
+        .padding(.vertical, 4)
+        .background(theme.color("bg-1").opacity(0.7))
+        .clipShape(Capsule())
+        .overlay(Capsule().strokeBorder(theme.color("line"), lineWidth: 0.5))
+    }
+
+    static func summary(_ goal: ACPGoalState) -> String {
+        let objective = goal.objective.count > 60
+            ? String(goal.objective.prefix(60)) + "…"
+            : goal.objective
+        var parts = ["Goal: \(objective)", statusLabel(goal.status)]
+        if let tokenBudget = goal.tokenBudget {
+            parts.append(tokenBudgetLabel(tokenBudget))
+        }
+        return parts.joined(separator: " · ")
+    }
+
+    private static func statusLabel(_ status: String) -> String {
+        switch status {
+        case "in_progress": return "in progress"
+        default: return status.replacingOccurrences(of: "_", with: " ")
+        }
+    }
+
+    private static func tokenBudgetLabel(_ value: Int) -> String {
+        if value >= 1000, value % 1000 == 0 {
+            return "\(value / 1000)k"
+        }
+        if value >= 1000 {
+            return String(format: "%.1fk", Double(value) / 1000.0)
+        }
+        return "\(value)"
+    }
+}
+```
+
+- [ ] **Step 4: Render in toolbar**
+
+In `Alas/Sources/ACP/UI/ACPToolbar.swift`, add after `ACPRecoveryPill(session:)`:
+
+```swift
+if let goal = session.currentGoal {
+    ACPGoalPill(goal: goal)
+        .layoutPriority(1)
+}
+```
+
+- [ ] **Step 5: Run tests and build**
+
+Run:
+
+```bash
+rtk xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -only-testing:AlasTests/ACPGoalPillTests test
+rtk xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -quiet build
+```
+
+Expected: both PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+rtk git add Alas/Sources/ACP/UI/ACPGoalPill.swift Alas/Sources/ACP/UI/ACPToolbar.swift AlasTests/ACP/UI/ACPGoalPillTests.swift
+rtk git commit -m "feat(acp): surface current goal"
+```
+
+---
+
+### Task 8: Final verification and cleanup
+
+**Files:**
+- Inspect all files changed by Tasks 1-7.
+
+- [ ] **Step 1: Run full project generation**
+
+Run:
+
+```bash
+rtk xcodegen
+```
+
+Expected: completes successfully. If `project.yml` was not edited, `Alas.xcodeproj` should either be unchanged or have no meaningful diff.
+
+- [ ] **Step 2: Run lightweight local build smoke only if the machine can handle it**
+
+Run:
+
+```bash
+rtk xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -quiet build
+```
+
+Expected: build succeeds when local resources allow it. If the laptop is under memory pressure or the build stalls, stop the local build and rely on GitHub Actions for the full authoritative build/test gate.
+
+- [ ] **Step 3: Push a PR and use CI as the full verification gate**
+
+Run:
+
+```bash
+rtk git fetch origin
+rtk git rebase origin/main
+rtk git push -u origin HEAD
+```
+
+Open a pull request for the current branch. Then monitor GitHub Actions and treat CI as the required full build/test verification. Do not run the full local test suite on a resource-constrained laptop unless CI is unavailable.
+
+- [ ] **Step 4: Loop on CI and PR review feedback**
+
+Use GitHub Actions logs for any failed checks. Fix the cause, commit the fix, push, and repeat until CI is green.
+
+If the PR receives an automated Codex review, inspect the review comments. Address actionable feedback, commit fixes, push, and repeat until the review is approving or has no requested changes.
+
+- [ ] **Step 5: Inspect diff for accidental scope creep**
+
+Run:
+
+```bash
+rtk git diff --stat HEAD
+rtk git diff HEAD -- Alas/Sources/ACP AlasTests/ACP docs/superpowers/plans/2026-07-03-acp-transcript-event-enrichment.md
+```
+
+Expected: changes are limited to ACP protocol/session/terminal/UI and ACP tests. No filesystem boundary expansion, provider-specific Codex UI branch, or attribution footer is present.
+
+- [ ] **Step 6: Commit any final cleanup**
+
+If Step 5 required cleanup, commit it:
+
+```bash
+rtk git add Alas/Sources/ACP AlasTests/ACP Alas.xcodeproj docs/superpowers/plans/2026-07-03-acp-transcript-event-enrichment.md
+rtk git commit -m "test(acp): verify transcript event enrichment"
+```
+
+If there is no cleanup diff, do not create an empty commit.

--- a/docs/superpowers/specs/2026-07-03-acp-transcript-event-enrichment-design.md
+++ b/docs/superpowers/specs/2026-07-03-acp-transcript-event-enrichment-design.md
@@ -1,0 +1,194 @@
+# ACP Transcript Event Enrichment Design
+
+## Context
+
+Issue #615 asks Alas to surface richer events emitted by the active
+`@agentclientprotocol/codex-acp` adapter. The Codex adapter now maps goals,
+reasoning, review events, web search, image generation and image view events,
+terminal output metadata, richer permission approvals, additional directories,
+and API-key authentication into ACP.
+
+Alas already handles many generic ACP concepts: text chunks, thoughts, plans,
+tool calls, tool-call content blocks, permissions, usage, and terminal-backed
+tool output. The main gaps are not Codex-specific UI branches; they are fields
+and update shapes that Alas currently drops before the transcript renderer can
+use them.
+
+## Goals
+
+- Preserve richer ACP update data in the protocol and transcript models.
+- Improve transcript rendering for terminal output, web search, images, MCP
+  calls, and review/thinking events through bridge-neutral presentation logic.
+- Surface current goal metadata separately from ordinary transcript rows.
+- Keep existing file and terminal safety boundaries intact.
+- Avoid Codex-only branches unless a field has no generic ACP representation.
+
+## Non-Goals
+
+- Do not expand filesystem read/write containment for additional workspace
+  directories in this pass.
+- Do not build a new review workflow UI. Review-related events only receive
+  clearer transcript rendering.
+- Do not require provider-specific code paths for Codex when the same data can
+  be represented by ACP fields.
+- Do not rewrite the transcript architecture or persistence store beyond the
+  fields needed for enriched events.
+
+## Architecture
+
+Add a small ACP enrichment layer between protocol decoding and SwiftUI
+rendering. The layer has three responsibilities:
+
+1. Decode and preserve richer protocol fields.
+2. Apply those fields to session and transcript state.
+3. Classify tool calls for rendering from generic ACP data.
+
+This keeps the protocol parser generic, keeps `ACPSession.apply(_:)` as the
+state transition point, and keeps UI-specific labeling in a presentation
+resolver instead of scattering string checks through `ACPToolCallCard`.
+
+## Protocol And Session Model
+
+Extend `ACPSessionUpdate` to decode `session_info_update` instead of mapping it
+to `.unknown`. The update should carry optional title and metadata. Metadata can
+remain an `AnyCodable`-backed value at the protocol edge, with typed extraction
+only for fields Alas understands.
+
+Extend `ACPToolCallPayload` and `ACPToolCallUpdate` to decode `_meta`. Extend
+`ACPToolCallUpdate` to decode optional `title`, `locations`, `rawInput`, and
+`rawOutput`, because upstream adapters can send those on updates, not just on
+the initial tool call.
+
+Extend `ACPMessage.ToolCall` with:
+
+- `rawOutput: String?`
+- `metadata: AnyCodable?` or a stable string/structured wrapper suitable for
+  persistence
+- preserved image/resource content summaries where needed for rendering
+
+`ACPSession.apply(_:)` should mutate existing tool-call rows with all updated
+fields. Existing behavior for status and content replacement stays intact.
+
+## Goal State
+
+Add a typed `ACPGoalState` on `ACPSession`:
+
+- `objective: String`
+- `status: String`
+- `tokenBudget: Int?`
+
+When `session_info_update` metadata contains a goal object, update
+`session.currentGoal`. When it contains a null goal, clear the goal. The Codex
+adapter currently sends this under `_meta.codex.goal`, but the extraction
+should be isolated so future bridge metadata can map into the same session
+state.
+
+Render the current goal outside normal transcript rows, most likely in the ACP
+toolbar/header area near plan and context indicators. Show the objective and,
+when present, status or token budget. Clearing the goal removes the indicator.
+Historical goal audit rows are out of scope.
+
+## Terminal Metadata
+
+Support terminal metadata emitted through tool-call `_meta`:
+
+- `terminal_info`
+- `terminal_output`
+- `terminal_output_delta`
+- `terminal_exit`
+
+Output metadata should feed a retained terminal-like buffer keyed by terminal
+id. Reuse `ACPTerminalTailView` where practical so command rows render the same
+whether output came from ACP `terminal/*` RPCs or from tool-call metadata.
+
+The UI should show command lifecycle information cleanly: command/title, cwd
+when available, running state, exit code or signal, and retained output. This
+should reduce duplicate or blank command rows when an adapter uses metadata
+instead of terminal RPCs.
+
+## Tool-Call Presentation
+
+Add an `ACPToolCallPresentation` resolver. It accepts an
+`ACPMessage.ToolCall` and returns display attributes such as label, icon,
+target chips, preview strategy, and expanded-body mode.
+
+The resolver should classify bridge-neutral shapes:
+
+- `kind == "search"` with titles such as `Web search`, `Open page`, or
+  `Find in page` renders as web search/open/find.
+- `kind == "other"` with title `Image generation` and image content or raw
+  output renders as image generation.
+- `kind == "read"` with image/resource link content renders as image view.
+- `_meta.is_mcp_tool_call == true` or an `mcp.*` title renders as an MCP call.
+- `kind == "think"` or title `Guardian Review` renders as review/thinking.
+- Existing read/search/execute/edit behavior remains the fallback.
+
+`ACPToolCallCard` should consume the resolver output rather than hard-coding
+all labels and icons directly.
+
+## Image Handling
+
+Preserve `ACPContentBlock.image` details from tool-call output instead of
+flattening them to `[image]` only. The renderer should show generated or viewed
+images in expanded tool cards when inline image data or a usable URI is
+available.
+
+Fallback behavior:
+
+- If only a resource link exists, show a file/resource chip.
+- If image data is unavailable after restore, show a stable placeholder rather
+  than an empty expanded card.
+- Keep existing user-prompt image attachment behavior unchanged.
+
+## Filesystem Boundaries
+
+The Codex adapter advertises additional workspace directory support, but Alas
+currently treats the session worktree as the containment boundary for file
+reads, writes, and terminal context. This design does not change that boundary.
+
+If additional workspace directories are needed later, they should get a separate
+design covering trust, user visibility, read/write containment, and persistence.
+
+## Data Flow
+
+1. ACP client decodes `session/update`.
+2. `ACPSessionUpdate` preserves enriched fields and metadata.
+3. `ACPSession.apply(_:)` updates either session-level state, such as goal, or
+   transcript rows, such as tool calls.
+4. Persistence stores enriched tool-call rows with backwards-compatible
+   decoding for older rows.
+5. SwiftUI resolves each tool call through `ACPToolCallPresentation`.
+6. Terminal metadata updates retained terminal buffers so existing terminal tail
+   UI can render output and exit state.
+
+## Error Handling
+
+- Unknown metadata fields are preserved when possible and ignored by the UI.
+- Malformed known metadata fields should not fail the whole session update.
+- Missing image data or missing retained terminal buffers should render a clear
+  fallback message, not an empty card.
+- Session goal extraction should tolerate absent, null, or partial fields.
+- Existing `.unknown` handling remains for unsupported session update kinds.
+
+## Testing
+
+Add Swift Testing coverage for:
+
+- Decoding `session_info_update` with metadata and title.
+- Decoding `_meta` on `tool_call` and `tool_call_update`.
+- Applying tool-call updates that mutate title, locations, raw input, raw
+  output, metadata, status, and content.
+- Applying goal metadata updates and clears.
+- Preserving image content from tool-call output.
+- Feeding terminal output and exit metadata into retained terminal rendering
+  state.
+- Presentation classification for web search, image generation, image view,
+  MCP calls, guardian review, and existing fallback kinds.
+
+Final implementation verification should use the project-standard commands:
+
+```bash
+xcodegen
+xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -quiet build
+xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' test
+```


### PR DESCRIPTION
## Summary
- Preserve enriched ACP session and tool-call metadata, including session goals, raw output, assets, locations, and terminal ids.
- Apply session metadata into transcript state and surface current goals in the ACP toolbar.
- Render richer bridge-neutral tool-call presentations for terminal metadata output, web/search-style calls, MCP/review events, and image assets.

Closes #615

## Verification
- `git diff --check`
- `rtk swiftc -parse Alas/Sources/ACP/Protocol/ACPSessionUpdate.swift Alas/Sources/ACP/Session/ACPSession.swift Alas/Sources/ACP/Session/ACPSessionRunner.swift AlasTests/ACP/Protocol/ACPSessionUpdateTests.swift`

Full build/test verification is left to CI because local Xcode builds are resource constrained on this machine.