### PR TITLE
fix(remote): stop tool cards collapsing to 1px as transcript fills

### DIFF
--- a/Alas/Resources/RemoteWeb/index.html
+++ b/Alas/Resources/RemoteWeb/index.html
@@ -11,7 +11,7 @@
   <link rel="icon" href="/icon.svg" type="image/svg+xml" />
   <link rel="apple-touch-icon" href="/icon-180.png" />
   <title>Alas Remote</title>
-  <link rel="stylesheet" href="/style.css?v=34" />
+  <link rel="stylesheet" href="/style.css?v=35" />
 </head>
 <body>
   <header id="bar">

--- a/Alas/Resources/RemoteWeb/style.css
+++ b/Alas/Resources/RemoteWeb/style.css
@@ -93,6 +93,10 @@ h1 { font-size: 22px; font-weight: 700; margin: 12px 4px 10px; }
 /* Transcript: a non-scrolling column — only #messages scrolls, #drivebar pins. */
 #transcript { display: flex; flex-direction: column; overflow: hidden; padding: 0; }
 #messages { flex: 1 1 auto; min-height: 0; overflow-y: auto; -webkit-overflow-scrolling: touch; padding: 2px 12px 8px; display: flex; flex-direction: column; }
+/* Message rows must keep their natural height. #messages is a flex column, so
+   without this its children shrink to fit once the transcript overflows —
+   tool cards (overflow: hidden → automatic min-size 0) collapse to ~1px lines. */
+#messages > * { flex-shrink: 0; }
 .msg { margin: 5px 0; line-height: 1.5; font-size: 15px; overflow-wrap: anywhere; white-space: pre-wrap; }
 .m-agent { align-self: stretch; color: var(--fg); padding: 1px 2px; }
 .m-user { align-self: flex-end; max-width: 82%; padding: 9px 13px; color: var(--fg); background: linear-gradient(180deg, color-mix(in oklab, var(--accent) 32%, transparent), color-mix(in oklab, var(--accent) 20%, transparent)); border: 0.5px solid color-mix(in oklab, var(--accent) 50%, transparent); border-radius: 13px 13px 4px 13px; box-shadow: 0 2px 8px rgba(0,0,0,.2); }

--- a/Alas/Resources/RemoteWeb/sw.js
+++ b/Alas/Resources/RemoteWeb/sw.js
@@ -1,8 +1,8 @@
-const CACHE_NAME = "alas-remote-shell-v25";
+const CACHE_NAME = "alas-remote-shell-v26";
 const SHELL_ASSETS = [
   "/",
   "/index.html",
-  "/style.css?v=34",
+  "/style.css?v=35",
   "/app.js?v=48",
   "/marked.min.js?v=28",
   "/purify.min.js?v=28",

--- a/AlasTests/Remote/RemoteWebAssetTests.swift
+++ b/AlasTests/Remote/RemoteWebAssetTests.swift
@@ -49,10 +49,10 @@ struct RemoteWebAssetTests {
         let sw = try asset("sw.js")
 
         #expect(html.contains(#"/app.js?v=48"#))
-        #expect(html.contains(#"/style.css?v=34"#))
-        #expect(sw.contains(#"const CACHE_NAME = "alas-remote-shell-v25";"#))
+        #expect(html.contains(#"/style.css?v=35"#))
+        #expect(sw.contains(#"const CACHE_NAME = "alas-remote-shell-v26";"#))
         #expect(sw.contains(#""/app.js?v=48""#))
-        #expect(sw.contains(#""/style.css?v=34""#))
+        #expect(sw.contains(#""/style.css?v=35""#))
     }
 
     @Test func remoteWebToolRowsAvoidNativeButtonRenderingOnMobileSafari() throws {
@@ -66,10 +66,10 @@ struct RemoteWebAssetTests {
         #expect(app.contains("function handleCardToggleKeydown"))
         #expect(!app.contains(#"const button = el("button", "tool-toggle")"#))
         #expect(html.contains(#"/app.js?v=48"#))
-        #expect(html.contains(#"/style.css?v=34"#))
-        #expect(sw.contains(#"const CACHE_NAME = "alas-remote-shell-v25";"#))
+        #expect(html.contains(#"/style.css?v=35"#))
+        #expect(sw.contains(#"const CACHE_NAME = "alas-remote-shell-v26";"#))
         #expect(sw.contains(#""/app.js?v=48""#))
-        #expect(sw.contains(#""/style.css?v=34""#))
+        #expect(sw.contains(#""/style.css?v=35""#))
     }
 
     @Test func remoteBareURLLinkifierPreservesIndentedCodeBlocks() throws {
@@ -111,7 +111,7 @@ struct RemoteWebAssetTests {
         #expect(css.contains(".session-state-inactive"))
         #expect(css.contains(".session-meta"))
         #expect(html.contains("/app.js?v=48"))
-        #expect(html.contains("/style.css?v=34"))
+        #expect(html.contains("/style.css?v=35"))
     }
 
     @Test func remoteWebExposesSessionRenameControls() throws {
@@ -137,7 +137,7 @@ struct RemoteWebAssetTests {
         #expect(css.contains("#detail-title"))
         #expect(css.contains(".sheet-input"))
         #expect(sw.contains(#""/app.js?v=48""#))
-        #expect(sw.contains(#""/style.css?v=34""#))
+        #expect(sw.contains(#""/style.css?v=35""#))
     }
 
     @Test func configSheetScrollsWhenModelListOverflows() throws {
@@ -151,6 +151,15 @@ struct RemoteWebAssetTests {
         #expect(css.contains("#cfg .sheet-card { max-height: min(85vh, 640px); display: flex; flex-direction: column; }"))
         #expect(css.contains("#cfg-scroll { min-height: 0; overflow-y: auto; -webkit-overflow-scrolling: touch; }"))
         #expect(css.contains("#cfg-close { flex: 0 0 auto; }"))
+    }
+
+    @Test func messageRowsDoNotShrinkInTranscriptFlexColumn() throws {
+        let css = try asset("style.css")
+
+        // #messages is a flex column; its children must not shrink or tool cards
+        // (overflow: hidden → automatic min-size 0) collapse to ~1px lines once
+        // the transcript fills the viewport.
+        #expect(css.contains("#messages > * { flex-shrink: 0; }"))
     }
 
     @Test func remoteWebIncludesNewSessionControls() throws {


### PR DESCRIPTION
## Problem

In the remote web app chat screen, tool cards render correctly at first but as the transcript fills the screen they shrink progressively until they are ~1px-tall lines — visible but useless. Plain text messages are unaffected.

## Root cause

`#messages` is a flex column:

```css
#messages { ... display: flex; flex-direction: column; }
```

Its children carry the default `flex-shrink: 1`, so once the total content height exceeds the container the flex algorithm shrinks them to fit. Tool cards (`.m-tool`) use `overflow: hidden`, which per the flexbox spec gives a flex item an **automatic minimum size of 0** — so they collapse all the way down. Text messages keep their content-based minimum size, which is why only tool cards degrade.

## Fix

Pin every message row so it keeps its natural height and lets `#messages` scroll instead:

```css
#messages > * { flex-shrink: 0; }
```

Bumped the `style.css` cache-buster (`v=33` → `v=34`) and the service-worker cache name (`v24` → `v25`) so clients pick up the new stylesheet, and updated the asset-version tests.

## Tests

Added `messageRowsDoNotShrinkInTranscriptFlexColumn` to `RemoteWebAssetTests` and updated the existing cache-buster assertions.

> Note: touches the same versioned assets as #626; whichever merges second will need a trivial cache-buster rebase.