### PR TITLE
fix(changes): hide Prepare/Push affordance when nothing to push

### DIFF
--- a/Alas/Sources/Right/ChangesPreparationModel.swift
+++ b/Alas/Sources/Right/ChangesPreparationModel.swift
@@ -78,10 +78,10 @@ struct ChangesPreparationModel: Equatable {
            effectiveAheadCommitCount == 0 {
             reviewRequestAction = nil
         } else if builtReviewRequestAction?.kind == .pushBranch,
-                   builtReviewRequestAction?.isInFlight != true,
-                   local?.needsPush == false,
-                   builtReviewAction == nil,
-                   builtDraftAction == nil {
+                    builtReviewRequestAction?.isInFlight != true,
+                    builtReviewAction == nil,
+                    builtDraftAction == nil,
+                    Self.pushHasNothingToPush(local: local, aheadCommitCount: effectiveAheadCommitCount) {
             reviewRequestAction = nil
         } else {
             reviewRequestAction = builtReviewRequestAction
@@ -123,4 +123,20 @@ struct ChangesPreparationModel: Equatable {
         .openReviewRequest,
         .refresh,
     ]
+
+    /// A `pushBranch` action is only useful when there's something to push.
+    /// `GitService.needsPush` returns `true` whenever the branch has no
+    /// upstream (so a fresh branch with no commits still reports "needs
+    /// push"), which surfaces a no-op Push button on clean worktrees. Hide
+    /// it when there's no upstream and no commits ahead of base — pushing
+    /// in that state has nothing to send. When an upstream exists, trust
+    /// `needsPush` since `@{u}..HEAD` reflects real unpushed commits.
+    private static func pushHasNothingToPush(
+        local: ReviewLoopLocalState?,
+        aheadCommitCount: Int
+    ) -> Bool {
+        guard let local else { return aheadCommitCount == 0 }
+        if local.needsPush == false { return true }
+        return !local.hasUpstream && local.aheadCommitCount == 0
+    }
 }

--- a/AlasTests/ReviewChangesModelsTests.swift
+++ b/AlasTests/ReviewChangesModelsTests.swift
@@ -362,6 +362,36 @@ struct ReviewChangesModelsTests {
         #expect(model.isVisible)
     }
 
+    @Test func preparationModelHidesPushWhenBranchHasNoUpstreamAndNoCommits() {
+        let actions = [
+            ReviewReadinessModel.Action(kind: .pushBranch, title: "Push", isEnabled: true),
+        ]
+        let local = ReviewLoopLocalState(
+            branchName: "feature",
+            headSHA: "abc123",
+            baseBranch: "main",
+            hasWorkingTreeChanges: false,
+            hasStagedChanges: false,
+            aheadCommitCount: 0,
+            hasUpstream: false,
+            needsPush: true
+        )
+
+        let model = ChangesPreparationModel(
+            changes: [],
+            hasDraft: false,
+            draftNonEmpty: false,
+            aheadCommitCount: 0,
+            local: local,
+            readinessActions: actions
+        )
+
+        #expect(model.reviewAction == nil)
+        #expect(model.draftAction == nil)
+        #expect(model.reviewRequestAction == nil)
+        #expect(!model.isVisible)
+    }
+
     @Test func preparationModelShowsPushUsingLocalStateCommitCount() throws {
         let actions = [
             ReviewReadinessModel.Action(kind: .pushBranch, title: "Push", isEnabled: true),


### PR DESCRIPTION
GitService.needsPush returns true whenever the branch has no upstream, so a clean worktree on a fresh branch with no commits still surfaced a Push button that did nothing when tapped.

Hide the `pushBranch` review-readiness action in `ChangesPreparationModel` when there is no upstream and no commits ahead of base. When an upstream exists, trust `needsPush` since `@{u}..HEAD` reflects real unpushed commits.

```bash
xcodegen && xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' test
``

Couldn't run the full suite locally in this worktree (missing zmx submodule + SwiftPM network), but the logic preserves all existing `ReviewChangesModelsTests` expectations and adds a new `preparationModelHidesPushWhenBranchHasNoUpstreamAndNoCommits` case.