### PR TITLE
feat(project): Customize project icons

### DIFF
--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -667,6 +667,7 @@
 		98CCFEFD7D0E8C27C6B373F6 /* ShortcutRecorder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 05B122F66B2DEA7853804624 /* ShortcutRecorder.swift */; };
 		98ED89EA20255EBB9D186AD5 /* MergeConflictBinaryDetectionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 31CE012ED93AA22C257FEB8A /* MergeConflictBinaryDetectionTests.swift */; };
 		9927E3934D3CAA9055EF5E44 /* DiffOpenFileAvailabilityTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2BFCE07604D55558B13FC33B /* DiffOpenFileAvailabilityTests.swift */; };
+		99613CF61A0F19105D8E7A71 /* EmojiPickerButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7BEC4E033DB3BA44C825D453 /* EmojiPickerButton.swift */; };
 		99711AA1B0FB450D32770415 /* ZmxSunPathBudget.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A40BDC5115B641AB26220D9 /* ZmxSunPathBudget.swift */; };
 		999C8421F3610FF682CE9D0E /* ReviewTabView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 500B60003934104E2CA5A895 /* ReviewTabView.swift */; };
 		9A3EB3ACA3AB366431C904EB /* WorktreeService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6C4E238E48247A6CDD5565D2 /* WorktreeService.swift */; };
@@ -1016,6 +1017,7 @@
 		E30832C33A680645C481826F /* ANSIStreamTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 86CB3F953562BAFB284B5DB7 /* ANSIStreamTests.swift */; };
 		E31120BCB281A62D767D85BC /* HunkPatchBuilderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA486F66BE4CEB2A16EB148B /* HunkPatchBuilderTests.swift */; };
 		E3158A4D8FBD36D06D421D28 /* RepoSelectorRecents.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9CA420C011D4235E47A3FB1B /* RepoSelectorRecents.swift */; };
+		E3217588485CC96AB05AA5B9 /* DialogChromeLayoutTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40497B428C9395535DF6C146 /* DialogChromeLayoutTests.swift */; };
 		E395C1299D215BA0EC4760E8 /* SpaceConfig.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7963D4DD10B67EB683510FF6 /* SpaceConfig.swift */; };
 		E3B38707284D08326C3183E4 /* FuzzyMatchTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E444D51CB35528C8E5AB150A /* FuzzyMatchTests.swift */; };
 		E3C34254BA474878AEC6683D /* PendingReviewTray.swift in Sources */ = {isa = PBXBuildFile; fileRef = FDFF1C68250433F4B9891F1A /* PendingReviewTray.swift */; };
@@ -1433,6 +1435,7 @@
 		3F4C58E8C0B1BC5B7CB2BBCB /* Code.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Code.swift; sourceTree = "<group>"; };
 		3F79A184C86BE6C6BF72EB57 /* ACPMessageList.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPMessageList.swift; sourceTree = "<group>"; };
 		3F8435ABAF423A6F5BC28E4C /* DiffPreferenceBindings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiffPreferenceBindings.swift; sourceTree = "<group>"; };
+		40497B428C9395535DF6C146 /* DialogChromeLayoutTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DialogChromeLayoutTests.swift; sourceTree = "<group>"; };
 		4068B3E83F9A82C2E3F8A6A1 /* OpenSessions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OpenSessions.swift; sourceTree = "<group>"; };
 		4069925EE709DD18AEA810B3 /* ShortcutResolver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShortcutResolver.swift; sourceTree = "<group>"; };
 		408F9FF672160D96B1C22648 /* FilesTabCompactChainTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FilesTabCompactChainTests.swift; sourceTree = "<group>"; };
@@ -1684,6 +1687,7 @@
 		7A240CD3EF074300828A1214 /* CommitReviewLoader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommitReviewLoader.swift; sourceTree = "<group>"; };
 		7A2B4B719D9F4EAAE84B14D1 /* ProjectAvatarPresetProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProjectAvatarPresetProvider.swift; sourceTree = "<group>"; };
 		7B22D5EBE7EDAC07C943C91D /* WebSocketFrame.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebSocketFrame.swift; sourceTree = "<group>"; };
+		7BEC4E033DB3BA44C825D453 /* EmojiPickerButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EmojiPickerButton.swift; sourceTree = "<group>"; };
 		7BF6F2D792F7DFAE3DA8E597 /* ThemeEnvironment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThemeEnvironment.swift; sourceTree = "<group>"; };
 		7C38FA009B7044E9DC5480A7 /* ACPSessionsButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPSessionsButton.swift; sourceTree = "<group>"; };
 		7C3A8A65C6EC8182FD23AE97 /* CodeTextViewAutoPairTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CodeTextViewAutoPairTests.swift; sourceTree = "<group>"; };
@@ -2487,6 +2491,7 @@
 				AA98E1DB8D77DE67918D6B9F /* CopilotInstallerTests.swift */,
 				BF3F87CE04B7E98606BF76CA /* CursorInstallerTests.swift */,
 				179A74F3A825DA1EC4C4E0FC /* DebounceTimerTests.swift */,
+				40497B428C9395535DF6C146 /* DialogChromeLayoutTests.swift */,
 				2B9CB2A64E9E16A2DE3A6272 /* DiffContextExpansionTests.swift */,
 				6181842BEA798CB8606F222B /* DiffDisplayModelBuilderTests.swift */,
 				729DDA22CA94FA0DC8810057 /* DiffInlineCommentModelTests.swift */,
@@ -2892,6 +2897,7 @@
 				524926F2D16B1AD83FC234AB /* ChangeSummaryVisibility.swift */,
 				0E6600436B01C75D85C01FFA /* Clipboard.swift */,
 				5C8BF1EC24E449A302A1E25C /* CopyFeedbackState.swift */,
+				7BEC4E033DB3BA44C825D453 /* EmojiPickerButton.swift */,
 				16CA8FEE64D73BDEBAF74878 /* Kbd.swift */,
 				7D4A000B32C3BF0E253BB0B6 /* PointingHandCursor.swift */,
 				EECB91379591DA21D216A894 /* RelativeTime.swift */,
@@ -4764,6 +4770,7 @@
 				395BC74AF07FD44D67DBE579 /* EditorOverlayPanel.swift in Sources */,
 				1066AF44E2FCA9B1B2DDE9D7 /* EditorTabView.swift in Sources */,
 				41F7A0E0854B545F99062BDC /* EditorTheme.swift in Sources */,
+				99613CF61A0F19105D8E7A71 /* EmojiPickerButton.swift in Sources */,
 				7CDFA95F095090FF242B8248 /* EmptyState.swift in Sources */,
 				950C937884477417569DC20B /* EmptyTabView.swift in Sources */,
 				7A0D3E122F34EF1A2A04984F /* EnvBuilder.swift in Sources */,
@@ -5299,6 +5306,7 @@
 				25347EFEF1B5F7F4915DB120 /* DebounceTimerTests.swift in Sources */,
 				7EB64E55CE27886D660C5D0C /* DefinitionSnippetCacheTests.swift in Sources */,
 				BFF99F8FDEA5D05EF4E1EEC3 /* DiagnosticsRangeTests.swift in Sources */,
+				E3217588485CC96AB05AA5B9 /* DialogChromeLayoutTests.swift in Sources */,
 				9DDA9F2462746F06A652973A /* DiffContextExpansionTests.swift in Sources */,
 				899FB89D155619CF846C6BDC /* DiffDisplayModelBuilderTests.swift in Sources */,
 				FD5B6E7F566A9D0BACD19267 /* DiffInlineCommentModelTests.swift in Sources */,

--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -650,6 +650,7 @@
 		960593EAB0380436038D1400 /* ACPSessionToolCallTruncationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2777D1596E51D8DCA8E7ABA3 /* ACPSessionToolCallTruncationTests.swift */; };
 		962361DC40B0707AB7CA6E75 /* session-update-tool-call-update-no-meta.json in Resources */ = {isa = PBXBuildFile; fileRef = 30BAC172C16C360F917B6EED /* session-update-tool-call-update-no-meta.json */; };
 		9624AE35A36692177C9EBD38 /* ACPSubmitIntent.swift in Sources */ = {isa = PBXBuildFile; fileRef = A655F5AA40CA10A7685794F7 /* ACPSubmitIntent.swift */; };
+		9627D6EAF83AA4B66FE09361 /* ProjectIconImageStagingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 270C700882ACFBBC59F931D2 /* ProjectIconImageStagingTests.swift */; };
 		9654335704CB69BA7216DD63 /* ReviewLoopStateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3939B27EA8D7A562048E5932 /* ReviewLoopStateTests.swift */; };
 		965621529CB4BD82DD646B76 /* ACPManagerAccessorsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B133843C0559BBD6E769ABB8 /* ACPManagerAccessorsTests.swift */; };
 		9666162EC5BE3445EEBCDEA1 /* RemoteWorktreeSummaryBuilderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20A5D6E7C4527B459EFC2CBB /* RemoteWorktreeSummaryBuilderTests.swift */; };
@@ -703,6 +704,7 @@
 		A05391FF4907AB0870A79C02 /* ReviewEvidenceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4B05E0E44B026AE7E8EA3101 /* ReviewEvidenceTests.swift */; };
 		A06C59805BCD9D3200896932 /* StagedDiffLoader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3B2FEDAAF927CDC9E4D19551 /* StagedDiffLoader.swift */; };
 		A0B5074B10E732616C917D10 /* DragHandleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1379AD82025AFEABD37EFC42 /* DragHandleTests.swift */; };
+		A0CAF1DC84D4D990617B96F7 /* ProjectIconImageStaging.swift in Sources */ = {isa = PBXBuildFile; fileRef = C6B874BF8AEC4B60FC536E04 /* ProjectIconImageStaging.swift */; };
 		A0F1E46BC1A9E2CC21805EE7 /* FilesTabFilterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1977C85C3DFD1F232A2755AD /* FilesTabFilterTests.swift */; };
 		A1252F6D967104D2B369CEA8 /* ReviewFeedbackBundleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C84E444E25F7DDBE30FB824 /* ReviewFeedbackBundleTests.swift */; };
 		A127B7AA4E95BEF74927FBDE /* WorktreePathTemplateRendererTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 71196F28AFF66FFA70E008D6 /* WorktreePathTemplateRendererTests.swift */; };
@@ -1295,6 +1297,7 @@
 		2648D58703B6C53ED15D536A /* TreeSitterHCL */ = {isa = PBXFileReference; lastKnownFileType = folder; name = TreeSitterHCL; path = ThirdParty/TreeSitterHCL; sourceTree = SOURCE_ROOT; };
 		269CE27A6F4F2E663EDF9052 /* GitNameValidator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GitNameValidator.swift; sourceTree = "<group>"; };
 		26E8DE57F9A8D5230BCB7A2C /* ACPSubmitIntentTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPSubmitIntentTests.swift; sourceTree = "<group>"; };
+		270C700882ACFBBC59F931D2 /* ProjectIconImageStagingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProjectIconImageStagingTests.swift; sourceTree = "<group>"; };
 		271F79A165CAA8617C1EAA4E /* GitTypesTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GitTypesTests.swift; sourceTree = "<group>"; };
 		274681651A972F6771B1930C /* session-update-tool-call-update-meta.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "session-update-tool-call-update-meta.json"; sourceTree = "<group>"; };
 		2763F93ADFDCDF6B31D16475 /* UpdateController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UpdateController.swift; sourceTree = "<group>"; };
@@ -1976,6 +1979,7 @@
 		C5E83B4DDF185280E01CA80A /* ContentSearcherTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentSearcherTests.swift; sourceTree = "<group>"; };
 		C60A6B7CB83D842FEE2D801C /* ThreePaneSizingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThreePaneSizingTests.swift; sourceTree = "<group>"; };
 		C682FF74C86B77BDCF46CF25 /* ChangesTabView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChangesTabView.swift; sourceTree = "<group>"; };
+		C6B874BF8AEC4B60FC536E04 /* ProjectIconImageStaging.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProjectIconImageStaging.swift; sourceTree = "<group>"; };
 		C6C27094E7804D975635EB11 /* WorktreeRowHeightTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorktreeRowHeightTests.swift; sourceTree = "<group>"; };
 		C6CA79B71B4AA72697392702 /* NumstatParser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NumstatParser.swift; sourceTree = "<group>"; };
 		C6E896FEA37B4691BD16E2DD /* EditorBufferTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditorBufferTests.swift; sourceTree = "<group>"; };
@@ -2592,6 +2596,7 @@
 				E1FD24B10ED0B3D4280F15E8 /* ProjectConfigAgentOverrideTests.swift */,
 				5B3FF64CC698074BFDE2A36A /* ProjectConfigTests.swift */,
 				8E3A9C194105E52A72293855 /* ProjectGitWatcherTests.swift */,
+				270C700882ACFBBC59F931D2 /* ProjectIconImageStagingTests.swift */,
 				141C4CAF1B49032EDF0FF404 /* ProjectIconTests.swift */,
 				00809DCA566AAAADD7448659 /* ProjectPickerTests.swift */,
 				BD708EEB35D93A7E7150981D /* ProjectsManagerHeadUpdatesTests.swift */,
@@ -2714,6 +2719,7 @@
 				B24ABE96ED3C62146A3CED62 /* EmptyState.swift */,
 				EC6599EB47850D1E13ACF0EB /* NewProjectDialog.swift */,
 				711F3E7BD099EDADEA0802FD /* NewWorktreeDialog.swift */,
+				C6B874BF8AEC4B60FC536E04 /* ProjectIconImageStaging.swift */,
 				3CE948F94DB2759E66CD4DEF /* ProjectPicker.swift */,
 				C2E05FF3EC7EAB497BA0FFE0 /* RepoSelector */,
 			);
@@ -4910,6 +4916,7 @@
 				1DCE55DBA4A9DC466D817D22 /* ProjectConfig.swift in Sources */,
 				F88FD8BE546E36A0E3BF2594 /* ProjectGitWatcher.swift in Sources */,
 				419029F5618BC364426491E5 /* ProjectIcon.swift in Sources */,
+				A0CAF1DC84D4D990617B96F7 /* ProjectIconImageStaging.swift in Sources */,
 				E8CD4B9C918E2A9A83FA637A /* ProjectIconView.swift in Sources */,
 				E175AE346DFAD0B62827C921 /* ProjectPicker.swift in Sources */,
 				6E69D87B57B23223A48AB6F7 /* ProjectsManager.swift in Sources */,
@@ -5424,6 +5431,7 @@
 				636ED129478744F9169AD774 /* ProjectConfigAgentOverrideTests.swift in Sources */,
 				D13AFC98364971915782491C /* ProjectConfigTests.swift in Sources */,
 				2A18F8265F467BF33AD69159 /* ProjectGitWatcherTests.swift in Sources */,
+				9627D6EAF83AA4B66FE09361 /* ProjectIconImageStagingTests.swift in Sources */,
 				7F2D2A9180110871CFF58192 /* ProjectIconTests.swift in Sources */,
 				4E7279E8E76C7778BC686DF1 /* ProjectPickerTests.swift in Sources */,
 				BEDFCA98CA9C992302618128 /* ProjectsManagerHeadUpdatesTests.swift in Sources */,

--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -1043,6 +1043,7 @@
 		E867128A3FF1EFD04C2D65E4 /* session-new-request.json in Resources */ = {isa = PBXBuildFile; fileRef = 22677ECD3E098EBE6389D776 /* session-new-request.json */; };
 		E89811545A8AD0ED03655AA3 /* RecommendedLanguageCatalogTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B77927262BEAF31E39CE6698 /* RecommendedLanguageCatalogTests.swift */; };
 		E8CCFE313DFCCA35BE8F93D7 /* GitServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 039741E1CCAEF9770D5DEE08 /* GitServiceTests.swift */; };
+		E8CD4B9C918E2A9A83FA637A /* ProjectIconView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 56C7878101DA7532B9850D13 /* ProjectIconView.swift */; };
 		E8F4E5FAC73026DAC29FDEF7 /* DiffDisplayModelBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 00F66827E8BFF9AB51D76A96 /* DiffDisplayModelBuilder.swift */; };
 		E9507AB389CE47A6A48C049B /* ACPProcessLiveness.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4DA695BB3D2901435BFF6C0E /* ACPProcessLiveness.swift */; };
 		E99E4DB46496707E7A3F044A /* PiACPInstaller.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE6F36C31DB1C13D86416B4B /* PiACPInstaller.swift */; };
@@ -1529,6 +1530,7 @@
 		563B664D082A9523260AA2EF /* RepoDot.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RepoDot.swift; sourceTree = "<group>"; };
 		56780EE994E2CA14A3ABBA7B /* MergeActionGutter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MergeActionGutter.swift; sourceTree = "<group>"; };
 		56BF141F589820AA91674BD0 /* TreeSitterJavaScript */ = {isa = PBXFileReference; lastKnownFileType = folder; name = TreeSitterJavaScript; path = ThirdParty/TreeSitterJavaScript; sourceTree = SOURCE_ROOT; };
+		56C7878101DA7532B9850D13 /* ProjectIconView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProjectIconView.swift; sourceTree = "<group>"; };
 		56D1AC9E1E00C3C5C234382C /* TouchTargetSmokeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TouchTargetSmokeTests.swift; sourceTree = "<group>"; };
 		56E964C72322223859CC6AF8 /* ReviewFeedbackAgentSender.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReviewFeedbackAgentSender.swift; sourceTree = "<group>"; };
 		5733BF1C52BA0FCFB2724D57 /* ACPQueuedBubbleActionMetricsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPQueuedBubbleActionMetricsTests.swift; sourceTree = "<group>"; };
@@ -3324,6 +3326,7 @@
 			isa = PBXGroup;
 			children = (
 				0544FCFB9BC3E26FDB57CC96 /* HarnessPill.swift */,
+				56C7878101DA7532B9850D13 /* ProjectIconView.swift */,
 				563B664D082A9523260AA2EF /* RepoDot.swift */,
 				768D12909DD5233659AC4E03 /* RepoGroupView.swift */,
 				B8052B601A9C834365A9D880 /* SidebarHeaderView.swift */,
@@ -4907,6 +4910,7 @@
 				1DCE55DBA4A9DC466D817D22 /* ProjectConfig.swift in Sources */,
 				F88FD8BE546E36A0E3BF2594 /* ProjectGitWatcher.swift in Sources */,
 				419029F5618BC364426491E5 /* ProjectIcon.swift in Sources */,
+				E8CD4B9C918E2A9A83FA637A /* ProjectIconView.swift in Sources */,
 				E175AE346DFAD0B62827C921 /* ProjectPicker.swift in Sources */,
 				6E69D87B57B23223A48AB6F7 /* ProjectsManager.swift in Sources */,
 				50D7FF67981533B21FCB0890 /* PromptEditorBody.swift in Sources */,

--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -245,6 +245,7 @@
 		395276FB3018E0B9E68A7D81 /* ACPMockClientTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11BA9F25CB0A6A2BFDB390EE /* ACPMockClientTests.swift */; };
 		395BC74AF07FD44D67DBE579 /* EditorOverlayPanel.swift in Sources */ = {isa = PBXBuildFile; fileRef = F6883364648BF4B9F5DA131F /* EditorOverlayPanel.swift */; };
 		3961F6003185B2FC9DFE7E14 /* ImageDiffDifferenceComputerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9278ED5964A66871F5299F0C /* ImageDiffDifferenceComputerTests.swift */; };
+		396AF154C56F4B5061756366 /* ProjectAvatarPresetProviderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 72B788982A64A04D18889D25 /* ProjectAvatarPresetProviderTests.swift */; };
 		397FADBCCF3211504DAEDC35 /* ZmxEnvTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 75DFDC1BD30B1D1CC469D54C /* ZmxEnvTests.swift */; };
 		39DE92AE4B12D2CD03655562 /* CommitPromptStatus.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A61DF43677282D4CA21769A /* CommitPromptStatus.swift */; };
 		3A108152BB33EF9B00FC2F1B /* EditorLSPStatusBadge.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDABED76CD2A552B1781D3F4 /* EditorLSPStatusBadge.swift */; };
@@ -525,6 +526,7 @@
 		79575F0DA597D2C2DFCDC9E2 /* LSPMessagesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE7675D7F75E36E9C81193C8 /* LSPMessagesTests.swift */; };
 		7A0D3E122F34EF1A2A04984F /* EnvBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 159FE807399835B0821E1CAB /* EnvBuilder.swift */; };
 		7A2C912B677A34391361B720 /* AdvancedSettingsVisibility.swift in Sources */ = {isa = PBXBuildFile; fileRef = 94B123596E047E4CE0FAFE3E /* AdvancedSettingsVisibility.swift */; };
+		7A7A04035A83C4AD9ED5897D /* ProjectAvatarPresetProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7A2B4B719D9F4EAAE84B14D1 /* ProjectAvatarPresetProvider.swift */; };
 		7A816022DD913BC76F5EBA7F /* InstallNudgeResolverTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 134EE8D2BC31085A504D27D8 /* InstallNudgeResolverTests.swift */; };
 		7ABF2BE84D6677FE5BCC8ED1 /* ACPMarkdownInlineRenderer.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC3814D8B30EBB9991F3388A /* ACPMarkdownInlineRenderer.swift */; };
 		7ACFA19EA43966431D906F55 /* TreeSitterPHP in Frameworks */ = {isa = PBXBuildFile; productRef = 78020033FC689A2BCDF51DED /* TreeSitterPHP */; };
@@ -1652,6 +1654,7 @@
 		7294C0B27241ADEB9A95347A /* ACPNewChatEmptyStateView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPNewChatEmptyStateView.swift; sourceTree = "<group>"; };
 		72970A1D2817539DB5243058 /* MergeWordDiffTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MergeWordDiffTests.swift; sourceTree = "<group>"; };
 		729DDA22CA94FA0DC8810057 /* DiffInlineCommentModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiffInlineCommentModelTests.swift; sourceTree = "<group>"; };
+		72B788982A64A04D18889D25 /* ProjectAvatarPresetProviderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProjectAvatarPresetProviderTests.swift; sourceTree = "<group>"; };
 		73539FDFE4BDBD4D3B4DE546 /* ACPFirstRunConnectingPhase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPFirstRunConnectingPhase.swift; sourceTree = "<group>"; };
 		737A9A3D11EA28582CA5D061 /* ACPFirstRunConnectingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPFirstRunConnectingView.swift; sourceTree = "<group>"; };
 		73A34259DE8E978943E8BE16 /* OKLCH.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OKLCH.swift; sourceTree = "<group>"; };
@@ -1679,6 +1682,7 @@
 		79DDEA496740F5B0B5EE808B /* Process+Git.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Process+Git.swift"; sourceTree = "<group>"; };
 		79F544A8DC56D0D4166E0A4F /* CommitContextBuilderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommitContextBuilderTests.swift; sourceTree = "<group>"; };
 		7A240CD3EF074300828A1214 /* CommitReviewLoader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommitReviewLoader.swift; sourceTree = "<group>"; };
+		7A2B4B719D9F4EAAE84B14D1 /* ProjectAvatarPresetProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProjectAvatarPresetProvider.swift; sourceTree = "<group>"; };
 		7B22D5EBE7EDAC07C943C91D /* WebSocketFrame.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebSocketFrame.swift; sourceTree = "<group>"; };
 		7BF6F2D792F7DFAE3DA8E597 /* ThemeEnvironment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThemeEnvironment.swift; sourceTree = "<group>"; };
 		7C38FA009B7044E9DC5480A7 /* ACPSessionsButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPSessionsButton.swift; sourceTree = "<group>"; };
@@ -2593,6 +2597,7 @@
 				4749A35B3BEF89C8E7B92CD7 /* PiInstallerTests.swift */,
 				FF741B889D6DC8B1F4EB350F /* ProcessGitDataTests.swift */,
 				5210D5B1E2FD2EF68139506E /* ProcessGitTests.swift */,
+				72B788982A64A04D18889D25 /* ProjectAvatarPresetProviderTests.swift */,
 				E1FD24B10ED0B3D4280F15E8 /* ProjectConfigAgentOverrideTests.swift */,
 				5B3FF64CC698074BFDE2A36A /* ProjectConfigTests.swift */,
 				8E3A9C194105E52A72293855 /* ProjectGitWatcherTests.swift */,
@@ -2719,6 +2724,7 @@
 				B24ABE96ED3C62146A3CED62 /* EmptyState.swift */,
 				EC6599EB47850D1E13ACF0EB /* NewProjectDialog.swift */,
 				711F3E7BD099EDADEA0802FD /* NewWorktreeDialog.swift */,
+				7A2B4B719D9F4EAAE84B14D1 /* ProjectAvatarPresetProvider.swift */,
 				C6B874BF8AEC4B60FC536E04 /* ProjectIconImageStaging.swift */,
 				3CE948F94DB2759E66CD4DEF /* ProjectPicker.swift */,
 				C2E05FF3EC7EAB497BA0FFE0 /* RepoSelector */,
@@ -4913,6 +4919,7 @@
 				C618DE3EE2A7CA06876D6C68 /* Process+Git.swift in Sources */,
 				106120CBE8107E0AC4EA353A /* ProcessKiller.swift in Sources */,
 				970B6BCA824C6AF4DA812946 /* ProcessMemoryProbe.swift in Sources */,
+				7A7A04035A83C4AD9ED5897D /* ProjectAvatarPresetProvider.swift in Sources */,
 				1DCE55DBA4A9DC466D817D22 /* ProjectConfig.swift in Sources */,
 				F88FD8BE546E36A0E3BF2594 /* ProjectGitWatcher.swift in Sources */,
 				419029F5618BC364426491E5 /* ProjectIcon.swift in Sources */,
@@ -5428,6 +5435,7 @@
 				D1C14B54BE27D97E354F448B /* ProcessGitDataTests.swift in Sources */,
 				7FC2A96DE87638A594DD8B61 /* ProcessGitTests.swift in Sources */,
 				82544FFCF9960E0BA0FD2C7F /* ProcessMemoryProbeTests.swift in Sources */,
+				396AF154C56F4B5061756366 /* ProjectAvatarPresetProviderTests.swift in Sources */,
 				636ED129478744F9169AD774 /* ProjectConfigAgentOverrideTests.swift in Sources */,
 				D13AFC98364971915782491C /* ProjectConfigTests.swift in Sources */,
 				2A18F8265F467BF33AD69159 /* ProjectGitWatcherTests.swift in Sources */,

--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -294,6 +294,7 @@
 		4151B68B1CF0A947AEC4C00A /* ACPAuthNudgeBannerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F68B06E93430D1C7B02F6BB2 /* ACPAuthNudgeBannerTests.swift */; };
 		4153DAD75F27395D2D385BED /* LanguageServerAvailabilityTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A8CC42BD54479E057902D392 /* LanguageServerAvailabilityTests.swift */; };
 		418D526733AA6B50A66CCCAF /* TabsManagerReviewRequestDraftTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 83A8622BA130E8FA339EDCEB /* TabsManagerReviewRequestDraftTests.swift */; };
+		419029F5618BC364426491E5 /* ProjectIcon.swift in Sources */ = {isa = PBXBuildFile; fileRef = CDEB760B98A1482CF30140A4 /* ProjectIcon.swift */; };
 		41C3F07661CA9B2B4E2C7BB1 /* GhosttyConfigBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = BCA505FF2E6CFA8278C95C6E /* GhosttyConfigBuilder.swift */; };
 		41C7E41360B2A443AE2A18B8 /* GhosttyHost.swift in Sources */ = {isa = PBXBuildFile; fileRef = 215C9AE9FBCB1FD9F6D030FE /* GhosttyHost.swift */; };
 		41E0F62323F788B8A3D3D731 /* ACPTerminalHost.swift in Sources */ = {isa = PBXBuildFile; fileRef = E504D11F9B69ACCE7B8E5CA4 /* ACPTerminalHost.swift */; };
@@ -545,6 +546,7 @@
 		7E56D356C235F59E1CE24210 /* AgentBuiltinsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4AED8A6EE8EF0CC317D7A4C7 /* AgentBuiltinsTests.swift */; };
 		7EB64E55CE27886D660C5D0C /* DefinitionSnippetCacheTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7D6BC5CC26EC6A242C2FDDDA /* DefinitionSnippetCacheTests.swift */; };
 		7EC95A2AAEFE78B51D9F599A /* ACPPlanSidebarVisibility.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7322805CC904D460A8C53C8 /* ACPPlanSidebarVisibility.swift */; };
+		7F2D2A9180110871CFF58192 /* ProjectIconTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 141C4CAF1B49032EDF0FF404 /* ProjectIconTests.swift */; };
 		7FC2A96DE87638A594DD8B61 /* ProcessGitTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5210D5B1E2FD2EF68139506E /* ProcessGitTests.swift */; };
 		7FFC3D96011714F0A131FAB8 /* ACPFileChip.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA6C7434D216D5C43A2FB921 /* ACPFileChip.swift */; };
 		8011EDCDB9E13B454E58F45E /* ReviewDraftCommentStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = B10E5AB5D726C40331681709 /* ReviewDraftCommentStore.swift */; };
@@ -1224,6 +1226,7 @@
 		137F79BD0DEB96B6F756ABD4 /* JSONHookSettingsFile.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JSONHookSettingsFile.swift; sourceTree = "<group>"; };
 		13B7B0E241FE2BEAE4623BA1 /* ParkChangesSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ParkChangesSheet.swift; sourceTree = "<group>"; };
 		14087D57E96448EEF0B80BD9 /* TerminalTabView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TerminalTabView.swift; sourceTree = "<group>"; };
+		141C4CAF1B49032EDF0FF404 /* ProjectIconTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProjectIconTests.swift; sourceTree = "<group>"; };
 		14907D679267359B3FB8A848 /* TabMergeConflictCodingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabMergeConflictCodingTests.swift; sourceTree = "<group>"; };
 		14CAEDA53AADBCE77C694E7B /* CodeHostModelsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CodeHostModelsTests.swift; sourceTree = "<group>"; };
 		14CEB6C5C076B4147D587909 /* ReviewThreadMutations.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReviewThreadMutations.swift; sourceTree = "<group>"; };
@@ -2009,6 +2012,7 @@
 		CD9289893FA7DC9DB8565353 /* MarkdownParser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MarkdownParser.swift; sourceTree = "<group>"; };
 		CDAE8FBBADF986E1E6585941 /* ReviewChangesModelsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReviewChangesModelsTests.swift; sourceTree = "<group>"; };
 		CDE49D2437D7E6AC9D67F136 /* RemoteSessionGateway.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteSessionGateway.swift; sourceTree = "<group>"; };
+		CDEB760B98A1482CF30140A4 /* ProjectIcon.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProjectIcon.swift; sourceTree = "<group>"; };
 		CE2AD8D0539591C434F51418 /* ACPAuthNudgeBanner.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPAuthNudgeBanner.swift; sourceTree = "<group>"; };
 		CE3FA58107EA372581313A5F /* MergeView3WayLayoutTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MergeView3WayLayoutTests.swift; sourceTree = "<group>"; };
 		CE6CCD7F7273667B5D67F821 /* SearchScope.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchScope.swift; sourceTree = "<group>"; };
@@ -2586,6 +2590,7 @@
 				E1FD24B10ED0B3D4280F15E8 /* ProjectConfigAgentOverrideTests.swift */,
 				5B3FF64CC698074BFDE2A36A /* ProjectConfigTests.swift */,
 				8E3A9C194105E52A72293855 /* ProjectGitWatcherTests.swift */,
+				141C4CAF1B49032EDF0FF404 /* ProjectIconTests.swift */,
 				00809DCA566AAAADD7448659 /* ProjectPickerTests.swift */,
 				BD708EEB35D93A7E7150981D /* ProjectsManagerHeadUpdatesTests.swift */,
 				CB0315FB9B537C0A240CFA32 /* ProjectsManagerProjectOrderingTests.swift */,
@@ -3478,6 +3483,7 @@
 				364213292935A05F3B52F51F /* Paths.swift */,
 				1A17A797374500E1FDD2382C /* PersistenceStore.swift */,
 				BD77FB052C8B5A937B14A4AE /* ProjectConfig.swift */,
+				CDEB760B98A1482CF30140A4 /* ProjectIcon.swift */,
 				7963D4DD10B67EB683510FF6 /* SpaceConfig.swift */,
 			);
 			path = Persistence;
@@ -4900,6 +4906,7 @@
 				970B6BCA824C6AF4DA812946 /* ProcessMemoryProbe.swift in Sources */,
 				1DCE55DBA4A9DC466D817D22 /* ProjectConfig.swift in Sources */,
 				F88FD8BE546E36A0E3BF2594 /* ProjectGitWatcher.swift in Sources */,
+				419029F5618BC364426491E5 /* ProjectIcon.swift in Sources */,
 				E175AE346DFAD0B62827C921 /* ProjectPicker.swift in Sources */,
 				6E69D87B57B23223A48AB6F7 /* ProjectsManager.swift in Sources */,
 				50D7FF67981533B21FCB0890 /* PromptEditorBody.swift in Sources */,
@@ -5413,6 +5420,7 @@
 				636ED129478744F9169AD774 /* ProjectConfigAgentOverrideTests.swift in Sources */,
 				D13AFC98364971915782491C /* ProjectConfigTests.swift in Sources */,
 				2A18F8265F467BF33AD69159 /* ProjectGitWatcherTests.swift in Sources */,
+				7F2D2A9180110871CFF58192 /* ProjectIconTests.swift in Sources */,
 				4E7279E8E76C7778BC686DF1 /* ProjectPickerTests.swift in Sources */,
 				BEDFCA98CA9C992302618128 /* ProjectsManagerHeadUpdatesTests.swift in Sources */,
 				9C20E8B060C753308748CE05 /* ProjectsManagerProjectOrderingTests.swift in Sources */,

--- a/Alas/Sources/App/AppState.swift
+++ b/Alas/Sources/App/AppState.swift
@@ -1175,8 +1175,8 @@ final class AppState {
         }
     }
 
-    func addProject(path: URL, displayName: String, color: String) async throws {
-        let project = try await projectsManager.addProject(path: path, displayName: displayName, color: color)
+    func addProject(path: URL, displayName: String, icon: ProjectIcon) async throws {
+        let project = try await projectsManager.addProject(path: path, displayName: displayName, icon: icon)
         spacesManager.addProject(project.id, toSpace: spacesManager.activeSpaceId)
         saveProjects()
         saveSpaces()
@@ -1184,6 +1184,10 @@ final class AppState {
             saveProjects()
         }
         startProjectGitWatcher(for: project)
+    }
+
+    func addProject(path: URL, displayName: String, color: String) async throws {
+        try await addProject(path: path, displayName: displayName, icon: ProjectIcon.default(color: color))
     }
 
     @discardableResult
@@ -1340,7 +1344,7 @@ final class AppState {
         projectGitWatchers.removeAll()
     }
 
-    func updateProject(id: String, name: String, color: String, startupScripts: ProjectStartupScripts) {
+    func updateProject(id: String, name: String, icon: ProjectIcon, startupScripts: ProjectStartupScripts) {
         let trimmedName = name.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !trimmedName.isEmpty else { return }
 
@@ -1348,11 +1352,20 @@ final class AppState {
             id: id,
             update: ProjectUpdate(
                 name: trimmedName,
-                color: color,
+                icon: icon,
                 startupScripts: startupScripts
             )
         )
         saveProjects()
+    }
+
+    func updateProject(id: String, name: String, color: String, startupScripts: ProjectStartupScripts) {
+        updateProject(
+            id: id,
+            name: name,
+            icon: ProjectIcon.default(color: color),
+            startupScripts: startupScripts
+        )
     }
 
     func setWorktreeLaunchDefaults(projectId: String, openAfterCreate: Bool, launcherMode: AppConfig.LauncherMode) {

--- a/Alas/Sources/App/AppState.swift
+++ b/Alas/Sources/App/AppState.swift
@@ -330,7 +330,7 @@ final class AppState {
                 id: project.id,
                 update: ProjectUpdate(
                     name: project.name,
-                    color: project.color,
+                    icon: project.icon,
                     startupScripts: updated
                 )
             )
@@ -1175,8 +1175,18 @@ final class AppState {
         }
     }
 
-    func addProject(path: URL, displayName: String, icon: ProjectIcon) async throws {
-        let project = try await projectsManager.addProject(path: path, displayName: displayName, icon: icon)
+    func addProject(
+        path: URL,
+        displayName: String,
+        icon: ProjectIcon,
+        id: String = UUID().uuidString
+    ) async throws {
+        let project = try await projectsManager.addProject(
+            path: path,
+            displayName: displayName,
+            icon: icon,
+            id: id
+        )
         spacesManager.addProject(project.id, toSpace: spacesManager.activeSpaceId)
         saveProjects()
         saveSpaces()
@@ -1186,8 +1196,18 @@ final class AppState {
         startProjectGitWatcher(for: project)
     }
 
-    func addProject(path: URL, displayName: String, color: String) async throws {
-        try await addProject(path: path, displayName: displayName, icon: ProjectIcon.default(color: color))
+    func addProject(
+        path: URL,
+        displayName: String,
+        color: String,
+        id: String = UUID().uuidString
+    ) async throws {
+        try await addProject(
+            path: path,
+            displayName: displayName,
+            icon: ProjectIcon.default(color: color),
+            id: id
+        )
     }
 
     @discardableResult

--- a/Alas/Sources/App/ProjectsManager.swift
+++ b/Alas/Sources/App/ProjectsManager.swift
@@ -57,14 +57,19 @@ final class ProjectsManager {
         self.defaultOrderingSource = source
     }
 
-    func addProject(path: URL, displayName: String, icon: ProjectIcon) async throws -> ProjectConfig {
+    func addProject(
+        path: URL,
+        displayName: String,
+        icon: ProjectIcon,
+        id: String = UUID().uuidString
+    ) async throws -> ProjectConfig {
         let isRepo = try await git.isGitRepository(path)
         guard isRepo else {
             throw NSError(domain: "ProjectsManager", code: 1,
                           userInfo: [NSLocalizedDescriptionKey: "Not a git repository: \(path.path)"])
         }
         let project = ProjectConfig(
-            id: UUID().uuidString,
+            id: id,
             name: displayName,
             path: path.path,
             color: icon.color,
@@ -75,8 +80,18 @@ final class ProjectsManager {
         return project
     }
 
-    func addProject(path: URL, displayName: String, color: String) async throws -> ProjectConfig {
-        try await addProject(path: path, displayName: displayName, icon: ProjectIcon.default(color: color))
+    func addProject(
+        path: URL,
+        displayName: String,
+        color: String,
+        id: String = UUID().uuidString
+    ) async throws -> ProjectConfig {
+        try await addProject(
+            path: path,
+            displayName: displayName,
+            icon: ProjectIcon.default(color: color),
+            id: id
+        )
     }
 
     func removeProject(id: String) {

--- a/Alas/Sources/App/ProjectsManager.swift
+++ b/Alas/Sources/App/ProjectsManager.swift
@@ -3,8 +3,18 @@ import Observation
 
 struct ProjectUpdate: Equatable {
     var name: String
-    var color: String
+    var icon: ProjectIcon
     var startupScripts: ProjectStartupScripts = .defaults
+
+    init(name: String, icon: ProjectIcon, startupScripts: ProjectStartupScripts = .defaults) {
+        self.name = name
+        self.icon = icon
+        self.startupScripts = startupScripts
+    }
+
+    init(name: String, color: String, startupScripts: ProjectStartupScripts = .defaults) {
+        self.init(name: name, icon: ProjectIcon.default(color: color), startupScripts: startupScripts)
+    }
 }
 
 enum WorktreeOperationState: Equatable {
@@ -47,7 +57,7 @@ final class ProjectsManager {
         self.defaultOrderingSource = source
     }
 
-    func addProject(path: URL, displayName: String, color: String) async throws -> ProjectConfig {
+    func addProject(path: URL, displayName: String, icon: ProjectIcon) async throws -> ProjectConfig {
         let isRepo = try await git.isGitRepository(path)
         guard isRepo else {
             throw NSError(domain: "ProjectsManager", code: 1,
@@ -57,11 +67,16 @@ final class ProjectsManager {
             id: UUID().uuidString,
             name: displayName,
             path: path.path,
-            color: color,
-            addedAt: Date()
+            color: icon.color,
+            addedAt: Date(),
+            icon: icon
         )
         projects.append(project)
         return project
+    }
+
+    func addProject(path: URL, displayName: String, color: String) async throws -> ProjectConfig {
+        try await addProject(path: path, displayName: displayName, icon: ProjectIcon.default(color: color))
     }
 
     func removeProject(id: String) {
@@ -74,7 +89,8 @@ final class ProjectsManager {
     func updateProject(id: String, update: ProjectUpdate) {
         guard let idx = projects.firstIndex(where: { $0.id == id }) else { return }
         projects[idx].name = update.name
-        projects[idx].color = update.color
+        projects[idx].icon = update.icon
+        projects[idx].color = update.icon.color
         projects[idx].startupScripts = update.startupScripts
     }
 

--- a/Alas/Sources/Dialogs/DialogChrome.swift
+++ b/Alas/Sources/Dialogs/DialogChrome.swift
@@ -1,8 +1,14 @@
 import SwiftUI
 
+enum DialogContainerLayout {
+    static let defaultWidth: CGFloat = 480
+    static let projectWidth: CGFloat = 640
+}
+
 struct DialogContainer<Content: View>: View {
     let title: String
     let subtitle: String?
+    let width: CGFloat
     @ViewBuilder let content: () -> Content
     let cancelTitle: String
     let confirmTitle: String
@@ -12,6 +18,30 @@ struct DialogContainer<Content: View>: View {
     let confirmEnabled: Bool
 
     @Environment(\.theme) var theme
+
+    init(
+        title: String,
+        subtitle: String?,
+        width: CGFloat = DialogContainerLayout.defaultWidth,
+        @ViewBuilder content: @escaping () -> Content,
+        cancelTitle: String,
+        confirmTitle: String,
+        confirmStyle: AlasButtonStyle,
+        onCancel: @escaping () -> Void,
+        onConfirm: @escaping () -> Void,
+        confirmEnabled: Bool
+    ) {
+        self.title = title
+        self.subtitle = subtitle
+        self.width = width
+        self.content = content
+        self.cancelTitle = cancelTitle
+        self.confirmTitle = confirmTitle
+        self.confirmStyle = confirmStyle
+        self.onCancel = onCancel
+        self.onConfirm = onConfirm
+        self.confirmEnabled = confirmEnabled
+    }
 
     var body: some View {
         VStack(spacing: 0) {
@@ -40,7 +70,7 @@ struct DialogContainer<Content: View>: View {
             .background(theme.color("bg-2"))
             .overlay(Divider(), alignment: .top)
         }
-        .frame(width: 480)
+        .frame(width: width)
         .background(theme.color("bg-1"))
         .clipShape(RoundedRectangle(cornerRadius: 10))
         .shadow(color: .black.opacity(0.6), radius: 80, y: 30)

--- a/Alas/Sources/Dialogs/NewProjectDialog.swift
+++ b/Alas/Sources/Dialogs/NewProjectDialog.swift
@@ -40,11 +40,12 @@ private struct ProjectDialog: View {
     @State private var iconSymbolName: String = "folder"
     @State private var iconEmoji: String = "🚀"
     @State private var iconImagePath: String?
-    @State private var pendingIconStorageId = "pending-\(UUID().uuidString)"
+    @State private var pendingProjectId = UUID().uuidString
     @State private var avatarPreset: ProjectAvatarPreset?
     @State private var avatarPresetData: Data?
     @State private var avatarPresetLoading = false
     @State private var avatarPresetError = false
+    @State private var avatarPresetRequestId = UUID()
     @State private var sessionOpenMode: ProjectStartupScriptMode = .useGlobal
     @State private var sessionOpenScript: String = ""
     @State private var worktreeCreateMode: ProjectStartupScriptMode = .useGlobal
@@ -384,33 +385,52 @@ private struct ProjectDialog: View {
 
     private func existingProjectIdForIconStorage() -> String {
         if case .edit(let project) = mode { return project.id }
-        return pendingIconStorageId
+        return pendingProjectId
     }
 
     private func loadAvatarPresetIfAvailable() async {
+        let requestId = UUID()
+        avatarPresetRequestId = requestId
         avatarPreset = nil
         avatarPresetData = nil
         avatarPresetError = false
+        avatarPresetLoading = false
 
-        let repoURL: URL
-        switch mode {
-        case .add:
-            guard !path.isEmpty else { return }
-            repoURL = URL(fileURLWithPath: path)
-        case .edit(let project):
-            repoURL = URL(fileURLWithPath: project.path)
-        }
+        guard let repoURL = currentAvatarPresetRepoURL() else { return }
+        let requestedPath = repoURL.path
 
         avatarPresetLoading = true
-        defer { avatarPresetLoading = false }
+        defer {
+            if avatarPresetRequestId == requestId {
+                avatarPresetLoading = false
+            }
+        }
 
         do {
             let remotes = try await GitService().remotes(worktreePath: repoURL)
             guard let preset = ProjectAvatarPresetProvider.candidate(from: remotes) else { return }
+            let data = try await ProjectAvatarPresetProvider.fetch(preset)
+            guard avatarPresetRequestId == requestId,
+                  currentAvatarPresetRepoURL()?.path == requestedPath
+            else {
+                return
+            }
             avatarPreset = preset
-            avatarPresetData = try await ProjectAvatarPresetProvider.fetch(preset)
+            avatarPresetData = data
         } catch {
-            avatarPresetError = true
+            if avatarPresetRequestId == requestId {
+                avatarPresetError = true
+            }
+        }
+    }
+
+    private func currentAvatarPresetRepoURL() -> URL? {
+        switch mode {
+        case .add:
+            guard !path.isEmpty else { return nil }
+            return URL(fileURLWithPath: path)
+        case .edit(let project):
+            return URL(fileURLWithPath: project.path)
         }
     }
 
@@ -439,7 +459,12 @@ private struct ProjectDialog: View {
             Task {
                 do {
                     let url = URL(fileURLWithPath: path)
-                    try await state.addProject(path: url, displayName: name, icon: draftIcon)
+                    try await state.addProject(
+                        path: url,
+                        displayName: name,
+                        icon: draftIcon,
+                        id: pendingProjectId
+                    )
                     presented = false
                 } catch {
                     errorMessage = error.localizedDescription

--- a/Alas/Sources/Dialogs/NewProjectDialog.swift
+++ b/Alas/Sources/Dialogs/NewProjectDialog.swift
@@ -1,5 +1,6 @@
 import SwiftUI
 import AppKit
+import UniformTypeIdentifiers
 
 struct NewProjectDialog: View {
     @Bindable var state: AppState
@@ -33,7 +34,17 @@ private struct ProjectDialog: View {
 
     @State private var path: String = ""
     @State private var name: String = ""
-    @State private var color: String = "#5fb7c4"
+    @State private var iconMode: ProjectIcon.Mode = .letter
+    @State private var iconColor: String = ProjectIcon.defaultColor
+    @State private var iconLabel: String = ""
+    @State private var iconSymbolName: String = "folder"
+    @State private var iconEmoji: String = "🚀"
+    @State private var iconImagePath: String?
+    @State private var pendingIconStorageId = "pending-\(UUID().uuidString)"
+    @State private var avatarPreset: ProjectAvatarPreset?
+    @State private var avatarPresetData: Data?
+    @State private var avatarPresetLoading = false
+    @State private var avatarPresetError = false
     @State private var sessionOpenMode: ProjectStartupScriptMode = .useGlobal
     @State private var sessionOpenScript: String = ""
     @State private var worktreeCreateMode: ProjectStartupScriptMode = .useGlobal
@@ -54,6 +65,17 @@ private struct ProjectDialog: View {
         (.disabled, "Disabled"),
     ]
 
+    private var draftIcon: ProjectIcon {
+        ProjectIcon(
+            mode: iconMode,
+            color: iconColor,
+            label: iconMode == .letter ? iconLabel : nil,
+            symbolName: iconMode == .symbol ? iconSymbolName : nil,
+            emoji: iconMode == .emoji ? iconEmoji : nil,
+            imagePath: iconMode == .image ? iconImagePath : nil
+        )
+    }
+
     var body: some View {
         DialogContainer(
             title: title,
@@ -73,20 +95,8 @@ private struct ProjectDialog: View {
                 DialogField(label: "Display name") {
                     AlasField(text: $name, placeholder: "repo-folder")
                 }
-                DialogField(label: "Color") {
-                    HStack(spacing: 8) {
-                        ForEach(availablePalette, id: \.self) { hex in
-                            Button { color = hex } label: {
-                                Circle()
-                                    .fill(Color(hex: hex))
-                                    .frame(width: 22, height: 22)
-                                    .overlay(
-                                        Circle().strokeBorder(.white, lineWidth: color == hex ? 2 : 0)
-                                    )
-                            }
-                            .buttonStyle(.plain)
-                        }
-                    }
+                DialogField(label: "Icon") {
+                    projectIconSection
                 }
                 if case .edit = mode {
                     Divider().padding(.vertical, 4)
@@ -103,10 +113,16 @@ private struct ProjectDialog: View {
             onConfirm: confirm,
             confirmEnabled: confirmEnabled
         )
-        .onAppear(perform: populateInitialValues)
+        .onAppear {
+            populateInitialValues()
+            Task { await loadAvatarPresetIfAvailable() }
+        }
         .onChange(of: path) { _, new in
             if case .add = mode {
-                Task { await suggestName(for: new) }
+                Task {
+                    await suggestName(for: new)
+                    await loadAvatarPresetIfAvailable()
+                }
             }
         }
     }
@@ -142,7 +158,107 @@ private struct ProjectDialog: View {
     }
 
     private var availablePalette: [String] {
-        palette.contains(color) ? palette : [color] + palette
+        palette.contains(iconColor) ? palette : [iconColor] + palette
+    }
+
+    private var projectIconSection: some View {
+        HStack(alignment: .top, spacing: 14) {
+            VStack(spacing: 8) {
+                ProjectIconView(icon: draftIcon, fallbackName: name, size: .dialog)
+                HStack(spacing: 8) {
+                    ProjectIconView(icon: draftIcon, fallbackName: name, size: .sidebar)
+                    ProjectIconView(icon: draftIcon, fallbackName: name, size: .picker)
+                }
+            }
+            VStack(alignment: .leading, spacing: 10) {
+                Seg(value: $iconMode, options: ProjectIcon.Mode.allCases.map { ($0, modeTitle($0)) })
+                iconModeControls
+                colorControls
+            }
+        }
+    }
+
+    private func modeTitle(_ mode: ProjectIcon.Mode) -> String {
+        switch mode {
+        case .letter: "Letter"
+        case .symbol: "Symbol"
+        case .emoji: "Emoji"
+        case .image: "Image"
+        }
+    }
+
+    @ViewBuilder
+    private var iconModeControls: some View {
+        switch iconMode {
+        case .letter:
+            AlasField(text: $iconLabel, placeholder: ProjectIcon.fallbackLabel(projectName: name))
+                .frame(width: 90)
+        case .symbol:
+            VStack(alignment: .leading, spacing: 6) {
+                AlasField(text: $iconSymbolName, placeholder: "folder")
+                symbolQuickChoices
+            }
+        case .emoji:
+            AlasField(text: $iconEmoji, placeholder: "🚀")
+                .frame(width: 90)
+        case .image:
+            imageControls
+        }
+    }
+
+    private var symbolQuickChoices: some View {
+        HStack(spacing: 6) {
+            ForEach(["folder", "terminal", "sparkle", "github", "gitlab", "commit"], id: \.self) { symbol in
+                Button {
+                    iconSymbolName = symbol
+                } label: {
+                    Icon(name: symbol, size: 13, color: theme.color("fg"))
+                        .frame(width: 24, height: 24)
+                        .background(iconSymbolName == symbol ? theme.color("bg-4") : theme.color("bg-2"))
+                        .clipShape(RoundedRectangle(cornerRadius: 5))
+                }
+                .buttonStyle(.plain)
+                .help(symbol)
+            }
+        }
+    }
+
+    private var colorControls: some View {
+        HStack(spacing: 8) {
+            ForEach(availablePalette, id: \.self) { hex in
+                Button { iconColor = hex } label: {
+                    Circle()
+                        .fill(Color(hex: hex))
+                        .frame(width: 22, height: 22)
+                        .overlay(Circle().strokeBorder(.white, lineWidth: iconColor == hex ? 2 : 0))
+                }
+                .buttonStyle(.plain)
+            }
+            AlasField(text: $iconColor, placeholder: ProjectIcon.defaultColor, monospaced: true)
+                .frame(width: 96)
+        }
+    }
+
+    private var imageControls: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            AlasButton(title: "Choose Image…", icon: "image", action: chooseProjectIconImage)
+            if let avatarPreset {
+                HStack(spacing: 8) {
+                    Text(avatarPreset.label)
+                        .font(.system(size: 11))
+                        .foregroundColor(theme.color("fg-muted"))
+                    AlasButton(
+                        title: avatarPresetLoading ? "Loading…" : "Use",
+                        action: useAvatarPreset
+                    )
+                    .disabled(avatarPresetData == nil || avatarPresetLoading)
+                }
+            } else if avatarPresetError {
+                Text("Avatar preset unavailable")
+                    .font(.system(size: 11))
+                    .foregroundColor(theme.color("fg-faint"))
+            }
+        }
     }
 
     private var readOnlyPath: some View {
@@ -208,7 +324,12 @@ private struct ProjectDialog: View {
         case .edit(let project):
             path = project.path
             name = project.name
-            color = project.color
+            iconMode = project.icon.mode
+            iconColor = project.icon.color
+            iconLabel = project.icon.label ?? ""
+            iconSymbolName = project.icon.symbolName ?? "folder"
+            iconEmoji = project.icon.emoji ?? "🚀"
+            iconImagePath = project.icon.imagePath
             sessionOpenMode = project.startupScripts.sessionOpenMode
             sessionOpenScript = project.startupScripts.sessionOpenScript
             worktreeCreateMode = project.startupScripts.worktreeCreateMode
@@ -226,6 +347,30 @@ private struct ProjectDialog: View {
         }
     }
 
+    private func chooseProjectIconImage() {
+        let panel = NSOpenPanel()
+        panel.canChooseDirectories = false
+        panel.canChooseFiles = true
+        panel.allowsMultipleSelection = false
+        panel.allowedContentTypes = [.png, .jpeg, .gif, .webP]
+        if panel.runModal() == .OK, let url = panel.url {
+            do {
+                let data = try Data(contentsOf: url)
+                let staged = try ProjectIconImageStaging.stage(
+                    data: data,
+                    projectId: existingProjectIdForIconStorage()
+                )
+                iconImagePath = staged.imagePath
+                iconMode = .image
+                errorMessage = nil
+            } catch let stagingError as ProjectIconImageStaging.StagingError {
+                errorMessage = stagingError.userMessage
+            } catch {
+                errorMessage = "Couldn't load that image. Please try another file."
+            }
+        }
+    }
+
     private func suggestName(for newPath: String) async {
         guard !newPath.isEmpty else { return }
         let url = URL(fileURLWithPath: newPath)
@@ -237,6 +382,55 @@ private struct ProjectDialog: View {
         }
     }
 
+    private func existingProjectIdForIconStorage() -> String {
+        if case .edit(let project) = mode { return project.id }
+        return pendingIconStorageId
+    }
+
+    private func loadAvatarPresetIfAvailable() async {
+        avatarPreset = nil
+        avatarPresetData = nil
+        avatarPresetError = false
+
+        let repoURL: URL
+        switch mode {
+        case .add:
+            guard !path.isEmpty else { return }
+            repoURL = URL(fileURLWithPath: path)
+        case .edit(let project):
+            repoURL = URL(fileURLWithPath: project.path)
+        }
+
+        avatarPresetLoading = true
+        defer { avatarPresetLoading = false }
+
+        do {
+            let remotes = try await GitService().remotes(worktreePath: repoURL)
+            guard let preset = ProjectAvatarPresetProvider.candidate(from: remotes) else { return }
+            avatarPreset = preset
+            avatarPresetData = try await ProjectAvatarPresetProvider.fetch(preset)
+        } catch {
+            avatarPresetError = true
+        }
+    }
+
+    private func useAvatarPreset() {
+        guard let data = avatarPresetData else { return }
+        do {
+            let staged = try ProjectIconImageStaging.stage(
+                data: data,
+                projectId: existingProjectIdForIconStorage()
+            )
+            iconImagePath = staged.imagePath
+            iconMode = .image
+            errorMessage = nil
+        } catch let stagingError as ProjectIconImageStaging.StagingError {
+            errorMessage = stagingError.userMessage
+        } catch {
+            errorMessage = "Couldn't save that avatar. Please try another image."
+        }
+    }
+
     private func confirm() {
         switch mode {
         case .add:
@@ -245,7 +439,7 @@ private struct ProjectDialog: View {
             Task {
                 do {
                     let url = URL(fileURLWithPath: path)
-                    try await state.addProject(path: url, displayName: name, color: color)
+                    try await state.addProject(path: url, displayName: name, icon: draftIcon)
                     presented = false
                 } catch {
                     errorMessage = error.localizedDescription
@@ -260,7 +454,7 @@ private struct ProjectDialog: View {
             state.updateProject(
                 id: project.id,
                 name: name,
-                color: color,
+                icon: draftIcon,
                 startupScripts: ProjectStartupScripts(
                     sessionOpenMode: sessionOpenMode,
                     sessionOpenScript: sessionOpenScript,

--- a/Alas/Sources/Dialogs/NewProjectDialog.swift
+++ b/Alas/Sources/Dialogs/NewProjectDialog.swift
@@ -356,6 +356,7 @@ private struct ProjectDialog: View {
         panel.allowedContentTypes = [.png, .jpeg, .gif, .webP]
         if panel.runModal() == .OK, let url = panel.url {
             do {
+                try ProjectIconImageStaging.validateFileSize(at: url)
                 let data = try Data(contentsOf: url)
                 let staged = try ProjectIconImageStaging.stage(
                     data: data,

--- a/Alas/Sources/Dialogs/NewProjectDialog.swift
+++ b/Alas/Sources/Dialogs/NewProjectDialog.swift
@@ -81,6 +81,7 @@ private struct ProjectDialog: View {
         DialogContainer(
             title: title,
             subtitle: subtitle,
+            width: DialogContainerLayout.projectWidth,
             content: {
                 DialogField(label: "Repository path") {
                     switch mode {
@@ -200,8 +201,10 @@ private struct ProjectDialog: View {
                 symbolQuickChoices
             }
         case .emoji:
-            AlasField(text: $iconEmoji, placeholder: "🚀")
-                .frame(width: 90)
+            EmojiPickerButton(selection: ProjectIcon.sanitizedEmoji(iconEmoji) ?? "🚀") { emoji in
+                iconEmoji = emoji
+            }
+            .accessibilityLabel("Project icon emoji")
         case .image:
             imageControls
         }

--- a/Alas/Sources/Dialogs/ProjectAvatarPresetProvider.swift
+++ b/Alas/Sources/Dialogs/ProjectAvatarPresetProvider.swift
@@ -1,0 +1,54 @@
+import Foundation
+
+struct ProjectAvatarPreset: Equatable {
+    let label: String
+    let url: URL
+}
+
+protocol ProjectAvatarFetching {
+    func data(from url: URL) async throws -> Data
+}
+
+struct URLSessionProjectAvatarFetcher: ProjectAvatarFetching {
+    func data(from url: URL) async throws -> Data {
+        let (data, response) = try await URLSession.shared.data(from: url)
+        if let http = response as? HTTPURLResponse,
+           !(200..<300).contains(http.statusCode) {
+            throw URLError(.badServerResponse)
+        }
+        return data
+    }
+}
+
+enum ProjectAvatarPresetProvider {
+    static func candidate(for remote: CodeHostRemote) -> ProjectAvatarPreset? {
+        switch remote.kind {
+        case .github:
+            guard let url = URL(string: "https://\(remote.host)/\(remote.owner).png?size=256") else {
+                return nil
+            }
+            return ProjectAvatarPreset(label: "GitHub avatar: \(remote.owner)", url: url)
+        case .gitlab:
+            let escaped = remote.owner.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed)?
+                .replacingOccurrences(of: "/", with: "%2F")
+            guard let escaped,
+                  let url = URL(string: "https://\(remote.host)/api/v4/groups/\(escaped)/avatar")
+            else {
+                return nil
+            }
+            return ProjectAvatarPreset(label: "GitLab avatar: \(remote.owner)", url: url)
+        }
+    }
+
+    static func candidate(from remotes: [GitRemote]) -> ProjectAvatarPreset? {
+        guard let remote = CodeHostRemoteDetector.detect(from: remotes) else { return nil }
+        return candidate(for: remote)
+    }
+
+    static func fetch(
+        _ preset: ProjectAvatarPreset,
+        fetcher: ProjectAvatarFetching = URLSessionProjectAvatarFetcher()
+    ) async throws -> Data {
+        try await fetcher.data(from: preset.url)
+    }
+}

--- a/Alas/Sources/Dialogs/ProjectIconImageStaging.swift
+++ b/Alas/Sources/Dialogs/ProjectIconImageStaging.swift
@@ -35,6 +35,14 @@ enum ProjectIconImageStaging {
         }
     }
 
+    static func validateFileSize(at url: URL) throws {
+        let values = try url.resourceValues(forKeys: [.fileSizeKey, .totalFileAllocatedSizeKey])
+        let size = values.fileSize ?? values.totalFileAllocatedSize
+        if let size, size > maxBytes {
+            throw StagingError.tooLarge
+        }
+    }
+
     static func url(for imagePath: String, root: URL = Paths.projectIconsRoot) -> URL {
         root.appendingPathComponent(imagePath)
     }

--- a/Alas/Sources/Dialogs/ProjectIconImageStaging.swift
+++ b/Alas/Sources/Dialogs/ProjectIconImageStaging.swift
@@ -1,0 +1,61 @@
+import CryptoKit
+import Foundation
+
+enum ProjectIconImageStaging {
+    struct Staged: Equatable {
+        let imagePath: String
+        let url: URL
+    }
+
+    enum StagingError: Error, Equatable {
+        case unsupportedFormat
+        case tooLarge
+        case writeFailed
+    }
+
+    static let maxBytes = 10 * 1024 * 1024
+
+    static func stage(data: Data, projectId: String, root: URL = Paths.projectIconsRoot) throws -> Staged {
+        guard data.count <= maxBytes else { throw StagingError.tooLarge }
+        guard let ext = fileExtension(for: data) else { throw StagingError.unsupportedFormat }
+
+        let hash = SHA256.hash(data: data).map { String(format: "%02x", $0) }.joined()
+        let filename = "\(hash).\(ext)"
+        let dir = root.appendingPathComponent(projectId, isDirectory: true)
+        let url = dir.appendingPathComponent(filename)
+
+        do {
+            try Paths.ensureDirectoryExists(dir)
+            if !FileManager.default.fileExists(atPath: url.path) {
+                try data.write(to: url, options: .atomic)
+            }
+            return Staged(imagePath: "\(projectId)/\(filename)", url: url)
+        } catch {
+            throw StagingError.writeFailed
+        }
+    }
+
+    static func url(for imagePath: String, root: URL = Paths.projectIconsRoot) -> URL {
+        root.appendingPathComponent(imagePath)
+    }
+
+    static func fileExtension(for data: Data) -> String? {
+        let b = [UInt8](data.prefix(16))
+        if b.count >= 8, b[0] == 0x89, b[1] == 0x50, b[2] == 0x4E, b[3] == 0x47 { return "png" }
+        if b.count >= 3, b[0] == 0xFF, b[1] == 0xD8, b[2] == 0xFF { return "jpg" }
+        if b.count >= 6, b[0] == 0x47, b[1] == 0x49, b[2] == 0x46 { return "gif" }
+        if b.count >= 12, b[0] == 0x52, b[1] == 0x49, b[2] == 0x46, b[3] == 0x46,
+           b[8] == 0x57, b[9] == 0x45, b[10] == 0x42, b[11] == 0x50 { return "webp" }
+        return nil
+    }
+}
+
+extension ProjectIconImageStaging.StagingError {
+    var userMessage: String {
+        switch self {
+        case .unsupportedFormat: return "That image format isn't supported (use PNG, JPEG, GIF, or WebP)."
+        case .tooLarge: return "That image is too large (max 10 MB)."
+        case .writeFailed: return "Couldn't save that project icon. Please try again."
+        }
+    }
+}

--- a/Alas/Sources/Dialogs/ProjectPicker.swift
+++ b/Alas/Sources/Dialogs/ProjectPicker.swift
@@ -20,9 +20,7 @@ struct ProjectPicker: View {
         Button(action: { open.toggle() }) {
             HStack(spacing: 6) {
                 if let project = selectedProject {
-                    Circle()
-                        .fill(Color(hex: project.color))
-                        .frame(width: 8, height: 8)
+                    ProjectIconView(icon: project.icon, fallbackName: project.name, size: .picker)
                 }
                 Text(selectedProject?.name ?? "Choose a repository")
                     .font(.system(size: 12))
@@ -86,9 +84,7 @@ struct ProjectPicker: View {
                     .font(.system(size: 10, weight: .semibold))
                     .foregroundColor(theme.color("fg"))
                     .opacity(project.id == selection ? 1 : 0)
-                Circle()
-                    .fill(Color(hex: project.color))
-                    .frame(width: 8, height: 8)
+                ProjectIconView(icon: project.icon, fallbackName: project.name, size: .picker)
                 Text(project.name)
                     .font(.system(size: 12))
                     .foregroundColor(theme.color("fg"))

--- a/Alas/Sources/Dialogs/RepoSelector/RepoSelectorRowView.swift
+++ b/Alas/Sources/Dialogs/RepoSelector/RepoSelectorRowView.swift
@@ -79,7 +79,7 @@ struct RepoSelectorRowView: View {
     private func worktreeContent(worktree: Worktree, indices: [Int], isCurrent: Bool) -> some View {
         HStack(spacing: 10) {
             if let project = projectsById[worktree.projectId] {
-                RepoDot(color: project.color, letter: String(project.name.prefix(1)).uppercased())
+                ProjectIconView(icon: project.icon, fallbackName: project.name, size: .sidebar)
             }
             if isCurrent {
                 Circle()

--- a/Alas/Sources/Persistence/Paths.swift
+++ b/Alas/Sources/Persistence/Paths.swift
@@ -72,3 +72,11 @@ extension Paths {
         acpAttachmentsRoot.appendingPathComponent(id, isDirectory: true)
     }
 }
+
+extension Paths {
+    static var projectIconsRoot: URL { appSupportRoot.appendingPathComponent("project-icons", isDirectory: true) }
+
+    static func projectIconsDir(forProjectId id: String) -> URL {
+        projectIconsRoot.appendingPathComponent(id, isDirectory: true)
+    }
+}

--- a/Alas/Sources/Persistence/ProjectConfig.swift
+++ b/Alas/Sources/Persistence/ProjectConfig.swift
@@ -78,6 +78,7 @@ struct ProjectConfig: Codable, Equatable, Identifiable {
     var name: String         // display name, defaulting to the repo directory name
     var path: String         // absolute repo path
     var color: String        // hex string, e.g. "#5fb7c4"
+    var icon: ProjectIcon
     var addedAt: Date
     var hiddenWorktreePaths: [String] = []
     var worktreeOrder: [String] = []
@@ -93,7 +94,7 @@ struct ProjectConfig: Codable, Equatable, Identifiable {
     var worktreeDefaultLauncherMode: AppConfig.LauncherMode?
 
     enum CodingKeys: String, CodingKey {
-        case id, name, path, color, addedAt, hiddenWorktreePaths, worktreeOrder,
+        case id, name, path, color, icon, addedAt, hiddenWorktreePaths, worktreeOrder,
              worktreeOrderIsManual, startupScripts,
              worktreeOpenAfterCreate, worktreeDefaultLauncherMode
     }
@@ -104,6 +105,7 @@ struct ProjectConfig: Codable, Equatable, Identifiable {
         path: String,
         color: String,
         addedAt: Date,
+        icon: ProjectIcon? = nil,
         hiddenWorktreePaths: [String] = [],
         worktreeOrder: [String] = [],
         worktreeOrderIsManual: Bool = false,
@@ -114,7 +116,8 @@ struct ProjectConfig: Codable, Equatable, Identifiable {
         self.id = id
         self.name = name
         self.path = path
-        self.color = color
+        self.icon = icon ?? ProjectIcon.default(color: color)
+        self.color = self.icon.color
         self.addedAt = addedAt
         self.hiddenWorktreePaths = hiddenWorktreePaths
         self.worktreeOrder = worktreeOrder
@@ -131,7 +134,11 @@ struct ProjectConfig: Codable, Equatable, Identifiable {
         id = try c.decode(String.self, forKey: .id)
         name = try c.decode(String.self, forKey: .name)
         path = try c.decode(String.self, forKey: .path)
-        color = try c.decode(String.self, forKey: .color)
+        let decodedColor = try c.decode(String.self, forKey: .color)
+        let decodedIcon = (try? c.decode(ProjectIcon.self, forKey: .icon))
+            ?? ProjectIcon.default(color: decodedColor)
+        icon = decodedIcon
+        color = decodedIcon.color
         addedAt = try c.decode(Date.self, forKey: .addedAt)
         hiddenWorktreePaths = (try? c.decode([String].self, forKey: .hiddenWorktreePaths)) ?? []
         worktreeOrder = (try? c.decode([String].self, forKey: .worktreeOrder)) ?? []
@@ -140,5 +147,21 @@ struct ProjectConfig: Codable, Equatable, Identifiable {
             ?? .defaults
         worktreeOpenAfterCreate = try? c.decode(Bool.self, forKey: .worktreeOpenAfterCreate)
         worktreeDefaultLauncherMode = try? c.decode(AppConfig.LauncherMode.self, forKey: .worktreeDefaultLauncherMode)
+    }
+
+    func encode(to encoder: Encoder) throws {
+        var c = encoder.container(keyedBy: CodingKeys.self)
+        try c.encode(id, forKey: .id)
+        try c.encode(name, forKey: .name)
+        try c.encode(path, forKey: .path)
+        try c.encode(icon.color, forKey: .color)
+        try c.encode(icon, forKey: .icon)
+        try c.encode(addedAt, forKey: .addedAt)
+        try c.encode(hiddenWorktreePaths, forKey: .hiddenWorktreePaths)
+        try c.encode(worktreeOrder, forKey: .worktreeOrder)
+        try c.encode(worktreeOrderIsManual, forKey: .worktreeOrderIsManual)
+        try c.encode(startupScripts, forKey: .startupScripts)
+        try c.encodeIfPresent(worktreeOpenAfterCreate, forKey: .worktreeOpenAfterCreate)
+        try c.encodeIfPresent(worktreeDefaultLauncherMode, forKey: .worktreeDefaultLauncherMode)
     }
 }

--- a/Alas/Sources/Persistence/ProjectConfig.swift
+++ b/Alas/Sources/Persistence/ProjectConfig.swift
@@ -77,8 +77,11 @@ struct ProjectConfig: Codable, Equatable, Identifiable {
     let id: String           // UUID string
     var name: String         // display name, defaulting to the repo directory name
     var path: String         // absolute repo path
-    var color: String        // hex string, e.g. "#5fb7c4"
     var icon: ProjectIcon
+    var color: String {      // legacy compatibility mirror
+        get { icon.color }
+        set { icon = icon.withColor(newValue) }
+    }
     var addedAt: Date
     var hiddenWorktreePaths: [String] = []
     var worktreeOrder: [String] = []
@@ -117,7 +120,6 @@ struct ProjectConfig: Codable, Equatable, Identifiable {
         self.name = name
         self.path = path
         self.icon = icon ?? ProjectIcon.default(color: color)
-        self.color = self.icon.color
         self.addedAt = addedAt
         self.hiddenWorktreePaths = hiddenWorktreePaths
         self.worktreeOrder = worktreeOrder
@@ -135,10 +137,12 @@ struct ProjectConfig: Codable, Equatable, Identifiable {
         name = try c.decode(String.self, forKey: .name)
         path = try c.decode(String.self, forKey: .path)
         let decodedColor = try c.decode(String.self, forKey: .color)
-        let decodedIcon = (try? c.decode(ProjectIcon.self, forKey: .icon))
+        let decodedIcon = (try? ProjectIcon.decode(
+            from: c.superDecoder(forKey: .icon),
+            fallbackColor: decodedColor
+        ))
             ?? ProjectIcon.default(color: decodedColor)
         icon = decodedIcon
-        color = decodedIcon.color
         addedAt = try c.decode(Date.self, forKey: .addedAt)
         hiddenWorktreePaths = (try? c.decode([String].self, forKey: .hiddenWorktreePaths)) ?? []
         worktreeOrder = (try? c.decode([String].self, forKey: .worktreeOrder)) ?? []

--- a/Alas/Sources/Persistence/ProjectIcon.swift
+++ b/Alas/Sources/Persistence/ProjectIcon.swift
@@ -15,10 +15,10 @@ struct ProjectIcon: Codable, Equatable {
     var label: String?
     var symbolName: String?
     var emoji: String?
-    var imageAssetName: String?
+    var imagePath: String?
 
     enum CodingKeys: String, CodingKey {
-        case mode, color, label, symbolName, emoji, imageAssetName
+        case mode, color, label, symbolName, emoji, imagePath, imageAssetName
     }
 
     init(
@@ -27,30 +27,77 @@ struct ProjectIcon: Codable, Equatable {
         label: String? = nil,
         symbolName: String? = nil,
         emoji: String? = nil,
-        imageAssetName: String? = nil
+        imagePath: String? = nil
+    ) {
+        self.init(
+            mode: mode,
+            color: color,
+            fallbackColor: Self.defaultColor,
+            label: label,
+            symbolName: symbolName,
+            emoji: emoji,
+            imagePath: imagePath
+        )
+    }
+
+    private init(
+        mode: Mode,
+        color: String?,
+        fallbackColor: String,
+        label: String?,
+        symbolName: String?,
+        emoji: String?,
+        imagePath: String?
     ) {
         self.mode = mode
-        self.color = Self.sanitizedColor(color)
+        self.color = Self.sanitizedColor(color, fallback: fallbackColor)
         self.label = Self.sanitizedLabel(label)
         self.symbolName = Self.sanitizedNonEmpty(symbolName)
         self.emoji = Self.sanitizedNonEmpty(emoji)
-        self.imageAssetName = Self.sanitizedNonEmpty(imageAssetName)
+        self.imagePath = Self.sanitizedNonEmpty(imagePath)
     }
 
     init(from decoder: Decoder) throws {
+        self = try Self.decode(from: decoder, fallbackColor: Self.defaultColor)
+    }
+
+    func encode(to encoder: Encoder) throws {
+        var c = encoder.container(keyedBy: CodingKeys.self)
+        try c.encode(mode, forKey: .mode)
+        try c.encode(color, forKey: .color)
+        try c.encodeIfPresent(label, forKey: .label)
+        try c.encodeIfPresent(symbolName, forKey: .symbolName)
+        try c.encodeIfPresent(emoji, forKey: .emoji)
+        try c.encodeIfPresent(imagePath, forKey: .imagePath)
+    }
+
+    static func decode(from decoder: Decoder, fallbackColor: String) throws -> ProjectIcon {
         let c = try decoder.container(keyedBy: CodingKeys.self)
-        self.init(
+        return ProjectIcon(
             mode: try c.decode(Mode.self, forKey: .mode),
-            color: (try? c.decode(String.self, forKey: .color)) ?? Self.defaultColor,
+            color: try? c.decode(String.self, forKey: .color),
+            fallbackColor: fallbackColor,
             label: try? c.decode(String.self, forKey: .label),
             symbolName: try? c.decode(String.self, forKey: .symbolName),
             emoji: try? c.decode(String.self, forKey: .emoji),
-            imageAssetName: try? c.decode(String.self, forKey: .imageAssetName)
+            imagePath: (try? c.decode(String.self, forKey: .imagePath))
+                ?? (try? c.decode(String.self, forKey: .imageAssetName))
         )
     }
 
     static func `default`(color: String = defaultColor) -> ProjectIcon {
         ProjectIcon(mode: .letter, color: color)
+    }
+
+    func withColor(_ color: String) -> ProjectIcon {
+        ProjectIcon(
+            mode: mode,
+            color: color,
+            label: label,
+            symbolName: symbolName,
+            emoji: emoji,
+            imagePath: imagePath
+        )
     }
 
     static func fallbackLabel(projectName: String) -> String {
@@ -68,11 +115,19 @@ struct ProjectIcon: Codable, Equatable {
     }
 
     static func sanitizedColor(_ raw: String) -> String {
+        normalizedHex(raw) ?? defaultColor
+    }
+
+    static func sanitizedColor(_ raw: String?, fallback: String) -> String {
+        raw.flatMap(normalizedHex) ?? normalizedHex(fallback) ?? defaultColor
+    }
+
+    private static func normalizedHex(_ raw: String) -> String? {
         let value = raw.hasPrefix("#") ? String(raw.dropFirst()) : raw
         guard value.count == 6,
               value.allSatisfy({ $0.isHexDigit })
         else {
-            return defaultColor
+            return nil
         }
         return "#\(value)"
     }

--- a/Alas/Sources/Persistence/ProjectIcon.swift
+++ b/Alas/Sources/Persistence/ProjectIcon.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 struct ProjectIcon: Codable, Equatable {
-    enum Mode: String, Codable, Equatable, CaseIterable {
+    enum Mode: String, Codable, Equatable, Hashable, CaseIterable {
         case letter
         case symbol
         case emoji

--- a/Alas/Sources/Persistence/ProjectIcon.swift
+++ b/Alas/Sources/Persistence/ProjectIcon.swift
@@ -53,7 +53,7 @@ struct ProjectIcon: Codable, Equatable {
         self.color = Self.sanitizedColor(color, fallback: fallbackColor)
         self.label = Self.sanitizedLabel(label)
         self.symbolName = Self.sanitizedNonEmpty(symbolName)
-        self.emoji = Self.sanitizedNonEmpty(emoji)
+        self.emoji = Self.sanitizedEmoji(emoji)
         self.imagePath = Self.sanitizedNonEmpty(imagePath)
     }
 
@@ -136,5 +136,9 @@ struct ProjectIcon: Codable, Equatable {
         guard let raw else { return nil }
         let trimmed = raw.trimmingCharacters(in: .whitespacesAndNewlines)
         return trimmed.isEmpty ? nil : trimmed
+    }
+
+    static func sanitizedEmoji(_ raw: String?) -> String? {
+        EmojiIcon.sanitized(raw)
     }
 }

--- a/Alas/Sources/Persistence/ProjectIcon.swift
+++ b/Alas/Sources/Persistence/ProjectIcon.swift
@@ -1,0 +1,85 @@
+import Foundation
+
+struct ProjectIcon: Codable, Equatable {
+    enum Mode: String, Codable, Equatable, CaseIterable {
+        case letter
+        case symbol
+        case emoji
+        case image
+    }
+
+    static let defaultColor = "#5fb7c4"
+
+    var mode: Mode
+    var color: String
+    var label: String?
+    var symbolName: String?
+    var emoji: String?
+    var imageAssetName: String?
+
+    enum CodingKeys: String, CodingKey {
+        case mode, color, label, symbolName, emoji, imageAssetName
+    }
+
+    init(
+        mode: Mode,
+        color: String,
+        label: String? = nil,
+        symbolName: String? = nil,
+        emoji: String? = nil,
+        imageAssetName: String? = nil
+    ) {
+        self.mode = mode
+        self.color = Self.sanitizedColor(color)
+        self.label = Self.sanitizedLabel(label)
+        self.symbolName = Self.sanitizedNonEmpty(symbolName)
+        self.emoji = Self.sanitizedNonEmpty(emoji)
+        self.imageAssetName = Self.sanitizedNonEmpty(imageAssetName)
+    }
+
+    init(from decoder: Decoder) throws {
+        let c = try decoder.container(keyedBy: CodingKeys.self)
+        self.init(
+            mode: try c.decode(Mode.self, forKey: .mode),
+            color: (try? c.decode(String.self, forKey: .color)) ?? Self.defaultColor,
+            label: try? c.decode(String.self, forKey: .label),
+            symbolName: try? c.decode(String.self, forKey: .symbolName),
+            emoji: try? c.decode(String.self, forKey: .emoji),
+            imageAssetName: try? c.decode(String.self, forKey: .imageAssetName)
+        )
+    }
+
+    static func `default`(color: String = defaultColor) -> ProjectIcon {
+        ProjectIcon(mode: .letter, color: color)
+    }
+
+    static func fallbackLabel(projectName: String) -> String {
+        let name = projectName.trimmingCharacters(in: .whitespacesAndNewlines)
+        let tail = name.split(separator: "/").last.map(String.init) ?? name
+        guard let first = tail.first else { return "?" }
+        return String(first).uppercased()
+    }
+
+    static func sanitizedLabel(_ raw: String?) -> String? {
+        guard let raw else { return nil }
+        let trimmed = raw.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return nil }
+        return String(trimmed.prefix(2)).uppercased()
+    }
+
+    static func sanitizedColor(_ raw: String) -> String {
+        let value = raw.hasPrefix("#") ? String(raw.dropFirst()) : raw
+        guard value.count == 6,
+              value.allSatisfy({ $0.isHexDigit })
+        else {
+            return defaultColor
+        }
+        return "#\(value)"
+    }
+
+    static func sanitizedNonEmpty(_ raw: String?) -> String? {
+        guard let raw else { return nil }
+        let trimmed = raw.trimmingCharacters(in: .whitespacesAndNewlines)
+        return trimmed.isEmpty ? nil : trimmed
+    }
+}

--- a/Alas/Sources/Persistence/SpaceConfig.swift
+++ b/Alas/Sources/Persistence/SpaceConfig.swift
@@ -47,9 +47,18 @@ struct SpaceConfig: Codable, Equatable, Identifiable {
 }
 
 enum SpaceIcon {
-    static let emojiOptions = ["🏠", "💼", "✨", "🚀", "🧪", "🎨", "📚", "🔧", "🌱", "🔥", "⭐️", "🧠"]
+    static let emojiOptions = EmojiIcon.emojiOptions
 
     static func sanitized(_ rawValue: String, fallback: String = SpaceConfig.defaultEmoji) -> String {
+        EmojiIcon.sanitized(rawValue, fallback: fallback) ?? fallback
+    }
+}
+
+enum EmojiIcon {
+    static let emojiOptions = ["🏠", "💼", "✨", "🚀", "🧪", "🎨", "📚", "🔧", "🌱", "🔥", "⭐️", "🧠"]
+
+    static func sanitized(_ rawValue: String?, fallback: String? = nil) -> String? {
+        guard let rawValue else { return fallback }
         for character in rawValue.trimmingCharacters(in: .whitespacesAndNewlines) where isAllowed(character) {
             return String(character)
         }

--- a/Alas/Sources/Settings/SpacesPane.swift
+++ b/Alas/Sources/Settings/SpacesPane.swift
@@ -70,7 +70,7 @@ private struct SpaceSettingsRow: View {
                 AlasField(text: $nameDraft, onSubmit: applyChanges)
                     .frame(width: 180)
                     .accessibilityLabel("Space name for \(space.name)")
-                SpaceIconPickerButton(selection: emojiDraft) { icon in
+                EmojiPickerButton(selection: emojiDraft) { icon in
                     emojiDraft = icon
                     applyChanges()
                 }
@@ -141,139 +141,6 @@ private struct SpaceRowIconButton: View {
         }
         .buttonStyle(.plain)
         .help(tooltip)
-    }
-}
-
-private struct SpaceIconPickerButton: View {
-    let selection: String
-    let onSelect: (String) -> Void
-    @Environment(\.theme) var theme
-
-    var body: some View {
-        SpaceEmojiPickerControl(selection: selection, onSelect: onSelect)
-            .frame(width: 34, height: 28)
-            .background(theme.color("bg-1"))
-            .overlay(
-                RoundedRectangle(cornerRadius: 6)
-                    .strokeBorder(theme.color("line"), lineWidth: 0.5)
-            )
-            .clipShape(RoundedRectangle(cornerRadius: 6))
-            .fixedSize()
-    }
-}
-
-private struct SpaceEmojiPickerControl: NSViewRepresentable {
-    let selection: String
-    let onSelect: (String) -> Void
-
-    func makeNSView(context: Context) -> BackingView {
-        let view = BackingView()
-        view.onSelect = onSelect
-        return view
-    }
-
-    func updateNSView(_ nsView: BackingView, context: Context) {
-        nsView.button.title = selection
-        nsView.onSelect = onSelect
-    }
-
-    final class BackingView: NSView, NSTextFieldDelegate {
-        var onSelect: ((String) -> Void)?
-        let button = NSButton()
-        private let input = NSTextField()
-
-        override init(frame frameRect: NSRect) {
-            super.init(frame: frameRect)
-
-            button.isBordered = false
-            button.bezelStyle = .regularSquare
-            button.setButtonType(.momentaryPushIn)
-            button.font = NSFont.systemFont(ofSize: 15)
-            button.target = self
-            button.action = #selector(openCharacterPalette)
-            addSubview(button)
-
-            input.isBordered = false
-            input.isBezeled = false
-            input.drawsBackground = false
-            input.focusRingType = .none
-            input.alphaValue = 0.01
-            input.font = NSFont.systemFont(ofSize: 15)
-            input.delegate = self
-            addSubview(input)
-        }
-
-        @available(*, unavailable)
-        required init?(coder: NSCoder) {
-            fatalError("init(coder:) has not been implemented")
-        }
-
-        override func layout() {
-            super.layout()
-            button.frame = bounds
-            input.frame = NSRect(x: bounds.minX, y: bounds.minY, width: 1, height: 1)
-        }
-
-        @objc func openCharacterPalette() {
-            input.stringValue = ""
-            window?.makeFirstResponder(input)
-            NSApp.orderFrontCharacterPalette(nil)
-        }
-
-        func controlTextDidChange(_ obj: Notification) {
-            commit(input.stringValue)
-        }
-
-        private func commit(_ rawValue: String) {
-            guard SpaceEmojiPickerSelection.commit(
-                rawValue,
-                onSelect: { [weak self] icon in
-                    self?.input.stringValue = ""
-                    self?.onSelect?(icon)
-                },
-                dismissPicker: { [weak self] in
-                    SpaceEmojiPickerWindowDismissal.dismiss(excluding: self?.window)
-                }
-            ) else { return }
-            input.stringValue = ""
-            window?.makeFirstResponder(button)
-            window?.makeKeyAndOrderFront(nil)
-        }
-    }
-}
-
-enum SpaceEmojiPickerSelection {
-    @discardableResult
-    static func commit(
-        _ rawValue: String,
-        onSelect: (String) -> Void,
-        dismissPicker: () -> Void
-    ) -> Bool {
-        let icon = SpaceIcon.sanitized(rawValue, fallback: "")
-        guard !icon.isEmpty else { return false }
-
-        onSelect(icon)
-        dismissPicker()
-        return true
-    }
-}
-
-enum SpaceEmojiPickerWindowDismissal {
-    @MainActor
-    static func dismiss(excluding ownerWindow: NSWindow?) {
-        for window in NSApp.windows where window !== ownerWindow && window.isVisible && isCharacterPalette(window) {
-            window.orderOut(nil)
-        }
-    }
-
-    private static func isCharacterPalette(_ window: NSWindow) -> Bool {
-        let className = String(describing: type(of: window)).lowercased()
-        let title = window.title.lowercased()
-
-        return className.contains("character")
-            || className.contains("emoji")
-            || title.contains("character")
-            || title.contains("emoji")
     }
 }
 

--- a/Alas/Sources/Sidebar/ProjectIconView.swift
+++ b/Alas/Sources/Sidebar/ProjectIconView.swift
@@ -100,7 +100,7 @@ struct ProjectIconView: View {
 
     private func loadImage() -> NSImage? {
         guard let imagePath = icon.imagePath else { return nil }
-        return NSImage(contentsOfFile: imagePath)
+        return NSImage(contentsOf: ProjectIconImageStaging.url(for: imagePath))
     }
 
     nonisolated static func accessibilityLabel(project: ProjectConfig) -> String {

--- a/Alas/Sources/Sidebar/ProjectIconView.swift
+++ b/Alas/Sources/Sidebar/ProjectIconView.swift
@@ -49,13 +49,13 @@ struct ProjectIconView: View {
         case .letter:
             labelView(ProjectIcon.sanitizedLabel(icon.label) ?? ProjectIcon.fallbackLabel(projectName: fallbackName))
         case .symbol:
-            if let symbolName = icon.symbolName {
+            if let symbolName = icon.symbolName, Self.canRenderSymbol(symbolName) {
                 symbolView(symbolName)
             } else {
                 labelView(ProjectIcon.fallbackLabel(projectName: fallbackName))
             }
         case .emoji:
-            if let emoji = icon.emoji, !emoji.isEmpty {
+            if let emoji = Self.renderableEmoji(icon.emoji) {
                 emojiView(emoji)
             } else {
                 labelView(ProjectIcon.fallbackLabel(projectName: fallbackName))
@@ -105,5 +105,23 @@ struct ProjectIconView: View {
 
     nonisolated static func accessibilityLabel(project: ProjectConfig) -> String {
         "\(project.name) project icon"
+    }
+
+    @MainActor
+    static func canRenderSymbol(_ name: String) -> Bool {
+        if Icon.rendersCustomGlyph(for: name) { return true }
+        return NSImage(systemSymbolName: Icon.symbol(for: name), accessibilityDescription: nil) != nil
+    }
+
+    nonisolated static func renderableEmoji(_ raw: String?) -> String? {
+        guard let value = ProjectIcon.sanitizedNonEmpty(raw),
+              value.count == 1,
+              value.unicodeScalars.contains(where: { scalar in
+                  scalar.properties.isEmojiPresentation || scalar.properties.isEmoji
+              })
+        else {
+            return nil
+        }
+        return value
     }
 }

--- a/Alas/Sources/Sidebar/ProjectIconView.swift
+++ b/Alas/Sources/Sidebar/ProjectIconView.swift
@@ -114,6 +114,12 @@ struct ProjectIconView: View {
     }
 
     nonisolated static func renderableEmoji(_ raw: String?) -> String? {
-        ProjectIcon.sanitizedEmoji(raw)
+        guard let value = ProjectIcon.sanitizedNonEmpty(raw),
+              value.count == 1,
+              EmojiIcon.sanitized(value) == value
+        else {
+            return nil
+        }
+        return value
     }
 }

--- a/Alas/Sources/Sidebar/ProjectIconView.swift
+++ b/Alas/Sources/Sidebar/ProjectIconView.swift
@@ -114,14 +114,6 @@ struct ProjectIconView: View {
     }
 
     nonisolated static func renderableEmoji(_ raw: String?) -> String? {
-        guard let value = ProjectIcon.sanitizedNonEmpty(raw),
-              value.count == 1,
-              value.unicodeScalars.contains(where: { scalar in
-                  scalar.properties.isEmojiPresentation || scalar.properties.isEmoji
-              })
-        else {
-            return nil
-        }
-        return value
+        ProjectIcon.sanitizedEmoji(raw)
     }
 }

--- a/Alas/Sources/Sidebar/ProjectIconView.swift
+++ b/Alas/Sources/Sidebar/ProjectIconView.swift
@@ -1,0 +1,109 @@
+import AppKit
+import SwiftUI
+
+struct ProjectIconView: View {
+    enum Size {
+        case sidebar
+        case picker
+        case dialog
+
+        var dimension: CGFloat {
+            switch self {
+            case .sidebar: 16
+            case .picker: 18
+            case .dialog: 72
+            }
+        }
+
+        var cornerRadius: CGFloat {
+            switch self {
+            case .sidebar: 4
+            case .picker: 5
+            case .dialog: 18
+            }
+        }
+
+        var fontSize: CGFloat {
+            switch self {
+            case .sidebar: 9.5
+            case .picker: 10.5
+            case .dialog: 26
+            }
+        }
+    }
+
+    let icon: ProjectIcon
+    let fallbackName: String
+    var size: Size = .sidebar
+
+    var body: some View {
+        content
+            .frame(width: size.dimension, height: size.dimension)
+            .clipShape(RoundedRectangle(cornerRadius: size.cornerRadius))
+            .accessibilityHidden(true)
+    }
+
+    @ViewBuilder
+    private var content: some View {
+        switch icon.mode {
+        case .letter:
+            labelView(ProjectIcon.sanitizedLabel(icon.label) ?? ProjectIcon.fallbackLabel(projectName: fallbackName))
+        case .symbol:
+            if let symbolName = icon.symbolName {
+                symbolView(symbolName)
+            } else {
+                labelView(ProjectIcon.fallbackLabel(projectName: fallbackName))
+            }
+        case .emoji:
+            if let emoji = icon.emoji, !emoji.isEmpty {
+                emojiView(emoji)
+            } else {
+                labelView(ProjectIcon.fallbackLabel(projectName: fallbackName))
+            }
+        case .image:
+            if let image = loadImage() {
+                Image(nsImage: image)
+                    .resizable()
+                    .scaledToFill()
+                    .frame(width: size.dimension, height: size.dimension)
+            } else {
+                labelView(ProjectIcon.fallbackLabel(projectName: fallbackName))
+            }
+        }
+    }
+
+    private func labelView(_ label: String) -> some View {
+        Text(label)
+            .font(.system(size: size.fontSize, weight: .bold))
+            .foregroundColor(.white)
+            .minimumScaleFactor(0.65)
+            .lineLimit(1)
+            .frame(width: size.dimension, height: size.dimension)
+            .background(Color(hex: icon.color))
+    }
+
+    private func symbolView(_ name: String) -> some View {
+        ZStack {
+            Color(hex: icon.color)
+            Icon(name: name, size: size.fontSize + 2, color: .white)
+        }
+    }
+
+    private func emojiView(_ emoji: String) -> some View {
+        Text(emoji)
+            .font(.system(size: size.fontSize + 2))
+            .minimumScaleFactor(0.55)
+            .lineLimit(1)
+            .frame(width: size.dimension, height: size.dimension)
+            .background(Color(hex: icon.color))
+    }
+
+    private func loadImage() -> NSImage? {
+        guard let imagePath = icon.imagePath else { return nil }
+        return NSImage(contentsOfFile: imagePath)
+    }
+
+    nonisolated static func accessibilityLabel(project: ProjectConfig) -> String {
+        "\(project.name) project icon"
+    }
+}

--- a/Alas/Sources/Sidebar/RepoGroupView.swift
+++ b/Alas/Sources/Sidebar/RepoGroupView.swift
@@ -55,7 +55,8 @@ struct RepoGroupView: View {
                 Icon(name: collapsed ? "chev-right" : "chev-down", size: 10, color: theme.color("fg-faint"))
                     .frame(width: 14, height: 14)
                     .contentShape(Rectangle())
-                RepoDot(color: project.color, letter: letter)
+                ProjectIconView(icon: project.icon, fallbackName: project.name, size: .sidebar)
+                    .accessibilityLabel(ProjectIconView.accessibilityLabel(project: project))
                 Text(project.name)
                     .font(.system(size: 11.5, weight: .semibold))
                     .foregroundColor(theme.color("fg-muted"))
@@ -164,11 +165,6 @@ struct RepoGroupView: View {
                 .padding(.horizontal, 6)
             }
         }
-    }
-
-    private var letter: String {
-        let after = project.name.split(separator: "/").last ?? Substring(project.name)
-        return after.prefix(1).uppercased()
     }
 
     private var summaries: [HarnessService.WorktreeHarnessSummary] {

--- a/Alas/Sources/UI/EmojiPickerButton.swift
+++ b/Alas/Sources/UI/EmojiPickerButton.swift
@@ -1,0 +1,134 @@
+import AppKit
+import SwiftUI
+
+struct EmojiPickerButton: View {
+    let selection: String
+    let onSelect: (String) -> Void
+    @Environment(\.theme) var theme
+
+    var body: some View {
+        EmojiPickerControl(selection: selection, onSelect: onSelect)
+            .frame(width: 34, height: 28)
+            .background(theme.color("bg-1"))
+            .overlay(
+                RoundedRectangle(cornerRadius: 6)
+                    .strokeBorder(theme.color("line"), lineWidth: 0.5)
+            )
+            .clipShape(RoundedRectangle(cornerRadius: 6))
+            .fixedSize()
+    }
+}
+
+private struct EmojiPickerControl: NSViewRepresentable {
+    let selection: String
+    let onSelect: (String) -> Void
+
+    func makeNSView(context: Context) -> BackingView {
+        let view = BackingView()
+        view.onSelect = onSelect
+        return view
+    }
+
+    func updateNSView(_ nsView: BackingView, context: Context) {
+        nsView.button.title = selection
+        nsView.onSelect = onSelect
+    }
+
+    final class BackingView: NSView, NSTextFieldDelegate {
+        var onSelect: ((String) -> Void)?
+        let button = NSButton()
+        private let input = NSTextField()
+
+        override init(frame frameRect: NSRect) {
+            super.init(frame: frameRect)
+
+            button.isBordered = false
+            button.bezelStyle = .regularSquare
+            button.setButtonType(.momentaryPushIn)
+            button.font = NSFont.systemFont(ofSize: 15)
+            button.target = self
+            button.action = #selector(openCharacterPalette)
+            addSubview(button)
+
+            input.isBordered = false
+            input.isBezeled = false
+            input.drawsBackground = false
+            input.focusRingType = .none
+            input.alphaValue = 0.01
+            input.font = NSFont.systemFont(ofSize: 15)
+            input.delegate = self
+            addSubview(input)
+        }
+
+        @available(*, unavailable)
+        required init?(coder: NSCoder) {
+            fatalError("init(coder:) has not been implemented")
+        }
+
+        override func layout() {
+            super.layout()
+            button.frame = bounds
+            input.frame = NSRect(x: bounds.minX, y: bounds.minY, width: 1, height: 1)
+        }
+
+        @objc func openCharacterPalette() {
+            input.stringValue = ""
+            window?.makeFirstResponder(input)
+            NSApp.orderFrontCharacterPalette(nil)
+        }
+
+        func controlTextDidChange(_ obj: Notification) {
+            commit(input.stringValue)
+        }
+
+        private func commit(_ rawValue: String) {
+            guard EmojiPickerSelection.commit(
+                rawValue,
+                onSelect: { [weak self] icon in
+                    self?.input.stringValue = ""
+                    self?.onSelect?(icon)
+                },
+                dismissPicker: { [weak self] in
+                    EmojiPickerWindowDismissal.dismiss(excluding: self?.window)
+                }
+            ) else { return }
+            input.stringValue = ""
+            window?.makeFirstResponder(button)
+            window?.makeKeyAndOrderFront(nil)
+        }
+    }
+}
+
+enum EmojiPickerSelection {
+    @discardableResult
+    static func commit(
+        _ rawValue: String,
+        onSelect: (String) -> Void,
+        dismissPicker: () -> Void
+    ) -> Bool {
+        guard let icon = EmojiIcon.sanitized(rawValue) else { return false }
+
+        onSelect(icon)
+        dismissPicker()
+        return true
+    }
+}
+
+enum EmojiPickerWindowDismissal {
+    @MainActor
+    static func dismiss(excluding ownerWindow: NSWindow?) {
+        for window in NSApp.windows where window !== ownerWindow && window.isVisible && isCharacterPalette(window) {
+            window.orderOut(nil)
+        }
+    }
+
+    private static func isCharacterPalette(_ window: NSWindow) -> Bool {
+        let className = String(describing: type(of: window)).lowercased()
+        let title = window.title.lowercased()
+
+        return className.contains("character")
+            || className.contains("emoji")
+            || title.contains("character")
+            || title.contains("emoji")
+    }
+}

--- a/AlasTests/DialogChromeLayoutTests.swift
+++ b/AlasTests/DialogChromeLayoutTests.swift
@@ -1,0 +1,9 @@
+import Testing
+@testable import Alas
+
+struct DialogChromeLayoutTests {
+    @Test("project dialogs reserve enough width for icon controls")
+    func projectDialogWidthFitsIconControls() {
+        #expect(DialogContainerLayout.projectWidth >= 640)
+    }
+}

--- a/AlasTests/ProjectAvatarPresetProviderTests.swift
+++ b/AlasTests/ProjectAvatarPresetProviderTests.swift
@@ -1,0 +1,36 @@
+import Foundation
+import Testing
+@testable import Alas
+
+struct ProjectAvatarPresetProviderTests {
+    @Test func githubRemoteMapsToOwnerAvatarURL() throws {
+        let remote = CodeHostRemote(
+            kind: .github,
+            host: "github.com",
+            owner: "mrmans0n",
+            repository: "alas",
+            remoteName: "origin",
+            webURL: URL(string: "https://github.com/mrmans0n/alas")!
+        )
+
+        let candidate = try #require(ProjectAvatarPresetProvider.candidate(for: remote))
+        #expect(candidate.label == "GitHub avatar: mrmans0n")
+        #expect(candidate.url == URL(string: "https://github.com/mrmans0n.png?size=256")!)
+    }
+
+    @Test func gitlabRemoteMapsToNamespaceAvatarURL() throws {
+        let remote = CodeHostRemote(
+            kind: .gitlab,
+            host: "gitlab.com",
+            owner: "group/subgroup",
+            repository: "repo",
+            remoteName: "origin",
+            webURL: URL(string: "https://gitlab.com/group/subgroup/repo")!
+        )
+
+        let candidate = try #require(ProjectAvatarPresetProvider.candidate(for: remote))
+        #expect(candidate.label == "GitLab avatar: group/subgroup")
+        #expect(candidate.url.absoluteString.contains("https://gitlab.com/api/v4/groups/"))
+        #expect(candidate.url.absoluteString.contains("group%2Fsubgroup"))
+    }
+}

--- a/AlasTests/ProjectConfigTests.swift
+++ b/AlasTests/ProjectConfigTests.swift
@@ -179,4 +179,59 @@ extension ProjectConfigTests {
         #expect(decoded.projects[0].icon.mode == .symbol)
         #expect(decoded.projects[0].icon.symbolName == "terminal")
     }
+
+    @Test func decodingPartialIconFallsBackToLegacyColor() throws {
+        let json = """
+        {
+          "version": 1,
+          "projects": [{
+            "id": "abc",
+            "name": "alpha",
+            "path": "/tmp/alpha",
+            "color": "#112233",
+            "icon": {
+              "mode": "emoji",
+              "emoji": "🚀"
+            },
+            "addedAt": 0
+          }]
+        }
+        """.data(using: .utf8)!
+
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .secondsSince1970
+        let file = try decoder.decode(ProjectsFile.self, from: json)
+
+        #expect(file.projects[0].color == "#112233")
+        #expect(file.projects[0].icon.color == "#112233")
+        #expect(file.projects[0].icon.mode == .emoji)
+        #expect(file.projects[0].icon.emoji == "🚀")
+    }
+
+    @Test func legacyColorMutationUpdatesIconColorBeforeEncoding() throws {
+        var project = ProjectConfig(
+            id: "abc",
+            name: "alpha",
+            path: "/tmp/alpha",
+            color: "#5fb7c4",
+            addedAt: Date(timeIntervalSince1970: 0),
+            icon: ProjectIcon(mode: .symbol, color: "#5fb7c4", symbolName: "terminal")
+        )
+
+        project.color = "#112233"
+
+        #expect(project.icon.mode == .symbol)
+        #expect(project.icon.symbolName == "terminal")
+        #expect(project.icon.color == "#112233")
+
+        let encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = .secondsSince1970
+        let data = try encoder.encode(ProjectsFile(projects: [project]))
+
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .secondsSince1970
+        let decoded = try decoder.decode(ProjectsFile.self, from: data)
+        #expect(decoded.projects[0].icon.color == "#112233")
+        #expect(decoded.projects[0].color == "#112233")
+    }
 }

--- a/AlasTests/ProjectConfigTests.swift
+++ b/AlasTests/ProjectConfigTests.swift
@@ -126,3 +126,57 @@ struct ProjectConfigTests {
         #expect(decoded.projects[0].worktreeDefaultLauncherMode == .acp)
     }
 }
+
+extension ProjectConfigTests {
+    @Test func decodingOlderProjectWithoutIconSynthesizesLetterIcon() throws {
+        let json = """
+        {
+          "version": 1,
+          "projects": [{
+            "id": "abc",
+            "name": "alpha",
+            "path": "/tmp/alpha",
+            "color": "#5fb7c4",
+            "addedAt": 0
+          }]
+        }
+        """.data(using: .utf8)!
+
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .secondsSince1970
+        let file = try decoder.decode(ProjectsFile.self, from: json)
+
+        #expect(file.projects[0].icon.mode == .letter)
+        #expect(file.projects[0].icon.color == "#5fb7c4")
+        #expect(file.projects[0].icon.label == nil)
+    }
+
+    @Test func roundTripPreservesProjectIconAndMirrorsLegacyColor() throws {
+        let project = ProjectConfig(
+            id: "abc",
+            name: "alpha",
+            path: "/tmp/alpha",
+            color: "#5fb7c4",
+            addedAt: Date(timeIntervalSince1970: 0),
+            icon: ProjectIcon(
+                mode: .symbol,
+                color: "#112233",
+                symbolName: "terminal"
+            )
+        )
+
+        let encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = .secondsSince1970
+        let data = try encoder.encode(ProjectsFile(projects: [project]))
+
+        let json = String(decoding: data, as: UTF8.self)
+        #expect(json.contains("\"color\":\"#112233\""))
+
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .secondsSince1970
+        let decoded = try decoder.decode(ProjectsFile.self, from: data)
+        #expect(decoded.projects[0].color == "#112233")
+        #expect(decoded.projects[0].icon.mode == .symbol)
+        #expect(decoded.projects[0].icon.symbolName == "terminal")
+    }
+}

--- a/AlasTests/ProjectIconImageStagingTests.swift
+++ b/AlasTests/ProjectIconImageStagingTests.swift
@@ -36,6 +36,18 @@ struct ProjectIconImageStagingTests {
         }
     }
 
+    @Test func oversizedFileValidationThrowsBeforeRead() throws {
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("project-icon-too-large-\(UUID().uuidString).png")
+        defer { try? FileManager.default.removeItem(at: url) }
+
+        try Data(count: ProjectIconImageStaging.maxBytes + 1).write(to: url)
+
+        #expect(throws: ProjectIconImageStaging.StagingError.tooLarge) {
+            try ProjectIconImageStaging.validateFileSize(at: url)
+        }
+    }
+
     private static let onePixelPNG = Data(base64Encoded:
         "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO+/p9sAAAAASUVORK5CYII="
     )!

--- a/AlasTests/ProjectIconImageStagingTests.swift
+++ b/AlasTests/ProjectIconImageStagingTests.swift
@@ -1,0 +1,42 @@
+import Foundation
+import Testing
+@testable import Alas
+
+struct ProjectIconImageStagingTests {
+    @Test func pngDataStagesUnderProjectDirectory() throws {
+        let data = Self.onePixelPNG
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("project-icons-\(UUID().uuidString)", isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let staged = try ProjectIconImageStaging.stage(
+            data: data,
+            projectId: "project-1",
+            root: root
+        )
+
+        #expect(staged.imagePath.hasSuffix(".png"))
+        #expect(staged.url.path.contains("/project-1/"))
+        #expect(ProjectIconImageStaging.url(for: staged.imagePath, root: root) == staged.url)
+        #expect(FileManager.default.fileExists(atPath: staged.url.path))
+        #expect(try Data(contentsOf: staged.url) == data)
+    }
+
+    @Test func unsupportedDataThrows() throws {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("project-icons-\(UUID().uuidString)", isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        #expect(throws: ProjectIconImageStaging.StagingError.unsupportedFormat) {
+            try ProjectIconImageStaging.stage(
+                data: Data("not an image".utf8),
+                projectId: "project-1",
+                root: root
+            )
+        }
+    }
+
+    private static let onePixelPNG = Data(base64Encoded:
+        "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO+/p9sAAAAASUVORK5CYII="
+    )!
+}

--- a/AlasTests/ProjectIconTests.swift
+++ b/AlasTests/ProjectIconTests.swift
@@ -10,7 +10,7 @@ struct ProjectIconTests {
         #expect(icon.label == nil)
         #expect(icon.symbolName == nil)
         #expect(icon.emoji == nil)
-        #expect(icon.imageAssetName == nil)
+        #expect(icon.imagePath == nil)
     }
 
     @Test func fallbackLabelUsesLastPathComponentInitial() {
@@ -29,5 +29,11 @@ struct ProjectIconTests {
         #expect(ProjectIcon.sanitizedColor("AABBCC") == "#AABBCC")
         #expect(ProjectIcon.sanitizedColor("bad") == ProjectIcon.defaultColor)
         #expect(ProjectIcon.sanitizedColor("#12345g") == ProjectIcon.defaultColor)
+    }
+
+    @Test func sanitizedColorCanUseCallerFallback() {
+        #expect(ProjectIcon.sanitizedColor(nil, fallback: "#112233") == "#112233")
+        #expect(ProjectIcon.sanitizedColor("nope", fallback: "#112233") == "#112233")
+        #expect(ProjectIcon.sanitizedColor("nope", fallback: "also-bad") == ProjectIcon.defaultColor)
     }
 }

--- a/AlasTests/ProjectIconTests.swift
+++ b/AlasTests/ProjectIconTests.swift
@@ -36,4 +36,10 @@ struct ProjectIconTests {
         #expect(ProjectIcon.sanitizedColor("nope", fallback: "#112233") == "#112233")
         #expect(ProjectIcon.sanitizedColor("nope", fallback: "also-bad") == ProjectIcon.defaultColor)
     }
+
+    @Test func sanitizedEmojiUsesFirstValidEmojiOnly() {
+        #expect(ProjectIcon.sanitizedEmoji("abc 🚀") == "🚀")
+        #expect(ProjectIcon.sanitizedEmoji("abc") == nil)
+        #expect(ProjectIcon(mode: .emoji, color: "#112233", emoji: "abc").emoji == nil)
+    }
 }

--- a/AlasTests/ProjectIconTests.swift
+++ b/AlasTests/ProjectIconTests.swift
@@ -1,0 +1,33 @@
+import Testing
+@testable import Alas
+
+struct ProjectIconTests {
+    @Test func defaultIconUsesLetterModeAndColor() {
+        let icon = ProjectIcon.default(color: "#123456")
+
+        #expect(icon.mode == .letter)
+        #expect(icon.color == "#123456")
+        #expect(icon.label == nil)
+        #expect(icon.symbolName == nil)
+        #expect(icon.emoji == nil)
+        #expect(icon.imageAssetName == nil)
+    }
+
+    @Test func fallbackLabelUsesLastPathComponentInitial() {
+        #expect(ProjectIcon.fallbackLabel(projectName: "mrmans0n/alas") == "A")
+        #expect(ProjectIcon.fallbackLabel(projectName: "  ") == "?")
+    }
+
+    @Test func sanitizedLabelClampsToTwoCharacters() {
+        #expect(ProjectIcon.sanitizedLabel("abc") == "AB")
+        #expect(ProjectIcon.sanitizedLabel("z") == "Z")
+        #expect(ProjectIcon.sanitizedLabel("  ") == nil)
+    }
+
+    @Test func sanitizedColorRequiresSixDigitHex() {
+        #expect(ProjectIcon.sanitizedColor("#aabbcc") == "#aabbcc")
+        #expect(ProjectIcon.sanitizedColor("AABBCC") == "#AABBCC")
+        #expect(ProjectIcon.sanitizedColor("bad") == ProjectIcon.defaultColor)
+        #expect(ProjectIcon.sanitizedColor("#12345g") == ProjectIcon.defaultColor)
+    }
+}

--- a/AlasTests/ProjectPickerTests.swift
+++ b/AlasTests/ProjectPickerTests.swift
@@ -62,6 +62,16 @@ struct ProjectPickerTests {
         #expect(ProjectIconView.accessibilityLabel(project: project) == "Alpha project icon")
     }
 
+    @MainActor
+    @Test func projectIconRendererRejectsInvalidSymbolAndEmojiValues() {
+        #expect(ProjectIconView.canRenderSymbol("terminal"))
+        #expect(ProjectIconView.canRenderSymbol("github"))
+        #expect(!ProjectIconView.canRenderSymbol("not-a-real-symbol"))
+        #expect(ProjectIconView.renderableEmoji("🚀") == "🚀")
+        #expect(ProjectIconView.renderableEmoji("abc") == nil)
+        #expect(ProjectIconView.renderableEmoji("🚀🚀") == nil)
+    }
+
     private static func project(name: String) -> ProjectConfig {
         ProjectConfig(
             id: UUID().uuidString,

--- a/AlasTests/ProjectPickerTests.swift
+++ b/AlasTests/ProjectPickerTests.swift
@@ -49,6 +49,19 @@ struct ProjectPickerTests {
         #expect(result.isEmpty)
     }
 
+    @Test func projectIconAccessibilityLabelNamesProject() {
+        let project = ProjectConfig(
+            id: "p1",
+            name: "Alpha",
+            path: "/tmp/alpha",
+            color: "#5fb7c4",
+            addedAt: Date(timeIntervalSince1970: 0),
+            icon: ProjectIcon(mode: .emoji, color: "#5fb7c4", emoji: "🚀")
+        )
+
+        #expect(ProjectIconView.accessibilityLabel(project: project) == "Alpha project icon")
+    }
+
     private static func project(name: String) -> ProjectConfig {
         ProjectConfig(
             id: UUID().uuidString,

--- a/AlasTests/ProjectsManagerTests.swift
+++ b/AlasTests/ProjectsManagerTests.swift
@@ -25,6 +25,18 @@ struct ProjectsManagerTests {
         #expect(project.name == "alpha")
     }
 
+    @Test func addProjectUsesProvidedIconAndMirrorsColor() async throws {
+        let repo = try await makeRepo(name: "lambda")
+        defer { try? FileManager.default.removeItem(at: repo) }
+        let mgr = ProjectsManager(persistedProjects: [])
+        let icon = ProjectIcon(mode: .emoji, color: "#112233", emoji: "🚀")
+
+        let project = try await mgr.addProject(path: repo, displayName: "lambda", icon: icon)
+
+        #expect(project.icon == icon)
+        #expect(project.color == "#112233")
+    }
+
     @Test func refreshWorktreesPopulatesIt() async throws {
         let repo = try await makeRepo(name: "beta")
         defer { try? FileManager.default.removeItem(at: repo) }
@@ -47,7 +59,7 @@ struct ProjectsManagerTests {
         #expect(mgr.worktrees(projectId: project.id).isEmpty)
     }
 
-    @Test func updateProjectUpdatesNameAndColorOnly() {
+    @Test func updateProjectUpdatesNameIconAndStartupScriptsOnly() {
         let addedAt = Date(timeIntervalSince1970: 1_700_000_000)
         let project = ProjectConfig(
             id: "project-1",
@@ -66,15 +78,17 @@ struct ProjectsManagerTests {
             hiddenWorktreePaths: []
         )
         let mgr = ProjectsManager(persistedProjects: [project, other])
+        let icon = ProjectIcon(mode: .symbol, color: "#d77b88", symbolName: "terminal")
 
         mgr.updateProject(
             id: project.id,
-            update: ProjectUpdate(name: "After", color: "#d77b88")
+            update: ProjectUpdate(name: "After", icon: icon)
         )
 
         #expect(mgr.projects[0].id == project.id)
         #expect(mgr.projects[0].name == "After")
         #expect(mgr.projects[0].path == project.path)
+        #expect(mgr.projects[0].icon == icon)
         #expect(mgr.projects[0].color == "#d77b88")
         #expect(mgr.projects[0].addedAt == project.addedAt)
         #expect(mgr.projects[0].hiddenWorktreePaths == project.hiddenWorktreePaths)
@@ -83,11 +97,11 @@ struct ProjectsManagerTests {
 
         mgr.updateProject(
             id: "missing",
-            update: ProjectUpdate(name: "Ignored", color: "#7fb978")
+            update: ProjectUpdate(name: "Ignored", icon: ProjectIcon.default(color: "#7fb978"))
         )
 
         #expect(mgr.projects[0].name == "After")
-        #expect(mgr.projects[0].color == "#d77b88")
+        #expect(mgr.projects[0].icon == icon)
         #expect(mgr.projects[1] == other)
     }
 

--- a/AlasTests/ProjectsManagerTests.swift
+++ b/AlasTests/ProjectsManagerTests.swift
@@ -37,6 +37,23 @@ struct ProjectsManagerTests {
         #expect(project.color == "#112233")
     }
 
+    @Test func addProjectUsesProvidedIdForPreStagedIconStorage() async throws {
+        let repo = try await makeRepo(name: "staged-icon")
+        defer { try? FileManager.default.removeItem(at: repo) }
+        let mgr = ProjectsManager(persistedProjects: [])
+        let icon = ProjectIcon(mode: .image, color: "#112233", imagePath: "project-1/icon.png")
+
+        let project = try await mgr.addProject(
+            path: repo,
+            displayName: "staged-icon",
+            icon: icon,
+            id: "project-1"
+        )
+
+        #expect(project.id == "project-1")
+        #expect(project.icon.imagePath == "project-1/icon.png")
+    }
+
     @Test func refreshWorktreesPopulatesIt() async throws {
         let repo = try await makeRepo(name: "beta")
         defer { try? FileManager.default.removeItem(at: repo) }

--- a/AlasTests/RepoGroupViewLayoutTests.swift
+++ b/AlasTests/RepoGroupViewLayoutTests.swift
@@ -7,20 +7,31 @@ import Testing
 @MainActor
 struct RepoGroupViewLayoutTests {
     @Test func repoHeaderAnchorDoesNotShiftWhenExpanded() throws {
-        let collapsedX = try repoDotMinX(collapsed: true)
-        let expandedX = try repoDotMinX(collapsed: false)
+        let collapsedX = try repoIconMinX(collapsed: true)
+        let expandedX = try repoIconMinX(collapsed: false)
 
         #expect(collapsedX == expandedX)
     }
 
-    private func repoDotMinX(collapsed: Bool) throws -> Int {
-        let color = "#ff0000"
+    @Test func projectIconSymbolHeaderAnchorDoesNotShiftWhenExpanded() throws {
+        let icon = ProjectIcon(mode: .symbol, color: "#ff0000", symbolName: "terminal")
+        let collapsedX = try repoIconMinX(collapsed: true, icon: icon)
+        let expandedX = try repoIconMinX(collapsed: false, icon: icon)
+
+        #expect(collapsedX == expandedX)
+    }
+
+    private func repoIconMinX(
+        collapsed: Bool,
+        icon: ProjectIcon = ProjectIcon.default(color: "#ff0000")
+    ) throws -> Int {
         let project = ProjectConfig(
             id: "project-1",
             name: "Sample",
             path: "/tmp/sample",
-            color: color,
-            addedAt: Date(timeIntervalSince1970: 0)
+            color: icon.color,
+            addedAt: Date(timeIntervalSince1970: 0),
+            icon: icon
         )
         let worktrees = [
             Worktree(

--- a/AlasTests/SpaceEmojiPickerSelectionTests.swift
+++ b/AlasTests/SpaceEmojiPickerSelectionTests.swift
@@ -2,12 +2,12 @@ import Testing
 @testable import Alas
 
 @MainActor
-struct SpaceEmojiPickerSelectionTests {
+struct EmojiPickerSelectionTests {
     @Test func validEmojiSelectionCommitsAndDismissesPicker() {
         var selections: [String] = []
         var dismissCount = 0
 
-        let didCommit = SpaceEmojiPickerSelection.commit(
+        let didCommit = EmojiPickerSelection.commit(
             "🚀",
             onSelect: { selections.append($0) },
             dismissPicker: { dismissCount += 1 }
@@ -22,7 +22,7 @@ struct SpaceEmojiPickerSelectionTests {
         var selections: [String] = []
         var dismissCount = 0
 
-        let didCommit = SpaceEmojiPickerSelection.commit(
+        let didCommit = EmojiPickerSelection.commit(
             "work",
             onSelect: { selections.append($0) },
             dismissPicker: { dismissCount += 1 }

--- a/docs/superpowers/plans/2026-07-04-project-icons.md
+++ b/docs/superpowers/plans/2026-07-04-project-icons.md
@@ -82,7 +82,7 @@ struct ProjectIconTests {
         #expect(icon.label == nil)
         #expect(icon.symbolName == nil)
         #expect(icon.emoji == nil)
-        #expect(icon.imageAssetName == nil)
+        #expect(icon.imagePath == nil)
     }
 
     @Test func fallbackLabelUsesLastPathComponentInitial() {
@@ -195,7 +195,7 @@ struct ProjectIcon: Codable, Equatable {
     var label: String?
     var symbolName: String?
     var emoji: String?
-    var imageAssetName: String?
+    var imagePath: String?
 
     init(
         mode: Mode,
@@ -203,14 +203,14 @@ struct ProjectIcon: Codable, Equatable {
         label: String? = nil,
         symbolName: String? = nil,
         emoji: String? = nil,
-        imageAssetName: String? = nil
+        imagePath: String? = nil
     ) {
         self.mode = mode
         self.color = Self.sanitizedColor(color)
         self.label = Self.sanitizedLabel(label)
         self.symbolName = Self.sanitizedNonEmpty(symbolName)
         self.emoji = Self.sanitizedNonEmpty(emoji)
-        self.imageAssetName = Self.sanitizedNonEmpty(imageAssetName)
+        self.imagePath = Self.sanitizedNonEmpty(imagePath)
     }
 
     static func `default`(color: String = defaultColor) -> ProjectIcon {
@@ -780,8 +780,8 @@ struct ProjectIconView: View {
     }
 
     private func loadImage() -> NSImage? {
-        guard let imageAssetName = icon.imageAssetName else { return nil }
-        return NSImage(contentsOfFile: imageAssetName)
+        guard let imagePath = icon.imagePath else { return nil }
+        return NSImage(contentsOfFile: imagePath)
     }
 
     static func accessibilityLabel(project: ProjectConfig) -> String {
@@ -876,7 +876,7 @@ struct ProjectIconImageStagingTests {
             root: root
         )
 
-        #expect(staged.assetName.hasSuffix(".png"))
+        #expect(staged.imagePath.hasSuffix(".png"))
         #expect(staged.url.path.contains("/project-1/"))
         #expect(FileManager.default.fileExists(atPath: staged.url.path))
         #expect(try Data(contentsOf: staged.url) == data)
@@ -938,7 +938,7 @@ import CryptoKit
 
 enum ProjectIconImageStaging {
     struct Staged: Equatable {
-        let assetName: String
+        let imagePath: String
         let url: URL
     }
 
@@ -964,14 +964,14 @@ enum ProjectIconImageStaging {
             if !FileManager.default.fileExists(atPath: url.path) {
                 try data.write(to: url, options: .atomic)
             }
-            return Staged(assetName: "\(projectId)/\(filename)", url: url)
+            return Staged(imagePath: "\(projectId)/\(filename)", url: url)
         } catch {
             throw StagingError.writeFailed
         }
     }
 
-    static func url(for assetName: String, root: URL = Paths.projectIconsRoot) -> URL {
-        root.appendingPathComponent(assetName)
+    static func url(for imagePath: String, root: URL = Paths.projectIconsRoot) -> URL {
+        root.appendingPathComponent(imagePath)
     }
 
     static func fileExtension(for data: Data) -> String? {
@@ -1002,8 +1002,8 @@ Modify `ProjectIconView.loadImage()`:
 
 ```swift
 private func loadImage() -> NSImage? {
-    guard let imageAssetName = icon.imageAssetName else { return nil }
-    let url = ProjectIconImageStaging.url(for: imageAssetName)
+    guard let imagePath = icon.imagePath else { return nil }
+    let url = ProjectIconImageStaging.url(for: imagePath)
     return NSImage(contentsOf: url)
 }
 ```
@@ -1189,7 +1189,7 @@ with:
 @State private var iconLabel: String = ""
 @State private var iconSymbolName: String = "folder"
 @State private var iconEmoji: String = "🚀"
-@State private var iconImageAssetName: String?
+@State private var iconImagePath: String?
 @State private var pendingIconStorageId = "pending-\(UUID().uuidString)"
 @State private var avatarPreset: ProjectAvatarPreset?
 @State private var avatarPresetData: Data?
@@ -1207,7 +1207,7 @@ private var draftIcon: ProjectIcon {
         label: iconLabel,
         symbolName: iconSymbolName,
         emoji: iconEmoji,
-        imageAssetName: iconImageAssetName
+        imagePath: iconImagePath
     )
 }
 ```
@@ -1374,7 +1374,7 @@ private func chooseProjectIconImage() {
             let data = try Data(contentsOf: url)
             let projectId = existingProjectIdForIconStorage()
             let staged = try ProjectIconImageStaging.stage(data: data, projectId: projectId)
-            iconImageAssetName = staged.assetName
+            iconImagePath = staged.imagePath
             iconMode = .image
             errorMessage = nil
         } catch let stagingError as ProjectIconImageStaging.StagingError {
@@ -1405,7 +1405,7 @@ iconColor = project.icon.color
 iconLabel = project.icon.label ?? ""
 iconSymbolName = project.icon.symbolName ?? "folder"
 iconEmoji = project.icon.emoji ?? "🚀"
-iconImageAssetName = project.icon.imageAssetName
+iconImagePath = project.icon.imagePath
 ```
 
 In add confirm:
@@ -1476,7 +1476,7 @@ private func useAvatarPreset() {
     guard let data = avatarPresetData else { return }
     do {
         let staged = try ProjectIconImageStaging.stage(data: data, projectId: existingProjectIdForIconStorage())
-        iconImageAssetName = staged.assetName
+        iconImagePath = staged.imagePath
         iconMode = .image
         errorMessage = nil
     } catch let stagingError as ProjectIconImageStaging.StagingError {

--- a/docs/superpowers/plans/2026-07-04-project-icons.md
+++ b/docs/superpowers/plans/2026-07-04-project-icons.md
@@ -1,0 +1,1585 @@
+# Project Icons Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add project icon customization with Letter, Symbol, Emoji, and Image modes, including GitHub/GitLab avatar presets and shared rendering across project identity surfaces.
+
+**Architecture:** Add `ProjectIcon` as a structured value on `ProjectConfig`, keep legacy `color` mirrored for compatibility, and route all project identity rendering through a reusable `ProjectIconView`. Keep file/image storage and avatar fetching in focused helpers so `ProjectsManager` remains a persistence/state coordinator, not a network or image-decoding owner.
+
+**Tech Stack:** Swift 5.9, SwiftUI for macOS 15, Swift Testing, AppKit `NSOpenPanel`/`NSImage`, ImageIO/CryptoKit for image staging, existing `CodeHostRemoteDetector`.
+
+---
+
+## File Structure
+
+- Create `Alas/Sources/Persistence/ProjectIcon.swift`: persisted icon model, sanitization helpers, defaults, and fallback label/color behavior.
+- Modify `Alas/Sources/Persistence/ProjectConfig.swift`: add `icon`, tolerant decode, encode mirror from `icon.color` to legacy `color`.
+- Modify `Alas/Sources/App/ProjectsManager.swift`: change `ProjectUpdate` and add/update project paths to carry `ProjectIcon`.
+- Modify `Alas/Sources/App/AppState.swift`: thread structured project icons through add/update methods.
+- Create `Alas/Sources/Sidebar/ProjectIconView.swift`: shared SwiftUI renderer and stable sizing.
+- Modify `Alas/Sources/Sidebar/RepoGroupView.swift`: replace `RepoDot`.
+- Modify `Alas/Sources/Dialogs/RepoSelector/RepoSelectorRowView.swift`: replace `RepoDot`.
+- Modify `Alas/Sources/Dialogs/ProjectPicker.swift`: replace small color dots.
+- Create `Alas/Sources/Dialogs/ProjectIconImageStaging.swift`: managed image copy/validation helper.
+- Create `Alas/Sources/Dialogs/ProjectAvatarPresetProvider.swift`: remote detection and non-blocking avatar fetch support.
+- Modify `Alas/Sources/Persistence/Paths.swift`: add `projectIconsRoot` and per-project directory helper.
+- Modify `Alas/Sources/Dialogs/NewProjectDialog.swift`: add Icon section, draft state, controls, image import, and avatar preset.
+- Add tests:
+  - `AlasTests/ProjectIconTests.swift`
+  - `AlasTests/ProjectIconImageStagingTests.swift`
+  - `AlasTests/ProjectAvatarPresetProviderTests.swift`
+  - extend `AlasTests/ProjectConfigTests.swift`
+  - extend `AlasTests/ProjectsManagerTests.swift`
+  - extend `AlasTests/RepoGroupViewLayoutTests.swift`
+  - extend `AlasTests/ProjectPickerTests.swift`
+
+## Verification Commands
+
+Use these after relevant tasks:
+
+```bash
+rtk xcodegen
+rtk xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -only-testing:AlasTests/ProjectIconTests -quiet test
+rtk xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -only-testing:AlasTests/ProjectIconImageStagingTests -quiet test
+rtk xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -only-testing:AlasTests/ProjectAvatarPresetProviderTests -quiet test
+rtk xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -only-testing:AlasTests/ProjectConfigTests -quiet test
+rtk xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -only-testing:AlasTests/ProjectsManagerTests -quiet test
+rtk xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -only-testing:AlasTests/RepoGroupViewLayoutTests -quiet test
+rtk xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -only-testing:AlasTests/ProjectPickerTests -quiet test
+rtk xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -quiet build
+```
+
+Run the full test command from `AGENTS.md` before final handoff:
+
+```bash
+rtk xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' test
+```
+
+---
+
+### Task 1: Persisted ProjectIcon Model
+
+**Files:**
+- Create: `Alas/Sources/Persistence/ProjectIcon.swift`
+- Modify: `Alas/Sources/Persistence/ProjectConfig.swift`
+- Test: `AlasTests/ProjectIconTests.swift`
+- Test: `AlasTests/ProjectConfigTests.swift`
+
+- [ ] **Step 1: Write model tests**
+
+Create `AlasTests/ProjectIconTests.swift`:
+
+```swift
+import Testing
+@testable import Alas
+
+struct ProjectIconTests {
+    @Test func defaultIconUsesLetterModeAndColor() {
+        let icon = ProjectIcon.default(color: "#123456")
+
+        #expect(icon.mode == .letter)
+        #expect(icon.color == "#123456")
+        #expect(icon.label == nil)
+        #expect(icon.symbolName == nil)
+        #expect(icon.emoji == nil)
+        #expect(icon.imageAssetName == nil)
+    }
+
+    @Test func fallbackLabelUsesLastPathComponentInitial() {
+        #expect(ProjectIcon.fallbackLabel(projectName: "mrmans0n/alas") == "A")
+        #expect(ProjectIcon.fallbackLabel(projectName: "  ") == "?")
+    }
+
+    @Test func sanitizedLabelClampsToTwoCharacters() {
+        #expect(ProjectIcon.sanitizedLabel("abc") == "AB")
+        #expect(ProjectIcon.sanitizedLabel("z") == "Z")
+        #expect(ProjectIcon.sanitizedLabel("  ") == nil)
+    }
+
+    @Test func sanitizedColorRequiresSixDigitHex() {
+        #expect(ProjectIcon.sanitizedColor("#aabbcc") == "#aabbcc")
+        #expect(ProjectIcon.sanitizedColor("AABBCC") == "#AABBCC")
+        #expect(ProjectIcon.sanitizedColor("bad") == ProjectIcon.defaultColor)
+        #expect(ProjectIcon.sanitizedColor("#12345g") == ProjectIcon.defaultColor)
+    }
+}
+```
+
+Extend `AlasTests/ProjectConfigTests.swift` with:
+
+```swift
+extension ProjectConfigTests {
+    @Test func decodingOlderProjectWithoutIconSynthesizesLetterIcon() throws {
+        let json = """
+        {
+          "version": 1,
+          "projects": [{
+            "id": "abc",
+            "name": "alpha",
+            "path": "/tmp/alpha",
+            "color": "#5fb7c4",
+            "addedAt": 0
+          }]
+        }
+        """.data(using: .utf8)!
+
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .secondsSince1970
+        let file = try decoder.decode(ProjectsFile.self, from: json)
+
+        #expect(file.projects[0].icon.mode == .letter)
+        #expect(file.projects[0].icon.color == "#5fb7c4")
+        #expect(file.projects[0].icon.label == nil)
+    }
+
+    @Test func roundTripPreservesProjectIconAndMirrorsLegacyColor() throws {
+        let project = ProjectConfig(
+            id: "abc",
+            name: "alpha",
+            path: "/tmp/alpha",
+            color: "#5fb7c4",
+            addedAt: Date(timeIntervalSince1970: 0),
+            icon: ProjectIcon(
+                mode: .symbol,
+                color: "#112233",
+                symbolName: "terminal"
+            )
+        )
+
+        let encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = .secondsSince1970
+        let data = try encoder.encode(ProjectsFile(projects: [project]))
+
+        let json = String(decoding: data, as: UTF8.self)
+        #expect(json.contains("\"color\":\"#112233\""))
+
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .secondsSince1970
+        let decoded = try decoder.decode(ProjectsFile.self, from: data)
+        #expect(decoded.projects[0].color == "#112233")
+        #expect(decoded.projects[0].icon.mode == .symbol)
+        #expect(decoded.projects[0].icon.symbolName == "terminal")
+    }
+}
+```
+
+- [ ] **Step 2: Run tests and verify failure**
+
+Run:
+
+```bash
+rtk xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -only-testing:AlasTests/ProjectIconTests -only-testing:AlasTests/ProjectConfigTests -quiet test
+```
+
+Expected: FAIL because `ProjectIcon` and `ProjectConfig.icon` do not exist.
+
+- [ ] **Step 3: Add `ProjectIcon`**
+
+Create `Alas/Sources/Persistence/ProjectIcon.swift`:
+
+```swift
+import Foundation
+
+struct ProjectIcon: Codable, Equatable {
+    enum Mode: String, Codable, Equatable, CaseIterable {
+        case letter
+        case symbol
+        case emoji
+        case image
+    }
+
+    static let defaultColor = "#5fb7c4"
+
+    var mode: Mode
+    var color: String
+    var label: String?
+    var symbolName: String?
+    var emoji: String?
+    var imageAssetName: String?
+
+    init(
+        mode: Mode,
+        color: String,
+        label: String? = nil,
+        symbolName: String? = nil,
+        emoji: String? = nil,
+        imageAssetName: String? = nil
+    ) {
+        self.mode = mode
+        self.color = Self.sanitizedColor(color)
+        self.label = Self.sanitizedLabel(label)
+        self.symbolName = Self.sanitizedNonEmpty(symbolName)
+        self.emoji = Self.sanitizedNonEmpty(emoji)
+        self.imageAssetName = Self.sanitizedNonEmpty(imageAssetName)
+    }
+
+    static func `default`(color: String = defaultColor) -> ProjectIcon {
+        ProjectIcon(mode: .letter, color: color)
+    }
+
+    static func fallbackLabel(projectName: String) -> String {
+        let name = projectName.trimmingCharacters(in: .whitespacesAndNewlines)
+        let tail = name.split(separator: "/").last.map(String.init) ?? name
+        guard let first = tail.first else { return "?" }
+        return String(first).uppercased()
+    }
+
+    static func sanitizedLabel(_ raw: String?) -> String? {
+        guard let raw else { return nil }
+        let trimmed = raw.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return nil }
+        return String(trimmed.prefix(2)).uppercased()
+    }
+
+    static func sanitizedColor(_ raw: String) -> String {
+        let value = raw.hasPrefix("#") ? String(raw.dropFirst()) : raw
+        guard value.count == 6,
+              value.allSatisfy({ $0.isHexDigit })
+        else {
+            return defaultColor
+        }
+        return "#\(value)"
+    }
+
+    static func sanitizedNonEmpty(_ raw: String?) -> String? {
+        guard let raw else { return nil }
+        let trimmed = raw.trimmingCharacters(in: .whitespacesAndNewlines)
+        return trimmed.isEmpty ? nil : trimmed
+    }
+}
+```
+
+- [ ] **Step 4: Add `icon` to `ProjectConfig` with tolerant decode**
+
+In `Alas/Sources/Persistence/ProjectConfig.swift`, add `var icon: ProjectIcon` directly after `var color: String`, and add `icon` to `CodingKeys` between `color` and `addedAt`.
+
+Update the initializer signature:
+
+```swift
+init(
+    id: String,
+    name: String,
+    path: String,
+    color: String,
+    addedAt: Date,
+    icon: ProjectIcon? = nil,
+    hiddenWorktreePaths: [String] = [],
+    worktreeOrder: [String] = [],
+    worktreeOrderIsManual: Bool = false,
+    startupScripts: ProjectStartupScripts = .defaults,
+    worktreeOpenAfterCreate: Bool? = nil,
+    worktreeDefaultLauncherMode: AppConfig.LauncherMode? = nil
+) {
+    self.id = id
+    self.name = name
+    self.path = path
+    self.icon = icon ?? ProjectIcon.default(color: color)
+    self.color = self.icon.color
+    self.addedAt = addedAt
+    self.hiddenWorktreePaths = hiddenWorktreePaths
+    self.worktreeOrder = worktreeOrder
+    self.worktreeOrderIsManual = worktreeOrderIsManual
+    self.startupScripts = startupScripts
+    self.worktreeOpenAfterCreate = worktreeOpenAfterCreate
+    self.worktreeDefaultLauncherMode = worktreeDefaultLauncherMode
+}
+```
+
+Update decode:
+
+```swift
+let decodedColor = try c.decode(String.self, forKey: .color)
+let decodedIcon = (try? c.decode(ProjectIcon.self, forKey: .icon))
+    ?? ProjectIcon.default(color: decodedColor)
+icon = decodedIcon
+color = decodedIcon.color
+```
+
+Add a custom `encode(to:)` so legacy `color` mirrors `icon.color`:
+
+```swift
+func encode(to encoder: Encoder) throws {
+    var c = encoder.container(keyedBy: CodingKeys.self)
+    try c.encode(id, forKey: .id)
+    try c.encode(name, forKey: .name)
+    try c.encode(path, forKey: .path)
+    try c.encode(icon.color, forKey: .color)
+    try c.encode(icon, forKey: .icon)
+    try c.encode(addedAt, forKey: .addedAt)
+    try c.encode(hiddenWorktreePaths, forKey: .hiddenWorktreePaths)
+    try c.encode(worktreeOrder, forKey: .worktreeOrder)
+    try c.encode(worktreeOrderIsManual, forKey: .worktreeOrderIsManual)
+    try c.encode(startupScripts, forKey: .startupScripts)
+    try c.encodeIfPresent(worktreeOpenAfterCreate, forKey: .worktreeOpenAfterCreate)
+    try c.encodeIfPresent(worktreeDefaultLauncherMode, forKey: .worktreeDefaultLauncherMode)
+}
+```
+
+- [ ] **Step 5: Run tests and verify pass**
+
+Run:
+
+```bash
+rtk xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -only-testing:AlasTests/ProjectIconTests -only-testing:AlasTests/ProjectConfigTests -quiet test
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+Run:
+
+```bash
+rtk git add Alas/Sources/Persistence/ProjectIcon.swift Alas/Sources/Persistence/ProjectConfig.swift AlasTests/ProjectIconTests.swift AlasTests/ProjectConfigTests.swift
+rtk git commit -m "feat: add project icon model"
+```
+
+---
+
+### Task 2: ProjectsManager and AppState Icon Plumbing
+
+**Files:**
+- Modify: `Alas/Sources/App/ProjectsManager.swift`
+- Modify: `Alas/Sources/App/AppState.swift`
+- Test: `AlasTests/ProjectsManagerTests.swift`
+
+- [ ] **Step 1: Write update/add tests**
+
+Update `AlasTests/ProjectsManagerTests.swift`:
+
+```swift
+@Test func addProjectUsesProvidedIconAndMirrorsColor() async throws {
+    let repo = try await makeRepo(name: "lambda")
+    defer { try? FileManager.default.removeItem(at: repo) }
+    let mgr = ProjectsManager(persistedProjects: [])
+    let icon = ProjectIcon(mode: .emoji, color: "#112233", emoji: "🚀")
+
+    let project = try await mgr.addProject(path: repo, displayName: "lambda", icon: icon)
+
+    #expect(project.icon == icon)
+    #expect(project.color == "#112233")
+}
+```
+
+Replace the body of `updateProjectUpdatesNameAndColorOnly` so it asserts icon preservation and update:
+
+```swift
+@Test func updateProjectUpdatesNameIconAndStartupScriptsOnly() {
+    let addedAt = Date(timeIntervalSince1970: 1_700_000_000)
+    let project = ProjectConfig(
+        id: "project-1",
+        name: "Before",
+        path: "/tmp/before",
+        color: "#5fb7c4",
+        addedAt: addedAt,
+        hiddenWorktreePaths: ["/tmp/before/.worktree"]
+    )
+    let other = ProjectConfig(
+        id: "project-2",
+        name: "Other",
+        path: "/tmp/other",
+        color: "#9789c7",
+        addedAt: addedAt.addingTimeInterval(1),
+        hiddenWorktreePaths: []
+    )
+    let mgr = ProjectsManager(persistedProjects: [project, other])
+    let icon = ProjectIcon(mode: .symbol, color: "#d77b88", symbolName: "terminal")
+
+    mgr.updateProject(
+        id: project.id,
+        update: ProjectUpdate(name: "After", icon: icon)
+    )
+
+    #expect(mgr.projects[0].id == project.id)
+    #expect(mgr.projects[0].name == "After")
+    #expect(mgr.projects[0].path == project.path)
+    #expect(mgr.projects[0].icon == icon)
+    #expect(mgr.projects[0].color == "#d77b88")
+    #expect(mgr.projects[0].addedAt == project.addedAt)
+    #expect(mgr.projects[0].hiddenWorktreePaths == project.hiddenWorktreePaths)
+    #expect(mgr.projects[0].startupScripts == .defaults)
+    #expect(mgr.projects[1] == other)
+
+    mgr.updateProject(
+        id: "missing",
+        update: ProjectUpdate(name: "Ignored", icon: ProjectIcon.default(color: "#7fb978"))
+    )
+
+    #expect(mgr.projects[0].name == "After")
+    #expect(mgr.projects[0].icon == icon)
+    #expect(mgr.projects[1] == other)
+}
+```
+
+- [ ] **Step 2: Run tests and verify failure**
+
+Run:
+
+```bash
+rtk xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -only-testing:AlasTests/ProjectsManagerTests -quiet test
+```
+
+Expected: FAIL because `ProjectUpdate.icon` and `addProject(... icon:)` do not exist.
+
+- [ ] **Step 3: Update manager APIs**
+
+Modify `Alas/Sources/App/ProjectsManager.swift`:
+
+```swift
+struct ProjectUpdate: Equatable {
+    var name: String
+    var icon: ProjectIcon
+    var startupScripts: ProjectStartupScripts = .defaults
+}
+```
+
+Replace `addProject(path:displayName:color:)` with:
+
+```swift
+func addProject(path: URL, displayName: String, icon: ProjectIcon) async throws -> ProjectConfig {
+    let isRepo = try await git.isGitRepository(path)
+    guard isRepo else {
+        throw NSError(domain: "ProjectsManager", code: 1,
+                      userInfo: [NSLocalizedDescriptionKey: "Not a git repository: \(path.path)"])
+    }
+    let project = ProjectConfig(
+        id: UUID().uuidString,
+        name: displayName,
+        path: path.path,
+        color: icon.color,
+        addedAt: Date(),
+        icon: icon
+    )
+    projects.append(project)
+    return project
+}
+```
+
+Update `updateProject`:
+
+```swift
+func updateProject(id: String, update: ProjectUpdate) {
+    guard let idx = projects.firstIndex(where: { $0.id == id }) else { return }
+    projects[idx].name = update.name
+    projects[idx].icon = update.icon
+    projects[idx].color = update.icon.color
+    projects[idx].startupScripts = update.startupScripts
+}
+```
+
+Update the known direct call sites:
+
+```swift
+let project = try await mgr.addProject(
+    path: repo,
+    displayName: "alpha",
+    icon: ProjectIcon.default(color: "#5fb7c4")
+)
+```
+
+```swift
+ProjectUpdate(
+    name: "After",
+    icon: ProjectIcon.default(color: "#d77b88"),
+    startupScripts: scripts
+)
+```
+
+Use this search to find any missed API calls:
+
+```bash
+rtk rg -n "addProject\\(|ProjectUpdate\\(" Alas/Sources AlasTests
+```
+
+- [ ] **Step 4: Update AppState API signatures**
+
+Modify `Alas/Sources/App/AppState.swift`:
+
+```swift
+func addProject(path: URL, displayName: String, icon: ProjectIcon) async throws {
+    let project = try await projectsManager.addProject(path: path, displayName: displayName, icon: icon)
+    spacesManager.addProject(project.id, toSpace: spacesManager.activeSpaceId)
+    saveProjects()
+    saveSpaces()
+    if await projectsManager.refreshAll() {
+        saveProjects()
+    }
+    startProjectGitWatcher(for: project)
+}
+```
+
+Modify update:
+
+```swift
+func updateProject(id: String, name: String, icon: ProjectIcon, startupScripts: ProjectStartupScripts) {
+    let trimmedName = name.trimmingCharacters(in: .whitespacesAndNewlines)
+    guard !trimmedName.isEmpty else { return }
+
+    projectsManager.updateProject(
+        id: id,
+        update: ProjectUpdate(
+            name: trimmedName,
+            icon: icon,
+            startupScripts: startupScripts
+        )
+    )
+    saveProjects()
+}
+```
+
+- [ ] **Step 5: Run tests and compile check**
+
+Run:
+
+```bash
+rtk xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -only-testing:AlasTests/ProjectsManagerTests -quiet test
+rtk xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -quiet build
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+Run:
+
+```bash
+rtk git add Alas/Sources/App/ProjectsManager.swift Alas/Sources/App/AppState.swift AlasTests/ProjectsManagerTests.swift
+rtk git commit -m "feat: thread project icons through project state"
+```
+
+---
+
+### Task 3: Shared ProjectIconView Renderer
+
+**Files:**
+- Create: `Alas/Sources/Sidebar/ProjectIconView.swift`
+- Modify: `Alas/Sources/Sidebar/RepoGroupView.swift`
+- Modify: `Alas/Sources/Dialogs/RepoSelector/RepoSelectorRowView.swift`
+- Modify: `Alas/Sources/Dialogs/ProjectPicker.swift`
+- Test: `AlasTests/RepoGroupViewLayoutTests.swift`
+- Test: `AlasTests/ProjectPickerTests.swift`
+
+- [ ] **Step 1: Add renderer layout tests**
+
+Extend `AlasTests/RepoGroupViewLayoutTests.swift` with:
+
+```swift
+@Test func projectIconSymbolHeaderAnchorDoesNotShiftWhenExpanded() throws {
+    let collapsedX = try repoIconMinX(collapsed: true, icon: ProjectIcon(mode: .symbol, color: "#ff0000", symbolName: "terminal"))
+    let expandedX = try repoIconMinX(collapsed: false, icon: ProjectIcon(mode: .symbol, color: "#ff0000", symbolName: "terminal"))
+
+    #expect(collapsedX == expandedX)
+}
+```
+
+Refactor the helper to accept `icon`:
+
+```swift
+private func repoIconMinX(collapsed: Bool, icon: ProjectIcon = ProjectIcon.default(color: "#ff0000")) throws -> Int {
+    let project = ProjectConfig(
+        id: "project-1",
+        name: "Sample",
+        path: "/tmp/sample",
+        color: icon.color,
+        addedAt: Date(timeIntervalSince1970: 0),
+        icon: icon
+    )
+    let view = RepoGroupView(
+        project: project,
+        worktrees: worktrees,
+        collapsed: .constant(collapsed),
+        selectedWorktreeId: nil,
+        isMain: { _ in false },
+        operationState: { _ in nil },
+        harnessSummary: { _ in nil },
+        onSelect: { _ in },
+        onNewWorktree: {},
+        onEditProject: {},
+        onRemoveProject: {},
+        onResetSort: {},
+        spaces: [],
+        activeSpaceId: "",
+        isProjectInSpace: { _ in false },
+        canRemoveFromSpace: { _ in true },
+        onToggleSpaceMembership: { _ in },
+        onOpenTerminal: { _ in },
+        onCopyPath: { _ in },
+        onCopyBranch: { _ in },
+        onRevealInFinder: { _ in },
+        onArchive: { _ in },
+        onDelete: { _ in },
+        onDeleteKeepBranch: { _ in },
+        showKeepBranchOption: false,
+        onActivateHarness: { _ in },
+        onCopyError: { _ in },
+        onRetryCreate: { _ in },
+        onRetryDelete: { _ in },
+        onRemoveFailed: { _ in },
+        onDropWorktree: { _, _ in },
+        onDropProject: { _, _ in }
+    )
+    .environment(\.theme, try ThemeStore().current)
+
+    let controller = NSHostingController(rootView: view)
+    controller.view.frame = NSRect(x: 0, y: 0, width: 260, height: collapsed ? 40 : 100)
+    controller.view.layoutSubtreeIfNeeded()
+
+    let bitmap = try #require(controller.view.bitmapImageRepForCachingDisplay(in: controller.view.bounds))
+    controller.view.cacheDisplay(in: controller.view.bounds, to: bitmap)
+
+    var minX: Int?
+    for y in 0..<bitmap.pixelsHigh {
+        for x in 0..<bitmap.pixelsWide {
+            guard let color = bitmap.colorAt(x: x, y: y)?.usingColorSpace(.sRGB) else { continue }
+            if color.redComponent > 0.8,
+               color.greenComponent < 0.2,
+               color.blueComponent < 0.2,
+               color.alphaComponent > 0.5 {
+                minX = min(minX ?? x, x)
+            }
+        }
+    }
+
+    return try #require(minX)
+}
+```
+
+Update `repoHeaderAnchorDoesNotShiftWhenExpanded` to call `repoIconMinX`.
+
+Extend `AlasTests/ProjectPickerTests.swift` with a pure helper test after Task 3 adds it:
+
+```swift
+@Test func projectIconAccessibilityLabelNamesModeAndProject() {
+    let project = ProjectConfig(
+        id: "p1",
+        name: "Alpha",
+        path: "/tmp/alpha",
+        color: "#5fb7c4",
+        addedAt: Date(timeIntervalSince1970: 0),
+        icon: ProjectIcon(mode: .emoji, color: "#5fb7c4", emoji: "🚀")
+    )
+
+    #expect(ProjectIconView.accessibilityLabel(project: project) == "Alpha project icon")
+}
+```
+
+- [ ] **Step 2: Run tests and verify failure**
+
+Run:
+
+```bash
+rtk xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -only-testing:AlasTests/RepoGroupViewLayoutTests -only-testing:AlasTests/ProjectPickerTests -quiet test
+```
+
+Expected: FAIL because `ProjectIconView` does not exist.
+
+- [ ] **Step 3: Implement renderer**
+
+Create `Alas/Sources/Sidebar/ProjectIconView.swift`:
+
+```swift
+import SwiftUI
+import AppKit
+
+struct ProjectIconView: View {
+    enum Size {
+        case sidebar
+        case picker
+        case dialog
+
+        var dimension: CGFloat {
+            switch self {
+            case .sidebar: 16
+            case .picker: 18
+            case .dialog: 72
+            }
+        }
+
+        var cornerRadius: CGFloat {
+            switch self {
+            case .sidebar: 4
+            case .picker: 5
+            case .dialog: 18
+            }
+        }
+
+        var fontSize: CGFloat {
+            switch self {
+            case .sidebar: 9.5
+            case .picker: 10.5
+            case .dialog: 26
+            }
+        }
+    }
+
+    let icon: ProjectIcon
+    let fallbackName: String
+    var size: Size = .sidebar
+
+    var body: some View {
+        content
+            .frame(width: size.dimension, height: size.dimension)
+            .clipShape(RoundedRectangle(cornerRadius: size.cornerRadius))
+            .accessibilityHidden(true)
+    }
+
+    @ViewBuilder
+    private var content: some View {
+        switch icon.mode {
+        case .letter:
+            labelView(ProjectIcon.sanitizedLabel(icon.label) ?? ProjectIcon.fallbackLabel(projectName: fallbackName))
+        case .symbol:
+            if let symbolName = icon.symbolName {
+                symbolView(symbolName)
+            } else {
+                labelView(ProjectIcon.fallbackLabel(projectName: fallbackName))
+            }
+        case .emoji:
+            if let emoji = icon.emoji, !emoji.isEmpty {
+                emojiView(emoji)
+            } else {
+                labelView(ProjectIcon.fallbackLabel(projectName: fallbackName))
+            }
+        case .image:
+            if let image = loadImage() {
+                Image(nsImage: image)
+                    .resizable()
+                    .scaledToFill()
+                    .frame(width: size.dimension, height: size.dimension)
+            } else {
+                labelView(ProjectIcon.fallbackLabel(projectName: fallbackName))
+            }
+        }
+    }
+
+    private func labelView(_ label: String) -> some View {
+        Text(label)
+            .font(.system(size: size.fontSize, weight: .bold))
+            .foregroundColor(.white)
+            .minimumScaleFactor(0.65)
+            .lineLimit(1)
+            .frame(width: size.dimension, height: size.dimension)
+            .background(Color(hex: icon.color))
+    }
+
+    @ViewBuilder
+    private func symbolView(_ name: String) -> some View {
+        ZStack {
+            Color(hex: icon.color)
+            Icon(name: name, size: size.fontSize + 2, color: .white)
+        }
+    }
+
+    private func emojiView(_ emoji: String) -> some View {
+        Text(emoji)
+            .font(.system(size: size.fontSize + 2))
+            .minimumScaleFactor(0.55)
+            .lineLimit(1)
+            .frame(width: size.dimension, height: size.dimension)
+            .background(Color(hex: icon.color))
+    }
+
+    private func loadImage() -> NSImage? {
+        guard let imageAssetName = icon.imageAssetName else { return nil }
+        return NSImage(contentsOfFile: imageAssetName)
+    }
+
+    static func accessibilityLabel(project: ProjectConfig) -> String {
+        "\(project.name) project icon"
+    }
+}
+```
+
+- [ ] **Step 4: Replace known project identity surfaces**
+
+In `Alas/Sources/Sidebar/RepoGroupView.swift`, replace:
+
+```swift
+RepoDot(color: project.color, letter: letter)
+```
+
+with:
+
+```swift
+ProjectIconView(icon: project.icon, fallbackName: project.name, size: .sidebar)
+    .accessibilityLabel(ProjectIconView.accessibilityLabel(project: project))
+```
+
+Remove the now-unused `letter` computed property if no call site remains.
+
+In `Alas/Sources/Dialogs/RepoSelector/RepoSelectorRowView.swift`, replace:
+
+```swift
+RepoDot(color: project.color, letter: String(project.name.prefix(1)).uppercased())
+```
+
+with:
+
+```swift
+ProjectIconView(icon: project.icon, fallbackName: project.name, size: .sidebar)
+```
+
+In `Alas/Sources/Dialogs/ProjectPicker.swift`, replace both small color `Circle()` snippets with:
+
+```swift
+ProjectIconView(icon: project.icon, fallbackName: project.name, size: .picker)
+```
+
+- [ ] **Step 5: Run focused renderer tests**
+
+Run:
+
+```bash
+rtk xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -only-testing:AlasTests/RepoGroupViewLayoutTests -only-testing:AlasTests/ProjectPickerTests -quiet test
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+Run:
+
+```bash
+rtk git add Alas/Sources/Sidebar/ProjectIconView.swift Alas/Sources/Sidebar/RepoGroupView.swift Alas/Sources/Dialogs/RepoSelector/RepoSelectorRowView.swift Alas/Sources/Dialogs/ProjectPicker.swift AlasTests/RepoGroupViewLayoutTests.swift AlasTests/ProjectPickerTests.swift
+rtk git commit -m "feat: render shared project icons"
+```
+
+---
+
+### Task 4: Managed Image Staging
+
+**Files:**
+- Modify: `Alas/Sources/Persistence/Paths.swift`
+- Create: `Alas/Sources/Dialogs/ProjectIconImageStaging.swift`
+- Modify: `Alas/Sources/Sidebar/ProjectIconView.swift`
+- Test: `AlasTests/ProjectIconImageStagingTests.swift`
+
+- [ ] **Step 1: Write staging tests**
+
+Create `AlasTests/ProjectIconImageStagingTests.swift`:
+
+```swift
+import Foundation
+import Testing
+@testable import Alas
+
+struct ProjectIconImageStagingTests {
+    @Test func pngDataStagesUnderProjectDirectory() throws {
+        let data = Self.onePixelPNG
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("project-icons-\(UUID().uuidString)", isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let staged = try ProjectIconImageStaging.stage(
+            data: data,
+            projectId: "project-1",
+            root: root
+        )
+
+        #expect(staged.assetName.hasSuffix(".png"))
+        #expect(staged.url.path.contains("/project-1/"))
+        #expect(FileManager.default.fileExists(atPath: staged.url.path))
+        #expect(try Data(contentsOf: staged.url) == data)
+    }
+
+    @Test func unsupportedDataThrows() throws {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("project-icons-\(UUID().uuidString)", isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        #expect(throws: ProjectIconImageStaging.StagingError.unsupportedFormat) {
+            try ProjectIconImageStaging.stage(
+                data: Data("not an image".utf8),
+                projectId: "project-1",
+                root: root
+            )
+        }
+    }
+
+    private static let onePixelPNG = Data(base64Encoded:
+        "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO+/p9sAAAAASUVORK5CYII="
+    )!
+}
+```
+
+- [ ] **Step 2: Run test and verify failure**
+
+Run:
+
+```bash
+rtk xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -only-testing:AlasTests/ProjectIconImageStagingTests -quiet test
+```
+
+Expected: FAIL because `ProjectIconImageStaging` does not exist.
+
+- [ ] **Step 3: Add project icon paths**
+
+Modify `Alas/Sources/Persistence/Paths.swift`:
+
+```swift
+extension Paths {
+    static var projectIconsRoot: URL {
+        appSupportRoot.appendingPathComponent("project-icons", isDirectory: true)
+    }
+
+    static func projectIconsDir(forProjectId id: String) -> URL {
+        projectIconsRoot.appendingPathComponent(id, isDirectory: true)
+    }
+}
+```
+
+- [ ] **Step 4: Implement staging helper**
+
+Create `Alas/Sources/Dialogs/ProjectIconImageStaging.swift`:
+
+```swift
+import Foundation
+import CryptoKit
+
+enum ProjectIconImageStaging {
+    struct Staged: Equatable {
+        let assetName: String
+        let url: URL
+    }
+
+    enum StagingError: Error, Equatable {
+        case unsupportedFormat
+        case tooLarge
+        case writeFailed
+    }
+
+    static let maxBytes = 10 * 1024 * 1024
+
+    static func stage(data: Data, projectId: String, root: URL = Paths.projectIconsRoot) throws -> Staged {
+        guard data.count <= maxBytes else { throw StagingError.tooLarge }
+        guard let ext = fileExtension(for: data) else { throw StagingError.unsupportedFormat }
+
+        let hash = SHA256.hash(data: data).map { String(format: "%02x", $0) }.joined()
+        let dir = root.appendingPathComponent(projectId, isDirectory: true)
+        let filename = "\(hash).\(ext)"
+        let url = dir.appendingPathComponent(filename)
+
+        do {
+            try Paths.ensureDirectoryExists(dir)
+            if !FileManager.default.fileExists(atPath: url.path) {
+                try data.write(to: url, options: .atomic)
+            }
+            return Staged(assetName: "\(projectId)/\(filename)", url: url)
+        } catch {
+            throw StagingError.writeFailed
+        }
+    }
+
+    static func url(for assetName: String, root: URL = Paths.projectIconsRoot) -> URL {
+        root.appendingPathComponent(assetName)
+    }
+
+    static func fileExtension(for data: Data) -> String? {
+        let b = [UInt8](data.prefix(16))
+        if b.count >= 8, b[0] == 0x89, b[1] == 0x50, b[2] == 0x4E, b[3] == 0x47 { return "png" }
+        if b.count >= 3, b[0] == 0xFF, b[1] == 0xD8, b[2] == 0xFF { return "jpg" }
+        if b.count >= 6, b[0] == 0x47, b[1] == 0x49, b[2] == 0x46 { return "gif" }
+        if b.count >= 12, b[0] == 0x52, b[1] == 0x49, b[2] == 0x46, b[3] == 0x46,
+           b[8] == 0x57, b[9] == 0x45, b[10] == 0x42, b[11] == 0x50 { return "webp" }
+        return nil
+    }
+}
+
+extension ProjectIconImageStaging.StagingError {
+    var userMessage: String {
+        switch self {
+        case .unsupportedFormat: "That image format isn't supported (use PNG, JPEG, GIF, or WebP)."
+        case .tooLarge: "That image is too large (max 10 MB)."
+        case .writeFailed: "Couldn't save that project icon. Please try again."
+        }
+    }
+}
+```
+
+- [ ] **Step 5: Resolve image assets in renderer**
+
+Modify `ProjectIconView.loadImage()`:
+
+```swift
+private func loadImage() -> NSImage? {
+    guard let imageAssetName = icon.imageAssetName else { return nil }
+    let url = ProjectIconImageStaging.url(for: imageAssetName)
+    return NSImage(contentsOf: url)
+}
+```
+
+- [ ] **Step 6: Run staging tests**
+
+Run:
+
+```bash
+rtk xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -only-testing:AlasTests/ProjectIconImageStagingTests -quiet test
+```
+
+Expected: PASS.
+
+- [ ] **Step 7: Commit**
+
+Run:
+
+```bash
+rtk git add Alas/Sources/Persistence/Paths.swift Alas/Sources/Dialogs/ProjectIconImageStaging.swift Alas/Sources/Sidebar/ProjectIconView.swift AlasTests/ProjectIconImageStagingTests.swift
+rtk git commit -m "feat: stage project icon images"
+```
+
+---
+
+### Task 5: Avatar Preset Provider
+
+**Files:**
+- Create: `Alas/Sources/Dialogs/ProjectAvatarPresetProvider.swift`
+- Test: `AlasTests/ProjectAvatarPresetProviderTests.swift`
+
+- [ ] **Step 1: Write preset mapping tests**
+
+Create `AlasTests/ProjectAvatarPresetProviderTests.swift`:
+
+```swift
+import Foundation
+import Testing
+@testable import Alas
+
+struct ProjectAvatarPresetProviderTests {
+    @Test func githubRemoteMapsToOwnerAvatarURL() throws {
+        let remote = CodeHostRemote(
+            kind: .github,
+            host: "github.com",
+            owner: "mrmans0n",
+            repository: "alas",
+            remoteName: "origin",
+            webURL: URL(string: "https://github.com/mrmans0n/alas")!
+        )
+
+        let candidate = try #require(ProjectAvatarPresetProvider.candidate(for: remote))
+        #expect(candidate.label == "GitHub avatar: mrmans0n")
+        #expect(candidate.url == URL(string: "https://github.com/mrmans0n.png?size=256")!)
+    }
+
+    @Test func gitlabRemoteMapsToNamespaceAvatarURL() throws {
+        let remote = CodeHostRemote(
+            kind: .gitlab,
+            host: "gitlab.com",
+            owner: "group/subgroup",
+            repository: "repo",
+            remoteName: "origin",
+            webURL: URL(string: "https://gitlab.com/group/subgroup/repo")!
+        )
+
+        let candidate = try #require(ProjectAvatarPresetProvider.candidate(for: remote))
+        #expect(candidate.label == "GitLab avatar: group/subgroup")
+        #expect(candidate.url.absoluteString.contains("https://gitlab.com/api/v4/groups/"))
+        #expect(candidate.url.absoluteString.contains("group%2Fsubgroup"))
+    }
+}
+```
+
+- [ ] **Step 2: Run tests and verify failure**
+
+Run:
+
+```bash
+rtk xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -only-testing:AlasTests/ProjectAvatarPresetProviderTests -quiet test
+```
+
+Expected: FAIL because `ProjectAvatarPresetProvider` does not exist.
+
+- [ ] **Step 3: Implement provider**
+
+Create `Alas/Sources/Dialogs/ProjectAvatarPresetProvider.swift`:
+
+```swift
+import Foundation
+
+struct ProjectAvatarPreset: Equatable {
+    let label: String
+    let url: URL
+}
+
+protocol ProjectAvatarFetching {
+    func data(from url: URL) async throws -> Data
+}
+
+struct URLSessionProjectAvatarFetcher: ProjectAvatarFetching {
+    func data(from url: URL) async throws -> Data {
+        let (data, response) = try await URLSession.shared.data(from: url)
+        if let http = response as? HTTPURLResponse,
+           !(200..<300).contains(http.statusCode) {
+            throw URLError(.badServerResponse)
+        }
+        return data
+    }
+}
+
+enum ProjectAvatarPresetProvider {
+    static func candidate(for remote: CodeHostRemote) -> ProjectAvatarPreset? {
+        switch remote.kind {
+        case .github:
+            guard let url = URL(string: "https://\(remote.host)/\(remote.owner).png?size=256") else {
+                return nil
+            }
+            return ProjectAvatarPreset(label: "GitHub avatar: \(remote.owner)", url: url)
+        case .gitlab:
+            let escaped = remote.owner.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed)?
+                .replacingOccurrences(of: "/", with: "%2F")
+            guard let escaped,
+                  let url = URL(string: "https://\(remote.host)/api/v4/groups/\(escaped)/avatar")
+            else {
+                return nil
+            }
+            return ProjectAvatarPreset(label: "GitLab avatar: \(remote.owner)", url: url)
+        }
+    }
+
+    static func candidate(from remotes: [GitRemote]) -> ProjectAvatarPreset? {
+        guard let remote = CodeHostRemoteDetector.detect(from: remotes) else { return nil }
+        return candidate(for: remote)
+    }
+
+    static func fetch(_ preset: ProjectAvatarPreset, fetcher: ProjectAvatarFetching = URLSessionProjectAvatarFetcher()) async throws -> Data {
+        try await fetcher.data(from: preset.url)
+    }
+}
+```
+
+- [ ] **Step 4: Run tests**
+
+Run:
+
+```bash
+rtk xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -only-testing:AlasTests/ProjectAvatarPresetProviderTests -quiet test
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+Run:
+
+```bash
+rtk git add Alas/Sources/Dialogs/ProjectAvatarPresetProvider.swift AlasTests/ProjectAvatarPresetProviderTests.swift
+rtk git commit -m "feat: derive project avatar presets"
+```
+
+---
+
+### Task 6: Add/Edit Project Icon Editor UI
+
+**Files:**
+- Modify: `Alas/Sources/Dialogs/NewProjectDialog.swift`
+- Test: existing dialog/model tests plus quiet build
+
+- [ ] **Step 1: Add draft state**
+
+In `ProjectDialog`, replace:
+
+```swift
+@State private var color: String = "#5fb7c4"
+```
+
+with:
+
+```swift
+@State private var iconMode: ProjectIcon.Mode = .letter
+@State private var iconColor: String = ProjectIcon.defaultColor
+@State private var iconLabel: String = ""
+@State private var iconSymbolName: String = "folder"
+@State private var iconEmoji: String = "🚀"
+@State private var iconImageAssetName: String?
+@State private var pendingIconStorageId = "pending-\(UUID().uuidString)"
+@State private var avatarPreset: ProjectAvatarPreset?
+@State private var avatarPresetData: Data?
+@State private var avatarPresetLoading = false
+@State private var avatarPresetError = false
+```
+
+Add:
+
+```swift
+private var draftIcon: ProjectIcon {
+    ProjectIcon(
+        mode: iconMode,
+        color: iconColor,
+        label: iconLabel,
+        symbolName: iconSymbolName,
+        emoji: iconEmoji,
+        imageAssetName: iconImageAssetName
+    )
+}
+```
+
+- [ ] **Step 2: Replace Color field with Icon section**
+
+In the dialog `content`, replace the `DialogField(label: "Color")` block with:
+
+```swift
+DialogField(label: "Icon") {
+    projectIconSection
+}
+```
+
+Add a `projectIconSection` view:
+
+```swift
+private var projectIconSection: some View {
+    HStack(alignment: .top, spacing: 14) {
+        VStack(spacing: 8) {
+            ProjectIconView(icon: draftIcon, fallbackName: name, size: .dialog)
+            HStack(spacing: 8) {
+                ProjectIconView(icon: draftIcon, fallbackName: name, size: .sidebar)
+                ProjectIconView(icon: draftIcon, fallbackName: name, size: .picker)
+            }
+        }
+        VStack(alignment: .leading, spacing: 10) {
+            Seg(value: $iconMode, options: ProjectIcon.Mode.allCases.map { ($0, modeTitle($0)) })
+            iconModeControls
+            colorControls
+        }
+    }
+}
+```
+
+Add:
+
+```swift
+private func modeTitle(_ mode: ProjectIcon.Mode) -> String {
+    switch mode {
+    case .letter: "Letter"
+    case .symbol: "Symbol"
+    case .emoji: "Emoji"
+    case .image: "Image"
+    }
+}
+```
+
+- [ ] **Step 3: Add mode-specific controls**
+
+Add:
+
+```swift
+@ViewBuilder
+private var iconModeControls: some View {
+    switch iconMode {
+    case .letter:
+        AlasField(text: $iconLabel, placeholder: ProjectIcon.fallbackLabel(projectName: name))
+            .frame(width: 90)
+    case .symbol:
+        VStack(alignment: .leading, spacing: 6) {
+            AlasField(text: $iconSymbolName, placeholder: "folder")
+            symbolQuickChoices
+        }
+    case .emoji:
+        AlasField(text: $iconEmoji, placeholder: "🚀")
+            .frame(width: 90)
+    case .image:
+        imageControls
+    }
+}
+```
+
+Add curated symbol choices:
+
+```swift
+private var symbolQuickChoices: some View {
+    HStack(spacing: 6) {
+        ForEach(["folder", "terminal", "sparkle", "github", "gitlab", "commit"], id: \.self) { symbol in
+            Button {
+                iconSymbolName = symbol
+            } label: {
+                Icon(name: symbol, size: 13, color: theme.color("fg"))
+                    .frame(width: 24, height: 24)
+                    .background(iconSymbolName == symbol ? theme.color("bg-4") : theme.color("bg-2"))
+                    .clipShape(RoundedRectangle(cornerRadius: 5))
+            }
+            .buttonStyle(.plain)
+            .help(symbol)
+        }
+    }
+}
+```
+
+- [ ] **Step 4: Add color controls**
+
+Replace `availablePalette` color references with `iconColor`. Add:
+
+```swift
+private var colorControls: some View {
+    HStack(spacing: 8) {
+        ForEach(availablePalette, id: \.self) { hex in
+            Button { iconColor = hex } label: {
+                Circle()
+                    .fill(Color(hex: hex))
+                    .frame(width: 22, height: 22)
+                    .overlay(Circle().strokeBorder(.white, lineWidth: iconColor == hex ? 2 : 0))
+            }
+            .buttonStyle(.plain)
+        }
+        AlasField(text: $iconColor, placeholder: "#5fb7c4", monospaced: true)
+            .frame(width: 96)
+    }
+}
+```
+
+Update `availablePalette`:
+
+```swift
+private var availablePalette: [String] {
+    palette.contains(iconColor) ? palette : [iconColor] + palette
+}
+```
+
+- [ ] **Step 5: Add image import and avatar controls**
+
+Add:
+
+```swift
+private var imageControls: some View {
+    VStack(alignment: .leading, spacing: 8) {
+        AlasButton(title: "Choose Image…", icon: "image", action: chooseProjectIconImage)
+        if let avatarPreset {
+            HStack(spacing: 8) {
+                Text(avatarPreset.label)
+                    .font(.system(size: 11))
+                    .foregroundColor(theme.color("fg-muted"))
+                AlasButton(
+                    title: avatarPresetLoading ? "Loading…" : "Use",
+                    action: useAvatarPreset
+                )
+                .disabled(avatarPresetData == nil || avatarPresetLoading)
+            }
+        } else if avatarPresetError {
+            Text("Avatar preset unavailable")
+                .font(.system(size: 11))
+                .foregroundColor(theme.color("fg-faint"))
+        }
+    }
+}
+```
+
+Add image chooser:
+
+```swift
+private func chooseProjectIconImage() {
+    let panel = NSOpenPanel()
+    panel.canChooseDirectories = false
+    panel.canChooseFiles = true
+    panel.allowsMultipleSelection = false
+    panel.allowedContentTypes = [.png, .jpeg, .gif, .webP]
+    if panel.runModal() == .OK, let url = panel.url {
+        do {
+            let data = try Data(contentsOf: url)
+            let projectId = existingProjectIdForIconStorage()
+            let staged = try ProjectIconImageStaging.stage(data: data, projectId: projectId)
+            iconImageAssetName = staged.assetName
+            iconMode = .image
+            errorMessage = nil
+        } catch let stagingError as ProjectIconImageStaging.StagingError {
+            errorMessage = stagingError.userMessage
+        } catch {
+            errorMessage = "Couldn't load that image. Please try another file."
+        }
+    }
+}
+```
+
+Use a stable storage id:
+
+```swift
+private func existingProjectIdForIconStorage() -> String {
+    if case .edit(let project) = mode { return project.id }
+    return pendingIconStorageId
+}
+```
+
+- [ ] **Step 6: Populate and save icon values**
+
+In `populateInitialValues`, set:
+
+```swift
+iconMode = project.icon.mode
+iconColor = project.icon.color
+iconLabel = project.icon.label ?? ""
+iconSymbolName = project.icon.symbolName ?? "folder"
+iconEmoji = project.icon.emoji ?? "🚀"
+iconImageAssetName = project.icon.imageAssetName
+```
+
+In add confirm:
+
+```swift
+try await state.addProject(path: url, displayName: name, icon: draftIcon)
+```
+
+In edit confirm:
+
+```swift
+state.updateProject(
+    id: project.id,
+    name: name,
+    icon: draftIcon,
+    startupScripts: ProjectStartupScripts(
+        sessionOpenMode: sessionOpenMode,
+        sessionOpenScript: sessionOpenScript,
+        worktreeCreateMode: worktreeCreateMode,
+        worktreeCreateScript: worktreeCreateScript,
+        worktreeAgentMode: project.startupScripts.worktreeAgentMode,
+        worktreeAgentId: project.startupScripts.worktreeAgentId,
+        worktreeAgentUseBypassPermissions: project.startupScripts.worktreeAgentUseBypassPermissions
+    )
+)
+```
+
+- [ ] **Step 7: Fetch avatar preset without blocking dialog**
+
+In `.onAppear`, call:
+
+```swift
+populateInitialValues()
+Task { await loadAvatarPresetIfAvailable() }
+```
+
+Add:
+
+```swift
+private func loadAvatarPresetIfAvailable() async {
+    let repoURL: URL
+    switch mode {
+    case .add:
+        guard !path.isEmpty else { return }
+        repoURL = URL(fileURLWithPath: path)
+    case .edit(let project):
+        repoURL = URL(fileURLWithPath: project.path)
+    }
+
+    avatarPresetLoading = true
+    defer { avatarPresetLoading = false }
+
+    do {
+        let remotes = try await GitService().remotes(worktreePath: repoURL)
+        guard let preset = ProjectAvatarPresetProvider.candidate(from: remotes) else { return }
+        avatarPreset = preset
+        avatarPresetData = try await ProjectAvatarPresetProvider.fetch(preset)
+    } catch {
+        avatarPresetError = true
+    }
+}
+```
+
+Add:
+
+```swift
+private func useAvatarPreset() {
+    guard let data = avatarPresetData else { return }
+    do {
+        let staged = try ProjectIconImageStaging.stage(data: data, projectId: existingProjectIdForIconStorage())
+        iconImageAssetName = staged.assetName
+        iconMode = .image
+        errorMessage = nil
+    } catch let stagingError as ProjectIconImageStaging.StagingError {
+        errorMessage = stagingError.userMessage
+    } catch {
+        errorMessage = "Couldn't save that avatar. Please try another image."
+    }
+}
+```
+
+- [ ] **Step 8: Run build and focused tests**
+
+Run:
+
+```bash
+rtk xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -only-testing:AlasTests/ProjectIconTests -only-testing:AlasTests/ProjectConfigTests -only-testing:AlasTests/ProjectsManagerTests -quiet test
+rtk xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -quiet build
+```
+
+Expected: PASS.
+
+- [ ] **Step 9: Commit**
+
+Run:
+
+```bash
+rtk git add Alas/Sources/Dialogs/NewProjectDialog.swift
+rtk git commit -m "feat: add project icon editor"
+```
+
+---
+
+### Task 7: Compatibility Sweep and Final Verification
+
+**Files:**
+- Modify only files required by compile errors from API signature changes.
+- Regenerate: `Alas.xcodeproj/project.pbxproj` if XcodeGen changes file references.
+
+- [ ] **Step 1: Regenerate project**
+
+Run:
+
+```bash
+rtk xcodegen
+```
+
+Expected: completes successfully. Sources are folder-based; keep `project.yml` unchanged unless XcodeGen reports a configuration error.
+
+- [ ] **Step 2: Run focused icon suite**
+
+Run:
+
+```bash
+rtk xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -only-testing:AlasTests/ProjectIconTests -only-testing:AlasTests/ProjectIconImageStagingTests -only-testing:AlasTests/ProjectAvatarPresetProviderTests -only-testing:AlasTests/ProjectConfigTests -only-testing:AlasTests/ProjectsManagerTests -only-testing:AlasTests/RepoGroupViewLayoutTests -only-testing:AlasTests/ProjectPickerTests -quiet test
+```
+
+Expected: PASS.
+
+- [ ] **Step 3: Run quiet build**
+
+Run:
+
+```bash
+rtk xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -quiet build
+```
+
+Expected: PASS.
+
+- [ ] **Step 4: Run full tests**
+
+Run:
+
+```bash
+rtk xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' test
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Manual verification checklist**
+
+Launch Alas locally and verify:
+
+- Add project defaults to Letter mode with current first-letter behavior.
+- Edit project Letter label to two characters and confirm sidebar/Cmd-K update.
+- Pick a Symbol alias such as `github` and confirm sidebar/Cmd-K update.
+- Pick an Emoji value and confirm sidebar/Cmd-K update.
+- Import a PNG image, relaunch, and confirm it persists.
+- Edit a GitHub/GitLab-backed project and confirm avatar preset appears without blocking the dialog.
+- Disable network and confirm the dialog still opens and saves.
+
+- [ ] **Step 6: Commit final compatibility fixes**
+
+Run this when Task 7 changed files or regenerated project files:
+
+```bash
+rtk git add Alas.xcodeproj/project.pbxproj Alas/Sources AlasTests
+rtk git commit -m "fix: finalize project icon integration"
+```
+
+When `rtk git status --short` prints no files, record "no final compatibility commit needed" in the task notes.
+
+## Plan Self-Review
+
+- Spec coverage: Tasks cover structured icon model, tolerant decode, image storage, avatar preset discovery/fetch, shared renderer, Add/Edit Project UI, target surfaces, error handling, and verification.
+- Placeholder scan: no TBD/TODO/later placeholders remain. Conditional verification steps have explicit commands and expected outcomes.
+- Type consistency: `ProjectIcon`, `ProjectIconView`, `ProjectIconImageStaging`, and `ProjectAvatarPresetProvider` names are consistent across tasks. The only intentional transition is `ProjectConfig.color` staying mirrored from `ProjectIcon.color`.

--- a/docs/superpowers/specs/2026-07-04-project-icons-design.md
+++ b/docs/superpowers/specs/2026-07-04-project-icons-design.md
@@ -1,0 +1,190 @@
+# Project Icons Design
+
+## Summary
+
+Give users direct control over the rounded-square project icons used for repositories across Alas. The icon is a project identity setting, not a worktree setting. Users can choose between letter, symbol, emoji, or image modes from the existing Add/Edit Project dialog, with richer color control and GitHub/GitLab avatar presets when a repository remote supports them.
+
+Existing projects continue to render as they do today: a colored sqcircle with the first letter of the project name.
+
+## Goals
+
+- Support four equal icon modes: Letter, Symbol, Emoji, and Image.
+- Keep icon customization inside the existing Add/Edit Project dialog for v1.
+- Preserve the current color-palette workflow while adding arbitrary custom colors.
+- Let Letter mode use an editable 1-2 character label.
+- Let Symbol mode use SF Symbols plus existing Alas aliases/custom glyphs.
+- Let Image mode import local images and use detected GitHub/GitLab owner avatars as presets.
+- Copy all selected images into Alas-managed Application Support storage.
+- Render project icons consistently wherever project identity appears.
+- Preserve tolerant decoding for old `projects.json` files.
+
+## Non-Goals
+
+- Do not add a quick customization popover from the sidebar or Cmd-K in v1.
+- Do not add per-worktree icons.
+- Do not reference external image files after selection.
+- Do not add an image crop editor. Image mode uses full-bleed center crop.
+- Do not refresh remote avatars outside the Add/Edit Project dialog in v1.
+
+## User Experience
+
+The Add/Edit Project dialog gains an Icon section near the project name and path fields. The section contains:
+
+- a live preview at large, sidebar, and Cmd-K sizes
+- an equal segmented mode picker: Letter, Symbol, Emoji, Image
+- mode-specific controls
+- curated color swatches plus a custom color picker or hex field
+
+Letter mode defaults to the project-name initial. Users can override it with a 1-2 character label. Empty labels fall back to the project-name initial.
+
+Symbol mode offers SF Symbols plus the aliases already supported by Alas, such as `github`, `gitlab`, and `commit`. V1 uses a curated searchable list of common project symbols and aliases, plus a text field for entering an SF Symbol name directly. Invalid or unavailable symbols fall back to Letter mode at render time.
+
+Emoji mode accepts a single emoji-style glyph. If input is empty or unusable, rendering falls back to Letter mode.
+
+Image mode supports choosing a local image file. Images render full-bleed inside the sqcircle with center crop. If a supported GitHub or GitLab remote is detected for the project, the dialog automatically attempts to fetch the remote owner avatar and shows it as a preset. Fetching is non-blocking; the dialog must open immediately even if the network is slow or unavailable.
+
+Selecting a local image or avatar preset copies the image into Alas-managed storage. The project stores a reference to that managed asset, not to the original source URL or source file.
+
+## Data Model
+
+Add a structured icon value to `ProjectConfig`:
+
+```swift
+struct ProjectIcon: Codable, Equatable {
+    enum Mode: String, Codable, Equatable {
+        case letter
+        case symbol
+        case emoji
+        case image
+    }
+
+    var mode: Mode
+    var color: String
+    var label: String?
+    var symbolName: String?
+    var emoji: String?
+    var imageAssetName: String?
+}
+```
+
+`ProjectConfig` gains `var icon: ProjectIcon`. Keep the existing `color` field during the migration period for backward compatibility and for old code paths while call sites move to the new renderer.
+
+When decoding an older project without `icon`, synthesize:
+
+- `mode = .letter`
+- `color = project.color`
+- `label = nil`
+
+When encoding new project data, include both `icon` and the legacy `color`. The legacy `color` should mirror `icon.color` so older code and simple tests keep behaving predictably during the transition.
+
+`ProjectUpdate`, `ProjectsManager.addProject`, `ProjectsManager.updateProject`, and `AppState.addProject/updateProject` should accept and persist the structured icon rather than only a color.
+
+## Image Storage
+
+Add a managed icon asset location under Application Support:
+
+```text
+Application Support/Alas/project-icons/<project-id>/
+```
+
+Image staging should:
+
+- accept PNG, JPEG, GIF, and WebP image inputs
+- reject oversized or unsupported inputs with a user-visible dialog error
+- copy data into the project icon directory
+- use content-addressed filenames derived from the copied image bytes
+- store only the managed filename or relative managed path in `ProjectIcon.imageAssetName`
+
+Removing or replacing an image icon does not need aggressive garbage collection in v1. A best-effort cleanup of superseded files is acceptable if it stays simple.
+
+## Avatar Presets
+
+Use the existing `CodeHostRemoteDetector` to inspect project remotes. If it detects GitHub or GitLab, the Add/Edit Project dialog derives one owner-avatar preset candidate:
+
+- GitHub owner avatar for `https://github.com/<owner>/<repo>`
+- GitLab owner or namespace avatar for the detected GitLab host when available from the unauthenticated public API
+
+The fetch is automatic, asynchronous, and non-blocking. Failure should not block editing or saving the project. The UI should either hide the preset or show it as unavailable with quiet copy.
+
+When the user chooses the avatar preset, Alas copies the downloaded image into the same managed storage used for manual image imports. After selection, the project icon no longer depends on the network or on the remote account.
+
+Private or self-hosted remotes may fail to expose avatars without authentication. That is acceptable in v1; the preset simply remains unavailable.
+
+## Rendering
+
+Introduce one reusable project icon renderer, for example:
+
+```swift
+ProjectIconView(icon: project.icon, fallbackName: project.name, size: .sidebar)
+```
+
+The renderer owns all fallback behavior and sizing rules. V1 replaces direct `RepoDot` and project color-dot usage in these known project identity surfaces:
+
+- `RepoGroupView`
+- `RepoSelectorRowView`
+- `ProjectPicker`
+- Add/Edit Project preview
+
+Rendering rules:
+
+- Letter: colored rounded square with the 1-2 character label
+- Symbol: colored rounded square with centered SF Symbol or Alas glyph
+- Emoji: colored rounded square with centered emoji glyph
+- Image: full-bleed rounded image, center-cropped
+- Fallback: render Letter mode using fallback project name and icon color
+
+The renderer should keep stable dimensions so hover states, row layout, and project header alignment do not shift. Sidebar sizing remains close to the current 16x16 `RepoDot`; larger picker/dialog sizes can be surface-specific.
+
+## Architecture
+
+Keep the feature local to project identity:
+
+- `ProjectIcon` owns persisted icon configuration.
+- `ProjectIconView` owns visual rendering and fallback.
+- A small image-staging helper owns copying and validating images.
+- A small avatar-preset helper owns remote detection and async fetch for the dialog.
+- `ProjectDialog` owns the editing controls and maps draft state to `ProjectIcon`.
+
+Avoid making `ProjectsManager` responsible for network fetches or image decoding. It should persist project records only. The dialog or a focused helper can fetch avatar presets because that work is UI-adjacent and only happens while editing a project.
+
+## Error Handling
+
+- Invalid hex colors fall back to `#5fb7c4`.
+- Empty letter labels fall back to the project-name initial.
+- Overlong letter labels are clamped to two display characters.
+- Invalid or unavailable symbols fall back to Letter mode.
+- Missing or unreadable image assets fall back to Letter mode and do not mutate stored config.
+- Avatar fetch failures are non-blocking and quiet.
+- Saving project edits should not wait for an in-flight avatar fetch unless the user selected that avatar and the image copy is required.
+
+## Testing
+
+Add focused Swift Testing coverage for:
+
+- decoding old `ProjectConfig` records without `icon`
+- round-tripping each `ProjectIcon` mode
+- keeping legacy `color` in sync with `icon.color`
+- clamping and fallback behavior for labels, symbols, colors, and missing images
+- image staging path behavior under `project-icons/<project-id>`
+- remote detection to avatar-preset candidate mapping
+- sidebar and Cmd-K renderer/layout behavior at small sizes
+
+Manual verification should cover:
+
+- adding a project with the default Letter icon
+- editing Letter label and custom color
+- selecting a Symbol icon and seeing it in sidebar and Cmd-K
+- selecting an Emoji icon and seeing it in sidebar and Cmd-K
+- importing a local image and relaunching to confirm it persists
+- selecting an automatically fetched GitHub/GitLab avatar preset
+- opening Add/Edit Project while offline or when avatar fetch fails
+- deleting or moving the original image file after import and confirming the icon still renders
+
+## Deferred
+
+- Sidebar or Cmd-K quick customization entry points.
+- Per-worktree icon overrides.
+- Linked external images.
+- Crop/zoom controls for image icons.
+- Scheduled avatar refresh or "refresh avatar" actions.
+- Rich symbol browser beyond the basic SF Symbol plus Alas alias selection needed for v1.


### PR DESCRIPTION
## Summary

Adds customizable project/repo sqcircle icons across the app:

- Adds a persisted `ProjectIcon` model with letter, symbol, emoji, and image modes while preserving legacy `color` compatibility.
- Threads project icons through project add/update state and renders them via a shared `ProjectIconView` in the sidebar, repo selector, and project picker.
- Adds managed project icon image staging under Application Support.
- Suggests GitHub/GitLab owner avatar presets when a project remote can be detected.
- Adds icon controls to the Add/Edit Project dialog with preview sizes, curated symbols, custom color, image picker, and avatar usage.

## Verification

- `rtk xcodegen`
- `ALAS_FFF_TARGET_ARCH=arm64 rtk xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS,arch=arm64' -only-testing:AlasTests/ProjectIconTests -only-testing:AlasTests/ProjectIconImageStagingTests -only-testing:AlasTests/ProjectAvatarPresetProviderTests -only-testing:AlasTests/ProjectConfigTests -only-testing:AlasTests/ProjectsManagerTests -only-testing:AlasTests/RepoGroupViewLayoutTests -only-testing:AlasTests/ProjectPickerTests -quiet test`
- `ALAS_FFF_TARGET_ARCH=arm64 rtk xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS,arch=arm64' -quiet build`

Full local test suite note: one full run failed in existing `ACPSessionTests` image-asset cases; both failed tests passed when rerun in isolation. A second full-suite rerun appeared stuck and was interrupted.