### PR TITLE
feat(changes): default main worktree comparison to origin/baseBranch

### DIFF
--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -294,6 +294,7 @@
 		4135B5BC24856ED442E39069 /* GitServiceStashTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1B218326D14AA360C7476D43 /* GitServiceStashTests.swift */; };
 		4151B68B1CF0A947AEC4C00A /* ACPAuthNudgeBannerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F68B06E93430D1C7B02F6BB2 /* ACPAuthNudgeBannerTests.swift */; };
 		4153DAD75F27395D2D385BED /* LanguageServerAvailabilityTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A8CC42BD54479E057902D392 /* LanguageServerAvailabilityTests.swift */; };
+		4186372EBF16A9C7CB38F558 /* RightPaneStoreBaseBranchTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8451C5BCEE50F118F07CDD83 /* RightPaneStoreBaseBranchTests.swift */; };
 		418D526733AA6B50A66CCCAF /* TabsManagerReviewRequestDraftTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 83A8622BA130E8FA339EDCEB /* TabsManagerReviewRequestDraftTests.swift */; };
 		419029F5618BC364426491E5 /* ProjectIcon.swift in Sources */ = {isa = PBXBuildFile; fileRef = CDEB760B98A1482CF30140A4 /* ProjectIcon.swift */; };
 		41C3F07661CA9B2B4E2C7BB1 /* GhosttyConfigBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = BCA505FF2E6CFA8278C95C6E /* GhosttyConfigBuilder.swift */; };
@@ -1720,6 +1721,7 @@
 		82F696636690652C48CE87D9 /* AlasGhostty.Config.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlasGhostty.Config.swift; sourceTree = "<group>"; };
 		835D847AD52A2CEB36DD5022 /* LegacyHookSweepTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LegacyHookSweepTests.swift; sourceTree = "<group>"; };
 		83A8622BA130E8FA339EDCEB /* TabsManagerReviewRequestDraftTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabsManagerReviewRequestDraftTests.swift; sourceTree = "<group>"; };
+		8451C5BCEE50F118F07CDD83 /* RightPaneStoreBaseBranchTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RightPaneStoreBaseBranchTests.swift; sourceTree = "<group>"; };
 		84A01D6512394EF1C41782AD /* ACPMarkdownInlineTextView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPMarkdownInlineTextView.swift; sourceTree = "<group>"; };
 		84E56989C04A4A478D68084C /* ACPMarkdownBlockCacheTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPMarkdownBlockCacheTests.swift; sourceTree = "<group>"; };
 		8526C9DB63760BDD2CE998BD /* fs-write.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "fs-write.json"; sourceTree = "<group>"; };
@@ -2644,6 +2646,7 @@
 				B84EFAC9F0FCF459416920B6 /* RightPaneStateReviewLoopPushTests.swift */,
 				1D3505FB870FA22C9C0FDB26 /* RightPaneStateSyncStatusTests.swift */,
 				0AAF2B901624C0629A1E3357 /* RightPaneStateUnstagePathsTests.swift */,
+				8451C5BCEE50F118F07CDD83 /* RightPaneStoreBaseBranchTests.swift */,
 				B3EC1A61207050A2585288FB /* RightPaneVisibilityTests.swift */,
 				6C4309EDC99FC1F98C479115 /* SearchModelTests.swift */,
 				4BF2EE8A6AAA7F9B45DACC0C /* SemanticVersionTests.swift */,
@@ -5507,6 +5510,7 @@
 				9D1939E70B46881CCDDC389C /* RightPaneStateReviewLoopPushTests.swift in Sources */,
 				DCACB5B624BFFE7C50DA6C61 /* RightPaneStateSyncStatusTests.swift in Sources */,
 				57D04CD70E3A716B81F58FF8 /* RightPaneStateUnstagePathsTests.swift in Sources */,
+				4186372EBF16A9C7CB38F558 /* RightPaneStoreBaseBranchTests.swift in Sources */,
 				4EC689B454508C1ED77C5FB4 /* RightPaneVisibilityTests.swift in Sources */,
 				B05D6011E0FDB7AA1B016844 /* SQLiteDatabaseTests.swift in Sources */,
 				3D5FC516052D2F06781A3F6E /* SearchModelTests.swift in Sources */,

--- a/Alas/Sources/Integrations/CodeHost/ReviewLoopState.swift
+++ b/Alas/Sources/Integrations/CodeHost/ReviewLoopState.swift
@@ -34,6 +34,9 @@ final class ReviewLoopState {
         isExpanded = expanded
     }
 
+    /// The base branch currently used for review lookup/creation.
+    var currentBaseBranch: String { baseBranch }
+
     func updateBaseBranch(_ branch: String) {
         baseBranch = branch
         if let current = snapshot?.local {

--- a/Alas/Sources/Right/RightPaneState.swift
+++ b/Alas/Sources/Right/RightPaneState.swift
@@ -116,10 +116,29 @@ final class RightPaneState {
     /// the global config default on the next render.
     var userOverrodeBaseBranch: Bool = false
 
-    /// The last base branch value that came from `AppConfig` (not from the
-    /// selector). Used by `RightPaneStore` to distinguish a Settings change
-    /// (new config value) from a normal render (same config value).
+    /// The last raw base branch value that came from `AppConfig` (not from the
+    /// selector, and not the effective `origin/<base>` default). Used by
+    /// `RightPaneStore` to distinguish a Settings change (new config value)
+    /// from a normal render (same config value).
     var lastConfigBaseBranch: String = ""
+
+    /// The last effective base branch default applied by `RightPaneStore`
+    /// (e.g. `origin/main` when on the base branch). Used to detect when the
+    /// effective default changed because the worktree branch changed, without
+    /// overwriting a verified fallback on every render.
+    var lastEffectiveBaseBranch: String = ""
+
+    /// Task handle for the async origin-ref probe, if one is in flight.
+    /// Cancelled when the base branch changes again before verification
+    /// finishes, so stale probe results never overwrite a newer default.
+    @ObservationIgnored
+    var baseBranchProbeTask: Task<Void, Never>? = nil
+
+    /// True for newly-created states whose initial `start()` is being deferred
+    /// until the `origin/<base>` probe confirms or falls back. Prevents
+    /// activation from starting an unverified refresh.
+    @ObservationIgnored
+    var isAwaitingBaseBranchProbe: Bool = false
 
     /// Mirrors `AppConfig.changes.trackUpstreamForCommits`. Synced by
     /// `RightPaneStore` on every `state(for:)` call. When false (the
@@ -557,7 +576,7 @@ final class RightPaneState {
         let local = ReviewLoopLocalState(
             branchName: currentBranch,
             headSHA: headSHA,
-            baseBranch: baseBranch,
+            baseBranch: reviewLoop.currentBaseBranch,
             hasWorkingTreeChanges: !changes.isEmpty,
             hasStagedChanges: changes.contains { $0.stage == .staged },
             aheadCommitCount: Self.reviewLoopAheadCommitCount(

--- a/Alas/Sources/Right/RightPaneStore.swift
+++ b/Alas/Sources/Right/RightPaneStore.swift
@@ -70,45 +70,51 @@ final class RightPaneStore {
 
             // Settings change: the configured base branch changed. Reset to the
             // new default unless the user picked a branch themselves.
-            if existing.lastConfigBaseBranch != rawDefault {
-                let wasOverridden = existing.userOverrodeBaseBranch
-                existing.lastConfigBaseBranch = rawDefault
+            if existing.lastConfigBaseBranch != baseBranch {
+                existing.lastConfigBaseBranch = baseBranch
+                existing.lastEffectiveBaseBranch = rawDefault
                 existing.userOverrodeBaseBranch = false
-                let baseChanged = existing.baseBranch != rawDefault
-                if baseChanged {
-                    existing.baseBranch = rawDefault
-                    existing.reviewLoop.updateBaseBranch(rawDefault)
-                }
-                if baseChanged || wasOverridden {
-                    // Clear the prior probe so the chip doesn't show a stale
-                    // count while comparison semantics are changing.
-                    existing.behindBase = nil
-                    Task { @MainActor in
-                        await existing.refresh()
-                        await existing.refreshSyncStatus()
-                    }
+                existing.baseBranch = rawDefault
+                existing.reviewLoop.updateBaseBranch(baseBranch)
+                existing.behindBase = nil
+                existing.baseBranchProbeTask?.cancel()
+                existing.isAwaitingBaseBranchProbe = false
+                Task { @MainActor in
+                    await existing.refresh()
+                    await existing.refreshSyncStatus()
                 }
 
                 // If the new default points to a guessed origin ref, verify it
                 // asynchronously and fall back to the configured base branch
                 // if the remote ref does not exist.
                 if rawDefault != baseBranch {
-                    Task { @MainActor [weak existing] in
-                        guard let state = existing else { return }
-                        let confirmed = await self.resolveEffectiveBaseBranch(
-                            worktreePath: worktree.path,
-                            baseBranch: baseBranch
-                        )
-                        guard confirmed != state.baseBranch,
-                              !state.userOverrodeBaseBranch,
-                              state.lastConfigBaseBranch == rawDefault else { return }
-                        state.baseBranch = confirmed
-                        state.lastConfigBaseBranch = confirmed
-                        state.reviewLoop.updateBaseBranch(confirmed)
-                        state.behindBase = nil
-                        await state.refresh()
-                        await state.refreshSyncStatus()
-                    }
+                    scheduleBaseBranchProbe(
+                        for: existing,
+                        worktreePath: worktree.path,
+                        rawBaseBranch: baseBranch
+                    )
+                }
+            } else if !existing.userOverrodeBaseBranch && existing.lastEffectiveBaseBranch != rawDefault {
+                // The configured base didn't change, but the effective default
+                // did (e.g. the worktree branch changed). Follow it without
+                // discarding a verified fallback.
+                existing.lastEffectiveBaseBranch = rawDefault
+                existing.baseBranch = rawDefault
+                // The review loop tracks the configured base branch, not the
+                // comparison ref, so PR actions target the right remote base.
+                existing.behindBase = nil
+                existing.baseBranchProbeTask?.cancel()
+                Task { @MainActor in
+                    await existing.refresh()
+                    await existing.refreshSyncStatus()
+                }
+
+                if rawDefault != baseBranch {
+                    scheduleBaseBranchProbe(
+                        for: existing,
+                        worktreePath: worktree.path,
+                        rawBaseBranch: baseBranch
+                    )
                 }
             }
             if trackUpstreamChanged {
@@ -117,9 +123,19 @@ final class RightPaneStore {
             }
             result = existing
         } else {
-            let new = RightPaneState(worktree: worktree, baseBranch: rawDefault)
-            new.lastConfigBaseBranch = rawDefault
+            // First activation for this worktree. If the effective default is a
+            // guessed origin ref, don't start the initial refresh until the
+            // probe either confirms it or falls back. That avoids racing two
+            // refreshes with different base refs.
+            let shouldDeferInitialRefresh = rawDefault != baseBranch
+            let new = RightPaneState(worktree: worktree, baseBranch: baseBranch)
+            // The commits comparison starts from the effective default, while
+            // the review loop keeps the configured base branch for PR actions.
+            new.baseBranch = rawDefault
+            new.lastConfigBaseBranch = baseBranch
+            new.lastEffectiveBaseBranch = rawDefault
             new.trackUpstreamForCommits = trackUpstreamForCommits
+            new.isAwaitingBaseBranchProbe = shouldDeferInitialRefresh
             new.closeDiffTabs = { [weak self] paths in
                 guard let app = self?.appState else { return }
                 app.tabs.closeDiffTabs(worktreeId: id, relativePaths: paths)
@@ -135,20 +151,32 @@ final class RightPaneStore {
                 app.tabs.activate(worktreeId: id, tabId: tab.id)
             }
 
-            if rawDefault != baseBranch {
-                Task { @MainActor [weak new] in
+            if shouldDeferInitialRefresh {
+                new.baseBranchProbeTask = Task { @MainActor [weak self, weak new] in
                     guard let state = new else { return }
-                    let confirmed = await self.resolveEffectiveBaseBranch(
+                    defer { state.isAwaitingBaseBranchProbe = false }
+                    let confirmed = await self?.resolveEffectiveBaseBranch(
                         worktreePath: worktree.path,
                         baseBranch: baseBranch
-                    )
-                    guard confirmed != state.baseBranch,
+                    ) ?? baseBranch
+                    guard !Task.isCancelled,
                           !state.userOverrodeBaseBranch,
-                          state.lastConfigBaseBranch == rawDefault else { return }
+                          confirmed != state.baseBranch else {
+                        // Even if we didn't change the base branch, kick off
+                        // the deferred initial refresh now that verification
+                        // is done, but only if this state is still active.
+                        guard self?.activeId == id else { return }
+                        state.start()
+                        return
+                    }
+                    // Invalidate any snapshot state populated with the guessed
+                    // origin ref before the fallback, then start with the
+                    // real base branch.
+                    state.markSnapshotUnknown()
                     state.baseBranch = confirmed
-                    state.lastConfigBaseBranch = confirmed
-                    state.reviewLoop.updateBaseBranch(confirmed)
                     state.behindBase = nil
+                    guard self?.activeId == id else { return }
+                    state.start()
                     await state.refresh()
                     await state.refreshSyncStatus()
                 }
@@ -157,20 +185,48 @@ final class RightPaneStore {
             states[id] = new
             result = new
         }
-        activate(id, on: result)
+        if activeId != id {
+            if let prev = activeId, let prevState = states[prev] {
+                prevState.stop()
+            }
+            activeId = id
+            // Don't start the state's background work here if we deferred it
+            // above to wait for the base-branch probe; the probe's task will
+            // call start() once it knows the real comparison ref.
+            if !result.isAwaitingBaseBranchProbe {
+                result.start()
+            }
+        }
         return result
     }
 
-    /// Marks `id` as the currently-displayed worktree. Stops the previously
-    /// active state's filesystem watcher and sync timer so background work
-    /// doesn't leak across every worktree the user has ever opened.
-    private func activate(_ id: String, on state: RightPaneState) {
-        guard activeId != id else { return }
-        if let prev = activeId, let prevState = states[prev] {
-            prevState.stop()
+    /// Verifies whether `origin/<rawBaseBranch>` resolves in the worktree. If
+    /// it does not, applies the original `rawBaseBranch` as the fallback.
+    /// Cancels any previous probe on the state first.
+    private func scheduleBaseBranchProbe(
+        for state: RightPaneState,
+        worktreePath: URL,
+        rawBaseBranch: String
+    ) {
+        state.baseBranchProbeTask?.cancel()
+        state.baseBranchProbeTask = Task { @MainActor [weak state] in
+            guard let state = state else { return }
+            defer { state.baseBranchProbeTask = nil }
+            let confirmed = await self.resolveEffectiveBaseBranch(
+                worktreePath: worktreePath,
+                baseBranch: rawBaseBranch
+            )
+            guard !Task.isCancelled,
+                  !state.userOverrodeBaseBranch,
+                  confirmed != state.baseBranch else { return }
+            // Invalidate any in-flight refresh that may have been started with
+            // the guessed origin ref before it falls back.
+            state.markSnapshotUnknown()
+            state.baseBranch = confirmed
+            state.behindBase = nil
+            await state.refresh()
+            await state.refreshSyncStatus()
         }
-        state.start()
-        activeId = id
     }
 
     /// Refreshes the cached `RightPaneState` for `worktreeId` if one exists.

--- a/Alas/Sources/Right/RightPaneStore.swift
+++ b/Alas/Sources/Right/RightPaneStore.swift
@@ -1,5 +1,6 @@
 import Foundation
 import Observation
+import os
 
 @Observable
 @MainActor
@@ -16,22 +17,60 @@ final class RightPaneStore {
     /// retain the app.
     weak var appState: AppState?
 
+    private let git: GitService
+
+    init(git: GitService = GitService()) {
+        self.git = git
+    }
+
+    /// Returns the branch name the Commits section should compare HEAD against
+    /// when no user override has been set. If the worktree is checked out on the
+    /// configured base branch itself, prefer `origin/<baseBranch>` so the
+    /// comparison is meaningful instead of `branch..branch`.
+    static func effectiveBaseBranch(worktree: Worktree, baseBranch: String) -> String {
+        guard !baseBranch.isEmpty else { return baseBranch }
+        guard worktree.branch == baseBranch else { return baseBranch }
+        return "origin/\(baseBranch)"
+    }
+
+    /// Verifies whether `origin/<baseBranch>` resolves in the worktree. If it
+    /// does not, returns the original `baseBranch`. Errors are swallowed and
+    /// logged so the UI never crashes on a bad git probe.
+    private func resolveEffectiveBaseBranch(
+        worktreePath: URL,
+        baseBranch: String
+    ) async -> String {
+        guard !baseBranch.isEmpty else { return baseBranch }
+        do {
+            if let resolved = try await git.resolveBaseRef(
+                worktreePath: worktreePath,
+                baseBranch: baseBranch,
+                preferLocal: false
+            ) {
+                return resolved.baseRef
+            }
+        } catch {
+            logger.error("Failed to resolve effective base branch for \(worktreePath.path): \(error.localizedDescription)")
+        }
+        return baseBranch
+    }
+
+    private let logger = Logger(subsystem: "io.nlopez.alas", category: "right-pane-store")
+
     func state(for worktree: Worktree, baseBranch: String, trackUpstreamForCommits: Bool) -> RightPaneState {
         let id = worktree.id
         let result: RightPaneState
         if let existing = states[id] {
+            let effectiveDefault = Self.effectiveBaseBranch(worktree: worktree, baseBranch: baseBranch)
             let trackUpstreamChanged = existing.trackUpstreamForCommits != trackUpstreamForCommits
-            // If the global config base branch changed (Settings → Worktrees),
-            // honor the new value and clear the user override. If it didn't
-            // change, leave the state's baseBranch alone so a user-picked
-            // override survives across renders.
-            if existing.lastConfigBaseBranch != baseBranch {
+            if existing.lastConfigBaseBranch != effectiveDefault {
                 let clearedUserOverride = existing.userOverrodeBaseBranch
-                let baseChanged = existing.baseBranch != baseBranch
-                existing.lastConfigBaseBranch = baseBranch
+                let baseChanged = existing.baseBranch != effectiveDefault
+                existing.lastConfigBaseBranch = effectiveDefault
                 existing.userOverrodeBaseBranch = false
                 if baseChanged {
-                    existing.baseBranch = baseBranch
+                    existing.baseBranch = effectiveDefault
+                    existing.reviewLoop.updateBaseBranch(effectiveDefault)
                 }
                 if baseChanged || clearedUserOverride {
                     // Clear the prior probe so the chip doesn't show a stale
@@ -49,8 +88,9 @@ final class RightPaneStore {
             }
             result = existing
         } else {
-            let new = RightPaneState(worktree: worktree, baseBranch: baseBranch)
-            new.lastConfigBaseBranch = baseBranch
+            let effectiveDefault = Self.effectiveBaseBranch(worktree: worktree, baseBranch: baseBranch)
+            let new = RightPaneState(worktree: worktree, baseBranch: effectiveDefault)
+            new.lastConfigBaseBranch = effectiveDefault
             new.trackUpstreamForCommits = trackUpstreamForCommits
             new.closeDiffTabs = { [weak self] paths in
                 guard let app = self?.appState else { return }
@@ -66,6 +106,26 @@ final class RightPaneStore {
                 )
                 app.tabs.activate(worktreeId: id, tabId: tab.id)
             }
+
+            if effectiveDefault != baseBranch {
+                Task { @MainActor [weak new] in
+                    guard let state = new else { return }
+                    let confirmed = await self.resolveEffectiveBaseBranch(
+                        worktreePath: worktree.path,
+                        baseBranch: baseBranch
+                    )
+                    guard confirmed != state.baseBranch,
+                          !state.userOverrodeBaseBranch,
+                          state.lastConfigBaseBranch == effectiveDefault else { return }
+                    state.baseBranch = confirmed
+                    state.lastConfigBaseBranch = confirmed
+                    state.reviewLoop.updateBaseBranch(confirmed)
+                    state.behindBase = nil
+                    await state.refresh()
+                    await state.refreshSyncStatus()
+                }
+            }
+
             states[id] = new
             result = new
         }

--- a/Alas/Sources/Right/RightPaneStore.swift
+++ b/Alas/Sources/Right/RightPaneStore.swift
@@ -36,19 +36,23 @@ final class RightPaneStore {
     /// Verifies whether `origin/<baseBranch>` resolves in the worktree. If it
     /// does not, returns the original `baseBranch`. Errors are swallowed and
     /// logged so the UI never crashes on a bad git probe.
+    ///
+    /// This probe specifically checks the remote-tracking ref
+    /// `refs/remotes/origin/<baseBranch>` rather than delegating to the generic
+    /// `resolveBaseRef` helper, so slash-named branches such as `release/1.0`
+    /// do not accidentally resolve to the local branch of the same name.
     private func resolveEffectiveBaseBranch(
         worktreePath: URL,
         baseBranch: String
     ) async -> String {
         guard !baseBranch.isEmpty else { return baseBranch }
         do {
-            if let resolved = try await git.resolveBaseRef(
-                worktreePath: worktreePath,
-                baseBranch: baseBranch,
-                preferLocal: false
-            ) {
-                return resolved.baseRef
-            }
+            let result = try await git.resolveRevision(
+                at: worktreePath,
+                ref: "refs/remotes/origin/\(baseBranch)"
+            )
+            guard !result.isEmpty else { return baseBranch }
+            return "origin/\(baseBranch)"
         } catch {
             logger.error("Failed to resolve effective base branch for \(worktreePath.path): \(error.localizedDescription)")
         }
@@ -60,25 +64,50 @@ final class RightPaneStore {
     func state(for worktree: Worktree, baseBranch: String, trackUpstreamForCommits: Bool) -> RightPaneState {
         let id = worktree.id
         let result: RightPaneState
+        let rawDefault = Self.effectiveBaseBranch(worktree: worktree, baseBranch: baseBranch)
         if let existing = states[id] {
-            let effectiveDefault = Self.effectiveBaseBranch(worktree: worktree, baseBranch: baseBranch)
             let trackUpstreamChanged = existing.trackUpstreamForCommits != trackUpstreamForCommits
-            if existing.lastConfigBaseBranch != effectiveDefault {
-                let clearedUserOverride = existing.userOverrodeBaseBranch
-                let baseChanged = existing.baseBranch != effectiveDefault
-                existing.lastConfigBaseBranch = effectiveDefault
+
+            // Settings change: the configured base branch changed. Reset to the
+            // new default unless the user picked a branch themselves.
+            if existing.lastConfigBaseBranch != rawDefault {
+                let wasOverridden = existing.userOverrodeBaseBranch
+                existing.lastConfigBaseBranch = rawDefault
                 existing.userOverrodeBaseBranch = false
+                let baseChanged = existing.baseBranch != rawDefault
                 if baseChanged {
-                    existing.baseBranch = effectiveDefault
-                    existing.reviewLoop.updateBaseBranch(effectiveDefault)
+                    existing.baseBranch = rawDefault
+                    existing.reviewLoop.updateBaseBranch(rawDefault)
                 }
-                if baseChanged || clearedUserOverride {
+                if baseChanged || wasOverridden {
                     // Clear the prior probe so the chip doesn't show a stale
                     // count while comparison semantics are changing.
                     existing.behindBase = nil
                     Task { @MainActor in
                         await existing.refresh()
                         await existing.refreshSyncStatus()
+                    }
+                }
+
+                // If the new default points to a guessed origin ref, verify it
+                // asynchronously and fall back to the configured base branch
+                // if the remote ref does not exist.
+                if rawDefault != baseBranch {
+                    Task { @MainActor [weak existing] in
+                        guard let state = existing else { return }
+                        let confirmed = await self.resolveEffectiveBaseBranch(
+                            worktreePath: worktree.path,
+                            baseBranch: baseBranch
+                        )
+                        guard confirmed != state.baseBranch,
+                              !state.userOverrodeBaseBranch,
+                              state.lastConfigBaseBranch == rawDefault else { return }
+                        state.baseBranch = confirmed
+                        state.lastConfigBaseBranch = confirmed
+                        state.reviewLoop.updateBaseBranch(confirmed)
+                        state.behindBase = nil
+                        await state.refresh()
+                        await state.refreshSyncStatus()
                     }
                 }
             }
@@ -88,9 +117,8 @@ final class RightPaneStore {
             }
             result = existing
         } else {
-            let effectiveDefault = Self.effectiveBaseBranch(worktree: worktree, baseBranch: baseBranch)
-            let new = RightPaneState(worktree: worktree, baseBranch: effectiveDefault)
-            new.lastConfigBaseBranch = effectiveDefault
+            let new = RightPaneState(worktree: worktree, baseBranch: rawDefault)
+            new.lastConfigBaseBranch = rawDefault
             new.trackUpstreamForCommits = trackUpstreamForCommits
             new.closeDiffTabs = { [weak self] paths in
                 guard let app = self?.appState else { return }
@@ -107,7 +135,7 @@ final class RightPaneStore {
                 app.tabs.activate(worktreeId: id, tabId: tab.id)
             }
 
-            if effectiveDefault != baseBranch {
+            if rawDefault != baseBranch {
                 Task { @MainActor [weak new] in
                     guard let state = new else { return }
                     let confirmed = await self.resolveEffectiveBaseBranch(
@@ -116,7 +144,7 @@ final class RightPaneStore {
                     )
                     guard confirmed != state.baseBranch,
                           !state.userOverrodeBaseBranch,
-                          state.lastConfigBaseBranch == effectiveDefault else { return }
+                          state.lastConfigBaseBranch == rawDefault else { return }
                     state.baseBranch = confirmed
                     state.lastConfigBaseBranch = confirmed
                     state.reviewLoop.updateBaseBranch(confirmed)

--- a/AlasTests/RightPaneStoreBaseBranchTests.swift
+++ b/AlasTests/RightPaneStoreBaseBranchTests.swift
@@ -17,11 +17,11 @@ struct RightPaneStoreBaseBranchTests {
         )
     }
 
-    private func makeRepoOnMain() async throws -> URL {
+    private func makeRepoOnMain(branch: String = "main") async throws -> URL {
         let tmp = FileManager.default.temporaryDirectory
             .appendingPathComponent("alas-basebranch-\(UUID().uuidString)")
         try FileManager.default.createDirectory(at: tmp, withIntermediateDirectories: true)
-        _ = try await Process.git(["init", "-q", "-b", "main"], cwd: tmp)
+        _ = try await Process.git(["init", "-q", "-b", branch], cwd: tmp)
         _ = try await Process.git(["config", "user.email", "t@e.com"], cwd: tmp)
         _ = try await Process.git(["config", "user.name", "t"], cwd: tmp)
         try "1\n".write(to: tmp.appendingPathComponent("a.txt"), atomically: true, encoding: .utf8)
@@ -48,6 +48,59 @@ struct RightPaneStoreBaseBranchTests {
     @Test func effectiveBaseBranchRespectsRemoteQualifiedBase() {
         let wt = makeWorktree(at: URL(fileURLWithPath: "/tmp/upstream"), branch: "upstream/main")
         #expect(RightPaneStore.effectiveBaseBranch(worktree: wt, baseBranch: "upstream/main") == "origin/upstream/main")
+    }
+
+    @Test func asyncProbeConfirmsSlashNamedOriginRef() async throws {
+        let repo = try await makeRepoOnMain(branch: "release/1.0")
+        defer { try? FileManager.default.removeItem(at: repo) }
+
+        let head = try await Process.git(["rev-parse", "HEAD"], cwd: repo).stdout.trimmingCharacters(in: .whitespacesAndNewlines)
+        _ = try await Process.git(["update-ref", "refs/remotes/origin/release/1.0", head], cwd: repo)
+
+        let store = RightPaneStore(git: GitService())
+        let state = store.state(for: makeWorktree(at: repo, branch: "release/1.0"), baseBranch: "release/1.0", trackUpstreamForCommits: false)
+        #expect(state.baseBranch == "origin/release/1.0")
+
+        try await Task.sleep(nanoseconds: 200_000_000)
+        #expect(state.baseBranch == "origin/release/1.0")
+    }
+
+    @Test func asyncProbeFallsBackForSlashNamedOriginRefWhenLocalBranchExists() async throws {
+        let repo = try await makeRepoOnMain(branch: "release/1.0")
+        defer { try? FileManager.default.removeItem(at: repo) }
+
+        // No origin ref, but the local branch release/1.0 exists. The generic
+        // resolver would return the local branch; our direct origin probe must
+        // fall back to the configured base branch instead.
+        let store = RightPaneStore(git: GitService())
+        let state = store.state(for: makeWorktree(at: repo, branch: "release/1.0"), baseBranch: "release/1.0", trackUpstreamForCommits: false)
+        #expect(state.baseBranch == "origin/release/1.0")
+
+        try await Task.sleep(nanoseconds: 200_000_000)
+        #expect(state.baseBranch == "release/1.0")
+    }
+
+    @Test func stateRemembersVerifiedFallbackAcrossRenders() async throws {
+        let repo = try await makeRepoOnMain()
+        defer { try? FileManager.default.removeItem(at: repo) }
+
+        let store = RightPaneStore(git: GitService())
+        let wt = makeWorktree(at: repo, branch: "main")
+        let state = store.state(for: wt, baseBranch: "main", trackUpstreamForCommits: false)
+        #expect(state.baseBranch == "origin/main")
+        #expect(state.lastConfigBaseBranch == "origin/main")
+
+        try await Task.sleep(nanoseconds: 200_000_000)
+        #expect(state.baseBranch == "main")
+        #expect(state.lastConfigBaseBranch == "main")
+
+        // Simulate a subsequent render with the same configured base branch.
+        // The store must not reset baseBranch back to the non-existent origin/main.
+        _ = store.state(for: wt, baseBranch: "main", trackUpstreamForCommits: false)
+        try await Task.sleep(nanoseconds: 50_000_000)
+        #expect(state.baseBranch == "main")
+        #expect(state.lastConfigBaseBranch == "main")
+        #expect(state.userOverrodeBaseBranch == false)
     }
 
     @Test func asyncProbeConfirmsOriginMainWhenRefExists() async throws {

--- a/AlasTests/RightPaneStoreBaseBranchTests.swift
+++ b/AlasTests/RightPaneStoreBaseBranchTests.swift
@@ -88,19 +88,22 @@ struct RightPaneStoreBaseBranchTests {
         let wt = makeWorktree(at: repo, branch: "main")
         let state = store.state(for: wt, baseBranch: "main", trackUpstreamForCommits: false)
         #expect(state.baseBranch == "origin/main")
-        #expect(state.lastConfigBaseBranch == "origin/main")
+        #expect(state.lastConfigBaseBranch == "main")
 
         try await Task.sleep(nanoseconds: 200_000_000)
         #expect(state.baseBranch == "main")
         #expect(state.lastConfigBaseBranch == "main")
 
-        // Simulate a subsequent render with the same configured base branch.
-        // The store must not reset baseBranch back to the non-existent origin/main.
-        _ = store.state(for: wt, baseBranch: "main", trackUpstreamForCommits: false)
-        try await Task.sleep(nanoseconds: 50_000_000)
-        #expect(state.baseBranch == "main")
-        #expect(state.lastConfigBaseBranch == "main")
-        #expect(state.userOverrodeBaseBranch == false)
+        // Simulate repeated renders with the same configured base branch. The
+        // store must not reset baseBranch back to the non-existent origin/main
+        // or re-trigger fallback probes each time.
+        for _ in 0..<3 {
+            _ = store.state(for: wt, baseBranch: "main", trackUpstreamForCommits: false)
+            try await Task.sleep(nanoseconds: 50_000_000)
+            #expect(state.baseBranch == "main")
+            #expect(state.lastConfigBaseBranch == "main")
+            #expect(state.userOverrodeBaseBranch == false)
+        }
     }
 
     @Test func asyncProbeConfirmsOriginMainWhenRefExists() async throws {

--- a/AlasTests/RightPaneStoreBaseBranchTests.swift
+++ b/AlasTests/RightPaneStoreBaseBranchTests.swift
@@ -1,0 +1,98 @@
+import Testing
+import Foundation
+@testable import Alas
+
+@MainActor
+@Suite(.serialized)
+struct RightPaneStoreBaseBranchTests {
+    private func makeWorktree(at path: URL, branch: String) -> Worktree {
+        Worktree(
+            id: Worktree.makeId(path: path),
+            projectId: "test-project",
+            name: branch,
+            branch: branch,
+            path: path,
+            status: .clean,
+            lastActivity: Date()
+        )
+    }
+
+    private func makeRepoOnMain() async throws -> URL {
+        let tmp = FileManager.default.temporaryDirectory
+            .appendingPathComponent("alas-basebranch-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: tmp, withIntermediateDirectories: true)
+        _ = try await Process.git(["init", "-q", "-b", "main"], cwd: tmp)
+        _ = try await Process.git(["config", "user.email", "t@e.com"], cwd: tmp)
+        _ = try await Process.git(["config", "user.name", "t"], cwd: tmp)
+        try "1\n".write(to: tmp.appendingPathComponent("a.txt"), atomically: true, encoding: .utf8)
+        _ = try await Process.git(["add", "."], cwd: tmp)
+        _ = try await Process.git(["commit", "-q", "-m", "feat: initial"], cwd: tmp)
+        return tmp
+    }
+
+    @Test func effectiveBaseBranchSwitchesToOriginWhenOnBase() {
+        let wt = makeWorktree(at: URL(fileURLWithPath: "/tmp/main"), branch: "main")
+        #expect(RightPaneStore.effectiveBaseBranch(worktree: wt, baseBranch: "main") == "origin/main")
+    }
+
+    @Test func effectiveBaseBranchKeepsBaseWhenOnDifferentBranch() {
+        let wt = makeWorktree(at: URL(fileURLWithPath: "/tmp/feature"), branch: "feature/x")
+        #expect(RightPaneStore.effectiveBaseBranch(worktree: wt, baseBranch: "main") == "main")
+    }
+
+    @Test func effectiveBaseBranchIsNoOpForEmptyBaseBranch() {
+        let wt = makeWorktree(at: URL(fileURLWithPath: "/tmp/empty"), branch: "main")
+        #expect(RightPaneStore.effectiveBaseBranch(worktree: wt, baseBranch: "").isEmpty)
+    }
+
+    @Test func effectiveBaseBranchRespectsRemoteQualifiedBase() {
+        let wt = makeWorktree(at: URL(fileURLWithPath: "/tmp/upstream"), branch: "upstream/main")
+        #expect(RightPaneStore.effectiveBaseBranch(worktree: wt, baseBranch: "upstream/main") == "origin/upstream/main")
+    }
+
+    @Test func asyncProbeConfirmsOriginMainWhenRefExists() async throws {
+        let repo = try await makeRepoOnMain()
+        defer { try? FileManager.default.removeItem(at: repo) }
+
+        let head = try await Process.git(["rev-parse", "HEAD"], cwd: repo).stdout.trimmingCharacters(in: .whitespacesAndNewlines)
+        _ = try await Process.git(["update-ref", "refs/remotes/origin/main", head], cwd: repo)
+
+        let store = RightPaneStore(git: GitService())
+        let state = store.state(for: makeWorktree(at: repo, branch: "main"), baseBranch: "main", trackUpstreamForCommits: false)
+        #expect(state.baseBranch == "origin/main")
+
+        try await Task.sleep(nanoseconds: 200_000_000)
+        #expect(state.baseBranch == "origin/main")
+    }
+
+    @Test func asyncProbeFallsBackWhenOriginMainMissing() async throws {
+        let repo = try await makeRepoOnMain()
+        defer { try? FileManager.default.removeItem(at: repo) }
+
+        let store = RightPaneStore(git: GitService())
+        let state = store.state(for: makeWorktree(at: repo, branch: "main"), baseBranch: "main", trackUpstreamForCommits: false)
+        #expect(state.baseBranch == "origin/main")
+
+        try await Task.sleep(nanoseconds: 200_000_000)
+        #expect(state.baseBranch == "main")
+    }
+
+    @Test func asyncProbeDoesNotOverrideUserSelection() async throws {
+        let repo = try await makeRepoOnMain()
+        defer { try? FileManager.default.removeItem(at: repo) }
+
+        let head = try await Process.git(["rev-parse", "HEAD"], cwd: repo).stdout.trimmingCharacters(in: .whitespacesAndNewlines)
+        _ = try await Process.git(["update-ref", "refs/remotes/origin/main", head], cwd: repo)
+        _ = try await Process.git(["branch", "develop"], cwd: repo)
+
+        let store = RightPaneStore(git: GitService())
+        let state = store.state(for: makeWorktree(at: repo, branch: "main"), baseBranch: "main", trackUpstreamForCommits: false)
+        #expect(state.baseBranch == "origin/main")
+
+        state.selectBaseBranch("develop")
+        #expect(state.userOverrodeBaseBranch)
+
+        try await Task.sleep(nanoseconds: 200_000_000)
+        #expect(state.baseBranch == "develop")
+    }
+}


### PR DESCRIPTION
# Main Worktree Defaults to Remote Base Branch in Changes Tab

## Summary

When a worktree's current branch matches the configured base branch, the Changes tab's Commits section currently compares HEAD against itself (`main..main`), producing an empty and useless list. This change makes the default comparison target `origin/<baseBranch>` in that case, so the main worktree shows meaningful ahead/behind information.

## Motivation

The configured base branch (`AppConfig.worktrees.baseBranch`) is used as the default comparison ref for every worktree. For a feature worktree checked out on `feature/x` with `baseBranch = "main"`, comparing against `main` is correct. But for the primary worktree checked out on `main` itself, the comparison becomes `main..main`, which is empty. Users expect the main worktree to show how far ahead/behind `origin/main` they are.

## Design

### Behavior

- In `RightPaneStore.state(for:baseBranch:trackUpstreamForCommits:)`, before seeding a new `RightPaneState`, compute an **effective default base branch** for the worktree:
  - If `worktree.branch` equals `baseBranch`, prefer `origin/<baseBranch>`.
  - If `origin/<baseBranch>` does not exist in the worktree, fall back to `baseBranch`.
  - If `worktree.branch` differs from `baseBranch`, keep `baseBranch`.
- Detached HEAD or empty branch names keep the configured `baseBranch` unchanged.
- If `baseBranch` already contains a remote qualifier (e.g. `upstream/main`), the equality check (`worktree.branch == baseBranch`) will not match ordinary local branch names, so no additional `origin/` prefix is prepended.

### Data Flow

```
AppState / RightPaneView asks RightPaneStore for state
  → RightPaneStore computes effectiveBaseBranch(worktree, baseBranch)
    → synchronous: returns origin/<baseBranch> or baseBranch
    → asynchronous: optionally verifies origin/<baseBranch> resolves
  → new RightPaneState seeded with effective base branch
  → lastConfigBaseBranch tracks effective default (not raw config string)
  → Settings change resets effective default
  → User override via BaseBranchSelector still preserved
```

### Component Architecture

- **`RightPaneStore`** — Gains a small helper `effectiveBaseBranch(worktree:baseBranch:)` that implements the rule above. The existing `state(for:baseBranch:trackUpstreamForCommits:)` uses its output as the initial `baseBranch` and `lastConfigBaseBranch`.
- **`RightPaneState`** — No changes to public interface. Its `baseBranch` simply starts at the resolved effective default.
- **`BaseBranchSelector` / `CommitsSectionView`** — No changes. They already operate on `rps.baseBranch` and `rps.comparisonRef`.

### Concurrency

The remote ref existence check is done asynchronously to avoid blocking UI construction. The initial state is created with the synchronous fallback (`baseBranch`). If an async probe confirms `origin/<baseBranch>` resolves, and the user has not yet overridden the base branch, the store updates the cached state's `baseBranch` and `lastConfigBaseBranch` and triggers a refresh.

### Error Handling

- If `origin/<baseBranch>` cannot be resolved (no remote named origin, missing remote ref), the fallback `baseBranch` remains. The UI behaves exactly as today.
- Probe failures are logged via `os.Logger` and do not surface user-facing errors.

## Testing Plan

Add Swift Testing unit tests for `RightPaneStore.effectiveBaseBranch` covering:

- `main` worktree + `baseBranch = "main"` resolves to `"origin/main"` when the remote ref exists.
- Falls back to `"main"` when `origin/main` does not exist.
- `feature` worktree + `baseBranch = "main"` keeps `"main"`.
- Manual user override is not overwritten by an async probe.
- Detached HEAD / empty branch keeps `"main"`.

## Out of Scope

- Persisting the effective default per worktree. It is recomputed each time the state is created or the config changes.
- Changing the Base Branch selector UI or the global Settings default.
- Affecting the Review Changes center pane or review-request flows; they have their own scope/branch resolution.

## Risks / Open Questions

- **Remote named something other than `origin`:** The rule hard-codes `origin/<baseBranch>`. Repos that use a different primary remote name will fall back to the configured base branch. This matches the existing convention in `BaseBranchSelector.smartList` and `GitService.resolveBaseRef`.
- **No network fetch:** We only check whether the remote ref exists locally (`refs/remotes/origin/<baseBranch>`). We do not fetch. This is intentional and consistent with the existing sync status behavior.
