### PR TITLE
fix(acp): transcript layout after pane resize

### DIFF
--- a/Alas/Sources/ACP/UI/ACPMessageList.swift
+++ b/Alas/Sources/ACP/UI/ACPMessageList.swift
@@ -223,6 +223,16 @@ struct ACPMessageList: View {
                     restoreTailIfNeeded(proxy: proxy, animated: false)
                     restoreRememberedAnchorIfNeeded(proxy: proxy)
                 }
+                .onChange(of: viewport.size.width) { oldWidth, newWidth in
+                    if Self.shouldRestoreTailAfterViewportWidthChange(
+                        previousWidth: oldWidth,
+                        newWidth: newWidth,
+                        followsTranscriptTail: session.followsTranscriptTail
+                    ) {
+                        restoreTailIfNeeded(proxy: proxy, animated: false)
+                    }
+                    restoreRememberedAnchorIfNeeded(proxy: proxy)
+                }
                 .onChange(of: scrollSignature) { _, _ in
                     if session.followsTranscriptTail {
                         scheduleTailScroll(
@@ -518,6 +528,15 @@ struct ACPMessageList: View {
 
     nonisolated static func shouldRunScheduledTailScroll(followsTranscriptTail: Bool) -> Bool {
         followsTranscriptTail
+    }
+
+    nonisolated static func shouldRestoreTailAfterViewportWidthChange(
+        previousWidth: CGFloat,
+        newWidth: CGFloat,
+        followsTranscriptTail: Bool
+    ) -> Bool {
+        guard followsTranscriptTail else { return false }
+        return abs(newWidth - previousWidth) > 0.5
     }
 
     nonisolated static func topVisibleAnchorID(in frames: [String: CGRect]) -> String? {

--- a/AlasTests/ACP/UI/ACPMarkdownInlineRendererTests.swift
+++ b/AlasTests/ACP/UI/ACPMarkdownInlineRendererTests.swift
@@ -227,6 +227,35 @@ struct ACPMarkdownInlineRendererTests {
         #expect(accessibilityLabel(in: host, containing: "`leadingX`") == nil)
     }
 
+    @Test("inline markdown text invalidates height when resized narrower")
+    func inlineMarkdownTextInvalidatesHeightWhenResizedNarrower() throws {
+        let theme = try Theme.loadBundled(id: "cool-slate")
+        let view = ACPMarkdownInlineTextView(
+            source: """
+            This is a deliberately long paragraph that should wrap into several additional lines when the ACP pane becomes narrow during a divider resize.
+            """,
+            typography: ACPChatTypography(fontFamily: "", fontSize: 12),
+            role: .body,
+            theme: theme
+        )
+        .frame(maxWidth: .infinity, alignment: .leading)
+
+        let host = NSHostingView(rootView: view)
+        host.frame = NSRect(x: 0, y: 0, width: 640, height: 1_000)
+        host.layoutSubtreeIfNeeded()
+
+        let wideTextView = try #require(allSubviews(of: host).compactMap { $0 as? NSTextView }.first)
+        let wideHeight = wideTextView.frame.height
+
+        host.frame = NSRect(x: 0, y: 0, width: 180, height: 1_000)
+        host.layoutSubtreeIfNeeded()
+
+        let narrowTextView = try #require(allSubviews(of: host).compactMap { $0 as? NSTextView }.first)
+        let narrowHeight = narrowTextView.frame.height
+
+        #expect(narrowHeight > wideHeight * 1.5)
+    }
+
     private func allSubviews(of view: NSView) -> [NSView] {
         view.subviews + view.subviews.flatMap { allSubviews(of: $0) }
     }

--- a/AlasTests/ACP/UI/ACPMessageListPaginationTests.swift
+++ b/AlasTests/ACP/UI/ACPMessageListPaginationTests.swift
@@ -126,6 +126,25 @@ struct ACPMessageListPaginationTests {
         #expect(!ACPMessageList.shouldRunScheduledTailScroll(followsTranscriptTail: false))
     }
 
+    @Test("viewport width changes restore the tail only while following")
+    func viewportWidthChangesRestoreTailOnlyWhileFollowing() {
+        #expect(ACPMessageList.shouldRestoreTailAfterViewportWidthChange(
+            previousWidth: 720,
+            newWidth: 560,
+            followsTranscriptTail: true
+        ))
+        #expect(!ACPMessageList.shouldRestoreTailAfterViewportWidthChange(
+            previousWidth: 720,
+            newWidth: 560,
+            followsTranscriptTail: false
+        ))
+        #expect(!ACPMessageList.shouldRestoreTailAfterViewportWidthChange(
+            previousWidth: 720,
+            newWidth: 720,
+            followsTranscriptTail: true
+        ))
+    }
+
     @Test("top visible anchor prefers the row crossing the viewport top")
     func topVisibleAnchorPrefersRowCrossingTop() {
         let frames: [String: CGRect] = [


### PR DESCRIPTION
## Summary

- Restore ACP transcript scroll anchoring when the message-list viewport width changes.
- Keep tail-following sessions pinned after resize-induced wrapping/content-height changes.
- Add focused coverage for width-change tail restore policy and hosted inline markdown reflow.

## Validation

- `rtk xcodegen`
- `rtk xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS,arch=arm64' ALAS_FFF_TARGET_ARCH=arm64 -quiet build`
- `rtk xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS,arch=arm64' ALAS_FFF_TARGET_ARCH=arm64 -only-testing:AlasTests/ACPMessageListPaginationTests -only-testing:AlasTests/ACPMarkdownInlineRendererTests test`
- Full suite was also run with the same arm64 fff override; it failed in two order-dependent `ACPSessionTests` for long image/data URI tool-call assets, and those two tests passed when rerun isolated.