### PR TITLE
feat(review): merge PRs in-app to close the review loop

### DIFF
--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -1058,6 +1058,7 @@
 		EA6EFDDEAE3FF9D878824EDC /* ACPProcessLivenessTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9797C4D8F5DCCC9563D79007 /* ACPProcessLivenessTests.swift */; };
 		EA9B2D81920F620209AB2C34 /* MasonSnapshotTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 97FBCF0F61C80FD8020B1ADD /* MasonSnapshotTests.swift */; };
 		EACD40C757361FC2C78F912A /* ACPCodeBlockHighlighter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 530767799372FE03C3695656 /* ACPCodeBlockHighlighter.swift */; };
+		EAEB68B3A06AEA14BC8E2985 /* ChangesPreparationModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2BD2F573498740A7DECCA3C /* ChangesPreparationModelTests.swift */; };
 		EB6136E15E4F1A4CBA230D12 /* GitServiceBehindStatusTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 82387CFDFFBF52E639095C65 /* GitServiceBehindStatusTests.swift */; };
 		EC2C564EBA85B494489DF323 /* CursorModelVariantsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 336ADD8484D99054ADDBA588 /* CursorModelVariantsTests.swift */; };
 		EC3209AD2538061259084545 /* ACPTerminalMessages.swift in Sources */ = {isa = PBXBuildFile; fileRef = 10E10C6559E26691EC906737 /* ACPTerminalMessages.swift */; };
@@ -2052,6 +2053,7 @@
 		D28AEE8E4821977FDAF13960 /* FileSnapshotTabView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileSnapshotTabView.swift; sourceTree = "<group>"; };
 		D2935EB661338757C478CD86 /* SurfaceViewShortcutTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SurfaceViewShortcutTests.swift; sourceTree = "<group>"; };
 		D2AD81E0DFE33CE4DACF0ADF /* WorktreeWatcher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorktreeWatcher.swift; sourceTree = "<group>"; };
+		D2BD2F573498740A7DECCA3C /* ChangesPreparationModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChangesPreparationModelTests.swift; sourceTree = "<group>"; };
 		D2F90D03073708AA01531533 /* GitService+Staging.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "GitService+Staging.swift"; sourceTree = "<group>"; };
 		D36137279CD9028BB6FFED0B /* WorktreeServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorktreeServiceTests.swift; sourceTree = "<group>"; };
 		D36EA68CE127E24991ABD5A6 /* ReviewDraftCommentStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReviewDraftCommentStoreTests.swift; sourceTree = "<group>"; };
@@ -2713,6 +2715,7 @@
 				08BD96F4379A0D250DE4303C /* JSONRPC */,
 				D7416CBAB1B316023E546714 /* Persistence */,
 				073D86784AF420D20A2149BB /* Remote */,
+				5DD135CB78273EA88FC491E7 /* Right */,
 				34382081666B7E8A95C0DA37 /* Settings */,
 				5FA3F5C4A99F2C74080DA0EF /* SQLiteKit */,
 				B637910FC726CC3C2C8983C1 /* Updates */,
@@ -3249,6 +3252,14 @@
 				0F68A9692F85197ED9E16262 /* WorktreesPane.swift */,
 			);
 			path = Settings;
+			sourceTree = "<group>";
+		};
+		5DD135CB78273EA88FC491E7 /* Right */ = {
+			isa = PBXGroup;
+			children = (
+				D2BD2F573498740A7DECCA3C /* ChangesPreparationModelTests.swift */,
+			);
+			path = Right;
 			sourceTree = "<group>";
 		};
 		5E838E5E31D2C1A333F73943 /* Center */ = {
@@ -5263,6 +5274,7 @@
 				5026424BC4EA8196D12E6F46 /* BuildIdentityTests.swift in Sources */,
 				F8143610563C28604A23B89A /* CenterSelectionStateResolverTests.swift in Sources */,
 				835AFE4A9EA0889E0AF316BD /* ChangeSummaryVisibilityTests.swift in Sources */,
+				EAEB68B3A06AEA14BC8E2985 /* ChangesPreparationModelTests.swift in Sources */,
 				59765FD789179C1BDC3F1BB9 /* ChangesTreeBuilderTests.swift in Sources */,
 				57C5E087A453B384485B4EE2 /* ChatFontCatalogTests.swift in Sources */,
 				981730A24BE369F4AE9012F3 /* ChatPaneTests.swift in Sources */,

--- a/Alas/Sources/App/RootView.swift
+++ b/Alas/Sources/App/RootView.swift
@@ -217,13 +217,13 @@ struct RootView: View {
         .alert(
             "Merge failed",
             isPresented: Binding(
-                get: { activeMergeState()?.mergeError != nil },
-                set: { if !$0 { activeMergeState()?.clearMergeError() } }
+                get: { state.rightPaneStore.stateReportingMergeError() != nil },
+                set: { if !$0 { state.rightPaneStore.stateReportingMergeError()?.clearMergeError() } }
             ),
-            presenting: activeMergeState()?.mergeError
+            presenting: state.rightPaneStore.stateReportingMergeError()?.mergeError
         ) { _ in
             Button("OK", role: .cancel) {
-                activeMergeState()?.clearMergeError()
+                state.rightPaneStore.stateReportingMergeError()?.clearMergeError()
             }
         } message: { message in
             Text(message)

--- a/Alas/Sources/App/RootView.swift
+++ b/Alas/Sources/App/RootView.swift
@@ -214,6 +214,20 @@ struct RootView: View {
                 Text("Squash-merge this review request and delete the branch.")
             }
         }
+        .alert(
+            "Merge failed",
+            isPresented: Binding(
+                get: { activeMergeState()?.mergeError != nil },
+                set: { if !$0 { activeMergeState()?.clearMergeError() } }
+            ),
+            presenting: activeMergeState()?.mergeError
+        ) { _ in
+            Button("OK", role: .cancel) {
+                activeMergeState()?.clearMergeError()
+            }
+        } message: { message in
+            Text(message)
+        }
         .onAppear {
             state.updates.checkOnLaunch()
         }

--- a/Alas/Sources/App/RootView.swift
+++ b/Alas/Sources/App/RootView.swift
@@ -192,6 +192,28 @@ struct RootView: View {
                 Text("Alas will stop tracking this project and its worktrees. No files will be deleted from disk. If any editor tabs have unsaved changes, you'll be asked to save or discard them.")
             }
         )
+        .confirmationDialog(
+            "Merge review request?",
+            isPresented: Binding(
+                get: { activeMergeState()?.pendingMerge != nil },
+                set: { if !$0 { activeMergeState()?.cancelMerge() } }
+            ),
+            titleVisibility: .visible,
+            presenting: activeMergeState()?.pendingMerge
+        ) { snapshot in
+            Button("Merge", role: .destructive) {
+                activeMergeState()?.performMerge()
+            }
+            Button("Cancel", role: .cancel) {
+                activeMergeState()?.cancelMerge()
+            }
+        } message: { snapshot in
+            if let request = snapshot.reviewRequest {
+                Text("Squash-merge \(request.displayIdentity) into \(request.baseRefName) and delete the branch.")
+            } else {
+                Text("Squash-merge this review request and delete the branch.")
+            }
+        }
         .onAppear {
             state.updates.checkOnLaunch()
         }
@@ -283,6 +305,11 @@ struct RootView: View {
                 newAgentChatShortcut: nil
             )
         }
+    }
+
+    private func activeMergeState() -> RightPaneState? {
+        guard let id = state.selectedWorktreeId else { return nil }
+        return state.rightPaneStore.activeState(worktreeId: id)
     }
 
     private func selectedWorktree() -> Worktree? {

--- a/Alas/Sources/App/RootView.swift
+++ b/Alas/Sources/App/RootView.swift
@@ -195,17 +195,17 @@ struct RootView: View {
         .confirmationDialog(
             "Merge review request?",
             isPresented: Binding(
-                get: { activeMergeState()?.pendingMerge != nil },
-                set: { if !$0 { activeMergeState()?.cancelMerge() } }
+                get: { state.rightPaneStore.stateWithPendingMerge() != nil },
+                set: { if !$0 { state.rightPaneStore.stateWithPendingMerge()?.cancelMerge() } }
             ),
             titleVisibility: .visible,
-            presenting: activeMergeState()?.pendingMerge
+            presenting: state.rightPaneStore.stateWithPendingMerge()?.pendingMerge
         ) { snapshot in
             Button("Merge", role: .destructive) {
-                activeMergeState()?.performMerge()
+                state.rightPaneStore.stateWithPendingMerge()?.performMerge()
             }
             Button("Cancel", role: .cancel) {
-                activeMergeState()?.cancelMerge()
+                state.rightPaneStore.stateWithPendingMerge()?.cancelMerge()
             }
         } message: { snapshot in
             if let request = snapshot.reviewRequest {
@@ -319,11 +319,6 @@ struct RootView: View {
                 newAgentChatShortcut: nil
             )
         }
-    }
-
-    private func activeMergeState() -> RightPaneState? {
-        guard let id = state.selectedWorktreeId else { return nil }
-        return state.rightPaneStore.activeState(worktreeId: id)
     }
 
     private func selectedWorktree() -> Worktree? {

--- a/Alas/Sources/Center/Review/ReviewTabView.swift
+++ b/Alas/Sources/Center/Review/ReviewTabView.swift
@@ -127,6 +127,15 @@ struct ReviewTabView: View {
         matchedSnapshot?.providerCapabilities ?? .readOnly
     }
 
+    private var canMergeReviewRequest: Bool {
+        guard let request = reviewRequest else { return false }
+        return capabilities.canMerge
+            && request.state == .open
+            && !request.isDraft
+            && request.mergeState == .clean
+            && (request.worstCheckBucket == nil || request.worstCheckBucket == .pass)
+    }
+
     private var outdatedAndFileLevelThreads: [ReviewThread] {
         localThreads.filter { $0.isFileLevel || $0.isOutdated }
     }
@@ -244,6 +253,17 @@ struct ReviewTabView: View {
                     isActive: false
                 ) {
                     NSWorkspace.shared.open(url)
+                }
+            }
+            if canMergeReviewRequest {
+                toolbarButton(
+                    systemName: "arrow.triangle.merge",
+                    tooltip: "Merge \(tabState.provider.reviewRequestLabel)",
+                    isActive: false
+                ) {
+                    appState.rightPaneStore
+                        .activeState(worktreeId: tabState.worktreeId)?
+                        .handleReviewReadinessAction(.merge, appState: appState)
                 }
             }
         }

--- a/Alas/Sources/Center/Review/ReviewTabView.swift
+++ b/Alas/Sources/Center/Review/ReviewTabView.swift
@@ -128,12 +128,8 @@ struct ReviewTabView: View {
     }
 
     private var canMergeReviewRequest: Bool {
-        guard let request = reviewRequest else { return false }
-        return capabilities.canMerge
-            && request.state == .open
-            && !request.isDraft
-            && request.mergeState == .clean
-            && (request.worstCheckBucket == nil || request.worstCheckBucket == .pass)
+        guard let snapshot = matchedSnapshot else { return false }
+        return ReviewReadinessModel.canMergeReviewRequest(snapshot: snapshot)
     }
 
     private var outdatedAndFileLevelThreads: [ReviewThread] {

--- a/Alas/Sources/Integrations/CodeHost/CodeHostModels.swift
+++ b/Alas/Sources/Integrations/CodeHost/CodeHostModels.swift
@@ -461,6 +461,28 @@ struct ReviewRequest: Identifiable, Equatable, Sendable {
         )
     }
 
+    /// Returns a copy with `threads` replaced, preserving every other field.
+    /// Same rationale as `withChecks`: a hand-rolled copy in the provider used
+    /// to silently drop `headRepositoryOwner`.
+    func withThreads(_ threads: [ReviewThread]) -> ReviewRequest {
+        ReviewRequest(
+            remote: remote,
+            number: number,
+            title: title,
+            url: url,
+            state: state,
+            isDraft: isDraft,
+            headRefName: headRefName,
+            baseRefName: baseRefName,
+            headSHA: headSHA,
+            headRepositoryOwner: headRepositoryOwner,
+            reviewDecision: reviewDecision,
+            mergeState: mergeState,
+            checks: checks,
+            threads: threads
+        )
+    }
+
     static func placeholder(remote: CodeHostRemote, number: Int) -> ReviewRequest {
         ReviewRequest(
             remote: remote,

--- a/Alas/Sources/Integrations/CodeHost/CodeHostModels.swift
+++ b/Alas/Sources/Integrations/CodeHost/CodeHostModels.swift
@@ -385,10 +385,12 @@ struct ReviewRequest: Identifiable, Equatable, Sendable {
     let headRefName: String
     let baseRefName: String
     let headSHA: String?
-    /// Owner (login) of the repository the head branch lives in. Differs from
-    /// `remote.owner` for forked pull requests. Used to scope remote-branch
-    /// cleanup so a same-named branch in the base repo is never deleted.
+    /// Owner (login) and name of the repository the head branch lives in.
+    /// Differ from `remote` for forked pull requests — including same-owner
+    /// forks, where only the name differs. Both are compared before remote-
+    /// branch cleanup so a same-named branch in the base repo is never deleted.
     let headRepositoryOwner: String?
+    let headRepositoryName: String?
     let reviewDecision: ReviewDecision
     let mergeState: ReviewMergeState
     let checks: [ReviewCheck]
@@ -413,6 +415,7 @@ struct ReviewRequest: Identifiable, Equatable, Sendable {
         baseRefName: String,
         headSHA: String? = nil,
         headRepositoryOwner: String? = nil,
+        headRepositoryName: String? = nil,
         reviewDecision: ReviewDecision,
         mergeState: ReviewMergeState,
         checks: [ReviewCheck],
@@ -429,6 +432,7 @@ struct ReviewRequest: Identifiable, Equatable, Sendable {
         self.baseRefName = baseRefName
         self.headSHA = headSHA
         self.headRepositoryOwner = headRepositoryOwner
+        self.headRepositoryName = headRepositoryName
         self.reviewDecision = reviewDecision
         self.mergeState = mergeState
         self.checks = checks
@@ -460,6 +464,7 @@ struct ReviewRequest: Identifiable, Equatable, Sendable {
             baseRefName: baseRefName,
             headSHA: headSHA,
             headRepositoryOwner: headRepositoryOwner,
+            headRepositoryName: headRepositoryName,
             reviewDecision: reviewDecision,
             mergeState: mergeState,
             checks: checks,
@@ -484,6 +489,7 @@ struct ReviewRequest: Identifiable, Equatable, Sendable {
             baseRefName: baseRefName,
             headSHA: headSHA,
             headRepositoryOwner: headRepositoryOwner,
+            headRepositoryName: headRepositoryName,
             reviewDecision: reviewDecision,
             mergeState: mergeState,
             checks: checks,

--- a/Alas/Sources/Integrations/CodeHost/CodeHostModels.swift
+++ b/Alas/Sources/Integrations/CodeHost/CodeHostModels.swift
@@ -39,6 +39,10 @@ enum CodeHostKind: String, Codable, Equatable, Sendable {
     var openReviewRequestTitle: String {
         "Open \(reviewRequestLabel)"
     }
+
+    var mergeReviewRequestTitle: String {
+        "Merge \(reviewRequestLabel)"
+    }
 }
 
 struct CodeHostRemote: Equatable, Sendable {
@@ -72,6 +76,7 @@ struct CodeHostProviderCapabilities: Equatable, Sendable {
     let canFetchAnnotations: Bool
     let canEditComment: Bool
     let canDeleteComment: Bool
+    let canMerge: Bool
 
     static let readOnly = CodeHostProviderCapabilities(
         canCreateReviewRequest: false,
@@ -83,7 +88,8 @@ struct CodeHostProviderCapabilities: Equatable, Sendable {
         canSubmitReview: false,
         canFetchAnnotations: false,
         canEditComment: false,
-        canDeleteComment: false
+        canDeleteComment: false,
+        canMerge: false
     )
 
     static let githubCLI = CodeHostProviderCapabilities(
@@ -96,7 +102,8 @@ struct CodeHostProviderCapabilities: Equatable, Sendable {
         canSubmitReview: true,
         canFetchAnnotations: true,
         canEditComment: true,
-        canDeleteComment: true
+        canDeleteComment: true,
+        canMerge: true
     )
 
     static let gitlabCLI = CodeHostProviderCapabilities(
@@ -109,7 +116,8 @@ struct CodeHostProviderCapabilities: Equatable, Sendable {
         canSubmitReview: true,
         canFetchAnnotations: false,
         canEditComment: true,
-        canDeleteComment: true
+        canDeleteComment: true,
+        canMerge: true
     )
 }
 
@@ -138,6 +146,12 @@ enum ReviewMergeState: String, Codable, Equatable, Sendable {
     case dirty
     case unstable
     case unknown
+}
+
+enum ReviewMergeMethod: String, Codable, Equatable, Sendable {
+    case squash
+    case merge
+    case rebase
 }
 
 enum ReviewCheckBucket: String, Codable, Equatable, Sendable {

--- a/Alas/Sources/Integrations/CodeHost/CodeHostModels.swift
+++ b/Alas/Sources/Integrations/CodeHost/CodeHostModels.swift
@@ -385,6 +385,10 @@ struct ReviewRequest: Identifiable, Equatable, Sendable {
     let headRefName: String
     let baseRefName: String
     let headSHA: String?
+    /// Owner (login) of the repository the head branch lives in. Differs from
+    /// `remote.owner` for forked pull requests. Used to scope remote-branch
+    /// cleanup so a same-named branch in the base repo is never deleted.
+    let headRepositoryOwner: String?
     let reviewDecision: ReviewDecision
     let mergeState: ReviewMergeState
     let checks: [ReviewCheck]
@@ -404,6 +408,7 @@ struct ReviewRequest: Identifiable, Equatable, Sendable {
         headRefName: String,
         baseRefName: String,
         headSHA: String? = nil,
+        headRepositoryOwner: String? = nil,
         reviewDecision: ReviewDecision,
         mergeState: ReviewMergeState,
         checks: [ReviewCheck],
@@ -418,6 +423,7 @@ struct ReviewRequest: Identifiable, Equatable, Sendable {
         self.headRefName = headRefName
         self.baseRefName = baseRefName
         self.headSHA = headSHA
+        self.headRepositoryOwner = headRepositoryOwner
         self.reviewDecision = reviewDecision
         self.mergeState = mergeState
         self.checks = checks

--- a/Alas/Sources/Integrations/CodeHost/CodeHostModels.swift
+++ b/Alas/Sources/Integrations/CodeHost/CodeHostModels.swift
@@ -438,6 +438,29 @@ struct ReviewRequest: Identifiable, Equatable, Sendable {
         reviewDecision == .changesRequested || threads.contains { $0.isActionable }
     }
 
+    /// Returns a copy with `checks` replaced, preserving every other field.
+    /// Used by the refresh path to attach freshly-fetched checks without
+    /// dropping metadata like `headSHA`/`headRepositoryOwner` that the merge
+    /// path relies on.
+    func withChecks(_ checks: [ReviewCheck]) -> ReviewRequest {
+        ReviewRequest(
+            remote: remote,
+            number: number,
+            title: title,
+            url: url,
+            state: state,
+            isDraft: isDraft,
+            headRefName: headRefName,
+            baseRefName: baseRefName,
+            headSHA: headSHA,
+            headRepositoryOwner: headRepositoryOwner,
+            reviewDecision: reviewDecision,
+            mergeState: mergeState,
+            checks: checks,
+            threads: threads
+        )
+    }
+
     static func placeholder(remote: CodeHostRemote, number: Int) -> ReviewRequest {
         ReviewRequest(
             remote: remote,

--- a/Alas/Sources/Integrations/CodeHost/CodeHostModels.swift
+++ b/Alas/Sources/Integrations/CodeHost/CodeHostModels.swift
@@ -393,6 +393,10 @@ struct ReviewRequest: Identifiable, Equatable, Sendable {
     let mergeState: ReviewMergeState
     let checks: [ReviewCheck]
     let threads: [ReviewThread]
+    /// False when loading review threads/discussions failed, so `threads` may
+    /// be missing actionable feedback. The merge gate fails closed on this: we
+    /// must not offer merge while we can't confirm there are no open threads.
+    let areThreadsComplete: Bool
 
     var provider: CodeHostKind { remote.kind }
 
@@ -412,7 +416,8 @@ struct ReviewRequest: Identifiable, Equatable, Sendable {
         reviewDecision: ReviewDecision,
         mergeState: ReviewMergeState,
         checks: [ReviewCheck],
-        threads: [ReviewThread]
+        threads: [ReviewThread],
+        areThreadsComplete: Bool = true
     ) {
         self.remote = remote
         self.number = number
@@ -428,6 +433,7 @@ struct ReviewRequest: Identifiable, Equatable, Sendable {
         self.mergeState = mergeState
         self.checks = checks
         self.threads = threads
+        self.areThreadsComplete = areThreadsComplete
     }
 
     var worstCheckBucket: ReviewCheckBucket? {
@@ -457,14 +463,16 @@ struct ReviewRequest: Identifiable, Equatable, Sendable {
             reviewDecision: reviewDecision,
             mergeState: mergeState,
             checks: checks,
-            threads: threads
+            threads: threads,
+            areThreadsComplete: areThreadsComplete
         )
     }
 
     /// Returns a copy with `threads` replaced, preserving every other field.
     /// Same rationale as `withChecks`: a hand-rolled copy in the provider used
-    /// to silently drop `headRepositoryOwner`.
-    func withThreads(_ threads: [ReviewThread]) -> ReviewRequest {
+    /// to silently drop `headRepositoryOwner`. `complete` records whether the
+    /// thread fetch succeeded so the merge gate can fail closed on a failure.
+    func withThreads(_ threads: [ReviewThread], complete: Bool = true) -> ReviewRequest {
         ReviewRequest(
             remote: remote,
             number: number,
@@ -479,7 +487,8 @@ struct ReviewRequest: Identifiable, Equatable, Sendable {
             reviewDecision: reviewDecision,
             mergeState: mergeState,
             checks: checks,
-            threads: threads
+            threads: threads,
+            areThreadsComplete: complete
         )
     }
 

--- a/Alas/Sources/Integrations/CodeHost/CodeHostProvider.swift
+++ b/Alas/Sources/Integrations/CodeHost/CodeHostProvider.swift
@@ -130,6 +130,13 @@ protocol CodeHostProvider: Sendable {
         cwd: URL
     ) async throws
 
+    func mergeReviewRequest(
+        _ request: ReviewRequest,
+        method: ReviewMergeMethod,
+        deleteBranch: Bool,
+        cwd: URL
+    ) async throws
+
     func startReview(
         remote: CodeHostRemote,
         request: ReviewRequest,
@@ -279,6 +286,15 @@ extension CodeHostProvider {
         cwd: URL
     ) async throws {
         throw CodeHostProviderError.unsupportedProvider(kind)
+    }
+
+    func mergeReviewRequest(
+        _ request: ReviewRequest,
+        method: ReviewMergeMethod,
+        deleteBranch: Bool,
+        cwd: URL
+    ) async throws {
+        throw CodeHostProviderError.unsupportedProvider(request.remote.kind)
     }
 
     func startReview(

--- a/Alas/Sources/Integrations/CodeHost/GitHubCLIProvider.swift
+++ b/Alas/Sources/Integrations/CodeHost/GitHubCLIProvider.swift
@@ -865,8 +865,10 @@ struct GitHubCLIProvider: CodeHostProvider {
             _ = try? await runner.run(
                 "gh",
                 args: [
-                    "api", "--method", "DELETE",
-                    "repos/\(Self.highLevelRepositorySelector(remote: request.remote))/git/refs/heads/\(request.headRefName)",
+                    "api",
+                    "--hostname", request.remote.host,
+                    "--method", "DELETE",
+                    "repos/\(request.remote.repositorySlug)/git/refs/heads/\(request.headRefName)",
                 ],
                 cwd: cwd
             )

--- a/Alas/Sources/Integrations/CodeHost/GitHubCLIProvider.swift
+++ b/Alas/Sources/Integrations/CodeHost/GitHubCLIProvider.swift
@@ -835,14 +835,33 @@ struct GitHubCLIProvider: CodeHostProvider {
         case .merge: args.append("--merge")
         case .rebase: args.append("--rebase")
         }
-        if deleteBranch {
-            args.append("--delete-branch")
+        // Pin the merge to the reviewed head so a push that lands between the
+        // snapshot load and the confirmation can't merge an unreviewed commit.
+        if let headSHA = request.headSHA {
+            args.append(contentsOf: ["--match-head-commit", headSHA])
         }
         args.append(contentsOf: ["-R", Self.highLevelRepositorySelector(remote: request.remote)])
 
         let result = try await runner.run("gh", args: args, cwd: cwd)
         guard result.exitCode == 0 else {
             throw CodeHostProviderError.commandFailed(command: "gh pr merge", stderr: result.stderr)
+        }
+
+        // Delete the remote branch only. `gh pr merge --delete-branch` also
+        // deletes the *local* branch, which fails in Alas' linked-worktree
+        // workflow when that branch is checked out — surfacing a false merge
+        // failure even though the PR already merged. Best-effort: the merge
+        // has succeeded, so ignore cleanup errors (e.g. a repo configured to
+        // auto-delete head branches will already have removed the ref).
+        if deleteBranch {
+            _ = try? await runner.run(
+                "gh",
+                args: [
+                    "api", "--method", "DELETE",
+                    "repos/\(Self.highLevelRepositorySelector(remote: request.remote))/git/refs/heads/\(request.headRefName)",
+                ],
+                cwd: cwd
+            )
         }
     }
 

--- a/Alas/Sources/Integrations/CodeHost/GitHubCLIProvider.swift
+++ b/Alas/Sources/Integrations/CodeHost/GitHubCLIProvider.swift
@@ -823,6 +823,29 @@ struct GitHubCLIProvider: CodeHostProvider {
         }
     }
 
+    func mergeReviewRequest(
+        _ request: ReviewRequest,
+        method: ReviewMergeMethod,
+        deleteBranch: Bool,
+        cwd: URL
+    ) async throws {
+        var args = ["pr", "merge", "\(request.number)"]
+        switch method {
+        case .squash: args.append("--squash")
+        case .merge: args.append("--merge")
+        case .rebase: args.append("--rebase")
+        }
+        if deleteBranch {
+            args.append("--delete-branch")
+        }
+        args.append(contentsOf: ["-R", Self.highLevelRepositorySelector(remote: request.remote)])
+
+        let result = try await runner.run("gh", args: args, cwd: cwd)
+        guard result.exitCode == 0 else {
+            throw CodeHostProviderError.commandFailed(command: "gh pr merge", stderr: result.stderr)
+        }
+    }
+
     func replyToThread(
         remote: CodeHostRemote,
         request: ReviewRequest,

--- a/Alas/Sources/Integrations/CodeHost/GitHubCLIProvider.swift
+++ b/Alas/Sources/Integrations/CodeHost/GitHubCLIProvider.swift
@@ -1695,7 +1695,6 @@ struct GitHubCLIProvider: CodeHostProvider {
             .joined(separator: "|")
     }
 
-
     private func pullRequestNodeID(remote: CodeHostRemote, request: ReviewRequest, cwd: URL) async throws -> String {
         let stdin = try Self.graphQLInput(
             query: Self.pullRequestNodeQuery,

--- a/Alas/Sources/Integrations/CodeHost/GitHubCLIProvider.swift
+++ b/Alas/Sources/Integrations/CodeHost/GitHubCLIProvider.swift
@@ -853,7 +853,15 @@ struct GitHubCLIProvider: CodeHostProvider {
         // failure even though the PR already merged. Best-effort: the merge
         // has succeeded, so ignore cleanup errors (e.g. a repo configured to
         // auto-delete head branches will already have removed the ref).
-        if deleteBranch {
+        //
+        // Only delete when the head lives in the base repo. For forked PRs the
+        // head branch is in a different repo (`headRepositoryOwner != remote.owner`);
+        // the DELETE ref endpoint is scoped by `{owner}/{repo}`, so targeting
+        // the base repo there would either miss the fork branch or delete an
+        // unrelated same-named base-repo branch. Leave fork branches alone.
+        if deleteBranch,
+           let headOwner = request.headRepositoryOwner,
+           headOwner == request.remote.owner {
             _ = try? await runner.run(
                 "gh",
                 args: [
@@ -1189,6 +1197,7 @@ struct GitHubCLIProvider: CodeHostProvider {
             headRefName: item.headRefName,
             baseRefName: item.baseRefName,
             headSHA: normalizedOptionalString(item.headRefOid),
+            headRepositoryOwner: item.headRepositoryOwner?.login,
             reviewDecision: mapReviewDecision(item.reviewDecision),
             mergeState: mapMergeState(item.mergeStateStatus),
             checks: [],
@@ -1226,6 +1235,7 @@ struct GitHubCLIProvider: CodeHostProvider {
             headRefName: item.headRefName,
             baseRefName: item.baseRefName,
             headSHA: normalizedOptionalString(item.headRefOid),
+            headRepositoryOwner: item.headRepositoryOwner?.login,
             reviewDecision: mapReviewDecision(item.reviewDecision),
             mergeState: mapMergeState(item.mergeStateStatus),
             checks: [],

--- a/Alas/Sources/Integrations/CodeHost/GitHubCLIProvider.swift
+++ b/Alas/Sources/Integrations/CodeHost/GitHubCLIProvider.swift
@@ -859,9 +859,15 @@ struct GitHubCLIProvider: CodeHostProvider {
         // the DELETE ref endpoint is scoped by `{owner}/{repo}`, so targeting
         // the base repo there would either miss the fork branch or delete an
         // unrelated same-named base-repo branch. Leave fork branches alone.
+        //
+        // A zero exit does not guarantee the PR merged: with a required merge
+        // queue, `gh pr merge` enqueues the PR (still open) and the queue needs
+        // the head branch to complete. Confirm the PR is actually merged before
+        // deleting; for a queued PR, leave cleanup to the queue / auto-delete.
         if deleteBranch,
            let headOwner = request.headRepositoryOwner,
-           headOwner == request.remote.owner {
+           headOwner == request.remote.owner,
+           await isReviewRequestMerged(request, cwd: cwd) {
             _ = try? await runner.run(
                 "gh",
                 args: [
@@ -873,6 +879,25 @@ struct GitHubCLIProvider: CodeHostProvider {
                 cwd: cwd
             )
         }
+    }
+
+    private func isReviewRequestMerged(_ request: ReviewRequest, cwd: URL) async -> Bool {
+        guard let result = try? await runner.run(
+            "gh",
+            args: [
+                "pr", "view", "\(request.number)",
+                "--json", "state",
+                "-R", Self.highLevelRepositorySelector(remote: request.remote),
+            ],
+            cwd: cwd
+        ), result.exitCode == 0 else {
+            return false
+        }
+        struct PRStateOnly: Decodable { let state: String }
+        guard let decoded = try? JSONDecoder().decode(PRStateOnly.self, from: Data(result.stdout.utf8)) else {
+            return false
+        }
+        return Self.mapState(decoded.state) == .merged
     }
 
     func replyToThread(

--- a/Alas/Sources/Integrations/CodeHost/GitHubCLIProvider.swift
+++ b/Alas/Sources/Integrations/CodeHost/GitHubCLIProvider.swift
@@ -290,7 +290,7 @@ struct GitHubCLIProvider: CodeHostProvider {
             return nil
         }
         let threads = (try? await reviewThreads(remote: remote, request: request, cwd: cwd)) ?? []
-        return Self.withThreads(threads, on: request)
+        return request.withThreads(threads)
     }
 
     func reviewRequest(remote: CodeHostRemote, number: Int, cwd: URL) async throws -> ReviewRequest {
@@ -697,7 +697,7 @@ struct GitHubCLIProvider: CodeHostProvider {
         }
         let request = try Self.parsePRView(result.stdout, remote: remote)
         let threads = (try? await reviewThreads(remote: remote, request: request, cwd: cwd)) ?? []
-        return Self.withThreads(threads, on: request)
+        return request.withThreads(threads)
     }
 
     func mutateReviewThread(_ mutation: ProviderThreadMutation) async throws -> ProviderThreadMutationResult {
@@ -1695,23 +1695,6 @@ struct GitHubCLIProvider: CodeHostProvider {
             .joined(separator: "|")
     }
 
-    private static func withThreads(_ threads: [ReviewThread], on request: ReviewRequest) -> ReviewRequest {
-        ReviewRequest(
-            remote: request.remote,
-            number: request.number,
-            title: request.title,
-            url: request.url,
-            state: request.state,
-            isDraft: request.isDraft,
-            headRefName: request.headRefName,
-            baseRefName: request.baseRefName,
-            headSHA: request.headSHA,
-            reviewDecision: request.reviewDecision,
-            mergeState: request.mergeState,
-            checks: request.checks,
-            threads: threads
-        )
-    }
 
     private func pullRequestNodeID(remote: CodeHostRemote, request: ReviewRequest, cwd: URL) async throws -> String {
         let stdin = try Self.graphQLInput(

--- a/Alas/Sources/Integrations/CodeHost/GitHubCLIProvider.swift
+++ b/Alas/Sources/Integrations/CodeHost/GitHubCLIProvider.swift
@@ -1642,6 +1642,11 @@ struct GitHubCLIProvider: CodeHostProvider {
     private static func mapMergeState(_ value: String?) -> ReviewMergeState {
         switch value?.uppercased() {
         case "CLEAN": .clean
+        // GitHub Enterprise reports HAS_HOOKS for a PR that is mergeable with
+        // passing status and pre-receive hooks. It's mergeable like CLEAN, so
+        // treat it as such rather than falling through to `.unknown` (which
+        // would hide the Merge action).
+        case "HAS_HOOKS": .clean
         case "BLOCKED": .blocked
         case "DIRTY": .dirty
         case "UNSTABLE": .unstable

--- a/Alas/Sources/Integrations/CodeHost/GitHubCLIProvider.swift
+++ b/Alas/Sources/Integrations/CodeHost/GitHubCLIProvider.swift
@@ -277,7 +277,7 @@ struct GitHubCLIProvider: CodeHostProvider {
                 "--base", base,
                 "--state", "open",
                 "--limit", "20",
-                "--json", "number,title,url,state,isDraft,headRefName,headRefOid,headRepositoryOwner,baseRefName,reviewDecision,mergeStateStatus",
+                "--json", "number,title,url,state,isDraft,headRefName,headRefOid,headRepositoryOwner,headRepository,baseRefName,reviewDecision,mergeStateStatus",
                 "-R", Self.highLevelRepositorySelector(remote: remote),
             ],
             cwd: cwd
@@ -702,7 +702,7 @@ struct GitHubCLIProvider: CodeHostProvider {
             "gh",
             args: [
                 "pr", "view", "\(request.number)",
-                "--json", "number,title,url,state,isDraft,headRefName,headRefOid,headRepositoryOwner,baseRefName,reviewDecision,mergeStateStatus",
+                "--json", "number,title,url,state,isDraft,headRefName,headRefOid,headRepositoryOwner,headRepository,baseRefName,reviewDecision,mergeStateStatus",
                 "-R", Self.highLevelRepositorySelector(remote: remote),
             ],
             cwd: cwd
@@ -873,7 +873,9 @@ struct GitHubCLIProvider: CodeHostProvider {
         // head branch is in a different repo (`headRepositoryOwner != remote.owner`);
         // the DELETE ref endpoint is scoped by `{owner}/{repo}`, so targeting
         // the base repo there would either miss the fork branch or delete an
-        // unrelated same-named base-repo branch. Leave fork branches alone.
+        // unrelated same-named base-repo branch. Both owner AND name must match
+        // — a same-owner fork (e.g. `owner/repo-fork`) shares the owner but not
+        // the repository. Leave fork branches alone.
         //
         // A zero exit does not guarantee the PR merged: with a required merge
         // queue, `gh pr merge` enqueues the PR (still open) and the queue needs
@@ -881,7 +883,9 @@ struct GitHubCLIProvider: CodeHostProvider {
         // deleting; for a queued PR, leave cleanup to the queue / auto-delete.
         if deleteBranch,
            let headOwner = request.headRepositoryOwner,
+           let headName = request.headRepositoryName,
            headOwner == request.remote.owner,
+           headName == request.remote.repository,
            await isReviewRequestMerged(request, cwd: cwd) {
             _ = try? await runner.run(
                 "gh",
@@ -1240,6 +1244,7 @@ struct GitHubCLIProvider: CodeHostProvider {
             baseRefName: item.baseRefName,
             headSHA: normalizedOptionalString(item.headRefOid),
             headRepositoryOwner: item.headRepositoryOwner?.login,
+            headRepositoryName: item.headRepository?.name,
             reviewDecision: mapReviewDecision(item.reviewDecision),
             mergeState: mapMergeState(item.mergeStateStatus),
             checks: [],
@@ -1278,6 +1283,7 @@ struct GitHubCLIProvider: CodeHostProvider {
             baseRefName: item.baseRefName,
             headSHA: normalizedOptionalString(item.headRefOid),
             headRepositoryOwner: item.headRepositoryOwner?.login,
+            headRepositoryName: item.headRepository?.name,
             reviewDecision: mapReviewDecision(item.reviewDecision),
             mergeState: mapMergeState(item.mergeStateStatus),
             checks: [],
@@ -1789,9 +1795,14 @@ private struct PRListItem: Decodable {
     let headRefName: String
     let headRefOid: String?
     let headRepositoryOwner: HeadRepositoryOwner?
+    let headRepository: HeadRepository?
     let baseRefName: String
     let reviewDecision: String?
     let mergeStateStatus: String?
+}
+
+private struct HeadRepository: Decodable {
+    let name: String
 }
 
 private struct HeadRepositoryOwner: Decodable {

--- a/Alas/Sources/Integrations/CodeHost/GitHubCLIProvider.swift
+++ b/Alas/Sources/Integrations/CodeHost/GitHubCLIProvider.swift
@@ -289,8 +289,23 @@ struct GitHubCLIProvider: CodeHostProvider {
         guard let request = try Self.parsePRList(result.stdout, remote: remote, headOwner: headOwner) else {
             return nil
         }
-        let threads = (try? await reviewThreads(remote: remote, request: request, cwd: cwd)) ?? []
-        return request.withThreads(threads)
+        let loadedThreads = await threadsWithCompleteness(remote: remote, request: request, cwd: cwd)
+        return request.withThreads(loadedThreads.threads, complete: loadedThreads.complete)
+    }
+
+    /// Loads review threads, reporting whether the fetch succeeded. A failure
+    /// yields no threads but flags the result incomplete so the merge gate can
+    /// fail closed instead of treating missing threads as "no feedback".
+    private func threadsWithCompleteness(
+        remote: CodeHostRemote,
+        request: ReviewRequest,
+        cwd: URL
+    ) async -> (threads: [ReviewThread], complete: Bool) {
+        do {
+            return (try await reviewThreads(remote: remote, request: request, cwd: cwd), true)
+        } catch {
+            return ([], false)
+        }
     }
 
     func reviewRequest(remote: CodeHostRemote, number: Int, cwd: URL) async throws -> ReviewRequest {
@@ -696,8 +711,8 @@ struct GitHubCLIProvider: CodeHostProvider {
             throw CodeHostProviderError.commandFailed(command: "gh pr view", stderr: result.stderr)
         }
         let request = try Self.parsePRView(result.stdout, remote: remote)
-        let threads = (try? await reviewThreads(remote: remote, request: request, cwd: cwd)) ?? []
-        return request.withThreads(threads)
+        let loadedThreads = await threadsWithCompleteness(remote: remote, request: request, cwd: cwd)
+        return request.withThreads(loadedThreads.threads, complete: loadedThreads.complete)
     }
 
     func mutateReviewThread(_ mutation: ProviderThreadMutation) async throws -> ProviderThreadMutationResult {

--- a/Alas/Sources/Integrations/CodeHost/GitLabCLIProvider.swift
+++ b/Alas/Sources/Integrations/CodeHost/GitLabCLIProvider.swift
@@ -78,9 +78,9 @@ struct GitLabCLIProvider: CodeHostProvider {
         }
 
         let detailedRequest = (try? await reviewRequestDetails(remote: remote, request: request, cwd: cwd)) ?? request
-        let threads = (try? await unresolvedDiscussions(remote: remote, request: detailedRequest, cwd: cwd)) ?? []
+        let loadedThreads = await discussionsWithCompleteness(remote: remote, request: detailedRequest, cwd: cwd)
         let checks = (try? await checks(remote: remote, request: detailedRequest, cwd: cwd)) ?? []
-        return Self.withEnrichment(threads: threads, checks: checks, on: detailedRequest)
+        return Self.withEnrichment(threads: loadedThreads.threads, checks: checks, threadsComplete: loadedThreads.complete, on: detailedRequest)
     }
 
     func reviewRequest(remote: CodeHostRemote, number: Int, cwd: URL) async throws -> ReviewRequest {
@@ -836,9 +836,9 @@ struct GitLabCLIProvider: CodeHostProvider {
         cwd: URL
     ) async throws -> ReviewRequest {
         let refreshed = try await reviewRequestDetails(remote: remote, request: request, cwd: cwd)
-        let threads = (try? await unresolvedDiscussions(remote: remote, request: refreshed, cwd: cwd)) ?? []
+        let loadedThreads = await discussionsWithCompleteness(remote: remote, request: refreshed, cwd: cwd)
         let checks = (try? await checks(remote: remote, request: refreshed, cwd: cwd)) ?? []
-        return Self.withEnrichment(threads: threads, checks: checks, on: refreshed)
+        return Self.withEnrichment(threads: loadedThreads.threads, checks: checks, threadsComplete: loadedThreads.complete, on: refreshed)
     }
 
     private func mergeRequestDiffRefs(
@@ -1655,6 +1655,7 @@ struct GitLabCLIProvider: CodeHostProvider {
     private static func withEnrichment(
         threads: [ReviewThread],
         checks: [ReviewCheck],
+        threadsComplete: Bool,
         on request: ReviewRequest
     ) -> ReviewRequest {
         ReviewRequest(
@@ -1670,8 +1671,24 @@ struct GitLabCLIProvider: CodeHostProvider {
             reviewDecision: request.reviewDecision,
             mergeState: request.mergeState,
             checks: checks,
-            threads: threads
+            threads: threads,
+            areThreadsComplete: threadsComplete
         )
+    }
+
+    /// Loads unresolved discussions, reporting whether the fetch succeeded so
+    /// the merge gate can fail closed instead of treating a failed load as
+    /// "no feedback".
+    private func discussionsWithCompleteness(
+        remote: CodeHostRemote,
+        request: ReviewRequest,
+        cwd: URL
+    ) async -> (threads: [ReviewThread], complete: Bool) {
+        do {
+            return (try await unresolvedDiscussions(remote: remote, request: request, cwd: cwd), true)
+        } catch {
+            return ([], false)
+        }
     }
 }
 

--- a/Alas/Sources/Integrations/CodeHost/GitLabCLIProvider.swift
+++ b/Alas/Sources/Integrations/CodeHost/GitLabCLIProvider.swift
@@ -126,6 +126,30 @@ struct GitLabCLIProvider: CodeHostProvider {
         return try Self.parseCreateOutput(result.stdout)
     }
 
+    func mergeReviewRequest(
+        _ request: ReviewRequest,
+        method: ReviewMergeMethod,
+        deleteBranch: Bool,
+        cwd: URL
+    ) async throws {
+        var args = ["mr", "merge", "\(request.number)"]
+        switch method {
+        case .squash: args.append("--squash")
+        case .merge: break
+        case .rebase: args.append("--rebase")
+        }
+        if deleteBranch {
+            args.append("--remove-source-branch")
+        }
+        args.append("--yes")
+        args.append(contentsOf: ["-R", request.remote.repositorySlug])
+
+        let result = try await runner.run("glab", args: args, cwd: cwd)
+        guard result.exitCode == 0 else {
+            throw CodeHostProviderError.commandFailed(command: "glab mr merge", stderr: result.stderr)
+        }
+    }
+
     func checks(remote: CodeHostRemote, request: ReviewRequest, cwd: URL) async throws -> [ReviewCheck] {
         let result = try await runner.run(
             "glab",

--- a/Alas/Sources/Integrations/CodeHost/GitLabCLIProvider.swift
+++ b/Alas/Sources/Integrations/CodeHost/GitLabCLIProvider.swift
@@ -141,6 +141,11 @@ struct GitLabCLIProvider: CodeHostProvider {
         if deleteBranch {
             args.append("--remove-source-branch")
         }
+        // Pin the merge to the reviewed head so a push landing between the
+        // snapshot load and the confirmation can't merge an unreviewed commit.
+        if let headSHA = request.headSHA {
+            args.append(contentsOf: ["--sha", headSHA])
+        }
         args.append("--yes")
         args.append(contentsOf: ["-R", request.remote.repositorySlug])
 

--- a/Alas/Sources/Integrations/CodeHost/ReviewLoopState.swift
+++ b/Alas/Sources/Integrations/CodeHost/ReviewLoopState.swift
@@ -247,20 +247,7 @@ final class ReviewLoopState {
             if let request {
                 let checks = try await provider.checks(remote: remote, request: request, cwd: worktreePath)
                 guard isCurrentRefresh(generation) else { return }
-                loadedRequest = ReviewRequest(
-                    remote: request.remote,
-                    number: request.number,
-                    title: request.title,
-                    url: request.url,
-                    state: request.state,
-                    isDraft: request.isDraft,
-                    headRefName: request.headRefName,
-                    baseRefName: request.baseRefName,
-                    reviewDecision: request.reviewDecision,
-                    mergeState: request.mergeState,
-                    checks: checks,
-                    threads: request.threads
-                )
+                loadedRequest = request.withChecks(checks)
             } else {
                 loadedRequest = nil
             }

--- a/Alas/Sources/Integrations/CodeHost/ReviewLoopState.swift
+++ b/Alas/Sources/Integrations/CodeHost/ReviewLoopState.swift
@@ -362,6 +362,28 @@ final class ReviewLoopState {
         }
     }
 
+    func merge(snapshot: ReviewLoopSnapshot) async -> Bool {
+        guard
+            let remote = snapshot.remote,
+            let request = snapshot.reviewRequest,
+            let provider = providerRegistry.provider(for: remote.kind)
+        else { return false }
+
+        lastError = nil
+        do {
+            try await provider.mergeReviewRequest(
+                request,
+                method: .squash,
+                deleteBranch: true,
+                cwd: worktreePath
+            )
+            return true
+        } catch {
+            lastError = Self.describe(error)
+            return false
+        }
+    }
+
     private func isCurrentRefresh(_ generation: Int) -> Bool {
         generation == refreshGeneration
     }

--- a/Alas/Sources/Integrations/CodeHost/ReviewLoopState.swift
+++ b/Alas/Sources/Integrations/CodeHost/ReviewLoopState.swift
@@ -352,12 +352,43 @@ final class ReviewLoopState {
     func merge(snapshot: ReviewLoopSnapshot) async -> Bool {
         guard
             let remote = snapshot.remote,
-            let request = snapshot.reviewRequest,
             let provider = providerRegistry.provider(for: remote.kind)
         else { return false }
 
         lastError = nil
         do {
+            // Re-query the provider immediately before merging so a refresh
+            // race (the generation guard can let the merge-triggered refresh
+            // return without publishing) can't merge on stale checks,
+            // mergeability, review state, or a closed PR. Build a fresh
+            // snapshot from live provider data + the caller-verified local
+            // state and re-run the full merge gate.
+            guard let fresh = try await provider.currentReviewRequest(
+                remote: remote,
+                branch: snapshot.local.branchName,
+                headOwner: snapshot.local.headRemoteOwner,
+                baseBranch: snapshot.local.baseBranch,
+                cwd: worktreePath
+            ) else {
+                lastError = "The review request could not be found."
+                return false
+            }
+            let checks = try await provider.checks(remote: remote, request: fresh, cwd: worktreePath)
+            let freshSnapshot = ReviewLoopSnapshot(
+                local: snapshot.local,
+                remote: remote,
+                reviewRequest: fresh.withChecks(checks),
+                providerAvailable: true,
+                providerAuthenticated: true,
+                providerCapabilities: provider.capabilities,
+                errorMessage: nil
+            )
+            guard ReviewReadinessModel.canMergeReviewRequest(snapshot: freshSnapshot),
+                  let request = freshSnapshot.reviewRequest
+            else {
+                lastError = "Merge is no longer available — the review state changed."
+                return false
+            }
             try await provider.mergeReviewRequest(
                 request,
                 method: .squash,

--- a/Alas/Sources/Integrations/CodeHost/ReviewReadinessModel.swift
+++ b/Alas/Sources/Integrations/CodeHost/ReviewReadinessModel.swift
@@ -295,6 +295,12 @@ struct ReviewReadinessModel: Equatable, Sendable {
               snapshot.local.pushState != .stale,
               !snapshot.local.needsPush
         else { return false }
+        // The local worktree HEAD must be exactly the reviewed PR head. If
+        // another contributor pushed and this worktree hasn't fetched, the
+        // provider reports the new remote head while local refs (and thus
+        // needsPush/upstreamAhead) look clean off the stale local commit —
+        // merging would ship/delete commits never present in the review diff.
+        guard request.headSHA == snapshot.local.headSHA else { return false }
         return snapshot.providerCapabilities.canMerge
             && request.state == .open
             && !request.isDraft

--- a/Alas/Sources/Integrations/CodeHost/ReviewReadinessModel.swift
+++ b/Alas/Sources/Integrations/CodeHost/ReviewReadinessModel.swift
@@ -295,6 +295,13 @@ struct ReviewReadinessModel: Equatable, Sendable {
               snapshot.local.pushState != .stale,
               !snapshot.local.needsPush
         else { return false }
+        // A dirty worktree means in-progress work on this branch that isn't in
+        // any commit (so `needsPush`/`headSHA` still look clean). Merging and
+        // deleting the branch now would strand it — block until it's committed
+        // or cleared.
+        guard !snapshot.local.hasWorkingTreeChanges,
+              !snapshot.local.hasStagedChanges
+        else { return false }
         // The local worktree HEAD must be exactly the reviewed PR head. If
         // another contributor pushed and this worktree hasn't fetched, the
         // provider reports the new remote head while local refs (and thus

--- a/Alas/Sources/Integrations/CodeHost/ReviewReadinessModel.swift
+++ b/Alas/Sources/Integrations/CodeHost/ReviewReadinessModel.swift
@@ -282,6 +282,11 @@ struct ReviewReadinessModel: Equatable, Sendable {
     /// would drop that work and delete the branch.
     static func canMergeReviewRequest(snapshot: ReviewLoopSnapshot) -> Bool {
         guard let request = snapshot.reviewRequest else { return false }
+        // A failed refresh preserves the previous (possibly green) request but
+        // sets `errorMessage`; the checks/mergeability are then stale, so never
+        // merge off an errored snapshot — mirror the drawer, which suppresses
+        // all actions in this state.
+        guard snapshot.errorMessage == nil else { return false }
         guard snapshot.remote != nil,
               snapshot.providerAvailable,
               snapshot.providerAuthenticated

--- a/Alas/Sources/Integrations/CodeHost/ReviewReadinessModel.swift
+++ b/Alas/Sources/Integrations/CodeHost/ReviewReadinessModel.swift
@@ -294,6 +294,7 @@ struct ReviewReadinessModel: Equatable, Sendable {
             && request.state == .open
             && !request.isDraft
             && request.mergeState == .clean
+            && request.reviewDecision != .reviewRequired
             && !request.hasActionableFeedback
             && (request.worstCheckBucket == nil || request.worstCheckBucket == .pass)
     }

--- a/Alas/Sources/Integrations/CodeHost/ReviewReadinessModel.swift
+++ b/Alas/Sources/Integrations/CodeHost/ReviewReadinessModel.swift
@@ -37,17 +37,20 @@ struct ReviewReadinessModel: Equatable, Sendable {
         let title: String
         let isEnabled: Bool
         let isInFlight: Bool
+        let emphasis: Emphasis
 
         init(
             kind: ReviewReadinessActionKind,
             title: String,
             isEnabled: Bool,
-            isInFlight: Bool = false
+            isInFlight: Bool = false,
+            emphasis: Emphasis? = nil
         ) {
             self.kind = kind
             self.title = title
             self.isEnabled = isEnabled
             self.isInFlight = isInFlight
+            self.emphasis = emphasis ?? Self.defaultEmphasis(for: kind)
         }
 
         var id: ReviewReadinessActionKind { kind }
@@ -66,11 +69,11 @@ struct ReviewReadinessModel: Equatable, Sendable {
             }
         }
 
-        var emphasis: Emphasis {
+        static func defaultEmphasis(for kind: ReviewReadinessActionKind) -> Emphasis {
             switch kind {
-            case .pushBranch, .forcePushBranch, .createReviewRequest, .inspectReviewEvidence:
+            case .pushBranch, .forcePushBranch, .createReviewRequest, .inspectReviewEvidence, .merge:
                 .primary
-            case .refresh, .openReviewRequest, .rerunFailedChecks, .openAgentHandoff, .merge:
+            case .refresh, .openReviewRequest, .rerunFailedChecks, .openAgentHandoff:
                 .normal
             }
         }
@@ -151,7 +154,8 @@ struct ReviewReadinessModel: Equatable, Sendable {
                 kind: action.kind,
                 title: action.title,
                 isEnabled: false,
-                isInFlight: action.kind == inFlightAction
+                isInFlight: action.kind == inFlightAction,
+                emphasis: action.emphasis
             )
         }
     }
@@ -249,19 +253,33 @@ struct ReviewReadinessModel: Equatable, Sendable {
             if request.worstCheckBucket == .pending {
                 actions.append(refreshAction)
             }
+            let canMergeNow = Self.canMergeReviewRequest(snapshot: snapshot, request: request)
+            if canMergeNow {
+                actions.append(Action(kind: .merge, title: request.provider.mergeReviewRequestTitle, isEnabled: true))
+            }
             if snapshot.providerCapabilities.canOpenReviewRequest {
                 actions.append(Action(kind: .openReviewRequest, title: request.provider.openReviewRequestTitle, isEnabled: true))
             }
             if request.hasRerunnableFailedCheck, snapshot.providerCapabilities.canRerunFailedChecks {
                 actions.append(Action(kind: .rerunFailedChecks, title: "Rerun", isEnabled: true))
             }
-            if request.worstCheckBucket == .fail || request.hasActionableFeedback {
+            if canMergeNow {
+                actions.append(Action(kind: .inspectReviewEvidence, title: "Review diff", isEnabled: true, emphasis: .normal))
+            } else if request.worstCheckBucket == .fail || request.hasActionableFeedback {
                 actions.append(Action(kind: .inspectReviewEvidence, title: "Inspect", isEnabled: true))
             }
         } else if canCreateReviewRequest(snapshot) {
             actions.append(Action(kind: .createReviewRequest, title: "Create \(requestLabel)", isEnabled: true))
         }
         return actions.isEmpty ? [refreshAction] : actions
+    }
+
+    private static func canMergeReviewRequest(snapshot: ReviewLoopSnapshot, request: ReviewRequest) -> Bool {
+        snapshot.providerCapabilities.canMerge
+            && request.state == .open
+            && !request.isDraft
+            && request.mergeState == .clean
+            && (request.worstCheckBucket == nil || request.worstCheckBucket == .pass)
     }
 
     private static func canCreateReviewRequest(_ snapshot: ReviewLoopSnapshot) -> Bool {

--- a/Alas/Sources/Integrations/CodeHost/ReviewReadinessModel.swift
+++ b/Alas/Sources/Integrations/CodeHost/ReviewReadinessModel.swift
@@ -253,7 +253,7 @@ struct ReviewReadinessModel: Equatable, Sendable {
             if request.worstCheckBucket == .pending {
                 actions.append(refreshAction)
             }
-            let canMergeNow = Self.canMergeReviewRequest(snapshot: snapshot, request: request)
+            let canMergeNow = Self.canMergeReviewRequest(snapshot: snapshot)
             if canMergeNow {
                 actions.append(Action(kind: .merge, title: request.provider.mergeReviewRequestTitle, isEnabled: true))
             }
@@ -274,8 +274,23 @@ struct ReviewReadinessModel: Equatable, Sendable {
         return actions.isEmpty ? [refreshAction] : actions
     }
 
-    private static func canMergeReviewRequest(snapshot: ReviewLoopSnapshot, request: ReviewRequest) -> Bool {
-        snapshot.providerCapabilities.canMerge
+    /// Single source of truth for "can this review request be merged now?".
+    /// Includes the local-sync preconditions (`makeActions` enforces these
+    /// structurally via its else-if chain, but the Inspect-tab button and the
+    /// merge handler reuse this helper directly, so the guards must live here
+    /// too): merging a green PR whose head predates unpushed local commits
+    /// would drop that work and delete the branch.
+    static func canMergeReviewRequest(snapshot: ReviewLoopSnapshot) -> Bool {
+        guard let request = snapshot.reviewRequest else { return false }
+        guard snapshot.remote != nil,
+              snapshot.providerAvailable,
+              snapshot.providerAuthenticated
+        else { return false }
+        guard snapshot.local.pushState != .diverged,
+              snapshot.local.pushState != .stale,
+              !snapshot.local.needsPush
+        else { return false }
+        return snapshot.providerCapabilities.canMerge
             && request.state == .open
             && !request.isDraft
             && request.mergeState == .clean

--- a/Alas/Sources/Integrations/CodeHost/ReviewReadinessModel.swift
+++ b/Alas/Sources/Integrations/CodeHost/ReviewReadinessModel.swift
@@ -306,6 +306,7 @@ struct ReviewReadinessModel: Equatable, Sendable {
             && !request.isDraft
             && request.mergeState == .clean
             && request.reviewDecision != .reviewRequired
+            && request.areThreadsComplete
             && !request.hasActionableFeedback
             && (request.worstCheckBucket == nil || request.worstCheckBucket == .pass)
     }

--- a/Alas/Sources/Integrations/CodeHost/ReviewReadinessModel.swift
+++ b/Alas/Sources/Integrations/CodeHost/ReviewReadinessModel.swift
@@ -294,6 +294,7 @@ struct ReviewReadinessModel: Equatable, Sendable {
             && request.state == .open
             && !request.isDraft
             && request.mergeState == .clean
+            && !request.hasActionableFeedback
             && (request.worstCheckBucket == nil || request.worstCheckBucket == .pass)
     }
 

--- a/Alas/Sources/Right/ChangesPreparationCard.swift
+++ b/Alas/Sources/Right/ChangesPreparationCard.swift
@@ -28,7 +28,7 @@ struct ChangesPreparationCard: View {
             if let reviewAction = model.reviewAction {
                 primaryReviewButton(reviewAction)
             }
-            if model.draftAction != nil || model.reviewRequestAction != nil {
+            if model.draftAction != nil || !model.reviewRequestActions.isEmpty {
                 ViewThatFits(in: .horizontal) {
                     secondaryActionsHorizontal
                     secondaryActionsVertical
@@ -104,8 +104,8 @@ struct ChangesPreparationCard: View {
             if let draftAction = model.draftAction {
                 secondaryDraftButton(draftAction)
             }
-            if let reviewRequestAction = model.reviewRequestAction {
-                secondaryReviewRequestButton(reviewRequestAction)
+            ForEach(model.reviewRequestActions, id: \.kind) { action in
+                secondaryReviewRequestButton(action)
             }
         }
     }
@@ -115,8 +115,8 @@ struct ChangesPreparationCard: View {
             if let draftAction = model.draftAction {
                 secondaryDraftButton(draftAction)
             }
-            if let reviewRequestAction = model.reviewRequestAction {
-                secondaryReviewRequestButton(reviewRequestAction)
+            ForEach(model.reviewRequestActions, id: \.kind) { action in
+                secondaryReviewRequestButton(action)
             }
         }
     }

--- a/Alas/Sources/Right/ChangesPreparationModel.swift
+++ b/Alas/Sources/Right/ChangesPreparationModel.swift
@@ -27,10 +27,10 @@ struct ChangesPreparationModel: Equatable {
 
     let reviewAction: ReviewAction?
     let draftAction: DraftAction?
-    let reviewRequestAction: ReviewRequestAction?
+    let reviewRequestActions: [ReviewRequestAction]
 
     var isVisible: Bool {
-        reviewAction != nil || draftAction != nil || reviewRequestAction != nil
+        reviewAction != nil || draftAction != nil || !reviewRequestActions.isEmpty
     }
 
     init(
@@ -69,54 +69,84 @@ struct ChangesPreparationModel: Equatable {
 
         reviewAction = builtReviewAction
         draftAction = builtDraftAction
-        let builtReviewRequestAction = Self.compactReviewRequestAction(from: readinessActions)
+        let builtActions = Self.compactReviewRequestActions(from: readinessActions)
         let effectiveAheadCommitCount = local?.aheadCommitCount ?? aheadCommitCount
-        if builtReviewRequestAction?.kind == .refresh,
-           builtReviewRequestAction?.isInFlight != true,
-           builtReviewAction == nil,
-           builtDraftAction == nil,
-           effectiveAheadCommitCount == 0 {
-            reviewRequestAction = nil
-        } else if builtReviewRequestAction?.kind == .pushBranch,
-                    builtReviewRequestAction?.isInFlight != true,
-                    builtReviewAction == nil,
-                    builtDraftAction == nil,
-                    Self.pushHasNothingToPush(local: local, aheadCommitCount: effectiveAheadCommitCount) {
-            reviewRequestAction = nil
-        } else {
-            reviewRequestAction = builtReviewRequestAction
-        }
+        reviewRequestActions = Self.applyingHideRules(
+            builtActions,
+            hasReviewAction: builtReviewAction != nil,
+            hasDraftAction: builtDraftAction != nil,
+            local: local,
+            aheadCommitCount: effectiveAheadCommitCount
+        )
     }
 
-    private static func compactReviewRequestAction(
+    private static func compactReviewRequestActions(
+        from actions: [ReviewReadinessModel.Action]
+    ) -> [ReviewRequestAction] {
+        if let merge = actions.first(where: { $0.kind == .merge }) {
+            var pair = [convert(merge)]
+            if let review = actions.first(where: { $0.kind == .inspectReviewEvidence }) {
+                pair.append(convert(review))
+            }
+            return pair
+        }
+        if let single = compactSingleAction(from: actions) {
+            return [single]
+        }
+        return []
+    }
+
+    private static func compactSingleAction(
         from actions: [ReviewReadinessModel.Action]
     ) -> ReviewRequestAction? {
         if let action = actions.first(where: { $0.isInFlight }) {
-            return ReviewRequestAction(
-                kind: action.kind,
-                title: action.title,
-                isEnabled: action.isEnabled,
-                isInFlight: action.isInFlight,
-                iconName: action.iconName,
-                emphasis: action.emphasis
-            )
+            return convert(action)
         }
-
         for kind in compactActionPriority {
             guard let action = actions.first(where: { $0.kind == kind }) else { continue }
-            return ReviewRequestAction(
-                kind: action.kind,
-                title: action.title,
-                isEnabled: action.isEnabled,
-                isInFlight: action.isInFlight,
-                iconName: action.iconName,
-                emphasis: action.emphasis
-            )
+            return convert(action)
         }
         return nil
     }
 
+    private static func convert(_ action: ReviewReadinessModel.Action) -> ReviewRequestAction {
+        ReviewRequestAction(
+            kind: action.kind,
+            title: action.title,
+            isEnabled: action.isEnabled,
+            isInFlight: action.isInFlight,
+            iconName: action.iconName,
+            emphasis: action.emphasis
+        )
+    }
+
+    private static func applyingHideRules(
+        _ actions: [ReviewRequestAction],
+        hasReviewAction: Bool,
+        hasDraftAction: Bool,
+        local: ReviewLoopLocalState?,
+        aheadCommitCount: Int
+    ) -> [ReviewRequestAction] {
+        guard actions.count == 1, let only = actions.first else { return actions }
+        if only.kind == .refresh,
+           !only.isInFlight,
+           !hasReviewAction,
+           !hasDraftAction,
+           aheadCommitCount == 0 {
+            return []
+        }
+        if only.kind == .pushBranch,
+           !only.isInFlight,
+           !hasReviewAction,
+           !hasDraftAction,
+           pushHasNothingToPush(local: local, aheadCommitCount: aheadCommitCount) {
+            return []
+        }
+        return actions
+    }
+
     private static let compactActionPriority: [ReviewReadinessActionKind] = [
+        .merge,
         .createReviewRequest,
         .pushBranch,
         .inspectReviewEvidence,

--- a/Alas/Sources/Right/ChangesPreparationModel.swift
+++ b/Alas/Sources/Right/ChangesPreparationModel.swift
@@ -146,6 +146,8 @@ struct ChangesPreparationModel: Equatable {
     }
 
     private static let compactActionPriority: [ReviewReadinessActionKind] = [
+        // `.merge` is handled by the pair path before the single-action
+        // fallback runs, so this entry is defensive and never actually matches.
         .merge,
         .createReviewRequest,
         .pushBranch,

--- a/Alas/Sources/Right/RightPaneState.swift
+++ b/Alas/Sources/Right/RightPaneState.swift
@@ -871,19 +871,27 @@ final class RightPaneState {
     func performMerge() {
         guard pendingMerge != nil else { return }
         pendingMerge = nil
-        // Re-validate against the CURRENT snapshot, not the one captured when
-        // the dialog opened. The review-loop watcher may have refreshed while
-        // the confirmation was up (a new unpushed commit, checks or review
-        // becoming blocking), which would make the captured snapshot stale.
-        // Merge the fresh snapshot only if it still qualifies.
-        guard let snapshot = reviewLoop.snapshot,
-              ReviewReadinessModel.canMergeReviewRequest(snapshot: snapshot) else {
-            sidebarError = "Merge is no longer available — the branch or review state changed."
+        // Fast reject against the currently-cached snapshot (also re-validates
+        // if the dialog captured a now-stale snapshot).
+        guard let cached = reviewLoop.snapshot,
+              ReviewReadinessModel.canMergeReviewRequest(snapshot: cached) else {
+            sidebarError = Self.mergeUnavailableMessage
             return
         }
         guard reviewLoop.beginAction(.merge) else { return }
         Task { @MainActor in
             defer { reviewLoop.endAction(.merge) }
+            // The cached snapshot can still lag reality: WorktreeWatcher
+            // debounces change events up to ~2s, so a commit created just
+            // before confirming may not have flipped `needsPush` yet. Force a
+            // live refresh (recomputes HEAD/upstream + provider checks and
+            // mergeability), then re-validate and merge the fresh snapshot.
+            await refresh()
+            guard let snapshot = reviewLoop.snapshot,
+                  ReviewReadinessModel.canMergeReviewRequest(snapshot: snapshot) else {
+                sidebarError = Self.mergeUnavailableMessage
+                return
+            }
             if await reviewLoop.merge(snapshot: snapshot) {
                 await refresh()
             } else {
@@ -891,6 +899,9 @@ final class RightPaneState {
             }
         }
     }
+
+    private static let mergeUnavailableMessage =
+        "Merge is no longer available — the branch or review state changed."
 
     func requestCherryPick(sha: String) {
         pendingCherryPickSHA = sha

--- a/Alas/Sources/Right/RightPaneState.swift
+++ b/Alas/Sources/Right/RightPaneState.swift
@@ -874,7 +874,7 @@ final class RightPaneState {
     }
 
     func performMerge() {
-        guard pendingMerge != nil else { return }
+        guard let pending = pendingMerge else { return }
         pendingMerge = nil
         // Fast reject against the currently-cached snapshot (also re-validates
         // if the dialog captured a now-stale snapshot).
@@ -883,6 +883,11 @@ final class RightPaneState {
             mergeError = Self.mergeUnavailableMessage
             return
         }
+        // The PR + head the user actually confirmed. After the forced refresh we
+        // require the fresh snapshot to still be this exact request/head, so a
+        // branch switch mid-dialog can't redirect the merge to a different PR.
+        let confirmedRequestID = pending.reviewRequest?.id
+        let confirmedHeadSHA = pending.reviewRequest?.headSHA
         guard reviewLoop.beginAction(.merge) else { return }
         Task { @MainActor in
             defer { reviewLoop.endAction(.merge) }
@@ -893,7 +898,10 @@ final class RightPaneState {
             // mergeability), then re-validate and merge the fresh snapshot.
             await refresh()
             guard let snapshot = reviewLoop.snapshot,
-                  ReviewReadinessModel.canMergeReviewRequest(snapshot: snapshot) else {
+                  ReviewReadinessModel.canMergeReviewRequest(snapshot: snapshot),
+                  snapshot.reviewRequest?.id == confirmedRequestID,
+                  snapshot.reviewRequest?.headSHA == confirmedHeadSHA
+            else {
                 mergeError = Self.mergeUnavailableMessage
                 return
             }

--- a/Alas/Sources/Right/RightPaneState.swift
+++ b/Alas/Sources/Right/RightPaneState.swift
@@ -905,12 +905,37 @@ final class RightPaneState {
                 mergeError = Self.mergeUnavailableMessage
                 return
             }
+            // The generation-guarded refresh above can be superseded by a
+            // concurrent watcher refresh and return without publishing, leaving
+            // the snapshot stale. Do a final authoritative read straight from
+            // git so a just-created commit or dirty tree can't slip through.
+            guard let reviewedHead = snapshot.reviewRequest?.headSHA,
+                  await localHeadIsCleanlyAt(reviewedHead)
+            else {
+                mergeError = Self.mergeUnavailableMessage
+                return
+            }
             if await reviewLoop.merge(snapshot: snapshot) {
                 await refresh()
             } else {
                 mergeError = reviewLoop.lastError ?? "Merge failed."
             }
         }
+    }
+
+    /// Authoritative, point-in-time check that the worktree HEAD is exactly the
+    /// reviewed head and the tree is clean — read straight from git, not via the
+    /// review-loop refresh (whose generation guard lets a concurrent watcher
+    /// refresh supersede the merge-triggered one without publishing).
+    private func localHeadIsCleanlyAt(_ reviewedHeadSHA: String) async -> Bool {
+        guard let head = try? await Process.git(["rev-parse", "HEAD"], cwd: worktree.path),
+              head.exitCode == 0,
+              head.stdout.trimmingCharacters(in: .whitespacesAndNewlines) == reviewedHeadSHA
+        else { return false }
+        guard let status = try? await Process.git(["status", "--porcelain"], cwd: worktree.path),
+              status.exitCode == 0
+        else { return false }
+        return status.stdout.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
     }
 
     // Merge failures are surfaced via an app-level alert (hosted in RootView

--- a/Alas/Sources/Right/RightPaneState.swift
+++ b/Alas/Sources/Right/RightPaneState.swift
@@ -868,8 +868,7 @@ final class RightPaneState {
         pendingMerge = nil
     }
 
-    func performMerge(appState: AppState) {
-        _ = appState
+    func performMerge() {
         guard let snapshot = pendingMerge else { return }
         pendingMerge = nil
         guard reviewLoop.beginAction(.merge) else { return }

--- a/Alas/Sources/Right/RightPaneState.swift
+++ b/Alas/Sources/Right/RightPaneState.swift
@@ -331,7 +331,7 @@ final class RightPaneState {
             }
         case .merge:
             guard let snapshot = reviewLoop.snapshot,
-                  snapshot.reviewRequest != nil
+                  ReviewReadinessModel.canMergeReviewRequest(snapshot: snapshot)
             else { return }
             pendingMerge = snapshot
         }

--- a/Alas/Sources/Right/RightPaneState.swift
+++ b/Alas/Sources/Right/RightPaneState.swift
@@ -131,6 +131,7 @@ final class RightPaneState {
     var pendingDiscard: PendingDiscard? = nil
     var pendingCherryPickSHA: String? = nil
     var pendingMerge: ReviewLoopSnapshot? = nil
+    var mergeError: String? = nil
 
     /// True while the workspace-level agent invocation is running.
     /// Surfaced in the Conflicts section header as a spinner; the
@@ -868,6 +869,10 @@ final class RightPaneState {
         pendingMerge = nil
     }
 
+    func clearMergeError() {
+        mergeError = nil
+    }
+
     func performMerge() {
         guard pendingMerge != nil else { return }
         pendingMerge = nil
@@ -875,7 +880,7 @@ final class RightPaneState {
         // if the dialog captured a now-stale snapshot).
         guard let cached = reviewLoop.snapshot,
               ReviewReadinessModel.canMergeReviewRequest(snapshot: cached) else {
-            sidebarError = Self.mergeUnavailableMessage
+            mergeError = Self.mergeUnavailableMessage
             return
         }
         guard reviewLoop.beginAction(.merge) else { return }
@@ -889,17 +894,21 @@ final class RightPaneState {
             await refresh()
             guard let snapshot = reviewLoop.snapshot,
                   ReviewReadinessModel.canMergeReviewRequest(snapshot: snapshot) else {
-                sidebarError = Self.mergeUnavailableMessage
+                mergeError = Self.mergeUnavailableMessage
                 return
             }
             if await reviewLoop.merge(snapshot: snapshot) {
                 await refresh()
             } else {
-                sidebarError = reviewLoop.lastError ?? "Merge failed."
+                mergeError = reviewLoop.lastError ?? "Merge failed."
             }
         }
     }
 
+    // Merge failures are surfaced via an app-level alert (hosted in RootView
+    // next to the confirmation dialog) rather than `sidebarError`, because a
+    // merge can be launched from the Review tab in the center pane while the
+    // right pane — the only place `sidebarError` renders — is collapsed.
     private static let mergeUnavailableMessage =
         "Merge is no longer available — the branch or review state changed."
 

--- a/Alas/Sources/Right/RightPaneState.swift
+++ b/Alas/Sources/Right/RightPaneState.swift
@@ -130,6 +130,7 @@ final class RightPaneState {
 
     var pendingDiscard: PendingDiscard? = nil
     var pendingCherryPickSHA: String? = nil
+    var pendingMerge: ReviewLoopSnapshot? = nil
 
     /// True while the workspace-level agent invocation is running.
     /// Surfaced in the Conflicts section header as a spinner; the
@@ -329,7 +330,10 @@ final class RightPaneState {
                 }
             }
         case .merge:
-            break
+            guard let snapshot = reviewLoop.snapshot,
+                  snapshot.reviewRequest != nil
+            else { return }
+            pendingMerge = snapshot
         }
     }
 
@@ -858,6 +862,25 @@ final class RightPaneState {
 
     func cancelDiscard() {
         pendingDiscard = nil
+    }
+
+    func cancelMerge() {
+        pendingMerge = nil
+    }
+
+    func performMerge(appState: AppState) {
+        _ = appState
+        guard let snapshot = pendingMerge else { return }
+        pendingMerge = nil
+        guard reviewLoop.beginAction(.merge) else { return }
+        Task { @MainActor in
+            defer { reviewLoop.endAction(.merge) }
+            if await reviewLoop.merge(snapshot: snapshot) {
+                await refresh()
+            } else {
+                sidebarError = reviewLoop.lastError ?? "Merge failed."
+            }
+        }
     }
 
     func requestCherryPick(sha: String) {

--- a/Alas/Sources/Right/RightPaneState.swift
+++ b/Alas/Sources/Right/RightPaneState.swift
@@ -869,8 +869,18 @@ final class RightPaneState {
     }
 
     func performMerge() {
-        guard let snapshot = pendingMerge else { return }
+        guard pendingMerge != nil else { return }
         pendingMerge = nil
+        // Re-validate against the CURRENT snapshot, not the one captured when
+        // the dialog opened. The review-loop watcher may have refreshed while
+        // the confirmation was up (a new unpushed commit, checks or review
+        // becoming blocking), which would make the captured snapshot stale.
+        // Merge the fresh snapshot only if it still qualifies.
+        guard let snapshot = reviewLoop.snapshot,
+              ReviewReadinessModel.canMergeReviewRequest(snapshot: snapshot) else {
+            sidebarError = "Merge is no longer available — the branch or review state changed."
+            return
+        }
         guard reviewLoop.beginAction(.merge) else { return }
         Task { @MainActor in
             defer { reviewLoop.endAction(.merge) }

--- a/Alas/Sources/Right/RightPaneStore.swift
+++ b/Alas/Sources/Right/RightPaneStore.swift
@@ -130,4 +130,12 @@ final class RightPaneStore {
     func stateReportingMergeError() -> RightPaneState? {
         states.values.first { $0.mergeError != nil }
     }
+
+    /// The first cached state with a pending merge confirmation, if any. The
+    /// confirmation dialog (see RootView) resolves its owning state through
+    /// this rather than the current selection, so switching worktrees while the
+    /// dialog is open can't cancel the wrong state and strand `pendingMerge`.
+    func stateWithPendingMerge() -> RightPaneState? {
+        states.values.first { $0.pendingMerge != nil }
+    }
 }

--- a/Alas/Sources/Right/RightPaneStore.swift
+++ b/Alas/Sources/Right/RightPaneStore.swift
@@ -121,4 +121,13 @@ final class RightPaneStore {
     func activeState(worktreeId: String) -> RightPaneState? {
         states[worktreeId]
     }
+
+    /// The first cached state currently reporting a merge failure, if any.
+    /// Merge errors are surfaced app-wide (see RootView) independent of the
+    /// selected worktree: the async merge can fail after the user has switched
+    /// away from the worktree that initiated it, so the alert must observe the
+    /// originating state rather than the current selection.
+    func stateReportingMergeError() -> RightPaneState? {
+        states.values.first { $0.mergeError != nil }
+    }
 }

--- a/Alas/Sources/Right/RightPaneView.swift
+++ b/Alas/Sources/Right/RightPaneView.swift
@@ -137,6 +137,28 @@ struct RightPaneView: View {
                 Text("Apply this commit to the current branch.")
             }
         )
+        .confirmationDialog(
+            "Merge review request?",
+            isPresented: Binding(
+                get: { rps.pendingMerge != nil },
+                set: { if !$0 { rps.cancelMerge() } }
+            ),
+            titleVisibility: .visible,
+            presenting: rps.pendingMerge
+        ) { snapshot in
+            Button("Merge", role: .destructive) {
+                rps.performMerge(appState: state)
+            }
+            Button("Cancel", role: .cancel) {
+                rps.cancelMerge()
+            }
+        } message: { snapshot in
+            if let request = snapshot.reviewRequest {
+                Text("Squash-merge \(request.displayIdentity) into \(request.baseRefName) and delete the branch.")
+            } else {
+                Text("Squash-merge this review request and delete the branch.")
+            }
+        }
         .sheet(
             isPresented: Binding(
                 get: { rps.pendingParkChanges },

--- a/Alas/Sources/Right/RightPaneView.swift
+++ b/Alas/Sources/Right/RightPaneView.swift
@@ -137,28 +137,6 @@ struct RightPaneView: View {
                 Text("Apply this commit to the current branch.")
             }
         )
-        .confirmationDialog(
-            "Merge review request?",
-            isPresented: Binding(
-                get: { rps.pendingMerge != nil },
-                set: { if !$0 { rps.cancelMerge() } }
-            ),
-            titleVisibility: .visible,
-            presenting: rps.pendingMerge
-        ) { snapshot in
-            Button("Merge", role: .destructive) {
-                rps.performMerge(appState: state)
-            }
-            Button("Cancel", role: .cancel) {
-                rps.cancelMerge()
-            }
-        } message: { snapshot in
-            if let request = snapshot.reviewRequest {
-                Text("Squash-merge \(request.displayIdentity) into \(request.baseRefName) and delete the branch.")
-            } else {
-                Text("Squash-merge this review request and delete the branch.")
-            }
-        }
         .sheet(
             isPresented: Binding(
                 get: { rps.pendingParkChanges },

--- a/AlasTests/Integrations/CodeHostModelsTests.swift
+++ b/AlasTests/Integrations/CodeHostModelsTests.swift
@@ -3,6 +3,42 @@ import Foundation
 @testable import Alas
 
 struct CodeHostModelsTests {
+    @Test func withChecksAndWithThreadsPreserveHeadMetadata() {
+        let request = ReviewRequest(
+            remote: CodeHostRemote(
+                kind: .github,
+                host: "github.com",
+                owner: "mrmans0n",
+                repository: "alas",
+                remoteName: "origin",
+                webURL: URL(string: "https://github.com/mrmans0n/alas")!
+            ),
+            number: 42,
+            title: "PR",
+            url: URL(string: "https://github.com/mrmans0n/alas/pull/42")!,
+            state: .open,
+            isDraft: false,
+            headRefName: "feature/x",
+            baseRefName: "main",
+            headSHA: "reviewed-head",
+            headRepositoryOwner: "mrmans0n",
+            reviewDecision: .approved,
+            mergeState: .clean,
+            checks: [],
+            threads: []
+        )
+        let check = ReviewCheck(id: "c", name: "CI", workflow: "CI", bucket: .pass, detailURL: nil, completedAt: nil)
+
+        let requestWithChecks = request.withChecks([check])
+        #expect(requestWithChecks.headSHA == "reviewed-head")
+        #expect(requestWithChecks.headRepositoryOwner == "mrmans0n")
+        #expect(requestWithChecks.checks == [check])
+
+        let requestWithThreads = request.withThreads([])
+        #expect(requestWithThreads.headSHA == "reviewed-head")
+        #expect(requestWithThreads.headRepositoryOwner == "mrmans0n")
+    }
+
     @Test func checkBucketSeverityOrdersFailuresBeforePendingBeforePass() {
         #expect(ReviewCheckBucket.fail.severity > ReviewCheckBucket.pending.severity)
         #expect(ReviewCheckBucket.pending.severity > ReviewCheckBucket.pass.severity)

--- a/AlasTests/Integrations/CodeHostModelsTests.swift
+++ b/AlasTests/Integrations/CodeHostModelsTests.swift
@@ -37,6 +37,12 @@ struct CodeHostModelsTests {
         let requestWithThreads = request.withThreads([])
         #expect(requestWithThreads.headSHA == "reviewed-head")
         #expect(requestWithThreads.headRepositoryOwner == "mrmans0n")
+        #expect(requestWithThreads.areThreadsComplete)
+
+        // A failed thread load flags the copy incomplete; withChecks preserves it.
+        let incomplete = request.withThreads([], complete: false)
+        #expect(!incomplete.areThreadsComplete)
+        #expect(!incomplete.withChecks([check]).areThreadsComplete)
     }
 
     @Test func checkBucketSeverityOrdersFailuresBeforePendingBeforePass() {

--- a/AlasTests/Integrations/CodeHostProviderTests.swift
+++ b/AlasTests/Integrations/CodeHostProviderTests.swift
@@ -148,6 +148,18 @@ struct CodeHostProviderTests {
         #expect(thread.location?.providerPosition == "github-position-1")
     }
 
+    @Test func githubCapabilitiesAllowMerge() {
+        #expect(CodeHostProviderCapabilities.githubCLI.canMerge)
+    }
+
+    @Test func gitlabCapabilitiesAllowMerge() {
+        #expect(CodeHostProviderCapabilities.gitlabCLI.canMerge)
+    }
+
+    @Test func readOnlyCapabilitiesDisallowMerge() {
+        #expect(!CodeHostProviderCapabilities.readOnly.canMerge)
+    }
+
     @Test func defaultFeedbackEvidenceSynthesizesChangesRequestedWhenThreadsAreMissing() async throws {
         let remote = CodeHostRemote(
             kind: .github,

--- a/AlasTests/Integrations/GitHubCLIProviderTests.swift
+++ b/AlasTests/Integrations/GitHubCLIProviderTests.swift
@@ -1563,6 +1563,27 @@ struct GitHubCLIProviderTests {
         ])
     }
 
+    @Test func mergeReviewRequestRunsSquashDeleteBranch() async throws {
+        let runner = FakeRunner(results: [ProcessResult(exitCode: 0, stdout: "", stderr: "")])
+        let provider = GitHubCLIProvider(runner: runner)
+        let request = Self.makeRequest()
+
+        try await provider.mergeReviewRequest(request, method: .squash, deleteBranch: true, cwd: Self.cwd)
+
+        #expect(await runner.commands == [
+            FakeRunner.Command(
+                executable: "gh",
+                args: [
+                    "pr", "merge", "42",
+                    "--squash",
+                    "--delete-branch",
+                    "-R", "mrmans0n/alas",
+                ],
+                cwd: Self.cwd
+            ),
+        ])
+    }
+
     private static let checkAnnotationsOutput = """
     [
       [

--- a/AlasTests/Integrations/GitHubCLIProviderTests.swift
+++ b/AlasTests/Integrations/GitHubCLIProviderTests.swift
@@ -1563,8 +1563,11 @@ struct GitHubCLIProviderTests {
         ])
     }
 
-    @Test func mergeReviewRequestRunsSquashDeleteBranch() async throws {
-        let runner = FakeRunner(results: [ProcessResult(exitCode: 0, stdout: "", stderr: "")])
+    @Test func mergeReviewRequestSquashesPinsHeadAndDeletesRemoteBranch() async throws {
+        let runner = FakeRunner(results: [
+            ProcessResult(exitCode: 0, stdout: "", stderr: ""),
+            ProcessResult(exitCode: 0, stdout: "", stderr: ""),
+        ])
         let provider = GitHubCLIProvider(runner: runner)
         let request = Self.makeRequest()
 
@@ -1576,7 +1579,35 @@ struct GitHubCLIProviderTests {
                 args: [
                     "pr", "merge", "42",
                     "--squash",
-                    "--delete-branch",
+                    "--match-head-commit", "head-sha-42",
+                    "-R", "mrmans0n/alas",
+                ],
+                cwd: Self.cwd
+            ),
+            FakeRunner.Command(
+                executable: "gh",
+                args: [
+                    "api", "--method", "DELETE",
+                    "repos/mrmans0n/alas/git/refs/heads/feature/github-provider",
+                ],
+                cwd: Self.cwd
+            ),
+        ])
+    }
+
+    @Test func mergeReviewRequestWithoutHeadSHAOmitsPinAndSkipsRemoteDelete() async throws {
+        let runner = FakeRunner(results: [ProcessResult(exitCode: 0, stdout: "", stderr: "")])
+        let provider = GitHubCLIProvider(runner: runner)
+        let request = Self.makeRequest(headSHA: nil)
+
+        try await provider.mergeReviewRequest(request, method: .squash, deleteBranch: false, cwd: Self.cwd)
+
+        #expect(await runner.commands == [
+            FakeRunner.Command(
+                executable: "gh",
+                args: [
+                    "pr", "merge", "42",
+                    "--squash",
                     "-R", "mrmans0n/alas",
                 ],
                 cwd: Self.cwd
@@ -1621,7 +1652,8 @@ struct GitHubCLIProviderTests {
     private static func makeRequest(
         checks: [ReviewCheck] = [],
         threads: [ReviewThread] = [],
-        reviewDecision: ReviewDecision = .approved
+        reviewDecision: ReviewDecision = .approved,
+        headSHA: String? = "head-sha-42"
     ) -> ReviewRequest {
         ReviewRequest(
             remote: Self.remote,
@@ -1632,7 +1664,7 @@ struct GitHubCLIProviderTests {
             isDraft: false,
             headRefName: "feature/github-provider",
             baseRefName: "main",
-            headSHA: "head-sha-42",
+            headSHA: headSHA,
             reviewDecision: reviewDecision,
             mergeState: .clean,
             checks: checks,

--- a/AlasTests/Integrations/GitHubCLIProviderTests.swift
+++ b/AlasTests/Integrations/GitHubCLIProviderTests.swift
@@ -904,6 +904,31 @@ struct GitHubCLIProviderTests {
         #expect(threads.first?.line == nil)
     }
 
+    @Test func hasHooksMergeStateMapsToClean() throws {
+        // GitHub Enterprise reports HAS_HOOKS for a mergeable PR with pre-receive
+        // hooks; it must not fall through to `.unknown` (which would hide Merge).
+        let request = try #require(try GitHubCLIProvider.parsePRList(
+            """
+            [
+              {
+                "number": 42,
+                "title": "GHE PR",
+                "url": "https://github.com/mrmans0n/alas/pull/42",
+                "state": "OPEN",
+                "isDraft": false,
+                "headRefName": "feature/x",
+                "headRepositoryOwner": { "login": "mrmans0n" },
+                "baseRefName": "main",
+                "reviewDecision": "APPROVED",
+                "mergeStateStatus": "HAS_HOOKS"
+              }
+            ]
+            """,
+            remote: Self.remote
+        ))
+        #expect(request.mergeState == .clean)
+    }
+
     @Test func prListFiltersByHeadOwnerWhenProvided() throws {
         let request = try #require(try GitHubCLIProvider.parsePRList(
             """

--- a/AlasTests/Integrations/GitHubCLIProviderTests.swift
+++ b/AlasTests/Integrations/GitHubCLIProviderTests.swift
@@ -1566,6 +1566,7 @@ struct GitHubCLIProviderTests {
     @Test func mergeReviewRequestSquashesPinsHeadAndDeletesRemoteBranch() async throws {
         let runner = FakeRunner(results: [
             ProcessResult(exitCode: 0, stdout: "", stderr: ""),
+            ProcessResult(exitCode: 0, stdout: #"{"state":"MERGED"}"#, stderr: ""),
             ProcessResult(exitCode: 0, stdout: "", stderr: ""),
         ])
         let provider = GitHubCLIProvider(runner: runner)
@@ -1587,10 +1588,54 @@ struct GitHubCLIProviderTests {
             FakeRunner.Command(
                 executable: "gh",
                 args: [
+                    "pr", "view", "42",
+                    "--json", "state",
+                    "-R", "mrmans0n/alas",
+                ],
+                cwd: Self.cwd
+            ),
+            FakeRunner.Command(
+                executable: "gh",
+                args: [
                     "api",
                     "--hostname", "github.com",
                     "--method", "DELETE",
                     "repos/mrmans0n/alas/git/refs/heads/feature/github-provider",
+                ],
+                cwd: Self.cwd
+            ),
+        ])
+    }
+
+    @Test func mergeReviewRequestSkipsBranchDeleteWhenPRIsQueuedNotMerged() async throws {
+        let runner = FakeRunner(results: [
+            ProcessResult(exitCode: 0, stdout: "", stderr: ""),
+            ProcessResult(exitCode: 0, stdout: #"{"state":"OPEN"}"#, stderr: ""),
+        ])
+        let provider = GitHubCLIProvider(runner: runner)
+        let request = Self.makeRequest()
+
+        try await provider.mergeReviewRequest(request, method: .squash, deleteBranch: true, cwd: Self.cwd)
+
+        // `gh pr merge` enqueued the PR (still OPEN), so the head branch must be
+        // left in place for the queue — no DELETE command is issued.
+        #expect(await runner.commands == [
+            FakeRunner.Command(
+                executable: "gh",
+                args: [
+                    "pr", "merge", "42",
+                    "--squash",
+                    "--match-head-commit", "head-sha-42",
+                    "-R", "mrmans0n/alas",
+                ],
+                cwd: Self.cwd
+            ),
+            FakeRunner.Command(
+                executable: "gh",
+                args: [
+                    "pr", "view", "42",
+                    "--json", "state",
+                    "-R", "mrmans0n/alas",
                 ],
                 cwd: Self.cwd
             ),

--- a/AlasTests/Integrations/GitHubCLIProviderTests.swift
+++ b/AlasTests/Integrations/GitHubCLIProviderTests.swift
@@ -1595,6 +1595,29 @@ struct GitHubCLIProviderTests {
         ])
     }
 
+    @Test func mergeReviewRequestForForkedHeadSkipsRemoteDelete() async throws {
+        let runner = FakeRunner(results: [ProcessResult(exitCode: 0, stdout: "", stderr: "")])
+        let provider = GitHubCLIProvider(runner: runner)
+        // Head lives in a fork (owner != base repo owner) — deleting a base-repo
+        // ref by name here could remove an unrelated branch, so cleanup is skipped.
+        let request = Self.makeRequest(headRepositoryOwner: "fork-owner")
+
+        try await provider.mergeReviewRequest(request, method: .squash, deleteBranch: true, cwd: Self.cwd)
+
+        #expect(await runner.commands == [
+            FakeRunner.Command(
+                executable: "gh",
+                args: [
+                    "pr", "merge", "42",
+                    "--squash",
+                    "--match-head-commit", "head-sha-42",
+                    "-R", "mrmans0n/alas",
+                ],
+                cwd: Self.cwd
+            ),
+        ])
+    }
+
     @Test func mergeReviewRequestWithoutHeadSHAOmitsPinAndSkipsRemoteDelete() async throws {
         let runner = FakeRunner(results: [ProcessResult(exitCode: 0, stdout: "", stderr: "")])
         let provider = GitHubCLIProvider(runner: runner)
@@ -1653,7 +1676,8 @@ struct GitHubCLIProviderTests {
         checks: [ReviewCheck] = [],
         threads: [ReviewThread] = [],
         reviewDecision: ReviewDecision = .approved,
-        headSHA: String? = "head-sha-42"
+        headSHA: String? = "head-sha-42",
+        headRepositoryOwner: String? = "mrmans0n"
     ) -> ReviewRequest {
         ReviewRequest(
             remote: Self.remote,
@@ -1665,6 +1689,7 @@ struct GitHubCLIProviderTests {
             headRefName: "feature/github-provider",
             baseRefName: "main",
             headSHA: headSHA,
+            headRepositoryOwner: headRepositoryOwner,
             reviewDecision: reviewDecision,
             mergeState: .clean,
             checks: checks,

--- a/AlasTests/Integrations/GitHubCLIProviderTests.swift
+++ b/AlasTests/Integrations/GitHubCLIProviderTests.swift
@@ -1587,7 +1587,9 @@ struct GitHubCLIProviderTests {
             FakeRunner.Command(
                 executable: "gh",
                 args: [
-                    "api", "--method", "DELETE",
+                    "api",
+                    "--hostname", "github.com",
+                    "--method", "DELETE",
                     "repos/mrmans0n/alas/git/refs/heads/feature/github-provider",
                 ],
                 cwd: Self.cwd

--- a/AlasTests/Integrations/GitHubCLIProviderTests.swift
+++ b/AlasTests/Integrations/GitHubCLIProviderTests.swift
@@ -210,7 +210,7 @@ struct GitHubCLIProviderTests {
                     "--base", "main",
                     "--state", "open",
                     "--limit", "20",
-                    "--json", "number,title,url,state,isDraft,headRefName,headRefOid,headRepositoryOwner,baseRefName,reviewDecision,mergeStateStatus",
+                    "--json", "number,title,url,state,isDraft,headRefName,headRefOid,headRepositoryOwner,headRepository,baseRefName,reviewDecision,mergeStateStatus",
                     "-R", "mrmans0n/alas",
                 ],
                 cwd: Self.cwd
@@ -379,7 +379,7 @@ struct GitHubCLIProviderTests {
         #expect(publishThreads.first?["startSide"] as? String == "RIGHT")
         #expect(commands[2].args == [
             "pr", "view", "42",
-            "--json", "number,title,url,state,isDraft,headRefName,headRefOid,headRepositoryOwner,baseRefName,reviewDecision,mergeStateStatus",
+            "--json", "number,title,url,state,isDraft,headRefName,headRefOid,headRepositoryOwner,headRepository,baseRefName,reviewDecision,mergeStateStatus",
             "-R", "mrmans0n/alas",
         ])
         #expect(result.published == [
@@ -716,13 +716,13 @@ struct GitHubCLIProviderTests {
         #expect(commands[0].args == ["api", "graphql", "--hostname", "github.com", "--input", "-"])
         #expect(commands[1].args == [
             "pr", "view", "42",
-            "--json", "number,title,url,state,isDraft,headRefName,headRefOid,headRepositoryOwner,baseRefName,reviewDecision,mergeStateStatus",
+            "--json", "number,title,url,state,isDraft,headRefName,headRefOid,headRepositoryOwner,headRepository,baseRefName,reviewDecision,mergeStateStatus",
             "-R", "mrmans0n/alas",
         ])
         #expect(commands[3].args == ["api", "graphql", "--hostname", "github.com", "--input", "-"])
         #expect(commands[4].args == [
             "pr", "view", "42",
-            "--json", "number,title,url,state,isDraft,headRefName,headRefOid,headRepositoryOwner,baseRefName,reviewDecision,mergeStateStatus",
+            "--json", "number,title,url,state,isDraft,headRefName,headRefOid,headRepositoryOwner,headRepository,baseRefName,reviewDecision,mergeStateStatus",
             "-R", "mrmans0n/alas",
         ])
         #expect(commands[0].stdin?.contains("addPullRequestReviewThreadReply") == true)
@@ -770,7 +770,7 @@ struct GitHubCLIProviderTests {
         #expect(commands.count == 2)
         #expect(commands[0].args == [
             "pr", "view", "42",
-            "--json", "number,title,url,state,isDraft,headRefName,headRefOid,headRepositoryOwner,baseRefName,reviewDecision,mergeStateStatus",
+            "--json", "number,title,url,state,isDraft,headRefName,headRefOid,headRepositoryOwner,headRepository,baseRefName,reviewDecision,mergeStateStatus",
             "-R", "github.enterprise.example.com/platform/alas",
         ])
         #expect(commands[1].args.prefix(3) == ["api", "graphql", "--hostname"])
@@ -1667,6 +1667,30 @@ struct GitHubCLIProviderTests {
         ])
     }
 
+    @Test func mergeReviewRequestForSameOwnerForkSkipsRemoteDelete() async throws {
+        let runner = FakeRunner(results: [ProcessResult(exitCode: 0, stdout: "", stderr: "")])
+        let provider = GitHubCLIProvider(runner: runner)
+        // Head lives in a fork under the SAME owner but a different repo name
+        // (`mrmans0n/alas-fork`). Owner matches the base repo, but the branch is
+        // not in it — deleting `mrmans0n/alas`'s same-named branch would be wrong.
+        let request = Self.makeRequest(headRepositoryName: "alas-fork")
+
+        try await provider.mergeReviewRequest(request, method: .squash, deleteBranch: true, cwd: Self.cwd)
+
+        #expect(await runner.commands == [
+            FakeRunner.Command(
+                executable: "gh",
+                args: [
+                    "pr", "merge", "42",
+                    "--squash",
+                    "--match-head-commit", "head-sha-42",
+                    "-R", "mrmans0n/alas",
+                ],
+                cwd: Self.cwd
+            ),
+        ])
+    }
+
     @Test func mergeReviewRequestForForkedHeadSkipsRemoteDelete() async throws {
         let runner = FakeRunner(results: [ProcessResult(exitCode: 0, stdout: "", stderr: "")])
         let provider = GitHubCLIProvider(runner: runner)
@@ -1749,7 +1773,8 @@ struct GitHubCLIProviderTests {
         threads: [ReviewThread] = [],
         reviewDecision: ReviewDecision = .approved,
         headSHA: String? = "head-sha-42",
-        headRepositoryOwner: String? = "mrmans0n"
+        headRepositoryOwner: String? = "mrmans0n",
+        headRepositoryName: String? = "alas"
     ) -> ReviewRequest {
         ReviewRequest(
             remote: Self.remote,
@@ -1762,6 +1787,7 @@ struct GitHubCLIProviderTests {
             baseRefName: "main",
             headSHA: headSHA,
             headRepositoryOwner: headRepositoryOwner,
+            headRepositoryName: headRepositoryName,
             reviewDecision: reviewDecision,
             mergeState: .clean,
             checks: checks,

--- a/AlasTests/Integrations/GitLabCLIProviderTests.swift
+++ b/AlasTests/Integrations/GitLabCLIProviderTests.swift
@@ -1779,6 +1779,7 @@ struct GitLabCLIProviderTests {
                     "mr", "merge", "42",
                     "--squash",
                     "--remove-source-branch",
+                    "--sha", "head123",
                     "--yes",
                     "-R", "platform/mobile/alas",
                 ],

--- a/AlasTests/Integrations/GitLabCLIProviderTests.swift
+++ b/AlasTests/Integrations/GitLabCLIProviderTests.swift
@@ -1763,6 +1763,30 @@ struct GitLabCLIProviderTests {
         #expect(args.contains("--draft"))
     }
 
+    @Test func mergeReviewRequestRunsSquashRemoveSourceBranch() async throws {
+        let runner = FakeRunner(results: [
+            ProcessResult(exitCode: 0, stdout: "", stderr: ""),
+        ])
+        let provider = GitLabCLIProvider(runner: runner)
+        let request = Self.makeRequest()
+
+        try await provider.mergeReviewRequest(request, method: .squash, deleteBranch: true, cwd: Self.cwd)
+
+        #expect(await runner.commands == [
+            FakeRunner.Command(
+                executable: "glab",
+                args: [
+                    "mr", "merge", "42",
+                    "--squash",
+                    "--remove-source-branch",
+                    "--yes",
+                    "-R", "platform/mobile/alas",
+                ],
+                cwd: Self.cwd
+            ),
+        ])
+    }
+
     private static let discussionsWithPositionOutput = """
     [
       { "id": "disc-1", "resolved": false, "notes": [

--- a/AlasTests/Integrations/ReviewLoopDrawerTests.swift
+++ b/AlasTests/Integrations/ReviewLoopDrawerTests.swift
@@ -54,7 +54,8 @@ struct ReviewLoopDrawerTests {
             canSubmitReview: true,
             canFetchAnnotations: false,
             canEditComment: true,
-            canDeleteComment: true
+            canDeleteComment: true,
+            canMerge: true
         )
         let model = ReviewReadinessModel(
             snapshot: Self.makeSnapshot(remote: remote, reviewRequest: nil, providerCapabilities: capabilities),

--- a/AlasTests/Integrations/ReviewLoopStateTests.swift
+++ b/AlasTests/Integrations/ReviewLoopStateTests.swift
@@ -527,6 +527,51 @@ struct ReviewLoopStateTests {
         ])
     }
 
+    @Test func mergeInvokesProviderWithSquashAndDeleteBranch() async throws {
+        let remote = Self.makeRemote()
+        let provider = FakeCodeHostProvider(
+            kind: .github,
+            request: Self.makeReviewRequest(remote: remote, checks: [])
+        )
+        let state = ReviewLoopState(
+            worktreePath: URL(fileURLWithPath: "/tmp/alas-review-loop"),
+            baseBranch: "main",
+            providerRegistry: CodeHostProviderRegistry(providers: [.github: provider])
+        )
+
+        await state.refresh(local: Self.makeLocal(needsPush: false), remotes: [Self.makeGitHubRemote()])
+        let snapshot = try #require(state.snapshot)
+
+        let ok = await state.merge(snapshot: snapshot)
+
+        #expect(ok)
+        #expect(provider.mergeRequestCalls == [
+            FakeCodeHostProvider.MergeRequestCall(number: 42, method: .squash, deleteBranch: true),
+        ])
+    }
+
+    @Test func mergeReturnsFalseAndRecordsErrorOnFailure() async throws {
+        let remote = Self.makeRemote()
+        let provider = FakeCodeHostProvider(
+            kind: .github,
+            request: Self.makeReviewRequest(remote: remote, checks: [])
+        )
+        provider.mergeError = CodeHostProviderError.commandFailed(command: "gh pr merge", stderr: "boom")
+        let state = ReviewLoopState(
+            worktreePath: URL(fileURLWithPath: "/tmp/alas-review-loop"),
+            baseBranch: "main",
+            providerRegistry: CodeHostProviderRegistry(providers: [.github: provider])
+        )
+
+        await state.refresh(local: Self.makeLocal(needsPush: false), remotes: [Self.makeGitHubRemote()])
+        let snapshot = try #require(state.snapshot)
+
+        let ok = await state.merge(snapshot: snapshot)
+
+        #expect(!ok)
+        #expect(state.lastError != nil)
+    }
+
     @Test func overlappingRefreshIgnoresOlderResult() async throws {
         let remote = Self.makeRemote()
         let slowRequest = Self.makeReviewRequest(
@@ -972,6 +1017,12 @@ private final class FakeCodeHostProvider: CodeHostProvider, @unchecked Sendable 
         let requestNumber: Int?
     }
 
+    struct MergeRequestCall: Equatable {
+        let number: Int
+        let method: ReviewMergeMethod
+        let deleteBranch: Bool
+    }
+
     let kind: CodeHostKind
     var available: Bool
     var authenticated: Bool
@@ -983,8 +1034,10 @@ private final class FakeCodeHostProvider: CodeHostProvider, @unchecked Sendable 
     var checksError: Error?
     var createError: Error?
     var rerunError: Error?
+    var mergeError: Error?
     var createdReviewRequests: [CreatedReviewRequest] = []
     var rerunFailedChecksRequests: [RerunFailedChecksRequest] = []
+    var mergeRequestCalls: [MergeRequestCall] = []
 
     init(
         kind: CodeHostKind,
@@ -1073,6 +1126,20 @@ private final class FakeCodeHostProvider: CodeHostProvider, @unchecked Sendable 
             branch: branch,
             headSHA: headSHA,
             requestNumber: request?.number
+        ))
+    }
+
+    func mergeReviewRequest(
+        _ request: ReviewRequest,
+        method: ReviewMergeMethod,
+        deleteBranch: Bool,
+        cwd: URL
+    ) async throws {
+        if let mergeError { throw mergeError }
+        mergeRequestCalls.append(MergeRequestCall(
+            number: request.number,
+            method: method,
+            deleteBranch: deleteBranch
         ))
     }
 }

--- a/AlasTests/Integrations/ReviewLoopStateTests.swift
+++ b/AlasTests/Integrations/ReviewLoopStateTests.swift
@@ -500,7 +500,8 @@ struct ReviewLoopStateTests {
         let remote = Self.makeRemote()
         let provider = FakeCodeHostProvider(
             kind: .github,
-            request: Self.makeReviewRequest(remote: remote, checks: [])
+            capabilities: .githubCLI,
+            request: Self.makeMergeableReviewRequest(remote: remote)
         )
         let state = ReviewLoopState(
             worktreePath: URL(fileURLWithPath: "/tmp/alas-review-loop"),
@@ -558,11 +559,24 @@ struct ReviewLoopStateTests {
         ])
     }
 
+    // A fully-mergeable request whose head matches `makeLocal`'s default SHA.
+    private static func makeMergeableReviewRequest(remote: CodeHostRemote) -> ReviewRequest {
+        makeReviewRequest(
+            remote: remote,
+            headSHA: "abc123",
+            headRepositoryOwner: "mrmans0n",
+            reviewDecision: .approved,
+            includeActionableThread: false,
+            checks: []
+        )
+    }
+
     @Test func mergeInvokesProviderWithSquashAndDeleteBranch() async throws {
         let remote = Self.makeRemote()
         let provider = FakeCodeHostProvider(
             kind: .github,
-            request: Self.makeReviewRequest(remote: remote, checks: [])
+            capabilities: .githubCLI,
+            request: Self.makeMergeableReviewRequest(remote: remote)
         )
         let state = ReviewLoopState(
             worktreePath: URL(fileURLWithPath: "/tmp/alas-review-loop"),
@@ -585,7 +599,8 @@ struct ReviewLoopStateTests {
         let remote = Self.makeRemote()
         let provider = FakeCodeHostProvider(
             kind: .github,
-            request: Self.makeReviewRequest(remote: remote, checks: [])
+            capabilities: .githubCLI,
+            request: Self.makeMergeableReviewRequest(remote: remote)
         )
         provider.mergeError = CodeHostProviderError.commandFailed(command: "gh pr merge", stderr: "boom")
         let state = ReviewLoopState(
@@ -600,6 +615,41 @@ struct ReviewLoopStateTests {
         let ok = await state.merge(snapshot: snapshot)
 
         #expect(!ok)
+        #expect(state.lastError != nil)
+    }
+
+    @Test func mergeReValidatesFreshProviderStateAndAbortsWhenNoLongerMergeable() async throws {
+        // Refresh sees a mergeable request; then the fresh re-query at merge
+        // time returns a non-mergeable one (review now required + actionable
+        // feedback). The merge must abort without invoking the provider merge.
+        let remote = Self.makeRemote()
+        let provider = FakeCodeHostProvider(
+            kind: .github,
+            capabilities: .githubCLI,
+            request: Self.makeMergeableReviewRequest(remote: remote)
+        )
+        let state = ReviewLoopState(
+            worktreePath: URL(fileURLWithPath: "/tmp/alas-review-loop"),
+            baseBranch: "main",
+            providerRegistry: CodeHostProviderRegistry(providers: [.github: provider])
+        )
+        await state.refresh(local: Self.makeLocal(needsPush: false), remotes: [Self.makeGitHubRemote()])
+        let snapshot = try #require(state.snapshot)
+
+        // Remote state changed since the (still green) snapshot.
+        provider.request = Self.makeReviewRequest(
+            remote: remote,
+            headSHA: "abc123",
+            headRepositoryOwner: "mrmans0n",
+            reviewDecision: .reviewRequired,
+            includeActionableThread: true,
+            checks: []
+        )
+
+        let ok = await state.merge(snapshot: snapshot)
+
+        #expect(!ok)
+        #expect(provider.mergeRequestCalls.isEmpty)
         #expect(state.lastError != nil)
     }
 
@@ -982,6 +1032,8 @@ struct ReviewLoopStateTests {
         headRefName: String = "feature/review-loop",
         headSHA: String? = nil,
         headRepositoryOwner: String? = nil,
+        reviewDecision: ReviewDecision = .reviewRequired,
+        includeActionableThread: Bool = true,
         checks: [ReviewCheck]
     ) -> ReviewRequest {
         ReviewRequest(
@@ -995,10 +1047,10 @@ struct ReviewLoopStateTests {
             baseRefName: "main",
             headSHA: headSHA,
             headRepositoryOwner: headRepositoryOwner,
-            reviewDecision: .reviewRequired,
+            reviewDecision: reviewDecision,
             mergeState: .clean,
             checks: checks,
-            threads: [
+            threads: includeActionableThread ? [
                 ReviewThread(
                     id: "thread-1",
                     path: nil,
@@ -1025,7 +1077,7 @@ struct ReviewLoopStateTests {
                     viewerCanReply: false,
                     url: nil
                 ),
-            ]
+            ] : []
         )
     }
 }
@@ -1059,6 +1111,7 @@ private final class FakeCodeHostProvider: CodeHostProvider, @unchecked Sendable 
     }
 
     let kind: CodeHostKind
+    let capabilities: CodeHostProviderCapabilities
     var available: Bool
     var authenticated: Bool
     var request: ReviewRequest?
@@ -1076,6 +1129,7 @@ private final class FakeCodeHostProvider: CodeHostProvider, @unchecked Sendable 
 
     init(
         kind: CodeHostKind,
+        capabilities: CodeHostProviderCapabilities = .readOnly,
         available: Bool = true,
         authenticated: Bool = true,
         request: ReviewRequest? = nil,
@@ -1088,6 +1142,7 @@ private final class FakeCodeHostProvider: CodeHostProvider, @unchecked Sendable 
         rerunError: Error? = nil
     ) {
         self.kind = kind
+        self.capabilities = capabilities
         self.available = available
         self.authenticated = authenticated
         self.request = request

--- a/AlasTests/Integrations/ReviewLoopStateTests.swift
+++ b/AlasTests/Integrations/ReviewLoopStateTests.swift
@@ -213,6 +213,37 @@ struct ReviewLoopStateTests {
         #expect(state.snapshot?.reviewRequest?.checks == [check])
     }
 
+    @Test func refreshPreservesHeadSHAAndRepositoryOwnerForMerge() async throws {
+        let remote = Self.makeRemote()
+        let request = Self.makeReviewRequest(
+            remote: remote,
+            headSHA: "reviewed-head-sha",
+            headRepositoryOwner: "mrmans0n",
+            checks: []
+        )
+        let check = ReviewCheck(
+            id: "ci-build",
+            name: "Build",
+            workflow: "CI",
+            bucket: .pass,
+            detailURL: nil,
+            completedAt: nil
+        )
+        let provider = FakeCodeHostProvider(kind: .github, request: request, checks: [check])
+        let state = ReviewLoopState(
+            worktreePath: URL(fileURLWithPath: "/tmp/alas-review-loop"),
+            baseBranch: "main",
+            providerRegistry: CodeHostProviderRegistry(providers: [.github: provider])
+        )
+
+        await state.refresh(local: Self.makeLocal(needsPush: false), remotes: [Self.makeGitHubRemote()])
+
+        // The refresh reattaches checks; it must not drop the head metadata the
+        // merge path relies on for `--match-head-commit` and branch cleanup.
+        #expect(state.snapshot?.reviewRequest?.headSHA == "reviewed-head-sha")
+        #expect(state.snapshot?.reviewRequest?.headRepositoryOwner == "mrmans0n")
+    }
+
     @Test func providerErrorPreservesPreviousRequestFactsForSameBranchAndRemote() async throws {
         let remote = Self.makeRemote()
         let request = Self.makeReviewRequest(remote: remote, checks: [])
@@ -949,6 +980,8 @@ struct ReviewLoopStateTests {
         remote: CodeHostRemote,
         number: Int = 42,
         headRefName: String = "feature/review-loop",
+        headSHA: String? = nil,
+        headRepositoryOwner: String? = nil,
         checks: [ReviewCheck]
     ) -> ReviewRequest {
         ReviewRequest(
@@ -960,6 +993,8 @@ struct ReviewLoopStateTests {
             isDraft: false,
             headRefName: headRefName,
             baseRefName: "main",
+            headSHA: headSHA,
+            headRepositoryOwner: headRepositoryOwner,
             reviewDecision: .reviewRequired,
             mergeState: .clean,
             checks: checks,

--- a/AlasTests/Integrations/ReviewReadinessModelTests.swift
+++ b/AlasTests/Integrations/ReviewReadinessModelTests.swift
@@ -305,6 +305,27 @@ struct ReviewReadinessModelTests {
         #expect(!model.actions.map(\.kind).contains(.merge))
     }
 
+    @Test func actionableFeedbackSuppressesMergeOnGreenPR() {
+        // Green + mergeable, but a reviewer has requested changes. Even in a
+        // repo that doesn't enforce reviews as a merge block (mergeState stays
+        // clean), in-app merge must not bypass the open feedback.
+        let request = Self.makeReviewRequest(
+            reviewDecision: .changesRequested,
+            mergeState: .clean,
+            checks: [Self.makeCheck(bucket: .pass)]
+        )
+        let snapshot = Self.makeSnapshot(reviewRequest: request)
+        let model = ReviewReadinessModel(
+            snapshot: snapshot,
+            lastError: nil,
+            canOpenAgentHandoff: false
+        )
+        #expect(!model.actions.map(\.kind).contains(.merge))
+        #expect(!ReviewReadinessModel.canMergeReviewRequest(snapshot: snapshot))
+        // Falls through to the feedback-inspection affordance instead.
+        #expect(model.actions.contains(Action(kind: .inspectReviewEvidence, title: "Inspect", isEnabled: true)))
+    }
+
     @Test func unpushedLocalCommitsSuppressMergeEvenWhenPRIsGreen() {
         let request = Self.makeReviewRequest(
             reviewDecision: .approved,

--- a/AlasTests/Integrations/ReviewReadinessModelTests.swift
+++ b/AlasTests/Integrations/ReviewReadinessModelTests.swift
@@ -305,6 +305,30 @@ struct ReviewReadinessModelTests {
         #expect(!model.actions.map(\.kind).contains(.merge))
     }
 
+    @Test func dirtyWorktreeSuppressesMergeOnGreenPR() {
+        // Staged/working-tree changes with no commit: needsPush stays false and
+        // the head SHAs still match, but there's in-progress work on the branch.
+        // Merging + deleting the branch would strand it, so the gate must block.
+        let request = Self.makeReviewRequest(
+            reviewDecision: .approved,
+            mergeState: .clean,
+            checks: [Self.makeCheck(bucket: .pass)]
+        )
+        for local in [
+            Self.makeLocal(hasWorkingTreeChanges: true),
+            Self.makeLocal(hasStagedChanges: true),
+        ] {
+            let snapshot = Self.makeSnapshot(local: local, reviewRequest: request)
+            let model = ReviewReadinessModel(
+                snapshot: snapshot,
+                lastError: nil,
+                canOpenAgentHandoff: false
+            )
+            #expect(!model.actions.map(\.kind).contains(.merge))
+            #expect(!ReviewReadinessModel.canMergeReviewRequest(snapshot: snapshot))
+        }
+    }
+
     @Test func incompleteFeedbackSuppressesMergeOnGreenPR() {
         // Loading review threads failed, so `threads` may be missing actionable
         // feedback. The gate must fail closed rather than treat the empty list
@@ -548,14 +572,16 @@ struct ReviewReadinessModelTests {
         baseBranch: String = "main",
         needsPush: Bool = false,
         upstreamAheadCommitCount: Int = 0,
-        aheadCommitCount: Int = 1
+        aheadCommitCount: Int = 1,
+        hasWorkingTreeChanges: Bool = false,
+        hasStagedChanges: Bool = false
     ) -> ReviewLoopLocalState {
         ReviewLoopLocalState(
             branchName: branchName,
             headSHA: "abc123",
             baseBranch: baseBranch,
-            hasWorkingTreeChanges: false,
-            hasStagedChanges: false,
+            hasWorkingTreeChanges: hasWorkingTreeChanges,
+            hasStagedChanges: hasStagedChanges,
             aheadCommitCount: aheadCommitCount,
             hasUpstream: true,
             upstreamAheadCommitCount: upstreamAheadCommitCount,

--- a/AlasTests/Integrations/ReviewReadinessModelTests.swift
+++ b/AlasTests/Integrations/ReviewReadinessModelTests.swift
@@ -305,6 +305,28 @@ struct ReviewReadinessModelTests {
         #expect(!model.actions.map(\.kind).contains(.merge))
     }
 
+    @Test func erroredSnapshotSuppressesMergeEvenWithGreenStaleRequest() {
+        // A failed refresh preserves the last (green) request but marks the
+        // snapshot with an errorMessage; its checks/mergeability are stale, so
+        // the gate (shared by the Inspect button and performMerge) must refuse.
+        let request = Self.makeReviewRequest(
+            reviewDecision: .approved,
+            mergeState: .clean,
+            checks: [Self.makeCheck(bucket: .pass)]
+        )
+        let snapshot = Self.makeSnapshot(
+            reviewRequest: request,
+            errorMessage: "gh pr view failed"
+        )
+        let model = ReviewReadinessModel(
+            snapshot: snapshot,
+            lastError: nil,
+            canOpenAgentHandoff: false
+        )
+        #expect(!model.actions.map(\.kind).contains(.merge))
+        #expect(!ReviewReadinessModel.canMergeReviewRequest(snapshot: snapshot))
+    }
+
     @Test func reviewRequiredSuppressesMergeOnGreenPR() {
         // Host requires a review that hasn't happened (e.g. GitLab approvalsLeft
         // > 0 maps to .reviewRequired while mergeState stays clean). Offering

--- a/AlasTests/Integrations/ReviewReadinessModelTests.swift
+++ b/AlasTests/Integrations/ReviewReadinessModelTests.swift
@@ -256,7 +256,7 @@ struct ReviewReadinessModelTests {
         #expect(!model.actions.map(\.kind).contains(.openAgentHandoff))
     }
 
-    @Test func approvedCleanRequestIsReadyWithoutMergeAction() {
+    @Test func approvedCleanRequestExposesMergeAction() {
         let request = Self.makeReviewRequest(reviewDecision: .approved, mergeState: .clean)
         let model = ReviewReadinessModel(
             snapshot: Self.makeSnapshot(reviewRequest: request),
@@ -266,8 +266,66 @@ struct ReviewReadinessModelTests {
 
         #expect(model.chips.map(\ReviewReadinessModel.Chip.title) == ["Ready"])
         #expect(model.chips.map(\ReviewReadinessModel.Chip.tone) == [.success])
-        #expect(!model.actions.map(\ReviewReadinessModel.Action.kind).contains(.merge))
+        #expect(model.actions.map(\ReviewReadinessModel.Action.kind).contains(.merge))
         #expect(!model.actions.map(\ReviewReadinessModel.Action.kind).contains(.refresh))
+    }
+
+    @Test func greenMergeableRequestExposesMergeAndReviewDiff() {
+        let request = Self.makeReviewRequest(
+            reviewDecision: .approved,
+            mergeState: .clean,
+            checks: [Self.makeCheck(bucket: .pass)]
+        )
+        let model = ReviewReadinessModel(
+            snapshot: Self.makeSnapshot(reviewRequest: request),
+            lastError: nil,
+            canOpenAgentHandoff: false
+        )
+
+        let merge = model.actions.first { $0.kind == .merge }
+        #expect(merge?.title == "Merge PR")
+        #expect(merge?.emphasis == .primary)
+        #expect(merge?.isEnabled == true)
+
+        let review = model.actions.first { $0.kind == .inspectReviewEvidence }
+        #expect(review?.title == "Review diff")
+        #expect(review?.emphasis == .normal)
+    }
+
+    @Test func blockedRequestDoesNotExposeMerge() {
+        let request = Self.makeReviewRequest(
+            mergeState: .blocked,
+            checks: [Self.makeCheck(bucket: .pass)]
+        )
+        let model = ReviewReadinessModel(
+            snapshot: Self.makeSnapshot(reviewRequest: request),
+            lastError: nil,
+            canOpenAgentHandoff: false
+        )
+        #expect(!model.actions.map(\.kind).contains(.merge))
+    }
+
+    @Test func pendingChecksDoNotExposeMerge() {
+        let request = Self.makeReviewRequest(
+            mergeState: .clean,
+            checks: [Self.makeCheck(bucket: .pending)]
+        )
+        let model = ReviewReadinessModel(
+            snapshot: Self.makeSnapshot(reviewRequest: request),
+            lastError: nil,
+            canOpenAgentHandoff: false
+        )
+        #expect(!model.actions.map(\.kind).contains(.merge))
+    }
+
+    @Test func mergeHiddenWhenCapabilityMissing() {
+        let request = Self.makeReviewRequest(mergeState: .clean, checks: [Self.makeCheck(bucket: .pass)])
+        let model = ReviewReadinessModel(
+            snapshot: Self.makeSnapshot(reviewRequest: request, providerCapabilities: .readOnly),
+            lastError: nil,
+            canOpenAgentHandoff: false
+        )
+        #expect(!model.actions.map(\.kind).contains(.merge))
     }
 
     @Test func pendingChecksKeepRefreshAsFallback() {

--- a/AlasTests/Integrations/ReviewReadinessModelTests.swift
+++ b/AlasTests/Integrations/ReviewReadinessModelTests.swift
@@ -305,6 +305,31 @@ struct ReviewReadinessModelTests {
         #expect(!model.actions.map(\.kind).contains(.merge))
     }
 
+    @Test func mismatchedLocalAndReviewedHeadSuppressesMerge() {
+        // The host reports a newer PR head (e.g. a teammate pushed) than the
+        // local worktree HEAD; local refs still look in-sync because they're
+        // stale. Merging would ship/delete a head that isn't in the review
+        // diff, so the gate must refuse until local matches the reviewed head.
+        let request = Self.makeReviewRequest(
+            reviewDecision: .approved,
+            mergeState: .clean,
+            checks: [Self.makeCheck(bucket: .pass)],
+            headSHA: "remote-head-xyz"
+        )
+        let snapshot = Self.makeSnapshot(
+            local: Self.makeLocal(),
+            reviewRequest: request
+        )
+        let model = ReviewReadinessModel(
+            snapshot: snapshot,
+            lastError: nil,
+            canOpenAgentHandoff: false
+        )
+        #expect(snapshot.local.headSHA == "abc123")
+        #expect(!model.actions.map(\.kind).contains(.merge))
+        #expect(!ReviewReadinessModel.canMergeReviewRequest(snapshot: snapshot))
+    }
+
     @Test func erroredSnapshotSuppressesMergeEvenWithGreenStaleRequest() {
         // A failed refresh preserves the last (green) request but marks the
         // snapshot with an errorMessage; its checks/mergeability are stale, so
@@ -534,7 +559,8 @@ struct ReviewReadinessModelTests {
         reviewDecision: ReviewDecision = .reviewRequired,
         mergeState: ReviewMergeState = .blocked,
         checks: [ReviewCheck] = [],
-        threads: [ReviewThread] = []
+        threads: [ReviewThread] = [],
+        headSHA: String? = "abc123"
     ) -> ReviewRequest {
         ReviewRequest(
             remote: remote,
@@ -545,6 +571,7 @@ struct ReviewReadinessModelTests {
             isDraft: false,
             headRefName: "feature/review-loop",
             baseRefName: "main",
+            headSHA: headSHA,
             reviewDecision: reviewDecision,
             mergeState: mergeState,
             checks: checks,

--- a/AlasTests/Integrations/ReviewReadinessModelTests.swift
+++ b/AlasTests/Integrations/ReviewReadinessModelTests.swift
@@ -305,6 +305,26 @@ struct ReviewReadinessModelTests {
         #expect(!model.actions.map(\.kind).contains(.merge))
     }
 
+    @Test func incompleteFeedbackSuppressesMergeOnGreenPR() {
+        // Loading review threads failed, so `threads` may be missing actionable
+        // feedback. The gate must fail closed rather than treat the empty list
+        // as "no feedback" and expose Merge.
+        let request = Self.makeReviewRequest(
+            reviewDecision: .approved,
+            mergeState: .clean,
+            checks: [Self.makeCheck(bucket: .pass)],
+            areThreadsComplete: false
+        )
+        let snapshot = Self.makeSnapshot(reviewRequest: request)
+        let model = ReviewReadinessModel(
+            snapshot: snapshot,
+            lastError: nil,
+            canOpenAgentHandoff: false
+        )
+        #expect(!model.actions.map(\.kind).contains(.merge))
+        #expect(!ReviewReadinessModel.canMergeReviewRequest(snapshot: snapshot))
+    }
+
     @Test func mismatchedLocalAndReviewedHeadSuppressesMerge() {
         // The host reports a newer PR head (e.g. a teammate pushed) than the
         // local worktree HEAD; local refs still look in-sync because they're
@@ -560,7 +580,8 @@ struct ReviewReadinessModelTests {
         mergeState: ReviewMergeState = .blocked,
         checks: [ReviewCheck] = [],
         threads: [ReviewThread] = [],
-        headSHA: String? = "abc123"
+        headSHA: String? = "abc123",
+        areThreadsComplete: Bool = true
     ) -> ReviewRequest {
         ReviewRequest(
             remote: remote,
@@ -575,7 +596,8 @@ struct ReviewReadinessModelTests {
             reviewDecision: reviewDecision,
             mergeState: mergeState,
             checks: checks,
-            threads: threads
+            threads: threads,
+            areThreadsComplete: areThreadsComplete
         )
     }
 

--- a/AlasTests/Integrations/ReviewReadinessModelTests.swift
+++ b/AlasTests/Integrations/ReviewReadinessModelTests.swift
@@ -305,6 +305,27 @@ struct ReviewReadinessModelTests {
         #expect(!model.actions.map(\.kind).contains(.merge))
     }
 
+    @Test func reviewRequiredSuppressesMergeOnGreenPR() {
+        // Host requires a review that hasn't happened (e.g. GitLab approvalsLeft
+        // > 0 maps to .reviewRequired while mergeState stays clean). Offering
+        // Merge here is a false affordance the host would reject and bypasses a
+        // pending review policy. A no-policy solo PR is .unknown, not
+        // .reviewRequired, so it is unaffected.
+        let request = Self.makeReviewRequest(
+            reviewDecision: .reviewRequired,
+            mergeState: .clean,
+            checks: [Self.makeCheck(bucket: .pass)]
+        )
+        let snapshot = Self.makeSnapshot(reviewRequest: request)
+        let model = ReviewReadinessModel(
+            snapshot: snapshot,
+            lastError: nil,
+            canOpenAgentHandoff: false
+        )
+        #expect(!model.actions.map(\.kind).contains(.merge))
+        #expect(!ReviewReadinessModel.canMergeReviewRequest(snapshot: snapshot))
+    }
+
     @Test func actionableFeedbackSuppressesMergeOnGreenPR() {
         // Green + mergeable, but a reviewer has requested changes. Even in a
         // repo that doesn't enforce reviews as a merge block (mergeState stays

--- a/AlasTests/Integrations/ReviewReadinessModelTests.swift
+++ b/AlasTests/Integrations/ReviewReadinessModelTests.swift
@@ -137,7 +137,8 @@ struct ReviewReadinessModelTests {
             canSubmitReview: true,
             canFetchAnnotations: false,
             canEditComment: true,
-            canDeleteComment: true
+            canDeleteComment: true,
+            canMerge: true
         )
 
         let model = ReviewReadinessModel(

--- a/AlasTests/Integrations/ReviewReadinessModelTests.swift
+++ b/AlasTests/Integrations/ReviewReadinessModelTests.swift
@@ -305,6 +305,29 @@ struct ReviewReadinessModelTests {
         #expect(!model.actions.map(\.kind).contains(.merge))
     }
 
+    @Test func unpushedLocalCommitsSuppressMergeEvenWhenPRIsGreen() {
+        let request = Self.makeReviewRequest(
+            reviewDecision: .approved,
+            mergeState: .clean,
+            checks: [Self.makeCheck(bucket: .pass)]
+        )
+        let snapshot = Self.makeSnapshot(
+            local: Self.makeLocal(needsPush: true),
+            reviewRequest: request
+        )
+        let model = ReviewReadinessModel(
+            snapshot: snapshot,
+            lastError: nil,
+            canOpenAgentHandoff: false
+        )
+        // Local head is ahead of what the green PR reviewed — merging now
+        // would ship the old head and delete the branch, dropping the
+        // unpushed commits. The gate (shared with the Inspect-tab button and
+        // the merge handler) must suppress merge here.
+        #expect(!model.actions.map(\.kind).contains(.merge))
+        #expect(!ReviewReadinessModel.canMergeReviewRequest(snapshot: snapshot))
+    }
+
     @Test func pendingChecksDoNotExposeMerge() {
         let request = Self.makeReviewRequest(
             mergeState: .clean,

--- a/AlasTests/ReviewChangesModelsTests.swift
+++ b/AlasTests/ReviewChangesModelsTests.swift
@@ -305,7 +305,7 @@ struct ReviewChangesModelsTests {
 
         #expect(model.reviewAction == nil)
         #expect(model.draftAction == nil)
-        #expect(model.reviewRequestAction == nil)
+        #expect(model.reviewRequestActions.isEmpty)
         #expect(!model.isVisible)
     }
 
@@ -324,7 +324,7 @@ struct ReviewChangesModelsTests {
 
         #expect(model.reviewAction == nil)
         #expect(model.draftAction == nil)
-        let request = try #require(model.reviewRequestAction)
+        let request = try #require(model.reviewRequestActions.first)
         #expect(request.kind == .pushBranch)
         #expect(request.title == "Push")
         #expect(model.isVisible)
@@ -356,7 +356,7 @@ struct ReviewChangesModelsTests {
 
         #expect(model.reviewAction == nil)
         #expect(model.draftAction == nil)
-        let request = try #require(model.reviewRequestAction)
+        let request = try #require(model.reviewRequestActions.first)
         #expect(request.kind == .pushBranch)
         #expect(request.title == "Push")
         #expect(model.isVisible)
@@ -388,7 +388,7 @@ struct ReviewChangesModelsTests {
 
         #expect(model.reviewAction == nil)
         #expect(model.draftAction == nil)
-        #expect(model.reviewRequestAction == nil)
+        #expect(model.reviewRequestActions.isEmpty)
         #expect(!model.isVisible)
     }
 
@@ -418,7 +418,7 @@ struct ReviewChangesModelsTests {
 
         #expect(model.reviewAction == nil)
         #expect(model.draftAction == nil)
-        let request = try #require(model.reviewRequestAction)
+        let request = try #require(model.reviewRequestActions.first)
         #expect(request.kind == .pushBranch)
         #expect(request.title == "Push")
         #expect(model.isVisible)
@@ -447,7 +447,7 @@ struct ReviewChangesModelsTests {
 
         #expect(model.reviewAction == nil)
         #expect(model.draftAction == nil)
-        #expect(model.reviewRequestAction == nil)
+        #expect(model.reviewRequestActions.isEmpty)
         #expect(!model.isVisible)
     }
 
@@ -466,7 +466,7 @@ struct ReviewChangesModelsTests {
 
         #expect(model.reviewAction == nil)
         #expect(model.draftAction == nil)
-        let request = try #require(model.reviewRequestAction)
+        let request = try #require(model.reviewRequestActions.first)
         #expect(request.kind == .pushBranch)
         #expect(request.title == "Push")
         #expect(model.isVisible)
@@ -494,7 +494,7 @@ struct ReviewChangesModelsTests {
 
         #expect(model.draftAction == nil)
         #expect(model.reviewAction == nil)
-        #expect(model.reviewRequestAction == nil)
+        #expect(model.reviewRequestActions.isEmpty)
         #expect(!model.isVisible)
     }
 
@@ -563,7 +563,7 @@ struct ReviewChangesModelsTests {
             readinessActions: actions
         )
 
-        let reviewRequest = try #require(model.reviewRequestAction)
+        let reviewRequest = try #require(model.reviewRequestActions.first)
         #expect(reviewRequest.kind == .createReviewRequest)
         #expect(reviewRequest.title == "Create PR")
     }
@@ -582,7 +582,7 @@ struct ReviewChangesModelsTests {
             readinessActions: actions
         )
 
-        let reviewRequest = try #require(model.reviewRequestAction)
+        let reviewRequest = try #require(model.reviewRequestActions.first)
         #expect(reviewRequest.kind == .pushBranch)
         #expect(reviewRequest.title == "Push")
     }
@@ -604,7 +604,7 @@ struct ReviewChangesModelsTests {
             readinessActions: actions
         )
 
-        let reviewRequest = try #require(model.reviewRequestAction)
+        let reviewRequest = try #require(model.reviewRequestActions.first)
         #expect(reviewRequest.kind == .pushBranch)
         #expect(!reviewRequest.isEnabled)
         #expect(reviewRequest.isInFlight)
@@ -632,7 +632,7 @@ struct ReviewChangesModelsTests {
             readinessActions: actions
         )
 
-        let reviewRequest = try #require(model.reviewRequestAction)
+        let reviewRequest = try #require(model.reviewRequestActions.first)
         #expect(reviewRequest.kind == .rerunFailedChecks)
         #expect(reviewRequest.title == "Rerun")
         #expect(reviewRequest.isInFlight)
@@ -653,8 +653,8 @@ struct ReviewChangesModelsTests {
         )
 
         #expect(model.reviewAction?.title == "Review current changes")
-        #expect(model.reviewRequestAction?.kind == .createReviewRequest)
-        #expect(model.reviewRequestAction?.title == "Create PR")
+        #expect(model.reviewRequestActions.first?.kind == .createReviewRequest)
+        #expect(model.reviewRequestActions.first?.title == "Create PR")
     }
 
     @Test func preparationModelDoesNotShowStandaloneRefreshWhileReadinessLoads() {
@@ -671,7 +671,7 @@ struct ReviewChangesModelsTests {
             readinessActions: loadingReadiness.actions
         )
 
-        #expect(model.reviewRequestAction == nil)
+        #expect(model.reviewRequestActions.isEmpty)
         #expect(!model.isVisible)
     }
 
@@ -690,7 +690,7 @@ struct ReviewChangesModelsTests {
         )
 
         #expect(model.isVisible)
-        let action = try #require(model.reviewRequestAction)
+        let action = try #require(model.reviewRequestActions.first)
         #expect(action.kind == .refresh)
     }
 
@@ -711,7 +711,7 @@ struct ReviewChangesModelsTests {
             readinessActions: readiness.actions
         )
 
-        let action = try #require(model.reviewRequestAction)
+        let action = try #require(model.reviewRequestActions.first)
         #expect(action.kind == .inspectReviewEvidence)
         #expect(action.title == "Inspect")
     }

--- a/AlasTests/Right/ChangesPreparationModelTests.swift
+++ b/AlasTests/Right/ChangesPreparationModelTests.swift
@@ -1,0 +1,51 @@
+import Foundation
+import Testing
+@testable import Alas
+
+struct ChangesPreparationModelTests {
+    private typealias Action = ReviewReadinessModel.Action
+
+    private func makeModel(actions: [Action], aheadCommitCount: Int = 1) -> ChangesPreparationModel {
+        ChangesPreparationModel(
+            changes: [],
+            hasDraft: false,
+            draftNonEmpty: false,
+            aheadCommitCount: aheadCommitCount,
+            local: nil,
+            readinessActions: actions
+        )
+    }
+
+    @Test func greenMergePairsMergeAndReviewDiff() {
+        let model = makeModel(actions: [
+            Action(kind: .merge, title: "Merge PR", isEnabled: true),
+            Action(kind: .openReviewRequest, title: "Open PR", isEnabled: true),
+            Action(kind: .inspectReviewEvidence, title: "Review diff", isEnabled: true, emphasis: .normal),
+        ])
+
+        #expect(model.reviewRequestActions.map(\.kind) == [.merge, .inspectReviewEvidence])
+        #expect(model.reviewRequestActions.first?.title == "Merge PR")
+        #expect(model.reviewRequestActions.first?.emphasis == .primary)
+        #expect(model.reviewRequestActions.last?.title == "Review diff")
+        #expect(!model.reviewRequestActions.map(\.kind).contains(.openReviewRequest))
+        #expect(model.isVisible)
+    }
+
+    @Test func nonGreenCollapsesToSingleAction() {
+        let model = makeModel(actions: [
+            Action(kind: .openReviewRequest, title: "Open PR", isEnabled: true),
+            Action(kind: .inspectReviewEvidence, title: "Inspect", isEnabled: true),
+        ])
+
+        #expect(model.reviewRequestActions.map(\.kind) == [.inspectReviewEvidence])
+    }
+
+    @Test func refreshOnlyHiddenWhenNothingAhead() {
+        let model = makeModel(
+            actions: [Action(kind: .refresh, title: "Refresh", isEnabled: true)],
+            aheadCommitCount: 0
+        )
+        #expect(model.reviewRequestActions.isEmpty)
+        #expect(!model.isVisible)
+    }
+}

--- a/AlasTests/RightPaneStateReviewLoopPushTests.swift
+++ b/AlasTests/RightPaneStateReviewLoopPushTests.swift
@@ -99,6 +99,30 @@ struct RightPaneStateReviewLoopPushTests {
         #expect(state.pendingMerge == nil)
     }
 
+    @Test func performMergeRevalidatesAgainstCurrentSnapshot() {
+        let worktreeId = "wt-merge-revalidate"
+        defer { try? FileManager.default.removeItem(at: Paths.tabsFile(forWorktreeId: worktreeId)) }
+        let worktree = Worktree(
+            id: worktreeId,
+            projectId: "p1",
+            name: "feature/review-loop",
+            branch: "feature/review-loop",
+            path: URL(fileURLWithPath: "/tmp/repo"),
+            status: .clean,
+            lastActivity: Date(timeIntervalSince1970: 0)
+        )
+        let state = RightPaneState(worktree: worktree, baseBranch: "main")
+        // A merge was queued via the dialog, but the current snapshot no longer
+        // qualifies (default snapshot is unpushed / has no mergeable request).
+        state.pendingMerge = Self.makeSnapshot()
+        state.reviewLoop.setSnapshotForTests(Self.makeSnapshot())
+
+        state.performMerge()
+
+        #expect(state.pendingMerge == nil)
+        #expect(state.sidebarError != nil)
+    }
+
     @Test func normalPushArgumentsDoNotForce() {
         let snapshot = Self.makeSnapshot()
 

--- a/AlasTests/RightPaneStateReviewLoopPushTests.swift
+++ b/AlasTests/RightPaneStateReviewLoopPushTests.swift
@@ -120,7 +120,7 @@ struct RightPaneStateReviewLoopPushTests {
         state.performMerge()
 
         #expect(state.pendingMerge == nil)
-        #expect(state.sidebarError != nil)
+        #expect(state.mergeError != nil)
     }
 
     @Test func normalPushArgumentsDoNotForce() {

--- a/AlasTests/RightPaneStateReviewLoopPushTests.swift
+++ b/AlasTests/RightPaneStateReviewLoopPushTests.swift
@@ -78,6 +78,27 @@ struct RightPaneStateReviewLoopPushTests {
         #expect(appState.tabs.tabs(forWorktree: worktreeId).isEmpty)
     }
 
+    @Test func mergeActionNoopsWithoutReviewRequest() {
+        let worktreeId = "wt-merge-no-request"
+        defer { try? FileManager.default.removeItem(at: Paths.tabsFile(forWorktreeId: worktreeId)) }
+        let appState = AppState(store: MemoryStore())
+        let worktree = Worktree(
+            id: worktreeId,
+            projectId: "p1",
+            name: "feature/review-loop",
+            branch: "feature/review-loop",
+            path: URL(fileURLWithPath: "/tmp/repo"),
+            status: .clean,
+            lastActivity: Date(timeIntervalSince1970: 0)
+        )
+        let state = RightPaneState(worktree: worktree, baseBranch: "main")
+        state.reviewLoop.setSnapshotForTests(Self.makeSnapshot())
+
+        state.handleReviewReadinessAction(.merge, appState: appState)
+
+        #expect(state.pendingMerge == nil)
+    }
+
     @Test func normalPushArgumentsDoNotForce() {
         let snapshot = Self.makeSnapshot()
 


### PR DESCRIPTION
## Summary

Adds a first-class in-app **Merge PR** action so a green, mergeable PR can be shipped without leaving Alas for the browser.

On a PR whose CI is green (`worstCheckBucket` nil/`.pass`) and that GitHub reports mergeable (`mergeState == .clean`), open + non-draft:

- The **Changes-tab Prepare card** surfaces a pair: **Merge PR** (primary) + **Review diff** (secondary), and demotes "Open PR (browser)" to the drawer. The pair rides the existing `ViewThatFits`, so it stacks vertically on a narrow pane.
- The **Inspect (Review PR) tab** toolbar gains a **Merge** button next to "Open in browser".
- Merging squash-merges the PR and deletes the remote branch in one shot — `gh pr merge --squash --delete-branch` (GitHub), `glab mr merge --squash --remove-source-branch --yes` (GitLab) — behind a confirmation dialog.

The merge gate is identical in the readiness model and the Inspect-tab button, so the card and the button never disagree about when merge is offered.

## Design decisions

- **Method:** fixed **squash** for now (no picker).
- **Gate:** `canMerge && state == .open && !isDraft && mergeState == .clean && (worstCheckBucket == nil || == .pass)`. Because we trust GitHub's `.clean`, branch-protection repos that require an approval report `.blocked` and simply don't show Merge — honest, since we couldn't merge anyway.
- **Confirmation:** required before merging (squash-merge + branch delete is the one irreversible step). The dialog is hosted app-wide (RootView), so the Inspect-tab Merge button works even when the right pane is collapsed.

## Out of scope (intentional)

- Approve affordance (approval stays the Review-tab verdict sheet).
- Merge-method choice.
- Local branch / worktree teardown after merge (stays the existing worktree-removal flow).

## Testing

- New coverage: provider capability presets, `gh pr merge`/`glab mr merge` arg assertions, readiness gate matrix (emit on green; hidden on blocked/pending/no-capability), Prepare-card pairing, `ReviewLoopState.merge` success/failure, and the `.merge` handler no-op guard.
- Full app build clean; the touched Swift Testing suites (75 tests incl. all merge cases) pass. Two pre-existing unrelated `ACPSessionTests` failures reproduce on the clean tree.

## Follow-ups (deferred, minor)

- Merge failures triggered from the Inspect tab aren't yet surfaced there (`sidebarError` renders only in the Changes tab).
- After-merge "branch merged — remove worktree?" prompt (the local-cleanup fast-follow).
