### PR TITLE
feat(review): support GitHub merge queues

### DIFF
--- a/Alas/Sources/App/RootView.swift
+++ b/Alas/Sources/App/RootView.swift
@@ -208,11 +208,7 @@ struct RootView: View {
                 state.rightPaneStore.stateWithPendingMerge()?.cancelMerge()
             }
         } message: { snapshot in
-            if let request = snapshot.reviewRequest {
-                Text("Squash-merge \(request.displayIdentity) into \(request.baseRefName) and delete the branch.")
-            } else {
-                Text("Squash-merge this review request and delete the branch.")
-            }
+            Text(RightPaneState.mergeConfirmationMessage(for: snapshot.reviewRequest))
         }
         .alert(
             "Merge failed",
@@ -224,6 +220,20 @@ struct RootView: View {
         ) { _ in
             Button("OK", role: .cancel) {
                 state.rightPaneStore.stateReportingMergeError()?.clearMergeError()
+            }
+        } message: { message in
+            Text(message)
+        }
+        .alert(
+            "Added to merge queue",
+            isPresented: Binding(
+                get: { state.rightPaneStore.stateReportingMergeQueuedMessage() != nil },
+                set: { if !$0 { state.rightPaneStore.stateReportingMergeQueuedMessage()?.clearMergeQueuedMessage() } }
+            ),
+            presenting: state.rightPaneStore.stateReportingMergeQueuedMessage()?.mergeQueuedMessage
+        ) { _ in
+            Button("OK", role: .cancel) {
+                state.rightPaneStore.stateReportingMergeQueuedMessage()?.clearMergeQueuedMessage()
             }
         } message: { message in
             Text(message)

--- a/Alas/Sources/Integrations/CodeHost/CodeHostModels.swift
+++ b/Alas/Sources/Integrations/CodeHost/CodeHostModels.swift
@@ -43,6 +43,11 @@ enum CodeHostKind: String, Codable, Equatable, Sendable {
     var mergeReviewRequestTitle: String {
         "Merge \(reviewRequestLabel)"
     }
+
+    func mergeReviewRequestTitle(for request: ReviewRequest) -> String {
+        if request.isMergeQueueEnabled { return "Add to queue" }
+        return mergeReviewRequestTitle
+    }
 }
 
 struct CodeHostRemote: Equatable, Sendable {
@@ -399,6 +404,8 @@ struct ReviewRequest: Identifiable, Equatable, Sendable {
     /// be missing actionable feedback. The merge gate fails closed on this: we
     /// must not offer merge while we can't confirm there are no open threads.
     let areThreadsComplete: Bool
+    let isMergeQueueEnabled: Bool
+    let isInMergeQueue: Bool
 
     var provider: CodeHostKind { remote.kind }
 
@@ -420,7 +427,9 @@ struct ReviewRequest: Identifiable, Equatable, Sendable {
         mergeState: ReviewMergeState,
         checks: [ReviewCheck],
         threads: [ReviewThread],
-        areThreadsComplete: Bool = true
+        areThreadsComplete: Bool = true,
+        isMergeQueueEnabled: Bool = false,
+        isInMergeQueue: Bool = false
     ) {
         self.remote = remote
         self.number = number
@@ -438,6 +447,8 @@ struct ReviewRequest: Identifiable, Equatable, Sendable {
         self.checks = checks
         self.threads = threads
         self.areThreadsComplete = areThreadsComplete
+        self.isMergeQueueEnabled = isMergeQueueEnabled
+        self.isInMergeQueue = isInMergeQueue
     }
 
     var worstCheckBucket: ReviewCheckBucket? {
@@ -469,7 +480,9 @@ struct ReviewRequest: Identifiable, Equatable, Sendable {
             mergeState: mergeState,
             checks: checks,
             threads: threads,
-            areThreadsComplete: areThreadsComplete
+            areThreadsComplete: areThreadsComplete,
+            isMergeQueueEnabled: isMergeQueueEnabled,
+            isInMergeQueue: isInMergeQueue
         )
     }
 
@@ -494,7 +507,9 @@ struct ReviewRequest: Identifiable, Equatable, Sendable {
             mergeState: mergeState,
             checks: checks,
             threads: threads,
-            areThreadsComplete: complete
+            areThreadsComplete: complete,
+            isMergeQueueEnabled: isMergeQueueEnabled,
+            isInMergeQueue: isInMergeQueue
         )
     }
 

--- a/Alas/Sources/Integrations/CodeHost/CodeHostModels.swift
+++ b/Alas/Sources/Integrations/CodeHost/CodeHostModels.swift
@@ -513,6 +513,29 @@ struct ReviewRequest: Identifiable, Equatable, Sendable {
         )
     }
 
+    func withMergeQueue(isEnabled: Bool, isInQueue: Bool) -> ReviewRequest {
+        ReviewRequest(
+            remote: remote,
+            number: number,
+            title: title,
+            url: url,
+            state: state,
+            isDraft: isDraft,
+            headRefName: headRefName,
+            baseRefName: baseRefName,
+            headSHA: headSHA,
+            headRepositoryOwner: headRepositoryOwner,
+            headRepositoryName: headRepositoryName,
+            reviewDecision: reviewDecision,
+            mergeState: mergeState,
+            checks: checks,
+            threads: threads,
+            areThreadsComplete: areThreadsComplete,
+            isMergeQueueEnabled: isEnabled,
+            isInMergeQueue: isInQueue
+        )
+    }
+
     static func placeholder(remote: CodeHostRemote, number: Int) -> ReviewRequest {
         ReviewRequest(
             remote: remote,

--- a/Alas/Sources/Integrations/CodeHost/GitHubCLIProvider.swift
+++ b/Alas/Sources/Integrations/CodeHost/GitHubCLIProvider.swift
@@ -106,6 +106,17 @@ struct GitHubCLIProvider: CodeHostProvider {
     }
     """
 
+    static let mergeQueueMetadataQuery = """
+    query($owner: String!, $name: String!, $number: Int!) {
+      repository(owner: $owner, name: $name) {
+        pullRequest(number: $number) {
+          isMergeQueueEnabled
+          isInMergeQueue
+        }
+      }
+    }
+    """
+
     static let addPullRequestReviewThreadReplyMutation = """
     mutation($threadId: ID!, $body: String!) {
       addPullRequestReviewThreadReply(input: {pullRequestReviewThreadId: $threadId, body: $body}) {
@@ -289,8 +300,13 @@ struct GitHubCLIProvider: CodeHostProvider {
         guard let request = try Self.parsePRList(result.stdout, remote: remote, headOwner: headOwner) else {
             return nil
         }
-        let loadedThreads = await threadsWithCompleteness(remote: remote, request: request, cwd: cwd)
-        return request.withThreads(loadedThreads.threads, complete: loadedThreads.complete)
+        let queueMetadata = await mergeQueueMetadata(remote: remote, number: request.number, cwd: cwd)
+        let enrichedRequest = request.withMergeQueue(
+            isEnabled: queueMetadata.isMergeQueueEnabled,
+            isInQueue: queueMetadata.isInMergeQueue
+        )
+        let loadedThreads = await threadsWithCompleteness(remote: remote, request: enrichedRequest, cwd: cwd)
+        return enrichedRequest.withThreads(loadedThreads.threads, complete: loadedThreads.complete)
     }
 
     /// Loads review threads, reporting whether the fetch succeeded. A failure
@@ -305,6 +321,34 @@ struct GitHubCLIProvider: CodeHostProvider {
             return (try await reviewThreads(remote: remote, request: request, cwd: cwd), true)
         } catch {
             return ([], false)
+        }
+    }
+
+    private func mergeQueueMetadata(remote: CodeHostRemote, number: Int, cwd: URL) async -> PullRequestQueueMetadata {
+        do {
+            let result = try await runner.run(
+                "gh",
+                args: [
+                    "api", "graphql",
+                    "--hostname", remote.host,
+                    "-f", "owner=\(remote.owner)",
+                    "-f", "name=\(remote.repository)",
+                    "-F", "number=\(number)",
+                    "-f", "query=\(Self.mergeQueueMetadataQuery)",
+                ],
+                cwd: cwd
+            )
+            guard result.exitCode == 0 else { return .unavailable }
+            let response = try JSONDecoder().decode(
+                GitHubQueueMetadataResponse.self,
+                from: Data(result.stdout.utf8)
+            )
+            return PullRequestQueueMetadata(
+                isMergeQueueEnabled: response.data.repository.pullRequest.isMergeQueueEnabled,
+                isInMergeQueue: response.data.repository.pullRequest.isInMergeQueue
+            )
+        } catch {
+            return .unavailable
         }
     }
 
@@ -711,8 +755,13 @@ struct GitHubCLIProvider: CodeHostProvider {
             throw CodeHostProviderError.commandFailed(command: "gh pr view", stderr: result.stderr)
         }
         let request = try Self.parsePRView(result.stdout, remote: remote)
-        let loadedThreads = await threadsWithCompleteness(remote: remote, request: request, cwd: cwd)
-        return request.withThreads(loadedThreads.threads, complete: loadedThreads.complete)
+        let queueMetadata = await mergeQueueMetadata(remote: remote, number: request.number, cwd: cwd)
+        let enrichedRequest = request.withMergeQueue(
+            isEnabled: queueMetadata.isMergeQueueEnabled,
+            isInQueue: queueMetadata.isInMergeQueue
+        )
+        let loadedThreads = await threadsWithCompleteness(remote: remote, request: enrichedRequest, cwd: cwd)
+        return enrichedRequest.withThreads(loadedThreads.threads, complete: loadedThreads.complete)
     }
 
     func mutateReviewThread(_ mutation: ProviderThreadMutation) async throws -> ProviderThreadMutationResult {
@@ -845,10 +894,12 @@ struct GitHubCLIProvider: CodeHostProvider {
         cwd: URL
     ) async throws {
         var args = ["pr", "merge", "\(request.number)"]
-        switch method {
-        case .squash: args.append("--squash")
-        case .merge: args.append("--merge")
-        case .rebase: args.append("--rebase")
+        if !request.isMergeQueueEnabled {
+            switch method {
+            case .squash: args.append("--squash")
+            case .merge: args.append("--merge")
+            case .rebase: args.append("--rebase")
+            }
         }
         // Pin the merge to the reviewed head so a push that lands between the
         // snapshot load and the confirmation can't merge an unreviewed commit.
@@ -1822,6 +1873,33 @@ private struct HeadRepositoryOwner: Decodable {
     private enum CodingKeys: String, CodingKey {
         case login
     }
+}
+
+private struct PullRequestQueueMetadata: Equatable, Sendable {
+    let isMergeQueueEnabled: Bool
+    let isInMergeQueue: Bool
+
+    static let unavailable = PullRequestQueueMetadata(
+        isMergeQueueEnabled: false,
+        isInMergeQueue: false
+    )
+}
+
+private struct GitHubQueueMetadataResponse: Decodable {
+    struct DataPayload: Decodable {
+        struct Repository: Decodable {
+            struct PullRequest: Decodable {
+                let isMergeQueueEnabled: Bool
+                let isInMergeQueue: Bool
+            }
+
+            let pullRequest: PullRequest
+        }
+
+        let repository: Repository
+    }
+
+    let data: DataPayload
 }
 
 private struct CheckItem: Decodable {

--- a/Alas/Sources/Integrations/CodeHost/ReviewLoopState.swift
+++ b/Alas/Sources/Integrations/CodeHost/ReviewLoopState.swift
@@ -6,6 +6,11 @@ struct ReviewLoopRefreshAttempt: Equatable, Sendable {
     fileprivate let generation: Int
 }
 
+enum ReviewMergeOutcome: Equatable, Sendable {
+    case merged
+    case queued
+}
+
 @Observable
 @MainActor
 final class ReviewLoopState {
@@ -352,11 +357,11 @@ final class ReviewLoopState {
         }
     }
 
-    func merge(snapshot: ReviewLoopSnapshot) async -> Bool {
+    func merge(snapshot: ReviewLoopSnapshot) async -> ReviewMergeOutcome? {
         guard
             let remote = snapshot.remote,
             let provider = providerRegistry.provider(for: remote.kind)
-        else { return false }
+        else { return nil }
 
         lastError = nil
         do {
@@ -374,7 +379,7 @@ final class ReviewLoopState {
                 cwd: worktreePath
             ) else {
                 lastError = "The review request could not be found."
-                return false
+                return nil
             }
             let checks = try await provider.checks(remote: remote, request: fresh, cwd: worktreePath)
             let freshSnapshot = ReviewLoopSnapshot(
@@ -390,7 +395,7 @@ final class ReviewLoopState {
                   let request = freshSnapshot.reviewRequest
             else {
                 lastError = "Merge is no longer available — the review state changed."
-                return false
+                return nil
             }
             try await provider.mergeReviewRequest(
                 request,
@@ -398,10 +403,10 @@ final class ReviewLoopState {
                 deleteBranch: true,
                 cwd: worktreePath
             )
-            return true
+            return request.isMergeQueueEnabled ? .queued : .merged
         } catch {
             lastError = Self.describe(error)
-            return false
+            return nil
         }
     }
 

--- a/Alas/Sources/Integrations/CodeHost/ReviewReadinessModel.swift
+++ b/Alas/Sources/Integrations/CodeHost/ReviewReadinessModel.swift
@@ -254,8 +254,11 @@ struct ReviewReadinessModel: Equatable, Sendable {
                 actions.append(refreshAction)
             }
             let canMergeNow = Self.canMergeReviewRequest(snapshot: snapshot)
+            let isQueued = request.isMergeQueueEnabled && request.isInMergeQueue
             if canMergeNow {
-                actions.append(Action(kind: .merge, title: request.provider.mergeReviewRequestTitle, isEnabled: true))
+                actions.append(Action(kind: .merge, title: request.provider.mergeReviewRequestTitle(for: request), isEnabled: true))
+            } else if isQueued {
+                actions.append(Action(kind: .merge, title: "In queue", isEnabled: false, emphasis: .normal))
             }
             if snapshot.providerCapabilities.canOpenReviewRequest {
                 actions.append(Action(kind: .openReviewRequest, title: request.provider.openReviewRequestTitle, isEnabled: true))
@@ -263,7 +266,7 @@ struct ReviewReadinessModel: Equatable, Sendable {
             if request.hasRerunnableFailedCheck, snapshot.providerCapabilities.canRerunFailedChecks {
                 actions.append(Action(kind: .rerunFailedChecks, title: "Rerun", isEnabled: true))
             }
-            if canMergeNow {
+            if canMergeNow || isQueued {
                 actions.append(Action(kind: .inspectReviewEvidence, title: "Review diff", isEnabled: true, emphasis: .normal))
             } else if request.worstCheckBucket == .fail || request.hasActionableFeedback {
                 actions.append(Action(kind: .inspectReviewEvidence, title: "Inspect", isEnabled: true))
@@ -308,10 +311,13 @@ struct ReviewReadinessModel: Equatable, Sendable {
         // needsPush/upstreamAhead) look clean off the stale local commit —
         // merging would ship/delete commits never present in the review diff.
         guard request.headSHA == snapshot.local.headSHA else { return false }
+        let mergeStateAllowsOperation = request.mergeState == .clean
+            || (request.isMergeQueueEnabled && request.mergeState == .blocked)
         return snapshot.providerCapabilities.canMerge
             && request.state == .open
             && !request.isDraft
-            && request.mergeState == .clean
+            && mergeStateAllowsOperation
+            && !request.isInMergeQueue
             && request.reviewDecision != .reviewRequired
             && request.areThreadsComplete
             && !request.hasActionableFeedback

--- a/Alas/Sources/Right/RightPaneState.swift
+++ b/Alas/Sources/Right/RightPaneState.swift
@@ -151,6 +151,7 @@ final class RightPaneState {
     var pendingCherryPickSHA: String? = nil
     var pendingMerge: ReviewLoopSnapshot? = nil
     var mergeError: String? = nil
+    var mergeQueuedMessage: String? = nil
 
     /// True while the workspace-level agent invocation is running.
     /// Surfaced in the Conflicts section header as a spinner; the
@@ -892,6 +893,20 @@ final class RightPaneState {
         mergeError = nil
     }
 
+    func clearMergeQueuedMessage() {
+        mergeQueuedMessage = nil
+    }
+
+    static func mergeConfirmationMessage(for request: ReviewRequest?) -> String {
+        guard let request else {
+            return "Squash-merge this review request and delete the branch."
+        }
+        if request.isMergeQueueEnabled {
+            return "Add \(request.displayIdentity) to the merge queue for \(request.baseRefName)."
+        }
+        return "Squash-merge \(request.displayIdentity) into \(request.baseRefName) and delete the branch."
+    }
+
     func performMerge() {
         guard let pending = pendingMerge else { return }
         pendingMerge = nil
@@ -934,9 +949,13 @@ final class RightPaneState {
                 mergeError = Self.mergeUnavailableMessage
                 return
             }
-            if await reviewLoop.merge(snapshot: snapshot) {
+            switch await reviewLoop.merge(snapshot: snapshot) {
+            case .merged:
                 await refresh()
-            } else {
+            case .queued:
+                mergeQueuedMessage = "Added to merge queue."
+                await refresh()
+            case nil:
                 mergeError = reviewLoop.lastError ?? "Merge failed."
             }
         }

--- a/Alas/Sources/Right/RightPaneStore.swift
+++ b/Alas/Sources/Right/RightPaneStore.swift
@@ -275,6 +275,14 @@ final class RightPaneStore {
         states.values.first { $0.mergeError != nil }
     }
 
+    /// The first cached state currently reporting that a PR was added to the
+    /// merge queue. Like merge errors, this is surfaced app-wide independent
+    /// of current selection because the async operation can finish after the
+    /// user switches worktrees.
+    func stateReportingMergeQueuedMessage() -> RightPaneState? {
+        states.values.first { $0.mergeQueuedMessage != nil }
+    }
+
     /// The first cached state with a pending merge confirmation, if any. The
     /// confirmation dialog (see RootView) resolves its owning state through
     /// this rather than the current selection, so switching worktrees while the

--- a/AlasTests/Integrations/CodeHostModelsTests.swift
+++ b/AlasTests/Integrations/CodeHostModelsTests.swift
@@ -25,18 +25,24 @@ struct CodeHostModelsTests {
             reviewDecision: .approved,
             mergeState: .clean,
             checks: [],
-            threads: []
+            threads: [],
+            isMergeQueueEnabled: true,
+            isInMergeQueue: true
         )
         let check = ReviewCheck(id: "c", name: "CI", workflow: "CI", bucket: .pass, detailURL: nil, completedAt: nil)
 
         let requestWithChecks = request.withChecks([check])
         #expect(requestWithChecks.headSHA == "reviewed-head")
         #expect(requestWithChecks.headRepositoryOwner == "mrmans0n")
+        #expect(requestWithChecks.isMergeQueueEnabled)
+        #expect(requestWithChecks.isInMergeQueue)
         #expect(requestWithChecks.checks == [check])
 
         let requestWithThreads = request.withThreads([])
         #expect(requestWithThreads.headSHA == "reviewed-head")
         #expect(requestWithThreads.headRepositoryOwner == "mrmans0n")
+        #expect(requestWithThreads.isMergeQueueEnabled)
+        #expect(requestWithThreads.isInMergeQueue)
         #expect(requestWithThreads.areThreadsComplete)
 
         // A failed thread load flags the copy incomplete; withChecks preserves it.

--- a/AlasTests/Integrations/GitHubCLIProviderTests.swift
+++ b/AlasTests/Integrations/GitHubCLIProviderTests.swift
@@ -188,6 +188,7 @@ struct GitHubCLIProviderTests {
     @Test func currentReviewRequestUsesExpectedCommandArgs() async throws {
         let runner = FakeRunner(results: [
             ProcessResult(exitCode: 0, stdout: Self.prListOutput, stderr: ""),
+            ProcessResult(exitCode: 0, stdout: Self.mergeQueueDisabledOutput, stderr: ""),
             ProcessResult(exitCode: 0, stdout: Self.reviewThreadsOutput, stderr: ""),
         ])
 
@@ -220,6 +221,18 @@ struct GitHubCLIProviderTests {
                 args: [
                     "api", "graphql",
                     "--hostname", "github.com",
+                    "-f", "owner=mrmans0n",
+                    "-f", "name=alas",
+                    "-F", "number=42",
+                    "-f", "query=\(Self.mergeQueueMetadataQuery)",
+                ],
+                cwd: Self.cwd
+            ),
+            FakeRunner.Command(
+                executable: "gh",
+                args: [
+                    "api", "graphql",
+                    "--hostname", "github.com",
                     "-f", "query=\(GitHubCLIProvider.reviewThreadsQuery)",
                     "-F", "owner=mrmans0n",
                     "-F", "repo=alas",
@@ -227,6 +240,53 @@ struct GitHubCLIProviderTests {
                 ],
                 cwd: Self.cwd
             ),
+        ])
+    }
+
+    @Test func currentReviewRequestEnrichesMergeQueueMetadata() async throws {
+        let runner = FakeRunner(results: [
+            ProcessResult(exitCode: 0, stdout: Self.prListOutput, stderr: ""),
+            ProcessResult(exitCode: 0, stdout: Self.mergeQueueEnabledOutput, stderr: ""),
+            ProcessResult(exitCode: 0, stdout: Self.reviewThreadsOutput, stderr: ""),
+        ])
+
+        let request = try await GitHubCLIProvider(runner: runner).currentReviewRequest(
+            remote: Self.remote,
+            branch: "feature/github-provider",
+            headOwner: nil,
+            baseBranch: "main",
+            cwd: Self.cwd
+        )
+
+        #expect(request?.isMergeQueueEnabled == true)
+        #expect(request?.isInMergeQueue == true)
+        #expect(request?.threads.count == 2)
+        #expect(await runner.commands.map(\.args) == [
+            [
+                "pr", "list",
+                "--head", "feature/github-provider",
+                "--base", "main",
+                "--state", "open",
+                "--limit", "20",
+                "--json", "number,title,url,state,isDraft,headRefName,headRefOid,headRepositoryOwner,headRepository,baseRefName,reviewDecision,mergeStateStatus",
+                "-R", "mrmans0n/alas",
+            ],
+            [
+                "api", "graphql",
+                "--hostname", "github.com",
+                "-f", "owner=mrmans0n",
+                "-f", "name=alas",
+                "-F", "number=42",
+                "-f", "query=\(Self.mergeQueueMetadataQuery)",
+            ],
+            [
+                "api", "graphql",
+                "--hostname", "github.com",
+                "-f", "query=\(GitHubCLIProvider.reviewThreadsQuery)",
+                "-F", "owner=mrmans0n",
+                "-F", "repo=alas",
+                "-F", "number=42",
+            ],
         ])
     }
 
@@ -270,6 +330,7 @@ struct GitHubCLIProviderTests {
     @Test func currentReviewRequestKeepsRequestWhenReviewThreadFetchFails() async throws {
         let runner = FakeRunner(results: [
             ProcessResult(exitCode: 0, stdout: Self.prListOutput, stderr: ""),
+            ProcessResult(exitCode: 0, stdout: Self.mergeQueueDisabledOutput, stderr: ""),
             ProcessResult(exitCode: 1, stdout: "", stderr: "GraphQL field unavailable"),
         ])
 
@@ -283,12 +344,13 @@ struct GitHubCLIProviderTests {
 
         #expect(request?.number == 42)
         #expect(request?.threads == [])
-        #expect(await runner.commands.count == 2)
+        #expect(await runner.commands.count == 3)
     }
 
     @Test func currentReviewRequestPagesReviewThreads() async throws {
         let runner = FakeRunner(results: [
             ProcessResult(exitCode: 0, stdout: Self.prListOutput, stderr: ""),
+            ProcessResult(exitCode: 0, stdout: Self.mergeQueueDisabledOutput, stderr: ""),
             ProcessResult(exitCode: 0, stdout: Self.reviewThreadsFirstPageOutput, stderr: ""),
             ProcessResult(exitCode: 0, stdout: Self.reviewThreadsSecondPageOutput, stderr: ""),
         ])
@@ -303,10 +365,10 @@ struct GitHubCLIProviderTests {
 
         #expect(request?.threads.map(\.id) == ["thread-page-1", "thread-page-2"])
         let commands = await runner.commands
-        #expect(commands.count == 3)
-        #expect(!commands[1].args.contains("-F cursor=cursor-1"))
-        #expect(commands[2].args.contains("-F"))
-        #expect(commands[2].args.contains("cursor=cursor-1"))
+        #expect(commands.count == 4)
+        #expect(!commands[2].args.contains("-F cursor=cursor-1"))
+        #expect(commands[3].args.contains("-F"))
+        #expect(commands[3].args.contains("cursor=cursor-1"))
     }
 
     @Test func reviewThreadsJSONParsesActionableSummaries() throws {
@@ -329,6 +391,7 @@ struct GitHubCLIProviderTests {
             ProcessResult(exitCode: 0, stdout: Self.pullRequestNodeOutput, stderr: ""),
             ProcessResult(exitCode: 0, stdout: Self.publishReviewMutationOutput, stderr: ""),
             ProcessResult(exitCode: 0, stdout: Self.prViewOutput, stderr: ""),
+            ProcessResult(exitCode: 0, stdout: Self.mergeQueueDisabledOutput, stderr: ""),
             ProcessResult(exitCode: 0, stdout: Self.reviewThreadsOutput, stderr: ""),
         ])
         let provider = GitHubCLIProvider(runner: runner)
@@ -360,7 +423,7 @@ struct GitHubCLIProviderTests {
         ))
 
         let commands = await runner.commands
-        #expect(commands.count == 4)
+        #expect(commands.count == 5)
         #expect(commands[0].args == ["api", "graphql", "--hostname", "github.com", "--input", "-"])
         #expect(commands[1].args == ["api", "graphql", "--hostname", "github.com", "--input", "-"])
         #expect(commands[0].stdin?.contains("pullRequest(number: $number)") == true)
@@ -381,6 +444,14 @@ struct GitHubCLIProviderTests {
             "pr", "view", "42",
             "--json", "number,title,url,state,isDraft,headRefName,headRefOid,headRepositoryOwner,headRepository,baseRefName,reviewDecision,mergeStateStatus",
             "-R", "mrmans0n/alas",
+        ])
+        #expect(commands[3].args == [
+            "api", "graphql",
+            "--hostname", "github.com",
+            "-f", "owner=mrmans0n",
+            "-f", "name=alas",
+            "-F", "number=42",
+            "-f", "query=\(Self.mergeQueueMetadataQuery)",
         ])
         #expect(result.published == [
             ProviderReviewPublishedComment(
@@ -407,6 +478,7 @@ struct GitHubCLIProviderTests {
             ProcessResult(exitCode: 0, stdout: Self.publishReviewMutationOutput, stderr: ""),
             ProcessResult(exitCode: 1, stdout: "", stderr: "line is not commentable"),
             ProcessResult(exitCode: 0, stdout: Self.prViewOutput, stderr: ""),
+            ProcessResult(exitCode: 0, stdout: Self.mergeQueueDisabledOutput, stderr: ""),
             ProcessResult(exitCode: 0, stdout: Self.reviewThreadsOutput, stderr: ""),
         ])
         let provider = GitHubCLIProvider(runner: runner)
@@ -438,7 +510,7 @@ struct GitHubCLIProviderTests {
         ))
 
         let commands = await runner.commands
-        #expect(commands.count == 6)
+        #expect(commands.count == 7)
         let batchVariables = try Self.graphQLVariables(from: commands[1].stdin)
         let batchInput = try #require(batchVariables["input"] as? [String: Any])
         let batchThreads = try #require(batchInput["threads"] as? [[String: Any]])
@@ -474,6 +546,7 @@ struct GitHubCLIProviderTests {
             ProcessResult(exitCode: 0, stdout: Self.pullRequestNodeOutput, stderr: ""),
             ProcessResult(exitCode: 0, stdout: Self.publishReviewMutationOutput(commentCount: 100), stderr: ""),
             ProcessResult(exitCode: 0, stdout: Self.prViewOutput, stderr: ""),
+            ProcessResult(exitCode: 0, stdout: Self.mergeQueueDisabledOutput, stderr: ""),
             ProcessResult(exitCode: 0, stdout: Self.reviewThreadsOutput, stderr: ""),
         ])
         let provider = GitHubCLIProvider(runner: runner)
@@ -501,6 +574,7 @@ struct GitHubCLIProviderTests {
             ProcessResult(exitCode: 0, stdout: Self.pullRequestNodeOutput, stderr: ""),
             ProcessResult(exitCode: 0, stdout: #"{"data":{}}"#, stderr: ""),
             ProcessResult(exitCode: 0, stdout: Self.prViewOutput, stderr: ""),
+            ProcessResult(exitCode: 0, stdout: Self.mergeQueueDisabledOutput, stderr: ""),
             ProcessResult(exitCode: 0, stdout: Self.reviewThreadsOutput, stderr: ""),
         ])
         let provider = GitHubCLIProvider(runner: runner)
@@ -532,7 +606,7 @@ struct GitHubCLIProviderTests {
         ))
 
         let commands = await runner.commands
-        #expect(commands.count == 4)
+        #expect(commands.count == 5)
         let publishVariables = try Self.graphQLVariables(from: commands[1].stdin)
         let publishInput = try #require(publishVariables["input"] as? [String: Any])
         let publishThreads = try #require(publishInput["threads"] as? [[String: Any]])
@@ -589,6 +663,7 @@ struct GitHubCLIProviderTests {
             ProcessResult(exitCode: 0, stdout: Self.pullRequestNodeOutput, stderr: ""),
             ProcessResult(exitCode: 0, stdout: Self.publishReviewMutationWithoutCommentsOutput, stderr: ""),
             ProcessResult(exitCode: 0, stdout: Self.prViewOutput, stderr: ""),
+            ProcessResult(exitCode: 0, stdout: Self.mergeQueueDisabledOutput, stderr: ""),
             ProcessResult(exitCode: 0, stdout: Self.reviewThreadsOutput, stderr: ""),
         ])
         let provider = GitHubCLIProvider(runner: runner)
@@ -603,7 +678,7 @@ struct GitHubCLIProviderTests {
         ))
 
         let commands = await runner.commands
-        #expect(commands.count == 4)
+        #expect(commands.count == 5)
         let publishVariables = try Self.graphQLVariables(from: commands[1].stdin)
         let publishInput = try #require(publishVariables["input"] as? [String: Any])
         let publishThreads = try #require(publishInput["threads"] as? [[String: Any]])
@@ -688,9 +763,11 @@ struct GitHubCLIProviderTests {
         let runner = FakeRunner(results: [
             ProcessResult(exitCode: 0, stdout: Self.replyMutationOutput, stderr: ""),
             ProcessResult(exitCode: 0, stdout: Self.prViewOutput, stderr: ""),
+            ProcessResult(exitCode: 0, stdout: Self.mergeQueueDisabledOutput, stderr: ""),
             ProcessResult(exitCode: 0, stdout: Self.reviewThreadsOutput, stderr: ""),
             ProcessResult(exitCode: 0, stdout: Self.resolveThreadMutationOutput, stderr: ""),
             ProcessResult(exitCode: 0, stdout: Self.prViewOutput, stderr: ""),
+            ProcessResult(exitCode: 0, stdout: Self.mergeQueueDisabledOutput, stderr: ""),
             ProcessResult(exitCode: 0, stdout: Self.reviewThreadsOutput, stderr: ""),
         ])
         let provider = GitHubCLIProvider(runner: runner)
@@ -719,16 +796,16 @@ struct GitHubCLIProviderTests {
             "--json", "number,title,url,state,isDraft,headRefName,headRefOid,headRepositoryOwner,headRepository,baseRefName,reviewDecision,mergeStateStatus",
             "-R", "mrmans0n/alas",
         ])
-        #expect(commands[3].args == ["api", "graphql", "--hostname", "github.com", "--input", "-"])
-        #expect(commands[4].args == [
+        #expect(commands[4].args == ["api", "graphql", "--hostname", "github.com", "--input", "-"])
+        #expect(commands[5].args == [
             "pr", "view", "42",
             "--json", "number,title,url,state,isDraft,headRefName,headRefOid,headRepositoryOwner,headRepository,baseRefName,reviewDecision,mergeStateStatus",
             "-R", "mrmans0n/alas",
         ])
         #expect(commands[0].stdin?.contains("addPullRequestReviewThreadReply") == true)
         #expect(commands[0].stdin?.contains("\"pullRequestReviewThreadId\":\"PRRT_thread_1\"") == true)
-        #expect(commands[3].stdin?.contains("resolveReviewThread") == true)
-        #expect(commands[3].stdin?.contains("\"threadId\":\"PRRT_thread_1\"") == true)
+        #expect(commands[4].stdin?.contains("resolveReviewThread") == true)
+        #expect(commands[4].stdin?.contains("\"threadId\":\"PRRT_thread_1\"") == true)
         #expect(replyResult.providerURL == URL(string: "https://github.com/mrmans0n/alas/pull/42#discussion_r2"))
         #expect(replyResult.refreshedRequest.number == 42)
         #expect(resolveResult.refreshedRequest.number == 42)
@@ -760,6 +837,7 @@ struct GitHubCLIProviderTests {
         )
         let runner = FakeRunner(results: [
             ProcessResult(exitCode: 0, stdout: Self.prViewOutput, stderr: ""),
+            ProcessResult(exitCode: 0, stdout: Self.mergeQueueDisabledOutput, stderr: ""),
             ProcessResult(exitCode: 0, stdout: Self.reviewThreadsOutput, stderr: ""),
         ])
         let provider = GitHubCLIProvider(runner: runner)
@@ -767,16 +845,24 @@ struct GitHubCLIProviderTests {
         _ = try await provider.reviewRequest(remote: enterpriseRemote, number: 42, cwd: Self.cwd)
 
         let commands = await runner.commands
-        #expect(commands.count == 2)
+        #expect(commands.count == 3)
         #expect(commands[0].args == [
             "pr", "view", "42",
             "--json", "number,title,url,state,isDraft,headRefName,headRefOid,headRepositoryOwner,headRepository,baseRefName,reviewDecision,mergeStateStatus",
             "-R", "github.enterprise.example.com/platform/alas",
         ])
-        #expect(commands[1].args.prefix(3) == ["api", "graphql", "--hostname"])
-        #expect(commands[1].args.contains("github.enterprise.example.com"))
-        #expect(commands[1].args.contains("owner=platform"))
-        #expect(commands[1].args.contains("repo=alas"))
+        #expect(commands[1].args == [
+            "api", "graphql",
+            "--hostname", "github.enterprise.example.com",
+            "-f", "owner=platform",
+            "-f", "name=alas",
+            "-F", "number=42",
+            "-f", "query=\(Self.mergeQueueMetadataQuery)",
+        ])
+        #expect(commands[2].args.prefix(3) == ["api", "graphql", "--hostname"])
+        #expect(commands[2].args.contains("github.enterprise.example.com"))
+        #expect(commands[2].args.contains("owner=platform"))
+        #expect(commands[2].args.contains("repo=alas"))
     }
 
     @Test func githubThreadMutationPreservesSuccessfulReplyWhenRefreshFails() async throws {
@@ -1493,6 +1579,7 @@ struct GitHubCLIProviderTests {
     @Test func parsesRichReviewThreadFields() async throws {
         let runner = FakeRunner(results: [
             ProcessResult(exitCode: 0, stdout: Self.prListOutput, stderr: ""),
+            ProcessResult(exitCode: 0, stdout: Self.mergeQueueDisabledOutput, stderr: ""),
             ProcessResult(exitCode: 0, stdout: Self.richReviewThreadsOutput, stderr: ""),
         ])
         let request = try await GitHubCLIProvider(runner: runner).currentReviewRequest(
@@ -1512,6 +1599,7 @@ struct GitHubCLIProviderTests {
     @Test func parsesFileLevelReviewThread() async throws {
         let runner = FakeRunner(results: [
             ProcessResult(exitCode: 0, stdout: Self.prListOutput, stderr: ""),
+            ProcessResult(exitCode: 0, stdout: Self.mergeQueueDisabledOutput, stderr: ""),
             ProcessResult(exitCode: 0, stdout: Self.fileLevelReviewThreadOutput, stderr: ""),
         ])
         let request = try await GitHubCLIProvider(runner: runner).currentReviewRequest(
@@ -1525,6 +1613,7 @@ struct GitHubCLIProviderTests {
     @Test func reviewThreadsFilterEmptyBodiedCommentsAndDropEmptyThreads() async throws {
         let runner = FakeRunner(results: [
             ProcessResult(exitCode: 0, stdout: Self.prListOutput, stderr: ""),
+            ProcessResult(exitCode: 0, stdout: Self.mergeQueueDisabledOutput, stderr: ""),
             ProcessResult(exitCode: 0, stdout: Self.emptyCommentReviewThreadsOutput, stderr: ""),
         ])
         let request = try await GitHubCLIProvider(runner: runner).currentReviewRequest(
@@ -1626,6 +1715,38 @@ struct GitHubCLIProviderTests {
                     "--hostname", "github.com",
                     "--method", "DELETE",
                     "repos/mrmans0n/alas/git/refs/heads/feature/github-provider",
+                ],
+                cwd: Self.cwd
+            ),
+        ])
+    }
+
+    @Test func mergeReviewRequestWithMergeQueueOmitsStrategyAndSkipsBranchDeleteWhenStillOpen() async throws {
+        let runner = FakeRunner(results: [
+            ProcessResult(exitCode: 0, stdout: "", stderr: ""),
+            ProcessResult(exitCode: 0, stdout: #"{"state":"OPEN"}"#, stderr: ""),
+        ])
+        let provider = GitHubCLIProvider(runner: runner)
+        let request = Self.makeRequest(isMergeQueueEnabled: true)
+
+        try await provider.mergeReviewRequest(request, method: .squash, deleteBranch: true, cwd: Self.cwd)
+
+        #expect(await runner.commands == [
+            FakeRunner.Command(
+                executable: "gh",
+                args: [
+                    "pr", "merge", "42",
+                    "--match-head-commit", "head-sha-42",
+                    "-R", "mrmans0n/alas",
+                ],
+                cwd: Self.cwd
+            ),
+            FakeRunner.Command(
+                executable: "gh",
+                args: [
+                    "pr", "view", "42",
+                    "--json", "state",
+                    "-R", "mrmans0n/alas",
                 ],
                 cwd: Self.cwd
             ),
@@ -1774,7 +1895,9 @@ struct GitHubCLIProviderTests {
         reviewDecision: ReviewDecision = .approved,
         headSHA: String? = "head-sha-42",
         headRepositoryOwner: String? = "mrmans0n",
-        headRepositoryName: String? = "alas"
+        headRepositoryName: String? = "alas",
+        isMergeQueueEnabled: Bool = false,
+        isInMergeQueue: Bool = false
     ) -> ReviewRequest {
         ReviewRequest(
             remote: Self.remote,
@@ -1791,7 +1914,9 @@ struct GitHubCLIProviderTests {
             reviewDecision: reviewDecision,
             mergeState: .clean,
             checks: checks,
-            threads: threads
+            threads: threads,
+            isMergeQueueEnabled: isMergeQueueEnabled,
+            isInMergeQueue: isInMergeQueue
         )
     }
 
@@ -1865,6 +1990,25 @@ struct GitHubCLIProviderTests {
       "reviewDecision": "APPROVED",
       "mergeStateStatus": "CLEAN"
     }
+    """
+
+    private static let mergeQueueMetadataQuery = """
+    query($owner: String!, $name: String!, $number: Int!) {
+      repository(owner: $owner, name: $name) {
+        pullRequest(number: $number) {
+          isMergeQueueEnabled
+          isInMergeQueue
+        }
+      }
+    }
+    """
+
+    private static let mergeQueueEnabledOutput = """
+    {"data":{"repository":{"pullRequest":{"isMergeQueueEnabled":true,"isInMergeQueue":true}}}}
+    """
+
+    private static let mergeQueueDisabledOutput = """
+    {"data":{"repository":{"pullRequest":{"isMergeQueueEnabled":false,"isInMergeQueue":false}}}}
     """
 
     private static let checksOutput = """

--- a/AlasTests/Integrations/ReviewLoopStateTests.swift
+++ b/AlasTests/Integrations/ReviewLoopStateTests.swift
@@ -589,7 +589,31 @@ struct ReviewLoopStateTests {
 
         let ok = await state.merge(snapshot: snapshot)
 
-        #expect(ok)
+        #expect(ok == .merged)
+        #expect(provider.mergeRequestCalls == [
+            FakeCodeHostProvider.MergeRequestCall(number: 42, method: .squash, deleteBranch: true),
+        ])
+    }
+
+    @Test func mergeReportsQueuedOutcomeForQueueRequest() async throws {
+        let remote = Self.makeRemote()
+        let provider = FakeCodeHostProvider(
+            kind: .github,
+            capabilities: .githubCLI,
+            request: Self.makeMergeableReviewRequest(remote: remote).withMergeQueue(isEnabled: true, isInQueue: false)
+        )
+        let state = ReviewLoopState(
+            worktreePath: URL(fileURLWithPath: "/tmp/alas-review-loop"),
+            baseBranch: "main",
+            providerRegistry: CodeHostProviderRegistry(providers: [.github: provider])
+        )
+
+        await state.refresh(local: Self.makeLocal(needsPush: false), remotes: [Self.makeGitHubRemote()])
+        let snapshot = try #require(state.snapshot)
+
+        let outcome = await state.merge(snapshot: snapshot)
+
+        #expect(outcome == .queued)
         #expect(provider.mergeRequestCalls == [
             FakeCodeHostProvider.MergeRequestCall(number: 42, method: .squash, deleteBranch: true),
         ])
@@ -614,7 +638,7 @@ struct ReviewLoopStateTests {
 
         let ok = await state.merge(snapshot: snapshot)
 
-        #expect(!ok)
+        #expect(ok == nil)
         #expect(state.lastError != nil)
     }
 
@@ -648,7 +672,7 @@ struct ReviewLoopStateTests {
 
         let ok = await state.merge(snapshot: snapshot)
 
-        #expect(!ok)
+        #expect(ok == nil)
         #expect(provider.mergeRequestCalls.isEmpty)
         #expect(state.lastError != nil)
     }

--- a/AlasTests/Integrations/ReviewReadinessModelTests.swift
+++ b/AlasTests/Integrations/ReviewReadinessModelTests.swift
@@ -292,6 +292,81 @@ struct ReviewReadinessModelTests {
         #expect(review?.emphasis == .normal)
     }
 
+    @Test func queueRequiredGreenPREmitsAddToQueueAction() {
+        let request = Self.makeReviewRequest(
+            reviewDecision: .approved,
+            mergeState: .blocked,
+            checks: [Self.makeCheck(bucket: .pass)],
+            isMergeQueueEnabled: true,
+            isInMergeQueue: false
+        )
+        let snapshot = Self.makeSnapshot(reviewRequest: request)
+        let model = ReviewReadinessModel(
+            snapshot: snapshot,
+            lastError: nil,
+            canOpenAgentHandoff: false
+        )
+
+        let merge = model.actions.first { $0.kind == .merge }
+        #expect(merge?.title == "Add to queue")
+        #expect(merge?.isEnabled == true)
+        #expect(ReviewReadinessModel.canMergeReviewRequest(snapshot: snapshot))
+    }
+
+    @Test func alreadyQueuedPRShowsInQueueAndDoesNotAllowMerge() {
+        let request = Self.makeReviewRequest(
+            reviewDecision: .approved,
+            mergeState: .blocked,
+            checks: [Self.makeCheck(bucket: .pass)],
+            isMergeQueueEnabled: true,
+            isInMergeQueue: true
+        )
+        let snapshot = Self.makeSnapshot(reviewRequest: request)
+        let model = ReviewReadinessModel(
+            snapshot: snapshot,
+            lastError: nil,
+            canOpenAgentHandoff: false
+        )
+
+        let merge = model.actions.first { $0.kind == .merge }
+        #expect(merge?.title == "In queue")
+        #expect(merge?.isEnabled == false)
+        #expect(model.actions.contains(Action(kind: .inspectReviewEvidence, title: "Review diff", isEnabled: true, emphasis: .normal)))
+        #expect(!ReviewReadinessModel.canMergeReviewRequest(snapshot: snapshot))
+    }
+
+    @Test func normalBlockedPRStillSuppressesMerge() {
+        let request = Self.makeReviewRequest(
+            reviewDecision: .approved,
+            mergeState: .blocked,
+            checks: [Self.makeCheck(bucket: .pass)]
+        )
+        let snapshot = Self.makeSnapshot(reviewRequest: request)
+
+        #expect(!ReviewReadinessModel.canMergeReviewRequest(snapshot: snapshot))
+    }
+
+    @Test func queueRequiredUnsafeMergeStatesStillSuppressMerge() {
+        for mergeState in [ReviewMergeState.dirty, .unstable, .unknown] {
+            let request = Self.makeReviewRequest(
+                reviewDecision: .approved,
+                mergeState: mergeState,
+                checks: [Self.makeCheck(bucket: .pass)],
+                isMergeQueueEnabled: true,
+                isInMergeQueue: false
+            )
+            let snapshot = Self.makeSnapshot(reviewRequest: request)
+            let model = ReviewReadinessModel(
+                snapshot: snapshot,
+                lastError: nil,
+                canOpenAgentHandoff: false
+            )
+
+            #expect(!model.actions.map(\.kind).contains(.merge))
+            #expect(!ReviewReadinessModel.canMergeReviewRequest(snapshot: snapshot))
+        }
+    }
+
     @Test func blockedRequestDoesNotExposeMerge() {
         let request = Self.makeReviewRequest(
             mergeState: .blocked,
@@ -607,7 +682,9 @@ struct ReviewReadinessModelTests {
         checks: [ReviewCheck] = [],
         threads: [ReviewThread] = [],
         headSHA: String? = "abc123",
-        areThreadsComplete: Bool = true
+        areThreadsComplete: Bool = true,
+        isMergeQueueEnabled: Bool = false,
+        isInMergeQueue: Bool = false
     ) -> ReviewRequest {
         ReviewRequest(
             remote: remote,
@@ -623,7 +700,9 @@ struct ReviewReadinessModelTests {
             mergeState: mergeState,
             checks: checks,
             threads: threads,
-            areThreadsComplete: areThreadsComplete
+            areThreadsComplete: areThreadsComplete,
+            isMergeQueueEnabled: isMergeQueueEnabled,
+            isInMergeQueue: isInMergeQueue
         )
     }
 

--- a/AlasTests/RightPaneStateReviewLoopPushTests.swift
+++ b/AlasTests/RightPaneStateReviewLoopPushTests.swift
@@ -123,6 +123,42 @@ struct RightPaneStateReviewLoopPushTests {
         #expect(state.mergeError != nil)
     }
 
+    @Test func mergeConfirmationMessageReflectsQueueOperation() {
+        let snapshot = Self.makeSnapshot(reviewRequest: Self.makeReviewRequest(isMergeQueueEnabled: true))
+
+        #expect(
+            RightPaneState.mergeConfirmationMessage(for: snapshot.reviewRequest)
+                == "Add GitHub #428 to the merge queue for main."
+        )
+    }
+
+    @Test func mergeConfirmationMessageReflectsSquashOperation() {
+        let snapshot = Self.makeSnapshot(reviewRequest: Self.makeReviewRequest())
+
+        #expect(
+            RightPaneState.mergeConfirmationMessage(for: snapshot.reviewRequest)
+                == "Squash-merge GitHub #428 into main and delete the branch."
+        )
+    }
+
+    @Test func clearMergeQueuedMessageClearsQueuedSuccess() {
+        let worktree = Worktree(
+            id: "wt-merge-queued-message",
+            projectId: "p1",
+            name: "feature/review-loop",
+            branch: "feature/review-loop",
+            path: URL(fileURLWithPath: "/tmp/repo"),
+            status: .clean,
+            lastActivity: Date(timeIntervalSince1970: 0)
+        )
+        let state = RightPaneState(worktree: worktree, baseBranch: "main")
+        state.mergeQueuedMessage = "Added to merge queue."
+
+        state.clearMergeQueuedMessage()
+
+        #expect(state.mergeQueuedMessage == nil)
+    }
+
     @Test func normalPushArgumentsDoNotForce() {
         let snapshot = Self.makeSnapshot()
 
@@ -216,7 +252,8 @@ struct RightPaneStateReviewLoopPushTests {
         hasUpstream: Bool = true,
         upstreamRemoteName: String? = nil,
         upstreamBranchName: String? = nil,
-        headRemoteName: String? = nil
+        headRemoteName: String? = nil,
+        reviewRequest: ReviewRequest? = nil
     ) -> ReviewLoopSnapshot {
         let remote = CodeHostRemote(
             kind: .github,
@@ -242,11 +279,39 @@ struct RightPaneStateReviewLoopPushTests {
                 needsPush: true
             ),
             remote: remote,
-            reviewRequest: nil,
+            reviewRequest: reviewRequest,
             providerAvailable: true,
             providerAuthenticated: true,
             providerCapabilities: .githubCLI,
             errorMessage: nil
+        )
+    }
+
+    private static func makeReviewRequest(isMergeQueueEnabled: Bool = false) -> ReviewRequest {
+        let remote = CodeHostRemote(
+            kind: .github,
+            host: "github.com",
+            owner: "mrmans0n",
+            repository: "alas",
+            remoteName: "origin",
+            webURL: URL(string: "https://github.com/mrmans0n/alas")!
+        )
+        return ReviewRequest(
+            remote: remote,
+            number: 428,
+            title: "Review loop",
+            url: URL(string: "https://github.com/mrmans0n/alas/pull/428")!,
+            state: .open,
+            isDraft: false,
+            headRefName: "feature/review-loop",
+            baseRefName: "main",
+            headSHA: "abc123",
+            reviewDecision: .approved,
+            mergeState: .clean,
+            checks: [],
+            threads: [],
+            isMergeQueueEnabled: isMergeQueueEnabled,
+            isInMergeQueue: false
         )
     }
 


### PR DESCRIPTION
## Summary
- detect GitHub merge queue state and show Add to queue / In queue in the review readiness UI
- omit explicit merge strategy for queue-required PRs while preserving head pinning and branch cleanup safety
- surface queued outcomes with an app-level Added to merge queue alert

Closes #634

## Test Plan
- ALAS_FFF_TARGET_ARCH=arm64 rtk xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS,arch=arm64' ONLY_ACTIVE_ARCH=YES ARCHS=arm64 test -only-testing:AlasTests/CodeHostModelsTests -only-testing:AlasTests/ReviewReadinessModelTests -only-testing:AlasTests/GitHubCLIProviderTests -only-testing:AlasTests/ReviewLoopStateTests -only-testing:AlasTests/RightPaneStateReviewLoopPushTests
- ALAS_FFF_TARGET_ARCH=arm64 rtk xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS,arch=arm64' ONLY_ACTIVE_ARCH=YES ARCHS=arm64 -quiet build
- rtk git diff --check origin/main...HEAD