### PR TITLE
fix(diff): duplicate stacked diff draft composers

### DIFF
--- a/Alas/Sources/Center/Diff/DiffPaneTextDocumentView.swift
+++ b/Alas/Sources/Center/Diff/DiffPaneTextDocumentView.swift
@@ -4,11 +4,19 @@ import SwiftUI
 private let diffContextExpansionChunkSize = 10
 
 struct DiffReviewLineAnchor: Equatable, Hashable, Sendable {
+    struct SelectedLine: Equatable, Hashable, Sendable {
+        let side: DiffReviewInlineFeedbackSide
+        let line: Int
+        let isChange: Bool
+    }
+
     let path: String
     let side: DiffReviewInlineFeedbackSide
     let line: Int
     let endLine: Int?
     let rowIndex: Int
+    let endRowIndex: Int
+    let selectedLines: [SelectedLine]
     let selectedText: String
 
     init(
@@ -17,6 +25,8 @@ struct DiffReviewLineAnchor: Equatable, Hashable, Sendable {
         line: Int,
         endLine: Int? = nil,
         rowIndex: Int,
+        endRowIndex: Int? = nil,
+        selectedLines: [SelectedLine]? = nil,
         selectedText: String
     ) {
         self.path = path
@@ -24,6 +34,10 @@ struct DiffReviewLineAnchor: Equatable, Hashable, Sendable {
         self.line = line
         self.endLine = endLine
         self.rowIndex = rowIndex
+        self.endRowIndex = endRowIndex ?? rowIndex
+        self.selectedLines = selectedLines ?? [
+            SelectedLine(side: side, line: line, isChange: side != .unknown),
+        ]
         self.selectedText = selectedText
     }
 }
@@ -1208,6 +1222,8 @@ final class DiffPaneCodeTextView: NSTextView {
             line: startLine,
             endLine: endLine,
             rowIndex: first.rowIndex,
+            endRowIndex: resolvedAnchors.last?.rowIndex ?? first.rowIndex,
+            selectedLines: resolvedAnchors.flatMap(\.selectedLines),
             selectedText: resolvedAnchors.map(\.selectedText).joined(separator: "\n")
         )
     }
@@ -1968,6 +1984,13 @@ private extension DiffPaneTextDocumentBuilder.LineMetadata {
             line: lineNumber,
             endLine: nil,
             rowIndex: rowIndex,
+            selectedLines: [
+                DiffReviewLineAnchor.SelectedLine(
+                    side: side,
+                    line: lineNumber,
+                    isChange: sourceLine.kind != .context
+                ),
+            ],
             selectedText: sourceLine.text
         )
     }

--- a/Alas/Sources/Center/DiffReview/DiffReviewFileSection.swift
+++ b/Alas/Sources/Center/DiffReview/DiffReviewFileSection.swift
@@ -598,17 +598,21 @@ struct DiffReviewFileSection: View {
 
     private func savePendingDraft() {
         guard let pendingDraftAnchor else { return }
+        let canonicalAnchor = ReviewDraftCommentRowSegmentation.canonicalPendingAnchor(
+            pendingDraftAnchor,
+            in: derivedDisplayGroups ?? []
+        )
         let body = pendingDraftBody.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !body.isEmpty else { return }
         guard currentDraftRowKeys.contains(ReviewDraftCommentPlacement.RowKey(
-            side: pendingDraftAnchor.side,
-            line: pendingDraftAnchor.draftPlacementLine
+            side: canonicalAnchor.side,
+            line: canonicalAnchor.draftPlacementLine
         )) else {
             clearPendingDraft()
             return
         }
 
-        onSaveDraftComment(pendingDraftAnchor, body)
+        onSaveDraftComment(canonicalAnchor, body)
         clearPendingDraft()
     }
 
@@ -1049,9 +1053,7 @@ enum ReviewDraftCommentRowSegmentation {
         pendingAnchor: DiffReviewLineAnchor?,
         canCreateDraftComment: Bool = true
     ) -> Result {
-        let pendingKey = pendingAnchor.map {
-            ReviewDraftCommentPlacement.RowKey(side: $0.side, line: $0.draftPlacementLine)
-        }
+        let pendingKey = pendingAnchor.flatMap { pendingRowKey(for: $0, in: group) }
         var segments: [Segment] = []
         var bufferedRows: [DiffDisplayRow] = []
         var emittedCommentIDs: Set<String> = []
@@ -1088,6 +1090,81 @@ enum ReviewDraftCommentRowSegmentation {
         }
 
         return Result(items: segments)
+    }
+
+    static func canonicalPendingAnchor(
+        _ anchor: DiffReviewLineAnchor,
+        in groups: [DiffDisplayGroup]
+    ) -> DiffReviewLineAnchor {
+        guard anchor.side == .unknown else { return anchor }
+        guard groups.contains(where: { canPlaceUnknownAnchor(anchor, in: $0) }) else { return anchor }
+
+        if let range = selectedLineRange(anchor.selectedLines, side: .new, requiresChange: true) {
+            return DiffReviewLineAnchor(
+                path: anchor.path,
+                side: .new,
+                line: range.lowerBound,
+                endLine: range.lowerBound == range.upperBound ? nil : range.upperBound,
+                rowIndex: anchor.rowIndex,
+                endRowIndex: anchor.endRowIndex,
+                selectedLines: anchor.selectedLines,
+                selectedText: anchor.selectedText
+            )
+        }
+
+        if let range = selectedLineRange(anchor.selectedLines, side: .old, requiresChange: true) {
+            return DiffReviewLineAnchor(
+                path: anchor.path,
+                side: .old,
+                line: range.lowerBound,
+                endLine: range.lowerBound == range.upperBound ? nil : range.upperBound,
+                rowIndex: anchor.rowIndex,
+                endRowIndex: anchor.endRowIndex,
+                selectedLines: anchor.selectedLines,
+                selectedText: anchor.selectedText
+            )
+        }
+
+        return anchor
+    }
+
+    private static func pendingRowKey(
+        for anchor: DiffReviewLineAnchor,
+        in group: DiffDisplayGroup
+    ) -> ReviewDraftCommentPlacement.RowKey? {
+        guard anchor.side == .unknown else {
+            return ReviewDraftCommentPlacement.RowKey(side: anchor.side, line: anchor.draftPlacementLine)
+        }
+
+        guard canPlaceUnknownAnchor(anchor, in: group) else { return nil }
+        let canonicalAnchor = canonicalPendingAnchor(anchor, in: [group])
+        return ReviewDraftCommentPlacement.RowKey(
+            side: canonicalAnchor.side,
+            line: canonicalAnchor.draftPlacementLine
+        )
+    }
+
+    private static func canPlaceUnknownAnchor(
+        _ anchor: DiffReviewLineAnchor,
+        in group: DiffDisplayGroup
+    ) -> Bool {
+        let keys = Set(ReviewDraftCommentPlacement.allRowKeys(in: group))
+        return keys.contains(ReviewDraftCommentPlacement.RowKey(side: .unknown, line: anchor.draftPlacementLine))
+            || keys.contains(ReviewDraftCommentPlacement.RowKey(side: .unknown, line: anchor.line))
+    }
+
+    private static func selectedLineRange(
+        _ selectedLines: [DiffReviewLineAnchor.SelectedLine],
+        side: DiffReviewInlineFeedbackSide,
+        requiresChange: Bool
+    ) -> ClosedRange<Int>? {
+        let lines = selectedLines.compactMap { line -> Int? in
+            guard line.side == side else { return nil }
+            guard !requiresChange || line.isChange else { return nil }
+            return line.line
+        }
+        guard let lower = lines.min(), let upper = lines.max() else { return nil }
+        return lower...upper
     }
 }
 

--- a/Alas/Sources/Center/DiffTabView.swift
+++ b/Alas/Sources/Center/DiffTabView.swift
@@ -511,14 +511,18 @@ struct DiffTabView: View {
     private func savePendingDraft() {
         guard let anchor = pendingDraftAnchor,
               let model = displayModel else { return }
+        let canonicalAnchor = ReviewDraftCommentRowSegmentation.canonicalPendingAnchor(anchor, in: model.groups)
         let body = pendingDraftBody.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !body.isEmpty else { return }
         let validKeys = Set(model.groups.flatMap(ReviewDraftCommentPlacement.allRowKeys))
-        guard validKeys.contains(ReviewDraftCommentPlacement.RowKey(side: anchor.side, line: anchor.line)) else {
+        guard validKeys.contains(ReviewDraftCommentPlacement.RowKey(
+            side: canonicalAnchor.side,
+            line: canonicalAnchor.endLine ?? canonicalAnchor.line
+        )) else {
             clearPendingDraft()
             return
         }
-        try? draftCommentController?.add(anchor: anchor, fileID: fileID, bodyMarkdown: body)
+        try? draftCommentController?.add(anchor: canonicalAnchor, fileID: fileID, bodyMarkdown: body)
         clearPendingDraft()
     }
 

--- a/AlasTests/DiffReviewSurfaceTests.swift
+++ b/AlasTests/DiffReviewSurfaceTests.swift
@@ -690,6 +690,199 @@ struct DiffReviewSurfaceTests {
         #expect(segments.items[0].rows.map(\.id) == [group.rows[0].id, group.rows[1].id])
     }
 
+    @Test func pendingMixedSideDraftComposerUsesSingleNewSideInsertionRow() throws {
+        let contextRow = DiffDisplayRow(
+            id: "context-row",
+            kind: .context,
+            old: diffLine(id: "old-1", side: .old, oldLine: 1, text: "let a = 1"),
+            new: diffLine(id: "new-1", side: .new, newLine: 1, text: "let a = 1"),
+            collapsedLineCount: 0
+        )
+        let deletedRow = DiffDisplayRow(
+            id: "deleted-row",
+            kind: .delete,
+            old: diffLine(id: "old-2", side: .old, oldLine: 2, text: "let b = 2"),
+            new: nil,
+            collapsedLineCount: 0
+        )
+        let addedRow = DiffDisplayRow(
+            id: "added-row",
+            kind: .add,
+            old: nil,
+            new: diffLine(id: "new-2", side: .new, newLine: 2, text: "let b = 3"),
+            collapsedLineCount: 0
+        )
+        let group = DiffDisplayGroup(
+            id: "group",
+            header: "@@ -1,2 +1,2 @@",
+            sourceHunk: parsedDiff().hunks[0],
+            rows: [contextRow, deletedRow, addedRow]
+        )
+        let pendingAnchor = DiffReviewLineAnchor(
+            path: "A.swift",
+            side: .unknown,
+            line: 2,
+            endLine: 2,
+            rowIndex: 1,
+            endRowIndex: 2,
+            selectedLines: [
+                DiffReviewLineAnchor.SelectedLine(side: .old, line: 2, isChange: true),
+                DiffReviewLineAnchor.SelectedLine(side: .new, line: 2, isChange: true),
+            ],
+            selectedText: "let b = 2\nlet b = 3"
+        )
+
+        let segments = ReviewDraftCommentRowSegmentation.segments(
+            for: group,
+            placement: ReviewDraftCommentPlacement.position([], in: [group]),
+            pendingAnchor: pendingAnchor
+        )
+
+        #expect(segments.items.count == 1)
+        #expect(segments.items[0].showsComposer)
+        #expect(segments.items[0].rows.map { $0.id } == ["context-row", "deleted-row", "added-row"])
+    }
+
+    @Test func pendingReplacementDraftComposerDoesNotUseFollowingDisplayRow() throws {
+        let replacementRow = DiffDisplayRow(
+            id: "replacement-row",
+            kind: .replacement,
+            old: diffLine(id: "old-1", side: .old, oldLine: 1, text: "let value = 1", kind: .delete),
+            new: diffLine(id: "new-1", side: .new, newLine: 1, text: "let value = 2", kind: .add),
+            collapsedLineCount: 0
+        )
+        let followingRow = DiffDisplayRow(
+            id: "following-row",
+            kind: .context,
+            old: diffLine(id: "old-2", side: .old, oldLine: 2, text: "return value"),
+            new: diffLine(id: "new-2", side: .new, newLine: 2, text: "return value"),
+            collapsedLineCount: 0
+        )
+        let group = DiffDisplayGroup(
+            id: "group",
+            header: "@@ -1,2 +1,2 @@",
+            sourceHunk: parsedDiff().hunks[0],
+            rows: [replacementRow, followingRow]
+        )
+        let pendingAnchor = DiffReviewLineAnchor(
+            path: "A.swift",
+            side: .unknown,
+            line: 1,
+            endLine: 1,
+            rowIndex: 0,
+            endRowIndex: 1,
+            selectedLines: [
+                DiffReviewLineAnchor.SelectedLine(side: .old, line: 1, isChange: true),
+                DiffReviewLineAnchor.SelectedLine(side: .new, line: 1, isChange: true),
+            ],
+            selectedText: "let value = 1\nlet value = 2"
+        )
+
+        let canonicalAnchor = ReviewDraftCommentRowSegmentation.canonicalPendingAnchor(pendingAnchor, in: [group])
+        let segments = ReviewDraftCommentRowSegmentation.segments(
+            for: group,
+            placement: ReviewDraftCommentPlacement.position([], in: [group]),
+            pendingAnchor: pendingAnchor
+        )
+
+        #expect(canonicalAnchor.side == .new)
+        #expect(canonicalAnchor.line == 1)
+        #expect(canonicalAnchor.endLine == nil)
+        #expect(segments.items.count == 2)
+        #expect(segments.items[0].showsComposer)
+        #expect(segments.items[0].rows.map { $0.id } == ["replacement-row"])
+    }
+
+    @Test func pendingContextAndDeletionDraftComposerUsesDeletedLine() throws {
+        let contextRow = DiffDisplayRow(
+            id: "context-row",
+            kind: .context,
+            old: diffLine(id: "old-10", side: .old, oldLine: 10, text: "let value = 1"),
+            new: diffLine(id: "new-10", side: .new, newLine: 10, text: "let value = 1"),
+            collapsedLineCount: 0
+        )
+        let deletedRow = DiffDisplayRow(
+            id: "deleted-row",
+            kind: .delete,
+            old: diffLine(id: "old-11", side: .old, oldLine: 11, text: "print(value)", kind: .delete),
+            new: nil,
+            collapsedLineCount: 0
+        )
+        let group = DiffDisplayGroup(
+            id: "group",
+            header: "@@ -10,2 +10,1 @@",
+            sourceHunk: parsedDiff().hunks[0],
+            rows: [contextRow, deletedRow]
+        )
+        let pendingAnchor = DiffReviewLineAnchor(
+            path: "A.swift",
+            side: .unknown,
+            line: 10,
+            endLine: 11,
+            rowIndex: 0,
+            endRowIndex: 1,
+            selectedLines: [
+                DiffReviewLineAnchor.SelectedLine(side: .unknown, line: 10, isChange: false),
+                DiffReviewLineAnchor.SelectedLine(side: .old, line: 11, isChange: true),
+            ],
+            selectedText: "let value = 1\nprint(value)"
+        )
+
+        let canonicalAnchor = ReviewDraftCommentRowSegmentation.canonicalPendingAnchor(pendingAnchor, in: [group])
+        let segments = ReviewDraftCommentRowSegmentation.segments(
+            for: group,
+            placement: ReviewDraftCommentPlacement.position([], in: [group]),
+            pendingAnchor: pendingAnchor
+        )
+
+        #expect(canonicalAnchor.side == .old)
+        #expect(canonicalAnchor.line == 11)
+        #expect(canonicalAnchor.endLine == nil)
+        #expect(segments.items.count == 1)
+        #expect(segments.items[0].showsComposer)
+        #expect(segments.items[0].rows.map { $0.id } == ["context-row", "deleted-row"])
+    }
+
+    @Test func pendingContextOnlyDraftComposerUsesUnknownInsertionRow() throws {
+        let contextRow = DiffDisplayRow(
+            id: "context-row",
+            kind: .context,
+            old: diffLine(id: "old-10", side: .old, oldLine: 10, text: "let value = 1"),
+            new: diffLine(id: "new-10", side: .new, newLine: 10, text: "let value = 1"),
+            collapsedLineCount: 0
+        )
+        let group = DiffDisplayGroup(
+            id: "group",
+            header: "@@ -10,1 +10,1 @@",
+            sourceHunk: parsedDiff().hunks[0],
+            rows: [contextRow]
+        )
+        let pendingAnchor = DiffReviewLineAnchor(
+            path: "A.swift",
+            side: .unknown,
+            line: 10,
+            endLine: nil,
+            rowIndex: 0,
+            selectedLines: [
+                DiffReviewLineAnchor.SelectedLine(side: .unknown, line: 10, isChange: false),
+            ],
+            selectedText: "let value = 1"
+        )
+
+        let canonicalAnchor = ReviewDraftCommentRowSegmentation.canonicalPendingAnchor(pendingAnchor, in: [group])
+        let segments = ReviewDraftCommentRowSegmentation.segments(
+            for: group,
+            placement: ReviewDraftCommentPlacement.position([], in: [group]),
+            pendingAnchor: pendingAnchor
+        )
+
+        #expect(canonicalAnchor.side == .unknown)
+        #expect(canonicalAnchor.line == 10)
+        #expect(segments.items.count == 1)
+        #expect(segments.items[0].showsComposer)
+        #expect(segments.items[0].rows.map { $0.id } == ["context-row"])
+    }
+
     @Test func localDraftCommentsOnCollapsedRowsAttachToCollapsedParent() throws {
         let hiddenLine = diffLine(
             id: "hidden-new",
@@ -2486,7 +2679,8 @@ struct DiffReviewSurfaceTests {
         side: DiffLineSide,
         oldLine: Int? = nil,
         newLine: Int? = nil,
-        text: String
+        text: String,
+        kind: ParsedDiff.Hunk.Line.Kind = .context
     ) -> DiffDisplayLine {
         DiffDisplayLine(
             id: id,
@@ -2500,7 +2694,7 @@ struct DiffReviewSurfaceTests {
             ),
             text: text,
             lineNumber: oldLine ?? newLine,
-            kind: .context,
+            kind: kind,
             inlineSpans: [],
             noTrailingNewline: false
         )


### PR DESCRIPTION
## Summary
- canonicalize mixed old/new stacked gutter selections into a single draft anchor
- prefer the new side when selected added lines are present, otherwise fall back to old
- add coverage for the mixed stacked selection composer path

## Verification
- rtk xcodegen
- rtk env ALAS_FFF_TARGET_ARCH=arm64 CURRENT_ARCH=arm64 xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS,arch=arm64' ONLY_ACTIVE_ARCH=YES -quiet build
- rtk env ALAS_FFF_TARGET_ARCH=arm64 CURRENT_ARCH=arm64 xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS,arch=arm64' ONLY_ACTIVE_ARCH=YES -only-testing:AlasTests/DiffReviewSurfaceTests test