### PR TITLE
fix(remote): Clarify remote QR address selection

### DIFF
--- a/Alas/Sources/Remote/Settings/RemoteServerPane.swift
+++ b/Alas/Sources/Remote/Settings/RemoteServerPane.swift
@@ -73,7 +73,7 @@ struct RemoteServerPane: View {
                                 name: "Pairing QR address",
                                 desc: "QR will use \(addressLabel(selected)): \(selected.url)"
                             ) {
-                                Picker("", selection: selectedAddressBinding()) {
+                                Picker("Pairing QR address", selection: selectedAddressBinding()) {
                                     ForEach(state.remoteAdvertisedAddresses) { address in
                                         Text(pickerAddressLabel(address)).tag(address.id)
                                     }

--- a/Alas/Sources/Remote/Settings/RemoteServerPane.swift
+++ b/Alas/Sources/Remote/Settings/RemoteServerPane.swift
@@ -46,9 +46,7 @@ struct RemoteServerPane: View {
                             let fallbackURL = "http://localhost:\(port)"
                             SettingsRow(name: "Localhost", desc: fallbackURL) {
                                 Button {
-                                    let pasteboard = NSPasteboard.general
-                                    pasteboard.clearContents()
-                                    pasteboard.setString(fallbackURL, forType: .string)
+                                    copyAddress(fallbackURL)
                                 } label: {
                                     Text("Copy")
                                         .font(.system(size: 12, weight: .medium))
@@ -61,30 +59,27 @@ struct RemoteServerPane: View {
                                 name: addressLabel(address),
                                 desc: addressDescription(address)
                             ) {
-                                HStack(spacing: 8) {
-                                    if selectedAddress()?.id == address.id {
-                                        Image(systemName: "checkmark")
-                                            .font(.system(size: 13))
-                                            .foregroundColor(theme.color("accent"))
-                                    }
-                                    Button {
-                                        let pasteboard = NSPasteboard.general
-                                        pasteboard.clearContents()
-                                        pasteboard.setString(address.url, forType: .string)
-                                    } label: {
-                                        Text("Copy")
-                                            .font(.system(size: 12, weight: .medium))
-                                    }
-                                    .buttonStyle(.plain)
-
-                                    Button {
-                                        chooseAddress(address)
-                                    } label: {
-                                        Text("Use for QR")
-                                            .font(.system(size: 12, weight: .medium))
-                                    }
-                                    .buttonStyle(.plain)
+                                Button {
+                                    copyAddress(address.url)
+                                } label: {
+                                    Text("Copy")
+                                        .font(.system(size: 12, weight: .medium))
                                 }
+                                .buttonStyle(.plain)
+                            }
+                        }
+                        if let selected = selectedAddress(), !state.remoteAdvertisedAddresses.isEmpty {
+                            SettingsRow(
+                                name: "Pairing QR address",
+                                desc: "QR will use \(addressLabel(selected)): \(selected.url)"
+                            ) {
+                                Picker("", selection: selectedAddressBinding()) {
+                                    ForEach(state.remoteAdvertisedAddresses) { address in
+                                        Text(addressLabel(address)).tag(address.id)
+                                    }
+                                }
+                                .pickerStyle(.segmented)
+                                .labelsHidden()
                             }
                         }
                         SettingsRow(
@@ -194,6 +189,22 @@ struct RemoteServerPane: View {
             return "\(address.url) on \(interface)"
         }
         return address.url
+    }
+
+    private func selectedAddressBinding() -> Binding<String> {
+        Binding(
+            get: { selectedAddress()?.id ?? "" },
+            set: { id in
+                guard let address = state.remoteAdvertisedAddresses.first(where: { $0.id == id }) else { return }
+                chooseAddress(address)
+            }
+        )
+    }
+
+    private func copyAddress(_ url: String) {
+        let pasteboard = NSPasteboard.general
+        pasteboard.clearContents()
+        pasteboard.setString(url, forType: .string)
     }
 
     private func chooseAddress(_ address: RemoteAdvertisedAddress) {

--- a/Alas/Sources/Remote/Settings/RemoteServerPane.swift
+++ b/Alas/Sources/Remote/Settings/RemoteServerPane.swift
@@ -75,7 +75,7 @@ struct RemoteServerPane: View {
                             ) {
                                 Picker("", selection: selectedAddressBinding()) {
                                     ForEach(state.remoteAdvertisedAddresses) { address in
-                                        Text(addressLabel(address)).tag(address.id)
+                                        Text(pickerAddressLabel(address)).tag(address.id)
                                     }
                                 }
                                 .pickerStyle(.segmented)
@@ -189,6 +189,18 @@ struct RemoteServerPane: View {
             return "\(address.url) on \(interface)"
         }
         return address.url
+    }
+
+    private func pickerAddressLabel(_ address: RemoteAdvertisedAddress) -> String {
+        let label = addressLabel(address)
+        let matching = state.remoteAdvertisedAddresses.filter { addressLabel($0) == label }
+        guard matching.count > 1 else { return label }
+
+        if let interfaceName = address.interfaceName,
+           matching.filter({ $0.interfaceName == interfaceName }).count == 1 {
+            return "\(label) \(interfaceName)"
+        }
+        return "\(label) \(address.host)"
     }
 
     private func selectedAddressBinding() -> Binding<String> {

--- a/docs/superpowers/plans/2026-07-05-remote-qr-address-picker.md
+++ b/docs/superpowers/plans/2026-07-05-remote-qr-address-picker.md
@@ -1,0 +1,183 @@
+# Remote QR Address Picker Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make the Remote settings pane clearly show and control which advertised URL is encoded into the pairing QR.
+
+**Architecture:** Keep the existing `RemoteServerPane` as the owner of the UI behavior and persisted `remote.preferredAdvertisedHost` state. Replace per-address "Use for QR" controls with one segmented selector row whose binding writes the selected address host through the existing `chooseAddress(_:)` path. Keep QR generation routed through `pairingURL(port:)` so generated and auto-refreshed QR codes inherit the selected address.
+
+**Tech Stack:** Swift 5.9+, SwiftUI for macOS settings UI, existing `RemoteAdvertisedAddress` and `AppConfig.Remote` persistence, Swift Testing only if a practical pure test seam is already present.
+
+---
+
+## File Structure
+
+- Modify `Alas/Sources/Remote/Settings/RemoteServerPane.swift`
+  - Add a dedicated `Pairing QR address` settings row.
+  - Add a segmented `Picker` bound to the selected advertised address id.
+  - Remove `Use for QR` buttons and selected checkmark from individual address rows.
+  - Keep `Copy`, fallback localhost behavior, and QR generation behavior intact.
+
+No new production file is needed because the change is tightly scoped to one settings pane. Do not alter unrelated settings infrastructure.
+
+## Task 1: Add the Segmented QR Address Selector
+
+**Files:**
+- Modify: `Alas/Sources/Remote/Settings/RemoteServerPane.swift`
+
+- [ ] **Step 1: Inspect the current pane and address helpers**
+
+Run:
+
+```bash
+rtk sed -n '1,260p' Alas/Sources/Remote/Settings/RemoteServerPane.swift
+```
+
+Expected: the file contains `ForEach(state.remoteAdvertisedAddresses)`, `chooseAddress(_:)`, `pairingURL(port:)`, and `selectedAddress()`.
+
+- [ ] **Step 2: Add the selector row after the advertised address rows**
+
+In `RemoteServerPane.body`, inside `if state.config.remote.enabled, let port = state.remotePort`, after the `ForEach(state.remoteAdvertisedAddresses)` block and before `SettingsRow(name: "PWA install", ...)`, add:
+
+```swift
+if let selected = selectedAddress(), !state.remoteAdvertisedAddresses.isEmpty {
+    SettingsRow(
+        name: "Pairing QR address",
+        desc: "QR will use \(addressLabel(selected)): \(selected.url)"
+    ) {
+        Picker("", selection: selectedAddressBinding()) {
+            ForEach(state.remoteAdvertisedAddresses) { address in
+                Text(addressLabel(address)).tag(address.id)
+            }
+        }
+        .pickerStyle(.segmented)
+        .labelsHidden()
+    }
+}
+```
+
+This row must be shown only when advertised addresses exist. The fallback localhost-only state must not show a selector.
+
+- [ ] **Step 3: Replace per-row selection controls with Copy only**
+
+In the `ForEach(state.remoteAdvertisedAddresses)` row control, replace the existing `HStack` containing the checkmark, `Copy`, and `Use for QR` button with this single `Copy` button:
+
+```swift
+Button {
+    copyAddress(address.url)
+} label: {
+    Text("Copy")
+        .font(.system(size: 12, weight: .medium))
+}
+.buttonStyle(.plain)
+```
+
+Also update the localhost fallback row's copy action to use the same helper:
+
+```swift
+copyAddress(fallbackURL)
+```
+
+- [ ] **Step 4: Add the binding and copy helpers**
+
+Near the existing private helper methods in `RemoteServerPane`, add:
+
+```swift
+private func selectedAddressBinding() -> Binding<String> {
+    Binding(
+        get: { selectedAddress()?.id ?? "" },
+        set: { id in
+            guard let address = state.remoteAdvertisedAddresses.first(where: { $0.id == id }) else { return }
+            chooseAddress(address)
+        }
+    )
+}
+
+private func copyAddress(_ url: String) {
+    let pasteboard = NSPasteboard.general
+    pasteboard.clearContents()
+    pasteboard.setString(url, forType: .string)
+}
+```
+
+Keep `chooseAddress(_:)`, `pairingURL(port:)`, and `selectedAddress()` as the source of persisted selection and QR URL behavior.
+
+- [ ] **Step 5: Build the app**
+
+Run:
+
+```bash
+rtk xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -quiet build
+```
+
+Expected: build exits 0.
+
+- [ ] **Step 6: Self-review the UI logic**
+
+Check:
+
+```bash
+rtk git diff -- Alas/Sources/Remote/Settings/RemoteServerPane.swift
+```
+
+Expected:
+
+- `Use for QR` no longer appears.
+- `Pairing QR address` appears exactly once.
+- The segmented picker writes through `chooseAddress(_:)`.
+- `pairingURL(port:)` still derives from `selectedAddress()`.
+- No fallback localhost selector is shown when `remoteAdvertisedAddresses` is empty.
+
+- [ ] **Step 7: Commit**
+
+Run:
+
+```bash
+rtk git add Alas/Sources/Remote/Settings/RemoteServerPane.swift
+rtk git commit -m "feat: clarify remote qr address selection"
+```
+
+Expected: commit succeeds with only the Remote settings pane change.
+
+## Task 2: Verify Focused Behavior and Plan Compliance
+
+**Files:**
+- Inspect: `docs/superpowers/specs/2026-07-05-remote-qr-address-picker-design.md`
+- Inspect: `Alas/Sources/Remote/Settings/RemoteServerPane.swift`
+
+- [ ] **Step 1: Compare implementation to the design spec**
+
+Run:
+
+```bash
+rtk sed -n '1,180p' docs/superpowers/specs/2026-07-05-remote-qr-address-picker-design.md
+rtk sed -n '1,260p' Alas/Sources/Remote/Settings/RemoteServerPane.swift
+```
+
+Expected:
+
+- Multiple advertised addresses show one segmented selector row.
+- Address rows remain visible for inspection and copying.
+- Selection persists through `remote.preferredAdvertisedHost`.
+- QR URL continues through `pairingURL(port:)`.
+- No extra remote behavior is introduced.
+
+- [ ] **Step 2: Run a focused build verification**
+
+Run:
+
+```bash
+rtk xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -quiet build
+```
+
+Expected: build exits 0.
+
+- [ ] **Step 3: Check the final diff**
+
+Run:
+
+```bash
+rtk git diff HEAD~1..HEAD -- Alas/Sources/Remote/Settings/RemoteServerPane.swift
+```
+
+Expected: the final implementation commit contains only the selector row, simplified copy rows, and small helper methods.

--- a/docs/superpowers/plans/2026-07-05-remote-qr-address-picker.md
+++ b/docs/superpowers/plans/2026-07-05-remote-qr-address-picker.md
@@ -25,7 +25,7 @@ No new production file is needed because the change is tightly scoped to one set
 **Files:**
 - Modify: `Alas/Sources/Remote/Settings/RemoteServerPane.swift`
 
-- [ ] **Step 1: Inspect the current pane and address helpers**
+- [x] **Step 1: Inspect the current pane and address helpers**
 
 Run:
 
@@ -35,7 +35,7 @@ rtk sed -n '1,260p' Alas/Sources/Remote/Settings/RemoteServerPane.swift
 
 Expected: the file contains `ForEach(state.remoteAdvertisedAddresses)`, `chooseAddress(_:)`, `pairingURL(port:)`, and `selectedAddress()`.
 
-- [ ] **Step 2: Add the selector row after the advertised address rows**
+- [x] **Step 2: Add the selector row after the advertised address rows**
 
 In `RemoteServerPane.body`, inside `if state.config.remote.enabled, let port = state.remotePort`, after the `ForEach(state.remoteAdvertisedAddresses)` block and before `SettingsRow(name: "PWA install", ...)`, add:
 
@@ -58,7 +58,7 @@ if let selected = selectedAddress(), !state.remoteAdvertisedAddresses.isEmpty {
 
 This row must be shown only when advertised addresses exist. The fallback localhost-only state must not show a selector.
 
-- [ ] **Step 3: Replace per-row selection controls with Copy only**
+- [x] **Step 3: Replace per-row selection controls with Copy only**
 
 In the `ForEach(state.remoteAdvertisedAddresses)` row control, replace the existing `HStack` containing the checkmark, `Copy`, and `Use for QR` button with this single `Copy` button:
 
@@ -78,7 +78,7 @@ Also update the localhost fallback row's copy action to use the same helper:
 copyAddress(fallbackURL)
 ```
 
-- [ ] **Step 4: Add the binding and copy helpers**
+- [x] **Step 4: Add the binding and copy helpers**
 
 Near the existing private helper methods in `RemoteServerPane`, add:
 
@@ -102,7 +102,7 @@ private func copyAddress(_ url: String) {
 
 Keep `chooseAddress(_:)`, `pairingURL(port:)`, and `selectedAddress()` as the source of persisted selection and QR URL behavior.
 
-- [ ] **Step 5: Build the app**
+- [x] **Step 5: Build the app**
 
 Run:
 
@@ -112,7 +112,7 @@ rtk xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS
 
 Expected: build exits 0.
 
-- [ ] **Step 6: Self-review the UI logic**
+- [x] **Step 6: Self-review the UI logic**
 
 Check:
 
@@ -128,7 +128,7 @@ Expected:
 - `pairingURL(port:)` still derives from `selectedAddress()`.
 - No fallback localhost selector is shown when `remoteAdvertisedAddresses` is empty.
 
-- [ ] **Step 7: Commit**
+- [x] **Step 7: Commit**
 
 Run:
 
@@ -145,7 +145,7 @@ Expected: commit succeeds with only the Remote settings pane change.
 - Inspect: `docs/superpowers/specs/2026-07-05-remote-qr-address-picker-design.md`
 - Inspect: `Alas/Sources/Remote/Settings/RemoteServerPane.swift`
 
-- [ ] **Step 1: Compare implementation to the design spec**
+- [x] **Step 1: Compare implementation to the design spec**
 
 Run:
 
@@ -162,7 +162,7 @@ Expected:
 - QR URL continues through `pairingURL(port:)`.
 - No extra remote behavior is introduced.
 
-- [ ] **Step 2: Run a focused build verification**
+- [x] **Step 2: Run a focused build verification**
 
 Run:
 
@@ -172,7 +172,7 @@ rtk xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS
 
 Expected: build exits 0.
 
-- [ ] **Step 3: Check the final diff**
+- [x] **Step 3: Check the final diff**
 
 Run:
 

--- a/docs/superpowers/specs/2026-07-05-remote-qr-address-picker-design.md
+++ b/docs/superpowers/specs/2026-07-05-remote-qr-address-picker-design.md
@@ -1,0 +1,62 @@
+# Remote QR Address Picker Design
+
+## Context
+
+The Remote settings pane can expose multiple advertised URLs for the same
+remote server: LAN, localhost, tailnet, or custom hostnames. The current UI lets
+each address row copy its URL and contains a separate "Use for QR" action. The
+selected state is only shown as a small checkmark on the row, while the actual
+"Pair a device" action lives lower in the section.
+
+That makes the pairing QR target easy to miss. The user should be able to tell,
+before generating or scanning a QR code, which advertised URL the QR will encode.
+
+## Goal
+
+Make the QR target explicit by adding a dedicated address selector near the
+pairing action. The control should preserve the existing persisted
+`remote.preferredAdvertisedHost` behavior and keep URL rows useful for copying.
+
+## Design
+
+When remote control is enabled and advertised addresses are available, the pane
+shows a new settings row between the address list and the "PWA install" / "Pair a
+device" rows:
+
+- Row title: `Pairing QR address`
+- Row description: `QR will use <label>: <url>`
+- Row control: a segmented `Picker` containing each available advertised address
+  label, such as `LAN`, `Localhost`, `Tailnet`, or `Custom`
+
+Selecting a segment immediately saves that address as
+`state.config.remote.preferredAdvertisedHost`, calls the same refresh path used
+by the existing row action, and causes future pairing URLs to use the selected
+address.
+
+The individual advertised address rows remain visible, but they stop carrying
+selection controls. Each row shows the address label, URL description, and a
+`Copy` action only. This separates URL inspection/copying from QR target
+selection.
+
+If no advertised addresses are available, the existing fallback behavior remains
+simple: the pairing URL uses `http://localhost:<port>`, and no segmented selector
+is shown.
+
+## QR Behavior
+
+The QR URL continues to be derived through the existing `pairingURL(port:)`
+flow. Because that function already reads `selectedAddress()`, changing the
+preferred host updates newly generated QR codes and also affects the automatic
+QR refresh while a code is visible.
+
+## Testing
+
+Add focused Swift Testing coverage for the pure selection behavior if a practical
+test seam already exists around remote advertised addresses. Otherwise verify
+with a focused macOS build and manual settings-pane inspection:
+
+- Remote enabled with multiple advertised addresses shows the segmented selector.
+- Changing the segment updates the persisted preferred host.
+- Generated QR uses the selected address.
+- URL rows still copy their exact URLs.
+- Fallback localhost behavior still works when there are no advertised addresses.


### PR DESCRIPTION
## Summary

- add a dedicated Remote settings row for choosing which advertised address is encoded into the pairing QR
- make advertised address rows copy-only so QR selection lives in one place
- disambiguate duplicate segmented-picker labels and give the hidden picker a useful accessibility label

## Verification

- `env ALAS_FFF_TARGET_ARCH=arm64 ALAS_ZMX_TARGET_ARCH=arm64 rtk xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS,arch=arm64' -quiet build`
