### PR TITLE
fix(acp): stop dropping leading fragments of new messages after restore

### DIFF
--- a/Alas/Sources/ACP/Session/ACPSession.swift
+++ b/Alas/Sources/ACP/Session/ACPSession.swift
@@ -1523,23 +1523,26 @@ final class ACPSession: ObservableObject, Identifiable {
         }
     }
 
-    /// When a diverged replay `candidate` reproduces the tail of the
-    /// trailing in-progress bubble of `kind` and then continues past it, the
-    /// stream is that already-present message replayed under a regenerated
-    /// id and continued past the boundary window. Append only the text
-    /// beyond the reproduced portion (so nothing already present is
-    /// duplicated) and rebind the bubble to the regenerated `messageId` so
-    /// subsequent chunks target it via `messageIndex`. Returns the adopted
-    /// message's index, or nil when no suffix of the bubble is a prefix of
-    /// the candidate (genuine new output).
+    /// When a diverged replay `candidate` reproduces the *entire* trailing
+    /// in-progress bubble of `kind` as a prefix and then continues past it,
+    /// the stream is that already-present message replayed under a
+    /// regenerated id and continued past the boundary window. Append only
+    /// the text beyond the bubble (so the hydrated prefix is not duplicated)
+    /// and rebind the bubble to the regenerated `messageId` so subsequent
+    /// chunks target it via `messageIndex`. Returns the adopted message's
+    /// index, or nil when the candidate does not begin with the whole bubble
+    /// (genuine new output).
     ///
-    /// Matching the longest *suffix* of the bubble (not just the whole
-    /// bubble) handles a mid-message replay slip: the suppression counter
-    /// can fall between chunks, so the first surviving chunk may be a middle
-    /// fragment (`"world"` of `"hello world"`) that then continues (`"!"`),
-    /// which must extend the bubble to `"hello world!"` rather than spawn a
-    /// duplicate. A full replay is just the special case where the matched
-    /// suffix is the whole bubble.
+    /// Only a *whole-bubble* prefix is adopted, never a partial suffix. A
+    /// regenerated id that reproduces just the tail of the bubble is
+    /// indistinguishable from a genuinely separate message that happens to
+    /// start with the bubble's last word (`"hello world"` followed by a new
+    /// `"world again"` reads identically to a mid-message replay `"world"` +
+    /// `"!"`), and ACP message ids normally delimit separate rows — so a
+    /// partial match starts its own row rather than risk a corrupting merge.
+    /// A mid-message replay slip that is then continued therefore surfaces as
+    /// a (rare) duplicate bubble instead; that is the accepted trade-off for
+    /// never mutating a genuinely separate message into an existing bubble.
     ///
     /// The adoption target is exactly `lastAgent()`/`lastThought()` — the
     /// same trailing bubble a legacy (id-less) chunk would extend — so the
@@ -1561,32 +1564,9 @@ final class ACPSession: ObservableObject, Identifiable {
         default:
             return nil
         }
-        guard !existing.isEmpty else { return nil }
-        // Longest suffix of `existing` that is a prefix of `candidate` — the
-        // reproduced portion. The remaining candidate is the genuine new
-        // continuation to append. The reproduced suffix must begin at a token
-        // boundary (the start of the bubble, or after a non-alphanumeric
-        // character — whitespace or punctuation): unrecognised message ids
-        // otherwise start their own rows, so a coincidental mid-word overlap
-        // (a new message `"Keep going"` whose `"K"` matches the tail of a
-        // hydrated `"OK"`) must not be mistaken for a replay continuation and
-        // merged into the old bubble, while a punctuation-bounded suffix
-        // (`"Running"` after `"tests completed."`) is still adopted.
-        var suffix: String?
-        let existingChars = Array(existing)
-        let maxOverlap = min(existingChars.count, candidate.count)
-        for overlap in stride(from: maxOverlap, through: 1, by: -1) {
-            let startOffset = existingChars.count - overlap
-            if startOffset > 0 {
-                let preceding = existingChars[startOffset - 1]
-                if preceding.isLetter || preceding.isNumber { continue }
-            }
-            if candidate.hasPrefix(String(existingChars[startOffset...])) {
-                suffix = String(candidate.dropFirst(overlap))
-                break
-            }
-        }
-        guard let suffix, !suffix.isEmpty else { return nil }
+        guard !existing.isEmpty, candidate.hasPrefix(existing) else { return nil }
+        let suffix = String(candidate.dropFirst(existing.count))
+        guard !suffix.isEmpty else { return nil }
         switch transcript.messages[i] {
         case .agent(let id, _, let buf):
             buf.append(suffix)

--- a/Alas/Sources/ACP/Session/ACPSession.swift
+++ b/Alas/Sources/ACP/Session/ACPSession.swift
@@ -101,6 +101,16 @@ final class ACPSession: ObservableObject, Identifiable {
     /// check is never reached).
     var allowsStreamingBoundaryCrossing: Bool = true
 
+    /// Running text of streaming chunks that arrived with an unrecognised
+    /// `messageId` while `allowsStreamingBoundaryCrossing` was false and
+    /// still look like a late load-replay (their accumulated text is a
+    /// prefix of an already-present message). Keyed by messageId. Held
+    /// rather than dropped so that if the stream diverges — i.e. it is
+    /// genuine new output whose leading fragment merely coincided with an
+    /// earlier message — the full text can be materialised without losing
+    /// the leading characters. Cleared once the boundary window ends.
+    private var pendingReplayPrefixes: [String: String] = [:]
+
     private var reconciledLocalUserPromptMessageIds: Set<String> = []
     private var reconciledLegacyLocalUserPromptIds: Set<UUID> = []
     private var liveUserChunkMessageIds: Set<String> = []
@@ -265,8 +275,8 @@ final class ACPSession: ObservableObject, Identifiable {
                 messageId: chunk.messageId,
                 locateByMessageId: { id in messageIndex(messageId: id, kind: .agent) },
                 locateLegacy: { lastAgent() },
-                isLikelyReplay: { text in chunkIsLikelyReplay(kind: .agent, of: text) },
-                makeNew: { .agent(id: UUID(), messageId: chunk.messageId, StreamingText(txt)) }) else {
+                replayPrefixMatches: { text in existingMessageHasPrefix(kind: .agent, text) },
+                makeNew: { text in .agent(id: UUID(), messageId: chunk.messageId, StreamingText(text)) }) else {
                 return []
             }
             return [i]
@@ -287,8 +297,8 @@ final class ACPSession: ObservableObject, Identifiable {
                 messageId: chunk.messageId,
                 locateByMessageId: { id in messageIndex(messageId: id, kind: .thought) },
                 locateLegacy: { lastThought() },
-                isLikelyReplay: { text in chunkIsLikelyReplay(kind: .thought, of: text) },
-                makeNew: { .thought(id: UUID(), messageId: chunk.messageId, StreamingText(txt)) }) else {
+                replayPrefixMatches: { text in existingMessageHasPrefix(kind: .thought, text) },
+                makeNew: { text in .thought(id: UUID(), messageId: chunk.messageId, StreamingText(text)) }) else {
                 return []
             }
             return [i]
@@ -1458,44 +1468,22 @@ final class ACPSession: ObservableObject, Identifiable {
         }
     }
 
-    /// A late load-replay frame with an unrecognised messageId
-    /// re-delivers a *complete*, previously seen message. Genuine live
-    /// output streams in small increments whose leading fragments (`I`,
-    /// `The`, `'ve`, a lone space) are almost always coincidental
-    /// substrings of an earlier message. Classifying such a fragment as a
-    /// replay drops it and rebuilds the message from a later chunk,
-    /// corrupting the visible text (`I've` rendered as `'ve`). Only treat
-    /// the chunk as a replay when it reproduces a whole existing message,
-    /// or is a substantial (non-fragment) span contained in one.
-    private func chunkIsLikelyReplay(kind: TextMessageKind, of addition: String) -> Bool {
-        let trimmed = addition.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard !trimmed.isEmpty else { return false }
+    /// Whether some existing message of `kind` begins with `text` — i.e.
+    /// `text` could be the running prefix of a late load-replay stream
+    /// reconstructing that already-present message. Drives the replay
+    /// guard in `appendStreaming`.
+    private func existingMessageHasPrefix(kind: TextMessageKind, _ text: String) -> Bool {
+        guard !text.isEmpty else { return false }
         return transcript.messages.contains { message in
-            let existing: String
             switch (kind, message) {
             case (.agent, .agent(_, _, let buf)),
                  (.thought, .thought(_, _, let buf)):
-                existing = buf.value
+                return buf.value.hasPrefix(text)
             default:
                 return false
             }
-            // Whole-message replay: the chunk reproduces an existing
-            // message verbatim (the canonical single-chunk replay frame).
-            if existing.trimmingCharacters(in: .whitespacesAndNewlines) == trimmed {
-                return true
-            }
-            // Multi-chunk replay straggler: a substantial span already
-            // present in an existing message. The length floor keeps short
-            // leading fragments of genuine new output from being dropped.
-            return trimmed.count >= Self.replayFragmentMinimumLength && existing.contains(addition)
         }
     }
-
-    /// Minimum length for a streaming chunk to be eligible for
-    /// substring-based replay suppression. Below this, a chunk is treated
-    /// as genuine new output even if it happens to appear inside an
-    /// earlier message — see `chunkIsLikelyReplay(kind:of:)`.
-    private static let replayFragmentMinimumLength = 16
 
     private func userMessageExists(containing text: String, attachments: [ACPMessage.Attachment]) -> Bool {
         guard !text.isEmpty || !attachments.isEmpty else { return false }
@@ -1513,8 +1501,14 @@ final class ACPSession: ObservableObject, Identifiable {
                                  messageId: String?,
                                  locateByMessageId: (String) -> Int?,
                                  locateLegacy: () -> Int?,
-                                 isLikelyReplay: (String) -> Bool,
-                                 makeNew: () -> ACPMessage) -> Int? {
+                                 replayPrefixMatches: (String) -> Bool,
+                                 makeNew: (String) -> ACPMessage) -> Int? {
+        // Outside the boundary-crossing window there is no late replay to
+        // guard against — drop any accumulated candidates so they never
+        // leak into a later window.
+        if allowsStreamingBoundaryCrossing, !pendingReplayPrefixes.isEmpty {
+            pendingReplayPrefixes.removeAll(keepingCapacity: false)
+        }
         let located = if let messageId {
             locateByMessageId(messageId)
         } else {
@@ -1546,10 +1540,28 @@ final class ACPSession: ObservableObject, Identifiable {
                 }
             }
         }
-        if messageId != nil, !allowsStreamingBoundaryCrossing, isLikelyReplay(addition) {
-            return nil
+        // Late load-replay guard for an unrecognised messageId. A replay
+        // re-streams an already-present message from its start, so we
+        // accumulate this messageId's chunks and keep suppressing while
+        // the running text stays a prefix of some existing message. Once
+        // it diverges it is genuine new output — materialise it in full so
+        // no leading fragment is lost (a short first fragment like "I" or
+        // "The " coinciding with an earlier message would otherwise be
+        // dropped, corrupting the text, or — if suppressed per-chunk —
+        // duplicate a chunked replay). Single-chunk full replays still
+        // never create a message.
+        var newMessageText = addition
+        if let messageId, !allowsStreamingBoundaryCrossing {
+            let previous = pendingReplayPrefixes[messageId]
+            let candidate = (previous ?? "") + Self.streamingSeparator(between: previous ?? "", and: addition) + addition
+            if replayPrefixMatches(candidate) {
+                pendingReplayPrefixes[messageId] = candidate
+                return nil
+            }
+            pendingReplayPrefixes.removeValue(forKey: messageId)
+            newMessageText = candidate
         }
-        transcript.messages.append(makeNew())
+        transcript.messages.append(makeNew(newMessageText))
         didAppendTranscriptMessage()
         return transcript.messages.count - 1
     }

--- a/Alas/Sources/ACP/Session/ACPSession.swift
+++ b/Alas/Sources/ACP/Session/ACPSession.swift
@@ -289,27 +289,33 @@ final class ACPSession: ObservableObject, Identifiable {
     /// transcript, not just the trailing row.
     @discardableResult
     func apply(_ update: ACPSessionUpdate) -> Set<Int> {
-        // Materialise any held replay candidate first when a row-appending
-        // update closes the current in-progress text message (a tool call or
-        // plan), or once the boundary window has ended — so a suppressed
-        // short fragment (e.g. "I", buffered because it is a substring of
-        // prior output) is emitted in order rather than being stranded in
-        // `pendingReplayCandidates` and dropped when the message ends without
-        // a further diverging text chunk. State-only updates
-        // (usage/model/mode/config/commands/sessionInfo, `toolCallUpdate`,
-        // unknown) append no row and do not close the text message, so they
-        // must NOT flush a still-buffered replay chunk into a duplicate row.
-        // `userMessageChunk` is handled inside `appendUserChunk` instead: it
-        // can itself be a replay that is dropped, so its flush is deferred
-        // until the chunk is known to append a real new prompt.
-        let shouldFlushPending: Bool
-        switch update {
-        case .toolCall, .plan:
-            shouldFlushPending = true
-        default:
-            shouldFlushPending = allowsStreamingBoundaryCrossing
+        // Materialise held replay candidates in order before an update that
+        // closes their message, so a suppressed short fragment (e.g. "I",
+        // buffered because it is a substring of prior output) is emitted in
+        // place rather than stranded in `pendingReplayCandidates` and dropped.
+        // Once the boundary window has ended, flush everything (residual
+        // candidates are genuine output). Within the window:
+        //   • a tool call or plan closes the whole in-progress run;
+        //   • an agent answer closes an in-progress thought (`lastThought()`
+        //     stops at `.agent`), so flush pending thoughts ahead of it — the
+        //     agent candidate itself is handled by `appendStreaming`.
+        // State-only updates append no row and must NOT flush a buffered
+        // chunk into a duplicate; `userMessageChunk` is handled inside
+        // `appendUserChunk` (it can itself be a dropped replay).
+        let kindsToFlush: Set<TextMessageKind>
+        if allowsStreamingBoundaryCrossing {
+            kindsToFlush = [.agent, .thought]
+        } else {
+            switch update {
+            case .toolCall, .plan:
+                kindsToFlush = [.agent, .thought]
+            case .agentMessageChunk:
+                kindsToFlush = [.thought]
+            default:
+                kindsToFlush = []
+            }
         }
-        let flushed = shouldFlushPending ? flushPendingReplayCandidates() : []
+        let flushed = kindsToFlush.isEmpty ? [] : flushPendingReplayCandidates(kinds: kindsToFlush)
         let result: Set<Int> = { () -> Set<Int> in
         switch update {
         case .agentMessageChunk(let chunk):
@@ -442,16 +448,30 @@ final class ACPSession: ObservableObject, Identifiable {
         return flushed.union(result)
     }
 
-    /// Materialise every held replay candidate as a new row (in a stable
-    /// order) and clear the buffer. Returns the indices appended so the
-    /// caller can persist them. Called when the current text message closes
-    /// (a non-text update) or the boundary window ends, so a suppressed
-    /// short fragment is never stranded and dropped.
-    private func flushPendingReplayCandidates() -> Set<Int> {
+    /// Materialise held replay candidates of the given `kinds` as new rows
+    /// (in a stable order), removing them from the buffer. Returns the
+    /// indices appended so the caller can persist them. Called when the
+    /// current text message closes (a row-appending update), the boundary
+    /// window ends, or the turn completes, so a suppressed short fragment is
+    /// never stranded and dropped.
+    ///
+    /// A candidate whose accumulated text exactly reproduces a complete
+    /// existing message of its kind is a pure full replay that never
+    /// diverged — it is dropped rather than materialised, preserving replay
+    /// suppression. A candidate that merely coincided with a *substring* of a
+    /// longer message (a genuine one-chunk reply like "OK" against an
+    /// existing "OK done.") is materialised.
+    @discardableResult
+    private func flushPendingReplayCandidates(kinds: Set<TextMessageKind> = [.agent, .thought]) -> Set<Int> {
         guard !pendingReplayCandidates.isEmpty else { return [] }
         var indices: Set<Int> = []
         for key in pendingReplayCandidates.keys.sorted(by: { $0.messageId < $1.messageId }) {
-            guard let candidate = pendingReplayCandidates[key] else { continue }
+            guard kinds.contains(key.kind), let candidate = pendingReplayCandidates[key] else { continue }
+            pendingReplayCandidates.removeValue(forKey: key)
+            if existingMessageEquals(kind: key.kind, candidate.display)
+                || existingMessageEquals(kind: key.kind, candidate.raw) {
+                continue // pure full replay — keep suppressed
+            }
             let message: ACPMessage
             switch key.kind {
             case .agent:
@@ -465,8 +485,21 @@ final class ACPSession: ObservableObject, Identifiable {
             didAppendTranscriptMessage()
             indices.insert(transcript.messages.count - 1)
         }
-        pendingReplayCandidates.removeAll()
         return indices
+    }
+
+    /// Whether some existing message of `kind` has value exactly equal to
+    /// `text` — i.e. `text` reproduces that complete message (a full replay).
+    private func existingMessageEquals(kind: TextMessageKind, _ text: String) -> Bool {
+        transcript.messages.contains { message in
+            switch (kind, message) {
+            case (.agent, .agent(_, _, let buf)),
+                 (.thought, .thought(_, _, let buf)):
+                return buf.value == text
+            default:
+                return false
+            }
+        }
     }
 
     func applySuppressedReplaySideEffects(_ update: ACPSessionUpdate) -> Set<Int> {

--- a/Alas/Sources/ACP/Session/ACPSession.swift
+++ b/Alas/Sources/ACP/Session/ACPSession.swift
@@ -1559,11 +1559,21 @@ final class ACPSession: ObservableObject, Identifiable {
         guard !existing.isEmpty else { return nil }
         // Longest suffix of `existing` that is a prefix of `candidate` — the
         // reproduced portion. The remaining candidate is the genuine new
-        // continuation to append.
+        // continuation to append. The reproduced suffix must begin at a word
+        // boundary (the start of the bubble, or just after whitespace):
+        // unrecognised message ids otherwise start their own rows, so a
+        // coincidental mid-token overlap (a new message `"Keep going"` whose
+        // `"K"` matches the tail of a hydrated `"OK"`) must not be mistaken
+        // for a replay continuation and merged into the old bubble.
         var suffix: String?
-        let maxOverlap = min(existing.count, candidate.count)
+        let existingChars = Array(existing)
+        let maxOverlap = min(existingChars.count, candidate.count)
         for overlap in stride(from: maxOverlap, through: 1, by: -1) {
-            if candidate.hasPrefix(String(existing.suffix(overlap))) {
+            let startOffset = existingChars.count - overlap
+            if startOffset > 0, !existingChars[startOffset - 1].isWhitespace {
+                continue
+            }
+            if candidate.hasPrefix(String(existingChars[startOffset...])) {
                 suffix = String(candidate.dropFirst(overlap))
                 break
             }

--- a/Alas/Sources/ACP/Session/ACPSession.swift
+++ b/Alas/Sources/ACP/Session/ACPSession.swift
@@ -290,18 +290,21 @@ final class ACPSession: ObservableObject, Identifiable {
     @discardableResult
     func apply(_ update: ACPSessionUpdate) -> Set<Int> {
         // Materialise any held replay candidate first when a row-appending
-        // update closes the current in-progress text message (a tool call,
-        // plan, or user prompt), or once the boundary window has ended — so a
-        // suppressed short fragment (e.g. "I", buffered because it is a
-        // substring of prior output) is emitted in order rather than being
-        // stranded in `pendingReplayCandidates` and dropped when the message
-        // ends without a further diverging text chunk. State-only updates
+        // update closes the current in-progress text message (a tool call or
+        // plan), or once the boundary window has ended — so a suppressed
+        // short fragment (e.g. "I", buffered because it is a substring of
+        // prior output) is emitted in order rather than being stranded in
+        // `pendingReplayCandidates` and dropped when the message ends without
+        // a further diverging text chunk. State-only updates
         // (usage/model/mode/config/commands/sessionInfo, `toolCallUpdate`,
         // unknown) append no row and do not close the text message, so they
         // must NOT flush a still-buffered replay chunk into a duplicate row.
+        // `userMessageChunk` is handled inside `appendUserChunk` instead: it
+        // can itself be a replay that is dropped, so its flush is deferred
+        // until the chunk is known to append a real new prompt.
         let shouldFlushPending: Bool
         switch update {
-        case .toolCall, .plan, .userMessageChunk:
+        case .toolCall, .plan:
             shouldFlushPending = true
         default:
             shouldFlushPending = allowsStreamingBoundaryCrossing
@@ -328,13 +331,15 @@ final class ACPSession: ObservableObject, Identifiable {
             return [i]
         case .userMessageChunk(let chunk):
             let txt = text(of: chunk.content)
+            var flushedForUser: Set<Int> = []
             guard let i = appendUserChunk(
                 text: txt,
                 attachments: ACPSessionRunner.attachments(of: [chunk.content]),
-                messageId: chunk.messageId) else {
+                messageId: chunk.messageId,
+                flushedReplayIndices: &flushedForUser) else {
                 return []
             }
-            return [i]
+            return flushedForUser.union([i])
         case .agentThoughtChunk(let chunk):
             clearRestoredContextRecoveryStatus()
             let txt = text(of: chunk.content)
@@ -1410,7 +1415,7 @@ final class ACPSession: ObservableObject, Identifiable {
         }
     }
 
-    private func appendUserChunk(text addition: String, attachments newAttachments: [ACPMessage.Attachment], messageId: String?) -> Int? {
+    private func appendUserChunk(text addition: String, attachments newAttachments: [ACPMessage.Attachment], messageId: String?, flushedReplayIndices: inout Set<Int>) -> Int? {
         let located = messageId.flatMap { messageIndex(messageId: $0, kind: .user) }
         if let i = located,
            case .user(let id, let existingMessageId, let text, let attachments) = transcript.messages[i] {
@@ -1493,6 +1498,11 @@ final class ACPSession: ObservableObject, Identifiable {
 
         if addition.isEmpty {
             guard !newAttachments.isEmpty else { return nil }
+            // A genuine new prompt closes the current text message; flush any
+            // held replay candidate first so it keeps its place ahead of the
+            // prompt. Deferred to here (past the replay guard above) so a
+            // replayed user chunk never materialises a still-buffered chunk.
+            flushedReplayIndices = flushPendingReplayCandidates()
             let id = UUID()
             transcript.messages.append(.user(id: id, messageId: messageId, text: addition, attachments: newAttachments))
             if let messageId {
@@ -1505,6 +1515,9 @@ final class ACPSession: ObservableObject, Identifiable {
             return transcript.messages.count - 1
         }
 
+        // Genuine new prompt (past the replay guard): flush held replay
+        // candidates first so they keep their place ahead of the prompt.
+        flushedReplayIndices = flushPendingReplayCandidates()
         let id = UUID()
         transcript.messages.append(.user(id: id, messageId: messageId, text: addition, attachments: newAttachments))
         if let messageId {

--- a/Alas/Sources/ACP/Session/ACPSession.swift
+++ b/Alas/Sources/ACP/Session/ACPSession.swift
@@ -265,7 +265,7 @@ final class ACPSession: ObservableObject, Identifiable {
                 messageId: chunk.messageId,
                 locateByMessageId: { id in messageIndex(messageId: id, kind: .agent) },
                 locateLegacy: { lastAgent() },
-                isLikelyReplay: { text in messageExists(kind: .agent, containing: text) },
+                isLikelyReplay: { text in chunkIsLikelyReplay(kind: .agent, of: text) },
                 makeNew: { .agent(id: UUID(), messageId: chunk.messageId, StreamingText(txt)) }) else {
                 return []
             }
@@ -287,7 +287,7 @@ final class ACPSession: ObservableObject, Identifiable {
                 messageId: chunk.messageId,
                 locateByMessageId: { id in messageIndex(messageId: id, kind: .thought) },
                 locateLegacy: { lastThought() },
-                isLikelyReplay: { text in messageExists(kind: .thought, containing: text) },
+                isLikelyReplay: { text in chunkIsLikelyReplay(kind: .thought, of: text) },
                 makeNew: { .thought(id: UUID(), messageId: chunk.messageId, StreamingText(txt)) }) else {
                 return []
             }
@@ -1458,18 +1458,44 @@ final class ACPSession: ObservableObject, Identifiable {
         }
     }
 
-    private func messageExists(kind: TextMessageKind, containing text: String) -> Bool {
-        guard !text.isEmpty else { return false }
+    /// A late load-replay frame with an unrecognised messageId
+    /// re-delivers a *complete*, previously seen message. Genuine live
+    /// output streams in small increments whose leading fragments (`I`,
+    /// `The`, `'ve`, a lone space) are almost always coincidental
+    /// substrings of an earlier message. Classifying such a fragment as a
+    /// replay drops it and rebuilds the message from a later chunk,
+    /// corrupting the visible text (`I've` rendered as `'ve`). Only treat
+    /// the chunk as a replay when it reproduces a whole existing message,
+    /// or is a substantial (non-fragment) span contained in one.
+    private func chunkIsLikelyReplay(kind: TextMessageKind, of addition: String) -> Bool {
+        let trimmed = addition.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return false }
         return transcript.messages.contains { message in
+            let existing: String
             switch (kind, message) {
-            case (.agent, .agent(_, _, let existing)),
-                 (.thought, .thought(_, _, let existing)):
-                return existing.value.contains(text)
+            case (.agent, .agent(_, _, let buf)),
+                 (.thought, .thought(_, _, let buf)):
+                existing = buf.value
             default:
                 return false
             }
+            // Whole-message replay: the chunk reproduces an existing
+            // message verbatim (the canonical single-chunk replay frame).
+            if existing.trimmingCharacters(in: .whitespacesAndNewlines) == trimmed {
+                return true
+            }
+            // Multi-chunk replay straggler: a substantial span already
+            // present in an existing message. The length floor keeps short
+            // leading fragments of genuine new output from being dropped.
+            return trimmed.count >= Self.replayFragmentMinimumLength && existing.contains(addition)
         }
     }
+
+    /// Minimum length for a streaming chunk to be eligible for
+    /// substring-based replay suppression. Below this, a chunk is treated
+    /// as genuine new output even if it happens to appear inside an
+    /// earlier message — see `chunkIsLikelyReplay(kind:of:)`.
+    private static let replayFragmentMinimumLength = 16
 
     private func userMessageExists(containing text: String, attachments: [ACPMessage.Attachment]) -> Bool {
         guard !text.isEmpty || !attachments.isEmpty else { return false }

--- a/Alas/Sources/ACP/Session/ACPSession.swift
+++ b/Alas/Sources/ACP/Session/ACPSession.swift
@@ -1564,19 +1564,22 @@ final class ACPSession: ObservableObject, Identifiable {
         guard !existing.isEmpty else { return nil }
         // Longest suffix of `existing` that is a prefix of `candidate` — the
         // reproduced portion. The remaining candidate is the genuine new
-        // continuation to append. The reproduced suffix must begin at a word
-        // boundary (the start of the bubble, or just after whitespace):
-        // unrecognised message ids otherwise start their own rows, so a
-        // coincidental mid-token overlap (a new message `"Keep going"` whose
-        // `"K"` matches the tail of a hydrated `"OK"`) must not be mistaken
-        // for a replay continuation and merged into the old bubble.
+        // continuation to append. The reproduced suffix must begin at a token
+        // boundary (the start of the bubble, or after a non-alphanumeric
+        // character — whitespace or punctuation): unrecognised message ids
+        // otherwise start their own rows, so a coincidental mid-word overlap
+        // (a new message `"Keep going"` whose `"K"` matches the tail of a
+        // hydrated `"OK"`) must not be mistaken for a replay continuation and
+        // merged into the old bubble, while a punctuation-bounded suffix
+        // (`"Running"` after `"tests completed."`) is still adopted.
         var suffix: String?
         let existingChars = Array(existing)
         let maxOverlap = min(existingChars.count, candidate.count)
         for overlap in stride(from: maxOverlap, through: 1, by: -1) {
             let startOffset = existingChars.count - overlap
-            if startOffset > 0, !existingChars[startOffset - 1].isWhitespace {
-                continue
+            if startOffset > 0 {
+                let preceding = existingChars[startOffset - 1]
+                if preceding.isLetter || preceding.isNumber { continue }
             }
             if candidate.hasPrefix(String(existingChars[startOffset...])) {
                 suffix = String(candidate.dropFirst(overlap))

--- a/Alas/Sources/ACP/Session/ACPSession.swift
+++ b/Alas/Sources/ACP/Session/ACPSession.swift
@@ -111,11 +111,22 @@ final class ACPSession: ObservableObject, Identifiable {
     /// — i.e. it is genuine new output whose leading fragment merely
     /// coincided with an earlier message — the full text can be materialised
     /// without losing the leading characters. Cleared once the window ends.
-    private var pendingReplayCandidates: [ReplayCandidateKey: String] = [:]
+    private var pendingReplayCandidates: [ReplayCandidateKey: ReplayCandidate] = [:]
 
     private struct ReplayCandidateKey: Hashable {
         let kind: TextMessageKind
         let messageId: String
+    }
+
+    /// Two views of the accumulated replay text. `display` carries the
+    /// sentence-boundary separators a live stream injects (used when the
+    /// text turns out to be genuine new output and is materialised);
+    /// `raw` is the plain concatenation used for matching, so a replay that
+    /// splits at a boundary the original stream did not is still recognised
+    /// (the injected `\n` would otherwise cause a false mismatch).
+    private struct ReplayCandidate {
+        var display: String
+        var raw: String
     }
 
     private var reconciledLocalUserPromptMessageIds: Set<String> = []
@@ -1483,27 +1494,6 @@ final class ACPSession: ObservableObject, Identifiable {
         }
     }
 
-    /// Start of the trailing in-progress output run — the index just past
-    /// the last message that closes a turn's output (a user prompt, tool
-    /// call, file edit, or system notice). `.agent`, `.thought`, and
-    /// `.plan` rows stay inside the span, matching `markCompletedOutputBoundary()`
-    /// (and `lastAgent()`, which skips plans). A late load-replay only
-    /// continues this trailing output; adoption must not reach back across
-    /// such a boundary into an already-closed bubble — that would mutate an
-    /// old bubble and then drop the real continuation via the
-    /// `hasUserAfterMessage` guard.
-    private var trailingOutputStartIndex: Int {
-        if let last = transcript.messages.lastIndex(where: { message in
-            switch message {
-            case .agent, .thought, .plan: return false
-            default: return true
-            }
-        }) {
-            return transcript.messages.index(after: last)
-        }
-        return transcript.messages.startIndex
-    }
-
     /// Whether some existing message of `kind` contains `text` — i.e.
     /// `text` could be the running span of a late load-replay stream that
     /// reproduces part of an already-present message. Uses containment
@@ -1528,34 +1518,37 @@ final class ACPSession: ObservableObject, Identifiable {
         }
     }
 
-    /// When a diverged replay `candidate` begins with the full text of an
-    /// existing trailing-output message of `kind`, the stream is that
+    /// When a diverged replay `candidate` begins with the full text of the
+    /// trailing in-progress bubble of `kind`, the stream is that
     /// already-present message replayed under a regenerated id and then
     /// continued past the boundary window. Append only the divergent suffix
-    /// to that message (so the hydrated prefix is not duplicated) and rebind
+    /// to that bubble (so the hydrated prefix is not duplicated) and rebind
     /// it to the regenerated `messageId` so subsequent chunks target it via
-    /// `messageIndex`. Returns the adopted message's index, or nil when no
-    /// trailing-output message is a prefix of the candidate (genuine new
-    /// output — including output that merely shares a prefix with an older
-    /// bubble already closed by a user prompt, tool call, or file edit).
+    /// `messageIndex`. Returns the adopted message's index, or nil when the
+    /// trailing bubble is not a prefix of the candidate (genuine new output).
+    ///
+    /// The adoption target is exactly `lastAgent()`/`lastThought()` — the
+    /// same trailing bubble a legacy (id-less) chunk would extend — so the
+    /// boundary rules (a user prompt, tool call, or file edit closes the
+    /// run; an agent row closes a thought; plans are skipped) stay
+    /// consistent with the rest of streaming instead of being re-derived.
     private func adoptReplayContinuation(kind: TextMessageKind, candidate: String, messageId: String) -> Int? {
-        var bestIndex: Int?
-        var bestPrefixCount = 0
-        for index in trailingOutputStartIndex..<transcript.messages.endIndex {
-            let existing: String
-            switch (kind, transcript.messages[index]) {
-            case (.agent, .agent(_, _, let buf)),
-                 (.thought, .thought(_, _, let buf)):
-                existing = buf.value
-            default:
-                continue
-            }
-            guard !existing.isEmpty, existing.count > bestPrefixCount, candidate.hasPrefix(existing) else { continue }
-            bestIndex = index
-            bestPrefixCount = existing.count
+        let trailingIndex: Int?
+        switch kind {
+        case .agent: trailingIndex = lastAgent()
+        case .thought: trailingIndex = lastThought()
+        case .user: trailingIndex = nil
         }
-        guard let i = bestIndex else { return nil }
-        let suffix = String(candidate.dropFirst(bestPrefixCount))
+        guard let i = trailingIndex else { return nil }
+        let existing: String
+        switch transcript.messages[i] {
+        case .agent(_, _, let buf), .thought(_, _, let buf):
+            existing = buf.value
+        default:
+            return nil
+        }
+        guard !existing.isEmpty, candidate.hasPrefix(existing) else { return nil }
+        let suffix = String(candidate.dropFirst(existing.count))
         switch transcript.messages[i] {
         case .agent(let id, _, let buf):
             buf.append(suffix)
@@ -1647,16 +1640,23 @@ final class ACPSession: ObservableObject, Identifiable {
         if let messageId, !allowsStreamingBoundaryCrossing {
             let candidateKey = ReplayCandidateKey(kind: replayKind, messageId: messageId)
             let previous = pendingReplayCandidates[candidateKey]
-            let candidate = (previous ?? "") + Self.streamingSeparator(between: previous ?? "", and: addition) + addition
-            if replayCandidateMatches(candidate) {
-                pendingReplayCandidates[candidateKey] = candidate
+            let previousDisplay = previous?.display ?? ""
+            let previousRaw = previous?.raw ?? ""
+            let display = previousDisplay + Self.streamingSeparator(between: previousDisplay, and: addition) + addition
+            let raw = previousRaw + addition
+            // Match on both forms: the display form (as a live stream would
+            // build it) and the raw concatenation, so a replay that splits
+            // at a sentence boundary the original stream did not is still
+            // recognised rather than duplicated by the injected separator.
+            if replayCandidateMatches(display) || replayCandidateMatches(raw) {
+                pendingReplayCandidates[candidateKey] = ReplayCandidate(display: display, raw: raw)
                 return nil
             }
             pendingReplayCandidates.removeValue(forKey: candidateKey)
-            if let adopted = adoptContinuation(candidate) {
+            if let adopted = adoptContinuation(display) ?? adoptContinuation(raw) {
                 return adopted
             }
-            newMessageText = candidate
+            newMessageText = display
         }
         transcript.messages.append(makeNew(newMessageText))
         didAppendTranscriptMessage()

--- a/Alas/Sources/ACP/Session/ACPSession.swift
+++ b/Alas/Sources/ACP/Session/ACPSession.swift
@@ -259,6 +259,11 @@ final class ACPSession: ObservableObject, Identifiable {
     }
 
     func recordUserPrompt(text: String, attachments: [ACPMessage.Attachment]) {
+        // Materialise any held replay candidate before the new prompt so
+        // stranded live text from the just-ended turn keeps its place ahead
+        // of the user message instead of being dropped. The runner persists
+        // from the pre-call message count, so the flushed rows are saved too.
+        _ = flushPendingReplayCandidates()
         transcript.messages.append(.user(id: UUID(), messageId: nil, text: text, attachments: attachments))
         didAppendTranscriptMessage()
         transcript.completedOutputBoundaryMessageIds.removeAll()
@@ -284,6 +289,22 @@ final class ACPSession: ObservableObject, Identifiable {
     /// transcript, not just the trailing row.
     @discardableResult
     func apply(_ update: ACPSessionUpdate) -> Set<Int> {
+        // A non-text update closes the current in-progress text message, and
+        // once the boundary window has ended every update is genuine new
+        // output. In both cases materialise any held replay candidate first,
+        // so a suppressed short fragment (e.g. "I", buffered because it is a
+        // substring of prior output) is emitted in order rather than being
+        // stranded in `pendingReplayCandidates` and dropped when the message
+        // ends without a further diverging text chunk.
+        let shouldFlushPending: Bool
+        switch update {
+        case .agentMessageChunk, .agentThoughtChunk:
+            shouldFlushPending = allowsStreamingBoundaryCrossing
+        default:
+            shouldFlushPending = true
+        }
+        let flushed = shouldFlushPending ? flushPendingReplayCandidates() : []
+        let result: Set<Int> = { () -> Set<Int> in
         switch update {
         case .agentMessageChunk(let chunk):
             clearRestoredContextRecoveryStatus()
@@ -409,6 +430,35 @@ final class ACPSession: ObservableObject, Identifiable {
         case .unknown:
             return []
         }
+        }()
+        return flushed.union(result)
+    }
+
+    /// Materialise every held replay candidate as a new row (in a stable
+    /// order) and clear the buffer. Returns the indices appended so the
+    /// caller can persist them. Called when the current text message closes
+    /// (a non-text update) or the boundary window ends, so a suppressed
+    /// short fragment is never stranded and dropped.
+    private func flushPendingReplayCandidates() -> Set<Int> {
+        guard !pendingReplayCandidates.isEmpty else { return [] }
+        var indices: Set<Int> = []
+        for key in pendingReplayCandidates.keys.sorted(by: { $0.messageId < $1.messageId }) {
+            guard let candidate = pendingReplayCandidates[key] else { continue }
+            let message: ACPMessage
+            switch key.kind {
+            case .agent:
+                message = .agent(id: UUID(), messageId: key.messageId, StreamingText(candidate.display))
+            case .thought:
+                message = .thought(id: UUID(), messageId: key.messageId, StreamingText(candidate.display))
+            case .user:
+                continue
+            }
+            transcript.messages.append(message)
+            didAppendTranscriptMessage()
+            indices.insert(transcript.messages.count - 1)
+        }
+        pendingReplayCandidates.removeAll()
+        return indices
     }
 
     func applySuppressedReplaySideEffects(_ update: ACPSessionUpdate) -> Set<Int> {
@@ -1601,12 +1651,10 @@ final class ACPSession: ObservableObject, Identifiable {
                                  replayCandidateMatches: (String) -> Bool,
                                  adoptContinuation: (String) -> Int?,
                                  makeNew: (String) -> ACPMessage) -> Int? {
-        // Outside the boundary-crossing window there is no late replay to
-        // guard against — drop any accumulated candidates so they never
-        // leak into a later window.
-        if allowsStreamingBoundaryCrossing, !pendingReplayCandidates.isEmpty {
-            pendingReplayCandidates.removeAll(keepingCapacity: false)
-        }
+        // Any held candidates from a prior window are flushed (materialised)
+        // by `apply` before this runs — once `allowsStreamingBoundaryCrossing`
+        // is true, or on the closing non-text update — so they are never
+        // stranded or leaked into a later window.
         let located = if let messageId {
             locateByMessageId(messageId)
         } else {

--- a/Alas/Sources/ACP/Session/ACPSession.swift
+++ b/Alas/Sources/ACP/Session/ACPSession.swift
@@ -475,14 +475,19 @@ final class ACPSession: ObservableObject, Identifiable {
     private func flushPendingReplayCandidates(kinds: Set<TextMessageKind> = [.agent, .thought]) -> Set<Int> {
         guard !pendingReplayCandidates.isEmpty else { return [] }
         var indices: Set<Int> = []
+        // Compare full-replay equality only against messages that existed
+        // before this flush, so two distinct held chunks with identical text
+        // (two one-chunk "OK" replies) don't collapse — the first materialised
+        // row must not make the second look like a replay of it.
+        let preFlushCount = transcript.messages.count
         let orderedKeys = pendingReplayCandidates.keys.sorted {
             (pendingReplayCandidates[$0]?.arrivalOrder ?? 0) < (pendingReplayCandidates[$1]?.arrivalOrder ?? 0)
         }
         for key in orderedKeys {
             guard kinds.contains(key.kind), let candidate = pendingReplayCandidates[key] else { continue }
             pendingReplayCandidates.removeValue(forKey: key)
-            if existingMessageEquals(kind: key.kind, candidate.display)
-                || existingMessageEquals(kind: key.kind, candidate.raw) {
+            if existingMessageEquals(kind: key.kind, candidate.display, before: preFlushCount)
+                || existingMessageEquals(kind: key.kind, candidate.raw, before: preFlushCount) {
                 continue // pure full replay — keep suppressed
             }
             let message: ACPMessage
@@ -501,10 +506,14 @@ final class ACPSession: ObservableObject, Identifiable {
         return indices
     }
 
-    /// Whether some existing message of `kind` has value exactly equal to
-    /// `text` — i.e. `text` reproduces that complete message (a full replay).
-    private func existingMessageEquals(kind: TextMessageKind, _ text: String) -> Bool {
-        transcript.messages.contains { message in
+    /// Whether some message of `kind` in `transcript.messages[..<upperBound]`
+    /// has value exactly equal to `text` — i.e. `text` reproduces that
+    /// complete message (a full replay). `upperBound` excludes rows appended
+    /// during the current flush so repeated identical outputs are preserved.
+    private func existingMessageEquals(kind: TextMessageKind, _ text: String, before upperBound: Int) -> Bool {
+        let end = min(upperBound, transcript.messages.count)
+        guard end > 0 else { return false }
+        return transcript.messages[..<end].contains { message in
             switch (kind, message) {
             case (.agent, .agent(_, _, let buf)),
                  (.thought, .thought(_, _, let buf)):
@@ -656,12 +665,20 @@ final class ACPSession: ObservableObject, Identifiable {
     }
 
     func appendSystemNotice(_ text: String) {
+        // A system notice closes the current output run; materialise any held
+        // replay candidate first so it keeps its place ahead of the notice.
+        flushPendingReplayCandidates()
         transcript.messages.append(.systemNotice(id: UUID(), text: text))
         didAppendTranscriptMessage()
     }
 
     func appendFileEdit(_ edit: ACPMessage.FileEdit) {
         clearRestoredContextRecoveryStatus()
+        // A file edit closes the current output run (see lastAgent()/
+        // lastThought(), which stop at .fileEdit); materialise any held replay
+        // candidate first so text that arrived before the edit stays ahead of
+        // it. This path does not flow through `apply`, so it must flush here.
+        flushPendingReplayCandidates()
         transcript.messages.append(.fileEdit(id: UUID(), edit))
         didAppendTranscriptMessage()
         transcript.completedOutputBoundaryMessageIds.removeAll()

--- a/Alas/Sources/ACP/Session/ACPSession.swift
+++ b/Alas/Sources/ACP/Session/ACPSession.swift
@@ -112,21 +112,27 @@ final class ACPSession: ObservableObject, Identifiable {
     /// coincided with an earlier message — the full text can be materialised
     /// without losing the leading characters. Cleared once the window ends.
     private var pendingReplayCandidates: [ReplayCandidateKey: ReplayCandidate] = [:]
+    /// Monotonic counter stamping each candidate with its arrival order, so a
+    /// flush materialises them in the order their first chunk arrived rather
+    /// than by the opaque `messageId` (which need not sort chronologically).
+    private var replayCandidateArrivalCounter: Int = 0
 
     private struct ReplayCandidateKey: Hashable {
         let kind: TextMessageKind
         let messageId: String
     }
 
-    /// Two views of the accumulated replay text. `display` carries the
-    /// sentence-boundary separators a live stream injects (used when the
-    /// text turns out to be genuine new output and is materialised);
-    /// `raw` is the plain concatenation used for matching, so a replay that
-    /// splits at a boundary the original stream did not is still recognised
-    /// (the injected `\n` would otherwise cause a false mismatch).
+    /// Two views of the accumulated replay text plus its arrival order.
+    /// `display` carries the sentence-boundary separators a live stream
+    /// injects (used when the text turns out to be genuine new output and is
+    /// materialised); `raw` is the plain concatenation used for matching, so
+    /// a replay that splits at a boundary the original stream did not is still
+    /// recognised (the injected `\n` would otherwise cause a false mismatch).
+    /// `arrivalOrder` preserves first-seen order across the buffer.
     private struct ReplayCandidate {
         var display: String
         var raw: String
+        var arrivalOrder: Int
     }
 
     private var reconciledLocalUserPromptMessageIds: Set<String> = []
@@ -465,7 +471,10 @@ final class ACPSession: ObservableObject, Identifiable {
     private func flushPendingReplayCandidates(kinds: Set<TextMessageKind> = [.agent, .thought]) -> Set<Int> {
         guard !pendingReplayCandidates.isEmpty else { return [] }
         var indices: Set<Int> = []
-        for key in pendingReplayCandidates.keys.sorted(by: { $0.messageId < $1.messageId }) {
+        let orderedKeys = pendingReplayCandidates.keys.sorted {
+            (pendingReplayCandidates[$0]?.arrivalOrder ?? 0) < (pendingReplayCandidates[$1]?.arrivalOrder ?? 0)
+        }
+        for key in orderedKeys {
             guard kinds.contains(key.kind), let candidate = pendingReplayCandidates[key] else { continue }
             pendingReplayCandidates.removeValue(forKey: key)
             if existingMessageEquals(kind: key.kind, candidate.display)
@@ -1772,7 +1781,15 @@ final class ACPSession: ObservableObject, Identifiable {
             // at a sentence boundary the original stream did not is still
             // recognised rather than duplicated by the injected separator.
             if replayCandidateMatches(display) || replayCandidateMatches(raw) {
-                pendingReplayCandidates[candidateKey] = ReplayCandidate(display: display, raw: raw)
+                // Preserve the first-seen arrival order across accumulation.
+                let arrivalOrder: Int
+                if let previous {
+                    arrivalOrder = previous.arrivalOrder
+                } else {
+                    arrivalOrder = replayCandidateArrivalCounter
+                    replayCandidateArrivalCounter += 1
+                }
+                pendingReplayCandidates[candidateKey] = ReplayCandidate(display: display, raw: raw, arrivalOrder: arrivalOrder)
                 return nil
             }
             pendingReplayCandidates.removeValue(forKey: candidateKey)

--- a/Alas/Sources/ACP/Session/ACPSession.swift
+++ b/Alas/Sources/ACP/Session/ACPSession.swift
@@ -276,6 +276,9 @@ final class ACPSession: ObservableObject, Identifiable {
                 locateByMessageId: { id in messageIndex(messageId: id, kind: .agent) },
                 locateLegacy: { lastAgent() },
                 replayCandidateMatches: { text in existingMessageContains(kind: .agent, text) },
+                adoptContinuation: { candidate in
+                    chunk.messageId.flatMap { adoptReplayContinuation(kind: .agent, candidate: candidate, messageId: $0) }
+                },
                 makeNew: { text in .agent(id: UUID(), messageId: chunk.messageId, StreamingText(text)) }) else {
                 return []
             }
@@ -298,6 +301,9 @@ final class ACPSession: ObservableObject, Identifiable {
                 locateByMessageId: { id in messageIndex(messageId: id, kind: .thought) },
                 locateLegacy: { lastThought() },
                 replayCandidateMatches: { text in existingMessageContains(kind: .thought, text) },
+                adoptContinuation: { candidate in
+                    chunk.messageId.flatMap { adoptReplayContinuation(kind: .thought, candidate: candidate, messageId: $0) }
+                },
                 makeNew: { text in .thought(id: UUID(), messageId: chunk.messageId, StreamingText(text)) }) else {
                 return []
             }
@@ -1489,6 +1495,46 @@ final class ACPSession: ObservableObject, Identifiable {
         }
     }
 
+    /// When a diverged replay `candidate` begins with the full text of an
+    /// existing message of `kind`, the stream is that already-present
+    /// message replayed under a regenerated id and then continued past the
+    /// boundary window. Append only the divergent suffix to that message
+    /// (so the hydrated prefix is not duplicated) and rebind it to the
+    /// regenerated `messageId` so subsequent chunks target it via
+    /// `messageIndex`. Returns the adopted message's index, or nil when no
+    /// existing message is a prefix of the candidate (genuine new output).
+    private func adoptReplayContinuation(kind: TextMessageKind, candidate: String, messageId: String) -> Int? {
+        var bestIndex: Int?
+        var bestPrefixCount = 0
+        for (index, message) in transcript.messages.enumerated() {
+            let existing: String
+            switch (kind, message) {
+            case (.agent, .agent(_, _, let buf)),
+                 (.thought, .thought(_, _, let buf)):
+                existing = buf.value
+            default:
+                continue
+            }
+            guard !existing.isEmpty, existing.count > bestPrefixCount, candidate.hasPrefix(existing) else { continue }
+            bestIndex = index
+            bestPrefixCount = existing.count
+        }
+        guard let i = bestIndex else { return nil }
+        let suffix = String(candidate.dropFirst(bestPrefixCount))
+        switch transcript.messages[i] {
+        case .agent(let id, _, let buf):
+            buf.append(suffix)
+            transcript.messages[i] = .agent(id: id, messageId: messageId, buf)
+        case .thought(let id, _, let buf):
+            buf.append(suffix)
+            transcript.messages[i] = .thought(id: id, messageId: messageId, buf)
+        default:
+            return nil
+        }
+        transcript.streamingTick &+= 1
+        return i
+    }
+
     private func userMessageExists(containing text: String, attachments: [ACPMessage.Attachment]) -> Bool {
         guard !text.isEmpty || !attachments.isEmpty else { return false }
         return transcript.messages.contains { message in
@@ -1506,6 +1552,7 @@ final class ACPSession: ObservableObject, Identifiable {
                                  locateByMessageId: (String) -> Int?,
                                  locateLegacy: () -> Int?,
                                  replayCandidateMatches: (String) -> Bool,
+                                 adoptContinuation: (String) -> Int?,
                                  makeNew: (String) -> ACPMessage) -> Int? {
         // Outside the boundary-crossing window there is no late replay to
         // guard against — drop any accumulated candidates so they never
@@ -1556,6 +1603,10 @@ final class ACPSession: ObservableObject, Identifiable {
         // first fragment like "I" coinciding with an earlier message would
         // otherwise be dropped, corrupting the text). Single-chunk full
         // replays and chunked/mid-stream replays never create a message.
+        // On divergence, if the candidate begins with an existing message
+        // it is that message replayed under a regenerated id and continued
+        // — adopt it (append only the divergent suffix) instead of
+        // materialising a new row that duplicates the hydrated prefix.
         var newMessageText = addition
         if let messageId, !allowsStreamingBoundaryCrossing {
             let previous = pendingReplayCandidates[messageId]
@@ -1565,6 +1616,9 @@ final class ACPSession: ObservableObject, Identifiable {
                 return nil
             }
             pendingReplayCandidates.removeValue(forKey: messageId)
+            if let adopted = adoptContinuation(candidate) {
+                return adopted
+            }
             newMessageText = candidate
         }
         transcript.messages.append(makeNew(newMessageText))

--- a/Alas/Sources/ACP/Session/ACPSession.swift
+++ b/Alas/Sources/ACP/Session/ACPSession.swift
@@ -306,8 +306,10 @@ final class ACPSession: ObservableObject, Identifiable {
         //     stops at `.agent`), so flush pending thoughts ahead of it — the
         //     agent candidate itself is handled by `appendStreaming`.
         // State-only updates append no row and must NOT flush a buffered
-        // chunk into a duplicate; `userMessageChunk` is handled inside
-        // `appendUserChunk` (it can itself be a dropped replay).
+        // chunk into a duplicate; `userMessageChunk` (via `appendUserChunk`)
+        // and the thought-before-agent-answer flush (via `appendStreaming`)
+        // are both deferred until the incoming chunk is known to be live
+        // rather than itself a suppressed replay.
         let kindsToFlush: Set<TextMessageKind>
         if allowsStreamingBoundaryCrossing {
             kindsToFlush = [.agent, .thought]
@@ -315,8 +317,6 @@ final class ACPSession: ObservableObject, Identifiable {
             switch update {
             case .toolCall, .plan:
                 kindsToFlush = [.agent, .thought]
-            case .agentMessageChunk:
-                kindsToFlush = [.thought]
             default:
                 kindsToFlush = []
             }
@@ -327,6 +327,7 @@ final class ACPSession: ObservableObject, Identifiable {
         case .agentMessageChunk(let chunk):
             clearRestoredContextRecoveryStatus()
             let txt = text(of: chunk.content)
+            var flushedForAgent: Set<Int> = []
             guard let i = appendStreaming(
                 text: txt,
                 messageId: chunk.messageId,
@@ -337,10 +338,11 @@ final class ACPSession: ObservableObject, Identifiable {
                 adoptContinuation: { candidate in
                     chunk.messageId.flatMap { adoptReplayContinuation(kind: .agent, candidate: candidate, messageId: $0) }
                 },
+                flushedReplayIndices: &flushedForAgent,
                 makeNew: { text in .agent(id: UUID(), messageId: chunk.messageId, StreamingText(text)) }) else {
-                return []
+                return flushedForAgent
             }
-            return [i]
+            return flushedForAgent.union([i])
         case .userMessageChunk(let chunk):
             let txt = text(of: chunk.content)
             var flushedForUser: Set<Int> = []
@@ -355,6 +357,7 @@ final class ACPSession: ObservableObject, Identifiable {
         case .agentThoughtChunk(let chunk):
             clearRestoredContextRecoveryStatus()
             let txt = text(of: chunk.content)
+            var flushedForThought: Set<Int> = []
             guard let i = appendStreaming(
                 text: txt,
                 messageId: chunk.messageId,
@@ -365,10 +368,11 @@ final class ACPSession: ObservableObject, Identifiable {
                 adoptContinuation: { candidate in
                     chunk.messageId.flatMap { adoptReplayContinuation(kind: .thought, candidate: candidate, messageId: $0) }
                 },
+                flushedReplayIndices: &flushedForThought,
                 makeNew: { text in .thought(id: UUID(), messageId: chunk.messageId, StreamingText(text)) }) else {
-                return []
+                return flushedForThought
             }
-            return [i]
+            return flushedForThought.union([i])
         case .toolCall(let payload):
             clearRestoredContextRecoveryStatus()
             let items = payload.content ?? []
@@ -1716,6 +1720,7 @@ final class ACPSession: ObservableObject, Identifiable {
                                  locateLegacy: () -> Int?,
                                  replayCandidateMatches: (String) -> Bool,
                                  adoptContinuation: (String) -> Int?,
+                                 flushedReplayIndices: inout Set<Int>,
                                  makeNew: (String) -> ACPMessage) -> Int? {
         // Any held candidates from a prior window are flushed (materialised)
         // by `apply` before this runs — once `allowsStreamingBoundaryCrossing`
@@ -1797,6 +1802,14 @@ final class ACPSession: ObservableObject, Identifiable {
                 return adopted
             }
             newMessageText = display
+        }
+        // A new agent row is live output that closes an in-progress thought
+        // (`lastThought()` stops at `.agent`); flush pending thoughts ahead of
+        // it now that the chunk is known not to be suppressed as replay. (The
+        // located/adopt paths above continue a bubble that predates any held
+        // thought, so their order is already correct.)
+        if replayKind == .agent {
+            flushedReplayIndices.formUnion(flushPendingReplayCandidates(kinds: [.thought]))
         }
         transcript.messages.append(makeNew(newMessageText))
         didAppendTranscriptMessage()

--- a/Alas/Sources/ACP/Session/ACPSession.swift
+++ b/Alas/Sources/ACP/Session/ACPSession.swift
@@ -103,13 +103,13 @@ final class ACPSession: ObservableObject, Identifiable {
 
     /// Running text of streaming chunks that arrived with an unrecognised
     /// `messageId` while `allowsStreamingBoundaryCrossing` was false and
-    /// still look like a late load-replay (their accumulated text is a
-    /// prefix of an already-present message). Keyed by messageId. Held
+    /// still look like a late load-replay (their accumulated text is
+    /// contained in an already-present message). Keyed by messageId. Held
     /// rather than dropped so that if the stream diverges — i.e. it is
     /// genuine new output whose leading fragment merely coincided with an
     /// earlier message — the full text can be materialised without losing
     /// the leading characters. Cleared once the boundary window ends.
-    private var pendingReplayPrefixes: [String: String] = [:]
+    private var pendingReplayCandidates: [String: String] = [:]
 
     private var reconciledLocalUserPromptMessageIds: Set<String> = []
     private var reconciledLegacyLocalUserPromptIds: Set<UUID> = []
@@ -275,7 +275,7 @@ final class ACPSession: ObservableObject, Identifiable {
                 messageId: chunk.messageId,
                 locateByMessageId: { id in messageIndex(messageId: id, kind: .agent) },
                 locateLegacy: { lastAgent() },
-                replayPrefixMatches: { text in existingMessageHasPrefix(kind: .agent, text) },
+                replayCandidateMatches: { text in existingMessageContains(kind: .agent, text) },
                 makeNew: { text in .agent(id: UUID(), messageId: chunk.messageId, StreamingText(text)) }) else {
                 return []
             }
@@ -297,7 +297,7 @@ final class ACPSession: ObservableObject, Identifiable {
                 messageId: chunk.messageId,
                 locateByMessageId: { id in messageIndex(messageId: id, kind: .thought) },
                 locateLegacy: { lastThought() },
-                replayPrefixMatches: { text in existingMessageHasPrefix(kind: .thought, text) },
+                replayCandidateMatches: { text in existingMessageContains(kind: .thought, text) },
                 makeNew: { text in .thought(id: UUID(), messageId: chunk.messageId, StreamingText(text)) }) else {
                 return []
             }
@@ -1468,17 +1468,21 @@ final class ACPSession: ObservableObject, Identifiable {
         }
     }
 
-    /// Whether some existing message of `kind` begins with `text` — i.e.
-    /// `text` could be the running prefix of a late load-replay stream
-    /// reconstructing that already-present message. Drives the replay
-    /// guard in `appendStreaming`.
-    private func existingMessageHasPrefix(kind: TextMessageKind, _ text: String) -> Bool {
+    /// Whether some existing message of `kind` contains `text` — i.e.
+    /// `text` could be the running span of a late load-replay stream that
+    /// reproduces part of an already-present message. Uses containment
+    /// rather than prefix matching because a replay slip can begin
+    /// mid-message: the suppression counter can fall between chunks of a
+    /// replayed message, so the first chunk reaching `appendStreaming`
+    /// may be a middle fragment (`"world"` of `"hello world"`). Drives the
+    /// replay guard in `appendStreaming`.
+    private func existingMessageContains(kind: TextMessageKind, _ text: String) -> Bool {
         guard !text.isEmpty else { return false }
         return transcript.messages.contains { message in
             switch (kind, message) {
             case (.agent, .agent(_, _, let buf)),
                  (.thought, .thought(_, _, let buf)):
-                return buf.value.hasPrefix(text)
+                return buf.value.contains(text)
             default:
                 return false
             }
@@ -1501,13 +1505,13 @@ final class ACPSession: ObservableObject, Identifiable {
                                  messageId: String?,
                                  locateByMessageId: (String) -> Int?,
                                  locateLegacy: () -> Int?,
-                                 replayPrefixMatches: (String) -> Bool,
+                                 replayCandidateMatches: (String) -> Bool,
                                  makeNew: (String) -> ACPMessage) -> Int? {
         // Outside the boundary-crossing window there is no late replay to
         // guard against — drop any accumulated candidates so they never
         // leak into a later window.
-        if allowsStreamingBoundaryCrossing, !pendingReplayPrefixes.isEmpty {
-            pendingReplayPrefixes.removeAll(keepingCapacity: false)
+        if allowsStreamingBoundaryCrossing, !pendingReplayCandidates.isEmpty {
+            pendingReplayCandidates.removeAll(keepingCapacity: false)
         }
         let located = if let messageId {
             locateByMessageId(messageId)
@@ -1541,24 +1545,26 @@ final class ACPSession: ObservableObject, Identifiable {
             }
         }
         // Late load-replay guard for an unrecognised messageId. A replay
-        // re-streams an already-present message from its start, so we
-        // accumulate this messageId's chunks and keep suppressing while
-        // the running text stays a prefix of some existing message. Once
-        // it diverges it is genuine new output — materialise it in full so
-        // no leading fragment is lost (a short first fragment like "I" or
-        // "The " coinciding with an earlier message would otherwise be
-        // dropped, corrupting the text, or — if suppressed per-chunk —
-        // duplicate a chunked replay). Single-chunk full replays still
-        // never create a message.
+        // re-streams text that is already present, so we accumulate this
+        // messageId's chunks and keep suppressing while the running text
+        // stays contained in some existing message. Containment (not just
+        // a prefix) is required because a replay slip can start mid-message
+        // — the suppression counter may fall between chunks, so the first
+        // chunk seen here can be a middle fragment ("world" of "hello
+        // world"). Once the running text diverges it is genuine new output
+        // — materialise it in full so no leading fragment is lost (a short
+        // first fragment like "I" coinciding with an earlier message would
+        // otherwise be dropped, corrupting the text). Single-chunk full
+        // replays and chunked/mid-stream replays never create a message.
         var newMessageText = addition
         if let messageId, !allowsStreamingBoundaryCrossing {
-            let previous = pendingReplayPrefixes[messageId]
+            let previous = pendingReplayCandidates[messageId]
             let candidate = (previous ?? "") + Self.streamingSeparator(between: previous ?? "", and: addition) + addition
-            if replayPrefixMatches(candidate) {
-                pendingReplayPrefixes[messageId] = candidate
+            if replayCandidateMatches(candidate) {
+                pendingReplayCandidates[messageId] = candidate
                 return nil
             }
-            pendingReplayPrefixes.removeValue(forKey: messageId)
+            pendingReplayCandidates.removeValue(forKey: messageId)
             newMessageText = candidate
         }
         transcript.messages.append(makeNew(newMessageText))

--- a/Alas/Sources/ACP/Session/ACPSession.swift
+++ b/Alas/Sources/ACP/Session/ACPSession.swift
@@ -1474,6 +1474,19 @@ final class ACPSession: ObservableObject, Identifiable {
         }
     }
 
+    /// Index just past the last user message — the start of the current
+    /// trailing turn. A late load-replay only reconstructs this trailing
+    /// in-progress output; messages before the last user prompt belong to
+    /// completed prior turns and must never be matched or adopted by the
+    /// replay guard (doing so would mutate an old bubble and then drop the
+    /// real continuation via the `hasUserAfterMessage` guard).
+    private var trailingTurnStartIndex: Int {
+        if let last = transcript.messages.lastIndex(where: { if case .user = $0 { return true } else { return false } }) {
+            return transcript.messages.index(after: last)
+        }
+        return transcript.messages.startIndex
+    }
+
     /// Whether some existing message of `kind` contains `text` — i.e.
     /// `text` could be the running span of a late load-replay stream that
     /// reproduces part of an already-present message. Uses containment
@@ -1481,7 +1494,10 @@ final class ACPSession: ObservableObject, Identifiable {
     /// mid-message: the suppression counter can fall between chunks of a
     /// replayed message, so the first chunk reaching `appendStreaming`
     /// may be a middle fragment (`"world"` of `"hello world"`). Drives the
-    /// replay guard in `appendStreaming`.
+    /// replay guard in `appendStreaming`. Scans the whole transcript — a
+    /// full replay can re-deliver a message that sits before a later user
+    /// prompt, and that must still be suppressed; only *adoption* of a
+    /// continuation is restricted to the trailing turn.
     private func existingMessageContains(kind: TextMessageKind, _ text: String) -> Bool {
         guard !text.isEmpty else { return false }
         return transcript.messages.contains { message in
@@ -1496,19 +1512,21 @@ final class ACPSession: ObservableObject, Identifiable {
     }
 
     /// When a diverged replay `candidate` begins with the full text of an
-    /// existing message of `kind`, the stream is that already-present
-    /// message replayed under a regenerated id and then continued past the
-    /// boundary window. Append only the divergent suffix to that message
-    /// (so the hydrated prefix is not duplicated) and rebind it to the
-    /// regenerated `messageId` so subsequent chunks target it via
+    /// existing trailing-turn message of `kind`, the stream is that
+    /// already-present message replayed under a regenerated id and then
+    /// continued past the boundary window. Append only the divergent suffix
+    /// to that message (so the hydrated prefix is not duplicated) and rebind
+    /// it to the regenerated `messageId` so subsequent chunks target it via
     /// `messageIndex`. Returns the adopted message's index, or nil when no
-    /// existing message is a prefix of the candidate (genuine new output).
+    /// trailing-turn message is a prefix of the candidate (genuine new
+    /// output — including output that merely shares a prefix with an older,
+    /// pre-user-prompt bubble).
     private func adoptReplayContinuation(kind: TextMessageKind, candidate: String, messageId: String) -> Int? {
         var bestIndex: Int?
         var bestPrefixCount = 0
-        for (index, message) in transcript.messages.enumerated() {
+        for index in trailingTurnStartIndex..<transcript.messages.endIndex {
             let existing: String
-            switch (kind, message) {
+            switch (kind, transcript.messages[index]) {
             case (.agent, .agent(_, _, let buf)),
                  (.thought, .thought(_, _, let buf)):
                 existing = buf.value

--- a/Alas/Sources/ACP/Session/ACPSession.swift
+++ b/Alas/Sources/ACP/Session/ACPSession.swift
@@ -1518,14 +1518,23 @@ final class ACPSession: ObservableObject, Identifiable {
         }
     }
 
-    /// When a diverged replay `candidate` begins with the full text of the
-    /// trailing in-progress bubble of `kind`, the stream is that
-    /// already-present message replayed under a regenerated id and then
-    /// continued past the boundary window. Append only the divergent suffix
-    /// to that bubble (so the hydrated prefix is not duplicated) and rebind
-    /// it to the regenerated `messageId` so subsequent chunks target it via
-    /// `messageIndex`. Returns the adopted message's index, or nil when the
-    /// trailing bubble is not a prefix of the candidate (genuine new output).
+    /// When a diverged replay `candidate` reproduces the tail of the
+    /// trailing in-progress bubble of `kind` and then continues past it, the
+    /// stream is that already-present message replayed under a regenerated
+    /// id and continued past the boundary window. Append only the text
+    /// beyond the reproduced portion (so nothing already present is
+    /// duplicated) and rebind the bubble to the regenerated `messageId` so
+    /// subsequent chunks target it via `messageIndex`. Returns the adopted
+    /// message's index, or nil when no suffix of the bubble is a prefix of
+    /// the candidate (genuine new output).
+    ///
+    /// Matching the longest *suffix* of the bubble (not just the whole
+    /// bubble) handles a mid-message replay slip: the suppression counter
+    /// can fall between chunks, so the first surviving chunk may be a middle
+    /// fragment (`"world"` of `"hello world"`) that then continues (`"!"`),
+    /// which must extend the bubble to `"hello world!"` rather than spawn a
+    /// duplicate. A full replay is just the special case where the matched
+    /// suffix is the whole bubble.
     ///
     /// The adoption target is exactly `lastAgent()`/`lastThought()` — the
     /// same trailing bubble a legacy (id-less) chunk would extend — so the
@@ -1547,8 +1556,19 @@ final class ACPSession: ObservableObject, Identifiable {
         default:
             return nil
         }
-        guard !existing.isEmpty, candidate.hasPrefix(existing) else { return nil }
-        let suffix = String(candidate.dropFirst(existing.count))
+        guard !existing.isEmpty else { return nil }
+        // Longest suffix of `existing` that is a prefix of `candidate` — the
+        // reproduced portion. The remaining candidate is the genuine new
+        // continuation to append.
+        var suffix: String?
+        let maxOverlap = min(existing.count, candidate.count)
+        for overlap in stride(from: maxOverlap, through: 1, by: -1) {
+            if candidate.hasPrefix(String(existing.suffix(overlap))) {
+                suffix = String(candidate.dropFirst(overlap))
+                break
+            }
+        }
+        guard let suffix, !suffix.isEmpty else { return nil }
         switch transcript.messages[i] {
         case .agent(let id, _, let buf):
             buf.append(suffix)

--- a/Alas/Sources/ACP/Session/ACPSession.swift
+++ b/Alas/Sources/ACP/Session/ACPSession.swift
@@ -1329,6 +1329,11 @@ final class ACPSession: ObservableObject, Identifiable {
             if case .thought = transcript.messages[i] { return i }
             if case .agent = transcript.messages[i] { return nil }
             if case .toolCall = transcript.messages[i] { return nil }
+            // A file edit closes the current output run, matching lastAgent()
+            // and markCompletedOutputBoundary(); a thought after an edit is a
+            // new bubble, so a legacy chunk (or a replay continuation adopted
+            // via this index) must not extend the pre-edit thought.
+            if case .fileEdit = transcript.messages[i] { return nil }
         }
         return nil
     }

--- a/Alas/Sources/ACP/Session/ACPSession.swift
+++ b/Alas/Sources/ACP/Session/ACPSession.swift
@@ -1474,14 +1474,21 @@ final class ACPSession: ObservableObject, Identifiable {
         }
     }
 
-    /// Index just past the last user message — the start of the current
-    /// trailing turn. A late load-replay only reconstructs this trailing
-    /// in-progress output; messages before the last user prompt belong to
-    /// completed prior turns and must never be matched or adopted by the
-    /// replay guard (doing so would mutate an old bubble and then drop the
-    /// real continuation via the `hasUserAfterMessage` guard).
-    private var trailingTurnStartIndex: Int {
-        if let last = transcript.messages.lastIndex(where: { if case .user = $0 { return true } else { return false } }) {
+    /// Start of the trailing contiguous run of agent/thought bubbles — the
+    /// index just past the last message that is neither `.agent` nor
+    /// `.thought` (a user prompt, tool call, file edit, plan, or system
+    /// notice). A late load-replay only continues this in-progress trailing
+    /// output; adoption must not reach back across such a boundary into an
+    /// already-closed bubble (mirroring how `lastAgent()`/`lastThought()`
+    /// stop at user/tool/file rows), which would mutate an old bubble and
+    /// then drop the real continuation via the `hasUserAfterMessage` guard.
+    private var trailingOutputStartIndex: Int {
+        if let last = transcript.messages.lastIndex(where: { message in
+            switch message {
+            case .agent, .thought: return false
+            default: return true
+            }
+        }) {
             return transcript.messages.index(after: last)
         }
         return transcript.messages.startIndex
@@ -1512,19 +1519,19 @@ final class ACPSession: ObservableObject, Identifiable {
     }
 
     /// When a diverged replay `candidate` begins with the full text of an
-    /// existing trailing-turn message of `kind`, the stream is that
+    /// existing trailing-output message of `kind`, the stream is that
     /// already-present message replayed under a regenerated id and then
     /// continued past the boundary window. Append only the divergent suffix
     /// to that message (so the hydrated prefix is not duplicated) and rebind
     /// it to the regenerated `messageId` so subsequent chunks target it via
     /// `messageIndex`. Returns the adopted message's index, or nil when no
-    /// trailing-turn message is a prefix of the candidate (genuine new
-    /// output — including output that merely shares a prefix with an older,
-    /// pre-user-prompt bubble).
+    /// trailing-output message is a prefix of the candidate (genuine new
+    /// output — including output that merely shares a prefix with an older
+    /// bubble already closed by a user prompt, tool call, or file edit).
     private func adoptReplayContinuation(kind: TextMessageKind, candidate: String, messageId: String) -> Int? {
         var bestIndex: Int?
         var bestPrefixCount = 0
-        for index in trailingTurnStartIndex..<transcript.messages.endIndex {
+        for index in trailingOutputStartIndex..<transcript.messages.endIndex {
             let existing: String
             switch (kind, transcript.messages[index]) {
             case (.agent, .agent(_, _, let buf)),

--- a/Alas/Sources/ACP/Session/ACPSession.swift
+++ b/Alas/Sources/ACP/Session/ACPSession.swift
@@ -289,19 +289,22 @@ final class ACPSession: ObservableObject, Identifiable {
     /// transcript, not just the trailing row.
     @discardableResult
     func apply(_ update: ACPSessionUpdate) -> Set<Int> {
-        // A non-text update closes the current in-progress text message, and
-        // once the boundary window has ended every update is genuine new
-        // output. In both cases materialise any held replay candidate first,
-        // so a suppressed short fragment (e.g. "I", buffered because it is a
+        // Materialise any held replay candidate first when a row-appending
+        // update closes the current in-progress text message (a tool call,
+        // plan, or user prompt), or once the boundary window has ended — so a
+        // suppressed short fragment (e.g. "I", buffered because it is a
         // substring of prior output) is emitted in order rather than being
         // stranded in `pendingReplayCandidates` and dropped when the message
-        // ends without a further diverging text chunk.
+        // ends without a further diverging text chunk. State-only updates
+        // (usage/model/mode/config/commands/sessionInfo, `toolCallUpdate`,
+        // unknown) append no row and do not close the text message, so they
+        // must NOT flush a still-buffered replay chunk into a duplicate row.
         let shouldFlushPending: Bool
         switch update {
-        case .agentMessageChunk, .agentThoughtChunk:
-            shouldFlushPending = allowsStreamingBoundaryCrossing
-        default:
+        case .toolCall, .plan, .userMessageChunk:
             shouldFlushPending = true
+        default:
+            shouldFlushPending = allowsStreamingBoundaryCrossing
         }
         let flushed = shouldFlushPending ? flushPendingReplayCandidates() : []
         let result: Set<Int> = { () -> Set<Int> in

--- a/Alas/Sources/ACP/Session/ACPSession.swift
+++ b/Alas/Sources/ACP/Session/ACPSession.swift
@@ -647,6 +647,14 @@ final class ACPSession: ObservableObject, Identifiable {
     }
 
     func markCompletedOutputBoundary() {
+        // The turn's output is complete; materialise any held replay
+        // candidate now (before marking boundaries so the flushed final
+        // message is itself recorded as a completed boundary). Otherwise a
+        // buffered final chunk whose text happens to be a substring of prior
+        // output — a one-chunk reply like "OK" — would stay outside
+        // `transcript.messages`, never persist, and be lost on detach/reopen,
+        // since turn completion reaches here without an `ACPSessionUpdate`.
+        _ = flushPendingReplayCandidates()
         transcript.completedOutputBoundaryMessageIds.removeAll()
         for message in transcript.messages.reversed() {
             switch message {

--- a/Alas/Sources/ACP/Session/ACPSession.swift
+++ b/Alas/Sources/ACP/Session/ACPSession.swift
@@ -104,12 +104,19 @@ final class ACPSession: ObservableObject, Identifiable {
     /// Running text of streaming chunks that arrived with an unrecognised
     /// `messageId` while `allowsStreamingBoundaryCrossing` was false and
     /// still look like a late load-replay (their accumulated text is
-    /// contained in an already-present message). Keyed by messageId. Held
-    /// rather than dropped so that if the stream diverges — i.e. it is
-    /// genuine new output whose leading fragment merely coincided with an
-    /// earlier message — the full text can be materialised without losing
-    /// the leading characters. Cleared once the boundary window ends.
-    private var pendingReplayCandidates: [String: String] = [:]
+    /// contained in an already-present message). Keyed by kind + messageId
+    /// (ids are kind-scoped elsewhere — see `messageIndex` and `stableId` —
+    /// so a thought and an agent chunk that reuse the same id must not share
+    /// a candidate). Held rather than dropped so that if the stream diverges
+    /// — i.e. it is genuine new output whose leading fragment merely
+    /// coincided with an earlier message — the full text can be materialised
+    /// without losing the leading characters. Cleared once the window ends.
+    private var pendingReplayCandidates: [ReplayCandidateKey: String] = [:]
+
+    private struct ReplayCandidateKey: Hashable {
+        let kind: TextMessageKind
+        let messageId: String
+    }
 
     private var reconciledLocalUserPromptMessageIds: Set<String> = []
     private var reconciledLegacyLocalUserPromptIds: Set<UUID> = []
@@ -273,6 +280,7 @@ final class ACPSession: ObservableObject, Identifiable {
             guard let i = appendStreaming(
                 text: txt,
                 messageId: chunk.messageId,
+                replayKind: .agent,
                 locateByMessageId: { id in messageIndex(messageId: id, kind: .agent) },
                 locateLegacy: { lastAgent() },
                 replayCandidateMatches: { text in existingMessageContains(kind: .agent, text) },
@@ -298,6 +306,7 @@ final class ACPSession: ObservableObject, Identifiable {
             guard let i = appendStreaming(
                 text: txt,
                 messageId: chunk.messageId,
+                replayKind: .thought,
                 locateByMessageId: { id in messageIndex(messageId: id, kind: .thought) },
                 locateLegacy: { lastThought() },
                 replayCandidateMatches: { text in existingMessageContains(kind: .thought, text) },
@@ -1313,7 +1322,7 @@ final class ACPSession: ObservableObject, Identifiable {
         return nil
     }
 
-    private enum TextMessageKind {
+    private enum TextMessageKind: Hashable {
         case user
         case agent
         case thought
@@ -1474,18 +1483,19 @@ final class ACPSession: ObservableObject, Identifiable {
         }
     }
 
-    /// Start of the trailing contiguous run of agent/thought bubbles — the
-    /// index just past the last message that is neither `.agent` nor
-    /// `.thought` (a user prompt, tool call, file edit, plan, or system
-    /// notice). A late load-replay only continues this in-progress trailing
-    /// output; adoption must not reach back across such a boundary into an
-    /// already-closed bubble (mirroring how `lastAgent()`/`lastThought()`
-    /// stop at user/tool/file rows), which would mutate an old bubble and
-    /// then drop the real continuation via the `hasUserAfterMessage` guard.
+    /// Start of the trailing in-progress output run — the index just past
+    /// the last message that closes a turn's output (a user prompt, tool
+    /// call, file edit, or system notice). `.agent`, `.thought`, and
+    /// `.plan` rows stay inside the span, matching `markCompletedOutputBoundary()`
+    /// (and `lastAgent()`, which skips plans). A late load-replay only
+    /// continues this trailing output; adoption must not reach back across
+    /// such a boundary into an already-closed bubble — that would mutate an
+    /// old bubble and then drop the real continuation via the
+    /// `hasUserAfterMessage` guard.
     private var trailingOutputStartIndex: Int {
         if let last = transcript.messages.lastIndex(where: { message in
             switch message {
-            case .agent, .thought: return false
+            case .agent, .thought, .plan: return false
             default: return true
             }
         }) {
@@ -1574,6 +1584,7 @@ final class ACPSession: ObservableObject, Identifiable {
     /// Returns the index of the message that was appended or mutated.
     private func appendStreaming(text addition: String,
                                  messageId: String?,
+                                 replayKind: TextMessageKind,
                                  locateByMessageId: (String) -> Int?,
                                  locateLegacy: () -> Int?,
                                  replayCandidateMatches: (String) -> Bool,
@@ -1634,13 +1645,14 @@ final class ACPSession: ObservableObject, Identifiable {
         // materialising a new row that duplicates the hydrated prefix.
         var newMessageText = addition
         if let messageId, !allowsStreamingBoundaryCrossing {
-            let previous = pendingReplayCandidates[messageId]
+            let candidateKey = ReplayCandidateKey(kind: replayKind, messageId: messageId)
+            let previous = pendingReplayCandidates[candidateKey]
             let candidate = (previous ?? "") + Self.streamingSeparator(between: previous ?? "", and: addition) + addition
             if replayCandidateMatches(candidate) {
-                pendingReplayCandidates[messageId] = candidate
+                pendingReplayCandidates[candidateKey] = candidate
                 return nil
             }
-            pendingReplayCandidates.removeValue(forKey: messageId)
+            pendingReplayCandidates.removeValue(forKey: candidateKey)
             if let adopted = adoptContinuation(candidate) {
                 return adopted
             }

--- a/Alas/Sources/ACP/Session/ACPSessionRunner.swift
+++ b/Alas/Sources/ACP/Session/ACPSessionRunner.swift
@@ -1342,7 +1342,14 @@ extension ACPSessionRunner {
         else { return false }
         pendingCompletedOutputBoundaryUpdateCount = nil
         flushStreamingPersist()
+        // markCompletedOutputBoundary() materialises any held replay candidate
+        // (a stranded final chunk); persist the appended rows so they survive
+        // detach/reopen — no `ACPSessionUpdate` carries them here.
+        let before = session.transcript.messages.count
         session.markCompletedOutputBoundary()
+        if session.transcript.messages.count > before {
+            persistFromIndex(before)
+        }
         guard activePromptID == nil else { return false }
         session.transcript.streamingState = .idle
         return true

--- a/AlasTests/ACP/Session/ACPSessionTests.swift
+++ b/AlasTests/ACP/Session/ACPSessionTests.swift
@@ -316,6 +316,36 @@ struct ACPSessionTests {
         #expect(agentTexts == ["hello world"])
     }
 
+    @Test("replay-then-continuation under a regenerated messageId merges into the hydrated message")
+    func replayThenContinuationMergesIntoHydratedMessage() async {
+        let session = ACPSession(id: "s", agentId: "codex", worktreeId: "w", title: "t")
+        session.transcript.messages = [
+            .agent(id: UUID(), messageId: "agent-1", StreamingText("hello"))
+        ]
+        session.allowsStreamingBoundaryCrossing = false
+
+        // The in-progress "hello" is replayed under a regenerated id and
+        // then continues with " world". The prefix must not be duplicated:
+        // the continuation merges into the hydrated message.
+        session.apply(.agentMessageChunk(.init(messageId: "regen-1", content: .text("hello"))))
+        session.apply(.agentMessageChunk(.init(messageId: "regen-1", content: .text(" world"))))
+
+        let agentTexts = session.transcript.messages.compactMap { message -> String? in
+            if case .agent(_, _, let text) = message { return text.value }
+            return nil
+        }
+        #expect(agentTexts == ["hello world"])
+
+        // A further continuation chunk targets the adopted message via its
+        // rebound id rather than spawning yet another row.
+        session.apply(.agentMessageChunk(.init(messageId: "regen-1", content: .text("!"))))
+        let after = session.transcript.messages.compactMap { message -> String? in
+            if case .agent(_, _, let text) = message { return text.value }
+            return nil
+        }
+        #expect(after == ["hello world!"])
+    }
+
     @Test("late replay user chunk with unknown messageId does not append prompt")
     func lateReplayUnknownUserMessageIdChunkDoesNotAppendPrompt() async {
         let session = ACPSession(id: "s", agentId: "codex", worktreeId: "w", title: "t")

--- a/AlasTests/ACP/Session/ACPSessionTests.swift
+++ b/AlasTests/ACP/Session/ACPSessionTests.swift
@@ -276,14 +276,14 @@ struct ACPSessionTests {
     func chunkedLateReplayShortFirstFragmentNotDuplicated() async {
         let session = ACPSession(id: "s", agentId: "codex", worktreeId: "w", title: "t")
         session.transcript.messages = [
-            .agent(id: UUID(), messageId: "agent-1", StreamingText("The plan is complete.")),
-            .user(id: UUID(), messageId: "user-1", text: "next prompt", attachments: [])
+            .user(id: UUID(), messageId: "user-1", text: "prev prompt", attachments: []),
+            .agent(id: UUID(), messageId: "agent-1", StreamingText("The plan is complete."))
         ]
         session.allowsStreamingBoundaryCrossing = false
 
-        // A late replay of the hydrated message arrives under a regenerated
-        // id, split into chunks whose first fragment is short. It must stay
-        // suppressed for its whole length and never create a duplicate.
+        // A late replay of the trailing hydrated message arrives under a
+        // regenerated id, split into chunks whose first fragment is short.
+        // It must stay suppressed for its whole length and never duplicate.
         session.apply(.agentMessageChunk(.init(messageId: "regen-1", content: .text("The "))))
         session.apply(.agentMessageChunk(.init(messageId: "regen-1", content: .text("plan is complete."))))
 
@@ -298,15 +298,15 @@ struct ACPSessionTests {
     func midStreamLateReplayFragmentNotDuplicated() async {
         let session = ACPSession(id: "s", agentId: "codex", worktreeId: "w", title: "t")
         session.transcript.messages = [
-            .agent(id: UUID(), messageId: "agent-1", StreamingText("hello world")),
-            .user(id: UUID(), messageId: "user-1", text: "next prompt", attachments: [])
+            .user(id: UUID(), messageId: "user-1", text: "prev prompt", attachments: []),
+            .agent(id: UUID(), messageId: "agent-1", StreamingText("hello world"))
         ]
         session.allowsStreamingBoundaryCrossing = false
 
         // The "hello " prefix was consumed while replay suppression was
         // still active; the slip that reaches appendStreaming is a middle
-        // fragment of the hydrated message. It must not be appended as a
-        // duplicate even though it is not a prefix of that message.
+        // fragment of the trailing hydrated message. It must not be appended
+        // as a duplicate even though it is not a prefix of that message.
         session.apply(.agentMessageChunk(.init(messageId: "regen-1", content: .text("world"))))
 
         let agentTexts = session.transcript.messages.compactMap { message -> String? in
@@ -344,6 +344,28 @@ struct ACPSessionTests {
             return nil
         }
         #expect(after == ["hello world!"])
+    }
+
+    @Test("post-prompt live output sharing a prefix with a prior turn is not adopted into the old bubble")
+    func postPromptLiveOutputNotAdoptedIntoPriorTurn() async {
+        let session = ACPSession(id: "s", agentId: "codex", worktreeId: "w", title: "t")
+        session.transcript.messages = [
+            .agent(id: UUID(), messageId: "agent-1", StreamingText("hello")),
+            .user(id: UUID(), messageId: "user-1", text: "next", attachments: [])
+        ]
+        session.allowsStreamingBoundaryCrossing = false
+
+        // Genuinely new output for the "next" turn that happens to start
+        // with the same word as the prior turn's "hello" bubble. It must
+        // become its own message, not mutate the earlier (pre-user) bubble.
+        session.apply(.agentMessageChunk(.init(messageId: "regen-1", content: .text("hello"))))
+        session.apply(.agentMessageChunk(.init(messageId: "regen-1", content: .text(" there"))))
+
+        let agentTexts = session.transcript.messages.compactMap { message -> String? in
+            if case .agent(_, _, let text) = message { return text.value }
+            return nil
+        }
+        #expect(agentTexts == ["hello", "hello there"])
     }
 
     @Test("late replay user chunk with unknown messageId does not append prompt")

--- a/AlasTests/ACP/Session/ACPSessionTests.swift
+++ b/AlasTests/ACP/Session/ACPSessionTests.swift
@@ -510,6 +510,55 @@ struct ACPSessionTests {
         #expect(agentTexts == ["alpha beta", "alpha", "beta"])
     }
 
+    @Test("two repeated held candidates with identical text are both materialized")
+    func repeatedHeldCandidatesBothMaterialized() async {
+        let session = ACPSession(id: "s", agentId: "codex", worktreeId: "w", title: "t")
+        session.transcript.messages = [
+            .agent(id: UUID(), messageId: "agent-1", StreamingText("OK done."))
+        ]
+        session.allowsStreamingBoundaryCrossing = false
+
+        // Two distinct new one-chunk "OK" replies, both held as substrings of
+        // "OK done.". Flushing must materialize both — the first must not make
+        // the second look like a full replay of it.
+        session.apply(.agentMessageChunk(.init(messageId: "z-1", content: .text("OK"))))
+        session.apply(.agentMessageChunk(.init(messageId: "a-1", content: .text("OK"))))
+        session.apply(.toolCall(.init(
+            toolCallId: "tool-1", title: "Run", kind: "execute", status: "completed",
+            content: nil, locations: nil, rawInput: nil, rawOutput: nil)))
+
+        let agentTexts = session.transcript.messages.compactMap { message -> String? in
+            if case .agent(_, _, let text) = message { return text.value }
+            return nil
+        }
+        #expect(agentTexts == ["OK done.", "OK", "OK"])
+    }
+
+    @Test("a held fragment is flushed before an appended file edit, preserving order")
+    func heldFragmentFlushedBeforeFileEdit() async {
+        let session = ACPSession(id: "s", agentId: "codex", worktreeId: "w", title: "t")
+        session.transcript.messages = [
+            .agent(id: UUID(), messageId: "agent-1", StreamingText("editing files"))
+        ]
+        session.allowsStreamingBoundaryCrossing = false
+
+        // A held fragment "editing" (substring), then a file edit. The file
+        // edit path does not flow through apply(), so it must flush the held
+        // text ahead of the edit rather than leave it after.
+        session.apply(.agentMessageChunk(.init(messageId: "regen-1", content: .text("editing"))))
+        session.appendFileEdit(.init(
+            path: "x.swift", added: 1, removed: 0, oldText: "a\n", newText: "a\nb\n"))
+
+        let ordered: [String] = session.transcript.messages.compactMap { message in
+            switch message {
+            case .agent(_, _, let t): return "agent:\(t.value)"
+            case .fileEdit: return "fileEdit"
+            default: return nil
+            }
+        }
+        #expect(ordered == ["agent:editing files", "agent:editing", "fileEdit"])
+    }
+
     @Test("chunked late replay with a regenerated messageId and short first fragment is not duplicated")
     func chunkedLateReplayShortFirstFragmentNotDuplicated() async {
         let session = ACPSession(id: "s", agentId: "codex", worktreeId: "w", title: "t")

--- a/AlasTests/ACP/Session/ACPSessionTests.swift
+++ b/AlasTests/ACP/Session/ACPSessionTests.swift
@@ -462,6 +462,32 @@ struct ACPSessionTests {
         #expect(agentTexts == ["hello world!"])
     }
 
+    @Test("regenerated thought replay is not adopted across a file edit")
+    func thoughtReplayNotAdoptedAcrossFileEdit() async {
+        let session = ACPSession(id: "s", agentId: "codex", worktreeId: "w", title: "t")
+        session.transcript.messages = [
+            .thought(id: UUID(), messageId: "thought-1", StreamingText("plan")),
+            .fileEdit(id: UUID(), .init(
+                path: "x.swift", added: 1, removed: 0,
+                oldText: "a\n", newText: "a\nb\n"
+            ))
+        ]
+        session.allowsStreamingBoundaryCrossing = false
+
+        // A file edit closes the pre-edit thought (like lastAgent() and the
+        // completed-output boundary). A regenerated thought stream starting
+        // with the pre-edit thought's text must not extend it across the
+        // edit; it becomes a new thought after the edit.
+        session.apply(.agentThoughtChunk(.init(messageId: "regen-1", content: .text("plan"))))
+        session.apply(.agentThoughtChunk(.init(messageId: "regen-1", content: .text(" more"))))
+
+        let thoughtTexts = session.transcript.messages.compactMap { message -> String? in
+            if case .thought(_, _, let text) = message { return text.value }
+            return nil
+        }
+        #expect(thoughtTexts == ["plan", "plan more"])
+    }
+
     @Test("a coincidental mid-token suffix overlap is not adopted as a replay continuation")
     func weakMidTokenSuffixOverlapNotAdopted() async {
         let session = ACPSession(id: "s", agentId: "codex", worktreeId: "w", title: "t")

--- a/AlasTests/ACP/Session/ACPSessionTests.swift
+++ b/AlasTests/ACP/Session/ACPSessionTests.swift
@@ -389,6 +389,28 @@ struct ACPSessionTests {
         #expect(texts == ["agent:hi there", "agent:hi", "user:do the thing"])
     }
 
+    @Test("a held final fragment is materialized when the output boundary completes")
+    func heldFragmentMaterializedOnCompletedOutputBoundary() async {
+        let session = ACPSession(id: "s", agentId: "codex", worktreeId: "w", title: "t")
+        session.transcript.messages = [
+            .agent(id: UUID(), messageId: "agent-1", StreamingText("OK done."))
+        ]
+        session.allowsStreamingBoundaryCrossing = false
+
+        // A one-chunk reply "OK" whose text is a substring of prior output is
+        // held. Turn completion reaches markCompletedOutputBoundary() without
+        // an update, so it must materialize the held chunk rather than leave
+        // it stranded (and lost on detach/reopen).
+        session.apply(.agentMessageChunk(.init(messageId: "regen-1", content: .text("OK"))))
+        session.markCompletedOutputBoundary()
+
+        let agentTexts = session.transcript.messages.compactMap { message -> String? in
+            if case .agent(_, _, let text) = message { return text.value }
+            return nil
+        }
+        #expect(agentTexts == ["OK done.", "OK"])
+    }
+
     @Test("chunked late replay with a regenerated messageId and short first fragment is not duplicated")
     func chunkedLateReplayShortFirstFragmentNotDuplicated() async {
         let session = ACPSession(id: "s", agentId: "codex", worktreeId: "w", title: "t")

--- a/AlasTests/ACP/Session/ACPSessionTests.swift
+++ b/AlasTests/ACP/Session/ACPSessionTests.swift
@@ -459,6 +459,30 @@ struct ACPSessionTests {
         #expect(ordered == ["thought:thinking hard", "thought:thinking", "agent:here is the answer"])
     }
 
+    @Test("multiple held candidates flush in arrival order, not by messageId")
+    func heldCandidatesFlushInArrivalOrder() async {
+        let session = ACPSession(id: "s", agentId: "codex", worktreeId: "w", title: "t")
+        session.transcript.messages = [
+            .agent(id: UUID(), messageId: "agent-1", StreamingText("alpha beta"))
+        ]
+        session.allowsStreamingBoundaryCrossing = false
+
+        // Two short live agent rows are both held (substrings of prior
+        // output). Their ids sort opposite to arrival ("a-1" < "z-1"), so a
+        // flush must still emit them in arrival order ("alpha" then "beta").
+        session.apply(.agentMessageChunk(.init(messageId: "z-1", content: .text("alpha"))))
+        session.apply(.agentMessageChunk(.init(messageId: "a-1", content: .text("beta"))))
+        session.apply(.toolCall(.init(
+            toolCallId: "tool-1", title: "Run", kind: "execute", status: "completed",
+            content: nil, locations: nil, rawInput: nil, rawOutput: nil)))
+
+        let agentTexts = session.transcript.messages.compactMap { message -> String? in
+            if case .agent(_, _, let text) = message { return text.value }
+            return nil
+        }
+        #expect(agentTexts == ["alpha beta", "alpha", "beta"])
+    }
+
     @Test("chunked late replay with a regenerated messageId and short first fragment is not duplicated")
     func chunkedLateReplayShortFirstFragmentNotDuplicated() async {
         let session = ACPSession(id: "s", agentId: "codex", worktreeId: "w", title: "t")

--- a/AlasTests/ACP/Session/ACPSessionTests.swift
+++ b/AlasTests/ACP/Session/ACPSessionTests.swift
@@ -323,6 +323,27 @@ struct ACPSessionTests {
         #expect(texts == ["agent:I'm working on it.", "agent:I", "user:next"])
     }
 
+    @Test("a state-only update does not flush a held replay candidate into a duplicate row")
+    func stateOnlyUpdateDoesNotFlushHeldCandidate() async {
+        let session = ACPSession(id: "s", agentId: "codex", worktreeId: "w", title: "t")
+        session.transcript.messages = [
+            .agent(id: UUID(), messageId: "agent-1", StreamingText("hello world"))
+        ]
+        session.allowsStreamingBoundaryCrossing = false
+
+        // A late replay chunk "hello" is buffered (substring of prior output).
+        // A state-only update (model change) appends no row and does not close
+        // the text, so it must not materialize the held chunk as a duplicate.
+        session.apply(.agentMessageChunk(.init(messageId: "regen-1", content: .text("hello"))))
+        session.apply(.currentModelUpdate(modelId: "gpt-5.5"))
+
+        let agentTexts = session.transcript.messages.compactMap { message -> String? in
+            if case .agent(_, _, let text) = message { return text.value }
+            return nil
+        }
+        #expect(agentTexts == ["hello world"])
+    }
+
     @Test("chunked late replay with a regenerated messageId and short first fragment is not duplicated")
     func chunkedLateReplayShortFirstFragmentNotDuplicated() async {
         let session = ACPSession(id: "s", agentId: "codex", worktreeId: "w", title: "t")

--- a/AlasTests/ACP/Session/ACPSessionTests.swift
+++ b/AlasTests/ACP/Session/ACPSessionTests.swift
@@ -272,6 +272,57 @@ struct ACPSessionTests {
         #expect(agentTexts.contains("I've made that warning cleanup."))
     }
 
+    @Test("a held short fragment is materialized when a tool call closes the message")
+    func heldFragmentMaterializedOnToolCall() async {
+        let session = ACPSession(id: "s", agentId: "codex", worktreeId: "w", title: "t")
+        session.transcript.messages = [
+            .agent(id: UUID(), messageId: "agent-1", StreamingText("I'm working on it."))
+        ]
+        session.allowsStreamingBoundaryCrossing = false
+
+        // A new live message whose only chunk "I" is a substring of prior
+        // output is held as a replay candidate. A tool call then closes the
+        // message with no further text chunk — the held "I" must be
+        // materialized (ahead of the tool call), not stranded and dropped.
+        session.apply(.agentMessageChunk(.init(messageId: "agent-live-2", content: .text("I"))))
+        session.apply(.toolCall(.init(
+            toolCallId: "tool-1", title: "Run", kind: "execute", status: "completed",
+            content: nil, locations: nil, rawInput: nil, rawOutput: nil)))
+
+        let agentTexts = session.transcript.messages.compactMap { message -> String? in
+            if case .agent(_, _, let text) = message { return text.value }
+            return nil
+        }
+        #expect(agentTexts == ["I'm working on it.", "I"])
+        if case .toolCall = session.transcript.messages.last {} else {
+            Issue.record("expected the tool call to follow the materialized fragment")
+        }
+    }
+
+    @Test("a held short fragment is materialized before the next user prompt")
+    func heldFragmentMaterializedBeforeNextPrompt() async {
+        let session = ACPSession(id: "s", agentId: "codex", worktreeId: "w", title: "t")
+        session.transcript.messages = [
+            .agent(id: UUID(), messageId: "agent-1", StreamingText("I'm working on it."))
+        ]
+        session.allowsStreamingBoundaryCrossing = false
+
+        // The held fragment "I" is stranded when the turn ends with no further
+        // text chunk; the next prompt must materialize it (keeping its place
+        // before the user message) rather than drop it.
+        session.apply(.agentMessageChunk(.init(messageId: "agent-live-2", content: .text("I"))))
+        session.recordUserPrompt(text: "next", attachments: [])
+
+        let texts: [String] = session.transcript.messages.compactMap { message in
+            switch message {
+            case .agent(_, _, let t): return "agent:\(t.value)"
+            case .user(_, _, let t, _): return "user:\(t)"
+            default: return nil
+            }
+        }
+        #expect(texts == ["agent:I'm working on it.", "agent:I", "user:next"])
+    }
+
     @Test("chunked late replay with a regenerated messageId and short first fragment is not duplicated")
     func chunkedLateReplayShortFirstFragmentNotDuplicated() async {
         let session = ACPSession(id: "s", agentId: "codex", worktreeId: "w", title: "t")

--- a/AlasTests/ACP/Session/ACPSessionTests.swift
+++ b/AlasTests/ACP/Session/ACPSessionTests.swift
@@ -294,6 +294,28 @@ struct ACPSessionTests {
         #expect(agentTexts == ["The plan is complete."])
     }
 
+    @Test("mid-stream late replay fragment with a regenerated messageId is not duplicated")
+    func midStreamLateReplayFragmentNotDuplicated() async {
+        let session = ACPSession(id: "s", agentId: "codex", worktreeId: "w", title: "t")
+        session.transcript.messages = [
+            .agent(id: UUID(), messageId: "agent-1", StreamingText("hello world")),
+            .user(id: UUID(), messageId: "user-1", text: "next prompt", attachments: [])
+        ]
+        session.allowsStreamingBoundaryCrossing = false
+
+        // The "hello " prefix was consumed while replay suppression was
+        // still active; the slip that reaches appendStreaming is a middle
+        // fragment of the hydrated message. It must not be appended as a
+        // duplicate even though it is not a prefix of that message.
+        session.apply(.agentMessageChunk(.init(messageId: "regen-1", content: .text("world"))))
+
+        let agentTexts = session.transcript.messages.compactMap { message -> String? in
+            if case .agent(_, _, let text) = message { return text.value }
+            return nil
+        }
+        #expect(agentTexts == ["hello world"])
+    }
+
     @Test("late replay user chunk with unknown messageId does not append prompt")
     func lateReplayUnknownUserMessageIdChunkDoesNotAppendPrompt() async {
         let session = ACPSession(id: "s", agentId: "codex", worktreeId: "w", title: "t")

--- a/AlasTests/ACP/Session/ACPSessionTests.swift
+++ b/AlasTests/ACP/Session/ACPSessionTests.swift
@@ -272,6 +272,28 @@ struct ACPSessionTests {
         #expect(agentTexts.contains("I've made that warning cleanup."))
     }
 
+    @Test("chunked late replay with a regenerated messageId and short first fragment is not duplicated")
+    func chunkedLateReplayShortFirstFragmentNotDuplicated() async {
+        let session = ACPSession(id: "s", agentId: "codex", worktreeId: "w", title: "t")
+        session.transcript.messages = [
+            .agent(id: UUID(), messageId: "agent-1", StreamingText("The plan is complete.")),
+            .user(id: UUID(), messageId: "user-1", text: "next prompt", attachments: [])
+        ]
+        session.allowsStreamingBoundaryCrossing = false
+
+        // A late replay of the hydrated message arrives under a regenerated
+        // id, split into chunks whose first fragment is short. It must stay
+        // suppressed for its whole length and never create a duplicate.
+        session.apply(.agentMessageChunk(.init(messageId: "regen-1", content: .text("The "))))
+        session.apply(.agentMessageChunk(.init(messageId: "regen-1", content: .text("plan is complete."))))
+
+        let agentTexts = session.transcript.messages.compactMap { message -> String? in
+            if case .agent(_, _, let text) = message { return text.value }
+            return nil
+        }
+        #expect(agentTexts == ["The plan is complete."])
+    }
+
     @Test("late replay user chunk with unknown messageId does not append prompt")
     func lateReplayUnknownUserMessageIdChunkDoesNotAppendPrompt() async {
         let session = ACPSession(id: "s", agentId: "codex", worktreeId: "w", title: "t")

--- a/AlasTests/ACP/Session/ACPSessionTests.swift
+++ b/AlasTests/ACP/Session/ACPSessionTests.swift
@@ -368,6 +368,34 @@ struct ACPSessionTests {
         #expect(agentTexts == ["hello", "hello there"])
     }
 
+    @Test("post-tool live output sharing a prefix with a pre-tool bubble is not adopted across the tool call")
+    func postToolLiveOutputNotAdoptedAcrossToolCall() async {
+        let session = ACPSession(id: "s", agentId: "codex", worktreeId: "w", title: "t")
+        session.transcript.messages = [
+            .agent(id: UUID(), messageId: "agent-1", StreamingText("OK")),
+            .toolCall(.init(
+                toolCallId: "tool-1",
+                title: "Run",
+                kind: "execute",
+                status: "completed",
+                content: "done"
+            ))
+        ]
+        session.allowsStreamingBoundaryCrossing = false
+
+        // Fresh post-tool output that happens to start with the pre-tool
+        // bubble's full text. It must become its own message after the tool
+        // call, not append to the already-closed pre-tool bubble.
+        session.apply(.agentMessageChunk(.init(messageId: "regen-1", content: .text("OK"))))
+        session.apply(.agentMessageChunk(.init(messageId: "regen-1", content: .text(" done"))))
+
+        let agentTexts = session.transcript.messages.compactMap { message -> String? in
+            if case .agent(_, _, let text) = message { return text.value }
+            return nil
+        }
+        #expect(agentTexts == ["OK", "OK done"])
+    }
+
     @Test("late replay user chunk with unknown messageId does not append prompt")
     func lateReplayUnknownUserMessageIdChunkDoesNotAppendPrompt() async {
         let session = ACPSession(id: "s", agentId: "codex", worktreeId: "w", title: "t")

--- a/AlasTests/ACP/Session/ACPSessionTests.swift
+++ b/AlasTests/ACP/Session/ACPSessionTests.swift
@@ -390,6 +390,56 @@ struct ACPSessionTests {
         #expect(agentTexts == ["response", "reply"])
     }
 
+    @Test("regenerated thought replay is not adopted into a thought that an agent row already closed")
+    func thoughtReplayNotAdoptedAcrossAgentRow() async {
+        let session = ACPSession(id: "s", agentId: "codex", worktreeId: "w", title: "t")
+        session.transcript.messages = [
+            .thought(id: UUID(), messageId: "thought-1", StreamingText("earlier")),
+            .agent(id: UUID(), messageId: "agent-1", StreamingText("answer"))
+        ]
+        session.allowsStreamingBoundaryCrossing = false
+
+        // A regenerated thought stream that starts with the earlier thought's
+        // text but continues. The agent row closed that thought (lastThought()
+        // stops at it), so it must not be adopted; a new thought row appears.
+        session.apply(.agentThoughtChunk(.init(messageId: "regen-1", content: .text("earlier"))))
+        session.apply(.agentThoughtChunk(.init(messageId: "regen-1", content: .text(" more"))))
+
+        let thoughtTexts = session.transcript.messages.compactMap { message -> String? in
+            if case .thought(_, _, let text) = message { return text.value }
+            return nil
+        }
+        #expect(thoughtTexts == ["earlier", "earlier more"])
+        // The agent bubble between them is untouched.
+        let agentTexts = session.transcript.messages.compactMap { message -> String? in
+            if case .agent(_, _, let text) = message { return text.value }
+            return nil
+        }
+        #expect(agentTexts == ["answer"])
+    }
+
+    @Test("replay split at a sentence boundary the original did not is still suppressed despite the separator")
+    func replaySplitAtSentenceBoundaryStillSuppressed() async {
+        let session = ACPSession(id: "s", agentId: "codex", worktreeId: "w", title: "t")
+        // Hydrated as one chunk, so it carries no injected separator.
+        session.transcript.messages = [
+            .agent(id: UUID(), messageId: "agent-1", StreamingText("tests completed.Running"))
+        ]
+        session.allowsStreamingBoundaryCrossing = false
+
+        // The replay splits at the sentence boundary, so streamingSeparator
+        // would inject a newline. Matching on the raw concatenation as well
+        // keeps this recognised as a replay instead of a duplicate.
+        session.apply(.agentMessageChunk(.init(messageId: "regen-1", content: .text("tests completed."))))
+        session.apply(.agentMessageChunk(.init(messageId: "regen-1", content: .text("Running"))))
+
+        let agentTexts = session.transcript.messages.compactMap { message -> String? in
+            if case .agent(_, _, let text) = message { return text.value }
+            return nil
+        }
+        #expect(agentTexts == ["tests completed.Running"])
+    }
+
     @Test("post-prompt live output sharing a prefix with a prior turn is not adopted into the old bubble")
     func postPromptLiveOutputNotAdoptedIntoPriorTurn() async {
         let session = ACPSession(id: "s", agentId: "codex", worktreeId: "w", title: "t")

--- a/AlasTests/ACP/Session/ACPSessionTests.swift
+++ b/AlasTests/ACP/Session/ACPSessionTests.swift
@@ -411,6 +411,54 @@ struct ACPSessionTests {
         #expect(agentTexts == ["OK done.", "OK"])
     }
 
+    @Test("a full-replay candidate is kept suppressed on flush, not materialized as a duplicate")
+    func fullReplayCandidateKeptSuppressedOnFlush() async {
+        let session = ACPSession(id: "s", agentId: "codex", worktreeId: "w", title: "t")
+        session.transcript.messages = [
+            .agent(id: UUID(), messageId: "agent-1", StreamingText("OK"))
+        ]
+        session.allowsStreamingBoundaryCrossing = false
+
+        // A late replay delivers the complete "OK" under a regenerated id, so
+        // it is held (it matches the existing message exactly). A tool call
+        // then triggers a flush — but a candidate that fully reproduces an
+        // existing message never diverged and must stay suppressed.
+        session.apply(.agentMessageChunk(.init(messageId: "regen-1", content: .text("OK"))))
+        session.apply(.toolCall(.init(
+            toolCallId: "tool-1", title: "Run", kind: "execute", status: "completed",
+            content: nil, locations: nil, rawInput: nil, rawOutput: nil)))
+
+        let agentTexts = session.transcript.messages.compactMap { message -> String? in
+            if case .agent(_, _, let text) = message { return text.value }
+            return nil
+        }
+        #expect(agentTexts == ["OK"])
+    }
+
+    @Test("a held thought is flushed before an agent answer, preserving transcript order")
+    func heldThoughtFlushedBeforeAgentAnswer() async {
+        let session = ACPSession(id: "s", agentId: "codex", worktreeId: "w", title: "t")
+        session.transcript.messages = [
+            .thought(id: UUID(), messageId: "thought-1", StreamingText("thinking hard"))
+        ]
+        session.allowsStreamingBoundaryCrossing = false
+
+        // A held thought fragment "thinking" (substring of the prior thought),
+        // then an agent answer. An agent answer closes an in-progress thought,
+        // so the thought must materialize ahead of the answer, not after it.
+        session.apply(.agentThoughtChunk(.init(messageId: "regen-thought", content: .text("thinking"))))
+        session.apply(.agentMessageChunk(.init(messageId: "regen-agent", content: .text("here is the answer"))))
+
+        let ordered: [String] = session.transcript.messages.compactMap { message in
+            switch message {
+            case .thought(_, _, let t): return "thought:\(t.value)"
+            case .agent(_, _, let t): return "agent:\(t.value)"
+            default: return nil
+            }
+        }
+        #expect(ordered == ["thought:thinking hard", "thought:thinking", "agent:here is the answer"])
+    }
+
     @Test("chunked late replay with a regenerated messageId and short first fragment is not duplicated")
     func chunkedLateReplayShortFirstFragmentNotDuplicated() async {
         let session = ACPSession(id: "s", agentId: "codex", worktreeId: "w", title: "t")

--- a/AlasTests/ACP/Session/ACPSessionTests.swift
+++ b/AlasTests/ACP/Session/ACPSessionTests.swift
@@ -344,6 +344,51 @@ struct ACPSessionTests {
         #expect(agentTexts == ["hello world"])
     }
 
+    @Test("a replayed user chunk does not flush a held agent replay candidate")
+    func replayedUserChunkDoesNotFlushHeldCandidate() async {
+        let session = ACPSession(id: "s", agentId: "codex", worktreeId: "w", title: "t")
+        session.transcript.messages = [
+            .user(id: UUID(), messageId: "user-1", text: "earlier prompt", attachments: []),
+            .agent(id: UUID(), messageId: "agent-1", StreamingText("hello world"))
+        ]
+        session.allowsStreamingBoundaryCrossing = false
+
+        // Held agent replay chunk "hello", then a replayed user prompt that
+        // appendUserChunk drops (its text already exists). The held chunk must
+        // not be flushed into a duplicate agent row by that dropped prompt.
+        session.apply(.agentMessageChunk(.init(messageId: "regen-agent", content: .text("hello"))))
+        session.apply(.userMessageChunk(.init(messageId: "regen-user", content: .text("earlier prompt"))))
+
+        let agentTexts = session.transcript.messages.compactMap { message -> String? in
+            if case .agent(_, _, let text) = message { return text.value }
+            return nil
+        }
+        #expect(agentTexts == ["hello world"])
+    }
+
+    @Test("a real user chunk flushes a held agent replay candidate ahead of the prompt")
+    func realUserChunkFlushesHeldCandidate() async {
+        let session = ACPSession(id: "s", agentId: "codex", worktreeId: "w", title: "t")
+        session.transcript.messages = [
+            .agent(id: UUID(), messageId: "agent-1", StreamingText("hi there"))
+        ]
+        session.allowsStreamingBoundaryCrossing = false
+
+        // Held agent chunk "hi", then a genuinely new user prompt. The held
+        // chunk must materialize in order, ahead of the prompt.
+        session.apply(.agentMessageChunk(.init(messageId: "regen-agent", content: .text("hi"))))
+        session.apply(.userMessageChunk(.init(messageId: "user-new", content: .text("do the thing"))))
+
+        let texts: [String] = session.transcript.messages.compactMap { message in
+            switch message {
+            case .agent(_, _, let t): return "agent:\(t.value)"
+            case .user(_, _, let t, _): return "user:\(t)"
+            default: return nil
+            }
+        }
+        #expect(texts == ["agent:hi there", "agent:hi", "user:do the thing"])
+    }
+
     @Test("chunked late replay with a regenerated messageId and short first fragment is not duplicated")
     func chunkedLateReplayShortFirstFragmentNotDuplicated() async {
         let session = ACPSession(id: "s", agentId: "codex", worktreeId: "w", title: "t")

--- a/AlasTests/ACP/Session/ACPSessionTests.swift
+++ b/AlasTests/ACP/Session/ACPSessionTests.swift
@@ -440,6 +440,28 @@ struct ACPSessionTests {
         #expect(agentTexts == ["tests completed.Running"])
     }
 
+    @Test("mid-message replay slip followed by real continuation extends the hydrated bubble")
+    func midMessageReplaySlipThenContinuationExtendsBubble() async {
+        let session = ACPSession(id: "s", agentId: "codex", worktreeId: "w", title: "t")
+        session.transcript.messages = [
+            .agent(id: UUID(), messageId: "agent-1", StreamingText("hello world"))
+        ]
+        session.allowsStreamingBoundaryCrossing = false
+
+        // The "hello " prefix was consumed during suppression; the surviving
+        // replay chunk is the middle fragment "world", which then continues
+        // with "!". This must extend the hydrated bubble to "hello world!"
+        // rather than materialize "world!" as a duplicate row.
+        session.apply(.agentMessageChunk(.init(messageId: "regen-1", content: .text("world"))))
+        session.apply(.agentMessageChunk(.init(messageId: "regen-1", content: .text("!"))))
+
+        let agentTexts = session.transcript.messages.compactMap { message -> String? in
+            if case .agent(_, _, let text) = message { return text.value }
+            return nil
+        }
+        #expect(agentTexts == ["hello world!"])
+    }
+
     @Test("post-prompt live output sharing a prefix with a prior turn is not adopted into the old bubble")
     func postPromptLiveOutputNotAdoptedIntoPriorTurn() async {
         let session = ACPSession(id: "s", agentId: "codex", worktreeId: "w", title: "t")

--- a/AlasTests/ACP/Session/ACPSessionTests.swift
+++ b/AlasTests/ACP/Session/ACPSessionTests.swift
@@ -462,6 +462,28 @@ struct ACPSessionTests {
         #expect(agentTexts == ["hello world!"])
     }
 
+    @Test("a coincidental mid-token suffix overlap is not adopted as a replay continuation")
+    func weakMidTokenSuffixOverlapNotAdopted() async {
+        let session = ACPSession(id: "s", agentId: "codex", worktreeId: "w", title: "t")
+        session.transcript.messages = [
+            .agent(id: UUID(), messageId: "agent-1", StreamingText("OK"))
+        ]
+        session.allowsStreamingBoundaryCrossing = false
+
+        // A genuinely new message "Keep going" whose first held fragment "K"
+        // coincides with the tail of "OK". The overlap is mid-token (not at a
+        // word boundary), so it must not be adopted into the old bubble as
+        // "OKeep going"; it starts its own row.
+        session.apply(.agentMessageChunk(.init(messageId: "regen-1", content: .text("K"))))
+        session.apply(.agentMessageChunk(.init(messageId: "regen-1", content: .text("eep going"))))
+
+        let agentTexts = session.transcript.messages.compactMap { message -> String? in
+            if case .agent(_, _, let text) = message { return text.value }
+            return nil
+        }
+        #expect(agentTexts == ["OK", "Keep going"])
+    }
+
     @Test("post-prompt live output sharing a prefix with a prior turn is not adopted into the old bubble")
     func postPromptLiveOutputNotAdoptedIntoPriorTurn() async {
         let session = ACPSession(id: "s", agentId: "codex", worktreeId: "w", title: "t")

--- a/AlasTests/ACP/Session/ACPSessionTests.swift
+++ b/AlasTests/ACP/Session/ACPSessionTests.swift
@@ -488,6 +488,29 @@ struct ACPSessionTests {
         #expect(thoughtTexts == ["plan", "plan more"])
     }
 
+    @Test("replay resuming after a punctuation-bounded split is adopted as a continuation")
+    func punctuationBoundedReplaySuffixAdopted() async {
+        let session = ACPSession(id: "s", agentId: "codex", worktreeId: "w", title: "t")
+        // No whitespace at the sentence split, as the raw/display replay case
+        // hydrates it.
+        session.transcript.messages = [
+            .agent(id: UUID(), messageId: "agent-1", StreamingText("tests completed.Running"))
+        ]
+        session.allowsStreamingBoundaryCrossing = false
+
+        // The replay resumes at "Running" (a suffix that begins after the
+        // period, not whitespace) and then continues. It must extend the
+        // hydrated bubble, not spawn a second "Running" row.
+        session.apply(.agentMessageChunk(.init(messageId: "regen-1", content: .text("Running"))))
+        session.apply(.agentMessageChunk(.init(messageId: "regen-1", content: .text("!"))))
+
+        let agentTexts = session.transcript.messages.compactMap { message -> String? in
+            if case .agent(_, _, let text) = message { return text.value }
+            return nil
+        }
+        #expect(agentTexts == ["tests completed.Running!"])
+    }
+
     @Test("a coincidental mid-token suffix overlap is not adopted as a replay continuation")
     func weakMidTokenSuffixOverlapNotAdopted() async {
         let session = ACPSession(id: "s", agentId: "codex", worktreeId: "w", title: "t")

--- a/AlasTests/ACP/Session/ACPSessionTests.swift
+++ b/AlasTests/ACP/Session/ACPSessionTests.swift
@@ -346,6 +346,50 @@ struct ACPSessionTests {
         #expect(after == ["hello world!"])
     }
 
+    @Test("replay continuation is still adopted across a trailing plan row")
+    func replayContinuationAdoptedAcrossTrailingPlan() async {
+        let session = ACPSession(id: "s", agentId: "codex", worktreeId: "w", title: "t")
+        session.transcript.messages = [
+            .agent(id: UUID(), messageId: "agent-1", StreamingText("hello")),
+            .plan(id: UUID(), [])
+        ]
+        session.allowsStreamingBoundaryCrossing = false
+
+        // A trailing plan does not close the agent output (like lastAgent()
+        // and markCompletedOutputBoundary(), which skip plans), so the
+        // replayed continuation must still merge into "hello", not duplicate.
+        session.apply(.agentMessageChunk(.init(messageId: "regen-1", content: .text("hello"))))
+        session.apply(.agentMessageChunk(.init(messageId: "regen-1", content: .text(" world"))))
+
+        let agentTexts = session.transcript.messages.compactMap { message -> String? in
+            if case .agent(_, _, let text) = message { return text.value }
+            return nil
+        }
+        #expect(agentTexts == ["hello world"])
+    }
+
+    @Test("pending replay candidates are namespaced by kind so a shared id does not mix thought into agent text")
+    func pendingReplayCandidatesNamespacedByKind() async {
+        let session = ACPSession(id: "s", agentId: "codex", worktreeId: "w", title: "t")
+        session.transcript.messages = [
+            .thought(id: UUID(), messageId: "thought-1", StreamingText("pondering")),
+            .agent(id: UUID(), messageId: "agent-1", StreamingText("response"))
+        ]
+        session.allowsStreamingBoundaryCrossing = false
+
+        // A thought and an agent chunk reuse the same id during the restore
+        // window. The suppressed thought fragment must not leak into the
+        // agent chunk's candidate and materialize as "ponderingreply".
+        session.apply(.agentThoughtChunk(.init(messageId: "dup", content: .text("pondering"))))
+        session.apply(.agentMessageChunk(.init(messageId: "dup", content: .text("reply"))))
+
+        let agentTexts = session.transcript.messages.compactMap { message -> String? in
+            if case .agent(_, _, let text) = message { return text.value }
+            return nil
+        }
+        #expect(agentTexts == ["response", "reply"])
+    }
+
     @Test("post-prompt live output sharing a prefix with a prior turn is not adopted into the old bubble")
     func postPromptLiveOutputNotAdoptedIntoPriorTurn() async {
         let session = ACPSession(id: "s", agentId: "codex", worktreeId: "w", title: "t")

--- a/AlasTests/ACP/Session/ACPSessionTests.swift
+++ b/AlasTests/ACP/Session/ACPSessionTests.swift
@@ -459,6 +459,33 @@ struct ACPSessionTests {
         #expect(ordered == ["thought:thinking hard", "thought:thinking", "agent:here is the answer"])
     }
 
+    @Test("a held thought is not flushed when the following agent chunk is itself suppressed as replay")
+    func heldThoughtNotFlushedWhenAgentChunkSuppressed() async {
+        let session = ACPSession(id: "s", agentId: "codex", worktreeId: "w", title: "t")
+        session.transcript.messages = [
+            .thought(id: UUID(), messageId: "thought-1", StreamingText("thinking hard")),
+            .agent(id: UUID(), messageId: "agent-1", StreamingText("the answer"))
+        ]
+        session.allowsStreamingBoundaryCrossing = false
+
+        // Held thought fragment "thinking", then a replayed agent chunk "the"
+        // (a substring of the existing agent message) that appendStreaming
+        // holds as a replay candidate. Since the agent chunk produces no live
+        // output, the thought must stay buffered — not materialize as a
+        // duplicate thought row.
+        session.apply(.agentThoughtChunk(.init(messageId: "regen-thought", content: .text("thinking"))))
+        session.apply(.agentMessageChunk(.init(messageId: "regen-agent", content: .text("the"))))
+
+        let ordered: [String] = session.transcript.messages.compactMap { message in
+            switch message {
+            case .thought(_, _, let t): return "thought:\(t.value)"
+            case .agent(_, _, let t): return "agent:\(t.value)"
+            default: return nil
+            }
+        }
+        #expect(ordered == ["thought:thinking hard", "agent:the answer"])
+    }
+
     @Test("multiple held candidates flush in arrival order, not by messageId")
     func heldCandidatesFlushInArrivalOrder() async {
         let session = ACPSession(id: "s", agentId: "codex", worktreeId: "w", title: "t")

--- a/AlasTests/ACP/Session/ACPSessionTests.swift
+++ b/AlasTests/ACP/Session/ACPSessionTests.swift
@@ -440,18 +440,21 @@ struct ACPSessionTests {
         #expect(agentTexts == ["tests completed.Running"])
     }
 
-    @Test("mid-message replay slip followed by real continuation extends the hydrated bubble")
-    func midMessageReplaySlipThenContinuationExtendsBubble() async {
+    @Test("mid-message replay slip followed by real continuation starts its own row, not a merge")
+    func midMessageReplaySlipThenContinuationStartsNewRow() async {
         let session = ACPSession(id: "s", agentId: "codex", worktreeId: "w", title: "t")
         session.transcript.messages = [
             .agent(id: UUID(), messageId: "agent-1", StreamingText("hello world"))
         ]
         session.allowsStreamingBoundaryCrossing = false
 
-        // The "hello " prefix was consumed during suppression; the surviving
-        // replay chunk is the middle fragment "world", which then continues
-        // with "!". This must extend the hydrated bubble to "hello world!"
-        // rather than materialize "world!" as a duplicate row.
+        // The surviving replay chunk is the middle fragment "world", which
+        // then continues with "!". Only a whole-bubble prefix is adopted, so
+        // a partial (suffix) match is NOT merged — it starts its own row.
+        // This is the accepted trade-off (a rare duplicate) for never merging
+        // a genuinely separate message into an existing bubble; a suffix like
+        // "world" is indistinguishable from new output starting with that
+        // word (see postPromptLiveOutputSharingTrailingWordNotAdopted).
         session.apply(.agentMessageChunk(.init(messageId: "regen-1", content: .text("world"))))
         session.apply(.agentMessageChunk(.init(messageId: "regen-1", content: .text("!"))))
 
@@ -459,7 +462,28 @@ struct ACPSessionTests {
             if case .agent(_, _, let text) = message { return text.value }
             return nil
         }
-        #expect(agentTexts == ["hello world!"])
+        #expect(agentTexts == ["hello world", "world!"])
+    }
+
+    @Test("post-prompt output sharing only the trailing word of the previous bubble is not merged")
+    func postPromptLiveOutputSharingTrailingWordNotAdopted() async {
+        let session = ACPSession(id: "s", agentId: "codex", worktreeId: "w", title: "t")
+        session.transcript.messages = [
+            .agent(id: UUID(), messageId: "agent-1", StreamingText("hello world"))
+        ]
+        session.allowsStreamingBoundaryCrossing = false
+
+        // A genuinely separate message that starts with the previous bubble's
+        // last word ("world") then diverges. It must be its own row, never
+        // merged into "hello world" as "hello world again".
+        session.apply(.agentMessageChunk(.init(messageId: "regen-1", content: .text("world"))))
+        session.apply(.agentMessageChunk(.init(messageId: "regen-1", content: .text(" again"))))
+
+        let agentTexts = session.transcript.messages.compactMap { message -> String? in
+            if case .agent(_, _, let text) = message { return text.value }
+            return nil
+        }
+        #expect(agentTexts == ["hello world", "world again"])
     }
 
     @Test("regenerated thought replay is not adopted across a file edit")
@@ -488,31 +512,8 @@ struct ACPSessionTests {
         #expect(thoughtTexts == ["plan", "plan more"])
     }
 
-    @Test("replay resuming after a punctuation-bounded split is adopted as a continuation")
-    func punctuationBoundedReplaySuffixAdopted() async {
-        let session = ACPSession(id: "s", agentId: "codex", worktreeId: "w", title: "t")
-        // No whitespace at the sentence split, as the raw/display replay case
-        // hydrates it.
-        session.transcript.messages = [
-            .agent(id: UUID(), messageId: "agent-1", StreamingText("tests completed.Running"))
-        ]
-        session.allowsStreamingBoundaryCrossing = false
-
-        // The replay resumes at "Running" (a suffix that begins after the
-        // period, not whitespace) and then continues. It must extend the
-        // hydrated bubble, not spawn a second "Running" row.
-        session.apply(.agentMessageChunk(.init(messageId: "regen-1", content: .text("Running"))))
-        session.apply(.agentMessageChunk(.init(messageId: "regen-1", content: .text("!"))))
-
-        let agentTexts = session.transcript.messages.compactMap { message -> String? in
-            if case .agent(_, _, let text) = message { return text.value }
-            return nil
-        }
-        #expect(agentTexts == ["tests completed.Running!"])
-    }
-
-    @Test("a coincidental mid-token suffix overlap is not adopted as a replay continuation")
-    func weakMidTokenSuffixOverlapNotAdopted() async {
+    @Test("a partial (non-whole-bubble) suffix match starts its own row rather than merging")
+    func partialSuffixMatchStartsNewRow() async {
         let session = ACPSession(id: "s", agentId: "codex", worktreeId: "w", title: "t")
         session.transcript.messages = [
             .agent(id: UUID(), messageId: "agent-1", StreamingText("OK"))
@@ -520,9 +521,9 @@ struct ACPSessionTests {
         session.allowsStreamingBoundaryCrossing = false
 
         // A genuinely new message "Keep going" whose first held fragment "K"
-        // coincides with the tail of "OK". The overlap is mid-token (not at a
-        // word boundary), so it must not be adopted into the old bubble as
-        // "OKeep going"; it starts its own row.
+        // coincides with the tail of "OK". Only a whole-bubble prefix is
+        // adopted, so this partial match is not merged into "OK" as
+        // "OKeep going" — it starts its own row.
         session.apply(.agentMessageChunk(.init(messageId: "regen-1", content: .text("K"))))
         session.apply(.agentMessageChunk(.init(messageId: "regen-1", content: .text("eep going"))))
 

--- a/AlasTests/ACP/Session/ACPSessionTests.swift
+++ b/AlasTests/ACP/Session/ACPSessionTests.swift
@@ -243,6 +243,35 @@ struct ACPSessionTests {
         }
     }
 
+    @Test("post-load live chunk whose short leading fragment coincides with earlier output is not dropped")
+    func postLoadLiveShortLeadingFragmentNotDroppedAsReplay() async {
+        let session = ACPSession(id: "s", agentId: "codex", worktreeId: "w", title: "t")
+        session.transcript.messages = [
+            .agent(id: UUID(), messageId: "agent-1", StreamingText("I'm rerunning the tests now.")),
+            .toolCall(.init(
+                toolCallId: "tool-1",
+                title: "Run tests",
+                kind: "execute",
+                status: "completed",
+                content: "done"
+            ))
+        ]
+        session.allowsStreamingBoundaryCrossing = false
+
+        // A genuinely new agent message streams its first fragment "I" — a
+        // coincidental substring of the earlier message. It must not be
+        // classified as a late replay and dropped; otherwise the message is
+        // rebuilt from the second fragment, losing its leading character.
+        session.apply(.agentMessageChunk(.init(messageId: "agent-live-2", content: .text("I"))))
+        session.apply(.agentMessageChunk(.init(messageId: "agent-live-2", content: .text("'ve made that warning cleanup."))))
+
+        let agentTexts = session.transcript.messages.compactMap { message -> String? in
+            if case .agent(_, _, let text) = message { return text.value }
+            return nil
+        }
+        #expect(agentTexts.contains("I've made that warning cleanup."))
+    }
+
     @Test("late replay user chunk with unknown messageId does not append prompt")
     func lateReplayUnknownUserMessageIdChunkDoesNotAppendPrompt() async {
         let session = ACPSession(id: "s", agentId: "codex", worktreeId: "w", title: "t")


### PR DESCRIPTION
## Problem

In the ACP pane, the first character(s) of an agent message were dropped (`I've` rendered as `'ve`, whole leading words missing), consistently at the start of messages. It only reproduced after **reopening a session while the agent was still working** (the "Restoring model context from transcript…" state).

## Root cause

When a mid-turn session is reopened, the transcript is hydrated from SQLite and the session enters the `allowsStreamingBoundaryCrossing == false` window, which suppresses *late load-replay frames* (the agent re-streaming already-stored messages) so they don't create duplicate bubbles.

That suppression used a naive substring check (`existing.value.contains(chunk)`). When the agent then produced **genuinely new** output, its first streaming chunk is tiny — `"I"`, `"The"`, `" "` — and almost always a coincidental substring of an earlier message. So it was misclassified as a replay and dropped (`appendStreaming` returns `nil`, no message created). The next, longer, unique chunk was kept, and the message got rebuilt starting from it — permanently losing the leading fragment.

## Fix

Replace the substring predicate with `chunkIsLikelyReplay(kind:of:)`, which only treats a chunk as a replay when the match is confident:

- it reproduces a whole existing message verbatim (the canonical single-chunk replay frame — preserves existing "late replay dropped" behavior), **or**
- it's a substantial span (≥16 chars) contained in an existing message (multi-chunk stragglers).

Short leading fragments of genuine new output fall through and are kept, so the message is built from its true beginning.

## Tests

- Added `postLoadLiveShortLeadingFragmentNotDroppedAsReplay` reproducing `"I"` + `"'ve made that warning cleanup."` — fails before, passes after.
- `ACPSessionTests` plus the replay/restore suites (`…HydrationTests`, `…RecoveryTests`, `…RecoveryIntegrationTests`, `…AttachRestoreTests`) pass; existing "late replay does not duplicate" contracts intact.
