### PR TITLE
Improve diff comment contrast

### DIFF
--- a/Alas/Sources/Center/Diff/DiffCodeText.swift
+++ b/Alas/Sources/Center/Diff/DiffCodeText.swift
@@ -61,6 +61,7 @@ struct DiffCodeText: View {
             to: output,
             text: text,
             fileExtension: fileExtension,
+            inlineTone: inlineTone,
             theme: theme,
             visibleLength: visibleLength
         )
@@ -91,6 +92,7 @@ struct DiffCodeText: View {
         to output: NSMutableAttributedString,
         text: String,
         fileExtension: String,
+        inlineTone: DiffInlineTone,
         theme: Theme,
         visibleLength: Int
     ) {
@@ -103,7 +105,7 @@ struct DiffCodeText: View {
             guard span.range.location >= cursor else { continue }
             output.addAttribute(
                 .foregroundColor,
-                value: NSColor(syntaxColor(for: span.capture, theme: theme)),
+                value: NSColor(syntaxColor(for: span.capture, inlineTone: inlineTone, theme: theme)),
                 range: span.range
             )
             cursor = NSMaxRange(span.range)
@@ -143,7 +145,7 @@ struct DiffCodeText: View {
         }
     }
 
-    private static func syntaxColor(for capture: HighlightCapture, theme: Theme) -> Color {
+    private static func syntaxColor(for capture: HighlightCapture, inlineTone: DiffInlineTone, theme: Theme) -> Color {
         switch capture {
         case .keyword:
             return theme.color("syntax-keyword")
@@ -156,6 +158,9 @@ struct DiffCodeText: View {
         case .number:
             return theme.color("mod")
         case .comment:
+            if inlineTone == .add || inlineTone == .del {
+                return theme.color("fg")
+            }
             return theme.color("fg-faint")
         case .attribute, .constant:
             return theme.color("syntax-keyword")

--- a/Alas/Sources/Center/DiffSelectableTextBuilder.swift
+++ b/Alas/Sources/Center/DiffSelectableTextBuilder.swift
@@ -36,6 +36,7 @@ struct DiffSelectableTextBuilder {
             let lineStart = location
             let attributedLine = attributedLine(
                 line.text,
+                kind: line.kind,
                 fileExtension: fileExtension,
                 font: font,
                 theme: theme
@@ -55,6 +56,7 @@ struct DiffSelectableTextBuilder {
 
     private static func attributedLine(
         _ line: String,
+        kind: ParsedDiff.Hunk.Line.Kind,
         fileExtension: String,
         font: NSFont,
         theme: Theme
@@ -82,7 +84,7 @@ struct DiffSelectableTextBuilder {
             }
             result.append(NSAttributedString(
                 string: ns.substring(with: span.range),
-                attributes: attributes(for: span.capture, font: font, theme: theme)
+                attributes: attributes(for: span.capture, kind: kind, font: font, theme: theme)
             ))
             cursor = NSMaxRange(span.range)
         }
@@ -122,15 +124,16 @@ struct DiffSelectableTextBuilder {
 
     private static func attributes(
         for capture: HighlightCapture,
+        kind: ParsedDiff.Hunk.Line.Kind,
         font: NSFont,
         theme: Theme
     ) -> [NSAttributedString.Key: Any] {
         var attributes = baseAttributes(font: font, theme: theme)
-        attributes[.foregroundColor] = NSColor(color(for: capture, theme: theme))
+        attributes[.foregroundColor] = NSColor(color(for: capture, kind: kind, theme: theme))
         return attributes
     }
 
-    private static func color(for capture: HighlightCapture, theme: Theme) -> Color {
+    private static func color(for capture: HighlightCapture, kind: ParsedDiff.Hunk.Line.Kind, theme: Theme) -> Color {
         switch capture {
         case .keyword:
             return theme.color("syntax-keyword")
@@ -143,6 +146,9 @@ struct DiffSelectableTextBuilder {
         case .number:
             return theme.color("mod")
         case .comment:
+            if kind == .add || kind == .delete {
+                return theme.color("fg")
+            }
             return theme.color("fg-faint")
         default:
             return theme.color("fg")

--- a/AlasTests/DiffSelectableTextTests.swift
+++ b/AlasTests/DiffSelectableTextTests.swift
@@ -74,6 +74,54 @@ struct Foo {
         #expect(result.lines.last?.range.location == (result.attributedString.string as NSString).length - 1)
     }
 
+    @Test func diffSelectableTextBuilderUsesReadableCommentColorOnChangedRows() throws {
+        let theme = currentTheme()
+        let text = "let value = 1 // whether this contains text"
+        let commentSpan = try #require(TreeSitterHighlighter.tokenize(line: text, fileExtension: "swift").first { $0.capture == .comment })
+        let hunk = ParsedDiff.Hunk(
+            header: "@@ -1,0 +1,1 @@",
+            oldStart: 1,
+            newStart: 1,
+            lines: [
+                .init(kind: .add, text: text, oldNumber: nil, newNumber: 1),
+            ]
+        )
+
+        let result = DiffSelectableTextBuilder.build(
+            hunk: hunk,
+            fileExtension: "swift",
+            font: CenterTypography.resolveCodeFont(family: "", size: 13),
+            theme: theme
+        )
+        let foreground = try #require(result.attributedString.attribute(
+            .foregroundColor,
+            at: commentSpan.range.location,
+            effectiveRange: nil
+        ) as? NSColor)
+
+        #expect(colorComponents(foreground).isClose(to: colorComponents(NSColor(theme.color("fg")))))
+    }
+
+    @Test func diffCodeTextUsesReadableCommentColorOnChangedRows() throws {
+        let theme = currentTheme()
+        let text = "let value = 1 // whether this contains text"
+        #expect(!colorComponents(NSColor(theme.color("fg-faint"))).isClose(to: colorComponents(NSColor(theme.color("fg")))))
+        let commentSpan = try #require(TreeSitterHighlighter.tokenize(line: text, fileExtension: "swift").first { $0.capture == .comment })
+        let rendered = DiffCodeText.attributedString(
+            text: text,
+            fileExtension: "swift",
+            codeFontFamily: "",
+            codeFontSize: 13,
+            showWhitespace: false,
+            inlineSpans: [],
+            inlineTone: .add,
+            theme: theme
+        )
+        let foreground = try #require(rendered.attribute(.foregroundColor, at: commentSpan.range.location, effectiveRange: nil) as? NSColor)
+
+        #expect(colorComponents(foreground).isClose(to: colorComponents(NSColor(theme.color("fg")))))
+    }
+
     @Test func diffSelectableTextViewHostsCodeOnlyNativeTextView() throws {
         let view = DiffSelectableTextView(
             hunk: sampleHunk(),
@@ -182,6 +230,30 @@ struct Foo {
 
     private func allSubviews(of view: NSView) -> [NSView] {
         view.subviews + view.subviews.flatMap { allSubviews(of: $0) }
+    }
+
+    private struct ColorComponents {
+        let red: Double
+        let green: Double
+        let blue: Double
+        let alpha: Double
+
+        func isClose(to other: ColorComponents, tolerance: Double = 0.001) -> Bool {
+            abs(red - other.red) <= tolerance
+                && abs(green - other.green) <= tolerance
+                && abs(blue - other.blue) <= tolerance
+                && abs(alpha - other.alpha) <= tolerance
+        }
+    }
+
+    private func colorComponents(_ color: NSColor) -> ColorComponents {
+        let normalized = color.usingColorSpace(.sRGB) ?? color
+        return ColorComponents(
+            red: Double(normalized.redComponent),
+            green: Double(normalized.greenComponent),
+            blue: Double(normalized.blueComponent),
+            alpha: Double(normalized.alphaComponent)
+        )
     }
 
     private func ancestorSubviews(of view: NSView) -> [NSView] {


### PR DESCRIPTION
## Summary

- Render syntax comments in added/deleted diff rows with the main code foreground instead of the faint comment color.
- Apply the same rule to the selectable diff text builder so diff components stay visually consistent.
- Add regression coverage for changed-row comment foreground color.

## Why

The faint comment syntax color became hard to read over the more vibrant green added-line background in PR review diffs.

## Validation

- `rtk xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS,arch=arm64' CURRENT_ARCH=arm64 ALAS_FFF_TARGET_ARCH=arm64 -only-testing:AlasTests/DiffSelectableTextTests test`
- `rtk xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS,arch=arm64' CURRENT_ARCH=arm64 ALAS_FFF_TARGET_ARCH=arm64 -quiet build`