### PR TITLE
fix(review): render subscript tags in comments

### DIFF
--- a/Alas/Sources/ACP/UI/ACPMarkdownInlineRenderer.swift
+++ b/Alas/Sources/ACP/UI/ACPMarkdownInlineRenderer.swift
@@ -368,13 +368,8 @@ enum ACPMarkdownInlineRenderer {
                     continue
                 }
 
-                if !isSubscript,
-                   let subscriptContentStart = subscriptOpenTagEnd(in: source, at: index),
-                   let closeRange = source.range(
-                       of: "</sub>",
-                       options: [.caseInsensitive],
-                       range: subscriptContentStart..<source.endIndex
-                   ) {
+                if let subscriptContentStart = subscriptOpenTagEnd(in: source, at: index),
+                   let closeRange = matchingSubscriptClose(in: source, from: subscriptContentStart) {
                     let marker = makeSubscriptMarker()
                     output += marker.start
                     output += render(String(source[subscriptContentStart..<closeRange.lowerBound]), isSubscript: true)
@@ -401,6 +396,54 @@ enum ACPMarkdownInlineRenderer {
                 index = source.index(after: index)
             }
             return output
+        }
+
+        private func matchingSubscriptClose(
+            in source: String,
+            from contentStart: String.Index
+        ) -> Range<String.Index>? {
+            var cursor = contentStart
+            var depth = 1
+
+            while cursor < source.endIndex {
+                let closeRange = source.range(
+                    of: "</sub>",
+                    options: [.caseInsensitive],
+                    range: cursor..<source.endIndex
+                )
+
+                if let openRange = nextSubscriptOpenTagRange(
+                    in: source,
+                    range: cursor..<(closeRange?.lowerBound ?? source.endIndex)
+                ) {
+                    depth += 1
+                    cursor = openRange.upperBound
+                    continue
+                }
+
+                guard let closeRange else { return nil }
+                depth -= 1
+                if depth == 0 {
+                    return closeRange
+                }
+                cursor = closeRange.upperBound
+            }
+
+            return nil
+        }
+
+        private func nextSubscriptOpenTagRange(
+            in source: String,
+            range: Range<String.Index>
+        ) -> Range<String.Index>? {
+            var cursor = range.lowerBound
+            while cursor < range.upperBound {
+                if let end = subscriptOpenTagEnd(in: source, at: cursor) {
+                    return cursor..<end
+                }
+                cursor = source.index(after: cursor)
+            }
+            return nil
         }
 
         private func subscriptOpenTagEnd(in source: String, at index: String.Index) -> String.Index? {

--- a/Alas/Sources/Center/Review/DiffInlineCommentCard.swift
+++ b/Alas/Sources/Center/Review/DiffInlineCommentCard.swift
@@ -65,7 +65,7 @@ struct DiffInlineCommentCard: View {
                     Text("\(first.author):")
                         .font(.system(size: 11, weight: .semibold))
                         .foregroundColor(.primary)
-                    Text(first.body)
+                    Text(DiffReviewInlineFeedbackMarkdown.plainText(first.body))
                         .font(.system(size: 11))
                         .foregroundColor(.secondary)
                         .lineLimit(1)

--- a/Alas/Sources/Center/Review/OutdatedThreadsDrawer.swift
+++ b/Alas/Sources/Center/Review/OutdatedThreadsDrawer.swift
@@ -6,6 +6,11 @@ struct OutdatedThreadsDrawer: View {
 
     @Environment(\.theme) private var theme
 
+    init(threads: [ReviewThread], initiallyExpanded: Bool = false) {
+        self.threads = threads
+        _isExpanded = State(initialValue: initiallyExpanded)
+    }
+
     var body: some View {
         if threads.isEmpty {
             EmptyView()
@@ -116,11 +121,11 @@ private struct OutdatedThreadRow: View {
                         .font(.system(size: 10, weight: .semibold))
                         .foregroundColor(theme.color("accent"))
                 }
-                Text(body)
-                    .font(.system(size: 11))
-                    .foregroundColor(theme.color("fg"))
+                DiffReviewInlineFeedbackMarkdown.view(body)
                     .lineLimit(4)
                     .truncationMode(.tail)
+                    .frame(maxHeight: 72, alignment: .top)
+                    .clipped()
                     .textSelection(.enabled)
             }
         }

--- a/Alas/Sources/Code/Markdown/MarkdownRenderer.swift
+++ b/Alas/Sources/Code/Markdown/MarkdownRenderer.swift
@@ -37,6 +37,7 @@ final class MarkdownRenderer {
 
     private var currentTraits: NSFontDescriptor.SymbolicTraits = []
     private var inStrikethrough: Bool = false
+    private var subscriptDepth: Int = 0
     private var listDepth: Int = 0
     /// Counts how many times each base slug has been seen so duplicate
     /// headings get GitHub-style `-1`, `-2`, … suffixes instead of clobbering
@@ -80,6 +81,7 @@ final class MarkdownRenderer {
         self.worktreeRoot = worktreeRoot
         self.currentTraits = []
         self.inStrikethrough = false
+        self.subscriptDepth = 0
         self.listDepth = 0
         self.slugCounts = [:]
 
@@ -107,6 +109,7 @@ final class MarkdownRenderer {
         case let s as Strong:           withTrait(.bold) { visitChildren(s) }
         case let s as Strikethrough:    withStrikethrough { visitChildren(s) }
         case let c as InlineCode:       appendText(c.code, attributes: inlineCodeAttributes())
+        case let h as InlineHTML:       visitInlineHTML(h)
         case _ as SoftBreak:            appendPlain(" ")
         case _ as LineBreak:            appendPlain("\n")
         case let l as Markdown.Link:    visitLink(l)
@@ -178,6 +181,26 @@ final class MarkdownRenderer {
             remoteImages.append(RemoteImageReference(url: url, attachment: attachment))
             output.append(NSAttributedString(attachment: attachment))
         }
+    }
+
+    private func visitInlineHTML(_ html: InlineHTML) {
+        let raw = html.rawHTML.trimmingCharacters(in: .whitespacesAndNewlines)
+        if Self.isSubscriptOpenTag(raw) {
+            subscriptDepth += 1
+        } else if raw.caseInsensitiveCompare("</sub>") == .orderedSame {
+            subscriptDepth = max(0, subscriptDepth - 1)
+        }
+    }
+
+    private static func isSubscriptOpenTag(_ raw: String) -> Bool {
+        guard raw.hasPrefix("<") else { return false }
+        let lower = raw.lowercased()
+        guard lower.hasPrefix("<sub") else { return false }
+        let nameEnd = lower.index(lower.startIndex, offsetBy: 4)
+        guard nameEnd < lower.endIndex else { return false }
+        let next = lower[nameEnd]
+        guard next == ">" || next.isWhitespace else { return false }
+        return lower.last == ">"
     }
 
     private func attachmentString(for image: NSImage) -> NSAttributedString {
@@ -338,11 +361,13 @@ final class MarkdownRenderer {
         let savedOutput = output
         let savedTraits = currentTraits
         let savedStrikethrough = inStrikethrough
+        let savedSubscriptDepth = subscriptDepth
         let cellOutput = NSMutableAttributedString()
 
         output = cellOutput
         currentTraits = []
         inStrikethrough = false
+        subscriptDepth = 0
 
         for child in cell.children {
             if let paragraph = child as? Paragraph {
@@ -358,6 +383,7 @@ final class MarkdownRenderer {
         output = savedOutput
         currentTraits = savedTraits
         inStrikethrough = savedStrikethrough
+        subscriptDepth = savedSubscriptDepth
 
         if rendered.length > 0 {
             return rendered
@@ -611,29 +637,42 @@ final class MarkdownRenderer {
     // MARK: - Attributes
 
     private func bodyAttributes() -> [NSAttributedString.Key: Any] {
+        let isSubscript = subscriptDepth > 0
         var attrs: [NSAttributedString.Key: Any] = [
-            .font: bodyFont(),
+            .font: bodyFont(size: isSubscript ? subscriptFontSize(base: NSFont.systemFontSize) : NSFont.systemFontSize),
             .foregroundColor: NSColor(theme.color("fg"))
         ]
         if inStrikethrough {
             attrs[.strikethroughStyle] = NSUnderlineStyle.single.rawValue
         }
+        if isSubscript {
+            attrs[.baselineOffset] = -max(1, subscriptFontSize(base: NSFont.systemFontSize) * 0.22)
+        }
         return attrs
     }
 
     private func inlineCodeAttributes() -> [NSAttributedString.Key: Any] {
-        [
-            .font: monospaceFont(size: monoSize - 1),
+        let isSubscript = subscriptDepth > 0
+        var attrs: [NSAttributedString.Key: Any] = [
+            .font: monospaceFont(size: isSubscript ? subscriptFontSize(base: monoSize - 1) : monoSize - 1),
             .foregroundColor: NSColor(theme.color("fg")),
             .backgroundColor: NSColor(theme.color("bg-2"))
         ]
+        if isSubscript {
+            attrs[.baselineOffset] = -max(1, subscriptFontSize(base: monoSize - 1) * 0.22)
+        }
+        return attrs
     }
 
-    private func bodyFont() -> NSFont {
-        let base = NSFont.systemFont(ofSize: NSFont.systemFontSize)
+    private func bodyFont(size: CGFloat = NSFont.systemFontSize) -> NSFont {
+        let base = NSFont.systemFont(ofSize: size)
         if currentTraits.isEmpty { return base }
         let desc = base.fontDescriptor.withSymbolicTraits(currentTraits)
         return NSFont(descriptor: desc, size: base.pointSize) ?? base
+    }
+
+    private func subscriptFontSize(base: CGFloat) -> CGFloat {
+        max(7, base * 0.82)
     }
 
     private func headerTableFont() -> NSFont {

--- a/AlasTests/ACP/UI/ACPMarkdownInlineRendererTests.swift
+++ b/AlasTests/ACP/UI/ACPMarkdownInlineRendererTests.swift
@@ -100,6 +100,19 @@ struct ACPMarkdownInlineRendererTests {
         #expect(plan.markdownSource.contains("</sub>") == false)
     }
 
+    @Test("nested subscript tags are stripped")
+    func nestedSubscriptTagsAreStripped() throws {
+        let source = "**<sub><sub>![P2 Badge](https://img.shields.io/badge/P2-yellow?style=flat)</sub></sub> Preserve text**"
+        let plain = ACPMarkdownInlineRenderer.plainText(source)
+        #expect(plain == "P2 Badge Preserve text")
+
+        let plan = ACPMarkdownInlineRenderer.makePlan(source)
+        let image = try #require(plan.images.first)
+        #expect(image.isSubscript)
+        #expect(plan.markdownSource.contains("<sub") == false)
+        #expect(plan.markdownSource.contains("</sub>") == false)
+    }
+
     @Test("malformed subscript remains visible")
     func malformedSubscriptRemainsVisible() {
         let plain = ACPMarkdownInlineRenderer.plainText("Before <sub>small after")
@@ -225,6 +238,59 @@ struct ACPMarkdownInlineRendererTests {
         #expect(!renderedBody.contains("`leadingX`"))
         #expect(accessibilityLabel(in: host, containing: "**<sub>") == nil)
         #expect(accessibilityLabel(in: host, containing: "`leadingX`") == nil)
+    }
+
+    @Test("outdated drawer thread body renders markdown")
+    func outdatedDrawerThreadBodyRendersMarkdown() throws {
+        let comment = ReviewComment(
+            id: "comment-1",
+            author: "chatgpt-codex-connector",
+            body: """
+            **<sub><sub>![P2 Badge](https://img.shields.io/badge/P2-yellow?style=flat)</sub></sub> Preserve streamed text**
+
+            Use `leadingX` instead of **resetting** each event.
+            """,
+            url: nil,
+            createdAt: nil,
+            viewerCanUpdate: false,
+            viewerCanDelete: false,
+            isPending: false
+        )
+        let thread = ReviewThread(
+            id: "thread-1",
+            path: "Sources/App.swift",
+            line: nil,
+            startLine: nil,
+            originalLine: nil,
+            diffHunk: nil,
+            isResolved: false,
+            isOutdated: true,
+            isFileLevel: false,
+            comments: [comment],
+            viewerCanResolve: false,
+            viewerCanReply: false,
+            url: nil
+        )
+
+        let host = NSHostingView(
+            rootView: OutdatedThreadsDrawer(threads: [thread], initiallyExpanded: true)
+                .environment(\.theme, try Theme.loadBundled(id: "cool-slate"))
+                .frame(width: 620, height: 360)
+        )
+        host.frame = NSRect(x: 0, y: 0, width: 620, height: 360)
+        host.layoutSubtreeIfNeeded()
+
+        let renderedBody = allSubviews(of: host)
+            .compactMap { $0 as? NSTextView }
+            .map(\.string)
+            .joined(separator: "\n")
+
+        #expect(renderedBody.contains("Preserve streamed text"))
+        #expect(renderedBody.contains("Use leadingX instead of resetting each event."))
+        #expect(!renderedBody.contains("**"))
+        #expect(!renderedBody.contains("<sub>"))
+        #expect(!renderedBody.contains("</sub>"))
+        #expect(!renderedBody.contains("`leadingX`"))
     }
 
     @Test("inline markdown text invalidates height when resized narrower")

--- a/AlasTests/MarkdownRendererTests.swift
+++ b/AlasTests/MarkdownRendererTests.swift
@@ -54,6 +54,18 @@ struct MarkdownRendererTests {
         #expect(font?.isFixedPitch == true)
     }
 
+    @Test func consumesSubscriptHTMLTags() throws {
+        let r = try MarkdownRendererTests.render("Before <sub><sub>P2</sub></sub> after")
+        let s = r.attributedString
+        #expect(s.string.contains("Before P2 after"))
+        #expect(!s.string.contains("<sub>"))
+        #expect(!s.string.contains("</sub>"))
+
+        let range = (s.string as NSString).range(of: "P2")
+        let baseline = s.attribute(.baselineOffset, at: range.location, effectiveRange: nil) as? CGFloat
+        #expect((baseline ?? 0) < 0)
+    }
+
     @Test func linkRunCarriesURLAttribute() throws {
         let r = try MarkdownRendererTests.render("[example](https://example.com)")
         let s = r.attributedString


### PR DESCRIPTION
## Summary
- Render outdated/file-level review comments through the shared markdown renderer
- Strip and interpret nested `<sub>` tags in ACP inline markdown and generic markdown surfaces
- Use markdown plain-text extraction for collapsed inline comment previews
- Preserve the bounded preview height for outdated/file-level comment bodies

## Verification
- `rtk xcodegen`
- `rtk env ALAS_FFF_TARGET_ARCH=arm64 xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -only-testing:AlasTests/ACPMarkdownInlineRendererTests -only-testing:AlasTests/MarkdownRendererTests test`
- `rtk env ALAS_FFF_TARGET_ARCH=arm64 xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -quiet build`
- `rtk git diff --check`
- GitHub Actions `Build / build-test` passed on `c952d131bf`