### PR TITLE
fix(review): Cap outdated review thread drawer height

### DIFF
--- a/Alas/Sources/Center/Review/OutdatedThreadsDrawer.swift
+++ b/Alas/Sources/Center/Review/OutdatedThreadsDrawer.swift
@@ -1,13 +1,31 @@
 import SwiftUI
 
+enum OutdatedThreadsDrawerPresentation {
+    static let defaultMaxExpandedListHeight: CGFloat = 280
+
+    static func expandedListMaxHeight(availableHeight: CGFloat) -> CGFloat {
+        guard availableHeight.isFinite, availableHeight > 0 else {
+            return defaultMaxExpandedListHeight
+        }
+
+        return min(defaultMaxExpandedListHeight, max(80, floor(availableHeight * 0.35)))
+    }
+}
+
 struct OutdatedThreadsDrawer: View {
     let threads: [ReviewThread]  // already filtered: isFileLevel || isOutdated
+    let maxExpandedListHeight: CGFloat
     @State private var isExpanded = false
 
     @Environment(\.theme) private var theme
 
-    init(threads: [ReviewThread], initiallyExpanded: Bool = false) {
+    init(
+        threads: [ReviewThread],
+        maxExpandedListHeight: CGFloat = OutdatedThreadsDrawerPresentation.defaultMaxExpandedListHeight,
+        initiallyExpanded: Bool = false
+    ) {
         self.threads = threads
+        self.maxExpandedListHeight = maxExpandedListHeight
         _isExpanded = State(initialValue: initiallyExpanded)
     }
 
@@ -43,12 +61,16 @@ struct OutdatedThreadsDrawer: View {
 
                 if isExpanded {
                     Divider().overlay(theme.color("line"))
-                    VStack(spacing: 0) {
-                        ForEach(threads) { thread in
-                            OutdatedThreadRow(thread: thread)
+                    ScrollView(.vertical) {
+                        LazyVStack(spacing: 0) {
+                            ForEach(threads) { thread in
+                                OutdatedThreadRow(thread: thread)
+                            }
                         }
+                        .padding(.vertical, 4)
                     }
-                    .padding(.vertical, 4)
+                    .fixedSize(horizontal: false, vertical: true)
+                    .frame(maxHeight: maxExpandedListHeight)
                 }
             }
             .background(theme.color("bg-2"))

--- a/Alas/Sources/Center/Review/ReviewTabView.swift
+++ b/Alas/Sources/Center/Review/ReviewTabView.swift
@@ -47,16 +47,23 @@ struct ReviewTabView: View {
     @State private var showWhitespace = false
 
     var body: some View {
-        VStack(spacing: 0) {
-            toolbar
-            Divider().overlay(theme.color("line"))
-            CIStatusStrip(checks: reviewRequest?.checks ?? [], onExpand: { check in
-                Task { await fetchAnnotations(for: check) }
-            })
-            OutdatedThreadsDrawer(threads: outdatedAndFileLevelThreads)
-            content
+        GeometryReader { geometry in
+            VStack(spacing: 0) {
+                toolbar
+                Divider().overlay(theme.color("line"))
+                CIStatusStrip(checks: reviewRequest?.checks ?? [], onExpand: { check in
+                    Task { await fetchAnnotations(for: check) }
+                })
+                OutdatedThreadsDrawer(
+                    threads: outdatedAndFileLevelThreads,
+                    maxExpandedListHeight: OutdatedThreadsDrawerPresentation.expandedListMaxHeight(
+                        availableHeight: geometry.size.height
+                    )
+                )
+                content
+            }
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
         }
-        .frame(maxWidth: .infinity, maxHeight: .infinity)
         .background(theme.color("bg-1"))
         .overlay(alignment: .bottom) {
             if let msg = errorMessage {

--- a/AlasTests/ACP/UI/ACPMarkdownInlineRendererTests.swift
+++ b/AlasTests/ACP/UI/ACPMarkdownInlineRendererTests.swift
@@ -293,6 +293,54 @@ struct ACPMarkdownInlineRendererTests {
         #expect(!renderedBody.contains("`leadingX`"))
     }
 
+    @Test("outdated drawer short thread list fits content before cap")
+    func outdatedDrawerShortThreadListFitsContentBeforeCap() throws {
+        let comment = ReviewComment(
+            id: "comment-1",
+            author: "chatgpt-codex-connector",
+            body: "Short note.",
+            url: nil,
+            createdAt: nil,
+            viewerCanUpdate: false,
+            viewerCanDelete: false,
+            isPending: false
+        )
+        let thread = ReviewThread(
+            id: "thread-1",
+            path: "Sources/App.swift",
+            line: nil,
+            startLine: nil,
+            originalLine: nil,
+            diffHunk: nil,
+            isResolved: false,
+            isOutdated: true,
+            isFileLevel: false,
+            comments: [comment],
+            viewerCanResolve: false,
+            viewerCanReply: false,
+            url: nil
+        )
+
+        let host = NSHostingView(
+            rootView: OutdatedThreadsDrawer(
+                threads: [thread],
+                maxExpandedListHeight: 280,
+                initiallyExpanded: true
+            )
+            .environment(\.theme, try Theme.loadBundled(id: "cool-slate"))
+            .frame(width: 620, height: 360)
+        )
+        host.frame = NSRect(x: 0, y: 0, width: 620, height: 360)
+        host.layoutSubtreeIfNeeded()
+
+        let drawerScrollView = try #require(
+            allSubviews(of: host)
+                .compactMap { $0 as? NSScrollView }
+                .max { $0.frame.height < $1.frame.height }
+        )
+        #expect(drawerScrollView.frame.height < 200)
+    }
+
     @Test("inline markdown text invalidates height when resized narrower")
     func inlineMarkdownTextInvalidatesHeightWhenResizedNarrower() throws {
         let theme = try Theme.loadBundled(id: "cool-slate")

--- a/AlasTests/Center/Review/ReviewTabViewTests.swift
+++ b/AlasTests/Center/Review/ReviewTabViewTests.swift
@@ -47,4 +47,11 @@ struct ReviewTabViewTests {
             hasPendingReviewScope: false
         ))
     }
+
+    @Test func outdatedDrawerCapsExpandedListHeightToProtectReviewContent() {
+        #expect(OutdatedThreadsDrawerPresentation.expandedListMaxHeight(availableHeight: 1_200) == 280)
+        #expect(OutdatedThreadsDrawerPresentation.expandedListMaxHeight(availableHeight: 600) == 210)
+        #expect(OutdatedThreadsDrawerPresentation.expandedListMaxHeight(availableHeight: 200) == 80)
+        #expect(OutdatedThreadsDrawerPresentation.expandedListMaxHeight(availableHeight: 0) == 280)
+    }
 }


### PR DESCRIPTION
## Summary

Fixes the inspect tab becoming unusable when the outdated and file-level review thread section contains many comments.

The expanded drawer now owns its overflow in a bounded scroll view instead of growing unbounded inside the tab layout. The height cap scales with the tab height and preserves the review content below.

## Verification

- `rtk env ALAS_FFF_TARGET_ARCH=arm64 xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -only-testing:AlasTests/ReviewTabViewTests -quiet test`
- `rtk env ALAS_FFF_TARGET_ARCH=arm64 xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -quiet build`