### PR TITLE
fix(center): cache resolved code font to prevent beachballs

### DIFF
--- a/Alas/Sources/Center/CenterTypography.swift
+++ b/Alas/Sources/Center/CenterTypography.swift
@@ -23,10 +23,28 @@ enum CenterTypography {
         (lineHeightMultiple - 1) * size * 1.2
     }
 
+    /// `resolveCodeFont` is called for every visible line of code across the diff,
+    /// merge, and markdown surfaces. The uncached lookup walks `NSFontManager`'s
+    /// font-family enumeration (IPC to fontd), which is expensive enough per call
+    /// to beachball the app when a custom code font is configured and many lines
+    /// re-render. Cache by (family, size) since the resolved font never changes
+    /// for a given input.
+    private static let resolvedFontCache = NSCache<NSString, NSFont>()
+
     static func resolveCodeFont(family: String, size: CGFloat) -> NSFont {
         guard !family.isEmpty else {
             return .monospacedSystemFont(ofSize: size, weight: .regular)
         }
+        let cacheKey = "\(family)|\(size)" as NSString
+        if let cached = resolvedFontCache.object(forKey: cacheKey) {
+            return cached
+        }
+        let font = resolveCodeFontUncached(family: family, size: size)
+        resolvedFontCache.setObject(font, forKey: cacheKey)
+        return font
+    }
+
+    private static func resolveCodeFontUncached(family: String, size: CGFloat) -> NSFont {
         let fixedFontNames = Set(NSFontManager.shared.availableFontNames(with: .fixedPitchFontMask) ?? [])
 
         func fixedPitchFont(named name: String) -> NSFont? {


### PR DESCRIPTION
## Summary
- A user reported a beachball; the hang report showed the main thread stuck in `CenterTypography.resolveCodeFont` → `NSFontManager.availableMembers(ofFontFamily:)`.
- `resolveCodeFont` is called once per visible code line (diff, merge, markdown surfaces). With a custom code font configured, every call re-enumerated all system font families via `NSFontManager`, an expensive AppKit call. On a large diff this compounded into a multi-second main-thread stall.
- Cache the resolved `NSFont` by `(family, size)` so the expensive lookup happens once per distinct font configuration instead of once per rendered line.

## Test plan
- [x] `xcodegen` + `xcodebuild ... build` succeeds
- [x] `xcodebuild ... test -only-testing:AlasTests/DiffPaneViewTests` — same result before/after the change (one pre-existing, unrelated failure)