### PR TITLE
fix(updates): run brew update before upgrading the cask

### DIFF
--- a/Alas/Sources/Updates/SelfUpdater.swift
+++ b/Alas/Sources/Updates/SelfUpdater.swift
@@ -8,22 +8,40 @@ struct SelfUpdateCommand: Equatable, Sendable {
 
     let executable: String
     let arguments: [String]
+    /// Overrides `displayCommandLine` for commands whose real invocation
+    /// (e.g. a `sh -c` wrapper chaining multiple steps) isn't what a user
+    /// should copy-paste into their own shell.
+    let displayOverride: String?
+
+    init(executable: String, arguments: [String], displayOverride: String? = nil) {
+        self.executable = executable
+        self.arguments = arguments
+        self.displayOverride = displayOverride
+    }
 
     /// Detects the `brew` executable on the host's PATH so the upgrade
     /// works on both Apple Silicon (`/opt/homebrew/bin/brew`) and Intel
     /// (`/usr/local/bin/brew`) Macs. Falls back to the Apple Silicon default
     /// if brew cannot be found.
+    ///
+    /// Runs `brew update` first: Homebrew doesn't always refresh its local
+    /// tap metadata before `upgrade`, so without this a stale local index
+    /// can make `brew upgrade --cask` report nothing to do even though the
+    /// app's own GitHub-based check just found a newer release.
     static var homebrew: SelfUpdateCommand {
         let host = InstallerHost.detect()
-        let executable = host.detected[.brew]?.executable ?? "/opt/homebrew/bin/brew"
+        let brew = host.detected[.brew]?.executable ?? "/opt/homebrew/bin/brew"
+        let updateCommand = "\(brew) update"
+        let upgradeCommand = "\(brew) upgrade --cask \(alasHomebrewCask)"
         return SelfUpdateCommand(
-            executable: executable,
-            arguments: ["upgrade", "--cask", alasHomebrewCask]
+            executable: "/bin/sh",
+            arguments: ["-c", "\(updateCommand) && \(upgradeCommand)"],
+            displayOverride: "brew update && brew upgrade --cask \(alasHomebrewCask)"
         )
     }
 
     var displayCommandLine: String {
-        ((executable as NSString).lastPathComponent as String) + " " + arguments.joined(separator: " ")
+        displayOverride ?? ((executable as NSString).lastPathComponent as String) + " " + arguments.joined(separator: " ")
     }
 }
 

--- a/Alas/Sources/Updates/SelfUpdater.swift
+++ b/Alas/Sources/Updates/SelfUpdater.swift
@@ -6,42 +6,43 @@ import Observation
 struct SelfUpdateCommand: Equatable, Sendable {
     static let alasHomebrewCask = "mrmans0n/tap/alas"
 
-    let executable: String
-    let arguments: [String]
-    /// Overrides `displayCommandLine` for commands whose real invocation
-    /// (e.g. a `sh -c` wrapper chaining multiple steps) isn't what a user
-    /// should copy-paste into their own shell.
-    let displayOverride: String?
+    /// A single subprocess invocation. Steps run in order; the sequence
+    /// stops at the first non-zero exit or cancellation.
+    struct Step: Equatable, Sendable {
+        let executable: String
+        let arguments: [String]
 
-    init(executable: String, arguments: [String], displayOverride: String? = nil) {
-        self.executable = executable
-        self.arguments = arguments
-        self.displayOverride = displayOverride
+        var displayCommandLine: String {
+            ((executable as NSString).lastPathComponent as String) + " " + arguments.joined(separator: " ")
+        }
     }
+
+    let steps: [Step]
 
     /// Detects the `brew` executable on the host's PATH so the upgrade
     /// works on both Apple Silicon (`/opt/homebrew/bin/brew`) and Intel
     /// (`/usr/local/bin/brew`) Macs. Falls back to the Apple Silicon default
     /// if brew cannot be found.
     ///
-    /// Runs `brew update` first: Homebrew doesn't always refresh its local
-    /// tap metadata before `upgrade`, so without this a stale local index
-    /// can make `brew upgrade --cask` report nothing to do even though the
-    /// app's own GitHub-based check just found a newer release.
+    /// Runs `brew update` as its own step first: Homebrew doesn't always
+    /// refresh its local tap metadata before `upgrade`, so without this a
+    /// stale local index can make `brew upgrade --cask` report nothing to
+    /// do even though the app's own GitHub-based check just found a newer
+    /// release. The two steps run as direct, separately-tracked processes
+    /// (not a `sh -c` chain) so `SelfUpdater` always signals the real
+    /// `brew` process — a shell wrapper would let a cancelled update leave
+    /// `brew` running in the background.
     static var homebrew: SelfUpdateCommand {
         let host = InstallerHost.detect()
         let brew = host.detected[.brew]?.executable ?? "/opt/homebrew/bin/brew"
-        let updateCommand = "\(brew) update"
-        let upgradeCommand = "\(brew) upgrade --cask \(alasHomebrewCask)"
-        return SelfUpdateCommand(
-            executable: "/bin/sh",
-            arguments: ["-c", "\(updateCommand) && \(upgradeCommand)"],
-            displayOverride: "brew update && brew upgrade --cask \(alasHomebrewCask)"
-        )
+        return SelfUpdateCommand(steps: [
+            Step(executable: brew, arguments: ["update"]),
+            Step(executable: brew, arguments: ["upgrade", "--cask", alasHomebrewCask]),
+        ])
     }
 
     var displayCommandLine: String {
-        displayOverride ?? ((executable as NSString).lastPathComponent as String) + " " + arguments.joined(separator: " ")
+        steps.map(\.displayCommandLine).joined(separator: " && ")
     }
 }
 
@@ -62,10 +63,10 @@ final class SelfUpdater {
     private var currentProcess: Process?
     private var watchdog: Task<Void, Never>?
     private var cancelRequested = false
-    /// Identity token for the currently-tracked update. Incremented on every
-    /// spawn and on every `reset()`. The readability/termination handlers only
-    /// mutate state/logs if this still matches the spawn-time value —
-    /// otherwise a stale handler from a killed process could corrupt a new run.
+    /// Identity token for the currently-tracked update run. Incremented on
+    /// every `start`/`runForTesting` call and on every `reset()`. Handlers
+    /// from a superseded run check this before touching state/logs so a
+    /// stale callback from a killed process can't corrupt a new run.
     private var generation: Int = 0
 
     /// Start the update. Requires `.idle`; otherwise throws.
@@ -73,11 +74,7 @@ final class SelfUpdater {
         guard state == .idle else {
             throw SelfUpdaterBusy()
         }
-        await _spawn(
-            executable: command.executable,
-            arguments: command.arguments,
-            commandLineForDisplay: command.displayCommandLine
-        )
+        await _runSequence(steps: command.steps, commandLineForDisplay: command.displayCommandLine)
     }
 
     func cancel() {
@@ -116,26 +113,80 @@ final class SelfUpdater {
         generation &+= 1
     }
 
-    /// Test seam: spawn a command directly without going through `start`.
-    func runForTesting(executable: String, arguments: [String]) async {
+    /// Test seam: run one or more steps directly without going through `start`.
+    func runForTesting(steps: [SelfUpdateCommand.Step]) async {
         precondition(state == .idle, "runForTesting requires idle state")
-        await _spawn(
-            executable: executable,
-            arguments: arguments,
-            commandLineForDisplay: ([executable] + arguments).joined(separator: " ")
-        )
+        await _runSequence(steps: steps, commandLineForDisplay: steps.map(\.displayCommandLine).joined(separator: " && "))
     }
 
-    // MARK: - Private spawn
+    func runForTesting(executable: String, arguments: [String]) async {
+        await runForTesting(steps: [SelfUpdateCommand.Step(executable: executable, arguments: arguments)])
+    }
 
-    private func _spawn(
-        executable: String,
-        arguments: [String],
-        commandLineForDisplay: String
-    ) async {
+    // MARK: - Private sequencing
+
+    private enum StepOutcome {
+        case launchFailed(Error)
+        case exited(status: Int32, reason: Process.TerminationReason)
+    }
+
+    private func _runSequence(steps: [SelfUpdateCommand.Step], commandLineForDisplay: String) async {
+        generation &+= 1
+        let myGeneration = generation
+        state = .running(commandLine: commandLineForDisplay)
+        logLines = []
+        cancelRequested = false
+
+        for step in steps {
+            guard generation == myGeneration else { return }
+            if cancelRequested {
+                state = .cancelled
+                watchdog?.cancel()
+                watchdog = nil
+                cancelRequested = false
+                return
+            }
+
+            let outcome = await _runStep(step, generation: myGeneration)
+            guard generation == myGeneration else { return }
+            currentProcess = nil
+
+            switch outcome {
+            case .launchFailed(let error):
+                state = .failed(message: String(describing: error))
+                watchdog?.cancel()
+                watchdog = nil
+                cancelRequested = false
+                return
+            case .exited(let status, let reason):
+                if cancelRequested || reason == .uncaughtSignal {
+                    state = .cancelled
+                    watchdog?.cancel()
+                    watchdog = nil
+                    cancelRequested = false
+                    return
+                }
+                if status != 0 {
+                    state = .finished(exitCode: status)
+                    watchdog?.cancel()
+                    watchdog = nil
+                    cancelRequested = false
+                    return
+                }
+                // Step succeeded; continue on to the next one.
+            }
+        }
+
+        state = .finished(exitCode: 0)
+        watchdog?.cancel()
+        watchdog = nil
+        cancelRequested = false
+    }
+
+    private func _runStep(_ step: SelfUpdateCommand.Step, generation myGeneration: Int) async -> StepOutcome {
         let process = Process()
-        process.executableURL = URL(fileURLWithPath: executable)
-        process.arguments = arguments
+        process.executableURL = URL(fileURLWithPath: step.executable)
+        process.arguments = step.arguments
 
         var env = ProcessInfo.processInfo.environment
         env["PATH"] = augmentedPATH(base: env["PATH"])
@@ -146,9 +197,6 @@ final class SelfUpdater {
         process.standardError = pipe
         let stdinPipe = Pipe()
         process.standardInput = stdinPipe
-
-        generation &+= 1
-        let myGeneration = generation
 
         let buffer = LineBuffer()
         pipe.fileHandleForReading.readabilityHandler = { [weak self] handle in
@@ -166,56 +214,48 @@ final class SelfUpdater {
             }
         }
 
-        process.terminationHandler = { [weak self, buffer, pipe] proc in
-            pipe.fileHandleForReading.readabilityHandler = nil
-            let finalData = (try? pipe.fileHandleForReading.readToEnd()) ?? Data()
-            let finalLines: [String]
-            if let chunk = String(data: finalData, encoding: .utf8), !chunk.isEmpty {
-                finalLines = buffer.feed(chunk)
-            } else {
-                finalLines = []
-            }
-            let finalTrailing = buffer.flush()
-            Task { @MainActor [weak self] in
-                guard let self else { return }
-                guard self.generation == myGeneration else { return }
-                if !finalLines.isEmpty {
-                    self.logLines.append(contentsOf: finalLines)
-                }
-                if let trailing = finalTrailing, !trailing.isEmpty {
-                    self.logLines.append(trailing)
-                }
-                self.currentProcess = nil
-                self.watchdog?.cancel()
-                self.watchdog = nil
-                defer { self.cancelRequested = false }
-                if case .running = self.state {
-                    if proc.terminationStatus == 0 {
-                        self.state = .finished(exitCode: 0)
-                    } else if self.cancelRequested || proc.terminationReason == .uncaughtSignal {
-                        self.state = .cancelled
-                    } else {
-                        self.state = .finished(exitCode: proc.terminationStatus)
-                    }
-                }
-            }
-        }
-
-        state = .running(commandLine: commandLineForDisplay)
-        logLines = []
         currentProcess = process
 
-        do {
-            try process.run()
-        } catch {
-            state = .failed(message: String(describing: error))
-            currentProcess = nil
-            return
-        }
+        return await withCheckedContinuation { (continuation: CheckedContinuation<StepOutcome, Never>) in
+            process.terminationHandler = { [weak self, buffer, pipe] proc in
+                pipe.fileHandleForReading.readabilityHandler = nil
+                let finalData = (try? pipe.fileHandleForReading.readToEnd()) ?? Data()
+                let finalLines: [String]
+                if let chunk = String(data: finalData, encoding: .utf8), !chunk.isEmpty {
+                    finalLines = buffer.feed(chunk)
+                } else {
+                    finalLines = []
+                }
+                let finalTrailing = buffer.flush()
+                Task { @MainActor [weak self] in
+                    if let self, self.generation == myGeneration {
+                        if !finalLines.isEmpty {
+                            self.logLines.append(contentsOf: finalLines)
+                        }
+                        if let trailing = finalTrailing, !trailing.isEmpty {
+                            self.logLines.append(trailing)
+                        }
+                    }
+                    continuation.resume(returning: .exited(
+                        status: proc.terminationStatus,
+                        reason: proc.terminationReason
+                    ))
+                }
+            }
 
-        try? stdinPipe.fileHandleForReading.close()
-        try? stdinPipe.fileHandleForWriting.close()
-        try? pipe.fileHandleForWriting.close()
+            do {
+                try process.run()
+            } catch {
+                process.terminationHandler = nil
+                pipe.fileHandleForReading.readabilityHandler = nil
+                continuation.resume(returning: .launchFailed(error))
+                return
+            }
+
+            try? stdinPipe.fileHandleForReading.close()
+            try? stdinPipe.fileHandleForWriting.close()
+            try? pipe.fileHandleForWriting.close()
+        }
     }
 
     private func augmentedPATH(base: String?) -> String {

--- a/AlasTests/Updates/SelfUpdaterTests.swift
+++ b/AlasTests/Updates/SelfUpdaterTests.swift
@@ -4,19 +4,15 @@ import Testing
 
 @Suite("SelfUpdater")
 struct SelfUpdaterTests {
-    @Test("homebrew command refreshes the tap before upgrading")
+    @Test("homebrew command refreshes the tap before upgrading, as two direct steps")
     func homebrewCommandShape() {
         let command = SelfUpdateCommand.homebrew
-        #expect(command.executable == "/bin/sh")
-        #expect(command.arguments.count == 2)
-        #expect(command.arguments[0] == "-c")
-
-        let steps = command.arguments[1].components(separatedBy: " && ")
-        #expect(steps.count == 2)
-        #expect(steps[0].hasSuffix("brew update"))
-        #expect(steps[1].hasSuffix("brew upgrade --cask mrmans0n/tap/alas"))
-        // Both steps must invoke the same resolved brew executable.
-        #expect(steps[0].dropLast("update".count) == steps[1].dropLast("upgrade --cask mrmans0n/tap/alas".count))
+        #expect(command.steps.count == 2)
+        #expect(command.steps[0].arguments == ["update"])
+        #expect(command.steps[1].arguments == ["upgrade", "--cask", "mrmans0n/tap/alas"])
+        // Both steps must invoke the same resolved brew executable directly
+        // (no shell wrapper), so cancellation always signals the real process.
+        #expect(command.steps[0].executable == command.steps[1].executable)
 
         #expect(command.displayCommandLine == "brew update && brew upgrade --cask mrmans0n/tap/alas")
     }
@@ -44,7 +40,7 @@ struct SelfUpdaterTests {
     @MainActor
     func cancelRunning() async throws {
         let updater = SelfUpdater()
-        await updater.runForTesting(executable: "/bin/sleep", arguments: ["30"])
+        Task { await updater.runForTesting(executable: "/bin/sleep", arguments: ["30"]) }
 
         for _ in 0..<50 {
             if case .running = updater.state { break }
@@ -63,6 +59,94 @@ struct SelfUpdaterTests {
             try await Task.sleep(nanoseconds: 50_000_000)
         }
         Issue.record("update did not cancel within timeout, state = \(updater.state)")
+    }
+
+    @Test("multi-step sequence runs steps in order and finishes(0)")
+    @MainActor
+    func multiStepSequenceRunsInOrder() async throws {
+        let updater = SelfUpdater()
+        await updater.runForTesting(steps: [
+            .init(executable: "/bin/echo", arguments: ["first"]),
+            .init(executable: "/bin/echo", arguments: ["second"]),
+        ])
+
+        for _ in 0..<50 {
+            if case .finished = updater.state { break }
+            try await Task.sleep(nanoseconds: 50_000_000)
+        }
+
+        if case .finished(let code) = updater.state {
+            #expect(code == 0)
+        } else {
+            Issue.record("expected finished, got \(updater.state)")
+        }
+        let log = updater.logLines.joined(separator: "\n")
+        #expect(log.contains("first"))
+        #expect(log.contains("second"))
+    }
+
+    @Test("a failing step stops the sequence before later steps run")
+    @MainActor
+    func failingStepStopsSequence() async throws {
+        let marker = FileManager.default.temporaryDirectory
+            .appendingPathComponent("alas-selfupdater-test-\(UUID().uuidString)")
+        let updater = SelfUpdater()
+        await updater.runForTesting(steps: [
+            .init(executable: "/usr/bin/false", arguments: []),
+            .init(executable: "/usr/bin/touch", arguments: [marker.path]),
+        ])
+
+        for _ in 0..<50 {
+            if case .finished = updater.state { break }
+            try await Task.sleep(nanoseconds: 50_000_000)
+        }
+
+        if case .finished(let code) = updater.state {
+            #expect(code != 0)
+        } else {
+            Issue.record("expected finished, got \(updater.state)")
+        }
+        #expect(!FileManager.default.fileExists(atPath: marker.path))
+    }
+
+    @Test("cancelling the first step prevents the second step from ever running")
+    @MainActor
+    func cancelBetweenStepsStopsSequence() async throws {
+        let marker = FileManager.default.temporaryDirectory
+            .appendingPathComponent("alas-selfupdater-test-\(UUID().uuidString)")
+        let updater = SelfUpdater()
+        Task {
+            await updater.runForTesting(steps: [
+                .init(executable: "/bin/sleep", arguments: ["30"]),
+                .init(executable: "/usr/bin/touch", arguments: [marker.path]),
+            ])
+        }
+
+        for _ in 0..<50 {
+            if case .running = updater.state { break }
+            try await Task.sleep(nanoseconds: 50_000_000)
+        }
+        if case .running = updater.state { } else {
+            Issue.record("expected running state, got \(updater.state)")
+            return
+        }
+
+        updater.cancel()
+
+        for _ in 0..<200 {
+            if case .cancelled = updater.state { break }
+            if case .failed = updater.state { break }
+            try await Task.sleep(nanoseconds: 50_000_000)
+        }
+        if case .cancelled = updater.state {
+            // expected
+        } else {
+            Issue.record("update did not cancel within timeout, state = \(updater.state)")
+        }
+
+        // Give a stray second step a moment to run if the bug regressed.
+        try await Task.sleep(nanoseconds: 200_000_000)
+        #expect(!FileManager.default.fileExists(atPath: marker.path))
     }
 
     @Test("missing executable transitions to .failed")
@@ -96,7 +180,7 @@ struct SelfUpdaterTests {
     @MainActor
     func startWhileRunningThrows() async throws {
         let updater = SelfUpdater()
-        await updater.runForTesting(executable: "/bin/sleep", arguments: ["10"])
+        Task { await updater.runForTesting(executable: "/bin/sleep", arguments: ["10"]) }
         for _ in 0..<50 {
             if case .running = updater.state { break }
             try await Task.sleep(nanoseconds: 50_000_000)

--- a/AlasTests/Updates/SelfUpdaterTests.swift
+++ b/AlasTests/Updates/SelfUpdaterTests.swift
@@ -4,11 +4,21 @@ import Testing
 
 @Suite("SelfUpdater")
 struct SelfUpdaterTests {
-    @Test("homebrew command has correct arguments and display line")
+    @Test("homebrew command refreshes the tap before upgrading")
     func homebrewCommandShape() {
         let command = SelfUpdateCommand.homebrew
-        #expect(command.arguments == ["upgrade", "--cask", "mrmans0n/tap/alas"])
-        #expect(command.displayCommandLine == "brew upgrade --cask mrmans0n/tap/alas")
+        #expect(command.executable == "/bin/sh")
+        #expect(command.arguments.count == 2)
+        #expect(command.arguments[0] == "-c")
+
+        let steps = command.arguments[1].components(separatedBy: " && ")
+        #expect(steps.count == 2)
+        #expect(steps[0].hasSuffix("brew update"))
+        #expect(steps[1].hasSuffix("brew upgrade --cask mrmans0n/tap/alas"))
+        // Both steps must invoke the same resolved brew executable.
+        #expect(steps[0].dropLast("update".count) == steps[1].dropLast("upgrade --cask mrmans0n/tap/alas".count))
+
+        #expect(command.displayCommandLine == "brew update && brew upgrade --cask mrmans0n/tap/alas")
     }
 
     @Test("echo transitions idle → running → finished(0)")


### PR DESCRIPTION
## Summary
- The update dialog's "Update" action ran `brew upgrade --cask mrmans0n/tap/alas` directly, but the app's own update check queries GitHub releases (not brew), so a stale local Homebrew tap index could make the upgrade silently no-op even after the app correctly detected a new release.
- `SelfUpdateCommand.homebrew` now chains `brew update && brew upgrade --cask mrmans0n/tap/alas` via `sh -c`, refreshing the tap before upgrading. The copy-pasteable command text shown in the update sheet is updated to match.

## Test plan
- [x] `AlasTests/Updates/SelfUpdaterTests.swift` updated and passing locally
- [ ] CI green