### PR TITLE
fix: terminate JSON-RPC child process trees

### DIFF
--- a/Alas/Sources/Code/LSP/LSPTransport.swift
+++ b/Alas/Sources/Code/LSP/LSPTransport.swift
@@ -101,8 +101,12 @@ final class LSPTransport: @unchecked Sendable {
             }
             self.descendantForkSource?.cancel()
             self.lock.lock()
+            let cachedTargets = self.orphanedDescendants
             self.rootHasExited = true
             self.lock.unlock()
+            for d in cachedTargets where Self.pidStillMatches(d) {
+                _ = Darwin.kill(d.pid, SIGTERM)
+            }
             self.continuation?.yield(.exited(p.terminationStatus))
             self.continuation?.finish()
         }

--- a/Alas/Sources/Code/LSP/LSPTransport.swift
+++ b/Alas/Sources/Code/LSP/LSPTransport.swift
@@ -49,6 +49,7 @@ final class LSPTransport: @unchecked Sendable {
     /// still belongs to our process before signaling it late.
     private var orphanedDescendants: Set<DescendantKey> = []
     private var descendantTracker: Task<Void, Never>?
+    private var descendantForkSource: DispatchSourceProcess?
 
     let incoming: AsyncStream<Incoming>
 
@@ -98,6 +99,7 @@ final class LSPTransport: @unchecked Sendable {
                 // paths avoid group signaling once the root pid can be stale.
                 _ = Darwin.kill(-pid, SIGTERM)
             }
+            self.descendantForkSource?.cancel()
             self.lock.lock()
             self.rootHasExited = true
             self.lock.unlock()
@@ -113,6 +115,7 @@ final class LSPTransport: @unchecked Sendable {
         // of those two calls succeeds and the child ends up as group
         // leader. Same pattern as `ACPTerminal`.
         _ = setpgid(process.processIdentifier, process.processIdentifier)
+        startDescendantForkObserver()
         startDescendantTracker()
     }
 
@@ -127,6 +130,7 @@ final class LSPTransport: @unchecked Sendable {
 
     func terminate() {
         descendantTracker?.cancel()
+        descendantForkSource?.cancel()
         let pid = process.processIdentifier
         guard pid > 0 else { return }
         lock.lock()
@@ -178,6 +182,21 @@ final class LSPTransport: @unchecked Sendable {
                 try? await Task.sleep(nanoseconds: 1_000_000_000)
             }
         }
+    }
+
+    private func startDescendantForkObserver() {
+        let pid = process.processIdentifier
+        guard pid > 0 else { return }
+        let source = DispatchSource.makeProcessSource(
+            identifier: pid,
+            eventMask: .fork,
+            queue: .global(qos: .utility)
+        )
+        source.setEventHandler { [weak self] in
+            self?.refreshOrphanSet()
+        }
+        descendantForkSource = source
+        source.resume()
     }
 
     private func refreshOrphanSet() {

--- a/Alas/Sources/Code/LSP/LSPTransport.swift
+++ b/Alas/Sources/Code/LSP/LSPTransport.swift
@@ -111,6 +111,8 @@ final class LSPTransport: @unchecked Sendable {
             self.continuation?.finish()
         }
         try process.run()
+        startDescendantForkObserver()
+        refreshOrphanSet()
         // Move the child into its own process group so signals from
         // `terminate()` can be delivered to the whole tree via
         // `kill(-pid, …)`. Foundation's Process doesn't expose
@@ -119,7 +121,6 @@ final class LSPTransport: @unchecked Sendable {
         // of those two calls succeeds and the child ends up as group
         // leader. Same pattern as `ACPTerminal`.
         _ = setpgid(process.processIdentifier, process.processIdentifier)
-        startDescendantForkObserver()
         startDescendantTracker()
     }
 

--- a/Alas/Sources/Code/LSP/LSPTransport.swift
+++ b/Alas/Sources/Code/LSP/LSPTransport.swift
@@ -50,7 +50,7 @@ final class LSPTransport: @unchecked Sendable {
     /// still belongs to our process before signaling it late.
     private var orphanedDescendants: Set<DescendantKey> = []
     private var descendantTracker: Task<Void, Never>?
-    private var descendantForkSource: DispatchSourceProcess?
+    private var descendantForkSources: [pid_t: DispatchSourceProcess] = [:]
 
     let incoming: AsyncStream<Incoming>
 
@@ -100,11 +100,11 @@ final class LSPTransport: @unchecked Sendable {
                 // paths avoid group signaling once the root pid can be stale.
                 _ = Darwin.kill(-pid, SIGTERM)
             }
-            self.descendantForkSource?.cancel()
             self.lock.lock()
             let cachedTargets = self.orphanedDescendants
             self.rootHasExited = true
             self.lock.unlock()
+            self.cancelDescendantForkObservers()
             for d in Self.currentlyMatching(cachedTargets) {
                 _ = Darwin.kill(d.pid, SIGTERM)
             }
@@ -112,7 +112,7 @@ final class LSPTransport: @unchecked Sendable {
             self.continuation?.finish()
         }
         try process.run()
-        startDescendantForkObserver()
+        startDescendantForkObserver(for: process.processIdentifier)
         refreshOrphanSet()
         // Move the child into its own process group so signals from
         // `terminate()` can be delivered to the whole tree via
@@ -136,7 +136,7 @@ final class LSPTransport: @unchecked Sendable {
 
     func terminate() {
         descendantTracker?.cancel()
-        descendantForkSource?.cancel()
+        cancelDescendantForkObservers()
         let pid = process.processIdentifier
         guard pid > 0 else { return }
         lock.lock()
@@ -190,9 +190,13 @@ final class LSPTransport: @unchecked Sendable {
         }
     }
 
-    private func startDescendantForkObserver() {
-        let pid = process.processIdentifier
+    private func startDescendantForkObserver(for pid: pid_t) {
         guard pid > 0 else { return }
+        lock.lock()
+        let alreadyWatching = descendantForkSources[pid] != nil
+        lock.unlock()
+        if alreadyWatching { return }
+
         let source = DispatchSource.makeProcessSource(
             identifier: pid,
             eventMask: .fork,
@@ -201,8 +205,46 @@ final class LSPTransport: @unchecked Sendable {
         source.setEventHandler { [weak self] in
             self?.refreshOrphanSet()
         }
-        descendantForkSource = source
+        lock.lock()
+        if descendantForkSources[pid] == nil, !rootHasExited {
+            descendantForkSources[pid] = source
+            lock.unlock()
+            source.resume()
+            return
+        }
+        lock.unlock()
         source.resume()
+        source.cancel()
+    }
+
+    private func cancelDescendantForkObservers() {
+        lock.lock()
+        let sources = Array(descendantForkSources.values)
+        descendantForkSources.removeAll()
+        lock.unlock()
+        for source in sources {
+            source.cancel()
+        }
+    }
+
+    private func pruneDescendantForkObservers(keeping pids: Set<pid_t>) {
+        lock.lock()
+        let stale = descendantForkSources.keys.filter { !pids.contains($0) }
+        let sources = stale.compactMap { descendantForkSources.removeValue(forKey: $0) }
+        lock.unlock()
+        for source in sources {
+            source.cancel()
+        }
+    }
+
+    private func observeForks(from descendants: Set<DescendantKey>) {
+        for pid in descendants.map(\.pid) {
+            startDescendantForkObserver(for: pid)
+        }
+        let rootPid = process.processIdentifier
+        var watched = Set(descendants.map(\.pid))
+        if rootPid > 0 { watched.insert(rootPid) }
+        pruneDescendantForkObservers(keeping: watched)
     }
 
     private func refreshOrphanSet() {
@@ -218,11 +260,14 @@ final class LSPTransport: @unchecked Sendable {
         let cached = orphanedDescendants
         lock.unlock()
         let retained = Self.currentlyMatching(cached)
+        let watched = retained.union(live)
         lock.lock()
         if !rootHasExited {
-            orphanedDescendants = retained.union(live)
+            orphanedDescendants.subtract(cached.subtracting(retained))
+            orphanedDescendants.formUnion(live)
         }
         lock.unlock()
+        observeForks(from: watched)
     }
 
     /// Walks the live process tree collecting every descendant of `root`.

--- a/Alas/Sources/Code/LSP/LSPTransport.swift
+++ b/Alas/Sources/Code/LSP/LSPTransport.swift
@@ -25,6 +25,11 @@ final class LSPTransport: @unchecked Sendable {
         case exited(Int32)
     }
 
+    private struct DescendantKey: Hashable {
+        let pid: pid_t
+        let command: String
+    }
+
     private let process = Process()
     private let stdin = Pipe()
     private let stdout = Pipe()
@@ -32,11 +37,18 @@ final class LSPTransport: @unchecked Sendable {
     private var decoder = JSONRPCFramer()
     private let lock = NSLock()
     private var continuation: AsyncStream<Incoming>.Continuation?
-    /// Captured in the termination handler so `terminate()` can still
-    /// reach descendants after the root exits and the kernel reparents
-    /// them to init (making them unfindable via a ppid walk from the
-    /// original root).
-    private var descendants: [pid_t]?
+    /// Set once the termination handler fires. We can't rely on
+    /// `process.isRunning` after that — the OS may reuse the root pid
+    /// for an unrelated process.
+    private var rootHasExited = false
+    /// `(pid, command)` pairs accumulated by the periodic descendant
+    /// tracker while the root is alive. Needed because the termination
+    /// handler runs after the kernel has reaped the root and reparented
+    /// its children to init, so a fresh ppid walk from the root pid
+    /// returns nothing. The command name lets us re-verify a cached PID
+    /// still belongs to our process before signaling it late.
+    private var orphanedDescendants: Set<DescendantKey> = []
+    private var descendantTracker: Task<Void, Never>?
 
     let incoming: AsyncStream<Incoming>
 
@@ -79,10 +91,8 @@ final class LSPTransport: @unchecked Sendable {
         }
         process.terminationHandler = { [weak self] p in
             guard let self else { return }
-            let pid = p.processIdentifier
-            let kids = Self.collectDescendants(of: pid)
             self.lock.lock()
-            self.descendants = kids
+            self.rootHasExited = true
             self.lock.unlock()
             self.continuation?.yield(.exited(p.terminationStatus))
             self.continuation?.finish()
@@ -96,6 +106,7 @@ final class LSPTransport: @unchecked Sendable {
         // of those two calls succeeds and the child ends up as group
         // leader. Same pattern as `ACPTerminal`.
         _ = setpgid(process.processIdentifier, process.processIdentifier)
+        startDescendantTracker()
     }
 
     /// Writes a JSON-RPC body framed with `Content-Length`. Header and body
@@ -108,38 +119,78 @@ final class LSPTransport: @unchecked Sendable {
     }
 
     func terminate() {
+        descendantTracker?.cancel()
         let pid = process.processIdentifier
         guard pid > 0 else { return }
-        // Signal the whole process group so descendants receive the
-        // signal even when the root doesn't forward it. Per-pid signal
-        // as a fallback for the case where `setpgid` lost the race
-        // against exec. Same pattern as `JSONRPCStdioTransport` and
-        // `ACPTerminal`.
-        _ = Darwin.kill(-pid, SIGTERM)
-        // Walk the process tree and signal any descendants the group
-        // kill may have missed. On macOS, parent-side setpgid frequently
-        // loses the exec race (Foundation's Process can't pass
-        // POSIX_SPAWN_SETPGROUP), leaving no process group to target.
-        // If the root exited before we got here, use the tree captured
-        // by the termination handler; otherwise walk live so we catch
-        // children spawned between handler capture and now.
         lock.lock()
-        let kids = descendants ?? Self.collectDescendants(of: pid)
+        let rootAlive = !rootHasExited
+        var targets = orphanedDescendants
         lock.unlock()
-        for d in kids {
-            _ = Darwin.kill(d, SIGTERM)
+
+        if rootAlive {
+            // Root is still alive: a process-group signal reaches the
+            // whole tree, and we can safely collect a live snapshot of
+            // descendants before the root disappears.
+            _ = Darwin.kill(-pid, SIGTERM)
+            _ = Darwin.kill(pid, SIGTERM)
+            for d in Self.collectDescendants(of: pid) {
+                targets.insert(d)
+            }
+            for d in targets {
+                _ = Darwin.kill(d.pid, SIGTERM)
+            }
+        } else {
+            // Root has already exited: the process group may have been
+            // reused by an unrelated process, so we only signal cached
+            // descendants whose command name still matches.
+            for d in targets where Self.pidStillMatches(d) {
+                _ = Darwin.kill(d.pid, SIGTERM)
+            }
         }
-        if process.isRunning { process.terminate() }
+
+        if process.isRunning {
+            process.terminate()
+        }
+    }
+
+    private func startDescendantTracker() {
+        descendantTracker = Task { [weak self] in
+            // Walk the live process tree every second while the root is
+            // alive, accumulating every descendant we observe. The last
+            // pre-exit snapshot is what `terminate()` relies on after
+            // the kernel reparents children to init.
+            while !Task.isCancelled {
+                guard let self else { return }
+                self.refreshOrphanSet()
+                self.lock.lock()
+                let shouldStop = self.rootHasExited
+                self.lock.unlock()
+                if shouldStop { return }
+                try? await Task.sleep(nanoseconds: 1_000_000_000)
+            }
+        }
+    }
+
+    private func refreshOrphanSet() {
+        let pid = process.processIdentifier
+        guard pid > 0 else { return }
+        let keys = Self.collectDescendants(of: pid)
+        lock.lock()
+        for k in keys { orphanedDescendants.insert(k) }
+        lock.unlock()
     }
 
     /// Walks the live process tree collecting every descendant of `root`.
     /// Returns the list immediately; once the root exits the kernel
     /// reparents children to init so they become unfindable via a ppid
     /// walk from the original root.
-    private static func collectDescendants(of root: pid_t) -> [pid_t] {
+    private static func collectDescendants(of root: pid_t) -> [DescendantKey] {
+        // `comm=` is the executable name (no header). It's stable across
+        // reads of the same process and changes when the PID is reused,
+        // so it's a cheap identity marker for late validation.
         let proc = Process()
         proc.executableURL = URL(fileURLWithPath: "/bin/ps")
-        proc.arguments = ["-o", "pid=,ppid=", "-ax"]
+        proc.arguments = ["-o", "pid=,ppid=,comm=", "-ax"]
         let pipe = Pipe()
         proc.standardOutput = pipe
         proc.standardError = FileHandle.nullDevice
@@ -151,24 +202,48 @@ final class LSPTransport: @unchecked Sendable {
         }
         guard let s = String(data: pipe.fileHandleForReading.readDataToEndOfFile(),
                              encoding: .utf8) else { return [] }
-        var childrenOf: [pid_t: [pid_t]] = [:]
+        var childrenOf: [pid_t: [(pid: pid_t, command: String)]] = [:]
         for line in s.split(separator: "\n") {
-            let parts = line.split(separator: " ", maxSplits: 1,
-                                   omittingEmptySubsequences: true)
-            guard parts.count >= 2,
+            let trimmed = line.drop(while: { $0 == " " })
+            let parts = trimmed.split(separator: " ", maxSplits: 2,
+                                      omittingEmptySubsequences: true)
+            guard parts.count >= 3,
                   let pid = pid_t(parts[0]),
                   let ppid = pid_t(parts[1]) else { continue }
-            childrenOf[ppid, default: []].append(pid)
+            childrenOf[ppid, default: []].append((pid, String(parts[2])))
         }
-        var out: [pid_t] = []
+        var out: [DescendantKey] = []
         var queue: [pid_t] = [root]
         while let p = queue.popLast() {
             for c in childrenOf[p] ?? [] {
-                out.append(c)
-                queue.append(c)
+                out.append(DescendantKey(pid: c.pid, command: c.command))
+                queue.append(c.pid)
             }
         }
         return out
+    }
+
+    /// Returns true when the current command for `pid` matches the
+    /// command captured when we recorded it. Used to skip stale cached
+    /// PIDs whose original process has exited and whose PID may have
+    /// been reused for an unrelated process.
+    private static func pidStillMatches(_ key: DescendantKey) -> Bool {
+        let proc = Process()
+        proc.executableURL = URL(fileURLWithPath: "/bin/ps")
+        proc.arguments = ["-p", "\(key.pid)", "-o", "comm="]
+        let pipe = Pipe()
+        proc.standardOutput = pipe
+        proc.standardError = FileHandle.nullDevice
+        do {
+            try proc.run()
+            proc.waitUntilExit()
+        } catch {
+            return false
+        }
+        guard let s = String(data: pipe.fileHandleForReading.readDataToEndOfFile(),
+                             encoding: .utf8) else { return false }
+        let current = s.trimmingCharacters(in: .whitespacesAndNewlines)
+        return !current.isEmpty && current == key.command
     }
 }
 

--- a/Alas/Sources/Code/LSP/LSPTransport.swift
+++ b/Alas/Sources/Code/LSP/LSPTransport.swift
@@ -27,6 +27,8 @@ final class LSPTransport: @unchecked Sendable {
 
     private struct DescendantKey: Hashable {
         let pid: pid_t
+        let pgid: pid_t
+        let startedAt: String
         let command: String
     }
 
@@ -218,12 +220,11 @@ final class LSPTransport: @unchecked Sendable {
     /// reparents children to init so they become unfindable via a ppid
     /// walk from the original root.
     private static func collectDescendants(of root: pid_t) -> [DescendantKey] {
-        // `comm=` is the executable name (no header). It's stable across
-        // reads of the same process and changes when the PID is reused,
-        // so it's a cheap identity marker for late validation.
+        // `lstart` and `pgid` make the cached PID identity stable across
+        // PID reuse, including common executable names like node or sh.
         let proc = Process()
         proc.executableURL = URL(fileURLWithPath: "/bin/ps")
-        proc.arguments = ["-o", "pid=,ppid=,comm=", "-ax"]
+        proc.arguments = ["-o", "pid=,ppid=,pgid=,lstart=,comm=", "-ax"]
         let pipe = Pipe()
         proc.standardOutput = pipe
         proc.standardError = FileHandle.nullDevice
@@ -236,35 +237,39 @@ final class LSPTransport: @unchecked Sendable {
             return []
         }
         guard let s = String(data: data, encoding: .utf8) else { return [] }
-        var childrenOf: [pid_t: [(pid: pid_t, command: String)]] = [:]
+        var childrenOf: [pid_t: [(pid: pid_t, pgid: pid_t, startedAt: String, command: String)]] = [:]
         for line in s.split(separator: "\n") {
             let trimmed = line.drop(while: { $0 == " " })
-            let parts = trimmed.split(separator: " ", maxSplits: 2,
+            let parts = trimmed.split(separator: " ", maxSplits: 8,
                                       omittingEmptySubsequences: true)
-            guard parts.count >= 3,
+            guard parts.count >= 9,
                   let pid = pid_t(parts[0]),
-                  let ppid = pid_t(parts[1]) else { continue }
-            childrenOf[ppid, default: []].append((pid, String(parts[2])))
+                  let ppid = pid_t(parts[1]),
+                  let pgid = pid_t(parts[2]) else { continue }
+            let startedAt = parts[3...7].joined(separator: " ")
+            let command = String(parts[8])
+            childrenOf[ppid, default: []].append((pid, pgid, startedAt, command))
         }
         var out: [DescendantKey] = []
         var queue: [pid_t] = [root]
         while let p = queue.popLast() {
             for c in childrenOf[p] ?? [] {
-                out.append(DescendantKey(pid: c.pid, command: c.command))
+                out.append(DescendantKey(pid: c.pid, pgid: c.pgid,
+                                         startedAt: c.startedAt, command: c.command))
                 queue.append(c.pid)
             }
         }
         return out
     }
 
-    /// Returns true when the current command for `pid` matches the
-    /// command captured when we recorded it. Used to skip stale cached
-    /// PIDs whose original process has exited and whose PID may have
-    /// been reused for an unrelated process.
+    /// Returns true when the current process identity for `pid` matches
+    /// what we captured earlier. Used to skip stale cached PIDs whose
+    /// original process has exited and whose PID may have been reused
+    /// for an unrelated process.
     private static func pidStillMatches(_ key: DescendantKey) -> Bool {
         let proc = Process()
         proc.executableURL = URL(fileURLWithPath: "/bin/ps")
-        proc.arguments = ["-p", "\(key.pid)", "-o", "comm="]
+        proc.arguments = ["-p", "\(key.pid)", "-o", "pgid=,lstart=,comm="]
         let pipe = Pipe()
         proc.standardOutput = pipe
         proc.standardError = FileHandle.nullDevice
@@ -277,8 +282,19 @@ final class LSPTransport: @unchecked Sendable {
             return false
         }
         guard let s = String(data: data, encoding: .utf8) else { return false }
-        let current = s.trimmingCharacters(in: .whitespacesAndNewlines)
-        return !current.isEmpty && current == key.command
+        let trimmed = s.trimmingCharacters(in: .whitespacesAndNewlines)
+        let parts = trimmed.split(separator: " ", maxSplits: 6,
+                                  omittingEmptySubsequences: true)
+        guard parts.count >= 7,
+              let pgid = pid_t(parts[0]) else { return false }
+        let current = (
+            pgid: pgid,
+            startedAt: parts[1...5].joined(separator: " "),
+            command: String(parts[6])
+        )
+        return current.pgid == key.pgid &&
+            current.startedAt == key.startedAt &&
+            current.command == key.command
     }
 }
 

--- a/Alas/Sources/Code/LSP/LSPTransport.swift
+++ b/Alas/Sources/Code/LSP/LSPTransport.swift
@@ -226,14 +226,15 @@ final class LSPTransport: @unchecked Sendable {
         let pipe = Pipe()
         proc.standardOutput = pipe
         proc.standardError = FileHandle.nullDevice
+        let data: Data
         do {
             try proc.run()
+            data = pipe.fileHandleForReading.readDataToEndOfFile()
             proc.waitUntilExit()
         } catch {
             return []
         }
-        guard let s = String(data: pipe.fileHandleForReading.readDataToEndOfFile(),
-                             encoding: .utf8) else { return [] }
+        guard let s = String(data: data, encoding: .utf8) else { return [] }
         var childrenOf: [pid_t: [(pid: pid_t, command: String)]] = [:]
         for line in s.split(separator: "\n") {
             let trimmed = line.drop(while: { $0 == " " })
@@ -266,14 +267,15 @@ final class LSPTransport: @unchecked Sendable {
         let pipe = Pipe()
         proc.standardOutput = pipe
         proc.standardError = FileHandle.nullDevice
+        let data: Data
         do {
             try proc.run()
+            data = pipe.fileHandleForReading.readDataToEndOfFile()
             proc.waitUntilExit()
         } catch {
             return false
         }
-        guard let s = String(data: pipe.fileHandleForReading.readDataToEndOfFile(),
-                             encoding: .utf8) else { return false }
+        guard let s = String(data: data, encoding: .utf8) else { return false }
         let current = s.trimmingCharacters(in: .whitespacesAndNewlines)
         return !current.isEmpty && current == key.command
     }

--- a/Alas/Sources/Code/LSP/LSPTransport.swift
+++ b/Alas/Sources/Code/LSP/LSPTransport.swift
@@ -36,6 +36,7 @@ final class LSPTransport: @unchecked Sendable {
     private let stderr = Pipe()
     private var decoder = JSONRPCFramer()
     private let lock = NSLock()
+    private let refreshLock = NSLock()
     private var continuation: AsyncStream<Incoming>.Continuation?
     /// Set once the termination handler fires. We can't rely on
     /// `process.isRunning` after that — the OS may reuse the root pid
@@ -99,10 +100,12 @@ final class LSPTransport: @unchecked Sendable {
                 // paths avoid group signaling once the root pid can be stale.
                 _ = Darwin.kill(-pid, SIGTERM)
             }
+            self.refreshLock.lock()
             self.lock.lock()
             let cachedTargets = self.orphanedDescendants
             self.rootHasExited = true
             self.lock.unlock()
+            self.refreshLock.unlock()
             self.cancelDescendantForkObservers()
             for d in Self.currentlyMatching(cachedTargets) {
                 _ = Darwin.kill(d.pid, SIGTERM)
@@ -138,10 +141,12 @@ final class LSPTransport: @unchecked Sendable {
         cancelDescendantForkObservers()
         let pid = process.processIdentifier
         guard pid > 0 else { return }
+        refreshLock.lock()
         lock.lock()
         let rootAlive = !rootHasExited
         let targets = orphanedDescendants
         lock.unlock()
+        refreshLock.unlock()
 
         if rootAlive {
             // Root is still alive: a process-group signal reaches the
@@ -247,6 +252,8 @@ final class LSPTransport: @unchecked Sendable {
     }
 
     private func refreshOrphanSet() {
+        refreshLock.lock()
+        defer { refreshLock.unlock() }
         lock.lock()
         let shouldStop = rootHasExited
         lock.unlock()
@@ -261,12 +268,13 @@ final class LSPTransport: @unchecked Sendable {
         let retained = Self.currentlyMatching(cached)
         let watched = retained.union(live)
         lock.lock()
-        if !rootHasExited {
-            orphanedDescendants.subtract(cached.subtracting(retained))
-            orphanedDescendants.formUnion(live)
-        }
+        orphanedDescendants.subtract(cached.subtracting(retained))
+        orphanedDescendants.formUnion(live)
+        let shouldObserve = !rootHasExited
         lock.unlock()
-        observeForks(from: watched)
+        if shouldObserve {
+            observeForks(from: watched)
+        }
     }
 
     /// Walks the live process tree collecting every descendant of `root`.

--- a/Alas/Sources/Code/LSP/LSPTransport.swift
+++ b/Alas/Sources/Code/LSP/LSPTransport.swift
@@ -32,10 +32,11 @@ final class LSPTransport: @unchecked Sendable {
     private var decoder = JSONRPCFramer()
     private let lock = NSLock()
     private var continuation: AsyncStream<Incoming>.Continuation?
-    /// True once the root process has exited so `terminate()` can skip
-    /// signalling a stale pid the OS may have reused. Set synchronously
-    /// in the termination handler.
-    private var rootHasExited = false
+    /// Captured in the termination handler so `terminate()` can still
+    /// reach descendants after the root exits and the kernel reparents
+    /// them to init (making them unfindable via a ppid walk from the
+    /// original root).
+    private var descendants: [pid_t]?
 
     let incoming: AsyncStream<Incoming>
 
@@ -76,10 +77,15 @@ final class LSPTransport: @unchecked Sendable {
             if data.isEmpty { return }
             self?.continuation?.yield(.stderr(data))
         }
-        process.terminationHandler = { [weak self] proc in
-            self?.rootHasExited = true
-            self?.continuation?.yield(.exited(proc.terminationStatus))
-            self?.continuation?.finish()
+        process.terminationHandler = { [weak self] p in
+            guard let self else { return }
+            let pid = p.processIdentifier
+            let kids = Self.collectDescendants(of: pid)
+            self.lock.lock()
+            self.descendants = kids
+            self.lock.unlock()
+            self.continuation?.yield(.exited(p.terminationStatus))
+            self.continuation?.finish()
         }
         try process.run()
         // Move the child into its own process group so signals from
@@ -102,7 +108,6 @@ final class LSPTransport: @unchecked Sendable {
     }
 
     func terminate() {
-        guard !rootHasExited else { return }
         let pid = process.processIdentifier
         guard pid > 0 else { return }
         // Signal the whole process group so descendants receive the
@@ -115,7 +120,13 @@ final class LSPTransport: @unchecked Sendable {
         // kill may have missed. On macOS, parent-side setpgid frequently
         // loses the exec race (Foundation's Process can't pass
         // POSIX_SPAWN_SETPGROUP), leaving no process group to target.
-        for d in Self.collectDescendants(of: pid) {
+        // If the root exited before we got here, use the tree captured
+        // by the termination handler; otherwise walk live so we catch
+        // children spawned between handler capture and now.
+        lock.lock()
+        let kids = descendants ?? Self.collectDescendants(of: pid)
+        lock.unlock()
+        for d in kids {
             _ = Darwin.kill(d, SIGTERM)
         }
         if process.isRunning { process.terminate() }

--- a/Alas/Sources/Code/LSP/LSPTransport.swift
+++ b/Alas/Sources/Code/LSP/LSPTransport.swift
@@ -91,6 +91,13 @@ final class LSPTransport: @unchecked Sendable {
         }
         process.terminationHandler = { [weak self] p in
             guard let self else { return }
+            let pid = p.processIdentifier
+            if pid > 0 {
+                // Last chance to reach same-group descendants that were
+                // spawned after the most recent tracker tick. Later shutdown
+                // paths avoid group signaling once the root pid can be stale.
+                _ = Darwin.kill(-pid, SIGTERM)
+            }
             self.lock.lock()
             self.rootHasExited = true
             self.lock.unlock()
@@ -124,20 +131,21 @@ final class LSPTransport: @unchecked Sendable {
         guard pid > 0 else { return }
         lock.lock()
         let rootAlive = !rootHasExited
-        var targets = orphanedDescendants
+        let targets = orphanedDescendants
         lock.unlock()
 
         if rootAlive {
             // Root is still alive: a process-group signal reaches the
             // whole tree. Take the fallback ppid snapshot before
             // signaling, while descendants are still parented to root.
-            let liveDescendants = Self.collectDescendants(of: pid)
+            let cachedTargets = targets
+            let liveDescendants = Set(Self.collectDescendants(of: pid))
             _ = Darwin.kill(-pid, SIGTERM)
             _ = Darwin.kill(pid, SIGTERM)
             for d in liveDescendants {
-                targets.insert(d)
+                _ = Darwin.kill(d.pid, SIGTERM)
             }
-            for d in targets {
+            for d in cachedTargets where !liveDescendants.contains(d) && Self.pidStillMatches(d) {
                 _ = Darwin.kill(d.pid, SIGTERM)
             }
         } else {

--- a/Alas/Sources/Code/LSP/LSPTransport.swift
+++ b/Alas/Sources/Code/LSP/LSPTransport.swift
@@ -111,7 +111,53 @@ final class LSPTransport: @unchecked Sendable {
         // against exec. Same pattern as `JSONRPCStdioTransport` and
         // `ACPTerminal`.
         _ = Darwin.kill(-pid, SIGTERM)
+        // Walk the process tree and signal any descendants the group
+        // kill may have missed. On macOS, parent-side setpgid frequently
+        // loses the exec race (Foundation's Process can't pass
+        // POSIX_SPAWN_SETPGROUP), leaving no process group to target.
+        for d in Self.collectDescendants(of: pid) {
+            _ = Darwin.kill(d, SIGTERM)
+        }
         if process.isRunning { process.terminate() }
+    }
+
+    /// Walks the live process tree collecting every descendant of `root`.
+    /// Returns the list immediately; once the root exits the kernel
+    /// reparents children to init so they become unfindable via a ppid
+    /// walk from the original root.
+    private static func collectDescendants(of root: pid_t) -> [pid_t] {
+        let proc = Process()
+        proc.executableURL = URL(fileURLWithPath: "/bin/ps")
+        proc.arguments = ["-o", "pid=,ppid=", "-ax"]
+        let pipe = Pipe()
+        proc.standardOutput = pipe
+        proc.standardError = FileHandle.nullDevice
+        do {
+            try proc.run()
+            proc.waitUntilExit()
+        } catch {
+            return []
+        }
+        guard let s = String(data: pipe.fileHandleForReading.readDataToEndOfFile(),
+                             encoding: .utf8) else { return [] }
+        var childrenOf: [pid_t: [pid_t]] = [:]
+        for line in s.split(separator: "\n") {
+            let parts = line.split(separator: " ", maxSplits: 1,
+                                   omittingEmptySubsequences: true)
+            guard parts.count >= 2,
+                  let pid = pid_t(parts[0]),
+                  let ppid = pid_t(parts[1]) else { continue }
+            childrenOf[ppid, default: []].append(pid)
+        }
+        var out: [pid_t] = []
+        var queue: [pid_t] = [root]
+        while let p = queue.popLast() {
+            for c in childrenOf[p] ?? [] {
+                out.append(c)
+                queue.append(c)
+            }
+        }
+        return out
     }
 }
 

--- a/Alas/Sources/Code/LSP/LSPTransport.swift
+++ b/Alas/Sources/Code/LSP/LSPTransport.swift
@@ -129,11 +129,12 @@ final class LSPTransport: @unchecked Sendable {
 
         if rootAlive {
             // Root is still alive: a process-group signal reaches the
-            // whole tree, and we can safely collect a live snapshot of
-            // descendants before the root disappears.
+            // whole tree. Take the fallback ppid snapshot before
+            // signaling, while descendants are still parented to root.
+            let liveDescendants = Self.collectDescendants(of: pid)
             _ = Darwin.kill(-pid, SIGTERM)
             _ = Darwin.kill(pid, SIGTERM)
-            for d in Self.collectDescendants(of: pid) {
+            for d in liveDescendants {
                 targets.insert(d)
             }
             for d in targets {

--- a/Alas/Sources/Code/LSP/LSPTransport.swift
+++ b/Alas/Sources/Code/LSP/LSPTransport.swift
@@ -43,10 +43,10 @@ final class LSPTransport: @unchecked Sendable {
     /// for an unrelated process.
     private var rootHasExited = false
     /// `(pid, start time, command)` entries accumulated by the periodic
-    /// descendant tracker while the root is alive. Needed because the termination
-    /// handler runs after the kernel has reaped the root and reparented
-    /// its children to init, so a fresh ppid walk from the root pid
-    /// returns nothing. The command name lets us re-verify a cached PID
+    /// descendant tracker while the root is alive. Needed because the
+    /// termination handler runs after the kernel has reaped the root and
+    /// reparented its children to init, so a fresh ppid walk from the root
+    /// pid returns nothing. The command name lets us re-verify a cached PID
     /// still belongs to our process before signaling it late.
     private var orphanedDescendants: Set<DescendantKey> = []
     private var descendantTracker: Task<Void, Never>?
@@ -303,7 +303,6 @@ final class LSPTransport: @unchecked Sendable {
         }
         return current.intersection(keys)
     }
-
 }
 
 extension LSPTransport: LSPTransporting {}

--- a/Alas/Sources/Code/LSP/LSPTransport.swift
+++ b/Alas/Sources/Code/LSP/LSPTransport.swift
@@ -181,11 +181,11 @@ final class LSPTransport: @unchecked Sendable {
             // the kernel reparents children to init.
             while !Task.isCancelled {
                 guard let self else { return }
-                self.refreshOrphanSet()
                 self.lock.lock()
                 let shouldStop = self.rootHasExited
                 self.lock.unlock()
                 if shouldStop { return }
+                self.refreshOrphanSet()
                 try? await Task.sleep(nanoseconds: 1_000_000_000)
             }
         }
@@ -207,6 +207,11 @@ final class LSPTransport: @unchecked Sendable {
     }
 
     private func refreshOrphanSet() {
+        lock.lock()
+        let shouldStop = rootHasExited
+        lock.unlock()
+        guard !shouldStop, process.isRunning else { return }
+
         let pid = process.processIdentifier
         guard pid > 0 else { return }
         let keys = Self.collectDescendants(of: pid)

--- a/Alas/Sources/Code/LSP/LSPTransport.swift
+++ b/Alas/Sources/Code/LSP/LSPTransport.swift
@@ -111,8 +111,6 @@ final class LSPTransport: @unchecked Sendable {
             self.continuation?.finish()
         }
         try process.run()
-        startDescendantForkObserver(for: process.processIdentifier)
-        refreshOrphanSet()
         // Move the child into its own process group so signals from
         // `terminate()` can be delivered to the whole tree via
         // `kill(-pid, …)`. Foundation's Process doesn't expose
@@ -121,6 +119,8 @@ final class LSPTransport: @unchecked Sendable {
         // of those two calls succeeds and the child ends up as group
         // leader. Same pattern as `ACPTerminal`.
         _ = setpgid(process.processIdentifier, process.processIdentifier)
+        startDescendantForkObserver(for: process.processIdentifier)
+        refreshOrphanSet()
         startDescendantTracker()
     }
 

--- a/Alas/Sources/Code/LSP/LSPTransport.swift
+++ b/Alas/Sources/Code/LSP/LSPTransport.swift
@@ -28,7 +28,6 @@ final class LSPTransport: @unchecked Sendable {
     private struct DescendantKey: Hashable {
         let pid: pid_t
         let startedAt: String
-        let command: String
     }
 
     private let process = Process()
@@ -42,12 +41,12 @@ final class LSPTransport: @unchecked Sendable {
     /// `process.isRunning` after that — the OS may reuse the root pid
     /// for an unrelated process.
     private var rootHasExited = false
-    /// `(pid, start time, command)` entries accumulated by the periodic
-    /// descendant tracker while the root is alive. Needed because the
+    /// `(pid, start time)` entries accumulated by the periodic descendant
+    /// tracker while the root is alive. Needed because the
     /// termination handler runs after the kernel has reaped the root and
     /// reparented its children to init, so a fresh ppid walk from the root
-    /// pid returns nothing. The command name lets us re-verify a cached PID
-    /// still belongs to our process before signaling it late.
+    /// pid returns nothing. The start time lets us re-verify a cached PID
+    /// still belongs to the same process before signaling it late.
     private var orphanedDescendants: Set<DescendantKey> = []
     private var descendantTracker: Task<Void, Never>?
     private var descendantForkSources: [pid_t: DispatchSourceProcess] = [:]
@@ -275,11 +274,11 @@ final class LSPTransport: @unchecked Sendable {
     /// reparents children to init so they become unfindable via a ppid
     /// walk from the original root.
     private static func collectDescendants(of root: pid_t) -> [DescendantKey] {
-        // `lstart` makes the cached PID identity stable across PID reuse,
-        // including common executable names like node or sh.
+        // `lstart` makes the cached PID identity stable across PID reuse
+        // while still surviving exec, where `comm` can legitimately change.
         let proc = Process()
         proc.executableURL = URL(fileURLWithPath: "/bin/ps")
-        proc.arguments = ["-o", "pid=,ppid=,lstart=,comm=", "-ax"]
+        proc.arguments = ["-o", "pid=,ppid=,lstart=", "-ax"]
         let pipe = Pipe()
         proc.standardOutput = pipe
         proc.standardError = FileHandle.nullDevice
@@ -292,24 +291,22 @@ final class LSPTransport: @unchecked Sendable {
             return []
         }
         guard let s = String(data: data, encoding: .utf8) else { return [] }
-        var childrenOf: [pid_t: [(pid: pid_t, startedAt: String, command: String)]] = [:]
+        var childrenOf: [pid_t: [(pid: pid_t, startedAt: String)]] = [:]
         for line in s.split(separator: "\n") {
             let trimmed = line.drop(while: { $0 == " " })
-            let parts = trimmed.split(separator: " ", maxSplits: 7,
+            let parts = trimmed.split(separator: " ", maxSplits: 6,
                                       omittingEmptySubsequences: true)
-            guard parts.count >= 8,
+            guard parts.count >= 7,
                   let pid = pid_t(parts[0]),
                   let ppid = pid_t(parts[1]) else { continue }
             let startedAt = parts[2...6].joined(separator: " ")
-            let command = String(parts[7])
-            childrenOf[ppid, default: []].append((pid, startedAt, command))
+            childrenOf[ppid, default: []].append((pid, startedAt))
         }
         var out: [DescendantKey] = []
         var queue: [pid_t] = [root]
         while let p = queue.popLast() {
             for c in childrenOf[p] ?? [] {
-                out.append(DescendantKey(pid: c.pid, startedAt: c.startedAt,
-                                         command: c.command))
+                out.append(DescendantKey(pid: c.pid, startedAt: c.startedAt))
                 queue.append(c.pid)
             }
         }
@@ -321,7 +318,7 @@ final class LSPTransport: @unchecked Sendable {
         let pids = Set(keys.map(\.pid))
         let proc = Process()
         proc.executableURL = URL(fileURLWithPath: "/bin/ps")
-        proc.arguments = ["-o", "pid=,lstart=,comm=", "-ax"]
+        proc.arguments = ["-o", "pid=,lstart=", "-ax"]
         let pipe = Pipe()
         proc.standardOutput = pipe
         proc.standardError = FileHandle.nullDevice
@@ -337,14 +334,13 @@ final class LSPTransport: @unchecked Sendable {
         var current: Set<DescendantKey> = []
         for line in s.split(separator: "\n") {
             let trimmed = line.drop(while: { $0 == " " })
-            let parts = trimmed.split(separator: " ", maxSplits: 6,
+            let parts = trimmed.split(separator: " ", maxSplits: 5,
                                       omittingEmptySubsequences: true)
-            guard parts.count >= 7,
+            guard parts.count >= 6,
                   let pid = pid_t(parts[0]),
                   pids.contains(pid) else { continue }
             current.insert(DescendantKey(pid: pid,
-                                         startedAt: parts[1...5].joined(separator: " "),
-                                         command: String(parts[6])))
+                                         startedAt: parts[1...5].joined(separator: " ")))
         }
         return current.intersection(keys)
     }

--- a/Alas/Sources/Code/LSP/LSPTransport.swift
+++ b/Alas/Sources/Code/LSP/LSPTransport.swift
@@ -27,7 +27,6 @@ final class LSPTransport: @unchecked Sendable {
 
     private struct DescendantKey: Hashable {
         let pid: pid_t
-        let pgid: pid_t
         let startedAt: String
         let command: String
     }
@@ -43,8 +42,8 @@ final class LSPTransport: @unchecked Sendable {
     /// `process.isRunning` after that — the OS may reuse the root pid
     /// for an unrelated process.
     private var rootHasExited = false
-    /// `(pid, command)` pairs accumulated by the periodic descendant
-    /// tracker while the root is alive. Needed because the termination
+    /// `(pid, start time, command)` entries accumulated by the periodic
+    /// descendant tracker while the root is alive. Needed because the termination
     /// handler runs after the kernel has reaped the root and reparented
     /// its children to init, so a fresh ppid walk from the root pid
     /// returns nothing. The command name lets us re-verify a cached PID
@@ -106,7 +105,7 @@ final class LSPTransport: @unchecked Sendable {
             let cachedTargets = self.orphanedDescendants
             self.rootHasExited = true
             self.lock.unlock()
-            for d in cachedTargets where Self.pidStillMatches(d) {
+            for d in Self.currentlyMatching(cachedTargets) {
                 _ = Darwin.kill(d.pid, SIGTERM)
             }
             self.continuation?.yield(.exited(p.terminationStatus))
@@ -156,14 +155,14 @@ final class LSPTransport: @unchecked Sendable {
             for d in liveDescendants {
                 _ = Darwin.kill(d.pid, SIGTERM)
             }
-            for d in cachedTargets where !liveDescendants.contains(d) && Self.pidStillMatches(d) {
+            for d in Self.currentlyMatching(cachedTargets.subtracting(liveDescendants)) {
                 _ = Darwin.kill(d.pid, SIGTERM)
             }
         } else {
             // Root has already exited: the process group may have been
             // reused by an unrelated process, so we only signal cached
-            // descendants whose command name still matches.
-            for d in targets where Self.pidStillMatches(d) {
+            // descendants whose process identity still matches.
+            for d in Self.currentlyMatching(targets) {
                 _ = Darwin.kill(d.pid, SIGTERM)
             }
         }
@@ -214,9 +213,15 @@ final class LSPTransport: @unchecked Sendable {
 
         let pid = process.processIdentifier
         guard pid > 0 else { return }
-        let keys = Self.collectDescendants(of: pid)
+        let live = Set(Self.collectDescendants(of: pid))
         lock.lock()
-        for k in keys { orphanedDescendants.insert(k) }
+        let cached = orphanedDescendants
+        lock.unlock()
+        let retained = Self.currentlyMatching(cached)
+        lock.lock()
+        if !rootHasExited {
+            orphanedDescendants = retained.union(live)
+        }
         lock.unlock()
     }
 
@@ -225,11 +230,11 @@ final class LSPTransport: @unchecked Sendable {
     /// reparents children to init so they become unfindable via a ppid
     /// walk from the original root.
     private static func collectDescendants(of root: pid_t) -> [DescendantKey] {
-        // `lstart` and `pgid` make the cached PID identity stable across
-        // PID reuse, including common executable names like node or sh.
+        // `lstart` makes the cached PID identity stable across PID reuse,
+        // including common executable names like node or sh.
         let proc = Process()
         proc.executableURL = URL(fileURLWithPath: "/bin/ps")
-        proc.arguments = ["-o", "pid=,ppid=,pgid=,lstart=,comm=", "-ax"]
+        proc.arguments = ["-o", "pid=,ppid=,lstart=,comm=", "-ax"]
         let pipe = Pipe()
         proc.standardOutput = pipe
         proc.standardError = FileHandle.nullDevice
@@ -242,39 +247,36 @@ final class LSPTransport: @unchecked Sendable {
             return []
         }
         guard let s = String(data: data, encoding: .utf8) else { return [] }
-        var childrenOf: [pid_t: [(pid: pid_t, pgid: pid_t, startedAt: String, command: String)]] = [:]
+        var childrenOf: [pid_t: [(pid: pid_t, startedAt: String, command: String)]] = [:]
         for line in s.split(separator: "\n") {
             let trimmed = line.drop(while: { $0 == " " })
-            let parts = trimmed.split(separator: " ", maxSplits: 8,
+            let parts = trimmed.split(separator: " ", maxSplits: 7,
                                       omittingEmptySubsequences: true)
-            guard parts.count >= 9,
+            guard parts.count >= 8,
                   let pid = pid_t(parts[0]),
-                  let ppid = pid_t(parts[1]),
-                  let pgid = pid_t(parts[2]) else { continue }
-            let startedAt = parts[3...7].joined(separator: " ")
-            let command = String(parts[8])
-            childrenOf[ppid, default: []].append((pid, pgid, startedAt, command))
+                  let ppid = pid_t(parts[1]) else { continue }
+            let startedAt = parts[2...6].joined(separator: " ")
+            let command = String(parts[7])
+            childrenOf[ppid, default: []].append((pid, startedAt, command))
         }
         var out: [DescendantKey] = []
         var queue: [pid_t] = [root]
         while let p = queue.popLast() {
             for c in childrenOf[p] ?? [] {
-                out.append(DescendantKey(pid: c.pid, pgid: c.pgid,
-                                         startedAt: c.startedAt, command: c.command))
+                out.append(DescendantKey(pid: c.pid, startedAt: c.startedAt,
+                                         command: c.command))
                 queue.append(c.pid)
             }
         }
         return out
     }
 
-    /// Returns true when the current process identity for `pid` matches
-    /// what we captured earlier. Used to skip stale cached PIDs whose
-    /// original process has exited and whose PID may have been reused
-    /// for an unrelated process.
-    private static func pidStillMatches(_ key: DescendantKey) -> Bool {
+    private static func currentlyMatching(_ keys: Set<DescendantKey>) -> Set<DescendantKey> {
+        guard !keys.isEmpty else { return [] }
+        let pids = Set(keys.map(\.pid))
         let proc = Process()
         proc.executableURL = URL(fileURLWithPath: "/bin/ps")
-        proc.arguments = ["-p", "\(key.pid)", "-o", "pgid=,lstart=,comm="]
+        proc.arguments = ["-o", "pid=,lstart=,comm=", "-ax"]
         let pipe = Pipe()
         proc.standardOutput = pipe
         proc.standardError = FileHandle.nullDevice
@@ -284,23 +286,24 @@ final class LSPTransport: @unchecked Sendable {
             data = pipe.fileHandleForReading.readDataToEndOfFile()
             proc.waitUntilExit()
         } catch {
-            return false
+            return []
         }
-        guard let s = String(data: data, encoding: .utf8) else { return false }
-        let trimmed = s.trimmingCharacters(in: .whitespacesAndNewlines)
-        let parts = trimmed.split(separator: " ", maxSplits: 6,
-                                  omittingEmptySubsequences: true)
-        guard parts.count >= 7,
-              let pgid = pid_t(parts[0]) else { return false }
-        let current = (
-            pgid: pgid,
-            startedAt: parts[1...5].joined(separator: " "),
-            command: String(parts[6])
-        )
-        return current.pgid == key.pgid &&
-            current.startedAt == key.startedAt &&
-            current.command == key.command
+        guard let s = String(data: data, encoding: .utf8) else { return [] }
+        var current: Set<DescendantKey> = []
+        for line in s.split(separator: "\n") {
+            let trimmed = line.drop(while: { $0 == " " })
+            let parts = trimmed.split(separator: " ", maxSplits: 6,
+                                      omittingEmptySubsequences: true)
+            guard parts.count >= 7,
+                  let pid = pid_t(parts[0]),
+                  pids.contains(pid) else { continue }
+            current.insert(DescendantKey(pid: pid,
+                                         startedAt: parts[1...5].joined(separator: " "),
+                                         command: String(parts[6])))
+        }
+        return current.intersection(keys)
     }
+
 }
 
 extension LSPTransport: LSPTransporting {}

--- a/Alas/Sources/Code/LSP/LSPTransport.swift
+++ b/Alas/Sources/Code/LSP/LSPTransport.swift
@@ -32,6 +32,10 @@ final class LSPTransport: @unchecked Sendable {
     private var decoder = JSONRPCFramer()
     private let lock = NSLock()
     private var continuation: AsyncStream<Incoming>.Continuation?
+    /// True once the root process has exited so `terminate()` can skip
+    /// signalling a stale pid the OS may have reused. Set synchronously
+    /// in the termination handler.
+    private var rootHasExited = false
 
     let incoming: AsyncStream<Incoming>
 
@@ -73,10 +77,19 @@ final class LSPTransport: @unchecked Sendable {
             self?.continuation?.yield(.stderr(data))
         }
         process.terminationHandler = { [weak self] proc in
+            self?.rootHasExited = true
             self?.continuation?.yield(.exited(proc.terminationStatus))
             self?.continuation?.finish()
         }
         try process.run()
+        // Move the child into its own process group so signals from
+        // `terminate()` can be delivered to the whole tree via
+        // `kill(-pid, …)`. Foundation's Process doesn't expose
+        // POSIX_SPAWN_SETPGROUP, so we race the child via the parent —
+        // either side may EACCES once exec completes, but at least one
+        // of those two calls succeeds and the child ends up as group
+        // leader. Same pattern as `ACPTerminal`.
+        _ = setpgid(process.processIdentifier, process.processIdentifier)
     }
 
     /// Writes a JSON-RPC body framed with `Content-Length`. Header and body
@@ -89,6 +102,15 @@ final class LSPTransport: @unchecked Sendable {
     }
 
     func terminate() {
+        guard !rootHasExited else { return }
+        let pid = process.processIdentifier
+        guard pid > 0 else { return }
+        // Signal the whole process group so descendants receive the
+        // signal even when the root doesn't forward it. Per-pid signal
+        // as a fallback for the case where `setpgid` lost the race
+        // against exec. Same pattern as `JSONRPCStdioTransport` and
+        // `ACPTerminal`.
+        _ = Darwin.kill(-pid, SIGTERM)
         if process.isRunning { process.terminate() }
     }
 }

--- a/Alas/Sources/JSONRPC/JSONRPCStdioTransport.swift
+++ b/Alas/Sources/JSONRPC/JSONRPCStdioTransport.swift
@@ -124,6 +124,52 @@ final class JSONRPCStdioTransport: @unchecked Sendable, JSONRPCStdioTransporting
         // previous behaviour; SIGKILL is not used so a graceful exit
         // can flush buffered output.
         _ = Darwin.kill(-pid, SIGTERM)
+        // Walk the process tree and signal any descendants the group
+        // kill may have missed. On macOS, parent-side setpgid frequently
+        // loses the exec race (Foundation's Process can't pass
+        // POSIX_SPAWN_SETPGROUP), leaving no process group to target.
+        for d in Self.collectDescendants(of: pid) {
+            _ = Darwin.kill(d, SIGTERM)
+        }
         if process.isRunning { process.terminate() }
+    }
+
+    /// Walks the live process tree collecting every descendant of `root`.
+    /// Returns the list immediately; once the root exits the kernel
+    /// reparents children to init so they become unfindable via a ppid
+    /// walk from the original root.
+    private static func collectDescendants(of root: pid_t) -> [pid_t] {
+        let proc = Process()
+        proc.executableURL = URL(fileURLWithPath: "/bin/ps")
+        proc.arguments = ["-o", "pid=,ppid=", "-ax"]
+        let pipe = Pipe()
+        proc.standardOutput = pipe
+        proc.standardError = FileHandle.nullDevice
+        do {
+            try proc.run()
+            proc.waitUntilExit()
+        } catch {
+            return []
+        }
+        guard let s = String(data: pipe.fileHandleForReading.readDataToEndOfFile(),
+                             encoding: .utf8) else { return [] }
+        var childrenOf: [pid_t: [pid_t]] = [:]
+        for line in s.split(separator: "\n") {
+            let parts = line.split(separator: " ", maxSplits: 1,
+                                   omittingEmptySubsequences: true)
+            guard parts.count >= 2,
+                  let pid = pid_t(parts[0]),
+                  let ppid = pid_t(parts[1]) else { continue }
+            childrenOf[ppid, default: []].append(pid)
+        }
+        var out: [pid_t] = []
+        var queue: [pid_t] = [root]
+        while let p = queue.popLast() {
+            for c in childrenOf[p] ?? [] {
+                out.append(c)
+                queue.append(c)
+            }
+        }
+        return out
     }
 }

--- a/Alas/Sources/JSONRPC/JSONRPCStdioTransport.swift
+++ b/Alas/Sources/JSONRPC/JSONRPCStdioTransport.swift
@@ -32,6 +32,7 @@ final class JSONRPCStdioTransport: @unchecked Sendable, JSONRPCStdioTransporting
     private var contentLengthFramer = JSONRPCFramer()
     private var newlineFramer = JSONRPCNewlineFramer()
     private let lock = NSLock()
+    private let refreshLock = NSLock()
     private var continuation: AsyncStream<Incoming>.Continuation?
     /// Set once the termination handler fires. We can't rely on
     /// `process.isRunning` after that — the OS may reuse the root pid
@@ -110,10 +111,12 @@ final class JSONRPCStdioTransport: @unchecked Sendable, JSONRPCStdioTransporting
                 // paths avoid group signaling once the root pid can be stale.
                 _ = Darwin.kill(-pid, SIGTERM)
             }
+            self.refreshLock.lock()
             self.lock.lock()
             let cachedTargets = self.orphanedDescendants
             self.rootHasExited = true
             self.lock.unlock()
+            self.refreshLock.unlock()
             self.cancelDescendantForkObservers()
             for d in Self.currentlyMatching(cachedTargets) {
                 _ = Darwin.kill(d.pid, SIGTERM)
@@ -149,10 +152,12 @@ final class JSONRPCStdioTransport: @unchecked Sendable, JSONRPCStdioTransporting
         cancelDescendantForkObservers()
         let pid = process.processIdentifier
         guard pid > 0 else { return }
+        refreshLock.lock()
         lock.lock()
         let rootAlive = !rootHasExited
         let targets = orphanedDescendants
         lock.unlock()
+        refreshLock.unlock()
 
         if rootAlive {
             // Root is still alive: a process-group signal reaches the
@@ -258,6 +263,8 @@ final class JSONRPCStdioTransport: @unchecked Sendable, JSONRPCStdioTransporting
     }
 
     private func refreshOrphanSet() {
+        refreshLock.lock()
+        defer { refreshLock.unlock() }
         lock.lock()
         let shouldStop = rootHasExited
         lock.unlock()
@@ -272,12 +279,13 @@ final class JSONRPCStdioTransport: @unchecked Sendable, JSONRPCStdioTransporting
         let retained = Self.currentlyMatching(cached)
         let watched = retained.union(live)
         lock.lock()
-        if !rootHasExited {
-            orphanedDescendants.subtract(cached.subtracting(retained))
-            orphanedDescendants.formUnion(live)
-        }
+        orphanedDescendants.subtract(cached.subtracting(retained))
+        orphanedDescendants.formUnion(live)
+        let shouldObserve = !rootHasExited
         lock.unlock()
-        observeForks(from: watched)
+        if shouldObserve {
+            observeForks(from: watched)
+        }
     }
 
     /// Walks the live process tree collecting every descendant of `root`.

--- a/Alas/Sources/JSONRPC/JSONRPCStdioTransport.swift
+++ b/Alas/Sources/JSONRPC/JSONRPCStdioTransport.swift
@@ -112,8 +112,12 @@ final class JSONRPCStdioTransport: @unchecked Sendable, JSONRPCStdioTransporting
             }
             self.descendantForkSource?.cancel()
             self.lock.lock()
+            let cachedTargets = self.orphanedDescendants
             self.rootHasExited = true
             self.lock.unlock()
+            for d in cachedTargets where Self.pidStillMatches(d) {
+                _ = Darwin.kill(d.pid, SIGTERM)
+            }
             self.continuation?.yield(.exited(p.terminationStatus))
             self.continuation?.finish()
         }

--- a/Alas/Sources/JSONRPC/JSONRPCStdioTransport.swift
+++ b/Alas/Sources/JSONRPC/JSONRPCStdioTransport.swift
@@ -237,14 +237,15 @@ final class JSONRPCStdioTransport: @unchecked Sendable, JSONRPCStdioTransporting
         let pipe = Pipe()
         proc.standardOutput = pipe
         proc.standardError = FileHandle.nullDevice
+        let data: Data
         do {
             try proc.run()
+            data = pipe.fileHandleForReading.readDataToEndOfFile()
             proc.waitUntilExit()
         } catch {
             return []
         }
-        guard let s = String(data: pipe.fileHandleForReading.readDataToEndOfFile(),
-                             encoding: .utf8) else { return [] }
+        guard let s = String(data: data, encoding: .utf8) else { return [] }
         var childrenOf: [pid_t: [(pid: pid_t, command: String)]] = [:]
         for line in s.split(separator: "\n") {
             let trimmed = line.drop(while: { $0 == " " })
@@ -277,14 +278,15 @@ final class JSONRPCStdioTransport: @unchecked Sendable, JSONRPCStdioTransporting
         let pipe = Pipe()
         proc.standardOutput = pipe
         proc.standardError = FileHandle.nullDevice
+        let data: Data
         do {
             try proc.run()
+            data = pipe.fileHandleForReading.readDataToEndOfFile()
             proc.waitUntilExit()
         } catch {
             return false
         }
-        guard let s = String(data: pipe.fileHandleForReading.readDataToEndOfFile(),
-                             encoding: .utf8) else { return false }
+        guard let s = String(data: data, encoding: .utf8) else { return false }
         let current = s.trimmingCharacters(in: .whitespacesAndNewlines)
         return !current.isEmpty && current == key.command
     }

--- a/Alas/Sources/JSONRPC/JSONRPCStdioTransport.swift
+++ b/Alas/Sources/JSONRPC/JSONRPCStdioTransport.swift
@@ -46,7 +46,7 @@ final class JSONRPCStdioTransport: @unchecked Sendable, JSONRPCStdioTransporting
     /// still belongs to our process before signaling it late.
     private var orphanedDescendants: Set<DescendantKey> = []
     private var descendantTracker: Task<Void, Never>?
-    private var descendantForkSource: DispatchSourceProcess?
+    private var descendantForkSources: [pid_t: DispatchSourceProcess] = [:]
 
     let incoming: AsyncStream<Incoming>
 
@@ -111,11 +111,11 @@ final class JSONRPCStdioTransport: @unchecked Sendable, JSONRPCStdioTransporting
                 // paths avoid group signaling once the root pid can be stale.
                 _ = Darwin.kill(-pid, SIGTERM)
             }
-            self.descendantForkSource?.cancel()
             self.lock.lock()
             let cachedTargets = self.orphanedDescendants
             self.rootHasExited = true
             self.lock.unlock()
+            self.cancelDescendantForkObservers()
             for d in Self.currentlyMatching(cachedTargets) {
                 _ = Darwin.kill(d.pid, SIGTERM)
             }
@@ -123,7 +123,7 @@ final class JSONRPCStdioTransport: @unchecked Sendable, JSONRPCStdioTransporting
             self.continuation?.finish()
         }
         try process.run()
-        startDescendantForkObserver()
+        startDescendantForkObserver(for: process.processIdentifier)
         refreshOrphanSet()
         // Move the child into its own process group so signals from
         // `terminate()` can be delivered to the whole tree via
@@ -147,7 +147,7 @@ final class JSONRPCStdioTransport: @unchecked Sendable, JSONRPCStdioTransporting
 
     func terminate() {
         descendantTracker?.cancel()
-        descendantForkSource?.cancel()
+        cancelDescendantForkObservers()
         let pid = process.processIdentifier
         guard pid > 0 else { return }
         lock.lock()
@@ -201,9 +201,13 @@ final class JSONRPCStdioTransport: @unchecked Sendable, JSONRPCStdioTransporting
         }
     }
 
-    private func startDescendantForkObserver() {
-        let pid = process.processIdentifier
+    private func startDescendantForkObserver(for pid: pid_t) {
         guard pid > 0 else { return }
+        lock.lock()
+        let alreadyWatching = descendantForkSources[pid] != nil
+        lock.unlock()
+        if alreadyWatching { return }
+
         let source = DispatchSource.makeProcessSource(
             identifier: pid,
             eventMask: .fork,
@@ -212,8 +216,46 @@ final class JSONRPCStdioTransport: @unchecked Sendable, JSONRPCStdioTransporting
         source.setEventHandler { [weak self] in
             self?.refreshOrphanSet()
         }
-        descendantForkSource = source
+        lock.lock()
+        if descendantForkSources[pid] == nil, !rootHasExited {
+            descendantForkSources[pid] = source
+            lock.unlock()
+            source.resume()
+            return
+        }
+        lock.unlock()
         source.resume()
+        source.cancel()
+    }
+
+    private func cancelDescendantForkObservers() {
+        lock.lock()
+        let sources = Array(descendantForkSources.values)
+        descendantForkSources.removeAll()
+        lock.unlock()
+        for source in sources {
+            source.cancel()
+        }
+    }
+
+    private func pruneDescendantForkObservers(keeping pids: Set<pid_t>) {
+        lock.lock()
+        let stale = descendantForkSources.keys.filter { !pids.contains($0) }
+        let sources = stale.compactMap { descendantForkSources.removeValue(forKey: $0) }
+        lock.unlock()
+        for source in sources {
+            source.cancel()
+        }
+    }
+
+    private func observeForks(from descendants: Set<DescendantKey>) {
+        for pid in descendants.map(\.pid) {
+            startDescendantForkObserver(for: pid)
+        }
+        let rootPid = process.processIdentifier
+        var watched = Set(descendants.map(\.pid))
+        if rootPid > 0 { watched.insert(rootPid) }
+        pruneDescendantForkObservers(keeping: watched)
     }
 
     private func refreshOrphanSet() {
@@ -229,11 +271,14 @@ final class JSONRPCStdioTransport: @unchecked Sendable, JSONRPCStdioTransporting
         let cached = orphanedDescendants
         lock.unlock()
         let retained = Self.currentlyMatching(cached)
+        let watched = retained.union(live)
         lock.lock()
         if !rootHasExited {
-            orphanedDescendants = retained.union(live)
+            orphanedDescendants.subtract(cached.subtracting(retained))
+            orphanedDescendants.formUnion(live)
         }
         lock.unlock()
+        observeForks(from: watched)
     }
 
     /// Walks the live process tree collecting every descendant of `root`.

--- a/Alas/Sources/JSONRPC/JSONRPCStdioTransport.swift
+++ b/Alas/Sources/JSONRPC/JSONRPCStdioTransport.swift
@@ -21,6 +21,8 @@ final class JSONRPCStdioTransport: @unchecked Sendable, JSONRPCStdioTransporting
 
     private struct DescendantKey: Hashable {
         let pid: pid_t
+        let pgid: pid_t
+        let startedAt: String
         let command: String
     }
 
@@ -229,12 +231,11 @@ final class JSONRPCStdioTransport: @unchecked Sendable, JSONRPCStdioTransporting
     /// reparents children to init so they become unfindable via a ppid
     /// walk from the original root.
     private static func collectDescendants(of root: pid_t) -> [DescendantKey] {
-        // `comm=` is the executable name (no header). It's stable across
-        // reads of the same process and changes when the PID is reused,
-        // so it's a cheap identity marker for late validation.
+        // `lstart` and `pgid` make the cached PID identity stable across
+        // PID reuse, including common executable names like node or sh.
         let proc = Process()
         proc.executableURL = URL(fileURLWithPath: "/bin/ps")
-        proc.arguments = ["-o", "pid=,ppid=,comm=", "-ax"]
+        proc.arguments = ["-o", "pid=,ppid=,pgid=,lstart=,comm=", "-ax"]
         let pipe = Pipe()
         proc.standardOutput = pipe
         proc.standardError = FileHandle.nullDevice
@@ -247,35 +248,39 @@ final class JSONRPCStdioTransport: @unchecked Sendable, JSONRPCStdioTransporting
             return []
         }
         guard let s = String(data: data, encoding: .utf8) else { return [] }
-        var childrenOf: [pid_t: [(pid: pid_t, command: String)]] = [:]
+        var childrenOf: [pid_t: [(pid: pid_t, pgid: pid_t, startedAt: String, command: String)]] = [:]
         for line in s.split(separator: "\n") {
             let trimmed = line.drop(while: { $0 == " " })
-            let parts = trimmed.split(separator: " ", maxSplits: 2,
+            let parts = trimmed.split(separator: " ", maxSplits: 8,
                                       omittingEmptySubsequences: true)
-            guard parts.count >= 3,
+            guard parts.count >= 9,
                   let pid = pid_t(parts[0]),
-                  let ppid = pid_t(parts[1]) else { continue }
-            childrenOf[ppid, default: []].append((pid, String(parts[2])))
+                  let ppid = pid_t(parts[1]),
+                  let pgid = pid_t(parts[2]) else { continue }
+            let startedAt = parts[3...7].joined(separator: " ")
+            let command = String(parts[8])
+            childrenOf[ppid, default: []].append((pid, pgid, startedAt, command))
         }
         var out: [DescendantKey] = []
         var queue: [pid_t] = [root]
         while let p = queue.popLast() {
             for c in childrenOf[p] ?? [] {
-                out.append(DescendantKey(pid: c.pid, command: c.command))
+                out.append(DescendantKey(pid: c.pid, pgid: c.pgid,
+                                         startedAt: c.startedAt, command: c.command))
                 queue.append(c.pid)
             }
         }
         return out
     }
 
-    /// Returns true when the current command for `pid` matches the
-    /// command captured when we recorded it. Used to skip stale cached
-    /// PIDs whose original process has exited and whose PID may have
-    /// been reused for an unrelated process.
+    /// Returns true when the current process identity for `pid` matches
+    /// what we captured earlier. Used to skip stale cached PIDs whose
+    /// original process has exited and whose PID may have been reused
+    /// for an unrelated process.
     private static func pidStillMatches(_ key: DescendantKey) -> Bool {
         let proc = Process()
         proc.executableURL = URL(fileURLWithPath: "/bin/ps")
-        proc.arguments = ["-p", "\(key.pid)", "-o", "comm="]
+        proc.arguments = ["-p", "\(key.pid)", "-o", "pgid=,lstart=,comm="]
         let pipe = Pipe()
         proc.standardOutput = pipe
         proc.standardError = FileHandle.nullDevice
@@ -288,7 +293,18 @@ final class JSONRPCStdioTransport: @unchecked Sendable, JSONRPCStdioTransporting
             return false
         }
         guard let s = String(data: data, encoding: .utf8) else { return false }
-        let current = s.trimmingCharacters(in: .whitespacesAndNewlines)
-        return !current.isEmpty && current == key.command
+        let trimmed = s.trimmingCharacters(in: .whitespacesAndNewlines)
+        let parts = trimmed.split(separator: " ", maxSplits: 6,
+                                  omittingEmptySubsequences: true)
+        guard parts.count >= 7,
+              let pgid = pid_t(parts[0]) else { return false }
+        let current = (
+            pgid: pgid,
+            startedAt: parts[1...5].joined(separator: " "),
+            command: String(parts[6])
+        )
+        return current.pgid == key.pgid &&
+            current.startedAt == key.startedAt &&
+            current.command == key.command
     }
 }

--- a/Alas/Sources/JSONRPC/JSONRPCStdioTransport.swift
+++ b/Alas/Sources/JSONRPC/JSONRPCStdioTransport.swift
@@ -102,6 +102,13 @@ final class JSONRPCStdioTransport: @unchecked Sendable, JSONRPCStdioTransporting
         }
         process.terminationHandler = { [weak self] p in
             guard let self else { return }
+            let pid = p.processIdentifier
+            if pid > 0 {
+                // Last chance to reach same-group descendants that were
+                // spawned after the most recent tracker tick. Later shutdown
+                // paths avoid group signaling once the root pid can be stale.
+                _ = Darwin.kill(-pid, SIGTERM)
+            }
             self.lock.lock()
             self.rootHasExited = true
             self.lock.unlock()
@@ -135,20 +142,21 @@ final class JSONRPCStdioTransport: @unchecked Sendable, JSONRPCStdioTransporting
         guard pid > 0 else { return }
         lock.lock()
         let rootAlive = !rootHasExited
-        var targets = orphanedDescendants
+        let targets = orphanedDescendants
         lock.unlock()
 
         if rootAlive {
             // Root is still alive: a process-group signal reaches the
             // whole tree. Take the fallback ppid snapshot before
             // signaling, while descendants are still parented to root.
-            let liveDescendants = Self.collectDescendants(of: pid)
+            let cachedTargets = targets
+            let liveDescendants = Set(Self.collectDescendants(of: pid))
             _ = Darwin.kill(-pid, SIGTERM)
             _ = Darwin.kill(pid, SIGTERM)
             for d in liveDescendants {
-                targets.insert(d)
+                _ = Darwin.kill(d.pid, SIGTERM)
             }
-            for d in targets {
+            for d in cachedTargets where !liveDescendants.contains(d) && Self.pidStillMatches(d) {
                 _ = Darwin.kill(d.pid, SIGTERM)
             }
         } else {

--- a/Alas/Sources/JSONRPC/JSONRPCStdioTransport.swift
+++ b/Alas/Sources/JSONRPC/JSONRPCStdioTransport.swift
@@ -140,11 +140,12 @@ final class JSONRPCStdioTransport: @unchecked Sendable, JSONRPCStdioTransporting
 
         if rootAlive {
             // Root is still alive: a process-group signal reaches the
-            // whole tree, and we can safely collect a live snapshot of
-            // descendants before the root disappears.
+            // whole tree. Take the fallback ppid snapshot before
+            // signaling, while descendants are still parented to root.
+            let liveDescendants = Self.collectDescendants(of: pid)
             _ = Darwin.kill(-pid, SIGTERM)
             _ = Darwin.kill(pid, SIGTERM)
-            for d in Self.collectDescendants(of: pid) {
+            for d in liveDescendants {
                 targets.insert(d)
             }
             for d in targets {

--- a/Alas/Sources/JSONRPC/JSONRPCStdioTransport.swift
+++ b/Alas/Sources/JSONRPC/JSONRPCStdioTransport.swift
@@ -45,6 +45,7 @@ final class JSONRPCStdioTransport: @unchecked Sendable, JSONRPCStdioTransporting
     /// still belongs to our process before signaling it late.
     private var orphanedDescendants: Set<DescendantKey> = []
     private var descendantTracker: Task<Void, Never>?
+    private var descendantForkSource: DispatchSourceProcess?
 
     let incoming: AsyncStream<Incoming>
 
@@ -109,6 +110,7 @@ final class JSONRPCStdioTransport: @unchecked Sendable, JSONRPCStdioTransporting
                 // paths avoid group signaling once the root pid can be stale.
                 _ = Darwin.kill(-pid, SIGTERM)
             }
+            self.descendantForkSource?.cancel()
             self.lock.lock()
             self.rootHasExited = true
             self.lock.unlock()
@@ -124,6 +126,7 @@ final class JSONRPCStdioTransport: @unchecked Sendable, JSONRPCStdioTransporting
         // of those two calls succeeds and the child ends up as group
         // leader. Same pattern as `ACPTerminal`.
         _ = setpgid(process.processIdentifier, process.processIdentifier)
+        startDescendantForkObserver()
         startDescendantTracker()
     }
 
@@ -138,6 +141,7 @@ final class JSONRPCStdioTransport: @unchecked Sendable, JSONRPCStdioTransporting
 
     func terminate() {
         descendantTracker?.cancel()
+        descendantForkSource?.cancel()
         let pid = process.processIdentifier
         guard pid > 0 else { return }
         lock.lock()
@@ -189,6 +193,21 @@ final class JSONRPCStdioTransport: @unchecked Sendable, JSONRPCStdioTransporting
                 try? await Task.sleep(nanoseconds: 1_000_000_000)
             }
         }
+    }
+
+    private func startDescendantForkObserver() {
+        let pid = process.processIdentifier
+        guard pid > 0 else { return }
+        let source = DispatchSource.makeProcessSource(
+            identifier: pid,
+            eventMask: .fork,
+            queue: .global(qos: .utility)
+        )
+        source.setEventHandler { [weak self] in
+            self?.refreshOrphanSet()
+        }
+        descendantForkSource = source
+        source.resume()
     }
 
     private func refreshOrphanSet() {

--- a/Alas/Sources/JSONRPC/JSONRPCStdioTransport.swift
+++ b/Alas/Sources/JSONRPC/JSONRPCStdioTransport.swift
@@ -22,7 +22,6 @@ final class JSONRPCStdioTransport: @unchecked Sendable, JSONRPCStdioTransporting
     private struct DescendantKey: Hashable {
         let pid: pid_t
         let startedAt: String
-        let command: String
     }
 
     private let process = Process()
@@ -38,12 +37,12 @@ final class JSONRPCStdioTransport: @unchecked Sendable, JSONRPCStdioTransporting
     /// `process.isRunning` after that — the OS may reuse the root pid
     /// for an unrelated process.
     private var rootHasExited = false
-    /// `(pid, start time, command)` entries accumulated by the periodic
-    /// descendant tracker while the root is alive. Needed because the
+    /// `(pid, start time)` entries accumulated by the periodic descendant
+    /// tracker while the root is alive. Needed because the
     /// termination handler runs after the kernel has reaped the root and
     /// reparented its children to init, so a fresh ppid walk from the root
-    /// pid returns nothing. The command name lets us re-verify a cached PID
-    /// still belongs to our process before signaling it late.
+    /// pid returns nothing. The start time lets us re-verify a cached PID
+    /// still belongs to the same process before signaling it late.
     private var orphanedDescendants: Set<DescendantKey> = []
     private var descendantTracker: Task<Void, Never>?
     private var descendantForkSources: [pid_t: DispatchSourceProcess] = [:]
@@ -286,11 +285,11 @@ final class JSONRPCStdioTransport: @unchecked Sendable, JSONRPCStdioTransporting
     /// reparents children to init so they become unfindable via a ppid
     /// walk from the original root.
     private static func collectDescendants(of root: pid_t) -> [DescendantKey] {
-        // `lstart` makes the cached PID identity stable across PID reuse,
-        // including common executable names like node or sh.
+        // `lstart` makes the cached PID identity stable across PID reuse
+        // while still surviving exec, where `comm` can legitimately change.
         let proc = Process()
         proc.executableURL = URL(fileURLWithPath: "/bin/ps")
-        proc.arguments = ["-o", "pid=,ppid=,lstart=,comm=", "-ax"]
+        proc.arguments = ["-o", "pid=,ppid=,lstart=", "-ax"]
         let pipe = Pipe()
         proc.standardOutput = pipe
         proc.standardError = FileHandle.nullDevice
@@ -303,24 +302,22 @@ final class JSONRPCStdioTransport: @unchecked Sendable, JSONRPCStdioTransporting
             return []
         }
         guard let s = String(data: data, encoding: .utf8) else { return [] }
-        var childrenOf: [pid_t: [(pid: pid_t, startedAt: String, command: String)]] = [:]
+        var childrenOf: [pid_t: [(pid: pid_t, startedAt: String)]] = [:]
         for line in s.split(separator: "\n") {
             let trimmed = line.drop(while: { $0 == " " })
-            let parts = trimmed.split(separator: " ", maxSplits: 7,
+            let parts = trimmed.split(separator: " ", maxSplits: 6,
                                       omittingEmptySubsequences: true)
-            guard parts.count >= 8,
+            guard parts.count >= 7,
                   let pid = pid_t(parts[0]),
                   let ppid = pid_t(parts[1]) else { continue }
             let startedAt = parts[2...6].joined(separator: " ")
-            let command = String(parts[7])
-            childrenOf[ppid, default: []].append((pid, startedAt, command))
+            childrenOf[ppid, default: []].append((pid, startedAt))
         }
         var out: [DescendantKey] = []
         var queue: [pid_t] = [root]
         while let p = queue.popLast() {
             for c in childrenOf[p] ?? [] {
-                out.append(DescendantKey(pid: c.pid, startedAt: c.startedAt,
-                                         command: c.command))
+                out.append(DescendantKey(pid: c.pid, startedAt: c.startedAt))
                 queue.append(c.pid)
             }
         }
@@ -332,7 +329,7 @@ final class JSONRPCStdioTransport: @unchecked Sendable, JSONRPCStdioTransporting
         let pids = Set(keys.map(\.pid))
         let proc = Process()
         proc.executableURL = URL(fileURLWithPath: "/bin/ps")
-        proc.arguments = ["-o", "pid=,lstart=,comm=", "-ax"]
+        proc.arguments = ["-o", "pid=,lstart=", "-ax"]
         let pipe = Pipe()
         proc.standardOutput = pipe
         proc.standardError = FileHandle.nullDevice
@@ -348,14 +345,13 @@ final class JSONRPCStdioTransport: @unchecked Sendable, JSONRPCStdioTransporting
         var current: Set<DescendantKey> = []
         for line in s.split(separator: "\n") {
             let trimmed = line.drop(while: { $0 == " " })
-            let parts = trimmed.split(separator: " ", maxSplits: 6,
+            let parts = trimmed.split(separator: " ", maxSplits: 5,
                                       omittingEmptySubsequences: true)
-            guard parts.count >= 7,
+            guard parts.count >= 6,
                   let pid = pid_t(parts[0]),
                   pids.contains(pid) else { continue }
             current.insert(DescendantKey(pid: pid,
-                                         startedAt: parts[1...5].joined(separator: " "),
-                                         command: String(parts[6])))
+                                         startedAt: parts[1...5].joined(separator: " ")))
         }
         return current.intersection(keys)
     }

--- a/Alas/Sources/JSONRPC/JSONRPCStdioTransport.swift
+++ b/Alas/Sources/JSONRPC/JSONRPCStdioTransport.swift
@@ -192,11 +192,11 @@ final class JSONRPCStdioTransport: @unchecked Sendable, JSONRPCStdioTransporting
             // the kernel reparents children to init.
             while !Task.isCancelled {
                 guard let self else { return }
-                self.refreshOrphanSet()
                 self.lock.lock()
                 let shouldStop = self.rootHasExited
                 self.lock.unlock()
                 if shouldStop { return }
+                self.refreshOrphanSet()
                 try? await Task.sleep(nanoseconds: 1_000_000_000)
             }
         }
@@ -218,6 +218,11 @@ final class JSONRPCStdioTransport: @unchecked Sendable, JSONRPCStdioTransporting
     }
 
     private func refreshOrphanSet() {
+        lock.lock()
+        let shouldStop = rootHasExited
+        lock.unlock()
+        guard !shouldStop, process.isRunning else { return }
+
         let pid = process.processIdentifier
         guard pid > 0 else { return }
         let keys = Self.collectDescendants(of: pid)

--- a/Alas/Sources/JSONRPC/JSONRPCStdioTransport.swift
+++ b/Alas/Sources/JSONRPC/JSONRPCStdioTransport.swift
@@ -122,8 +122,6 @@ final class JSONRPCStdioTransport: @unchecked Sendable, JSONRPCStdioTransporting
             self.continuation?.finish()
         }
         try process.run()
-        startDescendantForkObserver(for: process.processIdentifier)
-        refreshOrphanSet()
         // Move the child into its own process group so signals from
         // `terminate()` can be delivered to the whole tree via
         // `kill(-pid, …)`. Foundation's Process doesn't expose
@@ -132,6 +130,8 @@ final class JSONRPCStdioTransport: @unchecked Sendable, JSONRPCStdioTransporting
         // of those two calls succeeds and the child ends up as group
         // leader. Same pattern as `ACPTerminal`.
         _ = setpgid(process.processIdentifier, process.processIdentifier)
+        startDescendantForkObserver(for: process.processIdentifier)
+        refreshOrphanSet()
         startDescendantTracker()
     }
 

--- a/Alas/Sources/JSONRPC/JSONRPCStdioTransport.swift
+++ b/Alas/Sources/JSONRPC/JSONRPCStdioTransport.swift
@@ -19,6 +19,11 @@ final class JSONRPCStdioTransport: @unchecked Sendable, JSONRPCStdioTransporting
         case exited(Int32)
     }
 
+    private struct DescendantKey: Hashable {
+        let pid: pid_t
+        let command: String
+    }
+
     private let process = Process()
     private let stdin = Pipe()
     private let stdout = Pipe()
@@ -28,11 +33,18 @@ final class JSONRPCStdioTransport: @unchecked Sendable, JSONRPCStdioTransporting
     private var newlineFramer = JSONRPCNewlineFramer()
     private let lock = NSLock()
     private var continuation: AsyncStream<Incoming>.Continuation?
-    /// Captured in the termination handler so `terminate()` can still
-    /// reach descendants after the root exits and the kernel reparents
-    /// them to init (making them unfindable via a ppid walk from the
-    /// original root).
-    private var descendants: [pid_t]?
+    /// Set once the termination handler fires. We can't rely on
+    /// `process.isRunning` after that — the OS may reuse the root pid
+    /// for an unrelated process.
+    private var rootHasExited = false
+    /// `(pid, command)` pairs accumulated by the periodic descendant
+    /// tracker while the root is alive. Needed because the termination
+    /// handler runs after the kernel has reaped the root and reparented
+    /// its children to init, so a fresh ppid walk from the root pid
+    /// returns nothing. The command name lets us re-verify a cached PID
+    /// still belongs to our process before signaling it late.
+    private var orphanedDescendants: Set<DescendantKey> = []
+    private var descendantTracker: Task<Void, Never>?
 
     let incoming: AsyncStream<Incoming>
 
@@ -90,10 +102,8 @@ final class JSONRPCStdioTransport: @unchecked Sendable, JSONRPCStdioTransporting
         }
         process.terminationHandler = { [weak self] p in
             guard let self else { return }
-            let pid = p.processIdentifier
-            let kids = Self.collectDescendants(of: pid)
             self.lock.lock()
-            self.descendants = kids
+            self.rootHasExited = true
             self.lock.unlock()
             self.continuation?.yield(.exited(p.terminationStatus))
             self.continuation?.finish()
@@ -107,6 +117,7 @@ final class JSONRPCStdioTransport: @unchecked Sendable, JSONRPCStdioTransporting
         // of those two calls succeeds and the child ends up as group
         // leader. Same pattern as `ACPTerminal`.
         _ = setpgid(process.processIdentifier, process.processIdentifier)
+        startDescendantTracker()
     }
 
     func send(_ data: Data) throws {
@@ -119,40 +130,78 @@ final class JSONRPCStdioTransport: @unchecked Sendable, JSONRPCStdioTransporting
     }
 
     func terminate() {
+        descendantTracker?.cancel()
         let pid = process.processIdentifier
         guard pid > 0 else { return }
-        // Signal the whole process group first so descendants (node →
-        // codex, node → claude, etc.) receive the signal even when the
-        // root process doesn't forward it. Per-pid signal as a fallback
-        // for the case where `setpgid` lost the race against exec and
-        // the child never became a group leader. SIGTERM mirrors the
-        // previous behaviour; SIGKILL is not used so a graceful exit
-        // can flush buffered output.
-        _ = Darwin.kill(-pid, SIGTERM)
-        // Walk the process tree and signal any descendants the group
-        // kill may have missed. On macOS, parent-side setpgid frequently
-        // loses the exec race (Foundation's Process can't pass
-        // POSIX_SPAWN_SETPGROUP), leaving no process group to target.
-        // If the root exited before we got here, use the tree captured
-        // by the termination handler; otherwise walk live so we catch
-        // children spawned between handler capture and now.
         lock.lock()
-        let kids = descendants ?? Self.collectDescendants(of: pid)
+        let rootAlive = !rootHasExited
+        var targets = orphanedDescendants
         lock.unlock()
-        for d in kids {
-            _ = Darwin.kill(d, SIGTERM)
+
+        if rootAlive {
+            // Root is still alive: a process-group signal reaches the
+            // whole tree, and we can safely collect a live snapshot of
+            // descendants before the root disappears.
+            _ = Darwin.kill(-pid, SIGTERM)
+            _ = Darwin.kill(pid, SIGTERM)
+            for d in Self.collectDescendants(of: pid) {
+                targets.insert(d)
+            }
+            for d in targets {
+                _ = Darwin.kill(d.pid, SIGTERM)
+            }
+        } else {
+            // Root has already exited: the process group may have been
+            // reused by an unrelated process, so we only signal cached
+            // descendants whose command name still matches.
+            for d in targets where Self.pidStillMatches(d) {
+                _ = Darwin.kill(d.pid, SIGTERM)
+            }
         }
-        if process.isRunning { process.terminate() }
+
+        if process.isRunning {
+            process.terminate()
+        }
+    }
+
+    private func startDescendantTracker() {
+        descendantTracker = Task { [weak self] in
+            // Walk the live process tree every second while the root is
+            // alive, accumulating every descendant we observe. The last
+            // pre-exit snapshot is what `terminate()` relies on after
+            // the kernel reparents children to init.
+            while !Task.isCancelled {
+                guard let self else { return }
+                self.refreshOrphanSet()
+                self.lock.lock()
+                let shouldStop = self.rootHasExited
+                self.lock.unlock()
+                if shouldStop { return }
+                try? await Task.sleep(nanoseconds: 1_000_000_000)
+            }
+        }
+    }
+
+    private func refreshOrphanSet() {
+        let pid = process.processIdentifier
+        guard pid > 0 else { return }
+        let keys = Self.collectDescendants(of: pid)
+        lock.lock()
+        for k in keys { orphanedDescendants.insert(k) }
+        lock.unlock()
     }
 
     /// Walks the live process tree collecting every descendant of `root`.
     /// Returns the list immediately; once the root exits the kernel
     /// reparents children to init so they become unfindable via a ppid
     /// walk from the original root.
-    private static func collectDescendants(of root: pid_t) -> [pid_t] {
+    private static func collectDescendants(of root: pid_t) -> [DescendantKey] {
+        // `comm=` is the executable name (no header). It's stable across
+        // reads of the same process and changes when the PID is reused,
+        // so it's a cheap identity marker for late validation.
         let proc = Process()
         proc.executableURL = URL(fileURLWithPath: "/bin/ps")
-        proc.arguments = ["-o", "pid=,ppid=", "-ax"]
+        proc.arguments = ["-o", "pid=,ppid=,comm=", "-ax"]
         let pipe = Pipe()
         proc.standardOutput = pipe
         proc.standardError = FileHandle.nullDevice
@@ -164,23 +213,47 @@ final class JSONRPCStdioTransport: @unchecked Sendable, JSONRPCStdioTransporting
         }
         guard let s = String(data: pipe.fileHandleForReading.readDataToEndOfFile(),
                              encoding: .utf8) else { return [] }
-        var childrenOf: [pid_t: [pid_t]] = [:]
+        var childrenOf: [pid_t: [(pid: pid_t, command: String)]] = [:]
         for line in s.split(separator: "\n") {
-            let parts = line.split(separator: " ", maxSplits: 1,
-                                   omittingEmptySubsequences: true)
-            guard parts.count >= 2,
+            let trimmed = line.drop(while: { $0 == " " })
+            let parts = trimmed.split(separator: " ", maxSplits: 2,
+                                      omittingEmptySubsequences: true)
+            guard parts.count >= 3,
                   let pid = pid_t(parts[0]),
                   let ppid = pid_t(parts[1]) else { continue }
-            childrenOf[ppid, default: []].append(pid)
+            childrenOf[ppid, default: []].append((pid, String(parts[2])))
         }
-        var out: [pid_t] = []
+        var out: [DescendantKey] = []
         var queue: [pid_t] = [root]
         while let p = queue.popLast() {
             for c in childrenOf[p] ?? [] {
-                out.append(c)
-                queue.append(c)
+                out.append(DescendantKey(pid: c.pid, command: c.command))
+                queue.append(c.pid)
             }
         }
         return out
+    }
+
+    /// Returns true when the current command for `pid` matches the
+    /// command captured when we recorded it. Used to skip stale cached
+    /// PIDs whose original process has exited and whose PID may have
+    /// been reused for an unrelated process.
+    private static func pidStillMatches(_ key: DescendantKey) -> Bool {
+        let proc = Process()
+        proc.executableURL = URL(fileURLWithPath: "/bin/ps")
+        proc.arguments = ["-p", "\(key.pid)", "-o", "comm="]
+        let pipe = Pipe()
+        proc.standardOutput = pipe
+        proc.standardError = FileHandle.nullDevice
+        do {
+            try proc.run()
+            proc.waitUntilExit()
+        } catch {
+            return false
+        }
+        guard let s = String(data: pipe.fileHandleForReading.readDataToEndOfFile(),
+                             encoding: .utf8) else { return false }
+        let current = s.trimmingCharacters(in: .whitespacesAndNewlines)
+        return !current.isEmpty && current == key.command
     }
 }

--- a/Alas/Sources/JSONRPC/JSONRPCStdioTransport.swift
+++ b/Alas/Sources/JSONRPC/JSONRPCStdioTransport.swift
@@ -39,10 +39,10 @@ final class JSONRPCStdioTransport: @unchecked Sendable, JSONRPCStdioTransporting
     /// for an unrelated process.
     private var rootHasExited = false
     /// `(pid, start time, command)` entries accumulated by the periodic
-    /// descendant tracker while the root is alive. Needed because the termination
-    /// handler runs after the kernel has reaped the root and reparented
-    /// its children to init, so a fresh ppid walk from the root pid
-    /// returns nothing. The command name lets us re-verify a cached PID
+    /// descendant tracker while the root is alive. Needed because the
+    /// termination handler runs after the kernel has reaped the root and
+    /// reparented its children to init, so a fresh ppid walk from the root
+    /// pid returns nothing. The command name lets us re-verify a cached PID
     /// still belongs to our process before signaling it late.
     private var orphanedDescendants: Set<DescendantKey> = []
     private var descendantTracker: Task<Void, Never>?
@@ -314,5 +314,4 @@ final class JSONRPCStdioTransport: @unchecked Sendable, JSONRPCStdioTransporting
         }
         return current.intersection(keys)
     }
-
 }

--- a/Alas/Sources/JSONRPC/JSONRPCStdioTransport.swift
+++ b/Alas/Sources/JSONRPC/JSONRPCStdioTransport.swift
@@ -122,6 +122,8 @@ final class JSONRPCStdioTransport: @unchecked Sendable, JSONRPCStdioTransporting
             self.continuation?.finish()
         }
         try process.run()
+        startDescendantForkObserver()
+        refreshOrphanSet()
         // Move the child into its own process group so signals from
         // `terminate()` can be delivered to the whole tree via
         // `kill(-pid, …)`. Foundation's Process doesn't expose
@@ -130,7 +132,6 @@ final class JSONRPCStdioTransport: @unchecked Sendable, JSONRPCStdioTransporting
         // of those two calls succeeds and the child ends up as group
         // leader. Same pattern as `ACPTerminal`.
         _ = setpgid(process.processIdentifier, process.processIdentifier)
-        startDescendantForkObserver()
         startDescendantTracker()
     }
 

--- a/Alas/Sources/JSONRPC/JSONRPCStdioTransport.swift
+++ b/Alas/Sources/JSONRPC/JSONRPCStdioTransport.swift
@@ -21,7 +21,6 @@ final class JSONRPCStdioTransport: @unchecked Sendable, JSONRPCStdioTransporting
 
     private struct DescendantKey: Hashable {
         let pid: pid_t
-        let pgid: pid_t
         let startedAt: String
         let command: String
     }
@@ -39,8 +38,8 @@ final class JSONRPCStdioTransport: @unchecked Sendable, JSONRPCStdioTransporting
     /// `process.isRunning` after that — the OS may reuse the root pid
     /// for an unrelated process.
     private var rootHasExited = false
-    /// `(pid, command)` pairs accumulated by the periodic descendant
-    /// tracker while the root is alive. Needed because the termination
+    /// `(pid, start time, command)` entries accumulated by the periodic
+    /// descendant tracker while the root is alive. Needed because the termination
     /// handler runs after the kernel has reaped the root and reparented
     /// its children to init, so a fresh ppid walk from the root pid
     /// returns nothing. The command name lets us re-verify a cached PID
@@ -117,7 +116,7 @@ final class JSONRPCStdioTransport: @unchecked Sendable, JSONRPCStdioTransporting
             let cachedTargets = self.orphanedDescendants
             self.rootHasExited = true
             self.lock.unlock()
-            for d in cachedTargets where Self.pidStillMatches(d) {
+            for d in Self.currentlyMatching(cachedTargets) {
                 _ = Darwin.kill(d.pid, SIGTERM)
             }
             self.continuation?.yield(.exited(p.terminationStatus))
@@ -167,14 +166,14 @@ final class JSONRPCStdioTransport: @unchecked Sendable, JSONRPCStdioTransporting
             for d in liveDescendants {
                 _ = Darwin.kill(d.pid, SIGTERM)
             }
-            for d in cachedTargets where !liveDescendants.contains(d) && Self.pidStillMatches(d) {
+            for d in Self.currentlyMatching(cachedTargets.subtracting(liveDescendants)) {
                 _ = Darwin.kill(d.pid, SIGTERM)
             }
         } else {
             // Root has already exited: the process group may have been
             // reused by an unrelated process, so we only signal cached
-            // descendants whose command name still matches.
-            for d in targets where Self.pidStillMatches(d) {
+            // descendants whose process identity still matches.
+            for d in Self.currentlyMatching(targets) {
                 _ = Darwin.kill(d.pid, SIGTERM)
             }
         }
@@ -225,9 +224,15 @@ final class JSONRPCStdioTransport: @unchecked Sendable, JSONRPCStdioTransporting
 
         let pid = process.processIdentifier
         guard pid > 0 else { return }
-        let keys = Self.collectDescendants(of: pid)
+        let live = Set(Self.collectDescendants(of: pid))
         lock.lock()
-        for k in keys { orphanedDescendants.insert(k) }
+        let cached = orphanedDescendants
+        lock.unlock()
+        let retained = Self.currentlyMatching(cached)
+        lock.lock()
+        if !rootHasExited {
+            orphanedDescendants = retained.union(live)
+        }
         lock.unlock()
     }
 
@@ -236,11 +241,11 @@ final class JSONRPCStdioTransport: @unchecked Sendable, JSONRPCStdioTransporting
     /// reparents children to init so they become unfindable via a ppid
     /// walk from the original root.
     private static func collectDescendants(of root: pid_t) -> [DescendantKey] {
-        // `lstart` and `pgid` make the cached PID identity stable across
-        // PID reuse, including common executable names like node or sh.
+        // `lstart` makes the cached PID identity stable across PID reuse,
+        // including common executable names like node or sh.
         let proc = Process()
         proc.executableURL = URL(fileURLWithPath: "/bin/ps")
-        proc.arguments = ["-o", "pid=,ppid=,pgid=,lstart=,comm=", "-ax"]
+        proc.arguments = ["-o", "pid=,ppid=,lstart=,comm=", "-ax"]
         let pipe = Pipe()
         proc.standardOutput = pipe
         proc.standardError = FileHandle.nullDevice
@@ -253,39 +258,36 @@ final class JSONRPCStdioTransport: @unchecked Sendable, JSONRPCStdioTransporting
             return []
         }
         guard let s = String(data: data, encoding: .utf8) else { return [] }
-        var childrenOf: [pid_t: [(pid: pid_t, pgid: pid_t, startedAt: String, command: String)]] = [:]
+        var childrenOf: [pid_t: [(pid: pid_t, startedAt: String, command: String)]] = [:]
         for line in s.split(separator: "\n") {
             let trimmed = line.drop(while: { $0 == " " })
-            let parts = trimmed.split(separator: " ", maxSplits: 8,
+            let parts = trimmed.split(separator: " ", maxSplits: 7,
                                       omittingEmptySubsequences: true)
-            guard parts.count >= 9,
+            guard parts.count >= 8,
                   let pid = pid_t(parts[0]),
-                  let ppid = pid_t(parts[1]),
-                  let pgid = pid_t(parts[2]) else { continue }
-            let startedAt = parts[3...7].joined(separator: " ")
-            let command = String(parts[8])
-            childrenOf[ppid, default: []].append((pid, pgid, startedAt, command))
+                  let ppid = pid_t(parts[1]) else { continue }
+            let startedAt = parts[2...6].joined(separator: " ")
+            let command = String(parts[7])
+            childrenOf[ppid, default: []].append((pid, startedAt, command))
         }
         var out: [DescendantKey] = []
         var queue: [pid_t] = [root]
         while let p = queue.popLast() {
             for c in childrenOf[p] ?? [] {
-                out.append(DescendantKey(pid: c.pid, pgid: c.pgid,
-                                         startedAt: c.startedAt, command: c.command))
+                out.append(DescendantKey(pid: c.pid, startedAt: c.startedAt,
+                                         command: c.command))
                 queue.append(c.pid)
             }
         }
         return out
     }
 
-    /// Returns true when the current process identity for `pid` matches
-    /// what we captured earlier. Used to skip stale cached PIDs whose
-    /// original process has exited and whose PID may have been reused
-    /// for an unrelated process.
-    private static func pidStillMatches(_ key: DescendantKey) -> Bool {
+    private static func currentlyMatching(_ keys: Set<DescendantKey>) -> Set<DescendantKey> {
+        guard !keys.isEmpty else { return [] }
+        let pids = Set(keys.map(\.pid))
         let proc = Process()
         proc.executableURL = URL(fileURLWithPath: "/bin/ps")
-        proc.arguments = ["-p", "\(key.pid)", "-o", "pgid=,lstart=,comm="]
+        proc.arguments = ["-o", "pid=,lstart=,comm=", "-ax"]
         let pipe = Pipe()
         proc.standardOutput = pipe
         proc.standardError = FileHandle.nullDevice
@@ -295,21 +297,22 @@ final class JSONRPCStdioTransport: @unchecked Sendable, JSONRPCStdioTransporting
             data = pipe.fileHandleForReading.readDataToEndOfFile()
             proc.waitUntilExit()
         } catch {
-            return false
+            return []
         }
-        guard let s = String(data: data, encoding: .utf8) else { return false }
-        let trimmed = s.trimmingCharacters(in: .whitespacesAndNewlines)
-        let parts = trimmed.split(separator: " ", maxSplits: 6,
-                                  omittingEmptySubsequences: true)
-        guard parts.count >= 7,
-              let pgid = pid_t(parts[0]) else { return false }
-        let current = (
-            pgid: pgid,
-            startedAt: parts[1...5].joined(separator: " "),
-            command: String(parts[6])
-        )
-        return current.pgid == key.pgid &&
-            current.startedAt == key.startedAt &&
-            current.command == key.command
+        guard let s = String(data: data, encoding: .utf8) else { return [] }
+        var current: Set<DescendantKey> = []
+        for line in s.split(separator: "\n") {
+            let trimmed = line.drop(while: { $0 == " " })
+            let parts = trimmed.split(separator: " ", maxSplits: 6,
+                                      omittingEmptySubsequences: true)
+            guard parts.count >= 7,
+                  let pid = pid_t(parts[0]),
+                  pids.contains(pid) else { continue }
+            current.insert(DescendantKey(pid: pid,
+                                         startedAt: parts[1...5].joined(separator: " "),
+                                         command: String(parts[6])))
+        }
+        return current.intersection(keys)
     }
+
 }

--- a/Alas/Sources/JSONRPC/JSONRPCStdioTransport.swift
+++ b/Alas/Sources/JSONRPC/JSONRPCStdioTransport.swift
@@ -28,10 +28,11 @@ final class JSONRPCStdioTransport: @unchecked Sendable, JSONRPCStdioTransporting
     private var newlineFramer = JSONRPCNewlineFramer()
     private let lock = NSLock()
     private var continuation: AsyncStream<Incoming>.Continuation?
-    /// True once the root process has exited so `terminate()` can skip
-    /// signalling a stale pid the OS may have reused. Set synchronously
-    /// in the termination handler.
-    private var rootHasExited = false
+    /// Captured in the termination handler so `terminate()` can still
+    /// reach descendants after the root exits and the kernel reparents
+    /// them to init (making them unfindable via a ppid walk from the
+    /// original root).
+    private var descendants: [pid_t]?
 
     let incoming: AsyncStream<Incoming>
 
@@ -88,9 +89,14 @@ final class JSONRPCStdioTransport: @unchecked Sendable, JSONRPCStdioTransporting
             self?.continuation?.yield(.stderr(d))
         }
         process.terminationHandler = { [weak self] p in
-            self?.rootHasExited = true
-            self?.continuation?.yield(.exited(p.terminationStatus))
-            self?.continuation?.finish()
+            guard let self else { return }
+            let pid = p.processIdentifier
+            let kids = Self.collectDescendants(of: pid)
+            self.lock.lock()
+            self.descendants = kids
+            self.lock.unlock()
+            self.continuation?.yield(.exited(p.terminationStatus))
+            self.continuation?.finish()
         }
         try process.run()
         // Move the child into its own process group so signals from
@@ -113,7 +119,6 @@ final class JSONRPCStdioTransport: @unchecked Sendable, JSONRPCStdioTransporting
     }
 
     func terminate() {
-        guard !rootHasExited else { return }
         let pid = process.processIdentifier
         guard pid > 0 else { return }
         // Signal the whole process group first so descendants (node →
@@ -128,7 +133,13 @@ final class JSONRPCStdioTransport: @unchecked Sendable, JSONRPCStdioTransporting
         // kill may have missed. On macOS, parent-side setpgid frequently
         // loses the exec race (Foundation's Process can't pass
         // POSIX_SPAWN_SETPGROUP), leaving no process group to target.
-        for d in Self.collectDescendants(of: pid) {
+        // If the root exited before we got here, use the tree captured
+        // by the termination handler; otherwise walk live so we catch
+        // children spawned between handler capture and now.
+        lock.lock()
+        let kids = descendants ?? Self.collectDescendants(of: pid)
+        lock.unlock()
+        for d in kids {
             _ = Darwin.kill(d, SIGTERM)
         }
         if process.isRunning { process.terminate() }

--- a/Alas/Sources/JSONRPC/JSONRPCStdioTransport.swift
+++ b/Alas/Sources/JSONRPC/JSONRPCStdioTransport.swift
@@ -28,6 +28,10 @@ final class JSONRPCStdioTransport: @unchecked Sendable, JSONRPCStdioTransporting
     private var newlineFramer = JSONRPCNewlineFramer()
     private let lock = NSLock()
     private var continuation: AsyncStream<Incoming>.Continuation?
+    /// True once the root process has exited so `terminate()` can skip
+    /// signalling a stale pid the OS may have reused. Set synchronously
+    /// in the termination handler.
+    private var rootHasExited = false
 
     let incoming: AsyncStream<Incoming>
 
@@ -84,10 +88,19 @@ final class JSONRPCStdioTransport: @unchecked Sendable, JSONRPCStdioTransporting
             self?.continuation?.yield(.stderr(d))
         }
         process.terminationHandler = { [weak self] p in
+            self?.rootHasExited = true
             self?.continuation?.yield(.exited(p.terminationStatus))
             self?.continuation?.finish()
         }
         try process.run()
+        // Move the child into its own process group so signals from
+        // `terminate()` can be delivered to the whole tree via
+        // `kill(-pid, …)`. Foundation's Process doesn't expose
+        // POSIX_SPAWN_SETPGROUP, so we race the child via the parent —
+        // either side may EACCES once exec completes, but at least one
+        // of those two calls succeeds and the child ends up as group
+        // leader. Same pattern as `ACPTerminal`.
+        _ = setpgid(process.processIdentifier, process.processIdentifier)
     }
 
     func send(_ data: Data) throws {
@@ -99,5 +112,18 @@ final class JSONRPCStdioTransport: @unchecked Sendable, JSONRPCStdioTransporting
         try stdin.fileHandleForWriting.write(contentsOf: framed)
     }
 
-    func terminate() { if process.isRunning { process.terminate() } }
+    func terminate() {
+        guard !rootHasExited else { return }
+        let pid = process.processIdentifier
+        guard pid > 0 else { return }
+        // Signal the whole process group first so descendants (node →
+        // codex, node → claude, etc.) receive the signal even when the
+        // root process doesn't forward it. Per-pid signal as a fallback
+        // for the case where `setpgid` lost the race against exec and
+        // the child never became a group leader. SIGTERM mirrors the
+        // previous behaviour; SIGKILL is not used so a graceful exit
+        // can flush buffered output.
+        _ = Darwin.kill(-pid, SIGTERM)
+        if process.isRunning { process.terminate() }
+    }
 }

--- a/AlasTests/Code/LSP/LSPTransportTests.swift
+++ b/AlasTests/Code/LSP/LSPTransportTests.swift
@@ -54,12 +54,16 @@ struct ProcessTransportTerminationTests {
     func lspSnapshotsDescendantsBeforeRootSignal() throws {
         let source = try source(named: "Code/LSP/LSPTransport.swift")
         #expect(source.requiresLiveDescendantSnapshotBeforeRootSignal())
+        #expect(source.validatesCachedDescendantsBeforeKilling())
+        #expect(source.signalsProcessGroupFromTerminationHandler())
     }
 
     @Test("JSONRPCStdioTransport snapshots live descendants before signaling root")
     func jsonrpcSnapshotsDescendantsBeforeRootSignal() throws {
         let source = try source(named: "JSONRPC/JSONRPCStdioTransport.swift")
         #expect(source.requiresLiveDescendantSnapshotBeforeRootSignal())
+        #expect(source.validatesCachedDescendantsBeforeKilling())
+        #expect(source.signalsProcessGroupFromTerminationHandler())
     }
 
     private func source(named path: String) throws -> String {
@@ -75,10 +79,22 @@ struct ProcessTransportTerminationTests {
 
 private extension String {
     func requiresLiveDescendantSnapshotBeforeRootSignal() -> Bool {
-        guard let snapshot = range(of: "let liveDescendants = Self.collectDescendants(of: pid)"),
+        guard let snapshot = range(of: "let liveDescendants = Set(Self.collectDescendants(of: pid))") else {
+            return false
+        }
+        return self[snapshot.upperBound...].contains("Darwin.kill(-pid, SIGTERM)")
+    }
+
+    func validatesCachedDescendantsBeforeKilling() -> Bool {
+        contains("for d in cachedTargets where !liveDescendants.contains(d) && Self.pidStillMatches(d)")
+    }
+
+    func signalsProcessGroupFromTerminationHandler() -> Bool {
+        guard let handler = range(of: "process.terminationHandler"),
+              let rootExited = range(of: "self.rootHasExited = true"),
               let groupSignal = range(of: "Darwin.kill(-pid, SIGTERM)") else {
             return false
         }
-        return snapshot.lowerBound < groupSignal.lowerBound
+        return handler.lowerBound < groupSignal.lowerBound && groupSignal.lowerBound < rootExited.lowerBound
     }
 }

--- a/AlasTests/Code/LSP/LSPTransportTests.swift
+++ b/AlasTests/Code/LSP/LSPTransportTests.swift
@@ -47,3 +47,38 @@ struct LSPTransportFramingTests {
         return out
     }
 }
+
+@Suite("Process transport termination")
+struct ProcessTransportTerminationTests {
+    @Test("LSPTransport snapshots live descendants before signaling root")
+    func lspSnapshotsDescendantsBeforeRootSignal() throws {
+        let source = try source(named: "Code/LSP/LSPTransport.swift")
+        #expect(source.requiresLiveDescendantSnapshotBeforeRootSignal())
+    }
+
+    @Test("JSONRPCStdioTransport snapshots live descendants before signaling root")
+    func jsonrpcSnapshotsDescendantsBeforeRootSignal() throws {
+        let source = try source(named: "JSONRPC/JSONRPCStdioTransport.swift")
+        #expect(source.requiresLiveDescendantSnapshotBeforeRootSignal())
+    }
+
+    private func source(named path: String) throws -> String {
+        let root = URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+        return try String(contentsOf: root.appendingPathComponent("Alas/Sources/\(path)"),
+                          encoding: .utf8)
+    }
+}
+
+private extension String {
+    func requiresLiveDescendantSnapshotBeforeRootSignal() -> Bool {
+        guard let snapshot = range(of: "let liveDescendants = Self.collectDescendants(of: pid)"),
+              let groupSignal = range(of: "Darwin.kill(-pid, SIGTERM)") else {
+            return false
+        }
+        return snapshot.lowerBound < groupSignal.lowerBound
+    }
+}

--- a/AlasTests/Code/LSP/LSPTransportTests.swift
+++ b/AlasTests/Code/LSP/LSPTransportTests.swift
@@ -62,6 +62,7 @@ struct ProcessTransportTerminationTests {
         #expect(source.drainsPsOutputBeforeWaiting())
         #expect(source.validatesCachedDescendantsWithStableIdentity())
         #expect(source.checksRootExitBeforeTrackerRefresh())
+        #expect(source.prunesCachedDescendantsWithBatchedLookup())
     }
 
     @Test("JSONRPCStdioTransport snapshots live descendants before signaling root")
@@ -76,6 +77,7 @@ struct ProcessTransportTerminationTests {
         #expect(source.drainsPsOutputBeforeWaiting())
         #expect(source.validatesCachedDescendantsWithStableIdentity())
         #expect(source.checksRootExitBeforeTrackerRefresh())
+        #expect(source.prunesCachedDescendantsWithBatchedLookup())
     }
 
     private func source(named path: String) throws -> String {
@@ -98,7 +100,7 @@ private extension String {
     }
 
     func validatesCachedDescendantsBeforeKilling() -> Bool {
-        contains("for d in cachedTargets where !liveDescendants.contains(d) && Self.pidStillMatches(d)")
+        contains("for d in Self.currentlyMatching(cachedTargets.subtracting(liveDescendants))")
     }
 
     func signalsProcessGroupFromTerminationHandler() -> Bool {
@@ -113,7 +115,7 @@ private extension String {
     func signalsCachedDescendantsFromTerminationHandler() -> Bool {
         guard let handler = range(of: "process.terminationHandler"),
               let cachedTargets = range(of: "let cachedTargets = self.orphanedDescendants"),
-              let cachedSignal = range(of: "for d in cachedTargets where Self.pidStillMatches(d)"),
+              let cachedSignal = range(of: "for d in Self.currentlyMatching(cachedTargets)"),
               let finish = range(of: "self.continuation?.finish()") else {
             return false
         }
@@ -153,13 +155,12 @@ private extension String {
     }
 
     func validatesCachedDescendantsWithStableIdentity() -> Bool {
-        contains("let pgid: pid_t") &&
             contains("let startedAt: String") &&
-            contains(#""pid=,ppid=,pgid=,lstart=,comm=""#) &&
-            contains(#""pgid=,lstart=,comm=""#) &&
-            contains("current.pgid == key.pgid") &&
-            contains("current.startedAt == key.startedAt") &&
-            contains("current.command == key.command")
+            contains(#""pid=,ppid=,lstart=,comm=""#) &&
+            contains(#""pid=,lstart=,comm=""#) &&
+            !contains("current.pgid == key.pgid") &&
+            contains("startedAt: parts[1...5].joined(separator: \" \")") &&
+            contains("return current.intersection(keys)")
     }
 
     func checksRootExitBeforeTrackerRefresh() -> Bool {
@@ -169,5 +170,12 @@ private extension String {
             return false
         }
         return rootExited.lowerBound < refresh.lowerBound
+    }
+
+    func prunesCachedDescendantsWithBatchedLookup() -> Bool {
+        contains("private static func currentlyMatching(_ keys: Set<DescendantKey>) -> Set<DescendantKey>") &&
+            contains("let retained = Self.currentlyMatching(cached)") &&
+            contains("orphanedDescendants = retained.union(live)") &&
+            contains("for d in Self.currentlyMatching(targets)")
     }
 }

--- a/AlasTests/Code/LSP/LSPTransportTests.swift
+++ b/AlasTests/Code/LSP/LSPTransportTests.swift
@@ -57,7 +57,7 @@ struct ProcessTransportTerminationTests {
         #expect(source.validatesCachedDescendantsBeforeKilling())
         #expect(source.signalsProcessGroupFromTerminationHandler())
         #expect(source.signalsCachedDescendantsFromTerminationHandler())
-        #expect(source.startsDescendantTrackingBeforeSetpgid())
+        #expect(source.attemptsSetpgidBeforeBlockingDescendantSnapshot())
         #expect(source.refreshesDescendantsOnFork())
         #expect(source.drainsPsOutputBeforeWaiting())
         #expect(source.validatesCachedDescendantsWithStableIdentity())
@@ -75,7 +75,7 @@ struct ProcessTransportTerminationTests {
         #expect(source.validatesCachedDescendantsBeforeKilling())
         #expect(source.signalsProcessGroupFromTerminationHandler())
         #expect(source.signalsCachedDescendantsFromTerminationHandler())
-        #expect(source.startsDescendantTrackingBeforeSetpgid())
+        #expect(source.attemptsSetpgidBeforeBlockingDescendantSnapshot())
         #expect(source.refreshesDescendantsOnFork())
         #expect(source.drainsPsOutputBeforeWaiting())
         #expect(source.validatesCachedDescendantsWithStableIdentity())
@@ -134,19 +134,19 @@ private extension String {
         contains("eventMask: .fork") && contains("self?.refreshOrphanSet()")
     }
 
-    func startsDescendantTrackingBeforeSetpgid() -> Bool {
+    func attemptsSetpgidBeforeBlockingDescendantSnapshot() -> Bool {
         guard let run = range(of: "try process.run()"),
-              let observer = range(of: "startDescendantForkObserver(for: process.processIdentifier)",
-                                   range: run.upperBound..<endIndex),
-              let refresh = range(of: "refreshOrphanSet()", range: observer.upperBound..<endIndex),
               let setpgid = range(of: "setpgid(process.processIdentifier", range: run.upperBound..<endIndex),
+              let observer = range(of: "startDescendantForkObserver(for: process.processIdentifier)",
+                                   range: setpgid.upperBound..<endIndex),
+              let refresh = range(of: "refreshOrphanSet()", range: observer.upperBound..<endIndex),
               let tracker = range(of: "startDescendantTracker()", range: setpgid.upperBound..<endIndex) else {
             return false
         }
-        return run.lowerBound < observer.lowerBound &&
+        return run.lowerBound < setpgid.lowerBound &&
+            setpgid.lowerBound < observer.lowerBound &&
             observer.lowerBound < refresh.lowerBound &&
-            refresh.lowerBound < setpgid.lowerBound &&
-            setpgid.lowerBound < tracker.lowerBound
+            refresh.lowerBound < tracker.lowerBound
     }
 
     func drainsPsOutputBeforeWaiting() -> Bool {

--- a/AlasTests/Code/LSP/LSPTransportTests.swift
+++ b/AlasTests/Code/LSP/LSPTransportTests.swift
@@ -61,6 +61,7 @@ struct ProcessTransportTerminationTests {
         #expect(source.refreshesDescendantsOnFork())
         #expect(source.drainsPsOutputBeforeWaiting())
         #expect(source.validatesCachedDescendantsWithStableIdentity())
+        #expect(source.checksRootExitBeforeTrackerRefresh())
     }
 
     @Test("JSONRPCStdioTransport snapshots live descendants before signaling root")
@@ -74,6 +75,7 @@ struct ProcessTransportTerminationTests {
         #expect(source.refreshesDescendantsOnFork())
         #expect(source.drainsPsOutputBeforeWaiting())
         #expect(source.validatesCachedDescendantsWithStableIdentity())
+        #expect(source.checksRootExitBeforeTrackerRefresh())
     }
 
     private func source(named path: String) throws -> String {
@@ -158,5 +160,14 @@ private extension String {
             contains("current.pgid == key.pgid") &&
             contains("current.startedAt == key.startedAt") &&
             contains("current.command == key.command")
+    }
+
+    func checksRootExitBeforeTrackerRefresh() -> Bool {
+        guard let tracker = range(of: "private func startDescendantTracker()"),
+              let refresh = range(of: "self.refreshOrphanSet()", range: tracker.upperBound..<endIndex),
+              let rootExited = range(of: "let shouldStop = self.rootHasExited", range: tracker.upperBound..<endIndex) else {
+            return false
+        }
+        return rootExited.lowerBound < refresh.lowerBound
     }
 }

--- a/AlasTests/Code/LSP/LSPTransportTests.swift
+++ b/AlasTests/Code/LSP/LSPTransportTests.swift
@@ -57,6 +57,7 @@ struct ProcessTransportTerminationTests {
         #expect(source.validatesCachedDescendantsBeforeKilling())
         #expect(source.signalsProcessGroupFromTerminationHandler())
         #expect(source.signalsCachedDescendantsFromTerminationHandler())
+        #expect(source.startsDescendantTrackingBeforeSetpgid())
         #expect(source.refreshesDescendantsOnFork())
         #expect(source.drainsPsOutputBeforeWaiting())
     }
@@ -68,6 +69,7 @@ struct ProcessTransportTerminationTests {
         #expect(source.validatesCachedDescendantsBeforeKilling())
         #expect(source.signalsProcessGroupFromTerminationHandler())
         #expect(source.signalsCachedDescendantsFromTerminationHandler())
+        #expect(source.startsDescendantTrackingBeforeSetpgid())
         #expect(source.refreshesDescendantsOnFork())
         #expect(source.drainsPsOutputBeforeWaiting())
     }
@@ -118,6 +120,20 @@ private extension String {
 
     func refreshesDescendantsOnFork() -> Bool {
         contains("eventMask: .fork") && contains("self?.refreshOrphanSet()")
+    }
+
+    func startsDescendantTrackingBeforeSetpgid() -> Bool {
+        guard let run = range(of: "try process.run()"),
+              let observer = range(of: "startDescendantForkObserver()", range: run.upperBound..<endIndex),
+              let refresh = range(of: "refreshOrphanSet()", range: observer.upperBound..<endIndex),
+              let setpgid = range(of: "setpgid(process.processIdentifier", range: run.upperBound..<endIndex),
+              let tracker = range(of: "startDescendantTracker()", range: setpgid.upperBound..<endIndex) else {
+            return false
+        }
+        return run.lowerBound < observer.lowerBound &&
+            observer.lowerBound < refresh.lowerBound &&
+            refresh.lowerBound < setpgid.lowerBound &&
+            setpgid.lowerBound < tracker.lowerBound
     }
 
     func drainsPsOutputBeforeWaiting() -> Bool {

--- a/AlasTests/Code/LSP/LSPTransportTests.swift
+++ b/AlasTests/Code/LSP/LSPTransportTests.swift
@@ -60,6 +60,7 @@ struct ProcessTransportTerminationTests {
         #expect(source.startsDescendantTrackingBeforeSetpgid())
         #expect(source.refreshesDescendantsOnFork())
         #expect(source.drainsPsOutputBeforeWaiting())
+        #expect(source.validatesCachedDescendantsWithStableIdentity())
     }
 
     @Test("JSONRPCStdioTransport snapshots live descendants before signaling root")
@@ -72,6 +73,7 @@ struct ProcessTransportTerminationTests {
         #expect(source.startsDescendantTrackingBeforeSetpgid())
         #expect(source.refreshesDescendantsOnFork())
         #expect(source.drainsPsOutputBeforeWaiting())
+        #expect(source.validatesCachedDescendantsWithStableIdentity())
     }
 
     private func source(named path: String) throws -> String {
@@ -146,5 +148,15 @@ private extension String {
             return false
         }
         return read.lowerBound < wait.lowerBound
+    }
+
+    func validatesCachedDescendantsWithStableIdentity() -> Bool {
+        contains("let pgid: pid_t") &&
+            contains("let startedAt: String") &&
+            contains(#""pid=,ppid=,pgid=,lstart=,comm=""#) &&
+            contains(#""pgid=,lstart=,comm=""#) &&
+            contains("current.pgid == key.pgid") &&
+            contains("current.startedAt == key.startedAt") &&
+            contains("current.command == key.command")
     }
 }

--- a/AlasTests/Code/LSP/LSPTransportTests.swift
+++ b/AlasTests/Code/LSP/LSPTransportTests.swift
@@ -56,6 +56,7 @@ struct ProcessTransportTerminationTests {
         #expect(source.requiresLiveDescendantSnapshotBeforeRootSignal())
         #expect(source.validatesCachedDescendantsBeforeKilling())
         #expect(source.signalsProcessGroupFromTerminationHandler())
+        #expect(source.refreshesDescendantsOnFork())
     }
 
     @Test("JSONRPCStdioTransport snapshots live descendants before signaling root")
@@ -64,6 +65,7 @@ struct ProcessTransportTerminationTests {
         #expect(source.requiresLiveDescendantSnapshotBeforeRootSignal())
         #expect(source.validatesCachedDescendantsBeforeKilling())
         #expect(source.signalsProcessGroupFromTerminationHandler())
+        #expect(source.refreshesDescendantsOnFork())
     }
 
     private func source(named path: String) throws -> String {
@@ -96,5 +98,9 @@ private extension String {
             return false
         }
         return handler.lowerBound < groupSignal.lowerBound && groupSignal.lowerBound < rootExited.lowerBound
+    }
+
+    func refreshesDescendantsOnFork() -> Bool {
+        contains("eventMask: .fork") && contains("self?.refreshOrphanSet()")
     }
 }

--- a/AlasTests/Code/LSP/LSPTransportTests.swift
+++ b/AlasTests/Code/LSP/LSPTransportTests.swift
@@ -58,6 +58,7 @@ struct ProcessTransportTerminationTests {
         #expect(source.signalsProcessGroupFromTerminationHandler())
         #expect(source.signalsCachedDescendantsFromTerminationHandler())
         #expect(source.refreshesDescendantsOnFork())
+        #expect(source.drainsPsOutputBeforeWaiting())
     }
 
     @Test("JSONRPCStdioTransport snapshots live descendants before signaling root")
@@ -68,6 +69,7 @@ struct ProcessTransportTerminationTests {
         #expect(source.signalsProcessGroupFromTerminationHandler())
         #expect(source.signalsCachedDescendantsFromTerminationHandler())
         #expect(source.refreshesDescendantsOnFork())
+        #expect(source.drainsPsOutputBeforeWaiting())
     }
 
     private func source(named path: String) throws -> String {
@@ -116,5 +118,17 @@ private extension String {
 
     func refreshesDescendantsOnFork() -> Bool {
         contains("eventMask: .fork") && contains("self?.refreshOrphanSet()")
+    }
+
+    func drainsPsOutputBeforeWaiting() -> Bool {
+        guard let collect = range(of: "private static func collectDescendants"),
+              let read = range(
+                  of: "data = pipe.fileHandleForReading.readDataToEndOfFile()",
+                  range: collect.upperBound..<endIndex
+              ),
+              let wait = range(of: "proc.waitUntilExit()", range: collect.upperBound..<endIndex) else {
+            return false
+        }
+        return read.lowerBound < wait.lowerBound
     }
 }

--- a/AlasTests/Code/LSP/LSPTransportTests.swift
+++ b/AlasTests/Code/LSP/LSPTransportTests.swift
@@ -63,6 +63,8 @@ struct ProcessTransportTerminationTests {
         #expect(source.validatesCachedDescendantsWithStableIdentity())
         #expect(source.checksRootExitBeforeTrackerRefresh())
         #expect(source.prunesCachedDescendantsWithBatchedLookup())
+        #expect(source.tracksForksFromObservedDescendants())
+        #expect(source.mergesDescendantRefreshesWithoutOverwritingCache())
     }
 
     @Test("JSONRPCStdioTransport snapshots live descendants before signaling root")
@@ -78,6 +80,8 @@ struct ProcessTransportTerminationTests {
         #expect(source.validatesCachedDescendantsWithStableIdentity())
         #expect(source.checksRootExitBeforeTrackerRefresh())
         #expect(source.prunesCachedDescendantsWithBatchedLookup())
+        #expect(source.tracksForksFromObservedDescendants())
+        #expect(source.mergesDescendantRefreshesWithoutOverwritingCache())
     }
 
     private func source(named path: String) throws -> String {
@@ -130,7 +134,8 @@ private extension String {
 
     func startsDescendantTrackingBeforeSetpgid() -> Bool {
         guard let run = range(of: "try process.run()"),
-              let observer = range(of: "startDescendantForkObserver()", range: run.upperBound..<endIndex),
+              let observer = range(of: "startDescendantForkObserver(for: process.processIdentifier)",
+                                   range: run.upperBound..<endIndex),
               let refresh = range(of: "refreshOrphanSet()", range: observer.upperBound..<endIndex),
               let setpgid = range(of: "setpgid(process.processIdentifier", range: run.upperBound..<endIndex),
               let tracker = range(of: "startDescendantTracker()", range: setpgid.upperBound..<endIndex) else {
@@ -175,7 +180,27 @@ private extension String {
     func prunesCachedDescendantsWithBatchedLookup() -> Bool {
         contains("private static func currentlyMatching(_ keys: Set<DescendantKey>) -> Set<DescendantKey>") &&
             contains("let retained = Self.currentlyMatching(cached)") &&
-            contains("orphanedDescendants = retained.union(live)") &&
+            contains("orphanedDescendants.subtract(cached.subtracting(retained))") &&
+            contains("orphanedDescendants.formUnion(live)") &&
             contains("for d in Self.currentlyMatching(targets)")
+    }
+
+    func tracksForksFromObservedDescendants() -> Bool {
+        contains("private var descendantForkSources: [pid_t: DispatchSourceProcess] = [:]") &&
+            contains("private func startDescendantForkObserver(for pid: pid_t)") &&
+            contains("for pid in descendants.map(\\.pid)") &&
+            contains("startDescendantForkObserver(for: pid)")
+    }
+
+    func mergesDescendantRefreshesWithoutOverwritingCache() -> Bool {
+        guard let retained = range(of: "let retained = Self.currentlyMatching(cached)"),
+              let subtract = range(of: "orphanedDescendants.subtract(cached.subtracting(retained))",
+                                   range: retained.upperBound..<endIndex),
+              let union = range(of: "orphanedDescendants.formUnion(live)",
+                                range: retained.upperBound..<endIndex) else {
+            return false
+        }
+        return retained.lowerBound < subtract.lowerBound &&
+            subtract.lowerBound < union.lowerBound
     }
 }

--- a/AlasTests/Code/LSP/LSPTransportTests.swift
+++ b/AlasTests/Code/LSP/LSPTransportTests.swift
@@ -56,6 +56,7 @@ struct ProcessTransportTerminationTests {
         #expect(source.requiresLiveDescendantSnapshotBeforeRootSignal())
         #expect(source.validatesCachedDescendantsBeforeKilling())
         #expect(source.signalsProcessGroupFromTerminationHandler())
+        #expect(source.signalsCachedDescendantsFromTerminationHandler())
         #expect(source.refreshesDescendantsOnFork())
     }
 
@@ -65,6 +66,7 @@ struct ProcessTransportTerminationTests {
         #expect(source.requiresLiveDescendantSnapshotBeforeRootSignal())
         #expect(source.validatesCachedDescendantsBeforeKilling())
         #expect(source.signalsProcessGroupFromTerminationHandler())
+        #expect(source.signalsCachedDescendantsFromTerminationHandler())
         #expect(source.refreshesDescendantsOnFork())
     }
 
@@ -98,6 +100,18 @@ private extension String {
             return false
         }
         return handler.lowerBound < groupSignal.lowerBound && groupSignal.lowerBound < rootExited.lowerBound
+    }
+
+    func signalsCachedDescendantsFromTerminationHandler() -> Bool {
+        guard let handler = range(of: "process.terminationHandler"),
+              let cachedTargets = range(of: "let cachedTargets = self.orphanedDescendants"),
+              let cachedSignal = range(of: "for d in cachedTargets where Self.pidStillMatches(d)"),
+              let finish = range(of: "self.continuation?.finish()") else {
+            return false
+        }
+        return handler.lowerBound < cachedTargets.lowerBound &&
+            cachedTargets.lowerBound < cachedSignal.lowerBound &&
+            cachedSignal.lowerBound < finish.lowerBound
     }
 
     func refreshesDescendantsOnFork() -> Bool {

--- a/AlasTests/Code/LSP/LSPTransportTests.swift
+++ b/AlasTests/Code/LSP/LSPTransportTests.swift
@@ -65,6 +65,7 @@ struct ProcessTransportTerminationTests {
         #expect(source.prunesCachedDescendantsWithBatchedLookup())
         #expect(source.tracksForksFromObservedDescendants())
         #expect(source.mergesDescendantRefreshesWithoutOverwritingCache())
+        #expect(source.preservesCachedDescendantsAcrossExec())
     }
 
     @Test("JSONRPCStdioTransport snapshots live descendants before signaling root")
@@ -82,6 +83,7 @@ struct ProcessTransportTerminationTests {
         #expect(source.prunesCachedDescendantsWithBatchedLookup())
         #expect(source.tracksForksFromObservedDescendants())
         #expect(source.mergesDescendantRefreshesWithoutOverwritingCache())
+        #expect(source.preservesCachedDescendantsAcrossExec())
     }
 
     private func source(named path: String) throws -> String {
@@ -161,10 +163,9 @@ private extension String {
 
     func validatesCachedDescendantsWithStableIdentity() -> Bool {
             contains("let startedAt: String") &&
-            contains(#""pid=,ppid=,lstart=,comm=""#) &&
-            contains(#""pid=,lstart=,comm=""#) &&
+            contains(#""pid=,ppid=,lstart=""#) &&
+            contains(#""pid=,lstart=""#) &&
             !contains("current.pgid == key.pgid") &&
-            contains("startedAt: parts[1...5].joined(separator: \" \")") &&
             contains("return current.intersection(keys)")
     }
 
@@ -202,5 +203,13 @@ private extension String {
         }
         return retained.lowerBound < subtract.lowerBound &&
             subtract.lowerBound < union.lowerBound
+    }
+
+    func preservesCachedDescendantsAcrossExec() -> Bool {
+        contains("while still surviving exec, where `comm` can legitimately change") &&
+            !contains("let command: String") &&
+            !contains(#""comm=""#) &&
+            contains("let startedAt = parts[2...6].joined(separator: \" \")") &&
+            contains("startedAt: parts[1...5].joined(separator: \" \")")
     }
 }

--- a/AlasTests/Code/LSP/LSPTransportTests.swift
+++ b/AlasTests/Code/LSP/LSPTransportTests.swift
@@ -66,6 +66,7 @@ struct ProcessTransportTerminationTests {
         #expect(source.tracksForksFromObservedDescendants())
         #expect(source.mergesDescendantRefreshesWithoutOverwritingCache())
         #expect(source.preservesCachedDescendantsAcrossExec())
+        #expect(source.serializesRootExitWithDescendantRefresh())
     }
 
     @Test("JSONRPCStdioTransport snapshots live descendants before signaling root")
@@ -84,6 +85,7 @@ struct ProcessTransportTerminationTests {
         #expect(source.tracksForksFromObservedDescendants())
         #expect(source.mergesDescendantRefreshesWithoutOverwritingCache())
         #expect(source.preservesCachedDescendantsAcrossExec())
+        #expect(source.serializesRootExitWithDescendantRefresh())
     }
 
     private func source(named path: String) throws -> String {
@@ -211,5 +213,22 @@ private extension String {
             !contains(#""comm=""#) &&
             contains("let startedAt = parts[2...6].joined(separator: \" \")") &&
             contains("startedAt: parts[1...5].joined(separator: \" \")")
+    }
+
+    func serializesRootExitWithDescendantRefresh() -> Bool {
+        guard let refreshLock = range(of: "private let refreshLock = NSLock()"),
+              let handler = range(of: "process.terminationHandler"),
+              let handlerRefreshLock = range(of: "self.refreshLock.lock()", range: handler.upperBound..<endIndex),
+              let cachedTargets = range(of: "let cachedTargets = self.orphanedDescendants",
+                                        range: handlerRefreshLock.upperBound..<endIndex),
+              let refresh = range(of: "private func refreshOrphanSet()"),
+              let refreshRefreshLock = range(of: "refreshLock.lock()", range: refresh.upperBound..<endIndex),
+              let union = range(of: "orphanedDescendants.formUnion(live)", range: refreshRefreshLock.upperBound..<endIndex) else {
+            return false
+        }
+        return refreshLock.lowerBound < handler.lowerBound &&
+            handlerRefreshLock.lowerBound < cachedTargets.lowerBound &&
+            refreshRefreshLock.lowerBound < union.lowerBound &&
+            !contains("if !rootHasExited {\n            orphanedDescendants.subtract")
     }
 }


### PR DESCRIPTION
Ensure transports signal the whole process group so nested tool
processes exit cleanly when their root process does not forward SIGTERM.
Guard against stale pid reuse after the root process has already exited.