### PR TITLE
fix(diff): pane layout invalidation

### DIFF
--- a/Alas/Sources/Center/Diff/DiffPaneTextDocumentView.swift
+++ b/Alas/Sources/Center/Diff/DiffPaneTextDocumentView.swift
@@ -140,6 +140,7 @@ final class DiffPaneTextDocumentContainerView: NSView {
     private var measuredHeight: CGFloat = 0
     private var lastUpdateSignature: UpdateSignature?
     private var lastRowsUpdateSignature: RowsUpdateSignature?
+    private var pendingIntrinsicContentSizeInvalidation = false
 
     private let dividerWidth: CGFloat = 1
 
@@ -273,13 +274,26 @@ final class DiffPaneTextDocumentContainerView: NSView {
     override func layout() {
         super.layout()
         updateVisibility()
+        let previousMeasuredHeight = measuredHeight
         switch layoutMode {
         case .split:
             layoutSplit()
         case .stacked:
             layoutStacked()
         }
-        invalidateIntrinsicContentSize()
+        if abs(measuredHeight - previousMeasuredHeight) > 0.5 {
+            invalidateIntrinsicContentSizeAfterLayout()
+        }
+    }
+
+    private func invalidateIntrinsicContentSizeAfterLayout() {
+        guard !pendingIntrinsicContentSizeInvalidation else { return }
+        pendingIntrinsicContentSizeInvalidation = true
+        DispatchQueue.main.async { [weak self] in
+            guard let self else { return }
+            pendingIntrinsicContentSizeInvalidation = false
+            invalidateIntrinsicContentSize()
+        }
     }
 
     private func layoutSplit() {

--- a/AlasTests/DiffPaneViewTests.swift
+++ b/AlasTests/DiffPaneViewTests.swift
@@ -1882,6 +1882,31 @@ let second = true
         #expect(nsView.intrinsicContentSize.height > 0)
     }
 
+    @Test func containerViewLayoutDoesNotInvalidateAncestorConstraints() throws {
+        let rows = Array(try #require(model().groups.first).rows)
+        let theme = theme()
+        let font = CenterTypography.resolveCodeFont(family: "", size: 13)
+        let parent = ConstraintInvalidationCountingView(frame: NSRect(x: 0, y: 0, width: 800, height: 400))
+        let nsView = DiffPaneTextDocumentContainerView(frame: parent.bounds)
+        parent.addSubview(nsView)
+
+        nsView.update(
+            rows: rows,
+            layoutMode: .split,
+            wrapLines: false,
+            showWhitespace: false,
+            fileExtension: "swift",
+            font: font,
+            theme: theme,
+            lspContext: nil
+        )
+        parent.constraintInvalidationCount = 0
+
+        nsView.layout()
+
+        #expect(parent.constraintInvalidationCount == 0)
+    }
+
     @Test func diffPaneSegmentViewHostsContainerViewWithoutCrashing() throws {
         let rows = Array(try #require(model().groups.first).rows)
         let theme = theme()
@@ -2073,6 +2098,17 @@ let second = true
 
     private func allSubviews(of view: NSView) -> [NSView] {
         view.subviews + view.subviews.flatMap { allSubviews(of: $0) }
+    }
+
+    private final class ConstraintInvalidationCountingView: NSView {
+        var constraintInvalidationCount = 0
+
+        override var needsUpdateConstraints: Bool {
+            didSet {
+                guard needsUpdateConstraints else { return }
+                constraintInvalidationCount += 1
+            }
+        }
     }
 
     private func subview(withAccessibilityIdentifier identifier: String, in view: NSView) -> NSView? {


### PR DESCRIPTION
## Summary

Fixes a diff pane layout invalidation loop/crash by avoiding synchronous intrinsic-size invalidation from inside `DiffPaneTextDocumentContainerView.layout()`.

The container now only invalidates intrinsic content size after layout when the measured height changes materially, and coalesces that invalidation onto the next main-queue turn. This avoids re-entering SwiftUI/AppKit constraint updates during an active AppKit layout pass.

Adds a regression test covering layout-time ancestor constraint invalidation.

## Validation

- `xcodegen`
- `ALAS_FFF_TARGET_ARCH=arm64 xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS,arch=arm64' -only-testing:AlasTests/DiffPaneViewTests/containerViewLayoutDoesNotInvalidateAncestorConstraints test`
- `ALAS_FFF_TARGET_ARCH=arm64 xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS,arch=arm64' -quiet build`

The repo's unqualified `platform=macOS` build/test commands attempted the x86_64 `fff` Rust slice locally and failed before Swift compilation with missing Rust `core/std` for `x86_64-apple-darwin`.