### PR TITLE
fix(files): stop compacted directory rows blinking on refresh

### DIFF
--- a/Alas/Sources/Right/FilesTabView.swift
+++ b/Alas/Sources/Right/FilesTabView.swift
@@ -135,9 +135,15 @@ struct FilesTabView: View {
                         }
                         .contentShape(Rectangle())
                         .background(chain.chainPaths.contains(revealPath ?? "") ? theme.color("bg-hover") : Color.clear)
-                        .id("dir:\(terminal.path)")
+                        // Key the row on the chain's root (stable) rather than its
+                        // terminal, which moves deeper as levels load. A stable id
+                        // lets SwiftUI update the label in place while the chain
+                        // compacts instead of tearing the row down and rebuilding
+                        // it (a visible flash). Remaining chain paths get zero-size
+                        // anchors so scroll-to-reveal still works for any of them.
+                        .id("dir:\(node.path)")
                         .overlay(alignment: .top) {
-                            ForEach(chain.chainPaths.dropLast(), id: \.self) { p in
+                            ForEach(chain.chainPaths.dropFirst(), id: \.self) { p in
                                 Color.clear.frame(width: 0, height: 0).id("dir:\(p)")
                             }
                         }

--- a/Alas/Sources/Right/RightPaneState.swift
+++ b/Alas/Sources/Right/RightPaneState.swift
@@ -763,18 +763,22 @@ final class RightPaneState {
         }
     }
 
-    /// Rebuilds the child list of the directory at `path` from a fresh
-    /// filesystem listing, dropping entries that no longer exist. Used when
-    /// reconciling an already-loaded directory on refresh.
+    /// Reconciles the child list of the directory at `path` against a fresh
+    /// listing from `GitService.fileTreeChildren`. Used when re-loading an
+    /// already-loaded directory on refresh.
     ///
-    /// Unlike `mergingChildren`, which seeds from the existing children and
-    /// overlays incoming entries (so deletions/renames linger), this iterates
-    /// the fresh listing as the source of truth for what exists — but still
-    /// carries over each surviving entry's status metadata (badge, visibility,
-    /// submodule flag) and any already-loaded subtree from the existing node.
-    /// `GitService.fileTreeChildren` returns children with `badges: [:]` and a
-    /// `.tracked` default, so taking them verbatim would erase `M`/`A` badges
-    /// and untracked/ignored visibility until the next full refresh.
+    /// `mergingChildren` seeds from the existing children and only overlays
+    /// incoming entries, so deletions/renames linger. This instead treats the
+    /// listing as authoritative for what exists on disk and prunes entries that
+    /// are gone — but only when they are *filesystem*-authoritative (ignored or
+    /// excluded, with no git badge). Git-authoritative entries are kept even
+    /// when the listing omits them, because `fileTreeChildren` is a filesystem
+    /// scan and cannot represent them:
+    ///   - a tracked file deleted from disk still appears in the full tree with
+    ///     a `D` badge and must remain selectable;
+    ///   - surviving entries keep their badge, visibility, submodule flag, and
+    ///     any already-loaded subtree, since the listing has `badges: [:]` and a
+    ///     `.tracked` default that would otherwise erase that metadata.
     nonisolated static func replacingChildren(
         in nodes: [FileTreeNode],
         for path: String,
@@ -788,7 +792,8 @@ final class RightPaneState {
                 var updated = node
                 var existingByID: [String: FileTreeNode] = [:]
                 for child in node.children ?? [] { existingByID[child.id] = child }
-                updated.children = children.map { incoming -> FileTreeNode in
+                let incomingIDs = Set(children.map(\.id))
+                var reconciled = children.map { incoming -> FileTreeNode in
                     guard let existing = existingByID[incoming.id] else { return incoming }
                     var refreshed = incoming
                     refreshed.badge = incoming.badge ?? existing.badge
@@ -799,7 +804,19 @@ final class RightPaneState {
                         refreshed.children = existing.children
                     }
                     return refreshed
-                }.sorted { lhs, rhs in
+                }
+                // Keep git-authoritative entries the filesystem listing can't
+                // show (e.g. tracked deletions); drop only ignored/excluded
+                // entries with no badge that are actually gone from disk.
+                let keptDeletions = (node.children ?? []).filter { existing in
+                    guard !incomingIDs.contains(existing.id) else { return false }
+                    let filesystemAuthoritative =
+                        (existing.visibility == .ignored || existing.visibility == .excluded)
+                        && existing.badge == nil
+                    return !filesystemAuthoritative
+                }
+                reconciled.append(contentsOf: keptDeletions)
+                updated.children = reconciled.sorted { lhs, rhs in
                     if lhs.kind != rhs.kind { return lhs.kind == .dir }
                     return lhs.name.localizedStandardCompare(rhs.name) == .orderedAscending
                 }

--- a/Alas/Sources/Right/RightPaneState.swift
+++ b/Alas/Sources/Right/RightPaneState.swift
@@ -763,6 +763,44 @@ final class RightPaneState {
         }
     }
 
+    /// Rebuilds the child list of the directory at `path` from a fresh
+    /// filesystem listing, dropping entries that no longer exist while carrying
+    /// over any deeper lazy subtrees the user had already expanded (via
+    /// `preservingLazyChildren`). Used when reconciling an already-loaded lazy
+    /// directory on refresh: unlike `mergingChildren`, which only overlays
+    /// incoming entries onto the existing ones, this prunes deletions/renames so
+    /// the tree matches the directory's actual contents.
+    nonisolated static func replacingChildren(
+        in nodes: [FileTreeNode],
+        for path: String,
+        with children: [FileTreeNode],
+        state: DirectoryChildrenState
+    ) -> (nodes: [FileTreeNode], didMerge: Bool) {
+        var didMerge = false
+        let updatedNodes = nodes.map { node -> FileTreeNode in
+            if node.path == path {
+                didMerge = true
+                var updated = node
+                updated.children = preservingLazyChildren(
+                    fresh: children,
+                    previous: node.children ?? []
+                ).sorted { lhs, rhs in
+                    if lhs.kind != rhs.kind { return lhs.kind == .dir }
+                    return lhs.name.localizedStandardCompare(rhs.name) == .orderedAscending
+                }
+                updated.childrenState = state
+                return updated
+            }
+            guard let existing = node.children else { return node }
+            var updated = node
+            let result = replacingChildren(in: existing, for: path, with: children, state: state)
+            didMerge = didMerge || result.didMerge
+            updated.children = result.nodes
+            return updated
+        }
+        return (updatedNodes, didMerge)
+    }
+
     nonisolated static func fileTreeNode(at path: String, in nodes: [FileTreeNode]) -> FileTreeNode? {
         for node in nodes {
             if node.path == path { return node }
@@ -826,7 +864,15 @@ final class RightPaneState {
             do {
                 let children = try await git.fileTreeChildren(worktreePath: worktree.path, path: path)
                 guard self.fileTreeGeneration == generation else { return }
-                let result = Self.mergingChildren(in: self.fileTree, for: path, with: children, state: .loaded)
+                // On the first load, merge so concurrent per-level loads (e.g. the
+                // reveal flow expanding several ancestors at once) accumulate.
+                // When reconciling an already-loaded directory, rebuild its child
+                // list from the fresh filesystem listing so deleted/renamed
+                // entries drop out — `mergingChildren` only overlays and would
+                // leave stale children behind.
+                let result = alreadyLoaded
+                    ? Self.replacingChildren(in: self.fileTree, for: path, with: children, state: .loaded)
+                    : Self.mergingChildren(in: self.fileTree, for: path, with: children, state: .loaded)
                 guard result.didMerge else { return }
                 self.loadedFileTreeChildPaths.insert(path)
                 self.failedFileTreeChildPaths.remove(path)

--- a/Alas/Sources/Right/RightPaneState.swift
+++ b/Alas/Sources/Right/RightPaneState.swift
@@ -764,12 +764,17 @@ final class RightPaneState {
     }
 
     /// Rebuilds the child list of the directory at `path` from a fresh
-    /// filesystem listing, dropping entries that no longer exist while carrying
-    /// over any deeper lazy subtrees the user had already expanded (via
-    /// `preservingLazyChildren`). Used when reconciling an already-loaded lazy
-    /// directory on refresh: unlike `mergingChildren`, which only overlays
-    /// incoming entries onto the existing ones, this prunes deletions/renames so
-    /// the tree matches the directory's actual contents.
+    /// filesystem listing, dropping entries that no longer exist. Used when
+    /// reconciling an already-loaded directory on refresh.
+    ///
+    /// Unlike `mergingChildren`, which seeds from the existing children and
+    /// overlays incoming entries (so deletions/renames linger), this iterates
+    /// the fresh listing as the source of truth for what exists — but still
+    /// carries over each surviving entry's status metadata (badge, visibility,
+    /// submodule flag) and any already-loaded subtree from the existing node.
+    /// `GitService.fileTreeChildren` returns children with `badges: [:]` and a
+    /// `.tracked` default, so taking them verbatim would erase `M`/`A` badges
+    /// and untracked/ignored visibility until the next full refresh.
     nonisolated static func replacingChildren(
         in nodes: [FileTreeNode],
         for path: String,
@@ -781,10 +786,20 @@ final class RightPaneState {
             if node.path == path {
                 didMerge = true
                 var updated = node
-                updated.children = preservingLazyChildren(
-                    fresh: children,
-                    previous: node.children ?? []
-                ).sorted { lhs, rhs in
+                var existingByID: [String: FileTreeNode] = [:]
+                for child in node.children ?? [] { existingByID[child.id] = child }
+                updated.children = children.map { incoming -> FileTreeNode in
+                    guard let existing = existingByID[incoming.id] else { return incoming }
+                    var refreshed = incoming
+                    refreshed.badge = incoming.badge ?? existing.badge
+                    refreshed.visibility = mergedVisibility(existing: existing.visibility, incoming: incoming.visibility)
+                    refreshed.isSubmodule = incoming.isSubmodule || existing.isSubmodule
+                    refreshed.childrenState = mergedChildrenState(existing: existing.childrenState, incoming: incoming.childrenState)
+                    if refreshed.children == nil {
+                        refreshed.children = existing.children
+                    }
+                    return refreshed
+                }.sorted { lhs, rhs in
                     if lhs.kind != rhs.kind { return lhs.kind == .dir }
                     return lhs.name.localizedStandardCompare(rhs.name) == .orderedAscending
                 }

--- a/Alas/Sources/Right/RightPaneState.swift
+++ b/Alas/Sources/Right/RightPaneState.swift
@@ -470,7 +470,7 @@ final class RightPaneState {
             self.stashes = stashes
             self.changesGeneration += 1
             self.indexFingerprint = indexFingerprint
-            self.fileTree = tree
+            self.fileTree = Self.preservingLazyChildren(fresh: tree, previous: self.fileTree)
             self.commits = commits
             self.comparisonRef = ref
             let preferredCommitRemoteRef = ref ?? baseBranch
@@ -723,6 +723,57 @@ final class RightPaneState {
         }
     }
 
+    /// Carries previously loaded lazy-directory subtrees from `previous` into a
+    /// freshly rebuilt `fresh` tree.
+    ///
+    /// `GitService.fileTree` rebuilds lazily-loaded directories (ignored or
+    /// excluded roots, and anything expanded on demand) as `.notLoaded` with no
+    /// children. Assigning that tree verbatim on refresh collapses any directory
+    /// the user had already expanded — it briefly renders the uncompacted tree,
+    /// re-loads it level by level, and re-collapses (the "blink"). Grafting the
+    /// prior subtree keeps the expanded, compacted state stable across refreshes;
+    /// contents are still reconciled in the background by `loadFileTreeChildren`.
+    nonisolated static func preservingLazyChildren(
+        fresh: [FileTreeNode],
+        previous: [FileTreeNode]
+    ) -> [FileTreeNode] {
+        var previousByPath: [String: FileTreeNode] = [:]
+        for node in previous { previousByPath[node.path] = node }
+        return fresh.map { node in
+            var updated = node
+            let prior = previousByPath[node.path]
+            if node.kind == .dir,
+               node.childrenState == .notLoaded,
+               node.children == nil,
+               let prior,
+               prior.kind == .dir,
+               prior.childrenState == .loaded,
+               let priorChildren = prior.children {
+                updated.childrenState = .loaded
+                updated.children = priorChildren
+                return updated
+            }
+            if let children = node.children {
+                updated.children = preservingLazyChildren(
+                    fresh: children,
+                    previous: prior?.children ?? []
+                )
+            }
+            return updated
+        }
+    }
+
+    nonisolated static func fileTreeNode(at path: String, in nodes: [FileTreeNode]) -> FileTreeNode? {
+        for node in nodes {
+            if node.path == path { return node }
+            if let children = node.children,
+               let found = fileTreeNode(at: path, in: children) {
+                return found
+            }
+        }
+        return nil
+    }
+
     nonisolated static func shouldAutoLoadFileTreeChildren(
         path: String,
         childrenState: DirectoryChildrenState,
@@ -750,12 +801,21 @@ final class RightPaneState {
         guard !loadedFileTreeChildPaths.contains(path),
               !loadingFileTreeChildPaths.contains(path) else { return }
         loadingFileTreeChildPaths.insert(path)
-        let loadingMerge = Self.mergingChildren(in: fileTree, for: path, with: [], state: .loading)
-        guard loadingMerge.didMerge else {
-            loadingFileTreeChildPaths.remove(path)
-            return
+        // A directory whose children were carried over from a previous load
+        // (e.g. across a refresh) is being reconciled, not loaded for the first
+        // time. Flipping it to `.loading` would drop it out of a compacted chain
+        // and make the row visibly collapse and re-expand, so keep it `.loaded`
+        // and refresh its contents in the background instead.
+        let alreadyLoaded = Self.fileTreeNode(at: path, in: fileTree)
+            .map { $0.childrenState == .loaded && $0.children != nil } ?? false
+        if !alreadyLoaded {
+            let loadingMerge = Self.mergingChildren(in: fileTree, for: path, with: [], state: .loading)
+            guard loadingMerge.didMerge else {
+                loadingFileTreeChildPaths.remove(path)
+                return
+            }
+            fileTree = loadingMerge.nodes
         }
-        fileTree = loadingMerge.nodes
         let generation = fileTreeGeneration
         Task { @MainActor in
             defer {

--- a/AlasTests/RightPaneStateFileTreeTests.swift
+++ b/AlasTests/RightPaneStateFileTreeTests.swift
@@ -534,6 +534,73 @@ struct RightPaneStateFileTreeTests {
         #expect(gen?.children?.map(\.path) == ["build/gen/keep.o"])
     }
 
+    @Test func replacingChildrenPreservesStatusMetadataForSurvivingChildren() {
+        // An open, loaded tracked directory with a modified and an untracked
+        // file — the badges/visibility come from the full-tree git status.
+        let tree = [
+            FileTreeNode(
+                name: "Sources",
+                path: "Sources",
+                kind: .dir,
+                children: [
+                    FileTreeNode(
+                        name: "App.swift",
+                        path: "Sources/App.swift",
+                        kind: .file,
+                        children: nil,
+                        badge: "M",
+                        visibility: .tracked,
+                        childrenState: .loaded
+                    ),
+                    FileTreeNode(
+                        name: "New.swift",
+                        path: "Sources/New.swift",
+                        kind: .file,
+                        children: nil,
+                        badge: "A",
+                        visibility: .untracked,
+                        childrenState: .loaded
+                    )
+                ],
+                badge: nil,
+                visibility: .tracked,
+                childrenState: .loaded
+            )
+        ]
+        // A background reconcile from `fileTreeChildren`: no badges, defaults to
+        // `.tracked`.
+        let incoming = [
+            FileTreeNode(
+                name: "App.swift",
+                path: "Sources/App.swift",
+                kind: .file,
+                children: nil,
+                badge: nil,
+                visibility: .tracked,
+                childrenState: .loaded
+            ),
+            FileTreeNode(
+                name: "New.swift",
+                path: "Sources/New.swift",
+                kind: .file,
+                children: nil,
+                badge: nil,
+                visibility: .tracked,
+                childrenState: .loaded
+            )
+        ]
+
+        let result = RightPaneState.replacingChildren(in: tree, for: "Sources", with: incoming, state: .loaded)
+        let sources = result.nodes.first
+        let app = sources?.children?.first { $0.path == "Sources/App.swift" }
+        let new = sources?.children?.first { $0.path == "Sources/New.swift" }
+
+        #expect(result.didMerge)
+        #expect(app?.badge == "M")
+        #expect(new?.badge == "A")
+        #expect(new?.visibility == .untracked)
+    }
+
     @Test func replacingChildrenReportsMissingTargetWithoutMutating() {
         let tree = [
             FileTreeNode(

--- a/AlasTests/RightPaneStateFileTreeTests.swift
+++ b/AlasTests/RightPaneStateFileTreeTests.swift
@@ -457,6 +457,102 @@ struct RightPaneStateFileTreeTests {
         #expect(merged.first?.children == nil)
     }
 
+    @Test func replacingChildrenPrunesDeletedEntriesAndPreservesLoadedSubtrees() {
+        // "build" was expanded: it had a stale file and a nested loaded dir.
+        let tree = [
+            FileTreeNode(
+                name: "build",
+                path: "build",
+                kind: .dir,
+                children: [
+                    FileTreeNode(
+                        name: "old.o",
+                        path: "build/old.o",
+                        kind: .file,
+                        children: nil,
+                        badge: nil,
+                        visibility: .ignored,
+                        childrenState: .loaded
+                    ),
+                    FileTreeNode(
+                        name: "gen",
+                        path: "build/gen",
+                        kind: .dir,
+                        children: [
+                            FileTreeNode(
+                                name: "keep.o",
+                                path: "build/gen/keep.o",
+                                kind: .file,
+                                children: nil,
+                                badge: nil,
+                                visibility: .ignored,
+                                childrenState: .loaded
+                            )
+                        ],
+                        badge: nil,
+                        visibility: .ignored,
+                        childrenState: .loaded
+                    )
+                ],
+                badge: nil,
+                visibility: .ignored,
+                childrenState: .loaded
+            )
+        ]
+        // Fresh filesystem listing: old.o is gone, gen still exists (relisted as
+        // a lazy dir), and new.o appeared.
+        let incoming = [
+            FileTreeNode(
+                name: "gen",
+                path: "build/gen",
+                kind: .dir,
+                children: nil,
+                badge: nil,
+                visibility: .ignored,
+                childrenState: .notLoaded
+            ),
+            FileTreeNode(
+                name: "new.o",
+                path: "build/new.o",
+                kind: .file,
+                children: nil,
+                badge: nil,
+                visibility: .ignored,
+                childrenState: .loaded
+            )
+        ]
+
+        let result = RightPaneState.replacingChildren(in: tree, for: "build", with: incoming, state: .loaded)
+        let build = result.nodes.first
+        let gen = build?.children?.first { $0.path == "build/gen" }
+
+        #expect(result.didMerge)
+        #expect(build?.children?.contains { $0.path == "build/old.o" } == false)
+        #expect(build?.children?.contains { $0.path == "build/new.o" } == true)
+        // Nested expanded subtree survives the reconcile.
+        #expect(gen?.childrenState == .loaded)
+        #expect(gen?.children?.map(\.path) == ["build/gen/keep.o"])
+    }
+
+    @Test func replacingChildrenReportsMissingTargetWithoutMutating() {
+        let tree = [
+            FileTreeNode(
+                name: "build",
+                path: "build",
+                kind: .dir,
+                children: nil,
+                badge: nil,
+                visibility: .ignored,
+                childrenState: .notLoaded
+            )
+        ]
+
+        let result = RightPaneState.replacingChildren(in: tree, for: "missing", with: [], state: .loaded)
+
+        #expect(result.didMerge == false)
+        #expect(result.nodes == tree)
+    }
+
     @Test func fileTreeNodeFindsNestedNodeByPath() {
         let tree = [
             FileTreeNode(

--- a/AlasTests/RightPaneStateFileTreeTests.swift
+++ b/AlasTests/RightPaneStateFileTreeTests.swift
@@ -601,6 +601,62 @@ struct RightPaneStateFileTreeTests {
         #expect(new?.visibility == .untracked)
     }
 
+    @Test func replacingChildrenKeepsTrackedDeletionAbsentFromDiskListing() {
+        // An open tracked directory whose tracked file was deleted from disk:
+        // the full tree still carries the `D` node (from git's cached paths),
+        // but a filesystem listing cannot include it.
+        let tree = [
+            FileTreeNode(
+                name: "Sources",
+                path: "Sources",
+                kind: .dir,
+                children: [
+                    FileTreeNode(
+                        name: "Gone.swift",
+                        path: "Sources/Gone.swift",
+                        kind: .file,
+                        children: nil,
+                        badge: "D",
+                        visibility: .tracked,
+                        childrenState: .loaded
+                    ),
+                    FileTreeNode(
+                        name: "Kept.swift",
+                        path: "Sources/Kept.swift",
+                        kind: .file,
+                        children: nil,
+                        badge: nil,
+                        visibility: .tracked,
+                        childrenState: .loaded
+                    )
+                ],
+                badge: nil,
+                visibility: .tracked,
+                childrenState: .loaded
+            )
+        ]
+        // Filesystem listing only sees the file still on disk.
+        let incoming = [
+            FileTreeNode(
+                name: "Kept.swift",
+                path: "Sources/Kept.swift",
+                kind: .file,
+                children: nil,
+                badge: nil,
+                visibility: .tracked,
+                childrenState: .loaded
+            )
+        ]
+
+        let result = RightPaneState.replacingChildren(in: tree, for: "Sources", with: incoming, state: .loaded)
+        let sources = result.nodes.first
+        let gone = sources?.children?.first { $0.path == "Sources/Gone.swift" }
+
+        #expect(result.didMerge)
+        #expect(gone?.badge == "D")
+        #expect(sources?.children?.contains { $0.path == "Sources/Kept.swift" } == true)
+    }
+
     @Test func replacingChildrenReportsMissingTargetWithoutMutating() {
         let tree = [
             FileTreeNode(

--- a/AlasTests/RightPaneStateFileTreeTests.swift
+++ b/AlasTests/RightPaneStateFileTreeTests.swift
@@ -321,6 +321,180 @@ struct RightPaneStateFileTreeTests {
         #expect(generated?.children == nil)
     }
 
+    @Test func preservingLazyChildrenGraftsPriorSubtreeOntoNotLoadedDirectory() {
+        // Fresh tree rebuilds the lazy directory as `.notLoaded` with no
+        // children, as `GitService.fileTree` does for ignored/excluded roots.
+        let fresh = [
+            FileTreeNode(
+                name: "build",
+                path: "build",
+                kind: .dir,
+                children: nil,
+                badge: nil,
+                visibility: .ignored,
+                childrenState: .notLoaded
+            )
+        ]
+        let previous = [
+            FileTreeNode(
+                name: "build",
+                path: "build",
+                kind: .dir,
+                children: [
+                    FileTreeNode(
+                        name: "out.o",
+                        path: "build/out.o",
+                        kind: .file,
+                        children: nil,
+                        badge: nil,
+                        visibility: .ignored,
+                        childrenState: .loaded
+                    )
+                ],
+                badge: nil,
+                visibility: .ignored,
+                childrenState: .loaded
+            )
+        ]
+
+        let merged = RightPaneState.preservingLazyChildren(fresh: fresh, previous: previous)
+        let build = merged.first
+
+        #expect(build?.childrenState == .loaded)
+        #expect(build?.children?.map(\.path) == ["build/out.o"])
+    }
+
+    @Test func preservingLazyChildrenGraftsNestedLazySubtreeInsideLoadedDirectory() {
+        let fresh = [
+            FileTreeNode(
+                name: "Sources",
+                path: "Sources",
+                kind: .dir,
+                children: [
+                    FileTreeNode(
+                        name: "Generated",
+                        path: "Sources/Generated",
+                        kind: .dir,
+                        children: nil,
+                        badge: nil,
+                        visibility: .ignored,
+                        childrenState: .notLoaded
+                    )
+                ],
+                badge: nil,
+                visibility: .tracked,
+                childrenState: .loaded
+            )
+        ]
+        let previous = [
+            FileTreeNode(
+                name: "Sources",
+                path: "Sources",
+                kind: .dir,
+                children: [
+                    FileTreeNode(
+                        name: "Generated",
+                        path: "Sources/Generated",
+                        kind: .dir,
+                        children: [
+                            FileTreeNode(
+                                name: "cache.log",
+                                path: "Sources/Generated/cache.log",
+                                kind: .file,
+                                children: nil,
+                                badge: nil,
+                                visibility: .ignored,
+                                childrenState: .loaded
+                            )
+                        ],
+                        badge: nil,
+                        visibility: .ignored,
+                        childrenState: .loaded
+                    )
+                ],
+                badge: nil,
+                visibility: .tracked,
+                childrenState: .loaded
+            )
+        ]
+
+        let merged = RightPaneState.preservingLazyChildren(fresh: fresh, previous: previous)
+        let generated = merged.first?.children?.first
+
+        #expect(generated?.childrenState == .loaded)
+        #expect(generated?.children?.map(\.path) == ["Sources/Generated/cache.log"])
+    }
+
+    @Test func preservingLazyChildrenLeavesUnmatchedAndUnloadedDirectoriesUntouched() {
+        let fresh = [
+            FileTreeNode(
+                name: "build",
+                path: "build",
+                kind: .dir,
+                children: nil,
+                badge: nil,
+                visibility: .ignored,
+                childrenState: .notLoaded
+            )
+        ]
+        // Previous never loaded this directory either, so there is nothing to
+        // graft and the fresh node must stay `.notLoaded`.
+        let previous = [
+            FileTreeNode(
+                name: "build",
+                path: "build",
+                kind: .dir,
+                children: nil,
+                badge: nil,
+                visibility: .ignored,
+                childrenState: .notLoaded
+            )
+        ]
+
+        let merged = RightPaneState.preservingLazyChildren(fresh: fresh, previous: previous)
+
+        #expect(merged.first?.childrenState == .notLoaded)
+        #expect(merged.first?.children == nil)
+    }
+
+    @Test func fileTreeNodeFindsNestedNodeByPath() {
+        let tree = [
+            FileTreeNode(
+                name: "Sources",
+                path: "Sources",
+                kind: .dir,
+                children: [
+                    FileTreeNode(
+                        name: "Generated",
+                        path: "Sources/Generated",
+                        kind: .dir,
+                        children: [
+                            FileTreeNode(
+                                name: "cache.log",
+                                path: "Sources/Generated/cache.log",
+                                kind: .file,
+                                children: nil,
+                                badge: nil,
+                                visibility: .ignored,
+                                childrenState: .loaded
+                            )
+                        ],
+                        badge: nil,
+                        visibility: .ignored,
+                        childrenState: .loaded
+                    )
+                ],
+                badge: nil,
+                visibility: .tracked,
+                childrenState: .loaded
+            )
+        ]
+
+        #expect(RightPaneState.fileTreeNode(at: "Sources/Generated", in: tree)?.childrenState == .loaded)
+        #expect(RightPaneState.fileTreeNode(at: "Sources/Generated/cache.log", in: tree)?.kind == .file)
+        #expect(RightPaneState.fileTreeNode(at: "Missing", in: tree) == nil)
+    }
+
     @Test func shouldAutoLoadFileTreeChildrenReconcilesOpenLoadedDirectoriesOnce() {
         #expect(RightPaneState.shouldAutoLoadFileTreeChildren(
             path: "Sources",


### PR DESCRIPTION
## Problem

The Files tab flattens single-child directory chains into one row (e.g. `src/main/test` instead of `src` → `main` → `test`). Lazily-loaded directories — ignored/excluded roots and anything expanded on demand — blinked on every refresh: the row briefly showed the uncompacted tree, then re-collapsed into the flattened row.

## Root cause

Two compounding issues:

1. **Refresh discarded expanded lazy subtrees.** `refresh()` replaced `fileTree` with a freshly built tree where lazy directories come back as `.notLoaded` with no children. Any directory the user had expanded collapsed, and the auto-loader then re-fetched it level by level, visibly re-expanding and re-collapsing — on every FS-watcher refresh, unprompted.

2. **Unstable row identity.** The compacted row's `.id` was keyed on the chain's *terminal* path, which moves deeper as levels load. SwiftUI treats an `.id` change as a new identity, so it tore the row down and rebuilt it on each growth step (a hard flash) instead of updating the label in place.

## Fix

- `preservingLazyChildren` grafts previously loaded lazy subtrees into the freshly built tree on refresh, so expanded/compacted chains stay stable.
- `loadFileTreeChildren` skips the intermediate `.loading` flip when reconciling an already-loaded directory, keeping it in its compacted chain while contents refresh in the background.
- The compacted row is keyed on the stable chain **root** instead of the terminal, with zero-size anchors for the remaining chain paths so scroll-to-reveal still resolves any of them.

## Tests

Added unit tests for `preservingLazyChildren` (graft onto not-loaded dir, graft nested lazy subtree, leave unmatched/unloaded dirs untouched) and `fileTreeNode(at:in:)`. Existing compact-chain, merge, and reveal tests still pass.