### PR TITLE
Disable review controls in commit details

### DIFF
--- a/Alas/Sources/Center/Commit/CommitTabView.swift
+++ b/Alas/Sources/Center/Commit/CommitTabView.swift
@@ -123,12 +123,7 @@ struct CommitTabView: View {
                         codeFontSize: CGFloat(appState.config.code.fontSize),
                         worktreeId: worktreeId,
                         worktreePath: worktreePath,
-                        reviewDraftSessionID: CommitReviewBody.reviewDraftSessionID(
-                            worktreeID: worktreeId,
-                            repositoryPath: worktreePath,
-                            sha: sha
-                        ),
-                        reviewedCommitSHA: sha,
+                        allowsReviewing: false,
                         appState: appState
                     )
                 }
@@ -345,6 +340,7 @@ struct CommitReviewBody: View {
     var worktreePath: URL? = nil
     var reviewDraftSessionID: ReviewDraftSessionID? = nil
     var reviewedCommitSHA: String? = nil
+    var allowsReviewing = true
     var appState: AppState? = nil
 
     @State private var reviewSummaryCollapsed = false
@@ -367,6 +363,7 @@ struct CommitReviewBody: View {
         worktreePath: URL? = nil,
         reviewDraftSessionID: ReviewDraftSessionID? = nil,
         reviewedCommitSHA: String? = nil,
+        allowsReviewing: Bool = true,
         appState: AppState? = nil
     ) {
         self.session = session
@@ -381,6 +378,7 @@ struct CommitReviewBody: View {
         self.worktreePath = worktreePath
         self.reviewDraftSessionID = reviewDraftSessionID
         self.reviewedCommitSHA = reviewedCommitSHA
+        self.allowsReviewing = allowsReviewing
         self.appState = appState
     }
 
@@ -421,16 +419,16 @@ struct CommitReviewBody: View {
             codeFontSize: codeFontSize,
             showsSourceBadges: false,
             showsRailDisplayControls: true,
-            showsDraftSummaryRail: reviewDraftSessionID != nil,
-            allowsDraftCommentCreation: reviewDraftSessionID != nil,
+            showsDraftSummaryRail: effectiveReviewDraftSessionID != nil,
+            allowsDraftCommentCreation: effectiveReviewDraftSessionID != nil,
             lspContextForFile: { file in
                 makeLSPContext(relativePath: file.summary.path)
             },
             reviewFeedbackTarget: reviewFeedbackTarget,
-            draftCommentsByFileID: ReviewDraftCommentGrouping.commentsByFileID(draftCommentController?.comments ?? []),
+            draftCommentsByFileID: effectiveDraftCommentsByFileID,
             focusedDraftCommentID: focusedDraftCommentID,
             draftCommentScrollCommand: draftCommentScrollCommand,
-            draftCommentActions: draftCommentActions(),
+            draftCommentActions: effectiveDraftCommentActions,
             onSelectDraftComment: selectDraftComment,
             onSaveDraftComment: { fileID, originalPath, anchor, body in
                 saveDraftComment(fileID: fileID, originalPath: originalPath, anchor: anchor, body: body)
@@ -446,14 +444,29 @@ struct CommitReviewBody: View {
         .onAppear {
             loadDraftCommentController()
         }
-        .onChange(of: reviewDraftSessionID?.rawValue) { _, _ in
+        .onChange(of: effectiveReviewDraftSessionID?.rawValue) { _, _ in
             loadDraftCommentController()
         }
     }
 
+    private var effectiveReviewDraftSessionID: ReviewDraftSessionID? {
+        allowsReviewing ? reviewDraftSessionID : nil
+    }
+
     private var reviewFeedbackTarget: ReviewFeedbackTarget? {
+        guard allowsReviewing else { return nil }
         guard let worktreePath else { return nil }
         return Self.reviewFeedbackTarget(repositoryPath: worktreePath, sha: reviewedCommitSHA)
+    }
+
+    private var effectiveDraftCommentsByFileID: [DiffReviewFileID: [ReviewDraftComment]] {
+        guard allowsReviewing else { return [:] }
+        return ReviewDraftCommentGrouping.commentsByFileID(draftCommentController?.comments ?? [])
+    }
+
+    private var effectiveDraftCommentActions: ReviewDraftCommentActions {
+        guard allowsReviewing else { return ReviewDraftCommentActions() }
+        return draftCommentActions()
     }
 
     private func makeLSPContext(relativePath: String) -> DiffPaneLSPContext? {
@@ -523,7 +536,13 @@ struct CommitReviewBody: View {
     }
 
     private func loadDraftCommentController() {
-        guard let sessionID = reviewDraftSessionID else { return }
+        guard let sessionID = effectiveReviewDraftSessionID else {
+            draftCommentController = nil
+            loadedDraftSessionID = nil
+            focusedDraftCommentID = nil
+            draftCommentScrollCommand = nil
+            return
+        }
         if loadedDraftSessionID != sessionID {
             draftCommentController = ReviewDraftCommentController(sessionID: sessionID)
             loadedDraftSessionID = sessionID

--- a/AlasTests/CommitTabViewTests.swift
+++ b/AlasTests/CommitTabViewTests.swift
@@ -97,6 +97,52 @@ struct CommitTabViewTests {
         #expect(subview(withAccessibilityIdentifier: "diff-review-whitespace-toggle", in: controller.view) != nil)
     }
 
+    @Test func commitReviewBodyCanDisableDraftReviewControls() {
+        let file = summary(path: "Sources/App.swift")
+        let session = DiffReviewLoadedSession(
+            files: [
+                DiffReviewFileSectionModel(
+                    summary: file,
+                    parsedDiff: nil,
+                    displayModel: nil,
+                    placeholderMessage: "No diff.",
+                    openFile: nil,
+                    contextProvider: nil
+                ),
+            ],
+            summary: DiffReviewSessionModel(files: [file], groupsEnabled: false)
+        )
+        var selectedFileID: DiffReviewFileID?
+        var railCollapsed = false
+        var layoutMode = DiffLayoutMode.split
+        var wrapLines = false
+        var showWhitespace = false
+
+        let view = CommitReviewBody(
+            session: session,
+            selectedFileID: Binding(get: { selectedFileID }, set: { selectedFileID = $0 }),
+            railCollapsed: Binding(get: { railCollapsed }, set: { railCollapsed = $0 }),
+            layoutMode: Binding(get: { layoutMode }, set: { layoutMode = $0 }),
+            wrapLines: Binding(get: { wrapLines }, set: { wrapLines = $0 }),
+            showWhitespace: Binding(get: { showWhitespace }, set: { showWhitespace = $0 }),
+            codeFontFamily: "",
+            codeFontSize: 13,
+            reviewDraftSessionID: .commit(
+                worktreeID: "wt",
+                repositoryPath: URL(fileURLWithPath: "/repo"),
+                sha: "abc"
+            ),
+            allowsReviewing: false
+        )
+        .environment(\.theme, theme())
+
+        let controller = host(view, width: 1000, height: 700)
+
+        #expect(subview(withAccessibilityIdentifier: "commit-review-body", in: controller.view) != nil)
+        #expect(subview(withAccessibilityIdentifier: "review-draft-summary-rail", in: controller.view) == nil)
+        #expect(subview(withAccessibilityIdentifier: "diff-review-draft-composer", in: controller.view) == nil)
+    }
+
     @Test func commitReviewLoadIdentityRejectsStaleDetails() {
         let current = details(sha: "current-sha")
         let stale = details(sha: "stale-sha")


### PR DESCRIPTION
## Summary
- Render commit details with commit review controls disabled
- Gate draft review state, draft summary rail, and composer behind an explicit reviewing mode
- Add coverage for the read-only commit details behavior

## Verification
- `ALAS_FFF_TARGET_ARCH=arm64 rtk xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -only-testing:AlasTests/CommitTabViewTests test`
- `rtk xcodegen`
- `ALAS_FFF_TARGET_ARCH=arm64 rtk xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -quiet build`
- `git diff --check`

Full `xcodebuild test` was attempted locally but stalled without output for more than 15 minutes and was interrupted.