### PR TITLE
Trim hidden ACP tool output

### DIFF
--- a/Alas/Sources/ACP/Session/ACPSession.swift
+++ b/Alas/Sources/ACP/Session/ACPSession.swift
@@ -702,11 +702,8 @@ final class ACPSession: ObservableObject, Identifiable {
         // any chance of drift if a streaming update lands mid-shift.
         rebuildToolCallIndices()
         // Keep the visible window anchored to the tail the user is already
-        // looking at. Bypass `setVisibleHead` — it strips markdown caches
-        // for messages below the new head, which is exactly what we want
-        // to *avoid* here (older messages weren't visible before the shift
-        // and never had caches; the tail's caches must survive untouched).
-        transcript.visibleHead = transcript.visibleHead + older.count
+        // looking at while trimming newly-hidden historical tool output.
+        transcript.shiftVisibleHeadAfterPrepending(older.count)
     }
 
     func markCompletedOutputBoundary() {

--- a/Alas/Sources/ACP/Session/ACPTranscript.swift
+++ b/Alas/Sources/ACP/Session/ACPTranscript.swift
@@ -137,15 +137,31 @@ final class ACPTranscript: ObservableObject {
             return
         }
         for i in visibleHead..<clamped {
-            markdownCaches.removeValue(forKey: messages[i].stableId)
-            if case .toolCall(var tc) = messages[i] {
-                if tc.status != "in_progress", tc.status != "pending" {
-                    tc.truncateForOffWindow()
-                    messages[i] = .toolCall(tc)
-                }
-            }
+            trimHiddenMessage(at: i)
         }
         visibleHead = clamped
+    }
+
+    /// Shift the render window after hidden messages are prepended at the
+    /// front. This trims every row below the shifted head because prepended
+    /// rows never passed through `setVisibleHead`.
+    func shiftVisibleHeadAfterPrepending(_ insertedCount: Int) {
+        guard insertedCount > 0 else { return }
+        let shiftedHead = max(0, min(visibleHead + insertedCount, messages.count))
+        for i in 0..<shiftedHead {
+            trimHiddenMessage(at: i)
+        }
+        visibleHead = shiftedHead
+    }
+
+    private func trimHiddenMessage(at index: Int) {
+        markdownCaches.removeValue(forKey: messages[index].stableId)
+        if case .toolCall(var tc) = messages[index] {
+            if tc.status != "in_progress", tc.status != "pending" {
+                tc.truncateForOffWindow()
+                messages[index] = .toolCall(tc)
+            }
+        }
     }
 
     #if DEBUG

--- a/Alas/Sources/App/AppState.swift
+++ b/Alas/Sources/App/AppState.swift
@@ -4018,6 +4018,15 @@ extension AppState: RemoteSessionsProvider {
         return nil
     }
 
+    func fullToolCallContent(sessionId: String, toolCallId: String) -> String? {
+        for mgr in acpManagers.values {
+            if let content = mgr.reloadFullToolCallContent(sessionId: sessionId, toolCallId: toolCallId) {
+                return content
+            }
+        }
+        return nil
+    }
+
     func hydrateIfNeeded(id: String) async {
         // The remote list includes recent sessions that aren't currently open
         // on the Mac (no live ACPSession yet). Materialize the session in its

--- a/Alas/Sources/Remote/Gateway/RemoteSessionGateway.swift
+++ b/Alas/Sources/Remote/Gateway/RemoteSessionGateway.swift
@@ -250,7 +250,7 @@ final class RemoteSessionGateway {
     // MARK: snapshot / delta
 
     private func sendSnapshot(id: String, session: ACPSession) {
-        let wire = session.transcript.messages.enumerated().map { Self.toWire($0.element, index: $0.offset) }
+        let wire = wireMessages(id: id, session: session)
         send(.transcriptSnapshot(sessionId: id,
                                  streamingState: Self.stateString(session.transcript.streamingState),
                                  canDrive: provider.isWriter(for: id),
@@ -307,13 +307,30 @@ final class RemoteSessionGateway {
     private func sendDelta(id: String, session: ACPSession) {
         // v1: send a full re-snapshot as the "delta" (simple + always correct).
         // A true per-message diff optimization is intentionally deferred (YAGNI).
-        let wire = session.transcript.messages.enumerated().map { Self.toWire($0.element, index: $0.offset) }
+        let wire = wireMessages(id: id, session: session)
         send(.transcriptDelta(sessionId: id,
                               streamingState: Self.stateString(session.transcript.streamingState),
                               canDrive: provider.isWriter(for: id),
                               upserts: wire))
         emitPendingPermissionIfAny(id: id, session: session)
         emitPendingQuestionIfAny(id: id, session: session)
+    }
+
+    private func wireMessages(id: String, session: ACPSession) -> [RemoteWireMessage] {
+        session.transcript.messages.enumerated().map { index, message in
+            Self.toWire(
+                message,
+                index: index,
+                fullToolCallContent: fullToolCallContentIfNeeded(sessionId: id, message: message)
+            )
+        }
+    }
+
+    private func fullToolCallContentIfNeeded(sessionId: String, message: ACPMessage) -> String? {
+        guard case .toolCall(let toolCall) = message,
+              toolCall.isContentTruncated
+        else { return nil }
+        return provider.fullToolCallContent(sessionId: sessionId, toolCallId: toolCall.toolCallId)
     }
 
     private func emitPendingPermissionIfAny(id: String, session: ACPSession) {
@@ -459,7 +476,11 @@ final class RemoteSessionGateway {
     /// stable across our full re-snapshots. Position is — the Nth message stays
     /// the Nth — so the client can upsert idempotently instead of accumulating
     /// duplicate copies of the whole transcript on each refresh.
-    static func toWire(_ message: ACPMessage, index: Int) -> RemoteWireMessage {
+    static func toWire(
+        _ message: ACPMessage,
+        index: Int,
+        fullToolCallContent: String? = nil
+    ) -> RemoteWireMessage {
         let sid = "m\(index)"
         switch message {
         case .user(_, _, let text, let attachments):
@@ -477,7 +498,12 @@ final class RemoteSessionGateway {
         case .systemNotice(_, let text):
             return .init(stableId: sid, kind: "systemNotice", text: text, json: nil)
         case .toolCall(let call):
-            return .init(stableId: sid, kind: "toolCall", text: nil, json: Self.encodeJSON(remoteToolCall(call)))
+            return .init(
+                stableId: sid,
+                kind: "toolCall",
+                text: nil,
+                json: Self.encodeJSON(remoteToolCall(call, fullContent: fullToolCallContent))
+            )
         case .fileEdit(_, let edit):
             return .init(stableId: sid, kind: "fileEdit", text: nil, json: Self.encodeJSON(edit))
         case .plan(_, let items):
@@ -485,8 +511,14 @@ final class RemoteSessionGateway {
         }
     }
 
-    private static func remoteToolCall(_ call: ACPMessage.ToolCall) -> ACPMessage.ToolCall {
+    private static func remoteToolCall(
+        _ call: ACPMessage.ToolCall,
+        fullContent: String? = nil
+    ) -> ACPMessage.ToolCall {
         var remote = call
+        if let fullContent {
+            remote.content = fullContent
+        }
         remote.rawOutput = nil
         remote.metadata = nil
         remote.assets = call.assets.map { asset in

--- a/Alas/Sources/Remote/Gateway/RemoteSessionsProvider.swift
+++ b/Alas/Sources/Remote/Gateway/RemoteSessionsProvider.swift
@@ -12,6 +12,7 @@ protocol RemoteSessionsProvider: AnyObject {
     func permissionPolicy(for id: String) -> ACPPermissionPolicy?
     func hydrateIfNeeded(id: String) async
     func answerQuestion(for id: String, _ response: ACPQuestionResponse)
+    func fullToolCallContent(sessionId: String, toolCallId: String) -> String?
     func isWriter(for id: String) -> Bool
     func takeOver(for id: String)
     /// `onResult` fires once with the final outcome (false = refused now or

--- a/AlasTests/ACP/Session/ACPSessionToolCallTruncationTests.swift
+++ b/AlasTests/ACP/Session/ACPSessionToolCallTruncationTests.swift
@@ -28,6 +28,27 @@ struct ACPSessionToolCallTruncationTests {
         }
     }
 
+    @Test("prepending hidden older messages truncates completed tool calls")
+    func prependTruncatesHiddenOlderToolCalls() {
+        let session = ACPSession(id: "s", agentId: "claude", worktreeId: "w", title: "t")
+        let older = ACPMessage.ToolCall(
+            toolCallId: "old", title: "read",
+            status: "completed", content: bigContent(),
+            preview: "aaa...", locations: [])
+        let tail = ACPMessage.systemNotice(id: UUID(), text: "tail")
+        session.replaceTranscriptMessages([tail])
+
+        session.prependTranscriptMessages([.toolCall(older)])
+
+        #expect(session.transcript.visibleHead == 1)
+        if case .toolCall(let after) = session.transcript.messages[0] {
+            #expect(after.content.utf8.count <= ACPMessage.ToolCall.truncatedTailBytes + 64)
+            #expect(after.isContentTruncated)
+        } else {
+            Issue.record("expected prepended toolCall")
+        }
+    }
+
     @Test("setVisibleHead does NOT truncate in-progress or pending tool calls")
     func skipsLive() {
         let t = ACPTranscript()

--- a/AlasTests/Remote/RemoteSessionGatewayTests.swift
+++ b/AlasTests/Remote/RemoteSessionGatewayTests.swift
@@ -23,6 +23,7 @@ final class FakeSessionsProvider: RemoteSessionsProvider {
     var renamed: [(id: String, title: String)] = []
     var renameSucceeds = true
     var configs: [String: RemoteSessionConfig] = [:]
+    var fullToolCallContents: [String: String] = [:]
     var sessionSummariesCallCount = 0
     var remoteWorktreesCallCount = 0
     var remoteAgentsCallCount = 0
@@ -70,6 +71,10 @@ final class FakeSessionsProvider: RemoteSessionsProvider {
     func hydrateIfNeeded(id: String) async {}
     func answerQuestion(for id: String, _ response: ACPQuestionResponse) {
         lastQuestionResponse = (id, response)
+    }
+
+    func fullToolCallContent(sessionId: String, toolCallId: String) -> String? {
+        fullToolCallContents["\(sessionId)|\(toolCallId)"]
     }
 
     func isWriter(for id: String) -> Bool { writers.contains(id) }
@@ -388,6 +393,42 @@ struct RemoteSessionGatewayTests {
         }
         #expect(id == "s1")
         #expect(msgs.contains { $0.kind == "agent" && $0.text == "hello" })
+    }
+
+    @Test func snapshotRestoresFullTruncatedToolCallContent() async throws {
+        let provider = FakeSessionsProvider()
+        let fullContent = String(repeating: "abcdef0123456789", count: 400)
+        var toolCall = ACPMessage.ToolCall(
+            toolCallId: "old",
+            title: "read",
+            status: "completed",
+            content: fullContent,
+            preview: "abcdef"
+        )
+        toolCall.truncateForOffWindow()
+        let session = try makeSessionWithAgentText("tail")
+        session.transcript.messages = [.toolCall(toolCall)]
+        provider.sessions["s1"] = session
+        provider.fullToolCallContents["s1|old"] = fullContent
+        var sent: [RemoteServerMessage] = []
+        let gw = RemoteSessionGateway(provider: provider) { sent.append($0) }
+
+        await gw.handle(.subscribe(sessionId: "s1"))
+
+        guard case .transcriptSnapshot(_, _, _, let msgs)? = sent.first,
+              let json = msgs.first(where: { $0.kind == "toolCall" })?.json,
+              let data = json.data(using: .utf8)
+        else {
+            Issue.record("expected tool-call snapshot, got \(sent)")
+            return
+        }
+        let remoteToolCall = try JSONDecoder().decode(ACPMessage.ToolCall.self, from: data)
+        #expect(remoteToolCall.content == fullContent)
+        if case .toolCall(let localToolCall) = session.transcript.messages[0] {
+            #expect(localToolCall.isContentTruncated)
+        } else {
+            Issue.record("expected local tool call")
+        }
     }
 
     @Test func takeOverPushesSnapshotWithCanDrive() async throws {


### PR DESCRIPTION
## Summary

Trim completed ACP tool-call output that is prepended behind the visible transcript window, so tail-first hydration does not keep full historical tool output resident after older messages are loaded.

## Root Cause

`prependTranscriptMessages(_:)` shifted `visibleHead` directly after inserting older messages. That preserved the visible tail, but it bypassed the same hidden-row trimming path used by `setVisibleHead`, leaving completed off-window tool-call content fully resident.

## Changes

- Added a transcript helper for shifting the visible head after prepends while trimming hidden rows.
- Routed ACP session prepends through that helper.
- Restored persisted full tool-call content when remote snapshots/deltas encode truncated rows.
- Added regression coverage for prepended hidden completed tool calls and remote snapshots of truncated tool calls.

## Validation

- `rtk xcodegen`
- `ALAS_FFF_TARGET_ARCH=arm64 rtk xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -only-testing:AlasTests/ACPSessionToolCallTruncationTests test`
- `ALAS_FFF_TARGET_ARCH=arm64 rtk xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -only-testing:AlasTests/RemoteSessionGatewayTests test`

Full-suite validation is intentionally left to CI for this pass.