### PR TITLE
fix(diff): Auto-focus the diff pane comment composer

### DIFF
--- a/Alas/Sources/Center/DiffReview/DiffReviewFileSection.swift
+++ b/Alas/Sources/Center/DiffReview/DiffReviewFileSection.swift
@@ -792,7 +792,7 @@ enum ReviewDraftComposerKeyboardAction: Equatable {
     }
 }
 
-private struct ReviewDraftComposerTextEditor: NSViewRepresentable {
+struct ReviewDraftComposerTextEditor: NSViewRepresentable {
     @Binding var text: String
     let theme: Theme
     let isFocused: FocusState<Bool>.Binding

--- a/Alas/Sources/Center/DiffTabView.swift
+++ b/Alas/Sources/Center/DiffTabView.swift
@@ -810,15 +810,19 @@ struct DiffTabView: View {
 
     private var reviewDraftComposer: some View {
         VStack(alignment: .leading, spacing: 8) {
-            TextEditor(text: $pendingDraftBody)
-                .font(.system(size: 12))
-                .foregroundColor(theme.color("fg"))
-                .frame(minHeight: 64, maxHeight: 90)
-                .background(theme.color("bg-2"))
-                .clipShape(RoundedRectangle(cornerRadius: 6))
-                .overlay(RoundedRectangle(cornerRadius: 6).stroke(theme.color("line"), lineWidth: 0.5))
-                .focused($draftComposerFocused)
-                .accessibilityIdentifier("diff-review-draft-composer")
+            ReviewDraftComposerTextEditor(
+                text: $pendingDraftBody,
+                theme: theme,
+                isFocused: $draftComposerFocused,
+                onSave: savePendingDraft,
+                onCancel: clearPendingDraft
+            )
+            .frame(minHeight: 64, maxHeight: 90)
+            .background(theme.color("bg-2"))
+            .clipShape(RoundedRectangle(cornerRadius: 6))
+            .overlay(RoundedRectangle(cornerRadius: 6).stroke(theme.color("line"), lineWidth: 0.5))
+            .onAppear { draftComposerFocused = true }
+            .accessibilityIdentifier("diff-review-draft-composer")
             HStack(spacing: 6) {
                 Spacer(minLength: 0)
                 Button("Cancel") { clearPendingDraft() }


### PR DESCRIPTION
On the staged/unstaged diff pane, leaving a comment now focuses the comment textbox automatically.

## Problem

That pane's composer used a plain SwiftUI `TextEditor` with `.focused($draftComposerFocused)`, which does not reliably accept programmatic focus on macOS when the field has just appeared. So opening the composer left it unfocused, requiring an extra click before typing.

## Fix

Reuse the `NSViewRepresentable` composer (`ReviewDraftComposerTextEditor`) already used by the review and commit surfaces, which makes the backing text view first responder on appear via `window.makeFirstResponder`. The composer is now focused automatically as soon as it opens.

- `DiffReviewFileSection.swift`: made `ReviewDraftComposerTextEditor` module-internal so it can be shared.
- `DiffTabView.swift`: replaced the plain `TextEditor` with the shared composer, wired to save/cancel, and focus it on appear.

As a consistency bonus, this brings the pane's composer keyboard shortcuts (Cmd-Return to save, Esc to cancel) in line with the other surfaces.

## Verification

Full `xcodebuild` for macOS succeeds.