### PR TITLE
fix(acp): codex session restore

### DIFF
--- a/Alas/Sources/ACP/Protocol/ACPConnection.swift
+++ b/Alas/Sources/ACP/Protocol/ACPConnection.swift
@@ -34,7 +34,14 @@ final class ACPConnection: @unchecked Sendable {
         let req = ACPRequest(method: "session/new",
                              params: ACPSessionNewParams(cwd: cwd, mcpServers: []))
         let resp = try await client.send(req)
-        return try JSONDecoder().decode(ACPSessionNewResult.self, from: resp.body)
+        let result = try JSONDecoder().decode(ACPSessionNewResult.self, from: resp.body)
+        guard !result.sessionId.isEmpty else {
+            throw DecodingError.dataCorrupted(.init(
+                codingPath: [],
+                debugDescription: "session/new response is missing sessionId"
+            ))
+        }
+        return result
     }
 
     func authenticate(methodId: String) async throws {
@@ -48,7 +55,8 @@ final class ACPConnection: @unchecked Sendable {
         let req = ACPRequest(method: "session/load",
                              params: ACPSessionLoadParams(cwd: cwd, sessionId: sessionId, mcpServers: []))
         let resp = try await client.send(req)
-        return try JSONDecoder().decode(ACPSessionNewResult.self, from: resp.body)
+        let result = try JSONDecoder().decode(ACPSessionNewResult.self, from: resp.body)
+        return result.sessionId.isEmpty ? result.withSessionId(sessionId) : result
     }
 
     func cancel(sessionId: String) async throws {

--- a/Alas/Sources/ACP/Protocol/ACPMessages.swift
+++ b/Alas/Sources/ACP/Protocol/ACPMessages.swift
@@ -612,7 +612,7 @@ struct ACPSessionNewResult: Codable, Equatable {
 
     init(from decoder: Decoder) throws {
         let c = try decoder.container(keyedBy: CodingKeys.self)
-        sessionId = try c.decode(String.self, forKey: .sessionId)
+        sessionId = (try? c.decode(String.self, forKey: .sessionId)) ?? ""
 
         // ACP v1 nests these as `models: { availableModels, currentModelId }`
         // and `modes: { availableModes, currentModeId }`. Older drafts used
@@ -635,6 +635,18 @@ struct ACPSessionNewResult: Codable, Equatable {
 
         promptSuggestions = (try? c.decode([ACPPromptSuggestion].self, forKey: .promptSuggestions)) ?? []
         configOptions = (try? c.decode([ACPConfigOption].self, forKey: .configOptions)) ?? []
+    }
+
+    func withSessionId(_ sessionId: String) -> ACPSessionNewResult {
+        ACPSessionNewResult(
+            sessionId: sessionId,
+            availableModels: availableModels,
+            availableModes: availableModes,
+            currentModel: currentModel,
+            currentMode: currentMode,
+            promptSuggestions: promptSuggestions,
+            configOptions: configOptions
+        )
     }
 }
 

--- a/AlasTests/ACP/Session/ACPSessionManagerAttachRestoreTests.swift
+++ b/AlasTests/ACP/Session/ACPSessionManagerAttachRestoreTests.swift
@@ -25,6 +25,45 @@ struct ACPSessionManagerAttachRestoreTests {
         #expect(try store.loadSession(id: "local")?.remoteSessionId == "remote-restored")
     }
 
+    @Test("Codex-style load response without session id restores normally")
+    func codexStyleLoadResponseWithoutSessionIdRestoresNormally() async throws {
+        let store = try ACPSessionStore(path: tmpStorePath())
+        try store.upsertSession(row(remoteSessionId: "remote-old"))
+        let client = ACPMockClient()
+        scriptInitialize(client)
+        client.script(method: "session/load") { _ in
+            Data("""
+            {
+              "models": {
+                "currentModelId": "gpt-5",
+                "availableModels": []
+              },
+              "modes": {
+                "currentModeId": "default",
+                "availableModes": []
+              },
+              "configOptions": []
+            }
+            """.utf8)
+        }
+        client.script(method: "session/new") { _ in
+            Issue.record("session/new should not be called when session/load succeeds without a sessionId")
+            return Data("{}".utf8)
+        }
+        let manager = manager(store: store, client: client)
+
+        let session = try #require(manager.placeholderSession(id: "local"))
+        await manager.hydrateIfNeeded(id: "local")
+        await manager.attach(to: session.id, freshlyCreated: false)
+
+        #expect(client.sent.map(\.method) == ["initialize", "session/load"])
+        #expect(session.remoteSessionId == "remote-old")
+        #expect(session.currentModel == "gpt-5")
+        #expect(session.currentMode == "default")
+        #expect(session.contextRestoreWarning == nil)
+        #expect(try store.loadSession(id: "local")?.remoteSessionId == "remote-old")
+    }
+
     @Test("replayed load history is ignored when a session is already hydrated")
     func replayedLoadHistoryIgnoredWhenHydrated() async throws {
         let store = try ACPSessionStore(path: tmpStorePath())


### PR DESCRIPTION
## Summary
Fix Codex ACP session restore by accepting successful `session/load` responses that omit a top-level `sessionId`, which matches the Codex ACP behavior observed in practice. This prevents restored Codex ACP panes from falling back to lossy transcript recovery when normal restore already succeeded.

## Changes
- Fill a missing `session/load` result id from the requested remote session id.
- Keep `session/new` strict so new sessions still require a returned id.
- Add a regression test for a Codex-style load response with nested capabilities and no top-level `sessionId`.

## Verification
- `xcodegen`
- `xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -quiet build`
- `xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -only-testing:AlasTests/ACPSessionManagerAttachRestoreTests test`
- Started full `xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' test`; interrupted after Xcode stalled in test runner cleanup/worker materialization after several suites had already run.