### PR TITLE
feat(diff): Highlight active diff comment ranges

### DIFF
--- a/Alas/Sources/Center/Diff/DiffInlineCommentModel.swift
+++ b/Alas/Sources/Center/Diff/DiffInlineCommentModel.swift
@@ -26,6 +26,7 @@ struct DiffInlineCommentThread: Identifiable, Equatable {
     let id: String
     let filePath: String
     let newLine: Int
+    var startLine: Int? = nil
     var isOldSide: Bool = false
     let isResolved: Bool
     let isOutdated: Bool
@@ -33,6 +34,10 @@ struct DiffInlineCommentThread: Identifiable, Equatable {
     var viewerCanReply: Bool = true
     var viewerCanResolve: Bool = true
     var viewerCanUnresolve: Bool = true
+
+    var lineRange: ClosedRange<Int> {
+        min(startLine ?? newLine, newLine)...max(startLine ?? newLine, newLine)
+    }
 }
 
 struct DiffInlineComment: Identifiable, Equatable {
@@ -84,8 +89,8 @@ enum DiffInlineCommentLayout {
         threads: [DiffInlineCommentThread],
         annotations: [DiffInlineAnnotation]
     ) -> [Block] {
-        // Build map from row index → threads anchored after that row.
-        // A thread matches the first row where row.new?.anchor.newLine == thread.newLine.
+        // Build map from row index → threads anchored after their end row.
+        // Multi-line threads still render after the provider's end line.
         var threadsByRowIndex: [Int: [DiffInlineCommentThread]] = [:]
         for thread in threads {
             let rowIndex: Int?

--- a/Alas/Sources/Center/Diff/DiffPaneTextDocumentView.swift
+++ b/Alas/Sources/Center/Diff/DiffPaneTextDocumentView.swift
@@ -42,6 +42,65 @@ struct DiffReviewLineAnchor: Equatable, Hashable, Sendable {
     }
 }
 
+struct DiffReviewCommentHighlight: Equatable, Hashable, Sendable {
+    let path: String
+    let side: DiffReviewInlineFeedbackSide
+    let lineRange: ClosedRange<Int>
+
+    init(path: String, side: DiffReviewInlineFeedbackSide, lineRange: ClosedRange<Int>) {
+        self.path = path
+        self.side = side
+        self.lineRange = lineRange
+    }
+
+    init(path: String, side: DiffReviewInlineFeedbackSide, line: Int, endLine: Int? = nil) {
+        self.init(path: path, side: side, lineRange: min(line, endLine ?? line)...max(line, endLine ?? line))
+    }
+
+    func highlightedRowRange(in lines: [DiffPaneTextDocumentBuilder.LineMetadata]) -> ClosedRange<Int>? {
+        let matchingRows = lines.indices.filter { index in
+            matchesVisibleSourceLine(lines[index].sourceLine)
+        }
+        guard let first = matchingRows.first, let last = matchingRows.last else { return nil }
+        return first...last
+    }
+
+    func matchesVisibleSourceLine(_ sourceLine: DiffDisplayLine?) -> Bool {
+        guard let sourceLine,
+              sourceLine.anchor.filePath == path,
+              let lineNumber = sourceLine.highlightLineNumber(for: side),
+              lineRange.contains(lineNumber)
+        else {
+            return false
+        }
+        return side.matches(sourceLine.anchor.side)
+    }
+}
+
+extension DiffReviewInlineFeedbackSide {
+    func matches(_ lineSide: DiffLineSide) -> Bool {
+        switch (self, lineSide) {
+        case (.old, .old), (.new, .new), (.unknown, _), (.old, .paired), (.new, .paired):
+            return true
+        default:
+            return false
+        }
+    }
+}
+
+private extension DiffDisplayLine {
+    func highlightLineNumber(for side: DiffReviewInlineFeedbackSide) -> Int? {
+        switch side {
+        case .old:
+            return anchor.oldLine
+        case .new:
+            return anchor.newLine
+        case .unknown:
+            return lineNumber ?? anchor.newLine ?? anchor.oldLine
+        }
+    }
+}
+
 struct DiffPaneTextDocumentView: NSViewRepresentable {
     let group: DiffDisplayGroup
     let expandedCollapsedRowIDs: Set<String>
@@ -53,6 +112,7 @@ struct DiffPaneTextDocumentView: NSViewRepresentable {
     let codeFontSize: CGFloat
     let theme: Theme
     let lspContext: DiffPaneLSPContext?
+    let activeCommentHighlight: DiffReviewCommentHighlight?
     var allowsReviewLineSelection: Bool = true
     var onReviewLineSelected: (DiffReviewLineAnchor) -> Void = { _ in }
     var onContextExpansion: (DiffContextExpansionKey, DiffContextExpansionMode) -> Void = { _, _ in }
@@ -68,6 +128,7 @@ struct DiffPaneTextDocumentView: NSViewRepresentable {
         codeFontSize: CGFloat,
         theme: Theme,
         lspContext: DiffPaneLSPContext?,
+        activeCommentHighlight: DiffReviewCommentHighlight? = nil,
         allowsReviewLineSelection: Bool = true,
         onReviewLineSelected: @escaping (DiffReviewLineAnchor) -> Void = { _ in },
         onContextExpansion: @escaping (DiffContextExpansionKey, DiffContextExpansionMode) -> Void = { _, _ in }
@@ -82,6 +143,7 @@ struct DiffPaneTextDocumentView: NSViewRepresentable {
         self.codeFontSize = codeFontSize
         self.theme = theme
         self.lspContext = lspContext
+        self.activeCommentHighlight = activeCommentHighlight
         self.allowsReviewLineSelection = allowsReviewLineSelection
         self.onReviewLineSelected = onReviewLineSelected
         self.onContextExpansion = onContextExpansion
@@ -102,6 +164,7 @@ struct DiffPaneTextDocumentView: NSViewRepresentable {
             font: CenterTypography.resolveCodeFont(family: codeFontFamily, size: codeFontSize),
             theme: theme,
             lspContext: lspContext,
+            activeCommentHighlight: activeCommentHighlight,
             allowsReviewLineSelection: allowsReviewLineSelection,
             onReviewLineSelected: onReviewLineSelected,
             onContextExpansion: onContextExpansion
@@ -119,6 +182,7 @@ struct DiffPaneSegmentView: NSViewRepresentable {
     let codeFontSize: CGFloat
     let theme: Theme
     let lspContext: DiffPaneLSPContext?
+    var activeCommentHighlight: DiffReviewCommentHighlight? = nil
     var allowsReviewLineSelection: Bool = true
     var onReviewLineSelected: (DiffReviewLineAnchor) -> Void = { _ in }
     let onContextExpansion: (DiffContextExpansionKey, DiffContextExpansionMode) -> Void
@@ -137,6 +201,7 @@ struct DiffPaneSegmentView: NSViewRepresentable {
             font: CenterTypography.resolveCodeFont(family: codeFontFamily, size: codeFontSize),
             theme: theme,
             lspContext: lspContext,
+            activeCommentHighlight: activeCommentHighlight,
             allowsReviewLineSelection: allowsReviewLineSelection,
             onReviewLineSelected: onReviewLineSelected,
             onContextExpansion: onContextExpansion
@@ -187,6 +252,7 @@ final class DiffPaneTextDocumentContainerView: NSView {
         font: NSFont,
         theme: Theme,
         lspContext: DiffPaneLSPContext?,
+        activeCommentHighlight: DiffReviewCommentHighlight? = nil,
         allowsReviewLineSelection: Bool = true,
         onReviewLineSelected: @escaping (DiffReviewLineAnchor) -> Void = { _ in },
         onContextExpansion: @escaping (DiffContextExpansionKey, DiffContextExpansionMode) -> Void = { _, _ in }
@@ -200,6 +266,9 @@ final class DiffPaneTextDocumentContainerView: NSView {
         oldPane.onContextExpansion = onContextExpansion
         newPane.onContextExpansion = onContextExpansion
         stackedPane.onContextExpansion = onContextExpansion
+        oldPane.activeCommentHighlight = activeCommentHighlight
+        newPane.activeCommentHighlight = activeCommentHighlight
+        stackedPane.activeCommentHighlight = activeCommentHighlight
 
         let signature = UpdateSignature(
             group: group,
@@ -369,6 +438,7 @@ final class DiffPaneTextDocumentContainerView: NSView {
         font: NSFont,
         theme: Theme,
         lspContext: DiffPaneLSPContext?,
+        activeCommentHighlight: DiffReviewCommentHighlight? = nil,
         allowsReviewLineSelection: Bool = true,
         onReviewLineSelected: @escaping (DiffReviewLineAnchor) -> Void = { _ in },
         onContextExpansion: @escaping (DiffContextExpansionKey, DiffContextExpansionMode) -> Void = { _, _ in }
@@ -382,6 +452,9 @@ final class DiffPaneTextDocumentContainerView: NSView {
         oldPane.onContextExpansion = onContextExpansion
         newPane.onContextExpansion = onContextExpansion
         stackedPane.onContextExpansion = onContextExpansion
+        oldPane.activeCommentHighlight = activeCommentHighlight
+        newPane.activeCommentHighlight = activeCommentHighlight
+        stackedPane.activeCommentHighlight = activeCommentHighlight
 
         let signature = RowsUpdateSignature(
             rows: rows,
@@ -518,6 +591,12 @@ final class DiffPaneTextScrollView: NSScrollView {
     private var wraps = false
     private var font: NSFont = .monospacedSystemFont(ofSize: 13, weight: .regular)
     private var theme: Theme?
+    var activeCommentHighlight: DiffReviewCommentHighlight? {
+        didSet {
+            textView.activeCommentHighlight = activeCommentHighlight
+            (verticalRulerView as? DiffPaneLineNumberRulerView)?.activeCommentHighlight = activeCommentHighlight
+        }
+    }
     var allowsReviewLineSelection: Bool = true {
         didSet {
             (verticalRulerView as? DiffPaneLineNumberRulerView)?.allowsReviewLineSelection = allowsReviewLineSelection
@@ -627,6 +706,7 @@ final class DiffPaneTextScrollView: NSScrollView {
         textView.lineTones = lineTones
         textView.contextExpansionHandler = onContextExpansion
         textView.theme = theme
+        textView.activeCommentHighlight = activeCommentHighlight
         textView.lspContext = lspContext
         textView.allowedLSPSide = allowedLSPSide
         textView.updateLSPController()
@@ -640,6 +720,7 @@ final class DiffPaneTextScrollView: NSScrollView {
                 contentTopInset: textView.textContainerInset.height,
                 theme: theme,
                 expansionKeys: expansionKeys,
+                activeCommentHighlight: activeCommentHighlight,
                 onContextExpansion: onContextExpansion
             )
         }
@@ -851,6 +932,25 @@ final class DiffPaneCodeTextView: NSTextView {
         nil
     }
 
+    static func commentHighlightRect(
+        rowRects: [NSRect],
+        rowRange: ClosedRange<Int>,
+        visibleMinY: CGFloat,
+        contentWidth: CGFloat
+    ) -> NSRect {
+        let rows = rowRange.compactMap { index in
+            rowRects.indices.contains(index) ? rowRects[index] : nil
+        }
+        guard let first = rows.first else { return .zero }
+        let union = rows.dropFirst().reduce(first) { $0.union($1) }
+        return NSRect(
+            x: 4,
+            y: union.minY - visibleMinY,
+            width: max(contentWidth - 8, 1),
+            height: union.height
+        )
+    }
+
     private var ownedTextStorage: NSTextStorage?
     private var customTrackingArea: NSTrackingArea?
     private var lspController: DiffPaneLSPController?
@@ -869,7 +969,13 @@ final class DiffPaneCodeTextView: NSTextView {
         }
     }
     var lineMetadata: [DiffPaneTextDocumentBuilder.LineMetadata] = [] {
-        didSet { invalidateDiffRowGeometry() }
+        didSet {
+            invalidateDiffRowGeometry()
+            needsDisplay = true
+        }
+    }
+    var activeCommentHighlight: DiffReviewCommentHighlight? {
+        didSet { needsDisplay = true }
     }
     var hoverHandler: ((NSPoint) -> Void)?
     var commandClickHandler: ((NSPoint) -> Void)?
@@ -1323,6 +1429,28 @@ final class DiffPaneCodeTextView: NSTextView {
                 drawExpandableContextPill(row: index, in: rowRect, theme: theme)
             }
         }
+        drawActiveCommentHighlight(in: dirtyRect, rowRects: rowRects, theme: theme)
+    }
+
+    private func drawActiveCommentHighlight(in dirtyRect: NSRect, rowRects: [NSRect], theme: Theme) {
+        guard let rowRange = activeCommentHighlight?.highlightedRowRange(in: lineMetadata) else { return }
+        let rect = Self.commentHighlightRect(
+            rowRects: rowRects,
+            rowRange: rowRange,
+            visibleMinY: bounds.minY,
+            contentWidth: bounds.width
+        )
+        guard rect != .zero, rect.intersects(dirtyRect) else { return }
+
+        let accent = NSColor(theme.color("accent"))
+        accent.withAlphaComponent(0.12).setFill()
+        let fillPath = NSBezierPath(roundedRect: rect, xRadius: 4, yRadius: 4)
+        fillPath.fill()
+
+        accent.withAlphaComponent(0.82).setStroke()
+        let strokePath = NSBezierPath(roundedRect: rect.insetBy(dx: 0.5, dy: 0.5), xRadius: 4, yRadius: 4)
+        strokePath.lineWidth = 1
+        strokePath.stroke()
     }
 
     private func paragraphRanges(lineCount: Int) -> [NSRange] {
@@ -1495,6 +1623,9 @@ final class DiffPaneLineNumberRulerView: NSRulerView {
     var allowsReviewLineSelection: Bool = true
     var onReviewLineSelected: (DiffReviewLineAnchor) -> Void = { _ in }
     var onContextExpansion: (DiffContextExpansionKey, DiffContextExpansionMode) -> Void = { _, _ in }
+    var activeCommentHighlight: DiffReviewCommentHighlight? {
+        didSet { needsDisplay = true }
+    }
     private var contentTopInset: CGFloat = 6
     private var boundsObserver: NSObjectProtocol?
     private var selectionStartRow: Int?
@@ -1524,6 +1655,7 @@ final class DiffPaneLineNumberRulerView: NSRulerView {
         contentTopInset: CGFloat,
         theme: Theme,
         expansionKeys: [DiffContextExpansionKey?],
+        activeCommentHighlight: DiffReviewCommentHighlight?,
         onContextExpansion: @escaping (DiffContextExpansionKey, DiffContextExpansionMode) -> Void
     ) {
         self.labels = labels
@@ -1532,6 +1664,7 @@ final class DiffPaneLineNumberRulerView: NSRulerView {
         self.contentTopInset = contentTopInset
         self.theme = theme
         self.expansionKeys = expansionKeys
+        self.activeCommentHighlight = activeCommentHighlight
         self.onContextExpansion = onContextExpansion
         updateThickness()
         needsDisplay = true
@@ -1638,6 +1771,15 @@ final class DiffPaneLineNumberRulerView: NSRulerView {
         let rowRects = diffRowRects()
         guard !rowRects.isEmpty else { return }
 
+        for index in visibleRowIndices(in: visible) {
+            let sourceRowRect = rowRects[index]
+            let y = sourceRowRect.minY - visible.minY
+            let rowRect = NSRect(x: 0, y: y, width: ruleThickness, height: sourceRowRect.height)
+            drawRowBackground(index: index, rowRect: rowRect, theme: theme)
+        }
+
+        drawActiveCommentHighlight(visibleRect: visible, rowRects: rowRects, theme: theme)
+
         let textHeight = ("8" as NSString).size(withAttributes: labelAttributes(for: "", row: nil)).height
         let labelRects = labelDrawRects()
         for index in visibleRowIndices(in: visible) {
@@ -1645,7 +1787,6 @@ final class DiffPaneLineNumberRulerView: NSRulerView {
             let sourceRowRect = rowRects[index]
             let y = sourceRowRect.minY - visible.minY
             let rowRect = NSRect(x: 0, y: y, width: ruleThickness, height: sourceRowRect.height)
-            drawRowBackground(index: index, rowRect: rowRect, theme: theme)
             guard !label.isEmpty else { continue }
             let sourceLabelRect = labelRects.indices.contains(index)
                 ? labelRects[index]
@@ -1761,6 +1902,26 @@ final class DiffPaneLineNumberRulerView: NSRulerView {
             y: max(0, union.minY - visibleMinY),
             width: max(ruleThickness - 8, 1),
             height: union.height
+        )
+    }
+
+    static func activeCommentHighlightRect(
+        rowRects: [NSRect],
+        rowRange: ClosedRange<Int>,
+        visibleMinY: CGFloat,
+        ruleThickness: CGFloat
+    ) -> NSRect {
+        let rows = rowRange.compactMap { index in
+            rowRects.indices.contains(index) ? rowRects[index] : nil
+        }
+        guard let first = rows.first else { return .zero }
+        let union = rows.dropFirst().reduce(first) { $0.union($1) }
+        let clippedMinY = max(visibleMinY, union.minY)
+        return NSRect(
+            x: 0,
+            y: max(0, clippedMinY - visibleMinY),
+            width: ruleThickness,
+            height: max(0, union.maxY - clippedMinY)
         )
     }
 
@@ -1919,6 +2080,23 @@ final class DiffPaneLineNumberRulerView: NSRulerView {
         let path = NSBezierPath(roundedRect: outlineRect.insetBy(dx: 0.5, dy: 0.5), xRadius: 5, yRadius: 5)
         path.lineWidth = 1.5
         path.stroke()
+    }
+
+    private func drawActiveCommentHighlight(visibleRect: NSRect, rowRects: [NSRect], theme: Theme) {
+        guard let textView = scrollView?.documentView as? DiffPaneCodeTextView,
+              let rowRange = activeCommentHighlight?.highlightedRowRange(in: textView.lineMetadata)
+        else { return }
+        let highlightRect = Self.activeCommentHighlightRect(
+            rowRects: rowRects,
+            rowRange: rowRange,
+            visibleMinY: visibleRect.minY,
+            ruleThickness: ruleThickness
+        )
+        guard highlightRect != .zero else { return }
+
+        let accent = NSColor(theme.color("accent"))
+        accent.withAlphaComponent(0.18).setFill()
+        highlightRect.fill()
     }
 
     static func changeRailRect(in rowRect: NSRect, tone: DiffPaneLineTone) -> NSRect? {

--- a/Alas/Sources/Center/Diff/DiffPaneView.swift
+++ b/Alas/Sources/Center/Diff/DiffPaneView.swift
@@ -115,6 +115,7 @@ struct DiffPaneView: View {
     var showsToolbar: Bool = true
     var verticalScrollMode: DiffPaneVerticalScrollMode = .internalScroll
     var lspContext: DiffPaneLSPContext? = nil
+    var activeCommentHighlight: DiffReviewCommentHighlight? = nil
     var allowsReviewLineSelection: Bool = true
     var onReviewLineSelected: (DiffReviewLineAnchor) -> Void = { _ in }
     var onContextExpansion: (DiffContextExpansionKey, DiffContextExpansionMode) -> Void = { _, _ in }
@@ -133,6 +134,7 @@ struct DiffPaneView: View {
 
     @Environment(\.theme) private var theme
     @State private var expandedCollapsedRowIDs: Set<String> = []
+    @State private var activeThreadID: String?
 
     init(
         model: DiffDisplayModel,
@@ -145,6 +147,7 @@ struct DiffPaneView: View {
         showsToolbar: Bool = true,
         verticalScrollMode: DiffPaneVerticalScrollMode = .internalScroll,
         lspContext: DiffPaneLSPContext? = nil,
+        activeCommentHighlight: DiffReviewCommentHighlight? = nil,
         allowsReviewLineSelection: Bool = true,
         onReviewLineSelected: @escaping (DiffReviewLineAnchor) -> Void = { _ in },
         onContextExpansion: @escaping (DiffContextExpansionKey, DiffContextExpansionMode) -> Void = { _, _ in },
@@ -171,6 +174,7 @@ struct DiffPaneView: View {
         self.showsToolbar = showsToolbar
         self.verticalScrollMode = verticalScrollMode
         self.lspContext = lspContext
+        self.activeCommentHighlight = activeCommentHighlight
         self.allowsReviewLineSelection = allowsReviewLineSelection
         self.onReviewLineSelected = onReviewLineSelected
         self.onContextExpansion = onContextExpansion
@@ -327,8 +331,8 @@ struct DiffPaneView: View {
         let hunkThreads = threads.filter { t in
             visibleRows.contains {
                 t.isOldSide
-                    ? $0.old?.anchor.oldLine == t.newLine
-                    : $0.new?.anchor.newLine == t.newLine
+                    ? t.lineRange.contains($0.old?.anchor.oldLine ?? -1)
+                    : t.lineRange.contains($0.new?.anchor.newLine ?? -1)
             }
         }
         let hunkAnnotations = annotations.filter { a in
@@ -355,6 +359,7 @@ struct DiffPaneView: View {
                         codeFontSize: codeFontSize,
                         theme: theme,
                         lspContext: lspContext,
+                        activeCommentHighlight: activeHighlight(for: segment.rows),
                         allowsReviewLineSelection: allowsReviewLineSelection,
                         onReviewLineSelected: onReviewLineSelected,
                         onContextExpansion: onContextExpansion
@@ -371,7 +376,10 @@ struct DiffPaneView: View {
                         onDelete: { comment in onDelete(t, comment) },
                         canReply: canReply && t.viewerCanReply,
                         canResolve: canResolve && (t.viewerCanResolve || t.viewerCanUnresolve),
-                        canAddToReview: canAddToReview
+                        canAddToReview: canAddToReview,
+                        onActiveChange: { active in
+                            activeThreadID = active ? t.id : (activeThreadID == t.id ? nil : activeThreadID)
+                        }
                     )
                     .frame(maxWidth: .infinity, alignment: .leading)
                 case .annotation(let a):
@@ -389,6 +397,71 @@ struct DiffPaneView: View {
         .padding(.bottom, 10)
     }
 
+    private func activeHighlight(for rows: [DiffDisplayRow]) -> DiffReviewCommentHighlight? {
+        DiffPaneActiveHighlightResolver.activeHighlight(
+            parentHighlight: activeCommentHighlight,
+            threads: threads,
+            activeThreadID: activeThreadID,
+            rows: rows
+        )
+    }
+}
+
+enum DiffPaneActiveHighlightResolver {
+    static func activeHighlight(
+        parentHighlight: DiffReviewCommentHighlight?,
+        threads: [DiffInlineCommentThread],
+        activeThreadID: String?,
+        rows: [DiffDisplayRow]
+    ) -> DiffReviewCommentHighlight? {
+        if let threadHighlight = activeThreadHighlight(
+            threads: threads,
+            activeThreadID: activeThreadID,
+            rows: rows
+        ) {
+            return threadHighlight
+        }
+
+        if let parentHighlight,
+           rowsContainHighlight(parentHighlight, rows: rows) {
+            return parentHighlight
+        }
+
+        return nil
+    }
+
+    private static func activeThreadHighlight(
+        threads: [DiffInlineCommentThread],
+        activeThreadID: String?,
+        rows: [DiffDisplayRow]
+    ) -> DiffReviewCommentHighlight? {
+        guard let activeThread = threads.first(where: { $0.id == activeThreadID }),
+              rows.contains(where: { row in
+                  activeThread.isOldSide
+                      ? activeThread.lineRange.contains(row.old?.anchor.oldLine ?? -1)
+                      : activeThread.lineRange.contains(row.new?.anchor.newLine ?? -1)
+              })
+        else { return nil }
+
+        return DiffReviewCommentHighlight(
+            path: activeThread.filePath,
+            side: activeThread.isOldSide ? .old : .new,
+            lineRange: activeThread.lineRange
+        )
+    }
+
+    private static func rowsContainHighlight(_ highlight: DiffReviewCommentHighlight, rows: [DiffDisplayRow]) -> Bool {
+        rows.contains { row in
+            rowContainsHighlight(highlight, row: row)
+        }
+    }
+
+    private static func rowContainsHighlight(_ highlight: DiffReviewCommentHighlight, row: DiffDisplayRow) -> Bool {
+        highlight.matchesVisibleSourceLine(row.old) || highlight.matchesVisibleSourceLine(row.new)
+    }
+}
+
+extension DiffPaneView {
     private func hunkHeader(_ group: DiffDisplayGroup) -> some View {
         let actions = hunkActions(group.sourceHunk)
         return HStack(spacing: 8) {

--- a/Alas/Sources/Center/DiffReview/DiffReviewFileSection.swift
+++ b/Alas/Sources/Center/DiffReview/DiffReviewFileSection.swift
@@ -6,6 +6,30 @@ private struct PendingContextExpansion {
     let mode: DiffContextExpansionMode
 }
 
+enum DiffReviewActiveCommentCandidate: Equatable {
+    case draft(String)
+    case inlineFeedback(String)
+    case thread(String)
+}
+
+struct DiffReviewActiveCommentIDs {
+    var hoveredDraftCommentID: String?
+    var focusedDraftCommentID: String?
+    var hoveredInlineFeedbackID: String?
+    var focusedFeedbackID: String?
+    var activeThreadID: String?
+
+    var orderedCandidates: [DiffReviewActiveCommentCandidate] {
+        [
+            hoveredDraftCommentID.map(DiffReviewActiveCommentCandidate.draft),
+            hoveredInlineFeedbackID.map(DiffReviewActiveCommentCandidate.inlineFeedback),
+            activeThreadID.map(DiffReviewActiveCommentCandidate.thread),
+            focusedDraftCommentID.map(DiffReviewActiveCommentCandidate.draft),
+            focusedFeedbackID.map(DiffReviewActiveCommentCandidate.inlineFeedback),
+        ].compactMap(\.self)
+    }
+}
+
 struct DiffReviewFileSection: View {
     let file: DiffReviewFileSectionModel
     var inlineFeedback: [DiffReviewInlineFeedback] = []
@@ -57,6 +81,9 @@ struct DiffReviewFileSection: View {
     @State private var contextLoadGeneration = 0
     @State private var contextLoadError: String?
     @State private var pendingContextExpansions: [PendingContextExpansion] = []
+    @State private var hoveredInlineFeedbackID: String?
+    @State private var hoveredDraftCommentID: String?
+    @State private var activeThreadID: String?
     @FocusState private var draftComposerFocused: Bool
 
     var body: some View {
@@ -244,7 +271,10 @@ struct DiffReviewFileSection: View {
                         isFocused: comment.id == focusedDraftCommentID,
                         actions: feedbackDraftCommentActions,
                         reviewFeedbackTarget: effectiveReviewFeedbackTarget,
-                        onSelect: onSelectDraftComment
+                        onSelect: onSelectDraftComment,
+                        onHoverChange: { isHovered in
+                            hoveredDraftCommentID = isHovered ? comment.id : (hoveredDraftCommentID == comment.id ? nil : hoveredDraftCommentID)
+                        }
                     )
                     .id(DiffReviewDraftCommentTargetID.targetID(commentID: comment.id, fileID: file.id))
                 }
@@ -278,7 +308,10 @@ struct DiffReviewFileSection: View {
                         file: file,
                         isFocused: item.id == focusedFeedbackID,
                         actions: inlineFeedbackActions,
-                        onSelect: onSelectInlineFeedback
+                        onSelect: onSelectInlineFeedback,
+                        onHoverChange: { isHovered in
+                            hoveredInlineFeedbackID = isHovered ? item.id : (hoveredInlineFeedbackID == item.id ? nil : hoveredInlineFeedbackID)
+                        }
                     )
                     .id(DiffReviewInlineFeedbackTargetID.targetID(feedbackID: item.id, fileID: file.id))
                 }
@@ -407,6 +440,7 @@ struct DiffReviewFileSection: View {
                                     codeFontSize: codeFontSize,
                                     theme: theme,
                                     lspContext: lspContext,
+                                    activeCommentHighlight: activeHighlight(for: rowSeg.rows),
                                     allowsReviewLineSelection: allowsDraftCommentCreation,
                                     onReviewLineSelected: { anchor in
                                         pendingDraftAnchor = anchor
@@ -426,7 +460,10 @@ struct DiffReviewFileSection: View {
                                     onDelete: { comment in onDelete(thread, comment) },
                                     canReply: canReply && thread.viewerCanReply,
                                     canResolve: canResolve && (thread.viewerCanResolve || thread.viewerCanUnresolve),
-                                    canAddToReview: canAddToReview
+                                    canAddToReview: canAddToReview,
+                                    onActiveChange: { active in
+                                        activeThreadID = active ? thread.id : (activeThreadID == thread.id ? nil : activeThreadID)
+                                    }
                                 )
                                 .frame(maxWidth: .infinity, alignment: .leading)
                             case .annotation(let annotation):
@@ -462,6 +499,7 @@ struct DiffReviewFileSection: View {
                 showsToolbar: false,
                 verticalScrollMode: .staticHeight,
                 lspContext: lspContext,
+                activeCommentHighlight: activeHighlight(for: displayGroup.rows),
                 allowsReviewLineSelection: allowsDraftCommentCreation,
                 onReviewLineSelected: { anchor in
                     pendingDraftAnchor = anchor
@@ -487,6 +525,70 @@ struct DiffReviewFileSection: View {
                 }
             )
         }
+    }
+
+    private func activeHighlight(for rows: [DiffDisplayRow]) -> DiffReviewCommentHighlight? {
+        let highlight = activeCommentIDs.orderedCandidates.lazy.compactMap(activeHighlight(for:)).first
+        guard let highlight, rowsContainHighlight(highlight, rows: rows) else { return nil }
+        return highlight
+    }
+
+    private var activeCommentIDs: DiffReviewActiveCommentIDs {
+        DiffReviewActiveCommentIDs(
+            hoveredDraftCommentID: hoveredDraftCommentID,
+            focusedDraftCommentID: focusedDraftCommentID,
+            hoveredInlineFeedbackID: hoveredInlineFeedbackID,
+            focusedFeedbackID: focusedFeedbackID,
+            activeThreadID: activeThreadID
+        )
+    }
+
+    private func activeHighlight(for candidate: DiffReviewActiveCommentCandidate) -> DiffReviewCommentHighlight? {
+        switch candidate {
+        case .draft(let id):
+            return draftCommentHighlight(id: id)
+        case .inlineFeedback(let id):
+            return inlineFeedbackHighlight(id: id)
+        case .thread(let id):
+            return threadHighlight(id: id)
+        }
+    }
+
+    private func draftCommentHighlight(id: String) -> DiffReviewCommentHighlight? {
+        guard let comment = draftComments.first(where: { $0.id == id }),
+              comment.state != .dismissed
+        else { return nil }
+        return DiffReviewCommentHighlight(
+            path: comment.path,
+            side: comment.side,
+            lineRange: comment.normalizedLineRange
+        )
+    }
+
+    private func inlineFeedbackHighlight(id: String) -> DiffReviewCommentHighlight? {
+        guard let item = inlineFeedback.first(where: { $0.id == id }),
+              let line = item.anchor.line
+        else { return nil }
+        return DiffReviewCommentHighlight(path: item.anchor.path, side: item.anchor.side, line: line)
+    }
+
+    private func threadHighlight(id: String) -> DiffReviewCommentHighlight? {
+        guard let activeThread = threads.first(where: { $0.id == id }) else { return nil }
+        return DiffReviewCommentHighlight(
+            path: activeThread.filePath,
+            side: activeThread.isOldSide ? .old : .new,
+            lineRange: activeThread.lineRange
+        )
+    }
+
+    private func rowsContainHighlight(_ highlight: DiffReviewCommentHighlight, rows: [DiffDisplayRow]) -> Bool {
+        rows.contains { row in
+            rowContainsHighlight(highlight, row: row)
+        }
+    }
+
+    private func rowContainsHighlight(_ highlight: DiffReviewCommentHighlight, row: DiffDisplayRow) -> Bool {
+        highlight.matchesVisibleSourceLine(row.old) || highlight.matchesVisibleSourceLine(row.new)
     }
 
     private func segmentedHunkHeader(_ group: DiffDisplayGroup) -> some View {
@@ -1375,6 +1477,7 @@ struct ReviewDraftCommentCard: View {
     let actions: ReviewDraftCommentActions
     let reviewFeedbackTarget: ReviewFeedbackTarget
     let onSelect: (ReviewDraftComment) -> Void
+    var onHoverChange: (Bool) -> Void = { _ in }
 
     @Environment(\.theme) private var theme
     @State private var isEditing = false
@@ -1413,6 +1516,13 @@ struct ReviewDraftCommentCard: View {
             )
         )
         .background(focusedMarker)
+        .onHover { hovering in
+            onHoverChange(Self.reportsHover(isHovered: hovering, isFocused: isFocused))
+        }
+    }
+
+    static func reportsHover(isHovered: Bool, isFocused: Bool) -> Bool {
+        isHovered
     }
 
     private var cardContent: some View {
@@ -1730,12 +1840,13 @@ final class ReviewDraftCommentActionPressView: NSView {
     }
 }
 
-private struct DiffReviewInlineFeedbackCard: View {
+struct DiffReviewInlineFeedbackCard: View {
     let item: DiffReviewInlineFeedback
     let file: DiffReviewFileSummary
     let isFocused: Bool
     let actions: DiffReviewInlineFeedbackActions
     let onSelect: (DiffReviewInlineFeedback) -> Void
+    var onHoverChange: (Bool) -> Void = { _ in }
 
     @Environment(\.theme) private var theme
     @State private var replyEditor = DiffReviewInlineFeedbackReplyEditorState()
@@ -1798,6 +1909,13 @@ private struct DiffReviewInlineFeedbackCard: View {
             )
         )
         .background(focusedMarker)
+        .onHover { hovering in
+            onHoverChange(Self.reportsHover(isHovered: hovering, isFocused: isFocused))
+        }
+    }
+
+    static func reportsHover(isHovered: Bool, isFocused: Bool) -> Bool {
+        isHovered
     }
 
     @ViewBuilder

--- a/Alas/Sources/Center/DiffReview/DiffReviewRenderContext.swift
+++ b/Alas/Sources/Center/DiffReview/DiffReviewRenderContext.swift
@@ -703,6 +703,7 @@ private struct ThreadSignature: Hashable {
     let id: String
     let filePath: String
     let newLine: Int
+    let startLine: Int?
     let isOldSide: Bool
     let isResolved: Bool
     let isOutdated: Bool
@@ -715,6 +716,7 @@ private struct ThreadSignature: Hashable {
         id = thread.id
         filePath = thread.filePath
         newLine = thread.newLine
+        startLine = thread.startLine
         isOldSide = thread.isOldSide
         isResolved = thread.isResolved
         isOutdated = thread.isOutdated

--- a/Alas/Sources/Center/DiffReview/DiffReviewSurface.swift
+++ b/Alas/Sources/Center/DiffReview/DiffReviewSurface.swift
@@ -459,6 +459,7 @@ struct DiffReviewSurface: View {
                     id: thread.id,
                     filePath: thread.path ?? "",
                     newLine: line,
+                    startLine: thread.rangeStartLine(isOldSide: isOldSide),
                     isOldSide: isOldSide,
                     isResolved: thread.isResolved,
                     isOutdated: thread.isOutdated,

--- a/Alas/Sources/Center/Review/DiffInlineCommentCard.swift
+++ b/Alas/Sources/Center/Review/DiffInlineCommentCard.swift
@@ -11,12 +11,15 @@ struct DiffInlineCommentCard: View {
     var canResolve: Bool = true
     var onStageReply: (String) -> Void = { _ in }
     var canAddToReview: Bool = false
+    var onActiveChange: (Bool) -> Void = { _ in }
 
     @State private var isExpanded: Bool
     @State private var isComposerOpen = false
     @State private var replyDraft = ""
     @State private var editingCommentID: String? = nil
     @State private var editDraft = ""
+    @State private var isHovered = false
+    @FocusState private var isCardFocused: Bool
 
     init(
         thread: DiffInlineCommentThread,
@@ -28,7 +31,8 @@ struct DiffInlineCommentCard: View {
         onDelete: @escaping (DiffInlineComment) -> Void = { _ in },
         canReply: Bool = true,
         canResolve: Bool = true,
-        canAddToReview: Bool = false
+        canAddToReview: Bool = false,
+        onActiveChange: @escaping (Bool) -> Void = { _ in }
     ) {
         self.thread = thread
         self.onReply = onReply
@@ -40,16 +44,32 @@ struct DiffInlineCommentCard: View {
         self.canReply = canReply
         self.canResolve = canResolve
         self.canAddToReview = canAddToReview
+        self.onActiveChange = onActiveChange
         // Smart default: expanded when unresolved and not outdated
         _isExpanded = State(initialValue: !thread.isResolved && !thread.isOutdated)
     }
 
     var body: some View {
-        if isExpanded {
-            expandedView
-        } else {
-            collapsedPill
+        Group {
+            if isExpanded {
+                expandedView
+            } else {
+                collapsedPill
+            }
         }
+        .focusable(true)
+        .focused($isCardFocused)
+        .onHover { hovering in
+            isHovered = hovering
+            onActiveChange(Self.isActive(isHovered: hovering, isFocused: isCardFocused))
+        }
+        .onChange(of: isCardFocused) { _, isFocused in
+            onActiveChange(Self.isActive(isHovered: isHovered, isFocused: isFocused))
+        }
+    }
+
+    static func isActive(isHovered: Bool, isFocused: Bool) -> Bool {
+        isHovered || isFocused
     }
 
     // MARK: - Collapsed pill

--- a/Alas/Sources/Integrations/CodeHost/CodeHostModels.swift
+++ b/Alas/Sources/Integrations/CodeHost/CodeHostModels.swift
@@ -280,6 +280,7 @@ struct ReviewThread: Identifiable, Equatable, Sendable {
     let line: Int?
     let startLine: Int?
     let originalLine: Int?
+    let originalStartLine: Int?
     let diffHunk: String?
     let diffSide: String?
     let isResolved: Bool
@@ -297,6 +298,7 @@ struct ReviewThread: Identifiable, Equatable, Sendable {
         line: Int?,
         startLine: Int?,
         originalLine: Int?,
+        originalStartLine: Int? = nil,
         diffHunk: String?,
         diffSide: String? = nil,
         isResolved: Bool,
@@ -313,6 +315,7 @@ struct ReviewThread: Identifiable, Equatable, Sendable {
         self.line = line
         self.startLine = startLine
         self.originalLine = originalLine
+        self.originalStartLine = originalStartLine
         self.diffHunk = diffHunk
         self.diffSide = diffSide
         self.isResolved = isResolved
@@ -334,10 +337,15 @@ struct ReviewThread: Identifiable, Equatable, Sendable {
 
     var isActionable: Bool { !isResolved && !isOutdated }
 
+    func rangeStartLine(isOldSide: Bool) -> Int? {
+        isOldSide ? originalStartLine : startLine
+    }
+
     func addingReply(_ comment: ReviewComment) -> ReviewThread {
         ReviewThread(
             id: id, path: path, line: line, startLine: startLine,
-            originalLine: originalLine, diffHunk: diffHunk, diffSide: diffSide,
+            originalLine: originalLine, originalStartLine: originalStartLine,
+            diffHunk: diffHunk, diffSide: diffSide,
             isResolved: isResolved, isOutdated: isOutdated, isFileLevel: isFileLevel,
             comments: comments + [comment],
             viewerCanResolve: viewerCanResolve, viewerCanUnresolve: viewerCanUnresolve,
@@ -348,7 +356,8 @@ struct ReviewThread: Identifiable, Equatable, Sendable {
     func withResolved(_ resolved: Bool) -> ReviewThread {
         ReviewThread(
             id: id, path: path, line: line, startLine: startLine,
-            originalLine: originalLine, diffHunk: diffHunk, diffSide: diffSide,
+            originalLine: originalLine, originalStartLine: originalStartLine,
+            diffHunk: diffHunk, diffSide: diffSide,
             isResolved: resolved, isOutdated: isOutdated, isFileLevel: isFileLevel,
             comments: comments,
             viewerCanResolve: viewerCanResolve, viewerCanUnresolve: viewerCanUnresolve,
@@ -359,7 +368,8 @@ struct ReviewThread: Identifiable, Equatable, Sendable {
     func replacingComment(id commentID: String, with replacement: ReviewComment) -> ReviewThread {
         ReviewThread(
             id: id, path: path, line: line, startLine: startLine,
-            originalLine: originalLine, diffHunk: diffHunk, diffSide: diffSide,
+            originalLine: originalLine, originalStartLine: originalStartLine,
+            diffHunk: diffHunk, diffSide: diffSide,
             isResolved: isResolved, isOutdated: isOutdated, isFileLevel: isFileLevel,
             comments: comments.map { $0.id == commentID ? replacement : $0 },
             viewerCanResolve: viewerCanResolve, viewerCanUnresolve: viewerCanUnresolve,
@@ -370,7 +380,8 @@ struct ReviewThread: Identifiable, Equatable, Sendable {
     func removingComment(id commentID: String) -> ReviewThread {
         ReviewThread(
             id: id, path: path, line: line, startLine: startLine,
-            originalLine: originalLine, diffHunk: diffHunk, diffSide: diffSide,
+            originalLine: originalLine, originalStartLine: originalStartLine,
+            diffHunk: diffHunk, diffSide: diffSide,
             isResolved: isResolved, isOutdated: isOutdated, isFileLevel: isFileLevel,
             comments: comments.filter { $0.id != commentID },
             viewerCanResolve: viewerCanResolve, viewerCanUnresolve: viewerCanUnresolve,

--- a/Alas/Sources/Integrations/CodeHost/GitHubCLIProvider.swift
+++ b/Alas/Sources/Integrations/CodeHost/GitHubCLIProvider.swift
@@ -77,6 +77,7 @@ struct GitHubCLIProvider: CodeHostProvider {
               line
               startLine
               originalLine
+              originalStartLine
               subjectType
               diffSide
               viewerCanResolve
@@ -1541,6 +1542,7 @@ struct GitHubCLIProvider: CodeHostProvider {
                 line: node.line,
                 startLine: node.startLine,
                 originalLine: node.originalLine,
+                originalStartLine: node.originalStartLine,
                 diffHunk: node.comments.nodes.first?.diffHunk,
                 diffSide: node.diffSide,
                 isResolved: node.isResolved,
@@ -1598,6 +1600,7 @@ struct GitHubCLIProvider: CodeHostProvider {
             line: thread.line,
             startLine: thread.startLine,
             originalLine: thread.originalLine,
+            originalStartLine: thread.originalStartLine,
             diffHunk: thread.diffHunk,
             diffSide: thread.diffSide,
             isResolved: mutated.isResolved,
@@ -2094,6 +2097,7 @@ private struct ReviewThreadNode: Decodable {
     let line: Int?
     let startLine: Int?
     let originalLine: Int?
+    let originalStartLine: Int?
     let subjectType: String?
     let diffSide: String?
     let viewerCanResolve: Bool?
@@ -2110,6 +2114,7 @@ private struct ReviewThreadNode: Decodable {
         self.line = try? container.decode(Int.self, forKey: .line)
         self.startLine = try? container.decode(Int.self, forKey: .startLine)
         self.originalLine = try? container.decode(Int.self, forKey: .originalLine)
+        self.originalStartLine = try? container.decode(Int.self, forKey: .originalStartLine)
         self.subjectType = try? container.decode(String.self, forKey: .subjectType)
         self.diffSide = try? container.decode(String.self, forKey: .diffSide)
         self.viewerCanResolve = try? container.decode(Bool.self, forKey: .viewerCanResolve)
@@ -2126,6 +2131,7 @@ private struct ReviewThreadNode: Decodable {
         case line
         case startLine
         case originalLine
+        case originalStartLine
         case subjectType
         case diffSide
         case viewerCanResolve

--- a/Alas/Sources/Integrations/CodeHost/GitLabCLIProvider.swift
+++ b/Alas/Sources/Integrations/CodeHost/GitLabCLIProvider.swift
@@ -500,6 +500,7 @@ struct GitLabCLIProvider: CodeHostProvider {
             line: thread.line,
             startLine: thread.startLine,
             originalLine: thread.originalLine,
+            originalStartLine: thread.originalStartLine,
             diffHunk: thread.diffHunk,
             diffSide: thread.diffSide,
             isResolved: true,
@@ -540,6 +541,7 @@ struct GitLabCLIProvider: CodeHostProvider {
             line: thread.line,
             startLine: thread.startLine,
             originalLine: thread.originalLine,
+            originalStartLine: thread.originalStartLine,
             diffHunk: thread.diffHunk,
             diffSide: thread.diffSide,
             isResolved: false,
@@ -1204,8 +1206,9 @@ struct GitLabCLIProvider: CodeHostProvider {
                 id: discussion.id,
                 path: position?.newPath ?? position?.oldPath,
                 line: position?.newLine,
-                startLine: nil,
+                startLine: position?.newLine == nil ? nil : position?.lineRange?.start.newLine,
                 originalLine: position?.oldLine,
+                originalStartLine: isOldSide ? position?.lineRange?.start.oldLine : nil,
                 diffHunk: nil,
                 diffSide: isOldSide ? "LEFT" : nil,
                 isResolved: discussion.isResolved,
@@ -2078,10 +2081,26 @@ private struct GitLabNotePosition: Decodable {
     let oldPath: String?
     let newLine: Int?
     let oldLine: Int?
+    let lineRange: GitLabNoteLineRange?
 
     private enum CodingKeys: String, CodingKey {
         case newPath = "new_path"
         case oldPath = "old_path"
+        case newLine = "new_line"
+        case oldLine = "old_line"
+        case lineRange = "line_range"
+    }
+}
+
+private struct GitLabNoteLineRange: Decodable {
+    let start: GitLabNoteLineRangePoint
+}
+
+private struct GitLabNoteLineRangePoint: Decodable {
+    let newLine: Int?
+    let oldLine: Int?
+
+    private enum CodingKeys: String, CodingKey {
         case newLine = "new_line"
         case oldLine = "old_line"
     }

--- a/AlasTests/ACP/UI/ACPMarkdownInlineRendererTests.swift
+++ b/AlasTests/ACP/UI/ACPMarkdownInlineRendererTests.swift
@@ -240,6 +240,14 @@ struct ACPMarkdownInlineRendererTests {
         #expect(accessibilityLabel(in: host, containing: "`leadingX`") == nil)
     }
 
+    @Test("inline provider thread stays active while hovered or focused")
+    func inlineProviderThreadStaysActiveWhileHoveredOrFocused() {
+        #expect(DiffInlineCommentCard.isActive(isHovered: true, isFocused: false))
+        #expect(DiffInlineCommentCard.isActive(isHovered: false, isFocused: true))
+        #expect(DiffInlineCommentCard.isActive(isHovered: true, isFocused: true))
+        #expect(!DiffInlineCommentCard.isActive(isHovered: false, isFocused: false))
+    }
+
     @Test("outdated drawer thread body renders markdown")
     func outdatedDrawerThreadBodyRendersMarkdown() throws {
         let comment = ReviewComment(

--- a/AlasTests/DiffInlineCommentModelTests.swift
+++ b/AlasTests/DiffInlineCommentModelTests.swift
@@ -53,11 +53,12 @@ struct DiffInlineCommentModelTests {
         )
     }
 
-    private func makeThread(id: String, newLine: Int) -> DiffInlineCommentThread {
+    private func makeThread(id: String, newLine: Int, startLine: Int? = nil) -> DiffInlineCommentThread {
         DiffInlineCommentThread(
             id: id,
             filePath: "Sources/App.swift",
             newLine: newLine,
+            startLine: startLine,
             isResolved: false,
             isOutdated: false,
             comments: [
@@ -113,6 +114,42 @@ struct DiffInlineCommentModelTests {
         if case .rows(let seg) = blocks[2] {
             #expect(seg.rows.count == 1)
             #expect(seg.rows[0].id == "r2")
+        } else {
+            Issue.record("Block 2 should be .rows")
+        }
+    }
+
+    @Test func threadLineRangeNormalizesStartAndEndLines() {
+        #expect(makeThread(id: "single", newLine: 20).lineRange == 20...20)
+        #expect(makeThread(id: "multi", newLine: 20, startLine: 18).lineRange == 18...20)
+        #expect(makeThread(id: "reversed", newLine: 18, startLine: 20).lineRange == 18...20)
+    }
+
+    @Test func multilineThreadStillAnchorsAfterEndRow() {
+        let rows = [
+            makeRow(id: "r0", new: makeNewLine(newLine: 18, rowIndex: 0)),
+            makeRow(id: "r1", new: makeNewLine(newLine: 19, rowIndex: 1)),
+            makeRow(id: "r2", new: makeNewLine(newLine: 20, rowIndex: 2)),
+            makeRow(id: "r3", new: makeNewLine(newLine: 21, rowIndex: 3)),
+        ]
+        let thread = makeThread(id: "range", newLine: 20, startLine: 18)
+
+        let blocks = DiffInlineCommentLayout.blocks(visibleRows: rows, threads: [thread])
+
+        #expect(blocks.count == 3)
+        if case .rows(let seg) = blocks[0] {
+            #expect(seg.rows.map(\.id) == ["r0", "r1", "r2"])
+        } else {
+            Issue.record("Block 0 should be .rows")
+        }
+        if case .thread(let t) = blocks[1] {
+            #expect(t.id == "range")
+            #expect(t.lineRange == 18...20)
+        } else {
+            Issue.record("Block 1 should be .thread")
+        }
+        if case .rows(let seg) = blocks[2] {
+            #expect(seg.rows.map(\.id) == ["r3"])
         } else {
             Issue.record("Block 2 should be .rows")
         }

--- a/AlasTests/DiffPaneViewTests.swift
+++ b/AlasTests/DiffPaneViewTests.swift
@@ -832,6 +832,140 @@ let second = true
         #expect(outline == NSRect(x: 4, y: 0, width: 34, height: 58))
     }
 
+    @Test func activeCommentGutterHighlightFillsFullGutterRows() {
+        let rowRects = [
+            NSRect(x: 0, y: 8, width: 42, height: 18),
+            NSRect(x: 0, y: 26, width: 42, height: 22),
+            NSRect(x: 0, y: 48, width: 42, height: 18),
+        ]
+
+        let rect = DiffPaneLineNumberRulerView.activeCommentHighlightRect(
+            rowRects: rowRects,
+            rowRange: 1...2,
+            visibleMinY: 10,
+            ruleThickness: 42
+        )
+
+        #expect(rect == NSRect(x: 0, y: 16, width: 42, height: 40))
+    }
+
+    @Test func activeCommentGutterHighlightClipsRowsScrolledPastTop() {
+        let rowRects = [
+            NSRect(x: 0, y: 8, width: 42, height: 18),
+            NSRect(x: 0, y: 26, width: 42, height: 22),
+        ]
+
+        let rect = DiffPaneLineNumberRulerView.activeCommentHighlightRect(
+            rowRects: rowRects,
+            rowRange: 0...1,
+            visibleMinY: 20,
+            ruleThickness: 42
+        )
+
+        #expect(rect == NSRect(x: 0, y: 0, width: 42, height: 28))
+    }
+
+    @Test func activeCommentHighlightMatchesRowsBySideAndLineRange() {
+        let lines = [
+            DiffPaneTextDocumentBuilder.LineMetadata(
+                kind: .context,
+                range: NSRange(location: 0, length: 1),
+                sourceLine: diffLine(id: "new-10", side: .new, newLine: 10, text: "a")
+            ),
+            DiffPaneTextDocumentBuilder.LineMetadata(
+                kind: .context,
+                range: NSRange(location: 2, length: 1),
+                sourceLine: diffLine(id: "old-11", side: .old, oldLine: 11, text: "b")
+            ),
+            DiffPaneTextDocumentBuilder.LineMetadata(
+                kind: .context,
+                range: NSRange(location: 4, length: 1),
+                sourceLine: diffLine(id: "new-12", side: .new, newLine: 12, text: "c")
+            ),
+        ]
+        let highlight = DiffReviewCommentHighlight(path: "Sources/App.swift", side: .new, lineRange: 10...12)
+
+        #expect(highlight.highlightedRowRange(in: lines) == 0...2)
+    }
+
+    @Test func activeCommentHighlightMatchesPairedRowsByRequestedSideLineNumber() {
+        let line = DiffDisplayLine(
+            id: "paired-10-12",
+            anchor: DiffLineAnchor(
+                filePath: "Sources/App.swift",
+                hunkIndex: 0,
+                rowIndex: 0,
+                side: .paired,
+                oldLine: 10,
+                newLine: 12
+            ),
+            text: "let value = 1",
+            lineNumber: 12,
+            kind: .context,
+            inlineSpans: [],
+            noTrailingNewline: false
+        )
+
+        #expect(DiffReviewCommentHighlight(path: "Sources/App.swift", side: .old, line: 10).matchesVisibleSourceLine(line))
+        #expect(DiffReviewCommentHighlight(path: "Sources/App.swift", side: .new, line: 12).matchesVisibleSourceLine(line))
+        #expect(!DiffReviewCommentHighlight(path: "Sources/App.swift", side: .old, line: 12).matchesVisibleSourceLine(line))
+    }
+
+    @Test func activeCommentHighlightMatchesOnlyVisibleSourceLines() {
+        let highlight = DiffReviewCommentHighlight(path: "Sources/App.swift", side: .new, lineRange: 10...12)
+
+        #expect(highlight.matchesVisibleSourceLine(diffLine(id: "new-10", side: .new, newLine: 10, text: "a")))
+        #expect(!highlight.matchesVisibleSourceLine(nil))
+        #expect(!highlight.matchesVisibleSourceLine(diffLine(id: "old-10", side: .old, oldLine: 10, text: "b")))
+    }
+
+    @Test func activeThreadHighlightWinsOverParentHighlightInSameRows() {
+        let rows = [
+            DiffDisplayRow(
+                id: "row-10",
+                kind: .context,
+                old: diffLine(id: "old-8", side: .old, oldLine: 8, text: "let value = 1"),
+                new: diffLine(id: "new-10", side: .new, newLine: 10, text: "let value = 1"),
+                collapsedLineCount: 0
+            ),
+        ]
+        let parentHighlight = DiffReviewCommentHighlight(path: "Sources/App.swift", side: .old, line: 8)
+        let thread = DiffInlineCommentThread(
+            id: "thread-10",
+            filePath: "Sources/App.swift",
+            newLine: 10,
+            isResolved: false,
+            isOutdated: false,
+            comments: []
+        )
+
+        let highlight = DiffPaneActiveHighlightResolver.activeHighlight(
+            parentHighlight: parentHighlight,
+            threads: [thread],
+            activeThreadID: thread.id,
+            rows: rows
+        )
+
+        #expect(highlight == DiffReviewCommentHighlight(path: "Sources/App.swift", side: .new, line: 10))
+    }
+
+    @Test func activeCommentHighlightRectSpansMatchedRows() {
+        let rowRects = [
+            NSRect(x: 0, y: 8, width: 300, height: 18),
+            NSRect(x: 0, y: 26, width: 300, height: 22),
+            NSRect(x: 0, y: 48, width: 300, height: 18),
+        ]
+
+        let rect = DiffPaneCodeTextView.commentHighlightRect(
+            rowRects: rowRects,
+            rowRange: 1...2,
+            visibleMinY: 10,
+            contentWidth: 300
+        )
+
+        #expect(rect == NSRect(x: 4, y: 16, width: 292, height: 40))
+    }
+
     @Test func diffTextScrollPanesUseLeadingClipViewsAndStartScrolledLeft() throws {
         var layout = DiffLayoutMode.split
         var wrap = false

--- a/AlasTests/DiffReviewSurfaceTests.swift
+++ b/AlasTests/DiffReviewSurfaceTests.swift
@@ -910,6 +910,53 @@ struct DiffReviewSurfaceTests {
             threads: [],
             annotations: []
         )
+        let singleLineThread = DiffInlineCommentThread(
+            id: "thread",
+            filePath: model.filePath,
+            newLine: 2,
+            startLine: nil,
+            isResolved: false,
+            isOutdated: false,
+            comments: []
+        )
+        let multiLineThread = DiffInlineCommentThread(
+            id: singleLineThread.id,
+            filePath: singleLineThread.filePath,
+            newLine: singleLineThread.newLine,
+            startLine: 1,
+            isResolved: singleLineThread.isResolved,
+            isOutdated: singleLineThread.isOutdated,
+            comments: singleLineThread.comments,
+            viewerCanReply: singleLineThread.viewerCanReply,
+            viewerCanResolve: singleLineThread.viewerCanResolve,
+            viewerCanUnresolve: singleLineThread.viewerCanUnresolve
+        )
+        let singleLineThreadKey = DiffReviewRenderContextKey(
+            fileID: fileID,
+            displayModel: model,
+            contextSnapshot: nil,
+            contextProviderAvailable: false,
+            contextExpansion: DiffContextExpansionState(),
+            inlineFeedback: [],
+            draftComments: [],
+            pendingDraftAnchor: nil,
+            canCreateDraftComment: true,
+            threads: [singleLineThread],
+            annotations: []
+        )
+        let multiLineThreadKey = DiffReviewRenderContextKey(
+            fileID: fileID,
+            displayModel: model,
+            contextSnapshot: nil,
+            contextProviderAvailable: false,
+            contextExpansion: DiffContextExpansionState(),
+            inlineFeedback: [],
+            draftComments: [],
+            pendingDraftAnchor: nil,
+            canCreateDraftComment: true,
+            threads: [multiLineThread],
+            annotations: []
+        )
 
         #expect(baseKey == equalKey)
         #expect(baseKey != draftKey)
@@ -917,6 +964,7 @@ struct DiffReviewSurfaceTests {
         #expect(feedbackKey != feedbackURLKey)
         #expect(draftKey != draftSelectionKey)
         #expect(draftKey != draftCreatedAtKey)
+        #expect(singleLineThreadKey != multiLineThreadKey)
     }
 
     @Test func renderContextKeyChangesWhenExpandedContextTextChangesWithSameLineCount() {
@@ -1749,6 +1797,44 @@ struct DiffReviewSurfaceTests {
         RunLoop.main.run(until: Date(timeIntervalSinceNow: 0.05))
         controller.view.layoutSubtreeIfNeeded()
         #expect(accessibilityLabel(in: controller.view, containing: "Copied prompt") != nil)
+    }
+
+    @Test func activeCommentResolverPrefersHoveredCardsBeforeFocusedFallbacks() {
+        let inlineOverDraft = DiffReviewActiveCommentIDs(
+            hoveredDraftCommentID: nil,
+            focusedDraftCommentID: "focused-draft",
+            hoveredInlineFeedbackID: "hovered-inline",
+            focusedFeedbackID: nil,
+            activeThreadID: nil
+        )
+        #expect(inlineOverDraft.orderedCandidates == [
+            .inlineFeedback("hovered-inline"),
+            .draft("focused-draft"),
+        ])
+
+        let threadOverDraft = DiffReviewActiveCommentIDs(
+            hoveredDraftCommentID: nil,
+            focusedDraftCommentID: "focused-draft",
+            hoveredInlineFeedbackID: nil,
+            focusedFeedbackID: nil,
+            activeThreadID: "active-thread"
+        )
+        #expect(threadOverDraft.orderedCandidates == [
+            .thread("active-thread"),
+            .draft("focused-draft"),
+        ])
+    }
+
+    @Test func commentCardsReportHoverOnlyForHoverPriority() {
+        #expect(ReviewDraftCommentCard.reportsHover(isHovered: true, isFocused: false))
+        #expect(ReviewDraftCommentCard.reportsHover(isHovered: true, isFocused: true))
+        #expect(!ReviewDraftCommentCard.reportsHover(isHovered: false, isFocused: true))
+        #expect(!ReviewDraftCommentCard.reportsHover(isHovered: false, isFocused: false))
+
+        #expect(DiffReviewInlineFeedbackCard.reportsHover(isHovered: true, isFocused: false))
+        #expect(DiffReviewInlineFeedbackCard.reportsHover(isHovered: true, isFocused: true))
+        #expect(!DiffReviewInlineFeedbackCard.reportsHover(isHovered: false, isFocused: true))
+        #expect(!DiffReviewInlineFeedbackCard.reportsHover(isHovered: false, isFocused: false))
     }
 
     @Test func fileSectionDraftCommentCardDoesNotFireDisabledSendAction() {

--- a/AlasTests/Integrations/CodeHostModelsTests.swift
+++ b/AlasTests/Integrations/CodeHostModelsTests.swift
@@ -340,4 +340,27 @@ struct ReviewThreadModelTests {
         #expect(make(resolved: false, outdated: true).isActionable == false)
         #expect(make(resolved: false, outdated: false).isActionable == true)
     }
+
+    @Test func rangeStartLineUsesOriginalStartForOldSideThreads() {
+        let thread = ReviewThread(
+            id: "t",
+            path: "Sources/Foo.swift",
+            line: nil,
+            startLine: 12,
+            originalLine: 40,
+            originalStartLine: 38,
+            diffHunk: nil,
+            diffSide: "LEFT",
+            isResolved: false,
+            isOutdated: false,
+            isFileLevel: false,
+            comments: [],
+            viewerCanResolve: true,
+            viewerCanReply: true,
+            url: nil
+        )
+
+        #expect(thread.rangeStartLine(isOldSide: true) == 38)
+        #expect(thread.rangeStartLine(isOldSide: false) == 12)
+    }
 }

--- a/AlasTests/Integrations/GitHubCLIProviderTests.swift
+++ b/AlasTests/Integrations/GitHubCLIProviderTests.swift
@@ -1589,6 +1589,7 @@ struct GitHubCLIProviderTests {
         #expect(thread.path == "Sources/Foo.swift")
         #expect(thread.line == 42)
         #expect(thread.originalLine == 40)
+        #expect(thread.originalStartLine == 38)
         #expect(thread.diffHunk == "@@ -40,3 +40,3 @@")
         #expect(thread.viewerCanResolve == true)
         #expect(thread.comments.first?.id == "c1")
@@ -2267,7 +2268,7 @@ struct GitHubCLIProviderTests {
           {
             "id": "thread-1", "isResolved": false, "isOutdated": false,
             "path": "Sources/Foo.swift", "line": 42, "startLine": null,
-            "originalLine": 40,
+            "originalLine": 40, "originalStartLine": 38,
             "subjectType": "LINE", "viewerCanResolve": true, "viewerCanReply": true,
             "comments": { "nodes": [
               { "id": "c1", "body": "rename this",

--- a/AlasTests/Integrations/GitLabCLIProviderTests.swift
+++ b/AlasTests/Integrations/GitLabCLIProviderTests.swift
@@ -179,6 +179,89 @@ struct GitLabCLIProviderTests {
         #expect(threads.first?.comments.first?.id == "100")
     }
 
+    @Test func discussionsJSONPreservesLineRangeMetadata() throws {
+        let threads = try GitLabCLIProvider.parseDiscussions(
+            """
+            [
+              {
+                "id": "discussion-1",
+                "resolved": false,
+                "notes": [
+                  {
+                    "id": 100,
+                    "body": "This needs a guard.",
+                    "system": false,
+                    "web_url": "https://gitlab.example.com/group/proj/-/merge_requests/7#note_100",
+                    "author": { "username": "reviewer" },
+                    "position": {
+                      "new_path": "Sources/App.swift",
+                      "old_path": "Sources/App.swift",
+                      "new_line": 26,
+                      "old_line": null,
+                      "line_range": {
+                        "start": {
+                          "type": "new",
+                          "new_line": 24,
+                          "old_line": null
+                        },
+                        "end": {
+                          "type": "new",
+                          "new_line": 26,
+                          "old_line": null
+                        }
+                      }
+                    }
+                  }
+                ]
+              },
+              {
+                "id": "discussion-2",
+                "resolved": false,
+                "notes": [
+                  {
+                    "id": 101,
+                    "body": "This deleted range needs a guard.",
+                    "system": false,
+                    "web_url": "https://gitlab.example.com/group/proj/-/merge_requests/7#note_101",
+                    "author": { "username": "reviewer" },
+                    "position": {
+                      "new_path": "Sources/App.swift",
+                      "old_path": "Sources/App.swift",
+                      "new_line": null,
+                      "old_line": 14,
+                      "line_range": {
+                        "start": {
+                          "type": "old",
+                          "new_line": null,
+                          "old_line": 12
+                        },
+                        "end": {
+                          "type": "old",
+                          "new_line": null,
+                          "old_line": 14
+                        }
+                      }
+                    }
+                  }
+                ]
+              }
+            ]
+            """,
+            requestURL: URL(string: "https://gitlab.example.com/group/proj/-/merge_requests/7")!
+        )
+
+        #expect(threads.map(\.id) == ["discussion-1", "discussion-2"])
+        #expect(threads[0].line == 26)
+        #expect(threads[0].startLine == 24)
+        #expect(threads[0].originalLine == nil)
+        #expect(threads[0].originalStartLine == nil)
+        #expect(threads[1].line == nil)
+        #expect(threads[1].startLine == nil)
+        #expect(threads[1].originalLine == 14)
+        #expect(threads[1].originalStartLine == 12)
+        #expect(threads[1].diffSide == "LEFT")
+    }
+
     @Test func discussionsJSONIgnoresMalformedPositionMetadata() throws {
         let threads = try GitLabCLIProvider.parseDiscussions(
             """


### PR DESCRIPTION
## Summary

Adds a visual link between review comment cards and the exact diff rows they refer to. Hovering or focusing a thread, draft, or inline feedback card now highlights the corresponding code range so reviewers can keep the comment context visible while scanning the diff.

## Changes

- Thread active comment state through the diff pane and review file section for provider threads, local draft comments, and inline feedback cards.
- Add a shared `DiffReviewCommentHighlight` model that maps comment anchors to rendered visible diff row ranges.
- Draw the active code range with a subtle blue fill and outline, and draw the gutter as a full-width blue band instead of preserving the add/delete gutter tint.
- Keep provider thread highlights active while either hover or keyboard focus remains on the comment card.
- Keep draft and inline-feedback hover priority distinct from focused-card fallbacks so real hover wins across card types.
- Prefer hovered provider thread highlights over focused parent highlights when both are visible in the same diff segment.
- Preserve multi-line provider thread ranges while still placing the card after the provider's end line.
- Carry GitHub `originalStartLine` for old-side provider thread ranges so deleted/left-side multi-line comments highlight the selected old rows.
- Decode GitLab `position.line_range` starts so loaded GitLab multi-line discussions highlight the selected range.
- Include provider thread start lines in the review render-context cache key so cached multi-line ranges refresh correctly.
- Match paired context rows against the requested old/new side line number so old-side comments still highlight after line-number drift.
- Clip the active gutter band when the highlighted range starts above the visible ruler area.
- Avoid forwarding highlights for hidden collapsed child rows when there is no visible row for the native text view to paint.
- Rebase onto current `main` and integrate with the review render-context cache.
- Add focused Swift Testing coverage for row matching, highlight geometry, hover/focus active-state handling, visible-row matching, multi-line thread range handling, paired-row line matching, gutter clipping, cache invalidation, old-side provider range starts, GitLab line-range parsing, and active-card precedence.

## Validation

- `xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' test -only-testing:AlasTests/GitLabCLIProviderTests` passed: 88 tests.
- `xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' test -only-testing:AlasTests/GitHubCLIProviderTests -only-testing:AlasTests/CodeHostModelsTests -only-testing:AlasTests/DiffReviewSurfaceTests` passed: 171 tests.
- `xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' test -only-testing:AlasTests/ReviewThreadModelTests` passed: 3 tests.
- `xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' test -only-testing:AlasTests/DiffPaneViewTests` passed: 78 tests.
- `xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' test -only-testing:AlasTests/DiffReviewSurfaceTests` passed: 89 tests.
- `xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' test -only-testing:AlasTests/DiffPaneViewTests -only-testing:AlasTests/DiffReviewSurfaceTests -only-testing:AlasTests/DiffInlineCommentModelTests -only-testing:AlasTests/ACPMarkdownInlineRendererTests` passed previously: 200 tests.
- `xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -quiet build` passed.
- `git diff --check` passed.

## Notes for reviewers

Start with `Alas/Sources/Center/Diff/DiffPaneTextDocumentView.swift` for the rendering behavior and `Alas/Sources/Center/DiffReview/DiffReviewFileSection.swift` for the review-card activation wiring.