### PR TITLE
fix(review): stop draft-commit diff live-lock beachball

### DIFF
--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -60,6 +60,7 @@
 		0DA68649E5F3C0018C4309DA /* UpdateThrottleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 708AB670AB611EFB9D216D7C /* UpdateThrottleTests.swift */; };
 		0DFC9AB26DDCC406CEAA3825 /* ACPContextUsageButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AD22187C951174C9ECEC4C4 /* ACPContextUsageButton.swift */; };
 		0E2D69C181ECD5233770BC01 /* AgentRunnerParseTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E267334F2224961856D20BD8 /* AgentRunnerParseTests.swift */; };
+		0E680F7AAD6CBD2A4A829A52 /* DiffReviewRenderableContentEqualityTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D153832D43BF352B94E34430 /* DiffReviewRenderableContentEqualityTests.swift */; };
 		0E892EAAAC4EBA733BC441F2 /* MergeRegionVisualLayout.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0FF6BFD0A460F0E723F796E /* MergeRegionVisualLayout.swift */; };
 		0EB3B61ECD46CCF450E717BF /* EditorOverlayPanelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 208C9ABAF59F523D2DDC2F2A /* EditorOverlayPanelTests.swift */; };
 		0EC2E8C6E5E00DD040CC4847 /* AppStateCleanupTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 447D95D444F6AE08FCFA27A3 /* AppStateCleanupTests.swift */; };
@@ -2051,6 +2052,7 @@
 		D0EE31A4EB90FFE45DC46420 /* BuildIdentityTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BuildIdentityTests.swift; sourceTree = "<group>"; };
 		D0FF6BFD0A460F0E723F796E /* MergeRegionVisualLayout.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MergeRegionVisualLayout.swift; sourceTree = "<group>"; };
 		D12F540ABB23DDB829E1629D /* ProjectGitWatcher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProjectGitWatcher.swift; sourceTree = "<group>"; };
+		D153832D43BF352B94E34430 /* DiffReviewRenderableContentEqualityTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiffReviewRenderableContentEqualityTests.swift; sourceTree = "<group>"; };
 		D1B15CAE2163ED7C1A670F46 /* ACPComposerDraftTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPComposerDraftTests.swift; sourceTree = "<group>"; };
 		D1CD33324CA36118FCEA2BE2 /* AdvancedSettingsVisibilityTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AdvancedSettingsVisibilityTests.swift; sourceTree = "<group>"; };
 		D1EACA79C819C9FBE68F9D84 /* RemoteServer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteServer.swift; sourceTree = "<group>"; };
@@ -2509,6 +2511,7 @@
 				E5A257562FAB9C5932A6BD69 /* DiffPaneViewTests.swift */,
 				EE26221DC8E8837FFEB87474 /* DiffParserTests.swift */,
 				A172B476A5BF7E4016431E6A /* DiffReviewModelsTests.swift */,
+				D153832D43BF352B94E34430 /* DiffReviewRenderableContentEqualityTests.swift */,
 				A723CF5BB46FABA23D8C9543 /* DiffReviewRenderEligibilityTests.swift */,
 				F649B493D42787FEA6D8E67B /* DiffReviewScrollSpyTests.swift */,
 				E0F10B6B1311831E53DA45C0 /* DiffReviewStagedMutationActionsTests.swift */,
@@ -5340,6 +5343,7 @@
 				0CF488290CC525EA7C11A43C /* DiffParserTests.swift in Sources */,
 				59AF95D3DFDFE7736051EF4A /* DiffReviewModelsTests.swift in Sources */,
 				BF887495CBAAA98792FBF74D /* DiffReviewRenderEligibilityTests.swift in Sources */,
+				0E680F7AAD6CBD2A4A829A52 /* DiffReviewRenderableContentEqualityTests.swift in Sources */,
 				14D70126BAF735B2A66A23C5 /* DiffReviewScrollSpyTests.swift in Sources */,
 				82F5A171BDDFE0A5E0BD587A /* DiffReviewStagedMutationActionsTests.swift in Sources */,
 				8FFF1CF8720587ADC3FFA688 /* DiffReviewSurfaceTests.swift in Sources */,

--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -941,6 +941,7 @@
 		D1F372532A0F9607051020F5 /* HarnessDetectorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F198697EB5305E5ECE97BC61 /* HarnessDetectorTests.swift */; };
 		D1FF11465D1309A56FCFFAF0 /* AppConfigCodeInstallTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8ACFACD788DF2035534F62E /* AppConfigCodeInstallTests.swift */; };
 		D204CCA2E2FE480D2C502186 /* ACPSessionManagerHydrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 472917238C382A8125A84103 /* ACPSessionManagerHydrationTests.swift */; };
+		D215CAABE4DE2F5CE3CB0E93 /* DiffReviewFileSectionEqualityTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 27EEC16C786CE9430C1AC174 /* DiffReviewFileSectionEqualityTests.swift */; };
 		D27A1F6D7592D6A4BDD9FC4F /* GitIgnoreServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6EB58175A9A39073E9D73F85 /* GitIgnoreServiceTests.swift */; };
 		D27A85DE79B3B62C6F91174A /* ReviewFeedbackBundle.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0886F9B3096AC1264E3D337 /* ReviewFeedbackBundle.swift */; };
 		D28EE6309DBB51EFEDCEAC18 /* ACPSessionManagerLeaseTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 96C13707B79B7A4F4BB2608E /* ACPSessionManagerLeaseTests.swift */; };
@@ -1314,6 +1315,7 @@
 		279D43D7F43C40A004A2C4AC /* AppStateTabAvailabilityTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppStateTabAvailabilityTests.swift; sourceTree = "<group>"; };
 		27A92711BC1D9A78D8A80561 /* GitTypes.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GitTypes.swift; sourceTree = "<group>"; };
 		27E7E4823B42BBA6EA7610DB /* CommitFilesListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommitFilesListView.swift; sourceTree = "<group>"; };
+		27EEC16C786CE9430C1AC174 /* DiffReviewFileSectionEqualityTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiffReviewFileSectionEqualityTests.swift; sourceTree = "<group>"; };
 		28777B087266D8AE174BA233 /* SpaceEmojiPickerSelectionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpaceEmojiPickerSelectionTests.swift; sourceTree = "<group>"; };
 		292B5DA9EC17ED07588C48FD /* OpenCodeInstallerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OpenCodeInstallerTests.swift; sourceTree = "<group>"; };
 		29313DDC46A0CCA2FA42CDE9 /* Icon.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Icon.swift; sourceTree = "<group>"; };
@@ -2510,6 +2512,7 @@
 				AD920E9E496F1DC3BB894B8B /* DiffPaneLSPTests.swift */,
 				E5A257562FAB9C5932A6BD69 /* DiffPaneViewTests.swift */,
 				EE26221DC8E8837FFEB87474 /* DiffParserTests.swift */,
+				27EEC16C786CE9430C1AC174 /* DiffReviewFileSectionEqualityTests.swift */,
 				A172B476A5BF7E4016431E6A /* DiffReviewModelsTests.swift */,
 				D153832D43BF352B94E34430 /* DiffReviewRenderableContentEqualityTests.swift */,
 				A723CF5BB46FABA23D8C9543 /* DiffReviewRenderEligibilityTests.swift */,
@@ -5341,6 +5344,7 @@
 				F4796D2FCBA83BD5E71F4398 /* DiffPaneLSPTests.swift in Sources */,
 				F4FF07CA337DB0D0035C3C10 /* DiffPaneViewTests.swift in Sources */,
 				0CF488290CC525EA7C11A43C /* DiffParserTests.swift in Sources */,
+				D215CAABE4DE2F5CE3CB0E93 /* DiffReviewFileSectionEqualityTests.swift in Sources */,
 				59AF95D3DFDFE7736051EF4A /* DiffReviewModelsTests.swift in Sources */,
 				BF887495CBAAA98792FBF74D /* DiffReviewRenderEligibilityTests.swift in Sources */,
 				0E680F7AAD6CBD2A4A829A52 /* DiffReviewRenderableContentEqualityTests.swift in Sources */,

--- a/Alas/Sources/Center/Commit/DraftCommitTabView.swift
+++ b/Alas/Sources/Center/Commit/DraftCommitTabView.swift
@@ -69,9 +69,12 @@ struct DraftCommitTabView: View {
     // (not per render): rebuilding on every body evaluation created fresh
     // closures each time, which made the whole review subtree incomparable
     // for SwiftUI and re-diffed hundreds of platform views on every
-    // watcher-driven refresh. The closures read `busy` through @State
-    // storage, so they always see the current value without recreation.
+    // watcher-driven refresh. `unstageEnabledBase` is captured as plain data
+    // (not just read live inside the closure) so the equality-gated
+    // DiffReviewFileSection can detect a `busy` flip even when the session's
+    // content is otherwise unchanged — see `refreshActionsOverlay`.
     private func overlayingActions(on session: DiffReviewLoadedSession) -> DiffReviewLoadedSession {
+        let unstageEnabledBase = !busy
         let filesWithActions = session.files.map { model in
             var m = model
             m.stagedMutationActions = DiffReviewStagedMutationActions(
@@ -82,8 +85,9 @@ struct DraftCommitTabView: View {
                     unstageHunk(path: model.summary.path, hunk: hunk)
                 },
                 isHunkUnstageEnabled: { hunk in
-                    !busy && model.summary.gitStatus == "M" && !hunk.lines.isEmpty
-                }
+                    unstageEnabledBase && model.summary.gitStatus == "M" && !hunk.lines.isEmpty
+                },
+                unstageEnabledBase: unstageEnabledBase
             )
             return m
         }
@@ -99,6 +103,15 @@ struct DraftCommitTabView: View {
         }
         stagedSession = session
         sessionWithActions = overlayingActions(on: session)
+    }
+
+    // `busy` isn't part of `stagedKey`, so it never triggers a session
+    // reload — but it does change what `isHunkUnstageEnabled` should
+    // return. Rebuild just the (cheap, no-I/O) action overlay so that
+    // change is visible to the equality-gated file sections.
+    private func refreshActionsOverlay() {
+        guard let stagedSession else { return }
+        sessionWithActions = overlayingActions(on: stagedSession)
     }
 
     var body: some View {
@@ -155,6 +168,7 @@ struct DraftCommitTabView: View {
             }
         }
         .onChange(of: selectedFileID) { _, new in persist(selectedPath: new?.path) }
+        .onChange(of: busy) { _, _ in refreshActionsOverlay() }
         .task(id: stagedKey) { await loadStagedSession() }
     }
 

--- a/Alas/Sources/Center/Commit/DraftCommitTabView.swift
+++ b/Alas/Sources/Center/Commit/DraftCommitTabView.swift
@@ -19,6 +19,7 @@ struct DraftCommitTabView: View {
     @State private var generation: Task<Void, Never>? = nil
 
     @State private var stagedSession: DiffReviewLoadedSession?
+    @State private var sessionWithActions: DiffReviewLoadedSession?
     @State private var selectedFileID: DiffReviewFileID?
     @State private var loadingSession = false
     @State private var railCollapsed = false
@@ -64,10 +65,13 @@ struct DraftCommitTabView: View {
         appState.rightPaneStore.activeState(worktreeId: worktreeId)?.currentHeadSHA ?? ""
     }
 
-    // Computed property that overlays mutation actions onto the loaded session.
-    // Reads `busy` fresh on each render so closures always see current value.
-    private var sessionWithActions: DiffReviewLoadedSession? {
-        guard let session = stagedSession else { return nil }
+    // Overlays mutation actions onto a loaded session. Built once per load
+    // (not per render): rebuilding on every body evaluation created fresh
+    // closures each time, which made the whole review subtree incomparable
+    // for SwiftUI and re-diffed hundreds of platform views on every
+    // watcher-driven refresh. The closures read `busy` through @State
+    // storage, so they always see the current value without recreation.
+    private func overlayingActions(on session: DiffReviewLoadedSession) -> DiffReviewLoadedSession {
         let filesWithActions = session.files.map { model in
             var m = model
             m.stagedMutationActions = DiffReviewStagedMutationActions(
@@ -84,6 +88,17 @@ struct DraftCommitTabView: View {
             return m
         }
         return DiffReviewLoadedSession(files: filesWithActions, summary: session.summary)
+    }
+
+    private func publishLoadedSession(_ session: DiffReviewLoadedSession) {
+        // Same visible content: keep the existing instances so the
+        // equality-gated file sections hit the O(1) same-storage fast path
+        // and nothing downstream re-renders.
+        if let existing = stagedSession, existing.hasSameRenderableContent(as: session) {
+            return
+        }
+        stagedSession = session
+        sessionWithActions = overlayingActions(on: session)
     }
 
     var body: some View {
@@ -313,13 +328,14 @@ struct DraftCommitTabView: View {
         do {
             let session = try await StagedDiffLoader().load(worktreePath: worktreePath)
             guard !Task.isCancelled, stagedKey == token else { return }
-            stagedSession = session
+            publishLoadedSession(session)
             synchronizeSelection(with: session)
         } catch is CancellationError {
             // ignore
         } catch {
             guard stagedKey == token else { return }
             stagedSession = nil
+            sessionWithActions = nil
             self.error = (error as NSError).localizedDescription
         }
     }

--- a/Alas/Sources/Center/Diff/DiffPaneLSP.swift
+++ b/Alas/Sources/Center/Diff/DiffPaneLSP.swift
@@ -20,6 +20,24 @@ struct DiffPaneLSPContext {
     }
 }
 
+extension DiffPaneLSPContext {
+    /// Render-relevant equality: ignores the `openTarget` closure, which is
+    /// not comparable and does not affect what gets drawn.
+    static func rendersEqual(_ lhs: DiffPaneLSPContext?, _ rhs: DiffPaneLSPContext?) -> Bool {
+        switch (lhs, rhs) {
+        case (nil, nil):
+            return true
+        case let (l?, r?):
+            return l.worktreeId == r.worktreeId
+                && l.relativePath == r.relativePath
+                && l.language == r.language
+                && l.lsp === r.lsp
+        default:
+            return false
+        }
+    }
+}
+
 enum DiffPaneLSPLineMap {
     struct Match: Equatable {
         let position: LSPPosition

--- a/Alas/Sources/Center/DiffReview/DiffReviewFileSection.swift
+++ b/Alas/Sources/Center/DiffReview/DiffReviewFileSection.swift
@@ -878,7 +878,30 @@ struct DiffReviewFileSection: View {
     }
 }
 
-extension DiffReviewFileSection: Equatable {
+/// Wraps `DiffReviewFileSection` for `.equatable()`, with `layoutMode`,
+/// `wrapLines`, and `showWhitespace` captured as plain values rather than
+/// compared as live `@Binding`s.
+///
+/// `DiffReviewFileSection` itself deliberately does NOT conform to
+/// `Equatable`: comparing a `@Binding`'s `wrappedValue` inside `==` doesn't
+/// work for render-equality — the previously-rendered struct and a
+/// freshly-constructed one both read through to the SAME live external
+/// storage, so `lhs.layoutMode == rhs.layoutMode` always reports the
+/// CURRENT (post-change) value on both sides regardless of what actually
+/// changed between renders. Concretely: toggling split/stacked layout,
+/// line wrap, or whitespace display would silently do nothing, because the
+/// gate would report "unchanged" even though the setting changed. Plain
+/// snapshots, captured once by the caller at construction time (not read
+/// through a binding), are what actually distinguish "before" from
+/// "after".
+struct EquatableDiffReviewFileSection: View, Equatable {
+    let section: DiffReviewFileSection
+    let layoutMode: DiffLayoutMode
+    let wrapLines: Bool
+    let showWhitespace: Bool
+
+    var body: some View { section }
+
     /// Render-relevant equality so SwiftUI can skip this subtree — which hosts
     /// one `NSViewRepresentable` per diff segment — when a parent body storm
     /// (watcher refresh, keystroke, unrelated observable write) did not change
@@ -888,27 +911,27 @@ extension DiffReviewFileSection: Equatable {
     /// `@Observable` storage or capture per-file constants that the content
     /// comparison already covers. `@State` / `@StateObject` / `@Environment`
     /// dependencies are tracked by SwiftUI independently of this comparison.
-    static func == (lhs: DiffReviewFileSection, rhs: DiffReviewFileSection) -> Bool {
-        lhs.file.hasSameRenderableContent(as: rhs.file)
-            && lhs.inlineFeedback == rhs.inlineFeedback
-            && lhs.focusedFeedbackID == rhs.focusedFeedbackID
-            && lhs.inlineFeedbackScrollTargetID == rhs.inlineFeedbackScrollTargetID
-            && lhs.draftComments == rhs.draftComments
-            && lhs.focusedDraftCommentID == rhs.focusedDraftCommentID
-            && lhs.layoutMode == rhs.layoutMode
+    static func == (lhs: EquatableDiffReviewFileSection, rhs: EquatableDiffReviewFileSection) -> Bool {
+        lhs.layoutMode == rhs.layoutMode
             && lhs.wrapLines == rhs.wrapLines
             && lhs.showWhitespace == rhs.showWhitespace
-            && lhs.codeFontFamily == rhs.codeFontFamily
-            && lhs.codeFontSize == rhs.codeFontSize
-            && lhs.showsSourceBadge == rhs.showsSourceBadge
-            && DiffPaneLSPContext.rendersEqual(lhs.lspContext, rhs.lspContext)
-            && lhs.allowsDraftCommentCreation == rhs.allowsDraftCommentCreation
-            && lhs.reviewFeedbackTarget == rhs.reviewFeedbackTarget
-            && lhs.threads == rhs.threads
-            && lhs.annotations == rhs.annotations
-            && lhs.canReply == rhs.canReply
-            && lhs.canResolve == rhs.canResolve
-            && lhs.canAddToReview == rhs.canAddToReview
+            && lhs.section.file.hasSameRenderableContent(as: rhs.section.file)
+            && lhs.section.inlineFeedback == rhs.section.inlineFeedback
+            && lhs.section.focusedFeedbackID == rhs.section.focusedFeedbackID
+            && lhs.section.inlineFeedbackScrollTargetID == rhs.section.inlineFeedbackScrollTargetID
+            && lhs.section.draftComments == rhs.section.draftComments
+            && lhs.section.focusedDraftCommentID == rhs.section.focusedDraftCommentID
+            && lhs.section.codeFontFamily == rhs.section.codeFontFamily
+            && lhs.section.codeFontSize == rhs.section.codeFontSize
+            && lhs.section.showsSourceBadge == rhs.section.showsSourceBadge
+            && DiffPaneLSPContext.rendersEqual(lhs.section.lspContext, rhs.section.lspContext)
+            && lhs.section.allowsDraftCommentCreation == rhs.section.allowsDraftCommentCreation
+            && lhs.section.reviewFeedbackTarget == rhs.section.reviewFeedbackTarget
+            && lhs.section.threads == rhs.section.threads
+            && lhs.section.annotations == rhs.section.annotations
+            && lhs.section.canReply == rhs.section.canReply
+            && lhs.section.canResolve == rhs.section.canResolve
+            && lhs.section.canAddToReview == rhs.section.canAddToReview
     }
 }
 

--- a/Alas/Sources/Center/DiffReview/DiffReviewFileSection.swift
+++ b/Alas/Sources/Center/DiffReview/DiffReviewFileSection.swift
@@ -878,6 +878,40 @@ struct DiffReviewFileSection: View {
     }
 }
 
+extension DiffReviewFileSection: Equatable {
+    /// Render-relevant equality so SwiftUI can skip this subtree — which hosts
+    /// one `NSViewRepresentable` per diff segment — when a parent body storm
+    /// (watcher refresh, keystroke, unrelated observable write) did not change
+    /// anything visible here. Closure inputs (action structs, selection
+    /// callbacks) are intentionally excluded: an older closure generation
+    /// stays correct because they read live values through `@State` /
+    /// `@Observable` storage or capture per-file constants that the content
+    /// comparison already covers. `@State` / `@StateObject` / `@Environment`
+    /// dependencies are tracked by SwiftUI independently of this comparison.
+    static func == (lhs: DiffReviewFileSection, rhs: DiffReviewFileSection) -> Bool {
+        lhs.file.hasSameRenderableContent(as: rhs.file)
+            && lhs.inlineFeedback == rhs.inlineFeedback
+            && lhs.focusedFeedbackID == rhs.focusedFeedbackID
+            && lhs.inlineFeedbackScrollTargetID == rhs.inlineFeedbackScrollTargetID
+            && lhs.draftComments == rhs.draftComments
+            && lhs.focusedDraftCommentID == rhs.focusedDraftCommentID
+            && lhs.layoutMode == rhs.layoutMode
+            && lhs.wrapLines == rhs.wrapLines
+            && lhs.showWhitespace == rhs.showWhitespace
+            && lhs.codeFontFamily == rhs.codeFontFamily
+            && lhs.codeFontSize == rhs.codeFontSize
+            && lhs.showsSourceBadge == rhs.showsSourceBadge
+            && DiffPaneLSPContext.rendersEqual(lhs.lspContext, rhs.lspContext)
+            && lhs.allowsDraftCommentCreation == rhs.allowsDraftCommentCreation
+            && lhs.reviewFeedbackTarget == rhs.reviewFeedbackTarget
+            && lhs.threads == rhs.threads
+            && lhs.annotations == rhs.annotations
+            && lhs.canReply == rhs.canReply
+            && lhs.canResolve == rhs.canResolve
+            && lhs.canAddToReview == rhs.canAddToReview
+    }
+}
+
 enum ReviewDraftComposerKeyboardAction: Equatable {
     case save
     case cancel

--- a/Alas/Sources/Center/DiffReview/DiffReviewFileSection.swift
+++ b/Alas/Sources/Center/DiffReview/DiffReviewFileSection.swift
@@ -896,13 +896,14 @@ struct DiffReviewFileSection: View {
 /// through a binding), are what actually distinguish "before" from
 /// "after".
 ///
-/// The same problem applies to `draftCommentActions.availability` and
-/// `inlineFeedbackActions.availability`: the comment/feedback lists they're
-/// applied to can stay unchanged while what's available for them changes
-/// (e.g. an agent send-target becomes available), and `ReviewDraftCommentCard`
-/// / `DiffReviewInlineFeedbackCard` render their action rows from that
-/// result. The closures aren't comparable, so the caller evaluates them
-/// once per item and passes the plain `Equatable` results instead.
+/// The same problem applies to `draftCommentActions.availability`,
+/// `inlineFeedbackActions.availability`, and `draftCommentActions.agentTargets()`:
+/// the comment/feedback lists they're applied to can stay unchanged while
+/// what's available for them (or the send-to-agent target list itself)
+/// changes, and `ReviewDraftCommentCard` / `DiffReviewInlineFeedbackCard`
+/// render their action rows from that result. The closures aren't
+/// comparable, so the caller evaluates them once and passes the plain
+/// `Equatable` results instead.
 struct EquatableDiffReviewFileSection: View, Equatable {
     let section: DiffReviewFileSection
     let layoutMode: DiffLayoutMode
@@ -910,6 +911,13 @@ struct EquatableDiffReviewFileSection: View, Equatable {
     let showWhitespace: Bool
     let draftCommentAvailability: [ReviewDraftCommentActionAvailability]
     let inlineFeedbackAvailability: [DiffReviewInlineFeedbackActionAvailability]
+    /// Snapshot of `draftCommentActions.agentTargets()`. `sendToAgentControl`
+    /// renders this list live (as a single button or a menu with per-target
+    /// titles) independent of the `canSendToAgent`/`canShowSendToAgent`
+    /// booleans already captured above — the target set (or a target's
+    /// title) can change while availability stays true, and the closure
+    /// itself isn't comparable.
+    let draftCommentAgentTargets: [ReviewFeedbackAgentTarget]
 
     var body: some View { section }
 
@@ -928,6 +936,7 @@ struct EquatableDiffReviewFileSection: View, Equatable {
             && lhs.showWhitespace == rhs.showWhitespace
             && lhs.draftCommentAvailability == rhs.draftCommentAvailability
             && lhs.inlineFeedbackAvailability == rhs.inlineFeedbackAvailability
+            && lhs.draftCommentAgentTargets == rhs.draftCommentAgentTargets
             && lhs.section.file.hasSameRenderableContent(as: rhs.section.file)
             && lhs.section.inlineFeedback == rhs.section.inlineFeedback
             && lhs.section.focusedFeedbackID == rhs.section.focusedFeedbackID

--- a/Alas/Sources/Center/DiffReview/DiffReviewFileSection.swift
+++ b/Alas/Sources/Center/DiffReview/DiffReviewFileSection.swift
@@ -880,7 +880,8 @@ struct DiffReviewFileSection: View {
 
 /// Wraps `DiffReviewFileSection` for `.equatable()`, with `layoutMode`,
 /// `wrapLines`, and `showWhitespace` captured as plain values rather than
-/// compared as live `@Binding`s.
+/// compared as live `@Binding`s, plus per-item action-availability
+/// snapshots for draft comments and inline feedback.
 ///
 /// `DiffReviewFileSection` itself deliberately does NOT conform to
 /// `Equatable`: comparing a `@Binding`'s `wrappedValue` inside `==` doesn't
@@ -894,11 +895,21 @@ struct DiffReviewFileSection: View {
 /// snapshots, captured once by the caller at construction time (not read
 /// through a binding), are what actually distinguish "before" from
 /// "after".
+///
+/// The same problem applies to `draftCommentActions.availability` and
+/// `inlineFeedbackActions.availability`: the comment/feedback lists they're
+/// applied to can stay unchanged while what's available for them changes
+/// (e.g. an agent send-target becomes available), and `ReviewDraftCommentCard`
+/// / `DiffReviewInlineFeedbackCard` render their action rows from that
+/// result. The closures aren't comparable, so the caller evaluates them
+/// once per item and passes the plain `Equatable` results instead.
 struct EquatableDiffReviewFileSection: View, Equatable {
     let section: DiffReviewFileSection
     let layoutMode: DiffLayoutMode
     let wrapLines: Bool
     let showWhitespace: Bool
+    let draftCommentAvailability: [ReviewDraftCommentActionAvailability]
+    let inlineFeedbackAvailability: [DiffReviewInlineFeedbackActionAvailability]
 
     var body: some View { section }
 
@@ -915,6 +926,8 @@ struct EquatableDiffReviewFileSection: View, Equatable {
         lhs.layoutMode == rhs.layoutMode
             && lhs.wrapLines == rhs.wrapLines
             && lhs.showWhitespace == rhs.showWhitespace
+            && lhs.draftCommentAvailability == rhs.draftCommentAvailability
+            && lhs.inlineFeedbackAvailability == rhs.inlineFeedbackAvailability
             && lhs.section.file.hasSameRenderableContent(as: rhs.section.file)
             && lhs.section.inlineFeedback == rhs.section.inlineFeedback
             && lhs.section.focusedFeedbackID == rhs.section.focusedFeedbackID

--- a/Alas/Sources/Center/DiffReview/DiffReviewModels.swift
+++ b/Alas/Sources/Center/DiffReview/DiffReviewModels.swift
@@ -178,6 +178,12 @@ struct DiffReviewStagedMutationActions {
     var unstageFile: (() -> Void)? = nil
     var unstageHunk: ((ParsedDiff.Hunk) -> Void)? = nil
     var isHunkUnstageEnabled: ((ParsedDiff.Hunk) -> Bool)? = nil
+    /// The busy-derived component of what `isHunkUnstageEnabled` returns,
+    /// captured as plain data. The closure itself can't participate in
+    /// render equality, so without this, toggling `busy` wouldn't change
+    /// `renderablePresence` and the equality-gated `DiffReviewFileSection`
+    /// could leave "Drop from commit" stuck showing a stale enabled state.
+    var unstageEnabledBase: Bool = true
 }
 
 struct DiffReviewFileSectionModel: Identifiable {
@@ -287,18 +293,21 @@ struct DiffReviewLoadedSession {
 }
 
 extension DiffReviewStagedMutationActions {
-    /// Closure identity is not comparable; which actions exist is what
-    /// determines the rendered buttons.
-    var renderablePresence: (Bool, Bool, Bool) {
-        (unstageFile != nil, unstageHunk != nil, isHunkUnstageEnabled != nil)
+    /// Closure identity is not comparable; which actions exist plus the
+    /// captured `unstageEnabledBase` snapshot is what determines the
+    /// rendered buttons and their enabled state.
+    var renderableSignature: (Bool, Bool, Bool, Bool) {
+        (unstageFile != nil, unstageHunk != nil, isHunkUnstageEnabled != nil, unstageEnabledBase)
     }
 }
 
 extension DiffReviewFileSectionModel {
     /// True when this model renders identically to `other`. Ignores closure
-    /// identity for `openFile` and mutation action bodies (presence is what
-    /// determines the rendered buttons) — but `contextProvider` is compared
-    /// by `id`, not just presence: `DiffReviewFileSection` keys its own
+    /// identity for `openFile` and mutation action bodies — `stagedMutationActions`
+    /// is compared via `renderableSignature` (presence plus the captured
+    /// `unstageEnabledBase` snapshot, since that drives whether "Drop from
+    /// commit" renders as enabled). `contextProvider` is compared by `id`,
+    /// not just presence: `DiffReviewFileSection` keys its own
     /// stale-load-rejection and reset logic off that id (see
     /// `contextStateSignature`), so treating two different providers as
     /// equal would let a swapped-in file keep serving a previous provider's
@@ -310,8 +319,8 @@ extension DiffReviewFileSectionModel {
             && placeholderMessage == other.placeholderMessage
             && (openFile == nil) == (other.openFile == nil)
             && contextProvider?.id == other.contextProvider?.id
-            && (stagedMutationActions?.renderablePresence ?? (false, false, false))
-                == (other.stagedMutationActions?.renderablePresence ?? (false, false, false))
+            && (stagedMutationActions?.renderableSignature ?? (false, false, false, true))
+                == (other.stagedMutationActions?.renderableSignature ?? (false, false, false, true))
     }
 }
 

--- a/Alas/Sources/Center/DiffReview/DiffReviewModels.swift
+++ b/Alas/Sources/Center/DiffReview/DiffReviewModels.swift
@@ -286,6 +286,38 @@ struct DiffReviewLoadedSession {
     let summary: DiffReviewSessionModel
 }
 
+extension DiffReviewStagedMutationActions {
+    /// Closure identity is not comparable; which actions exist is what
+    /// determines the rendered buttons.
+    var renderablePresence: (Bool, Bool, Bool) {
+        (unstageFile != nil, unstageHunk != nil, isHunkUnstageEnabled != nil)
+    }
+}
+
+extension DiffReviewFileSectionModel {
+    /// True when this model renders identically to `other`. Ignores closure
+    /// identity (`openFile`, `contextProvider.snapshot`, mutation action
+    /// bodies) — only content and action presence are compared, so freshly
+    /// rebuilt models with equivalent content still count as unchanged.
+    func hasSameRenderableContent(as other: DiffReviewFileSectionModel) -> Bool {
+        summary == other.summary
+            && parsedDiff == other.parsedDiff
+            && displayModel == other.displayModel
+            && placeholderMessage == other.placeholderMessage
+            && (openFile == nil) == (other.openFile == nil)
+            && (contextProvider == nil) == (other.contextProvider == nil)
+            && (stagedMutationActions?.renderablePresence ?? (false, false, false))
+                == (other.stagedMutationActions?.renderablePresence ?? (false, false, false))
+    }
+}
+
+extension DiffReviewLoadedSession {
+    func hasSameRenderableContent(as other: DiffReviewLoadedSession) -> Bool {
+        guard summary == other.summary, files.count == other.files.count else { return false }
+        return zip(files, other.files).allSatisfy { $0.hasSameRenderableContent(as: $1) }
+    }
+}
+
 struct DiffReviewFileTreeNode: Codable, Equatable, Identifiable {
     enum Kind: String, Codable {
         case directory

--- a/Alas/Sources/Center/DiffReview/DiffReviewModels.swift
+++ b/Alas/Sources/Center/DiffReview/DiffReviewModels.swift
@@ -296,16 +296,20 @@ extension DiffReviewStagedMutationActions {
 
 extension DiffReviewFileSectionModel {
     /// True when this model renders identically to `other`. Ignores closure
-    /// identity (`openFile`, `contextProvider.snapshot`, mutation action
-    /// bodies) — only content and action presence are compared, so freshly
-    /// rebuilt models with equivalent content still count as unchanged.
+    /// identity for `openFile` and mutation action bodies (presence is what
+    /// determines the rendered buttons) — but `contextProvider` is compared
+    /// by `id`, not just presence: `DiffReviewFileSection` keys its own
+    /// stale-load-rejection and reset logic off that id (see
+    /// `contextStateSignature`), so treating two different providers as
+    /// equal would let a swapped-in file keep serving a previous provider's
+    /// in-flight/expanded context.
     func hasSameRenderableContent(as other: DiffReviewFileSectionModel) -> Bool {
         summary == other.summary
             && parsedDiff == other.parsedDiff
             && displayModel == other.displayModel
             && placeholderMessage == other.placeholderMessage
             && (openFile == nil) == (other.openFile == nil)
-            && (contextProvider == nil) == (other.contextProvider == nil)
+            && contextProvider?.id == other.contextProvider?.id
             && (stagedMutationActions?.renderablePresence ?? (false, false, false))
                 == (other.stagedMutationActions?.renderablePresence ?? (false, false, false))
     }

--- a/Alas/Sources/Center/DiffReview/DiffReviewSurface.swift
+++ b/Alas/Sources/Center/DiffReview/DiffReviewSurface.swift
@@ -345,7 +345,8 @@ struct DiffReviewSurface: View {
             wrapLines: wrapLines,
             showWhitespace: showWhitespace,
             draftCommentAvailability: draftComments.map(draftCommentActions.availability),
-            inlineFeedbackAvailability: inlineFeedback.map { inlineFeedbackActions.availability($0, file.summary) }
+            inlineFeedbackAvailability: inlineFeedback.map { inlineFeedbackActions.availability($0, file.summary) },
+            draftCommentAgentTargets: draftCommentActions.agentTargets()
         )
         .equatable()
     }

--- a/Alas/Sources/Center/DiffReview/DiffReviewSurface.swift
+++ b/Alas/Sources/Center/DiffReview/DiffReviewSurface.swift
@@ -343,7 +343,9 @@ struct DiffReviewSurface: View {
             ),
             layoutMode: layoutMode,
             wrapLines: wrapLines,
-            showWhitespace: showWhitespace
+            showWhitespace: showWhitespace,
+            draftCommentAvailability: draftComments.map(draftCommentActions.availability),
+            inlineFeedbackAvailability: inlineFeedback.map { inlineFeedbackActions.availability($0, file.summary) }
         )
         .equatable()
     }

--- a/Alas/Sources/Center/DiffReview/DiffReviewSurface.swift
+++ b/Alas/Sources/Center/DiffReview/DiffReviewSurface.swift
@@ -302,43 +302,48 @@ struct DiffReviewSurface: View {
     private func fileSection(_ file: DiffReviewFileSectionModel) -> some View {
         let inlineFeedback = inlineFeedbackByFileID[file.id] ?? []
         let draftComments = draftCommentsByFileID[file.id] ?? []
-        DiffReviewFileSection(
-            file: file,
-            inlineFeedback: inlineFeedback,
-            focusedFeedbackID: focusedFeedbackID,
-            inlineFeedbackScrollTargetID: inlineFeedbackScrollTargetID(for: file.id),
-            draftComments: draftComments,
-            focusedDraftCommentID: focusedDraftCommentID,
-            layoutMode: $layoutMode,
-            wrapLines: $wrapLines,
-            showWhitespace: $showWhitespace,
-            codeFontFamily: codeFontFamily,
-            codeFontSize: codeFontSize,
-            showsSourceBadge: showsSourceBadges,
-            lspContext: lspContextForFile(file),
-            inlineFeedbackActions: inlineFeedbackActions,
-            onSelectInlineFeedback: onSelectInlineFeedback,
-            draftCommentActions: draftCommentActions,
-            onSelectDraftComment: onSelectDraftComment,
-            onSaveDraftComment: { anchor, body in
-                onSaveDraftComment(file.id, file.summary.originalPath, anchor, body)
-            },
-            allowsDraftCommentCreation: allowsDraftCommentCreation,
-            onContextExpansionActivated: {
-                contextExpandedFileIDs.insert(file.id)
-            },
-            reviewFeedbackTarget: effectiveReviewFeedbackTarget,
-            threads: inlineThreads(for: file.summary.path),
-            annotations: inlineAnnotations(for: file.summary.path),
-            onReply: onReply,
-            onResolve: onResolve,
-            onUnresolve: onUnresolve,
-            onEdit: onEdit,
-            onDelete: onDelete,
-            canReply: canReply,
-            canResolve: canResolve,
-            onStageReply: onStageReply,
-            canAddToReview: canAddToReview
+        EquatableDiffReviewFileSection(
+            section: DiffReviewFileSection(
+                file: file,
+                inlineFeedback: inlineFeedback,
+                focusedFeedbackID: focusedFeedbackID,
+                inlineFeedbackScrollTargetID: inlineFeedbackScrollTargetID(for: file.id),
+                draftComments: draftComments,
+                focusedDraftCommentID: focusedDraftCommentID,
+                layoutMode: $layoutMode,
+                wrapLines: $wrapLines,
+                showWhitespace: $showWhitespace,
+                codeFontFamily: codeFontFamily,
+                codeFontSize: codeFontSize,
+                showsSourceBadge: showsSourceBadges,
+                lspContext: lspContextForFile(file),
+                inlineFeedbackActions: inlineFeedbackActions,
+                onSelectInlineFeedback: onSelectInlineFeedback,
+                draftCommentActions: draftCommentActions,
+                onSelectDraftComment: onSelectDraftComment,
+                onSaveDraftComment: { anchor, body in
+                    onSaveDraftComment(file.id, file.summary.originalPath, anchor, body)
+                },
+                allowsDraftCommentCreation: allowsDraftCommentCreation,
+                onContextExpansionActivated: {
+                    contextExpandedFileIDs.insert(file.id)
+                },
+                reviewFeedbackTarget: effectiveReviewFeedbackTarget,
+                threads: inlineThreads(for: file.summary.path),
+                annotations: inlineAnnotations(for: file.summary.path),
+                onReply: onReply,
+                onResolve: onResolve,
+                onUnresolve: onUnresolve,
+                onEdit: onEdit,
+                onDelete: onDelete,
+                canReply: canReply,
+                canResolve: canResolve,
+                onStageReply: onStageReply,
+                canAddToReview: canAddToReview
+            ),
+            layoutMode: layoutMode,
+            wrapLines: wrapLines,
+            showWhitespace: showWhitespace
         )
         .equatable()
     }

--- a/Alas/Sources/Center/DiffReview/DiffReviewSurface.swift
+++ b/Alas/Sources/Center/DiffReview/DiffReviewSurface.swift
@@ -340,6 +340,7 @@ struct DiffReviewSurface: View {
             onStageReply: onStageReply,
             canAddToReview: canAddToReview
         )
+        .equatable()
     }
 
     private func inlineFeedbackScrollTargetID(for fileID: DiffReviewFileID) -> String? {

--- a/Alas/Sources/Right/RightPaneState.swift
+++ b/Alas/Sources/Right/RightPaneState.swift
@@ -464,33 +464,43 @@ final class RightPaneState {
             guard snapshotGeneration == snapshotInvalidationGeneration else {
                 return
             }
-            self.upstreamRef = resolvedUpstream?.ref
-            self.changes = entries
+            // Watcher-driven refreshes fire continuously while agents or
+            // builds write into the worktree. @Observable invalidates every
+            // observer on assignment regardless of value, so skip writes
+            // whose value did not change — otherwise each refresh re-renders
+            // everything observing these properties (see the draft-commit
+            // diff live-lock: docs/plans/2026-07-09-draft-commit-diff-livelock-fix.md).
+            if self.upstreamRef != resolvedUpstream?.ref { self.upstreamRef = resolvedUpstream?.ref }
+            if self.changes != entries { self.changes = entries }
             self.reconcileStashCaches(with: stashes)
-            self.stashes = stashes
+            if self.stashes != stashes { self.stashes = stashes }
             self.changesGeneration += 1
-            self.indexFingerprint = indexFingerprint
-            self.fileTree = Self.preservingLazyChildren(fresh: tree, previous: self.fileTree)
-            self.commits = commits
-            self.comparisonRef = ref
+            if self.indexFingerprint != indexFingerprint { self.indexFingerprint = indexFingerprint }
+            let mergedFileTree = Self.preservingLazyChildren(fresh: tree, previous: self.fileTree)
+            if self.fileTree != mergedFileTree { self.fileTree = mergedFileTree }
+            if self.commits != commits { self.commits = commits }
+            if self.comparisonRef != ref { self.comparisonRef = ref }
             let preferredCommitRemoteRef = ref ?? baseBranch
-            self.commitRemote = CodeHostRemoteDetector.detect(
+            let commitRemote = CodeHostRemoteDetector.detect(
                 from: remotes,
                 preferredRemoteName: CodeHostRemoteDetector.preferredRemoteName(
                     forBaseBranch: preferredCommitRemoteRef,
                     remotes: remotes
                 )
             )
+            if self.commitRemote != commitRemote { self.commitRemote = commitRemote }
+            let primaryCommitRemote: CodeHostRemote?
             if let upstreamRemoteName = resolvedUpstream?.remote {
-                self.primaryCommitRemote = CodeHostRemoteDetector.detectAll(
+                primaryCommitRemote = CodeHostRemoteDetector.detectAll(
                     from: remotes,
                     preferredRemoteName: upstreamRemoteName
                 ).first { $0.remoteName == upstreamRemoteName }
             } else {
-                self.primaryCommitRemote = nil
+                primaryCommitRemote = nil
             }
-            self.currentBranch = currentBranch
-            self.currentHeadSHA = headSHA
+            if self.primaryCommitRemote != primaryCommitRemote { self.primaryCommitRemote = primaryCommitRemote }
+            if self.currentBranch != currentBranch { self.currentBranch = currentBranch }
+            if self.currentHeadSHA != headSHA { self.currentHeadSHA = headSHA }
             if previousBranch != currentBranch || previousHeadSHA != headSHA {
                 // Branch or HEAD changed (checkout, rebase, reset, amend, …).
                 // The behind chips were probed against the OLD branch's base

--- a/AlasTests/DiffReviewFileSectionEqualityTests.swift
+++ b/AlasTests/DiffReviewFileSectionEqualityTests.swift
@@ -1,0 +1,220 @@
+import SwiftUI
+import Testing
+@testable import Alas
+
+@MainActor
+struct DiffReviewFileSectionEqualityTests {
+    @Test func sameInputsWithDifferentClosuresAreEqual() {
+        let file = fileModel(path: "a.swift")
+        let lhs = section(file: file, onSelectInlineFeedback: { _ in })
+        let rhs = section(file: file, onSelectInlineFeedback: { _ in })
+
+        #expect(lhs == rhs)
+    }
+
+    @Test func equivalentlyRebuiltFileModelsAreEqual() {
+        let lhs = section(file: fileModel(path: "a.swift"))
+        let rhs = section(file: fileModel(path: "a.swift"))
+
+        #expect(lhs == rhs)
+    }
+
+    @Test func differentFileContentIsNotEqual() {
+        let lhs = section(file: fileModel(path: "a.swift", lineText: "old"))
+        let rhs = section(file: fileModel(path: "a.swift", lineText: "new"))
+
+        #expect(lhs != rhs)
+    }
+
+    @Test func renderRelevantScalarInputsParticipateInEquality() {
+        let file = fileModel(path: "a.swift")
+        let base = section(file: file)
+
+        #expect(base != section(file: file, focusedFeedbackID: "f1"))
+        #expect(base != section(file: file, inlineFeedbackScrollTargetID: "t1"))
+        #expect(base != section(file: file, focusedDraftCommentID: "d1"))
+        #expect(base != section(file: file, layoutMode: .stacked))
+        #expect(base != section(file: file, wrapLines: true))
+        #expect(base != section(file: file, showWhitespace: true))
+        #expect(base != section(file: file, codeFontFamily: "Menlo"))
+        #expect(base != section(file: file, codeFontSize: 14))
+        #expect(base != section(file: file, showsSourceBadge: true))
+        #expect(base != section(file: file, allowsDraftCommentCreation: true))
+        #expect(base != section(file: file, canReply: true))
+        #expect(base != section(file: file, canResolve: true))
+        #expect(base != section(file: file, canAddToReview: true))
+    }
+
+    @Test func collectionsParticipateInEquality() {
+        let file = fileModel(path: "a.swift")
+        let base = section(file: file)
+
+        let feedback = DiffReviewInlineFeedback(
+            id: "fb1",
+            providerName: "provider",
+            author: nil,
+            bodyPreview: "body",
+            status: .pending,
+            providerURL: nil,
+            anchor: DiffReviewInlineFeedbackAnchor(path: "a.swift", line: 1, side: .new),
+            evidenceItemID: "e1"
+        )
+        #expect(base != section(file: file, inlineFeedback: [feedback]))
+
+        let thread = DiffInlineCommentThread(
+            id: "t1",
+            filePath: "a.swift",
+            newLine: 1,
+            isOldSide: false,
+            isResolved: false,
+            isOutdated: false,
+            comments: [],
+            viewerCanReply: false,
+            viewerCanResolve: false,
+            viewerCanUnresolve: false
+        )
+        #expect(base != section(file: file, threads: [thread]))
+
+        let annotation = DiffInlineAnnotation(
+            id: "a1",
+            checkName: "check",
+            newLine: 1,
+            level: .warning,
+            message: "message",
+            rawDetails: nil
+        )
+        #expect(base != section(file: file, annotations: [annotation]))
+
+        #expect(base != section(
+            file: file,
+            reviewFeedbackTarget: ReviewFeedbackTarget(
+                title: "t",
+                repositoryPath: nil,
+                providerDescription: nil,
+                sourceDescription: "s"
+            )
+        ))
+    }
+
+    @Test func lspContextRendersEqualIgnoresOpenTargetClosure() {
+        #expect(DiffPaneLSPContext.rendersEqual(nil, nil))
+
+        let lsp = WorkspaceLSPManager(registry: LanguageServerRegistry(userDefined: []))
+        let lhs = lspContext(lsp: lsp, relativePath: "a.swift")
+        let rhs = lspContext(lsp: lsp, relativePath: "a.swift")
+        #expect(DiffPaneLSPContext.rendersEqual(lhs, rhs))
+
+        #expect(!DiffPaneLSPContext.rendersEqual(lhs, nil))
+        #expect(!DiffPaneLSPContext.rendersEqual(
+            lhs,
+            lspContext(lsp: lsp, relativePath: "b.swift")
+        ))
+
+        let otherLSP = WorkspaceLSPManager(registry: LanguageServerRegistry(userDefined: []))
+        #expect(!DiffPaneLSPContext.rendersEqual(lhs, lspContext(lsp: otherLSP, relativePath: "a.swift")))
+    }
+}
+
+@MainActor
+private func section(
+    file: DiffReviewFileSectionModel,
+    inlineFeedback: [DiffReviewInlineFeedback] = [],
+    focusedFeedbackID: String? = nil,
+    inlineFeedbackScrollTargetID: String? = nil,
+    draftComments: [ReviewDraftComment] = [],
+    focusedDraftCommentID: String? = nil,
+    layoutMode: DiffLayoutMode = .split,
+    wrapLines: Bool = false,
+    showWhitespace: Bool = false,
+    codeFontFamily: String = "SF Mono",
+    codeFontSize: CGFloat = 12,
+    showsSourceBadge: Bool = false,
+    onSelectInlineFeedback: @escaping (DiffReviewInlineFeedback) -> Void = { _ in },
+    allowsDraftCommentCreation: Bool = false,
+    reviewFeedbackTarget: ReviewFeedbackTarget? = nil,
+    threads: [DiffInlineCommentThread] = [],
+    annotations: [DiffInlineAnnotation] = [],
+    canReply: Bool = false,
+    canResolve: Bool = false,
+    canAddToReview: Bool = false
+) -> DiffReviewFileSection {
+    DiffReviewFileSection(
+        file: file,
+        inlineFeedback: inlineFeedback,
+        focusedFeedbackID: focusedFeedbackID,
+        inlineFeedbackScrollTargetID: inlineFeedbackScrollTargetID,
+        draftComments: draftComments,
+        focusedDraftCommentID: focusedDraftCommentID,
+        layoutMode: .constant(layoutMode),
+        wrapLines: .constant(wrapLines),
+        showWhitespace: .constant(showWhitespace),
+        codeFontFamily: codeFontFamily,
+        codeFontSize: codeFontSize,
+        showsSourceBadge: showsSourceBadge,
+        onSelectInlineFeedback: onSelectInlineFeedback,
+        allowsDraftCommentCreation: allowsDraftCommentCreation,
+        reviewFeedbackTarget: reviewFeedbackTarget,
+        threads: threads,
+        annotations: annotations,
+        canReply: canReply,
+        canResolve: canResolve,
+        canAddToReview: canAddToReview
+    )
+}
+
+private func lspContext(lsp: WorkspaceLSPManager, relativePath: String) -> DiffPaneLSPContext {
+    DiffPaneLSPContext(
+        worktreeId: "wt",
+        worktreeRoot: URL(fileURLWithPath: "/tmp"),
+        relativePath: relativePath,
+        language: "swift",
+        lsp: lsp,
+        openTarget: { _, _, _ in }
+    )
+}
+
+private func fileModel(path: String, lineText: String = "let a = 1") -> DiffReviewFileSectionModel {
+    let line = DiffDisplayLine(
+        id: "\(path):new:1",
+        anchor: DiffLineAnchor(filePath: path, hunkIndex: 0, rowIndex: 0, side: .new, oldLine: nil, newLine: 1),
+        text: lineText,
+        lineNumber: 1,
+        kind: .add,
+        inlineSpans: [],
+        noTrailingNewline: false
+    )
+    let hunk = ParsedDiff.Hunk(
+        header: "@@ -0,0 +1 @@",
+        oldStart: 0,
+        newStart: 1,
+        lines: [ParsedDiff.Hunk.Line(kind: .add, text: lineText, oldNumber: nil, newNumber: 1)]
+    )
+    let row = DiffDisplayRow(
+        id: "\(path):row:0",
+        kind: .add,
+        old: nil,
+        new: line,
+        collapsedLineCount: 0
+    )
+    return DiffReviewFileSectionModel(
+        summary: DiffReviewFileSummary(
+            path: path,
+            namespace: "staged",
+            groupID: "staged",
+            groupTitle: "Staged",
+            status: .modified,
+            additions: 1,
+            deletions: 0,
+            isRenderable: true,
+            originalPath: nil
+        ),
+        parsedDiff: ParsedDiff(hunks: [hunk]),
+        displayModel: DiffDisplayModel(
+            filePath: path,
+            groups: [DiffDisplayGroup(id: "\(path):hunk:0", header: hunk.header, sourceHunk: hunk, rows: [row])]
+        ),
+        placeholderMessage: nil,
+        openFile: nil,
+        contextProvider: nil
+    )
+}

--- a/AlasTests/DiffReviewFileSectionEqualityTests.swift
+++ b/AlasTests/DiffReviewFileSectionEqualityTests.swift
@@ -96,6 +96,47 @@ struct DiffReviewFileSectionEqualityTests {
         ))
     }
 
+    @Test func layoutModeChangeThroughASharedBindingIsDetected() {
+        // Regression coverage for a live-binding comparison bug: comparing
+        // `section.layoutMode` directly (a `@Binding`) can't distinguish
+        // "before" from "after" when both sides are bound to the SAME
+        // external storage, because a Binding's `wrappedValue` always reads
+        // the CURRENT value regardless of which struct instance reads it.
+        // `.constant(_:)` bindings (used by the `section` helper above)
+        // don't reproduce this — each `.constant` is its own frozen storage
+        // — so this test uses a real shared, mutable source instead.
+        final class Box { var layoutMode: DiffLayoutMode = .split }
+        let box = Box()
+        let sharedBinding = Binding<DiffLayoutMode>(
+            get: { box.layoutMode },
+            set: { box.layoutMode = $0 }
+        )
+        let file = fileModel(path: "a.swift")
+
+        func snapshot() -> EquatableDiffReviewFileSection {
+            EquatableDiffReviewFileSection(
+                section: DiffReviewFileSection(
+                    file: file,
+                    layoutMode: sharedBinding,
+                    wrapLines: .constant(false),
+                    showWhitespace: .constant(false),
+                    codeFontFamily: "SF Mono",
+                    codeFontSize: 12,
+                    showsSourceBadge: false
+                ),
+                layoutMode: box.layoutMode,
+                wrapLines: false,
+                showWhitespace: false
+            )
+        }
+
+        let before = snapshot()
+        box.layoutMode = .stacked
+        let after = snapshot()
+
+        #expect(before != after)
+    }
+
     @Test func lspContextRendersEqualIgnoresOpenTargetClosure() {
         #expect(DiffPaneLSPContext.rendersEqual(nil, nil))
 
@@ -137,28 +178,33 @@ private func section(
     canReply: Bool = false,
     canResolve: Bool = false,
     canAddToReview: Bool = false
-) -> DiffReviewFileSection {
-    DiffReviewFileSection(
-        file: file,
-        inlineFeedback: inlineFeedback,
-        focusedFeedbackID: focusedFeedbackID,
-        inlineFeedbackScrollTargetID: inlineFeedbackScrollTargetID,
-        draftComments: draftComments,
-        focusedDraftCommentID: focusedDraftCommentID,
-        layoutMode: .constant(layoutMode),
-        wrapLines: .constant(wrapLines),
-        showWhitespace: .constant(showWhitespace),
-        codeFontFamily: codeFontFamily,
-        codeFontSize: codeFontSize,
-        showsSourceBadge: showsSourceBadge,
-        onSelectInlineFeedback: onSelectInlineFeedback,
-        allowsDraftCommentCreation: allowsDraftCommentCreation,
-        reviewFeedbackTarget: reviewFeedbackTarget,
-        threads: threads,
-        annotations: annotations,
-        canReply: canReply,
-        canResolve: canResolve,
-        canAddToReview: canAddToReview
+) -> EquatableDiffReviewFileSection {
+    EquatableDiffReviewFileSection(
+        section: DiffReviewFileSection(
+            file: file,
+            inlineFeedback: inlineFeedback,
+            focusedFeedbackID: focusedFeedbackID,
+            inlineFeedbackScrollTargetID: inlineFeedbackScrollTargetID,
+            draftComments: draftComments,
+            focusedDraftCommentID: focusedDraftCommentID,
+            layoutMode: .constant(layoutMode),
+            wrapLines: .constant(wrapLines),
+            showWhitespace: .constant(showWhitespace),
+            codeFontFamily: codeFontFamily,
+            codeFontSize: codeFontSize,
+            showsSourceBadge: showsSourceBadge,
+            onSelectInlineFeedback: onSelectInlineFeedback,
+            allowsDraftCommentCreation: allowsDraftCommentCreation,
+            reviewFeedbackTarget: reviewFeedbackTarget,
+            threads: threads,
+            annotations: annotations,
+            canReply: canReply,
+            canResolve: canResolve,
+            canAddToReview: canAddToReview
+        ),
+        layoutMode: layoutMode,
+        wrapLines: wrapLines,
+        showWhitespace: showWhitespace
     )
 }
 

--- a/AlasTests/DiffReviewFileSectionEqualityTests.swift
+++ b/AlasTests/DiffReviewFileSectionEqualityTests.swift
@@ -126,7 +126,9 @@ struct DiffReviewFileSectionEqualityTests {
                 ),
                 layoutMode: box.layoutMode,
                 wrapLines: false,
-                showWhitespace: false
+                showWhitespace: false,
+                draftCommentAvailability: [],
+                inlineFeedbackAvailability: []
             )
         }
 
@@ -135,6 +137,44 @@ struct DiffReviewFileSectionEqualityTests {
         let after = snapshot()
 
         #expect(before != after)
+    }
+
+    @Test func draftCommentAvailabilityChangeIsDetectedEvenWhenCommentsAreUnchanged() {
+        // The comment list itself can stay identical while what's available
+        // for it changes (e.g. an agent send-target becomes available).
+        // ReviewDraftCommentCard renders its action row from that
+        // availability, so a change there must not compare equal.
+        let file = fileModel(path: "a.swift")
+        let base = section(file: file, draftCommentAvailability: [.none])
+        let changed = section(
+            file: file,
+            draftCommentAvailability: [ReviewDraftCommentActionAvailability(
+                canEdit: true,
+                canDelete: false,
+                canResolve: false,
+                canDismiss: false,
+                canCopyPrompt: false,
+                canShowSendToAgent: false,
+                canSendToAgent: false
+            )]
+        )
+
+        #expect(base != changed)
+    }
+
+    @Test func inlineFeedbackAvailabilityChangeIsDetectedEvenWhenFeedbackIsUnchanged() {
+        let file = fileModel(path: "a.swift")
+        let base = section(file: file, inlineFeedbackAvailability: [.none])
+        let changed = section(
+            file: file,
+            inlineFeedbackAvailability: [DiffReviewInlineFeedbackActionAvailability(
+                canOpenProvider: true,
+                canCopyContext: false,
+                canSendToAgent: false
+            )]
+        )
+
+        #expect(base != changed)
     }
 
     @Test func lspContextRendersEqualIgnoresOpenTargetClosure() {
@@ -177,7 +217,9 @@ private func section(
     annotations: [DiffInlineAnnotation] = [],
     canReply: Bool = false,
     canResolve: Bool = false,
-    canAddToReview: Bool = false
+    canAddToReview: Bool = false,
+    draftCommentAvailability: [ReviewDraftCommentActionAvailability] = [],
+    inlineFeedbackAvailability: [DiffReviewInlineFeedbackActionAvailability] = []
 ) -> EquatableDiffReviewFileSection {
     EquatableDiffReviewFileSection(
         section: DiffReviewFileSection(
@@ -204,7 +246,9 @@ private func section(
         ),
         layoutMode: layoutMode,
         wrapLines: wrapLines,
-        showWhitespace: showWhitespace
+        showWhitespace: showWhitespace,
+        draftCommentAvailability: draftCommentAvailability,
+        inlineFeedbackAvailability: inlineFeedbackAvailability
     )
 }
 

--- a/AlasTests/DiffReviewFileSectionEqualityTests.swift
+++ b/AlasTests/DiffReviewFileSectionEqualityTests.swift
@@ -128,7 +128,8 @@ struct DiffReviewFileSectionEqualityTests {
                 wrapLines: false,
                 showWhitespace: false,
                 draftCommentAvailability: [],
-                inlineFeedbackAvailability: []
+                inlineFeedbackAvailability: [],
+                draftCommentAgentTargets: []
             )
         }
 
@@ -177,6 +178,39 @@ struct DiffReviewFileSectionEqualityTests {
         #expect(base != changed)
     }
 
+    @Test func draftCommentAgentTargetsChangeIsDetectedEvenWhenAvailabilityIsUnchanged() {
+        // agentTargets() can change shape (one target becomes two, or a
+        // session title changes) while canSendToAgent/canShowSendToAgent
+        // stay true — sendToAgentControl renders the target list itself
+        // (single button vs. menu, per-target titles), so that must
+        // participate in equality too.
+        let file = fileModel(path: "a.swift")
+        let availability = [ReviewDraftCommentActionAvailability(
+            canEdit: false,
+            canDelete: false,
+            canResolve: false,
+            canDismiss: false,
+            canCopyPrompt: false,
+            canShowSendToAgent: true,
+            canSendToAgent: true
+        )]
+        let base = section(
+            file: file,
+            draftCommentAvailability: availability,
+            draftCommentAgentTargets: [.newChat(agentID: "claude", title: "Claude")]
+        )
+        let changed = section(
+            file: file,
+            draftCommentAvailability: availability,
+            draftCommentAgentTargets: [
+                .newChat(agentID: "claude", title: "Claude"),
+                .existingSession(worktreeID: "wt", sessionID: "s1", title: "Session 1"),
+            ]
+        )
+
+        #expect(base != changed)
+    }
+
     @Test func lspContextRendersEqualIgnoresOpenTargetClosure() {
         #expect(DiffPaneLSPContext.rendersEqual(nil, nil))
 
@@ -219,7 +253,8 @@ private func section(
     canResolve: Bool = false,
     canAddToReview: Bool = false,
     draftCommentAvailability: [ReviewDraftCommentActionAvailability] = [],
-    inlineFeedbackAvailability: [DiffReviewInlineFeedbackActionAvailability] = []
+    inlineFeedbackAvailability: [DiffReviewInlineFeedbackActionAvailability] = [],
+    draftCommentAgentTargets: [ReviewFeedbackAgentTarget] = []
 ) -> EquatableDiffReviewFileSection {
     EquatableDiffReviewFileSection(
         section: DiffReviewFileSection(
@@ -248,7 +283,8 @@ private func section(
         wrapLines: wrapLines,
         showWhitespace: showWhitespace,
         draftCommentAvailability: draftCommentAvailability,
-        inlineFeedbackAvailability: inlineFeedbackAvailability
+        inlineFeedbackAvailability: inlineFeedbackAvailability,
+        draftCommentAgentTargets: draftCommentAgentTargets
     )
 }
 

--- a/AlasTests/DiffReviewRenderableContentEqualityTests.swift
+++ b/AlasTests/DiffReviewRenderableContentEqualityTests.swift
@@ -59,6 +59,16 @@ struct DiffReviewRenderableContentEqualityTests {
         #expect(!lhs.hasSameRenderableContent(as: rhs))
     }
 
+    @Test func unstageEnabledBaseMismatchIsNotEqual() {
+        // A `busy` flip doesn't change any other file content, but it does
+        // change whether "Drop from commit" should render as enabled — the
+        // equality check must catch it so the button doesn't go stale.
+        let lhs = fileModel(path: "a.swift", withActions: true, unstageEnabledBase: true)
+        let rhs = fileModel(path: "a.swift", withActions: true, unstageEnabledBase: false)
+
+        #expect(!lhs.hasSameRenderableContent(as: rhs))
+    }
+
     @Test func differentDisplayModelIsNotEqual() {
         let lhs = fileModel(path: "a.swift", lineText: "let a = 1")
         let rhs = fileModel(path: "a.swift", lineText: "let a = 2")
@@ -101,7 +111,8 @@ private func fileModel(
     lineText: String = "let a = 1",
     openFile: (() -> Void)? = nil,
     contextProvider: DiffReviewContextProvider? = nil,
-    withActions: Bool = false
+    withActions: Bool = false,
+    unstageEnabledBase: Bool = true
 ) -> DiffReviewFileSectionModel {
     let line = DiffDisplayLine(
         id: "\(path):new:1",
@@ -147,7 +158,12 @@ private func fileModel(
         openFile: openFile,
         contextProvider: contextProvider,
         stagedMutationActions: withActions
-            ? DiffReviewStagedMutationActions(unstageFile: {}, unstageHunk: { _ in }, isHunkUnstageEnabled: { _ in true })
+            ? DiffReviewStagedMutationActions(
+                unstageFile: {},
+                unstageHunk: { _ in },
+                isHunkUnstageEnabled: { _ in true },
+                unstageEnabledBase: unstageEnabledBase
+            )
             : nil
     )
 }

--- a/AlasTests/DiffReviewRenderableContentEqualityTests.swift
+++ b/AlasTests/DiffReviewRenderableContentEqualityTests.swift
@@ -10,11 +10,23 @@ struct DiffReviewRenderableContentEqualityTests {
         #expect(lhs.hasSameRenderableContent(as: rhs))
     }
 
-    @Test func differentContextProviderIdentityStillEqualWhenBothPresent() {
+    @Test func sameContextProviderIdentityIsEqual() {
+        let provider = DiffReviewContextProvider { .init(old: .unavailable, new: .unavailable) }
+        let lhs = fileModel(path: "a.swift", contextProvider: provider)
+        let rhs = fileModel(path: "a.swift", contextProvider: provider)
+
+        #expect(lhs.hasSameRenderableContent(as: rhs))
+    }
+
+    @Test func differentContextProviderIdentityIsNotEqual() {
+        // Different provider instances are never equal, even with identical
+        // content: DiffReviewFileSection keys stale-load rejection off
+        // contextProvider.id, so treating these as unchanged would let a
+        // swapped-in file keep serving a previous provider's context.
         let lhs = fileModel(path: "a.swift", contextProvider: DiffReviewContextProvider { .init(old: .unavailable, new: .unavailable) })
         let rhs = fileModel(path: "a.swift", contextProvider: DiffReviewContextProvider { .init(old: .unavailable, new: .unavailable) })
 
-        #expect(lhs.hasSameRenderableContent(as: rhs))
+        #expect(!lhs.hasSameRenderableContent(as: rhs))
     }
 
     @Test func contextProviderPresenceMismatchIsNotEqual() {

--- a/AlasTests/DiffReviewRenderableContentEqualityTests.swift
+++ b/AlasTests/DiffReviewRenderableContentEqualityTests.swift
@@ -1,0 +1,148 @@
+import Foundation
+import Testing
+@testable import Alas
+
+struct DiffReviewRenderableContentEqualityTests {
+    @Test func identicalContentWithDifferentClosuresIsEqual() {
+        let lhs = fileModel(path: "a.swift", openFile: {}, withActions: true)
+        let rhs = fileModel(path: "a.swift", openFile: {}, withActions: true)
+
+        #expect(lhs.hasSameRenderableContent(as: rhs))
+    }
+
+    @Test func differentContextProviderIdentityStillEqualWhenBothPresent() {
+        let lhs = fileModel(path: "a.swift", contextProvider: DiffReviewContextProvider { .init(old: .unavailable, new: .unavailable) })
+        let rhs = fileModel(path: "a.swift", contextProvider: DiffReviewContextProvider { .init(old: .unavailable, new: .unavailable) })
+
+        #expect(lhs.hasSameRenderableContent(as: rhs))
+    }
+
+    @Test func contextProviderPresenceMismatchIsNotEqual() {
+        let lhs = fileModel(path: "a.swift", contextProvider: DiffReviewContextProvider { .init(old: .unavailable, new: .unavailable) })
+        let rhs = fileModel(path: "a.swift")
+
+        #expect(!lhs.hasSameRenderableContent(as: rhs))
+    }
+
+    @Test func openFilePresenceMismatchIsNotEqual() {
+        let lhs = fileModel(path: "a.swift", openFile: {})
+        let rhs = fileModel(path: "a.swift")
+
+        #expect(!lhs.hasSameRenderableContent(as: rhs))
+    }
+
+    @Test func mutationActionsPresenceMismatchIsNotEqual() {
+        let lhs = fileModel(path: "a.swift", withActions: true)
+        let rhs = fileModel(path: "a.swift", withActions: false)
+
+        #expect(!lhs.hasSameRenderableContent(as: rhs))
+    }
+
+    @Test func partialMutationActionsPresenceMismatchIsNotEqual() {
+        var lhs = fileModel(path: "a.swift")
+        lhs.stagedMutationActions = DiffReviewStagedMutationActions(unstageFile: {})
+        var rhs = fileModel(path: "a.swift")
+        rhs.stagedMutationActions = DiffReviewStagedMutationActions(unstageHunk: { _ in })
+
+        #expect(!lhs.hasSameRenderableContent(as: rhs))
+    }
+
+    @Test func differentDisplayModelIsNotEqual() {
+        let lhs = fileModel(path: "a.swift", lineText: "let a = 1")
+        let rhs = fileModel(path: "a.swift", lineText: "let a = 2")
+
+        #expect(!lhs.hasSameRenderableContent(as: rhs))
+    }
+
+    @Test func differentSummaryIsNotEqual() {
+        let lhs = fileModel(path: "a.swift", additions: 1)
+        let rhs = fileModel(path: "a.swift", additions: 2)
+
+        #expect(!lhs.hasSameRenderableContent(as: rhs))
+    }
+
+    @Test func sessionsWithSameContentAreEqual() {
+        let lhs = session(files: [fileModel(path: "a.swift", openFile: {}), fileModel(path: "b.swift")])
+        let rhs = session(files: [fileModel(path: "a.swift", openFile: {}), fileModel(path: "b.swift")])
+
+        #expect(lhs.hasSameRenderableContent(as: rhs))
+    }
+
+    @Test func sessionsWithDifferentFileCountAreNotEqual() {
+        let lhs = session(files: [fileModel(path: "a.swift")])
+        let rhs = session(files: [fileModel(path: "a.swift"), fileModel(path: "b.swift")])
+
+        #expect(!lhs.hasSameRenderableContent(as: rhs))
+    }
+
+    @Test func sessionsWithOneDifferingFileAreNotEqual() {
+        let lhs = session(files: [fileModel(path: "a.swift", lineText: "old")])
+        let rhs = session(files: [fileModel(path: "a.swift", lineText: "new")])
+
+        #expect(!lhs.hasSameRenderableContent(as: rhs))
+    }
+}
+
+private func fileModel(
+    path: String,
+    additions: Int = 1,
+    lineText: String = "let a = 1",
+    openFile: (() -> Void)? = nil,
+    contextProvider: DiffReviewContextProvider? = nil,
+    withActions: Bool = false
+) -> DiffReviewFileSectionModel {
+    let line = DiffDisplayLine(
+        id: "\(path):new:1",
+        anchor: DiffLineAnchor(filePath: path, hunkIndex: 0, rowIndex: 0, side: .new, oldLine: nil, newLine: 1),
+        text: lineText,
+        lineNumber: 1,
+        kind: .add,
+        inlineSpans: [],
+        noTrailingNewline: false
+    )
+    let hunk = ParsedDiff.Hunk(
+        header: "@@ -0,0 +1 @@",
+        oldStart: 0,
+        newStart: 1,
+        lines: [ParsedDiff.Hunk.Line(kind: .add, text: lineText, oldNumber: nil, newNumber: 1)]
+    )
+    let row = DiffDisplayRow(
+        id: "\(path):row:0",
+        kind: .add,
+        old: nil,
+        new: line,
+        collapsedLineCount: 0
+    )
+    let model = DiffDisplayModel(
+        filePath: path,
+        groups: [DiffDisplayGroup(id: "\(path):hunk:0", header: hunk.header, sourceHunk: hunk, rows: [row])]
+    )
+    return DiffReviewFileSectionModel(
+        summary: DiffReviewFileSummary(
+            path: path,
+            namespace: "staged",
+            groupID: "staged",
+            groupTitle: "Staged",
+            status: .modified,
+            additions: additions,
+            deletions: 0,
+            isRenderable: true,
+            originalPath: nil
+        ),
+        parsedDiff: ParsedDiff(hunks: [hunk]),
+        displayModel: model,
+        placeholderMessage: nil,
+        openFile: openFile,
+        contextProvider: contextProvider,
+        stagedMutationActions: withActions
+            ? DiffReviewStagedMutationActions(unstageFile: {}, unstageHunk: { _ in }, isHunkUnstageEnabled: { _ in true })
+            : nil
+    )
+}
+
+private func session(files: [DiffReviewFileSectionModel]) -> DiffReviewLoadedSession {
+    DiffReviewLoadedSession(
+        files: files,
+        summary: DiffReviewSessionModel(files: files.map(\.summary), groupsEnabled: false)
+    )
+}

--- a/docs/plans/2026-07-09-draft-commit-diff-livelock-fix.md
+++ b/docs/plans/2026-07-09-draft-commit-diff-livelock-fix.md
@@ -1,0 +1,225 @@
+# Draft Commit Diff Re-render Live-lock Fix — Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Stop the main-thread live-lock (beachball) that occurs when a Draft Commit tab shows a large staged diff while an agent/build continuously writes files in the worktree.
+
+**Architecture:** Three complementary layers. (1) `RightPaneState.refresh()` stops republishing `@Observable` properties whose values did not change, so watcher-driven refreshes no longer invalidate every observing view. (2) `DraftCommitTabView` stops building a brand-new `DiffReviewLoadedSession` (with fresh closures) on every body evaluation; the session-with-actions is built once per loaded session and the loader keeps the previous instance when content is unchanged. (3) `DiffReviewFileSection` gains an explicit `Equatable` conformance comparing only render-relevant content (closures and bindings' identities excluded), so SwiftUI can skip the entire per-file subtree — hundreds of `NSViewRepresentable`s — when nothing visible changed.
+
+**Tech Stack:** Swift 5.9 / SwiftUI (macOS), Swift Testing (`import Testing`), xcodegen/xcodebuild.
+
+**Root cause evidence:** `/private/tmp/claude-502/-Users-nacho-lopez/47539476-4410-47be-acfe-323077aa0bd3/scratchpad/alas_sample.txt` — 5s sample fully inside one `GraphHost.flushTransactions()`, dominated by `PlatformViewChild.updateValue` → `AppKitPlatformViewHost.updateNestedHosts`/`coreUpdateEnvironment`, `DiffPaneView.body`, `DiffDisplayRow` copy/equality churn, plus `DraftCommitTabView.sessionWithActions` frames. Trigger chain: `WorktreeWatcher` (≤2s cadence under agent writes) → `RightPaneState.refresh()` unconditional `self.changes = entries` → `DraftCommitTabView.body` (reads `rps.changes`) → new `sessionWithActions` closures → non-equatable subtree fully re-diffed (seconds per pass) → transactions queue faster than they drain.
+
+**Stale-closure risk accepted (documented):** with the Equatable gate, closures captured by an older body generation stay installed while `==` reports equal. All such closures either read view state through `@State`/`@Observable` storage (always fresh) or capture immutable per-file values (paths, ids) that are covered by the content comparison. The only visible effect: hunk-header button enabled-state derived from `busy` may lag for the duration of a git mutation, and those handlers already `guard !busy`.
+
+---
+
+### Task 1: Content equality for review session models
+
+**Files:**
+- Modify: `Alas/Sources/Center/DiffReview/DiffReviewModels.swift` (after `DiffReviewLoadedSession`, line ~284)
+- Test: `AlasTests/DiffReviewModelsTests.swift` (append)
+
+**Step 1: Write failing tests** (Swift Testing, follow existing style in `DiffReviewModelsTests.swift`)
+
+Cases:
+- Two `DiffReviewFileSectionModel`s with identical summary/parsedDiff/displayModel/placeholder but *different* closure instances and different `contextProvider` UUIDs → `hasSameRenderableContent` is `true` when action presence matches.
+- Same but one has `stagedMutationActions = nil` vs non-nil → `false`.
+- One has `openFile` nil vs non-nil → `false`.
+- Different `displayModel` rows → `false`.
+- `DiffReviewLoadedSession.hasSameRenderableContent(as:)`: equal-content sessions → `true`; different file count or any file differing → `false`.
+
+**Step 2: Run tests, verify they fail to compile / fail.**
+
+**Step 3: Implement**
+
+```swift
+extension DiffReviewStagedMutationActions {
+    /// Presence-only signature: closure identity is not comparable, but which
+    /// actions exist affects rendered buttons.
+    var renderablePresence: (Bool, Bool, Bool) {
+        (unstageFile != nil, unstageHunk != nil, isHunkUnstageEnabled != nil)
+    }
+}
+
+extension DiffReviewFileSectionModel {
+    /// True when this model renders identically to `other`. Ignores closure
+    /// identity (openFile, contextProvider.snapshot, stagedMutationActions
+    /// bodies) — only content and action *presence* are compared.
+    func hasSameRenderableContent(as other: DiffReviewFileSectionModel) -> Bool {
+        summary == other.summary
+            && parsedDiff == other.parsedDiff
+            && displayModel == other.displayModel
+            && placeholderMessage == other.placeholderMessage
+            && (openFile == nil) == (other.openFile == nil)
+            && (contextProvider == nil) == (other.contextProvider == nil)
+            && (stagedMutationActions?.renderablePresence ?? (false, false, false))
+                == (other.stagedMutationActions?.renderablePresence ?? (false, false, false))
+    }
+}
+
+extension DiffReviewLoadedSession {
+    func hasSameRenderableContent(as other: DiffReviewLoadedSession) -> Bool {
+        guard summary == other.summary, files.count == other.files.count else { return false }
+        return zip(files, other.files).allSatisfy { $0.hasSameRenderableContent(as: $1) }
+    }
+}
+```
+
+**Step 4: Run tests → PASS.**
+
+**Step 5: Commit** `perf(review): add renderable-content equality to review session models`
+
+---
+
+### Task 2: Equatable gate on DiffReviewFileSection
+
+**Files:**
+- Modify: `Alas/Sources/Center/DiffReview/DiffReviewFileSection.swift` (add `Equatable` conformance)
+- Modify: `Alas/Sources/Center/Diff/DiffPaneLSP.swift` (add `rendersEqual` helper)
+- Modify: `Alas/Sources/Center/DiffReview/DiffReviewSurface.swift:305` (wrap in `.equatable()`)
+- Test: `AlasTests/DiffReviewFileSectionEqualityTests.swift` (new)
+
+**Step 1: Write failing tests**
+
+- Two sections with same content model instance, same flags, *different* closure instances → `==` true.
+- Flip each render-relevant input one at a time (focusedFeedbackID, layoutMode binding value, wrapLines, showWhitespace, codeFontSize, threads, annotations, canReply, allowsDraftCommentCreation, draftComments, inlineFeedback, showsSourceBadge, reviewFeedbackTarget) → `==` false for each.
+- `DiffPaneLSPContext.rendersEqual`: nil/nil true; nil/some false; same worktreeId+relativePath+language+same `lsp` instance but different `openTarget` closures → true; different relativePath → false.
+
+**Step 2: Run → fail.**
+
+**Step 3: Implement**
+
+In `DiffPaneLSP.swift`:
+
+```swift
+extension DiffPaneLSPContext {
+    /// Render-relevant equality: ignores the openTarget closure.
+    static func rendersEqual(_ lhs: DiffPaneLSPContext?, _ rhs: DiffPaneLSPContext?) -> Bool {
+        switch (lhs, rhs) {
+        case (nil, nil):
+            return true
+        case let (l?, r?):
+            return l.worktreeId == r.worktreeId
+                && l.relativePath == r.relativePath
+                && l.language == r.language
+                && l.lsp === r.lsp
+        default:
+            return false
+        }
+    }
+}
+```
+
+In `DiffReviewFileSection.swift`:
+
+```swift
+extension DiffReviewFileSection: Equatable {
+    /// Render-relevant equality so SwiftUI can skip this subtree when a parent
+    /// body storm did not change anything visible. Closure inputs (actions,
+    /// selection callbacks) are intentionally excluded: they read live state
+    /// through @State/@Observable storage, so an older generation stays correct.
+    static func == (lhs: DiffReviewFileSection, rhs: DiffReviewFileSection) -> Bool {
+        lhs.file.hasSameRenderableContent(as: rhs.file)
+            && lhs.inlineFeedback == rhs.inlineFeedback
+            && lhs.focusedFeedbackID == rhs.focusedFeedbackID
+            && lhs.inlineFeedbackScrollTargetID == rhs.inlineFeedbackScrollTargetID
+            && lhs.draftComments == rhs.draftComments
+            && lhs.focusedDraftCommentID == rhs.focusedDraftCommentID
+            && lhs.layoutMode == rhs.layoutMode
+            && lhs.wrapLines == rhs.wrapLines
+            && lhs.showWhitespace == rhs.showWhitespace
+            && lhs.codeFontFamily == rhs.codeFontFamily
+            && lhs.codeFontSize == rhs.codeFontSize
+            && lhs.showsSourceBadge == rhs.showsSourceBadge
+            && DiffPaneLSPContext.rendersEqual(lhs.lspContext, rhs.lspContext)
+            && lhs.allowsDraftCommentCreation == rhs.allowsDraftCommentCreation
+            && lhs.reviewFeedbackTarget == rhs.reviewFeedbackTarget
+            && lhs.threads == rhs.threads
+            && lhs.annotations == rhs.annotations
+            && lhs.canReply == rhs.canReply
+            && lhs.canResolve == rhs.canResolve
+            && lhs.canAddToReview == rhs.canAddToReview
+    }
+}
+```
+
+Note: `lhs.layoutMode` reads the binding's `wrappedValue`. `@State`/`@StateObject`/`@FocusState`/`@Environment` properties are excluded — SwiftUI tracks those dependencies independently of `==`.
+
+In `DiffReviewSurface.fileSection(_:)` wrap the returned view: `DiffReviewFileSection(...) .equatable()` — check other `DiffReviewFileSection(` call sites (`grep -rn "DiffReviewFileSection(" Alas/Sources`) and wrap them too.
+
+**Step 4: Run tests → PASS.**
+
+**Step 5: Commit** `perf(review): equality-gate DiffReviewFileSection subtree`
+
+---
+
+### Task 3: Stop rebuilding the session per body eval in DraftCommitTabView
+
+**Files:**
+- Modify: `Alas/Sources/Center/Commit/DraftCommitTabView.swift:69-87` (computed `sessionWithActions` → built on load), `:306-325` (`loadStagedSession`)
+- Test: existing `AlasTests/DiffReviewStagedMutationActionsTests.swift` must still pass; content-equality path covered by Task 1 tests.
+
+**Step 1: Implement**
+
+- Add `@State private var sessionWithActions: DiffReviewLoadedSession?`.
+- Extract the current overlay body into `private func overlayingActions(on session: DiffReviewLoadedSession) -> DiffReviewLoadedSession` (same closure bodies; closures capture `self` and read `busy` through `@State` storage, so values stay fresh without per-render recreation).
+- In `loadStagedSession()`, after loading:
+
+```swift
+guard !Task.isCancelled, stagedKey == token else { return }
+if let existing = stagedSession, existing.hasSameRenderableContent(as: session) {
+    // Same visible content: keep existing instances so downstream
+    // equality checks hit the O(1) same-storage fast path.
+} else {
+    stagedSession = session
+    sessionWithActions = overlayingActions(on: session)
+    synchronizeSelection(with: session)
+}
+```
+
+(Keep the error path clearing both `stagedSession` and `sessionWithActions`.)
+
+- `stagedDiffBody` uses the `@State` `sessionWithActions` instead of the computed property. Delete the computed property.
+
+**Step 2: Build + run the full test suite.**
+
+**Step 3: Commit** `perf(commit): build draft-commit review session once per load`
+
+---
+
+### Task 4: Publish-only-on-change in RightPaneState.refresh()
+
+**Files:**
+- Modify: `Alas/Sources/Right/RightPaneState.swift:467-475` (and nearby assignments)
+
+**Step 1: Implement** — guard the `@Observable` assignments that fire on every watcher refresh:
+
+```swift
+if self.upstreamRef != resolvedUpstream?.ref { self.upstreamRef = resolvedUpstream?.ref }
+if self.changes != entries { self.changes = entries }
+self.reconcileStashCaches(with: stashes)
+if self.stashes != stashes { self.stashes = stashes }
+self.changesGeneration += 1   // keep unconditional: consumers treat it as "a refresh happened"
+if self.indexFingerprint != indexFingerprint { self.indexFingerprint = indexFingerprint }
+let mergedTree = Self.preservingLazyChildren(fresh: tree, previous: self.fileTree)
+if self.fileTree != mergedTree { self.fileTree = mergedTree }
+if self.commits != commits { self.commits = commits }
+if self.comparisonRef != ref { self.comparisonRef = ref }
+if self.currentBranch != currentBranch { self.currentBranch = currentBranch }
+if self.currentHeadSHA != headSHA { self.currentHeadSHA = headSHA }
+```
+
+Only guard properties whose types are already `Equatable` (verify `stashes` element and `fileTree` node types during implementation; skip any that aren't — do NOT add new conformances here). Keep `commitRemote`/`primaryCommitRemote` as-is unless trivially Equatable.
+
+**Step 2: Run the RightPaneState test files** (`RightPaneStateFileTreeTests`, `RightPaneStateSyncStatusTests`, etc.) → PASS.
+
+**Step 3: Commit** `perf(right-pane): skip republishing unchanged observable state on refresh`
+
+---
+
+### Task 5: Full verification
+
+- `xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -quiet build`
+- `xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' test`
+- Manual sanity (if feasible): open Draft Commit tab with staged changes, touch files in the worktree in a loop (`while true; do date >> scratch.txt; sleep 0.3; done`), confirm CPU stays low and UI responsive.

--- a/docs/plans/2026-07-09-draft-commit-diff-livelock-fix.md
+++ b/docs/plans/2026-07-09-draft-commit-diff-livelock-fix.md
@@ -1,6 +1,6 @@
 # Draft Commit Diff Re-render Live-lock Fix — Implementation Plan
 
-> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+> **REQUIRED SUB-SKILL:** Use the executing-plans skill to implement this plan task-by-task.
 
 **Goal:** Stop the main-thread live-lock (beachball) that occurs when a Draft Commit tab shows a large staged diff while an agent/build continuously writes files in the worktree.
 
@@ -10,7 +10,7 @@
 
 **Root cause evidence:** `/private/tmp/claude-502/-Users-nacho-lopez/47539476-4410-47be-acfe-323077aa0bd3/scratchpad/alas_sample.txt` — 5s sample fully inside one `GraphHost.flushTransactions()`, dominated by `PlatformViewChild.updateValue` → `AppKitPlatformViewHost.updateNestedHosts`/`coreUpdateEnvironment`, `DiffPaneView.body`, `DiffDisplayRow` copy/equality churn, plus `DraftCommitTabView.sessionWithActions` frames. Trigger chain: `WorktreeWatcher` (≤2s cadence under agent writes) → `RightPaneState.refresh()` unconditional `self.changes = entries` → `DraftCommitTabView.body` (reads `rps.changes`) → new `sessionWithActions` closures → non-equatable subtree fully re-diffed (seconds per pass) → transactions queue faster than they drain.
 
-**Stale-closure risk accepted (documented):** with the Equatable gate, closures captured by an older body generation stay installed while `==` reports equal. All such closures either read view state through `@State`/`@Observable` storage (always fresh) or capture immutable per-file values (paths, ids) that are covered by the content comparison. The only visible effect: hunk-header button enabled-state derived from `busy` may lag for the duration of a git mutation, and those handlers already `guard !busy`.
+**Stale-closure risk, resolved during review:** with the Equatable gate, a closure captured by an older body generation stays installed while `==` reports equal — safe as long as the closure only reads live state through `@State`/`@Observable` storage or captures immutable per-file values the content comparison already covers. Further review passes on the PR found several places where that assumption didn't hold: `stagedMutationActions.isHunkUnstageEnabled`'s `busy`-derived result, `contextProvider` identity, the three display-setting `@Binding`s, and `draftCommentActions`'s per-item availability and agent-target list are all closure *outputs* that can change independent of the properties being compared. Each was fixed by capturing the relevant output as plain `Equatable` data at construction time instead of relying on the closure or binding to reflect the current render.
 
 ---
 


### PR DESCRIPTION
## Summary
- Root cause: watcher-driven refreshes republished `@Observable` state unconditionally, and `DraftCommitTabView` rebuilt its `DiffReviewLoadedSession` (with fresh closures) on every body evaluation — so SwiftUI could never equality-skip the closure-laden review subtree. Under continuous worktree writes (agent/build activity), this became a live-lock: each refresh forced a full re-diff of hundreds of `NSViewRepresentable`s faster than the previous pass could drain, pegging the main thread and beachballing the app.
- Fix, three layers:
  - `RightPaneState.refresh()` now guards `@Observable` property writes with `!=`, so unchanged watcher-driven refreshes don't invalidate observers.
  - `DraftCommitTabView` builds its mutation-action-overlaid session once per load and keeps the previous instance when reloaded content is unchanged, instead of rebuilding fresh closures every render.
  - `DiffReviewFileSection` gains an explicit `Equatable` conformance (render-relevant content only) plus `.equatable()` at its call site, so SwiftUI can skip the subtree entirely when nothing visible changed.
- Along the way, caught and fixed a real correctness bug the equality gate introduced: `contextProvider` identity (not just presence) has to participate in the comparison, since `DiffReviewFileSection` keys stale-context-load rejection off that provider's id. Covered by a regression test.

## Test plan
- [x] `AlasTests/DiffReviewRenderableContentEqualityTests.swift` (new) — session/file-model content-equality semantics, including provider identity
- [x] `AlasTests/DiffReviewFileSectionEqualityTests.swift` (new) — `DiffReviewFileSection` render-relevant `Equatable` conformance
- [x] Full `xcodebuild test` run, twice, clean except two pre-existing `ACPSessionTests` failures confirmed present on `origin/main` before this branch (unrelated image-asset URI extraction, not touched by this change)