### PR TITLE
fix(terminal): Backpressure terminal pipe reads

### DIFF
--- a/Alas/Sources/ACP/Terminal/ACPTerminal.swift
+++ b/Alas/Sources/ACP/Terminal/ACPTerminal.swift
@@ -97,21 +97,7 @@ final class ACPTerminal: ObservableObject {
         process.standardInput = FileHandle.nullDevice
 
         let weakSelf = WeakBox(self)
-        pipe.fileHandleForReading.readabilityHandler = { handle in
-            let chunk = handle.availableData
-            if chunk.isEmpty {
-                // Empty chunk = EOF on the read end (every writer fd
-                // closed). Signal the exit path; further callbacks
-                // won't fire after this.
-                Task { @MainActor in
-                    weakSelf.value?.signalEOF()
-                }
-                return
-            }
-            Task { @MainActor in
-                weakSelf.value?.appendChunk(chunk)
-            }
-        }
+        installReadabilityHandler()
         process.terminationHandler = { proc in
             // Mark the root as exited synchronously here so any kill()
             // call that races ahead of the @MainActor handleExit Task
@@ -391,6 +377,24 @@ final class ACPTerminal: ObservableObject {
     }
 
     // MARK: - Helpers
+
+    private func installReadabilityHandler() {
+        guard let pipe, exitStatus == nil, !sawEOF else { return }
+        let weakSelf = WeakBox(self)
+        pipe.fileHandleForReading.readabilityHandler = { handle in
+            handle.readabilityHandler = nil
+            let chunk = handle.availableData
+            Task { @MainActor in
+                guard let terminal = weakSelf.value else { return }
+                if chunk.isEmpty {
+                    terminal.signalEOF()
+                    return
+                }
+                terminal.appendChunk(chunk)
+                terminal.installReadabilityHandler()
+            }
+        }
+    }
 
     private func appendChunk(_ chunk: Data) {
         buffer.append(chunk)

--- a/AlasTests/ACP/Terminal/ACPTerminalTests.swift
+++ b/AlasTests/ACP/Terminal/ACPTerminalTests.swift
@@ -313,4 +313,41 @@ struct ACPTerminalTests {
         #expect(snap.truncated == true)
         #expect(snap.text.count <= 2048)
     }
+
+    @Test("firehose output does not queue unbounded main actor chunks")
+    func firehoseOutputBackpressuresMainActor() async throws {
+        let baseline = physicalFootprint()
+        let t = try ACPTerminal(
+            id: "tfirehose",
+            command: "/usr/bin/yes",
+            args: ["x"],
+            env: [:],
+            cwd: "/tmp",
+            outputByteLimit: 2048
+        )
+
+        let sampledFootprint = Task.detached {
+            try? await Task.sleep(for: .milliseconds(500))
+            return physicalFootprint()
+        }
+        Thread.sleep(forTimeInterval: 0.75)
+        let highWater = await sampledFootprint.value
+        let footprintGrowth = highWater >= baseline ? highWater - baseline : 0
+
+        t.release()
+        _ = await t.waitForExit()
+        #expect(t.buffer.count <= ACPTerminal.internalBufferCap)
+        #expect(footprintGrowth < 32 * 1024 * 1024)
+    }
+}
+
+private func physicalFootprint() -> UInt64 {
+    var info = task_vm_info_data_t()
+    var count = mach_msg_type_number_t(MemoryLayout<task_vm_info_data_t>.size / MemoryLayout<natural_t>.size)
+    let result = withUnsafeMutablePointer(to: &info) { pointer in
+        pointer.withMemoryRebound(to: integer_t.self, capacity: Int(count)) { rebound in
+            task_info(mach_task_self_, task_flavor_t(TASK_VM_INFO), rebound, &count)
+        }
+    }
+    return result == KERN_SUCCESS ? info.phys_footprint : 0
 }


### PR DESCRIPTION
## Summary

Fixes the ACPTerminal output pipe reader so a fast child process cannot enqueue unbounded MainActor tasks holding output chunks. The readability handler now drains one chunk, processes it on the MainActor, and only then re-arms the handler, letting the pipe provide backpressure before memory can balloon.

## Changes

- Replaced the always-armed pipe readability handler with a one-chunk-at-a-time helper that re-arms after the chunk is appended or EOF is handled.
- Added a firehose regression test using `/usr/bin/yes` that blocks the MainActor briefly and verifies memory growth remains bounded while the rolling buffer stays capped.

## Validation

- `xcodegen`
- `xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -quiet build`
- `xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -only-testing:AlasTests/ACPTerminalTests test`

Full local test suite currently has unrelated failures in `ACPSessionTests.rawOutputDataURIAssetSurvivesLaterContentUpdate`, `ACPSessionTests.rawOutputLongImageURLAssetSurvivesLaterContentUpdate`, and `DiffPaneViewTests.lineNumberRulerKeepsReviewSelectionForNonExpandableRows`.