### PR TITLE
fix(acp): surface slash-command argument hints in the picker

### DIFF
--- a/Alas/Sources/ACP/Protocol/ACPMessages.swift
+++ b/Alas/Sources/ACP/Protocol/ACPMessages.swift
@@ -562,6 +562,13 @@ struct ACPModeInfo: Codable, Equatable, Identifiable, Hashable {
 struct ACPPromptSuggestion: Codable, Equatable, Hashable {
     let command: String
     let description: String?
+    let hint: String?
+
+    init(command: String, description: String?, hint: String? = nil) {
+        self.command = command
+        self.description = description
+        self.hint = hint
+    }
 }
 
 struct ACPSessionNewResult: Codable, Equatable {

--- a/Alas/Sources/ACP/Protocol/ACPSessionUpdate.swift
+++ b/Alas/Sources/ACP/Protocol/ACPSessionUpdate.swift
@@ -66,12 +66,13 @@ enum ACPSessionUpdate: Codable, Equatable {
             self = .sessionConfigOptionsUpdate(
                 try c.decode([ACPConfigOption].self, forKey: .configOptions))
         case "available_commands_update":
-            // Wire format: `{ availableCommands: [{ name, description, input }] }`.
-            // We don't surface `input` (argument hints) in v1.
+            // Wire format:
+            // `{ availableCommands: [{ name, description, input: { hint } }] }`.
             let raw = (try? c.decode([ACPAvailableCommand].self, forKey: .availableCommands)) ?? []
             self = .availableCommandsUpdate(raw.map {
                 let cmd = $0.name.hasPrefix("/") ? $0.name : "/" + $0.name
-                return ACPPromptSuggestion(command: cmd, description: $0.description)
+                return ACPPromptSuggestion(
+                    command: cmd, description: $0.description, hint: $0.input?.hint)
             })
         case "usage_update":
             self = .usageUpdate(try ACPUsageInfo(from: decoder))
@@ -88,6 +89,15 @@ enum ACPSessionUpdate: Codable, Equatable {
     private struct ACPAvailableCommand: Codable {
         let name: String
         let description: String?
+        let input: Input?
+        struct Input: Codable { let hint: String }
+        enum CodingKeys: String, CodingKey { case name, description, input }
+        init(from decoder: Decoder) throws {
+            let c = try decoder.container(keyedBy: CodingKeys.self)
+            name = try c.decode(String.self, forKey: .name)
+            description = try? c.decodeIfPresent(String.self, forKey: .description)
+            input = try? c.decodeIfPresent(Input.self, forKey: .input)
+        }
     }
 
     func encode(to encoder: Encoder) throws {

--- a/Alas/Sources/ACP/UI/ACPSlashPicker.swift
+++ b/Alas/Sources/ACP/UI/ACPSlashPicker.swift
@@ -128,14 +128,18 @@ struct ACPSlashPickerView: View {
                 .foregroundStyle(theme.color("fg"))
                 .lineLimit(1)
                 .fixedSize(horizontal: true, vertical: false)
+            if let hint = s.hint, !hint.isEmpty {
+                Text("‹\(hint)›")
+                    .font(.system(size: 11, design: .monospaced))
+                    .foregroundStyle(theme.color("fg-faint"))
+                    .lineLimit(1)
+                    .fixedSize(horizontal: true, vertical: false)
+            }
             if let d = s.description, !d.isEmpty {
                 MarqueeText(
                     text: d,
                     font: .system(size: 11),
                     color: theme.color("fg-faint"),
-                    // Marquee only for the currently-selected row; the
-                    // others stay statically truncated to keep visual
-                    // noise low.
                     isActive: isSelected
                 )
             }

--- a/AlasTests/ACP/Protocol/ACPSessionUpdateTests.swift
+++ b/AlasTests/ACP/Protocol/ACPSessionUpdateTests.swift
@@ -208,7 +208,8 @@ struct ACPSessionUpdateTests {
         let env = try JSONDecoder().decode(
             JSONRPCEnvelope<ACPSessionUpdateParams>.self, from: Data(json.utf8))
         guard case .availableCommandsUpdate(let cmds) = env.params!.update else {
-            Issue.record("expected availableCommandsUpdate"); return
+            Issue.record("expected availableCommandsUpdate")
+            return
         }
         #expect(cmds.count == 2)
         #expect(cmds[0].command == "/review")
@@ -239,7 +240,8 @@ struct ACPSessionUpdateTests {
         let env = try JSONDecoder().decode(
             JSONRPCEnvelope<ACPSessionUpdateParams>.self, from: Data(json.utf8))
         guard case .availableCommandsUpdate(let cmds) = env.params!.update else {
-            Issue.record("expected availableCommandsUpdate"); return
+            Issue.record("expected availableCommandsUpdate")
+            return
         }
         #expect(cmds.count == 3)
         #expect(cmds.allSatisfy { $0.hint == nil })

--- a/AlasTests/ACP/Protocol/ACPSessionUpdateTests.swift
+++ b/AlasTests/ACP/Protocol/ACPSessionUpdateTests.swift
@@ -186,6 +186,65 @@ struct ACPSessionUpdateTests {
         } else { Issue.record("expected sessionConfigOptionsUpdate") }
     }
 
+    @Test("decodes available_commands_update with argument hint")
+    func availableCommandsHint() throws {
+        let json = """
+        {
+          "jsonrpc": "2.0",
+          "method": "session/update",
+          "params": {
+            "sessionId": "s1",
+            "update": {
+              "sessionUpdate": "available_commands_update",
+              "availableCommands": [
+                { "name": "review", "description": "Review a PR",
+                  "input": { "hint": "<pr-number>" } },
+                { "name": "init", "description": "Initialize" }
+              ]
+            }
+          }
+        }
+        """
+        let env = try JSONDecoder().decode(
+            JSONRPCEnvelope<ACPSessionUpdateParams>.self, from: Data(json.utf8))
+        guard case .availableCommandsUpdate(let cmds) = env.params!.update else {
+            Issue.record("expected availableCommandsUpdate"); return
+        }
+        #expect(cmds.count == 2)
+        #expect(cmds[0].command == "/review")
+        #expect(cmds[0].hint == "<pr-number>")
+        #expect(cmds[1].command == "/init")
+        #expect(cmds[1].hint == nil)
+    }
+
+    @Test("tolerates malformed command input without dropping the update")
+    func availableCommandsMalformedInput() throws {
+        let json = """
+        {
+          "jsonrpc": "2.0",
+          "method": "session/update",
+          "params": {
+            "sessionId": "s1",
+            "update": {
+              "sessionUpdate": "available_commands_update",
+              "availableCommands": [
+                { "name": "a", "description": "A", "input": {} },
+                { "name": "b", "description": "B", "input": "nope" },
+                { "name": "c", "description": "C" }
+              ]
+            }
+          }
+        }
+        """
+        let env = try JSONDecoder().decode(
+            JSONRPCEnvelope<ACPSessionUpdateParams>.self, from: Data(json.utf8))
+        guard case .availableCommandsUpdate(let cmds) = env.params!.update else {
+            Issue.record("expected availableCommandsUpdate"); return
+        }
+        #expect(cmds.count == 3)
+        #expect(cmds.allSatisfy { $0.hint == nil })
+    }
+
     private func decode(_ name: String) throws -> JSONRPCEnvelope<ACPSessionUpdateParams> {
         let bundle = Bundle(for: ACPSessionUpdateFixtureMarker.self)
         let url = try #require(bundle.url(forResource: name, withExtension: "json"))


### PR DESCRIPTION
## Summary
- Decode the `input.hint` field from the ACP `available_commands_update` notification (previously discarded) into a new `hint` property on `ACPPromptSuggestion`, with defensive handling so a malformed/absent `input` never breaks decoding of the rest of the update.
- Render the hint as a dim, angle-bracketed token in the `/` command picker between the command name and its description.

Closes #658

## Test plan
- [x] New decode tests: hint present, absent, malformed (`{}`, wrong type) — verified via `xcodebuild test -only-testing:AlasTests/ACPSessionUpdateTests`
- [x] Picker UI change verified via a successful app build
- [ ] CI: full build + test suite