### PR TITLE
feat(stashes): collapse the stashes section by default

### DIFF
--- a/Alas/Sources/Right/RightPaneState.swift
+++ b/Alas/Sources/Right/RightPaneState.swift
@@ -12,7 +12,7 @@ final class RightPaneState {
     let reviewLoop: ReviewLoopState
     var changes: [ChangedFile] = []
     var stashes: [GitStash] = []
-    var stashesExpanded: Bool = true
+    var stashesExpanded: Bool = false
     var expandedStashRefs: Set<String> = []
     var stashFilesByRef: [String: [GitStashFile]] = [:]
     var loadingStashRefs: Set<String> = []


### PR DESCRIPTION
Stashes are a secondary concern in the changes pane, so start the
section collapsed rather than expanded to keep the default view
focused on the working-tree changes.