### PR TITLE
feat(acp): Browse and resume ACP agent sessions

### DIFF
--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -60,6 +60,7 @@
 		0DA68649E5F3C0018C4309DA /* UpdateThrottleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 708AB670AB611EFB9D216D7C /* UpdateThrottleTests.swift */; };
 		0DFC9AB26DDCC406CEAA3825 /* ACPContextUsageButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AD22187C951174C9ECEC4C4 /* ACPContextUsageButton.swift */; };
 		0E2D69C181ECD5233770BC01 /* AgentRunnerParseTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E267334F2224961856D20BD8 /* AgentRunnerParseTests.swift */; };
+		0E2F2A2FD567CE04CF549C29 /* ACPSessionDiscoveryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2A24F057893BB2179C1900C /* ACPSessionDiscoveryTests.swift */; };
 		0E680F7AAD6CBD2A4A829A52 /* DiffReviewRenderableContentEqualityTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D153832D43BF352B94E34430 /* DiffReviewRenderableContentEqualityTests.swift */; };
 		0E892EAAAC4EBA733BC441F2 /* MergeRegionVisualLayout.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0FF6BFD0A460F0E723F796E /* MergeRegionVisualLayout.swift */; };
 		0EB3B61ECD46CCF450E717BF /* EditorOverlayPanelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 208C9ABAF59F523D2DDC2F2A /* EditorOverlayPanelTests.swift */; };
@@ -478,6 +479,7 @@
 		6BA64E78F8AB2B8710665FC9 /* ReviewDraftModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = BFA871B5464E4F9D3350851B /* ReviewDraftModels.swift */; };
 		6BF6FE50DAC473322005A036 /* ProjectsManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F5B91F414F99741818BCB17 /* ProjectsManagerTests.swift */; };
 		6C33DC3A21C3223832EA5D28 /* ACPSessionLeaseTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F31E42DEC85081FEA8CA1BC3 /* ACPSessionLeaseTests.swift */; };
+		6C70755431CFBA41420A2F47 /* ACPSessionManagerRemoteRestoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 069895A7C4E29B3275D8320E /* ACPSessionManagerRemoteRestoreTests.swift */; };
 		6C800C9827E75F9F07C67DB9 /* AppConfigTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B78A7E7888D552AFC80BA3AA /* AppConfigTests.swift */; };
 		6C9E804AB246E7BFF8906C17 /* MarkdownTabView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E09A66AE390C7748A8847C8E /* MarkdownTabView.swift */; };
 		6D5DF06E64DA191F1EE4B057 /* RightPaneStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 795056B6AD803D2B555FC866 /* RightPaneStore.swift */; };
@@ -935,6 +937,7 @@
 		D05BDEF0D8651A9C2BD8C857 /* Seg.swift in Sources */ = {isa = PBXBuildFile; fileRef = 489C9B383554D7DAB170C2F8 /* Seg.swift */; };
 		D0F4A4F5BF5F1C3C625F11D9 /* Clipboard.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0E6600436B01C75D85C01FFA /* Clipboard.swift */; };
 		D10A8F47A537C1C8969752B1 /* ACPMessageTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8A0A083659269CDD16A6764 /* ACPMessageTests.swift */; };
+		D11DB95BC2F7094756EBCAC3 /* ACPSessionDiscovery.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63376280CA1D01F9D564A6F6 /* ACPSessionDiscovery.swift */; };
 		D13AFC98364971915782491C /* ProjectConfigTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B3FF64CC698074BFDE2A36A /* ProjectConfigTests.swift */; };
 		D1826BD546F4C8D2755D8F56 /* ReviewDraftCommentActions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2EC0311F5824C51F14EC4278 /* ReviewDraftCommentActions.swift */; };
 		D1C14B54BE27D97E354F448B /* ProcessGitDataTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF741B889D6DC8B1F4EB350F /* ProcessGitDataTests.swift */; };
@@ -1186,6 +1189,7 @@
 		05C9583C0CA5EDE7D2A1B7DF /* ACPDiffGeneratorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPDiffGeneratorTests.swift; sourceTree = "<group>"; };
 		05EE713DD3CACF29F206553C /* ThemeStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThemeStore.swift; sourceTree = "<group>"; };
 		06375E561569DA36EC289C6F /* JSONRPCNewlineFramer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JSONRPCNewlineFramer.swift; sourceTree = "<group>"; };
+		069895A7C4E29B3275D8320E /* ACPSessionManagerRemoteRestoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPSessionManagerRemoteRestoreTests.swift; sourceTree = "<group>"; };
 		0704EBDA62931ADE79B04F30 /* ReviewSessionStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReviewSessionStore.swift; sourceTree = "<group>"; };
 		074A17527610230DCFBEA13C /* ACPMockClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPMockClient.swift; sourceTree = "<group>"; };
 		07A17183B064CAB5EB5D5C11 /* ReviewRequestPromptEditorWindow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReviewRequestPromptEditorWindow.swift; sourceTree = "<group>"; };
@@ -1593,6 +1597,7 @@
 		61D4F5B30CE2AA0220A3E45C /* DiffInlineHighlighterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiffInlineHighlighterTests.swift; sourceTree = "<group>"; };
 		620C4A708CD1013DE2736A00 /* AppIconTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppIconTests.swift; sourceTree = "<group>"; };
 		626DBFF220D347A36859AB17 /* ZmxSessionNameTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ZmxSessionNameTests.swift; sourceTree = "<group>"; };
+		63376280CA1D01F9D564A6F6 /* ACPSessionDiscovery.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPSessionDiscovery.swift; sourceTree = "<group>"; };
 		638E94907851A6D0B4AB8F52 /* ImageDiffEndToEndTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageDiffEndToEndTests.swift; sourceTree = "<group>"; };
 		639B69601924624FFE573EBA /* ACPSessionRecoveryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPSessionRecoveryTests.swift; sourceTree = "<group>"; };
 		64C593F9F14DD962C9822C64 /* ReviewSessionTabView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReviewSessionTabView.swift; sourceTree = "<group>"; };
@@ -2061,6 +2066,7 @@
 		D21F30DB5A812E396262A926 /* ACPMessageWire.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPMessageWire.swift; sourceTree = "<group>"; };
 		D28AEE8E4821977FDAF13960 /* FileSnapshotTabView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileSnapshotTabView.swift; sourceTree = "<group>"; };
 		D2935EB661338757C478CD86 /* SurfaceViewShortcutTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SurfaceViewShortcutTests.swift; sourceTree = "<group>"; };
+		D2A24F057893BB2179C1900C /* ACPSessionDiscoveryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPSessionDiscoveryTests.swift; sourceTree = "<group>"; };
 		D2AD81E0DFE33CE4DACF0ADF /* WorktreeWatcher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorktreeWatcher.swift; sourceTree = "<group>"; };
 		D2BD2F573498740A7DECCA3C /* ChangesPreparationModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChangesPreparationModelTests.swift; sourceTree = "<group>"; };
 		D2F90D03073708AA01531533 /* GitService+Staging.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "GitService+Staging.swift"; sourceTree = "<group>"; };
@@ -3197,6 +3203,7 @@
 				4DA695BB3D2901435BFF6C0E /* ACPProcessLiveness.swift */,
 				BBBEFD27FD7013D458435779 /* ACPSession.swift */,
 				EBF4DE84207D33D518DD7D3E /* ACPSessionByteAccounting.swift */,
+				63376280CA1D01F9D564A6F6 /* ACPSessionDiscovery.swift */,
 				94D30693F45966ED1456811E /* ACPSessionHydrator.swift */,
 				7615FEA1F225EBDE52CF5E14 /* ACPSessionManager.swift */,
 				F332906E17C5865856DBB90B /* ACPSessionRunner.swift */,
@@ -3706,11 +3713,13 @@
 				2468AD293C8215FAF390C907 /* ACPMessageWireTests.swift */,
 				0F2A5B37528AD21CAD5ED051 /* ACPSessionAgentStateTests.swift */,
 				52B5F3FFF8AEF13BC48DCFBD /* ACPSessionByteAccountingTests.swift */,
+				D2A24F057893BB2179C1900C /* ACPSessionDiscoveryTests.swift */,
 				1DC1B975662D135B148443BC /* ACPSessionHydrationStateTests.swift */,
 				8D8A320D194DF0E64BF13BC5 /* ACPSessionHydratorTests.swift */,
 				F8D36A8AF55F212B9F32A944 /* ACPSessionManagerAttachRestoreTests.swift */,
 				472917238C382A8125A84103 /* ACPSessionManagerHydrationTests.swift */,
 				3DCFA45F98F080043C4D664A /* ACPSessionManagerPlanSidebarLayoutTests.swift */,
+				069895A7C4E29B3275D8320E /* ACPSessionManagerRemoteRestoreTests.swift */,
 				6D1AAAE396590865426C592A /* ACPSessionManagerRetentionTests.swift */,
 				FB5B73ECBD730B5BB24E2240 /* ACPSessionManagerTests.swift */,
 				0B057D23BD5B72E06E790C5B /* ACPSessionQueueAPITests.swift */,
@@ -4604,6 +4613,7 @@
 				900A70EF9D41AEF3953CABBB /* ACPSelectChip.swift in Sources */,
 				8BF52AFF90954B767B9D7E65 /* ACPSession.swift in Sources */,
 				38B6857CDB7D094A46F653E2 /* ACPSessionByteAccounting.swift in Sources */,
+				D11DB95BC2F7094756EBCAC3 /* ACPSessionDiscovery.swift in Sources */,
 				61D33019E9AA23F5042C39B2 /* ACPSessionHydrator.swift in Sources */,
 				209FB0AAF20BDE5850A139F4 /* ACPSessionManager.swift in Sources */,
 				1F89B774F2DC7DD818AD4E5B /* ACPSessionRunner.swift in Sources */,
@@ -5194,6 +5204,7 @@
 				702EC5CB48F37FC8B6F27FA4 /* ACPSelectChipTests.swift in Sources */,
 				9159297D87B2AA9B7A03F072 /* ACPSessionAgentStateTests.swift in Sources */,
 				9FDF577BDD6D5C47635229DE /* ACPSessionByteAccountingTests.swift in Sources */,
+				0E2F2A2FD567CE04CF549C29 /* ACPSessionDiscoveryTests.swift in Sources */,
 				4058A537B8CAE76FE7EFE184 /* ACPSessionHydrationStateTests.swift in Sources */,
 				D45D14487117192F9E5D7F0E /* ACPSessionHydratorTests.swift in Sources */,
 				45290287102551CF8726F0EF /* ACPSessionInfoUpdateDecodeTests.swift in Sources */,
@@ -5203,6 +5214,7 @@
 				D204CCA2E2FE480D2C502186 /* ACPSessionManagerHydrationTests.swift in Sources */,
 				D28EE6309DBB51EFEDCEAC18 /* ACPSessionManagerLeaseTests.swift in Sources */,
 				8EEB68F55286EF9DADAA710A /* ACPSessionManagerPlanSidebarLayoutTests.swift in Sources */,
+				6C70755431CFBA41420A2F47 /* ACPSessionManagerRemoteRestoreTests.swift in Sources */,
 				095E7D98616FB77A9F8BDFD9 /* ACPSessionManagerRetentionTests.swift in Sources */,
 				E30243803319861ACA6A4513 /* ACPSessionManagerTests.swift in Sources */,
 				832BDA6FD48E68F76E46D786 /* ACPSessionQueueAPITests.swift in Sources */,

--- a/Alas/Sources/ACP/Protocol/ACPConnection.swift
+++ b/Alas/Sources/ACP/Protocol/ACPConnection.swift
@@ -3,6 +3,8 @@ import Foundation
 struct ACPInitializeOutcome: Equatable {
     let promptCapabilities: ACPInitializeResult.ACPPromptCapabilities
     let authMethods: [ACPInitializeResult.ACPAuthMethod]
+    let loadSession: Bool
+    let sessionCapabilities: ACPInitializeResult.ACPAgentSessionCapabilities
 }
 
 /// Higher-level wrapper that owns one `ACPClient` and exposes typed
@@ -26,7 +28,9 @@ final class ACPConnection: @unchecked Sendable {
         let result = try JSONDecoder().decode(ACPInitializeResult.self, from: resp.body)
         return ACPInitializeOutcome(
             promptCapabilities: result.agentCapabilities?.promptCapabilities ?? .init(),
-            authMethods: result.authMethods
+            authMethods: result.authMethods,
+            loadSession: result.agentCapabilities?.loadSession ?? false,
+            sessionCapabilities: result.agentCapabilities?.sessionCapabilities ?? .init()
         )
     }
 
@@ -57,6 +61,34 @@ final class ACPConnection: @unchecked Sendable {
         let resp = try await client.send(req)
         let result = try JSONDecoder().decode(ACPSessionNewResult.self, from: resp.body)
         return result.sessionId.isEmpty ? result.withSessionId(sessionId) : result
+    }
+
+    func resumeSession(cwd: String, sessionId: String) async throws -> ACPSessionNewResult {
+        let req = ACPRequest(
+            method: "session/resume",
+            params: ACPSessionResumeParams(cwd: cwd, sessionId: sessionId, mcpServers: [])
+        )
+        let resp = try await client.send(req)
+        let result = try JSONDecoder().decode(ACPSessionNewResult.self, from: resp.body)
+        return result.sessionId.isEmpty ? result.withSessionId(sessionId) : result
+    }
+
+    func listSessions(cwd: String?, cursor: String? = nil) async throws -> ACPSessionListResult {
+        let req = ACPRequest(
+            method: "session/list",
+            params: ACPSessionListParams(cwd: cwd, cursor: cursor)
+        )
+        let resp = try await client.send(req)
+        return try JSONDecoder().decode(ACPSessionListResult.self, from: resp.body)
+    }
+
+    func forkSession(cwd: String, sessionId: String) async throws -> ACPSessionNewResult {
+        let req = ACPRequest(
+            method: "session/fork",
+            params: ACPSessionForkParams(cwd: cwd, sessionId: sessionId, mcpServers: [])
+        )
+        let resp = try await client.send(req)
+        return try JSONDecoder().decode(ACPSessionNewResult.self, from: resp.body)
     }
 
     func cancel(sessionId: String) async throws {

--- a/Alas/Sources/ACP/Protocol/ACPMessages.swift
+++ b/Alas/Sources/ACP/Protocol/ACPMessages.swift
@@ -197,6 +197,44 @@ struct ACPInitializeResult: Codable, Equatable {
 
     struct ACPAgentCapabilities: Codable, Equatable {
         let promptCapabilities: ACPPromptCapabilities?
+        let loadSession: Bool
+        let sessionCapabilities: ACPAgentSessionCapabilities
+
+        init(
+            promptCapabilities: ACPPromptCapabilities? = nil,
+            loadSession: Bool = false,
+            sessionCapabilities: ACPAgentSessionCapabilities = .init()
+        ) {
+            self.promptCapabilities = promptCapabilities
+            self.loadSession = loadSession
+            self.sessionCapabilities = sessionCapabilities
+        }
+
+        init(from decoder: Decoder) throws {
+            let c = try decoder.container(keyedBy: CodingKeys.self)
+            promptCapabilities = try c.decodeIfPresent(ACPPromptCapabilities.self, forKey: .promptCapabilities)
+            loadSession = try c.decodeIfPresent(Bool.self, forKey: .loadSession) ?? false
+            sessionCapabilities = try c.decodeIfPresent(
+                ACPAgentSessionCapabilities.self,
+                forKey: .sessionCapabilities
+            ) ?? .init()
+        }
+    }
+
+    struct ACPAgentSessionCapabilities: Codable, Equatable {
+        let list: EmptyObject?
+        let resume: EmptyObject?
+        let fork: EmptyObject?
+
+        init(list: EmptyObject? = nil, resume: EmptyObject? = nil, fork: EmptyObject? = nil) {
+            self.list = list
+            self.resume = resume
+            self.fork = fork
+        }
+
+        var supportsList: Bool { list != nil }
+        var supportsResume: Bool { resume != nil }
+        var supportsFork: Bool { fork != nil }
     }
     struct ACPPromptCapabilities: Codable, Equatable {
         let image: Bool
@@ -686,6 +724,50 @@ struct ACPSessionLoadParams: Codable, Equatable {
     let sessionId: String
     let mcpServers: [ACPSessionNewParams.ACPMCPServer]
 }
+
+// MARK: - session/list + session/resume + session/fork
+
+struct ACPSessionListParams: Codable, Equatable {
+    let cwd: String?
+    let cursor: String?
+}
+
+struct ACPSessionListResult: Codable, Equatable {
+    let sessions: [ACPAgentSessionInfo]
+    let nextCursor: String?
+
+    init(sessions: [ACPAgentSessionInfo], nextCursor: String? = nil) {
+        self.sessions = sessions
+        self.nextCursor = nextCursor
+    }
+}
+
+struct ACPAgentSessionInfo: Codable, Equatable, Identifiable {
+    var id: String { sessionId }
+
+    let sessionId: String
+    let cwd: String
+    let title: String?
+    let updatedAt: String?
+    let additionalDirectories: [String]?
+
+    init(
+        sessionId: String,
+        cwd: String,
+        title: String? = nil,
+        updatedAt: String? = nil,
+        additionalDirectories: [String]? = nil
+    ) {
+        self.sessionId = sessionId
+        self.cwd = cwd
+        self.title = title
+        self.updatedAt = updatedAt
+        self.additionalDirectories = additionalDirectories
+    }
+}
+
+typealias ACPSessionResumeParams = ACPSessionLoadParams
+typealias ACPSessionForkParams = ACPSessionLoadParams
 
 // MARK: - session/cancel
 

--- a/Alas/Sources/ACP/Session/ACPSession.swift
+++ b/Alas/Sources/ACP/Session/ACPSession.swift
@@ -43,6 +43,7 @@ final class ACPSession: ObservableObject, Identifiable {
 
     @Published var title: String
     @Published var titleSource: ACPSessionTitleSource
+    let origin: ACPSessionOrigin
     @Published var availableModels: [ACPModelInfo] = []
     @Published var availableModes: [ACPModeInfo] = []
     @Published var availableConfigOptions: [ACPConfigOption] = []
@@ -244,6 +245,7 @@ final class ACPSession: ObservableObject, Identifiable {
 
     init(id: ID, agentId: String, worktreeId: String, title: String,
          titleSource: ACPSessionTitleSource = .placeholder,
+         origin: ACPSessionOrigin = .alasCreated,
          createdAt: Date = Date(),
          hydrationState: HydrationState = .ready,
          restoredFromPersistence: Bool = false) {
@@ -252,6 +254,7 @@ final class ACPSession: ObservableObject, Identifiable {
         self.worktreeId = worktreeId
         self.title = title
         self.titleSource = titleSource
+        self.origin = origin
         self.createdAt = createdAt
         self.hydrationState = hydrationState
         self.restoredFromPersistence = restoredFromPersistence

--- a/Alas/Sources/ACP/Session/ACPSessionDiscovery.swift
+++ b/Alas/Sources/ACP/Session/ACPSessionDiscovery.swift
@@ -1,0 +1,197 @@
+import Foundation
+import Observation
+
+struct ACPSessionDiscoveryCapabilities: Equatable {
+    let canLoad: Bool
+    let canResume: Bool
+    let canFork: Bool
+
+    var canOpenRemoteSession: Bool { canLoad || canResume }
+}
+
+struct ACPDiscoveredSession: Identifiable, Equatable {
+    var id: String { remoteSessionId }
+
+    let agentId: String
+    let remoteSessionId: String
+    let cwd: String
+    let title: String
+    let updatedAt: Date?
+    let additionalDirectories: [String]
+    let localSessionId: String?
+
+    var isAlreadyInAlas: Bool { localSessionId != nil }
+    var isCompatibleWithAlas: Bool { additionalDirectories.isEmpty }
+}
+
+enum ACPSessionRestoreOperation: Equatable {
+    case resume
+    case loadWithRecovery
+    case loadStrict
+    case unavailable
+}
+
+enum ACPSessionRestorePolicy {
+    static func operation(
+        origin: ACPSessionOrigin,
+        canLoad: Bool,
+        canResume: Bool
+    ) -> ACPSessionRestoreOperation {
+        switch origin {
+        case .alasCreated:
+            return canResume ? .resume : .loadWithRecovery
+        case .agentImported, .agentForked:
+            if canLoad { return .loadStrict }
+            if canResume { return .resume }
+            return .unavailable
+        }
+    }
+}
+
+enum ACPSessionDiscoveryError: LocalizedError, Equatable {
+    case noLaunchSpec(String)
+    case setupRequired(String)
+    case listingUnsupported
+
+    var errorDescription: String? {
+        switch self {
+        case .noLaunchSpec(let agentId):
+            return "No ACP launch configuration is available for \(agentId)."
+        case .setupRequired(let reason):
+            return reason
+        case .listingUnsupported:
+            return "This agent does not support session browsing."
+        }
+    }
+}
+
+enum ACPSessionAttachError: LocalizedError, Equatable {
+    case remoteSessionUnsupported
+
+    var errorDescription: String? {
+        "This agent cannot reopen the selected session."
+    }
+}
+
+@MainActor
+final class ACPSessionDiscoveryHandle {
+    let capabilities: ACPSessionDiscoveryCapabilities
+    private let agentId: String
+    private let cwd: String
+    private let store: ACPSessionStore
+    private let connection: ACPConnection
+    private var nextCursor: String?
+    private var hasLoadedPage = false
+    private var closed = false
+
+    init(
+        agentId: String,
+        cwd: String,
+        store: ACPSessionStore,
+        connection: ACPConnection,
+        capabilities: ACPSessionDiscoveryCapabilities
+    ) {
+        self.agentId = agentId
+        self.cwd = cwd
+        self.store = store
+        self.connection = connection
+        self.capabilities = capabilities
+    }
+
+    var canLoadMore: Bool { !hasLoadedPage || nextCursor != nil }
+
+    func loadNextPage() async throws -> [ACPDiscoveredSession] {
+        guard !closed, canLoadMore else { return [] }
+        let page = try await connection.listSessions(cwd: cwd, cursor: nextCursor)
+        hasLoadedPage = true
+        nextCursor = page.nextCursor
+        let expectedCWD = URL(fileURLWithPath: cwd).standardizedFileURL.path
+        return page.sessions.compactMap { info in
+            guard URL(fileURLWithPath: info.cwd).standardizedFileURL.path == expectedCWD else {
+                return nil
+            }
+            let local = try? store.loadSession(agentId: agentId, remoteSessionId: info.sessionId)
+            let remoteTitle = info.title?.trimmingCharacters(in: .whitespacesAndNewlines)
+            let displayTitle = if let remoteTitle, !remoteTitle.isEmpty {
+                remoteTitle
+            } else {
+                "Agent session"
+            }
+            return ACPDiscoveredSession(
+                agentId: agentId,
+                remoteSessionId: info.sessionId,
+                cwd: info.cwd,
+                title: local?.title ?? displayTitle,
+                updatedAt: info.updatedAt.flatMap { ISO8601DateFormatter().date(from: $0) },
+                additionalDirectories: info.additionalDirectories ?? [],
+                localSessionId: local?.id
+            )
+        }
+    }
+
+    func close() async {
+        guard !closed else { return }
+        closed = true
+        await connection.shutdown()
+    }
+}
+
+@MainActor
+@Observable
+final class ACPSessionDiscoveryModel {
+    enum Phase: Equatable {
+        case idle
+        case loading
+        case ready
+        case unsupported
+        case failed(String)
+    }
+
+    private(set) var phase: Phase = .idle
+    private(set) var sessions: [ACPDiscoveredSession] = []
+    private(set) var capabilities: ACPSessionDiscoveryCapabilities?
+    private(set) var paginationError: String?
+    private var handle: ACPSessionDiscoveryHandle?
+    private var stopped = false
+
+    var canLoadMore: Bool { handle?.canLoadMore == true }
+
+    func start(manager: ACPSessionManager, agentId: String) async {
+        guard phase == .idle, !stopped else { return }
+        phase = .loading
+        do {
+            let handle = try await manager.makeSessionDiscoveryHandle(agentId: agentId)
+            guard !stopped else {
+                await handle.close()
+                return
+            }
+            self.handle = handle
+            capabilities = handle.capabilities
+            try await loadMore()
+            phase = .ready
+        } catch ACPSessionDiscoveryError.listingUnsupported {
+            phase = .unsupported
+        } catch {
+            phase = .failed(error.localizedDescription)
+        }
+    }
+
+    func loadMore() async throws {
+        guard let handle else { return }
+        do {
+            let page = try await handle.loadNextPage()
+            var known = Set(sessions.map(\.remoteSessionId))
+            sessions.append(contentsOf: page.filter { known.insert($0.remoteSessionId).inserted })
+            paginationError = nil
+        } catch {
+            paginationError = error.localizedDescription
+            throw error
+        }
+    }
+
+    func stop() async {
+        stopped = true
+        await handle?.close()
+        handle = nil
+    }
+}

--- a/Alas/Sources/ACP/Session/ACPSessionDiscovery.swift
+++ b/Alas/Sources/ACP/Session/ACPSessionDiscovery.swift
@@ -12,6 +12,7 @@ struct ACPSessionDiscoveryCapabilities: Equatable {
 struct ACPDiscoveredSession: Identifiable, Equatable {
     var id: String { remoteSessionId }
 
+    let worktreeId: String
     let agentId: String
     let remoteSessionId: String
     let cwd: String
@@ -78,6 +79,7 @@ enum ACPSessionAttachError: LocalizedError, Equatable {
 @MainActor
 final class ACPSessionDiscoveryHandle {
     let capabilities: ACPSessionDiscoveryCapabilities
+    private let worktreeId: String
     private let agentId: String
     private let cwd: String
     private let store: ACPSessionStore
@@ -87,12 +89,14 @@ final class ACPSessionDiscoveryHandle {
     private var closed = false
 
     init(
+        worktreeId: String,
         agentId: String,
         cwd: String,
         store: ACPSessionStore,
         connection: ACPConnection,
         capabilities: ACPSessionDiscoveryCapabilities
     ) {
+        self.worktreeId = worktreeId
         self.agentId = agentId
         self.cwd = cwd
         self.store = store
@@ -120,6 +124,7 @@ final class ACPSessionDiscoveryHandle {
                 "Agent session"
             }
             return ACPDiscoveredSession(
+                worktreeId: worktreeId,
                 agentId: agentId,
                 remoteSessionId: info.sessionId,
                 cwd: info.cwd,

--- a/Alas/Sources/ACP/Session/ACPSessionDiscovery.swift
+++ b/Alas/Sources/ACP/Session/ACPSessionDiscovery.swift
@@ -35,12 +35,14 @@ enum ACPSessionRestorePolicy {
     static func operation(
         origin: ACPSessionOrigin,
         canLoad: Bool,
-        canResume: Bool
+        canResume: Bool,
+        hasLocalTranscript: Bool = false
     ) -> ACPSessionRestoreOperation {
         switch origin {
         case .alasCreated:
             return canResume ? .resume : .loadWithRecovery
         case .agentImported, .agentForked:
+            if hasLocalTranscript, canResume { return .resume }
             if canLoad { return .loadStrict }
             if canResume { return .resume }
             return .unavailable

--- a/Alas/Sources/ACP/Session/ACPSessionManager.swift
+++ b/Alas/Sources/ACP/Session/ACPSessionManager.swift
@@ -1584,15 +1584,37 @@ extension ACPSessionManager {
                 }
                 switch restoreOperation {
                 case .resume:
-                    result = try await connection.resumeSession(cwd: worktreePath, sessionId: remoteId)
-                    if !pendingRecovery {
-                        session.contextRecoveryStatus = nil
-                    }
-                    if session.origin != .alasCreated, !session.hasConversationTranscript {
-                        restoreWarning = .init(
-                            message: "Earlier messages remain in the agent and are not available in Alas.",
-                            canSendTranscript: false
-                        )
+                    do {
+                        result = try await connection.resumeSession(cwd: worktreePath, sessionId: remoteId)
+                        if !pendingRecovery {
+                            session.contextRecoveryStatus = nil
+                        }
+                        if session.origin != .alasCreated, !session.hasConversationTranscript {
+                            restoreWarning = .init(
+                                message: "Earlier messages remain in the agent and are not available in Alas.",
+                                canSendTranscript: false
+                            )
+                        }
+                    } catch {
+                        guard session.origin == .alasCreated,
+                              ACPAuthFailure.message(from: error) == nil
+                        else { throw error }
+                        result = try await connection.newSession(cwd: worktreePath)
+                        if session.hasConversationTranscript {
+                            shouldHoldQueueForRecovery = true
+                            if !anotherLiveInstanceOwnsLease(sessionId: sessionId) {
+                                persistContextRecoveryPending(sessionId: sessionId, pending: true)
+                            }
+                        }
+                        if hasRestorableContext {
+                            restoreWarning = .init(
+                                message: "Agent context could not be restored.",
+                                canSendTranscript: session.hasConversationTranscript
+                            )
+                        }
+                        if session.hasConversationTranscript {
+                            session.contextRecoveryStatus = .sendingTranscript
+                        }
                     }
                 case .loadStrict:
                     do {

--- a/Alas/Sources/ACP/Session/ACPSessionManager.swift
+++ b/Alas/Sources/ACP/Session/ACPSessionManager.swift
@@ -1521,9 +1521,11 @@ extension ACPSessionManager {
             let restoreOperation = ACPSessionRestorePolicy.operation(
                 origin: session.origin,
                 canLoad: initialized.loadSession,
-                canResume: initialized.sessionCapabilities.supportsResume
+                canResume: initialized.sessionCapabilities.supportsResume,
+                hasLocalTranscript: session.hasConversationTranscript
             )
-            let shouldSuppressLoadReplay = restoreOperation == .loadWithRecovery
+            let shouldSuppressLoadReplay = (restoreOperation == .loadWithRecovery
+                || restoreOperation == .loadStrict)
                 && !freshlyCreated
                 && session.hydrationState == .ready
                 && session.hasConversationTranscript
@@ -1593,7 +1595,17 @@ extension ACPSessionManager {
                         )
                     }
                 case .loadStrict:
-                    result = try await connection.loadSession(cwd: worktreePath, sessionId: remoteId)
+                    do {
+                        result = try await connection.loadSession(cwd: worktreePath, sessionId: remoteId)
+                        runner.finishSuppressingLoadReplay(
+                            throughYieldedUpdateCount: connection.client.yieldedUpdateCount
+                        )
+                    } catch {
+                        runner.finishSuppressingLoadReplay(
+                            throughYieldedUpdateCount: connection.client.yieldedUpdateCount
+                        )
+                        throw error
+                    }
                     if !pendingRecovery {
                         session.contextRecoveryStatus = nil
                     }

--- a/Alas/Sources/ACP/Session/ACPSessionManager.swift
+++ b/Alas/Sources/ACP/Session/ACPSessionManager.swift
@@ -930,6 +930,7 @@ final class ACPSessionManager: ObservableObject {
                 throw ACPSessionDiscoveryError.listingUnsupported
             }
             return ACPSessionDiscoveryHandle(
+                worktreeId: worktreeId,
                 agentId: agentId,
                 cwd: worktreePath,
                 store: store,
@@ -952,6 +953,9 @@ final class ACPSessionManager: ObservableObject {
         autoRunDefault: Bool = false,
         origin: ACPSessionOrigin = .agentImported
     ) -> ACPSessionRow? {
+        let discoveredCWD = URL(fileURLWithPath: discovered.cwd).standardizedFileURL.path
+        let managerCWD = URL(fileURLWithPath: worktreePath).standardizedFileURL.path
+        guard discovered.worktreeId == worktreeId, discoveredCWD == managerCWD else { return nil }
         if let existing = try? store.loadSession(
             agentId: discovered.agentId,
             remoteSessionId: discovered.remoteSessionId

--- a/Alas/Sources/ACP/Session/ACPSessionManager.swift
+++ b/Alas/Sources/ACP/Session/ACPSessionManager.swift
@@ -248,7 +248,8 @@ final class ACPSessionManager: ObservableObject {
         try? store.upsertSession(row)
         let session = ACPSession(
             id: id, agentId: agentId, worktreeId: worktreeId,
-            title: row.title, titleSource: .placeholder, hydrationState: .ready)
+            title: row.title, titleSource: .placeholder, origin: row.origin,
+            hydrationState: .ready)
         session.autoRunEnabled = autoRunDefault
         sessions[id] = session
         refreshRecent()
@@ -267,7 +268,8 @@ final class ACPSessionManager: ObservableObject {
         guard let row = try? store.loadSession(id: id) else { return nil }
         let session = ACPSession(
             id: row.id, agentId: row.agentId, worktreeId: worktreeId,
-            title: row.title, titleSource: row.titleSource, hydrationState: .loading,
+            title: row.title, titleSource: row.titleSource, origin: row.origin,
+            hydrationState: .loading,
             restoredFromPersistence: true)
         session.remoteSessionId = row.remoteSessionId
         if let memory = transcriptScrollMemory[id] {
@@ -366,6 +368,7 @@ final class ACPSessionManager: ObservableObject {
             id: row.id, agentId: row.agentId, title: row.title,
             titleSource: row.titleSource,
             remoteSessionId: row.remoteSessionId,
+            origin: row.origin,
             contextRecoveryPending: row.contextRecoveryPending,
             currentModel: row.currentModel, currentMode: row.currentMode,
             autoRun: row.autoRun,
@@ -703,6 +706,9 @@ final class ACPSessionManager: ObservableObject {
         try? store.upsertSession(.init(
             id: row.id, agentId: row.agentId, title: s.title,
             titleSource: s.titleSource,
+            remoteSessionId: row.remoteSessionId,
+            origin: row.origin,
+            contextRecoveryPending: row.contextRecoveryPending,
             currentModel: s.currentModel, currentMode: s.currentMode,
             autoRun: s.autoRunEnabled,
             createdAt: row.createdAt, updatedAt: now,
@@ -719,6 +725,7 @@ final class ACPSessionManager: ObservableObject {
             title: row.title,
             titleSource: row.titleSource,
             remoteSessionId: s.remoteSessionId,
+            origin: row.origin,
             contextRecoveryPending: row.contextRecoveryPending,
             currentModel: row.currentModel,
             currentMode: row.currentMode,
@@ -905,6 +912,79 @@ final class ACPSessionManager: ObservableObject {
 
     func refreshRecent() {
         recent = (try? store.recentSessions()) ?? []
+    }
+
+    func makeSessionDiscoveryHandle(agentId: String) async throws -> ACPSessionDiscoveryHandle {
+        guard let spec = ACPLaunchCatalog.spec(for: agentId) else {
+            throw ACPSessionDiscoveryError.noLaunchSpec(agentId)
+        }
+        let setup = await setupEvaluator(spec)
+        guard case .ready = setup else {
+            throw ACPSessionDiscoveryError.setupRequired(setup.reasonText)
+        }
+
+        let connection = try connectionFactory(await resolvedLaunchSpec(for: spec))
+        do {
+            let initialized = try await connection.initialize()
+            guard initialized.sessionCapabilities.supportsList else {
+                throw ACPSessionDiscoveryError.listingUnsupported
+            }
+            return ACPSessionDiscoveryHandle(
+                agentId: agentId,
+                cwd: worktreePath,
+                store: store,
+                connection: connection,
+                capabilities: .init(
+                    canLoad: initialized.loadSession,
+                    canResume: initialized.sessionCapabilities.supportsResume,
+                    canFork: initialized.sessionCapabilities.supportsFork
+                )
+            )
+        } catch {
+            await connection.shutdown()
+            throw error
+        }
+    }
+
+    @discardableResult
+    func materializeDiscoveredSession(
+        _ discovered: ACPDiscoveredSession,
+        autoRunDefault: Bool = false,
+        origin: ACPSessionOrigin = .agentImported
+    ) -> ACPSessionRow? {
+        if let existing = try? store.loadSession(
+            agentId: discovered.agentId,
+            remoteSessionId: discovered.remoteSessionId
+        ) {
+            return existing
+        }
+        guard discovered.isCompatibleWithAlas else { return nil }
+
+        let now = Int64(Date().timeIntervalSince1970)
+        let remoteUpdatedAt = discovered.updatedAt.map { Int64($0.timeIntervalSince1970) } ?? now
+        let title = discovered.title.trimmingCharacters(in: .whitespacesAndNewlines)
+        let row = ACPSessionRow(
+            id: UUID().uuidString,
+            agentId: discovered.agentId,
+            title: title.isEmpty ? "Agent session" : title,
+            titleSource: title.isEmpty ? .placeholder : .generated,
+            remoteSessionId: discovered.remoteSessionId,
+            origin: origin,
+            currentModel: nil,
+            currentMode: nil,
+            autoRun: autoRunDefault,
+            createdAt: remoteUpdatedAt,
+            updatedAt: remoteUpdatedAt,
+            lastOpenedAt: now,
+            archived: false
+        )
+        do {
+            try store.upsertSession(row)
+            refreshRecent()
+            return row
+        } catch {
+            return nil
+        }
     }
 
     /// Loads the full persisted `content` for a tool call. Used by the
@@ -1438,7 +1518,13 @@ extension ACPSessionManager {
                     return
                 }
             }
-            let shouldSuppressLoadReplay = !freshlyCreated
+            let restoreOperation = ACPSessionRestorePolicy.operation(
+                origin: session.origin,
+                canLoad: initialized.loadSession,
+                canResume: initialized.sessionCapabilities.supportsResume
+            )
+            let shouldSuppressLoadReplay = restoreOperation == .loadWithRecovery
+                && !freshlyCreated
                 && session.hydrationState == .ready
                 && session.hasConversationTranscript
                 && !(session.remoteSessionId ?? "").isEmpty
@@ -1494,40 +1580,61 @@ extension ACPSessionManager {
                 if session.hasConversationTranscript {
                     session.contextRecoveryStatus = .restoring
                 }
-                do {
-                    result = try await connection.loadSession(cwd: worktreePath, sessionId: remoteId)
-                    runner.finishSuppressingLoadReplay(
-                        throughYieldedUpdateCount: connection.client.yieldedUpdateCount
-                    )
+                switch restoreOperation {
+                case .resume:
+                    result = try await connection.resumeSession(cwd: worktreePath, sessionId: remoteId)
                     if !pendingRecovery {
                         session.contextRecoveryStatus = nil
                     }
-                } catch {
-                    runner.finishSuppressingLoadReplay(
-                        throughYieldedUpdateCount: connection.client.yieldedUpdateCount
-                    )
-                    if ACPAuthFailure.message(from: error) != nil {
-                        throw error
-                    }
-                    result = try await connection.newSession(cwd: worktreePath)
-                    if session.hasConversationTranscript {
-                        shouldHoldQueueForRecovery = true
-                        // Guard the store write: if another instance took over
-                        // while we were awaiting loadSession/newSession, do not
-                        // persist recovery state to a session we no longer own.
-                        if !anotherLiveInstanceOwnsLease(sessionId: sessionId) {
-                            persistContextRecoveryPending(sessionId: sessionId, pending: true)
-                        }
-                    }
-                    if hasRestorableContext {
+                    if session.origin != .alasCreated, !session.hasConversationTranscript {
                         restoreWarning = .init(
-                            message: "Agent context could not be restored.",
-                            canSendTranscript: session.hasConversationTranscript
+                            message: "Earlier messages remain in the agent and are not available in Alas.",
+                            canSendTranscript: false
                         )
                     }
-                    if session.hasConversationTranscript {
-                        session.contextRecoveryStatus = .sendingTranscript
+                case .loadStrict:
+                    result = try await connection.loadSession(cwd: worktreePath, sessionId: remoteId)
+                    if !pendingRecovery {
+                        session.contextRecoveryStatus = nil
                     }
+                case .loadWithRecovery:
+                    do {
+                        result = try await connection.loadSession(cwd: worktreePath, sessionId: remoteId)
+                        runner.finishSuppressingLoadReplay(
+                            throughYieldedUpdateCount: connection.client.yieldedUpdateCount
+                        )
+                        if !pendingRecovery {
+                            session.contextRecoveryStatus = nil
+                        }
+                    } catch {
+                        runner.finishSuppressingLoadReplay(
+                            throughYieldedUpdateCount: connection.client.yieldedUpdateCount
+                        )
+                        if ACPAuthFailure.message(from: error) != nil {
+                            throw error
+                        }
+                        result = try await connection.newSession(cwd: worktreePath)
+                        if session.hasConversationTranscript {
+                            shouldHoldQueueForRecovery = true
+                            // Guard the store write: if another instance took over
+                            // while we were awaiting loadSession/newSession, do not
+                            // persist recovery state to a session we no longer own.
+                            if !anotherLiveInstanceOwnsLease(sessionId: sessionId) {
+                                persistContextRecoveryPending(sessionId: sessionId, pending: true)
+                            }
+                        }
+                        if hasRestorableContext {
+                            restoreWarning = .init(
+                                message: "Agent context could not be restored.",
+                                canSendTranscript: session.hasConversationTranscript
+                            )
+                        }
+                        if session.hasConversationTranscript {
+                            session.contextRecoveryStatus = .sendingTranscript
+                        }
+                    }
+                case .unavailable:
+                    throw ACPSessionAttachError.remoteSessionUnsupported
                 }
             } else {
                 result = try await connection.newSession(cwd: worktreePath)
@@ -1614,8 +1721,8 @@ extension ACPSessionManager {
             stderrTask.cancel()
             let tail = stderrBuffer.tail()
             let authReason = ACPAuthFailure.message(from: error)
-            let baseMessage = authReason ?? error.localizedDescription
-            let base = "ACP initialize/new failed: \(baseMessage)"
+            let baseMessage = authReason ?? (error as? JSONRPCError)?.message ?? error.localizedDescription
+            let base = "ACP session attach failed: \(baseMessage)"
             let full = tail.isEmpty ? base : base + "\nstderr: " + tail
             session.lastError = full
             session.contextRecoveryStatus = nil

--- a/Alas/Sources/ACP/Session/ACPSessionRunner.swift
+++ b/Alas/Sources/ACP/Session/ACPSessionRunner.swift
@@ -519,6 +519,9 @@ final class ACPSessionRunner {
         try? store.upsertSession(.init(
             id: row.id, agentId: row.agentId, title: session.title,
             titleSource: session.titleSource,
+            remoteSessionId: row.remoteSessionId,
+            origin: row.origin,
+            contextRecoveryPending: row.contextRecoveryPending,
             currentModel: session.currentModel, currentMode: session.currentMode,
             autoRun: session.autoRunEnabled,
             createdAt: row.createdAt, updatedAt: now,

--- a/Alas/Sources/ACP/Session/ACPSessionStore.swift
+++ b/Alas/Sources/ACP/Session/ACPSessionStore.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 final class ACPSessionStore {
-    static let targetSchemaVersion = 7
+    static let targetSchemaVersion = 8
     let db: SQLiteDatabase
 
     init(path: String) throws {
@@ -32,6 +32,7 @@ final class ACPSessionStore {
         if current < 5 { try migrate_to_v5() }
         if current < 6 { try migrate_to_v6() }
         if current < 7 { try migrate_to_v7() }
+        if current < 8 { try migrate_to_v8() }
         try recoverFromConcurrentWriters()
         if current == 0 {
             try db.exec("INSERT INTO schema_version (version) VALUES (?)", bindings: [Int64(Self.targetSchemaVersion)])
@@ -163,6 +164,15 @@ final class ACPSessionStore {
         )
         """)
     }
+
+    private func migrate_to_v8() throws {
+        try db.exec("ALTER TABLE sessions ADD COLUMN origin TEXT NOT NULL DEFAULT 'alasCreated'")
+        try db.exec("""
+        CREATE INDEX IF NOT EXISTS sessions_agent_remote_idx
+        ON sessions(agent_id, remote_session_id)
+        WHERE remote_session_id IS NOT NULL
+        """)
+    }
 }
 
 struct ACPSessionLease: Equatable {
@@ -173,12 +183,19 @@ struct ACPSessionLease: Equatable {
     let status: String   // "idle" | "busy"
 }
 
+enum ACPSessionOrigin: String, Codable, Equatable {
+    case alasCreated
+    case agentImported
+    case agentForked
+}
+
 struct ACPSessionRow: Equatable {
     let id: String
     let agentId: String
     var title: String
     var titleSource: ACPSessionTitleSource = .placeholder
     var remoteSessionId: String? = nil
+    var origin: ACPSessionOrigin = .alasCreated
     var contextRecoveryPending: Bool = false
     var currentModel: String?
     var currentMode: String?
@@ -201,13 +218,14 @@ struct ACPStoredMessage: Equatable {
 extension ACPSessionStore {
     func upsertSession(_ s: ACPSessionRow, preserveTitle: Bool = false) throws {
         try db.exec("""
-        INSERT INTO sessions (id, agent_id, title, title_source, remote_session_id, context_recovery_pending,
+        INSERT INTO sessions (id, agent_id, title, title_source, remote_session_id, origin, context_recovery_pending,
                               current_model, current_mode, auto_run, created_at, updated_at, last_opened_at, archived)
-        VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?)
+        VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?)
         ON CONFLICT(id) DO UPDATE SET
             title = CASE WHEN ? THEN sessions.title ELSE excluded.title END,
             title_source = CASE WHEN ? THEN sessions.title_source ELSE excluded.title_source END,
             remote_session_id = COALESCE(excluded.remote_session_id, sessions.remote_session_id),
+            origin = excluded.origin,
             context_recovery_pending = sessions.context_recovery_pending,
             current_model = excluded.current_model,
             current_mode = excluded.current_mode,
@@ -216,7 +234,8 @@ extension ACPSessionStore {
             last_opened_at = excluded.last_opened_at,
             archived = excluded.archived
         """, bindings: [
-            s.id, s.agentId, s.title, s.titleSource.rawValue, s.remoteSessionId, s.contextRecoveryPending ? 1 : 0,
+            s.id, s.agentId, s.title, s.titleSource.rawValue, s.remoteSessionId, s.origin.rawValue,
+            s.contextRecoveryPending ? 1 : 0,
             s.currentModel, s.currentMode, s.autoRun ? 1 : 0,
             s.createdAt, s.updatedAt, s.lastOpenedAt, s.archived ? 1 : 0,
             preserveTitle ? 1 : 0,
@@ -226,6 +245,16 @@ extension ACPSessionStore {
 
     func loadSession(id: String) throws -> ACPSessionRow? {
         let rows = try db.query("SELECT * FROM sessions WHERE id = ?", bindings: [id])
+        return rows.first.map(Self.rowToSession)
+    }
+
+    func loadSession(agentId: String, remoteSessionId: String) throws -> ACPSessionRow? {
+        let rows = try db.query("""
+        SELECT * FROM sessions
+        WHERE agent_id = ? AND remote_session_id = ? AND archived = 0
+        ORDER BY last_opened_at DESC
+        LIMIT 1
+        """, bindings: [agentId, remoteSessionId])
         return rows.first.map(Self.rowToSession)
     }
 
@@ -400,6 +429,7 @@ extension ACPSessionStore {
             title: r["title"] as? String ?? "",
             titleSource: ACPSessionTitleSource(rawValue: rawSource) ?? .placeholder,
             remoteSessionId: r["remote_session_id"] as? String,
+            origin: ACPSessionOrigin(rawValue: r["origin"] as? String ?? "") ?? .alasCreated,
             contextRecoveryPending: ((r["context_recovery_pending"] as? Int64) ?? 0) != 0,
             currentModel: r["current_model"] as? String,
             currentMode: r["current_mode"] as? String,

--- a/Alas/Sources/Agents/AgentLauncherDialog.swift
+++ b/Alas/Sources/Agents/AgentLauncherDialog.swift
@@ -5,6 +5,10 @@ struct AgentLauncherDialog: View {
     let selectedWorktree: () -> Worktree?
     @Environment(\.theme) private var theme
     @FocusState private var inputFocused: Bool
+    @State private var chatAgent: AgentDefinition?
+    @State private var discoveryModel: ACPSessionDiscoveryModel?
+    @State private var selectedSessionIndex = 0
+    @State private var loadingMore = false
 
     var body: some View {
         if appState.isAgentLauncherOpen {
@@ -15,7 +19,9 @@ struct AgentLauncherDialog: View {
 
                 VStack(spacing: 0) {
                     inputRow
-                    modePicker
+                    if chatAgent == nil {
+                        modePicker
+                    }
                     Divider().background(theme.color("line"))
                     rowList
                     footer
@@ -41,6 +47,9 @@ struct AgentLauncherDialog: View {
             .onChange(of: appState.isAgentLauncherOpen) { _, isOpen in
                 if isOpen { requestInputFocus() }
             }
+            .onChange(of: appState.agentLauncher.query) {
+                selectedSessionIndex = 0
+            }
         }
     }
 
@@ -50,7 +59,19 @@ struct AgentLauncherDialog: View {
 
     private var inputRow: some View {
         HStack(spacing: 8) {
-            Icon(name: "sparkle", size: 12, color: theme.color("fg-faint"))
+            if let chatAgent {
+                Button {
+                    backToAgents()
+                } label: {
+                    Image(systemName: "chevron.left")
+                        .font(.system(size: 11, weight: .semibold))
+                }
+                .buttonStyle(.plain)
+                .help("Back to agents")
+                AgentLogoView(agent: chatAgent).frame(width: 16, height: 16)
+            } else {
+                Icon(name: "sparkle", size: 12, color: theme.color("fg-faint"))
+            }
             TextField(placeholder, text: Bindable(appState.agentLauncher).query)
                 .textFieldStyle(.plain)
                 .focused($inputFocused)
@@ -84,7 +105,9 @@ struct AgentLauncherDialog: View {
     private var placeholder: String {
         switch appState.agentLauncher.mode {
         case .terminal: return "Launch agent in terminal…"
-        case .acp:      return "Launch ACP chat session…"
+        case .acp:
+            if let chatAgent { return "Search \(chatAgent.displayName) sessions…" }
+            return "Launch ACP chat session…"
         }
     }
 
@@ -144,7 +167,16 @@ struct AgentLauncherDialog: View {
         .buttonStyle(.plain)
     }
 
+    @ViewBuilder
     private var rowList: some View {
+        if let chatAgent {
+            sessionRowList(agent: chatAgent)
+        } else {
+            agentRowList
+        }
+    }
+
+    private var agentRowList: some View {
         let agents = rows
         return ScrollViewReader { proxy in
             ScrollView {
@@ -175,6 +207,121 @@ struct AgentLauncherDialog: View {
         }
     }
 
+    private func sessionRowList(agent: AgentDefinition) -> some View {
+        let discovered = filteredDiscoveredSessions
+        let capabilities = discoveryModel?.capabilities
+        return ScrollView {
+            LazyVStack(alignment: .leading, spacing: 0) {
+                AgentSessionLauncherRow(
+                    title: "New chat",
+                    detail: "Start a new \(agent.displayName) session",
+                    systemImage: "plus",
+                    isSelected: selectedSessionIndex == 0,
+                    isEnabled: true,
+                    onTap: launchNewChat
+                )
+
+                sessionDiscoveryState(agent: agent, discovered: discovered, capabilities: capabilities)
+            }
+            .padding(.vertical, 4)
+        }
+        .frame(minHeight: 180, maxHeight: 320)
+    }
+
+    @ViewBuilder
+    private func sessionDiscoveryState(
+        agent: AgentDefinition,
+        discovered: [ACPDiscoveredSession],
+        capabilities: ACPSessionDiscoveryCapabilities?
+    ) -> some View {
+        switch discoveryModel?.phase ?? .idle {
+        case .idle, .loading:
+            launcherStatusRow("Loading agent sessions…", progress: true)
+        case .unsupported:
+            launcherStatusRow("This agent does not expose session history.")
+        case .failed(let message):
+            HStack(spacing: 8) {
+                Text(message).lineLimit(2)
+                Spacer()
+                Button("Retry") { startDiscovery(for: agent) }
+                    .buttonStyle(.plain)
+                    .foregroundStyle(theme.color("accent"))
+            }
+            .font(.system(size: 11))
+            .foregroundStyle(theme.color("fg-faint"))
+            .padding(.horizontal, 14)
+            .frame(minHeight: 38)
+        case .ready:
+            if discovered.isEmpty {
+                launcherStatusRow("No agent sessions for this worktree.")
+            } else {
+                ForEach(Array(discovered.enumerated()), id: \.element.id) { index, item in
+                    let canOpen = item.isAlreadyInAlas
+                        || (capabilities?.canOpenRemoteSession == true && item.isCompatibleWithAlas)
+                    AgentSessionLauncherRow(
+                        title: item.title,
+                        detail: sessionDetail(item, canOpen: canOpen),
+                        systemImage: item.isAlreadyInAlas ? "checkmark.circle" : "clock",
+                        isSelected: selectedSessionIndex == index + 1,
+                        isEnabled: canOpen,
+                        onTap: { openDiscoveredSession(item) }
+                    )
+                    .onHover { hovering in
+                        if hovering { selectedSessionIndex = index + 1 }
+                    }
+                }
+            }
+            if discoveryModel?.canLoadMore == true {
+                Button {
+                    loadMoreSessions()
+                } label: {
+                    HStack(spacing: 7) {
+                        if loadingMore { ProgressView().controlSize(.small) }
+                        Text(loadingMore ? "Loading…" : "Load more")
+                    }
+                    .font(.system(size: 11, weight: .medium))
+                    .foregroundStyle(theme.color("accent"))
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .padding(.horizontal, 14)
+                    .frame(height: 32)
+                }
+                .buttonStyle(.plain)
+                .disabled(loadingMore)
+            }
+            if let paginationError = discoveryModel?.paginationError {
+                launcherStatusRow(paginationError)
+            }
+        }
+    }
+
+    private func launcherStatusRow(_ text: String, progress: Bool = false) -> some View {
+        HStack(spacing: 8) {
+            if progress { ProgressView().controlSize(.small) }
+            Text(text)
+        }
+        .font(.system(size: 11))
+        .foregroundStyle(theme.color("fg-faint"))
+        .padding(.horizontal, 14)
+        .frame(minHeight: 38)
+    }
+
+    private var filteredDiscoveredSessions: [ACPDiscoveredSession] {
+        guard let sessions = discoveryModel?.sessions else { return [] }
+        let query = appState.agentLauncher.query.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !query.isEmpty else { return sessions }
+        return sessions.filter { $0.title.localizedCaseInsensitiveContains(query) }
+    }
+
+    private func sessionDetail(_ session: ACPDiscoveredSession, canOpen: Bool) -> String {
+        if session.isAlreadyInAlas { return "Already in Alas" }
+        if !session.isCompatibleWithAlas { return "Uses unsupported additional folders" }
+        if !canOpen { return "Browsing only" }
+        if let updatedAt = session.updatedAt {
+            return updatedAt.formatted(.relative(presentation: .named))
+        }
+        return "Agent history"
+    }
+
     private var emptyState: some View {
         VStack(spacing: 4) {
             Text(emptyTitle)
@@ -200,9 +347,9 @@ struct AgentLauncherDialog: View {
     private var footer: some View {
         HStack(spacing: 12) {
             label("↑↓ navigate")
-            label("↵ launch")
-            label("⇥ swap mode")
-            label("esc close")
+            label(chatAgent == nil ? "↵ select" : "↵ open")
+            if chatAgent == nil { label("⇥ swap mode") }
+            label(chatAgent == nil ? "esc close" : "esc back")
             Spacer()
         }
         .padding(.horizontal, 14)
@@ -221,6 +368,9 @@ struct AgentLauncherDialog: View {
     }
 
     private func handleKey(_ press: KeyPress) -> KeyPress.Result {
+        if chatAgent != nil {
+            return handleSessionKey(press)
+        }
         switch press.key {
         case .escape:
             close()
@@ -241,6 +391,32 @@ struct AgentLauncherDialog: View {
         }
     }
 
+    private func handleSessionKey(_ press: KeyPress) -> KeyPress.Result {
+        switch press.key {
+        case .escape, .leftArrow:
+            backToAgents()
+            return .handled
+        case .upArrow:
+            selectedSessionIndex = max(0, selectedSessionIndex - 1)
+            return .handled
+        case .downArrow:
+            selectedSessionIndex = min(filteredDiscoveredSessions.count, selectedSessionIndex + 1)
+            return .handled
+        case .return:
+            if selectedSessionIndex == 0 {
+                launchNewChat()
+            } else {
+                let index = selectedSessionIndex - 1
+                if filteredDiscoveredSessions.indices.contains(index) {
+                    openDiscoveredSession(filteredDiscoveredSessions[index])
+                }
+            }
+            return .handled
+        default:
+            return .ignored
+        }
+    }
+
     private func launch(_ agent: AgentDefinition) {
         switch appState.agentLauncher.mode {
         case .terminal:
@@ -248,12 +424,78 @@ struct AgentLauncherDialog: View {
             return }
             _ = try? appState.openAgentTerminalTab(for: worktree, agentId: agent.id)
         case .acp:
-            appState.openNewACPSession(agentID: agent.id)
+            beginSessionBrowser(for: agent)
+            return
         }
         close()
     }
 
+    private func beginSessionBrowser(for agent: AgentDefinition) {
+        guard let worktree = selectedWorktree(),
+              appState.acpManager(for: worktree) != nil
+        else {
+            appState.openNewACPSession(agentID: agent.id)
+            close()
+            return
+        }
+        chatAgent = agent
+        appState.agentLauncher.query = ""
+        selectedSessionIndex = 0
+        startDiscovery(for: agent)
+        requestInputFocus()
+    }
+
+    private func startDiscovery(for agent: AgentDefinition) {
+        guard let worktree = selectedWorktree(),
+              let manager = appState.acpManager(for: worktree)
+        else { return }
+        let prior = discoveryModel
+        let model = ACPSessionDiscoveryModel()
+        discoveryModel = model
+        Task {
+            await prior?.stop()
+            await model.start(manager: manager, agentId: agent.id)
+        }
+    }
+
+    private func loadMoreSessions() {
+        guard let discoveryModel, !loadingMore else { return }
+        loadingMore = true
+        Task {
+            defer { loadingMore = false }
+            try? await discoveryModel.loadMore()
+        }
+    }
+
+    private func launchNewChat() {
+        guard let chatAgent else { return }
+        appState.openNewACPSession(agentID: chatAgent.id)
+        close()
+    }
+
+    private func openDiscoveredSession(_ session: ACPDiscoveredSession) {
+        guard let capabilities = discoveryModel?.capabilities,
+              appState.openDiscoveredACPSession(session, capabilities: capabilities)
+        else { return }
+        close()
+    }
+
+    private func backToAgents() {
+        let prior = discoveryModel
+        discoveryModel = nil
+        chatAgent = nil
+        selectedSessionIndex = 0
+        appState.agentLauncher.query = ""
+        Task { await prior?.stop() }
+        requestInputFocus()
+    }
+
     private func close() {
+        let prior = discoveryModel
+        discoveryModel = nil
+        chatAgent = nil
+        selectedSessionIndex = 0
+        Task { await prior?.stop() }
         appState.agentLauncher.reset()
         appState.isAgentLauncherOpen = false
     }
@@ -266,6 +508,44 @@ struct AgentLauncherDialog: View {
                 inputFocused = true
             }
         }
+    }
+}
+
+private struct AgentSessionLauncherRow: View {
+    let title: String
+    let detail: String
+    let systemImage: String
+    let isSelected: Bool
+    let isEnabled: Bool
+    let onTap: () -> Void
+    @Environment(\.theme) private var theme
+
+    var body: some View {
+        Button(action: onTap) {
+            HStack(spacing: 10) {
+                Image(systemName: systemImage)
+                    .font(.system(size: 12))
+                    .foregroundStyle(isEnabled ? theme.color("fg-muted") : theme.color("fg-faint"))
+                    .frame(width: 16)
+                VStack(alignment: .leading, spacing: 2) {
+                    Text(title)
+                        .font(.system(size: 12.5, weight: .medium))
+                        .foregroundStyle(isEnabled ? theme.color("fg") : theme.color("fg-faint"))
+                        .lineLimit(1)
+                    Text(detail)
+                        .font(.system(size: 10.5))
+                        .foregroundStyle(theme.color("fg-faint"))
+                        .lineLimit(1)
+                }
+                Spacer(minLength: 0)
+            }
+            .padding(.horizontal, 12)
+            .frame(height: 44)
+            .background(isSelected ? theme.color("bg-3") : .clear)
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+        .disabled(!isEnabled)
     }
 }
 

--- a/Alas/Sources/Agents/AgentLauncherDialog.swift
+++ b/Alas/Sources/Agents/AgentLauncherDialog.swift
@@ -11,44 +11,50 @@ struct AgentLauncherDialog: View {
     @State private var loadingMore = false
 
     var body: some View {
-        if appState.isAgentLauncherOpen {
-            ZStack {
-                Color.black.opacity(0.42)
-                    .ignoresSafeArea()
-                    .onTapGesture { close() }
+        Group {
+            if appState.isAgentLauncherOpen {
+                ZStack {
+                    Color.black.opacity(0.42)
+                        .ignoresSafeArea()
+                        .onTapGesture { close() }
 
-                VStack(spacing: 0) {
-                    inputRow
-                    if chatAgent == nil {
-                        modePicker
+                    VStack(spacing: 0) {
+                        inputRow
+                        if chatAgent == nil {
+                            modePicker
+                        }
+                        Divider().background(theme.color("line"))
+                        rowList
+                        footer
                     }
-                    Divider().background(theme.color("line"))
-                    rowList
-                    footer
+                    .frame(width: 460)
+                    .frame(maxHeight: 420)
+                    .background(theme.color("bg-1").opacity(0.92))
+                    .clipShape(RoundedRectangle(cornerRadius: 12, style: .continuous))
+                    .overlay(
+                        RoundedRectangle(cornerRadius: 12, style: .continuous)
+                            .strokeBorder(theme.color("line"), lineWidth: 0.5)
+                    )
+                    .shadow(color: .black.opacity(0.5), radius: 30, x: 0, y: 20)
+                    .padding(.top, 70)
+                    .frame(maxHeight: .infinity, alignment: .top)
+                    .onTapGesture { }
+                    .onKeyPress { press in handleKey(press) }
                 }
-                .frame(width: 460)
-                .frame(maxHeight: 420)
-                .background(theme.color("bg-1").opacity(0.92))
-                .clipShape(RoundedRectangle(cornerRadius: 12, style: .continuous))
-                .overlay(
-                    RoundedRectangle(cornerRadius: 12, style: .continuous)
-                        .strokeBorder(theme.color("line"), lineWidth: 0.5)
-                )
-                .shadow(color: .black.opacity(0.5), radius: 30, x: 0, y: 20)
-                .padding(.top, 70)
-                .frame(maxHeight: .infinity, alignment: .top)
-                .onTapGesture { }
-                .onKeyPress { press in handleKey(press) }
+                .transition(.opacity.combined(with: .offset(y: -6)))
+                .onAppear {
+                    requestInputFocus()
+                }
+                .onChange(of: appState.agentLauncher.query) {
+                    selectedSessionIndex = 0
+                }
             }
-            .transition(.opacity.combined(with: .offset(y: -6)))
-            .onAppear {
+        }
+        .onChange(of: appState.isAgentLauncherOpen) { _, isOpen in
+            if isOpen {
                 requestInputFocus()
-            }
-            .onChange(of: appState.isAgentLauncherOpen) { _, isOpen in
-                if isOpen { requestInputFocus() }
-            }
-            .onChange(of: appState.agentLauncher.query) {
-                selectedSessionIndex = 0
+            } else {
+                resetSessionBrowser()
             }
         }
     }
@@ -481,23 +487,24 @@ struct AgentLauncherDialog: View {
     }
 
     private func backToAgents() {
-        let prior = discoveryModel
-        discoveryModel = nil
-        chatAgent = nil
-        selectedSessionIndex = 0
+        resetSessionBrowser()
         appState.agentLauncher.query = ""
-        Task { await prior?.stop() }
         requestInputFocus()
     }
 
     private func close() {
+        resetSessionBrowser()
+        appState.agentLauncher.reset()
+        appState.isAgentLauncherOpen = false
+    }
+
+    private func resetSessionBrowser() {
         let prior = discoveryModel
         discoveryModel = nil
         chatAgent = nil
         selectedSessionIndex = 0
+        loadingMore = false
         Task { await prior?.stop() }
-        appState.agentLauncher.reset()
-        appState.isAgentLauncherOpen = false
     }
 
     private func requestInputFocus() {

--- a/Alas/Sources/App/AppState.swift
+++ b/Alas/Sources/App/AppState.swift
@@ -3632,11 +3632,11 @@ final class AppState {
         _ discovered: ACPDiscoveredSession,
         capabilities: ACPSessionDiscoveryCapabilities
     ) -> Bool {
-        guard let worktreeId = selectedWorktreeId,
-              let worktree = worktree(withId: worktreeId),
-              let manager = acpManager(for: worktree)
+        guard let resolved = projectAndWorktree(withWorktreeId: discovered.worktreeId),
+              let manager = acpManager(for: resolved.worktree)
         else { return false }
 
+        focusGlobalWorktree(id: resolved.worktree.id, projectId: resolved.project.id)
         if let localSessionId = discovered.localSessionId {
             openExistingACPSession(sessionId: localSessionId)
             return true

--- a/Alas/Sources/App/AppState.swift
+++ b/Alas/Sources/App/AppState.swift
@@ -3627,6 +3627,31 @@ final class AppState {
         tabs.append(acpSession: state, to: worktree.id)
     }
 
+    @discardableResult
+    func openDiscoveredACPSession(
+        _ discovered: ACPDiscoveredSession,
+        capabilities: ACPSessionDiscoveryCapabilities
+    ) -> Bool {
+        guard let worktreeId = selectedWorktreeId,
+              let worktree = worktree(withId: worktreeId),
+              let manager = acpManager(for: worktree)
+        else { return false }
+
+        if let localSessionId = discovered.localSessionId {
+            openExistingACPSession(sessionId: localSessionId)
+            return true
+        }
+        guard capabilities.canOpenRemoteSession,
+              let row = manager.materializeDiscoveredSession(
+                discovered,
+                autoRunDefault: config.harness.acpAutoRunByDefault
+              )
+        else { return false }
+
+        openExistingACPSession(sessionId: row.id)
+        return true
+    }
+
     /// Open a diff tab for the given worktree-relative path and comparison mode.
     /// Reuses an existing matching diff tab for the same path if one is already open.
     func openDiffTab(

--- a/AlasTests/ACP/ACPSessionLeaseTests.swift
+++ b/AlasTests/ACP/ACPSessionLeaseTests.swift
@@ -9,10 +9,10 @@ import Foundation
         return try ACPSessionStore(path: url.path)
     }
 
-    @Test("schema reaches version 7")
-    func schemaV7() throws {
+    @Test("schema includes leases and session origins")
+    func schemaIncludesLeasesAndOrigins() throws {
         let store = try tempStore()
-        #expect(try store.currentSchemaVersion() == 7)
+        #expect(try store.currentSchemaVersion() == 8)
     }
 
     @Test("session_leases table exists and is empty")

--- a/AlasTests/ACP/ACPSessionStoreDedupTests.swift
+++ b/AlasTests/ACP/ACPSessionStoreDedupTests.swift
@@ -35,6 +35,6 @@ import Foundation
             .appendingPathComponent("recover-clean-\(UUID()).sqlite")
         _ = try ACPSessionStore(path: url.path)
         let store = try ACPSessionStore(path: url.path)   // second open, no crash
-        #expect(try store.currentSchemaVersion() == 7)
+        #expect(try store.currentSchemaVersion() == ACPSessionStore.targetSchemaVersion)
     }
 }

--- a/AlasTests/ACP/Protocol/ACPConnectionTests.swift
+++ b/AlasTests/ACP/Protocol/ACPConnectionTests.swift
@@ -84,6 +84,48 @@ struct ACPConnectionTests {
         #expect(params.mcpServers.isEmpty)
     }
 
+    @Test("resumeSession sends session/resume and preserves the requested id for an empty result")
+    func resumeSessionRPC() async throws {
+        let mock = ACPMockClient()
+        mock.script(method: "session/resume") { _ in Data("{}".utf8) }
+
+        let conn = ACPConnection(client: mock)
+        let result = try await conn.resumeSession(cwd: "/tmp/wt", sessionId: "remote-old")
+
+        #expect(result.sessionId == "remote-old")
+        let req = try #require(mock.sent.last)
+        #expect(req.method == "session/resume")
+        let params = try #require(req.params as? ACPSessionResumeParams)
+        #expect(params.cwd == "/tmp/wt")
+        #expect(params.sessionId == "remote-old")
+    }
+
+    @Test("listSessions sends cwd and opaque cursor and decodes a page")
+    func listSessionsRPC() async throws {
+        let mock = ACPMockClient()
+        mock.script(method: "session/list") { _ in
+            try JSONEncoder().encode(ACPSessionListResult(
+                sessions: [.init(
+                    sessionId: "remote-1",
+                    cwd: "/tmp/wt",
+                    title: "Fix tests",
+                    updatedAt: "2026-07-10T10:00:00Z"
+                )],
+                nextCursor: "page-2"
+            ))
+        }
+
+        let conn = ACPConnection(client: mock)
+        let result = try await conn.listSessions(cwd: "/tmp/wt", cursor: "page-1")
+
+        #expect(result.sessions.map(\.sessionId) == ["remote-1"])
+        #expect(result.nextCursor == "page-2")
+        let req = try #require(mock.sent.last)
+        let params = try #require(req.params as? ACPSessionListParams)
+        #expect(params.cwd == "/tmp/wt")
+        #expect(params.cursor == "page-1")
+    }
+
     @Test("authenticate sends method id")
     func authenticateRPC() async throws {
         let mock = ACPMockClient()

--- a/AlasTests/ACP/Protocol/ACPInitializeTests.swift
+++ b/AlasTests/ACP/Protocol/ACPInitializeTests.swift
@@ -146,6 +146,32 @@ struct ACPInitializeTests {
         #expect(result.agentCapabilities?.promptCapabilities?.embeddedContext == true)
     }
 
+    @Test("decodes agent session lifecycle capabilities with conservative defaults")
+    func decodeSessionLifecycleCapabilities() throws {
+        let supported = try JSONDecoder().decode(ACPInitializeResult.self, from: Data("""
+        {
+          "protocolVersion": 1,
+          "agentCapabilities": {
+            "loadSession": true,
+            "sessionCapabilities": { "list": {}, "resume": {}, "fork": {} }
+          }
+        }
+        """.utf8))
+
+        #expect(supported.agentCapabilities?.loadSession == true)
+        #expect(supported.agentCapabilities?.sessionCapabilities.supportsList == true)
+        #expect(supported.agentCapabilities?.sessionCapabilities.supportsResume == true)
+        #expect(supported.agentCapabilities?.sessionCapabilities.supportsFork == true)
+
+        let omitted = try JSONDecoder().decode(ACPInitializeResult.self, from: Data("""
+        { "protocolVersion": 1, "agentCapabilities": {} }
+        """.utf8))
+        #expect(omitted.agentCapabilities?.loadSession == false)
+        #expect(omitted.agentCapabilities?.sessionCapabilities.supportsList == false)
+        #expect(omitted.agentCapabilities?.sessionCapabilities.supportsResume == false)
+        #expect(omitted.agentCapabilities?.sessionCapabilities.supportsFork == false)
+    }
+
     @Test("decodes terminal auth method metadata")
     func decodesTerminalAuthMethod() throws {
         let data = Data("""

--- a/AlasTests/ACP/Session/ACPSessionDiscoveryTests.swift
+++ b/AlasTests/ACP/Session/ACPSessionDiscoveryTests.swift
@@ -16,6 +16,12 @@ struct ACPSessionDiscoveryTests {
             origin: .agentImported, canLoad: true, canResume: true
         ) == .loadStrict)
         #expect(ACPSessionRestorePolicy.operation(
+            origin: .agentImported,
+            canLoad: true,
+            canResume: true,
+            hasLocalTranscript: true
+        ) == .resume)
+        #expect(ACPSessionRestorePolicy.operation(
             origin: .agentForked, canLoad: false, canResume: true
         ) == .resume)
         #expect(ACPSessionRestorePolicy.operation(

--- a/AlasTests/ACP/Session/ACPSessionDiscoveryTests.swift
+++ b/AlasTests/ACP/Session/ACPSessionDiscoveryTests.swift
@@ -71,6 +71,7 @@ struct ACPSessionDiscoveryTests {
         await model.start(manager: manager, agentId: "claude")
         #expect(model.phase == .ready)
         #expect(model.sessions.map(\.remoteSessionId) == ["remote-1"])
+        #expect(model.sessions.first?.worktreeId == "wt")
         #expect(model.sessions.first?.title == "Local title")
         #expect(model.sessions.first?.localSessionId == "local-1")
         #expect(model.canLoadMore)
@@ -113,6 +114,7 @@ struct ACPSessionDiscoveryTests {
         let store = try temporaryStore()
         let manager = manager(store: store, client: ACPMockClient())
         let discovered = ACPDiscoveredSession(
+            worktreeId: "wt",
             agentId: "claude",
             remoteSessionId: "remote-extra-roots",
             cwd: "/tmp/wt",
@@ -124,6 +126,26 @@ struct ACPSessionDiscoveryTests {
 
         #expect(manager.materializeDiscoveredSession(discovered) == nil)
         #expect(try store.loadSession(agentId: "claude", remoteSessionId: "remote-extra-roots") == nil)
+    }
+
+    @MainActor
+    @Test("materialization rejects discovery from another worktree")
+    func materializationRejectsAnotherWorktree() throws {
+        let store = try temporaryStore()
+        let manager = manager(store: store, client: ACPMockClient())
+        let discovered = ACPDiscoveredSession(
+            worktreeId: "other-worktree",
+            agentId: "claude",
+            remoteSessionId: "remote-other-worktree",
+            cwd: "/tmp/wt",
+            title: "Wrong scope",
+            updatedAt: nil,
+            additionalDirectories: [],
+            localSessionId: nil
+        )
+
+        #expect(manager.materializeDiscoveredSession(discovered) == nil)
+        #expect(try store.loadSession(agentId: "claude", remoteSessionId: "remote-other-worktree") == nil)
     }
 
     private func temporaryStore() throws -> ACPSessionStore {

--- a/AlasTests/ACP/Session/ACPSessionDiscoveryTests.swift
+++ b/AlasTests/ACP/Session/ACPSessionDiscoveryTests.swift
@@ -1,0 +1,163 @@
+import Foundation
+import Testing
+@testable import Alas
+
+@Suite("ACP session discovery")
+struct ACPSessionDiscoveryTests {
+    @Test("restore policy prefers resume locally and strict load for imported sessions")
+    func restorePolicy() {
+        #expect(ACPSessionRestorePolicy.operation(
+            origin: .alasCreated, canLoad: true, canResume: true
+        ) == .resume)
+        #expect(ACPSessionRestorePolicy.operation(
+            origin: .alasCreated, canLoad: false, canResume: false
+        ) == .loadWithRecovery)
+        #expect(ACPSessionRestorePolicy.operation(
+            origin: .agentImported, canLoad: true, canResume: true
+        ) == .loadStrict)
+        #expect(ACPSessionRestorePolicy.operation(
+            origin: .agentForked, canLoad: false, canResume: true
+        ) == .resume)
+        #expect(ACPSessionRestorePolicy.operation(
+            origin: .agentImported, canLoad: false, canResume: false
+        ) == .unavailable)
+    }
+
+    @MainActor
+    @Test("discovery filters by cwd, deduplicates local rows, and paginates on one connection")
+    func discoveryMergeAndPagination() async throws {
+        let store = try temporaryStore()
+        try store.upsertSession(row(
+            id: "local-1",
+            remoteSessionId: "remote-1",
+            title: "Local title",
+            origin: .alasCreated
+        ))
+        let client = ACPMockClient()
+        client.script(method: "initialize") { _ in
+            try JSONEncoder().encode(ACPInitializeResult(
+                protocolVersion: 1,
+                agentCapabilities: .init(
+                    loadSession: true,
+                    sessionCapabilities: .init(list: .init(), resume: .init())
+                ),
+                authMethods: []
+            ))
+        }
+        client.script(method: "session/list") { request in
+            let params = try #require(request.params as? ACPSessionListParams)
+            if params.cursor == nil {
+                return try JSONEncoder().encode(ACPSessionListResult(
+                    sessions: [
+                        .init(sessionId: "remote-1", cwd: "/tmp/wt", title: "Remote title"),
+                        .init(sessionId: "wrong-cwd", cwd: "/tmp/other", title: "Other")
+                    ],
+                    nextCursor: "next"
+                ))
+            }
+            return try JSONEncoder().encode(ACPSessionListResult(
+                sessions: [.init(sessionId: "remote-2", cwd: "/tmp/wt", title: "Second")]
+            ))
+        }
+        let manager = manager(store: store, client: client)
+        let model = ACPSessionDiscoveryModel()
+
+        await model.start(manager: manager, agentId: "claude")
+        #expect(model.phase == .ready)
+        #expect(model.sessions.map(\.remoteSessionId) == ["remote-1"])
+        #expect(model.sessions.first?.title == "Local title")
+        #expect(model.sessions.first?.localSessionId == "local-1")
+        #expect(model.canLoadMore)
+
+        try await model.loadMore()
+        #expect(model.sessions.map(\.remoteSessionId) == ["remote-1", "remote-2"])
+        #expect(!model.canLoadMore)
+        #expect(client.shutdownCount == 0)
+        await model.stop()
+        #expect(client.shutdownCount == 1)
+    }
+
+    @Test("store scopes remote identity by agent and preserves origin")
+    func storeRemoteIdentityAndOrigin() throws {
+        let store = try temporaryStore()
+        try store.upsertSession(row(
+            id: "claude-local",
+            remoteSessionId: "shared-id",
+            title: "Claude",
+            origin: .agentImported,
+            agentId: "claude"
+        ))
+        try store.upsertSession(row(
+            id: "codex-local",
+            remoteSessionId: "shared-id",
+            title: "Codex",
+            origin: .agentForked,
+            agentId: "codex"
+        ))
+
+        #expect(try store.loadSession(agentId: "claude", remoteSessionId: "shared-id")?.id == "claude-local")
+        #expect(try store.loadSession(agentId: "codex", remoteSessionId: "shared-id")?.id == "codex-local")
+        #expect(try store.loadSession(id: "claude-local")?.origin == .agentImported)
+        #expect(try store.loadSession(id: "codex-local")?.origin == .agentForked)
+    }
+
+    @MainActor
+    @Test("materialization rejects sessions whose additional roots Alas cannot enforce")
+    func materializationRejectsAdditionalDirectories() throws {
+        let store = try temporaryStore()
+        let manager = manager(store: store, client: ACPMockClient())
+        let discovered = ACPDiscoveredSession(
+            agentId: "claude",
+            remoteSessionId: "remote-extra-roots",
+            cwd: "/tmp/wt",
+            title: "Shared roots",
+            updatedAt: nil,
+            additionalDirectories: ["/tmp/shared"],
+            localSessionId: nil
+        )
+
+        #expect(manager.materializeDiscoveredSession(discovered) == nil)
+        #expect(try store.loadSession(agentId: "claude", remoteSessionId: "remote-extra-roots") == nil)
+    }
+
+    private func temporaryStore() throws -> ACPSessionStore {
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("acp-discovery-\(UUID().uuidString).sqlite")
+        return try ACPSessionStore(path: url.path)
+    }
+
+    @MainActor
+    private func manager(store: ACPSessionStore, client: ACPMockClient) -> ACPSessionManager {
+        ACPSessionManager(
+            worktreeId: "wt",
+            worktreePath: "/tmp/wt",
+            store: store,
+            setupEvaluator: { _ in .ready },
+            connectionFactory: { _ in ACPConnection(client: client) }
+        )
+    }
+
+    private func row(
+        id: String,
+        remoteSessionId: String,
+        title: String,
+        origin: ACPSessionOrigin,
+        agentId: String = "claude"
+    ) -> ACPSessionRow {
+        .init(
+            id: id,
+            agentId: agentId,
+            title: title,
+            titleSource: .manual,
+            remoteSessionId: remoteSessionId,
+            origin: origin,
+            currentModel: nil,
+            currentMode: nil,
+            autoRun: false,
+            createdAt: 1,
+            updatedAt: 1,
+            lastOpenedAt: 1,
+            archived: false
+        )
+    }
+}

--- a/AlasTests/ACP/Session/ACPSessionManagerRemoteRestoreTests.swift
+++ b/AlasTests/ACP/Session/ACPSessionManagerRemoteRestoreTests.swift
@@ -1,0 +1,144 @@
+import Foundation
+import Testing
+@testable import Alas
+
+@MainActor
+@Suite("ACPSessionManager remote restore")
+struct ACPSessionManagerRemoteRestoreTests {
+    @Test("Alas-owned sessions use resume when advertised")
+    func localSessionUsesResume() async throws {
+        let (manager, store, client, session) = try fixture(origin: .alasCreated)
+        scriptInitialize(client, canLoad: true, canResume: true)
+        client.script(method: "session/resume") { _ in Data("{}".utf8) }
+
+        await manager.attach(to: session.id, freshlyCreated: false)
+
+        #expect(client.sent.map(\.method).contains("session/resume"))
+        #expect(!client.sent.map(\.method).contains("session/load"))
+        #expect(!client.sent.map(\.method).contains("session/new"))
+        #expect(session.agentState == .ready)
+        #expect(try store.loadSession(id: session.id)?.remoteSessionId == "remote-id")
+        await manager.detach(sessionId: session.id)
+    }
+
+    @Test("imported sessions prefer strict load so history can replay")
+    func importedSessionUsesLoad() async throws {
+        let (manager, store, client, session) = try fixture(origin: .agentImported)
+        scriptInitialize(client, canLoad: true, canResume: true)
+        scriptSessionResult(client, method: "session/load", sessionId: "remote-id")
+
+        await manager.attach(to: session.id, freshlyCreated: false)
+
+        #expect(client.sent.map(\.method).contains("session/load"))
+        #expect(!client.sent.map(\.method).contains("session/resume"))
+        #expect(session.agentState == .ready)
+        await manager.detach(sessionId: session.id)
+        #expect(try store.loadSession(id: session.id)?.origin == .agentImported)
+    }
+
+    @Test("resume-only imports stay connected and disclose unavailable local history")
+    func importedSessionUsesResumeWithDisclosure() async throws {
+        let (manager, _, client, session) = try fixture(origin: .agentImported)
+        scriptInitialize(client, canLoad: false, canResume: true)
+        client.script(method: "session/resume") { _ in Data("{}".utf8) }
+
+        await manager.attach(to: session.id, freshlyCreated: false)
+
+        #expect(session.agentState == .ready)
+        #expect(session.contextRestoreWarning?.canSendTranscript == false)
+        #expect(session.contextRestoreWarning?.message.contains("remain in the agent") == true)
+        await manager.detach(sessionId: session.id)
+    }
+
+    @Test("failed imports never fall back to a new unrelated session")
+    func failedImportDoesNotCreateSession() async throws {
+        let (manager, _, client, session) = try fixture(origin: .agentImported)
+        scriptInitialize(client, canLoad: true, canResume: false)
+
+        await manager.attach(to: session.id, freshlyCreated: false)
+
+        #expect(client.sent.map(\.method).contains("session/load"))
+        #expect(!client.sent.map(\.method).contains("session/new"))
+        if case .failed = session.agentState {
+            // Expected.
+        } else {
+            Issue.record("Imported session should remain failed when its remote load fails")
+        }
+        #expect(session.remoteSessionId == "remote-id")
+    }
+
+    @Test("imports without load or resume fail without issuing a lifecycle request")
+    func unsupportedImportDoesNotCreateSession() async throws {
+        let (manager, _, client, session) = try fixture(origin: .agentImported)
+        scriptInitialize(client, canLoad: false, canResume: false)
+
+        await manager.attach(to: session.id, freshlyCreated: false)
+
+        #expect(client.sent.map(\.method) == ["initialize"])
+        #expect(!client.sent.map(\.method).contains("session/new"))
+        if case .failed = session.agentState {
+            // Expected.
+        } else {
+            Issue.record("Unsupported imported session should surface a failed state")
+        }
+    }
+
+    private func fixture(
+        origin: ACPSessionOrigin
+    ) throws -> (ACPSessionManager, ACPSessionStore, ACPMockClient, ACPSession) {
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("acp-remote-restore-\(UUID().uuidString).sqlite")
+        let store = try ACPSessionStore(path: url.path)
+        try store.upsertSession(.init(
+            id: "local-id",
+            agentId: "claude",
+            title: "Session",
+            titleSource: .generated,
+            remoteSessionId: "remote-id",
+            origin: origin,
+            currentModel: nil,
+            currentMode: nil,
+            autoRun: false,
+            createdAt: 1,
+            updatedAt: 1,
+            lastOpenedAt: 1,
+            archived: false
+        ))
+        let client = ACPMockClient()
+        let manager = ACPSessionManager(
+            worktreeId: "wt",
+            worktreePath: "/tmp/wt",
+            store: store,
+            setupEvaluator: { _ in .ready },
+            connectionFactory: { _ in ACPConnection(client: client) }
+        )
+        let session = try #require(manager.placeholderSession(id: "local-id"))
+        return (manager, store, client, session)
+    }
+
+    private func scriptInitialize(_ client: ACPMockClient, canLoad: Bool, canResume: Bool) {
+        client.script(method: "initialize") { _ in
+            try JSONEncoder().encode(ACPInitializeResult(
+                protocolVersion: 1,
+                agentCapabilities: .init(
+                    loadSession: canLoad,
+                    sessionCapabilities: .init(resume: canResume ? .init() : nil)
+                ),
+                authMethods: []
+            ))
+        }
+    }
+
+    private func scriptSessionResult(_ client: ACPMockClient, method: String, sessionId: String) {
+        client.script(method: method) { _ in
+            try JSONEncoder().encode(ACPSessionNewResult(
+                sessionId: sessionId,
+                availableModels: [],
+                availableModes: [],
+                currentModel: nil,
+                currentMode: nil,
+                promptSuggestions: []
+            ))
+        }
+    }
+}

--- a/AlasTests/ACP/Session/ACPSessionManagerRemoteRestoreTests.swift
+++ b/AlasTests/ACP/Session/ACPSessionManagerRemoteRestoreTests.swift
@@ -22,6 +22,34 @@ struct ACPSessionManagerRemoteRestoreTests {
         await manager.detach(sessionId: session.id)
     }
 
+    @Test("Alas-owned sessions recover locally when resume fails")
+    func localSessionResumeFailureRecoversWithNewSession() async throws {
+        let (manager, store, client, session) = try fixture(
+            origin: .alasCreated,
+            localMessage: .user(id: UUID(), text: "persisted context", attachments: [])
+        )
+        scriptInitialize(client, canLoad: true, canResume: true)
+        client.script(method: "session/resume") { _ in
+            throw JSONRPCError(code: -32000, message: "session expired", data: nil)
+        }
+        scriptSessionResult(client, method: "session/new", sessionId: "remote-new")
+        client.script(method: "session/prompt") { _ in Data("null".utf8) }
+
+        await manager.hydrateIfNeeded(id: session.id)
+        await manager.attach(to: session.id, freshlyCreated: false)
+        try await waitUntil {
+            client.sent.map(\.method).contains("session/prompt")
+                && session.contextRecoveryStatus == .restored
+        }
+
+        #expect(client.sent.map(\.method) == ["initialize", "session/resume", "session/new", "session/prompt"])
+        #expect(session.agentState == .ready)
+        #expect(session.remoteSessionId == "remote-new")
+        #expect(try store.loadSession(id: session.id)?.remoteSessionId == "remote-new")
+        #expect(try store.loadSession(id: session.id)?.contextRecoveryPending == false)
+        await manager.detach(sessionId: session.id)
+    }
+
     @Test("imported sessions prefer strict load so history can replay")
     func importedSessionUsesLoad() async throws {
         let (manager, store, client, session) = try fixture(origin: .agentImported)
@@ -201,6 +229,20 @@ struct ACPSessionManagerRemoteRestoreTests {
                 currentMode: nil,
                 promptSuggestions: []
             ))
+        }
+    }
+
+    private func waitUntil(
+        timeoutNanos: UInt64 = 500_000_000,
+        condition: @escaping @MainActor () -> Bool
+    ) async throws {
+        let start = DispatchTime.now().uptimeNanoseconds
+        while !condition() {
+            if DispatchTime.now().uptimeNanoseconds - start >= timeoutNanos {
+                Issue.record("Timed out waiting for condition")
+                return
+            }
+            try await Task.sleep(nanoseconds: 5_000_000)
         }
     }
 }

--- a/AlasTests/ACP/Session/ACPSessionManagerRemoteRestoreTests.swift
+++ b/AlasTests/ACP/Session/ACPSessionManagerRemoteRestoreTests.swift
@@ -11,6 +11,7 @@ struct ACPSessionManagerRemoteRestoreTests {
         scriptInitialize(client, canLoad: true, canResume: true)
         client.script(method: "session/resume") { _ in Data("{}".utf8) }
 
+        await manager.hydrateIfNeeded(id: session.id)
         await manager.attach(to: session.id, freshlyCreated: false)
 
         #expect(client.sent.map(\.method).contains("session/resume"))
@@ -34,6 +35,56 @@ struct ACPSessionManagerRemoteRestoreTests {
         #expect(session.agentState == .ready)
         await manager.detach(sessionId: session.id)
         #expect(try store.loadSession(id: session.id)?.origin == .agentImported)
+    }
+
+    @Test("imported sessions resume after their history has been persisted locally")
+    func importedSessionWithLocalHistoryUsesResume() async throws {
+        let (manager, store, client, session) = try fixture(
+            origin: .agentImported,
+            localMessage: .agent(id: UUID(), StreamingText("persisted history"))
+        )
+        scriptInitialize(client, canLoad: true, canResume: true)
+        client.script(method: "session/resume") { _ in Data("{}".utf8) }
+
+        await manager.hydrateIfNeeded(id: session.id)
+        await manager.attach(to: session.id, freshlyCreated: false)
+
+        #expect(client.sent.map(\.method).contains("session/resume"))
+        #expect(!client.sent.map(\.method).contains("session/load"))
+        #expect(try store.messageCount(sessionId: session.id) == 1)
+        await manager.detach(sessionId: session.id)
+    }
+
+    @Test("load-only imports suppress replay after history has been persisted locally")
+    func loadOnlyImportSuppressesPersistedHistoryReplay() async throws {
+        let (manager, store, client, session) = try fixture(
+            origin: .agentImported,
+            localMessage: .agent(id: UUID(), StreamingText("persisted history"))
+        )
+        scriptInitialize(client, canLoad: true, canResume: false)
+        client.scriptAsync(method: "session/load") { _ in
+            client.emit(.init(
+                sessionId: "remote-id",
+                update: .agentMessageChunk(.text("persisted history"))
+            ))
+            return try JSONEncoder().encode(ACPSessionNewResult(
+                sessionId: "remote-id",
+                availableModels: [],
+                availableModes: [],
+                currentModel: nil,
+                currentMode: nil,
+                promptSuggestions: []
+            ))
+        }
+
+        await manager.hydrateIfNeeded(id: session.id)
+        await manager.attach(to: session.id, freshlyCreated: false)
+        try await Task.sleep(nanoseconds: 100_000_000)
+
+        #expect(client.sent.map(\.method).contains("session/load"))
+        #expect(try store.messageCount(sessionId: session.id) == 1)
+        #expect(session.transcript.messages.count == 1)
+        await manager.detach(sessionId: session.id)
     }
 
     @Test("resume-only imports stay connected and disclose unavailable local history")
@@ -84,7 +135,8 @@ struct ACPSessionManagerRemoteRestoreTests {
     }
 
     private func fixture(
-        origin: ACPSessionOrigin
+        origin: ACPSessionOrigin,
+        localMessage: ACPMessage? = nil
     ) throws -> (ACPSessionManager, ACPSessionStore, ACPMockClient, ACPSession) {
         let url = FileManager.default.temporaryDirectory
             .appendingPathComponent("acp-remote-restore-\(UUID().uuidString).sqlite")
@@ -104,6 +156,16 @@ struct ACPSessionManagerRemoteRestoreTests {
             lastOpenedAt: 1,
             archived: false
         ))
+        if let localMessage {
+            try store.appendMessage(
+                sessionId: "local-id",
+                id: "message-0",
+                kind: localMessage.kind,
+                seq: 0,
+                payload: ACPMessageCodec.encode(localMessage),
+                createdAt: 1
+            )
+        }
         let client = ACPMockClient()
         let manager = ACPSessionManager(
             worktreeId: "wt",


### PR DESCRIPTION
## Summary
- expose ACP session list, resume, and fork protocol capabilities
- add an agent-scoped session browser with search and pagination to the launcher
- persist imported session identity and restore it without falling back to an unrelated new session
- filter discoveries to the selected worktree and reject unsupported additional-directory sessions

## Testing
- focused ACP protocol, discovery, persistence, and remote restore suites
- `xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS,arch=arm64' -quiet build`

Closes #659