### PR TITLE
fix(acp): filter model picker by visible names

### DIFF
--- a/Alas/Sources/ACP/UI/ACPComposerShell.swift
+++ b/Alas/Sources/ACP/UI/ACPComposerShell.swift
@@ -555,7 +555,8 @@ struct ACPComposer: View {
                     ?? "Model",
              placeholder: "Model",
              accent: theme.color("syntax-keyword"),
-             searchDescriptions: false)
+             searchDescriptions: false,
+             searchIdentifiers: false)
     }
 
     @ViewBuilder
@@ -623,7 +624,8 @@ struct ACPComposer: View {
                       label: String,
                       placeholder: String,
                       accent: Color,
-                      searchDescriptions: Bool = true) -> some View {
+                      searchDescriptions: Bool = true,
+                      searchIdentifiers: Bool = true) -> some View {
         ACPSelectChip(
             label: label,
             placeholder: placeholder,
@@ -633,6 +635,7 @@ struct ACPComposer: View {
             },
             selectedId: spec.currentId,
             searchDescriptions: searchDescriptions,
+            searchIdentifiers: searchIdentifiers,
             onSelect: { item in apply(spec: spec, selectedId: item.id) }
         )
     }

--- a/Alas/Sources/ACP/UI/ACPSelectChip.swift
+++ b/Alas/Sources/ACP/UI/ACPSelectChip.swift
@@ -18,6 +18,7 @@ struct ACPSelectChip: View {
     let items: [Item]
     let selectedId: String?
     let searchDescriptions: Bool
+    let searchIdentifiers: Bool
     let onSelect: (Item) -> Void
 
     @Environment(\.theme) private var theme
@@ -59,6 +60,7 @@ struct ACPSelectChip: View {
                 selectedId: selectedId,
                 accent: accent,
                 searchDescriptions: searchDescriptions,
+                searchIdentifiers: searchIdentifiers,
                 onSelect: { item in
                     onSelect(item)
                     showPopover = false
@@ -69,14 +71,19 @@ struct ACPSelectChip: View {
     }
 
     /// Case-insensitive substring filter used by the dropdown. Model pickers
-    /// disable description matching so numeric snippets in descriptions do
-    /// not pollute model results.
-    static func filteredItems(_ items: [Item], query: String, searchDescriptions: Bool = true) -> [Item] {
+    /// disable hidden metadata matching so invisible ids/descriptions do not
+    /// keep display-name misses in the result list.
+    static func filteredItems(
+        _ items: [Item],
+        query: String,
+        searchDescriptions: Bool = true,
+        searchIdentifiers: Bool = true
+    ) -> [Item] {
         let q = query.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
         if q.isEmpty { return items }
         return items.filter {
             $0.name.lowercased().contains(q)
-                || $0.id.lowercased().contains(q)
+                || (searchIdentifiers && $0.id.lowercased().contains(q))
                 || (searchDescriptions && ($0.description?.lowercased().contains(q) ?? false))
         }
     }
@@ -163,6 +170,7 @@ private struct DropdownPanel: View {
     let selectedId: String?
     let accent: Color
     let searchDescriptions: Bool
+    let searchIdentifiers: Bool
     let onSelect: (ACPSelectChip.Item) -> Void
 
     @Environment(\.theme) private var theme
@@ -179,7 +187,12 @@ private struct DropdownPanel: View {
     private var showSearch: Bool { items.count > 5 }
 
     private var filtered: [ACPSelectChip.Item] {
-        ACPSelectChip.filteredItems(items, query: query, searchDescriptions: searchDescriptions)
+        ACPSelectChip.filteredItems(
+            items,
+            query: query,
+            searchDescriptions: searchDescriptions,
+            searchIdentifiers: searchIdentifiers
+        )
     }
 
     var body: some View {

--- a/AlasTests/ACP/UI/ACPSelectChipTests.swift
+++ b/AlasTests/ACP/UI/ACPSelectChipTests.swift
@@ -165,6 +165,26 @@ struct ACPSelectChipTests {
         #expect(ACPSelectChip.filteredItems(items, query: "kimi-2.7").map(\.id) == ["kimi-2.7"])
     }
 
+    @Test("can exclude hidden identifiers for model filtering")
+    func filteringCanIgnoreHiddenIdentifiers() {
+        let items = [
+            ACPSelectChip.Item(id: "auto", name: "Auto", description: nil),
+            ACPSelectChip.Item(id: "provider:gpt-5-composer-2.5", name: "Composer 2.5", description: nil),
+            ACPSelectChip.Item(id: "provider:gpt-5-opus-4.8", name: "Opus 4.8", description: nil),
+            ACPSelectChip.Item(id: "provider:gpt-5.5", name: "GPT-5.5", description: nil),
+            ACPSelectChip.Item(id: "provider:gpt-5-fable-5", name: "Fable 5", description: nil),
+        ]
+
+        let result = ACPSelectChip.filteredItems(
+            items,
+            query: "gpt-5",
+            searchDescriptions: false,
+            searchIdentifiers: false
+        )
+
+        #expect(result.map(\.name) == ["GPT-5.5"])
+    }
+
     @Test("trims whitespace from query before filtering")
     func filteringTrimsWhitespace() {
         let items = [


### PR DESCRIPTION
## Summary
- Make the model picker search match visible model names only
- Keep identifier and description search available for the shared select chip elsewhere
- Add a regression test for hidden model identifiers that previously kept unrelated rows visible

## Validation
- xcodegen
- xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -quiet build
- xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' test -only-testing:AlasTests/ACPSelectChipTests

Note: the full local test suite was attempted, but Xcode was interrupted while finalizing runner output after several minutes without producing a failure summary.