### PR TITLE
fix(diff): prevent duplicate diff comment composer

### DIFF
--- a/Alas/Sources/Center/Diff/DiffPaneTextDocumentView.swift
+++ b/Alas/Sources/Center/Diff/DiffPaneTextDocumentView.swift
@@ -154,6 +154,10 @@ struct DiffPaneTextDocumentView: NSViewRepresentable {
     }
 
     func updateNSView(_ nsView: DiffPaneTextDocumentContainerView, context: Context) {
+        let visibleRows = DiffPaneRowProjection.visibleRows(
+            in: group,
+            expandedCollapsedRowIDs: expandedCollapsedRowIDs
+        )
         nsView.update(
             group: group,
             expandedCollapsedRowIDs: expandedCollapsedRowIDs,
@@ -166,7 +170,9 @@ struct DiffPaneTextDocumentView: NSViewRepresentable {
             lspContext: lspContext,
             activeCommentHighlight: activeCommentHighlight,
             allowsReviewLineSelection: allowsReviewLineSelection,
-            onReviewLineSelected: onReviewLineSelected,
+            onReviewLineSelected: { anchor in
+                onReviewLineSelected(ReviewDraftCommentRowSegmentation.sourceIndexedAnchor(anchor, in: visibleRows))
+            },
             onContextExpansion: onContextExpansion
         )
     }
@@ -203,7 +209,9 @@ struct DiffPaneSegmentView: NSViewRepresentable {
             lspContext: lspContext,
             activeCommentHighlight: activeCommentHighlight,
             allowsReviewLineSelection: allowsReviewLineSelection,
-            onReviewLineSelected: onReviewLineSelected,
+            onReviewLineSelected: { anchor in
+                onReviewLineSelected(ReviewDraftCommentRowSegmentation.sourceIndexedAnchor(anchor, in: rows))
+            },
             onContextExpansion: onContextExpansion
         )
     }

--- a/Alas/Sources/Center/DiffReview/DiffReviewFileSection.swift
+++ b/Alas/Sources/Center/DiffReview/DiffReviewFileSection.swift
@@ -1238,6 +1238,9 @@ enum ReviewDraftCommentRowSegmentation {
         canCreateDraftComment: Bool = true
     ) -> Result {
         let pendingKey = pendingAnchor.flatMap { pendingRowKey(for: $0, in: group) }
+        let duplicatePendingKey = pendingKey.map { key in
+            group.rows.filter { ReviewDraftCommentPlacement.allRowKeys(in: $0).contains(key) }.count > 1
+        } ?? false
         var segments: [Segment] = []
         var bufferedRows: [DiffDisplayRow] = []
         var emittedCommentIDs: Set<String> = []
@@ -1252,7 +1255,11 @@ enum ReviewDraftCommentRowSegmentation {
                 excludingIDs: emittedCommentIDs
             )
             emittedCommentIDs.formUnion(comments.map(\.id))
-            let showsComposer = canCreateDraftComment && (pendingKey.map { keys.contains($0) } ?? false)
+            let showsComposer = canCreateDraftComment && (pendingKey.map { key in
+                guard keys.contains(key) else { return false }
+                guard duplicatePendingKey, let pendingAnchor else { return true }
+                return rowContainsDisplayRowIndex(pendingAnchor.endRowIndex, row: row)
+            } ?? false)
             guard !comments.isEmpty || showsComposer else { continue }
 
             segments.append(Segment(
@@ -1312,6 +1319,26 @@ enum ReviewDraftCommentRowSegmentation {
         return anchor
     }
 
+    static func sourceIndexedAnchor(
+        _ anchor: DiffReviewLineAnchor,
+        in rows: [DiffDisplayRow]
+    ) -> DiffReviewLineAnchor {
+        let rowIndex = sourceRowIndex(for: anchor.rowIndex, side: anchor.side, in: rows) ?? anchor.rowIndex
+        let endRowIndex = sourceRowIndex(for: anchor.endRowIndex, side: anchor.side, in: rows) ?? anchor.endRowIndex
+        guard rowIndex != anchor.rowIndex || endRowIndex != anchor.endRowIndex else { return anchor }
+
+        return DiffReviewLineAnchor(
+            path: anchor.path,
+            side: anchor.side,
+            line: anchor.line,
+            endLine: anchor.endLine,
+            rowIndex: rowIndex,
+            endRowIndex: endRowIndex,
+            selectedLines: anchor.selectedLines,
+            selectedText: anchor.selectedText
+        )
+    }
+
     private static func pendingRowKey(
         for anchor: DiffReviewLineAnchor,
         in group: DiffDisplayGroup
@@ -1335,6 +1362,29 @@ enum ReviewDraftCommentRowSegmentation {
         let keys = Set(ReviewDraftCommentPlacement.allRowKeys(in: group))
         return keys.contains(ReviewDraftCommentPlacement.RowKey(side: .unknown, line: anchor.draftPlacementLine))
             || keys.contains(ReviewDraftCommentPlacement.RowKey(side: .unknown, line: anchor.line))
+    }
+
+    private static func rowContainsDisplayRowIndex(_ rowIndex: Int, row: DiffDisplayRow) -> Bool {
+        row.old?.anchor.rowIndex == rowIndex
+            || row.new?.anchor.rowIndex == rowIndex
+            || row.collapsedRows.contains { rowContainsDisplayRowIndex(rowIndex, row: $0) }
+    }
+
+    private static func sourceRowIndex(
+        for localRowIndex: Int,
+        side: DiffReviewInlineFeedbackSide,
+        in rows: [DiffDisplayRow]
+    ) -> Int? {
+        guard rows.indices.contains(localRowIndex) else { return nil }
+        let row = rows[localRowIndex]
+        switch side {
+        case .old:
+            return row.old?.anchor.rowIndex ?? row.new?.anchor.rowIndex
+        case .new:
+            return row.new?.anchor.rowIndex ?? row.old?.anchor.rowIndex
+        case .unknown:
+            return row.old?.anchor.rowIndex ?? row.new?.anchor.rowIndex
+        }
     }
 
     private static func selectedLineRange(

--- a/AlasTests/DiffReviewSurfaceTests.swift
+++ b/AlasTests/DiffReviewSurfaceTests.swift
@@ -1367,15 +1367,15 @@ struct DiffReviewSurfaceTests {
         let firstRow = DiffDisplayRow(
             id: "row-1",
             kind: .context,
-            old: diffLine(id: "old-1", side: .old, oldLine: 1, text: "one"),
-            new: diffLine(id: "new-2", side: .new, newLine: 2, text: "two"),
+            old: diffLine(id: "old-1", side: .old, oldLine: 1, text: "one", rowIndex: 0),
+            new: diffLine(id: "new-2", side: .new, newLine: 2, text: "two", rowIndex: 0),
             collapsedLineCount: 0
         )
         let secondRow = DiffDisplayRow(
             id: "row-2",
             kind: .context,
-            old: diffLine(id: "old-2", side: .old, oldLine: 2, text: "two"),
-            new: diffLine(id: "new-3", side: .new, newLine: 3, text: "three"),
+            old: diffLine(id: "old-2", side: .old, oldLine: 2, text: "two", rowIndex: 1),
+            new: diffLine(id: "new-3", side: .new, newLine: 3, text: "three", rowIndex: 1),
             collapsedLineCount: 0
         )
         let group = DiffDisplayGroup(
@@ -1394,6 +1394,123 @@ struct DiffReviewSurfaceTests {
         )
 
         #expect(segments.items.flatMap(\.draftComments).map(\.id) == ["draft-shifted"])
+    }
+
+    @Test func pendingUnknownDraftComposerDoesNotDuplicateAcrossShiftedContextRows() {
+        let firstRow = DiffDisplayRow(
+            id: "row-1",
+            kind: .context,
+            old: diffLine(id: "old-1", side: .old, oldLine: 1, text: "one", rowIndex: 0),
+            new: diffLine(id: "new-2", side: .new, newLine: 2, text: "two", rowIndex: 0),
+            collapsedLineCount: 0
+        )
+        let secondRow = DiffDisplayRow(
+            id: "row-2",
+            kind: .context,
+            old: diffLine(id: "old-2", side: .old, oldLine: 2, text: "two", rowIndex: 1),
+            new: diffLine(id: "new-3", side: .new, newLine: 3, text: "three", rowIndex: 1),
+            collapsedLineCount: 0
+        )
+        let group = DiffDisplayGroup(
+            id: "group",
+            header: "@@ -1,2 +2,2 @@",
+            sourceHunk: parsedDiff().hunks[0],
+            rows: [firstRow, secondRow]
+        )
+        let pendingAnchor = DiffReviewLineAnchor(
+            path: "A.swift",
+            side: .unknown,
+            line: 2,
+            rowIndex: 1,
+            selectedLines: [
+                DiffReviewLineAnchor.SelectedLine(side: .unknown, line: 2, isChange: false),
+            ],
+            selectedText: "two"
+        )
+
+        let segments = ReviewDraftCommentRowSegmentation.segments(
+            for: group,
+            placement: ReviewDraftCommentPlacement.position([], in: [group]),
+            pendingAnchor: pendingAnchor
+        )
+
+        #expect(segments.items.filter(\.showsComposer).count == 1)
+        #expect(segments.items.filter(\.showsComposer).first?.rows.map(\.id) == ["row-1", "row-2"])
+    }
+
+    @Test func sourceIndexedPendingAnchorMapsSegmentLocalRowsToDisplayRows() {
+        let row = DiffDisplayRow(
+            id: "row-2",
+            kind: .context,
+            old: diffLine(id: "old-2", side: .old, oldLine: 2, text: "two", rowIndex: 1),
+            new: diffLine(id: "new-3", side: .new, newLine: 3, text: "three", rowIndex: 1),
+            collapsedLineCount: 0
+        )
+        let localAnchor = DiffReviewLineAnchor(
+            path: "A.swift",
+            side: .unknown,
+            line: 2,
+            rowIndex: 0,
+            selectedLines: [
+                DiffReviewLineAnchor.SelectedLine(side: .unknown, line: 2, isChange: false),
+            ],
+            selectedText: "two"
+        )
+
+        let sourceAnchor = ReviewDraftCommentRowSegmentation.sourceIndexedAnchor(localAnchor, in: [row])
+
+        #expect(sourceAnchor.rowIndex == 1)
+        #expect(sourceAnchor.endRowIndex == 1)
+    }
+
+    @Test func pendingUnknownDraftComposerUsesSourceRowAfterExistingDraftSegment() {
+        let firstRow = DiffDisplayRow(
+            id: "row-1",
+            kind: .context,
+            old: diffLine(id: "old-1", side: .old, oldLine: 1, text: "one", rowIndex: 0),
+            new: diffLine(id: "new-2", side: .new, newLine: 2, text: "two", rowIndex: 0),
+            collapsedLineCount: 0
+        )
+        let secondRow = DiffDisplayRow(
+            id: "row-2",
+            kind: .context,
+            old: diffLine(id: "old-2", side: .old, oldLine: 2, text: "two", rowIndex: 1),
+            new: diffLine(id: "new-3", side: .new, newLine: 3, text: "three", rowIndex: 1),
+            collapsedLineCount: 0
+        )
+        let group = DiffDisplayGroup(
+            id: "group",
+            header: "@@ -1,2 +2,2 @@",
+            sourceHunk: parsedDiff().hunks[0],
+            rows: [firstRow, secondRow]
+        )
+        let localAnchor = DiffReviewLineAnchor(
+            path: "A.swift",
+            side: .unknown,
+            line: 2,
+            rowIndex: 0,
+            selectedLines: [
+                DiffReviewLineAnchor.SelectedLine(side: .unknown, line: 2, isChange: false),
+            ],
+            selectedText: "two"
+        )
+        let sourceAnchor = ReviewDraftCommentRowSegmentation.sourceIndexedAnchor(localAnchor, in: [secondRow])
+        let placement = ReviewDraftCommentPlacement.position(
+            [draftComment(id: "draft-shifted", path: "A.swift", side: .unknown, startLine: 2)],
+            in: [group]
+        )
+
+        let segments = ReviewDraftCommentRowSegmentation.segments(
+            for: group,
+            placement: placement,
+            pendingAnchor: sourceAnchor
+        )
+
+        #expect(segments.items.map(\.rows).map { $0.map(\.id) } == [["row-1"], ["row-2"]])
+        #expect(segments.items[0].draftComments.map(\.id) == ["draft-shifted"])
+        #expect(segments.items[0].showsComposer == false)
+        #expect(segments.items[1].draftComments.isEmpty)
+        #expect(segments.items[1].showsComposer)
     }
 
     @Test func localDraftCommentsWithUnknownSideDoNotDuplicateAcrossMatchingHunks() {
@@ -3218,14 +3335,15 @@ struct DiffReviewSurfaceTests {
         oldLine: Int? = nil,
         newLine: Int? = nil,
         text: String,
-        kind: ParsedDiff.Hunk.Line.Kind = .context
+        kind: ParsedDiff.Hunk.Line.Kind = .context,
+        rowIndex: Int = 0
     ) -> DiffDisplayLine {
         DiffDisplayLine(
             id: id,
             anchor: DiffLineAnchor(
                 filePath: "A.swift",
                 hunkIndex: 0,
-                rowIndex: 0,
+                rowIndex: rowIndex,
                 side: side,
                 oldLine: oldLine,
                 newLine: newLine


### PR DESCRIPTION
## Summary
Fix duplicate draft composer placement when an unknown-side pending comment key can match more than one shifted context row. Context-line commenting remains enabled; ambiguous pending anchors are normalized from segment-local row indices back to source diff row indices before composer placement.

## Changes
- Keep existing context-line review anchor behavior intact.
- Detect duplicate pending row keys inside a diff group and gate composer rendering to the selected source row.
- Normalize review anchors emitted by segmented diff panes so existing draft/comment segments do not shift composer placement.
- Add regression coverage for shifted context rows that share the same unknown-side line key, including the existing-draft segmented case raised by Codex.

## Verification
- `xcodegen`
- `xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -quiet build`
- `xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -resultBundlePath /tmp/alas-review-surface.xcresult test -only-testing:AlasTests/DiffReviewSurfaceTests`
- `xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -resultBundlePath /tmp/alas-focused-after-codex.xcresult test -only-testing:AlasTests/DiffPaneViewTests -only-testing:AlasTests/DiffReviewSurfaceTests`
- Earlier full `xcodebuild ... test` ran 4,797 tests and failed with the same 2 unrelated `ACPSession` image asset persistence issues seen before this correction.