### PR TITLE
fix(ui): defer pane width persistence

### DIFF
--- a/Alas/Sources/App/AppState.swift
+++ b/Alas/Sources/App/AppState.swift
@@ -193,6 +193,8 @@ final class AppState {
     }
     @ObservationIgnored
     private var lspManager: WorkspaceLSPManager?
+    @ObservationIgnored
+    private var languageServerConfigChangeTracker: LanguageServerConfigChangeTracker
     @ObservationIgnored lazy var updates = UpdateController(
         isEnabled: { [weak self] in self?.config.general.autoUpdate ?? true }
     )
@@ -455,6 +457,9 @@ final class AppState {
         let projectsFile = (try? store.readIfExists(ProjectsFile.self, from: Paths.projectsFile)) ?? ProjectsFile(projects: [])
         let spacesFile = try? store.readIfExists(SpacesFile.self, from: Paths.spacesFile)
         self.config = config
+        self.languageServerConfigChangeTracker = LanguageServerConfigChangeTracker(
+            initial: config.code.languageServers
+        )
         // Publish the effective shortcut reservations so the terminal pane
         // can honor user overrides from the very first keystroke.
         ShortcutReservations.update(from: config)
@@ -644,6 +649,7 @@ final class AppState {
 
     @discardableResult
     func saveConfig() -> Bool {
+        let shouldUpdateLSPRegistry = languageServerConfigChangeTracker.consumeChange(in: config)
         let saved: Bool
         do {
             try store.write(config, to: Paths.appConfigFile)
@@ -652,8 +658,24 @@ final class AppState {
             saved = false
             persistenceErrorHandler("Settings Save Failed", error.localizedDescription)
         }
-        lspManager?.updateRegistry(LanguageServerRegistry(userDefined: config.code.languageServers))
+        if shouldUpdateLSPRegistry {
+            lspManager?.updateRegistry(LanguageServerRegistry(userDefined: config.code.languageServers))
+        }
         return saved
+    }
+
+    struct LanguageServerConfigChangeTracker {
+        private var lastSavedLanguageServers: [LanguageServerConfig]
+
+        init(initial: [LanguageServerConfig]) {
+            lastSavedLanguageServers = initial
+        }
+
+        mutating func consumeChange(in config: AppConfig) -> Bool {
+            guard config.code.languageServers != lastSavedLanguageServers else { return false }
+            lastSavedLanguageServers = config.code.languageServers
+            return true
+        }
     }
 
     @discardableResult

--- a/Alas/Sources/Layout/DragHandle.swift
+++ b/Alas/Sources/Layout/DragHandle.swift
@@ -2,14 +2,43 @@ import SwiftUI
 
 struct DragHandle: View {
     enum Axis { case horizontal, vertical }
+
+    struct DragState {
+        let axis: Axis
+        private var lastTranslation: CGFloat = 0
+
+        init(axis: Axis) {
+            self.axis = axis
+        }
+
+        mutating func changed(width: CGFloat, height: CGFloat) -> CGFloat {
+            let cumulative = axis == .horizontal ? width : height
+            let delta = cumulative - lastTranslation
+            lastTranslation = cumulative
+            return delta
+        }
+
+        mutating func ended() {
+            lastTranslation = 0
+        }
+    }
+
     let axis: Axis
     /// Per-event delta (not cumulative). Caller adds it to current width and
     /// clamps. Sums to the same total a user expects from their cursor motion.
     let onDrag: (CGFloat) -> Void
+    let onEnded: () -> Void
     @State private var hovering = false
     @State private var dragging = false
     @State private var cursorPushed = false
-    @State private var lastTranslation: CGFloat = 0
+    @State private var dragState: DragState
+
+    init(axis: Axis, onDrag: @escaping (CGFloat) -> Void, onEnded: @escaping () -> Void = {}) {
+        self.axis = axis
+        self.onDrag = onDrag
+        self.onEnded = onEnded
+        _dragState = State(initialValue: DragState(axis: axis))
+    }
 
     var body: some View {
         VisualEffectView(material: .sidebar, blendingMode: .behindWindow)
@@ -30,14 +59,16 @@ struct DragHandle: View {
                 DragGesture(coordinateSpace: .local)
                     .onChanged { value in
                         dragging = true
-                        let cumulative = axis == .horizontal ? value.translation.width : value.translation.height
-                        let delta = cumulative - lastTranslation
-                        lastTranslation = cumulative
+                        let delta = dragState.changed(
+                            width: value.translation.width,
+                            height: value.translation.height
+                        )
                         onDrag(delta)
                     }
                     .onEnded { _ in
                         dragging = false
-                        lastTranslation = 0
+                        dragState.ended()
+                        onEnded()
                         if !hovering {
                             popCursor()
                         }

--- a/Alas/Sources/Layout/ThreePaneLayout.swift
+++ b/Alas/Sources/Layout/ThreePaneLayout.swift
@@ -40,25 +40,23 @@ struct ThreePaneLayout<Sidebar: View, Center: View, Right: View>: View {
                     sidebar()
                         .frame(width: CGFloat(sizing.sidebarWidth))
                         .frame(maxHeight: .infinity)
-                    DragHandle(axis: .horizontal) { delta in
+                    DragHandle(axis: .horizontal, onDrag: { delta in
                         sidebarWidth = DragHandle.clamp(
                             value: sidebarWidth + Double(delta),
                             min: sidebarMin, max: sidebarMax
                         )
-                        onWidthsChanged()
-                    }
+                    }, onEnded: onWidthsChanged)
                 }
                 center()
                     .frame(width: CGFloat(sizing.centerWidth))
                     .frame(maxHeight: .infinity)
                 if sizing.rightVisible {
-                    DragHandle(axis: .horizontal) { delta in
+                    DragHandle(axis: .horizontal, onDrag: { delta in
                         rightWidth = DragHandle.clamp(
                             value: rightWidth - Double(delta),
                             min: rightMin, max: rightMax
                         )
-                        onWidthsChanged()
-                    }
+                    }, onEnded: onWidthsChanged)
                     right()
                         .frame(width: CGFloat(sizing.rightWidth))
                         .frame(maxHeight: .infinity)

--- a/AlasTests/AppStatePersistenceTests.swift
+++ b/AlasTests/AppStatePersistenceTests.swift
@@ -63,4 +63,29 @@ struct AppStatePersistenceTests {
                 .some(ShortcutBinding(key: "o", modifiers: [.command])))
         #expect(reloaded.shortcutOverrides[ShortcutAction.switchRepository.rawValue] == .some(nil))
     }
+
+    @Test func languageServerRegistryRefreshesOnlyWhenLanguageServersChange() {
+        var tracker = AppState.LanguageServerConfigChangeTracker(
+            initial: AppConfig.defaults.code.languageServers
+        )
+
+        var widthOnlyConfig = AppConfig.defaults
+        widthOnlyConfig.sidebarWidth = 300
+        #expect(tracker.consumeChange(in: widthOnlyConfig) == false)
+
+        var languageServerConfig = widthOnlyConfig
+        languageServerConfig.code.languageServers = [
+            LanguageServerConfig(
+                language: "swift",
+                extensions: ["swift"],
+                command: "/usr/bin/sourcekit-lsp",
+                args: [],
+                env: [:],
+                rootMarkers: ["Package.swift"],
+                enabled: true
+            )
+        ]
+        #expect(tracker.consumeChange(in: languageServerConfig) == true)
+        #expect(tracker.consumeChange(in: languageServerConfig) == false)
+    }
 }

--- a/AlasTests/DragHandleTests.swift
+++ b/AlasTests/DragHandleTests.swift
@@ -12,4 +12,13 @@ struct DragHandleTests {
     @Test func passesThroughInRange() {
         #expect(DragHandle.clamp(value: 350, min: 200, max: 600) == 350)
     }
+
+    @Test func dragSequenceSeparatesChangeDeltasFromEnd() {
+        var state = DragHandle.DragState(axis: .horizontal)
+
+        #expect(state.changed(width: 10, height: 0) == 10)
+        #expect(state.changed(width: 16, height: 0) == 6)
+        state.ended()
+        #expect(state.changed(width: 4, height: 0) == 4)
+    }
 }


### PR DESCRIPTION
## Summary
Fixes #695.

Pane divider drags were saving the full app config and refreshing the LSP registry on every drag tick. This keeps live resize behavior but defers config persistence until the drag ends, and it gates LSP registry refreshes to actual language server setting changes.

## Changes
- Add a drag-state reducer and `onEnded` hook to `DragHandle`.
- Persist `ThreePaneLayout` width changes only after the sidebar/right divider drag completes.
- Track language server config changes in `AppState.saveConfig()` so unrelated settings saves do not rebuild the LSP registry.
- Cover the drag delta reset behavior and LSP registry refresh gate with Swift Testing tests.

## Validation
- `xcodegen`
- `xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -quiet build`
- `xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' test -only-testing:AlasTests/DragHandleTests -only-testing:AlasTests/AppStatePersistenceTests`

## Notes
Full-suite `xcodebuild ... test` currently fails in `ACPSessionTests` image asset preservation tests, and the same failures reproduce when `ACPSessionTests` is run standalone. Those failures are outside this pane-width change.
