### PR TITLE
perf(acp): Avoid highlighting streaming ACP code fences

### DIFF
--- a/Alas/Sources/ACP/UI/ACPMarkdownText.swift
+++ b/Alas/Sources/ACP/UI/ACPMarkdownText.swift
@@ -54,7 +54,21 @@ struct ACPMarkdownText: View {
                 Spacer(minLength: 0)
             }
         case .code(let lang, let body):
-            CodeBlockView(language: lang, code: body, typography: typography, showsCopyButton: showsCodeBlockCopyButton)
+            CodeBlockView(
+                language: lang,
+                code: body,
+                typography: typography,
+                showsCopyButton: showsCodeBlockCopyButton,
+                highlightsSyntax: true
+            )
+        case .streamingCode(let lang, let body):
+            CodeBlockView(
+                language: lang,
+                code: body,
+                typography: typography,
+                showsCopyButton: showsCodeBlockCopyButton,
+                highlightsSyntax: false
+            )
         case .table(let header, let rows):
             tableView(header: header, rows: rows)
         }
@@ -141,6 +155,7 @@ struct ACPMarkdownText: View {
         case paragraph(String)
         case quote(String)
         case code(language: String?, body: String)
+        case streamingCode(language: String?, body: String)
         case table(header: [String], rows: [[String]])
     }
 
@@ -256,8 +271,14 @@ struct ACPMarkdownText: View {
                     body.append(lines[i])
                     i += 1
                 }
-                if i < lines.count { i += 1 } // skip closing fence
-                blocks.append(.code(language: fence.language, body: body.joined(separator: "\n")))
+                let closesBeforeEnd = i < lines.count
+                if closesBeforeEnd { i += 1 } // skip closing fence
+                let codeBody = body.joined(separator: "\n")
+                if closesBeforeEnd {
+                    blocks.append(.code(language: fence.language, body: codeBody))
+                } else {
+                    blocks.append(.streamingCode(language: fence.language, body: codeBody))
+                }
                 continue
             }
 
@@ -319,6 +340,7 @@ private struct CodeBlockView: View {
     let code: String
     let typography: ACPChatTypography
     var showsCopyButton: Bool = true
+    var highlightsSyntax: Bool = true
     @Environment(\.theme) private var theme
     @State private var copied = false
 
@@ -326,13 +348,8 @@ private struct CodeBlockView: View {
         VStack(alignment: .leading, spacing: 0) {
             header
             ScrollView(.horizontal, showsIndicators: false) {
-                ACPSyntaxHighlightedText(
-                    text: code,
-                    explicitLanguage: language,
-                    fontFamily: typography.fontFamily,
-                    fontSize: typography.codeSize
-                )
-                .padding(.horizontal, 10).padding(.vertical, 8)
+                codeText
+                    .padding(.horizontal, 10).padding(.vertical, 8)
             }
         }
         .background(theme.color("bg-0").opacity(0.6))
@@ -388,6 +405,26 @@ private struct CodeBlockView: View {
         }
         .buttonStyle(.plain)
         .help("Copy code")
+    }
+
+    @ViewBuilder
+    private var codeText: some View {
+        if highlightsSyntax {
+            ACPSyntaxHighlightedText(
+                text: code,
+                explicitLanguage: language,
+                fontFamily: typography.fontFamily,
+                fontSize: typography.codeSize
+            )
+        } else {
+            Text(verbatim: code)
+                .font(Font(CenterTypography.resolveCodeFont(family: typography.fontFamily, size: typography.codeSize)))
+                .foregroundStyle(theme.color("fg"))
+                .lineSpacing(2)
+                .textSelection(.enabled)
+                .fixedSize(horizontal: false, vertical: true)
+                .frame(maxWidth: .infinity, alignment: .leading)
+        }
     }
 
     private func copy() {

--- a/Alas/Sources/ACP/UI/ACPSyntaxHighlightedText.swift
+++ b/Alas/Sources/ACP/UI/ACPSyntaxHighlightedText.swift
@@ -15,14 +15,30 @@ struct ACPSyntaxHighlightCacheKey: Equatable {
         fontFamily: String = ACPChatTypography.default.fontFamily,
         fontSize: CGFloat
     ) {
+        self.init(
+            text: text,
+            resolvedExtension: resolvedExtension,
+            themeKey: Self.themeKey(theme),
+            fontFamily: fontFamily,
+            fontSize: fontSize
+        )
+    }
+
+    init(
+        text: String,
+        resolvedExtension: String?,
+        themeKey: String,
+        fontFamily: String = ACPChatTypography.default.fontFamily,
+        fontSize: CGFloat
+    ) {
         self.text = text
         self.resolvedExtension = resolvedExtension
-        self.themeKey = Self.themeKey(theme)
+        self.themeKey = themeKey
         self.fontFamily = fontFamily
         self.fontSize = fontSize
     }
 
-    private static func themeKey(_ theme: Theme) -> String {
+    static func themeKey(_ theme: Theme) -> String {
         let tokenKey = theme.tokens
             .sorted { $0.key < $1.key }
             .map { "\($0.key)=\($0.value)" }
@@ -53,6 +69,8 @@ struct ACPSyntaxHighlightCacheKey: Equatable {
 private final class ACPSyntaxHighlightedTextCache: ObservableObject {
     private var key: ACPSyntaxHighlightCacheKey?
     private var value: AttributedString?
+    private var cachedTheme: Theme?
+    private var cachedThemeKey: String?
 
     func attributedString(
         text: String,
@@ -64,10 +82,11 @@ private final class ACPSyntaxHighlightedTextCache: ObservableObject {
     ) -> AttributedString {
         let resolvedExtension = explicitLanguage.flatMap(ACPCodeLanguage.highlighterExtension(for:))
             ?? ACPCodeLanguage.highlighterExtension(forPath: sourcePath)
+        let themeKey = themeKey(for: theme)
         let nextKey = ACPSyntaxHighlightCacheKey(
             text: text,
             resolvedExtension: resolvedExtension,
-            theme: theme,
+            themeKey: themeKey,
             fontFamily: fontFamily,
             fontSize: fontSize
         )
@@ -85,6 +104,16 @@ private final class ACPSyntaxHighlightedTextCache: ObservableObject {
         key = nextKey
         value = highlighted
         return highlighted
+    }
+
+    private func themeKey(for theme: Theme) -> String {
+        if cachedTheme == theme, let cachedThemeKey {
+            return cachedThemeKey
+        }
+        let key = ACPSyntaxHighlightCacheKey.themeKey(theme)
+        cachedTheme = theme
+        cachedThemeKey = key
+        return key
     }
 }
 

--- a/Alas/Sources/Center/DiffReview/DiffReviewFileSection.swift
+++ b/Alas/Sources/Center/DiffReview/DiffReviewFileSection.swift
@@ -1588,7 +1588,7 @@ enum DiffReviewInlineFeedbackMarkdown {
             switch block {
             case .heading(_, let text), .paragraph(let text), .quote(let text):
                 return ACPMarkdownInlineRenderer.plainText(text)
-            case .code(_, let body):
+            case .code(_, let body), .streamingCode(_, let body):
                 return body
             case .table(let header, let rows):
                 return ([header] + rows).map { row in

--- a/AlasTests/ACP/UI/ACPCodeBlockHighlighterTests.swift
+++ b/AlasTests/ACP/UI/ACPCodeBlockHighlighterTests.swift
@@ -300,6 +300,12 @@ struct ACPCodeBlockHighlighterTests {
             theme: dark,
             fontSize: 12
         )
+        let precomputedThemeKey = ACPSyntaxHighlightCacheKey(
+            text: "let value = 1",
+            resolvedExtension: "swift",
+            themeKey: ACPSyntaxHighlightCacheKey.themeKey(dark),
+            fontSize: 12
+        )
         let b = ACPSyntaxHighlightCacheKey(
             text: "let value = 1",
             resolvedExtension: "diff",
@@ -344,6 +350,7 @@ struct ACPCodeBlockHighlighterTests {
         )
 
         #expect(a == a)
+        #expect(a == precomputedThemeKey)
         #expect(a != b)
         #expect(a != c)
         #expect(a != differentText)

--- a/AlasTests/ACP/UI/ACPMarkdownBlockCacheTests.swift
+++ b/AlasTests/ACP/UI/ACPMarkdownBlockCacheTests.swift
@@ -27,6 +27,22 @@ struct ACPMarkdownBlockCacheTests {
         #expect(cache.stableBlocks.count > stableAfterOpen)
     }
 
+    @Test("unclosed fenced code remains a streaming block")
+    func unclosedFenceParsesAsStreamingCode() async {
+        let cache = ACPMarkdownBlockCache()
+        cache.update(with: "```swift\nfunc greet() {\n")
+
+        #expect(ACPMarkdownText.parse(cache.tailUnparsed) == [
+            .streamingCode(language: "swift", body: "func greet() {\n"),
+        ])
+
+        cache.update(with: "```swift\nfunc greet() {\n}\n```")
+
+        #expect(ACPMarkdownText.parse(cache.tailUnparsed) == [
+            .code(language: "swift", body: "func greet() {\n}"),
+        ])
+    }
+
     @Test("blank line inside an unclosed tilde fence does NOT promote stable blocks")
     func tildeFenceKeepsUnstable() async {
         let cache = ACPMarkdownBlockCache()


### PR DESCRIPTION
## Summary

- Render unclosed ACP markdown code fences as plain monospaced streaming code instead of syntax-highlighted code.
- Keep closed fences on the existing tree-sitter syntax highlighting path.
- Cache the syntax highlighter theme fingerprint per rendered cache object so body re-evaluations do not rebuild it on every pass.

Fixes #667.

## Validation

- `rtk env ALAS_FFF_TARGET_ARCH=arm64 xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -only-testing:AlasTests/ACPMarkdownBlockCacheTests -only-testing:AlasTests/ACPCodeBlockHighlighterTests test`
- `rtk env ALAS_FFF_TARGET_ARCH=arm64 xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -quiet build`