### PR TITLE
perf(acp): reduce streaming invalidation work

### DIFF
--- a/Alas/Sources/ACP/Session/ACPMessage.swift
+++ b/Alas/Sources/ACP/Session/ACPMessage.swift
@@ -21,20 +21,71 @@ enum ACPMessage: Equatable {
         .thought(id: id, messageId: nil, text)
     }
 
-    var stableId: String {
+    enum StableIdentityKey: Hashable {
+        case userMessageId(String)
+        case agentMessageId(String)
+        case thoughtMessageId(String)
+        case userUUID(UUID)
+        case agentUUID(UUID)
+        case thoughtUUID(UUID)
+        case fileEdit(UUID)
+        case plan(UUID)
+        case systemNotice(UUID)
+        case toolCall(String)
+    }
+
+    var stableIdentityKey: StableIdentityKey {
         switch self {
         case .user(let id, let messageId, _, _):
-            return messageId.map { "acp-user:\($0)" } ?? id.uuidString
+            messageId.map(StableIdentityKey.userMessageId) ?? .userUUID(id)
         case .agent(let id, let messageId, _):
-            return messageId.map { "acp-agent:\($0)" } ?? id.uuidString
+            messageId.map(StableIdentityKey.agentMessageId) ?? .agentUUID(id)
         case .thought(let id, let messageId, _):
-            return messageId.map { "acp-thought:\($0)" } ?? id.uuidString
-        case .fileEdit(let id, _),
-             .plan(let id, _),
-             .systemNotice(let id, _):
-            return id.uuidString
+            messageId.map(StableIdentityKey.thoughtMessageId) ?? .thoughtUUID(id)
+        case .fileEdit(let id, _):
+            .fileEdit(id)
+        case .plan(let id, _):
+            .plan(id)
+        case .systemNotice(let id, _):
+            .systemNotice(id)
         case .toolCall(let tc):
-            return "tc-\(tc.toolCallId)"
+            .toolCall(tc.toolCallId)
+        }
+    }
+
+    var stableId: String {
+        Self.stableId(for: stableIdentityKey)
+    }
+
+    static func stableId(for key: StableIdentityKey) -> String {
+        switch key {
+        case .userMessageId(let messageId):
+            "acp-user:\(messageId)"
+        case .agentMessageId(let messageId):
+            "acp-agent:\(messageId)"
+        case .thoughtMessageId(let messageId):
+            "acp-thought:\(messageId)"
+        case .userUUID(let id), .agentUUID(let id), .thoughtUUID(let id),
+             .fileEdit(let id), .plan(let id), .systemNotice(let id):
+            id.uuidString
+        case .toolCall(let toolCallId):
+            "tc-\(toolCallId)"
+        }
+    }
+
+    @MainActor
+    var contentUTF8Length: Int {
+        switch self {
+        case .user(_, _, let text, _):
+            text.utf8.count
+        case .agent(_, _, let text), .thought(_, _, let text):
+            text.utf8Length
+        case .systemNotice(_, let text):
+            text.utf8.count
+        case .toolCall(let tc):
+            tc.content.utf8.count
+        case .fileEdit, .plan:
+            0
         }
     }
 

--- a/Alas/Sources/ACP/Session/ACPStreamingText.swift
+++ b/Alas/Sources/ACP/Session/ACPStreamingText.swift
@@ -15,13 +15,20 @@ import Combine
 @MainActor
 final class StreamingText: ObservableObject {
     @Published private(set) var value: String
+    private(set) var utf8Length: Int
+    private(set) var revision: UInt64 = 0
+    private(set) var lastAppendedSuffix: String?
 
     init(_ initial: String = "") {
         self.value = initial
+        self.utf8Length = initial.utf8.count
     }
 
     func append(_ s: String) {
         value.append(s)
+        utf8Length += s.utf8.count
+        revision &+= 1
+        lastAppendedSuffix = s
     }
 }
 

--- a/Alas/Sources/ACP/Session/ACPTranscript.swift
+++ b/Alas/Sources/ACP/Session/ACPTranscript.swift
@@ -8,12 +8,24 @@ import Combine
 /// state no longer invalidate the message list.
 @MainActor
 final class ACPTranscript: ObservableObject {
-    @Published var messages: [ACPMessage] = []
+    @Published var messages: [ACPMessage] = [] {
+        didSet {
+            refreshPlanCaches()
+        }
+    }
     @Published var streamingState: ACPSession.StreamingState = .idle
     @Published var pendingPermission: ACPSession.PendingPermission?
     @Published var pendingQuestion: ACPSession.PendingQuestion?
     @Published var pendingUserInputs: [ACPUserInputRequest] = []
     @Published var urlElicitationWaits: [ACPURLElicitationWait] = []
+    /// Items of the plan emitted for the current turn. Updated when the
+    /// transcript array changes so high-frequency streaming ticks do not scan
+    /// the full message list from `ACPSessionView` / plan UI bodies.
+    @Published private(set) var currentPlan: [ACPMessage.PlanItem]?
+    /// The most recent non-empty plan emitted in this session, ignoring turn
+    /// boundaries. Sidebar-only signal that intentionally survives the gap
+    /// between a new user prompt and the next `.plan` arrival.
+    @Published private(set) var latestPlan: [ACPMessage.PlanItem]?
     /// Tick incremented on every streaming chunk that mutates an existing
     /// agent/thought buffer. The buffer itself publishes (so the row's
     /// inner Text re-renders), but the transcript array doesn't change —
@@ -49,6 +61,17 @@ final class ACPTranscript: ObservableObject {
     // MARK: - Per-message markdown caches
 
     private var markdownCaches: [String: ACPMarkdownBlockCache] = [:]
+    private var stableIdCache: [ACPMessage.StableIdentityKey: String] = [:]
+
+    func stableId(for message: ACPMessage) -> String {
+        let key = message.stableIdentityKey
+        if let cached = stableIdCache[key] {
+            return cached
+        }
+        let stableId = ACPMessage.stableId(for: key)
+        stableIdCache[key] = stableId
+        return stableId
+    }
 
     func markdownCache(forMessage id: String) -> ACPMarkdownBlockCache {
         if let c = markdownCaches[id] { return c }
@@ -75,42 +98,29 @@ final class ACPTranscript: ObservableObject {
         markdownCaches.removeAll()
     }
 
-    /// Items of the plan emitted for the current turn — the latest `.plan`
-    /// message that comes after the latest `.user` prompt. Returns nil
-    /// when no plan has arrived for this turn yet, even if an older turn
-    /// left a plan behind. The toolbar pill renders the *current* turn's
-    /// work, not stale progress from a previous prompt.
-    /// (See also `latestPlan`, which is turn-stable and treats an empty plan as nil.)
-    var currentPlan: [ACPMessage.PlanItem]? {
+    private func refreshPlanCaches() {
+        var newCurrentPlan: [ACPMessage.PlanItem]?
         for m in messages.reversed() {
-            if case .user = m { return nil }
-            if case .plan(_, let items) = m { return items }
-        }
-        return nil
-    }
-
-    /// The most recent plan emitted in this session, ignoring turn
-    /// boundaries. Unlike `currentPlan`, this survives the gap between
-    /// a fresh user prompt and the next `.plan` arrival — so the sidebar
-    /// can stay visible across turns per spec §6 ("stays until the next
-    /// plan or session reset").
-    ///
-    /// Returns nil when no plan message has ever arrived, or when the
-    /// most recent plan is empty. Note: unlike `currentPlan`, which returns an empty array for an empty current-turn plan, `latestPlan` normalises empty to nil — the sidebar uses this to decide whether to render at all.
-    ///
-    /// **Sidebar-only intent.** The toolbar pill deliberately keeps reading
-    /// `currentPlan` so it reflects the *active* turn — a per-turn signal
-    /// matches the pill's "what's the agent doing right now" framing. The
-    /// turn-stable semantics here exist only because the sidebar wants the
-    /// previous plan to linger across the brief gap when a new user prompt
-    /// has landed but the next `.plan` hasn't yet arrived.
-    var latestPlan: [ACPMessage.PlanItem]? {
-        for m in messages.reversed() {
+            if case .user = m { break }
             if case .plan(_, let items) = m {
-                return items.isEmpty ? nil : items
+                newCurrentPlan = items
+                break
             }
         }
-        return nil
+
+        var newLatestPlan: [ACPMessage.PlanItem]?
+        for m in messages.reversed() {
+            if case .plan(_, let items) = m {
+                newLatestPlan = items.isEmpty ? nil : items
+                break
+            }
+        }
+        if currentPlan != newCurrentPlan {
+            currentPlan = newCurrentPlan
+        }
+        if latestPlan != newLatestPlan {
+            latestPlan = newLatestPlan
+        }
     }
 
     // MARK: - Render window helpers

--- a/Alas/Sources/ACP/UI/ACPFileEditCard.swift
+++ b/Alas/Sources/ACP/UI/ACPFileEditCard.swift
@@ -2,7 +2,7 @@ import SwiftUI
 
 struct ACPFileEditCard: View {
     let edit: ACPMessage.FileEdit
-    let onOpenDiff: () -> Void
+    let onOpenDiff: (String) -> Void
     @Environment(\.theme) private var theme
     @State private var expanded = false
 
@@ -65,7 +65,9 @@ struct ACPFileEditCard: View {
             }
             .buttonStyle(.plain)
 
-            Button("Open diff", action: onOpenDiff)
+            Button("Open diff") {
+                onOpenDiff(edit.path)
+            }
                 .buttonStyle(.plain)
                 .font(.system(size: 11, weight: .medium))
                 .foregroundStyle(theme.color("accent"))
@@ -89,7 +91,7 @@ private struct _InlineDiffPanel: View {
     let oldText: String?
     let newText: String
     let relativePath: String
-    let onShowAll: () -> Void
+    let onShowAll: (String) -> Void
     @Environment(\.theme) private var theme
     @State private var diff: ParsedDiff?
     @State private var loading = true
@@ -111,7 +113,7 @@ private struct _InlineDiffPanel: View {
                     diff: diff,
                     relativePath: relativePath,
                     maxLines: 15,
-                    onShowAll: onShowAll
+                    onShowAll: { onShowAll(relativePath) }
                 )
             } else {
                 Text("No changes")

--- a/Alas/Sources/ACP/UI/ACPMarkdownBlockCache.swift
+++ b/Alas/Sources/ACP/UI/ACPMarkdownBlockCache.swift
@@ -14,7 +14,11 @@ final class ACPMarkdownBlockCache {
     private(set) var stableBlocks: [ACPMarkdownText.Block] = []
     private(set) var tailUnparsed: String = ""
     private var stablePrefixLength: Int = 0
+    private var tailUnparsedLength: Int = 0
     private var lastFullText: String = ""
+    private var lastFullUTF8Length: Int = 0
+    private var lastRevision: UInt64?
+    private var lastSourceID: ObjectIdentifier?
     private var promotionScanner = PromotionScanner()
 
     #if DEBUG
@@ -29,17 +33,46 @@ final class ACPMarkdownBlockCache {
     }
     #endif
 
-    func update(with full: String) {
+    func update(
+        with full: String,
+        knownAppendedSuffix: String? = nil,
+        revision: UInt64? = nil,
+        sourceID: ObjectIdentifier? = nil
+    ) {
+        let fullUTF8Length = full.utf8.count
+        if let revision, lastRevision == revision {
+            if let sourceID, lastSourceID == sourceID, lastFullUTF8Length == fullUTF8Length {
+                return
+            }
+            if sourceID == nil, lastFullText == full {
+                return
+            }
+        }
+        defer {
+            lastRevision = revision
+            lastSourceID = sourceID
+        }
+
+        if let suffix = knownAppendedSuffix,
+           lastRevision != nil,
+           lastSourceID == sourceID,
+           fullUTF8Length == lastFullUTF8Length + suffix.utf8.count {
+            appendStreamingSuffix(suffix, full: full, fullUTF8Length: fullUTF8Length)
+            return
+        }
+
         // Detect non-extending updates and reset.
         let extendsPreviousFullText = full.hasPrefix(lastFullText)
         if !extendsPreviousFullText {
             stableBlocks = []
             stablePrefixLength = 0
+            tailUnparsedLength = 0
             promotionScanner.reset()
         }
-        let previousTailLength = tailUnparsed.count
+        let previousTailLength = tailUnparsedLength
         lastFullText = full
-        tailUnparsed = String(full.dropFirst(stablePrefixLength))
+        lastFullUTF8Length = fullUTF8Length
+        replaceTailFromFull(full)
         if extendsPreviousFullText {
             let appended = tailUnparsed.dropFirst(previousTailLength)
             scanPromotionTail(String(appended), startingAt: previousTailLength)
@@ -48,6 +81,29 @@ final class ACPMarkdownBlockCache {
             scanPromotionTail(tailUnparsed, startingAt: 0)
         }
         promoteIfPossible()
+    }
+
+    private func appendStreamingSuffix(_ suffix: String, full: String, fullUTF8Length: Int) {
+        lastFullText = full
+        lastFullUTF8Length = fullUTF8Length
+        let previousTailLength = tailUnparsedLength
+        tailUnparsed.append(suffix)
+        tailUnparsedLength = tailUnparsed.count
+        let actualTailGrowth = tailUnparsedLength - previousTailLength
+        guard actualTailGrowth == suffix.count else {
+            replaceTailFromFull(full)
+            promotionScanner.reset()
+            scanPromotionTail(tailUnparsed, startingAt: 0)
+            promoteIfPossible()
+            return
+        }
+        scanPromotionTail(suffix, startingAt: previousTailLength)
+        promoteIfPossible()
+    }
+
+    private func replaceTailFromFull(_ full: String) {
+        tailUnparsed = String(full.dropFirst(stablePrefixLength))
+        tailUnparsedLength = tailUnparsed.count
     }
 
     /// Walk tailUnparsed; find the latest blank line outside fenced code
@@ -62,6 +118,7 @@ final class ACPMarkdownBlockCache {
         stableBlocks.append(contentsOf: newBlocks)
         stablePrefixLength += promoted.count
         tailUnparsed = String(tailUnparsed.dropFirst(safeEnd))
+        tailUnparsedLength -= safeEnd
         promotionScanner.reset()
         scanPromotionTail(tailUnparsed, startingAt: 0)
     }

--- a/Alas/Sources/ACP/UI/ACPMarkdownText.swift
+++ b/Alas/Sources/ACP/UI/ACPMarkdownText.swift
@@ -13,6 +13,9 @@ import AppKit
 struct ACPMarkdownText: View {
     let raw: String
     var cache: ACPMarkdownBlockCache? = nil
+    var knownAppendedSuffix: String? = nil
+    var updateRevision: UInt64? = nil
+    var updateSourceID: ObjectIdentifier? = nil
     var typography: ACPChatTypography = .default
     var showsCodeBlockCopyButton: Bool = true
     @Environment(\.theme) private var theme
@@ -27,7 +30,12 @@ struct ACPMarkdownText: View {
 
     private func currentBlocks() -> [Block] {
         if let cache {
-            cache.update(with: raw)
+            cache.update(
+                with: raw,
+                knownAppendedSuffix: knownAppendedSuffix,
+                revision: updateRevision,
+                sourceID: updateSourceID
+            )
             let tailBlocks = ACPMarkdownText.parse(cache.tailUnparsed)
             return cache.stableBlocks + tailBlocks
         }

--- a/Alas/Sources/ACP/UI/ACPMessageGutter.swift
+++ b/Alas/Sources/ACP/UI/ACPMessageGutter.swift
@@ -15,11 +15,25 @@ import SwiftUI
 /// wrapper only reveals the button and positions it into the reserved right
 /// lane via an offset.
 struct ACPMessageGutter<Content: View>: View {
-    /// Produces the raw Markdown copied by "Copy message". A closure (not a
-    /// stored `String`) so streaming agent text is read at click time rather
-    /// than captured stale at view-build time. Matches
-    /// `ACPTranscriptMarkdown.messageBody` for this message.
-    let markdown: () -> String
+    enum CopySource {
+        case text(String)
+        case streaming(StreamingText)
+
+        @MainActor
+        var markdown: String {
+            switch self {
+            case .text(let text):
+                text
+            case .streaming(let text):
+                text.value
+            }
+        }
+    }
+
+    /// Produces the raw Markdown copied by "Copy message". Streaming rows keep
+    /// a reference to the live buffer so copy reads the latest text without a
+    /// per-row closure recreated on every list evaluation.
+    let copySource: CopySource
     @ViewBuilder var content: Content
 
     @StateObject private var hover = ACPDelayedHoverVisibility()
@@ -60,7 +74,7 @@ struct ACPMessageGutter<Content: View>: View {
     private var dotsMenu: some View {
         Menu {
             Button("Copy message") {
-                let text = markdown()
+                let text = copySource.markdown
                 NSPasteboard.general.clearContents()
                 NSPasteboard.general.setString(text, forType: .string)
             }

--- a/Alas/Sources/ACP/UI/ACPMessageList.swift
+++ b/Alas/Sources/ACP/UI/ACPMessageList.swift
@@ -59,12 +59,12 @@ struct ACPMessageList: View {
     /// reset to `max(0, count - tailWindow)` after hydration); the
     /// filter drops `.plan` entries because the toolbar pill renders
     /// the current turn's plan instead of an inline card.
-    private var visibleRows: [(index: Int, message: ACPMessage)] {
+    private var visibleRows: [(index: Int, stableId: String, message: ACPMessage)] {
         let head = min(transcript.visibleHead, transcript.messages.count)
         return (head..<transcript.messages.count).compactMap { index in
             let message = transcript.messages[index]
             if case .plan = message { return nil }
-            return (index, message)
+            return (index, transcript.stableId(for: message), message)
         }
     }
 
@@ -87,23 +87,25 @@ struct ACPMessageList: View {
         if let last = transcript.messages.last {
             hasher.combine(last.kind)
             switch last {
-            case .agent(_, _, let buf), .thought(_, _, let buf):
-                hasher.combine(buf.value.count)
-            case .systemNotice(_, let t):
-                hasher.combine(t.count)
+            case .agent, .thought, .systemNotice, .user:
+                hasher.combine(last.contentUTF8Length)
             case .toolCall(let tc):
                 hasher.combine(tc.status)
-                hasher.combine(tc.content.count)
+                hasher.combine(last.contentUTF8Length)
             case .fileEdit(_, let e):
                 hasher.combine(e.added)
                 hasher.combine(e.removed)
             case .plan:
                 break
-            case .user(_, _, let t, _):
-                hasher.combine(t.count)
             }
         }
         return hasher.finalize()
+    }
+
+    private var openTranscriptURLAction: OpenURLAction {
+        OpenURLAction { url in
+            onOpenTranscriptLink(url) ? .handled : .systemAction
+        }
     }
 
     var body: some View {
@@ -126,12 +128,9 @@ struct ACPMessageList: View {
                                 .padding(.bottom, 4)
                                 .background(topPaginationSentinel)
                         }
-                        ForEach(visibleRows, id: \.message.stableId) { item in
-                            row(for: item.message)
-                                .environment(\.openURL, OpenURLAction { url in
-                                    onOpenTranscriptLink(url) ? .handled : .systemAction
-                                })
-                                .background(rowFrameReporter(id: item.message.stableId))
+                        ForEach(visibleRows, id: \.stableId) { item in
+                            row(for: item.message, stableId: item.stableId)
+                                .background(rowFrameReporter(id: item.stableId))
                         }
                         if transcript.pendingPermission != nil, let policy = policy {
                             ACPPermissionPrompt(session: session, policy: policy, scopeKey: scopeKey)
@@ -205,6 +204,7 @@ struct ACPMessageList: View {
                     .padding(.horizontal, 28 + ACPMessageGutterLayout.laneWidth)
                     .padding(.top, 24)
                     .frame(maxWidth: .infinity, alignment: .center)
+                    .environment(\.openURL, openTranscriptURLAction)
                     .modifier(ACPScrollTargetLayoutTracking())
                 }
                 .coordinateSpace(.named(scrollSpaceName))
@@ -483,7 +483,7 @@ struct ACPMessageList: View {
 
     private var visibleMessageLookup: VisibleMessageLookup {
         Self.visibleMessageLookup(rows: visibleRows.map { row in
-            (index: row.index, stableId: row.message.stableId)
+            (index: row.index, stableId: row.stableId)
         })
     }
 
@@ -787,10 +787,10 @@ struct ACPMessageList: View {
     }
 
     @ViewBuilder
-    private func row(for m: ACPMessage) -> some View {
+    private func row(for m: ACPMessage, stableId: String) -> some View {
         switch m {
         case .user(_, _, let text, let attachments):
-            ACPMessageGutter(markdown: { text }) {
+            ACPMessageGutter(copySource: .text(text)) {
                 UserMessageRow(
                     text: text,
                     attachments: attachments,
@@ -799,9 +799,9 @@ struct ACPMessageList: View {
                 )
             }
         case .agent(_, _, let buf):
-            ACPMessageGutter(markdown: { buf.value }) {
+            ACPMessageGutter(copySource: .streaming(buf)) {
                 AgentMessageRow(
-                    messageId: Self.markdownCacheMessageId(for: m),
+                    messageId: stableId,
                     transcript: transcript,
                     buffer: buf,
                     typography: typography
@@ -813,12 +813,10 @@ struct ACPMessageList: View {
             ACPToolCallCard(
                 toolCall: tc,
                 trustedImageRoot: trustedImageRoot,
-                loadFullContent: tc.isContentTruncated
-                    ? { [tcid = tc.toolCallId] in onLoadFullToolCallContent(tcid) }
-                    : nil)
+                loadFullContent: tc.isContentTruncated ? onLoadFullToolCallContent : nil)
                 .environment(\.acpTerminalHost, session.terminalHost)
         case .fileEdit(_, let edit):
-            ACPFileEditCard(edit: edit, onOpenDiff: { onOpenDiff(edit.path) })
+            ACPFileEditCard(edit: edit, onOpenDiff: onOpenDiff)
         case .plan:
             EmptyView()
         case .systemNotice(_, let text):
@@ -1238,6 +1236,9 @@ private struct AgentMessageRow: View {
         ACPMarkdownText(
             raw: buffer.value,
             cache: transcript.markdownCache(forMessage: messageId),
+            knownAppendedSuffix: buffer.lastAppendedSuffix,
+            updateRevision: buffer.revision,
+            updateSourceID: ObjectIdentifier(buffer),
             typography: typography
         )
             .frame(maxWidth: .infinity, alignment: .leading)

--- a/Alas/Sources/ACP/UI/ACPToolCallCard.swift
+++ b/Alas/Sources/ACP/UI/ACPToolCallCard.swift
@@ -14,7 +14,7 @@ struct ACPToolCallCard: View {
     /// in `expandedContent` and rendered in place of the truncated copy.
     /// Optional — when nil (or when the lookup returns nil) the card falls
     /// back to the in-memory `toolCall.content`.
-    var loadFullContent: (() -> String?)? = nil
+    var loadFullContent: ((String) -> String?)? = nil
     @State private var expanded = false
     @State private var expandedContent: String? = nil
     @Environment(\.theme) private var theme
@@ -28,7 +28,7 @@ struct ACPToolCallCard: View {
                     // First expand of an off-window truncated card: page the
                     // full content back in from SQLite via the host-provided
                     // loader. Subsequent toggles reuse the cached string.
-                    expandedContent = loadFullContent?()
+                    expandedContent = loadFullContent?(toolCall.toolCallId)
                 }
             } label: {
                 HStack(spacing: 8) {

--- a/AlasTests/ACP/Session/ACPStreamingTextTests.swift
+++ b/AlasTests/ACP/Session/ACPStreamingTextTests.swift
@@ -13,6 +13,18 @@ struct ACPStreamingTextTests {
         #expect(t.value == "abc")
     }
 
+    @Test("append tracks byte length, revision, and latest suffix")
+    func appendTracksStreamingMetadata() async {
+        let t = StreamingText("a")
+
+        t.append("é")
+
+        #expect(t.value == "aé")
+        #expect(t.utf8Length == 3)
+        #expect(t.revision == 1)
+        #expect(t.lastAppendedSuffix == "é")
+    }
+
     @Test("two ACPMessage.agent values backed by the same buffer compare equal")
     func identityEqualityForSharedBuffer() async {
         let buf = StreamingText("hi")

--- a/AlasTests/ACP/UI/ACPMarkdownBlockCacheTests.swift
+++ b/AlasTests/ACP/UI/ACPMarkdownBlockCacheTests.swift
@@ -87,4 +87,69 @@ struct ACPMarkdownBlockCacheTests {
 
         #expect(cache.promotionScanCharacterCountForTests == afterInitial + 1)
     }
+
+    @Test("streaming hint scans suffix once per revision")
+    func streamingHintScansSuffixOncePerRevision() async {
+        let cache = ACPMarkdownBlockCache()
+        final class Source {}
+        let source = Source()
+        let sourceID = ObjectIdentifier(source)
+        let first = String(repeating: "a", count: 10_000)
+        cache.update(with: first, revision: 0, sourceID: sourceID)
+        let afterInitial = cache.promotionScanCharacterCountForTests
+
+        let second = first + "b"
+        cache.update(with: second, knownAppendedSuffix: "b", revision: 1, sourceID: sourceID)
+        cache.update(with: second, knownAppendedSuffix: "b", revision: 1, sourceID: sourceID)
+
+        #expect(cache.promotionScanCharacterCountForTests == afterInitial + 1)
+    }
+
+    @Test("same revision from a replacement source reparses new text")
+    func repeatedRevisionFromReplacementSourceReparses() async {
+        final class Source {}
+        let cache = ACPMarkdownBlockCache()
+        let oldSource = Source()
+        let newSource = Source()
+        cache.update(with: "old", revision: 0, sourceID: ObjectIdentifier(oldSource))
+
+        cache.update(with: "new", revision: 0, sourceID: ObjectIdentifier(newSource))
+
+        let cached = cache.stableBlocks + ACPMarkdownText.parse(cache.tailUnparsed)
+        #expect(cached == ACPMarkdownText.parse("new"))
+    }
+
+    @Test("streaming hint keeps tail length valid when suffix joins previous grapheme")
+    func streamingHintHandlesCombiningMarkSuffix() async {
+        let cache = ACPMarkdownBlockCache()
+        final class Source {}
+        let sourceID = ObjectIdentifier(Source())
+        cache.update(with: "e", revision: 0, sourceID: sourceID)
+        cache.update(with: "e\u{0301}", knownAppendedSuffix: "\u{0301}", revision: 1, sourceID: sourceID)
+
+        cache.update(with: "e\u{0301}\n\nnext", knownAppendedSuffix: "\n\nnext", revision: 2, sourceID: sourceID)
+
+        let cached = cache.stableBlocks + ACPMarkdownText.parse(cache.tailUnparsed)
+        let direct = ACPMarkdownText.parse("e\u{0301}\n\nnext")
+        #expect(cached == direct)
+    }
+
+    @Test("streaming hint handles joining suffix that contains promotion boundary")
+    func streamingHintHandlesCombiningMarkSuffixWithBoundary() async {
+        let cache = ACPMarkdownBlockCache()
+        final class Source {}
+        let sourceID = ObjectIdentifier(Source())
+        cache.update(with: "e", revision: 0, sourceID: sourceID)
+
+        cache.update(
+            with: "e\u{0301}\n\nnext",
+            knownAppendedSuffix: "\u{0301}\n\nnext",
+            revision: 1,
+            sourceID: sourceID
+        )
+
+        let cached = cache.stableBlocks + ACPMarkdownText.parse(cache.tailUnparsed)
+        let direct = ACPMarkdownText.parse("e\u{0301}\n\nnext")
+        #expect(cached == direct)
+    }
 }


### PR DESCRIPTION
## Summary

Fixes #668.

Reduces ACP streaming hot-path work by caching stable row identifiers, maintaining streaming buffer byte lengths/revisions, caching plan lookups on transcript mutation, stabilizing row callback inputs, and letting the markdown block cache consume known appended suffixes without re-walking the whole message.

## Validation

- `rtk xcodegen`
- `ALAS_FFF_TARGET_ARCH=arm64 rtk xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS,arch=arm64' -quiet build`
- `ALAS_FFF_TARGET_ARCH=arm64 rtk xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS,arch=arm64' test -only-testing:AlasTests/ACPMarkdownBlockCacheTests -only-testing:AlasTests/ACPStreamingTextTests -only-testing:AlasTests/ACPTranscriptCurrentPlanTests -only-testing:AlasTests/ACPMessageStableIdTests`

Note: the full local `xcodebuild ... test` sweep was started but stayed silent for several minutes and was interrupted without failure output; CI should cover the exhaustive pass.