### PR TITLE
perf(acp): keep per-streamed-chunk persistence off the main-actor SQLite/encode path

### DIFF
--- a/Alas/Sources/ACP/Session/ACPSessionRunner.swift
+++ b/Alas/Sources/ACP/Session/ACPSessionRunner.swift
@@ -1524,11 +1524,14 @@ extension ACPSessionRunner {
             guard let payload = try? ACPMessageCodec.encode(message) else { continue }
             let basePayload: Data?
             if i < persistedMessageCount {
-                // Prefer our in-memory record of the row we last wrote; only
-                // fall back to a one-time SQLite read for a row persisted by a
-                // previous session load that this runner never rewrote.
-                let id = "msg-\(sessionId)-\(i)"
-                guard let base = lastPersistedPayloads[i] ?? (try? store.loadMessagePayload(id: id)) else { continue }
+                // The compare-and-swap base MUST be what THIS runner last wrote
+                // while it still held the lease. Reading the row from SQLite now
+                // is unsafe — the lease has already moved, so the row may hold
+                // the new owner's payload, which would become `expectedPayload`
+                // and let the CAS clobber the new writer. Without our own record
+                // we cannot write this row safely, so skip it; the new owner is
+                // authoritative for a row we never persisted ourselves.
+                guard let base = lastPersistedPayloads[i] else { continue }
                 basePayload = base
             } else {
                 basePayload = nil

--- a/Alas/Sources/ACP/Session/ACPSessionRunner.swift
+++ b/Alas/Sources/ACP/Session/ACPSessionRunner.swift
@@ -67,6 +67,16 @@ final class ACPSessionRunner {
     private var pendingCompletedOutputBoundaryUpdateCount: Int?
     private var pendingStreamingPersistIndices: Set<Int> = []
     private var pendingStreamingPersistSnapshots: [Int: StreamingPersistSnapshot] = [:]
+    /// The exact payload bytes this runner last wrote for each message row.
+    /// Used as the compare-and-swap base when a takeover forces a stand-down
+    /// flush, so the CAS never reads the (potentially growing) payload blob
+    /// from SQLite on the streaming path.
+    private var lastPersistedPayloads: [Int: Data] = [:]
+    /// Set once a cross-process takeover is detected mid-stream. While true,
+    /// streamed chunks are no longer buffered for persistence and the
+    /// stand-down flush writes the frozen snapshots via compare-and-swap
+    /// instead of the (now-diverging) live transcript.
+    private var streamingLeaseLost = false
     private var streamingPersistTask: Task<Void, Never>?
     private let streamingPersistDebounceNanos: UInt64
     private var suppressingLoadReplay: Bool
@@ -78,6 +88,12 @@ final class ACPSessionRunner {
     /// restored snapshot ahead of the steer's replacement prompt. Once
     /// the redirect is in flight, normal drain semantics resume.
     private var steerInProgress: Bool = false
+
+    /// How many trailing rows to retain in `lastPersistedPayloads`. Only the
+    /// actively-streamed tail is ever re-persisted, so older rows can be
+    /// dropped; a pruned row that is somehow touched again falls back to a
+    /// one-time SQLite read in `freezeStreamingPersistSnapshots`.
+    private static let lastPersistedPayloadsWindow = 256
 
     private struct StreamingPersistSnapshot {
         let kind: String
@@ -169,10 +185,26 @@ final class ACPSessionRunner {
                         self.persistIndices(dirty)
                     } else {
                         let shouldBatchStreamingPersist = self.shouldBatchStreamingPersist(for: u.update)
-                        let dirty = self.session.apply(u.update)
                         if shouldBatchStreamingPersist {
-                            self.scheduleStreamingPersist(dirty)
+                            // Detect a cross-process takeover BEFORE this chunk
+                            // mutates the transcript. If the lease has moved,
+                            // freeze the buffered rows' pre-chunk state (our
+                            // last output produced under the lease) so the
+                            // stand-down flush persists that — not this chunk,
+                            // which belongs to a session another instance now
+                            // owns. The lease read is a single-row WAL SELECT;
+                            // the expensive encode/blob-read work stays off the
+                            // per-chunk path.
+                            if !self.streamingLeaseLost, !self.holdsLeaseForWrite() {
+                                self.freezeStreamingPersistSnapshots()
+                                self.streamingLeaseLost = true
+                            }
+                            let dirty = self.session.apply(u.update)
+                            if !self.streamingLeaseLost {
+                                self.scheduleStreamingPersist(dirty)
+                            }
                         } else {
+                            let dirty = self.session.apply(u.update)
                             self.flushStreamingPersist()
                             self.persistIndices(dirty)
                         }
@@ -692,6 +724,7 @@ final class ACPSessionRunner {
                     if let payload = try? ACPMessageCodec.encode(m) {
                         let id = "msg-\(sessionId)-\(i)"
                         try? store.updateMessagePayload(id: id, payload: payload)
+                        lastPersistedPayloads[i] = payload
                     }
                 }
             }
@@ -1152,6 +1185,7 @@ extension ACPSessionRunner {
                         self.persistQueue()
                     }
                 }
+                self.resetStreamingPersistBuffer()
                 self.session.transcript.streamingState = .sending
                 return true
             }
@@ -1251,6 +1285,7 @@ extension ACPSessionRunner {
                     return false
                 }
                 self.session.allowsStreamingBoundaryCrossing = true
+                self.resetStreamingPersistBuffer()
                 self.session.transcript.streamingState = .sending
                 return true
             }
@@ -1402,7 +1437,10 @@ extension ACPSessionRunner {
 
     private func scheduleStreamingPersist(_ indices: Set<Int>) {
         guard !indices.isEmpty else { return }
-        snapshotStreamingPersistPayloads(for: indices)
+        // Per-chunk work is intentionally cheap: record the dirty indices and
+        // arm the debounce. Encoding the (growing) message and reading its
+        // stored payload happen once per debounce window in the flush, not
+        // once per streamed chunk.
         pendingStreamingPersistIndices.formUnion(indices)
         guard streamingPersistTask == nil else { return }
         streamingPersistTask = Task { @MainActor [weak self] in
@@ -1417,41 +1455,84 @@ extension ACPSessionRunner {
         flushStreamingPersist(requiresLease: true)
     }
 
+    /// Clear streaming-persist buffer state carried over from a prior stream.
+    /// A taken-over stream leaves frozen snapshots and a set latch behind; if
+    /// this runner later reacquires the lease and sends a fresh prompt, those
+    /// stale rows must not resurrect.
+    private func resetStreamingPersistBuffer() {
+        guard streamingLeaseLost else { return }
+        streamingLeaseLost = false
+        pendingStreamingPersistIndices.removeAll()
+        pendingStreamingPersistSnapshots.removeAll()
+    }
+
+    /// Bound the compare-and-swap base cache to the recent tail so it can't
+    /// grow without limit over a long session.
+    private func trimLastPersistedPayloads() {
+        let keepFrom = persistedMessageCount - Self.lastPersistedPayloadsWindow
+        guard keepFrom > 0, lastPersistedPayloads.count > Self.lastPersistedPayloadsWindow else { return }
+        lastPersistedPayloads = lastPersistedPayloads.filter { $0.key >= keepFrom }
+    }
+
     private func flushStreamingPersistOnStop() {
         // During takeover, the lease row may already point at the new owner
-        // by the time stand-down stops this runner. The pending rows here are
-        // snapshots captured while this runner still held the lease; flush
-        // them once so the debounce buffer is not the only copy.
+        // by the time stand-down stops this runner. Flush once so the debounce
+        // buffer is not the only copy of the tail chunks.
         flushStreamingPersist(requiresLease: false)
     }
 
+    /// Flush the buffered streaming rows.
+    ///
+    /// - If a takeover was already detected mid-stream, only the frozen
+    ///   snapshots are safe to write, and only via compare-and-swap.
+    /// - Otherwise the live transcript is authoritative: try a lease-gated
+    ///   write. If that reveals the lease has since moved, freeze the buffered
+    ///   rows so a later stand-down can CAS-write them; when this *is* the
+    ///   stand-down flush (`requiresLease == false`), CAS-write them now.
     private func flushStreamingPersist(requiresLease: Bool) {
         streamingPersistTask?.cancel()
         streamingPersistTask = nil
-        guard !pendingStreamingPersistIndices.isEmpty else { return }
-        if !requiresLease {
+        if streamingLeaseLost {
             persistStreamingPersistSnapshots()
             return
         }
+        guard !pendingStreamingPersistIndices.isEmpty else { return }
         let indices = pendingStreamingPersistIndices
-        if persistIndices(indices, requiresLease: requiresLease) {
+        if persistIndices(indices, requiresLease: true) {
             pendingStreamingPersistIndices.subtract(indices)
-            for i in indices {
-                pendingStreamingPersistSnapshots.removeValue(forKey: i)
-            }
+            return
+        }
+        // The lease moved between the last chunk and this flush. Freeze the
+        // buffered rows' current state — every chunk so far arrived while we
+        // held the lease — for the stand-down CAS write.
+        freezeStreamingPersistSnapshots()
+        streamingLeaseLost = true
+        if !requiresLease {
+            persistStreamingPersistSnapshots()
         }
     }
 
-    private func snapshotStreamingPersistPayloads(for indices: Set<Int>) {
-        guard holdsLeaseForWrite() else { return }
+    /// Encode the buffered streaming rows from the live transcript into
+    /// compare-and-swap snapshots. Called exactly once, at the moment a
+    /// takeover is detected, so the payloads capture the last transcript
+    /// state produced while we still held the lease.
+    private func freezeStreamingPersistSnapshots() {
         let messages = session.transcript.messages
-        for i in indices {
+        for i in pendingStreamingPersistIndices {
             guard i >= 0, i < messages.count else { continue }
             let message = messageForPersistence(messages[i])
             guard let payload = try? ACPMessageCodec.encode(message) else { continue }
-            let id = "msg-\(sessionId)-\(i)"
-            let basePayload = i < persistedMessageCount ? try? store.loadMessagePayload(id: id) : nil
-            if i < persistedMessageCount, basePayload == nil { continue }
+            let basePayload: Data?
+            if i < persistedMessageCount {
+                // Prefer our in-memory record of the row we last wrote; only
+                // fall back to a one-time SQLite read for a row persisted by a
+                // previous session load that this runner never rewrote.
+                let id = "msg-\(sessionId)-\(i)"
+                guard let base = lastPersistedPayloads[i] ?? (try? store.loadMessagePayload(id: id)) else { continue }
+                basePayload = base
+            } else {
+                basePayload = nil
+            }
             pendingStreamingPersistSnapshots[i] = .init(kind: message.kind, payload: payload, basePayload: basePayload)
         }
     }
@@ -1481,9 +1562,11 @@ extension ACPSessionRunner {
                     continue
                 }
             }
+            lastPersistedPayloads[i] = snapshot.payload
             pendingStreamingPersistIndices.remove(i)
             pendingStreamingPersistSnapshots.removeValue(forKey: i)
         }
+        trimLastPersistedPayloads()
         onPersist?()
     }
 
@@ -1508,18 +1591,22 @@ extension ACPSessionRunner {
             let id = "msg-\(sessionId)-\(i)"
             if i < persistedMessageCount {
                 try? store.updateMessagePayload(id: id, payload: payload)
+                lastPersistedPayloads[i] = payload
             } else {
                 do {
                     try store.appendMessage(sessionId: sessionId, id: id, kind: m.kind,
                                             seq: Int64(i), payload: payload, createdAt: now)
                     persistedMessageCount = max(persistedMessageCount, i + 1)
+                    lastPersistedPayloads[i] = payload
                 } catch {
                     if (try? store.updateMessageRow(id: id, kind: m.kind, seq: Int64(i), payload: payload)) == true {
                         persistedMessageCount = max(persistedMessageCount, i + 1)
+                        lastPersistedPayloads[i] = payload
                     }
                 }
             }
         }
+        trimLastPersistedPayloads()
         onPersist?()
         return true
     }
@@ -1574,18 +1661,22 @@ extension ACPSessionRunner {
             let id = "msg-\(sessionId)-\(i)"
             if i < persistedMessageCount {
                 try? store.updateMessagePayload(id: id, payload: payload)
+                lastPersistedPayloads[i] = payload
             } else {
                 do {
                     try store.appendMessage(sessionId: sessionId, id: id, kind: m.kind,
                                             seq: Int64(i), payload: payload, createdAt: now)
                     persistedMessageCount = max(persistedMessageCount, i + 1)
+                    lastPersistedPayloads[i] = payload
                 } catch {
                     if (try? store.updateMessageRow(id: id, kind: m.kind, seq: Int64(i), payload: payload)) == true {
                         persistedMessageCount = max(persistedMessageCount, i + 1)
+                        lastPersistedPayloads[i] = payload
                     }
                 }
             }
         }
+        trimLastPersistedPayloads()
         onPersist?()
     }
 }

--- a/Alas/Sources/ACP/Session/ACPSessionRunner.swift
+++ b/Alas/Sources/ACP/Session/ACPSessionRunner.swift
@@ -1441,6 +1441,21 @@ extension ACPSessionRunner {
         // arm the debounce. Encoding the (growing) message and reading its
         // stored payload happen once per debounce window in the flush, not
         // once per streamed chunk.
+        //
+        // One exception: an already-persisted row this runner has not written
+        // yet (loaded from disk, or trimmed from the cache) has no compare-and-
+        // swap base. Capture its stored payload NOW — the caller reaches here
+        // only after confirming we hold the lease, so this reads our own view,
+        // not a future owner's. Deferring to the stand-down freeze would be too
+        // late (the row could hold a new owner's payload by then), and skipping
+        // it would silently drop a legitimate under-lease update. This reads at
+        // most once per such row, never on the hot streaming-tail path (a new
+        // trailing row is not yet persisted, so it is written, not read).
+        for i in indices where i < persistedMessageCount && lastPersistedPayloads[i] == nil {
+            if let base = try? store.loadMessagePayload(id: "msg-\(sessionId)-\(i)") {
+                lastPersistedPayloads[i] = base
+            }
+        }
         pendingStreamingPersistIndices.formUnion(indices)
         guard streamingPersistTask == nil else { return }
         streamingPersistTask = Task { @MainActor [weak self] in
@@ -1524,13 +1539,14 @@ extension ACPSessionRunner {
             guard let payload = try? ACPMessageCodec.encode(message) else { continue }
             let basePayload: Data?
             if i < persistedMessageCount {
-                // The compare-and-swap base MUST be what THIS runner last wrote
-                // while it still held the lease. Reading the row from SQLite now
-                // is unsafe — the lease has already moved, so the row may hold
-                // the new owner's payload, which would become `expectedPayload`
-                // and let the CAS clobber the new writer. Without our own record
-                // we cannot write this row safely, so skip it; the new owner is
-                // authoritative for a row we never persisted ourselves.
+                // The compare-and-swap base MUST be a payload captured while we
+                // held the lease — `scheduleStreamingPersist` records one for
+                // every persisted row it buffers, so the entry is normally
+                // present. Reading the row from SQLite HERE would be unsafe: the
+                // lease has already moved, so the row may hold the new owner's
+                // payload, which would become `expectedPayload` and let the CAS
+                // clobber it. If no under-lease base exists we cannot write
+                // safely, so skip the row and leave the new owner authoritative.
                 guard let base = lastPersistedPayloads[i] else { continue }
                 basePayload = base
             } else {

--- a/AlasTests/ACP/Session/ACPSessionRunnerTests.swift
+++ b/AlasTests/ACP/Session/ACPSessionRunnerTests.swift
@@ -1436,6 +1436,78 @@ struct ACPSessionRunnerTests {
         #expect(persisted.content == "new owner")
     }
 
+    @Test("takeover flush persists an under-lease update to a loaded row the new owner left alone")
+    func takeoverFlushPersistsUnderLeaseUpdateToLoadedRow() async throws {
+        let url = FileManager.default.temporaryDirectory.appendingPathComponent("rn-\(UUID()).sqlite")
+        let store = try ACPSessionStore(path: url.path)
+        let sid = "s"
+        try store.upsertSession(.init(id: sid, agentId: "claude", title: "t",
+            currentModel: nil, currentMode: nil, autoRun: false,
+            createdAt: 0, updatedAt: 0, lastOpenedAt: 0, archived: false))
+        let now = Int64(Date().timeIntervalSince1970)
+        try store.seizeLease(sessionId: sid, instanceId: "ME", pid: Int64(getpid()), now: now)
+
+        // A tool row persisted by a previous session load — no cache entry.
+        let tool = ACPMessage.toolCall(.init(
+            toolCallId: "tool-x", title: "Run", kind: "execute",
+            status: "in_progress", content: "base"))
+        try store.appendMessage(
+            sessionId: sid, id: "msg-\(sid)-0", kind: "tool_call",
+            seq: 0, payload: try ACPMessageCodec.encode(tool), createdAt: now)
+
+        let mock = StreamingBatchACPClient()
+        let session = ACPSession(id: sid, agentId: "claude", worktreeId: "wt", title: "t")
+        session.agentState = .ready
+        session.replaceTranscriptMessages([tool])
+        let runner = ACPSessionRunner(
+            session: session,
+            connection: ACPConnection(client: mock),
+            store: store,
+            sessionId: sid,
+            worktreePath: FileManager.default.temporaryDirectory.path,
+            streamingPersistDebounceNanos: 5_000_000_000,
+            ownerInstanceId: "ME"
+        )
+        runner.start()
+
+        let completed = Task {
+            await withCheckedContinuation { continuation in
+                runner.send(text: "start", attachments: []) { succeeded in
+                    continuation.resume(returning: succeeded)
+                }
+            }
+        }
+
+        await mock.waitForChunks()
+        // Update the loaded row while we still hold the lease. The CAS base is
+        // captured now, against the on-disk "base" payload.
+        mock.emitToolCallUpdate(.init(
+            toolCallId: "tool-x",
+            status: "completed",
+            content: [.content(.text("mine"))]))
+        try await Task.sleep(nanoseconds: 50_000_000)
+
+        // Takeover, but the new owner never touches this row.
+        try store.seizeLease(sessionId: sid, instanceId: "OTHER", pid: Int64(getpid()), now: now)
+        mock.emitUsageUpdate()
+        try await Task.sleep(nanoseconds: 50_000_000)
+        runner.stop()
+        await mock.finishPrompt()
+        _ = await completed.value
+
+        // The row still matches the base we captured under the lease, so the
+        // CAS succeeds and our under-lease update is not silently dropped.
+        let rows = try store.loadMessages(sessionId: sid)
+        let toolRow = try #require(rows.first(where: { $0.id == "msg-\(sid)-0" }))
+        guard case .toolCall(let persisted) =
+                try ACPMessageCodec.decode(kind: toolRow.kind, payload: toolRow.payload) else {
+            Issue.record("expected persisted tool call")
+            return
+        }
+        #expect(persisted.content == "mine")
+        #expect(persisted.status == "completed")
+    }
+
     @Test("stop persists buffered streamed chunks while the lease is still held")
     func stopPersistsBufferedStreamingChunksWhileLeaseHeld() async throws {
         let url = FileManager.default.temporaryDirectory.appendingPathComponent("rn-\(UUID()).sqlite")

--- a/AlasTests/ACP/Session/ACPSessionRunnerTests.swift
+++ b/AlasTests/ACP/Session/ACPSessionRunnerTests.swift
@@ -1358,6 +1358,68 @@ struct ACPSessionRunnerTests {
         #expect(text.value == "new writer")
     }
 
+    @Test("stop persists buffered streamed chunks while the lease is still held")
+    func stopPersistsBufferedStreamingChunksWhileLeaseHeld() async throws {
+        let url = FileManager.default.temporaryDirectory.appendingPathComponent("rn-\(UUID()).sqlite")
+        let store = try ACPSessionStore(path: url.path)
+        let sid = "s"
+        try store.upsertSession(.init(id: sid, agentId: "claude", title: "t",
+            currentModel: nil, currentMode: nil, autoRun: false,
+            createdAt: 0, updatedAt: 0, lastOpenedAt: 0, archived: false))
+        let now = Int64(Date().timeIntervalSince1970)
+        try store.seizeLease(sessionId: sid, instanceId: "ME", pid: Int64(getpid()), now: now)
+
+        let mock = StreamingBatchACPClient()
+        let session = ACPSession(id: sid, agentId: "claude", worktreeId: "wt", title: "t")
+        session.agentState = .ready
+        // A debounce long enough that no periodic flush fires: the only write
+        // must come from stop()'s stand-down flush, which — since the lease is
+        // still held — persists the live transcript rather than per-chunk
+        // snapshots. This is the path the per-chunk-encode removal reworked.
+        let runner = ACPSessionRunner(
+            session: session,
+            connection: ACPConnection(client: mock),
+            store: store,
+            sessionId: sid,
+            worktreePath: FileManager.default.temporaryDirectory.path,
+            streamingPersistDebounceNanos: 5_000_000_000,
+            ownerInstanceId: "ME"
+        )
+        runner.start()
+
+        let completed = Task {
+            await withCheckedContinuation { continuation in
+                runner.send(text: "start", attachments: []) { succeeded in
+                    continuation.resume(returning: succeeded)
+                }
+            }
+        }
+
+        await mock.waitForChunks()
+        // A chunk beyond the mock's initial two — it must be included in the
+        // stand-down flush, proving stop() reads the live transcript and does
+        // not rely on a snapshot captured per chunk.
+        mock.emitAgentChunk(" and more")
+        try await Task.sleep(nanoseconds: 50_000_000)
+
+        // Nothing persisted yet: the debounce has not fired.
+        let rowsBeforeStop = try store.loadMessages(sessionId: sid)
+        #expect(!rowsBeforeStop.contains { $0.kind == "agent" })
+
+        runner.stop()
+        await mock.finishPrompt()
+        _ = await completed.value
+
+        let rows = try store.loadMessages(sessionId: sid)
+        let agentRow = try #require(rows.first(where: { $0.kind == "agent" }))
+        let decoded = try ACPMessageCodec.decode(kind: agentRow.kind, payload: agentRow.payload)
+        guard case .agent(_, _, let text) = decoded else {
+            Issue.record("expected persisted agent message")
+            return
+        }
+        #expect(text.value == "hello world and more")
+    }
+
     @Test("in-place plan update persists to disk even when plan is not the trailing message")
     func planUpdatePersistsWhenNotTrailingMessage() async throws {
         let url = FileManager.default.temporaryDirectory.appendingPathComponent("rn-\(UUID()).sqlite")

--- a/AlasTests/ACP/Session/ACPSessionRunnerTests.swift
+++ b/AlasTests/ACP/Session/ACPSessionRunnerTests.swift
@@ -1358,6 +1358,84 @@ struct ACPSessionRunnerTests {
         #expect(text.value == "new writer")
     }
 
+    @Test("takeover flush skips a dirtied row this runner never persisted")
+    func takeoverFlushSkipsRowWithoutCachedBase() async throws {
+        let url = FileManager.default.temporaryDirectory.appendingPathComponent("rn-\(UUID()).sqlite")
+        let store = try ACPSessionStore(path: url.path)
+        let sid = "s"
+        try store.upsertSession(.init(id: sid, agentId: "claude", title: "t",
+            currentModel: nil, currentMode: nil, autoRun: false,
+            createdAt: 0, updatedAt: 0, lastOpenedAt: 0, archived: false))
+        let now = Int64(Date().timeIntervalSince1970)
+        try store.seizeLease(sessionId: sid, instanceId: "ME", pid: Int64(getpid()), now: now)
+
+        // A tool row persisted by a *previous* session load: it counts toward
+        // persistedMessageCount, but this runner never wrote it, so it has no
+        // entry in lastPersistedPayloads.
+        let tool = ACPMessage.toolCall(.init(
+            toolCallId: "tool-x", title: "Run", kind: "execute",
+            status: "in_progress", content: "base"))
+        try store.appendMessage(
+            sessionId: sid, id: "msg-\(sid)-0", kind: "tool_call",
+            seq: 0, payload: try ACPMessageCodec.encode(tool), createdAt: now)
+
+        let mock = StreamingBatchACPClient()
+        let session = ACPSession(id: sid, agentId: "claude", worktreeId: "wt", title: "t")
+        session.agentState = .ready
+        session.replaceTranscriptMessages([tool])
+        let runner = ACPSessionRunner(
+            session: session,
+            connection: ACPConnection(client: mock),
+            store: store,
+            sessionId: sid,
+            worktreePath: FileManager.default.temporaryDirectory.path,
+            streamingPersistDebounceNanos: 5_000_000_000,
+            ownerInstanceId: "ME"
+        )
+        runner.start()
+
+        let completed = Task {
+            await withCheckedContinuation { continuation in
+                runner.send(text: "start", attachments: []) { succeeded in
+                    continuation.resume(returning: succeeded)
+                }
+            }
+        }
+
+        await mock.waitForChunks()
+        // Dirty the pre-existing tool row mid-stream: it enters the persist
+        // buffer without a CAS base captured while we held the lease.
+        mock.emitToolCallUpdate(.init(
+            toolCallId: "tool-x",
+            status: "completed",
+            content: [.content(.text("mine"))]))
+        try await Task.sleep(nanoseconds: 50_000_000)
+
+        // Takeover, then the new owner rewrites that same row.
+        try store.seizeLease(sessionId: sid, instanceId: "OTHER", pid: Int64(getpid()), now: now)
+        let newOwnerPayload = try ACPMessageCodec.encode(.toolCall(.init(
+            toolCallId: "tool-x", title: "Run", kind: "execute",
+            status: "completed", content: "new owner")))
+        try store.updateMessagePayload(id: "msg-\(sid)-0", payload: newOwnerPayload)
+        mock.emitUsageUpdate()
+        try await Task.sleep(nanoseconds: 50_000_000)
+        runner.stop()
+        await mock.finishPrompt()
+        _ = await completed.value
+
+        // Without a base captured under our lease, reading the row now would
+        // pick up the new owner's payload and let the CAS clobber it — so the
+        // row must be skipped entirely.
+        let rows = try store.loadMessages(sessionId: sid)
+        let toolRow = try #require(rows.first(where: { $0.id == "msg-\(sid)-0" }))
+        guard case .toolCall(let persisted) =
+                try ACPMessageCodec.decode(kind: toolRow.kind, payload: toolRow.payload) else {
+            Issue.record("expected persisted tool call")
+            return
+        }
+        #expect(persisted.content == "new owner")
+    }
+
     @Test("stop persists buffered streamed chunks while the lease is still held")
     func stopPersistsBufferedStreamingChunksWhileLeaseHeld() async throws {
         let url = FileManager.default.temporaryDirectory.appendingPathComponent("rn-\(UUID()).sqlite")


### PR DESCRIPTION
Fixes #672.

## Problem

`scheduleStreamingPersist` debounced the SQLite *write*, but
`snapshotStreamingPersistPayloads` ran on **every** streamed chunk
(`agentMessageChunk`/`agentThoughtChunk`/`toolCallUpdate`), and per chunk it did:

- a synchronous `store.loadLease` read on the main actor;
- `ACPMessageCodec.encode` of the **entire accumulated message** — cost grows
  with length, so a long streamed reply is quadratic total encode work;
- once the trailing row was persisted, a synchronous `loadMessagePayload` blob
  read of the growing payload.

A ~200 KB reply in ~2,000 chunks meant thousands of main-actor encodes + blob
reads + lease reads competing directly with typing and scrolling.

## Fix

Per chunk now only records the dirty indices and arms the debounce. The
expensive work moves off the streaming path:

- **Encode once per debounce window** in the flush (`persistIndices`), plus once
  more only if a takeover is detected mid-stream — never per chunk.
- **No per-chunk blob read.** The compare-and-swap base for the stand-down flush
  comes from an in-memory record of what this runner last wrote
  (`lastPersistedPayloads`, bounded to the recent tail), not a growing SQLite
  read. This is also required for correctness: at stand-down time the DB row may
  already hold a *new* writer's data, so the CAS base must be our own last write.
- **Takeover is still detected before a chunk mutates the transcript**
  (a single-row lease read), so the stand-down flush persists the last state
  produced under our lease and never swallows a post-takeover chunk or clobbers
  the new writer's row.

## Testing

- All existing streaming/takeover invariant tests pass unchanged
  (`stop flushes pending streamed chunks during takeover`,
  `takeover flush excludes chunks received after lease loss`,
  `takeover flush does not overwrite rows changed by new writer`,
  `takeover snapshot preserves stored full tool content`).
- Adds `stop persists buffered streamed chunks while the lease is still held`,
  covering the reworked stand-down path that persists the live transcript.
- `xcodebuild ... build` and the `ACPSessionRunnerTests` suite (45 tests) pass.

> Note: two tests in `ACPSessionTests` (`raw output data URI asset survives
> later content update`, `raw output long image URL asset survives later content
> update`) fail on `main` as well and are unrelated to this change (they exercise
> `ACPSession.apply` asset extraction, untouched here).