### PR TITLE
perf(acp): serve agent fs/read off the main actor

### DIFF
--- a/Alas/Sources/ACP/Session/ACPSessionRunner.swift
+++ b/Alas/Sources/ACP/Session/ACPSessionRunner.swift
@@ -260,22 +260,37 @@ final class ACPSessionRunner {
                         // without this an adapter could request any
                         // absolute path (e.g. `~/.ssh/config`) and
                         // exfiltrate it without a permission prompt.
+                        // Cheap pure string work, safe on-main.
                         let target = try writer.resolveInsideWorktree(path: params.path)
                         // Prefer the live editor buffer when the file
                         // is open and dirty so the agent sees what the
                         // user sees (avoids "agent reads stale disk,
                         // then writes a replacement that clobbers
-                        // unsaved edits").
-                        let full: String
-                        if let live = self.onLiveBufferRead?(target.path) {
-                            full = live
-                        } else {
-                            let data = try Data(contentsOf: target)
-                            full = String(data: data, encoding: .utf8) ?? ""
+                        // unsaved edits"). This lookup reads editor
+                        // state, so it MUST stay on the main actor; only
+                        // the resulting snapshot crosses the hop below.
+                        let live = self.onLiveBufferRead?(target.path)
+                        // Disk read + slice + encode run off-main.
+                        let outcome = await Self.serveRead(
+                            target: target, liveBuffer: live,
+                            line: params.line, limit: params.limit
+                        )
+                        // A detach/takeover can cancel this task during the
+                        // off-main read. `return` (not `break`) so we exit the
+                        // whole `filesTask` loop — a bare `break` only leaves
+                        // the `switch` and would let a buffered next request
+                        // (e.g. an outside-worktree read that persists a notice)
+                        // run on a runner that no longer owns the session.
+                        if Task.isCancelled { return }
+                        switch outcome {
+                        case .success(let body):
+                            self.connection.client.respondToFileRequest(id: id, result: .success(body))
+                        case .failure(let message):
+                            self.connection.client.respondToFileRequest(
+                                id: id,
+                                result: .failure(.init(code: -32000, message: message, data: nil))
+                            )
                         }
-                        let sliced = Self.sliceLines(full, line: params.line, limit: params.limit)
-                        let body = try JSONEncoder().encode(ACPFsReadResult(content: sliced))
-                        self.connection.client.respondToFileRequest(id: id, result: .success(body))
                     } catch ACPFileWriter.Error.outsideWorktree(let p) {
                         self.appendAndPersistSystemNotice("Blocked read outside worktree: \(p)")
                         self.connection.client.respondToFileRequest(
@@ -298,6 +313,16 @@ final class ACPSessionRunner {
                     // of a takeover ping, and runner.stop() calls
                     // terminalHost.killAll(), so in-flight terminal commands
                     // are already gated by that path.
+                    //
+                    // Unlike the read path, the write stays fully on the main
+                    // actor. An in-app editor save also runs on the main actor,
+                    // so a synchronous write here cannot run in parallel with —
+                    // and silently clobber — a concurrent save of the same file,
+                    // and the lease check / dirty gate stay atomic with the
+                    // replacement. Hopping the write off-main safely requires
+                    // serializing agent writes against editor saves; that is
+                    // deferred to a follow-up. The unbounded-read hot path
+                    // (`serveRead`) carries the bulk of the main-thread win.
                     guard self.holdsLeaseForWrite() else {
                         self.connection.client.respondToFileRequest(
                             id: id,
@@ -610,7 +635,7 @@ final class ACPSessionRunner {
     /// agents fetch bounded slices of large files instead of always
     /// receiving the whole content (and avoids dumping huge files into
     /// the agent's context window).
-    static func sliceLines(_ full: String, line: Int?, limit: Int?) -> String {
+    nonisolated static func sliceLines(_ full: String, line: Int?, limit: Int?) -> String {
         if line == nil, limit == nil { return full }
         let lines = full.split(separator: "\n", omittingEmptySubsequences: false)
         let startLine = max(1, line ?? 1)
@@ -622,6 +647,44 @@ final class ACPSessionRunner {
             endIdx = lines.count
         }
         return lines[startIdx ..< endIdx].joined(separator: "\n")
+    }
+
+    /// Sendable outcome of an off-main agent `fs/read_text_file`. Kept minimal
+    /// (only value types) so it can cross back to the main actor without an
+    /// `@unchecked Sendable` escape hatch.
+    enum FileReadOutcome: Sendable {
+        case success(Data)
+        case failure(message: String)
+    }
+
+    /// Reads a file from disk (or uses a caller-supplied live-buffer snapshot),
+    /// slices it, and JSON-encodes the `fs/read_text_file` response body.
+    ///
+    /// `nonisolated async` so the disk read + string slicing + encoding run on
+    /// the cooperative pool instead of the main actor — agents read files
+    /// constantly and a large lockfile/asset would otherwise block the UI. The
+    /// live-buffer lookup itself stays on the main actor at the call site; only
+    /// its already-materialized `String` snapshot is passed in here.
+    nonisolated static func serveRead(
+        target: URL,
+        liveBuffer: String?,
+        line: Int?,
+        limit: Int?
+    ) async -> FileReadOutcome {
+        do {
+            let full: String
+            if let liveBuffer {
+                full = liveBuffer
+            } else {
+                let data = try Data(contentsOf: target)
+                full = String(data: data, encoding: .utf8) ?? ""
+            }
+            let sliced = sliceLines(full, line: line, limit: limit)
+            let body = try JSONEncoder().encode(ACPFsReadResult(content: sliced))
+            return .success(body)
+        } catch {
+            return .failure(message: error.localizedDescription)
+        }
     }
 
     /// Called from every "user interrupted" code path (Esc, composer Stop

--- a/AlasTests/ACP/Session/ACPSessionRunnerTests.swift
+++ b/AlasTests/ACP/Session/ACPSessionRunnerTests.swift
@@ -1584,6 +1584,57 @@ struct ACPSessionRunnerTests {
         #expect(ACPSessionRunner.sliceLines(full, line: 4, limit: 99) == "four\nfive")
     }
 
+    @Test("serveRead reads from disk and slices the requested range")
+    func serveReadFromDisk() async throws {
+        let dir = FileManager.default.temporaryDirectory.appendingPathComponent("sr-\(UUID())")
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let file = dir.appendingPathComponent("read.txt")
+        try "one\ntwo\nthree\nfour".write(to: file, atomically: true, encoding: .utf8)
+
+        let outcome = await ACPSessionRunner.serveRead(
+            target: file, liveBuffer: nil, line: 2, limit: 2
+        )
+        guard case .success(let body) = outcome else {
+            Issue.record("expected success outcome")
+            return
+        }
+        let decoded = try JSONDecoder().decode(ACPFsReadResult.self, from: body)
+        #expect(decoded.content == "two\nthree")
+    }
+
+    @Test("serveRead prefers the live buffer snapshot over disk")
+    func serveReadPrefersLiveBuffer() async throws {
+        let dir = FileManager.default.temporaryDirectory.appendingPathComponent("sr-\(UUID())")
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let file = dir.appendingPathComponent("read.txt")
+        try "stale\ndisk".write(to: file, atomically: true, encoding: .utf8)
+
+        let outcome = await ACPSessionRunner.serveRead(
+            target: file, liveBuffer: "fresh\nbuffer", line: nil, limit: nil
+        )
+        guard case .success(let body) = outcome else {
+            Issue.record("expected success outcome")
+            return
+        }
+        let decoded = try JSONDecoder().decode(ACPFsReadResult.self, from: body)
+        #expect(decoded.content == "fresh\nbuffer")
+    }
+
+    @Test("serveRead returns a failure message for a missing file")
+    func serveReadMissingFile() async {
+        let missing = FileManager.default.temporaryDirectory
+            .appendingPathComponent("does-not-exist-\(UUID()).txt")
+        let outcome = await ACPSessionRunner.serveRead(
+            target: missing, liveBuffer: nil, line: nil, limit: nil
+        )
+        guard case .failure = outcome else {
+            Issue.record("expected failure outcome for missing file")
+            return
+        }
+    }
+
     private func makeRunner(
         onUserCancel: (() -> Void)? = nil
     ) throws -> (ACPSessionRunner, ACPMockClient) {


### PR DESCRIPTION
## Summary

Addresses #684 (MAIN-F2 from the 2026-07-10 performance audit). `ACPSessionRunner`'s `filesTask` served every agent `fs/read_text_file` on the main actor — `Data(contentsOf:)` with **no size cap** plus a whole-string `sliceLines` split, once per read. Agents read files constantly, so a large lockfile/asset repeatedly blocked the UI.

## Fix

Hoist the read IO off-main into a `nonisolated async` helper `serveRead(target:liveBuffer:line:limit:)` that returns a small `Sendable` `FileReadOutcome` — mirroring the existing `hydrate` pattern already in this file. The disk read + slice + JSON-encode now run on the cooperative pool.

Only the pieces that must stay on the main actor remain there:
- the worktree containment check (`resolveInsideWorktree`) — cheap, pure string work;
- the `onLiveBufferRead` editor-buffer lookup — reads live editor state; its materialized `String` snapshot is passed into the hop.

On cancellation the handler `return`s to exit the whole `filesTask` loop (not a bare `break`, which would only leave the `switch` and let a buffered next request run on a runner that no longer owns the session). `sliceLines` is now `nonisolated`.

The attachment resource read the audit also mentioned (`embeddedTextResource` via `hydrate`) is already `nonisolated`, so it needed no change.

## Why the write path stays on the main actor

The audit also flagged `fs/write`'s on-main pre-read. I prototyped moving it off-main, but review surfaced that an off-main write runs in **true parallel** with in-app editor saves (which run on the main actor): a user saving a file during a slow agent write could have those bytes silently clobbered with no dirty-buffer notice — a data-loss race the fully-synchronous-on-main write cannot have. Keeping the write on the main actor preserves that serialization (and keeps the lease/dirty gate atomic with the replacement).

Agents overwhelmingly write small source files, where the pre-read is not the bottleneck; the large files that motivate #684 are on the read hot path. **Moving writes off-main safely requires serializing agent writes against editor saves and is left as a focused follow-up.** This PR lands the unbounded-read win, which carries the bulk of the main-thread cost.

## Tests

Added `serveRead` unit tests: disk read + slicing, live-buffer preference over disk, and failure on a missing file. Full `Alas` scheme builds; `ACPSessionRunnerTests` + `ACPFileWriterTests` pass.