### PR TITLE
perf(diff): Optimize diff syntax highlighting

### DIFF
--- a/Alas/Sources/Center/Diff/DiffCodeText.swift
+++ b/Alas/Sources/Center/Diff/DiffCodeText.swift
@@ -40,7 +40,7 @@ struct DiffCodeText: View {
         ))
     }
 
-    static func attributedString(
+    nonisolated static func attributedString(
         text: String,
         fileExtension: String,
         codeFontFamily: String,
@@ -48,7 +48,8 @@ struct DiffCodeText: View {
         showWhitespace: Bool,
         inlineSpans: [DiffInlineSpan],
         inlineTone: DiffInlineTone,
-        theme: Theme
+        theme: Theme,
+        highlightSyntax: Bool = true
     ) -> NSAttributedString {
         let visibleText = visibleWhitespaceText(text, enabled: showWhitespace)
         let output = NSMutableAttributedString(
@@ -57,14 +58,16 @@ struct DiffCodeText: View {
         )
         let visibleLength = (visibleText as NSString).length
 
-        applySyntaxSpans(
-            to: output,
-            text: text,
-            fileExtension: fileExtension,
-            inlineTone: inlineTone,
-            theme: theme,
-            visibleLength: visibleLength
-        )
+        if highlightSyntax {
+            applySyntaxSpans(
+                to: output,
+                spans: TreeSitterHighlighter.tokenize(line: text, fileExtension: fileExtension),
+                offset: 0,
+                inlineTone: inlineTone,
+                theme: theme,
+                visibleLength: visibleLength
+            )
+        }
         applyInlineSpans(
             to: output,
             inlineSpans: inlineSpans,
@@ -76,7 +79,7 @@ struct DiffCodeText: View {
         return output
     }
 
-    private static func baseAttributes(
+    nonisolated private static func baseAttributes(
         codeFontFamily: String,
         codeFontSize: CGFloat,
         theme: Theme
@@ -88,31 +91,33 @@ struct DiffCodeText: View {
         ]
     }
 
-    private static func applySyntaxSpans(
+    nonisolated static func applySyntaxSpans(
         to output: NSMutableAttributedString,
-        text: String,
-        fileExtension: String,
+        spans: [HighlightSpan],
+        offset: Int,
         inlineTone: DiffInlineTone,
         theme: Theme,
         visibleLength: Int
     ) {
-        let spans = TreeSitterHighlighter.tokenize(line: text, fileExtension: fileExtension)
+        let spans = spans
             .filter { isValid($0.range, in: visibleLength) }
             .sorted { $0.range.location < $1.range.location }
 
         var cursor = 0
         for span in spans {
             guard span.range.location >= cursor else { continue }
+            let outputRange = NSRange(location: offset + span.range.location, length: span.range.length)
+            guard isValid(outputRange, in: output.length) else { continue }
             output.addAttribute(
                 .foregroundColor,
                 value: NSColor(syntaxColor(for: span.capture, inlineTone: inlineTone, theme: theme)),
-                range: span.range
+                range: outputRange
             )
             cursor = NSMaxRange(span.range)
         }
     }
 
-    private static func applyInlineSpans(
+    nonisolated private static func applyInlineSpans(
         to output: NSMutableAttributedString,
         inlineSpans: [DiffInlineSpan],
         inlineTone: DiffInlineTone,
@@ -130,11 +135,11 @@ struct DiffCodeText: View {
         }
     }
 
-    private static func isValid(_ range: NSRange, in length: Int) -> Bool {
+    nonisolated private static func isValid(_ range: NSRange, in length: Int) -> Bool {
         range.location >= 0 && range.length >= 0 && NSMaxRange(range) <= length
     }
 
-    private static func inlineColor(for tone: DiffInlineTone, theme: Theme) -> Color {
+    nonisolated private static func inlineColor(for tone: DiffInlineTone, theme: Theme) -> Color {
         switch tone {
         case .add:
             return theme.color("add")
@@ -145,7 +150,7 @@ struct DiffCodeText: View {
         }
     }
 
-    private static func syntaxColor(for capture: HighlightCapture, inlineTone: DiffInlineTone, theme: Theme) -> Color {
+    nonisolated private static func syntaxColor(for capture: HighlightCapture, inlineTone: DiffInlineTone, theme: Theme) -> Color {
         switch capture {
         case .keyword:
             return theme.color("syntax-keyword")
@@ -169,7 +174,7 @@ struct DiffCodeText: View {
         }
     }
 
-    private static func visibleWhitespaceText(_ text: String, enabled: Bool) -> String {
+    nonisolated private static func visibleWhitespaceText(_ text: String, enabled: Bool) -> String {
         guard enabled else { return text }
         return text
             .replacingOccurrences(of: " ", with: "·")

--- a/Alas/Sources/Center/Diff/DiffPaneTextDocumentBuilder.swift
+++ b/Alas/Sources/Center/Diff/DiffPaneTextDocumentBuilder.swift
@@ -8,6 +8,7 @@ struct DiffPaneTextDocumentBuilder {
         var tone: DiffPaneLineTone? = nil
         var sourceLine: DiffDisplayLine? = nil
         var sourceRange: NSRange? = nil
+        var syntaxGroup: Int? = nil
         var expansionKey: DiffContextExpansionKey? = nil
         var expansionBoundary: DiffContextBoundary? = nil
     }
@@ -15,6 +16,13 @@ struct DiffPaneTextDocumentBuilder {
     struct CodeDocument {
         let attributedString: NSAttributedString
         let lines: [LineMetadata]
+        let syntaxSource: String?
+
+        init(attributedString: NSAttributedString, lines: [LineMetadata], syntaxSource: String? = nil) {
+            self.attributedString = attributedString
+            self.lines = lines
+            self.syntaxSource = syntaxSource
+        }
     }
 
     struct SplitResult {
@@ -136,9 +144,17 @@ struct DiffPaneTextDocumentBuilder {
         }
 
         return SplitResult(
-            oldCode: oldColumn.document,
+            oldCode: highlightedCodeDocument(
+                oldColumn.document,
+                fileExtension: fileExtension,
+                theme: theme
+            ),
             oldGutter: oldGutter.attributedString,
-            newCode: newColumn.document,
+            newCode: highlightedCodeDocument(
+                newColumn.document,
+                fileExtension: fileExtension,
+                theme: theme
+            ),
             newGutter: newGutter.attributedString
         )
     }
@@ -223,7 +239,14 @@ struct DiffPaneTextDocumentBuilder {
             }
         }
 
-        return StackedResult(code: codeColumn.document, gutter: gutter.attributedString)
+        return StackedResult(
+            code: highlightedCodeDocument(
+                codeColumn.document,
+                fileExtension: fileExtension,
+                theme: theme
+            ),
+            gutter: gutter.attributedString
+        )
     }
 
     static func build(
@@ -517,8 +540,143 @@ struct DiffPaneTextDocumentBuilder {
             showWhitespace: showWhitespace,
             inlineSpans: line.inlineSpans,
             inlineTone: inlineTone(for: line.kind),
-            theme: theme
+            theme: theme,
+            highlightSyntax: false
         )
+    }
+
+    private static func highlightedCodeDocument(
+        _ document: CodeDocument,
+        fileExtension: String,
+        theme: Theme
+    ) -> CodeDocument {
+        guard let source = document.syntaxSource, !source.isEmpty else {
+            return document
+        }
+
+        let output = NSMutableAttributedString(attributedString: document.attributedString)
+        for segment in syntaxSegments(in: document.lines) {
+            let segmentRange = NSRange(
+                location: segment.start,
+                length: segment.end - segment.start
+            )
+            let segmentSource = (source as NSString).substring(with: segmentRange)
+            let spans = TreeSitterHighlighter.highlight(source: segmentSource, fileExtension: fileExtension)
+                .map {
+                    HighlightSpan(
+                        range: NSRange(location: $0.range.location + segmentRange.location, length: $0.range.length),
+                        capture: $0.capture
+                    )
+                }
+                .sorted { $0.range.location < $1.range.location }
+            applySyntaxSpans(
+                spans,
+                to: output,
+                lines: document.lines,
+                startIndex: segment.startIndex,
+                endIndex: segment.endIndex,
+                theme: theme
+            )
+        }
+
+        return CodeDocument(
+            attributedString: output,
+            lines: document.lines,
+            syntaxSource: source
+        )
+    }
+
+    private static func syntaxSegments(in lines: [LineMetadata]) -> [SyntaxSegment] {
+        var result: [SyntaxSegment] = []
+        var index = 0
+        while index < lines.count {
+            guard let group = lines[index].syntaxGroup,
+                  let range = lines[index].sourceRange else {
+                index += 1
+                continue
+            }
+
+            let startIndex = index
+            var endIndex = index
+            var end = NSMaxRange(range)
+            index += 1
+            while index < lines.count, lines[index].syntaxGroup == group {
+                endIndex = index
+                if let nextRange = lines[index].sourceRange {
+                    end = NSMaxRange(nextRange)
+                } else {
+                    end = NSMaxRange(lines[index].range)
+                }
+                index += 1
+            }
+
+            result.append(SyntaxSegment(
+                start: range.location,
+                end: end,
+                startIndex: startIndex,
+                endIndex: endIndex
+            ))
+        }
+        return result
+    }
+
+    private static func applySyntaxSpans(
+        _ spans: [HighlightSpan],
+        to output: NSMutableAttributedString,
+        lines: [LineMetadata],
+        startIndex: Int,
+        endIndex: Int,
+        theme: Theme
+    ) {
+        var spansByLine = Array(repeating: [HighlightSpan](), count: endIndex - startIndex + 1)
+        var lineIndex = startIndex
+        for span in spans {
+            let spanEnd = NSMaxRange(span.range)
+            while lineIndex <= endIndex {
+                guard let sourceRange = lines[lineIndex].sourceRange else {
+                    lineIndex += 1
+                    continue
+                }
+                if NSMaxRange(sourceRange) > span.range.location {
+                    break
+                }
+                lineIndex += 1
+            }
+
+            var index = lineIndex
+            while index <= endIndex {
+                guard let sourceRange = lines[index].sourceRange else {
+                    index += 1
+                    continue
+                }
+                if sourceRange.location >= spanEnd { break }
+
+                let intersection = NSIntersectionRange(span.range, sourceRange)
+                if intersection.length > 0 {
+                    spansByLine[index - startIndex].append(HighlightSpan(
+                        range: NSRange(
+                            location: intersection.location - sourceRange.location,
+                            length: intersection.length
+                        ),
+                        capture: span.capture
+                    ))
+                }
+                index += 1
+            }
+        }
+
+        for (offset, lineSpans) in spansByLine.enumerated() where !lineSpans.isEmpty {
+            let line = lines[startIndex + offset]
+            guard let sourceRange = line.sourceRange else { continue }
+            DiffCodeText.applySyntaxSpans(
+                to: output,
+                spans: lineSpans,
+                offset: sourceRange.location,
+                inlineTone: inlineTone(for: line.tone ?? .context),
+                theme: theme,
+                visibleLength: sourceRange.length
+            )
+        }
     }
 
     fileprivate static func marker(
@@ -645,6 +803,17 @@ struct DiffPaneTextDocumentBuilder {
         }
     }
 
+    private static func inlineTone(for tone: DiffPaneLineTone) -> DiffInlineTone {
+        switch tone {
+        case .add:
+            return .add
+        case .delete:
+            return .del
+        case .context, .placeholder, .collapsed:
+            return .accent
+        }
+    }
+
     private static func markerColor(for side: DiffLineSide, theme: Theme) -> Color {
         switch side {
         case .old:
@@ -685,8 +854,11 @@ struct DiffPaneTextDocumentBuilder {
 
 private struct ColumnAccumulator {
     private let output = NSMutableAttributedString()
+    private let syntaxSource = NSMutableString()
     private var metadata: [DiffPaneTextDocumentBuilder.LineMetadata] = []
     private let newlineAttributes: [NSAttributedString.Key: Any]
+    private var syntaxGroup = 0
+    private var activeSyntaxSide: DiffLineSide?
 
     init(font: NSFont, theme: Theme) {
         newlineAttributes = [
@@ -699,7 +871,8 @@ private struct ColumnAccumulator {
     var document: DiffPaneTextDocumentBuilder.CodeDocument {
         DiffPaneTextDocumentBuilder.CodeDocument(
             attributedString: output,
-            lines: metadata
+            lines: metadata,
+            syntaxSource: syntaxSource as String
         )
     }
 
@@ -712,19 +885,57 @@ private struct ColumnAccumulator {
     ) {
         if output.length > 0 {
             output.append(NSAttributedString(string: "\n", attributes: newlineAttributes))
+            syntaxSource.append("\n")
         }
         let start = output.length
         output.append(line)
+        let lineSyntaxGroup: Int?
+        if let sourceLine {
+            syntaxSource.append(sourceLine.text)
+            if shouldStartNewSyntaxGroup(for: sourceLine.anchor.side) {
+                syntaxGroup += 1
+            }
+            lineSyntaxGroup = syntaxGroup
+            updateActiveSyntaxSide(with: sourceLine.anchor.side)
+        } else {
+            syntaxSource.append(String(repeating: " ", count: line.length))
+            if kind == .collapsed || kind == .expandableContext {
+                lineSyntaxGroup = nil
+                syntaxGroup += 1
+                activeSyntaxSide = nil
+            } else {
+                lineSyntaxGroup = syntaxGroup
+            }
+        }
         metadata.append(DiffPaneTextDocumentBuilder.LineMetadata(
             kind: kind,
             range: NSRange(location: start, length: line.length),
             tone: tone,
             sourceLine: sourceLine,
             sourceRange: sourceLine.map { _ in NSRange(location: start, length: line.length) },
+            syntaxGroup: lineSyntaxGroup,
             expansionKey: expansion?.key,
             expansionBoundary: expansion?.boundary
         ))
     }
+
+    private func shouldStartNewSyntaxGroup(for side: DiffLineSide) -> Bool {
+        guard let activeSyntaxSide, activeSyntaxSide != side else {
+            return false
+        }
+        return true
+    }
+
+    private mutating func updateActiveSyntaxSide(with side: DiffLineSide) {
+        activeSyntaxSide = side
+    }
+}
+
+private struct SyntaxSegment {
+    let start: Int
+    let end: Int
+    let startIndex: Int
+    let endIndex: Int
 }
 
 private struct GutterAccumulator {

--- a/AlasTests/DiffPaneViewTests.swift
+++ b/AlasTests/DiffPaneViewTests.swift
@@ -1889,6 +1889,186 @@ let second = true
         #expect(rendered.attribute(.backgroundColor, at: 9, effectiveRange: nil) != nil)
     }
 
+    @Test func splitDocumentHighlightsSyntaxAcrossRowsWithOriginalWhitespaceSource() throws {
+        let theme = theme()
+        let diff = ParsedDiff(hunks: [
+            ParsedDiff.Hunk(
+                header: "@@ -1,3 +1,3 @@",
+                oldStart: 1,
+                newStart: 1,
+                lines: [
+                    .init(kind: .context, text: "\t/* start", oldNumber: 1, newNumber: 1),
+                    .init(kind: .context, text: "still comment */", oldNumber: 2, newNumber: 2),
+                    .init(kind: .context, text: "let value = 1", oldNumber: 3, newNumber: 3),
+                ]
+            ),
+        ])
+        let model = DiffDisplayModelBuilder.build(diff: diff, filePath: "Sources/App.swift")
+        let result = DiffPaneTextDocumentBuilder.buildSplit(
+            group: try #require(model.groups.first),
+            expandedCollapsedRowIDs: [],
+            fileExtension: "swift",
+            font: CenterTypography.resolveCodeFont(family: "", size: 13),
+            showWhitespace: true,
+            theme: theme
+        )
+        let rendered = result.newCode.attributedString.string as NSString
+        let commentStart = rendered.range(of: "still comment").location
+        let foreground = try #require(result.newCode.attributedString.attribute(
+            .foregroundColor,
+            at: commentStart,
+            effectiveRange: nil
+        ) as? NSColor)
+
+        #expect(result.newCode.syntaxSource == "\t/* start\nstill comment */\nlet value = 1")
+        #expect(rendered.hasPrefix("→/*·start"))
+        #expect(colorComponents(foreground).isClose(to: colorComponents(NSColor(theme.color("fg-faint")))))
+    }
+
+    @Test func stackedDocumentDoesNotCarrySyntaxFromDeletedLinesIntoAddedLines() throws {
+        let theme = theme()
+        let diff = ParsedDiff(hunks: [
+            ParsedDiff.Hunk(
+                header: "@@ -1,1 +1,1 @@",
+                oldStart: 1,
+                newStart: 1,
+                lines: [
+                    .init(kind: .delete, text: "/* deleted starts", oldNumber: 1, newNumber: nil),
+                    .init(kind: .add, text: "let value = 1", oldNumber: nil, newNumber: 1),
+                ]
+            ),
+        ])
+        let model = DiffDisplayModelBuilder.build(diff: diff, filePath: "Sources/App.swift")
+        let result = DiffPaneTextDocumentBuilder.buildStacked(
+            group: try #require(model.groups.first),
+            expandedCollapsedRowIDs: [],
+            fileExtension: "swift",
+            font: CenterTypography.resolveCodeFont(family: "", size: 13),
+            showWhitespace: false,
+            theme: theme
+        )
+        let rendered = result.code.attributedString.string as NSString
+        let addedStart = rendered.range(of: "let value").location
+        let foreground = try #require(result.code.attributedString.attribute(
+            .foregroundColor,
+            at: addedStart,
+            effectiveRange: nil
+        ) as? NSColor)
+
+        #expect(colorComponents(foreground).isClose(to: colorComponents(NSColor(theme.color("syntax-keyword")))))
+    }
+
+    @Test func stackedDocumentDoesNotCarrySyntaxFromDeletedLinesIntoFollowingContext() throws {
+        let theme = theme()
+        let diff = ParsedDiff(hunks: [
+            ParsedDiff.Hunk(
+                header: "@@ -1,2 +1,1 @@",
+                oldStart: 1,
+                newStart: 1,
+                lines: [
+                    .init(kind: .delete, text: "/* deleted starts", oldNumber: 1, newNumber: nil),
+                    .init(kind: .context, text: "let value = 1", oldNumber: 2, newNumber: 1),
+                ]
+            ),
+        ])
+        let model = DiffDisplayModelBuilder.build(diff: diff, filePath: "Sources/App.swift")
+        let result = DiffPaneTextDocumentBuilder.buildStacked(
+            group: try #require(model.groups.first),
+            expandedCollapsedRowIDs: [],
+            fileExtension: "swift",
+            font: CenterTypography.resolveCodeFont(family: "", size: 13),
+            showWhitespace: false,
+            theme: theme
+        )
+        let rendered = result.code.attributedString.string as NSString
+        let contextStart = rendered.range(of: "let value").location
+        let foreground = try #require(result.code.attributedString.attribute(
+            .foregroundColor,
+            at: contextStart,
+            effectiveRange: nil
+        ) as? NSColor)
+
+        #expect(colorComponents(foreground).isClose(to: colorComponents(NSColor(theme.color("syntax-keyword")))))
+    }
+
+    @Test func splitDocumentDoesNotCarrySyntaxAcrossCollapsedRows() throws {
+        let theme = theme()
+        let rows = [
+            DiffDisplayRow(
+                id: "context-open",
+                kind: .context,
+                old: diffLine(id: "old-open", side: .paired, oldLine: 1, newLine: 1, text: "/* open"),
+                new: diffLine(id: "new-open", side: .paired, oldLine: 1, newLine: 1, text: "/* open"),
+                collapsedLineCount: 0
+            ),
+            DiffDisplayRow(
+                id: "collapsed",
+                kind: .collapsed,
+                old: nil,
+                new: nil,
+                collapsedLineCount: 8
+            ),
+            DiffDisplayRow(
+                id: "context-after",
+                kind: .context,
+                old: diffLine(id: "old-after", side: .paired, oldLine: 10, newLine: 10, text: "let value = 1"),
+                new: diffLine(id: "new-after", side: .paired, oldLine: 10, newLine: 10, text: "let value = 1"),
+                collapsedLineCount: 0
+            ),
+        ]
+
+        let result = DiffPaneTextDocumentBuilder.buildSplit(
+            rows: rows,
+            fileExtension: "swift",
+            font: CenterTypography.resolveCodeFont(family: "", size: 13),
+            showWhitespace: false,
+            theme: theme
+        )
+        let rendered = result.newCode.attributedString.string as NSString
+        let afterStart = rendered.range(of: "let value").location
+        let foreground = try #require(result.newCode.attributedString.attribute(
+            .foregroundColor,
+            at: afterStart,
+            effectiveRange: nil
+        ) as? NSColor)
+
+        #expect(colorComponents(foreground).isClose(to: colorComponents(NSColor(theme.color("syntax-keyword")))))
+    }
+
+    @Test func splitDocumentCarriesSyntaxAcrossAlignmentPlaceholders() throws {
+        let theme = theme()
+        let diff = ParsedDiff(hunks: [
+            ParsedDiff.Hunk(
+                header: "@@ -1,2 +1,3 @@",
+                oldStart: 1,
+                newStart: 1,
+                lines: [
+                    .init(kind: .context, text: "/* open", oldNumber: 1, newNumber: 1),
+                    .init(kind: .add, text: "let inserted = 1", oldNumber: nil, newNumber: 2),
+                    .init(kind: .context, text: "still comment */", oldNumber: 2, newNumber: 3),
+                ]
+            ),
+        ])
+        let model = DiffDisplayModelBuilder.build(diff: diff, filePath: "Sources/App.swift")
+        let result = DiffPaneTextDocumentBuilder.buildSplit(
+            group: try #require(model.groups.first),
+            expandedCollapsedRowIDs: [],
+            fileExtension: "swift",
+            font: CenterTypography.resolveCodeFont(family: "", size: 13),
+            showWhitespace: false,
+            theme: theme
+        )
+        let rendered = result.oldCode.attributedString.string as NSString
+        let commentStart = rendered.range(of: "still comment").location
+        let foreground = try #require(result.oldCode.attributedString.attribute(
+            .foregroundColor,
+            at: commentStart,
+            effectiveRange: nil
+        ) as? NSColor)
+
+        #expect(colorComponents(foreground).isClose(to: colorComponents(NSColor(theme.color("fg-faint")))))
+    }
+
     @Test func stackedProjectionRendersContextRowsOnce() throws {
         let row = try #require(model().groups[0].rows.first)
         #expect(row.kind == .context)
@@ -2478,6 +2658,30 @@ let second = true
 
     private func allSubviews(of view: NSView) -> [NSView] {
         view.subviews + view.subviews.flatMap { allSubviews(of: $0) }
+    }
+
+    private struct ColorComponents {
+        let red: Double
+        let green: Double
+        let blue: Double
+        let alpha: Double
+
+        func isClose(to other: ColorComponents, tolerance: Double = 0.001) -> Bool {
+            abs(red - other.red) <= tolerance
+                && abs(green - other.green) <= tolerance
+                && abs(blue - other.blue) <= tolerance
+                && abs(alpha - other.alpha) <= tolerance
+        }
+    }
+
+    private func colorComponents(_ color: NSColor) -> ColorComponents {
+        let normalized = color.usingColorSpace(.sRGB) ?? color
+        return ColorComponents(
+            red: Double(normalized.redComponent),
+            green: Double(normalized.greenComponent),
+            blue: Double(normalized.blueComponent),
+            alpha: Double(normalized.alphaComponent)
+        )
     }
 
     private final class ConstraintInvalidationCountingView: NSView {


### PR DESCRIPTION
## Summary
- Parse rendered diff code in syntax segments instead of tokenizing every diff row independently.
- Keep per-row inline diff backgrounds and LSP source ranges intact by applying segment syntax spans back through line metadata.
- Break syntax segments across collapsed/expandable gaps and rendered side transitions in stacked mode so syntax state does not leak between code that does not coexist.
- Preserve syntax state across split-view alignment placeholders, which are not real source gaps.
- Add regression coverage for cross-row Swift block comments, visible-whitespace source offset preservation, stacked old/new boundaries, stacked context after deletions, split placeholders, and collapsed context gaps.

## Root cause
Diff document construction called `TreeSitterHighlighter.tokenize(line:fileExtension:)` for every rendered diff line. Split view doubled that work across old/new columns and repeated it synchronously during `NSViewRepresentable` updates.

## Validation
- `rtk xcodegen`
- `ALAS_FFF_TARGET_ARCH=arm64 rtk xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -quiet build`
- `ALAS_FFF_TARGET_ARCH=arm64 rtk xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -only-testing:AlasTests/DiffPaneViewTests/splitDocumentHighlightsSyntaxAcrossRowsWithOriginalWhitespaceSource -only-testing:AlasTests/DiffPaneViewTests/stackedDocumentDoesNotCarrySyntaxFromDeletedLinesIntoAddedLines -only-testing:AlasTests/DiffPaneViewTests/stackedDocumentDoesNotCarrySyntaxFromDeletedLinesIntoFollowingContext -only-testing:AlasTests/DiffPaneViewTests/splitDocumentDoesNotCarrySyntaxAcrossCollapsedRows -only-testing:AlasTests/DiffPaneViewTests/splitDocumentCarriesSyntaxAcrossAlignmentPlaceholders -only-testing:AlasTests/DiffPaneViewTests/visibleWhitespacePreservesInlineBackgrounds -only-testing:AlasTests/DiffPaneLSPLineMapTests -only-testing:AlasTests/DiffSelectableTextTests/diffCodeTextUsesReadableCommentColorOnChangedRows test`

Fixes #675