### PR TITLE
perf(diff): precompute display digests to keep review body O(1)

### DIFF
--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -683,6 +683,7 @@
 		9A3EB3ACA3AB366431C904EB /* WorktreeService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6C4E238E48247A6CDD5565D2 /* WorktreeService.swift */; };
 		9AB33F6B645EBA3F92A4E40F /* ACPSessionUpdate.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD1F34E025D235A5CECCE36E /* ACPSessionUpdate.swift */; };
 		9AC7E08307DA010181E2DE58 /* ACPFirstRunConnectingPolicy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B4BB6C10F3718F7D0A50BAE /* ACPFirstRunConnectingPolicy.swift */; };
+		9B00878F781FADB428684B2D /* DiffDisplaySignatureTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 283613E170E25F69521F64ED /* DiffDisplaySignatureTests.swift */; };
 		9B2B055195430A5A40BC7659 /* TreeSitterJSON in Frameworks */ = {isa = PBXBuildFile; productRef = 5130D28B6980AF12D2256A6D /* TreeSitterJSON */; };
 		9B51DB62236B865AB86AA0F1 /* TreeSitterTypeScript in Frameworks */ = {isa = PBXBuildFile; productRef = 1F70A188A5F7992AC8C8717E /* TreeSitterTypeScript */; };
 		9B6940D68B098D1F1305324B /* GitTypesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 271F79A165CAA8617C1EAA4E /* GitTypesTests.swift */; };
@@ -1329,6 +1330,7 @@
 		27A92711BC1D9A78D8A80561 /* GitTypes.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GitTypes.swift; sourceTree = "<group>"; };
 		27E7E4823B42BBA6EA7610DB /* CommitFilesListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommitFilesListView.swift; sourceTree = "<group>"; };
 		27EEC16C786CE9430C1AC174 /* DiffReviewFileSectionEqualityTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiffReviewFileSectionEqualityTests.swift; sourceTree = "<group>"; };
+		283613E170E25F69521F64ED /* DiffDisplaySignatureTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiffDisplaySignatureTests.swift; sourceTree = "<group>"; };
 		28777B087266D8AE174BA233 /* SpaceEmojiPickerSelectionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpaceEmojiPickerSelectionTests.swift; sourceTree = "<group>"; };
 		292B5DA9EC17ED07588C48FD /* OpenCodeInstallerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OpenCodeInstallerTests.swift; sourceTree = "<group>"; };
 		29313DDC46A0CCA2FA42CDE9 /* Icon.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Icon.swift; sourceTree = "<group>"; };
@@ -2528,6 +2530,7 @@
 				40497B428C9395535DF6C146 /* DialogChromeLayoutTests.swift */,
 				2B9CB2A64E9E16A2DE3A6272 /* DiffContextExpansionTests.swift */,
 				6181842BEA798CB8606F222B /* DiffDisplayModelBuilderTests.swift */,
+				283613E170E25F69521F64ED /* DiffDisplaySignatureTests.swift */,
 				729DDA22CA94FA0DC8810057 /* DiffInlineCommentModelTests.swift */,
 				61D4F5B30CE2AA0220A3E45C /* DiffInlineHighlighterTests.swift */,
 				2BFCE07604D55558B13FC33B /* DiffOpenFileAvailabilityTests.swift */,
@@ -5382,6 +5385,7 @@
 				E3217588485CC96AB05AA5B9 /* DialogChromeLayoutTests.swift in Sources */,
 				9DDA9F2462746F06A652973A /* DiffContextExpansionTests.swift in Sources */,
 				899FB89D155619CF846C6BDC /* DiffDisplayModelBuilderTests.swift in Sources */,
+				9B00878F781FADB428684B2D /* DiffDisplaySignatureTests.swift in Sources */,
 				FD5B6E7F566A9D0BACD19267 /* DiffInlineCommentModelTests.swift in Sources */,
 				172298A09BC94456A27EFCB7 /* DiffInlineHighlighterTests.swift in Sources */,
 				9927E3934D3CAA9055EF5E44 /* DiffOpenFileAvailabilityTests.swift in Sources */,

--- a/Alas/Sources/Center/Diff/DiffDisplayModel.swift
+++ b/Alas/Sources/Center/Diff/DiffDisplayModel.swift
@@ -97,7 +97,7 @@ struct DiffContextExpansionRow: Codable, Equatable, Hashable, Sendable {
 }
 
 struct DiffDisplayRow: Identifiable, Equatable {
-    enum Kind: Equatable {
+    enum Kind: Equatable, Hashable {
         case context
         case add
         case delete
@@ -139,9 +139,148 @@ struct DiffDisplayGroup: Identifiable, Equatable {
     let header: String
     let sourceHunk: ParsedDiff.Hunk
     let rows: [DiffDisplayRow]
+
+    /// Full-fidelity content fingerprint (row/line identity, text, kinds,
+    /// inline spans, collapse structure). Precomputed once at build time and
+    /// read in O(1) so the render-context cache key never has to walk every
+    /// row on each SwiftUI body pass.
+    let contentHash: Int
+    /// Coarse structural fingerprint (row identity + line numbers + collapse
+    /// counts). Used for `.onChange` state-reset signals that only care about
+    /// structural changes, not pure text edits.
+    let structuralHash: Int
+    /// Extent of the old/new side of the source hunk. Precomputed to avoid an
+    /// O(hunk-lines) reduce every time a context-expansion signature is built.
+    let oldSideExtent: DiffHunkSideExtent
+    let newSideExtent: DiffHunkSideExtent
+
+    init(id: String, header: String, sourceHunk: ParsedDiff.Hunk, rows: [DiffDisplayRow]) {
+        self.id = id
+        self.header = header
+        self.sourceHunk = sourceHunk
+        self.rows = rows
+
+        var content = Hasher()
+        content.combine(id)
+        content.combine(header)
+        for row in rows {
+            DiffDisplaySignatureBuilder.combineContent(row, into: &content)
+        }
+        contentHash = content.finalize()
+
+        var structural = Hasher()
+        structural.combine(id)
+        for row in rows {
+            structural.combine(row.id)
+            structural.combine(row.old?.lineNumber)
+            structural.combine(row.new?.lineNumber)
+            structural.combine(row.collapsedRows.count)
+        }
+        structuralHash = structural.finalize()
+
+        oldSideExtent = DiffDisplaySignatureBuilder.sideExtent(of: sourceHunk, side: .old)
+        newSideExtent = DiffDisplaySignatureBuilder.sideExtent(of: sourceHunk, side: .new)
+    }
 }
 
 struct DiffDisplayModel: Equatable {
     let filePath: String
     let groups: [DiffDisplayGroup]
+
+    /// Full-fidelity fingerprint over `filePath` + every group's `contentHash`.
+    /// Keys the render-context cache without re-hashing all rows per body pass.
+    let contentHash: Int
+    /// Coarse structural fingerprint over every group's `structuralHash`.
+    let structuralHash: Int
+
+    init(filePath: String, groups: [DiffDisplayGroup]) {
+        self.filePath = filePath
+        self.groups = groups
+
+        var content = Hasher()
+        content.combine(filePath)
+        for group in groups {
+            content.combine(group.contentHash)
+        }
+        contentHash = content.finalize()
+
+        var structural = Hasher()
+        for group in groups {
+            structural.combine(group.structuralHash)
+        }
+        structuralHash = structural.finalize()
+    }
+}
+
+/// Line-count extent of one side (old or new) of a diff hunk.
+struct DiffHunkSideExtent: Equatable {
+    let start: Int
+    let count: Int
+
+    var lineBefore: Int {
+        count > 0 ? start - 1 : start
+    }
+
+    var lineAfter: Int {
+        start + max(count, 1)
+    }
+}
+
+/// Builds the precomputed fingerprints and hunk extents stored on
+/// `DiffDisplayGroup`/`DiffDisplayModel`. Kept in one place so the fidelity of
+/// the content hash mirrors the render-context cache key exactly.
+enum DiffDisplaySignatureBuilder {
+    static func combineContent(_ row: DiffDisplayRow, into hasher: inout Hasher) {
+        hasher.combine(row.id)
+        hasher.combine(row.kind)
+        combineContent(row.old, into: &hasher)
+        combineContent(row.new, into: &hasher)
+        hasher.combine(row.collapsedLineCount)
+        hasher.combine(row.collapsedRows.count)
+        for collapsed in row.collapsedRows {
+            combineContent(collapsed, into: &hasher)
+        }
+        if let expansion = row.contextExpansion {
+            hasher.combine(true)
+            hasher.combine(expansion.key.groupID)
+            hasher.combine(expansion.boundary)
+            hasher.combine(expansion.remainingLineCount)
+        } else {
+            hasher.combine(false)
+        }
+    }
+
+    private static func combineContent(_ line: DiffDisplayLine?, into hasher: inout Hasher) {
+        guard let line else {
+            hasher.combine(UInt8(0))
+            return
+        }
+        hasher.combine(UInt8(1))
+        hasher.combine(line.id)
+        hasher.combine(line.anchor.side)
+        hasher.combine(line.anchor.oldLine)
+        hasher.combine(line.anchor.newLine)
+        hasher.combine(line.text)
+        hasher.combine(line.lineNumber)
+        hasher.combine(line.kind)
+        hasher.combine(line.inlineSpans)
+        hasher.combine(line.noTrailingNewline)
+    }
+
+    static func sideExtent(of hunk: ParsedDiff.Hunk, side: DiffLineSide) -> DiffHunkSideExtent {
+        let start = side == .old ? hunk.oldStart : hunk.newStart
+        let count = hunk.lines.reduce(0) { partial, line in
+            partial + (lineConsumes(line, side: side) ? 1 : 0)
+        }
+        return DiffHunkSideExtent(start: start, count: count)
+    }
+
+    private static func lineConsumes(_ line: ParsedDiff.Hunk.Line, side: DiffLineSide) -> Bool {
+        switch (line.kind, side) {
+        case (.context, .old), (.context, .new), (.delete, .old), (.add, .new):
+            return true
+        case (_, .paired), (.add, .old), (.delete, .new):
+            return false
+        }
+    }
 }

--- a/Alas/Sources/Center/DiffReview/DiffReviewFileSection.swift
+++ b/Alas/Sources/Center/DiffReview/DiffReviewFileSection.swift
@@ -6,6 +6,22 @@ private struct PendingContextExpansion {
     let mode: DiffContextExpansionMode
 }
 
+/// O(1) signal that clears a pending draft when the file's structural layout
+/// changes. `structuralHash` is `nil` while the display model is still a
+/// placeholder. Backed by the digest precomputed on `DiffDisplayModel`.
+struct DiffReviewDraftCommentDisplaySignature: Equatable {
+    let fileID: String
+    let structuralHash: Int?
+}
+
+/// O(1) signal that resets loaded context state when the file, its context
+/// provider, or its structural layout changes.
+struct DiffReviewContextStateSignature: Equatable {
+    let fileID: String
+    let providerID: String
+    let structuralHash: Int?
+}
+
 enum DiffReviewActiveCommentCandidate: Equatable {
     case draft(String)
     case inlineFeedback(String)
@@ -77,7 +93,7 @@ struct DiffReviewFileSection: View {
     @State private var contextExpansion = DiffContextExpansionState()
     @State private var contextLoadTask: Task<Void, Never>?
     @State private var contextLoadFileID: DiffReviewFileID?
-    @State private var contextLoadSignature: String?
+    @State private var contextLoadSignature: DiffReviewContextStateSignature?
     @State private var contextLoadGeneration = 0
     @State private var contextLoadError: String?
     @State private var pendingContextExpansions: [PendingContextExpansion] = []
@@ -732,31 +748,26 @@ struct DiffReviewFileSection: View {
         return Set(groups.flatMap(ReviewDraftCommentPlacement.allRowKeys))
     }
 
-    private var displayGroupSignature: String {
-        let groupSignature = file.displayModel?.groups.map { group in
-            let rowSignature = group.rows.map { row in
-                [
-                    row.id,
-                    row.old?.lineNumber.map { "o\($0)" } ?? "o-",
-                    row.new?.lineNumber.map { "n\($0)" } ?? "n-",
-                    "\(row.collapsedRows.count)",
-                ].joined(separator: ":")
-            }.joined(separator: ",")
-            return "\(group.id)[\(rowSignature)]"
-        }.joined(separator: "|") ?? "placeholder"
-        return groupSignature
+    /// Coarse structural fingerprint of the current display model, read in O(1)
+    /// from the digest precomputed at model-build time. `.onChange` re-evaluates
+    /// its value on every body pass, so this must never walk the rows.
+    private var displayStructuralHash: Int? {
+        file.displayModel?.structuralHash
     }
 
-    private var draftCommentDisplaySignature: String {
-        "\(file.id.rawValue)|\(displayGroupSignature)"
+    private var draftCommentDisplaySignature: DiffReviewDraftCommentDisplaySignature {
+        DiffReviewDraftCommentDisplaySignature(
+            fileID: file.id.rawValue,
+            structuralHash: displayStructuralHash
+        )
     }
 
-    private var contextStateSignature: String {
-        [
-            file.id.rawValue,
-            file.contextProvider?.id.uuidString ?? "no-context-provider",
-            displayGroupSignature,
-        ].joined(separator: "|")
+    private var contextStateSignature: DiffReviewContextStateSignature {
+        DiffReviewContextStateSignature(
+            fileID: file.id.rawValue,
+            providerID: file.contextProvider?.id.uuidString ?? "no-context-provider",
+            structuralHash: displayStructuralHash
+        )
     }
 
     private func loadContextAndExpand(_ key: DiffContextExpansionKey, mode: DiffContextExpansionMode) {

--- a/Alas/Sources/Center/DiffReview/DiffReviewRenderContext.swift
+++ b/Alas/Sources/Center/DiffReview/DiffReviewRenderContext.swift
@@ -3,7 +3,7 @@ import Foundation
 
 struct DiffReviewRenderContextKey: Hashable {
     private let fileID: String
-    private let displayModel: DisplayModelSignature
+    private let displayContentHash: Int
     private let providerAvailable: Bool
     private let contextExpansion: ContextExpansionStateSignature
     private let inlineFeedback: [InlineFeedbackSignature]
@@ -27,7 +27,7 @@ struct DiffReviewRenderContextKey: Hashable {
         annotations: [DiffInlineAnnotation]
     ) {
         self.fileID = fileID.rawValue
-        self.displayModel = DisplayModelSignature(filePath: displayModel.filePath, groups: displayModel.groups)
+        self.displayContentHash = displayModel.contentHash
         self.providerAvailable = contextProviderAvailable
         self.contextExpansion = ContextExpansionStateSignature(
             groups: displayModel.groups,
@@ -212,84 +212,6 @@ final class DiffReviewRenderContextCache: ObservableObject {
     }
 }
 
-private struct DisplayModelSignature: Hashable {
-    let filePath: String
-    let groups: [GroupSignature]
-
-    init(filePath: String, groups: [DiffDisplayGroup]) {
-        self.filePath = filePath
-        self.groups = groups.map(GroupSignature.init)
-    }
-}
-
-private struct GroupSignature: Hashable {
-    let id: String
-    let header: String
-    let rows: [RowSignature]
-
-    init(_ group: DiffDisplayGroup) {
-        id = group.id
-        header = group.header
-        rows = group.rows.map(RowSignature.init)
-    }
-}
-
-private struct RowSignature: Hashable {
-    let id: String
-    let kind: String
-    let old: LineSignature?
-    let new: LineSignature?
-    let collapsedLineCount: Int
-    let collapsedRows: [RowSignature]
-    let contextExpansion: ContextExpansionSignature?
-
-    init(_ row: DiffDisplayRow) {
-        id = row.id
-        kind = String(describing: row.kind)
-        old = row.old.map(LineSignature.init)
-        new = row.new.map(LineSignature.init)
-        collapsedLineCount = row.collapsedLineCount
-        collapsedRows = row.collapsedRows.map(RowSignature.init)
-        contextExpansion = row.contextExpansion.map(ContextExpansionSignature.init)
-    }
-}
-
-private struct LineSignature: Hashable {
-    let id: String
-    let side: Int
-    let oldLine: Int?
-    let newLine: Int?
-    let textHash: Int
-    let lineNumber: Int?
-    let kind: String
-    let inlineSpansHash: Int
-    let noTrailingNewline: Bool
-
-    init(_ line: DiffDisplayLine) {
-        id = line.id
-        side = line.anchor.side.rawValue
-        oldLine = line.anchor.oldLine
-        newLine = line.anchor.newLine
-        textHash = line.text.hashValue
-        lineNumber = line.lineNumber
-        kind = String(describing: line.kind)
-        inlineSpansHash = line.inlineSpans.hashValue
-        noTrailingNewline = line.noTrailingNewline
-    }
-}
-
-private struct ContextExpansionSignature: Hashable {
-    let groupID: String
-    let boundary: String
-    let remainingLineCount: Int
-
-    init(_ expansion: DiffContextExpansionRow) {
-        groupID = expansion.key.groupID
-        boundary = expansion.boundary.rawValue
-        remainingLineCount = expansion.remainingLineCount
-    }
-}
-
 private struct ContextExpansionStateSignature: Hashable {
     let snapshot: SnapshotSignature
     let boundaries: [BoundarySignature]
@@ -420,12 +342,12 @@ private struct BoundaryRange {
 
         let previous = groupIndex > 0 ? groups[groupIndex - 1] : nil
         let next = groupIndex + 1 < groups.count ? groups[groupIndex + 1] : nil
-        let currentOld = Self.hunkSideExtent(in: group, side: .old)
-        let currentNew = Self.hunkSideExtent(in: group, side: .new)
-        let previousOld = previous.map { Self.hunkSideExtent(in: $0, side: .old) }
-        let previousNew = previous.map { Self.hunkSideExtent(in: $0, side: .new) }
-        let nextOld = next.map { Self.hunkSideExtent(in: $0, side: .old) }
-        let nextNew = next.map { Self.hunkSideExtent(in: $0, side: .new) }
+        let currentOld = group.oldSideExtent
+        let currentNew = group.newSideExtent
+        let previousOld = previous?.oldSideExtent
+        let previousNew = previous?.newSideExtent
+        let nextOld = next?.oldSideExtent
+        let nextNew = next?.newSideExtent
 
         switch boundary {
         case .above:
@@ -512,23 +434,6 @@ private struct BoundaryRange {
         return clampedEnd - clampedStart + 1
     }
 
-    private static func hunkSideExtent(in group: DiffDisplayGroup, side: DiffLineSide) -> HunkSideExtent {
-        let start = side == .old ? group.sourceHunk.oldStart : group.sourceHunk.newStart
-        let count = group.sourceHunk.lines.reduce(0) { partial, line in
-            partial + (lineConsumes(line, side: side) ? 1 : 0)
-        }
-        return HunkSideExtent(start: start, count: count)
-    }
-
-    private static func lineConsumes(_ line: ParsedDiff.Hunk.Line, side: DiffLineSide) -> Bool {
-        switch (line.kind, side) {
-        case (.context, .old), (.context, .new), (.delete, .old), (.add, .new):
-            return true
-        case (_, .paired), (.add, .old), (.delete, .new):
-            return false
-        }
-    }
-
     private static func lineNumber(
         start: Int?,
         count: Int,
@@ -547,19 +452,6 @@ private struct BoundaryRange {
             guard offset < count else { return nil }
             return start + offset
         }
-    }
-}
-
-private struct HunkSideExtent {
-    let start: Int
-    let count: Int
-
-    var lineBefore: Int {
-        count > 0 ? start - 1 : start
-    }
-
-    var lineAfter: Int {
-        start + max(count, 1)
     }
 }
 

--- a/AlasTests/DiffDisplaySignatureTests.swift
+++ b/AlasTests/DiffDisplaySignatureTests.swift
@@ -1,0 +1,137 @@
+import Testing
+@testable import Alas
+
+struct DiffDisplaySignatureTests {
+    private func hunk(
+        header: String = "@@ -4,3 +4,3 @@",
+        oldStart: Int = 4,
+        newStart: Int = 4,
+        lines: [ParsedDiff.Hunk.Line]
+    ) -> ParsedDiff.Hunk {
+        ParsedDiff.Hunk(header: header, oldStart: oldStart, newStart: newStart, lines: lines)
+    }
+
+    private func sampleLines() -> [ParsedDiff.Hunk.Line] {
+        [
+            .init(kind: .context, text: "old/new 4", oldNumber: 4, newNumber: 4),
+            .init(kind: .delete, text: "old 5", oldNumber: 5, newNumber: nil),
+            .init(kind: .add, text: "new 5", oldNumber: nil, newNumber: 5),
+            .init(kind: .context, text: "old/new 6", oldNumber: 6, newNumber: 6),
+        ]
+    }
+
+    private func model(lines: [ParsedDiff.Hunk.Line]) -> DiffDisplayModel {
+        DiffDisplayModelBuilder.build(diff: ParsedDiff(hunks: [hunk(lines: lines)]), filePath: "a.swift")
+    }
+
+    // MARK: - contentHash
+
+    @Test func contentHashEqualForIdenticalModels() {
+        #expect(model(lines: sampleLines()).contentHash == model(lines: sampleLines()).contentHash)
+    }
+
+    @Test func contentHashDiffersWhenLineTextChanges() {
+        var changed = sampleLines()
+        changed[0] = .init(kind: .context, text: "old/new 4 EDITED", oldNumber: 4, newNumber: 4)
+        #expect(model(lines: sampleLines()).contentHash != model(lines: changed).contentHash)
+    }
+
+    @Test func contentHashDiffersWhenFilePathChanges() {
+        let a = DiffDisplayModelBuilder.build(diff: ParsedDiff(hunks: [hunk(lines: sampleLines())]), filePath: "a.swift")
+        let b = DiffDisplayModelBuilder.build(diff: ParsedDiff(hunks: [hunk(lines: sampleLines())]), filePath: "b.swift")
+        #expect(a.contentHash != b.contentHash)
+    }
+
+    // MARK: - structuralHash
+
+    @Test func structuralHashEqualForIdenticalModels() {
+        #expect(model(lines: sampleLines()).structuralHash == model(lines: sampleLines()).structuralHash)
+    }
+
+    @Test func structuralHashIgnoresPureTextEdits() {
+        // A text-only edit that keeps line numbers/row structure must not change
+        // the structural fingerprint used for state-reset .onChange signals.
+        var changed = sampleLines()
+        changed[0] = .init(kind: .context, text: "old/new 4 EDITED", oldNumber: 4, newNumber: 4)
+        #expect(model(lines: sampleLines()).structuralHash == model(lines: changed).structuralHash)
+    }
+
+    @Test func structuralHashDiffersWhenLineNumbersChange() {
+        var changed = sampleLines()
+        changed[0] = .init(kind: .context, text: "old/new 4", oldNumber: 40, newNumber: 40)
+        #expect(model(lines: sampleLines()).structuralHash != model(lines: changed).structuralHash)
+    }
+
+    // MARK: - precomputed side extents
+
+    @Test func precomputedSideExtentsMatchConsumedLines() {
+        let group = model(lines: sampleLines()).groups[0]
+        // old side: context(4) + delete(5) + context(6) = 3 lines starting at 4.
+        #expect(group.oldSideExtent.start == 4)
+        #expect(group.oldSideExtent.count == 3)
+        #expect(group.oldSideExtent.lineBefore == 3)
+        #expect(group.oldSideExtent.lineAfter == 7)
+        // new side: context(4) + add(5) + context(6) = 3 lines starting at 4.
+        #expect(group.newSideExtent.start == 4)
+        #expect(group.newSideExtent.count == 3)
+    }
+
+    @Test func precomputedSideExtentsHandleEmptySide() {
+        let deletionOnly = model(lines: [
+            .init(kind: .delete, text: "gone", oldNumber: 5, newNumber: nil),
+        ])
+        let group = deletionOnly.groups[0]
+        #expect(group.newSideExtent.count == 0)
+        // With no consumed lines, lineBefore/lineAfter fall back to the start.
+        #expect(group.newSideExtent.lineBefore == group.newSideExtent.start)
+        #expect(group.newSideExtent.lineAfter == group.newSideExtent.start + 1)
+    }
+
+    // MARK: - render context key keys on content hash
+
+    @Test func renderContextKeyEqualForIdenticalModels() {
+        let a = model(lines: sampleLines())
+        let b = model(lines: sampleLines())
+        let fileID = DiffReviewFileID(namespace: "commit", path: "a.swift")
+        func key(_ m: DiffDisplayModel) -> DiffReviewRenderContextKey {
+            DiffReviewRenderContextKey(
+                fileID: fileID,
+                displayModel: m,
+                contextSnapshot: nil,
+                contextProviderAvailable: false,
+                contextExpansion: DiffContextExpansionState(),
+                inlineFeedback: [],
+                draftComments: [],
+                pendingDraftAnchor: nil,
+                canCreateDraftComment: true,
+                threads: [],
+                annotations: []
+            )
+        }
+        #expect(key(a) == key(b))
+    }
+
+    @Test func renderContextKeyDiffersWhenModelTextChanges() {
+        var changed = sampleLines()
+        changed[0] = .init(kind: .context, text: "old/new 4 EDITED", oldNumber: 4, newNumber: 4)
+        let a = model(lines: sampleLines())
+        let b = model(lines: changed)
+        let fileID = DiffReviewFileID(namespace: "commit", path: "a.swift")
+        func key(_ m: DiffDisplayModel) -> DiffReviewRenderContextKey {
+            DiffReviewRenderContextKey(
+                fileID: fileID,
+                displayModel: m,
+                contextSnapshot: nil,
+                contextProviderAvailable: false,
+                contextExpansion: DiffContextExpansionState(),
+                inlineFeedback: [],
+                draftComments: [],
+                pendingDraftAnchor: nil,
+                canCreateDraftComment: true,
+                threads: [],
+                annotations: []
+            )
+        }
+        #expect(key(a) != key(b))
+    }
+}


### PR DESCRIPTION
## Summary

`DiffReviewFileSection.body` ran two O(all-rows) computations on **every** SwiftUI update, and body updates fire constantly during review (scroll spy writes `selectedFileID`, hover state invalidates the section). Each invalidation cost O(lines) in string building, reflection, and hashing on the main actor.

This moves the per-row work to **model-build time** so body passes read precomputed scalars in O(1):

- `DiffDisplayModel`/`DiffDisplayGroup` now carry `contentHash` (full fidelity — keys the render-context cache) and `structuralHash` (coarse — drives the `.onChange` state resets), computed once in their initializers. `DiffDisplayGroup` also carries precomputed old/new side extents.
- The render-context key stores `contentHash` instead of rebuilding `DisplayModelSignature` (which mapped every group/row/line into signature structs with `String(describing:)` reflection per row before hashing). The dead signature structs are deleted.
- `BoundaryRange` reads the precomputed extents instead of an O(hunk-lines) `reduce` that ran per body pass whenever a context provider was present.
- The section's draft/context `.onChange` signatures become O(1) reads of `structuralHash` via small `Equatable` structs, replacing a joined string that was rebuilt twice per pass.
- `DiffDisplayRow.Kind` is now `Hashable`, replacing `String(describing:)`.

`DiffTabView`'s parallel `DiffTabRenderContextKey` has the same shape and is tracked separately by the issue.

## Testing

- `xcodebuild build` — succeeds.
- New `DiffDisplaySignatureTests` covers `contentHash` vs `structuralHash` semantics (text edits change content but not structure; line-number/collapse changes move both), precomputed side extents, and that the render key still distinguishes model content while treating identical models as equal.
- All diff/review/render suites pass (`DiffReviewSurfaceTests`, `DiffContextExpansionTests`, `DiffReviewModelsTests`, `DiffReviewFileSectionEqualityTests`, `DiffPaneViewTests`), including the existing test that verifies expanded-context text changes still invalidate the cache through the new content-hash key.

Closes #676