### PR TITLE
fix(acp): transcript render scaling

### DIFF
--- a/Alas/Sources/ACP/UI/ACPMessageList.swift
+++ b/Alas/Sources/ACP/UI/ACPMessageList.swift
@@ -40,7 +40,7 @@ struct ACPMessageList: View {
     @State private var restoredRememberedAnchor: String?
     @State private var pendingTailScrollTask: Task<Void, Never>?
 
-    /// Height of an invisible spacer at the tail of the VStack. The
+    /// Height of an invisible spacer at the tail of the transcript stack. The
     /// composer pill plus its outer padding occupies roughly this much
     /// vertical space, so by scrolling THAT element to the viewport
     /// bottom we guarantee the streaming caret / last message sits
@@ -112,7 +112,7 @@ struct ACPMessageList: View {
         ScrollViewReader { proxy in
             GeometryReader { viewport in
                 ScrollView {
-                    VStack(alignment: .leading, spacing: 18) {
+                    LazyVStack(alignment: .leading, spacing: 18) {
                         switch Self.topPaginationIndicator(
                             visibleHead: transcript.visibleHead,
                             isBackfillingOlderMessages: transcript.isBackfillingOlderMessages
@@ -251,6 +251,7 @@ struct ACPMessageList: View {
                 }
                 .onChange(of: scrollSignature) { _, _ in
                     if session.followsTranscriptTail {
+                        transcript.resetWindowToTail()
                         scheduleTailScroll(
                             proxy: proxy,
                             animated: Self.shouldAnimateTailScroll(
@@ -290,6 +291,7 @@ struct ACPMessageList: View {
 
     private func restoreTailIfNeeded(proxy: ScrollViewProxy, animated: Bool) {
         guard session.followsTranscriptTail else { return }
+        transcript.resetWindowToTail()
         scrollToTail(proxy: proxy, animated: animated)
     }
 
@@ -406,6 +408,7 @@ struct ACPMessageList: View {
         guard session.followsTranscriptTail != follows else { return }
         session.followsTranscriptTail = follows
         if follows {
+            transcript.resetWindowToTail()
             onRememberScrollAnchor(nil, nil, true)
             latestRememberedScrollAnchorIndex = nil
         } else {

--- a/AlasTests/ACP/Session/ACPTranscriptMarkdownCacheEvictionTests.swift
+++ b/AlasTests/ACP/Session/ACPTranscriptMarkdownCacheEvictionTests.swift
@@ -60,6 +60,27 @@ struct ACPTranscriptMarkdownCacheEvictionTests {
         #expect(t.markdownCacheCountForTests == after)
     }
 
+    @Test("resetWindowToTail drops caches outside the tail window")
+    func resetWindowToTailDropsOutsideTail() {
+        let t = ACPTranscript()
+        for i in 0..<50 { t.messages.append(.systemNotice(id: UUID(), text: "\(i)")) }
+        let ids = t.messages.map(\.stableId)
+        for id in ids {
+            t.markdownCache(forMessage: id).update(with: id)
+        }
+
+        t.resetWindowToTail()
+
+        #expect(t.visibleHead == 20)
+        #expect(t.markdownCacheCountForTests == ACPTranscript.tailWindow)
+        for id in ids[0..<20] {
+            #expect(!t.hasMarkdownCacheForTests(messageId: id))
+        }
+        for id in ids[20..<50] {
+            #expect(t.hasMarkdownCacheForTests(messageId: id))
+        }
+    }
+
     @Test("resetMarkdownCaches empties the cache map")
     func resetClears() {
         let t = ACPTranscript()


### PR DESCRIPTION
## Summary

Fixes #666.

- Render ACP transcript rows in a `LazyVStack` so previously revealed long histories do not eagerly instantiate every message row.
- Keep row frame reporting on the macOS 14 fallback path only; macOS 15+ continues using scroll target visibility without per-row `GeometryReader` preferences.
- Recompact the transcript window back to the tail while tail-follow is active, and cover tail-window cache eviction with a focused test.

## Validation

- `xcodegen`
- `ALAS_FFF_TARGET_ARCH=arm64 rtk xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -only-testing:AlasTests/ACPTranscriptMarkdownCacheEvictionTests test`
- `ALAS_FFF_TARGET_ARCH=arm64 rtk xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -quiet build`

Note: a full local `xcodebuild ... test` run was started before publishing but was interrupted after staying silent for several minutes; this PR relies on CI for the exhaustive pass.