### PR TITLE
perf(acp): gate row frame tracking to legacy scroll

### DIFF
--- a/Alas/Sources/ACP/UI/ACPMessageList.swift
+++ b/Alas/Sources/ACP/UI/ACPMessageList.swift
@@ -275,9 +275,9 @@ struct ACPMessageList: View {
                 .onChange(of: transcript.visibleHead) { _, _ in
                     restoreRememberedAnchorIfNeeded(proxy: proxy)
                 }
-                .onPreferenceChange(ACPRowFramesPreferenceKey.self) { frames in
+                .modifier(ACPRowFramePreferenceTracking { frames in
                     handleRowFramePreference(frames, proxy: proxy)
-                }
+                })
             }
         }
         .background(
@@ -472,7 +472,22 @@ struct ACPMessageList: View {
         restoredRememberedAnchor = anchor
     }
 
+    @ViewBuilder
     private func rowFrameReporter(id: String) -> some View {
+        if #available(macOS 15, *) {
+            if Self.shouldUseLegacyRowFramePreferences(isModernScrollTrackingAvailable: true) {
+                legacyRowFrameReporter(id: id)
+            } else {
+                EmptyView()
+            }
+        } else if Self.shouldUseLegacyRowFramePreferences(isModernScrollTrackingAvailable: false) {
+            legacyRowFrameReporter(id: id)
+        } else {
+            EmptyView()
+        }
+    }
+
+    private func legacyRowFrameReporter(id: String) -> some View {
         GeometryReader { rowGeometry in
             Color.clear.preference(
                 key: ACPRowFramesPreferenceKey.self,
@@ -592,6 +607,12 @@ struct ACPMessageList: View {
         visibleMessageIds: Set<String>
     ) -> String? {
         ids.first { visibleMessageIds.contains($0) }
+    }
+
+    nonisolated static func shouldUseLegacyRowFramePreferences(
+        isModernScrollTrackingAvailable: Bool
+    ) -> Bool {
+        !isModernScrollTrackingAvailable
     }
 
     struct VisibleMessageLookup {
@@ -848,6 +869,25 @@ private struct ACPRowFramesPreferenceKey: PreferenceKey {
     static let defaultValue: [String: CGRect] = [:]
     static func reduce(value: inout [String: CGRect], nextValue: () -> [String: CGRect]) {
         value.merge(nextValue(), uniquingKeysWith: { _, new in new })
+    }
+}
+
+private struct ACPRowFramePreferenceTracking: ViewModifier {
+    let onFrames: ([String: CGRect]) -> Void
+
+    @ViewBuilder
+    func body(content: Content) -> some View {
+        if #available(macOS 15, *) {
+            if ACPMessageList.shouldUseLegacyRowFramePreferences(isModernScrollTrackingAvailable: true) {
+                content.onPreferenceChange(ACPRowFramesPreferenceKey.self, perform: onFrames)
+            } else {
+                content
+            }
+        } else if ACPMessageList.shouldUseLegacyRowFramePreferences(isModernScrollTrackingAvailable: false) {
+            content.onPreferenceChange(ACPRowFramesPreferenceKey.self, perform: onFrames)
+        } else {
+            content
+        }
     }
 }
 

--- a/AlasTests/ACP/UI/ACPMessageListPaginationTests.swift
+++ b/AlasTests/ACP/UI/ACPMessageListPaginationTests.swift
@@ -183,6 +183,16 @@ struct ACPMessageListPaginationTests {
         ) == nil)
     }
 
+    @Test("row frame preferences are legacy-only")
+    func rowFramePreferencesAreLegacyOnly() {
+        #expect(ACPMessageList.shouldUseLegacyRowFramePreferences(
+            isModernScrollTrackingAvailable: false
+        ))
+        #expect(!ACPMessageList.shouldUseLegacyRowFramePreferences(
+            isModernScrollTrackingAvailable: true
+        ))
+    }
+
     @Test("visible message lookup records ids and transcript indices")
     func visibleMessageLookupRecordsIdsAndTranscriptIndices() {
         let lookup = ACPMessageList.visibleMessageLookup(rows: [


### PR DESCRIPTION
## Summary

Fixes #669 by keeping the ACP transcript row-frame preference pipeline on the macOS 14 fallback path only.

- avoids mounting per-row `GeometryReader` frame reporters on macOS 15+
- avoids attaching the row-frame `onPreferenceChange` handler on macOS 15+
- keeps the existing legacy preference path for macOS 14
- adds focused coverage for the legacy-only tracking decision

## Root cause

`ACPMessageList` still installed the old row-frame `PreferenceKey` pipeline even on macOS 15+, where scroll tracking has moved to SwiftUI scroll geometry and scroll target visibility APIs. That left an O(rows) preference merge and anchor scan active during layout/streaming changes even though the path was no longer the source of scroll truth on modern macOS.

## Validation

- `rtk xcodegen`
- `ALAS_FFF_TARGET_ARCH=arm64 rtk xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -quiet build`
- `ALAS_FFF_TARGET_ARCH=arm64 rtk xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -only-testing:AlasTests/ACPMessageListPaginationTests test`

Note: a full local `xcodebuild ... test` run was started before publishing, but stayed silent for an extended period and was interrupted rather than reported as green.