### PR TITLE
perf(diff): cap per-file diff rendering with a Show full diff escape hatch

### DIFF
--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -959,6 +959,7 @@
 		D2B345D1AEB1D5CEF48354C3 /* HoverHighlightFeatureTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 100091C8ABC3F3FA66C744E9 /* HoverHighlightFeatureTests.swift */; };
 		D2D5D79EE8DE82FC44C2D36A /* CompletionFeature.swift in Sources */ = {isa = PBXBuildFile; fileRef = D510DACCD80A328B2DFABDC0 /* CompletionFeature.swift */; };
 		D397C3E94E3F00F012CBE5AE /* Tab.swift in Sources */ = {isa = PBXBuildFile; fileRef = B27595490B7D883CF5D9FFD5 /* Tab.swift */; };
+		D3C333539943019DB3439AE6 /* DiffReviewRenderBudget.swift in Sources */ = {isa = PBXBuildFile; fileRef = 34971259AB0FE69892952670 /* DiffReviewRenderBudget.swift */; };
 		D3EAFAA986CE4441B7F103F9 /* HookCommandShellTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 23532A4B85092F720FD0E9F9 /* HookCommandShellTests.swift */; };
 		D45D14487117192F9E5D7F0E /* ACPSessionHydratorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8D8A320D194DF0E64BF13BC5 /* ACPSessionHydratorTests.swift */; };
 		D46F8DF1FB66AD0ED92F3DF0 /* ChangesTreeBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 910CB5077C8E89A778F1E896 /* ChangesTreeBuilder.swift */; };
@@ -1006,6 +1007,7 @@
 		DD18C5FF006D18BC66964D94 /* TerminalTabView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 14087D57E96448EEF0B80BD9 /* TerminalTabView.swift */; };
 		DD2553E3635BFE3B15355E08 /* ACPLaunchPathResolverTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D911D138AF8A0E99191C862 /* ACPLaunchPathResolverTests.swift */; };
 		DDAA1FF54466B7F5424D315E /* TreeSitterMarkdown in Frameworks */ = {isa = PBXBuildFile; productRef = 49F7F27A9183521F9997AF49 /* TreeSitterMarkdown */; };
+		DE33366A35436471AE0DAE96 /* DiffReviewRenderBudgetTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AEE54F0320B9F40BEF46FB85 /* DiffReviewRenderBudgetTests.swift */; };
 		DE41CB04CDC89D09346494A5 /* LineEndingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EB52B59655B85764D85CFB7F /* LineEndingTests.swift */; };
 		DE431266B60826A2EA3736DF /* LineBuffer.swift in Sources */ = {isa = PBXBuildFile; fileRef = C954F77AD0867F7FD39A5ED7 /* LineBuffer.swift */; };
 		DEBA25FCF25D26395BD04F73 /* EditorConflictBanner.swift in Sources */ = {isa = PBXBuildFile; fileRef = BFD267BE3F08611B376F3CC7 /* EditorConflictBanner.swift */; };
@@ -1398,6 +1400,7 @@
 		3428750EA8626EEBF3FE928B /* TitlelessWindow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TitlelessWindow.swift; sourceTree = "<group>"; };
 		345CFF4DBE5794DEBF43F996 /* LanguageServerRegistryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LanguageServerRegistryTests.swift; sourceTree = "<group>"; };
 		348D2E5F6030BB9F2BDEFA26 /* CompletionPopup.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CompletionPopup.swift; sourceTree = "<group>"; };
+		34971259AB0FE69892952670 /* DiffReviewRenderBudget.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiffReviewRenderBudget.swift; sourceTree = "<group>"; };
 		35004DC60214F616FA84ED8B /* ReleaseInfo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReleaseInfo.swift; sourceTree = "<group>"; };
 		3519B5A28746C49C35D9DAF9 /* SearchInputRow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchInputRow.swift; sourceTree = "<group>"; };
 		35543E9F4994774A3743BC12 /* EditorBufferStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditorBufferStoreTests.swift; sourceTree = "<group>"; };
@@ -1909,6 +1912,7 @@
 		AE0A6F237480EE72CB8DBE28 /* TitlelessWindowTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TitlelessWindowTests.swift; sourceTree = "<group>"; };
 		AE35206EEBD7E3A35C3421EA /* ACPRecoveryPill.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPRecoveryPill.swift; sourceTree = "<group>"; };
 		AEAF044BC36E6083CC1529BE /* session-update-session-info-no-meta.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "session-update-session-info-no-meta.json"; sourceTree = "<group>"; };
+		AEE54F0320B9F40BEF46FB85 /* DiffReviewRenderBudgetTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiffReviewRenderBudgetTests.swift; sourceTree = "<group>"; };
 		AF05DF16587C5A48A9E04B2A /* ACPSessionUsageTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPSessionUsageTests.swift; sourceTree = "<group>"; };
 		AF2F716F911BB20B3E78C40B /* AgentDefinition.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentDefinition.swift; sourceTree = "<group>"; };
 		AF522B02666DB6AC4C82339E /* ACPContextRing.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPContextRing.swift; sourceTree = "<group>"; };
@@ -2540,6 +2544,7 @@
 				27EEC16C786CE9430C1AC174 /* DiffReviewFileSectionEqualityTests.swift */,
 				A172B476A5BF7E4016431E6A /* DiffReviewModelsTests.swift */,
 				D153832D43BF352B94E34430 /* DiffReviewRenderableContentEqualityTests.swift */,
+				AEE54F0320B9F40BEF46FB85 /* DiffReviewRenderBudgetTests.swift */,
 				A723CF5BB46FABA23D8C9543 /* DiffReviewRenderEligibilityTests.swift */,
 				F649B493D42787FEA6D8E67B /* DiffReviewScrollSpyTests.swift */,
 				E0F10B6B1311831E53DA45C0 /* DiffReviewStagedMutationActionsTests.swift */,
@@ -3971,6 +3976,7 @@
 				E8B46B2287CA16E683490301 /* DiffReviewInlineFeedbackActions.swift */,
 				14D1ECA099BBDCB5BB2EEC67 /* DiffReviewModels.swift */,
 				4BECCB29ED6324C55C541D54 /* DiffReviewRail.swift */,
+				34971259AB0FE69892952670 /* DiffReviewRenderBudget.swift */,
 				5B7B8B82A8D4F5B1F1DF1731 /* DiffReviewRenderContext.swift */,
 				389D0EB957CCC8447DB9C4FE /* DiffReviewRenderEligibility.swift */,
 				D73C433B373577FD515FECD3 /* DiffReviewScrollSpy.swift */,
@@ -4814,6 +4820,7 @@
 				AB4B19ECC0C3D7242ECD42C6 /* DiffReviewInlineFeedbackActions.swift in Sources */,
 				5806E3E41DA735380E33BF76 /* DiffReviewModels.swift in Sources */,
 				3D32D8FA2A63B3C2080B9E3A /* DiffReviewRail.swift in Sources */,
+				D3C333539943019DB3439AE6 /* DiffReviewRenderBudget.swift in Sources */,
 				A65ED0AF2D8880576486505C /* DiffReviewRenderContext.swift in Sources */,
 				9547580C9DFECD838C120B90 /* DiffReviewRenderEligibility.swift in Sources */,
 				E5D32C15B08F30DF3B46CA74 /* DiffReviewScrollSpy.swift in Sources */,
@@ -5394,6 +5401,7 @@
 				0CF488290CC525EA7C11A43C /* DiffParserTests.swift in Sources */,
 				D215CAABE4DE2F5CE3CB0E93 /* DiffReviewFileSectionEqualityTests.swift in Sources */,
 				59AF95D3DFDFE7736051EF4A /* DiffReviewModelsTests.swift in Sources */,
+				DE33366A35436471AE0DAE96 /* DiffReviewRenderBudgetTests.swift in Sources */,
 				BF887495CBAAA98792FBF74D /* DiffReviewRenderEligibilityTests.swift in Sources */,
 				0E680F7AAD6CBD2A4A829A52 /* DiffReviewRenderableContentEqualityTests.swift in Sources */,
 				14D70126BAF735B2A66A23C5 /* DiffReviewScrollSpyTests.swift in Sources */,

--- a/Alas/Sources/Center/DiffReview/DiffReviewFileSection.swift
+++ b/Alas/Sources/Center/DiffReview/DiffReviewFileSection.swift
@@ -460,12 +460,34 @@ struct DiffReviewFileSection: View {
         .padding(.horizontal, 14)
         .padding(.vertical, 18)
         .background(theme.color("bg-1"))
+        .background(renderBudgetScrollAnchors)
         .background(
             DiffReviewAccessibilityMarker(
                 identifier: "diff-review-render-budget-\(file.id.rawValue)",
                 label: "Large diff hidden for performance"
             )
         )
+    }
+
+    /// Zero-size anchors carrying the same target IDs the rendered comment views
+    /// would, so the summary-rail / comment-selection scroll flow resolves a
+    /// target even while the diff body is deferred. Scrolling lands on the
+    /// placeholder (with its "N comments hidden" hint) instead of silently
+    /// no-oping; the reviewer can then choose "Show full diff".
+    private var renderBudgetScrollAnchors: some View {
+        VStack(spacing: 0) {
+            ForEach(draftComments, id: \.id) { comment in
+                Color.clear
+                    .frame(height: 0)
+                    .id(DiffReviewDraftCommentTargetID.targetID(commentID: comment.id, fileID: file.id))
+            }
+            ForEach(inlineFeedback, id: \.id) { item in
+                Color.clear
+                    .frame(height: 0)
+                    .id(DiffReviewInlineFeedbackTargetID.targetID(feedbackID: item.id, fileID: file.id))
+            }
+        }
+        .accessibilityHidden(true)
     }
 
     @ViewBuilder

--- a/Alas/Sources/Center/DiffReview/DiffReviewFileSection.swift
+++ b/Alas/Sources/Center/DiffReview/DiffReviewFileSection.swift
@@ -100,16 +100,30 @@ struct DiffReviewFileSection: View {
     @State private var hoveredInlineFeedbackID: String?
     @State private var hoveredDraftCommentID: String?
     @State private var activeThreadID: String?
+    @State private var showFullDiffOverride = false
     @FocusState private var draftComposerFocused: Bool
 
+    private var isOverRenderBudget: Bool {
+        guard let displayModel = file.displayModel else { return false }
+        return DiffReviewRenderBudget.isOverBudget(displayModel)
+    }
+
+    private var shouldDeferRender: Bool {
+        isOverRenderBudget && !showFullDiffOverride
+    }
+
     var body: some View {
-        let renderContext = renderContext
         VStack(spacing: 0) {
             header
             contextLoadErrorRow
-            fileLevelDraftCommentStack(renderContext: renderContext)
-            fileLevelInlineFeedbackStack(renderContext: renderContext)
-            content(renderContext: renderContext)
+            if shouldDeferRender {
+                renderBudgetPlaceholder
+            } else {
+                let renderContext = renderContext
+                fileLevelDraftCommentStack(renderContext: renderContext)
+                fileLevelInlineFeedbackStack(renderContext: renderContext)
+                content(renderContext: renderContext)
+            }
         }
         .background(theme.color("bg-1"))
         .clipShape(RoundedRectangle(cornerRadius: 8))
@@ -129,6 +143,7 @@ struct DiffReviewFileSection: View {
             clearPendingDraft()
         }
         .onChange(of: file.id) { _, _ in
+            showFullDiffOverride = false
             resetContextState()
         }
         .onChange(of: contextStateSignature) { _, _ in
@@ -395,6 +410,41 @@ struct DiffReviewFileSection: View {
 
     private var currentDisplayGroups: [DiffDisplayGroup]? {
         renderContext?.groups.map(\.displayGroup)
+    }
+
+    private var renderBudgetPlaceholder: some View {
+        let changedLines = file.summary.additions + file.summary.deletions
+        return VStack(alignment: .leading, spacing: 8) {
+            Text("Large diff hidden for performance")
+                .font(.system(size: 12, weight: .semibold))
+                .foregroundColor(theme.color("fg"))
+            Text("\(changedLines.formatted()) changed lines. Rendering may be slow.")
+                .font(.system(size: 12))
+                .foregroundColor(theme.color("fg-dim"))
+            Button {
+                showFullDiffOverride = true
+            } label: {
+                Text("Show full diff")
+                    .font(.system(size: 11, weight: .semibold))
+                    .foregroundColor(theme.color("fg-muted"))
+                    .padding(.horizontal, 10)
+                    .frame(height: 24)
+                    .background(theme.color("bg-3"))
+                    .clipShape(RoundedRectangle(cornerRadius: 5))
+            }
+            .buttonStyle(.plain)
+            .accessibilityIdentifier("diff-review-show-full-diff-\(file.id.rawValue)")
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .padding(.horizontal, 14)
+        .padding(.vertical, 18)
+        .background(theme.color("bg-1"))
+        .background(
+            DiffReviewAccessibilityMarker(
+                identifier: "diff-review-render-budget-\(file.id.rawValue)",
+                label: "Large diff hidden for performance"
+            )
+        )
     }
 
     @ViewBuilder

--- a/Alas/Sources/Center/DiffReview/DiffReviewFileSection.swift
+++ b/Alas/Sources/Center/DiffReview/DiffReviewFileSection.swift
@@ -412,8 +412,15 @@ struct DiffReviewFileSection: View {
         renderContext?.groups.map(\.displayGroup)
     }
 
+    /// Review annotations that the placeholder hides while the diff is deferred.
+    /// Computed from the cheap input arrays so it never forces a `renderContext` build.
+    private var hiddenReviewItemCount: Int {
+        draftComments.count + inlineFeedback.count + threads.count
+    }
+
     private var renderBudgetPlaceholder: some View {
         let changedLines = file.summary.additions + file.summary.deletions
+        let hiddenItems = hiddenReviewItemCount
         return VStack(alignment: .leading, spacing: 8) {
             Text("Large diff hidden for performance")
                 .font(.system(size: 12, weight: .semibold))
@@ -421,6 +428,12 @@ struct DiffReviewFileSection: View {
             Text("\(changedLines.formatted()) changed lines. Rendering may be slow.")
                 .font(.system(size: 12))
                 .foregroundColor(theme.color("fg-dim"))
+            if hiddenItems > 0 {
+                Text("^[\(hiddenItems) comment](inflect: true) hidden — show the full diff to view.")
+                    .font(.system(size: 12))
+                    .foregroundColor(theme.color("fg-dim"))
+                    .accessibilityIdentifier("diff-review-render-budget-hidden-comments-\(file.id.rawValue)")
+            }
             Button {
                 showFullDiffOverride = true
             } label: {

--- a/Alas/Sources/Center/DiffReview/DiffReviewFileSection.swift
+++ b/Alas/Sources/Center/DiffReview/DiffReviewFileSection.swift
@@ -146,12 +146,15 @@ struct DiffReviewFileSection: View {
             showFullDiffOverride = false
             resetContextState()
         }
-        .onChange(of: contextStateSignature) { _, _ in
-            // Re-arm the render budget when the same file reloads with new
-            // content (structuralHash changes) under an unchanged file.id.
-            // Context expansion does not alter this signature, so an opened
-            // large diff stays open while the reviewer expands context.
+        .onChange(of: renderBudgetResetSignal) { _, _ in
+            // Re-arm the render budget whenever the same file reloads with new
+            // content under an unchanged file.id. Keyed off `contentHash`, which
+            // captures text-only edits (unlike `structuralHash`); context
+            // expansion never mutates `file.displayModel`, so an opened large
+            // diff stays open while the reviewer expands context.
             showFullDiffOverride = false
+        }
+        .onChange(of: contextStateSignature) { _, _ in
             resetContextState()
         }
         .onChange(of: pendingDraftAnchor) { _, anchor in
@@ -821,6 +824,14 @@ struct DiffReviewFileSection: View {
     /// its value on every body pass, so this must never walk the rows.
     private var displayStructuralHash: Int? {
         file.displayModel?.structuralHash
+    }
+
+    /// Content-level fingerprint (includes row text) used to re-arm the render
+    /// budget on same-file reloads. Unlike `structuralHash`, it changes on
+    /// pure text edits; unlike `file.id`, it changes when a same-path file
+    /// reloads with new content.
+    private var renderBudgetResetSignal: Int? {
+        file.displayModel?.contentHash
     }
 
     private var draftCommentDisplaySignature: DiffReviewDraftCommentDisplaySignature {

--- a/Alas/Sources/Center/DiffReview/DiffReviewFileSection.swift
+++ b/Alas/Sources/Center/DiffReview/DiffReviewFileSection.swift
@@ -147,6 +147,11 @@ struct DiffReviewFileSection: View {
             resetContextState()
         }
         .onChange(of: contextStateSignature) { _, _ in
+            // Re-arm the render budget when the same file reloads with new
+            // content (structuralHash changes) under an unchanged file.id.
+            // Context expansion does not alter this signature, so an opened
+            // large diff stays open while the reviewer expands context.
+            showFullDiffOverride = false
             resetContextState()
         }
         .onChange(of: pendingDraftAnchor) { _, anchor in

--- a/Alas/Sources/Center/DiffReview/DiffReviewRenderBudget.swift
+++ b/Alas/Sources/Center/DiffReview/DiffReviewRenderBudget.swift
@@ -1,0 +1,27 @@
+import Foundation
+
+/// Per-file render budget for the diff review surface.
+///
+/// A file whose post-collapse display model exceeds `maxRenderedRows` is not
+/// auto-rendered; its section shows a placeholder with a "Show full diff"
+/// action instead. This bounds the pathological case — a huge generated file,
+/// frequently a single add/delete hunk — that would otherwise build one
+/// enormous `NSTextView` document the moment it scrolls into view.
+enum DiffReviewRenderBudget {
+    /// Comfortably above any hand-authored file, well below the pathological range.
+    static let maxRenderedRows = 20_000
+
+    /// Total post-collapse rows across all hunks. A collapsed context run counts
+    /// as the single row that represents it, matching what the view renders.
+    static func renderedRowCount(of model: DiffDisplayModel) -> Int {
+        model.groups.reduce(0) { $0 + $1.rows.count }
+    }
+
+    static func isOverBudget(rowCount: Int) -> Bool {
+        rowCount > maxRenderedRows
+    }
+
+    static func isOverBudget(_ model: DiffDisplayModel) -> Bool {
+        isOverBudget(rowCount: renderedRowCount(of: model))
+    }
+}

--- a/AlasTests/DiffReviewRenderBudgetTests.swift
+++ b/AlasTests/DiffReviewRenderBudgetTests.swift
@@ -12,9 +12,29 @@ struct DiffReviewRenderBudgetTests {
         return DiffDisplayModelBuilder.build(diff: diff, filePath: "a.swift")
     }
 
+    /// A single hunk that is entirely unchanged context, long enough to trigger
+    /// the builder's context-run collapse (default threshold 12, edge count 3).
+    private func contextOnlyModel(lineCount: Int) -> DiffDisplayModel {
+        let lines = (1...lineCount).map {
+            ParsedDiff.Hunk.Line(kind: .context, text: "let v\($0) = \($0)", oldNumber: $0, newNumber: $0)
+        }
+        let diff = ParsedDiff(hunks: [
+            ParsedDiff.Hunk(header: "@@ -1,\(lineCount) +1,\(lineCount) @@", oldStart: 1, newStart: 1, lines: lines)
+        ])
+        return DiffDisplayModelBuilder.build(diff: diff, filePath: "a.swift")
+    }
+
     @Test func countsPostCollapseRowsAcrossGroups() {
         let model = addOnlyModel(lineCount: 3)
         #expect(DiffReviewRenderBudget.renderedRowCount(of: model) == 3)
+    }
+
+    @Test func collapsedContextRunCountsAsOneRow() {
+        // 40 unchanged lines collapse to: 3 edge + 1 collapsed + 3 edge = 7 rows.
+        let model = contextOnlyModel(lineCount: 40)
+        let count = DiffReviewRenderBudget.renderedRowCount(of: model)
+        #expect(count == 7)
+        #expect(count < 40)
     }
 
     @Test func rowCountAtCapIsNotOverBudget() {

--- a/AlasTests/DiffReviewRenderBudgetTests.swift
+++ b/AlasTests/DiffReviewRenderBudgetTests.swift
@@ -1,0 +1,40 @@
+import Testing
+@testable import Alas
+
+struct DiffReviewRenderBudgetTests {
+    private func addOnlyModel(lineCount: Int) -> DiffDisplayModel {
+        let lines = (1...lineCount).map {
+            ParsedDiff.Hunk.Line(kind: .add, text: "let v\($0) = \($0)", oldNumber: nil, newNumber: $0)
+        }
+        let diff = ParsedDiff(hunks: [
+            ParsedDiff.Hunk(header: "@@ -0,0 +1,\(lineCount) @@", oldStart: 0, newStart: 1, lines: lines)
+        ])
+        return DiffDisplayModelBuilder.build(diff: diff, filePath: "a.swift")
+    }
+
+    @Test func countsPostCollapseRowsAcrossGroups() {
+        let model = addOnlyModel(lineCount: 3)
+        #expect(DiffReviewRenderBudget.renderedRowCount(of: model) == 3)
+    }
+
+    @Test func rowCountAtCapIsNotOverBudget() {
+        #expect(DiffReviewRenderBudget.isOverBudget(rowCount: DiffReviewRenderBudget.maxRenderedRows) == false)
+    }
+
+    @Test func rowCountAboveCapIsOverBudget() {
+        #expect(DiffReviewRenderBudget.isOverBudget(rowCount: DiffReviewRenderBudget.maxRenderedRows + 1) == true)
+    }
+
+    @Test func smallRowCountIsNotOverBudget() {
+        #expect(DiffReviewRenderBudget.isOverBudget(rowCount: 10) == false)
+    }
+
+    @Test func smallModelIsNotOverBudget() {
+        #expect(DiffReviewRenderBudget.isOverBudget(addOnlyModel(lineCount: 5)) == false)
+    }
+
+    @Test func modelAboveCapIsOverBudget() {
+        let model = addOnlyModel(lineCount: DiffReviewRenderBudget.maxRenderedRows + 1)
+        #expect(DiffReviewRenderBudget.isOverBudget(model) == true)
+    }
+}


### PR DESCRIPTION
Closes #677.

## Problem

The review stream virtualizes at the **file** level, but inside a file every hunk renders in a plain `VStack`, and each hunk builds a full `NSTextView` document (plus per-line tree-sitter highlighting). A generated 50k-line file — frequently a single giant add/delete hunk — synchronously builds one enormous document the moment it scrolls into view, hanging the UI. Context-run collapse bounds *context* but not add/delete-heavy files. There was no line/byte cap anywhere.

## Change

Adds a **per-file render budget**. When a file's post-collapse `DiffDisplayModel` exceeds **20,000 rows**, its section renders a lightweight placeholder with a **Show full diff** button instead of auto-building the document views. Clicking the button renders the file normally.

- New pure helper `DiffReviewRenderBudget` (constant + row-count + over-budget predicate), unit-tested including the collapsed-run-counts-as-one-row semantic.
- Gate lives in the **shared** `DiffReviewFileSection`, so all six diff-review surfaces (staged, commit, range, draft review request, PR review, review-changes) benefit in one place. Deferred files skip building `renderContext`/documents entirely; the override is view-local `@State` that re-arms on file switch/reload.
- The placeholder surfaces changed-line count and, when present, a "N comments hidden" hint (computed from cheap input arrays, no `renderContext` build) so reviewers aren't blind to existing threads on a large file.

## Out of scope

- Making the per-hunk stack lazy (a single giant hunk is one document, so the row cap is what bounds the pathological case).
- Byte-based caps / configurability.

## Testing

`DiffReviewRenderBudgetTests` + the DiffReview/DiffPane suites pass locally (`Test run with 202 tests … passed`). Build is clean. (The full local suite is blocked by an unrelated headless `NSTextView` flake in `DiffPaneViewTests`, outside this diff — CI runs it in a clean environment.)