### PR TITLE
fix(lsp): Cache missing LSP availability

### DIFF
--- a/Alas/Sources/Code/Editor/BlockedNudgeBanner.swift
+++ b/Alas/Sources/Code/Editor/BlockedNudgeBanner.swift
@@ -88,6 +88,7 @@ struct BlockedNudgeBanner: View {
             remediationState = .idle
             // Wake up LSP for any open buffers in this language so
             // diagnostics/hover start without a manual reopen.
+            appState.lsp.invalidateAvailabilityCache(forLanguage: nudge.language)
             appState.tabs.reopenLSPDocuments(forLanguage: nudge.language)
         case .stillBlocked:
             remediationState = .error("Quarantine removed but \(nudge.displayName) is still blocked. Try reinstalling it.")

--- a/Alas/Sources/Code/Editor/InstallNudgeBanner.swift
+++ b/Alas/Sources/Code/Editor/InstallNudgeBanner.swift
@@ -39,6 +39,7 @@ struct InstallNudgeBanner: View {
                 // installed language so hover/diagnostics/definitions
                 // wake up without a manual close-and-reopen.
                 if let completedLanguage {
+                    appState.lsp.invalidateAvailabilityCache(forLanguage: completedLanguage)
                     if let package = pendingMasonPackage {
                         let config = LanguageServerConfig.prefilled(from: package)
                         appState.config.code.saveLanguageServerConfig(

--- a/Alas/Sources/Code/LSP/LanguageServerAvailability.swift
+++ b/Alas/Sources/Code/LSP/LanguageServerAvailability.swift
@@ -19,7 +19,7 @@ struct LanguageServerAvailability {
     init(
         environment: [String: String] = ProcessInfo.processInfo.environment,
         fileManager: FileManager = .default,
-        xcrunFind: @escaping (String) -> String? = LanguageServerAvailability.xcrunFind,
+        xcrunFind: @escaping (String) -> String? = LanguageServerAvailability.cachedXcrunFind,
         additionalPathDirectories: [String] = LanguageServerAvailability.defaultAdditionalPathDirectories(),
         gatekeeperAssessor: @escaping (String) -> GatekeeperAssessor.Result = { GatekeeperAssessor.shared.assess(realPath: $0) },
         gatekeeperRemediator: @escaping (String, String) async -> GatekeeperRemediator.Outcome = {
@@ -228,6 +228,45 @@ struct LanguageServerAvailability {
             .split(whereSeparator: \.isNewline)
             .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
             .filter { !$0.isEmpty && !$0.hasPrefix("#") }
+    }
+
+    nonisolated private static func cachedXcrunFind(_ tool: String) -> String? {
+        sharedXcrunFindCache.value(for: tool) {
+            xcrunFind(tool)
+        }
+    }
+
+    nonisolated private static let sharedXcrunFindCache = XcrunFindCache()
+
+    nonisolated private final class XcrunFindCache: @unchecked Sendable {
+        private enum Result {
+            case found(String)
+            case missing
+        }
+
+        private let lock = NSLock()
+        private var results: [String: Result] = [:]
+
+        func value(for tool: String, resolve: () -> String?) -> String? {
+            lock.lock()
+            if let cached = results[tool] {
+                lock.unlock()
+                switch cached {
+                case .found(let path):
+                    return path
+                case .missing:
+                    return nil
+                }
+            }
+            lock.unlock()
+
+            let resolved = resolve()
+
+            lock.lock()
+            results[tool] = resolved.map(Result.found) ?? .missing
+            lock.unlock()
+            return resolved
+        }
     }
 
     nonisolated private static func xcrunFind(_ tool: String) -> String? {

--- a/Alas/Sources/Code/LSP/WorkspaceLSPManager.swift
+++ b/Alas/Sources/Code/LSP/WorkspaceLSPManager.swift
@@ -148,25 +148,40 @@ final class WorkspaceLSPManager: DocumentFormatter {
     /// caching the result. Designed for hot-path callers like the status
     /// badge resolver.
     ///
-    /// Only stable results (`.available`, `.disabled`) are cached — those
-    /// don't change without a registry update. `.notInstalled` and
-    /// `.blockedByGatekeeper` are re-probed on every call so runtime user
-    /// actions (install via the install nudge, quarantine removal via the
-    /// blocked nudge) are picked up without an explicit cache invalidation
-    /// hook. The fast-path PATH walk is cheap; the `xcrun --find` fallback
-    /// for `sourcekit-lsp` only fires when the binary isn't on PATH, which
-    /// is uncommon on dev machines.
+    /// Missing Swift `sourcekit-lsp` is cached too: that resolution can fall
+    /// back to `xcrun --find`, so negative results must not be re-probed from
+    /// render-adjacent status badge paths. Other `.notInstalled` statuses
+    /// continue to re-probe so manual installs outside Alas are picked up.
+    /// Runtime installs explicitly invalidate the language below.
+    /// `.blockedByGatekeeper` still re-probes because remediation can flip
+    /// without changing the registry.
     func availabilityStatus(forLanguage language: String) -> LanguageServerAvailability.Status? {
         if let cached = availabilityCache[language] { return cached }
         guard let entry = registry.allEntries().first(where: { $0.language == language }) else { return nil }
         let status = cachedAvailability.status(for: entry)
-        switch status {
-        case .available, .disabled:
+        if shouldCacheAvailabilityStatus(status, for: entry) {
             availabilityCache[language] = status
-        case .notInstalled, .blockedByGatekeeper:
-            break
         }
         return status
+    }
+
+    private func shouldCacheAvailabilityStatus(
+        _ status: LanguageServerAvailability.Status,
+        for entry: LanguageServerConfig
+    ) -> Bool {
+        switch status {
+        case .available, .disabled:
+            return true
+        case .notInstalled:
+            return entry.language == "swift" && entry.command == "sourcekit-lsp"
+        case .blockedByGatekeeper:
+            return false
+        }
+    }
+
+    func invalidateAvailabilityCache(forLanguage language: String) {
+        let languages = Set(RecommendedLanguageCatalog.aliasGroup(forLanguage: language))
+        availabilityCache = availabilityCache.filter { !languages.contains($0.key) }
     }
 
     /// Register an open editor tab for `(worktreeRoot, fileURL)`. Spawns

--- a/Alas/Sources/Settings/CodePane.swift
+++ b/Alas/Sources/Settings/CodePane.swift
@@ -45,11 +45,12 @@ struct CodePane: View {
 
                 SettingsGroup(title: "Languages") {
                     ForEach(allEntries(), id: \.id) { entry in
+                        let status = availability.status(for: entry)
                         SettingsRow(name: entry.language,
                                     desc: entry.extensions.joined(separator: ", ")) {
                             HStack(spacing: 8) {
-                                statusBadge(for: entry)
-                                installAffordance(for: entry)
+                                statusBadge(status)
+                                installAffordance(for: entry, status: status)
                                 AlasButton(title: "Edit",
                                            style: .subtle,
                                            action: { selected = entry })
@@ -101,6 +102,7 @@ struct CodePane: View {
                 // language so their hover/diagnostics/definitions wake up
                 // without the user closing and reopening the tab.
                 if let completedLanguage {
+                    state.lsp.invalidateAvailabilityCache(forLanguage: completedLanguage)
                     state.tabs.reopenLSPDocuments(forLanguage: completedLanguage)
                 }
             }
@@ -114,10 +116,10 @@ struct CodePane: View {
 
     private let availability = LanguageServerAvailability()
 
-    private func statusBadge(for entry: LanguageServerConfig) -> some View {
+    private func statusBadge(_ status: LanguageServerAvailability.Status) -> some View {
         let label: String
         let color: Color
-        switch availability.status(for: entry) {
+        switch status {
         case .disabled:
             label = "Disabled"
             color = theme.color("fg-faint")
@@ -135,9 +137,8 @@ struct CodePane: View {
     }
 
     @ViewBuilder
-    private func installAffordance(for entry: LanguageServerConfig) -> some View {
+    private func installAffordance(for entry: LanguageServerConfig, status: LanguageServerAvailability.Status) -> some View {
         let recipes = recipes(for: entry.language)
-        let status = availability.status(for: entry)
         if status == .notInstalled, !recipes.isEmpty {
             InstallSplitButton(
                 recipes: recipes,

--- a/AlasTests/WorkspaceLSPManagerStatusTests.swift
+++ b/AlasTests/WorkspaceLSPManagerStatusTests.swift
@@ -155,6 +155,79 @@ struct WorkspaceLSPManagerStatusTests {
         #expect(box.calls == 1)
     }
 
+    @Test func notInstalledStatusIsCachedUntilInvalidated() {
+        final class Box { var calls = 0 }
+        let box = Box()
+        let registry = LanguageServerRegistry(userDefined: [
+            LanguageServerConfig(
+                language: "swift",
+                extensions: ["swift"],
+                command: "sourcekit-lsp",
+                args: [],
+                env: [:],
+                rootMarkers: [],
+                enabled: true
+            )
+        ])
+        let mgr = WorkspaceLSPManager(
+            registry: registry,
+            makeAvailability: {
+                LanguageServerAvailability(
+                    environment: ["PATH": ""],
+                    xcrunFind: { _ in
+                        box.calls += 1
+                        return nil
+                    },
+                    additionalPathDirectories: [],
+                    gatekeeperAssessor: { _ in .allowed }
+                )
+            }
+        )
+
+        _ = mgr.availabilityStatus(forLanguage: "swift")
+        _ = mgr.availabilityStatus(forLanguage: "swift")
+        #expect(box.calls == 1)
+
+        mgr.invalidateAvailabilityCache(forLanguage: "swift")
+        _ = mgr.availabilityStatus(forLanguage: "swift")
+        #expect(box.calls == 2)
+    }
+
+    @Test func nonXcrunNotInstalledStatusIsReprobed() throws {
+        let dir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("alas-lsp-availability-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let executable = dir.appendingPathComponent("rust-analyzer")
+        let registry = LanguageServerRegistry(userDefined: [
+            LanguageServerConfig(
+                language: "rust",
+                extensions: ["rs"],
+                command: "rust-analyzer",
+                args: [],
+                env: [:],
+                rootMarkers: [],
+                enabled: true
+            )
+        ])
+        let mgr = WorkspaceLSPManager(
+            registry: registry,
+            makeAvailability: {
+                LanguageServerAvailability(
+                    environment: ["PATH": dir.path],
+                    xcrunFind: { _ in nil },
+                    additionalPathDirectories: [],
+                    gatekeeperAssessor: { _ in .allowed }
+                )
+            }
+        )
+
+        #expect(mgr.availabilityStatus(forLanguage: "rust") == .notInstalled)
+        #expect(FileManager.default.createFile(atPath: executable.path, contents: Data()))
+        try FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: executable.path)
+        #expect(mgr.availabilityStatus(forLanguage: "rust") == .available)
+    }
+
     @Test func openDocumentRemediatesGatekeeperBlockBeforeSpawning() async {
         final class Box {
             let path = "/usr/bin/true"


### PR DESCRIPTION
## Summary

Fixes #686 by avoiding repeated synchronous `xcrun --find sourcekit-lsp` probes from render-adjacent LSP status paths.

## Changes

- Cache default `xcrun --find` results, including missing results, for the app process.
- Cache `.notInstalled` in `WorkspaceLSPManager.availabilityStatus(forLanguage:)` only for the Swift `sourcekit-lsp` fallback, so recipe-less/manual installs for other servers can be detected on later probes.
- Add explicit availability-cache invalidation after install and Gatekeeper remediation success.
- Reduce Settings > Code language rows to a single availability probe per row.
- Add regression tests for cached Swift `sourcekit-lsp` misses and non-xcrun missing server re-probing.

## Validation

- `ALAS_FFF_TARGET_ARCH=arm64 rtk xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -quiet build`
- `ALAS_FFF_TARGET_ARCH=arm64 rtk xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -only-testing:AlasTests/WorkspaceLSPManagerStatusTests/notInstalledStatusIsCachedUntilInvalidated -only-testing:AlasTests/WorkspaceLSPManagerStatusTests/nonXcrunNotInstalledStatusIsReprobed -resultBundlePath /tmp/alas-686-cache-tests.xcresult -quiet test`

Note: the full `WorkspaceLSPManagerStatusTests` suite currently exits 65 with existing signal-pipe crashes in LSP process tests; the focused cache regression tests pass by themselves.