### PR TITLE
feat(acp): attach project MCP servers

### DIFF
--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -580,6 +580,7 @@
 		839AF384DDFF728207769920 /* ACPContentBlockImageTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4D4DEBF2A9CFDCFDAD288499 /* ACPContentBlockImageTests.swift */; };
 		83A76F6425CD1406DA85B0E9 /* ACPUserScrollEventTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0535D92433898E76670B9FF0 /* ACPUserScrollEventTests.swift */; };
 		84103C99FE430DB2B36982D1 /* OpenSessionsSection.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE35A47BA74E306A4699B27D /* OpenSessionsSection.swift */; };
+		847356E199302CCFDA9172DA /* ACPMCPStatusPolicyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E64221361A2743CDAD692E64 /* ACPMCPStatusPolicyTests.swift */; };
 		84AFBFC844DF35AF5D37445B /* ACPGoalPillTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BA7FA6A8011D88FDFEE30A0 /* ACPGoalPillTests.swift */; };
 		84C505BF196A3BDA23C80235 /* LanguageServerConfigMasonPrefill.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC01D9A0927AF9DD7524CEB7 /* LanguageServerConfigMasonPrefill.swift */; };
 		84E96EB0EF4267784462B866 /* ACPComposerImageExtractTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A637073E5D65DAA4E0CF6EA4 /* ACPComposerImageExtractTests.swift */; };
@@ -843,6 +844,7 @@
 		BAE4D422FC3950E61FEE1D15 /* AppIntents.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = CA43AA9C8462D579E733B46C /* AppIntents.framework */; };
 		BAE6B1D93387807ADD7ED0CC /* ACPImageThumbnail.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5E1462C85D0E49127BCED81 /* ACPImageThumbnail.swift */; };
 		BB565B8EE9BA20EE961B32FB /* ThemeSidebarContrastTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B70ED4990428C46B69784970 /* ThemeSidebarContrastTests.swift */; };
+		BBACA7DCC1EFA6D55AEB38CE /* ACPMCPStatusControl.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1936C815E64C7DB204340469 /* ACPMCPStatusControl.swift */; };
 		BC0EC69E1BC62514BBE129E7 /* OpenSessionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEFCC9CAC7B3254708748815 /* OpenSessionsTests.swift */; };
 		BC19B95DAAC3943FF1BE5817 /* CommitTabView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 59DBB72EE97F0E906442919B /* CommitTabView.swift */; };
 		BC4B8B193F020CBEA02B01A6 /* ACPMessageWireTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2468AD293C8215FAF390C907 /* ACPMessageWireTests.swift */; };
@@ -943,6 +945,7 @@
 		CF81F0AE28C56D1DF5AD871B /* SurfaceViewShortcutTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2935EB661338757C478CD86 /* SurfaceViewShortcutTests.swift */; };
 		D002012348D4DA7E124632BF /* SpacePagerIndicator.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9294E94F46763CC8DCD93A3 /* SpacePagerIndicator.swift */; };
 		D05BDEF0D8651A9C2BD8C857 /* Seg.swift in Sources */ = {isa = PBXBuildFile; fileRef = 489C9B383554D7DAB170C2F8 /* Seg.swift */; };
+		D0F370E528AA4D07814AEB15 /* ACPMCPStatusPolicy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C051018EB105E225122750C /* ACPMCPStatusPolicy.swift */; };
 		D0F4A4F5BF5F1C3C625F11D9 /* Clipboard.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0E6600436B01C75D85C01FFA /* Clipboard.swift */; };
 		D10A8F47A537C1C8969752B1 /* ACPMessageTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8A0A083659269CDD16A6764 /* ACPMessageTests.swift */; };
 		D11DB95BC2F7094756EBCAC3 /* ACPSessionDiscovery.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63376280CA1D01F9D564A6F6 /* ACPSessionDiscovery.swift */; };
@@ -1272,6 +1275,7 @@
 		1874031C788ADB4398151FF1 /* StageChip.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StageChip.swift; sourceTree = "<group>"; };
 		18B5372BF572EBA3A84113E4 /* AgentLifecycleEventMapperTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentLifecycleEventMapperTests.swift; sourceTree = "<group>"; };
 		18CA47D5E0D1BF962CF45ABE /* AgentHookInstallNudgeBanner.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentHookInstallNudgeBanner.swift; sourceTree = "<group>"; };
+		1936C815E64C7DB204340469 /* ACPMCPStatusControl.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPMCPStatusControl.swift; sourceTree = "<group>"; };
 		1977C85C3DFD1F232A2755AD /* FilesTabFilterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FilesTabFilterTests.swift; sourceTree = "<group>"; };
 		19C327BB65463E878DDCDA5E /* MarkdownFileTypeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MarkdownFileTypeTests.swift; sourceTree = "<group>"; };
 		1A17A797374500E1FDD2382C /* PersistenceStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PersistenceStore.swift; sourceTree = "<group>"; };
@@ -1348,6 +1352,7 @@
 		2B9E3F080F847EF069137844 /* ShortcutBinding.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShortcutBinding.swift; sourceTree = "<group>"; };
 		2BFCE07604D55558B13FC33B /* DiffOpenFileAvailabilityTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiffOpenFileAvailabilityTests.swift; sourceTree = "<group>"; };
 		2BFD4C762D8323B78934ECE7 /* BranchPicker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BranchPicker.swift; sourceTree = "<group>"; };
+		2C051018EB105E225122750C /* ACPMCPStatusPolicy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPMCPStatusPolicy.swift; sourceTree = "<group>"; };
 		2C17465AF6747EDCD8CCE416 /* ReviewSessionLoader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReviewSessionLoader.swift; sourceTree = "<group>"; };
 		2C2381497E73D74C8C314928 /* AgentRegistryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentRegistryTests.swift; sourceTree = "<group>"; };
 		2C84E444E25F7DDBE30FB824 /* ReviewFeedbackBundleTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReviewFeedbackBundleTests.swift; sourceTree = "<group>"; };
@@ -2172,6 +2177,7 @@
 		E5788263AE679D146F9BF49C /* MergeConflictMinimap.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MergeConflictMinimap.swift; sourceTree = "<group>"; };
 		E5A257562FAB9C5932A6BD69 /* DiffPaneViewTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiffPaneViewTests.swift; sourceTree = "<group>"; };
 		E63FA8816D43E1A08AE8164B /* .gitkeep */ = {isa = PBXFileReference; path = .gitkeep; sourceTree = "<group>"; };
+		E64221361A2743CDAD692E64 /* ACPMCPStatusPolicyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPMCPStatusPolicyTests.swift; sourceTree = "<group>"; };
 		E69452CB123EB0AABB632F03 /* ACPComposerActionButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPComposerActionButton.swift; sourceTree = "<group>"; };
 		E6CA3930F30444A51FB2393D /* Theme.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Theme.swift; sourceTree = "<group>"; };
 		E6DE88BE229FD6C1DF35F7EA /* ACPToolbar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPToolbar.swift; sourceTree = "<group>"; };
@@ -3164,6 +3170,7 @@
 				50F0FBAC37A6C6A46C8D426E /* ACPMarkdownInlineRendererTests.swift */,
 				7F4B57FBB6E595E5DF1C6F93 /* ACPMarkdownLiveStylerImageChipTests.swift */,
 				8718406234B8C879B9D0CAB1 /* ACPMarkdownTextBareURLTests.swift */,
+				E64221361A2743CDAD692E64 /* ACPMCPStatusPolicyTests.swift */,
 				E941397D0207F68135B3464D /* ACPMentionPickerTests.swift */,
 				9272E334A0A5DF460514CF01 /* ACPMessageListPaginationTests.swift */,
 				D0CE3F0637B3CA27B1D87080 /* ACPNewChatEmptyStateTests.swift */,
@@ -3472,6 +3479,8 @@
 				84A01D6512394EF1C41782AD /* ACPMarkdownInlineTextView.swift */,
 				2AE565966DD010FDFD7DFF50 /* ACPMarkdownLiveStyler.swift */,
 				DE2AC16E9220C05F670BE3EB /* ACPMarkdownText.swift */,
+				1936C815E64C7DB204340469 /* ACPMCPStatusControl.swift */,
+				2C051018EB105E225122750C /* ACPMCPStatusPolicy.swift */,
 				329882D757C34246C9848C3A /* ACPMentionChipAttachment.swift */,
 				E49006251DFBE67CCD0C4008 /* ACPMentionPicker.swift */,
 				29FCCD153F9C2AF78A7B2E47 /* ACPMessageGutter.swift */,
@@ -4602,6 +4611,8 @@
 				5789FC76BEC6965E56C2DF3C /* ACPLaunchPathResolver.swift in Sources */,
 				542C76AF3A21CBD6B2838CEE /* ACPLaunchSpec.swift in Sources */,
 				6294D44BE2DC7F96933F7C4B /* ACPMCPServer.swift in Sources */,
+				BBACA7DCC1EFA6D55AEB38CE /* ACPMCPStatusControl.swift in Sources */,
+				D0F370E528AA4D07814AEB15 /* ACPMCPStatusPolicy.swift in Sources */,
 				B1665774383C03F0C0765A43 /* ACPMarkdownBlockCache.swift in Sources */,
 				7ABF2BE84D6677FE5BCC8ED1 /* ACPMarkdownInlineRenderer.swift in Sources */,
 				88C1A4EBC12F7F7BA7FE9B06 /* ACPMarkdownInlineTextView.swift in Sources */,
@@ -5207,6 +5218,7 @@
 				864B31874E286ED036347975 /* ACPLaunchSpecNpmPackageTests.swift in Sources */,
 				7433DB9396574A02DBF9953D /* ACPLaunchSpecTests.swift in Sources */,
 				BD0DE08853936F416EFD377C /* ACPMCPServerTests.swift in Sources */,
+				847356E199302CCFDA9172DA /* ACPMCPStatusPolicyTests.swift in Sources */,
 				965621529CB4BD82DD646B76 /* ACPManagerAccessorsTests.swift in Sources */,
 				21A94ADFA16F85C7ACAB4DA1 /* ACPMarkdownBlockCacheTests.swift in Sources */,
 				BDA40E9BFA15217CDED5B2F0 /* ACPMarkdownInlineRendererTests.swift in Sources */,

--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -450,6 +450,7 @@
 		62055BD147E504C658B93E20 /* ACPFirstRunConnectingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 737A9A3D11EA28582CA5D061 /* ACPFirstRunConnectingView.swift */; };
 		6256EAEB315812ED4F4E9107 /* StageChip.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1874031C788ADB4398151FF1 /* StageChip.swift */; };
 		6291072E82FC282625FD1617 /* GitServiceCommitEditingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F3AB3D6DF4A23648F0C45AC5 /* GitServiceCommitEditingTests.swift */; };
+		6294D44BE2DC7F96933F7C4B /* ACPMCPServer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 99CD81CC540ACCF1132E62A8 /* ACPMCPServer.swift */; };
 		629B98E07ED9A159A695707D /* JetBrainsMonoNerdFont-Regular.ttf in Resources */ = {isa = PBXBuildFile; fileRef = 9110E0F4F4EF24444FA0BE3A /* JetBrainsMonoNerdFont-Regular.ttf */; };
 		63327D1ACC38C6559F2FDA99 /* CodeHostProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 031B1108F04B06EAC224AB5B /* CodeHostProvider.swift */; };
 		636ED129478744F9169AD774 /* ProjectConfigAgentOverrideTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1FD24B10ED0B3D4280F15E8 /* ProjectConfigAgentOverrideTests.swift */; };
@@ -843,6 +844,7 @@
 		BC19B95DAAC3943FF1BE5817 /* CommitTabView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 59DBB72EE97F0E906442919B /* CommitTabView.swift */; };
 		BC4B8B193F020CBEA02B01A6 /* ACPMessageWireTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2468AD293C8215FAF390C907 /* ACPMessageWireTests.swift */; };
 		BC98C2BCDB4F6C88C66117A6 /* InlineErrorStrip.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7206BC51596AE2A57D8B28B /* InlineErrorStrip.swift */; };
+		BD0DE08853936F416EFD377C /* ACPMCPServerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C53CBDB829C193CF9294E28D /* ACPMCPServerTests.swift */; };
 		BD1CDAECF2D1928C95796F63 /* ACPSessionStoreQueueTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03D901BF4399752A3FC658F8 /* ACPSessionStoreQueueTests.swift */; };
 		BD8E82E61D1E23931FE69C1D /* SidebarVisibilityTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 98A00D845A8B82E27B7D2352 /* SidebarVisibilityTests.swift */; };
 		BDA40E9BFA15217CDED5B2F0 /* ACPMarkdownInlineRendererTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50F0FBAC37A6C6A46C8D426E /* ACPMarkdownInlineRendererTests.swift */; };
@@ -1820,6 +1822,7 @@
 		987FAB1E4DB4B81D5D0902B1 /* AppConfigMarkdownTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppConfigMarkdownTests.swift; sourceTree = "<group>"; };
 		98A00D845A8B82E27B7D2352 /* SidebarVisibilityTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SidebarVisibilityTests.swift; sourceTree = "<group>"; };
 		98A7F35818C95A567DDA586A /* ACPSelectChipTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPSelectChipTests.swift; sourceTree = "<group>"; };
+		99CD81CC540ACCF1132E62A8 /* ACPMCPServer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPMCPServer.swift; sourceTree = "<group>"; };
 		99CD99C81057F377C5E249B7 /* StagedDiffLoaderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StagedDiffLoaderTests.swift; sourceTree = "<group>"; };
 		9A06D96DE3FEBF63E7A157DD /* HunkPatchBuilder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HunkPatchBuilder.swift; sourceTree = "<group>"; };
 		9A187BD52742E8F4A6E52667 /* tool-call-content-diff.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "tool-call-content-diff.json"; sourceTree = "<group>"; };
@@ -1999,6 +2002,7 @@
 		C4E0BB32D1A3B26473464A0F /* ZmxEnv.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ZmxEnv.swift; sourceTree = "<group>"; };
 		C506EF972D34E2F937D4FEEC /* InstallerHost.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InstallerHost.swift; sourceTree = "<group>"; };
 		C50700F7960B44D0116F09C8 /* DiffCodeText.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiffCodeText.swift; sourceTree = "<group>"; };
+		C53CBDB829C193CF9294E28D /* ACPMCPServerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPMCPServerTests.swift; sourceTree = "<group>"; };
 		C54F4827435F746DC54616D0 /* HookInstallNudgeResolverTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HookInstallNudgeResolverTests.swift; sourceTree = "<group>"; };
 		C5679CA959D40E1682A91F31 /* PendingReview.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PendingReview.swift; sourceTree = "<group>"; };
 		C56EFAFF71ABDBCDECAAA305 /* StartupScriptInstaller.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StartupScriptInstaller.swift; sourceTree = "<group>"; };
@@ -2806,6 +2810,7 @@
 				701F837327D905FAAA0E0AF3 /* ACPConnectionTests.swift */,
 				4D4DEBF2A9CFDCFDAD288499 /* ACPContentBlockImageTests.swift */,
 				9DF8B5E766D2B3649D2555ED /* ACPInitializeTests.swift */,
+				C53CBDB829C193CF9294E28D /* ACPMCPServerTests.swift */,
 				11BA9F25CB0A6A2BFDB390EE /* ACPMockClientTests.swift */,
 				2B932ED9D5A485AE1545223C /* ACPPermissionFSTests.swift */,
 				C2D7EA3F2B69C0A8D2F8F8A5 /* ACPPromptCapabilitiesTests.swift */,
@@ -3182,6 +3187,7 @@
 				88C6356C759B509DD81EDEBB /* ACPConfigOption.swift */,
 				E4C4BEC7F392AF938F468B1F /* ACPConnection.swift */,
 				435D9E527A76820947F426A8 /* ACPFilesystem.swift */,
+				99CD81CC540ACCF1132E62A8 /* ACPMCPServer.swift */,
 				D46B68FD01B15E3EEA09CB79 /* ACPMessages.swift */,
 				074A17527610230DCFBEA13C /* ACPMockClient.swift */,
 				67E03BF5DB4E6BFF8C2FA6A2 /* ACPPermissionRequest.swift */,
@@ -4583,6 +4589,7 @@
 				433EC05E13C676C1C2EB6888 /* ACPLaunchCatalog.swift in Sources */,
 				5789FC76BEC6965E56C2DF3C /* ACPLaunchPathResolver.swift in Sources */,
 				542C76AF3A21CBD6B2838CEE /* ACPLaunchSpec.swift in Sources */,
+				6294D44BE2DC7F96933F7C4B /* ACPMCPServer.swift in Sources */,
 				B1665774383C03F0C0765A43 /* ACPMarkdownBlockCache.swift in Sources */,
 				7ABF2BE84D6677FE5BCC8ED1 /* ACPMarkdownInlineRenderer.swift in Sources */,
 				88C1A4EBC12F7F7BA7FE9B06 /* ACPMarkdownInlineTextView.swift in Sources */,
@@ -5185,6 +5192,7 @@
 				DD2553E3635BFE3B15355E08 /* ACPLaunchPathResolverTests.swift in Sources */,
 				864B31874E286ED036347975 /* ACPLaunchSpecNpmPackageTests.swift in Sources */,
 				7433DB9396574A02DBF9953D /* ACPLaunchSpecTests.swift in Sources */,
+				BD0DE08853936F416EFD377C /* ACPMCPServerTests.swift in Sources */,
 				965621529CB4BD82DD646B76 /* ACPManagerAccessorsTests.swift in Sources */,
 				21A94ADFA16F85C7ACAB4DA1 /* ACPMarkdownBlockCacheTests.swift in Sources */,
 				BDA40E9BFA15217CDED5B2F0 /* ACPMarkdownInlineRendererTests.swift in Sources */,

--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -195,6 +195,7 @@
 		2C520D1FB289610CEB70BDB6 /* GitServiceDiscardTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F936C036893FC70AD506FDD4 /* GitServiceDiscardTests.swift */; };
 		2C96C81EBF3C4B0951FA2A57 /* MarkdownFileType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5D486FD440D802AEC65D1555 /* MarkdownFileType.swift */; };
 		2C9C311A6DFC9DC5954F5CC2 /* RepoGroupView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 768D12909DD5233659AC4E03 /* RepoGroupView.swift */; };
+		2CEFCA2E399E7EADBFE3A064 /* ProjectMCPServerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 792BD8DAE4AAED201252C9E2 /* ProjectMCPServerTests.swift */; };
 		2D313A7E99C93242DD35AA8E /* CursorInstaller.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7948BA9EC461BA2E3617FBF0 /* CursorInstaller.swift */; };
 		2D3E3F75B6CBDF63A3FF2CD7 /* ACPStarterPrompt.swift in Sources */ = {isa = PBXBuildFile; fileRef = 96C6D6594CCA4EBC83BDF264 /* ACPStarterPrompt.swift */; };
 		2D6004EEFF10BA1E2B1357B9 /* SettingsSectionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E92F018C967A8D1421D83A06 /* SettingsSectionTests.swift */; };
@@ -526,6 +527,7 @@
 		771CD72B94194370E783F7DD /* StartupScriptResolverTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9D3C76F2F0F6BCE4023A9D7F /* StartupScriptResolverTests.swift */; };
 		77CDD88F7C517095DE580B50 /* ReviewEvidence.swift in Sources */ = {isa = PBXBuildFile; fileRef = FC11F5C6667A6ECB74E066AE /* ReviewEvidence.swift */; };
 		78D25A04EAE26A0F3021A057 /* Paths.swift in Sources */ = {isa = PBXBuildFile; fileRef = 364213292935A05F3B52F51F /* Paths.swift */; };
+		78D7FFD42803C098160BADC6 /* ProjectMCPServer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 81E981C10B13C43CE65DA74D /* ProjectMCPServer.swift */; };
 		79212B50265AAC9A392957C9 /* GitLFSBlobResolver.swift in Sources */ = {isa = PBXBuildFile; fileRef = 90F0CBE40E2CF0251ABE72AE /* GitLFSBlobResolver.swift */; };
 		7950F5765E0B95EB1CB5B818 /* ACPNewChatEmptyStatePolicy.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF80D59C3200AD3215D1E140 /* ACPNewChatEmptyStatePolicy.swift */; };
 		79575F0DA597D2C2DFCDC9E2 /* LSPMessagesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE7675D7F75E36E9C81193C8 /* LSPMessagesTests.swift */; };
@@ -1691,6 +1693,7 @@
 		781B8F6F0A3085FEBFC615C2 /* DefinitionPicker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefinitionPicker.swift; sourceTree = "<group>"; };
 		7831AEE2807254F6BCC5B65B /* GhosttyKit.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = GhosttyKit.xcframework; path = .build/ghostty/GhosttyKit.xcframework; sourceTree = "<group>"; };
 		784A5C206CA363AB14B709E6 /* RepoSelectorRecentsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RepoSelectorRecentsTests.swift; sourceTree = "<group>"; };
+		792BD8DAE4AAED201252C9E2 /* ProjectMCPServerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProjectMCPServerTests.swift; sourceTree = "<group>"; };
 		7948BA9EC461BA2E3617FBF0 /* CursorInstaller.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CursorInstaller.swift; sourceTree = "<group>"; };
 		795056B6AD803D2B555FC866 /* RightPaneStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RightPaneStore.swift; sourceTree = "<group>"; };
 		79624D3718BCE5CC605F0D6D /* DraftReviewRequestTabView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DraftReviewRequestTabView.swift; sourceTree = "<group>"; };
@@ -1727,6 +1730,7 @@
 		80BAFADCDC3E349AC3DBDDEA /* ACPPlanPillStateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPPlanPillStateTests.swift; sourceTree = "<group>"; };
 		8149AEEF45B05C60E06888E5 /* HoverWindowController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HoverWindowController.swift; sourceTree = "<group>"; };
 		81773A01826A91080F5A2E95 /* ACPCodeBlockHighlighterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPCodeBlockHighlighterTests.swift; sourceTree = "<group>"; };
+		81E981C10B13C43CE65DA74D /* ProjectMCPServer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProjectMCPServer.swift; sourceTree = "<group>"; };
 		822D37F962CC1C97981533A3 /* RepoSelectorModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RepoSelectorModel.swift; sourceTree = "<group>"; };
 		82387CFDFFBF52E639095C65 /* GitServiceBehindStatusTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GitServiceBehindStatusTests.swift; sourceTree = "<group>"; };
 		82E98F9835497D830C12AA8F /* CodeHostRemoteDetector.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CodeHostRemoteDetector.swift; sourceTree = "<group>"; };
@@ -3537,6 +3541,7 @@
 				1A17A797374500E1FDD2382C /* PersistenceStore.swift */,
 				BD77FB052C8B5A937B14A4AE /* ProjectConfig.swift */,
 				CDEB760B98A1482CF30140A4 /* ProjectIcon.swift */,
+				81E981C10B13C43CE65DA74D /* ProjectMCPServer.swift */,
 				7963D4DD10B67EB683510FF6 /* SpaceConfig.swift */,
 			);
 			path = Persistence;
@@ -4036,6 +4041,7 @@
 			isa = PBXGroup;
 			children = (
 				4D4F87B7B6F4A6E6ED882F1F /* HarnessConfigAutoRunTests.swift */,
+				792BD8DAE4AAED201252C9E2 /* ProjectMCPServerTests.swift */,
 			);
 			path = Persistence;
 			sourceTree = "<group>";
@@ -4970,6 +4976,7 @@
 				419029F5618BC364426491E5 /* ProjectIcon.swift in Sources */,
 				A0CAF1DC84D4D990617B96F7 /* ProjectIconImageStaging.swift in Sources */,
 				E8CD4B9C918E2A9A83FA637A /* ProjectIconView.swift in Sources */,
+				78D7FFD42803C098160BADC6 /* ProjectMCPServer.swift in Sources */,
 				E175AE346DFAD0B62827C921 /* ProjectPicker.swift in Sources */,
 				6E69D87B57B23223A48AB6F7 /* ProjectsManager.swift in Sources */,
 				50D7FF67981533B21FCB0890 /* PromptEditorBody.swift in Sources */,
@@ -5492,6 +5499,7 @@
 				2A18F8265F467BF33AD69159 /* ProjectGitWatcherTests.swift in Sources */,
 				9627D6EAF83AA4B66FE09361 /* ProjectIconImageStagingTests.swift in Sources */,
 				7F2D2A9180110871CFF58192 /* ProjectIconTests.swift in Sources */,
+				2CEFCA2E399E7EADBFE3A064 /* ProjectMCPServerTests.swift in Sources */,
 				4E7279E8E76C7778BC686DF1 /* ProjectPickerTests.swift in Sources */,
 				BEDFCA98CA9C992302618128 /* ProjectsManagerHeadUpdatesTests.swift in Sources */,
 				9C20E8B060C753308748CE05 /* ProjectsManagerProjectOrderingTests.swift in Sources */,

--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -678,6 +678,7 @@
 		99613CF61A0F19105D8E7A71 /* EmojiPickerButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7BEC4E033DB3BA44C825D453 /* EmojiPickerButton.swift */; };
 		99711AA1B0FB450D32770415 /* ZmxSunPathBudget.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A40BDC5115B641AB26220D9 /* ZmxSunPathBudget.swift */; };
 		999C8421F3610FF682CE9D0E /* ReviewTabView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 500B60003934104E2CA5A895 /* ReviewTabView.swift */; };
+		99CD435501BBBAAD8C4214D8 /* ProjectMCPServerEditorPolicyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 178EAF6036A9BEAEA2C55082 /* ProjectMCPServerEditorPolicyTests.swift */; };
 		9A3EB3ACA3AB366431C904EB /* WorktreeService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6C4E238E48247A6CDD5565D2 /* WorktreeService.swift */; };
 		9AB33F6B645EBA3F92A4E40F /* ACPSessionUpdate.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD1F34E025D235A5CECCE36E /* ACPSessionUpdate.swift */; };
 		9AC7E08307DA010181E2DE58 /* ACPFirstRunConnectingPolicy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B4BB6C10F3718F7D0A50BAE /* ACPFirstRunConnectingPolicy.swift */; };
@@ -692,6 +693,7 @@
 		9C73FEDF9B7B93D60FA3B51F /* ZmxClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = C47AF847BD698EAB373D128B /* ZmxClient.swift */; };
 		9C78AF82EA26A9928865C5C6 /* ACPSessionManagerAttachRestoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8D36A8AF55F212B9F32A944 /* ACPSessionManagerAttachRestoreTests.swift */; };
 		9C9EC609F3ED8EFF1151D611 /* JSONRPCFramerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F03C1E46A0853704E9B4449A /* JSONRPCFramerTests.swift */; };
+		9CB593F0CB94D2EEF6DE8D0D /* ProjectMCPServerEditorPolicy.swift in Sources */ = {isa = PBXBuildFile; fileRef = D9C7B2268F3CE7A5FEDF8580 /* ProjectMCPServerEditorPolicy.swift */; };
 		9CCB74669051D30EF12FE306 /* AlasGhostty.App.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2119507B66D09AF3DF347280 /* AlasGhostty.App.swift */; };
 		9CF654B4AB74CC1A9FBCE55F /* ACPContextRing.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF522B02666DB6AC4C82339E /* ACPContextRing.swift */; };
 		9CF6B43A0B19392A597A53EC /* ACPComposerActionButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = E69452CB123EB0AABB632F03 /* ACPComposerActionButton.swift */; };
@@ -1262,6 +1264,7 @@
 		169FC38D03727F34855EB521 /* AlasFieldTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlasFieldTests.swift; sourceTree = "<group>"; };
 		16C9E59E3987C1D3C9989D91 /* PaneTreeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaneTreeTests.swift; sourceTree = "<group>"; };
 		16CA8FEE64D73BDEBAF74878 /* Kbd.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Kbd.swift; sourceTree = "<group>"; };
+		178EAF6036A9BEAEA2C55082 /* ProjectMCPServerEditorPolicyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProjectMCPServerEditorPolicyTests.swift; sourceTree = "<group>"; };
 		179A74F3A825DA1EC4C4E0FC /* DebounceTimerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DebounceTimerTests.swift; sourceTree = "<group>"; };
 		17C2AC0F8B3A1B75239995AC /* AppState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppState.swift; sourceTree = "<group>"; };
 		17F7DB6F391F1AAA9FED1A86 /* ReviewLoopHandoffBuilder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReviewLoopHandoffBuilder.swift; sourceTree = "<group>"; };
@@ -2113,6 +2116,7 @@
 		D921D1C8A44F1937769CDB60 /* EditorBufferStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditorBufferStore.swift; sourceTree = "<group>"; };
 		D97EF761C70A3AF83C00879A /* VisualEffectView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VisualEffectView.swift; sourceTree = "<group>"; };
 		D99E47A1F0E3C85A34EABBE6 /* EditorLSPStatus.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditorLSPStatus.swift; sourceTree = "<group>"; };
+		D9C7B2268F3CE7A5FEDF8580 /* ProjectMCPServerEditorPolicy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProjectMCPServerEditorPolicy.swift; sourceTree = "<group>"; };
 		D9E6D61B213F3378243B4A26 /* AlasField.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlasField.swift; sourceTree = "<group>"; };
 		DA09B830D18CCEE251D0E10A /* EmptyTabViewTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EmptyTabViewTests.swift; sourceTree = "<group>"; };
 		DA5A64AEDC7F12F08DA8D2A5 /* RepoSelectorRow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RepoSelectorRow.swift; sourceTree = "<group>"; };
@@ -2640,6 +2644,7 @@
 				8E3A9C194105E52A72293855 /* ProjectGitWatcherTests.swift */,
 				270C700882ACFBBC59F931D2 /* ProjectIconImageStagingTests.swift */,
 				141C4CAF1B49032EDF0FF404 /* ProjectIconTests.swift */,
+				178EAF6036A9BEAEA2C55082 /* ProjectMCPServerEditorPolicyTests.swift */,
 				00809DCA566AAAADD7448659 /* ProjectPickerTests.swift */,
 				BD708EEB35D93A7E7150981D /* ProjectsManagerHeadUpdatesTests.swift */,
 				CB0315FB9B537C0A240CFA32 /* ProjectsManagerProjectOrderingTests.swift */,
@@ -2765,6 +2770,7 @@
 				711F3E7BD099EDADEA0802FD /* NewWorktreeDialog.swift */,
 				7A2B4B719D9F4EAAE84B14D1 /* ProjectAvatarPresetProvider.swift */,
 				C6B874BF8AEC4B60FC536E04 /* ProjectIconImageStaging.swift */,
+				D9C7B2268F3CE7A5FEDF8580 /* ProjectMCPServerEditorPolicy.swift */,
 				3CE948F94DB2759E66CD4DEF /* ProjectPicker.swift */,
 				C2E05FF3EC7EAB497BA0FFE0 /* RepoSelector */,
 			);
@@ -4991,6 +4997,7 @@
 				A0CAF1DC84D4D990617B96F7 /* ProjectIconImageStaging.swift in Sources */,
 				E8CD4B9C918E2A9A83FA637A /* ProjectIconView.swift in Sources */,
 				78D7FFD42803C098160BADC6 /* ProjectMCPServer.swift in Sources */,
+				9CB593F0CB94D2EEF6DE8D0D /* ProjectMCPServerEditorPolicy.swift in Sources */,
 				E175AE346DFAD0B62827C921 /* ProjectPicker.swift in Sources */,
 				6E69D87B57B23223A48AB6F7 /* ProjectsManager.swift in Sources */,
 				50D7FF67981533B21FCB0890 /* PromptEditorBody.swift in Sources */,
@@ -5515,6 +5522,7 @@
 				2A18F8265F467BF33AD69159 /* ProjectGitWatcherTests.swift in Sources */,
 				9627D6EAF83AA4B66FE09361 /* ProjectIconImageStagingTests.swift in Sources */,
 				7F2D2A9180110871CFF58192 /* ProjectIconTests.swift in Sources */,
+				99CD435501BBBAAD8C4214D8 /* ProjectMCPServerEditorPolicyTests.swift in Sources */,
 				2CEFCA2E399E7EADBFE3A064 /* ProjectMCPServerTests.swift in Sources */,
 				4E7279E8E76C7778BC686DF1 /* ProjectPickerTests.swift in Sources */,
 				BEDFCA98CA9C992302618128 /* ProjectsManagerHeadUpdatesTests.swift in Sources */,

--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -96,6 +96,7 @@
 		14BC25FE7259A545420F28AA /* ComposerAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE5FDAB31C577FC38CE53032 /* ComposerAction.swift */; };
 		14D70126BAF735B2A66A23C5 /* DiffReviewScrollSpyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F649B493D42787FEA6D8E67B /* DiffReviewScrollSpyTests.swift */; };
 		14DC8D8191E6E39E8741108D /* ReviewTabViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9CAED428443C9A7FE55E9A31 /* ReviewTabViewTests.swift */; };
+		159525C0A1B6C8E0B7C9FA9D /* ProjectMCPServerEditor.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD456A92D66BA31E0E74B836 /* ProjectMCPServerEditor.swift */; };
 		162363BDA6BC54B372C77B91 /* ACPMarkdownTextBareURLTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8718406234B8C879B9D0CAB1 /* ACPMarkdownTextBareURLTests.swift */; };
 		162A6ABEAE92BB3AD1511567 /* AdvancedSettingsVisibilityTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1CD33324CA36118FCEA2BE2 /* AdvancedSettingsVisibilityTests.swift */; };
 		165300DDFFB445D8AAE7A5E5 /* MarkdownFileTypeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 19C327BB65463E878DDCDA5E /* MarkdownFileTypeTests.swift */; };
@@ -719,6 +720,7 @@
 		A06C59805BCD9D3200896932 /* StagedDiffLoader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3B2FEDAAF927CDC9E4D19551 /* StagedDiffLoader.swift */; };
 		A0B5074B10E732616C917D10 /* DragHandleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1379AD82025AFEABD37EFC42 /* DragHandleTests.swift */; };
 		A0CAF1DC84D4D990617B96F7 /* ProjectIconImageStaging.swift in Sources */ = {isa = PBXBuildFile; fileRef = C6B874BF8AEC4B60FC536E04 /* ProjectIconImageStaging.swift */; };
+		A0D904EB04508A3DB97E9ECA /* ProjectMCPServerManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = AFDDDF6CCDD6CE4A78AEF8F2 /* ProjectMCPServerManager.swift */; };
 		A0F1E46BC1A9E2CC21805EE7 /* FilesTabFilterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1977C85C3DFD1F232A2755AD /* FilesTabFilterTests.swift */; };
 		A1252F6D967104D2B369CEA8 /* ReviewFeedbackBundleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C84E444E25F7DDBE30FB824 /* ReviewFeedbackBundleTests.swift */; };
 		A127B7AA4E95BEF74927FBDE /* WorktreePathTemplateRendererTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 71196F28AFF66FFA70E008D6 /* WorktreePathTemplateRendererTests.swift */; };
@@ -1916,6 +1918,7 @@
 		AF05DF16587C5A48A9E04B2A /* ACPSessionUsageTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPSessionUsageTests.swift; sourceTree = "<group>"; };
 		AF2F716F911BB20B3E78C40B /* AgentDefinition.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentDefinition.swift; sourceTree = "<group>"; };
 		AF522B02666DB6AC4C82339E /* ACPContextRing.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPContextRing.swift; sourceTree = "<group>"; };
+		AFDDDF6CCDD6CE4A78AEF8F2 /* ProjectMCPServerManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProjectMCPServerManager.swift; sourceTree = "<group>"; };
 		B0886F9B3096AC1264E3D337 /* ReviewFeedbackBundle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReviewFeedbackBundle.swift; sourceTree = "<group>"; };
 		B0D0ED01C390D1F729993B13 /* MarkdownImageLoaderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MarkdownImageLoaderTests.swift; sourceTree = "<group>"; };
 		B0D2C54087C4501C3E7793FE /* ChatPane.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatPane.swift; sourceTree = "<group>"; };
@@ -1974,6 +1977,7 @@
 		BCA9015C063CDD90D021D928 /* TreeSitterCSS */ = {isa = PBXFileReference; lastKnownFileType = folder; name = TreeSitterCSS; path = ThirdParty/TreeSitterCSS; sourceTree = SOURCE_ROOT; };
 		BCAB297DB983CBDD70CDDB24 /* ReviewRequestDiffLoaderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReviewRequestDiffLoaderTests.swift; sourceTree = "<group>"; };
 		BCE0DA8D81AE8E0BFE54D279 /* ACPImageBlocksTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPImageBlocksTests.swift; sourceTree = "<group>"; };
+		BD456A92D66BA31E0E74B836 /* ProjectMCPServerEditor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProjectMCPServerEditor.swift; sourceTree = "<group>"; };
 		BD4A3B9B1103346242438940 /* FilesTabView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FilesTabView.swift; sourceTree = "<group>"; };
 		BD708EEB35D93A7E7150981D /* ProjectsManagerHeadUpdatesTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProjectsManagerHeadUpdatesTests.swift; sourceTree = "<group>"; };
 		BD77FB052C8B5A937B14A4AE /* ProjectConfig.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProjectConfig.swift; sourceTree = "<group>"; };
@@ -2776,7 +2780,9 @@
 				711F3E7BD099EDADEA0802FD /* NewWorktreeDialog.swift */,
 				7A2B4B719D9F4EAAE84B14D1 /* ProjectAvatarPresetProvider.swift */,
 				C6B874BF8AEC4B60FC536E04 /* ProjectIconImageStaging.swift */,
+				BD456A92D66BA31E0E74B836 /* ProjectMCPServerEditor.swift */,
 				D9C7B2268F3CE7A5FEDF8580 /* ProjectMCPServerEditorPolicy.swift */,
+				AFDDDF6CCDD6CE4A78AEF8F2 /* ProjectMCPServerManager.swift */,
 				3CE948F94DB2759E66CD4DEF /* ProjectPicker.swift */,
 				C2E05FF3EC7EAB497BA0FFE0 /* RepoSelector */,
 			);
@@ -5008,7 +5014,9 @@
 				A0CAF1DC84D4D990617B96F7 /* ProjectIconImageStaging.swift in Sources */,
 				E8CD4B9C918E2A9A83FA637A /* ProjectIconView.swift in Sources */,
 				78D7FFD42803C098160BADC6 /* ProjectMCPServer.swift in Sources */,
+				159525C0A1B6C8E0B7C9FA9D /* ProjectMCPServerEditor.swift in Sources */,
 				9CB593F0CB94D2EEF6DE8D0D /* ProjectMCPServerEditorPolicy.swift in Sources */,
+				A0D904EB04508A3DB97E9ECA /* ProjectMCPServerManager.swift in Sources */,
 				E175AE346DFAD0B62827C921 /* ProjectPicker.swift in Sources */,
 				6E69D87B57B23223A48AB6F7 /* ProjectsManager.swift in Sources */,
 				50D7FF67981533B21FCB0890 /* PromptEditorBody.swift in Sources */,

--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -764,6 +764,7 @@
 		AC2EA26D999115E66DF40142 /* ACPChangeNotifierTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CFB62547E5E1FD480BD0322 /* ACPChangeNotifierTests.swift */; };
 		AC47E67A657F67FF9374C654 /* DiffTabView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F15E14D45EC3926768DE5BD1 /* DiffTabView.swift */; };
 		AC905947E88C7A2BE39D9B00 /* AppIntents.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = CA43AA9C8462D579E733B46C /* AppIntents.framework */; };
+		AC915AF49731E075051CA4FC /* MCPAttachmentPlanner.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA6486CAD3FE633F9B6F4ABF /* MCPAttachmentPlanner.swift */; };
 		ACB0AD03C9DFD88A431E6BC5 /* OutdatedThreadsDrawer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 699EA14937A07B8DDD57F401 /* OutdatedThreadsDrawer.swift */; };
 		ACD22D2C262833B77006E8BE /* DeleteFailedWorktreeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1944B7BC9FC74CD09D816B6 /* DeleteFailedWorktreeView.swift */; };
 		ACDDE4B18A94164BDFEED06B /* BranchOpsMenu.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6BAD20759A17B6EFE3AC0C81 /* BranchOpsMenu.swift */; };
@@ -892,6 +893,7 @@
 		C5644E1144140B99E8676064 /* ACPSlashPicker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 93C3F02ECEA5D545FA268DB8 /* ACPSlashPicker.swift */; };
 		C618DE3EE2A7CA06876D6C68 /* Process+Git.swift in Sources */ = {isa = PBXBuildFile; fileRef = 79DDEA496740F5B0B5EE808B /* Process+Git.swift */; };
 		C653712419D5B5A78AA53E84 /* AgentsPaneTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB5E3661944CDA65ABCCB826 /* AgentsPaneTests.swift */; };
+		C679AA50F077B1EBC0D4CC82 /* MCPAttachmentPlannerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 532AA1B8AD5E8139D2EEE948 /* MCPAttachmentPlannerTests.swift */; };
 		C6991F6E93C1EBCFCD5EE003 /* ReviewScopeSelection.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8D583586BC5171D2FE91F6C /* ReviewScopeSelection.swift */; };
 		C70D6BEC5321C16B70301CBF /* GitService+ReviewRequestDraft.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0EE97D2D6875CD6A1DBF4DE9 /* GitService+ReviewRequestDraft.swift */; };
 		C7A839C87B7C9F70F5BD6631 /* CompletionEngine.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50B0831638833C386E5CC9E8 /* CompletionEngine.swift */; };
@@ -1537,6 +1539,7 @@
 		530767799372FE03C3695656 /* ACPCodeBlockHighlighter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPCodeBlockHighlighter.swift; sourceTree = "<group>"; };
 		5319C6707FCBA825E5CB1003 /* HookInstallNudgeResolver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HookInstallNudgeResolver.swift; sourceTree = "<group>"; };
 		531DB20F5FBC0D8240778FE6 /* InlineDiffView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InlineDiffView.swift; sourceTree = "<group>"; };
+		532AA1B8AD5E8139D2EEE948 /* MCPAttachmentPlannerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MCPAttachmentPlannerTests.swift; sourceTree = "<group>"; };
 		5337D60F19641CF933A1F855 /* CloseTabConfirmationPolicyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CloseTabConfirmationPolicyTests.swift; sourceTree = "<group>"; };
 		5377288BFD5A1B410E141C54 /* ThreePaneLayout.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThreePaneLayout.swift; sourceTree = "<group>"; };
 		53C0EBA9F81668C89977770E /* ACPLaunchPathResolver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPLaunchPathResolver.swift; sourceTree = "<group>"; };
@@ -1884,6 +1887,7 @@
 		A919B8770029DBE7FCFF0EE2 /* AgentRunner.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentRunner.swift; sourceTree = "<group>"; };
 		A9294E94F46763CC8DCD93A3 /* SpacePagerIndicator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpacePagerIndicator.swift; sourceTree = "<group>"; };
 		A98D0A96093087BF4C284053 /* AlasSlider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlasSlider.swift; sourceTree = "<group>"; };
+		AA6486CAD3FE633F9B6F4ABF /* MCPAttachmentPlanner.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MCPAttachmentPlanner.swift; sourceTree = "<group>"; };
 		AA98E1DB8D77DE67918D6B9F /* CopilotInstallerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CopilotInstallerTests.swift; sourceTree = "<group>"; };
 		AAEDACEB27E6AF219054496E /* DialogChrome.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DialogChrome.swift; sourceTree = "<group>"; };
 		AB3DAB779A962AC2092A2879 /* CommitTabViewTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommitTabViewTests.swift; sourceTree = "<group>"; };
@@ -3223,6 +3227,7 @@
 				0B0317FF3C6E6D3F149FB4F5 /* ACPTranscript.swift */,
 				04B44F1DD775D2543439D508 /* ACPTranscriptMarkdown.swift */,
 				87F9063CCA0DA839EB342993 /* CursorModelVariants.swift */,
+				AA6486CAD3FE633F9B6F4ABF /* MCPAttachmentPlanner.swift */,
 				9F3A345F0B643467352DB5F3 /* ProcessKiller.swift */,
 				BFE0C069E5446132D39C4DE5 /* QueuedPrompt.swift */,
 			);
@@ -3754,6 +3759,7 @@
 				A5069EF396F2CB8E81B2AD11 /* ACPTranscriptMarkdownTests.swift */,
 				7DCF803DF778CF9C06AC1579 /* ACPTranscriptWindowTests.swift */,
 				336ADD8484D99054ADDBA588 /* CursorModelVariantsTests.swift */,
+				532AA1B8AD5E8139D2EEE948 /* MCPAttachmentPlannerTests.swift */,
 				FC961032C642C166F17EFD99 /* QueuedPromptTests.swift */,
 			);
 			path = Session;
@@ -4917,6 +4923,7 @@
 				E468E95C778E0C9BE6F1EDED /* LegacyHookSweep.swift in Sources */,
 				DE431266B60826A2EA3736DF /* LineBuffer.swift in Sources */,
 				6866301B0A6F1F7488819B98 /* LineEnding.swift in Sources */,
+				AC915AF49731E075051CA4FC /* MCPAttachmentPlanner.swift in Sources */,
 				2C96C81EBF3C4B0951FA2A57 /* MarkdownFileType.swift in Sources */,
 				B3BA844FBD11333E74A05655 /* MarkdownImageLoader.swift in Sources */,
 				29418562DE5554B282C83D75 /* MarkdownParser.swift in Sources */,
@@ -5467,6 +5474,7 @@
 				9422B6F8F6C1E3E64B259712 /* LanguageServerRegistryTests.swift in Sources */,
 				599A6D9A3A1CCF1F618146C8 /* LegacyHookSweepTests.swift in Sources */,
 				DE41CB04CDC89D09346494A5 /* LineEndingTests.swift in Sources */,
+				C679AA50F077B1EBC0D4CC82 /* MCPAttachmentPlannerTests.swift in Sources */,
 				165300DDFFB445D8AAE7A5E5 /* MarkdownFileTypeTests.swift in Sources */,
 				6A5D19016FE0100CD54D24B2 /* MarkdownImageLoaderTests.swift in Sources */,
 				E2279478EBE8BF9CDC412EDE /* MarkdownParserTests.swift in Sources */,

--- a/Alas/Sources/ACP/Protocol/ACPConnection.swift
+++ b/Alas/Sources/ACP/Protocol/ACPConnection.swift
@@ -5,6 +5,7 @@ struct ACPInitializeOutcome: Equatable {
     let authMethods: [ACPInitializeResult.ACPAuthMethod]
     let loadSession: Bool
     let sessionCapabilities: ACPInitializeResult.ACPAgentSessionCapabilities
+    let mcpCapabilities: ACPMCPServerCapabilities
 }
 
 /// Higher-level wrapper that owns one `ACPClient` and exposes typed
@@ -30,7 +31,8 @@ final class ACPConnection: @unchecked Sendable {
             promptCapabilities: result.agentCapabilities?.promptCapabilities ?? .init(),
             authMethods: result.authMethods,
             loadSession: result.agentCapabilities?.loadSession ?? false,
-            sessionCapabilities: result.agentCapabilities?.sessionCapabilities ?? .init()
+            sessionCapabilities: result.agentCapabilities?.sessionCapabilities ?? .init(),
+            mcpCapabilities: result.agentCapabilities?.mcpCapabilities ?? .init()
         )
     }
 

--- a/Alas/Sources/ACP/Protocol/ACPConnection.swift
+++ b/Alas/Sources/ACP/Protocol/ACPConnection.swift
@@ -36,9 +36,9 @@ final class ACPConnection: @unchecked Sendable {
         )
     }
 
-    func newSession(cwd: String) async throws -> ACPSessionNewResult {
+    func newSession(cwd: String, mcpServers: [ACPMCPServer]) async throws -> ACPSessionNewResult {
         let req = ACPRequest(method: "session/new",
-                             params: ACPSessionNewParams(cwd: cwd, mcpServers: []))
+                             params: ACPSessionNewParams(cwd: cwd, mcpServers: mcpServers))
         let resp = try await client.send(req)
         let result = try JSONDecoder().decode(ACPSessionNewResult.self, from: resp.body)
         guard !result.sessionId.isEmpty else {
@@ -57,18 +57,18 @@ final class ACPConnection: @unchecked Sendable {
         ))
     }
 
-    func loadSession(cwd: String, sessionId: String) async throws -> ACPSessionNewResult {
+    func loadSession(cwd: String, sessionId: String, mcpServers: [ACPMCPServer]) async throws -> ACPSessionNewResult {
         let req = ACPRequest(method: "session/load",
-                             params: ACPSessionLoadParams(cwd: cwd, sessionId: sessionId, mcpServers: []))
+                             params: ACPSessionLoadParams(cwd: cwd, sessionId: sessionId, mcpServers: mcpServers))
         let resp = try await client.send(req)
         let result = try JSONDecoder().decode(ACPSessionNewResult.self, from: resp.body)
         return result.sessionId.isEmpty ? result.withSessionId(sessionId) : result
     }
 
-    func resumeSession(cwd: String, sessionId: String) async throws -> ACPSessionNewResult {
+    func resumeSession(cwd: String, sessionId: String, mcpServers: [ACPMCPServer]) async throws -> ACPSessionNewResult {
         let req = ACPRequest(
             method: "session/resume",
-            params: ACPSessionResumeParams(cwd: cwd, sessionId: sessionId, mcpServers: [])
+            params: ACPSessionResumeParams(cwd: cwd, sessionId: sessionId, mcpServers: mcpServers)
         )
         let resp = try await client.send(req)
         let result = try JSONDecoder().decode(ACPSessionNewResult.self, from: resp.body)
@@ -84,10 +84,10 @@ final class ACPConnection: @unchecked Sendable {
         return try JSONDecoder().decode(ACPSessionListResult.self, from: resp.body)
     }
 
-    func forkSession(cwd: String, sessionId: String) async throws -> ACPSessionNewResult {
+    func forkSession(cwd: String, sessionId: String, mcpServers: [ACPMCPServer]) async throws -> ACPSessionNewResult {
         let req = ACPRequest(
             method: "session/fork",
-            params: ACPSessionForkParams(cwd: cwd, sessionId: sessionId, mcpServers: [])
+            params: ACPSessionForkParams(cwd: cwd, sessionId: sessionId, mcpServers: mcpServers)
         )
         let resp = try await client.send(req)
         return try JSONDecoder().decode(ACPSessionNewResult.self, from: resp.body)

--- a/Alas/Sources/ACP/Protocol/ACPMCPServer.swift
+++ b/Alas/Sources/ACP/Protocol/ACPMCPServer.swift
@@ -1,0 +1,94 @@
+import Foundation
+
+struct ACPMCPKeyValue: Codable, Equatable {
+    let name: String
+    let value: String
+}
+
+enum ACPMCPServer: Codable, Equatable {
+    case stdio(name: String, command: String, args: [String], env: [ACPMCPKeyValue])
+    case http(name: String, url: String, headers: [ACPMCPKeyValue])
+    case sse(name: String, url: String, headers: [ACPMCPKeyValue])
+
+    private enum CodingKeys: String, CodingKey {
+        case type
+        case name
+        case command
+        case args
+        case env
+        case url
+        case headers
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        let type = try container.decodeIfPresent(String.self, forKey: .type)
+        let name = try container.decode(String.self, forKey: .name)
+
+        switch type {
+        case nil:
+            self = .stdio(
+                name: name,
+                command: try container.decode(String.self, forKey: .command),
+                args: try container.decodeIfPresent([String].self, forKey: .args) ?? [],
+                env: try container.decodeIfPresent([ACPMCPKeyValue].self, forKey: .env) ?? []
+            )
+        case "http":
+            self = .http(
+                name: name,
+                url: try container.decode(String.self, forKey: .url),
+                headers: try container.decodeIfPresent([ACPMCPKeyValue].self, forKey: .headers) ?? []
+            )
+        case "sse":
+            self = .sse(
+                name: name,
+                url: try container.decode(String.self, forKey: .url),
+                headers: try container.decodeIfPresent([ACPMCPKeyValue].self, forKey: .headers) ?? []
+            )
+        case let .some(type):
+            throw DecodingError.dataCorruptedError(
+                forKey: .type,
+                in: container,
+                debugDescription: "Unsupported MCP server type: \(type)"
+            )
+        }
+    }
+
+    func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+
+        switch self {
+        case let .stdio(name, command, args, env):
+            try container.encode(name, forKey: .name)
+            try container.encode(command, forKey: .command)
+            try container.encode(args, forKey: .args)
+            try container.encode(env, forKey: .env)
+        case let .http(name, url, headers):
+            try container.encode("http", forKey: .type)
+            try container.encode(name, forKey: .name)
+            try container.encode(url, forKey: .url)
+            try container.encode(headers, forKey: .headers)
+        case let .sse(name, url, headers):
+            try container.encode("sse", forKey: .type)
+            try container.encode(name, forKey: .name)
+            try container.encode(url, forKey: .url)
+            try container.encode(headers, forKey: .headers)
+        }
+    }
+}
+
+struct ACPMCPServerCapabilities: Codable, Equatable {
+    let http: Bool
+    let sse: Bool
+
+    init(http: Bool = false, sse: Bool = false) {
+        self.http = http
+        self.sse = sse
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        http = try container.decodeIfPresent(Bool.self, forKey: .http) ?? false
+        sse = try container.decodeIfPresent(Bool.self, forKey: .sse) ?? false
+    }
+}

--- a/Alas/Sources/ACP/Protocol/ACPMessages.swift
+++ b/Alas/Sources/ACP/Protocol/ACPMessages.swift
@@ -199,15 +199,18 @@ struct ACPInitializeResult: Codable, Equatable {
         let promptCapabilities: ACPPromptCapabilities?
         let loadSession: Bool
         let sessionCapabilities: ACPAgentSessionCapabilities
+        let mcpCapabilities: ACPMCPServerCapabilities
 
         init(
             promptCapabilities: ACPPromptCapabilities? = nil,
             loadSession: Bool = false,
-            sessionCapabilities: ACPAgentSessionCapabilities = .init()
+            sessionCapabilities: ACPAgentSessionCapabilities = .init(),
+            mcpCapabilities: ACPMCPServerCapabilities = .init()
         ) {
             self.promptCapabilities = promptCapabilities
             self.loadSession = loadSession
             self.sessionCapabilities = sessionCapabilities
+            self.mcpCapabilities = mcpCapabilities
         }
 
         init(from decoder: Decoder) throws {
@@ -218,6 +221,7 @@ struct ACPInitializeResult: Codable, Equatable {
                 ACPAgentSessionCapabilities.self,
                 forKey: .sessionCapabilities
             ) ?? .init()
+            mcpCapabilities = try c.decodeIfPresent(ACPMCPServerCapabilities.self, forKey: .mcpCapabilities) ?? .init()
         }
     }
 
@@ -529,12 +533,6 @@ struct AnyCodable: Codable, Equatable, Hashable, @unchecked Sendable {
 struct ACPSessionNewParams: Codable, Equatable {
     let cwd: String
     let mcpServers: [ACPMCPServer]
-
-    struct ACPMCPServer: Codable, Equatable {
-        let name: String
-        let command: String
-        let args: [String]
-    }
 }
 
 struct ACPModelInfo: Codable, Equatable, Identifiable, Hashable {
@@ -722,7 +720,7 @@ private struct ACPModesBlock: Decodable {
 struct ACPSessionLoadParams: Codable, Equatable {
     let cwd: String
     let sessionId: String
-    let mcpServers: [ACPSessionNewParams.ACPMCPServer]
+    let mcpServers: [ACPMCPServer]
 }
 
 // MARK: - session/list + session/resume + session/fork

--- a/Alas/Sources/ACP/Session/ACPSession.swift
+++ b/Alas/Sources/ACP/Session/ACPSession.swift
@@ -80,6 +80,9 @@ final class ACPSession: ObservableObject, Identifiable {
     /// Runtime-only: re-learned on each attach and used when an agent asks
     /// the client to authenticate before ACP can continue.
     @Published var authMethods: [ACPInitializeResult.ACPAuthMethod] = []
+    /// Runtime-only MCP attachment result for the most recent attach. It
+    /// contains no resolved commands, environment values, or headers.
+    @Published var mcpAttachmentSummary: MCPAttachmentSummary?
     /// Runtime-only auth method selected by the user in the sign-in banner.
     /// The next attach consumes it by calling ACP `authenticate` after
     /// initialize and before session creation/loading.

--- a/Alas/Sources/ACP/Session/ACPSessionManager.swift
+++ b/Alas/Sources/ACP/Session/ACPSessionManager.swift
@@ -12,6 +12,7 @@ private struct ACPTranscriptScrollMemory: Equatable {
 final class ACPSessionManager: ObservableObject {
     typealias ACPSetupEvaluator = @MainActor (_ spec: ACPLaunchSpec) async -> ACPSetupResult
     typealias ACPConnectionFactory = @MainActor (_ spec: ACPLaunchSpec) throws -> ACPConnection
+    typealias MCPProjectContextProvider = @MainActor () -> MCPProjectContext?
 
     let instanceId: String
     let pid: Int64
@@ -28,6 +29,7 @@ final class ACPSessionManager: ObservableObject {
     /// the user's unsaved edits rather than stale disk bytes.
     let onLiveBufferRead: ((String) -> String?)?
     private let onSessionTitleUpdated: ((ACPSession.ID, String) -> Void)?
+    private let mcpProjectContextProvider: MCPProjectContextProvider?
     @Published private(set) var sessions: [ACPSession.ID: ACPSession] = [:]
     @Published private(set) var recent: [ACPSessionRow] = []
     private(set) var runners: [ACPSession.ID: ACPSessionRunner] = [:]
@@ -202,7 +204,8 @@ final class ACPSessionManager: ObservableObject {
          onSessionTitleUpdated: ((ACPSession.ID, String) -> Void)? = nil,
          changeNotifier: ACPChangeNotifier? = nil,
          setupEvaluator: ACPSetupEvaluator? = nil,
-         connectionFactory: ACPConnectionFactory? = nil)
+         connectionFactory: ACPConnectionFactory? = nil,
+         mcpProjectContextProvider: MCPProjectContextProvider? = nil)
     {
         self.instanceId = instanceId
         self.pid = pid
@@ -212,6 +215,7 @@ final class ACPSessionManager: ObservableObject {
         self.onDirtyCheck = onDirtyCheck
         self.onLiveBufferRead = onLiveBufferRead
         self.onSessionTitleUpdated = onSessionTitleUpdated
+        self.mcpProjectContextProvider = mcpProjectContextProvider
         self.changeNotifier = changeNotifier ?? DarwinChangeNotifier(worktreeId: worktreeId)
         self.hydrator = hydratorPath.flatMap { try? ACPSessionHydrator(path: $0) }
         self.setupEvaluator = setupEvaluator ?? { spec in
@@ -1510,6 +1514,16 @@ extension ACPSessionManager {
             let initialized = try await connection.initialize()
             session.promptCapabilities = initialized.promptCapabilities
             session.authMethods = initialized.authMethods
+            let projectContext = mcpProjectContextProvider?()
+                ?? MCPProjectContext(projectDirectory: worktreePath, configuredServers: [])
+            let mcpPlan = MCPAttachmentPlanner.plan(.init(
+                configuredServers: projectContext.configuredServers,
+                projectDirectory: projectContext.projectDirectory,
+                worktreeDirectory: worktreePath,
+                environment: ProcessInfo.processInfo.environment,
+                capabilities: initialized.mcpCapabilities
+            ))
+            session.mcpAttachmentSummary = .init(plan: mcpPlan)
             if let pendingAuthMethodId = session.pendingAuthMethodId {
                 do {
                     try await connection.authenticate(methodId: pendingAuthMethodId)
@@ -1581,7 +1595,7 @@ extension ACPSessionManager {
                 session.firstRunConnectingPhase = .creatingSession
             }
             if freshlyCreated {
-                result = try await connection.newSession(cwd: worktreePath)
+                result = try await connection.newSession(cwd: worktreePath, mcpServers: mcpPlan.wireServers)
             } else if let remoteId = session.remoteSessionId, !remoteId.isEmpty {
                 if session.hasConversationTranscript {
                     session.contextRecoveryStatus = .restoring
@@ -1589,7 +1603,8 @@ extension ACPSessionManager {
                 switch restoreOperation {
                 case .resume:
                     do {
-                        result = try await connection.resumeSession(cwd: worktreePath, sessionId: remoteId)
+                        result = try await connection.resumeSession(
+                            cwd: worktreePath, sessionId: remoteId, mcpServers: mcpPlan.wireServers)
                         if !pendingRecovery {
                             session.contextRecoveryStatus = nil
                         }
@@ -1603,7 +1618,7 @@ extension ACPSessionManager {
                         guard session.origin == .alasCreated,
                               ACPAuthFailure.message(from: error) == nil
                         else { throw error }
-                        result = try await connection.newSession(cwd: worktreePath)
+                        result = try await connection.newSession(cwd: worktreePath, mcpServers: mcpPlan.wireServers)
                         if session.hasConversationTranscript {
                             shouldHoldQueueForRecovery = true
                             if !anotherLiveInstanceOwnsLease(sessionId: sessionId) {
@@ -1622,7 +1637,8 @@ extension ACPSessionManager {
                     }
                 case .loadStrict:
                     do {
-                        result = try await connection.loadSession(cwd: worktreePath, sessionId: remoteId)
+                        result = try await connection.loadSession(
+                            cwd: worktreePath, sessionId: remoteId, mcpServers: mcpPlan.wireServers)
                         runner.finishSuppressingLoadReplay(
                             throughYieldedUpdateCount: connection.client.yieldedUpdateCount
                         )
@@ -1637,7 +1653,8 @@ extension ACPSessionManager {
                     }
                 case .loadWithRecovery:
                     do {
-                        result = try await connection.loadSession(cwd: worktreePath, sessionId: remoteId)
+                        result = try await connection.loadSession(
+                            cwd: worktreePath, sessionId: remoteId, mcpServers: mcpPlan.wireServers)
                         runner.finishSuppressingLoadReplay(
                             throughYieldedUpdateCount: connection.client.yieldedUpdateCount
                         )
@@ -1651,7 +1668,7 @@ extension ACPSessionManager {
                         if ACPAuthFailure.message(from: error) != nil {
                             throw error
                         }
-                        result = try await connection.newSession(cwd: worktreePath)
+                        result = try await connection.newSession(cwd: worktreePath, mcpServers: mcpPlan.wireServers)
                         if session.hasConversationTranscript {
                             shouldHoldQueueForRecovery = true
                             // Guard the store write: if another instance took over
@@ -1675,7 +1692,7 @@ extension ACPSessionManager {
                     throw ACPSessionAttachError.remoteSessionUnsupported
                 }
             } else {
-                result = try await connection.newSession(cwd: worktreePath)
+                result = try await connection.newSession(cwd: worktreePath, mcpServers: mcpPlan.wireServers)
                 if session.hasConversationTranscript {
                     shouldHoldQueueForRecovery = true
                     // Guard the store write: if another instance took over

--- a/Alas/Sources/ACP/Session/ACPSessionManager.swift
+++ b/Alas/Sources/ACP/Session/ACPSessionManager.swift
@@ -1514,13 +1514,14 @@ extension ACPSessionManager {
             let initialized = try await connection.initialize()
             session.promptCapabilities = initialized.promptCapabilities
             session.authMethods = initialized.authMethods
+            let agentEnvironment = ACPProcessEnvironment.sanitizedForACP(extra: spec.extraEnv)
             let projectContext = mcpProjectContextProvider?()
                 ?? MCPProjectContext(projectDirectory: worktreePath, configuredServers: [])
             let mcpPlan = MCPAttachmentPlanner.plan(.init(
                 configuredServers: projectContext.configuredServers,
                 projectDirectory: projectContext.projectDirectory,
                 worktreeDirectory: worktreePath,
-                environment: ProcessInfo.processInfo.environment,
+                environment: agentEnvironment,
                 capabilities: initialized.mcpCapabilities
             ))
             session.mcpAttachmentSummary = .init(plan: mcpPlan)
@@ -1551,7 +1552,7 @@ extension ACPSessionManager {
             let runner = ACPSessionRunner(session: session, connection: connection,
                                           store: store, sessionId: sessionId,
                                           worktreePath: worktreePath,
-                                          agentEnv: ACPProcessEnvironment.sanitizedForACP(extra: spec.extraEnv),
+                                          agentEnv: agentEnvironment,
                                           suppressingLoadReplay: shouldSuppressLoadReplay,
                                           onDirtyCheck: onDirtyCheck,
                                           onLiveBufferRead: onLiveBufferRead,

--- a/Alas/Sources/ACP/Session/MCPAttachmentPlanner.swift
+++ b/Alas/Sources/ACP/Session/MCPAttachmentPlanner.swift
@@ -46,9 +46,16 @@ struct MCPAttachmentSummary: Equatable {
     let statuses: [MCPAttachmentServerStatus]
     let configurationFingerprint: String
 
+    init(statuses: [MCPAttachmentServerStatus], configurationFingerprint: String) {
+        self.statuses = statuses
+        self.configurationFingerprint = configurationFingerprint
+    }
+
     init(plan: MCPAttachmentPlan) {
-        statuses = plan.statuses
-        configurationFingerprint = plan.configurationFingerprint
+        self.init(
+            statuses: plan.statuses,
+            configurationFingerprint: plan.configurationFingerprint
+        )
     }
 }
 

--- a/Alas/Sources/ACP/Session/MCPAttachmentPlanner.swift
+++ b/Alas/Sources/ACP/Session/MCPAttachmentPlanner.swift
@@ -1,0 +1,315 @@
+import CryptoKit
+import Foundation
+
+enum MCPTransportKind: String, Codable, Equatable {
+    case stdio
+    case http
+    case sse
+}
+
+enum MCPAttachmentSkipReason: Equatable {
+    case unsupportedTransport
+    case missingVariable(String)
+    case invalidConfiguration(String)
+}
+
+enum MCPAttachmentDisposition: Equatable {
+    case requested
+    case skipped(MCPAttachmentSkipReason)
+}
+
+struct MCPAttachmentServerStatus: Equatable, Identifiable {
+    let name: String
+    let transport: MCPTransportKind
+    let disposition: MCPAttachmentDisposition
+
+    var id: String { "\(transport.rawValue):\(name)" }
+}
+
+struct MCPAttachmentPlan: Equatable {
+    let wireServers: [ACPMCPServer]
+    let statuses: [MCPAttachmentServerStatus]
+    let configurationFingerprint: String
+}
+
+struct MCPAttachmentPlannerInput {
+    let configuredServers: [ProjectMCPServer]
+    let projectDirectory: String
+    let worktreeDirectory: String
+    let environment: [String: String]
+    let capabilities: ACPMCPServerCapabilities
+}
+
+enum MCPAttachmentPlanner {
+    private enum ResolutionError: Error {
+        case missingVariable(String)
+    }
+    static func plan(_ input: MCPAttachmentPlannerInput) -> MCPAttachmentPlan {
+        let validationIssues = ProjectMCPValidation.validate(input.configuredServers)
+        let environment = resolvedEnvironment(for: input)
+        var wireServers: [ACPMCPServer] = []
+        var statuses: [MCPAttachmentServerStatus] = []
+
+        for server in input.configuredServers {
+            let transport = transportKind(for: server.transport)
+            let disposition: MCPAttachmentDisposition
+
+            if validationIssues.contains(where: { applies($0, to: server) && !isDeferredTemplateURLIssue($0, server: server) }) {
+                disposition = .skipped(.invalidConfiguration("The server configuration is invalid."))
+            } else if !isSupported(transport, capabilities: input.capabilities) {
+                disposition = .skipped(.unsupportedTransport)
+            } else {
+                switch makeWireServer(server, environment: environment) {
+                case let .success(wireServer):
+                    if hasValidResolvedURL(wireServer) {
+                        wireServers.append(wireServer)
+                        disposition = .requested
+                    } else {
+                        disposition = .skipped(.invalidConfiguration("The server configuration is invalid."))
+                    }
+                case let .failure(.missingVariable(variable)):
+                    disposition = .skipped(.missingVariable(variable))
+                }
+            }
+
+            statuses.append(.init(name: server.name, transport: transport, disposition: disposition))
+        }
+
+        return .init(
+            wireServers: wireServers,
+            statuses: statuses,
+            configurationFingerprint: configurationFingerprint(for: input.configuredServers)
+        )
+    }
+
+    static func configurationFingerprint(for servers: [ProjectMCPServer]) -> String {
+        let definitions = servers.map(FingerprintDefinition.init)
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.sortedKeys, .withoutEscapingSlashes]
+        let data = (try? encoder.encode(definitions)) ?? Data()
+        return SHA256.hash(data: data).map { String(format: "%02x", $0) }.joined()
+    }
+
+    private static func resolvedEnvironment(for input: MCPAttachmentPlannerInput) -> [String: String] {
+        var environment = input.environment
+        environment["PROJECT_DIR"] = input.projectDirectory
+        environment["WORKTREE_DIR"] = input.worktreeDirectory
+        return environment
+    }
+
+    private static func transportKind(for transport: ProjectMCPTransport) -> MCPTransportKind {
+        switch transport {
+        case .stdio: .stdio
+        case .http: .http
+        case .sse: .sse
+        }
+    }
+
+    private static func isSupported(_ transport: MCPTransportKind, capabilities: ACPMCPServerCapabilities) -> Bool {
+        switch transport {
+        case .stdio: true
+        case .http: capabilities.http
+        case .sse: capabilities.sse
+        }
+    }
+
+    private static func applies(_ issue: ProjectMCPValidationIssue, to server: ProjectMCPServer) -> Bool {
+        let name = server.name.trimmingCharacters(in: .whitespacesAndNewlines)
+        switch issue {
+        case let .emptyServerName(serverId):
+            return server.id == serverId
+        case let .duplicateServerName(serverName),
+             let .emptyCommand(serverName),
+             let .invalidURL(serverName),
+             let .invalidEnvironmentName(serverName, _),
+             let .duplicateEnvironmentName(serverName, _),
+             let .emptyHeaderName(serverName),
+             let .duplicateHeaderName(serverName, _):
+            return name == serverName
+        }
+    }
+
+    private static func isDeferredTemplateURLIssue(_ issue: ProjectMCPValidationIssue, server: ProjectMCPServer) -> Bool {
+        guard case .invalidURL = issue else { return false }
+        switch server.transport {
+        case let .http(url, _), let .sse(url, _):
+            return variableRegex.firstMatch(in: url, range: NSRange(url.startIndex..., in: url)) != nil
+        case .stdio:
+            return false
+        }
+    }
+
+    private static func hasValidResolvedURL(_ server: ACPMCPServer) -> Bool {
+        let value: String?
+        switch server {
+        case .stdio:
+            return true
+        case let .http(_, url, _), let .sse(_, url, _):
+            value = url
+        }
+        guard let value, value == value.trimmingCharacters(in: .whitespacesAndNewlines),
+              let url = URL(string: value), let host = url.host, !host.isEmpty else { return false }
+        return url.scheme?.lowercased() == "http" || url.scheme?.lowercased() == "https"
+    }
+
+    private static func makeWireServer(
+        _ server: ProjectMCPServer,
+        environment: [String: String]
+    ) -> Result<ACPMCPServer, ResolutionError> {
+        switch server.transport {
+        case let .stdio(command, args, variables):
+            guard let command = interpolate(command, environment: environment) else {
+                return .failure(.missingVariable(firstMissingVariable(in: command, environment: environment)!))
+            }
+            var resolvedArgs: [String] = []
+            for argument in args {
+                guard let argument = interpolate(argument, environment: environment) else {
+                    return .failure(.missingVariable(firstMissingVariable(in: argument, environment: environment)!))
+                }
+                resolvedArgs.append(argument)
+            }
+            var resolvedEnvironment: [ACPMCPKeyValue] = []
+            for variable in variables {
+                guard let value = interpolate(variable.value, environment: environment) else {
+                    return .failure(.missingVariable(firstMissingVariable(in: variable.value, environment: environment)!))
+                }
+                resolvedEnvironment.append(.init(name: variable.name, value: value))
+            }
+            return .success(.stdio(name: server.name, command: command, args: resolvedArgs, env: resolvedEnvironment))
+
+        case let .http(url, headers):
+            return makeRemoteWireServer(name: server.name, url: url, headers: headers, environment: environment, type: .http)
+        case let .sse(url, headers):
+            return makeRemoteWireServer(name: server.name, url: url, headers: headers, environment: environment, type: .sse)
+        }
+    }
+
+    private static func makeRemoteWireServer(
+        name: String,
+        url: String,
+        headers: [MCPKeyValue],
+        environment: [String: String],
+        type: MCPTransportKind
+    ) -> Result<ACPMCPServer, ResolutionError> {
+        guard let url = interpolate(url, environment: environment) else {
+            return .failure(.missingVariable(firstMissingVariable(in: url, environment: environment)!))
+        }
+        var resolvedHeaders: [ACPMCPKeyValue] = []
+        for header in headers {
+            guard let value = interpolate(header.value, environment: environment) else {
+                return .failure(.missingVariable(firstMissingVariable(in: header.value, environment: environment)!))
+            }
+            resolvedHeaders.append(.init(name: header.name, value: value))
+        }
+        switch type {
+        case .http:
+            return .success(.http(name: name, url: url, headers: resolvedHeaders))
+        case .sse:
+            return .success(.sse(name: name, url: url, headers: resolvedHeaders))
+        case .stdio:
+            preconditionFailure("Remote server must use an HTTP transport")
+        }
+    }
+
+    private static func interpolate(_ value: String, environment: [String: String]) -> String? {
+        guard firstMissingVariable(in: value, environment: environment) == nil else { return nil }
+        return replacingVariables(in: value, environment: environment)
+    }
+
+    private static func firstMissingVariable(in value: String, environment: [String: String]) -> String? {
+        for match in variableMatches(in: value) where environment[match] == nil {
+            return match
+        }
+        return nil
+    }
+
+    private static func replacingVariables(in value: String, environment: [String: String]) -> String {
+        var result = value
+        let matches = variableRegex.matches(in: value, range: NSRange(value.startIndex..., in: value))
+        for match in matches.reversed() {
+            guard let range = Range(match.range, in: result),
+                  let nameRange = Range(match.range(at: 1), in: result),
+                  let replacement = environment[String(result[nameRange])] else {
+                continue
+            }
+            result.replaceSubrange(range, with: replacement)
+        }
+        return result
+    }
+
+    private static func variableMatches(in value: String) -> [String] {
+        variableRegex.matches(in: value, range: NSRange(value.startIndex..., in: value)).compactMap { match in
+            guard let range = Range(match.range(at: 1), in: value) else { return nil }
+            return String(value[range])
+        }
+    }
+
+    private static let variableRegex = try! NSRegularExpression(pattern: #"\$\{([A-Za-z_][A-Za-z0-9_]*)\}"#)
+}
+
+private extension MCPAttachmentPlanner {
+    struct FingerprintDefinition: Encodable {
+        let name: String
+        let transport: FingerprintTransport
+
+        init(_ server: ProjectMCPServer) {
+            name = server.name
+            transport = .init(server.transport)
+        }
+    }
+
+    struct FingerprintKeyValue: Encodable {
+        let name: String
+        let value: String
+
+        init(_ value: MCPKeyValue) {
+            name = value.name
+            self.value = value.value
+        }
+    }
+
+    enum FingerprintTransport: Encodable {
+        case stdio(command: String, args: [String], environment: [FingerprintKeyValue])
+        case http(url: String, headers: [FingerprintKeyValue])
+        case sse(url: String, headers: [FingerprintKeyValue])
+
+        private enum CodingKeys: String, CodingKey {
+            case kind
+            case command
+            case args
+            case environment
+            case url
+            case headers
+        }
+
+        init(_ transport: ProjectMCPTransport) {
+            switch transport {
+            case let .stdio(command, args, environment):
+                self = .stdio(command: command, args: args, environment: environment.map(FingerprintKeyValue.init))
+            case let .http(url, headers):
+                self = .http(url: url, headers: headers.map(FingerprintKeyValue.init))
+            case let .sse(url, headers):
+                self = .sse(url: url, headers: headers.map(FingerprintKeyValue.init))
+            }
+        }
+
+        func encode(to encoder: Encoder) throws {
+            var container = encoder.container(keyedBy: CodingKeys.self)
+            switch self {
+            case let .stdio(command, args, environment):
+                try container.encode(MCPTransportKind.stdio, forKey: .kind)
+                try container.encode(command, forKey: .command)
+                try container.encode(args, forKey: .args)
+                try container.encode(environment, forKey: .environment)
+            case let .http(url, headers):
+                try container.encode(MCPTransportKind.http, forKey: .kind)
+                try container.encode(url, forKey: .url)
+                try container.encode(headers, forKey: .headers)
+            case let .sse(url, headers):
+                try container.encode(MCPTransportKind.sse, forKey: .kind)
+                try container.encode(url, forKey: .url)
+                try container.encode(headers, forKey: .headers)
+            }
+        }
+    }
+}

--- a/Alas/Sources/ACP/Session/MCPAttachmentPlanner.swift
+++ b/Alas/Sources/ACP/Session/MCPAttachmentPlanner.swift
@@ -189,11 +189,13 @@ enum MCPAttachmentPlanner {
         let value: String?
         switch server {
         case let .stdio(_, command, _, _):
-            return !command.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+            let trimmedCommand = command.trimmingCharacters(in: .whitespacesAndNewlines)
+            return command == trimmedCommand && !trimmedCommand.isEmpty
         case let .http(_, url, _), let .sse(_, url, _):
             value = url
         }
         guard let value, value == value.trimmingCharacters(in: .whitespacesAndNewlines),
+              !value.contains(where: \.isWhitespace),
               let url = URL(string: value), let host = url.host, !host.isEmpty else { return false }
         return url.scheme?.lowercased() == "http" || url.scheme?.lowercased() == "https"
     }

--- a/Alas/Sources/ACP/Session/MCPAttachmentPlanner.swift
+++ b/Alas/Sources/ACP/Session/MCPAttachmentPlanner.swift
@@ -61,7 +61,7 @@ enum MCPAttachmentPlanner {
             } else {
                 switch makeWireServer(server, environment: environment) {
                 case let .success(wireServer):
-                    if hasValidResolvedURL(wireServer) {
+                    if hasValidResolvedWireServer(wireServer) {
                         wireServers.append(wireServer)
                         disposition = .requested
                     } else {
@@ -139,11 +139,11 @@ enum MCPAttachmentPlanner {
         }
     }
 
-    private static func hasValidResolvedURL(_ server: ACPMCPServer) -> Bool {
+    private static func hasValidResolvedWireServer(_ server: ACPMCPServer) -> Bool {
         let value: String?
         switch server {
-        case .stdio:
-            return true
+        case let .stdio(_, command, _, _):
+            return !command.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
         case let .http(_, url, _), let .sse(_, url, _):
             value = url
         }

--- a/Alas/Sources/ACP/Session/MCPAttachmentPlanner.swift
+++ b/Alas/Sources/ACP/Session/MCPAttachmentPlanner.swift
@@ -27,11 +27,22 @@ struct MCPProjectContext: Equatable {
 }
 
 struct MCPAttachmentServerStatus: Equatable, Identifiable {
+    let id: String
     let name: String
     let transport: MCPTransportKind
     let disposition: MCPAttachmentDisposition
 
-    var id: String { "\(transport.rawValue):\(name)" }
+    init(
+        id: String,
+        name: String,
+        transport: MCPTransportKind,
+        disposition: MCPAttachmentDisposition
+    ) {
+        self.id = id
+        self.name = name
+        self.transport = transport
+        self.disposition = disposition
+    }
 }
 
 struct MCPAttachmentPlan: Equatable {
@@ -77,7 +88,7 @@ enum MCPAttachmentPlanner {
         var wireServers: [ACPMCPServer] = []
         var statuses: [MCPAttachmentServerStatus] = []
 
-        for server in input.configuredServers {
+        for (index, server) in input.configuredServers.enumerated() {
             let transport = transportKind(for: server.transport)
             let disposition: MCPAttachmentDisposition
 
@@ -99,7 +110,14 @@ enum MCPAttachmentPlanner {
                 }
             }
 
-            statuses.append(.init(name: server.name, transport: transport, disposition: disposition))
+            // Configuration can be edited externally and contain duplicate names.
+            // Keep the presentation identity unique without retaining sensitive values.
+            statuses.append(.init(
+                id: String(index),
+                name: server.name,
+                transport: transport,
+                disposition: disposition
+            ))
         }
 
         return .init(

--- a/Alas/Sources/ACP/Session/MCPAttachmentPlanner.swift
+++ b/Alas/Sources/ACP/Session/MCPAttachmentPlanner.swift
@@ -169,6 +169,7 @@ enum MCPAttachmentPlanner {
              let .invalidEnvironmentName(serverName, _),
              let .duplicateEnvironmentName(serverName, _),
              let .emptyHeaderName(serverName),
+             let .invalidHeaderName(serverName, _),
              let .duplicateHeaderName(serverName, _):
             return name == serverName
         }

--- a/Alas/Sources/ACP/Session/MCPAttachmentPlanner.swift
+++ b/Alas/Sources/ACP/Session/MCPAttachmentPlanner.swift
@@ -18,6 +18,14 @@ enum MCPAttachmentDisposition: Equatable {
     case skipped(MCPAttachmentSkipReason)
 }
 
+/// Project-scoped input that is deliberately fetched at attach time, so a
+/// fresh attach reflects the current project configuration without restarting
+/// an already connected session.
+struct MCPProjectContext: Equatable {
+    let projectDirectory: String
+    let configuredServers: [ProjectMCPServer]
+}
+
 struct MCPAttachmentServerStatus: Equatable, Identifiable {
     let name: String
     let transport: MCPTransportKind
@@ -30,6 +38,18 @@ struct MCPAttachmentPlan: Equatable {
     let wireServers: [ACPMCPServer]
     let statuses: [MCPAttachmentServerStatus]
     let configurationFingerprint: String
+}
+
+/// Session-visible attachment state. This intentionally excludes resolved
+/// wire definitions, which may contain environment-expanded credentials.
+struct MCPAttachmentSummary: Equatable {
+    let statuses: [MCPAttachmentServerStatus]
+    let configurationFingerprint: String
+
+    init(plan: MCPAttachmentPlan) {
+        statuses = plan.statuses
+        configurationFingerprint = plan.configurationFingerprint
+    }
 }
 
 struct MCPAttachmentPlannerInput {

--- a/Alas/Sources/ACP/UI/ACPMCPStatusControl.swift
+++ b/Alas/Sources/ACP/UI/ACPMCPStatusControl.swift
@@ -1,0 +1,129 @@
+import SwiftUI
+
+/// Session-scoped MCP attachment status. It is intentionally informational:
+/// editing the project configuration only makes this summary stale, because
+/// a different attachment plan cannot be applied until the next reconnect.
+struct ACPMCPStatusControl: View {
+    @ObservedObject var session: ACPSession
+    let currentServers: [ProjectMCPServer]
+    @Environment(\.theme) private var theme
+    @State private var popoverOpen = false
+
+    private var status: ACPMCPStatusState? {
+        ACPMCPStatusState(
+            summary: session.mcpAttachmentSummary,
+            currentServers: currentServers
+        )
+    }
+
+    var body: some View {
+        if let status {
+            Button {
+                popoverOpen.toggle()
+            } label: {
+                HStack(spacing: 5) {
+                    Image(systemName: "server.rack")
+                        .font(.system(size: 11, weight: .medium))
+                    Text("MCP \(status.requestedCount)")
+                        .font(.system(size: 10.5, weight: .semibold, design: .monospaced))
+                    if status.skippedCount > 0 {
+                        Image(systemName: "exclamationmark.triangle.fill")
+                            .font(.system(size: 9))
+                    }
+                    if status.isStale {
+                        Image(systemName: "arrow.triangle.2.circlepath")
+                            .font(.system(size: 9, weight: .semibold))
+                    }
+                }
+                .foregroundStyle(foregroundColor(for: status))
+                .padding(.horizontal, 8)
+                .frame(height: 24)
+                .background(backgroundColor(for: status))
+                .clipShape(RoundedRectangle(cornerRadius: 5, style: .continuous))
+                .overlay {
+                    RoundedRectangle(cornerRadius: 5, style: .continuous)
+                        .strokeBorder(foregroundColor(for: status).opacity(0.28), lineWidth: 0.5)
+                }
+            }
+            .buttonStyle(.plain)
+            .help(status.accessibilitySummary)
+            .accessibilityLabel(status.accessibilitySummary)
+            .popover(isPresented: $popoverOpen, arrowEdge: .top) {
+                ACPMCPStatusPopover(status: status)
+            }
+        }
+    }
+
+    private func foregroundColor(for status: ACPMCPStatusState) -> Color {
+        if status.isStale || status.skippedCount > 0 {
+            return theme.color("warn")
+        }
+        return theme.color("accent")
+    }
+
+    private func backgroundColor(for status: ACPMCPStatusState) -> Color {
+        foregroundColor(for: status).opacity(0.10)
+    }
+}
+
+private struct ACPMCPStatusPopover: View {
+    let status: ACPMCPStatusState
+    @Environment(\.theme) private var theme
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            HStack {
+                Text("MCP servers")
+                    .font(.system(size: 12, weight: .semibold))
+                    .foregroundStyle(theme.color("fg"))
+                Spacer()
+                Text(status.summaryText)
+                    .font(.system(size: 10.5, weight: .medium, design: .monospaced))
+                    .foregroundStyle(theme.color("fg-muted"))
+            }
+            .padding(.horizontal, 12)
+            .padding(.vertical, 10)
+
+            if status.isStale {
+                HStack(spacing: 7) {
+                    Image(systemName: "arrow.triangle.2.circlepath")
+                        .font(.system(size: 10, weight: .semibold))
+                    Text("New settings apply on reconnect.")
+                        .font(.system(size: 11))
+                }
+                .foregroundStyle(theme.color("warn"))
+                .padding(.horizontal, 12)
+                .padding(.vertical, 7)
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .background(theme.color("warn").opacity(0.10))
+            }
+
+            Divider().background(theme.color("line"))
+
+            VStack(spacing: 0) {
+                ForEach(status.rows) { row in
+                    HStack(alignment: .firstTextBaseline, spacing: 8) {
+                        Image(systemName: row.isRequested ? "checkmark.circle.fill" : "exclamationmark.triangle.fill")
+                            .font(.system(size: 11))
+                            .foregroundStyle(row.isRequested ? theme.color("accent") : theme.color("warn"))
+                        VStack(alignment: .leading, spacing: 2) {
+                            Text(row.name)
+                                .font(.system(size: 11.5, weight: .medium))
+                                .foregroundStyle(theme.color("fg"))
+                                .lineLimit(1)
+                            Text("\(row.transport) - \(row.detail)")
+                                .font(.system(size: 10.5))
+                                .foregroundStyle(theme.color("fg-muted"))
+                                .lineLimit(2)
+                        }
+                        Spacer(minLength: 0)
+                    }
+                    .padding(.horizontal, 12)
+                    .padding(.vertical, 8)
+                }
+            }
+        }
+        .frame(width: 300)
+        .background(theme.color("bg-1"))
+    }
+}

--- a/Alas/Sources/ACP/UI/ACPMCPStatusPolicy.swift
+++ b/Alas/Sources/ACP/UI/ACPMCPStatusPolicy.swift
@@ -1,0 +1,86 @@
+import Foundation
+
+/// Presentation-only state for the MCP attachment status control. The
+/// planner's summary never retains resolved commands, environment values, or
+/// headers, and this policy deliberately keeps the same boundary.
+struct ACPMCPStatusState: Equatable {
+    struct Row: Equatable, Identifiable {
+        let id: String
+        let name: String
+        let transport: String
+        let detail: String
+        let isRequested: Bool
+    }
+
+    let requestedCount: Int
+    let skippedCount: Int
+    let isStale: Bool
+    let rows: [Row]
+
+    init?(summary: MCPAttachmentSummary?, currentServers: [ProjectMCPServer]) {
+        guard let summary,
+              !summary.statuses.isEmpty || !currentServers.isEmpty else {
+            return nil
+        }
+
+        requestedCount = summary.statuses.count { $0.disposition == .requested }
+        skippedCount = summary.statuses.count - requestedCount
+        isStale = summary.configurationFingerprint
+            != MCPAttachmentPlanner.configurationFingerprint(for: currentServers)
+        rows = summary.statuses.map(Self.row)
+    }
+
+    var summaryText: String {
+        "\(requestedCount) requested"
+    }
+
+    var accessibilitySummary: String {
+        var parts = ["MCP: \(requestedCount) requested"]
+        if skippedCount > 0 {
+            parts.append("\(skippedCount) skipped")
+        }
+        if isStale {
+            parts.append("New settings apply on reconnect.")
+        }
+        return parts.joined(separator: ", ")
+    }
+
+    private static func row(_ status: MCPAttachmentServerStatus) -> Row {
+        let transport: String
+        switch status.transport {
+        case .stdio: transport = "stdio"
+        case .http: transport = "HTTP"
+        case .sse: transport = "Legacy SSE"
+        }
+
+        switch status.disposition {
+        case .requested:
+            return .init(
+                id: status.id,
+                name: status.name,
+                transport: transport,
+                detail: "Requested",
+                isRequested: true
+            )
+        case let .skipped(reason):
+            return .init(
+                id: status.id,
+                name: status.name,
+                transport: transport,
+                detail: skipDetail(reason),
+                isRequested: false
+            )
+        }
+    }
+
+    private static func skipDetail(_ reason: MCPAttachmentSkipReason) -> String {
+        switch reason {
+        case .unsupportedTransport:
+            return "Skipped: unsupported transport"
+        case let .missingVariable(variable):
+            return "Skipped: missing \(variable)"
+        case .invalidConfiguration:
+            return "Skipped: invalid configuration"
+        }
+    }
+}

--- a/Alas/Sources/ACP/UI/ACPToolbar.swift
+++ b/Alas/Sources/ACP/UI/ACPToolbar.swift
@@ -19,6 +19,10 @@ struct ACPToolbar: View {
                 worktree: worktree,
                 agentLookup: agentLookup
             )
+            ACPMCPStatusControl(
+                session: session,
+                currentServers: state.projects.first(where: { $0.id == worktree.projectId })?.mcpServers ?? []
+            )
             ACPRecoveryPill(session: session)
             if let currentGoal = session.currentGoal {
                 ACPGoalPill(goal: currentGoal)

--- a/Alas/Sources/App/AppState.swift
+++ b/Alas/Sources/App/AppState.swift
@@ -3453,6 +3453,15 @@ final class AppState {
                         sessionId: sessionId,
                         title: title
                     )
+                },
+                mcpProjectContextProvider: { [weak self] in
+                    guard let project = self?.projects.first(where: { $0.id == worktree.projectId }) else {
+                        return nil
+                    }
+                    return MCPProjectContext(
+                        projectDirectory: project.path,
+                        configuredServers: project.mcpServers
+                    )
                 }
             )
             acpManagers[worktree.id] = mgr

--- a/Alas/Sources/App/AppState.swift
+++ b/Alas/Sources/App/AppState.swift
@@ -1364,7 +1364,13 @@ final class AppState {
         projectGitWatchers.removeAll()
     }
 
-    func updateProject(id: String, name: String, icon: ProjectIcon, startupScripts: ProjectStartupScripts) {
+    func updateProject(
+        id: String,
+        name: String,
+        icon: ProjectIcon,
+        startupScripts: ProjectStartupScripts,
+        mcpServers: [ProjectMCPServer]
+    ) {
         let trimmedName = name.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !trimmedName.isEmpty else { return }
 
@@ -1373,18 +1379,26 @@ final class AppState {
             update: ProjectUpdate(
                 name: trimmedName,
                 icon: icon,
-                startupScripts: startupScripts
+                startupScripts: startupScripts,
+                mcpServers: mcpServers
             )
         )
         saveProjects()
     }
 
-    func updateProject(id: String, name: String, color: String, startupScripts: ProjectStartupScripts) {
+    func updateProject(
+        id: String,
+        name: String,
+        color: String,
+        startupScripts: ProjectStartupScripts,
+        mcpServers: [ProjectMCPServer]
+    ) {
         updateProject(
             id: id,
             name: name,
             icon: ProjectIcon.default(color: color),
-            startupScripts: startupScripts
+            startupScripts: startupScripts,
+            mcpServers: mcpServers
         )
     }
 

--- a/Alas/Sources/App/ProjectsManager.swift
+++ b/Alas/Sources/App/ProjectsManager.swift
@@ -5,15 +5,33 @@ struct ProjectUpdate: Equatable {
     var name: String
     var icon: ProjectIcon
     var startupScripts: ProjectStartupScripts = .defaults
+    /// `nil` means this update does not change the project's MCP configuration.
+    var mcpServers: [ProjectMCPServer]?
 
-    init(name: String, icon: ProjectIcon, startupScripts: ProjectStartupScripts = .defaults) {
+    init(
+        name: String,
+        icon: ProjectIcon,
+        startupScripts: ProjectStartupScripts = .defaults,
+        mcpServers: [ProjectMCPServer]? = nil
+    ) {
         self.name = name
         self.icon = icon
         self.startupScripts = startupScripts
+        self.mcpServers = mcpServers
     }
 
-    init(name: String, color: String, startupScripts: ProjectStartupScripts = .defaults) {
-        self.init(name: name, icon: ProjectIcon.default(color: color), startupScripts: startupScripts)
+    init(
+        name: String,
+        color: String,
+        startupScripts: ProjectStartupScripts = .defaults,
+        mcpServers: [ProjectMCPServer]? = nil
+    ) {
+        self.init(
+            name: name,
+            icon: ProjectIcon.default(color: color),
+            startupScripts: startupScripts,
+            mcpServers: mcpServers
+        )
     }
 }
 
@@ -107,6 +125,9 @@ final class ProjectsManager {
         projects[idx].icon = update.icon
         projects[idx].color = update.icon.color
         projects[idx].startupScripts = update.startupScripts
+        if let mcpServers = update.mcpServers {
+            projects[idx].mcpServers = mcpServers
+        }
     }
 
     func reorderProject(fromIndex: Int, toIndex: Int) {

--- a/Alas/Sources/Dialogs/NewProjectDialog.swift
+++ b/Alas/Sources/Dialogs/NewProjectDialog.swift
@@ -50,6 +50,7 @@ private struct ProjectDialog: View {
     @State private var sessionOpenScript: String = ""
     @State private var worktreeCreateMode: ProjectStartupScriptMode = .useGlobal
     @State private var worktreeCreateScript: String = ""
+    @State private var mcpServers: [ProjectMCPServer] = []
     @State private var isValidating = false
     @State private var errorMessage: String?
 
@@ -338,6 +339,7 @@ private struct ProjectDialog: View {
             sessionOpenScript = project.startupScripts.sessionOpenScript
             worktreeCreateMode = project.startupScripts.worktreeCreateMode
             worktreeCreateScript = project.startupScripts.worktreeCreateScript
+            mcpServers = project.mcpServers
         }
     }
 
@@ -492,7 +494,8 @@ private struct ProjectDialog: View {
                     worktreeAgentMode: project.startupScripts.worktreeAgentMode,
                     worktreeAgentId: project.startupScripts.worktreeAgentId,
                     worktreeAgentUseBypassPermissions: project.startupScripts.worktreeAgentUseBypassPermissions
-                )
+                ),
+                mcpServers: mcpServers
             )
             presented = false
         }

--- a/Alas/Sources/Dialogs/NewProjectDialog.swift
+++ b/Alas/Sources/Dialogs/NewProjectDialog.swift
@@ -51,6 +51,7 @@ private struct ProjectDialog: View {
     @State private var worktreeCreateMode: ProjectStartupScriptMode = .useGlobal
     @State private var worktreeCreateScript: String = ""
     @State private var mcpServers: [ProjectMCPServer] = []
+    @State private var mcpManagerPresented = false
     @State private var isValidating = false
     @State private var errorMessage: String?
 
@@ -104,6 +105,8 @@ private struct ProjectDialog: View {
                 if case .edit = mode {
                     Divider().padding(.vertical, 4)
                     startupScriptsSection
+                    Divider().padding(.vertical, 4)
+                    integrationsSection
                 }
                 if let errorMessage {
                     Text(errorMessage).font(.system(size: 11)).foregroundColor(.red)
@@ -127,6 +130,9 @@ private struct ProjectDialog: View {
                     await loadAvatarPresetIfAvailable()
                 }
             }
+        }
+        .sheet(isPresented: $mcpManagerPresented) {
+            ProjectMCPServerManager(servers: $mcpServers)
         }
     }
 
@@ -318,6 +324,23 @@ private struct ProjectDialog: View {
                         .background(theme.color("bg-0"))
                         .overlay(RoundedRectangle(cornerRadius: 6).strokeBorder(theme.color("line"), lineWidth: 0.5))
                 }
+            }
+        }
+    }
+
+    private var integrationsSection: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text("Integrations")
+                .font(.system(size: 12.5, weight: .semibold))
+                .foregroundColor(theme.color("fg"))
+            HStack(spacing: 8) {
+                Text(mcpServers.isEmpty ? "No MCP servers configured" : "\(mcpServers.count) MCP server\(mcpServers.count == 1 ? "" : "s") configured")
+                    .font(.system(size: 11.5))
+                    .foregroundColor(theme.color("fg-dim"))
+                Spacer()
+                AlasButton(title: "Manage MCP Servers…", icon: "slider", action: {
+                    mcpManagerPresented = true
+                })
             }
         }
     }

--- a/Alas/Sources/Dialogs/ProjectMCPServerEditor.swift
+++ b/Alas/Sources/Dialogs/ProjectMCPServerEditor.swift
@@ -1,0 +1,305 @@
+import SwiftUI
+
+private enum ProjectMCPTransportEditorKind: String, CaseIterable, Hashable {
+    case stdio
+    case http
+    case sse
+
+    init(_ transport: ProjectMCPTransport) {
+        switch transport {
+        case .stdio: self = .stdio
+        case .http: self = .http
+        case .sse: self = .sse
+        }
+    }
+
+    var title: String {
+        switch self {
+        case .stdio: "Stdio"
+        case .http: "HTTP"
+        case .sse: "Legacy SSE"
+        }
+    }
+}
+
+struct ProjectMCPServerEditor: View {
+    let onSave: (ProjectMCPServer) -> Void
+
+    @State private var draft: ProjectMCPServer
+    @State private var transportKind: ProjectMCPTransportEditorKind
+    @Environment(\.dismiss) private var dismiss
+    @Environment(\.theme) private var theme
+
+    init(server: ProjectMCPServer, onSave: @escaping (ProjectMCPServer) -> Void) {
+        self.onSave = onSave
+        _draft = State(initialValue: server)
+        _transportKind = State(initialValue: ProjectMCPTransportEditorKind(server.transport))
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            Text(draft.name.isEmpty ? "Add MCP Server" : "Edit MCP Server")
+                .font(.system(size: 16, weight: .semibold))
+                .padding(.bottom, 16)
+
+            ScrollView {
+                VStack(alignment: .leading, spacing: 12) {
+                    field(label: "Name") {
+                        AlasField(text: $draft.name, placeholder: "filesystem")
+                    }
+                    field(label: "Transport") {
+                        Seg(value: $transportKind, options: ProjectMCPTransportEditorKind.allCases.map { ($0, $0.title) })
+                            .onChange(of: transportKind) { _, newValue in
+                                replaceTransport(with: newValue)
+                            }
+                    }
+                    transportFields
+                    templateHelp
+                }
+                .frame(maxWidth: .infinity, alignment: .leading)
+            }
+            .frame(maxHeight: 470)
+
+            if let validationMessage {
+                Text(validationMessage)
+                    .font(.system(size: 11))
+                    .foregroundColor(.red)
+                    .padding(.top, 10)
+            }
+
+            HStack(spacing: 8) {
+                Spacer()
+                AlasButton(title: "Cancel", style: .subtle, action: { dismiss() })
+                AlasButton(title: "Save", style: .primary, action: save)
+                    .disabled(!canSave)
+            }
+            .padding(.top, 16)
+        }
+        .padding(24)
+        .frame(width: 620)
+        .background(theme.color("bg-1"))
+    }
+
+    @ViewBuilder
+    private var transportFields: some View {
+        switch draft.transport {
+        case .stdio:
+            field(label: "Command") {
+                AlasField(text: commandBinding, placeholder: "npx", monospaced: true)
+            }
+            argumentEditor
+            keyValueEditor(title: "Environment", entries: environmentBinding, valuePlaceholder: "${TOKEN}")
+        case .http, .sse:
+            field(label: "URL") {
+                AlasField(text: urlBinding, placeholder: "https://mcp.example.com", monospaced: true)
+            }
+            if transportKind == .sse {
+                Text("Legacy SSE is supported for older MCP servers. Prefer HTTP for new servers.")
+                    .font(.system(size: 11))
+                    .foregroundColor(theme.color("fg-muted"))
+            }
+            keyValueEditor(title: "Headers", entries: headersBinding, valuePlaceholder: "${MCP_TOKEN}")
+        }
+    }
+
+    private var argumentEditor: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            Text("Arguments")
+                .font(.system(size: 11.5, weight: .medium))
+                .foregroundColor(theme.color("fg"))
+            ForEach(argumentValues.indices, id: \.self) { index in
+                HStack(spacing: 8) {
+                    AlasField(text: argumentBinding(at: index), placeholder: "--root", monospaced: true)
+                    MCPServerIconButton(icon: "trash", tooltip: "Remove argument") {
+                        removeArgument(at: index)
+                    }
+                }
+            }
+            AlasButton(title: "Add Argument", icon: "plus", style: .subtle, action: addArgument)
+        }
+    }
+
+    private func keyValueEditor(
+        title: String,
+        entries: Binding<[MCPKeyValue]>,
+        valuePlaceholder: String
+    ) -> some View {
+        VStack(alignment: .leading, spacing: 6) {
+            Text(title)
+                .font(.system(size: 11.5, weight: .medium))
+                .foregroundColor(theme.color("fg"))
+            ForEach(entries.wrappedValue.indices, id: \.self) { index in
+                HStack(spacing: 8) {
+                    AlasField(text: keyValueNameBinding(entries, at: index), placeholder: title == "Headers" ? "Authorization" : "NAME", monospaced: true)
+                    AlasField(text: keyValueValueBinding(entries, at: index), placeholder: valuePlaceholder, monospaced: true)
+                    MCPServerIconButton(icon: "trash", tooltip: "Remove \(title.lowercased()) entry") {
+                        entries.wrappedValue.remove(at: index)
+                    }
+                }
+            }
+            AlasButton(title: "Add \(title == "Headers" ? "Header" : "Variable")", icon: "plus", style: .subtle) {
+                entries.wrappedValue.append(MCPKeyValue(id: UUID().uuidString, name: "", value: ""))
+            }
+        }
+    }
+
+    private var templateHelp: some View {
+        Text("Use ${VAR} for environment values. PROJECT_DIR and WORKTREE_DIR are available automatically. Put secret values in environment variables, then reference them here.")
+            .font(.system(size: 11))
+            .foregroundColor(theme.color("fg-muted"))
+            .fixedSize(horizontal: false, vertical: true)
+    }
+
+    private var canSave: Bool {
+        ProjectMCPServerEditorPolicy.canSave([draft])
+    }
+
+    private var validationMessage: String? {
+        guard !canSave else { return nil }
+        return "Complete the server name and transport fields, and use unique variable or header names."
+    }
+
+    private var commandBinding: Binding<String> {
+        Binding(
+            get: {
+                if case let .stdio(command, _, _) = draft.transport { return command }
+                return ""
+            },
+            set: { value in
+                guard case let .stdio(_, args, environment) = draft.transport else { return }
+                draft.transport = .stdio(command: value, args: args, environment: environment)
+            }
+        )
+    }
+
+    private var urlBinding: Binding<String> {
+        Binding(
+            get: {
+                switch draft.transport {
+                case let .http(url, _), let .sse(url, _): url
+                case .stdio: ""
+                }
+            },
+            set: { value in
+                switch draft.transport {
+                case let .http(_, headers): draft.transport = .http(url: value, headers: headers)
+                case let .sse(_, headers): draft.transport = .sse(url: value, headers: headers)
+                case .stdio: break
+                }
+            }
+        )
+    }
+
+    private var argumentValues: [String] {
+        if case let .stdio(_, args, _) = draft.transport { return args }
+        return []
+    }
+
+    private func argumentBinding(at index: Int) -> Binding<String> {
+        Binding(
+            get: { argumentValues.indices.contains(index) ? argumentValues[index] : "" },
+            set: { value in
+                guard case .stdio(let command, var args, let environment) = draft.transport,
+                      args.indices.contains(index) else { return }
+                args[index] = value
+                draft.transport = .stdio(command: command, args: args, environment: environment)
+            }
+        )
+    }
+
+    private var environmentBinding: Binding<[MCPKeyValue]> {
+        Binding(
+            get: {
+                if case let .stdio(_, _, environment) = draft.transport { return environment }
+                return []
+            },
+            set: { value in
+                guard case let .stdio(command, args, _) = draft.transport else { return }
+                draft.transport = .stdio(command: command, args: args, environment: value)
+            }
+        )
+    }
+
+    private var headersBinding: Binding<[MCPKeyValue]> {
+        Binding(
+            get: {
+                switch draft.transport {
+                case let .http(_, headers), let .sse(_, headers): headers
+                case .stdio: []
+                }
+            },
+            set: { value in
+                switch draft.transport {
+                case let .http(url, _): draft.transport = .http(url: url, headers: value)
+                case let .sse(url, _): draft.transport = .sse(url: url, headers: value)
+                case .stdio: break
+                }
+            }
+        )
+    }
+
+    private func keyValueNameBinding(_ entries: Binding<[MCPKeyValue]>, at index: Int) -> Binding<String> {
+        Binding(
+            get: { entries.wrappedValue.indices.contains(index) ? entries.wrappedValue[index].name : "" },
+            set: { value in
+                guard entries.wrappedValue.indices.contains(index) else { return }
+                entries.wrappedValue[index].name = value
+            }
+        )
+    }
+
+    private func keyValueValueBinding(_ entries: Binding<[MCPKeyValue]>, at index: Int) -> Binding<String> {
+        Binding(
+            get: { entries.wrappedValue.indices.contains(index) ? entries.wrappedValue[index].value : "" },
+            set: { value in
+                guard entries.wrappedValue.indices.contains(index) else { return }
+                entries.wrappedValue[index].value = value
+            }
+        )
+    }
+
+    private func replaceTransport(with newKind: ProjectMCPTransportEditorKind) {
+        guard newKind != ProjectMCPTransportEditorKind(draft.transport) else { return }
+        switch (draft.transport, newKind) {
+        case let (.http(url, headers), .sse):
+            draft.transport = .sse(url: url, headers: headers)
+        case let (.sse(url, headers), .http):
+            draft.transport = .http(url: url, headers: headers)
+        case (.stdio, .http):
+            draft.transport = .http(url: "", headers: [])
+        case (.stdio, .sse):
+            draft.transport = .sse(url: "", headers: [])
+        case (.http, .stdio), (.sse, .stdio):
+            draft.transport = .stdio(command: "", args: [], environment: [])
+        case (.stdio, .stdio), (.http, .http), (.sse, .sse):
+            break
+        }
+    }
+
+    private func addArgument() {
+        guard case let .stdio(command, args, environment) = draft.transport else { return }
+        draft.transport = .stdio(command: command, args: args + [""], environment: environment)
+    }
+
+    private func removeArgument(at index: Int) {
+        guard case .stdio(let command, var args, let environment) = draft.transport,
+              args.indices.contains(index) else { return }
+        args.remove(at: index)
+        draft.transport = .stdio(command: command, args: args, environment: environment)
+    }
+
+    private func field<Content: View>(label: String, @ViewBuilder content: () -> Content) -> some View {
+        VStack(alignment: .leading, spacing: 6) {
+            Text(label)
+                .font(.system(size: 11.5, weight: .medium))
+                .foregroundColor(theme.color("fg"))
+            content()
+        }
+    }
+
+    private func save() {
+        guard canSave else { return }
+        draft.name = draft.name.trimmingCharacters(in: .whitespacesAndNewlines)
+        onSave(draft)
+    }
+}

--- a/Alas/Sources/Dialogs/ProjectMCPServerEditorPolicy.swift
+++ b/Alas/Sources/Dialogs/ProjectMCPServerEditorPolicy.swift
@@ -17,8 +17,10 @@ enum ProjectMCPServerEditorPolicy {
         return servers.allSatisfy { server in
             switch server.transport {
             case let .http(url, _), let .sse(url, _):
-                guard !templateVariables(in: url).isEmpty else { return true }
-                return isValidHTTPURL(replacingTemplateVariables(in: url))
+                let validationURL = templateVariables(in: url).isEmpty
+                    ? url
+                    : replacingTemplateVariables(in: url)
+                return isValidHTTPURL(validationURL)
             case .stdio:
                 return true
             }

--- a/Alas/Sources/Dialogs/ProjectMCPServerEditorPolicy.swift
+++ b/Alas/Sources/Dialogs/ProjectMCPServerEditorPolicy.swift
@@ -5,11 +5,22 @@ import Foundation
 /// available when an ACP session is created for a specific worktree.
 enum ProjectMCPServerEditorPolicy {
     static func canSave(_ servers: [ProjectMCPServer]) -> Bool {
-        ProjectMCPValidation.validate(servers).allSatisfy { issue in
+        let validationAllowsTemplates = ProjectMCPValidation.validate(servers).allSatisfy { issue in
             guard case let .invalidURL(serverName) = issue else { return false }
             return servers.contains { server in
                 server.name.trimmingCharacters(in: .whitespacesAndNewlines) == serverName
                     && hasStructurallyValidTemplateURL(server.transport)
+            }
+        }
+        guard validationAllowsTemplates else { return false }
+
+        return servers.allSatisfy { server in
+            switch server.transport {
+            case let .http(url, _), let .sse(url, _):
+                guard !templateVariables(in: url).isEmpty else { return true }
+                return isValidHTTPURL(replacingTemplateVariables(in: url))
+            case .stdio:
+                return true
             }
         }
     }
@@ -109,6 +120,7 @@ enum ProjectMCPServerEditorPolicy {
     private static func isValidHTTPURL(_ value: String) -> Bool {
         let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
         guard value == trimmed,
+              !value.contains(where: \.isWhitespace),
               let url = URL(string: value),
               let host = url.host,
               !host.isEmpty else { return false }

--- a/Alas/Sources/Dialogs/ProjectMCPServerEditorPolicy.swift
+++ b/Alas/Sources/Dialogs/ProjectMCPServerEditorPolicy.swift
@@ -1,0 +1,108 @@
+import Foundation
+
+/// Pure presentation policy for editing a project's MCP server definitions.
+/// It deliberately permits URL templates because their final values are only
+/// available when an ACP session is created for a specific worktree.
+enum ProjectMCPServerEditorPolicy {
+    static func canSave(_ servers: [ProjectMCPServer]) -> Bool {
+        ProjectMCPValidation.validate(servers).allSatisfy { issue in
+            guard case let .invalidURL(serverName) = issue else { return false }
+            return servers.contains { server in
+                server.name.trimmingCharacters(in: .whitespacesAndNewlines) == serverName
+                    && hasTemplateURL(server.transport)
+            }
+        }
+    }
+
+    static func templateVariables(in value: String) -> [String] {
+        let pattern = #"\$\{([A-Za-z_][A-Za-z0-9_]*)\}"#
+        guard let expression = try? NSRegularExpression(pattern: pattern) else { return [] }
+
+        let range = NSRange(value.startIndex..., in: value)
+        var variables: [String] = []
+        var seen = Set<String>()
+        for match in expression.matches(in: value, range: range) {
+            guard let variableRange = Range(match.range(at: 1), in: value) else { continue }
+            let variable = String(value[variableRange])
+            if seen.insert(variable).inserted {
+                variables.append(variable)
+            }
+        }
+        return variables
+    }
+
+    static func templateVariables(in server: ProjectMCPServer) -> [String] {
+        let values: [String]
+        switch server.transport {
+        case let .stdio(command, args, environment):
+            values = [command] + args + environment.map(\.value)
+        case let .http(url, headers), let .sse(url, headers):
+            values = [url] + headers.map(\.value)
+        }
+        return templateVariables(in: values)
+    }
+
+    static func templateVariables(in values: [String]) -> [String] {
+        var variables: [String] = []
+        var seen = Set<String>()
+        for value in values {
+            for variable in templateVariables(in: value) where seen.insert(variable).inserted {
+                variables.append(variable)
+            }
+        }
+        return variables
+    }
+
+    static func transportLabel(for transport: ProjectMCPTransport) -> String {
+        switch transport {
+        case .stdio: "Stdio"
+        case .http: "HTTP"
+        case .sse: "Legacy SSE"
+        }
+    }
+
+    static func summary(for server: ProjectMCPServer) -> String {
+        switch server.transport {
+        case let .stdio(command, args, _):
+            return ([command] + args).joined(separator: " ")
+        case let .http(url, _), let .sse(url, _):
+            return safeRemoteSummary(url)
+        }
+    }
+
+    static func safeRemoteSummary(_ value: String) -> String {
+        let withoutUserInfo = strippingUserInfo(from: value)
+        let withoutFragment = withoutUserInfo.split(separator: "#", maxSplits: 1).first.map(String.init) ?? ""
+        let withoutQuery = withoutFragment.split(separator: "?", maxSplits: 1).first.map(String.init) ?? ""
+
+        guard var components = URLComponents(string: withoutQuery) else {
+            return withoutQuery
+        }
+        components.user = nil
+        components.password = nil
+        components.query = nil
+        components.fragment = nil
+        return components.string ?? withoutQuery
+    }
+
+    private static func hasTemplateURL(_ transport: ProjectMCPTransport) -> Bool {
+        switch transport {
+        case let .http(url, _), let .sse(url, _):
+            return !templateVariables(in: url).isEmpty
+        case .stdio:
+            return false
+        }
+    }
+
+    private static func strippingUserInfo(from value: String) -> String {
+        guard let schemeRange = value.range(of: "://") else { return value }
+        let authorityStart = schemeRange.upperBound
+        let authorityEnd = value[authorityStart...].firstIndex(of: "/") ?? value.endIndex
+        let authority = value[authorityStart..<authorityEnd]
+        guard let userInfoEnd = authority.lastIndex(of: "@") else { return value }
+
+        return String(value[..<authorityStart])
+            + String(authority[authority.index(after: userInfoEnd)...])
+            + String(value[authorityEnd...])
+    }
+}

--- a/Alas/Sources/Dialogs/ProjectMCPServerEditorPolicy.swift
+++ b/Alas/Sources/Dialogs/ProjectMCPServerEditorPolicy.swift
@@ -17,6 +17,7 @@ enum ProjectMCPServerEditorPolicy {
         return servers.allSatisfy { server in
             switch server.transport {
             case let .http(url, _), let .sse(url, _):
+                guard !isStandaloneTemplate(url) else { return true }
                 let validationURL = templateVariables(in: url).isEmpty
                     ? url
                     : replacingTemplateVariables(in: url)
@@ -102,10 +103,17 @@ enum ProjectMCPServerEditorPolicy {
         switch transport {
         case let .http(url, _), let .sse(url, _):
             guard !templateVariables(in: url).isEmpty else { return false }
+            guard !isStandaloneTemplate(url) else { return true }
             return isValidHTTPURL(replacingTemplateVariables(in: url))
         case .stdio:
             return false
         }
+    }
+
+    private static func isStandaloneTemplate(_ value: String) -> Bool {
+        guard value == value.trimmingCharacters(in: .whitespacesAndNewlines) else { return false }
+        let pattern = #"^\$\{[A-Za-z_][A-Za-z0-9_]*\}$"#
+        return value.range(of: pattern, options: .regularExpression) != nil
     }
 
     private static func replacingTemplateVariables(in value: String) -> String {

--- a/Alas/Sources/Dialogs/ProjectMCPServerEditorPolicy.swift
+++ b/Alas/Sources/Dialogs/ProjectMCPServerEditorPolicy.swift
@@ -9,7 +9,7 @@ enum ProjectMCPServerEditorPolicy {
             guard case let .invalidURL(serverName) = issue else { return false }
             return servers.contains { server in
                 server.name.trimmingCharacters(in: .whitespacesAndNewlines) == serverName
-                    && hasTemplateURL(server.transport)
+                    && hasStructurallyValidTemplateURL(server.transport)
             }
         }
     }
@@ -63,8 +63,8 @@ enum ProjectMCPServerEditorPolicy {
 
     static func summary(for server: ProjectMCPServer) -> String {
         switch server.transport {
-        case let .stdio(command, args, _):
-            return ([command] + args).joined(separator: " ")
+        case let .stdio(command, _, _):
+            return command
         case let .http(url, _), let .sse(url, _):
             return safeRemoteSummary(url)
         }
@@ -85,13 +85,34 @@ enum ProjectMCPServerEditorPolicy {
         return components.string ?? withoutQuery
     }
 
-    private static func hasTemplateURL(_ transport: ProjectMCPTransport) -> Bool {
+    private static func hasStructurallyValidTemplateURL(_ transport: ProjectMCPTransport) -> Bool {
         switch transport {
         case let .http(url, _), let .sse(url, _):
-            return !templateVariables(in: url).isEmpty
+            guard !templateVariables(in: url).isEmpty else { return false }
+            return isValidHTTPURL(replacingTemplateVariables(in: url))
         case .stdio:
             return false
         }
+    }
+
+    private static func replacingTemplateVariables(in value: String) -> String {
+        let pattern = #"\$\{[A-Za-z_][A-Za-z0-9_]*\}"#
+        guard let expression = try? NSRegularExpression(pattern: pattern) else { return value }
+        let range = NSRange(value.startIndex..., in: value)
+        return expression.stringByReplacingMatches(
+            in: value,
+            range: range,
+            withTemplate: "mcp"
+        )
+    }
+
+    private static func isValidHTTPURL(_ value: String) -> Bool {
+        let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard value == trimmed,
+              let url = URL(string: value),
+              let host = url.host,
+              !host.isEmpty else { return false }
+        return url.scheme?.lowercased() == "http" || url.scheme?.lowercased() == "https"
     }
 
     private static func strippingUserInfo(from value: String) -> String {

--- a/Alas/Sources/Dialogs/ProjectMCPServerManager.swift
+++ b/Alas/Sources/Dialogs/ProjectMCPServerManager.swift
@@ -1,0 +1,186 @@
+import SwiftUI
+
+struct ProjectMCPServerManager: View {
+    @Binding var servers: [ProjectMCPServer]
+
+    @State private var draft: [ProjectMCPServer]
+    @State private var editor: ProjectMCPServerEditorTarget?
+    @State private var deleteTarget: ProjectMCPServer?
+    @Environment(\.dismiss) private var dismiss
+    @Environment(\.theme) private var theme
+
+    init(servers: Binding<[ProjectMCPServer]>) {
+        _servers = servers
+        _draft = State(initialValue: servers.wrappedValue)
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            Text("MCP Servers")
+                .font(.system(size: 16, weight: .semibold))
+            Text("Servers are attached when a new agent session is created.")
+                .font(.system(size: 12))
+                .foregroundColor(theme.color("fg-dim"))
+                .padding(.top, 3)
+                .padding(.bottom, 16)
+
+            ScrollView {
+                VStack(alignment: .leading, spacing: 8) {
+                    if draft.isEmpty {
+                        Text("No MCP servers configured")
+                            .font(.system(size: 12))
+                            .foregroundColor(theme.color("fg-dim"))
+                            .frame(maxWidth: .infinity, minHeight: 88, alignment: .center)
+                    } else {
+                        ForEach(draft) { server in
+                            serverRow(server)
+                        }
+                    }
+                }
+                .frame(maxWidth: .infinity, alignment: .leading)
+            }
+            .frame(minHeight: 160, maxHeight: 340)
+
+            HStack(spacing: 8) {
+                AlasButton(title: "Add Server", icon: "plus", action: {
+                    editor = .new
+                })
+                Spacer()
+                AlasButton(title: "Cancel", style: .subtle, action: { dismiss() })
+                AlasButton(title: "Done", style: .primary, action: commit)
+                    .disabled(!ProjectMCPServerEditorPolicy.canSave(draft))
+            }
+            .padding(.top, 16)
+        }
+        .padding(24)
+        .frame(width: 620)
+        .background(theme.color("bg-1"))
+        .sheet(item: $editor) { target in
+            ProjectMCPServerEditor(server: target.server) { saved in
+                save(saved, replacing: target.existingID)
+            }
+        }
+        .confirmationDialog(
+            deleteConfirmationTitle,
+            isPresented: Binding(
+                get: { deleteTarget != nil },
+                set: { if !$0 { deleteTarget = nil } }
+            ),
+            titleVisibility: .visible
+        ) {
+            Button("Delete Server", role: .destructive) {
+                if let deleteTarget {
+                    draft.removeAll { $0.id == deleteTarget.id }
+                }
+                deleteTarget = nil
+            }
+            Button("Cancel", role: .cancel) { deleteTarget = nil }
+        } message: {
+            Text("The server will not be attached to future sessions after you save the project.")
+        }
+    }
+
+    private func serverRow(_ server: ProjectMCPServer) -> some View {
+        HStack(spacing: 10) {
+            VStack(alignment: .leading, spacing: 3) {
+                HStack(spacing: 6) {
+                    Text(server.name.isEmpty ? "Unnamed server" : server.name)
+                        .font(.system(size: 12, weight: .medium))
+                        .foregroundColor(theme.color("fg"))
+                    Text(ProjectMCPServerEditorPolicy.transportLabel(for: server.transport))
+                        .font(.system(size: 10.5))
+                        .foregroundColor(theme.color("fg-muted"))
+                }
+                Text(ProjectMCPServerEditorPolicy.summary(for: server))
+                    .font(.system(size: 11, design: .monospaced))
+                    .foregroundColor(theme.color("fg-dim"))
+                    .lineLimit(1)
+                    .truncationMode(.middle)
+            }
+            Spacer(minLength: 8)
+            MCPServerIconButton(icon: "pencil", tooltip: "Edit \(server.name)") {
+                editor = .existing(server)
+            }
+            MCPServerIconButton(icon: "trash", tooltip: "Delete \(server.name)") {
+                deleteTarget = server
+            }
+        }
+        .padding(10)
+        .background(theme.color("bg-0"))
+        .overlay(
+            RoundedRectangle(cornerRadius: 6)
+                .strokeBorder(theme.color("line"), lineWidth: 0.5)
+        )
+        .clipShape(RoundedRectangle(cornerRadius: 6))
+    }
+
+    private func save(_ server: ProjectMCPServer, replacing existingID: String?) {
+        if let existingID, let index = draft.firstIndex(where: { $0.id == existingID }) {
+            draft[index] = server
+        } else {
+            draft.append(server)
+        }
+        editor = nil
+    }
+
+    private func commit() {
+        guard ProjectMCPServerEditorPolicy.canSave(draft) else { return }
+        servers = draft
+        dismiss()
+    }
+
+    private var deleteConfirmationTitle: String {
+        guard let deleteTarget, !deleteTarget.name.isEmpty else {
+            return "Delete this MCP server?"
+        }
+        return "Delete \(deleteTarget.name)?"
+    }
+}
+
+private enum ProjectMCPServerEditorTarget: Identifiable {
+    case new
+    case existing(ProjectMCPServer)
+
+    var id: String {
+        switch self {
+        case .new: "new"
+        case let .existing(server): server.id
+        }
+    }
+
+    var existingID: String? {
+        if case let .existing(server) = self { return server.id }
+        return nil
+    }
+
+    var server: ProjectMCPServer {
+        switch self {
+        case .new:
+            ProjectMCPServer.stdio(name: "", command: "")
+        case let .existing(server):
+            server
+        }
+    }
+}
+
+struct MCPServerIconButton: View {
+    let icon: String
+    let tooltip: String
+    let action: () -> Void
+    @Environment(\.theme) private var theme
+
+    var body: some View {
+        Button(action: action) {
+            Icon(name: icon, size: 11, color: theme.color("fg"))
+                .frame(width: 28, height: 28)
+                .background(theme.color("bg-3"))
+                .overlay(
+                    RoundedRectangle(cornerRadius: 6)
+                        .strokeBorder(theme.color("line"), lineWidth: 0.5)
+                )
+                .clipShape(RoundedRectangle(cornerRadius: 6))
+        }
+        .buttonStyle(.plain)
+        .help(tooltip)
+    }
+}

--- a/Alas/Sources/Persistence/ProjectConfig.swift
+++ b/Alas/Sources/Persistence/ProjectConfig.swift
@@ -91,6 +91,7 @@ struct ProjectConfig: Codable, Equatable, Identifiable {
     /// cleared by "Reset Sort to Default".
     var worktreeOrderIsManual: Bool = false
     var startupScripts: ProjectStartupScripts = .defaults
+    var mcpServers: [ProjectMCPServer] = []
     /// Per-project "open after create" preference. `nil` = use global default (true).
     var worktreeOpenAfterCreate: Bool?
     /// Per-project launcher mode preference. `nil` = use global default.
@@ -99,7 +100,7 @@ struct ProjectConfig: Codable, Equatable, Identifiable {
     enum CodingKeys: String, CodingKey {
         case id, name, path, color, icon, addedAt, hiddenWorktreePaths, worktreeOrder,
              worktreeOrderIsManual, startupScripts,
-             worktreeOpenAfterCreate, worktreeDefaultLauncherMode
+             mcpServers, worktreeOpenAfterCreate, worktreeDefaultLauncherMode
     }
 
     init(
@@ -113,6 +114,7 @@ struct ProjectConfig: Codable, Equatable, Identifiable {
         worktreeOrder: [String] = [],
         worktreeOrderIsManual: Bool = false,
         startupScripts: ProjectStartupScripts = .defaults,
+        mcpServers: [ProjectMCPServer] = [],
         worktreeOpenAfterCreate: Bool? = nil,
         worktreeDefaultLauncherMode: AppConfig.LauncherMode? = nil
     ) {
@@ -125,6 +127,7 @@ struct ProjectConfig: Codable, Equatable, Identifiable {
         self.worktreeOrder = worktreeOrder
         self.worktreeOrderIsManual = worktreeOrderIsManual
         self.startupScripts = startupScripts
+        self.mcpServers = mcpServers
         self.worktreeOpenAfterCreate = worktreeOpenAfterCreate
         self.worktreeDefaultLauncherMode = worktreeDefaultLauncherMode
     }
@@ -149,6 +152,7 @@ struct ProjectConfig: Codable, Equatable, Identifiable {
         worktreeOrderIsManual = (try? c.decode(Bool.self, forKey: .worktreeOrderIsManual)) ?? false
         startupScripts = (try? c.decode(ProjectStartupScripts.self, forKey: .startupScripts))
             ?? .defaults
+        mcpServers = (try? c.decode([ProjectMCPServer].self, forKey: .mcpServers)) ?? []
         worktreeOpenAfterCreate = try? c.decode(Bool.self, forKey: .worktreeOpenAfterCreate)
         worktreeDefaultLauncherMode = try? c.decode(AppConfig.LauncherMode.self, forKey: .worktreeDefaultLauncherMode)
     }
@@ -165,6 +169,7 @@ struct ProjectConfig: Codable, Equatable, Identifiable {
         try c.encode(worktreeOrder, forKey: .worktreeOrder)
         try c.encode(worktreeOrderIsManual, forKey: .worktreeOrderIsManual)
         try c.encode(startupScripts, forKey: .startupScripts)
+        try c.encode(mcpServers, forKey: .mcpServers)
         try c.encodeIfPresent(worktreeOpenAfterCreate, forKey: .worktreeOpenAfterCreate)
         try c.encodeIfPresent(worktreeDefaultLauncherMode, forKey: .worktreeDefaultLauncherMode)
     }

--- a/Alas/Sources/Persistence/ProjectMCPServer.swift
+++ b/Alas/Sources/Persistence/ProjectMCPServer.swift
@@ -1,0 +1,180 @@
+import Foundation
+
+struct MCPKeyValue: Codable, Equatable, Identifiable {
+    let id: String
+    var name: String
+    var value: String
+}
+
+enum ProjectMCPTransport: Codable, Equatable {
+    case stdio(command: String, args: [String], environment: [MCPKeyValue])
+    case http(url: String, headers: [MCPKeyValue])
+    case sse(url: String, headers: [MCPKeyValue])
+
+    private enum Kind: String, Codable {
+        case stdio
+        case http
+        case sse
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case kind
+        case command
+        case args
+        case environment
+        case url
+        case headers
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        switch try container.decode(Kind.self, forKey: .kind) {
+        case .stdio:
+            self = .stdio(
+                command: try container.decode(String.self, forKey: .command),
+                args: try container.decode([String].self, forKey: .args),
+                environment: try container.decode([MCPKeyValue].self, forKey: .environment)
+            )
+        case .http:
+            self = .http(
+                url: try container.decode(String.self, forKey: .url),
+                headers: try container.decode([MCPKeyValue].self, forKey: .headers)
+            )
+        case .sse:
+            self = .sse(
+                url: try container.decode(String.self, forKey: .url),
+                headers: try container.decode([MCPKeyValue].self, forKey: .headers)
+            )
+        }
+    }
+
+    func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        switch self {
+        case let .stdio(command, args, environment):
+            try container.encode(Kind.stdio, forKey: .kind)
+            try container.encode(command, forKey: .command)
+            try container.encode(args, forKey: .args)
+            try container.encode(environment, forKey: .environment)
+        case let .http(url, headers):
+            try container.encode(Kind.http, forKey: .kind)
+            try container.encode(url, forKey: .url)
+            try container.encode(headers, forKey: .headers)
+        case let .sse(url, headers):
+            try container.encode(Kind.sse, forKey: .kind)
+            try container.encode(url, forKey: .url)
+            try container.encode(headers, forKey: .headers)
+        }
+    }
+}
+
+struct ProjectMCPServer: Codable, Equatable, Identifiable {
+    let id: String
+    var name: String
+    var transport: ProjectMCPTransport
+
+    static func stdio(name: String, command: String) -> ProjectMCPServer {
+        ProjectMCPServer(
+            id: UUID().uuidString,
+            name: name,
+            transport: .stdio(command: command, args: [], environment: [])
+        )
+    }
+
+    func withFreshId() -> ProjectMCPServer {
+        ProjectMCPServer(id: UUID().uuidString, name: name, transport: transport)
+    }
+}
+
+enum ProjectMCPValidationIssue: Equatable {
+    case emptyServerName(serverId: String)
+    case duplicateServerName(String)
+    case emptyCommand(serverName: String)
+    case invalidURL(serverName: String)
+    case invalidEnvironmentName(serverName: String, name: String)
+    case duplicateEnvironmentName(serverName: String, name: String)
+    case emptyHeaderName(serverName: String)
+    case duplicateHeaderName(serverName: String, name: String)
+}
+
+enum ProjectMCPValidation {
+    static func validate(_ servers: [ProjectMCPServer]) -> [ProjectMCPValidationIssue] {
+        var issues: [ProjectMCPValidationIssue] = []
+        var serverNames = Set<String>()
+
+        for server in servers {
+            let serverName = server.name.trimmingCharacters(in: .whitespacesAndNewlines)
+            if serverName.isEmpty {
+                issues.append(.emptyServerName(serverId: server.id))
+            } else if !serverNames.insert(serverName).inserted {
+                issues.append(.duplicateServerName(serverName))
+            }
+
+            switch server.transport {
+            case let .stdio(command, _, environment):
+                if command.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+                    issues.append(.emptyCommand(serverName: serverName))
+                }
+                validateEnvironment(environment, serverName: serverName, issues: &issues)
+            case let .http(url, headers), let .sse(url, headers):
+                if !isValidHTTPURL(url) {
+                    issues.append(.invalidURL(serverName: serverName))
+                }
+                validateHeaders(headers, serverName: serverName, issues: &issues)
+            }
+        }
+
+        return issues
+    }
+
+    private static func validateEnvironment(
+        _ environment: [MCPKeyValue],
+        serverName: String,
+        issues: inout [ProjectMCPValidationIssue]
+    ) {
+        var names = Set<String>()
+        for entry in environment {
+            let name = entry.name.trimmingCharacters(in: .whitespacesAndNewlines)
+            guard isValidEnvironmentName(name) else {
+                issues.append(.invalidEnvironmentName(serverName: serverName, name: name))
+                continue
+            }
+            if !names.insert(name).inserted {
+                issues.append(.duplicateEnvironmentName(serverName: serverName, name: name))
+            }
+        }
+    }
+
+    private static func validateHeaders(
+        _ headers: [MCPKeyValue],
+        serverName: String,
+        issues: inout [ProjectMCPValidationIssue]
+    ) {
+        var names = Set<String>()
+        for header in headers {
+            let name = header.name.trimmingCharacters(in: .whitespacesAndNewlines)
+            guard !name.isEmpty else {
+                issues.append(.emptyHeaderName(serverName: serverName))
+                continue
+            }
+            if !names.insert(name.lowercased()).inserted {
+                issues.append(.duplicateHeaderName(serverName: serverName, name: name))
+            }
+        }
+    }
+
+    private static func isValidEnvironmentName(_ name: String) -> Bool {
+        name.range(
+            of: "^[A-Za-z_][A-Za-z0-9_]*$",
+            options: .regularExpression
+        ) != nil
+    }
+
+    private static func isValidHTTPURL(_ value: String) -> Bool {
+        let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard let url = URL(string: trimmed), let host = url.host, !host.isEmpty else {
+            return false
+        }
+        return url.scheme?.lowercased() == "http" || url.scheme?.lowercased() == "https"
+    }
+}

--- a/Alas/Sources/Persistence/ProjectMCPServer.swift
+++ b/Alas/Sources/Persistence/ProjectMCPServer.swift
@@ -113,7 +113,8 @@ enum ProjectMCPValidation {
 
             switch server.transport {
             case let .stdio(command, _, environment):
-                if command.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+                let trimmedCommand = command.trimmingCharacters(in: .whitespacesAndNewlines)
+                if command != trimmedCommand || trimmedCommand.isEmpty {
                     issues.append(.emptyCommand(serverName: serverName))
                 }
                 validateEnvironment(environment, serverName: serverName, issues: &issues)
@@ -180,6 +181,7 @@ enum ProjectMCPValidation {
     private static func isValidHTTPURL(_ value: String) -> Bool {
         let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
         guard value == trimmed,
+              !value.contains(where: \.isWhitespace),
               let url = URL(string: trimmed),
               let host = url.host,
               !host.isEmpty else {

--- a/Alas/Sources/Persistence/ProjectMCPServer.swift
+++ b/Alas/Sources/Persistence/ProjectMCPServer.swift
@@ -94,6 +94,7 @@ enum ProjectMCPValidationIssue: Equatable {
     case invalidEnvironmentName(serverName: String, name: String)
     case duplicateEnvironmentName(serverName: String, name: String)
     case emptyHeaderName(serverName: String)
+    case invalidHeaderName(serverName: String, name: String)
     case duplicateHeaderName(serverName: String, name: String)
 }
 
@@ -134,9 +135,10 @@ enum ProjectMCPValidation {
     ) {
         var names = Set<String>()
         for entry in environment {
-            let name = entry.name.trimmingCharacters(in: .whitespacesAndNewlines)
-            guard isValidEnvironmentName(name) else {
-                issues.append(.invalidEnvironmentName(serverName: serverName, name: name))
+            let rawName = entry.name
+            let name = rawName.trimmingCharacters(in: .whitespacesAndNewlines)
+            guard rawName == name, isValidEnvironmentName(name) else {
+                issues.append(.invalidEnvironmentName(serverName: serverName, name: rawName))
                 continue
             }
             if !names.insert(name).inserted {
@@ -152,9 +154,14 @@ enum ProjectMCPValidation {
     ) {
         var names = Set<String>()
         for header in headers {
-            let name = header.name.trimmingCharacters(in: .whitespacesAndNewlines)
+            let rawName = header.name
+            let name = rawName.trimmingCharacters(in: .whitespacesAndNewlines)
             guard !name.isEmpty else {
                 issues.append(.emptyHeaderName(serverName: serverName))
+                continue
+            }
+            guard rawName == name else {
+                issues.append(.invalidHeaderName(serverName: serverName, name: rawName))
                 continue
             }
             if !names.insert(name.lowercased()).inserted {

--- a/Alas/Sources/Persistence/ProjectMCPServer.swift
+++ b/Alas/Sources/Persistence/ProjectMCPServer.swift
@@ -172,7 +172,10 @@ enum ProjectMCPValidation {
 
     private static func isValidHTTPURL(_ value: String) -> Bool {
         let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard let url = URL(string: trimmed), let host = url.host, !host.isEmpty else {
+        guard value == trimmed,
+              let url = URL(string: trimmed),
+              let host = url.host,
+              !host.isEmpty else {
             return false
         }
         return url.scheme?.lowercased() == "http" || url.scheme?.lowercased() == "https"

--- a/AlasTests/ACP/E2E/ACPGeminiE2ETests.swift
+++ b/AlasTests/ACP/E2E/ACPGeminiE2ETests.swift
@@ -15,7 +15,7 @@ struct ACPGeminiE2ETests {
         try client.start()
         let conn = ACPConnection(client: client)
         try await conn.initialize()
-        let new = try await conn.newSession(cwd: FileManager.default.temporaryDirectory.path)
+        let new = try await conn.newSession(cwd: FileManager.default.temporaryDirectory.path, mcpServers: [])
         try await conn.prompt(sessionId: new.sessionId, blocks: [.text("say hi in three words")])
 
         let got = await withTimeout(seconds: 30) { () async -> String? in

--- a/AlasTests/ACP/Protocol/ACPConnectionTests.swift
+++ b/AlasTests/ACP/Protocol/ACPConnectionTests.swift
@@ -40,6 +40,10 @@ struct ACPConnectionTests {
                   "image": true,
                   "audio": false,
                   "embeddedContext": true
+                },
+                "mcpCapabilities": {
+                  "http": true,
+                  "sse": true
                 }
               },
               "authMethods": [
@@ -56,6 +60,7 @@ struct ACPConnectionTests {
         #expect(initialized.promptCapabilities.audio == false)
         #expect(initialized.promptCapabilities.embeddedContext == true)
         #expect(initialized.authMethods.map(\.id) == ["claude-ai-login"])
+        #expect(initialized.mcpCapabilities == .init(http: true, sse: true))
     }
 
     @Test("loadSession sends session/load with cwd and remote session id")

--- a/AlasTests/ACP/Protocol/ACPConnectionTests.swift
+++ b/AlasTests/ACP/Protocol/ACPConnectionTests.swift
@@ -22,10 +22,13 @@ struct ACPConnectionTests {
 
         let conn = ACPConnection(client: mock)
         try await conn.initialize()
-        let new = try await conn.newSession(cwd: "/tmp")
+        let mcpServers: [ACPMCPServer] = [.stdio(name: "files", command: "mcp-files", args: ["--root", "/tmp"], env: [])]
+        let new = try await conn.newSession(cwd: "/tmp", mcpServers: mcpServers)
         #expect(new.sessionId == "s1")
         #expect(new.availableModels.count == 1)
         #expect(new.availableModes.first?.id == "agent")
+        let params = try #require(mock.sent.last?.params as? ACPSessionNewParams)
+        #expect(params.mcpServers == mcpServers)
     }
 
     @Test("initialize returns prompt capabilities")
@@ -78,7 +81,8 @@ struct ACPConnectionTests {
         }
 
         let conn = ACPConnection(client: mock)
-        let result = try await conn.loadSession(cwd: "/tmp/wt", sessionId: "remote-old")
+        let mcpServers: [ACPMCPServer] = [.http(name: "remote", url: "https://mcp.example.com", headers: [])]
+        let result = try await conn.loadSession(cwd: "/tmp/wt", sessionId: "remote-old", mcpServers: mcpServers)
 
         #expect(result.sessionId == "remote-restored")
         let req = try #require(mock.sent.last)
@@ -86,7 +90,7 @@ struct ACPConnectionTests {
         let params = try #require(req.params as? ACPSessionLoadParams)
         #expect(params.cwd == "/tmp/wt")
         #expect(params.sessionId == "remote-old")
-        #expect(params.mcpServers.isEmpty)
+        #expect(params.mcpServers == mcpServers)
     }
 
     @Test("resumeSession sends session/resume and preserves the requested id for an empty result")
@@ -95,7 +99,8 @@ struct ACPConnectionTests {
         mock.script(method: "session/resume") { _ in Data("{}".utf8) }
 
         let conn = ACPConnection(client: mock)
-        let result = try await conn.resumeSession(cwd: "/tmp/wt", sessionId: "remote-old")
+        let mcpServers: [ACPMCPServer] = [.sse(name: "events", url: "https://mcp.example.com/events", headers: [])]
+        let result = try await conn.resumeSession(cwd: "/tmp/wt", sessionId: "remote-old", mcpServers: mcpServers)
 
         #expect(result.sessionId == "remote-old")
         let req = try #require(mock.sent.last)
@@ -103,6 +108,7 @@ struct ACPConnectionTests {
         let params = try #require(req.params as? ACPSessionResumeParams)
         #expect(params.cwd == "/tmp/wt")
         #expect(params.sessionId == "remote-old")
+        #expect(params.mcpServers == mcpServers)
     }
 
     @Test("listSessions sends cwd and opaque cursor and decodes a page")

--- a/AlasTests/ACP/Protocol/ACPInitializeTests.swift
+++ b/AlasTests/ACP/Protocol/ACPInitializeTests.swift
@@ -172,6 +172,34 @@ struct ACPInitializeTests {
         #expect(omitted.agentCapabilities?.sessionCapabilities.supportsFork == false)
     }
 
+    @Test("decodes MCP transport capabilities with conservative defaults")
+    func decodeMCPTransportCapabilities() throws {
+        let supported = try JSONDecoder().decode(ACPInitializeResult.self, from: Data("""
+        {
+          "protocolVersion": 1,
+          "agentCapabilities": {
+            "mcpCapabilities": { "http": true, "sse": true }
+          }
+        }
+        """.utf8))
+        let missingObject = try JSONDecoder().decode(ACPInitializeResult.self, from: Data("""
+        { "protocolVersion": 1, "agentCapabilities": {} }
+        """.utf8))
+        let missingFields = try JSONDecoder().decode(ACPInitializeResult.self, from: Data("""
+        {
+          "protocolVersion": 1,
+          "agentCapabilities": { "mcpCapabilities": {} }
+        }
+        """.utf8))
+
+        #expect(supported.agentCapabilities?.mcpCapabilities.http == true)
+        #expect(supported.agentCapabilities?.mcpCapabilities.sse == true)
+        #expect(missingObject.agentCapabilities?.mcpCapabilities.http == false)
+        #expect(missingObject.agentCapabilities?.mcpCapabilities.sse == false)
+        #expect(missingFields.agentCapabilities?.mcpCapabilities.http == false)
+        #expect(missingFields.agentCapabilities?.mcpCapabilities.sse == false)
+    }
+
     @Test("decodes terminal auth method metadata")
     func decodesTerminalAuthMethod() throws {
         let data = Data("""

--- a/AlasTests/ACP/Protocol/ACPMCPServerTests.swift
+++ b/AlasTests/ACP/Protocol/ACPMCPServerTests.swift
@@ -1,0 +1,99 @@
+import Foundation
+import Testing
+@testable import Alas
+
+@Suite("ACP MCP servers")
+struct ACPMCPServerTests {
+    @Test("encodes stdio servers without a type and with empty collections")
+    func encodeStdio() throws {
+        let json = try encodedObject(.stdio(
+            name: "filesystem",
+            command: "npx",
+            args: [],
+            env: []
+        ))
+
+        #expect(json["type"] == nil)
+        #expect(json["name"] as? String == "filesystem")
+        #expect(json["command"] as? String == "npx")
+        #expect(json["args"] as? [String] == [])
+        #expect(json["env"] as? [[String: String]] == [])
+    }
+
+    @Test("encodes HTTP servers with a type and empty headers")
+    func encodeHTTP() throws {
+        let json = try encodedObject(.http(
+            name: "remote",
+            url: "https://example.com/mcp",
+            headers: []
+        ))
+
+        #expect(json["type"] as? String == "http")
+        #expect(json["name"] as? String == "remote")
+        #expect(json["url"] as? String == "https://example.com/mcp")
+        #expect(json["headers"] as? [[String: String]] == [])
+    }
+
+    @Test("encodes SSE servers with a type and headers")
+    func encodeSSE() throws {
+        let json = try encodedObject(.sse(
+            name: "events",
+            url: "https://example.com/sse",
+            headers: [.init(name: "Authorization", value: "Bearer token")]
+        ))
+
+        #expect(json["type"] as? String == "sse")
+        #expect(json["name"] as? String == "events")
+        #expect(json["url"] as? String == "https://example.com/sse")
+        #expect(json["headers"] as? [[String: String]] == [[
+            "name": "Authorization",
+            "value": "Bearer token",
+        ]])
+    }
+
+    @Test("decodes omitted server collections as empty")
+    func decodeMissingCollections() throws {
+        let stdio = try JSONDecoder().decode(ACPMCPServer.self, from: Data("""
+        { "name": "filesystem", "command": "npx" }
+        """.utf8))
+        let http = try JSONDecoder().decode(ACPMCPServer.self, from: Data("""
+        { "type": "http", "name": "remote", "url": "https://example.com/mcp" }
+        """.utf8))
+        let sse = try JSONDecoder().decode(ACPMCPServer.self, from: Data("""
+        { "type": "sse", "name": "events", "url": "https://example.com/sse" }
+        """.utf8))
+
+        #expect(stdio == .stdio(name: "filesystem", command: "npx", args: [], env: []))
+        #expect(http == .http(name: "remote", url: "https://example.com/mcp", headers: []))
+        #expect(sse == .sse(name: "events", url: "https://example.com/sse", headers: []))
+    }
+
+    @Test("rejects unknown MCP server types")
+    func decodeUnknownType() {
+        let data = Data("""
+        { "type": "websocket", "name": "remote", "url": "wss://example.com/mcp" }
+        """.utf8)
+
+        #expect(throws: DecodingError.self) {
+            try JSONDecoder().decode(ACPMCPServer.self, from: data)
+        }
+    }
+
+    @Test("decodes MCP transport capabilities with false defaults")
+    func decodeCapabilities() throws {
+        let httpOnly = try JSONDecoder().decode(ACPMCPServerCapabilities.self, from: Data("""
+        { "http": true }
+        """.utf8))
+        let omitted = try JSONDecoder().decode(ACPMCPServerCapabilities.self, from: Data("{}".utf8))
+
+        #expect(httpOnly.http == true)
+        #expect(httpOnly.sse == false)
+        #expect(omitted.http == false)
+        #expect(omitted.sse == false)
+    }
+
+    private func encodedObject(_ server: ACPMCPServer) throws -> [String: Any] {
+        let data = try JSONEncoder().encode(server)
+        return try #require(JSONSerialization.jsonObject(with: data) as? [String: Any])
+    }
+}

--- a/AlasTests/ACP/Protocol/ACPMCPServerTests.swift
+++ b/AlasTests/ACP/Protocol/ACPMCPServerTests.swift
@@ -68,6 +68,27 @@ struct ACPMCPServerTests {
         #expect(sse == .sse(name: "events", url: "https://example.com/sse", headers: []))
     }
 
+    @Test("round trips nonempty stdio environment and remote headers")
+    func roundTripsNonemptyCollections() throws {
+        let servers: [ACPMCPServer] = [
+            .stdio(
+                name: "filesystem",
+                command: "npx",
+                args: ["-y", "@modelcontextprotocol/server-filesystem"],
+                env: [.init(name: "ROOT", value: "/workspace")]
+            ),
+            .http(
+                name: "remote",
+                url: "https://example.com/mcp",
+                headers: [.init(name: "Authorization", value: "Bearer token")]
+            ),
+        ]
+
+        for server in servers {
+            #expect(try JSONDecoder().decode(ACPMCPServer.self, from: JSONEncoder().encode(server)) == server)
+        }
+    }
+
     @Test("rejects unknown MCP server types")
     func decodeUnknownType() {
         let data = Data("""

--- a/AlasTests/ACP/Session/ACPSessionManagerAttachRestoreTests.swift
+++ b/AlasTests/ACP/Session/ACPSessionManagerAttachRestoreTests.swift
@@ -22,7 +22,7 @@ struct ACPSessionManagerAttachRestoreTests {
         let params = try #require(client.sent.last?.params as? ACPSessionNewParams)
         #expect(params.mcpServers == [.stdio(name: "filesystem", command: "mcp-files", args: [], env: [])])
         let summary = try #require(session.mcpAttachmentSummary)
-        #expect(summary.statuses == [.init(name: "filesystem", transport: .stdio, disposition: .requested)])
+        #expect(summary.statuses == [.init(id: "0", name: "filesystem", transport: .stdio, disposition: .requested)])
         #expect(summary.configurationFingerprint == MCPAttachmentPlanner.configurationFingerprint(for: configuredServers))
     }
 

--- a/AlasTests/ACP/Session/ACPSessionManagerAttachRestoreTests.swift
+++ b/AlasTests/ACP/Session/ACPSessionManagerAttachRestoreTests.swift
@@ -5,6 +5,27 @@ import Testing
 @MainActor
 @Suite("ACPSessionManager attach restore")
 struct ACPSessionManagerAttachRestoreTests {
+    @Test("new session attaches the current project MCP plan")
+    func newSessionAttachesCurrentProjectMCPPlan() async throws {
+        let store = try ACPSessionStore(path: tmpStorePath())
+        let client = ACPMockClient()
+        scriptInitialize(client)
+        scriptSessionResult(client, method: "session/new", sessionId: "remote-new")
+        let configuredServers = [ProjectMCPServer.stdio(name: "filesystem", command: "mcp-files")]
+        let manager = manager(store: store, client: client, mcpProjectContextProvider: {
+            MCPProjectContext(projectDirectory: "/tmp/project", configuredServers: configuredServers)
+        })
+        let session = manager.createSession(agentId: "claude")
+
+        await manager.attach(to: session.id, freshlyCreated: true)
+
+        let params = try #require(client.sent.last?.params as? ACPSessionNewParams)
+        #expect(params.mcpServers == [.stdio(name: "filesystem", command: "mcp-files", args: [], env: [])])
+        let summary = try #require(session.mcpAttachmentSummary)
+        #expect(summary.statuses == [.init(name: "filesystem", transport: .stdio, disposition: .requested)])
+        #expect(summary.configurationFingerprint == MCPAttachmentPlanner.configurationFingerprint(for: configuredServers))
+    }
+
     @Test("reopened session uses session/load")
     func reopenedSessionUsesLoad() async throws {
         let store = try ACPSessionStore(path: tmpStorePath())
@@ -1298,13 +1319,18 @@ struct ACPSessionManagerAttachRestoreTests {
         )
     }
 
-    private func manager(store: ACPSessionStore, client: ACPMockClient) -> ACPSessionManager {
+    private func manager(
+        store: ACPSessionStore,
+        client: ACPMockClient,
+        mcpProjectContextProvider: ACPSessionManager.MCPProjectContextProvider? = nil
+    ) -> ACPSessionManager {
         ACPSessionManager(
             worktreeId: "wt",
             worktreePath: "/tmp/wt",
             store: store,
             setupEvaluator: { _ in .ready },
-            connectionFactory: { _ in ACPConnection(client: client) }
+            connectionFactory: { _ in ACPConnection(client: client) },
+            mcpProjectContextProvider: mcpProjectContextProvider
         )
     }
 

--- a/AlasTests/ACP/Session/MCPAttachmentPlannerTests.swift
+++ b/AlasTests/ACP/Session/MCPAttachmentPlannerTests.swift
@@ -148,6 +148,17 @@ struct MCPAttachmentPlannerTests {
         #expect(result.statuses[0].disposition == .skipped(.invalidConfiguration("The server configuration is invalid.")))
     }
 
+    @Test("a whitespace-surrounded resolved command skips only its server")
+    func untrimmedResolvedCommand() {
+        let result = plan([
+            .init(id: "untrimmed", name: "untrimmed", transport: .stdio(command: "${CMD}", args: [], environment: [])),
+            .stdio(name: "good", command: "node"),
+        ], environment: ["CMD": " npx "])
+
+        #expect(result.wireServers == [.stdio(name: "good", command: "node", args: [], env: [])])
+        #expect(result.statuses[0].disposition == .skipped(.invalidConfiguration("The server configuration is invalid.")))
+    }
+
     @Test("invalid configurations skip before capability checks and keep a safe explanation")
     func invalidConfiguration() {
         let result = plan([

--- a/AlasTests/ACP/Session/MCPAttachmentPlannerTests.swift
+++ b/AlasTests/ACP/Session/MCPAttachmentPlannerTests.swift
@@ -137,6 +137,17 @@ struct MCPAttachmentPlannerTests {
         #expect(!String(describing: result.statuses).contains(secret))
     }
 
+    @Test("an empty resolved command skips only its server")
+    func emptyResolvedCommand() {
+        let result = plan([
+            .init(id: "empty", name: "empty", transport: .stdio(command: "${CMD}", args: [], environment: [])),
+            .stdio(name: "good", command: "node"),
+        ], environment: ["CMD": ""])
+
+        #expect(result.wireServers == [.stdio(name: "good", command: "node", args: [], env: [])])
+        #expect(result.statuses[0].disposition == .skipped(.invalidConfiguration("The server configuration is invalid.")))
+    }
+
     @Test("invalid configurations skip before capability checks and keep a safe explanation")
     func invalidConfiguration() {
         let result = plan([

--- a/AlasTests/ACP/Session/MCPAttachmentPlannerTests.swift
+++ b/AlasTests/ACP/Session/MCPAttachmentPlannerTests.swift
@@ -20,7 +20,7 @@ struct MCPAttachmentPlannerTests {
             ))
 
             #expect(plan.wireServers == [.stdio(name: "local", command: "npx", args: [], env: [])])
-            #expect(plan.statuses == [.init(name: "local", transport: .stdio, disposition: .requested)])
+            #expect(plan.statuses == [.init(id: "0", name: "local", transport: .stdio, disposition: .requested)])
         }
     }
 
@@ -131,8 +131,8 @@ struct MCPAttachmentPlannerTests {
 
         #expect(result.wireServers == [.stdio(name: "good", command: "node", args: [], env: [])])
         #expect(result.statuses == [
-            .init(name: "bad", transport: .stdio, disposition: .skipped(.missingVariable("MISSING"))),
-            .init(name: "good", transport: .stdio, disposition: .requested),
+            .init(id: "0", name: "bad", transport: .stdio, disposition: .skipped(.missingVariable("MISSING"))),
+            .init(id: "1", name: "good", transport: .stdio, disposition: .requested),
         ])
         #expect(!String(describing: result.statuses).contains(secret))
     }
@@ -158,6 +158,19 @@ struct MCPAttachmentPlannerTests {
         #expect(result.wireServers == [.stdio(name: "good", command: "node", args: [], env: [])])
         #expect(result.statuses[0].disposition == .skipped(.invalidConfiguration("The server configuration is invalid.")))
         #expect(!String(describing: result.statuses[0]).contains("not a URL"))
+    }
+
+    @Test("duplicate invalid server names retain unique status identities")
+    func duplicateServerStatusesHaveUniqueIDs() {
+        let result = plan([
+            .init(id: "first", name: "duplicate", transport: .stdio(command: "", args: [], environment: [])),
+            .init(id: "second", name: "duplicate", transport: .stdio(command: "", args: [], environment: [])),
+        ])
+
+        #expect(result.statuses.map(\.id) == ["0", "1"])
+        #expect(result.statuses.allSatisfy {
+            $0.disposition == .skipped(.invalidConfiguration("The server configuration is invalid."))
+        })
     }
 
     @Test("configuration fingerprints exclude edit IDs and include persisted values")

--- a/AlasTests/ACP/Session/MCPAttachmentPlannerTests.swift
+++ b/AlasTests/ACP/Session/MCPAttachmentPlannerTests.swift
@@ -1,0 +1,214 @@
+import Testing
+@testable import Alas
+
+@Suite("MCP attachment planner")
+struct MCPAttachmentPlannerTests {
+    @Test("stdio is requested for every remote capability combination")
+    func stdioIsAlwaysRequested() {
+        for capabilities in [
+            ACPMCPServerCapabilities(http: false, sse: false),
+            ACPMCPServerCapabilities(http: true, sse: false),
+            ACPMCPServerCapabilities(http: false, sse: true),
+            ACPMCPServerCapabilities(http: true, sse: true),
+        ] {
+            let plan = MCPAttachmentPlanner.plan(.init(
+                configuredServers: [.stdio(name: "local", command: "npx")],
+                projectDirectory: "/project",
+                worktreeDirectory: "/worktree",
+                environment: [:],
+                capabilities: capabilities
+            ))
+
+            #expect(plan.wireServers == [.stdio(name: "local", command: "npx", args: [], env: [])])
+            #expect(plan.statuses == [.init(name: "local", transport: .stdio, disposition: .requested)])
+        }
+    }
+
+    @Test("remote transports respect advertised capabilities and configured order")
+    func remoteCapabilities() {
+        let servers = [
+            ProjectMCPServer.stdio(name: "local", command: "npx"),
+            .init(id: "http", name: "remote", transport: .http(url: "https://mcp.example.com", headers: [])),
+            .init(id: "sse", name: "events", transport: .sse(url: "https://mcp.example.com/sse", headers: [])),
+        ]
+
+        let neither = plan(servers, capabilities: .init())
+        #expect(neither.wireServers.map(serverName) == ["local"])
+        #expect(neither.statuses.map(\.disposition) == [
+            .requested,
+            .skipped(.unsupportedTransport),
+            .skipped(.unsupportedTransport),
+        ])
+
+        let httpOnly = plan(servers, capabilities: .init(http: true))
+        #expect(httpOnly.wireServers.map(serverName) == ["local", "remote"])
+        #expect(httpOnly.statuses.map(\.disposition) == [
+            .requested,
+            .requested,
+            .skipped(.unsupportedTransport),
+        ])
+
+        let sseOnly = plan(servers, capabilities: .init(sse: true))
+        #expect(sseOnly.wireServers.map(serverName) == ["local", "events"])
+        #expect(sseOnly.statuses.map(\.disposition) == [
+            .requested,
+            .skipped(.unsupportedTransport),
+            .requested,
+        ])
+
+        let both = plan(servers, capabilities: .init(http: true, sse: true))
+        #expect(both.wireServers.map(serverName) == ["local", "remote", "events"])
+        #expect(both.statuses.allSatisfy { $0.disposition == .requested })
+    }
+
+    @Test("interpolates all supported values and reserves directory variables")
+    func interpolation() {
+        let servers = [
+            ProjectMCPServer(
+                id: "stdio",
+                name: "local",
+                transport: .stdio(
+                    command: "${BIN}",
+                    args: ["--root=${PROJECT_DIR}", "${WORKTREE_DIR}/${NAME}", "${NAME}-${NAME}"],
+                    environment: [.init(id: "token", name: "TOKEN", value: "${PREFIX}-${TOKEN}")]
+                )
+            ),
+            ProjectMCPServer(
+                id: "remote",
+                name: "remote",
+                transport: .http(
+                    url: "https://${HOST}/${PROJECT_DIR}",
+                    headers: [.init(id: "header", name: "Authorization", value: "Bearer ${TOKEN} ${TOKEN}")]
+                )
+            ),
+        ]
+
+        let result = plan(
+            servers,
+            environment: [
+                "BIN": "node",
+                "HOST": "mcp.example.com",
+                "NAME": "service",
+                "PREFIX": "secret",
+                "TOKEN": "token",
+                "PROJECT_DIR": "untrusted-project",
+                "WORKTREE_DIR": "untrusted-worktree",
+            ],
+            capabilities: .init(http: true)
+        )
+
+        #expect(result.wireServers == [
+            .stdio(
+                name: "local",
+                command: "node",
+                args: ["--root=/project", "/worktree/service", "service-service"],
+                env: [.init(name: "TOKEN", value: "secret-token")]
+            ),
+            .http(
+                name: "remote",
+                url: "https://mcp.example.com//project",
+                headers: [.init(name: "Authorization", value: "Bearer token token")]
+            ),
+        ])
+        #expect(result.statuses.allSatisfy { $0.disposition == .requested })
+    }
+
+    @Test("a missing variable skips only its server without exposing configuration values")
+    func missingVariable() {
+        let secret = "top-secret-token"
+        let result = plan([
+            .init(
+                id: "bad",
+                name: "bad",
+                transport: .stdio(
+                    command: "npx",
+                    args: ["${MISSING}"],
+                    environment: [.init(id: "secret", name: "TOKEN", value: secret)]
+                )
+            ),
+            .stdio(name: "good", command: "node"),
+        ])
+
+        #expect(result.wireServers == [.stdio(name: "good", command: "node", args: [], env: [])])
+        #expect(result.statuses == [
+            .init(name: "bad", transport: .stdio, disposition: .skipped(.missingVariable("MISSING"))),
+            .init(name: "good", transport: .stdio, disposition: .requested),
+        ])
+        #expect(!String(describing: result.statuses).contains(secret))
+    }
+
+    @Test("invalid configurations skip before capability checks and keep a safe explanation")
+    func invalidConfiguration() {
+        let result = plan([
+            .init(id: "invalid", name: "remote", transport: .http(url: "not a URL", headers: [])),
+            .stdio(name: "good", command: "node"),
+        ])
+
+        #expect(result.wireServers == [.stdio(name: "good", command: "node", args: [], env: [])])
+        #expect(result.statuses[0].disposition == .skipped(.invalidConfiguration("The server configuration is invalid.")))
+        #expect(!String(describing: result.statuses[0]).contains("not a URL"))
+    }
+
+    @Test("configuration fingerprints exclude edit IDs and include persisted values")
+    func configurationFingerprint() {
+        let original = ProjectMCPServer(
+            id: "server-a",
+            name: "remote",
+            transport: .http(
+                url: "https://mcp.example.com",
+                headers: [.init(id: "header-a", name: "Authorization", value: "Bearer one")]
+            )
+        )
+        let differentIDs = ProjectMCPServer(
+            id: "server-b",
+            name: "remote",
+            transport: .http(
+                url: "https://mcp.example.com",
+                headers: [.init(id: "header-b", name: "Authorization", value: "Bearer one")]
+            )
+        )
+        let changedValue = ProjectMCPServer(
+            id: "server-c",
+            name: "remote",
+            transport: .http(
+                url: "https://mcp.example.com",
+                headers: [.init(id: "header-c", name: "Authorization", value: "Bearer two")]
+            )
+        )
+
+        let fingerprint = MCPAttachmentPlanner.configurationFingerprint(for: [original])
+        #expect(fingerprint.count == 64)
+        #expect(fingerprint == MCPAttachmentPlanner.configurationFingerprint(for: [differentIDs]))
+        #expect(fingerprint != MCPAttachmentPlanner.configurationFingerprint(for: [changedValue]))
+    }
+
+    @Test("empty configuration has no attachment requests")
+    func emptyConfiguration() {
+        let result = plan([])
+
+        #expect(result.wireServers.isEmpty)
+        #expect(result.statuses.isEmpty)
+        #expect(result.configurationFingerprint == MCPAttachmentPlanner.configurationFingerprint(for: []))
+    }
+
+    private func plan(
+        _ servers: [ProjectMCPServer],
+        environment: [String: String] = [:],
+        capabilities: ACPMCPServerCapabilities = .init()
+    ) -> MCPAttachmentPlan {
+        MCPAttachmentPlanner.plan(.init(
+            configuredServers: servers,
+            projectDirectory: "/project",
+            worktreeDirectory: "/worktree",
+            environment: environment,
+            capabilities: capabilities
+        ))
+    }
+
+    private func serverName(_ server: ACPMCPServer) -> String {
+        switch server {
+        case let .stdio(name, _, _, _), let .http(name, _, _), let .sse(name, _, _):
+            name
+        }
+    }
+}

--- a/AlasTests/ACP/UI/ACPMCPStatusPolicyTests.swift
+++ b/AlasTests/ACP/UI/ACPMCPStatusPolicyTests.swift
@@ -12,9 +12,9 @@ struct ACPMCPStatusPolicyTests {
     func summarizesRequestedAndSkippedServers() {
         let token = "never-display-this"
         let summary = MCPAttachmentSummary(statuses: [
-            .init(name: "filesystem", transport: .stdio, disposition: .requested),
-            .init(name: "remote", transport: .http, disposition: .skipped(.missingVariable("MCP_TOKEN"))),
-            .init(name: "legacy", transport: .sse, disposition: .skipped(.unsupportedTransport))
+            .init(id: "0", name: "filesystem", transport: .stdio, disposition: .requested),
+            .init(id: "1", name: "remote", transport: .http, disposition: .skipped(.missingVariable("MCP_TOKEN"))),
+            .init(id: "2", name: "legacy", transport: .sse, disposition: .skipped(.unsupportedTransport))
         ], configurationFingerprint: MCPAttachmentPlanner.configurationFingerprint(for: []))
 
         let state = ACPMCPStatusState(summary: summary, currentServers: [])
@@ -35,7 +35,7 @@ struct ACPMCPStatusPolicyTests {
         let attached = [ProjectMCPServer.stdio(name: "filesystem", command: "mcp-files")]
         let changed = [ProjectMCPServer.stdio(name: "filesystem", command: "mcp-files-v2")]
         let summary = MCPAttachmentSummary(
-            statuses: [.init(name: "filesystem", transport: .stdio, disposition: .requested)],
+            statuses: [.init(id: "0", name: "filesystem", transport: .stdio, disposition: .requested)],
             configurationFingerprint: MCPAttachmentPlanner.configurationFingerprint(for: attached)
         )
 

--- a/AlasTests/ACP/UI/ACPMCPStatusPolicyTests.swift
+++ b/AlasTests/ACP/UI/ACPMCPStatusPolicyTests.swift
@@ -1,0 +1,63 @@
+import Testing
+@testable import Alas
+
+@Suite("ACPMCPStatusState")
+struct ACPMCPStatusPolicyTests {
+    @Test("does not display before an MCP attachment plan exists")
+    func absentSummaryDoesNotDisplay() {
+        #expect(ACPMCPStatusState(summary: nil, currentServers: []) == nil)
+    }
+
+    @Test("summarizes requested and skipped servers without secret values")
+    func summarizesRequestedAndSkippedServers() {
+        let token = "never-display-this"
+        let summary = MCPAttachmentSummary(statuses: [
+            .init(name: "filesystem", transport: .stdio, disposition: .requested),
+            .init(name: "remote", transport: .http, disposition: .skipped(.missingVariable("MCP_TOKEN"))),
+            .init(name: "legacy", transport: .sse, disposition: .skipped(.unsupportedTransport))
+        ], configurationFingerprint: MCPAttachmentPlanner.configurationFingerprint(for: []))
+
+        let state = ACPMCPStatusState(summary: summary, currentServers: [])
+
+        #expect(state?.requestedCount == 1)
+        #expect(state?.skippedCount == 2)
+        #expect(state?.rows.map(\.detail) == [
+            "Requested",
+            "Skipped: missing MCP_TOKEN",
+            "Skipped: unsupported transport"
+        ])
+        #expect(state?.rows[2].transport == "Legacy SSE")
+        #expect(!(state?.accessibilitySummary.contains(token) ?? true))
+    }
+
+    @Test("marks settings changes stale until reconnect")
+    func marksChangedConfigurationStale() {
+        let attached = [ProjectMCPServer.stdio(name: "filesystem", command: "mcp-files")]
+        let changed = [ProjectMCPServer.stdio(name: "filesystem", command: "mcp-files-v2")]
+        let summary = MCPAttachmentSummary(
+            statuses: [.init(name: "filesystem", transport: .stdio, disposition: .requested)],
+            configurationFingerprint: MCPAttachmentPlanner.configurationFingerprint(for: attached)
+        )
+
+        let current = ACPMCPStatusState(summary: summary, currentServers: attached)
+        let stale = ACPMCPStatusState(summary: summary, currentServers: changed)
+
+        #expect(current?.isStale == false)
+        #expect(stale?.isStale == true)
+        #expect(stale?.accessibilitySummary == "MCP: 1 requested, New settings apply on reconnect.")
+    }
+
+    @Test("shows a stale zero-server state after MCP servers are added")
+    func showsStaleStateWhenServersAreAddedAfterAttach() {
+        let added = [ProjectMCPServer.stdio(name: "filesystem", command: "mcp-files")]
+        let summary = MCPAttachmentSummary(
+            statuses: [],
+            configurationFingerprint: MCPAttachmentPlanner.configurationFingerprint(for: [])
+        )
+
+        let state = ACPMCPStatusState(summary: summary, currentServers: added)
+
+        #expect(state?.requestedCount == 0)
+        #expect(state?.isStale == true)
+    }
+}

--- a/AlasTests/Persistence/ProjectMCPServerTests.swift
+++ b/AlasTests/Persistence/ProjectMCPServerTests.swift
@@ -31,6 +31,25 @@ struct ProjectMCPServerTests {
         ]
 
         let data = try JSONEncoder().encode(servers)
+        let objects = try #require(JSONSerialization.jsonObject(with: data) as? [[String: Any]])
+        let stdio = try #require(objects[0]["transport"] as? [String: Any])
+        let http = try #require(objects[1]["transport"] as? [String: Any])
+        let sse = try #require(objects[2]["transport"] as? [String: Any])
+
+        #expect(stdio["kind"] as? String == "stdio")
+        #expect(stdio["command"] as? String == "npx")
+        #expect(stdio["args"] as? [String] == ["-y", "server", "${WORKTREE_DIR}"])
+        #expect(stdio["environment"] as? [[String: String]] == [[
+            "id": "env", "name": "API_TOKEN", "value": "${TOKEN}",
+        ]])
+        #expect(http["kind"] as? String == "http")
+        #expect(http["url"] as? String == "https://mcp.linear.app/mcp")
+        #expect(http["headers"] as? [[String: String]] == [[
+            "id": "header", "name": "Authorization", "value": "Bearer ${LINEAR_TOKEN}",
+        ]])
+        #expect(sse["kind"] as? String == "sse")
+        #expect(sse["url"] as? String == "https://example.com/sse")
+        #expect(sse["headers"] as? [[String: String]] == [])
         #expect(try JSONDecoder().decode([ProjectMCPServer].self, from: data) == servers)
     }
 
@@ -66,7 +85,7 @@ struct ProjectMCPServerTests {
         #expect(ProjectMCPValidation.validate([server]) == [.invalidURL(serverName: "remote")])
     }
 
-    @Test(arguments: ["ftp://mcp.example.com", "https:///missing-host", "not a url"])
+    @Test(arguments: ["ftp://mcp.example.com", "https:///missing-host", "not a url", " https://mcp.example.com "])
     func validationRejectsInvalidRemoteURLs(_ url: String) {
         let server = ProjectMCPServer(
             id: "server",

--- a/AlasTests/Persistence/ProjectMCPServerTests.swift
+++ b/AlasTests/Persistence/ProjectMCPServerTests.swift
@@ -85,7 +85,13 @@ struct ProjectMCPServerTests {
         #expect(ProjectMCPValidation.validate([server]) == [.invalidURL(serverName: "remote")])
     }
 
-    @Test(arguments: ["ftp://mcp.example.com", "https:///missing-host", "not a url", " https://mcp.example.com "])
+    @Test(arguments: [
+        "ftp://mcp.example.com",
+        "https:///missing-host",
+        "not a url",
+        " https://mcp.example.com ",
+        "https://mcp.example.com/a path",
+    ])
     func validationRejectsInvalidRemoteURLs(_ url: String) {
         let server = ProjectMCPServer(
             id: "server",
@@ -94,6 +100,12 @@ struct ProjectMCPServerTests {
         )
 
         #expect(ProjectMCPValidation.validate([server]) == [.invalidURL(serverName: "remote")])
+    }
+
+    @Test func validationRejectsUntrimmedStdioCommands() {
+        let server = ProjectMCPServer.stdio(name: "filesystem", command: " npx ")
+
+        #expect(ProjectMCPValidation.validate([server]) == [.emptyCommand(serverName: "filesystem")])
     }
 
     @Test func validationRejectsInvalidAndDuplicateEnvironmentNames() {

--- a/AlasTests/Persistence/ProjectMCPServerTests.swift
+++ b/AlasTests/Persistence/ProjectMCPServerTests.swift
@@ -1,0 +1,141 @@
+import Foundation
+import Testing
+@testable import Alas
+
+@Suite("Project MCP server")
+struct ProjectMCPServerTests {
+    @Test func roundTripsAllTransports() throws {
+        let servers = [
+            ProjectMCPServer(
+                id: "stdio",
+                name: "filesystem",
+                transport: .stdio(
+                    command: "npx",
+                    args: ["-y", "server", "${WORKTREE_DIR}"],
+                    environment: [.init(id: "env", name: "API_TOKEN", value: "${TOKEN}")]
+                )
+            ),
+            ProjectMCPServer(
+                id: "http",
+                name: "linear",
+                transport: .http(
+                    url: "https://mcp.linear.app/mcp",
+                    headers: [.init(id: "header", name: "Authorization", value: "Bearer ${LINEAR_TOKEN}")]
+                )
+            ),
+            ProjectMCPServer(
+                id: "sse",
+                name: "legacy",
+                transport: .sse(url: "https://example.com/sse", headers: [])
+            ),
+        ]
+
+        let data = try JSONEncoder().encode(servers)
+        #expect(try JSONDecoder().decode([ProjectMCPServer].self, from: data) == servers)
+    }
+
+    @Test func validationRejectsDuplicateServerNames() {
+        let issues = ProjectMCPValidation.validate([
+            .stdio(name: "filesystem", command: "first"),
+            .stdio(name: " filesystem ", command: "second"),
+        ])
+
+        #expect(issues == [.duplicateServerName("filesystem")])
+    }
+
+    @Test func validationRejectsEmptyNamesAndCommands() {
+        let server = ProjectMCPServer(
+            id: "server",
+            name: "  ",
+            transport: .stdio(command: "\n", args: [], environment: [])
+        )
+
+        #expect(ProjectMCPValidation.validate([server]) == [
+            .emptyServerName(serverId: "server"),
+            .emptyCommand(serverName: ""),
+        ])
+    }
+
+    @Test func validationRejectsFileURL() {
+        let server = ProjectMCPServer(
+            id: "server",
+            name: "remote",
+            transport: .http(url: "file:///tmp/mcp", headers: [])
+        )
+
+        #expect(ProjectMCPValidation.validate([server]) == [.invalidURL(serverName: "remote")])
+    }
+
+    @Test(arguments: ["ftp://mcp.example.com", "https:///missing-host", "not a url"])
+    func validationRejectsInvalidRemoteURLs(_ url: String) {
+        let server = ProjectMCPServer(
+            id: "server",
+            name: "remote",
+            transport: .http(url: url, headers: [])
+        )
+
+        #expect(ProjectMCPValidation.validate([server]) == [.invalidURL(serverName: "remote")])
+    }
+
+    @Test func validationRejectsInvalidAndDuplicateEnvironmentNames() {
+        let server = ProjectMCPServer(
+            id: "server",
+            name: "filesystem",
+            transport: .stdio(
+                command: "npx",
+                args: [],
+                environment: [
+                    .init(id: "one", name: "1INVALID", value: "a"),
+                    .init(id: "two", name: " TOKEN ", value: "b"),
+                    .init(id: "three", name: "TOKEN", value: "c"),
+                ]
+            )
+        )
+
+        #expect(ProjectMCPValidation.validate([server]) == [
+            .invalidEnvironmentName(serverName: "filesystem", name: "1INVALID"),
+            .duplicateEnvironmentName(serverName: "filesystem", name: "TOKEN"),
+        ])
+    }
+
+    @Test func validationRejectsDuplicateHeaderNamesCaseInsensitively() {
+        let server = ProjectMCPServer(
+            id: "server",
+            name: "remote",
+            transport: .sse(
+                url: "https://mcp.example.com/sse",
+                headers: [
+                    .init(id: "one", name: " Authorization ", value: "a"),
+                    .init(id: "two", name: "authorization", value: "b"),
+                ]
+            )
+        )
+
+        #expect(ProjectMCPValidation.validate([server]) == [
+            .duplicateHeaderName(serverName: "remote", name: "authorization"),
+        ])
+    }
+
+    @Test func validationRejectsEmptyHeaderNames() {
+        let server = ProjectMCPServer(
+            id: "server",
+            name: "remote",
+            transport: .http(
+                url: "https://mcp.example.com",
+                headers: [.init(id: "header", name: " \n ", value: "token")]
+            )
+        )
+
+        #expect(ProjectMCPValidation.validate([server]) == [.emptyHeaderName(serverName: "remote")])
+    }
+
+    @Test func validationAcceptsEmptyArgumentsEnvironmentAndHeaders() {
+        let servers = [
+            ProjectMCPServer.stdio(name: "filesystem", command: "npx"),
+            ProjectMCPServer(id: "http", name: "remote", transport: .http(url: "https://mcp.example.com", headers: [])),
+            ProjectMCPServer(id: "sse", name: "events", transport: .sse(url: "https://mcp.example.com/sse", headers: [])),
+        ]
+
+        #expect(ProjectMCPValidation.validate(servers).isEmpty)
+    }
+}

--- a/AlasTests/Persistence/ProjectMCPServerTests.swift
+++ b/AlasTests/Persistence/ProjectMCPServerTests.swift
@@ -113,7 +113,25 @@ struct ProjectMCPServerTests {
 
         #expect(ProjectMCPValidation.validate([server]) == [
             .invalidEnvironmentName(serverName: "filesystem", name: "1INVALID"),
-            .duplicateEnvironmentName(serverName: "filesystem", name: "TOKEN"),
+            .invalidEnvironmentName(serverName: "filesystem", name: " TOKEN "),
+        ])
+    }
+
+    @Test func validationRejectsWhitespaceAroundHeaderNames() {
+        let server = ProjectMCPServer(
+            id: "server",
+            name: "remote",
+            transport: .sse(
+                url: "https://mcp.example.com/sse",
+                headers: [
+                    .init(id: "one", name: " Authorization ", value: "a"),
+                    .init(id: "two", name: "authorization", value: "b"),
+                ]
+            )
+        )
+
+        #expect(ProjectMCPValidation.validate([server]) == [
+            .invalidHeaderName(serverName: "remote", name: " Authorization "),
         ])
     }
 
@@ -124,7 +142,7 @@ struct ProjectMCPServerTests {
             transport: .sse(
                 url: "https://mcp.example.com/sse",
                 headers: [
-                    .init(id: "one", name: " Authorization ", value: "a"),
+                    .init(id: "one", name: "Authorization", value: "a"),
                     .init(id: "two", name: "authorization", value: "b"),
                 ]
             )

--- a/AlasTests/ProjectConfigTests.swift
+++ b/AlasTests/ProjectConfigTests.swift
@@ -23,6 +23,7 @@ struct ProjectConfigTests {
         #expect(file.projects.count == 1)
         #expect(file.projects[0].hiddenWorktreePaths == [])
         #expect(file.projects[0].startupScripts == .defaults)
+        #expect(file.projects[0].mcpServers == [])
     }
 
     @Test func roundTripPreservesHiddenPaths() throws {
@@ -64,6 +65,22 @@ struct ProjectConfigTests {
         #expect(scripts.sessionOpenScript == "mise install")
         #expect(scripts.worktreeCreateMode == .overrideGlobal)
         #expect(scripts.worktreeCreateScript == "pnpm install")
+    }
+
+    @Test func roundTripPreservesMCPServers() throws {
+        let project = ProjectConfig(
+            id: "abc", name: "alpha", path: "/tmp/alpha",
+            color: "#5fb7c4", addedAt: Date(timeIntervalSince1970: 0),
+            mcpServers: [.stdio(name: "filesystem", command: "npx")]
+        )
+        let encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = .secondsSince1970
+        let data = try encoder.encode(ProjectsFile(projects: [project]))
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .secondsSince1970
+        let decoded = try decoder.decode(ProjectsFile.self, from: data)
+
+        #expect(decoded.projects[0].mcpServers == project.mcpServers)
     }
 
     @Test func decodingOlderProjectWithHiddenPathsButNoStartupScripts() throws {

--- a/AlasTests/ProjectMCPServerEditorPolicyTests.swift
+++ b/AlasTests/ProjectMCPServerEditorPolicyTests.swift
@@ -10,9 +10,15 @@ struct ProjectMCPServerEditorPolicyTests {
             name: "remote",
             transport: .http(url: "https://${MCP_HOST}/mcp", headers: [])
         )
+        let fullURLTemplate = ProjectMCPServer(
+            id: "full-url",
+            name: "full-url",
+            transport: .http(url: "${MCP_URL}", headers: [])
+        )
 
         #expect(!ProjectMCPServerEditorPolicy.canSave([incomplete]))
         #expect(ProjectMCPServerEditorPolicy.canSave([deferred]))
+        #expect(ProjectMCPServerEditorPolicy.canSave([fullURLTemplate]))
     }
 
     @Test func canSaveRejectsStructurallyInvalidURLTemplates() {

--- a/AlasTests/ProjectMCPServerEditorPolicyTests.swift
+++ b/AlasTests/ProjectMCPServerEditorPolicyTests.swift
@@ -31,6 +31,16 @@ struct ProjectMCPServerEditorPolicyTests {
         #expect(!ProjectMCPServerEditorPolicy.canSave([malformed]))
     }
 
+    @Test func canSaveRejectsLiteralRemoteURLsWithWhitespace() {
+        let server = ProjectMCPServer(
+            id: "literal",
+            name: "literal",
+            transport: .http(url: "https://mcp.example.com/a path", headers: [])
+        )
+
+        #expect(!ProjectMCPServerEditorPolicy.canSave([server]))
+    }
+
     @Test func extractsDistinctTemplateVariablesInEncounterOrder() {
         let server = ProjectMCPServer(
             id: "server",

--- a/AlasTests/ProjectMCPServerEditorPolicyTests.swift
+++ b/AlasTests/ProjectMCPServerEditorPolicyTests.swift
@@ -1,0 +1,53 @@
+import Testing
+@testable import Alas
+
+@Suite("Project MCP server editor policy")
+struct ProjectMCPServerEditorPolicyTests {
+    @Test func canSaveRequiresValidStructureButPermitsDeferredURLTemplates() {
+        let incomplete = ProjectMCPServer.stdio(name: "filesystem", command: "  ")
+        let deferred = ProjectMCPServer(
+            id: "remote",
+            name: "remote",
+            transport: .http(url: "https://${MCP_HOST}/mcp", headers: [])
+        )
+
+        #expect(!ProjectMCPServerEditorPolicy.canSave([incomplete]))
+        #expect(ProjectMCPServerEditorPolicy.canSave([deferred]))
+    }
+
+    @Test func extractsDistinctTemplateVariablesInEncounterOrder() {
+        let server = ProjectMCPServer(
+            id: "server",
+            name: "filesystem",
+            transport: .stdio(
+                command: "mcp-${COMMAND}",
+                args: ["${WORKTREE_DIR}", "${COMMAND}"],
+                environment: [
+                    .init(id: "one", name: "TOKEN", value: "${API_TOKEN}"),
+                    .init(id: "two", name: "EMPTY", value: "${NOT-VALID!}"),
+                ]
+            )
+        )
+
+        #expect(ProjectMCPServerEditorPolicy.templateVariables(in: server) == [
+            "COMMAND", "WORKTREE_DIR", "API_TOKEN",
+        ])
+    }
+
+    @Test func summaryNeverIncludesRemoteCredentialsQueryOrFragment() {
+        let server = ProjectMCPServer(
+            id: "remote",
+            name: "remote",
+            transport: .http(
+                url: "https://user:secret@mcp.example.com/v1?token=top-secret#private",
+                headers: []
+            )
+        )
+
+        #expect(ProjectMCPServerEditorPolicy.summary(for: server) == "https://mcp.example.com/v1")
+    }
+
+    @Test func labelsSSEAsLegacy() {
+        #expect(ProjectMCPServerEditorPolicy.transportLabel(for: .sse(url: "https://example.com/sse", headers: [])) == "Legacy SSE")
+    }
+}

--- a/AlasTests/ProjectMCPServerEditorPolicyTests.swift
+++ b/AlasTests/ProjectMCPServerEditorPolicyTests.swift
@@ -15,6 +15,22 @@ struct ProjectMCPServerEditorPolicyTests {
         #expect(ProjectMCPServerEditorPolicy.canSave([deferred]))
     }
 
+    @Test func canSaveRejectsStructurallyInvalidURLTemplates() {
+        let wrongScheme = ProjectMCPServer(
+            id: "wrong-scheme",
+            name: "wrong-scheme",
+            transport: .http(url: "ftp://${HOST}/mcp", headers: [])
+        )
+        let malformed = ProjectMCPServer(
+            id: "malformed",
+            name: "malformed",
+            transport: .http(url: "https://example.com/${TOKEN} not-valid", headers: [])
+        )
+
+        #expect(!ProjectMCPServerEditorPolicy.canSave([wrongScheme]))
+        #expect(!ProjectMCPServerEditorPolicy.canSave([malformed]))
+    }
+
     @Test func extractsDistinctTemplateVariablesInEncounterOrder() {
         let server = ProjectMCPServer(
             id: "server",
@@ -45,6 +61,20 @@ struct ProjectMCPServerEditorPolicyTests {
         )
 
         #expect(ProjectMCPServerEditorPolicy.summary(for: server) == "https://mcp.example.com/v1")
+    }
+
+    @Test func stdioSummaryNeverIncludesArguments() {
+        let server = ProjectMCPServer(
+            id: "stdio",
+            name: "stdio",
+            transport: .stdio(
+                command: "mcp-files",
+                args: ["--token", "literal-secret"],
+                environment: []
+            )
+        )
+
+        #expect(ProjectMCPServerEditorPolicy.summary(for: server) == "mcp-files")
     }
 
     @Test func labelsSSEAsLegacy() {

--- a/AlasTests/ProjectsManagerTests.swift
+++ b/AlasTests/ProjectsManagerTests.swift
@@ -76,7 +76,7 @@ struct ProjectsManagerTests {
         #expect(mgr.worktrees(projectId: project.id).isEmpty)
     }
 
-    @Test func updateProjectUpdatesNameIconAndStartupScriptsOnly() {
+    @Test func updateProjectUpdatesNameIconAndStartupScriptsWhilePreservingMCPServers() {
         let addedAt = Date(timeIntervalSince1970: 1_700_000_000)
         let project = ProjectConfig(
             id: "project-1",
@@ -84,7 +84,8 @@ struct ProjectsManagerTests {
             path: "/tmp/before",
             color: "#5fb7c4",
             addedAt: addedAt,
-            hiddenWorktreePaths: ["/tmp/before/.worktree"]
+            hiddenWorktreePaths: ["/tmp/before/.worktree"],
+            mcpServers: [.stdio(name: "filesystem", command: "npx")]
         )
         let other = ProjectConfig(
             id: "project-2",
@@ -110,6 +111,7 @@ struct ProjectsManagerTests {
         #expect(mgr.projects[0].addedAt == project.addedAt)
         #expect(mgr.projects[0].hiddenWorktreePaths == project.hiddenWorktreePaths)
         #expect(mgr.projects[0].startupScripts == .defaults)
+        #expect(mgr.projects[0].mcpServers == project.mcpServers)
         #expect(mgr.projects[1] == other)
 
         mgr.updateProject(
@@ -120,6 +122,35 @@ struct ProjectsManagerTests {
         #expect(mgr.projects[0].name == "After")
         #expect(mgr.projects[0].icon == icon)
         #expect(mgr.projects[1] == other)
+    }
+
+    @Test func updateProjectReplacesMCPServersWhenExplicitlyProvided() {
+        let original = ProjectMCPServer.stdio(name: "filesystem", command: "npx")
+        let replacement = ProjectMCPServer(
+            id: "linear",
+            name: "linear",
+            transport: .http(url: "https://mcp.linear.app/mcp", headers: [])
+        )
+        let project = ProjectConfig(
+            id: "project-1",
+            name: "Before",
+            path: "/tmp/before",
+            color: "#5fb7c4",
+            addedAt: Date(timeIntervalSince1970: 0),
+            mcpServers: [original]
+        )
+        let manager = ProjectsManager(persistedProjects: [project])
+
+        manager.updateProject(
+            id: project.id,
+            update: ProjectUpdate(
+                name: "After",
+                icon: project.icon,
+                mcpServers: [replacement]
+            )
+        )
+
+        #expect(manager.projects[0].mcpServers == [replacement])
     }
 
     @Test func setWorktreeLaunchDefaultsPersistsPerProject() {

--- a/docs/superpowers/plans/2026-07-11-acp-mcp-server-passthrough.md
+++ b/docs/superpowers/plans/2026-07-11-acp-mcp-server-passthrough.md
@@ -1,0 +1,832 @@
+# ACP MCP Server Passthrough Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Let Alas projects configure stdio, HTTP, and legacy SSE MCP servers that are safely resolved, capability-filtered, passed through every ACP session lifecycle request, and reported honestly in project and session UI.
+
+**Architecture:** Persist non-resolved project MCP definitions, then build one pure `MCPAttachmentPlan` after the ACP initialize handshake. Inject a current-project provider into each worktree manager, pass only resolved wire servers to `ACPConnection`, and retain only safe requested/skipped metadata on `ACPSession` for the toolbar.
+
+**Tech Stack:** Swift 5.9, SwiftUI, Observation/Combine, Foundation/CryptoKit, Swift Testing, ACP v1 JSON-RPC, XcodeGen.
+
+---
+
+## File Structure
+
+Create focused files rather than growing `ACPMessages.swift`, `ACPSessionManager.swift`, and `NewProjectDialog.swift` further:
+
+- `Alas/Sources/Persistence/ProjectMCPServer.swift`: persisted server, transport, and key/value models plus structural validation.
+- `Alas/Sources/ACP/Protocol/ACPMCPServer.swift`: ACP v1 MCP wire union and initialized transport capabilities.
+- `Alas/Sources/ACP/Session/MCPAttachmentPlanner.swift`: interpolation, filtering, safe status, and configuration fingerprinting.
+- `Alas/Sources/Dialogs/ProjectMCPServerManager.swift`: project draft list and deletion flow.
+- `Alas/Sources/Dialogs/ProjectMCPServerEditor.swift`: adaptive add/edit form.
+- `Alas/Sources/Dialogs/ProjectMCPServerEditorPolicy.swift`: pure validation, labels, reference extraction, and safe summaries.
+- `Alas/Sources/ACP/UI/ACPMCPStatusControl.swift`: toolbar button and popover.
+- `Alas/Sources/ACP/UI/ACPMCPStatusPolicy.swift`: pure visibility/count/staleness projection.
+- `scripts/mcp-smoke-server.py`: dependency-free deterministic MCP stdio server for adapter smoke verification.
+
+Modify existing ownership points only where wiring is required:
+
+- `Alas/Sources/Persistence/ProjectConfig.swift`
+- `Alas/Sources/App/ProjectsManager.swift`
+- `Alas/Sources/App/AppState.swift`
+- `Alas/Sources/ACP/Protocol/ACPMessages.swift`
+- `Alas/Sources/ACP/Protocol/ACPConnection.swift`
+- `Alas/Sources/ACP/Session/ACPSession.swift`
+- `Alas/Sources/ACP/Session/ACPSessionManager.swift`
+- `Alas/Sources/Dialogs/NewProjectDialog.swift`
+- `Alas/Sources/ACP/UI/ACPToolbar.swift`
+
+### Task 1: Persist Project MCP Definitions
+
+**Files:**
+- Create: `Alas/Sources/Persistence/ProjectMCPServer.swift`
+- Modify: `Alas/Sources/Persistence/ProjectConfig.swift`
+- Test: `AlasTests/Persistence/ProjectMCPServerTests.swift`
+- Test: `AlasTests/ProjectConfigTests.swift`
+- Regenerate: `Alas.xcodeproj/project.pbxproj`
+
+- [ ] **Step 1: Write failing model and compatibility tests**
+
+Create `ProjectMCPServerTests` covering all transports and semantic validation:
+
+```swift
+import Foundation
+import Testing
+@testable import Alas
+
+@Suite("Project MCP server")
+struct ProjectMCPServerTests {
+    @Test func roundTripsAllTransports() throws {
+        let servers = [
+            ProjectMCPServer(id: "stdio", name: "filesystem", transport: .stdio(
+                command: "npx", args: ["-y", "server", "${WORKTREE_DIR}"],
+                environment: [.init(id: "env", name: "API_TOKEN", value: "${TOKEN}")]
+            )),
+            ProjectMCPServer(id: "http", name: "linear", transport: .http(
+                url: "https://mcp.linear.app/mcp",
+                headers: [.init(id: "header", name: "Authorization", value: "Bearer ${LINEAR_TOKEN}")]
+            )),
+            ProjectMCPServer(id: "sse", name: "legacy", transport: .sse(
+                url: "https://example.com/sse", headers: []
+            )),
+        ]
+        let data = try JSONEncoder().encode(servers)
+        #expect(try JSONDecoder().decode([ProjectMCPServer].self, from: data) == servers)
+    }
+
+    @Test func validationRejectsDuplicateNamesAndInvalidFields() {
+        let duplicate = ProjectMCPServer.stdio(name: "filesystem", command: "npx")
+        #expect(ProjectMCPValidation.validate([duplicate, duplicate.withFreshId()]) ==
+                [.duplicateServerName("filesystem")])
+        #expect(ProjectMCPValidation.validate([
+            .init(id: "bad", name: "remote", transport: .http(url: "file:///tmp/mcp", headers: []))
+        ]).contains(.invalidURL(serverName: "remote")))
+    }
+}
+```
+
+Extend `ProjectConfigTests.decodingOlderProjectsFileSuppliesEmptyHiddenPaths` with:
+
+```swift
+#expect(file.projects[0].mcpServers.isEmpty)
+```
+
+Add a project round-trip assertion with one stdio server.
+
+- [ ] **Step 2: Run the focused tests and verify they fail**
+
+Run:
+
+```bash
+rtk xcodegen
+rtk xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -only-testing:AlasTests/ProjectMCPServerTests -only-testing:AlasTests/ProjectConfigTests test
+```
+
+Expected: compile failure because the project MCP types and `mcpServers` do not exist.
+
+- [ ] **Step 3: Implement the persisted types and validator**
+
+Use this public shape in `ProjectMCPServer.swift`:
+
+```swift
+import Foundation
+
+struct MCPKeyValue: Codable, Equatable, Identifiable {
+    let id: String
+    var name: String
+    var value: String
+}
+
+enum ProjectMCPTransport: Codable, Equatable {
+    case stdio(command: String, args: [String], environment: [MCPKeyValue])
+    case http(url: String, headers: [MCPKeyValue])
+    case sse(url: String, headers: [MCPKeyValue])
+}
+
+struct ProjectMCPServer: Codable, Equatable, Identifiable {
+    let id: String
+    var name: String
+    var transport: ProjectMCPTransport
+
+    static func stdio(name: String, command: String) -> Self {
+        .init(id: UUID().uuidString, name: name,
+              transport: .stdio(command: command, args: [], environment: []))
+    }
+
+    func withFreshId() -> Self {
+        .init(id: UUID().uuidString, name: name, transport: transport)
+    }
+}
+
+enum ProjectMCPValidationIssue: Equatable {
+    case emptyServerName(serverId: String)
+    case duplicateServerName(String)
+    case emptyCommand(serverName: String)
+    case invalidURL(serverName: String)
+    case invalidEnvironmentName(serverName: String, name: String)
+    case duplicateEnvironmentName(serverName: String, name: String)
+    case emptyHeaderName(serverName: String)
+    case duplicateHeaderName(serverName: String, name: String)
+}
+```
+
+Implement `ProjectMCPValidation.validate(_:)` with trimmed, case-sensitive server-name uniqueness; POSIX environment-name validation using `^[A-Za-z_][A-Za-z0-9_]*$`; case-insensitive header-name uniqueness; non-empty stdio command; and HTTP/HTTPS URL validation.
+
+Add `mcpServers` to `ProjectConfig`, its initializer, coding keys, tolerant decoder, and encoder. Missing values decode as `[]`.
+
+- [ ] **Step 4: Regenerate and run focused tests**
+
+Run the Step 2 commands again.
+
+Expected: both suites pass.
+
+- [ ] **Step 5: Commit persistence support**
+
+```bash
+rtk git add Alas/Sources/Persistence/ProjectMCPServer.swift Alas/Sources/Persistence/ProjectConfig.swift AlasTests/Persistence/ProjectMCPServerTests.swift AlasTests/ProjectConfigTests.swift Alas.xcodeproj/project.pbxproj
+rtk git commit -m "feat(acp): persist project MCP servers"
+```
+
+### Task 2: Model ACP v1 MCP Wire Shapes and Capabilities
+
+**Files:**
+- Create: `Alas/Sources/ACP/Protocol/ACPMCPServer.swift`
+- Modify: `Alas/Sources/ACP/Protocol/ACPMessages.swift`
+- Modify: `Alas/Sources/ACP/Protocol/ACPConnection.swift`
+- Test: `AlasTests/ACP/Protocol/ACPMCPServerTests.swift`
+- Test: `AlasTests/ACP/Protocol/ACPInitializeTests.swift`
+- Regenerate: `Alas.xcodeproj/project.pbxproj`
+
+- [ ] **Step 1: Write failing wire encoding tests**
+
+Test JSON objects, not encoded string ordering:
+
+```swift
+@Test func encodesStableV1TransportShapes() throws {
+    let servers: [ACPMCPServer] = [
+        .stdio(name: "fs", command: "npx", args: [], env: []),
+        .http(name: "linear", url: "https://mcp.linear.app/mcp", headers: []),
+        .sse(name: "legacy", url: "https://example.com/sse", headers: []),
+    ]
+    let objects = try servers.map { server -> [String: Any] in
+        try #require(JSONSerialization.jsonObject(with: JSONEncoder().encode(server)) as? [String: Any])
+    }
+    #expect(objects[0]["type"] == nil)
+    #expect(objects[0]["args"] as? [String] == [])
+    #expect(objects[0]["env"] as? [[String: String]] == [])
+    #expect(objects[1]["type"] as? String == "http")
+    #expect(objects[1]["headers"] as? [[String: String]] == [])
+    #expect(objects[2]["type"] as? String == "sse")
+}
+```
+
+Add initialize decoding tests for `{ "mcpCapabilities": { "http": true, "sse": false } }` and missing capability defaults.
+
+- [ ] **Step 2: Run focused tests and verify failure**
+
+```bash
+rtk xcodegen
+rtk xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -only-testing:AlasTests/ACPMCPServerTests -only-testing:AlasTests/ACPInitializeTests test
+```
+
+Expected: compile failure for missing wire and capability types.
+
+- [ ] **Step 3: Implement the custom wire union**
+
+Create:
+
+```swift
+import Foundation
+
+struct ACPMCPKeyValue: Codable, Equatable {
+    let name: String
+    let value: String
+}
+
+enum ACPMCPServer: Codable, Equatable {
+    case stdio(name: String, command: String, args: [String], env: [ACPMCPKeyValue])
+    case http(name: String, url: String, headers: [ACPMCPKeyValue])
+    case sse(name: String, url: String, headers: [ACPMCPKeyValue])
+}
+
+struct ACPMCPServerCapabilities: Codable, Equatable {
+    let http: Bool
+    let sse: Bool
+
+    init(http: Bool = false, sse: Bool = false) {
+        self.http = http
+        self.sse = sse
+    }
+}
+```
+
+Give `ACPMCPServer` explicit coding keys so stdio omits `type`, while remote variants require it. Decode missing `args`, `env`, or `headers` as empty for tolerance, but always encode those arrays.
+
+Add `mcpCapabilities` to `ACPInitializeResult.ACPAgentCapabilities` with a default `.init()`. Add the same property to `ACPInitializeOutcome` and return it from `ACPConnection.initialize()`.
+
+Replace nested `ACPSessionNewParams.ACPMCPServer` references in all lifecycle params with `[ACPMCPServer]`.
+
+- [ ] **Step 4: Run focused tests**
+
+Run the Step 2 commands again.
+
+Expected: pass.
+
+- [ ] **Step 5: Commit protocol modeling**
+
+```bash
+rtk git add Alas/Sources/ACP/Protocol/ACPMCPServer.swift Alas/Sources/ACP/Protocol/ACPMessages.swift Alas/Sources/ACP/Protocol/ACPConnection.swift AlasTests/ACP/Protocol/ACPMCPServerTests.swift AlasTests/ACP/Protocol/ACPInitializeTests.swift Alas.xcodeproj/project.pbxproj
+rtk git commit -m "feat(acp): model MCP transport capabilities"
+```
+
+### Task 3: Build the Pure Attachment Planner
+
+**Files:**
+- Create: `Alas/Sources/ACP/Session/MCPAttachmentPlanner.swift`
+- Test: `AlasTests/ACP/Session/MCPAttachmentPlannerTests.swift`
+- Regenerate: `Alas.xcodeproj/project.pbxproj`
+
+- [ ] **Step 1: Write failing planner tests**
+
+Cover stdio baseline, optional capability filtering, built-in precedence, multi-reference expansion, missing variables, semantic invalidity, safe status, and fingerprint stability:
+
+```swift
+@Test func plansRequestedAndSkippedServersWithoutLeakingSecrets() throws {
+    let input = MCPAttachmentPlannerInput(
+        configuredServers: [
+            .init(id: "stdio", name: "fs", transport: .stdio(
+                command: "npx", args: ["${WORKTREE_DIR}"],
+                environment: [.init(id: "token", name: "API_TOKEN", value: "${TOKEN}")]
+            )),
+            .init(id: "http", name: "linear", transport: .http(
+                url: "https://mcp.linear.app/mcp", headers: []
+            )),
+        ],
+        projectDirectory: "/repo",
+        worktreeDirectory: "/repo/wt",
+        environment: ["TOKEN": "super-secret", "WORKTREE_DIR": "/wrong"],
+        capabilities: .init(http: false, sse: false)
+    )
+    let plan = MCPAttachmentPlanner.plan(input)
+    #expect(plan.wireServers.count == 1)
+    #expect(plan.statuses == [
+        .init(name: "fs", transport: .stdio, disposition: .requested),
+        .init(name: "linear", transport: .http, disposition: .skipped(.unsupportedTransport)),
+    ])
+    #expect(String(describing: plan.statuses).contains("super-secret") == false)
+}
+```
+
+Add a test proving two definitions with different editing IDs have the same fingerprint and changing a referenced value changes it.
+
+- [ ] **Step 2: Run tests and verify failure**
+
+```bash
+rtk xcodegen
+rtk xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -only-testing:AlasTests/MCPAttachmentPlannerTests test
+```
+
+Expected: compile failure for missing planner types.
+
+- [ ] **Step 3: Implement planner inputs, status, and interpolation**
+
+Use these consistent types:
+
+```swift
+import CryptoKit
+import Foundation
+
+enum MCPTransportKind: String, Codable, Equatable { case stdio, http, sse }
+
+enum MCPAttachmentSkipReason: Equatable {
+    case unsupportedTransport
+    case missingVariable(String)
+    case invalidConfiguration(String)
+}
+
+enum MCPAttachmentDisposition: Equatable {
+    case requested
+    case skipped(MCPAttachmentSkipReason)
+}
+
+struct MCPAttachmentServerStatus: Equatable, Identifiable {
+    var id: String { "\(transport.rawValue):\(name)" }
+    let name: String
+    let transport: MCPTransportKind
+    let disposition: MCPAttachmentDisposition
+}
+
+struct MCPAttachmentPlan: Equatable {
+    let wireServers: [ACPMCPServer]
+    let statuses: [MCPAttachmentServerStatus]
+    let configurationFingerprint: String
+}
+```
+
+Implement `${NAME}` substitution with `NSRegularExpression`, resolving reserved `PROJECT_DIR` and `WORKTREE_DIR` before the supplied environment. Return the first missing variable name and skip the whole server. Never include resolved values in errors or status.
+
+Fingerprint a normalized Codable representation that excludes all editing IDs, using `JSONEncoder.outputFormatting = [.sortedKeys]` and SHA-256 hex.
+Expose `MCPAttachmentPlanner.configurationFingerprint(for:)` so the toolbar can
+compare current saved definitions without resolving environment values.
+
+- [ ] **Step 4: Run focused tests**
+
+Run the Step 2 commands again.
+
+Expected: pass.
+
+- [ ] **Step 5: Commit planner**
+
+```bash
+rtk git add Alas/Sources/ACP/Session/MCPAttachmentPlanner.swift AlasTests/ACP/Session/MCPAttachmentPlannerTests.swift Alas.xcodeproj/project.pbxproj
+rtk git commit -m "feat(acp): plan MCP server attachments"
+```
+
+### Task 4: Pass MCP Servers Through ACPConnection
+
+**Files:**
+- Modify: `Alas/Sources/ACP/Protocol/ACPConnection.swift`
+- Modify: `Alas/Sources/ACP/Session/ACPSessionManager.swift`
+- Test: `AlasTests/ACP/Protocol/ACPConnectionTests.swift`
+
+- [ ] **Step 1: Update connection tests to require passthrough**
+
+For each lifecycle method, pass a non-empty array and assert typed params contain it:
+
+```swift
+let servers: [ACPMCPServer] = [.stdio(name: "fs", command: "npx", args: [], env: [])]
+let result = try await conn.loadSession(cwd: "/tmp/wt", sessionId: "remote-old", mcpServers: servers)
+let params = try #require(mock.sent.last?.params as? ACPSessionLoadParams)
+#expect(params.mcpServers == servers)
+```
+
+Add equivalent assertions for new, resume, and fork.
+
+- [ ] **Step 2: Run and verify compile failure**
+
+```bash
+rtk xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -only-testing:AlasTests/ACPConnectionTests test
+```
+
+Expected: method signatures do not accept `mcpServers`.
+
+- [ ] **Step 3: Change all four method signatures**
+
+Use required parameters, not default empty arrays, so future call sites cannot accidentally omit the plan:
+
+```swift
+func newSession(cwd: String, mcpServers: [ACPMCPServer]) async throws -> ACPSessionNewResult
+func loadSession(cwd: String, sessionId: String, mcpServers: [ACPMCPServer]) async throws -> ACPSessionNewResult
+func resumeSession(cwd: String, sessionId: String, mcpServers: [ACPMCPServer]) async throws -> ACPSessionNewResult
+func forkSession(cwd: String, sessionId: String, mcpServers: [ACPMCPServer]) async throws -> ACPSessionNewResult
+```
+
+Construct each params value with the supplied array.
+
+Update the existing manager call sites to pass `[]` in this task. This is an
+explicit, short-lived compilation bridge; Task 5 replaces every one of those
+arrays with the single planned server list. `forkSession` has no production
+caller today, so its required argument and connection test are the complete
+current integration surface rather than a reason to invent a fork workflow.
+
+- [ ] **Step 4: Run focused tests**
+
+Expected: `ACPConnectionTests` pass and the app target compiles with the
+explicit empty manager call sites.
+
+- [ ] **Step 5: Commit connection passthrough**
+
+```bash
+rtk git add Alas/Sources/ACP/Protocol/ACPConnection.swift Alas/Sources/ACP/Session/ACPSessionManager.swift AlasTests/ACP/Protocol/ACPConnectionTests.swift
+rtk git commit -m "feat(acp): pass MCP servers through lifecycle RPCs"
+```
+
+### Task 5: Integrate Planning Into Session Attachment
+
+**Files:**
+- Modify: `Alas/Sources/ACP/Session/ACPSession.swift`
+- Modify: `Alas/Sources/ACP/Session/ACPSessionManager.swift`
+- Modify: `Alas/Sources/App/AppState.swift`
+- Modify: `AlasTests/ACP/Session/ACPSessionManagerAttachRestoreTests.swift`
+
+- [ ] **Step 1: Write failing attach-flow tests**
+
+Extend the test helper to accept a provider:
+
+```swift
+private func manager(
+    store: ACPSessionStore,
+    client: ACPMockClient,
+    context: @escaping () -> MCPProjectContext? = { nil }
+) -> ACPSessionManager {
+    ACPSessionManager(
+        worktreeId: "wt", worktreePath: "/tmp/wt", store: store,
+        mcpProjectContextProvider: context,
+        setupEvaluator: { _ in .ready },
+        connectionFactory: { _ in ACPConnection(client: client) }
+    )
+}
+```
+
+Add tests proving:
+
+- initialize capabilities filter the plan before `session/new`
+- `session/load`, `session/resume`, and load-to-new recovery receive the same plan
+- invoking the provider again on a second attach reads changed configuration
+- the safe summary is present on `ACPSession` and contains no resolved values
+
+- [ ] **Step 2: Run focused tests and verify failure**
+
+```bash
+rtk xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -only-testing:AlasTests/ACPSessionManagerAttachRestoreTests test
+```
+
+Expected: compile failure for the provider and session summary.
+
+- [ ] **Step 3: Add current-project injection and runtime summary**
+
+Define:
+
+```swift
+struct MCPProjectContext: Equatable {
+    let projectPath: String
+    let servers: [ProjectMCPServer]
+}
+
+struct MCPAttachmentSummary: Equatable {
+    let statuses: [MCPAttachmentServerStatus]
+    let configurationFingerprint: String
+}
+```
+
+Add `@Published var mcpAttachmentSummary: MCPAttachmentSummary?` to `ACPSession`. Add an `mcpProjectContextProvider` closure to `ACPSessionManager.init`, defaulting to `{ nil }` for existing tests.
+
+Immediately after `initialize`, call the provider and planner with:
+
+```swift
+let projectContext = mcpProjectContextProvider()
+let mcpPlan = MCPAttachmentPlanner.plan(.init(
+    configuredServers: projectContext?.servers ?? [],
+    projectDirectory: projectContext?.projectPath ?? worktreePath,
+    worktreeDirectory: worktreePath,
+    environment: ACPProcessEnvironment.sanitizedForACP(extra: spec.extraEnv),
+    capabilities: initialized.mcpCapabilities
+))
+session.mcpAttachmentSummary = .init(
+    statuses: mcpPlan.statuses,
+    configurationFingerprint: mcpPlan.configurationFingerprint
+)
+```
+
+Pass `mcpPlan.wireServers` to every lifecycle call, including existing recovery-to-new branches. Never recompute the plan during one attach attempt.
+
+In `AppState.acpManager(for:)`, inject a closure that uses `worktree.projectId` to find the current project and returns its path and current servers.
+
+- [ ] **Step 4: Run focused manager and connection tests**
+
+```bash
+rtk xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -only-testing:AlasTests/ACPConnectionTests -only-testing:AlasTests/ACPSessionManagerAttachRestoreTests test
+```
+
+Expected: pass.
+
+- [ ] **Step 5: Commit lifecycle integration**
+
+```bash
+rtk git add Alas/Sources/ACP/Protocol/ACPConnection.swift Alas/Sources/ACP/Session/ACPSession.swift Alas/Sources/ACP/Session/ACPSessionManager.swift Alas/Sources/App/AppState.swift AlasTests/ACP/Protocol/ACPConnectionTests.swift AlasTests/ACP/Session/ACPSessionManagerAttachRestoreTests.swift
+rtk git commit -m "feat(acp): attach project MCP servers"
+```
+
+### Task 6: Preserve MCP Definitions Through Project Draft Updates
+
+**Files:**
+- Modify: `Alas/Sources/App/ProjectsManager.swift`
+- Modify: `Alas/Sources/App/AppState.swift`
+- Modify: `Alas/Sources/Dialogs/NewProjectDialog.swift`
+- Create: `Alas/Sources/Dialogs/ProjectMCPServerEditorPolicy.swift`
+- Test: `AlasTests/ProjectConfigTests.swift`
+- Test: `AlasTests/ProjectMCPServerEditorPolicyTests.swift`
+- Regenerate: `Alas.xcodeproj/project.pbxproj`
+
+- [ ] **Step 1: Write failing project-update and editor-policy tests**
+
+Add a `ProjectsManager` update test proving MCP values survive the update and a pure editor policy test:
+
+```swift
+@Test @MainActor func projectUpdatePersistsMCPDraft() {
+    let server = ProjectMCPServer.stdio(name: "fs", command: "npx")
+    let project = ProjectConfig(
+        id: "project", name: "alas", path: "/tmp/alas",
+        color: "#5fb7c4", addedAt: Date(timeIntervalSince1970: 0)
+    )
+    let manager = ProjectsManager(persistedProjects: [project])
+    manager.updateProject(id: "project", update: .init(
+        name: "renamed", icon: .default(color: "#5fb7c4"),
+        startupScripts: .defaults, mcpServers: [server]
+    ))
+    #expect(manager.projects[0].mcpServers == [server])
+}
+
+@Test @MainActor func unrelatedProjectUpdatePreservesExistingMCPServers() {
+    let server = ProjectMCPServer.stdio(name: "fs", command: "npx")
+    var project = ProjectConfig(
+        id: "project", name: "alas", path: "/tmp/alas",
+        color: "#5fb7c4", addedAt: Date(timeIntervalSince1970: 0)
+    )
+    project.mcpServers = [server]
+    let manager = ProjectsManager(persistedProjects: [project])
+    manager.updateProject(id: "project", update: .init(
+        name: "renamed", icon: .default(color: "#5fb7c4")
+    ))
+    #expect(manager.projects[0].mcpServers == [server])
+}
+
+@Test func editorBlocksStructuralErrorsButAllowsMissingReferences() {
+    #expect(ProjectMCPServerEditorPolicy.canSave(
+        server: .stdio(name: "fs", command: "npx"), siblingServers: []
+    ))
+    #expect(ProjectMCPServerEditorPolicy.environmentReferences(in: "Bearer ${TOKEN}") == ["TOKEN"])
+}
+```
+
+- [ ] **Step 2: Run focused tests and verify failure**
+
+```bash
+rtk xcodegen
+rtk xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -only-testing:AlasTests/ProjectConfigTests -only-testing:AlasTests/ProjectMCPServerEditorPolicyTests test
+```
+
+Expected: compile failure for `ProjectUpdate.mcpServers` and editor policy.
+
+- [ ] **Step 3: Wire MCP values through the existing project update path**
+
+Add `mcpServers: [ProjectMCPServer]? = nil` to `ProjectUpdate`. In
+`ProjectsManager.updateProject`, assign it only when the optional contains a
+value. This patch semantics preserves MCP configuration at unrelated
+`ProjectUpdate` call sites. Add a required `[ProjectMCPServer]` parameter to the
+Edit Project `AppState.updateProject` overload and pass it from
+`ProjectDialog.confirm`.
+
+Add `@State private var mcpServers: [ProjectMCPServer] = []` to `ProjectDialog`; populate it from edit mode; leave it empty in add mode. Keep the manager entry point edit-only, matching startup scripts.
+
+Implement `ProjectMCPServerEditorPolicy` as a pure wrapper over `ProjectMCPValidation` plus `${NAME}` reference extraction. Missing runtime variables produce advisory warnings and do not make `canSave` false.
+
+- [ ] **Step 4: Run focused tests**
+
+Expected: pass.
+
+- [ ] **Step 5: Commit project draft plumbing**
+
+```bash
+rtk git add Alas/Sources/App/ProjectsManager.swift Alas/Sources/App/AppState.swift Alas/Sources/Dialogs/NewProjectDialog.swift Alas/Sources/Dialogs/ProjectMCPServerEditorPolicy.swift AlasTests/ProjectConfigTests.swift AlasTests/ProjectMCPServerEditorPolicyTests.swift Alas.xcodeproj/project.pbxproj
+rtk git commit -m "feat(projects): preserve MCP configuration drafts"
+```
+
+### Task 7: Build the MCP Server Manager and Adaptive Editor
+
+**Files:**
+- Create: `Alas/Sources/Dialogs/ProjectMCPServerManager.swift`
+- Create: `Alas/Sources/Dialogs/ProjectMCPServerEditor.swift`
+- Modify: `Alas/Sources/Dialogs/NewProjectDialog.swift`
+- Test: `AlasTests/ProjectMCPServerEditorPolicyTests.swift`
+- Regenerate: `Alas.xcodeproj/project.pbxproj`
+
+- [ ] **Step 1: Extend policy tests for display and validation states**
+
+Cover trimmed unique names, invalid command/URL, duplicate environment/header keys, safe summaries that omit args/query/userinfo/fragment, and the label `Legacy SSE`.
+
+```swift
+@Test func remoteSummaryStripsCredentialsAndQuery() {
+    let server = ProjectMCPServer(
+        id: "remote", name: "linear",
+        transport: .http(url: "https://user:secret@example.com/mcp?token=secret#fragment", headers: [])
+    )
+    #expect(ProjectMCPServerEditorPolicy.safeSummary(server) == "https://example.com/mcp")
+}
+```
+
+- [ ] **Step 2: Run tests and verify failure**
+
+Run the Task 6 focused test command.
+
+Expected: failure for missing summary and label behavior.
+
+- [ ] **Step 3: Implement manager list UI**
+
+`ProjectMCPServerManager` takes `@Binding var servers`, snapshots the binding on appear for its own Cancel behavior, and provides:
+
+- name, transport label, and safe summary per row
+- `Add` command
+- overflow menu with `Edit` and `Delete`
+- delete confirmation
+- `Done` that keeps the edited binding
+- `Cancel` that restores the snapshot
+
+Use individual list rows, not nested cards. Use `Icon`/SF Symbols and existing `AlasButton` controls.
+
+- [ ] **Step 4: Implement the adaptive editor**
+
+`ProjectMCPServerEditor` owns a draft server and uses `Seg` with `stdio`, `HTTP`, and `Legacy SSE`. Render:
+
+- ordered argument rows with add/remove controls
+- ordered environment or header rows with add/remove controls
+- inline structural error text
+- missing-reference advisory text
+- SSE deprecation text
+- disabled confirm button until `ProjectMCPServerEditorPolicy.canSave` is true
+
+Switching transport preserves the name but initializes transport-specific fields to empty values. Saving normalizes trimmed server/key names while preserving values verbatim.
+
+- [ ] **Step 5: Add the Edit Project entry point**
+
+In the `Integrations` section, show `No servers configured` or `N configured for ACP sessions`, plus `Manage...`. Present the manager as a sheet bound to the parent `mcpServers` draft.
+
+- [ ] **Step 6: Regenerate, run policy tests, and build**
+
+```bash
+rtk xcodegen
+rtk xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -only-testing:AlasTests/ProjectMCPServerEditorPolicyTests test
+rtk xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -quiet build
+```
+
+Expected: tests and build pass.
+
+- [ ] **Step 7: Commit project MCP UI**
+
+```bash
+rtk git add Alas/Sources/Dialogs/ProjectMCPServerManager.swift Alas/Sources/Dialogs/ProjectMCPServerEditor.swift Alas/Sources/Dialogs/NewProjectDialog.swift AlasTests/ProjectMCPServerEditorPolicyTests.swift Alas.xcodeproj/project.pbxproj
+rtk git commit -m "feat(projects): manage MCP servers"
+```
+
+### Task 8: Add Honest ACP Toolbar Status
+
+**Files:**
+- Create: `Alas/Sources/ACP/UI/ACPMCPStatusPolicy.swift`
+- Create: `Alas/Sources/ACP/UI/ACPMCPStatusControl.swift`
+- Modify: `Alas/Sources/ACP/UI/ACPToolbar.swift`
+- Modify: `Alas/Sources/App/AppState.swift`
+- Test: `AlasTests/ACP/UI/ACPMCPStatusPolicyTests.swift`
+- Regenerate: `Alas.xcodeproj/project.pbxproj`
+
+- [ ] **Step 1: Write failing status policy tests**
+
+```swift
+@Suite("ACP MCP status policy")
+struct ACPMCPStatusPolicyTests {
+    @Test func projectsVisibilityCountsWarningsAndStaleness() {
+        #expect(ACPMCPStatusPolicy.presentation(summary: nil, currentFingerprint: nil) == nil)
+        let summary = MCPAttachmentSummary(statuses: [
+            .init(name: "fs", transport: .stdio, disposition: .requested),
+            .init(name: "legacy", transport: .sse, disposition: .skipped(.unsupportedTransport)),
+        ], configurationFingerprint: "old")
+        let state = ACPMCPStatusPolicy.presentation(summary: summary, currentFingerprint: "new")
+        #expect(state?.requestedCount == 1)
+        #expect(state?.hasWarning == true)
+        #expect(state?.isStale == true)
+    }
+}
+```
+
+Also test all-skipped visibility, requested-only no-warning state, and safe reason strings.
+
+- [ ] **Step 2: Run and verify failure**
+
+```bash
+rtk xcodegen
+rtk xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -only-testing:AlasTests/ACPMCPStatusPolicyTests test
+```
+
+Expected: compile failure for policy types.
+
+- [ ] **Step 3: Implement pure presentation policy**
+
+Return `nil` only when there are no requested or skipped statuses. Project requested count, warning presence, staleness, transport labels, and safe skip descriptions. Use exactly:
+
+- `Requested for this session`
+- `Skipped: agent does not support HTTP`
+- `Skipped: agent does not support SSE`
+- `Skipped: missing environment variable NAME`
+- `Skipped: invalid configuration — REASON`
+
+- [ ] **Step 4: Implement toolbar control and popover**
+
+Create a compact button matching existing toolbar chrome. Label it `MCP N`; add a warning badge only when skipped entries exist. The popover lists name, transport, and safe status. When stale, show:
+
+`Project MCP configuration changed. New settings apply when this session reconnects.`
+
+Do not render commands, arguments, URLs, headers, environment values, or resolved data.
+
+Add `AppState.mcpProjectContext(for:)` as an internal read-only helper and compute the current fingerprint with the planner's fingerprint helper. Insert `ACPMCPStatusControl` after `ACPRecoveryPill` in `ACPToolbar`.
+
+- [ ] **Step 5: Regenerate, test, and build**
+
+```bash
+rtk xcodegen
+rtk xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -only-testing:AlasTests/ACPMCPStatusPolicyTests test
+rtk xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -quiet build
+```
+
+Expected: pass.
+
+- [ ] **Step 6: Commit toolbar status**
+
+```bash
+rtk git add Alas/Sources/ACP/UI/ACPMCPStatusPolicy.swift Alas/Sources/ACP/UI/ACPMCPStatusControl.swift Alas/Sources/ACP/UI/ACPToolbar.swift Alas/Sources/App/AppState.swift AlasTests/ACP/UI/ACPMCPStatusPolicyTests.swift Alas.xcodeproj/project.pbxproj
+rtk git commit -m "feat(acp): show MCP attachment status"
+```
+
+### Task 9: Adapter Smoke Fixture and Final Verification
+
+**Files:**
+- Create: `scripts/mcp-smoke-server.py`
+- Test: focused suites from Tasks 1-8
+
+- [ ] **Step 1: Add a dependency-free MCP stdio fixture**
+
+Implement a newline-delimited JSON-RPC loop that handles:
+
+- `initialize`: echo the requested protocol version and advertise tools
+- `notifications/initialized`: no response
+- `tools/list`: expose `alas_echo` with one required string argument, `text`
+- `tools/call`: return `alas-mcp-smoke:<text>`
+- unknown requests: return JSON-RPC `-32601`
+
+The script must write protocol responses only to stdout and diagnostics only to stderr. Mark it executable.
+
+- [ ] **Step 2: Exercise the fixture directly**
+
+Run:
+
+```bash
+printf '%s\n' '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-03-26","capabilities":{},"clientInfo":{"name":"test","version":"1"}}}' | scripts/mcp-smoke-server.py
+```
+
+Expected: one JSON-RPC response whose `serverInfo.name` is `alas-mcp-smoke`.
+
+- [ ] **Step 3: Run focused regression suites**
+
+```bash
+rtk xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -only-testing:AlasTests/ProjectMCPServerTests -only-testing:AlasTests/ProjectConfigTests -only-testing:AlasTests/ACPMCPServerTests -only-testing:AlasTests/ACPInitializeTests -only-testing:AlasTests/MCPAttachmentPlannerTests -only-testing:AlasTests/ACPConnectionTests -only-testing:AlasTests/ACPSessionManagerAttachRestoreTests -only-testing:AlasTests/ProjectMCPServerEditorPolicyTests -only-testing:AlasTests/ACPMCPStatusPolicyTests test
+```
+
+Expected: pass.
+
+- [ ] **Step 4: Perform real adapter smoke checks**
+
+In Edit Project, add:
+
+- name: `alas-smoke`
+- transport: `stdio`
+- command: the absolute path to `scripts/mcp-smoke-server.py`
+- environment: `ALAS_MCP_SMOKE_TOKEN=${ALAS_MCP_SMOKE_TOKEN}`
+
+Launch Alas with `ALAS_MCP_SMOKE_TOKEN=present`. For both `claude-agent-acp` and `codex-acp`:
+
+1. Create a fresh ACP session.
+2. Confirm the toolbar says `MCP 1` without a warning.
+3. Ask the agent to call `alas_echo` with `hello`.
+4. Confirm the result contains `alas-mcp-smoke:hello`.
+5. Reconnect the session and repeat the tool call.
+
+Then remove `ALAS_MCP_SMOKE_TOKEN`, reconnect, and confirm the session starts while the toolbar reports the server skipped for the missing variable.
+
+- [ ] **Step 5: Run required project verification**
+
+```bash
+rtk xcodegen
+rtk xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -quiet build
+rtk xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' test
+```
+
+Expected: build and full test suite pass.
+
+- [ ] **Step 6: Inspect the final diff and commit verification fixture**
+
+```bash
+rtk git diff --check
+rtk git status --short
+rtk git add scripts/mcp-smoke-server.py Alas.xcodeproj/project.pbxproj
+rtk git commit -m "test(acp): add MCP adapter smoke fixture"
+```
+
+Expected: only intended implementation, tests, generated project changes, and the smoke fixture remain; the worktree is clean after the commit.

--- a/docs/superpowers/specs/2026-07-11-acp-mcp-server-passthrough-design.md
+++ b/docs/superpowers/specs/2026-07-11-acp-mcp-server-passthrough-design.md
@@ -1,0 +1,435 @@
+# ACP MCP Server Passthrough Design
+
+## Context
+
+[Issue #657](https://github.com/mrmans0n/alas/issues/657) identifies that
+Alas sends an empty `mcpServers` array on every ACP session lifecycle request.
+The current wire model supports only the stdio fields `name`, `command`, and
+`args`; `initialize` does not decode the agent's MCP transport capabilities;
+and projects have no MCP configuration surface.
+
+The current branch also supports `session/resume` and `session/fork`, both of
+which carry `mcpServers`. The implementation must therefore cover
+`session/new`, `session/load`, `session/resume`, and `session/fork`, rather than
+leaving newly added lifecycle paths hardcoded to an empty list.
+
+Stable ACP v1 defines these server transports:
+
+- stdio: `name`, `command`, required `args`, and required `env`
+- HTTP: `type: "http"`, `name`, `url`, and required `headers`
+- SSE: `type: "sse"`, `name`, `url`, and required `headers`
+
+HTTP and SSE are gated by `agentCapabilities.mcpCapabilities`. Stdio is
+required by ACP v1 and has no capability flag. Contrary to the original issue
+description, the stable v1 stdio server shape has no per-server `cwd`; the
+session lifecycle request already carries the active worktree `cwd`.
+
+References:
+
+- [ACP v1 session setup and MCP servers](https://agentclientprotocol.com/protocol/v1/session-setup)
+- [Issue #657](https://github.com/mrmans0n/alas/issues/657)
+
+## Goals
+
+- Let each Alas project define one MCP server list shared by every ACP agent.
+- Support the complete stable ACP v1 stdio, HTTP, and SSE wire shapes.
+- Filter optional transports using capabilities returned by `initialize`.
+- Resolve secret-bearing references from the app's launch environment without
+  persisting the resolved values.
+- Recompute the server list from current project configuration on every
+  attach, including load, resume, and fork flows.
+- Skip attributable per-server configuration problems without blocking the
+  remaining session.
+- Show an honest per-attachment `requested` and `skipped` summary in the ACP
+  toolbar.
+- Verify real stdio MCP use with both `claude-agent-acp` and `codex-acp`.
+
+## Non-Goals
+
+- No per-agent MCP lists or per-agent enablement.
+- No automatic discovery or import from `.mcp.json`, Claude settings, or other
+  external formats.
+- No global MCP server catalog.
+- No Keychain or encrypted literal-secret storage. Alas cannot reliably
+  classify arbitrary user-entered literals; the editor directs users to
+  environment references for secret-bearing values.
+- No automatic reconnect when project MCP configuration changes.
+- No per-server stdio working-directory wrapper.
+- No attempt to infer whether an agent successfully connected to an individual
+  server; ACP v1 does not report that result.
+- No generalized integration-provider framework.
+
+## Architecture
+
+Use a dedicated, pure `MCPAttachmentPlanner` between project persistence and
+the ACP wire layer.
+
+The responsibilities remain separated:
+
+1. `ProjectConfig` persists user-authored MCP definitions and reference
+   expressions.
+2. The MCP server manager edits and structurally validates a project draft.
+3. `ACPConnection.initialize()` decodes the agent's MCP capabilities.
+4. `ACPSessionManager.attach` asks an injected project-context provider for the
+   current configuration, then calls `MCPAttachmentPlanner` with that context,
+   the sanitized ACP process environment, and the initialized capabilities.
+5. The planner returns resolved ACP wire servers plus safe status entries for
+   requested and skipped definitions.
+6. `ACPConnection` sends the resolved servers on the selected lifecycle
+   request.
+7. `ACPSession` retains only the safe, runtime attachment summary needed by the
+   toolbar.
+
+`AppState` already creates one `ACPSessionManager` per worktree. Add a narrow
+provider closure at that construction point. The closure resolves the owning
+project each time it is called and returns:
+
+```swift
+struct MCPProjectContext: Equatable {
+    let projectPath: String
+    let servers: [ProjectMCPServer]
+}
+```
+
+This avoids making `ACPSessionManager` depend on `AppState` or
+`ProjectsManager`, while ensuring a reattach does not use configuration copied
+when the manager was first created.
+
+## Persisted Model
+
+Extend `ProjectConfig` with:
+
+```swift
+var mcpServers: [ProjectMCPServer] = []
+```
+
+Older `projects.json` files decode the missing field as an empty array.
+
+Suggested configuration types:
+
+```swift
+struct ProjectMCPServer: Codable, Equatable, Identifiable {
+    let id: String
+    var name: String
+    var transport: ProjectMCPTransport
+}
+
+enum ProjectMCPTransport: Codable, Equatable {
+    case stdio(command: String, args: [String], environment: [MCPKeyValue])
+    case http(url: String, headers: [MCPKeyValue])
+    case sse(url: String, headers: [MCPKeyValue])
+}
+
+struct MCPKeyValue: Codable, Equatable, Identifiable {
+    let id: String
+    var name: String
+    var value: String
+}
+```
+
+The IDs are stable Alas editing identities and are never sent over ACP. Server
+names are trimmed, non-empty, and unique within a project. Environment names
+must be valid environment identifiers and unique within one server. HTTP
+header names must be non-empty and case-insensitively unique.
+
+Stdio commands must be non-empty. Do not require an absolute command path:
+Alas already supports launching agent commands through `/usr/bin/env`, and MCP
+configurations commonly rely on PATH-resolved tools such as `npx`.
+
+HTTP and SSE URLs must use `http` or `https`. Empty argument, environment, and
+header lists are valid in project configuration. The ACP v1 encoder still emits
+the required arrays when they are empty.
+
+## ACP Wire Model and Capabilities
+
+Move the shared lifecycle MCP wire type out of `ACPSessionNewParams` and model
+it as a custom Codable union:
+
+- stdio omits `type` and encodes `name`, `command`, `args`, and `env`
+- HTTP encodes `type: "http"`, `name`, `url`, and `headers`
+- SSE encodes `type: "sse"`, `name`, `url`, and `headers`
+
+ACP v1 represents environment variables and headers as arrays of
+`{ "name": ..., "value": ... }`, not dictionaries. Preserve ordering so the
+wire encoding and editor behavior are deterministic.
+
+Extend `ACPInitializeResult.ACPAgentCapabilities` with conservatively decoded
+MCP capabilities:
+
+```swift
+struct ACPMCPServerCapabilities: Codable, Equatable {
+    let http: Bool
+    let sse: Bool
+}
+```
+
+Missing capability objects or fields decode to `false`. Stdio remains
+supported without a capability check under ACP v1.
+
+Change the lifecycle connection methods to accept `[ACPMCPServer]` rather than
+constructing an empty list internally:
+
+- `newSession(cwd:mcpServers:)`
+- `loadSession(cwd:sessionId:mcpServers:)`
+- `resumeSession(cwd:sessionId:mcpServers:)`
+- `forkSession(cwd:sessionId:mcpServers:)`
+
+An empty project list must preserve today's encoded requests exactly.
+
+## Attachment Planning
+
+The planner is a synchronous, side-effect-free unit. Its inputs are:
+
+```swift
+struct MCPAttachmentPlannerInput {
+    let configuredServers: [ProjectMCPServer]
+    let projectDirectory: String
+    let worktreeDirectory: String
+    let environment: [String: String]
+    let capabilities: ACPMCPServerCapabilities
+}
+```
+
+Its output separates resolved wire data from safe presentation data:
+
+```swift
+struct MCPAttachmentPlan {
+    let wireServers: [ACPMCPServer]
+    let statuses: [MCPAttachmentServerStatus]
+    let configurationFingerprint: String
+}
+```
+
+`MCPAttachmentServerStatus` contains only server name, transport, and either
+`requested` or a typed skipped reason. It must never contain resolved commands,
+arguments, URLs, environment values, or header values.
+
+The fingerprint is deterministic over the wire-relevant, non-resolved project
+MCP definitions. Exclude Alas-only editing IDs so an identity-only change does
+not mark the attachment stale. The toolbar compares the fingerprint with the
+current saved project configuration to show that changes will apply on
+reconnect. It is runtime state, not session persistence.
+
+### Interpolation
+
+Expand `${NAME}` references at attachment time in:
+
+- stdio command
+- each stdio argument
+- each stdio environment value
+- HTTP/SSE URL
+- each HTTP/SSE header value
+
+Do not expand server names, environment names, or header names.
+
+The environment input is the same sanitized ACP process environment used to
+launch the selected adapter, including the adapter's configured extra
+environment. Add two reserved built-ins:
+
+- `${PROJECT_DIR}`: the registered project's root path
+- `${WORKTREE_DIR}`: the active session worktree path
+
+The built-ins override launch-environment entries with those names. Values may
+contain more than one reference. A missing reference skips only that server and
+produces a status naming the missing variable, never any resolved value.
+
+Projects persist reference expressions exactly as authored. Resolved values
+exist only in the in-memory attachment plan used for the lifecycle call. Do not
+write them to `projects.json`, SQLite, logs, mirrored session metadata, error
+messages, or toolbar state.
+
+Plain literals remain valid for non-secret values such as `LOG_LEVEL=warn` or
+`Content-Type: application/json`. The editor does not offer a separate secret
+field and instructs users to use environment references for tokens, passwords,
+authorization values, and other credentials.
+
+### Capability and Validation Results
+
+The planner requests:
+
+- every structurally valid stdio server
+- each valid HTTP server only when `mcpCapabilities.http` is true
+- each valid SSE server only when `mcpCapabilities.sse` is true
+
+Unsupported transports, missing variables, and invalid persisted definitions
+produce skipped statuses. The editor prevents new structural errors, but the
+planner remains defensive because users may edit `projects.json` externally.
+
+## Session Lifecycle Flow
+
+Build one attachment plan after `initialize` and before selecting the lifecycle
+RPC. Use that same plan throughout one attach attempt:
+
+- fresh session: `session/new`
+- persisted Alas or imported session with replay: `session/load`
+- imported or resumed session without replay: `session/resume`
+- forked session: `session/fork`
+- existing load/resume recovery to a new session: reuse the same plan for the
+  fallback `session/new`
+
+Do not silently retry a lifecycle request with an empty MCP list. If the agent
+rejects the request, ACP v1 does not identify which server caused the failure;
+an MCP-free retry would silently remove expected tools and could duplicate
+lifecycle side effects.
+
+Every later attach calls the project-context provider again and builds a fresh
+plan. Configuration changes therefore affect the next reconnect but never
+interrupt an existing session.
+
+## Project Configuration UI
+
+MCP configuration is available when editing an existing project. New projects
+start with an empty list and can be configured after creation.
+
+Add an `Integrations` section to Edit Project with an `MCP servers` summary:
+
+- `No servers configured`, or
+- `<count> configured for ACP sessions`
+
+A `Manage...` button opens a dedicated MCP server manager. The manager edits
+the parent Edit Project draft. `Done` returns to Edit Project; `Cancel` discards
+changes made since the manager opened. The parent `Save changes` persists the
+MCP draft atomically with the other project fields. Canceling Edit Project
+discards all MCP changes.
+
+The manager shows one row per server with name, transport, a safe endpoint
+summary, and an overflow menu for Edit and Delete. A stdio summary shows only
+the authored command, never arguments or environment values. A remote summary
+shows scheme, host, and path while stripping user information, query, and
+fragment. Delete requires confirmation. There is no enable toggle in this
+scope: configured entries participate in the next plan, while temporary
+suppression can be achieved by removing the entry.
+
+`Add` and `Edit` use one adaptive sheet:
+
+- a segmented transport control for `stdio`, `HTTP`, and `Legacy SSE`
+- common name field
+- command and ordered argument rows for stdio
+- ordered environment name/value rows for stdio
+- URL and ordered header name/value rows for HTTP and SSE
+- inline structural validation
+- a note that `${ENV_VAR}` references resolve when attaching
+- a Legacy SSE deprecation note
+
+Missing environment references may be warned about using the current app
+environment, but they do not block saving because a later app launch may supply
+them.
+
+## ACP Toolbar Status
+
+Add a compact MCP control to `ACPToolbar` only when the current plan has at
+least one requested or skipped server.
+
+Presentation rules:
+
+- all requested and none skipped: `MCP <requested count>` with no warning
+- any skipped: the same count plus a warning mark
+- no requested and no skipped: hide the control
+- configuration fingerprint differs from the current saved project
+  configuration: keep the current attachment counts and show a stale-settings
+  footer
+
+The popover lists each server as:
+
+- `Requested for this session`, or
+- `Skipped: <safe reason>`
+
+Use `requested`, not `attached` or `connected`. ACP v1 does not provide a
+per-server success result. If a server fails after the lifecycle request is
+accepted, the agent owns reporting that through its normal messages and tool
+flow.
+
+After a project save, existing sessions remain attached. Their popover shows:
+
+`Project MCP configuration changed. New settings apply when this session reconnects.`
+
+## Error Handling
+
+| Condition | Behavior |
+|---|---|
+| HTTP/SSE capability absent | Skip that server and show the unsupported transport. |
+| Environment reference missing | Skip that server and show the missing variable name. |
+| Invalid persisted server | Skip that server and point the editor to the invalid field. |
+| Lifecycle RPC rejects the request | Use the existing ACP attach failure and retry UI; do not retry without MCP. |
+| Server fails after request acceptance | Leave status as requested; render agent-reported errors normally. |
+| Project configuration changes | Keep the live session and mark its status stale until reconnect. |
+
+## Testing
+
+### Protocol
+
+- Encode stdio, HTTP, and SSE exactly as ACP v1, including empty required
+  arrays and the absence of `type` for stdio.
+- Decode missing `mcpCapabilities` and missing fields as unsupported optional
+  transports.
+- Verify `session/new`, `session/load`, `session/resume`, and `session/fork`
+  receive and encode their supplied server arrays.
+
+### Attachment Planner
+
+- Cover every stdio/HTTP/SSE capability combination.
+- Cover environment interpolation, multiple references, and reserved built-in
+  precedence.
+- Cover missing variables, invalid URLs, duplicate names, and malformed
+  persisted values.
+- Verify skipped status is attributable and resolved values never enter status.
+- Verify deterministic configuration fingerprints use persisted references,
+  not resolved secrets.
+
+### Persistence and Project Editing
+
+- Round-trip all project MCP variants.
+- Decode older projects with an empty MCP list.
+- Verify the project dialog preserves MCP fields when editing unrelated values.
+- Verify manager Done/Cancel and parent Save/Cancel draft semantics.
+
+### Session Manager
+
+- Build the plan only after `initialize` returns capabilities.
+- Pass the same plan through fresh, load, resume, fork, and recovery-to-new
+  paths.
+- Verify a later attach reads current project configuration.
+- Verify project changes do not reconnect existing sessions.
+
+### UI Policies
+
+- Cover hidden, requested-only, skipped-warning, all-skipped, and stale toolbar
+  states with pure policy tests.
+- Cover transport-specific editor validation and Legacy SSE labeling.
+- Verify resolved environment and header values never appear in status models.
+
+### Adapter Smoke Verification
+
+Use a deterministic local stdio MCP server exposing one identifiable tool:
+
+1. Configure it for a project using `${WORKTREE_DIR}` and one environment
+   reference.
+2. Start a fresh `claude-agent-acp` session and verify the agent lists and uses
+   the tool.
+3. Start a fresh `codex-acp` session and verify the same behavior.
+4. Reconnect each session and verify the tool remains available.
+5. Configure an unsupported remote transport and verify it is skipped without
+   preventing session attachment.
+
+Final repository verification uses:
+
+```bash
+xcodegen
+xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -quiet build
+xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' test
+```
+
+## Acceptance Criteria
+
+- A configured stdio MCP server is listed and usable by both
+  `claude-agent-acp` and `codex-acp` in fresh sessions.
+- HTTP and SSE definitions are sent only when the initialized agent advertises
+  the matching capability.
+- Missing variables or unsupported transports skip only the affected server and
+  produce safe toolbar status.
+- The current project configuration is re-sent on load, resume, and fork.
+- Existing sessions are not automatically reconnected after project edits.
+- The toolbar distinguishes requested from skipped servers without claiming
+  connection success.
+- Tests cover all three wire shapes, capability gating, interpolation,
+  persistence compatibility, lifecycle propagation, and UI state policies.

--- a/scripts/mcp-smoke-server.py
+++ b/scripts/mcp-smoke-server.py
@@ -1,0 +1,128 @@
+#!/usr/bin/env python3
+"""A dependency-free stdio MCP server for manually exercising ACP adapters.
+
+Run from the repository root:
+
+    python3 scripts/mcp-smoke-server.py
+
+It uses the MCP stdio transport: one JSON-RPC 2.0 message per line on stdin
+and stdout. The only tool, ``echo``, returns its required string ``message``
+argument unchanged. Keep stdout protocol-only; diagnostics go to stderr.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from typing import Any
+
+
+PROTOCOL_VERSION = "2024-11-05"
+SERVER_INFO = {"name": "alas-mcp-smoke", "version": "1.0.0"}
+
+
+def write_message(message: dict[str, Any]) -> None:
+    """Write one JSON-RPC message without contaminating stdout with logs."""
+    sys.stdout.write(json.dumps(message, separators=(",", ":")) + "\n")
+    sys.stdout.flush()
+
+
+def respond(request_id: Any, result: dict[str, Any]) -> None:
+    write_message({"jsonrpc": "2.0", "id": request_id, "result": result})
+
+
+def respond_error(request_id: Any, code: int, message: str) -> None:
+    write_message({
+        "jsonrpc": "2.0",
+        "id": request_id,
+        "error": {"code": code, "message": message},
+    })
+
+
+def handle_request(message: dict[str, Any]) -> None:
+    method = message.get("method")
+    request_id = message.get("id")
+    is_request = "id" in message
+
+    if not isinstance(method, str):
+        if is_request:
+            respond_error(request_id, -32600, "Invalid Request")
+        return
+
+    if method == "notifications/initialized":
+        return
+
+    if method == "initialize":
+        if is_request:
+            respond(request_id, {
+                "protocolVersion": PROTOCOL_VERSION,
+                "capabilities": {"tools": {"listChanged": False}},
+                "serverInfo": SERVER_INFO,
+            })
+        return
+
+    if method == "ping":
+        if is_request:
+            respond(request_id, {})
+        return
+
+    if method == "tools/list":
+        if is_request:
+            respond(request_id, {
+                "tools": [{
+                    "name": "echo",
+                    "description": "Returns the supplied message unchanged.",
+                    "inputSchema": {
+                        "type": "object",
+                        "properties": {"message": {"type": "string"}},
+                        "required": ["message"],
+                        "additionalProperties": False,
+                    },
+                }],
+            })
+        return
+
+    if method == "tools/call":
+        params = message.get("params")
+        arguments = params.get("arguments") if isinstance(params, dict) else None
+        value = arguments.get("message") if isinstance(arguments, dict) else None
+
+        if not is_request:
+            return
+        if not isinstance(params, dict) or params.get("name") != "echo":
+            respond(request_id, {
+                "content": [{"type": "text", "text": "Unknown tool."}],
+                "isError": True,
+            })
+        elif not isinstance(value, str):
+            respond(request_id, {
+                "content": [{"type": "text", "text": "echo requires a string message."}],
+                "isError": True,
+            })
+        else:
+            respond(request_id, {"content": [{"type": "text", "text": value}]})
+        return
+
+    if is_request:
+        respond_error(request_id, -32601, "Method not found")
+
+
+def main() -> int:
+    for raw_line in sys.stdin:
+        line = raw_line.strip()
+        if not line:
+            continue
+        try:
+            message = json.loads(line)
+        except json.JSONDecodeError:
+            respond_error(None, -32700, "Parse error")
+            continue
+        if not isinstance(message, dict):
+            respond_error(None, -32600, "Invalid Request")
+            continue
+        handle_request(message)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
Closes #657

## Summary
- persist project-scoped stdio, HTTP, and Legacy SSE MCP server definitions
- resolve and capability-gate MCP attachments once per ACP session lifecycle operation
- add the Edit Project MCP manager and session attachment-status popover
- include a deterministic local stdio MCP smoke server

## Validation
- `xcodegen`
- `ALAS_FFF_TARGET_ARCH=arm64 xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -quiet build`\n- `ALAS_FFF_TARGET_ARCH=arm64 xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -quiet test`\n- focused ACP planner, session, toolbar, project-policy tests\n- `python3 -m py_compile scripts/mcp-smoke-server.py`