### PR TITLE
fix(session): Avoid main-thread hangs during session restore

### DIFF
--- a/Alas/Sources/App/AppState.swift
+++ b/Alas/Sources/App/AppState.swift
@@ -2000,6 +2000,48 @@ final class AppState {
     /// leaves are skipped, and the failing leaf is retried.
     @discardableResult
     func restoreTerminalTabIfNeeded(worktreeId: String, tabId: TabID) throws -> Tab? {
+        try restoreTerminalTabIfNeeded(
+            worktreeId: worktreeId,
+            tabId: tabId,
+            legacySessionInfos: nil
+        )
+    }
+
+    @discardableResult
+    func restoreTerminalTabIfNeededAsync(worktreeId: String, tabId: TabID) async throws -> Tab? {
+        let legacySessionInfos = await legacySessionInfosForTerminalRestore(
+            worktreeId: worktreeId,
+            tabId: tabId
+        )
+        return try restoreTerminalTabIfNeeded(
+            worktreeId: worktreeId,
+            tabId: tabId,
+            legacySessionInfos: legacySessionInfos
+        )
+    }
+
+    private func legacySessionInfosForTerminalRestore(
+        worktreeId: String,
+        tabId: TabID
+    ) async -> [ZmxSessionInfo]? {
+        guard config.terminal.keepSessionsAlive,
+              terminal.zmxClient.isAvailable,
+              let tab = tabs.tabs(forWorktree: worktreeId).first(where: { $0.id == tabId }),
+              case .terminal(let state) = tab,
+              state.root.leaves().contains(where: { terminal.registry.session(for: $0.id) == nil })
+        else { return nil }
+
+        let client = terminal.zmxClient
+        return await Task.detached(priority: .utility) {
+            client.listSessionInfos()
+        }.value
+    }
+
+    private func restoreTerminalTabIfNeeded(
+        worktreeId: String,
+        tabId: TabID,
+        legacySessionInfos: [ZmxSessionInfo]?
+    ) throws -> Tab? {
         guard let tab = tabs.tabs(forWorktree: worktreeId).first(where: { $0.id == tabId }),
               case .terminal(let state) = tab,
               let worktree = worktree(withId: worktreeId),
@@ -2035,12 +2077,23 @@ final class AppState {
             if terminal.registry.session(for: leaf.id) != nil { continue }
 
             let forcedCwd = leaf.lastCwd.map { URL(fileURLWithPath: $0) }
+            let allowLegacyAttach = config.terminal.keepSessionsAlive
+            let preResolvedZmxSessionName = legacySessionInfos.map {
+                TerminalService.resolveSessionNameForAttach(
+                    worktreeId: worktree.id,
+                    projectPath: project.path,
+                    leafId: leaf.id,
+                    allowLegacy: allowLegacyAttach,
+                    legacySessionInfos: $0
+                )
+            }
             let session = try terminal.openSession(
                 worktree: worktree, project: project,
                 cfg: config.terminal, theme: themeStore.current,
                 forcedCwd: forcedCwd,
                 leafId: leaf.id,
-                allowLegacyAttach: true
+                allowLegacyAttach: allowLegacyAttach,
+                preResolvedZmxSessionName: preResolvedZmxSessionName
             )
             harness.detector.register(sessionId: session.id) { [weak session] in
                 session?.surface.foregroundPid

--- a/Alas/Sources/Center/TerminalTabView.swift
+++ b/Alas/Sources/Center/TerminalTabView.swift
@@ -31,7 +31,7 @@ struct TerminalTabView: View {
             state.terminalLeafFrames[tabId] = frames
         }
         .task(id: tabId) {
-            _ = try? state.restoreTerminalTabIfNeeded(worktreeId: worktreeId, tabId: tabId)
+            _ = try? await state.restoreTerminalTabIfNeededAsync(worktreeId: worktreeId, tabId: tabId)
         }
         .background(theme.color("bg-0"))
     }
@@ -302,7 +302,7 @@ private struct TerminalRecoverPlaceholder: View {
                 .font(.system(size: 14))
                 .foregroundColor(theme.color("fg-muted"))
             AlasButton(title: "Open new terminal", style: .primary) {
-                Task { _ = try? state.restoreTerminalTabIfNeeded(worktreeId: worktreeId, tabId: tabId) }
+                Task { _ = try? await state.restoreTerminalTabIfNeededAsync(worktreeId: worktreeId, tabId: tabId) }
             }
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)

--- a/Alas/Sources/JSONRPC/JSONRPCStdioTransport.swift
+++ b/Alas/Sources/JSONRPC/JSONRPCStdioTransport.swift
@@ -1,3 +1,4 @@
+import Darwin
 import Foundation
 
 enum JSONRPCFraming {
@@ -21,7 +22,17 @@ final class JSONRPCStdioTransport: @unchecked Sendable, JSONRPCStdioTransporting
 
     private struct DescendantKey: Hashable {
         let pid: pid_t
-        let startedAt: String
+        let startedAt: ProcessStartTime
+    }
+
+    private struct ProcessStartTime: Hashable, Sendable {
+        let seconds: Int64
+        let microseconds: Int64
+    }
+
+    private struct ProcessIdentity: Sendable {
+        let parentPid: pid_t
+        let startedAt: ProcessStartTime
     }
 
     private let process = Process()
@@ -134,7 +145,10 @@ final class JSONRPCStdioTransport: @unchecked Sendable, JSONRPCStdioTransporting
         // leader. Same pattern as `ACPTerminal`.
         _ = setpgid(process.processIdentifier, process.processIdentifier)
         startDescendantForkObserver(for: process.processIdentifier)
-        refreshOrphanSet()
+        refreshLock.lock()
+        let initialDescendants = Set(Self.collectChildDescendants(of: process.processIdentifier))
+        mergeInitialOrphanSet(initialDescendants)
+        refreshLock.unlock()
         startDescendantTracker()
     }
 
@@ -188,7 +202,7 @@ final class JSONRPCStdioTransport: @unchecked Sendable, JSONRPCStdioTransporting
     }
 
     private func startDescendantTracker() {
-        descendantTracker = Task { [weak self] in
+        descendantTracker = Task.detached(priority: .utility) { [weak self] in
             // Walk the live process tree every second while the root is
             // alive, accumulating every descendant we observe. The last
             // pre-exit snapshot is what `terminate()` relies on after
@@ -262,6 +276,19 @@ final class JSONRPCStdioTransport: @unchecked Sendable, JSONRPCStdioTransporting
         pruneDescendantForkObservers(keeping: watched)
     }
 
+    private func mergeInitialOrphanSet(_ descendants: Set<DescendantKey>) {
+        guard !descendants.isEmpty else { return }
+        lock.lock()
+        let shouldObserve = !rootHasExited
+        if shouldObserve {
+            orphanedDescendants.formUnion(descendants)
+        }
+        lock.unlock()
+        if shouldObserve {
+            observeForks(from: descendants)
+        }
+    }
+
     private func refreshOrphanSet() {
         refreshLock.lock()
         defer { refreshLock.unlock() }
@@ -293,11 +320,9 @@ final class JSONRPCStdioTransport: @unchecked Sendable, JSONRPCStdioTransporting
     /// reparents children to init so they become unfindable via a ppid
     /// walk from the original root.
     private static func collectDescendants(of root: pid_t) -> [DescendantKey] {
-        // `lstart` makes the cached PID identity stable across PID reuse
-        // while still surviving exec, where `comm` can legitimately change.
         let proc = Process()
         proc.executableURL = URL(fileURLWithPath: "/bin/ps")
-        proc.arguments = ["-o", "pid=,ppid=,lstart=", "-ax"]
+        proc.arguments = ["-o", "pid=,ppid=", "-ax"]
         let pipe = Pipe()
         proc.standardOutput = pipe
         proc.standardError = FileHandle.nullDevice
@@ -310,57 +335,96 @@ final class JSONRPCStdioTransport: @unchecked Sendable, JSONRPCStdioTransporting
             return []
         }
         guard let s = String(data: data, encoding: .utf8) else { return [] }
-        var childrenOf: [pid_t: [(pid: pid_t, startedAt: String)]] = [:]
+        var childrenOf: [pid_t: [pid_t]] = [:]
         for line in s.split(separator: "\n") {
             let trimmed = line.drop(while: { $0 == " " })
-            let parts = trimmed.split(separator: " ", maxSplits: 6,
+            let parts = trimmed.split(separator: " ", maxSplits: 1,
                                       omittingEmptySubsequences: true)
-            guard parts.count >= 7,
+            guard parts.count >= 2,
                   let pid = pid_t(parts[0]),
                   let ppid = pid_t(parts[1]) else { continue }
-            let startedAt = parts[2...6].joined(separator: " ")
-            childrenOf[ppid, default: []].append((pid, startedAt))
+            childrenOf[ppid, default: []].append(pid)
         }
         var out: [DescendantKey] = []
         var queue: [pid_t] = [root]
         while let p = queue.popLast() {
             for c in childrenOf[p] ?? [] {
-                out.append(DescendantKey(pid: c.pid, startedAt: c.startedAt))
-                queue.append(c.pid)
+                guard let identity = processIdentity(of: c),
+                      identity.parentPid == p else { continue }
+                out.append(DescendantKey(pid: c, startedAt: identity.startedAt))
+                queue.append(c)
             }
         }
         return out
     }
 
+    /// Lightweight startup snapshot. Unlike `collectDescendants`, this
+    /// uses libproc's ppid index instead of spawning `/bin/ps -ax`, so
+    /// `start()` can capture immediate descendants before returning
+    /// without blocking the main actor on a subprocess process-table walk.
+    private static func collectChildDescendants(of root: pid_t) -> [DescendantKey] {
+        var out: [DescendantKey] = []
+        var queue: [pid_t] = [root]
+        while let parent = queue.popLast() {
+            for child in childPids(of: parent) {
+                guard let identity = processIdentity(of: child),
+                      identity.parentPid == parent else { continue }
+                out.append(DescendantKey(pid: child, startedAt: identity.startedAt))
+                queue.append(child)
+            }
+        }
+        return out
+    }
+
+    private static func childPids(of parent: pid_t) -> [pid_t] {
+        var capacity = 16
+        while capacity <= 4096 {
+            var pids = [pid_t](repeating: 0, count: capacity)
+            let pidCount = pids.withUnsafeMutableBufferPointer { buffer in
+                proc_listchildpids(parent, buffer.baseAddress,
+                                   Int32(capacity * MemoryLayout<pid_t>.stride))
+            }
+            guard pidCount > 0 else { return [] }
+            let count = min(capacity, Int(pidCount))
+            if count < capacity {
+                return Array(pids.prefix(count)).filter { $0 > 0 }
+            }
+            capacity *= 2
+        }
+        return []
+    }
+
     private static func currentlyMatching(_ keys: Set<DescendantKey>) -> Set<DescendantKey> {
         guard !keys.isEmpty else { return [] }
-        let pids = Set(keys.map(\.pid))
-        let proc = Process()
-        proc.executableURL = URL(fileURLWithPath: "/bin/ps")
-        proc.arguments = ["-o", "pid=,lstart=", "-ax"]
-        let pipe = Pipe()
-        proc.standardOutput = pipe
-        proc.standardError = FileHandle.nullDevice
-        let data: Data
-        do {
-            try proc.run()
-            data = pipe.fileHandleForReading.readDataToEndOfFile()
-            proc.waitUntilExit()
-        } catch {
-            return []
-        }
-        guard let s = String(data: data, encoding: .utf8) else { return [] }
         var current: Set<DescendantKey> = []
-        for line in s.split(separator: "\n") {
-            let trimmed = line.drop(while: { $0 == " " })
-            let parts = trimmed.split(separator: " ", maxSplits: 5,
-                                      omittingEmptySubsequences: true)
-            guard parts.count >= 6,
-                  let pid = pid_t(parts[0]),
-                  pids.contains(pid) else { continue }
-            current.insert(DescendantKey(pid: pid,
-                                         startedAt: parts[1...5].joined(separator: " ")))
+        for key in keys {
+            guard processStartTime(of: key.pid) == key.startedAt else { continue }
+            current.insert(key)
         }
-        return current.intersection(keys)
+        return current
+    }
+
+    private static func processStartTime(of pid: pid_t) -> ProcessStartTime? {
+        processIdentity(of: pid)?.startedAt
+    }
+
+    /// Kernel process birth time, used as the stable half of cached
+    /// descendant identity. Unlike `ps lstart`, this is raw timeval
+    /// data rather than a locale/timezone-formatted, second-precision
+    /// wall-clock string.
+    private static func processIdentity(of pid: pid_t) -> ProcessIdentity? {
+        var info = proc_bsdinfo()
+        let size = MemoryLayout<proc_bsdinfo>.stride
+        let result = withUnsafeMutablePointer(to: &info) { pointer in
+            pointer.withMemoryRebound(to: UInt8.self, capacity: size) { rebound in
+                proc_pidinfo(pid, PROC_PIDTBSDINFO, 0, rebound, Int32(size))
+            }
+        }
+        guard result == Int32(size) else { return nil }
+        return ProcessIdentity(
+            parentPid: pid_t(info.pbi_ppid),
+            startedAt: ProcessStartTime(seconds: Int64(info.pbi_start_tvsec),
+                                        microseconds: Int64(info.pbi_start_tvusec))
+        )
     }
 }

--- a/Alas/Sources/Terminal/TerminalService.swift
+++ b/Alas/Sources/Terminal/TerminalService.swift
@@ -92,7 +92,8 @@ final class TerminalService {
         environmentOverrides: [String: String] = [:],
         environmentRemovals: Set<String> = [],
         leafId: String = UUID().uuidString,
-        allowLegacyAttach: Bool = false
+        allowLegacyAttach: Bool = false,
+        preResolvedZmxSessionName: String? = nil
     ) throws -> TerminalSession {
         try ensureApp(cfg: cfg, theme: theme)
         guard let app else { throw NSError(domain: "TerminalService", code: 1) }
@@ -134,7 +135,7 @@ final class TerminalService {
             startupScript: effectiveScript,
             sessionId: sessionId
         )
-        let zmxSessionName = sessionNameForAttach(
+        let zmxSessionName = preResolvedZmxSessionName ?? sessionNameForAttach(
             worktree: worktree,
             project: project,
             leafId: sessionId,
@@ -452,15 +453,13 @@ final class TerminalService {
     ) -> String {
         let scoped = ZmxSessionName.derive(worktreeId: worktree.id, leafId: leafId)
         guard allowLegacy else { return scoped }
-        let legacy = ZmxSessionName.legacy(leafId: leafId)
-        guard Self.legacySessionBelongsToKnownRoot(
-            legacy,
-            roots: [worktree.id, project.path],
-            zmxClient: zmxClient
-        ) else {
-            return scoped
-        }
-        return legacy
+        return Self.resolveSessionNameForAttach(
+            worktreeId: worktree.id,
+            projectPath: project.path,
+            leafId: leafId,
+            allowLegacy: allowLegacy,
+            legacySessionInfos: zmxClient.listSessionInfos()
+        )
     }
 
     nonisolated private static func sessionNamesForCleanup(
@@ -478,13 +477,45 @@ final class TerminalService {
         return [scoped, legacy]
     }
 
+    nonisolated static func resolveSessionNameForAttach(
+        worktreeId: String,
+        projectPath: String,
+        leafId: String,
+        allowLegacy: Bool,
+        legacySessionInfos: [ZmxSessionInfo]
+    ) -> String {
+        let scoped = ZmxSessionName.derive(worktreeId: worktreeId, leafId: leafId)
+        guard allowLegacy else { return scoped }
+        let legacy = ZmxSessionName.legacy(leafId: leafId)
+        guard legacySessionBelongsToKnownRoot(
+            legacy,
+            roots: [worktreeId, projectPath],
+            sessionInfos: legacySessionInfos
+        ) else {
+            return scoped
+        }
+        return legacy
+    }
+
     nonisolated static func legacySessionBelongsToKnownRoot(
         _ name: String,
         roots: [String],
         zmxClient: ZmxClient
     ) -> Bool {
+        legacySessionBelongsToKnownRoot(
+            name,
+            roots: roots,
+            sessionInfos: zmxClient.listSessionInfos()
+        )
+    }
+
+    nonisolated static func legacySessionBelongsToKnownRoot(
+        _ name: String,
+        roots: [String],
+        sessionInfos: [ZmxSessionInfo]
+    ) -> Bool {
         let roots = Set(roots.map { URL(fileURLWithPath: $0).standardizedFileURL.path })
-        return zmxClient.listSessionInfos().contains { info in
+        return sessionInfos.contains { info in
             info.name == name && startDir(info.startDir, belongsToAnyOf: roots)
         }
     }

--- a/AlasTests/Code/LSP/LSPTransportTests.swift
+++ b/AlasTests/Code/LSP/LSPTransportTests.swift
@@ -76,15 +76,14 @@ struct ProcessTransportTerminationTests {
         #expect(source.validatesCachedDescendantsBeforeKilling())
         #expect(source.signalsProcessGroupFromTerminationHandler())
         #expect(source.signalsCachedDescendantsFromTerminationHandler())
-        #expect(source.attemptsSetpgidBeforeBlockingDescendantSnapshot())
+        #expect(source.startsDescendantTrackerWithoutBlockingStart())
         #expect(source.refreshesDescendantsOnFork())
         #expect(source.drainsPsOutputBeforeWaiting())
-        #expect(source.validatesCachedDescendantsWithStableIdentity())
+        #expect(source.validatesCachedDescendantsWithProcessStartTime())
         #expect(source.checksRootExitBeforeTrackerRefresh())
         #expect(source.prunesCachedDescendantsWithBatchedLookup())
         #expect(source.tracksForksFromObservedDescendants())
         #expect(source.mergesDescendantRefreshesWithoutOverwritingCache())
-        #expect(source.preservesCachedDescendantsAcrossExec())
         #expect(source.serializesRootExitWithDescendantRefresh())
     }
 
@@ -151,6 +150,30 @@ private extension String {
             refresh.lowerBound < tracker.lowerBound
     }
 
+    func startsDescendantTrackerWithoutBlockingStart() -> Bool {
+        guard let run = range(of: "try process.run()"),
+              let setpgid = range(of: "setpgid(process.processIdentifier", range: run.upperBound..<endIndex),
+              let observer = range(of: "startDescendantForkObserver(for: process.processIdentifier)",
+                                   range: setpgid.upperBound..<endIndex),
+              let initial = range(of: "let initialDescendants = Set(Self.collectChildDescendants(of: process.processIdentifier))",
+                                  range: observer.upperBound..<endIndex),
+              let merge = range(of: "mergeInitialOrphanSet(initialDescendants)",
+                                range: initial.upperBound..<endIndex),
+              let tracker = range(of: "startDescendantTracker()", range: merge.upperBound..<endIndex),
+              let detached = range(of: "descendantTracker = Task.detached(priority: .utility)") else {
+            return false
+        }
+        let startTail = self[observer.upperBound..<tracker.lowerBound]
+        return run.lowerBound < setpgid.lowerBound &&
+            setpgid.lowerBound < observer.lowerBound &&
+            observer.lowerBound < initial.lowerBound &&
+            initial.lowerBound < merge.lowerBound &&
+            merge.lowerBound < tracker.lowerBound &&
+            detached.lowerBound > tracker.lowerBound &&
+            !startTail.contains("refreshOrphanSet()") &&
+            !startTail.contains("collectDescendants(of:")
+    }
+
     func drainsPsOutputBeforeWaiting() -> Bool {
         guard let collect = range(of: "private static func collectDescendants"),
               let read = range(
@@ -169,6 +192,21 @@ private extension String {
             contains(#""pid=,lstart=""#) &&
             !contains("current.pgid == key.pgid") &&
             contains("return current.intersection(keys)")
+    }
+
+    func validatesCachedDescendantsWithProcessStartTime() -> Bool {
+        contains("let startedAt: ProcessStartTime") &&
+            contains("private static func collectChildDescendants(of root: pid_t) -> [DescendantKey]") &&
+            contains("proc_listchildpids(parent") &&
+            contains("private static func processStartTime(of pid: pid_t) -> ProcessStartTime?") &&
+            contains("private static func processIdentity(of pid: pid_t) -> ProcessIdentity?") &&
+            contains("proc_pidinfo(pid, PROC_PIDTBSDINFO") &&
+            contains("parentPid: pid_t(info.pbi_ppid)") &&
+            contains("identity.parentPid == p") &&
+            contains("identity.parentPid == parent") &&
+            contains(#""pid=,ppid=""#) &&
+            !contains(#""pid=,ppid=,lstart=""#) &&
+            !contains(#""pid=,lstart=""#)
     }
 
     func checksRootExitBeforeTrackerRefresh() -> Bool {

--- a/AlasTests/TerminalServiceZmxTests.swift
+++ b/AlasTests/TerminalServiceZmxTests.swift
@@ -242,6 +242,50 @@ struct TerminalServiceZmxTests {
         #expect(recorder.calls.map(\.args) == [["ls"]])
     }
 
+    @Test func resolveSessionNameForAttachUsesPreloadedLegacyInfo() {
+        let infos = [
+            ZmxSessionInfo(
+                name: "alas-legacy-leaf",
+                startDir: "/tmp/repo/subdir",
+                pid: 1,
+                clients: 0,
+                created: 1,
+                cmd: "/bin/zsh -l"
+            ),
+        ]
+
+        let name = TerminalService.resolveSessionNameForAttach(
+            worktreeId: "/tmp/wt",
+            projectPath: "/tmp/repo",
+            leafId: "legacy-leaf",
+            allowLegacy: true,
+            legacySessionInfos: infos
+        )
+
+        #expect(name == "alas-legacy-leaf")
+    }
+
+    @Test func resolveSessionNameForAttachFallsBackToScopedName() {
+        let name = TerminalService.resolveSessionNameForAttach(
+            worktreeId: "/tmp/wt",
+            projectPath: "/tmp/repo",
+            leafId: "legacy-leaf",
+            allowLegacy: true,
+            legacySessionInfos: [
+                ZmxSessionInfo(
+                    name: "alas-legacy-leaf",
+                    startDir: "/tmp/repo-other",
+                    pid: 1,
+                    clients: 0,
+                    created: 1,
+                    cmd: "/bin/zsh -l"
+                ),
+            ]
+        )
+
+        #expect(name == ZmxSessionName.derive(worktreeId: "/tmp/wt", leafId: "legacy-leaf"))
+    }
+
     // MARK: detachAll
 
     @Test


### PR DESCRIPTION
## Summary

- Preload legacy zmx session info off-main for persisted terminal tab restore.
- Pass pre-resolved zmx session names into terminal launch while preserving legacy repo/worktree-root validation.
- Give JSON-RPC transports a lightweight libproc startup descendant snapshot, then keep expensive process-table walks on a detached utility task.

## Root Cause

Persisted terminal restore could synchronously run `zmx ls` on the main actor while deciding whether to attach a legacy session. ACP startup also synchronously refreshed the JSON-RPC orphan descendant set, which shells out to `ps -ax`, before returning from `start()`.

## Validation

- `rtk xcodegen`
- `rtk proxy env ALAS_FFF_TARGET_ARCH=arm64 xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -only-testing:AlasTests/TerminalServiceZmxTests -only-testing:AlasTests/ProcessTransportTerminationTests test`
- `rtk proxy env ALAS_FFF_TARGET_ARCH=arm64 xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -quiet build`
- `rtk git diff --check`

Full `xcodebuild ... test` was not green locally due to unrelated existing ACP image-asset assertions and a DiffPaneView attributed-string exception observed during the run.

Closes #687