### PR TITLE
fix(acp): clear sent composer drafts on restore

### DIFF
--- a/Alas/Sources/ACP/Session/ACPComposerDraft.swift
+++ b/Alas/Sources/ACP/Session/ACPComposerDraft.swift
@@ -87,6 +87,68 @@ struct ACPComposerDraft: Codable, Equatable {
 }
 
 extension ACPComposerDraft {
+    func matchesPersistedUserPrompt(text: String, attachments: [ACPMessage.Attachment]) -> Bool {
+        normalizedPromptBlocks == Self.contentBlocks(text: text, attachments: attachments)
+    }
+
+    func matchesRecordedQueuedPrompt(in queue: [QueuedPrompt]) -> Bool {
+        queue.contains { item in
+            item.transcriptRecorded && self == item.restorableDraft
+        }
+    }
+
+    private var normalizedPromptBlocks: [ACPContentBlock] {
+        var text = ""
+        var attachments: [ACPMessage.Attachment] = []
+        for segment in segments {
+            switch segment {
+            case .text(let value):
+                text += value
+            case .mention(let displayName, let uri):
+                text += "@\(displayName) "
+                attachments.append(.init(uri: uri, name: displayName))
+            case .image(let uri, let mimeType):
+                attachments.append(.init(
+                    uri: uri,
+                    name: Self.displayName(forURI: uri),
+                    mimeType: mimeType))
+            }
+        }
+        return Self.contentBlocks(text: text, attachments: attachments)
+    }
+
+    func matchesSubmittedRecoveryPrompt(
+        seq: Int64,
+        text: String,
+        attachments: [ACPMessage.Attachment],
+        queue: [QueuedPrompt],
+        submittedAfterSeq: Int64?
+    ) -> Bool {
+        seq > (submittedAfterSeq ?? -1)
+            && !matchesRecordedQueuedPrompt(in: queue)
+            && matchesPersistedUserPrompt(text: text, attachments: attachments)
+    }
+
+    // Keep this isolation-free for hydration, which runs off the main actor.
+    // It mirrors ACPSessionRunner.blocks without pulling the runner into the
+    // persistence path.
+    private static func contentBlocks(
+        text: String,
+        attachments: [ACPMessage.Attachment]
+    ) -> [ACPContentBlock] {
+        var blocks: [ACPContentBlock] = text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+            ? []
+            : [.text(text)]
+        for attachment in attachments {
+            if let mimeType = attachment.mimeType, mimeType.hasPrefix("image/") {
+                blocks.append(.image(data: nil, uri: attachment.uri, mimeType: mimeType))
+            } else {
+                blocks.append(.resourceLink(uri: attachment.uri, name: attachment.name))
+            }
+        }
+        return blocks
+    }
+
     /// Rebuild an editable draft from a queued prompt's content blocks —
     /// the inverse of the submit path's draft→blocks serialization. Used
     /// when the user clicks "edit" on a queued item to pull it back into

--- a/Alas/Sources/ACP/Session/ACPMessageWire.swift
+++ b/Alas/Sources/ACP/Session/ACPMessageWire.swift
@@ -14,6 +14,15 @@ enum ACPMessageWire: Sendable {
     case plan([ACPMessage.PlanItem])
     case systemNotice(text: String)
 
+    var isAgentSideProgress: Bool {
+        switch self {
+        case .agent, .thought, .toolCall, .fileEdit, .plan:
+            return true
+        case .user, .systemNotice:
+            return false
+        }
+    }
+
     /// Decode a persisted `(kind, payload)` pair into the matching wire variant.
     /// Mirrors `ACPMessageCodec.decode` but produces Sendable values and is
     /// safe to call from any isolation domain. Unknown kinds become system

--- a/Alas/Sources/ACP/Session/ACPSessionHydrator.swift
+++ b/Alas/Sources/ACP/Session/ACPSessionHydrator.swift
@@ -29,16 +29,45 @@ actor ACPSessionHydrator {
         // Malformed payloads are skipped (matching the legacy try? in
         // openSession) rather than failing the whole hydration.
         let stored = try store.loadMessages(sessionId: sessionId)
+        let storedDraft = try? store.loadComposerDraftRecord(sessionId: sessionId)
+        let queue = (try? store.loadQueue(sessionId: sessionId)) ?? []
+        var staleSubmittedDraft = false
+        var sawRecordedSubmittedDraft = false
         var wire: [ACPMessageWire] = []
         wire.reserveCapacity(stored.count)
         for m in stored {
             if let w = try? ACPMessageWire.decode(kind: m.kind, payload: m.payload, decoder: decoder) {
                 wire.append(w)
+                if storedDraft != nil,
+                   sawRecordedSubmittedDraft,
+                   w.isAgentSideProgress {
+                    staleSubmittedDraft = true
+                }
+                if let storedDraft,
+                   storedDraft.submittedRecovery,
+                   case .user(_, let text, let attachments) = w,
+                   storedDraft.draft.matchesSubmittedRecoveryPrompt(
+                    seq: m.seq,
+                    text: text,
+                    attachments: attachments,
+                    queue: queue,
+                    submittedAfterSeq: storedDraft.submittedAfterSeq)
+                {
+                    sawRecordedSubmittedDraft = true
+                }
             }
         }
 
-        let queue = (try? store.loadQueue(sessionId: sessionId)) ?? []
-        let draft = try? store.loadComposerDraft(sessionId: sessionId)
+        let draft: ACPComposerDraft?
+        if staleSubmittedDraft, let storedDraft {
+            if (try? store.deleteComposerDraft(sessionId: sessionId, matching: storedDraft)) == true {
+                draft = nil
+            } else {
+                draft = (try? store.loadComposerDraftRecord(sessionId: sessionId))?.draft
+            }
+        } else {
+            draft = storedDraft?.draft
+        }
 
         // Post-load side effect: bump `last_opened_at` so the recents
         // list orders this session to the top. Use the narrow UPDATE

--- a/Alas/Sources/ACP/Session/ACPSessionManager.swift
+++ b/Alas/Sources/ACP/Session/ACPSessionManager.swift
@@ -374,16 +374,35 @@ final class ACPSessionManager: ObservableObject {
             throw ACPSessionHydrator.Error.sessionNotFound(id)
         }
         let stored = (try? store.loadMessages(sessionId: id)) ?? []
+        let storedDraft = try? store.loadComposerDraftRecord(sessionId: id)
+        let queue = (try? store.loadQueue(sessionId: id)) ?? []
+        var staleSubmittedDraft = false
+        var sawRecordedSubmittedDraft = false
         var wire: [ACPMessageWire] = []
         wire.reserveCapacity(stored.count)
         let decoder = JSONDecoder()
         for m in stored {
             if let w = try? ACPMessageWire.decode(kind: m.kind, payload: m.payload, decoder: decoder) {
                 wire.append(w)
+                if storedDraft != nil,
+                   sawRecordedSubmittedDraft,
+                   w.isAgentSideProgress {
+                    staleSubmittedDraft = true
+                }
+                if let storedDraft,
+                   storedDraft.submittedRecovery,
+                   case .user(_, let text, let attachments) = w,
+                   storedDraft.draft.matchesSubmittedRecoveryPrompt(
+                    seq: m.seq,
+                    text: text,
+                    attachments: attachments,
+                    queue: queue,
+                    submittedAfterSeq: storedDraft.submittedAfterSeq)
+                {
+                    sawRecordedSubmittedDraft = true
+                }
             }
         }
-        let queue = (try? store.loadQueue(sessionId: id)) ?? []
-        let draft = try? store.loadComposerDraft(sessionId: id)
         let now = Int64(Date().timeIntervalSince1970)
         try? store.touchLastOpenedAt(id: id, at: now)
         let touched = ACPSessionRow(
@@ -398,6 +417,16 @@ final class ACPSessionManager: ObservableObject {
             lastOpenedAt: now,
             archived: row.archived)
         let recent = (try? store.recentSessions()) ?? []
+        let draft: ACPComposerDraft?
+        if staleSubmittedDraft, let storedDraft {
+            if (try? store.deleteComposerDraft(sessionId: id, matching: storedDraft)) == true {
+                draft = nil
+            } else {
+                draft = (try? store.loadComposerDraftRecord(sessionId: id))?.draft
+            }
+        } else {
+            draft = storedDraft?.draft
+        }
         return HydrationResult(row: touched, wireMessages: wire,
                                queue: queue, draft: draft, recent: recent)
     }
@@ -901,7 +930,14 @@ final class ACPSessionManager: ObservableObject {
         pendingDraftWrites[sid] = nil
         if !submitted.isEmpty {
             let now = Int64(Date().timeIntervalSince1970)
-            try? store.upsertComposerDraft(sessionId: sid, draft: submitted, updatedAt: now)
+            let submittedAfterSeq = try? store.latestMessageSeq(sessionId: sid)
+            try? store.upsertComposerDraft(
+                sessionId: sid,
+                draft: submitted,
+                updatedAt: now,
+                submittedRecovery: true,
+                submittedAfterSeq: submittedAfterSeq
+            )
         }
         session.replaceComposerDraft(.empty)
         return session.composerDraftRevision
@@ -935,6 +971,8 @@ final class ACPSessionManager: ObservableObject {
               session.composerDraft.isEmpty
         else { return }
         session.replaceComposerDraft(submitted)
+        let now = Int64(Date().timeIntervalSince1970)
+        try? store.upsertComposerDraft(sessionId: session.id, draft: submitted, updatedAt: now)
     }
 
     func refreshRecent() {

--- a/Alas/Sources/ACP/Session/ACPSessionRunner.swift
+++ b/Alas/Sources/ACP/Session/ACPSessionRunner.swift
@@ -1094,7 +1094,7 @@ extension ACPSessionRunner {
             // stays consistent.
             Task { @MainActor in onPromptFinished?(false) }
         case .sendNow:
-            sendNow(blocks: blocks, queuedItemId: nil, onPromptFinished: onPromptFinished)
+            sendNow(blocks: blocks, queuedItemId: nil, draft: draft, onPromptFinished: onPromptFinished)
         case .enqueue:
             session.enqueue(blocks: blocks, draft: draft)
             persistQueue()
@@ -1104,7 +1104,7 @@ extension ACPSessionRunner {
             // later when the flusher drains the head.
             Task { @MainActor in onPromptFinished?(true) }
         case .steer:
-            steer(blocks: blocks, onPromptFinished: onPromptFinished)
+            steer(blocks: blocks, draft: draft, onPromptFinished: onPromptFinished)
         }
     }
 
@@ -1187,6 +1187,7 @@ extension ACPSessionRunner {
     func steer(
         blocks: [ACPContentBlock],
         recordUserPrompt: Bool = true,
+        draft: ACPComposerDraft? = nil,
         onPromptFinished: (@MainActor (_ succeeded: Bool) -> Void)? = nil
     ) {
         flushPendingIncomingUpdates(flushQueueWhenBoundaryReady: false)
@@ -1236,6 +1237,7 @@ extension ACPSessionRunner {
                     blocks: blocks,
                     queuedItemId: nil,
                     recordUserPrompt: recordUserPrompt,
+                    draft: draft,
                     onPromptFinished: onPromptFinished
                 )
             }
@@ -1279,6 +1281,7 @@ extension ACPSessionRunner {
         blocks: [ACPContentBlock],
         queuedItemId: UUID?,
         recordUserPrompt: Bool = true,
+        draft: ACPComposerDraft? = nil,
         onPromptFinished: (@MainActor (_ succeeded: Bool) -> Void)? = nil
     ) {
         flushPendingIncomingUpdates()

--- a/Alas/Sources/ACP/Session/ACPSessionStore.swift
+++ b/Alas/Sources/ACP/Session/ACPSessionStore.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 final class ACPSessionStore {
-    static let targetSchemaVersion = 8
+    static let targetSchemaVersion = 10
     let db: SQLiteDatabase
 
     init(path: String) throws {
@@ -33,6 +33,8 @@ final class ACPSessionStore {
         if current < 6 { try migrate_to_v6() }
         if current < 7 { try migrate_to_v7() }
         if current < 8 { try migrate_to_v8() }
+        if current < 9 { try migrate_to_v9() }
+        if current < 10 { try migrate_to_v10() }
         try recoverFromConcurrentWriters()
         if current == 0 {
             try db.exec("INSERT INTO schema_version (version) VALUES (?)", bindings: [Int64(Self.targetSchemaVersion)])
@@ -173,6 +175,14 @@ final class ACPSessionStore {
         WHERE remote_session_id IS NOT NULL
         """)
     }
+
+    private func migrate_to_v9() throws {
+        try db.exec("ALTER TABLE composer_drafts ADD COLUMN submitted_recovery INTEGER NOT NULL DEFAULT 0")
+    }
+
+    private func migrate_to_v10() throws {
+        try db.exec("ALTER TABLE composer_drafts ADD COLUMN submitted_after_seq INTEGER")
+    }
 }
 
 struct ACPSessionLease: Equatable {
@@ -213,6 +223,14 @@ struct ACPStoredMessage: Equatable {
     let seq: Int64
     let payload: Data
     let createdAt: Int64
+}
+
+struct ACPStoredComposerDraft: Equatable {
+    let draft: ACPComposerDraft
+    let updatedAt: Int64
+    let payload: Data
+    let submittedRecovery: Bool
+    let submittedAfterSeq: Int64?
 }
 
 extension ACPSessionStore {
@@ -288,26 +306,69 @@ extension ACPSessionStore {
     }
 
     func loadComposerDraft(sessionId: String) throws -> ACPComposerDraft? {
-        let rows = try db.query("""
-        SELECT payload FROM composer_drafts WHERE session_id = ?
-        """, bindings: [sessionId])
-        guard let payload = rows.first?["payload"] as? Data else { return nil }
-        return try JSONDecoder().decode(ACPComposerDraft.self, from: payload)
+        try loadComposerDraftRecord(sessionId: sessionId)?.draft
     }
 
-    func upsertComposerDraft(sessionId: String, draft: ACPComposerDraft, updatedAt: Int64) throws {
+    func loadComposerDraftRecord(sessionId: String) throws -> ACPStoredComposerDraft? {
+        let rows = try db.query("""
+        SELECT payload, updated_at, submitted_recovery, submitted_after_seq
+        FROM composer_drafts WHERE session_id = ?
+        """, bindings: [sessionId])
+        guard let row = rows.first,
+              let payload = row["payload"] as? Data,
+              let updatedAt = row["updated_at"] as? Int64
+        else { return nil }
+        return try ACPStoredComposerDraft(
+            draft: JSONDecoder().decode(ACPComposerDraft.self, from: payload),
+            updatedAt: updatedAt,
+            payload: payload,
+            submittedRecovery: (row["submitted_recovery"] as? Int64) == 1,
+            submittedAfterSeq: row["submitted_after_seq"] as? Int64
+        )
+    }
+
+    func upsertComposerDraft(
+        sessionId: String,
+        draft: ACPComposerDraft,
+        updatedAt: Int64,
+        submittedRecovery: Bool = false,
+        submittedAfterSeq: Int64? = nil
+    ) throws {
         let payload = try JSONEncoder().encode(draft)
         try db.exec("""
-        INSERT INTO composer_drafts (session_id, payload, updated_at)
-        VALUES (?,?,?)
+        INSERT INTO composer_drafts (session_id, payload, updated_at, submitted_recovery, submitted_after_seq)
+        VALUES (?,?,?,?,?)
         ON CONFLICT(session_id) DO UPDATE SET
             payload = excluded.payload,
-            updated_at = excluded.updated_at
-        """, bindings: [sessionId, payload, updatedAt])
+            updated_at = excluded.updated_at,
+            submitted_recovery = excluded.submitted_recovery,
+            submitted_after_seq = excluded.submitted_after_seq
+        """, bindings: [sessionId, payload, updatedAt, submittedRecovery ? 1 : 0, submittedAfterSeq])
     }
 
     func deleteComposerDraft(sessionId: String) throws {
         try db.exec("DELETE FROM composer_drafts WHERE session_id = ?", bindings: [sessionId])
+    }
+
+    func deleteComposerDraft(sessionId: String, matching stored: ACPStoredComposerDraft) throws -> Bool {
+        try db.execChanges("""
+        DELETE FROM composer_drafts
+        WHERE session_id = ?
+          AND payload = ?
+          AND updated_at = ?
+          AND submitted_recovery = ?
+          AND (
+            (submitted_after_seq IS NULL AND ? IS NULL)
+            OR submitted_after_seq = ?
+          )
+        """, bindings: [
+            sessionId,
+            stored.payload,
+            stored.updatedAt,
+            stored.submittedRecovery ? 1 : 0,
+            stored.submittedAfterSeq,
+            stored.submittedAfterSeq
+        ]) > 0
     }
 
     func setArchived(id: String, archived: Bool) throws {
@@ -386,6 +447,14 @@ extension ACPSessionStore {
         FROM messages WHERE session_id = ?
         """, bindings: [sessionId])
         return Int((rows.first?["count"] as? Int64) ?? 0)
+    }
+
+    func latestMessageSeq(sessionId: String) throws -> Int64? {
+        let rows = try db.query("""
+        SELECT MAX(seq) AS seq
+        FROM messages WHERE session_id = ?
+        """, bindings: [sessionId])
+        return rows.first?["seq"] as? Int64
     }
 
     func loadMessages(sessionId: String) throws -> [ACPStoredMessage] {

--- a/AlasTests/ACP/ACPSessionLeaseTests.swift
+++ b/AlasTests/ACP/ACPSessionLeaseTests.swift
@@ -12,7 +12,7 @@ import Foundation
     @Test("schema includes leases and session origins")
     func schemaIncludesLeasesAndOrigins() throws {
         let store = try tempStore()
-        #expect(try store.currentSchemaVersion() == 8)
+        #expect(try store.currentSchemaVersion() == ACPSessionStore.targetSchemaVersion)
     }
 
     @Test("session_leases table exists and is empty")

--- a/AlasTests/ACP/Session/ACPComposerDraftTests.swift
+++ b/AlasTests/ACP/Session/ACPComposerDraftTests.swift
@@ -44,4 +44,17 @@ struct ACPComposerDraftTests {
         #expect(!draft.isEmpty)
         #expect(draft.hasContent)
     }
+
+    @Test("persisted prompt matching normalizes image chips")
+    func persistedPromptMatchingNormalizesImageChips() {
+        let draft = ACPComposerDraft(segments: [
+            .text("Look at "),
+            .image(uri: "file:///tmp/shot.png", mimeType: "image/png"),
+            .text(" ")
+        ])
+
+        #expect(draft.matchesPersistedUserPrompt(
+            text: "Look at  ",
+            attachments: [.init(uri: "file:///tmp/shot.png", name: "shot.png", mimeType: "image/png")]))
+    }
 }

--- a/AlasTests/ACP/Session/ACPSessionManagerHydrationTests.swift
+++ b/AlasTests/ACP/Session/ACPSessionManagerHydrationTests.swift
@@ -101,6 +101,361 @@ struct ACPSessionManagerHydrationTests {
         #expect(s.remoteSessionId == "remote-1")
     }
 
+    @Test("hydrateIfNeeded drops a suspended draft already recorded in the transcript")
+    func hydrateDropsRecordedSuspendedDraft() async throws {
+        let path = tmpStorePath()
+        let store = try ACPSessionStore(path: path)
+        try store.upsertSession(.init(
+            id: "s", agentId: "claude", title: "t",
+            currentModel: nil, currentMode: nil, autoRun: false,
+            createdAt: 0, updatedAt: 0, lastOpenedAt: 0, archived: false))
+        let draft = ACPComposerDraft(segments: [.text("already sent")])
+        try store.upsertComposerDraft(
+            sessionId: "s",
+            draft: draft,
+            updatedAt: 10,
+            submittedRecovery: true
+        )
+        let userMessage = ACPMessage.user(
+            id: UUID(),
+            text: "already sent",
+            attachments: []
+        )
+        try store.appendMessage(
+            sessionId: "s",
+            id: "m0",
+            kind: userMessage.kind,
+            seq: 0,
+            payload: ACPMessageCodec.encode(userMessage),
+            createdAt: 11
+        )
+        let agentMessage = ACPMessage.agent(id: UUID(), StreamingText("done"))
+        try store.appendMessage(
+            sessionId: "s",
+            id: "m1",
+            kind: agentMessage.kind,
+            seq: 1,
+            payload: ACPMessageCodec.encode(agentMessage),
+            createdAt: 12
+        )
+
+        let mgr = ACPSessionManager(worktreeId: "wt", worktreePath: "/tmp/wt", store: store)
+        let s = try #require(mgr.placeholderSession(id: "s"))
+
+        await mgr.hydrateIfNeeded(id: "s")
+
+        #expect(s.hydrationState == .ready)
+        #expect(s.composerDraft == .empty)
+        #expect(try store.loadComposerDraft(sessionId: "s") == nil)
+    }
+
+    @Test("hydrateIfNeeded preserves a recorded draft until agent progress is stored")
+    func hydratePreservesRecordedDraftUntilAgentProgress() async throws {
+        let path = tmpStorePath()
+        let store = try ACPSessionStore(path: path)
+        try store.upsertSession(.init(
+            id: "s", agentId: "claude", title: "t",
+            currentModel: nil, currentMode: nil, autoRun: false,
+            createdAt: 0, updatedAt: 0, lastOpenedAt: 0, archived: false))
+        let draft = ACPComposerDraft(segments: [.text("maybe not delivered")])
+        try store.upsertComposerDraft(
+            sessionId: "s",
+            draft: draft,
+            updatedAt: 10,
+            submittedRecovery: true
+        )
+        let userMessage = ACPMessage.user(
+            id: UUID(),
+            text: "maybe not delivered",
+            attachments: []
+        )
+        try store.appendMessage(
+            sessionId: "s",
+            id: "m0",
+            kind: userMessage.kind,
+            seq: 0,
+            payload: ACPMessageCodec.encode(userMessage),
+            createdAt: 11
+        )
+
+        let mgr = ACPSessionManager(worktreeId: "wt", worktreePath: "/tmp/wt", store: store)
+        let s = try #require(mgr.placeholderSession(id: "s"))
+
+        await mgr.hydrateIfNeeded(id: "s")
+
+        #expect(s.hydrationState == .ready)
+        #expect(s.composerDraft == draft)
+        #expect(try store.loadComposerDraft(sessionId: "s") == draft)
+    }
+
+    @Test("hydrateIfNeeded preserves a matching draft newer than the transcript prompt")
+    func hydratePreservesNewerMatchingDraft() async throws {
+        let path = tmpStorePath()
+        let store = try ACPSessionStore(path: path)
+        try store.upsertSession(.init(
+            id: "s", agentId: "claude", title: "t",
+            currentModel: nil, currentMode: nil, autoRun: false,
+            createdAt: 0, updatedAt: 0, lastOpenedAt: 0, archived: false))
+        let userMessage = ACPMessage.user(
+            id: UUID(),
+            text: "repeat this",
+            attachments: []
+        )
+        try store.appendMessage(
+            sessionId: "s",
+            id: "m0",
+            kind: userMessage.kind,
+            seq: 0,
+            payload: ACPMessageCodec.encode(userMessage),
+            createdAt: 10
+        )
+        let draft = ACPComposerDraft(segments: [.text("repeat this")])
+        try store.upsertComposerDraft(sessionId: "s", draft: draft, updatedAt: 11)
+
+        let mgr = ACPSessionManager(worktreeId: "wt", worktreePath: "/tmp/wt", store: store)
+        let s = try #require(mgr.placeholderSession(id: "s"))
+
+        await mgr.hydrateIfNeeded(id: "s")
+
+        #expect(s.hydrationState == .ready)
+        #expect(s.composerDraft == draft)
+        #expect(try store.loadComposerDraft(sessionId: "s") == draft)
+    }
+
+    @Test("hydrateIfNeeded preserves a matching draft saved in the same second as a prompt")
+    func hydratePreservesSameSecondMatchingDraft() async throws {
+        let path = tmpStorePath()
+        let store = try ACPSessionStore(path: path)
+        try store.upsertSession(.init(
+            id: "s", agentId: "claude", title: "t",
+            currentModel: nil, currentMode: nil, autoRun: false,
+            createdAt: 0, updatedAt: 0, lastOpenedAt: 0, archived: false))
+        let userMessage = ACPMessage.user(
+            id: UUID(),
+            text: "repeat this",
+            attachments: []
+        )
+        try store.appendMessage(
+            sessionId: "s",
+            id: "m0",
+            kind: userMessage.kind,
+            seq: 0,
+            payload: ACPMessageCodec.encode(userMessage),
+            createdAt: 10
+        )
+        let agentMessage = ACPMessage.agent(id: UUID(), StreamingText("done"))
+        try store.appendMessage(
+            sessionId: "s",
+            id: "m1",
+            kind: agentMessage.kind,
+            seq: 1,
+            payload: ACPMessageCodec.encode(agentMessage),
+            createdAt: 10
+        )
+        let draft = ACPComposerDraft(segments: [.text("repeat this")])
+        try store.upsertComposerDraft(sessionId: "s", draft: draft, updatedAt: 10)
+
+        let mgr = ACPSessionManager(worktreeId: "wt", worktreePath: "/tmp/wt", store: store)
+        let s = try #require(mgr.placeholderSession(id: "s"))
+
+        await mgr.hydrateIfNeeded(id: "s")
+
+        #expect(s.hydrationState == .ready)
+        #expect(s.composerDraft == draft)
+        #expect(try store.loadComposerDraft(sessionId: "s") == draft)
+    }
+
+    @Test("hydrateIfNeeded drops a submitted recovery draft saved in the same second as a prompt")
+    func hydrateDropsSameSecondSubmittedRecoveryDraft() async throws {
+        let path = tmpStorePath()
+        let store = try ACPSessionStore(path: path)
+        try store.upsertSession(.init(
+            id: "s", agentId: "claude", title: "t",
+            currentModel: nil, currentMode: nil, autoRun: false,
+            createdAt: 0, updatedAt: 0, lastOpenedAt: 0, archived: false))
+        let draft = ACPComposerDraft(segments: [.text("repeat this")])
+        try store.upsertComposerDraft(
+            sessionId: "s",
+            draft: draft,
+            updatedAt: 10,
+            submittedRecovery: true
+        )
+        let userMessage = ACPMessage.user(
+            id: UUID(),
+            text: "repeat this",
+            attachments: []
+        )
+        try store.appendMessage(
+            sessionId: "s",
+            id: "m0",
+            kind: userMessage.kind,
+            seq: 0,
+            payload: ACPMessageCodec.encode(userMessage),
+            createdAt: 10
+        )
+        let agentMessage = ACPMessage.agent(id: UUID(), StreamingText("done"))
+        try store.appendMessage(
+            sessionId: "s",
+            id: "m1",
+            kind: agentMessage.kind,
+            seq: 1,
+            payload: ACPMessageCodec.encode(agentMessage),
+            createdAt: 10
+        )
+
+        let mgr = ACPSessionManager(worktreeId: "wt", worktreePath: "/tmp/wt", store: store)
+        let s = try #require(mgr.placeholderSession(id: "s"))
+
+        await mgr.hydrateIfNeeded(id: "s")
+
+        #expect(s.hydrationState == .ready)
+        #expect(s.composerDraft == .empty)
+        #expect(try store.loadComposerDraft(sessionId: "s") == nil)
+    }
+
+    @Test("hydrateIfNeeded preserves a submitted recovery draft that only matches an older turn")
+    func hydratePreservesSubmittedRecoveryDraftMatchingOnlyOlderTurn() async throws {
+        let path = tmpStorePath()
+        let store = try ACPSessionStore(path: path)
+        try store.upsertSession(.init(
+            id: "s", agentId: "claude", title: "t",
+            currentModel: nil, currentMode: nil, autoRun: false,
+            createdAt: 0, updatedAt: 0, lastOpenedAt: 0, archived: false))
+        let oldUserMessage = ACPMessage.user(
+            id: UUID(),
+            text: "repeat this",
+            attachments: []
+        )
+        try store.appendMessage(
+            sessionId: "s",
+            id: "m0",
+            kind: oldUserMessage.kind,
+            seq: 0,
+            payload: ACPMessageCodec.encode(oldUserMessage),
+            createdAt: 8
+        )
+        let oldAgentMessage = ACPMessage.agent(id: UUID(), StreamingText("old done"))
+        try store.appendMessage(
+            sessionId: "s",
+            id: "m1",
+            kind: oldAgentMessage.kind,
+            seq: 1,
+            payload: ACPMessageCodec.encode(oldAgentMessage),
+            createdAt: 9
+        )
+        let draft = ACPComposerDraft(segments: [.text("repeat this")])
+        try store.upsertComposerDraft(
+            sessionId: "s",
+            draft: draft,
+            updatedAt: 10,
+            submittedRecovery: true,
+            submittedAfterSeq: 1
+        )
+
+        let mgr = ACPSessionManager(worktreeId: "wt", worktreePath: "/tmp/wt", store: store)
+        let s = try #require(mgr.placeholderSession(id: "s"))
+
+        await mgr.hydrateIfNeeded(id: "s")
+
+        #expect(s.hydrationState == .ready)
+        #expect(s.composerDraft == draft)
+        #expect(try store.loadComposerDraft(sessionId: "s") == draft)
+    }
+
+    @Test("hydrateIfNeeded drops a submitted image recovery draft once the image prompt progresses")
+    func hydrateDropsSubmittedImageRecoveryDraftAfterProgress() async throws {
+        let path = tmpStorePath()
+        let store = try ACPSessionStore(path: path)
+        try store.upsertSession(.init(
+            id: "s", agentId: "claude", title: "t",
+            currentModel: nil, currentMode: nil, autoRun: false,
+            createdAt: 0, updatedAt: 0, lastOpenedAt: 0, archived: false))
+        let draft = ACPComposerDraft(segments: [
+            .text("Look at "),
+            .image(uri: "file:///tmp/shot.png", mimeType: "image/png"),
+            .text(" ")
+        ])
+        try store.upsertComposerDraft(
+            sessionId: "s",
+            draft: draft,
+            updatedAt: 10,
+            submittedRecovery: true
+        )
+        let userMessage = ACPMessage.user(
+            id: UUID(),
+            text: "Look at  ",
+            attachments: [.init(uri: "file:///tmp/shot.png", name: "shot.png", mimeType: "image/png")]
+        )
+        try store.appendMessage(
+            sessionId: "s",
+            id: "m0",
+            kind: userMessage.kind,
+            seq: 0,
+            payload: ACPMessageCodec.encode(userMessage),
+            createdAt: 10
+        )
+        let agentMessage = ACPMessage.agent(id: UUID(), StreamingText("done"))
+        try store.appendMessage(
+            sessionId: "s",
+            id: "m1",
+            kind: agentMessage.kind,
+            seq: 1,
+            payload: ACPMessageCodec.encode(agentMessage),
+            createdAt: 11
+        )
+
+        let mgr = ACPSessionManager(worktreeId: "wt", worktreePath: "/tmp/wt", store: store)
+        let s = try #require(mgr.placeholderSession(id: "s"))
+
+        await mgr.hydrateIfNeeded(id: "s")
+
+        #expect(s.hydrationState == .ready)
+        #expect(s.composerDraft == .empty)
+        #expect(try store.loadComposerDraft(sessionId: "s") == nil)
+    }
+
+    @Test("hydrateIfNeeded preserves a draft that matches a recorded queued prompt")
+    func hydratePreservesDraftMatchingRecordedQueueItem() async throws {
+        let path = tmpStorePath()
+        let store = try ACPSessionStore(path: path)
+        try store.upsertSession(.init(
+            id: "s", agentId: "claude", title: "t",
+            currentModel: nil, currentMode: nil, autoRun: false,
+            createdAt: 0, updatedAt: 0, lastOpenedAt: 0, archived: false))
+        let userMessage = ACPMessage.user(
+            id: UUID(),
+            text: "queued repeat",
+            attachments: []
+        )
+        try store.appendMessage(
+            sessionId: "s",
+            id: "m0",
+            kind: userMessage.kind,
+            seq: 0,
+            payload: ACPMessageCodec.encode(userMessage),
+            createdAt: 11
+        )
+        let draft = ACPComposerDraft(segments: [.text("queued repeat")])
+        try store.upsertComposerDraft(sessionId: "s", draft: draft, updatedAt: 10)
+        try store.upsertQueue(sessionId: "s", items: [
+            QueuedPrompt(
+                blocks: [.text("queued repeat")],
+                draft: draft,
+                transcriptRecorded: true
+            )
+        ])
+
+        let mgr = ACPSessionManager(worktreeId: "wt", worktreePath: "/tmp/wt", store: store)
+        let s = try #require(mgr.placeholderSession(id: "s"))
+
+        await mgr.hydrateIfNeeded(id: "s")
+
+        #expect(s.hydrationState == .ready)
+        #expect(s.composerDraft == draft)
+        #expect(try store.loadComposerDraft(sessionId: "s") == draft)
+        #expect(s.queue.count == 1)
+    }
+
     @Test("hydrateIfNeeded does not overwrite a newer in-memory remote ACP session id")
     func hydratePreservesNewerRemoteSessionId() async throws {
         let path = tmpStorePath()

--- a/AlasTests/ACP/Session/ACPSessionManagerTests.swift
+++ b/AlasTests/ACP/Session/ACPSessionManagerTests.swift
@@ -168,6 +168,14 @@ struct ACPSessionManagerTests {
         let store = try ACPSessionStore(path: url.path)
         let mgr = ACPSessionManager(worktreeId: "wt", worktreePath: "/tmp/wt", store: store)
         let session = mgr.createSession(agentId: "claude")
+        try store.appendMessage(
+            sessionId: session.id,
+            id: "m0",
+            kind: "user",
+            seq: 0,
+            payload: Data("old".utf8),
+            createdAt: 1
+        )
         let submitted = ACPComposerDraft(segments: [.text("sent")])
 
         // Schedule a debounced write but DO NOT flush — simulates the
@@ -180,6 +188,7 @@ struct ACPSessionManagerTests {
         #expect(session.composerDraftRevision == suspendedRevision)
         // SQLite was written synchronously by suspend, no flush needed.
         #expect(try store.loadComposerDraft(sessionId: session.id) == submitted)
+        #expect(try store.loadComposerDraftRecord(sessionId: session.id)?.submittedAfterSeq == 0)
     }
 
     @Test("purgeSuspendedComposerDraft deletes SQLite only when revision matches")

--- a/AlasTests/ACP/Session/ACPSessionRunnerTests.swift
+++ b/AlasTests/ACP/Session/ACPSessionRunnerTests.swift
@@ -69,6 +69,56 @@ struct ACPSessionRunnerTests {
         #expect(runner.session.transcript.streamingState == .idle)
     }
 
+    @Test("recording a submitted prompt keeps the suspended composer draft until prompt completion")
+    func recordingPromptKeepsSuspendedDraftUntilPromptCompletion() async throws {
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("rn-recorded-draft-\(UUID().uuidString).sqlite")
+        let store = try ACPSessionStore(path: url.path)
+        try store.upsertSession(.init(id: "s", agentId: "claude", title: "t",
+            currentModel: nil, currentMode: nil, autoRun: false,
+            createdAt: 0, updatedAt: 0, lastOpenedAt: 0, archived: false))
+        let submitted = ACPComposerDraft(segments: [.text("hello")])
+        try store.upsertComposerDraft(
+            sessionId: "s",
+            draft: submitted,
+            updatedAt: 1,
+            submittedRecovery: true
+        )
+        let client = StreamingBatchACPClient()
+        let session = ACPSession(id: "s", agentId: "claude", worktreeId: "wt", title: "t")
+        session.agentState = .ready
+        let runner = ACPSessionRunner(
+            session: session,
+            connection: ACPConnection(client: client),
+            store: store,
+            sessionId: "s",
+            worktreePath: FileManager.default.temporaryDirectory.path
+        )
+
+        var completion: Bool?
+        runner.send(
+            text: "hello",
+            attachments: [],
+            intent: .auto,
+            draft: submitted
+        ) { succeeded in
+            completion = succeeded
+        }
+
+        try await waitUntil {
+            session.transcript.messages.contains {
+                    if case .user(_, _, "hello", _) = $0 { return true }
+                    return false
+                }
+        }
+        #expect(try store.loadComposerDraft(sessionId: "s") == submitted)
+        #expect(completion == nil)
+
+        await client.finishPrompt()
+        try await waitUntil { completion == true }
+        #expect(try store.loadComposerDraft(sessionId: "s") == submitted)
+    }
+
     @Test("prompt completion waits for yielded updates before marking output boundary")
     func promptCompletionWaitsForYieldedUpdatesBeforeBoundary() async throws {
         let url = FileManager.default.temporaryDirectory

--- a/AlasTests/ACP/Session/ACPSessionStoreCRUDTests.swift
+++ b/AlasTests/ACP/Session/ACPSessionStoreCRUDTests.swift
@@ -446,6 +446,9 @@ struct ACPSessionStoreCRUDTests {
         #expect(try store.messageCount(sessionId: "s") == 2)
         #expect(try store.messageCount(sessionId: "other") == 1)
         #expect(try store.messageCount(sessionId: "missing") == 0)
+        #expect(try store.latestMessageSeq(sessionId: "s") == 1)
+        #expect(try store.latestMessageSeq(sessionId: "other") == 0)
+        #expect(try store.latestMessageSeq(sessionId: "missing") == nil)
     }
 
     @Test("composer draft upsert load and delete round-trips")
@@ -466,6 +469,23 @@ struct ACPSessionStoreCRUDTests {
 
         #expect(try store.loadComposerDraft(sessionId: "s") == draft)
         #expect(try ACPSessionStore(path: url.path).loadComposerDraft(sessionId: "s") == draft)
+
+        let stored = try #require(try store.loadComposerDraftRecord(sessionId: "s"))
+        #expect(stored.submittedRecovery == false)
+        #expect(stored.submittedAfterSeq == nil)
+        let newer = ACPComposerDraft(segments: [.text("newer")])
+        try store.upsertComposerDraft(
+            sessionId: "s",
+            draft: newer,
+            updatedAt: 124,
+            submittedRecovery: true,
+            submittedAfterSeq: 42
+        )
+        let newerStored = try #require(try store.loadComposerDraftRecord(sessionId: "s"))
+        #expect(newerStored.submittedRecovery == true)
+        #expect(newerStored.submittedAfterSeq == 42)
+        #expect(try store.deleteComposerDraft(sessionId: "s", matching: stored) == false)
+        #expect(try store.loadComposerDraft(sessionId: "s") == newer)
 
         try store.deleteComposerDraft(sessionId: "s")
         #expect(try store.loadComposerDraft(sessionId: "s") == nil)

--- a/AlasTests/ACP/Session/ACPSessionStoreTests.swift
+++ b/AlasTests/ACP/Session/ACPSessionStoreTests.swift
@@ -81,5 +81,6 @@ struct ACPSessionStoreSchemaTests {
         try store.upsertComposerDraft(sessionId: "s", draft: draft, updatedAt: 123)
 
         #expect(try store.loadComposerDraft(sessionId: "s") == draft)
+        #expect(try store.loadComposerDraftRecord(sessionId: "s")?.submittedRecovery == false)
     }
 }


### PR DESCRIPTION
## Summary

Fixes ACP composer restore so a message that was already sent before quitting Alas does not come back pre-filled after relaunch.

## Root cause

The submit path intentionally persisted the submitted composer draft as crash recovery while the prompt RPC was in flight. If Alas exited after the prompt had already progressed and transcript output was persisted, but before the composer success callback deleted that recovery row, hydration could treat the old submitted text as an unsent draft. Timestamp-only cleanup was not precise enough because draft writes and transcript rows use second-resolution timestamps, and repeated prompts can have the same text as older transcript turns.

## Changes

- Keep the suspended composer draft while prompt delivery is still in flight, so a locally recorded but undelivered prompt remains retryable after restore.
- Add a `submitted_recovery` marker to composer draft persistence so restore can distinguish submitted recovery rows from normal typed drafts, including same-second repeated text.
- Store the latest transcript sequence alongside submitted recovery drafts and only match them against user messages recorded after that boundary, so older duplicate turns do not delete a newly submitted recovery draft.
- Normalize image-chip drafts before matching persisted user prompts, so sent image prompts with trailing chip whitespace are cleared once agent progress exists.
- During hydration, discard submitted recovery rows that match a persisted user prompt only after later agent-side progress exists, while preserving genuinely typed drafts and recorded queued prompts.
- Make restore-time stale-draft cleanup conditional on the exact row that was inspected, so a newer draft written during hydration is not deleted.
- Add focused regressions for restore-time cleanup, undelivered prompt preservation, same-second submitted recovery cleanup, same-second typed draft preservation, duplicate prompt boundaries, image prompt normalization, recorded queued prompt preservation, schema migration, and conditional draft deletion.

## Validation

```bash
rtk env ALAS_FFF_TARGET_ARCH=arm64 xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -only-testing:AlasTests/ACPSessionManagerHydrationTests -only-testing:AlasTests/ACPSessionRunnerTests -only-testing:AlasTests/ACPSessionStoreCRUDTests -only-testing:AlasTests/ACPSessionStoreSchemaTests -only-testing:AlasTests/ACPSessionLeaseTests -only-testing:AlasTests/ACPSessionHydratorTests -only-testing:AlasTests/ACPSessionStoreQueueTests -only-testing:AlasTests/ACPSessionStoreDedupTests -only-testing:AlasTests/ACPComposerDraftTests test
```

Passed: 137 tests in 9 suites.