### PR TITLE
chore(treesitter): Update tree-sitter Swift grammar

### DIFF
--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -5976,7 +5976,7 @@
 			repositoryURL = "https://github.com/alex-pinkus/tree-sitter-swift";
 			requirement = {
 				kind = revision;
-				revision = 7b7909f2f6b9414be0958275f4c8e5d69c3bca43;
+				revision = 31d17fe7e818a2048c808b5c6fdc2dc792f4f5b5;
 			};
 		};
 		84754D9A43AEB55E1268F11A /* XCRemoteSwiftPackageReference "tree-sitter-go" */ = {

--- a/Alas.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Alas.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -158,7 +158,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/alex-pinkus/tree-sitter-swift",
       "state" : {
-        "revision" : "7b7909f2f6b9414be0958275f4c8e5d69c3bca43"
+        "revision" : "31d17fe7e818a2048c808b5c6fdc2dc792f4f5b5"
       }
     },
     {

--- a/project.yml
+++ b/project.yml
@@ -21,10 +21,10 @@ packages:
     from: 0.25.0
   TreeSitterSwift:
     url: https://github.com/alex-pinkus/tree-sitter-swift
-    # tag 0.7.2-with-generated-files; this fork's `main` branch
+    # tag 0.7.3-with-generated-files; this fork's `main` branch
     # gitignores generated parser files, so SPM consumers must
     # pin to a `*-with-generated-files` revision.
-    revision: 7b7909f2f6b9414be0958275f4c8e5d69c3bca43
+    revision: 31d17fe7e818a2048c808b5c6fdc2dc792f4f5b5
   TreeSitterYAML:
     # Vendored at ThirdParty/TreeSitterYAML — upstream's Package.swift
     # conditionally adds src/scanner.c via a relative-path FileManager


### PR DESCRIPTION
## Summary

- Bump the `TreeSitterSwift` generated-files revision from `0.7.2-with-generated-files` to `0.7.3-with-generated-files`.
- Regenerate `Alas.xcodeproj` with `xcodegen` and update `Package.resolved` to the same revision.

## Audit notes

- Vendored tree-sitter grammars (`CSS`, `HCL`, `JavaScript`, `Lua`, `Python`, `YAML`) are already at their latest upstream semver tags.
- Other direct tree-sitter grammar package pins are already current.
- `tree-sitter` runtime has a newer `v0.26.10`, but `swift-tree-sitter 0.25.0` constrains it to `.upToNextMinor(from: "0.25.0")`, so the runtime stays at `0.25.10`.

## Verification

- `rtk xcodegen`
- `rtk xcodebuild -resolvePackageDependencies -project Alas.xcodeproj -scheme Alas`
- `ALAS_FFF_TARGET_ARCH=arm64 rtk xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -only-testing:AlasTests/TreeSitterHighlighterTests test`
- `ALAS_FFF_TARGET_ARCH=arm64 rtk xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -quiet build`

Full `xcodebuild ... test` was started locally, but `xcodebuild` hung silently with no active test child after the focused tree-sitter suite and full app build passed.