### PR TITLE
fix(acp): Shorten ACP SQLite busy timeout on main

### DIFF
--- a/Alas/Sources/ACP/Protocol/ACPStdioClient.swift
+++ b/Alas/Sources/ACP/Protocol/ACPStdioClient.swift
@@ -241,10 +241,10 @@ final class ACPStdioClient: ACPClient, @unchecked Sendable {
     // MARK: - Outbound
 
     func send(_ request: ACPRequest) async throws -> ACPResponse {
-        stateLock.lock()
-        nextId += 1
-        let id = JSONRPCID.number(nextId)
-        stateLock.unlock()
+        let id = stateLock.withLock {
+            nextId += 1
+            return JSONRPCID.number(nextId)
+        }
 
         let body = try Self.encode(envelopeFor: request, id: id)
         let data: Data = try await withCheckedThrowingContinuation { (cont: CheckedContinuation<Data, Error>) in

--- a/Alas/Sources/ACP/Session/ACPSessionManager.swift
+++ b/Alas/Sources/ACP/Session/ACPSessionManager.swift
@@ -1,4 +1,5 @@
 import Foundation
+import SQLite3
 
 private struct ACPTranscriptScrollMemory: Equatable {
     var anchorMessageId: String?
@@ -25,6 +26,7 @@ final class ACPSessionManager: ObservableObject {
     let worktreeId: String
     let worktreePath: String
     let store: ACPSessionStore
+    private let leaseStore: ACPSessionStore
     let changeNotifier: ACPChangeNotifier
     /// Called by each runner's write handler to check whether the target path
     /// has an open, dirty editor buffer. `nil` disables the check (no notices).
@@ -90,10 +92,10 @@ final class ACPSessionManager: ObservableObject {
     /// its heartbeat stands down (~5s). Trusting the in-memory set alone would
     /// let a phone connected to the old owner keep writing into a session
     /// another instance now drives — corrupting the active conversation. So we
-    /// also consult the store row via `anotherLiveInstanceOwnsLease`, the same
-    /// guard the local write path (`holdsLeaseForWrite`) relies on.
+    /// also consult the store row via `canWriteSession`, the same fail-closed
+    /// ownership check the manager write paths rely on.
     func isWriter(for id: ACPSession.ID) -> Bool {
-        _ownedLeases.contains(id) && !anotherLiveInstanceOwnsLease(sessionId: id)
+        _ownedLeases.contains(id) && canWriteSession(sessionId: id)
     }
 
     /// Submit a prompt using the same path the local composer uses (`.auto`
@@ -171,6 +173,8 @@ final class ACPSessionManager: ObservableObject {
 
     /// Sessions for which THIS instance holds the writer lease (backing store).
     var _ownedLeases: Set<ACPSession.ID> = []
+    private var ownedLeaseTokens: [ACPSession.ID: String] = [:]
+    private var leaseReleaseGenerations: [ACPSession.ID: Int] = [:]
     /// Per-session periodic heartbeat tasks (backing store).
     var _heartbeatTasks: [ACPSession.ID: Task<Void, Never>] = [:]
     /// Per-session debounced write tasks for `composer_drafts`. The
@@ -179,8 +183,21 @@ final class ACPSessionManager: ObservableObject {
     /// flush on submit / delete). Cancelled and re-scheduled on each
     /// further keystroke so a typing burst produces one write.
     private var pendingDraftWrites: [ACPSession.ID: Task<Void, Never>] = [:]
+    private var draftFlushCandidates: Set<ACPSession.ID> = []
+    private struct SubmittedDraftRecovery {
+        let draft: ACPComposerDraft
+        let updatedAt: Int64
+        let submittedAfterSeq: Int64?
+    }
+    private struct PendingComposerDraftWrite {
+        let draft: ACPComposerDraft
+        let updatedAt: Int64
+    }
+    private var pendingSubmittedDraftRecoveries: [ACPSession.ID: SubmittedDraftRecovery] = [:]
+    private var pendingComposerDraftWrites: [ACPSession.ID: PendingComposerDraftWrite] = [:]
+    private var pendingComposerDraftPurges: Set<ACPSession.ID> = []
     private static let draftDebounceNanos: UInt64 = 300_000_000
-    private let hydrator: ACPSessionHydrator?
+    private let hydratorTask: Task<ACPSessionHydrator?, Never>?
     private let setupEvaluator: ACPSetupEvaluator
     private let connectionFactory: ACPConnectionFactory
     private var inFlightHydrations: [ACPSession.ID: Task<Void, Never>] = [:]
@@ -231,6 +248,7 @@ final class ACPSessionManager: ObservableObject {
     private var attachingSessions: Set<ACPSession.ID> = []
 
     init(worktreeId: String, worktreePath: String, store: ACPSessionStore,
+         leaseStore: ACPSessionStore? = nil,
          instanceId: String = UUID().uuidString,
          pid: Int64 = Int64(ProcessInfo.processInfo.processIdentifier),
          hydratorPath: String? = nil,
@@ -247,12 +265,18 @@ final class ACPSessionManager: ObservableObject {
         self.worktreeId = worktreeId
         self.worktreePath = worktreePath
         self.store = store
+        self.leaseStore = leaseStore ?? store
+        self.store.setBackgroundBusyRetryOwnerInstanceId(instanceId)
         self.onDirtyCheck = onDirtyCheck
         self.onLiveBufferRead = onLiveBufferRead
         self.onSessionTitleUpdated = onSessionTitleUpdated
         self.mcpProjectContextProvider = mcpProjectContextProvider
         self.changeNotifier = changeNotifier ?? DarwinChangeNotifier(worktreeId: worktreeId)
-        self.hydrator = hydratorPath.flatMap { try? ACPSessionHydrator(path: $0) }
+        self.hydratorTask = hydratorPath.map { path in
+            Task.detached(priority: .utility) {
+                try? ACPSessionHydrator(path: path)
+            }
+        }
         self.setupEvaluator = setupEvaluator ?? { spec in
             let checker = ACPSetupChecker(env: ProcessInfo.processInfo.environment)
             return await checker.evaluate(spec.setupCheck)
@@ -366,7 +390,7 @@ final class ACPSessionManager: ObservableObject {
     private func runHydration(id: ACPSession.ID, session: ACPSession) async {
         do {
             let result: HydrationResult
-            if let hydrator {
+            if let hydrator = await hydratorTask?.value {
                 result = try await hydrator.hydrate(sessionId: id)
             } else {
                 // No off-main hydrator (test fallback): perform the same
@@ -836,7 +860,7 @@ final class ACPSessionManager: ObservableObject {
     /// No-ops only when another live instance owns the writer lease (this pane
     /// is a mirror); the writer and not-yet-leased cases persist normally.
     func persist(_ s: ACPSession, preserveTitle: Bool = true) {
-        guard !anotherLiveInstanceOwnsLease(sessionId: s.id) else { return }
+        guard canWriteSession(sessionId: s.id) else { return }
         guard let row = try? store.loadSession(id: s.id) else { return }
         let now = Int64(Date().timeIntervalSince1970)
         try? store.upsertSession(.init(
@@ -881,7 +905,7 @@ final class ACPSessionManager: ObservableObject {
     /// the in-memory session and SQLite in one call. No-ops only when
     /// another live instance owns the writer lease (this pane is a mirror).
     func renameSession(id: ACPSession.ID, title: String, source: ACPSessionTitleSource) {
-        guard !anotherLiveInstanceOwnsLease(sessionId: id) else { return }
+        guard canWriteSession(sessionId: id) else { return }
         guard let session = sessions[id] else { return }
         let trimmed = title.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !trimmed.isEmpty else { return }
@@ -916,17 +940,30 @@ final class ACPSessionManager: ObservableObject {
         // In-memory state updates instantly so cross-tab restore is live.
         // The SQLite write is debounced so a typing burst produces at
         // most one upsert per ~300ms instead of one per keystroke.
+        pendingSubmittedDraftRecoveries[session.id] = nil
+        pendingComposerDraftWrites[session.id] = nil
+        pendingComposerDraftPurges.remove(session.id)
         session.replaceComposerDraft(draft)
         scheduleDraftPersistence(for: session.id)
     }
 
     func clearComposerDraft(for session: ACPSession) {
+        pendingSubmittedDraftRecoveries[session.id] = nil
+        pendingComposerDraftWrites[session.id] = nil
+        pendingComposerDraftPurges.remove(session.id)
         session.replaceComposerDraft(.empty)
         cancelPendingDraftWrite(for: session.id)
-        try? store.deleteComposerDraft(sessionId: session.id)
+        draftFlushCandidates.insert(session.id)
+        do {
+            try store.deleteComposerDraft(sessionId: session.id)
+            draftFlushCandidates.remove(session.id)
+        } catch {
+            pendingComposerDraftPurges.insert(session.id)
+        }
     }
 
     private func scheduleDraftPersistence(for sessionId: ACPSession.ID) {
+        draftFlushCandidates.insert(sessionId)
         pendingDraftWrites[sessionId]?.cancel()
         pendingDraftWrites[sessionId] = Task { [weak self] in
             try? await Task.sleep(nanoseconds: Self.draftDebounceNanos)
@@ -935,19 +972,86 @@ final class ACPSessionManager: ObservableObject {
         }
     }
 
-    private func flushPendingDraftWrite(for sessionId: ACPSession.ID) {
+    private func flushPendingDraftWrite(for sessionId: ACPSession.ID, using targetStore: ACPSessionStore? = nil) {
         pendingDraftWrites[sessionId] = nil
+        let targetStore = targetStore ?? store
+        if pendingComposerDraftPurges.contains(sessionId) {
+            do {
+                try targetStore.deleteComposerDraft(sessionId: sessionId)
+                pendingComposerDraftPurges.remove(sessionId)
+                pendingComposerDraftWrites[sessionId] = nil
+                draftFlushCandidates.remove(sessionId)
+                invalidateOriginalComposerDraftRetryIfNeeded(sessionId: sessionId, targetStore: targetStore)
+            } catch {
+                draftFlushCandidates.insert(sessionId)
+            }
+            return
+        }
+        if let recovery = pendingSubmittedDraftRecoveries[sessionId] {
+            do {
+                try targetStore.upsertComposerDraft(
+                    sessionId: sessionId,
+                    draft: recovery.draft,
+                    updatedAt: recovery.updatedAt,
+                    submittedRecovery: true,
+                    submittedAfterSeq: recovery.submittedAfterSeq
+                )
+                pendingSubmittedDraftRecoveries[sessionId] = nil
+                pendingComposerDraftWrites[sessionId] = nil
+                draftFlushCandidates.remove(sessionId)
+                invalidateOriginalComposerDraftRetryIfNeeded(sessionId: sessionId, targetStore: targetStore)
+            } catch {
+                draftFlushCandidates.insert(sessionId)
+            }
+            return
+        }
+        if let pending = pendingComposerDraftWrites[sessionId],
+           sessions[sessionId] == nil {
+            do {
+                if pending.draft.isEmpty {
+                    try targetStore.deleteComposerDraft(sessionId: sessionId)
+                } else {
+                    try targetStore.upsertComposerDraft(
+                        sessionId: sessionId,
+                        draft: pending.draft,
+                        updatedAt: pending.updatedAt
+                    )
+                }
+                pendingComposerDraftWrites[sessionId] = nil
+                draftFlushCandidates.remove(sessionId)
+                invalidateOriginalComposerDraftRetryIfNeeded(sessionId: sessionId, targetStore: targetStore)
+            } catch {
+                draftFlushCandidates.insert(sessionId)
+            }
+            return
+        }
         // Write the LATEST in-memory state, not whatever was captured at
         // schedule time — additional keystrokes may have come in during
         // the debounce window.
         guard let session = sessions[sessionId] else { return }
         let draft = session.composerDraft
-        if draft.isEmpty {
-            try? store.deleteComposerDraft(sessionId: sessionId)
-        } else {
-            let now = Int64(Date().timeIntervalSince1970)
-            try? store.upsertComposerDraft(sessionId: sessionId, draft: draft, updatedAt: now)
+        let now = Int64(Date().timeIntervalSince1970)
+        do {
+            if draft.isEmpty {
+                try targetStore.deleteComposerDraft(sessionId: sessionId)
+            } else {
+                try targetStore.upsertComposerDraft(sessionId: sessionId, draft: draft, updatedAt: now)
+            }
+            pendingComposerDraftWrites[sessionId] = nil
+            draftFlushCandidates.remove(sessionId)
+            invalidateOriginalComposerDraftRetryIfNeeded(sessionId: sessionId, targetStore: targetStore)
+        } catch {
+            pendingComposerDraftWrites[sessionId] = PendingComposerDraftWrite(draft: draft, updatedAt: now)
+            draftFlushCandidates.insert(sessionId)
         }
+    }
+
+    private func invalidateOriginalComposerDraftRetryIfNeeded(
+        sessionId: ACPSession.ID,
+        targetStore: ACPSessionStore
+    ) {
+        guard targetStore !== store else { return }
+        store.invalidatePendingComposerDraftRetry(sessionId: sessionId)
     }
 
     private func cancelPendingDraftWrite(for sessionId: ACPSession.ID) {
@@ -959,8 +1063,21 @@ final class ACPSessionManager: ObservableObject {
     /// app-termination, scene resign, or tests that need a deterministic
     /// post-write read.
     func flushPendingDraftWrites() {
-        for sessionId in Array(pendingDraftWrites.keys) {
+        let sessionIds = Set(pendingDraftWrites.keys).union(draftFlushCandidates)
+        for sessionId in Array(sessionIds) {
             flushPendingDraftWrite(for: sessionId)
+        }
+    }
+
+    /// Flush pending draft writes during app termination using a separate
+    /// default-timeout connection. The normal store intentionally has a short
+    /// main-actor timeout and may queue retries, but process exit cannot wait
+    /// for those background retries.
+    func flushPendingDraftWritesForTermination() {
+        let terminationStore = (try? ACPSessionStore(path: store.path)) ?? store
+        let sessionIds = Set(pendingDraftWrites.keys).union(draftFlushCandidates)
+        for sessionId in Array(sessionIds) {
+            flushPendingDraftWrite(for: sessionId, using: terminationStore)
         }
     }
 
@@ -982,7 +1099,7 @@ final class ACPSessionManager: ObservableObject {
     /// mirror must not overwrite the active owner's queue. The writer and
     /// not-yet-leased cases persist normally.
     func persistQueue(for session: ACPSession) {
-        guard !anotherLiveInstanceOwnsLease(sessionId: session.id) else { return }
+        guard canWriteSession(sessionId: session.id) else { return }
         try? store.upsertQueue(sessionId: session.id, items: session.queue)
     }
 
@@ -1008,16 +1125,35 @@ final class ACPSessionManager: ObservableObject {
         let sid = session.id
         pendingDraftWrites[sid]?.cancel()
         pendingDraftWrites[sid] = nil
+        pendingSubmittedDraftRecoveries[sid] = nil
+        pendingComposerDraftWrites[sid] = nil
+        pendingComposerDraftPurges.remove(sid)
         if !submitted.isEmpty {
             let now = Int64(Date().timeIntervalSince1970)
             let submittedAfterSeq = try? store.latestMessageSeq(sessionId: sid)
-            try? store.upsertComposerDraft(
-                sessionId: sid,
+            let recovery = SubmittedDraftRecovery(
                 draft: submitted,
                 updatedAt: now,
-                submittedRecovery: true,
                 submittedAfterSeq: submittedAfterSeq
             )
+            pendingSubmittedDraftRecoveries[sid] = recovery
+            draftFlushCandidates.insert(sid)
+            do {
+                try store.upsertComposerDraft(
+                    sessionId: sid,
+                    draft: submitted,
+                    updatedAt: now,
+                    submittedRecovery: true,
+                    submittedAfterSeq: submittedAfterSeq
+                )
+                pendingSubmittedDraftRecoveries[sid] = nil
+                pendingComposerDraftWrites[sid] = nil
+                draftFlushCandidates.remove(sid)
+            } catch {
+                draftFlushCandidates.insert(sid)
+            }
+        } else {
+            draftFlushCandidates.remove(sid)
         }
         session.replaceComposerDraft(.empty)
         return session.composerDraftRevision
@@ -1033,7 +1169,15 @@ final class ACPSessionManager: ObservableObject {
         guard session.composerDraftRevision == suspendedRevision,
               session.composerDraft.isEmpty
         else { return }
-        try? store.deleteComposerDraft(sessionId: session.id)
+        pendingSubmittedDraftRecoveries[session.id] = nil
+        pendingComposerDraftWrites[session.id] = nil
+        pendingComposerDraftPurges.insert(session.id)
+        draftFlushCandidates.insert(session.id)
+        do {
+            try store.deleteComposerDraft(sessionId: session.id)
+            pendingComposerDraftPurges.remove(session.id)
+            draftFlushCandidates.remove(session.id)
+        } catch {}
     }
 
     /// Restore the suspended draft back into memory when the prompt
@@ -1050,9 +1194,16 @@ final class ACPSessionManager: ObservableObject {
         guard session.composerDraftRevision == suspendedRevision,
               session.composerDraft.isEmpty
         else { return }
+        pendingSubmittedDraftRecoveries[session.id] = nil
+        pendingComposerDraftWrites[session.id] = nil
+        pendingComposerDraftPurges.remove(session.id)
         session.replaceComposerDraft(submitted)
         let now = Int64(Date().timeIntervalSince1970)
-        try? store.upsertComposerDraft(sessionId: session.id, draft: submitted, updatedAt: now)
+        draftFlushCandidates.insert(session.id)
+        do {
+            try store.upsertComposerDraft(sessionId: session.id, draft: submitted, updatedAt: now)
+            draftFlushCandidates.remove(session.id)
+        } catch {}
     }
 
     func refreshRecent() {
@@ -1156,17 +1307,254 @@ extension ACPSessionManager {
     /// now hold the lease. Idempotent for a lease we already own.
     @discardableResult
     func acquireWriterLease(sessionId: ACPSession.ID) -> Bool {
-        let now = Int64(Date().timeIntervalSince1970)
-        let won = (try? store.claimLease(
-            sessionId: sessionId, instanceId: instanceId, pid: pid,
-            now: now, staleAfter: Self.leaseStaleAfter)) ?? false
-        if won { _ownedLeases.insert(sessionId) } else { _ownedLeases.remove(sessionId) }
-        return won
+        for attempt in 0..<3 {
+            let now = Int64(Date().timeIntervalSince1970)
+            let leaseToken = UUID().uuidString
+            do {
+                let won = try leaseStore.claimLease(
+                    sessionId: sessionId, instanceId: instanceId, pid: pid,
+                    now: now, staleAfter: Self.leaseStaleAfter, leaseToken: leaseToken)
+                if won {
+                    invalidatePendingLeaseRelease(sessionId: sessionId)
+                    _ownedLeases.insert(sessionId)
+                    ownedLeaseTokens[sessionId] = (try? leaseStore.loadLease(sessionId: sessionId))?.token ?? leaseToken
+                } else {
+                    _ownedLeases.remove(sessionId)
+                    ownedLeaseTokens.removeValue(forKey: sessionId)
+                }
+                return won
+            } catch {
+                guard Self.isSQLiteBusy(error) else {
+                    _ownedLeases.remove(sessionId)
+                    ownedLeaseTokens.removeValue(forKey: sessionId)
+                    return false
+                }
+                if attempt < 2 {
+                    Thread.sleep(forTimeInterval: 0.05)
+                    continue
+                }
+                _ownedLeases.remove(sessionId)
+                ownedLeaseTokens.removeValue(forKey: sessionId)
+                return false
+            }
+        }
+        return false
+    }
+
+    private func acquireWriterLeaseOffMain(sessionId: ACPSession.ID) async -> Bool {
+        let path = leaseStore.path
+        let instanceId = instanceId
+        let pid = pid
+        let deadline = Date().addingTimeInterval(
+            Double(ACPSessionStore.defaultBusyTimeoutMilliseconds) / 1_000.0)
+        while true {
+            let attempt = await Task.detached(priority: .utility) {
+                Self.tryClaimWriterLease(
+                    path: path,
+                    sessionId: sessionId,
+                    instanceId: instanceId,
+                    pid: pid
+                )
+            }.value
+            switch attempt {
+            case .won(let token):
+                invalidatePendingLeaseRelease(sessionId: sessionId)
+                _ownedLeases.insert(sessionId)
+                ownedLeaseTokens[sessionId] = token
+                return true
+            case .ownedByOther, .failed:
+                _ownedLeases.remove(sessionId)
+                ownedLeaseTokens.removeValue(forKey: sessionId)
+                return false
+            case .busy:
+                guard Date() < deadline else {
+                    _ownedLeases.remove(sessionId)
+                    ownedLeaseTokens.removeValue(forKey: sessionId)
+                    return false
+                }
+                try? await Task.sleep(nanoseconds: 50_000_000)
+            }
+        }
+    }
+
+    nonisolated private static func tryClaimWriterLease(
+        path: String,
+        sessionId: ACPSession.ID,
+        instanceId: String,
+        pid: Int64
+    ) -> LeaseClaimAttempt {
+        do {
+            let store = try ACPSessionStore(
+                path: path,
+                busyTimeoutMilliseconds: ACPSessionStore.mainActorBusyTimeoutMilliseconds
+            )
+            let now = Int64(Date().timeIntervalSince1970)
+            let leaseToken = UUID().uuidString
+            let won = try store.claimLease(
+                sessionId: sessionId,
+                instanceId: instanceId,
+                pid: pid,
+                now: now,
+                staleAfter: leaseStaleAfter,
+                leaseToken: leaseToken
+            )
+            let storedToken = (try? store.loadLease(sessionId: sessionId))?.token ?? leaseToken
+            return won ? .won(token: storedToken) : .ownedByOther
+        } catch {
+            return Self.isSQLiteBusy(error) ? .busy : .failed
+        }
+    }
+
+    private func seizeWriterLeaseOffMain(sessionId: ACPSession.ID) async -> String? {
+        let path = leaseStore.path
+        let instanceId = instanceId
+        let pid = pid
+        let attempt = await Task.detached(priority: .userInitiated) {
+            Self.trySeizeWriterLease(
+                path: path,
+                sessionId: sessionId,
+                instanceId: instanceId,
+                pid: pid
+            )
+        }.value
+        switch attempt {
+        case .won(let token):
+            return token
+        case .failed:
+            return nil
+        }
+    }
+
+    nonisolated private static func trySeizeWriterLease(
+        path: String,
+        sessionId: ACPSession.ID,
+        instanceId: String,
+        pid: Int64
+    ) -> LeaseSeizeAttempt {
+        do {
+            let store = try ACPSessionStore(path: path)
+            let now = Int64(Date().timeIntervalSince1970)
+            let leaseToken = UUID().uuidString
+            try store.seizeLease(
+                sessionId: sessionId,
+                instanceId: instanceId,
+                pid: pid,
+                now: now,
+                leaseToken: leaseToken
+            )
+            let storedToken = (try? store.loadLease(sessionId: sessionId))?.token ?? leaseToken
+            return .won(token: storedToken)
+        } catch {
+            return .failed
+        }
+    }
+
+    private func releaseSeizedWriterLeaseOffMain(sessionId: ACPSession.ID, leaseToken: String) async {
+        let path = leaseStore.path
+        let instanceId = instanceId
+        await Task.detached(priority: .utility) {
+            do {
+                let store = try ACPSessionStore(path: path)
+                try store.releaseLease(sessionId: sessionId, instanceId: instanceId, leaseToken: leaseToken)
+            } catch {}
+        }.value
     }
 
     func releaseWriterLease(sessionId: ACPSession.ID) {
-        try? store.releaseLease(sessionId: sessionId, instanceId: instanceId)
+        let leaseToken = ownedLeaseTokens[sessionId]
+        do {
+            try leaseStore.releaseLease(sessionId: sessionId, instanceId: instanceId, leaseToken: leaseToken)
+            _ownedLeases.remove(sessionId)
+            ownedLeaseTokens.removeValue(forKey: sessionId)
+        } catch {
+            retryWriterLeaseRelease(sessionId: sessionId, leaseToken: leaseToken)
+            return
+        }
+    }
+
+    private func retryWriterLeaseRelease(sessionId: ACPSession.ID, leaseToken: String?) {
+        let path = leaseStore.path
+        let instanceId = instanceId
+        let retryWindow = TimeInterval(Self.leaseStaleAfter)
+        let generation = bumpLeaseReleaseGeneration(sessionId: sessionId)
+        Task.detached(priority: .utility) { [weak self] in
+            let deadline = Date().addingTimeInterval(retryWindow)
+            while !Task.isCancelled {
+                let shouldRelease = await MainActor.run {
+                    guard let self else { return true }
+                    return self.leaseReleaseGenerations[sessionId] == generation
+                }
+                guard shouldRelease else { return }
+                do {
+                    let retryStore = try ACPSessionStore(path: path, busyTimeoutMilliseconds: 0)
+                    try retryStore.releaseLease(
+                        sessionId: sessionId,
+                        instanceId: instanceId,
+                        leaseToken: leaseToken)
+                    await MainActor.run {
+                        self?.clearLocalLeaseOwnershipAfterReleaseAttempt(
+                            sessionId: sessionId,
+                            generation: generation
+                        )
+                    }
+                    return
+                } catch {
+                    if Date() >= deadline {
+                        await MainActor.run {
+                            self?.clearLocalLeaseOwnershipAfterReleaseAttempt(
+                                sessionId: sessionId,
+                                generation: generation
+                            )
+                        }
+                        return
+                    }
+                    try? await Task.sleep(nanoseconds: 250_000_000)
+                }
+            }
+        }
+    }
+
+    private func clearLocalLeaseOwnershipAfterReleaseAttempt(
+        sessionId: ACPSession.ID,
+        generation: Int
+    ) {
+        guard leaseReleaseGenerations[sessionId] == generation else { return }
         _ownedLeases.remove(sessionId)
+        ownedLeaseTokens.removeValue(forKey: sessionId)
+    }
+
+    private func bumpLeaseReleaseGeneration(sessionId: ACPSession.ID) -> Int {
+        let next = (leaseReleaseGenerations[sessionId] ?? 0) + 1
+        leaseReleaseGenerations[sessionId] = next
+        return next
+    }
+
+    private func invalidatePendingLeaseRelease(sessionId: ACPSession.ID) {
+        _ = bumpLeaseReleaseGeneration(sessionId: sessionId)
+    }
+
+    nonisolated private static func isSQLiteBusy(_ error: Error) -> Bool {
+        guard case SQLiteError.stepFailed(let code, _, _) = error else { return false }
+        return code == SQLITE_BUSY || code == SQLITE_LOCKED
+    }
+
+    private enum LeaseOwnershipStatus {
+        case ownedBySelf
+        case ownedByOtherLiveInstance
+        case noLiveOwner
+        case unknown
+    }
+
+    private enum LeaseClaimAttempt {
+        case won(token: String)
+        case ownedByOther
+        case busy
+        case failed
+    }
+
+    private enum LeaseSeizeAttempt {
+        case won(token: String)
+        case failed
     }
 
     /// True when this session is open here but owned by another live
@@ -1177,6 +1565,15 @@ extension ACPSessionManager {
         anotherLiveInstanceOwnsLease(sessionId: sessionId)
     }
 
+    private func canWriteSession(sessionId: ACPSession.ID) -> Bool {
+        switch leaseOwnershipStatus(sessionId: sessionId) {
+        case .ownedBySelf, .noLiveOwner:
+            return true
+        case .ownedByOtherLiveInstance, .unknown:
+            return false
+        }
+    }
+
     /// True when a DIFFERENT, live instance currently owns this session's
     /// lease in the store. Unlike `isMirror`, this does NOT short-circuit on
     /// our in-memory `_ownedLeases`: during a takeover the former owner keeps
@@ -1184,17 +1581,35 @@ extension ACPSessionManager {
     /// writes must consult the store row directly to avoid writing to a
     /// session another instance now owns.
     private func anotherLiveInstanceOwnsLease(sessionId: ACPSession.ID) -> Bool {
-        guard let lease = try? store.loadLease(sessionId: sessionId) else { return false }
-        return lease.ownerInstance != instanceId
-            && ACPProcessLiveness.pidAlive(lease.pid)
-            && lease.heartbeatAt >= Int64(Date().timeIntervalSince1970) - Self.leaseStaleAfter
+        leaseOwnershipStatus(sessionId: sessionId) == .ownedByOtherLiveInstance
+    }
+
+    private func leaseOwnershipStatus(sessionId: ACPSession.ID) -> LeaseOwnershipStatus {
+        for attempt in 0..<3 {
+            do {
+                let lease = try leaseStore.loadLease(sessionId: sessionId)
+                guard let lease else { return .noLiveOwner }
+                if lease.ownerInstance == instanceId {
+                    return .ownedBySelf
+                }
+                if ACPProcessLiveness.pidAlive(lease.pid)
+                    && lease.heartbeatAt >= Int64(Date().timeIntervalSince1970) - Self.leaseStaleAfter {
+                    return .ownedByOtherLiveInstance
+                }
+                return .noLiveOwner
+            } catch {
+                guard Self.isSQLiteBusy(error), attempt < 2 else { return .unknown }
+                Thread.sleep(forTimeInterval: 0.05)
+            }
+        }
+        return .unknown
     }
 
     /// Whether the instance currently writing this mirrored session is
     /// actively streaming (drives the mirror's busy spinner). Reads the
     /// lease status written by the owner's heartbeat.
     func mirrorIsBusy(sessionId: ACPSession.ID) -> Bool {
-        guard let lease = try? store.loadLease(sessionId: sessionId) else { return false }
+        guard let lease = try? leaseStore.loadLease(sessionId: sessionId) else { return false }
         return lease.status == "busy"
     }
 
@@ -1210,20 +1625,34 @@ extension ACPSessionManager {
     func heartbeatTick(sessionId: ACPSession.ID) -> Bool {
         guard _ownedLeases.contains(sessionId) else { return false }
         let now = Int64(Date().timeIntervalSince1970)
-        if let lease = try? store.loadLease(sessionId: sessionId) {
+        let lease: ACPSessionLease?
+        do {
+            lease = try leaseStore.loadLease(sessionId: sessionId)
+        } catch {
+            return false
+        }
+        if let lease {
             if lease.ownerInstance != instanceId {
                 return true   // taken over → stand down
             }
+            ownedLeaseTokens[sessionId] = lease.token
             // Still ours — refresh heartbeat + status.
             let status = runners[sessionId]?.session.transcript.streamingState == .streaming
                 ? "busy" : "idle"
-            try? store.refreshHeartbeat(
+            try? leaseStore.refreshHeartbeat(
                 sessionId: sessionId, instanceId: instanceId, now: now, status: status)
             return false
         } else {
             // Row missing but we believe we own it — re-assert ownership so
             // the session isn't left rowless and claimable by another instance.
-            try? store.seizeLease(sessionId: sessionId, instanceId: instanceId, pid: pid, now: now)
+            let leaseToken = ownedLeaseTokens[sessionId] ?? UUID().uuidString
+            try? leaseStore.seizeLease(
+                sessionId: sessionId,
+                instanceId: instanceId,
+                pid: pid,
+                now: now,
+                leaseToken: leaseToken)
+            ownedLeaseTokens[sessionId] = leaseToken
             return false
         }
     }
@@ -1282,6 +1711,7 @@ extension ACPSessionManager {
                 guard self._ownedLeases.contains(sessionId) else { return }
                 if self.heartbeatTick(sessionId: sessionId) {
                     self._ownedLeases.remove(sessionId)
+                    self.ownedLeaseTokens.removeValue(forKey: sessionId)
                     Task { await self.standDown(sessionId: sessionId) }
                 }
             }
@@ -1308,10 +1738,25 @@ extension ACPSessionManager {
     /// writer (re-attaching to the remote session via session/load inside
     /// `attach`). The previous owner stands down when its heartbeat sees
     /// it no longer owns the lease (within ~5s).
-    func takeOver(sessionId: ACPSession.ID) {
-        let now = Int64(Date().timeIntervalSince1970)
-        try? store.seizeLease(sessionId: sessionId, instanceId: instanceId, pid: pid, now: now)
+    @discardableResult
+    func takeOver(sessionId: ACPSession.ID) async -> Bool {
+        guard let leaseToken = await seizeWriterLeaseOffMain(sessionId: sessionId) else {
+            _ownedLeases.remove(sessionId)
+            ownedLeaseTokens.removeValue(forKey: sessionId)
+            return false
+        }
+        guard sessions[sessionId] != nil else {
+            await releaseSeizedWriterLeaseOffMain(sessionId: sessionId, leaseToken: leaseToken)
+            return false
+        }
+        completeTakeOver(sessionId: sessionId, leaseToken: leaseToken)
+        return true
+    }
+
+    private func completeTakeOver(sessionId: ACPSession.ID, leaseToken: String) {
+        invalidatePendingLeaseRelease(sessionId: sessionId)
         _ownedLeases.insert(sessionId)
+        ownedLeaseTokens[sessionId] = leaseToken
         changeNotifier.post()
         startHeartbeat(sessionId: sessionId)
         startWriterWatch(sessionId: sessionId)
@@ -1358,6 +1803,7 @@ extension ACPSessionManager {
         stopHeartbeat(sessionId: sessionId)
         stopWriterWatch(sessionId: sessionId)
         _ownedLeases.remove(sessionId)
+        ownedLeaseTokens.removeValue(forKey: sessionId)
         // We no longer own the lease — drop any not-yet-applied config so it
         // can't fire against a session another instance now drives.
         pendingModel.removeValue(forKey: sessionId)
@@ -1389,7 +1835,19 @@ extension ACPSessionManager {
     func isDisposedForTest() -> Bool { isDisposed }
 
     func ownsLeaseForTest(sessionId: ACPSession.ID) -> Bool {
-        (try? store.loadLease(sessionId: sessionId))?.ownerInstance == instanceId
+        (try? leaseStore.loadLease(sessionId: sessionId))?.ownerInstance == instanceId
+    }
+
+    func tracksOwnedLeaseForTest(sessionId: ACPSession.ID) -> Bool {
+        _ownedLeases.contains(sessionId)
+    }
+
+    func leaseReleaseGenerationForTest(sessionId: ACPSession.ID) -> Int? {
+        leaseReleaseGenerations[sessionId]
+    }
+
+    func clearLocalLeaseOwnershipAfterReleaseAttemptForTest(sessionId: ACPSession.ID, generation: Int) {
+        clearLocalLeaseOwnershipAfterReleaseAttempt(sessionId: sessionId, generation: generation)
     }
 
     /// True while an `attach` coroutine holds the lease for `sessionId`
@@ -1471,8 +1929,15 @@ extension ACPSessionManager {
     /// goes stale in 15 s if the attach coroutine is permanently wedged.
     func releaseAllOwnedLeases() {
         for sid in Array(_ownedLeases) where !attachingSessions.contains(sid) {
-            try? store.releaseLease(sessionId: sid, instanceId: instanceId)
-            _ownedLeases.remove(sid)
+            let leaseToken = ownedLeaseTokens[sid]
+            do {
+                try leaseStore.releaseLease(sessionId: sid, instanceId: instanceId, leaseToken: leaseToken)
+                _ownedLeases.remove(sid)
+                ownedLeaseTokens.removeValue(forKey: sid)
+            } catch {
+                retryWriterLeaseRelease(sessionId: sid, leaseToken: leaseToken)
+                continue
+            }
         }
     }
 
@@ -1546,7 +2011,7 @@ extension ACPSessionManager {
         guard let session = sessions[sessionId] else { return }
         let result: HydrationResult
         do {
-            if let hydrator {
+            if let hydrator = await hydratorTask?.value {
                 result = try await hydrator.mirrorSnapshot(sessionId: sessionId)
             } else {
                 result = try synchronousMirrorSnapshot(id: sessionId)
@@ -1642,9 +2107,15 @@ extension ACPSessionManager {
         // backfill wait) early-returns on the `.spawning` guard above
         // instead of racing into a duplicate runner.
         session.agentState = .spawning
+        if firstRunAttach {
+            guard await waitForPersistedSessionRow(sessionId: sessionId) else {
+                session.agentState = .idle
+                return
+            }
+        }
         // Only the lease holder runs a live agent + writes. If another
         // live instance owns this session, stay a read-only mirror.
-        guard acquireWriterLease(sessionId: sessionId) else {
+        guard await acquireWriterLeaseOffMain(sessionId: sessionId) else {
             session.agentState = .idle
             beginMirroring(sessionId: sessionId)
             return
@@ -1871,7 +2342,7 @@ extension ACPSessionManager {
                         result = try await connection.newSession(cwd: worktreePath, mcpServers: mcpPlan.wireServers)
                         if session.hasConversationTranscript {
                             shouldHoldQueueForRecovery = true
-                            if !anotherLiveInstanceOwnsLease(sessionId: sessionId) {
+                            if canWriteSession(sessionId: sessionId) {
                                 persistContextRecoveryPending(sessionId: sessionId, pending: true)
                             }
                         }
@@ -1924,7 +2395,7 @@ extension ACPSessionManager {
                             // Guard the store write: if another instance took over
                             // while we were awaiting loadSession/newSession, do not
                             // persist recovery state to a session we no longer own.
-                            if !anotherLiveInstanceOwnsLease(sessionId: sessionId) {
+                            if canWriteSession(sessionId: sessionId) {
                                 persistContextRecoveryPending(sessionId: sessionId, pending: true)
                             }
                         }
@@ -1948,7 +2419,7 @@ extension ACPSessionManager {
                     // Guard the store write: if another instance took over
                     // while we were awaiting newSession, do not persist
                     // recovery state to a session we no longer own.
-                    if !anotherLiveInstanceOwnsLease(sessionId: sessionId) {
+                    if canWriteSession(sessionId: sessionId) {
                         persistContextRecoveryPending(sessionId: sessionId, pending: true)
                     }
                 }
@@ -1976,11 +2447,14 @@ extension ACPSessionManager {
             // persist for a session we no longer (or never will) own.
             // `attachSucceeded` stays false so the defer releases the lease
             // and stops the heartbeat/writerWatch.
-            if isDisposed || anotherLiveInstanceOwnsLease(sessionId: sessionId) {
+            let ownershipStatus = leaseOwnershipStatus(sessionId: sessionId)
+            if isDisposed || ownershipStatus == .ownedByOtherLiveInstance || ownershipStatus == .unknown {
                 await connection.shutdown()
                 startedRunner?.stop()
                 session.agentState = .idle
-                if !isDisposed { beginMirroring(sessionId: sessionId) }   // don't start a mirror on a disposed manager
+                if !isDisposed, ownershipStatus == .ownedByOtherLiveInstance {
+                    beginMirroring(sessionId: sessionId)
+                }
                 return
             }
             session.remoteSessionId = result.sessionId
@@ -2041,6 +2515,32 @@ extension ACPSessionManager {
             startedRunner?.stop()
             await connection.shutdown()
         }
+    }
+
+    private func waitForPersistedSessionRow(sessionId: ACPSession.ID) async -> Bool {
+        let storePath = store.path
+        return await Task.detached(priority: .utility) {
+            let deadline = Date().addingTimeInterval(
+                Double(ACPSessionStore.defaultBusyTimeoutMilliseconds) / 1_000.0)
+            while Date() < deadline {
+                guard let pollingStore = try? ACPSessionStore(
+                    path: storePath,
+                    runtimeBusyTimeoutMilliseconds: ACPSessionStore.mainActorBusyTimeoutMilliseconds
+                ) else {
+                    try? await Task.sleep(nanoseconds: 50_000_000)
+                    continue
+                }
+                if (try? pollingStore.loadSession(id: sessionId)) != nil {
+                    return true
+                }
+                try? await Task.sleep(nanoseconds: 50_000_000)
+            }
+            guard let pollingStore = try? ACPSessionStore(
+                path: storePath,
+                runtimeBusyTimeoutMilliseconds: ACPSessionStore.mainActorBusyTimeoutMilliseconds
+            ) else { return false }
+            return (try? pollingStore.loadSession(id: sessionId)) != nil
+        }.value
     }
 
     /// Idempotent recovery entry point. Called by the composer when the

--- a/Alas/Sources/ACP/Session/ACPSessionRunner.swift
+++ b/Alas/Sources/ACP/Session/ACPSessionRunner.swift
@@ -154,7 +154,10 @@ final class ACPSessionRunner {
             session: session,
             log: ACPPermissionDecisionLog(store: store, canWrite: {
                 guard let id = _ownerInstanceId else { return true }
-                return (try? _store.loadLease(sessionId: _sessionId))?.ownerInstance == id
+                return Self.leaseReadAllowsWrite(
+                    store: _store,
+                    sessionId: _sessionId,
+                    ownerInstanceId: id)
             })
         )
     }
@@ -1579,7 +1582,22 @@ extension ACPSessionRunner {
     /// without a lease), gating is disabled and writes always proceed.
     private func holdsLeaseForWrite() -> Bool {
         guard let ownerInstanceId else { return true }
-        return (try? store.loadLease(sessionId: sessionId))?.ownerInstance == ownerInstanceId
+        return Self.leaseReadAllowsWrite(
+            store: store,
+            sessionId: sessionId,
+            ownerInstanceId: ownerInstanceId)
+    }
+
+    private static func leaseReadAllowsWrite(
+        store: ACPSessionStore,
+        sessionId: String,
+        ownerInstanceId: String
+    ) -> Bool {
+        do {
+            return try store.loadLease(sessionId: sessionId)?.ownerInstance == ownerInstanceId
+        } catch {
+            return false
+        }
     }
 
     private func shouldBatchStreamingPersist(

--- a/Alas/Sources/ACP/Session/ACPSessionStore.swift
+++ b/Alas/Sources/ACP/Session/ACPSessionStore.swift
@@ -1,20 +1,43 @@
 import Foundation
 
 final class ACPSessionStore {
-    static let targetSchemaVersion = 10
+    static let targetSchemaVersion = 11
+    static let defaultBusyTimeoutMilliseconds: Int32 = 5_000
+    static let mainActorBusyTimeoutMilliseconds: Int32 = 100
+    let path: String
     let db: SQLiteDatabase
 
-    init(path: String) throws {
+    init(
+        path: String,
+        busyTimeoutMilliseconds: Int32 = ACPSessionStore.defaultBusyTimeoutMilliseconds,
+        runtimeBusyTimeoutMilliseconds: Int32? = nil,
+        backgroundBusyRetryMilliseconds: Int32? = nil
+    ) throws {
+        self.path = path
         try? FileManager.default.createDirectory(
             at: URL(fileURLWithPath: path).deletingLastPathComponent(),
             withIntermediateDirectories: true)
-        self.db = try SQLiteDatabase(path: path)
+        self.db = try SQLiteDatabase(
+            path: path,
+            busyTimeoutMilliseconds: busyTimeoutMilliseconds)
         try migrate()
+        if let runtimeBusyTimeoutMilliseconds {
+            db.setBusyTimeout(milliseconds: runtimeBusyTimeoutMilliseconds)
+        }
+        db.setBusyRetryTimeout(milliseconds: backgroundBusyRetryMilliseconds)
     }
 
     func currentSchemaVersion() throws -> Int {
         let rows = try db.query("SELECT version FROM schema_version LIMIT 1")
         return (rows.first?["version"] as? Int64).map(Int.init) ?? 0
+    }
+
+    func setBackgroundBusyRetryOwnerInstanceId(_ ownerInstanceId: String?) {
+        db.setBusyRetryOwnerInstanceId(ownerInstanceId)
+    }
+
+    func invalidatePendingComposerDraftRetry(sessionId: String) {
+        db.invalidateBusyRetry(generationKey: "composer_drafts:\(sessionId)")
     }
 
     private func migrate() throws {
@@ -35,6 +58,7 @@ final class ACPSessionStore {
         if current < 8 { try migrate_to_v8() }
         if current < 9 { try migrate_to_v9() }
         if current < 10 { try migrate_to_v10() }
+        if current < 11 { try migrate_to_v11() }
         try recoverFromConcurrentWriters()
         if current == 0 {
             try db.exec("INSERT INTO schema_version (version) VALUES (?)", bindings: [Int64(Self.targetSchemaVersion)])
@@ -183,6 +207,16 @@ final class ACPSessionStore {
     private func migrate_to_v10() throws {
         try db.exec("ALTER TABLE composer_drafts ADD COLUMN submitted_after_seq INTEGER")
     }
+
+    private func migrate_to_v11() throws {
+        guard try !table("session_leases", hasColumn: "lease_token") else { return }
+        try db.exec("ALTER TABLE session_leases ADD COLUMN lease_token TEXT NOT NULL DEFAULT ''")
+    }
+
+    private func table(_ tableName: String, hasColumn columnName: String) throws -> Bool {
+        let rows = try db.query("PRAGMA table_info(\(tableName))")
+        return rows.contains { $0["name"] as? String == columnName }
+    }
 }
 
 struct ACPSessionLease: Equatable {
@@ -191,6 +225,7 @@ struct ACPSessionLease: Equatable {
     let pid: Int64
     let heartbeatAt: Int64
     let status: String   // "idle" | "busy"
+    let token: String
 }
 
 enum ACPSessionOrigin: String, Codable, Equatable {
@@ -250,7 +285,7 @@ extension ACPSessionStore {
             auto_run = excluded.auto_run,
             updated_at = excluded.updated_at,
             last_opened_at = excluded.last_opened_at,
-            archived = excluded.archived
+            archived = CASE WHEN sessions.archived = 1 THEN 1 ELSE excluded.archived END
         """, bindings: [
             s.id, s.agentId, s.title, s.titleSource.rawValue, s.remoteSessionId, s.origin.rawValue,
             s.contextRecoveryPending ? 1 : 0,
@@ -389,7 +424,8 @@ extension ACPSessionStore {
         SET title = ?, title_source = ?, updated_at = ?
         WHERE id = ? AND archived = 0 AND title_source = ?
         """, bindings: [title, ACPSessionTitleSource.generated.rawValue, updatedAt, id,
-                         ACPSessionTitleSource.placeholder.rawValue]) > 0
+                         ACPSessionTitleSource.placeholder.rawValue],
+            retryOnBusy: true) > 0
     }
 
     func updateGeneratedTitleIfNotManual(id: String, title: String, updatedAt: Int64) throws -> Bool {
@@ -398,7 +434,8 @@ extension ACPSessionStore {
         SET title = ?, title_source = ?, updated_at = ?
         WHERE id = ? AND archived = 0 AND title_source != ?
         """, bindings: [title, ACPSessionTitleSource.generated.rawValue, updatedAt, id,
-                         ACPSessionTitleSource.manual.rawValue]) > 0
+                         ACPSessionTitleSource.manual.rawValue],
+            retryOnBusy: true) > 0
     }
 
     func clearGeneratedTitleIfNotManual(id: String, updatedAt: Int64) throws -> Bool {
@@ -407,7 +444,8 @@ extension ACPSessionStore {
         SET title = ?, title_source = ?, updated_at = ?
         WHERE id = ? AND archived = 0 AND title_source != ?
         """, bindings: ["New session", ACPSessionTitleSource.placeholder.rawValue, updatedAt, id,
-                         ACPSessionTitleSource.manual.rawValue]) > 0
+                         ACPSessionTitleSource.manual.rawValue],
+            retryOnBusy: true) > 0
     }
 
     func appendMessage(sessionId: String, id: String, kind: String, seq: Int64, payload: Data, createdAt: Int64) throws {
@@ -424,7 +462,8 @@ extension ACPSessionStore {
     func updateMessageRow(id: String, kind: String, seq: Int64, payload: Data) throws -> Bool {
         try db.execChanges(
             "UPDATE messages SET kind = ?, seq = ?, payload = ? WHERE id = ?",
-            bindings: [kind, seq, payload, id]
+            bindings: [kind, seq, payload, id],
+            retryOnBusy: true
         ) > 0
     }
 
@@ -433,7 +472,7 @@ extension ACPSessionStore {
         UPDATE messages
         SET payload = ?
         WHERE id = ? AND payload = ?
-        """, bindings: [payload, id, expectedPayload]) > 0
+        """, bindings: [payload, id, expectedPayload], retryOnBusy: true) > 0
     }
 
     func loadMessagePayload(id: String) throws -> Data? {
@@ -549,7 +588,8 @@ extension ACPSessionStore {
             ownerInstance: r["owner_instance"] as? String ?? "",
             pid: (r["pid"] as? Int64) ?? 0,
             heartbeatAt: (r["heartbeat_at"] as? Int64) ?? 0,
-            status: r["status"] as? String ?? "idle")
+            status: r["status"] as? String ?? "idle",
+            token: r["lease_token"] as? String ?? "")
     }
 
     /// Atomically claim the writer role for `sessionId`. Returns true if
@@ -565,7 +605,8 @@ extension ACPSessionStore {
     /// same dead-owner lease can't both delete-then-insert and both win.
     /// A plain `BEGIN` (WAL) would defer the write lock and still race.
     func claimLease(sessionId: String, instanceId: String, pid: Int64,
-                    now: Int64, staleAfter: Int64) throws -> Bool {
+                    now: Int64, staleAfter: Int64,
+                    leaseToken: String = UUID().uuidString) throws -> Bool {
         let staleCutoff = now - staleAfter
         try db.exec("BEGIN IMMEDIATE")
         do {
@@ -579,16 +620,21 @@ extension ACPSessionStore {
                     bindings: [sessionId, existing.ownerInstance])
             }
             try db.exec("""
-            INSERT INTO session_leases (session_id, owner_instance, pid, heartbeat_at, status)
-            VALUES (?,?,?,?,'idle')
+            INSERT INTO session_leases (session_id, owner_instance, pid, heartbeat_at, status, lease_token)
+            VALUES (?,?,?,?,'idle',?)
             ON CONFLICT(session_id) DO UPDATE SET
                 owner_instance = excluded.owner_instance,
                 pid = excluded.pid,
                 heartbeat_at = excluded.heartbeat_at,
-                status = 'idle'
+                status = 'idle',
+                lease_token = CASE
+                    WHEN session_leases.owner_instance = excluded.owner_instance
+                    THEN session_leases.lease_token
+                    ELSE excluded.lease_token
+                END
             WHERE session_leases.owner_instance = excluded.owner_instance
                OR session_leases.heartbeat_at < ?
-            """, bindings: [sessionId, instanceId, pid, now, staleCutoff])
+            """, bindings: [sessionId, instanceId, pid, now, leaseToken, staleCutoff])
             let won = try loadLease(sessionId: sessionId)?.ownerInstance == instanceId
             try db.exec("COMMIT")
             return won
@@ -608,23 +654,36 @@ extension ACPSessionStore {
         """, bindings: [now, status, sessionId, instanceId])
     }
 
-    func releaseLease(sessionId: String, instanceId: String) throws {
-        try db.exec(
-            "DELETE FROM session_leases WHERE session_id = ? AND owner_instance = ?",
-            bindings: [sessionId, instanceId])
+    func releaseLease(sessionId: String, instanceId: String, leaseToken: String? = nil) throws {
+        if let leaseToken {
+            try db.exec(
+                "DELETE FROM session_leases WHERE session_id = ? AND owner_instance = ? AND lease_token = ?",
+                bindings: [sessionId, instanceId, leaseToken])
+        } else {
+            try db.exec(
+                "DELETE FROM session_leases WHERE session_id = ? AND owner_instance = ?",
+                bindings: [sessionId, instanceId])
+        }
     }
 
     /// Forcibly seize the lease (explicit user takeover) regardless of
     /// the current owner's liveness.
-    func seizeLease(sessionId: String, instanceId: String, pid: Int64, now: Int64) throws {
+    func seizeLease(
+        sessionId: String,
+        instanceId: String,
+        pid: Int64,
+        now: Int64,
+        leaseToken: String = UUID().uuidString
+    ) throws {
         try db.exec("""
-        INSERT INTO session_leases (session_id, owner_instance, pid, heartbeat_at, status)
-        VALUES (?,?,?,?,'idle')
+        INSERT INTO session_leases (session_id, owner_instance, pid, heartbeat_at, status, lease_token)
+        VALUES (?,?,?,?,'idle',?)
         ON CONFLICT(session_id) DO UPDATE SET
             owner_instance = excluded.owner_instance,
             pid = excluded.pid,
             heartbeat_at = excluded.heartbeat_at,
-            status = 'idle'
-        """, bindings: [sessionId, instanceId, pid, now])
+            status = 'idle',
+            lease_token = excluded.lease_token
+        """, bindings: [sessionId, instanceId, pid, now, leaseToken])
     }
 }

--- a/Alas/Sources/ACP/UI/ACPSlashPicker.swift
+++ b/Alas/Sources/ACP/UI/ACPSlashPicker.swift
@@ -232,7 +232,7 @@ private struct MarqueeText: View {
 }
 
 private struct MarqueeTextWidthKey: PreferenceKey {
-    static var defaultValue: CGFloat = 0
+    static let defaultValue: CGFloat = 0
     static func reduce(value: inout CGFloat, nextValue: () -> CGFloat) {
         value = max(value, nextValue())
     }

--- a/Alas/Sources/ACP/UI/ACPTabView.swift
+++ b/Alas/Sources/ACP/UI/ACPTabView.swift
@@ -579,7 +579,9 @@ private struct ACPSessionView: View {
         .foregroundStyle(.secondary)
         .frame(maxWidth: .infinity, alignment: .leading)
         .overlay(alignment: .trailing) {
-            Button("Take over here") { manager.takeOver(sessionId: sessionId) }
+            Button("Take over here") {
+                Task { _ = await manager.takeOver(sessionId: sessionId) }
+            }
                 .controlSize(.small)
                 .padding(.trailing, 12)
         }

--- a/Alas/Sources/App/AppState.swift
+++ b/Alas/Sources/App/AppState.swift
@@ -2,6 +2,7 @@ import Foundation
 import AppKit
 import Observation
 import os
+import SQLite3
 
 @Observable
 @MainActor
@@ -3466,7 +3467,7 @@ final class AppState {
     /// debounce window.
     func flushAllACPComposerDrafts() {
         for manager in acpManagers.values {
-            manager.flushPendingDraftWrites()
+            manager.flushPendingDraftWritesForTermination()
         }
     }
 
@@ -3522,11 +3523,20 @@ final class AppState {
         if let existing = acpManagers[worktree.id] { return existing }
         let dbURL = Paths.acpSessionsDB(forWorktreeId: worktree.id)
         do {
-            let store = try ACPSessionStore(path: dbURL.path)
+            let store = try openACPStore(
+                path: dbURL.path,
+                busyTimeoutMilliseconds: ACPSessionStore.mainActorBusyTimeoutMilliseconds,
+                runtimeBusyTimeoutMilliseconds: ACPSessionStore.mainActorBusyTimeoutMilliseconds,
+                backgroundBusyRetryMilliseconds: ACPSessionStore.defaultBusyTimeoutMilliseconds)
+            let leaseStore = try openACPStore(
+                path: dbURL.path,
+                busyTimeoutMilliseconds: ACPSessionStore.mainActorBusyTimeoutMilliseconds,
+                runtimeBusyTimeoutMilliseconds: ACPSessionStore.mainActorBusyTimeoutMilliseconds)
             let mgr = ACPSessionManager(
                 worktreeId: worktree.id,
                 worktreePath: worktree.path.path,
                 store: store,
+                leaseStore: leaseStore,
                 instanceId: instanceId,
                 pid: Int64(ProcessInfo.processInfo.processIdentifier),
                 hydratorPath: dbURL.path,
@@ -3564,6 +3574,24 @@ final class AppState {
         }
     }
 
+    private func openACPStore(
+        path: String,
+        busyTimeoutMilliseconds: Int32 = ACPSessionStore.defaultBusyTimeoutMilliseconds,
+        runtimeBusyTimeoutMilliseconds: Int32? = nil,
+        backgroundBusyRetryMilliseconds: Int32? = nil
+    ) throws -> ACPSessionStore {
+        try ACPSessionStore(
+            path: path,
+            busyTimeoutMilliseconds: busyTimeoutMilliseconds,
+            runtimeBusyTimeoutMilliseconds: runtimeBusyTimeoutMilliseconds,
+            backgroundBusyRetryMilliseconds: backgroundBusyRetryMilliseconds)
+    }
+
+    private func isSQLiteBusy(_ error: Error) -> Bool {
+        guard case SQLiteError.stepFailed(let code, _, _) = error else { return false }
+        return code == SQLITE_BUSY || code == SQLITE_LOCKED
+    }
+
     /// Release the ACP session manager for the given worktree id.
     /// Called from `cleanupWorktreeState` when a worktree is
     /// removed/archived. Stops every attached runner (which cancels
@@ -3573,10 +3601,10 @@ final class AppState {
     /// after the UI was torn down.
     func disposeACPManager(for worktreeId: String) {
         guard let manager = acpManagers.removeValue(forKey: worktreeId) else { return }
-        // Flush any pending debounced draft writes before tearing the
-        // manager down — otherwise the last ~300ms of typing in any
-        // composer for this worktree never reaches SQLite.
-        manager.flushPendingDraftWrites()
+        // Flush pending draft writes through a default-timeout store before
+        // dropping the manager; otherwise a short-timeout busy failure can
+        // leave only a weak background retry behind as the store deallocates.
+        manager.flushPendingDraftWritesForTermination()
         #if DEBUG
         memoryDiagnostics.detach(worktreeId: worktreeId)
         #endif
@@ -4188,11 +4216,11 @@ extension AppState: RemoteSessionsProvider {
         return false
     }
 
-    func takeOver(for id: String) {
+    func takeOver(for id: String) async -> Bool {
         for mgr in acpManagers.values where mgr.liveSession(for: id) != nil {
-            mgr.takeOver(sessionId: id)
-            return
+            return await mgr.takeOver(sessionId: id)
         }
+        return false
     }
 
     /// `onResult` fires once (false when no manager owns the id, the manager

--- a/Alas/Sources/Remote/Gateway/RemoteSessionGateway.swift
+++ b/Alas/Sources/Remote/Gateway/RemoteSessionGateway.swift
@@ -85,15 +85,15 @@ final class RemoteSessionGateway {
                 content: content
             )
         case .takeOver(let id):
-            provider.takeOver(for: id)
-            // Takeover seizes the writer lease synchronously but mostly mutates
+            let tookOver = await provider.takeOver(for: id)
+            // Takeover seizes the writer lease before returning but mostly mutates
             // lease/agent state, not the transcript — so the objectWillChange
             // delta that normally carries `canDrive` may never fire on an idle
             // session. Push a snapshot now so the client learns canDrive=true
             // immediately and the composer unlocks (otherwise the take-over
             // button stays up and sendPrompt stays blocked until some unrelated
             // transcript mutation happens to occur).
-            if let session = provider.session(for: id) {
+            if tookOver, let session = provider.session(for: id) {
                 sendSnapshot(id: id, session: session)
             }
         case .sendPrompt(let id, let text, let attachments):

--- a/Alas/Sources/Remote/Gateway/RemoteSessionsProvider.swift
+++ b/Alas/Sources/Remote/Gateway/RemoteSessionsProvider.swift
@@ -15,7 +15,7 @@ protocol RemoteSessionsProvider: AnyObject {
     func respondToUserInput(for id: String, token: UUID, action: ACPUserInputAction)
     func fullToolCallContent(sessionId: String, toolCallId: String) -> String?
     func isWriter(for id: String) -> Bool
-    func takeOver(for id: String)
+    func takeOver(for id: String) async -> Bool
     /// `onResult` fires once with the final outcome (false = refused now or
     /// failed delivery later); the gateway emits `promptRejected` on false so
     /// the client can restore the text instead of losing it.

--- a/Alas/Sources/SQLiteKit/SQLiteDatabase.swift
+++ b/Alas/Sources/SQLiteKit/SQLiteDatabase.swift
@@ -2,9 +2,34 @@ import Foundation
 import SQLite3
 
 final class SQLiteDatabase {
-    private var handle: OpaquePointer?
+    private struct BusyRetryIdentity {
+        let generationKey: String
+        let sessionId: String?
+        var requiresExistingSessionRow: Bool
+        var expectedLeaseToken: String?
+    }
 
-    init(path: String) throws {
+    private enum BusyRetryReplayDecision {
+        case allow
+        case blocked
+        case retryLater
+    }
+
+    private static let busyRetryQueue = DispatchQueue(
+        label: "SQLiteDatabase.busyRetry",
+        qos: .utility,
+        attributes: .concurrent)
+    private static let busyRetryLeaseStaleAfter: Int64 = 15
+
+    private var handle: OpaquePointer?
+    private let path: String
+    private var busyRetryTimeoutMilliseconds: Int32?
+    private var busyRetryOwnerInstanceId: String?
+    private let busyRetryLock = NSLock()
+    private var busyRetryGenerations: [String: Int] = [:]
+
+    init(path: String, busyTimeoutMilliseconds: Int32 = 5_000) throws {
+        self.path = path
         let flags = SQLITE_OPEN_READWRITE | SQLITE_OPEN_CREATE | SQLITE_OPEN_FULLMUTEX
         let rc = sqlite3_open_v2(path, &handle, flags, nil)
         guard rc == SQLITE_OK, let h = handle else {
@@ -12,25 +37,57 @@ final class SQLiteDatabase {
             sqlite3_close(handle)
             throw SQLiteError.openFailed(code: rc, message: msg)
         }
-        sqlite3_busy_timeout(h, 5_000)
+        sqlite3_busy_timeout(h, busyTimeoutMilliseconds)
         _ = sqlite3_exec(h, "PRAGMA journal_mode = WAL;", nil, nil, nil)
         _ = sqlite3_exec(h, "PRAGMA foreign_keys = ON;", nil, nil, nil)
     }
 
     deinit { sqlite3_close(handle) }
 
+    func setBusyTimeout(milliseconds: Int32) {
+        guard let h = handle else { return }
+        sqlite3_busy_timeout(h, milliseconds)
+    }
+
+    func setBusyRetryTimeout(milliseconds: Int32?) {
+        busyRetryTimeoutMilliseconds = milliseconds
+    }
+
+    func setBusyRetryOwnerInstanceId(_ ownerInstanceId: String?) {
+        busyRetryOwnerInstanceId = ownerInstanceId
+    }
+
+    func invalidateBusyRetry(generationKey: String) {
+        guard busyRetryTimeoutMilliseconds != nil else { return }
+        _ = bumpBusyRetryGeneration(for: generationKey)
+    }
+
     func exec(_ sql: String, bindings: [Any?] = []) throws {
         guard let h = handle else { return }
         let stmt = try SQLiteStatement(db: h, sql: sql)
         try stmt.bind(bindings)
-        try stmt.run()
+        do {
+            try stmt.run()
+            invalidatePendingBusyRetry(sql: sql, bindings: bindings)
+        } catch {
+            scheduleBusyRetryIfNeeded(sql: sql, bindings: bindings, error: error)
+            throw error
+        }
     }
 
-    func execChanges(_ sql: String, bindings: [Any?] = []) throws -> Int32 {
+    func execChanges(_ sql: String, bindings: [Any?] = [], retryOnBusy: Bool = false) throws -> Int32 {
         guard let h = handle else { return 0 }
         let stmt = try SQLiteStatement(db: h, sql: sql)
         try stmt.bind(bindings)
-        try stmt.run()
+        do {
+            try stmt.run()
+            invalidatePendingBusyRetry(sql: sql, bindings: bindings)
+        } catch {
+            if retryOnBusy {
+                scheduleBusyRetryIfNeeded(sql: sql, bindings: bindings, error: error)
+            }
+            throw error
+        }
         return sqlite3_changes(h)
     }
 
@@ -51,5 +108,326 @@ final class SQLiteDatabase {
             try? exec("ROLLBACK")
             throw error
         }
+    }
+
+    private func scheduleBusyRetryIfNeeded(sql: String, bindings: [Any?], error: Error) {
+        guard let timeout = busyRetryTimeoutMilliseconds,
+              var identity = busyRetryIdentity(sql: sql, bindings: bindings),
+              shouldScheduleBusyRetry(for: error, identity: identity)
+        else { return }
+
+        if identity.generationKey.hasPrefix("sessions.upsert:"),
+           let sessionId = identity.sessionId,
+           sessionRowExistsNow(sessionId: sessionId) == true {
+            identity.requiresExistingSessionRow = true
+        }
+        if let ownerInstanceId = busyRetryOwnerInstanceId,
+           let sessionId = identity.sessionId {
+            identity.expectedLeaseToken = busyRetryLeaseToken(
+                sessionId: sessionId,
+                ownerInstanceId: ownerInstanceId
+            )
+        }
+        if (isSessionDelete(sql) || isSessionArchiveUpdate(sql)), let sessionId = identity.sessionId {
+            _ = bumpBusyRetryGeneration(for: "sessions.upsert:\(sessionId)")
+        }
+
+        let generation = bumpBusyRetryGeneration(for: identity.generationKey)
+        let leaseGenerationKey = identity.sessionId.map { "session_lease:\($0)" }
+        let leaseGeneration = leaseGenerationKey.flatMap { busyRetryGeneration(for: $0) } ?? 0
+        let path = self.path
+        let deadline = Date().addingTimeInterval(Double(timeout) / 1_000.0)
+        SQLiteDatabase.busyRetryQueue.async { [weak self] in
+            guard let self else { return }
+            guard Date() < deadline else { return }
+            guard let db = try? SQLiteDatabase(path: path, busyTimeoutMilliseconds: 0) else { return }
+            while Date() < deadline {
+                guard self.busyRetryGeneration(for: identity.generationKey) == generation else { return }
+                if let leaseGenerationKey,
+                   (self.busyRetryGeneration(for: leaseGenerationKey) ?? 0) != leaseGeneration {
+                    return
+                }
+                switch self.busyRetryReplayDecision(for: identity, using: db) {
+                case .allow:
+                    break
+                case .blocked:
+                    return
+                case .retryLater:
+                    Thread.sleep(forTimeInterval: 0.05)
+                    continue
+                }
+                guard self.busyRetryGeneration(for: identity.generationKey) == generation else { return }
+                if let leaseGenerationKey,
+                   (self.busyRetryGeneration(for: leaseGenerationKey) ?? 0) != leaseGeneration {
+                    return
+                }
+                do {
+                    try db.exec(sql, bindings: bindings)
+                    self.invalidatePendingBusyRetry(sql: sql, bindings: bindings)
+                    return
+                } catch {
+                    guard self.isBusyRetryable(error) else { return }
+                    Thread.sleep(forTimeInterval: 0.05)
+                }
+            }
+        }
+    }
+
+    private func invalidatePendingBusyRetry(sql: String, bindings: [Any?]) {
+        guard busyRetryTimeoutMilliseconds != nil,
+              let identity = busyRetryIdentity(sql: sql, bindings: bindings)
+        else { return }
+        _ = bumpBusyRetryGeneration(for: identity.generationKey)
+        if (isSessionDelete(sql) || isSessionArchiveUpdate(sql)), let sessionId = identity.sessionId {
+            _ = bumpBusyRetryGeneration(for: "sessions.upsert:\(sessionId)")
+        }
+        if isSessionLeaseDelete(sql), let sessionId = identity.sessionId {
+            _ = bumpBusyRetryGeneration(for: "session_lease:\(sessionId)")
+        }
+    }
+
+    private func bumpBusyRetryGeneration(for key: String) -> Int {
+        busyRetryLock.lock()
+        defer { busyRetryLock.unlock() }
+        let next = (busyRetryGenerations[key] ?? 0) + 1
+        busyRetryGenerations[key] = next
+        return next
+    }
+
+    private func busyRetryGeneration(for key: String) -> Int? {
+        busyRetryLock.lock()
+        defer { busyRetryLock.unlock() }
+        return busyRetryGenerations[key]
+    }
+
+    private func busyRetryIdentity(sql: String, bindings: [Any?]) -> BusyRetryIdentity? {
+        let normalized = sql.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        if normalized.contains("composer_drafts") {
+            return firstStringBinding(in: bindings).map {
+                BusyRetryIdentity(generationKey: "composer_drafts:\($0)", sessionId: $0,
+                                  requiresExistingSessionRow: true, expectedLeaseToken: nil)
+            }
+        }
+        if normalized.contains("session_queue") {
+            return firstStringBinding(in: bindings).map {
+                BusyRetryIdentity(generationKey: "session_queue:\($0)", sessionId: $0,
+                                  requiresExistingSessionRow: true, expectedLeaseToken: nil)
+            }
+        }
+        if normalized.contains("session_leases") {
+            return firstStringBinding(in: bindings).map {
+                BusyRetryIdentity(generationKey: "session_leases:\($0)", sessionId: $0,
+                                  requiresExistingSessionRow: true, expectedLeaseToken: nil)
+            }
+        }
+        if normalized.contains("permission_decisions") {
+            guard let sessionId = stringBinding(at: 0, in: bindings),
+                  let scopeKey = stringBinding(at: 1, in: bindings)
+            else { return nil }
+            return BusyRetryIdentity(
+                generationKey: "permission_decisions:\(sessionId):\(scopeKey)",
+                sessionId: sessionId,
+                requiresExistingSessionRow: true,
+                expectedLeaseToken: nil)
+        }
+        if normalized.contains("messages") {
+            if normalized.hasPrefix("insert") || normalized.hasPrefix("replace") {
+                guard let messageId = stringBinding(at: 0, in: bindings) else { return nil }
+                return BusyRetryIdentity(
+                    generationKey: "messages.insert:\(messageId)",
+                    sessionId: stringBinding(at: 1, in: bindings),
+                    requiresExistingSessionRow: true,
+                    expectedLeaseToken: nil)
+            }
+            guard let messageId = lastStringBinding(in: bindings) else { return nil }
+            return BusyRetryIdentity(
+                generationKey: "messages.update:\(messageId)",
+                sessionId: sessionId(fromMessageRowId: messageId),
+                requiresExistingSessionRow: true,
+                expectedLeaseToken: nil)
+        }
+        if normalized.contains("sessions") {
+            let sessionId: String?
+            let operation: String
+            if normalized.hasPrefix("insert") || normalized.hasPrefix("replace") {
+                sessionId = stringBinding(at: 0, in: bindings)
+                operation = "upsert"
+            } else {
+                sessionId = whereIdStringBinding(in: bindings) ?? firstStringBinding(in: bindings)
+                operation = sessionRetryOperation(for: normalized)
+            }
+            return sessionId.map {
+                BusyRetryIdentity(generationKey: "sessions.\(operation):\($0)", sessionId: $0,
+                                  requiresExistingSessionRow: false, expectedLeaseToken: nil)
+            }
+        }
+        return nil
+    }
+
+    private func busyRetryReplayDecision(
+        for identity: BusyRetryIdentity,
+        using db: SQLiteDatabase
+    ) -> BusyRetryReplayDecision {
+        if let sessionId = identity.sessionId, identity.requiresExistingSessionRow {
+            switch sessionRowExists(sessionId: sessionId, using: db) {
+            case .allow:
+                break
+            case .blocked:
+                return .blocked
+            case .retryLater:
+                return .retryLater
+            }
+        }
+        guard let ownerInstanceId = busyRetryOwnerInstanceId,
+              let sessionId = identity.sessionId
+        else { return .allow }
+        do {
+            let rows = try db.query(
+                "SELECT owner_instance, pid, heartbeat_at, lease_token FROM session_leases WHERE session_id = ?",
+                bindings: [sessionId])
+            guard let owner = rows.first?["owner_instance"] as? String else {
+                return identity.expectedLeaseToken == nil ? .allow : .blocked
+            }
+            let pid = (rows.first?["pid"] as? Int64) ?? 0
+            let heartbeatAt = (rows.first?["heartbeat_at"] as? Int64) ?? 0
+            let staleCutoff = Int64(Date().timeIntervalSince1970) - Self.busyRetryLeaseStaleAfter
+            guard ACPProcessLiveness.pidAlive(pid), heartbeatAt >= staleCutoff else { return .allow }
+            guard owner == ownerInstanceId else { return .blocked }
+            if let expectedLeaseToken = identity.expectedLeaseToken {
+                return rows.first?["lease_token"] as? String == expectedLeaseToken ? .allow : .blocked
+            }
+            return .allow
+        } catch {
+            return isBusyRetryable(error) ? .retryLater : .allow
+        }
+    }
+
+    private func sessionRowExistsNow(sessionId: String) -> Bool? {
+        do {
+            let rows = try query("SELECT 1 FROM sessions WHERE id = ? LIMIT 1", bindings: [sessionId])
+            return !rows.isEmpty
+        } catch {
+            return nil
+        }
+    }
+
+    private func busyRetryLeaseToken(sessionId: String, ownerInstanceId: String) -> String? {
+        do {
+            let rows = try query(
+                "SELECT lease_token FROM session_leases WHERE session_id = ? AND owner_instance = ? LIMIT 1",
+                bindings: [sessionId, ownerInstanceId]
+            )
+            guard let token = rows.first?["lease_token"] as? String, !token.isEmpty else { return nil }
+            return token
+        } catch {
+            return nil
+        }
+    }
+
+    private func sessionRowExists(
+        sessionId: String,
+        using db: SQLiteDatabase
+    ) -> BusyRetryReplayDecision {
+        do {
+            let rows = try db.query("SELECT 1 FROM sessions WHERE id = ? LIMIT 1", bindings: [sessionId])
+            return rows.isEmpty ? .retryLater : .allow
+        } catch {
+            return isBusyRetryable(error) ? .retryLater : .allow
+        }
+    }
+
+    private func shouldScheduleBusyRetry(for error: Error, identity: BusyRetryIdentity) -> Bool {
+        if isBusyRetryable(error) { return true }
+        guard isChildForeignKeyRetryable(error, identity: identity),
+              let sessionId = identity.sessionId
+        else { return false }
+        switch sessionRowExists(sessionId: sessionId, using: self) {
+        case .retryLater:
+            return true
+        case .allow, .blocked:
+            return false
+        }
+    }
+
+    private func isChildForeignKeyRetryable(_ error: Error, identity: BusyRetryIdentity) -> Bool {
+        guard let sessionId = identity.sessionId,
+              !sessionId.isEmpty,
+              !identity.generationKey.hasPrefix("sessions."),
+              case SQLiteError.stepFailed(let code, let message, _) = error
+        else { return false }
+        return code == SQLITE_CONSTRAINT
+            || message.localizedCaseInsensitiveContains("foreign key")
+    }
+
+    private func firstStringBinding(in bindings: [Any?]) -> String? {
+        bindings.compactMap { $0 as? String }.first
+    }
+
+    private func lastStringBinding(in bindings: [Any?]) -> String? {
+        bindings.compactMap { $0 as? String }.last
+    }
+
+    private func stringBinding(at index: Int, in bindings: [Any?]) -> String? {
+        guard bindings.indices.contains(index) else { return nil }
+        return bindings[index] as? String
+    }
+
+    private func whereIdStringBinding(in bindings: [Any?]) -> String? {
+        let strings = bindings.compactMap { $0 as? String }
+        guard strings.count >= 2 else { return strings.first }
+        switch strings.last {
+        case "manual", "generated", "placeholder":
+            return strings[strings.count - 2]
+        default:
+            return strings.last
+        }
+    }
+
+    private func sessionRetryOperation(for normalizedSQL: String) -> String {
+        if normalizedSQL.hasPrefix("delete") {
+            return "delete"
+        }
+        if normalizedSQL.contains("last_opened_at") {
+            return "last_opened_at"
+        }
+        if normalizedSQL.contains("context_recovery_pending") {
+            return "context_recovery"
+        }
+        if normalizedSQL.contains("remote_session_id") {
+            return "remote_session"
+        }
+        if normalizedSQL.contains("title") || normalizedSQL.contains("title_source") {
+            return "title"
+        }
+        return "update"
+    }
+
+    private func sessionId(fromMessageRowId messageId: String) -> String? {
+        guard messageId.hasPrefix("msg-"),
+              let dash = messageId.lastIndex(of: "-")
+        else { return nil }
+        return String(messageId.dropFirst(4).prefix(upTo: dash))
+    }
+
+    private func isSessionDelete(_ sql: String) -> Bool {
+        let normalized = sql.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        return normalized.hasPrefix("delete") && normalized.contains("sessions")
+    }
+
+    private func isSessionArchiveUpdate(_ sql: String) -> Bool {
+        let normalized = sql.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        return normalized.hasPrefix("update")
+            && normalized.contains("sessions")
+            && normalized.contains("archived")
+    }
+
+    private func isSessionLeaseDelete(_ sql: String) -> Bool {
+        let normalized = sql.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        return normalized.hasPrefix("delete") && normalized.contains("session_leases")
+    }
+
+    private func isBusyRetryable(_ error: Error) -> Bool {
+        guard case SQLiteError.stepFailed(let code, _, _) = error else { return false }
+        return code == SQLITE_BUSY || code == SQLITE_LOCKED
     }
 }

--- a/AlasTests/ACP/ACPSessionLeaseTests.swift
+++ b/AlasTests/ACP/ACPSessionLeaseTests.swift
@@ -15,6 +15,19 @@ import Foundation
         #expect(try store.currentSchemaVersion() == ACPSessionStore.targetSchemaVersion)
     }
 
+    @Test("v11 lease token migration is idempotent")
+    func v11LeaseTokenMigrationIsIdempotent() throws {
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("lease-migration-\(UUID()).sqlite")
+        let store = try ACPSessionStore(path: url.path)
+        try store.db.exec("UPDATE schema_version SET version = ?", bindings: [Int64(10)])
+
+        let reopened = try ACPSessionStore(path: url.path)
+        #expect(try reopened.currentSchemaVersion() == ACPSessionStore.targetSchemaVersion)
+        let columns = try reopened.db.query("PRAGMA table_info(session_leases)")
+        #expect(columns.filter { $0["name"] as? String == "lease_token" }.count == 1)
+    }
+
     @Test("session_leases table exists and is empty")
     func leaseTableExists() throws {
         let store = try tempStore()
@@ -90,6 +103,31 @@ import Foundation
         _ = try store.claimLease(sessionId: "s1", instanceId: "A", pid: Int64(getpid()), now: now, staleAfter: 15)
         try store.releaseLease(sessionId: "s1", instanceId: "A")
         #expect(try store.loadLease(sessionId: "s1") == nil)
+    }
+
+    @Test("same-owner lease refresh preserves token")
+    func sameOwnerLeaseRefreshPreservesToken() throws {
+        let store = try tempStore()
+        try seedSession(store, id: "s1")
+        let now = Int64(Date().timeIntervalSince1970)
+        #expect(try store.claimLease(
+            sessionId: "s1",
+            instanceId: "A",
+            pid: Int64(getpid()),
+            now: now,
+            staleAfter: 15,
+            leaseToken: "old-token") == true)
+        #expect(try store.claimLease(
+            sessionId: "s1",
+            instanceId: "A",
+            pid: Int64(getpid()),
+            now: now + 1,
+            staleAfter: 15,
+            leaseToken: "new-token") == true)
+
+        let lease = try #require(try store.loadLease(sessionId: "s1"))
+        #expect(lease.ownerInstance == "A")
+        #expect(lease.token == "old-token")
     }
 
     @Test("seize wins over a live, fresh lease")

--- a/AlasTests/ACP/ACPSessionManagerLeaseTests.swift
+++ b/AlasTests/ACP/ACPSessionManagerLeaseTests.swift
@@ -55,6 +55,49 @@ import Foundation
         #expect(mgrB.acquireWriterLease(sessionId: session.id) == true)
     }
 
+    @Test("busy first lease claim waits for transient writer lock")
+    func busyFirstLeaseClaimWaitsForTransientWriterLock() throws {
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("mgr-claim-busy-\(UUID()).sqlite")
+        let storeA = try ACPSessionStore(
+            path: url.path,
+            busyTimeoutMilliseconds: ACPSessionStore.mainActorBusyTimeoutMilliseconds)
+        let mgrA = tempManager(instanceId: "A", store: storeA)
+        let session = mgrA.createSession(agentId: "claude")
+
+        let blocker = try ACPSessionStore(path: url.path)
+        try blocker.db.exec("BEGIN IMMEDIATE")
+        DispatchQueue.global().asyncAfter(deadline: .now() + 0.2) {
+            try? blocker.db.exec("ROLLBACK")
+        }
+
+        #expect(mgrA.acquireWriterLease(sessionId: session.id))
+        #expect(mgrA.tracksOwnedLeaseForTest(sessionId: session.id))
+    }
+
+    @Test("failed lease release keeps local ownership tracked")
+    func failedReleaseKeepsOwnershipTracked() throws {
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("mgr-release-busy-\(UUID()).sqlite")
+        let storeA = try ACPSessionStore(path: url.path, busyTimeoutMilliseconds: 0)
+        let mgrA = tempManager(instanceId: "A", store: storeA)
+        let session = mgrA.createSession(agentId: "claude")
+        #expect(mgrA.acquireWriterLease(sessionId: session.id) == true)
+
+        let blocker = try ACPSessionStore(path: url.path)
+        try blocker.db.exec("BEGIN IMMEDIATE")
+        defer { try? blocker.db.exec("ROLLBACK") }
+
+        mgrA.releaseWriterLease(sessionId: session.id)
+        #expect(mgrA.tracksOwnedLeaseForTest(sessionId: session.id),
+                "local ownership must remain tracked when the lease row was not removed")
+
+        try blocker.db.exec("ROLLBACK")
+        mgrA.releaseWriterLease(sessionId: session.id)
+        #expect(!mgrA.tracksOwnedLeaseForTest(sessionId: session.id))
+        #expect(try storeA.loadLease(sessionId: session.id)?.ownerInstance == nil)
+    }
+
     @Test("mirror re-read applies appended messages from another writer")
     func mirrorReReads() async throws {
         let url = FileManager.default.temporaryDirectory
@@ -94,12 +137,129 @@ import Foundation
         let storeB = try ACPSessionStore(path: url.path)
         let mgrB = tempManager(instanceId: "B", store: storeB)
         _ = mgrB.placeholderSession(id: session.id)
-        mgrB.takeOver(sessionId: session.id)
+        await mgrB.takeOver(sessionId: session.id)
 
-        // The synchronous parts (seizeLease + _ownedLeases insert) must have
-        // completed before takeOver returns; the async attach kicks off later.
+        try await waitUntil {
+            try storeB.loadLease(sessionId: session.id)?.ownerInstance == "B"
+        }
         #expect(try storeB.loadLease(sessionId: session.id)?.ownerInstance == "B")
         #expect(mgrA.ownsLeaseForTest(sessionId: session.id) == false)
+    }
+
+    @Test("takeover invalidates stale lease release retries")
+    func takeOverInvalidatesStaleReleaseRetry() async throws {
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("takeover-stale-release-\(UUID()).sqlite")
+        let storeA = try ACPSessionStore(path: url.path)
+        let mgrA = tempManager(instanceId: "A", store: storeA)
+        let session = mgrA.createSession(agentId: "claude")
+        _ = mgrA.acquireWriterLease(sessionId: session.id)
+
+        let storeB = try ACPSessionStore(path: url.path, busyTimeoutMilliseconds: 0)
+        let mgrB = tempManager(instanceId: "B", store: storeB)
+        _ = mgrB.placeholderSession(id: session.id)
+        await mgrB.takeOver(sessionId: session.id)
+
+        let blocker = try ACPSessionStore(path: url.path)
+        try blocker.db.exec("BEGIN IMMEDIATE")
+        defer { try? blocker.db.exec("ROLLBACK") }
+        mgrB.releaseWriterLease(sessionId: session.id)
+
+        let staleGeneration = try #require(mgrB.leaseReleaseGenerationForTest(sessionId: session.id))
+        try blocker.db.exec("ROLLBACK")
+        try storeA.seizeLease(
+            sessionId: session.id,
+            instanceId: "A",
+            pid: Int64(getpid()),
+            now: Int64(Date().timeIntervalSince1970)
+        )
+
+        await mgrB.takeOver(sessionId: session.id)
+        #expect(mgrB.tracksOwnedLeaseForTest(sessionId: session.id))
+
+        mgrB.clearLocalLeaseOwnershipAfterReleaseAttemptForTest(
+            sessionId: session.id,
+            generation: staleGeneration
+        )
+        #expect(mgrB.tracksOwnedLeaseForTest(sessionId: session.id),
+                "stale release retry must not clear ownership acquired by takeover")
+    }
+
+    @Test("busy takeover waits for a transient writer lock")
+    func busyTakeoverWaitsForTransientWriterLock() async throws {
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("takeover-busy-\(UUID()).sqlite")
+        let storeA = try ACPSessionStore(path: url.path)
+        let mgrA = tempManager(instanceId: "A", store: storeA)
+        let session = mgrA.createSession(agentId: "claude")
+        #expect(mgrA.acquireWriterLease(sessionId: session.id) == true)
+
+        let storeB = try ACPSessionStore(path: url.path)
+        let mgrB = tempManager(instanceId: "B", store: storeB)
+        _ = mgrB.placeholderSession(id: session.id)
+
+        let blocker = try ACPSessionStore(path: url.path)
+        try blocker.db.exec("BEGIN IMMEDIATE")
+        defer { try? blocker.db.exec("ROLLBACK") }
+        DispatchQueue.global().asyncAfter(deadline: .now() + 0.2) {
+            try? blocker.db.exec("ROLLBACK")
+        }
+
+        await mgrB.takeOver(sessionId: session.id)
+
+        #expect(mgrB.tracksOwnedLeaseForTest(sessionId: session.id),
+                "takeover must claim local ownership after a transient busy lock clears")
+        #expect(try storeA.loadLease(sessionId: session.id)?.ownerInstance == "B")
+    }
+
+    @Test("takeover releases the seized lease when the tab closes while waiting")
+    func takeOverReleasesLeaseWhenSessionClosesWhileWaiting() async throws {
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("takeover-close-\(UUID()).sqlite")
+        let storeA = try ACPSessionStore(path: url.path)
+        let mgrA = tempManager(instanceId: "A", store: storeA)
+        let session = mgrA.createSession(agentId: "claude")
+        #expect(mgrA.acquireWriterLease(sessionId: session.id) == true)
+
+        let storeB = try ACPSessionStore(path: url.path)
+        let mgrB = tempManager(instanceId: "B", store: storeB)
+        _ = mgrB.placeholderSession(id: session.id)
+
+        let blocker = try ACPSessionStore(path: url.path)
+        try blocker.db.exec("BEGIN IMMEDIATE")
+        defer { try? blocker.db.exec("ROLLBACK") }
+
+        let takeover = Task { @MainActor in
+            await mgrB.takeOver(sessionId: session.id)
+        }
+        try await Task.sleep(nanoseconds: 50_000_000)
+        mgrB.closeSession(id: session.id)
+
+        try blocker.db.exec("ROLLBACK")
+        #expect(await takeover.value == false)
+        #expect(!mgrB.tracksOwnedLeaseForTest(sessionId: session.id))
+        #expect(try storeA.loadLease(sessionId: session.id) == nil)
+    }
+
+    @Test("busy claim after takeover does not trust stale local ownership")
+    func busyClaimAfterTakeoverFailsClosed() throws {
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("claim-busy-stale-\(UUID()).sqlite")
+        let storeA = try ACPSessionStore(path: url.path, busyTimeoutMilliseconds: 0)
+        let mgrA = tempManager(instanceId: "A", store: storeA)
+        let session = mgrA.createSession(agentId: "claude")
+        #expect(mgrA.acquireWriterLease(sessionId: session.id) == true)
+
+        let now = Int64(Date().timeIntervalSince1970)
+        try storeA.seizeLease(sessionId: session.id, instanceId: "B", pid: Int64(getpid()), now: now)
+
+        let blocker = try ACPSessionStore(path: url.path)
+        try blocker.db.exec("BEGIN IMMEDIATE")
+        defer { try? blocker.db.exec("ROLLBACK") }
+
+        #expect(mgrA.acquireWriterLease(sessionId: session.id) == false,
+                "busy claim must not return true solely from stale _ownedLeases")
+        #expect(!mgrA.tracksOwnedLeaseForTest(sessionId: session.id))
     }
 
     @Test("heartbeat re-asserts ownership when the lease row went missing")
@@ -219,6 +379,30 @@ import Foundation
                 "former owner must not write queue when another live instance owns the store lease")
     }
 
+    @Test("former owner is not a writer when the lease cannot be read")
+    func unreadableLeaseFailsWriterGateClosed() throws {
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("handoff-unreadable-\(UUID()).sqlite")
+        let storeA = try ACPSessionStore(path: url.path, busyTimeoutMilliseconds: 0)
+        let mgrA = tempManager(instanceId: "A", store: storeA)
+        let session = mgrA.createSession(agentId: "claude")
+        #expect(mgrA.acquireWriterLease(sessionId: session.id) == true)
+
+        let now = Int64(Date().timeIntervalSince1970)
+        try storeA.seizeLease(sessionId: session.id, instanceId: "B",
+                              pid: Int64(getpid()), now: now)
+
+        try storeA.db.exec("DROP TABLE session_leases")
+
+        do {
+            _ = try storeA.loadLease(sessionId: session.id)
+            Issue.record("precondition failed: missing lease table should make the lease read fail")
+        } catch {
+            #expect(mgrA.isWriter(for: session.id) == false,
+                    "writer gate must fail closed when the store lease cannot be read")
+        }
+    }
+
     // MARK: - P2: Mirror poll teardown on eviction
 
     @Test("endMirroring is idempotent and evictIfIdle cancels the mirror poll")
@@ -334,7 +518,7 @@ import Foundation
     }
 
     @Test("shutdownBackgroundTasks cancels writer-watch tokens")
-    func shutdownCancelsWriterWatch() throws {
+    func shutdownCancelsWriterWatch() async throws {
         let url = FileManager.default.temporaryDirectory
             .appendingPathComponent("ww-shutdown-\(UUID()).sqlite")
         let storeA = try ACPSessionStore(path: url.path)
@@ -348,7 +532,10 @@ import Foundation
         let mgrB = tempManager(instanceId: "B", store: storeB)
         _ = mgrB.placeholderSession(id: session.id)
         // B takes over — it calls startWriterWatch on B's manager.
-        mgrB.takeOver(sessionId: session.id)
+        await mgrB.takeOver(sessionId: session.id)
+        try await waitUntil {
+            mgrB.writerWatchActiveForTest(sessionId: session.id)
+        }
         #expect(mgrB.writerWatchActiveForTest(sessionId: session.id) == true,
                 "takeOver must activate the writer-watch subscription")
 
@@ -397,7 +584,7 @@ import Foundation
     // MARK: - Fix 2 (P1): takeOver refreshes remoteSessionId from store
 
     @Test("takeOver refreshes remoteSessionId from store when cached value is nil")
-    func takeOverRefreshesRemoteSessionId() throws {
+    func takeOverRefreshesRemoteSessionId() async throws {
         let url = FileManager.default.temporaryDirectory
             .appendingPathComponent("takeover-remote-\(UUID()).sqlite")
         let storeA = try ACPSessionStore(path: url.path)
@@ -425,9 +612,11 @@ import Foundation
         mirrorSession!.remoteSessionId = nil   // simulate stale mirror
 
         // B takes over — must refresh from the store before spawning attach.
-        mgrB.takeOver(sessionId: session.id)
+        await mgrB.takeOver(sessionId: session.id)
 
-        // The synchronous refresh inside takeOver must have restored the stored value.
+        try await waitUntil {
+            mgrB.sessions[session.id]?.remoteSessionId == remoteId
+        }
         #expect(mgrB.sessions[session.id]?.remoteSessionId == remoteId,
                 "takeOver must refresh remoteSessionId from the store so attach uses session/load")
     }
@@ -789,7 +978,7 @@ import Foundation
     // MARK: - Fix 2: takeOver refreshes queue from store
 
     @Test("takeOver restores queue from store into the taking-over session")
-    func takeOverRestoresQueueFromStore() throws {
+    func takeOverRestoresQueueFromStore() async throws {
         let url = FileManager.default.temporaryDirectory
             .appendingPathComponent("takeover-queue-\(UUID()).sqlite")
         let storeA = try ACPSessionStore(path: url.path)
@@ -811,12 +1000,12 @@ import Foundation
         #expect(mirrorSession!.queue.isEmpty,
                 "precondition: mirror placeholder queue is empty before takeOver")
 
-        // B takes over — must refresh the queue from the store synchronously.
-        mgrB.takeOver(sessionId: session.id)
+        // B takes over — must refresh the queue from the store before attach resumes.
+        await mgrB.takeOver(sessionId: session.id)
 
-        // The synchronous queue refresh inside takeOver must have restored
-        // the persisted queue so the taking-over instance starts from the
-        // current state (not the mirror's stale/empty cached queue).
+        try await waitUntil {
+            mgrB.sessions[session.id]?.queue.count == 1
+        }
         #expect(mgrB.sessions[session.id]?.queue.count == 1,
                 "takeOver must refresh queue from the store before spawning attach")
     }
@@ -992,6 +1181,21 @@ import Foundation
 }
 
 // MARK: - Helpers
+
+private func waitUntil(
+    timeoutNanos: UInt64 = 500_000_000,
+    _ predicate: () throws -> Bool
+) async throws {
+    let start = DispatchTime.now().uptimeNanoseconds
+    while true {
+        if try predicate() { return }
+        if DispatchTime.now().uptimeNanoseconds - start >= timeoutNanos {
+            Issue.record("Timed out waiting for condition")
+            return
+        }
+        try await Task.sleep(nanoseconds: 10_000_000)
+    }
+}
 
 /// Simple async gate used by lease tests to suspend an in-flight `attach`
 /// at the setupEvaluator await so we can inspect and manipulate state while

--- a/AlasTests/ACP/Session/ACPSessionManagerTests.swift
+++ b/AlasTests/ACP/Session/ACPSessionManagerTests.swift
@@ -122,6 +122,86 @@ struct ACPSessionManagerTests {
         #expect(try store.loadComposerDraft(sessionId: session.id) == nil)
     }
 
+    @Test("termination flush persists draft after a failed debounce write")
+    func terminationFlushPersistsDraftAfterFailedDebounceWrite() async throws {
+        let url = FileManager.default.temporaryDirectory.appendingPathComponent("mgr-draft-terminate-\(UUID()).sqlite")
+        let store = try ACPSessionStore(path: url.path, busyTimeoutMilliseconds: 0)
+        let mgr = ACPSessionManager(worktreeId: "wt", worktreePath: "/tmp/wt", store: store)
+        let session = mgr.createSession(agentId: "claude")
+        let draft = ACPComposerDraft(segments: [.text("survive termination")])
+
+        let blocker = try ACPSessionStore(path: url.path)
+        try blocker.db.exec("BEGIN IMMEDIATE")
+        mgr.persistComposerDraft(draft, for: session)
+        mgr.flushPendingDraftWrites()
+        #expect(try store.loadComposerDraft(sessionId: session.id) == nil)
+
+        try blocker.db.exec("ROLLBACK")
+        mgr.flushPendingDraftWritesForTermination()
+        #expect(try store.loadComposerDraft(sessionId: session.id) == draft)
+    }
+
+    @Test("termination flush persists failed draft after session eviction")
+    func terminationFlushPersistsFailedDraftAfterSessionEviction() async throws {
+        let url = FileManager.default.temporaryDirectory.appendingPathComponent("mgr-draft-evicted-\(UUID()).sqlite")
+        let store = try ACPSessionStore(path: url.path, busyTimeoutMilliseconds: 0)
+        let mgr = ACPSessionManager(worktreeId: "wt", worktreePath: "/tmp/wt", store: store)
+        let session = mgr.createSession(agentId: "claude")
+        let draft = ACPComposerDraft(segments: [.text("survive eviction")])
+
+        let blocker = try ACPSessionStore(path: url.path)
+        try blocker.db.exec("BEGIN IMMEDIATE")
+        mgr.persistComposerDraft(draft, for: session)
+        mgr.flushPendingDraftWrites()
+        mgr.closeSession(id: session.id)
+        #expect(try store.loadComposerDraft(sessionId: session.id) == nil)
+
+        try blocker.db.exec("ROLLBACK")
+        mgr.flushPendingDraftWritesForTermination()
+        #expect(try store.loadComposerDraft(sessionId: session.id) == draft)
+    }
+
+    @Test("termination flush persists submitted recovery after a busy suspend write")
+    func terminationFlushPersistsSubmittedRecoveryAfterBusySuspendWrite() async throws {
+        let url = FileManager.default.temporaryDirectory.appendingPathComponent("mgr-draft-submit-terminate-\(UUID()).sqlite")
+        let store = try ACPSessionStore(path: url.path, busyTimeoutMilliseconds: 0)
+        let mgr = ACPSessionManager(worktreeId: "wt", worktreePath: "/tmp/wt", store: store)
+        let session = mgr.createSession(agentId: "claude")
+        let submitted = ACPComposerDraft(segments: [.text("submitted while locked")])
+
+        let blocker = try ACPSessionStore(path: url.path)
+        try blocker.db.exec("BEGIN IMMEDIATE")
+        mgr.persistComposerDraft(submitted, for: session)
+        _ = mgr.suspendComposerDraftForSubmission(submitted, for: session)
+        #expect(session.composerDraft == .empty)
+
+        try blocker.db.exec("ROLLBACK")
+        mgr.flushPendingDraftWritesForTermination()
+        let stored = try #require(try store.loadComposerDraftRecord(sessionId: session.id))
+        #expect(stored.draft == submitted)
+        #expect(stored.submittedRecovery)
+    }
+
+    @Test("regular flush persists submitted recovery after a busy suspend write")
+    func regularFlushPersistsSubmittedRecoveryAfterBusySuspendWrite() async throws {
+        let url = FileManager.default.temporaryDirectory.appendingPathComponent("mgr-draft-submit-dispose-\(UUID()).sqlite")
+        let store = try ACPSessionStore(path: url.path, busyTimeoutMilliseconds: 0)
+        let mgr = ACPSessionManager(worktreeId: "wt", worktreePath: "/tmp/wt", store: store)
+        let session = mgr.createSession(agentId: "claude")
+        let submitted = ACPComposerDraft(segments: [.text("submitted before dispose")])
+
+        let blocker = try ACPSessionStore(path: url.path)
+        try blocker.db.exec("BEGIN IMMEDIATE")
+        mgr.persistComposerDraft(submitted, for: session)
+        _ = mgr.suspendComposerDraftForSubmission(submitted, for: session)
+
+        try blocker.db.exec("ROLLBACK")
+        mgr.flushPendingDraftWrites()
+        let stored = try #require(try store.loadComposerDraftRecord(sessionId: session.id))
+        #expect(stored.draft == submitted)
+        #expect(stored.submittedRecovery)
+    }
+
     @Test("persisting composer drafts does not publish the whole session")
     func persistingComposerDraftDoesNotPublishWholeSession() async throws {
         let url = FileManager.default.temporaryDirectory.appendingPathComponent("mgr-draft-observation-\(UUID()).sqlite")
@@ -216,6 +296,49 @@ struct ACPSessionManagerTests {
         #expect(session.composerDraft == newer)
         mgr.flushPendingDraftWrites()
         #expect(try store.loadComposerDraft(sessionId: session.id) == newer)
+    }
+
+    @Test("termination flush retries failed suspended draft purge")
+    func terminationFlushRetriesFailedSuspendedDraftPurge() async throws {
+        let url = FileManager.default.temporaryDirectory.appendingPathComponent("mgr-draft-purge-terminate-\(UUID()).sqlite")
+        let store = try ACPSessionStore(path: url.path, busyTimeoutMilliseconds: 0)
+        let mgr = ACPSessionManager(worktreeId: "wt", worktreePath: "/tmp/wt", store: store)
+        let session = mgr.createSession(agentId: "claude")
+        let submitted = ACPComposerDraft(segments: [.text("sent")])
+        mgr.persistComposerDraft(submitted, for: session)
+        let suspendedRevision = mgr.suspendComposerDraftForSubmission(submitted, for: session)
+        #expect(try store.loadComposerDraft(sessionId: session.id) == submitted)
+
+        let blocker = try ACPSessionStore(path: url.path)
+        try blocker.db.exec("BEGIN IMMEDIATE")
+        mgr.purgeSuspendedComposerDraft(for: session, suspendedRevision: suspendedRevision)
+
+        try blocker.db.exec("ROLLBACK")
+        mgr.flushPendingDraftWritesForTermination()
+        #expect(try store.loadComposerDraft(sessionId: session.id) == nil)
+    }
+
+    @Test("termination flush retries failed explicit draft clear after eviction")
+    func terminationFlushRetriesFailedExplicitDraftClearAfterEviction() async throws {
+        let url = FileManager.default.temporaryDirectory.appendingPathComponent("mgr-draft-clear-terminate-\(UUID()).sqlite")
+        let store = try ACPSessionStore(path: url.path, busyTimeoutMilliseconds: 0)
+        let mgr = ACPSessionManager(worktreeId: "wt", worktreePath: "/tmp/wt", store: store)
+        let session = mgr.createSession(agentId: "claude")
+        let draft = ACPComposerDraft(segments: [.text("clear me")])
+        mgr.persistComposerDraft(draft, for: session)
+        mgr.flushPendingDraftWrites()
+        #expect(try store.loadComposerDraft(sessionId: session.id) == draft)
+
+        let blocker = try ACPSessionStore(path: url.path)
+        try blocker.db.exec("BEGIN IMMEDIATE")
+        mgr.clearComposerDraft(for: session)
+        #expect(session.composerDraft == .empty)
+        mgr.closeSession(id: session.id)
+        #expect(try store.loadComposerDraft(sessionId: session.id) == draft)
+
+        try blocker.db.exec("ROLLBACK")
+        mgr.flushPendingDraftWritesForTermination()
+        #expect(try store.loadComposerDraft(sessionId: session.id) == nil)
     }
 
     @Test("reinstateSuspendedComposerDraft restores memory only when revision matches")

--- a/AlasTests/ACP/Session/ACPSessionStoreCRUDTests.swift
+++ b/AlasTests/ACP/Session/ACPSessionStoreCRUDTests.swift
@@ -1,4 +1,5 @@
 import Foundation
+import SQLite3
 import Testing
 @testable import Alas
 
@@ -89,6 +90,42 @@ struct ACPSessionStoreCRUDTests {
         #expect(row.currentModel == "opus")
     }
 
+    @Test("session upsert does not unarchive archived rows")
+    func sessionUpsertDoesNotUnarchiveArchivedRows() throws {
+        let store = try tmp()
+        try store.upsertSession(.init(
+            id: "local-1",
+            agentId: "claude",
+            title: "Archived",
+            currentModel: nil,
+            currentMode: nil,
+            autoRun: false,
+            createdAt: 1,
+            updatedAt: 2,
+            lastOpenedAt: 3,
+            archived: false
+        ))
+        try store.setArchived(id: "local-1", archived: true)
+
+        try store.upsertSession(.init(
+            id: "local-1",
+            agentId: "claude",
+            title: "Stale retry",
+            currentModel: "opus",
+            currentMode: nil,
+            autoRun: false,
+            createdAt: 1,
+            updatedAt: 4,
+            lastOpenedAt: 5,
+            archived: false
+        ))
+
+        let row = try #require(try store.loadSession(id: "local-1"))
+        #expect(row.archived)
+        #expect(row.title == "Stale retry")
+        #expect(row.currentModel == "opus")
+    }
+
     @Test("metadata-only upsert can preserve stored title")
     func sessionMetadataUpsertPreservesStoredTitleWhenRequested() throws {
         let store = try tmp()
@@ -154,6 +191,53 @@ struct ACPSessionStoreCRUDTests {
         let row = try #require(try store.loadSession(id: "local-1"))
         #expect(!renamed)
         #expect(row.title == "Archived")
+        #expect(row.titleSource == .placeholder)
+    }
+
+    @Test("rename session busy failure does not retry after returning")
+    func renameSessionBusyFailureDoesNotRetryAfterReturning() async throws {
+        let url = tmpURL()
+        defer { try? FileManager.default.removeItem(at: url) }
+        let store = try ACPSessionStore(
+            path: url.path,
+            busyTimeoutMilliseconds: 0,
+            backgroundBusyRetryMilliseconds: 1_000
+        )
+        try store.upsertSession(.init(
+            id: "local-1",
+            agentId: "claude",
+            title: "Original",
+            titleSource: .placeholder,
+            currentModel: nil,
+            currentMode: nil,
+            autoRun: false,
+            createdAt: 1,
+            updatedAt: 2,
+            lastOpenedAt: 3,
+            archived: false
+        ))
+
+        let writer = try SQLiteDatabase(path: url.path)
+        try writer.exec("BEGIN IMMEDIATE")
+        do {
+            _ = try store.renameSession(
+                id: "local-1",
+                title: "Remote Title",
+                titleSource: .manual,
+                updatedAt: 4
+            )
+            Issue.record("Expected the blocked rename to hit SQLITE_BUSY")
+        } catch SQLiteError.stepFailed(let code, _, _) {
+            #expect(code == SQLITE_BUSY)
+        } catch {
+            Issue.record("Expected SQLITE_BUSY, got \(error)")
+        }
+
+        try writer.exec("ROLLBACK")
+        try await Task.sleep(nanoseconds: 300_000_000)
+
+        let row = try #require(try store.loadSession(id: "local-1"))
+        #expect(row.title == "Original")
         #expect(row.titleSource == .placeholder)
     }
 

--- a/AlasTests/Remote/RemoteSessionGatewayTests.swift
+++ b/AlasTests/Remote/RemoteSessionGatewayTests.swift
@@ -82,9 +82,10 @@ final class FakeSessionsProvider: RemoteSessionsProvider {
     }
 
     func isWriter(for id: String) -> Bool { writers.contains(id) }
-    func takeOver(for id: String) {
+    func takeOver(for id: String) async -> Bool {
         tookOver.append(id)
         writers.insert(id)
+        return true
     }
 
     var sendPromptResultIsAsync = false   // deliver onResult on a later tick (models a late delivery failure)
@@ -436,7 +437,7 @@ struct RemoteSessionGatewayTests {
     }
 
     @Test func takeOverPushesSnapshotWithCanDrive() async throws {
-        // Regression: takeover seizes the writer lease synchronously but mutates
+        // Regression: takeover seizes the writer lease before returning but mutates
         // lease/agent state rather than the transcript, so the objectWillChange
         // delta may never fire on an idle session. The gateway must push a
         // snapshot itself so the client learns canDrive=true and unlocks the

--- a/AlasTests/SQLiteKit/SQLiteDatabaseTests.swift
+++ b/AlasTests/SQLiteKit/SQLiteDatabaseTests.swift
@@ -1,4 +1,5 @@
 import Foundation
+import SQLite3
 import Testing
 @testable import Alas
 
@@ -52,5 +53,516 @@ struct SQLiteDatabaseTests {
 
         #expect(changed == 1)
         #expect(missing == 0)
+    }
+
+    @Test("busy timeout is configurable")
+    func busyTimeoutIsConfigurable() throws {
+        let url = tmp()
+        defer { try? FileManager.default.removeItem(at: url) }
+        let writer = try SQLiteDatabase(path: url.path)
+        try writer.exec("CREATE TABLE t (id INTEGER PRIMARY KEY, name TEXT NOT NULL)")
+        try writer.exec("BEGIN IMMEDIATE")
+        defer { try? writer.exec("ROLLBACK") }
+
+        let blocked = try SQLiteDatabase(path: url.path, busyTimeoutMilliseconds: 25)
+        let start = Date()
+        do {
+            try blocked.exec("INSERT INTO t (name) VALUES ('blocked')")
+            Issue.record("Expected the blocked writer to hit SQLITE_BUSY")
+        } catch SQLiteError.stepFailed(let code, _, _) {
+            #expect(code == SQLITE_BUSY)
+        } catch {
+            Issue.record("Expected SQLITE_BUSY, got \(error)")
+        }
+        #expect(Date().timeIntervalSince(start) < 1.0)
+    }
+
+    @Test("busy retry persists permission decisions")
+    func busyRetryPersistsPermissionDecisions() async throws {
+        let url = tmp()
+        defer { try? FileManager.default.removeItem(at: url) }
+        let writer = try SQLiteDatabase(path: url.path)
+        try writer.exec("""
+        CREATE TABLE permission_decisions (
+          session_id  TEXT NOT NULL,
+          scope_key   TEXT NOT NULL,
+          decision    TEXT NOT NULL,
+          scope       TEXT NOT NULL,
+          decided_at  INTEGER NOT NULL,
+          PRIMARY KEY (session_id, scope_key)
+        )
+        """)
+        try writer.exec("BEGIN IMMEDIATE")
+
+        let blocked = try SQLiteDatabase(path: url.path, busyTimeoutMilliseconds: 0)
+        blocked.setBusyRetryTimeout(milliseconds: 1_000)
+        do {
+            try blocked.exec("""
+            INSERT INTO permission_decisions (session_id, scope_key, decision, scope, decided_at)
+            VALUES (?,?,?,?,?)
+            ON CONFLICT(session_id, scope_key) DO UPDATE SET
+                decision = excluded.decision,
+                scope = excluded.scope,
+                decided_at = excluded.decided_at
+            """, bindings: ["session-1", "scope-key", "allow", "session", Int64(1)])
+            Issue.record("Expected the blocked permission write to hit SQLITE_BUSY")
+        } catch SQLiteError.stepFailed(let code, _, _) {
+            #expect(code == SQLITE_BUSY)
+        } catch {
+            Issue.record("Expected SQLITE_BUSY, got \(error)")
+        }
+
+        try writer.exec("ROLLBACK")
+        let deadline = Date().addingTimeInterval(2)
+        while Date() < deadline {
+            let rows = try writer.query("""
+            SELECT decision FROM permission_decisions
+            WHERE session_id = ? AND scope_key = ?
+            """, bindings: ["session-1", "scope-key"])
+            if rows.first?["decision"] as? String == "allow" {
+                return
+            }
+            try await Task.sleep(nanoseconds: 50_000_000)
+        }
+        Issue.record("Expected permission decision to be replayed after the writer lock cleared")
+    }
+
+    @Test("busy retry waits for parent session before replaying child rows")
+    func busyRetryWaitsForSessionParentBeforeChildRows() async throws {
+        let url = tmp()
+        defer { try? FileManager.default.removeItem(at: url) }
+        let writer = try SQLiteDatabase(path: url.path)
+        try writer.exec("""
+        CREATE TABLE sessions (
+          id TEXT PRIMARY KEY,
+          title TEXT NOT NULL
+        )
+        """)
+        try writer.exec("""
+        CREATE TABLE composer_drafts (
+          session_id TEXT PRIMARY KEY REFERENCES sessions(id) ON DELETE CASCADE,
+          payload TEXT NOT NULL
+        )
+        """)
+        try writer.exec("BEGIN IMMEDIATE")
+
+        let blocked = try SQLiteDatabase(path: url.path, busyTimeoutMilliseconds: 0)
+        blocked.setBusyRetryTimeout(milliseconds: 1_000)
+        do {
+            try blocked.exec("""
+            INSERT INTO composer_drafts (session_id, payload)
+            VALUES (?, ?)
+            """, bindings: ["session-1", "draft"])
+            Issue.record("Expected the blocked draft write to hit SQLITE_BUSY")
+        } catch SQLiteError.stepFailed(let code, _, _) {
+            #expect(code == SQLITE_BUSY)
+        } catch {
+            Issue.record("Expected SQLITE_BUSY, got \(error)")
+        }
+
+        try writer.exec("ROLLBACK")
+        try await Task.sleep(nanoseconds: 200_000_000)
+        try writer.exec("INSERT INTO sessions (id, title) VALUES (?, ?)", bindings: ["session-1", "New"])
+
+        let deadline = Date().addingTimeInterval(2)
+        while Date() < deadline {
+            let rows = try writer.query("""
+            SELECT payload FROM composer_drafts
+            WHERE session_id = ?
+            """, bindings: ["session-1"])
+            if rows.first?["payload"] as? String == "draft" {
+                return
+            }
+            try await Task.sleep(nanoseconds: 50_000_000)
+        }
+        Issue.record("Expected child row retry to wait for and persist after the parent session exists")
+    }
+
+    @Test("foreign key retry waits for parent session before replaying child rows")
+    func foreignKeyRetryWaitsForSessionParentBeforeChildRows() async throws {
+        let url = tmp()
+        defer { try? FileManager.default.removeItem(at: url) }
+        let db = try SQLiteDatabase(path: url.path)
+        try db.exec("""
+        CREATE TABLE sessions (
+          id TEXT PRIMARY KEY,
+          title TEXT NOT NULL
+        )
+        """)
+        try db.exec("""
+        CREATE TABLE composer_drafts (
+          session_id TEXT PRIMARY KEY REFERENCES sessions(id) ON DELETE CASCADE,
+          payload TEXT NOT NULL
+        )
+        """)
+        db.setBusyRetryTimeout(milliseconds: 1_000)
+        do {
+            try db.exec("""
+            INSERT INTO composer_drafts (session_id, payload)
+            VALUES (?, ?)
+            """, bindings: ["session-1", "draft"])
+            Issue.record("Expected the child write to hit a foreign-key failure")
+        } catch SQLiteError.stepFailed(let code, _, _) {
+            #expect(code == SQLITE_CONSTRAINT)
+        } catch {
+            Issue.record("Expected SQLITE_CONSTRAINT, got \(error)")
+        }
+
+        try await Task.sleep(nanoseconds: 200_000_000)
+        try db.exec("INSERT INTO sessions (id, title) VALUES (?, ?)", bindings: ["session-1", "New"])
+
+        let deadline = Date().addingTimeInterval(2)
+        while Date() < deadline {
+            let rows = try db.query("""
+            SELECT payload FROM composer_drafts
+            WHERE session_id = ?
+            """, bindings: ["session-1"])
+            if rows.first?["payload"] as? String == "draft" {
+                return
+            }
+            try await Task.sleep(nanoseconds: 50_000_000)
+        }
+        Issue.record("Expected child row retry to wait for and persist after the parent session exists")
+    }
+
+    @Test("busy retry does not recreate deleted sessions from queued upserts")
+    func busyRetryDoesNotRecreateDeletedSessionsFromQueuedUpserts() async throws {
+        let url = tmp()
+        defer { try? FileManager.default.removeItem(at: url) }
+        let writer = try SQLiteDatabase(path: url.path)
+        try writer.exec("""
+        CREATE TABLE sessions (
+          id TEXT PRIMARY KEY,
+          title TEXT NOT NULL
+        )
+        """)
+        try writer.exec("INSERT INTO sessions (id, title) VALUES (?, ?)", bindings: ["session-1", "Original"])
+        try writer.exec("BEGIN IMMEDIATE")
+        try writer.exec("DELETE FROM sessions WHERE id = ?", bindings: ["session-1"])
+
+        let blocked = try SQLiteDatabase(path: url.path, busyTimeoutMilliseconds: 0)
+        blocked.setBusyRetryTimeout(milliseconds: 300)
+        do {
+            try blocked.exec("""
+            INSERT INTO sessions (id, title)
+            VALUES (?, ?)
+            ON CONFLICT(id) DO UPDATE SET title = excluded.title
+            """, bindings: ["session-1", "Recreated"])
+            Issue.record("Expected the blocked session upsert to hit SQLITE_BUSY")
+        } catch SQLiteError.stepFailed(let code, _, _) {
+            #expect(code == SQLITE_BUSY)
+        } catch {
+            Issue.record("Expected SQLITE_BUSY, got \(error)")
+        }
+
+        try writer.exec("COMMIT")
+        try await Task.sleep(nanoseconds: 600_000_000)
+        let rows = try writer.query("SELECT title FROM sessions WHERE id = ?", bindings: ["session-1"])
+        #expect(rows.isEmpty)
+    }
+
+    @Test("busy retry replays new session upserts")
+    func busyRetryReplaysNewSessionUpserts() async throws {
+        let url = tmp()
+        defer { try? FileManager.default.removeItem(at: url) }
+        let writer = try SQLiteDatabase(path: url.path)
+        try writer.exec("""
+        CREATE TABLE sessions (
+          id TEXT PRIMARY KEY,
+          title TEXT NOT NULL
+        )
+        """)
+        try writer.exec("BEGIN IMMEDIATE")
+
+        let blocked = try SQLiteDatabase(path: url.path, busyTimeoutMilliseconds: 0)
+        blocked.setBusyRetryTimeout(milliseconds: 1_000)
+        do {
+            try blocked.exec("""
+            INSERT INTO sessions (id, title)
+            VALUES (?, ?)
+            ON CONFLICT(id) DO UPDATE SET title = excluded.title
+            """, bindings: ["session-1", "Created"])
+            Issue.record("Expected the blocked session upsert to hit SQLITE_BUSY")
+        } catch SQLiteError.stepFailed(let code, _, _) {
+            #expect(code == SQLITE_BUSY)
+        } catch {
+            Issue.record("Expected SQLITE_BUSY, got \(error)")
+        }
+
+        try writer.exec("ROLLBACK")
+        let deadline = Date().addingTimeInterval(2)
+        while Date() < deadline {
+            let rows = try writer.query("SELECT title FROM sessions WHERE id = ?", bindings: ["session-1"])
+            if rows.first?["title"] as? String == "Created" {
+                return
+            }
+            try await Task.sleep(nanoseconds: 50_000_000)
+        }
+        Issue.record("Expected new session upsert to replay after the writer lock cleared")
+    }
+
+    @Test("busy retry delete intent cancels queued new session upserts")
+    func busyRetryDeleteIntentCancelsQueuedNewSessionUpserts() async throws {
+        let url = tmp()
+        defer { try? FileManager.default.removeItem(at: url) }
+        let writer = try SQLiteDatabase(path: url.path)
+        try writer.exec("""
+        CREATE TABLE sessions (
+          id TEXT PRIMARY KEY,
+          title TEXT NOT NULL
+        )
+        """)
+        try writer.exec("BEGIN IMMEDIATE")
+
+        let blocked = try SQLiteDatabase(path: url.path, busyTimeoutMilliseconds: 0)
+        blocked.setBusyRetryTimeout(milliseconds: 1_000)
+        do {
+            try blocked.exec("""
+            INSERT INTO sessions (id, title)
+            VALUES (?, ?)
+            ON CONFLICT(id) DO UPDATE SET title = excluded.title
+            """, bindings: ["session-1", "Created"])
+            Issue.record("Expected the blocked session upsert to hit SQLITE_BUSY")
+        } catch SQLiteError.stepFailed(let code, _, _) {
+            #expect(code == SQLITE_BUSY)
+        } catch {
+            Issue.record("Expected SQLITE_BUSY, got \(error)")
+        }
+        do {
+            try blocked.exec("DELETE FROM sessions WHERE id = ?", bindings: ["session-1"])
+            Issue.record("Expected the blocked session delete to hit SQLITE_BUSY")
+        } catch SQLiteError.stepFailed(let code, _, _) {
+            #expect(code == SQLITE_BUSY)
+        } catch {
+            Issue.record("Expected SQLITE_BUSY, got \(error)")
+        }
+
+        try writer.exec("ROLLBACK")
+        try await Task.sleep(nanoseconds: 600_000_000)
+        let rows = try writer.query("SELECT title FROM sessions WHERE id = ?", bindings: ["session-1"])
+        #expect(rows.isEmpty)
+    }
+
+    @Test("owner-scoped busy retry allows writable sessions without leases")
+    func ownerScopedBusyRetryAllowsWritableSessionWithoutLease() async throws {
+        let url = tmp()
+        defer { try? FileManager.default.removeItem(at: url) }
+        let writer = try SQLiteDatabase(path: url.path)
+        try writer.exec("CREATE TABLE sessions (id TEXT PRIMARY KEY)")
+        try writer.exec("""
+        CREATE TABLE session_leases (
+          session_id TEXT PRIMARY KEY,
+          owner_instance TEXT NOT NULL
+        )
+        """)
+        try writer.exec("""
+        CREATE TABLE composer_drafts (
+          session_id TEXT PRIMARY KEY REFERENCES sessions(id) ON DELETE CASCADE,
+          payload TEXT NOT NULL
+        )
+        """)
+        try writer.exec("INSERT INTO sessions (id) VALUES (?)", bindings: ["session-1"])
+        try writer.exec("BEGIN IMMEDIATE")
+
+        let blocked = try SQLiteDatabase(path: url.path, busyTimeoutMilliseconds: 0)
+        blocked.setBusyRetryOwnerInstanceId("owner-1")
+        blocked.setBusyRetryTimeout(milliseconds: 300)
+        do {
+            try blocked.exec("""
+            INSERT INTO composer_drafts (session_id, payload)
+            VALUES (?, ?)
+            """, bindings: ["session-1", "stale"])
+            Issue.record("Expected the blocked draft write to hit SQLITE_BUSY")
+        } catch SQLiteError.stepFailed(let code, _, _) {
+            #expect(code == SQLITE_BUSY)
+        } catch {
+            Issue.record("Expected SQLITE_BUSY, got \(error)")
+        }
+
+        try writer.exec("ROLLBACK")
+        let deadline = Date().addingTimeInterval(2)
+        while Date() < deadline {
+            let rows = try writer.query("SELECT payload FROM composer_drafts WHERE session_id = ?", bindings: ["session-1"])
+            if rows.first?["payload"] as? String == "stale" {
+                return
+            }
+            try await Task.sleep(nanoseconds: 50_000_000)
+        }
+        Issue.record("Expected owner-scoped retry to replay for a session without a lease row")
+    }
+
+    @Test("owner-scoped busy retry allows stale lease rows")
+    func ownerScopedBusyRetryAllowsStaleLeaseRow() async throws {
+        let url = tmp()
+        defer { try? FileManager.default.removeItem(at: url) }
+        let writer = try SQLiteDatabase(path: url.path)
+        try writer.exec("CREATE TABLE sessions (id TEXT PRIMARY KEY)")
+        try writer.exec("""
+        CREATE TABLE session_leases (
+          session_id TEXT PRIMARY KEY,
+          owner_instance TEXT NOT NULL,
+          pid INTEGER NOT NULL,
+          heartbeat_at INTEGER NOT NULL
+        )
+        """)
+        try writer.exec("""
+        CREATE TABLE composer_drafts (
+          session_id TEXT PRIMARY KEY REFERENCES sessions(id) ON DELETE CASCADE,
+          payload TEXT NOT NULL
+        )
+        """)
+        try writer.exec("INSERT INTO sessions (id) VALUES (?)", bindings: ["session-1"])
+        try writer.exec("""
+        INSERT INTO session_leases (session_id, owner_instance, pid, heartbeat_at)
+        VALUES (?,?,?,?)
+        """, bindings: ["session-1", "dead-owner", Int64(Int32.max) + 1, Int64(0)])
+        try writer.exec("BEGIN IMMEDIATE")
+
+        let blocked = try SQLiteDatabase(path: url.path, busyTimeoutMilliseconds: 0)
+        blocked.setBusyRetryOwnerInstanceId("owner-1")
+        blocked.setBusyRetryTimeout(milliseconds: 1_000)
+        do {
+            try blocked.exec("""
+            INSERT INTO composer_drafts (session_id, payload)
+            VALUES (?, ?)
+            """, bindings: ["session-1", "draft"])
+            Issue.record("Expected the blocked draft write to hit SQLITE_BUSY")
+        } catch SQLiteError.stepFailed(let code, _, _) {
+            #expect(code == SQLITE_BUSY)
+        } catch {
+            Issue.record("Expected SQLITE_BUSY, got \(error)")
+        }
+
+        try writer.exec("ROLLBACK")
+        let deadline = Date().addingTimeInterval(2)
+        while Date() < deadline {
+            let rows = try writer.query("SELECT payload FROM composer_drafts WHERE session_id = ?", bindings: ["session-1"])
+            if rows.first?["payload"] as? String == "draft" {
+                return
+            }
+            try await Task.sleep(nanoseconds: 50_000_000)
+        }
+        Issue.record("Expected owner-scoped retry to replay past a stale lease row")
+    }
+
+    @Test("owner-scoped busy retry is fenced by lease token")
+    func ownerScopedBusyRetryIsFencedByLeaseToken() async throws {
+        let url = tmp()
+        defer { try? FileManager.default.removeItem(at: url) }
+        let writer = try SQLiteDatabase(path: url.path)
+        try writer.exec("CREATE TABLE sessions (id TEXT PRIMARY KEY)")
+        try writer.exec("""
+        CREATE TABLE session_leases (
+          session_id TEXT PRIMARY KEY,
+          owner_instance TEXT NOT NULL,
+          pid INTEGER NOT NULL,
+          heartbeat_at INTEGER NOT NULL,
+          lease_token TEXT NOT NULL
+        )
+        """)
+        try writer.exec("""
+        CREATE TABLE composer_drafts (
+          session_id TEXT PRIMARY KEY REFERENCES sessions(id) ON DELETE CASCADE,
+          payload TEXT NOT NULL
+        )
+        """)
+        try writer.exec("INSERT INTO sessions (id) VALUES (?)", bindings: ["session-1"])
+        try writer.exec("""
+        INSERT INTO session_leases (session_id, owner_instance, pid, heartbeat_at, lease_token)
+        VALUES (?,?,?,?,?)
+        """, bindings: [
+            "session-1",
+            "owner-1",
+            Int64(ProcessInfo.processInfo.processIdentifier),
+            Int64(Date().timeIntervalSince1970),
+            "old-token"
+        ])
+        try writer.exec("BEGIN IMMEDIATE")
+
+        let blocked = try SQLiteDatabase(path: url.path, busyTimeoutMilliseconds: 0)
+        blocked.setBusyRetryOwnerInstanceId("owner-1")
+        blocked.setBusyRetryTimeout(milliseconds: 300)
+        do {
+            try blocked.exec("""
+            INSERT INTO composer_drafts (session_id, payload)
+            VALUES (?, ?)
+            """, bindings: ["session-1", "stale"])
+            Issue.record("Expected the blocked draft write to hit SQLITE_BUSY")
+        } catch SQLiteError.stepFailed(let code, _, _) {
+            #expect(code == SQLITE_BUSY)
+        } catch {
+            Issue.record("Expected SQLITE_BUSY, got \(error)")
+        }
+
+        try writer.exec("""
+        UPDATE session_leases
+        SET lease_token = ?, heartbeat_at = ?
+        WHERE session_id = ? AND owner_instance = ?
+        """, bindings: [
+            "new-token",
+            Int64(Date().timeIntervalSince1970),
+            "session-1",
+            "owner-1"
+        ])
+        try writer.exec("COMMIT")
+        try await Task.sleep(nanoseconds: 600_000_000)
+        let rows = try writer.query("SELECT payload FROM composer_drafts WHERE session_id = ?", bindings: ["session-1"])
+        #expect(rows.isEmpty)
+    }
+
+    @Test("owner-scoped busy retry blocks when captured lease disappears")
+    func ownerScopedBusyRetryBlocksWhenCapturedLeaseDisappears() async throws {
+        let url = tmp()
+        defer { try? FileManager.default.removeItem(at: url) }
+        let writer = try SQLiteDatabase(path: url.path)
+        try writer.exec("CREATE TABLE sessions (id TEXT PRIMARY KEY)")
+        try writer.exec("""
+        CREATE TABLE session_leases (
+          session_id TEXT PRIMARY KEY,
+          owner_instance TEXT NOT NULL,
+          pid INTEGER NOT NULL,
+          heartbeat_at INTEGER NOT NULL,
+          lease_token TEXT NOT NULL
+        )
+        """)
+        try writer.exec("""
+        CREATE TABLE composer_drafts (
+          session_id TEXT PRIMARY KEY REFERENCES sessions(id) ON DELETE CASCADE,
+          payload TEXT NOT NULL
+        )
+        """)
+        try writer.exec("INSERT INTO sessions (id) VALUES (?)", bindings: ["session-1"])
+        try writer.exec("""
+        INSERT INTO session_leases (session_id, owner_instance, pid, heartbeat_at, lease_token)
+        VALUES (?,?,?,?,?)
+        """, bindings: [
+            "session-1",
+            "owner-1",
+            Int64(ProcessInfo.processInfo.processIdentifier),
+            Int64(Date().timeIntervalSince1970),
+            "lease-token"
+        ])
+        try writer.exec("BEGIN IMMEDIATE")
+
+        let blocked = try SQLiteDatabase(path: url.path, busyTimeoutMilliseconds: 0)
+        blocked.setBusyRetryOwnerInstanceId("owner-1")
+        blocked.setBusyRetryTimeout(milliseconds: 300)
+        do {
+            try blocked.exec("""
+            INSERT INTO composer_drafts (session_id, payload)
+            VALUES (?, ?)
+            """, bindings: ["session-1", "stale"])
+            Issue.record("Expected the blocked draft write to hit SQLITE_BUSY")
+        } catch SQLiteError.stepFailed(let code, _, _) {
+            #expect(code == SQLITE_BUSY)
+        } catch {
+            Issue.record("Expected SQLITE_BUSY, got \(error)")
+        }
+
+        try writer.exec("DELETE FROM session_leases WHERE session_id = ?", bindings: ["session-1"])
+        try writer.exec("COMMIT")
+        try await Task.sleep(nanoseconds: 600_000_000)
+        let rows = try writer.query("SELECT payload FROM composer_drafts WHERE session_id = ?", bindings: ["session-1"])
+        #expect(rows.isEmpty)
     }
 }


### PR DESCRIPTION
## Summary

- Make `SQLiteDatabase` busy timeout configurable while preserving the 5s default for non-main paths.
- Use a 100ms timeout for the main-actor ACP session store created by `AppState`.
- Add a SQLite contention test that verifies a short timeout fails fast with `SQLITE_BUSY`.

## Why

ACP session managers run on the main actor, and their synchronous SQLite lease/heartbeat paths previously inherited the 5s busy timeout. A contended writer could therefore block UI responsiveness for several seconds. This keeps the existing longer timeout for off-main handles while making the main-actor store fail quickly under write contention.

## Validation

- `rtk xcodegen`
- `ALAS_FFF_TARGET_ARCH=arm64 rtk xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -only-testing:AlasTests/SQLiteDatabaseTests test`
- `ALAS_FFF_TARGET_ARCH=arm64 rtk xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -quiet build`

Note: full `xcodebuild ... test` stayed silent/active for an extended period locally and was interrupted cleanly.

Closes #689