### PR TITLE
perf(git): preserve sync fetch throttle

### DIFF
--- a/Alas/Sources/Right/RightPaneState.swift
+++ b/Alas/Sources/Right/RightPaneState.swift
@@ -20,6 +20,11 @@ struct ReviewLoopRemoteFingerprint: Equatable, Sendable {
     var remotes: [String]
 }
 
+private struct SyncFetchTarget: Hashable {
+    let remote: String
+    let branch: String
+}
+
 @Observable
 @MainActor
 final class RightPaneState {
@@ -63,6 +68,7 @@ final class RightPaneState {
     /// and disables re-entry. Only `pull()` mutates it.
     private(set) var pullInFlight: Bool = false
     private var fetchInFlight: Bool = false
+    private var lastSyncFetchAtByTarget: [SyncFetchTarget: Date] = [:]
     var fileTree: [FileTreeNode] = []
     var loading: Bool = false
     var openPaths: Set<String> = []   // expanded directories in the tree
@@ -1564,6 +1570,17 @@ final class RightPaneState {
     }
 
     @MainActor
+    private func shouldFetchSyncTarget(remote: String, branch: String, force: Bool) -> Bool {
+        let target = SyncFetchTarget(remote: remote, branch: branch)
+        let now = Date()
+        if force || now.timeIntervalSince(lastSyncFetchAtByTarget[target] ?? .distantPast) > 30 {
+            lastSyncFetchAtByTarget[target] = now
+            return true
+        }
+        return false
+    }
+
+    @MainActor
     private func refreshBehindBase(force: Bool = false) async {
         do {
             guard let resolved = try await git.resolveBaseRef(
@@ -1575,13 +1592,13 @@ final class RightPaneState {
                 return
             }
             if let remote = resolved.remote {
-                let last = behindBase?.probedAt ?? .distantPast
-                if force || Date().timeIntervalSince(last) > 30 {
+                let branch = resolved.fetchBranch ?? baseBranch
+                if shouldFetchSyncTarget(remote: remote, branch: branch, force: force) {
                     do {
                         try await git.fetchRef(
                             worktreePath: worktree.path,
                             remote: remote,
-                            branch: resolved.fetchBranch ?? baseBranch
+                            branch: branch
                         )
                     } catch {
                         logger.error("base fetch failed for \(self.worktree.path.path, privacy: .public): \(error.localizedDescription, privacy: .public)")
@@ -1611,8 +1628,7 @@ final class RightPaneState {
             // Upstream ref looks like "origin/<branch>"; the local branch name
             // is what we fetch.
             let branchName = String(upstream.ref.dropFirst(upstream.remote.count + 1))
-            let last = behindUpstream?.probedAt ?? .distantPast
-            if force || Date().timeIntervalSince(last) > 30 {
+            if shouldFetchSyncTarget(remote: upstream.remote, branch: branchName, force: force) {
                 do {
                     try await git.fetchRef(
                         worktreePath: worktree.path,

--- a/Alas/Sources/Watch/WorktreeWatcher.swift
+++ b/Alas/Sources/Watch/WorktreeWatcher.swift
@@ -104,16 +104,16 @@ final class WorktreeWatcher {
     }
 
     /// Returns `true` iff at least one event path represents a change we want
-    /// to react to. Git lockfiles are filtered out (matching the rule in
-    /// `GitEventFilter.classify`): they appear when another git process is
-    /// mid-write (commit, rebase, fetch); reacting would (a) trigger a
-    /// redundant refresh during the user's operation and (b) historically
-    /// caused `.git/index.lock` contention with terminal git. Project
-    /// lockfiles outside `.git/` (e.g. `Cargo.lock`, `package-lock.json`) are
-    /// real changes and DO trigger a refresh.
+    /// to react to. Transient git-write files are filtered out: lockfiles
+    /// appear when another git process is mid-write, and `FETCH_HEAD` is
+    /// updated by fetches that the sync-status probe itself can trigger.
+    /// Reacting would schedule redundant refreshes during the user's
+    /// operation. Project lockfiles outside `.git/` (e.g. `Cargo.lock`,
+    /// `package-lock.json`) are real changes and DO trigger a refresh.
     static func shouldRefresh(forEventPaths paths: [String]) -> Bool {
         for path in paths {
-            if path.hasSuffix(".lock") && path.contains("/.git/") {
+            if path.contains("/.git/"),
+               path.hasSuffix(".lock") || path.hasSuffix("/FETCH_HEAD") {
                 continue
             }
             return true

--- a/AlasTests/RightPaneStatePullTests.swift
+++ b/AlasTests/RightPaneStatePullTests.swift
@@ -66,6 +66,20 @@ struct RightPaneStatePullTests {
         return (clone, remote)
     }
 
+    private func pushRemoteCommit(to remote: URL, fileName: String, message: String) async throws {
+        let tmp = FileManager.default.temporaryDirectory
+            .appendingPathComponent("alas-rpspull-push-\(UUID().uuidString)")
+        defer { try? FileManager.default.removeItem(at: tmp) }
+        _ = try await Process.git(["clone", "-q", remote.path, tmp.path], cwd: nil)
+        _ = try await Process.git(["config", "user.email", "x@e"], cwd: tmp)
+        _ = try await Process.git(["config", "user.name", "x"], cwd: tmp)
+        _ = try await Process.git(["config", "commit.gpgsign", "false"], cwd: tmp)
+        try "remote change\n".write(to: tmp.appendingPathComponent(fileName), atomically: true, encoding: .utf8)
+        _ = try await Process.git(["add", fileName], cwd: tmp)
+        _ = try await Process.git(["commit", "-q", "-m", message], cwd: tmp)
+        _ = try await Process.git(["push", "-q", "origin", "main"], cwd: tmp)
+    }
+
     /// Polls `condition` on the main actor up to ~5s, returning as soon as it
     /// holds. Avoids fixed sleeps that flake under load.
     private func wait(until condition: () -> Bool) async throws {
@@ -144,23 +158,39 @@ struct RightPaneStatePullTests {
             try? FileManager.default.removeItem(at: remote)
         }
         let state = RightPaneState(worktree: makeWorktree(at: clone, branch: "main"), baseBranch: "main")
-        // Simulate a very recent probe so the 30s throttle would skip fetches
-        // for both the upstream chip AND the base chip (which also resolves to
-        // origin/main here and would otherwise side-channel the fetch).
-        let recentDate = Date()
-        state.behindBase = GitService.BehindStatus(
-            ref: "origin/main", sha: "deadbeef", count: 0, probedAt: recentDate
-        )
-        state.behindUpstream = GitService.BehindStatus(
-            ref: "origin/main", sha: "deadbeef", count: 0, probedAt: recentDate
-        )
-
-        // Non-forced: throttle skips the fetch, so the stale ref still reads 0.
         await state.refreshSyncStatus()
-        #expect(state.behindUpstream?.count == 0)
-
-        // Forced: fetches now, sees the upstream commit → behind by 1.
-        await state.refreshSyncStatus(force: true)
         #expect(state.behindUpstream?.count == 1)
+
+        try await pushRemoteCommit(to: remote, fileName: "c.txt", message: "remote-2")
+
+        // Non-forced: throttle skips the fetch, so the stale ref still reads 1.
+        await state.refreshSyncStatus()
+        #expect(state.behindUpstream?.count == 1)
+
+        // Forced: fetches now, sees the upstream commit → behind by 2.
+        await state.refreshSyncStatus(force: true)
+        #expect(state.behindUpstream?.count == 2)
+    }
+
+    @Test func refreshThrottleSurvivesClearedBehindState() async throws {
+        let (clone, remote) = try await makeCloneBehindUpstream(conflicting: false)
+        defer {
+            try? FileManager.default.removeItem(at: clone)
+            try? FileManager.default.removeItem(at: remote)
+        }
+        let state = RightPaneState(worktree: makeWorktree(at: clone, branch: "main"), baseBranch: "main")
+
+        await state.refreshSyncStatus()
+        #expect(state.behindUpstream?.count == 1)
+
+        state.behindBase = nil
+        state.behindUpstream = nil
+        try await pushRemoteCommit(to: remote, fileName: "d.txt", message: "remote-2")
+
+        await state.refreshSyncStatus()
+        #expect(state.behindUpstream?.count == 1)
+
+        await state.refreshSyncStatus(force: true)
+        #expect(state.behindUpstream?.count == 2)
     }
 }

--- a/AlasTests/WorktreeWatcherTests.swift
+++ b/AlasTests/WorktreeWatcherTests.swift
@@ -25,6 +25,12 @@ struct WorktreeWatcherTests {
         ) == false)
     }
 
+    @Test func gitFetchHeadSkipsRefresh() {
+        #expect(WorktreeWatcher.shouldRefresh(
+            forEventPaths: ["/Users/x/repo/.git/FETCH_HEAD"]
+        ) == false)
+    }
+
     @Test func linkedWorktreeIndexLockSkipsRefresh() {
         #expect(WorktreeWatcher.shouldRefresh(
             forEventPaths: ["/Users/x/repo/.git/worktrees/feat-foo/index.lock"]


### PR DESCRIPTION
## Summary

Fixes #693.

- Decouple sync-status fetch throttling from the published behind-chip state.
- Key the fetch throttle by remote and branch so clearing `behindBase` / `behindUpstream` on HEAD changes does not force a network fetch on every commit or rebase step.
- Ignore `.git/FETCH_HEAD` events in the worktree watcher so sync-status fetches do not schedule redundant refresh cycles.

## Validation

- `ALAS_FFF_TARGET_ARCH=arm64 rtk xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -only-testing:AlasTests/RightPaneStatePullTests -only-testing:AlasTests/WorktreeWatcherTests test`
- `ALAS_FFF_TARGET_ARCH=arm64 rtk xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -quiet build`

A full `-quiet test` run was started locally but stopped after it remained quiet/running for several minutes without a terminal result; the focused regression tests and build passed.