### PR TITLE
fix(harness): nudge churn

### DIFF
--- a/Alas/Sources/Center/AgentHookInstallNudgeBanner.swift
+++ b/Alas/Sources/Center/AgentHookInstallNudgeBanner.swift
@@ -77,6 +77,8 @@ struct AgentHookInstallNudgeBanner: View {
                     installStatus = nil
                     resolvedNudge = nil
                 }
+                let key = await MainActor.run { nudgeKey }
+                await refreshNudge(for: key)
             } catch {
                 await MainActor.run {
                     installStatus = "Error: \(error.localizedDescription)"
@@ -95,6 +97,7 @@ struct AgentHookInstallNudgeBanner: View {
         }
     }
 
+    @MainActor
     private func refreshNudge(for key: HookInstallNudgeKey) async {
         guard !key.detectedHarnesses.isEmpty else {
             resolvedNudgeKey = key

--- a/Alas/Sources/Center/AgentHookInstallNudgeBanner.swift
+++ b/Alas/Sources/Center/AgentHookInstallNudgeBanner.swift
@@ -33,6 +33,10 @@ struct AgentHookInstallNudgeBanner: View {
         .task(id: currentNudgeKey) {
             await refreshNudge(for: currentNudgeKey)
         }
+        .onReceive(NotificationCenter.default.publisher(for: .agentHookInstallStateDidChange)) { _ in
+            let key = nudgeKey
+            Task { await refreshNudge(for: key) }
+        }
     }
 
     private func bannerRow(nudge: HookInstallNudge) -> some View {
@@ -76,6 +80,7 @@ struct AgentHookInstallNudgeBanner: View {
                 await MainActor.run {
                     installStatus = nil
                     resolvedNudge = nil
+                    NotificationCenter.default.post(name: .agentHookInstallStateDidChange, object: nil)
                 }
                 let key = await MainActor.run { nudgeKey }
                 await refreshNudge(for: key)

--- a/Alas/Sources/Center/AgentHookInstallNudgeBanner.swift
+++ b/Alas/Sources/Center/AgentHookInstallNudgeBanner.swift
@@ -9,28 +9,29 @@ struct AgentHookInstallNudgeBanner: View {
 
     @Environment(\.theme) var theme
     @State private var installStatus: String? = nil
+    @State private var resolvedNudgeKey: HookInstallNudgeKey?
+    @State private var resolvedNudge: HookInstallNudge?
 
-    private var nudge: HookInstallNudge? {
-        // Avoid re-evaluating installState() continuously during animation
-        // by memoizing around `terminalTab` identity changes.
+    private var nudgeKey: HookInstallNudgeKey {
         let sessionIds = terminalTab.root.leaves().map(\.sessionId)
         let detected = sessionIds.compactMap { appState.harness.activeHarnessBySession[$0] }
         var seen = Set<HarnessKind>()
         let uniqueDetected = detected.filter { seen.insert($0).inserted }
-        guard !uniqueDetected.isEmpty else { return nil }
-        let registry = AgentInstallerRegistry()
-        return HookInstallNudgeResolver.resolve(
+        return HookInstallNudgeKey(
             detectedHarnesses: uniqueDetected,
-            dismissed: appState.config.harness.dismissedHookInstallNudges,
-            installState: { agent in registry.installer(for: agent)?.installState() ?? .notInstalled }
+            dismissed: appState.config.harness.dismissedHookInstallNudges
         )
     }
 
     var body: some View {
+        let currentNudgeKey = nudgeKey
         Group {
-            if let nudge = nudge {
+            if resolvedNudgeKey == currentNudgeKey, let nudge = resolvedNudge {
                 bannerRow(nudge: nudge)
             }
+        }
+        .task(id: currentNudgeKey) {
+            await refreshNudge(for: currentNudgeKey)
         }
     }
 
@@ -74,6 +75,7 @@ struct AgentHookInstallNudgeBanner: View {
                 try await installer.install()
                 await MainActor.run {
                     installStatus = nil
+                    resolvedNudge = nil
                 }
             } catch {
                 await MainActor.run {
@@ -89,6 +91,31 @@ struct AgentHookInstallNudgeBanner: View {
             dismissed.append(agent.rawValue)
             appState.config.harness.dismissedHookInstallNudges = dismissed
             appState.saveConfig()
+            resolvedNudge = nil
         }
     }
+
+    private func refreshNudge(for key: HookInstallNudgeKey) async {
+        guard !key.detectedHarnesses.isEmpty else {
+            resolvedNudgeKey = key
+            resolvedNudge = nil
+            return
+        }
+        let nudge = await Task.detached(priority: .userInitiated) {
+            let registry = AgentInstallerRegistry()
+            return HookInstallNudgeResolver.resolve(
+                detectedHarnesses: key.detectedHarnesses,
+                dismissed: key.dismissed,
+                installState: { agent in registry.installer(for: agent)?.installState() ?? .notInstalled }
+            )
+        }.value
+        guard !Task.isCancelled, key == nudgeKey else { return }
+        resolvedNudgeKey = key
+        resolvedNudge = nudge
+    }
+}
+
+private struct HookInstallNudgeKey: Hashable, Sendable {
+    let detectedHarnesses: [HarnessKind]
+    let dismissed: [String]
 }

--- a/Alas/Sources/Harness/AgentInstaller.swift
+++ b/Alas/Sources/Harness/AgentInstaller.swift
@@ -13,6 +13,10 @@ protocol AgentInstaller: Sendable {
     func uninstall() throws
 }
 
+extension Notification.Name {
+    static let agentHookInstallStateDidChange = Notification.Name("io.nlopez.alas.agentHookInstallStateDidChange")
+}
+
 struct AgentInstallerRegistry: Sendable {
     let installers: [any AgentInstaller]
 

--- a/Alas/Sources/Harness/HarnessKind.swift
+++ b/Alas/Sources/Harness/HarnessKind.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-enum HarnessKind: String, Codable, CaseIterable, Identifiable {
+enum HarnessKind: String, Codable, CaseIterable, Identifiable, Sendable {
     case claudeCode = "claude-code"
     case codex      = "codex-cli"
     case cursor     = "cursor-agent"

--- a/Alas/Sources/Harness/HarnessService.swift
+++ b/Alas/Sources/Harness/HarnessService.swift
@@ -60,8 +60,8 @@ final class HarnessService {
 
     func recordHarnessDetection(sessionId: String, kind: HarnessKind?) {
         if let kind {
-            harnessBySession[sessionId] = kind
-            activeHarnessBySession[sessionId] = kind
+            if harnessBySession[sessionId] != kind { harnessBySession[sessionId] = kind }
+            if activeHarnessBySession[sessionId] != kind { activeHarnessBySession[sessionId] = kind }
             // Seed running activity for users without hooks installed (or for
             // the gap before the first hook fires). Don't clobber an existing
             // hook-driven state — socket events are authoritative once they
@@ -76,7 +76,9 @@ final class HarnessService {
                 )
             }
         } else {
-            activeHarnessBySession.removeValue(forKey: sessionId)
+            if activeHarnessBySession[sessionId] != nil {
+                activeHarnessBySession.removeValue(forKey: sessionId)
+            }
             // Process exited. Drop the running badge but preserve
             // awaiting/idle state — those carry the last notification
             // context, and the stop-hook may still race process exit.

--- a/Alas/Sources/Harness/HookInstallNudgeResolver.swift
+++ b/Alas/Sources/Harness/HookInstallNudgeResolver.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-struct HookInstallNudge: Equatable {
+struct HookInstallNudge: Equatable, Sendable {
     let agent: AgentKind
     let installState: InstallState
     let title: String

--- a/Alas/Sources/Settings/TerminalPane.swift
+++ b/Alas/Sources/Settings/TerminalPane.swift
@@ -179,6 +179,7 @@ struct TerminalPane: View {
             do {
                 try await installer.install()
                 refreshInstallStates()
+                NotificationCenter.default.post(name: .agentHookInstallStateDidChange, object: nil)
                 hookStatus[agent] = "Installed"
             } catch {
                 refreshInstallStates()
@@ -192,6 +193,7 @@ struct TerminalPane: View {
         do {
             try installer.uninstall()
             refreshInstallStates()
+            NotificationCenter.default.post(name: .agentHookInstallStateDidChange, object: nil)
             hookStatus[agent] = "Uninstalled"
         } catch {
             refreshInstallStates()

--- a/AlasTests/HarnessServiceTests.swift
+++ b/AlasTests/HarnessServiceTests.swift
@@ -1,5 +1,6 @@
 import Testing
 import Foundation
+import Observation
 import UserNotifications
 @testable import Alas
 
@@ -262,6 +263,38 @@ struct HarnessServiceTests {
         service.recordHarnessDetection(sessionId: "s2", kind: nil)
         #expect(service.activityBySession["s2"]?.state == .awaitingInput)
         #expect(service.activeHarnessBySession["s2"] == nil)
+    }
+
+    @Test func recordHarnessDetection_skipsUnchangedActiveHarnessMutation() {
+        let (service, _) = makeService()
+        service.recordHarnessDetection(sessionId: "s1", kind: .claudeCode)
+
+        var invalidations = 0
+        _ = withObservationTracking {
+            _ = service.activeHarnessBySession
+        } onChange: {
+            invalidations += 1
+        }
+
+        service.recordHarnessDetection(sessionId: "s1", kind: .claudeCode)
+        #expect(invalidations == 0)
+
+        service.recordHarnessDetection(sessionId: "s1", kind: nil)
+        #expect(invalidations == 1)
+    }
+
+    @Test func recordHarnessDetection_nilSkipsAbsentActiveHarnessMutation() {
+        let (service, _) = makeService()
+
+        var invalidations = 0
+        _ = withObservationTracking {
+            _ = service.activeHarnessBySession
+        } onChange: {
+            invalidations += 1
+        }
+
+        service.recordHarnessDetection(sessionId: "missing", kind: nil)
+        #expect(invalidations == 0)
     }
 
     // MARK: - Cursor idle debounce


### PR DESCRIPTION
Fixes #698.

Summary:
- Skips unchanged HarnessService detection writes so polling does not invalidate observers.
- Resolves the hook install nudge from a cached task key instead of running installer state checks in SwiftUI body.
- Adds observation tests for no-op detection updates.

Validation:
- ALAS_FFF_TARGET_ARCH=arm64 xcodebuild -project Alas.xcodeproj -scheme Alas -destination platform=macOS -only-testing:AlasTests/HarnessServiceTests test
- ALAS_FFF_TARGET_ARCH=arm64 xcodebuild -project Alas.xcodeproj -scheme Alas -destination platform=macOS -quiet build
- ALAS_FFF_TARGET_ARCH=arm64 xcodebuild -project Alas.xcodeproj -scheme Alas -destination platform=macOS test was interrupted after unrelated existing failures/hang in ACPSession long image URL asset tests and DiffPaneViewTests syntax highlighting.