### PR TITLE
perf(ui): cache theme colors and formatters

### DIFF
--- a/Alas/Sources/Center/Commit/CommitHeaderView.swift
+++ b/Alas/Sources/Center/Commit/CommitHeaderView.swift
@@ -106,13 +106,17 @@ struct CommitHeaderView: View {
     }
 
     private func absoluteDate(_ date: Date) -> String {
-        let fmt = DateFormatter()
-        fmt.dateFormat = "yyyy-MM-dd HH:mm"
-        return fmt.string(from: date)
+        Self.absoluteDateFormatter.string(from: date)
     }
 
     private func copyToPasteboard(_ text: String, feedback: String) {
         Clipboard.copy(text)
         copyFeedback.show(feedback)
     }
+
+    private static let absoluteDateFormatter: DateFormatter = {
+        let formatter = DateFormatter()
+        formatter.dateFormat = "yyyy-MM-dd HH:mm"
+        return formatter
+    }()
 }

--- a/Alas/Sources/Sidebar/WorktreeRowView.swift
+++ b/Alas/Sources/Sidebar/WorktreeRowView.swift
@@ -155,9 +155,7 @@ struct WorktreeRowView: View {
     }
 
     private func relative(_ date: Date) -> String {
-        let formatter = RelativeDateTimeFormatter()
-        formatter.unitsStyle = .abbreviated
-        return formatter.localizedString(for: date, relativeTo: Date())
+        Self.relativeDateFormatter.localizedString(for: date, relativeTo: Date())
     }
 
     private func pillTooltip(for summary: HarnessService.WorktreeHarnessSummary) -> String {
@@ -168,6 +166,12 @@ struct WorktreeRowView: View {
         }
         return "\(summary.agent.displayName) · \(stateText)"
     }
+
+    private static let relativeDateFormatter: RelativeDateTimeFormatter = {
+        let formatter = RelativeDateTimeFormatter()
+        formatter.unitsStyle = .abbreviated
+        return formatter
+    }()
 }
 
 private extension String {

--- a/Alas/Sources/Theme/Theme.swift
+++ b/Alas/Sources/Theme/Theme.swift
@@ -20,7 +20,20 @@ struct Theme: Codable, Equatable {
     /// are purely runtime-derived.
     var resolvedColorOverrides: [String: Color] = [:]
 
+    /// Token-name → precomputed `Color` values derived from `tokens`.
+    /// Populated when bundled themes load so `color(_:)` does not parse and
+    /// convert OKLCH strings during every SwiftUI body pass.
+    private(set) var resolvedColors: [String: Color] = [:]
+
     enum CodingKeys: String, CodingKey { case id, name, tokens }
+
+    static func == (lhs: Theme, rhs: Theme) -> Bool {
+        lhs.id == rhs.id
+            && lhs.name == rhs.name
+            && lhs.tokens == rhs.tokens
+            && lhs.accentOverrideHex == rhs.accentOverrideHex
+            && lhs.resolvedColorOverrides == rhs.resolvedColorOverrides
+    }
 
     static let bundledIds = ["cool-slate", "light"]
 
@@ -46,7 +59,9 @@ struct Theme: Codable, Equatable {
             throw NSError(domain: "Theme", code: 1, userInfo: [NSLocalizedDescriptionKey: "Missing theme \(id)"])
         }
         let data = try Data(contentsOf: url)
-        return try JSONDecoder().decode(Theme.self, from: data)
+        var theme = try JSONDecoder().decode(Theme.self, from: data)
+        theme.resolvedColors = precomputedColors(from: theme.tokens)
+        return theme
     }
 
     func color(_ token: String) -> Color {
@@ -61,11 +76,24 @@ struct Theme: Codable, Equatable {
                 return Color(hex: hex).opacity(0.18)
             }
         }
+        if let resolved = resolvedColors[token] {
+            return resolved
+        }
         guard let raw = tokens[token],
               let parsed = try? OKLCH.parse(raw) else {
             return .pink   // sentinel, easy to spot
         }
         return parsed.toColor()
+    }
+
+    private static func precomputedColors(from tokens: [String: String]) -> [String: Color] {
+        var colors: [String: Color] = [:]
+        colors.reserveCapacity(tokens.count)
+        for (token, raw) in tokens {
+            guard let parsed = try? OKLCH.parse(raw) else { continue }
+            colors[token] = parsed.toColor()
+        }
+        return colors
     }
 }
 

--- a/Alas/Sources/UI/RelativeTime.swift
+++ b/Alas/Sources/UI/RelativeTime.swift
@@ -1,5 +1,13 @@
 import Foundation
 
+private enum RelativeTimeFormatters {
+    static let monthDay: DateFormatter = {
+        let formatter = DateFormatter()
+        formatter.dateFormat = "MMM d"
+        return formatter
+    }()
+}
+
 /// Compact "now / Nm / Nh / Nd / MMM d" age label, used in commit rows
 /// and commit headers.
 func relativeTime(_ date: Date) -> String {
@@ -8,7 +16,5 @@ func relativeTime(_ date: Date) -> String {
     if delta < 3600 { return "\(Int(delta / 60))m" }
     if delta < 86_400 { return "\(Int(delta / 3600))h" }
     if delta < 30 * 86_400 { return "\(Int(delta / 86_400))d" }
-    let fmt = DateFormatter()
-    fmt.dateFormat = "MMM d"
-    return fmt.string(from: date)
+    return RelativeTimeFormatters.monthDay.string(from: date)
 }

--- a/AlasTests/ThemeTests.swift
+++ b/AlasTests/ThemeTests.swift
@@ -1,4 +1,5 @@
 import Testing
+import SwiftUI
 @testable import Alas
 
 struct ThemeTests {
@@ -18,6 +19,31 @@ struct ThemeTests {
 
     @Test func bundledIdsAreLightAndDark() {
         #expect(Theme.bundledIds.sorted() == ["cool-slate", "light"])
+    }
+
+    @Test func bundledThemesPrecomputeTokenColors() throws {
+        let theme = try Theme.loadBundled(id: "cool-slate")
+        #expect(theme.resolvedColors.count == theme.tokens.count)
+        #expect(theme.resolvedColors["fg"] != nil)
+        #expect(theme.resolvedColors["accent"] != nil)
+    }
+
+    @Test func themeEqualityIgnoresDerivedColorCache() throws {
+        let cached = try Theme.loadBundled(id: "cool-slate")
+        let uncached = Theme(id: cached.id, name: cached.name, tokens: cached.tokens)
+        #expect(cached == uncached)
+    }
+
+    @Test func colorLookupUsesAccentOverrideBeforePrecomputedToken() throws {
+        var theme = try Theme.loadBundled(id: "cool-slate")
+        theme.accentOverrideHex = "#123456"
+        #expect(theme.color("accent") == Color(hex: "#123456"))
+    }
+
+    @Test func colorLookupUsesRuntimeOverrideBeforePrecomputedToken() throws {
+        var theme = try Theme.loadBundled(id: "cool-slate")
+        theme.resolvedColorOverrides["fg"] = .white
+        #expect(theme.color("fg") == .white)
     }
 
     @Test func darkModeIsFalseForLight() throws {


### PR DESCRIPTION
## Summary

Fixes #699.

- Reuse static date formatter instances in sidebar worktree rows, compact relative time labels, and commit header absolute dates.
- Precompute bundled theme token colors at load time so `Theme.color(_:)` does not parse OKLCH strings and convert color spaces during every SwiftUI render pass.
- Preserve runtime override precedence for sidebar contrast and accent overrides, and keep the derived color cache out of theme equality.

## Validation

- `ALAS_FFF_TARGET_ARCH=arm64 rtk xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -only-testing:AlasTests/ThemeTests -only-testing:AlasTests/ThemeSidebarContrastTests -only-testing:AlasTests/CommitHeaderViewTests -only-testing:AlasTests/WorktreeRowHeightTests test`
- `rtk xcodegen`
- `ALAS_FFF_TARGET_ARCH=arm64 rtk xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -quiet build`
- `git diff --check`

A full `xcodebuild test` run was started locally but stopped after a long quiet run without a terminal result; focused coverage and the quiet build passed.