### PR TITLE
feat(diff): Redesign the diff expand-context button

### DIFF
--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -1162,6 +1162,7 @@
 		FF23739CD41997C6DD44E18B /* ACPFileWriter.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE0C0029F439C282D474ED77 /* ACPFileWriter.swift */; };
 		FF34E8DF7CDAECF80934F3A0 /* PendingStashDropTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F66CF7F86AACAAEA759C8A1B /* PendingStashDropTests.swift */; };
 		FF4707BB143F25062DD3BC43 /* AgentAutoLaunchTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 36F875ED8D44E6C298588E60 /* AgentAutoLaunchTests.swift */; };
+		FF77548C74703C8DDC9B480B /* DiffPaneTextDocumentBuilderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8501B285B416ECC49BCC22C3 /* DiffPaneTextDocumentBuilderTests.swift */; };
 		FF7DDFC667CE2E3964B51FA5 /* LSPInstallProgressSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2379C3F8504AD2EE73130AC4 /* LSPInstallProgressSheet.swift */; };
 		FFC747D542D806E6CF6FCD03 /* CompletionPopup.swift in Sources */ = {isa = PBXBuildFile; fileRef = 348D2E5F6030BB9F2BDEFA26 /* CompletionPopup.swift */; };
 /* End PBXBuildFile section */
@@ -1773,6 +1774,7 @@
 		8451C5BCEE50F118F07CDD83 /* RightPaneStoreBaseBranchTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RightPaneStoreBaseBranchTests.swift; sourceTree = "<group>"; };
 		84A01D6512394EF1C41782AD /* ACPMarkdownInlineTextView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPMarkdownInlineTextView.swift; sourceTree = "<group>"; };
 		84E56989C04A4A478D68084C /* ACPMarkdownBlockCacheTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPMarkdownBlockCacheTests.swift; sourceTree = "<group>"; };
+		8501B285B416ECC49BCC22C3 /* DiffPaneTextDocumentBuilderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiffPaneTextDocumentBuilderTests.swift; sourceTree = "<group>"; };
 		8526C9DB63760BDD2CE998BD /* fs-write.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "fs-write.json"; sourceTree = "<group>"; };
 		8528D2A61E1FC9F51296C9F6 /* ACPLaunchSpec.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPLaunchSpec.swift; sourceTree = "<group>"; };
 		856607304A9F2409EF40BD5F /* PendingDiscardTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PendingDiscardTests.swift; sourceTree = "<group>"; };
@@ -2567,6 +2569,7 @@
 				61D4F5B30CE2AA0220A3E45C /* DiffInlineHighlighterTests.swift */,
 				2BFCE07604D55558B13FC33B /* DiffOpenFileAvailabilityTests.swift */,
 				AD920E9E496F1DC3BB894B8B /* DiffPaneLSPTests.swift */,
+				8501B285B416ECC49BCC22C3 /* DiffPaneTextDocumentBuilderTests.swift */,
 				E5A257562FAB9C5932A6BD69 /* DiffPaneViewTests.swift */,
 				EE26221DC8E8837FFEB87474 /* DiffParserTests.swift */,
 				27EEC16C786CE9430C1AC174 /* DiffReviewFileSectionEqualityTests.swift */,
@@ -5449,6 +5452,7 @@
 				172298A09BC94456A27EFCB7 /* DiffInlineHighlighterTests.swift in Sources */,
 				9927E3934D3CAA9055EF5E44 /* DiffOpenFileAvailabilityTests.swift in Sources */,
 				F4796D2FCBA83BD5E71F4398 /* DiffPaneLSPTests.swift in Sources */,
+				FF77548C74703C8DDC9B480B /* DiffPaneTextDocumentBuilderTests.swift in Sources */,
 				F4FF07CA337DB0D0035C3C10 /* DiffPaneViewTests.swift in Sources */,
 				0CF488290CC525EA7C11A43C /* DiffParserTests.swift in Sources */,
 				D215CAABE4DE2F5CE3CB0E93 /* DiffReviewFileSectionEqualityTests.swift in Sources */,

--- a/Alas/Sources/Center/Diff/DiffPaneTextDocumentBuilder.swift
+++ b/Alas/Sources/Center/Diff/DiffPaneTextDocumentBuilder.swift
@@ -516,34 +516,35 @@ struct DiffPaneTextDocumentBuilder {
     private static func expandableContextAttributes(font: NSFont, theme: Theme) -> [NSAttributedString.Key: Any] {
         let paragraph = NSMutableParagraphStyle()
         paragraph.setParagraphStyle(CenterTypography.paragraphStyle())
-        paragraph.firstLineHeadIndent = expandableContextHeadIndent
-        paragraph.headIndent = expandableContextHeadIndent
-        // Give the row a taller fixed line height so the row rect itself grows and
-        // the button pill has vertical room without being clipped by neighbouring
-        // rows. (Paragraph spacing does not enlarge the measured row rect.)
-        paragraph.minimumLineHeight = expandableContextRowHeight
-        paragraph.maximumLineHeight = expandableContextRowHeight
-        // A fixed line height puts all the extra space above the glyphs (they end
-        // up bottom-aligned). Raise the glyphs by half the surplus so they sit in
-        // the vertical center of the row, letting the pill center on the row and
-        // still wrap the label symmetrically.
+        let headIndent = expandableContextHeadIndent(font: font)
+        paragraph.firstLineHeadIndent = headIndent
+        paragraph.headIndent = headIndent
+        // Size the row from the font (code font is user-configurable up to 64pt),
+        // not a fixed height: natural line height plus symmetric vertical padding,
+        // so the row rect grows with the glyphs and the pill keeps its breathing
+        // room at any size. Baseline-shift the glyphs by the padding so they sit in
+        // the vertical center of the row and the pill can center on the row.
         let naturalLineHeight = font.ascender - font.descender
-        let baselineOffset = max(0, (expandableContextRowHeight - naturalLineHeight) / 2)
+        let rowHeight = naturalLineHeight + expandableContextRowPadding * 2
+        paragraph.minimumLineHeight = rowHeight
+        paragraph.maximumLineHeight = rowHeight
         return [
             .font: font,
             .foregroundColor: NSColor(theme.color("seg-pill-active-fg")),
             .paragraphStyle: paragraph,
-            .baselineOffset: baselineOffset,
+            .baselineOffset: expandableContextRowPadding,
         ]
     }
 
-    /// Left inset of the expand label from the code column edge. Leaves room for
-    /// the separately-drawn chevron and the pill's left padding.
-    static let expandableContextHeadIndent: CGFloat = 26
+    /// Symmetric vertical padding between the label and the pill edge.
+    private static let expandableContextRowPadding: CGFloat = 5
 
-    /// Fixed line height for the expandable-context row, taller than a code line
-    /// so the button pill has room around the label.
-    private static let expandableContextRowHeight: CGFloat = 26
+    /// Left inset of the expand label, leaving room for the separately-drawn
+    /// chevron and the pill's left padding. Scales with the font so the chevron
+    /// (sized from the same font) still fits at larger sizes.
+    static func expandableContextHeadIndent(font: NSFont) -> CGFloat {
+        font.pointSize + 16
+    }
 
     static func expandableContextLabel(_ row: DiffDisplayRow) -> String {
         let boundaryText = row.contextExpansion?.boundary == .below ? "below" : "above"

--- a/Alas/Sources/Center/Diff/DiffPaneTextDocumentBuilder.swift
+++ b/Alas/Sources/Center/Diff/DiffPaneTextDocumentBuilder.swift
@@ -474,10 +474,10 @@ struct DiffPaneTextDocumentBuilder {
         font: NSFont,
         theme: Theme
     ) -> NSAttributedString {
-        NSAttributedString(
-            string: "      \(expandableContextLabel(row))",
-            attributes: collapsedTextAttributes(font: font, theme: theme)
-        )
+        // Unified/stacked column. Previously prefixed with six spaces for indent,
+        // which pushed the label off-center inside the pill. Indent now comes from
+        // the paragraph style, so the pill wraps the glyphs symmetrically.
+        expandableContextAttributedString(row, font: font, theme: theme)
     }
 
     private static func collapsedCodeText(
@@ -496,18 +496,69 @@ struct DiffPaneTextDocumentBuilder {
         font: NSFont,
         theme: Theme
     ) -> NSAttributedString {
-        NSAttributedString(
-            string: expandableContextLabel(row),
-            attributes: collapsedTextAttributes(font: font, theme: theme)
-        )
+        expandableContextAttributedString(row, font: font, theme: theme)
     }
 
-    private static func expandableContextLabel(_ row: DiffDisplayRow) -> String {
+    private static func expandableContextAttributedString(
+        _ row: DiffDisplayRow,
+        font: NSFont,
+        theme: Theme
+    ) -> NSAttributedString {
+        let attributes = expandableContextAttributes(font: font, theme: theme)
+        let result = NSMutableAttributedString()
+
+        let symbolName = expandableContextSymbolName(boundary: row.contextExpansion?.boundary)
+        let tint = NSColor(theme.color("seg-pill-active-fg"))
+        if let attachment = chevronAttachment(symbolName: symbolName, font: font, color: tint) {
+            result.append(NSAttributedString(attachment: attachment))
+            result.append(NSAttributedString(string: " ", attributes: attributes))
+        }
+        result.append(NSAttributedString(string: expandableContextLabel(row), attributes: attributes))
+        result.addAttributes(attributes, range: NSRange(location: 0, length: result.length))
+        return result
+    }
+
+    private static func expandableContextAttributes(font: NSFont, theme: Theme) -> [NSAttributedString.Key: Any] {
+        let paragraph = NSMutableParagraphStyle()
+        paragraph.setParagraphStyle(CenterTypography.paragraphStyle())
+        paragraph.firstLineHeadIndent = expandableContextHeadIndent
+        paragraph.headIndent = expandableContextHeadIndent
+        return [
+            .font: font,
+            .foregroundColor: NSColor(theme.color("seg-pill-active-fg")),
+            .paragraphStyle: paragraph,
+        ]
+    }
+
+    /// Left inset of the expand button from the code column edge. Replaces the old
+    /// six-space string prefix; keeps the pill from hugging the gutter.
+    private static let expandableContextHeadIndent: CGFloat = 8
+
+    private static func chevronAttachment(symbolName: String, font: NSFont, color: NSColor) -> NSTextAttachment? {
+        let config = NSImage.SymbolConfiguration(pointSize: font.pointSize - 1, weight: .semibold)
+            .applying(NSImage.SymbolConfiguration(paletteColors: [color]))
+        guard let image = NSImage(systemSymbolName: symbolName, accessibilityDescription: nil)?
+            .withSymbolConfiguration(config)
+        else { return nil }
+        let attachment = NSTextAttachment()
+        attachment.image = image
+        let size = image.size
+        // Center the glyph on the font's cap height so it sits inline with the label.
+        let yOffset = (font.capHeight - size.height) / 2
+        attachment.bounds = CGRect(x: 0, y: yOffset, width: size.width, height: size.height)
+        return attachment
+    }
+
+    static func expandableContextLabel(_ row: DiffDisplayRow) -> String {
         let boundaryText = row.contextExpansion?.boundary == .below ? "below" : "above"
         guard row.collapsedLineCount > 0 else {
             return "Expand context \(boundaryText)"
         }
         return "Expand \(row.collapsedLineCount) unchanged lines \(boundaryText)"
+    }
+
+    static func expandableContextSymbolName(boundary: DiffContextBoundary?) -> String {
+        boundary == .above ? "chevron.up" : "chevron.down"
     }
 
     private static func collapsedTextAttributes(font: NSFont, theme: Theme) -> [NSAttributedString.Key: Any] {

--- a/Alas/Sources/Center/Diff/DiffPaneTextDocumentBuilder.swift
+++ b/Alas/Sources/Center/Diff/DiffPaneTextDocumentBuilder.swift
@@ -523,16 +523,32 @@ struct DiffPaneTextDocumentBuilder {
         paragraph.setParagraphStyle(CenterTypography.paragraphStyle())
         paragraph.firstLineHeadIndent = expandableContextHeadIndent
         paragraph.headIndent = expandableContextHeadIndent
+        // Give the row a taller fixed line height so the row rect itself grows and
+        // the button pill has vertical room without being clipped by neighbouring
+        // rows. (Paragraph spacing does not enlarge the measured row rect.)
+        paragraph.minimumLineHeight = expandableContextRowHeight
+        paragraph.maximumLineHeight = expandableContextRowHeight
+        // A fixed line height puts all the extra space above the glyphs (they end
+        // up bottom-aligned). Raise the glyphs by half the surplus so they sit in
+        // the vertical center of the row, letting the pill center on the row and
+        // still wrap the label symmetrically.
+        let naturalLineHeight = font.ascender - font.descender
+        let baselineOffset = max(0, (expandableContextRowHeight - naturalLineHeight) / 2)
         return [
             .font: font,
             .foregroundColor: NSColor(theme.color("seg-pill-active-fg")),
             .paragraphStyle: paragraph,
+            .baselineOffset: baselineOffset,
         ]
     }
 
     /// Left inset of the expand button from the code column edge. Replaces the old
     /// six-space string prefix; keeps the pill from hugging the gutter.
     private static let expandableContextHeadIndent: CGFloat = 8
+
+    /// Fixed line height for the expandable-context row, taller than a code line
+    /// so the button pill has room around the label.
+    private static let expandableContextRowHeight: CGFloat = 26
 
     private static func chevronAttachment(symbolName: String, font: NSFont, color: NSColor) -> NSTextAttachment? {
         let config = NSImage.SymbolConfiguration(pointSize: font.pointSize - 1, weight: .semibold)

--- a/Alas/Sources/Center/Diff/DiffPaneTextDocumentBuilder.swift
+++ b/Alas/Sources/Center/Diff/DiffPaneTextDocumentBuilder.swift
@@ -477,7 +477,7 @@ struct DiffPaneTextDocumentBuilder {
         // Unified/stacked column. Previously prefixed with six spaces for indent,
         // which pushed the label off-center inside the pill. Indent now comes from
         // the paragraph style, so the pill wraps the glyphs symmetrically.
-        expandableContextAttributedString(row, font: font, theme: theme)
+        expandableContextLabelString(row, font: font, theme: theme)
     }
 
     private static func collapsedCodeText(
@@ -496,26 +496,21 @@ struct DiffPaneTextDocumentBuilder {
         font: NSFont,
         theme: Theme
     ) -> NSAttributedString {
-        expandableContextAttributedString(row, font: font, theme: theme)
+        expandableContextLabelString(row, font: font, theme: theme)
     }
 
-    private static func expandableContextAttributedString(
+    /// The backing string is the plain label only. The directional chevron is
+    /// drawn separately by the text view (see `drawExpandableContextPill`) so it
+    /// stays out of the model — keeping selection/copy to just the label text.
+    private static func expandableContextLabelString(
         _ row: DiffDisplayRow,
         font: NSFont,
         theme: Theme
     ) -> NSAttributedString {
-        let attributes = expandableContextAttributes(font: font, theme: theme)
-        let result = NSMutableAttributedString()
-
-        let symbolName = expandableContextSymbolName(boundary: row.contextExpansion?.boundary)
-        let tint = NSColor(theme.color("seg-pill-active-fg"))
-        if let attachment = chevronAttachment(symbolName: symbolName, font: font, color: tint) {
-            result.append(NSAttributedString(attachment: attachment))
-            result.append(NSAttributedString(string: " ", attributes: attributes))
-        }
-        result.append(NSAttributedString(string: expandableContextLabel(row), attributes: attributes))
-        result.addAttributes(attributes, range: NSRange(location: 0, length: result.length))
-        return result
+        NSAttributedString(
+            string: expandableContextLabel(row),
+            attributes: expandableContextAttributes(font: font, theme: theme)
+        )
     }
 
     private static func expandableContextAttributes(font: NSFont, theme: Theme) -> [NSAttributedString.Key: Any] {
@@ -542,28 +537,13 @@ struct DiffPaneTextDocumentBuilder {
         ]
     }
 
-    /// Left inset of the expand button from the code column edge. Replaces the old
-    /// six-space string prefix; keeps the pill from hugging the gutter.
-    private static let expandableContextHeadIndent: CGFloat = 8
+    /// Left inset of the expand label from the code column edge. Leaves room for
+    /// the separately-drawn chevron and the pill's left padding.
+    static let expandableContextHeadIndent: CGFloat = 26
 
     /// Fixed line height for the expandable-context row, taller than a code line
     /// so the button pill has room around the label.
     private static let expandableContextRowHeight: CGFloat = 26
-
-    private static func chevronAttachment(symbolName: String, font: NSFont, color: NSColor) -> NSTextAttachment? {
-        let config = NSImage.SymbolConfiguration(pointSize: font.pointSize - 1, weight: .semibold)
-            .applying(NSImage.SymbolConfiguration(paletteColors: [color]))
-        guard let image = NSImage(systemSymbolName: symbolName, accessibilityDescription: nil)?
-            .withSymbolConfiguration(config)
-        else { return nil }
-        let attachment = NSTextAttachment()
-        attachment.image = image
-        let size = image.size
-        // Center the glyph on the font's cap height so it sits inline with the label.
-        let yOffset = (font.capHeight - size.height) / 2
-        attachment.bounds = CGRect(x: 0, y: yOffset, width: size.width, height: size.height)
-        return attachment
-    }
 
     static func expandableContextLabel(_ row: DiffDisplayRow) -> String {
         let boundaryText = row.contextExpansion?.boundary == .below ? "below" : "above"

--- a/Alas/Sources/Center/Diff/DiffPaneTextDocumentView.swift
+++ b/Alas/Sources/Center/Diff/DiffPaneTextDocumentView.swift
@@ -964,7 +964,20 @@ final class DiffPaneCodeTextView: NSTextView {
     private var lspController: DiffPaneLSPController?
     private var cachedRowGeometry: RowGeometry?
     private var rowGeometryComputationCount = 0
-    private var isPointingHandCursor = false
+    private var hoverExpansionRow: Int? {
+        didSet { if hoverExpansionRow != oldValue { needsDisplay = true } }
+    }
+    private var pressedExpansionRow: Int? {
+        didSet { if pressedExpansionRow != oldValue { needsDisplay = true } }
+    }
+    private var armedExpansionRow: Int?
+    private var armedExpansionOptionKey = false
+
+    static func expandPillFillAlpha(hovered: Bool, pressed: Bool) -> CGFloat {
+        if pressed { return 0.36 }
+        if hovered { return 0.28 }
+        return 0.18
+    }
 
     var rowGeometryComputationCountForTesting: Int {
         rowGeometryComputationCount
@@ -1073,12 +1086,15 @@ final class DiffPaneCodeTextView: NSTextView {
         super.mouseMoved(with: event)
         let point = convert(event.locationInWindow, from: nil)
         hoverHandler?(point)
-        updateCursor(at: point)
+        hoverExpansionRow = expansionRow(at: point)
     }
 
     override func mouseDown(with event: NSEvent) {
         let point = convert(event.locationInWindow, from: nil)
-        if invokeExpansion(at: point, optionKey: event.modifierFlags.contains(.option)) {
+        if let row = expansionRow(at: point) {
+            armedExpansionRow = row
+            armedExpansionOptionKey = event.modifierFlags.contains(.option)
+            pressedExpansionRow = row
             return
         }
         if event.modifierFlags.contains(.command), let commandClickHandler {
@@ -1088,6 +1104,30 @@ final class DiffPaneCodeTextView: NSTextView {
         super.mouseDown(with: event)
     }
 
+    override func mouseDragged(with event: NSEvent) {
+        guard let armed = armedExpansionRow else {
+            super.mouseDragged(with: event)
+            return
+        }
+        let point = convert(event.locationInWindow, from: nil)
+        pressedExpansionRow = expansionRow(at: point) == armed ? armed : nil
+    }
+
+    override func mouseUp(with event: NSEvent) {
+        guard let armed = armedExpansionRow else {
+            super.mouseUp(with: event)
+            return
+        }
+        let point = convert(event.locationInWindow, from: nil)
+        let releasedInside = expansionRow(at: point) == armed
+        let optionKey = armedExpansionOptionKey
+        pressedExpansionRow = nil
+        armedExpansionRow = nil
+        if releasedInside, let key = expansionKey(atRow: armed) {
+            invokeExpansion(key: key, optionKey: optionKey)
+        }
+    }
+
     override func flagsChanged(with event: NSEvent) {
         super.flagsChanged(with: event)
         flagsChangedHandler?(event)
@@ -1095,7 +1135,7 @@ final class DiffPaneCodeTextView: NSTextView {
 
     override func mouseExited(with event: NSEvent) {
         super.mouseExited(with: event)
-        clearPointingHandCursor()
+        hoverExpansionRow = nil
         mouseExitedHandler?()
     }
 
@@ -1127,6 +1167,7 @@ final class DiffPaneCodeTextView: NSTextView {
 
     func invalidateDiffRowGeometry() {
         cachedRowGeometry = nil
+        window?.invalidateCursorRects(for: self)
     }
 
     private func rowGeometry() -> RowGeometry {
@@ -1366,14 +1407,11 @@ final class DiffPaneCodeTextView: NSTextView {
         return rowRects.firstIndex(where: { $0.contains(point) })
     }
 
-    private func updateCursor(at point: NSPoint) {
-        guard let row = reviewLineRow(at: point),
-              rowShouldUsePointingHandCursor(row)
-        else {
-            clearPointingHandCursor()
-            return
+    override func resetCursorRects() {
+        super.resetCursorRects()
+        for (row, rect) in diffRowRects().enumerated() where rowShouldUsePointingHandCursor(row) {
+            addCursorRect(rect, cursor: .pointingHand)
         }
-        setPointingHandCursor()
     }
 
     private func rowShouldUsePointingHandCursor(_ row: Int) -> Bool {
@@ -1382,32 +1420,18 @@ final class DiffPaneCodeTextView: NSTextView {
         return metadata.expansionKey != nil || metadata.sourceLine != nil
     }
 
-    private func setPointingHandCursor() {
-        guard !isPointingHandCursor else { return }
-        NSCursor.pointingHand.set()
-        isPointingHandCursor = true
-    }
-
-    private func clearPointingHandCursor() {
-        guard isPointingHandCursor else { return }
-        NSCursor.arrow.set()
-        isPointingHandCursor = false
-    }
-
     func invokeExpansionForTesting(row: Int, optionKey: Bool) {
         guard let key = expansionKey(atRow: row) else { return }
         invokeExpansion(key: key, optionKey: optionKey)
     }
 
-    private func invokeExpansion(at point: NSPoint, optionKey: Bool) -> Bool {
+    /// Row index of the expandable-context button under `point`, if any.
+    private func expansionRow(at point: NSPoint) -> Int? {
         let rowRects = diffRowRects()
         guard let row = rowRects.firstIndex(where: { $0.contains(point) }),
-              let key = expansionKey(atRow: row)
-        else {
-            return false
-        }
-        invokeExpansion(key: key, optionKey: optionKey)
-        return true
+              expansionKey(atRow: row) != nil
+        else { return nil }
+        return row
     }
 
     private func expansionKey(atRow row: Int) -> DiffContextExpansionKey? {
@@ -1605,12 +1629,13 @@ final class DiffPaneCodeTextView: NSTextView {
             width: textRect.width + 20,
             height: pillHeight
         )
-        let path = NSBezierPath(roundedRect: pillRect, xRadius: pillHeight / 2, yRadius: pillHeight / 2)
-        NSColor(theme.color("bg-1")).withAlphaComponent(0.72).setFill()
+        let alpha = Self.expandPillFillAlpha(
+            hovered: hoverExpansionRow == row,
+            pressed: pressedExpansionRow == row
+        )
+        let path = NSBezierPath(roundedRect: pillRect, xRadius: 6, yRadius: 6)
+        NSColor(theme.color("accent")).withAlphaComponent(alpha).setFill()
         path.fill()
-        NSColor(theme.color("line")).withAlphaComponent(0.55).setStroke()
-        path.lineWidth = 1
-        path.stroke()
     }
 }
 

--- a/Alas/Sources/Center/Diff/DiffPaneTextDocumentView.swift
+++ b/Alas/Sources/Center/Diff/DiffPaneTextDocumentView.swift
@@ -1087,6 +1087,16 @@ final class DiffPaneCodeTextView: NSTextView {
         let point = convert(event.locationInWindow, from: nil)
         hoverHandler?(point)
         hoverExpansionRow = expansionRow(at: point)
+        // `super.mouseMoved` re-asserts the text view's I-beam on every move and
+        // wins the ordering against `cursorUpdate`, so re-apply the pointer here
+        // (unconditionally, no cached-state guard) after super has run.
+        applyPointerCursorIfNeeded(at: point)
+    }
+
+    private func applyPointerCursorIfNeeded(at point: NSPoint) {
+        if let row = reviewLineRow(at: point), rowShouldUsePointingHandCursor(row) {
+            NSCursor.pointingHand.set()
+        }
     }
 
     override func mouseDown(with event: NSEvent) {
@@ -1149,7 +1159,7 @@ final class DiffPaneCodeTextView: NSTextView {
         }
         let trackingArea = NSTrackingArea(
             rect: bounds,
-            options: [.mouseMoved, .mouseEnteredAndExited, .activeInActiveApp, .inVisibleRect],
+            options: [.mouseMoved, .mouseEnteredAndExited, .cursorUpdate, .activeInActiveApp, .inVisibleRect],
             owner: self,
             userInfo: nil
         )
@@ -1167,7 +1177,6 @@ final class DiffPaneCodeTextView: NSTextView {
 
     func invalidateDiffRowGeometry() {
         cachedRowGeometry = nil
-        window?.invalidateCursorRects(for: self)
     }
 
     private func rowGeometry() -> RowGeometry {
@@ -1407,10 +1416,16 @@ final class DiffPaneCodeTextView: NSTextView {
         return rowRects.firstIndex(where: { $0.contains(point) })
     }
 
-    override func resetCursorRects() {
-        super.resetCursorRects()
-        for (row, rect) in diffRowRects().enumerated() where rowShouldUsePointingHandCursor(row) {
-            addCursorRect(rect, cursor: .pointingHand)
+    override func cursorUpdate(with event: NSEvent) {
+        // A selectable NSTextView asserts its I-beam through `cursorUpdate(with:)`
+        // on its own cursor-update tracking areas, which overrides the legacy
+        // `addCursorRect`/`resetCursorRects` mechanism. Override it here so
+        // expandable-context and reviewable source rows show the pointer instead.
+        let point = convert(event.locationInWindow, from: nil)
+        if let row = reviewLineRow(at: point), rowShouldUsePointingHandCursor(row) {
+            NSCursor.pointingHand.set()
+        } else {
+            super.cursorUpdate(with: event)
         }
     }
 
@@ -1622,11 +1637,16 @@ final class DiffPaneCodeTextView: NSTextView {
             .offsetBy(dx: textContainerOrigin.x, dy: textContainerOrigin.y)
         guard !textRect.isEmpty else { return }
 
-        let pillHeight = min(max(textRect.height + 6, 18), max(rowRect.height - 4, 1))
+        // The expandable row uses a taller fixed line height and the label is
+        // baseline-shifted to the row's vertical center (see the builder), so the
+        // pill can simply center on the row and inset a little to fit within it.
+        let horizontalPadding: CGFloat = 12
+        let verticalInset: CGFloat = 2
+        let pillHeight = max(rowRect.height - verticalInset * 2, 1)
         let pillRect = NSRect(
-            x: textRect.minX - 10,
+            x: textRect.minX - horizontalPadding,
             y: rowRect.midY - pillHeight / 2,
-            width: textRect.width + 20,
+            width: textRect.width + horizontalPadding * 2,
             height: pillHeight
         )
         let alpha = Self.expandPillFillAlpha(

--- a/Alas/Sources/Center/Diff/DiffPaneTextDocumentView.swift
+++ b/Alas/Sources/Center/Diff/DiffPaneTextDocumentView.swift
@@ -972,6 +972,9 @@ final class DiffPaneCodeTextView: NSTextView {
     }
     private var armedExpansionRow: Int?
     private var armedExpansionOptionKey = false
+    /// Whether we last forced the pointing-hand cursor, so it can be restored to
+    /// the default when the mouse leaves the view.
+    private var didSetPointerCursor = false
 
     static func expandPillFillAlpha(hovered: Bool, pressed: Bool) -> CGFloat {
         if pressed { return 0.36 }
@@ -1096,6 +1099,9 @@ final class DiffPaneCodeTextView: NSTextView {
     private func applyPointerCursorIfNeeded(at point: NSPoint) {
         if let row = reviewLineRow(at: point), rowShouldUsePointingHandCursor(row) {
             NSCursor.pointingHand.set()
+            didSetPointerCursor = true
+        } else {
+            didSetPointerCursor = false
         }
     }
 
@@ -1146,6 +1152,13 @@ final class DiffPaneCodeTextView: NSTextView {
     override func mouseExited(with event: NSEvent) {
         super.mouseExited(with: event)
         hoverExpansionRow = nil
+        // Restore the default cursor when leaving the view, otherwise a pointing
+        // hand set over an expandable/source row can linger over the surrounding
+        // non-interactive chrome until the next cursor update.
+        if didSetPointerCursor {
+            NSCursor.arrow.set()
+            didSetPointerCursor = false
+        }
         mouseExitedHandler?()
     }
 
@@ -1424,7 +1437,9 @@ final class DiffPaneCodeTextView: NSTextView {
         let point = convert(event.locationInWindow, from: nil)
         if let row = reviewLineRow(at: point), rowShouldUsePointingHandCursor(row) {
             NSCursor.pointingHand.set()
+            didSetPointerCursor = true
         } else {
+            didSetPointerCursor = false
             super.cursorUpdate(with: event)
         }
     }

--- a/Alas/Sources/Center/Diff/DiffPaneTextDocumentView.swift
+++ b/Alas/Sources/Center/Diff/DiffPaneTextDocumentView.swift
@@ -1655,13 +1655,26 @@ final class DiffPaneCodeTextView: NSTextView {
         // The expandable row uses a taller fixed line height and the label is
         // baseline-shifted to the row's vertical center (see the builder), so the
         // pill can simply center on the row and inset a little to fit within it.
+        // The chevron is drawn here (not baked into the text) so the backing
+        // string stays a plain label for selection/copy.
+        let chevronGap: CGFloat = 5
+        let tint = NSColor(theme.color("seg-pill-active-fg"))
+        let chevronImage = Self.expandChevronImage(
+            boundary: lineMetadata[row].expansionBoundary,
+            font: font,
+            color: tint
+        )
+        let chevronSize = chevronImage?.size ?? .zero
+        let chevronLeftX = textRect.minX - chevronGap - chevronSize.width
+
         let horizontalPadding: CGFloat = 12
         let verticalInset: CGFloat = 2
         let pillHeight = max(rowRect.height - verticalInset * 2, 1)
+        let pillLeft = (chevronImage == nil ? textRect.minX : chevronLeftX) - horizontalPadding
         let pillRect = NSRect(
-            x: textRect.minX - horizontalPadding,
+            x: pillLeft,
             y: rowRect.midY - pillHeight / 2,
-            width: textRect.width + horizontalPadding * 2,
+            width: textRect.maxX + horizontalPadding - pillLeft,
             height: pillHeight
         )
         let alpha = Self.expandPillFillAlpha(
@@ -1671,6 +1684,29 @@ final class DiffPaneCodeTextView: NSTextView {
         let path = NSBezierPath(roundedRect: pillRect, xRadius: 6, yRadius: 6)
         NSColor(theme.color("accent")).withAlphaComponent(alpha).setFill()
         path.fill()
+
+        if let chevronImage {
+            let chevronRect = NSRect(
+                x: chevronLeftX,
+                y: rowRect.midY - chevronSize.height / 2,
+                width: chevronSize.width,
+                height: chevronSize.height
+            )
+            chevronImage.draw(in: chevronRect)
+        }
+    }
+
+    private static func expandChevronImage(
+        boundary: DiffContextBoundary?,
+        font: NSFont?,
+        color: NSColor
+    ) -> NSImage? {
+        let symbol = DiffPaneTextDocumentBuilder.expandableContextSymbolName(boundary: boundary)
+        let pointSize = (font?.pointSize ?? 13) - 1
+        let config = NSImage.SymbolConfiguration(pointSize: pointSize, weight: .semibold)
+            .applying(NSImage.SymbolConfiguration(paletteColors: [color]))
+        return NSImage(systemSymbolName: symbol, accessibilityDescription: nil)?
+            .withSymbolConfiguration(config)
     }
 }
 

--- a/Alas/Sources/Center/Diff/DiffPaneTextDocumentView.swift
+++ b/Alas/Sources/Center/Diff/DiffPaneTextDocumentView.swift
@@ -976,7 +976,7 @@ final class DiffPaneCodeTextView: NSTextView {
     /// the default when the mouse leaves the view.
     private var didSetPointerCursor = false
 
-    static func expandPillFillAlpha(hovered: Bool, pressed: Bool) -> CGFloat {
+    nonisolated static func expandPillFillAlpha(hovered: Bool, pressed: Bool) -> CGFloat {
         if pressed { return 0.36 }
         if hovered { return 0.28 }
         return 0.18
@@ -1644,6 +1644,12 @@ final class DiffPaneCodeTextView: NSTextView {
 
         let range = lineMetadata[row].range
         guard range.length > 0 else { return }
+
+        // In split mode the opposite column keeps the expandable-context metadata
+        // on a blank " " placeholder. Only the column holding the real label
+        // should render the button, so skip rows whose text is empty.
+        let label = (string as NSString).substring(with: range)
+        guard !label.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else { return }
 
         let glyphRange = layoutManager.glyphRange(forCharacterRange: range, actualCharacterRange: nil)
         guard glyphRange.length > 0 else { return }

--- a/AlasTests/DiffPaneTextDocumentBuilderTests.swift
+++ b/AlasTests/DiffPaneTextDocumentBuilderTests.swift
@@ -1,0 +1,16 @@
+import Testing
+@testable import Alas
+
+struct DiffPaneTextDocumentBuilderTests {
+    @Test func chevronPointsDownForBelowBoundary() {
+        #expect(DiffPaneTextDocumentBuilder.expandableContextSymbolName(boundary: .below) == "chevron.down")
+    }
+
+    @Test func chevronPointsUpForAboveBoundary() {
+        #expect(DiffPaneTextDocumentBuilder.expandableContextSymbolName(boundary: .above) == "chevron.up")
+    }
+
+    @Test func chevronDefaultsToDownWhenBoundaryMissing() {
+        #expect(DiffPaneTextDocumentBuilder.expandableContextSymbolName(boundary: nil) == "chevron.down")
+    }
+}

--- a/AlasTests/DiffPaneTextDocumentBuilderTests.swift
+++ b/AlasTests/DiffPaneTextDocumentBuilderTests.swift
@@ -13,4 +13,11 @@ struct DiffPaneTextDocumentBuilderTests {
     @Test func chevronDefaultsToDownWhenBoundaryMissing() {
         #expect(DiffPaneTextDocumentBuilder.expandableContextSymbolName(boundary: nil) == "chevron.down")
     }
+
+    @Test func pillFillAlphaByState() {
+        #expect(DiffPaneCodeTextView.expandPillFillAlpha(hovered: false, pressed: false) == 0.18)
+        #expect(DiffPaneCodeTextView.expandPillFillAlpha(hovered: true, pressed: false) == 0.28)
+        #expect(DiffPaneCodeTextView.expandPillFillAlpha(hovered: true, pressed: true) == 0.36)
+        #expect(DiffPaneCodeTextView.expandPillFillAlpha(hovered: false, pressed: true) == 0.36)
+    }
 }

--- a/AlasTests/DiffPaneViewTests.swift
+++ b/AlasTests/DiffPaneViewTests.swift
@@ -1560,7 +1560,21 @@ let second = true
             pressure: 1
         ))
 
+        let upEvent = try #require(NSEvent.mouseEvent(
+            with: .leftMouseUp,
+            location: windowPoint,
+            modifierFlags: [],
+            timestamp: 0,
+            windowNumber: window.windowNumber,
+            context: nil,
+            eventNumber: 0,
+            clickCount: 1,
+            pressure: 1
+        ))
+
+        // Expansion fires on mouse-up (the button models a real press cycle).
         textView.mouseDown(with: event)
+        textView.mouseUp(with: upEvent)
 
         #expect(captured?.0 == key)
         #expect(captured?.1 == .chunk(size: 10))
@@ -1616,7 +1630,21 @@ let second = true
             pressure: 1
         ))
 
+        let upEvent = try #require(NSEvent.mouseEvent(
+            with: .leftMouseUp,
+            location: windowPoint,
+            modifierFlags: .option,
+            timestamp: 0,
+            windowNumber: window.windowNumber,
+            context: nil,
+            eventNumber: 0,
+            clickCount: 1,
+            pressure: 1
+        ))
+
+        // Expansion fires on mouse-up (the button models a real press cycle).
         textView.mouseDown(with: event)
+        textView.mouseUp(with: upEvent)
 
         #expect(captured?.0 == key)
         #expect(captured?.1 == .all)


### PR DESCRIPTION
## What

Reworks the inline **"Expand N unchanged lines above/below"** control in the diff pane so it reads and behaves like a real button (the "selected segmented-control" look) instead of a faint, oversized pill.

## Why

The old control had a fully-rounded pill with a faint fill, the label pushed off-center by six hard-coded leading spaces, no hover/press feedback, and an I-beam cursor on hover — so it didn't read as clickable.

## Changes

- **Shape/fill:** full pill → 6px-radius accent segment (`seg-pill-active-bg` fill, `seg-pill-active-fg` text), no border.
- **Padding/centering:** removed the six leading spaces; indent now comes from a paragraph head-indent, and the label is baseline-centered in a taller fixed row so the pill wraps it symmetrically.
- **Feedback:** real hover (0.28) and pressed (0.36) fill states over the resting 0.18, driven by a proper `mouseDown → mouseUp` press cycle (release-off cancels; option-click still expands all).
- **Directional chevron:** `chevron.down` for "below", `chevron.up` for "above".
- **Cursor:** pointing-hand over expandable rows. A selectable `NSTextView` re-asserts its I-beam in `mouseMoved` on every move (overriding `cursorUpdate`), so the pointer is re-applied there after `super`.

Gutter expand affordance and expansion behavior (chunk vs. option-click "all") are unchanged.

## Testing

- Unit tests for the pure helpers (chevron-by-boundary, pill fill-alpha by state).
- Drawing/cursor/interaction is AppKit view code, verified visually in the running app (hover cursor + highlight, press feedback, centered pill, both `cool-slate` and `light` themes).