### PR TITLE
fix(diff): Avoid full diff row height rewrites

### DIFF
--- a/Alas/Sources/Center/Diff/DiffPaneTextDocumentView.swift
+++ b/Alas/Sources/Center/Diff/DiffPaneTextDocumentView.swift
@@ -595,6 +595,7 @@ final class DiffPaneTextScrollView: NSScrollView {
     private var expansionKeys: [DiffContextExpansionKey?] = []
     private var baseDocument: DiffPaneTextDocumentBuilder.CodeDocument?
     private var synchronizedRowHeights: [CGFloat] = []
+    private var synchronizedRowLineHeights: [CGFloat?] = []
     private var shouldResetHorizontalOrigin = false
     private var wraps = false
     private var font: NSFont = .monospacedSystemFont(ofSize: 13, weight: .regular)
@@ -701,6 +702,7 @@ final class DiffPaneTextScrollView: NSScrollView {
         self.expansionKeys = document.lines.map(\.expansionKey)
         self.baseDocument = document
         self.synchronizedRowHeights = []
+        self.synchronizedRowLineHeights = []
         self.shouldResetHorizontalOrigin = true
         self.wraps = wraps
         self.font = font
@@ -757,38 +759,77 @@ final class DiffPaneTextScrollView: NSScrollView {
         }
 
         let currentRows = textView.diffRowRects()
-        let synchronized = NSMutableAttributedString(attributedString: baseDocument.attributedString)
-        for index in 0..<min(rowHeights.count, baseDocument.lines.count, currentRows.count) {
-            let targetHeight = rowHeights[index]
-            let currentHeight = currentRows[index].height
-            guard targetHeight > currentHeight + 0.5 else { continue }
+        guard let textStorage = textView.textStorage else { return }
+        let previousRowHeights = synchronizedRowHeights
+        var nextLineHeights = Array<CGFloat?>(repeating: nil, count: rowHeights.count)
+        var changedParagraphs = false
+        var needsFollowUpSynchronization = false
+        let affectedCount = min(max(rowHeights.count, previousRowHeights.count), baseDocument.lines.count, currentRows.count)
+
+        textStorage.beginEditing()
+        for index in 0..<affectedCount {
+            let previousHeight = index < previousRowHeights.count ? previousRowHeights[index] : nil
+            let targetHeight = index < rowHeights.count ? rowHeights[index] : nil
+            let previousLineHeight = index < synchronizedRowLineHeights.count ? synchronizedRowLineHeights[index] : nil
+            let targetChanged = previousHeight == nil
+                || targetHeight == nil
+                || abs(previousHeight! - targetHeight!) > 0.5
+            guard targetChanged || previousLineHeight != nil
+            else {
+                nextLineHeights[index] = previousLineHeight
+                continue
+            }
 
             let range = baseDocument.lines[index].range
-            guard range.location < synchronized.length else { continue }
-            let paragraphRange = (synchronized.string as NSString).paragraphRange(for: NSRange(
+            guard range.location < textStorage.length else { continue }
+            let paragraphRange = (textStorage.string as NSString).paragraphRange(for: NSRange(
                 location: range.location,
                 length: max(range.length, 1)
             ))
-            let lineCount = max(1, Int(round(currentHeight / max(lineHeight(), 1))))
-            let targetLineHeight = targetHeight / CGFloat(lineCount)
+            let baseParagraph = paragraphStyle(from: baseDocument, at: range.location)
             let paragraph = NSMutableParagraphStyle()
-            if let existing = synchronized.attribute(.paragraphStyle, at: range.location, effectiveRange: nil) as? NSParagraphStyle {
-                paragraph.setParagraphStyle(existing)
-            } else {
-                paragraph.setParagraphStyle(CenterTypography.paragraphStyle())
-            }
-            paragraph.minimumLineHeight = targetLineHeight
-            paragraph.maximumLineHeight = targetLineHeight
-            synchronized.addAttribute(.paragraphStyle, value: paragraph, range: paragraphRange)
-        }
+            paragraph.setParagraphStyle(baseParagraph)
 
-        synchronizedRowHeights = rowHeights
-        textView.textStorage?.setAttributedString(synchronized)
+            if targetChanged, let targetHeight {
+                let lineCountHeight = synchronizedLineHeight(at: index) ?? lineHeight()
+                let lineCount = max(1, Int(round(currentRows[index].height / max(lineCountHeight, 1))))
+                let targetLineHeight = targetHeight / CGFloat(lineCount)
+                if targetLineHeight > lineHeight() + 0.5 {
+                    paragraph.minimumLineHeight = targetLineHeight
+                    paragraph.maximumLineHeight = targetLineHeight
+                    nextLineHeights[index] = targetLineHeight
+                }
+            } else if previousLineHeight != nil {
+                needsFollowUpSynchronization = true
+            }
+
+            textStorage.addAttribute(.paragraphStyle, value: paragraph, range: paragraphRange)
+            changedParagraphs = true
+        }
+        textStorage.endEditing()
+
+        synchronizedRowHeights = needsFollowUpSynchronization ? [] : rowHeights
+        synchronizedRowLineHeights = nextLineHeights
         textView.lineTones = lineTones
         textView.theme = theme
-        needsLayout = true
-        invalidateIntrinsicContentSize()
-        (verticalRulerView as? DiffPaneLineNumberRulerView)?.needsDisplay = true
+        if changedParagraphs {
+            needsLayout = true
+            invalidateIntrinsicContentSize()
+            (verticalRulerView as? DiffPaneLineNumberRulerView)?.needsDisplay = true
+        }
+    }
+
+    private func paragraphStyle(
+        from document: DiffPaneTextDocumentBuilder.CodeDocument,
+        at location: Int
+    ) -> NSParagraphStyle {
+        document.attributedString.attribute(.paragraphStyle, at: location, effectiveRange: nil) as? NSParagraphStyle
+            ?? CenterTypography.paragraphStyle()
+    }
+
+    private func synchronizedLineHeight(at index: Int) -> CGFloat? {
+        guard index < synchronizedRowLineHeights.count else { return nil }
+        return synchronizedRowLineHeights[index]
     }
 
     override func layout() {

--- a/AlasTests/DiffPaneViewTests.swift
+++ b/AlasTests/DiffPaneViewTests.swift
@@ -815,6 +815,143 @@ let second = true
         }
     }
 
+    @Test func synchronizedRowHeightsPreserveUntouchedTextStorageAttributes() throws {
+        let theme = theme()
+        let font = CenterTypography.resolveCodeFont(family: "", size: 13)
+        let lines = [
+            "let short = true",
+            "let medium = false",
+            "let untouched = true",
+        ]
+        let text = lines.joined(separator: "\n")
+        var location = 0
+        let metadata = lines.map { line in
+            defer { location += (line as NSString).length + 1 }
+            return DiffPaneTextDocumentBuilder.LineMetadata(
+                kind: .context,
+                range: NSRange(location: location, length: (line as NSString).length)
+            )
+        }
+        let document = DiffPaneTextDocumentBuilder.CodeDocument(
+            attributedString: NSAttributedString(
+                string: text,
+                attributes: [
+                    .font: font,
+                    .paragraphStyle: CenterTypography.paragraphStyle(),
+                ]
+            ),
+            lines: metadata
+        )
+        let scrollView = DiffPaneTextScrollView(frame: NSRect(x: 0, y: 0, width: 420, height: 140))
+
+        scrollView.update(
+            document: document,
+            lineLabels: ["1", "2", "3"],
+            wraps: true,
+            font: font,
+            theme: theme,
+            lspContext: nil,
+            allowedLSPSide: .new
+        )
+        scrollView.layoutSubtreeIfNeeded()
+
+        let codeView = try #require(scrollView.documentView as? DiffPaneCodeTextView)
+        let rowRects = codeView.diffRowRects()
+        #expect(rowRects.count == 3)
+        let sentinel = NSAttributedString.Key("DiffPaneRowHeightSentinel")
+        let untouchedRange = metadata[2].range
+        codeView.textStorage?.addAttribute(sentinel, value: "kept", range: untouchedRange)
+
+        scrollView.synchronizeRowHeights([
+            rowRects[0].height + 18,
+            rowRects[1].height,
+            rowRects[2].height,
+        ])
+
+        let value = codeView.textStorage?.attribute(sentinel, at: untouchedRange.location, effectiveRange: nil) as? String
+        #expect(value == "kept")
+    }
+
+    @Test func synchronizedRowHeightsResetPreviouslyPaddedRowsForRemeasurement() throws {
+        let theme = theme()
+        let font = CenterTypography.resolveCodeFont(family: "", size: 13)
+        let lines = [
+            "let first = true",
+            "let second = false",
+            "let third = true",
+        ]
+        let text = lines.joined(separator: "\n")
+        var location = 0
+        let metadata = lines.map { line in
+            defer { location += (line as NSString).length + 1 }
+            return DiffPaneTextDocumentBuilder.LineMetadata(
+                kind: .context,
+                range: NSRange(location: location, length: (line as NSString).length)
+            )
+        }
+        let document = DiffPaneTextDocumentBuilder.CodeDocument(
+            attributedString: NSAttributedString(
+                string: text,
+                attributes: [
+                    .font: font,
+                    .paragraphStyle: CenterTypography.paragraphStyle(),
+                ]
+            ),
+            lines: metadata
+        )
+        let scrollView = DiffPaneTextScrollView(frame: NSRect(x: 0, y: 0, width: 420, height: 140))
+
+        scrollView.update(
+            document: document,
+            lineLabels: ["1", "2", "3"],
+            wraps: true,
+            font: font,
+            theme: theme,
+            lspContext: nil,
+            allowedLSPSide: .new
+        )
+        scrollView.layoutSubtreeIfNeeded()
+
+        let codeView = try #require(scrollView.documentView as? DiffPaneCodeTextView)
+        let rowRects = codeView.diffRowRects()
+        #expect(rowRects.count == 3)
+
+        let firstInflatedHeight = rowRects[0].height + 18
+        scrollView.synchronizeRowHeights([
+            firstInflatedHeight,
+            rowRects[1].height,
+            rowRects[2].height,
+        ])
+
+        let paddedParagraph = try #require(
+            codeView.textStorage?.attribute(.paragraphStyle, at: metadata[0].range.location, effectiveRange: nil) as? NSParagraphStyle
+        )
+        #expect(paddedParagraph.minimumLineHeight > rowRects[0].height + 0.5)
+
+        scrollView.synchronizeRowHeights([
+            firstInflatedHeight,
+            rowRects[1].height + 18,
+            rowRects[2].height,
+        ])
+
+        let restoredParagraph = try #require(
+            codeView.textStorage?.attribute(.paragraphStyle, at: metadata[0].range.location, effectiveRange: nil) as? NSParagraphStyle
+        )
+        #expect(restoredParagraph.minimumLineHeight <= rowRects[0].height + 0.5)
+
+        scrollView.layoutSubtreeIfNeeded()
+        scrollView.synchronizeRowHeights([
+            firstInflatedHeight,
+            rowRects[1].height + 18,
+            rowRects[2].height,
+        ])
+
+        let reappliedParagraph = try #require(
+            codeView.textStorage?.attribute(.paragraphStyle, at: metadata[0].range.location, effectiveRange: nil) as? NSParagraphStyle
+        )
+        #expect(reappliedParagraph.minimumLineHeight > rowRects[0].height + 0.5)
+    }
+
     @Test func gutterSelectionOutlineWrapsContiguousRows() {
         let rowRects = [
             NSRect(x: 0, y: 8, width: 42, height: 18),


### PR DESCRIPTION
## Summary

Fixes #681 by making split diff row-height synchronization update only affected paragraph ranges in the existing text storage instead of rebuilding the entire attributed document during layout.

## Details

- Tracks applied synchronized line heights per row so later layout passes can expand or reset changed rows without copying the whole document.
- Rebaselines previously padded rows before preserving them, and forces the follow-up synchronization pass to re-evaluate unchanged target heights when needed.
- Adds regressions for preserving runtime text-storage attributes and for reset/reapply behavior after stale padded row heights.

## Validation

- `xcodegen`
- `git diff --check`
- `ALAS_FFF_TARGET_ARCH=arm64 xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS,arch=arm64' -quiet build`
- `ALAS_FFF_TARGET_ARCH=arm64 xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS,arch=arm64' -only-testing:AlasTests/DiffPaneViewTests test` reached both row-height regression tests and they passed; the suite later hit an existing `splitDocumentHighlightsSyntaxAcrossRowsWithOriginalWhitespaceSource` out-of-bounds exception also seen before this fix.

Local exact checklist build without `ALAS_FFF_TARGET_ARCH=arm64` is blocked by the local Homebrew Rust toolchain: the fff x86_64 slice fails with `can't find crate for core` for target `x86_64-apple-darwin`.

GitHub Actions `Build` run 3070 passed on `cc990f9098cf3a5d1bd251135eb91e4cf0b0d4df`.