### PR TITLE
fix(acp): cache transcript image thumbnails

### DIFF
--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -37,6 +37,7 @@
 		06AD46194E45984A1297D928 /* CommitHeaderViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E43F9F04AF6A6FF0A4D328F4 /* CommitHeaderViewTests.swift */; };
 		0722316C2ADB93575221246D /* ACPBareURLLinkifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = B2F3473392B284B69E6621DB /* ACPBareURLLinkifier.swift */; };
 		07385C7266A0694AB7F4E872 /* AppStateSpacesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EFDB90A7F9E58F4C1A258D23 /* AppStateSpacesTests.swift */; };
+		074B2BB17D428AE20AB482AA /* ACPThumbnailImageCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45952C734DFE7E7F02B047E7 /* ACPThumbnailImageCache.swift */; };
 		07BB2B329992BA535053BB80 /* ACPSetupNudgeBannerModeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0AB6FA9F258818E8B464CB0A /* ACPSetupNudgeBannerModeTests.swift */; };
 		082582F4BBA9DCFF0EAB9588 /* OperationCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4941BFBEEEAF9DE9E1752548 /* OperationCard.swift */; };
 		08681BEDBD6D7232CC937704 /* HoverFeatureBehaviorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 65E853C6AAB6450A0845A7CD /* HoverFeatureBehaviorTests.swift */; };
@@ -180,6 +181,7 @@
 		27F842092C9CA4D871B6127A /* DraftReviewRequestDiffSessionBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 615B4D8618F0BDEAEB216942 /* DraftReviewRequestDiffSessionBuilder.swift */; };
 		281C65FD7F2B509B963B74ED /* AlasHookCommandTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A77AA40A1700F0AF21335876 /* AlasHookCommandTests.swift */; };
 		2843F603A4D71AEEA4C09317 /* CloseTabConfirmationPolicy.swift in Sources */ = {isa = PBXBuildFile; fileRef = C78D0715973BD840FDE95AA2 /* CloseTabConfirmationPolicy.swift */; };
+		28710B18EF9FAE100B99E0A7 /* ACPThumbnailImageCacheTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3E9B2665E18F4C4BF3FB683 /* ACPThumbnailImageCacheTests.swift */; };
 		28BFB7C825FE3CFD8999A988 /* CodePane.swift in Sources */ = {isa = PBXBuildFile; fileRef = 93CDC9895F48619E97461875 /* CodePane.swift */; };
 		28F42E0137436A3B5F72CB85 /* ACPImageEncodingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FDE53456308778DF77B18AF4 /* ACPImageEncodingTests.swift */; };
 		2908D330D59E98775E26C688 /* MarkdownPreviewView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEE9287C21CF9E153D3D6D19 /* MarkdownPreviewView.swift */; };
@@ -1505,6 +1507,7 @@
 		45513A6B9EAA4E9744502597 /* AppConfigShortcutsCodingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppConfigShortcutsCodingTests.swift; sourceTree = "<group>"; };
 		4575017544CD7603B3AB9069 /* GitEventFilter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GitEventFilter.swift; sourceTree = "<group>"; };
 		457858DB2CF0B558A1A490BC /* AlasCLIWorktreeResolver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlasCLIWorktreeResolver.swift; sourceTree = "<group>"; };
+		45952C734DFE7E7F02B047E7 /* ACPThumbnailImageCache.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPThumbnailImageCache.swift; sourceTree = "<group>"; };
 		45D7C5464CA7B663A9A7BBFF /* ACPSessionStoreCRUDTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPSessionStoreCRUDTests.swift; sourceTree = "<group>"; };
 		45D8B88C4D4837376C123D45 /* AgentLauncherModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentLauncherModelTests.swift; sourceTree = "<group>"; };
 		45EABFDF5380D8D48B15312C /* ACPHarnessBridge.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPHarnessBridge.swift; sourceTree = "<group>"; };
@@ -1954,6 +1957,7 @@
 		B29505F108227C8F43822585 /* ACPLaunchCatalogTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPLaunchCatalogTests.swift; sourceTree = "<group>"; };
 		B2F3473392B284B69E6621DB /* ACPBareURLLinkifier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPBareURLLinkifier.swift; sourceTree = "<group>"; };
 		B3C89163A30EA4D278E86959 /* RightPaneStateLoadOlderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RightPaneStateLoadOlderTests.swift; sourceTree = "<group>"; };
+		B3E9B2665E18F4C4BF3FB683 /* ACPThumbnailImageCacheTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPThumbnailImageCacheTests.swift; sourceTree = "<group>"; };
 		B3EC1A61207050A2585288FB /* RightPaneVisibilityTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RightPaneVisibilityTests.swift; sourceTree = "<group>"; };
 		B44D759586280250330A9A04 /* FontSizeCommands.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FontSizeCommands.swift; sourceTree = "<group>"; };
 		B4C486F9097A2B145D101E2C /* AlasButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlasButton.swift; sourceTree = "<group>"; };
@@ -3215,6 +3219,7 @@
 				E2D5632302DE981B0BD36273 /* ACPSelectChipMetricsTests.swift */,
 				98A7F35818C95A567DDA586A /* ACPSelectChipTests.swift */,
 				0AB6FA9F258818E8B464CB0A /* ACPSetupNudgeBannerModeTests.swift */,
+				B3E9B2665E18F4C4BF3FB683 /* ACPThumbnailImageCacheTests.swift */,
 				B77D7A400059AFD189D1CA5A /* ACPToolCallPresentationTests.swift */,
 				79A6CF0F6BDA59AAE1354EE7 /* ACPUserInputFormStateTests.swift */,
 				EDABAB5EEE4C15A78B5429E6 /* ComposerActionTests.swift */,
@@ -3547,6 +3552,7 @@
 				B832ED19AC178DAD77C78D37 /* ACPTabView.swift */,
 				CBFD1CE53DE229626220B457 /* ACPTerminalTailView.swift */,
 				0FB91182CAC794B0BEDD222D /* ACPThoughtView.swift */,
+				45952C734DFE7E7F02B047E7 /* ACPThumbnailImageCache.swift */,
 				E6DE88BE229FD6C1DF35F7EA /* ACPToolbar.swift */,
 				CC3CF39EE3E5E2AB9B0968B3 /* ACPToolCallCard.swift */,
 				D710BC995453481F445E2ECF /* ACPToolCallPresentation.swift */,
@@ -4717,6 +4723,7 @@
 				EC3209AD2538061259084545 /* ACPTerminalMessages.swift in Sources */,
 				610486A9FA350E77D1BF594B /* ACPTerminalTailView.swift in Sources */,
 				48040D7ABD4A23B3947E945F /* ACPThoughtView.swift in Sources */,
+				074B2BB17D428AE20AB482AA /* ACPThumbnailImageCache.swift in Sources */,
 				3C30C1EAE4786BB1BE42F994 /* ACPToolCallCard.swift in Sources */,
 				AF071864CA8C882F74753E39 /* ACPToolCallPresentation.swift in Sources */,
 				312DB6016C040DE52CD365E8 /* ACPToolbar.swift in Sources */,
@@ -5334,6 +5341,7 @@
 				D874E635B8E9CDB1610D36E8 /* ACPSubmitIntentTests.swift in Sources */,
 				11827C40372D7209868161C0 /* ACPTerminalHostTests.swift in Sources */,
 				89F58C7178B661EAE0057622 /* ACPTerminalTests.swift in Sources */,
+				28710B18EF9FAE100B99E0A7 /* ACPThumbnailImageCacheTests.swift in Sources */,
 				E1E4C11CC5BFF761DF397507 /* ACPToolCallContentTests.swift in Sources */,
 				1C2C949642E10060172AB1BA /* ACPToolCallPresentationTests.swift in Sources */,
 				4B8BD1280C2DFF3CE1FD3C4B /* ACPTranscriptCurrentPlanTests.swift in Sources */,

--- a/Alas/Sources/ACP/UI/ACPImageThumbnail.swift
+++ b/Alas/Sources/ACP/UI/ACPImageThumbnail.swift
@@ -20,7 +20,7 @@ struct ACPImageThumbnail: View {
 
     @ViewBuilder private var thumbnail: some View {
         ACPCachedThumbnail(
-            cacheKey: "file:\(fileURL.standardizedFileURL.path)",
+            cacheKey: ACPThumbnailImageCache.fileCacheKey(for: fileURL),
             loadImage: { NSImage(contentsOf: fileURL) }
         ) { image in
             Image(nsImage: image)

--- a/Alas/Sources/ACP/UI/ACPImageThumbnail.swift
+++ b/Alas/Sources/ACP/UI/ACPImageThumbnail.swift
@@ -19,14 +19,17 @@ struct ACPImageThumbnail: View {
     }
 
     @ViewBuilder private var thumbnail: some View {
-        if let image = NSImage(contentsOf: fileURL) {
+        ACPCachedThumbnail(
+            cacheKey: "file:\(fileURL.standardizedFileURL.path)",
+            loadImage: { NSImage(contentsOf: fileURL) }
+        ) { image in
             Image(nsImage: image)
                 .resizable()
                 .aspectRatio(contentMode: .fill)
                 .frame(width: 96, height: 96)
                 .clipShape(RoundedRectangle(cornerRadius: 8))
                 .overlay(RoundedRectangle(cornerRadius: 8).strokeBorder(.white.opacity(0.15), lineWidth: 0.5))
-        } else {
+        } placeholder: {
             RoundedRectangle(cornerRadius: 8)
                 .fill(.gray.opacity(0.3))
                 .frame(width: 96, height: 96)

--- a/Alas/Sources/ACP/UI/ACPThumbnailImageCache.swift
+++ b/Alas/Sources/ACP/UI/ACPThumbnailImageCache.swift
@@ -1,0 +1,83 @@
+import AppKit
+import Foundation
+import SwiftUI
+
+final class ACPThumbnailImageCache: @unchecked Sendable {
+    static let shared = ACPThumbnailImageCache()
+
+    private let cache = NSCache<NSString, NSImage>()
+
+    init(countLimit: Int = 128) {
+        cache.countLimit = countLimit
+    }
+
+    func cachedImage(for key: String) -> NSImage? {
+        cache.object(forKey: key as NSString)
+    }
+
+    func store(_ image: NSImage, for key: String) {
+        cache.setObject(image, forKey: key as NSString)
+    }
+
+    func image(
+        for key: String,
+        load: @escaping @Sendable () -> NSImage?
+    ) async -> NSImage? {
+        if let cached = cachedImage(for: key) {
+            return cached
+        }
+
+        let loaded = await Task.detached(priority: .utility) {
+            load()
+        }.value
+
+        if let loaded {
+            store(loaded, for: key)
+        }
+        return loaded
+    }
+}
+
+struct ACPCachedThumbnail<Thumbnail: View, Placeholder: View>: View {
+    let cacheKey: String
+    let loadImage: @Sendable () -> NSImage?
+    @ViewBuilder var thumbnail: (NSImage) -> Thumbnail
+    @ViewBuilder var placeholder: () -> Placeholder
+
+    @State private var image: NSImage?
+
+    init(
+        cacheKey: String,
+        loadImage: @escaping @Sendable () -> NSImage?,
+        @ViewBuilder thumbnail: @escaping (NSImage) -> Thumbnail,
+        @ViewBuilder placeholder: @escaping () -> Placeholder
+    ) {
+        self.cacheKey = cacheKey
+        self.loadImage = loadImage
+        self.thumbnail = thumbnail
+        self.placeholder = placeholder
+        _image = State(initialValue: ACPThumbnailImageCache.shared.cachedImage(for: cacheKey))
+    }
+
+    var body: some View {
+        Group {
+            if let image {
+                thumbnail(image)
+            } else {
+                placeholder()
+            }
+        }
+        .onChange(of: cacheKey) { _, newValue in
+            image = ACPThumbnailImageCache.shared.cachedImage(for: newValue)
+        }
+        .task(id: cacheKey) {
+            if let cached = ACPThumbnailImageCache.shared.cachedImage(for: cacheKey) {
+                image = cached
+                return
+            }
+            let loaded = await ACPThumbnailImageCache.shared.image(for: cacheKey, load: loadImage)
+            guard !Task.isCancelled else { return }
+            image = loaded
+        }
+    }
+}

--- a/Alas/Sources/ACP/UI/ACPThumbnailImageCache.swift
+++ b/Alas/Sources/ACP/UI/ACPThumbnailImageCache.swift
@@ -19,6 +19,14 @@ final class ACPThumbnailImageCache: @unchecked Sendable {
         cache.setObject(image, forKey: key as NSString)
     }
 
+    static func fileCacheKey(for fileURL: URL) -> String {
+        let standardizedURL = fileURL.standardizedFileURL
+        let attributes = try? FileManager.default.attributesOfItem(atPath: standardizedURL.path)
+        let size = (attributes?[.size] as? NSNumber)?.uint64Value ?? 0
+        let modified = (attributes?[.modificationDate] as? Date)?.timeIntervalSince1970 ?? 0
+        return "file:\(standardizedURL.path):\(size):\(modified)"
+    }
+
     func image(
         for key: String,
         load: @escaping @Sendable () -> NSImage?

--- a/Alas/Sources/ACP/UI/ACPThumbnailImageCache.swift
+++ b/Alas/Sources/ACP/UI/ACPThumbnailImageCache.swift
@@ -46,24 +46,28 @@ final class ACPThumbnailImageCache: @unchecked Sendable {
     }
 }
 
-struct ACPCachedThumbnail<Thumbnail: View, Placeholder: View>: View {
+struct ACPCachedThumbnail<Thumbnail: View, Placeholder: View, Failure: View>: View {
     let cacheKey: String
     let loadImage: @Sendable () -> NSImage?
     @ViewBuilder var thumbnail: (NSImage) -> Thumbnail
     @ViewBuilder var placeholder: () -> Placeholder
+    @ViewBuilder var failure: () -> Failure
 
     @State private var image: NSImage?
+    @State private var didFinishLoading = false
 
     init(
         cacheKey: String,
         loadImage: @escaping @Sendable () -> NSImage?,
         @ViewBuilder thumbnail: @escaping (NSImage) -> Thumbnail,
-        @ViewBuilder placeholder: @escaping () -> Placeholder
+        @ViewBuilder placeholder: @escaping () -> Placeholder,
+        @ViewBuilder failure: @escaping () -> Failure
     ) {
         self.cacheKey = cacheKey
         self.loadImage = loadImage
         self.thumbnail = thumbnail
         self.placeholder = placeholder
+        self.failure = failure
         _image = State(initialValue: ACPThumbnailImageCache.shared.cachedImage(for: cacheKey))
     }
 
@@ -71,21 +75,43 @@ struct ACPCachedThumbnail<Thumbnail: View, Placeholder: View>: View {
         Group {
             if let image {
                 thumbnail(image)
+            } else if didFinishLoading {
+                failure()
             } else {
                 placeholder()
             }
         }
         .onChange(of: cacheKey) { _, newValue in
             image = ACPThumbnailImageCache.shared.cachedImage(for: newValue)
+            didFinishLoading = false
         }
         .task(id: cacheKey) {
             if let cached = ACPThumbnailImageCache.shared.cachedImage(for: cacheKey) {
                 image = cached
+                didFinishLoading = false
                 return
             }
             let loaded = await ACPThumbnailImageCache.shared.image(for: cacheKey, load: loadImage)
             guard !Task.isCancelled else { return }
             image = loaded
+            didFinishLoading = true
         }
+    }
+}
+
+extension ACPCachedThumbnail where Failure == Placeholder {
+    init(
+        cacheKey: String,
+        loadImage: @escaping @Sendable () -> NSImage?,
+        @ViewBuilder thumbnail: @escaping (NSImage) -> Thumbnail,
+        @ViewBuilder placeholder: @escaping () -> Placeholder
+    ) {
+        self.init(
+            cacheKey: cacheKey,
+            loadImage: loadImage,
+            thumbnail: thumbnail,
+            placeholder: placeholder,
+            failure: placeholder
+        )
     }
 }

--- a/Alas/Sources/ACP/UI/ACPToolCallCard.swift
+++ b/Alas/Sources/ACP/UI/ACPToolCallCard.swift
@@ -334,7 +334,7 @@ extension ACPMessage.ToolCallAsset {
             return "data-uri:\(uri.hashValue)"
         }
         if let uri = nonEmpty(uri), let url = Self.trustedLocalURL(from: uri, trustedRoot: trustedRoot) {
-            return "file:\(url.standardizedFileURL.path)"
+            return ACPThumbnailImageCache.fileCacheKey(for: url)
         }
         return "asset:\(hashValue)"
     }

--- a/Alas/Sources/ACP/UI/ACPToolCallCard.swift
+++ b/Alas/Sources/ACP/UI/ACPToolCallCard.swift
@@ -205,19 +205,30 @@ private struct ACPToolCallAssetView: View {
     var body: some View {
         switch asset.kind {
         case .image:
-            if let image = asset.loadedImage(trustedRoot: trustedImageRoot) {
-                imageThumbnail(image)
-                    .help(asset.displayText)
+            if asset.canLoadImage(trustedRoot: trustedImageRoot) {
+                cachedImageThumbnail
             } else {
                 compactRow(iconSystemName: "photo", title: asset.displayTitle, detail: asset.displayDetail)
             }
         case .resource:
-            if asset.looksLikeImage, let image = asset.loadedImage(trustedRoot: trustedImageRoot) {
-                imageThumbnail(image)
-                    .help(asset.displayText)
+            if asset.looksLikeImage, asset.canLoadImage(trustedRoot: trustedImageRoot) {
+                cachedImageThumbnail
             } else {
                 compactRow(iconSystemName: "doc.text", title: asset.displayTitle, detail: asset.displayDetail)
             }
+        }
+    }
+
+    private var cachedImageThumbnail: some View {
+        ACPCachedThumbnail(
+            cacheKey: asset.thumbnailCacheKey(trustedRoot: trustedImageRoot),
+            loadImage: { asset.loadedImage(trustedRoot: trustedImageRoot) }
+        ) { image in
+            imageThumbnail(image)
+                .help(asset.displayText)
+        } placeholder: {
+            imagePlaceholder
+                .help(asset.displayText)
         }
     }
 
@@ -232,6 +243,18 @@ private struct ACPToolCallAssetView: View {
         }
             .frame(width: 160, height: 120)
             .overlay(RoundedRectangle(cornerRadius: 8).strokeBorder(.white.opacity(0.15), lineWidth: 0.5))
+    }
+
+    private var imagePlaceholder: some View {
+        ZStack {
+            RoundedRectangle(cornerRadius: 8)
+                .fill(theme.color("bg-1").opacity(0.7))
+            Image(systemName: "photo")
+                .font(.system(size: 20))
+                .foregroundStyle(theme.color("fg-faint"))
+        }
+        .frame(width: 160, height: 120)
+        .overlay(RoundedRectangle(cornerRadius: 8).strokeBorder(.white.opacity(0.15), lineWidth: 0.5))
     }
 
     private func compactRow(iconSystemName: String, title: String, detail: String?) -> some View {
@@ -278,6 +301,17 @@ extension ACPMessage.ToolCallAsset {
         }
     }
 
+    func canLoadImage(trustedRoot: URL?) -> Bool {
+        if data != nil {
+            return true
+        }
+        guard let uri = nonEmpty(uri) else { return false }
+        if Self.isDataURI(uri) {
+            return true
+        }
+        return Self.trustedLocalURL(from: uri, trustedRoot: trustedRoot) != nil
+    }
+
     func loadedImage(trustedRoot: URL?) -> NSImage? {
         if let data, let decoded = Self.decodeBase64ImageData(data), let image = NSImage(data: decoded) {
             return image
@@ -290,6 +324,19 @@ extension ACPMessage.ToolCallAsset {
         }
         guard let url = Self.trustedLocalURL(from: uri, trustedRoot: trustedRoot) else { return nil }
         return NSImage(contentsOf: url)
+    }
+
+    func thumbnailCacheKey(trustedRoot: URL?) -> String {
+        if let data = nonEmpty(data) {
+            return "data:\(data.hashValue)"
+        }
+        if let uri = nonEmpty(uri), Self.isDataURI(uri) {
+            return "data-uri:\(uri.hashValue)"
+        }
+        if let uri = nonEmpty(uri), let url = Self.trustedLocalURL(from: uri, trustedRoot: trustedRoot) {
+            return "file:\(url.standardizedFileURL.path)"
+        }
+        return "asset:\(hashValue)"
     }
 
     var displayTitle: String {

--- a/Alas/Sources/ACP/UI/ACPToolCallCard.swift
+++ b/Alas/Sources/ACP/UI/ACPToolCallCard.swift
@@ -229,6 +229,8 @@ private struct ACPToolCallAssetView: View {
         } placeholder: {
             imagePlaceholder
                 .help(asset.displayText)
+        } failure: {
+            compactRow(iconSystemName: "photo", title: asset.displayTitle, detail: asset.displayDetail)
         }
     }
 

--- a/AlasTests/ACP/UI/ACPThumbnailImageCacheTests.swift
+++ b/AlasTests/ACP/UI/ACPThumbnailImageCacheTests.swift
@@ -23,6 +23,27 @@ struct ACPThumbnailImageCacheTests {
         #expect(second === image)
         #expect(counter.value == 1)
     }
+
+    @Test("file cache key changes when file contents are replaced")
+    func fileCacheKeyChangesWhenFileContentsAreReplaced() throws {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: directory) }
+
+        let fileURL = directory.appendingPathComponent("screenshot.png")
+        try Data([1]).write(to: fileURL)
+        let firstKey = ACPThumbnailImageCache.fileCacheKey(for: fileURL)
+
+        try Data([1, 2, 3]).write(to: fileURL)
+        try FileManager.default.setAttributes(
+            [.modificationDate: Date(timeIntervalSince1970: 2_000_000_000)],
+            ofItemAtPath: fileURL.path
+        )
+        let secondKey = ACPThumbnailImageCache.fileCacheKey(for: fileURL)
+
+        #expect(secondKey != firstKey)
+    }
 }
 
 private final class LoadCounter: @unchecked Sendable {

--- a/AlasTests/ACP/UI/ACPThumbnailImageCacheTests.swift
+++ b/AlasTests/ACP/UI/ACPThumbnailImageCacheTests.swift
@@ -1,0 +1,39 @@
+import AppKit
+import Testing
+@testable import Alas
+
+@Suite("ACP thumbnail image cache")
+struct ACPThumbnailImageCacheTests {
+    @Test("reuses decoded image for repeated cache key loads")
+    func reusesDecodedImageForRepeatedCacheKeyLoads() async throws {
+        let cache = ACPThumbnailImageCache(countLimit: 8)
+        let image = NSImage(size: NSSize(width: 1, height: 1))
+        let counter = LoadCounter()
+
+        let first = await cache.image(for: "asset:one") {
+            counter.increment()
+            return image
+        }
+        let second = await cache.image(for: "asset:one") {
+            counter.increment()
+            return NSImage(size: NSSize(width: 2, height: 2))
+        }
+
+        #expect(first === image)
+        #expect(second === image)
+        #expect(counter.value == 1)
+    }
+}
+
+private final class LoadCounter: @unchecked Sendable {
+    private let lock = NSLock()
+    private var count = 0
+
+    var value: Int {
+        lock.withLock { count }
+    }
+
+    func increment() {
+        lock.withLock { count += 1 }
+    }
+}


### PR DESCRIPTION
Fixes #670.

Summary:
- Add an async thumbnail cache for ACP transcript image rows.
- Reuse decoded NSImage thumbnails for file, data URI, and tool-call image assets instead of decoding in SwiftUI body evaluation.
- Add focused Swift Testing coverage for repeated cache-key loads.

Validation:
- xcodegen
- ALAS_FFF_TARGET_ARCH=arm64 xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -quiet build
- ALAS_FFF_TARGET_ARCH=arm64 xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -only-testing:AlasTests/ACPThumbnailImageCacheTests -only-testing:AlasTests/ACPToolCallPresentationTests test

Local note:
- The exact default build command fails on this machine before Swift compilation because Homebrew Rust is missing core/std for x86_64-apple-darwin while build-fff.sh tries the x86_64 target.