### PR TITLE
perf(ui): scope observations and guard no-op refreshes

### DIFF
--- a/Alas/Sources/Center/CenterPaneView.swift
+++ b/Alas/Sources/Center/CenterPaneView.swift
@@ -28,6 +28,9 @@ struct CenterPaneView: View {
                     // re-evaluates this closure on every keystroke; without
                     // this, `dirty` (which depends on non-observable
                     // NSTextStorage) would only refresh on theme/tab changes.
+                    // The closure is consumed by the per-tab close button,
+                    // so the invalidation is scoped to that tiny view
+                    // instead of the whole tab bar.
                     _ = buffer?.editGeneration
                     return buffer?.dirty ?? false
                 },
@@ -169,11 +172,6 @@ struct CenterPaneView: View {
                         let openAvailable = DiffOpenFileAvailability.isAvailable(
                             worktreePath: worktree.path, relativePath: s.relativePath
                         )
-                        let rps = state.rightPaneStore.state(
-                            for: worktree,
-                            baseBranch: state.config.worktrees.baseBranch,
-                            trackUpstreamForCommits: state.config.changes.trackUpstreamForCommits
-                        )
                         DiffTabView(
                             worktreePath: worktree.path,
                             relativePath: s.relativePath,
@@ -188,9 +186,14 @@ struct CenterPaneView: View {
                                 ? { state.openFile(relativePath: s.relativePath, worktreeId: worktree.id) }
                                 : nil,
                             onRequestDiscardFile: {
+                                let rps = state.rightPaneStore.activeState(worktreeId: worktree.id)
+                                    ?? activateRightPaneStateForCenterTab()
                                 rps.requestDiscardFile(path: s.relativePath)
                             }
                         )
+                        .task(id: rightPaneActivationKey) {
+                            activateRightPaneStateForCenterTab()
+                        }
                     case .stashDiff(let s):
                         StashDiffTabView(
                             worktreePath: worktree.path,
@@ -216,11 +219,6 @@ struct CenterPaneView: View {
                         )
                         .id(s.id)
                     case .draftCommit(let draftState):
-                        let _ = state.rightPaneStore.state(
-                            for: worktree,
-                            baseBranch: state.config.worktrees.baseBranch,
-                            trackUpstreamForCommits: state.config.changes.trackUpstreamForCommits
-                        )
                         DraftCommitTabView(
                             worktreePath: worktree.path,
                             worktreeId: worktree.id,
@@ -228,6 +226,9 @@ struct CenterPaneView: View {
                             appState: state
                         )
                         .id(draftState.id)
+                        .task(id: rightPaneActivationKey) {
+                            activateRightPaneStateForCenterTab()
+                        }
                     case .draftReviewRequest(let draftState):
                         DraftReviewRequestTabView(
                             worktreePath: worktree.path,
@@ -237,29 +238,25 @@ struct CenterPaneView: View {
                         )
                         .id(draftState.id)
                     case .reviewChanges(let reviewState):
-                        let _ = state.rightPaneStore.state(
-                            for: worktree,
-                            baseBranch: state.config.worktrees.baseBranch,
-                            trackUpstreamForCommits: state.config.changes.trackUpstreamForCommits
-                        )
                         ReviewChangesTabView(
                             worktree: worktree,
                             tabState: reviewState,
                             appState: state
                         )
                         .id(reviewState.id)
+                        .task(id: rightPaneActivationKey) {
+                            activateRightPaneStateForCenterTab()
+                        }
                     case .reviewPR(let prState):
-                        let _ = state.rightPaneStore.state(
-                            for: worktree,
-                            baseBranch: state.config.worktrees.baseBranch,
-                            trackUpstreamForCommits: state.config.changes.trackUpstreamForCommits
-                        )
                         ReviewTabView(
                             worktree: worktree,
                             tabState: prState,
                             appState: state
                         )
                         .id(prState.id)
+                        .task(id: rightPaneActivationKey) {
+                            activateRightPaneStateForCenterTab()
+                        }
                     case .reviewSession(let sessionState):
                         ReviewSessionTabView(
                             worktree: worktree,
@@ -301,6 +298,19 @@ struct CenterPaneView: View {
             .frame(maxWidth: .infinity, maxHeight: .infinity)
         }
         .background(theme.color("bg-1"))
+    }
+
+    private var rightPaneActivationKey: String {
+        "\(worktree.id)\u{0000}\(worktree.branch)\u{0000}\(state.config.worktrees.baseBranch)\u{0000}\(state.config.changes.trackUpstreamForCommits)"
+    }
+
+    @discardableResult
+    private func activateRightPaneStateForCenterTab() -> RightPaneState {
+        state.rightPaneStore.state(
+            for: worktree,
+            baseBranch: state.config.worktrees.baseBranch,
+            trackUpstreamForCommits: state.config.changes.trackUpstreamForCommits
+        )
     }
 
     private func openTerminal() {

--- a/Alas/Sources/Center/TabBarView.swift
+++ b/Alas/Sources/Center/TabBarView.swift
@@ -54,50 +54,7 @@ struct TabBarView: View {
                 ScrollView(.horizontal, showsIndicators: false) {
                     HStack(spacing: 0) {
                         ForEach(Array(tabs.enumerated()), id: \.element.id) { idx, tab in
-                            TabButton(
-                                titleLookup: titleLookup,
-                                tab: tab,
-                                active: tab.id == activeId,
-                                showClose: true,
-                                harnessInfo: harnessLookup(tab.id),
-                                dirty: dirtyLookup(tab.id),
-                                transcript: transcriptLookup(tab.id),
-                                acpAgent: acpAgentLookup(tab.id),
-                                onActivate: { onActivate(tab.id) },
-                                onClose: { onClose(tab.id) }
-                            )
-                            .id(tab.id)
-                            .draggable(tab.id)
-                            .dropDestination(for: TabID.self) { ids, _ in
-                                guard let draggedId = ids.first, draggedId != tab.id else { return false }
-                                onMove(draggedId, tab.id)
-                                return true
-                            }
-                            .contextMenu {
-                                if case .terminal = tab {
-                                    Button("Rename…") { onRenameTerminal(tab.id) }
-                                    Divider()
-                                }
-                                if case .acpSession = tab {
-                                    Button("Rename…") { onRenameACPSession(tab.id) }
-                                    Button("Copy Session as Markdown") { onCopyACPSession(tab.id) }
-                                    Button("Save Session as Markdown…") { onExportACPSession(tab.id) }
-                                    Divider()
-                                }
-                                Button("Close") { onClose(tab.id) }
-                                Button("Close Other Tabs") { onCloseOthers(tab.id) }
-                                    .disabled(tabs.count <= 1)
-                                Button("Close All Tabs") { onCloseAll() }
-                                Button("Close Tabs to the Left") { onCloseToLeft(tab.id) }
-                                    .disabled(idx == 0)
-                                Button("Close Tabs to the Right") { onCloseToRight(tab.id) }
-                                    .disabled(idx == tabs.count - 1)
-                                Divider()
-                                if tab.relativeFilePath != nil {
-                                    Button("Copy Path") { onCopyPath(tab.id) }
-                                    Button("Copy Relative Path") { onCopyRelativePath(tab.id) }
-                                }
-                            }
+                            tabButton(for: idx, tab: tab)
                         }
                     }
                 }
@@ -146,6 +103,53 @@ struct TabBarView: View {
         .windowDragHandle()
     }
 
+    private func tabButton(for idx: Int, tab: Tab) -> some View {
+        TabButton(
+            titleLookup: titleLookup,
+            tab: tab,
+            active: tab.id == activeId,
+            showClose: true,
+            harnessInfo: harnessLookup(tab.id),
+            dirtyLookup: { dirtyLookup(tab.id) },
+            transcript: transcriptLookup(tab.id),
+            acpAgent: acpAgentLookup(tab.id),
+            onActivate: { onActivate(tab.id) },
+            onClose: { onClose(tab.id) }
+        )
+        .id(tab.id)
+        .draggable(tab.id)
+        .dropDestination(for: TabID.self) { ids, _ in
+            guard let draggedId = ids.first, draggedId != tab.id else { return false }
+            onMove(draggedId, tab.id)
+            return true
+        }
+        .contextMenu {
+            if case .terminal = tab {
+                Button("Rename…") { onRenameTerminal(tab.id) }
+                Divider()
+            }
+            if case .acpSession = tab {
+                Button("Rename…") { onRenameACPSession(tab.id) }
+                Button("Copy Session as Markdown") { onCopyACPSession(tab.id) }
+                Button("Save Session as Markdown…") { onExportACPSession(tab.id) }
+                Divider()
+            }
+            Button("Close") { onClose(tab.id) }
+            Button("Close Other Tabs") { onCloseOthers(tab.id) }
+                .disabled(tabs.count <= 1)
+            Button("Close All Tabs") { onCloseAll() }
+            Button("Close Tabs to the Left") { onCloseToLeft(tab.id) }
+                .disabled(idx == 0)
+            Button("Close Tabs to the Right") { onCloseToRight(tab.id) }
+                .disabled(idx == tabs.count - 1)
+            Divider()
+            if tab.relativeFilePath != nil {
+                Button("Copy Path") { onCopyPath(tab.id) }
+                Button("Copy Relative Path") { onCopyRelativePath(tab.id) }
+            }
+        }
+    }
+
     private func scrollActiveTab(using proxy: ScrollViewProxy, animated: Bool) {
         guard let activeId else { return }
         if animated {
@@ -180,13 +184,12 @@ private struct TabButton: View {
     let active: Bool
     let showClose: Bool
     let harnessInfo: (agent: AgentKind, state: ActivityState)?
-    let dirty: Bool
+    let dirtyLookup: () -> Bool
     let transcript: ACPTranscript?
     let acpAgent: AgentDefinition?
     let onActivate: () -> Void
     let onClose: () -> Void
     @Environment(\.theme) var theme
-    @State private var hoveringClose = false
 
     var body: some View {
         HStack(spacing: 6) {
@@ -216,28 +219,7 @@ private struct TabButton: View {
                 TabPlanProgressChip(transcript: transcript)
             }
             if showClose {
-                Button(action: onClose) {
-                    ZStack {
-                        ZStack {
-                            if dirty && !hoveringClose {
-                                Circle()
-                                    .fill(theme.color("fg"))
-                                    .frame(width: 7, height: 7)
-                            } else {
-                                Icon(name: "x", size: 9,
-                                     color: hoveringClose ? theme.color("fg") : theme.color("fg-faint"))
-                                    .background(hoveringClose ? theme.color("bg-4") : .clear)
-                                    .clipShape(RoundedRectangle(cornerRadius: 3))
-                            }
-                        }
-                        .frame(width: 14, height: 14)
-                    }
-                    .frame(width: 20, height: 20)
-                    .contentShape(Rectangle())
-                }
-                .buttonStyle(.plain)
-                .onHover { hoveringClose = $0 }
-                .help(dirty ? "Unsaved changes — click to close" : "Close")
+                TabCloseButton(dirtyLookup: dirtyLookup, onClose: onClose)
             }
         }
         .padding(.horizontal, 10)
@@ -267,6 +249,42 @@ private struct TabButton: View {
         case .permissionRequest: return theme.color("mod")
         case .idle:          return theme.color("fg-faint")
         }
+    }
+}
+
+/// Small isolated view that observes the buffer's `editGeneration` so that
+/// typing in one editor only invalidates this tab's close/dirty dot, not the
+/// whole tab bar.
+private struct TabCloseButton: View {
+    let dirtyLookup: () -> Bool
+    let onClose: () -> Void
+    @Environment(\.theme) private var theme
+    @State private var hoveringClose = false
+
+    var body: some View {
+        let dirty = dirtyLookup()
+        Button(action: onClose) {
+            ZStack {
+                ZStack {
+                    if dirty && !hoveringClose {
+                        Circle()
+                            .fill(theme.color("fg"))
+                            .frame(width: 7, height: 7)
+                    } else {
+                        Icon(name: "x", size: 9,
+                             color: hoveringClose ? theme.color("fg") : theme.color("fg-faint"))
+                            .background(hoveringClose ? theme.color("bg-4") : .clear)
+                            .clipShape(RoundedRectangle(cornerRadius: 3))
+                    }
+                }
+                .frame(width: 14, height: 14)
+            }
+            .frame(width: 20, height: 20)
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+        .onHover { hoveringClose = $0 }
+        .help(dirty ? "Unsaved changes — click to close" : "Close")
     }
 }
 

--- a/Alas/Sources/Right/RightPaneState.swift
+++ b/Alas/Sources/Right/RightPaneState.swift
@@ -45,7 +45,11 @@ final class RightPaneState {
     }
     /// Increments whenever `refresh()` publishes a new change list. This
     /// catches same-line unstaged edits whose add/delete totals stay constant.
+    /// It is now guarded by an effective-change fingerprint so no-op
+    /// watcher-driven refreshes do not re-fire downstream loaders.
     private(set) var changesGeneration: Int = 0
+    @ObservationIgnored
+    private var lastChangesFingerprint: String = ""
     /// Increments whenever cached snapshot data is explicitly invalidated.
     /// In-flight refreshes capture this before doing async work and must not
     /// publish if it changed underneath them.
@@ -491,6 +495,10 @@ final class RightPaneState {
             self.isLoadingOlder = false
             let ignoreUpstream = userOverrodeBaseBranch || !trackUpstreamForCommits
             async let s = git.status(worktreePath: worktree.path)
+            async let statusRaw = Process.git(
+                ["status", "--porcelain=v2", "-z", "--untracked-files=all"],
+                cwd: worktree.path
+            )
             async let c = git.commitsAhead(
                 at: worktree.path,
                 baseBranch: baseBranch,
@@ -530,10 +538,22 @@ final class RightPaneState {
             } else {
                 indexFingerprint = ""
             }
+            async let trackedContentFingerprintTask = Self.trackedContentFingerprint(worktreePath: worktree.path)
+            let statusRawResult = try? await statusRaw
+            let untrackedPaths = Self.untrackedPaths(from: statusRawResult?.stdout ?? "")
+            async let untrackedContentFingerprintTask = Self.untrackedContentFingerprint(paths: untrackedPaths, worktreePath: worktree.path)
             let previousBranch = self.currentBranch
             let previousHeadSHA = self.currentHeadSHA
             let currentBranch = (try? await br) ?? self.currentBranch
             let headSHA = (try? await self.git.revParseHEAD(worktreePath: self.worktree.path)) ?? ""
+            let trackedContentFingerprint = await trackedContentFingerprintTask
+            let untrackedContentFingerprint = await untrackedContentFingerprintTask
+            let workingTreeContentFingerprint = "\(trackedContentFingerprint)\u{0000}\(untrackedContentFingerprint)"
+            let newChangesFingerprint = Self.changesFingerprint(
+                changes: entries,
+                indexFingerprint: indexFingerprint,
+                workingTreeContentFingerprint: workingTreeContentFingerprint
+            )
             guard snapshotGeneration == snapshotInvalidationGeneration else {
                 return
             }
@@ -547,7 +567,10 @@ final class RightPaneState {
             if self.changes != entries { self.changes = entries }
             self.reconcileStashCaches(with: stashes)
             if self.stashes != stashes { self.stashes = stashes }
-            self.changesGeneration += 1
+            if self.lastChangesFingerprint != newChangesFingerprint {
+                self.lastChangesFingerprint = newChangesFingerprint
+                self.changesGeneration += 1
+            }
             if self.indexFingerprint != indexFingerprint { self.indexFingerprint = indexFingerprint }
             let mergedFileTree = Self.preservingLazyChildren(fresh: tree, previous: self.fileTree)
             if self.fileTree != mergedFileTree { self.fileTree = mergedFileTree }
@@ -595,6 +618,7 @@ final class RightPaneState {
                 didInitDefaultTab = true
             }
             self.hasLoadedSnapshot = true
+            let previousReviewRequestFingerprint = Self.reviewRequestReloadFingerprint(reviewLoop.snapshot?.reviewRequest)
             let upstreamBranchName = resolvedUpstream.map {
                 String($0.ref.dropFirst($0.remote.count + 1))
             }
@@ -609,6 +633,10 @@ final class RightPaneState {
                 remotes: remotes,
                 forceRemote: forceReviewLoopRemote
             )
+            let currentReviewRequestFingerprint = Self.reviewRequestReloadFingerprint(reviewLoop.snapshot?.reviewRequest)
+            if previousReviewRequestFingerprint != currentReviewRequestFingerprint {
+                changesGeneration += 1
+            }
         } catch {
             reviewLoop.failLocalRefresh(reviewLoopInspection, error: error)
             guard snapshotGeneration == snapshotInvalidationGeneration else {
@@ -646,6 +674,7 @@ final class RightPaneState {
         commitsNeedPush = true
         sidebarError = nil
         pendingDiscard = nil
+        lastChangesFingerprint = ""
         changesGeneration += 1
         invalidateFileTreeChildLoadsForRefresh()
     }
@@ -718,6 +747,16 @@ final class RightPaneState {
         await reviewLoop.refresh(attempt, remotes: remotes)
     }
 
+    nonisolated static func reviewRequestReloadFingerprint(_ request: ReviewRequest?) -> String {
+        guard let request else { return "nil" }
+        return [
+            request.id,
+            request.headSHA ?? "",
+            request.headRefName,
+            request.baseRefName
+        ].joined(separator: "\u{0000}")
+    }
+
     static func reviewLoopRemoteFingerprintRemotes(_ remotes: [GitRemote]) -> [String] {
         remotes
             .map { remote in
@@ -738,6 +777,151 @@ final class RightPaneState {
             return true
         }
         return now.timeIntervalSince(lastRefreshAt) >= minimumInterval
+    }
+
+    /// Extracts untracked paths from `git status --porcelain=v2 -z` output.
+    nonisolated static func untrackedPaths(from statusRaw: String) -> [String] {
+        statusRaw
+            .split(separator: "\0", omittingEmptySubsequences: true)
+            .compactMap { line -> String? in
+                let str = String(line)
+                guard str.hasPrefix("? ") else { return nil }
+                return String(str.dropFirst(2))
+            }
+    }
+
+    /// Returns a content fingerprint for tracked changes. Raw diff metadata is
+    /// insufficient for unstaged worktree edits because Git reports an all-zero
+    /// destination object when the filesystem copy is out of sync with the
+    /// index, but full binary patches can be very large. Keep the cheap raw
+    /// metadata and add path-scoped worktree blob hashes instead.
+    nonisolated static func trackedContentFingerprint(worktreePath: URL) async -> String {
+        if let raw = try? await Process.git(
+            ["diff", "--raw", "-z", "--no-renames", "HEAD"],
+            cwd: worktreePath
+        ), raw.exitCode == 0 {
+            let paths = await gitChangedPaths(
+                ["diff", "--name-only", "-z", "--no-renames", "HEAD"],
+                worktreePath: worktreePath
+            )
+            let content = await pathContentFingerprint(paths: paths, worktreePath: worktreePath)
+            return "\(raw.stdout)\u{0000}\(content)"
+        }
+
+        let cachedRaw = (try? await Process.git(
+            ["diff", "--raw", "-z", "--no-renames", "--cached"],
+            cwd: worktreePath
+        )).flatMap { $0.exitCode == 0 ? $0.stdout : nil } ?? ""
+        let unstagedRaw = (try? await Process.git(
+            ["diff", "--raw", "-z", "--no-renames"],
+            cwd: worktreePath
+        )).flatMap { $0.exitCode == 0 ? $0.stdout : nil } ?? ""
+        let cachedPaths = await gitChangedPaths(
+            ["diff", "--name-only", "-z", "--no-renames", "--cached"],
+            worktreePath: worktreePath
+        )
+        let unstagedPaths = await gitChangedPaths(
+            ["diff", "--name-only", "-z", "--no-renames"],
+            worktreePath: worktreePath
+        )
+        let paths = cachedPaths + unstagedPaths
+        let content = await pathContentFingerprint(paths: paths, worktreePath: worktreePath)
+        return "\(cachedRaw)\u{0000}\(unstagedRaw)\u{0000}\(content)"
+    }
+
+    /// Hashes the contents of untracked files so content edits that leave the
+    /// status line unchanged still invalidate the change fingerprint.
+    nonisolated static func untrackedContentFingerprint(paths: [String], worktreePath: URL) async -> String {
+        await pathContentFingerprint(paths: paths, worktreePath: worktreePath)
+    }
+
+    nonisolated private static func gitChangedPaths(_ args: [String], worktreePath: URL) async -> [String] {
+        guard let result = try? await Process.git(args, cwd: worktreePath), result.exitCode == 0 else {
+            return []
+        }
+        return result.stdout
+            .split(separator: "\0", omittingEmptySubsequences: true)
+            .map(String.init)
+    }
+
+    nonisolated private static func pathContentFingerprint(paths: [String], worktreePath: URL) async -> String {
+        let sortedPaths = Array(Set(paths)).sorted()
+        guard !sortedPaths.isEmpty else { return "" }
+
+        var pathKinds: [String: String] = [:]
+        var filePaths: [String] = []
+        for path in sortedPaths {
+            let fileURL = worktreePath.appendingPathComponent(path)
+            let attributes = try? FileManager.default.attributesOfItem(atPath: fileURL.path)
+            if let fileType = attributes?[.type] as? FileAttributeType {
+                switch fileType {
+                case .typeSymbolicLink:
+                    let destination = (try? FileManager.default.destinationOfSymbolicLink(atPath: fileURL.path)) ?? "unreadable"
+                    pathKinds[path] = "symlink:\(destination)"
+                case .typeDirectory:
+                    pathKinds[path] = "directory"
+                case .typeRegular:
+                    filePaths.append(path)
+                default:
+                    pathKinds[path] = "special:\(fileType.rawValue)"
+                }
+                continue
+            }
+
+            var isDirectory: ObjCBool = false
+            guard FileManager.default.fileExists(atPath: fileURL.path, isDirectory: &isDirectory) else {
+                pathKinds[path] = "missing"
+                continue
+            }
+            if isDirectory.boolValue {
+                pathKinds[path] = "directory"
+            } else {
+                filePaths.append(path)
+            }
+        }
+
+        let hashes = await hashObjects(paths: filePaths, worktreePath: worktreePath)
+        return sortedPaths.map { path in
+            let value = pathKinds[path] ?? hashes[path] ?? "hash-error"
+            return "\(path)\u{0000}\(value)"
+        }.joined(separator: "\u{0000}")
+    }
+
+    nonisolated private static func hashObjects(paths: [String], worktreePath: URL) async -> [String: String] {
+        guard !paths.isEmpty else { return [:] }
+        if let result = try? await Process.git(["hash-object", "--"] + paths, cwd: worktreePath),
+           result.exitCode == 0 {
+            let hashes = result.stdout.split(whereSeparator: \.isNewline).map(String.init)
+            if hashes.count == paths.count {
+                return Dictionary(uniqueKeysWithValues: zip(paths, hashes))
+            }
+        }
+
+        var hashes: [String: String] = [:]
+        for path in paths {
+            guard let result = try? await Process.git(["hash-object", "--", path], cwd: worktreePath),
+                  result.exitCode == 0 else {
+                continue
+            }
+            hashes[path] = result.stdout.trimmingCharacters(in: .whitespacesAndNewlines)
+        }
+        return hashes
+    }
+
+    /// Stable fingerprint of the effective change list, including staged
+    /// index contents, tracked/untracked file contents, and status metadata.
+    /// Used to decide whether `changesGeneration` really changed.
+    nonisolated static func changesFingerprint(
+        changes: [ChangedFile],
+        indexFingerprint: String,
+        workingTreeContentFingerprint: String
+    ) -> String {
+        let base = ReviewChangesLoadKey.fingerprint(
+            changes: changes,
+            indexFingerprint: indexFingerprint,
+            changesGeneration: 0
+        )
+        return "\(base)\u{0000}\(workingTreeContentFingerprint)"
     }
 
     func invalidateFileTreeChildLoadsForRefresh() {

--- a/Alas/Sources/Right/RightPaneView.swift
+++ b/Alas/Sources/Right/RightPaneView.swift
@@ -8,82 +8,190 @@ struct RightPaneView: View {
     let onSelectCommit: (CommitInfo) -> Void
     let onEditCommit: (CommitInfo, String) -> Void
     @Environment(\.theme) var theme
+    @State private var rps: RightPaneState?
+
+    init(
+        state: AppState,
+        worktree: Worktree,
+        onSelectChangedFile: @escaping (ChangedFile) -> Void,
+        onSelectTreeFile: @escaping (FileTreeNode) -> Void,
+        onSelectCommit: @escaping (CommitInfo) -> Void,
+        onEditCommit: @escaping (CommitInfo, String) -> Void
+    ) {
+        self.state = state
+        self.worktree = worktree
+        self.onSelectChangedFile = onSelectChangedFile
+        self.onSelectTreeFile = onSelectTreeFile
+        self.onSelectCommit = onSelectCommit
+        self.onEditCommit = onEditCommit
+        // Resolve without activating: the cached state (if any) gives us
+        // something to render immediately, and `.task` handles the mutating
+        // activation + refresh off the view-update path.
+        _rps = State(initialValue: state.rightPaneStore.activeState(worktreeId: worktree.id))
+    }
 
     var body: some View {
-        let rps = state.rightPaneStore.state(
-            for: worktree,
-            baseBranch: state.config.worktrees.baseBranch,
-            trackUpstreamForCommits: state.config.changes.trackUpstreamForCommits
-        )
-        let displayChanges = rps.displayChanges
         let override = state.config.sidebarChromeOverride(forThemeId: state.themeStore.current.id)
         ZStack {
             SidebarMaterialBackground(
                 choice: state.config.sidebarMaterial,
                 backgroundOpacity: override.backgroundOpacity
             )
-            VStack(spacing: 0) {
-                RightPaneTabBar(
-                    activeTab: Binding(
-                        get: { rps.activeTab },
-                        set: { rps.activeTab = $0 }
+            if let rps = rps, rps.worktree.id == worktree.id {
+                VStack(spacing: 0) {
+                    RightPaneTabBar(
+                        activeTab: Binding(
+                            get: { rps.activeTab },
+                            set: { rps.activeTab = $0 }
+                        ),
+                        changesCount: rps.displayChanges.count,
+                        totalAdd: rps.displayChanges.reduce(0) { $0 + $1.add },
+                        totalDel: rps.displayChanges.reduce(0) { $0 + $1.del },
+                        onHidePane: {
+                            state.config.rightPaneVisible = false
+                            state.saveConfig()
+                        },
+                        showIgnored: state.config.files.showIgnored,
+                        onToggleShowIgnored: {
+                            state.config.files.showIgnored.toggle()
+                            state.saveConfig()
+                        }
+                    )
+
+                    if rps.hasLoadedSnapshot {
+                        switch rps.activeTab {
+                        case .changes:
+                            ChangesTabView(
+                                rps: rps,
+                                appState: state,
+                                onSelect: onSelectChangedFile,
+                                onSelectCommit: onSelectCommit,
+                                onEditCommit: onEditCommit
+                            )
+                        case .files:
+                            FilesTabView(
+                                nodes: rps.fileTree,
+                                fileTreeGeneration: rps.fileTreeGeneration,
+                                openPaths: Binding(
+                                    get: { rps.openPaths },
+                                    set: { rps.openPaths = $0 }
+                                ),
+                                onSelectFile: onSelectTreeFile,
+                                shouldAutoLoadChildren: { path, childrenState in
+                                    rps.shouldAutoLoadFileTreeChildren(path: path, childrenState: childrenState)
+                                },
+                                onLoadChildren: { rps.loadFileTreeChildren(path: $0) },
+                                showIgnored: state.config.files.showIgnored,
+                                revealPath: rps.revealPath,
+                                revealTick: rps.revealTick,
+                                onClearReveal: { rps.clearReveal() }
+                            )
+                        }
+                    } else {
+                        RightPaneLoadingSkeletonView(activeTab: rps.activeTab)
+                    }
+                }
+                .sidebarChromeTheme(textContrast: override.textContrast)
+                // Host the discard confirmation here (not on ChangesTabView) so
+                // diff-tab Discard actions still present the alert when the right
+                // pane is on the Files tab — `requestDiscardFile` sets pending state
+                // regardless of which child view is mounted.
+                .alert(
+                    PendingDiscard.alertTitle(for: rps.pendingDiscard ?? .placeholder),
+                    isPresented: Binding(
+                        get: { rps.pendingDiscard != nil },
+                        set: { if !$0 { rps.cancelDiscard() } }
                     ),
-                    changesCount: displayChanges.count,
-                    totalAdd: displayChanges.reduce(0) { $0 + $1.add },
-                    totalDel: displayChanges.reduce(0) { $0 + $1.del },
-                    onHidePane: {
-                        state.config.rightPaneVisible = false
-                        state.saveConfig()
+                    presenting: rps.pendingDiscard,
+                    actions: { _ in
+                        Button("Discard", role: .destructive) {
+                            if let pending = rps.pendingDiscard {
+                                rps.pendingDiscard = nil
+                                Task { @MainActor in await rps.confirmDiscard(pending) }
+                            }
+                        }
+                        Button("Cancel", role: .cancel) {
+                            rps.cancelDiscard()
+                        }
                     },
-                    showIgnored: state.config.files.showIgnored,
-                    onToggleShowIgnored: {
-                        state.config.files.showIgnored.toggle()
-                        state.saveConfig()
+                    message: { p in
+                        Text(PendingDiscard.alertMessage(for: p))
                     }
                 )
-
-                if rps.hasLoadedSnapshot {
-                    switch rps.activeTab {
-                    case .changes:
-                        ChangesTabView(
-                            rps: rps,
-                            appState: state,
-                            onSelect: onSelectChangedFile,
-                            onSelectCommit: onSelectCommit,
-                            onEditCommit: onEditCommit
-                        )
-                    case .files:
-                        FilesTabView(
-                            nodes: rps.fileTree,
-                            fileTreeGeneration: rps.fileTreeGeneration,
-                            openPaths: Binding(
-                                get: { rps.openPaths },
-                                set: { rps.openPaths = $0 }
-                            ),
-                            onSelectFile: onSelectTreeFile,
-                            shouldAutoLoadChildren: { path, childrenState in
-                                rps.shouldAutoLoadFileTreeChildren(path: path, childrenState: childrenState)
-                            },
-                            onLoadChildren: { rps.loadFileTreeChildren(path: $0) },
-                            showIgnored: state.config.files.showIgnored,
-                            revealPath: rps.revealPath,
-                            revealTick: rps.revealTick,
-                            onClearReveal: { rps.clearReveal() }
-                        )
+                .alert(
+                    "Cherry-pick commit?",
+                    isPresented: Binding(
+                        get: { rps.pendingCherryPickSHA != nil },
+                        set: { if !$0 { rps.cancelCherryPick() } }
+                    ),
+                    presenting: rps.pendingCherryPickSHA,
+                    actions: { sha in
+                        Button("Cherry-pick \(sha.prefix(7))") {
+                            rps.confirmCherryPick()
+                        }
+                        Button("Cancel", role: .cancel) {
+                            rps.cancelCherryPick()
+                        }
+                    },
+                    message: { _ in
+                        Text("Apply this commit to the current branch.")
                     }
-                } else {
-                    RightPaneLoadingSkeletonView(activeTab: rps.activeTab)
+                )
+                .sheet(
+                    isPresented: Binding(
+                        get: { rps.pendingParkChanges },
+                        set: { if !$0 { rps.cancelParkChanges() } }
+                    )
+                ) {
+                    ParkChangesSheet(
+                        onPark: { message, includeUntracked in
+                            rps.parkChanges(message: message, includeUntracked: includeUntracked)
+                        },
+                        onCancel: { rps.cancelParkChanges() }
+                    )
                 }
+                .alert(
+                    PendingStashDrop.alertTitle(for: rps.pendingStashDrop ?? .placeholder),
+                    isPresented: Binding(
+                        get: { rps.pendingStashDrop != nil },
+                        set: { if !$0 { rps.cancelDropStash() } }
+                    ),
+                    presenting: rps.pendingStashDrop,
+                    actions: { pending in
+                        Button("Drop", role: .destructive) {
+                            rps.confirmDropStash(pending)
+                        }
+                        Button("Cancel", role: .cancel) {
+                            rps.cancelDropStash()
+                        }
+                    },
+                    message: { pending in
+                        Text(PendingStashDrop.alertMessage(for: pending))
+                    }
+                )
+            } else {
+                RightPaneLoadingSkeletonView(activeTab: .changes)
+                    .sidebarChromeTheme(textContrast: override.textContrast)
             }
-            .sidebarChromeTheme(textContrast: override.textContrast)
         }
-        // Force a refresh whenever the user (re-)selects this worktree. The
-        // FSEvent watcher is the primary update path, but if it ever misses
-        // a burst (debouncer starved, stream hiccup) re-selection is the
-        // user's expected escape hatch — switching away and back should
-        // surface current state.
-        .task(id: worktree.id) {
-            await rps.refresh()
+        // Force a refresh whenever the user (re-)selects this worktree, when
+        // its branch changes, or when relevant settings change. The
+        // FSEvent watcher is the primary update path, but if it ever misses a
+        // burst (debouncer starved, stream hiccup) re-selection is the user's
+        // expected escape hatch — switching away and back should surface current
+        // state. Activation happens inside the task, not during body evaluation,
+        // so `RightPaneStore` mutations don't run inside a view update.
+        .task(id: "\(worktree.id)\u{0000}\(worktree.branch)\u{0000}\(state.config.worktrees.baseBranch)\u{0000}\(state.config.changes.trackUpstreamForCommits)") {
+            if rps?.worktree.id != worktree.id {
+                rps = nil
+            }
+            let activated = state.rightPaneStore.state(
+                for: worktree,
+                baseBranch: state.config.worktrees.baseBranch,
+                trackUpstreamForCommits: state.config.changes.trackUpstreamForCommits
+            )
+            rps = activated
+            await activated.refresh()
         }
         // When the right pane is hidden or unmounted (no worktree selected),
         // stop the active state's filesystem watcher and 5-min sync timer
@@ -92,82 +200,5 @@ struct RightPaneView: View {
         .onDisappear {
             state.rightPaneStore.deactivate()
         }
-        // Host the discard confirmation here (not on ChangesTabView) so
-        // diff-tab Discard actions still present the alert when the right
-        // pane is on the Files tab — `requestDiscardFile` sets pending state
-        // regardless of which child view is mounted.
-        .alert(
-            PendingDiscard.alertTitle(for: rps.pendingDiscard ?? .placeholder),
-            isPresented: Binding(
-                get: { rps.pendingDiscard != nil },
-                set: { if !$0 { rps.cancelDiscard() } }
-            ),
-            presenting: rps.pendingDiscard,
-            actions: { _ in
-                Button("Discard", role: .destructive) {
-                    if let pending = rps.pendingDiscard {
-                        rps.pendingDiscard = nil
-                        Task { @MainActor in await rps.confirmDiscard(pending) }
-                    }
-                }
-                Button("Cancel", role: .cancel) {
-                    rps.cancelDiscard()
-                }
-            },
-            message: { p in
-                Text(PendingDiscard.alertMessage(for: p))
-            }
-        )
-        .alert(
-            "Cherry-pick commit?",
-            isPresented: Binding(
-                get: { rps.pendingCherryPickSHA != nil },
-                set: { if !$0 { rps.cancelCherryPick() } }
-            ),
-            presenting: rps.pendingCherryPickSHA,
-            actions: { sha in
-                Button("Cherry-pick \(sha.prefix(7))") {
-                    rps.confirmCherryPick()
-                }
-                Button("Cancel", role: .cancel) {
-                    rps.cancelCherryPick()
-                }
-            },
-            message: { _ in
-                Text("Apply this commit to the current branch.")
-            }
-        )
-        .sheet(
-            isPresented: Binding(
-                get: { rps.pendingParkChanges },
-                set: { if !$0 { rps.cancelParkChanges() } }
-            )
-        ) {
-            ParkChangesSheet(
-                onPark: { message, includeUntracked in
-                    rps.parkChanges(message: message, includeUntracked: includeUntracked)
-                },
-                onCancel: { rps.cancelParkChanges() }
-            )
-        }
-        .alert(
-            PendingStashDrop.alertTitle(for: rps.pendingStashDrop ?? .placeholder),
-            isPresented: Binding(
-                get: { rps.pendingStashDrop != nil },
-                set: { if !$0 { rps.cancelDropStash() } }
-            ),
-            presenting: rps.pendingStashDrop,
-            actions: { pending in
-                Button("Drop", role: .destructive) {
-                    rps.confirmDropStash(pending)
-                }
-                Button("Cancel", role: .cancel) {
-                    rps.cancelDropStash()
-                }
-            },
-            message: { pending in
-                Text(PendingStashDrop.alertMessage(for: pending))
-            }
-        )
     }
 }

--- a/Alas/Sources/Settings/TerminalPane.swift
+++ b/Alas/Sources/Settings/TerminalPane.swift
@@ -5,7 +5,7 @@ struct TerminalPane: View {
     @Environment(\.theme) var theme
 
     @State private var hookStatus: [AgentKind: String] = [:]
-    @State private var installStateRefreshToken = 0
+    @State private var installStates: [AgentKind: InstallState] = [:]
     private let installerRegistry = AgentInstallerRegistry()
     private let installStateRefreshTimer = Timer.publish(every: 2, on: .main, in: .common).autoconnect()
 
@@ -135,16 +135,23 @@ struct TerminalPane: View {
                     ForEach(installerRegistry.supportedAgents) { agent in
                         SettingsRow(name: agent.displayName) {
                             HStack {
-                                let integrationState = installState(for: agent, refreshToken: installStateRefreshToken)
-                                ForEach(TerminalIntegrationActions.actions(for: integrationState)) { action in
-                                    AlasButton(title: action.title) {
-                                        switch action.kind {
-                                        case .install:
-                                            installAgent(agent)
-                                        case .uninstall:
-                                            uninstallAgent(agent)
+                                if let integrationState = installStates[agent] {
+                                    ForEach(TerminalIntegrationActions.actions(for: integrationState)) { action in
+                                        AlasButton(title: action.title) {
+                                            switch action.kind {
+                                            case .install:
+                                                installAgent(agent)
+                                            case .uninstall:
+                                                uninstallAgent(agent)
+                                            }
                                         }
                                     }
+                                } else {
+                                    ProgressView()
+                                        .controlSize(.small)
+                                    Text("Checking…")
+                                        .font(.system(size: 11))
+                                        .foregroundColor(theme.color("fg-dim"))
                                 }
                                 if let status = hookStatus[agent] {
                                     Text(status).font(.system(size: 11))
@@ -165,12 +172,18 @@ struct TerminalPane: View {
         }
     }
 
-    private func installState(for agent: AgentKind, refreshToken _: Int) -> InstallState {
-        return installerRegistry.installer(for: agent)?.installState() ?? .notInstalled
-    }
-
     private func refreshInstallStates() {
-        installStateRefreshToken &+= 1
+        Task { @MainActor in
+            let registry = installerRegistry
+            let states = await Task.detached(priority: .utility) { [registry] in
+                var states: [AgentKind: InstallState] = [:]
+                for agent in registry.supportedAgents {
+                    states[agent] = registry.installer(for: agent)?.installState() ?? .notInstalled
+                }
+                return states
+            }.value
+            self.installStates = states
+        }
     }
 
     private func installAgent(_ agent: AgentKind) {

--- a/Alas/Sources/Terminal/GhosttyHost.swift
+++ b/Alas/Sources/Terminal/GhosttyHost.swift
@@ -56,7 +56,8 @@ struct GhosttyHost: NSViewRepresentable {
             ])
         }
         guard isFocused else { return }
-        DispatchQueue.main.async {
+        DispatchQueue.main.async { [weak container] in
+            guard let container, container.window?.firstResponder !== session.surface else { return }
             container.window?.makeFirstResponder(session.surface)
         }
     }


### PR DESCRIPTION
Closes #700

- Scope dirty-dot editGeneration read to per-tab close button so keystrokes only invalidate the tiny TabCloseButton, not the entire tab bar.
- Move RightPaneStore activation out of view bodies into .task(id:) so state mutations don't run during view updates.
- Guard changesGeneration increments with an effective-change fingerprint (tracked diff raw + untracked content hash) so no-op watcher-driven refreshes don't re-fire downstream loaders.
- Move TerminalPane install-state reads off the main thread via Task.detached, eliminating synchronous file I/O in body.
- Skip GhosttyHost makeFirstResponder when the surface is already first responder, avoiding wasteful per-frame enqueues.