### PR TITLE
feat(ssh): remote machine support

### DIFF
--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -103,6 +103,7 @@
 		14D70126BAF735B2A66A23C5 /* DiffReviewScrollSpyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F649B493D42787FEA6D8E67B /* DiffReviewScrollSpyTests.swift */; };
 		14DC8D8191E6E39E8741108D /* ReviewTabViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9CAED428443C9A7FE55E9A31 /* ReviewTabViewTests.swift */; };
 		159525C0A1B6C8E0B7C9FA9D /* ProjectMCPServerEditor.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD456A92D66BA31E0E74B836 /* ProjectMCPServerEditor.swift */; };
+		15BAFAC3EC3613E406024EFD /* RemoteLSPLauncher.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3ACA7839782B71490BFD3A6F /* RemoteLSPLauncher.swift */; };
 		162363BDA6BC54B372C77B91 /* ACPMarkdownTextBareURLTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8718406234B8C879B9D0CAB1 /* ACPMarkdownTextBareURLTests.swift */; };
 		162A6ABEAE92BB3AD1511567 /* AdvancedSettingsVisibilityTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1CD33324CA36118FCEA2BE2 /* AdvancedSettingsVisibilityTests.swift */; };
 		165300DDFFB445D8AAE7A5E5 /* MarkdownFileTypeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 19C327BB65463E878DDCDA5E /* MarkdownFileTypeTests.swift */; };
@@ -445,6 +446,7 @@
 		5A0AE37CBA893BD09558C27E /* CIStatusStrip.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8FAF07CCA81D986D1C30D05 /* CIStatusStrip.swift */; };
 		5B02C8E213F6EA67BEB7E5BA /* ContentResultGroupViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 97134381F91B44B46CAFE082 /* ContentResultGroupViewTests.swift */; };
 		5B415F5F89EAE4B2EEA07046 /* ShortcutResolver.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4069925EE709DD18AEA810B3 /* ShortcutResolver.swift */; };
+		5BB2FF7F9DFFFEF75CA508A2 /* RemoteLSPLauncherTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D89D9FFAC80BDE46A651A0F /* RemoteLSPLauncherTests.swift */; };
 		5BCB202710E37EA60DCC91F0 /* ACPPlanSidebar.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC2BB41ECA8AEAB278294B8A /* ACPPlanSidebar.swift */; };
 		5C6F0DC6F76FC0B55F2F4051 /* DiffPaneTextDocumentBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 52E5D3E9FAA7B6B251C3883D /* DiffPaneTextDocumentBuilder.swift */; };
 		5C86AEAEA5497DBF5FD7D604 /* initialize-response.json in Resources */ = {isa = PBXBuildFile; fileRef = 2463B784210156F489A13FAC /* initialize-response.json */; };
@@ -487,6 +489,7 @@
 		65095BDBA1E160D7DF4F2A65 /* AgentLauncherDialog.swift in Sources */ = {isa = PBXBuildFile; fileRef = FBFB85AF60C0E4520ED0DA8E /* AgentLauncherDialog.swift */; };
 		659B9DBE590DCF6C395C64B3 /* AgentRegistryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C2381497E73D74C8C314928 /* AgentRegistryTests.swift */; };
 		65E2D21A8616B9E86E684136 /* libsqlite3.tbd in Frameworks */ = {isa = PBXBuildFile; fileRef = 2FD28E0005DE3A33A974A511 /* libsqlite3.tbd */; };
+		664EEC1B4A18A02A49897FBA /* ACPTerminalCRLFTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF798A386DD56B4127D5272A /* ACPTerminalCRLFTests.swift */; };
 		6682233134C258D81E22D7AD /* ACPTranscriptMarkdownTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5069EF396F2CB8E81B2AD11 /* ACPTranscriptMarkdownTests.swift */; };
 		66D3CC7109527B2938684292 /* ProjectsManagerWorktreeOrderingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3711FACCAD4DE3E29AB13DD2 /* ProjectsManagerWorktreeOrderingTests.swift */; };
 		671F28D6A18DD75EB912596B /* PersistenceStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A17A797374500E1FDD2382C /* PersistenceStore.swift */; };
@@ -700,6 +703,7 @@
 		9654335704CB69BA7216DD63 /* ReviewLoopStateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3939B27EA8D7A562048E5932 /* ReviewLoopStateTests.swift */; };
 		965621529CB4BD82DD646B76 /* ACPManagerAccessorsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B133843C0559BBD6E769ABB8 /* ACPManagerAccessorsTests.swift */; };
 		9666162EC5BE3445EEBCDEA1 /* RemoteWorktreeSummaryBuilderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20A5D6E7C4527B459EFC2CBB /* RemoteWorktreeSummaryBuilderTests.swift */; };
+		96BE44DEEDA6FDF72BD51173 /* ACPReconnectPolicy.swift in Sources */ = {isa = PBXBuildFile; fileRef = D020BC9CC6586ECAB8A38042 /* ACPReconnectPolicy.swift */; };
 		9707DC02317F0E92AB06196B /* ImageDiffModeApplicabilityTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FFE911B77AC087704180BDB5 /* ImageDiffModeApplicabilityTests.swift */; };
 		970B6BCA824C6AF4DA812946 /* ProcessMemoryProbe.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5AA350F5909E28954C623B7 /* ProcessMemoryProbe.swift */; };
 		971F93A8880B095537B9A2A8 /* ACPUserInputPrompt.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4D974BDA7FAE214495278557 /* ACPUserInputPrompt.swift */; };
@@ -713,6 +717,7 @@
 		98ED89EA20255EBB9D186AD5 /* MergeConflictBinaryDetectionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 31CE012ED93AA22C257FEB8A /* MergeConflictBinaryDetectionTests.swift */; };
 		9927E3934D3CAA9055EF5E44 /* DiffOpenFileAvailabilityTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2BFCE07604D55558B13FC33B /* DiffOpenFileAvailabilityTests.swift */; };
 		99613CF61A0F19105D8E7A71 /* EmojiPickerButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7BEC4E033DB3BA44C825D453 /* EmojiPickerButton.swift */; };
+		996B67B45E7247CDED5F98EF /* AppStateRemoteWorktreePathTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FED0AAD3FE0E143D409A3E8B /* AppStateRemoteWorktreePathTests.swift */; };
 		99711AA1B0FB450D32770415 /* ZmxSunPathBudget.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A40BDC5115B641AB26220D9 /* ZmxSunPathBudget.swift */; };
 		999C8421F3610FF682CE9D0E /* ReviewTabView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 500B60003934104E2CA5A895 /* ReviewTabView.swift */; };
 		99CD435501BBBAAD8C4214D8 /* ProjectMCPServerEditorPolicyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 178EAF6036A9BEAEA2C55082 /* ProjectMCPServerEditorPolicyTests.swift */; };
@@ -853,6 +858,7 @@
 		B40B75555598C42713157C5C /* TreeSitterCSS in Frameworks */ = {isa = PBXBuildFile; productRef = 3F76DFBA5D1CB707989C86AB /* TreeSitterCSS */; };
 		B472D692A8D8D1C664EAC467 /* ACPSessionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1281A3235F08DC8A95D015A9 /* ACPSessionTests.swift */; };
 		B4C4E13CFE986FC20DC12808 /* ACPFileWriterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6CA51D49B1AE4C4E10D450C6 /* ACPFileWriterTests.swift */; };
+		B4F98348084DEFA5C1D51A6E /* RemoteImageCacheTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1CA759D2C99D1FEE3C67A1BA /* RemoteImageCacheTests.swift */; };
 		B54B0BFA87B2566DB59C3D59 /* ConflictMarkerParserTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A00CFC045C4BF9C13B4105BF /* ConflictMarkerParserTests.swift */; };
 		B574D2D5DF3129E326DCFCCF /* ShellEnvResolverTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 09246CDA0F77D86F05727407 /* ShellEnvResolverTests.swift */; };
 		B58BF89C3A788A31CBED2067 /* TreeSitterJavaScript in Frameworks */ = {isa = PBXBuildFile; productRef = B3568F495249430FBBE2FCCF /* TreeSitterJavaScript */; };
@@ -946,6 +952,8 @@
 		C679AA50F077B1EBC0D4CC82 /* MCPAttachmentPlannerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 532AA1B8AD5E8139D2EEE948 /* MCPAttachmentPlannerTests.swift */; };
 		C6991F6E93C1EBCFCD5EE003 /* ReviewScopeSelection.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8D583586BC5171D2FE91F6C /* ReviewScopeSelection.swift */; };
 		C70D6BEC5321C16B70301CBF /* GitService+ReviewRequestDraft.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0EE97D2D6875CD6A1DBF4DE9 /* GitService+ReviewRequestDraft.swift */; };
+		C71971EF735837CD260359C6 /* RemoteImageCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5DABE7D3F41C67D28CA2C2F9 /* RemoteImageCache.swift */; };
+		C7658D1AF7744BB694D2388A /* ACPReconnectPolicyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8C040E975A14DE31446BCEB7 /* ACPReconnectPolicyTests.swift */; };
 		C7A839C87B7C9F70F5BD6631 /* CompletionEngine.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50B0831638833C386E5CC9E8 /* CompletionEngine.swift */; };
 		C7AACF777FF0DAD9ACA426F3 /* AgentLifecycleEventMapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 73B4D726525024EBE47A0C7E /* AgentLifecycleEventMapper.swift */; };
 		C7AD6F2DDAE9E11920277D41 /* RemoteSessionGateway.swift in Sources */ = {isa = PBXBuildFile; fileRef = CDE49D2437D7E6AC9D67F136 /* RemoteSessionGateway.swift */; };
@@ -1059,6 +1067,8 @@
 		DD18C5FF006D18BC66964D94 /* TerminalTabView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 14087D57E96448EEF0B80BD9 /* TerminalTabView.swift */; };
 		DD2553E3635BFE3B15355E08 /* ACPLaunchPathResolverTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D911D138AF8A0E99191C862 /* ACPLaunchPathResolverTests.swift */; };
 		DDAA1FF54466B7F5424D315E /* TreeSitterMarkdown in Frameworks */ = {isa = PBXBuildFile; productRef = 49F7F27A9183521F9997AF49 /* TreeSitterMarkdown */; };
+		DDBEA2D41ECA8F0F28CF5DF6 /* RemoteRepoValidatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 27192411BB5CB8F8F7AD09B2 /* RemoteRepoValidatorTests.swift */; };
+		DE207C4CFA1A45866FCB4E22 /* RemoteFileOps.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B44E54236211F972F3D1C24 /* RemoteFileOps.swift */; };
 		DE33366A35436471AE0DAE96 /* DiffReviewRenderBudgetTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AEE54F0320B9F40BEF46FB85 /* DiffReviewRenderBudgetTests.swift */; };
 		DE41CB04CDC89D09346494A5 /* LineEndingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EB52B59655B85764D85CFB7F /* LineEndingTests.swift */; };
 		DE431266B60826A2EA3736DF /* LineBuffer.swift in Sources */ = {isa = PBXBuildFile; fileRef = C954F77AD0867F7FD39A5ED7 /* LineBuffer.swift */; };
@@ -1113,6 +1123,7 @@
 		E703B4895A0337310A17FED6 /* GitService+ImageDiff.swift in Sources */ = {isa = PBXBuildFile; fileRef = A8EFC853C0D2EB4AC2B01D9E /* GitService+ImageDiff.swift */; };
 		E71191CF46FA3E7BC2C4A91E /* ACPBareURLLinkifierTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F59AAA1AFFBA04A837BCBA13 /* ACPBareURLLinkifierTests.swift */; };
 		E77C416471C1AAADF35EE085 /* MemorySnapshot.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BCE20FA56461E66A58A7AA2 /* MemorySnapshot.swift */; };
+		E7BB827F6AD4758BB2FA39BB /* RemoteFileOpsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDB2D3836ADF55732C5A416D /* RemoteFileOpsTests.swift */; };
 		E7C047F37A5C7100149FED4A /* ImageDiffPairResolverTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 76942B028C3CBAED16BC4CC1 /* ImageDiffPairResolverTests.swift */; };
 		E822ADCC0B35087C38FB01A3 /* TabsManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D6A9977C979705A40595FD5E /* TabsManagerTests.swift */; };
 		E83BA776F26C011D034CAE18 /* HoverHighlightFeature.swift in Sources */ = {isa = PBXBuildFile; fileRef = 019A03B92542169A6595D432 /* HoverHighlightFeature.swift */; };
@@ -1357,6 +1368,7 @@
 		1B218326D14AA360C7476D43 /* GitServiceStashTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GitServiceStashTests.swift; sourceTree = "<group>"; };
 		1BB00E2F151520DC02B80BD4 /* GitServicePullTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GitServicePullTests.swift; sourceTree = "<group>"; };
 		1C63CBD839A151565AE577AE /* SSHIntegrationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SSHIntegrationTests.swift; sourceTree = "<group>"; };
+		1CA759D2C99D1FEE3C67A1BA /* RemoteImageCacheTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteImageCacheTests.swift; sourceTree = "<group>"; };
 		1D3505FB870FA22C9C0FDB26 /* RightPaneStateSyncStatusTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RightPaneStateSyncStatusTests.swift; sourceTree = "<group>"; };
 		1D4A5200C6EBB6434DD6B8BD /* ShortcutReservationsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShortcutReservationsTests.swift; sourceTree = "<group>"; };
 		1DC1B975662D135B148443BC /* ACPSessionHydrationStateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPSessionHydrationStateTests.swift; sourceTree = "<group>"; };
@@ -1397,6 +1409,7 @@
 		269CE27A6F4F2E663EDF9052 /* GitNameValidator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GitNameValidator.swift; sourceTree = "<group>"; };
 		26E8DE57F9A8D5230BCB7A2C /* ACPSubmitIntentTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPSubmitIntentTests.swift; sourceTree = "<group>"; };
 		270C700882ACFBBC59F931D2 /* ProjectIconImageStagingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProjectIconImageStagingTests.swift; sourceTree = "<group>"; };
+		27192411BB5CB8F8F7AD09B2 /* RemoteRepoValidatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteRepoValidatorTests.swift; sourceTree = "<group>"; };
 		271F79A165CAA8617C1EAA4E /* GitTypesTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GitTypesTests.swift; sourceTree = "<group>"; };
 		274681651A972F6771B1930C /* session-update-tool-call-update-meta.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "session-update-tool-call-update-meta.json"; sourceTree = "<group>"; };
 		2763F93ADFDCDF6B31D16475 /* UpdateController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UpdateController.swift; sourceTree = "<group>"; };
@@ -1435,6 +1448,7 @@
 		2CFB62547E5E1FD480BD0322 /* ACPChangeNotifierTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPChangeNotifierTests.swift; sourceTree = "<group>"; };
 		2D4CC3ED497796474F107EBE /* ReviewLoopDrawer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReviewLoopDrawer.swift; sourceTree = "<group>"; };
 		2D751485790AD46EBC15A979 /* session-update-session-info-goal.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "session-update-session-info-goal.json"; sourceTree = "<group>"; };
+		2D89D9FFAC80BDE46A651A0F /* RemoteLSPLauncherTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteLSPLauncherTests.swift; sourceTree = "<group>"; };
 		2D904085EDE14D7C09A6BC9A /* AgentPathResolveTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentPathResolveTests.swift; sourceTree = "<group>"; };
 		2D911D138AF8A0E99191C862 /* ACPLaunchPathResolverTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPLaunchPathResolverTests.swift; sourceTree = "<group>"; };
 		2DCB7DA8B6EA8CF8B98EA267 /* ACPAuthFailure.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPAuthFailure.swift; sourceTree = "<group>"; };
@@ -1513,6 +1527,7 @@
 		3A110966FCF7EA47C18BE71A /* ACPAgentProfilesTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPAgentProfilesTests.swift; sourceTree = "<group>"; };
 		3A8A5932B664C88F20BF00CA /* AppStateCreateWorktreeLaunchSurfaceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppStateCreateWorktreeLaunchSurfaceTests.swift; sourceTree = "<group>"; };
 		3ABD3A575FAEC381A5744BFA /* FileTreeBuilderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileTreeBuilderTests.swift; sourceTree = "<group>"; };
+		3ACA7839782B71490BFD3A6F /* RemoteLSPLauncher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteLSPLauncher.swift; sourceTree = "<group>"; };
 		3B2FEDAAF927CDC9E4D19551 /* StagedDiffLoader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StagedDiffLoader.swift; sourceTree = "<group>"; };
 		3B7BE659F7E386D15047C374 /* WorktreeCreateFetchTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorktreeCreateFetchTests.swift; sourceTree = "<group>"; };
 		3BE23A4881B60D7F16A4ACA5 /* GhosttyConfigBuilderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GhosttyConfigBuilderTests.swift; sourceTree = "<group>"; };
@@ -1676,6 +1691,7 @@
 		5D486FD440D802AEC65D1555 /* MarkdownFileType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MarkdownFileType.swift; sourceTree = "<group>"; };
 		5D68E2007F0370A6C4E7DBC7 /* FileSearchBackend.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileSearchBackend.swift; sourceTree = "<group>"; };
 		5DA887927D32EBA2252792D9 /* ReviewChangesTabView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReviewChangesTabView.swift; sourceTree = "<group>"; };
+		5DABE7D3F41C67D28CA2C2F9 /* RemoteImageCache.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteImageCache.swift; sourceTree = "<group>"; };
 		5DC558BE723378DCC7AA5B55 /* ACPChatTypography.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPChatTypography.swift; sourceTree = "<group>"; };
 		5DD723B8C15EF2413C5D935D /* BlockedLanguageServerNudgeResolver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BlockedLanguageServerNudgeResolver.swift; sourceTree = "<group>"; };
 		5E21106B4804D62C1D3C7F62 /* AlasGhostty.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlasGhostty.swift; sourceTree = "<group>"; };
@@ -1871,6 +1887,7 @@
 		8B94010802299E6AC5597E85 /* WorktreeCodableTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorktreeCodableTests.swift; sourceTree = "<group>"; };
 		8BA7FA6A8011D88FDFEE30A0 /* ACPGoalPillTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPGoalPillTests.swift; sourceTree = "<group>"; };
 		8BCE20FA56461E66A58A7AA2 /* MemorySnapshot.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MemorySnapshot.swift; sourceTree = "<group>"; };
+		8C040E975A14DE31446BCEB7 /* ACPReconnectPolicyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPReconnectPolicyTests.swift; sourceTree = "<group>"; };
 		8C11E3449E4A7B4E69E83C1C /* AppStatePersistenceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppStatePersistenceTests.swift; sourceTree = "<group>"; };
 		8C245764E69F92CBB8D31BF6 /* GatekeeperRemediator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GatekeeperRemediator.swift; sourceTree = "<group>"; };
 		8C28D64372B5B4C734A92533 /* GitHubCLIProviderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GitHubCLIProviderTests.swift; sourceTree = "<group>"; };
@@ -1943,6 +1960,7 @@
 		9A40BDC5115B641AB26220D9 /* ZmxSunPathBudget.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ZmxSunPathBudget.swift; sourceTree = "<group>"; };
 		9B15F58AFF7BC19419935C05 /* PendingDiscard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PendingDiscard.swift; sourceTree = "<group>"; };
 		9B3DCDC9F76F91CE1071471C /* StagedDiffSelectionBridgingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StagedDiffSelectionBridgingTests.swift; sourceTree = "<group>"; };
+		9B44E54236211F972F3D1C24 /* RemoteFileOps.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteFileOps.swift; sourceTree = "<group>"; };
 		9C165BAAF80F9B4A5949BD39 /* RightPaneTransitionalView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RightPaneTransitionalView.swift; sourceTree = "<group>"; };
 		9C45A26ADB0D1CCFBB5BEAE8 /* TerminalSession.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TerminalSession.swift; sourceTree = "<group>"; };
 		9CA420C011D4235E47A3FB1B /* RepoSelectorRecents.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RepoSelectorRecents.swift; sourceTree = "<group>"; };
@@ -2088,6 +2106,7 @@
 		BD77FB052C8B5A937B14A4AE /* ProjectConfig.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProjectConfig.swift; sourceTree = "<group>"; };
 		BD8249F7BF5F86B0AFD5CAB8 /* RemoteContentSearchTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteContentSearchTests.swift; sourceTree = "<group>"; };
 		BDABED76CD2A552B1781D3F4 /* EditorLSPStatusBadge.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditorLSPStatusBadge.swift; sourceTree = "<group>"; };
+		BDB2D3836ADF55732C5A416D /* RemoteFileOpsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteFileOpsTests.swift; sourceTree = "<group>"; };
 		BDD799D0EC22F74A3DCB7F09 /* DeletingWorktreeView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeletingWorktreeView.swift; sourceTree = "<group>"; };
 		BDEA5E54A30636928F5D3B3E /* GitIgnoreService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GitIgnoreService.swift; sourceTree = "<group>"; };
 		BE51418F7A0C3D24A60464C7 /* ACPUsageUpdateDecodeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPUsageUpdateDecodeTests.swift; sourceTree = "<group>"; };
@@ -2182,8 +2201,10 @@
 		CF15D3E39502C1BA6618943B /* MergeConflictTabModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MergeConflictTabModel.swift; sourceTree = "<group>"; };
 		CF41C5BD384265499AEEE4CF /* CompletionDocumentationRendererTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CompletionDocumentationRendererTests.swift; sourceTree = "<group>"; };
 		CF5143046167375A802ED378 /* SurfaceViewKeyboardTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SurfaceViewKeyboardTests.swift; sourceTree = "<group>"; };
+		CF798A386DD56B4127D5272A /* ACPTerminalCRLFTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPTerminalCRLFTests.swift; sourceTree = "<group>"; };
 		CF80D59C3200AD3215D1E140 /* ACPNewChatEmptyStatePolicy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPNewChatEmptyStatePolicy.swift; sourceTree = "<group>"; };
 		CF8CB5B1DA091EE7D5DA0436 /* DiffDisplayModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiffDisplayModel.swift; sourceTree = "<group>"; };
+		D020BC9CC6586ECAB8A38042 /* ACPReconnectPolicy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPReconnectPolicy.swift; sourceTree = "<group>"; };
 		D02E429B37288215EBC89571 /* CommitHeaderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommitHeaderView.swift; sourceTree = "<group>"; };
 		D081C8802733D2532DBCD74D /* BlockedLanguageServerNudgeResolverTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BlockedLanguageServerNudgeResolverTests.swift; sourceTree = "<group>"; };
 		D0CE3F0637B3CA27B1D87080 /* ACPNewChatEmptyStateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPNewChatEmptyStateTests.swift; sourceTree = "<group>"; };
@@ -2413,6 +2434,7 @@
 		FE66950F2226F1182DCDD39A /* RightPaneView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RightPaneView.swift; sourceTree = "<group>"; };
 		FEB2EC20D23F9A4F50B1A6E3 /* TerminalPane.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TerminalPane.swift; sourceTree = "<group>"; };
 		FEC68B05B719B9235865027F /* ThreePaneSizing.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThreePaneSizing.swift; sourceTree = "<group>"; };
+		FED0AAD3FE0E143D409A3E8B /* AppStateRemoteWorktreePathTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppStateRemoteWorktreePathTests.swift; sourceTree = "<group>"; };
 		FF71AF50DF50AA4158A96177 /* DiffContextExpansion.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiffContextExpansion.swift; sourceTree = "<group>"; };
 		FF741B889D6DC8B1F4EB350F /* ProcessGitDataTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProcessGitDataTests.swift; sourceTree = "<group>"; };
 		FFAFB40F5FACBC726C7E4172 /* ACPAdapterInstaller.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPAdapterInstaller.swift; sourceTree = "<group>"; };
@@ -2618,6 +2640,7 @@
 				6612D1543C76A6EAF38A14F4 /* AppStateOverlayFocusTests.swift */,
 				69FCCEC91C40EBC896CF9089 /* AppStateOverlayTests.swift */,
 				8C11E3449E4A7B4E69E83C1C /* AppStatePersistenceTests.swift */,
+				FED0AAD3FE0E143D409A3E8B /* AppStateRemoteWorktreePathTests.swift */,
 				EFDB90A7F9E58F4C1A258D23 /* AppStateSpacesTests.swift */,
 				279D43D7F43C40A004A2C4AC /* AppStateTabAvailabilityTests.swift */,
 				6CB9643BE01E416D3D2F4454 /* BaseBranchSelectorTests.swift */,
@@ -3578,6 +3601,7 @@
 		6C950D9947AAFA5DBD17CFF1 /* SSH */ = {
 			isa = PBXGroup;
 			children = (
+				D020BC9CC6586ECAB8A38042 /* ACPReconnectPolicy.swift */,
 				817DF0174BF04CF5DA288E99 /* ACPRemoteFileServer.swift */,
 				B5DC5AC55D5FF5BF7FECAD2F /* ACPRemoteLaunch.swift */,
 				0CB5D1C8046EF9B6A95C41CD /* ACPRemoteMCPFilter.swift */,
@@ -3585,10 +3609,13 @@
 				43C24D126BC74FF514F19E5D /* RemoteContentSearch.swift */,
 				6DF3C93B3FB8B2FDDD8E859D /* RemoteExec.swift */,
 				0046CA3B9FF996E55A85D853 /* RemoteFileAccess.swift */,
+				9B44E54236211F972F3D1C24 /* RemoteFileOps.swift */,
 				FBB8BF6C61840B9F972ABACC /* RemoteFileStats.swift */,
 				10B3615A1591964AB1C9E524 /* RemoteHostCapabilities.swift */,
 				8DF79BBCD948528D655A9A81 /* RemoteHostRegistry.swift */,
 				416C797DBD3F9F4901817769 /* RemoteHostStatusStore.swift */,
+				5DABE7D3F41C67D28CA2C2F9 /* RemoteImageCache.swift */,
+				3ACA7839782B71490BFD3A6F /* RemoteLSPLauncher.swift */,
 				7ECE27F4EE6CA578693BE83D /* RemoteProjectGitWatcher.swift */,
 				2DDE190423707662BDC8E6EA /* RemoteRepoValidator.swift */,
 				191BAF20EAD2D227D9E7B418 /* RemoteStatusFingerprint.swift */,
@@ -4064,21 +4091,27 @@
 		BB299962DBB46EEC6165F3D3 /* SSH */ = {
 			isa = PBXGroup;
 			children = (
+				8C040E975A14DE31446BCEB7 /* ACPReconnectPolicyTests.swift */,
 				D2BDAB5BEDF7FE5EBFBFE9A2 /* ACPRemoteFileServerTests.swift */,
 				8CA0EE530F852A921942B04C /* ACPRemoteLaunchTests.swift */,
 				09140CEE45083CFDCE8D262B /* ACPRemoteMCPFilterTests.swift */,
+				CF798A386DD56B4127D5272A /* ACPTerminalCRLFTests.swift */,
 				03A4B0CD519C39CCB197CBD4 /* GitInvocationTests.swift */,
 				BD8249F7BF5F86B0AFD5CAB8 /* RemoteContentSearchTests.swift */,
 				E8BAFC83D9BC1577CB14ADD5 /* RemoteExecTests.swift */,
 				B9A252BAD78A56343D68E782 /* RemoteFileAccessTests.swift */,
+				BDB2D3836ADF55732C5A416D /* RemoteFileOpsTests.swift */,
 				D7331F53100D12A0DDFD6B1D /* RemoteFileSearchGateTests.swift */,
 				E3F09E1DA9C67475445F4B63 /* RemoteFileStatsTests.swift */,
 				843E7D6E8972C01B3DC924F2 /* RemoteHostCapabilitiesTests.swift */,
 				1854EA4072F4F45DA70854D0 /* RemoteHostRegistryTests.swift */,
 				621C13FD3A997CCB29273993 /* RemoteHostStatusStoreTests.swift */,
+				1CA759D2C99D1FEE3C67A1BA /* RemoteImageCacheTests.swift */,
 				69B2FEBEDD6FD3B2B37F4895 /* RemoteLastActivityTests.swift */,
+				2D89D9FFAC80BDE46A651A0F /* RemoteLSPLauncherTests.swift */,
 				807FC0DF3AE4C069E77F85B6 /* RemotePollCadenceTests.swift */,
 				442D62D5E8B59845EB9494D3 /* RemoteProjectCollisionTests.swift */,
+				27192411BB5CB8F8F7AD09B2 /* RemoteRepoValidatorTests.swift */,
 				DF0CB94DB8949712B0274413 /* RemoteStatusFingerprintTests.swift */,
 				90E25D0520B813E8AC9A7174 /* RemoteTerminalLaunchTests.swift */,
 				2E14E781F0E1127387A06907 /* RemoteTerminalScriptTests.swift */,
@@ -4845,6 +4878,7 @@
 				52D1F226CE8DB1967977D3F3 /* ACPQuestionRequest.swift in Sources */,
 				F269D59E1E21AD57EF3EE909 /* ACPQueueHeader.swift in Sources */,
 				518F761277C4C5E4E6C512A3 /* ACPQueuedBubble.swift in Sources */,
+				96BE44DEEDA6FDF72BD51173 /* ACPReconnectPolicy.swift in Sources */,
 				C85FF0853DE69CE2EB59633E /* ACPRecoveryPill.swift in Sources */,
 				86B6F59A54E8A3029C8A1656 /* ACPRemoteFileServer.swift in Sources */,
 				99FA2F1F9D41CA81E59B20E5 /* ACPRemoteLaunch.swift in Sources */,
@@ -5242,11 +5276,14 @@
 				B3B038297A419A0E8DF73440 /* RemoteDevice.swift in Sources */,
 				CE41DBC2472CA576CA52062C /* RemoteExec.swift in Sources */,
 				AA0E67AEE21718BF9BEC7F13 /* RemoteFileAccess.swift in Sources */,
+				DE207C4CFA1A45866FCB4E22 /* RemoteFileOps.swift in Sources */,
 				30582A6DE1CFD0B9D5CB2E14 /* RemoteFileStats.swift in Sources */,
 				C9C01E8A89C6767524FAC63B /* RemoteHTTPResponder.swift in Sources */,
 				330D198F38767801994BF84C /* RemoteHostCapabilities.swift in Sources */,
 				F47287FCE8C870F02F2A55E0 /* RemoteHostRegistry.swift in Sources */,
 				52AB869F9071103FD1649552 /* RemoteHostStatusStore.swift in Sources */,
+				C71971EF735837CD260359C6 /* RemoteImageCache.swift in Sources */,
+				15BAFAC3EC3613E406024EFD /* RemoteLSPLauncher.swift in Sources */,
 				4F2BB7482C39B07F5E35E9D1 /* RemoteMessageWireJSON.swift in Sources */,
 				528CB7F6FF36C6809DE532B8 /* RemoteNetwork.swift in Sources */,
 				342C28B197D5048F78D2E8D6 /* RemotePairingService.swift in Sources */,
@@ -5470,6 +5507,7 @@
 				86759BF3DE64FFAA4FE98822 /* ACPPromptCapabilitiesTests.swift in Sources */,
 				1A56FAF2DE8FFB95272EE948 /* ACPQuestionPromptTests.swift in Sources */,
 				23F92214B30096D070419921 /* ACPQueuedBubbleActionMetricsTests.swift in Sources */,
+				C7658D1AF7744BB694D2388A /* ACPReconnectPolicyTests.swift in Sources */,
 				018F0BE1174B9020C52007BE /* ACPRemoteFileServerTests.swift in Sources */,
 				F35B489DCC169F2B77DB6F3F /* ACPRemoteLaunchTests.swift in Sources */,
 				5E22B20F69866FAEDABA2812 /* ACPRemoteMCPFilterTests.swift in Sources */,
@@ -5514,6 +5552,7 @@
 				929C2E12D6178FF3728365A2 /* ACPStdioTerminalDispatchTests.swift in Sources */,
 				1B16FCB3621BB868C34334D7 /* ACPStreamingTextTests.swift in Sources */,
 				D874E635B8E9CDB1610D36E8 /* ACPSubmitIntentTests.swift in Sources */,
+				664EEC1B4A18A02A49897FBA /* ACPTerminalCRLFTests.swift in Sources */,
 				11827C40372D7209868161C0 /* ACPTerminalHostTests.swift in Sources */,
 				89F58C7178B661EAE0057622 /* ACPTerminalTests.swift in Sources */,
 				28710B18EF9FAE100B99E0A7 /* ACPThumbnailImageCacheTests.swift in Sources */,
@@ -5573,6 +5612,7 @@
 				ABB5595A9A39C8AF203B5873 /* AppStateOverlayFocusTests.swift in Sources */,
 				51E0500756DC8DD5238F4D19 /* AppStateOverlayTests.swift in Sources */,
 				25B94D8823F2A5A2BA4545B5 /* AppStatePersistenceTests.swift in Sources */,
+				996B67B45E7247CDED5F98EF /* AppStateRemoteWorktreePathTests.swift in Sources */,
 				07385C7266A0694AB7F4E872 /* AppStateSpacesTests.swift in Sources */,
 				956B221EC4FF3A18C713A64F /* AppStateTabAvailabilityTests.swift in Sources */,
 				A5742BE7348C02324B8119D0 /* BaseBranchSelectorTests.swift in Sources */,
@@ -5795,17 +5835,21 @@
 				32324CCE247B8B4784674453 /* RemoteContentSearchTests.swift in Sources */,
 				472B73818FD74F0A4D40DA59 /* RemoteExecTests.swift in Sources */,
 				61FEA0F7DAF21FA0AFE88BAE /* RemoteFileAccessTests.swift in Sources */,
+				E7BB827F6AD4758BB2FA39BB /* RemoteFileOpsTests.swift in Sources */,
 				FB000FBA6BA9ED49F65681AC /* RemoteFileSearchGateTests.swift in Sources */,
 				61E93449DD65CFD2643A9AC6 /* RemoteFileStatsTests.swift in Sources */,
 				395A56C7C48EDDDE1F39F335 /* RemoteHostCapabilitiesTests.swift in Sources */,
 				A45A26B8B43E49BC8F952CD6 /* RemoteHostRegistryTests.swift in Sources */,
 				6AE8EFD251D182A476F90E4B /* RemoteHostStatusStoreTests.swift in Sources */,
+				B4F98348084DEFA5C1D51A6E /* RemoteImageCacheTests.swift in Sources */,
+				5BB2FF7F9DFFFEF75CA508A2 /* RemoteLSPLauncherTests.swift in Sources */,
 				6B51524A0970D593F6AEEAB1 /* RemoteLastActivityTests.swift in Sources */,
 				FBEC59B1FD0C1DDDB6CE3100 /* RemoteNetworkTests.swift in Sources */,
 				E22E6141A5EF030F79CF8CBE /* RemotePairingServiceTests.swift in Sources */,
 				F53E906F828DEFF6A41C46BA /* RemotePollCadenceTests.swift in Sources */,
 				3D561C5EDA7AAB4831CA58CF /* RemoteProjectCollisionTests.swift in Sources */,
 				A7B9BDE0F2EB1D1769EC81B5 /* RemoteProtocolTests.swift in Sources */,
+				DDBEA2D41ECA8F0F28CF5DF6 /* RemoteRepoValidatorTests.swift in Sources */,
 				A962107126052DEF597CB7FA /* RemoteServerIntegrationTests.swift in Sources */,
 				0B6ADBF320E6130E5888CAA7 /* RemoteSessionGatewayTests.swift in Sources */,
 				8723FD954481CDFA5B2916DF /* RemoteStatusFingerprintTests.swift in Sources */,

--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -223,9 +223,12 @@
 		2FAAA60EF431D109D842428F /* SelfUpdaterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EBDEF50915BACBD0C3EE36AE /* SelfUpdaterTests.swift */; };
 		2FE10FC44BD9CDBD0C969374 /* MergeBulkResolvePromptEditorWindow.swift in Sources */ = {isa = PBXBuildFile; fileRef = F61EB45499D244E44EB170BC /* MergeBulkResolvePromptEditorWindow.swift */; };
 		303E16565ECF8BDDC7A28AF1 /* ACPTopPaginationIndicator.swift in Sources */ = {isa = PBXBuildFile; fileRef = F01FD27D107E0207950F00D3 /* ACPTopPaginationIndicator.swift */; };
+		30582A6DE1CFD0B9D5CB2E14 /* RemoteFileStats.swift in Sources */ = {isa = PBXBuildFile; fileRef = FBB8BF6C61840B9F972ABACC /* RemoteFileStats.swift */; };
 		30A1BE2F8E2777CFF6460486 /* ACPConnectionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 701F837327D905FAAA0E0AF3 /* ACPConnectionTests.swift */; };
 		312DB6016C040DE52CD365E8 /* ACPToolbar.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6DE88BE229FD6C1DF35F7EA /* ACPToolbar.swift */; };
+		316A645ECCB46A0F74915EA4 /* RemoteProjectGitWatcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7ECE27F4EE6CA578693BE83D /* RemoteProjectGitWatcher.swift */; };
 		316ABEA3944051EA41569FDC /* ACPContextRingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = ECD9419E685AD7EED286006B /* ACPContextRingTests.swift */; };
+		31CB9FBE16CECDE2C6D94EC6 /* RemoteStatusFingerprint.swift in Sources */ = {isa = PBXBuildFile; fileRef = 191BAF20EAD2D227D9E7B418 /* RemoteStatusFingerprint.swift */; };
 		32660CEE9955165AE3CCDFBE /* InstallerHostTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 364507D55CD5D73CD44819E7 /* InstallerHostTests.swift */; };
 		32674DB95F2B62C00FC0AAA2 /* RemoteProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = E4A54DD8080E3395C8E7049E /* RemoteProtocol.swift */; };
 		32727E2775753CDBF02D4660 /* TreeSitterDockerfile in Frameworks */ = {isa = PBXBuildFile; productRef = B0B462D196CBF339A0F9B651 /* TreeSitterDockerfile */; };
@@ -233,6 +236,7 @@
 		32A11F8AF508AA2A7D3EF788 /* ThemeEnvironment.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7BF6F2D792F7DFAE3DA8E597 /* ThemeEnvironment.swift */; };
 		32A4E1C6A5A43C8B9C47C3C9 /* MergeOperationState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 542B9A0D90AC20BBCA6073F8 /* MergeOperationState.swift */; };
 		32B3513F0BFC2F9B72763773 /* GitHubCLIProviderVerdictTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 48594A1746139E9C11B175FF /* GitHubCLIProviderVerdictTests.swift */; };
+		330D198F38767801994BF84C /* RemoteHostCapabilities.swift in Sources */ = {isa = PBXBuildFile; fileRef = 10B3615A1591964AB1C9E524 /* RemoteHostCapabilities.swift */; };
 		3326658AC801C394C43AC8A2 /* SearchKbd.swift in Sources */ = {isa = PBXBuildFile; fileRef = 36992F601C8EB6C3D45B584F /* SearchKbd.swift */; };
 		33376EB37508D556E2385D33 /* ACPSessionUpdateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5D62D907375A5CBAED1E698 /* ACPSessionUpdateTests.swift */; };
 		3388D5141427C0046BD8CCC7 /* LanguageRegistry.swift in Sources */ = {isa = PBXBuildFile; fileRef = 328607AAAAA12EE2206ED5A4 /* LanguageRegistry.swift */; };
@@ -256,6 +260,7 @@
 		38EB2BAA50A7B7B37DDE2A4C /* RightPaneStateBaseBranchTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6713F5A8712C0962BED1EFEA /* RightPaneStateBaseBranchTests.swift */; };
 		3910AEED9AC1888582616BEA /* FileTreeRowIndentationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 431BECA1461B76DF86BBFBDF /* FileTreeRowIndentationTests.swift */; };
 		395276FB3018E0B9E68A7D81 /* ACPMockClientTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11BA9F25CB0A6A2BFDB390EE /* ACPMockClientTests.swift */; };
+		395A56C7C48EDDDE1F39F335 /* RemoteHostCapabilitiesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 843E7D6E8972C01B3DC924F2 /* RemoteHostCapabilitiesTests.swift */; };
 		395BC74AF07FD44D67DBE579 /* EditorOverlayPanel.swift in Sources */ = {isa = PBXBuildFile; fileRef = F6883364648BF4B9F5DA131F /* EditorOverlayPanel.swift */; };
 		3961F6003185B2FC9DFE7E14 /* ImageDiffDifferenceComputerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9278ED5964A66871F5299F0C /* ImageDiffDifferenceComputerTests.swift */; };
 		396AF154C56F4B5061756366 /* ProjectAvatarPresetProviderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 72B788982A64A04D18889D25 /* ProjectAvatarPresetProviderTests.swift */; };
@@ -341,6 +346,7 @@
 		467BA12331DB76C41313BF70 /* WorktreesPane.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0F68A9692F85197ED9E16262 /* WorktreesPane.swift */; };
 		46A9AFFA9A459522F71E073E /* DiffTabRenderContext.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2F14E32DEBE042825BCA44A /* DiffTabRenderContext.swift */; };
 		46E3CCB2AC426BD5F8CB55DC /* ACPImageBlocksTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BCE0DA8D81AE8E0BFE54D279 /* ACPImageBlocksTests.swift */; };
+		472B73818FD74F0A4D40DA59 /* RemoteExecTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E8BAFC83D9BC1577CB14ADD5 /* RemoteExecTests.swift */; };
 		474DF7FE50CB6146644B2450 /* ImageDiffEndToEndTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 638E94907851A6D0B4AB8F52 /* ImageDiffEndToEndTests.swift */; };
 		476CE4945CF013F76A96AFC6 /* MergeConflictTabState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2A69F4742D3C251A59F400B8 /* MergeConflictTabState.swift */; };
 		47789166FA5C563AE2F550ED /* ACPDiffGeneratorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 05C9583C0CA5EDE7D2A1B7DF /* ACPDiffGeneratorTests.swift */; };
@@ -396,6 +402,7 @@
 		5269ED23D9732680EF7F4E16 /* ReviewChangesScrollSpy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80694744AA6D7E12FEB38A1A /* ReviewChangesScrollSpy.swift */; };
 		528CB7F6FF36C6809DE532B8 /* RemoteNetwork.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC6FA61556FA530605C9FE81 /* RemoteNetwork.swift */; };
 		52A5CDD852333A0C4BDC6995 /* ACPPermissionRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 67E03BF5DB4E6BFF8C2FA6A2 /* ACPPermissionRequest.swift */; };
+		52AB869F9071103FD1649552 /* RemoteHostStatusStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 416C797DBD3F9F4901817769 /* RemoteHostStatusStore.swift */; };
 		52D1F226CE8DB1967977D3F3 /* ACPQuestionRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB9D4FBF08CBAB59C08BBF1D /* ACPQuestionRequest.swift */; };
 		5426DC977050AACBCBDA37E9 /* AgentDetectorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3DAAC7481503A68EA0888682 /* AgentDetectorTests.swift */; };
 		542C76AF3A21CBD6B2838CEE /* ACPLaunchSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8528D2A61E1FC9F51296C9F6 /* ACPLaunchSpec.swift */; };
@@ -459,6 +466,7 @@
 		6140E9DE848A53A37DFB8890 /* CodexInstallerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F59C2CF9199EC099B1814AC /* CodexInstallerTests.swift */; };
 		61D309EDA409B06C83D52CEE /* FilesTabCompactChainTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 408F9FF672160D96B1C22648 /* FilesTabCompactChainTests.swift */; };
 		61D33019E9AA23F5042C39B2 /* ACPSessionHydrator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 94D30693F45966ED1456811E /* ACPSessionHydrator.swift */; };
+		61E93449DD65CFD2643A9AC6 /* RemoteFileStatsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E3F09E1DA9C67475445F4B63 /* RemoteFileStatsTests.swift */; };
 		62055BD147E504C658B93E20 /* ACPFirstRunConnectingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 737A9A3D11EA28582CA5D061 /* ACPFirstRunConnectingView.swift */; };
 		6256EAEB315812ED4F4E9107 /* StageChip.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1874031C788ADB4398151FF1 /* StageChip.swift */; };
 		6291072E82FC282625FD1617 /* GitServiceCommitEditingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F3AB3D6DF4A23648F0C45AC5 /* GitServiceCommitEditingTests.swift */; };
@@ -488,8 +496,10 @@
 		6AB631ACAD28A187F15282AB /* FileSnapshotTabView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D28AEE8E4821977FDAF13960 /* FileSnapshotTabView.swift */; };
 		6AD85D472EF03EAE992D65D0 /* session-new-response.json in Resources */ = {isa = PBXBuildFile; fileRef = E7C070765F0474DF1C4ACEF0 /* session-new-response.json */; };
 		6AE129E340CA74CC26B34B66 /* ACPMarkdownLiveStyler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2AE565966DD010FDFD7DFF50 /* ACPMarkdownLiveStyler.swift */; };
+		6AE8EFD251D182A476F90E4B /* RemoteHostStatusStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 621C13FD3A997CCB29273993 /* RemoteHostStatusStoreTests.swift */; };
 		6AFE04B669CA654D7733F97E /* AlasCLICommandRouter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1271747193D1594AEA596278 /* AlasCLICommandRouter.swift */; };
 		6B2B0731DBCD5D1BE353FFCB /* AlasGhostty.SurfaceView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02FCDD45C23BAE141549D03F /* AlasGhostty.SurfaceView.swift */; };
+		6B51524A0970D593F6AEEAB1 /* RemoteLastActivityTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 69B2FEBEDD6FD3B2B37F4895 /* RemoteLastActivityTests.swift */; };
 		6B9E188A6C0A39C38D8723BF /* ReviewRequestDraftTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A1A152D4297DBB5B8DFF950 /* ReviewRequestDraftTests.swift */; };
 		6BA64E78F8AB2B8710665FC9 /* ReviewDraftModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = BFA871B5464E4F9D3350851B /* ReviewDraftModels.swift */; };
 		6BF6FE50DAC473322005A036 /* ProjectsManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F5B91F414F99741818BCB17 /* ProjectsManagerTests.swift */; };
@@ -608,6 +618,7 @@
 		864B31874E286ED036347975 /* ACPLaunchSpecNpmPackageTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6BDB3231FFACC0398F973876 /* ACPLaunchSpecNpmPackageTests.swift */; };
 		86718F7E55531B8E4356D7D1 /* PaneTree.swift in Sources */ = {isa = PBXBuildFile; fileRef = A2943FBB1D6371EFAC9BBE68 /* PaneTree.swift */; };
 		86759BF3DE64FFAA4FE98822 /* ACPPromptCapabilitiesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C2D7EA3F2B69C0A8D2F8F8A5 /* ACPPromptCapabilitiesTests.swift */; };
+		8723FD954481CDFA5B2916DF /* RemoteStatusFingerprintTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DF0CB94DB8949712B0274413 /* RemoteStatusFingerprintTests.swift */; };
 		873535DE3342024BD7AA057E /* ShortcutReservations.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8942D0F47DBCFFB3549EE775 /* ShortcutReservations.swift */; };
 		8744A1DB40A1EC0D01D4C895 /* AlasGhostty.Config.swift in Sources */ = {isa = PBXBuildFile; fileRef = 82F696636690652C48CE87D9 /* AlasGhostty.Config.swift */; };
 		8775C1FD6CE74B0555D778A3 /* Carbon.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8DD66F449B380BC74B373647 /* Carbon.framework */; };
@@ -938,6 +949,7 @@
 		C9C01E8A89C6767524FAC63B /* RemoteHTTPResponder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 85AC3FB0255285382EF24D8D /* RemoteHTTPResponder.swift */; };
 		C9DAC0F907752F6D3B955DD8 /* HoverFeatureRenderingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F1D8FEB5416139D8B2BA780 /* HoverFeatureRenderingTests.swift */; };
 		CA4CE5E97DB02330A1151245 /* ACPSetupCheck.swift in Sources */ = {isa = PBXBuildFile; fileRef = FC8E722C16FFBEEEC43337D5 /* ACPSetupCheck.swift */; };
+		CA7269D9237C925D7C1358D7 /* RemoteWorktreePollTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 32EEB37C08A315D65558B273 /* RemoteWorktreePollTests.swift */; };
 		CAD36BB3EBF8B31309B7BEFF /* DiffSelectableTextBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 44E87586CA07BA62C84BAD24 /* DiffSelectableTextBuilder.swift */; };
 		CAE149AF78F3A62AC985EA2D /* TerminalIntegrationActionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 606DD97D8F66AC2B5883F984 /* TerminalIntegrationActionsTests.swift */; };
 		CAE7524F4289A256FF1069FC /* PaneTreeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16C9E59E3987C1D3C9989D91 /* PaneTreeTests.swift */; };
@@ -959,6 +971,7 @@
 		CDE156FA8E19E85437E79908 /* CompletionFeatureTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7C80F21C310F35EBA6FBDF58 /* CompletionFeatureTests.swift */; };
 		CDEE1CFA85DF21346B05C2E2 /* Icon.swift in Sources */ = {isa = PBXBuildFile; fileRef = 29313DDC46A0CCA2FA42CDE9 /* Icon.swift */; };
 		CE24C8CA495726CD294FD223 /* CommitsSectionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6FFE12732C0D83715FC990A9 /* CommitsSectionView.swift */; };
+		CE41DBC2472CA576CA52062C /* RemoteExec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6DF3C93B3FB8B2FDDD8E859D /* RemoteExec.swift */; };
 		CE43461FCD815780370E90D8 /* SearchKind.swift in Sources */ = {isa = PBXBuildFile; fileRef = 36B06AE8BA5FBDEAD4586616 /* SearchKind.swift */; };
 		CEEDAC1603DF2F3BD9223238 /* AlasCLIReviewTargetResolverTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA0482EAA16C6A9987C16EE8 /* AlasCLIReviewTargetResolverTests.swift */; };
 		CF105C488C01331534C65D88 /* MergeConflictBinaryView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 69B7FA3997B6A60397B56CD4 /* MergeConflictBinaryView.swift */; };
@@ -1128,6 +1141,7 @@
 		F1C4DD0D3A95ED5301EE2AC9 /* ACPTranscriptMarkdownCacheEvictionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3708552C2BF0E70F10C76B63 /* ACPTranscriptMarkdownCacheEvictionTests.swift */; };
 		F2385B8730E9D1F47C7FA423 /* ReviewChangesRail.swift in Sources */ = {isa = PBXBuildFile; fileRef = 09C9EEDB5A71C5FAE2D0E42B /* ReviewChangesRail.swift */; };
 		F269D59E1E21AD57EF3EE909 /* ACPQueueHeader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 10602801D3FA990E60CB072D /* ACPQueueHeader.swift */; };
+		F2983AF4C5674B906BEF2E88 /* RemoteWorktreePoll.swift in Sources */ = {isa = PBXBuildFile; fileRef = D837246E56472EBA3993F515 /* RemoteWorktreePoll.swift */; };
 		F2F75C44CD5042F209299FB9 /* InstallSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E7E61C3BD4AD4AE3828A6F0 /* InstallSource.swift */; };
 		F3C9321ABD5230C4FA4F7D4E /* GatekeeperRemediatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9FE7571B9A83F6BFFA6BFC6 /* GatekeeperRemediatorTests.swift */; };
 		F3E7DF34D9DDA268E40575AE /* CommitInfoTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9427B922BAFA43AF6EB21080 /* CommitInfoTests.swift */; };
@@ -1136,6 +1150,7 @@
 		F4796D2FCBA83BD5E71F4398 /* DiffPaneLSPTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AD920E9E496F1DC3BB894B8B /* DiffPaneLSPTests.swift */; };
 		F4B9A51A40365909B7644561 /* ShortcutsPane.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6821B71680094791995C4975 /* ShortcutsPane.swift */; };
 		F4FF07CA337DB0D0035C3C10 /* DiffPaneViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E5A257562FAB9C5932A6BD69 /* DiffPaneViewTests.swift */; };
+		F53E906F828DEFF6A41C46BA /* RemotePollCadenceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 807FC0DF3AE4C069E77F85B6 /* RemotePollCadenceTests.swift */; };
 		F5626F154B2CF446FF3F917B /* ReviewLoopState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0299820D15A2A4C7838B2CE9 /* ReviewLoopState.swift */; };
 		F57297D50FC237F7993F7B81 /* ACPSelectChipMetricsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2D5632302DE981B0BD36273 /* ACPSelectChipMetricsTests.swift */; };
 		F60AF5FD23412D018F263322 /* NotificationDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = C19E98A53E2B793436D2F10D /* NotificationDelegate.swift */; };
@@ -1272,6 +1287,7 @@
 		100091C8ABC3F3FA66C744E9 /* HoverHighlightFeatureTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HoverHighlightFeatureTests.swift; sourceTree = "<group>"; };
 		1003EEEA51DA385A0DD57CA0 /* ThemeStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThemeStoreTests.swift; sourceTree = "<group>"; };
 		10602801D3FA990E60CB072D /* ACPQueueHeader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPQueueHeader.swift; sourceTree = "<group>"; };
+		10B3615A1591964AB1C9E524 /* RemoteHostCapabilities.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteHostCapabilities.swift; sourceTree = "<group>"; };
 		10E10C6559E26691EC906737 /* ACPTerminalMessages.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPTerminalMessages.swift; sourceTree = "<group>"; };
 		11BA9F25CB0A6A2BFDB390EE /* ACPMockClientTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPMockClientTests.swift; sourceTree = "<group>"; };
 		11C3EC94DBE871DFC45C7D25 /* AgentTerminalLaunchTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentTerminalLaunchTests.swift; sourceTree = "<group>"; };
@@ -1310,6 +1326,7 @@
 		1874031C788ADB4398151FF1 /* StageChip.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StageChip.swift; sourceTree = "<group>"; };
 		18B5372BF572EBA3A84113E4 /* AgentLifecycleEventMapperTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentLifecycleEventMapperTests.swift; sourceTree = "<group>"; };
 		18CA47D5E0D1BF962CF45ABE /* AgentHookInstallNudgeBanner.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentHookInstallNudgeBanner.swift; sourceTree = "<group>"; };
+		191BAF20EAD2D227D9E7B418 /* RemoteStatusFingerprint.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteStatusFingerprint.swift; sourceTree = "<group>"; };
 		1936C815E64C7DB204340469 /* ACPMCPStatusControl.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPMCPStatusControl.swift; sourceTree = "<group>"; };
 		1977C85C3DFD1F232A2755AD /* FilesTabFilterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FilesTabFilterTests.swift; sourceTree = "<group>"; };
 		19C327BB65463E878DDCDA5E /* MarkdownFileTypeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MarkdownFileTypeTests.swift; sourceTree = "<group>"; };
@@ -1431,6 +1448,7 @@
 		328607AAAAA12EE2206ED5A4 /* LanguageRegistry.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LanguageRegistry.swift; sourceTree = "<group>"; };
 		329882D757C34246C9848C3A /* ACPMentionChipAttachment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPMentionChipAttachment.swift; sourceTree = "<group>"; };
 		32D6E47CC4523FDE263C764C /* WindowDragHandle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WindowDragHandle.swift; sourceTree = "<group>"; };
+		32EEB37C08A315D65558B273 /* RemoteWorktreePollTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteWorktreePollTests.swift; sourceTree = "<group>"; };
 		333EA07C2BCA5E18F55E2613 /* AppConfigChangesTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppConfigChangesTests.swift; sourceTree = "<group>"; };
 		336ADD8484D99054ADDBA588 /* CursorModelVariantsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CursorModelVariantsTests.swift; sourceTree = "<group>"; };
 		3375A79ACFD3567389DA855C /* FileResultRow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileResultRow.swift; sourceTree = "<group>"; };
@@ -1507,6 +1525,7 @@
 		410A42B1C46E68965FD36793 /* ShortcutChip.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShortcutChip.swift; sourceTree = "<group>"; };
 		412B2AF1B68E3B56DE21EB91 /* DiagnosticsRangeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiagnosticsRangeTests.swift; sourceTree = "<group>"; };
 		413CE0B0BBC96D412D048B1D /* .gitkeep */ = {isa = PBXFileReference; path = .gitkeep; sourceTree = "<group>"; };
+		416C797DBD3F9F4901817769 /* RemoteHostStatusStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteHostStatusStore.swift; sourceTree = "<group>"; };
 		417CDD7CCA0D0A86E9EE281F /* CenterSelectionState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CenterSelectionState.swift; sourceTree = "<group>"; };
 		41995BCAEF1E2B356E499333 /* ReviewChangesFileSection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReviewChangesFileSection.swift; sourceTree = "<group>"; };
 		419EF533C4D29448483045DA /* ACPChangeNotifier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPChangeNotifier.swift; sourceTree = "<group>"; };
@@ -1654,6 +1673,7 @@
 		61C69060B922A729DD807920 /* LSPURI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LSPURI.swift; sourceTree = "<group>"; };
 		61D4F5B30CE2AA0220A3E45C /* DiffInlineHighlighterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiffInlineHighlighterTests.swift; sourceTree = "<group>"; };
 		620C4A708CD1013DE2736A00 /* AppIconTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppIconTests.swift; sourceTree = "<group>"; };
+		621C13FD3A997CCB29273993 /* RemoteHostStatusStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteHostStatusStoreTests.swift; sourceTree = "<group>"; };
 		626DBFF220D347A36859AB17 /* ZmxSessionNameTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ZmxSessionNameTests.swift; sourceTree = "<group>"; };
 		63376280CA1D01F9D564A6F6 /* ACPSessionDiscovery.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPSessionDiscovery.swift; sourceTree = "<group>"; };
 		638E94907851A6D0B4AB8F52 /* ImageDiffEndToEndTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageDiffEndToEndTests.swift; sourceTree = "<group>"; };
@@ -1682,6 +1702,7 @@
 		694DDEC8133EFBC33822BC26 /* ReviewLoopHandoffRoutingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReviewLoopHandoffRoutingTests.swift; sourceTree = "<group>"; };
 		695C887147631ACF1FA73C3F /* MergeView3Way.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MergeView3Way.swift; sourceTree = "<group>"; };
 		699EA14937A07B8DDD57F401 /* OutdatedThreadsDrawer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OutdatedThreadsDrawer.swift; sourceTree = "<group>"; };
+		69B2FEBEDD6FD3B2B37F4895 /* RemoteLastActivityTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteLastActivityTests.swift; sourceTree = "<group>"; };
 		69B7FA3997B6A60397B56CD4 /* MergeConflictBinaryView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MergeConflictBinaryView.swift; sourceTree = "<group>"; };
 		69CE1F098A251F24BC352816 /* AlasGhosttySmokeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlasGhosttySmokeTests.swift; sourceTree = "<group>"; };
 		69CF2E2BF116094A9FEE3F8D /* SelfUpdater.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SelfUpdater.swift; sourceTree = "<group>"; };
@@ -1703,6 +1724,7 @@
 		6D8E02BB3FEB3C71AEEBBE6F /* ACPChatLayout.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPChatLayout.swift; sourceTree = "<group>"; };
 		6D95FBEE2C9BF1AD1A602C28 /* GitLabCLIProviderVerdictTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GitLabCLIProviderVerdictTests.swift; sourceTree = "<group>"; };
 		6DF0AEE54BDB4FC4FD5E02F4 /* GitServiceStagingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GitServiceStagingTests.swift; sourceTree = "<group>"; };
+		6DF3C93B3FB8B2FDDD8E859D /* RemoteExec.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteExec.swift; sourceTree = "<group>"; };
 		6DF51E6FAFBB47E2F31DA287 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		6E8B52175A7F6144B4C52010 /* EditorTabView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditorTabView.swift; sourceTree = "<group>"; };
 		6E8FA892877AE2FDBCD4C747 /* ShortcutResolverTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShortcutResolverTests.swift; sourceTree = "<group>"; };
@@ -1776,6 +1798,7 @@
 		7DED8CE500F7170B1C0857FE /* ACPAdapterUpdateStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPAdapterUpdateStore.swift; sourceTree = "<group>"; };
 		7E39F15B0B7395FB81D2C9D0 /* AlasApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlasApp.swift; sourceTree = "<group>"; };
 		7EAE4B623CC10B4544E8D17A /* PersistenceStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PersistenceStoreTests.swift; sourceTree = "<group>"; };
+		7ECE27F4EE6CA578693BE83D /* RemoteProjectGitWatcher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteProjectGitWatcher.swift; sourceTree = "<group>"; };
 		7F42E564C149FA33CF0E9870 /* MasonSnapshot.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MasonSnapshot.swift; sourceTree = "<group>"; };
 		7F4A17C42833BE6190A45AF3 /* GitService+CommitEditing.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "GitService+CommitEditing.swift"; sourceTree = "<group>"; };
 		7F4B57FBB6E595E5DF1C6F93 /* ACPMarkdownLiveStylerImageChipTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPMarkdownLiveStylerImageChipTests.swift; sourceTree = "<group>"; };
@@ -1785,6 +1808,7 @@
 		802EF6C18E2E27F68F6B770E /* ImageDiffSwipeView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageDiffSwipeView.swift; sourceTree = "<group>"; };
 		8062405A67C934905EE61D98 /* TextEditCoordinates.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TextEditCoordinates.swift; sourceTree = "<group>"; };
 		80694744AA6D7E12FEB38A1A /* ReviewChangesScrollSpy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReviewChangesScrollSpy.swift; sourceTree = "<group>"; };
+		807FC0DF3AE4C069E77F85B6 /* RemotePollCadenceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemotePollCadenceTests.swift; sourceTree = "<group>"; };
 		80BAFADCDC3E349AC3DBDDEA /* ACPPlanPillStateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPPlanPillStateTests.swift; sourceTree = "<group>"; };
 		8149AEEF45B05C60E06888E5 /* HoverWindowController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HoverWindowController.swift; sourceTree = "<group>"; };
 		81773A01826A91080F5A2E95 /* ACPCodeBlockHighlighterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPCodeBlockHighlighterTests.swift; sourceTree = "<group>"; };
@@ -1796,6 +1820,7 @@
 		8351793355009D8A73AA91A2 /* SSHCommand.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SSHCommand.swift; sourceTree = "<group>"; };
 		835D847AD52A2CEB36DD5022 /* LegacyHookSweepTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LegacyHookSweepTests.swift; sourceTree = "<group>"; };
 		83A8622BA130E8FA339EDCEB /* TabsManagerReviewRequestDraftTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabsManagerReviewRequestDraftTests.swift; sourceTree = "<group>"; };
+		843E7D6E8972C01B3DC924F2 /* RemoteHostCapabilitiesTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteHostCapabilitiesTests.swift; sourceTree = "<group>"; };
 		8451C5BCEE50F118F07CDD83 /* RightPaneStoreBaseBranchTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RightPaneStoreBaseBranchTests.swift; sourceTree = "<group>"; };
 		84A01D6512394EF1C41782AD /* ACPMarkdownInlineTextView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPMarkdownInlineTextView.swift; sourceTree = "<group>"; };
 		84E56989C04A4A478D68084C /* ACPMarkdownBlockCacheTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPMarkdownBlockCacheTests.swift; sourceTree = "<group>"; };
@@ -2172,6 +2197,7 @@
 		D7322805CC904D460A8C53C8 /* ACPPlanSidebarVisibility.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPPlanSidebarVisibility.swift; sourceTree = "<group>"; };
 		D73C433B373577FD515FECD3 /* DiffReviewScrollSpy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiffReviewScrollSpy.swift; sourceTree = "<group>"; };
 		D76C02E43360C0BCFEDF5428 /* DiffOpenFileAvailability.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiffOpenFileAvailability.swift; sourceTree = "<group>"; };
+		D837246E56472EBA3993F515 /* RemoteWorktreePoll.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteWorktreePoll.swift; sourceTree = "<group>"; };
 		D8ACFACD788DF2035534F62E /* AppConfigCodeInstallTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppConfigCodeInstallTests.swift; sourceTree = "<group>"; };
 		D8D583586BC5171D2FE91F6C /* ReviewScopeSelection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReviewScopeSelection.swift; sourceTree = "<group>"; };
 		D906A11E19D165C7F5447E67 /* ACPElicitationCoordinatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPElicitationCoordinatorTests.swift; sourceTree = "<group>"; };
@@ -2197,6 +2223,7 @@
 		DE74A483930F70A0C79CC3E8 /* CodeHostRemoteDetectorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CodeHostRemoteDetectorTests.swift; sourceTree = "<group>"; };
 		DE7675D7F75E36E9C81193C8 /* LSPMessagesTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LSPMessagesTests.swift; sourceTree = "<group>"; };
 		DEFCC9CAC7B3254708748815 /* OpenSessionsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OpenSessionsTests.swift; sourceTree = "<group>"; };
+		DF0CB94DB8949712B0274413 /* RemoteStatusFingerprintTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteStatusFingerprintTests.swift; sourceTree = "<group>"; };
 		DF32A1544E13321E9E223AFF /* DiffPaneView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiffPaneView.swift; sourceTree = "<group>"; };
 		DF919734A34EEB87FA61FE07 /* WebSocketFrameTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebSocketFrameTests.swift; sourceTree = "<group>"; };
 		DF9310EAA75C6B6567F303B6 /* ACPChipState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPChipState.swift; sourceTree = "<group>"; };
@@ -2225,6 +2252,7 @@
 		E2F14E32DEBE042825BCA44A /* DiffTabRenderContext.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiffTabRenderContext.swift; sourceTree = "<group>"; };
 		E373805AEFD068B97BC33A82 /* StashDiffTabView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StashDiffTabView.swift; sourceTree = "<group>"; };
 		E3C49F11F34AA97B21936FC1 /* ACPElicitationCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPElicitationCoordinator.swift; sourceTree = "<group>"; };
+		E3F09E1DA9C67475445F4B63 /* RemoteFileStatsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteFileStatsTests.swift; sourceTree = "<group>"; };
 		E43F9F04AF6A6FF0A4D328F4 /* CommitHeaderViewTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommitHeaderViewTests.swift; sourceTree = "<group>"; };
 		E444D51CB35528C8E5AB150A /* FuzzyMatchTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FuzzyMatchTests.swift; sourceTree = "<group>"; };
 		E49006251DFBE67CCD0C4008 /* ACPMentionPicker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPMentionPicker.swift; sourceTree = "<group>"; };
@@ -2246,6 +2274,7 @@
 		E8272ACF30256E328519815C /* SQLiteDatabaseTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SQLiteDatabaseTests.swift; sourceTree = "<group>"; };
 		E8A63557B4F06AA00761B547 /* session-new-response-with-config-options.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "session-new-response-with-config-options.json"; sourceTree = "<group>"; };
 		E8B46B2287CA16E683490301 /* DiffReviewInlineFeedbackActions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiffReviewInlineFeedbackActions.swift; sourceTree = "<group>"; };
+		E8BAFC83D9BC1577CB14ADD5 /* RemoteExecTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteExecTests.swift; sourceTree = "<group>"; };
 		E91A6AFCC9B3AEFB43D8946F /* CodeLanguageDetailViewTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CodeLanguageDetailViewTests.swift; sourceTree = "<group>"; };
 		E92F018C967A8D1421D83A06 /* SettingsSectionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsSectionTests.swift; sourceTree = "<group>"; };
 		E940D4265B42839BBC7681DC /* AppStateCreateWorktreeSymlinkTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppStateCreateWorktreeSymlinkTests.swift; sourceTree = "<group>"; };
@@ -2331,6 +2360,7 @@
 		FB19F036D793E5DFBBD3C675 /* AgentHookSocketServerCLITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentHookSocketServerCLITests.swift; sourceTree = "<group>"; };
 		FB5B73ECBD730B5BB24E2240 /* ACPSessionManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPSessionManagerTests.swift; sourceTree = "<group>"; };
 		FB9E78C70091168556C9669B /* ReviewChangesTabViewTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReviewChangesTabViewTests.swift; sourceTree = "<group>"; };
+		FBB8BF6C61840B9F972ABACC /* RemoteFileStats.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteFileStats.swift; sourceTree = "<group>"; };
 		FBC01971BF41E6D0B9B317CF /* CodeTextView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CodeTextView.swift; sourceTree = "<group>"; };
 		FBFB85AF60C0E4520ED0DA8E /* AgentLauncherDialog.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentLauncherDialog.swift; sourceTree = "<group>"; };
 		FC084336F2435440CE1E0AFB /* ReviewChangesLoader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReviewChangesLoader.swift; sourceTree = "<group>"; };
@@ -3517,8 +3547,15 @@
 			isa = PBXGroup;
 			children = (
 				F83370751580C42D5DE93F80 /* GitInvocation.swift */,
+				6DF3C93B3FB8B2FDDD8E859D /* RemoteExec.swift */,
+				FBB8BF6C61840B9F972ABACC /* RemoteFileStats.swift */,
+				10B3615A1591964AB1C9E524 /* RemoteHostCapabilities.swift */,
 				8DF79BBCD948528D655A9A81 /* RemoteHostRegistry.swift */,
+				416C797DBD3F9F4901817769 /* RemoteHostStatusStore.swift */,
+				7ECE27F4EE6CA578693BE83D /* RemoteProjectGitWatcher.swift */,
 				2DDE190423707662BDC8E6EA /* RemoteRepoValidator.swift */,
+				191BAF20EAD2D227D9E7B418 /* RemoteStatusFingerprint.swift */,
+				D837246E56472EBA3993F515 /* RemoteWorktreePoll.swift */,
 				8351793355009D8A73AA91A2 /* SSHCommand.swift */,
 			);
 			path = SSH;
@@ -3989,8 +4026,16 @@
 			isa = PBXGroup;
 			children = (
 				03A4B0CD519C39CCB197CBD4 /* GitInvocationTests.swift */,
+				E8BAFC83D9BC1577CB14ADD5 /* RemoteExecTests.swift */,
+				E3F09E1DA9C67475445F4B63 /* RemoteFileStatsTests.swift */,
+				843E7D6E8972C01B3DC924F2 /* RemoteHostCapabilitiesTests.swift */,
 				1854EA4072F4F45DA70854D0 /* RemoteHostRegistryTests.swift */,
+				621C13FD3A997CCB29273993 /* RemoteHostStatusStoreTests.swift */,
+				69B2FEBEDD6FD3B2B37F4895 /* RemoteLastActivityTests.swift */,
+				807FC0DF3AE4C069E77F85B6 /* RemotePollCadenceTests.swift */,
 				442D62D5E8B59845EB9494D3 /* RemoteProjectCollisionTests.swift */,
+				DF0CB94DB8949712B0274413 /* RemoteStatusFingerprintTests.swift */,
+				32EEB37C08A315D65558B273 /* RemoteWorktreePollTests.swift */,
 				90A3C6694C4027DE1A26EC59 /* SSHCommandTests.swift */,
 				1C63CBD839A151565AE577AE /* SSHIntegrationTests.swift */,
 			);
@@ -5143,11 +5188,16 @@
 				0FA612529F7E2BC05E577420 /* RemoteAccessPolicy.swift in Sources */,
 				8C1E756AFF4125E7ED04E0B8 /* RemoteConnection.swift in Sources */,
 				B3B038297A419A0E8DF73440 /* RemoteDevice.swift in Sources */,
+				CE41DBC2472CA576CA52062C /* RemoteExec.swift in Sources */,
+				30582A6DE1CFD0B9D5CB2E14 /* RemoteFileStats.swift in Sources */,
 				C9C01E8A89C6767524FAC63B /* RemoteHTTPResponder.swift in Sources */,
+				330D198F38767801994BF84C /* RemoteHostCapabilities.swift in Sources */,
 				F47287FCE8C870F02F2A55E0 /* RemoteHostRegistry.swift in Sources */,
+				52AB869F9071103FD1649552 /* RemoteHostStatusStore.swift in Sources */,
 				4F2BB7482C39B07F5E35E9D1 /* RemoteMessageWireJSON.swift in Sources */,
 				528CB7F6FF36C6809DE532B8 /* RemoteNetwork.swift in Sources */,
 				342C28B197D5048F78D2E8D6 /* RemotePairingService.swift in Sources */,
+				316A645ECCB46A0F74915EA4 /* RemoteProjectGitWatcher.swift in Sources */,
 				32674DB95F2B62C00FC0AAA2 /* RemoteProtocol.swift in Sources */,
 				257D3CF69FE6A97D058FF959 /* RemoteRepoValidator.swift in Sources */,
 				FB6FF6C91476DEE43E512E30 /* RemoteServer.swift in Sources */,
@@ -5155,6 +5205,8 @@
 				C3E59948BD9108C1BD3243AD /* RemoteServerPane.swift in Sources */,
 				C7AD6F2DDAE9E11920277D41 /* RemoteSessionGateway.swift in Sources */,
 				A770A357750B4713AF21C0E0 /* RemoteSessionsProvider.swift in Sources */,
+				31CB9FBE16CECDE2C6D94EC6 /* RemoteStatusFingerprint.swift in Sources */,
+				F2983AF4C5674B906BEF2E88 /* RemoteWorktreePoll.swift in Sources */,
 				8C492CBACC6D6DACE56DADA9 /* RemoteWorktreeSummaryBuilder.swift in Sources */,
 				A7340B3C1C6B2BC7189F3695 /* RepoDot.swift in Sources */,
 				2C9C311A6DFC9DC5954F5CC2 /* RepoGroupView.swift in Sources */,
@@ -5682,14 +5734,22 @@
 				C99FAC8BF1908B490E058FDA /* RemoteAccessPolicyTests.swift in Sources */,
 				6F0EA54CB15AB5507C84B4A7 /* RemoteAppStateAccessTests.swift in Sources */,
 				0F556F82FA5BF1E8D50096E2 /* RemoteConfigTests.swift in Sources */,
+				472B73818FD74F0A4D40DA59 /* RemoteExecTests.swift in Sources */,
+				61E93449DD65CFD2643A9AC6 /* RemoteFileStatsTests.swift in Sources */,
+				395A56C7C48EDDDE1F39F335 /* RemoteHostCapabilitiesTests.swift in Sources */,
 				A45A26B8B43E49BC8F952CD6 /* RemoteHostRegistryTests.swift in Sources */,
+				6AE8EFD251D182A476F90E4B /* RemoteHostStatusStoreTests.swift in Sources */,
+				6B51524A0970D593F6AEEAB1 /* RemoteLastActivityTests.swift in Sources */,
 				FBEC59B1FD0C1DDDB6CE3100 /* RemoteNetworkTests.swift in Sources */,
 				E22E6141A5EF030F79CF8CBE /* RemotePairingServiceTests.swift in Sources */,
+				F53E906F828DEFF6A41C46BA /* RemotePollCadenceTests.swift in Sources */,
 				3D561C5EDA7AAB4831CA58CF /* RemoteProjectCollisionTests.swift in Sources */,
 				A7B9BDE0F2EB1D1769EC81B5 /* RemoteProtocolTests.swift in Sources */,
 				A962107126052DEF597CB7FA /* RemoteServerIntegrationTests.swift in Sources */,
 				0B6ADBF320E6130E5888CAA7 /* RemoteSessionGatewayTests.swift in Sources */,
+				8723FD954481CDFA5B2916DF /* RemoteStatusFingerprintTests.swift in Sources */,
 				0C0C65E3012A722B10816F8D /* RemoteWebAssetTests.swift in Sources */,
+				CA7269D9237C925D7C1358D7 /* RemoteWorktreePollTests.swift in Sources */,
 				9666162EC5BE3445EEBCDEA1 /* RemoteWorktreeSummaryBuilderTests.swift in Sources */,
 				133597E7D43CFE746EF4EF2B /* RepoGroupViewLayoutTests.swift in Sources */,
 				737EC7C9A35C9ED61ED67B83 /* RepoSelectorModelTests.swift in Sources */,

--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -58,6 +58,7 @@
 		0BBFEE487AF71AD858B19EC5 /* ACPPermissionPrompt.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0BCD93747BF71CB256038314 /* ACPPermissionPrompt.swift */; };
 		0C0C65E3012A722B10816F8D /* RemoteWebAssetTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5AA5809066E33EB30E09E0D8 /* RemoteWebAssetTests.swift */; };
 		0C54356D0ACEDD5275FFB6EB /* CodeLanguageDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A727D24652E45B98C10917F8 /* CodeLanguageDetailView.swift */; };
+		0C7A044AC34BF225A4149556 /* RemoteTerminalLaunchTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 90E25D0520B813E8AC9A7174 /* RemoteTerminalLaunchTests.swift */; };
 		0CF488290CC525EA7C11A43C /* DiffParserTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE26221DC8E8837FFEB87474 /* DiffParserTests.swift */; };
 		0D17211026C6790B96CC6578 /* CopyFeedbackState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5C8BF1EC24E449A302A1E25C /* CopyFeedbackState.swift */; };
 		0D65F2B699E6B0CF0915D25D /* ImageDiffMode.swift in Sources */ = {isa = PBXBuildFile; fileRef = 09007B6E90DE89B7215A5D44 /* ImageDiffMode.swift */; };
@@ -145,6 +146,7 @@
 		1ED78A36E993D85D0DD1E3CC /* ACPSessionUsageTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF05DF16587C5A48A9E04B2A /* ACPSessionUsageTests.swift */; };
 		1F5AA7624BE0459338EE0EEC /* DragHandle.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7D398D06BDFFA5EDC24D3E6A /* DragHandle.swift */; };
 		1F84796DE0ABC832C0303B27 /* ACPSessionStoreDedupTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FADFC82400385AD76A200A2B /* ACPSessionStoreDedupTests.swift */; };
+		1F860C66D658B0DA5A0599F6 /* RemoteZmxInstaller.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B4239E76E57C63CD983437F /* RemoteZmxInstaller.swift */; };
 		1F89B774F2DC7DD818AD4E5B /* ACPSessionRunner.swift in Sources */ = {isa = PBXBuildFile; fileRef = F332906E17C5865856DBB90B /* ACPSessionRunner.swift */; };
 		20096441D4850614A3CB8187 /* ACPSessionStoreCRUDTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45D7C5464CA7B663A9A7BBFF /* ACPSessionStoreCRUDTests.swift */; };
 		208E237B41BA6F234151683D /* HTTPRequestParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = DAA7CD14A8FA2D335A59B062 /* HTTPRequestParser.swift */; };
@@ -555,6 +557,7 @@
 		771CD72B94194370E783F7DD /* StartupScriptResolverTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9D3C76F2F0F6BCE4023A9D7F /* StartupScriptResolverTests.swift */; };
 		77CDD88F7C517095DE580B50 /* ReviewEvidence.swift in Sources */ = {isa = PBXBuildFile; fileRef = FC11F5C6667A6ECB74E066AE /* ReviewEvidence.swift */; };
 		78D25A04EAE26A0F3021A057 /* Paths.swift in Sources */ = {isa = PBXBuildFile; fileRef = 364213292935A05F3B52F51F /* Paths.swift */; };
+		78D49DF401553D2A9BCE1EE5 /* RemoteTerminalScriptTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E14E781F0E1127387A06907 /* RemoteTerminalScriptTests.swift */; };
 		78D7FFD42803C098160BADC6 /* ProjectMCPServer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 81E981C10B13C43CE65DA74D /* ProjectMCPServer.swift */; };
 		79212B50265AAC9A392957C9 /* GitLFSBlobResolver.swift in Sources */ = {isa = PBXBuildFile; fileRef = 90F0CBE40E2CF0251ABE72AE /* GitLFSBlobResolver.swift */; };
 		7950F5765E0B95EB1CB5B818 /* ACPNewChatEmptyStatePolicy.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF80D59C3200AD3215D1E140 /* ACPNewChatEmptyStatePolicy.swift */; };
@@ -1191,7 +1194,9 @@
 		FBEC59B1FD0C1DDDB6CE3100 /* RemoteNetworkTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2AF8084388AF564A1907548C /* RemoteNetworkTests.swift */; };
 		FC9BC95960AE236F82D69E0B /* ACPQuestionPrompt.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4306DE43C5ADCC65310C1169 /* ACPQuestionPrompt.swift */; };
 		FCB5091692C10A45B4E5D6BB /* AppConfigWorktreeOrderingDecodeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0458AFA9BCBC4484B084085 /* AppConfigWorktreeOrderingDecodeTests.swift */; };
+		FCC6BC72DF062AA572F5535F /* RemoteZmxInstallerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 93079B18AE14C7AA3516727D /* RemoteZmxInstallerTests.swift */; };
 		FCE78F165C46577F64D9B9AD /* CenterSelectionState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 417CDD7CCA0D0A86E9EE281F /* CenterSelectionState.swift */; };
+		FD4196C9F558CE954D94E060 /* RemoteTerminalScript.swift in Sources */ = {isa = PBXBuildFile; fileRef = 85C6579202DFD8E5FBF26DE5 /* RemoteTerminalScript.swift */; };
 		FD5AC98DEE4448EB95C49485 /* ACPUserInputFormStateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 79A6CF0F6BDA59AAE1354EE7 /* ACPUserInputFormStateTests.swift */; };
 		FD5B6E7F566A9D0BACD19267 /* DiffInlineCommentModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 729DDA22CA94FA0DC8810057 /* DiffInlineCommentModelTests.swift */; };
 		FD7719ABDA6CFCF28BB0F800 /* ACPMessageListPaginationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9272E334A0A5DF460514CF01 /* ACPMessageListPaginationTests.swift */; };
@@ -1435,6 +1440,7 @@
 		2DCB7DA8B6EA8CF8B98EA267 /* ACPAuthFailure.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPAuthFailure.swift; sourceTree = "<group>"; };
 		2DD6714E62064D5438AAE139 /* MemoryDiagnosticsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MemoryDiagnosticsTests.swift; sourceTree = "<group>"; };
 		2DDE190423707662BDC8E6EA /* RemoteRepoValidator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteRepoValidator.swift; sourceTree = "<group>"; };
+		2E14E781F0E1127387A06907 /* RemoteTerminalScriptTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteTerminalScriptTests.swift; sourceTree = "<group>"; };
 		2E669FEBE09BC250B477B335 /* ACPLaunchCatalog.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPLaunchCatalog.swift; sourceTree = "<group>"; };
 		2E7E61C3BD4AD4AE3828A6F0 /* InstallSource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InstallSource.swift; sourceTree = "<group>"; };
 		2EB39DE3614B5BEC4D3EBF13 /* ACPSessionLifecycleTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPSessionLifecycleTests.swift; sourceTree = "<group>"; };
@@ -1658,6 +1664,7 @@
 		5A85E1D1600F487D359F363F /* RightPaneStateFileTreeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RightPaneStateFileTreeTests.swift; sourceTree = "<group>"; };
 		5AA5809066E33EB30E09E0D8 /* RemoteWebAssetTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteWebAssetTests.swift; sourceTree = "<group>"; };
 		5B3FF64CC698074BFDE2A36A /* ProjectConfigTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProjectConfigTests.swift; sourceTree = "<group>"; };
+		5B4239E76E57C63CD983437F /* RemoteZmxInstaller.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteZmxInstaller.swift; sourceTree = "<group>"; };
 		5B72D621D704CB5B2CCA82C6 /* RemoteAppStateAccessTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteAppStateAccessTests.swift; sourceTree = "<group>"; };
 		5B7B8B82A8D4F5B1F1DF1731 /* DiffReviewRenderContext.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiffReviewRenderContext.swift; sourceTree = "<group>"; };
 		5B9583B34B9AAD4454C558E5 /* GitService+Pull.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "GitService+Pull.swift"; sourceTree = "<group>"; };
@@ -1845,6 +1852,7 @@
 		8528D2A61E1FC9F51296C9F6 /* ACPLaunchSpec.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPLaunchSpec.swift; sourceTree = "<group>"; };
 		856607304A9F2409EF40BD5F /* PendingDiscardTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PendingDiscardTests.swift; sourceTree = "<group>"; };
 		85AC3FB0255285382EF24D8D /* RemoteHTTPResponder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteHTTPResponder.swift; sourceTree = "<group>"; };
+		85C6579202DFD8E5FBF26DE5 /* RemoteTerminalScript.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteTerminalScript.swift; sourceTree = "<group>"; };
 		85E54E9F53ECFE9C205788F1 /* ACPComposerPlaceholderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPComposerPlaceholderTests.swift; sourceTree = "<group>"; };
 		866CFEB75B7F754485C6BE77 /* WorkingTreeSectionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkingTreeSectionView.swift; sourceTree = "<group>"; };
 		8673293AD419AA36F7DF02A9 /* CommitsOlderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommitsOlderTests.swift; sourceTree = "<group>"; };
@@ -1884,6 +1892,7 @@
 		90817EC3BAA727EF6D9FBD97 /* GitService+Discard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "GitService+Discard.swift"; sourceTree = "<group>"; };
 		90A3C6694C4027DE1A26EC59 /* SSHCommandTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SSHCommandTests.swift; sourceTree = "<group>"; };
 		90D74C28EB7B8C3CBC53994D /* MergeAgent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MergeAgent.swift; sourceTree = "<group>"; };
+		90E25D0520B813E8AC9A7174 /* RemoteTerminalLaunchTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteTerminalLaunchTests.swift; sourceTree = "<group>"; };
 		90F0CBE40E2CF0251ABE72AE /* GitLFSBlobResolver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GitLFSBlobResolver.swift; sourceTree = "<group>"; };
 		910CB5077C8E89A778F1E896 /* ChangesTreeBuilder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChangesTreeBuilder.swift; sourceTree = "<group>"; };
 		9110E0F4F4EF24444FA0BE3A /* JetBrainsMonoNerdFont-Regular.ttf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "JetBrainsMonoNerdFont-Regular.ttf"; sourceTree = "<group>"; };
@@ -1893,6 +1902,7 @@
 		9272E334A0A5DF460514CF01 /* ACPMessageListPaginationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPMessageListPaginationTests.swift; sourceTree = "<group>"; };
 		9278ED5964A66871F5299F0C /* ImageDiffDifferenceComputerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageDiffDifferenceComputerTests.swift; sourceTree = "<group>"; };
 		92F1C71C2574B1077964E5E1 /* ACPPermissionDecisionLogTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPPermissionDecisionLogTests.swift; sourceTree = "<group>"; };
+		93079B18AE14C7AA3516727D /* RemoteZmxInstallerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteZmxInstallerTests.swift; sourceTree = "<group>"; };
 		932EA49288A0444FB8BB9CE3 /* PiInstaller.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PiInstaller.swift; sourceTree = "<group>"; };
 		932F0FEE5330D5B4470C1874 /* DiagnosticsFeature.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiagnosticsFeature.swift; sourceTree = "<group>"; };
 		9346272D3AF9A7D78067C96F /* SettingsSaveNormalizationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsSaveNormalizationTests.swift; sourceTree = "<group>"; };
@@ -3582,7 +3592,9 @@
 				7ECE27F4EE6CA578693BE83D /* RemoteProjectGitWatcher.swift */,
 				2DDE190423707662BDC8E6EA /* RemoteRepoValidator.swift */,
 				191BAF20EAD2D227D9E7B418 /* RemoteStatusFingerprint.swift */,
+				85C6579202DFD8E5FBF26DE5 /* RemoteTerminalScript.swift */,
 				D837246E56472EBA3993F515 /* RemoteWorktreePoll.swift */,
+				5B4239E76E57C63CD983437F /* RemoteZmxInstaller.swift */,
 				8351793355009D8A73AA91A2 /* SSHCommand.swift */,
 			);
 			path = SSH;
@@ -4068,7 +4080,10 @@
 				807FC0DF3AE4C069E77F85B6 /* RemotePollCadenceTests.swift */,
 				442D62D5E8B59845EB9494D3 /* RemoteProjectCollisionTests.swift */,
 				DF0CB94DB8949712B0274413 /* RemoteStatusFingerprintTests.swift */,
+				90E25D0520B813E8AC9A7174 /* RemoteTerminalLaunchTests.swift */,
+				2E14E781F0E1127387A06907 /* RemoteTerminalScriptTests.swift */,
 				32EEB37C08A315D65558B273 /* RemoteWorktreePollTests.swift */,
+				93079B18AE14C7AA3516727D /* RemoteZmxInstallerTests.swift */,
 				90A3C6694C4027DE1A26EC59 /* SSHCommandTests.swift */,
 				1C63CBD839A151565AE577AE /* SSHIntegrationTests.swift */,
 			);
@@ -5244,8 +5259,10 @@
 				C7AD6F2DDAE9E11920277D41 /* RemoteSessionGateway.swift in Sources */,
 				A770A357750B4713AF21C0E0 /* RemoteSessionsProvider.swift in Sources */,
 				31CB9FBE16CECDE2C6D94EC6 /* RemoteStatusFingerprint.swift in Sources */,
+				FD4196C9F558CE954D94E060 /* RemoteTerminalScript.swift in Sources */,
 				F2983AF4C5674B906BEF2E88 /* RemoteWorktreePoll.swift in Sources */,
 				8C492CBACC6D6DACE56DADA9 /* RemoteWorktreeSummaryBuilder.swift in Sources */,
+				1F860C66D658B0DA5A0599F6 /* RemoteZmxInstaller.swift in Sources */,
 				A7340B3C1C6B2BC7189F3695 /* RepoDot.swift in Sources */,
 				2C9C311A6DFC9DC5954F5CC2 /* RepoGroupView.swift in Sources */,
 				A2B0E4C1D80EB12F7BECE7FC /* RepoSelectorDialog.swift in Sources */,
@@ -5792,9 +5809,12 @@
 				A962107126052DEF597CB7FA /* RemoteServerIntegrationTests.swift in Sources */,
 				0B6ADBF320E6130E5888CAA7 /* RemoteSessionGatewayTests.swift in Sources */,
 				8723FD954481CDFA5B2916DF /* RemoteStatusFingerprintTests.swift in Sources */,
+				0C7A044AC34BF225A4149556 /* RemoteTerminalLaunchTests.swift in Sources */,
+				78D49DF401553D2A9BCE1EE5 /* RemoteTerminalScriptTests.swift in Sources */,
 				0C0C65E3012A722B10816F8D /* RemoteWebAssetTests.swift in Sources */,
 				CA7269D9237C925D7C1358D7 /* RemoteWorktreePollTests.swift in Sources */,
 				9666162EC5BE3445EEBCDEA1 /* RemoteWorktreeSummaryBuilderTests.swift in Sources */,
+				FCC6BC72DF062AA572F5535F /* RemoteZmxInstallerTests.swift in Sources */,
 				133597E7D43CFE746EF4EF2B /* RepoGroupViewLayoutTests.swift in Sources */,
 				737EC7C9A35C9ED61ED67B83 /* RepoSelectorModelTests.swift in Sources */,
 				35705563BBEDDC1D0092C1F5 /* RepoSelectorRecentsTests.swift in Sources */,

--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -9,6 +9,7 @@
 /* Begin PBXBuildFile section */
 		004A8BA5B9353F67AAA3AE83 /* NotificationService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2975A1465CA308E9766521F2 /* NotificationService.swift */; };
 		00D95534280A5CED2356D06D /* AlasCLIWorktreeResolver.swift in Sources */ = {isa = PBXBuildFile; fileRef = 457858DB2CF0B558A1A490BC /* AlasCLIWorktreeResolver.swift */; };
+		00ED86F7E72AFBF6C8DD69C7 /* GitInvocationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03A4B0CD519C39CCB197CBD4 /* GitInvocationTests.swift */; };
 		01568CB821D2E938C51BBCAB /* ACPHarnessBridgeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A5A3E6B2F9AC2CBB1CDA78E /* ACPHarnessBridgeTests.swift */; };
 		01C919A6F3868980D51539DD /* ACPInitializeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9DF8B5E766D2B3649D2555ED /* ACPInitializeTests.swift */; };
 		01CBEF6793755D3D9B000BC1 /* CodeLanguageDetailViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E91A6AFCC9B3AEFB43D8946F /* CodeLanguageDetailViewTests.swift */; };
@@ -41,6 +42,7 @@
 		07BB2B329992BA535053BB80 /* ACPSetupNudgeBannerModeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0AB6FA9F258818E8B464CB0A /* ACPSetupNudgeBannerModeTests.swift */; };
 		082582F4BBA9DCFF0EAB9588 /* OperationCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4941BFBEEEAF9DE9E1752548 /* OperationCard.swift */; };
 		08681BEDBD6D7232CC937704 /* HoverFeatureBehaviorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 65E853C6AAB6450A0845A7CD /* HoverFeatureBehaviorTests.swift */; };
+		086C7DE57FBE661C6E3C718F /* GitInvocation.swift in Sources */ = {isa = PBXBuildFile; fileRef = F83370751580C42D5DE93F80 /* GitInvocation.swift */; };
 		0871949C8A9030B15FA56FFF /* JSONRPCNewlineFramer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 06375E561569DA36EC289C6F /* JSONRPCNewlineFramer.swift */; };
 		0890C803E92308809BE12930 /* MergeWordDiff.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7DD6C7F7A898CE1A030F28C3 /* MergeWordDiff.swift */; };
 		08DBBE562CC62A888617AC09 /* SidebarHeaderViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 25DBE942154BD154F2D10B9D /* SidebarHeaderViewTests.swift */; };
@@ -168,6 +170,7 @@
 		25311FAD068B5590F459CED9 /* ACPChatLayout.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6D8E02BB3FEB3C71AEEBBE6F /* ACPChatLayout.swift */; };
 		25347EFEF1B5F7F4915DB120 /* DebounceTimerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 179A74F3A825DA1EC4C4E0FC /* DebounceTimerTests.swift */; };
 		255E9EAE89D521E08EB90918 /* JSONHookSettingsFile.swift in Sources */ = {isa = PBXBuildFile; fileRef = 137F79BD0DEB96B6F756ABD4 /* JSONHookSettingsFile.swift */; };
+		257D3CF69FE6A97D058FF959 /* RemoteRepoValidator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2DDE190423707662BDC8E6EA /* RemoteRepoValidator.swift */; };
 		2584552219DE6987E1E6AF36 /* AgentRunError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3BF2F213480B30034B25B2B8 /* AgentRunError.swift */; };
 		25B497084FDEA8605FF8C5CA /* EditorFindController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 55DE02E1672044B68F9DE0B1 /* EditorFindController.swift */; };
 		25B94D8823F2A5A2BA4545B5 /* AppStatePersistenceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8C11E3449E4A7B4E69E83C1C /* AppStatePersistenceTests.swift */; };
@@ -243,6 +246,7 @@
 		35A0942B075D267EBB9A4484 /* RightPaneStateFileTreeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A85E1D1600F487D359F363F /* RightPaneStateFileTreeTests.swift */; };
 		363F31C705CF7D17162E2CF6 /* CommitTabStateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A2FC38CF24F011448A3705F9 /* CommitTabStateTests.swift */; };
 		370EA3E196540ACC6174D5CC /* GitLabCLIProviderVerdictTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6D95FBEE2C9BF1AD1A602C28 /* GitLabCLIProviderVerdictTests.swift */; };
+		3739AAA93F150060DDAADACA /* SSHCommand.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8351793355009D8A73AA91A2 /* SSHCommand.swift */; };
 		376A08C73011C5CA9E445C4B /* ImageDiffView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9D7D83CD76ABF9FED3B29F62 /* ImageDiffView.swift */; };
 		37DD3F3B818131973DAA2B9B /* ACPMessageList.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F79A184C86BE6C6BF72EB57 /* ACPMessageList.swift */; };
 		387EF12B6875648E422956F7 /* Highlighted.swift in Sources */ = {isa = PBXBuildFile; fileRef = 66E8A2A1A02BD06F4B782D03 /* Highlighted.swift */; };
@@ -275,6 +279,7 @@
 		3CD81DD1B1FF8C1EA849237C /* TerminalSession.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9C45A26ADB0D1CCFBB5BEAE8 /* TerminalSession.swift */; };
 		3CFC291E5868CCD147D573E7 /* ACPAdapterUpdateBannerDeciderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F9B399B5355B20890D8E42C /* ACPAdapterUpdateBannerDeciderTests.swift */; };
 		3D32D8FA2A63B3C2080B9E3A /* DiffReviewRail.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4BECCB29ED6324C55C541D54 /* DiffReviewRail.swift */; };
+		3D561C5EDA7AAB4831CA58CF /* RemoteProjectCollisionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 442D62D5E8B59845EB9494D3 /* RemoteProjectCollisionTests.swift */; };
 		3D5FC516052D2F06781A3F6E /* SearchModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6C4309EDC99FC1F98C479115 /* SearchModelTests.swift */; };
 		3D711A767050DB05E4C77548 /* SurfaceViewKeyboardTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF5143046167375A802ED378 /* SurfaceViewKeyboardTests.swift */; };
 		3D98C4F5EE2C0B1203C76752 /* ACPImageChipAttachment.swift in Sources */ = {isa = PBXBuildFile; fileRef = A7FB37A9430467B477E40819 /* ACPImageChipAttachment.swift */; };
@@ -559,6 +564,7 @@
 		7D087329E7B873B1E7A1CE89 /* CommitMessageEditorViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 95DA6BFFE45ED25669869C76 /* CommitMessageEditorViewTests.swift */; };
 		7D0897F6872ABAC08F09281E /* SpacesPane.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57B7225443DF69C32D25338D /* SpacesPane.swift */; };
 		7D75AEB67376431930CB37E3 /* GitEventFilter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4575017544CD7603B3AB9069 /* GitEventFilter.swift */; };
+		7DAAFE51C9C35BADB78B4A30 /* SSHIntegrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1C63CBD839A151565AE577AE /* SSHIntegrationTests.swift */; };
 		7DEFB0A61614D65F509A11AE /* ImageDiffDifferenceView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4246F7A17DCEC4D2A669BC43 /* ImageDiffDifferenceView.swift */; };
 		7DFE8DCEA8A4BABF51F54215 /* GitTypes.swift in Sources */ = {isa = PBXBuildFile; fileRef = 27A92711BC1D9A78D8A80561 /* GitTypes.swift */; };
 		7E56D356C235F59E1CE24210 /* AgentBuiltinsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4AED8A6EE8EF0CC317D7A4C7 /* AgentBuiltinsTests.swift */; };
@@ -750,6 +756,7 @@
 		A3EE2DE5C01EB87DE7BCC801 /* ACPStdioClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4D20C843AB88A6EB14D2A1BD /* ACPStdioClient.swift */; };
 		A3F27DE52BAC71EFFA69938A /* ACPTranscriptWindowTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7DCF803DF778CF9C06AC1579 /* ACPTranscriptWindowTests.swift */; };
 		A4476A509577896F9DADE5CB /* ACPSessionVisibleQueueTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EAA78FF7BA562DC4423AC35D /* ACPSessionVisibleQueueTests.swift */; };
+		A45A26B8B43E49BC8F952CD6 /* RemoteHostRegistryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1854EA4072F4F45DA70854D0 /* RemoteHostRegistryTests.swift */; };
 		A4AB930CA0EEA2CEF0302646 /* ImageCheckerboardBackground.swift in Sources */ = {isa = PBXBuildFile; fileRef = 206F1DBCB1C34D71BEBB7DE4 /* ImageCheckerboardBackground.swift */; };
 		A5742BE7348C02324B8119D0 /* BaseBranchSelectorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6CB9643BE01E416D3D2F4454 /* BaseBranchSelectorTests.swift */; };
 		A58568C1EFF4A274FBDC83A4 /* Theme.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6CA3930F30444A51FB2393D /* Theme.swift */; };
@@ -773,6 +780,7 @@
 		A9D16AD457FE772237B7A710 /* ReviewChangesLoaderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC958412AAB6B8788171F74A /* ReviewChangesLoaderTests.swift */; };
 		AA19B3B2B1CE418BFD6FD134 /* ACPElicitationCoordinatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D906A11E19D165C7F5447E67 /* ACPElicitationCoordinatorTests.swift */; };
 		AA3024661C46385700D8B3A6 /* TitlelessWindow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3428750EA8626EEBF3FE928B /* TitlelessWindow.swift */; };
+		AA6F188E5E31B83D45380279 /* SSHCommandTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 90A3C6694C4027DE1A26EC59 /* SSHCommandTests.swift */; };
 		AA8FEF94B861001AB643E005 /* FontFamilyPicker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 12F5FD1C6AEC80509D52C724 /* FontFamilyPicker.swift */; };
 		AB4B19ECC0C3D7242ECD42C6 /* DiffReviewInlineFeedbackActions.swift in Sources */ = {isa = PBXBuildFile; fileRef = E8B46B2287CA16E683490301 /* DiffReviewInlineFeedbackActions.swift */; };
 		AB81A1DA27A87F7C7E49D9CF /* ACPPlanChecklist.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF02DDF9183C6C8D28EC68C0 /* ACPPlanChecklist.swift */; };
@@ -808,6 +816,7 @@
 		B08F7ECC5E2612CC503E1BE0 /* MergeConflictTextStorage.swift in Sources */ = {isa = PBXBuildFile; fileRef = EBBFE202A6AB6F0EFB46EB5D /* MergeConflictTextStorage.swift */; };
 		B092D71B3D727B89EAF5D753 /* SymbolsFeatureTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E15A32659EEBFA80F816CE31 /* SymbolsFeatureTests.swift */; };
 		B0AECC4F3D22B2C863752CF8 /* ACPAdapterUpdateBannerDecider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3111744632DAC342A40DB62A /* ACPAdapterUpdateBannerDecider.swift */; };
+		B1065D7EB6719FE2C0F82B6B /* ProjectConfigHostTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 71A90560CED6562BBC313F3C /* ProjectConfigHostTests.swift */; };
 		B13673C3423177C3431D758D /* JSONRPCFramer.swift in Sources */ = {isa = PBXBuildFile; fileRef = E00A5AB85B99550DFDB99F46 /* JSONRPCFramer.swift */; };
 		B13C57CF7090C966143A6840 /* ReviewChangesScrollSpyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F2C9F8BAEDB1D157E321A328 /* ReviewChangesScrollSpyTests.swift */; };
 		B140AFAD75EC181870BDC0D1 /* ACPAdapterUpdateStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7DED8CE500F7170B1C0857FE /* ACPAdapterUpdateStore.swift */; };
@@ -1123,6 +1132,7 @@
 		F3C9321ABD5230C4FA4F7D4E /* GatekeeperRemediatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9FE7571B9A83F6BFFA6BFC6 /* GatekeeperRemediatorTests.swift */; };
 		F3E7DF34D9DDA268E40575AE /* CommitInfoTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9427B922BAFA43AF6EB21080 /* CommitInfoTests.swift */; };
 		F3EB289C9DA8B25FC26DAB58 /* MasonSnapshot.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7F42E564C149FA33CF0E9870 /* MasonSnapshot.swift */; };
+		F47287FCE8C870F02F2A55E0 /* RemoteHostRegistry.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8DF79BBCD948528D655A9A81 /* RemoteHostRegistry.swift */; };
 		F4796D2FCBA83BD5E71F4398 /* DiffPaneLSPTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AD920E9E496F1DC3BB894B8B /* DiffPaneLSPTests.swift */; };
 		F4B9A51A40365909B7644561 /* ShortcutsPane.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6821B71680094791995C4975 /* ShortcutsPane.swift */; };
 		F4FF07CA337DB0D0035C3C10 /* DiffPaneViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E5A257562FAB9C5932A6BD69 /* DiffPaneViewTests.swift */; };
@@ -1212,6 +1222,7 @@
 		0359D6646D12B66B70B5BB43 /* AiSplitButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AiSplitButton.swift; sourceTree = "<group>"; };
 		039741E1CCAEF9770D5DEE08 /* GitServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GitServiceTests.swift; sourceTree = "<group>"; };
 		039C5E652B7A9457EB13BD70 /* ReviewRequestContextBuilder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReviewRequestContextBuilder.swift; sourceTree = "<group>"; };
+		03A4B0CD519C39CCB197CBD4 /* GitInvocationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GitInvocationTests.swift; sourceTree = "<group>"; };
 		03D901BF4399752A3FC658F8 /* ACPSessionStoreQueueTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPSessionStoreQueueTests.swift; sourceTree = "<group>"; };
 		0452819DD42784CF60D466A4 /* AlasApplicationDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlasApplicationDelegate.swift; sourceTree = "<group>"; };
 		04B44F1DD775D2543439D508 /* ACPTranscriptMarkdown.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPTranscriptMarkdown.swift; sourceTree = "<group>"; };
@@ -1295,6 +1306,7 @@
 		17C2AC0F8B3A1B75239995AC /* AppState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppState.swift; sourceTree = "<group>"; };
 		17F7DB6F391F1AAA9FED1A86 /* ReviewLoopHandoffBuilder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReviewLoopHandoffBuilder.swift; sourceTree = "<group>"; };
 		1841997CCBDB9611576B930C /* AlasToggle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlasToggle.swift; sourceTree = "<group>"; };
+		1854EA4072F4F45DA70854D0 /* RemoteHostRegistryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteHostRegistryTests.swift; sourceTree = "<group>"; };
 		1874031C788ADB4398151FF1 /* StageChip.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StageChip.swift; sourceTree = "<group>"; };
 		18B5372BF572EBA3A84113E4 /* AgentLifecycleEventMapperTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentLifecycleEventMapperTests.swift; sourceTree = "<group>"; };
 		18CA47D5E0D1BF962CF45ABE /* AgentHookInstallNudgeBanner.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentHookInstallNudgeBanner.swift; sourceTree = "<group>"; };
@@ -1308,6 +1320,7 @@
 		1B0785F1FFC8008C74009584 /* session-update-available-models.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "session-update-available-models.json"; sourceTree = "<group>"; };
 		1B218326D14AA360C7476D43 /* GitServiceStashTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GitServiceStashTests.swift; sourceTree = "<group>"; };
 		1BB00E2F151520DC02B80BD4 /* GitServicePullTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GitServicePullTests.swift; sourceTree = "<group>"; };
+		1C63CBD839A151565AE577AE /* SSHIntegrationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SSHIntegrationTests.swift; sourceTree = "<group>"; };
 		1D3505FB870FA22C9C0FDB26 /* RightPaneStateSyncStatusTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RightPaneStateSyncStatusTests.swift; sourceTree = "<group>"; };
 		1D4A5200C6EBB6434DD6B8BD /* ShortcutReservationsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShortcutReservationsTests.swift; sourceTree = "<group>"; };
 		1DC1B975662D135B148443BC /* ACPSessionHydrationStateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPSessionHydrationStateTests.swift; sourceTree = "<group>"; };
@@ -1390,6 +1403,7 @@
 		2D911D138AF8A0E99191C862 /* ACPLaunchPathResolverTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPLaunchPathResolverTests.swift; sourceTree = "<group>"; };
 		2DCB7DA8B6EA8CF8B98EA267 /* ACPAuthFailure.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPAuthFailure.swift; sourceTree = "<group>"; };
 		2DD6714E62064D5438AAE139 /* MemoryDiagnosticsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MemoryDiagnosticsTests.swift; sourceTree = "<group>"; };
+		2DDE190423707662BDC8E6EA /* RemoteRepoValidator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteRepoValidator.swift; sourceTree = "<group>"; };
 		2E669FEBE09BC250B477B335 /* ACPLaunchCatalog.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPLaunchCatalog.swift; sourceTree = "<group>"; };
 		2E7E61C3BD4AD4AE3828A6F0 /* InstallSource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InstallSource.swift; sourceTree = "<group>"; };
 		2EB39DE3614B5BEC4D3EBF13 /* ACPSessionLifecycleTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPSessionLifecycleTests.swift; sourceTree = "<group>"; };
@@ -1505,6 +1519,7 @@
 		435D9E527A76820947F426A8 /* ACPFilesystem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPFilesystem.swift; sourceTree = "<group>"; };
 		436E8992D7373486BA25D290 /* CodeTextViewCompletionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CodeTextViewCompletionTests.swift; sourceTree = "<group>"; };
 		43DF691FC778F3A71CE20FBB /* StartupScriptInstallerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StartupScriptInstallerTests.swift; sourceTree = "<group>"; };
+		442D62D5E8B59845EB9494D3 /* RemoteProjectCollisionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteProjectCollisionTests.swift; sourceTree = "<group>"; };
 		4457B30E0C8A22BF06D0BC4B /* ACPPermissionScope.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPPermissionScope.swift; sourceTree = "<group>"; };
 		447D95D444F6AE08FCFA27A3 /* AppStateCleanupTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppStateCleanupTests.swift; sourceTree = "<group>"; };
 		44ACE3DEC81C465524111058 /* ACPQuestionPromptTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPQuestionPromptTests.swift; sourceTree = "<group>"; };
@@ -1708,6 +1723,7 @@
 		71196F28AFF66FFA70E008D6 /* WorktreePathTemplateRendererTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorktreePathTemplateRendererTests.swift; sourceTree = "<group>"; };
 		711F3E7BD099EDADEA0802FD /* NewWorktreeDialog.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NewWorktreeDialog.swift; sourceTree = "<group>"; };
 		71A2A074CEB9C9BA2AD34DD7 /* CenterSelectionStateResolverTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CenterSelectionStateResolverTests.swift; sourceTree = "<group>"; };
+		71A90560CED6562BBC313F3C /* ProjectConfigHostTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProjectConfigHostTests.swift; sourceTree = "<group>"; };
 		71BFAD7D324EEAE4DA5D402E /* TerminalTabStateCodableTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TerminalTabStateCodableTests.swift; sourceTree = "<group>"; };
 		71F9CE2A0C76E75E95A641AE /* DraftAmendPrefill.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DraftAmendPrefill.swift; sourceTree = "<group>"; };
 		7294C0B27241ADEB9A95347A /* ACPNewChatEmptyStateView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPNewChatEmptyStateView.swift; sourceTree = "<group>"; };
@@ -1777,6 +1793,7 @@
 		82387CFDFFBF52E639095C65 /* GitServiceBehindStatusTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GitServiceBehindStatusTests.swift; sourceTree = "<group>"; };
 		82E98F9835497D830C12AA8F /* CodeHostRemoteDetector.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CodeHostRemoteDetector.swift; sourceTree = "<group>"; };
 		82F696636690652C48CE87D9 /* AlasGhostty.Config.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlasGhostty.Config.swift; sourceTree = "<group>"; };
+		8351793355009D8A73AA91A2 /* SSHCommand.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SSHCommand.swift; sourceTree = "<group>"; };
 		835D847AD52A2CEB36DD5022 /* LegacyHookSweepTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LegacyHookSweepTests.swift; sourceTree = "<group>"; };
 		83A8622BA130E8FA339EDCEB /* TabsManagerReviewRequestDraftTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabsManagerReviewRequestDraftTests.swift; sourceTree = "<group>"; };
 		8451C5BCEE50F118F07CDD83 /* RightPaneStoreBaseBranchTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RightPaneStoreBaseBranchTests.swift; sourceTree = "<group>"; };
@@ -1813,6 +1830,7 @@
 		8D8A320D194DF0E64BF13BC5 /* ACPSessionHydratorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPSessionHydratorTests.swift; sourceTree = "<group>"; };
 		8DD66F449B380BC74B373647 /* Carbon.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Carbon.framework; path = System/Library/Frameworks/Carbon.framework; sourceTree = SDKROOT; };
 		8DEB85132B767DB3B253620C /* cool-slate.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "cool-slate.json"; sourceTree = "<group>"; };
+		8DF79BBCD948528D655A9A81 /* RemoteHostRegistry.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteHostRegistry.swift; sourceTree = "<group>"; };
 		8E3A9C194105E52A72293855 /* ProjectGitWatcherTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProjectGitWatcherTests.swift; sourceTree = "<group>"; };
 		8E8EB674A5221235F1C7594E /* SemanticVersion.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SemanticVersion.swift; sourceTree = "<group>"; };
 		8EC619ECA68DC50B9C56CC33 /* SidebarView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SidebarView.swift; sourceTree = "<group>"; };
@@ -1822,6 +1840,7 @@
 		906D92F7AD84F313508D9CFD /* ACPComposerShell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPComposerShell.swift; sourceTree = "<group>"; };
 		90762AFB51B237B783D4190C /* ACPChatLayoutTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPChatLayoutTests.swift; sourceTree = "<group>"; };
 		90817EC3BAA727EF6D9FBD97 /* GitService+Discard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "GitService+Discard.swift"; sourceTree = "<group>"; };
+		90A3C6694C4027DE1A26EC59 /* SSHCommandTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SSHCommandTests.swift; sourceTree = "<group>"; };
 		90D74C28EB7B8C3CBC53994D /* MergeAgent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MergeAgent.swift; sourceTree = "<group>"; };
 		90F0CBE40E2CF0251ABE72AE /* GitLFSBlobResolver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GitLFSBlobResolver.swift; sourceTree = "<group>"; };
 		910CB5077C8E89A778F1E896 /* ChangesTreeBuilder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChangesTreeBuilder.swift; sourceTree = "<group>"; };
@@ -2295,6 +2314,7 @@
 		F721FB733081A583D4053DDA /* FileTypeIconView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileTypeIconView.swift; sourceTree = "<group>"; };
 		F748F06725644571785BF658 /* PendingStashDrop.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PendingStashDrop.swift; sourceTree = "<group>"; };
 		F787781F8DE2077B7B679C07 /* RepoSelectorRowView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RepoSelectorRowView.swift; sourceTree = "<group>"; };
+		F83370751580C42D5DE93F80 /* GitInvocation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GitInvocation.swift; sourceTree = "<group>"; };
 		F8685E5E5AC7A77D6D27A847 /* CenterPaneView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CenterPaneView.swift; sourceTree = "<group>"; };
 		F8D36A8AF55F212B9F32A944 /* ACPSessionManagerAttachRestoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPSessionManagerAttachRestoreTests.swift; sourceTree = "<group>"; };
 		F936C036893FC70AD506FDD4 /* GitServiceDiscardTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GitServiceDiscardTests.swift; sourceTree = "<group>"; };
@@ -2690,6 +2710,7 @@
 				5210D5B1E2FD2EF68139506E /* ProcessGitTests.swift */,
 				72B788982A64A04D18889D25 /* ProjectAvatarPresetProviderTests.swift */,
 				E1FD24B10ED0B3D4280F15E8 /* ProjectConfigAgentOverrideTests.swift */,
+				71A90560CED6562BBC313F3C /* ProjectConfigHostTests.swift */,
 				5B3FF64CC698074BFDE2A36A /* ProjectConfigTests.swift */,
 				8E3A9C194105E52A72293855 /* ProjectGitWatcherTests.swift */,
 				270C700882ACFBBC59F931D2 /* ProjectIconImageStagingTests.swift */,
@@ -2804,6 +2825,7 @@
 				5DD135CB78273EA88FC491E7 /* Right */,
 				34382081666B7E8A95C0DA37 /* Settings */,
 				5FA3F5C4A99F2C74080DA0EF /* SQLiteKit */,
+				BB299962DBB46EEC6165F3D3 /* SSH */,
 				B637910FC726CC3C2C8983C1 /* Updates */,
 			);
 			path = AlasTests;
@@ -3048,6 +3070,7 @@
 				DA23E862C6C2D386B4C76E10 /* Shortcuts */,
 				697AACFEA2DCEBE4CEB2CD4E /* Sidebar */,
 				F4E7F552A9A004DB7193809A /* SQLiteKit */,
+				6C950D9947AAFA5DBD17CFF1 /* SSH */,
 				F556D34B5B6FE20EA80F892A /* Terminal */,
 				7592B5DE2FBCFC47DB6F481D /* Theme */,
 				35407CBFC8CDF3C3395FE123 /* UI */,
@@ -3488,6 +3511,17 @@
 				4A87288C819AD4B9E41D1858 /* UI */,
 			);
 			path = ACP;
+			sourceTree = "<group>";
+		};
+		6C950D9947AAFA5DBD17CFF1 /* SSH */ = {
+			isa = PBXGroup;
+			children = (
+				F83370751580C42D5DE93F80 /* GitInvocation.swift */,
+				8DF79BBCD948528D655A9A81 /* RemoteHostRegistry.swift */,
+				2DDE190423707662BDC8E6EA /* RemoteRepoValidator.swift */,
+				8351793355009D8A73AA91A2 /* SSHCommand.swift */,
+			);
+			path = SSH;
 			sourceTree = "<group>";
 		};
 		7592B5DE2FBCFC47DB6F481D /* Theme */ = {
@@ -3949,6 +3983,18 @@
 				FC4A215AF2876091E31F6F8A /* LineEnding.swift */,
 			);
 			path = Editor;
+			sourceTree = "<group>";
+		};
+		BB299962DBB46EEC6165F3D3 /* SSH */ = {
+			isa = PBXGroup;
+			children = (
+				03A4B0CD519C39CCB197CBD4 /* GitInvocationTests.swift */,
+				1854EA4072F4F45DA70854D0 /* RemoteHostRegistryTests.swift */,
+				442D62D5E8B59845EB9494D3 /* RemoteProjectCollisionTests.swift */,
+				90A3C6694C4027DE1A26EC59 /* SSHCommandTests.swift */,
+				1C63CBD839A151565AE577AE /* SSHIntegrationTests.swift */,
+			);
+			path = SSH;
 			sourceTree = "<group>";
 		};
 		BC977D789D4034668241C654 /* Install */ = {
@@ -4939,6 +4985,7 @@
 				7D75AEB67376431930CB37E3 /* GitEventFilter.swift in Sources */,
 				C1D83EEBE3AF4ABC04B3F7EB /* GitHubCLIProvider.swift in Sources */,
 				B66EE6A2445C0DDA607788C2 /* GitIgnoreService.swift in Sources */,
+				086C7DE57FBE661C6E3C718F /* GitInvocation.swift in Sources */,
 				79212B50265AAC9A392957C9 /* GitLFSBlobResolver.swift in Sources */,
 				EA2BAFA70ED22F6085EB1971 /* GitLabCLIProvider.swift in Sources */,
 				175951CE78A1446A9131BA1F /* GitNameValidator.swift in Sources */,
@@ -5097,10 +5144,12 @@
 				8C1E756AFF4125E7ED04E0B8 /* RemoteConnection.swift in Sources */,
 				B3B038297A419A0E8DF73440 /* RemoteDevice.swift in Sources */,
 				C9C01E8A89C6767524FAC63B /* RemoteHTTPResponder.swift in Sources */,
+				F47287FCE8C870F02F2A55E0 /* RemoteHostRegistry.swift in Sources */,
 				4F2BB7482C39B07F5E35E9D1 /* RemoteMessageWireJSON.swift in Sources */,
 				528CB7F6FF36C6809DE532B8 /* RemoteNetwork.swift in Sources */,
 				342C28B197D5048F78D2E8D6 /* RemotePairingService.swift in Sources */,
 				32674DB95F2B62C00FC0AAA2 /* RemoteProtocol.swift in Sources */,
+				257D3CF69FE6A97D058FF959 /* RemoteRepoValidator.swift in Sources */,
 				FB6FF6C91476DEE43E512E30 /* RemoteServer.swift in Sources */,
 				D9C26E07021DC6938013FBBE /* RemoteServerError.swift in Sources */,
 				C3E59948BD9108C1BD3243AD /* RemoteServerPane.swift in Sources */,
@@ -5156,6 +5205,7 @@
 				175D0A77579A022F3AB81E48 /* SQLiteDatabase.swift in Sources */,
 				102686FD795DE94337B3A030 /* SQLiteError.swift in Sources */,
 				C82A2082E6E61069068B8FAB /* SQLiteStatement.swift in Sources */,
+				3739AAA93F150060DDAADACA /* SSHCommand.swift in Sources */,
 				065F1A7FCF81FF29BAEF5A86 /* ScopeRow.swift in Sources */,
 				295EF629FAAA46FCD6802F4E /* ScrollEventCapturingView.swift in Sources */,
 				42C0AE388E5CF8B2AAEADE3C /* SearchEmptyState.swift in Sources */,
@@ -5517,6 +5567,7 @@
 				6AA812880B9E28C4AE9A6BFC /* GitHubCLIProviderTests.swift in Sources */,
 				32B3513F0BFC2F9B72763773 /* GitHubCLIProviderVerdictTests.swift in Sources */,
 				D27A1F6D7592D6A4BDD9FC4F /* GitIgnoreServiceTests.swift in Sources */,
+				00ED86F7E72AFBF6C8DD69C7 /* GitInvocationTests.swift in Sources */,
 				195102F7D680452476D70329 /* GitLabCLIProviderTests.swift in Sources */,
 				370EA3E196540ACC6174D5CC /* GitLabCLIProviderVerdictTests.swift in Sources */,
 				513BF637E5FF0BF3883FB1CC /* GitNameValidatorTests.swift in Sources */,
@@ -5610,6 +5661,7 @@
 				82544FFCF9960E0BA0FD2C7F /* ProcessMemoryProbeTests.swift in Sources */,
 				396AF154C56F4B5061756366 /* ProjectAvatarPresetProviderTests.swift in Sources */,
 				636ED129478744F9169AD774 /* ProjectConfigAgentOverrideTests.swift in Sources */,
+				B1065D7EB6719FE2C0F82B6B /* ProjectConfigHostTests.swift in Sources */,
 				D13AFC98364971915782491C /* ProjectConfigTests.swift in Sources */,
 				2A18F8265F467BF33AD69159 /* ProjectGitWatcherTests.swift in Sources */,
 				9627D6EAF83AA4B66FE09361 /* ProjectIconImageStagingTests.swift in Sources */,
@@ -5630,8 +5682,10 @@
 				C99FAC8BF1908B490E058FDA /* RemoteAccessPolicyTests.swift in Sources */,
 				6F0EA54CB15AB5507C84B4A7 /* RemoteAppStateAccessTests.swift in Sources */,
 				0F556F82FA5BF1E8D50096E2 /* RemoteConfigTests.swift in Sources */,
+				A45A26B8B43E49BC8F952CD6 /* RemoteHostRegistryTests.swift in Sources */,
 				FBEC59B1FD0C1DDDB6CE3100 /* RemoteNetworkTests.swift in Sources */,
 				E22E6141A5EF030F79CF8CBE /* RemotePairingServiceTests.swift in Sources */,
+				3D561C5EDA7AAB4831CA58CF /* RemoteProjectCollisionTests.swift in Sources */,
 				A7B9BDE0F2EB1D1769EC81B5 /* RemoteProtocolTests.swift in Sources */,
 				A962107126052DEF597CB7FA /* RemoteServerIntegrationTests.swift in Sources */,
 				0B6ADBF320E6130E5888CAA7 /* RemoteSessionGatewayTests.swift in Sources */,
@@ -5677,6 +5731,8 @@
 				4186372EBF16A9C7CB38F558 /* RightPaneStoreBaseBranchTests.swift in Sources */,
 				4EC689B454508C1ED77C5FB4 /* RightPaneVisibilityTests.swift in Sources */,
 				B05D6011E0FDB7AA1B016844 /* SQLiteDatabaseTests.swift in Sources */,
+				AA6F188E5E31B83D45380279 /* SSHCommandTests.swift in Sources */,
+				7DAAFE51C9C35BADB78B4A30 /* SSHIntegrationTests.swift in Sources */,
 				3D5FC516052D2F06781A3F6E /* SearchModelTests.swift in Sources */,
 				2FAAA60EF431D109D842428F /* SelfUpdaterTests.swift in Sources */,
 				2B4CBD06D1568EBC1BD327E0 /* SemanticVersionTests.swift in Sources */,

--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -11,6 +11,7 @@
 		00D95534280A5CED2356D06D /* AlasCLIWorktreeResolver.swift in Sources */ = {isa = PBXBuildFile; fileRef = 457858DB2CF0B558A1A490BC /* AlasCLIWorktreeResolver.swift */; };
 		00ED86F7E72AFBF6C8DD69C7 /* GitInvocationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03A4B0CD519C39CCB197CBD4 /* GitInvocationTests.swift */; };
 		01568CB821D2E938C51BBCAB /* ACPHarnessBridgeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A5A3E6B2F9AC2CBB1CDA78E /* ACPHarnessBridgeTests.swift */; };
+		018F0BE1174B9020C52007BE /* ACPRemoteFileServerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2BDAB5BEDF7FE5EBFBFE9A2 /* ACPRemoteFileServerTests.swift */; };
 		01C919A6F3868980D51539DD /* ACPInitializeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9DF8B5E766D2B3649D2555ED /* ACPInitializeTests.swift */; };
 		01CBEF6793755D3D9B000BC1 /* CodeLanguageDetailViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E91A6AFCC9B3AEFB43D8946F /* CodeLanguageDetailViewTests.swift */; };
 		01D2A32A3366C5CF6A225004 /* GhosttyConfigBuilderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3BE23A4881B60D7F16A4ACA5 /* GhosttyConfigBuilderTests.swift */; };
@@ -451,6 +452,7 @@
 		5D3E7C2D040B58D0C9D1C0E8 /* AlasButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = B4C486F9097A2B145D101E2C /* AlasButton.swift */; };
 		5D8DF496FC722EE24F69A60A /* AgentHookSocketServer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 976B145EAC17A395380DFB47 /* AgentHookSocketServer.swift */; };
 		5DF3F01E3DC672E4C6CBEDBC /* CommitEditorTabView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7268D601058775FE02B6B06 /* CommitEditorTabView.swift */; };
+		5E22B20F69866FAEDABA2812 /* ACPRemoteMCPFilterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 09140CEE45083CFDCE8D262B /* ACPRemoteMCPFilterTests.swift */; };
 		5E5600E6451068BCBF732ABD /* ACPChipStateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 239125BB939233233D405EB8 /* ACPChipStateTests.swift */; };
 		5E687CE659E83EF3B71CA86F /* PiInstaller.swift in Sources */ = {isa = PBXBuildFile; fileRef = 932EA49288A0444FB8BB9CE3 /* PiInstaller.swift */; };
 		5EA1AA5C8D9DE003BACE8291 /* AlasGhostty.Surface.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7E76CA315A7B08E09A80AA8 /* AlasGhostty.Surface.swift */; };
@@ -620,6 +622,7 @@
 		864B31874E286ED036347975 /* ACPLaunchSpecNpmPackageTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6BDB3231FFACC0398F973876 /* ACPLaunchSpecNpmPackageTests.swift */; };
 		86718F7E55531B8E4356D7D1 /* PaneTree.swift in Sources */ = {isa = PBXBuildFile; fileRef = A2943FBB1D6371EFAC9BBE68 /* PaneTree.swift */; };
 		86759BF3DE64FFAA4FE98822 /* ACPPromptCapabilitiesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C2D7EA3F2B69C0A8D2F8F8A5 /* ACPPromptCapabilitiesTests.swift */; };
+		86B6F59A54E8A3029C8A1656 /* ACPRemoteFileServer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 817DF0174BF04CF5DA288E99 /* ACPRemoteFileServer.swift */; };
 		8723FD954481CDFA5B2916DF /* RemoteStatusFingerprintTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DF0CB94DB8949712B0274413 /* RemoteStatusFingerprintTests.swift */; };
 		873535DE3342024BD7AA057E /* ShortcutReservations.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8942D0F47DBCFFB3549EE775 /* ShortcutReservations.swift */; };
 		8744A1DB40A1EC0D01D4C895 /* AlasGhostty.Config.swift in Sources */ = {isa = PBXBuildFile; fileRef = 82F696636690652C48CE87D9 /* AlasGhostty.Config.swift */; };
@@ -710,6 +713,7 @@
 		99711AA1B0FB450D32770415 /* ZmxSunPathBudget.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A40BDC5115B641AB26220D9 /* ZmxSunPathBudget.swift */; };
 		999C8421F3610FF682CE9D0E /* ReviewTabView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 500B60003934104E2CA5A895 /* ReviewTabView.swift */; };
 		99CD435501BBBAAD8C4214D8 /* ProjectMCPServerEditorPolicyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 178EAF6036A9BEAEA2C55082 /* ProjectMCPServerEditorPolicyTests.swift */; };
+		99FA2F1F9D41CA81E59B20E5 /* ACPRemoteLaunch.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5DC5AC55D5FF5BF7FECAD2F /* ACPRemoteLaunch.swift */; };
 		9A3EB3ACA3AB366431C904EB /* WorktreeService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6C4E238E48247A6CDD5565D2 /* WorktreeService.swift */; };
 		9AB33F6B645EBA3F92A4E40F /* ACPSessionUpdate.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD1F34E025D235A5CECCE36E /* ACPSessionUpdate.swift */; };
 		9AC7E08307DA010181E2DE58 /* ACPFirstRunConnectingPolicy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B4BB6C10F3718F7D0A50BAE /* ACPFirstRunConnectingPolicy.swift */; };
@@ -985,6 +989,7 @@
 		CF6CC4CD0C7841CA79DB0E4E /* ACPPlanPillState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CDDDC4C6146165CA4C7474E /* ACPPlanPillState.swift */; };
 		CF81F0AE28C56D1DF5AD871B /* SurfaceViewShortcutTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2935EB661338757C478CD86 /* SurfaceViewShortcutTests.swift */; };
 		D002012348D4DA7E124632BF /* SpacePagerIndicator.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9294E94F46763CC8DCD93A3 /* SpacePagerIndicator.swift */; };
+		D02BB257817B709817CAB2B6 /* ACPRemoteMCPFilter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CB5D1C8046EF9B6A95C41CD /* ACPRemoteMCPFilter.swift */; };
 		D05BDEF0D8651A9C2BD8C857 /* Seg.swift in Sources */ = {isa = PBXBuildFile; fileRef = 489C9B383554D7DAB170C2F8 /* Seg.swift */; };
 		D0F370E528AA4D07814AEB15 /* ACPMCPStatusPolicy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C051018EB105E225122750C /* ACPMCPStatusPolicy.swift */; };
 		D0F4A4F5BF5F1C3C625F11D9 /* Clipboard.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0E6600436B01C75D85C01FFA /* Clipboard.swift */; };
@@ -1147,6 +1152,7 @@
 		F269D59E1E21AD57EF3EE909 /* ACPQueueHeader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 10602801D3FA990E60CB072D /* ACPQueueHeader.swift */; };
 		F2983AF4C5674B906BEF2E88 /* RemoteWorktreePoll.swift in Sources */ = {isa = PBXBuildFile; fileRef = D837246E56472EBA3993F515 /* RemoteWorktreePoll.swift */; };
 		F2F75C44CD5042F209299FB9 /* InstallSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E7E61C3BD4AD4AE3828A6F0 /* InstallSource.swift */; };
+		F35B489DCC169F2B77DB6F3F /* ACPRemoteLaunchTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8CA0EE530F852A921942B04C /* ACPRemoteLaunchTests.swift */; };
 		F3C9321ABD5230C4FA4F7D4E /* GatekeeperRemediatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9FE7571B9A83F6BFFA6BFC6 /* GatekeeperRemediatorTests.swift */; };
 		F3E7DF34D9DDA268E40575AE /* CommitInfoTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9427B922BAFA43AF6EB21080 /* CommitInfoTests.swift */; };
 		F3EB289C9DA8B25FC26DAB58 /* MasonSnapshot.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7F42E564C149FA33CF0E9870 /* MasonSnapshot.swift */; };
@@ -1262,6 +1268,7 @@
 		08ACB3B79B74153668DA29D8 /* LSPTransportTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LSPTransportTests.swift; sourceTree = "<group>"; };
 		08F7B16F39935718801DAA95 /* AppStateCLIRoutingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppStateCLIRoutingTests.swift; sourceTree = "<group>"; };
 		09007B6E90DE89B7215A5D44 /* ImageDiffMode.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageDiffMode.swift; sourceTree = "<group>"; };
+		09140CEE45083CFDCE8D262B /* ACPRemoteMCPFilterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPRemoteMCPFilterTests.swift; sourceTree = "<group>"; };
 		0914F0E19514D1DF89C74B41 /* MergeConflictResolvedEmptyView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MergeConflictResolvedEmptyView.swift; sourceTree = "<group>"; };
 		09246CDA0F77D86F05727407 /* ShellEnvResolverTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShellEnvResolverTests.swift; sourceTree = "<group>"; };
 		0934F7BB22E33263B63925B7 /* ImageDiffPair.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageDiffPair.swift; sourceTree = "<group>"; };
@@ -1280,6 +1287,7 @@
 		0C5373F76231F229D3F96AF3 /* session-update-config-option.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "session-update-config-option.json"; sourceTree = "<group>"; };
 		0C70536C65F2A78F4935DCAD /* ACPTranscriptLatestPlanTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPTranscriptLatestPlanTests.swift; sourceTree = "<group>"; };
 		0C8541BE5617C7E212CCD034 /* FilesTabLoadingIndicatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FilesTabLoadingIndicatorTests.swift; sourceTree = "<group>"; };
+		0CB5D1C8046EF9B6A95C41CD /* ACPRemoteMCPFilter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPRemoteMCPFilter.swift; sourceTree = "<group>"; };
 		0CC074B85082A8BB30EEAFA5 /* UpdateAvailableSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UpdateAvailableSheet.swift; sourceTree = "<group>"; };
 		0D4901C499EFE969EC36D116 /* MarkdownPreviewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MarkdownPreviewController.swift; sourceTree = "<group>"; };
 		0D8D902B9FF4F44E5C2C7F03 /* MergeOperationStateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MergeOperationStateTests.swift; sourceTree = "<group>"; };
@@ -1819,6 +1827,7 @@
 		80BAFADCDC3E349AC3DBDDEA /* ACPPlanPillStateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPPlanPillStateTests.swift; sourceTree = "<group>"; };
 		8149AEEF45B05C60E06888E5 /* HoverWindowController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HoverWindowController.swift; sourceTree = "<group>"; };
 		81773A01826A91080F5A2E95 /* ACPCodeBlockHighlighterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPCodeBlockHighlighterTests.swift; sourceTree = "<group>"; };
+		817DF0174BF04CF5DA288E99 /* ACPRemoteFileServer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPRemoteFileServer.swift; sourceTree = "<group>"; };
 		81E981C10B13C43CE65DA74D /* ProjectMCPServer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProjectMCPServer.swift; sourceTree = "<group>"; };
 		822D37F962CC1C97981533A3 /* RepoSelectorModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RepoSelectorModel.swift; sourceTree = "<group>"; };
 		82387CFDFFBF52E639095C65 /* GitServiceBehindStatusTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GitServiceBehindStatusTests.swift; sourceTree = "<group>"; };
@@ -1857,6 +1866,7 @@
 		8C11E3449E4A7B4E69E83C1C /* AppStatePersistenceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppStatePersistenceTests.swift; sourceTree = "<group>"; };
 		8C245764E69F92CBB8D31BF6 /* GatekeeperRemediator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GatekeeperRemediator.swift; sourceTree = "<group>"; };
 		8C28D64372B5B4C734A92533 /* GitHubCLIProviderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GitHubCLIProviderTests.swift; sourceTree = "<group>"; };
+		8CA0EE530F852A921942B04C /* ACPRemoteLaunchTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPRemoteLaunchTests.swift; sourceTree = "<group>"; };
 		8CAB78A2ED0F4B736B089701 /* MergeConflictColumnView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MergeConflictColumnView.swift; sourceTree = "<group>"; };
 		8CFED7F76987C01213CB68A9 /* TabActivityPulse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabActivityPulse.swift; sourceTree = "<group>"; };
 		8D8A320D194DF0E64BF13BC5 /* ACPSessionHydratorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPSessionHydratorTests.swift; sourceTree = "<group>"; };
@@ -2025,6 +2035,7 @@
 		B58DD85A6E01972B39F2D8AD /* AgentPath.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentPath.swift; sourceTree = "<group>"; };
 		B5BEBDB5A6617C62D0F1C0D1 /* FormatOnSaveTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FormatOnSaveTests.swift; sourceTree = "<group>"; };
 		B5D2DA50E978EB0571D6A74C /* GitHubCLIProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GitHubCLIProvider.swift; sourceTree = "<group>"; };
+		B5DC5AC55D5FF5BF7FECAD2F /* ACPRemoteLaunch.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPRemoteLaunch.swift; sourceTree = "<group>"; };
 		B5E898E9F7E2680132FF54D4 /* ACPSelectChip.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPSelectChip.swift; sourceTree = "<group>"; };
 		B65018D176CD2E52A3999CF0 /* AlasTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = AlasTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		B6F6E707551671670D8CBA38 /* AgentLogoView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentLogoView.swift; sourceTree = "<group>"; };
@@ -2179,6 +2190,7 @@
 		D2A24F057893BB2179C1900C /* ACPSessionDiscoveryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPSessionDiscoveryTests.swift; sourceTree = "<group>"; };
 		D2AD81E0DFE33CE4DACF0ADF /* WorktreeWatcher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorktreeWatcher.swift; sourceTree = "<group>"; };
 		D2BD2F573498740A7DECCA3C /* ChangesPreparationModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChangesPreparationModelTests.swift; sourceTree = "<group>"; };
+		D2BDAB5BEDF7FE5EBFBFE9A2 /* ACPRemoteFileServerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPRemoteFileServerTests.swift; sourceTree = "<group>"; };
 		D2F90D03073708AA01531533 /* GitService+Staging.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "GitService+Staging.swift"; sourceTree = "<group>"; };
 		D36137279CD9028BB6FFED0B /* WorktreeServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorktreeServiceTests.swift; sourceTree = "<group>"; };
 		D36EA68CE127E24991ABD5A6 /* ReviewDraftCommentStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReviewDraftCommentStoreTests.swift; sourceTree = "<group>"; };
@@ -3556,6 +3568,9 @@
 		6C950D9947AAFA5DBD17CFF1 /* SSH */ = {
 			isa = PBXGroup;
 			children = (
+				817DF0174BF04CF5DA288E99 /* ACPRemoteFileServer.swift */,
+				B5DC5AC55D5FF5BF7FECAD2F /* ACPRemoteLaunch.swift */,
+				0CB5D1C8046EF9B6A95C41CD /* ACPRemoteMCPFilter.swift */,
 				F83370751580C42D5DE93F80 /* GitInvocation.swift */,
 				43C24D126BC74FF514F19E5D /* RemoteContentSearch.swift */,
 				6DF3C93B3FB8B2FDDD8E859D /* RemoteExec.swift */,
@@ -4037,6 +4052,9 @@
 		BB299962DBB46EEC6165F3D3 /* SSH */ = {
 			isa = PBXGroup;
 			children = (
+				D2BDAB5BEDF7FE5EBFBFE9A2 /* ACPRemoteFileServerTests.swift */,
+				8CA0EE530F852A921942B04C /* ACPRemoteLaunchTests.swift */,
+				09140CEE45083CFDCE8D262B /* ACPRemoteMCPFilterTests.swift */,
 				03A4B0CD519C39CCB197CBD4 /* GitInvocationTests.swift */,
 				BD8249F7BF5F86B0AFD5CAB8 /* RemoteContentSearchTests.swift */,
 				E8BAFC83D9BC1577CB14ADD5 /* RemoteExecTests.swift */,
@@ -4813,6 +4831,9 @@
 				F269D59E1E21AD57EF3EE909 /* ACPQueueHeader.swift in Sources */,
 				518F761277C4C5E4E6C512A3 /* ACPQueuedBubble.swift in Sources */,
 				C85FF0853DE69CE2EB59633E /* ACPRecoveryPill.swift in Sources */,
+				86B6F59A54E8A3029C8A1656 /* ACPRemoteFileServer.swift in Sources */,
+				99FA2F1F9D41CA81E59B20E5 /* ACPRemoteLaunch.swift in Sources */,
+				D02BB257817B709817CAB2B6 /* ACPRemoteMCPFilter.swift in Sources */,
 				502B274A6E7E801B76B8564A /* ACPScrollDirectionClassifier.swift in Sources */,
 				900A70EF9D41AEF3953CABBB /* ACPSelectChip.swift in Sources */,
 				8BF52AFF90954B767B9D7E65 /* ACPSession.swift in Sources */,
@@ -5432,6 +5453,9 @@
 				86759BF3DE64FFAA4FE98822 /* ACPPromptCapabilitiesTests.swift in Sources */,
 				1A56FAF2DE8FFB95272EE948 /* ACPQuestionPromptTests.swift in Sources */,
 				23F92214B30096D070419921 /* ACPQueuedBubbleActionMetricsTests.swift in Sources */,
+				018F0BE1174B9020C52007BE /* ACPRemoteFileServerTests.swift in Sources */,
+				F35B489DCC169F2B77DB6F3F /* ACPRemoteLaunchTests.swift in Sources */,
+				5E22B20F69866FAEDABA2812 /* ACPRemoteMCPFilterTests.swift in Sources */,
 				A383F1C9B0B00B2805576209 /* ACPScrollDirectionClassifierTests.swift in Sources */,
 				F57297D50FC237F7993F7B81 /* ACPSelectChipMetricsTests.swift in Sources */,
 				702EC5CB48F37FC8B6F27FA4 /* ACPSelectChipTests.swift in Sources */,

--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -229,6 +229,7 @@
 		316A645ECCB46A0F74915EA4 /* RemoteProjectGitWatcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7ECE27F4EE6CA578693BE83D /* RemoteProjectGitWatcher.swift */; };
 		316ABEA3944051EA41569FDC /* ACPContextRingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = ECD9419E685AD7EED286006B /* ACPContextRingTests.swift */; };
 		31CB9FBE16CECDE2C6D94EC6 /* RemoteStatusFingerprint.swift in Sources */ = {isa = PBXBuildFile; fileRef = 191BAF20EAD2D227D9E7B418 /* RemoteStatusFingerprint.swift */; };
+		32324CCE247B8B4784674453 /* RemoteContentSearchTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD8249F7BF5F86B0AFD5CAB8 /* RemoteContentSearchTests.swift */; };
 		32660CEE9955165AE3CCDFBE /* InstallerHostTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 364507D55CD5D73CD44819E7 /* InstallerHostTests.swift */; };
 		32674DB95F2B62C00FC0AAA2 /* RemoteProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = E4A54DD8080E3395C8E7049E /* RemoteProtocol.swift */; };
 		32727E2775753CDBF02D4660 /* TreeSitterDockerfile in Frameworks */ = {isa = PBXBuildFile; productRef = B0B462D196CBF339A0F9B651 /* TreeSitterDockerfile */; };
@@ -467,6 +468,7 @@
 		61D309EDA409B06C83D52CEE /* FilesTabCompactChainTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 408F9FF672160D96B1C22648 /* FilesTabCompactChainTests.swift */; };
 		61D33019E9AA23F5042C39B2 /* ACPSessionHydrator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 94D30693F45966ED1456811E /* ACPSessionHydrator.swift */; };
 		61E93449DD65CFD2643A9AC6 /* RemoteFileStatsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E3F09E1DA9C67475445F4B63 /* RemoteFileStatsTests.swift */; };
+		61FEA0F7DAF21FA0AFE88BAE /* RemoteFileAccessTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9A252BAD78A56343D68E782 /* RemoteFileAccessTests.swift */; };
 		62055BD147E504C658B93E20 /* ACPFirstRunConnectingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 737A9A3D11EA28582CA5D061 /* ACPFirstRunConnectingView.swift */; };
 		6256EAEB315812ED4F4E9107 /* StageChip.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1874031C788ADB4398151FF1 /* StageChip.swift */; };
 		6291072E82FC282625FD1617 /* GitServiceCommitEditingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F3AB3D6DF4A23648F0C45AC5 /* GitServiceCommitEditingTests.swift */; };
@@ -789,6 +791,7 @@
 		A9AD5B31C3A9FCBE76A15179 /* BlockedLanguageServerNudgeResolver.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5DD723B8C15EF2413C5D935D /* BlockedLanguageServerNudgeResolver.swift */; };
 		A9D0D8D94E1D46F35D17DDBA /* CodeEditorView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FC93F4FB957C2CCD4E1E2326 /* CodeEditorView.swift */; };
 		A9D16AD457FE772237B7A710 /* ReviewChangesLoaderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC958412AAB6B8788171F74A /* ReviewChangesLoaderTests.swift */; };
+		AA0E67AEE21718BF9BEC7F13 /* RemoteFileAccess.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0046CA3B9FF996E55A85D853 /* RemoteFileAccess.swift */; };
 		AA19B3B2B1CE418BFD6FD134 /* ACPElicitationCoordinatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D906A11E19D165C7F5447E67 /* ACPElicitationCoordinatorTests.swift */; };
 		AA3024661C46385700D8B3A6 /* TitlelessWindow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3428750EA8626EEBF3FE928B /* TitlelessWindow.swift */; };
 		AA6F188E5E31B83D45380279 /* SSHCommandTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 90A3C6694C4027DE1A26EC59 /* SSHCommandTests.swift */; };
@@ -911,6 +914,7 @@
 		C179C5202C4BB8D73E7EB701 /* AppIconTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 620C4A708CD1013DE2736A00 /* AppIconTests.swift */; };
 		C1D83EEBE3AF4ABC04B3F7EB /* GitHubCLIProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5D2DA50E978EB0571D6A74C /* GitHubCLIProvider.swift */; };
 		C1EBF68A32C7C1D61ECC89AC /* LSPClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = A35E05B1FB7CC5229ACCB065 /* LSPClient.swift */; };
+		C1F16BAC9C4B9A0457208816 /* RemoteContentSearch.swift in Sources */ = {isa = PBXBuildFile; fileRef = 43C24D126BC74FF514F19E5D /* RemoteContentSearch.swift */; };
 		C245B74D0083CE00B6CD392C /* ACPAdapterVersionChecker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 15630570F849AC577CA0D379 /* ACPAdapterVersionChecker.swift */; };
 		C245DDADA1D81810E9302134 /* VerdictSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2942AD875C0E7AB71E8E3CAD /* VerdictSheet.swift */; };
 		C2CE2E3DE88344FDDE67D66A /* LSPTransportTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08ACB3B79B74153668DA29D8 /* LSPTransportTests.swift */; };
@@ -1170,6 +1174,7 @@
 		F9FED997CCAD027FBBE36C1D /* PendingReview.swift in Sources */ = {isa = PBXBuildFile; fileRef = C5679CA959D40E1682A91F31 /* PendingReview.swift */; };
 		FA2FB05351C86883B303D538 /* EditorFindHighlightRenderer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 94255B602EB04BD063346B3E /* EditorFindHighlightRenderer.swift */; };
 		FAC5B044ADA2ECF467814CE4 /* ConflictsSection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 561094BA96058468F12002A1 /* ConflictsSection.swift */; };
+		FB000FBA6BA9ED49F65681AC /* RemoteFileSearchGateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7331F53100D12A0DDFD6B1D /* RemoteFileSearchGateTests.swift */; };
 		FB2AE30704F39C0BDA83F3CC /* ACPConfigOptionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9877AAC39AAB55596495B816 /* ACPConfigOptionTests.swift */; };
 		FB51C37DBD897B3A690DCDC3 /* ACPNewChatEmptyStateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0CE3F0637B3CA27B1D87080 /* ACPNewChatEmptyStateTests.swift */; };
 		FB5FD89FC2800E173FC31E7A /* ACPAuthFailure.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2DCB7DA8B6EA8CF8B98EA267 /* ACPAuthFailure.swift */; };
@@ -1211,6 +1216,7 @@
 		00057A43DD2D53F8F79FAC43 /* ShortcutActionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShortcutActionTests.swift; sourceTree = "<group>"; };
 		001E204C8DBD41063D806ECA /* HTTPRequestParserTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HTTPRequestParserTests.swift; sourceTree = "<group>"; };
 		002C8D5C52466955E0A90606 /* BaseBranchSelector.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BaseBranchSelector.swift; sourceTree = "<group>"; };
+		0046CA3B9FF996E55A85D853 /* RemoteFileAccess.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteFileAccess.swift; sourceTree = "<group>"; };
 		00809DCA566AAAADD7448659 /* ProjectPickerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProjectPickerTests.swift; sourceTree = "<group>"; };
 		008E982C8526670670425AB8 /* EmptyTabView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EmptyTabView.swift; sourceTree = "<group>"; };
 		00B894D92F014C2ADB3CCC9B /* TreeSitterPython */ = {isa = PBXFileReference; lastKnownFileType = folder; name = TreeSitterPython; path = ThirdParty/TreeSitterPython; sourceTree = SOURCE_ROOT; };
@@ -1537,6 +1543,7 @@
 		431BECA1461B76DF86BBFBDF /* FileTreeRowIndentationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileTreeRowIndentationTests.swift; sourceTree = "<group>"; };
 		435D9E527A76820947F426A8 /* ACPFilesystem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPFilesystem.swift; sourceTree = "<group>"; };
 		436E8992D7373486BA25D290 /* CodeTextViewCompletionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CodeTextViewCompletionTests.swift; sourceTree = "<group>"; };
+		43C24D126BC74FF514F19E5D /* RemoteContentSearch.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteContentSearch.swift; sourceTree = "<group>"; };
 		43DF691FC778F3A71CE20FBB /* StartupScriptInstallerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StartupScriptInstallerTests.swift; sourceTree = "<group>"; };
 		442D62D5E8B59845EB9494D3 /* RemoteProjectCollisionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteProjectCollisionTests.swift; sourceTree = "<group>"; };
 		4457B30E0C8A22BF06D0BC4B /* ACPPermissionScope.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPPermissionScope.swift; sourceTree = "<group>"; };
@@ -2042,6 +2049,7 @@
 		B9454F0214E21F91473C96F6 /* ACPComposerDraftBridgeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPComposerDraftBridgeTests.swift; sourceTree = "<group>"; };
 		B9749FB435319F01F9E70D08 /* GitServiceMergeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GitServiceMergeTests.swift; sourceTree = "<group>"; };
 		B9830BAAE86AA0A20A77731D /* ProcessMemoryProbeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProcessMemoryProbeTests.swift; sourceTree = "<group>"; };
+		B9A252BAD78A56343D68E782 /* RemoteFileAccessTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteFileAccessTests.swift; sourceTree = "<group>"; };
 		BA59378FB8733DBAC67592A3 /* RemotePairingServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemotePairingServiceTests.swift; sourceTree = "<group>"; };
 		BA6C7434D216D5C43A2FB921 /* ACPFileChip.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPFileChip.swift; sourceTree = "<group>"; };
 		BA9D3F3FFE39D7E29827D83D /* TabsManagerReviewSessionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabsManagerReviewSessionTests.swift; sourceTree = "<group>"; };
@@ -2057,6 +2065,7 @@
 		BD4A3B9B1103346242438940 /* FilesTabView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FilesTabView.swift; sourceTree = "<group>"; };
 		BD708EEB35D93A7E7150981D /* ProjectsManagerHeadUpdatesTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProjectsManagerHeadUpdatesTests.swift; sourceTree = "<group>"; };
 		BD77FB052C8B5A937B14A4AE /* ProjectConfig.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProjectConfig.swift; sourceTree = "<group>"; };
+		BD8249F7BF5F86B0AFD5CAB8 /* RemoteContentSearchTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteContentSearchTests.swift; sourceTree = "<group>"; };
 		BDABED76CD2A552B1781D3F4 /* EditorLSPStatusBadge.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditorLSPStatusBadge.swift; sourceTree = "<group>"; };
 		BDD799D0EC22F74A3DCB7F09 /* DeletingWorktreeView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeletingWorktreeView.swift; sourceTree = "<group>"; };
 		BDEA5E54A30636928F5D3B3E /* GitIgnoreService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GitIgnoreService.swift; sourceTree = "<group>"; };
@@ -2195,6 +2204,7 @@
 		D710BC995453481F445E2ECF /* ACPToolCallPresentation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPToolCallPresentation.swift; sourceTree = "<group>"; };
 		D7268D601058775FE02B6B06 /* CommitEditorTabView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommitEditorTabView.swift; sourceTree = "<group>"; };
 		D7322805CC904D460A8C53C8 /* ACPPlanSidebarVisibility.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPPlanSidebarVisibility.swift; sourceTree = "<group>"; };
+		D7331F53100D12A0DDFD6B1D /* RemoteFileSearchGateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteFileSearchGateTests.swift; sourceTree = "<group>"; };
 		D73C433B373577FD515FECD3 /* DiffReviewScrollSpy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiffReviewScrollSpy.swift; sourceTree = "<group>"; };
 		D76C02E43360C0BCFEDF5428 /* DiffOpenFileAvailability.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiffOpenFileAvailability.swift; sourceTree = "<group>"; };
 		D837246E56472EBA3993F515 /* RemoteWorktreePoll.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteWorktreePoll.swift; sourceTree = "<group>"; };
@@ -3547,7 +3557,9 @@
 			isa = PBXGroup;
 			children = (
 				F83370751580C42D5DE93F80 /* GitInvocation.swift */,
+				43C24D126BC74FF514F19E5D /* RemoteContentSearch.swift */,
 				6DF3C93B3FB8B2FDDD8E859D /* RemoteExec.swift */,
+				0046CA3B9FF996E55A85D853 /* RemoteFileAccess.swift */,
 				FBB8BF6C61840B9F972ABACC /* RemoteFileStats.swift */,
 				10B3615A1591964AB1C9E524 /* RemoteHostCapabilities.swift */,
 				8DF79BBCD948528D655A9A81 /* RemoteHostRegistry.swift */,
@@ -4026,7 +4038,10 @@
 			isa = PBXGroup;
 			children = (
 				03A4B0CD519C39CCB197CBD4 /* GitInvocationTests.swift */,
+				BD8249F7BF5F86B0AFD5CAB8 /* RemoteContentSearchTests.swift */,
 				E8BAFC83D9BC1577CB14ADD5 /* RemoteExecTests.swift */,
+				B9A252BAD78A56343D68E782 /* RemoteFileAccessTests.swift */,
+				D7331F53100D12A0DDFD6B1D /* RemoteFileSearchGateTests.swift */,
 				E3F09E1DA9C67475445F4B63 /* RemoteFileStatsTests.swift */,
 				843E7D6E8972C01B3DC924F2 /* RemoteHostCapabilitiesTests.swift */,
 				1854EA4072F4F45DA70854D0 /* RemoteHostRegistryTests.swift */,
@@ -5187,8 +5202,10 @@
 				D6F28C27DB02285A62C969A4 /* ReleaseInfo.swift in Sources */,
 				0FA612529F7E2BC05E577420 /* RemoteAccessPolicy.swift in Sources */,
 				8C1E756AFF4125E7ED04E0B8 /* RemoteConnection.swift in Sources */,
+				C1F16BAC9C4B9A0457208816 /* RemoteContentSearch.swift in Sources */,
 				B3B038297A419A0E8DF73440 /* RemoteDevice.swift in Sources */,
 				CE41DBC2472CA576CA52062C /* RemoteExec.swift in Sources */,
+				AA0E67AEE21718BF9BEC7F13 /* RemoteFileAccess.swift in Sources */,
 				30582A6DE1CFD0B9D5CB2E14 /* RemoteFileStats.swift in Sources */,
 				C9C01E8A89C6767524FAC63B /* RemoteHTTPResponder.swift in Sources */,
 				330D198F38767801994BF84C /* RemoteHostCapabilities.swift in Sources */,
@@ -5734,7 +5751,10 @@
 				C99FAC8BF1908B490E058FDA /* RemoteAccessPolicyTests.swift in Sources */,
 				6F0EA54CB15AB5507C84B4A7 /* RemoteAppStateAccessTests.swift in Sources */,
 				0F556F82FA5BF1E8D50096E2 /* RemoteConfigTests.swift in Sources */,
+				32324CCE247B8B4784674453 /* RemoteContentSearchTests.swift in Sources */,
 				472B73818FD74F0A4D40DA59 /* RemoteExecTests.swift in Sources */,
+				61FEA0F7DAF21FA0AFE88BAE /* RemoteFileAccessTests.swift in Sources */,
+				FB000FBA6BA9ED49F65681AC /* RemoteFileSearchGateTests.swift in Sources */,
 				61E93449DD65CFD2643A9AC6 /* RemoteFileStatsTests.swift in Sources */,
 				395A56C7C48EDDDE1F39F335 /* RemoteHostCapabilitiesTests.swift in Sources */,
 				A45A26B8B43E49BC8F952CD6 /* RemoteHostRegistryTests.swift in Sources */,

--- a/Alas/Sources/ACP/FileWriter/ACPFileWriter.swift
+++ b/Alas/Sources/ACP/FileWriter/ACPFileWriter.swift
@@ -20,7 +20,7 @@ struct ACPFileWriter {
         try FileManager.default.createDirectory(at: target.deletingLastPathComponent(),
                                                 withIntermediateDirectories: true)
         try content.write(to: target, atomically: true, encoding: .utf8)
-        return Self.makeResult(oldText: pre ?? "", newText: content, path: target.path)
+        return Self.makeResult(oldText: pre, newText: content, path: target.path)
     }
 
     /// Throws `outsideWorktree` if `path` resolves outside the
@@ -47,8 +47,8 @@ struct ACPFileWriter {
         return (setB.subtracting(setA).count, setA.subtracting(setB).count)
     }
 
-    static func makeResult(oldText: String, newText: String, path: String) -> Result {
-        let (added, removed) = diffLineCount(pre: oldText, post: newText)
+    static func makeResult(oldText: String?, newText: String, path: String) -> Result {
+        let (added, removed) = diffLineCount(pre: oldText ?? "", post: newText)
         return Result(added: added, removed: removed, path: path, oldText: oldText, newText: newText)
     }
 }

--- a/Alas/Sources/ACP/FileWriter/ACPFileWriter.swift
+++ b/Alas/Sources/ACP/FileWriter/ACPFileWriter.swift
@@ -20,9 +20,7 @@ struct ACPFileWriter {
         try FileManager.default.createDirectory(at: target.deletingLastPathComponent(),
                                                 withIntermediateDirectories: true)
         try content.write(to: target, atomically: true, encoding: .utf8)
-        let (added, removed) = Self.diffLineCount(pre: pre ?? "", post: content)
-        return Result(added: added, removed: removed, path: target.path,
-                      oldText: pre, newText: content)
+        return Self.makeResult(oldText: pre ?? "", newText: content, path: target.path)
     }
 
     /// Throws `outsideWorktree` if `path` resolves outside the
@@ -47,5 +45,10 @@ struct ACPFileWriter {
         let b = post.split(separator: "\n", omittingEmptySubsequences: false).map(String.init)
         let setA = Set(a), setB = Set(b)
         return (setB.subtracting(setA).count, setA.subtracting(setB).count)
+    }
+
+    static func makeResult(oldText: String, newText: String, path: String) -> Result {
+        let (added, removed) = diffLineCount(pre: oldText, post: newText)
+        return Result(added: added, removed: removed, path: path, oldText: oldText, newText: newText)
     }
 }

--- a/Alas/Sources/ACP/Session/ACPSession.swift
+++ b/Alas/Sources/ACP/Session/ACPSession.swift
@@ -72,6 +72,8 @@ final class ACPSession: ObservableObject, Identifiable {
     /// lifecycle), distinct from `StreamingState.idle` which means
     /// "runner is attached but not currently mid-prompt" (turn lifecycle).
     @Published var agentState: AgentState = .idle
+    /// Runtime-only state for bounded remote SSH reconnection attempts.
+    @Published var autoReconnecting: Bool = false
     /// Prompt content capabilities learned from ACP `initialize`.
     /// Runtime-only: re-learned on each attach, never persisted. Drives
     /// send-time hydration in `ACPSessionRunner.hydrate`.
@@ -235,6 +237,7 @@ final class ACPSession: ObservableObject, Identifiable {
         case checking
         case ready
         case needsSetup(reason: String)
+        case setupError(reason: String)
         case needsAuth(methods: [ACPInitializeResult.ACPAuthMethod], reason: String?)
     }
     struct PendingPermission: Identifiable, Equatable {

--- a/Alas/Sources/ACP/Session/ACPSessionManager.swift
+++ b/Alas/Sources/ACP/Session/ACPSessionManager.swift
@@ -51,6 +51,7 @@ final class ACPSessionManager: ObservableObject {
     private var draftFlushHandoffSequence: UInt64 = 0
     private(set) var runners: [ACPSession.ID: ACPSessionRunner] = [:]
     private var elicitationCoordinators: [ACPSession.ID: ACPElicitationCoordinator] = [:]
+    private var autoReconnectTasks: [ACPSession.ID: Task<Void, Never>] = [:]
     #if DEBUG
     /// Number of attached runners. Public-but-namespaced read accessor for
     /// `MemoryDiagnostics`; we don't expose the runner instances themselves.
@@ -723,6 +724,7 @@ final class ACPSessionManager: ObservableObject {
     }
 
     func closeSession(id: ACPSession.ID) {
+        autoReconnectTasks.removeValue(forKey: id)?.cancel()
         // Flush any pending draft write before dropping the in-memory
         // session reference — otherwise a tab-switch-while-typing
         // window can lose the last ~300ms of input.
@@ -741,6 +743,7 @@ final class ACPSessionManager: ObservableObject {
     }
 
     func deleteSession(id: ACPSession.ID) {
+        autoReconnectTasks.removeValue(forKey: id)?.cancel()
         cancelPendingDraftWrite(for: id)
         inFlightBackfills[id]?.cancel()
         inFlightBackfills[id] = nil
@@ -1253,7 +1256,7 @@ final class ACPSessionManager: ObservableObject {
         }
 
         let host = RemoteHostRegistry.shared.host(forPath: worktreePath)
-        let launchSpec = await resolvedLaunchSpec(for: spec)
+        let launchSpec = await resolvedLaunchSpec(for: spec, host: host)
         let connection = try connectionFactory(launchSpec, host, worktreePath)
         do {
             let initialized = try await connection.initialize()
@@ -1626,6 +1629,7 @@ extension ACPSessionManager {
             await runner.flushPersistence()
             await runner.connection.shutdown()
         }
+        autoReconnectTasks.removeValue(forKey: sessionId)?.cancel()
         elicitationCoordinators.removeValue(forKey: sessionId)?.stop()
         if let session = sessions[sessionId] {
             session.agentState = .idle
@@ -1954,7 +1958,7 @@ extension ACPSessionManager {
         }
         let setup = await evaluateSetup(for: spec)
         guard case .ready = setup else {
-            session.setupState = .needsSetup(reason: setup.reasonText)
+            session.setupState = setup.sessionSetupState
             session.agentState = .failed(setup.reasonText)
             await releaseWriterLease(sessionId: sessionId)
             return
@@ -1967,7 +1971,7 @@ extension ACPSessionManager {
         let connection: ACPConnection
         do {
             let host = RemoteHostRegistry.shared.host(forPath: worktreePath)
-            let launchSpec = await resolvedLaunchSpec(for: spec)
+            let launchSpec = await resolvedLaunchSpec(for: spec, host: host)
             connection = try connectionFactory(launchSpec, host, worktreePath)
         } catch {
             let msg = "Failed to launch agent: \(error.localizedDescription)"
@@ -2098,6 +2102,11 @@ extension ACPSessionManager {
                                           leaseFenceProvider: { [weak self] in
                                               self?.leaseFence(sessionId: sessionId)
                                           })
+            runner.onUnexpectedDisconnect = { [weak self] in
+                Task { @MainActor in
+                    self?.scheduleAutoReconnect(sessionId: sessionId)
+                }
+            }
             var runnerStarted = false
             func startRunnerIfNeeded() {
                 guard !runnerStarted else { return }
@@ -2341,6 +2350,45 @@ extension ACPSessionManager {
         }
     }
 
+    /// Remote SSH channel drops are commonly transient. Reuse the regular
+    /// reattach path so restoration and queued-prompt handling stay identical.
+    func scheduleAutoReconnect(sessionId: ACPSession.ID) {
+        guard sessions[sessionId] != nil,
+              RemoteHostRegistry.shared.host(forPath: worktreePath) != nil
+        else { return }
+
+        autoReconnectTasks.removeValue(forKey: sessionId)?.cancel()
+        autoReconnectTasks[sessionId] = Task { @MainActor [weak self] in
+            defer {
+                self?.autoReconnectTasks.removeValue(forKey: sessionId)
+                self?.sessions[sessionId]?.autoReconnecting = false
+            }
+            self?.sessions[sessionId]?.autoReconnecting = true
+            var attempt = 0
+            while let delay = ACPReconnectPolicy.delay(forAttempt: attempt), !Task.isCancelled {
+                attempt += 1
+                try? await Task.sleep(nanoseconds: UInt64(delay * 1_000_000_000))
+                guard let self, !Task.isCancelled,
+                      let session = self.sessions[sessionId]
+                else { return }
+                switch session.agentState {
+                case .ready:
+                    return
+                case .disconnected, .failed:
+                    break
+                case .idle, .spawning:
+                    continue
+                }
+                if let host = RemoteHostRegistry.shared.host(forPath: self.worktreePath),
+                   RemoteHostStatusStore.shared.isOffline(host) {
+                    continue
+                }
+                await self.reattach(to: sessionId)
+                if self.sessions[sessionId]?.agentState == .ready { return }
+            }
+        }
+    }
+
     func transcriptContextPrompt(for session: ACPSession, agentName: String?) -> String? {
         guard session.hasConversationTranscript else { return nil }
         let markdown = ACPTranscriptMarkdown.document(
@@ -2475,17 +2523,25 @@ extension ACPSessionManager {
     /// Swap `spec.command` for the verified absolute launch path when one can
     /// be resolved (npm-backed adapters); otherwise return `spec` unchanged so
     /// launch falls back to PATH-based `/usr/bin/env <command>`.
-    private func resolvedLaunchSpec(for spec: ACPLaunchSpec) async -> ACPLaunchSpec {
-        guard RemoteHostRegistry.shared.host(forPath: worktreePath) == nil else {
-            return spec
+    private func resolvedLaunchSpec(for spec: ACPLaunchSpec, host: String?) async -> ACPLaunchSpec {
+        if let host {
+            guard let command = ACPRemoteLaunch.launchPathProbeCommand(for: spec),
+                  let probe = try? await RemoteExec.run(host: host, cwd: nil, command: command),
+                  probe.exitCode == 0
+            else {
+                return spec
+            }
+            let path = probe.stdout.trimmingCharacters(in: .whitespacesAndNewlines)
+            return path.isEmpty ? spec : spec.overridingCommand(path)
+        } else {
+            let env = ProcessInfo.processInfo.environment
+            let resolver = ACPLaunchPathResolver(
+                env: env,
+                additionalPathDirectories: AgentPath.wellKnownDirectories,
+                npmGlobalBinDirectory: ACPLaunchPathResolver.defaultNpmGlobalBinDirectory(env: env))
+            guard let path = await resolver.resolvedLaunchPath(for: spec) else { return spec }
+            return spec.overridingCommand(path)
         }
-        let env = ProcessInfo.processInfo.environment
-        let resolver = ACPLaunchPathResolver(
-            env: env,
-            additionalPathDirectories: AgentPath.wellKnownDirectories,
-            npmGlobalBinDirectory: ACPLaunchPathResolver.defaultNpmGlobalBinDirectory(env: env))
-        guard let path = await resolver.resolvedLaunchPath(for: spec) else { return spec }
-        return spec.overridingCommand(path)
     }
 
     private func evaluateSetup(for spec: ACPLaunchSpec) async -> ACPSetupResult {
@@ -2497,10 +2553,10 @@ extension ACPSessionManager {
             let probe = try await RemoteExec.run(
                 host: host,
                 cwd: nil,
-                command: ACPRemoteLaunch.setupProbeCommand(command: spec.command)
+                command: ACPRemoteLaunch.setupProbeCommand(check: spec.setupCheck)
             )
             guard probe.exitCode == 0 else {
-                return .missing(reason: "\(spec.command) not found on \(host)")
+                return .error(message: "Required agent setup for \(spec.agentID) is missing on \(host)")
             }
             return .ready
         } catch {
@@ -2579,6 +2635,14 @@ private extension ACPSetupResult {
         case .ready: return ""
         case .missing(let r): return r
         case .error(let m): return m
+        }
+    }
+
+    var sessionSetupState: ACPSession.SetupState {
+        switch self {
+        case .ready: return .ready
+        case .missing(let reason): return .needsSetup(reason: reason)
+        case .error(let message): return .setupError(reason: message)
         }
     }
 }

--- a/Alas/Sources/ACP/Session/ACPSessionManager.swift
+++ b/Alas/Sources/ACP/Session/ACPSessionManager.swift
@@ -17,7 +17,11 @@ private enum ACPMirrorRefreshPolicy {
 @MainActor
 final class ACPSessionManager: ObservableObject {
     typealias ACPSetupEvaluator = @MainActor (_ spec: ACPLaunchSpec) async -> ACPSetupResult
-    typealias ACPConnectionFactory = @MainActor (_ spec: ACPLaunchSpec) throws -> ACPConnection
+    typealias ACPConnectionFactory = @MainActor (
+        _ spec: ACPLaunchSpec,
+        _ host: String?,
+        _ worktreePath: String
+    ) throws -> ACPConnection
     typealias MCPProjectContextProvider = @MainActor () -> MCPProjectContext?
 
     let instanceId: String
@@ -291,9 +295,23 @@ final class ACPSessionManager: ObservableObject {
             let checker = ACPSetupChecker(env: ProcessInfo.processInfo.environment)
             return await checker.evaluate(spec.setupCheck)
         }
-        self.connectionFactory = connectionFactory ?? { spec in
+        self.connectionFactory = connectionFactory ?? { spec, host, worktreePath in
             let client: ACPStdioClient
-            if spec.command.hasPrefix("/") {
+            if let host {
+                let invocation = ACPRemoteLaunch.channelInvocation(
+                    host: host,
+                    worktreePath: worktreePath,
+                    command: spec.command,
+                    arguments: spec.arguments
+                )
+                // Keep ssh's parent environment intact for SSH_AUTH_SOCK,
+                // HOME, and any host-specific connection configuration.
+                client = try ACPStdioClient(
+                    executable: URL(fileURLWithPath: invocation.executable),
+                    arguments: invocation.args,
+                    environment: nil
+                )
+            } else if spec.command.hasPrefix("/") {
                 client = try ACPStdioClient(
                     executable: URL(fileURLWithPath: spec.command),
                     arguments: spec.arguments,
@@ -1229,12 +1247,14 @@ final class ACPSessionManager: ObservableObject {
         guard let spec = ACPLaunchCatalog.spec(for: agentId) else {
             throw ACPSessionDiscoveryError.noLaunchSpec(agentId)
         }
-        let setup = await setupEvaluator(spec)
+        let setup = await evaluateSetup(for: spec)
         guard case .ready = setup else {
             throw ACPSessionDiscoveryError.setupRequired(setup.reasonText)
         }
 
-        let connection = try connectionFactory(await resolvedLaunchSpec(for: spec))
+        let host = RemoteHostRegistry.shared.host(forPath: worktreePath)
+        let launchSpec = await resolvedLaunchSpec(for: spec)
+        let connection = try connectionFactory(launchSpec, host, worktreePath)
         do {
             let initialized = try await connection.initialize()
             guard initialized.sessionCapabilities.supportsList else {
@@ -1932,7 +1952,7 @@ extension ACPSessionManager {
             await releaseWriterLease(sessionId: sessionId)
             return
         }
-        let setup = await setupEvaluator(spec)
+        let setup = await evaluateSetup(for: spec)
         guard case .ready = setup else {
             session.setupState = .needsSetup(reason: setup.reasonText)
             session.agentState = .failed(setup.reasonText)
@@ -1946,7 +1966,9 @@ extension ACPSessionManager {
 
         let connection: ACPConnection
         do {
-            connection = try connectionFactory(await resolvedLaunchSpec(for: spec))
+            let host = RemoteHostRegistry.shared.host(forPath: worktreePath)
+            let launchSpec = await resolvedLaunchSpec(for: spec)
+            connection = try connectionFactory(launchSpec, host, worktreePath)
         } catch {
             let msg = "Failed to launch agent: \(error.localizedDescription)"
             session.lastError = msg
@@ -2000,6 +2022,16 @@ extension ACPSessionManager {
                 capabilities: initialized.mcpCapabilities
             ))
             session.mcpAttachmentSummary = .init(plan: mcpPlan)
+            let mcpSplit = RemoteHostRegistry.shared.host(forPath: worktreePath).map { _ in
+                ACPRemoteMCPFilter.split(mcpPlan.wireServers)
+            }
+            let wireMCPServers = mcpSplit?.kept ?? mcpPlan.wireServers
+            let remoteMCPNotice: String?
+            if let mcpSplit, !mcpSplit.droppedStdio.isEmpty {
+                remoteMCPNotice = "MCP servers unavailable on remote host: \(mcpSplit.droppedStdio.joined(separator: ", "))"
+            } else {
+                remoteMCPNotice = nil
+            }
             if let pendingAuthMethodId = session.pendingAuthMethodId {
                 do {
                     try await connection.authenticate(methodId: pendingAuthMethodId)
@@ -2085,7 +2117,7 @@ extension ACPSessionManager {
                 session.firstRunConnectingPhase = .creatingSession
             }
             if freshlyCreated {
-                result = try await connection.newSession(cwd: worktreePath, mcpServers: mcpPlan.wireServers)
+                result = try await connection.newSession(cwd: worktreePath, mcpServers: wireMCPServers)
             } else if let remoteId = session.remoteSessionId, !remoteId.isEmpty {
                 if session.hasConversationTranscript {
                     session.contextRecoveryStatus = .restoring
@@ -2094,7 +2126,7 @@ extension ACPSessionManager {
                 case .resume:
                     do {
                         result = try await connection.resumeSession(
-                            cwd: worktreePath, sessionId: remoteId, mcpServers: mcpPlan.wireServers)
+                            cwd: worktreePath, sessionId: remoteId, mcpServers: wireMCPServers)
                         if !pendingRecovery {
                             session.contextRecoveryStatus = nil
                         }
@@ -2108,7 +2140,7 @@ extension ACPSessionManager {
                         guard session.origin == .alasCreated,
                               ACPAuthFailure.message(from: error) == nil
                         else { throw error }
-                        result = try await connection.newSession(cwd: worktreePath, mcpServers: mcpPlan.wireServers)
+                        result = try await connection.newSession(cwd: worktreePath, mcpServers: wireMCPServers)
                         if session.hasConversationTranscript {
                             shouldHoldQueueForRecovery = true
                             if isWriter(for: sessionId) {
@@ -2128,7 +2160,7 @@ extension ACPSessionManager {
                 case .loadStrict:
                     do {
                         result = try await connection.loadSession(
-                            cwd: worktreePath, sessionId: remoteId, mcpServers: mcpPlan.wireServers)
+                            cwd: worktreePath, sessionId: remoteId, mcpServers: wireMCPServers)
                         runner.finishSuppressingLoadReplay(
                             throughYieldedUpdateCount: connection.client.yieldedUpdateCount
                         )
@@ -2144,7 +2176,7 @@ extension ACPSessionManager {
                 case .loadWithRecovery:
                     do {
                         result = try await connection.loadSession(
-                            cwd: worktreePath, sessionId: remoteId, mcpServers: mcpPlan.wireServers)
+                            cwd: worktreePath, sessionId: remoteId, mcpServers: wireMCPServers)
                         runner.finishSuppressingLoadReplay(
                             throughYieldedUpdateCount: connection.client.yieldedUpdateCount
                         )
@@ -2158,7 +2190,7 @@ extension ACPSessionManager {
                         if ACPAuthFailure.message(from: error) != nil {
                             throw error
                         }
-                        result = try await connection.newSession(cwd: worktreePath, mcpServers: mcpPlan.wireServers)
+                        result = try await connection.newSession(cwd: worktreePath, mcpServers: wireMCPServers)
                         if session.hasConversationTranscript {
                             shouldHoldQueueForRecovery = true
                             // Guard the store write: if another instance took over
@@ -2182,7 +2214,7 @@ extension ACPSessionManager {
                     throw ACPSessionAttachError.remoteSessionUnsupported
                 }
             } else {
-                result = try await connection.newSession(cwd: worktreePath, mcpServers: mcpPlan.wireServers)
+                result = try await connection.newSession(cwd: worktreePath, mcpServers: wireMCPServers)
                 if session.hasConversationTranscript {
                     shouldHoldQueueForRecovery = true
                     // Guard the store write: if another instance took over
@@ -2246,6 +2278,9 @@ extension ACPSessionManager {
             keepElicitationCoordinator = true
             attachSucceeded = true
             session.agentState = .ready
+            if let remoteMCPNotice {
+                runner.appendAndPersistSystemNotice(remoteMCPNotice)
+            }
             if shouldHoldQueueForRecovery {
                 sendTranscriptAsContext(sessionId: sessionId, agentName: nil)
             } else {
@@ -2441,6 +2476,9 @@ extension ACPSessionManager {
     /// be resolved (npm-backed adapters); otherwise return `spec` unchanged so
     /// launch falls back to PATH-based `/usr/bin/env <command>`.
     private func resolvedLaunchSpec(for spec: ACPLaunchSpec) async -> ACPLaunchSpec {
+        guard RemoteHostRegistry.shared.host(forPath: worktreePath) == nil else {
+            return spec
+        }
         let env = ProcessInfo.processInfo.environment
         let resolver = ACPLaunchPathResolver(
             env: env,
@@ -2448,6 +2486,26 @@ extension ACPSessionManager {
             npmGlobalBinDirectory: ACPLaunchPathResolver.defaultNpmGlobalBinDirectory(env: env))
         guard let path = await resolver.resolvedLaunchPath(for: spec) else { return spec }
         return spec.overridingCommand(path)
+    }
+
+    private func evaluateSetup(for spec: ACPLaunchSpec) async -> ACPSetupResult {
+        guard let host = RemoteHostRegistry.shared.host(forPath: worktreePath) else {
+            return await setupEvaluator(spec)
+        }
+
+        do {
+            let probe = try await RemoteExec.run(
+                host: host,
+                cwd: nil,
+                command: ACPRemoteLaunch.setupProbeCommand(command: spec.command)
+            )
+            guard probe.exitCode == 0 else {
+                return .missing(reason: "\(spec.command) not found on \(host)")
+            }
+            return .ready
+        } catch {
+            return .error(message: "Could not verify \(spec.command) on \(host): \(error.localizedDescription)")
+        }
     }
 
     private func handleAuthRequiredRunner(

--- a/Alas/Sources/ACP/Session/ACPSessionRunner.swift
+++ b/Alas/Sources/ACP/Session/ACPSessionRunner.swift
@@ -104,6 +104,7 @@ final class ACPSessionRunner {
     /// restored snapshot ahead of the steer's replacement prompt. Once
     /// the redirect is in flight, normal drain semantics resume.
     private var steerInProgress: Bool = false
+    var onUnexpectedDisconnect: (() -> Void)?
 
     /// How many trailing rows to retain in `lastPersistedPayloads`. Only the
     /// actively-streamed tail is ever re-persisted, so older rows can be
@@ -252,6 +253,7 @@ final class ACPSessionRunner {
                 // the next prompt would just fail. The queue stays put
                 // and drains naturally on the next successful reattach.
                 self.appendAndPersistSystemNotice("Agent disconnected.")
+                self.onUnexpectedDisconnect?()
             }
         }
 
@@ -271,7 +273,8 @@ final class ACPSessionRunner {
         // CLAUDECODE/CLAUDE_SESSION_ID markers (otherwise a Claude-
         // aware CLI run from the terminal refuses to start).
         session.terminalHost.updateContext(sessionCwd: worktreePath,
-                                           sessionEnv: agentEnv)
+                                           sessionEnv: agentEnv,
+                                           sessionRemoteHost: RemoteHostRegistry.shared.host(forPath: worktreePath))
 
         filesTask = Task { @MainActor [weak self] in
             guard let self else { return }
@@ -287,9 +290,9 @@ final class ACPSessionRunner {
                 case .read(let id, let params):
                     do {
                         if let remoteServer {
-                            let target = try remoteServer.resolveInsideWorktree(path: params.path)
+                            let target = try remoteServer.lexicallyResolveInsideWorktree(path: params.path)
                             let live = self.onLiveBufferRead?(target)
-                            let full = try await remoteServer.read(path: target, liveBuffer: live)
+                            let full = try await remoteServer.read(path: params.path, liveBuffer: live)
                             let body = try JSONEncoder().encode(ACPFsReadResult(content: Self.sliceLines(full, line: params.line, limit: params.limit)))
                             self.connection.client.respondToFileRequest(id: id, result: .success(body))
                             continue
@@ -379,8 +382,11 @@ final class ACPSessionRunner {
                     do {
                         let res: ACPFileWriter.Result
                         if let remoteServer {
-                            let target = try remoteServer.resolveInsideWorktree(path: params.path)
-                            res = try await remoteServer.write(path: target, content: params.content)
+                            res = try await remoteServer.write(path: params.path, content: params.content) {
+                                guard self.holdsLeaseForWrite() else {
+                                    throw ACPRemoteFileServer.ServerError.leaseLost
+                                }
+                            }
                         } else {
                             res = try writer.write(path: params.path, content: params.content)
                         }
@@ -408,6 +414,10 @@ final class ACPSessionRunner {
                         self.connection.client.respondToFileRequest(
                             id: id,
                             result: .failure(.init(code: -32001, message: "path outside worktree", data: nil)))
+                    } catch ACPRemoteFileServer.ServerError.leaseLost {
+                        self.connection.client.respondToFileRequest(
+                            id: id,
+                            result: .failure(.init(code: -32003, message: "lease lost to another instance", data: nil)))
                     } catch {
                         self.connection.client.respondToFileRequest(
                             id: id,

--- a/Alas/Sources/ACP/Session/ACPSessionRunner.swift
+++ b/Alas/Sources/ACP/Session/ACPSessionRunner.swift
@@ -278,11 +278,22 @@ final class ACPSessionRunner {
             let writer = ACPFileWriter(
                 worktreeRoot: URL(fileURLWithPath: self.worktreePath)
             )
+            let remoteServer = RemoteHostRegistry.shared.host(forPath: self.worktreePath).map {
+                ACPRemoteFileServer(host: $0, worktreeRoot: self.worktreePath)
+            }
             for await req in self.connection.client.fileRequests {
                 self.flushPendingIncomingUpdates()
                 switch req {
                 case .read(let id, let params):
                     do {
+                        if let remoteServer {
+                            let target = try remoteServer.resolveInsideWorktree(path: params.path)
+                            let live = self.onLiveBufferRead?(target)
+                            let full = try await remoteServer.read(path: target, liveBuffer: live)
+                            let body = try JSONEncoder().encode(ACPFsReadResult(content: Self.sliceLines(full, line: params.line, limit: params.limit)))
+                            self.connection.client.respondToFileRequest(id: id, result: .success(body))
+                            continue
+                        }
                         // Same containment check as the write path —
                         // without this an adapter could request any
                         // absolute path (e.g. `~/.ssh/config`) and
@@ -324,6 +335,12 @@ final class ACPSessionRunner {
                             id: id,
                             result: .failure(.init(code: -32001, message: "path outside worktree", data: nil))
                         )
+                    } catch ACPRemoteFileServer.ServerError.outsideWorktree(let p) {
+                        self.appendAndPersistSystemNotice("Blocked read outside worktree: \(p)")
+                        self.connection.client.respondToFileRequest(
+                            id: id,
+                            result: .failure(.init(code: -32001, message: "path outside worktree", data: nil))
+                        )
                     } catch {
                         self.connection.client.respondToFileRequest(
                             id: id,
@@ -360,7 +377,13 @@ final class ACPSessionRunner {
                         self.appendAndPersistSystemNotice("Agent wrote to \(URL(fileURLWithPath: params.path).lastPathComponent) — you have unsaved changes in this file.")
                     }
                     do {
-                        let res = try writer.write(path: params.path, content: params.content)
+                        let res: ACPFileWriter.Result
+                        if let remoteServer {
+                            let target = try remoteServer.resolveInsideWorktree(path: params.path)
+                            res = try await remoteServer.write(path: target, content: params.content)
+                        } else {
+                            res = try writer.write(path: params.path, content: params.content)
+                        }
                         // Persist the worktree-relative path so the
                         // "Open diff" button can pass it straight to
                         // `git.diff(file:)` (which keys by relative
@@ -376,6 +399,11 @@ final class ACPSessionRunner {
                         let body = Data("null".utf8)
                         self.connection.client.respondToFileRequest(id: id, result: .success(body))
                     } catch ACPFileWriter.Error.outsideWorktree(let p) {
+                        self.appendAndPersistSystemNotice("Blocked write outside worktree: \(p)")
+                        self.connection.client.respondToFileRequest(
+                            id: id,
+                            result: .failure(.init(code: -32001, message: "path outside worktree", data: nil)))
+                    } catch ACPRemoteFileServer.ServerError.outsideWorktree(let p) {
                         self.appendAndPersistSystemNotice("Blocked write outside worktree: \(p)")
                         self.connection.client.respondToFileRequest(
                             id: id,

--- a/Alas/Sources/ACP/Terminal/ACPTerminal.swift
+++ b/Alas/Sources/ACP/Terminal/ACPTerminal.swift
@@ -16,6 +16,7 @@ final class ACPTerminal: ObservableObject {
     let id: String
     let createdAt: Date
     let outputByteLimit: Int
+    private let normalizesCRLF: Bool
 
     @Published private(set) var cwd: String?
     @Published private(set) var buffer: Data = Data()
@@ -69,11 +70,13 @@ final class ACPTerminal: ObservableObject {
          args: [String],
          env: [String: String],
          cwd: String,
-         outputByteLimit: Int) throws
+         outputByteLimit: Int,
+         normalizesCRLF: Bool = false) throws
     {
         self.id = id
         self.createdAt = Date()
         self.cwd = cwd
+        self.normalizesCRLF = normalizesCRLF
         // Cap against the internal buffer so an agent can't ask us to
         // return more than we ever retain. Floor at 1 so callers that
         // pass 0 or negative don't trip divide-by-zero / nonsense math
@@ -135,6 +138,7 @@ final class ACPTerminal: ObservableObject {
         self.createdAt = Date()
         self.cwd = cwd
         self.outputByteLimit = max(1, min(outputByteLimit, Self.internalBufferCap))
+        self.normalizesCRLF = false
         self.process = nil
         self.pipe = nil
     }
@@ -494,7 +498,13 @@ final class ACPTerminal: ObservableObject {
         var stream = ANSIStream()
         let runs = stream.feed(slice)
         let text = runs.map(\.text).joined()
-        return (text, truncated || didTruncate)
+        return (normalizesCRLF ? Self.normalizeCRLF(text) : text, truncated || didTruncate)
+    }
+
+    /// Remote SSH terminals use a pty, which translates LF to CRLF. Preserve
+    /// lone carriage returns because they carry progress-bar redraw semantics.
+    nonisolated static func normalizeCRLF(_ text: String) -> String {
+        text.replacingOccurrences(of: "\r\n", with: "\n")
     }
 
     // MARK: - Helpers

--- a/Alas/Sources/ACP/Terminal/ACPTerminalHost.swift
+++ b/Alas/Sources/ACP/Terminal/ACPTerminalHost.swift
@@ -43,13 +43,14 @@ final class ACPTerminalHost: ObservableObject {
         let env = mergedEnv(p.env)
         let limit = p.outputByteLimit ?? 65_536
         do {
-            let term = try ACPTerminal(
-                id: id,
-                command: p.command,
-                args: p.args ?? [],
-                env: env,
-                cwd: cwd,
-                outputByteLimit: limit)
+            let term: ACPTerminal
+            if let host = RemoteHostRegistry.shared.host(forPath: cwd) {
+                let script = ACPRemoteLaunch.terminalCommand(command: p.command, args: p.args ?? [], env: agentRequestedEnv(p.env), cwd: cwd)
+                let ssh = SSHCommand(host: host, mode: .batch)
+                term = try ACPTerminal(id: id, command: SSHCommand.executable, args: ssh.argv(remoteScript: SSHCommand.remoteScript(command: script)), env: ProcessInfo.processInfo.environment, cwd: FileManager.default.temporaryDirectory.path, outputByteLimit: limit)
+            } else {
+                term = try ACPTerminal(id: id, command: p.command, args: p.args ?? [], env: env, cwd: cwd, outputByteLimit: limit)
+            }
             term.onExit = { [weak self] in
                 self?.pruneFinishedTerminals()
             }
@@ -139,6 +140,10 @@ final class ACPTerminalHost: ObservableObject {
         var out = sessionEnv
         for v in overlay ?? [] { out[v.name] = v.value }
         return out
+    }
+
+    private func agentRequestedEnv(_ env: [ACPEnvVar]?) -> [String: String] {
+        Dictionary(uniqueKeysWithValues: (env ?? []).map { ($0.name, $0.value) })
     }
 
     private func metadataTerminal(terminalId: String, cwd: String?) -> ACPTerminal {

--- a/Alas/Sources/ACP/Terminal/ACPTerminalHost.swift
+++ b/Alas/Sources/ACP/Terminal/ACPTerminalHost.swift
@@ -14,11 +14,13 @@ final class ACPTerminalHost: ObservableObject {
 
     private(set) var sessionCwd: String
     private(set) var sessionEnv: [String: String]
+    private(set) var sessionRemoteHost: String?
     @Published private(set) var terminals: [String: ACPTerminal] = [:]
 
-    init(sessionCwd: String, sessionEnv: [String: String]) {
+    init(sessionCwd: String, sessionEnv: [String: String], sessionRemoteHost: String? = nil) {
         self.sessionCwd = sessionCwd
         self.sessionEnv = sessionEnv
+        self.sessionRemoteHost = sessionRemoteHost
     }
 
     /// UI lookup: returns released terminals too, so a tool card can keep
@@ -44,10 +46,10 @@ final class ACPTerminalHost: ObservableObject {
         let limit = p.outputByteLimit ?? 65_536
         do {
             let term: ACPTerminal
-            if let host = RemoteHostRegistry.shared.host(forPath: cwd) {
+            if let host = executionHost(forResolvedCwd: cwd) {
                 let script = ACPRemoteLaunch.terminalCommand(command: p.command, args: p.args ?? [], env: agentRequestedEnv(p.env), cwd: cwd)
                 let ssh = SSHCommand(host: host, mode: .batch)
-                term = try ACPTerminal(id: id, command: SSHCommand.executable, args: ssh.argv(remoteScript: SSHCommand.remoteScript(command: script)), env: ProcessInfo.processInfo.environment, cwd: FileManager.default.temporaryDirectory.path, outputByteLimit: limit)
+                term = try ACPTerminal(id: id, command: SSHCommand.executable, args: ["-tt"] + ssh.argv(remoteScript: SSHCommand.remoteScript(command: script)), env: ProcessInfo.processInfo.environment, cwd: FileManager.default.temporaryDirectory.path, outputByteLimit: limit, normalizesCRLF: true)
             } else {
                 term = try ACPTerminal(id: id, command: p.command, args: p.args ?? [], env: env, cwd: cwd, outputByteLimit: limit)
             }
@@ -122,12 +124,17 @@ final class ACPTerminalHost: ObservableObject {
         terminals.values.reduce(0) { $0 &+ UInt64($1.buffer.count) }
     }
 
-    func updateContext(sessionCwd: String, sessionEnv: [String: String]) {
+    func updateContext(sessionCwd: String, sessionEnv: [String: String], sessionRemoteHost: String? = nil) {
         self.sessionCwd = sessionCwd
         self.sessionEnv = sessionEnv
+        self.sessionRemoteHost = sessionRemoteHost
     }
 
     // MARK: - Helpers
+
+    func executionHost(forResolvedCwd cwd: String) -> String? {
+        sessionRemoteHost ?? RemoteHostRegistry.shared.host(forPath: cwd)
+    }
 
     private func resolveCwd(_ requested: String?) -> String {
         guard let r = requested, !r.isEmpty else { return sessionCwd }
@@ -142,8 +149,12 @@ final class ACPTerminalHost: ObservableObject {
         return out
     }
 
-    private func agentRequestedEnv(_ env: [ACPEnvVar]?) -> [String: String] {
-        Dictionary(uniqueKeysWithValues: (env ?? []).map { ($0.name, $0.value) })
+    func agentRequestedEnv(_ env: [ACPEnvVar]?) -> [String: String] {
+        var out: [String: String] = [:]
+        for v in env ?? [] {
+            out[v.name] = v.value
+        }
+        return out
     }
 
     private func metadataTerminal(terminalId: String, cwd: String?) -> ACPTerminal {

--- a/Alas/Sources/ACP/UI/ACPFirstRunConnectingPolicy.swift
+++ b/Alas/Sources/ACP/UI/ACPFirstRunConnectingPolicy.swift
@@ -13,6 +13,7 @@ enum ACPFirstRunConnectingPolicy {
 
         if case .failed = session.hydrationState { return nil }
         if case .needsSetup = session.setupState { return nil }
+        if case .setupError = session.setupState { return nil }
         if case .needsAuth = session.setupState { return nil }
         if case .disconnected = session.agentState { return nil }
         if case .failed = session.agentState { return nil }

--- a/Alas/Sources/ACP/UI/ACPRecoveryPill.swift
+++ b/Alas/Sources/ACP/UI/ACPRecoveryPill.swift
@@ -9,7 +9,7 @@ struct ACPRecoveryPill: View {
     @Environment(\.theme) private var theme
 
     var body: some View {
-        if let label = label(for: session.agentState) {
+        if let label = label(for: session.agentState, autoReconnecting: session.autoReconnecting) {
             HStack(spacing: 6) {
                 statusDot(animating: isAnimating(session.agentState))
                 Text(label)
@@ -28,24 +28,27 @@ struct ACPRecoveryPill: View {
                 RoundedRectangle(cornerRadius: 11, style: .continuous)
                     .strokeBorder(theme.color("line"), lineWidth: 0.5)
             )
-            .help(helpText(for: session.agentState))
+            .help(helpText(for: session.agentState, autoReconnecting: session.autoReconnecting))
             .transition(.opacity)
         }
     }
 
-    private func label(for state: ACPSession.AgentState) -> String? {
+    private func label(for state: ACPSession.AgentState, autoReconnecting: Bool) -> String? {
         switch state {
         case .idle, .ready: return nil
         case .spawning: return "Reconnecting…"
-        case .disconnected: return "Disconnected"
+        case .disconnected: return autoReconnecting ? "Reconnecting…" : "Disconnected"
         case .failed: return "Failed"
         }
     }
 
-    private func helpText(for state: ACPSession.AgentState) -> String {
+    private func helpText(for state: ACPSession.AgentState, autoReconnecting: Bool) -> String {
         switch state {
         case .spawning: return "Bringing the agent process back up…"
-        case .disconnected: return "Agent process exited. Will reconnect on next send."
+        case .disconnected:
+            return autoReconnecting
+                ? "Connection lost. Retrying automatically; sending a message also reconnects."
+                : "Agent process exited. Will reconnect on next send."
         case .failed(let reason): return "Failed: \(reason)"
         default: return ""
         }

--- a/Alas/Sources/ACP/UI/ACPTabView.swift
+++ b/Alas/Sources/ACP/UI/ACPTabView.swift
@@ -228,6 +228,7 @@ private struct ACPSessionView: View {
         if session.hydrationState == .loading { return true }
         guard manager.runners[sessionId] == nil else { return false }
         if case .needsSetup = session.setupState { return false }
+        if case .setupError = session.setupState { return false }
         if case .needsAuth = session.setupState { return false }
         if session.lastError != nil { return false }
         if session.agentState == .disconnected { return false }
@@ -587,6 +588,12 @@ private struct ACPSessionView: View {
                 } else if case .needsSetup(let reason) = session.setupState {
                     setupReasonBanner(reason: reason)
                 }
+            case .none:
+                if case .setupError(let reason) = session.setupState {
+                    setupReasonBanner(reason: reason)
+                } else {
+                    EmptyView()
+                }
             case .showUpdate(let current, let latest):
                 if let installer = ACPInstallerRegistry.installer(for: session.agentId) {
                     ACPSetupNudgeBanner(
@@ -691,15 +698,17 @@ private struct ACPSessionView: View {
             session.lastError = "Failed to launch auth terminal: unsupported sign-in method."
             return
         }
-        do {
-            _ = try state.openACPAuthTerminalTab(for: worktree, command: command) {
-                Task { @MainActor in
-                    session.pendingAuthMethodId = method.id
-                    await reattachAndRefreshAdapterUpdateState()
+        Task { @MainActor in
+            do {
+                _ = try await state.openACPAuthTerminalTabPreparingRemoteZmxIfNeeded(for: worktree, command: command) {
+                    Task { @MainActor in
+                        session.pendingAuthMethodId = method.id
+                        await reattachAndRefreshAdapterUpdateState()
+                    }
                 }
+            } catch {
+                session.lastError = "Failed to launch auth terminal: \(error.localizedDescription)"
             }
-        } catch {
-            session.lastError = "Failed to launch auth terminal: \(error.localizedDescription)"
         }
     }
 

--- a/Alas/Sources/ACP/UI/ACPToolCallCard.swift
+++ b/Alas/Sources/ACP/UI/ACPToolCallCard.swift
@@ -273,12 +273,26 @@ private struct ACPToolCallAssetView: View {
         case .image:
             if asset.canLoadImage(trustedRoot: trustedImageRoot) {
                 cachedImageThumbnail
+            } else if let remoteImage = remoteImageLocation {
+                RemoteToolCallAssetImage(
+                    host: remoteImage.host,
+                    worktreeRoot: remoteImage.worktreeRoot,
+                    path: remoteImage.path,
+                    asset: asset
+                )
             } else {
                 compactRow(iconSystemName: "photo", title: asset.displayTitle, detail: asset.displayDetail)
             }
         case .resource:
             if asset.looksLikeImage, asset.canLoadImage(trustedRoot: trustedImageRoot) {
                 cachedImageThumbnail
+            } else if asset.looksLikeImage, let remoteImage = remoteImageLocation {
+                RemoteToolCallAssetImage(
+                    host: remoteImage.host,
+                    worktreeRoot: remoteImage.worktreeRoot,
+                    path: remoteImage.path,
+                    asset: asset
+                )
             } else {
                 compactRow(iconSystemName: "doc.text", title: asset.displayTitle, detail: asset.displayDetail)
             }
@@ -298,6 +312,18 @@ private struct ACPToolCallAssetView: View {
         } failure: {
             compactRow(iconSystemName: "photo", title: asset.displayTitle, detail: asset.displayDetail)
         }
+    }
+
+    private var remoteImageLocation: (host: String, worktreeRoot: String, path: String)? {
+        guard let trustedImageRoot, trustedImageRoot.isRemoteAlasPath,
+              let host = RemoteHostRegistry.shared.host(forPath: trustedImageRoot.path),
+              let uri = asset.uri,
+              let path = ACPToolCallCard.trustedRemotePath(
+                from: uri,
+                trustedRoot: trustedImageRoot
+              )
+        else { return nil }
+        return (host, trustedImageRoot.standardizedFileURL.path, path)
     }
 
     private func imageThumbnail(_ image: NSImage) -> some View {
@@ -354,6 +380,99 @@ private struct ACPToolCallAssetView: View {
         .clipShape(RoundedRectangle(cornerRadius: 6))
         .overlay(RoundedRectangle(cornerRadius: 6).strokeBorder(theme.color("line-soft"), lineWidth: 0.5))
         .help(asset.displayText)
+    }
+}
+
+private struct RemoteToolCallAssetImage: View {
+    let host: String
+    let worktreeRoot: String
+    let path: String
+    let asset: ACPMessage.ToolCallAsset
+    @State private var image: NSImage?
+    @Environment(\.theme) private var theme
+
+    var body: some View {
+        Group {
+            if let image {
+                ZStack {
+                    RoundedRectangle(cornerRadius: 8)
+                        .fill(theme.color("bg-1").opacity(0.7))
+                    Image(nsImage: image)
+                        .resizable()
+                        .scaledToFit()
+                        .padding(6)
+                }
+                .frame(width: 160, height: 120)
+                .overlay(RoundedRectangle(cornerRadius: 8).strokeBorder(.white.opacity(0.15), lineWidth: 0.5))
+            } else {
+                placeholder
+            }
+        }
+        .help(asset.displayText)
+        .task(id: "\(host)\u{0}\(path)") {
+            image = nil
+            guard (try? await ACPRemoteFileServer(host: host, worktreeRoot: worktreeRoot)
+                .verifyRemoteContainment(path: path)) != nil
+            else { return }
+            guard let data = await RemoteImageCache.shared.imageData(host: host, path: path),
+                  !Task.isCancelled
+            else { return }
+            image = NSImage(data: data)
+        }
+    }
+
+    private var placeholder: some View {
+        HStack(spacing: 8) {
+            Image(systemName: "photo")
+                .font(.system(size: 12))
+                .foregroundStyle(theme.color("accent"))
+                .frame(width: 18, height: 18)
+
+            VStack(alignment: .leading, spacing: 2) {
+                Text(asset.displayTitle)
+                    .font(.system(size: 11.5, weight: .semibold))
+                    .foregroundStyle(theme.color("fg"))
+                    .lineLimit(1)
+                    .truncationMode(.middle)
+                if let detail = asset.displayDetail {
+                    Text(detail)
+                        .font(.system(size: 10.5))
+                        .foregroundStyle(theme.color("fg-faint"))
+                        .lineLimit(1)
+                        .truncationMode(.middle)
+                }
+            }
+
+            Spacer(minLength: 0)
+        }
+        .padding(.horizontal, 8).padding(.vertical, 7)
+        .background(theme.color("bg-1").opacity(0.7))
+        .clipShape(RoundedRectangle(cornerRadius: 6))
+        .overlay(RoundedRectangle(cornerRadius: 6).strokeBorder(theme.color("line-soft"), lineWidth: 0.5))
+    }
+}
+
+extension ACPToolCallCard {
+    /// Resolves a remote tool asset under its worktree using the same lexical
+    /// containment rule as ACP remote file serving. Remote symlinks are not
+    /// resolved here because doing so would require an SSH round trip.
+    static func trustedRemotePath(from value: String, trustedRoot: URL) -> String? {
+        let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return nil }
+
+        let candidate: String
+        if let url = URL(string: trimmed), let scheme = url.scheme {
+            guard scheme.lowercased() == "file" else { return nil }
+            candidate = url.path
+        } else if trimmed.hasPrefix("/") {
+            candidate = trimmed
+        } else {
+            candidate = trustedRoot.path + "/" + trimmed
+        }
+
+        let root = trustedRoot.standardizedFileURL.path
+        return try? ACPRemoteFileServer(host: "", worktreeRoot: root)
+            .lexicallyResolveInsideWorktree(path: candidate)
     }
 }
 

--- a/Alas/Sources/Agents/AgentLauncherDialog.swift
+++ b/Alas/Sources/Agents/AgentLauncherDialog.swift
@@ -428,7 +428,9 @@ struct AgentLauncherDialog: View {
         case .terminal:
             guard let worktree = selectedWorktree() else { close()
             return }
-            _ = try? appState.openAgentTerminalTab(for: worktree, agentId: agent.id)
+            Task { @MainActor in
+                _ = try? await appState.openAgentTerminalTabPreparingRemoteZmxIfNeeded(for: worktree, agentId: agent.id)
+            }
         case .acp:
             beginSessionBrowser(for: agent)
             return

--- a/Alas/Sources/App/AppState.swift
+++ b/Alas/Sources/App/AppState.swift
@@ -870,11 +870,12 @@ final class AppState {
         destination: URL,
         runStartup: Bool,
         launchSurface: WorktreeLaunchSurface
-    ) -> String {
+    ) async -> String {
         guard let project = projects.first(where: { $0.id == projectId }) else {
             // Should not happen if the dialog validated the project; fail silently.
             return ""
         }
+        let repoPath = URL(fileURLWithPath: project.path)
         // Canonicalize once and use this URL everywhere downstream — both
         // the optimistic row and the eventual `WorktreeService.add` return
         // value derive their `id` from the path we hand in, so any
@@ -884,10 +885,16 @@ final class AppState {
         // resolvingSymlinksInPath only resolves links along path components
         // that exist on disk; the leaf doesn't exist yet, so resolve the
         // parent (which does) and reattach the leaf.
-        let canonicalDestination = destination
-            .deletingLastPathComponent()
-            .resolvingSymlinksInPath()
-            .appendingPathComponent(destination.lastPathComponent)
+        let canonicalDestination: URL
+        do {
+            canonicalDestination = try await Self.preparedCreateWorktreeDestination(
+                repoPath: repoPath,
+                destination: destination
+            )
+        } catch {
+            showFileActionError(title: "Create Worktree Failed", message: error.localizedDescription)
+            return ""
+        }
         let optimisticId = Worktree.makeId(path: canonicalDestination)
         if projectsManager.worktrees(projectId: projectId).contains(where: { $0.id == optimisticId }) {
             let isRetryingFailedCreate: Bool
@@ -918,7 +925,6 @@ final class AppState {
         projectsManager.setOperationState(id: optimistic.id, state: .creating)
         selectWorktree(id: optimistic.id)
 
-        let repoPath = URL(fileURLWithPath: project.path)
         let startupScript = StartupScriptResolver.worktreeCreateScript(
             global: config.terminal,
             project: project
@@ -946,11 +952,15 @@ final class AppState {
                 )
                 guard projects.contains(where: { $0.id == projectId }) else { return }
                 if runStartup && !startupScript.isEmpty {
-                    _ = try? await Process.run(
-                        "/bin/zsh",
-                        args: ["-c", startupScript],
-                        cwd: newWorktree.path
-                    )
+                    if let host = project.host ?? RemoteHostRegistry.shared.host(forPath: newWorktree.path.path) {
+                        _ = try? await RemoteExec.run(host: host, cwd: newWorktree.path.path, command: startupScript)
+                    } else {
+                        _ = try? await Process.run(
+                            "/bin/zsh",
+                            args: ["-c", startupScript],
+                            cwd: newWorktree.path
+                        )
+                    }
                 }
                 guard projects.contains(where: { $0.id == projectId }) else { return }
 
@@ -982,7 +992,7 @@ final class AppState {
                             else { return nil }
                             return self.agentStartupCommand(for: agent, project: project)
                         }()
-                        _ = try? openTerminalTab(
+                        _ = try? await openTerminalTabPreparingRemoteZmxIfNeeded(
                             for: newWorktree,
                             startupScriptSuffix: suffix
                         )
@@ -1035,7 +1045,7 @@ final class AppState {
             )
         }
 
-        let id = createWorktree(
+        let id = await createWorktree(
             projectId: project.id,
             base: resolvedBase,
             branch: branch,
@@ -1098,10 +1108,32 @@ final class AppState {
             throw AgentTerminalLaunchError.agentUnavailable
         }
         do {
-            if agent.id == AgentKind.copilot.rawValue {
+            if agent.id == AgentKind.copilot.rawValue, project.host == nil {
                 try CopilotInstaller(projectRootURL: worktree.path).install()
             }
             return try openTerminalTab(
+                for: worktree,
+                startupScriptSuffix: agentStartupCommand(for: agent, project: project)
+            )
+        } catch {
+            showFileActionError(title: "Launch Agent Failed", message: error.localizedDescription)
+            throw error
+        }
+    }
+
+    @discardableResult
+    func openAgentTerminalTabPreparingRemoteZmxIfNeeded(for worktree: Worktree, agentId: String) async throws -> Tab {
+        guard let project = projects.first(where: { $0.id == worktree.projectId }) else {
+            throw AgentTerminalLaunchError.projectUnavailable
+        }
+        guard let agent = agentRegistry.enabled().first(where: { $0.id == agentId }) else {
+            throw AgentTerminalLaunchError.agentUnavailable
+        }
+        do {
+            if agent.id == AgentKind.copilot.rawValue, project.host == nil {
+                try CopilotInstaller(projectRootURL: worktree.path).install()
+            }
+            return try await openTerminalTabPreparingRemoteZmxIfNeeded(
                 for: worktree,
                 startupScriptSuffix: agentStartupCommand(for: agent, project: project)
             )
@@ -1124,6 +1156,32 @@ final class AppState {
             exitOnCompletion: true
         )
         let tab = try openTerminalTab(
+            for: worktree,
+            startupScriptSuffix: startupScriptSuffix,
+            includeUserStartupScript: false,
+            forceInheritParentEnv: true,
+            environmentOverrides: Self.acpAuthTerminalEnvironmentOverrides(extra: command.env),
+            environmentRemovals: ACPProcessEnvironment.agentSessionMarkerKeys
+        )
+        if case .terminal(let terminal) = tab {
+            acpAuthTerminalExitHandlers[terminal.root.firstLeaf().sessionId] = onExit
+        }
+        return tab
+    }
+
+    @discardableResult
+    func openACPAuthTerminalTabPreparingRemoteZmxIfNeeded(
+        for worktree: Worktree,
+        command: ACPAuthTerminalCommand,
+        onExit: @escaping () -> Void
+    ) async throws -> Tab {
+        let startupScriptSuffix = try Self.shellCommand(
+            command: command.command,
+            args: command.args,
+            env: command.env,
+            exitOnCompletion: true
+        )
+        let tab = try await openTerminalTabPreparingRemoteZmxIfNeeded(
             for: worktree,
             startupScriptSuffix: startupScriptSuffix,
             includeUserStartupScript: false,
@@ -1200,10 +1258,12 @@ final class AppState {
         projectId: String
     ) async throws -> Worktree {
         try await Task.detached {
-            try FileManager.default.createDirectory(
-                at: destination.deletingLastPathComponent(),
-                withIntermediateDirectories: true
-            )
+            if !repoPath.isRemoteAlasPath {
+                try FileManager.default.createDirectory(
+                    at: destination.deletingLastPathComponent(),
+                    withIntermediateDirectories: true
+                )
+            }
             return try await WorktreeService().add(
                 repoPath: repoPath,
                 base: base,
@@ -1212,6 +1272,60 @@ final class AppState {
                 projectId: projectId
             )
         }.value
+    }
+
+    nonisolated static func preparedCreateWorktreeDestination(repoPath: URL, destination: URL) async throws -> URL {
+        let isRemote = repoPath.isRemoteAlasPath
+        let preparedDestination: URL
+        if isRemote,
+           let host = RemoteHostRegistry.shared.host(forPath: repoPath.path) {
+            let remoteHome = try await Self.remoteHomeDirectory(host: host)
+            preparedDestination = URL(fileURLWithPath: Self.destinationPathReplacingLocalHome(
+                destination.path,
+                remoteHome: remoteHome
+            ))
+        } else {
+            preparedDestination = destination
+        }
+        if isRemote {
+            return preparedDestination
+        }
+        return preparedDestination
+            .deletingLastPathComponent()
+            .resolvingSymlinksInPath()
+            .appendingPathComponent(preparedDestination.lastPathComponent)
+    }
+
+    nonisolated static func destinationPathReplacingLocalHome(
+        _ path: String,
+        localHome: String = NSHomeDirectory(),
+        remoteHome: String
+    ) -> String {
+        let normalizedLocalHome = localHome.trimmingCharacters(in: CharacterSet(charactersIn: "/"))
+        let localHomePath = "/\(normalizedLocalHome)"
+        guard path == localHomePath || path.hasPrefix("\(localHomePath)/") else { return path }
+        let suffix = path.dropFirst(localHomePath.count)
+        return remoteHome.trimmingCharacters(in: CharacterSet(charactersIn: "/")).isEmpty
+            ? path
+            : "/\(remoteHome.trimmingCharacters(in: CharacterSet(charactersIn: "/")))\(suffix)"
+    }
+
+    nonisolated private static func remoteHomeDirectory(host: String) async throws -> String {
+        let result = try await RemoteExec.run(
+            host: host,
+            cwd: nil,
+            command: "printf '%s' \"$HOME\"",
+            timeout: 10
+        )
+        let home = result.stdout.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard result.exitCode == 0, !home.isEmpty else {
+            throw NSError(
+                domain: "RemoteHomeDirectory",
+                code: Int(result.exitCode),
+                userInfo: [NSLocalizedDescriptionKey: "Could not resolve remote home directory for \(host)."]
+            )
+        }
+        return home
     }
 
     func removeFailedOptimisticWorktree(id: String, projectId: String) {
@@ -1261,7 +1375,18 @@ final class AppState {
 
     @discardableResult
     func removeProject(id: String) -> Bool {
-        guard let project = projects.first(where: { $0.id == id }) else { return false }
+        removeProjectResult(id: id) == .removed
+    }
+
+    private enum ProjectRemovalResult {
+        case removed
+        case scheduled
+        case cancelled
+    }
+
+    @discardableResult
+    private func removeProjectResult(id: String) -> ProjectRemovalResult {
+        guard let project = projects.first(where: { $0.id == id }) else { return .cancelled }
 
         let mainId = Worktree.makeId(path: URL(fileURLWithPath: project.path))
         let liveWorktrees = projectsManager.worktrees(projectId: id)
@@ -1304,27 +1429,47 @@ final class AppState {
                 dirtyCount: dirtyTotal
             ) {
             case .save:
-                for entry in dirtyByWorktree {
-                    guard saveDirtyBuffers(in: entry.worktree) else { return false }
+                let worktreesToSave = dirtyByWorktree.map(\.worktree)
+                Task { @MainActor in
+                    for worktree in worktreesToSave {
+                        guard await saveDirtyBuffers(in: worktree) else { return }
+                    }
+                    _ = removeProjectAfterDirtyResolution(id: id, candidateIds: candidateIds)
                 }
+                return .scheduled
             case .discard:
                 break
             case .cancel:
-                return false
+                return .cancelled
             }
         }
 
+        return removeProjectAfterDirtyResolution(id: id, candidateIds: candidateIds) ? .removed : .cancelled
+    }
+
+    @discardableResult
+    private func removeProjectAfterDirtyResolution(id: String, candidateIds: Set<String>) -> Bool {
         var beforeIds = allWorktreeIds()
         for candidateId in candidateIds {
             beforeIds.insert(candidateId)
         }
+        let remoteRootsToUnregister: [String]
+        if let project = projects.first(where: { $0.id == id }),
+           project.host != nil {
+            remoteRootsToUnregister = [project.path] + projectsManager.worktrees(projectId: id).map(\.path.path)
+        } else {
+            remoteRootsToUnregister = []
+        }
         stopProjectGitWatcher(projectId: id)
-        projectsManager.removeProject(id: id)
+        projectsManager.removeProject(id: id, unregisterRemoteRoots: remoteRootsToUnregister.isEmpty)
         spacesManager.removeProjectEverywhere(id)
         saveProjects()
         saveSpaces()
         let removedIds = beforeIds.subtracting(allWorktreeIds())
         cleanupMissingWorktrees(beforeIds: beforeIds)
+        for root in remoteRootsToUnregister {
+            RemoteHostRegistry.shared.unregister(root: root)
+        }
         for worktreeId in removedIds {
             try? FileManager.default.removeItem(at: Paths.tabsFile(forWorktreeId: worktreeId))
             try? FileManager.default.removeItem(at: Paths.buffersDir(forWorktreeId: worktreeId))
@@ -1337,8 +1482,14 @@ final class AppState {
         let ids = projects.map(\.id)
         var removed = 0
         for id in ids {
-            guard removeProject(id: id) else { break }
-            removed += 1
+            switch removeProjectResult(id: id) {
+            case .removed:
+                removed += 1
+            case .scheduled:
+                continue
+            case .cancelled:
+                return removed
+            }
         }
         return removed
     }
@@ -1350,6 +1501,7 @@ final class AppState {
             do {
                 try await projectsManager.refreshWorktrees(projectId: project.id)
             } catch {
+                guard project.host == nil else { continue }
                 guard !FileManager.default.fileExists(atPath: project.path) else { continue }
                 staleProjectIds.append(project.id)
                 continue
@@ -1362,8 +1514,14 @@ final class AppState {
 
         var removed = 0
         for id in staleProjectIds {
-            guard removeProject(id: id) else { break }
-            removed += 1
+            switch removeProjectResult(id: id) {
+            case .removed:
+                removed += 1
+            case .scheduled:
+                continue
+            case .cancelled:
+                return removed
+            }
         }
         return removed
     }
@@ -1415,10 +1573,19 @@ final class AppState {
 
     private func handleProjectTopologyChange(projectId: String) {
         Task { @MainActor in
-            let beforeIds = allWorktreeIds()
-            if (try? await projectsManager.refreshWorktrees(projectId: projectId)) == true { saveProjects() }
-            cleanupMissingWorktrees(beforeIds: beforeIds)
+            await refreshProjectTopology(projectId: projectId)
         }
+    }
+
+    func refreshProjectTopology(projectId: String) async {
+        let beforeIds = allWorktreeIds()
+        if (try? await projectsManager.refreshWorktrees(projectId: projectId)) == true { saveProjects() }
+        let afterIds = allWorktreeIds()
+        let addedIds = afterIds.subtracting(beforeIds)
+        if !addedIds.isEmpty {
+            tabs.loadAll(worktreeIds: Array(addedIds))
+        }
+        cleanupMissingWorktrees(beforeIds: beforeIds)
     }
 
     func updateProject(
@@ -1481,7 +1648,11 @@ final class AppState {
                 onDiskDestructive: false
             ) {
             case .save:
-                guard saveDirtyBuffers(in: worktree) else { return }
+                Task { @MainActor in
+                    guard await saveDirtyBuffers(in: worktree) else { return }
+                    archiveWorktreeAfterSaving(worktree)
+                }
+                return
             case .discard:
                 break
             case .cancel:
@@ -1489,6 +1660,10 @@ final class AppState {
             }
         }
 
+        archiveWorktreeAfterSaving(worktree)
+    }
+
+    private func archiveWorktreeAfterSaving(_ worktree: Worktree) {
         // Snapshot index in the visible list BEFORE we mutate anything, so we
         // can pick a sensible follow-up selection.
         let siblingsBefore = projectsManager.visibleWorktrees(projectId: worktree.projectId)
@@ -1723,6 +1898,29 @@ final class AppState {
     }
 
     @discardableResult
+    func openTerminalTabPreparingRemoteZmxIfNeeded(
+        for worktree: Worktree,
+        startupScriptSuffix: String? = nil,
+        includeUserStartupScript: Bool = true,
+        forceInheritParentEnv: Bool = false,
+        environmentOverrides: [String: String] = [:],
+        environmentRemovals: Set<String> = []
+    ) async throws -> Tab {
+        guard let project = projects.first(where: { $0.id == worktree.projectId }) else {
+            throw NSError(domain: "AppState", code: 2)
+        }
+        await prepareRemoteZmxIfNeeded(for: project)
+        return try openTerminalTab(
+            for: worktree,
+            startupScriptSuffix: startupScriptSuffix,
+            includeUserStartupScript: includeUserStartupScript,
+            forceInheritParentEnv: forceInheritParentEnv,
+            environmentOverrides: environmentOverrides,
+            environmentRemovals: environmentRemovals
+        )
+    }
+
+    @discardableResult
     func openTerminalTab(
         for worktree: Worktree,
         startupScriptSuffix: String? = nil,
@@ -1734,7 +1932,6 @@ final class AppState {
         guard let project = projects.first(where: { $0.id == worktree.projectId }) else {
             throw NSError(domain: "AppState", code: 2)
         }
-        offerRemoteZmxInstallIfNeeded(for: project)
         // Single identity for this pane: used with the worktree id to derive
         // the zmx session name, plus the SessionRegistry key, leaf id, persisted
         // sessionId (mirrored to id on encode), and ALAS_SESSION_ID. Generated
@@ -1783,7 +1980,7 @@ final class AppState {
         return tabs.appendTerminal(worktreeId: worktree.id, title: title, sessionId: opened.id)
     }
 
-    private func offerRemoteZmxInstallIfNeeded(for project: ProjectConfig) {
+    private func prepareRemoteZmxIfNeeded(for project: ProjectConfig) async {
         guard config.terminal.keepSessionsAlive,
               let host = project.host,
               !promptedRemoteZmxHosts.contains(host),
@@ -1791,32 +1988,29 @@ final class AppState {
         else { return }
 
         promptedRemoteZmxHosts.insert(host)
-        Task { [weak self] in
-            guard let self,
-                  let capabilities = await RemoteHostCapabilityStore.shared.capabilities(for: host),
-                  !capabilities.hasZmx,
-                  let resources = Bundle.main.resourceURL,
-                  RemoteZmxInstaller.bundledBinaryPath(
-                    os: capabilities.os,
-                    arch: capabilities.arch,
-                    resourceURL: resources
-                  ) != nil
-            else { return }
-
-            guard self.confirmPushZmx(host: host) else {
-                var declined = Set(UserDefaults.standard.stringArray(forKey: "remote.zmx.declinedHosts") ?? [])
-                declined.insert(host)
-                UserDefaults.standard.set(Array(declined).sorted(), forKey: "remote.zmx.declinedHosts")
-                return
-            }
-
-            if await RemoteZmxInstaller.install(
-                host: host,
-                capabilities: capabilities,
+        guard let capabilities = await RemoteHostCapabilityStore.shared.capabilities(for: host),
+              !capabilities.hasZmx,
+              let resources = Bundle.main.resourceURL,
+              RemoteZmxInstaller.bundledBinaryPath(
+                os: capabilities.os,
+                arch: capabilities.arch,
                 resourceURL: resources
-            ) {
-                RemoteHostCapabilityStore.shared.invalidate(host: host)
-            }
+              ) != nil
+        else { return }
+
+        guard confirmPushZmx(host: host) else {
+            var declined = Set(UserDefaults.standard.stringArray(forKey: "remote.zmx.declinedHosts") ?? [])
+            declined.insert(host)
+            UserDefaults.standard.set(Array(declined).sorted(), forKey: "remote.zmx.declinedHosts")
+            return
+        }
+
+        if await RemoteZmxInstaller.install(
+            host: host,
+            capabilities: capabilities,
+            resourceURL: resources
+        ) {
+            RemoteHostCapabilityStore.shared.invalidate(host: host)
         }
     }
 
@@ -2206,18 +2400,20 @@ final class AppState {
     }
 
     func saveAllTabs() {
-        var roots: [String: URL] = [:]
-        for project in projects {
-            for worktree in projectsManager.worktrees(projectId: project.id) {
-                roots[worktree.id] = roots[worktree.id] ?? worktree.path
+        Task { @MainActor in
+            var roots: [String: URL] = [:]
+            for project in projects {
+                for worktree in projectsManager.worktrees(projectId: project.id) {
+                    roots[worktree.id] = roots[worktree.id] ?? worktree.path
+                }
             }
+            let errors = await tabs.saveAllAwaitingRemote(worktreeRoots: roots)
+            guard !errors.isEmpty else { return }
+            showFileActionError(
+                title: "Save All Failed",
+                message: "\(errors.count) file\(errors.count == 1 ? "" : "s") could not be saved."
+            )
         }
-        let errors = tabs.saveAll(worktreeRoots: roots)
-        guard !errors.isEmpty else { return }
-        showFileActionError(
-            title: "Save All Failed",
-            message: "\(errors.count) file\(errors.count == 1 ? "" : "s") could not be saved."
-        )
     }
 
     func revertActiveTab(worktreeId: String) {
@@ -2225,7 +2421,29 @@ final class AppState {
     }
 
     func newFile(in worktreeId: String) {
-        guard let worktree = worktree(withId: worktreeId) else { return }
+        guard let (project, worktree) = projectAndWorktree(withWorktreeId: worktreeId) else { return }
+        if let host = project.host {
+            guard let relativePath = promptForRemoteRelativePath(
+                title: "New File",
+                message: "Enter a path relative to the remote worktree.",
+                defaultValue: "untitled.txt",
+                confirmTitle: "Create",
+                errorTitle: "New File Failed"
+            ) else { return }
+            guard !tabs.hasEditor(worktreeId: worktreeId, relativePath: relativePath) else {
+                showFileActionError(title: "New File Failed", message: "That file is already open in another editor tab.")
+                return
+            }
+            Task { @MainActor [weak self] in
+                do {
+                    try await Self.createRemoteEmptyFile(host: host, worktreeRoot: worktree.path, relativePath: relativePath)
+                    self?.openFile(relativePath: relativePath, worktreeId: worktreeId)
+                } catch {
+                    self?.showFileActionError(title: "New File Failed", message: error.localizedDescription)
+                }
+            }
+            return
+        }
         let panel = NSSavePanel()
         panel.title = "New File"
         panel.message = "Choose where to create the new file."
@@ -2247,10 +2465,47 @@ final class AppState {
         }
     }
 
+    nonisolated private static func createRemoteEmptyFile(host: String, worktreeRoot: URL, relativePath: String) async throws {
+        let path = worktreeRoot.appendingPathComponent(relativePath).path
+        try await RemotePathContainment.verifyRemoteContainment(host: host, path: path, worktreeRoot: worktreeRoot.path)
+        let result = try await RemoteExec.run(host: host, cwd: nil, command: RemoteFileOps.createEmptyFileCommand(path: path))
+        if RemoteExec.isConnectionFailure(exitCode: result.exitCode) {
+            throw RemoteFileAccessError.connectionFailed(result.stderr)
+        }
+        guard result.exitCode == 0 else {
+            if result.exitCode == 1 {
+                throw CocoaError(.fileWriteFileExists)
+            }
+            throw RemoteFileAccessError.writeFailed(result.stderr)
+        }
+    }
+
     func saveActiveTabAs(worktreeId: String) {
         guard let worktree = worktree(withId: worktreeId),
               let context = tabs.activeEditorContext(worktreeId: worktreeId) else { return }
         let currentURL = worktree.path.appendingPathComponent(context.tab.relativePath)
+        if context.buffer.isRemote {
+            guard let relativePath = promptForRemoteRelativePath(
+                title: "Save As",
+                message: "Enter a path relative to the remote worktree.",
+                defaultValue: context.tab.relativePath,
+                confirmTitle: "Save",
+                errorTitle: "Save As Failed"
+            ) else { return }
+            guard !tabs.hasEditor(worktreeId: worktreeId, relativePath: relativePath, excluding: context.tab.id) else {
+                showFileActionError(title: "Save As Failed", message: "That file is already open in another editor tab.")
+                return
+            }
+            Task { @MainActor [weak self] in
+                do {
+                    try await context.buffer.saveAsRemote(relativePath: relativePath)
+                    _ = self?.tabs.updateEditorPath(worktreeId: worktreeId, tabId: context.tab.id, relativePath: relativePath)
+                } catch {
+                    self?.showFileActionError(title: "Save As Failed", message: error.localizedDescription)
+                }
+            }
+            return
+        }
         let panel = NSSavePanel()
         panel.title = "Save As"
         panel.message = "Choose the new path for this editor buffer."
@@ -2272,10 +2527,71 @@ final class AppState {
         }
     }
 
+    private func promptForRemoteRelativePath(
+        title: String,
+        message: String,
+        defaultValue: String,
+        confirmTitle: String,
+        errorTitle: String
+    ) -> String? {
+        let alert = NSAlert()
+        alert.messageText = title
+        alert.informativeText = message
+        alert.alertStyle = .informational
+        alert.addButton(withTitle: confirmTitle)
+        alert.addButton(withTitle: "Cancel")
+        let field = NSTextField(frame: NSRect(x: 0, y: 0, width: 360, height: 24))
+        field.stringValue = defaultValue
+        alert.accessoryView = field
+        guard alert.runModal() == .alertFirstButtonReturn else { return nil }
+        do {
+            return try Self.normalizedRemoteRelativePath(field.stringValue)
+        } catch {
+            showFileActionError(title: errorTitle, message: error.localizedDescription)
+            return nil
+        }
+    }
+
+    nonisolated static func normalizedRemoteRelativePath(_ raw: String) throws -> String {
+        let normalized = raw
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+            .replacingOccurrences(of: "\\", with: "/")
+        guard !normalized.isEmpty,
+              !normalized.hasPrefix("/"),
+              !normalized.split(separator: "/", omittingEmptySubsequences: false).contains("..")
+        else {
+            throw NSError(
+                domain: "AppState",
+                code: 6,
+                userInfo: [NSLocalizedDescriptionKey: "Enter a relative path inside the remote worktree."]
+            )
+        }
+        return normalized
+    }
+
     func renameActiveFile(worktreeId: String) {
         guard let worktree = worktree(withId: worktreeId),
               let context = tabs.activeEditorContext(worktreeId: worktreeId) else { return }
         let currentURL = worktree.path.appendingPathComponent(context.tab.relativePath)
+        if context.buffer.isRemote {
+            guard let relativePath = promptForRemoteRelativePath(
+                title: "Rename File",
+                message: "Enter a path relative to the remote worktree.",
+                defaultValue: context.tab.relativePath,
+                confirmTitle: "Rename",
+                errorTitle: "Rename File Failed"
+            ) else { return }
+            guard relativePath != context.tab.relativePath else { return }
+            Task { @MainActor [weak self] in
+                do {
+                    try await context.buffer.moveToRemote(relativePath: relativePath)
+                    _ = self?.tabs.updateEditorPath(worktreeId: worktreeId, tabId: context.tab.id, relativePath: relativePath)
+                } catch {
+                    self?.showFileActionError(title: "Rename File Failed", message: error.localizedDescription)
+                }
+            }
+            return
+        }
         let panel = NSSavePanel()
         panel.title = "Rename File"
         panel.message = "Choose the new path for this file."
@@ -3024,8 +3340,16 @@ final class AppState {
             }
         }
         if saveBuffersFirst {
-            guard saveDirtyBuffers(in: worktree) else { return }
+            Task { @MainActor in
+                guard await saveDirtyBuffers(in: worktree) else { return }
+                beginDeleteWorktree(worktree, keepBranch: keepBranch)
+            }
+            return
         }
+        beginDeleteWorktree(worktree, keepBranch: keepBranch)
+    }
+
+    private func beginDeleteWorktree(_ worktree: Worktree, keepBranch: Bool) {
         guard let project = projects.first(where: { $0.id == worktree.projectId }) else {
             showFileActionError(title: "Delete Failed", message: "Could not find the project for this worktree.")
             return
@@ -3524,8 +3848,8 @@ final class AppState {
     /// snapshot on disk. Returns true on full success; on partial failure
     /// surfaces an aggregate error and returns false so the caller can bail
     /// before the destructive cleanup.
-    private func saveDirtyBuffers(in worktree: Worktree) -> Bool {
-        let errors = tabs.saveAllUnsaved(forWorktree: worktree.id, root: worktree.path)
+    private func saveDirtyBuffers(in worktree: Worktree) async -> Bool {
+        let errors = await tabs.saveAllUnsavedAwaitingRemote(forWorktree: worktree.id, root: worktree.path)
         if !errors.isEmpty {
             let count = errors.count
             showFileActionError(

--- a/Alas/Sources/App/AppState.swift
+++ b/Alas/Sources/App/AppState.swift
@@ -438,6 +438,8 @@ final class AppState {
     /// the sidebar when branches flip or worktrees appear/disappear externally.
     @ObservationIgnored
     private var projectGitWatchers: [String: ProjectGitWatcher] = [:]
+    @ObservationIgnored
+    private var remoteProjectWatchers: [String: RemoteProjectGitWatcher] = [:]
 
     init(
         store: any PersistenceStoreProtocol = PersistenceStore(),
@@ -1351,34 +1353,27 @@ final class AppState {
     /// stops any existing watcher for the same project id first.
     func startProjectGitWatcher(for project: ProjectConfig) {
         stopProjectGitWatcher(projectId: project.id)
-        if URL(fileURLWithPath: project.path).isRemoteAlasPath { return }
+        if project.host != nil {
+            let watcher = RemoteProjectGitWatcher(projectPath: URL(fileURLWithPath: project.path))
+            watcher.onHeadChanged = { [weak self] updates in
+                self?.handleProjectHeadUpdates(projectId: project.id, branchByWorktreePath: updates)
+            }
+            watcher.onTopologyChanged = { [weak self] in self?.handleProjectTopologyChange(projectId: project.id) }
+            remoteProjectWatchers[project.id] = watcher
+            watcher.start()
+            return
+        }
         let watcher = ProjectGitWatcher(repoPath: URL(fileURLWithPath: project.path))
         let projectId = project.id
-        watcher.onHeadChanged = { [weak self] map in
-            self?.projectsManager.applyHeadUpdates(
-                projectId: projectId,
-                branchByWorktreePath: map
-            )
-        }
-        watcher.onTopologyChanged = { [weak self] in
-            Task { @MainActor in
-                guard let self else { return }
-                let beforeIds = self.allWorktreeIds()
-                // refreshWorktrees returns true when the hidden-path GC dropped
-                // entries — persist so archived worktrees removed externally
-                // don't reappear after relaunch.
-                if (try? await self.projectsManager.refreshWorktrees(projectId: projectId)) == true {
-                    self.saveProjects()
-                }
-                self.cleanupMissingWorktrees(beforeIds: beforeIds)
-            }
-        }
+        watcher.onHeadChanged = { [weak self] map in self?.handleProjectHeadUpdates(projectId: projectId, branchByWorktreePath: map) }
+        watcher.onTopologyChanged = { [weak self] in self?.handleProjectTopologyChange(projectId: projectId) }
         watcher.start()
         projectGitWatchers[projectId] = watcher
     }
 
     func stopProjectGitWatcher(projectId: String) {
         projectGitWatchers.removeValue(forKey: projectId)?.stop()
+        remoteProjectWatchers.removeValue(forKey: projectId)?.stop()
     }
 
     func startAllProjectGitWatchers() {
@@ -1390,6 +1385,20 @@ final class AppState {
     func stopAllProjectGitWatchers() {
         for (_, watcher) in projectGitWatchers { watcher.stop() }
         projectGitWatchers.removeAll()
+        for (_, watcher) in remoteProjectWatchers { watcher.stop() }
+        remoteProjectWatchers.removeAll()
+    }
+
+    private func handleProjectHeadUpdates(projectId: String, branchByWorktreePath: [URL: String]) {
+        projectsManager.applyHeadUpdates(projectId: projectId, branchByWorktreePath: branchByWorktreePath)
+    }
+
+    private func handleProjectTopologyChange(projectId: String) {
+        Task { @MainActor in
+            let beforeIds = allWorktreeIds()
+            if (try? await projectsManager.refreshWorktrees(projectId: projectId)) == true { saveProjects() }
+            cleanupMissingWorktrees(beforeIds: beforeIds)
+        }
     }
 
     func updateProject(

--- a/Alas/Sources/App/AppState.swift
+++ b/Alas/Sources/App/AppState.swift
@@ -48,6 +48,8 @@ final class AppState {
     private let terminalSessionOpener: TerminalSessionOpener?
     @ObservationIgnored
     private var acpAuthTerminalExitHandlers: [String: () -> Void] = [:]
+    @ObservationIgnored
+    private var promptedRemoteZmxHosts: Set<String> = []
     let rightPaneStore = RightPaneStore()
     let harness = HarnessService()
     let acpAdapterUpdateStore = ACPAdapterUpdateStore()
@@ -597,6 +599,21 @@ final class AppState {
             knownWorktreeIds: Set(worktreeIds),
             knownLeafIds: leafIds
         )
+
+        let remoteProjects = projects.filter { $0.host != nil }
+        for host in Set(remoteProjects.compactMap(\.host)) {
+            let hostWorktreeIds = Set(remoteProjects
+                .filter { $0.host == host }
+                .flatMap { projectsManager.worktrees(projectId: $0.id).map(\.id) })
+            guard !hostWorktreeIds.isEmpty else { continue }
+            Task {
+                await TerminalService.sweepRemoteOrphans(
+                    host: host,
+                    knownWorktreeIds: hostWorktreeIds,
+                    knownLeafIds: leafIds
+                )
+            }
+        }
     }
 
     var projects: [ProjectConfig] { projectsManager.projects }
@@ -1033,7 +1050,10 @@ final class AppState {
     }
 
     func agentStartupCommand(for agent: AgentDefinition, project: ProjectConfig) -> String {
-        var argv = [agent.resolvedBinary]
+        let binary = project.host == nil
+            ? agent.resolvedBinary
+            : URL(fileURLWithPath: agent.resolvedBinary).lastPathComponent
+        var argv = [binary]
         if let extra = agent.extraTerminalArgs, !extra.isEmpty {
             argv.append(contentsOf: extra)
         }
@@ -1714,6 +1734,7 @@ final class AppState {
         guard let project = projects.first(where: { $0.id == worktree.projectId }) else {
             throw NSError(domain: "AppState", code: 2)
         }
+        offerRemoteZmxInstallIfNeeded(for: project)
         // Single identity for this pane: used with the worktree id to derive
         // the zmx session name, plus the SessionRegistry key, leaf id, persisted
         // sessionId (mirrored to id on encode), and ALAS_SESSION_ID. Generated
@@ -1760,6 +1781,53 @@ final class AppState {
         // `terminalSessionOpener` (test-only) generates its own id and we
         // honor it for backward-compat with existing tests.
         return tabs.appendTerminal(worktreeId: worktree.id, title: title, sessionId: opened.id)
+    }
+
+    private func offerRemoteZmxInstallIfNeeded(for project: ProjectConfig) {
+        guard config.terminal.keepSessionsAlive,
+              let host = project.host,
+              !promptedRemoteZmxHosts.contains(host),
+              !Set(UserDefaults.standard.stringArray(forKey: "remote.zmx.declinedHosts") ?? []).contains(host)
+        else { return }
+
+        promptedRemoteZmxHosts.insert(host)
+        Task { [weak self] in
+            guard let self,
+                  let capabilities = await RemoteHostCapabilityStore.shared.capabilities(for: host),
+                  !capabilities.hasZmx,
+                  let resources = Bundle.main.resourceURL,
+                  RemoteZmxInstaller.bundledBinaryPath(
+                    os: capabilities.os,
+                    arch: capabilities.arch,
+                    resourceURL: resources
+                  ) != nil
+            else { return }
+
+            guard self.confirmPushZmx(host: host) else {
+                var declined = Set(UserDefaults.standard.stringArray(forKey: "remote.zmx.declinedHosts") ?? [])
+                declined.insert(host)
+                UserDefaults.standard.set(Array(declined).sorted(), forKey: "remote.zmx.declinedHosts")
+                return
+            }
+
+            if await RemoteZmxInstaller.install(
+                host: host,
+                capabilities: capabilities,
+                resourceURL: resources
+            ) {
+                RemoteHostCapabilityStore.shared.invalidate(host: host)
+            }
+        }
+    }
+
+    private func confirmPushZmx(host: String) -> Bool {
+        let alert = NSAlert()
+        alert.alertStyle = .informational
+        alert.messageText = "Enable persistent terminals on \(host)?"
+        alert.informativeText = "Alas can install its zmx helper to ~/.alas/bin on \(host) so terminal sessions survive disconnects and app restarts."
+        alert.addButton(withTitle: "Install zmx")
+        alert.addButton(withTitle: "Not Now")
+        return alert.runModal() == .alertFirstButtonReturn
     }
 
     // MARK: - Pane splits

--- a/Alas/Sources/App/AppState.swift
+++ b/Alas/Sources/App/AppState.swift
@@ -1204,12 +1204,14 @@ final class AppState {
         path: URL,
         displayName: String,
         icon: ProjectIcon,
+        host: String? = nil,
         id: String = UUID().uuidString
     ) async throws {
         let project = try await projectsManager.addProject(
             path: path,
             displayName: displayName,
             icon: icon,
+            host: host,
             id: id
         )
         spacesManager.addProject(project.id, toSpace: spacesManager.activeSpaceId)
@@ -1349,6 +1351,7 @@ final class AppState {
     /// stops any existing watcher for the same project id first.
     func startProjectGitWatcher(for project: ProjectConfig) {
         stopProjectGitWatcher(projectId: project.id)
+        if URL(fileURLWithPath: project.path).isRemoteAlasPath { return }
         let watcher = ProjectGitWatcher(repoPath: URL(fileURLWithPath: project.path))
         let projectId = project.id
         watcher.onHeadChanged = { [weak self] map in

--- a/Alas/Sources/App/ProjectsManager.swift
+++ b/Alas/Sources/App/ProjectsManager.swift
@@ -87,7 +87,13 @@ final class ProjectsManager {
         host: String? = nil,
         id: String = UUID().uuidString
     ) async throws -> ProjectConfig {
-        try Self.ensureNoPathCollision(newRoot: path.path, newHost: host, existing: projects)
+        let worktreeRootsByProject = worktreesByProject.mapValues { $0.map(\.path.path) }
+        try Self.ensureNoPathCollision(
+            newRoot: path.path,
+            newHost: host,
+            existing: projects,
+            existingWorktreeRootsByProject: worktreeRootsByProject
+        )
         if let host {
             try await RemoteRepoValidator.validate(host: host, path: path.path)
         } else {
@@ -127,8 +133,9 @@ final class ProjectsManager {
         )
     }
 
-    func removeProject(id: String) {
-        if let project = projects.first(where: { $0.id == id }), project.host != nil {
+    func removeProject(id: String, unregisterRemoteRoots: Bool = true) {
+        if unregisterRemoteRoots,
+           let project = projects.first(where: { $0.id == id }), project.host != nil {
             RemoteHostRegistry.shared.unregister(root: project.path)
             for worktree in worktreesByProject[id, default: []] {
                 RemoteHostRegistry.shared.unregister(root: worktree.path.path)
@@ -361,11 +368,7 @@ final class ProjectsManager {
         for id in clearOperationIds {
             worktreeOperationStates.removeValue(forKey: id)
         }
-        if let host = project.host {
-            for worktree in reconciled {
-                RemoteHostRegistry.shared.register(root: worktree.path.path, host: host)
-            }
-        }
+        reconcileRemoteHostRegistrations(project: project, previous: previous, reconciled: reconciled)
         worktreesByProject[projectId] = reconciled
         let orderChanged = applyWorktreeOrdering(projectId: projectId)
 
@@ -376,26 +379,40 @@ final class ProjectsManager {
         return orderChanged || projects[idx].hiddenWorktreePaths.count != before
     }
 
+    func reconcileRemoteHostRegistrations(project: ProjectConfig, previous: [Worktree], reconciled: [Worktree]) {
+        guard let host = project.host else { return }
+        let liveRoots = Set(reconciled.map { $0.path.path })
+        for worktree in previous where !liveRoots.contains(worktree.path.path) {
+            RemoteHostRegistry.shared.unregister(root: worktree.path.path)
+        }
+        for worktree in reconciled {
+            RemoteHostRegistry.shared.register(root: worktree.path.path, host: host)
+        }
+    }
+
     /// Remote and local roots must not overlap: a prefix collision would make
     /// host routing ambiguous. Existing local-to-local nesting remains valid.
     nonisolated static func ensureNoPathCollision(
         newRoot: String,
         newHost: String?,
-        existing: [ProjectConfig]
+        existing: [ProjectConfig],
+        existingWorktreeRootsByProject: [String: [String]] = [:]
     ) throws {
         func overlaps(_ lhs: String, _ rhs: String) -> Bool {
             lhs == rhs || lhs.hasPrefix(rhs + "/") || rhs.hasPrefix(lhs + "/")
         }
 
         for project in existing {
-            let bothLocal = newHost == nil && project.host == nil
-            let sameHost = newHost != nil && newHost == project.host
-            if bothLocal || sameHost { continue }
-            if overlaps(newRoot, project.path) {
+            let roots = [project.path] + existingWorktreeRootsByProject[project.id, default: []]
+            for root in roots {
+                let bothLocal = newHost == nil && project.host == nil
+                let sameHost = newHost != nil && newHost == project.host
+                if bothLocal || sameHost { continue }
+                if !overlaps(newRoot, root) { continue }
                 throw NSError(
                     domain: "ProjectsManager",
                     code: 2,
-                    userInfo: [NSLocalizedDescriptionKey: "Path \(newRoot) collides with existing project \(project.name) (\(project.path)). Remote and local project roots must not overlap."]
+                    userInfo: [NSLocalizedDescriptionKey: "Path \(newRoot) collides with existing project \(project.name) (\(root)). Remote and local project roots must not overlap."]
                 )
             }
         }

--- a/Alas/Sources/App/ProjectsManager.swift
+++ b/Alas/Sources/App/ProjectsManager.swift
@@ -63,6 +63,11 @@ final class ProjectsManager {
     ) {
         self.projects = persistedProjects
         self.defaultOrderingSource = defaultOrdering
+        for project in persistedProjects {
+            if let host = project.host {
+                RemoteHostRegistry.shared.register(root: project.path, host: host)
+            }
+        }
     }
 
     /// Replace the live source of the global default sort mode. The closure is
@@ -79,12 +84,18 @@ final class ProjectsManager {
         path: URL,
         displayName: String,
         icon: ProjectIcon,
+        host: String? = nil,
         id: String = UUID().uuidString
     ) async throws -> ProjectConfig {
-        let isRepo = try await git.isGitRepository(path)
-        guard isRepo else {
-            throw NSError(domain: "ProjectsManager", code: 1,
-                          userInfo: [NSLocalizedDescriptionKey: "Not a git repository: \(path.path)"])
+        try Self.ensureNoPathCollision(newRoot: path.path, newHost: host, existing: projects)
+        if let host {
+            try await RemoteRepoValidator.validate(host: host, path: path.path)
+        } else {
+            let isRepo = try await git.isGitRepository(path)
+            guard isRepo else {
+                throw NSError(domain: "ProjectsManager", code: 1,
+                              userInfo: [NSLocalizedDescriptionKey: "Not a git repository: \(path.path)"])
+            }
         }
         let project = ProjectConfig(
             id: id,
@@ -92,8 +103,12 @@ final class ProjectsManager {
             path: path.path,
             color: icon.color,
             addedAt: Date(),
-            icon: icon
+            icon: icon,
+            host: host
         )
+        if let host {
+            RemoteHostRegistry.shared.register(root: path.path, host: host)
+        }
         projects.append(project)
         return project
     }
@@ -113,6 +128,12 @@ final class ProjectsManager {
     }
 
     func removeProject(id: String) {
+        if let project = projects.first(where: { $0.id == id }), project.host != nil {
+            RemoteHostRegistry.shared.unregister(root: project.path)
+            for worktree in worktreesByProject[id, default: []] {
+                RemoteHostRegistry.shared.unregister(root: worktree.path.path)
+            }
+        }
         let ids = Set(worktreesByProject[id, default: []].map(\.id))
         projects.removeAll { $0.id == id }
         worktreesByProject.removeValue(forKey: id)
@@ -340,6 +361,11 @@ final class ProjectsManager {
         for id in clearOperationIds {
             worktreeOperationStates.removeValue(forKey: id)
         }
+        if let host = project.host {
+            for worktree in reconciled {
+                RemoteHostRegistry.shared.register(root: worktree.path.path, host: host)
+            }
+        }
         worktreesByProject[projectId] = reconciled
         let orderChanged = applyWorktreeOrdering(projectId: projectId)
 
@@ -348,6 +374,31 @@ final class ProjectsManager {
         let before = projects[idx].hiddenWorktreePaths.count
         projects[idx].hiddenWorktreePaths.removeAll { !live.contains($0) }
         return orderChanged || projects[idx].hiddenWorktreePaths.count != before
+    }
+
+    /// Remote and local roots must not overlap: a prefix collision would make
+    /// host routing ambiguous. Existing local-to-local nesting remains valid.
+    static func ensureNoPathCollision(
+        newRoot: String,
+        newHost: String?,
+        existing: [ProjectConfig]
+    ) throws {
+        func overlaps(_ lhs: String, _ rhs: String) -> Bool {
+            lhs == rhs || lhs.hasPrefix(rhs + "/") || rhs.hasPrefix(lhs + "/")
+        }
+
+        for project in existing {
+            let bothLocal = newHost == nil && project.host == nil
+            let sameHost = newHost != nil && newHost == project.host
+            if bothLocal || sameHost { continue }
+            if overlaps(newRoot, project.path) {
+                throw NSError(
+                    domain: "ProjectsManager",
+                    code: 2,
+                    userInfo: [NSLocalizedDescriptionKey: "Path \(newRoot) collides with existing project \(project.name) (\(project.path)). Remote and local project roots must not overlap."]
+                )
+            }
+        }
     }
 
     /// Refresh every project. Returns `true` when at least one project's

--- a/Alas/Sources/App/ProjectsManager.swift
+++ b/Alas/Sources/App/ProjectsManager.swift
@@ -378,7 +378,7 @@ final class ProjectsManager {
 
     /// Remote and local roots must not overlap: a prefix collision would make
     /// host routing ambiguous. Existing local-to-local nesting remains valid.
-    static func ensureNoPathCollision(
+    nonisolated static func ensureNoPathCollision(
         newRoot: String,
         newHost: String?,
         existing: [ProjectConfig]

--- a/Alas/Sources/App/RootView.swift
+++ b/Alas/Sources/App/RootView.swift
@@ -473,7 +473,11 @@ private struct RootBaseHandlers: ViewModifier {
             }
         let e = d
             .onReceive(NotificationCenter.default.publisher(for: .alasNewTerminalTab)) { _ in
-                if let wt = selectedWorktree() { _ = try? state.openTerminalTab(for: wt) }
+                if let wt = selectedWorktree() {
+                    Task { @MainActor in
+                        _ = try? await state.openTerminalTabPreparingRemoteZmxIfNeeded(for: wt)
+                    }
+                }
             }
         let f = e
             .onReceive(NotificationCenter.default.publisher(for: .alasCloseTab)) { _ in

--- a/Alas/Sources/Center/CenterPaneView.swift
+++ b/Alas/Sources/Center/CenterPaneView.swift
@@ -68,7 +68,9 @@ struct CenterPaneView: View {
                 onNewTerminal: openTerminal,
                 enabledAgents: state.agentRegistry.enabled(),
                 onLaunchAgent: { agentId in
-                    _ = try? state.openAgentTerminalTab(for: worktree, agentId: agentId)
+                    Task { @MainActor in
+                        _ = try? await state.openAgentTerminalTabPreparingRemoteZmxIfNeeded(for: worktree, agentId: agentId)
+                    }
                 },
                 onLaunchACPSession: { agentId in
                     state.openNewACPSession(agentID: agentId)
@@ -314,6 +316,8 @@ struct CenterPaneView: View {
     }
 
     private func openTerminal() {
-        _ = try? state.openTerminalTab(for: worktree)
+        Task { @MainActor in
+            _ = try? await state.openTerminalTabPreparingRemoteZmxIfNeeded(for: worktree)
+        }
     }
 }

--- a/Alas/Sources/Center/Diff/DiffPaneLSP.swift
+++ b/Alas/Sources/Center/Diff/DiffPaneLSP.swift
@@ -118,9 +118,7 @@ final class DiffPaneLSPDocumentRetain {
         open: Open,
         close: @escaping Close
     ) async throws -> DiffPaneLSPDocumentRetain {
-        let text = try await Task.detached(priority: .userInitiated) {
-            try String(contentsOf: fileURL, encoding: .utf8)
-        }.value
+        let text = try await fileText(at: fileURL)
         let client = await open(worktreeRoot, fileURL, language, text)
         return DiffPaneLSPDocumentRetain(
             worktreeRoot: worktreeRoot,
@@ -135,6 +133,20 @@ final class DiffPaneLSPDocumentRetain {
         guard !didClose else { return }
         didClose = true
         await closeDocument(worktreeRoot, fileURL, language)
+    }
+
+    fileprivate static func fileText(at fileURL: URL) async throws -> String {
+        if let host = RemoteHostRegistry.shared.host(forPath: fileURL.path) {
+            guard case let .file(data, _) = try await RemoteFileAccess.read(host: host, path: fileURL.path),
+                  let text = String(data: data, encoding: .utf8)
+            else {
+                throw CocoaError(.fileReadInapplicableStringEncoding)
+            }
+            return text
+        }
+        return try await Task.detached(priority: .userInitiated) {
+            try String(contentsOf: fileURL, encoding: .utf8)
+        }.value
     }
 
     deinit {
@@ -351,16 +363,17 @@ final class DiffPaneLSPController {
         let fileURL = context.fileURL
         let lineNumber = match.position.line
         let sourceText = match.sourceText
-        let diskMatches = await Task.detached(priority: .userInitiated) {
-            guard let text = try? String(contentsOf: fileURL, encoding: .utf8) else {
-                return false
-            }
+        let diskMatches: Bool
+        do {
+            let text = try await DiffPaneLSPDocumentRetain.fileText(at: fileURL)
             let lines = text.split(separator: "\n", omittingEmptySubsequences: false)
             guard lineNumber >= 0, lineNumber < lines.count else {
                 return false
             }
-            return String(lines[lineNumber]) == sourceText
-        }.value
+            diskMatches = String(lines[lineNumber]) == sourceText
+        } catch {
+            diskMatches = false
+        }
         guard diskMatches else { return false }
         if let lspMatches = context.lsp.openedDocumentLineMatches(
             forFile: fileURL,

--- a/Alas/Sources/Center/DiffOpenFileAvailability.swift
+++ b/Alas/Sources/Center/DiffOpenFileAvailability.swift
@@ -5,8 +5,10 @@ enum DiffOpenFileAvailability: Equatable {
     case available
     case unavailable(reason: String)
 
-    /// True when the file exists on disk and is not a directory.
+    /// True when the file can be opened by the editor path. Remote worktrees are
+    /// loaded over SSH, so local filesystem existence is not a useful gate.
     static func isAvailable(worktreePath: URL, relativePath: String) -> Bool {
+        if worktreePath.isRemoteAlasPath { return true }
         let absolute = worktreePath.appendingPathComponent(relativePath)
         var isDir: ObjCBool = false
         let exists = FileManager.default.fileExists(atPath: absolute.path, isDirectory: &isDir)

--- a/Alas/Sources/Center/DiffTabView.swift
+++ b/Alas/Sources/Center/DiffTabView.swift
@@ -386,13 +386,9 @@ struct DiffTabView: View {
                 tracked: tracked,
                 untrackedMode: untrackedMode
             )
-            let tmp = FileManager.default.temporaryDirectory
-                .appendingPathComponent("alas-stage-\(UUID().uuidString).patch")
-            defer { try? FileManager.default.removeItem(at: tmp) }
             var didFail = false
             do {
-                try patch.write(to: tmp, atomically: true, encoding: .utf8)
-                let result = try await Process.git(["apply", "--cached", tmp.path], cwd: worktreePath)
+                let result = try await Process.git(["apply", "--cached", "-"], cwd: worktreePath, stdin: patch)
                 if result.exitCode != 0 {
                     self.error = result.stderr.trimmingCharacters(in: .whitespacesAndNewlines)
                     didFail = true

--- a/Alas/Sources/Center/ImagePreviewTabView.swift
+++ b/Alas/Sources/Center/ImagePreviewTabView.swift
@@ -138,8 +138,12 @@ struct ImagePreviewTabView: View {
             do {
                 switch try await RemoteFileAccess.read(host: host, path: url.path) {
                 case let .file(contents, _): data = contents
-                case .missing, .directory: loadState = .missing; return
-                case .unreadable: loadState = .decodeFailed; return
+                case .missing, .directory, .symlink:
+                    loadState = .missing
+                    return
+                case .unreadable:
+                    loadState = .decodeFailed
+                    return
                 }
             } catch {
                 loadState = .missing
@@ -172,7 +176,6 @@ struct ImagePreviewTabView: View {
         }
         return CGSize(width: cgImage.width, height: cgImage.height)
     }
-
 }
 
 private enum LoadState {

--- a/Alas/Sources/Center/ImagePreviewTabView.swift
+++ b/Alas/Sources/Center/ImagePreviewTabView.swift
@@ -15,7 +15,7 @@ struct ImagePreviewTabView: View {
         }
         .background(theme.color("bg-1"))
         .task(id: absoluteURL) {
-            loadImage()
+            await loadImage()
         }
     }
 
@@ -124,7 +124,7 @@ struct ImagePreviewTabView: View {
         worktreePath.appendingPathComponent(relativePath)
     }
 
-    private func loadImage() {
+    private func loadImage() async {
         loadState = .loading
 
         guard ImageFileType.isSupported(relativePath: relativePath) else {
@@ -133,12 +133,27 @@ struct ImagePreviewTabView: View {
         }
 
         let url = absoluteURL
-        guard FileManager.default.fileExists(atPath: url.path) else {
-            loadState = .missing
-            return
+        let data: Data
+        if let host = RemoteHostRegistry.shared.host(forPath: url.path) {
+            do {
+                switch try await RemoteFileAccess.read(host: host, path: url.path) {
+                case let .file(contents, _): data = contents
+                case .missing, .directory: loadState = .missing; return
+                case .unreadable: loadState = .decodeFailed; return
+                }
+            } catch {
+                loadState = .missing
+                return
+            }
+        } else {
+            guard FileManager.default.fileExists(atPath: url.path), let contents = try? Data(contentsOf: url) else {
+                loadState = .missing
+                return
+            }
+            data = contents
         }
 
-        guard let image = NSImage(contentsOf: url) else {
+        guard let image = NSImage(data: data) else {
             loadState = .decodeFailed
             return
         }
@@ -146,7 +161,7 @@ struct ImagePreviewTabView: View {
         loadState = .loaded(ImagePreviewInfo(
             image: image,
             pixelSize: pixelSize(for: image),
-            byteCount: byteCount(for: url)
+            byteCount: Int64(data.count)
         ))
     }
 
@@ -158,11 +173,6 @@ struct ImagePreviewTabView: View {
         return CGSize(width: cgImage.width, height: cgImage.height)
     }
 
-    private func byteCount(for url: URL) -> Int64? {
-        guard let values = try? url.resourceValues(forKeys: [.fileSizeKey]),
-              let size = values.fileSize else { return nil }
-        return Int64(size)
-    }
 }
 
 private enum LoadState {

--- a/Alas/Sources/Center/TabsManager.swift
+++ b/Alas/Sources/Center/TabsManager.swift
@@ -1211,7 +1211,7 @@ final class TabsManager {
             return existing
         }
         let buffer: EditorBuffer
-        if let lsp, !worktreeRoot.isRemoteAlasPath {
+        if let lsp {
             buffer = EditorBuffer(
                 worktreeRoot: worktreeRoot,
                 relativePath: relativePath,
@@ -1622,6 +1622,40 @@ final class TabsManager {
         return errors
     }
 
+    @discardableResult
+    func saveAllAwaitingRemote(worktreeRoots: [String: URL] = [:]) async -> [(tabId: TabID, error: Error)] {
+        var errors: [(TabID, Error)] = []
+        var saved = Set<ObjectIdentifier>()
+        for (tabId, key) in bufferKeys {
+            guard let buffer = buffers[key], buffer.dirty else { continue }
+            let id = ObjectIdentifier(buffer)
+            guard !saved.contains(id) else { continue }
+            saved.insert(id)
+            do {
+                try await buffer.saveRecordingErrorAwaitingRemote()
+            } catch {
+                errors.append((tabId, error))
+            }
+        }
+        for (worktreeId, file) in byWorktree {
+            guard let root = worktreeRoots[worktreeId] else { continue }
+            for tab in file.tabs {
+                guard case .editor(let state) = tab,
+                      peekBuffer(tabId: state.id) == nil,
+                      (try? bufferStore.read(worktreeId: worktreeId, tabId: state.id)) != nil else { continue }
+                guard let buffer = materializeSnapshotBufferForSave(worktreeId: worktreeId, tabId: state.id, worktreeRoot: root, relativePath: state.relativePath) else { continue }
+                do {
+                    try await buffer.saveRecordingErrorAwaitingRemote()
+                    buffer.close(persistDirtySnapshot: false)
+                } catch {
+                    errors.append((state.id, error))
+                    buffer.close(persistDirtySnapshot: true)
+                }
+            }
+        }
+        return errors
+    }
+
     /// Save all unsaved buffers for a single worktree. Mirrors the snapshot-
     /// materialize pattern from `saveAll(worktreeRoots:)` but scoped to one
     /// worktree so archive/delete can save before teardown.
@@ -1652,6 +1686,41 @@ final class TabsManager {
             guard let buffer = materializeSnapshotBufferForSave(worktreeId: worktreeId, tabId: state.id, worktreeRoot: root, relativePath: state.relativePath) else { continue }
             do {
                 try buffer.saveRecordingError()
+                buffer.close(persistDirtySnapshot: false)
+            } catch {
+                errors.append((state.id, error))
+                buffer.close(persistDirtySnapshot: true)
+            }
+        }
+        return errors
+    }
+
+    @discardableResult
+    func saveAllUnsavedAwaitingRemote(forWorktree worktreeId: String, root: URL) async -> [(tabId: TabID, error: Error)] {
+        var errors: [(TabID, Error)] = []
+        var saved = Set<ObjectIdentifier>()
+        // Pass 1: live dirty buffers belonging to this worktree.
+        for (tabId, key) in bufferKeys {
+            guard key.worktreeId == worktreeId,
+                  let buffer = buffers[key], buffer.dirty else { continue }
+            let id = ObjectIdentifier(buffer)
+            guard !saved.contains(id) else { continue }
+            saved.insert(id)
+            do {
+                try await buffer.saveRecordingErrorAwaitingRemote()
+            } catch {
+                errors.append((tabId, error))
+            }
+        }
+        // Pass 2: editor tabs with no live buffer but a persisted snapshot.
+        guard let file = byWorktree[worktreeId] else { return errors }
+        for tab in file.tabs {
+            guard case .editor(let state) = tab,
+                  peekBuffer(tabId: state.id) == nil,
+                  (try? bufferStore.read(worktreeId: worktreeId, tabId: state.id)) != nil else { continue }
+            guard let buffer = materializeSnapshotBufferForSave(worktreeId: worktreeId, tabId: state.id, worktreeRoot: root, relativePath: state.relativePath) else { continue }
+            do {
+                try await buffer.saveRecordingErrorAwaitingRemote()
                 buffer.close(persistDirtySnapshot: false)
             } catch {
                 errors.append((state.id, error))

--- a/Alas/Sources/Center/TabsManager.swift
+++ b/Alas/Sources/Center/TabsManager.swift
@@ -1211,7 +1211,7 @@ final class TabsManager {
             return existing
         }
         let buffer: EditorBuffer
-        if let lsp {
+        if let lsp, !worktreeRoot.isRemoteAlasPath {
             buffer = EditorBuffer(
                 worktreeRoot: worktreeRoot,
                 relativePath: relativePath,

--- a/Alas/Sources/Code/Editor/EditorBuffer.swift
+++ b/Alas/Sources/Code/Editor/EditorBuffer.swift
@@ -16,11 +16,17 @@ import Observation
 final class EditorBuffer {
     enum SaveError: LocalizedError {
         case loadPending
+        case remoteSaveRequiresAwait
+        case remoteSaveConflict
 
         var errorDescription: String? {
             switch self {
             case .loadPending:
                 "File is still loading. Try saving again after it finishes."
+            case .remoteSaveRequiresAwait:
+                "Remote saves must finish before this action can continue."
+            case .remoteSaveConflict:
+                "The remote file changed before the save completed."
             }
         }
     }
@@ -91,12 +97,19 @@ final class EditorBuffer {
     private var watcherFD: Int32 = -1
     @ObservationIgnored
     private let remoteHost: String?
+    var isRemote: Bool { remoteHost != nil }
     @ObservationIgnored
     private var remotePollTask: Task<Void, Never>?
     @ObservationIgnored
     private static let remoteConflictPollNanos: UInt64 = 15 * 1_000_000_000
     @ObservationIgnored
     private var remoteLoadGeneration = 0
+    @ObservationIgnored
+    private var remoteSaveGeneration = 0
+    @ObservationIgnored
+    private var remoteSaveInFlight = false
+    @ObservationIgnored
+    private var remoteOverwriteAfterConflict = false
     @ObservationIgnored
     private var restoredRemoteSnapshot = false
     @ObservationIgnored
@@ -765,11 +778,16 @@ final class EditorBuffer {
 
     func resolveConflictKeepingMine() {
         if let host = remoteHost {
+            remoteOverwriteAfterConflict = true
+            let mtimeProbeGeneration = remoteSaveGeneration
             let path = absoluteFileURL.path
             Task { @MainActor [weak self] in
                 do {
                     if let mtime = try await RemoteFileAccess.mtime(host: host, path: path) {
-                        self?.originalMtime = mtime
+                        guard let self,
+                              self.remoteSaveGeneration == mtimeProbeGeneration,
+                              self.remoteOverwriteAfterConflict else { return }
+                        self.originalMtime = mtime
                     }
                     RemoteHostStatusStore.shared.reportSuccess(host: host)
                 } catch {
@@ -810,10 +828,31 @@ final class EditorBuffer {
         case .clean, .ready:
             break
         }
+        if remoteHost != nil {
+            throw SaveError.remoteSaveRequiresAwait
+        }
+        try saveLocal()
+    }
+
+    func saveAwaitingRemote() async throws {
+        lastSaveError = nil
+        guard !readOnly else { return }
+        switch saveDisposition {
+        case .blockedByLoad:
+            throw SaveError.loadPending
+        case .clean where isLoading:
+            return
+        case .clean, .ready:
+            break
+        }
         if let host = remoteHost {
-            saveRemote(host: host)
+            try await saveRemote(host: host)
             return
         }
+        try saveLocal()
+    }
+
+    private func saveLocal() throws {
         let url = worktreeRoot.appendingPathComponent(relativePath)
         if dirty,
            let onDiskMtime = (try? FileManager.default.attributesOfItem(atPath: url.path)[.modificationDate]) as? Date,
@@ -831,49 +870,92 @@ final class EditorBuffer {
         notifyDidSave(url: url)
     }
 
-    /// Remote writes must not block the main actor. The visible state moves to
-    /// clean immediately, then rolls back to the pre-save baseline if the
-    /// mtime gate or write fails.
-    private func saveRemote(host: String) {
+    /// Remote writes must not block the main actor. Keep the buffer dirty and
+    /// its hot-exit snapshot intact until the SSH write is confirmed.
+    private func saveRemote(host: String) async throws {
+        remoteSaveGeneration += 1
+        let generation = remoteSaveGeneration
         let canonical = storage.string
         let serialized = lineEnding.normalize(canonical)
-        let priorOriginalText = originalText
-        let baseline = originalMtime
+        var priorOriginalText = originalText
         let path = absoluteFileURL.path
 
-        originalText = canonical
-        discardSnapshot()
-        notifyDidSave(url: absoluteFileURL)
+        do {
+            while remoteSaveInFlight {
+                try await Task.sleep(nanoseconds: 25_000_000)
+                guard remoteSaveGeneration == generation else { return }
+            }
+            guard remoteSaveGeneration == generation else { return }
+            remoteSaveInFlight = true
+            defer {
+                remoteSaveInFlight = false
+            }
 
-        Task { @MainActor [weak self] in
-            do {
-                let remoteMtime = try await RemoteFileAccess.mtime(host: host, path: path)
+            try await verifyRemoteFileContained(host: host, path: path)
+            priorOriginalText = originalText
+            let baseline = originalMtime
+            let remoteMtime = try await RemoteFileAccess.mtime(host: host, path: path)
+            let shouldOverwriteConflict = remoteOverwriteAfterConflict
+            if !shouldOverwriteConflict {
                 switch RemoteSaveGate.decision(
                     originalMtime: baseline,
                     remoteMtime: remoteMtime
                 ) {
                 case .conflict:
-                    self?.rollbackRemoteSave(to: priorOriginalText, conflict: .changedOnDisk)
-                    return
-                case .proceed, .targetDeleted:
+                    guard remoteSaveGeneration == generation else { return }
+                    rollbackRemoteSave(to: priorOriginalText, conflict: .changedOnDisk)
+                    throw SaveError.remoteSaveConflict
+                case .targetDeleted:
+                    guard remoteSaveGeneration == generation else { return }
+                    rollbackRemoteSave(to: priorOriginalText, conflict: .deletedOnDisk)
+                    throw SaveError.remoteSaveConflict
+                case .proceed:
                     break
                 }
-
-                let newMtime = try await RemoteFileAccess.write(
-                    host: host,
-                    path: path,
-                    content: serialized
-                )
-                guard let self else { return }
-                self.originalMtime = newMtime
-                RemoteHostStatusStore.shared.reportSuccess(host: host)
-            } catch {
-                guard let self else { return }
-                if case .connectionFailed = error as? RemoteFileAccessError {
-                    RemoteHostStatusStore.shared.reportConnectionFailure(host: host)
+                if RemoteSaveGate.requiresContentCheck(originalMtime: baseline, remoteMtime: remoteMtime) {
+                    guard try await remoteContentsStillMatchBaseline(host: host, path: path, baseline: priorOriginalText) else {
+                        guard remoteSaveGeneration == generation else { return }
+                        rollbackRemoteSave(to: priorOriginalText, conflict: .changedOnDisk)
+                        throw SaveError.remoteSaveConflict
+                    }
                 }
-                self.rollbackRemoteSave(to: priorOriginalText, error: error)
             }
+
+            let newMtime = try await RemoteFileAccess.write(
+                host: host,
+                path: path,
+                content: serialized
+            )
+            guard remoteSaveGeneration == generation else {
+                originalText = canonical
+                originalMtime = newMtime
+                RemoteHostStatusStore.shared.reportSuccess(host: host)
+                return
+            }
+            originalText = canonical
+            originalMtime = newMtime
+            remoteOverwriteAfterConflict = false
+            discardSnapshot()
+            notifyDidSave(url: absoluteFileURL)
+            RemoteHostStatusStore.shared.reportSuccess(host: host)
+        } catch {
+            if case .connectionFailed = error as? RemoteFileAccessError {
+                RemoteHostStatusStore.shared.reportConnectionFailure(host: host)
+            }
+            rollbackRemoteSave(to: priorOriginalText, error: error)
+            throw error
+        }
+    }
+
+    private func remoteContentsStillMatchBaseline(host: String, path: String, baseline: String) async throws -> Bool {
+        switch try await RemoteFileAccess.read(host: host, path: path) {
+        case let .file(data, _):
+            guard let remoteText = String(data: data, encoding: .utf8) else { return false }
+            return remoteText == lineEnding.normalize(baseline)
+        case .missing:
+            return false
+        case .directory, .symlink, .unreadable:
+            return false
         }
     }
 
@@ -971,6 +1053,93 @@ final class EditorBuffer {
             }
             notifyDidClose(url: oldURL)
             notifyDidOpen()
+            onPathChanged?(oldURLRelativePath(from: oldURL), newRelativePath)
+            startWatching()
+        } catch {
+            startWatching()
+            throw error
+        }
+    }
+
+    func saveAsRemote(relativePath newRelativePath: String) async throws {
+        guard let host = remoteHost else { throw remotePathOperationError() }
+        guard !readOnly else { return }
+        guard shouldFollowPathChange?(relativePath, newRelativePath) ?? true else {
+            throw CocoaError(.fileWriteFileExists)
+        }
+        lastSaveError = nil
+        let oldURL = absoluteFileURL
+        let newURL = worktreeRoot.appendingPathComponent(newRelativePath)
+        let canonical = storage.string
+        stopWatching()
+        languageReopenTask?.cancel()
+        languageReopenTask = nil
+        do {
+            try await verifyRemoteFileContained(host: host, path: newURL.path)
+            let available = try await RemoteExec.run(
+                host: host, cwd: nil,
+                command: "p=\(SSHCommand.shellQuote(newURL.path)); [ ! -e \"$p\" ] && [ ! -L \"$p\" ]",
+                timeout: 15
+            )
+            guard available.exitCode == 0 else {
+                throw CocoaError(.fileWriteFileExists)
+            }
+            let mkdir = try await RemoteExec.run(
+                host: host, cwd: nil,
+                command: RemoteFileOps.mkdirCommand(parentOf: newURL.path), timeout: 15
+            )
+            guard mkdir.exitCode == 0 else {
+                throw NSError(domain: "EditorBuffer", code: 101, userInfo: [
+                    NSLocalizedDescriptionKey: "Could not create the remote directory: \(mkdir.stderr)"
+                ])
+            }
+            let mtime = try await RemoteFileAccess.write(
+                host: host, path: newURL.path, content: lineEnding.normalize(canonical)
+            )
+            relativePath = newRelativePath
+            language = lsp?.language(forFileExtension: (newRelativePath as NSString).pathExtension)
+            originalText = canonical
+            originalMtime = mtime
+            discardSnapshot()
+            notifyDidClose(url: oldURL)
+            notifyDidOpen(url: newURL, text: canonical)
+            notifyDidSave(url: newURL)
+            onPathChanged?(oldURLRelativePath(from: oldURL), newRelativePath)
+            startWatching()
+        } catch {
+            startWatching()
+            throw error
+        }
+    }
+
+    func moveToRemote(relativePath newRelativePath: String) async throws {
+        guard let host = remoteHost else { throw remotePathOperationError() }
+        guard !readOnly else { return }
+        guard shouldFollowPathChange?(relativePath, newRelativePath) ?? true else {
+            throw CocoaError(.fileWriteFileExists)
+        }
+        lastSaveError = nil
+        let oldURL = absoluteFileURL
+        let newURL = worktreeRoot.appendingPathComponent(newRelativePath)
+        stopWatching()
+        languageReopenTask?.cancel()
+        languageReopenTask = nil
+        do {
+            try await verifyRemoteFileContained(host: host, path: newURL.path)
+            let moved = try await RemoteExec.run(
+                host: host, cwd: nil,
+                command: RemoteFileOps.moveCommand(from: oldURL.path, to: newURL.path), timeout: 15
+            )
+            guard moved.exitCode == 0 else {
+                throw NSError(domain: "EditorBuffer", code: 102, userInfo: [
+                    NSLocalizedDescriptionKey: "Could not move the remote file: \(moved.stderr)"
+                ])
+            }
+            relativePath = newRelativePath
+            language = lsp?.language(forFileExtension: (newRelativePath as NSString).pathExtension)
+            if dirty { snapshotNow() } else { discardSnapshot() }
+            notifyDidClose(url: oldURL)
+            notifyDidOpen(url: newURL, text: storage.string)
             onPathChanged?(oldURLRelativePath(from: oldURL), newRelativePath)
             startWatching()
         } catch {
@@ -1266,11 +1435,52 @@ final class EditorBuffer {
         openLSPDocumentIfReady()
     }
 
+    private func notifyDidOpen(url: URL, text: String) {
+        guard remoteHost != nil else {
+            notifyDidOpen()
+            return
+        }
+        guard initialLoadFinished,
+              !isExternal,
+              openedLanguage == nil,
+              let lsp,
+              let effective = effectiveLanguage
+        else { return }
+        openedLanguage = effective
+        let worktreeRoot = worktreeRoot
+        Task { await lsp.openDocument(worktreeRoot: worktreeRoot, fileURL: url, languageId: effective, text: text) }
+    }
+
     func saveRecordingError() throws {
         do {
             try save()
         } catch {
             lastSaveError = (error as NSError).localizedDescription
+            throw error
+        }
+    }
+
+    func saveRecordingErrorAwaitingRemote() async throws {
+        do {
+            try await saveAwaitingRemote()
+        } catch {
+            lastSaveError = (error as NSError).localizedDescription
+            throw error
+        }
+    }
+
+    func saveConflictKeepingMineAwaitingRemote() async throws {
+        let isRemote = remoteHost != nil
+        if isRemote {
+            remoteOverwriteAfterConflict = true
+        }
+        do {
+            try await saveRecordingErrorAwaitingRemote()
+            conflict = nil
+        } catch {
+            if isRemote {
+                remoteOverwriteAfterConflict = false
+            }
             throw error
         }
     }
@@ -1291,11 +1501,11 @@ final class EditorBuffer {
     /// changed while the formatter was in flight.
     func formatAndSave(config: AppConfig.Code, lsp: DocumentFormatter?, formattingTimeoutNanoseconds: UInt64 = 5_000_000_000) async throws {
         guard !readOnly, !isExternal else {
-            try save()
+            try await saveAwaitingRemote()
             return
         }
         guard config.formatOnSave, let lsp else {
-            try save()
+            try await saveAwaitingRemote()
             return
         }
         // Prefer the user's runtime override, then whatever the server
@@ -1309,7 +1519,7 @@ final class EditorBuffer {
             ?? language
             ?? lsp.language(forFileExtension: ((relativePath as NSString).pathExtension))
         guard let resolvedLanguage else {
-            try save()
+            try await saveAwaitingRemote()
             return
         }
         let generation = editGeneration
@@ -1319,20 +1529,20 @@ final class EditorBuffer {
         let options = LSPFormattingOptions(tabSize: 4, insertSpaces: true)
         let edits: [LSPTextEdit]? = await requestFormatting(lsp: lsp, url: url, language: resolvedLanguage, options: options, timeoutNanoseconds: formattingTimeoutNanoseconds)
         guard editGeneration == generation else {
-            try save()
+            try await saveAwaitingRemote()
             return
         }
         guard let edits, !edits.isEmpty else {
-            try save()
+            try await saveAwaitingRemote()
             return
         }
         guard applyFormattingEdits(edits) else {
-            try save()
+            try await saveAwaitingRemote()
             return
         }
         let formattedText = storage.string
         await lsp.didChange(worktreeRoot: worktreeRoot, fileURL: url, languageId: resolvedLanguage, text: formattedText, edits: nil)
-        try save()
+        try await saveAwaitingRemote()
     }
 
     private func requestFormatting(lsp: DocumentFormatter, url: URL, language: String, options: LSPFormattingOptions, timeoutNanoseconds: UInt64) async -> [LSPTextEdit]? {
@@ -1414,11 +1624,10 @@ final class EditorBuffer {
         originalText = snap.originalText
         originalMtime = snap.originalMtime
         lineEnding = snap.lineEnding
-        // Remote buffers need a successful async read before becoming editable.
-        // Keep a restored draft intact until that read establishes whether its
-        // on-host baseline changed while the app was closed.
+        // Keep restored remote drafts dirty until async load/save establishes
+        // whether the on-host baseline changed while the app was closed.
         restoredRemoteSnapshot = remoteHost != nil
-        readOnly = remoteHost != nil
+        readOnly = false
         if remoteHost == nil {
             updateOriginalFileIdentityAndPermissions(from: worktreeRoot.appendingPathComponent(snap.relativePath))
         }
@@ -1568,6 +1777,8 @@ final class EditorBuffer {
         Task { @MainActor [weak self] in
             let result: RemoteReadResult
             do {
+                guard let self, self.remoteLoadGeneration == generation else { return }
+                try await self.verifyRemoteFileContained(host: host, path: path)
                 result = try await RemoteFileAccess.read(host: host, path: path)
             } catch {
                 guard let self, self.remoteLoadGeneration == generation else { return }
@@ -1575,7 +1786,7 @@ final class EditorBuffer {
                     RemoteHostStatusStore.shared.reportConnectionFailure(host: host)
                 }
                 if replacingDirty || !self.restoredRemoteSnapshot {
-                    self.setStorageText("(unable to read remote file: host unreachable)")
+                    self.setStorageText("(unable to read remote file: \(Self.remoteFileErrorDescription(error)))")
                 }
                 return
             }
@@ -1587,6 +1798,11 @@ final class EditorBuffer {
                 if replacingDirty || !self.restoredRemoteSnapshot {
                     self.setStorageText("(unable to read file)")
                 }
+            case .symlink:
+                if replacingDirty || !self.restoredRemoteSnapshot {
+                    self.setStorageText("(read-only: remote symbolic links are not editable)")
+                }
+                self.readOnly = true
             case let .unreadable(detail):
                 if replacingDirty || !self.restoredRemoteSnapshot {
                     self.setStorageText("(unable to read remote file: \(detail))")
@@ -1600,21 +1816,61 @@ final class EditorBuffer {
                 }
                 if self.restoredRemoteSnapshot {
                     self.restoredRemoteSnapshot = false
-                    self.readOnly = false
+                    self.markRemoteFileEditable()
                     if self.storage.string != self.originalText, mtime != self.originalMtime {
                         self.conflict = .changedOnDisk
                     }
                     self.startWatching()
+                    self.openRemoteLSPIfNeeded()
                     return
                 }
                 self.withLoadEditTrackingSuppressed {
                     self.applyLoadedText(raw)
                 }
                 self.originalMtime = mtime
-                self.readOnly = false
+                self.markRemoteFileEditable()
                 self.startWatching()
+                self.openRemoteLSPIfNeeded()
             }
         }
+    }
+
+    private func verifyRemoteFileContained(host: String, path: String) async throws {
+        try await RemotePathContainment.verifyRemoteContainment(
+            host: host,
+            path: path,
+            worktreeRoot: worktreeRoot.path
+        )
+    }
+
+    private static func remoteFileErrorDescription(_ error: Error) -> String {
+        switch error {
+        case let RemoteFileAccessError.connectionFailed(detail):
+            return detail.isEmpty ? "host unreachable" : detail
+        case let RemotePathContainment.ContainmentError.outsideWorktree(path):
+            return "path is outside the worktree: \(path)"
+        default:
+            return (error as NSError).localizedDescription
+        }
+    }
+
+    private func markRemoteFileEditable() {
+        // Remote symlinks return `.symlink` before bytes are read, so only
+        // ordinary remote files reach this state transition.
+        readOnly = false
+    }
+
+    private func openRemoteLSPIfNeeded() {
+        guard !isExternal,
+              remoteHost != nil,
+              openedLanguage == nil,
+              let lsp,
+              let language
+        else { return }
+        let url = worktreeRoot.appendingPathComponent(relativePath)
+        openedLanguage = language
+        let text = storage.string
+        Task { await lsp.openDocument(worktreeRoot: worktreeRoot, fileURL: url, languageId: language, text: text) }
     }
 
     /// Load the file from disk, calling `completion` on the main actor

--- a/Alas/Sources/Code/Editor/EditorBuffer.swift
+++ b/Alas/Sources/Code/Editor/EditorBuffer.swift
@@ -90,6 +90,16 @@ final class EditorBuffer {
     @ObservationIgnored
     private var watcherFD: Int32 = -1
     @ObservationIgnored
+    private let remoteHost: String?
+    @ObservationIgnored
+    private var remotePollTask: Task<Void, Never>?
+    @ObservationIgnored
+    private static let remoteConflictPollNanos: UInt64 = 15 * 1_000_000_000
+    @ObservationIgnored
+    private var remoteLoadGeneration = 0
+    @ObservationIgnored
+    private var restoredRemoteSnapshot = false
+    @ObservationIgnored
     private static let watchQueue = DispatchQueue(label: "alas.editor.buffer.watch", qos: .utility)
     @ObservationIgnored
     private var moveLookupTask: Task<MovedFileLookupResult?, Never>?
@@ -253,6 +263,9 @@ final class EditorBuffer {
         self.worktreeRoot = worktreeRoot
         self.relativePath = relativePath
         self.isExternal = isExternal
+        self.remoteHost = RemoteHostRegistry.shared.host(
+            forPath: worktreeRoot.appendingPathComponent(relativePath).path
+        )
         self.storage = NSTextStorage()
         self.store = store
         self.worktreeId = worktreeId
@@ -345,6 +358,7 @@ final class EditorBuffer {
     private func openLSPDocumentIfReady() {
         guard initialLoadFinished,
               !isExternal,
+              remoteHost == nil,
               openedLanguage == nil,
               lspOpenTask == nil,
               let lsp,
@@ -510,6 +524,12 @@ final class EditorBuffer {
     }
 
     func revert() {
+        if let remoteHost {
+            beginRemoteLoad(host: remoteHost, replacingDirty: true)
+            discardSnapshot()
+            handleEdit(edit: nil)
+            return
+        }
         loadFromDisk(preservePendingEdits: false) { [weak self] _ in
             self?.discardSnapshot()
             self?.handleEdit(edit: nil)
@@ -518,6 +538,10 @@ final class EditorBuffer {
 
     func startWatching() {
         stopWatching()
+        if remoteHost != nil {
+            startRemoteConflictPolling()
+            return
+        }
         let path = worktreeRoot.appendingPathComponent(relativePath).path
         let fd = open(path, O_EVTONLY)
         guard fd >= 0 else { return }
@@ -536,10 +560,41 @@ final class EditorBuffer {
     }
 
     func stopWatching() {
+        remotePollTask?.cancel()
+        remotePollTask = nil
         watcherSource?.cancel()
         watcherSource = nil
         watcherFD = -1
         cancelMoveLookup()
+    }
+
+    private func startRemoteConflictPolling() {
+        guard let host = remoteHost else { return }
+        let path = absoluteFileURL.path
+        remotePollTask = Task { @MainActor [weak self] in
+            while !Task.isCancelled {
+                try? await Task.sleep(nanoseconds: Self.remoteConflictPollNanos)
+                guard let self, !Task.isCancelled else { return }
+
+                do {
+                    guard let mtime = try await RemoteFileAccess.mtime(host: host, path: path) else {
+                        if self.dirty { self.conflict = .deletedOnDisk }
+                        continue
+                    }
+                    RemoteHostStatusStore.shared.reportSuccess(host: host)
+                    guard mtime > self.originalMtime else { continue }
+                    if self.dirty {
+                        self.conflict = .changedOnDisk
+                    } else {
+                        self.revert()
+                    }
+                } catch {
+                    if case .connectionFailed = error as? RemoteFileAccessError {
+                        RemoteHostStatusStore.shared.reportConnectionFailure(host: host)
+                    }
+                }
+            }
+        }
     }
 
     private func handleWatcherEvent() {
@@ -569,6 +624,7 @@ final class EditorBuffer {
     }
 
     private func startMoveLookupForMissingFile(at missingURL: URL) {
+        guard remoteHost == nil else { return }
         guard moveLookupTask == nil else { return }
         guard let originalIdentity else {
             markDeletedConflictIfNeeded()
@@ -708,6 +764,23 @@ final class EditorBuffer {
     }
 
     func resolveConflictKeepingMine() {
+        if let host = remoteHost {
+            let path = absoluteFileURL.path
+            Task { @MainActor [weak self] in
+                do {
+                    if let mtime = try await RemoteFileAccess.mtime(host: host, path: path) {
+                        self?.originalMtime = mtime
+                    }
+                    RemoteHostStatusStore.shared.reportSuccess(host: host)
+                } catch {
+                    if case .connectionFailed = error as? RemoteFileAccessError {
+                        RemoteHostStatusStore.shared.reportConnectionFailure(host: host)
+                    }
+                }
+            }
+            conflict = nil
+            return
+        }
         let url = worktreeRoot.appendingPathComponent(relativePath)
         if let mtime = (try? FileManager.default.attributesOfItem(atPath: url.path)[.modificationDate]) as? Date {
             originalMtime = mtime
@@ -737,6 +810,10 @@ final class EditorBuffer {
         case .clean, .ready:
             break
         }
+        if let host = remoteHost {
+            saveRemote(host: host)
+            return
+        }
         let url = worktreeRoot.appendingPathComponent(relativePath)
         if dirty,
            let onDiskMtime = (try? FileManager.default.attributesOfItem(atPath: url.path)[.modificationDate]) as? Date,
@@ -754,10 +831,84 @@ final class EditorBuffer {
         notifyDidSave(url: url)
     }
 
+    /// Remote writes must not block the main actor. The visible state moves to
+    /// clean immediately, then rolls back to the pre-save baseline if the
+    /// mtime gate or write fails.
+    private func saveRemote(host: String) {
+        let canonical = storage.string
+        let serialized = lineEnding.normalize(canonical)
+        let priorOriginalText = originalText
+        let baseline = originalMtime
+        let path = absoluteFileURL.path
+
+        originalText = canonical
+        discardSnapshot()
+        notifyDidSave(url: absoluteFileURL)
+
+        Task { @MainActor [weak self] in
+            do {
+                let remoteMtime = try await RemoteFileAccess.mtime(host: host, path: path)
+                switch RemoteSaveGate.decision(
+                    originalMtime: baseline,
+                    remoteMtime: remoteMtime
+                ) {
+                case .conflict:
+                    self?.rollbackRemoteSave(to: priorOriginalText, conflict: .changedOnDisk)
+                    return
+                case .proceed, .targetDeleted:
+                    break
+                }
+
+                let newMtime = try await RemoteFileAccess.write(
+                    host: host,
+                    path: path,
+                    content: serialized
+                )
+                guard let self else { return }
+                self.originalMtime = newMtime
+                RemoteHostStatusStore.shared.reportSuccess(host: host)
+            } catch {
+                guard let self else { return }
+                if case .connectionFailed = error as? RemoteFileAccessError {
+                    RemoteHostStatusStore.shared.reportConnectionFailure(host: host)
+                }
+                self.rollbackRemoteSave(to: priorOriginalText, error: error)
+            }
+        }
+    }
+
+    private func rollbackRemoteSave(to originalText: String, conflict: Conflict) {
+        self.originalText = originalText
+        self.conflict = conflict
+    }
+
+    private func rollbackRemoteSave(to originalText: String, error: Error) {
+        self.originalText = originalText
+        switch error {
+        case let RemoteFileAccessError.connectionFailed(detail):
+            lastSaveError = "Unable to save remote file: \(detail)"
+        case let RemoteFileAccessError.writeFailed(detail):
+            lastSaveError = "Unable to save remote file: \(detail)"
+        default:
+            lastSaveError = (error as NSError).localizedDescription
+        }
+    }
+
+    private func remotePathOperationError() -> NSError {
+        NSError(
+            domain: "EditorBuffer",
+            code: 100,
+            userInfo: [
+                NSLocalizedDescriptionKey: "Renaming or moving files is not yet supported for remote projects."
+            ]
+        )
+    }
+
     func saveAs(relativePath newRelativePath: String) throws {
         lastSaveError = nil
         guard !readOnly else { return }
         guard !isLoading else { throw SaveError.loadPending }
+        if remoteHost != nil { throw remotePathOperationError() }
         guard shouldFollowPathChange?(relativePath, newRelativePath) ?? true else {
             throw CocoaError(.fileWriteFileExists)
         }
@@ -790,6 +941,7 @@ final class EditorBuffer {
         lastSaveError = nil
         guard !readOnly else { return }
         guard !isLoading else { throw SaveError.loadPending }
+        if remoteHost != nil { throw remotePathOperationError() }
         guard shouldFollowPathChange?(relativePath, newRelativePath) ?? true else {
             throw CocoaError(.fileWriteFileExists)
         }
@@ -858,6 +1010,7 @@ final class EditorBuffer {
     }
 
     private func renameItem(at oldURL: URL, to newURL: URL) throws {
+        if remoteHost != nil { throw remotePathOperationError() }
         guard oldURL.path != newURL.path else { return }
         if Darwin.rename(oldURL.path, newURL.path) != 0 {
             throw POSIXError(POSIXErrorCode(rawValue: errno) ?? .EIO)
@@ -1261,8 +1414,14 @@ final class EditorBuffer {
         originalText = snap.originalText
         originalMtime = snap.originalMtime
         lineEnding = snap.lineEnding
-        readOnly = false
-        updateOriginalFileIdentityAndPermissions(from: worktreeRoot.appendingPathComponent(snap.relativePath))
+        // Remote buffers need a successful async read before becoming editable.
+        // Keep a restored draft intact until that read establishes whether its
+        // on-host baseline changed while the app was closed.
+        restoredRemoteSnapshot = remoteHost != nil
+        readOnly = remoteHost != nil
+        if remoteHost == nil {
+            updateOriginalFileIdentityAndPermissions(from: worktreeRoot.appendingPathComponent(snap.relativePath))
+        }
     }
 
     private func replayPendingUserEdits(_ edits: [EditorTextEdit], fallbackText: String) {
@@ -1366,6 +1525,7 @@ final class EditorBuffer {
     /// user's snapshot is "their version" against a moved baseline — show
     /// the conflict banner. Called on first display after restore.
     func checkForConflictOnRestore() {
+        if remoteHost != nil { return }
         let url = worktreeRoot.appendingPathComponent(relativePath)
         guard FileManager.default.fileExists(atPath: url.path) else {
             if dirty { conflict = .deletedOnDisk }
@@ -1377,17 +1537,106 @@ final class EditorBuffer {
         }
     }
 
+    private var absoluteFileURL: URL {
+        worktreeRoot.appendingPathComponent(relativePath)
+    }
+
+    private func setStorageText(_ text: String) {
+        withLoadEditTrackingSuppressed {
+            storage.setAttributedString(NSAttributedString(string: text))
+        }
+    }
+
+    private func applyLoadedText(_ raw: String) {
+        let detected = LineEnding.detect(in: raw)
+        let canonical = LineEnding.lf.normalize(raw)
+        storage.setAttributedString(NSAttributedString(string: canonical))
+        originalText = canonical
+        lineEnding = detected
+    }
+
+    private func beginRemoteLoad(host: String, replacingDirty: Bool) {
+        remoteLoadGeneration &+= 1
+        let generation = remoteLoadGeneration
+        let path = absoluteFileURL.path
+        if replacingDirty {
+            restoredRemoteSnapshot = false
+        }
+        setStorageText("(loading remote file...)")
+        readOnly = true
+
+        Task { @MainActor [weak self] in
+            let result: RemoteReadResult
+            do {
+                result = try await RemoteFileAccess.read(host: host, path: path)
+            } catch {
+                guard let self, self.remoteLoadGeneration == generation else { return }
+                if case .connectionFailed = error as? RemoteFileAccessError {
+                    RemoteHostStatusStore.shared.reportConnectionFailure(host: host)
+                }
+                if replacingDirty || !self.restoredRemoteSnapshot {
+                    self.setStorageText("(unable to read remote file: host unreachable)")
+                }
+                return
+            }
+
+            guard let self, self.remoteLoadGeneration == generation else { return }
+            RemoteHostStatusStore.shared.reportSuccess(host: host)
+            switch result {
+            case .missing, .directory:
+                if replacingDirty || !self.restoredRemoteSnapshot {
+                    self.setStorageText("(unable to read file)")
+                }
+            case let .unreadable(detail):
+                if replacingDirty || !self.restoredRemoteSnapshot {
+                    self.setStorageText("(unable to read remote file: \(detail))")
+                }
+            case let .file(data, mtime):
+                guard let raw = String(data: data, encoding: .utf8) else {
+                    if replacingDirty || !self.restoredRemoteSnapshot {
+                        self.setStorageText("(read-only: file is not valid UTF-8)")
+                    }
+                    return
+                }
+                if self.restoredRemoteSnapshot {
+                    self.restoredRemoteSnapshot = false
+                    self.readOnly = false
+                    if self.storage.string != self.originalText, mtime != self.originalMtime {
+                        self.conflict = .changedOnDisk
+                    }
+                    self.startWatching()
+                    return
+                }
+                self.withLoadEditTrackingSuppressed {
+                    self.applyLoadedText(raw)
+                }
+                self.originalMtime = mtime
+                self.readOnly = false
+                self.startWatching()
+            }
+        }
+    }
+
     /// Load the file from disk, calling `completion` on the main actor
     /// when the content has been applied. The file read happens in a
     /// `Task.detached` so the main thread isn't blocked by
     /// `String(contentsOf:)` on large files.
     private func loadFromDisk(
         preservePendingEdits: Bool = false,
+        replacingDirty: Bool = false,
         notifyAfterLoad: Bool = true,
         hasPendingSnapshot: Bool = false,
         completion: @escaping @MainActor (LoadState.Pending?) -> Void
     ) {
-        let url = worktreeRoot.appendingPathComponent(relativePath)
+        if let remoteHost {
+            let generation = beginAsyncLoad(hasPendingSnapshot: hasPendingSnapshot)
+            beginRemoteLoad(host: remoteHost, replacingDirty: replacingDirty)
+            if let pending = acceptLoadCompletion(generation: generation) {
+                completion(preservePendingEdits ? pending : nil)
+            }
+            return
+        }
+        let url = absoluteFileURL
         let resolvedURL = url.resolvingSymlinksInPath()
         let isExternal = self.isExternal
         let generation = beginAsyncLoad(hasPendingSnapshot: hasPendingSnapshot)
@@ -1493,7 +1742,7 @@ final class EditorBuffer {
 
     @discardableResult
     private func loadFromDiskSync() -> Self {
-        let url = worktreeRoot.appendingPathComponent(relativePath)
+        let url = absoluteFileURL
         let resolvedURL = url.resolvingSymlinksInPath()
         guard FileManager.default.fileExists(atPath: resolvedURL.path) else {
             withLoadEditTrackingSuppressed {

--- a/Alas/Sources/Code/Editor/EditorConflictBanner.swift
+++ b/Alas/Sources/Code/Editor/EditorConflictBanner.swift
@@ -23,12 +23,13 @@ struct EditorConflictBanner: View {
                 row(
                     message: "File was deleted on disk.",
                     primary: ("Save anyway", {
-                        do {
-                            try buffer.saveRecordingError()
-                            buffer.resolveConflictKeepingMine()
-                        } catch {
-                            // saveRecordingError() already set lastSaveError; leave the
-                            // conflict in place so the user can retry.
+                        Task { @MainActor in
+                            do {
+                                try await buffer.saveConflictKeepingMineAwaitingRemote()
+                            } catch {
+                                // saveConflictKeepingMineAwaitingRemote() already set lastSaveError;
+                                // leave the conflict in place so the user can retry.
+                            }
                         }
                     }),
                     secondary: ("Keep mine", { buffer.resolveConflictKeepingMine() })

--- a/Alas/Sources/Code/LSP/WorkspaceLSPManager.swift
+++ b/Alas/Sources/Code/LSP/WorkspaceLSPManager.swift
@@ -210,7 +210,18 @@ final class WorkspaceLSPManager: DocumentFormatter {
         ownership: DocumentOwnership
     ) async -> LSPClient? {
         guard let entry = registry.entry(forLanguage: languageId) else { return nil }
-        let lspRoot = Self.resolveLSPRoot(fileURL: fileURL, worktreeRoot: worktreeRoot, markers: entry.rootMarkers)
+        let remoteHost = RemoteHostRegistry.shared.host(forPath: worktreeRoot.path)
+        let lspRoot: URL
+        if let remoteHost {
+            lspRoot = await Self.resolveRemoteLSPRoot(
+                fileURL: fileURL,
+                worktreeRoot: worktreeRoot,
+                markers: entry.rootMarkers,
+                host: remoteHost
+            )
+        } else {
+            lspRoot = Self.resolveLSPRoot(fileURL: fileURL, worktreeRoot: worktreeRoot, markers: entry.rootMarkers)
+        }
         let key = Key(root: lspRoot.path, command: entry.command, args: entry.args, env: entry.env)
         let uri = fileURL.lspURI
         var shouldReplaceTemporaryText = false
@@ -261,20 +272,27 @@ final class WorkspaceLSPManager: DocumentFormatter {
         } else {
             addPendingOpenRef(key: key, uri: uri, ownership: ownership)
             let availability = makeAvailability()
-            switch await availability.statusRemediatingGatekeeper(for: entry) {
-            case .disabled, .notInstalled:
-                _ = consumePendingOpenRef(key: key, uri: uri, ownership: ownership)
-                return nil
-            case .blockedByGatekeeper(let realPath):
-                _ = consumePendingOpenRef(key: key, uri: uri, ownership: ownership)
-                NotificationCenter.default.post(
-                    name: .lspBlockedByGatekeeper,
-                    object: nil,
-                    userInfo: ["language": entry.language, "realPath": realPath]
-                )
-                return nil
-            case .available:
-                break
+            if let remoteHost {
+                guard await RemoteLSPLauncher.isAvailable(command: entry.command, host: remoteHost, env: entry.env) else {
+                    _ = consumePendingOpenRef(key: key, uri: uri, ownership: ownership)
+                    return nil
+                }
+            } else {
+                switch await availability.statusRemediatingGatekeeper(for: entry) {
+                case .disabled, .notInstalled:
+                    _ = consumePendingOpenRef(key: key, uri: uri, ownership: ownership)
+                    return nil
+                case .blockedByGatekeeper(let realPath):
+                    _ = consumePendingOpenRef(key: key, uri: uri, ownership: ownership)
+                    NotificationCenter.default.post(
+                        name: .lspBlockedByGatekeeper,
+                        object: nil,
+                        userInfo: ["language": entry.language, "realPath": realPath]
+                    )
+                    return nil
+                case .available:
+                    break
+                }
             }
             guard consumePendingOpenRef(key: key, uri: uri, ownership: ownership) else { return nil }
             if let existing = holders[key] {
@@ -305,7 +323,9 @@ final class WorkspaceLSPManager: DocumentFormatter {
                     args: entry.args,
                     env: entry.env,
                     language: entry.language,
-                    availability: availability
+                    availability: availability,
+                    remoteHost: remoteHost,
+                    rootPath: lspRoot.path
                 )
                 let newClient = makeClient(spawn.executable, spawn.arguments, spawn.environment, languageId, lspRoot.lspURI)
                 let task = Task<Bool, Never> {
@@ -1192,8 +1212,24 @@ final class WorkspaceLSPManager: DocumentFormatter {
         args: [String],
         env: [String: String],
         language: String,
-        availability: LanguageServerAvailability
+        availability: LanguageServerAvailability,
+        remoteHost: String? = nil,
+        rootPath: String? = nil
     ) -> Spawn {
+        if let remoteHost, let rootPath {
+            let invocation = RemoteLSPLauncher.invocation(
+                host: remoteHost,
+                rootPath: rootPath,
+                command: command,
+                args: args,
+                env: env
+            )
+            return Spawn(
+                executable: URL(fileURLWithPath: invocation.executable),
+                arguments: invocation.args,
+                environment: [:]
+            )
+        }
         let probe = LanguageServerConfig(
             language: language, extensions: [], command: command, args: args,
             env: env, rootMarkers: [], enabled: true
@@ -1244,6 +1280,41 @@ final class WorkspaceLSPManager: DocumentFormatter {
             dir = parent
         }
         return worktreeRoot
+    }
+
+    static func remoteLSPRootProbeCommand(fileURL: URL, worktreeRoot: URL, markers: [String]) -> String {
+        let markerAssignments = markers.enumerated().map { index, marker in
+            "m\(index)=\(SSHCommand.shellQuote(marker))"
+        }.joined(separator: "; ")
+        let markerChecks = markers.enumerated().map { index, marker -> String in
+            let markerVariable = "\"$m\(index)\""
+            if marker.contains("*") {
+                return "if find \"$dir\" -maxdepth 1 -name \(markerVariable) -print -quit | grep -q .; then printf '%s\\n' \"$dir\"; exit 0; fi"
+            }
+            return "if [ -e \"$dir/$m\(index)\" ]; then printf '%s\\n' \"$dir\"; exit 0; fi"
+        }.joined(separator: "; ")
+        let file = SSHCommand.shellQuote(fileURL.path)
+        let root = SSHCommand.shellQuote(worktreeRoot.path)
+        return """
+        file=\(file); root=\(root); \(markerAssignments); dir=$(dirname "$file"); case "$dir" in "$root"|"$root"/*) ;; *) printf '%s\\n' "$root"; exit 0;; esac; while :; do \(markerChecks); [ "$dir" = "$root" ] && break; parent=$(dirname "$dir"); [ "$parent" = "$dir" ] && break; dir="$parent"; done; printf '%s\\n' "$root"
+        """
+    }
+
+    static func resolveRemoteLSPRoot(fileURL: URL, worktreeRoot: URL, markers: [String], host: String) async -> URL {
+        guard !markers.isEmpty else { return worktreeRoot }
+        do {
+            let result = try await RemoteExec.run(
+                host: host,
+                cwd: nil,
+                command: remoteLSPRootProbeCommand(fileURL: fileURL, worktreeRoot: worktreeRoot, markers: markers)
+            )
+            guard result.exitCode == 0 else { return worktreeRoot }
+            let path = result.stdout.trimmingCharacters(in: .whitespacesAndNewlines)
+            guard !path.isEmpty else { return worktreeRoot }
+            return URL(fileURLWithPath: path)
+        } catch {
+            return worktreeRoot
+        }
     }
 
     private static func directory(_ dir: URL, contains markers: [String], fm: FileManager) -> Bool {

--- a/Alas/Sources/Dialogs/NewProjectDialog.swift
+++ b/Alas/Sources/Dialogs/NewProjectDialog.swift
@@ -33,6 +33,12 @@ private struct ProjectDialog: View {
     @Environment(\.theme) var theme
 
     @State private var path: String = ""
+    private enum ProjectLocation: String, CaseIterable {
+        case local = "Local"
+        case remoteSSH = "Remote (SSH)"
+    }
+    @State private var location: ProjectLocation = .local
+    @State private var sshHost: String = ""
     @State private var name: String = ""
     @State private var iconMode: ProjectIcon.Mode = .letter
     @State private var iconColor: String = ProjectIcon.defaultColor
@@ -85,12 +91,24 @@ private struct ProjectDialog: View {
             subtitle: subtitle,
             width: DialogContainerLayout.projectWidth,
             content: {
-                DialogField(label: "Repository path") {
+                if case .add = mode {
+                    DialogField(label: "Location") {
+                        Seg(value: $location, options: ProjectLocation.allCases.map { ($0, $0.rawValue) })
+                    }
+                }
+                DialogField(label: location == .remoteSSH ? "Remote repository path" : "Repository path") {
                     switch mode {
                     case .add:
-                        HStack(spacing: 6) {
-                            AlasField(text: $path, placeholder: "/path/to/repo", monospaced: true)
-                            AlasButton(title: "Choose…", action: choose)
+                        if location == .local {
+                            HStack(spacing: 6) {
+                                AlasField(text: $path, placeholder: "/path/to/repo", monospaced: true)
+                                AlasButton(title: "Choose…", action: choose)
+                            }
+                        } else {
+                            VStack(alignment: .leading, spacing: 6) {
+                                AlasField(text: $sshHost, placeholder: "Host from ~/.ssh/config, e.g. devbox", monospaced: true)
+                                AlasField(text: $path, placeholder: "/home/me/repo", monospaced: true)
+                            }
                         }
                     case .edit:
                         readOnlyPath
@@ -124,7 +142,7 @@ private struct ProjectDialog: View {
             Task { await loadAvatarPresetIfAvailable() }
         }
         .onChange(of: path) { _, new in
-            if case .add = mode {
+            if case .add = mode, location == .local {
                 Task {
                     await suggestName(for: new)
                     await loadAvatarPresetIfAvailable()
@@ -160,9 +178,12 @@ private struct ProjectDialog: View {
     private var confirmEnabled: Bool {
         switch mode {
         case .add:
-            !path.isEmpty && !name.isEmpty && !isValidating
+            let hasLocation = location == .local
+                ? !path.isEmpty
+                : !sshHost.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty && path.hasPrefix("/")
+            return hasLocation && !name.isEmpty && !isValidating
         case .edit:
-            !name.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+            return !name.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
         }
     }
 
@@ -492,6 +513,9 @@ private struct ProjectDialog: View {
                         path: url,
                         displayName: name,
                         icon: draftIcon,
+                        host: location == .remoteSSH
+                            ? sshHost.trimmingCharacters(in: .whitespacesAndNewlines)
+                            : nil,
                         id: pendingProjectId
                     )
                     presented = false

--- a/Alas/Sources/Dialogs/NewWorktreeDialog.swift
+++ b/Alas/Sources/Dialogs/NewWorktreeDialog.swift
@@ -250,25 +250,27 @@ struct NewWorktreeDialog: View {
                 surface = .acp(agentId: launchAgentId)
             }
         }
-        let id = state.createWorktree(
-            projectId: project.id,
-            base: base,
-            branch: branch,
-            destination: dest,
-            runStartup: runStartup,
-            launchSurface: surface
-        )
-        guard !id.isEmpty else {
-            createErrorMessage = "A worktree already exists at this path."
-            return
+        Task { @MainActor in
+            let id = await state.createWorktree(
+                projectId: project.id,
+                base: base,
+                branch: branch,
+                destination: dest,
+                runStartup: runStartup,
+                launchSurface: surface
+            )
+            guard !id.isEmpty else {
+                createErrorMessage = "A worktree already exists at this path."
+                return
+            }
+            state.setWorktreeLaunchDefaults(
+                projectId: project.id,
+                openAfterCreate: openAfterCreate,
+                launcherMode: persistableLaunchMode
+            )
+            createErrorMessage = nil
+            presented = false
         }
-        state.setWorktreeLaunchDefaults(
-            projectId: project.id,
-            openAfterCreate: openAfterCreate,
-            launcherMode: persistableLaunchMode
-        )
-        createErrorMessage = nil
-        presented = false
     }
 
     private func submitCreate() {

--- a/Alas/Sources/Git/GitService+Discard.swift
+++ b/Alas/Sources/Git/GitService+Discard.swift
@@ -6,15 +6,16 @@ extension GitService {
     /// e.g. staged-rename origins no longer in the index), and truly untracked.
     /// In-index and HEAD-only paths route through
     /// `git restore --staged --worktree --source=HEAD --` (one batched call);
-    /// untracked paths are removed via `FileManager`. On unborn HEAD where
-    /// `--source=HEAD` won't resolve, every in-index path is necessarily a
-    /// staged add, so we use `git rm -f --cached --` + `FileManager` removal.
+    /// untracked paths are removed from the backing filesystem. On unborn HEAD
+    /// where `--source=HEAD` won't resolve, every in-index path is necessarily a
+    /// staged add, so we use `git rm -f --cached --` + filesystem removal.
     /// Empty `files` is a no-op. Missing untracked paths (ENOENT) are
     /// silently tolerated — the user already saw what they wanted gone.
     func discardPaths(worktreePath: URL, files: [String]) async throws {
         guard !files.isEmpty else { return }
 
         let head = try await hasHead(worktreePath: worktreePath)
+        let remoteHost = RemoteHostRegistry.shared.host(forPath: worktreePath.path)
 
         // Partition by index presence. ls-files --error-unmatch exits 0 iff
         // the path is tracked in the index (includes staged adds and renames).
@@ -71,13 +72,7 @@ extension GitService {
                 )
                 try Self.assertSuccess(rm, op: "discard")
                 for path in indexTracked {
-                    let url = worktreePath.appendingPathComponent(path)
-                    do {
-                        try FileManager.default.removeItem(at: url)
-                    } catch CocoaError.fileNoSuchFile {
-                        continue
-                    }
-                    // any other error propagates
+                    try await removeUntrackedPath(worktreePath: worktreePath, path: path, remoteHost: remoteHost)
                 }
             }
         } else if !headOnlyPaths.isEmpty {
@@ -110,13 +105,27 @@ extension GitService {
 
         // Remove truly untracked files from disk.
         for path in trulyUntracked {
-            let url = worktreePath.appendingPathComponent(path)
+            try await removeUntrackedPath(worktreePath: worktreePath, path: path, remoteHost: remoteHost)
+        }
+    }
+
+    private func removeUntrackedPath(worktreePath: URL, path: String, remoteHost: String?) async throws {
+        let url = worktreePath.appendingPathComponent(path)
+        guard let remoteHost else {
             do {
                 try FileManager.default.removeItem(at: url)
             } catch CocoaError.fileNoSuchFile {
-                continue
+                return
             }
+            return
         }
+        let result = try await RemoteExec.run(
+            host: remoteHost,
+            cwd: nil,
+            command: RemoteFileOps.removeCommand(path: url.path),
+            timeout: 15
+        )
+        try Self.assertSuccess(result, op: "discard")
     }
 
     /// True iff `path` is a submodule registered in the index or HEAD.
@@ -140,19 +149,16 @@ extension GitService {
     }
 
     /// Apply a unified-diff patch in reverse against the worktree. Used by
-    /// per-hunk "Discard hunk" for tracked files. Writes the patch to a
-    /// temp file (git apply needs a real path, not stdin) and removes it
-    /// on completion. Throws if `git apply --reverse` exits non-zero —
+    /// per-hunk "Discard hunk" for tracked files. Pipes the patch over stdin
+    /// so the same path works for local and SSH-backed worktrees. Throws if
+    /// `git apply --reverse` exits non-zero —
     /// typically because the patch context no longer matches the working
     /// copy (e.g. the user already discarded it elsewhere).
     func applyPatchReverse(worktreePath: URL, patch: String) async throws {
-        let tmp = FileManager.default.temporaryDirectory
-            .appendingPathComponent("alas-discard-\(UUID().uuidString).patch")
-        try patch.write(to: tmp, atomically: true, encoding: .utf8)
-        defer { try? FileManager.default.removeItem(at: tmp) }
         let result = try await Process.git(
-            ["apply", "--reverse", tmp.path],
-            cwd: worktreePath
+            ["apply", "--reverse", "-"],
+            cwd: worktreePath,
+            stdin: patch
         )
         try Self.assertSuccess(result, op: "applyPatchReverse")
     }

--- a/Alas/Sources/Git/GitService.swift
+++ b/Alas/Sources/Git/GitService.swift
@@ -128,7 +128,8 @@ extension GitService {
                 // under-report. Count the file's lines as adds when it exists
                 // on disk; deleted files (no longer present) stay at 0/0.
                 let url = worktreePath.appendingPathComponent(entries[i].path)
-                if let data = try? Data(contentsOf: url),
+                if !worktreePath.isRemoteAlasPath,
+                   let data = try? Data(contentsOf: url),
                    let text = String(data: data, encoding: .utf8) {
                     let lines = text.isEmpty
                         ? 0
@@ -350,6 +351,7 @@ extension GitService {
     }
 
     private func worktreeLinesOrUnavailable(worktreePath: URL, path: String) async throws -> DiffReviewFileContextLines {
+        if worktreePath.isRemoteAlasPath { return .unavailable }
         let url = worktreePath.appendingPathComponent(path)
         if let destination = try? FileManager.default.destinationOfSymbolicLink(atPath: url.path) {
             return .available([destination])
@@ -517,7 +519,8 @@ extension GitService {
             }
         }
 
-        do {
+        if !worktreePath.isRemoteAlasPath {
+            do {
             let rootEntries = try FileManager.default.contentsOfDirectory(
                 at: worktreePath,
                 includingPropertiesForKeys: [.isDirectoryKey, .isRegularFileKey],
@@ -572,10 +575,11 @@ extension GitService {
                     }
                 }
             }
-        } catch {
-            // Git-visible paths are still useful if the best-effort all-files
-            // root scan or ignore classification fails.
-            Self.logger.error("file tree root scan failed for \(worktreePath.path, privacy: .public): \(error.localizedDescription, privacy: .public)")
+            } catch {
+                // Git-visible paths are still useful if the best-effort all-files
+                // root scan or ignore classification fails.
+                Self.logger.error("file tree root scan failed for \(worktreePath.path, privacy: .public): \(error.localizedDescription, privacy: .public)")
+            }
         }
 
         let submodules = (try? await submodulePaths(worktreePath: worktreePath)) ?? []
@@ -609,6 +613,28 @@ extension GitService {
     }
 
     func fileTreeChildren(worktreePath: URL, path: String) async throws -> [FileTreeNode] {
+        if worktreePath.isRemoteAlasPath {
+            let prefix = path.isEmpty ? "" : path + "/"
+            let paths = try await gitVisibleFilePaths(worktreePath: worktreePath)
+                .filter { path.isEmpty || $0.hasPrefix(prefix) }
+            var directories = Set<String>()
+            for candidate in paths {
+                let components = candidate.split(separator: "/")
+                guard components.count > 1 else { continue }
+                for index in 1 ..< components.count {
+                    directories.insert(components.prefix(index).joined(separator: "/"))
+                }
+            }
+            let built = FileTreeBuilder.build(
+                paths: paths,
+                badges: [:],
+                visibility: [:],
+                directories: directories,
+                lazyDirectories: directories,
+                submodules: (try? await submodulePaths(worktreePath: worktreePath)) ?? []
+            )
+            return path.isEmpty ? built : findFileTreeNode(path: path, in: built)?.children ?? []
+        }
         let directory = worktreePath.appendingPathComponent(path)
         let urls = try FileManager.default.contentsOfDirectory(
             at: directory,

--- a/Alas/Sources/Git/GitService.swift
+++ b/Alas/Sources/Git/GitService.swift
@@ -112,6 +112,13 @@ extension GitService {
             : ["diff", "--numstat", "--cached"]
         let numstat = try await Process.git(numstatArgs, cwd: worktreePath)
         let counts = NumstatParser.parse(numstat.stdout)
+        let untrackedPaths = entries.filter { $0.add == 0 && $0.del == 0 }.map(\.path)
+        let remoteCounts: [String: Int]
+        if worktreePath.isRemoteAlasPath, let host = RemoteHostRegistry.shared.host(forPath: worktreePath.path) {
+            remoteCounts = await RemoteFileStats.lineCounts(host: host, cwd: worktreePath.path, paths: untrackedPaths)
+        } else {
+            remoteCounts = [:]
+        }
 
         for i in entries.indices {
             if let c = counts[entries[i].path] {
@@ -127,8 +134,11 @@ extension GitService {
                 // show 0/0 in the Changes pane and the totals would
                 // under-report. Count the file's lines as adds when it exists
                 // on disk; deleted files (no longer present) stay at 0/0.
-                let url = worktreePath.appendingPathComponent(entries[i].path)
-                if !worktreePath.isRemoteAlasPath,
+                if worktreePath.isRemoteAlasPath, let lines = remoteCounts[entries[i].path] {
+                    entries[i] = ChangedFile(path: entries[i].path, status: entries[i].status, stage: entries[i].stage, add: lines, del: 0, renameFrom: entries[i].renameFrom, conflict: entries[i].conflict)
+                } else {
+                    let url = worktreePath.appendingPathComponent(entries[i].path)
+                    if !worktreePath.isRemoteAlasPath,
                    let data = try? Data(contentsOf: url),
                    let text = String(data: data, encoding: .utf8) {
                     let lines = text.isEmpty
@@ -141,6 +151,7 @@ extension GitService {
                                              del: 0,
                                              renameFrom: entries[i].renameFrom,
                                              conflict: entries[i].conflict)
+                    }
                 }
             }
         }
@@ -615,7 +626,7 @@ extension GitService {
     func fileTreeChildren(worktreePath: URL, path: String) async throws -> [FileTreeNode] {
         if worktreePath.isRemoteAlasPath {
             let prefix = path.isEmpty ? "" : path + "/"
-            let paths = try await gitVisibleFilePaths(worktreePath: worktreePath)
+            var paths = try await gitVisibleFilePaths(worktreePath: worktreePath)
                 .filter { path.isEmpty || $0.hasPrefix(prefix) }
             var directories = Set<String>()
             for candidate in paths {
@@ -623,6 +634,15 @@ extension GitService {
                 guard components.count > 1 else { continue }
                 for index in 1 ..< components.count {
                     directories.insert(components.prefix(index).joined(separator: "/"))
+                }
+            }
+            if let host = RemoteHostRegistry.shared.host(forPath: worktreePath.path) {
+                let directory = path.isEmpty ? worktreePath.path : worktreePath.appendingPathComponent(path).path
+                if let result = try? await RemoteExec.run(host: host, cwd: nil, command: "ls -1Ap " + SSHCommand.shellQuote(directory)), result.exitCode == 0 {
+                    for entry in RemoteFileStats.parseLsEntries(result.stdout) where entry.name != ".git" {
+                        let fullPath = path.isEmpty ? entry.name : path + "/" + entry.name
+                        if entry.isDirectory { directories.insert(fullPath) } else if !paths.contains(fullPath) { paths.append(fullPath) }
+                    }
                 }
             }
             let built = FileTreeBuilder.build(

--- a/Alas/Sources/Git/GitService.swift
+++ b/Alas/Sources/Git/GitService.swift
@@ -641,16 +641,18 @@ extension GitService {
                 if let result = try? await RemoteExec.run(host: host, cwd: nil, command: "ls -1Ap " + SSHCommand.shellQuote(directory)), result.exitCode == 0 {
                     for entry in RemoteFileStats.parseLsEntries(result.stdout) where entry.name != ".git" {
                         let fullPath = path.isEmpty ? entry.name : path + "/" + entry.name
-                        if entry.isDirectory { directories.insert(fullPath) } else if !paths.contains(fullPath) { paths.append(fullPath) }
+                        if entry.isDirectory { directories.insert(fullPath) }
+                        if !paths.contains(fullPath) { paths.append(fullPath) }
                     }
                 }
             }
+            let lazyDirectories = path.isEmpty ? directories : directories.subtracting([path])
             let built = FileTreeBuilder.build(
                 paths: paths,
                 badges: [:],
                 visibility: [:],
                 directories: directories,
-                lazyDirectories: directories,
+                lazyDirectories: lazyDirectories,
                 submodules: (try? await submodulePaths(worktreePath: worktreePath)) ?? []
             )
             return path.isEmpty ? built : findFileTreeNode(path: path, in: built)?.children ?? []

--- a/Alas/Sources/Git/Process+Git.swift
+++ b/Alas/Sources/Git/Process+Git.swift
@@ -189,11 +189,16 @@ extension Process {
         stdin: String? = nil,
         timeout: TimeInterval = Process.defaultTimeout
     ) async throws -> ProcessResult {
-        try await run(
-            "/usr/bin/env",
-            args: ["git"] + args,
+        let invocation = GitInvocation.build(
+            gitArgs: args,
             cwd: cwd,
-            env: gitEnv(),
+            host: RemoteHostRegistry.shared.host(forPath: cwd?.path)
+        )
+        return try await run(
+            invocation.executable,
+            args: invocation.args,
+            cwd: invocation.cwd,
+            env: invocation.env,
             stdin: stdin,
             timeout: timeout
         )
@@ -216,11 +221,16 @@ extension Process {
         cwd: URL? = nil,
         timeout: TimeInterval = Process.defaultTimeout
     ) async throws -> ProcessResultData {
-        try await runData(
-            "/usr/bin/env",
-            args: ["git"] + args,
+        let invocation = GitInvocation.build(
+            gitArgs: args,
             cwd: cwd,
-            env: gitEnv(),
+            host: RemoteHostRegistry.shared.host(forPath: cwd?.path)
+        )
+        return try await runData(
+            invocation.executable,
+            args: invocation.args,
+            cwd: invocation.cwd,
+            env: invocation.env,
             timeout: timeout
         )
     }

--- a/Alas/Sources/Git/WorktreeService.swift
+++ b/Alas/Sources/Git/WorktreeService.swift
@@ -35,7 +35,9 @@ struct WorktreeService {
     func list(repoPath: URL, projectId: String) async throws -> [Worktree] {
         let result = try await Process.git(["worktree", "list", "--porcelain"], cwd: repoPath)
         guard result.exitCode == 0 else { throw WorktreeError.gitFailed(result.stderr) }
-        return Self.parsePorcelain(result.stdout, projectId: projectId)
+        var trees = Self.parsePorcelain(result.stdout, projectId: projectId)
+        if repoPath.isRemoteAlasPath { trees = await Self.fillingRemoteLastActivity(trees) }
+        return trees
     }
 
     /// Returns a best-effort "last activity" timestamp for the worktree at
@@ -112,6 +114,24 @@ struct WorktreeService {
         // (it's rewritten on each detached commit/checkout).
         if let m = mtime(of: headPath) { return m }
         return dirMtime()
+    }
+
+    static func date(fromEpochOutput output: String) -> Date? {
+        TimeInterval(output.trimmingCharacters(in: .whitespacesAndNewlines)).map(Date.init(timeIntervalSince1970:))
+    }
+
+    private static func fillingRemoteLastActivity(_ trees: [Worktree]) async -> [Worktree] {
+        await withTaskGroup(of: (Int, Date?).self) { group in
+            for (index, tree) in trees.enumerated() {
+                group.addTask {
+                    let result = try? await Process.git(["log", "-1", "--format=%ct", "HEAD"], cwd: tree.path)
+                    return (index, result.flatMap { $0.exitCode == 0 ? date(fromEpochOutput: $0.stdout) : nil })
+                }
+            }
+            var trees = trees
+            for await (index, date) in group where date != nil { trees[index].lastActivity = date! }
+            return trees
+        }
     }
 
     static func parsePorcelain(_ out: String, projectId: String) -> [Worktree] {

--- a/Alas/Sources/Git/WorktreeService.swift
+++ b/Alas/Sources/Git/WorktreeService.swift
@@ -36,7 +36,9 @@ struct WorktreeService {
         let result = try await Process.git(["worktree", "list", "--porcelain"], cwd: repoPath)
         guard result.exitCode == 0 else { throw WorktreeError.gitFailed(result.stderr) }
         var trees = Self.parsePorcelain(result.stdout, projectId: projectId)
-        if repoPath.isRemoteAlasPath { trees = await Self.fillingRemoteLastActivity(trees) }
+        if let host = RemoteHostRegistry.shared.host(forPath: repoPath.path) {
+            trees = await Self.fillingRemoteLastActivity(trees, host: host)
+        }
         return trees
     }
 
@@ -120,11 +122,21 @@ struct WorktreeService {
         TimeInterval(output.trimmingCharacters(in: .whitespacesAndNewlines)).map(Date.init(timeIntervalSince1970:))
     }
 
-    private static func fillingRemoteLastActivity(_ trees: [Worktree]) async -> [Worktree] {
+    private static func fillingRemoteLastActivity(_ trees: [Worktree], host: String) async -> [Worktree] {
         await withTaskGroup(of: (Int, Date?).self) { group in
             for (index, tree) in trees.enumerated() {
                 group.addTask {
-                    let result = try? await Process.git(["log", "-1", "--format=%ct", "HEAD"], cwd: tree.path)
+                    let invocation = GitInvocation.build(
+                        gitArgs: ["log", "-1", "--format=%ct", "HEAD"],
+                        cwd: tree.path,
+                        host: host
+                    )
+                    let result = try? await Process.run(
+                        invocation.executable,
+                        args: invocation.args,
+                        cwd: invocation.cwd,
+                        env: invocation.env
+                    )
                     return (index, result.flatMap { $0.exitCode == 0 ? date(fromEpochOutput: $0.stdout) : nil })
                 }
             }

--- a/Alas/Sources/Git/WorktreeService.swift
+++ b/Alas/Sources/Git/WorktreeService.swift
@@ -45,6 +45,7 @@ struct WorktreeService {
     /// Falls back through packed-refs, HEAD's own mtime, and the worktree
     /// directory mtime if any layer can't be resolved.
     static func lastActivity(forWorktreeAt path: URL) -> Date? {
+        if path.isRemoteAlasPath { return nil }
         let fm = FileManager.default
 
         func mtime(of pathStr: String) -> Date? {

--- a/Alas/Sources/Persistence/ProjectConfig.swift
+++ b/Alas/Sources/Persistence/ProjectConfig.swift
@@ -96,11 +96,13 @@ struct ProjectConfig: Codable, Equatable, Identifiable {
     var worktreeOpenAfterCreate: Bool?
     /// Per-project launcher mode preference. `nil` = use global default.
     var worktreeDefaultLauncherMode: AppConfig.LauncherMode?
+    /// SSH destination when this project lives on another machine.
+    var host: String?
 
     enum CodingKeys: String, CodingKey {
         case id, name, path, color, icon, addedAt, hiddenWorktreePaths, worktreeOrder,
              worktreeOrderIsManual, startupScripts,
-             mcpServers, worktreeOpenAfterCreate, worktreeDefaultLauncherMode
+             mcpServers, worktreeOpenAfterCreate, worktreeDefaultLauncherMode, host
     }
 
     init(
@@ -116,7 +118,8 @@ struct ProjectConfig: Codable, Equatable, Identifiable {
         startupScripts: ProjectStartupScripts = .defaults,
         mcpServers: [ProjectMCPServer] = [],
         worktreeOpenAfterCreate: Bool? = nil,
-        worktreeDefaultLauncherMode: AppConfig.LauncherMode? = nil
+        worktreeDefaultLauncherMode: AppConfig.LauncherMode? = nil,
+        host: String? = nil
     ) {
         self.id = id
         self.name = name
@@ -130,6 +133,7 @@ struct ProjectConfig: Codable, Equatable, Identifiable {
         self.mcpServers = mcpServers
         self.worktreeOpenAfterCreate = worktreeOpenAfterCreate
         self.worktreeDefaultLauncherMode = worktreeDefaultLauncherMode
+        self.host = host
     }
 
     // Tolerant decode: older projects.json files predate hiddenWorktreePaths
@@ -155,6 +159,7 @@ struct ProjectConfig: Codable, Equatable, Identifiable {
         mcpServers = (try? c.decode([ProjectMCPServer].self, forKey: .mcpServers)) ?? []
         worktreeOpenAfterCreate = try? c.decode(Bool.self, forKey: .worktreeOpenAfterCreate)
         worktreeDefaultLauncherMode = try? c.decode(AppConfig.LauncherMode.self, forKey: .worktreeDefaultLauncherMode)
+        host = try? c.decode(String.self, forKey: .host)
     }
 
     func encode(to encoder: Encoder) throws {
@@ -172,5 +177,6 @@ struct ProjectConfig: Codable, Equatable, Identifiable {
         try c.encode(mcpServers, forKey: .mcpServers)
         try c.encodeIfPresent(worktreeOpenAfterCreate, forKey: .worktreeOpenAfterCreate)
         try c.encodeIfPresent(worktreeDefaultLauncherMode, forKey: .worktreeDefaultLauncherMode)
+        try c.encodeIfPresent(host, forKey: .host)
     }
 }

--- a/Alas/Sources/Right/ChangesTabView.swift
+++ b/Alas/Sources/Right/ChangesTabView.swift
@@ -119,7 +119,7 @@ struct ChangesTabView: View {
                     let absolute = rps.worktree.path.appendingPathComponent(file.path).path
                     Clipboard.copy(absolute)
                 },
-                onRevealInFinder: { file in
+                onRevealInFinder: rps.worktree.path.isRemoteAlasPath ? nil : { file in
                     let url = rps.worktree.path.appendingPathComponent(file.path)
                     NSWorkspace.shared.activateFileViewerSelecting([url])
                 },

--- a/Alas/Sources/Right/RightPaneState.swift
+++ b/Alas/Sources/Right/RightPaneState.swift
@@ -250,6 +250,9 @@ final class RightPaneState {
 
     @ObservationIgnored
     private let reviewLoopRemoteRefreshMinimumInterval: TimeInterval = 45
+    @ObservationIgnored private var remotePollTask: Task<Void, Never>?
+    @ObservationIgnored private var remoteFingerprint: String?
+    private static let remotePollIntervalNanos: UInt64 = 7 * 1_000_000_000
 
     /// True iff the "behind base" chip should be shown.
     var showBehindBaseChip: Bool {
@@ -284,6 +287,8 @@ final class RightPaneState {
     func start() {
         if !worktree.path.isRemoteAlasPath {
             watcher.start()
+        } else {
+            startRemotePolling()
         }
         Task { @MainActor in await self.refresh() }
         Task { @MainActor in await self.refreshSyncStatus() }
@@ -305,6 +310,38 @@ final class RightPaneState {
         watcher.stop()
         syncStatusTimer?.cancel()
         syncStatusTimer = nil
+        remotePollTask?.cancel()
+        remotePollTask = nil
+    }
+
+    private func startRemotePolling() {
+        remotePollTask?.cancel()
+        remotePollTask = Task { @MainActor [weak self] in
+            while !Task.isCancelled {
+                try? await Task.sleep(nanoseconds: Self.remotePollIntervalNanos)
+                guard let self, !Task.isCancelled, NSApp?.isActive ?? true else { continue }
+                await remotePollTick()
+            }
+        }
+    }
+
+    private func remotePollTick() async {
+        let host = RemoteHostRegistry.shared.host(forPath: worktree.path.path)
+        let status = try? await Process.git(["status", "--porcelain=v2", "-z", "--untracked-files=all"], cwd: worktree.path)
+        guard let status, !RemoteExec.isConnectionFailure(exitCode: status.exitCode) else {
+            if let host { RemoteHostStatusStore.shared.reportConnectionFailure(host: host) }
+            return
+        }
+        if let host { RemoteHostStatusStore.shared.reportSuccess(host: host) }
+        guard status.exitCode == 0 else { return }
+        let head = try? await Process.git(["rev-parse", "HEAD"], cwd: worktree.path)
+        let fingerprint = RemoteStatusFingerprint.make(
+            status: status.stdout,
+            head: head?.stdout.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+        )
+        let shouldRefresh = RemoteStatusFingerprint.shouldRefresh(previous: remoteFingerprint, current: fingerprint)
+        remoteFingerprint = fingerprint
+        if shouldRefresh { await refresh() }
     }
 
     /// Update the base branch, record it in the recent list, and refresh.

--- a/Alas/Sources/Right/RightPaneState.swift
+++ b/Alas/Sources/Right/RightPaneState.swift
@@ -28,6 +28,8 @@ private struct SyncFetchTarget: Hashable {
 @Observable
 @MainActor
 final class RightPaneState {
+    nonisolated static let remoteUntrackedContentFingerprintCommand = "git ls-files --others --exclude-standard -z | xargs -0 sh -c '[ \"$#\" -gt 0 ] || exit 0; git hash-object -- \"$@\"' sh 2>/dev/null"
+
     let worktree: Worktree
     let reviewLoop: ReviewLoopState
     var changes: [ChangedFile] = []
@@ -335,9 +337,25 @@ final class RightPaneState {
         if let host { RemoteHostStatusStore.shared.reportSuccess(host: host) }
         guard status.exitCode == 0 else { return }
         let head = try? await Process.git(["rev-parse", "HEAD"], cwd: worktree.path)
+        let unstagedDiff = try? await Process.git(["diff", "--no-ext-diff", "--binary"], cwd: worktree.path)
+        let stagedDiff = try? await Process.git(["diff", "--cached", "--no-ext-diff", "--binary"], cwd: worktree.path)
+        let untrackedContent: ProcessResult?
+        if let host {
+            untrackedContent = try? await RemoteExec.run(
+                host: host,
+                cwd: worktree.path.path,
+                command: Self.remoteUntrackedContentFingerprintCommand,
+                timeout: 15
+            )
+        } else {
+            untrackedContent = nil
+        }
         let fingerprint = RemoteStatusFingerprint.make(
             status: status.stdout,
-            head: head?.stdout.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+            head: head?.stdout.trimmingCharacters(in: .whitespacesAndNewlines) ?? "",
+            unstagedDiff: unstagedDiff?.stdout ?? "",
+            stagedDiff: stagedDiff?.stdout ?? "",
+            untrackedContent: untrackedContent?.stdout ?? ""
         )
         let shouldRefresh = RemoteStatusFingerprint.shouldRefresh(previous: remoteFingerprint, current: fingerprint)
         remoteFingerprint = fingerprint

--- a/Alas/Sources/Right/RightPaneState.swift
+++ b/Alas/Sources/Right/RightPaneState.swift
@@ -282,7 +282,9 @@ final class RightPaneState {
     }
 
     func start() {
-        watcher.start()
+        if !worktree.path.isRemoteAlasPath {
+            watcher.start()
+        }
         Task { @MainActor in await self.refresh() }
         Task { @MainActor in await self.refreshSyncStatus() }
         syncStatusTimer?.cancel()

--- a/Alas/Sources/SSH/ACPReconnectPolicy.swift
+++ b/Alas/Sources/SSH/ACPReconnectPolicy.swift
@@ -1,0 +1,11 @@
+import Foundation
+
+/// Bounded retry schedule for remote ACP sessions whose SSH channel drops.
+enum ACPReconnectPolicy {
+    static let delays: [TimeInterval] = [2, 5, 15, 30, 60]
+
+    static func delay(forAttempt attempt: Int) -> TimeInterval? {
+        guard attempt >= 0, attempt < delays.count else { return nil }
+        return delays[attempt]
+    }
+}

--- a/Alas/Sources/SSH/ACPRemoteFileServer.swift
+++ b/Alas/Sources/SSH/ACPRemoteFileServer.swift
@@ -1,0 +1,47 @@
+import Foundation
+
+/// Remote ACP file serving uses lexical containment. Resolving remote
+/// symlinks would require an additional ssh round trip per request.
+struct ACPRemoteFileServer {
+    enum ServerError: Error, LocalizedError {
+        case outsideWorktree(String)
+        case unreadable(String)
+
+        var errorDescription: String? {
+            switch self {
+            case let .outsideWorktree(path): "Path is outside the worktree: \(path)"
+            case let .unreadable(detail): "Could not read remote file: \(detail)"
+            }
+        }
+    }
+
+    let host: String
+    let worktreeRoot: String
+
+    func resolveInsideWorktree(path: String) throws -> String {
+        let absolute = path.hasPrefix("/") ? path : worktreeRoot + "/" + path
+        let normalized = URL(fileURLWithPath: absolute).standardizedFileURL.path
+        guard normalized == worktreeRoot || normalized.hasPrefix(worktreeRoot + "/") else {
+            throw ServerError.outsideWorktree(path)
+        }
+        return normalized
+    }
+
+    func read(path: String, liveBuffer: String?) async throws -> String {
+        if let liveBuffer { return liveBuffer }
+        switch try await RemoteFileAccess.read(host: host, path: path) {
+        case let .file(data, _):
+            guard let text = String(data: data, encoding: .utf8) else { throw ServerError.unreadable("not valid UTF-8") }
+            return text
+        case .missing: throw ServerError.unreadable("no such file")
+        case .directory: throw ServerError.unreadable("path is a directory")
+        case let .unreadable(detail): throw ServerError.unreadable(detail)
+        }
+    }
+
+    func write(path: String, content: String) async throws -> ACPFileWriter.Result {
+        let previous = try? await read(path: path, liveBuffer: nil)
+        _ = try await RemoteFileAccess.write(host: host, path: path, content: content)
+        return ACPFileWriter.makeResult(oldText: previous ?? "", newText: content, path: path)
+    }
+}

--- a/Alas/Sources/SSH/ACPRemoteFileServer.swift
+++ b/Alas/Sources/SSH/ACPRemoteFileServer.swift
@@ -1,16 +1,61 @@
 import Foundation
 
-/// Remote ACP file serving uses lexical containment. Resolving remote
-/// symlinks would require an additional ssh round trip per request.
+enum RemotePathContainment {
+    enum ContainmentError: Error, LocalizedError {
+        case outsideWorktree(String)
+
+        var errorDescription: String? {
+            switch self {
+            case let .outsideWorktree(path): "Path is outside the worktree: \(path)"
+            }
+        }
+    }
+
+    static func lexicallyResolveInsideWorktree(path: String, worktreeRoot: String) throws -> String {
+        let absolute = path.hasPrefix("/") ? path : worktreeRoot + "/" + path
+        let normalized = URL(fileURLWithPath: absolute).standardizedFileURL.path
+        guard normalized == worktreeRoot || normalized.hasPrefix(worktreeRoot + "/") else {
+            throw ContainmentError.outsideWorktree(path)
+        }
+        return normalized
+    }
+
+    static func containmentProbeCommand(path: String, worktreeRoot: String) -> String {
+        let root = SSHCommand.shellQuote(worktreeRoot)
+        let target = SSHCommand.shellQuote(path)
+        return """
+        root=\(root); target=\(target); parent=$(dirname "$target"); existing="$parent"; \
+        while [ ! -e "$existing" ]; do next=$(dirname "$existing"); [ "$next" = "$existing" ] && exit 3; existing="$next"; done; \
+        root_phys=$(cd "$root" && pwd -P) || exit 4; existing_phys=$(cd "$existing" && pwd -P) || exit 5; \
+        case "$existing_phys" in "$root_phys"|"$root_phys"/*) exit 0 ;; *) exit 6 ;; esac
+        """
+    }
+
+    static func verifyRemoteContainment(host: String, path: String, worktreeRoot: String) async throws {
+        let target = try lexicallyResolveInsideWorktree(path: path, worktreeRoot: worktreeRoot)
+        let result = try await RemoteExec.run(host: host, cwd: nil, command: containmentProbeCommand(path: target, worktreeRoot: worktreeRoot))
+        if RemoteExec.isConnectionFailure(exitCode: result.exitCode) {
+            throw RemoteFileAccessError.connectionFailed(result.stderr)
+        }
+        guard result.exitCode == 0 else {
+            throw ContainmentError.outsideWorktree(path)
+        }
+    }
+}
+
+/// Remote ACP file serving uses lexical containment first, then a remote
+/// physical-parent containment probe before touching the file.
 struct ACPRemoteFileServer {
     enum ServerError: Error, LocalizedError {
         case outsideWorktree(String)
         case unreadable(String)
+        case leaseLost
 
         var errorDescription: String? {
             switch self {
             case let .outsideWorktree(path): "Path is outside the worktree: \(path)"
             case let .unreadable(detail): "Could not read remote file: \(detail)"
+            case .leaseLost: "Session lease was lost before the remote write."
             }
         }
     }
@@ -18,30 +63,60 @@ struct ACPRemoteFileServer {
     let host: String
     let worktreeRoot: String
 
-    func resolveInsideWorktree(path: String) throws -> String {
-        let absolute = path.hasPrefix("/") ? path : worktreeRoot + "/" + path
-        let normalized = URL(fileURLWithPath: absolute).standardizedFileURL.path
-        guard normalized == worktreeRoot || normalized.hasPrefix(worktreeRoot + "/") else {
+    func lexicallyResolveInsideWorktree(path: String) throws -> String {
+        do {
+            return try RemotePathContainment.lexicallyResolveInsideWorktree(path: path, worktreeRoot: worktreeRoot)
+        } catch {
             throw ServerError.outsideWorktree(path)
         }
-        return normalized
     }
 
     func read(path: String, liveBuffer: String?) async throws -> String {
         if let liveBuffer { return liveBuffer }
-        switch try await RemoteFileAccess.read(host: host, path: path) {
+        let target = try lexicallyResolveInsideWorktree(path: path)
+        try await verifyRemoteContainment(path: target)
+        switch try await RemoteFileAccess.read(host: host, path: target) {
         case let .file(data, _):
             guard let text = String(data: data, encoding: .utf8) else { throw ServerError.unreadable("not valid UTF-8") }
             return text
         case .missing: throw ServerError.unreadable("no such file")
         case .directory: throw ServerError.unreadable("path is a directory")
+        case .symlink: throw ServerError.unreadable("path is a symbolic link")
         case let .unreadable(detail): throw ServerError.unreadable(detail)
         }
     }
 
-    func write(path: String, content: String) async throws -> ACPFileWriter.Result {
-        let previous = try? await read(path: path, liveBuffer: nil)
-        _ = try await RemoteFileAccess.write(host: host, path: path, content: content)
-        return ACPFileWriter.makeResult(oldText: previous ?? "", newText: content, path: path)
+    func write(
+        path: String,
+        content: String,
+        beforeRemoteWrite: (@MainActor @Sendable () async throws -> Void)? = nil
+    ) async throws -> ACPFileWriter.Result {
+        let target = try lexicallyResolveInsideWorktree(path: path)
+        try await verifyRemoteContainment(path: target)
+        let previous = try? await read(path: target, liveBuffer: nil)
+        let mkdir = try await RemoteExec.run(host: host, cwd: nil, command: RemoteFileOps.mkdirCommand(parentOf: target))
+        if RemoteExec.isConnectionFailure(exitCode: mkdir.exitCode) {
+            throw RemoteFileAccessError.connectionFailed(mkdir.stderr)
+        }
+        guard mkdir.exitCode == 0 else {
+            throw ServerError.unreadable(mkdir.stderr)
+        }
+        try await beforeRemoteWrite?()
+        _ = try await RemoteFileAccess.write(host: host, path: target, content: content)
+        return ACPFileWriter.makeResult(oldText: previous, newText: content, path: target)
+    }
+
+    func containmentProbeCommand(path: String) -> String {
+        RemotePathContainment.containmentProbeCommand(path: path, worktreeRoot: worktreeRoot)
+    }
+
+    func verifyRemoteContainment(path: String) async throws {
+        do {
+            try await RemotePathContainment.verifyRemoteContainment(host: host, path: path, worktreeRoot: worktreeRoot)
+        } catch RemotePathContainment.ContainmentError.outsideWorktree(_) {
+            throw ServerError.outsideWorktree(path)
+        } catch {
+            throw error
+        }
     }
 }

--- a/Alas/Sources/SSH/ACPRemoteLaunch.swift
+++ b/Alas/Sources/SSH/ACPRemoteLaunch.swift
@@ -1,0 +1,58 @@
+import Foundation
+
+/// Builders for running ACP agents and their terminal requests on a
+/// remote host. The agent channel is a long-lived ssh child whose
+/// stdin/stdout carry newline-framed JSON-RPC; its exit is the agent's
+/// death signal, so the existing transport `.exited` handling works.
+enum ACPRemoteLaunch {
+    /// Claude-aware CLIs refuse to start when these leak into their env
+    /// (mirrors ACPProcessEnvironment.agentSessionMarkerKeys). Local
+    /// sanitization cannot cross ssh because the remote login shell might
+    /// set its own values, so scrub remote-side with `env -u`.
+    static let markerScrub = [
+        "CLAUDECODE", "CLAUDE_CODE", "CLAUDE_PROJECT_DIR",
+        "CLAUDE_CODE_ENTRYPOINT", "CLAUDE_SESSION_ID",
+    ]
+
+    static func agentCommand(command: String, arguments: [String]) -> String {
+        let scrub = markerScrub.map { "-u \($0)" }.joined(separator: " ")
+        let argv = ([command] + arguments).map(SSHCommand.shellQuote).joined(separator: " ")
+        return "env \(scrub) \(argv)"
+    }
+
+    static func channelInvocation(
+        host: String,
+        worktreePath: String,
+        command: String,
+        arguments: [String]
+    ) -> RemoteExecInvocation {
+        RemoteExec.invocation(
+            host: host,
+            cwd: worktreePath,
+            command: agentCommand(command: command, arguments: arguments)
+        )
+    }
+
+    /// Availability probe for the remote login shell's PATH. Uses the
+    /// first word so multi-word catalog commands probe the binary, not flags.
+    static func setupProbeCommand(command: String) -> String {
+        let binary = command.split(separator: " ").first.map(String.init) ?? command
+        return "command -v \(SSHCommand.shellQuote(binary))"
+    }
+
+    /// Remote script for an agent `terminal/create`. Only agent-requested
+    /// env pairs cross the connection; sorting keeps the result deterministic.
+    static func terminalCommand(
+        command: String,
+        args: [String],
+        env: [String: String],
+        cwd: String
+    ) -> String {
+        let pairs = env.sorted { $0.key < $1.key }
+            .map { SSHCommand.shellQuote("\($0.key)=\($0.value)") }
+        let scrub = markerScrub.map { "-u \($0)" }
+        let argv = ([command] + args).map(SSHCommand.shellQuote)
+        let envCommand = (["env"] + scrub + pairs + argv).joined(separator: " ")
+        return "cd -- \(SSHCommand.shellQuote(cwd)) && \(envCommand)"
+    }
+}

--- a/Alas/Sources/SSH/ACPRemoteLaunch.swift
+++ b/Alas/Sources/SSH/ACPRemoteLaunch.swift
@@ -40,6 +40,37 @@ enum ACPRemoteLaunch {
         return "command -v \(SSHCommand.shellQuote(binary))"
     }
 
+    static func setupProbeCommand(check: ACPSetupCheck) -> String {
+        switch check {
+        case .binaryOnPath(let name):
+            return "command -v \(SSHCommand.shellQuote(name))"
+        case .npxPackage(let name):
+            return npmPackageProbeCommand(package: name)
+        case .binaryOnPathOrNpmPackage(let binary, let package):
+            return "command -v \(SSHCommand.shellQuote(binary)) >/dev/null 2>&1 || (\(npmPackageProbeCommand(package: package)))"
+        }
+    }
+
+    static func launchPathProbeCommand(for spec: ACPLaunchSpec) -> String? {
+        let binary = SSHCommand.shellQuote(spec.command)
+        switch spec.setupCheck {
+        case .binaryOnPath:
+            return nil
+        case .npxPackage:
+            return "\(npmGlobalBinaryProbeCommand(binary: spec.command)) || command -v \(binary)"
+        case .binaryOnPathOrNpmPackage:
+            return "command -v \(binary) || \(npmGlobalBinaryProbeCommand(binary: spec.command))"
+        }
+    }
+
+    private static func npmPackageProbeCommand(package: String) -> String {
+        "pkg=\(SSHCommand.shellQuote(package)); root=$(npm root -g 2>/dev/null) && [ -n \"$root\" ] && [ -d \"$root/$pkg\" ]"
+    }
+
+    private static func npmGlobalBinaryProbeCommand(binary: String) -> String {
+        "bin=\(SSHCommand.shellQuote(binary)); prefix=$(npm prefix -g 2>/dev/null) && [ -n \"$prefix\" ] && p=\"$prefix/bin/$bin\" && [ -x \"$p\" ] && printf '%s\\n' \"$p\""
+    }
+
     /// Remote script for an agent `terminal/create`. Only agent-requested
     /// env pairs cross the connection; sorting keeps the result deterministic.
     static func terminalCommand(
@@ -53,6 +84,6 @@ enum ACPRemoteLaunch {
         let scrub = markerScrub.map { "-u \($0)" }
         let argv = ([command] + args).map(SSHCommand.shellQuote)
         let envCommand = (["env"] + scrub + pairs + argv).joined(separator: " ")
-        return "cd -- \(SSHCommand.shellQuote(cwd)) && \(envCommand)"
+        return "cd \(SSHCommand.shellQuote(cwd)) && \(envCommand)"
     }
 }

--- a/Alas/Sources/SSH/ACPRemoteMCPFilter.swift
+++ b/Alas/Sources/SSH/ACPRemoteMCPFilter.swift
@@ -1,0 +1,25 @@
+import Foundation
+
+/// Project MCP servers for remote sessions: stdio entries name commands on
+/// the local machine, so a remote agent cannot execute them reliably. URL-based
+/// servers remain reachable from the remote agent and are passed through.
+enum ACPRemoteMCPFilter {
+    static func split(_ servers: [ACPMCPServer]) -> (
+        kept: [ACPMCPServer],
+        droppedStdio: [String]
+    ) {
+        var kept: [ACPMCPServer] = []
+        var droppedStdio: [String] = []
+
+        for server in servers {
+            switch server {
+            case let .stdio(name, _, _, _):
+                droppedStdio.append(name)
+            case .http, .sse:
+                kept.append(server)
+            }
+        }
+
+        return (kept, droppedStdio)
+    }
+}

--- a/Alas/Sources/SSH/GitInvocation.swift
+++ b/Alas/Sources/SSH/GitInvocation.swift
@@ -1,0 +1,34 @@
+import Foundation
+
+/// The concrete process configuration for one local or remote git invocation.
+struct GitInvocation: Equatable {
+    let executable: String
+    let args: [String]
+    let env: [String: String]?
+    let cwd: URL?
+
+    static func build(gitArgs: [String], cwd: URL?, host: String?) -> GitInvocation {
+        guard let host else {
+            return GitInvocation(
+                executable: "/usr/bin/env",
+                args: ["git"] + gitArgs,
+                env: Process.gitEnv(),
+                cwd: cwd
+            )
+        }
+
+        let command = ["env", "GIT_OPTIONAL_LOCKS=0", "LC_ALL=C", "git"]
+            .joined(separator: " ")
+            + " "
+            + gitArgs.map(SSHCommand.shellQuote).joined(separator: " ")
+        let script = cwd.map { SSHCommand.remoteScript(cwd: $0.path, command: command) }
+            ?? SSHCommand.remoteScript(command: command)
+        let ssh = SSHCommand(host: host, mode: .batch)
+        return GitInvocation(
+            executable: SSHCommand.executable,
+            args: ssh.argv(remoteScript: script),
+            env: nil,
+            cwd: nil
+        )
+    }
+}

--- a/Alas/Sources/SSH/RemoteContentSearch.swift
+++ b/Alas/Sources/SSH/RemoteContentSearch.swift
@@ -1,0 +1,43 @@
+import Foundation
+
+/// Remote content search either streams `rg --json` through ssh or uses the
+/// host-aware `git grep` fallback when ripgrep is unavailable.
+enum RemoteContentSearch {
+    /// `git grep` does not offer a portable per-file result cap. Keep its
+    /// buffered fallback bounded before yielding into the search model.
+    static let maxGitGrepHits = 2_000
+
+    static func rgInvocation(host: String, cwd: String, rgArgs: [String]) -> RemoteExecInvocation {
+        let command = "rg " + rgArgs.map(SSHCommand.shellQuote).joined(separator: " ")
+        return RemoteExec.invocation(host: host, cwd: cwd, command: command)
+    }
+
+    static func gitGrepArgs(query: String, options: SearchContentOptions) -> [String] {
+        var args = ["grep", "-nI", "--column", "--untracked", "-z"]
+        if !options.regex { args.append("-F") }
+        if options.wholeWord { args.append("-w") }
+
+        // Content search's unchecked case control is smart-case, matching
+        // the local ripgrep invocation.
+        if !options.caseSensitive, !query.contains(where: \.isUppercase) {
+            args.append("-i")
+        }
+        args += ["-e", query, "--"]
+        return args
+    }
+
+    /// `git grep -z` output is `path\\0line:column:text`. The NUL delimiter
+    /// keeps colon-containing paths unambiguous.
+    static func parseGitGrepLine(_ line: String) -> (path: String, line: Int, column: Int, text: String)? {
+        guard let nul = line.firstIndex(of: "\u{0}") else { return nil }
+        let path = String(line[..<nul])
+        let rest = line[line.index(after: nul)...]
+        let parts = rest.split(separator: ":", maxSplits: 2, omittingEmptySubsequences: false)
+        guard parts.count == 3,
+              let lineNumber = Int(parts[0]),
+              let column = Int(parts[1]),
+              !path.isEmpty
+        else { return nil }
+        return (path, lineNumber, column, String(parts[2]))
+    }
+}

--- a/Alas/Sources/SSH/RemoteContentSearch.swift
+++ b/Alas/Sources/SSH/RemoteContentSearch.swift
@@ -14,7 +14,11 @@ enum RemoteContentSearch {
 
     static func gitGrepArgs(query: String, options: SearchContentOptions) -> [String] {
         var args = ["grep", "-nI", "--column", "--untracked", "-z"]
-        if !options.regex { args.append("-F") }
+        if options.regex {
+            args.append("-E")
+        } else {
+            args.append("-F")
+        }
         if options.wholeWord { args.append("-w") }
 
         // Content search's unchecked case control is smart-case, matching
@@ -26,18 +30,35 @@ enum RemoteContentSearch {
         return args
     }
 
-    /// `git grep -z` output is `path\\0line:column:text`. The NUL delimiter
-    /// keeps colon-containing paths unambiguous.
+    static func cappedGitGrepInvocation(host: String, cwd: String, query: String, options: SearchContentOptions) -> RemoteExecInvocation {
+        let gitArgs = gitGrepArgs(query: query, options: options).map(SSHCommand.shellQuote).joined(separator: " ")
+        let cap = maxGitGrepHits
+        let command = [
+            "fifo=\"${TMPDIR:-/tmp}/alas-git-grep-$$.fifo\"",
+            "rm -f \"$fifo\"",
+            "mkfifo \"$fifo\" || exit 2",
+            "trap 'rm -f \"$fifo\"' EXIT HUP INT TERM",
+            "awk -v cap=\(cap) '{ print; if (NR >= cap) exit }' < \"$fifo\" & awk_pid=$!",
+            "env GIT_OPTIONAL_LOCKS=0 LC_ALL=C git \(gitArgs) > \"$fifo\"",
+            "git_status=$?",
+            "wait \"$awk_pid\"",
+            "awk_status=$?",
+            "case \"$git_status\" in 13|141) exit 0 ;; esac",
+            "[ \"$awk_status\" -eq 0 ] || exit \"$awk_status\"",
+            "exit \"$git_status\"",
+        ].joined(separator: "; ")
+        return RemoteExec.invocation(host: host, cwd: cwd, command: command)
+    }
+
+    /// `git grep -z` output is `path\\0line\\0column\\0text`.
     static func parseGitGrepLine(_ line: String) -> (path: String, line: Int, column: Int, text: String)? {
-        guard let nul = line.firstIndex(of: "\u{0}") else { return nil }
-        let path = String(line[..<nul])
-        let rest = line[line.index(after: nul)...]
-        let parts = rest.split(separator: ":", maxSplits: 2, omittingEmptySubsequences: false)
-        guard parts.count == 3,
-              let lineNumber = Int(parts[0]),
-              let column = Int(parts[1]),
-              !path.isEmpty
+        let parts = line.split(separator: "\u{0}", maxSplits: 3, omittingEmptySubsequences: false)
+        guard parts.count == 4,
+              let lineNumber = Int(parts[1]),
+              let column = Int(parts[2]),
+              !parts[0].isEmpty
         else { return nil }
-        return (path, lineNumber, column, String(parts[2]))
+        let path = String(parts[0])
+        return (path, lineNumber, column, String(parts[3]))
     }
 }

--- a/Alas/Sources/SSH/RemoteExec.swift
+++ b/Alas/Sources/SSH/RemoteExec.swift
@@ -1,0 +1,37 @@
+import Foundation
+
+struct RemoteExecInvocation: Equatable {
+    let executable: String
+    let args: [String]
+}
+
+/// Runs a non-git command on a remote host in batch mode. Git commands go
+/// through `Process.git` (host-aware via `RemoteHostRegistry`); this is for
+/// everything else a remote project needs: capability probes, `ls`, `wc`.
+enum RemoteExec {
+    static func invocation(host: String, cwd: String?, command: String) -> RemoteExecInvocation {
+        let script = cwd.map { SSHCommand.remoteScript(cwd: $0, command: command) }
+            ?? SSHCommand.remoteScript(command: command)
+        let ssh = SSHCommand(host: host, mode: .batch)
+        return RemoteExecInvocation(
+            executable: SSHCommand.executable,
+            args: ssh.argv(remoteScript: script)
+        )
+    }
+
+    static func run(
+        host: String,
+        cwd: String?,
+        command: String,
+        timeout: TimeInterval = Process.defaultTimeout
+    ) async throws -> ProcessResult {
+        let invocation = invocation(host: host, cwd: cwd, command: command)
+        return try await Process.run(invocation.executable, args: invocation.args, timeout: timeout)
+    }
+
+    /// ssh reserves exit code 255 for its own failures (connect, auth,
+    /// host key); any other code is the remote command's exit status.
+    static func isConnectionFailure(exitCode: Int32) -> Bool {
+        exitCode == 255
+    }
+}

--- a/Alas/Sources/SSH/RemoteExec.swift
+++ b/Alas/Sources/SSH/RemoteExec.swift
@@ -29,6 +29,21 @@ enum RemoteExec {
         return try await Process.run(invocation.executable, args: invocation.args, timeout: timeout)
     }
 
+    /// Binary-safe variant of `run` (stdout as raw `Data`).
+    static func runData(
+        host: String,
+        cwd: String?,
+        command: String,
+        timeout: TimeInterval = Process.defaultTimeout
+    ) async throws -> ProcessResultData {
+        let invocation = invocation(host: host, cwd: cwd, command: command)
+        return try await Process.runData(
+            invocation.executable,
+            args: invocation.args,
+            timeout: timeout
+        )
+    }
+
     /// ssh reserves exit code 255 for its own failures (connect, auth,
     /// host key); any other code is the remote command's exit status.
     static func isConnectionFailure(exitCode: Int32) -> Bool {

--- a/Alas/Sources/SSH/RemoteFileAccess.swift
+++ b/Alas/Sources/SSH/RemoteFileAccess.swift
@@ -1,0 +1,128 @@
+import Foundation
+
+enum RemoteReadResult: Equatable {
+    case file(data: Data, mtime: Date)
+    case missing
+    case directory
+    case unreadable(String)
+}
+
+enum RemoteFileAccessError: Error, Equatable {
+    case connectionFailed(String)
+    case writeFailed(String)
+}
+
+/// Should a remote save proceed given the buffer's baseline mtime and the
+/// file's current remote mtime? A strictly newer remote mtime means someone
+/// else wrote the file since we loaded it.
+enum RemoteSaveGate {
+    enum Decision: Equatable {
+        case proceed
+        case conflict
+        case targetDeleted
+    }
+
+    static func decision(originalMtime: Date?, remoteMtime: Date?) -> Decision {
+        guard let originalMtime else { return .proceed }
+        guard let remoteMtime else { return .targetDeleted }
+        return remoteMtime > originalMtime ? .conflict : .proceed
+    }
+}
+
+/// File I/O over ssh, one round trip per operation. Scripts are POSIX
+/// portable (GNU and BSD remotes); `stat` flavors are chained instead of
+/// OS-gated. Exit-code contract for reads: 3 = directory, 4 = missing.
+enum RemoteFileAccess {
+    /// Chained GNU-then-BSD mtime probe, reused across scripts.
+    private static let statMtime = "stat -c %Y -- \"$f\" 2>/dev/null || stat -f %m -- \"$f\""
+
+    static func readScript(path: String) -> String {
+        "f=\(SSHCommand.shellQuote(path)); "
+            + "[ -d \"$f\" ] && exit 3; "
+            + "[ -e \"$f\" ] || exit 4; "
+            + "(\(statMtime)); "
+            + "cat -- \"$f\""
+    }
+
+    /// Payload is `<epoch-seconds>\\n<raw bytes>`; the body is binary-safe.
+    static func parseReadPayload(_ data: Data) -> (mtime: Date, contents: Data)? {
+        guard let newline = data.firstIndex(of: UInt8(ascii: "\n")) else { return nil }
+        guard let header = String(data: data[data.startIndex..<newline], encoding: .utf8),
+              let seconds = TimeInterval(header.trimmingCharacters(in: .whitespaces))
+        else { return nil }
+        let body = data[data.index(after: newline)...]
+        return (Date(timeIntervalSince1970: seconds), Data(body))
+    }
+
+    static func read(host: String, path: String) async throws -> RemoteReadResult {
+        let result = try await RemoteExec.runData(
+            host: host,
+            cwd: nil,
+            command: readScript(path: path)
+        )
+        if RemoteExec.isConnectionFailure(exitCode: result.exitCode) {
+            throw RemoteFileAccessError.connectionFailed(result.stderr)
+        }
+        switch result.exitCode {
+        case 3:
+            return .directory
+        case 4:
+            return .missing
+        case 0:
+            guard let parsed = parseReadPayload(result.stdout) else {
+                return .unreadable("unexpected read payload")
+            }
+            return .file(data: parsed.contents, mtime: parsed.mtime)
+        default:
+            return .unreadable(result.stderr)
+        }
+    }
+
+    /// Atomically writes content while preserving the mode of an existing
+    /// file. New files use the remote process's umask. Prints the post-save
+    /// mtime on stdout.
+    static func writeScript(path: String) -> String {
+        "f=\(SSHCommand.shellQuote(path)); t=\"$f.alas-$$.tmp\"; "
+            + "if [ -f \"$f\" ]; then cp -p -- \"$f\" \"$t\" || exit 3; fi; "
+            + "cat > \"$t\" || { rm -f -- \"$t\"; exit 4; }; "
+            + "mv -- \"$t\" \"$f\" || { rm -f -- \"$t\"; exit 5; }; "
+            + statMtime
+    }
+
+    static func write(host: String, path: String, content: String) async throws -> Date {
+        let invocation = RemoteExec.invocation(
+            host: host,
+            cwd: nil,
+            command: writeScript(path: path)
+        )
+        let result = try await Process.run(
+            invocation.executable,
+            args: invocation.args,
+            stdin: content,
+            timeout: 60
+        )
+        if RemoteExec.isConnectionFailure(exitCode: result.exitCode) {
+            throw RemoteFileAccessError.connectionFailed(result.stderr)
+        }
+        guard result.exitCode == 0,
+              let seconds = TimeInterval(result.stdout.trimmingCharacters(in: .whitespacesAndNewlines))
+        else {
+            throw RemoteFileAccessError.writeFailed(result.stderr)
+        }
+        return Date(timeIntervalSince1970: seconds)
+    }
+
+    /// Returns nil when the target does not exist. Throws only for an ssh
+    /// connection failure.
+    static func mtime(host: String, path: String) async throws -> Date? {
+        let command = "f=\(SSHCommand.shellQuote(path)); \(statMtime)"
+        let result = try await RemoteExec.run(host: host, cwd: nil, command: command)
+        if RemoteExec.isConnectionFailure(exitCode: result.exitCode) {
+            throw RemoteFileAccessError.connectionFailed(result.stderr)
+        }
+        guard result.exitCode == 0,
+              let seconds = TimeInterval(result.stdout.trimmingCharacters(in: .whitespacesAndNewlines))
+        else { return nil }
+        return Date(timeIntervalSince1970: seconds)
+    }
+}

--- a/Alas/Sources/SSH/RemoteFileAccess.swift
+++ b/Alas/Sources/SSH/RemoteFileAccess.swift
@@ -4,6 +4,7 @@ enum RemoteReadResult: Equatable {
     case file(data: Data, mtime: Date)
     case missing
     case directory
+    case symlink
     case unreadable(String)
 }
 
@@ -27,6 +28,11 @@ enum RemoteSaveGate {
         guard let remoteMtime else { return .targetDeleted }
         return remoteMtime > originalMtime ? .conflict : .proceed
     }
+
+    static func requiresContentCheck(originalMtime: Date?, remoteMtime: Date?) -> Bool {
+        guard let originalMtime, let remoteMtime else { return false }
+        return remoteMtime <= originalMtime
+    }
 }
 
 /// File I/O over ssh, one round trip per operation. Scripts are POSIX
@@ -34,14 +40,15 @@ enum RemoteSaveGate {
 /// OS-gated. Exit-code contract for reads: 3 = directory, 4 = missing.
 enum RemoteFileAccess {
     /// Chained GNU-then-BSD mtime probe, reused across scripts.
-    private static let statMtime = "stat -c %Y -- \"$f\" 2>/dev/null || stat -f %m -- \"$f\""
+    private static let statMtime = "stat -c %Y -- \"$f\" 2>/dev/null || stat -f %m \"$f\""
 
     static func readScript(path: String) -> String {
         "f=\(SSHCommand.shellQuote(path)); "
+            + "[ -L \"$f\" ] && exit 5; "
             + "[ -d \"$f\" ] && exit 3; "
             + "[ -e \"$f\" ] || exit 4; "
             + "(\(statMtime)); "
-            + "cat -- \"$f\""
+            + "cat \"$f\""
     }
 
     /// Payload is `<epoch-seconds>\\n<raw bytes>`; the body is binary-safe.
@@ -68,6 +75,8 @@ enum RemoteFileAccess {
             return .directory
         case 4:
             return .missing
+        case 5:
+            return .symlink
         case 0:
             guard let parsed = parseReadPayload(result.stdout) else {
                 return .unreadable("unexpected read payload")
@@ -83,9 +92,17 @@ enum RemoteFileAccess {
     /// mtime on stdout.
     static func writeScript(path: String) -> String {
         "f=\(SSHCommand.shellQuote(path)); t=\"$f.alas-$$.tmp\"; "
-            + "if [ -f \"$f\" ]; then cp -p -- \"$f\" \"$t\" || exit 3; fi; "
-            + "cat > \"$t\" || { rm -f -- \"$t\"; exit 4; }; "
-            + "mv -- \"$t\" \"$f\" || { rm -f -- \"$t\"; exit 5; }; "
+            + "[ -L \"$f\" ] && exit 6; "
+            + "[ -d \"$f\" ] && exit 7; "
+            + "mode=\"\"; "
+            + "if [ -f \"$f\" ]; then "
+            + "mode=$(stat -c %a -- \"$f\" 2>/dev/null || stat -f %Lp \"$f\") || exit 3; "
+            + "cp -p \"$f\" \"$t\" || exit 3; "
+            + "chmod u+w \"$t\" || { rm -f \"$t\"; exit 3; }; "
+            + "fi; "
+            + "cat > \"$t\" || { rm -f \"$t\"; exit 4; }; "
+            + "[ -z \"$mode\" ] || chmod \"$mode\" \"$t\" || { rm -f \"$t\"; exit 4; }; "
+            + "mv \"$t\" \"$f\" || { rm -f \"$t\"; exit 5; }; "
             + statMtime
     }
 

--- a/Alas/Sources/SSH/RemoteFileOps.swift
+++ b/Alas/Sources/SSH/RemoteFileOps.swift
@@ -1,0 +1,24 @@
+import Foundation
+
+/// POSIX-portable filesystem operations used for remote editor path changes.
+enum RemoteFileOps {
+    static func mkdirCommand(parentOf path: String) -> String {
+        let parent = URL(fileURLWithPath: path).deletingLastPathComponent().path
+        return "mkdir -p \(SSHCommand.shellQuote(parent))"
+    }
+
+    static func moveCommand(from: String, to: String) -> String {
+        let quotedSource = SSHCommand.shellQuote(from)
+        let quotedDestination = SSHCommand.shellQuote(to)
+        return "\(mkdirCommand(parentOf: to)) && [ ! -e \(quotedDestination) ] && [ ! -L \(quotedDestination) ] && mv \(quotedSource) \(quotedDestination)"
+    }
+
+    static func removeCommand(path: String) -> String {
+        "p=\(SSHCommand.shellQuote(path)); rm -rf \"$p\""
+    }
+
+    static func createEmptyFileCommand(path: String) -> String {
+        let quotedPath = SSHCommand.shellQuote(path)
+        return "\(mkdirCommand(parentOf: path)) && f=\(quotedPath) && [ ! -e \"$f\" ] && [ ! -L \"$f\" ] && (set -C; : > \"$f\")"
+    }
+}

--- a/Alas/Sources/SSH/RemoteFileStats.swift
+++ b/Alas/Sources/SSH/RemoteFileStats.swift
@@ -1,0 +1,38 @@
+import Foundation
+import OSLog
+
+enum RemoteFileStats {
+    private static let logger = Logger(subsystem: "app.alas", category: "RemoteFileStats")
+    static let maxBatchedPaths = 200
+
+    static func wcCommand(paths: [String]) -> String? {
+        guard !paths.isEmpty else { return nil }
+        return "wc -l " + paths.map(SSHCommand.shellQuote).joined(separator: " ")
+    }
+
+    static func parseWcOutput(_ output: String, requested: [String]) -> [String: Int] {
+        let requested = Set(requested)
+        return output.split(separator: "\n").reduce(into: [:]) { counts, line in
+            let line = line.trimmingCharacters(in: .whitespaces)
+            guard let separator = line.firstIndex(of: " "), let count = Int(line[..<separator]) else { return }
+            let path = String(line[line.index(after: separator)...])
+            if requested.contains(path) { counts[path] = count }
+        }
+    }
+
+    static func lineCounts(host: String, cwd: String, paths: [String]) async -> [String: Int] {
+        let paths = Array(paths.prefix(maxBatchedPaths))
+        guard let command = wcCommand(paths: paths),
+              let result = try? await RemoteExec.run(host: host, cwd: cwd, command: command),
+              !RemoteExec.isConnectionFailure(exitCode: result.exitCode)
+        else { return [:] }
+        return parseWcOutput(result.stdout, requested: paths)
+    }
+
+    static func parseLsEntries(_ output: String) -> [(name: String, isDirectory: Bool)] {
+        output.split(separator: "\n").map {
+            let name = String($0)
+            return name.hasSuffix("/") ? (String(name.dropLast()), true) : (name, false)
+        }
+    }
+}

--- a/Alas/Sources/SSH/RemoteHostCapabilities.swift
+++ b/Alas/Sources/SSH/RemoteHostCapabilities.swift
@@ -1,0 +1,102 @@
+import Foundation
+
+/// What a remote host offers, probed once per host per app run. Drives
+/// BSD-vs-GNU tool choices and graceful degradation (`rg` fallback, zmx
+/// availability for remote terminals).
+struct RemoteHostCapabilities: Equatable {
+    enum OS: Equatable {
+        case linux
+        case macos
+        case other
+    }
+
+    let os: OS
+    let gitVersion: String?
+    let hasRipgrep: Bool
+    let hasZmx: Bool
+
+    /// POSIX-portable probe; each line is independently parseable so a
+    /// missing tool never shifts the others.
+    static let probeCommand =
+        "uname -s; git version 2>/dev/null; "
+        + "command -v rg >/dev/null 2>&1 && echo rg=yes || echo rg=no; "
+        + "command -v zmx >/dev/null 2>&1 && echo zmx=yes || echo zmx=no"
+
+    static func parse(_ output: String) -> RemoteHostCapabilities {
+        var os = OS.other
+        var gitVersion: String?
+        var hasRipgrep = false
+        var hasZmx = false
+
+        for line in output.split(separator: "\n").map({ $0.trimmingCharacters(in: .whitespaces) }) {
+            switch line {
+            case "Linux": os = .linux
+            case "Darwin": os = .macos
+            case "rg=yes": hasRipgrep = true
+            case "zmx=yes": hasZmx = true
+            default:
+                if line.hasPrefix("git version ") {
+                    gitVersion = line.dropFirst("git version ".count)
+                        .split(separator: " ").first.map(String.init)
+                }
+            }
+        }
+
+        return RemoteHostCapabilities(
+            os: os,
+            gitVersion: gitVersion,
+            hasRipgrep: hasRipgrep,
+            hasZmx: hasZmx
+        )
+    }
+}
+
+/// One probe per host per app run, cached. Connection failures are not
+/// cached so a host that comes online later probes again.
+final class RemoteHostCapabilityStore: @unchecked Sendable {
+    static let shared = RemoteHostCapabilityStore()
+
+    private let lock = NSLock()
+    private var cache: [String: RemoteHostCapabilities] = [:]
+    private var inFlight: [String: Task<RemoteHostCapabilities?, Never>] = [:]
+
+    func capabilities(for host: String) async -> RemoteHostCapabilities? {
+        lock.lock()
+        if let cached = cache[host] {
+            lock.unlock()
+            return cached
+        }
+        if let running = inFlight[host] {
+            lock.unlock()
+            return await running.value
+        }
+
+        let task = Task<RemoteHostCapabilities?, Never> {
+            guard let result = try? await RemoteExec.run(
+                host: host,
+                cwd: nil,
+                command: RemoteHostCapabilities.probeCommand
+            ), !RemoteExec.isConnectionFailure(exitCode: result.exitCode) else {
+                return nil
+            }
+            return RemoteHostCapabilities.parse(result.stdout)
+        }
+        inFlight[host] = task
+        lock.unlock()
+
+        let capabilities = await task.value
+        lock.lock()
+        inFlight.removeValue(forKey: host)
+        if let capabilities {
+            cache[host] = capabilities
+        }
+        lock.unlock()
+        return capabilities
+    }
+
+    func invalidate(host: String) {
+        lock.lock()
+        cache.removeValue(forKey: host)
+        lock.unlock()
+    }
+}

--- a/Alas/Sources/SSH/RemoteHostCapabilities.swift
+++ b/Alas/Sources/SSH/RemoteHostCapabilities.swift
@@ -22,7 +22,7 @@ struct RemoteHostCapabilities: Equatable {
     static let probeCommand =
         "uname -s; git version 2>/dev/null; "
         + "command -v rg >/dev/null 2>&1 && echo rg=yes || echo rg=no; "
-        + "command -v zmx >/dev/null 2>&1 && echo zmx=yes || echo zmx=no; "
+        + "(command -v zmx >/dev/null 2>&1 || [ -x \"$HOME/.alas/bin/zmx\" ]) && echo zmx=yes || echo zmx=no; "
         + "echo \"arch=$(uname -m)\""
 
     static func parse(_ output: String) -> RemoteHostCapabilities {

--- a/Alas/Sources/SSH/RemoteHostCapabilities.swift
+++ b/Alas/Sources/SSH/RemoteHostCapabilities.swift
@@ -14,19 +14,23 @@ struct RemoteHostCapabilities: Equatable {
     let gitVersion: String?
     let hasRipgrep: Bool
     let hasZmx: Bool
+    /// Normalized machine architecture (`arm64` is represented as `aarch64`).
+    let arch: String?
 
     /// POSIX-portable probe; each line is independently parseable so a
     /// missing tool never shifts the others.
     static let probeCommand =
         "uname -s; git version 2>/dev/null; "
         + "command -v rg >/dev/null 2>&1 && echo rg=yes || echo rg=no; "
-        + "command -v zmx >/dev/null 2>&1 && echo zmx=yes || echo zmx=no"
+        + "command -v zmx >/dev/null 2>&1 && echo zmx=yes || echo zmx=no; "
+        + "echo \"arch=$(uname -m)\""
 
     static func parse(_ output: String) -> RemoteHostCapabilities {
         var os = OS.other
         var gitVersion: String?
         var hasRipgrep = false
         var hasZmx = false
+        var arch: String?
 
         for line in output.split(separator: "\n").map({ $0.trimmingCharacters(in: .whitespaces) }) {
             switch line {
@@ -38,6 +42,10 @@ struct RemoteHostCapabilities: Equatable {
                 if line.hasPrefix("git version ") {
                     gitVersion = line.dropFirst("git version ".count)
                         .split(separator: " ").first.map(String.init)
+                } else if line.hasPrefix("arch=") {
+                    let value = String(line.dropFirst("arch=".count))
+                    guard !value.isEmpty else { continue }
+                    arch = value == "arm64" ? "aarch64" : value
                 }
             }
         }
@@ -46,7 +54,8 @@ struct RemoteHostCapabilities: Equatable {
             os: os,
             gitVersion: gitVersion,
             hasRipgrep: hasRipgrep,
-            hasZmx: hasZmx
+            hasZmx: hasZmx,
+            arch: arch
         )
     }
 }

--- a/Alas/Sources/SSH/RemoteHostRegistry.swift
+++ b/Alas/Sources/SSH/RemoteHostRegistry.swift
@@ -1,0 +1,55 @@
+import Foundation
+
+/// Maps absolute filesystem roots of remote projects and linked worktrees to
+/// their SSH host. Local projects are never registered, preserving the local
+/// git path unchanged.
+final class RemoteHostRegistry: @unchecked Sendable {
+    static let shared = RemoteHostRegistry()
+
+    private let lock = NSLock()
+    private var hostsByRoot: [String: String] = [:]
+
+    private static func normalize(_ root: String) -> String {
+        root.count > 1 && root.hasSuffix("/") ? String(root.dropLast()) : root
+    }
+
+    func register(root: String, host: String) {
+        lock.lock()
+        hostsByRoot[Self.normalize(root)] = host
+        lock.unlock()
+    }
+
+    func unregister(root: String) {
+        lock.lock()
+        hostsByRoot.removeValue(forKey: Self.normalize(root))
+        lock.unlock()
+    }
+
+    /// Finds the longest path-component root containing `path`.
+    func host(forPath path: String?) -> String? {
+        guard let path else { return nil }
+        lock.lock()
+        defer { lock.unlock() }
+
+        var best: (root: String, host: String)?
+        for (root, host) in hostsByRoot where path == root || path.hasPrefix(root + "/") {
+            if best == nil || root.count > best!.root.count {
+                best = (root, host)
+            }
+        }
+        return best?.host
+    }
+
+    func removeAll() {
+        lock.lock()
+        hostsByRoot.removeAll()
+        lock.unlock()
+    }
+}
+
+extension URL {
+    /// Direct local-filesystem operations cannot be used for registered paths.
+    var isRemoteAlasPath: Bool {
+        RemoteHostRegistry.shared.host(forPath: path) != nil
+    }
+}

--- a/Alas/Sources/SSH/RemoteHostStatusStore.swift
+++ b/Alas/Sources/SSH/RemoteHostStatusStore.swift
@@ -1,0 +1,30 @@
+import Combine
+import Foundation
+
+/// Tracks per-host reachability from background poll results. Two
+/// consecutive connection failures flip a host offline (one can be a
+/// transient blip mid-roam); any success flips it back.
+@MainActor
+final class RemoteHostStatusStore: ObservableObject {
+    static let shared = RemoteHostStatusStore()
+
+    @Published private(set) var offlineHosts: Set<String> = []
+    private var consecutiveFailures: [String: Int] = [:]
+
+    func reportConnectionFailure(host: String) {
+        let count = (consecutiveFailures[host] ?? 0) + 1
+        consecutiveFailures[host] = count
+        if count >= 2 {
+            offlineHosts.insert(host)
+        }
+    }
+
+    func reportSuccess(host: String) {
+        consecutiveFailures[host] = nil
+        offlineHosts.remove(host)
+    }
+
+    func isOffline(_ host: String) -> Bool {
+        offlineHosts.contains(host)
+    }
+}

--- a/Alas/Sources/SSH/RemoteImageCache.swift
+++ b/Alas/Sources/SSH/RemoteImageCache.swift
@@ -1,0 +1,32 @@
+import Foundation
+
+/// Small in-memory cache for remote image bytes shown in ACP tool cards.
+/// Failed reads are deliberately not cached so a recovered SSH connection can
+/// retry the image on the next render.
+actor RemoteImageCache {
+    static let shared = RemoteImageCache()
+
+    private var cache: [String: Data] = [:]
+    private var order: [String] = []
+    private let capacity = 32
+
+    func imageData(host: String, path: String) async -> Data? {
+        let key = "\(host)\u{0}\(path)"
+        if let cached = cache[key] { return cached }
+
+        guard case let .file(data, _) = try? await RemoteFileAccess.read(host: host, path: path)
+        else { return nil }
+
+        // Another task can complete the same read while this actor awaits.
+        // Reuse the cached result instead of recording the key twice.
+        if let cached = cache[key] { return cached }
+
+        while order.count >= capacity, let oldest = order.first {
+            order.removeFirst()
+            cache.removeValue(forKey: oldest)
+        }
+        cache[key] = data
+        order.append(key)
+        return data
+    }
+}

--- a/Alas/Sources/SSH/RemoteLSPLauncher.swift
+++ b/Alas/Sources/SSH/RemoteLSPLauncher.swift
@@ -1,0 +1,88 @@
+import Foundation
+
+/// Spawns language servers on the remote host. The Content-Length-framed
+/// LSP stream rides the ssh child's stdio exactly like the ACP channel;
+/// `file://` URIs are correct on both sides because the server and the
+/// files share the remote filesystem.
+enum RemoteLSPLauncher {
+    static func invocation(
+        host: String,
+        rootPath: String,
+        command: String,
+        args: [String],
+        env: [String: String]
+    ) -> RemoteExecInvocation {
+        let prefix = sourceKitResolutionPrefix(command: command, env: env)
+        let executable = prefix == nil ? SSHCommand.shellQuote(command) : "\"$resolved_lsp\""
+        let argv = ([executable] + args.map(SSHCommand.shellQuote)).joined(separator: " ")
+        let run: String
+        if env.isEmpty {
+            run = "\(prefix ?? "")exec \(argv)"
+        } else {
+            let pairs = env.sorted { $0.key < $1.key }
+                .map { SSHCommand.shellQuote("\($0.key)=\($0.value)") }
+                .joined(separator: " ")
+            run = "\(prefix ?? "")exec env \(pairs) \(argv)"
+        }
+        return RemoteExec.invocation(host: host, cwd: rootPath, command: run)
+    }
+
+    private static let availabilityLock = NSLock()
+    nonisolated(unsafe) private static var availability: [String: Bool] = [:]
+
+    /// Cached `command -v` probe. Connection failures return false but are
+    /// not cached, so a host that comes back online probes again.
+    static func isAvailable(command: String, host: String, env: [String: String] = [:]) async -> Bool {
+        let key = availabilityCacheKey(command: command, host: host, env: env)
+        availabilityLock.lock()
+        let cached = availability[key]
+        availabilityLock.unlock()
+        if let cached { return cached }
+
+        guard let result = try? await RemoteExec.run(
+            host: host,
+            cwd: nil,
+            command: availabilityProbeCommand(command: command, env: env),
+            timeout: 10
+        ), !RemoteExec.isConnectionFailure(exitCode: result.exitCode) else {
+            return false
+        }
+
+        let available = result.exitCode == 0
+        availabilityLock.lock()
+        availability[key] = available
+        availabilityLock.unlock()
+        return available
+    }
+
+    static func availabilityProbeCommand(command: String, env: [String: String] = [:]) -> String {
+        let probe: String
+        if command == "sourcekit-lsp" {
+            probe = "command -v 'sourcekit-lsp' >/dev/null 2>&1 || xcrun --find 'sourcekit-lsp' >/dev/null 2>&1"
+        } else {
+            probe = "command -v \(SSHCommand.shellQuote(command))"
+        }
+        guard !env.isEmpty else { return probe }
+        return "env \(envAssignments(env)) sh -c \(SSHCommand.shellQuote(probe))"
+    }
+
+    private static func sourceKitResolutionPrefix(command: String, env: [String: String]) -> String? {
+        guard command == "sourcekit-lsp" else { return nil }
+        if !env.isEmpty {
+            let resolver = #"command -v "$1" 2>/dev/null || xcrun --find "$1""#
+            return "resolved_lsp=$(env \(envAssignments(env)) sh -c \(SSHCommand.shellQuote(resolver)) sh 'sourcekit-lsp') && "
+        }
+        return "resolved_lsp=$(command -v 'sourcekit-lsp' 2>/dev/null || xcrun --find 'sourcekit-lsp') && "
+    }
+
+    private static func availabilityCacheKey(command: String, host: String, env: [String: String]) -> String {
+        ([host, command] + env.sorted { $0.key < $1.key }.map { "\($0.key)=\($0.value)" })
+            .joined(separator: "\u{0}")
+    }
+
+    private static func envAssignments(_ env: [String: String]) -> String {
+        env.sorted { $0.key < $1.key }
+            .map { SSHCommand.shellQuote("\($0.key)=\($0.value)") }
+            .joined(separator: " ")
+    }
+}

--- a/Alas/Sources/SSH/RemoteProjectGitWatcher.swift
+++ b/Alas/Sources/SSH/RemoteProjectGitWatcher.swift
@@ -1,0 +1,75 @@
+import AppKit
+import Foundation
+
+enum RemotePollCadence {
+    static let activeInterval: TimeInterval = 5
+    static let inactiveInterval: TimeInterval = 45
+    static let maxBackoff: TimeInterval = 300
+
+    static func nextDelay(succeeded: Bool, appActive: Bool, previous: TimeInterval) -> TimeInterval {
+        succeeded ? (appActive ? activeInterval : inactiveInterval) : min(previous * 2, maxBackoff)
+    }
+}
+
+@MainActor
+final class RemoteProjectGitWatcher {
+    var onHeadChanged: (([URL: String]) -> Void)?
+    var onTopologyChanged: (() -> Void)?
+
+    private let projectPath: URL
+    private let host: String?
+    private var pollTask: Task<Void, Never>?
+    private var lastEntries: [RemoteWorktreePollEntry]?
+
+    init(projectPath: URL) {
+        self.projectPath = projectPath
+        host = RemoteHostRegistry.shared.host(forPath: projectPath.path)
+    }
+
+    func start() {
+        guard pollTask == nil else { return }
+        pollTask = Task { [weak self] in
+            var delay = RemotePollCadence.activeInterval
+            while !Task.isCancelled {
+                guard let self else { return }
+                let succeeded = await tick()
+                delay = RemotePollCadence.nextDelay(
+                    succeeded: succeeded,
+                    appActive: NSApp?.isActive ?? true,
+                    previous: delay
+                )
+                try? await Task.sleep(nanoseconds: UInt64(delay * 1_000_000_000))
+            }
+        }
+    }
+
+    func stop() {
+        pollTask?.cancel()
+        pollTask = nil
+    }
+
+    private func tick() async -> Bool {
+        let result = try? await Process.git(["worktree", "list", "--porcelain"], cwd: projectPath)
+        guard let result, !RemoteExec.isConnectionFailure(exitCode: result.exitCode) else {
+            if let host { RemoteHostStatusStore.shared.reportConnectionFailure(host: host) }
+            return false
+        }
+        if let host { RemoteHostStatusStore.shared.reportSuccess(host: host) }
+        guard result.exitCode == 0 else { return true }
+
+        let entries = RemoteWorktreePoll.parse(porcelain: result.stdout)
+        defer { lastEntries = entries }
+        guard let old = lastEntries, let delta = RemoteWorktreePoll.classify(old: old, new: entries) else {
+            return true
+        }
+        if !delta.branchLabelsByPath.isEmpty {
+            onHeadChanged?(Dictionary(uniqueKeysWithValues: delta.branchLabelsByPath.map {
+                (URL(fileURLWithPath: $0.key), $0.value)
+            }))
+        }
+        if delta.topologyChanged { onTopologyChanged?() }
+        return true
+    }
+
+    deinit { pollTask?.cancel() }
+}

--- a/Alas/Sources/SSH/RemoteProjectGitWatcher.swift
+++ b/Alas/Sources/SSH/RemoteProjectGitWatcher.swift
@@ -59,6 +59,10 @@ final class RemoteProjectGitWatcher {
 
         let entries = RemoteWorktreePoll.parse(porcelain: result.stdout)
         defer { lastEntries = entries }
+        guard lastEntries != nil else {
+            onTopologyChanged?()
+            return true
+        }
         guard let old = lastEntries, let delta = RemoteWorktreePoll.classify(old: old, new: entries) else {
             return true
         }

--- a/Alas/Sources/SSH/RemoteRepoValidator.swift
+++ b/Alas/Sources/SSH/RemoteRepoValidator.swift
@@ -1,0 +1,36 @@
+import Foundation
+
+enum RemoteRepoValidationError: LocalizedError {
+    case unreachable(String)
+    case notARepository(String)
+
+    var errorDescription: String? {
+        switch self {
+        case let .unreachable(detail):
+            let message = detail.trimmingCharacters(in: .whitespacesAndNewlines)
+            return message.isEmpty ? "Could not reach the host over SSH." : message
+        case let .notARepository(path):
+            return "Not a git repository on the remote host: \(path)"
+        }
+    }
+}
+
+/// Batch-mode repository validation for the add-project flow.
+struct RemoteRepoValidator {
+    static func validate(host: String, path: String) async throws {
+        let command = "git -C \(SSHCommand.shellQuote(path)) rev-parse --is-inside-work-tree"
+        let ssh = SSHCommand(host: host, mode: .batch)
+        let result = try await Process.run(
+            SSHCommand.executable,
+            args: ssh.argv(remoteScript: SSHCommand.remoteScript(command: command)),
+            timeout: 20
+        )
+        if result.exitCode == 255 {
+            throw RemoteRepoValidationError.unreachable(result.stderr)
+        }
+        let output = result.stdout.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard result.exitCode == 0, output == "true" else {
+            throw RemoteRepoValidationError.notARepository(path)
+        }
+    }
+}

--- a/Alas/Sources/SSH/RemoteRepoValidator.swift
+++ b/Alas/Sources/SSH/RemoteRepoValidator.swift
@@ -15,22 +15,58 @@ enum RemoteRepoValidationError: LocalizedError {
     }
 }
 
-/// Batch-mode repository validation for the add-project flow.
+/// User-driven repository validation for the add-project flow.
 struct RemoteRepoValidator {
-    static func validate(host: String, path: String) async throws {
-        let command = "git -C \(SSHCommand.shellQuote(path)) rev-parse --is-inside-work-tree"
-        let ssh = SSHCommand(host: host, mode: .batch)
-        let result = try await Process.run(
+    typealias Runner = (String, [String], TimeInterval) async throws -> ProcessResult
+
+    static func validate(
+        host: String,
+        path: String,
+        runner: @escaping Runner = { executable, args, timeout in
+            try await Process.run(executable, args: args, timeout: timeout)
+        }
+    ) async throws {
+        let interactiveSSH = SSHCommand(host: host, mode: .interactive)
+        let preflight = try await runner(
             SSHCommand.executable,
-            args: ssh.argv(remoteScript: SSHCommand.remoteScript(command: command)),
-            timeout: 20
+            interactiveSSH.argv(remoteScript: SSHCommand.remoteScript(command: "true")),
+            30
+        )
+        guard preflight.exitCode == 0 else {
+            throw RemoteRepoValidationError.unreachable(firstContactFailureMessage(host: host, detail: preflight.stderr))
+        }
+
+        let batchSSH = SSHCommand(host: host, mode: .batch)
+        let command = "git -C \(SSHCommand.shellQuote(path)) rev-parse --is-inside-work-tree"
+        let result = try await runner(
+            SSHCommand.executable,
+            batchSSH.argv(remoteScript: SSHCommand.remoteScript(command: command)),
+            30
         )
         if result.exitCode == 255 {
-            throw RemoteRepoValidationError.unreachable(result.stderr)
+            throw RemoteRepoValidationError.unreachable(firstContactFailureMessage(host: host, detail: result.stderr))
         }
         let output = result.stdout.trimmingCharacters(in: .whitespacesAndNewlines)
         guard result.exitCode == 0, output == "true" else {
             throw RemoteRepoValidationError.notARepository(path)
         }
+    }
+
+    static func firstContactFailureMessage(host: String, detail: String) -> String {
+        let trimmed = detail.trimmingCharacters(in: .whitespacesAndNewlines)
+        let setupCommand = ([SSHCommand.executable] + SSHCommand(host: host, mode: .interactive).argv(
+            remoteScript: SSHCommand.remoteScript(command: "true")
+        ))
+        .map(localShellQuote)
+        .joined(separator: " ")
+        let guidance = "SSH access to \(host) needs interactive setup before adding this remote project. Run `\(setupCommand)` from a terminal to accept host keys or complete authentication, then try again."
+        return trimmed.isEmpty ? guidance : "\(guidance)\n\(trimmed)"
+    }
+
+    private static func localShellQuote(_ value: String) -> String {
+        if value.range(of: "[^A-Za-z0-9_/.@%+=,:~-]", options: .regularExpression) == nil {
+            return value
+        }
+        return SSHCommand.shellQuote(value)
     }
 }

--- a/Alas/Sources/SSH/RemoteStatusFingerprint.swift
+++ b/Alas/Sources/SSH/RemoteStatusFingerprint.swift
@@ -1,0 +1,8 @@
+import Foundation
+
+enum RemoteStatusFingerprint {
+    static func make(status: String, head: String) -> String { status + "\u{0}" + head }
+    static func shouldRefresh(previous: String?, current: String) -> Bool {
+        previous.map { $0 != current } ?? false
+    }
+}

--- a/Alas/Sources/SSH/RemoteStatusFingerprint.swift
+++ b/Alas/Sources/SSH/RemoteStatusFingerprint.swift
@@ -1,8 +1,17 @@
 import Foundation
 
 enum RemoteStatusFingerprint {
-    static func make(status: String, head: String) -> String { status + "\u{0}" + head }
+    static func make(
+        status: String,
+        head: String,
+        unstagedDiff: String = "",
+        stagedDiff: String = "",
+        untrackedContent: String = ""
+    ) -> String {
+        [status, head, unstagedDiff, stagedDiff, untrackedContent].joined(separator: "\u{0}")
+    }
+
     static func shouldRefresh(previous: String?, current: String) -> Bool {
-        previous.map { $0 != current } ?? false
+        previous.map { $0 != current } ?? true
     }
 }

--- a/Alas/Sources/SSH/RemoteTerminalScript.swift
+++ b/Alas/Sources/SSH/RemoteTerminalScript.swift
@@ -36,7 +36,7 @@ enum RemoteTerminalScript {
         } else {
             body = "exec \(shell)"
         }
-        return "cd -- \(SSHCommand.shellQuote(worktreePath)) && \(body)"
+        return "cd \(SSHCommand.shellQuote(worktreePath)) || exit; \(body)"
     }
 
     /// `-tt` forces remote pty allocation. Interactive SSH permits first-use

--- a/Alas/Sources/SSH/RemoteTerminalScript.swift
+++ b/Alas/Sources/SSH/RemoteTerminalScript.swift
@@ -1,0 +1,59 @@
+import Foundation
+
+/// Remote-side scripts for user-facing terminal surfaces and background zmx
+/// operations. All zmx state lives under `$HOME/.alas/zmx` so Alas never
+/// lists or kills a user's own zmx sessions.
+enum RemoteTerminalScript {
+    static let remoteZmxDirExport =
+        "export ZMX_DIR=\"$HOME/.alas/zmx\"; mkdir -p \"$ZMX_DIR\""
+
+    /// Prefer a host-installed zmx, then the Alas-pushed copy. An empty value
+    /// lets terminal surfaces fall back to a plain login shell.
+    private static let resolveZmx =
+        "Z=\"$(command -v zmx 2>/dev/null || true)\"; "
+        + "[ -z \"$Z\" ] && [ -x \"$HOME/.alas/bin/zmx\" ] && Z=\"$HOME/.alas/bin/zmx\""
+
+    /// The command handed to zmx, or run directly without persistence.
+    private static func shellCommand(startupSuffix: String?) -> String {
+        guard let suffix = startupSuffix, !suffix.isEmpty else {
+            return "\"$SHELL\" -l"
+        }
+        return "\"$SHELL\" -l -c \(SSHCommand.shellQuote("\(suffix); exec \"$SHELL\" -l"))"
+    }
+
+    static func attachScript(
+        worktreePath: String,
+        sessionName: String,
+        useZmx: Bool,
+        startupSuffix: String?
+    ) -> String {
+        let shell = shellCommand(startupSuffix: startupSuffix)
+        let body: String
+        if useZmx {
+            body = "\(remoteZmxDirExport); \(resolveZmx); "
+                + "if [ -n \"$Z\" ]; then exec \"$Z\" attach \(SSHCommand.shellQuote(sessionName)) \(shell); "
+                + "else exec \(shell); fi"
+        } else {
+            body = "exec \(shell)"
+        }
+        return "cd -- \(SSHCommand.shellQuote(worktreePath)) && \(body)"
+    }
+
+    /// `-tt` forces remote pty allocation. Interactive SSH permits first-use
+    /// host-key and authentication prompts to appear in the terminal surface.
+    static func surfaceInvocation(host: String, script: String) -> RemoteExecInvocation {
+        let ssh = SSHCommand(host: host, mode: .interactive)
+        return RemoteExecInvocation(
+            executable: SSHCommand.executable,
+            args: ["-tt"] + ssh.argv(remoteScript: SSHCommand.remoteScript(command: script))
+        )
+    }
+
+    /// Background zmx operation sharing the surface sessions' state directory
+    /// and binary-resolution ladder. A missing zmx reports no sessions.
+    static func zmxBatchCommand(_ args: [String]) -> String {
+        let argv = args.map(SSHCommand.shellQuote).joined(separator: " ")
+        return "\(remoteZmxDirExport); \(resolveZmx); "
+            + "[ -n \"$Z\" ] || exit 0; \"$Z\" \(argv)"
+    }
+}

--- a/Alas/Sources/SSH/RemoteWorktreePoll.swift
+++ b/Alas/Sources/SSH/RemoteWorktreePoll.swift
@@ -1,0 +1,86 @@
+import Foundation
+
+struct RemoteWorktreePollEntry: Equatable {
+    let path: String
+    let head: String
+    /// Full ref (`refs/heads/x`); nil when detached.
+    let branch: String?
+}
+
+struct RemoteWorktreePollDelta: Equatable {
+    /// Worktree path to display branch label, for `applyHeadUpdates`.
+    let branchLabelsByPath: [String: String]
+    /// True when worktrees were added/removed or any HEAD moved.
+    let topologyChanged: Bool
+}
+
+/// Pure snapshot/delta logic behind `RemoteProjectGitWatcher`. One
+/// `git worktree list --porcelain` per poll yields paths, HEAD shas, and
+/// branches for every worktree in a single ssh round trip.
+enum RemoteWorktreePoll {
+    static func parse(porcelain: String) -> [RemoteWorktreePollEntry] {
+        var entries: [RemoteWorktreePollEntry] = []
+        var path: String?
+        var head = ""
+        var branch: String?
+
+        func flush() {
+            if let path {
+                entries.append(RemoteWorktreePollEntry(path: path, head: head, branch: branch))
+            }
+            path = nil
+            head = ""
+            branch = nil
+        }
+
+        for rawLine in porcelain.split(separator: "\n", omittingEmptySubsequences: false) {
+            let line = String(rawLine)
+            if line.isEmpty {
+                flush()
+            } else if line.hasPrefix("worktree ") {
+                flush()
+                path = String(line.dropFirst("worktree ".count))
+            } else if line.hasPrefix("HEAD ") {
+                head = String(line.dropFirst("HEAD ".count))
+            } else if line.hasPrefix("branch ") {
+                branch = String(line.dropFirst("branch ".count))
+            }
+        }
+        flush()
+        return entries
+    }
+
+    static func label(forBranch branch: String?) -> String {
+        guard let branch else { return "(detached)" }
+        return branch.hasPrefix("refs/heads/")
+            ? String(branch.dropFirst("refs/heads/".count))
+            : branch
+    }
+
+    static func classify(
+        old: [RemoteWorktreePollEntry],
+        new: [RemoteWorktreePollEntry]
+    ) -> RemoteWorktreePollDelta? {
+        guard old != new else { return nil }
+
+        let oldByPath = Dictionary(uniqueKeysWithValues: old.map { ($0.path, $0) })
+        let pathSetChanged = Set(oldByPath.keys) != Set(new.map(\.path))
+        var branchLabelsByPath: [String: String] = [:]
+        var headMoved = false
+
+        for entry in new {
+            guard let previous = oldByPath[entry.path] else { continue }
+            if previous.branch != entry.branch {
+                branchLabelsByPath[entry.path] = label(forBranch: entry.branch)
+            }
+            if previous.head != entry.head {
+                headMoved = true
+            }
+        }
+
+        return RemoteWorktreePollDelta(
+            branchLabelsByPath: branchLabelsByPath,
+            topologyChanged: pathSetChanged || headMoved
+        )
+    }
+}

--- a/Alas/Sources/SSH/RemoteZmxInstaller.swift
+++ b/Alas/Sources/SSH/RemoteZmxInstaller.swift
@@ -1,0 +1,76 @@
+import Foundation
+
+/// Installs the bundled zmx helper in Alas' private remote directory. The
+/// caller owns consent; this type only performs bounded batch operations.
+enum RemoteZmxInstaller {
+    #if arch(arm64)
+    static let localArch = "aarch64"
+    #else
+    static let localArch = "x86_64"
+    #endif
+
+    static func bundledBinaryPath(
+        os: RemoteHostCapabilities.OS,
+        arch: String?,
+        resourceURL: URL
+    ) -> URL? {
+        guard let arch else { return nil }
+        switch (os, arch) {
+        case (.linux, "x86_64"):
+            return resourceURL.appendingPathComponent("zmx/linux-x86_64/zmx")
+        case (.linux, "aarch64"):
+            return resourceURL.appendingPathComponent("zmx/linux-aarch64/zmx")
+        case (.macos, let remoteArch) where remoteArch == localArch:
+            return resourceURL.appendingPathComponent("zmx/zmx")
+        default:
+            return nil
+        }
+    }
+
+    static func install(
+        host: String,
+        capabilities: RemoteHostCapabilities,
+        resourceURL: URL
+    ) async -> Bool {
+        guard let binary = bundledBinaryPath(
+            os: capabilities.os,
+            arch: capabilities.arch,
+            resourceURL: resourceURL
+        ), FileManager.default.isExecutableFile(atPath: binary.path) else {
+            return false
+        }
+
+        guard let mkdir = try? await RemoteExec.run(
+            host: host,
+            cwd: nil,
+            command: "mkdir -p \"$HOME/.alas/bin\"",
+            timeout: 10
+        ), mkdir.exitCode == 0 else {
+            return false
+        }
+
+        guard let copy = try? await Process.run(
+            SSHCommand.scpExecutable,
+            args: SSHCommand.scpArgv(
+                localPath: binary.path,
+                host: host,
+                remotePath: ".alas/bin/zmx.tmp"
+            ),
+            timeout: 60
+        ), copy.exitCode == 0 else {
+            return false
+        }
+
+        guard let finalize = try? await RemoteExec.run(
+            host: host,
+            cwd: nil,
+            command: "chmod +x \"$HOME/.alas/bin/zmx.tmp\" && "
+                + "mv \"$HOME/.alas/bin/zmx.tmp\" \"$HOME/.alas/bin/zmx\" && "
+                + "[ -x \"$HOME/.alas/bin/zmx\" ]",
+            timeout: 10
+        ) else {
+            return false
+        }
+        return finalize.exitCode == 0
+    }
+}

--- a/Alas/Sources/SSH/SSHCommand.swift
+++ b/Alas/Sources/SSH/SSHCommand.swift
@@ -31,19 +31,22 @@ struct SSHCommand: Equatable {
 
     /// Remote-side script that runs `command` in `cwd`.
     ///
-    /// `exec "$SHELL" -l -c` forces a login shell: sshd runs remote
-    /// commands through a non-login shell whose PATH misses Homebrew
-    /// (macOS remotes) and per-user additions (Linux), so `git`/`rg`
-    /// would otherwise be "command not found".
+    /// The top-level string is parsed by the account's login shell before
+    /// it reaches our script. Keep that layer to a simple `/bin/sh` launch
+    /// so users with fish/csh login shells can still run the POSIX snippets
+    /// generated throughout the remote stack.
     static func remoteScript(cwd: String, command: String) -> String {
-        "cd -- \(shellQuote(cwd)) && \(remoteScript(command: command))"
+        remoteScript(command: "cd \(shellQuote(cwd)) && \(command)")
     }
 
     /// Remote-side script without a working-directory change (probes that
     /// must not assume `cwd` exists, e.g. repo validation via `git -C`).
     static func remoteScript(command: String) -> String {
-        "exec \"$SHELL\" -l -c \(shellQuote(command))"
+        "/bin/sh -c \(shellQuote(remotePathPrelude + command))"
     }
+
+    private static let remotePathPrelude =
+        "PATH=\"$HOME/.alas/bin:$HOME/.local/bin:$HOME/bin:/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:$PATH\"; export PATH; "
 
     /// Argv after `SSHCommand.executable`. The script rides as the final
     /// argument; sshd hands it to the remote shell as a single string.

--- a/Alas/Sources/SSH/SSHCommand.swift
+++ b/Alas/Sources/SSH/SSHCommand.swift
@@ -18,6 +18,7 @@ struct SSHCommand: Equatable {
     }
 
     static let executable = "/usr/bin/ssh"
+    static let scpExecutable = "/usr/bin/scp"
 
     let host: String
     let mode: Mode
@@ -47,6 +48,18 @@ struct SSHCommand: Equatable {
     /// Argv after `SSHCommand.executable`. The script rides as the final
     /// argument; sshd hands it to the remote shell as a single string.
     func argv(remoteScript: String) -> [String] {
+        optionArgs + [host, remoteScript]
+    }
+
+    /// scp rides the same multiplexed batch connection as remote commands.
+    /// The destination is home-relative because scp does not reliably expand
+    /// a quoted `~` on every server implementation.
+    static func scpArgv(localPath: String, host: String, remotePath: String) -> [String] {
+        SSHCommand(host: host, mode: .batch).optionArgs
+            + ["-q", localPath, "\(host):\(remotePath)"]
+    }
+
+    private var optionArgs: [String] {
         var options: [String] = [
             "-o", "ControlMaster=auto",
             // %C is a short hash of (host, port, user); keeps the socket
@@ -64,6 +77,6 @@ struct SSHCommand: Equatable {
         case .interactive:
             options += ["-o", "ConnectTimeout=30"]
         }
-        return options + [host, remoteScript]
+        return options
     }
 }

--- a/Alas/Sources/SSH/SSHCommand.swift
+++ b/Alas/Sources/SSH/SSHCommand.swift
@@ -1,0 +1,69 @@
+import Foundation
+
+/// Builds `ssh` invocations for remote-project support.
+///
+/// Every invocation shares one multiplexed master connection per host
+/// (`ControlMaster=auto` + `ControlPersist`), so background git probes pay
+/// one round trip instead of a TCP+auth handshake, and the user
+/// authenticates (password / 2FA / FIDO touch) at most once per idle window.
+struct SSHCommand: Equatable {
+    /// Background probes must never hang on an interactive prompt; they
+    /// fail fast instead (`BatchMode=yes`, short connect timeout).
+    /// Interactive invocations (terminal surfaces, first-time connects
+    /// driven by the user) omit BatchMode so host-key and 2FA prompts can
+    /// render.
+    enum Mode: Equatable {
+        case batch
+        case interactive
+    }
+
+    static let executable = "/usr/bin/ssh"
+
+    let host: String
+    let mode: Mode
+
+    /// POSIX single-quote escaping: wraps in '...' with embedded single
+    /// quotes escaped as '\''. Safe for any content except NUL bytes.
+    static func shellQuote(_ value: String) -> String {
+        "'" + value.replacingOccurrences(of: "'", with: "'\\''") + "'"
+    }
+
+    /// Remote-side script that runs `command` in `cwd`.
+    ///
+    /// `exec "$SHELL" -l -c` forces a login shell: sshd runs remote
+    /// commands through a non-login shell whose PATH misses Homebrew
+    /// (macOS remotes) and per-user additions (Linux), so `git`/`rg`
+    /// would otherwise be "command not found".
+    static func remoteScript(cwd: String, command: String) -> String {
+        "cd -- \(shellQuote(cwd)) && \(remoteScript(command: command))"
+    }
+
+    /// Remote-side script without a working-directory change (probes that
+    /// must not assume `cwd` exists, e.g. repo validation via `git -C`).
+    static func remoteScript(command: String) -> String {
+        "exec \"$SHELL\" -l -c \(shellQuote(command))"
+    }
+
+    /// Argv after `SSHCommand.executable`. The script rides as the final
+    /// argument; sshd hands it to the remote shell as a single string.
+    func argv(remoteScript: String) -> [String] {
+        var options: [String] = [
+            "-o", "ControlMaster=auto",
+            // %C is a short hash of (host, port, user); keeps the socket
+            // path well under the ~104-byte unix-socket limit.
+            "-o", "ControlPath=~/.ssh/alas-%C",
+            "-o", "ControlPersist=10m",
+            // Dead-peer detection on every invocation that might become
+            // the master: ~15s (3 missed 5s keepalives).
+            "-o", "ServerAliveInterval=5",
+            "-o", "ServerAliveCountMax=3",
+        ]
+        switch mode {
+        case .batch:
+            options += ["-o", "BatchMode=yes", "-o", "ConnectTimeout=10"]
+        case .interactive:
+            options += ["-o", "ConnectTimeout=30"]
+        }
+        return options + [host, remoteScript]
+    }
+}

--- a/Alas/Sources/Search/ContentSearcher.swift
+++ b/Alas/Sources/Search/ContentSearcher.swift
@@ -42,16 +42,11 @@ final class ContentSearcher: Sendable {
     ) -> AsyncThrowingStream<ContentSearchHit, Error> {
         AsyncThrowingStream { continuation in
             let task = Task {
-                guard let rg = await Self.discoverRg() else {
-                    continuation.finish(throwing: SearchError.rgNotFound)
-                    return
-                }
                 var deferredFailure: Error? = nil
                 for wt in worktrees {
                     if Task.isCancelled { break }
                     do {
                         try await self.streamRg(
-                            rg: rg,
                             query: query,
                             options: options,
                             worktree: wt,
@@ -86,7 +81,6 @@ final class ContentSearcher: Sendable {
     }
 
     private func streamRg(
-        rg: String,
         query: String,
         options: SearchContentOptions,
         worktree: SearchWorktree,
@@ -114,9 +108,30 @@ final class ContentSearcher: Sendable {
         args.append(".")
 
         let process = Process()
-        process.executableURL = URL(fileURLWithPath: rg)
-        process.arguments = args
-        process.currentDirectoryURL = worktree.absolutePath
+        if let host = RemoteHostRegistry.shared.host(forPath: worktree.absolutePath.path) {
+            let capabilities = await RemoteHostCapabilityStore.shared.capabilities(for: host)
+            guard capabilities?.hasRipgrep == true else {
+                try await streamGitGrep(
+                    query: query,
+                    options: options,
+                    worktree: worktree,
+                    into: continuation
+                )
+                return
+            }
+            let invocation = RemoteContentSearch.rgInvocation(
+                host: host,
+                cwd: worktree.absolutePath.path,
+                rgArgs: args
+            )
+            process.executableURL = URL(fileURLWithPath: invocation.executable)
+            process.arguments = invocation.args
+        } else {
+            guard let rg = Self.discoverRg() else { throw SearchError.rgNotFound }
+            process.executableURL = URL(fileURLWithPath: rg)
+            process.arguments = args
+            process.currentDirectoryURL = worktree.absolutePath
+        }
 
         let outPipe = Pipe()
         let errPipe = Pipe()
@@ -200,6 +215,94 @@ final class ContentSearcher: Sendable {
     /// the blocking `availableData` calls cannot occupy Swift's cooperative
     /// executor, and it starts before `process.run()` so pipe output is drained
     /// concurrently with the child.
+
+    /// Buffered fallback for remote hosts without ripgrep. `Process.git` is
+    /// already remote-aware, so it runs this command through the same batch
+    /// ssh transport while preserving the normal local Git environment.
+    private func streamGitGrep(
+        query: String,
+        options: SearchContentOptions,
+        worktree: SearchWorktree,
+        into continuation: AsyncThrowingStream<ContentSearchHit, Error>.Continuation
+    ) async throws {
+        let result = try await Process.git(
+            RemoteContentSearch.gitGrepArgs(query: query, options: options),
+            cwd: worktree.absolutePath,
+            timeout: 60
+        )
+        // git grep uses 1 for a valid search without matches.
+        guard result.exitCode == 0 || result.exitCode == 1 else {
+            throw SearchError.rgFailed(exitCode: result.exitCode)
+        }
+
+        var emitted = 0
+        for line in result.stdout.split(separator: "\n", omittingEmptySubsequences: true) {
+            if Task.isCancelled { throw CancellationError() }
+            guard emitted < RemoteContentSearch.maxGitGrepHits else {
+                logger.notice("remote git grep hit cap (\(RemoteContentSearch.maxGitGrepHits))")
+                break
+            }
+            guard let parsed = RemoteContentSearch.parseGitGrepLine(String(line)) else { continue }
+            continuation.yield(makeGitGrepHit(
+                parsed,
+                worktree: worktree,
+                query: query,
+                options: options
+            ))
+            emitted += 1
+        }
+    }
+
+    private func makeGitGrepHit(
+        _ parsed: (path: String, line: Int, column: Int, text: String),
+        worktree: SearchWorktree,
+        query: String,
+        options: SearchContentOptions
+    ) -> ContentSearchHit {
+        let raw = parsed.text
+        let matchRange = firstMatchRange(in: raw, query: query, options: options)
+        let fallbackStart = max(0, parsed.column - 1)
+        let startByte = matchRange.map { raw[..<$0.lowerBound].utf8.count } ?? fallbackStart
+        let endByte = matchRange.map { raw[..<$0.upperBound].utf8.count } ?? startByte
+        let column = charOffset(forByteOffset: startByte, in: raw).map { $0 + 1 } ?? (startByte + 1)
+        let revealColumn = utf16Offset(forByteOffset: startByte, in: raw).map { $0 + 1 } ?? column
+        let (snippet, matchCharRange) = windowSnippet(
+            raw: raw,
+            matchStartByte: startByte,
+            matchEndByte: endByte
+        )
+        return ContentSearchHit(
+            worktreeId: worktree.id,
+            projectId: worktree.projectId,
+            relativePath: parsed.path,
+            line: parsed.line,
+            column: column,
+            revealColumn: revealColumn,
+            snippet: snippet,
+            matchCharRange: matchCharRange
+        )
+    }
+
+    private func firstMatchRange(
+        in text: String,
+        query: String,
+        options: SearchContentOptions
+    ) -> Range<String.Index>? {
+        let caseInsensitive = !options.caseSensitive && !query.contains(where: \.isUppercase)
+        if !options.regex {
+            return text.range(
+                of: query,
+                options: caseInsensitive ? [.caseInsensitive] : []
+            )
+        }
+
+        let regexOptions: NSRegularExpression.Options = caseInsensitive ? [.caseInsensitive] : []
+        guard let regex = try? NSRegularExpression(pattern: query, options: regexOptions),
+              let match = regex.firstMatch(in: text, range: NSRange(text.startIndex..., in: text))
+        else { return nil }
+        return Range(match.range, in: text)
+    }
+
     private func readAllLines(
         handle: FileHandle,
         worktree: SearchWorktree,

--- a/Alas/Sources/Search/ContentSearcher.swift
+++ b/Alas/Sources/Search/ContentSearcher.swift
@@ -127,7 +127,7 @@ final class ContentSearcher: Sendable {
             process.executableURL = URL(fileURLWithPath: invocation.executable)
             process.arguments = invocation.args
         } else {
-            guard let rg = Self.discoverRg() else { throw SearchError.rgNotFound }
+            guard let rg = await Self.discoverRg() else { throw SearchError.rgNotFound }
             process.executableURL = URL(fileURLWithPath: rg)
             process.arguments = args
             process.currentDirectoryURL = worktree.absolutePath
@@ -225,11 +225,22 @@ final class ContentSearcher: Sendable {
         worktree: SearchWorktree,
         into continuation: AsyncThrowingStream<ContentSearchHit, Error>.Continuation
     ) async throws {
-        let result = try await Process.git(
-            RemoteContentSearch.gitGrepArgs(query: query, options: options),
-            cwd: worktree.absolutePath,
-            timeout: 60
-        )
+        let result: ProcessResult
+        if let host = RemoteHostRegistry.shared.host(forPath: worktree.absolutePath.path) {
+            let invocation = RemoteContentSearch.cappedGitGrepInvocation(
+                host: host,
+                cwd: worktree.absolutePath.path,
+                query: query,
+                options: options
+            )
+            result = try await Process.run(invocation.executable, args: invocation.args, timeout: 60)
+        } else {
+            result = try await Process.git(
+                RemoteContentSearch.gitGrepArgs(query: query, options: options),
+                cwd: worktree.absolutePath,
+                timeout: 60
+            )
+        }
         // git grep uses 1 for a valid search without matches.
         guard result.exitCode == 0 || result.exitCode == 1 else {
             throw SearchError.rgFailed(exitCode: result.exitCode)
@@ -260,10 +271,9 @@ final class ContentSearcher: Sendable {
         options: SearchContentOptions
     ) -> ContentSearchHit {
         let raw = parsed.text
-        let matchRange = firstMatchRange(in: raw, query: query, options: options)
         let fallbackStart = max(0, parsed.column - 1)
-        let startByte = matchRange.map { raw[..<$0.lowerBound].utf8.count } ?? fallbackStart
-        let endByte = matchRange.map { raw[..<$0.upperBound].utf8.count } ?? startByte
+        let startByte = min(fallbackStart, raw.utf8.count)
+        let endByte = gitGrepMatchEndByte(in: raw, startByte: startByte, query: query, options: options)
         let column = charOffset(forByteOffset: startByte, in: raw).map { $0 + 1 } ?? (startByte + 1)
         let revealColumn = utf16Offset(forByteOffset: startByte, in: raw).map { $0 + 1 } ?? column
         let (snippet, matchCharRange) = windowSnippet(
@@ -281,6 +291,24 @@ final class ContentSearcher: Sendable {
             snippet: snippet,
             matchCharRange: matchCharRange
         )
+    }
+
+    private func gitGrepMatchEndByte(
+        in text: String,
+        startByte: Int,
+        query: String,
+        options: SearchContentOptions
+    ) -> Int {
+        guard startByte >= 0, startByte <= text.utf8.count else { return startByte }
+        let utf8Index = text.utf8.index(text.utf8.startIndex, offsetBy: startByte)
+        guard let startIndex = utf8Index.samePosition(in: text) else { return startByte }
+        let suffix = String(text[startIndex...])
+        guard let matchRange = firstMatchRange(in: suffix, query: query, options: options),
+              matchRange.lowerBound == suffix.startIndex
+        else {
+            return min(text.utf8.count, startByte + query.utf8.count)
+        }
+        return startByte + suffix[..<matchRange.upperBound].utf8.count
     }
 
     private func firstMatchRange(

--- a/Alas/Sources/Search/FileSearchBackend.swift
+++ b/Alas/Sources/Search/FileSearchBackend.swift
@@ -37,6 +37,10 @@ actor FffFileSearchBackend {
     }
 
     func search(query: String, worktree: SearchWorktree, limit: Int) async throws -> [FileSearchBackendResult]? {
+        // fff mmaps and watches the local filesystem, neither of which is
+        // meaningful for an ssh-backed worktree. Returning nil selects the
+        // existing host-aware git-ls-files fallback in SearchModel.
+        if worktree.absolutePath.isRemoteAlasPath { return nil }
 #if canImport(FffC)
         guard canSearchWithFff(query: query) else {
             return nil

--- a/Alas/Sources/Sidebar/RepoGroupView.swift
+++ b/Alas/Sources/Sidebar/RepoGroupView.swift
@@ -60,6 +60,16 @@ struct RepoGroupView: View {
                 Text(project.name)
                     .font(.system(size: 11.5, weight: .semibold))
                     .foregroundColor(theme.color("fg-muted"))
+                if let host = project.host {
+                    Text(host)
+                        .font(.system(size: 9.5, weight: .medium))
+                        .foregroundColor(theme.color("fg-faint"))
+                        .padding(.horizontal, 5)
+                        .padding(.vertical, 1)
+                        .background(theme.color("bg-4"))
+                        .clipShape(Capsule())
+                        .help("Remote project on \(host) (SSH)")
+                }
                 Spacer(minLength: 0)
             }
             .padding(.leading, 12)

--- a/Alas/Sources/Sidebar/RepoGroupView.swift
+++ b/Alas/Sources/Sidebar/RepoGroupView.swift
@@ -42,6 +42,7 @@ struct RepoGroupView: View {
     let onDropWorktree: (_ draggedId: String, _ destinationId: String) -> Void
     let onDropProject: (_ draggedId: String, _ destinationId: String) -> Void
     @Environment(\.theme) var theme
+    @ObservedObject private var hostStatus = RemoteHostStatusStore.shared
     @State private var hovering = false
     @State private var plusHovering = false
 
@@ -61,14 +62,23 @@ struct RepoGroupView: View {
                     .font(.system(size: 11.5, weight: .semibold))
                     .foregroundColor(theme.color("fg-muted"))
                 if let host = project.host {
-                    Text(host)
+                    HStack(spacing: 3) {
+                        if hostStatus.isOffline(host) {
+                            Image(systemName: "bolt.horizontal.circle")
+                                .font(.system(size: 9))
+                                .foregroundColor(.orange)
+                        }
+                        Text(host)
+                    }
                         .font(.system(size: 9.5, weight: .medium))
                         .foregroundColor(theme.color("fg-faint"))
                         .padding(.horizontal, 5)
                         .padding(.vertical, 1)
                         .background(theme.color("bg-4"))
                         .clipShape(Capsule())
-                        .help("Remote project on \(host) (SSH)")
+                        .help(hostStatus.isOffline(host)
+                            ? "Host \(host) is unreachable"
+                            : "Remote project on \(host) (SSH)")
                 }
                 Spacer(minLength: 0)
             }

--- a/Alas/Sources/Sidebar/SidebarView.swift
+++ b/Alas/Sources/Sidebar/SidebarView.swift
@@ -79,7 +79,9 @@ struct SidebarView: View {
                                 },
                                 onOpenTerminal: { wt in
                                     state.selectWorktree(id: wt.id)
-                                    _ = try? state.openTerminalTab(for: wt)
+                                    Task { @MainActor in
+                                        _ = try? await state.openTerminalTabPreparingRemoteZmxIfNeeded(for: wt)
+                                    }
                                 },
                                 onCopyPath: { wt in
                                     let pb = NSPasteboard.general
@@ -126,14 +128,16 @@ struct SidebarView: View {
                                     } else {
                                         retryBase = state.config.worktrees.baseBranch
                                     }
-                                    state.createWorktree(
-                                        projectId: project.id,
-                                        base: retryBase,
-                                        branch: wt.branch,
-                                        destination: wt.path,
-                                        runStartup: false,
-                                        launchSurface: .none
-                                    )
+                                    Task { @MainActor in
+                                        await state.createWorktree(
+                                            projectId: project.id,
+                                            base: retryBase,
+                                            branch: wt.branch,
+                                            destination: wt.path,
+                                            runStartup: false,
+                                            launchSurface: .none
+                                        )
+                                    }
                                 },
                                 onRetryDelete: { wt in state.deleteWorktree(wt) },
                                 onRemoveFailed: { wt in

--- a/Alas/Sources/Sidebar/WorktreeRowView.swift
+++ b/Alas/Sources/Sidebar/WorktreeRowView.swift
@@ -143,7 +143,9 @@ struct WorktreeRowView: View {
                 Button("Open in Terminal", action: onOpenTerminal)
                 Button("Copy Path", action: onCopyPath)
                 Button("Copy Branch Name", action: onCopyBranch)
-                Button("Reveal in Finder", action: onRevealInFinder)
+                if !worktree.path.isRemoteAlasPath {
+                    Button("Reveal in Finder", action: onRevealInFinder)
+                }
                 Divider()
                 Button("Archive", action: onArchive)
                 Button("Delete Worktree…", role: .destructive, action: onDelete)

--- a/Alas/Sources/Terminal/TerminalService.swift
+++ b/Alas/Sources/Terminal/TerminalService.swift
@@ -57,6 +57,15 @@ final class TerminalService {
         }
     }
 
+    private func dispatchTrackedKill(_ body: @escaping @Sendable () async -> Void) {
+        let task = Task.detached(operation: body)
+        pendingKillTasks.insert(task)
+        Task { @MainActor [weak self] in
+            _ = await task.value
+            self?.pendingKillTasks.remove(task)
+        }
+    }
+
     /// Build the global config file for this app + theme combination, then
     /// (re)create the AlasGhostty.App if the config has changed materially.
     /// Call this on launch and whenever theme/terminal settings change.
@@ -144,9 +153,10 @@ final class TerminalService {
         let args: [String]
         let envOverrides: [String: String]
         if let remoteHost {
+            let remoteCwd = forcedCwd?.path ?? worktree.path.path
             let launch = Self.remoteLaunch(
                 host: remoteHost,
-                worktreePath: worktree.path.path,
+                worktreePath: remoteCwd,
                 zmxSessionName: zmxSessionName,
                 keepAlive: cfg.keepSessionsAlive,
                 startupSuffix: effectiveScript.isEmpty ? nil : effectiveScript
@@ -198,7 +208,7 @@ final class TerminalService {
         return session
     }
 
-    static func remoteLaunch(host: String, worktreePath: String, zmxSessionName: String, keepAlive: Bool, startupSuffix: String?) -> (executable: String, args: [String]) {
+    nonisolated static func remoteLaunch(host: String, worktreePath: String, zmxSessionName: String, keepAlive: Bool, startupSuffix: String?) -> (executable: String, args: [String]) {
         let script = RemoteTerminalScript.attachScript(worktreePath: worktreePath, sessionName: zmxSessionName, useZmx: keepAlive, startupSuffix: startupSuffix)
         let invocation = RemoteTerminalScript.surfaceInvocation(host: host, script: script)
         return (invocation.executable, invocation.args)
@@ -220,12 +230,13 @@ final class TerminalService {
         // otherwise a quick close+Cmd-Q race would leak the daemon-side
         // session, and the next launch would carry forward the orphan.
         if let host = existing?.remoteHost, let existingName = existing?.zmxSessionName {
-            Task { await Self.killRemoteSession(host: host, name: existingName) }
+            dispatchTrackedKill { await Self.killRemoteSession(host: host, name: existingName) }
         } else if let existingName = existing?.zmxSessionName {
             let client = zmxClient
             dispatchTrackedKill { client.killSession(name: existingName) }
         } else if let worktreeId = explicitWorktreeId ?? existing?.worktreeId {
             let client = zmxClient
+            let remoteHost = Self.remoteHostForCleanup(worktreeId: worktreeId, projectPath: projectPath)
             dispatchTrackedKill {
                 let sessionNames = Self.sessionNamesForCleanup(
                     worktreeId: worktreeId,
@@ -234,7 +245,11 @@ final class TerminalService {
                     zmxClient: client
                 )
                 for sessionName in sessionNames {
-                    client.killSession(name: sessionName)
+                    if let remoteHost {
+                        await Self.killRemoteSession(host: remoteHost, name: sessionName)
+                    } else {
+                        client.killSession(name: sessionName)
+                    }
                 }
             }
         }
@@ -265,22 +280,38 @@ final class TerminalService {
     /// `ZmxClient.killSession` blocks up to ~5s, so we run the sweep on
     /// `Task.detached` to keep the MainActor (UI) responsive.
     func terminateAll(additionalSessions: [TerminalSessionIdentity] = []) {
-        let liveNames = registry.all.map {
-            $0.zmxSessionName ?? ZmxSessionName.derive(worktreeId: $0.worktreeId, leafId: $0.id)
+        var localNames = Set<String>()
+        var remoteNamesByHost: [String: Set<String>] = [:]
+        for session in registry.all {
+            let name = session.zmxSessionName ?? ZmxSessionName.derive(worktreeId: session.worktreeId, leafId: session.id)
+            if let host = session.remoteHost {
+                remoteNamesByHost[host, default: []].insert(name)
+            } else {
+                localNames.insert(name)
+            }
         }
         let client = zmxClient
-        dispatchTrackedKill {
-            var allNames = Set(liveNames)
-            for session in additionalSessions {
-                allNames.formUnion(Self.sessionNamesForCleanup(
-                    worktreeId: session.worktreeId,
-                    projectPath: session.projectPath,
-                    leafId: session.leafId,
-                    zmxClient: client
-                ))
+        for session in additionalSessions {
+            let names = Self.sessionNamesForCleanup(
+                worktreeId: session.worktreeId,
+                projectPath: session.projectPath,
+                leafId: session.leafId,
+                zmxClient: client
+            )
+            if let host = Self.remoteHostForCleanup(worktreeId: session.worktreeId, projectPath: session.projectPath) {
+                remoteNamesByHost[host, default: []].formUnion(names)
+            } else {
+                localNames.formUnion(names)
             }
-            for name in allNames {
+        }
+        dispatchTrackedKill {
+            for name in localNames {
                 client.killSession(name: name)
+            }
+            for (host, names) in remoteNamesByHost {
+                for name in names {
+                    await Self.killRemoteSession(host: host, name: name)
+                }
             }
         }
     }
@@ -327,6 +358,11 @@ final class TerminalService {
             command: RemoteTerminalScript.zmxBatchCommand(["kill", name]),
             timeout: 10
         )
+    }
+
+    nonisolated static func remoteHostForCleanup(worktreeId: String, projectPath: String?) -> String? {
+        RemoteHostRegistry.shared.host(forPath: worktreeId)
+            ?? RemoteHostRegistry.shared.host(forPath: projectPath)
     }
 
     /// Find scoped remote sessions with no persisted terminal leaf and remove

--- a/Alas/Sources/Terminal/TerminalService.swift
+++ b/Alas/Sources/Terminal/TerminalService.swift
@@ -99,16 +99,17 @@ final class TerminalService {
         guard let app else { throw NSError(domain: "TerminalService", code: 1) }
 
         let sessionId = leafId
+        let remoteHost = project.host
         // Per-session socket path: AppState wires `socketPathProvider` to
         // `AgentHookSocketServer.linkSession(leafId:)`, which (re)creates
         // a per-leaf symlink. The same symlink path stays valid across
         // Alas restarts, so zmx-persisted shells keep delivering hooks
         // to the live socket on the next launch.
-        let perSessionSocket = socketPathProvider?(sessionId)
+        let perSessionSocket = remoteHost == nil ? socketPathProvider?(sessionId) : nil
         var env = EnvBuilder.build(
             project: project, worktree: worktree, sessionId: sessionId,
             socketPath: perSessionSocket, inheritParent: cfg.inheritParentEnv,
-            zmxDir: zmxClient.env.zmxDir?.path
+            zmxDir: remoteHost == nil ? zmxClient.env.zmxDir?.path : nil
         )
         for key in environmentRemovals {
             env.removeValue(forKey: key)
@@ -116,24 +117,22 @@ final class TerminalService {
         for (key, value) in environmentOverrides {
             env[key] = value
         }
-        if perSessionSocket != nil {
+        if remoteHost != nil {
+            env = env.filter { !$0.key.hasPrefix("ALAS_") }
+            env.removeValue(forKey: "ZMX_DIR")
+        }
+        if remoteHost == nil, perSessionSocket != nil {
             let binDir = try TerminalCLIInjection.installExecutables()
             env["PATH"] = TerminalCLIInjection.pathValue(
                 prepending: binDir.path,
                 to: env["PATH"]
             )
         }
-        let baseScript = includeUserStartupScript
-            ? StartupScriptResolver.sessionOpenScript(global: cfg, project: project)
-            : ""
-        let effectiveScript = Self.composeStartupScript(
-            userStartupScript: baseScript,
+        let effectiveScript = Self.effectiveStartupScript(
+            global: cfg,
+            project: project,
+            includeUserStartupScript: includeUserStartupScript,
             startupScriptSuffix: startupScriptSuffix
-        )
-        let innerPlan = try StartupScriptInstaller.plan(
-            shell: cfg.shell,
-            startupScript: effectiveScript,
-            sessionId: sessionId
         )
         let zmxSessionName = preResolvedZmxSessionName ?? sessionNameForAttach(
             worktree: worktree,
@@ -141,25 +140,40 @@ final class TerminalService {
             leafId: sessionId,
             allowLegacy: allowLegacyAttach
         )
-        let plan = TerminalService.resolveLaunchPlan(
-            keepAlive: cfg.keepSessionsAlive,
-            zmxClient: zmxClient,
-            sessionName: zmxSessionName,
-            innerPlan: innerPlan
-        )
+        let executable: String
+        let args: [String]
+        let envOverrides: [String: String]
+        if let remoteHost {
+            let launch = Self.remoteLaunch(
+                host: remoteHost,
+                worktreePath: worktree.path.path,
+                zmxSessionName: zmxSessionName,
+                keepAlive: cfg.keepSessionsAlive,
+                startupSuffix: effectiveScript.isEmpty ? nil : effectiveScript
+            )
+            executable = launch.executable
+            args = launch.args
+            envOverrides = [:]
+        } else {
+            let innerPlan = try StartupScriptInstaller.plan(shell: cfg.shell, startupScript: effectiveScript, sessionId: sessionId)
+            let plan = TerminalService.resolveLaunchPlan(keepAlive: cfg.keepSessionsAlive, zmxClient: zmxClient, sessionName: zmxSessionName, innerPlan: innerPlan)
+            executable = plan.executable
+            args = plan.args
+            envOverrides = plan.envOverrides
+        }
         // Plan-supplied env overrides (e.g. ZDOTDIR for zsh startup scripts)
         // win over inherited env.
-        for (k, v) in plan.envOverrides { env[k] = v }
-        let cwd = forcedCwd ?? resolveWorkingDirectory(
+        for (k, v) in envOverrides { env[k] = v }
+        let cwd = remoteHost == nil ? (forcedCwd ?? resolveWorkingDirectory(
             preference: cfg.workingDirectory,
             worktree: worktree,
             project: project
-        )
+        )) : FileManager.default.homeDirectoryForCurrentUser
         let surfaceConfig = GhosttyConfigBuilder.makeSurfaceConfiguration(
             cwd: cwd,
             env: env,
-            executable: plan.executable,
-            args: plan.args
+            executable: executable,
+            args: args
         )
         let surface = AlasGhostty.SurfaceView(
             app: app,
@@ -175,12 +189,19 @@ final class TerminalService {
             worktreeId: worktree.id,
             projectId: project.id,
             surface: surface,
-            executable: plan.executable,
-            args: plan.args,
-            zmxSessionName: (cfg.keepSessionsAlive && zmxClient.isAvailable) ? zmxSessionName : nil
+            executable: executable,
+            args: args,
+            zmxSessionName: cfg.keepSessionsAlive && (remoteHost != nil || zmxClient.isAvailable) ? zmxSessionName : nil,
+            remoteHost: remoteHost
         )
         registry.register(session)
         return session
+    }
+
+    static func remoteLaunch(host: String, worktreePath: String, zmxSessionName: String, keepAlive: Bool, startupSuffix: String?) -> (executable: String, args: [String]) {
+        let script = RemoteTerminalScript.attachScript(worktreePath: worktreePath, sessionName: zmxSessionName, useZmx: keepAlive, startupSuffix: startupSuffix)
+        let invocation = RemoteTerminalScript.surfaceInvocation(host: host, script: script)
+        return (invocation.executable, invocation.args)
     }
 
     func closeSession(
@@ -198,7 +219,9 @@ final class TerminalService {
         // `waitForPendingKills` can drain it before the app exits —
         // otherwise a quick close+Cmd-Q race would leak the daemon-side
         // session, and the next launch would carry forward the orphan.
-        if let existingName = existing?.zmxSessionName {
+        if let host = existing?.remoteHost, let existingName = existing?.zmxSessionName {
+            Task { await Self.killRemoteSession(host: host, name: existingName) }
+        } else if let existingName = existing?.zmxSessionName {
             let client = zmxClient
             dispatchTrackedKill { client.killSession(name: existingName) }
         } else if let worktreeId = explicitWorktreeId ?? existing?.worktreeId {
@@ -292,6 +315,45 @@ final class TerminalService {
             for name in orphans {
                 client.killSession(name: name)
             }
+        }
+    }
+
+    /// Best-effort remote counterpart to `ZmxClient.killSession`. This is
+    /// intentionally batch-mode so closing a pane can never wait for auth.
+    nonisolated static func killRemoteSession(host: String, name: String) async {
+        _ = try? await RemoteExec.run(
+            host: host,
+            cwd: nil,
+            command: RemoteTerminalScript.zmxBatchCommand(["kill", name]),
+            timeout: 10
+        )
+    }
+
+    /// Find scoped remote sessions with no persisted terminal leaf and remove
+    /// them one at a time. Connection failures are ignored; the next boot or
+    /// a later successful connection will retry the sweep.
+    nonisolated static func sweepRemoteOrphans(
+        host: String,
+        knownWorktreeIds: Set<String>,
+        knownLeafIds: Set<String>
+    ) async {
+        guard let result = try? await RemoteExec.run(
+            host: host,
+            cwd: nil,
+            command: RemoteTerminalScript.zmxBatchCommand(["ls", "--short"]),
+            timeout: 10
+        ), result.exitCode == 0 else {
+            return
+        }
+
+        let names = result.stdout.split(separator: "\n").map(String.init)
+        let orphans = orphanSessionNames(
+            allSessionNames: names,
+            knownWorktreeIdHashes: Set(knownWorktreeIds.map(ZmxSessionName.hash16)),
+            knownLeafIdHashes: Set(knownLeafIds.map(ZmxSessionName.hash16))
+        )
+        for name in orphans {
+            await killRemoteSession(host: host, name: name)
         }
     }
 
@@ -433,7 +495,22 @@ final class TerminalService {
         )
     }
 
-    private static func composeStartupScript(
+    nonisolated static func effectiveStartupScript(
+        global: AppConfig.Terminal,
+        project: ProjectConfig,
+        includeUserStartupScript: Bool,
+        startupScriptSuffix: String?
+    ) -> String {
+        let baseScript = includeUserStartupScript
+            ? StartupScriptResolver.sessionOpenScript(global: global, project: project)
+            : ""
+        return composeStartupScript(
+            userStartupScript: baseScript,
+            startupScriptSuffix: startupScriptSuffix
+        )
+    }
+
+    private nonisolated static func composeStartupScript(
         userStartupScript: String,
         startupScriptSuffix: String?
     ) -> String {

--- a/Alas/Sources/Terminal/TerminalSession.swift
+++ b/Alas/Sources/Terminal/TerminalSession.swift
@@ -40,6 +40,7 @@ final class TerminalSession {
     let executable: String
     let args: [String]
     let zmxSessionName: String?
+    let remoteHost: String?
 
     /// Set by HarnessService in Plan 5 — nil here.
     var harnessKind: String? = nil
@@ -52,7 +53,8 @@ final class TerminalSession {
         surface: AlasGhostty.SurfaceView,
         executable: String,
         args: [String],
-        zmxSessionName: String? = nil
+        zmxSessionName: String? = nil,
+        remoteHost: String? = nil
     ) {
         self.id = id
         self.worktreeId = worktreeId
@@ -61,6 +63,7 @@ final class TerminalSession {
         self.executable = executable
         self.args = args
         self.zmxSessionName = zmxSessionName
+        self.remoteHost = remoteHost
         self.createdAt = Date()
     }
 }

--- a/AlasTests/ACP/ACPSessionManagerLeaseTests.swift
+++ b/AlasTests/ACP/ACPSessionManagerLeaseTests.swift
@@ -175,7 +175,7 @@ import Foundation
             worktreeId: "wt", worktreePath: "/tmp/wt",
             store: storeA, instanceId: "A", pid: Int64(getpid()),
             setupEvaluator: { _ in .ready },
-            connectionFactory: { _ in throw StubError() })
+            connectionFactory: { _, _, _ in throw StubError() })
         let session = mgrA.createSession(agentId: "claude")
         await mgrA.attach(to: session.id, freshlyCreated: true)
         // attach failed at connectionFactory; the defer must have released the lease.
@@ -698,7 +698,7 @@ import Foundation
             worktreeId: "wt", worktreePath: "/tmp/wt",
             store: storeA, instanceId: "A", pid: Int64(getpid()),
             setupEvaluator: { _ in .ready },
-            connectionFactory: { [weak storeA] _ throws -> ACPConnection in
+            connectionFactory: { [weak storeA] _, _, _ throws -> ACPConnection in
                 connectionCallCount += 1
                 // On the first connection attempt, seize the lease as "B"
                 // to simulate a takeover arriving while A awaits loadSession.
@@ -786,7 +786,7 @@ import Foundation
             worktreeId: "wt", worktreePath: "/tmp/wt", store: store,
             instanceId: "A", pid: Int64(getpid()),
             setupEvaluator: { _ in .ready },
-            connectionFactory: { _ in ACPConnection(client: client) })
+            connectionFactory: { _, _, _ in ACPConnection(client: client) })
         let session = mgr.createSession(agentId: "claude")
         // Dispose the manager BEFORE attach so any in-flight attach finds
         // isDisposed == true at the pre-commit guard.
@@ -882,7 +882,7 @@ import Foundation
                 await setupGate.wait()   // block until test releases
                 return .ready
             },
-            connectionFactory: { _ throws -> ACPConnection in
+            connectionFactory: { _, _, _ throws -> ACPConnection in
                 throw CancellationError()  // attach will fail here, but attach's defer still runs
             })
 

--- a/AlasTests/ACP/Session/ACPSessionDiscoveryTests.swift
+++ b/AlasTests/ACP/Session/ACPSessionDiscoveryTests.swift
@@ -163,7 +163,7 @@ struct ACPSessionDiscoveryTests {
             worktreePath: "/tmp/wt",
             store: store,
             setupEvaluator: { _ in .ready },
-            connectionFactory: { _ in ACPConnection(client: client) }
+            connectionFactory: { _, _, _ in ACPConnection(client: client) }
         )
     }
 

--- a/AlasTests/ACP/Session/ACPSessionManagerAttachRestoreTests.swift
+++ b/AlasTests/ACP/Session/ACPSessionManagerAttachRestoreTests.swift
@@ -210,7 +210,7 @@ struct ACPSessionManagerAttachRestoreTests {
             store: store,
             onSessionTitleUpdated: { titleCallbacks.append(($0, $1)) },
             setupEvaluator: { _ in .ready },
-            connectionFactory: { _ in ACPConnection(client: ACPMockClient()) }
+            connectionFactory: { _, _, _ in ACPConnection(client: ACPMockClient()) }
         )
 
         let session = try #require(manager.placeholderSession(id: "local"))
@@ -1238,7 +1238,7 @@ struct ACPSessionManagerAttachRestoreTests {
                 captured.count = mgrBox.pointee?.sessions["local"]?.transcript.messages.count ?? -2
                 return .ready
             },
-            connectionFactory: { _ in ACPConnection(client: client) }
+            connectionFactory: { _, _, _ in ACPConnection(client: client) }
         )
         mgrBox.pointee = manager
 
@@ -1329,7 +1329,7 @@ struct ACPSessionManagerAttachRestoreTests {
             worktreePath: "/tmp/wt",
             store: store,
             setupEvaluator: { _ in .ready },
-            connectionFactory: { _ in ACPConnection(client: client) },
+            connectionFactory: { _, _, _ in ACPConnection(client: client) },
             mcpProjectContextProvider: mcpProjectContextProvider
         )
     }

--- a/AlasTests/ACP/Session/ACPSessionManagerRemoteRestoreTests.swift
+++ b/AlasTests/ACP/Session/ACPSessionManagerRemoteRestoreTests.swift
@@ -200,7 +200,7 @@ struct ACPSessionManagerRemoteRestoreTests {
             worktreePath: "/tmp/wt",
             store: store,
             setupEvaluator: { _ in .ready },
-            connectionFactory: { _ in ACPConnection(client: client) }
+            connectionFactory: { _, _, _ in ACPConnection(client: client) }
         )
         let session = try #require(manager.placeholderSession(id: "local-id"))
         return (manager, store, client, session)

--- a/AlasTests/ACP/Terminal/ACPTerminalHostTests.swift
+++ b/AlasTests/ACP/Terminal/ACPTerminalHostTests.swift
@@ -17,6 +17,25 @@ struct ACPTerminalHostTests {
         #expect(host.terminal(id: r1.terminalId) != nil)
     }
 
+    @Test("remote sessions keep absolute requested cwd on the remote host")
+    func remoteSessionRoutesAbsoluteCwdToSessionHost() {
+        let host = ACPTerminalHost(sessionCwd: "/srv/repo", sessionEnv: [:], sessionRemoteHost: "devbox")
+
+        #expect(host.executionHost(forResolvedCwd: "/tmp") == "devbox")
+    }
+
+    @Test("agent-requested env handles duplicate names with last value winning")
+    func agentRequestedEnvDuplicateNamesAreLastWins() {
+        let host = ACPTerminalHost(sessionCwd: "/tmp", sessionEnv: [:])
+
+        let env = host.agentRequestedEnv([
+            ACPEnvVar(name: "TOKEN", value: "old"),
+            ACPEnvVar(name: "TOKEN", value: "new"),
+        ])
+
+        #expect(env == ["TOKEN": "new"])
+    }
+
     @Test("output on unknown id throws 'terminal not found'")
     func unknownOutput() {
         let host = ACPTerminalHost(sessionCwd: "/tmp", sessionEnv: [:])

--- a/AlasTests/AgentTerminalLaunchTests.swift
+++ b/AlasTests/AgentTerminalLaunchTests.swift
@@ -380,6 +380,39 @@ struct AgentTerminalLaunchTests {
         #expect(FileManager.default.fileExists(atPath: hookURL.path))
     }
 
+    @Test func launchingCopilotForRemoteWorktreeSkipsLocalHookInstall() throws {
+        var project = project(mode: .useGlobal, useBypass: false)
+        project.path = "/srv/project"
+        project.host = "devbox"
+        let worktree = Worktree(
+            id: "wt",
+            projectId: project.id,
+            name: "main",
+            branch: "main",
+            path: URL(fileURLWithPath: "/srv/project"),
+            status: .clean,
+            lastActivity: Date()
+        )
+        var openerCalled = false
+        let state = AppState(
+            store: MemoryStore(),
+            terminalSessionOpener: { _, _, _, _, _, _, _, _, _ in
+                openerCalled = true
+                return AppState.OpenedTerminalSession(id: "session-1", foregroundPid: { nil })
+            }
+        )
+        state.projectsManager = ProjectsManager(persistedProjects: [project])
+        state.agentRegistry = AgentRegistry(
+            builtinState: [:],
+            customs: [],
+            installedIds: ["copilot"]
+        )
+
+        _ = try state.openAgentTerminalTab(for: worktree, agentId: "copilot")
+
+        #expect(openerCalled)
+    }
+
     @Test func launchingNonCopilotDoesNotCreateCopilotHook() throws {
         let (dir, cleanup) = tmpDir()
         defer { cleanup() }

--- a/AlasTests/AppStateCleanupTests.swift
+++ b/AlasTests/AppStateCleanupTests.swift
@@ -162,6 +162,34 @@ struct AppStateCleanupTests {
         #expect(state.tabs.tabs(forWorktree: treesB[0].id).count == 1)
     }
 
+    @Test func topologyRefreshLoadsPersistedTabsForNewWorktrees() async throws {
+        let repo = try await makeRepo(name: "topology-load-tabs")
+        let linked = FileManager.default.temporaryDirectory
+            .appendingPathComponent("alas-cleanup-linked-\(UUID().uuidString)")
+        defer {
+            try? FileManager.default.removeItem(at: linked)
+            try? FileManager.default.removeItem(at: repo)
+            try? FileManager.default.removeItem(at: Paths.tabsFile(forWorktreeId: Worktree.makeId(path: linked)))
+        }
+
+        let state = AppState()
+        let project = try await state.projectsManager.addProject(
+            path: repo, displayName: "topology-load-tabs", color: "#5fb7c4"
+        )
+        try await state.projectsManager.refreshWorktrees(projectId: project.id)
+        #expect(state.projectsManager.worktrees(projectId: project.id).count == 1)
+
+        _ = try await Process.git(["worktree", "add", "-q", "-b", "linked-tabs", linked.path, "HEAD"], cwd: repo)
+        let linkedId = Worktree.makeId(path: linked)
+        let seededTabs = TabsManager()
+        seededTabs.appendTerminal(worktreeId: linkedId, title: "persisted", sessionId: "s1")
+
+        await state.refreshProjectTopology(projectId: project.id)
+
+        #expect(state.projectsManager.worktrees(projectId: project.id).contains { $0.id == linkedId })
+        #expect(state.tabs.tabs(forWorktree: linkedId).map(\.title) == ["persisted"])
+    }
+
     @Test func createWorktreeInsertsOptimisticRowImmediately() async throws {
         let repo = try await makeRepo(name: "create-opt")
         defer { try? FileManager.default.removeItem(at: repo) }
@@ -170,7 +198,7 @@ struct AppStateCleanupTests {
         try await state.projectsManager.refreshWorktrees(projectId: project.id)
 
         let dest = repo.appendingPathComponent("wt-opt")
-        let id = state.createWorktree(
+        let id = await state.createWorktree(
             projectId: project.id,
             base: "main",
             branch: "opt-b",
@@ -197,7 +225,7 @@ struct AppStateCleanupTests {
         state.selectedWorktreeId = existing.id
 
         let dest = repo.appendingPathComponent("wt-select-opt")
-        let id = state.createWorktree(
+        let id = await state.createWorktree(
             projectId: project.id,
             base: "main",
             branch: "select-opt-b",
@@ -225,7 +253,7 @@ struct AppStateCleanupTests {
         try await state.projectsManager.refreshWorktrees(projectId: project.id)
         let existing = try #require(state.projectsManager.worktrees(projectId: project.id).first)
 
-        let id = state.createWorktree(
+        let id = await state.createWorktree(
             projectId: project.id,
             base: "main",
             branch: "existing-path",
@@ -247,7 +275,7 @@ struct AppStateCleanupTests {
         try await state.projectsManager.refreshWorktrees(projectId: project.id)
 
         let dest = repo.appendingPathComponent("wt-fail")
-        let id = state.createWorktree(
+        let id = await state.createWorktree(
             projectId: project.id,
             base: "missing-base",
             branch: "fail-b",
@@ -277,7 +305,7 @@ struct AppStateCleanupTests {
         try await state.projectsManager.refreshWorktrees(projectId: project.id)
 
         let dest = repo.appendingPathComponent("wt-retry")
-        let failedId = state.createWorktree(
+        let failedId = await state.createWorktree(
             projectId: project.id,
             base: "missing-base",
             branch: "retry-b",
@@ -290,7 +318,7 @@ struct AppStateCleanupTests {
             return false
         }
 
-        let retryId = state.createWorktree(
+        let retryId = await state.createWorktree(
             projectId: project.id,
             base: "main",
             branch: "retry-b",
@@ -646,6 +674,26 @@ struct AppStateCleanupTests {
         #expect(state.projects.map(\.id) == [project.id])
     }
 
+    @Test func clearProjectsWithoutWorktreesKeepsRemoteProjectWhenRefreshFails() async throws {
+        let project = ProjectConfig(
+            id: UUID().uuidString,
+            name: "remote",
+            path: "/srv/offline-repo-\(UUID().uuidString)",
+            color: "#5fb7c4",
+            addedAt: Date(),
+            host: "localhost"
+        )
+        defer { RemoteHostRegistry.shared.unregister(root: project.path) }
+        let state = AppState(
+            store: MemoryStore(projectsFile: ProjectsFile(projects: [project]))
+        )
+
+        let removed = await state.clearProjectsWithoutWorktrees()
+
+        #expect(removed == 0)
+        #expect(state.projects.map(\.id) == [project.id])
+    }
+
     @Test func removeProjectResetsSelectionWhenSelectedWorktreeIsRemoved() async throws {
         let repoA = try await makeRepo(name: "remove-sel-a")
         let repoB = try await makeRepo(name: "remove-sel-b")
@@ -846,7 +894,7 @@ struct AppStateCleanupTests {
 
         let destination = repo.deletingLastPathComponent()
             .appendingPathComponent("race-wt-\(UUID().uuidString)")
-        _ = state.createWorktree(
+        _ = await state.createWorktree(
             projectId: project.id,
             base: "main",
             branch: "race/wt",

--- a/AlasTests/AppStateCreateWorktreeLaunchSurfaceTests.swift
+++ b/AlasTests/AppStateCreateWorktreeLaunchSurfaceTests.swift
@@ -55,7 +55,7 @@ struct AppStateCreateWorktreeLaunchSurfaceTests {
 
         let dest = repo.deletingLastPathComponent()
             .appendingPathComponent("wt-acp-\(UUID().uuidString)")
-        let id = state.createWorktree(
+        let id = await state.createWorktree(
             projectId: project.id,
             base: "main",
             branch: "acp-branch",

--- a/AlasTests/AppStateCreateWorktreeSymlinkTests.swift
+++ b/AlasTests/AppStateCreateWorktreeSymlinkTests.swift
@@ -62,7 +62,7 @@ struct AppStateCreateWorktreeSymlinkTests {
         // report.
         let destinationThroughSymlink = linkURL.appendingPathComponent("wt-symlink")
 
-        let optimisticId = state.createWorktree(
+        let optimisticId = await state.createWorktree(
             projectId: project.id,
             base: "main",
             branch: "symlink-branch",

--- a/AlasTests/AppStateKeepSessionsAliveTests.swift
+++ b/AlasTests/AppStateKeepSessionsAliveTests.swift
@@ -133,4 +133,26 @@ struct AppStateKeepSessionsAliveTests {
 
         #expect(state.tabs.tabs(forWorktree: trees[0].id).map(\.id) == [term.id])
     }
+
+    @Test func topologyRefreshDoesNotPruneUnrelatedTerminalTabsWhenKeepAliveFalse() async throws {
+        let repo = try await makeRepo(name: "topology-keep")
+        defer { try? FileManager.default.removeItem(at: repo) }
+
+        let state = AppState()
+        let project = try await state.projectsManager.addProject(
+            path: repo, displayName: "test", color: "#000000"
+        )
+        try await state.projectsManager.refreshWorktrees(projectId: project.id)
+        let trees = state.projectsManager.worktrees(projectId: project.id)
+        state.selectedWorktreeId = trees[0].id
+        state.config.terminal.keepSessionsAlive = false
+
+        let term = state.tabs.appendTerminal(
+            worktreeId: trees[0].id, title: "a", sessionId: "leaf-a"
+        )
+
+        await state.refreshProjectTopology(projectId: project.id)
+
+        #expect(state.tabs.tabs(forWorktree: trees[0].id).map(\.id) == [term.id])
+    }
 }

--- a/AlasTests/AppStateRemoteWorktreePathTests.swift
+++ b/AlasTests/AppStateRemoteWorktreePathTests.swift
@@ -1,0 +1,39 @@
+import Testing
+@testable import Alas
+
+struct AppStateRemoteWorktreePathTests {
+    @Test func remoteWorktreeDestinationReplacesLocalHomePrefix() {
+        let path = AppState.destinationPathReplacingLocalHome(
+            "/Users/local/.alas/worktrees/repo-feature",
+            localHome: "/Users/local",
+            remoteHome: "/home/remote"
+        )
+
+        #expect(path == "/home/remote/.alas/worktrees/repo-feature")
+    }
+
+    @Test func remoteWorktreeDestinationKeepsNonHomeAbsolutePath() {
+        let path = AppState.destinationPathReplacingLocalHome(
+            "/srv/worktrees/repo-feature",
+            localHome: "/Users/local",
+            remoteHome: "/home/remote"
+        )
+
+        #expect(path == "/srv/worktrees/repo-feature")
+    }
+
+    @Test func remoteSaveAsNormalizesRelativePath() throws {
+        let path = try AppState.normalizedRemoteRelativePath(" nested\\file.txt ")
+
+        #expect(path == "nested/file.txt")
+    }
+
+    @Test func remoteSaveAsRejectsAbsoluteOrEscapingPaths() {
+        #expect(throws: (any Error).self) {
+            try AppState.normalizedRemoteRelativePath("/tmp/file.txt")
+        }
+        #expect(throws: (any Error).self) {
+            try AppState.normalizedRemoteRelativePath("../file.txt")
+        }
+    }
+}

--- a/AlasTests/AppStateSpacesTests.swift
+++ b/AlasTests/AppStateSpacesTests.swift
@@ -572,7 +572,7 @@ struct AppStateSpacesTests {
         let state = AppState(store: MemoryStore(projectsFile: ProjectsFile(projects: [p1, p2]), spacesFile: spaces))
         state.config.worktrees.fetchRemoteBeforeCreate = false
 
-        let id = state.createWorktree(
+        let id = await state.createWorktree(
             projectId: "p2",
             base: "main",
             branch: "space-create",

--- a/AlasTests/DiffOpenFileAvailabilityTests.swift
+++ b/AlasTests/DiffOpenFileAvailabilityTests.swift
@@ -34,6 +34,14 @@ struct DiffOpenFileAvailabilityTests {
         #expect(!DiffOpenFileAvailability.isAvailable(worktreePath: tmp, relativePath: "Sources"))
     }
 
+    @Test func availableForRemoteWorktreeWithoutLocalFile() {
+        let root = URL(fileURLWithPath: "/srv/remote-\(UUID().uuidString)")
+        RemoteHostRegistry.shared.register(root: root.path, host: "devbox")
+        defer { RemoteHostRegistry.shared.unregister(root: root.path) }
+
+        #expect(DiffOpenFileAvailability.isAvailable(worktreePath: root, relativePath: "Sources/App.swift"))
+    }
+
     @Test func equatableConformance() {
         #expect(DiffOpenFileAvailability.available == .available)
         #expect(DiffOpenFileAvailability.unavailable(reason: "a") == .unavailable(reason: "a"))

--- a/AlasTests/FileTreeBuilderTests.swift
+++ b/AlasTests/FileTreeBuilderTests.swift
@@ -90,6 +90,19 @@ struct FileTreeBuilderTests {
         #expect(buildDir.children == nil)
     }
 
+    @Test func requestedDirectoryWithLoadedChildrenMustNotBeLazy() {
+        let tree = FileTreeBuilder.build(
+            paths: ["src", "src/App.swift"],
+            badges: [:],
+            directories: ["src"],
+            lazyDirectories: []
+        )
+
+        let src = tree.first { $0.path == "src" }!
+        #expect(src.childrenState == .loaded)
+        #expect(src.children?.map(\.path) == ["src/App.swift"])
+    }
+
     @Test func preservesUntrackedStatusBadgeSeparatelyFromVisibility() {
         let tree = FileTreeBuilder.build(
             paths: ["new.txt"],

--- a/AlasTests/ProjectConfigHostTests.swift
+++ b/AlasTests/ProjectConfigHostTests.swift
@@ -1,0 +1,27 @@
+import Foundation
+import Testing
+@testable import Alas
+
+struct ProjectConfigHostTests {
+    private func makeProject(host: String? = nil) -> ProjectConfig {
+        ProjectConfig(
+            id: "test-id", name: "Repo", path: "/srv/repo", color: "blue",
+            addedAt: Date(timeIntervalSince1970: 0), host: host
+        )
+    }
+
+    @Test func legacyJSONDecodesWithNilHost() throws {
+        let data = try JSONEncoder().encode(makeProject())
+        #expect(try JSONDecoder().decode(ProjectConfig.self, from: data).host == nil)
+    }
+
+    @Test func nilHostIsOmittedFromEncoding() throws {
+        let data = try JSONEncoder().encode(makeProject())
+        #expect(!(try #require(String(data: data, encoding: .utf8))).contains("\"host\""))
+    }
+
+    @Test func hostRoundTrips() throws {
+        let data = try JSONEncoder().encode(makeProject(host: "devbox"))
+        #expect(try JSONDecoder().decode(ProjectConfig.self, from: data).host == "devbox")
+    }
+}

--- a/AlasTests/ProjectsManagerTests.swift
+++ b/AlasTests/ProjectsManagerTests.swift
@@ -65,6 +65,47 @@ struct ProjectsManagerTests {
         #expect(trees.first?.branch == "main")
     }
 
+    @Test func remoteRegistrationReconcileUnregistersRemovedWorktreeRoots() {
+        let project = ProjectConfig(
+            id: "remote-project",
+            name: "remote",
+            path: "/srv/remote",
+            color: "#5fb7c4",
+            addedAt: Date(),
+            host: "devbox"
+        )
+        let removed = Worktree(
+            id: "removed",
+            projectId: project.id,
+            name: "removed",
+            branch: "main",
+            path: URL(fileURLWithPath: "/srv/remote-removed"),
+            status: .clean,
+            lastActivity: Date()
+        )
+        let live = Worktree(
+            id: "live",
+            projectId: project.id,
+            name: "live",
+            branch: "main",
+            path: URL(fileURLWithPath: "/srv/remote-live"),
+            status: .clean,
+            lastActivity: Date()
+        )
+        defer {
+            RemoteHostRegistry.shared.unregister(root: project.path)
+            RemoteHostRegistry.shared.unregister(root: removed.path.path)
+            RemoteHostRegistry.shared.unregister(root: live.path.path)
+        }
+        let mgr = ProjectsManager(persistedProjects: [project])
+        RemoteHostRegistry.shared.register(root: removed.path.path, host: "devbox")
+
+        mgr.reconcileRemoteHostRegistrations(project: project, previous: [removed], reconciled: [live])
+
+        #expect(RemoteHostRegistry.shared.host(forPath: removed.path.path) == nil)
+        #expect(RemoteHostRegistry.shared.host(forPath: live.path.path) == "devbox")
+    }
+
     @Test func removeProjectStripsItAndItsWorktrees() async throws {
         let repo = try await makeRepo(name: "gamma")
         defer { try? FileManager.default.removeItem(at: repo) }

--- a/AlasTests/SSH/ACPReconnectPolicyTests.swift
+++ b/AlasTests/SSH/ACPReconnectPolicyTests.swift
@@ -1,0 +1,12 @@
+import Testing
+@testable import Alas
+
+struct ACPReconnectPolicyTests {
+    @Test func delaysBackOffAndGiveUp() {
+        #expect(ACPReconnectPolicy.delay(forAttempt: 0) == 2)
+        #expect(ACPReconnectPolicy.delay(forAttempt: 1) == 5)
+        #expect(ACPReconnectPolicy.delay(forAttempt: 4) == 60)
+        #expect(ACPReconnectPolicy.delay(forAttempt: 5) == nil)
+        #expect(ACPReconnectPolicy.delay(forAttempt: -1) == nil)
+    }
+}

--- a/AlasTests/SSH/ACPRemoteFileServerTests.swift
+++ b/AlasTests/SSH/ACPRemoteFileServerTests.swift
@@ -5,16 +5,35 @@ struct ACPRemoteFileServerTests {
     private let server = ACPRemoteFileServer(host: "devbox", worktreeRoot: "/srv/repo")
 
     @Test func containsPathsInsideRoot() throws {
-        #expect(try server.resolveInsideWorktree(path: "src/main.swift") == "/srv/repo/src/main.swift")
-        #expect(try server.resolveInsideWorktree(path: "/srv/repo/a.txt") == "/srv/repo/a.txt")
+        #expect(try server.lexicallyResolveInsideWorktree(path: "src/main.swift") == "/srv/repo/src/main.swift")
+        #expect(try server.lexicallyResolveInsideWorktree(path: "/srv/repo/a.txt") == "/srv/repo/a.txt")
     }
 
     @Test func normalizesDotSegments() throws {
-        #expect(try server.resolveInsideWorktree(path: "src/../src/./m.swift") == "/srv/repo/src/m.swift")
+        #expect(try server.lexicallyResolveInsideWorktree(path: "src/../src/./m.swift") == "/srv/repo/src/m.swift")
     }
 
     @Test func rejectsEscapes() {
-        #expect(throws: (any Error).self) { try server.resolveInsideWorktree(path: "../outside") }
-        #expect(throws: (any Error).self) { try server.resolveInsideWorktree(path: "/srv/repo-other/x") }
+        #expect(throws: (any Error).self) { try server.lexicallyResolveInsideWorktree(path: "../outside") }
+        #expect(throws: (any Error).self) { try server.lexicallyResolveInsideWorktree(path: "/srv/repo-other/x") }
+    }
+
+    @Test func containmentProbeUsesPhysicalParentCheck() {
+        let command = server.containmentProbeCommand(path: "/srv/repo/link/passwd")
+
+        #expect(command.contains("root='/srv/repo'"))
+        #expect(command.contains("target='/srv/repo/link/passwd'"))
+        #expect(command.contains("pwd -P"))
+        #expect(command.contains("existing_phys"))
+        #expect(command.contains("exit 6"))
+    }
+
+    @Test func sharedContainmentHelperUsesSameProbe() {
+        let command = RemotePathContainment.containmentProbeCommand(
+            path: "/srv/repo/link/passwd",
+            worktreeRoot: "/srv/repo"
+        )
+
+        #expect(command == server.containmentProbeCommand(path: "/srv/repo/link/passwd"))
     }
 }

--- a/AlasTests/SSH/ACPRemoteFileServerTests.swift
+++ b/AlasTests/SSH/ACPRemoteFileServerTests.swift
@@ -1,0 +1,20 @@
+import Testing
+@testable import Alas
+
+struct ACPRemoteFileServerTests {
+    private let server = ACPRemoteFileServer(host: "devbox", worktreeRoot: "/srv/repo")
+
+    @Test func containsPathsInsideRoot() throws {
+        #expect(try server.resolveInsideWorktree(path: "src/main.swift") == "/srv/repo/src/main.swift")
+        #expect(try server.resolveInsideWorktree(path: "/srv/repo/a.txt") == "/srv/repo/a.txt")
+    }
+
+    @Test func normalizesDotSegments() throws {
+        #expect(try server.resolveInsideWorktree(path: "src/../src/./m.swift") == "/srv/repo/src/m.swift")
+    }
+
+    @Test func rejectsEscapes() {
+        #expect(throws: (any Error).self) { try server.resolveInsideWorktree(path: "../outside") }
+        #expect(throws: (any Error).self) { try server.resolveInsideWorktree(path: "/srv/repo-other/x") }
+    }
+}

--- a/AlasTests/SSH/ACPRemoteLaunchTests.swift
+++ b/AlasTests/SSH/ACPRemoteLaunchTests.swift
@@ -26,7 +26,7 @@ struct ACPRemoteLaunchTests {
         #expect(invocation.executable == "/usr/bin/ssh")
         #expect(invocation.args.contains("BatchMode=yes"))
         let script = invocation.args.last ?? ""
-        #expect(script.hasPrefix("cd -- '/srv/repo' && "))
+        #expect(script.contains("cd '\\''/srv/repo'\\'' && "))
         #expect(script.contains("'codex-acp'"))
     }
 
@@ -37,6 +37,60 @@ struct ACPRemoteLaunchTests {
             == "command -v 'codex-acp'")
     }
 
+    @Test func setupProbePreservesPackageChecks() {
+        #expect(ACPRemoteLaunch.setupProbeCommand(check: .binaryOnPath(name: "gemini"))
+            == "command -v 'gemini'")
+
+        let codexProbe = ACPRemoteLaunch.setupProbeCommand(check: .npxPackage(name: "@agentclientprotocol/codex-acp"))
+        #expect(codexProbe.contains("npm root -g"))
+        #expect(codexProbe.contains("'@agentclientprotocol/codex-acp'"))
+        #expect(!codexProbe.contains("command -v 'codex-acp'"))
+
+        let mixedProbe = ACPRemoteLaunch.setupProbeCommand(
+            check: .binaryOnPathOrNpmPackage(binary: "claude-agent-acp", npmPackage: "@zed-industries/claude-code-acp")
+        )
+        #expect(mixedProbe.contains("command -v 'claude-agent-acp'"))
+        #expect(mixedProbe.contains("'@zed-industries/claude-code-acp'"))
+    }
+
+    @Test func launchPathProbePreservesNpmPackagePrecedence() throws {
+        let codex = ACPLaunchSpec(
+            agentID: "codex",
+            command: "codex-acp",
+            arguments: [],
+            extraEnv: [:],
+            setupCheck: .npxPackage(name: "@agentclientprotocol/codex-acp"),
+            supportsModelSelection: false,
+            supportsModeSelection: false
+        )
+
+        let command = try #require(ACPRemoteLaunch.launchPathProbeCommand(for: codex))
+        #expect(command.contains("npm prefix -g"))
+        #expect(command.contains("command -v 'codex-acp'"))
+        let npm = try #require(command.range(of: "npm prefix -g")?.lowerBound)
+        let path = try #require(command.range(of: "command -v 'codex-acp'")?.lowerBound)
+        #expect(npm < path)
+    }
+
+    @Test func launchPathProbePreservesBinaryOrPackagePrecedence() {
+        let claude = ACPLaunchSpec(
+            agentID: "claude",
+            command: "claude-agent-acp",
+            arguments: [],
+            extraEnv: [:],
+            setupCheck: .binaryOnPathOrNpmPackage(
+                binary: "claude-agent-acp",
+                npmPackage: "@zed-industries/claude-code-acp"
+            ),
+            supportsModelSelection: false,
+            supportsModeSelection: false
+        )
+
+        let command = ACPRemoteLaunch.launchPathProbeCommand(for: claude)
+        #expect(command?.hasPrefix("command -v 'claude-agent-acp'") == true)
+        #expect(command?.contains("npm prefix -g") == true)
+    }
+
     @Test func terminalCommandForwardsAgentEnvPairs() {
         let command = ACPRemoteLaunch.terminalCommand(
             command: "npm", args: ["test"],
@@ -45,7 +99,7 @@ struct ACPRemoteLaunchTests {
 
         #expect(command.contains("'CI=1'"))
         #expect(command.contains("'npm' 'test'"))
-        #expect(command.hasPrefix("cd -- '/srv/repo/sub' && env "))
+        #expect(command.hasPrefix("cd '/srv/repo/sub' && env "))
     }
 
     @Test func terminalCommandSortsEnvForDeterminism() {

--- a/AlasTests/SSH/ACPRemoteLaunchTests.swift
+++ b/AlasTests/SSH/ACPRemoteLaunchTests.swift
@@ -1,0 +1,62 @@
+import Testing
+@testable import Alas
+
+struct ACPRemoteLaunchTests {
+    @Test func agentCommandScrubsClaudeMarkersAndQuotes() {
+        let command = ACPRemoteLaunch.agentCommand(
+            command: "claude-agent-acp", arguments: ["--flag", "va l"]
+        )
+
+        for marker in [
+            "CLAUDECODE", "CLAUDE_CODE", "CLAUDE_PROJECT_DIR",
+            "CLAUDE_CODE_ENTRYPOINT", "CLAUDE_SESSION_ID",
+        ] {
+            #expect(command.contains("-u \(marker)"))
+        }
+        #expect(command.hasPrefix("env -u "))
+        #expect(command.hasSuffix("'claude-agent-acp' '--flag' 'va l'"))
+    }
+
+    @Test func channelInvocationRunsBatchSSHInWorktree() {
+        let invocation = ACPRemoteLaunch.channelInvocation(
+            host: "devbox", worktreePath: "/srv/repo",
+            command: "codex-acp", arguments: []
+        )
+
+        #expect(invocation.executable == "/usr/bin/ssh")
+        #expect(invocation.args.contains("BatchMode=yes"))
+        let script = invocation.args.last ?? ""
+        #expect(script.hasPrefix("cd -- '/srv/repo' && "))
+        #expect(script.contains("'codex-acp'"))
+    }
+
+    @Test func setupProbeUsesFirstWordOfCommand() {
+        #expect(ACPRemoteLaunch.setupProbeCommand(command: "gemini --experimental-acp")
+            == "command -v 'gemini'")
+        #expect(ACPRemoteLaunch.setupProbeCommand(command: "codex-acp")
+            == "command -v 'codex-acp'")
+    }
+
+    @Test func terminalCommandForwardsAgentEnvPairs() {
+        let command = ACPRemoteLaunch.terminalCommand(
+            command: "npm", args: ["test"],
+            env: ["CI": "1"], cwd: "/srv/repo/sub"
+        )
+
+        #expect(command.contains("'CI=1'"))
+        #expect(command.contains("'npm' 'test'"))
+        #expect(command.hasPrefix("cd -- '/srv/repo/sub' && env "))
+    }
+
+    @Test func terminalCommandSortsEnvForDeterminism() {
+        let first = ACPRemoteLaunch.terminalCommand(
+            command: "x", args: [], env: ["B": "2", "A": "1"], cwd: "/w"
+        )
+        let second = ACPRemoteLaunch.terminalCommand(
+            command: "x", args: [], env: ["A": "1", "B": "2"], cwd: "/w"
+        )
+
+        #expect(first == second)
+        #expect(first.range(of: "'A=1'")!.lowerBound < first.range(of: "'B=2'")!.lowerBound)
+    }
+}

--- a/AlasTests/SSH/ACPRemoteMCPFilterTests.swift
+++ b/AlasTests/SSH/ACPRemoteMCPFilterTests.swift
@@ -1,0 +1,29 @@
+import Testing
+@testable import Alas
+
+struct ACPRemoteMCPFilterTests {
+    @Test func dropsStdioKeepsURLBasedServers() {
+        let servers: [ACPMCPServer] = [
+            .stdio(
+                name: "local-tool",
+                command: "/usr/local/bin/tool",
+                args: [],
+                env: []
+            ),
+            .http(name: "docs", url: "https://mcp.example.com", headers: []),
+            .sse(name: "events", url: "https://mcp.example.com/sse", headers: []),
+        ]
+
+        let result = ACPRemoteMCPFilter.split(servers)
+
+        #expect(result.kept == [servers[1], servers[2]])
+        #expect(result.droppedStdio == ["local-tool"])
+    }
+
+    @Test func emptyInputYieldsEmptyOutput() {
+        let result = ACPRemoteMCPFilter.split([])
+
+        #expect(result.kept.isEmpty)
+        #expect(result.droppedStdio.isEmpty)
+    }
+}

--- a/AlasTests/SSH/ACPTerminalCRLFTests.swift
+++ b/AlasTests/SSH/ACPTerminalCRLFTests.swift
@@ -1,0 +1,10 @@
+import Testing
+@testable import Alas
+
+struct ACPTerminalCRLFTests {
+    @Test func collapsesCRLFOnly() {
+        #expect(ACPTerminal.normalizeCRLF("a\r\nb\r\n") == "a\nb\n")
+        #expect(ACPTerminal.normalizeCRLF("progress\rprogress2\n") == "progress\rprogress2\n")
+        #expect(ACPTerminal.normalizeCRLF("") == "")
+    }
+}

--- a/AlasTests/SSH/GitInvocationTests.swift
+++ b/AlasTests/SSH/GitInvocationTests.swift
@@ -1,0 +1,53 @@
+import Foundation
+import Testing
+@testable import Alas
+
+struct GitInvocationTests {
+    @Test func localInvocationIsUnchangedFromToday() {
+        let inv = GitInvocation.build(
+            gitArgs: ["status", "--porcelain=v2"],
+            cwd: URL(fileURLWithPath: "/Users/n/repo"),
+            host: nil
+        )
+        #expect(inv.executable == "/usr/bin/env")
+        #expect(inv.args == ["git", "status", "--porcelain=v2"])
+        #expect(inv.cwd == URL(fileURLWithPath: "/Users/n/repo"))
+        #expect(inv.env?["GIT_OPTIONAL_LOCKS"] == "0")
+        #expect(inv.env?["LC_ALL"] == "C")
+    }
+
+    @Test func remoteInvocationRunsSSHBatch() {
+        let inv = GitInvocation.build(gitArgs: ["status"], cwd: URL(fileURLWithPath: "/srv/repo"), host: "devbox")
+        #expect(inv.executable == "/usr/bin/ssh")
+        #expect(inv.args.contains("BatchMode=yes"))
+        #expect(inv.args.dropLast().last == "devbox")
+        #expect(inv.cwd == nil)
+        #expect(inv.env == nil)
+    }
+
+    @Test func remoteScriptSetsGitEnvOnRemoteSide() throws {
+        let inv = GitInvocation.build(gitArgs: ["status"], cwd: URL(fileURLWithPath: "/srv/repo"), host: "devbox")
+        let script = try #require(inv.args.last)
+        #expect(script.hasPrefix("cd -- '/srv/repo' && "))
+        #expect(script.contains("GIT_OPTIONAL_LOCKS=0"))
+        #expect(script.contains("LC_ALL=C"))
+        #expect(script.contains("git 'status'"))
+    }
+
+    @Test func remoteArgsComposeThroughBothQuotingLayers() throws {
+        let inv = GitInvocation.build(
+            gitArgs: ["commit", "-m", "fix: don't break"],
+            cwd: URL(fileURLWithPath: "/srv/repo"),
+            host: "devbox"
+        )
+        let command = "env GIT_OPTIONAL_LOCKS=0 LC_ALL=C git 'commit' '-m' "
+            + SSHCommand.shellQuote("fix: don't break")
+        #expect(try #require(inv.args.last) == SSHCommand.remoteScript(cwd: "/srv/repo", command: command))
+    }
+
+    @Test func remoteWithoutCwdStillRunsRemotely() throws {
+        let inv = GitInvocation.build(gitArgs: ["--version"], cwd: nil, host: "devbox")
+        #expect(inv.executable == "/usr/bin/ssh")
+        #expect(!(try #require(inv.args.last)).contains("cd -- "))
+    }
+}

--- a/AlasTests/SSH/GitInvocationTests.swift
+++ b/AlasTests/SSH/GitInvocationTests.swift
@@ -28,10 +28,11 @@ struct GitInvocationTests {
     @Test func remoteScriptSetsGitEnvOnRemoteSide() throws {
         let inv = GitInvocation.build(gitArgs: ["status"], cwd: URL(fileURLWithPath: "/srv/repo"), host: "devbox")
         let script = try #require(inv.args.last)
-        #expect(script.hasPrefix("cd -- '/srv/repo' && "))
+        #expect(script.hasPrefix("/bin/sh -c "))
+        #expect(script.contains("cd '\\''/srv/repo'\\'' && "))
         #expect(script.contains("GIT_OPTIONAL_LOCKS=0"))
         #expect(script.contains("LC_ALL=C"))
-        #expect(script.contains("git 'status'"))
+        #expect(script.contains("git '\\''status'\\''"))
     }
 
     @Test func remoteArgsComposeThroughBothQuotingLayers() throws {
@@ -48,6 +49,6 @@ struct GitInvocationTests {
     @Test func remoteWithoutCwdStillRunsRemotely() throws {
         let inv = GitInvocation.build(gitArgs: ["--version"], cwd: nil, host: "devbox")
         #expect(inv.executable == "/usr/bin/ssh")
-        #expect(!(try #require(inv.args.last)).contains("cd -- "))
+        #expect(!(try #require(inv.args.last)).contains("cd "))
     }
 }

--- a/AlasTests/SSH/RemoteContentSearchTests.swift
+++ b/AlasTests/SSH/RemoteContentSearchTests.swift
@@ -1,0 +1,50 @@
+import Testing
+@testable import Alas
+
+struct RemoteContentSearchTests {
+    @Test func rgInvocationRunsBatchSSHInWorktree() {
+        let invocation = RemoteContentSearch.rgInvocation(
+            host: "devbox",
+            cwd: "/srv/repo",
+            rgArgs: ["--json", "--", "needle", "."]
+        )
+
+        #expect(invocation.executable == "/usr/bin/ssh")
+        #expect(invocation.args.contains("BatchMode=yes"))
+        let script = invocation.args.last ?? ""
+        #expect(script.hasPrefix("cd -- '/srv/repo' && "))
+        #expect(script.contains("rg '--json' '--' 'needle' '.'"))
+    }
+
+    @Test func gitGrepEmulatesSmartCase() {
+        #expect(RemoteContentSearch.gitGrepArgs(
+            query: "needle", options: SearchContentOptions()
+        ).contains("-i"))
+        #expect(!RemoteContentSearch.gitGrepArgs(
+            query: "Needle", options: SearchContentOptions()
+        ).contains("-i"))
+    }
+
+    @Test func gitGrepAlwaysSearchesUntrackedAndSkipsBinary() {
+        let args = RemoteContentSearch.gitGrepArgs(query: "x", options: SearchContentOptions())
+        #expect(args.first == "grep")
+        for flag in ["-nI", "--column", "--untracked", "-z"] {
+            #expect(args.contains(flag))
+        }
+    }
+
+    @Test func parsesNulSeparatedGrepLine() {
+        let line = "src/a:b.txt\u{0}12:5:let value = needle"
+        let hit = RemoteContentSearch.parseGitGrepLine(line)
+        #expect(hit?.path == "src/a:b.txt")
+        #expect(hit?.line == 12)
+        #expect(hit?.column == 5)
+        #expect(hit?.text == "let value = needle")
+    }
+
+    @Test func rejectsMalformedGrepLines() {
+        #expect(RemoteContentSearch.parseGitGrepLine("") == nil)
+        #expect(RemoteContentSearch.parseGitGrepLine("no-nul-here:1:2:x") == nil)
+        #expect(RemoteContentSearch.parseGitGrepLine("p\u{0}notanumber:2:x") == nil)
+    }
+}

--- a/AlasTests/SSH/RemoteContentSearchTests.swift
+++ b/AlasTests/SSH/RemoteContentSearchTests.swift
@@ -12,8 +12,10 @@ struct RemoteContentSearchTests {
         #expect(invocation.executable == "/usr/bin/ssh")
         #expect(invocation.args.contains("BatchMode=yes"))
         let script = invocation.args.last ?? ""
-        #expect(script.hasPrefix("cd -- '/srv/repo' && "))
-        #expect(script.contains("rg '--json' '--' 'needle' '.'"))
+        #expect(script.contains("cd '\\''/srv/repo'\\'' && "))
+        #expect(script.contains("rg"))
+        #expect(script.contains("--json"))
+        #expect(script.contains("needle"))
     }
 
     @Test func gitGrepEmulatesSmartCase() {
@@ -33,8 +35,35 @@ struct RemoteContentSearchTests {
         }
     }
 
+    @Test func gitGrepUsesExtendedRegexWhenRegexSearchIsEnabled() {
+        let args = RemoteContentSearch.gitGrepArgs(query: "foo|bar", options: SearchContentOptions(regex: true))
+
+        #expect(args.contains("-E"))
+        #expect(!args.contains("-F"))
+    }
+
+    @Test func cappedGitGrepInvocationLimitsOutputOnRemoteSide() {
+        let invocation = RemoteContentSearch.cappedGitGrepInvocation(
+            host: "devbox",
+            cwd: "/srv/repo",
+            query: "needle",
+            options: SearchContentOptions()
+        )
+
+        #expect(invocation.executable == "/usr/bin/ssh")
+        #expect(invocation.args.contains("BatchMode=yes"))
+        let script = invocation.args.last ?? ""
+        #expect(script.contains("cd '\\''/srv/repo'\\'' && "))
+        #expect(script.contains("mkfifo \"$fifo\" || exit 2"))
+        #expect(script.contains("env GIT_OPTIONAL_LOCKS=0 LC_ALL=C git '\\''grep'\\''"))
+        #expect(script.contains("awk -v cap=2000"))
+        #expect(script.contains("if (NR >= cap) exit"))
+        #expect(script.contains("git_status=$?"))
+        #expect(script.contains("exit \"$git_status\""))
+    }
+
     @Test func parsesNulSeparatedGrepLine() {
-        let line = "src/a:b.txt\u{0}12:5:let value = needle"
+        let line = "src/a:b.txt\u{0}12\u{0}5\u{0}let value = needle"
         let hit = RemoteContentSearch.parseGitGrepLine(line)
         #expect(hit?.path == "src/a:b.txt")
         #expect(hit?.line == 12)
@@ -45,6 +74,6 @@ struct RemoteContentSearchTests {
     @Test func rejectsMalformedGrepLines() {
         #expect(RemoteContentSearch.parseGitGrepLine("") == nil)
         #expect(RemoteContentSearch.parseGitGrepLine("no-nul-here:1:2:x") == nil)
-        #expect(RemoteContentSearch.parseGitGrepLine("p\u{0}notanumber:2:x") == nil)
+        #expect(RemoteContentSearch.parseGitGrepLine("p\u{0}notanumber\u{0}2\u{0}x") == nil)
     }
 }

--- a/AlasTests/SSH/RemoteExecTests.swift
+++ b/AlasTests/SSH/RemoteExecTests.swift
@@ -1,0 +1,26 @@
+import Testing
+@testable import Alas
+
+struct RemoteExecTests {
+    @Test func invocationWithCwdComposesCdScript() {
+        let invocation = RemoteExec.invocation(host: "devbox", cwd: "/srv/repo", command: "ls -1Ap")
+        #expect(invocation.executable == "/usr/bin/ssh")
+        #expect(invocation.args.contains("BatchMode=yes"))
+        let expected = SSHCommand(host: "devbox", mode: .batch)
+            .argv(remoteScript: SSHCommand.remoteScript(cwd: "/srv/repo", command: "ls -1Ap"))
+        #expect(invocation.args == expected)
+    }
+
+    @Test func invocationWithoutCwdOmitsCd() {
+        let invocation = RemoteExec.invocation(host: "devbox", cwd: nil, command: "uname -s")
+        let expected = SSHCommand(host: "devbox", mode: .batch)
+            .argv(remoteScript: SSHCommand.remoteScript(command: "uname -s"))
+        #expect(invocation.args == expected)
+    }
+
+    @Test func exit255IsConnectionFailure() {
+        #expect(RemoteExec.isConnectionFailure(exitCode: 255))
+        #expect(!RemoteExec.isConnectionFailure(exitCode: 0))
+        #expect(!RemoteExec.isConnectionFailure(exitCode: 1))
+    }
+}

--- a/AlasTests/SSH/RemoteFileAccessTests.swift
+++ b/AlasTests/SSH/RemoteFileAccessTests.swift
@@ -1,0 +1,59 @@
+import Foundation
+import Testing
+@testable import Alas
+
+struct RemoteFileAccessTests {
+    @Test func readScriptEmitsMtimeHeaderThenBytes() {
+        let script = RemoteFileAccess.readScript(path: "/srv/repo/a.txt")
+        #expect(script.contains("f='/srv/repo/a.txt'"))
+        #expect(script.contains("[ -d \"$f\" ] && exit 3"))
+        #expect(script.contains("[ -e \"$f\" ] || exit 4"))
+        #expect(script.contains("stat -c %Y -- \"$f\" 2>/dev/null || stat -f %m -- \"$f\""))
+        #expect(script.contains("cat -- \"$f\""))
+    }
+
+    @Test func parseReadPayloadSplitsHeaderFromBinaryBody() {
+        var payload = Data("1752249600\n".utf8)
+        let body = Data([0x00, 0xFF, 0x0A, 0x42])
+        payload.append(body)
+        let parsed = RemoteFileAccess.parseReadPayload(payload)
+        #expect(parsed?.mtime == Date(timeIntervalSince1970: 1_752_249_600))
+        #expect(parsed?.contents == body)
+    }
+
+    @Test func parseReadPayloadHandlesEmptyFile() {
+        let parsed = RemoteFileAccess.parseReadPayload(Data("42\n".utf8))
+        #expect(parsed?.mtime == Date(timeIntervalSince1970: 42))
+        #expect(parsed?.contents == Data())
+    }
+
+    @Test func parseReadPayloadRejectsGarbageHeader() {
+        #expect(RemoteFileAccess.parseReadPayload(Data("not-a-number\nx".utf8)) == nil)
+        #expect(RemoteFileAccess.parseReadPayload(Data()) == nil)
+    }
+
+    @Test func writeScriptPreservesPermissionsAndIsAtomic() {
+        let script = RemoteFileAccess.writeScript(path: "/srv/repo/run.sh")
+        #expect(script.contains("f='/srv/repo/run.sh'"))
+        #expect(script.contains("cp -p -- \"$f\" \"$t\""))
+        #expect(script.contains("cat > \"$t\""))
+        #expect(script.contains("mv -- \"$t\" \"$f\""))
+        #expect(script.contains("rm -f -- \"$t\""))
+        #expect(script.contains("stat -c %Y -- \"$f\" 2>/dev/null || stat -f %m -- \"$f\""))
+    }
+
+    @Test func scriptsQuoteApostrophePaths() {
+        let read = RemoteFileAccess.readScript(path: "/srv/o'brien.txt")
+        #expect(read.contains("f='/srv/o'\\''brien.txt'"))
+    }
+
+    @Test func saveGateDecisions() {
+        let t1 = Date(timeIntervalSince1970: 100)
+        let t2 = Date(timeIntervalSince1970: 200)
+        #expect(RemoteSaveGate.decision(originalMtime: t1, remoteMtime: t1) == .proceed)
+        #expect(RemoteSaveGate.decision(originalMtime: t1, remoteMtime: t2) == .conflict)
+        #expect(RemoteSaveGate.decision(originalMtime: t1, remoteMtime: nil) == .targetDeleted)
+        #expect(RemoteSaveGate.decision(originalMtime: nil, remoteMtime: nil) == .proceed)
+        #expect(RemoteSaveGate.decision(originalMtime: t2, remoteMtime: t1) == .proceed)
+    }
+}

--- a/AlasTests/SSH/RemoteFileAccessTests.swift
+++ b/AlasTests/SSH/RemoteFileAccessTests.swift
@@ -6,10 +6,11 @@ struct RemoteFileAccessTests {
     @Test func readScriptEmitsMtimeHeaderThenBytes() {
         let script = RemoteFileAccess.readScript(path: "/srv/repo/a.txt")
         #expect(script.contains("f='/srv/repo/a.txt'"))
+        #expect(script.contains("[ -L \"$f\" ] && exit 5"))
         #expect(script.contains("[ -d \"$f\" ] && exit 3"))
         #expect(script.contains("[ -e \"$f\" ] || exit 4"))
-        #expect(script.contains("stat -c %Y -- \"$f\" 2>/dev/null || stat -f %m -- \"$f\""))
-        #expect(script.contains("cat -- \"$f\""))
+        #expect(script.contains("stat -c %Y -- \"$f\" 2>/dev/null || stat -f %m \"$f\""))
+        #expect(script.contains("cat \"$f\""))
     }
 
     @Test func parseReadPayloadSplitsHeaderFromBinaryBody() {
@@ -35,11 +36,16 @@ struct RemoteFileAccessTests {
     @Test func writeScriptPreservesPermissionsAndIsAtomic() {
         let script = RemoteFileAccess.writeScript(path: "/srv/repo/run.sh")
         #expect(script.contains("f='/srv/repo/run.sh'"))
-        #expect(script.contains("cp -p -- \"$f\" \"$t\""))
+        #expect(script.contains("[ -L \"$f\" ] && exit 6"))
+        #expect(script.contains("[ -d \"$f\" ] && exit 7"))
+        #expect(script.contains("mode=$(stat -c %a -- \"$f\" 2>/dev/null || stat -f %Lp \"$f\")"))
+        #expect(script.contains("cp -p \"$f\" \"$t\""))
+        #expect(script.contains("chmod u+w \"$t\""))
         #expect(script.contains("cat > \"$t\""))
-        #expect(script.contains("mv -- \"$t\" \"$f\""))
-        #expect(script.contains("rm -f -- \"$t\""))
-        #expect(script.contains("stat -c %Y -- \"$f\" 2>/dev/null || stat -f %m -- \"$f\""))
+        #expect(script.contains("chmod \"$mode\" \"$t\""))
+        #expect(script.contains("mv \"$t\" \"$f\""))
+        #expect(script.contains("rm -f \"$t\""))
+        #expect(script.contains("stat -c %Y -- \"$f\" 2>/dev/null || stat -f %m \"$f\""))
     }
 
     @Test func scriptsQuoteApostrophePaths() {
@@ -55,5 +61,14 @@ struct RemoteFileAccessTests {
         #expect(RemoteSaveGate.decision(originalMtime: t1, remoteMtime: nil) == .targetDeleted)
         #expect(RemoteSaveGate.decision(originalMtime: nil, remoteMtime: nil) == .proceed)
         #expect(RemoteSaveGate.decision(originalMtime: t2, remoteMtime: t1) == .proceed)
+    }
+
+    @Test func saveGateTreatsEqualMtimeAsAmbiguousForCallerContentCheck() {
+        let baseline = Date(timeIntervalSince1970: 100)
+        #expect(RemoteSaveGate.requiresContentCheck(originalMtime: baseline, remoteMtime: baseline))
+        #expect(RemoteSaveGate.requiresContentCheck(originalMtime: baseline, remoteMtime: Date(timeIntervalSince1970: 99)))
+        #expect(!RemoteSaveGate.requiresContentCheck(originalMtime: baseline, remoteMtime: Date(timeIntervalSince1970: 101)))
+        #expect(!RemoteSaveGate.requiresContentCheck(originalMtime: nil, remoteMtime: baseline))
+        #expect(!RemoteSaveGate.requiresContentCheck(originalMtime: baseline, remoteMtime: nil))
     }
 }

--- a/AlasTests/SSH/RemoteFileOpsTests.swift
+++ b/AlasTests/SSH/RemoteFileOpsTests.swift
@@ -1,0 +1,24 @@
+import Testing
+@testable import Alas
+
+struct RemoteFileOpsTests {
+    @Test func moveCommandCreatesParentAndMoves() {
+        #expect(RemoteFileOps.moveCommand(
+            from: "/srv/repo/a.txt", to: "/srv/repo/sub dir/b.txt"
+        ) == "mkdir -p '/srv/repo/sub dir' && [ ! -e '/srv/repo/sub dir/b.txt' ] && [ ! -L '/srv/repo/sub dir/b.txt' ] && mv '/srv/repo/a.txt' '/srv/repo/sub dir/b.txt'")
+    }
+
+    @Test func mkdirCommandTargetsParent() {
+        #expect(RemoteFileOps.mkdirCommand(parentOf: "/srv/repo/x/y.txt") == "mkdir -p '/srv/repo/x'")
+    }
+
+    @Test func removeCommandQuotesPathAndAvoidsGNUSeparator() {
+        #expect(RemoteFileOps.removeCommand(path: "/srv/repo/a b.txt") == "p='/srv/repo/a b.txt'; rm -rf \"$p\"")
+    }
+
+    @Test func createEmptyFileCommandCreatesParentAndDoesNotClobber() {
+        #expect(RemoteFileOps.createEmptyFileCommand(
+            path: "/srv/repo/sub dir/new.txt"
+        ) == "mkdir -p '/srv/repo/sub dir' && f='/srv/repo/sub dir/new.txt' && [ ! -e \"$f\" ] && [ ! -L \"$f\" ] && (set -C; : > \"$f\")")
+    }
+}

--- a/AlasTests/SSH/RemoteFileSearchGateTests.swift
+++ b/AlasTests/SSH/RemoteFileSearchGateTests.swift
@@ -1,0 +1,21 @@
+import Foundation
+import Testing
+@testable import Alas
+
+@Suite(.serialized)
+struct RemoteFileSearchGateTests {
+    @Test func fffBackendDeclinesRemoteWorktrees() async throws {
+        RemoteHostRegistry.shared.register(root: "/srv/remote-gate-test", host: "devbox")
+        defer { RemoteHostRegistry.shared.unregister(root: "/srv/remote-gate-test") }
+
+        let backend = FffFileSearchBackend()
+        let worktree = SearchWorktree(
+            id: "wt",
+            projectId: "p",
+            displayName: "remote",
+            absolutePath: URL(fileURLWithPath: "/srv/remote-gate-test")
+        )
+        let result = try await backend.search(query: "main", worktree: worktree, limit: 50)
+        #expect(result == nil)
+    }
+}

--- a/AlasTests/SSH/RemoteFileStatsTests.swift
+++ b/AlasTests/SSH/RemoteFileStatsTests.swift
@@ -1,0 +1,18 @@
+import Testing
+@testable import Alas
+
+struct RemoteFileStatsTests {
+    @Test func wcCommandQuotesPathsAndAvoidsEmptyInput() {
+        #expect(RemoteFileStats.wcCommand(paths: []) == nil)
+        #expect(RemoteFileStats.wcCommand(paths: ["a.txt", "dir/o'brien.txt"]) == "wc -l 'a.txt' 'dir/o'\\''brien.txt'")
+    }
+    @Test func parsesWcOutput() {
+        #expect(RemoteFileStats.parseWcOutput("      12 a.txt\n       0 b.txt\n      12 total", requested: ["a.txt", "b.txt"]) == ["a.txt": 12, "b.txt": 0])
+    }
+    @Test func parsesLsEntries() {
+        let entries = RemoteFileStats.parseLsEntries("src/\nREADME.md\n")
+        #expect(entries.count == 2)
+        #expect(entries[0].name == "src" && entries[0].isDirectory)
+        #expect(entries[1].name == "README.md" && !entries[1].isDirectory)
+    }
+}

--- a/AlasTests/SSH/RemoteHostCapabilitiesTests.swift
+++ b/AlasTests/SSH/RemoteHostCapabilitiesTests.swift
@@ -1,0 +1,48 @@
+import Testing
+@testable import Alas
+
+struct RemoteHostCapabilitiesTests {
+    @Test func parsesLinuxHostWithEverything() {
+        let output = """
+        Linux
+        git version 2.43.0
+        rg=yes
+        zmx=yes
+        """
+        let capabilities = RemoteHostCapabilities.parse(output)
+        #expect(capabilities.os == .linux)
+        #expect(capabilities.gitVersion == "2.43.0")
+        #expect(capabilities.hasRipgrep)
+        #expect(capabilities.hasZmx)
+    }
+
+    @Test func parsesMacHostWithoutTools() {
+        let output = """
+        Darwin
+        git version 2.39.5 (Apple Git-154)
+        rg=no
+        zmx=no
+        """
+        let capabilities = RemoteHostCapabilities.parse(output)
+        #expect(capabilities.os == .macos)
+        #expect(capabilities.gitVersion == "2.39.5")
+        #expect(!capabilities.hasRipgrep)
+        #expect(!capabilities.hasZmx)
+    }
+
+    @Test func missingGitYieldsNilVersion() {
+        let capabilities = RemoteHostCapabilities.parse("Linux\nrg=no\nzmx=no")
+        #expect(capabilities.gitVersion == nil)
+        #expect(capabilities.os == .linux)
+    }
+
+    @Test func unknownUnameIsOther() {
+        #expect(RemoteHostCapabilities.parse("FreeBSD\nrg=no\nzmx=no").os == .other)
+        #expect(RemoteHostCapabilities.parse("").os == .other)
+    }
+
+    @Test func probeCommandIsPOSIXPortable() {
+        #expect(!RemoteHostCapabilities.probeCommand.contains("xargs"))
+        #expect(!RemoteHostCapabilities.probeCommand.contains("--"))
+    }
+}

--- a/AlasTests/SSH/RemoteHostCapabilitiesTests.swift
+++ b/AlasTests/SSH/RemoteHostCapabilitiesTests.swift
@@ -46,6 +46,10 @@ struct RemoteHostCapabilitiesTests {
         #expect(!RemoteHostCapabilities.probeCommand.contains("--"))
     }
 
+    @Test func probeCommandChecksInstalledZmxFallback() {
+        #expect(RemoteHostCapabilities.probeCommand.contains("[ -x \"$HOME/.alas/bin/zmx\" ]"))
+    }
+
     @Test func parsesArchAndNormalizesArm64() {
         #expect(RemoteHostCapabilities.parse("Linux\narch=x86_64").arch == "x86_64")
         #expect(RemoteHostCapabilities.parse("Darwin\narch=arm64").arch == "aarch64")

--- a/AlasTests/SSH/RemoteHostCapabilitiesTests.swift
+++ b/AlasTests/SSH/RemoteHostCapabilitiesTests.swift
@@ -45,4 +45,14 @@ struct RemoteHostCapabilitiesTests {
         #expect(!RemoteHostCapabilities.probeCommand.contains("xargs"))
         #expect(!RemoteHostCapabilities.probeCommand.contains("--"))
     }
+
+    @Test func parsesArchAndNormalizesArm64() {
+        #expect(RemoteHostCapabilities.parse("Linux\narch=x86_64").arch == "x86_64")
+        #expect(RemoteHostCapabilities.parse("Darwin\narch=arm64").arch == "aarch64")
+        #expect(RemoteHostCapabilities.parse("Linux").arch == nil)
+    }
+
+    @Test func probeCommandEmitsArchLine() {
+        #expect(RemoteHostCapabilities.probeCommand.contains("echo \"arch=$(uname -m)\""))
+    }
 }

--- a/AlasTests/SSH/RemoteHostRegistryTests.swift
+++ b/AlasTests/SSH/RemoteHostRegistryTests.swift
@@ -1,0 +1,54 @@
+import Foundation
+import Testing
+@testable import Alas
+
+struct RemoteHostRegistryTests {
+    private func makeRegistry() -> RemoteHostRegistry {
+        let registry = RemoteHostRegistry()
+        registry.register(root: "/srv/repo", host: "devbox")
+        return registry
+    }
+
+    @Test func exactRootMatches() {
+        #expect(makeRegistry().host(forPath: "/srv/repo") == "devbox")
+    }
+
+    @Test func trailingSlashOnRootIsNormalized() {
+        let registry = RemoteHostRegistry()
+        registry.register(root: "/srv/repo/", host: "devbox")
+        #expect(registry.host(forPath: "/srv/repo") == "devbox")
+    }
+
+    @Test func nestedPathMatches() {
+        #expect(makeRegistry().host(forPath: "/srv/repo/src/main.swift") == "devbox")
+    }
+
+    @Test func siblingWithSharedPrefixDoesNotMatch() {
+        #expect(makeRegistry().host(forPath: "/srv/repo-other") == nil)
+    }
+
+    @Test func unregisteredPathReturnsNil() {
+        #expect(makeRegistry().host(forPath: "/Users/nacho/local") == nil)
+        #expect(makeRegistry().host(forPath: nil) == nil)
+    }
+
+    @Test func longestRootWins() {
+        let registry = makeRegistry()
+        registry.register(root: "/srv/repo/vendored", host: "otherbox")
+        #expect(registry.host(forPath: "/srv/repo/vendored/lib.c") == "otherbox")
+        #expect(registry.host(forPath: "/srv/repo/src.c") == "devbox")
+    }
+
+    @Test func unregisterRemovesRoot() {
+        let registry = makeRegistry()
+        registry.unregister(root: "/srv/repo")
+        #expect(registry.host(forPath: "/srv/repo") == nil)
+    }
+
+    @Test func urlConvenienceReflectsSharedRegistry() {
+        RemoteHostRegistry.shared.register(root: "/srv/only-in-test", host: "devbox")
+        defer { RemoteHostRegistry.shared.unregister(root: "/srv/only-in-test") }
+        #expect(URL(fileURLWithPath: "/srv/only-in-test/a.txt").isRemoteAlasPath)
+        #expect(!URL(fileURLWithPath: "/tmp").isRemoteAlasPath)
+    }
+}

--- a/AlasTests/SSH/RemoteHostStatusStoreTests.swift
+++ b/AlasTests/SSH/RemoteHostStatusStoreTests.swift
@@ -1,0 +1,39 @@
+import Testing
+@testable import Alas
+
+@MainActor
+struct RemoteHostStatusStoreTests {
+    @Test func singleFailureIsNotOffline() {
+        let store = RemoteHostStatusStore()
+        store.reportConnectionFailure(host: "devbox")
+        #expect(!store.isOffline("devbox"))
+    }
+
+    @Test func twoConsecutiveFailuresAreOffline() {
+        let store = RemoteHostStatusStore()
+        store.reportConnectionFailure(host: "devbox")
+        store.reportConnectionFailure(host: "devbox")
+        #expect(store.isOffline("devbox"))
+    }
+
+    @Test func successResetsFailureCountAndOfflineState() {
+        let store = RemoteHostStatusStore()
+        store.reportConnectionFailure(host: "devbox")
+        store.reportSuccess(host: "devbox")
+        store.reportConnectionFailure(host: "devbox")
+        #expect(!store.isOffline("devbox"))
+
+        store.reportConnectionFailure(host: "devbox")
+        #expect(store.isOffline("devbox"))
+        store.reportSuccess(host: "devbox")
+        #expect(!store.isOffline("devbox"))
+    }
+
+    @Test func hostsAreIndependent() {
+        let store = RemoteHostStatusStore()
+        store.reportConnectionFailure(host: "a")
+        store.reportConnectionFailure(host: "a")
+        #expect(store.isOffline("a"))
+        #expect(!store.isOffline("b"))
+    }
+}

--- a/AlasTests/SSH/RemoteImageCacheTests.swift
+++ b/AlasTests/SSH/RemoteImageCacheTests.swift
@@ -1,0 +1,30 @@
+import Foundation
+import Testing
+@testable import Alas
+
+struct RemoteImageCacheTests {
+    @Test func trustedRemotePathAcceptsFileURLAndRelativePath() {
+        let root = URL(fileURLWithPath: "/srv/repo")
+
+        #expect(
+            ACPToolCallCard.trustedRemotePath(
+                from: "file:///srv/repo/shot.png",
+                trustedRoot: root
+            ) == "/srv/repo/shot.png"
+        )
+        #expect(
+            ACPToolCallCard.trustedRemotePath(
+                from: "assets/shot.png",
+                trustedRoot: root
+            ) == "/srv/repo/assets/shot.png"
+        )
+    }
+
+    @Test func trustedRemotePathRejectsEscapesAndNonFileSchemes() {
+        let root = URL(fileURLWithPath: "/srv/repo")
+
+        #expect(ACPToolCallCard.trustedRemotePath(from: "https://x/y.png", trustedRoot: root) == nil)
+        #expect(ACPToolCallCard.trustedRemotePath(from: "../secrets.png", trustedRoot: root) == nil)
+        #expect(ACPToolCallCard.trustedRemotePath(from: "/etc/passwd", trustedRoot: root) == nil)
+    }
+}

--- a/AlasTests/SSH/RemoteLSPLauncherTests.swift
+++ b/AlasTests/SSH/RemoteLSPLauncherTests.swift
@@ -1,0 +1,85 @@
+import Testing
+@testable import Alas
+
+struct RemoteLSPLauncherTests {
+    @Test func invocationRunsServerInWorkspaceRootWithEnv() {
+        let invocation = RemoteLSPLauncher.invocation(
+            host: "devbox",
+            rootPath: "/srv/repo",
+            command: "rust-analyzer",
+            args: [],
+            env: ["RA_LOG": "error"]
+        )
+
+        #expect(invocation.executable == "/usr/bin/ssh")
+        #expect(invocation.args.contains("BatchMode=yes"))
+        let script = invocation.args.last ?? ""
+        #expect(script.contains("cd '\\''/srv/repo'\\'' && "))
+        #expect(script.contains("'RA_LOG=error'"))
+        #expect(script.contains("exec env 'RA_LOG=error' 'rust-analyzer'")
+            || script.contains("'rust-analyzer'"))
+    }
+
+    @Test func invocationWithoutEnvHasNoEnvPrefix() {
+        let invocation = RemoteLSPLauncher.invocation(
+            host: "devbox",
+            rootPath: "/srv/repo",
+            command: "typescript-language-server",
+            args: ["--stdio"],
+            env: [:]
+        )
+
+        let script = invocation.args.last ?? ""
+        #expect(!script.contains(" env "))
+        #expect(script.contains("typescript-language-server"))
+        #expect(script.contains("--stdio"))
+        #expect(script.contains("exec "))
+    }
+
+    @Test func sourceKitProbeFallsBackToXcrun() {
+        #expect(RemoteLSPLauncher.availabilityProbeCommand(command: "sourcekit-lsp")
+            == "command -v 'sourcekit-lsp' >/dev/null 2>&1 || xcrun --find 'sourcekit-lsp' >/dev/null 2>&1")
+    }
+
+    @Test func availabilityProbeRunsWithConfiguredEnvironment() {
+        let command = RemoteLSPLauncher.availabilityProbeCommand(
+            command: "custom-lsp",
+            env: ["PATH": "/opt/lsp/bin:$PATH"]
+        )
+
+        #expect(command.contains("env 'PATH=/opt/lsp/bin:$PATH' sh -c"))
+        #expect(command.contains("command -v '\\''custom-lsp'\\''"))
+    }
+
+    @Test func sourceKitInvocationUsesResolvedRemotePath() {
+        let invocation = RemoteLSPLauncher.invocation(
+            host: "devbox",
+            rootPath: "/srv/repo",
+            command: "sourcekit-lsp",
+            args: [],
+            env: [:]
+        )
+
+        let script = invocation.args.last ?? ""
+        #expect(script.contains("xcrun --find"))
+        #expect(script.contains("sourcekit-lsp"))
+        #expect(script.contains("exec \"$resolved_lsp\""))
+    }
+
+    @Test func sourceKitResolutionUsesConfiguredEnvironment() {
+        let invocation = RemoteLSPLauncher.invocation(
+            host: "devbox",
+            rootPath: "/srv/repo",
+            command: "sourcekit-lsp",
+            args: [],
+            env: ["PATH": "/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin"]
+        )
+
+        let script = invocation.args.last ?? ""
+        #expect(script.contains("PATH=/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin"))
+        #expect(script.contains("sh -c"))
+        #expect(script.contains("xcrun --find"))
+        #expect(script.contains("exec env"))
+        #expect(script.contains("\"$resolved_lsp\""))
+    }
+}

--- a/AlasTests/SSH/RemoteLastActivityTests.swift
+++ b/AlasTests/SSH/RemoteLastActivityTests.swift
@@ -1,0 +1,13 @@
+import Foundation
+import Testing
+@testable import Alas
+
+struct RemoteLastActivityTests {
+    @Test func parsesEpochSeconds() {
+        #expect(WorktreeService.date(fromEpochOutput: "1752249600\n") == Date(timeIntervalSince1970: 1_752_249_600))
+    }
+    @Test func rejectsInvalidEpochs() {
+        #expect(WorktreeService.date(fromEpochOutput: "bad") == nil)
+        #expect(WorktreeService.date(fromEpochOutput: "") == nil)
+    }
+}

--- a/AlasTests/SSH/RemotePollCadenceTests.swift
+++ b/AlasTests/SSH/RemotePollCadenceTests.swift
@@ -1,0 +1,13 @@
+import Testing
+@testable import Alas
+
+struct RemotePollCadenceTests {
+    @Test func cadenceUsesActiveAndInactiveIntervals() {
+        #expect(RemotePollCadence.nextDelay(succeeded: true, appActive: true, previous: 300) == 5)
+        #expect(RemotePollCadence.nextDelay(succeeded: true, appActive: false, previous: 5) == 45)
+    }
+    @Test func failuresBackOffAndCap() {
+        #expect(RemotePollCadence.nextDelay(succeeded: false, appActive: true, previous: 5) == 10)
+        #expect(RemotePollCadence.nextDelay(succeeded: false, appActive: true, previous: 200) == 300)
+    }
+}

--- a/AlasTests/SSH/RemoteProjectCollisionTests.swift
+++ b/AlasTests/SSH/RemoteProjectCollisionTests.swift
@@ -31,6 +31,40 @@ struct RemoteProjectCollisionTests {
         }
     }
 
+    @Test func localRootEqualToRemoteWorktreeRootIsRejected() {
+        let existing = project(path: "/srv/repo", host: "devbox")
+        #expect(throws: (any Error).self) {
+            try ProjectsManager.ensureNoPathCollision(
+                newRoot: "/srv/linked",
+                newHost: nil,
+                existing: [existing],
+                existingWorktreeRootsByProject: [existing.id: ["/srv/linked"]]
+            )
+        }
+    }
+
+    @Test func differentHostRootNestedInRemoteWorktreeRootIsRejected() {
+        let existing = project(path: "/srv/repo", host: "devbox")
+        #expect(throws: (any Error).self) {
+            try ProjectsManager.ensureNoPathCollision(
+                newRoot: "/srv/linked/sub",
+                newHost: "otherbox",
+                existing: [existing],
+                existingWorktreeRootsByProject: [existing.id: ["/srv/linked"]]
+            )
+        }
+    }
+
+    @Test func sameHostRootMayOverlapRemoteWorktreeRoot() throws {
+        let existing = project(path: "/srv/repo", host: "devbox")
+        try ProjectsManager.ensureNoPathCollision(
+            newRoot: "/srv/linked/sub",
+            newHost: "devbox",
+            existing: [existing],
+            existingWorktreeRootsByProject: [existing.id: ["/srv/linked"]]
+        )
+    }
+
     @Test func disjointRootsAreAccepted() throws {
         let existing = [project(path: "/srv/repo", host: "devbox")]
         try ProjectsManager.ensureNoPathCollision(newRoot: "/srv/other", newHost: nil, existing: existing)

--- a/AlasTests/SSH/RemoteProjectCollisionTests.swift
+++ b/AlasTests/SSH/RemoteProjectCollisionTests.swift
@@ -1,0 +1,43 @@
+import Foundation
+import Testing
+@testable import Alas
+
+struct RemoteProjectCollisionTests {
+    private func project(path: String, host: String?) -> ProjectConfig {
+        ProjectConfig(id: UUID().uuidString, name: "p", path: path, color: "blue", addedAt: Date(timeIntervalSince1970: 0), host: host)
+    }
+
+    @Test func remoteRootEqualToLocalRootIsRejected() {
+        #expect(throws: (any Error).self) {
+            try ProjectsManager.ensureNoPathCollision(newRoot: "/srv/repo", newHost: "devbox", existing: [project(path: "/srv/repo", host: nil)])
+        }
+    }
+
+    @Test func remoteRootNestedInLocalRootIsRejected() {
+        #expect(throws: (any Error).self) {
+            try ProjectsManager.ensureNoPathCollision(newRoot: "/srv/repo/sub", newHost: "devbox", existing: [project(path: "/srv/repo", host: nil)])
+        }
+    }
+
+    @Test func localRootNestedInRemoteRootIsRejected() {
+        #expect(throws: (any Error).self) {
+            try ProjectsManager.ensureNoPathCollision(newRoot: "/srv/repo/sub", newHost: nil, existing: [project(path: "/srv/repo", host: "devbox")])
+        }
+    }
+
+    @Test func sameRootOnDifferentHostsIsRejected() {
+        #expect(throws: (any Error).self) {
+            try ProjectsManager.ensureNoPathCollision(newRoot: "/srv/repo", newHost: "otherbox", existing: [project(path: "/srv/repo", host: "devbox")])
+        }
+    }
+
+    @Test func disjointRootsAreAccepted() throws {
+        let existing = [project(path: "/srv/repo", host: "devbox")]
+        try ProjectsManager.ensureNoPathCollision(newRoot: "/srv/other", newHost: nil, existing: existing)
+        try ProjectsManager.ensureNoPathCollision(newRoot: "/srv/repo-two", newHost: "devbox", existing: existing)
+    }
+
+    @Test func twoLocalProjectsMayNest() throws {
+        try ProjectsManager.ensureNoPathCollision(newRoot: "/srv/repo/sub", newHost: nil, existing: [project(path: "/srv/repo", host: nil)])
+    }
+}

--- a/AlasTests/SSH/RemoteRepoValidatorTests.swift
+++ b/AlasTests/SSH/RemoteRepoValidatorTests.swift
@@ -1,0 +1,76 @@
+import Foundation
+import Testing
+@testable import Alas
+
+struct RemoteRepoValidatorTests {
+    @Test func validateRunsInteractivePreflightBeforeBatchRepoCheck() async throws {
+        let recorder = RemoteRepoValidatorRunner(results: [
+            ProcessResult(exitCode: 0, stdout: "", stderr: ""),
+            ProcessResult(exitCode: 0, stdout: "true\n", stderr: ""),
+        ])
+
+        try await RemoteRepoValidator.validate(
+            host: "devbox",
+            path: "/srv/repo",
+            runner: { executable, args, timeout in
+                await recorder.run(executable: executable, args: args, timeout: timeout)
+            }
+        )
+
+        let calls = await recorder.calls
+        #expect(calls.count == 2)
+        #expect(calls[0].timeout == 30)
+        #expect(!calls[0].args.contains("BatchMode=yes"))
+        #expect(calls[0].args.contains("ConnectTimeout=30"))
+        #expect(calls[0].args.last?.contains("true") == true)
+        #expect(calls[1].timeout == 30)
+        #expect(calls[1].args.contains("BatchMode=yes"))
+        #expect(calls[1].args.last?.contains("git -C") == true)
+    }
+
+    @Test func preflightFailureTellsUserToConnectFirst() async throws {
+        let recorder = RemoteRepoValidatorRunner(results: [
+            ProcessResult(exitCode: 255, stdout: "", stderr: "Host key verification failed."),
+        ])
+
+        do {
+            try await RemoteRepoValidator.validate(
+                host: "devbox",
+                path: "/srv/repo",
+                runner: { executable, args, timeout in
+                    await recorder.run(executable: executable, args: args, timeout: timeout)
+                }
+            )
+            Issue.record("Expected validation to fail")
+        } catch let error as RemoteRepoValidationError {
+            guard case let .unreachable(message) = error else {
+                Issue.record("Expected unreachable error")
+                return
+            }
+            #expect(message.contains("Run `/usr/bin/ssh"))
+            #expect(message.contains("ControlMaster=auto"))
+            #expect(message.contains("devbox"))
+            #expect(message.contains("Host key verification failed."))
+        }
+    }
+}
+
+private actor RemoteRepoValidatorRunner {
+    struct Call {
+        let executable: String
+        let args: [String]
+        let timeout: TimeInterval
+    }
+
+    private(set) var calls: [Call] = []
+    private var results: [ProcessResult]
+
+    init(results: [ProcessResult]) {
+        self.results = results
+    }
+
+    func run(executable: String, args: [String], timeout: TimeInterval) -> ProcessResult {
+        calls.append(Call(executable: executable, args: args, timeout: timeout))
+        return results.isEmpty ? ProcessResult(exitCode: 1, stdout: "", stderr: "") : results.removeFirst()
+    }
+}

--- a/AlasTests/SSH/RemoteStatusFingerprintTests.swift
+++ b/AlasTests/SSH/RemoteStatusFingerprintTests.swift
@@ -2,13 +2,37 @@ import Testing
 @testable import Alas
 
 struct RemoteStatusFingerprintTests {
-    @Test func firstObservationDoesNotRefresh() {
+    @Test func firstObservationRefreshes() {
         let value = RemoteStatusFingerprint.make(status: "s", head: "h")
-        #expect(!RemoteStatusFingerprint.shouldRefresh(previous: nil, current: value))
+        #expect(RemoteStatusFingerprint.shouldRefresh(previous: nil, current: value))
     }
     @Test func changesRefresh() {
         let first = RemoteStatusFingerprint.make(status: "s", head: "h")
         #expect(!RemoteStatusFingerprint.shouldRefresh(previous: first, current: first))
         #expect(RemoteStatusFingerprint.shouldRefresh(previous: first, current: RemoteStatusFingerprint.make(status: "s2", head: "h")))
+        #expect(RemoteStatusFingerprint.shouldRefresh(previous: first, current: RemoteStatusFingerprint.make(
+            status: "s",
+            head: "h",
+            unstagedDiff: "diff"
+        )))
+        #expect(RemoteStatusFingerprint.shouldRefresh(previous: first, current: RemoteStatusFingerprint.make(
+            status: "s",
+            head: "h",
+            stagedDiff: "cached"
+        )))
+        #expect(RemoteStatusFingerprint.shouldRefresh(previous: first, current: RemoteStatusFingerprint.make(
+            status: "s",
+            head: "h",
+            untrackedContent: "blob"
+        )))
+    }
+
+    @Test func remoteUntrackedContentCommandAvoidsShellNulReadExtensions() {
+        let command = RightPaneState.remoteUntrackedContentFingerprintCommand
+        #expect(command.contains("git ls-files --others --exclude-standard -z"))
+        #expect(command.contains("xargs -0 sh -c"))
+        #expect(command.contains("[ \"$#\" -gt 0 ] || exit 0"))
+        #expect(command.contains("git hash-object -- \"$@\""))
+        #expect(!command.contains("read -d"))
     }
 }

--- a/AlasTests/SSH/RemoteStatusFingerprintTests.swift
+++ b/AlasTests/SSH/RemoteStatusFingerprintTests.swift
@@ -1,0 +1,14 @@
+import Testing
+@testable import Alas
+
+struct RemoteStatusFingerprintTests {
+    @Test func firstObservationDoesNotRefresh() {
+        let value = RemoteStatusFingerprint.make(status: "s", head: "h")
+        #expect(!RemoteStatusFingerprint.shouldRefresh(previous: nil, current: value))
+    }
+    @Test func changesRefresh() {
+        let first = RemoteStatusFingerprint.make(status: "s", head: "h")
+        #expect(!RemoteStatusFingerprint.shouldRefresh(previous: first, current: first))
+        #expect(RemoteStatusFingerprint.shouldRefresh(previous: first, current: RemoteStatusFingerprint.make(status: "s2", head: "h")))
+    }
+}

--- a/AlasTests/SSH/RemoteTerminalLaunchTests.swift
+++ b/AlasTests/SSH/RemoteTerminalLaunchTests.swift
@@ -1,0 +1,89 @@
+import Foundation
+import Testing
+@testable import Alas
+
+struct RemoteTerminalLaunchTests {
+    @Test func remoteLaunchBuildsInteractiveSSHSurface() {
+        let launch = TerminalService.remoteLaunch(
+            host: "devbox",
+            worktreePath: "/srv/repo",
+            zmxSessionName: "alas-aaaa-bbbb",
+            keepAlive: true,
+            startupSuffix: nil
+        )
+        #expect(launch.executable == "/usr/bin/ssh")
+        #expect(launch.args.first == "-tt")
+        #expect((launch.args.last ?? "").contains("alas-aaaa-bbbb"))
+    }
+
+    @Test func keepAliveOffSkipsZmx() {
+        let launch = TerminalService.remoteLaunch(
+            host: "devbox",
+            worktreePath: "/srv/repo",
+            zmxSessionName: "alas-aaaa-bbbb",
+            keepAlive: false,
+            startupSuffix: nil
+        )
+        #expect(!(launch.args.last ?? "").contains("zmx"))
+    }
+
+    @Test func agentSuffixRidesInsideScript() {
+        let launch = TerminalService.remoteLaunch(
+            host: "devbox",
+            worktreePath: "/srv/repo",
+            zmxSessionName: "alas-aaaa-bbbb",
+            keepAlive: true,
+            startupSuffix: "claude"
+        )
+        #expect((launch.args.last ?? "").contains("claude"))
+    }
+
+    @Test func launchScriptUsesProvidedRemoteCwd() {
+        let launch = TerminalService.remoteLaunch(
+            host: "devbox",
+            worktreePath: "/srv/repo/subdir",
+            zmxSessionName: "alas-aaaa-bbbb",
+            keepAlive: true,
+            startupSuffix: nil
+        )
+
+        #expect((launch.args.last ?? "").contains("cd '\\''/srv/repo/subdir'\\'' || exit"))
+    }
+
+    @Test func remoteLaunchPreservesConfiguredStartupScript() {
+        var terminal = AppConfig.defaults.terminal
+        terminal.startupScript = "echo global"
+        let project = ProjectConfig(
+            id: "p1",
+            name: "Remote",
+            path: "/srv/repo",
+            color: "#5fb7c4",
+            addedAt: Date(timeIntervalSince1970: 0),
+            startupScripts: ProjectStartupScripts(
+                sessionOpenMode: .appendToGlobal,
+                sessionOpenScript: "echo project",
+                worktreeCreateMode: .useGlobal,
+                worktreeCreateScript: ""
+            ),
+            host: "devbox"
+        )
+        let startupScript = TerminalService.effectiveStartupScript(
+            global: terminal,
+            project: project,
+            includeUserStartupScript: true,
+            startupScriptSuffix: "claude --continue"
+        )
+        let launch = TerminalService.remoteLaunch(
+            host: "devbox",
+            worktreePath: "/srv/repo",
+            zmxSessionName: "alas-aaaa-bbbb",
+            keepAlive: true,
+            startupSuffix: startupScript
+        )
+        let remoteScript = launch.args.last ?? ""
+
+        #expect(remoteScript.contains("echo global"))
+        #expect(remoteScript.contains("echo project"))
+        #expect(remoteScript.contains("claude --continue"))
+    }
+}

--- a/AlasTests/SSH/RemoteTerminalScriptTests.swift
+++ b/AlasTests/SSH/RemoteTerminalScriptTests.swift
@@ -1,0 +1,51 @@
+import Testing
+@testable import Alas
+
+struct RemoteTerminalScriptTests {
+    @Test func attachScriptResolvesZmxLadderAndAttaches() {
+        let script = RemoteTerminalScript.attachScript(
+            worktreePath: "/srv/repo", sessionName: "alas-aaaa-bbbb",
+            useZmx: true, startupSuffix: nil
+        )
+        #expect(script.hasPrefix("cd -- '/srv/repo' && "))
+        #expect(script.contains("export ZMX_DIR=\"$HOME/.alas/zmx\""))
+        #expect(script.contains("Z=\"$(command -v zmx 2>/dev/null || true)\""))
+        #expect(script.contains("[ -x \"$HOME/.alas/bin/zmx\" ] && Z=\"$HOME/.alas/bin/zmx\""))
+        #expect(script.contains("exec \"$Z\" attach 'alas-aaaa-bbbb' \"$SHELL\" -l"))
+        #expect(script.contains("exec \"$SHELL\" -l"))
+    }
+
+    @Test func attachScriptWithoutZmxIsPlainLoginShell() {
+        let script = RemoteTerminalScript.attachScript(
+            worktreePath: "/srv/repo", sessionName: "alas-aaaa-bbbb",
+            useZmx: false, startupSuffix: nil
+        )
+        #expect(!script.contains("zmx"))
+        #expect(script.contains("exec \"$SHELL\" -l"))
+    }
+
+    @Test func startupSuffixRunsThenDropsToInteractiveShell() {
+        let script = RemoteTerminalScript.attachScript(
+            worktreePath: "/srv/repo", sessionName: "alas-aaaa-bbbb",
+            useZmx: true, startupSuffix: "claude --continue"
+        )
+        #expect(script.contains("-c 'claude --continue; exec \"$SHELL\" -l'"))
+    }
+
+    @Test func surfaceInvocationIsInteractiveWithForcedTTY() {
+        let invocation = RemoteTerminalScript.surfaceInvocation(host: "devbox", script: "true")
+        #expect(invocation.executable == "/usr/bin/ssh")
+        #expect(invocation.args.first == "-tt")
+        #expect(!invocation.args.contains("BatchMode=yes"))
+        #expect(invocation.args.contains("ConnectTimeout=30"))
+        #expect(invocation.args.dropLast().last == "devbox")
+        #expect(invocation.args.last == "exec \"$SHELL\" -l -c 'true'")
+    }
+
+    @Test func zmxBatchCommandSharesDirAndLadder() {
+        let command = RemoteTerminalScript.zmxBatchCommand(["ls", "--short"])
+        #expect(command.contains("export ZMX_DIR=\"$HOME/.alas/zmx\""))
+        #expect(command.contains("\"$Z\" 'ls' '--short'"))
+        #expect(command.contains("command -v zmx"))
+    }
+}

--- a/AlasTests/SSH/RemoteTerminalScriptTests.swift
+++ b/AlasTests/SSH/RemoteTerminalScriptTests.swift
@@ -7,7 +7,7 @@ struct RemoteTerminalScriptTests {
             worktreePath: "/srv/repo", sessionName: "alas-aaaa-bbbb",
             useZmx: true, startupSuffix: nil
         )
-        #expect(script.hasPrefix("cd -- '/srv/repo' && "))
+        #expect(script.hasPrefix("cd '/srv/repo' || exit; "))
         #expect(script.contains("export ZMX_DIR=\"$HOME/.alas/zmx\""))
         #expect(script.contains("Z=\"$(command -v zmx 2>/dev/null || true)\""))
         #expect(script.contains("[ -x \"$HOME/.alas/bin/zmx\" ] && Z=\"$HOME/.alas/bin/zmx\""))
@@ -39,7 +39,7 @@ struct RemoteTerminalScriptTests {
         #expect(!invocation.args.contains("BatchMode=yes"))
         #expect(invocation.args.contains("ConnectTimeout=30"))
         #expect(invocation.args.dropLast().last == "devbox")
-        #expect(invocation.args.last == "exec \"$SHELL\" -l -c 'true'")
+        #expect(invocation.args.last == SSHCommand.remoteScript(command: "true"))
     }
 
     @Test func zmxBatchCommandSharesDirAndLadder() {

--- a/AlasTests/SSH/RemoteWorktreePollTests.swift
+++ b/AlasTests/SSH/RemoteWorktreePollTests.swift
@@ -1,0 +1,78 @@
+import Testing
+@testable import Alas
+
+struct RemoteWorktreePollTests {
+    private let porcelain = """
+    worktree /srv/repo
+    HEAD 1111111111111111111111111111111111111111
+    branch refs/heads/main
+
+    worktree /srv/wt/feature
+    HEAD 2222222222222222222222222222222222222222
+    branch refs/heads/feature-x
+
+    worktree /srv/wt/detached
+    HEAD 3333333333333333333333333333333333333333
+    detached
+    """
+
+    @Test func parsesEntriesWithBranchAndDetached() {
+        let entries = RemoteWorktreePoll.parse(porcelain: porcelain)
+        #expect(entries.count == 3)
+        #expect(entries[0] == RemoteWorktreePollEntry(
+            path: "/srv/repo",
+            head: "1111111111111111111111111111111111111111",
+            branch: "refs/heads/main"
+        ))
+        #expect(entries[2].branch == nil)
+    }
+
+    @Test func parseIgnoresBareAndUnknownLines() {
+        let entries = RemoteWorktreePoll.parse(porcelain: "worktree /srv/bare\nbare\n")
+        #expect(entries.count == 1)
+        #expect(entries[0].head == "")
+    }
+
+    @Test func identicalSnapshotsClassifyAsNil() {
+        let entries = RemoteWorktreePoll.parse(porcelain: porcelain)
+        #expect(RemoteWorktreePoll.classify(old: entries, new: entries) == nil)
+    }
+
+    @Test func branchSwitchYieldsLabelUpdateWithoutTopology() {
+        let old = RemoteWorktreePoll.parse(porcelain: porcelain)
+        var new = old
+        new[1] = RemoteWorktreePollEntry(path: new[1].path, head: new[1].head, branch: "refs/heads/other")
+        let delta = RemoteWorktreePoll.classify(old: old, new: new)
+        #expect(delta == RemoteWorktreePollDelta(
+            branchLabelsByPath: ["/srv/wt/feature": "other"],
+            topologyChanged: false
+        ))
+    }
+
+    @Test func detachedYieldsDetachedLabel() {
+        let old = RemoteWorktreePoll.parse(porcelain: porcelain)
+        var new = old
+        new[0] = RemoteWorktreePollEntry(path: new[0].path, head: new[0].head, branch: nil)
+        let delta = RemoteWorktreePoll.classify(old: old, new: new)
+        #expect(delta?.branchLabelsByPath["/srv/repo"] == "(detached)")
+    }
+
+    @Test func newCommitYieldsTopologyChange() {
+        let old = RemoteWorktreePoll.parse(porcelain: porcelain)
+        var new = old
+        new[0] = RemoteWorktreePollEntry(
+            path: new[0].path,
+            head: "9999999999999999999999999999999999999999",
+            branch: new[0].branch
+        )
+        let delta = RemoteWorktreePoll.classify(old: old, new: new)
+        #expect(delta == RemoteWorktreePollDelta(branchLabelsByPath: [:], topologyChanged: true))
+    }
+
+    @Test func addedOrRemovedWorktreeYieldsTopologyChange() {
+        let old = RemoteWorktreePoll.parse(porcelain: porcelain)
+        let new = Array(old.dropLast())
+        let delta = RemoteWorktreePoll.classify(old: old, new: new)
+        #expect(delta?.topologyChanged == true)
+    }
+}

--- a/AlasTests/SSH/RemoteZmxInstallerTests.swift
+++ b/AlasTests/SSH/RemoteZmxInstallerTests.swift
@@ -1,0 +1,45 @@
+import Foundation
+import Testing
+@testable import Alas
+
+struct RemoteZmxInstallerTests {
+    private let resources = URL(fileURLWithPath: "/App/Resources")
+
+    @Test func picksLinuxBinariesByArch() {
+        #expect(RemoteZmxInstaller.bundledBinaryPath(
+            os: .linux, arch: "x86_64", resourceURL: resources
+        )?.path == "/App/Resources/zmx/linux-x86_64/zmx")
+        #expect(RemoteZmxInstaller.bundledBinaryPath(
+            os: .linux, arch: "aarch64", resourceURL: resources
+        )?.path == "/App/Resources/zmx/linux-aarch64/zmx")
+    }
+
+    @Test func unsupportedTargetsYieldNil() {
+        #expect(RemoteZmxInstaller.bundledBinaryPath(
+            os: .linux, arch: nil, resourceURL: resources
+        ) == nil)
+        #expect(RemoteZmxInstaller.bundledBinaryPath(
+            os: .other, arch: "x86_64", resourceURL: resources
+        ) == nil)
+    }
+
+    @Test func macRemoteRequiresMatchingLocalArch() {
+        let other = RemoteZmxInstaller.localArch == "aarch64" ? "x86_64" : "aarch64"
+        #expect(RemoteZmxInstaller.bundledBinaryPath(
+            os: .macos, arch: other, resourceURL: resources
+        ) == nil)
+        #expect(RemoteZmxInstaller.bundledBinaryPath(
+            os: .macos, arch: RemoteZmxInstaller.localArch, resourceURL: resources
+        )?.path == "/App/Resources/zmx/zmx")
+    }
+
+    @Test func scpArgvUsesBatchOptionsAndQuietMode() {
+        let args = SSHCommand.scpArgv(
+            localPath: "/tmp/zmx", host: "devbox", remotePath: ".alas/bin/zmx.tmp"
+        )
+        #expect(args.contains("BatchMode=yes"))
+        #expect(args.contains("ControlMaster=auto"))
+        #expect(args.contains("-q"))
+        #expect(Array(args.suffix(2)) == ["/tmp/zmx", "devbox:.alas/bin/zmx.tmp"])
+    }
+}

--- a/AlasTests/SSH/SSHCommandTests.swift
+++ b/AlasTests/SSH/SSHCommandTests.swift
@@ -14,19 +14,26 @@ struct SSHCommandTests {
         #expect(SSHCommand.shellQuote("") == "''")
     }
 
-    @Test func remoteScriptChangesDirectoryThenExecsLoginShell() {
+    @Test func remoteScriptChangesDirectoryInsidePOSIXShell() {
         let script = SSHCommand.remoteScript(cwd: "/srv/repo", command: "git status")
-        #expect(script == "cd -- '/srv/repo' && exec \"$SHELL\" -l -c 'git status'")
+        #expect(script == "/bin/sh -c 'PATH=\"$HOME/.alas/bin:$HOME/.local/bin:$HOME/bin:/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:$PATH\"; export PATH; cd '\\''/srv/repo'\\'' && git status'")
     }
 
     @Test func remoteScriptQuotesCwdWithSpaces() {
         let script = SSHCommand.remoteScript(cwd: "/srv/my repo", command: "git status")
-        #expect(script.hasPrefix("cd -- '/srv/my repo' && "))
+        #expect(script.contains("cd '\\''/srv/my repo'\\'' && git status"))
     }
 
     @Test func remoteScriptWithoutCwdOmitsCd() {
         let script = SSHCommand.remoteScript(command: "git --version")
-        #expect(script == "exec \"$SHELL\" -l -c 'git --version'")
+        #expect(script == "/bin/sh -c 'PATH=\"$HOME/.alas/bin:$HOME/.local/bin:$HOME/bin:/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:$PATH\"; export PATH; git --version'")
+    }
+
+    @Test func remoteScriptTopLevelIsSafeForNonPOSIXLoginShells() {
+        let script = SSHCommand.remoteScript(command: "f='x'; [ -e \"$f\" ]")
+        #expect(script.hasPrefix("/bin/sh -c "))
+        #expect(!script.hasPrefix("PATH="))
+        #expect(!script.contains("\"$SHELL\" -l -c"))
     }
 
     @Test func batchModeArgvFailsFastAndNeverPrompts() {

--- a/AlasTests/SSH/SSHCommandTests.swift
+++ b/AlasTests/SSH/SSHCommandTests.swift
@@ -1,0 +1,55 @@
+import Testing
+@testable import Alas
+
+struct SSHCommandTests {
+    @Test func shellQuoteWrapsPlainString() {
+        #expect(SSHCommand.shellQuote("git status") == "'git status'")
+    }
+
+    @Test func shellQuoteEscapesEmbeddedSingleQuote() {
+        #expect(SSHCommand.shellQuote("it's") == "'it'\\''s'")
+    }
+
+    @Test func shellQuoteEmptyString() {
+        #expect(SSHCommand.shellQuote("") == "''")
+    }
+
+    @Test func remoteScriptChangesDirectoryThenExecsLoginShell() {
+        let script = SSHCommand.remoteScript(cwd: "/srv/repo", command: "git status")
+        #expect(script == "cd -- '/srv/repo' && exec \"$SHELL\" -l -c 'git status'")
+    }
+
+    @Test func remoteScriptQuotesCwdWithSpaces() {
+        let script = SSHCommand.remoteScript(cwd: "/srv/my repo", command: "git status")
+        #expect(script.hasPrefix("cd -- '/srv/my repo' && "))
+    }
+
+    @Test func remoteScriptWithoutCwdOmitsCd() {
+        let script = SSHCommand.remoteScript(command: "git --version")
+        #expect(script == "exec \"$SHELL\" -l -c 'git --version'")
+    }
+
+    @Test func batchModeArgvFailsFastAndNeverPrompts() {
+        let argv = SSHCommand(host: "devbox", mode: .batch).argv(remoteScript: "true")
+        #expect(argv.contains("BatchMode=yes"))
+        #expect(argv.contains("ConnectTimeout=10"))
+        #expect(Array(argv.suffix(2)) == ["devbox", "true"])
+    }
+
+    @Test func interactiveArgvAllowsPrompts() {
+        let argv = SSHCommand(host: "devbox", mode: .interactive).argv(remoteScript: "true")
+        #expect(!argv.contains("BatchMode=yes"))
+        #expect(argv.contains("ConnectTimeout=30"))
+    }
+
+    @Test func everyInvocationMultiplexesAndDetectsDeadPeers() {
+        for mode in [SSHCommand.Mode.batch, .interactive] {
+            let argv = SSHCommand(host: "devbox", mode: mode).argv(remoteScript: "true")
+            #expect(argv.contains("ControlMaster=auto"))
+            #expect(argv.contains("ControlPath=~/.ssh/alas-%C"))
+            #expect(argv.contains("ControlPersist=10m"))
+            #expect(argv.contains("ServerAliveInterval=5"))
+            #expect(argv.contains("ServerAliveCountMax=3"))
+        }
+    }
+}

--- a/AlasTests/SSH/SSHIntegrationTests.swift
+++ b/AlasTests/SSH/SSHIntegrationTests.swift
@@ -1,0 +1,44 @@
+import Foundation
+import Testing
+@testable import Alas
+
+/// Enable with ALAS_SSH_INTEGRATION=1 and key-authenticated ssh localhost.
+struct SSHIntegrationTests {
+    private var enabled: Bool {
+        ProcessInfo.processInfo.environment["ALAS_SSH_INTEGRATION"] == "1"
+    }
+
+    @Test func remoteGitStatusOverSSHLocalhost() async throws {
+        try #require(enabled, "set ALAS_SSH_INTEGRATION=1 to run")
+
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("alas-ssh-itest-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        defer {
+            RemoteHostRegistry.shared.unregister(root: directory.path)
+            try? FileManager.default.removeItem(at: directory)
+        }
+
+        _ = try await Process.run("/usr/bin/env", args: ["git", "init"], cwd: directory)
+        RemoteHostRegistry.shared.register(root: directory.path, host: "localhost")
+        let status = try await Process.git(["status", "--porcelain=v2"], cwd: directory)
+        #expect(status.exitCode == 0)
+        let repository = try await Process.git(["rev-parse", "--is-inside-work-tree"], cwd: directory)
+        #expect(repository.stdout.trimmingCharacters(in: .whitespacesAndNewlines) == "true")
+    }
+
+    @Test func remoteValidatorAcceptsAndRejects() async throws {
+        try #require(enabled, "set ALAS_SSH_INTEGRATION=1 to run")
+
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("alas-ssh-itest-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: directory) }
+        _ = try await Process.run("/usr/bin/env", args: ["git", "init"], cwd: directory)
+
+        try await RemoteRepoValidator.validate(host: "localhost", path: directory.path)
+        await #expect(throws: RemoteRepoValidationError.self) {
+            try await RemoteRepoValidator.validate(host: "localhost", path: "/nonexistent-alas")
+        }
+    }
+}

--- a/AlasTests/SSH/SSHIntegrationTests.swift
+++ b/AlasTests/SSH/SSHIntegrationTests.swift
@@ -51,4 +51,27 @@ struct SSHIntegrationTests {
         #expect(capabilities?.os == .macos)
         #expect(capabilities?.gitVersion != nil)
     }
+
+    @Test func remoteFileAccessRoundTripAndConflictGate() async throws {
+        try #require(enabled, "set ALAS_SSH_INTEGRATION=1 to run")
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("alas-ssh-file-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let file = directory.appendingPathComponent("run.sh")
+        try Data("one\n".utf8).write(to: file)
+        try FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: file.path)
+
+        let initial = try await RemoteFileAccess.read(host: "localhost", path: file.path)
+        guard case let .file(data, mtime) = initial else { Issue.record("expected readable file"); return }
+        #expect(String(data: data, encoding: .utf8) == "one\n")
+        #expect(RemoteSaveGate.decision(originalMtime: mtime, remoteMtime: mtime) == .proceed)
+        _ = try await RemoteFileAccess.write(host: "localhost", path: file.path, content: "two\n")
+        let updated = try await RemoteFileAccess.read(host: "localhost", path: file.path)
+        guard case let .file(updatedData, updatedMtime) = updated else { Issue.record("expected updated file"); return }
+        #expect(String(data: updatedData, encoding: .utf8) == "two\n")
+        #expect(RemoteSaveGate.decision(originalMtime: mtime, remoteMtime: updatedMtime) == .conflict)
+        let mode = try FileManager.default.attributesOfItem(atPath: file.path)[.posixPermissions] as? NSNumber
+        #expect(mode?.intValue == 0o755)
+    }
 }

--- a/AlasTests/SSH/SSHIntegrationTests.swift
+++ b/AlasTests/SSH/SSHIntegrationTests.swift
@@ -41,4 +41,14 @@ struct SSHIntegrationTests {
             try await RemoteRepoValidator.validate(host: "localhost", path: "/nonexistent-alas")
         }
     }
+
+    @Test func remoteExecAndCapabilitiesAgainstLocalhost() async throws {
+        try #require(enabled, "set ALAS_SSH_INTEGRATION=1 to run")
+        let echo = try await RemoteExec.run(host: "localhost", cwd: nil, command: "echo alas-ok")
+        #expect(echo.exitCode == 0)
+        #expect(echo.stdout.contains("alas-ok"))
+        let capabilities = await RemoteHostCapabilityStore.shared.capabilities(for: "localhost")
+        #expect(capabilities?.os == .macos)
+        #expect(capabilities?.gitVersion != nil)
+    }
 }

--- a/AlasTests/SSH/SSHIntegrationTests.swift
+++ b/AlasTests/SSH/SSHIntegrationTests.swift
@@ -63,12 +63,18 @@ struct SSHIntegrationTests {
         try FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: file.path)
 
         let initial = try await RemoteFileAccess.read(host: "localhost", path: file.path)
-        guard case let .file(data, mtime) = initial else { Issue.record("expected readable file"); return }
+        guard case let .file(data, mtime) = initial else {
+            Issue.record("expected readable file")
+            return
+        }
         #expect(String(data: data, encoding: .utf8) == "one\n")
         #expect(RemoteSaveGate.decision(originalMtime: mtime, remoteMtime: mtime) == .proceed)
         _ = try await RemoteFileAccess.write(host: "localhost", path: file.path, content: "two\n")
         let updated = try await RemoteFileAccess.read(host: "localhost", path: file.path)
-        guard case let .file(updatedData, updatedMtime) = updated else { Issue.record("expected updated file"); return }
+        guard case let .file(updatedData, updatedMtime) = updated else {
+            Issue.record("expected updated file")
+            return
+        }
         #expect(String(data: updatedData, encoding: .utf8) == "two\n")
         #expect(RemoteSaveGate.decision(originalMtime: mtime, remoteMtime: updatedMtime) == .conflict)
         let mode = try FileManager.default.attributesOfItem(atPath: file.path)[.posixPermissions] as? NSNumber
@@ -102,5 +108,74 @@ struct SSHIntegrationTests {
         )
         #expect(result.exitCode == 0)
         #expect(result.stdout.contains("/tmp"))
+    }
+
+    @Test func remoteMoveAndTTYCleanupAgainstLocalhost() async throws {
+        try #require(enabled, "set ALAS_SSH_INTEGRATION=1 to run")
+
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("alas-ssh-p6-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: directory) }
+
+        let from = directory.appendingPathComponent("a.txt").path
+        _ = try await RemoteFileAccess.write(host: "localhost", path: from, content: "x\n")
+        let to = directory.appendingPathComponent("nested/dir/b.txt").path
+        let move = try await RemoteExec.run(
+            host: "localhost",
+            cwd: nil,
+            command: RemoteFileOps.moveCommand(from: from, to: to),
+            timeout: 15
+        )
+        #expect(move.exitCode == 0)
+        #expect(FileManager.default.fileExists(atPath: to))
+        #expect(!FileManager.default.fileExists(atPath: from))
+
+        let marker = "alas-hup-probe-\(UUID().uuidString.prefix(8))"
+        let ssh = SSHCommand(host: "localhost", mode: .batch)
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: SSHCommand.executable)
+        process.arguments = ["-tt"] + ssh.argv(remoteScript: SSHCommand.remoteScript(
+            command: "sleep 300; : \(marker)"
+        ))
+        try process.run()
+        try await Task.sleep(nanoseconds: 1_500_000_000)
+        process.terminate()
+        try await Task.sleep(nanoseconds: 1_500_000_000)
+        let survivors = try await Process.run(
+            "/usr/bin/env", args: ["pgrep", "-f", marker], timeout: 10
+        )
+        #expect(survivors.exitCode != 0)
+    }
+
+    @Test func remoteDiscardRemovesUntrackedFilesAgainstLocalhost() async throws {
+        try #require(enabled, "set ALAS_SSH_INTEGRATION=1 to run")
+
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("alas-ssh-discard-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        defer {
+            RemoteHostRegistry.shared.unregister(root: directory.path)
+            try? FileManager.default.removeItem(at: directory)
+        }
+
+        _ = try await Process.run("/usr/bin/env", args: ["git", "init", "-q", "-b", "main"], cwd: directory)
+        _ = try await Process.run("/usr/bin/env", args: ["git", "config", "user.email", "t@e"], cwd: directory)
+        _ = try await Process.run("/usr/bin/env", args: ["git", "config", "user.name", "t"], cwd: directory)
+        try Data("seed\n".utf8).write(to: directory.appendingPathComponent("seed.txt"))
+        _ = try await Process.run("/usr/bin/env", args: ["git", "add", "seed.txt"], cwd: directory)
+        _ = try await Process.run("/usr/bin/env", args: ["git", "commit", "-q", "-m", "seed"], cwd: directory)
+        try Data("remote\n".utf8).write(to: directory.appendingPathComponent("untracked.txt"))
+        RemoteHostRegistry.shared.register(root: directory.path, host: "localhost")
+
+        try await GitService().discardPaths(worktreePath: directory, files: ["untracked.txt"])
+
+        let exists = try await RemoteExec.run(
+            host: "localhost",
+            cwd: nil,
+            command: "[ -e \(SSHCommand.shellQuote(directory.appendingPathComponent("untracked.txt").path)) ]",
+            timeout: 10
+        )
+        #expect(exists.exitCode != 0)
     }
 }

--- a/AlasTests/SSH/SSHIntegrationTests.swift
+++ b/AlasTests/SSH/SSHIntegrationTests.swift
@@ -74,4 +74,33 @@ struct SSHIntegrationTests {
         let mode = try FileManager.default.attributesOfItem(atPath: file.path)[.posixPermissions] as? NSNumber
         #expect(mode?.intValue == 0o755)
     }
+
+    @Test func remoteZmxBatchLadderDegradesGracefully() async throws {
+        try #require(enabled, "set ALAS_SSH_INTEGRATION=1 to run")
+        let result = try await RemoteExec.run(
+            host: "localhost",
+            cwd: nil,
+            command: RemoteTerminalScript.zmxBatchCommand(["ls", "--short"]),
+            timeout: 10
+        )
+        #expect(result.exitCode == 0)
+    }
+
+    @Test func attachScriptRunsPlainShellOverSSH() async throws {
+        try #require(enabled, "set ALAS_SSH_INTEGRATION=1 to run")
+        let script = RemoteTerminalScript.attachScript(
+            worktreePath: "/tmp",
+            sessionName: "alas-itest",
+            useZmx: false,
+            startupSuffix: "pwd; exit 0"
+        )
+        let result = try await RemoteExec.run(
+            host: "localhost",
+            cwd: nil,
+            command: script,
+            timeout: 20
+        )
+        #expect(result.exitCode == 0)
+        #expect(result.stdout.contains("/tmp"))
+    }
 }

--- a/AlasTests/WorkspaceLSPManagerStatusTests.swift
+++ b/AlasTests/WorkspaceLSPManagerStatusTests.swift
@@ -17,14 +17,11 @@ struct WorkspaceLSPManagerStatusTests {
 
     private func manager(
         withFakeEntry language: String = "swift",
-        makeClient: @escaping (_ executable: URL, _ arguments: [String], _ environment: [String: String], _ language: String, _ rootURI: String) -> LSPClient = { executable, arguments, environment, language, rootURI in
-            LSPClient(
-                transport: LSPTransport(executable: executable, arguments: arguments, environment: environment),
-                language: language,
-                rootURI: rootURI
-            )
-        }
+        makeClient: ((_ executable: URL, _ arguments: [String], _ environment: [String: String], _ language: String, _ rootURI: String) -> LSPClient)? = nil
     ) -> WorkspaceLSPManager {
+        let makeClient = makeClient ?? { _, _, _, language, rootURI in
+            readyClient(language: language, rootURI: rootURI)
+        }
         let registry = LanguageServerRegistry(userDefined: [
             LanguageServerConfig(
                 language: language,
@@ -50,9 +47,46 @@ struct WorkspaceLSPManagerStatusTests {
         )
     }
 
+    private func readyClient(language: String, rootURI: String) -> LSPClient {
+        let transport = FakeTransport()
+        transport.onSend = { sent in
+            guard let id = Self.requestId(in: sent) else { return }
+            if sent.contains(#""method":"initialize""#) {
+                transport.deliverFrame(
+                    #"{"jsonrpc":"2.0","id":\#(id),"result":{"capabilities":{"textDocumentSync":1}}}"#
+                )
+            } else if sent.contains(#""method":"shutdown""#) {
+                transport.deliverFrame(#"{"jsonrpc":"2.0","id":\#(id),"result":null}"#)
+            }
+        }
+        return LSPClient(transport: transport, language: language, rootURI: rootURI)
+    }
+
+    private static func requestId(in json: String) -> Int? {
+        guard let data = json.data(using: .utf8),
+              let object = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else { return nil }
+        return object["id"] as? Int
+    }
+
     @Test func documentStatusIsNoneBeforeOpen() {
         let mgr = manager()
         #expect(mgr.documentStatus(forFile: fileURL, worktreeRoot: root) == .none)
+    }
+
+    @Test func remoteRootProbeCommandUsesQuotedMarkerVariables() {
+        let command = WorkspaceLSPManager.remoteLSPRootProbeCommand(
+            fileURL: URL(fileURLWithPath: "/srv/repo/Package/Sources/App/main.swift"),
+            worktreeRoot: URL(fileURLWithPath: "/srv/repo"),
+            markers: ["Package.swift", "*.xcodeproj", "quote'file"]
+        )
+
+        #expect(command.contains("root='/srv/repo'"))
+        #expect(command.contains("m0='Package.swift'"))
+        #expect(command.contains("m1='*.xcodeproj'"))
+        #expect(command.contains("m2='quote'\\''file'"))
+        #expect(command.contains("find \"$dir\" -maxdepth 1 -name \"$m1\""))
+        #expect(command.contains("[ -e \"$dir/$m0\" ]"))
+        #expect(!command.contains("dirname --"))
     }
 
     @Test func stateTickStartsAtZero() {
@@ -260,6 +294,9 @@ struct WorkspaceLSPManagerStatusTests {
                         return .allowed
                     }
                 )
+            },
+            makeClient: { _, _, _, language, rootURI in
+                readyClient(language: language, rootURI: rootURI)
             }
         )
 
@@ -355,6 +392,9 @@ struct WorkspaceLSPManagerStatusTests {
                     gatekeeperAssessor: { _ in box.blocked ? .rejected : .allowed },
                     gatekeeperRemediator: { _, _ in await box.waitForBothRemediationAttempts() }
                 )
+            },
+            makeClient: { _, _, _, language, rootURI in
+                readyClient(language: language, rootURI: rootURI)
             }
         )
 

--- a/AlasTests/WorktreeCreateFetchTests.swift
+++ b/AlasTests/WorktreeCreateFetchTests.swift
@@ -157,7 +157,7 @@ struct WorktreeCreateFetchTests {
         try await state.projectsManager.refreshWorktrees(projectId: project.id)
 
         let dest = repo.appendingPathComponent("wt-fetched")
-        let id = state.createWorktree(
+        let id = await state.createWorktree(
             projectId: project.id,
             base: "origin/main",
             branch: "fetched-branch",
@@ -188,7 +188,7 @@ struct WorktreeCreateFetchTests {
         try await state.projectsManager.refreshWorktrees(projectId: project.id)
 
         let dest = repo.appendingPathComponent("wt-local")
-        let id = state.createWorktree(
+        let id = await state.createWorktree(
             projectId: project.id,
             base: "main",
             branch: "local-branch",
@@ -220,7 +220,7 @@ struct WorktreeCreateFetchTests {
         try await state.projectsManager.refreshWorktrees(projectId: project.id)
 
         let dest = repo.appendingPathComponent("wt-fail-continue")
-        let id = state.createWorktree(
+        let id = await state.createWorktree(
             projectId: project.id,
             base: "origin/main",
             branch: "fail-continue-branch",
@@ -248,7 +248,7 @@ struct WorktreeCreateFetchTests {
         try await state.projectsManager.refreshWorktrees(projectId: project.id)
 
         let dest = repo.appendingPathComponent("wt-no-fetch")
-        let id = state.createWorktree(
+        let id = await state.createWorktree(
             projectId: project.id,
             base: "origin/main",
             branch: "no-fetch-branch",

--- a/scripts/build-zmx.sh
+++ b/scripts/build-zmx.sh
@@ -73,13 +73,18 @@ linux_zmx_output() {
 }
 
 build_linux_binaries() {
-    local linux_target linux_arch linux_prefix linux_output
+    local linux_target linux_arch linux_prefix linux_output linux_marker linux_fingerprint
     for linux_target in x86_64-linux-musl aarch64-linux-musl; do
         linux_arch="${linux_target%%-*}"
         linux_prefix="${srcroot}/.build/zmx/linux-${linux_arch}/install"
         linux_output="${linux_prefix}/bin/zmx"
-        [ -x "${linux_output}" ] && continue
+        linux_marker="${srcroot}/.build/zmx/linux-${linux_arch}/fingerprint"
+        linux_fingerprint="$(printf '%s\n%s\n%s\n%s\n%s\n%s\n' "${zmx_sha}" "${zmx_dirt}" "${linux_target}" "${zig_bin}" "${zig_id}" "${script_id}" | shasum -a 256 | awk '{print $1}')"
+        if [ -x "${linux_output}" ] && [ -f "${linux_marker}" ] && [ "$(cat "${linux_marker}")" = "${linux_fingerprint}" ]; then
+            continue
+        fi
 
+        rm -f "${linux_output}"
         mkdir -p "${linux_prefix}"
         (
             cd "${zmx_src}"
@@ -91,6 +96,8 @@ build_linux_binaries() {
                 --global-cache-dir "${srcroot}/.build/zmx/linux-${linux_arch}/.zig-global-cache"
         )
         [ -x "${linux_output}" ] || die "Linux zmx build produced no binary: ${linux_output}"
+        printf '%s\n' "${linux_fingerprint}" > "${linux_marker}.tmp"
+        mv "${linux_marker}.tmp" "${linux_marker}"
     done
 }
 

--- a/scripts/build-zmx.sh
+++ b/scripts/build-zmx.sh
@@ -68,6 +68,32 @@ skip_if_optional() {
     die "$*"
 }
 
+linux_zmx_output() {
+    printf '%s/.build/zmx/linux-%s/install/bin/zmx\n' "${srcroot}" "$1"
+}
+
+build_linux_binaries() {
+    local linux_target linux_arch linux_prefix linux_output
+    for linux_target in x86_64-linux-musl aarch64-linux-musl; do
+        linux_arch="${linux_target%%-*}"
+        linux_prefix="${srcroot}/.build/zmx/linux-${linux_arch}/install"
+        linux_output="${linux_prefix}/bin/zmx"
+        [ -x "${linux_output}" ] && continue
+
+        mkdir -p "${linux_prefix}"
+        (
+            cd "${zmx_src}"
+            "${zig_bin}" build \
+                -Doptimize=ReleaseFast \
+                -Dtarget="${linux_target}" \
+                --prefix "${linux_prefix}" \
+                --cache-dir "${srcroot}/.build/zmx/linux-${linux_arch}/.zig-cache" \
+                --global-cache-dir "${srcroot}/.build/zmx/linux-${linux_arch}/.zig-global-cache"
+        )
+        [ -x "${linux_output}" ] || die "Linux zmx build produced no binary: ${linux_output}"
+    done
+}
+
 # Universal-build fast path: recursively invoke this script for each slice,
 # then `lipo` the results. Each per-arch recursive call goes through the
 # normal cache, so re-archives with no zmx change short-circuit on both
@@ -143,6 +169,7 @@ cached_binary="${cache_dir}/zmx"
 if [ -x "${cached_binary}" ]; then
     cp "${cached_binary}" "${zmx_output}"
     chmod +x "${zmx_output}"
+    build_linux_binaries
     exit 0
 fi
 
@@ -184,6 +211,7 @@ run_zig_build_with_retries() {
 }
 
 run_zig_build_with_retries
+build_linux_binaries
 
 # Publish to cache atomically. Use a per-process temp file so two concurrent
 # builds with the same fingerprint don't trample each other's `.tmp` mid-copy

--- a/scripts/embed-ghostty-resources.sh
+++ b/scripts/embed-ghostty-resources.sh
@@ -35,6 +35,17 @@ if [ -x "${zmx_source}" ]; then
     mkdir -p "${zmx_destination_dir}"
     rsync -a "${zmx_source}" "${zmx_destination}"
     chmod +x "${zmx_destination}"
+    for linux_arch in x86_64 aarch64; do
+        linux_source="${SRCROOT}/.build/zmx/linux-${linux_arch}/install/bin/zmx"
+        linux_destination_dir="${zmx_destination_dir}/linux-${linux_arch}"
+        if [ ! -x "${linux_source}" ]; then
+            echo "embed-ghostty-resources.sh: error: Linux zmx binary not found or not executable at ${linux_source}" >&2
+            exit 1
+        fi
+        mkdir -p "${linux_destination_dir}"
+        rsync -a "${linux_source}" "${linux_destination_dir}/zmx"
+        chmod +x "${linux_destination_dir}/zmx"
+    done
 elif [ "${ALAS_ZMX_OPTIONAL:-}" = "1" ]; then
     # Drop any previously bundled zmx so an incremental optional build does
     # not silently ship a stale helper despite warning that panes will not


### PR DESCRIPTION
## Summary
- add SSH-backed remote project metadata, polling, file access, editor/search support, ACP sessions, and terminal persistence
- add remote follow-up support for reconnects, LSP over SSH, remote images, file operations, and PTY cleanup
- add focused unit/integration coverage for the remote SSH primitives and terminal paths

## Verification
- xcodegen
- ALAS_FFF_TARGET_ARCH=arm64 ALAS_ZMX_OPTIONAL=1 xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -derivedDataPath /private/tmp/alas-remote-pr-tests-dd4 -quiet test -only-testing:AlasTests/ACPReconnectPolicyTests -only-testing:AlasTests/RemoteLSPLauncherTests -only-testing:AlasTests/RemoteImageCacheTests -only-testing:AlasTests/RemoteFileOpsTests -only-testing:AlasTests/ACPTerminalCRLFTests -only-testing:AlasTests/RemoteTerminalLaunchTests
- ALAS_FFF_TARGET_ARCH=arm64 ALAS_ZMX_OPTIONAL=1 xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -derivedDataPath /private/tmp/alas-remote-pr-build-dd -quiet build