### PR TITLE
perf(diff): low-severity diff rendering cleanups

### DIFF
--- a/Alas/Sources/Center/Diff/DiffCodeText.swift
+++ b/Alas/Sources/Center/Diff/DiffCodeText.swift
@@ -7,40 +7,8 @@ enum DiffInlineTone {
     case accent
 }
 
-struct DiffCodeText: View {
-    let text: String
-    let fileExtension: String
-    let codeFontFamily: String
-    let codeFontSize: CGFloat
-    let wrapLines: Bool
-    let allowHorizontalExpansion: Bool
-    let showWhitespace: Bool
-    let inlineSpans: [DiffInlineSpan]
-    let inlineTone: DiffInlineTone
-
-    @Environment(\.theme) private var theme
-
-    var body: some View {
-        Text(attributedText)
-            .lineSpacing(CenterTypography.textLineSpacing(forFontSize: codeFontSize))
-            .lineLimit(wrapLines ? nil : 1)
-            .fixedSize(horizontal: allowHorizontalExpansion && !wrapLines, vertical: true)
-    }
-
-    private var attributedText: AttributedString {
-        AttributedString(Self.attributedString(
-            text: text,
-            fileExtension: fileExtension,
-            codeFontFamily: codeFontFamily,
-            codeFontSize: codeFontSize,
-            showWhitespace: showWhitespace,
-            inlineSpans: inlineSpans,
-            inlineTone: inlineTone,
-            theme: theme
-        ))
-    }
-
-    nonisolated static func attributedString(
+enum DiffCodeText {
+    static func attributedString(
         text: String,
         fileExtension: String,
         codeFontFamily: String,
@@ -79,7 +47,7 @@ struct DiffCodeText: View {
         return output
     }
 
-    nonisolated private static func baseAttributes(
+    private static func baseAttributes(
         codeFontFamily: String,
         codeFontSize: CGFloat,
         theme: Theme
@@ -91,7 +59,7 @@ struct DiffCodeText: View {
         ]
     }
 
-    nonisolated static func applySyntaxSpans(
+    static func applySyntaxSpans(
         to output: NSMutableAttributedString,
         spans: [HighlightSpan],
         offset: Int,
@@ -117,7 +85,7 @@ struct DiffCodeText: View {
         }
     }
 
-    nonisolated private static func applyInlineSpans(
+    private static func applyInlineSpans(
         to output: NSMutableAttributedString,
         inlineSpans: [DiffInlineSpan],
         inlineTone: DiffInlineTone,
@@ -135,11 +103,11 @@ struct DiffCodeText: View {
         }
     }
 
-    nonisolated private static func isValid(_ range: NSRange, in length: Int) -> Bool {
+    private static func isValid(_ range: NSRange, in length: Int) -> Bool {
         range.location >= 0 && range.length >= 0 && NSMaxRange(range) <= length
     }
 
-    nonisolated private static func inlineColor(for tone: DiffInlineTone, theme: Theme) -> Color {
+    private static func inlineColor(for tone: DiffInlineTone, theme: Theme) -> Color {
         switch tone {
         case .add:
             return theme.color("add")
@@ -150,7 +118,7 @@ struct DiffCodeText: View {
         }
     }
 
-    nonisolated private static func syntaxColor(for capture: HighlightCapture, inlineTone: DiffInlineTone, theme: Theme) -> Color {
+    private static func syntaxColor(for capture: HighlightCapture, inlineTone: DiffInlineTone, theme: Theme) -> Color {
         switch capture {
         case .keyword:
             return theme.color("syntax-keyword")
@@ -174,7 +142,7 @@ struct DiffCodeText: View {
         }
     }
 
-    nonisolated private static func visibleWhitespaceText(_ text: String, enabled: Bool) -> String {
+    private static func visibleWhitespaceText(_ text: String, enabled: Bool) -> String {
         guard enabled else { return text }
         return text
             .replacingOccurrences(of: " ", with: "·")

--- a/Alas/Sources/Center/Diff/DiffPaneTextDocumentView.swift
+++ b/Alas/Sources/Center/Diff/DiffPaneTextDocumentView.swift
@@ -1467,7 +1467,7 @@ final class DiffPaneCodeTextView: NSTextView {
 
     func reviewLineRow(at point: NSPoint) -> Int? {
         let rowRects = diffRowRects()
-        return rowRects.firstIndex(where: { $0.contains(point) })
+        return rowRects.binarySearchRow(containing: point)
     }
 
     override func cursorUpdate(with event: NSEvent) {
@@ -1499,7 +1499,7 @@ final class DiffPaneCodeTextView: NSTextView {
     /// Row index of the expandable-context button under `point`, if any.
     private func expansionRow(at point: NSPoint) -> Int? {
         let rowRects = diffRowRects()
-        guard let row = rowRects.firstIndex(where: { $0.contains(point) }),
+        guard let row = rowRects.binarySearchRow(containing: point),
               expansionKey(atRow: row) != nil
         else { return nil }
         return row
@@ -2106,12 +2106,7 @@ final class DiffPaneLineNumberRulerView: NSRulerView {
     }
 
     private func rowIndex(at point: NSPoint) -> Int? {
-        let rowRects = rowGeometry().rowRects
-        let visibleRows = visibleRowIndices(
-            in: NSRect(x: point.x, y: point.y, width: 1, height: 0),
-            rowRects: rowRects
-        )
-        return visibleRows.first { rowRects[$0].contains(point) }
+        diffRowRects().binarySearchRow(containing: point)
     }
 
     private func invokeExpansion(row: Int, optionKey: Bool) -> Bool {
@@ -2424,5 +2419,27 @@ private extension DiffPaneTextDocumentBuilder.LineMetadata {
             ],
             selectedText: sourceLine.text
         )
+    }
+}
+
+extension Array where Element == NSRect {
+    func binarySearchRow(containing point: NSPoint) -> Int? {
+        var low = 0
+        var high = count - 1
+        while low <= high {
+            let mid = (low + high) / 2
+            let rect = self[mid]
+            if rect.contains(point) {
+                return mid
+            }
+            if point.y < rect.minY {
+                high = mid - 1
+            } else if point.y > rect.maxY {
+                low = mid + 1
+            } else {
+                return nil
+            }
+        }
+        return nil
     }
 }

--- a/Alas/Sources/Center/Diff/DiffPaneView.swift
+++ b/Alas/Sources/Center/Diff/DiffPaneView.swift
@@ -395,9 +395,9 @@ struct DiffPaneView: View {
         let newLines = Set(visibleRows.compactMap { $0.new?.anchor.newLine })
         return threads.filter { t in
             if t.isOldSide {
-                return t.lineRange.contains(where: { oldLines.contains($0) })
+                return oldLines.contains(where: { t.lineRange.contains($0) })
             } else {
-                return t.lineRange.contains(where: { newLines.contains($0) })
+                return newLines.contains(where: { t.lineRange.contains($0) })
             }
         }
     }

--- a/Alas/Sources/Center/Diff/DiffPaneView.swift
+++ b/Alas/Sources/Center/Diff/DiffPaneView.swift
@@ -328,16 +328,8 @@ struct DiffPaneView: View {
             in: group,
             expandedCollapsedRowIDs: expandedCollapsedRowIDs
         )
-        let hunkThreads = threads.filter { t in
-            visibleRows.contains {
-                t.isOldSide
-                    ? t.lineRange.contains($0.old?.anchor.oldLine ?? -1)
-                    : t.lineRange.contains($0.new?.anchor.newLine ?? -1)
-            }
-        }
-        let hunkAnnotations = annotations.filter { a in
-            visibleRows.contains { $0.new?.anchor.newLine == a.newLine }
-        }
+        let hunkThreads = threadsForVisibleRows(visibleRows)
+        let hunkAnnotations = annotationsForVisibleRows(visibleRows)
         let blocks = DiffInlineCommentLayout.blocks(
             visibleRows: visibleRows,
             threads: hunkThreads,
@@ -395,6 +387,25 @@ struct DiffPaneView: View {
                 .stroke(theme.color("line"), lineWidth: 0.75)
         )
         .padding(.bottom, 10)
+    }
+
+    private func threadsForVisibleRows(_ visibleRows: [DiffDisplayRow]) -> [DiffInlineCommentThread] {
+        guard !threads.isEmpty else { return [] }
+        let oldLines = Set(visibleRows.compactMap { $0.old?.anchor.oldLine })
+        let newLines = Set(visibleRows.compactMap { $0.new?.anchor.newLine })
+        return threads.filter { t in
+            if t.isOldSide {
+                return t.lineRange.contains(where: { oldLines.contains($0) })
+            } else {
+                return t.lineRange.contains(where: { newLines.contains($0) })
+            }
+        }
+    }
+
+    private func annotationsForVisibleRows(_ visibleRows: [DiffDisplayRow]) -> [DiffInlineAnnotation] {
+        guard !annotations.isEmpty else { return [] }
+        let newLines = Set(visibleRows.compactMap { $0.new?.anchor.newLine })
+        return annotations.filter { newLines.contains($0.newLine) }
     }
 
     private func activeHighlight(for rows: [DiffDisplayRow]) -> DiffReviewCommentHighlight? {

--- a/Alas/Sources/Center/DiffReview/DiffReviewSurface.swift
+++ b/Alas/Sources/Center/DiffReview/DiffReviewSurface.swift
@@ -498,6 +498,13 @@ enum DiffReviewSurfaceSelectionSync {
         let programmaticScroll: DiffReviewProgrammaticScrollController
     }
 
+    private struct VisibilityLookupCache {
+        let topTargetLookup: [String: DiffReviewFileID]
+        let sectionTargetLookup: [String: DiffReviewFileID]
+    }
+
+    private static var visibilityLookupCache: (key: String, value: VisibilityLookupCache)?
+
     static func fileSetKey(for fileIDs: [DiffReviewFileID]) -> String {
         fileIDs.map { "\($0.rawValue.count):\($0.rawValue)" }.joined(separator: "|")
     }
@@ -529,13 +536,21 @@ enum DiffReviewSurfaceSelectionSync {
         fileIDs: [DiffReviewFileID],
         programmaticScroll: DiffReviewProgrammaticScrollController
     ) -> DiffReviewFileID? {
-        let topTargetLookup = Dictionary(uniqueKeysWithValues: fileIDs.map {
-            (topVisibilityTargetID(for: $0), $0)
-        })
-        let sectionTargetLookup = Dictionary(uniqueKeysWithValues: fileIDs.map {
-            (sectionVisibilityTargetID(for: $0), $0)
-        })
-        let visibleTopTarget = visibleRawIDs.lazy.compactMap { topTargetLookup[$0] }.first
+        let key = fileSetKey(for: fileIDs)
+        let cache: VisibilityLookupCache
+        if let cached = visibilityLookupCache, cached.key == key {
+            cache = cached.value
+        } else {
+            let topTargetLookup = Dictionary(uniqueKeysWithValues: fileIDs.map {
+                (topVisibilityTargetID(for: $0), $0)
+            })
+            let sectionTargetLookup = Dictionary(uniqueKeysWithValues: fileIDs.map {
+                (sectionVisibilityTargetID(for: $0), $0)
+            })
+            cache = VisibilityLookupCache(topTargetLookup: topTargetLookup, sectionTargetLookup: sectionTargetLookup)
+            visibilityLookupCache = (key, cache)
+        }
+        let visibleTopTarget = visibleRawIDs.lazy.compactMap { cache.topTargetLookup[$0] }.first
         let currentIsVisible = current.map { current in
             visibleRawIDs.contains(topVisibilityTargetID(for: current))
                 || visibleRawIDs.contains(sectionVisibilityTargetID(for: current))
@@ -543,7 +558,7 @@ enum DiffReviewSurfaceSelectionSync {
         guard visibleTopTarget != nil || !currentIsVisible else { return nil }
 
         let active = visibleTopTarget
-            ?? visibleRawIDs.lazy.compactMap { sectionTargetLookup[$0] }.first
+            ?? visibleRawIDs.lazy.compactMap { cache.sectionTargetLookup[$0] }.first
         guard let active,
               active != current,
               programmaticScroll.acceptsScrollSpyUpdate(for: active)

--- a/Alas/Sources/Center/Merge/MergeSidePane.swift
+++ b/Alas/Sources/Center/Merge/MergeSidePane.swift
@@ -156,24 +156,25 @@ struct MergeSidePane: NSViewRepresentable {
         case .local:  tint = NSColor.systemGreen.withAlphaComponent(0.14)
         case .remote: tint = NSColor.systemBlue.withAlphaComponent(0.14)
         }
+        let font = CenterTypography.resolveCodeFont(family: codeFontFamily, size: codeFontSize)
         let pad = NSAttributedString(string: "\n", attributes: [
-            .font: CenterTypography.resolveCodeFont(family: codeFontFamily, size: codeFontSize),
+            .font: font,
             .foregroundColor: NSColor.clear,
             .backgroundColor: NSColor.clear,
         ])
+        let hunkIndexSet = hunkRanges.isEmpty ? Set<Int>() : Set(hunkRanges.flatMap { $0 })
+        let attrs: [NSAttributedString.Key: Any] = [
+            .font: font,
+            .foregroundColor: NSColor(theme.color("fg")),
+        ]
         for (i, row) in rows.enumerated() {
             if row.isPadding {
                 result.append(pad)
                 continue
             }
             let content = row.content + "\n"
-            let inHunk = hunkRanges.contains { $0.contains(i) }
-            let attrs: [NSAttributedString.Key: Any] = [
-                .font: CenterTypography.resolveCodeFont(family: codeFontFamily, size: codeFontSize),
-                .foregroundColor: NSColor(theme.color("fg")),
-            ]
             let line = NSMutableAttributedString(string: content, attributes: attrs)
-            if inHunk {
+            if hunkIndexSet.contains(i) {
                 line.addAttribute(.backgroundColor, value: tint,
                                   range: NSRange(location: 0, length: line.length))
             }


### PR DESCRIPTION
Closes #682

- **DiffPaneView.hunk()**: replace O(threads × rows) nested contains with Set-based line lookups for thread/annotation filtering
- **DiffPaneTextDocumentView**: replace linear firstIndex(where:) scans over row rects with binary search on mouse-move hot paths
- **DiffReviewSurface**: cache visibility lookup dictionaries keyed by fileSetKey to avoid rebuilding per scroll event
- **DiffCodeText**: convert from View struct to enum since only static methods are used, removing dead body/attributedText computed props
- **MergeSidePane**: hoist font resolution out of per-row loop and replace O(rows × hunkRanges) contains with flat Set lookup