### PR TITLE
fix(acp): move session persistence off main actor

### DIFF
--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -209,6 +209,7 @@
 		2DDF8175D7490F505AED7DF4 /* WebSocketFrameTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DF919734A34EEB87FA61FE07 /* WebSocketFrameTests.swift */; };
 		2DE20AB5DAEF233BE008E5AA /* RepoSelectorRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA5A64AEDC7F12F08DA8D2A5 /* RepoSelectorRow.swift */; };
 		2E1D743806714BE4CD88A240 /* ContentSearcherTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C5E83B4DDF185280E01CA80A /* ContentSearcherTests.swift */; };
+		2E386BCE2DC24809A1B68244 /* ACPSessionPersistenceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0349ABD94031DE1BA929C8ED /* ACPSessionPersistenceTests.swift */; };
 		2E82C412B34A091035A7DB41 /* CommitMessageEditorView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D65BEFA85B6671FDE505A30D /* CommitMessageEditorView.swift */; };
 		2E952C4C62784847AF4B7870 /* ZmxSessionName.swift in Sources */ = {isa = PBXBuildFile; fileRef = 89B23F35BE6FD53B74DD84ED /* ZmxSessionName.swift */; };
 		2EA0D9B6F711518ECBF14CF7 /* TabMergeConflictCodingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 14907D679267359B3FB8A848 /* TabMergeConflictCodingTests.swift */; };
@@ -629,6 +630,7 @@
 		8BF52AFF90954B767B9D7E65 /* ACPSession.swift in Sources */ = {isa = PBXBuildFile; fileRef = BBBEFD27FD7013D458435779 /* ACPSession.swift */; };
 		8C1E756AFF4125E7ED04E0B8 /* RemoteConnection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A2EFB5253073D6A4A328FE0 /* RemoteConnection.swift */; };
 		8C492CBACC6D6DACE56DADA9 /* RemoteWorktreeSummaryBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9DD81682586D187AB70D1CDB /* RemoteWorktreeSummaryBuilder.swift */; };
+		8CAD455D39C888978F7E66EF /* AlasApplicationDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0452819DD42784CF60D466A4 /* AlasApplicationDelegate.swift */; };
 		8CEA8B0352538A42B8DC01A9 /* EmptyTabViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA09B830D18CCEE251D0E10A /* EmptyTabViewTests.swift */; };
 		8D22459A108B6BF47AEA71F7 /* session-update-available-models.json in Resources */ = {isa = PBXBuildFile; fileRef = 1B0785F1FFC8008C74009584 /* session-update-available-models.json */; };
 		8D43C0AEB98BC9F3F5A08CC5 /* PendingReviewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D43F393A27EF521D4A73B050 /* PendingReviewTests.swift */; };
@@ -637,6 +639,7 @@
 		8DBA8F6E781ADBD5D59EDA13 /* CompletionDocumentationRenderer.swift in Sources */ = {isa = PBXBuildFile; fileRef = ECFB48AF581F74C564ACBCF5 /* CompletionDocumentationRenderer.swift */; };
 		8E2FB28D4C7681611BC67537 /* WorkspaceLSPManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = BE809DBC1E614321EE793D00 /* WorkspaceLSPManager.swift */; };
 		8E8ABE6BBA778EEA4170423C /* MergeScrollCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7095EA2868EF619BA4202BDF /* MergeScrollCoordinator.swift */; };
+		8E988C41547B229AF19CBE31 /* ACPSessionPersistence.swift in Sources */ = {isa = PBXBuildFile; fileRef = B7A590E6B7A73546D38D4F95 /* ACPSessionPersistence.swift */; };
 		8EEB68F55286EF9DADAA710A /* ACPSessionManagerPlanSidebarLayoutTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3DCFA45F98F080043C4D664A /* ACPSessionManagerPlanSidebarLayoutTests.swift */; };
 		8F4B6B83968BE4C1E6D0D912 /* AlasCLIRequestTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA730D3A9214ED3ECD15C0ED /* AlasCLIRequestTests.swift */; };
 		8F5B93A115E4554430ADC0FD /* ChangesPane.swift in Sources */ = {isa = PBXBuildFile; fileRef = EB1E14CFAC880D31CE8FBE8F /* ChangesPane.swift */; };
@@ -1205,10 +1208,12 @@
 		031B1108F04B06EAC224AB5B /* CodeHostProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CodeHostProvider.swift; sourceTree = "<group>"; };
 		0326789AA29BD63CC1B8F81F /* DefinitionSnippetCache.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefinitionSnippetCache.swift; sourceTree = "<group>"; };
 		033CEEE92FCAFF8A177428E4 /* ACPStreamingText.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPStreamingText.swift; sourceTree = "<group>"; };
+		0349ABD94031DE1BA929C8ED /* ACPSessionPersistenceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPSessionPersistenceTests.swift; sourceTree = "<group>"; };
 		0359D6646D12B66B70B5BB43 /* AiSplitButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AiSplitButton.swift; sourceTree = "<group>"; };
 		039741E1CCAEF9770D5DEE08 /* GitServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GitServiceTests.swift; sourceTree = "<group>"; };
 		039C5E652B7A9457EB13BD70 /* ReviewRequestContextBuilder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReviewRequestContextBuilder.swift; sourceTree = "<group>"; };
 		03D901BF4399752A3FC658F8 /* ACPSessionStoreQueueTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPSessionStoreQueueTests.swift; sourceTree = "<group>"; };
+		0452819DD42784CF60D466A4 /* AlasApplicationDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlasApplicationDelegate.swift; sourceTree = "<group>"; };
 		04B44F1DD775D2543439D508 /* ACPTranscriptMarkdown.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPTranscriptMarkdown.swift; sourceTree = "<group>"; };
 		0535D92433898E76670B9FF0 /* ACPUserScrollEventTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPUserScrollEventTests.swift; sourceTree = "<group>"; };
 		0544FCFB9BC3E26FDB57CC96 /* HarnessPill.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HarnessPill.swift; sourceTree = "<group>"; };
@@ -1978,6 +1983,7 @@
 		B77D7A400059AFD189D1CA5A /* ACPToolCallPresentationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPToolCallPresentationTests.swift; sourceTree = "<group>"; };
 		B78414C2E79104BC6218B1F4 /* ACPPermissionPolicy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPPermissionPolicy.swift; sourceTree = "<group>"; };
 		B78A7E7888D552AFC80BA3AA /* AppConfigTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppConfigTests.swift; sourceTree = "<group>"; };
+		B7A590E6B7A73546D38D4F95 /* ACPSessionPersistence.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPSessionPersistence.swift; sourceTree = "<group>"; };
 		B7AAAEB5A9C69FC459AAD70B /* ACPPlanPill.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPPlanPill.swift; sourceTree = "<group>"; };
 		B7CE7B4DAFDB65A79308FB63 /* GitService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GitService.swift; sourceTree = "<group>"; };
 		B7E50B0600EF60A0D9B09877 /* HighlightCapture.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HighlightCapture.swift; sourceTree = "<group>"; };
@@ -3278,6 +3284,7 @@
 				63376280CA1D01F9D564A6F6 /* ACPSessionDiscovery.swift */,
 				94D30693F45966ED1456811E /* ACPSessionHydrator.swift */,
 				7615FEA1F225EBDE52CF5E14 /* ACPSessionManager.swift */,
+				B7A590E6B7A73546D38D4F95 /* ACPSessionPersistence.swift */,
 				F332906E17C5865856DBB90B /* ACPSessionRunner.swift */,
 				E0E1BF90CB3BE5BFDFA2EC7C /* ACPSessionStore.swift */,
 				033CEEE92FCAFF8A177428E4 /* ACPStreamingText.swift */,
@@ -3803,6 +3810,7 @@
 				069895A7C4E29B3275D8320E /* ACPSessionManagerRemoteRestoreTests.swift */,
 				6D1AAAE396590865426C592A /* ACPSessionManagerRetentionTests.swift */,
 				FB5B73ECBD730B5BB24E2240 /* ACPSessionManagerTests.swift */,
+				0349ABD94031DE1BA929C8ED /* ACPSessionPersistenceTests.swift */,
 				0B057D23BD5B72E06E790C5B /* ACPSessionQueueAPITests.swift */,
 				3E0616B1F0B84C45792C804E /* ACPSessionRecoveryIntegrationTests.swift */,
 				639B69601924624FFE573EBA /* ACPSessionRecoveryTests.swift */,
@@ -4323,6 +4331,7 @@
 			isa = PBXGroup;
 			children = (
 				7E39F15B0B7395FB81D2C9D0 /* AlasApp.swift */,
+				0452819DD42784CF60D466A4 /* AlasApplicationDelegate.swift */,
 				1271747193D1594AEA596278 /* AlasCLICommandRouter.swift */,
 				430FCE70CDAB35CB0594CF44 /* AlasCLIReviewTargetResolver.swift */,
 				457858DB2CF0B558A1A490BC /* AlasCLIWorktreeResolver.swift */,
@@ -4705,6 +4714,7 @@
 				D11DB95BC2F7094756EBCAC3 /* ACPSessionDiscovery.swift in Sources */,
 				61D33019E9AA23F5042C39B2 /* ACPSessionHydrator.swift in Sources */,
 				209FB0AAF20BDE5850A139F4 /* ACPSessionManager.swift in Sources */,
+				8E988C41547B229AF19CBE31 /* ACPSessionPersistence.swift in Sources */,
 				1F89B774F2DC7DD818AD4E5B /* ACPSessionRunner.swift in Sources */,
 				027A326E7DAB6C6E133E5FD3 /* ACPSessionStore.swift in Sources */,
 				9AB33F6B645EBA3F92A4E40F /* ACPSessionUpdate.swift in Sources */,
@@ -4761,6 +4771,7 @@
 				55C7881F382ACCEBCDB7D157 /* AgentsPane.swift in Sources */,
 				59EFDD354514B21BBA4206AD /* AiSplitButton.swift in Sources */,
 				A240E6FE68F27C04D32A270A /* AlasApp.swift in Sources */,
+				8CAD455D39C888978F7E66EF /* AlasApplicationDelegate.swift in Sources */,
 				5D3E7C2D040B58D0C9D1C0E8 /* AlasButton.swift in Sources */,
 				6AFE04B669CA654D7733F97E /* AlasCLICommandRouter.swift in Sources */,
 				29806D50EECB300991471A7C /* AlasCLIRequest.swift in Sources */,
@@ -5320,6 +5331,7 @@
 				6C70755431CFBA41420A2F47 /* ACPSessionManagerRemoteRestoreTests.swift in Sources */,
 				095E7D98616FB77A9F8BDFD9 /* ACPSessionManagerRetentionTests.swift in Sources */,
 				E30243803319861ACA6A4513 /* ACPSessionManagerTests.swift in Sources */,
+				2E386BCE2DC24809A1B68244 /* ACPSessionPersistenceTests.swift in Sources */,
 				832BDA6FD48E68F76E46D786 /* ACPSessionQueueAPITests.swift in Sources */,
 				C9004250BC974548165BE5B3 /* ACPSessionRecoveryIntegrationTests.swift in Sources */,
 				3E4934D7DC18EB748B81436F /* ACPSessionRecoveryTests.swift in Sources */,

--- a/Alas/Sources/ACP/Permissions/ACPPermissionDecisionLog.swift
+++ b/Alas/Sources/ACP/Permissions/ACPPermissionDecisionLog.swift
@@ -1,45 +1,53 @@
 import Foundation
 
-struct ACPPermissionDecisionLog {
-    let store: ACPSessionStore
+struct ACPPermissionDecisionLog: @unchecked Sendable {
+    let persistence: ACPSessionPersistence
     /// Optional gate: when provided, `record` becomes a no-op if the
     /// closure returns `false`. Used by `ACPSessionRunner` to prevent
     /// writes to the `permission_decisions` table after another instance
     /// has seized the session lease.
     let canWrite: (() -> Bool)?
+    let leaseFence: (() -> ACPSessionLeaseFence?)?
 
-    init(store: ACPSessionStore, canWrite: (() -> Bool)? = nil) {
-        self.store = store
+    init(
+        store: ACPSessionStore,
+        canWrite: (() -> Bool)? = nil,
+        leaseFence: (() -> ACPSessionLeaseFence?)? = nil
+    ) {
+        self.persistence = ACPSessionPersistence(path: store.path)
         self.canWrite = canWrite
+        self.leaseFence = leaseFence
     }
 
-    func record(sessionId: String, scopeKey: String, decision: ACPPermissionDecision, scope: ACPPermissionScopeKind) throws {
+    init(
+        persistence: ACPSessionPersistence,
+        canWrite: (() -> Bool)? = nil,
+        leaseFence: (() -> ACPSessionLeaseFence?)? = nil
+    ) {
+        self.persistence = persistence
+        self.canWrite = canWrite
+        self.leaseFence = leaseFence
+    }
+
+    func record(
+        sessionId: String,
+        scopeKey: String,
+        decision: ACPPermissionDecision,
+        scope: ACPPermissionScopeKind
+    ) async throws {
         if let canWrite, !canWrite() { return }
-        let now = Int64(Date().timeIntervalSince1970)
-        try store.db.exec("""
-        INSERT INTO permission_decisions (session_id, scope_key, decision, scope, decided_at)
-        VALUES (?,?,?,?,?)
-        ON CONFLICT(session_id, scope_key) DO UPDATE SET
-            decision = excluded.decision,
-            scope = excluded.scope,
-            decided_at = excluded.decided_at
-        """, bindings: [sessionId, scopeKey, decision.rawValue, scope.rawValue, now])
+        _ = try await persistence.recordPermissionDecision(
+            sessionId: sessionId,
+            scopeKey: scopeKey,
+            decision: decision,
+            scope: scope,
+            fence: leaseFence?()
+        )
     }
 
     /// Returns the matching decision for this session, prefer session-scoped
     /// then project-scoped (any session in this worktree).
-    func lookup(sessionId: String, scopeKey: String) throws -> ACPPermissionDecision? {
-        let sessionRows = try store.db.query("""
-        SELECT decision FROM permission_decisions WHERE session_id = ? AND scope_key = ?
-        """, bindings: [sessionId, scopeKey])
-        if let d = sessionRows.first?["decision"] as? String { return ACPPermissionDecision(rawValue: d) }
-
-        let projectRows = try store.db.query("""
-        SELECT decision FROM permission_decisions
-        WHERE scope_key = ? AND scope = 'project' LIMIT 1
-        """, bindings: [scopeKey])
-        if let d = projectRows.first?["decision"] as? String { return ACPPermissionDecision(rawValue: d) }
-
-        return nil
+    func lookup(sessionId: String, scopeKey: String) async throws -> ACPPermissionDecision? {
+        try await persistence.lookupPermissionDecision(sessionId: sessionId, scopeKey: scopeKey)
     }
 }

--- a/Alas/Sources/ACP/Permissions/ACPPermissionPolicy.swift
+++ b/Alas/Sources/ACP/Permissions/ACPPermissionPolicy.swift
@@ -19,7 +19,7 @@ final class ACPPermissionPolicy {
         if session.autoRunEnabled, let allow = options.first(where: { $0.kind.hasPrefix("allow") }) {
             return .init(outcome: .selected(optionId: allow.optionId))
         }
-        if let logged = try? log.lookup(sessionId: session.id, scopeKey: scopeKey) {
+        if let logged = try? await log.lookup(sessionId: session.id, scopeKey: scopeKey) {
             switch logged {
             case .allow:
                 if let allow = options.first(where: { $0.kind.hasPrefix("allow") }) {
@@ -48,9 +48,19 @@ final class ACPPermissionPolicy {
     /// Called by the UI when the user clicks a button. `persistScope` is
     /// .session for Allow/Deny, .project for "Always for this tool", and nil
     /// for Allow-once. Decision recorded if non-nil.
-    func userDecided(scopeKey: String, optionId: String, decision: ACPPermissionDecision, persistScope: ACPPermissionScopeKind?) {
+    func userDecided(
+        scopeKey: String,
+        optionId: String,
+        decision: ACPPermissionDecision,
+        persistScope: ACPPermissionScopeKind?
+    ) async {
         if let scope = persistScope {
-            try? log.record(sessionId: session.id, scopeKey: scopeKey, decision: decision, scope: scope)
+            try? await log.record(
+                sessionId: session.id,
+                scopeKey: scopeKey,
+                decision: decision,
+                scope: scope
+            )
         }
         session.transcript.pendingPermission = nil
         session.transcript.streamingState = .streaming

--- a/Alas/Sources/ACP/Permissions/ACPPermissionScope.swift
+++ b/Alas/Sources/ACP/Permissions/ACPPermissionScope.swift
@@ -1,11 +1,11 @@
 import Foundation
 
-enum ACPPermissionDecision: String, Codable, Equatable {
+enum ACPPermissionDecision: String, Codable, Equatable, Sendable {
     case allow
     case deny
 }
 
-enum ACPPermissionScopeKind: String, Codable, Equatable {
+enum ACPPermissionScopeKind: String, Codable, Equatable, Sendable {
     case session
     case project
 }

--- a/Alas/Sources/ACP/Protocol/ACPMessages.swift
+++ b/Alas/Sources/ACP/Protocol/ACPMessages.swift
@@ -796,14 +796,14 @@ struct ACPSessionPromptParams: Codable, Equatable {
     let prompt: [ACPContentBlock]
 }
 
-enum ACPContentBlock: Codable, Equatable {
+enum ACPContentBlock: Codable, Equatable, Sendable {
     case text(String)
     case resourceLink(uri: String, name: String?)
     case image(data: String?, uri: String?, mimeType: String?)
     case resource(uri: String, mimeType: String?, text: String)
 
     private enum Keys: String, CodingKey { case type, text, uri, name, mimeType, data, resource }
-    private struct EmbeddedResource: Codable, Equatable {
+    private struct EmbeddedResource: Codable, Equatable, Sendable {
         let uri: String
         let mimeType: String?
         let text: String?

--- a/Alas/Sources/ACP/Session/ACPComposerDraft.swift
+++ b/Alas/Sources/ACP/Session/ACPComposerDraft.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-struct ACPComposerDraft: Codable, Equatable {
+struct ACPComposerDraft: Codable, Equatable, Sendable {
     var segments: [Segment]
 
     static let empty = ACPComposerDraft(segments: [])
@@ -30,7 +30,7 @@ struct ACPComposerDraft: Codable, Equatable {
         }
     }
 
-    enum Segment: Codable, Equatable {
+    enum Segment: Codable, Equatable, Sendable {
         case text(String)
         case mention(displayName: String, uri: String)
         case image(uri: String, mimeType: String)
@@ -43,7 +43,7 @@ struct ACPComposerDraft: Codable, Equatable {
             case mimeType
         }
 
-        private enum SegmentType: String, Codable {
+        private enum SegmentType: String, Codable, Sendable {
             case text
             case mention
             case image

--- a/Alas/Sources/ACP/Session/ACPSession.swift
+++ b/Alas/Sources/ACP/Session/ACPSession.swift
@@ -16,7 +16,7 @@ final class ACPComposerState: ObservableObject {
     }
 }
 
-enum ACPSessionTitleSource: String, Codable {
+enum ACPSessionTitleSource: String, Codable, Sendable {
     case placeholder
     case generated
     case manual

--- a/Alas/Sources/ACP/Session/ACPSessionDiscovery.swift
+++ b/Alas/Sources/ACP/Session/ACPSessionDiscovery.swift
@@ -82,7 +82,7 @@ final class ACPSessionDiscoveryHandle {
     private let worktreeId: String
     private let agentId: String
     private let cwd: String
-    private let store: ACPSessionStore
+    private let persistence: ACPSessionPersistence
     private let connection: ACPConnection
     private var nextCursor: String?
     private var hasLoadedPage = false
@@ -92,14 +92,14 @@ final class ACPSessionDiscoveryHandle {
         worktreeId: String,
         agentId: String,
         cwd: String,
-        store: ACPSessionStore,
+        persistence: ACPSessionPersistence,
         connection: ACPConnection,
         capabilities: ACPSessionDiscoveryCapabilities
     ) {
         self.worktreeId = worktreeId
         self.agentId = agentId
         self.cwd = cwd
-        self.store = store
+        self.persistence = persistence
         self.connection = connection
         self.capabilities = capabilities
     }
@@ -112,18 +112,23 @@ final class ACPSessionDiscoveryHandle {
         hasLoadedPage = true
         nextCursor = page.nextCursor
         let expectedCWD = URL(fileURLWithPath: cwd).standardizedFileURL.path
-        return page.sessions.compactMap { info in
+        var discovered: [ACPDiscoveredSession] = []
+        discovered.reserveCapacity(page.sessions.count)
+        for info in page.sessions {
             guard URL(fileURLWithPath: info.cwd).standardizedFileURL.path == expectedCWD else {
-                return nil
+                continue
             }
-            let local = try? store.loadSession(agentId: agentId, remoteSessionId: info.sessionId)
+            let local = try? await persistence.loadSession(
+                agentId: agentId,
+                remoteSessionId: info.sessionId
+            )
             let remoteTitle = info.title?.trimmingCharacters(in: .whitespacesAndNewlines)
             let displayTitle = if let remoteTitle, !remoteTitle.isEmpty {
                 remoteTitle
             } else {
                 "Agent session"
             }
-            return ACPDiscoveredSession(
+            discovered.append(ACPDiscoveredSession(
                 worktreeId: worktreeId,
                 agentId: agentId,
                 remoteSessionId: info.sessionId,
@@ -132,8 +137,9 @@ final class ACPSessionDiscoveryHandle {
                 updatedAt: info.updatedAt.flatMap { ISO8601DateFormatter().date(from: $0) },
                 additionalDirectories: info.additionalDirectories ?? [],
                 localSessionId: local?.id
-            )
+            ))
         }
+        return discovered
     }
 
     func close() async {

--- a/Alas/Sources/ACP/Session/ACPSessionManager.swift
+++ b/Alas/Sources/ACP/Session/ACPSessionManager.swift
@@ -24,7 +24,7 @@ final class ACPSessionManager: ObservableObject {
     let pid: Int64
     let worktreeId: String
     let worktreePath: String
-    let store: ACPSessionStore
+    let persistence: ACPSessionPersistence
     let changeNotifier: ACPChangeNotifier
     /// Called by each runner's write handler to check whether the target path
     /// has an open, dirty editor buffer. `nil` disables the check (no notices).
@@ -38,6 +38,13 @@ final class ACPSessionManager: ObservableObject {
     private let mcpProjectContextProvider: MCPProjectContextProvider?
     @Published private(set) var sessions: [ACPSession.ID: ACPSession] = [:]
     @Published private(set) var recent: [ACPSessionRow] = []
+    @Published private(set) var persistenceError: String?
+    @Published private var persistedRows: [ACPSession.ID: ACPSessionRow] = [:]
+    @Published private var missingPersistedSessionIds: Set<ACPSession.ID> = []
+    private var rowLoadTasks: [ACPSession.ID: Task<Void, Never>] = [:]
+    private var persistenceTail: Task<Void, Never>?
+    private var persistenceGeneration = 0
+    private var draftFlushHandoffSequence: UInt64 = 0
     private(set) var runners: [ACPSession.ID: ACPSessionRunner] = [:]
     private var elicitationCoordinators: [ACPSession.ID: ACPElicitationCoordinator] = [:]
     #if DEBUG
@@ -85,15 +92,33 @@ final class ACPSessionManager: ObservableObject {
     /// Whether this instance is the legitimate current writer for the session —
     /// gates every remote drive action (`canDrive`, `sendPrompt`, `stop`).
     ///
-    /// Requires BOTH the in-memory claim AND store agreement: after another
-    /// window takes over, the former owner keeps the id in `_ownedLeases` until
-    /// its heartbeat stands down (~5s). Trusting the in-memory set alone would
-    /// let a phone connected to the old owner keep writing into a session
-    /// another instance now drives — corrupting the active conversation. So we
-    /// also consult the store row via `anotherLiveInstanceOwnsLease`, the same
-    /// guard the local write path (`holdsLeaseForWrite`) relies on.
+    /// Combines the local claim with the latest lease observation. The writer
+    /// watch refreshes that observation after takeover; SQLite mutations also
+    /// carry a token fence so stale cached authority cannot commit.
     func isWriter(for id: ACPSession.ID) -> Bool {
         _ownedLeases.contains(id) && !anotherLiveInstanceOwnsLease(sessionId: id)
+    }
+
+    /// Confirms ownership off-main immediately before an RPC or local process
+    /// side effect. Cached observations remain suitable for rendering, but are
+    /// not authority for actions that cannot be transactionally fenced.
+    private func confirmedWriterLease(for sessionId: ACPSession.ID) async -> Bool {
+        guard _ownedLeases.contains(sessionId),
+              let token = ownedLeaseTokens[sessionId]
+        else { return false }
+        do {
+            let lease = try await persistence.loadLease(sessionId: sessionId)
+            observedLeases[sessionId] = lease
+            guard lease?.ownerInstance == instanceId, lease?.token == token else {
+                await standDown(sessionId: sessionId)
+                return false
+            }
+            return true
+        } catch {
+            persistenceError = error.localizedDescription
+            await standDown(sessionId: sessionId)
+            return false
+        }
     }
 
     /// Submit a prompt using the same path the local composer uses (`.auto`
@@ -112,8 +137,8 @@ final class ACPSessionManager: ObservableObject {
     /// land between the gateway's `isWriter` gate and here, and `submit`'s
     /// `.idle`/`.disconnected` path would otherwise enqueue + persist the prompt
     /// as a mirror — injecting it into a session another instance now drives.
-    func sendPrompt(for id: ACPSession.ID, text: String, attachments: [ACPMessage.Attachment], onResult: @escaping @MainActor (Bool) -> Void) {
-        guard isWriter(for: id) else {
+    func sendPrompt(for id: ACPSession.ID, text: String, attachments: [ACPMessage.Attachment], onResult: @escaping @MainActor (Bool) -> Void) async {
+        guard await confirmedWriterLease(for: id) else {
             onResult(false)
             return
         }
@@ -124,9 +149,9 @@ final class ACPSessionManager: ObservableObject {
 
     /// Interrupt the in-flight turn (same as the composer Stop / Esc). Guarded
     /// on the live lease for the same cross-process-takeover reason as `sendPrompt`.
-    func interrupt(for id: ACPSession.ID) {
-        guard isWriter(for: id), let runner = runners[id] else { return }
-        Task { await runner.userCancel() }
+    func interrupt(for id: ACPSession.ID) async {
+        guard await confirmedWriterLease(for: id), let runner = runners[id] else { return }
+        await runner.userCancel()
     }
 
     /// Pending model/mode to apply once a runner registers (the writer took over
@@ -135,8 +160,8 @@ final class ACPSessionManager: ObservableObject {
     var pendingMode: [ACPSession.ID: String] = [:]
 
     /// Toggle auto-run for a remotely-driven session. Writer-gated; persists.
-    func setAutoRun(for id: ACPSession.ID, enabled: Bool) {
-        guard isWriter(for: id), let session = sessions[id] else { return }
+    func setAutoRun(for id: ACPSession.ID, enabled: Bool) async {
+        guard await confirmedWriterLease(for: id), let session = sessions[id] else { return }
         session.autoRunEnabled = enabled
         persist(session)
     }
@@ -144,8 +169,8 @@ final class ACPSessionManager: ObservableObject {
     /// Select the agent model. Optimistically updates + persists, then issues the
     /// agent RPC on the live runner — or records it pending until `attach`
     /// registers one (post-takeover window). Writer-gated.
-    func setModel(for id: ACPSession.ID, modelId: String) {
-        guard isWriter(for: id), let session = sessions[id] else { return }
+    func setModel(for id: ACPSession.ID, modelId: String) async {
+        guard await confirmedWriterLease(for: id), let session = sessions[id] else { return }
         session.currentModel = modelId
         persist(session)
         guard let runner = runners[id] else {
@@ -153,12 +178,12 @@ final class ACPSessionManager: ObservableObject {
             return
         }
         let remoteId = session.remoteSessionId ?? id
-        Task { try? await runner.connection.setModel(sessionId: remoteId, modelId: modelId) }
+        try? await runner.connection.setModel(sessionId: remoteId, modelId: modelId)
     }
 
     /// Select the agent mode. Same semantics as `setModel`.
-    func setMode(for id: ACPSession.ID, modeId: String) {
-        guard isWriter(for: id), let session = sessions[id] else { return }
+    func setMode(for id: ACPSession.ID, modeId: String) async {
+        guard await confirmedWriterLease(for: id), let session = sessions[id] else { return }
         session.currentMode = modeId
         persist(session)
         guard let runner = runners[id] else {
@@ -166,11 +191,13 @@ final class ACPSessionManager: ObservableObject {
             return
         }
         let remoteId = session.remoteSessionId ?? id
-        Task { try? await runner.connection.setMode(sessionId: remoteId, modeId: modeId) }
+        try? await runner.connection.setMode(sessionId: remoteId, modeId: modeId)
     }
 
     /// Sessions for which THIS instance holds the writer lease (backing store).
     var _ownedLeases: Set<ACPSession.ID> = []
+    private var ownedLeaseTokens: [ACPSession.ID: String] = [:]
+    private var observedLeases: [ACPSession.ID: ACPSessionLease?] = [:]
     /// Per-session periodic heartbeat tasks (backing store).
     var _heartbeatTasks: [ACPSession.ID: Task<Void, Never>] = [:]
     /// Per-session debounced write tasks for `composer_drafts`. The
@@ -179,8 +206,12 @@ final class ACPSessionManager: ObservableObject {
     /// flush on submit / delete). Cancelled and re-scheduled on each
     /// further keystroke so a typing burst produces one write.
     private var pendingDraftWrites: [ACPSession.ID: Task<Void, Never>] = [:]
+    private struct DraftFlushHandoff {
+        let draft: ACPComposerDraft
+        let sequence: UInt64
+    }
+    private var draftFlushHandoffs: [ACPSession.ID: DraftFlushHandoff] = [:]
     private static let draftDebounceNanos: UInt64 = 300_000_000
-    private let hydrator: ACPSessionHydrator?
     private let setupEvaluator: ACPSetupEvaluator
     private let connectionFactory: ACPConnectionFactory
     private var inFlightHydrations: [ACPSession.ID: Task<Void, Never>] = [:]
@@ -230,7 +261,8 @@ final class ACPSessionManager: ObservableObject {
     /// correct shutdown order (connection down before lease freed).
     private var attachingSessions: Set<ACPSession.ID> = []
 
-    init(worktreeId: String, worktreePath: String, store: ACPSessionStore,
+    init(worktreeId: String, worktreePath: String, store: ACPSessionStore? = nil,
+         persistence: ACPSessionPersistence? = nil,
          instanceId: String = UUID().uuidString,
          pid: Int64 = Int64(ProcessInfo.processInfo.processIdentifier),
          hydratorPath: String? = nil,
@@ -242,17 +274,19 @@ final class ACPSessionManager: ObservableObject {
          connectionFactory: ACPConnectionFactory? = nil,
          mcpProjectContextProvider: MCPProjectContextProvider? = nil)
     {
+        precondition(store != nil || persistence != nil, "ACPSessionManager requires persistence")
+        let resolvedPersistence = persistence ?? ACPSessionPersistence(path: store!.path)
         self.instanceId = instanceId
         self.pid = pid
         self.worktreeId = worktreeId
         self.worktreePath = worktreePath
-        self.store = store
+        self.persistence = resolvedPersistence
         self.onDirtyCheck = onDirtyCheck
         self.onLiveBufferRead = onLiveBufferRead
         self.onSessionTitleUpdated = onSessionTitleUpdated
         self.mcpProjectContextProvider = mcpProjectContextProvider
         self.changeNotifier = changeNotifier ?? DarwinChangeNotifier(worktreeId: worktreeId)
-        self.hydrator = hydratorPath.flatMap { try? ACPSessionHydrator(path: $0) }
+        _ = hydratorPath
         self.setupEvaluator = setupEvaluator ?? { spec in
             let checker = ACPSetupChecker(env: ProcessInfo.processInfo.environment)
             return await checker.evaluate(spec.setupCheck)
@@ -273,7 +307,47 @@ final class ACPSessionManager: ObservableObject {
             try client.start()
             return ACPConnection(client: client)
         }
-        self.recent = (try? store.recentSessions()) ?? []
+        let initialRecent = store.flatMap { try? $0.recentSessions() } ?? []
+        self.recent = initialRecent
+        self.persistedRows = Dictionary(uniqueKeysWithValues: initialRecent.map { ($0.id, $0) })
+        if store == nil {
+            refreshRecent()
+        }
+    }
+
+    @discardableResult
+    private func enqueuePersistence(
+        _ operation: @escaping @Sendable (ACPSessionPersistence) async throws -> Void
+    ) -> Task<Void, Never> {
+        let previous = persistenceTail
+        let persistence = persistence
+        persistenceGeneration += 1
+        let task = Task { @MainActor [weak self] in
+            await previous?.value
+            guard !Task.isCancelled else { return }
+            do {
+                try await operation(persistence)
+            } catch {
+                self?.persistenceError = error.localizedDescription
+            }
+        }
+        persistenceTail = task
+        return task
+    }
+
+    func flushPersistence() async {
+        while let tail = persistenceTail {
+            let generation = persistenceGeneration
+            await tail.value
+            if persistenceGeneration == generation { return }
+        }
+    }
+
+    func flushAllPersistence() async {
+        for runner in runners.values {
+            await runner.flushPersistence()
+        }
+        await flushPersistence()
     }
 
     func createSession(agentId: String, autoRunDefault: Bool = false) -> ACPSession {
@@ -284,14 +358,18 @@ final class ACPSessionManager: ObservableObject {
             titleSource: .placeholder,
             currentModel: nil, currentMode: nil, autoRun: autoRunDefault,
             createdAt: now, updatedAt: now, lastOpenedAt: now, archived: false)
-        try? store.upsertSession(row)
+        persistedRows[id] = row
+        recent.removeAll { $0.id == id }
+        recent.insert(row, at: 0)
+        enqueuePersistence { persistence in
+            try await persistence.upsertSession(row)
+        }
         let session = ACPSession(
             id: id, agentId: agentId, worktreeId: worktreeId,
             title: row.title, titleSource: .placeholder, origin: row.origin,
             hydrationState: .ready)
         session.autoRunEnabled = autoRunDefault
         sessions[id] = session
-        refreshRecent()
         return session
     }
 
@@ -302,9 +380,10 @@ final class ACPSessionManager: ObservableObject {
     /// reading the queue + draft) is deferred to `hydrateIfNeeded`.
     func placeholderSession(id: ACPSession.ID) -> ACPSession? {
         if let s = sessions[id] { return s }
-        // Verify the session exists before allocating a placeholder so we
-        // don't insert orphan loading entries for typo'd ids.
-        guard let row = try? store.loadSession(id: id) else { return nil }
+        guard let row = persistedRows[id] else {
+            loadPersistedRowIfNeeded(id: id)
+            return nil
+        }
         let session = ACPSession(
             id: row.id, agentId: row.agentId, worktreeId: worktreeId,
             title: row.title, titleSource: row.titleSource, origin: row.origin,
@@ -314,8 +393,49 @@ final class ACPSessionManager: ObservableObject {
         if let memory = transcriptScrollMemory[id] {
             session.followsTranscriptTail = memory.followsTail
         }
+        if let handoff = draftFlushHandoffs[id] {
+            session.replaceComposerDraft(handoff.draft)
+        }
         sessions[id] = session
         return session
+    }
+
+    func isKnownMissingSession(id: ACPSession.ID) -> Bool {
+        missingPersistedSessionIds.contains(id)
+    }
+
+    private func loadPersistedRowIfNeeded(id: ACPSession.ID) {
+        guard rowLoadTasks[id] == nil else { return }
+        let persistence = persistence
+        rowLoadTasks[id] = Task { @MainActor [weak self] in
+            defer { self?.rowLoadTasks[id] = nil }
+            do {
+                guard let row = try await persistence.loadSession(id: id) else {
+                    self?.missingPersistedSessionIds.insert(id)
+                    return
+                }
+                self?.persistedRows[id] = row
+                self?.missingPersistedSessionIds.remove(id)
+            } catch {
+                self?.persistenceError = error.localizedDescription
+            }
+        }
+    }
+
+    /// Loads one row for an explicit open request. Unlike `sessionRows`, this
+    /// covers rows outside the lazy recent-session cache before a tab title is
+    /// chosen.
+    func persistedSessionRow(id: ACPSession.ID) async -> ACPSessionRow? {
+        if let row = persistedRows[id] { return row }
+        do {
+            guard let row = try await persistence.loadSession(id: id) else { return nil }
+            persistedRows[id] = row
+            missingPersistedSessionIds.remove(id)
+            return row
+        } catch {
+            persistenceError = error.localizedDescription
+            return nil
+        }
     }
 
     /// Awaits any in-flight background backfill of older transcript messages
@@ -365,14 +485,7 @@ final class ACPSessionManager: ObservableObject {
 
     private func runHydration(id: ACPSession.ID, session: ACPSession) async {
         do {
-            let result: HydrationResult
-            if let hydrator {
-                result = try await hydrator.hydrate(sessionId: id)
-            } else {
-                // No off-main hydrator (test fallback): perform the same
-                // work synchronously via the manager's store.
-                result = try synchronousHydrate(id: id)
-            }
+            let result = try await persistence.hydrate(sessionId: id)
             // Drop the result if the captured session was closed (or closed
             // and reopened — the cached entry now points to a different
             // ACPSession instance) while we awaited. The fresh placeholder
@@ -385,72 +498,11 @@ final class ACPSessionManager: ObservableObject {
         }
     }
 
-    /// Synchronous hydration fallback used when no hydrator was wired in
-    /// (tests that construct the manager without a path). Same data, same
-    /// shape — just on the main thread.
-    private func synchronousHydrate(id: ACPSession.ID) throws -> HydrationResult {
-        guard let row = try store.loadSession(id: id) else {
-            throw ACPSessionHydrator.Error.sessionNotFound(id)
-        }
-        let stored = (try? store.loadMessages(sessionId: id)) ?? []
-        let storedDraft = try? store.loadComposerDraftRecord(sessionId: id)
-        let queue = (try? store.loadQueue(sessionId: id)) ?? []
-        var staleSubmittedDraft = false
-        var sawRecordedSubmittedDraft = false
-        var wire: [ACPMessageWire] = []
-        wire.reserveCapacity(stored.count)
-        let decoder = JSONDecoder()
-        for m in stored {
-            if let w = try? ACPMessageWire.decode(kind: m.kind, payload: m.payload, decoder: decoder) {
-                wire.append(w)
-                if storedDraft != nil,
-                   sawRecordedSubmittedDraft,
-                   w.isAgentSideProgress {
-                    staleSubmittedDraft = true
-                }
-                if let storedDraft,
-                   storedDraft.submittedRecovery,
-                   case .user(_, let text, let attachments) = w,
-                   storedDraft.draft.matchesSubmittedRecoveryPrompt(
-                    seq: m.seq,
-                    text: text,
-                    attachments: attachments,
-                    queue: queue,
-                    submittedAfterSeq: storedDraft.submittedAfterSeq)
-                {
-                    sawRecordedSubmittedDraft = true
-                }
-            }
-        }
-        let now = Int64(Date().timeIntervalSince1970)
-        try? store.touchLastOpenedAt(id: id, at: now)
-        let touched = ACPSessionRow(
-            id: row.id, agentId: row.agentId, title: row.title,
-            titleSource: row.titleSource,
-            remoteSessionId: row.remoteSessionId,
-            origin: row.origin,
-            contextRecoveryPending: row.contextRecoveryPending,
-            currentModel: row.currentModel, currentMode: row.currentMode,
-            autoRun: row.autoRun,
-            createdAt: row.createdAt, updatedAt: row.updatedAt,
-            lastOpenedAt: now,
-            archived: row.archived)
-        let recent = (try? store.recentSessions()) ?? []
-        let draft: ACPComposerDraft?
-        if staleSubmittedDraft, let storedDraft {
-            if (try? store.deleteComposerDraft(sessionId: id, matching: storedDraft)) == true {
-                draft = nil
-            } else {
-                draft = (try? store.loadComposerDraftRecord(sessionId: id))?.draft
-            }
-        } else {
-            draft = storedDraft?.draft
-        }
-        return HydrationResult(row: touched, wireMessages: wire,
-                               queue: queue, draft: draft, recent: recent)
-    }
-
     private func applyHydration(_ result: HydrationResult, to session: ACPSession) {
+        persistedRows[result.row.id] = result.row
+        for row in result.recent {
+            persistedRows[row.id] = row
+        }
         // Tail-first hydration: a long transcript would otherwise force an
         // O(N) main-actor pass to wrap every wire message in `StreamingText`
         // (a `@MainActor` class) before the first paint can land, freezing
@@ -471,12 +523,16 @@ final class ACPSessionManager: ObservableObject {
         session.restoreQueue(result.queue)
         // The composer is rendered (and focused) the moment the placeholder
         // appears, so the user can start typing before hydration finishes.
-        // Only restore the persisted draft when the live composer is still
-        // pristine (revision == 0); an intentional clear still bumps the
-        // revision, so it's distinguishable from "never edited" even though
-        // both leave `composerDraft.isEmpty == true`.
-        if let draft = result.draft, session.composerDraftRevision == 0 {
-            session.replaceComposerDraft(draft)
+        // Only restore the draft when the live composer is still pristine
+        // (revision == 0); an intentional clear still bumps the revision, so
+        // it's distinguishable from "never edited" even though both leave
+        // `composerDraft.isEmpty == true`.
+        if session.composerDraftRevision == 0 {
+            if let handoff = draftFlushHandoffs[session.id] {
+                session.replaceComposerDraft(handoff.draft)
+            } else if let draft = result.draft {
+                session.replaceComposerDraft(draft)
+            }
         }
         session.currentModel = result.row.currentModel
         session.currentMode = result.row.currentMode
@@ -679,8 +735,11 @@ final class ACPSessionManager: ObservableObject {
         transcriptScrollMemory.removeValue(forKey: id)
         pendingModel.removeValue(forKey: id)
         pendingMode.removeValue(forKey: id)
-        try? store.deleteSession(id: id)
-        refreshRecent()
+        persistedRows.removeValue(forKey: id)
+        recent.removeAll { $0.id == id }
+        enqueuePersistence { persistence in
+            try await persistence.deleteSession(id: id)
+        }
     }
 
     /// Increment the UI refcount for `id`. No-op if the session isn't
@@ -791,8 +850,8 @@ final class ACPSessionManager: ObservableObject {
         case .idle, .disconnected, .failed: break
         }
         guard (sessionRefCounts[id] ?? 0) == 0 else { return }
-        // Flush the debounced composer-draft write SYNCHRONOUSLY before
-        // dropping the in-memory session. Otherwise a typing burst that
+        // Submit the debounced composer-draft write before dropping the
+        // in-memory session. Otherwise a typing burst that
         // ends within the 300ms debounce window loses its tail when the
         // session is evicted — the timer task fires on a nil `sessions[id]`
         // and silently returns.
@@ -810,8 +869,14 @@ final class ACPSessionManager: ObservableObject {
     }
 
     func setArchived(id: ACPSession.ID, archived: Bool) {
-        try? store.setArchived(id: id, archived: archived)
-        refreshRecent()
+        if var row = persistedRows[id] {
+            row.archived = archived
+            persistedRows[id] = row
+        }
+        recent.removeAll { $0.id == id }
+        enqueuePersistence { persistence in
+            try await persistence.setArchived(id: id, archived: archived)
+        }
     }
 
     /// Persist a fresh trailing chunk of messages (`from..<session.transcript.messages.count`)
@@ -822,13 +887,27 @@ final class ACPSessionManager: ObservableObject {
         let now = Int64(Date().timeIntervalSince1970)
         let messages = session.transcript.messages
         guard from < messages.count else { return }
+        var rows: [ACPStoredMessage] = []
         for i in from..<messages.count {
             let m = messages[i]
             guard let payload = try? ACPMessageCodec.encode(m) else { continue }
             let id = "msg-\(session.id)-\(i)"
-            try? store.appendMessage(
-                sessionId: session.id, id: id, kind: m.kind,
-                seq: Int64(i), payload: payload, createdAt: now)
+            let sessionId = session.id
+            rows.append(ACPStoredMessage(
+                id: id,
+                sessionId: sessionId,
+                kind: m.kind,
+                seq: Int64(i),
+                payload: payload,
+                createdAt: now
+            ))
+        }
+        let messageRows = rows
+        let fence = leaseFence(sessionId: session.id)
+        if !messageRows.isEmpty {
+            enqueuePersistence { persistence in
+                _ = try await persistence.persistMessages(messageRows, fence: fence)
+            }
         }
     }
 
@@ -836,52 +915,62 @@ final class ACPSessionManager: ObservableObject {
     /// No-ops only when another live instance owns the writer lease (this pane
     /// is a mirror); the writer and not-yet-leased cases persist normally.
     func persist(_ s: ACPSession, preserveTitle: Bool = true) {
-        guard !anotherLiveInstanceOwnsLease(sessionId: s.id) else { return }
-        guard let row = try? store.loadSession(id: s.id) else { return }
+        guard !isMirror(sessionId: s.id) else { return }
+        guard var row = persistedRows[s.id] else { return }
         let now = Int64(Date().timeIntervalSince1970)
-        try? store.upsertSession(.init(
-            id: row.id, agentId: row.agentId, title: s.title,
-            titleSource: s.titleSource,
-            remoteSessionId: row.remoteSessionId,
-            origin: row.origin,
-            contextRecoveryPending: row.contextRecoveryPending,
-            currentModel: s.currentModel, currentMode: s.currentMode,
-            autoRun: s.autoRunEnabled,
-            createdAt: row.createdAt, updatedAt: now,
-            lastOpenedAt: row.lastOpenedAt, archived: row.archived),
-            preserveTitle: preserveTitle)
-        refreshRecent()
+        if !preserveTitle {
+            row.title = s.title
+            row.titleSource = s.titleSource
+        }
+        row.currentModel = s.currentModel
+        row.currentMode = s.currentMode
+        row.autoRun = s.autoRunEnabled
+        row.updatedAt = now
+        persistedRows[s.id] = row
+        replaceRecentRow(row)
+        let rowToPersist = row
+        let fence = leaseFence(sessionId: s.id)
+        enqueuePersistence { persistence in
+            _ = try await persistence.upsertSession(
+                rowToPersist,
+                preserveTitle: preserveTitle,
+                fence: fence
+            )
+        }
     }
 
     private func persistSessionRemoteId(_ s: ACPSession) {
-        guard let row = try? store.loadSession(id: s.id) else { return }
-        try? store.upsertSession(.init(
-            id: row.id,
-            agentId: row.agentId,
-            title: row.title,
-            titleSource: row.titleSource,
-            remoteSessionId: s.remoteSessionId,
-            origin: row.origin,
-            contextRecoveryPending: row.contextRecoveryPending,
-            currentModel: row.currentModel,
-            currentMode: row.currentMode,
-            autoRun: row.autoRun,
-            createdAt: row.createdAt,
-            updatedAt: row.updatedAt,
-            lastOpenedAt: row.lastOpenedAt,
-            archived: row.archived
-        ))
+        guard var row = persistedRows[s.id] else { return }
+        row.remoteSessionId = s.remoteSessionId
+        persistedRows[s.id] = row
+        replaceRecentRow(row)
+        let rowToPersist = row
+        let fence = leaseFence(sessionId: s.id)
+        enqueuePersistence { persistence in
+            _ = try await persistence.upsertSession(rowToPersist, fence: fence)
+        }
     }
 
     private func persistContextRecoveryPending(sessionId: ACPSession.ID, pending: Bool) {
-        try? store.setContextRecoveryPending(sessionId: sessionId, pending: pending)
+        if var row = persistedRows[sessionId] {
+            row.contextRecoveryPending = pending
+            persistedRows[sessionId] = row
+        }
+        let fence = leaseFence(sessionId: sessionId)
+        enqueuePersistence { persistence in
+            _ = try await persistence.setContextRecoveryPending(
+                sessionId: sessionId,
+                pending: pending,
+                fence: fence
+            )
+        }
     }
 
     /// Rename a session with the given title and source. Updates both
     /// the in-memory session and SQLite in one call. No-ops only when
     /// another live instance owns the writer lease (this pane is a mirror).
     func renameSession(id: ACPSession.ID, title: String, source: ACPSessionTitleSource) {
-        guard !anotherLiveInstanceOwnsLease(sessionId: id) else { return }
+        guard !isMirror(sessionId: id) else { return }
         guard let session = sessions[id] else { return }
         let trimmed = title.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !trimmed.isEmpty else { return }
@@ -894,22 +983,27 @@ final class ACPSessionManager: ObservableObject {
     func renameSessionCosmetic(id: ACPSession.ID, title: String, source: ACPSessionTitleSource) -> Bool {
         let trimmed = title.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !trimmed.isEmpty,
-              let row = try? store.loadSession(id: id),
+              var row = persistedRows[id],
               !row.archived else { return false }
         let now = Int64(Date().timeIntervalSince1970)
-        do {
-            guard try store.renameSession(id: id, title: trimmed, titleSource: source, updatedAt: now) else {
-                return false
-            }
-            if let session = sessions[id] {
-                session.title = trimmed
-                session.titleSource = source
-            }
-            refreshRecent()
-            return true
-        } catch {
-            return false
+        row.title = trimmed
+        row.titleSource = source
+        row.updatedAt = now
+        persistedRows[id] = row
+        replaceRecentRow(row)
+        if let session = sessions[id] {
+            session.title = trimmed
+            session.titleSource = source
         }
+        enqueuePersistence { persistence in
+            _ = try await persistence.renameSession(
+                id: id,
+                title: trimmed,
+                titleSource: source,
+                updatedAt: now
+            )
+        }
+        return true
     }
 
     func persistComposerDraft(_ draft: ACPComposerDraft, for session: ACPSession) {
@@ -923,7 +1017,11 @@ final class ACPSessionManager: ObservableObject {
     func clearComposerDraft(for session: ACPSession) {
         session.replaceComposerDraft(.empty)
         cancelPendingDraftWrite(for: session.id)
-        try? store.deleteComposerDraft(sessionId: session.id)
+        let sessionId = session.id
+        let fence = leaseFence(sessionId: sessionId)
+        enqueuePersistence { persistence in
+            _ = try await persistence.deleteComposerDraft(sessionId: sessionId, fence: fence)
+        }
     }
 
     private func scheduleDraftPersistence(for sessionId: ACPSession.ID) {
@@ -931,7 +1029,7 @@ final class ACPSessionManager: ObservableObject {
         pendingDraftWrites[sessionId] = Task { [weak self] in
             try? await Task.sleep(nanoseconds: Self.draftDebounceNanos)
             guard !Task.isCancelled else { return }
-            await self?.flushPendingDraftWrite(for: sessionId)
+            self?.flushPendingDraftWrite(for: sessionId)
         }
     }
 
@@ -942,11 +1040,30 @@ final class ACPSessionManager: ObservableObject {
         // the debounce window.
         guard let session = sessions[sessionId] else { return }
         let draft = session.composerDraft
+        let fence = leaseFence(sessionId: sessionId)
+        draftFlushHandoffSequence += 1
+        let handoffSequence = draftFlushHandoffSequence
+        draftFlushHandoffs[sessionId] = DraftFlushHandoff(draft: draft, sequence: handoffSequence)
+        let persistenceTask: Task<Void, Never>
         if draft.isEmpty {
-            try? store.deleteComposerDraft(sessionId: sessionId)
+            persistenceTask = enqueuePersistence { persistence in
+                _ = try await persistence.deleteComposerDraft(sessionId: sessionId, fence: fence)
+            }
         } else {
             let now = Int64(Date().timeIntervalSince1970)
-            try? store.upsertComposerDraft(sessionId: sessionId, draft: draft, updatedAt: now)
+            persistenceTask = enqueuePersistence { persistence in
+                try await persistence.upsertComposerDraft(
+                    sessionId: sessionId,
+                    draft: draft,
+                    updatedAt: now,
+                    fence: fence
+                )
+            }
+        }
+        Task { @MainActor [weak self] in
+            await persistenceTask.value
+            guard self?.draftFlushHandoffs[sessionId]?.sequence == handoffSequence else { return }
+            self?.draftFlushHandoffs.removeValue(forKey: sessionId)
         }
     }
 
@@ -955,9 +1072,8 @@ final class ACPSessionManager: ObservableObject {
         pendingDraftWrites[sessionId] = nil
     }
 
-    /// Flush every pending debounced draft write synchronously. Hook for
-    /// app-termination, scene resign, or tests that need a deterministic
-    /// post-write read.
+    /// Submit every pending debounced draft write to the ordered persistence
+    /// pipeline. Callers that require durability then await `flushPersistence`.
     func flushPendingDraftWrites() {
         for sessionId in Array(pendingDraftWrites.keys) {
             flushPendingDraftWrite(for: sessionId)
@@ -982,8 +1098,17 @@ final class ACPSessionManager: ObservableObject {
     /// mirror must not overwrite the active owner's queue. The writer and
     /// not-yet-leased cases persist normally.
     func persistQueue(for session: ACPSession) {
-        guard !anotherLiveInstanceOwnsLease(sessionId: session.id) else { return }
-        try? store.upsertQueue(sessionId: session.id, items: session.queue)
+        guard !isMirror(sessionId: session.id) else { return }
+        let sessionId = session.id
+        let items = session.queue
+        let fence = leaseFence(sessionId: sessionId)
+        enqueuePersistence { persistence in
+            _ = try await persistence.upsertQueue(
+                sessionId: sessionId,
+                items: items,
+                fence: fence
+            )
+        }
     }
 
     /// Eager-clear hook for an accepted composer submission. Synchronously
@@ -1010,14 +1135,20 @@ final class ACPSessionManager: ObservableObject {
         pendingDraftWrites[sid] = nil
         if !submitted.isEmpty {
             let now = Int64(Date().timeIntervalSince1970)
-            let submittedAfterSeq = try? store.latestMessageSeq(sessionId: sid)
-            try? store.upsertComposerDraft(
-                sessionId: sid,
-                draft: submitted,
-                updatedAt: now,
-                submittedRecovery: true,
-                submittedAfterSeq: submittedAfterSeq
-            )
+            let submittedAfterSeq = session.transcript.messages.isEmpty
+                ? nil
+                : Int64(session.transcript.messages.count - 1)
+            let fence = leaseFence(sessionId: sid)
+            enqueuePersistence { persistence in
+                try await persistence.upsertComposerDraft(
+                    sessionId: sid,
+                    draft: submitted,
+                    updatedAt: now,
+                    submittedRecovery: true,
+                    submittedAfterSeq: submittedAfterSeq,
+                    fence: fence
+                )
+            }
         }
         session.replaceComposerDraft(.empty)
         return session.composerDraftRevision
@@ -1033,7 +1164,11 @@ final class ACPSessionManager: ObservableObject {
         guard session.composerDraftRevision == suspendedRevision,
               session.composerDraft.isEmpty
         else { return }
-        try? store.deleteComposerDraft(sessionId: session.id)
+        let sessionId = session.id
+        let fence = leaseFence(sessionId: sessionId)
+        enqueuePersistence { persistence in
+            _ = try await persistence.deleteComposerDraft(sessionId: sessionId, fence: fence)
+        }
     }
 
     /// Restore the suspended draft back into memory when the prompt
@@ -1052,11 +1187,42 @@ final class ACPSessionManager: ObservableObject {
         else { return }
         session.replaceComposerDraft(submitted)
         let now = Int64(Date().timeIntervalSince1970)
-        try? store.upsertComposerDraft(sessionId: session.id, draft: submitted, updatedAt: now)
+        let sessionId = session.id
+        let fence = leaseFence(sessionId: sessionId)
+        enqueuePersistence { persistence in
+            try await persistence.upsertComposerDraft(
+                sessionId: sessionId,
+                draft: submitted,
+                updatedAt: now,
+                fence: fence
+            )
+        }
     }
 
     func refreshRecent() {
-        recent = (try? store.recentSessions()) ?? []
+        Task { @MainActor [weak self] in
+            await self?.refreshRecentNow()
+        }
+    }
+
+    func refreshRecentNow() async {
+        let persistence = persistence
+        do {
+            let rows = try await persistence.recentSessions()
+            recent = rows
+            for row in rows {
+                persistedRows[row.id] = row
+            }
+        } catch {
+            persistenceError = error.localizedDescription
+        }
+    }
+
+    private func replaceRecentRow(_ row: ACPSessionRow) {
+        recent.removeAll { $0.id == row.id }
+        guard !row.archived else { return }
+        let insertionIndex = recent.firstIndex { $0.lastOpenedAt < row.lastOpenedAt } ?? recent.endIndex
+        recent.insert(row, at: insertionIndex)
     }
 
     func makeSessionDiscoveryHandle(agentId: String) async throws -> ACPSessionDiscoveryHandle {
@@ -1078,7 +1244,7 @@ final class ACPSessionManager: ObservableObject {
                 worktreeId: worktreeId,
                 agentId: agentId,
                 cwd: worktreePath,
-                store: store,
+                persistence: persistence,
                 connection: connection,
                 capabilities: .init(
                     canLoad: initialized.loadSession,
@@ -1097,11 +1263,11 @@ final class ACPSessionManager: ObservableObject {
         _ discovered: ACPDiscoveredSession,
         autoRunDefault: Bool = false,
         origin: ACPSessionOrigin = .agentImported
-    ) -> ACPSessionRow? {
+    ) async -> ACPSessionRow? {
         let discoveredCWD = URL(fileURLWithPath: discovered.cwd).standardizedFileURL.path
         let managerCWD = URL(fileURLWithPath: worktreePath).standardizedFileURL.path
         guard discovered.worktreeId == worktreeId, discoveredCWD == managerCWD else { return nil }
-        if let existing = try? store.loadSession(
+        if let existing = try? await persistence.loadSession(
             agentId: discovered.agentId,
             remoteSessionId: discovered.remoteSessionId
         ) {
@@ -1128,10 +1294,12 @@ final class ACPSessionManager: ObservableObject {
             archived: false
         )
         do {
-            try store.upsertSession(row)
-            refreshRecent()
+            try await persistence.upsertSession(row)
+            persistedRows[row.id] = row
+            replaceRecentRow(row)
             return row
         } catch {
+            persistenceError = error.localizedDescription
             return nil
         }
     }
@@ -1140,8 +1308,8 @@ final class ACPSessionManager: ObservableObject {
     /// tool-call card when expanding a message whose in-memory content
     /// was truncated to save memory. Returns nil if the row is gone or
     /// the payload can't be decoded.
-    func reloadFullToolCallContent(sessionId: ACPSession.ID, toolCallId: String) -> String? {
-        try? store.loadToolCallContent(sessionId: sessionId, toolCallId: toolCallId)
+    func reloadFullToolCallContent(sessionId: ACPSession.ID, toolCallId: String) async -> String? {
+        try? await persistence.loadToolCallContent(sessionId: sessionId, toolCallId: toolCallId)
     }
 }
 
@@ -1155,95 +1323,143 @@ extension ACPSessionManager {
     /// Attempt to become the writer for `sessionId`. Returns true if we
     /// now hold the lease. Idempotent for a lease we already own.
     @discardableResult
-    func acquireWriterLease(sessionId: ACPSession.ID) -> Bool {
+    func acquireWriterLease(sessionId: ACPSession.ID) async -> Bool {
+        await flushPersistence()
         let now = Int64(Date().timeIntervalSince1970)
-        let won = (try? store.claimLease(
-            sessionId: sessionId, instanceId: instanceId, pid: pid,
-            now: now, staleAfter: Self.leaseStaleAfter)) ?? false
-        if won { _ownedLeases.insert(sessionId) } else { _ownedLeases.remove(sessionId) }
-        return won
+        let requestedToken = UUID().uuidString
+        do {
+            guard let lease = try await persistence.claimLease(
+                sessionId: sessionId,
+                instanceId: instanceId,
+                pid: pid,
+                now: now,
+                staleAfter: Self.leaseStaleAfter,
+                leaseToken: requestedToken
+            ) else {
+                let current = try? await persistence.loadLease(sessionId: sessionId)
+                observedLeases[sessionId] = current
+                _ownedLeases.remove(sessionId)
+                ownedLeaseTokens.removeValue(forKey: sessionId)
+                return false
+            }
+            observedLeases[sessionId] = lease
+            _ownedLeases.insert(sessionId)
+            ownedLeaseTokens[sessionId] = lease.token
+            return true
+        } catch {
+            persistenceError = error.localizedDescription
+            _ownedLeases.remove(sessionId)
+            ownedLeaseTokens.removeValue(forKey: sessionId)
+            return false
+        }
     }
 
-    func releaseWriterLease(sessionId: ACPSession.ID) {
-        try? store.releaseLease(sessionId: sessionId, instanceId: instanceId)
+    func releaseWriterLease(sessionId: ACPSession.ID) async {
+        await flushAllPersistence()
+        do {
+            try await persistence.releaseLease(
+                sessionId: sessionId,
+                instanceId: instanceId,
+                leaseToken: ownedLeaseTokens[sessionId]
+            )
+        } catch {
+            persistenceError = error.localizedDescription
+        }
         _ownedLeases.remove(sessionId)
+        ownedLeaseTokens.removeValue(forKey: sessionId)
+        observedLeases[sessionId] = nil
     }
 
-    /// True when this session is open here but owned by another live
-    /// instance (read-only mirror). Delegates to `anotherLiveInstanceOwnsLease`
-    /// so a stale former owner (still in `_ownedLeases`) is immediately treated
-    /// as read-only after a takeover ping, without waiting for the heartbeat.
+    /// True when this session is open here and the latest observed lease is
+    /// owned by another live instance.
     func isMirror(sessionId: ACPSession.ID) -> Bool {
-        anotherLiveInstanceOwnsLease(sessionId: sessionId)
-    }
-
-    /// True when a DIFFERENT, live instance currently owns this session's
-    /// lease in the store. Unlike `isMirror`, this does NOT short-circuit on
-    /// our in-memory `_ownedLeases`: during a takeover the former owner keeps
-    /// the id in `_ownedLeases` until its heartbeat catches up, so manager
-    /// writes must consult the store row directly to avoid writing to a
-    /// session another instance now owns.
-    private func anotherLiveInstanceOwnsLease(sessionId: ACPSession.ID) -> Bool {
-        guard let lease = try? store.loadLease(sessionId: sessionId) else { return false }
+        if _ownedLeases.contains(sessionId) { return false }
+        guard let observed = observedLeases[sessionId] else {
+            return isAwaitingInitialLeaseObservation(sessionId: sessionId)
+        }
+        guard let lease = observed else { return false }
         return lease.ownerInstance != instanceId
             && ACPProcessLiveness.pidAlive(lease.pid)
             && lease.heartbeatAt >= Int64(Date().timeIntervalSince1970) - Self.leaseStaleAfter
+    }
+
+    private func isAwaitingInitialLeaseObservation(sessionId: ACPSession.ID) -> Bool {
+        guard let session = sessions[sessionId],
+              session.restoredFromPersistence
+        else { return false }
+        return session.hydrationState == .loading || session.agentState == .spawning
+    }
+
+    /// True when the latest off-main lease read observed a different live
+    /// owner. This never performs SQLite work on the main actor.
+    private func anotherLiveInstanceOwnsLease(sessionId: ACPSession.ID) -> Bool {
+        guard let observed = observedLeases[sessionId], let lease = observed else { return false }
+        return lease.ownerInstance != instanceId
+            && ACPProcessLiveness.pidAlive(lease.pid)
+            && lease.heartbeatAt >= Int64(Date().timeIntervalSince1970) - Self.leaseStaleAfter
+    }
+
+    private func leaseFence(sessionId: ACPSession.ID) -> ACPSessionLeaseFence? {
+        guard _ownedLeases.contains(sessionId),
+              let token = ownedLeaseTokens[sessionId] else { return nil }
+        return ACPSessionLeaseFence(
+            sessionId: sessionId,
+            ownerInstance: instanceId,
+            token: token
+        )
     }
 
     /// Whether the instance currently writing this mirrored session is
     /// actively streaming (drives the mirror's busy spinner). Reads the
     /// lease status written by the owner's heartbeat.
     func mirrorIsBusy(sessionId: ACPSession.ID) -> Bool {
-        guard let lease = try? store.loadLease(sessionId: sessionId) else { return false }
+        guard let observed = observedLeases[sessionId], let lease = observed else { return false }
         return lease.status == "busy"
     }
 
     /// One heartbeat tick for an owned session. Returns true if the
     /// caller should stand down (we lost the lease to another instance).
-    /// Side effects: refreshes our heartbeat when we still own the row,
-    /// or re-asserts ownership (re-inserts) when the row has gone missing
-    /// while we still believe we own it (e.g. a failed concurrent takeover
-    /// deleted it) — preventing a rowless session another instance could
-    /// claim out from under us.
+    /// Side effects: refreshes our heartbeat when we still own the row. A
+    /// missing or differently owned row fails closed and requests stand-down.
     // exposed for tests
     @discardableResult
-    func heartbeatTick(sessionId: ACPSession.ID) -> Bool {
+    func heartbeatTick(sessionId: ACPSession.ID) async -> Bool {
         guard _ownedLeases.contains(sessionId) else { return false }
         let now = Int64(Date().timeIntervalSince1970)
-        if let lease = try? store.loadLease(sessionId: sessionId) {
+        do {
+            guard let lease = try await persistence.loadLease(sessionId: sessionId) else {
+                observedLeases[sessionId] = nil
+                return true
+            }
+            observedLeases[sessionId] = lease
             if lease.ownerInstance != instanceId {
                 return true   // taken over → stand down
             }
             // Still ours — refresh heartbeat + status.
             let status = runners[sessionId]?.session.transcript.streamingState == .streaming
                 ? "busy" : "idle"
-            try? store.refreshHeartbeat(
+            try await persistence.refreshHeartbeat(
                 sessionId: sessionId, instanceId: instanceId, now: now, status: status)
             return false
-        } else {
-            // Row missing but we believe we own it — re-assert ownership so
-            // the session isn't left rowless and claimable by another instance.
-            try? store.seizeLease(sessionId: sessionId, instanceId: instanceId, pid: pid, now: now)
+        } catch {
+            persistenceError = error.localizedDescription
             return false
         }
     }
 
     private func startHeartbeat(sessionId: ACPSession.ID) {
         _heartbeatTasks[sessionId]?.cancel()
-        _heartbeatTasks[sessionId] = Task { [weak self] in
+        _heartbeatTasks[sessionId] = Task { @MainActor [weak self] in
             // Refresh immediately so the just-claimed lease doesn't rely on
             // the first 5s tick (a slow initialize/newSession could otherwise
             // let the heartbeat age past leaseStaleAfter mid-attach).
-            await MainActor.run {
-                guard let self else { return }
-                if self.heartbeatTick(sessionId: sessionId) {
-                    Task { await self.standDown(sessionId: sessionId) }
-                }
+            guard let self else { return }
+            if await self.heartbeatTick(sessionId: sessionId) {
+                await self.standDown(sessionId: sessionId)
             }
             while !Task.isCancelled {
                 try? await Task.sleep(nanoseconds: 5_000_000_000)   // 5s
-                guard let self else { return }
-                let shouldStandDown = await MainActor.run { self.heartbeatTick(sessionId: sessionId) }
+                let shouldStandDown = await self.heartbeatTick(sessionId: sessionId)
                 if shouldStandDown {
                     await self.standDown(sessionId: sessionId)
                 }
@@ -1273,17 +1489,13 @@ extension ACPSessionManager {
 
     private func scheduleWriterOwnershipCheck(sessionId: ACPSession.ID) {
         writerWatchDebounce[sessionId]?.cancel()
-        writerWatchDebounce[sessionId] = Task { [weak self] in
+        writerWatchDebounce[sessionId] = Task { @MainActor [weak self] in
             // 100 ms coalesce window: the writer itself posts a ping on every
             // persist, so we debounce to avoid checking on each of those.
             try? await Task.sleep(nanoseconds: 100_000_000)
-            guard let self else { return }
-            await MainActor.run {
-                guard self._ownedLeases.contains(sessionId) else { return }
-                if self.heartbeatTick(sessionId: sessionId) {
-                    self._ownedLeases.remove(sessionId)
-                    Task { await self.standDown(sessionId: sessionId) }
-                }
+            guard let self, self._ownedLeases.contains(sessionId) else { return }
+            if await self.heartbeatTick(sessionId: sessionId) {
+                await self.standDown(sessionId: sessionId)
             }
         }
     }
@@ -1308,10 +1520,34 @@ extension ACPSessionManager {
     /// writer (re-attaching to the remote session via session/load inside
     /// `attach`). The previous owner stands down when its heartbeat sees
     /// it no longer owns the lease (within ~5s).
-    func takeOver(sessionId: ACPSession.ID) {
+    @discardableResult
+    func takeOver(sessionId: ACPSession.ID) async -> Bool {
         let now = Int64(Date().timeIntervalSince1970)
-        try? store.seizeLease(sessionId: sessionId, instanceId: instanceId, pid: pid, now: now)
+        let requestedToken = UUID().uuidString
+        let lease: ACPSessionLease
+        do {
+            lease = try await persistence.seizeLease(
+                sessionId: sessionId,
+                instanceId: instanceId,
+                pid: pid,
+                now: now,
+                leaseToken: requestedToken
+            )
+        } catch {
+            persistenceError = error.localizedDescription
+            return false
+        }
+        guard sessions[sessionId] != nil else {
+            try? await persistence.releaseLease(
+                sessionId: sessionId,
+                instanceId: instanceId,
+                leaseToken: lease.token
+            )
+            return false
+        }
         _ownedLeases.insert(sessionId)
+        ownedLeaseTokens[sessionId] = lease.token
+        observedLeases[sessionId] = lease
         changeNotifier.post()
         startHeartbeat(sessionId: sessionId)
         startWriterWatch(sessionId: sessionId)
@@ -1324,8 +1560,9 @@ extension ACPSessionManager {
             // the store row here fixes that before attach branches on it.
             // Only overwrite when the store has a non-empty value so we
             // don't clobber a good in-memory id with a missing row.
-            if let row = try? store.loadSession(id: sessionId),
+            if let row = try? await persistence.loadSession(id: sessionId),
                let remote = row.remoteSessionId, !remote.isEmpty {
+                persistedRows[sessionId] = row
                 session.remoteSessionId = remote
             }
             // Refresh the queue from the store so the taking-over instance
@@ -1333,7 +1570,7 @@ extension ACPSessionManager {
             // stale/empty in-memory state the mirror cached. Queue writes
             // don't post a change notification, so the mirror's in-memory
             // queue can be stale at takeover time.
-            let queue = (try? store.loadQueue(sessionId: sessionId)) ?? []
+            let queue = (try? await persistence.loadQueue(sessionId: sessionId)) ?? []
             session.restoreQueue(queue)
             // Block immediate sends while the final mirror snapshot catches
             // the cached transcript up to the store before writer attach.
@@ -1349,6 +1586,7 @@ extension ACPSessionManager {
         } else {
             endMirroring(sessionId: sessionId)
         }
+        return true
     }
 
     /// Relinquish the writer role we just lost to a takeover: cancel any
@@ -1365,6 +1603,7 @@ extension ACPSessionManager {
         if let runner = runners.removeValue(forKey: sessionId) {
             runner.invalidateActivePrompt()
             runner.stop()
+            await runner.flushPersistence()
             await runner.connection.shutdown()
         }
         elicitationCoordinators.removeValue(forKey: sessionId)?.stop()
@@ -1388,8 +1627,8 @@ extension ACPSessionManager {
     /// registering a runner on a disposed manager.
     func isDisposedForTest() -> Bool { isDisposed }
 
-    func ownsLeaseForTest(sessionId: ACPSession.ID) -> Bool {
-        (try? store.loadLease(sessionId: sessionId))?.ownerInstance == instanceId
+    func ownsLeaseForTest(sessionId: ACPSession.ID) async -> Bool {
+        (try? await persistence.loadLease(sessionId: sessionId))?.ownerInstance == instanceId
     }
 
     /// True while an `attach` coroutine holds the lease for `sessionId`
@@ -1399,8 +1638,8 @@ extension ACPSessionManager {
         attachingSessions.contains(sessionId)
     }
 
-    func heartbeatTickForTest(sessionId: ACPSession.ID) -> Bool {
-        heartbeatTick(sessionId: sessionId)
+    func heartbeatTickForTest(sessionId: ACPSession.ID) async -> Bool {
+        await heartbeatTick(sessionId: sessionId)
     }
 
     /// True when a mirror poll task is active for `sessionId`. Used by
@@ -1469,10 +1708,9 @@ extension ACPSessionManager {
     /// `connection.shutdown`, preserving the correct teardown order. The lease
     /// is never leaked — it is either released by the attach defer on abort, or
     /// goes stale in 15 s if the attach coroutine is permanently wedged.
-    func releaseAllOwnedLeases() {
+    func releaseAllOwnedLeases() async {
         for sid in Array(_ownedLeases) where !attachingSessions.contains(sid) {
-            try? store.releaseLease(sessionId: sid, instanceId: instanceId)
-            _ownedLeases.remove(sid)
+            await releaseWriterLease(sessionId: sid)
         }
     }
 
@@ -1496,7 +1734,7 @@ extension ACPSessionManager {
         mirrorPoll[sessionId]?.cancel()
         mirrorPoll[sessionId] = Task { [weak self] in
             while !Task.isCancelled {
-                let interval = await self?.mirrorPollIntervalNanos(sessionId: sessionId)
+                let interval = self?.mirrorPollIntervalNanos(sessionId: sessionId)
                     ?? ACPMirrorRefreshPolicy.inactivePollNanos
                 try? await Task.sleep(nanoseconds: interval)
                 guard !Task.isCancelled else { return }
@@ -1546,11 +1784,8 @@ extension ACPSessionManager {
         guard let session = sessions[sessionId] else { return }
         let result: HydrationResult
         do {
-            if let hydrator {
-                result = try await hydrator.mirrorSnapshot(sessionId: sessionId)
-            } else {
-                result = try synchronousMirrorSnapshot(id: sessionId)
-            }
+            result = try await persistence.mirrorSnapshot(sessionId: sessionId)
+            observedLeases[sessionId] = try await persistence.loadLease(sessionId: sessionId)
         } catch {
             return
         }
@@ -1571,29 +1806,12 @@ extension ACPSessionManager {
             session: session)
     }
 
-    private func synchronousMirrorSnapshot(id: ACPSession.ID) throws -> HydrationResult {
-        guard let row = try store.loadSession(id: id) else {
-            throw ACPSessionHydrator.Error.sessionNotFound(id)
-        }
-        let stored = (try? store.loadMessages(sessionId: id)) ?? []
-        var wire: [ACPMessageWire] = []
-        wire.reserveCapacity(stored.count)
-        let decoder = JSONDecoder()
-        for m in stored {
-            if let w = try? ACPMessageWire.decode(kind: m.kind, payload: m.payload, decoder: decoder) {
-                wire.append(w)
-            }
-        }
-        let queue = (try? store.loadQueue(sessionId: id)) ?? []
-        let recent = (try? store.recentSessions()) ?? []
-        return HydrationResult(row: row, wireMessages: wire, queue: queue, draft: nil, recent: recent)
-    }
-
     private func syncMirrorSessionMetadata(
         _ row: ACPSessionRow,
         to session: ACPSession,
         recentRows: [ACPSessionRow]? = nil
     ) {
+        persistedRows[row.id] = row
         let titleChanged = session.title != row.title || session.titleSource != row.titleSource
         session.title = row.title
         session.titleSource = row.titleSource
@@ -1603,7 +1821,12 @@ extension ACPSessionManager {
         if session.remoteSessionId == nil || session.remoteSessionId == row.remoteSessionId {
             session.remoteSessionId = row.remoteSessionId
         }
-        recent = recentRows ?? (try? store.recentSessions()) ?? []
+        if let recentRows {
+            recent = recentRows
+            for recentRow in recentRows {
+                persistedRows[recentRow.id] = recentRow
+            }
+        }
         if titleChanged {
             onSessionTitleUpdated?(row.id, row.title)
         }
@@ -1644,7 +1867,7 @@ extension ACPSessionManager {
         session.agentState = .spawning
         // Only the lease holder runs a live agent + writes. If another
         // live instance owns this session, stay a read-only mirror.
-        guard acquireWriterLease(sessionId: sessionId) else {
+        guard await acquireWriterLease(sessionId: sessionId) else {
             session.agentState = .idle
             beginMirroring(sessionId: sessionId)
             return
@@ -1664,7 +1887,6 @@ extension ACPSessionManager {
             if !attachSucceeded {
                 stopHeartbeat(sessionId: sessionId)
                 stopWriterWatch(sessionId: sessionId)
-                releaseWriterLease(sessionId: sessionId)
             }
         }
         // The runner persists transcript mutations under `msg-<sid>-<index>`,
@@ -1679,7 +1901,10 @@ extension ACPSessionManager {
         await awaitBackfill(id: sessionId)
         // Re-verify the session still exists; a close during the await above
         // would have cleared it.
-        guard sessions[sessionId] === session else { return }
+        guard sessions[sessionId] === session else {
+            await releaseWriterLease(sessionId: sessionId)
+            return
+        }
         // Drop any stale runner left over from a prior process (e.g. the
         // runner's stream-end branch flipped agentState to .disconnected
         // but did not unregister itself). The .ready/.spawning early-return
@@ -1688,6 +1913,7 @@ extension ACPSessionManager {
         // is a zombie whose update task already exited.
         if let stale = runners[sessionId] {
             stale.stop()
+            await stale.flushPersistence()
         }
         runners[sessionId] = nil
         elicitationCoordinators.removeValue(forKey: sessionId)?.stop()
@@ -1703,12 +1929,14 @@ extension ACPSessionManager {
             let reason = "No ACP launch spec for \(session.agentId)"
             session.setupState = .needsSetup(reason: reason)
             session.agentState = .failed(reason)
+            await releaseWriterLease(sessionId: sessionId)
             return
         }
         let setup = await setupEvaluator(spec)
         guard case .ready = setup else {
             session.setupState = .needsSetup(reason: setup.reasonText)
             session.agentState = .failed(setup.reasonText)
+            await releaseWriterLease(sessionId: sessionId)
             return
         }
         session.setupState = .ready
@@ -1723,6 +1951,7 @@ extension ACPSessionManager {
             let msg = "Failed to launch agent: \(error.localizedDescription)"
             session.lastError = msg
             session.agentState = .failed(msg)
+            await releaseWriterLease(sessionId: sessionId)
             return
         }
         // Collect a short tail of stderr so we can surface it when the
@@ -1796,7 +2025,7 @@ extension ACPSessionManager {
                 && session.hasConversationTranscript
                 && !(session.remoteSessionId ?? "").isEmpty
             let runner = ACPSessionRunner(session: session, connection: connection,
-                                          store: store, sessionId: sessionId,
+                                          sessionId: sessionId,
                                           worktreePath: worktreePath,
                                           agentEnv: agentEnvironment,
                                           suppressingLoadReplay: shouldSuppressLoadReplay,
@@ -1825,7 +2054,18 @@ extension ACPSessionManager {
                                                 followsTail: true
                                               )
                                           },
-                                          ownerInstanceId: instanceId)
+                                          ownerInstanceId: instanceId,
+                                          persistence: persistence,
+                                          persistedMessageCount: session.transcript.messages.count,
+                                          canWrite: { [weak self] in
+                                              self?.isWriter(for: sessionId) == true
+                                          },
+                                          validateLease: { [weak self] in
+                                              await self?.confirmedWriterLease(for: sessionId) == true
+                                          },
+                                          leaseFenceProvider: { [weak self] in
+                                              self?.leaseFence(sessionId: sessionId)
+                                          })
             var runnerStarted = false
             func startRunnerIfNeeded() {
                 guard !runnerStarted else { return }
@@ -1836,7 +2076,7 @@ extension ACPSessionManager {
             if shouldSuppressLoadReplay {
                 startRunnerIfNeeded()
             }
-            let pendingRecovery = (try? store.loadSession(id: sessionId)?.contextRecoveryPending) == true
+            let pendingRecovery = persistedRows[sessionId]?.contextRecoveryPending == true
             let result: ACPSessionNewResult
             var restoreWarning: ACPSession.ContextRestoreWarning?
             let hasRestorableContext = pendingRecovery || session.hasConversationTranscript
@@ -1871,7 +2111,7 @@ extension ACPSessionManager {
                         result = try await connection.newSession(cwd: worktreePath, mcpServers: mcpPlan.wireServers)
                         if session.hasConversationTranscript {
                             shouldHoldQueueForRecovery = true
-                            if !anotherLiveInstanceOwnsLease(sessionId: sessionId) {
+                            if isWriter(for: sessionId) {
                                 persistContextRecoveryPending(sessionId: sessionId, pending: true)
                             }
                         }
@@ -1924,7 +2164,7 @@ extension ACPSessionManager {
                             // Guard the store write: if another instance took over
                             // while we were awaiting loadSession/newSession, do not
                             // persist recovery state to a session we no longer own.
-                            if !anotherLiveInstanceOwnsLease(sessionId: sessionId) {
+                            if isWriter(for: sessionId) {
                                 persistContextRecoveryPending(sessionId: sessionId, pending: true)
                             }
                         }
@@ -1948,7 +2188,7 @@ extension ACPSessionManager {
                     // Guard the store write: if another instance took over
                     // while we were awaiting newSession, do not persist
                     // recovery state to a session we no longer own.
-                    if !anotherLiveInstanceOwnsLease(sessionId: sessionId) {
+                    if isWriter(for: sessionId) {
                         persistContextRecoveryPending(sessionId: sessionId, pending: true)
                     }
                 }
@@ -1976,11 +2216,19 @@ extension ACPSessionManager {
             // persist for a session we no longer (or never will) own.
             // `attachSucceeded` stays false so the defer releases the lease
             // and stops the heartbeat/writerWatch.
-            if isDisposed || anotherLiveInstanceOwnsLease(sessionId: sessionId) {
+            let shouldAbortAttach: Bool
+            if isDisposed {
+                shouldAbortAttach = true
+            } else {
+                shouldAbortAttach = !(await confirmedWriterLease(for: sessionId))
+            }
+            if shouldAbortAttach {
                 await connection.shutdown()
                 startedRunner?.stop()
+                await startedRunner?.flushPersistence()
                 session.agentState = .idle
                 if !isDisposed { beginMirroring(sessionId: sessionId) }   // don't start a mirror on a disposed manager
+                await releaseWriterLease(sessionId: sessionId)
                 return
             }
             session.remoteSessionId = result.sessionId
@@ -1992,6 +2240,7 @@ extension ACPSessionManager {
             session.availableConfigOptions = result.configOptions
             session.contextRestoreWarning = restoreWarning
             persistSessionRemoteId(session)
+            await flushPersistence()
             startRunnerIfNeeded()
             runners[sessionId] = runner
             keepElicitationCoordinator = true
@@ -2039,7 +2288,9 @@ extension ACPSessionManager {
                 session.agentState = .failed(full)
             }
             startedRunner?.stop()
+            await startedRunner?.flushPersistence()
             await connection.shutdown()
+            await releaseWriterLease(sessionId: sessionId)
         }
     }
 
@@ -2107,10 +2358,14 @@ extension ACPSessionManager {
         guard let session = sessions[sessionId] else { return }
         let blocks = ACPSessionRunner.blocks(text: text, attachments: attachments)
         session.enqueue(blocks: blocks, draft: draft)
-        do {
-            try store.upsertQueue(sessionId: sessionId, items: session.queue)
-        } catch {
-            session.lastError = "Failed to persist queued prompt: \(error.localizedDescription)"
+        let items = session.queue
+        let fence = leaseFence(sessionId: sessionId)
+        enqueuePersistence { persistence in
+            _ = try await persistence.upsertQueue(
+                sessionId: sessionId,
+                items: items,
+                fence: fence
+            )
         }
     }
 
@@ -2206,6 +2461,7 @@ extension ACPSessionManager {
             session.restoreQueue(session.queue)
         }
         runner.stop()
+        await runner.flushPersistence()
         runners[sessionId] = nil
         elicitationCoordinators.removeValue(forKey: sessionId)?.stop()
         await runner.connection.shutdown()
@@ -2242,12 +2498,13 @@ extension ACPSessionManager {
             // head can come back as cleanly `.pending` after restoreQueue.
             runner.invalidateActivePrompt()
             runner.stop()
+            await runner.flushPersistence()
             await runner.connection.shutdown()
         }
         elicitationCoordinators.removeValue(forKey: sessionId)?.stop()
         stopHeartbeat(sessionId: sessionId)
         stopWriterWatch(sessionId: sessionId)
-        releaseWriterLease(sessionId: sessionId)
+        await releaseWriterLease(sessionId: sessionId)
         endMirroring(sessionId: sessionId)
         // SwiftUI's `.onDisappear` retain release for a closing tab can
         // arrive BEFORE this async detach starts, so the release runs while

--- a/Alas/Sources/ACP/Session/ACPSessionPersistence.swift
+++ b/Alas/Sources/ACP/Session/ACPSessionPersistence.swift
@@ -1,0 +1,475 @@
+import Foundation
+import SQLite3
+
+/// Serial, off-main owner of a worktree's writable ACP session store.
+///
+/// The initializer only records a path. Opening SQLite and running migrations
+/// happen on this actor's executor when the first operation is awaited, so
+/// constructing a manager on `MainActor` never performs database I/O.
+actor ACPSessionPersistence {
+    nonisolated let path: String
+
+    private let busyTimeoutMilliseconds: Int32
+    private var store: ACPSessionStore?
+    private var hydrator: ACPSessionHydrator?
+
+    init(path: String, busyTimeoutMilliseconds: Int32 = 5_000) {
+        self.path = path
+        self.busyTimeoutMilliseconds = busyTimeoutMilliseconds
+    }
+
+    private func openedStore() throws -> ACPSessionStore {
+        if let store { return store }
+        let opened = try ACPSessionStore(
+            path: path,
+            busyTimeoutMilliseconds: busyTimeoutMilliseconds
+        )
+        store = opened
+        return opened
+    }
+
+    private func openedHydrator() throws -> ACPSessionHydrator {
+        if let hydrator { return hydrator }
+        let opened = try ACPSessionHydrator(path: path)
+        hydrator = opened
+        return opened
+    }
+
+    func prepare() throws {
+        _ = try openedStore()
+    }
+
+    func hydrate(sessionId: String) async throws -> HydrationResult {
+        try await openedHydrator().hydrate(sessionId: sessionId)
+    }
+
+    func mirrorSnapshot(sessionId: String) async throws -> HydrationResult {
+        try await openedHydrator().mirrorSnapshot(sessionId: sessionId)
+    }
+
+    func recentSessions(limit: Int = 50) throws -> [ACPSessionRow] {
+        try openedStore().recentSessions(limit: limit)
+    }
+
+    func loadSession(id: String) throws -> ACPSessionRow? {
+        try openedStore().loadSession(id: id)
+    }
+
+    func loadSession(agentId: String, remoteSessionId: String) throws -> ACPSessionRow? {
+        try openedStore().loadSession(agentId: agentId, remoteSessionId: remoteSessionId)
+    }
+
+    func upsertSession(_ row: ACPSessionRow, preserveTitle: Bool = false) throws {
+        try openedStore().upsertSession(row, preserveTitle: preserveTitle)
+    }
+
+    @discardableResult
+    func upsertSession(
+        _ row: ACPSessionRow,
+        preserveTitle: Bool = false,
+        fence: ACPSessionLeaseFence?
+    ) throws -> Bool {
+        let store = try openedStore()
+        let operation = { try store.upsertSession(row, preserveTitle: preserveTitle) }
+        if let fence { return try store.withLeaseFence(fence, operation) != nil }
+        try operation()
+        return true
+    }
+
+    @discardableResult
+    func updateSessionFromRuntime(
+        id: String,
+        title: String,
+        titleSource: ACPSessionTitleSource,
+        currentModel: String?,
+        currentMode: String?,
+        autoRun: Bool,
+        preserveTitle: Bool,
+        fence: ACPSessionLeaseFence?
+    ) throws -> ACPSessionRow? {
+        let store = try openedStore()
+        let operation = {
+            guard var row = try store.loadSession(id: id) else { return nil as ACPSessionRow? }
+            if !preserveTitle {
+                row.title = title
+                row.titleSource = titleSource
+            }
+            row.currentModel = currentModel
+            row.currentMode = currentMode
+            row.autoRun = autoRun
+            row.updatedAt = Int64(Date().timeIntervalSince1970)
+            try store.upsertSession(row, preserveTitle: preserveTitle)
+            return row
+        }
+        if let fence {
+            return try store.withLeaseFence(fence, operation) ?? nil
+        }
+        return try operation()
+    }
+
+    func touchLastOpenedAt(id: String, at timestamp: Int64) throws {
+        try openedStore().touchLastOpenedAt(id: id, at: timestamp)
+    }
+
+    func setContextRecoveryPending(sessionId: String, pending: Bool) throws {
+        try openedStore().setContextRecoveryPending(sessionId: sessionId, pending: pending)
+    }
+
+    @discardableResult
+    func setContextRecoveryPending(
+        sessionId: String,
+        pending: Bool,
+        fence: ACPSessionLeaseFence?
+    ) throws -> Bool {
+        let store = try openedStore()
+        let operation = { try store.setContextRecoveryPending(sessionId: sessionId, pending: pending) }
+        if let fence { return try store.withLeaseFence(fence, operation) != nil }
+        try operation()
+        return true
+    }
+
+    func deleteSession(id: String) throws {
+        try openedStore().deleteSession(id: id)
+    }
+
+    func setArchived(id: String, archived: Bool) throws {
+        try openedStore().setArchived(id: id, archived: archived)
+    }
+
+    func renameSession(
+        id: String,
+        title: String,
+        titleSource: ACPSessionTitleSource,
+        updatedAt: Int64
+    ) throws -> Bool {
+        try openedStore().renameSession(
+            id: id,
+            title: title,
+            titleSource: titleSource,
+            updatedAt: updatedAt
+        )
+    }
+
+    func updateGeneratedTitleIfPlaceholder(id: String, title: String, updatedAt: Int64) throws -> Bool {
+        try openedStore().updateGeneratedTitleIfPlaceholder(id: id, title: title, updatedAt: updatedAt)
+    }
+
+    func updateGeneratedTitleIfPlaceholder(
+        id: String,
+        title: String,
+        updatedAt: Int64,
+        fence: ACPSessionLeaseFence?
+    ) throws -> Bool {
+        let store = try openedStore()
+        let operation = {
+            try store.updateGeneratedTitleIfPlaceholder(id: id, title: title, updatedAt: updatedAt)
+        }
+        if let fence { return try store.withLeaseFence(fence, operation) ?? false }
+        return try operation()
+    }
+
+    func updateGeneratedTitleIfNotManual(id: String, title: String, updatedAt: Int64) throws -> Bool {
+        try openedStore().updateGeneratedTitleIfNotManual(id: id, title: title, updatedAt: updatedAt)
+    }
+
+    func updateGeneratedTitleIfNotManual(
+        id: String,
+        title: String,
+        updatedAt: Int64,
+        fence: ACPSessionLeaseFence?
+    ) throws -> Bool {
+        let store = try openedStore()
+        let operation = {
+            try store.updateGeneratedTitleIfNotManual(id: id, title: title, updatedAt: updatedAt)
+        }
+        if let fence { return try store.withLeaseFence(fence, operation) ?? false }
+        return try operation()
+    }
+
+    func clearGeneratedTitleIfNotManual(id: String, updatedAt: Int64) throws -> Bool {
+        try openedStore().clearGeneratedTitleIfNotManual(id: id, updatedAt: updatedAt)
+    }
+
+    func clearGeneratedTitleIfNotManual(
+        id: String,
+        updatedAt: Int64,
+        fence: ACPSessionLeaseFence?
+    ) throws -> Bool {
+        let store = try openedStore()
+        let operation = { try store.clearGeneratedTitleIfNotManual(id: id, updatedAt: updatedAt) }
+        if let fence { return try store.withLeaseFence(fence, operation) ?? false }
+        return try operation()
+    }
+
+    func loadComposerDraftRecord(sessionId: String) throws -> ACPStoredComposerDraft? {
+        try openedStore().loadComposerDraftRecord(sessionId: sessionId)
+    }
+
+    func upsertComposerDraft(
+        sessionId: String,
+        draft: ACPComposerDraft,
+        updatedAt: Int64,
+        submittedRecovery: Bool = false,
+        submittedAfterSeq: Int64? = nil
+    ) throws {
+        try openedStore().upsertComposerDraft(
+            sessionId: sessionId,
+            draft: draft,
+            updatedAt: updatedAt,
+            submittedRecovery: submittedRecovery,
+            submittedAfterSeq: submittedAfterSeq
+        )
+    }
+
+    @discardableResult
+    func upsertComposerDraft(
+        sessionId: String,
+        draft: ACPComposerDraft,
+        updatedAt: Int64,
+        submittedRecovery: Bool = false,
+        submittedAfterSeq: Int64? = nil,
+        fence: ACPSessionLeaseFence?
+    ) throws -> Bool {
+        let store = try openedStore()
+        let operation = {
+            try store.upsertComposerDraft(
+                sessionId: sessionId,
+                draft: draft,
+                updatedAt: updatedAt,
+                submittedRecovery: submittedRecovery,
+                submittedAfterSeq: submittedAfterSeq
+            )
+        }
+        if let fence { return try store.withLeaseFence(fence, operation) != nil }
+        try operation()
+        return true
+    }
+
+    func deleteComposerDraft(sessionId: String) throws {
+        try openedStore().deleteComposerDraft(sessionId: sessionId)
+    }
+
+    @discardableResult
+    func deleteComposerDraft(
+        sessionId: String,
+        fence: ACPSessionLeaseFence?
+    ) throws -> Bool {
+        let store = try openedStore()
+        let operation = { try store.deleteComposerDraft(sessionId: sessionId) }
+        if let fence { return try store.withLeaseFence(fence, operation) != nil }
+        try operation()
+        return true
+    }
+
+    func deleteComposerDraft(sessionId: String, matching stored: ACPStoredComposerDraft) throws -> Bool {
+        try openedStore().deleteComposerDraft(sessionId: sessionId, matching: stored)
+    }
+
+    @discardableResult
+    func recordPermissionDecision(
+        sessionId: String,
+        scopeKey: String,
+        decision: ACPPermissionDecision,
+        scope: ACPPermissionScopeKind,
+        fence: ACPSessionLeaseFence?
+    ) throws -> Bool {
+        let store = try openedStore()
+        let decidedAt = Int64(Date().timeIntervalSince1970)
+        let operation = {
+            try store.recordPermissionDecision(
+                sessionId: sessionId,
+                scopeKey: scopeKey,
+                decision: decision,
+                scope: scope,
+                decidedAt: decidedAt
+            )
+        }
+        if let fence { return try store.withLeaseFence(fence, operation) != nil }
+        try operation()
+        return true
+    }
+
+    func lookupPermissionDecision(sessionId: String, scopeKey: String) throws -> ACPPermissionDecision? {
+        try openedStore().lookupPermissionDecision(sessionId: sessionId, scopeKey: scopeKey)
+    }
+
+    func appendMessage(
+        sessionId: String,
+        id: String,
+        kind: String,
+        seq: Int64,
+        payload: Data,
+        createdAt: Int64
+    ) throws {
+        try openedStore().appendMessage(
+            sessionId: sessionId,
+            id: id,
+            kind: kind,
+            seq: seq,
+            payload: payload,
+            createdAt: createdAt
+        )
+    }
+
+    @discardableResult
+    func persistMessages(
+        _ messages: [ACPStoredMessage],
+        fence: ACPSessionLeaseFence?
+    ) throws -> Bool {
+        let store = try openedStore()
+        if let fence {
+            return try store.withLeaseFence(fence) {
+                try store.upsertMessages(messages)
+            } != nil
+        }
+        try store.upsertMessages(messages)
+        return true
+    }
+
+    @discardableResult
+    func insertMessageIfMissing(_ message: ACPStoredMessage) throws -> Bool {
+        try openedStore().insertMessageIfMissing(message)
+    }
+
+    func compareAndSwapMessagePayload(
+        id: String,
+        payload: Data,
+        expectedPayload: Data
+    ) throws -> Bool {
+        try openedStore().updateMessagePayloadIfUnchanged(
+            id: id,
+            payload: payload,
+            expectedPayload: expectedPayload
+        )
+    }
+
+    func updateMessagePayload(id: String, payload: Data) throws {
+        try openedStore().updateMessagePayload(id: id, payload: payload)
+    }
+
+    func updateMessageRow(id: String, kind: String, seq: Int64, payload: Data) throws -> Bool {
+        try openedStore().updateMessageRow(id: id, kind: kind, seq: seq, payload: payload)
+    }
+
+    func updateMessagePayloadIfUnchanged(
+        id: String,
+        payload: Data,
+        expectedPayload: Data
+    ) throws -> Bool {
+        try openedStore().updateMessagePayloadIfUnchanged(
+            id: id,
+            payload: payload,
+            expectedPayload: expectedPayload
+        )
+    }
+
+    func loadMessagePayload(id: String) throws -> Data? {
+        try openedStore().loadMessagePayload(id: id)
+    }
+
+    func loadMessagePayload(id: String, fence: ACPSessionLeaseFence) throws -> Data? {
+        let store = try openedStore()
+        return try store.withLeaseFence(fence) {
+            try store.loadMessagePayload(id: id)
+        } ?? nil
+    }
+
+    func messageCount(sessionId: String) throws -> Int {
+        try openedStore().messageCount(sessionId: sessionId)
+    }
+
+    func latestMessageSeq(sessionId: String) throws -> Int64? {
+        try openedStore().latestMessageSeq(sessionId: sessionId)
+    }
+
+    func loadMessages(sessionId: String) throws -> [ACPStoredMessage] {
+        try openedStore().loadMessages(sessionId: sessionId)
+    }
+
+    func loadToolCallContent(sessionId: String, toolCallId: String) throws -> String? {
+        try openedStore().loadToolCallContent(sessionId: sessionId, toolCallId: toolCallId)
+    }
+
+    func upsertQueue(sessionId: String, items: [QueuedPrompt]) throws {
+        try openedStore().upsertQueue(sessionId: sessionId, items: items)
+    }
+
+    @discardableResult
+    func upsertQueue(
+        sessionId: String,
+        items: [QueuedPrompt],
+        fence: ACPSessionLeaseFence?
+    ) throws -> Bool {
+        let store = try openedStore()
+        let operation = { try store.upsertQueue(sessionId: sessionId, items: items) }
+        if let fence { return try store.withLeaseFence(fence, operation) != nil }
+        try operation()
+        return true
+    }
+
+    func loadQueue(sessionId: String) throws -> [QueuedPrompt] {
+        try openedStore().loadQueue(sessionId: sessionId)
+    }
+
+    func loadLease(sessionId: String) throws -> ACPSessionLease? {
+        try openedStore().loadLease(sessionId: sessionId)
+    }
+
+    func claimLease(
+        sessionId: String,
+        instanceId: String,
+        pid: Int64,
+        now: Int64,
+        staleAfter: Int64,
+        leaseToken: String
+    ) throws -> ACPSessionLease? {
+        let store = try openedStore()
+        let won = try store.claimLease(
+            sessionId: sessionId,
+            instanceId: instanceId,
+            pid: pid,
+            now: now,
+            staleAfter: staleAfter,
+            leaseToken: leaseToken
+        )
+        return won ? try store.loadLease(sessionId: sessionId) : nil
+    }
+
+    func refreshHeartbeat(sessionId: String, instanceId: String, now: Int64, status: String) throws {
+        try openedStore().refreshHeartbeat(
+            sessionId: sessionId,
+            instanceId: instanceId,
+            now: now,
+            status: status
+        )
+    }
+
+    func releaseLease(sessionId: String, instanceId: String, leaseToken: String? = nil) throws {
+        try openedStore().releaseLease(
+            sessionId: sessionId,
+            instanceId: instanceId,
+            leaseToken: leaseToken
+        )
+    }
+
+    func seizeLease(
+        sessionId: String,
+        instanceId: String,
+        pid: Int64,
+        now: Int64,
+        leaseToken: String
+    ) throws -> ACPSessionLease {
+        let store = try openedStore()
+        try store.seizeLease(
+            sessionId: sessionId,
+            instanceId: instanceId,
+            pid: pid,
+            now: now,
+            leaseToken: leaseToken
+        )
+        guard let lease = try store.loadLease(sessionId: sessionId) else {
+            throw SQLiteError.stepFailed(code: SQLITE_ERROR, message: "Lease seizure did not persist", sql: "session_leases")
+        }
+        return lease
+    }
+}

--- a/Alas/Sources/ACP/Session/ACPSessionRunner.swift
+++ b/Alas/Sources/ACP/Session/ACPSessionRunner.swift
@@ -4,7 +4,7 @@ import Foundation
 final class ACPSessionRunner {
     let session: ACPSession
     let connection: ACPConnection
-    let store: ACPSessionStore
+    let persistence: ACPSessionPersistence
     /// LOCAL session id — our UUID assigned by `ACPSessionManager.createSession`,
     /// used as the persistence key in `ACPSessionStore`. The protocol-side
     /// (remote) session id lives on `session.remoteSessionId` and is what
@@ -42,6 +42,9 @@ final class ACPSessionRunner {
     /// back in via a re-augment from `ProcessInfo`.
     private let agentEnv: [String: String]
     private let ownerInstanceId: String?
+    private let canWrite: () -> Bool
+    private let validateLease: () async -> Bool
+    private let leaseFenceProvider: () -> ACPSessionLeaseFence?
     private let onAuthRequired: ((ACPSessionRunner, String) async -> Void)?
     private let onPersist: (() -> Void)?
     private let onSessionTitleUpdated: ((String) -> Void)?
@@ -62,14 +65,21 @@ final class ACPSessionRunner {
     private var cancelledPromptIDs: Set<Int> = []
     private var appliedUpdateCount = 0
     private var persistedMessageCount: Int
+    private var persistenceTail: Task<Void, Never>?
+    private var persistenceGeneration = 0
     private var pendingCompletedOutputBoundaryUpdateCount: Int?
     private var pendingStreamingPersistIndices: Set<Int> = []
+    /// Revisions distinguish a new streamed chunk from the payload currently
+    /// being written. A successful write may only clear the revision it saw.
+    private var pendingStreamingPersistRevisions: [Int: Int] = [:]
+    private var streamingPersistInFlightIndices: Set<Int> = []
     private var pendingStreamingPersistSnapshots: [Int: StreamingPersistSnapshot] = [:]
     /// The exact payload bytes this runner last wrote for each message row.
     /// Used as the compare-and-swap base when a takeover forces a stand-down
     /// flush, so the CAS never reads the (potentially growing) payload blob
     /// from SQLite on the streaming path.
     private var lastPersistedPayloads: [Int: Data] = [:]
+    private var capturingPersistedBaseIndices: Set<Int> = []
     /// Set once a cross-process takeover is detected mid-stream. While true,
     /// streamed chunks are no longer buffered for persistence and the
     /// stand-down flush writes the frozen snapshots via compare-and-swap
@@ -107,7 +117,7 @@ final class ACPSessionRunner {
         let basePayload: Data?
     }
 
-    init(session: ACPSession, connection: ACPConnection, store: ACPSessionStore,
+    init(session: ACPSession, connection: ACPConnection, store: ACPSessionStore? = nil,
          sessionId: String, worktreePath: String,
          agentEnv: [String: String] = ProcessInfo.processInfo.environment,
          suppressingLoadReplay: Bool = false,
@@ -120,11 +130,18 @@ final class ACPSessionRunner {
          onResumeTranscriptTail: (() -> Void)? = nil,
          streamingPersistDebounceNanos: UInt64 = 250_000_000,
          incomingUpdateCoalesceNanos: UInt64 = 16_000_000,
-         ownerInstanceId: String? = nil)
+         ownerInstanceId: String? = nil,
+         persistence: ACPSessionPersistence? = nil,
+         persistedMessageCount: Int? = nil,
+         canWrite: (() -> Bool)? = nil,
+         validateLease: (() async -> Bool)? = nil,
+         leaseFenceProvider: (() -> ACPSessionLeaseFence?)? = nil)
     {
+        precondition(store != nil || persistence != nil, "ACPSessionRunner requires persistence")
+        let resolvedPersistence = persistence ?? ACPSessionPersistence(path: store!.path)
         self.session = session
         self.connection = connection
-        self.store = store
+        self.persistence = resolvedPersistence
         self.sessionId = sessionId
         self.worktreePath = worktreePath
         self.agentEnv = agentEnv
@@ -142,28 +159,84 @@ final class ACPSessionRunner {
         self.onLiveBufferRead = onLiveBufferRead
         self.onUserCancel = onUserCancel
         self.onResumeTranscriptTail = onResumeTranscriptTail
-        self.persistedMessageCount = (try? store.messageCount(sessionId: sessionId)) ?? 0
-        self.seq = Int64(persistedMessageCount)
+        let initialPersistedMessageCount = persistedMessageCount
+            ?? store.flatMap { try? $0.messageCount(sessionId: sessionId) }
+            ?? 0
+        self.persistedMessageCount = initialPersistedMessageCount
+        self.seq = Int64(initialPersistedMessageCount)
         // Capture the three values holdsLeaseForWrite() reads so the closure
         // can be formed before `self` is fully initialised (policy is the
         // last stored property). The logic is identical to holdsLeaseForWrite.
-        let _store = store
         let _sessionId = sessionId
         let _ownerInstanceId = ownerInstanceId
+        let defaultCanWrite = {
+            guard let id = _ownerInstanceId else { return true }
+            guard let store else { return false }
+            return (try? store.loadLease(sessionId: _sessionId))?.ownerInstance == id
+        }
+        self.canWrite = canWrite ?? defaultCanWrite
+        self.validateLease = validateLease ?? { canWrite?() ?? defaultCanWrite() }
+        let initialLease = ownerInstanceId.flatMap { owner in
+            guard let lease = try? store?.loadLease(sessionId: sessionId),
+                  lease.ownerInstance == owner else { return nil as ACPSessionLeaseFence? }
+            return ACPSessionLeaseFence(
+                sessionId: sessionId,
+                ownerInstance: owner,
+                token: lease.token
+            )
+        }
+        self.leaseFenceProvider = leaseFenceProvider ?? { initialLease }
         self.policy = ACPPermissionPolicy(
             session: session,
-            log: ACPPermissionDecisionLog(store: store, canWrite: {
-                guard let id = _ownerInstanceId else { return true }
-                return (try? _store.loadLease(sessionId: _sessionId))?.ownerInstance == id
-            })
+            log: ACPPermissionDecisionLog(
+                persistence: resolvedPersistence,
+                canWrite: canWrite ?? defaultCanWrite,
+                leaseFence: leaseFenceProvider
+            )
         )
+    }
+
+    private func enqueuePersistence(
+        _ operation: @escaping @Sendable (ACPSessionPersistence) async throws -> Void
+    ) {
+        let previous = persistenceTail
+        let persistence = persistence
+        persistenceGeneration += 1
+        persistenceTail = Task { @MainActor in
+            await previous?.value
+            guard !Task.isCancelled else { return }
+            try? await operation(persistence)
+        }
+    }
+
+    private func enqueuePersistence<Result: Sendable>(
+        _ operation: @escaping @Sendable (ACPSessionPersistence) async throws -> Result,
+        completion: @escaping @MainActor (Result?) async -> Void
+    ) {
+        let previous = persistenceTail
+        let persistence = persistence
+        persistenceGeneration += 1
+        let task = Task { @MainActor in
+            await previous?.value
+            guard !Task.isCancelled else { return }
+            await completion(try? await operation(persistence))
+        }
+        persistenceTail = Task { await task.value }
+    }
+
+    func flushPersistence() async {
+        while let tail = persistenceTail {
+            let generation = persistenceGeneration
+            await tail.value
+            if persistenceGeneration == generation { return }
+        }
     }
 
     func start() {
         updatesTask = Task { [weak self] in
             guard let self else { return }
             for await u in self.connection.client.incomingUpdates {
-                await self.enqueueIncomingUpdate(u)
+                self.enqueueIncomingUpdate(u)
             }
             // The for-await also exits when the task gets cancelled —
             // that's the intentional detach path (tab close, worktree
@@ -171,7 +244,7 @@ final class ACPSessionRunner {
             // an "Agent disconnected" notice in that case; only flag
             // the unexpected stream-end.
             if Task.isCancelled { return }
-            await self.flushPendingIncomingUpdates(flushQueueWhenBoundaryReady: false)
+            self.flushPendingIncomingUpdates(flushQueueWhenBoundaryReady: false)
             await MainActor.run {
                 self.session.agentState = .disconnected
                 self.session.transcript.streamingState = .idle
@@ -277,7 +350,7 @@ final class ACPSessionRunner {
                     // serializing agent writes against editor saves; that is
                     // deferred to a follow-up. The unbounded-read hot path
                     // (`serveRead`) carries the bulk of the main-thread win.
-                    guard self.holdsLeaseForWrite() else {
+                    guard await self.hasConfirmedLeaseForSideEffect() else {
                         self.connection.client.respondToFileRequest(
                             id: id,
                             result: .failure(.init(code: -32003, message: "lease lost to another instance", data: nil)))
@@ -319,7 +392,7 @@ final class ACPSessionRunner {
         terminalsTask = Task { @MainActor [weak self] in
             guard let self else { return }
             for await req in self.connection.client.terminalRequests {
-                self.handleTerminalRequest(req)
+                await self.handleTerminalRequest(req)
             }
         }
     }
@@ -343,11 +416,8 @@ final class ACPSessionRunner {
     }
 
     private func capturePersistedBasesForIncomingUpdate(_ update: ACPSessionUpdate) {
-        for i in persistedCandidateIndices(for: update)
-        where i >= 0 && i < persistedMessageCount && lastPersistedPayloads[i] == nil {
-            if let base = try? store.loadMessagePayload(id: "msg-\(sessionId)-\(i)") {
-                lastPersistedPayloads[i] = base
-            }
+        for index in persistedCandidateIndices(for: update) {
+            capturePersistedBaseIfNeeded(at: index)
         }
     }
 
@@ -437,9 +507,11 @@ final class ACPSessionRunner {
             preAppliedSessionInfoDirty = nil
         }
         if suppressingLoadReplay {
-            let dirty = preAppliedSessionInfoDirty
-                ?? session.applySuppressedReplaySideEffects(params.update)
-            persistIndices(dirty)
+            if let dirty = preAppliedSessionInfoDirty {
+                persistIndices(dirty)
+            } else {
+                _ = session.applySuppressedReplaySideEffects(params.update)
+            }
             if let target = loadReplaySuppressionTarget,
                observedUpdateCount >= target {
                 finishLoadReplaySuppression()
@@ -486,6 +558,12 @@ final class ACPSessionRunner {
         }
     }
 
+    #if DEBUG
+    func applyIncomingUpdateForTesting(_ params: ACPSessionUpdateParams) {
+        applyIncomingUpdate(params)
+    }
+    #endif
+
     func finishSuppressingLoadReplay(throughYieldedUpdateCount target: Int) {
         guard suppressingLoadReplay else { return }
         loadReplaySuppressionTarget = target
@@ -530,7 +608,7 @@ final class ACPSessionRunner {
         onPersist?()
     }
 
-    private func handleTerminalRequest(_ req: ACPTerminalRequest) {
+    private func handleTerminalRequest(_ req: ACPTerminalRequest) async {
         let host = self.session.terminalHost
         switch req {
         case .create(let id, let p):
@@ -540,7 +618,7 @@ final class ACPSessionRunner {
             // defense-in-depth alongside the heartbeat/stand-down path
             // (which calls stop() → terminalHost.killAll() within ~100ms
             // of a takeover ping). Matches the existing file-write gate.
-            guard holdsLeaseForWrite() else {
+            guard await hasConfirmedLeaseForSideEffect() else {
                 self.connection.client.respondToTerminalRequest(
                     id: id, result: .failure(.init(code: -32003, message: "lease lost to another instance", data: nil)))
                 break
@@ -598,7 +676,7 @@ final class ACPSessionRunner {
             // another instance now owns. Note: runner.stop() calls
             // terminalHost.killAll() directly (NOT through this handler),
             // so teardown is unaffected by this gate.
-            guard holdsLeaseForWrite() else {
+            guard await hasConfirmedLeaseForSideEffect() else {
                 self.connection.client.respondToTerminalRequest(
                     id: id, result: .failure(.init(code: -32003, message: "lease lost to another instance", data: nil)))
                 break
@@ -620,7 +698,7 @@ final class ACPSessionRunner {
             // another instance now owns. Note: runner.stop() calls
             // terminalHost.killAll() directly (NOT through this handler),
             // so teardown is unaffected by this gate.
-            guard holdsLeaseForWrite() else {
+            guard await hasConfirmedLeaseForSideEffect() else {
                 self.connection.client.respondToTerminalRequest(
                     id: id, result: .failure(.init(code: -32003, message: "lease lost to another instance", data: nil)))
                 break
@@ -662,36 +740,47 @@ final class ACPSessionRunner {
     /// handle, and the next open via the manager picks up the new row.
     func persistSessionRow(preserveTitle: Bool = true) {
         guard holdsLeaseForWrite() else { return }
-        guard let row = try? store.loadSession(id: sessionId) else { return }
-        let now = Int64(Date().timeIntervalSince1970)
-        try? store.upsertSession(.init(
-            id: row.id, agentId: row.agentId, title: session.title,
-            titleSource: session.titleSource,
-            remoteSessionId: row.remoteSessionId,
-            origin: row.origin,
-            contextRecoveryPending: row.contextRecoveryPending,
-            currentModel: session.currentModel, currentMode: session.currentMode,
-            autoRun: session.autoRunEnabled,
-            createdAt: row.createdAt, updatedAt: now,
-            lastOpenedAt: row.lastOpenedAt, archived: row.archived
-        ), preserveTitle: preserveTitle)
+        let title = session.title
+        let titleSource = session.titleSource
+        let currentModel = session.currentModel
+        let currentMode = session.currentMode
+        let autoRun = session.autoRunEnabled
+        let fence = leaseFenceProvider()
+        let sessionId = sessionId
+        enqueuePersistence { persistence in
+            _ = try await persistence.updateSessionFromRuntime(
+                id: sessionId,
+                title: title,
+                titleSource: titleSource,
+                currentModel: currentModel,
+                currentMode: currentMode,
+                autoRun: autoRun,
+                preserveTitle: preserveTitle,
+                fence: fence
+            )
+        }
     }
 
     func persistGeneratedTitleIfStoredPlaceholder() {
         guard holdsLeaseForWrite() else { return }
         let now = Int64(Date().timeIntervalSince1970)
-        guard (try? store.updateGeneratedTitleIfPlaceholder(
-            id: sessionId,
-            title: session.title,
-            updatedAt: now
-        )) == true else {
-            guard let row = try? store.loadSession(id: sessionId) else { return }
-            if row.titleSource != .placeholder {
-                session.title = row.title
-                session.titleSource = row.titleSource
-            }
-            return
-        }
+        let title = session.title
+        let fence = leaseFenceProvider()
+        let sessionId = sessionId
+        enqueuePersistence({ persistence in
+            try await persistence.updateGeneratedTitleIfPlaceholder(
+                id: sessionId,
+                title: title,
+                updatedAt: now,
+                fence: fence
+            )
+        }, completion: { [weak self] updated in
+            guard updated != true, let self else { return }
+            guard let row = try? await self.persistence.loadSession(id: self.sessionId),
+                  row.titleSource != .placeholder else { return }
+            self.session.title = row.title
+            self.session.titleSource = row.titleSource
+        })
     }
 
     func applySessionInfoTitle(_ info: ACPSessionInfoUpdate) {
@@ -712,43 +801,52 @@ final class ACPSessionRunner {
         guard session.titleSource != .manual else { return }
 
         let now = Int64(Date().timeIntervalSince1970)
-        guard (try? store.updateGeneratedTitleIfNotManual(
-            id: sessionId,
-            title: trimmed,
-            updatedAt: now
-        )) == true else {
-            guard let row = try? store.loadSession(id: sessionId) else { return }
-            if row.titleSource == .manual {
-                session.title = row.title
-                session.titleSource = row.titleSource
-            }
-            return
-        }
-
         session.title = trimmed
         session.titleSource = .generated
-        onSessionTitleUpdated?(trimmed)
+        let fence = leaseFenceProvider()
+        let sessionId = sessionId
+        enqueuePersistence({ persistence in
+            try await persistence.updateGeneratedTitleIfNotManual(
+                id: sessionId,
+                title: trimmed,
+                updatedAt: now,
+                fence: fence
+            )
+        }, completion: { [weak self] updated in
+            guard let self else { return }
+            if updated == true {
+                self.onSessionTitleUpdated?(trimmed)
+                return
+            }
+            guard let row = try? await self.persistence.loadSession(id: self.sessionId),
+                  row.titleSource == .manual else { return }
+            self.session.title = row.title
+            self.session.titleSource = row.titleSource
+        })
     }
 
     private func clearSessionInfoTitle() {
         guard session.titleSource != .manual else { return }
 
         let now = Int64(Date().timeIntervalSince1970)
-        guard (try? store.clearGeneratedTitleIfNotManual(
-            id: sessionId,
-            updatedAt: now
-        )) == true else {
-            guard let row = try? store.loadSession(id: sessionId) else { return }
-            if row.titleSource == .manual {
-                session.title = row.title
-                session.titleSource = row.titleSource
-            }
-            return
-        }
-
         session.title = "New session"
         session.titleSource = .placeholder
         onSessionTitleUpdated?("New session")
+        let fence = leaseFenceProvider()
+        let sessionId = sessionId
+        enqueuePersistence({ persistence in
+            try await persistence.clearGeneratedTitleIfNotManual(
+                id: sessionId,
+                updatedAt: now,
+                fence: fence
+            )
+        }, completion: { [weak self] updated in
+            guard updated != true, let self else { return }
+            guard let row = try? await self.persistence.loadSession(id: self.sessionId),
+                  row.titleSource == .manual else { return }
+            self.session.title = row.title
+            self.session.titleSource = row.titleSource
+        })
     }
 
     /// Returns `absolutePath` relative to the runner's worktree, or
@@ -859,7 +957,7 @@ final class ACPSessionRunner {
         // bookkeeping above (cancelledPromptIDs insert) is fine to keep —
         // it only affects this runner's own sendNow catch path and has no
         // cross-instance side effects.
-        guard holdsLeaseForWrite() else { return }
+        guard await hasConfirmedLeaseForSideEffect() else { return }
         onUserCancel?()
         let remoteId = session.remoteSessionId ?? sessionId
         try? await connection.cancel(sessionId: remoteId)
@@ -877,14 +975,7 @@ final class ACPSessionRunner {
             let changedIndices = session.cancelInFlightToolCalls()
             session.terminalHost.killAll()
             if holdsLeaseForWrite() {
-                for i in changedIndices {
-                    let m = session.transcript.messages[i]
-                    if let payload = try? ACPMessageCodec.encode(m) {
-                        let id = "msg-\(sessionId)-\(i)"
-                        try? store.updateMessagePayload(id: id, payload: payload)
-                        lastPersistedPayloads[i] = payload
-                    }
-                }
+                _ = persistIndices(Set(changedIndices))
             }
             // Pop the head ONLY if it's the same `.sending` item we
             // were aiming at. If a queued item promoted itself during
@@ -1115,7 +1206,16 @@ extension ACPSessionRunner {
     /// lose a queue snapshot than the user's draft.
     func persistQueue() {
         guard holdsLeaseForWrite() else { return }
-        try? store.upsertQueue(sessionId: sessionId, items: session.queue)
+        let items = session.queue
+        let fence = leaseFenceProvider()
+        let sessionId = sessionId
+        enqueuePersistence { persistence in
+            _ = try await persistence.upsertQueue(
+                sessionId: sessionId,
+                items: items,
+                fence: fence
+            )
+        }
     }
 
     /// Drain the queue head if the runner is still live, setup is not
@@ -1300,6 +1400,16 @@ extension ACPSessionRunner {
                 await MainActor.run { onPromptFinished?(false) }
                 return
             }
+            guard await self.hasConfirmedLeaseForSideEffect() else {
+                await MainActor.run {
+                    if self.activePromptID == promptID {
+                        self.activePromptID = nil
+                    }
+                    self.cancelledPromptIDs.remove(promptID)
+                    onPromptFinished?(false)
+                }
+                return
+            }
             let proceeded = await MainActor.run { () -> Bool in
                 // If we were cancelled while this Task was being scheduled,
                 // exit without touching transcript or state. The connection
@@ -1368,6 +1478,9 @@ extension ACPSessionRunner {
                     promptCapabilities: promptCapabilities,
                     worktreePath: self.worktreePath
                 )
+                guard await self.hasConfirmedLeaseForSideEffect() else {
+                    throw CancellationError()
+                }
                 try await self.connection.prompt(sessionId: remoteId, blocks: wireBlocks)
                 await MainActor.run {
                     let isActivePrompt = self.activePromptID == promptID
@@ -1578,8 +1691,15 @@ extension ACPSessionRunner {
     /// When `ownerInstanceId` is nil (tests that construct a runner directly
     /// without a lease), gating is disabled and writes always proceed.
     private func holdsLeaseForWrite() -> Bool {
-        guard let ownerInstanceId else { return true }
-        return (try? store.loadLease(sessionId: sessionId))?.ownerInstance == ownerInstanceId
+        canWrite()
+    }
+
+    /// Cached authority is enough for in-memory updates and persistence fences,
+    /// but RPCs and process/file side effects must confirm the token against
+    /// SQLite immediately before they run.
+    private func hasConfirmedLeaseForSideEffect() async -> Bool {
+        guard holdsLeaseForWrite() else { return false }
+        return await validateLease()
     }
 
     private func shouldBatchStreamingPersist(
@@ -1625,13 +1745,14 @@ extension ACPSessionRunner {
         // most once per such row, never on the hot streaming-tail path (a new
         // trailing row is not yet persisted, so it is written, not read).
         if mayCapturePersistedBases {
-            for i in indices where i < persistedMessageCount && lastPersistedPayloads[i] == nil {
-                if let base = try? store.loadMessagePayload(id: "msg-\(sessionId)-\(i)") {
-                    lastPersistedPayloads[i] = base
-                }
+            for i in indices {
+                capturePersistedBaseIfNeeded(at: i)
             }
         }
         pendingStreamingPersistIndices.formUnion(indices)
+        for index in indices {
+            pendingStreamingPersistRevisions[index, default: 0] += 1
+        }
         guard streamingPersistTask == nil else { return }
         streamingPersistTask = Task { @MainActor [weak self] in
             guard let self else { return }
@@ -1639,6 +1760,28 @@ extension ACPSessionRunner {
             guard !Task.isCancelled else { return }
             self.flushStreamingPersist()
         }
+    }
+
+    private func capturePersistedBaseIfNeeded(at index: Int) {
+        guard index < persistedMessageCount,
+              lastPersistedPayloads[index] == nil,
+              !capturingPersistedBaseIndices.contains(index),
+              let fence = leaseFenceProvider()
+        else { return }
+        capturingPersistedBaseIndices.insert(index)
+        let id = "msg-\(sessionId)-\(index)"
+        enqueuePersistence({ persistence in
+            try await persistence.loadMessagePayload(id: id, fence: fence)
+        }, completion: { [weak self] payload in
+            guard let self else { return }
+            self.capturingPersistedBaseIndices.remove(index)
+            guard let payload = payload ?? nil else { return }
+            self.lastPersistedPayloads[index] = payload
+            if self.streamingLeaseLost {
+                self.freezeStreamingPersistSnapshots()
+                self.persistStreamingPersistSnapshots()
+            }
+        })
     }
 
     private func flushStreamingPersist() {
@@ -1653,6 +1796,8 @@ extension ACPSessionRunner {
         guard streamingLeaseLost else { return }
         streamingLeaseLost = false
         pendingStreamingPersistIndices.removeAll()
+        pendingStreamingPersistRevisions.removeAll()
+        streamingPersistInFlightIndices.removeAll()
         pendingStreamingPersistSnapshots.removeAll()
     }
 
@@ -1686,20 +1831,38 @@ extension ACPSessionRunner {
             persistStreamingPersistSnapshots()
             return
         }
-        guard !pendingStreamingPersistIndices.isEmpty else { return }
-        let indices = pendingStreamingPersistIndices
-        if persistIndices(indices, requiresLease: true) {
-            pendingStreamingPersistIndices.subtract(indices)
+        let indices = pendingStreamingPersistIndices.subtracting(streamingPersistInFlightIndices)
+        guard !indices.isEmpty else { return }
+        let revisions = Dictionary(uniqueKeysWithValues: indices.map {
+            ($0, pendingStreamingPersistRevisions[$0, default: 0])
+        })
+        streamingPersistInFlightIndices.formUnion(indices)
+        if persistIndices(indices, requiresLease: true, completion: { [weak self] succeeded in
+            guard let self else { return }
+            self.streamingPersistInFlightIndices.subtract(indices)
+            if succeeded {
+                for index in indices where self.pendingStreamingPersistRevisions[index] == revisions[index] {
+                    self.pendingStreamingPersistIndices.remove(index)
+                    self.pendingStreamingPersistRevisions.removeValue(forKey: index)
+                }
+                if !self.pendingStreamingPersistIndices.isEmpty, !self.streamingLeaseLost {
+                    self.flushStreamingPersist()
+                }
+                return
+            }
+            self.freezeStreamingPersistSnapshots()
+            self.streamingLeaseLost = true
+            self.persistStreamingPersistSnapshots()
+        }) {
             return
         }
+        streamingPersistInFlightIndices.subtract(indices)
         // The lease moved between the last chunk and this flush. Freeze the
         // buffered rows' current state — every chunk so far arrived while we
         // held the lease — for the stand-down CAS write.
         freezeStreamingPersistSnapshots()
         streamingLeaseLost = true
-        if !requiresLease {
-            persistStreamingPersistSnapshots()
-        }
+        persistStreamingPersistSnapshots()
     }
 
     /// Encode the buffered streaming rows from the live transcript into
@@ -1713,17 +1876,16 @@ extension ACPSessionRunner {
             let message = messageForPersistence(messages[i])
             guard let payload = try? ACPMessageCodec.encode(message) else { continue }
             let basePayload: Data?
-            if i < persistedMessageCount {
-                // The compare-and-swap base MUST be a payload captured while we
-                // held the lease — `scheduleStreamingPersist` records one for
-                // every persisted row it buffers, so the entry is normally
-                // present. Reading the row from SQLite HERE would be unsafe: the
-                // lease has already moved, so the row may hold the new owner's
-                // payload, which would become `expectedPayload` and let the CAS
-                // clobber it. If no under-lease base exists we cannot write
-                // safely, so skip the row and leave the new owner authoritative.
-                guard let base = lastPersistedPayloads[i] else { continue }
+            // A row may have been created by an earlier queued persistence
+            // operation even when `persistedMessageCount` has not caught up.
+            // Only a payload captured under our token may authorize a CAS
+            // update after takeover; otherwise this remains insert-only.
+            if let base = lastPersistedPayloads[i] {
                 basePayload = base
+            } else if i < persistedMessageCount {
+                // Never read a missing base after takeover: that could capture
+                // the new owner's payload and make a stale CAS destructive.
+                continue
             } else {
                 basePayload = nil
             }
@@ -1738,26 +1900,32 @@ extension ACPSessionRunner {
         for i in snapshots.keys.sorted() {
             guard let snapshot = snapshots[i] else { continue }
             let id = "msg-\(sessionId)-\(i)"
-            if i < persistedMessageCount {
-                guard let basePayload = snapshot.basePayload,
-                      (try? store.updateMessagePayloadIfUnchanged(
+            if let basePayload = snapshot.basePayload {
+                let payload = snapshot.payload
+                enqueuePersistence { persistence in
+                    _ = try await persistence.compareAndSwapMessagePayload(
                         id: id,
-                        payload: snapshot.payload,
+                        payload: payload,
                         expectedPayload: basePayload
-                      )) == true else {
-                    continue
+                    )
                 }
             } else {
-                do {
-                    try store.appendMessage(sessionId: sessionId, id: id, kind: snapshot.kind,
-                                            seq: Int64(i), payload: snapshot.payload, createdAt: now)
-                    persistedMessageCount = max(persistedMessageCount, i + 1)
-                } catch {
-                    continue
+                let row = ACPStoredMessage(
+                    id: id,
+                    sessionId: sessionId,
+                    kind: snapshot.kind,
+                    seq: Int64(i),
+                    payload: snapshot.payload,
+                    createdAt: now
+                )
+                enqueuePersistence { persistence in
+                    _ = try await persistence.insertMessageIfMissing(row)
                 }
+                persistedMessageCount = max(persistedMessageCount, i + 1)
             }
             lastPersistedPayloads[i] = snapshot.payload
             pendingStreamingPersistIndices.remove(i)
+            pendingStreamingPersistRevisions.removeValue(forKey: i)
             pendingStreamingPersistSnapshots.removeValue(forKey: i)
         }
         trimLastPersistedPayloads()
@@ -1771,52 +1939,67 @@ extension ACPSessionRunner {
     /// one, so the count-delta heuristic in `persistFromIndex` would
     /// write back the wrong row.
     @discardableResult
-    func persistIndices(_ indices: Set<Int>, requiresLease: Bool = true) -> Bool {
+    func persistIndices(
+        _ indices: Set<Int>,
+        requiresLease: Bool = true,
+        completion: ((Bool) -> Void)? = nil
+    ) -> Bool {
         streamingPersistTask?.cancel()
         streamingPersistTask = nil
         guard !requiresLease || holdsLeaseForWrite() else { return false }
-        guard !indices.isEmpty else { return true }
+        guard !indices.isEmpty else {
+            completion?(true)
+            return true
+        }
         let messages = session.transcript.messages
         let now = Int64(Date().timeIntervalSince1970)
+        var rows: [ACPStoredMessage] = []
         for i in indices.sorted() {
             guard i >= 0, i < messages.count else { continue }
             let m = messageForPersistence(messages[i])
             guard let payload = try? ACPMessageCodec.encode(m) else { continue }
             let id = "msg-\(sessionId)-\(i)"
-            if i < persistedMessageCount {
-                try? store.updateMessagePayload(id: id, payload: payload)
-                lastPersistedPayloads[i] = payload
-            } else {
-                do {
-                    try store.appendMessage(sessionId: sessionId, id: id, kind: m.kind,
-                                            seq: Int64(i), payload: payload, createdAt: now)
-                    persistedMessageCount = max(persistedMessageCount, i + 1)
-                    lastPersistedPayloads[i] = payload
-                } catch {
-                    if (try? store.updateMessageRow(id: id, kind: m.kind, seq: Int64(i), payload: payload)) == true {
-                        persistedMessageCount = max(persistedMessageCount, i + 1)
-                        lastPersistedPayloads[i] = payload
-                    }
-                }
-            }
+            rows.append(ACPStoredMessage(
+                id: id,
+                sessionId: sessionId,
+                kind: m.kind,
+                seq: Int64(i),
+                payload: payload,
+                createdAt: now
+            ))
         }
-        trimLastPersistedPayloads()
-        onPersist?()
+        let fence = requiresLease ? leaseFenceProvider() : nil
+        if !rows.isEmpty {
+            let messageRows = rows
+            enqueuePersistence({ persistence in
+                try await persistence.persistMessages(messageRows, fence: fence)
+            }, completion: { [weak self] persisted in
+                guard let self else { return }
+                guard persisted == true else {
+                    completion?(false)
+                    return
+                }
+                self.commitPersistedMessageRows(messageRows)
+                completion?(true)
+            })
+        } else {
+            completion?(true)
+        }
         return true
     }
 
     private func messageForPersistence(_ message: ACPMessage) -> ACPMessage {
-        guard case .toolCall(var toolCall) = message,
-              toolCall.isContentTruncated,
-              let storedContent = try? store.loadToolCallContent(
-                sessionId: sessionId,
-                toolCallId: toolCall.toolCallId
-              )
-        else {
-            return message
+        message
+    }
+
+    private func commitPersistedMessageRows(_ rows: [ACPStoredMessage]) {
+        for row in rows {
+            let index = Int(row.seq)
+            persistedMessageCount = max(persistedMessageCount, index + 1)
+            lastPersistedPayloads[index] = row.payload
         }
-        toolCall.content = storedContent
-        return .toolCall(toolCall)
+        trimLastPersistedPayloads()
+        onPersist?()
     }
 
     /// Persist messages from the apply() boundary. Three cases:
@@ -1849,28 +2032,29 @@ extension ACPSessionRunner {
         }
 
         let now = Int64(Date().timeIntervalSince1970)
+        var rows: [ACPStoredMessage] = []
         for i in lowerBound..<messages.count {
             let m = messages[i]
             guard let payload = try? ACPMessageCodec.encode(m) else { continue }
             let id = "msg-\(sessionId)-\(i)"
-            if i < persistedMessageCount {
-                try? store.updateMessagePayload(id: id, payload: payload)
-                lastPersistedPayloads[i] = payload
-            } else {
-                do {
-                    try store.appendMessage(sessionId: sessionId, id: id, kind: m.kind,
-                                            seq: Int64(i), payload: payload, createdAt: now)
-                    persistedMessageCount = max(persistedMessageCount, i + 1)
-                    lastPersistedPayloads[i] = payload
-                } catch {
-                    if (try? store.updateMessageRow(id: id, kind: m.kind, seq: Int64(i), payload: payload)) == true {
-                        persistedMessageCount = max(persistedMessageCount, i + 1)
-                        lastPersistedPayloads[i] = payload
-                    }
-                }
-            }
+            rows.append(ACPStoredMessage(
+                id: id,
+                sessionId: sessionId,
+                kind: m.kind,
+                seq: Int64(i),
+                payload: payload,
+                createdAt: now
+            ))
         }
-        trimLastPersistedPayloads()
-        onPersist?()
+        let fence = leaseFenceProvider()
+        if !rows.isEmpty {
+            let messageRows = rows
+            enqueuePersistence({ persistence in
+                try await persistence.persistMessages(messageRows, fence: fence)
+            }, completion: { [weak self] persisted in
+                guard let self, persisted == true else { return }
+                self.commitPersistedMessageRows(messageRows)
+            })
+        }
     }
 }

--- a/Alas/Sources/ACP/Session/ACPSessionStore.swift
+++ b/Alas/Sources/ACP/Session/ACPSessionStore.swift
@@ -1,14 +1,16 @@
 import Foundation
 
 final class ACPSessionStore {
-    static let targetSchemaVersion = 10
+    static let targetSchemaVersion = 11
+    let path: String
     let db: SQLiteDatabase
 
-    init(path: String) throws {
+    init(path: String, busyTimeoutMilliseconds: Int32 = 5_000) throws {
+        self.path = path
         try? FileManager.default.createDirectory(
             at: URL(fileURLWithPath: path).deletingLastPathComponent(),
             withIntermediateDirectories: true)
-        self.db = try SQLiteDatabase(path: path)
+        self.db = try SQLiteDatabase(path: path, busyTimeoutMilliseconds: busyTimeoutMilliseconds)
         try migrate()
     }
 
@@ -35,6 +37,7 @@ final class ACPSessionStore {
         if current < 8 { try migrate_to_v8() }
         if current < 9 { try migrate_to_v9() }
         if current < 10 { try migrate_to_v10() }
+        if current < 11 { try migrate_to_v11() }
         try recoverFromConcurrentWriters()
         if current == 0 {
             try db.exec("INSERT INTO schema_version (version) VALUES (?)", bindings: [Int64(Self.targetSchemaVersion)])
@@ -183,23 +186,36 @@ final class ACPSessionStore {
     private func migrate_to_v10() throws {
         try db.exec("ALTER TABLE composer_drafts ADD COLUMN submitted_after_seq INTEGER")
     }
+
+    private func migrate_to_v11() throws {
+        let columns = try db.query("PRAGMA table_info(session_leases)")
+        guard !columns.contains(where: { ($0["name"] as? String) == "lease_token" }) else { return }
+        try db.exec("ALTER TABLE session_leases ADD COLUMN lease_token TEXT NOT NULL DEFAULT ''")
+    }
 }
 
-struct ACPSessionLease: Equatable {
+struct ACPSessionLease: Equatable, Sendable {
     let sessionId: String
     let ownerInstance: String
     let pid: Int64
     let heartbeatAt: Int64
     let status: String   // "idle" | "busy"
+    let token: String
 }
 
-enum ACPSessionOrigin: String, Codable, Equatable {
+struct ACPSessionLeaseFence: Equatable, Sendable {
+    let sessionId: String
+    let ownerInstance: String
+    let token: String
+}
+
+enum ACPSessionOrigin: String, Codable, Equatable, Sendable {
     case alasCreated
     case agentImported
     case agentForked
 }
 
-struct ACPSessionRow: Equatable {
+struct ACPSessionRow: Equatable, Sendable {
     let id: String
     let agentId: String
     var title: String
@@ -216,7 +232,7 @@ struct ACPSessionRow: Equatable {
     var archived: Bool
 }
 
-struct ACPStoredMessage: Equatable {
+struct ACPStoredMessage: Equatable, Sendable {
     let id: String
     let sessionId: String
     let kind: String
@@ -225,12 +241,45 @@ struct ACPStoredMessage: Equatable {
     let createdAt: Int64
 }
 
-struct ACPStoredComposerDraft: Equatable {
+struct ACPStoredComposerDraft: Equatable, Sendable {
     let draft: ACPComposerDraft
     let updatedAt: Int64
     let payload: Data
     let submittedRecovery: Bool
     let submittedAfterSeq: Int64?
+}
+
+extension ACPSessionStore {
+    func recordPermissionDecision(
+        sessionId: String,
+        scopeKey: String,
+        decision: ACPPermissionDecision,
+        scope: ACPPermissionScopeKind,
+        decidedAt: Int64
+    ) throws {
+        try db.exec("""
+        INSERT INTO permission_decisions (session_id, scope_key, decision, scope, decided_at)
+        VALUES (?,?,?,?,?)
+        ON CONFLICT(session_id, scope_key) DO UPDATE SET
+            decision = excluded.decision,
+            scope = excluded.scope,
+            decided_at = excluded.decided_at
+        """, bindings: [sessionId, scopeKey, decision.rawValue, scope.rawValue, decidedAt])
+    }
+
+    func lookupPermissionDecision(sessionId: String, scopeKey: String) throws -> ACPPermissionDecision? {
+        let sessionRows = try db.query("""
+        SELECT decision FROM permission_decisions WHERE session_id = ? AND scope_key = ?
+        """, bindings: [sessionId, scopeKey])
+        if let decision = sessionRows.first?["decision"] as? String {
+            return ACPPermissionDecision(rawValue: decision)
+        }
+        let projectRows = try db.query("""
+        SELECT decision FROM permission_decisions
+        WHERE scope_key = ? AND scope = 'project' LIMIT 1
+        """, bindings: [scopeKey])
+        return (projectRows.first?["decision"] as? String).flatMap(ACPPermissionDecision.init(rawValue:))
+    }
 }
 
 extension ACPSessionStore {
@@ -351,7 +400,7 @@ extension ACPSessionStore {
     }
 
     func deleteComposerDraft(sessionId: String, matching stored: ACPStoredComposerDraft) throws -> Bool {
-        try db.execChanges("""
+        return try db.execChanges("""
         DELETE FROM composer_drafts
         WHERE session_id = ?
           AND payload = ?
@@ -417,6 +466,59 @@ extension ACPSessionStore {
         """, bindings: [id, sessionId, kind, seq, payload, createdAt])
     }
 
+    func upsertMessages(_ messages: [ACPStoredMessage]) throws {
+        for message in messages {
+            let payload = try payloadPreservingStoredToolCallContent(for: message)
+            try db.exec("""
+            INSERT INTO messages (id, session_id, kind, seq, payload, created_at)
+            VALUES (?,?,?,?,?,?)
+            ON CONFLICT(id) DO UPDATE SET
+                kind = excluded.kind,
+                seq = excluded.seq,
+                payload = excluded.payload
+            """, bindings: [
+                message.id,
+                message.sessionId,
+                message.kind,
+                message.seq,
+                payload,
+                message.createdAt
+            ])
+        }
+    }
+
+    /// Salvage a streamed row received by the former owner only when the new
+    /// owner has not created that deterministic row id yet. Unlike the normal
+    /// upsert path this must never replace a concurrent takeover's transcript.
+    func insertMessageIfMissing(_ message: ACPStoredMessage) throws -> Bool {
+        try db.execChanges("""
+        INSERT INTO messages (id, session_id, kind, seq, payload, created_at)
+        VALUES (?,?,?,?,?,?)
+        ON CONFLICT(id) DO NOTHING
+        """, bindings: [
+            message.id,
+            message.sessionId,
+            message.kind,
+            message.seq,
+            message.payload,
+            message.createdAt
+        ]) > 0
+    }
+
+    private func payloadPreservingStoredToolCallContent(for message: ACPStoredMessage) throws -> Data {
+        guard message.kind == "tool_call",
+              var incoming = try? JSONDecoder().decode(ACPMessage.ToolCall.self, from: message.payload),
+              let existingPayload = try loadMessagePayload(id: message.id),
+              let existing = try? JSONDecoder().decode(ACPMessage.ToolCall.self, from: existingPayload),
+              incoming.isContentTruncated
+                || (existing.content.count > incoming.content.count
+                    && existing.content.hasPrefix(incoming.content))
+        else { return message.payload }
+        incoming.content = existing.content
+        incoming.isContentTruncated = existing.isContentTruncated
+        return try JSONEncoder().encode(incoming)
+    }
+
     func updateMessagePayload(id: String, payload: Data) throws {
         try db.exec("UPDATE messages SET payload = ? WHERE id = ?", bindings: [payload, id])
     }
@@ -429,11 +531,23 @@ extension ACPSessionStore {
     }
 
     func updateMessagePayloadIfUnchanged(id: String, payload: Data, expectedPayload: Data) throws -> Bool {
-        try db.execChanges("""
+        let mergedPayload: Data
+        if var incoming = try? JSONDecoder().decode(ACPMessage.ToolCall.self, from: payload),
+           let existing = try? JSONDecoder().decode(ACPMessage.ToolCall.self, from: expectedPayload),
+           incoming.isContentTruncated
+             || (existing.content.count > incoming.content.count
+                 && existing.content.hasPrefix(incoming.content)) {
+            incoming.content = existing.content
+            incoming.isContentTruncated = existing.isContentTruncated
+            mergedPayload = try JSONEncoder().encode(incoming)
+        } else {
+            mergedPayload = payload
+        }
+        return try db.execChanges("""
         UPDATE messages
         SET payload = ?
         WHERE id = ? AND payload = ?
-        """, bindings: [payload, id, expectedPayload]) > 0
+        """, bindings: [mergedPayload, id, expectedPayload]) > 0
     }
 
     func loadMessagePayload(id: String) throws -> Data? {
@@ -549,7 +663,8 @@ extension ACPSessionStore {
             ownerInstance: r["owner_instance"] as? String ?? "",
             pid: (r["pid"] as? Int64) ?? 0,
             heartbeatAt: (r["heartbeat_at"] as? Int64) ?? 0,
-            status: r["status"] as? String ?? "idle")
+            status: r["status"] as? String ?? "idle",
+            token: r["lease_token"] as? String ?? "")
     }
 
     /// Atomically claim the writer role for `sessionId`. Returns true if
@@ -565,7 +680,8 @@ extension ACPSessionStore {
     /// same dead-owner lease can't both delete-then-insert and both win.
     /// A plain `BEGIN` (WAL) would defer the write lock and still race.
     func claimLease(sessionId: String, instanceId: String, pid: Int64,
-                    now: Int64, staleAfter: Int64) throws -> Bool {
+                    now: Int64, staleAfter: Int64,
+                    leaseToken: String = UUID().uuidString) throws -> Bool {
         let staleCutoff = now - staleAfter
         try db.exec("BEGIN IMMEDIATE")
         do {
@@ -579,16 +695,21 @@ extension ACPSessionStore {
                     bindings: [sessionId, existing.ownerInstance])
             }
             try db.exec("""
-            INSERT INTO session_leases (session_id, owner_instance, pid, heartbeat_at, status)
-            VALUES (?,?,?,?,'idle')
+            INSERT INTO session_leases (session_id, owner_instance, pid, heartbeat_at, status, lease_token)
+            VALUES (?,?,?,?,'idle',?)
             ON CONFLICT(session_id) DO UPDATE SET
                 owner_instance = excluded.owner_instance,
                 pid = excluded.pid,
                 heartbeat_at = excluded.heartbeat_at,
-                status = 'idle'
+                status = 'idle',
+                lease_token = CASE
+                    WHEN session_leases.owner_instance = excluded.owner_instance
+                    THEN session_leases.lease_token
+                    ELSE excluded.lease_token
+                END
             WHERE session_leases.owner_instance = excluded.owner_instance
                OR session_leases.heartbeat_at < ?
-            """, bindings: [sessionId, instanceId, pid, now, staleCutoff])
+            """, bindings: [sessionId, instanceId, pid, now, leaseToken, staleCutoff])
             let won = try loadLease(sessionId: sessionId)?.ownerInstance == instanceId
             try db.exec("COMMIT")
             return won
@@ -608,23 +729,54 @@ extension ACPSessionStore {
         """, bindings: [now, status, sessionId, instanceId])
     }
 
-    func releaseLease(sessionId: String, instanceId: String) throws {
-        try db.exec(
-            "DELETE FROM session_leases WHERE session_id = ? AND owner_instance = ?",
-            bindings: [sessionId, instanceId])
+    func releaseLease(sessionId: String, instanceId: String, leaseToken: String? = nil) throws {
+        if let leaseToken {
+            try db.exec(
+                "DELETE FROM session_leases WHERE session_id = ? AND owner_instance = ? AND lease_token = ?",
+                bindings: [sessionId, instanceId, leaseToken])
+        } else {
+            try db.exec(
+                "DELETE FROM session_leases WHERE session_id = ? AND owner_instance = ?",
+                bindings: [sessionId, instanceId])
+        }
     }
 
     /// Forcibly seize the lease (explicit user takeover) regardless of
     /// the current owner's liveness.
-    func seizeLease(sessionId: String, instanceId: String, pid: Int64, now: Int64) throws {
+    func seizeLease(
+        sessionId: String,
+        instanceId: String,
+        pid: Int64,
+        now: Int64,
+        leaseToken: String = UUID().uuidString
+    ) throws {
         try db.exec("""
-        INSERT INTO session_leases (session_id, owner_instance, pid, heartbeat_at, status)
-        VALUES (?,?,?,?,'idle')
+        INSERT INTO session_leases (session_id, owner_instance, pid, heartbeat_at, status, lease_token)
+        VALUES (?,?,?,?,'idle',?)
         ON CONFLICT(session_id) DO UPDATE SET
             owner_instance = excluded.owner_instance,
             pid = excluded.pid,
             heartbeat_at = excluded.heartbeat_at,
-            status = 'idle'
-        """, bindings: [sessionId, instanceId, pid, now])
+            status = 'idle',
+            lease_token = excluded.lease_token
+        """, bindings: [sessionId, instanceId, pid, now, leaseToken])
+    }
+
+    func withLeaseFence<T>(_ fence: ACPSessionLeaseFence, _ operation: () throws -> T) throws -> T? {
+        try db.exec("BEGIN IMMEDIATE")
+        do {
+            let lease = try loadLease(sessionId: fence.sessionId)
+            guard lease?.ownerInstance == fence.ownerInstance,
+                  lease?.token == fence.token else {
+                try db.exec("ROLLBACK")
+                return nil
+            }
+            let result = try operation()
+            try db.exec("COMMIT")
+            return result
+        } catch {
+            try? db.exec("ROLLBACK")
+            throw error
+        }
     }
 }

--- a/Alas/Sources/ACP/Session/QueuedPrompt.swift
+++ b/Alas/Sources/ACP/Session/QueuedPrompt.swift
@@ -1,7 +1,7 @@
 import Foundation
 
-struct QueuedPrompt: Identifiable, Equatable, Codable {
-    enum Status: String, Codable, Equatable { case pending, sending }
+struct QueuedPrompt: Identifiable, Equatable, Codable, Sendable {
+    enum Status: String, Codable, Equatable, Sendable { case pending, sending }
 
     let id: UUID
     var blocks: [ACPContentBlock]

--- a/Alas/Sources/ACP/UI/ACPMessageList.swift
+++ b/Alas/Sources/ACP/UI/ACPMessageList.swift
@@ -29,7 +29,7 @@ struct ACPMessageList: View {
     /// expanded card's in-memory content was truncated. Wired by the host
     /// to `ACPSessionManager.reloadFullToolCallContent`. Returns nil when
     /// the row is gone or the payload is undecodable.
-    let onLoadFullToolCallContent: (String) -> String?
+    let onLoadFullToolCallContent: (String) async -> String?
     @Environment(\.theme) private var theme
     @State private var isRestoringTail = false
     @State private var headFrame: CGRect = .zero

--- a/Alas/Sources/ACP/UI/ACPPermissionPrompt.swift
+++ b/Alas/Sources/ACP/UI/ACPPermissionPrompt.swift
@@ -196,8 +196,14 @@ struct ACPPermissionPrompt: View {
         case "allow_always", "reject_always": persistScope = .project
         default:                              persistScope = .session
         }
-        policy.userDecided(scopeKey: scopeKey, optionId: option.optionId,
-                           decision: decision, persistScope: persistScope)
+        Task {
+            await policy.userDecided(
+                scopeKey: scopeKey,
+                optionId: option.optionId,
+                decision: decision,
+                persistScope: persistScope
+            )
+        }
     }
 }
 

--- a/Alas/Sources/ACP/UI/ACPSessionsButton.swift
+++ b/Alas/Sources/ACP/UI/ACPSessionsButton.swift
@@ -143,7 +143,11 @@ private struct SessionsPopover: View {
         let isCurrent = row.id == session.id
         Button {
             if !isCurrent {
-                state.openExistingACPSession(sessionId: row.id)
+                Task {
+                    await state.openExistingACPSession(sessionId: row.id)
+                    onPick()
+                }
+                return
             }
             onPick()
         } label: {

--- a/Alas/Sources/ACP/UI/ACPTabView.swift
+++ b/Alas/Sources/ACP/UI/ACPTabView.swift
@@ -12,8 +12,36 @@ struct ACPTabView: View {
     let worktree: Worktree
 
     var body: some View {
-        if let manager = state.acpManager(for: worktree),
-           let session = manager.placeholderSession(id: sessionId) {
+        if let manager = state.acpManager(for: worktree) {
+            ACPManagedTabView(
+                sessionId: sessionId,
+                state: state,
+                worktree: worktree,
+                manager: manager
+            )
+        } else {
+            unavailable
+        }
+    }
+
+    private var unavailable: some View {
+        VStack {
+            Spacer()
+            Text("ACP session unavailable").foregroundStyle(.secondary)
+            Spacer()
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+    }
+}
+
+private struct ACPManagedTabView: View {
+    let sessionId: ACPSession.ID
+    let state: AppState
+    let worktree: Worktree
+    @ObservedObject var manager: ACPSessionManager
+
+    var body: some View {
+        if let session = manager.placeholderSession(id: sessionId) {
             ACPSessionView(
                 sessionId: sessionId,
                 state: state,
@@ -36,12 +64,21 @@ struct ACPTabView: View {
                 manager.releaseSession(id: sessionId)
             }
         } else {
-            VStack {
-                Spacer()
-                Text("ACP session unavailable").foregroundStyle(.secondary)
-                Spacer()
+            if manager.isKnownMissingSession(id: sessionId) {
+                VStack {
+                    Spacer()
+                    Text("ACP session unavailable").foregroundStyle(.secondary)
+                    Spacer()
+                }
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
+            } else {
+                ProgressView()
+                    .controlSize(.small)
+                    .frame(maxWidth: .infinity, maxHeight: .infinity)
+                    .task {
+                        _ = manager.placeholderSession(id: sessionId)
+                    }
             }
-            .frame(maxWidth: .infinity, maxHeight: .infinity)
         }
     }
 }
@@ -403,7 +440,7 @@ private struct ACPSessionView: View {
                 )
             },
             onLoadFullToolCallContent: { toolCallId in
-                manager.reloadFullToolCallContent(
+                await manager.reloadFullToolCallContent(
                     sessionId: sessionId, toolCallId: toolCallId)
             }
         )
@@ -582,7 +619,9 @@ private struct ACPSessionView: View {
         .foregroundStyle(.secondary)
         .frame(maxWidth: .infinity, alignment: .leading)
         .overlay(alignment: .trailing) {
-            Button("Take over here") { manager.takeOver(sessionId: sessionId) }
+            Button("Take over here") {
+                Task { await manager.takeOver(sessionId: sessionId) }
+            }
                 .controlSize(.small)
                 .padding(.trailing, 12)
         }

--- a/Alas/Sources/ACP/UI/ACPToolCallCard.swift
+++ b/Alas/Sources/ACP/UI/ACPToolCallCard.swift
@@ -14,10 +14,11 @@ struct ACPToolCallCard: View {
     /// in `expandedContent` and rendered in place of the truncated copy.
     /// Optional — when nil (or when the lookup returns nil) the card falls
     /// back to the in-memory `toolCall.content`.
-    var loadFullContent: ((String) -> String?)? = nil
+    var loadFullContent: ((String) async -> String?)? = nil
     @State private var expanded = false
     @State private var expandedContent: String? = nil
     @State private var expandedSyntax = ACPToolCallSyntaxCache()
+    @State private var loadingContentToolCallId: String? = nil
     @Environment(\.theme) private var theme
     @Environment(\.acpTerminalHost) private var terminalHost
 
@@ -29,7 +30,14 @@ struct ACPToolCallCard: View {
                     // First expand of an off-window truncated card: page the
                     // full content back in from SQLite via the host-provided
                     // loader. Subsequent toggles reuse the cached string.
-                    expandedContent = loadFullContent?(toolCall.toolCallId)
+                    let toolCallId = toolCall.toolCallId
+                    loadingContentToolCallId = toolCallId
+                    Task { @MainActor in
+                        let loaded = await loadFullContent?(toolCallId)
+                        guard loadingContentToolCallId == toolCallId else { return }
+                        expandedContent = loaded
+                        loadingContentToolCallId = nil
+                    }
                 }
             } label: {
                 HStack(spacing: 8) {
@@ -80,6 +88,7 @@ struct ACPToolCallCard: View {
         .onChange(of: toolCall.toolCallId) { _, _ in
             expandedContent = nil
             expandedSyntax.clear()
+            loadingContentToolCallId = nil
         }
         .onChange(of: toolCall.contentRevision) { _, _ in
             expandedSyntax.clear()

--- a/Alas/Sources/Agents/AgentLauncherDialog.swift
+++ b/Alas/Sources/Agents/AgentLauncherDialog.swift
@@ -480,10 +480,14 @@ struct AgentLauncherDialog: View {
     }
 
     private func openDiscoveredSession(_ session: ACPDiscoveredSession) {
-        guard let capabilities = discoveryModel?.capabilities,
-              appState.openDiscoveredACPSession(session, capabilities: capabilities)
-        else { return }
-        close()
+        guard let capabilities = discoveryModel?.capabilities else { return }
+        Task {
+            guard await appState.openDiscoveredACPSession(
+                session,
+                capabilities: capabilities
+            ) else { return }
+            close()
+        }
     }
 
     private func backToAgents() {

--- a/Alas/Sources/App/AlasApp.swift
+++ b/Alas/Sources/App/AlasApp.swift
@@ -3,6 +3,7 @@ import SwiftUI
 
 @main
 struct AlasApp: App {
+    @NSApplicationDelegateAdaptor(AlasApplicationDelegate.self) private var appDelegate
     @State private var state = AppState()
 
     private static var isRunningUnitTests: Bool {

--- a/Alas/Sources/App/AlasApplicationDelegate.swift
+++ b/Alas/Sources/App/AlasApplicationDelegate.swift
@@ -1,0 +1,27 @@
+import AppKit
+
+@MainActor
+final class AlasTerminationCoordinator {
+    static let shared = AlasTerminationCoordinator()
+
+    var flush: (() async -> Void)?
+
+    private init() {}
+}
+
+@MainActor
+final class AlasApplicationDelegate: NSObject, NSApplicationDelegate {
+    private var terminationInProgress = false
+
+    func applicationShouldTerminate(_ sender: NSApplication) -> NSApplication.TerminateReply {
+        guard !terminationInProgress, let flush = AlasTerminationCoordinator.shared.flush else {
+            return .terminateNow
+        }
+        terminationInProgress = true
+        Task {
+            await flush()
+            sender.reply(toApplicationShouldTerminate: true)
+        }
+        return .terminateLater
+    }
+}

--- a/Alas/Sources/App/AppState.swift
+++ b/Alas/Sources/App/AppState.swift
@@ -498,6 +498,9 @@ final class AppState {
         // we'd resolve to a 0-element id list. RootView calls reloadTabs() after
         // refreshAll() returns.
         rightPaneStore.appState = self
+        AlasTerminationCoordinator.shared.flush = { [weak self] in
+            await self?.flushAllACPComposerDrafts()
+        }
 
         // Kick off a background resolution of the user's login-shell PATH so
         // every `Process.git()` invocation uses the same environment a terminal
@@ -3464,9 +3467,12 @@ final class AppState {
     /// all live managers. Called from app-will-terminate so an in-flight
     /// typing burst doesn't lose its last ~300ms of input to the
     /// debounce window.
-    func flushAllACPComposerDrafts() {
+    func flushAllACPComposerDrafts() async {
         for manager in acpManagers.values {
             manager.flushPendingDraftWrites()
+        }
+        for manager in acpManagers.values {
+            await manager.flushAllPersistence()
         }
     }
 
@@ -3517,51 +3523,47 @@ final class AppState {
     }
 
     /// Returns (or lazily creates) the ACP session manager for the given worktree.
-    /// Returns nil when the SQLite backing store cannot be opened.
+    /// Store opening and migration happen lazily on the persistence actor.
     func acpManager(for worktree: Worktree) -> ACPSessionManager? {
         if let existing = acpManagers[worktree.id] { return existing }
         let dbURL = Paths.acpSessionsDB(forWorktreeId: worktree.id)
-        do {
-            let store = try ACPSessionStore(path: dbURL.path)
-            let mgr = ACPSessionManager(
-                worktreeId: worktree.id,
-                worktreePath: worktree.path.path,
-                store: store,
-                instanceId: instanceId,
-                pid: Int64(ProcessInfo.processInfo.processIdentifier),
-                hydratorPath: dbURL.path,
-                onDirtyCheck: { [weak self] path in
-                    self?.editorHasDirtyBuffer(for: path, worktreeId: worktree.id) ?? false
-                },
-                onLiveBufferRead: { [weak self] path in
-                    self?.editorLiveBufferText(for: path, worktreeId: worktree.id)
-                },
-                onSessionTitleUpdated: { [weak self] sessionId, title in
-                    _ = self?.tabs.renameACPSessionTabs(
-                        worktreeId: worktree.id,
-                        sessionId: sessionId,
-                        title: title
-                    )
-                },
-                mcpProjectContextProvider: { [weak self] in
-                    guard let project = self?.projects.first(where: { $0.id == worktree.projectId }) else {
-                        return nil
-                    }
-                    return MCPProjectContext(
-                        projectDirectory: project.path,
-                        configuredServers: project.mcpServers
-                    )
+        let persistence = ACPSessionPersistence(path: dbURL.path)
+        let mgr = ACPSessionManager(
+            worktreeId: worktree.id,
+            worktreePath: worktree.path.path,
+            persistence: persistence,
+            instanceId: instanceId,
+            pid: Int64(ProcessInfo.processInfo.processIdentifier),
+            hydratorPath: dbURL.path,
+            onDirtyCheck: { [weak self] path in
+                self?.editorHasDirtyBuffer(for: path, worktreeId: worktree.id) ?? false
+            },
+            onLiveBufferRead: { [weak self] path in
+                self?.editorLiveBufferText(for: path, worktreeId: worktree.id)
+            },
+            onSessionTitleUpdated: { [weak self] sessionId, title in
+                _ = self?.tabs.renameACPSessionTabs(
+                    worktreeId: worktree.id,
+                    sessionId: sessionId,
+                    title: title
+                )
+            },
+            mcpProjectContextProvider: { [weak self] in
+                guard let project = self?.projects.first(where: { $0.id == worktree.projectId }) else {
+                    return nil
                 }
-            )
-            acpManagers[worktree.id] = mgr
-            acpHarnessBridge.attach(manager: mgr)
-            #if DEBUG
-            memoryDiagnostics.attach(manager: mgr)
-            #endif
-            return mgr
-        } catch {
-            return nil
-        }
+                return MCPProjectContext(
+                    projectDirectory: project.path,
+                    configuredServers: project.mcpServers
+                )
+            }
+        )
+        acpManagers[worktree.id] = mgr
+        acpHarnessBridge.attach(manager: mgr)
+        #if DEBUG
+        memoryDiagnostics.attach(manager: mgr)
+        #endif
+        return mgr
     }
 
     /// Release the ACP session manager for the given worktree id.
@@ -3595,6 +3597,7 @@ final class AppState {
         // notifier subscriptions from outliving the manager.
         manager.shutdownBackgroundTasks()
         Task { @MainActor in
+            await manager.flushAllPersistence()
             for sid in sessionIds { await manager.detach(sessionId: sid) }
             // Release any leases this manager still owns AFTER all runner
             // connections are shut down (detach above). A freed lease must
@@ -3602,7 +3605,7 @@ final class AppState {
             // `detach` already released runner-session leases; this mops up
             // any remaining pre-runner owned leases (e.g. sessions acquired
             // a lease but didn't register a runner yet).
-            manager.releaseAllOwnedLeases()
+            await manager.releaseAllOwnedLeases()
         }
     }
 
@@ -3698,7 +3701,7 @@ final class AppState {
     /// for this session is already open in the current worktree we
     /// just focus it; otherwise we create one and let openSession()
     /// rehydrate the transcript from disk.
-    func openExistingACPSession(sessionId: ACPSession.ID) {
+    func openExistingACPSession(sessionId: ACPSession.ID) async {
         guard let worktreeId = selectedWorktreeId,
               let worktree = worktree(withId: worktreeId) else { return }
         guard let mgr = acpManager(for: worktree) else { return }
@@ -3713,9 +3716,12 @@ final class AppState {
             return
         }
 
-        // Load the row so we can stamp the right title onto the new tab.
+        // Resolve an uncached row before creating the tab so hydration cannot
+        // leave a generic title behind indefinitely.
         let title: String
-        if let row = try? mgr.store.loadSession(id: sessionId) {
+        if let liveTitle = mgr.liveSession(for: sessionId)?.title {
+            title = liveTitle
+        } else if let row = await mgr.persistedSessionRow(id: sessionId) {
             title = row.title
         } else {
             title = "ACP session"
@@ -3729,24 +3735,24 @@ final class AppState {
     func openDiscoveredACPSession(
         _ discovered: ACPDiscoveredSession,
         capabilities: ACPSessionDiscoveryCapabilities
-    ) -> Bool {
+    ) async -> Bool {
         guard let resolved = projectAndWorktree(withWorktreeId: discovered.worktreeId),
               let manager = acpManager(for: resolved.worktree)
         else { return false }
 
         focusGlobalWorktree(id: resolved.worktree.id, projectId: resolved.project.id)
         if let localSessionId = discovered.localSessionId {
-            openExistingACPSession(sessionId: localSessionId)
+            await openExistingACPSession(sessionId: localSessionId)
             return true
         }
         guard capabilities.canOpenRemoteSession,
-              let row = manager.materializeDiscoveredSession(
+              let row = await manager.materializeDiscoveredSession(
                 discovered,
                 autoRunDefault: config.harness.acpAutoRunByDefault
               )
         else { return false }
 
-        openExistingACPSession(sessionId: row.id)
+        await openExistingACPSession(sessionId: row.id)
         return true
     }
 
@@ -4141,9 +4147,12 @@ extension AppState: RemoteSessionsProvider {
         return nil
     }
 
-    func fullToolCallContent(sessionId: String, toolCallId: String) -> String? {
+    func fullToolCallContent(sessionId: String, toolCallId: String) async -> String? {
         for mgr in acpManagers.values {
-            if let content = mgr.reloadFullToolCallContent(sessionId: sessionId, toolCallId: toolCallId) {
+            if let content = await mgr.reloadFullToolCallContent(
+                sessionId: sessionId,
+                toolCallId: toolCallId
+            ) {
                 return content
             }
         }
@@ -4188,18 +4197,18 @@ extension AppState: RemoteSessionsProvider {
         return false
     }
 
-    func takeOver(for id: String) {
+    func takeOver(for id: String) async {
         for mgr in acpManagers.values where mgr.liveSession(for: id) != nil {
-            mgr.takeOver(sessionId: id)
+            await mgr.takeOver(sessionId: id)
             return
         }
     }
 
     /// `onResult` fires once (false when no manager owns the id, the manager
     /// refuses, or delivery later fails) so the gateway can restore the text.
-    func sendPrompt(for id: String, text: String, attachments: [ACPMessage.Attachment], onResult: @escaping @MainActor (Bool) -> Void) {
+    func sendPrompt(for id: String, text: String, attachments: [ACPMessage.Attachment], onResult: @escaping @MainActor (Bool) -> Void) async {
         for mgr in acpManagers.values where mgr.liveSession(for: id) != nil {
-            mgr.sendPrompt(for: id, text: text, attachments: attachments, onResult: onResult)
+            await mgr.sendPrompt(for: id, text: text, attachments: attachments, onResult: onResult)
             return
         }
         onResult(false)
@@ -4216,30 +4225,30 @@ extension AppState: RemoteSessionsProvider {
         return url
     }
 
-    func stop(for id: String) {
+    func stop(for id: String) async {
         for mgr in acpManagers.values where mgr.liveSession(for: id) != nil {
-            mgr.interrupt(for: id)
+            await mgr.interrupt(for: id)
             return
         }
     }
 
-    func setModel(for id: String, modelId: String) {
+    func setModel(for id: String, modelId: String) async {
         for mgr in acpManagers.values where mgr.liveSession(for: id) != nil {
-            mgr.setModel(for: id, modelId: modelId)
+            await mgr.setModel(for: id, modelId: modelId)
             return
         }
     }
 
-    func setMode(for id: String, modeId: String) {
+    func setMode(for id: String, modeId: String) async {
         for mgr in acpManagers.values where mgr.liveSession(for: id) != nil {
-            mgr.setMode(for: id, modeId: modeId)
+            await mgr.setMode(for: id, modeId: modeId)
             return
         }
     }
 
-    func setAutoRun(for id: String, enabled: Bool) {
+    func setAutoRun(for id: String, enabled: Bool) async {
         for mgr in acpManagers.values where mgr.liveSession(for: id) != nil {
-            mgr.setAutoRun(for: id, enabled: enabled)
+            await mgr.setAutoRun(for: id, enabled: enabled)
             return
         }
     }

--- a/Alas/Sources/App/RootView.swift
+++ b/Alas/Sources/App/RootView.swift
@@ -568,7 +568,6 @@ private struct RootBaseHandlers: ViewModifier {
                 state.flushScheduledSpacesSave()
                 state.stopAllProjectGitWatchers()
                 state.tabs.snapshotDirtyBuffersForQuit()
-                state.flushAllACPComposerDrafts()
                 // Cancel the hook socket accept loop and any pending cursor
                 // idle debouncers before the process tears down. Otherwise
                 // in-flight hook subprocesses (cursor-agent fires a 1s `nc -U`

--- a/Alas/Sources/Center/ReviewWorkspace/ReviewFeedbackAgentSender.swift
+++ b/Alas/Sources/Center/ReviewWorkspace/ReviewFeedbackAgentSender.swift
@@ -68,8 +68,10 @@ struct ReviewFeedbackAgentSender {
                     appState.openNewACPSession(agentID: agentID, initialPrompt: prompt)
                     completion(.success(()))
                 case .existingSession(_, let sessionID, _):
-                    appState.sendPrompt(for: sessionID, text: prompt, attachments: []) { accepted in
-                        completion(accepted ? .success(()) : .failure(ReviewFeedbackAgentSendError.rejected))
+                    Task { @MainActor in
+                        await appState.sendPrompt(for: sessionID, text: prompt, attachments: []) { accepted in
+                            completion(accepted ? .success(()) : .failure(ReviewFeedbackAgentSendError.rejected))
+                        }
                     }
                 }
             }

--- a/Alas/Sources/Remote/Gateway/RemoteSessionGateway.swift
+++ b/Alas/Sources/Remote/Gateway/RemoteSessionGateway.swift
@@ -57,7 +57,7 @@ final class RemoteSessionGateway {
                 send(.sessionClosed(sessionId: id))
                 return
             }
-            sendSnapshot(id: id, session: session)
+            await sendSnapshot(id: id, session: session)
             if let cfg = provider.sessionConfig(for: id) {
                 send(.sessionConfig(cfg))
             }
@@ -74,7 +74,7 @@ final class RemoteSessionGateway {
             lastQuestionReq[id] = nil
             lastElicitationReq[id] = nil
         case .permissionDecision(let id, let requestId, let optionId, let persistScope):
-            applyDecision(sessionId: id, requestId: requestId, optionId: optionId, persistScope: persistScope)
+            await applyDecision(sessionId: id, requestId: requestId, optionId: optionId, persistScope: persistScope)
         case .questionAnswer(let id, let requestId, let answers):
             applyQuestionAnswer(sessionId: id, requestId: requestId, answers: answers)
         case .elicitationResponse(let id, let requestId, let action, let content):
@@ -85,7 +85,7 @@ final class RemoteSessionGateway {
                 content: content
             )
         case .takeOver(let id):
-            provider.takeOver(for: id)
+            await provider.takeOver(for: id)
             // Takeover seizes the writer lease synchronously but mostly mutates
             // lease/agent state, not the transcript — so the objectWillChange
             // delta that normally carries `canDrive` may never fire on an idle
@@ -94,7 +94,7 @@ final class RemoteSessionGateway {
             // button stays up and sendPrompt stays blocked until some unrelated
             // transcript mutation happens to occur).
             if let session = provider.session(for: id) {
-                sendSnapshot(id: id, session: session)
+                await sendSnapshot(id: id, session: session)
             }
         case .sendPrompt(let id, let text, let attachments):
             // Pre-check the lease BEFORE materializing — `materialize` writes the
@@ -131,7 +131,7 @@ final class RemoteSessionGateway {
             // these file URIs (the transcript bubble references them), so we
             // must keep the files.
             var refusalIsSynchronous = true
-            provider.sendPrompt(for: id, text: trimmed, attachments: materialized) { [weak self] accepted in
+            await provider.sendPrompt(for: id, text: trimmed, attachments: materialized) { [weak self] accepted in
                 guard let self else { return }
                 if !accepted {
                     self.send(.promptRejected(sessionId: id))
@@ -141,16 +141,16 @@ final class RemoteSessionGateway {
             refusalIsSynchronous = false
         case .stop(let id):
             guard provider.isWriter(for: id) else { return }
-            provider.stop(for: id)
+            await provider.stop(for: id)
         case .setModel(let id, let modelId):
             guard provider.isWriter(for: id) else { return }
-            provider.setModel(for: id, modelId: modelId)
+            await provider.setModel(for: id, modelId: modelId)
         case .setMode(let id, let modeId):
             guard provider.isWriter(for: id) else { return }
-            provider.setMode(for: id, modeId: modeId)
+            await provider.setMode(for: id, modeId: modeId)
         case .setAutoRun(let id, let enabled):
             guard provider.isWriter(for: id) else { return }
-            provider.setAutoRun(for: id, enabled: enabled)
+            await provider.setAutoRun(for: id, enabled: enabled)
         case .renameSession(let id, let title):
             let trimmed = title.trimmingCharacters(in: .whitespacesAndNewlines)
             guard !trimmed.isEmpty else { return }
@@ -259,8 +259,8 @@ final class RemoteSessionGateway {
 
     // MARK: snapshot / delta
 
-    private func sendSnapshot(id: String, session: ACPSession) {
-        let wire = wireMessages(id: id, session: session)
+    private func sendSnapshot(id: String, session: ACPSession) async {
+        let wire = await wireMessages(id: id, session: session)
         send(.transcriptSnapshot(sessionId: id,
                                  streamingState: Self.stateString(session.transcript.streamingState),
                                  canDrive: provider.isWriter(for: id),
@@ -284,7 +284,7 @@ final class RemoteSessionGateway {
             self.coalesce[id] = Task { @MainActor [weak self, weak session] in
                 try? await Task.sleep(nanoseconds: Self.coalesceNanos)
                 guard !Task.isCancelled, let self, let session else { return }
-                self.sendDelta(id: id, session: session)
+                await self.sendDelta(id: id, session: session)
             }
         }
         // Re-emit sessionConfig when the session's config publishers change.
@@ -315,10 +315,10 @@ final class RemoteSessionGateway {
         }
     }
 
-    private func sendDelta(id: String, session: ACPSession) {
+    private func sendDelta(id: String, session: ACPSession) async {
         // v1: send a full re-snapshot as the "delta" (simple + always correct).
         // A true per-message diff optimization is intentionally deferred (YAGNI).
-        let wire = wireMessages(id: id, session: session)
+        let wire = await wireMessages(id: id, session: session)
         send(.transcriptDelta(sessionId: id,
                               streamingState: Self.stateString(session.transcript.streamingState),
                               canDrive: provider.isWriter(for: id),
@@ -328,21 +328,27 @@ final class RemoteSessionGateway {
         emitPendingElicitationIfAny(id: id, session: session)
     }
 
-    private func wireMessages(id: String, session: ACPSession) -> [RemoteWireMessage] {
-        session.transcript.messages.enumerated().map { index, message in
-            Self.toWire(
+    private func wireMessages(id: String, session: ACPSession) async -> [RemoteWireMessage] {
+        var wire: [RemoteWireMessage] = []
+        wire.reserveCapacity(session.transcript.messages.count)
+        for (index, message) in session.transcript.messages.enumerated() {
+            wire.append(Self.toWire(
                 message,
                 index: index,
-                fullToolCallContent: fullToolCallContentIfNeeded(sessionId: id, message: message)
-            )
+                fullToolCallContent: await fullToolCallContentIfNeeded(
+                    sessionId: id,
+                    message: message
+                )
+            ))
         }
+        return wire
     }
 
-    private func fullToolCallContentIfNeeded(sessionId: String, message: ACPMessage) -> String? {
+    private func fullToolCallContentIfNeeded(sessionId: String, message: ACPMessage) async -> String? {
         guard case .toolCall(let toolCall) = message,
               toolCall.isContentTruncated
         else { return nil }
-        return provider.fullToolCallContent(sessionId: sessionId, toolCallId: toolCall.toolCallId)
+        return await provider.fullToolCallContent(sessionId: sessionId, toolCallId: toolCall.toolCallId)
     }
 
     private func emitPendingPermissionIfAny(id: String, session: ACPSession) {
@@ -448,7 +454,7 @@ final class RemoteSessionGateway {
 
     // MARK: decision
 
-    private func applyDecision(sessionId: String, requestId: Int, optionId: String, persistScope: String?) {
+    private func applyDecision(sessionId: String, requestId: Int, optionId: String, persistScope: String?) async {
         guard let session = provider.session(for: sessionId),
               let policy = provider.permissionPolicy(for: sessionId),
               let pending = session.transcript.pendingPermission,
@@ -473,7 +479,7 @@ final class RemoteSessionGateway {
 
         // Same scopeKey derivation as ACPTabView.scopeKey(for:).
         let scopeKey = Self.scopeKey(for: pending.params)
-        policy.userDecided(scopeKey: scopeKey, optionId: optionId, decision: decision, persistScope: scope)
+        await policy.userDecided(scopeKey: scopeKey, optionId: optionId, decision: decision, persistScope: scope)
         lastPermissionReq[sessionId] = nil
         send(.permissionResolved(sessionId: sessionId, requestId: requestId))
     }

--- a/Alas/Sources/Remote/Gateway/RemoteSessionsProvider.swift
+++ b/Alas/Sources/Remote/Gateway/RemoteSessionsProvider.swift
@@ -13,20 +13,20 @@ protocol RemoteSessionsProvider: AnyObject {
     func hydrateIfNeeded(id: String) async
     func answerQuestion(for id: String, requestId: JSONRPCID, _ response: ACPQuestionResponse)
     func respondToUserInput(for id: String, token: UUID, action: ACPUserInputAction)
-    func fullToolCallContent(sessionId: String, toolCallId: String) -> String?
+    func fullToolCallContent(sessionId: String, toolCallId: String) async -> String?
     func isWriter(for id: String) -> Bool
-    func takeOver(for id: String)
+    func takeOver(for id: String) async
     /// `onResult` fires once with the final outcome (false = refused now or
     /// failed delivery later); the gateway emits `promptRejected` on false so
     /// the client can restore the text instead of losing it.
-    func sendPrompt(for id: String, text: String, attachments: [ACPMessage.Attachment], onResult: @escaping @MainActor (Bool) -> Void)
+    func sendPrompt(for id: String, text: String, attachments: [ACPMessage.Attachment], onResult: @escaping @MainActor (Bool) -> Void) async
     /// Decode a base64 image to a file under the session's acp-attachments dir.
     /// Returns the file URL on success, nil on any write error.
     func writeAttachment(_ data: Data, mimeType: String, name: String?, for id: String) -> URL?
-    func stop(for id: String)
-    func setModel(for id: String, modelId: String)
-    func setMode(for id: String, modeId: String)
-    func setAutoRun(for id: String, enabled: Bool)
+    func stop(for id: String) async
+    func setModel(for id: String, modelId: String) async
+    func setMode(for id: String, modeId: String) async
+    func setAutoRun(for id: String, enabled: Bool) async
     func renameSession(for id: String, title: String) -> Bool
     /// Projection of the session's config for the `sessionConfig` wire message,
     /// or nil if the session isn't live.

--- a/Alas/Sources/SQLiteKit/SQLiteDatabase.swift
+++ b/Alas/Sources/SQLiteKit/SQLiteDatabase.swift
@@ -4,7 +4,7 @@ import SQLite3
 final class SQLiteDatabase {
     private var handle: OpaquePointer?
 
-    init(path: String) throws {
+    init(path: String, busyTimeoutMilliseconds: Int32 = 5_000) throws {
         let flags = SQLITE_OPEN_READWRITE | SQLITE_OPEN_CREATE | SQLITE_OPEN_FULLMUTEX
         let rc = sqlite3_open_v2(path, &handle, flags, nil)
         guard rc == SQLITE_OK, let h = handle else {
@@ -12,7 +12,7 @@ final class SQLiteDatabase {
             sqlite3_close(handle)
             throw SQLiteError.openFailed(code: rc, message: msg)
         }
-        sqlite3_busy_timeout(h, 5_000)
+        sqlite3_busy_timeout(h, busyTimeoutMilliseconds)
         _ = sqlite3_exec(h, "PRAGMA journal_mode = WAL;", nil, nil, nil)
         _ = sqlite3_exec(h, "PRAGMA foreign_keys = ON;", nil, nil, nil)
     }

--- a/AlasTests/ACP/ACPSessionManagerLeaseTests.swift
+++ b/AlasTests/ACP/ACPSessionManagerLeaseTests.swift
@@ -14,7 +14,7 @@ import Foundation
     }
 
     @Test("manager exposes its instanceId")
-    func exposesInstanceId() throws {
+    func exposesInstanceId() async throws {
         let url = FileManager.default.temporaryDirectory
             .appendingPathComponent("mgr-\(UUID()).sqlite")
         let store = try ACPSessionStore(path: url.path)
@@ -31,13 +31,44 @@ import Foundation
         let mgrA = tempManager(instanceId: "A", store: storeA)
         let session = mgrA.createSession(agentId: "claude")
 
-        #expect(mgrA.acquireWriterLease(sessionId: session.id) == true)
+        #expect(await mgrA.acquireWriterLease(sessionId: session.id) == true)
         #expect(mgrA.isMirror(sessionId: session.id) == false)
 
         let storeB = try ACPSessionStore(path: url.path)
         let mgrB = tempManager(instanceId: "B", store: storeB)
-        #expect(mgrB.acquireWriterLease(sessionId: session.id) == false)
+        #expect(await mgrB.acquireWriterLease(sessionId: session.id) == false)
         #expect(mgrB.isMirror(sessionId: session.id) == true)
+    }
+
+    @Test("restored session awaiting its first lease observation is a mirror")
+    func restoredSessionAwaitingLeaseObservationIsMirror() throws {
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("mgr-restored-pending-lease-\(UUID()).sqlite")
+        let store = try ACPSessionStore(path: url.path)
+        try store.upsertSession(.init(id: "stored", agentId: "claude", title: "Stored",
+            currentModel: nil, currentMode: nil, autoRun: false,
+            createdAt: 0, updatedAt: 0, lastOpenedAt: 0, archived: false))
+        let manager = tempManager(instanceId: "A", store: store)
+
+        _ = manager.placeholderSession(id: "stored")
+
+        #expect(manager.isMirror(sessionId: "stored") == true)
+    }
+
+    @Test("restored session without a lease observation is writable after hydration")
+    func restoredSessionWithoutObservedLeaseIsWritableAfterHydration() async throws {
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("mgr-restored-no-lease-\(UUID()).sqlite")
+        let store = try ACPSessionStore(path: url.path)
+        try store.upsertSession(.init(id: "stored", agentId: "claude", title: "Stored",
+            currentModel: nil, currentMode: nil, autoRun: false,
+            createdAt: 0, updatedAt: 0, lastOpenedAt: 0, archived: false))
+        let manager = tempManager(instanceId: "A", store: store)
+
+        _ = manager.placeholderSession(id: "stored")
+        await manager.hydrateIfNeeded(id: "stored")
+
+        #expect(manager.isMirror(sessionId: "stored") == false)
     }
 
     @Test("releasing the lease lets another instance claim it")
@@ -47,12 +78,12 @@ import Foundation
         let storeA = try ACPSessionStore(path: url.path)
         let mgrA = tempManager(instanceId: "A", store: storeA)
         let session = mgrA.createSession(agentId: "claude")
-        #expect(mgrA.acquireWriterLease(sessionId: session.id) == true)
-        mgrA.releaseWriterLease(sessionId: session.id)
+        #expect(await mgrA.acquireWriterLease(sessionId: session.id) == true)
+        await mgrA.releaseWriterLease(sessionId: session.id)
 
         let storeB = try ACPSessionStore(path: url.path)
         let mgrB = tempManager(instanceId: "B", store: storeB)
-        #expect(mgrB.acquireWriterLease(sessionId: session.id) == true)
+        #expect(await mgrB.acquireWriterLease(sessionId: session.id) == true)
     }
 
     @Test("mirror re-read applies appended messages from another writer")
@@ -62,7 +93,7 @@ import Foundation
         let storeA = try ACPSessionStore(path: url.path)
         let mgrA = tempManager(instanceId: "A", store: storeA)
         let session = mgrA.createSession(agentId: "claude")
-        _ = mgrA.acquireWriterLease(sessionId: session.id)
+        _ = await mgrA.acquireWriterLease(sessionId: session.id)
 
         // Writer appends a user message directly to the shared DB.
         let msg: ACPMessage = .user(id: UUID(), text: "hello from writer", attachments: [])
@@ -88,35 +119,36 @@ import Foundation
         let storeA = try ACPSessionStore(path: url.path)
         let mgrA = tempManager(instanceId: "A", store: storeA)
         let session = mgrA.createSession(agentId: "claude")
-        _ = mgrA.acquireWriterLease(sessionId: session.id)
+        _ = await mgrA.acquireWriterLease(sessionId: session.id)
         #expect(mgrA.isMirror(sessionId: session.id) == false)
 
         let storeB = try ACPSessionStore(path: url.path)
         let mgrB = tempManager(instanceId: "B", store: storeB)
         _ = mgrB.placeholderSession(id: session.id)
-        mgrB.takeOver(sessionId: session.id)
+        await mgrB.takeOver(sessionId: session.id)
 
         // The synchronous parts (seizeLease + _ownedLeases insert) must have
         // completed before takeOver returns; the async attach kicks off later.
         #expect(try storeB.loadLease(sessionId: session.id)?.ownerInstance == "B")
-        #expect(mgrA.ownsLeaseForTest(sessionId: session.id) == false)
+        #expect(await mgrA.ownsLeaseForTest(sessionId: session.id) == false)
     }
 
-    @Test("heartbeat re-asserts ownership when the lease row went missing")
-    func heartbeatReassertsMissingRow() async throws {
+    @Test("heartbeat stands down when the lease row went missing")
+    func heartbeatStandsDownForMissingRow() async throws {
         let url = FileManager.default.temporaryDirectory
             .appendingPathComponent("hb-missing-\(UUID()).sqlite")
         let store = try ACPSessionStore(path: url.path)
         let mgr = tempManager(instanceId: "A", store: store)
         let session = mgr.createSession(agentId: "claude")
-        #expect(mgr.acquireWriterLease(sessionId: session.id) == true)
+        #expect(await mgr.acquireWriterLease(sessionId: session.id) == true)
         // Simulate a failed-takeover deleting the row out from under us.
         try store.releaseLease(sessionId: session.id, instanceId: "A")
         #expect(try store.loadLease(sessionId: session.id) == nil)
-        // A heartbeat tick should re-assert our ownership, not stand down.
-        let standDown = mgr.heartbeatTickForTest(sessionId: session.id)
-        #expect(standDown == false)
-        #expect(try store.loadLease(sessionId: session.id)?.ownerInstance == "A")
+        // Missing ownership is ambiguous. Fail closed instead of recreating a
+        // lease that may have been deliberately removed during takeover.
+        let standDown = await mgr.heartbeatTickForTest(sessionId: session.id)
+        #expect(standDown == true)
+        #expect(try store.loadLease(sessionId: session.id) == nil)
     }
 
     @Test("heartbeat signals stand-down when another instance owns the lease")
@@ -126,11 +158,11 @@ import Foundation
         let storeA = try ACPSessionStore(path: url.path)
         let mgrA = tempManager(instanceId: "A", store: storeA)
         let session = mgrA.createSession(agentId: "claude")
-        #expect(mgrA.acquireWriterLease(sessionId: session.id) == true)
+        #expect(await mgrA.acquireWriterLease(sessionId: session.id) == true)
         // B seizes it.
         let now = Int64(Date().timeIntervalSince1970)
         try storeA.seizeLease(sessionId: session.id, instanceId: "B", pid: Int64(getpid()), now: now)
-        #expect(mgrA.heartbeatTickForTest(sessionId: session.id) == true)   // A should stand down
+        #expect(await mgrA.heartbeatTickForTest(sessionId: session.id) == true)   // A should stand down
     }
 
     @Test("a failed attach releases the writer lease")
@@ -151,25 +183,25 @@ import Foundation
         let mgrB = ACPSessionManager(
             worktreeId: "wt", worktreePath: "/tmp/wt",
             store: storeB, instanceId: "B", pid: Int64(getpid()))
-        #expect(mgrB.acquireWriterLease(sessionId: session.id) == true)
+        #expect(await mgrB.acquireWriterLease(sessionId: session.id) == true)
     }
 
     // MARK: - P1: Queue-write lease guard
 
     @Test("mirror cannot persist the queue; writer can")
-    func mirrorCannotPersistQueue() throws {
+    func mirrorCannotPersistQueue() async throws {
         let url = FileManager.default.temporaryDirectory
             .appendingPathComponent("queue-guard-\(UUID()).sqlite")
         // Writer: instance A owns the lease.
         let storeA = try ACPSessionStore(path: url.path)
         let mgrA = tempManager(instanceId: "A", store: storeA)
         let session = mgrA.createSession(agentId: "claude")
-        #expect(mgrA.acquireWriterLease(sessionId: session.id) == true)
+        #expect(await mgrA.acquireWriterLease(sessionId: session.id) == true)
 
         // Mirror: instance B fails to acquire.
         let storeB = try ACPSessionStore(path: url.path)
         let mgrB = tempManager(instanceId: "B", store: storeB)
-        #expect(mgrB.acquireWriterLease(sessionId: session.id) == false)
+        #expect(await mgrB.acquireWriterLease(sessionId: session.id) == false)
 
         // Give mgrB a placeholder session so it has a local ACPSession to work with.
         let mirrorSession = mgrB.placeholderSession(id: session.id)
@@ -181,6 +213,7 @@ import Foundation
 
         // Mirror calls persistQueue — must be a no-op at the store level.
         mgrB.persistQueue(for: mirrorSession!)
+        await mgrB.flushPersistence()
         let storedAfterMirrorWrite = try storeB.loadQueue(sessionId: session.id)
         #expect(storedAfterMirrorWrite.isEmpty,
                 "mirror must not write session_queue when it does not hold the lease")
@@ -188,6 +221,7 @@ import Foundation
         // Positive case: writer can persist its queue.
         session.enqueue(blocks: [.text("writer prompt")])
         mgrA.persistQueue(for: session)
+        await mgrA.flushPersistence()
         let storedAfterWriterWrite = try storeA.loadQueue(sessionId: session.id)
         #expect(storedAfterWriterWrite.count == 1,
                 "writer must be able to persist the queue when it holds the lease")
@@ -202,7 +236,7 @@ import Foundation
         let storeA = try ACPSessionStore(path: url.path)
         let mgrA = tempManager(instanceId: "A", store: storeA)
         let session = mgrA.createSession(agentId: "claude")
-        #expect(mgrA.acquireWriterLease(sessionId: session.id) == true)   // A owns it (in _ownedLeases)
+        #expect(await mgrA.acquireWriterLease(sessionId: session.id) == true)   // A owns it (in _ownedLeases)
         // B seizes the lease in the shared store (takeover) — A's _ownedLeases is now stale.
         let now = Int64(Date().timeIntervalSince1970)
         try storeA.seizeLease(sessionId: session.id, instanceId: "B", pid: Int64(getpid()), now: now)
@@ -214,6 +248,7 @@ import Foundation
         #expect(session.queue.count == 1)
         // A still THINKS it owns the session in memory, but a manager write must be blocked.
         mgrA.persistQueue(for: session)
+        await mgrA.flushPersistence()
         let stored = try storeA.loadQueue(sessionId: session.id)
         #expect(stored.isEmpty,
                 "former owner must not write queue when another live instance owns the store lease")
@@ -222,18 +257,18 @@ import Foundation
     // MARK: - P2: Mirror poll teardown on eviction
 
     @Test("endMirroring is idempotent and evictIfIdle cancels the mirror poll")
-    func mirrorPollCancelledOnEvict() throws {
+    func mirrorPollCancelledOnEvict() async throws {
         let url = FileManager.default.temporaryDirectory
             .appendingPathComponent("evict-mirror-\(UUID()).sqlite")
         let storeA = try ACPSessionStore(path: url.path)
         let mgrA = tempManager(instanceId: "A", store: storeA)
         let sessionA = mgrA.createSession(agentId: "claude")
-        #expect(mgrA.acquireWriterLease(sessionId: sessionA.id) == true)
+        #expect(await mgrA.acquireWriterLease(sessionId: sessionA.id) == true)
 
         // Instance B mirrors the session.
         let storeB = try ACPSessionStore(path: url.path)
         let mgrB = tempManager(instanceId: "B", store: storeB)
-        #expect(mgrB.acquireWriterLease(sessionId: sessionA.id) == false)
+        #expect(await mgrB.acquireWriterLease(sessionId: sessionA.id) == false)
         let mirrorSession = mgrB.placeholderSession(id: sessionA.id)
         #expect(mirrorSession != nil)
         mgrB.beginMirroring(sessionId: sessionA.id)
@@ -270,15 +305,15 @@ import Foundation
 
     // MARK: - Fix 2: isMirror reads store even when _ownedLeases is stale
 
-    @Test("isMirror reads store even when _ownedLeases is stale after takeover")
-    func isMirrorReadsStoreAfterTakeover() throws {
+    @Test("heartbeat detects takeover while cached ownership is stale")
+    func heartbeatDetectsTakeover() async throws {
         let url = FileManager.default.temporaryDirectory
             .appendingPathComponent("mirror-stale-\(UUID()).sqlite")
         let storeA = try ACPSessionStore(path: url.path)
         let mgrA = tempManager(instanceId: "A", store: storeA)
         let session = mgrA.createSession(agentId: "claude")
         // A acquires — now in both _ownedLeases and the store.
-        #expect(mgrA.acquireWriterLease(sessionId: session.id) == true)
+        #expect(await mgrA.acquireWriterLease(sessionId: session.id) == true)
         #expect(mgrA.isMirror(sessionId: session.id) == false)
 
         // B seizes the lease in the shared store (simulates takeOver).
@@ -286,30 +321,30 @@ import Foundation
         try storeA.seizeLease(sessionId: session.id, instanceId: "B",
                               pid: Int64(getpid()), now: now)
 
-        // A's _ownedLeases still contains the session (stale), but
-        // isMirror must now return true because the store says B owns it.
+        // A's cache is intentionally stale until its writer watch or heartbeat
+        // refreshes it. The transactional lease fence blocks writes meanwhile.
         #expect(mgrA._ownedLeases.contains(session.id),
                 "precondition: _ownedLeases is stale (still contains sessionId)")
-        #expect(mgrA.isMirror(sessionId: session.id) == true,
-                "isMirror must read the store and reflect that B is now the owner")
+        #expect(await mgrA.heartbeatTickForTest(sessionId: session.id),
+                "heartbeat must detect that B now owns the lease")
     }
 
     // MARK: - Fix 1: Writer-watch stand-down on takeover ping
 
     @Test("startWriterWatch activates a token; stopWriterWatch removes it")
-    func writerWatchTokenLifecycle() throws {
+    func writerWatchTokenLifecycle() async throws {
         let url = FileManager.default.temporaryDirectory
             .appendingPathComponent("ww-lifecycle-\(UUID()).sqlite")
         let store = try ACPSessionStore(path: url.path)
         let mgr = tempManager(instanceId: "A", store: store)
         let session = mgr.createSession(agentId: "claude")
-        #expect(mgr.acquireWriterLease(sessionId: session.id) == true)
+        #expect(await mgr.acquireWriterLease(sessionId: session.id) == true)
 
         // Before anything: no writer-watch token.
         #expect(mgr.writerWatchActiveForTest(sessionId: session.id) == false)
 
         // heartbeatTick while we still own it returns false (no stand-down).
-        #expect(mgr.heartbeatTickForTest(sessionId: session.id) == false)
+        #expect(await mgr.heartbeatTickForTest(sessionId: session.id) == false)
 
         // Simulate what attach/takeOver does: acquire + startWriterWatch.
         // We test the token bookkeeping synchronously here; the async
@@ -329,18 +364,18 @@ import Foundation
         let now = Int64(Date().timeIntervalSince1970)
         try store.seizeLease(sessionId: session.id, instanceId: "B",
                              pid: Int64(getpid()), now: now)
-        #expect(mgr.heartbeatTickForTest(sessionId: session.id) == true,
+        #expect(await mgr.heartbeatTickForTest(sessionId: session.id) == true,
                 "heartbeatTick must return true (stand-down) when another instance owns the lease")
     }
 
     @Test("shutdownBackgroundTasks cancels writer-watch tokens")
-    func shutdownCancelsWriterWatch() throws {
+    func shutdownCancelsWriterWatch() async throws {
         let url = FileManager.default.temporaryDirectory
             .appendingPathComponent("ww-shutdown-\(UUID()).sqlite")
         let storeA = try ACPSessionStore(path: url.path)
         let mgrA = tempManager(instanceId: "A", store: storeA)
         let session = mgrA.createSession(agentId: "claude")
-        _ = mgrA.acquireWriterLease(sessionId: session.id)
+        _ = await mgrA.acquireWriterLease(sessionId: session.id)
 
         // Simulate becoming a writer by calling takeOver on a fresh manager.
         // takeOver calls startWriterWatch internally.
@@ -348,7 +383,7 @@ import Foundation
         let mgrB = tempManager(instanceId: "B", store: storeB)
         _ = mgrB.placeholderSession(id: session.id)
         // B takes over — it calls startWriterWatch on B's manager.
-        mgrB.takeOver(sessionId: session.id)
+        await mgrB.takeOver(sessionId: session.id)
         #expect(mgrB.writerWatchActiveForTest(sessionId: session.id) == true,
                 "takeOver must activate the writer-watch subscription")
 
@@ -371,7 +406,7 @@ import Foundation
         // Simulate the "attach window": A holds the lease + heartbeat + writer-watch
         // but no runner has been registered yet (i.e. the runner registration step
         // inside `attach` hasn't been reached).
-        #expect(mgrA.acquireWriterLease(sessionId: session.id) == true)
+        #expect(await mgrA.acquireWriterLease(sessionId: session.id) == true)
         // Manually start heartbeat and writer-watch via beginMirroring + takeOver
         // side-effect free path: just verify lease is released by detach with no runner.
         _ = mgrA.sessions[session.id]   // ensure session is cached
@@ -385,7 +420,7 @@ import Foundation
         // Lease must be released so another instance can acquire it.
         let storeB = try ACPSessionStore(path: url.path)
         let mgrB = tempManager(instanceId: "B", store: storeB)
-        #expect(mgrB.acquireWriterLease(sessionId: session.id) == true,
+        #expect(await mgrB.acquireWriterLease(sessionId: session.id) == true,
                 "another instance must be able to acquire the lease after detach")
         // Mirror and writer-watch must not be active after detach.
         #expect(!mgrA.mirrorPollActiveForTest(sessionId: session.id),
@@ -397,13 +432,13 @@ import Foundation
     // MARK: - Fix 2 (P1): takeOver refreshes remoteSessionId from store
 
     @Test("takeOver refreshes remoteSessionId from store when cached value is nil")
-    func takeOverRefreshesRemoteSessionId() throws {
+    func takeOverRefreshesRemoteSessionId() async throws {
         let url = FileManager.default.temporaryDirectory
             .appendingPathComponent("takeover-remote-\(UUID()).sqlite")
         let storeA = try ACPSessionStore(path: url.path)
         let mgrA = tempManager(instanceId: "A", store: storeA)
         let session = mgrA.createSession(agentId: "claude")
-        _ = mgrA.acquireWriterLease(sessionId: session.id)
+        _ = await mgrA.acquireWriterLease(sessionId: session.id)
 
         // Writer (A) persists a non-empty remote_session_id into the store —
         // this happens after session/new completes in a real attach.
@@ -425,7 +460,7 @@ import Foundation
         mirrorSession!.remoteSessionId = nil   // simulate stale mirror
 
         // B takes over — must refresh from the store before spawning attach.
-        mgrB.takeOver(sessionId: session.id)
+        await mgrB.takeOver(sessionId: session.id)
 
         // The synchronous refresh inside takeOver must have restored the stored value.
         #expect(mgrB.sessions[session.id]?.remoteSessionId == remoteId,
@@ -441,11 +476,12 @@ import Foundation
         let storeA = try ACPSessionStore(path: url.path)
         let mgrA = tempManager(instanceId: "A", store: storeA)
         let session = mgrA.createSession(agentId: "claude")
-        _ = mgrA.acquireWriterLease(sessionId: session.id)
+        _ = await mgrA.acquireWriterLease(sessionId: session.id)
 
         // Writer enqueues a prompt and persists it to the shared store.
         session.enqueue(blocks: [.text("queued from writer")])
         mgrA.persistQueue(for: session)
+        await mgrA.flushPersistence()
         let storedBeforeRefresh = try storeA.loadQueue(sessionId: session.id)
         #expect(storedBeforeRefresh.count == 1,
                 "precondition: writer persisted one queue item")
@@ -486,7 +522,7 @@ import Foundation
         let storeA = try ACPSessionStore(path: url.path)
         let mgrA = tempManager(instanceId: "A", store: storeA)
         let session = mgrA.createSession(agentId: "claude")
-        _ = mgrA.acquireWriterLease(sessionId: session.id)
+        _ = await mgrA.acquireWriterLease(sessionId: session.id)
 
         // Mirror instance creates a placeholder (queue starts empty, no transcript rows).
         let storeB = try ACPSessionStore(path: url.path)
@@ -499,6 +535,7 @@ import Foundation
         // Writer persists a queue item WITHOUT adding any transcript messages.
         session.enqueue(blocks: [.text("writer queued item")])
         mgrA.persistQueue(for: session)
+        await mgrA.flushPersistence()
         let storedQueue = try storeA.loadQueue(sessionId: session.id)
         #expect(storedQueue.count == 1, "precondition: writer persisted one queue item")
         #expect((try? storeA.loadMessages(sessionId: session.id))?.isEmpty != false,
@@ -581,7 +618,7 @@ import Foundation
     }
 
     @Test("mirror poll slows when the session tab is not visible")
-    func mirrorPollIntervalTracksVisibleTab() throws {
+    func mirrorPollIntervalTracksVisibleTab() async throws {
         let url = FileManager.default.temporaryDirectory
             .appendingPathComponent("mirror-interval-\(UUID()).sqlite")
         let store = try ACPSessionStore(path: url.path)
@@ -602,7 +639,8 @@ import Foundation
         let storeA = try ACPSessionStore(path: url.path)
         let mgrA = tempManager(instanceId: "A", store: storeA)
         let session = mgrA.createSession(agentId: "claude")
-        _ = mgrA.acquireWriterLease(sessionId: session.id)
+        await mgrA.flushPersistence()
+        _ = await mgrA.acquireWriterLease(sessionId: session.id)
 
         let storeB = try ACPSessionStore(path: url.path)
         let mgrB = tempManager(instanceId: "B", store: storeB, hydratorPath: url.path)
@@ -632,7 +670,7 @@ import Foundation
     // MARK: - Fix 2 (P2): standDown on closed session doesn't start mirroring
 
     @Test("beginMirroring on a non-existent session is a no-op (no poll started)")
-    func beginMirroringNonExistentSessionIsNoop() throws {
+    func beginMirroringNonExistentSessionIsNoop() async throws {
         let url = FileManager.default.temporaryDirectory
             .appendingPathComponent("beginmirror-noop-\(UUID()).sqlite")
         let store = try ACPSessionStore(path: url.path)
@@ -673,6 +711,7 @@ import Foundation
             })
 
         let session = mgrA.createSession(agentId: "claude")
+        await mgrA.flushPersistence()
         // Persist a remote session id so the attach takes the loadSession path.
         let remoteId = "remote-abc"
         session.remoteSessionId = remoteId
@@ -703,14 +742,14 @@ import Foundation
 
     // MARK: - Fix 3: anotherLiveInstanceOwnsLease predicate (attach re-check)
 
-    @Test("anotherLiveInstanceOwnsLease returns true after a takeover seizes the store")
-    func anotherLiveInstanceOwnsLeaseAfterSeize() throws {
+    @Test("takeover is detected without a synchronous store read")
+    func takeoverDetectedAsynchronously() async throws {
         let url = FileManager.default.temporaryDirectory
             .appendingPathComponent("aliol-\(UUID()).sqlite")
         let storeA = try ACPSessionStore(path: url.path)
         let mgrA = tempManager(instanceId: "A", store: storeA)
         let session = mgrA.createSession(agentId: "claude")
-        #expect(mgrA.acquireWriterLease(sessionId: session.id) == true)
+        #expect(await mgrA.acquireWriterLease(sessionId: session.id) == true)
 
         // Before seizure: A owns the lease — not another live instance.
         #expect(mgrA.isMirror(sessionId: session.id) == false)
@@ -720,10 +759,8 @@ import Foundation
         try storeA.seizeLease(sessionId: session.id, instanceId: "B",
                               pid: Int64(getpid()), now: now)
 
-        // The guard predicate in attach must fire.
-        // isMirror now delegates to anotherLiveInstanceOwnsLease directly.
-        #expect(mgrA.isMirror(sessionId: session.id) == true,
-                "isMirror (== anotherLiveInstanceOwnsLease) must be true after B seizes; the attach re-check guard will abort the commit")
+        #expect(await mgrA.heartbeatTickForTest(sessionId: session.id),
+                "the next ownership check must detect the seized lease")
     }
 
     @Test("attach does not commit after the manager is disposed")
@@ -769,7 +806,7 @@ import Foundation
         let mgrA = tempManager(instanceId: "A", store: storeA)
         let session = mgrA.createSession(agentId: "claude")
         // A owns the lease but has no runner (the pre-runner attach window).
-        #expect(mgrA.acquireWriterLease(sessionId: session.id) == true)
+        #expect(await mgrA.acquireWriterLease(sessionId: session.id) == true)
 
         // Simulate the dispose ordering: cancel tasks first, then release
         // leases after connections are shut down.
@@ -778,28 +815,29 @@ import Foundation
         // would be shut down between these two calls in production).
         #expect(mgrA._ownedLeases.contains(session.id),
                 "lease must still be held after shutdownBackgroundTasks (released separately)")
-        mgrA.releaseAllOwnedLeases()
+        await mgrA.releaseAllOwnedLeases()
 
         let storeB = try ACPSessionStore(path: url.path)
         let mgrB = tempManager(instanceId: "B", store: storeB)
-        #expect(mgrB.acquireWriterLease(sessionId: session.id) == true,
+        #expect(await mgrB.acquireWriterLease(sessionId: session.id) == true,
                 "another instance must be able to acquire after releaseAllOwnedLeases")
     }
 
     // MARK: - Fix 2: takeOver refreshes queue from store
 
     @Test("takeOver restores queue from store into the taking-over session")
-    func takeOverRestoresQueueFromStore() throws {
+    func takeOverRestoresQueueFromStore() async throws {
         let url = FileManager.default.temporaryDirectory
             .appendingPathComponent("takeover-queue-\(UUID()).sqlite")
         let storeA = try ACPSessionStore(path: url.path)
         let mgrA = tempManager(instanceId: "A", store: storeA)
         let session = mgrA.createSession(agentId: "claude")
-        _ = mgrA.acquireWriterLease(sessionId: session.id)
+        _ = await mgrA.acquireWriterLease(sessionId: session.id)
 
         // Writer (A) persists a non-empty queue into the store.
         session.enqueue(blocks: [.text("queued item from writer")])
         mgrA.persistQueue(for: session)
+        await mgrA.flushPersistence()
         let stored = try storeA.loadQueue(sessionId: session.id)
         #expect(stored.count == 1, "precondition: writer persisted one queue item")
 
@@ -812,7 +850,7 @@ import Foundation
                 "precondition: mirror placeholder queue is empty before takeOver")
 
         // B takes over — must refresh the queue from the store synchronously.
-        mgrB.takeOver(sessionId: session.id)
+        await mgrB.takeOver(sessionId: session.id)
 
         // The synchronous queue refresh inside takeOver must have restored
         // the persisted queue so the taking-over instance starts from the
@@ -852,7 +890,7 @@ import Foundation
         let attachingSession = mgr.createSession(agentId: "claude")
         // Session whose lease is owned but NOT attaching (plain _ownedLeases entry).
         let ownedSession = mgr.createSession(agentId: "claude")
-        #expect(mgr.acquireWriterLease(sessionId: ownedSession.id) == true,
+        #expect(await mgr.acquireWriterLease(sessionId: ownedSession.id) == true,
                 "precondition: ownedSession lease acquired")
 
         // Start attach in background — blocks inside setupEvaluator.
@@ -873,14 +911,14 @@ import Foundation
 
         // Dispose + release. The attaching session must be skipped.
         mgr.shutdownBackgroundTasks()
-        mgr.releaseAllOwnedLeases()
+        await mgr.releaseAllOwnedLeases()
 
         // Non-attaching owned session must have been released.
         #expect(!mgr._ownedLeases.contains(ownedSession.id),
                 "non-attaching owned session must be removed from _ownedLeases by releaseAllOwnedLeases")
         let storeC = try ACPSessionStore(path: url.path)
         let mgrC = tempManager(instanceId: "C", store: storeC)
-        #expect(mgrC.acquireWriterLease(sessionId: ownedSession.id) == true,
+        #expect(await mgrC.acquireWriterLease(sessionId: ownedSession.id) == true,
                 "non-attaching owned session lease must be claimable after releaseAllOwnedLeases")
 
         // Attaching session's lease must still be held in the store.
@@ -896,7 +934,7 @@ import Foundation
         // After the attach defer runs, the lease must be freed so another instance can claim it.
         let storeD = try ACPSessionStore(path: url.path)
         let mgrD = tempManager(instanceId: "D", store: storeD)
-        #expect(mgrD.acquireWriterLease(sessionId: attachingSession.id) == true,
+        #expect(await mgrD.acquireWriterLease(sessionId: attachingSession.id) == true,
                 "attaching session lease must be released by attach's own defer after the coroutine exits")
     }
 

--- a/AlasTests/ACP/Permissions/ACPPermissionDecisionLogTests.swift
+++ b/AlasTests/ACP/Permissions/ACPPermissionDecisionLogTests.swift
@@ -5,7 +5,7 @@ import Testing
 @Suite("ACPPermissionDecisionLog")
 struct ACPPermissionDecisionLogTests {
     @Test("session-scoped allow is found by exact session id only")
-    func sessionScope() throws {
+    func sessionScope() async throws {
         let url = FileManager.default.temporaryDirectory.appendingPathComponent("perm-\(UUID()).sqlite")
         let store = try ACPSessionStore(path: url.path)
         try store.upsertSession(.init(id: "s1", agentId: "claude", title: "t",
@@ -16,13 +16,13 @@ struct ACPPermissionDecisionLogTests {
             createdAt: 0, updatedAt: 0, lastOpenedAt: 0, archived: false))
 
         let log = ACPPermissionDecisionLog(store: store)
-        try log.record(sessionId: "s1", scopeKey: "tool:bash", decision: .allow, scope: .session)
-        #expect(try log.lookup(sessionId: "s1", scopeKey: "tool:bash") == .allow)
-        #expect(try log.lookup(sessionId: "s2", scopeKey: "tool:bash") == nil)
+        try await log.record(sessionId: "s1", scopeKey: "tool:bash", decision: .allow, scope: .session)
+        #expect(try await log.lookup(sessionId: "s1", scopeKey: "tool:bash") == .allow)
+        #expect(try await log.lookup(sessionId: "s2", scopeKey: "tool:bash") == nil)
     }
 
     @Test("project-scoped allow is found across any session")
-    func projectScope() throws {
+    func projectScope() async throws {
         let url = FileManager.default.temporaryDirectory.appendingPathComponent("perm-\(UUID()).sqlite")
         let store = try ACPSessionStore(path: url.path)
         try store.upsertSession(.init(id: "s1", agentId: "claude", title: "t",
@@ -33,7 +33,7 @@ struct ACPPermissionDecisionLogTests {
             createdAt: 0, updatedAt: 0, lastOpenedAt: 0, archived: false))
 
         let log = ACPPermissionDecisionLog(store: store)
-        try log.record(sessionId: "s1", scopeKey: "tool:bash", decision: .allow, scope: .project)
-        #expect(try log.lookup(sessionId: "s2", scopeKey: "tool:bash") == .allow)
+        try await log.record(sessionId: "s1", scopeKey: "tool:bash", decision: .allow, scope: .project)
+        #expect(try await log.lookup(sessionId: "s2", scopeKey: "tool:bash") == .allow)
     }
 }

--- a/AlasTests/ACP/Permissions/ACPPermissionPolicyTests.swift
+++ b/AlasTests/ACP/Permissions/ACPPermissionPolicyTests.swift
@@ -33,7 +33,7 @@ struct ACPPermissionPolicyTests {
         let store = try makeStore()
         let session = ACPSession(id: "s", agentId: "claude", worktreeId: "wt", title: "t")
         let log = ACPPermissionDecisionLog(store: store)
-        try log.record(sessionId: "s", scopeKey: "tool:bash", decision: .deny, scope: .session)
+        try await log.record(sessionId: "s", scopeKey: "tool:bash", decision: .deny, scope: .session)
         let policy = ACPPermissionPolicy(session: session, log: log)
         let opts: [ACPPermissionOption] = [
             .init(optionId: "allow", name: "Allow", kind: "allow_once"),
@@ -41,6 +41,22 @@ struct ACPPermissionPolicyTests {
         ]
         let resp = await policy.evaluate(scopeKey: "tool:bash", options: opts, params: stubParams())
         #expect(resp.outcome == .selected(optionId: "deny"))
+    }
+
+    @Test("persisted user decisions commit before userDecided returns")
+    func persistedUserDecisionIsAwaited() async throws {
+        let store = try makeStore()
+        let session = ACPSession(id: "s", agentId: "claude", worktreeId: "wt", title: "t")
+        let log = ACPPermissionDecisionLog(store: store)
+        let policy = ACPPermissionPolicy(session: session, log: log)
+        await policy.userDecided(
+            scopeKey: "tool:bash",
+            optionId: "allow",
+            decision: .allow,
+            persistScope: .session
+        )
+
+        #expect(try await log.lookup(sessionId: "s", scopeKey: "tool:bash") == .allow)
     }
 
     private func stubParams() -> ACPPermissionRequestParams {

--- a/AlasTests/ACP/Session/ACPSessionDiscoveryTests.swift
+++ b/AlasTests/ACP/Session/ACPSessionDiscoveryTests.swift
@@ -110,7 +110,7 @@ struct ACPSessionDiscoveryTests {
 
     @MainActor
     @Test("materialization rejects sessions whose additional roots Alas cannot enforce")
-    func materializationRejectsAdditionalDirectories() throws {
+    func materializationRejectsAdditionalDirectories() async throws {
         let store = try temporaryStore()
         let manager = manager(store: store, client: ACPMockClient())
         let discovered = ACPDiscoveredSession(
@@ -124,13 +124,14 @@ struct ACPSessionDiscoveryTests {
             localSessionId: nil
         )
 
-        #expect(manager.materializeDiscoveredSession(discovered) == nil)
+        let materialized = await manager.materializeDiscoveredSession(discovered)
+        #expect(materialized == nil)
         #expect(try store.loadSession(agentId: "claude", remoteSessionId: "remote-extra-roots") == nil)
     }
 
     @MainActor
     @Test("materialization rejects discovery from another worktree")
-    func materializationRejectsAnotherWorktree() throws {
+    func materializationRejectsAnotherWorktree() async throws {
         let store = try temporaryStore()
         let manager = manager(store: store, client: ACPMockClient())
         let discovered = ACPDiscoveredSession(
@@ -144,7 +145,8 @@ struct ACPSessionDiscoveryTests {
             localSessionId: nil
         )
 
-        #expect(manager.materializeDiscoveredSession(discovered) == nil)
+        let materialized = await manager.materializeDiscoveredSession(discovered)
+        #expect(materialized == nil)
         #expect(try store.loadSession(agentId: "claude", remoteSessionId: "remote-other-worktree") == nil)
     }
 

--- a/AlasTests/ACP/Session/ACPSessionManagerRetentionTests.swift
+++ b/AlasTests/ACP/Session/ACPSessionManagerRetentionTests.swift
@@ -97,7 +97,32 @@ struct ACPSessionManagerRetentionTests {
         #expect(mgr.sessions[id] == nil)
         // The store must contain the draft — flushPendingDraftWrite was
         // called inline by evictIfIdle.
-        let loaded = try mgr.store.loadComposerDraft(sessionId: id)
+        await mgr.flushPersistence()
+        let loaded = try await mgr.persistence.loadComposerDraftRecord(sessionId: id)?.draft
+        #expect(loaded == draft)
+    }
+
+    @Test("reopening before an evicted draft commits keeps the flushed draft")
+    func reopenBeforeEvictedDraftCommitUsesHandoff() async throws {
+        let mgr = makeManager()
+        let s = mgr.createSession(agentId: "claude")
+        let id = s.id
+        await mgr.flushPersistence()
+
+        let draft = ACPComposerDraft(segments: [.text("restore immediately")])
+        mgr.persistComposerDraft(draft, for: s)
+        mgr.retainSession(id: id)
+        mgr.releaseSession(id: id)
+        #expect(mgr.sessions[id] == nil)
+
+        let reopened = try #require(mgr.placeholderSession(id: id))
+        #expect(reopened.composerDraft == draft)
+
+        await mgr.hydrateIfNeeded(id: id)
+        #expect(reopened.composerDraft == draft)
+
+        await mgr.flushPersistence()
+        let loaded = try await mgr.persistence.loadComposerDraftRecord(sessionId: id)?.draft
         #expect(loaded == draft)
     }
 }

--- a/AlasTests/ACP/Session/ACPSessionManagerTests.swift
+++ b/AlasTests/ACP/Session/ACPSessionManagerTests.swift
@@ -13,6 +13,7 @@ struct ACPSessionManagerTests {
         let s = mgr.createSession(agentId: "claude")
         #expect(mgr.sessions[s.id] != nil)
         #expect(!s.restoredFromPersistence)
+        await mgr.flushPersistence()
         let row = try store.loadSession(id: s.id)
         #expect(row?.agentId == "claude")
     }
@@ -24,6 +25,7 @@ struct ACPSessionManagerTests {
         let mgr = ACPSessionManager(worktreeId: "/tmp/wt", worktreePath: "/tmp/wt", store: store)
         let s = mgr.createSession(agentId: "claude", autoRunDefault: true)
         #expect(s.autoRunEnabled == true)
+        await mgr.flushPersistence()
         let row = try store.loadSession(id: s.id)
         #expect(row?.autoRun == true)
     }
@@ -35,6 +37,7 @@ struct ACPSessionManagerTests {
         let mgr = ACPSessionManager(worktreeId: "/tmp/wt", worktreePath: "/tmp/wt", store: store)
         let s = mgr.createSession(agentId: "claude")
         #expect(s.autoRunEnabled == false)
+        await mgr.flushPersistence()
         let row = try store.loadSession(id: s.id)
         #expect(row?.autoRun == false)
     }
@@ -113,12 +116,14 @@ struct ACPSessionManagerTests {
         #expect(session.composerDraft == draft)
         #expect(session.composerDraftRevision == 1)
         mgr.flushPendingDraftWrites()
+        await mgr.flushPersistence()
         #expect(try store.loadComposerDraft(sessionId: session.id) == draft)
 
         mgr.persistComposerDraft(.empty, for: session)
         #expect(session.composerDraft == .empty)
         #expect(session.composerDraftRevision == 2)
         mgr.flushPendingDraftWrites()
+        await mgr.flushPersistence()
         #expect(try store.loadComposerDraft(sessionId: session.id) == nil)
     }
 
@@ -157,6 +162,7 @@ struct ACPSessionManagerTests {
         mgr.persistComposerDraft(ACPComposerDraft(segments: [.text("sent")]), for: session)
 
         mgr.clearComposerDraft(for: session)
+        await mgr.flushPersistence()
 
         #expect(session.composerDraft == .empty)
         #expect(try store.loadComposerDraft(sessionId: session.id) == nil)
@@ -168,12 +174,15 @@ struct ACPSessionManagerTests {
         let store = try ACPSessionStore(path: url.path)
         let mgr = ACPSessionManager(worktreeId: "wt", worktreePath: "/tmp/wt", store: store)
         let session = mgr.createSession(agentId: "claude")
+        await mgr.flushPersistence()
+        let existingMessage: ACPMessage = .user(id: UUID(), text: "old", attachments: [])
+        session.transcript.messages.append(existingMessage)
         try store.appendMessage(
             sessionId: session.id,
             id: "m0",
-            kind: "user",
+            kind: existingMessage.kind,
             seq: 0,
-            payload: Data("old".utf8),
+            payload: try ACPMessageCodec.encode(existingMessage),
             createdAt: 1
         )
         let submitted = ACPComposerDraft(segments: [.text("sent")])
@@ -184,9 +193,10 @@ struct ACPSessionManagerTests {
         mgr.persistComposerDraft(submitted, for: session)
 
         let suspendedRevision = mgr.suspendComposerDraftForSubmission(submitted, for: session)
+        await mgr.flushPersistence()
         #expect(session.composerDraft == .empty)
         #expect(session.composerDraftRevision == suspendedRevision)
-        // SQLite was written synchronously by suspend, no flush needed.
+        // The explicit persistence barrier makes the recovery row durable.
         #expect(try store.loadComposerDraft(sessionId: session.id) == submitted)
         #expect(try store.loadComposerDraftRecord(sessionId: session.id)?.submittedAfterSeq == 0)
     }
@@ -204,6 +214,7 @@ struct ACPSessionManagerTests {
 
         // Success path with no intervening typing: SQLite row is purged.
         mgr.purgeSuspendedComposerDraft(for: session, suspendedRevision: suspendedRevision)
+        await mgr.flushPersistence()
         #expect(try store.loadComposerDraft(sessionId: session.id) == nil)
 
         // Re-suspend, then simulate the user typing while the prompt is
@@ -215,6 +226,7 @@ struct ACPSessionManagerTests {
         mgr.purgeSuspendedComposerDraft(for: session, suspendedRevision: suspendedAgain)
         #expect(session.composerDraft == newer)
         mgr.flushPendingDraftWrites()
+        await mgr.flushPersistence()
         #expect(try store.loadComposerDraft(sessionId: session.id) == newer)
     }
 
@@ -259,6 +271,7 @@ struct ACPSessionManagerTests {
 
         mgr.persistComposerDraft(submitted, for: session)
         _ = mgr.suspendComposerDraftForSubmission(submitted, for: session)
+        await mgr.flushPersistence()
 
         // What `ACPInputField.makeCoordinator()` reads as `initialDraft`.
         #expect(session.composerDraft.isEmpty)
@@ -288,7 +301,7 @@ struct ACPSessionManagerTests {
     }
 
     @Test("persistQueue writes to SQLite without requiring a runner")
-    func persistQueueWithoutRunner() throws {
+    func persistQueueWithoutRunner() async throws {
         // Regression: ACPTabView's queue actions used to call
         // `manager.runners[sessionId]?.persistQueue()`, which silently
         // no-oped when no runner was attached (setup nudge / launch
@@ -302,11 +315,13 @@ struct ACPSessionManagerTests {
         session.enqueue(blocks: [.text("b")])
 
         mgr.persistQueue(for: session)
+        await mgr.flushPersistence()
         let persisted = try store.loadQueue(sessionId: session.id)
         #expect(persisted == session.queue)
 
         session.clearPendingQueue()
         mgr.persistQueue(for: session)
+        await mgr.flushPersistence()
         let afterClear = try store.loadQueue(sessionId: session.id)
         #expect(afterClear.isEmpty)
     }

--- a/AlasTests/ACP/Session/ACPSessionPersistenceTests.swift
+++ b/AlasTests/ACP/Session/ACPSessionPersistenceTests.swift
@@ -1,0 +1,142 @@
+import Foundation
+import Testing
+@testable import Alas
+
+private actor SQLiteWriteLock {
+    let path: String
+
+    init(path: String) {
+        self.path = path
+    }
+
+    func hold(for seconds: TimeInterval, didLock: @Sendable () -> Void) throws {
+        let database = try SQLiteDatabase(path: path)
+        try database.exec("BEGIN IMMEDIATE")
+        didLock()
+        Thread.sleep(forTimeInterval: seconds)
+        try database.exec("ROLLBACK")
+    }
+}
+
+@MainActor
+@Suite("ACP session persistence")
+struct ACPSessionPersistenceTests {
+    @Test("SQLite lock waits do not block the main actor")
+    func lockWaitRunsOffMainActor() async throws {
+        let url = temporaryDatabaseURL()
+        let seed = try ACPSessionStore(path: url.path)
+        try seed.upsertSession(row(id: "seed"))
+
+        let lock = SQLiteWriteLock(path: url.path)
+        let (locked, continuation) = AsyncStream<Void>.makeStream()
+        let lockTask = Task {
+            try await lock.hold(for: 0.4) {
+                continuation.yield()
+                continuation.finish()
+            }
+        }
+        var iterator = locked.makeAsyncIterator()
+        _ = await iterator.next()
+
+        let persistence = ACPSessionPersistence(path: url.path)
+        let startedAt = Date()
+        let writeTask = Task {
+            try await persistence.upsertSession(row(id: "waiter"))
+        }
+
+        try await Task.sleep(for: .milliseconds(50))
+        #expect(Date().timeIntervalSince(startedAt) < 0.2)
+
+        try await writeTask.value
+        try await lockTask.value
+        #expect(try await persistence.loadSession(id: "waiter") != nil)
+    }
+
+    @Test("manager preserves parent-before-child persistence order")
+    func parentSessionPrecedesDraft() async throws {
+        let url = temporaryDatabaseURL()
+        let persistence = ACPSessionPersistence(path: url.path)
+        let manager = ACPSessionManager(
+            worktreeId: "wt",
+            worktreePath: "/tmp/wt",
+            persistence: persistence
+        )
+        let session = manager.createSession(agentId: "claude")
+        let draft = ACPComposerDraft(segments: [.text("ordered")])
+
+        manager.persistComposerDraft(draft, for: session)
+        manager.flushPendingDraftWrites()
+        await manager.flushPersistence()
+
+        #expect(try await persistence.loadSession(id: session.id) != nil)
+        #expect(try await persistence.loadComposerDraftRecord(sessionId: session.id)?.draft == draft)
+    }
+
+    @Test("takeover fences every write from the old owner")
+    func staleLeaseTokenCannotWrite() async throws {
+        let url = temporaryDatabaseURL()
+        let persistence = ACPSessionPersistence(path: url.path)
+        try await persistence.upsertSession(row(id: "session"))
+        let now = Int64(Date().timeIntervalSince1970)
+        let oldLease = try #require(try await persistence.claimLease(
+            sessionId: "session",
+            instanceId: "old",
+            pid: Int64(getpid()),
+            now: now,
+            staleAfter: 15,
+            leaseToken: "old-token"
+        ))
+        let newLease = try await persistence.seizeLease(
+            sessionId: "session",
+            instanceId: "new",
+            pid: Int64(getpid()),
+            now: now + 1,
+            leaseToken: "new-token"
+        )
+
+        let oldWrite = try await persistence.setContextRecoveryPending(
+            sessionId: "session",
+            pending: true,
+            fence: fence(for: oldLease)
+        )
+        #expect(!oldWrite)
+        #expect(try await persistence.loadSession(id: "session")?.contextRecoveryPending == false)
+
+        let newWrite = try await persistence.setContextRecoveryPending(
+            sessionId: "session",
+            pending: true,
+            fence: fence(for: newLease)
+        )
+        #expect(newWrite)
+        #expect(try await persistence.loadSession(id: "session")?.contextRecoveryPending == true)
+    }
+
+    private func temporaryDatabaseURL() -> URL {
+        FileManager.default.temporaryDirectory
+            .appendingPathComponent("acp-persistence-\(UUID()).sqlite")
+    }
+
+    private func row(id: String) -> ACPSessionRow {
+        let now = Int64(Date().timeIntervalSince1970)
+        return ACPSessionRow(
+            id: id,
+            agentId: "claude",
+            title: "New session",
+            currentModel: nil,
+            currentMode: nil,
+            autoRun: false,
+            createdAt: now,
+            updatedAt: now,
+            lastOpenedAt: now,
+            archived: false
+        )
+    }
+
+    private func fence(for lease: ACPSessionLease) -> ACPSessionLeaseFence {
+        ACPSessionLeaseFence(
+            sessionId: lease.sessionId,
+            ownerInstance: lease.ownerInstance,
+            token: lease.token
+        )
+    }
+}

--- a/AlasTests/ACP/Session/ACPSessionRecoveryTests.swift
+++ b/AlasTests/ACP/Session/ACPSessionRecoveryTests.swift
@@ -34,9 +34,34 @@ struct ACPSessionEnqueueWhileRecoveringTests {
             Issue.record("expected first block to be .text(\"hello\"), got \(String(describing: head.blocks.first))")
         }
 
+        await mgr.flushPersistence()
         let persisted = try store.loadQueue(sessionId: session.id)
         #expect(persisted.count == 1)
         #expect(persisted.first?.id == head.id)
+    }
+
+    @Test("enqueueWhileRecovering fences a stale queued write after takeover")
+    func enqueueIsFencedAfterTakeover() async throws {
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("mgr-recover-fence-\(UUID()).sqlite")
+        let store = try ACPSessionStore(path: url.path)
+        let manager = ACPSessionManager(
+            worktreeId: "/tmp/wt",
+            worktreePath: "/tmp/wt",
+            store: store,
+            instanceId: "ME",
+            pid: Int64(getpid())
+        )
+        let session = manager.createSession(agentId: "claude")
+        await manager.flushPersistence()
+        #expect(await manager.acquireWriterLease(sessionId: session.id))
+
+        manager.enqueueWhileRecovering(text: "stale", attachments: [], into: session.id)
+        let now = Int64(Date().timeIntervalSince1970)
+        try store.seizeLease(sessionId: session.id, instanceId: "OTHER", pid: Int64(getpid()), now: now)
+        await manager.flushPersistence()
+
+        #expect(try store.loadQueue(sessionId: session.id).isEmpty)
     }
 
     @Test("enqueueWhileRecovering preserves attachments as resource links")

--- a/AlasTests/ACP/Session/ACPSessionRunnerTests.swift
+++ b/AlasTests/ACP/Session/ACPSessionRunnerTests.swift
@@ -695,7 +695,8 @@ struct ACPSessionRunnerTests {
 
         try await Task.sleep(nanoseconds: 50_000_000)
 
-        let row = try #require(try runner.store.loadSession(id: "s"))
+        await runner.flushPersistence()
+        let row = try #require(try await runner.persistence.loadSession(id: "s"))
         #expect(runner.session.title == "t")
         #expect(row.title == "t")
     }
@@ -1020,7 +1021,7 @@ struct ACPSessionRunnerTests {
         }
     }
 
-    @Test("initial tool image enrichments apply during load replay suppression")
+    @Test("initial tool image enrichments apply in memory during load replay suppression")
     func initialToolImageEnrichmentsApplyDuringLoadReplaySuppression() async throws {
         let url = FileManager.default.temporaryDirectory
             .appendingPathComponent("rn-tool-initial-image-replay-\(UUID().uuidString).sqlite")
@@ -1057,10 +1058,7 @@ struct ACPSessionRunnerTests {
             worktreePath: FileManager.default.temporaryDirectory.path,
             suppressingLoadReplay: true
         )
-        runner.start()
-        defer { runner.stop() }
-
-        mock.emit(.init(
+        runner.applyIncomingUpdateForTesting(.init(
             sessionId: "s",
             update: .toolCall(.init(
                 toolCallId: "tc-initial-image-replay",
@@ -1079,14 +1077,7 @@ struct ACPSessionRunnerTests {
                         ])
                     ])
                 ])))))
-        mock.emit(.init(sessionId: "s", update: .agentMessageChunk(.text("suppressed replay"))))
-
-        try await waitUntil {
-            guard case .toolCall(let tc) = session.transcript.messages.first else { return false }
-            return tc.status == "completed"
-                && tc.assets.contains(.image(data: "content-image-data", mimeType: "image/png"))
-                && tc.assets.contains(.image(data: "raw-output-data", mimeType: "image/png"))
-        }
+        runner.applyIncomingUpdateForTesting(.init(sessionId: "s", update: .agentMessageChunk(.text("suppressed replay"))))
 
         #expect(session.transcript.messages.count == 1)
         if case .toolCall(let tc) = session.transcript.messages[0] {
@@ -1100,14 +1091,7 @@ struct ACPSessionRunnerTests {
             Issue.record("expected restored toolCall message")
         }
 
-        try await waitUntil {
-            guard let row = try? store.loadMessages(sessionId: "s").first,
-                  let decoded = try? ACPMessageCodec.decode(kind: row.kind, payload: row.payload),
-                  case .toolCall(let persisted) = decoded
-            else { return false }
-            return persisted.assets.contains(.image(data: "content-image-data", mimeType: "image/png"))
-                && persisted.assets.contains(.image(data: "raw-output-data", mimeType: "image/png"))
-        }
+        #expect(try store.loadMessages(sessionId: "s").isEmpty)
     }
 
     @Test("streaming chunks are persisted in a batch when streaming ends")
@@ -1153,6 +1137,7 @@ struct ACPSessionRunnerTests {
 
         await mock.finishPrompt()
         #expect(await completed.value)
+        await runner.flushPersistence()
 
         let rows = try store.loadMessages(sessionId: "s")
         let agentRow = try #require(rows.first(where: { $0.kind == "agent" }))
@@ -1558,6 +1543,7 @@ struct ACPSessionRunnerTests {
         mock.emitUsageUpdate()
         try await Task.sleep(nanoseconds: 50_000_000)
         runner.stop()
+        await runner.flushPersistence()
         await mock.finishPrompt()
         _ = await completed.value
 
@@ -1614,6 +1600,7 @@ struct ACPSessionRunnerTests {
         try store.seizeLease(sessionId: sid, instanceId: "OTHER", pid: Int64(getpid()), now: now)
         try await Task.sleep(nanoseconds: 250_000_000)
         runner.stop()
+        await runner.flushPersistence()
 
         let rows = try store.loadMessages(sessionId: sid)
         let agentRow = try #require(rows.first(where: { $0.kind == "agent" }))
@@ -1666,6 +1653,7 @@ struct ACPSessionRunnerTests {
         runner.stop()
         await mock.finishPrompt()
         _ = await completed.value
+        await runner.flushPersistence()
 
         let rows = try store.loadMessages(sessionId: sid)
         let agentRow = try #require(rows.first(where: { $0.kind == "agent" }))
@@ -1719,6 +1707,7 @@ struct ACPSessionRunnerTests {
 
         runner.invalidateActivePrompt()
         runner.stop()
+        await runner.flushPersistence()
         await finishPrompt.open()
 
         let rows = try store.loadMessages(sessionId: sid)
@@ -1799,6 +1788,7 @@ struct ACPSessionRunnerTests {
         mock.emitUsageUpdate()
         try await Task.sleep(nanoseconds: 50_000_000)
         runner.stop()
+        await runner.flushPersistence()
         await mock.finishPrompt()
         _ = await completed.value
 
@@ -1885,6 +1875,7 @@ struct ACPSessionRunnerTests {
         runner.stop()
         await mock.finishPrompt()
         _ = await completed.value
+        await runner.flushPersistence()
 
         let rows = try store.loadMessages(sessionId: sid)
         let agentRow = try #require(rows.first(where: { $0.kind == "agent" }))
@@ -1941,6 +1932,7 @@ struct ACPSessionRunnerTests {
         mock.emitUsageUpdate()
         try await Task.sleep(nanoseconds: 50_000_000)
         runner.stop()
+        await runner.flushPersistence()
         await mock.finishPrompt()
         _ = await completed.value
 
@@ -2016,6 +2008,7 @@ struct ACPSessionRunnerTests {
         mock.emitUsageUpdate()
         try await Task.sleep(nanoseconds: 50_000_000)
         runner.stop()
+        await runner.flushPersistence()
         await mock.finishPrompt()
         _ = await completed.value
 
@@ -2161,6 +2154,7 @@ struct ACPSessionRunnerTests {
         mock.emitUsageUpdate()
         try await Task.sleep(nanoseconds: 50_000_000)
         runner.stop()
+        await runner.flushPersistence()
         await mock.finishPrompt()
         _ = await completed.value
 
@@ -2228,6 +2222,7 @@ struct ACPSessionRunnerTests {
         runner.stop()
         await mock.finishPrompt()
         _ = await completed.value
+        await runner.flushPersistence()
 
         let rows = try store.loadMessages(sessionId: sid)
         let agentRow = try #require(rows.first(where: { $0.kind == "agent" }))
@@ -2237,6 +2232,64 @@ struct ACPSessionRunnerTests {
             return
         }
         #expect(text.value == "hello world and more")
+    }
+
+    @Test("fenced streaming write failure preserves the pending tail for takeover salvage")
+    func fencedStreamingWriteFailurePreservesPendingTail() async throws {
+        let url = FileManager.default.temporaryDirectory.appendingPathComponent("rn-\(UUID()).sqlite")
+        let store = try ACPSessionStore(path: url.path)
+        let sid = "s"
+        try store.upsertSession(.init(id: sid, agentId: "claude", title: "t",
+            currentModel: nil, currentMode: nil, autoRun: false,
+            createdAt: 0, updatedAt: 0, lastOpenedAt: 0, archived: false))
+        let now = Int64(Date().timeIntervalSince1970)
+        try store.seizeLease(sessionId: sid, instanceId: "ME", pid: Int64(getpid()), now: now)
+        let oldLease = try #require(try store.loadLease(sessionId: sid))
+
+        let mock = StreamingBatchACPClient()
+        let session = ACPSession(id: sid, agentId: "claude", worktreeId: "wt", title: "t")
+        session.agentState = .ready
+        let runner = ACPSessionRunner(
+            session: session,
+            connection: ACPConnection(client: mock),
+            store: store,
+            sessionId: sid,
+            worktreePath: FileManager.default.temporaryDirectory.path,
+            streamingPersistDebounceNanos: 5_000_000_000,
+            ownerInstanceId: "ME",
+            canWrite: { true },
+            leaseFenceProvider: {
+                .init(sessionId: sid, ownerInstance: "ME", token: oldLease.token)
+            }
+        )
+        runner.start()
+
+        let completed = Task {
+            await withCheckedContinuation { continuation in
+                runner.send(text: "start", attachments: []) { succeeded in
+                    continuation.resume(returning: succeeded)
+                }
+            }
+        }
+
+        await mock.waitForChunks()
+        try await Task.sleep(nanoseconds: 50_000_000)
+        try store.seizeLease(sessionId: sid, instanceId: "OTHER", pid: Int64(getpid()), now: now)
+
+        // The cached canWrite closure still allows the enqueue, but the
+        // persistence actor observes the old token and rejects the write.
+        runner.stop()
+        await runner.flushPersistence()
+        await mock.finishPrompt()
+        _ = await completed.value
+
+        let rows = try store.loadMessages(sessionId: sid)
+        let agentRow = try #require(rows.first(where: { $0.kind == "agent" }))
+        guard case .agent(_, _, let text) = try ACPMessageCodec.decode(kind: agentRow.kind, payload: agentRow.payload) else {
+            Issue.record("expected persisted agent message")
+            return
+        }
+        #expect(text.value == "hello world")
     }
 
     @Test("in-place plan update persists to disk even when plan is not the trailing message")
@@ -2424,7 +2477,7 @@ struct ACPSessionRunnerTests {
     // MARK: - onPersist callback tests
 
     @Test("onPersist fires after persistFromIndex writes a message")
-    func onPersistFiresAfterPersistFromIndex() throws {
+    func onPersistFiresAfterPersistFromIndex() async throws {
         let url = FileManager.default.temporaryDirectory
             .appendingPathComponent("rn-onpersist-\(UUID().uuidString).sqlite")
         let store = try ACPSessionStore(path: url.path)
@@ -2433,6 +2486,7 @@ struct ACPSessionRunnerTests {
             createdAt: 0, updatedAt: 0, lastOpenedAt: 0, archived: false))
 
         var posts = 0
+        var observedStoredMessage = false
         let mock = ACPMockClient()
         let session = ACPSession(id: "s", agentId: "claude", worktreeId: "wt", title: "t")
         let runner = ACPSessionRunner(
@@ -2441,16 +2495,21 @@ struct ACPSessionRunnerTests {
             store: store,
             sessionId: "s",
             worktreePath: FileManager.default.temporaryDirectory.path,
-            onPersist: { posts += 1 }
+            onPersist: {
+                posts += 1
+                observedStoredMessage = (try? store.loadMessages(sessionId: "s").isEmpty == false) == true
+            }
         )
 
         session.appendSystemNotice("hello")
         runner.persistFromIndex(0)
+        await runner.flushPersistence()
         #expect(posts >= 1)
+        #expect(observedStoredMessage)
     }
 
     @Test("onPersist fires after persistIndices writes a message")
-    func onPersistFiresAfterPersistIndices() throws {
+    func onPersistFiresAfterPersistIndices() async throws {
         let url = FileManager.default.temporaryDirectory
             .appendingPathComponent("rn-onpersist-idx-\(UUID().uuidString).sqlite")
         let store = try ACPSessionStore(path: url.path)
@@ -2472,11 +2531,12 @@ struct ACPSessionRunnerTests {
 
         session.appendSystemNotice("hello")
         runner.persistIndices([0])
+        await runner.flushPersistence()
         #expect(posts >= 1)
     }
 
     @Test("persistIndices preserves stored full tool content after metadata-only update")
-    func persistIndicesPreservesStoredFullToolContentAfterMetadataOnlyUpdate() throws {
+    func persistIndicesPreservesStoredFullToolContentAfterMetadataOnlyUpdate() async throws {
         let url = FileManager.default.temporaryDirectory
             .appendingPathComponent("rn-persist-truncated-tool-\(UUID().uuidString).sqlite")
         let store = try ACPSessionStore(path: url.path)
@@ -2523,6 +2583,7 @@ struct ACPSessionRunnerTests {
             ])
         )))
         runner.persistIndices(dirty)
+        await runner.flushPersistence()
 
         let rows = try store.loadMessages(sessionId: "s")
         let row = try #require(rows.first(where: { $0.kind == "tool_call" }))
@@ -2536,7 +2597,7 @@ struct ACPSessionRunnerTests {
     }
 
     @Test("persistIndices stores replacement tool content after truncation")
-    func persistIndicesStoresReplacementToolContentAfterTruncation() throws {
+    func persistIndicesStoresReplacementToolContentAfterTruncation() async throws {
         let url = FileManager.default.temporaryDirectory
             .appendingPathComponent("rn-persist-replacement-tool-\(UUID().uuidString).sqlite")
         let store = try ACPSessionStore(path: url.path)
@@ -2573,6 +2634,7 @@ struct ACPSessionRunnerTests {
             content: [.content(.text(replacementContent))]
         )))
         runner.persistIndices(dirty)
+        await runner.flushPersistence()
 
         let rows = try store.loadMessages(sessionId: "s")
         let row = try #require(rows.first(where: { $0.kind == "tool_call" }))
@@ -2586,7 +2648,7 @@ struct ACPSessionRunnerTests {
     }
 
     @Test("persistIndices updates deterministic row kind that appeared after runner initialization")
-    func persistIndicesUpdatesLateDeterministicRowCollisionKind() throws {
+    func persistIndicesUpdatesLateDeterministicRowCollisionKind() async throws {
         let url = FileManager.default.temporaryDirectory
             .appendingPathComponent("rn-persist-collision-\(UUID().uuidString).sqlite")
         let store = try ACPSessionStore(path: url.path)
@@ -2616,6 +2678,7 @@ struct ACPSessionRunnerTests {
 
         session.appendSystemNotice("fresh")
         runner.persistIndices([0])
+        await runner.flushPersistence()
 
         let rows = try store.loadMessages(sessionId: "s")
         let row = try #require(rows.first(where: { $0.id == "msg-s-0" }))
@@ -2654,7 +2717,7 @@ struct ACPSessionRunnerTests {
     }
 
     @Test("runner does not persist when it has lost the session lease")
-    func persistSkippedWhenLeaseLost() throws {
+    func persistSkippedWhenLeaseLost() async throws {
         let url = FileManager.default.temporaryDirectory
             .appendingPathComponent("rn-lease-lost-\(UUID().uuidString).sqlite")
         let store = try ACPSessionStore(path: url.path)
@@ -2681,13 +2744,14 @@ struct ACPSessionRunnerTests {
         // Put one message in the transcript, then attempt to persist.
         session.appendSystemNotice("should not land")
         runner.persistFromIndex(0)
+        await runner.flushPersistence()
 
         // Nothing should have been written — the lease is held by "OTHER", not "ME".
         #expect(try store.messageCount(sessionId: sid) == 0)
     }
 
     @Test("runner persists when it holds the session lease")
-    func persistProceedsWhenLeaseHeld() throws {
+    func persistProceedsWhenLeaseHeld() async throws {
         let url = FileManager.default.temporaryDirectory
             .appendingPathComponent("rn-lease-held-\(UUID().uuidString).sqlite")
         let store = try ACPSessionStore(path: url.path)
@@ -2713,6 +2777,7 @@ struct ACPSessionRunnerTests {
 
         session.appendSystemNotice("should land")
         runner.persistFromIndex(0)
+        await runner.flushPersistence()
 
         // The lease owner matches, so the message must be written.
         #expect(try store.messageCount(sessionId: sid) == 1)
@@ -2753,8 +2818,8 @@ struct ACPSessionRunnerTests {
 
     // MARK: - Fix 3 (P2): Terminal-create lease gate
 
-    @Test("terminal create denied when lease is held by another instance")
-    func terminalCreateDeniedWhenLeaseLost() async throws {
+    @Test("terminal create requires an authoritative lease check")
+    func terminalCreateDeniedWhenAuthoritativeLeaseCheckFails() async throws {
         let url = FileManager.default.temporaryDirectory
             .appendingPathComponent("rn-terminal-lease-\(UUID().uuidString).sqlite")
         let store = try ACPSessionStore(path: url.path)
@@ -2763,9 +2828,10 @@ struct ACPSessionRunnerTests {
             currentModel: nil, currentMode: nil, autoRun: false,
             createdAt: 0, updatedAt: 0, lastOpenedAt: 0, archived: false))
 
-        // Seize the lease for a DIFFERENT instance than the runner's ownerInstanceId.
+        // The cache still says this runner owns the lease, but the authoritative
+        // check represents a takeover that landed before the side effect.
         let now = Int64(Date().timeIntervalSince1970)
-        try store.seizeLease(sessionId: sid, instanceId: "OTHER", pid: Int64(getpid()), now: now)
+        try store.seizeLease(sessionId: sid, instanceId: "ME", pid: Int64(getpid()), now: now)
 
         let mock = ACPMockClient()
         let session = ACPSession(id: sid, agentId: "claude", worktreeId: "wt", title: "t")
@@ -2775,12 +2841,15 @@ struct ACPSessionRunnerTests {
             store: store,
             sessionId: sid,
             worktreePath: FileManager.default.temporaryDirectory.path,
-            ownerInstanceId: "ME"
+            ownerInstanceId: "ME",
+            canWrite: { true },
+            validateLease: { false }
         )
         runner.start()
         defer { runner.stop() }
 
-        // Request a terminal/create while the lease is held by "OTHER".
+        // Request a terminal/create after the authoritative check has rejected
+        // the stale cached authority.
         let params = ACPTerminalCreateParams(
             sessionId: sid, command: "/bin/echo",
             args: ["hi"], env: nil, cwd: nil, outputByteLimit: nil)
@@ -2905,6 +2974,7 @@ struct ACPSessionRunnerTests {
         }
 
         #expect(succeeded)
+        await runner.flushPersistence()
         let row = try #require(try store.loadSession(id: sid))
         #expect(row.title == "Remote Title")
         #expect(row.titleSource == .manual)

--- a/AlasTests/ACP/Session/ACPSessionStoreTests.swift
+++ b/AlasTests/ACP/Session/ACPSessionStoreTests.swift
@@ -22,6 +22,23 @@ struct ACPSessionStoreSchemaTests {
         _ = try ACPSessionStore(path: url.path) // must not throw
     }
 
+    @Test("migrates a version 10 lease table with a stable token column")
+    func migratesV10LeaseToken() throws {
+        let url = FileManager.default.temporaryDirectory.appendingPathComponent("acp-store-\(UUID()).sqlite")
+        do {
+            let store = try ACPSessionStore(path: url.path)
+            try store.db.exec("ALTER TABLE session_leases DROP COLUMN lease_token")
+            try store.db.exec("UPDATE schema_version SET version = 10")
+        }
+
+        let store = try ACPSessionStore(path: url.path)
+        let columns = try store.db.query("PRAGMA table_info(session_leases)")
+        #expect(columns.contains { ($0["name"] as? String) == "lease_token" })
+        #expect(try store.currentSchemaVersion() == 11)
+
+        _ = try ACPSessionStore(path: url.path)
+    }
+
     @Test("migrates schema version 1 to current target")
     func migratesV1ToCurrent() throws {
         let url = FileManager.default.temporaryDirectory.appendingPathComponent("acp-store-\(UUID()).sqlite")
@@ -82,5 +99,33 @@ struct ACPSessionStoreSchemaTests {
 
         #expect(try store.loadComposerDraft(sessionId: "s") == draft)
         #expect(try store.loadComposerDraftRecord(sessionId: "s")?.submittedRecovery == false)
+    }
+
+    @Test("streaming salvage never replaces an existing deterministic row")
+    @MainActor
+    func insertMessageIfMissingPreservesNewOwnerRow() throws {
+        let store = try tmpStore()
+        try store.upsertSession(.init(id: "s", agentId: "claude", title: "t",
+            currentModel: nil, currentMode: nil, autoRun: false,
+            createdAt: 0, updatedAt: 0, lastOpenedAt: 0, archived: false))
+        let first = ACPStoredMessage(
+            id: "msg-s-1", sessionId: "s", kind: "agent", seq: 1,
+            payload: try ACPMessageCodec.encode(.agent(id: UUID(), StreamingText("new owner"))),
+            createdAt: 1
+        )
+        let stale = ACPStoredMessage(
+            id: "msg-s-1", sessionId: "s", kind: "agent", seq: 1,
+            payload: try ACPMessageCodec.encode(.agent(id: UUID(), StreamingText("former owner"))),
+            createdAt: 2
+        )
+
+        #expect(try store.insertMessageIfMissing(first))
+        #expect(!(try store.insertMessageIfMissing(stale)))
+        let stored = try #require(try store.loadMessages(sessionId: "s").first)
+        guard case .agent(_, _, let text) = try ACPMessageCodec.decode(kind: stored.kind, payload: stored.payload) else {
+            Issue.record("expected agent message")
+            return
+        }
+        #expect(text.value == "new owner")
     }
 }

--- a/AlasTests/Remote/ACPManagerAccessorsTests.swift
+++ b/AlasTests/Remote/ACPManagerAccessorsTests.swift
@@ -45,27 +45,26 @@ struct ACPManagerAccessorsTests {
         #expect(mgr.isWriter(for: s.id) == true)
     }
 
-    @Test func isWriterFalseWhenAnotherLiveInstanceOwnsLease() throws {
-        // Regression: after another window seizes the lease, the former owner
-        // keeps the id in `_ownedLeases` until its heartbeat stands down
-        // (~leaseStaleAfter seconds). isWriter must consult the store and report
-        // false in that window so a phone on the old owner can't keep writing
-        // into a session another instance now drives.
+    @Test func authoritativeWriterCheckStandsDownAfterTakeover() async throws {
         let url = FileManager.default.temporaryDirectory
             .appendingPathComponent("acp-accessors-\(UUID()).sqlite")
         let store = try ACPSessionStore(path: url.path)
         let mgr = ACPSessionManager(worktreeId: "wt", worktreePath: "/tmp", store: store)
         let s = mgr.createSession(agentId: "claude")
-        mgr._ownedLeases.insert(s.id)
-        #expect(mgr.isWriter(for: s.id) == true)   // we claim it; no conflicting store row
-        // Another LIVE instance seizes the store lease (fresh heartbeat, live pid).
+        await mgr.flushPersistence()
+        #expect(await mgr.acquireWriterLease(sessionId: s.id))
+        #expect(mgr.isWriter(for: s.id))
         let now = Int64(Date().timeIntervalSince1970)
         try store.seizeLease(sessionId: s.id, instanceId: "other-window",
                              pid: Int64(ProcessInfo.processInfo.processIdentifier), now: now)
-        #expect(mgr.isWriter(for: s.id) == false)  // store says another live instance owns it
+
+        var result: Bool?
+        await mgr.sendPrompt(for: s.id, text: "hi", attachments: []) { result = $0 }
+        #expect(result == false)
+        #expect(mgr.isWriter(for: s.id) == false)
     }
 
-    @Test func sendPromptRefusedWhenNotWriter() throws {
+    @Test func sendPromptRefusedWhenNotWriter() async throws {
         // Re-checks the lease at call time: a manager that isn't the writer must
         // refuse the remote prompt instead of enqueuing it as a mirror (closing
         // the TOCTOU window between the gateway's isWriter gate and submit).
@@ -73,30 +72,55 @@ struct ACPManagerAccessorsTests {
         let s = mgr.createSession(agentId: "claude")
         #expect(mgr.isWriter(for: s.id) == false)
         var result: Bool?
-        mgr.sendPrompt(for: s.id, text: "hi", attachments: []) { result = $0 }
+        await mgr.sendPrompt(for: s.id, text: "hi", attachments: []) { result = $0 }
         #expect(result == false)   // refused synchronously
         #expect(s.queue.isEmpty)   // nothing enqueued/persisted as a mirror
     }
 
-    @Test func setAutoRunRequiresWriter() throws {
+    @Test func setAutoRunRequiresWriter() async throws {
         let mgr = try makeManager()
         let s = mgr.createSession(agentId: "claude")
-        mgr.setAutoRun(for: s.id, enabled: true)
+        await mgr.setAutoRun(for: s.id, enabled: true)
         #expect(s.autoRunEnabled == false)          // not writer → ignored
-        mgr._ownedLeases.insert(s.id)
-        mgr.setAutoRun(for: s.id, enabled: true)
+        await mgr.flushPersistence()
+        #expect(await mgr.acquireWriterLease(sessionId: s.id))
+        await mgr.setAutoRun(for: s.id, enabled: true)
         #expect(s.autoRunEnabled == true)
     }
 
-    @Test func setModelOptimisticallyUpdatesAndRequiresWriter() throws {
+    @Test func setModelOptimisticallyUpdatesAndRequiresWriter() async throws {
         let mgr = try makeManager()
         let s = mgr.createSession(agentId: "claude")
-        mgr.setModel(for: s.id, modelId: "opus")
+        await mgr.setModel(for: s.id, modelId: "opus")
         #expect(s.currentModel == nil)              // not writer → ignored
-        mgr._ownedLeases.insert(s.id)
-        mgr.setModel(for: s.id, modelId: "opus")
+        await mgr.flushPersistence()
+        #expect(await mgr.acquireWriterLease(sessionId: s.id))
+        await mgr.setModel(for: s.id, modelId: "opus")
         #expect(s.currentModel == "opus")           // optimistic update even with no runner
-        mgr.setMode(for: s.id, modeId: "ask")
+        await mgr.setMode(for: s.id, modeId: "ask")
         #expect(s.currentMode == "ask")
+    }
+
+    @Test func sendPromptRejectsFormerWriterAfterTakeover() async throws {
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("acp-former-writer-\(UUID()).sqlite")
+        let store = try ACPSessionStore(path: url.path)
+        let mgr = ACPSessionManager(worktreeId: "wt", worktreePath: "/tmp", store: store)
+        let session = mgr.createSession(agentId: "claude")
+        await mgr.flushPersistence()
+        #expect(await mgr.acquireWriterLease(sessionId: session.id))
+        try store.seizeLease(
+            sessionId: session.id,
+            instanceId: "other-window",
+            pid: Int64(ProcessInfo.processInfo.processIdentifier),
+            now: Int64(Date().timeIntervalSince1970)
+        )
+
+        var result: Bool?
+        await mgr.sendPrompt(for: session.id, text: "hi", attachments: []) { result = $0 }
+
+        #expect(result == false)
+        #expect(mgr.isWriter(for: session.id) == false)
+        #expect(session.queue.isEmpty)
     }
 }

--- a/AlasTests/Remote/RemoteAppStateAccessTests.swift
+++ b/AlasTests/Remote/RemoteAppStateAccessTests.swift
@@ -76,7 +76,7 @@ struct RemoteAppStateAccessTests {
         #expect(state.remoteAdvertisedAddresses.isEmpty)
     }
 
-    @Test func remoteRenameSessionUpdatesManualSessionTitleAndOpenTab() throws {
+    @Test func remoteRenameSessionUpdatesManualSessionTitleAndOpenTab() async throws {
         var cleanupWorktreeId: String?
         defer {
             if let cleanupWorktreeId {
@@ -120,13 +120,13 @@ struct RemoteAppStateAccessTests {
         let manager = try #require(state.acpManager(forWorktreeId: worktreeId))
         let session = try #require(manager.placeholderSession(id: tab.sessionId))
         session.remoteSessionId = "remote-shared"
-        try seedStoredSession(
+        try await seedStoredSession(
             id: tab.sessionId,
             title: "New session",
             titleSource: .placeholder,
             in: manager
         )
-        try seedStoredSession(
+        try await seedStoredSession(
             id: "historical-copy",
             title: "Actual Remote Title",
             titleSource: .manual,
@@ -155,7 +155,7 @@ struct RemoteAppStateAccessTests {
         cleanupWorktreeId = worktreeId
         state.openNewACPSession(agentID: "test-agent")
         let manager = try #require(state.acpManager(forWorktreeId: worktreeId))
-        try seedStoredSession(
+        try await seedStoredSession(
             id: "historical-\(UUID().uuidString)",
             title: "Historical",
             titleSource: .manual,
@@ -166,6 +166,42 @@ struct RemoteAppStateAccessTests {
         let historical = try #require(summaries.first { $0.title == "Historical" })
 
         #expect(!historical.isActive)
+    }
+
+    @Test func openingUncachedStoredSessionUsesPersistedTitleForTab() async throws {
+        var cleanupWorktreeId: String?
+        defer {
+            if let cleanupWorktreeId {
+                cleanupRemoteRenameFiles(worktreeId: cleanupWorktreeId)
+            }
+        }
+
+        let state = makeRemoteRenameState()
+        let worktreeId = try #require(state.selectedWorktreeId)
+        cleanupWorktreeId = worktreeId
+        state.openNewACPSession(agentID: "test-agent")
+        let manager = try #require(state.acpManager(forWorktreeId: worktreeId))
+        let id = "uncached-\(UUID().uuidString)"
+        let now = Int64(Date().timeIntervalSince1970)
+        try await manager.persistence.upsertSession(.init(
+            id: id,
+            agentId: "test-agent",
+            title: "Persisted Title",
+            titleSource: .manual,
+            currentModel: nil,
+            currentMode: nil,
+            autoRun: false,
+            createdAt: now,
+            updatedAt: now,
+            lastOpenedAt: now,
+            archived: false
+        ))
+        #expect(!manager.sessionRows.contains { $0.id == id })
+
+        await state.openExistingACPSession(sessionId: id)
+
+        let tab = try #require(acpTabs(in: state).first { $0.sessionId == id })
+        #expect(tab.title == "Persisted Title")
     }
 
     @Test func remoteSessionSummariesPreferLivePlaceholderOverStoredDuplicate() async throws {
@@ -184,6 +220,7 @@ struct RemoteAppStateAccessTests {
         let manager = try #require(state.acpManager(forWorktreeId: worktreeId))
         let session = try #require(manager.placeholderSession(id: tab.sessionId))
         session.remoteSessionId = "remote-shared"
+        await manager.flushPersistence()
         let mirrorOwner = try ACPSessionManager(
             worktreeId: worktreeId,
             worktreePath: "/tmp/mirror-owner",
@@ -192,12 +229,10 @@ struct RemoteAppStateAccessTests {
             pid: Int64(getpid())
         )
         _ = try #require(mirrorOwner.placeholderSession(id: tab.sessionId))
-        #expect(mirrorOwner.acquireWriterLease(sessionId: tab.sessionId))
+        #expect(await mirrorOwner.acquireWriterLease(sessionId: tab.sessionId))
+        #expect(!(await manager.acquireWriterLease(sessionId: tab.sessionId)))
         #expect(manager.isMirror(sessionId: tab.sessionId))
-        defer {
-            mirrorOwner.releaseWriterLease(sessionId: tab.sessionId)
-        }
-        try seedStoredSession(
+        try await seedStoredSession(
             id: tab.sessionId,
             title: "New session",
             titleSource: .placeholder,
@@ -205,7 +240,7 @@ struct RemoteAppStateAccessTests {
             lastOpenedAt: 1,
             in: manager
         )
-        try seedStoredSession(
+        try await seedStoredSession(
             id: "historical-copy",
             title: "Actual Remote Title",
             titleSource: .manual,
@@ -220,6 +255,7 @@ struct RemoteAppStateAccessTests {
         #expect(summaries.count == 1)
         #expect(summaries.first?.id == tab.sessionId)
         #expect(summaries.first?.title == "Actual Remote Title")
+        await mirrorOwner.releaseWriterLease(sessionId: tab.sessionId)
     }
 
     @Test func remoteSessionSummariesKeepDifferentAgentsWithSameRemoteSessionId() async throws {
@@ -235,7 +271,7 @@ struct RemoteAppStateAccessTests {
         cleanupWorktreeId = worktreeId
         state.openNewACPSession(agentID: "test-agent")
         let manager = try #require(state.acpManager(forWorktreeId: worktreeId))
-        try seedStoredSession(
+        try await seedStoredSession(
             id: "codex-session",
             agentId: "codex",
             title: "Codex Session",
@@ -243,7 +279,7 @@ struct RemoteAppStateAccessTests {
             remoteSessionId: "remote-shared",
             in: manager
         )
-        try seedStoredSession(
+        try await seedStoredSession(
             id: "claude-session",
             agentId: "claude",
             title: "Claude Session",
@@ -258,7 +294,7 @@ struct RemoteAppStateAccessTests {
         #expect(summaries.map(\.id).contains("claude-session"))
     }
 
-    @Test func remoteRenameSessionRejectsEmptyAndUnknownSession() throws {
+    @Test func remoteRenameSessionRejectsEmptyAndUnknownSession() async throws {
         var cleanupWorktreeId: String?
         defer {
             if let cleanupWorktreeId {
@@ -300,7 +336,7 @@ struct RemoteAppStateAccessTests {
             cleanupWorktreeId = worktreeId
             state.openNewACPSession(agentID: "test-agent")
             let manager = try #require(state.acpManager(forWorktreeId: worktreeId))
-            try seedStoredSession(id: sessionId, title: "Recent", in: manager)
+            try await seedStoredSession(id: sessionId, title: "Recent", in: manager)
 
             let renamed = state.renameSession(for: sessionId, title: "Recent Remote")
 
@@ -319,7 +355,7 @@ struct RemoteAppStateAccessTests {
         }
     }
 
-    @Test func remoteRenameSessionRejectsArchivedSession() throws {
+    @Test func remoteRenameSessionRejectsArchivedSession() async throws {
         var cleanupWorktreeId: String?
         defer {
             if let cleanupWorktreeId {
@@ -335,14 +371,14 @@ struct RemoteAppStateAccessTests {
             cleanupWorktreeId = worktreeId
             state.openNewACPSession(agentID: "test-agent")
             let manager = try #require(state.acpManager(forWorktreeId: worktreeId))
-            try seedStoredSession(id: sessionId, title: "Archived", archived: true, in: manager)
+            try await seedStoredSession(id: sessionId, title: "Archived", archived: true, in: manager)
 
             #expect(!state.renameSession(for: sessionId, title: "Remote Title"))
             #expect(manager.liveSession(for: sessionId) == nil)
         }
     }
 
-    @Test func remoteRenameSessionUpdatesMirrorSessionWithoutWriterLease() throws {
+    @Test func remoteRenameSessionUpdatesMirrorSessionWithoutWriterLease() async throws {
         var cleanupWorktreeId: String?
         defer {
             if let cleanupWorktreeId {
@@ -361,6 +397,7 @@ struct RemoteAppStateAccessTests {
             sessionId = tab.sessionId
             let manager = try #require(state.acpManager(forWorktreeId: worktreeId))
             let session = try #require(manager.placeholderSession(id: sessionId))
+            await manager.flushPersistence()
             let mirrorOwner = try ACPSessionManager(
                 worktreeId: worktreeId,
                 worktreePath: "/tmp/mirror-owner",
@@ -369,10 +406,12 @@ struct RemoteAppStateAccessTests {
                 pid: Int64(getpid())
             )
             let writerSession = try #require(mirrorOwner.placeholderSession(id: sessionId))
-            #expect(mirrorOwner.acquireWriterLease(sessionId: sessionId))
+            #expect(await mirrorOwner.acquireWriterLease(sessionId: sessionId))
+            #expect(!(await manager.acquireWriterLease(sessionId: sessionId)))
             #expect(manager.isMirror(sessionId: sessionId))
 
             let renamed = state.renameSession(for: sessionId, title: "Mirror Title")
+            await manager.flushPersistence()
 
             #expect(renamed)
             #expect(session.title == "Mirror Title")
@@ -381,7 +420,7 @@ struct RemoteAppStateAccessTests {
             #expect(writerSession.title == "New session")
             writerSession.autoRunEnabled = true
             mirrorOwner.persist(writerSession)
-            mirrorOwner.releaseWriterLease(sessionId: sessionId)
+            await mirrorOwner.releaseWriterLease(sessionId: sessionId)
         }
 
         do {
@@ -432,7 +471,7 @@ struct RemoteAppStateAccessTests {
         #expect(ids.contains(deleteFailed.id))
     }
 
-    @Test func remoteAgentsIncludeEnabledACPCapableAgentsOnly() throws {
+    @Test func remoteAgentsIncludeEnabledACPCapableAgentsOnly() async throws {
         let state = makeRemoteRenameState()
         let customAgent = AgentDefinition(
             id: "custom-agent",
@@ -461,7 +500,7 @@ struct RemoteAppStateAccessTests {
         #expect(agents == [RemoteAgentOption(id: "claude", name: claudeName, isDefault: true)])
     }
 
-    @Test func remoteAgentsPreserveNativeACPLaunchOrder() throws {
+    @Test func remoteAgentsPreserveNativeACPLaunchOrder() async throws {
         let state = makeRemoteRenameState()
         state.agentRegistry = AgentRegistry(
             builtinState: [
@@ -793,9 +832,9 @@ struct RemoteAppStateAccessTests {
         updatedAt: Int64? = nil,
         lastOpenedAt: Int64? = nil,
         in manager: ACPSessionManager
-    ) throws {
+    ) async throws {
         let now = Int64(Date().timeIntervalSince1970)
-        try manager.store.upsertSession(ACPSessionRow(
+        try await manager.persistence.upsertSession(ACPSessionRow(
             id: id,
             agentId: agentId,
             title: title,
@@ -809,7 +848,7 @@ struct RemoteAppStateAccessTests {
             lastOpenedAt: lastOpenedAt ?? now,
             archived: archived
         ))
-        manager.refreshRecent()
+        await manager.refreshRecentNow()
     }
 
     private func cleanupRemoteRenameFiles(worktreeId: String) {

--- a/AlasTests/Remote/RemoteSessionGatewayTests.swift
+++ b/AlasTests/Remote/RemoteSessionGatewayTests.swift
@@ -77,12 +77,12 @@ final class FakeSessionsProvider: RemoteSessionsProvider {
         lastUserInputResponse = (id, token, action)
     }
 
-    func fullToolCallContent(sessionId: String, toolCallId: String) -> String? {
+    func fullToolCallContent(sessionId: String, toolCallId: String) async -> String? {
         fullToolCallContents["\(sessionId)|\(toolCallId)"]
     }
 
     func isWriter(for id: String) -> Bool { writers.contains(id) }
-    func takeOver(for id: String) {
+    func takeOver(for id: String) async {
         tookOver.append(id)
         writers.insert(id)
     }

--- a/AlasTests/ReviewLoopHandoffRoutingTests.swift
+++ b/AlasTests/ReviewLoopHandoffRoutingTests.swift
@@ -21,7 +21,7 @@ struct ReviewLoopHandoffRoutingTests {
         }
     }
 
-    @Test func handoffReusesActiveACPChatWithEmptyComposer() throws {
+    @Test func handoffReusesActiveACPChatWithEmptyComposer() async throws {
         let state = makeState()
         state.openNewACPSession(agentID: "test-agent")
         let initialTabs = acpTabs(in: state)
@@ -38,7 +38,7 @@ struct ReviewLoopHandoffRoutingTests {
         #expect(state.tabs.activeTabId(forWorktree: worktreeId) == existing.id)
     }
 
-    @Test func handoffOpensNewACPChatWhenActiveComposerHasText() throws {
+    @Test func handoffOpensNewACPChatWhenActiveComposerHasText() async throws {
         let state = makeState()
         state.openNewACPSession(agentID: "test-agent")
         let existing = try #require(acpTabs(in: state).first)
@@ -58,7 +58,7 @@ struct ReviewLoopHandoffRoutingTests {
         #expect(state.tabs.activeTabId(forWorktree: worktreeId) == newTab.id)
     }
 
-    @Test func handoffOpensNewACPChatWhenActiveComposerHasWhitespaceOnlyText() throws {
+    @Test func handoffOpensNewACPChatWhenActiveComposerHasWhitespaceOnlyText() async throws {
         let state = makeState()
         state.openNewACPSession(agentID: "test-agent")
         let existing = try #require(acpTabs(in: state).first)
@@ -84,7 +84,7 @@ struct ReviewLoopHandoffRoutingTests {
         let worktreeId = try #require(state.selectedWorktreeId)
         let restoredSessionId = "restored-\(UUID().uuidString)"
         let persistedDraft = ACPComposerDraft(segments: [.text("Persisted draft")])
-        try seedPersistedSession(id: restoredSessionId, worktreeId: worktreeId, draft: persistedDraft)
+        try await seedPersistedSession(id: restoredSessionId, worktreeId: worktreeId, draft: persistedDraft)
         let existing = ACPSessionTabState(sessionId: restoredSessionId, title: "Restored")
         state.tabs.append(acpSession: existing, to: worktreeId)
 
@@ -93,6 +93,7 @@ struct ReviewLoopHandoffRoutingTests {
         let tabs = acpTabs(in: state)
         #expect(tabs.count == 2)
         let manager = try #require(state.acpManager(forWorktreeId: worktreeId))
+        await manager.refreshRecentNow()
         let restoredSession = try #require(manager.placeholderSession(id: restoredSessionId))
         #expect(restoredSession.hydrationState == .loading)
         let newTab = try #require(tabs.last)
@@ -103,7 +104,7 @@ struct ReviewLoopHandoffRoutingTests {
         #expect(restoredSession.composerDraft == persistedDraft)
     }
 
-    @Test func handoffOpensNewACPChatWhenActiveSessionHasTranscriptHistory() throws {
+    @Test func handoffOpensNewACPChatWhenActiveSessionHasTranscriptHistory() async throws {
         let state = makeState()
         state.openNewACPSession(agentID: "test-agent")
         let existing = try #require(acpTabs(in: state).first)
@@ -123,7 +124,7 @@ struct ReviewLoopHandoffRoutingTests {
         #expect(state.tabs.activeTabId(forWorktree: worktreeId) == newTab.id)
     }
 
-    @Test func handoffOpensNewACPChatWhenActiveSessionHasQueuedPrompt() throws {
+    @Test func handoffOpensNewACPChatWhenActiveSessionHasQueuedPrompt() async throws {
         let state = makeState()
         state.openNewACPSession(agentID: "test-agent")
         let existing = try #require(acpTabs(in: state).first)
@@ -143,7 +144,7 @@ struct ReviewLoopHandoffRoutingTests {
         #expect(state.tabs.activeTabId(forWorktree: worktreeId) == newTab.id)
     }
 
-    @Test func handoffOpensNewACPChatWhenActiveSessionUsesDifferentAgent() throws {
+    @Test func handoffOpensNewACPChatWhenActiveSessionUsesDifferentAgent() async throws {
         let state = makeState()
         state.openNewACPSession(agentID: "other-agent")
         let existing = try #require(acpTabs(in: state).first)
@@ -162,12 +163,13 @@ struct ReviewLoopHandoffRoutingTests {
         #expect(state.tabs.activeTabId(forWorktree: worktreeId) == newTab.id)
     }
 
-    @Test func handoffOpensNewACPChatWhenActiveSessionIsMirror() throws {
+    @Test func handoffOpensNewACPChatWhenActiveSessionIsMirror() async throws {
         let state = makeState()
         state.openNewACPSession(agentID: "test-agent")
         let existing = try #require(acpTabs(in: state).first)
         let worktreeId = try #require(state.selectedWorktreeId)
         let manager = try #require(state.acpManager(forWorktreeId: worktreeId))
+        await manager.flushPersistence()
         let mirrorOwner = ACPSessionManager(
             worktreeId: worktreeId,
             worktreePath: "/tmp/mirror-owner",
@@ -175,7 +177,8 @@ struct ReviewLoopHandoffRoutingTests {
             instanceId: "mirror-owner",
             pid: Int64(getpid())
         )
-        #expect(mirrorOwner.acquireWriterLease(sessionId: existing.sessionId))
+        #expect(await mirrorOwner.acquireWriterLease(sessionId: existing.sessionId))
+        #expect(!(await manager.acquireWriterLease(sessionId: existing.sessionId)))
         #expect(manager.isMirror(sessionId: existing.sessionId))
 
         state.openACPHandoff(agentID: "test-agent", initialPrompt: "Review feedback")
@@ -188,10 +191,10 @@ struct ReviewLoopHandoffRoutingTests {
         #expect(sessionFor(tab: newTab, in: state)?.composerDraft == ACPComposerDraft(segments: [.text("Review feedback")]))
         #expect(state.tabs.activeTabId(forWorktree: worktreeId) == newTab.id)
 
-        mirrorOwner.releaseWriterLease(sessionId: existing.sessionId)
+        await mirrorOwner.releaseWriterLease(sessionId: existing.sessionId)
     }
 
-    @Test func handoffOpensNewACPChatWhenNoActiveACPChatExists() throws {
+    @Test func handoffOpensNewACPChatWhenNoActiveACPChatExists() async throws {
         let state = makeState()
 
         state.openACPHandoff(agentID: "test-agent", initialPrompt: "Review feedback")
@@ -271,7 +274,7 @@ struct ReviewLoopHandoffRoutingTests {
         return state.acpManager(forWorktreeId: worktreeId)?.placeholderSession(id: tab.sessionId)
     }
 
-    private func seedPersistedSession(id: String, worktreeId: String, draft: ACPComposerDraft) throws {
+    private func seedPersistedSession(id: String, worktreeId: String, draft: ACPComposerDraft) async throws {
         let storeURL = Paths.acpSessionsDB(forWorktreeId: worktreeId)
         try? FileManager.default.removeItem(at: storeURL)
         try FileManager.default.createDirectory(

--- a/docs/plans/2026-07-12-acp-persistence-redesign.md
+++ b/docs/plans/2026-07-12-acp-persistence-redesign.md
@@ -1,0 +1,89 @@
+# ACP Persistence Redesign
+
+## Problem
+
+`ACPSessionManager`, `ACPSessionRunner`, and `AppState` are main-actor types,
+but they call the synchronous `ACPSessionStore` directly. SQLite's five-second
+busy timeout therefore turns ordinary cross-process writer contention into a
+main-thread hang.
+
+Lowering the main-thread timeout is not a complete fix. It changes a hang into
+failed reads and writes, and transparent background replay cannot preserve the
+domain ordering, lease ownership, and lifecycle semantics of ACP sessions.
+
+## Invariants
+
+1. Production main-actor code never opens SQLite, migrates a database, executes
+   SQL, waits for a busy handler, or sleeps while retrying persistence.
+2. A single off-main persistence service owns the writable SQLite connection
+   for each worktree and serializes local mutations.
+3. Persistence APIs are honest: success means the operation committed; failure
+   does not schedule an invisible raw-SQL replay.
+4. Retries, when needed, repeat one typed domain operation without allowing a
+   newer mutation to commit ahead of an older retry.
+5. Writer-owned mutations are fenced by the lease token in the same SQLite
+   transaction as the mutation. A preflight lease read is not a commit fence.
+   The only post-takeover exception is typed compare-and-swap salvage of
+   buffered transcript payloads against a base captured under the old token;
+   it cannot overwrite a row changed by the new owner.
+6. Manager and runner UI state remains main-actor isolated. Database inputs are
+   immutable Sendable values and database outputs are Sendable snapshots.
+7. Session creation is durable before a runner can attach or child rows can be
+   written. Parent/child ordering is explicit rather than recovered later.
+8. Shutdown performs a bounded flush of the existing ordered pipeline. It does
+   not create an unrelated fallback writer that can overtake queued work.
+9. SQLiteKit remains domain-neutral. It must not parse ACP SQL, know table
+   names, inspect binding positions, or evaluate session leases.
+
+## Target Boundaries
+
+### `SQLiteDatabase`
+
+Generic synchronous SQLite primitive. It keeps the configurable busy timeout
+for focused tests and non-UI callers, but contains no retry scheduler.
+
+### `ACPSessionStore`
+
+Typed synchronous SQL and transactions. It is only used from persistence
+executors in production. Lease-fenced store methods validate the expected
+owner and token inside `BEGIN IMMEDIATE` before changing owner-scoped state.
+
+### `ACPSessionPersistence`
+
+Off-main serialized service, created from a database path without opening the
+database in its initializer. Its first awaited operation opens and migrates the
+store. It exposes typed reads, mutations, hydration snapshots, and lease
+commands. Manager and runner queues provide moving-tail flush barriers.
+
+### `ACPSessionManager` and `ACPSessionRunner`
+
+Main-actor state owners. They keep synchronous operations for in-memory UI
+changes, but persistence is submitted to `ACPSessionPersistence`. Operations
+whose result controls behavior, including creation, lease acquisition, and
+takeover, are awaited.
+
+## Migration Sequence
+
+1. Add Sendable persistence value types and the lazy persistence service.
+2. Make production manager construction I/O-free and load recents off-main.
+3. Replace synchronous placeholder lookup with the manager's persisted-row
+   cache, populated by recents and explicit async row loads.
+4. Move manager mutations and draft flushing to the ordered service.
+5. Remove the runner's direct store dependency and persist immutable snapshots.
+6. Add lease tokens and move claim, heartbeat, release, and takeover off-main.
+7. Fence runner and manager owner-scoped mutations transactionally.
+8. Replace synchronous shutdown flushes with a bounded persistence barrier.
+9. Remove all production direct store access from main-actor files.
+
+## Verification
+
+- Hold a competing `BEGIN IMMEDIATE` transaction and prove a main-actor
+  heartbeat continues to execute while persistence waits.
+- Verify FIFO ordering for session creation followed by draft, queue, and
+  transcript writes.
+- Verify a mutation queued under an old lease token cannot commit after
+  takeover.
+- Verify delete/archive cannot be undone by older pending work.
+- Verify draft submit, clear, eviction, and shutdown preserve the latest intent.
+- Verify migration/open failures produce an explicit manager error state rather
+  than a main-thread stall or a permanently missing manager.


### PR DESCRIPTION
## Summary

- move ACP SQLite access behind a lazy off-main persistence actor
- fence owner-scoped writes with lease tokens and preserve safe transcript takeover salvage
- make shutdown and teardown drain ordered persistence before releasing leases

## Verification

- xcodebuild quiet build
- focused ACP persistence, manager, runner, lease, migration, remote gateway, permission, discovery, retention, and review handoff suites

Closes #689.