### PR TITLE
perf(acp): trim markdown transcript rendering churn

### DIFF
--- a/Alas/Sources/ACP/UI/ACPMarkdownInlineRenderer.swift
+++ b/Alas/Sources/ACP/UI/ACPMarkdownInlineRenderer.swift
@@ -91,10 +91,13 @@ enum ACPMarkdownInlineRenderer {
         source: String,
         theme: Theme,
         typography: ACPChatTypography,
-        role: ACPMarkdownInlineRole
+        role: ACPMarkdownInlineRole,
+        memoizeInlineMarkdown: Bool = true
     ) -> NSMutableAttributedString {
         let plan = makePlan(source)
-        let attributed = NSMutableAttributedString(ACPMarkdownText.inlineMarkdown(plan.markdownSource))
+        let attributed = NSMutableAttributedString(
+            ACPMarkdownText.inlineMarkdown(plan.markdownSource, memoize: memoizeInlineMarkdown)
+        )
         applyBaseAttributes(to: attributed, theme: theme, typography: typography, role: role)
         applySubscriptRanges(to: attributed, markers: plan.subscriptMarkers, typography: typography, role: role)
         replaceImages(in: attributed, images: plan.images, theme: theme)

--- a/Alas/Sources/ACP/UI/ACPMarkdownInlineTextView.swift
+++ b/Alas/Sources/ACP/UI/ACPMarkdownInlineTextView.swift
@@ -8,6 +8,7 @@ struct ACPMarkdownInlineTextView: NSViewRepresentable {
     let typography: ACPChatTypography
     let role: ACPMarkdownInlineRole
     let theme: Theme
+    var memoizesInlineMarkdown: Bool = true
 
     func makeCoordinator() -> Coordinator {
         Coordinator()
@@ -24,15 +25,26 @@ struct ACPMarkdownInlineTextView: NSViewRepresentable {
         textView.textContainer?.lineFragmentPadding = 0
         textView.textContainer?.widthTracksTextView = true
         textView.backgroundColor = .clear
+        context.coordinator.resetRenderedState()
         return textView
     }
 
     func updateNSView(_ textView: NSTextView, context: Context) {
+        let renderState = RenderState(
+            source: source,
+            typography: typography,
+            role: role,
+            theme: theme,
+            memoizesInlineMarkdown: memoizesInlineMarkdown
+        )
+        guard context.coordinator.shouldRender(renderState) else { return }
+
         let rendered = ACPMarkdownInlineRenderer.makeAttributedString(
             source: source,
             theme: theme,
             typography: typography,
-            role: role
+            role: role,
+            memoizeInlineMarkdown: memoizesInlineMarkdown
         )
         textView.textStorage?.setAttributedString(rendered)
         context.coordinator.loadRemoteImages(in: textView, attributedString: rendered)
@@ -55,10 +67,25 @@ struct ACPMarkdownInlineTextView: NSViewRepresentable {
 
     @MainActor
     final class Coordinator {
-        private let imageLoader = MarkdownImageLoader()
+        private let imageLoader: MarkdownImageLoader
+        private var lastRenderedState: RenderState?
         private var generation = 0
         private var inFlightImageURLs: Set<URL> = []
         private var currentRemoteImageTargets: [URL: RemoteImageRenderTargets] = [:]
+
+        init(imageLoader: MarkdownImageLoader = .shared) {
+            self.imageLoader = imageLoader
+        }
+
+        func resetRenderedState() {
+            lastRenderedState = nil
+        }
+
+        func shouldRender(_ state: RenderState) -> Bool {
+            guard lastRenderedState != state else { return false }
+            lastRenderedState = state
+            return true
+        }
 
         func loadRemoteImages(in textView: NSTextView, attributedString: NSAttributedString) {
             generation += 1
@@ -170,6 +197,14 @@ struct ACPMarkdownInlineTextView: NSViewRepresentable {
             }
             return foundRange
         }
+    }
+
+    struct RenderState: Equatable {
+        let source: String
+        let typography: ACPChatTypography
+        let role: ACPMarkdownInlineRole
+        let theme: Theme
+        let memoizesInlineMarkdown: Bool
     }
 }
 

--- a/Alas/Sources/ACP/UI/ACPMarkdownText.swift
+++ b/Alas/Sources/ACP/UI/ACPMarkdownText.swift
@@ -22,13 +22,13 @@ struct ACPMarkdownText: View {
 
     var body: some View {
         VStack(alignment: .leading, spacing: 8) {
-            ForEach(Array(currentBlocks().enumerated()), id: \.offset) { _, block in
-                view(for: block)
+            ForEach(Array(currentRenderBlocks().enumerated()), id: \.offset) { _, renderBlock in
+                view(for: renderBlock)
             }
         }
     }
 
-    private func currentBlocks() -> [Block] {
+    private func currentRenderBlocks() -> [RenderBlock] {
         if let cache {
             cache.update(
                 with: raw,
@@ -37,27 +37,46 @@ struct ACPMarkdownText: View {
                 sourceID: updateSourceID
             )
             let tailBlocks = ACPMarkdownText.parse(cache.tailUnparsed)
-            return cache.stableBlocks + tailBlocks
+            return cache.stableBlocks.map { RenderBlock(block: $0, memoizesInlineMarkdown: true) }
+                + tailBlocks.map { RenderBlock(block: $0, memoizesInlineMarkdown: false) }
         }
-        return ACPMarkdownText.parse(raw)
+        return ACPMarkdownText.parse(raw).map { RenderBlock(block: $0, memoizesInlineMarkdown: true) }
     }
 
     @ViewBuilder
-    private func view(for block: Block) -> some View {
-        switch block {
+    private func view(for renderBlock: RenderBlock) -> some View {
+        switch renderBlock.block {
         case .heading(let level, let text):
-            ACPMarkdownInlineTextView(source: text, typography: typography, role: .heading(level: level), theme: theme)
+            ACPMarkdownInlineTextView(
+                source: text,
+                typography: typography,
+                role: .heading(level: level),
+                theme: theme,
+                memoizesInlineMarkdown: renderBlock.memoizesInlineMarkdown
+            )
                 .padding(.top, level == 1 ? 4 : 2)
                 .frame(maxWidth: .infinity, alignment: .leading)
         case .paragraph(let text):
-            ACPMarkdownInlineTextView(source: text, typography: typography, role: .body, theme: theme)
+            ACPMarkdownInlineTextView(
+                source: text,
+                typography: typography,
+                role: .body,
+                theme: theme,
+                memoizesInlineMarkdown: renderBlock.memoizesInlineMarkdown
+            )
                 .frame(maxWidth: .infinity, alignment: .leading)
         case .quote(let text):
             HStack(alignment: .top, spacing: 10) {
                 Rectangle()
                     .fill(theme.color("accent").opacity(0.55))
                     .frame(width: 2)
-                ACPMarkdownInlineTextView(source: text, typography: typography, role: .quote, theme: theme)
+                ACPMarkdownInlineTextView(
+                    source: text,
+                    typography: typography,
+                    role: .quote,
+                    theme: theme,
+                    memoizesInlineMarkdown: renderBlock.memoizesInlineMarkdown
+                )
                     .frame(maxWidth: .infinity, alignment: .leading)
                 Spacer(minLength: 0)
             }
@@ -78,18 +97,36 @@ struct ACPMarkdownText: View {
                 highlightsSyntax: false
             )
         case .table(let header, let rows):
-            tableView(header: header, rows: rows)
+            tableView(
+                header: header,
+                rows: rows,
+                memoizesInlineMarkdown: renderBlock.memoizesInlineMarkdown
+            )
         }
     }
 
-    private func tableView(header: [String], rows: [[String]]) -> some View {
+    private func tableView(
+        header: [String],
+        rows: [[String]],
+        memoizesInlineMarkdown: Bool
+    ) -> some View {
         let columnCount = max(header.count, rows.map(\.count).max() ?? 0)
         return ScrollView(.horizontal, showsIndicators: false) {
             VStack(alignment: .leading, spacing: 0) {
-                tableRow(cells: header, isHeader: true, columnCount: columnCount)
+                tableRow(
+                    cells: header,
+                    isHeader: true,
+                    columnCount: columnCount,
+                    memoizesInlineMarkdown: memoizesInlineMarkdown
+                )
                 Rectangle().fill(theme.color("line")).frame(height: 0.5)
                 ForEach(Array(rows.enumerated()), id: \.offset) { _, r in
-                    tableRow(cells: r, isHeader: false, columnCount: columnCount)
+                    tableRow(
+                        cells: r,
+                        isHeader: false,
+                        columnCount: columnCount,
+                        memoizesInlineMarkdown: memoizesInlineMarkdown
+                    )
                     if r != rows.last {
                         Rectangle().fill(theme.color("line-soft")).frame(height: 0.5)
                     }
@@ -101,7 +138,12 @@ struct ACPMarkdownText: View {
         .overlay(RoundedRectangle(cornerRadius: 6).strokeBorder(theme.color("line"), lineWidth: 0.5))
     }
 
-    private func tableRow(cells: [String], isHeader: Bool, columnCount: Int) -> some View {
+    private func tableRow(
+        cells: [String],
+        isHeader: Bool,
+        columnCount: Int,
+        memoizesInlineMarkdown: Bool
+    ) -> some View {
         HStack(alignment: .top, spacing: 0) {
             ForEach(0..<columnCount, id: \.self) { i in
                 let value = i < cells.count ? cells[i] : ""
@@ -109,7 +151,8 @@ struct ACPMarkdownText: View {
                     source: value,
                     typography: typography,
                     role: .tableCell(isHeader: isHeader),
-                    theme: theme
+                    theme: theme,
+                    memoizesInlineMarkdown: memoizesInlineMarkdown
                 )
                     .frame(minWidth: 80, alignment: .leading)
                     .padding(.horizontal, 10).padding(.vertical, 6)
@@ -129,12 +172,28 @@ struct ACPMarkdownText: View {
         return c
     }()
 
+    private static let inlineCacheStatsLock = NSLock()
+    nonisolated(unsafe) private static var inlineCacheInsertionCount = 0
+
+    static var inlineCacheInsertionCountForTesting: Int {
+        inlineCacheStatsLock.lock()
+        defer { inlineCacheStatsLock.unlock() }
+        return inlineCacheInsertionCount
+    }
+
+    static func removeAllInlineCacheObjectsForTesting() {
+        inlineCache.removeAllObjects()
+        inlineCacheStatsLock.lock()
+        defer { inlineCacheStatsLock.unlock() }
+        inlineCacheInsertionCount = 0
+    }
+
     /// Inline parser: bold / italic / inline code / links via the
     /// system AttributedString initializer. Results are memoized in a
     /// process-static NSCache; stable blocks stay warm across chunks.
-    static func inlineMarkdown(_ s: String) -> AttributedString {
+    static func inlineMarkdown(_ s: String, memoize: Bool = true) -> AttributedString {
         let key = s as NSString
-        if let hit = inlineCache.object(forKey: key) {
+        if memoize, let hit = inlineCache.object(forKey: key) {
             return AttributedString(hit)
         }
         let renderSource = ACPBareURLLinkifier.markdownAutolinkingBareURLs(
@@ -152,7 +211,12 @@ struct ACPMarkdownText: View {
         } else {
             attr = AttributedString(s)
         }
-        inlineCache.setObject(NSAttributedString(attr), forKey: key)
+        if memoize {
+            inlineCache.setObject(NSAttributedString(attr), forKey: key)
+            inlineCacheStatsLock.lock()
+            inlineCacheInsertionCount += 1
+            inlineCacheStatsLock.unlock()
+        }
         return attr
     }
 
@@ -165,6 +229,11 @@ struct ACPMarkdownText: View {
         case code(language: String?, body: String)
         case streamingCode(language: String?, body: String)
         case table(header: [String], rows: [[String]])
+    }
+
+    private struct RenderBlock {
+        let block: Block
+        let memoizesInlineMarkdown: Bool
     }
 
     /// Detect a GitHub-flavoured markdown table starting at `start`:

--- a/Alas/Sources/Code/Markdown/MarkdownImageLoader.swift
+++ b/Alas/Sources/Code/Markdown/MarkdownImageLoader.swift
@@ -7,9 +7,11 @@ import Foundation
 /// fetched image to the placeholder attachment and invalidating layout.
 ///
 /// `@unchecked Sendable` is sound because the only mutable state is
-/// `NSCache`, which is documented thread-safe, and `URLSession`, which is
-/// itself `Sendable`. The class has no other writable storage.
+/// `NSCache`, which is documented thread-safe, and the main-actor-confined
+/// remote-load coalescing table. `URLSession` is itself `Sendable`.
 final class MarkdownImageLoader: @unchecked Sendable {
+    static let shared = MarkdownImageLoader()
+
     enum Source: Equatable {
         case local(String)
         case remote(URL)
@@ -30,6 +32,7 @@ final class MarkdownImageLoader: @unchecked Sendable {
 
     private let cache = NSCache<NSURL, NSImage>()
     private let session: URLSession
+    private var inFlightRemoteCompletions: [URL: [@MainActor (NSImage?) -> Void]] = [:]
 
     init(session: URLSession = .shared) {
         self.session = session
@@ -51,12 +54,27 @@ final class MarkdownImageLoader: @unchecked Sendable {
         if let cached = cache.object(forKey: url as NSURL) {
             return cached
         }
+        if inFlightRemoteCompletions[url] != nil {
+            inFlightRemoteCompletions[url, default: []].append(completion)
+            return nil
+        }
+        inFlightRemoteCompletions[url] = [completion]
+
         let task = session.dataTask(with: url) { [weak self] data, _, _ in
             let image = data.flatMap { NSImage(data: $0) }
-            if let image, let self {
-                self.cache.setObject(image, forKey: url as NSURL)
+            Task { @MainActor in
+                guard let self else {
+                    completion(image)
+                    return
+                }
+                if let image {
+                    self.cache.setObject(image, forKey: url as NSURL)
+                }
+                let completions = self.inFlightRemoteCompletions.removeValue(forKey: url) ?? [completion]
+                for completion in completions {
+                    completion(image)
+                }
             }
-            Task { @MainActor in completion(image) }
         }
         task.resume()
         return nil

--- a/AlasTests/ACP/UI/ACPMarkdownTextBareURLTests.swift
+++ b/AlasTests/ACP/UI/ACPMarkdownTextBareURLTests.swift
@@ -131,4 +131,18 @@ struct ACPMarkdownTextBareURLTests {
         #expect(url?.absoluteString == "https://example.com/foo*bar*")
         #expect(effectiveRange == range)
     }
+
+    @Test("non-memoized inline markdown does not populate cache")
+    func nonMemoizedInlineMarkdownDoesNotPopulateCache() {
+        ACPMarkdownText.removeAllInlineCacheObjectsForTesting()
+
+        _ = ACPMarkdownText.inlineMarkdown("streamed **prefix**", memoize: false)
+        #expect(ACPMarkdownText.inlineCacheInsertionCountForTesting == 0)
+
+        _ = ACPMarkdownText.inlineMarkdown("stable **block**")
+        #expect(ACPMarkdownText.inlineCacheInsertionCountForTesting == 1)
+
+        _ = ACPMarkdownText.inlineMarkdown("stable **block**")
+        #expect(ACPMarkdownText.inlineCacheInsertionCountForTesting == 1)
+    }
 }

--- a/AlasTests/MarkdownImageLoaderTests.swift
+++ b/AlasTests/MarkdownImageLoaderTests.swift
@@ -60,4 +60,95 @@ struct MarkdownImageLoaderTests {
         default: Issue.record("expected .invalid for empty string")
         }
     }
+
+    @MainActor
+    @Test func remoteLoadsShareInFlightRequest() async throws {
+        let imageData = try #require(makePNGData())
+        MarkdownImageLoaderURLProtocol.reset(responseData: imageData)
+
+        let configuration = URLSessionConfiguration.ephemeral
+        configuration.protocolClasses = [MarkdownImageLoaderURLProtocol.self]
+        let session = URLSession(configuration: configuration)
+        let loader = MarkdownImageLoader(session: session)
+        let url = try #require(URL(string: "https://example.com/badge.png"))
+
+        var completions = 0
+        await withCheckedContinuation { (continuation: CheckedContinuation<Void, Never>) in
+            func recordCompletion(_ image: NSImage?) {
+                #expect(image != nil)
+                completions += 1
+                if completions == 2 {
+                    continuation.resume()
+                }
+            }
+
+            #expect(loader.loadRemote(url: url, completion: recordCompletion) == nil)
+            #expect(loader.loadRemote(url: url, completion: recordCompletion) == nil)
+        }
+
+        #expect(MarkdownImageLoaderURLProtocol.requestCount == 1)
+        #expect(loader.loadRemote(url: url) { _ in
+            Issue.record("cached remote load should return synchronously")
+        } != nil)
+        #expect(MarkdownImageLoaderURLProtocol.requestCount == 1)
+    }
+
+    private func makePNGData() -> Data? {
+        let img = NSImage(size: NSSize(width: 1, height: 1))
+        img.lockFocus()
+        NSColor.red.setFill()
+        NSRect(x: 0, y: 0, width: 1, height: 1).fill()
+        img.unlockFocus()
+        guard let tiff = img.tiffRepresentation,
+              let rep = NSBitmapImageRep(data: tiff)
+        else { return nil }
+        return rep.representation(using: .png, properties: [:])
+    }
+}
+
+private final class MarkdownImageLoaderURLProtocol: URLProtocol {
+    private static let lock = NSLock()
+    private static var data = Data()
+    private static var count = 0
+
+    static var requestCount: Int {
+        lock.lock()
+        defer { lock.unlock() }
+        return count
+    }
+
+    static func reset(responseData: Data) {
+        lock.lock()
+        defer { lock.unlock() }
+        data = responseData
+        count = 0
+    }
+
+    override class func canInit(with request: URLRequest) -> Bool {
+        true
+    }
+
+    override class func canonicalRequest(for request: URLRequest) -> URLRequest {
+        request
+    }
+
+    override func startLoading() {
+        Self.lock.lock()
+        Self.count += 1
+        let responseData = Self.data
+        Self.lock.unlock()
+        if let url = request.url,
+           let response = HTTPURLResponse(
+               url: url,
+               statusCode: 200,
+               httpVersion: nil,
+               headerFields: ["Content-Type": "image/png"]
+           ) {
+            client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
+        }
+        client?.urlProtocol(self, didLoad: responseData)
+        client?.urlProtocolDidFinishLoading(self)
+    }
+
+    override func stopLoading() {}
 }


### PR DESCRIPTION
## Summary
- avoid populating the inline markdown cache from streaming tail blocks while keeping stable blocks memoized
- skip redundant `NSTextView` updates when ACP inline markdown render inputs are unchanged
- share and coalesce remote markdown image loads across inline rows

Fixes #674.

## Verification
- `xcodegen`
- `ALAS_FFF_TARGET_ARCH=arm64 xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -quiet build`
- `ALAS_FFF_TARGET_ARCH=arm64 xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -only-testing:AlasTests/MarkdownImageLoaderTests -only-testing:AlasTests/ACPMarkdownTextBareURLTests test`

Note: the full local test command was started but remained active without a terminal result after an extended wait, so I interrupted it and left broad coverage to CI.