### PR TITLE
perf(acp): cache tool output syntax resolution

### DIFF
--- a/Alas/Sources/ACP/Session/ACPMessage.swift
+++ b/Alas/Sources/ACP/Session/ACPMessage.swift
@@ -170,6 +170,10 @@ enum ACPMessage: Equatable {
         /// Rendered inside the expanded card. Updated in place when the
         /// agent sends `tool_call_update` with new content.
         var content: String
+        /// In-memory revision for displayed content changes. Restored rows
+        /// start from their persisted snapshot, so this is intentionally not
+        /// encoded.
+        var contentRevision: Int = 0
         /// One-line teaser shown on the collapsed row (first text chunk,
         /// truncated). Computed at apply() time so we don't repeatedly
         /// scan the full content during rendering.
@@ -211,6 +215,7 @@ enum ACPMessage: Equatable {
             guard !isContentTruncated else { return }
             if content.count > Self.truncatedTailBytes {
                 content = String(content.prefix(Self.truncatedTailBytes))
+                contentRevision &+= 1
             }
             isContentTruncated = true
         }
@@ -313,6 +318,12 @@ enum ACPMessage: Equatable {
             hasher.combine(assets)
             hasher.combine(locations)
             hasher.combine(terminalIds)
+        }
+
+        mutating func replaceContent(_ newContent: String) {
+            guard content != newContent else { return }
+            content = newContent
+            contentRevision &+= 1
         }
     }
 

--- a/Alas/Sources/ACP/Session/ACPSession.swift
+++ b/Alas/Sources/ACP/Session/ACPSession.swift
@@ -597,7 +597,7 @@ final class ACPSession: ObservableObject, Identifiable {
         let raw = Self.flatten(items)
         let full = Self.stripWrappingFence(raw,
                                            isFinal: Self.isFinalStatus(payload.status))
-        tc.content = full
+        tc.replaceContent(full)
         tc.isContentTruncated = false
         tc.preview = Self.previewLine(full)
         tc.contentLanguage = Self.wrappingFenceLanguage(raw)
@@ -645,7 +645,7 @@ final class ACPSession: ObservableObject, Identifiable {
             let raw = Self.flatten(content)
             let full = Self.stripWrappingFence(raw,
                                                isFinal: Self.isFinalStatus(tc.status))
-            tc.content = full
+            tc.replaceContent(full)
             tc.isContentTruncated = false
             tc.preview = Self.previewLine(full)
             tc.contentLanguage = Self.wrappingFenceLanguage(raw)
@@ -691,8 +691,32 @@ final class ACPSession: ObservableObject, Identifiable {
     }
 
     func replaceTranscriptMessages(_ messages: [ACPMessage]) {
-        transcript.messages = messages
+        transcript.messages = messagesPreservingToolCallContentRevisions(messages)
         rebuildToolCallIndices()
+    }
+
+    private func messagesPreservingToolCallContentRevisions(_ messages: [ACPMessage]) -> [ACPMessage] {
+        let previousToolCalls = transcript.messages.reduce(into: [String: ACPMessage.ToolCall]()) { result, message in
+            if case .toolCall(let toolCall) = message {
+                result[toolCall.toolCallId] = toolCall
+            }
+        }
+
+        guard !previousToolCalls.isEmpty else {
+            return messages
+        }
+
+        return messages.map { message in
+            guard case .toolCall(var toolCall) = message,
+                  let previous = previousToolCalls[toolCall.toolCallId] else {
+                return message
+            }
+            toolCall.contentRevision = previous.contentRevision
+            if toolCall.content != previous.content {
+                toolCall.contentRevision &+= 1
+            }
+            return .toolCall(toolCall)
+        }
     }
 
     /// Insert `older` at the head of the transcript and shift `visibleHead`

--- a/Alas/Sources/ACP/UI/ACPToolCallCard.swift
+++ b/Alas/Sources/ACP/UI/ACPToolCallCard.swift
@@ -17,6 +17,7 @@ struct ACPToolCallCard: View {
     var loadFullContent: ((String) -> String?)? = nil
     @State private var expanded = false
     @State private var expandedContent: String? = nil
+    @State private var expandedSyntax = ACPToolCallSyntaxCache()
     @Environment(\.theme) private var theme
     @Environment(\.acpTerminalHost) private var terminalHost
 
@@ -78,6 +79,10 @@ struct ACPToolCallCard: View {
         // body from the previous tool call.
         .onChange(of: toolCall.toolCallId) { _, _ in
             expandedContent = nil
+            expandedSyntax.clear()
+        }
+        .onChange(of: toolCall.contentRevision) { _, _ in
+            expandedSyntax.clear()
         }
     }
 
@@ -88,6 +93,26 @@ struct ACPToolCallCard: View {
     /// always render straight from `toolCall.content`.
     private var displayContent: String {
         expandedContent ?? toolCall.content
+    }
+
+    private var displayContentSource: ACPToolCallSyntaxCache.ContentSource {
+        expandedContent == nil ? .message : .expanded
+    }
+
+    private var displayContentLanguage: String? {
+        if let explicit = toolCall.contentLanguage {
+            return explicit
+        }
+        return expandedSyntax.language(
+            for: .init(
+                toolCallId: toolCall.toolCallId,
+                contentRevision: toolCall.contentRevision,
+                contentSource: displayContentSource,
+                locations: toolCall.locations
+            ),
+            content: displayContent,
+            locations: toolCall.locations
+        )
     }
 
     @ViewBuilder
@@ -113,10 +138,7 @@ struct ACPToolCallCard: View {
                     ScrollView(.horizontal, showsIndicators: false) {
                         ACPSyntaxHighlightedText(
                             text: displayContent,
-                            explicitLanguage: toolCall.contentLanguage ?? ACPToolOutputSyntax.highlighterExtension(
-                                content: displayContent,
-                                locations: toolCall.locations
-                            ),
+                            explicitLanguage: displayContentLanguage,
                             fontSize: 11.5
                         )
                             .padding(.horizontal, 12).padding(.vertical, 10)
@@ -194,6 +216,41 @@ struct ACPToolCallCard: View {
                 .foregroundStyle(theme.color("accent"))
         }
         .frame(width: 18, height: 18)
+    }
+}
+
+private final class ACPToolCallSyntaxCache {
+    private var key: Key?
+    private var cachedLanguage: String?
+
+    func language(for key: Key, content: String, locations: [String]) -> String? {
+        if self.key == key {
+            return cachedLanguage
+        }
+        let language = ACPToolOutputSyntax.highlighterExtension(
+            content: content,
+            locations: locations
+        )
+        self.key = key
+        cachedLanguage = language
+        return language
+    }
+
+    func clear() {
+        key = nil
+        cachedLanguage = nil
+    }
+
+    enum ContentSource: Hashable {
+        case message
+        case expanded
+    }
+
+    struct Key: Hashable {
+        let toolCallId: String
+        let contentRevision: Int
+        let contentSource: ContentSource
+        let locations: [String]
     }
 }
 

--- a/AlasTests/ACP/Session/ACPMessageTests.swift
+++ b/AlasTests/ACP/Session/ACPMessageTests.swift
@@ -42,6 +42,38 @@ struct ACPMessageTests {
         #expect(back == m)
     }
 
+    @Test("tool call content revision advances only when displayed content changes")
+    func toolCallContentRevisionTracksDisplayedContentChanges() {
+        var toolCall = ACPMessage.ToolCall(
+            toolCallId: "tc-revision",
+            title: "run",
+            kind: "execute",
+            status: "in_progress",
+            content: "first")
+
+        #expect(toolCall.contentRevision == 0)
+        toolCall.replaceContent("first")
+        #expect(toolCall.contentRevision == 0)
+        toolCall.replaceContent("second")
+        #expect(toolCall.content == "second")
+        #expect(toolCall.contentRevision == 1)
+    }
+
+    @Test("tool call truncation advances content revision when displayed content is shortened")
+    func toolCallTruncationAdvancesContentRevisionWhenContentChanges() {
+        var toolCall = ACPMessage.ToolCall(
+            toolCallId: "tc-truncated-revision",
+            title: "run",
+            kind: "execute",
+            status: "completed",
+            content: String(repeating: "x", count: ACPMessage.ToolCall.truncatedTailBytes + 8))
+
+        toolCall.truncateForOffWindow()
+
+        #expect(toolCall.content.count == ACPMessage.ToolCall.truncatedTailBytes)
+        #expect(toolCall.contentRevision == 1)
+    }
+
     @Test("tool call enriched fields round-trip")
     func toolCallEnrichedRoundtrip() throws {
         let metadata = AnyCodable([

--- a/AlasTests/ACP/Session/ACPSessionTests.swift
+++ b/AlasTests/ACP/Session/ACPSessionTests.swift
@@ -5,6 +5,61 @@ import Testing
 @MainActor
 @Suite("ACPSession")
 struct ACPSessionTests {
+    @Test("replacement transcript preserves tool call content revision when content is unchanged")
+    func replaceTranscriptPreservesToolCallContentRevisionForSameContent() {
+        let session = ACPSession(id: "s", agentId: "codex", worktreeId: "w", title: "t")
+        var original = ACPMessage.ToolCall(
+            toolCallId: "tool-1",
+            title: "run",
+            kind: "execute",
+            status: "completed",
+            content: "same output")
+        original.replaceContent("new output")
+        original.replaceContent("same output")
+        session.replaceTranscriptMessages([.toolCall(original)])
+
+        let replacement = ACPMessage.ToolCall(
+            toolCallId: "tool-1",
+            title: "run",
+            kind: "execute",
+            status: "completed",
+            content: "same output")
+        session.replaceTranscriptMessages([.toolCall(replacement)])
+
+        guard case .toolCall(let toolCall) = session.transcript.messages.first else {
+            Issue.record("expected replacement tool call")
+            return
+        }
+        #expect(toolCall.contentRevision == original.contentRevision)
+    }
+
+    @Test("replacement transcript advances tool call content revision when content changes")
+    func replaceTranscriptAdvancesToolCallContentRevisionForChangedContent() {
+        let session = ACPSession(id: "s", agentId: "codex", worktreeId: "w", title: "t")
+        var original = ACPMessage.ToolCall(
+            toolCallId: "tool-1",
+            title: "run",
+            kind: "execute",
+            status: "completed",
+            content: "plain output")
+        original.replaceContent("still plain")
+        session.replaceTranscriptMessages([.toolCall(original)])
+
+        let replacement = ACPMessage.ToolCall(
+            toolCallId: "tool-1",
+            title: "run",
+            kind: "execute",
+            status: "completed",
+            content: "@@ -1 +1 @@\n-old\n+new")
+        session.replaceTranscriptMessages([.toolCall(replacement)])
+
+        guard case .toolCall(let toolCall) = session.transcript.messages.first else {
+            Issue.record("expected replacement tool call")
+            return
+        }
+        #expect(toolCall.contentRevision == original.contentRevision + 1)
+    }
+
     @Test("agent message chunks append to a single agent message")
     func chunksMerge() async {
         let session = ACPSession(id: "s", agentId: "claude", worktreeId: "w", title: "t")


### PR DESCRIPTION
## Summary

- Add an in-memory tool-call content revision so rendered-output changes have a stable cache key.
- Cache ACP tool output syntax language resolution per expanded card and content revision, including nil language results.
- Route ACP tool-call content replacements and transcript replacements through revision-aware helpers, with focused regression coverage.

Closes #671

## Validation

- `xcodegen`
- `ALAS_FFF_TARGET_ARCH=arm64 xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -only-testing:AlasTests/ACPMessageTests -quiet test`
- `ALAS_FFF_TARGET_ARCH=arm64 xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -only-testing:AlasTests/ACPMessageTests -only-testing:AlasTests/ACPSessionTests/replaceTranscriptPreservesToolCallContentRevisionForSameContent -only-testing:AlasTests/ACPSessionTests/replaceTranscriptAdvancesToolCallContentRevisionForChangedContent -quiet test`
- `ALAS_FFF_TARGET_ARCH=arm64 xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -quiet build`

## Notes

A broader `xcodebuild ... test` run was started but interrupted after it hung following an unrelated AppKit exception in `DiffPaneViewTests.splitDocumentHighlightsSyntaxAcrossRowsWithOriginalWhitespaceSource`. A full `ACPSessionTests` run also exposes pre-existing order-dependent failures in `rawOutputDataURIAssetSurvivesLaterContentUpdate` and `rawOutputLongImageURLAssetSurvivesLaterContentUpdate`; both pass when isolated and when run with the new replacement-revision tests.