### PR TITLE
fix(shortcuts): ignore unsupported menu shortcuts

### DIFF
--- a/Alas/Sources/Shortcuts/ShortcutBinding.swift
+++ b/Alas/Sources/Shortcuts/ShortcutBinding.swift
@@ -41,11 +41,21 @@ struct ShortcutBinding: Codable, Equatable, Hashable, Sendable {
         }
     }
 
-    func asKeyboardShortcut() -> KeyboardShortcut {
-        KeyboardShortcut(keyEquivalent, modifiers: eventModifiers)
+    var hasSupportedKey: Bool {
+        keyEquivalent != nil
     }
 
-    private var keyEquivalent: KeyEquivalent {
+    func asKeyboardShortcut() -> KeyboardShortcut? {
+        guard let keyEquivalent else { return nil }
+        return KeyboardShortcut(keyEquivalent, modifiers: eventModifiers)
+    }
+
+    static func isSupportedLiteralKey(_ key: String) -> Bool {
+        guard key.count == 1, let first = key.first else { return false }
+        return first.isLetter || first.isNumber || "0123456789-=,.;'/[]\\`".contains(first)
+    }
+
+    private var keyEquivalent: KeyEquivalent? {
         switch key {
         case "return":     return .return
         case "leftArrow":  return .leftArrow
@@ -57,7 +67,8 @@ struct ShortcutBinding: Codable, Equatable, Hashable, Sendable {
         case "tab":        return .tab
         case "space":      return .space
         default:
-            return key.count == 1 ? KeyEquivalent(key.first!) : KeyEquivalent(" ")
+            guard Self.isSupportedLiteralKey(key), let first = key.first else { return nil }
+            return KeyEquivalent(first)
         }
     }
 

--- a/Alas/Sources/Shortcuts/ShortcutRecorder.swift
+++ b/Alas/Sources/Shortcuts/ShortcutRecorder.swift
@@ -123,7 +123,7 @@ final class ShortcutRecorderSession {
         case 126: key = "upArrow"
         default:
             let raw = (event.charactersIgnoringModifiers ?? "").lowercased()
-            guard !raw.isEmpty, raw.first?.isLetter == true || "0123456789-=,.;'/[]\\`".contains(raw) else {
+            guard ShortcutBinding.isSupportedLiteralKey(raw) else {
                 return nil
             }
             key = raw

--- a/Alas/Sources/Shortcuts/ShortcutResolver.swift
+++ b/Alas/Sources/Shortcuts/ShortcutResolver.swift
@@ -15,7 +15,8 @@ extension AppState {
 
     /// SwiftUI-ready form. Pass directly into `.keyboardShortcut(_:)`.
     func shortcut(for action: ShortcutAction) -> KeyboardShortcut? {
-        binding(for: action)?.asKeyboardShortcut()
+        guard let binding = binding(for: action) else { return nil }
+        return binding.asKeyboardShortcut()
     }
 
     /// Assign or unbind a shortcut.
@@ -25,6 +26,7 @@ extension AppState {
     ///   the action will have no shortcut).
     /// - Use `resetShortcut(for:)` instead if you want the default restored.
     func setShortcut(_ binding: ShortcutBinding?, for action: ShortcutAction) {
+        guard binding?.hasSupportedKey != false else { return }
         config.shortcutOverrides[action.rawValue] = .some(binding)
         _ = saveConfig()
         ShortcutReservations.update(from: config)

--- a/AlasTests/ShortcutBindingTests.swift
+++ b/AlasTests/ShortcutBindingTests.swift
@@ -40,16 +40,23 @@ struct ShortcutBindingTests {
         #expect(b.displayString == "⌃ ⇧ ⌘ K")
     }
 
-    @Test func asKeyboardShortcutLetter() {
+    @Test func asKeyboardShortcutLetter() throws {
         let b = ShortcutBinding(key: "p", modifiers: [.command])
-        let ks = b.asKeyboardShortcut()
+        let ks = try #require(b.asKeyboardShortcut())
         #expect(ks.key == KeyEquivalent("p"))
         #expect(ks.modifiers == .command)
     }
 
-    @Test func asKeyboardShortcutReturn() {
+    @Test func asKeyboardShortcutReturn() throws {
         let b = ShortcutBinding(key: "return", modifiers: [.command])
-        let ks = b.asKeyboardShortcut()
+        let ks = try #require(b.asKeyboardShortcut())
         #expect(ks.key == .return)
+    }
+
+    @Test func asKeyboardShortcutRejectsUnsupportedKeys() {
+        #expect(ShortcutBinding(key: "", modifiers: [.command]).asKeyboardShortcut() == nil)
+        #expect(ShortcutBinding(key: "ab", modifiers: [.command]).asKeyboardShortcut() == nil)
+        #expect(ShortcutBinding(key: "f13", modifiers: [.command]).asKeyboardShortcut() == nil)
+        #expect(ShortcutBinding(key: "🙂", modifiers: [.command]).asKeyboardShortcut() == nil)
     }
 }

--- a/AlasTests/ShortcutResolverTests.swift
+++ b/AlasTests/ShortcutResolverTests.swift
@@ -100,4 +100,21 @@ struct ShortcutResolverTests {
         #expect(conflict == .searchFiles || conflict == .switchRepository,
                 "expected override to participate in conflict detection")
     }
+
+    @Test func shortcutIgnoresUnsupportedPersistedKey() async {
+        let state = makeState()
+        state.config.shortcutOverrides[ShortcutAction.searchFiles.rawValue] =
+            .some(ShortcutBinding(key: "unsupported", modifiers: [.command]))
+
+        #expect(state.binding(for: .searchFiles)?.key == "unsupported")
+        #expect(state.shortcut(for: .searchFiles) == nil)
+    }
+
+    @Test func setShortcutRejectsUnsupportedKeys() async {
+        let state = makeState()
+        state.setShortcut(ShortcutBinding(key: "unsupported", modifiers: [.command]), for: .searchFiles)
+
+        #expect(state.config.shortcutOverrides.isEmpty)
+        #expect(state.binding(for: .searchFiles) == ShortcutAction.searchFiles.defaultBinding)
+    }
 }


### PR DESCRIPTION
## Summary

- Treat unsupported persisted shortcut keys as unbound instead of converting them to Space.
- Reuse the same supported-key predicate when recording shortcuts.
- Reject unsupported shortcut assignments before they reach persisted config.

## Root Cause

ShortcutBinding converted any unknown multi-character key into a Space key equivalent. A stale or malformed shortcut override could therefore feed bogus shortcut metadata into SwiftUI's AppKit menu bridge while the main menu was being rebuilt.

## Validation

- `xcodegen`
- `ALAS_FFF_TARGET_ARCH=arm64 xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS,arch=arm64' -quiet build`
- `ALAS_FFF_TARGET_ARCH=arm64 xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS,arch=arm64' -only-testing:AlasTests/ShortcutBindingTests -only-testing:AlasTests/ShortcutResolverTests test`

Full local `xcodebuild ... test` was attempted but interrupted after it wedged for several minutes following unrelated existing failures/logged exceptions in ACP/DiffPane tests.