### PR TITLE
fix(acp): avoid ACPMessage copies in transcript rows

### DIFF
--- a/Alas/Sources/ACP/UI/ACPMessageList.swift
+++ b/Alas/Sources/ACP/UI/ACPMessageList.swift
@@ -59,13 +59,12 @@ struct ACPMessageList: View {
     /// reset to `max(0, count - tailWindow)` after hydration); the
     /// filter drops `.plan` entries because the toolbar pill renders
     /// the current turn's plan instead of an inline card.
-    private var visibleRows: [(index: Int, stableId: String, message: ACPMessage)] {
-        let head = min(transcript.visibleHead, transcript.messages.count)
-        return (head..<transcript.messages.count).compactMap { index in
-            let message = transcript.messages[index]
-            if case .plan = message { return nil }
-            return (index, transcript.stableId(for: message), message)
-        }
+    private var visibleRows: [VisibleRow] {
+        Self.visibleRows(
+            messages: transcript.messages,
+            visibleHead: transcript.visibleHead,
+            stableId: { transcript.stableId(for: $0) }
+        )
     }
 
     /// Cheap signature of the entire transcript. SwiftUI re-evaluates when
@@ -128,9 +127,8 @@ struct ACPMessageList: View {
                                 .padding(.bottom, 4)
                                 .background(topPaginationSentinel)
                         }
-                        ForEach(visibleRows, id: \.stableId) { item in
-                            row(for: item.message, stableId: item.stableId)
-                                .background(rowFrameReporter(id: item.stableId))
+                        ForEach(visibleRows) { row in
+                            visibleRow(row)
                         }
                         if transcript.pendingPermission != nil, let policy = policy {
                             ACPPermissionPrompt(session: session, policy: policy, scopeKey: scopeKey)
@@ -618,6 +616,26 @@ struct ACPMessageList: View {
         !isModernScrollTrackingAvailable
     }
 
+    struct VisibleRow: Identifiable, Equatable {
+        let index: Int
+        let stableId: String
+
+        var id: String { stableId }
+    }
+
+    static func visibleRows(
+        messages: [ACPMessage],
+        visibleHead: Int,
+        stableId: (ACPMessage) -> String
+    ) -> [VisibleRow] {
+        let head = min(visibleHead, messages.count)
+        return (head..<messages.count).compactMap { index in
+            let message = messages[index]
+            if case .plan = message { return nil }
+            return VisibleRow(index: index, stableId: stableId(message))
+        }
+    }
+
     struct VisibleMessageLookup {
         let ids: Set<String>
         let indexByStableId: [String: Int]
@@ -807,6 +825,17 @@ struct ACPMessageList: View {
                 proxy.scrollTo(anchorId, anchor: .top)
             }
             DispatchQueue.main.async { isRestoringTail = false }
+        }
+    }
+
+    @ViewBuilder
+    private func visibleRow(_ visibleRow: VisibleRow) -> some View {
+        if transcript.messages.indices.contains(visibleRow.index) {
+            let message = transcript.messages[visibleRow.index]
+            row(for: message, stableId: visibleRow.stableId)
+                .background(rowFrameReporter(id: visibleRow.stableId))
+        } else {
+            EmptyView()
         }
     }
 

--- a/AlasTests/ACP/UI/ACPMessageListPaginationTests.swift
+++ b/AlasTests/ACP/UI/ACPMessageListPaginationTests.swift
@@ -1,4 +1,5 @@
 import Testing
+import Foundation
 import CoreGraphics
 @testable import Alas
 
@@ -204,6 +205,26 @@ struct ACPMessageListPaginationTests {
         #expect(!lookup.contains("message-39"))
         #expect(lookup.transcriptIndex(for: "message-41") == 41)
         #expect(lookup.firstStableId == "message-40")
+    }
+
+    @Test("visible rows contain only transcript indices and stable ids")
+    @MainActor
+    func visibleRowsContainOnlyIndicesAndStableIds() {
+        let messages: [ACPMessage] = [
+            .user(id: UUID(), messageId: "user-1", text: "old", attachments: []),
+            .plan(id: UUID(), [ACPMessage.PlanItem(content: "skip", status: "pending")]),
+            .agent(id: UUID(), messageId: "agent-1", StreamingText("new"))
+        ]
+
+        let rows = ACPMessageList.visibleRows(
+            messages: messages,
+            visibleHead: 1,
+            stableId: { $0.stableId }
+        )
+
+        #expect(rows == [
+            ACPMessageList.VisibleRow(index: 2, stableId: "acp-agent:agent-1")
+        ])
     }
 
     @Test("visible anchor memory accepts live anchors when the remembered id is stale")


### PR DESCRIPTION
## Summary

- replace ACP transcript visible row data with a lightweight index/stable-id descriptor
- fetch the full `ACPMessage` only inside row rendering, outside SwiftUI's `ForEach` identity path
- add focused coverage for the visible-row projection that skips plan rows while preserving transcript indices

## Root Cause

`ACPMessageList` fed `(index, stableId, message: ACPMessage)` tuples directly into `ForEach`. Even with `id: \.stableId`, SwiftUI still copied and destroyed the heavy enum payload while generating lazy-stack row identity, which showed up in samples under `ForEach.IDGenerator.makeID`.

## Validation

- `rtk xcodegen`
- `ALAS_FFF_TARGET_ARCH=arm64 rtk xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -only-testing:AlasTests/ACPMessageListPaginationTests -only-testing:AlasTests/ACPMessageStableIdTests test`
- `ALAS_FFF_TARGET_ARCH=arm64 rtk xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -quiet build`