### PR TITLE
fix(acp): stabilize transcript tail scrolling

### DIFF
--- a/Alas/Sources/ACP/Session/ACPTranscript.swift
+++ b/Alas/Sources/ACP/Session/ACPTranscript.swift
@@ -144,6 +144,7 @@ final class ACPTranscript: ObservableObject {
     /// `visibleHead` directly when advancing the window.
     func setVisibleHead(_ newHead: Int) {
         let clamped = max(0, min(newHead, messages.count))
+        guard clamped != visibleHead else { return }
         guard clamped > visibleHead else {
             visibleHead = clamped
             return

--- a/Alas/Sources/ACP/UI/ACPMessageList.swift
+++ b/Alas/Sources/ACP/UI/ACPMessageList.swift
@@ -339,6 +339,9 @@ struct ACPMessageList: View {
     }
 
     private func scheduleTailScroll(proxy: ScrollViewProxy, animated: Bool) {
+        guard Self.shouldScheduleTailScroll(hasPendingTailScroll: pendingTailScrollTask != nil) else {
+            return
+        }
         pendingTailScrollTask?.cancel()
         pendingTailScrollTask = Task { @MainActor in
             await Task.yield()
@@ -346,7 +349,10 @@ struct ACPMessageList: View {
                   ACPMessageList.shouldRunScheduledTailScroll(
                     followsTranscriptTail: session.followsTranscriptTail
                   )
-            else { return }
+            else {
+                pendingTailScrollTask = nil
+                return
+            }
             scrollToTail(proxy: proxy, animated: animated)
         }
     }
@@ -581,6 +587,10 @@ struct ACPMessageList: View {
 
     nonisolated static func shouldRunScheduledTailScroll(followsTranscriptTail: Bool) -> Bool {
         followsTranscriptTail
+    }
+
+    nonisolated static func shouldScheduleTailScroll(hasPendingTailScroll: Bool) -> Bool {
+        !hasPendingTailScroll
     }
 
     nonisolated static func shouldRestoreTailAfterViewportWidthChange(

--- a/AlasTests/ACP/Session/ACPTranscriptWindowTests.swift
+++ b/AlasTests/ACP/Session/ACPTranscriptWindowTests.swift
@@ -1,4 +1,5 @@
 import Foundation
+import Combine
 import Testing
 @testable import Alas
 
@@ -34,6 +35,25 @@ struct ACPTranscriptWindowTests {
         }
         t.resetWindowToTail()
         #expect(t.visibleHead == 0)
+    }
+
+    @Test("resetWindowToTail does not publish when head is already current")
+    func resetDoesNotPublishWhenUnchanged() {
+        let t = ACPTranscript()
+        for _ in 0..<50 {
+            t.messages.append(.systemNotice(id: UUID(), text: "x"))
+        }
+        t.resetWindowToTail()
+
+        var changeCount = 0
+        let cancellable = t.objectWillChange.sink {
+            changeCount += 1
+        }
+
+        t.resetWindowToTail()
+
+        #expect(changeCount == 0)
+        cancellable.cancel()
     }
 
     @Test("stepHeadBack decrements by tailWindow, clamped at zero")

--- a/AlasTests/ACP/UI/ACPMessageListPaginationTests.swift
+++ b/AlasTests/ACP/UI/ACPMessageListPaginationTests.swift
@@ -126,6 +126,12 @@ struct ACPMessageListPaginationTests {
         #expect(!ACPMessageList.shouldRunScheduledTailScroll(followsTranscriptTail: false))
     }
 
+    @Test("tail scroll scheduling coalesces pending work")
+    func tailScrollSchedulingCoalescesPendingWork() {
+        #expect(ACPMessageList.shouldScheduleTailScroll(hasPendingTailScroll: false))
+        #expect(!ACPMessageList.shouldScheduleTailScroll(hasPendingTailScroll: true))
+    }
+
     @Test("viewport width changes restore the tail only while following")
     func viewportWidthChangesRestoreTailOnlyWhileFollowing() {
         #expect(ACPMessageList.shouldRestoreTailAfterViewportWidthChange(


### PR DESCRIPTION
## Summary

Fixes a transient ACP transcript blanking risk during live streaming by reducing avoidable lazy-stack invalidation and preventing tail-scroll correction from being starved by rapid updates.

## Details

- Avoid republishing `visibleHead` when `resetWindowToTail()` computes the same head.
- Coalesce pending tail-scroll tasks so fast streaming updates do not repeatedly cancel the scroll-to-tail correction before it can run.
- Add focused regression coverage for no-op transcript window resets and tail-scroll scheduling coalescing.

## Validation

- `rtk git submodule update --init ThirdParty/zmx ThirdParty/fff`
- `ALAS_FFF_TARGET_ARCH=arm64 rtk xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -only-testing:AlasTests/ACPTranscriptWindowTests -only-testing:AlasTests/ACPMessageListPaginationTests test`
- `ALAS_FFF_TARGET_ARCH=arm64 rtk xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -quiet build`
- `rtk xcodegen`

A full local `xcodebuild ... test` was started before publishing but stayed silent for several minutes and was interrupted without failure output; CI should provide the broad suite signal.