### PR TITLE
fix(elicitation): Match elicitation text field styling

### DIFF
--- a/Alas/Sources/ACP/UI/ACPUserInputPrompt.swift
+++ b/Alas/Sources/ACP/UI/ACPUserInputPrompt.swift
@@ -124,18 +124,12 @@ struct ACPUserInputPrompt: View {
         case "string" where field.schema.format == "date" || field.schema.format == "date-time":
             dateField(field)
         case "string":
-            TextField(
-                field.label,
-                text: Binding(
-                    get: { formState.textValues[field.key] ?? "" },
-                    set: {
-                        formState.textValues[field.key] = $0
-                        formState.markTouched(field.key)
-                    }
-                )
-            )
-            .textFieldStyle(.roundedBorder)
-            .focused($focusedField, equals: field.key)
+            TextField(field.label, text: textBinding(for: field))
+                .textFieldStyle(.plain)
+                .font(.system(size: 12))
+                .foregroundColor(theme.color("fg"))
+                .alasFieldChrome(theme: theme)
+                .focused($focusedField, equals: field.key)
         case "number", "integer":
             numericField(field)
         case "boolean":
@@ -203,18 +197,12 @@ struct ACPUserInputPrompt: View {
 
     private func numericField(_ field: ACPUserInputField) -> some View {
         HStack(spacing: 6) {
-            TextField(
-                field.label,
-                text: Binding(
-                    get: { formState.textValues[field.key] ?? "" },
-                    set: {
-                        formState.textValues[field.key] = $0
-                        formState.markTouched(field.key)
-                    }
-                )
-            )
-            .textFieldStyle(.roundedBorder)
-            .focused($focusedField, equals: field.key)
+            TextField(field.label, text: textBinding(for: field))
+                .textFieldStyle(.plain)
+                .font(.system(size: 12))
+                .foregroundColor(theme.color("fg"))
+                .alasFieldChrome(theme: theme)
+                .focused($focusedField, equals: field.key)
             Button {
                 step(field, delta: -1)
             } label: {
@@ -228,6 +216,16 @@ struct ACPUserInputPrompt: View {
             }
             .help("Increase")
         }
+    }
+
+    private func textBinding(for field: ACPUserInputField) -> Binding<String> {
+        Binding(
+            get: { formState.textValues[field.key] ?? "" },
+            set: {
+                formState.textValues[field.key] = $0
+                formState.markTouched(field.key)
+            }
+        )
     }
 
     @ViewBuilder

--- a/Alas/Sources/UI/AlasField.swift
+++ b/Alas/Sources/UI/AlasField.swift
@@ -21,7 +21,7 @@ struct AlasField: View {
                 onSubmit: onSubmit,
                 inputFilter: inputFilter
             )
-            .fieldChrome(theme: theme)
+            .alasFieldChrome(theme: theme)
         } else {
             let field = TextField(placeholder, text: $text)
                 .textFieldStyle(.plain)
@@ -36,17 +36,17 @@ struct AlasField: View {
                         .accessibilityHidden(true)
                     field
                 }
-                .fieldChrome(theme: theme)
+                .alasFieldChrome(theme: theme)
             } else {
                 field
-                    .fieldChrome(theme: theme)
+                    .alasFieldChrome(theme: theme)
             }
         }
     }
 }
 
-private extension View {
-    func fieldChrome(theme: Theme) -> some View {
+extension View {
+    func alasFieldChrome(theme: Theme) -> some View {
         padding(.horizontal, 10)
             .frame(height: 28)
             .background(theme.color("bg-1"))


### PR DESCRIPTION
## Summary
- Reuse the app's shared dark text-field chrome for ACP elicitation string and numeric inputs.
- Remove the default rounded-border field style that rendered the free-text "Other" field with a warm system background.

## Validation
- `xcodegen`
- `ALAS_FFF_TARGET_ARCH=arm64 rtk xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -quiet build`
- `ALAS_FFF_TARGET_ARCH=arm64 rtk xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' test -only-testing:AlasTests/ACPUserInputFormStateTests`

## Notes
- Full local `xcodebuild test` was run and failed on unrelated existing/environment failures in ACP queue/recovery persistence tests plus SSH integration tests requiring `ALAS_SSH_INTEGRATION=1`.