### PR TITLE
fix(acp): repair blank rows in slash-command picker

### DIFF
--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -800,6 +800,7 @@
 		A8EE9207A828D4D1BAF1C1C1 /* ACPTranscriptLatestPlanTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C70536C65F2A78F4935DCAD /* ACPTranscriptLatestPlanTests.swift */; };
 		A962107126052DEF597CB7FA /* RemoteServerIntegrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A79A06E48E215BF7B9EC2408 /* RemoteServerIntegrationTests.swift */; };
 		A971C64CC3136E00C5FC158C /* DiffPaneView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DF32A1544E13321E9E223AFF /* DiffPaneView.swift */; };
+		A975EADB16D1050CA973B5B3 /* ACPSlashPickerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 39B7BC45B64591618784F650 /* ACPSlashPickerTests.swift */; };
 		A98F3436BE8AB680178B341C /* MarkdownViewMode.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC83C13F9F6391F9CE8BF2CA /* MarkdownViewMode.swift */; };
 		A9AD5B31C3A9FCBE76A15179 /* BlockedLanguageServerNudgeResolver.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5DD723B8C15EF2413C5D935D /* BlockedLanguageServerNudgeResolver.swift */; };
 		A9D0D8D94E1D46F35D17DDBA /* CodeEditorView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FC93F4FB957C2CCD4E1E2326 /* CodeEditorView.swift */; };
@@ -1526,6 +1527,7 @@
 		3979B98C0A060BB118239A5E /* ReviewRequestContextBuilderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReviewRequestContextBuilderTests.swift; sourceTree = "<group>"; };
 		3985F2F58DB6E3BBF3520EFD /* CodexACPInstaller.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CodexACPInstaller.swift; sourceTree = "<group>"; };
 		3986789560012DF861565F12 /* ChatPaneTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatPaneTests.swift; sourceTree = "<group>"; };
+		39B7BC45B64591618784F650 /* ACPSlashPickerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPSlashPickerTests.swift; sourceTree = "<group>"; };
 		39DFD138FE855D8CFC464847 /* SearchFooter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchFooter.swift; sourceTree = "<group>"; };
 		3A0FF718D68E15F539577F56 /* SearchResult.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchResult.swift; sourceTree = "<group>"; };
 		3A110966FCF7EA47C18BE71A /* ACPAgentProfilesTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPAgentProfilesTests.swift; sourceTree = "<group>"; };
@@ -3342,6 +3344,7 @@
 				E2D5632302DE981B0BD36273 /* ACPSelectChipMetricsTests.swift */,
 				98A7F35818C95A567DDA586A /* ACPSelectChipTests.swift */,
 				0AB6FA9F258818E8B464CB0A /* ACPSetupNudgeBannerModeTests.swift */,
+				39B7BC45B64591618784F650 /* ACPSlashPickerTests.swift */,
 				B3E9B2665E18F4C4BF3FB683 /* ACPThumbnailImageCacheTests.swift */,
 				B77D7A400059AFD189D1CA5A /* ACPToolCallPresentationTests.swift */,
 				79A6CF0F6BDA59AAE1354EE7 /* ACPUserInputFormStateTests.swift */,
@@ -5578,6 +5581,7 @@
 				A4476A509577896F9DADE5CB /* ACPSessionVisibleQueueTests.swift in Sources */,
 				AC2574A26E931F0881F560C6 /* ACPSetupCheckerTests.swift in Sources */,
 				07BB2B329992BA535053BB80 /* ACPSetupNudgeBannerModeTests.swift in Sources */,
+				A975EADB16D1050CA973B5B3 /* ACPSlashPickerTests.swift in Sources */,
 				E239749EA0CB37C2C12B3591 /* ACPStdioClientTests.swift in Sources */,
 				588A1EB3D20EB2419A5A03B4 /* ACPStdioQuestionDispatchTests.swift in Sources */,
 				929C2E12D6178FF3728365A2 /* ACPStdioTerminalDispatchTests.swift in Sources */,

--- a/Alas/Sources/ACP/UI/ACPSlashPicker.swift
+++ b/Alas/Sources/ACP/UI/ACPSlashPicker.swift
@@ -13,7 +13,14 @@ final class ACPSlashPickerModel: ObservableObject {
     let allSuggestions: [ACPPromptSuggestion]
 
     init(suggestions: [ACPPromptSuggestion]) {
-        self.allSuggestions = suggestions
+        // De-duplicate by `command` (case-sensitive) keeping the first
+        // occurrence in original order. Some agents emit the same slash
+        // command more than once (e.g. across re-sent
+        // `available_commands_update` payloads); duplicates would otherwise
+        // render as repeated rows and, with element-based ForEach identity,
+        // as blank phantom rows.
+        var seen = Set<String>()
+        self.allSuggestions = suggestions.filter { seen.insert($0.command).inserted }
     }
 
     /// Score each suggestion by how well it matches the (lowercased)
@@ -103,7 +110,16 @@ struct ACPSlashPickerView: View {
                             .frame(maxWidth: .infinity, alignment: .leading)
                             .padding(.horizontal, 10).padding(.vertical, 6)
                     } else {
-                        ForEach(Array(items.enumerated()), id: \.element) { idx, s in
+                        // Identity is positional (offset == idx), matching
+                        // the row's `.id(idx)` and the index-based
+                        // `selectedIndex` / `scrollTo`. Using `\.element` here
+                        // would collide when the agent emits duplicate
+                        // commands and would disagree with `.id(idx)` when
+                        // the filtered list reorders on every keystroke —
+                        // the LazyVStack then recycles cells by element id but
+                        // re-identifies the row by index, leaving blank
+                        // recycled rows interspersed with live ones.
+                        ForEach(Array(items.enumerated()), id: \.offset) { idx, s in
                             row(s, isSelected: idx == model.selectedIndex)
                                 .id(idx)
                                 .contentShape(Rectangle())

--- a/AlasTests/ACP/UI/ACPSlashPickerTests.swift
+++ b/AlasTests/ACP/UI/ACPSlashPickerTests.swift
@@ -1,0 +1,85 @@
+import Testing
+@testable import Alas
+
+@MainActor
+@Suite("ACP slash picker model")
+struct ACPSlashPickerTests {
+    @Test("empty query keeps the full (de-duplicated) list in order")
+    func emptyQueryKeepsAll() {
+        let model = ACPSlashPickerModel(suggestions: [
+            .init(command: "/clear", description: "Clear"),
+            .init(command: "/init", description: "Init"),
+            .init(command: "/review", description: "Review a PR", hint: "<pr>"),
+        ])
+        #expect(model.query.isEmpty)
+        #expect(model.filtered.map(\.command) == ["/clear", "/init", "/review"])
+    }
+
+    @Test("filters by prefix/contains/subsequence and ranks best match first")
+    func filteringRanks() {
+        let model = ACPSlashPickerModel(suggestions: [
+            .init(command: "/init", description: nil),
+            .init(command: "/clear", description: nil),
+            .init(command: "/review", description: nil),
+        ])
+        model.setQuery("i")
+        // "/init" is an exact match (minus slash) and should beat "/review"
+        // (subsequence) and outrank everything else.
+        #expect(model.filtered.first?.command == "/init")
+        // "/review" contains "i" as a subsequence and should still appear.
+        #expect(model.filtered.map(\.command).contains("/review"))
+        // "/clear" has no "i" at all and must be dropped.
+        #expect(!model.filtered.map(\.command).contains("/clear"))
+    }
+
+    @Test("setQuery resets the selection cursor to the top")
+    func setQueryResetsSelection() {
+        let model = ACPSlashPickerModel(suggestions: [
+            .init(command: "/a", description: nil),
+            .init(command: "/b", description: nil),
+        ])
+        model.moveDown()
+        #expect(model.selectedIndex == 1)
+        model.setQuery("a")
+        #expect(model.selectedIndex == 0)
+        #expect(model.selected()?.command == "/a")
+    }
+
+    @Test("de-duplicates commands emitted more than once by the agent")
+    func deduplicatesDuplicateCommands() {
+        let model = ACPSlashPickerModel(suggestions: [
+            .init(command: "/clear", description: "Clear context"),
+            .init(command: "/clear", description: "Clear context"),   // exact dup
+            .init(command: "/init", description: "Init", hint: "<lang>"),
+            .init(command: "/clear", description: "Different desc"),  // same command, kept once
+            .init(command: "/init", description: "Init", hint: "<lang>"), // dup of /init
+        ])
+        // First occurrence wins; later duplicates are dropped, order preserved.
+        #expect(model.filtered.map(\.command) == ["/clear", "/init"])
+        #expect(model.filtered[0].description == "Clear context")
+        #expect(model.filtered[1].hint == "<lang>")
+    }
+
+    @Test("arrow keys wrap within the filtered list bounds")
+    func arrowKeysClampAndWrap() {
+        let model = ACPSlashPickerModel(suggestions: [
+            .init(command: "/a", description: nil),
+            .init(command: "/b", description: nil),
+            .init(command: "/c", description: nil),
+        ])
+        // Up from index 0 wraps to the last row.
+        model.moveUp()
+        #expect(model.selectedIndex == 2)
+        #expect(model.selected()?.command == "/c")
+        model.moveDown()
+        #expect(model.selectedIndex == 0)
+
+        // With a filter that leaves one row, movement is a no-op at 0.
+        model.setQuery("b")
+        #expect(model.filtered.count == 1)
+        model.moveDown()
+        model.moveUp()
+        #expect(model.selectedIndex == 0)
+        #expect(model.selected()?.command == "/b")
+    }
+}


### PR DESCRIPTION
<!-- gg:managed:start -->
The slash-command autocomplete popover rendered blank rows
interspersed with live entries. ACPSlashPickerView diffed its
ForEach by element identity (id: \.element) while each row view
was re-identified by positional index (.id(idx)). On every keystroke
the filtered list is re-scored and reordered, so the LazyVStack
recycled cells by element id but re-identified the row by index,
leaving recycled cells blank. Duplicate commands from an agent
collapsed into the same ForEach id and produced blank phantom rows.

Use positional ForEach identity (id: \.offset) so row identity
matches .id(idx), selectedIndex, and scrollTo — eliminating the
blank recycled rows. De-duplicate allSuggestions by command (first
occurrence wins, order preserved) as a defensive guard against
agents re-sending the same slash command.

Add ACPSlashPickerTests covering empty-query passthrough, ranked
filtering, setQuery cursor reset, dedup, and arrow-key wrap/clamp.
<!-- gg:managed:end -->