### PR TITLE
feat(ssh): add remote helper rpc channel

### DIFF
--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -12,6 +12,7 @@
 		00ED86F7E72AFBF6C8DD69C7 /* GitInvocationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03A4B0CD519C39CCB197CBD4 /* GitInvocationTests.swift */; };
 		01568CB821D2E938C51BBCAB /* ACPHarnessBridgeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A5A3E6B2F9AC2CBB1CDA78E /* ACPHarnessBridgeTests.swift */; };
 		018F0BE1174B9020C52007BE /* ACPRemoteFileServerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2BDAB5BEDF7FE5EBFBFE9A2 /* ACPRemoteFileServerTests.swift */; };
+		019D3627B3CEB44C34CC34F9 /* RemoteHelperProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0B0D8590E0335CD31B758E0 /* RemoteHelperProtocol.swift */; };
 		01C919A6F3868980D51539DD /* ACPInitializeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9DF8B5E766D2B3649D2555ED /* ACPInitializeTests.swift */; };
 		01CBEF6793755D3D9B000BC1 /* CodeLanguageDetailViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E91A6AFCC9B3AEFB43D8946F /* CodeLanguageDetailViewTests.swift */; };
 		01D2A32A3366C5CF6A225004 /* GhosttyConfigBuilderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3BE23A4881B60D7F16A4ACA5 /* GhosttyConfigBuilderTests.swift */; };
@@ -287,6 +288,7 @@
 		3C5E243B78F3461F75AB02A8 /* CodeTextViewCompletionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 436E8992D7373486BA25D290 /* CodeTextViewCompletionTests.swift */; };
 		3C8FAA4464E4D928F1DC6C91 /* session-new-response-with-config-options.json in Resources */ = {isa = PBXBuildFile; fileRef = E8A63557B4F06AA00761B547 /* session-new-response-with-config-options.json */; };
 		3CD81DD1B1FF8C1EA849237C /* TerminalSession.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9C45A26ADB0D1CCFBB5BEAE8 /* TerminalSession.swift */; };
+		3CEE8409AAAAAE34D469B19D /* RemoteHelperClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = C42BD0252E4292E53150CB8C /* RemoteHelperClient.swift */; };
 		3CFC291E5868CCD147D573E7 /* ACPAdapterUpdateBannerDeciderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F9B399B5355B20890D8E42C /* ACPAdapterUpdateBannerDeciderTests.swift */; };
 		3D32D8FA2A63B3C2080B9E3A /* DiffReviewRail.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4BECCB29ED6324C55C541D54 /* DiffReviewRail.swift */; };
 		3D561C5EDA7AAB4831CA58CF /* RemoteProjectCollisionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 442D62D5E8B59845EB9494D3 /* RemoteProjectCollisionTests.swift */; };
@@ -502,6 +504,7 @@
 		6A5B87FF631136E5246D0F38 /* AgentLauncherModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A43A7D90E591CFD18088C70 /* AgentLauncherModel.swift */; };
 		6A5D19016FE0100CD54D24B2 /* MarkdownImageLoaderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0D0ED01C390D1F729993B13 /* MarkdownImageLoaderTests.swift */; };
 		6A639AFB741004AA32C9D81A /* TabActivityPulseTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7DD2CA21EC45168D6E43564 /* TabActivityPulseTests.swift */; };
+		6A6FC93066027CBC0406C41D /* RemoteHelperClientTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9D1D9C02088B9B4C15D88D57 /* RemoteHelperClientTests.swift */; };
 		6AA812880B9E28C4AE9A6BFC /* GitHubCLIProviderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8C28D64372B5B4C734A92533 /* GitHubCLIProviderTests.swift */; };
 		6AB631ACAD28A187F15282AB /* FileSnapshotTabView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D28AEE8E4821977FDAF13960 /* FileSnapshotTabView.swift */; };
 		6AD85D472EF03EAE992D65D0 /* session-new-response.json in Resources */ = {isa = PBXBuildFile; fileRef = E7C070765F0474DF1C4ACEF0 /* session-new-response.json */; };
@@ -1972,6 +1975,7 @@
 		9C45A26ADB0D1CCFBB5BEAE8 /* TerminalSession.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TerminalSession.swift; sourceTree = "<group>"; };
 		9CA420C011D4235E47A3FB1B /* RepoSelectorRecents.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RepoSelectorRecents.swift; sourceTree = "<group>"; };
 		9CAED428443C9A7FE55E9A31 /* ReviewTabViewTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReviewTabViewTests.swift; sourceTree = "<group>"; };
+		9D1D9C02088B9B4C15D88D57 /* RemoteHelperClientTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteHelperClientTests.swift; sourceTree = "<group>"; };
 		9D209865BE187943BF14B830 /* AgentRunnerInvocationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentRunnerInvocationTests.swift; sourceTree = "<group>"; };
 		9D32294F9B916DFAFF5E9A6F /* WorkingTreeChangeGroup.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkingTreeChangeGroup.swift; sourceTree = "<group>"; };
 		9D3C76F2F0F6BCE4023A9D7F /* StartupScriptResolverTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StartupScriptResolverTests.swift; sourceTree = "<group>"; };
@@ -2046,6 +2050,7 @@
 		AF522B02666DB6AC4C82339E /* ACPContextRing.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPContextRing.swift; sourceTree = "<group>"; };
 		AFDDDF6CCDD6CE4A78AEF8F2 /* ProjectMCPServerManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProjectMCPServerManager.swift; sourceTree = "<group>"; };
 		B0886F9B3096AC1264E3D337 /* ReviewFeedbackBundle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReviewFeedbackBundle.swift; sourceTree = "<group>"; };
+		B0B0D8590E0335CD31B758E0 /* RemoteHelperProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteHelperProtocol.swift; sourceTree = "<group>"; };
 		B0D0ED01C390D1F729993B13 /* MarkdownImageLoaderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MarkdownImageLoaderTests.swift; sourceTree = "<group>"; };
 		B0D2C54087C4501C3E7793FE /* ChatPane.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatPane.swift; sourceTree = "<group>"; };
 		B0F47561DB37D2ED72B6BE25 /* ReviewLoopDrawerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReviewLoopDrawerTests.swift; sourceTree = "<group>"; };
@@ -2143,6 +2148,7 @@
 		C371360F83FE318A5B8AEDBF /* GitLabCLIProviderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GitLabCLIProviderTests.swift; sourceTree = "<group>"; };
 		C3B53E3E92FA696866F44FDD /* ACPLaunchSpecTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPLaunchSpecTests.swift; sourceTree = "<group>"; };
 		C3BC736DAAD590624B840923 /* ACPSystemNoticeView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPSystemNoticeView.swift; sourceTree = "<group>"; };
+		C42BD0252E4292E53150CB8C /* RemoteHelperClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteHelperClient.swift; sourceTree = "<group>"; };
 		C432B6C03738D6ACB4293471 /* ReviewDraftSummaryRail.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReviewDraftSummaryRail.swift; sourceTree = "<group>"; };
 		C47AF847BD698EAB373D128B /* ZmxClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ZmxClient.swift; sourceTree = "<group>"; };
 		C48DB0098D71F26ABF594615 /* permission-request.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "permission-request.json"; sourceTree = "<group>"; };
@@ -3620,8 +3626,10 @@
 				0046CA3B9FF996E55A85D853 /* RemoteFileAccess.swift */,
 				9B44E54236211F972F3D1C24 /* RemoteFileOps.swift */,
 				FBB8BF6C61840B9F972ABACC /* RemoteFileStats.swift */,
+				C42BD0252E4292E53150CB8C /* RemoteHelperClient.swift */,
 				C9042DA34C7025958BCFEE08 /* RemoteHelperHandshake.swift */,
 				0EE8745F3A4C6F0645D1D44A /* RemoteHelperInstaller.swift */,
+				B0B0D8590E0335CD31B758E0 /* RemoteHelperProtocol.swift */,
 				10B3615A1591964AB1C9E524 /* RemoteHostCapabilities.swift */,
 				8DF79BBCD948528D655A9A81 /* RemoteHostRegistry.swift */,
 				416C797DBD3F9F4901817769 /* RemoteHostStatusStore.swift */,
@@ -4114,6 +4122,7 @@
 				BDB2D3836ADF55732C5A416D /* RemoteFileOpsTests.swift */,
 				D7331F53100D12A0DDFD6B1D /* RemoteFileSearchGateTests.swift */,
 				E3F09E1DA9C67475445F4B63 /* RemoteFileStatsTests.swift */,
+				9D1D9C02088B9B4C15D88D57 /* RemoteHelperClientTests.swift */,
 				7DFB9832AA15DF6888553C7E /* RemoteHelperInstallerTests.swift */,
 				843E7D6E8972C01B3DC924F2 /* RemoteHostCapabilitiesTests.swift */,
 				1854EA4072F4F45DA70854D0 /* RemoteHostRegistryTests.swift */,
@@ -5311,8 +5320,10 @@
 				DE207C4CFA1A45866FCB4E22 /* RemoteFileOps.swift in Sources */,
 				30582A6DE1CFD0B9D5CB2E14 /* RemoteFileStats.swift in Sources */,
 				C9C01E8A89C6767524FAC63B /* RemoteHTTPResponder.swift in Sources */,
+				3CEE8409AAAAAE34D469B19D /* RemoteHelperClient.swift in Sources */,
 				B0C493B1DE30CD22F1BAD24C /* RemoteHelperHandshake.swift in Sources */,
 				40C56ABCF57F6F3F7D40E020 /* RemoteHelperInstaller.swift in Sources */,
+				019D3627B3CEB44C34CC34F9 /* RemoteHelperProtocol.swift in Sources */,
 				330D198F38767801994BF84C /* RemoteHostCapabilities.swift in Sources */,
 				F47287FCE8C870F02F2A55E0 /* RemoteHostRegistry.swift in Sources */,
 				52AB869F9071103FD1649552 /* RemoteHostStatusStore.swift in Sources */,
@@ -5873,6 +5884,7 @@
 				E7BB827F6AD4758BB2FA39BB /* RemoteFileOpsTests.swift in Sources */,
 				FB000FBA6BA9ED49F65681AC /* RemoteFileSearchGateTests.swift in Sources */,
 				61E93449DD65CFD2643A9AC6 /* RemoteFileStatsTests.swift in Sources */,
+				6A6FC93066027CBC0406C41D /* RemoteHelperClientTests.swift in Sources */,
 				D8254D678C89FC54678A1A88 /* RemoteHelperInstallerTests.swift in Sources */,
 				395A56C7C48EDDDE1F39F335 /* RemoteHostCapabilitiesTests.swift in Sources */,
 				A45A26B8B43E49BC8F952CD6 /* RemoteHostRegistryTests.swift in Sources */,

--- a/Alas/Sources/SSH/RemoteHelperClient.swift
+++ b/Alas/Sources/SSH/RemoteHelperClient.swift
@@ -1,0 +1,504 @@
+import Foundation
+
+struct RemoteHelperInvocation: Equatable {
+    let executable: String
+    let args: [String]
+}
+
+private struct ActiveRemoteHelperSubscription {
+    let params: RemoteHelperWatchSubscribeParams
+    var helperSubscriptionId: String
+    var helperGeneration: Int
+}
+
+enum RemoteHelperClientError: Error, Equatable {
+    case notRunning
+    case unavailable(String)
+    case jsonrpc(JSONRPCError)
+    case decoding(String)
+
+    var shouldFallbackToRemoteExec: Bool {
+        switch self {
+        case .notRunning, .unavailable:
+            return true
+        case .jsonrpc, .decoding:
+            return false
+        }
+    }
+}
+
+actor RemoteHelperClient {
+    typealias TransportFactory = @Sendable () -> JSONRPCStdioTransporting
+
+    static let defaultIdleShutdownNanoseconds: UInt64 = 600_000_000_000
+
+    nonisolated let host: String
+    nonisolated let watchEvents: AsyncStream<RemoteHelperWatchEvent>
+
+    private let transportFactory: TransportFactory
+    private let idleShutdownNanoseconds: UInt64
+    private let watchEventsCont: AsyncStream<RemoteHelperWatchEvent>.Continuation
+    private var transport: JSONRPCStdioTransporting?
+    private var dispatchTask: Task<Void, Never>?
+    private var idleShutdownTask: Task<Void, Never>?
+    private var generation = 0
+    private var nextId = 0
+    private var nextClientSubscriptionId = 0
+    private var pending: [JSONRPCID: CheckedContinuation<Data, Error>] = [:]
+    private var activeSubscriptions: [String: ActiveRemoteHelperSubscription] = [:]
+    private var subscriptionReplayTask: Task<Void, Error>?
+    private var subscriptionsNeedReplay = false
+    private var lastExitStatus: Int32?
+
+    init(
+        host: String,
+        idleShutdownNanoseconds: UInt64 = RemoteHelperClient.defaultIdleShutdownNanoseconds,
+        transportFactory: TransportFactory? = nil
+    ) {
+        self.host = host
+        self.idleShutdownNanoseconds = idleShutdownNanoseconds
+        self.transportFactory = transportFactory ?? {
+            Self.makeTransport(host: host)
+        }
+        var eventsCont: AsyncStream<RemoteHelperWatchEvent>.Continuation!
+        self.watchEvents = AsyncStream { eventsCont = $0 }
+        self.watchEventsCont = eventsCont
+    }
+
+    static func invocation(host: String) -> RemoteHelperInvocation {
+        let ssh = SSHCommand(host: host, mode: .batch)
+        let script = SSHCommand.remoteScript(command: "exec \"$HOME/.alas/bin/alas-helper\" serve")
+        return RemoteHelperInvocation(
+            executable: SSHCommand.executable,
+            args: ssh.argv(remoteScript: script)
+        )
+    }
+
+    private static func makeTransport(host: String) -> JSONRPCStdioTransporting {
+        let invocation = invocation(host: host)
+        return JSONRPCStdioTransport(
+            executable: URL(fileURLWithPath: invocation.executable),
+            arguments: invocation.args,
+            environment: nil,
+            framing: .newline
+        )
+    }
+
+    func hello(_ params: RemoteHelperHelloParams = .init()) async throws -> RemoteHelperHelloResult {
+        try await request(method: "hello", params: params)
+    }
+
+    func ping() async throws -> RemoteHelperPingResult {
+        try await request(method: "ping", params: RemoteHelperNoParams())
+    }
+
+    func subscribe(
+        root: String,
+        kinds: [RemoteHelperWatchKind]
+    ) async throws -> RemoteHelperWatchSubscribeResult {
+        let helperResult: RemoteHelperWatchSubscribeResult = try await request(
+            method: "watch/subscribe",
+            params: RemoteHelperWatchSubscribeParams(root: root, kinds: kinds)
+        )
+        let params = RemoteHelperWatchSubscribeParams(root: root, kinds: kinds)
+        let clientSubscriptionId = makeClientSubscriptionId(avoiding: helperResult.subscriptionId)
+        activeSubscriptions[clientSubscriptionId] = ActiveRemoteHelperSubscription(
+            params: params,
+            helperSubscriptionId: helperResult.subscriptionId,
+            helperGeneration: generation
+        )
+        return RemoteHelperWatchSubscribeResult(subscriptionId: clientSubscriptionId)
+    }
+
+    func unsubscribe(subscriptionId: String) async throws -> RemoteHelperWatchUnsubscribeResult {
+        let helperSubscriptionId = activeSubscriptions[subscriptionId]?.helperSubscriptionId ?? subscriptionId
+        guard transport != nil else {
+            activeSubscriptions.removeValue(forKey: subscriptionId)
+            scheduleIdleShutdownIfPossible()
+            return RemoteHelperWatchUnsubscribeResult(ok: true)
+        }
+
+        let result: RemoteHelperWatchUnsubscribeResult
+        do {
+            result = try await request(
+                method: "watch/unsubscribe",
+                params: RemoteHelperWatchUnsubscribeParams(subscriptionId: helperSubscriptionId),
+                replaySubscriptionsOnStart: false
+            )
+        } catch RemoteHelperClientError.notRunning {
+            activeSubscriptions.removeValue(forKey: subscriptionId)
+            scheduleIdleShutdownIfPossible()
+            return RemoteHelperWatchUnsubscribeResult(ok: true)
+        }
+        activeSubscriptions.removeValue(forKey: subscriptionId)
+        scheduleIdleShutdownIfPossible()
+        return result
+    }
+
+    func read(path: String, offset: UInt64? = nil) async throws -> RemoteHelperFSReadResult {
+        try await request(method: "fs/read", params: RemoteHelperFSReadParams(path: path, offset: offset))
+    }
+
+    func write(path: String, content: String, expectedMtime: Double? = nil) async throws -> RemoteHelperFSWriteResult {
+        try await request(
+            method: "fs/write",
+            params: RemoteHelperFSWriteParams(path: path, content: content, expectedMtime: expectedMtime)
+        )
+    }
+
+    func stat(paths: [String]) async throws -> RemoteHelperFSStatResult {
+        try await request(method: "fs/stat", params: RemoteHelperFSStatParams(paths: paths))
+    }
+
+    func shutdown() {
+        idleShutdownTask?.cancel()
+        idleShutdownTask = nil
+        subscriptionReplayTask?.cancel()
+        subscriptionReplayTask = nil
+        subscriptionsNeedReplay = false
+        activeSubscriptions.removeAll()
+        drainPending(with: RemoteHelperClientError.notRunning)
+        dispatchTask?.cancel()
+        dispatchTask = nil
+        transport?.terminate()
+        transport = nil
+    }
+
+    func lastObservedExitStatus() -> Int32? {
+        lastExitStatus
+    }
+
+    private func request<Params: Encodable, Result: Decodable>(
+        method: String,
+        params: Params,
+        replaySubscriptionsOnStart: Bool = true
+    ) async throws -> Result {
+        let didStart = try ensureStarted()
+        if replaySubscriptionsOnStart {
+            if didStart, !activeSubscriptions.isEmpty {
+                subscriptionsNeedReplay = true
+            }
+            if subscriptionsNeedReplay {
+                startSubscriptionReplayIfNeeded()
+            }
+            if let subscriptionReplayTask {
+                try await subscriptionReplayTask.value
+            }
+        }
+        idleShutdownTask?.cancel()
+        idleShutdownTask = nil
+        defer {
+            scheduleIdleShutdownIfPossible()
+        }
+
+        nextId += 1
+        let id = JSONRPCID.number(nextId)
+        let body = try Self.encodeRequest(method: method, params: params, id: id)
+
+        let data: Data
+        do {
+            data = try await withCheckedThrowingContinuation { (cont: CheckedContinuation<Data, Error>) in
+                pending[id] = cont
+                do {
+                    guard let transport else {
+                        pending.removeValue(forKey: id)
+                        cont.resume(throwing: RemoteHelperClientError.notRunning)
+                        return
+                    }
+                    try transport.send(body)
+                } catch {
+                    let stillPending = pending.removeValue(forKey: id) != nil
+                    if stillPending { cont.resume(throwing: error) }
+                }
+            }
+        } catch {
+            if Self.responseErrorIndicatesLiveHost(error) {
+                await reportHostSuccess()
+            }
+            throw error
+        }
+        await reportHostSuccess()
+        do {
+            return try JSONDecoder().decode(Result.self, from: data)
+        } catch {
+            throw RemoteHelperClientError.decoding(error.localizedDescription)
+        }
+    }
+
+    private func ensureStarted() throws -> Bool {
+        if transport != nil {
+            return false
+        }
+        let nextTransport = transportFactory()
+        try nextTransport.start()
+        generation += 1
+        let transportGeneration = generation
+        transport = nextTransport
+        lastExitStatus = nil
+        dispatchTask = Task { [weak self] in
+            for await event in nextTransport.incoming {
+                await self?.handle(event, generation: transportGeneration)
+            }
+        }
+        return true
+    }
+
+    private func startSubscriptionReplayIfNeeded() {
+        guard subscriptionReplayTask == nil, !activeSubscriptions.isEmpty else { return }
+        subscriptionReplayTask = Task { [weak self] in
+            guard let self else { return }
+            try await self.replayActiveSubscriptions()
+        }
+    }
+
+    private func makeClientSubscriptionId(avoiding helperSubscriptionId: String) -> String {
+        while true {
+            nextClientSubscriptionId += 1
+            let candidate = "client-\(nextClientSubscriptionId)"
+            guard candidate != helperSubscriptionId,
+                  activeSubscriptions[candidate] == nil,
+                  !activeSubscriptions.values.contains(where: { $0.helperSubscriptionId == candidate })
+            else {
+                continue
+            }
+            return candidate
+        }
+    }
+
+    private func replayActiveSubscriptions() async throws {
+        defer {
+            subscriptionReplayTask = nil
+        }
+        var restartCount = 0
+        while true {
+            _ = try ensureStarted()
+            let replayGeneration = generation
+            let subscriptions = activeSubscriptions
+            guard !subscriptions.isEmpty else {
+                subscriptionsNeedReplay = false
+                return
+            }
+
+            var shouldRestartReplay = false
+            for (clientSubscriptionId, subscription) in subscriptions {
+                guard subscription.helperGeneration != replayGeneration else {
+                    continue
+                }
+                guard transport != nil, generation == replayGeneration else {
+                    shouldRestartReplay = true
+                    break
+                }
+
+                let result: RemoteHelperWatchSubscribeResult
+                do {
+                    result = try await request(
+                        method: "watch/subscribe",
+                        params: subscription.params,
+                        replaySubscriptionsOnStart: false
+                    )
+                } catch RemoteHelperClientError.notRunning where transport == nil || generation != replayGeneration {
+                    shouldRestartReplay = true
+                    break
+                }
+
+                guard transport != nil, generation == replayGeneration else {
+                    shouldRestartReplay = true
+                    break
+                }
+                guard activeSubscriptions[clientSubscriptionId]?.params == subscription.params else {
+                    let _: RemoteHelperWatchUnsubscribeResult? = try? await request(
+                        method: "watch/unsubscribe",
+                        params: RemoteHelperWatchUnsubscribeParams(subscriptionId: result.subscriptionId),
+                        replaySubscriptionsOnStart: false
+                    )
+                    continue
+                }
+                activeSubscriptions[clientSubscriptionId] = ActiveRemoteHelperSubscription(
+                    params: subscription.params,
+                    helperSubscriptionId: result.subscriptionId,
+                    helperGeneration: replayGeneration
+                )
+            }
+
+            guard shouldRestartReplay else {
+                subscriptionsNeedReplay = false
+                return
+            }
+            restartCount += 1
+            guard restartCount <= subscriptions.count + 1 else {
+                throw RemoteHelperClientError.notRunning
+            }
+        }
+    }
+
+    private func handle(_ event: JSONRPCStdioTransport.Incoming, generation eventGeneration: Int) {
+        guard eventGeneration == generation else { return }
+        switch event {
+        case .frame(let data):
+            handleFrame(data)
+        case .stderr:
+            break
+        case .exited(let status):
+            handleExit(status)
+        }
+    }
+
+    private struct AnyEnvelopeHead: Decodable {
+        let id: JSONRPCID?
+        let method: String?
+    }
+
+    private func handleFrame(_ data: Data) {
+        guard let head = try? JSONDecoder().decode(AnyEnvelopeHead.self, from: data) else {
+            return
+        }
+
+        if let id = head.id, head.method == nil {
+            let cont = pending.removeValue(forKey: id)
+            guard let cont else { return }
+            if let env = try? JSONDecoder().decode(RemoteHelperJSONRPCErrorEnvelope.self, from: data),
+               let error = env.error {
+                cont.resume(throwing: RemoteHelperClientError.jsonrpc(error))
+                return
+            }
+            guard let result = Self.extractResultBytes(from: data) else {
+                cont.resume(throwing: RemoteHelperClientError.decoding("no result/error in response"))
+                return
+            }
+            cont.resume(returning: result)
+            return
+        }
+
+        guard head.method == "watch/event",
+              let env = try? JSONDecoder().decode(JSONRPCEnvelope<RemoteHelperWatchEvent>.self, from: data),
+              let event = env.params
+        else {
+            return
+        }
+        watchEventsCont.yield(event)
+    }
+
+    private func handleExit(_ status: Int32) {
+        lastExitStatus = status
+        transport = nil
+        dispatchTask = nil
+        subscriptionsNeedReplay = !activeSubscriptions.isEmpty
+        idleShutdownTask?.cancel()
+        idleShutdownTask = nil
+        drainPending(with: RemoteHelperClientError.notRunning)
+        if RemoteExec.isConnectionFailure(exitCode: status) {
+            Task { @MainActor [host] in
+                RemoteHostStatusStore.shared.reportConnectionFailure(host: host)
+            }
+        }
+    }
+
+    private func drainPending(with error: Error) {
+        let snapshot = pending
+        pending.removeAll()
+        for (_, cont) in snapshot {
+            cont.resume(throwing: error)
+        }
+    }
+
+    private func scheduleIdleShutdownIfPossible() {
+        guard idleShutdownNanoseconds > 0, pending.isEmpty, activeSubscriptions.isEmpty, transport != nil else { return }
+        idleShutdownTask?.cancel()
+        let delay = idleShutdownNanoseconds
+        idleShutdownTask = Task { [weak self] in
+            try? await Task.sleep(nanoseconds: delay)
+            await self?.shutdownIfIdle()
+        }
+    }
+
+    private func shutdownIfIdle() {
+        guard pending.isEmpty, activeSubscriptions.isEmpty else { return }
+        shutdown()
+    }
+
+    @MainActor
+    private func reportHostSuccess() {
+        RemoteHostStatusStore.shared.reportSuccess(host: host)
+    }
+
+    private static func encodeRequest<Params: Encodable>(
+        method: String,
+        params: Params,
+        id: JSONRPCID
+    ) throws -> Data {
+        var dict: [String: Any] = ["jsonrpc": "2.0", "id": id.asJSON, "method": method]
+        let paramsData = try JSONEncoder().encode(RemoteHelperAnyEncodableBox(params))
+        dict["params"] = try JSONSerialization.jsonObject(with: paramsData)
+        return try JSONSerialization.data(withJSONObject: dict)
+    }
+
+    private static func responseErrorIndicatesLiveHost(_ error: Error) -> Bool {
+        guard let error = error as? RemoteHelperClientError else { return false }
+        switch error {
+        case .jsonrpc, .decoding:
+            return true
+        case .notRunning, .unavailable:
+            return false
+        }
+    }
+
+    private static func extractResultBytes(from envelope: Data) -> Data? {
+        guard let obj = try? JSONSerialization.jsonObject(with: envelope) as? [String: Any],
+              let result = obj["result"]
+        else { return nil }
+        return try? JSONSerialization.data(withJSONObject: result, options: [.fragmentsAllowed])
+    }
+}
+
+actor RemoteHelperClientPool {
+    static let shared = RemoteHelperClientPool()
+
+    private var clients: [String: RemoteHelperClient] = [:]
+
+    func client(for host: String) -> RemoteHelperClient {
+        if let client = clients[host] {
+            return client
+        }
+        let client = RemoteHelperClient(host: host)
+        clients[host] = client
+        return client
+    }
+
+    func shutdown(host: String) {
+        guard let client = clients.removeValue(forKey: host) else { return }
+        Task {
+            await client.shutdown()
+        }
+    }
+
+    func shutdownAll() {
+        let snapshot = clients
+        clients.removeAll()
+        for (_, client) in snapshot {
+            Task {
+                await client.shutdown()
+            }
+        }
+    }
+}
+
+private struct RemoteHelperNoParams: Encodable {}
+
+private struct RemoteHelperJSONRPCErrorEnvelope: Decodable {
+    let error: JSONRPCError?
+}
+
+private struct RemoteHelperAnyEncodableBox: Encodable {
+    let value: Encodable
+    init(_ value: Encodable) { self.value = value }
+    func encode(to encoder: Encoder) throws { try value.encode(to: encoder) }
+}
+
+private extension JSONRPCID {
+    var asJSON: Any {
+        switch self {
+        case .number(let value): return value
+        case .string(let value): return value
+        }
+    }
+}

--- a/Alas/Sources/SSH/RemoteHelperProtocol.swift
+++ b/Alas/Sources/SSH/RemoteHelperProtocol.swift
@@ -1,0 +1,115 @@
+import Foundation
+
+enum RemoteHelperProtocolVersion {
+    static let current = 1
+}
+
+struct RemoteHelperHelloParams: Codable, Equatable, Sendable {
+    let clientName: String
+    let protocolVersion: Int
+
+    init(clientName: String = "Alas", protocolVersion: Int = RemoteHelperProtocolVersion.current) {
+        self.clientName = clientName
+        self.protocolVersion = protocolVersion
+    }
+}
+
+struct RemoteHelperHelloResult: Codable, Equatable, Sendable {
+    let name: String
+    let protocolVersion: Int
+    let binaryVersion: String
+    let capabilities: RemoteHelperCapabilities
+}
+
+struct RemoteHelperCapabilities: Codable, Equatable, Sendable {
+    let watchKinds: [RemoteHelperWatchKind]
+    let fs: RemoteHelperFSCapabilities
+    let ping: Bool
+}
+
+struct RemoteHelperFSCapabilities: Codable, Equatable, Sendable {
+    let read: Bool
+    let write: Bool
+    let stat: Bool
+}
+
+enum RemoteHelperWatchKind: String, Codable, Equatable, Sendable {
+    case files
+    case git
+}
+
+struct RemoteHelperPingResult: Codable, Equatable, Sendable {
+    let ok: Bool
+}
+
+struct RemoteHelperWatchSubscribeParams: Codable, Equatable, Sendable {
+    let root: String
+    let kinds: [RemoteHelperWatchKind]
+}
+
+struct RemoteHelperWatchSubscribeResult: Codable, Equatable, Sendable {
+    let subscriptionId: String
+}
+
+struct RemoteHelperWatchUnsubscribeParams: Codable, Equatable, Sendable {
+    let subscriptionId: String
+}
+
+struct RemoteHelperWatchUnsubscribeResult: Codable, Equatable, Sendable {
+    let ok: Bool
+}
+
+struct RemoteHelperWatchEvent: Codable, Equatable, Sendable {
+    let subscriptionId: String
+    let root: String
+    let kind: RemoteHelperWatchKind
+    let paths: [String]
+}
+
+struct RemoteHelperFSReadParams: Codable, Equatable, Sendable {
+    let path: String
+    let offset: UInt64?
+
+    init(path: String, offset: UInt64? = nil) {
+        self.path = path
+        self.offset = offset
+    }
+}
+
+struct RemoteHelperFSReadResult: Codable, Equatable, Sendable {
+    let content: String
+    let mtime: Double?
+}
+
+struct RemoteHelperFSWriteParams: Codable, Equatable, Sendable {
+    let path: String
+    let content: String
+    let expectedMtime: Double?
+
+    init(path: String, content: String, expectedMtime: Double? = nil) {
+        self.path = path
+        self.content = content
+        self.expectedMtime = expectedMtime
+    }
+}
+
+struct RemoteHelperFSWriteResult: Codable, Equatable, Sendable {
+    let mtime: Double?
+}
+
+struct RemoteHelperFSStatParams: Codable, Equatable, Sendable {
+    let paths: [String]
+}
+
+struct RemoteHelperFSStatResult: Codable, Equatable, Sendable {
+    let entries: [RemoteHelperFSStatEntry]
+}
+
+struct RemoteHelperFSStatEntry: Codable, Equatable, Sendable {
+    let path: String
+    let exists: Bool
+    let isDirectory: Bool
+    let isFile: Bool
+    let size: UInt64?
+    let mtime: Double?
+}

--- a/AlasHelper/Cargo.lock
+++ b/AlasHelper/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "alas-helper"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "serde",
  "serde_json",

--- a/AlasHelper/Cargo.toml
+++ b/AlasHelper/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "alas-helper"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2024"
 publish = false
 

--- a/AlasHelper/manifest.json
+++ b/AlasHelper/manifest.json
@@ -1,1 +1,1 @@
-{"name":"alas-helper","protocolVersion":1,"binaryVersion":"0.1.0"}
+{"name":"alas-helper","protocolVersion":1,"binaryVersion":"0.2.0"}

--- a/AlasHelper/src/main.rs
+++ b/AlasHelper/src/main.rs
@@ -1,4 +1,9 @@
 use serde::{Deserialize, Serialize};
+use serde_json::{Value, json};
+use std::collections::HashMap;
+use std::io::{self, BufRead, Write};
+use std::path::{Path, PathBuf};
+use std::time::{SystemTime, UNIX_EPOCH};
 
 const PROTOCOL_VERSION: u32 = 1;
 
@@ -10,6 +15,57 @@ struct Handshake<'a> {
     binary_version: &'a str,
 }
 
+#[derive(Debug, Deserialize)]
+struct JsonRpcRequest {
+    id: Option<Value>,
+    method: Option<String>,
+    params: Option<Value>,
+}
+
+#[derive(Debug)]
+struct HelperError {
+    code: i64,
+    message: String,
+}
+
+#[derive(Debug, Default)]
+struct HelperState {
+    next_subscription_id: u64,
+    subscriptions: HashMap<String, PathBuf>,
+}
+
+#[derive(Debug, Deserialize)]
+struct WatchSubscribeParams {
+    root: String,
+    #[allow(dead_code)]
+    kinds: Vec<String>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct WatchUnsubscribeParams {
+    subscription_id: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct FsReadParams {
+    path: String,
+    offset: Option<u64>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct FsWriteParams {
+    path: String,
+    content: String,
+    expected_mtime: Option<f64>,
+}
+
+#[derive(Debug, Deserialize)]
+struct FsStatParams {
+    paths: Vec<String>,
+}
+
 fn handshake() -> Handshake<'static> {
     Handshake {
         name: env!("CARGO_PKG_NAME"),
@@ -18,16 +74,449 @@ fn handshake() -> Handshake<'static> {
     }
 }
 
+fn capabilities() -> Value {
+    json!({
+        "watchKinds": [],
+        "fs": {
+            "read": true,
+            "write": true,
+            "stat": true
+        },
+        "ping": true
+    })
+}
+
 fn main() {
     let command = std::env::args().nth(1);
-    if command.as_deref().is_some_and(|value| value != "version") {
-        eprintln!("usage: alas-helper [version]");
-        std::process::exit(2);
+    match command.as_deref() {
+        None | Some("version") => {
+            println!(
+                "{}",
+                serde_json::to_string(&handshake()).expect("handshake serialization must succeed")
+            );
+        }
+        Some("serve") => {
+            if let Err(error) = serve() {
+                eprintln!("alas-helper: {error}");
+                std::process::exit(1);
+            }
+        }
+        Some(_) => {
+            eprintln!("usage: alas-helper [version|serve]");
+            std::process::exit(2);
+        }
     }
-    println!(
-        "{}",
-        serde_json::to_string(&handshake()).expect("handshake serialization must succeed")
-    );
+}
+
+fn serve() -> io::Result<()> {
+    let stdin = io::stdin();
+    let mut stdout = io::stdout().lock();
+    let mut state = HelperState::default();
+
+    for line in stdin.lock().lines() {
+        let line = line?;
+        if line.trim().is_empty() {
+            continue;
+        }
+        let response = handle_line(&mut state, &line);
+        if let Some(response) = response {
+            writeln!(stdout, "{response}")?;
+            stdout.flush()?;
+        }
+    }
+    Ok(())
+}
+
+fn handle_line(state: &mut HelperState, line: &str) -> Option<String> {
+    let request: Result<JsonRpcRequest, _> = serde_json::from_str(line);
+    let request = match request {
+        Ok(request) => request,
+        Err(error) => {
+            return Some(error_response(
+                Value::Null,
+                -32700,
+                format!("parse error: {error}"),
+            ));
+        }
+    };
+
+    let id = request.id.clone();
+    let Some(id) = id else {
+        return None;
+    };
+    let Some(method) = request.method.as_deref() else {
+        return Some(error_response(id, -32600, "missing method"));
+    };
+
+    match handle_request(state, method, request.params) {
+        Ok(result) => Some(success_response(id, result)),
+        Err(error) => Some(error_response(id, error.code, error.message)),
+    }
+}
+
+fn handle_request(
+    state: &mut HelperState,
+    method: &str,
+    params: Option<Value>,
+) -> Result<Value, HelperError> {
+    match method {
+        "hello" => Ok(json!({
+            "name": handshake().name,
+            "protocolVersion": handshake().protocol_version,
+            "binaryVersion": handshake().binary_version,
+            "capabilities": capabilities()
+        })),
+        "ping" => Ok(json!({ "ok": true })),
+        "watch/subscribe" => watch_subscribe(state, params),
+        "watch/unsubscribe" => watch_unsubscribe(state, params),
+        "fs/read" => fs_read(state, params),
+        "fs/write" => fs_write(state, params),
+        "fs/stat" => fs_stat(state, params),
+        _ => Err(jsonrpc_error(-32601, format!("method not found: {method}"))),
+    }
+}
+
+fn watch_subscribe(state: &mut HelperState, params: Option<Value>) -> Result<Value, HelperError> {
+    let params: WatchSubscribeParams = decode_params(params)?;
+    let root = std::fs::canonicalize(&params.root)
+        .map_err(|error| jsonrpc_error(-32010, format!("invalid root: {error}")))?;
+    state.next_subscription_id += 1;
+    let id = state.next_subscription_id.to_string();
+    state.subscriptions.insert(id.clone(), root);
+    Ok(json!({ "subscriptionId": id }))
+}
+
+fn watch_unsubscribe(state: &mut HelperState, params: Option<Value>) -> Result<Value, HelperError> {
+    let params: WatchUnsubscribeParams = decode_params(params)?;
+    state.subscriptions.remove(&params.subscription_id);
+    Ok(json!({ "ok": true }))
+}
+
+fn fs_read(state: &HelperState, params: Option<Value>) -> Result<Value, HelperError> {
+    let params: FsReadParams = decode_params(params)?;
+    let path = contained_existing_path(state, &params.path)?;
+    let metadata = std::fs::metadata(&path)
+        .map_err(|error| jsonrpc_error(-32020, format!("metadata failed: {error}")))?;
+    if !metadata.is_file() {
+        return Err(jsonrpc_error(-32025, "path is not a regular file"));
+    }
+    let bytes = std::fs::read(&path)
+        .map_err(|error| jsonrpc_error(-32020, format!("read failed: {error}")))?;
+    let offset = params.offset.unwrap_or(0) as usize;
+    let content = std::str::from_utf8(bytes.get(offset..).unwrap_or_default())
+        .map_err(|error| jsonrpc_error(-32024, format!("invalid utf-8: {error}")))?
+        .to_string();
+    let mtime = modified_seconds(&metadata);
+    Ok(json!({ "content": content, "mtime": mtime }))
+}
+
+fn fs_write(state: &HelperState, params: Option<Value>) -> Result<Value, HelperError> {
+    let params: FsWriteParams = decode_params(params)?;
+    let path = contained_write_path(state, &params.path)?;
+    if let Some(expected) = params.expected_mtime {
+        let metadata = std::fs::metadata(&path).map_err(|error| {
+            if error.kind() == io::ErrorKind::NotFound {
+                jsonrpc_error(-32030, "mtime target missing")
+            } else {
+                jsonrpc_error(-32020, format!("mtime failed: {error}"))
+            }
+        })?;
+        if let Some(actual) = modified_seconds(&metadata) {
+            if (actual - expected).abs() > 0.000_001 {
+                return Err(jsonrpc_error(-32030, "mtime mismatch"));
+            }
+        }
+    }
+    write_replacing_path(&path, &params.content)?;
+    let mtime = std::fs::metadata(path)
+        .ok()
+        .and_then(|metadata| modified_seconds(&metadata));
+    Ok(json!({ "mtime": mtime }))
+}
+
+fn fs_stat(state: &HelperState, params: Option<Value>) -> Result<Value, HelperError> {
+    let params: FsStatParams = decode_params(params)?;
+    let mut entries = Vec::with_capacity(params.paths.len());
+    for path in params.paths {
+        match contained_existing_path(state, &path) {
+            Ok(contained) => {
+                let metadata = std::fs::metadata(&contained)
+                    .map_err(|error| jsonrpc_error(-32020, format!("stat failed: {error}")))?;
+                entries.push(json!({
+                    "path": path,
+                    "exists": true,
+                    "isDirectory": metadata.is_dir(),
+                    "isFile": metadata.is_file(),
+                    "size": metadata.len(),
+                    "mtime": modified_seconds(&metadata)
+                }));
+            }
+            Err(error) if error.code == -32021 => {
+                entries.push(json!({
+                    "path": path,
+                    "exists": false,
+                    "isDirectory": false,
+                    "isFile": false,
+                    "size": null,
+                    "mtime": null
+                }));
+            }
+            Err(error) => return Err(error),
+        }
+    }
+    Ok(json!({ "entries": entries }))
+}
+
+fn contained_existing_path(state: &HelperState, path: &str) -> Result<PathBuf, HelperError> {
+    if state.subscriptions.is_empty() {
+        return Err(jsonrpc_error(-32022, "no registered roots"));
+    }
+    let canonical = match std::fs::canonicalize(path) {
+        Ok(path) => path,
+        Err(error) if error.kind() == io::ErrorKind::NotFound => {
+            ensure_missing_path_parent_is_contained(state, path)?;
+            return Err(jsonrpc_error(-32021, "path not found"));
+        }
+        Err(error) => return Err(jsonrpc_error(-32020, format!("path failed: {error}"))),
+    };
+    if state
+        .subscriptions
+        .values()
+        .any(|root| canonical.starts_with(root))
+    {
+        Ok(canonical)
+    } else {
+        Err(jsonrpc_error(-32023, "path outside registered roots"))
+    }
+}
+
+fn contained_write_path(state: &HelperState, path: &str) -> Result<PathBuf, HelperError> {
+    if state.subscriptions.is_empty() {
+        return Err(jsonrpc_error(-32022, "no registered roots"));
+    }
+    let path = Path::new(path);
+    let parent = path
+        .parent()
+        .ok_or_else(|| jsonrpc_error(-32020, "path has no parent"))?;
+    let parent = std::fs::canonicalize(parent)
+        .map_err(|error| jsonrpc_error(-32020, format!("parent failed: {error}")))?;
+    if !state
+        .subscriptions
+        .values()
+        .any(|root| parent.starts_with(root))
+    {
+        return Err(jsonrpc_error(-32023, "path outside registered roots"));
+    }
+    let file_name = path
+        .file_name()
+        .ok_or_else(|| jsonrpc_error(-32020, "path has no filename"))?;
+    let target = parent.join(file_name);
+    match std::fs::symlink_metadata(&target) {
+        Ok(metadata) if metadata.file_type().is_symlink() => {
+            let canonical = std::fs::canonicalize(&target).map_err(|error| {
+                jsonrpc_error(-32020, format!("symlink target failed: {error}"))
+            })?;
+            if state
+                .subscriptions
+                .values()
+                .any(|root| canonical.starts_with(root))
+            {
+                Ok(canonical)
+            } else {
+                Err(jsonrpc_error(-32023, "path outside registered roots"))
+            }
+        }
+        Ok(_) => Ok(target),
+        Err(error) if error.kind() == io::ErrorKind::NotFound => Ok(target),
+        Err(error) => Err(jsonrpc_error(-32020, format!("path failed: {error}"))),
+    }
+}
+
+fn write_replacing_path(path: &Path, content: &str) -> Result<(), HelperError> {
+    let parent = path
+        .parent()
+        .ok_or_else(|| jsonrpc_error(-32020, "path has no parent"))?;
+    let file_name = path
+        .file_name()
+        .ok_or_else(|| jsonrpc_error(-32020, "path has no filename"))?
+        .to_string_lossy();
+    let nonce = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|duration| duration.as_nanos())
+        .unwrap_or_default();
+    let temp = parent.join(format!(
+        ".{file_name}.alas-helper-write-{}-{nonce}",
+        std::process::id()
+    ));
+
+    write_restrictive_temp_file(&temp, content)?;
+    if let Err(error) = apply_final_write_permissions(path, &temp, parent, &file_name) {
+        let _ = std::fs::remove_file(&temp);
+        return Err(error);
+    }
+    if let Err(error) = std::fs::rename(&temp, path) {
+        let _ = std::fs::remove_file(&temp);
+        return Err(jsonrpc_error(-32020, format!("rename failed: {error}")));
+    }
+    Ok(())
+}
+
+fn write_restrictive_temp_file(path: &Path, content: &str) -> Result<(), HelperError> {
+    let mut options = std::fs::OpenOptions::new();
+    options.write(true).create_new(true);
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::OpenOptionsExt;
+        options.mode(0o600);
+    }
+    let mut file = options
+        .open(path)
+        .map_err(|error| jsonrpc_error(-32020, format!("temp create failed: {error}")))?;
+    file.write_all(content.as_bytes())
+        .map_err(|error| jsonrpc_error(-32020, format!("write failed: {error}")))
+}
+
+fn apply_final_write_permissions(
+    path: &Path,
+    temp: &Path,
+    parent: &Path,
+    file_name: &str,
+) -> Result<(), HelperError> {
+    let permissions = match std::fs::metadata(path) {
+        Ok(metadata) => metadata.permissions(),
+        Err(error) if error.kind() == io::ErrorKind::NotFound => {
+            return apply_new_file_permissions(temp, parent, file_name);
+        }
+        Err(error) => return Err(jsonrpc_error(-32020, format!("metadata failed: {error}"))),
+    };
+    std::fs::set_permissions(temp, permissions)
+        .map_err(|error| jsonrpc_error(-32020, format!("chmod failed: {error}")))
+}
+
+#[cfg(unix)]
+fn apply_new_file_permissions(
+    temp: &Path,
+    parent: &Path,
+    file_name: &str,
+) -> Result<(), HelperError> {
+    let probe = parent.join(format!(
+        ".{file_name}.alas-helper-mode-probe-{}-{}",
+        std::process::id(),
+        SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .map(|duration| duration.as_nanos())
+            .unwrap_or_default()
+    ));
+    let mut options = std::fs::OpenOptions::new();
+    options.write(true).create_new(true);
+    {
+        use std::os::unix::fs::OpenOptionsExt;
+        options.mode(0o666);
+    }
+    let probe_file = options
+        .open(&probe)
+        .map_err(|error| jsonrpc_error(-32020, format!("mode probe failed: {error}")))?;
+    drop(probe_file);
+    let permissions = match std::fs::metadata(&probe) {
+        Ok(metadata) => metadata.permissions(),
+        Err(error) => {
+            let _ = std::fs::remove_file(&probe);
+            return Err(jsonrpc_error(
+                -32020,
+                format!("mode probe metadata failed: {error}"),
+            ));
+        }
+    };
+    let _ = std::fs::remove_file(&probe);
+    std::fs::set_permissions(temp, permissions)
+        .map_err(|error| jsonrpc_error(-32020, format!("chmod failed: {error}")))
+}
+
+#[cfg(not(unix))]
+fn apply_new_file_permissions(
+    _temp: &Path,
+    _parent: &Path,
+    _file_name: &str,
+) -> Result<(), HelperError> {
+    Ok(())
+}
+
+fn ensure_missing_path_parent_is_contained(
+    state: &HelperState,
+    path: &str,
+) -> Result<(), HelperError> {
+    let path = Path::new(path);
+    let mut ancestor = path
+        .parent()
+        .ok_or_else(|| jsonrpc_error(-32020, "path has no parent"))?;
+    let parent = loop {
+        match std::fs::canonicalize(ancestor) {
+            Ok(parent) => break parent,
+            Err(error) if error.kind() == io::ErrorKind::NotFound => {
+                ancestor = ancestor
+                    .parent()
+                    .ok_or_else(|| jsonrpc_error(-32021, "path not found"))?;
+            }
+            Err(error) => {
+                return Err(jsonrpc_error(-32020, format!("parent failed: {error}")));
+            }
+        }
+    };
+    if state
+        .subscriptions
+        .values()
+        .any(|root| parent.starts_with(root))
+    {
+        Ok(())
+    } else {
+        Err(jsonrpc_error(-32023, "path outside registered roots"))
+    }
+}
+
+fn modified_seconds(metadata: &std::fs::Metadata) -> Option<f64> {
+    let modified = metadata.modified().ok()?;
+    let duration = modified.duration_since(UNIX_EPOCH).ok()?;
+    Some(duration.as_secs() as f64 + f64::from(duration.subsec_nanos()) / 1_000_000_000.0)
+}
+
+fn decode_params<T: for<'de> Deserialize<'de>>(params: Option<Value>) -> Result<T, HelperError> {
+    let params = params.ok_or_else(|| jsonrpc_error(-32602, "missing params"))?;
+    serde_json::from_value(params)
+        .map_err(|error| jsonrpc_error(-32602, format!("invalid params: {error}")))
+}
+
+fn success_response(id: Value, result: Value) -> String {
+    json!({
+        "jsonrpc": "2.0",
+        "id": id,
+        "result": result
+    })
+    .to_string()
+}
+
+fn error_response(id: Value, code: i64, message: impl Into<String>) -> String {
+    json!({
+        "jsonrpc": "2.0",
+        "id": id,
+        "error": {
+            "code": code,
+            "message": message.into()
+        }
+    })
+    .to_string()
+}
+
+fn jsonrpc_error(code: i64, message: impl Into<String>) -> HelperError {
+    HelperError {
+        code,
+        message: message.into(),
+    }
+}
+
+#[allow(dead_code)]
+fn system_time_seconds(time: SystemTime) -> Option<f64> {
+    let duration = time.duration_since(UNIX_EPOCH).ok()?;
+    Some(duration.as_secs() as f64 + f64::from(duration.subsec_nanos()) / 1_000_000_000.0)
 }
 
 #[cfg(test)]
@@ -39,5 +528,402 @@ mod tests {
         let manifest: Handshake<'_> =
             serde_json::from_str(include_str!("../manifest.json")).expect("valid manifest");
         assert_eq!(manifest, handshake());
+    }
+
+    #[test]
+    fn hello_returns_protocol_capabilities() {
+        let mut state = HelperState::default();
+        let response = handle_line(
+            &mut state,
+            r#"{"jsonrpc":"2.0","id":1,"method":"hello","params":{"clientName":"Alas","protocolVersion":1}}"#,
+        )
+        .expect("response");
+        let value: Value = serde_json::from_str(&response).expect("json");
+        assert_eq!(value["result"]["protocolVersion"], 1);
+        assert!(
+            value["result"]["capabilities"]["watchKinds"]
+                .as_array()
+                .expect("watch kinds")
+                .is_empty()
+        );
+        assert_eq!(value["result"]["capabilities"]["fs"]["read"], true);
+    }
+
+    #[test]
+    fn notification_without_id_has_no_response() {
+        let mut state = HelperState::default();
+        assert!(
+            handle_line(
+                &mut state,
+                r#"{"jsonrpc":"2.0","method":"watch/event","params":{}}"#
+            )
+            .is_none()
+        );
+    }
+
+    #[test]
+    fn stat_missing_path_requires_registered_parent() {
+        let root = std::env::temp_dir().join(format!(
+            "alas-helper-test-{}-{}",
+            std::process::id(),
+            system_time_seconds(SystemTime::now()).unwrap()
+        ));
+        std::fs::create_dir_all(&root).expect("root");
+        let outside = std::env::temp_dir().join(format!(
+            "alas-helper-outside-{}-{}",
+            std::process::id(),
+            system_time_seconds(SystemTime::now()).unwrap()
+        ));
+        std::fs::create_dir_all(&outside).expect("outside");
+        let mut state = HelperState::default();
+        handle_line(
+            &mut state,
+            &format!(
+                r#"{{"jsonrpc":"2.0","id":1,"method":"watch/subscribe","params":{{"root":"{}","kinds":["files"]}}}}"#,
+                root.display()
+            ),
+        )
+        .expect("subscribe response");
+
+        let inside_response = handle_line(
+            &mut state,
+            &format!(
+                r#"{{"jsonrpc":"2.0","id":2,"method":"fs/stat","params":{{"paths":["{}"]}}}}"#,
+                root.join("missing.txt").display()
+            ),
+        )
+        .expect("inside response");
+        let inside: Value = serde_json::from_str(&inside_response).expect("inside json");
+        assert_eq!(inside["result"]["entries"][0]["exists"], false);
+
+        let outside_response = handle_line(
+            &mut state,
+            &format!(
+                r#"{{"jsonrpc":"2.0","id":3,"method":"fs/stat","params":{{"paths":["{}"]}}}}"#,
+                outside.join("missing.txt").display()
+            ),
+        )
+        .expect("outside response");
+        let outside_json: Value = serde_json::from_str(&outside_response).expect("outside json");
+        assert_eq!(outside_json["error"]["code"], -32023);
+
+        let _ = std::fs::remove_dir_all(root);
+        let _ = std::fs::remove_dir_all(outside);
+    }
+
+    #[test]
+    fn stat_nested_missing_path_under_registered_root_is_absent() {
+        let root = std::env::temp_dir().join(format!(
+            "alas-helper-nested-missing-{}-{}",
+            std::process::id(),
+            system_time_seconds(SystemTime::now()).unwrap()
+        ));
+        std::fs::create_dir_all(&root).expect("root");
+        let nested = root.join("removed").join("file.txt");
+
+        let mut state = HelperState::default();
+        state.subscriptions.insert(
+            "1".to_string(),
+            std::fs::canonicalize(&root).expect("canonical root"),
+        );
+        let result = fs_stat(
+            &state,
+            Some(json!({
+                "paths": [nested.display().to_string()]
+            })),
+        )
+        .expect("nested missing path should be reported absent");
+
+        assert_eq!(result["entries"][0]["exists"], false);
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn read_rejects_invalid_utf8() {
+        let root = std::env::temp_dir().join(format!(
+            "alas-helper-invalid-utf8-{}-{}",
+            std::process::id(),
+            system_time_seconds(SystemTime::now()).unwrap()
+        ));
+        std::fs::create_dir_all(&root).expect("root");
+        let file = root.join("binary.dat");
+        std::fs::write(&file, [0xff, 0xfe]).expect("binary file");
+
+        let mut state = HelperState::default();
+        state.subscriptions.insert(
+            "1".to_string(),
+            std::fs::canonicalize(&root).expect("canonical root"),
+        );
+        let error = fs_read(
+            &state,
+            Some(json!({
+                "path": file.display().to_string()
+            })),
+        )
+        .expect_err("invalid utf-8 should be rejected");
+
+        assert_eq!(error.code, -32024);
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn read_rejects_non_regular_file() {
+        let root = std::env::temp_dir().join(format!(
+            "alas-helper-non-regular-{}-{}",
+            std::process::id(),
+            system_time_seconds(SystemTime::now()).unwrap()
+        ));
+        let directory = root.join("directory");
+        std::fs::create_dir_all(&directory).expect("directory");
+
+        let mut state = HelperState::default();
+        state.subscriptions.insert(
+            "1".to_string(),
+            std::fs::canonicalize(&root).expect("canonical root"),
+        );
+        let error = fs_read(
+            &state,
+            Some(json!({
+                "path": directory.display().to_string()
+            })),
+        )
+        .expect_err("non-regular files should be rejected");
+
+        assert_eq!(error.code, -32025);
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn write_with_expected_mtime_rejects_missing_target() {
+        let root = std::env::temp_dir().join(format!(
+            "alas-helper-missing-mtime-{}-{}",
+            std::process::id(),
+            system_time_seconds(SystemTime::now()).unwrap()
+        ));
+        std::fs::create_dir_all(&root).expect("root");
+        let missing = root.join("deleted.txt");
+
+        let mut state = HelperState::default();
+        state.subscriptions.insert(
+            "1".to_string(),
+            std::fs::canonicalize(&root).expect("canonical root"),
+        );
+        let error = fs_write(
+            &state,
+            Some(json!({
+                "path": missing.display().to_string(),
+                "content": "changed",
+                "expectedMtime": 12.0
+            })),
+        )
+        .expect_err("missing mtime target should conflict");
+
+        assert_eq!(error.code, -32030);
+        assert!(!missing.exists());
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn write_replaces_hardlink_without_mutating_outside_inode() {
+        let root = std::env::temp_dir().join(format!(
+            "alas-helper-hardlink-root-{}-{}",
+            std::process::id(),
+            system_time_seconds(SystemTime::now()).unwrap()
+        ));
+        let outside = std::env::temp_dir().join(format!(
+            "alas-helper-hardlink-outside-{}-{}",
+            std::process::id(),
+            system_time_seconds(SystemTime::now()).unwrap()
+        ));
+        std::fs::create_dir_all(&root).expect("root");
+        std::fs::create_dir_all(&outside).expect("outside");
+        let outside_file = outside.join("secret.txt");
+        std::fs::write(&outside_file, "original").expect("outside file");
+        let link = root.join("link.txt");
+        std::fs::hard_link(&outside_file, &link).expect("hardlink");
+
+        let mut state = HelperState::default();
+        state.subscriptions.insert(
+            "1".to_string(),
+            std::fs::canonicalize(&root).expect("canonical root"),
+        );
+        let result = fs_write(
+            &state,
+            Some(json!({
+                "path": link.display().to_string(),
+                "content": "changed"
+            })),
+        )
+        .expect("write should replace the hardlink entry");
+
+        assert!(result["mtime"].is_number());
+        assert_eq!(
+            std::fs::read_to_string(&outside_file).expect("outside content"),
+            "original"
+        );
+        assert_eq!(
+            std::fs::read_to_string(&link).expect("inside content"),
+            "changed"
+        );
+
+        let _ = std::fs::remove_dir_all(root);
+        let _ = std::fs::remove_dir_all(outside);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn write_preserves_existing_file_mode() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let root = std::env::temp_dir().join(format!(
+            "alas-helper-mode-root-{}-{}",
+            std::process::id(),
+            system_time_seconds(SystemTime::now()).unwrap()
+        ));
+        std::fs::create_dir_all(&root).expect("root");
+        let script = root.join("script.sh");
+        std::fs::write(&script, "#!/bin/sh\n").expect("script");
+        std::fs::set_permissions(&script, std::fs::Permissions::from_mode(0o755))
+            .expect("script mode");
+
+        let mut state = HelperState::default();
+        state.subscriptions.insert(
+            "1".to_string(),
+            std::fs::canonicalize(&root).expect("canonical root"),
+        );
+        fs_write(
+            &state,
+            Some(json!({
+                "path": script.display().to_string(),
+                "content": "#!/bin/sh\necho changed\n"
+            })),
+        )
+        .expect("write should preserve mode");
+
+        let mode = std::fs::metadata(&script)
+            .expect("script metadata")
+            .permissions()
+            .mode();
+        assert_eq!(mode & 0o777, 0o755);
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn temp_write_uses_restrictive_permissions_before_replace() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let root = std::env::temp_dir().join(format!(
+            "alas-helper-temp-mode-{}-{}",
+            std::process::id(),
+            system_time_seconds(SystemTime::now()).unwrap()
+        ));
+        std::fs::create_dir_all(&root).expect("root");
+        let temp = root.join("payload.tmp");
+
+        write_restrictive_temp_file(&temp, "secret").expect("write temp");
+
+        let mode = std::fs::metadata(&temp)
+            .expect("temp metadata")
+            .permissions()
+            .mode();
+        assert_eq!(mode & 0o777, 0o600);
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn write_new_file_uses_default_file_mode() {
+        use std::os::unix::fs::{OpenOptionsExt, PermissionsExt};
+
+        let root = std::env::temp_dir().join(format!(
+            "alas-helper-new-file-mode-{}-{}",
+            std::process::id(),
+            system_time_seconds(SystemTime::now()).unwrap()
+        ));
+        std::fs::create_dir_all(&root).expect("root");
+        let expected_mode = {
+            let probe = root.join("probe");
+            let mut options = std::fs::OpenOptions::new();
+            options.write(true).create_new(true).mode(0o666);
+            let file = options.open(&probe).expect("probe");
+            drop(file);
+            let mode = std::fs::metadata(&probe)
+                .expect("probe metadata")
+                .permissions()
+                .mode()
+                & 0o777;
+            std::fs::remove_file(&probe).expect("remove probe");
+            mode
+        };
+        let file = root.join("created.txt");
+        let mut state = HelperState::default();
+        state.subscriptions.insert(
+            "1".to_string(),
+            std::fs::canonicalize(&root).expect("canonical root"),
+        );
+
+        fs_write(
+            &state,
+            Some(json!({
+                "path": file.display().to_string(),
+                "content": "new\n"
+            })),
+        )
+        .expect("write should create file");
+
+        let mode = std::fs::metadata(&file)
+            .expect("file metadata")
+            .permissions()
+            .mode()
+            & 0o777;
+        assert_eq!(mode, expected_mode);
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn write_rejects_symlink_target_outside_registered_root() {
+        use std::os::unix::fs::symlink;
+
+        let root = std::env::temp_dir().join(format!(
+            "alas-helper-symlink-root-{}-{}",
+            std::process::id(),
+            system_time_seconds(SystemTime::now()).unwrap()
+        ));
+        let outside = std::env::temp_dir().join(format!(
+            "alas-helper-symlink-outside-{}-{}",
+            std::process::id(),
+            system_time_seconds(SystemTime::now()).unwrap()
+        ));
+        std::fs::create_dir_all(&root).expect("root");
+        std::fs::create_dir_all(&outside).expect("outside");
+        let outside_file = outside.join("secret.txt");
+        std::fs::write(&outside_file, "original").expect("outside file");
+        let link = root.join("link.txt");
+        symlink(&outside_file, &link).expect("symlink");
+
+        let mut state = HelperState::default();
+        state.subscriptions.insert(
+            "1".to_string(),
+            std::fs::canonicalize(&root).expect("canonical root"),
+        );
+        let error = fs_write(
+            &state,
+            Some(json!({
+                "path": link.display().to_string(),
+                "content": "changed"
+            })),
+        )
+        .expect_err("write should reject escaping symlink");
+
+        assert_eq!(error.code, -32023);
+        assert_eq!(
+            std::fs::read_to_string(&outside_file).expect("outside content"),
+            "original"
+        );
+
+        let _ = std::fs::remove_dir_all(root);
+        let _ = std::fs::remove_dir_all(outside);
     }
 }

--- a/AlasTests/ACP/Protocol/FakeJSONRPCTransport.swift
+++ b/AlasTests/ACP/Protocol/FakeJSONRPCTransport.swift
@@ -8,6 +8,7 @@ final class FakeJSONRPCTransport: JSONRPCStdioTransporting, @unchecked Sendable 
     private let cont: AsyncStream<JSONRPCStdioTransport.Incoming>.Continuation
     let incoming: AsyncStream<JSONRPCStdioTransport.Incoming>
     private(set) var sentFrames: [Data] = []
+    private(set) var terminateCount = 0
 
     init() {
         var c: AsyncStream<JSONRPCStdioTransport.Incoming>.Continuation!
@@ -29,6 +30,7 @@ final class FakeJSONRPCTransport: JSONRPCStdioTransporting, @unchecked Sendable 
     var emitExitOnTerminate = true
 
     func terminate() {
+        terminateCount += 1
         if emitExitOnTerminate {
             cont.yield(.exited(0))
         }
@@ -38,5 +40,10 @@ final class FakeJSONRPCTransport: JSONRPCStdioTransporting, @unchecked Sendable 
     /// Inject an inbound JSON frame as if the agent sent it.
     func send(frame: Data) {
         cont.yield(.frame(frame))
+    }
+
+    func send(exitStatus: Int32) {
+        cont.yield(.exited(exitStatus))
+        cont.finish()
     }
 }

--- a/AlasTests/SSH/RemoteHelperClientTests.swift
+++ b/AlasTests/SSH/RemoteHelperClientTests.swift
@@ -1,0 +1,808 @@
+import Foundation
+import Testing
+@testable import Alas
+
+@MainActor
+struct RemoteHelperClientTests {
+    @Test func invocationStartsHelperServeOverBatchSSH() {
+        let invocation = RemoteHelperClient.invocation(host: "devbox")
+        #expect(invocation.executable == "/usr/bin/ssh")
+        #expect(invocation.args.contains("BatchMode=yes"))
+        #expect(invocation.args.contains("devbox"))
+        #expect(invocation.args.last?.contains("alas-helper\" serve") == true)
+    }
+
+    @Test func pingUsesJSONRPCNewlineTransport() async throws {
+        let transport = FakeJSONRPCTransport()
+        let client = RemoteHelperClient(
+            host: "devbox",
+            idleShutdownNanoseconds: 0,
+            transportFactory: { transport }
+        )
+
+        let ping = Task {
+            try await client.ping()
+        }
+
+        try await waitUntil { !transport.sentFrames.isEmpty }
+        let request = try #require(
+            JSONSerialization.jsonObject(with: transport.sentFrames[0]) as? [String: Any]
+        )
+        #expect(request["jsonrpc"] as? String == "2.0")
+        #expect(request["id"] as? Int == 1)
+        #expect(request["method"] as? String == "ping")
+
+        transport.send(frame: Data(#"{"jsonrpc":"2.0","id":1,"result":{"ok":true}}"#.utf8))
+        #expect(try await ping.value == RemoteHelperPingResult(ok: true))
+    }
+
+    @Test func concurrentRequestsAreMatchedById() async throws {
+        let transport = FakeJSONRPCTransport()
+        let client = RemoteHelperClient(
+            host: "devbox",
+            idleShutdownNanoseconds: 0,
+            transportFactory: { transport }
+        )
+
+        let hello = Task {
+            try await client.hello()
+        }
+        let ping = Task {
+            try await client.ping()
+        }
+
+        try await waitUntil { transport.sentFrames.count == 2 }
+        transport.send(frame: Data(#"{"jsonrpc":"2.0","id":2,"result":{"ok":true}}"#.utf8))
+        transport.send(frame: Data(#"""
+        {"jsonrpc":"2.0","id":1,"result":{
+          "name":"alas-helper",
+          "protocolVersion":1,
+          "binaryVersion":"0.2.0",
+          "capabilities":{"watchKinds":[],"fs":{"read":true,"write":true,"stat":true},"ping":true}
+        }}
+        """#.utf8))
+
+        #expect(try await ping.value == RemoteHelperPingResult(ok: true))
+        #expect((try await hello.value).name == "alas-helper")
+    }
+
+    @Test func watchEventNotificationsAreYielded() async throws {
+        let transport = FakeJSONRPCTransport()
+        let client = RemoteHelperClient(
+            host: "devbox",
+            idleShutdownNanoseconds: 0,
+            transportFactory: { transport }
+        )
+
+        let ping = Task { try await client.ping() }
+        try await waitUntil { !transport.sentFrames.isEmpty }
+        transport.send(frame: Data(#"{"jsonrpc":"2.0","id":1,"result":{"ok":true}}"#.utf8))
+        _ = try await ping.value
+
+        var iterator = client.watchEvents.makeAsyncIterator()
+        transport.send(frame: Data(#"""
+        {"jsonrpc":"2.0","method":"watch/event","params":{
+          "subscriptionId":"sub-1",
+          "root":"/srv/repo",
+          "kind":"files",
+          "paths":["/srv/repo/README.md"]
+        }}
+        """#.utf8))
+
+        #expect(await iterator.next() == RemoteHelperWatchEvent(
+            subscriptionId: "sub-1",
+            root: "/srv/repo",
+            kind: .files,
+            paths: ["/srv/repo/README.md"]
+        ))
+    }
+
+    @Test func jsonrpcErrorResponseStillSchedulesIdleShutdown() async throws {
+        let transport = FakeJSONRPCTransport()
+        let client = RemoteHelperClient(
+            host: "devbox",
+            idleShutdownNanoseconds: 1,
+            transportFactory: { transport }
+        )
+
+        let write = Task {
+            try await client.write(path: "/repo/file.txt", content: "new", expectedMtime: 1)
+        }
+
+        try await waitUntil { !transport.sentFrames.isEmpty }
+        transport.send(frame: Data(#"{"jsonrpc":"2.0","id":1,"error":{"code":-32030,"message":"mtime mismatch"}}"#.utf8))
+        await #expect(throws: RemoteHelperClientError.self) {
+            try await write.value
+        }
+        try await waitUntil {
+            transport.terminateCount == 1
+        }
+    }
+
+    @Test func activeSubscriptionPreventsIdleShutdownUntilUnsubscribe() async throws {
+        let transport = FakeJSONRPCTransport()
+        let client = RemoteHelperClient(
+            host: "devbox",
+            idleShutdownNanoseconds: 1,
+            transportFactory: { transport }
+        )
+
+        let subscribe = Task {
+            try await client.subscribe(root: "/repo", kinds: [.files])
+        }
+        try await waitUntil { transport.sentFrames.count == 1 }
+        transport.send(frame: Data(#"{"jsonrpc":"2.0","id":1,"result":{"subscriptionId":"sub-1"}}"#.utf8))
+        #expect((try await subscribe.value).subscriptionId == "client-1")
+        try await Task.sleep(for: .milliseconds(25))
+        #expect(transport.terminateCount == 0)
+
+        let unsubscribe = Task {
+            try await client.unsubscribe(subscriptionId: "client-1")
+        }
+        try await waitUntil { transport.sentFrames.count == 2 }
+        transport.send(frame: Data(#"{"jsonrpc":"2.0","id":2,"result":{"ok":true}}"#.utf8))
+        #expect((try await unsubscribe.value).ok)
+        try await waitUntil {
+            transport.terminateCount == 1
+        }
+    }
+
+    @Test func subscribeReturnsClientOwnedIdsWhenHelperIdsCollide() async throws {
+        let transport = FakeJSONRPCTransport()
+        let client = RemoteHelperClient(
+            host: "devbox",
+            idleShutdownNanoseconds: 0,
+            transportFactory: { transport }
+        )
+
+        let firstSubscribe = Task {
+            try await client.subscribe(root: "/repo-a", kinds: [.files])
+        }
+        try await waitUntil { transport.sentFrames.count == 1 }
+        transport.send(frame: Data(#"{"jsonrpc":"2.0","id":1,"result":{"subscriptionId":"helper-a"}}"#.utf8))
+        #expect((try await firstSubscribe.value).subscriptionId == "client-1")
+
+        let secondSubscribe = Task {
+            try await client.subscribe(root: "/repo-b", kinds: [.files])
+        }
+        try await waitUntil { transport.sentFrames.count == 2 }
+        transport.send(frame: Data(#"{"jsonrpc":"2.0","id":2,"result":{"subscriptionId":"helper-b"}}"#.utf8))
+        #expect((try await secondSubscribe.value).subscriptionId == "client-2")
+
+        let thirdSubscribe = Task {
+            try await client.subscribe(root: "/repo-c", kinds: [.files])
+        }
+        try await waitUntil { transport.sentFrames.count == 3 }
+        transport.send(frame: Data(#"{"jsonrpc":"2.0","id":3,"result":{"subscriptionId":"client-2"}}"#.utf8))
+        #expect((try await thirdSubscribe.value).subscriptionId == "client-3")
+
+        let secondUnsubscribe = Task {
+            try await client.unsubscribe(subscriptionId: "client-2")
+        }
+        try await waitUntil { transport.sentFrames.count == 4 }
+        let secondUnsubscribeRequest = try #require(
+            JSONSerialization.jsonObject(with: transport.sentFrames[3]) as? [String: Any]
+        )
+        let secondParams = try #require(secondUnsubscribeRequest["params"] as? [String: Any])
+        #expect(secondParams["subscriptionId"] as? String == "helper-b")
+        transport.send(frame: Data(#"{"jsonrpc":"2.0","id":4,"result":{"ok":true}}"#.utf8))
+        #expect((try await secondUnsubscribe.value).ok)
+
+        let thirdUnsubscribe = Task {
+            try await client.unsubscribe(subscriptionId: "client-3")
+        }
+        try await waitUntil { transport.sentFrames.count == 5 }
+        let thirdUnsubscribeRequest = try #require(
+            JSONSerialization.jsonObject(with: transport.sentFrames[4]) as? [String: Any]
+        )
+        let thirdParams = try #require(thirdUnsubscribeRequest["params"] as? [String: Any])
+        #expect(thirdParams["subscriptionId"] as? String == "client-2")
+        transport.send(frame: Data(#"{"jsonrpc":"2.0","id":5,"result":{"ok":true}}"#.utf8))
+        #expect((try await thirdUnsubscribe.value).ok)
+    }
+
+    @Test func helperCrashReplaysSubscriptionsBeforeNextRequest() async throws {
+        let firstTransport = FakeJSONRPCTransport()
+        let secondTransport = FakeJSONRPCTransport()
+        let queue = RemoteHelperTransportQueue([firstTransport, secondTransport])
+        let client = RemoteHelperClient(
+            host: "devbox",
+            idleShutdownNanoseconds: 0,
+            transportFactory: { queue.next() }
+        )
+
+        let subscribe = Task {
+            try await client.subscribe(root: "/repo", kinds: [.files])
+        }
+        try await waitUntil { firstTransport.sentFrames.count == 1 }
+        firstTransport.send(frame: Data(#"{"jsonrpc":"2.0","id":1,"result":{"subscriptionId":"sub-1"}}"#.utf8))
+        #expect((try await subscribe.value).subscriptionId == "client-1")
+
+        firstTransport.send(exitStatus: 1)
+        try await waitUntilAsync {
+            await client.lastObservedExitStatus() == 1
+        }
+
+        let read = Task {
+            try await client.read(path: "/repo/file.txt")
+        }
+        try await waitUntil { secondTransport.sentFrames.count == 1 }
+        let replay = try #require(
+            JSONSerialization.jsonObject(with: secondTransport.sentFrames[0]) as? [String: Any]
+        )
+        #expect(replay["method"] as? String == "watch/subscribe")
+        secondTransport.send(frame: Data(#"{"jsonrpc":"2.0","id":2,"result":{"subscriptionId":"sub-2"}}"#.utf8))
+
+        try await waitUntil { secondTransport.sentFrames.count == 2 }
+        let readRequest = try #require(
+            JSONSerialization.jsonObject(with: secondTransport.sentFrames[1]) as? [String: Any]
+        )
+        #expect(readRequest["method"] as? String == "fs/read")
+        secondTransport.send(frame: Data(#"{"jsonrpc":"2.0","id":3,"result":{"content":"ok","mtime":null}}"#.utf8))
+        #expect((try await read.value).content == "ok")
+
+        let unsubscribe = Task {
+            try await client.unsubscribe(subscriptionId: "client-1")
+        }
+        try await waitUntil { secondTransport.sentFrames.count == 3 }
+        let unsubscribeRequest = try #require(
+            JSONSerialization.jsonObject(with: secondTransport.sentFrames[2]) as? [String: Any]
+        )
+        #expect(unsubscribeRequest["method"] as? String == "watch/unsubscribe")
+        let params = try #require(unsubscribeRequest["params"] as? [String: Any])
+        #expect(params["subscriptionId"] as? String == "sub-2")
+        secondTransport.send(frame: Data(#"{"jsonrpc":"2.0","id":4,"result":{"ok":true}}"#.utf8))
+        #expect((try await unsubscribe.value).ok)
+    }
+
+    @Test func restartReplaysAllSubscriptionsBeforeConcurrentRead() async throws {
+        let firstTransport = FakeJSONRPCTransport()
+        let secondTransport = FakeJSONRPCTransport()
+        let queue = RemoteHelperTransportQueue([firstTransport, secondTransport])
+        let client = RemoteHelperClient(
+            host: "devbox",
+            idleShutdownNanoseconds: 0,
+            transportFactory: { queue.next() }
+        )
+
+        let firstSubscribe = Task {
+            try await client.subscribe(root: "/repo-a", kinds: [.files])
+        }
+        try await waitUntil { firstTransport.sentFrames.count == 1 }
+        firstTransport.send(frame: Data(#"{"jsonrpc":"2.0","id":1,"result":{"subscriptionId":"sub-a"}}"#.utf8))
+        _ = try await firstSubscribe.value
+
+        let secondSubscribe = Task {
+            try await client.subscribe(root: "/repo-b", kinds: [.files])
+        }
+        try await waitUntil { firstTransport.sentFrames.count == 2 }
+        firstTransport.send(frame: Data(#"{"jsonrpc":"2.0","id":2,"result":{"subscriptionId":"sub-b"}}"#.utf8))
+        _ = try await secondSubscribe.value
+
+        firstTransport.send(exitStatus: 1)
+        try await waitUntilAsync {
+            await client.lastObservedExitStatus() == 1
+        }
+
+        let read = Task {
+            try await client.read(path: "/repo-b/file.txt")
+        }
+        try await waitUntil { secondTransport.sentFrames.count == 1 }
+        let firstReplay = try #require(
+            JSONSerialization.jsonObject(with: secondTransport.sentFrames[0]) as? [String: Any]
+        )
+        #expect(firstReplay["method"] as? String == "watch/subscribe")
+        let firstReplayId = try #require(firstReplay["id"] as? Int)
+        secondTransport.send(frame: Data(#"{"jsonrpc":"2.0","id":\#(firstReplayId),"result":{"subscriptionId":"replay-1"}}"#.utf8))
+
+        try await waitUntil { secondTransport.sentFrames.count == 2 }
+        let secondReplay = try #require(
+            JSONSerialization.jsonObject(with: secondTransport.sentFrames[1]) as? [String: Any]
+        )
+        #expect(secondReplay["method"] as? String == "watch/subscribe")
+        let secondReplayId = try #require(secondReplay["id"] as? Int)
+        secondTransport.send(frame: Data(#"{"jsonrpc":"2.0","id":\#(secondReplayId),"result":{"subscriptionId":"replay-2"}}"#.utf8))
+
+        try await waitUntil { secondTransport.sentFrames.count == 3 }
+        let readRequest = try #require(
+            JSONSerialization.jsonObject(with: secondTransport.sentFrames[2]) as? [String: Any]
+        )
+        #expect(readRequest["method"] as? String == "fs/read")
+        let readId = try #require(readRequest["id"] as? Int)
+        secondTransport.send(frame: Data(#"{"jsonrpc":"2.0","id":\#(readId),"result":{"content":"ok","mtime":null}}"#.utf8))
+        #expect((try await read.value).content == "ok")
+    }
+
+    @Test func failedReplayPreservesEarlierFreshHelperSubscriptionIds() async throws {
+        let firstTransport = FakeJSONRPCTransport()
+        let secondTransport = FakeJSONRPCTransport()
+        let queue = RemoteHelperTransportQueue([firstTransport, secondTransport])
+        let client = RemoteHelperClient(
+            host: "devbox",
+            idleShutdownNanoseconds: 0,
+            transportFactory: { queue.next() }
+        )
+
+        let firstSubscribe = Task {
+            try await client.subscribe(root: "/repo-a", kinds: [.files])
+        }
+        try await waitUntil { firstTransport.sentFrames.count == 1 }
+        firstTransport.send(frame: Data(#"{"jsonrpc":"2.0","id":1,"result":{"subscriptionId":"sub-a"}}"#.utf8))
+        _ = try await firstSubscribe.value
+
+        let secondSubscribe = Task {
+            try await client.subscribe(root: "/repo-b", kinds: [.files])
+        }
+        try await waitUntil { firstTransport.sentFrames.count == 2 }
+        firstTransport.send(frame: Data(#"{"jsonrpc":"2.0","id":2,"result":{"subscriptionId":"sub-b"}}"#.utf8))
+        _ = try await secondSubscribe.value
+
+        firstTransport.send(exitStatus: 1)
+        try await waitUntilAsync {
+            await client.lastObservedExitStatus() == 1
+        }
+
+        let read = Task {
+            try await client.read(path: "/repo-a/file.txt")
+        }
+        try await waitUntil { secondTransport.sentFrames.count == 1 }
+        let firstReplay = try #require(
+            JSONSerialization.jsonObject(with: secondTransport.sentFrames[0]) as? [String: Any]
+        )
+        let firstReplayParams = try #require(firstReplay["params"] as? [String: Any])
+        let firstReplayRoot = try #require(firstReplayParams["root"] as? String)
+        let replayedClientSubscriptionId = firstReplayRoot == "/repo-a" ? "client-1" : "client-2"
+        let firstReplayId = try #require(firstReplay["id"] as? Int)
+        secondTransport.send(frame: Data(#"{"jsonrpc":"2.0","id":\#(firstReplayId),"result":{"subscriptionId":"replay-a"}}"#.utf8))
+
+        try await waitUntil { secondTransport.sentFrames.count == 2 }
+        let secondReplay = try #require(
+            JSONSerialization.jsonObject(with: secondTransport.sentFrames[1]) as? [String: Any]
+        )
+        let secondReplayId = try #require(secondReplay["id"] as? Int)
+        secondTransport.send(frame: Data(#"{"jsonrpc":"2.0","id":\#(secondReplayId),"error":{"code":-32010,"message":"invalid root"}}"#.utf8))
+        await #expect(throws: RemoteHelperClientError.self) {
+            try await read.value
+        }
+
+        let unsubscribe = Task {
+            try await client.unsubscribe(subscriptionId: replayedClientSubscriptionId)
+        }
+        try await waitUntil { secondTransport.sentFrames.count == 3 }
+        let unsubscribeRequest = try #require(
+            JSONSerialization.jsonObject(with: secondTransport.sentFrames[2]) as? [String: Any]
+        )
+        #expect(unsubscribeRequest["method"] as? String == "watch/unsubscribe")
+        let params = try #require(unsubscribeRequest["params"] as? [String: Any])
+        #expect(params["subscriptionId"] as? String == "replay-a")
+        let unsubscribeId = try #require(unsubscribeRequest["id"] as? Int)
+        secondTransport.send(frame: Data(#"{"jsonrpc":"2.0","id":\#(unsubscribeId),"result":{"ok":true}}"#.utf8))
+        #expect((try await unsubscribe.value).ok)
+    }
+
+    @Test func successfulReplayIsNotDuplicatedOnSameLiveHelperAfterPartialFailure() async throws {
+        let firstTransport = FakeJSONRPCTransport()
+        let secondTransport = FakeJSONRPCTransport()
+        let queue = RemoteHelperTransportQueue([firstTransport, secondTransport])
+        let client = RemoteHelperClient(
+            host: "devbox",
+            idleShutdownNanoseconds: 0,
+            transportFactory: { queue.next() }
+        )
+
+        let firstSubscribe = Task {
+            try await client.subscribe(root: "/repo-a", kinds: [.files])
+        }
+        try await waitUntil { firstTransport.sentFrames.count == 1 }
+        firstTransport.send(frame: Data(#"{"jsonrpc":"2.0","id":1,"result":{"subscriptionId":"sub-a"}}"#.utf8))
+        _ = try await firstSubscribe.value
+
+        let secondSubscribe = Task {
+            try await client.subscribe(root: "/repo-b", kinds: [.files])
+        }
+        try await waitUntil { firstTransport.sentFrames.count == 2 }
+        firstTransport.send(frame: Data(#"{"jsonrpc":"2.0","id":2,"result":{"subscriptionId":"sub-b"}}"#.utf8))
+        _ = try await secondSubscribe.value
+
+        firstTransport.send(exitStatus: 1)
+        try await waitUntilAsync {
+            await client.lastObservedExitStatus() == 1
+        }
+
+        let firstRead = Task {
+            try await client.read(path: "/repo-a/file.txt")
+        }
+        try await waitUntil { secondTransport.sentFrames.count == 1 }
+        let firstReplay = try #require(
+            JSONSerialization.jsonObject(with: secondTransport.sentFrames[0]) as? [String: Any]
+        )
+        let firstReplayParams = try #require(firstReplay["params"] as? [String: Any])
+        let firstReplayRoot = try #require(firstReplayParams["root"] as? String)
+        let firstReplayId = try #require(firstReplay["id"] as? Int)
+        secondTransport.send(frame: Data(#"{"jsonrpc":"2.0","id":\#(firstReplayId),"result":{"subscriptionId":"replay-ok"}}"#.utf8))
+
+        try await waitUntil { secondTransport.sentFrames.count == 2 }
+        let secondReplay = try #require(
+            JSONSerialization.jsonObject(with: secondTransport.sentFrames[1]) as? [String: Any]
+        )
+        let secondReplayParams = try #require(secondReplay["params"] as? [String: Any])
+        let secondReplayRoot = try #require(secondReplayParams["root"] as? String)
+        let secondReplayId = try #require(secondReplay["id"] as? Int)
+        secondTransport.send(frame: Data(#"{"jsonrpc":"2.0","id":\#(secondReplayId),"error":{"code":-32010,"message":"invalid root"}}"#.utf8))
+        await #expect(throws: RemoteHelperClientError.self) {
+            try await firstRead.value
+        }
+
+        let failedClientSubscriptionId = secondReplayRoot == "/repo-a" ? "client-1" : "client-2"
+        let remainingRoot = firstReplayRoot
+        let remainingReadPath = "\(remainingRoot)/file.txt"
+        let unsubscribe = Task {
+            try await client.unsubscribe(subscriptionId: failedClientSubscriptionId)
+        }
+        try await waitUntil { secondTransport.sentFrames.count == 3 }
+        let unsubscribeRequest = try #require(
+            JSONSerialization.jsonObject(with: secondTransport.sentFrames[2]) as? [String: Any]
+        )
+        #expect(unsubscribeRequest["method"] as? String == "watch/unsubscribe")
+        let unsubscribeId = try #require(unsubscribeRequest["id"] as? Int)
+        secondTransport.send(frame: Data(#"{"jsonrpc":"2.0","id":\#(unsubscribeId),"result":{"ok":true}}"#.utf8))
+        #expect((try await unsubscribe.value).ok)
+
+        let secondRead = Task {
+            try await client.read(path: remainingReadPath)
+        }
+        try await waitUntil { secondTransport.sentFrames.count == 4 }
+        let readRequest = try #require(
+            JSONSerialization.jsonObject(with: secondTransport.sentFrames[3]) as? [String: Any]
+        )
+        #expect(readRequest["method"] as? String == "fs/read")
+        let readId = try #require(readRequest["id"] as? Int)
+        secondTransport.send(frame: Data(#"{"jsonrpc":"2.0","id":\#(readId),"result":{"content":"ok","mtime":null}}"#.utf8))
+        #expect((try await secondRead.value).content == "ok")
+    }
+
+    @Test func replayUnsubscribesFreshHelperIdWhenClientSubscriptionWasRemovedDuringReplay() async throws {
+        let firstTransport = FakeJSONRPCTransport()
+        let secondTransport = FakeJSONRPCTransport()
+        let queue = RemoteHelperTransportQueue([firstTransport, secondTransport])
+        let client = RemoteHelperClient(
+            host: "devbox",
+            idleShutdownNanoseconds: 0,
+            transportFactory: { queue.next() }
+        )
+
+        let firstSubscribe = Task {
+            try await client.subscribe(root: "/repo-a", kinds: [.files])
+        }
+        try await waitUntil { firstTransport.sentFrames.count == 1 }
+        firstTransport.send(frame: Data(#"{"jsonrpc":"2.0","id":1,"result":{"subscriptionId":"sub-a"}}"#.utf8))
+        _ = try await firstSubscribe.value
+
+        let secondSubscribe = Task {
+            try await client.subscribe(root: "/repo-b", kinds: [.files])
+        }
+        try await waitUntil { firstTransport.sentFrames.count == 2 }
+        firstTransport.send(frame: Data(#"{"jsonrpc":"2.0","id":2,"result":{"subscriptionId":"sub-b"}}"#.utf8))
+        _ = try await secondSubscribe.value
+
+        firstTransport.send(exitStatus: 1)
+        try await waitUntilAsync {
+            await client.lastObservedExitStatus() == 1
+        }
+
+        let read = Task {
+            try await client.read(path: "/repo-a/file.txt")
+        }
+        try await waitUntil { secondTransport.sentFrames.count == 1 }
+        let replay = try #require(
+            JSONSerialization.jsonObject(with: secondTransport.sentFrames[0]) as? [String: Any]
+        )
+        let replayParams = try #require(replay["params"] as? [String: Any])
+        let replayRoot = try #require(replayParams["root"] as? String)
+        let removedClientSubscriptionId = replayRoot == "/repo-a" ? "client-1" : "client-2"
+        let replayId = try #require(replay["id"] as? Int)
+
+        let unsubscribe = Task {
+            try await client.unsubscribe(subscriptionId: removedClientSubscriptionId)
+        }
+        try await waitUntil { secondTransport.sentFrames.count == 2 }
+        let staleUnsubscribe = try #require(
+            JSONSerialization.jsonObject(with: secondTransport.sentFrames[1]) as? [String: Any]
+        )
+        #expect(staleUnsubscribe["method"] as? String == "watch/unsubscribe")
+        let staleUnsubscribeId = try #require(staleUnsubscribe["id"] as? Int)
+        secondTransport.send(frame: Data(#"{"jsonrpc":"2.0","id":\#(staleUnsubscribeId),"result":{"ok":true}}"#.utf8))
+        #expect((try await unsubscribe.value).ok)
+
+        secondTransport.send(frame: Data(#"{"jsonrpc":"2.0","id":\#(replayId),"result":{"subscriptionId":"replayed-removed"}}"#.utf8))
+        try await waitUntil { secondTransport.sentFrames.count == 3 }
+        let compensatingUnsubscribe = try #require(
+            JSONSerialization.jsonObject(with: secondTransport.sentFrames[2]) as? [String: Any]
+        )
+        #expect(compensatingUnsubscribe["method"] as? String == "watch/unsubscribe")
+        let compensatingParams = try #require(compensatingUnsubscribe["params"] as? [String: Any])
+        #expect(compensatingParams["subscriptionId"] as? String == "replayed-removed")
+        let compensatingId = try #require(compensatingUnsubscribe["id"] as? Int)
+        secondTransport.send(frame: Data(#"{"jsonrpc":"2.0","id":\#(compensatingId),"result":{"ok":true}}"#.utf8))
+
+        try await waitUntil { secondTransport.sentFrames.count == 4 }
+        let remainingReplay = try #require(
+            JSONSerialization.jsonObject(with: secondTransport.sentFrames[3]) as? [String: Any]
+        )
+        #expect(remainingReplay["method"] as? String == "watch/subscribe")
+        let remainingReplayId = try #require(remainingReplay["id"] as? Int)
+        secondTransport.send(frame: Data(#"{"jsonrpc":"2.0","id":\#(remainingReplayId),"result":{"subscriptionId":"remaining"}}"#.utf8))
+
+        try await waitUntil { secondTransport.sentFrames.count == 5 }
+        let readRequest = try #require(
+            JSONSerialization.jsonObject(with: secondTransport.sentFrames[4]) as? [String: Any]
+        )
+        #expect(readRequest["method"] as? String == "fs/read")
+        let readId = try #require(readRequest["id"] as? Int)
+        if replayRoot == "/repo-a" {
+            secondTransport.send(frame: Data(#"{"jsonrpc":"2.0","id":\#(readId),"error":{"code":-32023,"message":"path outside registered roots"}}"#.utf8))
+            await #expect(throws: RemoteHelperClientError.self) {
+                try await read.value
+            }
+        } else {
+            secondTransport.send(frame: Data(#"{"jsonrpc":"2.0","id":\#(readId),"result":{"content":"ok","mtime":null}}"#.utf8))
+            #expect((try await read.value).content == "ok")
+        }
+    }
+
+    @Test func failedReplayIsRetriedOnLiveHelperAfterStaleSubscriptionDrops() async throws {
+        let firstTransport = FakeJSONRPCTransport()
+        let secondTransport = FakeJSONRPCTransport()
+        let queue = RemoteHelperTransportQueue([firstTransport, secondTransport])
+        let client = RemoteHelperClient(
+            host: "devbox",
+            idleShutdownNanoseconds: 0,
+            transportFactory: { queue.next() }
+        )
+
+        let firstSubscribe = Task {
+            try await client.subscribe(root: "/repo-a", kinds: [.files])
+        }
+        try await waitUntil { firstTransport.sentFrames.count == 1 }
+        firstTransport.send(frame: Data(#"{"jsonrpc":"2.0","id":1,"result":{"subscriptionId":"sub-a"}}"#.utf8))
+        _ = try await firstSubscribe.value
+
+        let secondSubscribe = Task {
+            try await client.subscribe(root: "/repo-b", kinds: [.files])
+        }
+        try await waitUntil { firstTransport.sentFrames.count == 2 }
+        firstTransport.send(frame: Data(#"{"jsonrpc":"2.0","id":2,"result":{"subscriptionId":"sub-b"}}"#.utf8))
+        _ = try await secondSubscribe.value
+
+        firstTransport.send(exitStatus: 1)
+        try await waitUntilAsync {
+            await client.lastObservedExitStatus() == 1
+        }
+
+        let firstRead = Task {
+            try await client.read(path: "/repo-a/file.txt")
+        }
+        try await waitUntil { secondTransport.sentFrames.count == 1 }
+        let failedReplay = try #require(
+            JSONSerialization.jsonObject(with: secondTransport.sentFrames[0]) as? [String: Any]
+        )
+        let failedReplayParams = try #require(failedReplay["params"] as? [String: Any])
+        let failedReplayRoot = try #require(failedReplayParams["root"] as? String)
+        let failedReplayId = try #require(failedReplay["id"] as? Int)
+        secondTransport.send(frame: Data(#"{"jsonrpc":"2.0","id":\#(failedReplayId),"error":{"code":-32010,"message":"invalid root"}}"#.utf8))
+        await #expect(throws: RemoteHelperClientError.self) {
+            try await firstRead.value
+        }
+
+        let failedClientSubscriptionId = failedReplayRoot == "/repo-a" ? "client-1" : "client-2"
+        let remainingRoot = failedReplayRoot == "/repo-a" ? "/repo-b" : "/repo-a"
+        let unsubscribe = Task {
+            try await client.unsubscribe(subscriptionId: failedClientSubscriptionId)
+        }
+        try await waitUntil { secondTransport.sentFrames.count == 2 }
+        let unsubscribeRequest = try #require(
+            JSONSerialization.jsonObject(with: secondTransport.sentFrames[1]) as? [String: Any]
+        )
+        #expect(unsubscribeRequest["method"] as? String == "watch/unsubscribe")
+        let unsubscribeId = try #require(unsubscribeRequest["id"] as? Int)
+        secondTransport.send(frame: Data(#"{"jsonrpc":"2.0","id":\#(unsubscribeId),"result":{"ok":true}}"#.utf8))
+        #expect((try await unsubscribe.value).ok)
+
+        let secondRead = Task {
+            try await client.read(path: "\(remainingRoot)/file.txt")
+        }
+        try await waitUntil { secondTransport.sentFrames.count == 3 }
+        let retryReplay = try #require(
+            JSONSerialization.jsonObject(with: secondTransport.sentFrames[2]) as? [String: Any]
+        )
+        #expect(retryReplay["method"] as? String == "watch/subscribe")
+        let retryReplayParams = try #require(retryReplay["params"] as? [String: Any])
+        #expect(retryReplayParams["root"] as? String == remainingRoot)
+        let retryReplayId = try #require(retryReplay["id"] as? Int)
+        secondTransport.send(frame: Data(#"{"jsonrpc":"2.0","id":\#(retryReplayId),"result":{"subscriptionId":"replay-retry"}}"#.utf8))
+
+        try await waitUntil { secondTransport.sentFrames.count == 4 }
+        let readRequest = try #require(
+            JSONSerialization.jsonObject(with: secondTransport.sentFrames[3]) as? [String: Any]
+        )
+        #expect(readRequest["method"] as? String == "fs/read")
+        let readId = try #require(readRequest["id"] as? Int)
+        secondTransport.send(frame: Data(#"{"jsonrpc":"2.0","id":\#(readId),"result":{"content":"ok","mtime":null}}"#.utf8))
+        #expect((try await secondRead.value).content == "ok")
+    }
+
+    @Test func unsubscribeAfterHelperExitDropsSubscriptionWithoutReplay() async throws {
+        let firstTransport = FakeJSONRPCTransport()
+        let secondTransport = FakeJSONRPCTransport()
+        let queue = RemoteHelperTransportQueue([firstTransport, secondTransport])
+        let client = RemoteHelperClient(
+            host: "devbox",
+            idleShutdownNanoseconds: 0,
+            transportFactory: { queue.next() }
+        )
+
+        let subscribe = Task {
+            try await client.subscribe(root: "/deleted-repo", kinds: [.files])
+        }
+        try await waitUntil { firstTransport.sentFrames.count == 1 }
+        firstTransport.send(frame: Data(#"{"jsonrpc":"2.0","id":1,"result":{"subscriptionId":"sub-1"}}"#.utf8))
+        _ = try await subscribe.value
+
+        firstTransport.send(exitStatus: 1)
+        try await waitUntilAsync {
+            await client.lastObservedExitStatus() == 1
+        }
+
+        #expect(try await client.unsubscribe(subscriptionId: "client-1").ok)
+        #expect(secondTransport.sentFrames.isEmpty)
+    }
+
+    @Test func replayRestartsAllSubscriptionsAfterGenerationExit() async throws {
+        let firstTransport = FakeJSONRPCTransport()
+        let secondTransport = FakeJSONRPCTransport()
+        let thirdTransport = FakeJSONRPCTransport()
+        let queue = RemoteHelperTransportQueue([firstTransport, secondTransport, thirdTransport])
+        let client = RemoteHelperClient(
+            host: "devbox",
+            idleShutdownNanoseconds: 0,
+            transportFactory: { queue.next() }
+        )
+
+        let firstSubscribe = Task {
+            try await client.subscribe(root: "/repo-a", kinds: [.files])
+        }
+        try await waitUntil { firstTransport.sentFrames.count == 1 }
+        firstTransport.send(frame: Data(#"{"jsonrpc":"2.0","id":1,"result":{"subscriptionId":"sub-a"}}"#.utf8))
+        _ = try await firstSubscribe.value
+
+        let secondSubscribe = Task {
+            try await client.subscribe(root: "/repo-b", kinds: [.files])
+        }
+        try await waitUntil { firstTransport.sentFrames.count == 2 }
+        firstTransport.send(frame: Data(#"{"jsonrpc":"2.0","id":2,"result":{"subscriptionId":"sub-b"}}"#.utf8))
+        _ = try await secondSubscribe.value
+
+        firstTransport.send(exitStatus: 1)
+        try await waitUntilAsync {
+            await client.lastObservedExitStatus() == 1
+        }
+
+        let read = Task {
+            try await client.read(path: "/repo-a/file.txt")
+        }
+        try await waitUntil { secondTransport.sentFrames.count == 1 }
+        let firstReplay = try #require(
+            JSONSerialization.jsonObject(with: secondTransport.sentFrames[0]) as? [String: Any]
+        )
+        let firstReplayId = try #require(firstReplay["id"] as? Int)
+        secondTransport.send(frame: Data(#"{"jsonrpc":"2.0","id":\#(firstReplayId),"result":{"subscriptionId":"second-generation"}}"#.utf8))
+        secondTransport.send(exitStatus: 2)
+
+        for expectedReplayCount in 1 ... 2 {
+            try await waitUntil { thirdTransport.sentFrames.count == expectedReplayCount }
+            let frame = thirdTransport.sentFrames[expectedReplayCount - 1]
+            let replayRequest = try #require(JSONSerialization.jsonObject(with: frame) as? [String: Any])
+            #expect(replayRequest["method"] as? String == "watch/subscribe")
+            let replayId = try #require(replayRequest["id"] as? Int)
+            thirdTransport.send(frame: Data(#"{"jsonrpc":"2.0","id":\#(replayId),"result":{"subscriptionId":"third-\#(replayId)"}}"#.utf8))
+        }
+
+        try await waitUntil { thirdTransport.sentFrames.count == 3 }
+        let readRequest = try #require(
+            JSONSerialization.jsonObject(with: thirdTransport.sentFrames[2]) as? [String: Any]
+        )
+        #expect(readRequest["method"] as? String == "fs/read")
+        let readId = try #require(readRequest["id"] as? Int)
+        thirdTransport.send(frame: Data(#"{"jsonrpc":"2.0","id":\#(readId),"result":{"content":"ok","mtime":null}}"#.utf8))
+        #expect((try await read.value).content == "ok")
+    }
+
+    @Test func connectionExitMarksHostOfflineOnlyForSSHFailure() async throws {
+        defer {
+            RemoteHostStatusStore.shared.reportSuccess(host: "crashbox")
+            RemoteHostStatusStore.shared.reportSuccess(host: "sshbox")
+        }
+        let store = RemoteHostStatusStore()
+        store.reportConnectionFailure(host: "devbox")
+        store.reportConnectionFailure(host: "devbox")
+        #expect(store.isOffline("devbox"))
+
+        let crashTransport = FakeJSONRPCTransport()
+        let crashClient = RemoteHelperClient(
+            host: "crashbox",
+            idleShutdownNanoseconds: 0,
+            transportFactory: { crashTransport }
+        )
+        let crashRequest = Task { try await crashClient.ping() }
+        try await waitUntil { !crashTransport.sentFrames.isEmpty }
+        crashTransport.send(exitStatus: 1)
+        await #expect(throws: RemoteHelperClientError.self) {
+            try await crashRequest.value
+        }
+        #expect(!RemoteHostStatusStore.shared.isOffline("crashbox"))
+
+        let sshTransport = FakeJSONRPCTransport()
+        let sshClient = RemoteHelperClient(
+            host: "sshbox",
+            idleShutdownNanoseconds: 0,
+            transportFactory: { sshTransport }
+        )
+        let sshRequest = Task { try await sshClient.ping() }
+        try await waitUntil { !sshTransport.sentFrames.isEmpty }
+        sshTransport.send(exitStatus: 255)
+        await #expect(throws: RemoteHelperClientError.self) {
+            try await sshRequest.value
+        }
+        RemoteHostStatusStore.shared.reportConnectionFailure(host: "sshbox")
+        try await waitUntil {
+            RemoteHostStatusStore.shared.isOffline("sshbox")
+        }
+    }
+
+    private func waitUntil(
+        timeout: Duration = .seconds(1),
+        _ predicate: @escaping @MainActor () -> Bool
+    ) async throws {
+        let start = ContinuousClock.now
+        while !predicate() {
+            if ContinuousClock.now - start > timeout {
+                Issue.record("timed out waiting for predicate")
+                return
+            }
+            try await Task.sleep(for: .milliseconds(10))
+        }
+    }
+
+    private func waitUntilAsync(
+        timeout: Duration = .seconds(1),
+        _ predicate: @escaping () async -> Bool
+    ) async throws {
+        let start = ContinuousClock.now
+        while !(await predicate()) {
+            if ContinuousClock.now - start > timeout {
+                Issue.record("timed out waiting for async predicate")
+                return
+            }
+            try await Task.sleep(for: .milliseconds(10))
+        }
+    }
+}
+
+private final class RemoteHelperTransportQueue: @unchecked Sendable {
+    private let lock = NSLock()
+    private let transports: [FakeJSONRPCTransport]
+    private var index = 0
+
+    init(_ transports: [FakeJSONRPCTransport]) {
+        self.transports = transports
+    }
+
+    func next() -> JSONRPCStdioTransporting {
+        lock.lock()
+        defer {
+            index += 1
+            lock.unlock()
+        }
+        return transports[index]
+    }
+}

--- a/docs/architecture/remote-helper-protocol.md
+++ b/docs/architecture/remote-helper-protocol.md
@@ -1,0 +1,160 @@
+# Remote Helper Protocol v1
+
+`alas-helper serve` runs on a remote host as a long-lived stdio process launched
+over batch SSH:
+
+```text
+ssh <batch opts> <host> /bin/sh -c '... "$HOME/.alas/bin/alas-helper" serve'
+```
+
+The app speaks JSON-RPC 2.0 using one newline-delimited JSON object per frame on
+stdin/stdout. Stderr is diagnostic-only. The helper binds to no socket and opens
+no listening port.
+
+## Lifecycle
+
+The app owns one `RemoteHelperClient` actor per SSH host through
+`RemoteHelperClientPool`. A client starts lazily on the first request and shuts
+down after ten idle minutes when there are no active subscriptions. Active
+subscriptions keep the helper alive; if a helper crash forces a restart, the
+client replays those subscriptions before sending the next caller request. If
+the SSH channel exits with status `255`, the app reports a host connection
+failure through `RemoteHostStatusStore`. Other exits are treated as helper
+crashes: in-flight requests fail with a fallback-capable client error, but the
+host is not marked offline. The next request starts a new helper channel.
+
+## Handshake
+
+Request:
+
+```json
+{"jsonrpc":"2.0","id":1,"method":"hello","params":{"clientName":"Alas","protocolVersion":1}}
+```
+
+Result:
+
+```json
+{
+  "name": "alas-helper",
+  "protocolVersion": 1,
+  "binaryVersion": "0.2.0",
+  "capabilities": {
+    "watchKinds": [],
+    "fs": {"read": true, "write": true, "stat": true},
+    "ping": true
+  }
+}
+```
+
+`alas-helper version` prints the same `{name, protocolVersion, binaryVersion}`
+handshake used by capability probing and installer checks.
+
+## Methods
+
+`ping`
+
+Params: `{}`  
+Result: `{"ok": true}`
+
+`watch/subscribe`
+
+Params: `{"root": "/srv/repo", "kinds": ["files", "git"]}`  
+Result: `{"subscriptionId": "1"}`
+
+The helper canonicalizes `root` and registers it as an allowed containment root.
+Future watcher implementations will emit `watch/event` notifications for the
+registered subscription and advertise their supported kinds in
+`hello.capabilities.watchKinds`.
+
+`watch/unsubscribe`
+
+Params: `{"subscriptionId": "1"}`  
+Result: `{"ok": true}`
+
+`watch/event`
+
+Notification:
+
+```json
+{
+  "jsonrpc": "2.0",
+  "method": "watch/event",
+  "params": {
+    "subscriptionId": "1",
+    "root": "/srv/repo",
+    "kind": "files",
+    "paths": ["/srv/repo/README.md"]
+  }
+}
+```
+
+`fs/read`
+
+Params: `{"path": "/srv/repo/README.md", "offset": 0}`  
+Result: `{"content": "...", "mtime": 1783940000.25}`
+
+The helper only reads regular files and decodes content as strict UTF-8. Binary
+or otherwise invalid UTF-8 files return an error instead of lossy replacement
+text.
+
+`fs/write`
+
+Params:
+
+```json
+{"path":"/srv/repo/README.md","content":"...","expectedMtime":1783940000.25}
+```
+
+Result: `{"mtime": 1783940100.5}`
+
+`expectedMtime` is optional. When provided and the existing file mtime differs,
+or the target file no longer exists, the helper returns an error instead of
+writing.
+
+`fs/stat`
+
+Params: `{"paths": ["/srv/repo/README.md"]}`  
+Result:
+
+```json
+{
+  "entries": [{
+    "path": "/srv/repo/README.md",
+    "exists": true,
+    "isDirectory": false,
+    "isFile": true,
+    "size": 1234,
+    "mtime": 1783940000.25
+  }]
+}
+```
+
+## Security
+
+The helper only serves paths under registered roots. `watch/subscribe` resolves
+the requested root with the remote host filesystem. `fs/read` and `fs/stat`
+resolve existing target paths and require them to be under a registered root.
+`fs/write` resolves the parent directory and requires that parent to be under a
+registered root before writing. If the final path already exists as a symlink,
+the helper resolves the symlink target and rejects writes outside registered
+roots. Writes use a sibling temporary file plus rename, preserving the existing
+target mode when replacing a file, so hardlinks inside a registered root are
+replaced instead of mutating an outside shared inode. This catches symlink and
+hardlink escapes on the host that lexical path checks cannot see.
+
+## Errors
+
+JSON-RPC parse errors use `-32700`; invalid requests and params use `-32600` and
+`-32602`; missing methods use `-32601`. Helper-specific errors use the `-320xx`
+range:
+
+| Code | Meaning |
+| --- | --- |
+| `-32010` | invalid subscription root |
+| `-32020` | filesystem operation failed |
+| `-32021` | path does not exist |
+| `-32022` | no containment roots have been registered |
+| `-32023` | path is outside registered roots |
+| `-32024` | file content is not valid UTF-8 |
+| `-32025` | path is not a regular file |
+| `-32030` | `expectedMtime` did not match |


### PR DESCRIPTION
## Summary
- add a long-lived remote helper JSON-RPC client over SSH stdio
- define protocol v1 request, response, and event models for hello, ping, watch, and fs operations
- implement alas-helper serve with newline-framed JSON-RPC handlers and containment checks
- document the protocol and lifecycle expectations

Closes #751

## Validation
- cargo test --manifest-path AlasHelper/Cargo.toml
- xcodegen
- xcodebuild -project Alas.xcodeproj -scheme Alas -destination platform=macOS -only-testing:AlasTests/RemoteHelperClientTests -quiet test
- xcodebuild -project Alas.xcodeproj -scheme Alas -destination platform=macOS -quiet build
- git diff --check

Note: the full isolated macOS test suite currently has unrelated failures in ACP recovery/queue persistence tests and SSH integration tests gated by ALAS_SSH_INTEGRATION=1.