### PR TITLE
feat(ssh): pick remote host from ~/.ssh/config

### DIFF
--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -1148,6 +1148,7 @@
 		EACD40C757361FC2C78F912A /* ACPCodeBlockHighlighter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 530767799372FE03C3695656 /* ACPCodeBlockHighlighter.swift */; };
 		EAEB68B3A06AEA14BC8E2985 /* ChangesPreparationModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2BD2F573498740A7DECCA3C /* ChangesPreparationModelTests.swift */; };
 		EB6136E15E4F1A4CBA230D12 /* GitServiceBehindStatusTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 82387CFDFFBF52E639095C65 /* GitServiceBehindStatusTests.swift */; };
+		EBED65EE62760994B7C6010F /* SSHHostSuggestions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3790CACE965BC5005DA5A51B /* SSHHostSuggestions.swift */; };
 		EC2C564EBA85B494489DF323 /* CursorModelVariantsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 336ADD8484D99054ADDBA588 /* CursorModelVariantsTests.swift */; };
 		EC3209AD2538061259084545 /* ACPTerminalMessages.swift in Sources */ = {isa = PBXBuildFile; fileRef = 10E10C6559E26691EC906737 /* ACPTerminalMessages.swift */; };
 		EC9A9B3211CFE0B652F5CA83 /* MemoryDiagnosticsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2DD6714E62064D5438AAE139 /* MemoryDiagnosticsTests.swift */; };
@@ -1224,6 +1225,7 @@
 		FE5F2F9B468D045194B9443B /* ACPChatTypography.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5DC558BE723378DCC7AA5B55 /* ACPChatTypography.swift */; };
 		FF23739CD41997C6DD44E18B /* ACPFileWriter.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE0C0029F439C282D474ED77 /* ACPFileWriter.swift */; };
 		FF34E8DF7CDAECF80934F3A0 /* PendingStashDropTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F66CF7F86AACAAEA759C8A1B /* PendingStashDropTests.swift */; };
+		FF35D0B630AC692B24FA9909 /* SSHHostSuggestionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B96B454EC8216FFF50B92C1D /* SSHHostSuggestionsTests.swift */; };
 		FF4707BB143F25062DD3BC43 /* AgentAutoLaunchTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 36F875ED8D44E6C298588E60 /* AgentAutoLaunchTests.swift */; };
 		FF77548C74703C8DDC9B480B /* DiffPaneTextDocumentBuilderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8501B285B416ECC49BCC22C3 /* DiffPaneTextDocumentBuilderTests.swift */; };
 		FF7DDFC667CE2E3964B51FA5 /* LSPInstallProgressSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2379C3F8504AD2EE73130AC4 /* LSPInstallProgressSheet.swift */; };
@@ -1515,6 +1517,7 @@
 		3708552C2BF0E70F10C76B63 /* ACPTranscriptMarkdownCacheEvictionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPTranscriptMarkdownCacheEvictionTests.swift; sourceTree = "<group>"; };
 		3711FACCAD4DE3E29AB13DD2 /* ProjectsManagerWorktreeOrderingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProjectsManagerWorktreeOrderingTests.swift; sourceTree = "<group>"; };
 		373D587E3153D902EB10208B /* MarkdownParserTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MarkdownParserTests.swift; sourceTree = "<group>"; };
+		3790CACE965BC5005DA5A51B /* SSHHostSuggestions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SSHHostSuggestions.swift; sourceTree = "<group>"; };
 		37987D5884297401F95478D3 /* AgentPathTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentPathTests.swift; sourceTree = "<group>"; };
 		379D90AD620EAF6E84A04902 /* ImageDiffSideBySideView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageDiffSideBySideView.swift; sourceTree = "<group>"; };
 		37C7F4710313BA1671A3AED0 /* RepoSelectorEnvironment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RepoSelectorEnvironment.swift; sourceTree = "<group>"; };
@@ -2097,6 +2100,7 @@
 		B8FAF07CCA81D986D1C30D05 /* CIStatusStrip.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CIStatusStrip.swift; sourceTree = "<group>"; };
 		B91E5E766925FD6499548CFC /* ACPSessionRunnerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPSessionRunnerTests.swift; sourceTree = "<group>"; };
 		B9454F0214E21F91473C96F6 /* ACPComposerDraftBridgeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPComposerDraftBridgeTests.swift; sourceTree = "<group>"; };
+		B96B454EC8216FFF50B92C1D /* SSHHostSuggestionsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SSHHostSuggestionsTests.swift; sourceTree = "<group>"; };
 		B9749FB435319F01F9E70D08 /* GitServiceMergeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GitServiceMergeTests.swift; sourceTree = "<group>"; };
 		B9830BAAE86AA0A20A77731D /* ProcessMemoryProbeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProcessMemoryProbeTests.swift; sourceTree = "<group>"; };
 		B9A252BAD78A56343D68E782 /* RemoteFileAccessTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteFileAccessTests.swift; sourceTree = "<group>"; };
@@ -2943,6 +2947,7 @@
 				D9C7B2268F3CE7A5FEDF8580 /* ProjectMCPServerEditorPolicy.swift */,
 				AFDDDF6CCDD6CE4A78AEF8F2 /* ProjectMCPServerManager.swift */,
 				3CE948F94DB2759E66CD4DEF /* ProjectPicker.swift */,
+				3790CACE965BC5005DA5A51B /* SSHHostSuggestions.swift */,
 				C2E05FF3EC7EAB497BA0FFE0 /* RepoSelector */,
 			);
 			path = Dialogs;
@@ -4136,6 +4141,7 @@
 				93079B18AE14C7AA3516727D /* RemoteZmxInstallerTests.swift */,
 				90A3C6694C4027DE1A26EC59 /* SSHCommandTests.swift */,
 				575A2C5C173D2D9870A9C274 /* SSHConfigParserTests.swift */,
+				B96B454EC8216FFF50B92C1D /* SSHHostSuggestionsTests.swift */,
 				1C63CBD839A151565AE577AE /* SSHIntegrationTests.swift */,
 			);
 			path = SSH;
@@ -5391,6 +5397,7 @@
 				C82A2082E6E61069068B8FAB /* SQLiteStatement.swift in Sources */,
 				3739AAA93F150060DDAADACA /* SSHCommand.swift in Sources */,
 				30A03E2F26084723538C97BB /* SSHConfigParser.swift in Sources */,
+				EBED65EE62760994B7C6010F /* SSHHostSuggestions.swift in Sources */,
 				065F1A7FCF81FF29BAEF5A86 /* ScopeRow.swift in Sources */,
 				295EF629FAAA46FCD6802F4E /* ScrollEventCapturingView.swift in Sources */,
 				42C0AE388E5CF8B2AAEADE3C /* SearchEmptyState.swift in Sources */,
@@ -5944,6 +5951,7 @@
 				B05D6011E0FDB7AA1B016844 /* SQLiteDatabaseTests.swift in Sources */,
 				AA6F188E5E31B83D45380279 /* SSHCommandTests.swift in Sources */,
 				4C3DFB4EDC26169A6D63E05E /* SSHConfigParserTests.swift in Sources */,
+				FF35D0B630AC692B24FA9909 /* SSHHostSuggestionsTests.swift in Sources */,
 				7DAAFE51C9C35BADB78B4A30 /* SSHIntegrationTests.swift in Sources */,
 				3D5FC516052D2F06781A3F6E /* SearchModelTests.swift in Sources */,
 				2FAAA60EF431D109D842428F /* SelfUpdaterTests.swift in Sources */,

--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -228,6 +228,7 @@
 		2FE10FC44BD9CDBD0C969374 /* MergeBulkResolvePromptEditorWindow.swift in Sources */ = {isa = PBXBuildFile; fileRef = F61EB45499D244E44EB170BC /* MergeBulkResolvePromptEditorWindow.swift */; };
 		303E16565ECF8BDDC7A28AF1 /* ACPTopPaginationIndicator.swift in Sources */ = {isa = PBXBuildFile; fileRef = F01FD27D107E0207950F00D3 /* ACPTopPaginationIndicator.swift */; };
 		30582A6DE1CFD0B9D5CB2E14 /* RemoteFileStats.swift in Sources */ = {isa = PBXBuildFile; fileRef = FBB8BF6C61840B9F972ABACC /* RemoteFileStats.swift */; };
+		30A03E2F26084723538C97BB /* SSHConfigParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2641F3E2016CE8C83E75BA5D /* SSHConfigParser.swift */; };
 		30A1BE2F8E2777CFF6460486 /* ACPConnectionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 701F837327D905FAAA0E0AF3 /* ACPConnectionTests.swift */; };
 		312DB6016C040DE52CD365E8 /* ACPToolbar.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6DE88BE229FD6C1DF35F7EA /* ACPToolbar.swift */; };
 		316A645ECCB46A0F74915EA4 /* RemoteProjectGitWatcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7ECE27F4EE6CA578693BE83D /* RemoteProjectGitWatcher.swift */; };
@@ -375,6 +376,7 @@
 		4B8BD1280C2DFF3CE1FD3C4B /* ACPTranscriptCurrentPlanTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC7FA2ABE27A4CC2EB0BCA18 /* ACPTranscriptCurrentPlanTests.swift */; };
 		4BDE8C92734D3A60645C0500 /* PaneLeafEncodeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4DA7089B238D285A1A2040CA /* PaneLeafEncodeTests.swift */; };
 		4C31A14595F4AE906BFE67D2 /* ACPAgentProfiles.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC3692D5EB4BCA66AB702D43 /* ACPAgentProfiles.swift */; };
+		4C3DFB4EDC26169A6D63E05E /* SSHConfigParserTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 575A2C5C173D2D9870A9C274 /* SSHConfigParserTests.swift */; };
 		4CFC511BB3BEFB139BDF66F6 /* MemoryReportWindow.swift in Sources */ = {isa = PBXBuildFile; fileRef = A6C3E23DCE2A602A87915ECE /* MemoryReportWindow.swift */; };
 		4D1584E4013D1A667723E4A6 /* MergeAgent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 90D74C28EB7B8C3CBC53994D /* MergeAgent.swift */; };
 		4D9A57C74B314FA3570B0406 /* GitServiceReviewRequestDraftTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FFB1CCDE2E4D85A46E6CFB1A /* GitServiceReviewRequestDraftTests.swift */; };
@@ -1410,6 +1412,7 @@
 		25C1AD69581AAE3D34624F23 /* AgentAutoLaunch.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentAutoLaunch.swift; sourceTree = "<group>"; };
 		25CBAF6618B6D11EC3B9CC76 /* InstallNudgeResolver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InstallNudgeResolver.swift; sourceTree = "<group>"; };
 		25DBE942154BD154F2D10B9D /* SidebarHeaderViewTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SidebarHeaderViewTests.swift; sourceTree = "<group>"; };
+		2641F3E2016CE8C83E75BA5D /* SSHConfigParser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SSHConfigParser.swift; sourceTree = "<group>"; };
 		2648D58703B6C53ED15D536A /* TreeSitterHCL */ = {isa = PBXFileReference; lastKnownFileType = folder; name = TreeSitterHCL; path = ThirdParty/TreeSitterHCL; sourceTree = SOURCE_ROOT; };
 		269CE27A6F4F2E663EDF9052 /* GitNameValidator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GitNameValidator.swift; sourceTree = "<group>"; };
 		26E8DE57F9A8D5230BCB7A2C /* ACPSubmitIntentTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPSubmitIntentTests.swift; sourceTree = "<group>"; };
@@ -1671,6 +1674,7 @@
 		56D1AC9E1E00C3C5C234382C /* TouchTargetSmokeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TouchTargetSmokeTests.swift; sourceTree = "<group>"; };
 		56E964C72322223859CC6AF8 /* ReviewFeedbackAgentSender.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReviewFeedbackAgentSender.swift; sourceTree = "<group>"; };
 		5733BF1C52BA0FCFB2724D57 /* ACPQueuedBubbleActionMetricsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPQueuedBubbleActionMetricsTests.swift; sourceTree = "<group>"; };
+		575A2C5C173D2D9870A9C274 /* SSHConfigParserTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SSHConfigParserTests.swift; sourceTree = "<group>"; };
 		576619C2726DFDE8F627AE19 /* CommitsAheadTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommitsAheadTests.swift; sourceTree = "<group>"; };
 		57713D7143CFD53124E0523F /* AlasHookCommand.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlasHookCommand.swift; sourceTree = "<group>"; };
 		57B7225443DF69C32D25338D /* SpacesPane.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpacesPane.swift; sourceTree = "<group>"; };
@@ -3634,6 +3638,7 @@
 				D837246E56472EBA3993F515 /* RemoteWorktreePoll.swift */,
 				5B4239E76E57C63CD983437F /* RemoteZmxInstaller.swift */,
 				8351793355009D8A73AA91A2 /* SSHCommand.swift */,
+				2641F3E2016CE8C83E75BA5D /* SSHConfigParser.swift */,
 			);
 			path = SSH;
 			sourceTree = "<group>";
@@ -4130,6 +4135,7 @@
 				32EEB37C08A315D65558B273 /* RemoteWorktreePollTests.swift */,
 				93079B18AE14C7AA3516727D /* RemoteZmxInstallerTests.swift */,
 				90A3C6694C4027DE1A26EC59 /* SSHCommandTests.swift */,
+				575A2C5C173D2D9870A9C274 /* SSHConfigParserTests.swift */,
 				1C63CBD839A151565AE577AE /* SSHIntegrationTests.swift */,
 			);
 			path = SSH;
@@ -5384,6 +5390,7 @@
 				102686FD795DE94337B3A030 /* SQLiteError.swift in Sources */,
 				C82A2082E6E61069068B8FAB /* SQLiteStatement.swift in Sources */,
 				3739AAA93F150060DDAADACA /* SSHCommand.swift in Sources */,
+				30A03E2F26084723538C97BB /* SSHConfigParser.swift in Sources */,
 				065F1A7FCF81FF29BAEF5A86 /* ScopeRow.swift in Sources */,
 				295EF629FAAA46FCD6802F4E /* ScrollEventCapturingView.swift in Sources */,
 				42C0AE388E5CF8B2AAEADE3C /* SearchEmptyState.swift in Sources */,
@@ -5936,6 +5943,7 @@
 				4EC689B454508C1ED77C5FB4 /* RightPaneVisibilityTests.swift in Sources */,
 				B05D6011E0FDB7AA1B016844 /* SQLiteDatabaseTests.swift in Sources */,
 				AA6F188E5E31B83D45380279 /* SSHCommandTests.swift in Sources */,
+				4C3DFB4EDC26169A6D63E05E /* SSHConfigParserTests.swift in Sources */,
 				7DAAFE51C9C35BADB78B4A30 /* SSHIntegrationTests.swift in Sources */,
 				3D5FC516052D2F06781A3F6E /* SearchModelTests.swift in Sources */,
 				2FAAA60EF431D109D842428F /* SelfUpdaterTests.swift in Sources */,

--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -423,6 +423,7 @@
 		5632CE3BB7220370D87A987B /* AgentLauncherModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45D8B88C4D4837376C123D45 /* AgentLauncherModelTests.swift */; };
 		5685074AFE30889AAC69EB8D /* ThreePaneLayout.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5377288BFD5A1B410E141C54 /* ThreePaneLayout.swift */; };
 		56891962450BF0BF596A428A /* TreeSitterKotlin in Frameworks */ = {isa = PBXBuildFile; productRef = 69B81D6B7546F6A8AF3207E9 /* TreeSitterKotlin */; };
+		568F6E986ED37A79D21CF09B /* SSHHostPicker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0FA3C5D49DC1B6AB83479412 /* SSHHostPicker.swift */; };
 		56B6EF95B863B557992AE9DA /* ACPAutoRunToggle.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3EDEEB00185F9C717205540 /* ACPAutoRunToggle.swift */; };
 		5711B2BE2D70220A4BED5B2B /* DefinitionFeature.swift in Sources */ = {isa = PBXBuildFile; fileRef = F12340A649892955245BECB7 /* DefinitionFeature.swift */; };
 		57138814D45D03AE10BE9D67 /* ACPPermissionFSTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2B932ED9D5A485AE1545223C /* ACPPermissionFSTests.swift */; };
@@ -1322,6 +1323,7 @@
 		0EE97D2D6875CD6A1DBF4DE9 /* GitService+ReviewRequestDraft.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "GitService+ReviewRequestDraft.swift"; sourceTree = "<group>"; };
 		0F2A5B37528AD21CAD5ED051 /* ACPSessionAgentStateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPSessionAgentStateTests.swift; sourceTree = "<group>"; };
 		0F68A9692F85197ED9E16262 /* WorktreesPane.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorktreesPane.swift; sourceTree = "<group>"; };
+		0FA3C5D49DC1B6AB83479412 /* SSHHostPicker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SSHHostPicker.swift; sourceTree = "<group>"; };
 		0FB91182CAC794B0BEDD222D /* ACPThoughtView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPThoughtView.swift; sourceTree = "<group>"; };
 		100091C8ABC3F3FA66C744E9 /* HoverHighlightFeatureTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HoverHighlightFeatureTests.swift; sourceTree = "<group>"; };
 		1003EEEA51DA385A0DD57CA0 /* ThemeStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThemeStoreTests.swift; sourceTree = "<group>"; };
@@ -2947,6 +2949,7 @@
 				D9C7B2268F3CE7A5FEDF8580 /* ProjectMCPServerEditorPolicy.swift */,
 				AFDDDF6CCDD6CE4A78AEF8F2 /* ProjectMCPServerManager.swift */,
 				3CE948F94DB2759E66CD4DEF /* ProjectPicker.swift */,
+				0FA3C5D49DC1B6AB83479412 /* SSHHostPicker.swift */,
 				3790CACE965BC5005DA5A51B /* SSHHostSuggestions.swift */,
 				C2E05FF3EC7EAB497BA0FFE0 /* RepoSelector */,
 			);
@@ -5397,6 +5400,7 @@
 				C82A2082E6E61069068B8FAB /* SQLiteStatement.swift in Sources */,
 				3739AAA93F150060DDAADACA /* SSHCommand.swift in Sources */,
 				30A03E2F26084723538C97BB /* SSHConfigParser.swift in Sources */,
+				568F6E986ED37A79D21CF09B /* SSHHostPicker.swift in Sources */,
 				EBED65EE62760994B7C6010F /* SSHHostSuggestions.swift in Sources */,
 				065F1A7FCF81FF29BAEF5A86 /* ScopeRow.swift in Sources */,
 				295EF629FAAA46FCD6802F4E /* ScrollEventCapturingView.swift in Sources */,

--- a/Alas/Sources/Dialogs/NewProjectDialog.swift
+++ b/Alas/Sources/Dialogs/NewProjectDialog.swift
@@ -153,7 +153,7 @@ private struct ProjectDialog: View {
                     integrationsSection
                 }
                 if let errorMessage {
-                    Text(errorMessage).font(.system(size: 11)).foregroundColor(.red)
+                    errorField(errorMessage)
                 }
             },
             cancelTitle: "Cancel",
@@ -338,6 +338,37 @@ private struct ProjectDialog: View {
                     .strokeBorder(theme.color("line"), lineWidth: 0.5)
             )
             .clipShape(RoundedRectangle(cornerRadius: 6))
+    }
+
+    // Errors here can carry SSH stderr or a setup command the user needs to
+    // paste into a terminal, so the field is selectable with a Copy button.
+    private func errorField(_ message: String) -> some View {
+        HStack(alignment: .top, spacing: 8) {
+            Text(message)
+                .font(.system(size: 11))
+                .foregroundColor(.red)
+                .textSelection(.enabled)
+                .fixedSize(horizontal: false, vertical: true)
+                .frame(maxWidth: .infinity, alignment: .leading)
+            Button(action: {
+                NSPasteboard.general.clearContents()
+                NSPasteboard.general.setString(message, forType: .string)
+            }) {
+                Image(systemName: "doc.on.doc")
+                    .font(.system(size: 11))
+                    .foregroundColor(theme.color("fg-dim"))
+            }
+            .buttonStyle(.plain)
+            .help("Copy error")
+            .accessibilityLabel("Copy error message")
+        }
+        .padding(8)
+        .background(theme.color("bg-0"))
+        .overlay(
+            RoundedRectangle(cornerRadius: 6)
+                .strokeBorder(theme.color("line"), lineWidth: 0.5)
+        )
+        .clipShape(RoundedRectangle(cornerRadius: 6))
     }
 
     private var startupScriptsSection: some View {

--- a/Alas/Sources/Dialogs/NewProjectDialog.swift
+++ b/Alas/Sources/Dialogs/NewProjectDialog.swift
@@ -39,6 +39,9 @@ private struct ProjectDialog: View {
     }
     @State private var location: ProjectLocation = .local
     @State private var sshHost: String = ""
+    @State private var showHostPicker = false
+    @State private var sshHosts: [SSHConfigHost] = []
+    @State private var sshHostsLoading = false
     @State private var name: String = ""
     @State private var iconMode: ProjectIcon.Mode = .letter
     @State private var iconColor: String = ProjectIcon.defaultColor
@@ -106,7 +109,29 @@ private struct ProjectDialog: View {
                             }
                         } else {
                             VStack(alignment: .leading, spacing: 6) {
-                                AlasField(text: $sshHost, placeholder: "Host from ~/.ssh/config, e.g. devbox", monospaced: true)
+                                HStack(spacing: 6) {
+                                    AlasField(text: $sshHost, placeholder: "devbox or user@host", monospaced: true)
+                                    Button(action: { showHostPicker.toggle() }) {
+                                        Image(systemName: "list.bullet")
+                                            .font(.system(size: 12, weight: .semibold))
+                                            .foregroundColor(theme.color("fg-dim"))
+                                            .frame(width: 30, height: 28)
+                                            .background(theme.color("bg-2"))
+                                            .overlay(RoundedRectangle(cornerRadius: 6)
+                                                .strokeBorder(theme.color("line"), lineWidth: 0.5))
+                                            .clipShape(RoundedRectangle(cornerRadius: 6))
+                                    }
+                                    .buttonStyle(.plain)
+                                    .help("Choose a host from ~/.ssh/config")
+                                    .popover(isPresented: $showHostPicker, arrowEdge: .bottom) {
+                                        SSHHostPicker(
+                                            host: $sshHost,
+                                            hosts: sshHosts,
+                                            isLoading: sshHostsLoading,
+                                            isPresented: $showHostPicker
+                                        )
+                                    }
+                                }
                                 AlasField(text: $path, placeholder: "/home/me/repo", monospaced: true)
                             }
                         }
@@ -147,6 +172,11 @@ private struct ProjectDialog: View {
                     await suggestName(for: new)
                     await loadAvatarPresetIfAvailable()
                 }
+            }
+        }
+        .onChange(of: showHostPicker) { _, isOpen in
+            if isOpen && sshHosts.isEmpty && !sshHostsLoading {
+                loadSSHHosts()
             }
         }
         .sheet(isPresented: $mcpManagerPresented) {
@@ -430,6 +460,16 @@ private struct ProjectDialog: View {
             if let suggested = try? await svc.suggestProjectName(url), name.isEmpty {
                 name = suggested
             }
+        }
+    }
+
+    private func loadSSHHosts() {
+        sshHostsLoading = true
+        Task {
+            let home = FileManager.default.homeDirectoryForCurrentUser
+            let parsed = await Task.detached { SSHConfigParser.parse(home: home) }.value
+            sshHosts = parsed
+            sshHostsLoading = false
         }
     }
 

--- a/Alas/Sources/Dialogs/NewProjectDialog.swift
+++ b/Alas/Sources/Dialogs/NewProjectDialog.swift
@@ -123,6 +123,7 @@ private struct ProjectDialog: View {
                                     }
                                     .buttonStyle(.plain)
                                     .help("Choose a host from ~/.ssh/config")
+                                    .accessibilityLabel("Choose SSH host")
                                     .popover(isPresented: $showHostPicker, arrowEdge: .bottom) {
                                         SSHHostPicker(
                                             host: $sshHost,

--- a/Alas/Sources/Dialogs/SSHHostPicker.swift
+++ b/Alas/Sources/Dialogs/SSHHostPicker.swift
@@ -1,0 +1,113 @@
+import SwiftUI
+import AppKit
+
+/// Popover content: pick an SSH host from `~/.ssh/config`, or fall back to
+/// free-text with guidance for hosts that aren't configured.
+struct SSHHostPicker: View {
+    @Binding var host: String
+    let hosts: [SSHConfigHost]
+    let isLoading: Bool
+    @Binding var isPresented: Bool
+
+    @Environment(\.theme) var theme
+    @State private var search = ""
+
+    private var filtered: [SSHConfigHost] {
+        SSHHostSuggestions.filter(hosts, query: search)
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            AlasField(text: $search, placeholder: "Search hosts…", focusOnAppear: true)
+                .padding(8)
+            Divider().background(theme.color("line"))
+
+            if isLoading {
+                Text("Reading ~/.ssh/config…")
+                    .font(.system(size: 12))
+                    .foregroundColor(theme.color("fg-dim"))
+                    .padding(12)
+            } else if filtered.isEmpty {
+                guidanceFooter
+            } else {
+                ScrollView {
+                    LazyVStack(alignment: .leading, spacing: 0) {
+                        ForEach(filtered) { host in
+                            row(host)
+                        }
+                    }
+                }
+                .frame(maxHeight: 260)
+            }
+        }
+        .frame(width: 320)
+    }
+
+    @ViewBuilder
+    private func row(_ configHost: SSHConfigHost) -> some View {
+        Button(action: {
+            host = configHost.alias
+            isPresented = false
+        }) {
+            HStack(spacing: 8) {
+                Image(systemName: "checkmark")
+                    .font(.system(size: 10, weight: .semibold))
+                    .foregroundColor(theme.color("fg"))
+                    .opacity(configHost.alias == host ? 1 : 0)
+                VStack(alignment: .leading, spacing: 1) {
+                    Text(configHost.alias)
+                        .font(.system(size: 12.5, weight: .semibold, design: .monospaced))
+                        .foregroundColor(theme.color("fg"))
+                        .lineLimit(1)
+                        .truncationMode(.middle)
+                    if let subtitle = configHost.subtitle {
+                        Text(subtitle)
+                            .font(.system(size: 11, design: .monospaced))
+                            .foregroundColor(theme.color("fg-faint"))
+                            .lineLimit(1)
+                            .truncationMode(.middle)
+                    }
+                }
+                Spacer(minLength: 0)
+            }
+            .padding(.horizontal, 10)
+            .padding(.vertical, 6)
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+    }
+
+    private var guidanceFooter: some View {
+        VStack(alignment: .leading, spacing: 7) {
+            Text("No match in ~/.ssh/config. Type any user@host directly, or add an entry:")
+                .font(.system(size: 11))
+                .foregroundColor(theme.color("fg-dim"))
+                .fixedSize(horizontal: false, vertical: true)
+            let snippet = SSHHostSuggestions.snippet(for: search)
+            HStack(alignment: .top, spacing: 8) {
+                Text(snippet)
+                    .font(.system(size: 11, design: .monospaced))
+                    .foregroundColor(theme.color("fg"))
+                    .textSelection(.enabled)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                Button(action: {
+                    NSPasteboard.general.clearContents()
+                    NSPasteboard.general.setString(snippet, forType: .string)
+                }) {
+                    Text("Copy")
+                        .font(.system(size: 10))
+                        .foregroundColor(theme.color("fg-dim"))
+                        .padding(.horizontal, 6)
+                        .padding(.vertical, 2)
+                        .overlay(RoundedRectangle(cornerRadius: 4)
+                            .strokeBorder(theme.color("line"), lineWidth: 0.5))
+                }
+                .buttonStyle(.plain)
+            }
+            .padding(8)
+            .background(theme.color("bg-0"))
+            .clipShape(RoundedRectangle(cornerRadius: 6))
+        }
+        .padding(12)
+    }
+}

--- a/Alas/Sources/Dialogs/SSHHostPicker.swift
+++ b/Alas/Sources/Dialogs/SSHHostPicker.swift
@@ -32,8 +32,8 @@ struct SSHHostPicker: View {
             } else {
                 ScrollView {
                     LazyVStack(alignment: .leading, spacing: 0) {
-                        ForEach(filtered) { host in
-                            row(host)
+                        ForEach(filtered) { configHost in
+                            row(configHost)
                         }
                     }
                 }
@@ -79,7 +79,9 @@ struct SSHHostPicker: View {
 
     private var guidanceFooter: some View {
         VStack(alignment: .leading, spacing: 7) {
-            Text("No match in ~/.ssh/config. Type any user@host directly, or add an entry:")
+            Text(hosts.isEmpty
+                ? "No hosts found in ~/.ssh/config. Type any user@host directly, or add an entry:"
+                : "No match in ~/.ssh/config. Type any user@host directly, or add an entry:")
                 .font(.system(size: 11))
                 .foregroundColor(theme.color("fg-dim"))
                 .fixedSize(horizontal: false, vertical: true)

--- a/Alas/Sources/Dialogs/SSHHostSuggestions.swift
+++ b/Alas/Sources/Dialogs/SSHHostSuggestions.swift
@@ -27,13 +27,26 @@ enum SSHHostSuggestions {
     }
 
     /// A ready-to-paste `~/.ssh/config` stanza seeded with the typed name.
+    /// A `user@host` entry is split into `User`/`Host`, since OpenSSH matches
+    /// `Host` against the host part only and takes the user separately.
     static func snippet(for name: String) -> String {
         let trimmed = name.trimmingCharacters(in: .whitespaces)
-        let alias = trimmed.isEmpty ? "<name>" : trimmed
+        var user: String?
+        var host = trimmed
+        if let at = trimmed.firstIndex(of: "@") {
+            let hostPart = String(trimmed[trimmed.index(after: at)...])
+            if !hostPart.isEmpty {
+                let userPart = String(trimmed[..<at])
+                if !userPart.isEmpty { user = userPart }
+                host = hostPart
+            }
+        }
+        let hostLine = host.isEmpty ? "<name>" : host
+        let userLine = user ?? "<you>"
         return """
-        Host \(alias)
+        Host \(hostLine)
             HostName <server-address>
-            User <you>
+            User \(userLine)
         """
     }
 }

--- a/Alas/Sources/Dialogs/SSHHostSuggestions.swift
+++ b/Alas/Sources/Dialogs/SSHHostSuggestions.swift
@@ -1,0 +1,39 @@
+import Foundation
+
+extension SSHConfigHost {
+    /// "user@hostname:port", omitting whichever parts are absent.
+    var subtitle: String? {
+        var base: String?
+        switch (user, hostName) {
+        case let (u?, h?): base = "\(u)@\(h)"
+        case let (nil, h?): base = h
+        case let (u?, nil): base = u
+        case (nil, nil): base = nil
+        }
+        guard var result = base else { return nil }
+        if let port { result += ":\(port)" }
+        return result
+    }
+}
+
+enum SSHHostSuggestions {
+    static func filter(_ hosts: [SSHConfigHost], query: String) -> [SSHConfigHost] {
+        let q = query.trimmingCharacters(in: .whitespaces)
+        guard !q.isEmpty else { return hosts }
+        return hosts.filter {
+            $0.alias.localizedCaseInsensitiveContains(q)
+                || ($0.hostName?.localizedCaseInsensitiveContains(q) ?? false)
+        }
+    }
+
+    /// A ready-to-paste `~/.ssh/config` stanza seeded with the typed name.
+    static func snippet(for name: String) -> String {
+        let trimmed = name.trimmingCharacters(in: .whitespaces)
+        let alias = trimmed.isEmpty ? "<name>" : trimmed
+        return """
+        Host \(alias)
+            HostName <server-address>
+            User <you>
+        """
+    }
+}

--- a/Alas/Sources/SSH/SSHConfigParser.swift
+++ b/Alas/Sources/SSH/SSHConfigParser.swift
@@ -131,35 +131,42 @@ enum SSHConfigParser {
     }
 
     /// Splits a directive value into arguments the way ssh_config does:
-    /// double quotes group an argument containing spaces (and are removed),
-    /// and a backslash escapes a following space, tab, quote, or backslash
-    /// (so `Application\ Support` stays one token). Other backslashes are
-    /// preserved literally.
+    /// single or double quotes group an argument containing spaces (and are
+    /// removed — a quote of the other kind inside stays literal), and a
+    /// backslash escapes a following space, tab, quote, or backslash (so
+    /// `Application\ Support` stays one token). Other backslashes are kept.
     private static func tokenize(_ value: String) -> [String] {
         let chars = Array(value)
         var tokens: [String] = []
         var current = ""
         var hasToken = false
-        var inQuotes = false
+        var quoteChar: Character?
         var i = 0
         while i < chars.count {
             let ch = chars[i]
             if ch == "\\", i + 1 < chars.count {
                 let next = chars[i + 1]
-                if next == " " || next == "\t" || next == "\"" || next == "\\" {
+                if next == " " || next == "\t" || next == "\"" || next == "'" || next == "\\" {
                     current.append(next)
                     hasToken = true
                     i += 2
                     continue
                 }
             }
-            if ch == "\"" {
-                inQuotes.toggle()
+            if let open = quoteChar {
+                if ch == open {
+                    quoteChar = nil
+                    hasToken = true
+                    i += 1
+                    continue
+                }
+            } else if ch == "\"" || ch == "'" {
+                quoteChar = ch
                 hasToken = true
                 i += 1
                 continue
             }
-            if (ch == " " || ch == "\t") && !inQuotes {
+            if (ch == " " || ch == "\t") && quoteChar == nil {
                 if hasToken {
                     tokens.append(current)
                     current = ""

--- a/Alas/Sources/SSH/SSHConfigParser.swift
+++ b/Alas/Sources/SSH/SSHConfigParser.swift
@@ -1,0 +1,139 @@
+import Foundation
+import Darwin
+
+/// One selectable host alias parsed from `~/.ssh/config`.
+struct SSHConfigHost: Identifiable, Equatable {
+    let alias: String
+    var hostName: String?
+    var user: String?
+    var port: Int?
+    var id: String { alias }
+}
+
+/// Parses `~/.ssh/config` into pickable host aliases. Read-only, no side effects.
+enum SSHConfigParser {
+    private static let maxIncludeDepth = 16
+
+    static func parse(
+        home: URL,
+        configPath: URL? = nil,
+        fileManager: FileManager = .default
+    ) -> [SSHConfigHost] {
+        let root = configPath ?? home.appendingPathComponent(".ssh/config")
+        var hosts: [SSHConfigHost] = []
+        var seenAliases = Set<String>()
+        var visitedFiles = Set<String>()
+        parseFile(root, home: home, fileManager: fileManager,
+                  hosts: &hosts, seenAliases: &seenAliases,
+                  visitedFiles: &visitedFiles, depth: 0)
+        return hosts
+    }
+
+    private static func parseFile(
+        _ url: URL,
+        home: URL,
+        fileManager: FileManager,
+        hosts: inout [SSHConfigHost],
+        seenAliases: inout Set<String>,
+        visitedFiles: inout Set<String>,
+        depth: Int
+    ) {
+        guard depth <= maxIncludeDepth else { return }
+        let canonical = url.standardizedFileURL.resolvingSymlinksInPath().path
+        guard !visitedFiles.contains(canonical) else { return }
+        visitedFiles.insert(canonical)
+
+        guard let contents = try? String(contentsOf: url, encoding: .utf8) else { return }
+
+        var stanza: [Int] = []   // indices into `hosts` for the current Host stanza
+
+        for rawLine in contents.split(separator: "\n", omittingEmptySubsequences: false) {
+            let line = rawLine.trimmingCharacters(in: .whitespaces)
+            if line.isEmpty || line.hasPrefix("#") { continue }
+            guard let (keyword, value) = splitKeyword(line) else { continue }
+
+            switch keyword.lowercased() {
+            case "host":
+                stanza = []
+                for token in tokenize(value) where isPlainAlias(token) {
+                    guard !seenAliases.contains(token) else { continue }
+                    seenAliases.insert(token)
+                    hosts.append(SSHConfigHost(alias: token, hostName: nil, user: nil, port: nil))
+                    stanza.append(hosts.count - 1)
+                }
+            case "hostname":
+                if let v = tokenize(value).first {
+                    for i in stanza where hosts[i].hostName == nil { hosts[i].hostName = v }
+                }
+            case "user":
+                if let v = tokenize(value).first {
+                    for i in stanza where hosts[i].user == nil { hosts[i].user = v }
+                }
+            case "port":
+                if let v = tokenize(value).first, let p = Int(v) {
+                    for i in stanza where hosts[i].port == nil { hosts[i].port = p }
+                }
+            case "include":
+                for pattern in tokenize(value) {
+                    for file in expandInclude(pattern, home: home, fileManager: fileManager) {
+                        parseFile(file, home: home, fileManager: fileManager,
+                                  hosts: &hosts, seenAliases: &seenAliases,
+                                  visitedFiles: &visitedFiles, depth: depth + 1)
+                    }
+                }
+            default:
+                continue
+            }
+        }
+    }
+
+    /// Splits "Keyword value" or "Keyword=value"; nil for blank keywords.
+    private static func splitKeyword(_ line: String) -> (String, String)? {
+        let scalars = Array(line.unicodeScalars)
+        let isSep: (Unicode.Scalar) -> Bool = { $0 == " " || $0 == "\t" || $0 == "=" }
+        guard let sep = scalars.firstIndex(where: isSep) else {
+            return line.isEmpty ? nil : (line, "")
+        }
+        let key = String(String.UnicodeScalarView(scalars[..<sep]))
+        var rest = scalars[scalars.index(after: sep)...]
+        while let first = rest.first, isSep(first) { rest = rest.dropFirst() }
+        let value = String(String.UnicodeScalarView(rest))
+        return key.isEmpty ? nil : (key, value)
+    }
+
+    private static func tokenize(_ value: String) -> [String] {
+        value.split(whereSeparator: { $0 == " " || $0 == "\t" }).map(String.init)
+    }
+
+    private static func isPlainAlias(_ token: String) -> Bool {
+        !token.isEmpty && !token.hasPrefix("!") && !token.contains("*") && !token.contains("?")
+    }
+
+    /// Resolves an `Include` pattern to concrete files. Supports a glob only in
+    /// the final path component (covers `config.d/*`, `config.d/*.conf`).
+    private static func expandInclude(
+        _ pattern: String, home: URL, fileManager: FileManager
+    ) -> [URL] {
+        var relative = pattern
+        var base: URL
+        if relative.hasPrefix("~/") {
+            base = home
+            relative = String(relative.dropFirst(2))
+        } else if relative.hasPrefix("/") {
+            base = URL(fileURLWithPath: "/")
+            relative = String(relative.dropFirst())
+        } else {
+            base = home.appendingPathComponent(".ssh")   // user-config relative Includes → ~/.ssh
+        }
+        let comps = relative.split(separator: "/").map(String.init)
+        guard let last = comps.last else { return [] }
+        let dir = comps.dropLast().reduce(base) { $0.appendingPathComponent($1) }
+        if last.contains("*") || last.contains("?") {
+            guard let entries = try? fileManager.contentsOfDirectory(atPath: dir.path) else { return [] }
+            return entries.sorted()
+                .filter { fnmatch(last, $0, 0) == 0 }
+                .map { dir.appendingPathComponent($0) }
+        }
+        return [dir.appendingPathComponent(last)]
+    }
+}

--- a/Alas/Sources/SSH/SSHConfigParser.swift
+++ b/Alas/Sources/SSH/SSHConfigParser.swift
@@ -48,8 +48,9 @@ enum SSHConfigParser {
         var stanza: [Int] = []   // indices into `hosts` for the current Host stanza
 
         for rawLine in contents.components(separatedBy: .newlines) {
-            let line = rawLine.trimmingCharacters(in: .whitespacesAndNewlines)
-            if line.isEmpty || line.hasPrefix("#") { continue }
+            let trimmed = rawLine.trimmingCharacters(in: .whitespacesAndNewlines)
+            let line = stripInlineComment(trimmed)
+            if line.isEmpty { continue }
             guard let (keyword, value) = splitKeyword(line) else { continue }
 
             switch keyword.lowercased() {
@@ -99,6 +100,22 @@ enum SSHConfigParser {
         while let first = rest.first, isSep(first) { rest = rest.dropFirst() }
         let value = String(String.UnicodeScalarView(rest))
         return key.isEmpty ? nil : (key, value)
+    }
+
+    /// Removes an inline `# comment`. OpenSSH treats an unquoted `#` that
+    /// starts a token as the beginning of a comment; we don't track quotes,
+    /// so we strip from the first `#` at the start of the line or following
+    /// whitespace (a mid-token `#`, e.g. `foo#bar`, is preserved).
+    private static func stripInlineComment(_ line: String) -> String {
+        var prevWasSpace = true   // start of line is a token boundary
+        for (offset, scalar) in line.unicodeScalars.enumerated() {
+            if scalar == "#" && prevWasSpace {
+                let idx = line.unicodeScalars.index(line.unicodeScalars.startIndex, offsetBy: offset)
+                return String(line.unicodeScalars[..<idx]).trimmingCharacters(in: .whitespaces)
+            }
+            prevWasSpace = (scalar == " " || scalar == "\t")
+        }
+        return line
     }
 
     private static func tokenize(_ value: String) -> [String] {

--- a/Alas/Sources/SSH/SSHConfigParser.swift
+++ b/Alas/Sources/SSH/SSHConfigParser.swift
@@ -130,8 +130,50 @@ enum SSHConfigParser {
         return line
     }
 
+    /// Splits a directive value into arguments the way ssh_config does:
+    /// double quotes group an argument containing spaces (and are removed),
+    /// and a backslash escapes a following space, tab, quote, or backslash
+    /// (so `Application\ Support` stays one token). Other backslashes are
+    /// preserved literally.
     private static func tokenize(_ value: String) -> [String] {
-        value.split(whereSeparator: { $0 == " " || $0 == "\t" }).map(String.init)
+        let chars = Array(value)
+        var tokens: [String] = []
+        var current = ""
+        var hasToken = false
+        var inQuotes = false
+        var i = 0
+        while i < chars.count {
+            let ch = chars[i]
+            if ch == "\\", i + 1 < chars.count {
+                let next = chars[i + 1]
+                if next == " " || next == "\t" || next == "\"" || next == "\\" {
+                    current.append(next)
+                    hasToken = true
+                    i += 2
+                    continue
+                }
+            }
+            if ch == "\"" {
+                inQuotes.toggle()
+                hasToken = true
+                i += 1
+                continue
+            }
+            if (ch == " " || ch == "\t") && !inQuotes {
+                if hasToken {
+                    tokens.append(current)
+                    current = ""
+                    hasToken = false
+                }
+                i += 1
+                continue
+            }
+            current.append(ch)
+            hasToken = true
+            i += 1
+        }
+        if hasToken { tokens.append(current) }
+        return tokens
     }
 
     private static func isPlainAlias(_ token: String) -> Bool {

--- a/Alas/Sources/SSH/SSHConfigParser.swift
+++ b/Alas/Sources/SSH/SSHConfigParser.swift
@@ -22,10 +22,10 @@ enum SSHConfigParser {
         let root = configPath ?? home.appendingPathComponent(".ssh/config")
         var hosts: [SSHConfigHost] = []
         var seenAliases = Set<String>()
-        var visitedFiles = Set<String>()
+        var activeFiles = Set<String>()
         parseFile(root, home: home, fileManager: fileManager, guards: [],
                   hosts: &hosts, seenAliases: &seenAliases,
-                  visitedFiles: &visitedFiles, depth: 0)
+                  activeFiles: &activeFiles, depth: 0)
         return hosts
     }
 
@@ -41,13 +41,18 @@ enum SSHConfigParser {
         guards: [[String]],
         hosts: inout [SSHConfigHost],
         seenAliases: inout Set<String>,
-        visitedFiles: inout Set<String>,
+        activeFiles: inout Set<String>,
         depth: Int
     ) {
         guard depth <= maxIncludeDepth else { return }
+        // Recursion-stack cycle guard: block only files that are ancestors in
+        // the current Include chain, and release on exit. The same file may be
+        // included from several contexts (e.g. under different `Host` guards),
+        // and each must be re-parsed so guard-filtered aliases aren't lost.
         let canonical = url.standardizedFileURL.resolvingSymlinksInPath().path
-        guard !visitedFiles.contains(canonical) else { return }
-        visitedFiles.insert(canonical)
+        guard !activeFiles.contains(canonical) else { return }
+        activeFiles.insert(canonical)
+        defer { activeFiles.remove(canonical) }
 
         guard let contents = try? String(contentsOf: url, encoding: .utf8) else { return }
 
@@ -102,7 +107,7 @@ enum SSHConfigParser {
                     for file in expandInclude(pattern, home: home, fileManager: fileManager) {
                         parseFile(file, home: home, fileManager: fileManager, guards: includeGuards,
                                   hosts: &hosts, seenAliases: &seenAliases,
-                                  visitedFiles: &visitedFiles, depth: depth + 1)
+                                  activeFiles: &activeFiles, depth: depth + 1)
                     }
                 }
             default:

--- a/Alas/Sources/SSH/SSHConfigParser.swift
+++ b/Alas/Sources/SSH/SSHConfigParser.swift
@@ -46,6 +46,12 @@ enum SSHConfigParser {
         guard let contents = try? String(contentsOf: url, encoding: .utf8) else { return }
 
         var stanza: [Int] = []   // indices into `hosts` for the current Host stanza
+        // Directives are governed by the most recent Host/Match block. An
+        // `Include` inside a conditional block (any `Host`/`Match` other than
+        // the catch-all `Host *` / `Match all`) only applies when connecting
+        // to a matching host, so those aliases are not usable top-level — we
+        // skip them rather than offer hosts `ssh` would not resolve.
+        var conditionalScope = false
 
         for rawLine in contents.components(separatedBy: .newlines) {
             let trimmed = rawLine.trimmingCharacters(in: .whitespacesAndNewlines)
@@ -56,12 +62,17 @@ enum SSHConfigParser {
             switch keyword.lowercased() {
             case "host":
                 stanza = []
-                for token in tokenize(value) where isPlainAlias(token) {
+                let tokens = tokenize(value)
+                conditionalScope = tokens != ["*"]
+                for token in tokens where isPlainAlias(token) {
                     guard !seenAliases.contains(token) else { continue }
                     seenAliases.insert(token)
                     hosts.append(SSHConfigHost(alias: token, hostName: nil, user: nil, port: nil))
                     stanza.append(hosts.count - 1)
                 }
+            case "match":
+                stanza = []
+                conditionalScope = tokenize(value).map { $0.lowercased() } != ["all"]
             case "hostname":
                 if let v = tokenize(value).first {
                     for i in stanza where hosts[i].hostName == nil { hosts[i].hostName = v }
@@ -75,6 +86,7 @@ enum SSHConfigParser {
                     for i in stanza where hosts[i].port == nil { hosts[i].port = p }
                 }
             case "include":
+                if conditionalScope { continue }
                 for pattern in tokenize(value) {
                     for file in expandInclude(pattern, home: home, fileManager: fileManager) {
                         parseFile(file, home: home, fileManager: fileManager,
@@ -126,8 +138,10 @@ enum SSHConfigParser {
         !token.isEmpty && !token.hasPrefix("!") && !token.contains("*") && !token.contains("?")
     }
 
-    /// Resolves an `Include` pattern to concrete files. Supports a glob only in
-    /// the final path component (covers `config.d/*`, `config.d/*.conf`).
+    /// Resolves an `Include` pattern to concrete files. Globs are expanded in
+    /// every path component (covers `config.d/*`, `config.d/*.conf`, and nested
+    /// `config.d/*/*.conf`); intermediate components only descend into
+    /// directories.
     private static func expandInclude(
         _ pattern: String, home: URL, fileManager: FileManager
     ) -> [URL] {
@@ -143,14 +157,32 @@ enum SSHConfigParser {
             base = home.appendingPathComponent(".ssh")   // user-config relative Includes → ~/.ssh
         }
         let comps = relative.split(separator: "/").map(String.init)
-        guard let last = comps.last else { return [] }
-        let dir = comps.dropLast().reduce(base) { $0.appendingPathComponent($1) }
-        if last.contains("*") || last.contains("?") {
-            guard let entries = try? fileManager.contentsOfDirectory(atPath: dir.path) else { return [] }
-            return entries.sorted()
-                .filter { fnmatch(last, $0, 0) == 0 }
-                .map { dir.appendingPathComponent($0) }
+        guard !comps.isEmpty else { return [] }
+
+        var current = [base]
+        for (index, comp) in comps.enumerated() {
+            let isLast = index == comps.count - 1
+            if comp.contains("*") || comp.contains("?") {
+                var next: [URL] = []
+                for dir in current {
+                    guard let entries = try? fileManager.contentsOfDirectory(atPath: dir.path) else { continue }
+                    for name in entries.sorted() where fnmatch(comp, name, 0) == 0 {
+                        let candidate = dir.appendingPathComponent(name)
+                        if isLast {
+                            next.append(candidate)
+                        } else {
+                            var isDir: ObjCBool = false
+                            if fileManager.fileExists(atPath: candidate.path, isDirectory: &isDir), isDir.boolValue {
+                                next.append(candidate)
+                            }
+                        }
+                    }
+                }
+                current = next
+            } else {
+                current = current.map { $0.appendingPathComponent(comp) }
+            }
         }
-        return [dir.appendingPathComponent(last)]
+        return current
     }
 }

--- a/Alas/Sources/SSH/SSHConfigParser.swift
+++ b/Alas/Sources/SSH/SSHConfigParser.swift
@@ -23,7 +23,7 @@ enum SSHConfigParser {
         var hosts: [SSHConfigHost] = []
         var seenAliases = Set<String>()
         var visitedFiles = Set<String>()
-        parseFile(root, home: home, fileManager: fileManager,
+        parseFile(root, home: home, fileManager: fileManager, guards: [],
                   hosts: &hosts, seenAliases: &seenAliases,
                   visitedFiles: &visitedFiles, depth: 0)
         return hosts
@@ -33,6 +33,12 @@ enum SSHConfigParser {
         _ url: URL,
         home: URL,
         fileManager: FileManager,
+        // Host patterns governing this file's inclusion. An included file
+        // reached through `Host P` blocks carries those patterns; an alias it
+        // defines is only usable (bare `ssh <alias>`) if it matches every
+        // guard, so `Host bastion` → include of `Host internal` is dropped
+        // while `Host *.corp` → include of `Host dev.corp` is kept.
+        guards: [[String]],
         hosts: inout [SSHConfigHost],
         seenAliases: inout Set<String>,
         visitedFiles: inout Set<String>,
@@ -46,12 +52,12 @@ enum SSHConfigParser {
         guard let contents = try? String(contentsOf: url, encoding: .utf8) else { return }
 
         var stanza: [Int] = []   // indices into `hosts` for the current Host stanza
-        // Directives are governed by the most recent Host/Match block. An
-        // `Include` inside a conditional block (any `Host`/`Match` other than
-        // the catch-all `Host *` / `Match all`) only applies when connecting
-        // to a matching host, so those aliases are not usable top-level — we
-        // skip them rather than offer hosts `ssh` would not resolve.
-        var conditionalScope = false
+        // Host patterns of the current block in THIS file (nil at file scope).
+        // Includes nested in a Host block extend the guard passed downward.
+        var currentHostPatterns: [String]?
+        // `Match` conditions depend on runtime state we can't evaluate, so any
+        // Include nested under a Match block is skipped rather than guessed.
+        var inMatchBlock = false
 
         for rawLine in contents.components(separatedBy: .newlines) {
             let trimmed = rawLine.trimmingCharacters(in: .whitespacesAndNewlines)
@@ -63,8 +69,10 @@ enum SSHConfigParser {
             case "host":
                 stanza = []
                 let tokens = tokenize(value)
-                conditionalScope = tokens != ["*"]
+                currentHostPatterns = tokens
+                inMatchBlock = false
                 for token in tokens where isPlainAlias(token) {
+                    guard aliasMatchesGuards(token, guards) else { continue }
                     guard !seenAliases.contains(token) else { continue }
                     seenAliases.insert(token)
                     hosts.append(SSHConfigHost(alias: token, hostName: nil, user: nil, port: nil))
@@ -72,7 +80,8 @@ enum SSHConfigParser {
                 }
             case "match":
                 stanza = []
-                conditionalScope = tokenize(value).map { $0.lowercased() } != ["all"]
+                currentHostPatterns = nil
+                inMatchBlock = true
             case "hostname":
                 if let v = tokenize(value).first {
                     for i in stanza where hosts[i].hostName == nil { hosts[i].hostName = v }
@@ -86,10 +95,12 @@ enum SSHConfigParser {
                     for i in stanza where hosts[i].port == nil { hosts[i].port = p }
                 }
             case "include":
-                if conditionalScope { continue }
+                if inMatchBlock { continue }
+                var includeGuards = guards
+                if let patterns = currentHostPatterns { includeGuards.append(patterns) }
                 for pattern in tokenize(value) {
                     for file in expandInclude(pattern, home: home, fileManager: fileManager) {
-                        parseFile(file, home: home, fileManager: fileManager,
+                        parseFile(file, home: home, fileManager: fileManager, guards: includeGuards,
                                   hosts: &hosts, seenAliases: &seenAliases,
                                   visitedFiles: &visitedFiles, depth: depth + 1)
                     }
@@ -185,6 +196,27 @@ enum SSHConfigParser {
 
     private static func isPlainAlias(_ token: String) -> Bool {
         !token.isEmpty && !token.hasPrefix("!") && !token.contains("*") && !token.contains("?")
+    }
+
+    /// An alias is usable at the top level only if it satisfies every guard
+    /// (the `Host` patterns of the blocks that included its file). An empty
+    /// guard list — the main config — matches everything.
+    private static func aliasMatchesGuards(_ alias: String, _ guards: [[String]]) -> Bool {
+        guards.allSatisfy { hostPatternMatches(alias, $0) }
+    }
+
+    /// OpenSSH host-pattern match: the alias must match a positive pattern and
+    /// no negated (`!`) pattern.
+    private static func hostPatternMatches(_ alias: String, _ patterns: [String]) -> Bool {
+        var matched = false
+        for pattern in patterns {
+            if pattern.hasPrefix("!") {
+                if fnmatch(String(pattern.dropFirst()), alias, 0) == 0 { return false }
+            } else if fnmatch(pattern, alias, 0) == 0 {
+                matched = true
+            }
+        }
+        return matched
     }
 
     /// Resolves an `Include` pattern to concrete files. Globs are expanded in

--- a/Alas/Sources/SSH/SSHConfigParser.swift
+++ b/Alas/Sources/SSH/SSHConfigParser.swift
@@ -47,8 +47,8 @@ enum SSHConfigParser {
 
         var stanza: [Int] = []   // indices into `hosts` for the current Host stanza
 
-        for rawLine in contents.split(separator: "\n", omittingEmptySubsequences: false) {
-            let line = rawLine.trimmingCharacters(in: .whitespaces)
+        for rawLine in contents.components(separatedBy: .newlines) {
+            let line = rawLine.trimmingCharacters(in: .whitespacesAndNewlines)
             if line.isEmpty || line.hasPrefix("#") { continue }
             guard let (keyword, value) = splitKeyword(line) else { continue }
 

--- a/AlasTests/SSH/SSHConfigParserTests.swift
+++ b/AlasTests/SSH/SSHConfigParserTests.swift
@@ -118,4 +118,14 @@ struct SSHConfigParserTests {
         let home = try makeHome(config: "Host crlfbox\r\n    HostName 10.0.0.9\r\n    User me\r\n")
         #expect(SSHConfigParser.parse(home: home) == [SSHConfigHost(alias: "crlfbox", hostName: "10.0.0.9", user: "me", port: nil)])
     }
+
+    @Test func stripsInlineComments() throws {
+        let home = try makeHome(config: """
+        Host devbox # staging box
+            HostName 10.0.0.7 # main interface
+        """)
+        // The inline comments must not become extra aliases or corrupt HostName.
+        #expect(SSHConfigParser.parse(home: home)
+            == [SSHConfigHost(alias: "devbox", hostName: "10.0.0.7", user: nil, port: nil)])
+    }
 }

--- a/AlasTests/SSH/SSHConfigParserTests.swift
+++ b/AlasTests/SSH/SSHConfigParserTests.swift
@@ -1,0 +1,82 @@
+import Foundation
+import Testing
+@testable import Alas
+
+struct SSHConfigParserTests {
+    /// Writes `config` to `<tmp>/.ssh/config` and returns the tmp home dir.
+    private func makeHome(config: String, extraFiles: [String: String] = [:]) throws -> URL {
+        let home = FileManager.default.temporaryDirectory
+            .appendingPathComponent("ssh-config-tests-\(UUID().uuidString)")
+        let ssh = home.appendingPathComponent(".ssh")
+        try FileManager.default.createDirectory(at: ssh, withIntermediateDirectories: true)
+        try config.write(to: ssh.appendingPathComponent("config"), atomically: true, encoding: .utf8)
+        for (rel, contents) in extraFiles {
+            let url = home.appendingPathComponent(rel)
+            try FileManager.default.createDirectory(
+                at: url.deletingLastPathComponent(), withIntermediateDirectories: true)
+            try contents.write(to: url, atomically: true, encoding: .utf8)
+        }
+        return home
+    }
+
+    @Test func parsesAliasWithMetadata() throws {
+        let home = try makeHome(config: """
+        Host devbox
+            HostName 10.0.0.7
+            User me
+            Port 2222
+        """)
+        let hosts = SSHConfigParser.parse(home: home)
+        #expect(hosts == [SSHConfigHost(alias: "devbox", hostName: "10.0.0.7", user: "me", port: 2222)])
+    }
+
+    @Test func multiAliasLineSharesMetadata() throws {
+        let home = try makeHome(config: """
+        Host a b c
+            HostName shared.example.com
+        """)
+        let hosts = SSHConfigParser.parse(home: home)
+        #expect(hosts.map(\.alias) == ["a", "b", "c"])
+        #expect(hosts.allSatisfy { $0.hostName == "shared.example.com" })
+    }
+
+    @Test func skipsWildcardAndNegatedAliases() throws {
+        let home = try makeHome(config: """
+        Host *
+            User default
+        Host prod !staging foo?
+            HostName prod.example.com
+        Host realbox
+            HostName real.example.com
+        """)
+        let hosts = SSHConfigParser.parse(home: home)
+        #expect(hosts.map(\.alias) == ["prod", "realbox"])
+    }
+
+    @Test func missingConfigYieldsEmpty() {
+        let home = FileManager.default.temporaryDirectory
+            .appendingPathComponent("no-ssh-\(UUID().uuidString)")
+        #expect(SSHConfigParser.parse(home: home).isEmpty)
+    }
+
+    @Test func duplicateAliasFirstWins() throws {
+        let home = try makeHome(config: """
+        Host devbox
+            HostName first.example.com
+        Host devbox
+            HostName second.example.com
+        """)
+        let hosts = SSHConfigParser.parse(home: home)
+        #expect(hosts == [SSHConfigHost(alias: "devbox", hostName: "first.example.com", user: nil, port: nil)])
+    }
+
+    @Test func supportsEqualsSeparatorAndComments() throws {
+        let home = try makeHome(config: """
+        # a comment
+        Host=devbox
+            HostName=10.0.0.9
+        """)
+        let hosts = SSHConfigParser.parse(home: home)
+        #expect(hosts == [SSHConfigHost(alias: "devbox", hostName: "10.0.0.9", user: nil, port: nil)])
+    }
+}

--- a/AlasTests/SSH/SSHConfigParserTests.swift
+++ b/AlasTests/SSH/SSHConfigParserTests.swift
@@ -79,4 +79,43 @@ struct SSHConfigParserTests {
         let hosts = SSHConfigParser.parse(home: home)
         #expect(hosts == [SSHConfigHost(alias: "devbox", hostName: "10.0.0.9", user: nil, port: nil)])
     }
+
+    @Test func followsIncludeGlobInOrder() throws {
+        let home = try makeHome(
+            config: """
+            Include config.d/*.conf
+            Host local-tail
+                HostName tail.example.com
+            """,
+            extraFiles: [
+                ".ssh/config.d/10-a.conf": "Host from-a\n    HostName a.example.com\n",
+                ".ssh/config.d/20-b.conf": "Host from-b\n    HostName b.example.com\n",
+                ".ssh/config.d/skip.txt": "Host should-not-load\n",
+            ]
+        )
+        let hosts = SSHConfigParser.parse(home: home)
+        #expect(hosts.map(\.alias) == ["from-a", "from-b", "local-tail"])
+    }
+
+    @Test func expandsTildeInclude() throws {
+        let home = try makeHome(
+            config: "Include ~/.ssh/extra\n",
+            extraFiles: [".ssh/extra": "Host tilde-host\n    HostName t.example.com\n"]
+        )
+        #expect(SSHConfigParser.parse(home: home).map(\.alias) == ["tilde-host"])
+    }
+
+    @Test func includeCycleTerminates() throws {
+        let home = try makeHome(config: "Include config.d/loop\nHost base\n",
+            extraFiles: [".ssh/config.d/loop": "Include ../config\nHost loop-host\n"]
+        )
+        let hosts = SSHConfigParser.parse(home: home)
+        // Terminates (no infinite recursion) and captures each alias once.
+        #expect(Set(hosts.map(\.alias)) == ["base", "loop-host"])
+    }
+
+    @Test func handlesCRLFLineEndings() throws {
+        let home = try makeHome(config: "Host crlfbox\r\n    HostName 10.0.0.9\r\n    User me\r\n")
+        #expect(SSHConfigParser.parse(home: home) == [SSHConfigHost(alias: "crlfbox", hostName: "10.0.0.9", user: "me", port: nil)])
+    }
 }

--- a/AlasTests/SSH/SSHConfigParserTests.swift
+++ b/AlasTests/SSH/SSHConfigParserTests.swift
@@ -164,4 +164,20 @@ struct SSHConfigParserTests {
         // `Host *` is unconditional, so its Include applies to every host.
         #expect(SSHConfigParser.parse(home: home).map(\.alias) == ["common"])
     }
+
+    @Test func stripsQuotesFromHostAlias() throws {
+        let home = try makeHome(config: "Host \"devbox\"\n    HostName 10.0.0.7\n")
+        // Quotes must be removed so the alias matches what `ssh` resolves.
+        #expect(SSHConfigParser.parse(home: home)
+            == [SSHConfigHost(alias: "devbox", hostName: "10.0.0.7", user: nil, port: nil)])
+    }
+
+    @Test func handlesEscapedSpaceInIncludePath() throws {
+        let home = try makeHome(
+            config: "Include dir\\ with\\ space/extra.conf\n",
+            extraFiles: [".ssh/dir with space/extra.conf": "Host from-escaped\n    HostName e.example.com\n"]
+        )
+        // A backslash-escaped space is part of the path, not an argument break.
+        #expect(SSHConfigParser.parse(home: home).map(\.alias) == ["from-escaped"])
+    }
 }

--- a/AlasTests/SSH/SSHConfigParserTests.swift
+++ b/AlasTests/SSH/SSHConfigParserTests.swift
@@ -176,6 +176,26 @@ struct SSHConfigParserTests {
         #expect(hosts.first?.hostName == "10.2.2.2")
     }
 
+    @Test func reparsesSharedIncludeUnderDifferentGuards() throws {
+        let home = try makeHome(
+            config: """
+            Host *.corp
+                Include shared
+            Host *.prod
+                Include shared
+            """,
+            extraFiles: [".ssh/shared": """
+            Host app.corp
+                HostName 10.1.1.1
+            Host app.prod
+                HostName 10.2.2.2
+            """]
+        )
+        // The shared file is included under two different guards; the global
+        // visited-file skip must not drop the alias matching the second guard.
+        #expect(Set(SSHConfigParser.parse(home: home).map(\.alias)) == ["app.corp", "app.prod"])
+    }
+
     @Test func followsIncludeUnderWildcardHost() throws {
         let home = try makeHome(
             config: "Host *\n    Include common.conf\n",

--- a/AlasTests/SSH/SSHConfigParserTests.swift
+++ b/AlasTests/SSH/SSHConfigParserTests.swift
@@ -156,6 +156,26 @@ struct SSHConfigParserTests {
         #expect(SSHConfigParser.parse(home: home).map(\.alias) == ["top", "bastion"])
     }
 
+    @Test func keepsHostScopedIncludeAliasesMatchingGuard() throws {
+        let home = try makeHome(
+            config: """
+            Host *.corp
+                Include corp
+            """,
+            extraFiles: [".ssh/corp": """
+            Host dev.corp
+                HostName 10.2.2.2
+            Host other.example
+                HostName 10.3.3.3
+            """]
+        )
+        // `dev.corp` matches the guarding `*.corp` pattern and is usable via
+        // bare `ssh dev.corp`; `other.example` does not match and is dropped.
+        let hosts = SSHConfigParser.parse(home: home)
+        #expect(hosts.map(\.alias) == ["dev.corp"])
+        #expect(hosts.first?.hostName == "10.2.2.2")
+    }
+
     @Test func followsIncludeUnderWildcardHost() throws {
         let home = try makeHome(
             config: "Host *\n    Include common.conf\n",

--- a/AlasTests/SSH/SSHConfigParserTests.swift
+++ b/AlasTests/SSH/SSHConfigParserTests.swift
@@ -128,4 +128,40 @@ struct SSHConfigParserTests {
         #expect(SSHConfigParser.parse(home: home)
             == [SSHConfigHost(alias: "devbox", hostName: "10.0.0.7", user: nil, port: nil)])
     }
+
+    @Test func expandsGlobInEveryIncludeComponent() throws {
+        let home = try makeHome(
+            config: "Include config.d/*/*.conf\n",
+            extraFiles: [
+                ".ssh/config.d/providerA/prod.conf": "Host a-prod\n    HostName a.example.com\n",
+                ".ssh/config.d/providerB/prod.conf": "Host b-prod\n    HostName b.example.com\n",
+                ".ssh/config.d/providerA/notes.txt": "Host should-not-load\n",
+            ]
+        )
+        #expect(Set(SSHConfigParser.parse(home: home).map(\.alias)) == ["a-prod", "b-prod"])
+    }
+
+    @Test func skipsIncludeInsideConditionalHostBlock() throws {
+        let home = try makeHome(
+            config: """
+            Host top
+                HostName top.example.com
+            Host bastion
+                Include bastion.conf
+            """,
+            extraFiles: [".ssh/bastion.conf": "Host internal\n    HostName 10.1.1.1\n"]
+        )
+        // `internal` is conditionally included under `Host bastion`, so it is
+        // not a usable top-level alias and must not appear in the picker.
+        #expect(SSHConfigParser.parse(home: home).map(\.alias) == ["top", "bastion"])
+    }
+
+    @Test func followsIncludeUnderWildcardHost() throws {
+        let home = try makeHome(
+            config: "Host *\n    Include common.conf\n",
+            extraFiles: [".ssh/common.conf": "Host common\n    HostName c.example.com\n"]
+        )
+        // `Host *` is unconditional, so its Include applies to every host.
+        #expect(SSHConfigParser.parse(home: home).map(\.alias) == ["common"])
+    }
 }

--- a/AlasTests/SSH/SSHConfigParserTests.swift
+++ b/AlasTests/SSH/SSHConfigParserTests.swift
@@ -180,4 +180,16 @@ struct SSHConfigParserTests {
         // A backslash-escaped space is part of the path, not an argument break.
         #expect(SSHConfigParser.parse(home: home).map(\.alias) == ["from-escaped"])
     }
+
+    @Test func stripsSingleQuotesFromTokens() throws {
+        let home = try makeHome(
+            config: "Include 'extra hosts.conf'\nHost 'devbox'\n    HostName 10.0.0.7\n",
+            extraFiles: [".ssh/extra hosts.conf": "Host from-sq\n    HostName s.example.com\n"]
+        )
+        // OpenSSH strips single quotes too: the alias and the quoted Include
+        // path with a space must both resolve unquoted.
+        let hosts = SSHConfigParser.parse(home: home)
+        #expect(hosts.map(\.alias) == ["from-sq", "devbox"])
+        #expect(hosts.first(where: { $0.alias == "devbox" })?.hostName == "10.0.0.7")
+    }
 }

--- a/AlasTests/SSH/SSHHostSuggestionsTests.swift
+++ b/AlasTests/SSH/SSHHostSuggestionsTests.swift
@@ -28,4 +28,11 @@ struct SSHHostSuggestionsTests {
         #expect(SSHHostSuggestions.snippet(for: "staging42").contains("Host staging42"))
         #expect(SSHHostSuggestions.snippet(for: "  ").contains("Host <name>"))
     }
+
+    @Test func snippetSplitsUserFromHost() {
+        let s = SSHHostSuggestions.snippet(for: "me@dev")
+        #expect(s.contains("Host dev"))
+        #expect(s.contains("User me"))
+        #expect(!s.contains("me@dev"))
+    }
 }

--- a/AlasTests/SSH/SSHHostSuggestionsTests.swift
+++ b/AlasTests/SSH/SSHHostSuggestionsTests.swift
@@ -1,0 +1,31 @@
+import Foundation
+import Testing
+@testable import Alas
+
+struct SSHHostSuggestionsTests {
+    @Test func subtitleCombinesUserHostPort() {
+        #expect(SSHConfigHost(alias: "a", hostName: "h.example.com", user: "me", port: 2222).subtitle
+            == "me@h.example.com:2222")
+    }
+
+    @Test func subtitleOmitsMissingParts() {
+        #expect(SSHConfigHost(alias: "a", hostName: "h.example.com", user: nil, port: nil).subtitle
+            == "h.example.com")
+        #expect(SSHConfigHost(alias: "a", hostName: nil, user: nil, port: nil).subtitle == nil)
+    }
+
+    @Test func filterMatchesAliasAndHostName() {
+        let hosts = [
+            SSHConfigHost(alias: "devbox", hostName: "10.0.0.7", user: nil, port: nil),
+            SSHConfigHost(alias: "prod", hostName: "app.example.com", user: nil, port: nil),
+        ]
+        #expect(SSHHostSuggestions.filter(hosts, query: "dev").map(\.alias) == ["devbox"])
+        #expect(SSHHostSuggestions.filter(hosts, query: "example").map(\.alias) == ["prod"])
+        #expect(SSHHostSuggestions.filter(hosts, query: "  ").map(\.alias) == ["devbox", "prod"])
+    }
+
+    @Test func snippetSeedsHostName() {
+        #expect(SSHHostSuggestions.snippet(for: "staging42").contains("Host staging42"))
+        #expect(SSHHostSuggestions.snippet(for: "  ").contains("Host <name>"))
+    }
+}


### PR DESCRIPTION
## What

Adds an SSH host picker to the **Add project → Remote (SSH)** dialog. Instead of hand-typing the ssh host, you can now pick it from a searchable popover sourced from `~/.ssh/config`. Free-text `user@host` entry stays primary for hosts not in the config.

## Why

Remote projects (#738) required typing the ssh host name by hand into a plain field. This makes the common case (a host already in `~/.ssh/config`) a one-click pick, and guides users whose host isn't configured yet.

## How

- **`SSHConfigParser`** (new, `Alas/Sources/SSH/`) — pure, injectable parser of `~/.ssh/config`. Extracts `Host` aliases + `HostName`/`User`/`Port`, follows `Include` directives (glob + `~` expansion, cycle-safe), skips wildcard/pattern entries (`*`, `?`, leading `!`), de-dupes first-wins. Reads only — never writes the config.
- **`SSHHostSuggestions`** (new, `Alas/Sources/Dialogs/`) — pure helpers: `subtitle` (`user@host:port`), search `filter`, and a copy-paste `~/.ssh/config` snippet for hosts not yet configured.
- **`SSHHostPicker`** (new) — popover (modeled on `BranchPicker`): search field, host list with metadata subtitles, and a guidance footer with a copyable snippet when nothing matches.
- **`NewProjectDialog`** — the Remote (SSH) host field gains a browse (☰) button that opens the picker; hosts are parsed off the main actor when it opens. The field stays free-text and editable; edit-mode, validation, and `addProject(host:)` are unchanged.

## Scope

- Read-only over `~/.ssh/config`; the app never modifies it (guidance snippet only).
- No `known_hosts` scraping; no edit-mode changes.

## Tests

14 Swift Testing unit tests across the parser (aliases, metadata, wildcard/negation exclusion, dedup, `Include` glob/`~`/cycle, CRLF, missing file) and the suggestion helpers (subtitle/filter/snippet). The popover view is build-verified.