### PR TITLE
fix(anr): Cap Mason extension install options

### DIFF
--- a/Alas/Sources/Code/Editor/InstallNudgeResolver.swift
+++ b/Alas/Sources/Code/Editor/InstallNudgeResolver.swift
@@ -103,19 +103,24 @@ struct InstallNudgeResolver {
         guard !dismissedInstallNudges.contains(dismissalKey) else { return nil }
         guard !registry.disabledUserDefinedEntryClaims(fileExtension: ext) else { return nil }
 
-        let options = masonSnapshot.packages(forFileExtension: ext).compactMap { package -> InstallNudgeOption? in
-            guard !package.recipes.isEmpty else { return nil }
+        var options: [InstallNudgeOption] = []
+        var seenPackageIds = Set<String>()
+        options.reserveCapacity(MasonSnapshot.maxResults)
+        for package in masonSnapshot.packages(forFileExtension: ext) {
+            guard !package.recipes.isEmpty else { continue }
             let available = installerHost.allAvailable(in: package.recipes)
-            guard !available.isEmpty else { return nil }
+            guard !available.isEmpty else { continue }
             let config = LanguageServerConfig.prefilled(from: package)
-            guard availabilityStatus(config) == .notInstalled else { return nil }
-            return InstallNudgeOption(
+            guard availabilityStatus(config) == .notInstalled else { continue }
+            guard seenPackageIds.insert(package.masonId).inserted else { continue }
+            options.append(InstallNudgeOption(
                 package: package,
                 language: config.language,
                 displayName: package.displayName,
                 command: config.command,
                 available: available
-            )
+            ))
+            if options.count >= MasonSnapshot.maxResults { break }
         }
         guard let selected = options.first else { return nil }
 

--- a/AlasTests/Code/LSP/Install/MasonSnapshotTests.swift
+++ b/AlasTests/Code/LSP/Install/MasonSnapshotTests.swift
@@ -123,6 +123,21 @@ struct MasonSnapshotTests {
         ])
     }
 
+    @Test("packages for extension returns all ranked matches")
+    func packagesForExtensionReturnsAllRankedMatches() {
+        let packages = (0..<(MasonSnapshot.maxResults + 10)).flatMap { idx in
+            [
+                package(id: "pkg-\(idx)", languageId: "bar", extensions: ["foo"]),
+                package(id: "pkg-\(idx)", languageId: "bar", extensions: ["foo"]),
+            ]
+        }
+        let snap = MasonSnapshot(packages: packages)
+
+        let results = snap.packages(forFileExtension: "foo")
+
+        #expect(results.count == (MasonSnapshot.maxResults + 10) * 2)
+    }
+
     private func package(
         id: String,
         languageId: String,

--- a/AlasTests/Code/LSP/InstallNudgeResolverTests.swift
+++ b/AlasTests/Code/LSP/InstallNudgeResolverTests.swift
@@ -161,6 +161,93 @@ struct InstallNudgeResolverTests {
         #expect(resolver.nudgeData(forAbsolutePath: "/tmp/app.js") == nil)
     }
 
+    @Test("Mason fallback scans past unavailable matches before selecting")
+    func masonFallbackScansPastUnavailableMatchesBeforeSelecting() {
+        let skipped = (0..<(MasonSnapshot.maxResults + 5)).map { idx in
+            package(
+                id: String(format: "a-skip-%02d", idx),
+                languageId: "bar",
+                extensions: ["foo"],
+                command: String(format: "a-skip-%02d", idx)
+            )
+        }
+        let installable = package(
+            id: "z-installable",
+            languageId: "bar",
+            extensions: ["foo"],
+            command: "z-installable"
+        )
+        let resolver = InstallNudgeResolver(
+            registry: LanguageServerRegistry(userDefined: []),
+            userDefinedRecipes: [:],
+            dismissedInstallNudges: [],
+            installerHost: InstallerHost(detected: [.brew: DetectedInstaller(kind: .brew, executable: "/opt/homebrew/bin/brew")]),
+            masonSnapshot: MasonSnapshot(packages: skipped + [installable]),
+            availabilityStatus: { config in
+                config.command.hasPrefix("a-skip-") ? .available : .notInstalled
+            }
+        )
+
+        let nudge = resolver.nudgeData(forAbsolutePath: "/tmp/file.foo")
+
+        #expect(nudge?.masonPackage?.masonId == "z-installable")
+    }
+
+    @Test("Mason fallback caps installable options")
+    func masonFallbackCapsInstallableOptions() {
+        let packages = (0..<(MasonSnapshot.maxResults + 10)).map { idx in
+            package(
+                id: String(format: "pkg-%02d", idx),
+                languageId: "bar",
+                extensions: ["foo"],
+                command: String(format: "pkg-%02d", idx)
+            )
+        }
+        let resolver = InstallNudgeResolver(
+            registry: LanguageServerRegistry(userDefined: []),
+            userDefinedRecipes: [:],
+            dismissedInstallNudges: [],
+            installerHost: InstallerHost(detected: [.brew: DetectedInstaller(kind: .brew, executable: "/opt/homebrew/bin/brew")]),
+            masonSnapshot: MasonSnapshot(packages: packages),
+            availabilityStatus: { _ in .notInstalled }
+        )
+
+        let nudge = resolver.nudgeData(forAbsolutePath: "/tmp/file.foo")
+
+        #expect(nudge?.masonOptions.count == MasonSnapshot.maxResults)
+    }
+
+    @Test("Mason fallback deduplicates after installability filtering")
+    func masonFallbackDeduplicatesAfterInstallabilityFiltering() {
+        let alreadyAvailable = package(
+            id: "duplicate",
+            languageId: "bar",
+            extensions: ["foo"],
+            command: "already-available"
+        )
+        let installable = package(
+            id: "duplicate",
+            languageId: "bar",
+            extensions: ["foo"],
+            command: "installable"
+        )
+        let resolver = InstallNudgeResolver(
+            registry: LanguageServerRegistry(userDefined: []),
+            userDefinedRecipes: [:],
+            dismissedInstallNudges: [],
+            installerHost: InstallerHost(detected: [.brew: DetectedInstaller(kind: .brew, executable: "/opt/homebrew/bin/brew")]),
+            masonSnapshot: MasonSnapshot(packages: [alreadyAvailable, installable]),
+            availabilityStatus: { config in
+                config.command == "already-available" ? .available : .notInstalled
+            }
+        )
+
+        let nudge = resolver.nudgeData(forAbsolutePath: "/tmp/file.foo")
+
+        #expect(nudge?.command == "installable")
+        #expect(nudge?.masonOptions.map(\.id) == ["duplicate"])
+    }
+
     private func package(
         id: String,
         languageId: String,


### PR DESCRIPTION
## Summary

- cap the install nudge menu to `MasonSnapshot.maxResults` after recipe, installer, availability, and duplicate filtering
- keep Mason extension lookup ranked and complete so later installable matches are not hidden by earlier unavailable ones
- add regression coverage for late installable matches, duplicate package IDs, and capped final menu options

## Root Cause

The install nudge menu picker is fed by Mason extension lookup results. The menu needed a bounded, stable option set, but capping or deduplicating before installability filtering can hide a later package that is actually installable. The corrected flow scans the ranked Mason matches, filters for installable options, deduplicates only surviving options by `masonId`, and stops after 25 final menu options.

## Validation

- `rtk xcodegen`
- `rtk env ALAS_FFF_TARGET_ARCH=arm64 xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -quiet build`
- `rtk env ALAS_FFF_TARGET_ARCH=arm64 xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -only-testing:AlasTests/MasonSnapshotTests -only-testing:AlasTests/InstallNudgeResolverTests test`

Full local suite was also run before publish and reached unrelated ACP queue/recovery and SSH integration failures already outside this change scope.