### PR TITLE
fix(helper): remote helper replay timeout crash

### DIFF
--- a/AlasTests/SSH/RemoteHelperClientTests.swift
+++ b/AlasTests/SSH/RemoteHelperClientTests.swift
@@ -766,8 +766,7 @@ struct RemoteHelperClientTests {
         let start = ContinuousClock.now
         while !predicate() {
             if ContinuousClock.now - start > timeout {
-                Issue.record("timed out waiting for predicate")
-                return
+                throw RemoteHelperClientTestTimeout("timed out waiting for predicate")
             }
             try await Task.sleep(for: .milliseconds(10))
         }
@@ -780,11 +779,18 @@ struct RemoteHelperClientTests {
         let start = ContinuousClock.now
         while !(await predicate()) {
             if ContinuousClock.now - start > timeout {
-                Issue.record("timed out waiting for async predicate")
-                return
+                throw RemoteHelperClientTestTimeout("timed out waiting for async predicate")
             }
             try await Task.sleep(for: .milliseconds(10))
         }
+    }
+}
+
+private struct RemoteHelperClientTestTimeout: Error, CustomStringConvertible {
+    let description: String
+
+    init(_ description: String) {
+        self.description = description
     }
 }
 


### PR DESCRIPTION
## Summary
- add the remote helper RPC channel work
- make remote helper replay wait helpers throw on timeout so failed waits stop before out-of-bounds frame indexing

## Testing
- rtk git diff --check
- ALAS_FFF_TARGET_ARCH=arm64 xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -only-testing:AlasTests/RemoteHelperClientTests/replayRestartsAllSubscriptionsAfterGenerationExit test

Note: the focused Xcode filter compiled and launched the test bundle, but selected 0 Swift Testing tests.