### PR TITLE
feat(commit): Add commit review context menu

### DIFF
--- a/Alas/Sources/App/RootView.swift
+++ b/Alas/Sources/App/RootView.swift
@@ -6,12 +6,18 @@ struct NewWorktreePresentation: Identifiable, Equatable {
     let projectId: String?
 }
 
+private struct CommitReviewSessionLaunchError: Identifiable, Equatable {
+    let id = UUID()
+    let message: String
+}
+
 struct RootView: View {
     @Bindable var state: AppState
     @State private var showNewProject = false
     @State private var editingProject: ProjectConfig?
     @State private var removingProject: ProjectConfig?
     @State private var newWorktreePresentation: NewWorktreePresentation?
+    @State private var commitReviewSessionLaunchError: CommitReviewSessionLaunchError?
     @Environment(\.openWindow) private var openWindow
 
     var body: some View {
@@ -42,6 +48,20 @@ struct RootView: View {
                 removingProject: $removingProject,
                 newWorktreePresentation: $newWorktreePresentation
             ))
+            .alert(
+                "Could not open review session",
+                isPresented: Binding(
+                    get: { commitReviewSessionLaunchError != nil },
+                    set: { if !$0 { commitReviewSessionLaunchError = nil } }
+                ),
+                presenting: commitReviewSessionLaunchError
+            ) { _ in
+                Button("OK", role: .cancel) {
+                    commitReviewSessionLaunchError = nil
+                }
+            } message: { error in
+                Text(error.message)
+            }
             .task {
                 state.startHarness()
                 if await state.projectsManager.refreshAll() {
@@ -153,6 +173,9 @@ struct RootView: View {
                 },
                 onEditCommit: { commit, baseRef in
                     openOrFocusCommitEditor(worktree: wt, commit: commit, baseRef: baseRef)
+                },
+                onReviewCommit: { commit in
+                    openOrFocusCommitReviewSession(worktree: wt, commit: commit)
                 }
             )
         case .creating(let wt):
@@ -267,6 +290,35 @@ struct RootView: View {
             title: title
         )
         state.tabs.activate(worktreeId: worktree.id, tabId: tab.id)
+    }
+
+    static func commitReviewSessionTarget(worktree: Worktree, commit: CommitInfo) -> ReviewSessionTarget {
+        CommitTabView.reviewSessionTarget(
+            worktreeID: worktree.id,
+            repositoryPath: worktree.path,
+            sha: commit.sha,
+            title: commit.subject
+        )
+    }
+
+    @MainActor
+    private func openOrFocusCommitReviewSession(worktree: Worktree, commit: CommitInfo) {
+        let target = Self.commitReviewSessionTarget(worktree: worktree, commit: commit)
+        let store = ReviewSessionStore()
+        ReviewSessionLauncher.openOrFocus(
+            target: target,
+            findActive: { try store.findActive(targetID: $0) },
+            save: { try store.save($0) },
+            open: { record in
+                commitReviewSessionLaunchError = nil
+                state.tabs.openOrFocusReviewSession(worktreeId: worktree.id, record: record)
+            },
+            onFailure: { error in
+                commitReviewSessionLaunchError = CommitReviewSessionLaunchError(
+                    message: error.localizedDescription
+                )
+            }
+        )
     }
 }
 

--- a/Alas/Sources/Right/ChangesTabView.swift
+++ b/Alas/Sources/Right/ChangesTabView.swift
@@ -7,6 +7,7 @@ struct ChangesTabView: View {
     let onSelect: (ChangedFile) -> Void
     let onSelectCommit: (CommitInfo) -> Void
     let onEditCommit: (CommitInfo, String) -> Void
+    let onReviewCommit: (CommitInfo) -> Void
 
     private var conflicts: [ChangedFile] {
         rps.changes.filter { $0.conflict != nil }
@@ -197,6 +198,7 @@ struct ChangesTabView: View {
                         onEditCommit(commit, ref)
                     }
                 },
+                onReview: onReviewCommit,
                 onLoadOlder: { Task { @MainActor in await rps.loadOlder() } },
                 onSelectBaseBranch: { branch in
                     rps.selectBaseBranch(branch)

--- a/Alas/Sources/Right/CommitRow.swift
+++ b/Alas/Sources/Right/CommitRow.swift
@@ -1,6 +1,11 @@
 import SwiftUI
 
 struct CommitRow: View {
+    enum ContextMenuAction: Hashable {
+        case edit
+        case review
+    }
+
     let commit: CommitInfo
     let isLast: Bool
     var isHistorical: Bool = false
@@ -9,6 +14,7 @@ struct CommitRow: View {
     var onCopyMessage: (() -> Void)? = nil
     var onOpenRemote: (() -> Void)? = nil
     var onEdit: (() -> Void)? = nil
+    var onReview: (() -> Void)? = nil
     var onCherryPick: (() -> Void)? = nil
     var onRevert: (() -> Void)? = nil
 
@@ -34,8 +40,15 @@ struct CommitRow: View {
         .buttonStyle(.plain)
         .copyFeedbackOverlay(message: copyFeedback.message)
         .contextMenu {
-            if let onEdit {
-                Button("Edit Commit…") { onEdit() }
+            ForEach(Self.leadingContextMenuActions(canEdit: onEdit != nil, canReview: onReview != nil), id: \.self) { action in
+                switch action {
+                case .edit:
+                    Button("Edit Commit…") { onEdit?() }
+                case .review:
+                    Button("Review Commit…") { onReview?() }
+                }
+            }
+            if onEdit != nil || onReview != nil {
                 Divider()
             }
             Button("Copy Commit SHA") { copySHA() }
@@ -64,6 +77,17 @@ struct CommitRow: View {
         } message: {
             Text("Create a new commit that reverses this commit.")
         }
+    }
+
+    static func leadingContextMenuActions(canEdit: Bool, canReview: Bool) -> [ContextMenuAction] {
+        var actions: [ContextMenuAction] = []
+        if canEdit {
+            actions.append(.edit)
+        }
+        if canReview {
+            actions.append(.review)
+        }
+        return actions
     }
 
     private var rail: some View {

--- a/Alas/Sources/Right/CommitsSectionView.swift
+++ b/Alas/Sources/Right/CommitsSectionView.swift
@@ -94,6 +94,7 @@ struct CommitsSectionView: View {
     let onSelect: (CommitInfo) -> Void
     let onCopySHA: (CommitInfo) -> Void
     let onEdit: (CommitInfo) -> Void
+    let onReview: (CommitInfo) -> Void
     let onLoadOlder: () -> Void
     let onSelectBaseBranch: (String) -> Void
     let onOpenBaseBranchSelector: () -> Void
@@ -162,6 +163,7 @@ struct CommitsSectionView: View {
                     onCopyMessage: { Clipboard.copy(commit.fullMessage) },
                     onOpenRemote: rps.commitsNeedPush ? nil : openRemoteAction(for: commit, remote: rps.primaryCommitRemote),
                     onEdit: { onEdit(commit) },
+                    onReview: { onReview(commit) },
                     onCherryPick: { rps.requestCherryPick(sha: commit.sha) },
                     onRevert: { rps.runRevert(sha: commit.sha) }
                 )
@@ -187,6 +189,7 @@ struct CommitsSectionView: View {
                     onCopySHA: { onCopySHA(commit) },
                     onCopyMessage: { Clipboard.copy(commit.fullMessage) },
                     onOpenRemote: openRemoteAction(for: commit, remote: rps.commitRemote),
+                    onReview: { onReview(commit) },
                     onCherryPick: { rps.requestCherryPick(sha: commit.sha) },
                     onRevert: { rps.runRevert(sha: commit.sha) }
                 )

--- a/Alas/Sources/Right/RightPaneView.swift
+++ b/Alas/Sources/Right/RightPaneView.swift
@@ -7,6 +7,7 @@ struct RightPaneView: View {
     let onSelectTreeFile: (FileTreeNode) -> Void
     let onSelectCommit: (CommitInfo) -> Void
     let onEditCommit: (CommitInfo, String) -> Void
+    let onReviewCommit: (CommitInfo) -> Void
     @Environment(\.theme) var theme
     @State private var rps: RightPaneState?
 
@@ -16,7 +17,8 @@ struct RightPaneView: View {
         onSelectChangedFile: @escaping (ChangedFile) -> Void,
         onSelectTreeFile: @escaping (FileTreeNode) -> Void,
         onSelectCommit: @escaping (CommitInfo) -> Void,
-        onEditCommit: @escaping (CommitInfo, String) -> Void
+        onEditCommit: @escaping (CommitInfo, String) -> Void,
+        onReviewCommit: @escaping (CommitInfo) -> Void
     ) {
         self.state = state
         self.worktree = worktree
@@ -24,6 +26,7 @@ struct RightPaneView: View {
         self.onSelectTreeFile = onSelectTreeFile
         self.onSelectCommit = onSelectCommit
         self.onEditCommit = onEditCommit
+        self.onReviewCommit = onReviewCommit
         // Resolve without activating: the cached state (if any) gives us
         // something to render immediately, and `.task` handles the mutating
         // activation + refresh off the view-update path.
@@ -66,7 +69,8 @@ struct RightPaneView: View {
                                 appState: state,
                                 onSelect: onSelectChangedFile,
                                 onSelectCommit: onSelectCommit,
-                                onEditCommit: onEditCommit
+                                onEditCommit: onEditCommit,
+                                onReviewCommit: onReviewCommit
                             )
                         case .files:
                             FilesTabView(

--- a/AlasTests/CommitRowTests.swift
+++ b/AlasTests/CommitRowTests.swift
@@ -61,6 +61,12 @@ struct CommitRowTests {
         #expect(commit.id == "aabbccdd11223344556677889900aabbccdd1122")
     }
 
+    @Test func contextMenuShowsReviewCommitImmediatelyAfterEditCommit() {
+        #expect(CommitRow.leadingContextMenuActions(canEdit: true, canReview: true) == [.edit, .review])
+        #expect(CommitRow.leadingContextMenuActions(canEdit: false, canReview: true) == [.review])
+        #expect(CommitRow.leadingContextMenuActions(canEdit: true, canReview: false) == [.edit])
+    }
+
     @MainActor
     @Test func copyFeedbackShowsThenDismisses() async throws {
         let feedback = CopyFeedbackState(displayNanoseconds: 10_000_000)

--- a/AlasTests/CommitTabViewTests.swift
+++ b/AlasTests/CommitTabViewTests.swift
@@ -39,6 +39,43 @@ struct CommitTabViewTests {
         #expect(target.revisionDescription == "abcdef1234567890")
     }
 
+    @Test func commitReviewContextMenuBuildsCommitReviewTarget() {
+        let worktree = Worktree(
+            id: "wt-1",
+            projectId: "project-1",
+            name: "feature",
+            branch: "feature",
+            path: URL(fileURLWithPath: "/repo"),
+            status: .clean,
+            lastActivity: Date(timeIntervalSince1970: 0)
+        )
+        let commit = CommitInfo(
+            sha: "abcdef1234567890",
+            shortSha: "abcdef1",
+            author: "Nacho Lopez",
+            authorInitials: "NL",
+            date: Date(timeIntervalSince1970: 1),
+            subject: "Add review sessions",
+            conventionalTag: nil,
+            filesChanged: 1,
+            insertions: 2,
+            deletions: 0
+        )
+
+        let target = RootView.commitReviewSessionTarget(worktree: worktree, commit: commit)
+
+        #expect(target.kind == .commit)
+        #expect(target.worktreeID == "wt-1")
+        #expect(target.repositoryPath == URL(fileURLWithPath: "/repo"))
+        #expect(target.title == "Review Add review sessions")
+        #expect(target.revisionDescription == "abcdef1234567890")
+        #expect(target.draftSessionID == .commit(
+            worktreeID: "wt-1",
+            repositoryPath: URL(fileURLWithPath: "/repo"),
+            sha: "abcdef1234567890"
+        ))
+    }
+
     @Test func commitReviewFeedbackTargetIncludesCommitSHA() {
         let sha = "abcdef1234567890abcdef1234567890abcdef12"
         let target = CommitReviewBody.reviewFeedbackTarget(


### PR DESCRIPTION
## Summary
- Adds a `Review Commit…` item directly under `Edit Commit…` in the Changes tab commit context menu.
- Wires the action through the changes/right-pane/root callbacks so it opens or focuses a commit review session with `ReviewSessionLauncher`.
- Surfaces review-session launch failures from the context-menu path with a root alert.
- Covers the menu ordering and commit review target construction with Swift Testing tests.

## Validation
- `xcodegen`
- `git diff --check`
- `xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS,arch=arm64' -derivedDataPath /tmp/alas-dd-pr763 -quiet build`
- `xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS,arch=arm64' -derivedDataPath /tmp/alas-dd-pr763 -only-testing:AlasTests/CommitTabViewTests/commitReviewContextMenuBuildsCommitReviewTarget -only-testing:AlasTests/CommitRowTests/contextMenuShowsReviewCommitImmediatelyAfterEditCommit -quiet test`
- `xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -only-testing:AlasTests/ACPSessionRunnerQueueTests/persistenceRoundTrip -only-testing:AlasTests/ACPSessionRecoveryIntegrationTests/queueOrderingInvariant -only-testing:AlasTests/ACPSessionRecoveryIntegrationTests/submitDuringRecoveryRoundTrip -only-testing:AlasTests/ACPSessionManagerSubmitTests/submitWhileSpawningEnqueues -quiet test`

Full local `xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' test` completed the run but reported 12 failures: 8 SSH integration tests gated by `ALAS_SSH_INTEGRATION=1`, plus 4 ACP queue/recovery tests that passed when rerun in isolation.