### PR TITLE
fix(git): Guard subprocess launch configuration

### DIFF
--- a/Alas/Sources/Git/Process+Git.swift
+++ b/Alas/Sources/Git/Process+Git.swift
@@ -30,6 +30,8 @@ extension Process {
         stdin: String? = nil,
         timeout: TimeInterval = Process.defaultTimeout
     ) async throws -> ProcessResult {
+        try validateLaunchConfiguration(executable: executable, cwd: cwd)
+
         let process = Process()
         process.executableURL = URL(fileURLWithPath: executable)
         process.arguments = args
@@ -243,6 +245,8 @@ extension Process {
         env: [String: String]? = nil,
         timeout: TimeInterval = Process.defaultTimeout
     ) async throws -> ProcessResultData {
+        try validateLaunchConfiguration(executable: executable, cwd: cwd)
+
         let process = Process()
         process.executableURL = URL(fileURLWithPath: executable)
         process.arguments = args
@@ -323,6 +327,18 @@ extension Process {
             stdout: outAccum.snapshot(),
             stderr: String(data: errAccum.snapshot(), encoding: .utf8) ?? ""
         )
+    }
+}
+
+private func validateLaunchConfiguration(executable: String, cwd: URL?) throws {
+    guard FileManager.default.isExecutableFile(atPath: executable) else {
+        throw ProcessError.launchFailed("Executable is not runnable: \(executable)")
+    }
+
+    guard let cwd else { return }
+    var isDirectory: ObjCBool = false
+    guard FileManager.default.fileExists(atPath: cwd.path, isDirectory: &isDirectory), isDirectory.boolValue else {
+        throw ProcessError.launchFailed("Working directory does not exist: \(cwd.path)")
     }
 }
 

--- a/AlasTests/ProcessGitTests.swift
+++ b/AlasTests/ProcessGitTests.swift
@@ -15,6 +15,20 @@ struct ProcessGitTests {
         #expect(result.exitCode == 1)
     }
 
+    @Test func invalidWorkingDirectoryThrowsLaunchFailed() async throws {
+        let missing = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("alas-missing-cwd-\(UUID().uuidString)")
+
+        do {
+            _ = try await Process.run("/bin/echo", args: ["hi"], cwd: missing)
+            Issue.record("expected launch failure")
+        } catch ProcessError.launchFailed(let message) {
+            #expect(!message.isEmpty)
+        } catch {
+            Issue.record("wrong error: \(error)")
+        }
+    }
+
     @Test func gitVersionRuns() async throws {
         let result = try await Process.run("/usr/bin/env", args: ["git", "--version"])
         #expect(result.exitCode == 0)


### PR DESCRIPTION
## Summary

- Validate subprocess executable and working directory before launching `Process`
- Convert invalid launch configuration into `ProcessError.launchFailed` instead of allowing Foundation to raise an uncaught Objective-C exception
- Add a regression test for missing working-directory launch failures

## Context

The crash reports both abort from an uncaught Objective-C exception in `NSConcreteTask launchWithDictionary:error:` while fingerprinting right-pane file content through the shared process launcher. The same launch guard applies to both string and data process helpers.

## Validation

- `xcodegen` passed
- Focused `ProcessGitTests` passed before rebasing
- Full/local Xcode build validation was interrupted after Xcode stayed silent in build operation state for several minutes; CI should provide the authoritative full build/test signal