### PR TITLE
feat(ssh): push remote file and git events

### DIFF
--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -382,6 +382,7 @@
 		4CFC511BB3BEFB139BDF66F6 /* MemoryReportWindow.swift in Sources */ = {isa = PBXBuildFile; fileRef = A6C3E23DCE2A602A87915ECE /* MemoryReportWindow.swift */; };
 		4D1584E4013D1A667723E4A6 /* MergeAgent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 90D74C28EB7B8C3CBC53994D /* MergeAgent.swift */; };
 		4D9A57C74B314FA3570B0406 /* GitServiceReviewRequestDraftTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FFB1CCDE2E4D85A46E6CFB1A /* GitServiceReviewRequestDraftTests.swift */; };
+		4DEFF78597731750310ABE00 /* RemoteHelperWatchSession.swift in Sources */ = {isa = PBXBuildFile; fileRef = 59F17DE68E81565014FC9454 /* RemoteHelperWatchSession.swift */; };
 		4DF50D8995FBF711085A40AF /* ReviewThreadMutations.swift in Sources */ = {isa = PBXBuildFile; fileRef = 14CEB6C5C076B4147D587909 /* ReviewThreadMutations.swift */; };
 		4E08D715B766E9D04B4BA0B0 /* WindowAppearance.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB020862232495EC1C5ECBEA /* WindowAppearance.swift */; };
 		4E352BDC87A204DE2912F54F /* ACPHarnessBridge.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45EABFDF5380D8D48B15312C /* ACPHarnessBridge.swift */; };
@@ -1691,6 +1692,7 @@
 		58B78EE378B0A076C904E2E4 /* TreeSitterLua */ = {isa = PBXFileReference; lastKnownFileType = folder; name = TreeSitterLua; path = ThirdParty/TreeSitterLua; sourceTree = SOURCE_ROOT; };
 		58BC051640BBB02A2EBF6E4F /* ReviewDraftCommentController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReviewDraftCommentController.swift; sourceTree = "<group>"; };
 		59DBB72EE97F0E906442919B /* CommitTabView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommitTabView.swift; sourceTree = "<group>"; };
+		59F17DE68E81565014FC9454 /* RemoteHelperWatchSession.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteHelperWatchSession.swift; sourceTree = "<group>"; };
 		5A1A152D4297DBB5B8DFF950 /* ReviewRequestDraftTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReviewRequestDraftTests.swift; sourceTree = "<group>"; };
 		5A2EFB5253073D6A4A328FE0 /* RemoteConnection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteConnection.swift; sourceTree = "<group>"; };
 		5A43A7D90E591CFD18088C70 /* AgentLauncherModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentLauncherModel.swift; sourceTree = "<group>"; };
@@ -3642,6 +3644,7 @@
 				C9042DA34C7025958BCFEE08 /* RemoteHelperHandshake.swift */,
 				0EE8745F3A4C6F0645D1D44A /* RemoteHelperInstaller.swift */,
 				B0B0D8590E0335CD31B758E0 /* RemoteHelperProtocol.swift */,
+				59F17DE68E81565014FC9454 /* RemoteHelperWatchSession.swift */,
 				10B3615A1591964AB1C9E524 /* RemoteHostCapabilities.swift */,
 				8DF79BBCD948528D655A9A81 /* RemoteHostRegistry.swift */,
 				416C797DBD3F9F4901817769 /* RemoteHostStatusStore.swift */,
@@ -5339,6 +5342,7 @@
 				B0C493B1DE30CD22F1BAD24C /* RemoteHelperHandshake.swift in Sources */,
 				40C56ABCF57F6F3F7D40E020 /* RemoteHelperInstaller.swift in Sources */,
 				019D3627B3CEB44C34CC34F9 /* RemoteHelperProtocol.swift in Sources */,
+				4DEFF78597731750310ABE00 /* RemoteHelperWatchSession.swift in Sources */,
 				330D198F38767801994BF84C /* RemoteHostCapabilities.swift in Sources */,
 				F47287FCE8C870F02F2A55E0 /* RemoteHostRegistry.swift in Sources */,
 				52AB869F9071103FD1649552 /* RemoteHostStatusStore.swift in Sources */,

--- a/Alas/Sources/Code/Editor/EditorBuffer.swift
+++ b/Alas/Sources/Code/Editor/EditorBuffer.swift
@@ -2,6 +2,29 @@ import AppKit
 import Foundation
 import Observation
 
+struct RemoteConflictCheckCoalescer {
+    private var isChecking = false
+    private var hasPendingCheck = false
+
+    mutating func beginOrMarkPending() -> Bool {
+        guard !isChecking else {
+            hasPendingCheck = true
+            return false
+        }
+        isChecking = true
+        return true
+    }
+
+    mutating func finishCheck() -> Bool {
+        guard hasPendingCheck else {
+            isChecking = false
+            return false
+        }
+        hasPendingCheck = false
+        return true
+    }
+}
+
 /// Editor buffer for one open worktree file. Owns the live `NSTextStorage` displayed by
 /// `CodeTextView`, plus the original-on-disk snapshot used for dirty
 /// detection, save normalization, and conflict resolution.
@@ -103,7 +126,7 @@ final class EditorBuffer {
     @ObservationIgnored
     private var remoteHelperSession: RemoteHelperWatchSession?
     @ObservationIgnored
-    private var remoteConflictCheckInFlight = false
+    private var remoteConflictChecks = RemoteConflictCheckCoalescer()
     @ObservationIgnored
     private static let remoteConflictPollNanos: UInt64 = 15 * 1_000_000_000
     @ObservationIgnored
@@ -635,9 +658,13 @@ final class EditorBuffer {
     }
 
     private func checkRemoteConflict(host: String) async {
-        guard !remoteConflictCheckInFlight else { return }
-        remoteConflictCheckInFlight = true
-        defer { remoteConflictCheckInFlight = false }
+        guard remoteConflictChecks.beginOrMarkPending() else { return }
+        repeat {
+            await checkRemoteConflictOnce(host: host)
+        } while remoteConflictChecks.finishCheck()
+    }
+
+    private func checkRemoteConflictOnce(host: String) async {
         do {
             guard let mtime = try await RemoteFileAccess.mtime(host: host, path: absoluteFileURL.path) else {
                 if dirty { conflict = .deletedOnDisk }

--- a/Alas/Sources/Code/Editor/EditorBuffer.swift
+++ b/Alas/Sources/Code/Editor/EditorBuffer.swift
@@ -635,18 +635,17 @@ final class EditorBuffer {
 
     private func startRemoteHelperWatching(host: String) {
         guard remoteHelperSession == nil else { return }
+        let watchedRoot = absoluteFileURL.deletingLastPathComponent()
+        let targetPath = absoluteFileURL.standardizedFileURL.path
         let session = RemoteHelperWatchSession(
             host: host,
-            root: worktreeRoot.path,
+            root: watchedRoot.path,
             kinds: [.files]
         )
         session.onEvent = { [weak self] event in
             guard let self, event.kind == .files else { return }
-            let target = URL(fileURLWithPath: event.root)
-                .appendingPathComponent(relativePath)
-                .standardizedFileURL.path
             guard event.paths.contains(where: {
-                URL(fileURLWithPath: $0).standardizedFileURL.path == target
+                URL(fileURLWithPath: $0).standardizedFileURL.path == targetPath
             }) else { return }
             Task { @MainActor in await self.checkRemoteConflict(host: host) }
         }

--- a/Alas/Sources/Code/Editor/EditorBuffer.swift
+++ b/Alas/Sources/Code/Editor/EditorBuffer.swift
@@ -25,6 +25,62 @@ struct RemoteConflictCheckCoalescer {
     }
 }
 
+struct RemoteHelperFileWatchMatcher {
+    private let targetPath: String
+    private let targetRelativePath: String?
+
+    init(targetURL: URL, watchedRootURL: URL) {
+        targetPath = Self.normalizedPath(targetURL.path)
+        targetRelativePath = Self.relativePath(of: targetURL.path, under: watchedRootURL.path)
+    }
+
+    func matches(event: RemoteHelperWatchEvent) -> Bool {
+        event.paths.contains { eventPath in
+            let normalizedEventPath = Self.normalizedPath(eventPath)
+            if normalizedEventPath == targetPath { return true }
+            guard
+                let targetRelativePath,
+                let eventRelativePath = Self.relativePath(of: normalizedEventPath, under: event.root)
+            else {
+                return false
+            }
+            return eventRelativePath == targetRelativePath
+        }
+    }
+
+    private static func relativePath(of path: String, under root: String) -> String? {
+        let path = normalizedPath(path)
+        let root = normalizedPath(root)
+        guard !root.isEmpty, path != root else { return nil }
+        let prefix = root == "/" ? root : root + "/"
+        guard path.hasPrefix(prefix) else { return nil }
+        return String(path.dropFirst(prefix.count))
+    }
+
+    private static func normalizedPath(_ path: String) -> String {
+        guard !path.isEmpty else { return path }
+        let isAbsolute = path.hasPrefix("/")
+        var components: [String] = []
+        for component in path.split(separator: "/", omittingEmptySubsequences: true) {
+            switch component {
+            case ".":
+                continue
+            case "..":
+                if !components.isEmpty {
+                    components.removeLast()
+                } else if !isAbsolute {
+                    components.append(String(component))
+                }
+            default:
+                components.append(String(component))
+            }
+        }
+        let joined = components.joined(separator: "/")
+        if isAbsolute { return "/" + joined }
+        return joined
+    }
+}
+
 /// Editor buffer for one open worktree file. Owns the live `NSTextStorage` displayed by
 /// `CodeTextView`, plus the original-on-disk snapshot used for dirty
 /// detection, save normalization, and conflict resolution.
@@ -636,7 +692,10 @@ final class EditorBuffer {
     private func startRemoteHelperWatching(host: String) {
         guard remoteHelperSession == nil else { return }
         let watchedRoot = absoluteFileURL.deletingLastPathComponent()
-        let targetPath = absoluteFileURL.standardizedFileURL.path
+        let fileWatchMatcher = RemoteHelperFileWatchMatcher(
+            targetURL: absoluteFileURL,
+            watchedRootURL: watchedRoot
+        )
         let session = RemoteHelperWatchSession(
             host: host,
             root: watchedRoot.path,
@@ -644,9 +703,7 @@ final class EditorBuffer {
         )
         session.onEvent = { [weak self] event in
             guard let self, event.kind == .files else { return }
-            guard event.paths.contains(where: {
-                URL(fileURLWithPath: $0).standardizedFileURL.path == targetPath
-            }) else { return }
+            guard fileWatchMatcher.matches(event: event) else { return }
             Task { @MainActor in await self.checkRemoteConflict(host: host) }
         }
         session.onAvailabilityChanged = { [weak self] _ in

--- a/Alas/Sources/Code/Editor/EditorBuffer.swift
+++ b/Alas/Sources/Code/Editor/EditorBuffer.swift
@@ -665,6 +665,7 @@ final class EditorBuffer {
     }
 
     private func checkRemoteConflictOnce(host: String) async {
+        guard !remoteSaveInFlight else { return }
         do {
             guard let mtime = try await RemoteFileAccess.mtime(host: host, path: absoluteFileURL.path) else {
                 if dirty { conflict = .deletedOnDisk }

--- a/Alas/Sources/Code/Editor/EditorBuffer.swift
+++ b/Alas/Sources/Code/Editor/EditorBuffer.swift
@@ -101,7 +101,13 @@ final class EditorBuffer {
     @ObservationIgnored
     private var remotePollTask: Task<Void, Never>?
     @ObservationIgnored
+    private var remoteHelperSession: RemoteHelperWatchSession?
+    @ObservationIgnored
+    private var remoteConflictCheckInFlight = false
+    @ObservationIgnored
     private static let remoteConflictPollNanos: UInt64 = 15 * 1_000_000_000
+    @ObservationIgnored
+    private static let remoteHelperSafetyNetNanos: UInt64 = 5 * 60 * 1_000_000_000
     @ObservationIgnored
     private var remoteLoadGeneration = 0
     @ObservationIgnored
@@ -551,7 +557,8 @@ final class EditorBuffer {
 
     func startWatching() {
         stopWatching()
-        if remoteHost != nil {
+        if let remoteHost {
+            startRemoteHelperWatching(host: remoteHost)
             startRemoteConflictPolling()
             return
         }
@@ -575,6 +582,8 @@ final class EditorBuffer {
     func stopWatching() {
         remotePollTask?.cancel()
         remotePollTask = nil
+        remoteHelperSession?.stop()
+        remoteHelperSession = nil
         watcherSource?.cancel()
         watcherSource = nil
         watcherFD = -1
@@ -583,29 +592,67 @@ final class EditorBuffer {
 
     private func startRemoteConflictPolling() {
         guard let host = remoteHost else { return }
-        let path = absoluteFileURL.path
+        remotePollTask?.cancel()
         remotePollTask = Task { @MainActor [weak self] in
             while !Task.isCancelled {
-                try? await Task.sleep(nanoseconds: Self.remoteConflictPollNanos)
-                guard let self, !Task.isCancelled else { return }
-
+                let interval = self?.remoteHelperSession?.isAvailable == true
+                    ? Self.remoteHelperSafetyNetNanos
+                    : Self.remoteConflictPollNanos
                 do {
-                    guard let mtime = try await RemoteFileAccess.mtime(host: host, path: path) else {
-                        if self.dirty { self.conflict = .deletedOnDisk }
-                        continue
-                    }
-                    RemoteHostStatusStore.shared.reportSuccess(host: host)
-                    guard mtime > self.originalMtime else { continue }
-                    if self.dirty {
-                        self.conflict = .changedOnDisk
-                    } else {
-                        self.revert()
-                    }
+                    try await Task.sleep(nanoseconds: interval)
                 } catch {
-                    if case .connectionFailed = error as? RemoteFileAccessError {
-                        RemoteHostStatusStore.shared.reportConnectionFailure(host: host)
-                    }
+                    return
                 }
+                guard let self, !Task.isCancelled else { return }
+                await checkRemoteConflict(host: host)
+                remoteHelperSession?.retryIfNeeded()
+            }
+        }
+    }
+
+    private func startRemoteHelperWatching(host: String) {
+        guard remoteHelperSession == nil else { return }
+        let session = RemoteHelperWatchSession(
+            host: host,
+            root: worktreeRoot.path,
+            kinds: [.files]
+        )
+        session.onEvent = { [weak self] event in
+            guard let self, event.kind == .files else { return }
+            let target = URL(fileURLWithPath: event.root)
+                .appendingPathComponent(relativePath)
+                .standardizedFileURL.path
+            guard event.paths.contains(where: {
+                URL(fileURLWithPath: $0).standardizedFileURL.path == target
+            }) else { return }
+            Task { @MainActor in await self.checkRemoteConflict(host: host) }
+        }
+        session.onAvailabilityChanged = { [weak self] _ in
+            self?.startRemoteConflictPolling()
+        }
+        remoteHelperSession = session
+        session.start()
+    }
+
+    private func checkRemoteConflict(host: String) async {
+        guard !remoteConflictCheckInFlight else { return }
+        remoteConflictCheckInFlight = true
+        defer { remoteConflictCheckInFlight = false }
+        do {
+            guard let mtime = try await RemoteFileAccess.mtime(host: host, path: absoluteFileURL.path) else {
+                if dirty { conflict = .deletedOnDisk }
+                return
+            }
+            RemoteHostStatusStore.shared.reportSuccess(host: host)
+            guard mtime > originalMtime else { return }
+            if dirty {
+                conflict = .changedOnDisk
+            } else {
+                revert()
+            }
+        } catch {
+            if case .connectionFailed = error as? RemoteFileAccessError {
+                RemoteHostStatusStore.shared.reportConnectionFailure(host: host)
             }
         }
     }

--- a/Alas/Sources/Right/RightPaneState.swift
+++ b/Alas/Sources/Right/RightPaneState.swift
@@ -253,8 +253,11 @@ final class RightPaneState {
     @ObservationIgnored
     private let reviewLoopRemoteRefreshMinimumInterval: TimeInterval = 45
     @ObservationIgnored private var remotePollTask: Task<Void, Never>?
+    @ObservationIgnored private var remoteHelperSession: RemoteHelperWatchSession?
+    @ObservationIgnored private let remoteEventDebouncer = DebounceTimer(interval: 0.5, maxWait: 2.0)
     @ObservationIgnored private var remoteFingerprint: String?
     private static let remotePollIntervalNanos: UInt64 = 7 * 1_000_000_000
+    private static let remoteHelperSafetyNetNanos: UInt64 = 5 * 60 * 1_000_000_000
 
     /// True iff the "behind base" chip should be shown.
     var showBehindBaseChip: Bool {
@@ -284,12 +287,16 @@ final class RightPaneState {
         watcher.onChange = { [weak self] in
             Task { @MainActor in await self?.refresh() }
         }
+        remoteEventDebouncer.onFire = { [weak self] in
+            Task { @MainActor in await self?.refresh() }
+        }
     }
 
     func start() {
         if !worktree.path.isRemoteAlasPath {
             watcher.start()
         } else {
+            startRemoteHelperWatching()
             startRemotePolling()
         }
         Task { @MainActor in await self.refresh() }
@@ -314,15 +321,45 @@ final class RightPaneState {
         syncStatusTimer = nil
         remotePollTask?.cancel()
         remotePollTask = nil
+        remoteHelperSession?.stop()
+        remoteHelperSession = nil
+        remoteEventDebouncer.cancel()
+    }
+
+    private func startRemoteHelperWatching() {
+        guard remoteHelperSession == nil,
+              let host = RemoteHostRegistry.shared.host(forPath: worktree.path.path)
+        else { return }
+        let session = RemoteHelperWatchSession(
+            host: host,
+            root: worktree.path.path,
+            kinds: [.files, .git]
+        )
+        session.onEvent = { [weak self] _ in
+            self?.remoteEventDebouncer.poke()
+        }
+        session.onAvailabilityChanged = { [weak self] _ in
+            self?.startRemotePolling()
+        }
+        remoteHelperSession = session
+        session.start()
     }
 
     private func startRemotePolling() {
         remotePollTask?.cancel()
         remotePollTask = Task { @MainActor [weak self] in
             while !Task.isCancelled {
-                try? await Task.sleep(nanoseconds: Self.remotePollIntervalNanos)
+                let interval = self?.remoteHelperSession?.isAvailable == true
+                    ? Self.remoteHelperSafetyNetNanos
+                    : Self.remotePollIntervalNanos
+                do {
+                    try await Task.sleep(nanoseconds: interval)
+                } catch {
+                    return
+                }
                 guard let self, !Task.isCancelled, NSApp?.isActive ?? true else { continue }
                 await remotePollTick()
+                remoteHelperSession?.retryIfNeeded()
             }
         }
     }

--- a/Alas/Sources/SSH/RemoteHelperClient.swift
+++ b/Alas/Sources/SSH/RemoteHelperClient.swift
@@ -33,6 +33,7 @@ actor RemoteHelperClient {
     typealias TransportFactory = @Sendable () -> JSONRPCStdioTransporting
 
     static let defaultIdleShutdownNanoseconds: UInt64 = 600_000_000_000
+    static let legacyWatchEventBufferLimit = 64
 
     nonisolated let host: String
     nonisolated let watchEvents: AsyncStream<RemoteHelperWatchEvent>
@@ -63,7 +64,9 @@ actor RemoteHelperClient {
             Self.makeTransport(host: host)
         }
         var eventsCont: AsyncStream<RemoteHelperWatchEvent>.Continuation!
-        self.watchEvents = AsyncStream { eventsCont = $0 }
+        self.watchEvents = AsyncStream(
+            bufferingPolicy: .bufferingNewest(Self.legacyWatchEventBufferLimit)
+        ) { eventsCont = $0 }
         self.watchEventsCont = eventsCont
     }
 

--- a/Alas/Sources/SSH/RemoteHelperClient.swift
+++ b/Alas/Sources/SSH/RemoteHelperClient.swift
@@ -9,6 +9,8 @@ private struct ActiveRemoteHelperSubscription {
     let params: RemoteHelperWatchSubscribeParams
     var helperSubscriptionId: String
     var helperGeneration: Int
+    let updates: AsyncStream<RemoteHelperWatchUpdate>
+    let updatesContinuation: AsyncStream<RemoteHelperWatchUpdate>.Continuation
 }
 
 enum RemoteHelperClientError: Error, Equatable {
@@ -96,24 +98,39 @@ actor RemoteHelperClient {
         root: String,
         kinds: [RemoteHelperWatchKind]
     ) async throws -> RemoteHelperWatchSubscribeResult {
+        let handle = try await subscribeWithUpdates(root: root, kinds: kinds)
+        return RemoteHelperWatchSubscribeResult(subscriptionId: handle.subscriptionId)
+    }
+
+    func subscribeWithUpdates(
+        root: String,
+        kinds: [RemoteHelperWatchKind]
+    ) async throws -> RemoteHelperWatchHandle {
         let helperResult: RemoteHelperWatchSubscribeResult = try await request(
             method: "watch/subscribe",
             params: RemoteHelperWatchSubscribeParams(root: root, kinds: kinds)
         )
         let params = RemoteHelperWatchSubscribeParams(root: root, kinds: kinds)
         let clientSubscriptionId = makeClientSubscriptionId(avoiding: helperResult.subscriptionId)
+        var updatesContinuation: AsyncStream<RemoteHelperWatchUpdate>.Continuation!
+        let updates = AsyncStream<RemoteHelperWatchUpdate> { updatesContinuation = $0 }
         activeSubscriptions[clientSubscriptionId] = ActiveRemoteHelperSubscription(
             params: params,
             helperSubscriptionId: helperResult.subscriptionId,
-            helperGeneration: generation
+            helperGeneration: generation,
+            updates: updates,
+            updatesContinuation: updatesContinuation
         )
-        return RemoteHelperWatchSubscribeResult(subscriptionId: clientSubscriptionId)
+        updatesContinuation.yield(.available)
+        return RemoteHelperWatchHandle(subscriptionId: clientSubscriptionId, updates: updates)
     }
 
     func unsubscribe(subscriptionId: String) async throws -> RemoteHelperWatchUnsubscribeResult {
-        let helperSubscriptionId = activeSubscriptions[subscriptionId]?.helperSubscriptionId ?? subscriptionId
+        let subscription = activeSubscriptions[subscriptionId]
+        let helperSubscriptionId = subscription?.helperSubscriptionId ?? subscriptionId
         guard transport != nil else {
             activeSubscriptions.removeValue(forKey: subscriptionId)
+            subscription?.updatesContinuation.finish()
             scheduleIdleShutdownIfPossible()
             return RemoteHelperWatchUnsubscribeResult(ok: true)
         }
@@ -127,10 +144,12 @@ actor RemoteHelperClient {
             )
         } catch RemoteHelperClientError.notRunning {
             activeSubscriptions.removeValue(forKey: subscriptionId)
+            subscription?.updatesContinuation.finish()
             scheduleIdleShutdownIfPossible()
             return RemoteHelperWatchUnsubscribeResult(ok: true)
         }
         activeSubscriptions.removeValue(forKey: subscriptionId)
+        subscription?.updatesContinuation.finish()
         scheduleIdleShutdownIfPossible()
         return result
     }
@@ -156,6 +175,10 @@ actor RemoteHelperClient {
         subscriptionReplayTask?.cancel()
         subscriptionReplayTask = nil
         subscriptionsNeedReplay = false
+        for subscription in activeSubscriptions.values {
+            subscription.updatesContinuation.yield(.unavailable)
+            subscription.updatesContinuation.finish()
+        }
         activeSubscriptions.removeAll()
         drainPending(with: RemoteHelperClientError.notRunning)
         dispatchTask?.cancel()
@@ -316,8 +339,11 @@ actor RemoteHelperClient {
                 activeSubscriptions[clientSubscriptionId] = ActiveRemoteHelperSubscription(
                     params: subscription.params,
                     helperSubscriptionId: result.subscriptionId,
-                    helperGeneration: replayGeneration
+                    helperGeneration: replayGeneration,
+                    updates: subscription.updates,
+                    updatesContinuation: subscription.updatesContinuation
                 )
+                subscription.updatesContinuation.yield(.available)
             }
 
             guard shouldRestartReplay else {
@@ -375,7 +401,21 @@ actor RemoteHelperClient {
         else {
             return
         }
-        watchEventsCont.yield(event)
+        guard let (clientSubscriptionId, subscription) = activeSubscriptions.first(where: {
+            $0.value.helperGeneration == generation
+                && $0.value.helperSubscriptionId == event.subscriptionId
+        }) else {
+            watchEventsCont.yield(event)
+            return
+        }
+        let stableEvent = RemoteHelperWatchEvent(
+            subscriptionId: clientSubscriptionId,
+            root: event.root,
+            kind: event.kind,
+            paths: event.paths
+        )
+        watchEventsCont.yield(stableEvent)
+        subscription.updatesContinuation.yield(.event(stableEvent))
     }
 
     private func handleExit(_ status: Int32) {
@@ -386,6 +426,9 @@ actor RemoteHelperClient {
         idleShutdownTask?.cancel()
         idleShutdownTask = nil
         drainPending(with: RemoteHelperClientError.notRunning)
+        for subscription in activeSubscriptions.values {
+            subscription.updatesContinuation.yield(.unavailable)
+        }
         if RemoteExec.isConnectionFailure(exitCode: status) {
             Task { @MainActor [host] in
                 RemoteHostStatusStore.shared.reportConnectionFailure(host: host)

--- a/Alas/Sources/SSH/RemoteHelperClient.swift
+++ b/Alas/Sources/SSH/RemoteHelperClient.swift
@@ -157,6 +157,13 @@ actor RemoteHelperClient {
         return result
     }
 
+    func dropLocalSubscription(subscriptionId: String) {
+        guard let subscription = activeSubscriptions.removeValue(forKey: subscriptionId) else { return }
+        subscription.updatesContinuation.yield(.unavailable)
+        subscription.updatesContinuation.finish()
+        scheduleIdleShutdownIfPossible()
+    }
+
     func read(path: String, offset: UInt64? = nil) async throws -> RemoteHelperFSReadResult {
         try await request(method: "fs/read", params: RemoteHelperFSReadParams(path: path, offset: offset))
     }

--- a/Alas/Sources/SSH/RemoteHelperProtocol.swift
+++ b/Alas/Sources/SSH/RemoteHelperProtocol.swift
@@ -66,6 +66,17 @@ struct RemoteHelperWatchEvent: Codable, Equatable, Sendable {
     let paths: [String]
 }
 
+enum RemoteHelperWatchUpdate: Equatable, Sendable {
+    case available
+    case unavailable
+    case event(RemoteHelperWatchEvent)
+}
+
+struct RemoteHelperWatchHandle: Sendable {
+    let subscriptionId: String
+    let updates: AsyncStream<RemoteHelperWatchUpdate>
+}
+
 struct RemoteHelperFSReadParams: Codable, Equatable, Sendable {
     let path: String
     let offset: UInt64?

--- a/Alas/Sources/SSH/RemoteHelperWatchSession.swift
+++ b/Alas/Sources/SSH/RemoteHelperWatchSession.swift
@@ -65,10 +65,27 @@ final class RemoteHelperWatchSession {
             return
         }
         retryTask = Task { [weak self] in
-            _ = try? await client.ping()
+            do {
+                _ = try await client.ping()
+            } catch RemoteHelperClientError.notRunning {
+                // Keep the subscription registered locally so the next helper process can replay it.
+            } catch {
+                await self?.dropStaleSubscription(client: client, subscriptionId: handle?.subscriptionId)
+            }
             guard let self, !Task.isCancelled else { return }
             self.retryTask = nil
         }
+    }
+
+    private func dropStaleSubscription(client: RemoteHelperClient, subscriptionId: String?) async {
+        generation &+= 1
+        connectionTask?.cancel()
+        connectionTask = nil
+        self.client = nil
+        handle = nil
+        setAvailable(false)
+        guard let subscriptionId else { return }
+        await client.dropLocalSubscription(subscriptionId: subscriptionId)
     }
 
     private func beginConnection(attemptDate: Date = Date()) {

--- a/Alas/Sources/SSH/RemoteHelperWatchSession.swift
+++ b/Alas/Sources/SSH/RemoteHelperWatchSession.swift
@@ -1,0 +1,124 @@
+import Foundation
+
+@MainActor
+final class RemoteHelperWatchSession {
+    var onEvent: ((RemoteHelperWatchEvent) -> Void)?
+    var onAvailabilityChanged: ((Bool) -> Void)?
+
+    private(set) var isAvailable = false
+
+    private let host: String
+    private let root: String
+    private let kinds: [RemoteHelperWatchKind]
+    private let retryInterval: TimeInterval
+    private var connectionTask: Task<Void, Never>?
+    private var retryTask: Task<Void, Never>?
+    private var client: RemoteHelperClient?
+    private var handle: RemoteHelperWatchHandle?
+    private var lastAttemptAt: Date?
+    private var generation = 0
+
+    init(
+        host: String,
+        root: String,
+        kinds: [RemoteHelperWatchKind],
+        retryInterval: TimeInterval = 5 * 60
+    ) {
+        self.host = host
+        self.root = root
+        self.kinds = kinds
+        self.retryInterval = retryInterval
+    }
+
+    func start() {
+        guard connectionTask == nil, handle == nil else { return }
+        beginConnection()
+    }
+
+    func stop() {
+        generation &+= 1
+        connectionTask?.cancel()
+        connectionTask = nil
+        retryTask?.cancel()
+        retryTask = nil
+        let client = client
+        let subscriptionId = handle?.subscriptionId
+        self.client = nil
+        handle = nil
+        isAvailable = false
+        if let client, let subscriptionId {
+            Task {
+                _ = try? await client.unsubscribe(subscriptionId: subscriptionId)
+            }
+        }
+    }
+
+    func retryIfNeeded(now: Date = Date()) {
+        guard !isAvailable, retryTask == nil else { return }
+        if let lastAttemptAt, now.timeIntervalSince(lastAttemptAt) < retryInterval {
+            return
+        }
+        lastAttemptAt = now
+        guard let client, handle != nil else {
+            guard connectionTask == nil else { return }
+            beginConnection(attemptDate: now)
+            return
+        }
+        retryTask = Task { [weak self] in
+            _ = try? await client.ping()
+            guard let self, !Task.isCancelled else { return }
+            self.retryTask = nil
+        }
+    }
+
+    private func beginConnection(attemptDate: Date = Date()) {
+        lastAttemptAt = attemptDate
+        generation &+= 1
+        let attemptGeneration = generation
+        connectionTask = Task { [weak self] in
+            guard let self else { return }
+            do {
+                let client = await RemoteHelperClientPool.shared.client(for: host)
+                let hello = try await client.hello()
+                guard kinds.allSatisfy({ hello.capabilities.watchKinds.contains($0) }) else {
+                    await client.shutdown()
+                    throw RemoteHelperClientError.unavailable("helper does not support requested watch kinds")
+                }
+                let handle = try await client.subscribeWithUpdates(root: root, kinds: kinds)
+                guard !Task.isCancelled, generation == attemptGeneration else {
+                    _ = try? await client.unsubscribe(subscriptionId: handle.subscriptionId)
+                    return
+                }
+                self.client = client
+                self.handle = handle
+                setAvailable(true)
+
+                for await update in handle.updates {
+                    guard !Task.isCancelled, generation == attemptGeneration else { return }
+                    switch update {
+                    case .available:
+                        setAvailable(true)
+                    case .unavailable:
+                        setAvailable(false)
+                    case .event(let event):
+                        onEvent?(event)
+                    }
+                }
+            } catch {
+                guard !Task.isCancelled, generation == attemptGeneration else { return }
+                setAvailable(false)
+            }
+            guard generation == attemptGeneration else { return }
+            self.client = nil
+            self.handle = nil
+            self.connectionTask = nil
+            setAvailable(false)
+        }
+    }
+
+    private func setAvailable(_ available: Bool) {
+        guard isAvailable != available else { return }
+        isAvailable = available
+        onAvailabilityChanged?(available)
+    }
+}

--- a/Alas/Sources/SSH/RemoteHelperWatchSession.swift
+++ b/Alas/Sources/SSH/RemoteHelperWatchSession.swift
@@ -1,21 +1,57 @@
 import Foundation
 
+struct RemoteHelperRetryGate {
+    private let retryInterval: TimeInterval
+    private var lastAttemptAt: Date?
+    private(set) var isAvailable = false
+
+    init(retryInterval: TimeInterval) {
+        self.retryInterval = retryInterval
+    }
+
+    func shouldAttempt(now: Date) -> Bool {
+        guard !isAvailable else { return false }
+        if let lastAttemptAt, now.timeIntervalSince(lastAttemptAt) < retryInterval {
+            return false
+        }
+        return true
+    }
+
+    mutating func markAttempt(at date: Date) {
+        lastAttemptAt = date
+    }
+
+    mutating func setAvailable(_ available: Bool) -> Bool {
+        let wasAvailable = isAvailable
+        guard wasAvailable != available else { return false }
+        isAvailable = available
+        if available || wasAvailable {
+            lastAttemptAt = nil
+        }
+        return true
+    }
+
+    mutating func stop() {
+        isAvailable = false
+        lastAttemptAt = nil
+    }
+}
+
 @MainActor
 final class RemoteHelperWatchSession {
     var onEvent: ((RemoteHelperWatchEvent) -> Void)?
     var onAvailabilityChanged: ((Bool) -> Void)?
 
-    private(set) var isAvailable = false
+    var isAvailable: Bool { retryGate.isAvailable }
 
     private let host: String
     private let root: String
     private let kinds: [RemoteHelperWatchKind]
-    private let retryInterval: TimeInterval
+    private var retryGate: RemoteHelperRetryGate
     private var connectionTask: Task<Void, Never>?
     private var retryTask: Task<Void, Never>?
     private var client: RemoteHelperClient?
     private var handle: RemoteHelperWatchHandle?
-    private var lastAttemptAt: Date?
     private var generation = 0
 
     init(
@@ -27,7 +63,7 @@ final class RemoteHelperWatchSession {
         self.host = host
         self.root = root
         self.kinds = kinds
-        self.retryInterval = retryInterval
+        self.retryGate = RemoteHelperRetryGate(retryInterval: retryInterval)
     }
 
     func start() {
@@ -45,7 +81,7 @@ final class RemoteHelperWatchSession {
         let subscriptionId = handle?.subscriptionId
         self.client = nil
         handle = nil
-        isAvailable = false
+        retryGate.stop()
         if let client, let subscriptionId {
             Task {
                 _ = try? await client.unsubscribe(subscriptionId: subscriptionId)
@@ -55,22 +91,20 @@ final class RemoteHelperWatchSession {
 
     func retryIfNeeded(now: Date = Date()) {
         guard !isAvailable, retryTask == nil else { return }
-        if let lastAttemptAt, now.timeIntervalSince(lastAttemptAt) < retryInterval {
-            return
-        }
-        lastAttemptAt = now
+        guard retryGate.shouldAttempt(now: now) else { return }
         guard let client, handle != nil else {
             guard connectionTask == nil else { return }
             beginConnection(attemptDate: now)
             return
         }
+        retryGate.markAttempt(at: now)
         retryTask = Task { [weak self] in
             do {
                 _ = try await client.ping()
             } catch RemoteHelperClientError.notRunning {
                 // Keep the subscription registered locally so the next helper process can replay it.
             } catch {
-                await self?.dropStaleSubscription(client: client, subscriptionId: handle?.subscriptionId)
+                await self?.dropStaleSubscription(client: client, subscriptionId: self?.handle?.subscriptionId)
             }
             guard let self, !Task.isCancelled else { return }
             self.retryTask = nil
@@ -89,7 +123,7 @@ final class RemoteHelperWatchSession {
     }
 
     private func beginConnection(attemptDate: Date = Date()) {
-        lastAttemptAt = attemptDate
+        retryGate.markAttempt(at: attemptDate)
         generation &+= 1
         let attemptGeneration = generation
         connectionTask = Task { [weak self] in
@@ -134,8 +168,7 @@ final class RemoteHelperWatchSession {
     }
 
     private func setAvailable(_ available: Bool) {
-        guard isAvailable != available else { return }
-        isAvailable = available
+        guard retryGate.setAvailable(available) else { return }
         onAvailabilityChanged?(available)
     }
 }

--- a/Alas/Sources/SSH/RemoteProjectGitWatcher.swift
+++ b/Alas/Sources/SSH/RemoteProjectGitWatcher.swift
@@ -12,6 +12,29 @@ enum RemotePollCadence {
     }
 }
 
+struct RemoteProjectGitTickGate {
+    private var isTicking = false
+    private var hasPendingTick = false
+
+    mutating func beginOrMarkPending() -> Bool {
+        guard !isTicking else {
+            hasPendingTick = true
+            return false
+        }
+        isTicking = true
+        return true
+    }
+
+    mutating func finishTick() -> Bool {
+        guard hasPendingTick else {
+            isTicking = false
+            return false
+        }
+        hasPendingTick = false
+        return true
+    }
+}
+
 @MainActor
 final class RemoteProjectGitWatcher {
     var onHeadChanged: (([URL: String]) -> Void)?
@@ -22,6 +45,7 @@ final class RemoteProjectGitWatcher {
     private var pollTask: Task<Void, Never>?
     private var helperSession: RemoteHelperWatchSession?
     private var lastEntries: [RemoteWorktreePollEntry]?
+    private var tickGate = RemoteProjectGitTickGate()
 
     init(projectPath: URL) {
         self.projectPath = projectPath
@@ -38,7 +62,7 @@ final class RemoteProjectGitWatcher {
             )
             session.onEvent = { [weak self] event in
                 guard event.kind == .git else { return }
-                Task { @MainActor in _ = await self?.tick() }
+                Task { @MainActor in _ = await self?.runTick() }
             }
             session.onAvailabilityChanged = { [weak self] _ in
                 self?.restartPolling()
@@ -62,10 +86,10 @@ final class RemoteProjectGitWatcher {
                         return
                     }
                     guard !Task.isCancelled else { return }
-                    _ = await tick()
+                    _ = await runTick()
                     continue
                 }
-                let succeeded = await tick()
+                let succeeded = await runTick()
                 helperSession?.retryIfNeeded()
                 delay = RemotePollCadence.nextDelay(
                     succeeded: succeeded,
@@ -84,7 +108,16 @@ final class RemoteProjectGitWatcher {
         helperSession = nil
     }
 
-    private func tick() async -> Bool {
+    private func runTick() async -> Bool {
+        guard tickGate.beginOrMarkPending() else { return true }
+        var succeeded = true
+        repeat {
+            succeeded = await tickOnce()
+        } while tickGate.finishTick()
+        return succeeded
+    }
+
+    private func tickOnce() async -> Bool {
         let result = try? await Process.git(["worktree", "list", "--porcelain"], cwd: projectPath)
         guard let result, !RemoteExec.isConnectionFailure(exitCode: result.exitCode) else {
             if let host { RemoteHostStatusStore.shared.reportConnectionFailure(host: host) }

--- a/Alas/Sources/SSH/RemoteProjectGitWatcher.swift
+++ b/Alas/Sources/SSH/RemoteProjectGitWatcher.swift
@@ -5,6 +5,7 @@ enum RemotePollCadence {
     static let activeInterval: TimeInterval = 5
     static let inactiveInterval: TimeInterval = 45
     static let maxBackoff: TimeInterval = 300
+    static let helperSafetyNetInterval: TimeInterval = 300
 
     static func nextDelay(succeeded: Bool, appActive: Bool, previous: TimeInterval) -> TimeInterval {
         succeeded ? (appActive ? activeInterval : inactiveInterval) : min(previous * 2, maxBackoff)
@@ -19,6 +20,7 @@ final class RemoteProjectGitWatcher {
     private let projectPath: URL
     private let host: String?
     private var pollTask: Task<Void, Never>?
+    private var helperSession: RemoteHelperWatchSession?
     private var lastEntries: [RemoteWorktreePollEntry]?
 
     init(projectPath: URL) {
@@ -27,12 +29,44 @@ final class RemoteProjectGitWatcher {
     }
 
     func start() {
-        guard pollTask == nil else { return }
+        guard pollTask == nil, helperSession == nil else { return }
+        if let host {
+            let session = RemoteHelperWatchSession(
+                host: host,
+                root: projectPath.path,
+                kinds: [.git]
+            )
+            session.onEvent = { [weak self] event in
+                guard event.kind == .git else { return }
+                Task { @MainActor in _ = await self?.tick() }
+            }
+            session.onAvailabilityChanged = { [weak self] _ in
+                self?.restartPolling()
+            }
+            helperSession = session
+            session.start()
+        }
+        restartPolling()
+    }
+
+    private func restartPolling() {
+        pollTask?.cancel()
         pollTask = Task { [weak self] in
             var delay = RemotePollCadence.activeInterval
             while !Task.isCancelled {
                 guard let self else { return }
+                if helperSession?.isAvailable == true {
+                    do {
+                        try await Task.sleep(nanoseconds: UInt64(RemotePollCadence.helperSafetyNetInterval * 1_000_000_000))
+                    } catch {
+                        return
+                    }
+                    guard !Task.isCancelled else { return }
+                    _ = await tick()
+                    continue
+                }
                 let succeeded = await tick()
+                helperSession?.retryIfNeeded()
                 delay = RemotePollCadence.nextDelay(
                     succeeded: succeeded,
                     appActive: NSApp?.isActive ?? true,
@@ -46,6 +80,8 @@ final class RemoteProjectGitWatcher {
     func stop() {
         pollTask?.cancel()
         pollTask = nil
+        helperSession?.stop()
+        helperSession = nil
     }
 
     private func tick() async -> Bool {

--- a/AlasHelper/Cargo.lock
+++ b/AlasHelper/Cargo.lock
@@ -4,10 +4,46 @@ version = 4
 
 [[package]]
 name = "alas-helper"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
+ "notify",
  "serde",
  "serde_json",
+]
+
+[[package]]
+name = "bitflags"
+version = "2.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4388bee8683e3d04af747c73422af53102d2bd24d9eadb6cbc100baef4b43f8"
+
+[[package]]
+name = "fsevent-sys"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76ee7a02da4d231650c7cea31349b889be2f45ddb3ef3032d2ec8185f6313fd2"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "inotify"
+version = "0.11.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "153be1941a183ec9ccd095ddbe17a8b8d435ef6c76e9e02451b933c3999af2c8"
+dependencies = [
+ "bitflags",
+ "inotify-sys",
+ "libc",
+]
+
+[[package]]
+name = "inotify-sys"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c033f80b2c113cdf91ab7a33faa9cbc014726dcad99880c8609af2a370edf37d"
+dependencies = [
+ "libc",
 ]
 
 [[package]]
@@ -17,10 +53,81 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
+name = "kqueue"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "273c0752728918e0ac4976f2b275b6fefb9ecd400585dec929419f3844cd87b5"
+dependencies = [
+ "kqueue-sys",
+ "libc",
+]
+
+[[package]]
+name = "kqueue-sys"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07293a4e297ac234359b510362495713f75ea345d5307140414f20c69ffeb087"
+dependencies = [
+ "bitflags",
+ "libc",
+]
+
+[[package]]
+name = "libc"
+version = "0.2.186"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
+
+[[package]]
+name = "log"
+version = "0.4.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad"
+
+[[package]]
 name = "memchr"
 version = "2.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98"
+
+[[package]]
+name = "mio"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02bd0af71c67b473010cbbc60715ee815645a4dc942899111f494b4b737d6fda"
+dependencies = [
+ "libc",
+ "log",
+ "wasi",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "notify"
+version = "8.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d3d07927151ff8575b7087f245456e549fea62edf0ec4e565a5ee50c8402bc3"
+dependencies = [
+ "bitflags",
+ "fsevent-sys",
+ "inotify",
+ "kqueue",
+ "libc",
+ "log",
+ "mio",
+ "notify-types",
+ "walkdir",
+ "windows-sys 0.60.2",
+]
+
+[[package]]
+name = "notify-types"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42b8cfee0e339a0337359f3c88165702ac6e600dc01c0cc9579a92d62b08477a"
+dependencies = [
+ "bitflags",
+]
 
 [[package]]
 name = "proc-macro2"
@@ -38,6 +145,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dfbc457d0c7a0759a614551b11a6409e5951f6c7537be1f1b7682b9ae9230368"
 dependencies = [
  "proc-macro2",
+]
+
+[[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
 ]
 
 [[package]]
@@ -99,6 +215,120 @@ name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
+
+[[package]]
+name = "walkdir"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
+dependencies = [
+ "same-file",
+ "winapi-util",
+]
+
+[[package]]
+name = "wasi"
+version = "0.11.1+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
+
+[[package]]
+name = "winapi-util"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "windows-link"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-sys"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
+dependencies = [
+ "windows-targets",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.61.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.53.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
+dependencies = [
+ "windows-link",
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_gnullvm",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
+]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "960e6da069d81e09becb0ca57a65220ddff016ff2d6af6a223cf372a506593a3"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
 name = "zmij"

--- a/AlasHelper/Cargo.toml
+++ b/AlasHelper/Cargo.toml
@@ -1,10 +1,11 @@
 [package]
 name = "alas-helper"
-version = "0.2.0"
+version = "0.3.0"
 edition = "2024"
 publish = false
 
 [dependencies]
+notify = "8.2.0"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 

--- a/AlasHelper/manifest.json
+++ b/AlasHelper/manifest.json
@@ -1,1 +1,1 @@
-{"name":"alas-helper","protocolVersion":1,"binaryVersion":"0.2.0"}
+{"name":"alas-helper","protocolVersion":1,"binaryVersion":"0.3.0"}

--- a/AlasHelper/src/main.rs
+++ b/AlasHelper/src/main.rs
@@ -1,9 +1,14 @@
+mod watch;
+
 use serde::{Deserialize, Serialize};
 use serde_json::{Value, json};
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::io::{self, BufRead, Write};
 use std::path::{Path, PathBuf};
-use std::time::{SystemTime, UNIX_EPOCH};
+use std::sync::mpsc::{self, RecvTimeoutError, Sender};
+use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
+
+use watch::{SubscriptionWatcher, WatchKind, WatchNotification};
 
 const PROTOCOL_VERSION: u32 = 1;
 
@@ -28,10 +33,12 @@ struct HelperError {
     message: String,
 }
 
-#[derive(Debug, Default)]
+#[derive(Default)]
 struct HelperState {
     next_subscription_id: u64,
     subscriptions: HashMap<String, PathBuf>,
+    watchers: HashMap<String, SubscriptionWatcher>,
+    event_sender: Option<Sender<ServerMessage>>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -66,6 +73,12 @@ struct FsStatParams {
     paths: Vec<String>,
 }
 
+pub(crate) enum ServerMessage {
+    Request(String),
+    Watch(WatchNotification),
+    InputClosed,
+}
+
 fn handshake() -> Handshake<'static> {
     Handshake {
         name: env!("CARGO_PKG_NAME"),
@@ -76,7 +89,7 @@ fn handshake() -> Handshake<'static> {
 
 fn capabilities() -> Value {
     json!({
-        "watchKinds": [],
+        "watchKinds": ["files", "git"],
         "fs": {
             "read": true,
             "write": true,
@@ -109,20 +122,103 @@ fn main() {
 }
 
 fn serve() -> io::Result<()> {
-    let stdin = io::stdin();
-    let mut stdout = io::stdout().lock();
-    let mut state = HelperState::default();
+    const DEBOUNCE: Duration = Duration::from_millis(250);
+    let (sender, receiver) = mpsc::channel();
+    let input_sender = sender.clone();
+    std::thread::spawn(move || {
+        let stdin = io::stdin();
+        for line in stdin.lock().lines() {
+            match line {
+                Ok(line) => {
+                    if input_sender.send(ServerMessage::Request(line)).is_err() {
+                        break;
+                    }
+                }
+                Err(_) => break,
+            }
+        }
+        let _ = input_sender.send(ServerMessage::InputClosed);
+    });
 
-    for line in stdin.lock().lines() {
-        let line = line?;
-        if line.trim().is_empty() {
+    let mut stdout = io::stdout().lock();
+    let mut state = HelperState {
+        event_sender: Some(sender),
+        ..HelperState::default()
+    };
+    let mut pending_events: HashMap<(String, WatchKind), HashSet<String>> = HashMap::new();
+    let mut flush_at: Option<Instant> = None;
+
+    loop {
+        let message = match flush_at {
+            Some(deadline) => {
+                let timeout = deadline.saturating_duration_since(Instant::now());
+                match receiver.recv_timeout(timeout) {
+                    Ok(message) => Some(message),
+                    Err(RecvTimeoutError::Timeout) => None,
+                    Err(RecvTimeoutError::Disconnected) => break,
+                }
+            }
+            None => match receiver.recv() {
+                Ok(message) => Some(message),
+                Err(_) => break,
+            },
+        };
+
+        match message {
+            Some(ServerMessage::Request(line)) => {
+                if line.trim().is_empty() {
+                    continue;
+                }
+                if let Some(response) = handle_line(&mut state, &line) {
+                    write_json_line(&mut stdout, &response)?;
+                }
+            }
+            Some(ServerMessage::Watch(notification)) => {
+                pending_events
+                    .entry((notification.subscription_id, notification.kind))
+                    .or_default()
+                    .extend(notification.paths);
+                flush_at.get_or_insert_with(|| Instant::now() + DEBOUNCE);
+            }
+            Some(ServerMessage::InputClosed) => {
+                flush_watch_events(&mut stdout, &state, &mut pending_events)?;
+                break;
+            }
+            None => {
+                flush_watch_events(&mut stdout, &state, &mut pending_events)?;
+                flush_at = None;
+            }
+        }
+    }
+    Ok(())
+}
+
+fn write_json_line(stdout: &mut impl Write, line: &str) -> io::Result<()> {
+    writeln!(stdout, "{line}")?;
+    stdout.flush()
+}
+
+fn flush_watch_events(
+    stdout: &mut impl Write,
+    state: &HelperState,
+    pending: &mut HashMap<(String, WatchKind), HashSet<String>>,
+) -> io::Result<()> {
+    let events = std::mem::take(pending);
+    for ((subscription_id, kind), paths) in events {
+        let Some(root) = state.subscriptions.get(&subscription_id) else {
             continue;
-        }
-        let response = handle_line(&mut state, &line);
-        if let Some(response) = response {
-            writeln!(stdout, "{response}")?;
-            stdout.flush()?;
-        }
+        };
+        let notification = json!({
+            "jsonrpc": "2.0",
+            "method": "watch/event",
+            "params": {
+                "subscriptionId": subscription_id,
+                "root": root.display().to_string(),
+                "kind": kind.as_str(),
+                "paths": paths.into_iter().collect::<Vec<_>>()
+            }
+        });
+        write_json_line(stdout, &notification.to_string())?;
     }
     Ok(())
 }
@@ -180,8 +276,24 @@ fn watch_subscribe(state: &mut HelperState, params: Option<Value>) -> Result<Val
     let params: WatchSubscribeParams = decode_params(params)?;
     let root = std::fs::canonicalize(&params.root)
         .map_err(|error| jsonrpc_error(-32010, format!("invalid root: {error}")))?;
+    let kinds: HashSet<_> = params
+        .kinds
+        .iter()
+        .map(|kind| {
+            WatchKind::parse(kind)
+                .ok_or_else(|| jsonrpc_error(-32602, format!("unsupported watch kind: {kind}")))
+        })
+        .collect::<Result<_, _>>()?;
+    if kinds.is_empty() {
+        return Err(jsonrpc_error(-32602, "at least one watch kind is required"));
+    }
     state.next_subscription_id += 1;
     let id = state.next_subscription_id.to_string();
+    if let Some(sender) = state.event_sender.clone() {
+        let watcher = SubscriptionWatcher::new(id.clone(), root.clone(), kinds, sender)
+            .map_err(|error| jsonrpc_error(-32011, error))?;
+        state.watchers.insert(id.clone(), watcher);
+    }
     state.subscriptions.insert(id.clone(), root);
     Ok(json!({ "subscriptionId": id }))
 }
@@ -189,6 +301,7 @@ fn watch_subscribe(state: &mut HelperState, params: Option<Value>) -> Result<Val
 fn watch_unsubscribe(state: &mut HelperState, params: Option<Value>) -> Result<Value, HelperError> {
     let params: WatchUnsubscribeParams = decode_params(params)?;
     state.subscriptions.remove(&params.subscription_id);
+    state.watchers.remove(&params.subscription_id);
     Ok(json!({ "ok": true }))
 }
 
@@ -540,11 +653,9 @@ mod tests {
         .expect("response");
         let value: Value = serde_json::from_str(&response).expect("json");
         assert_eq!(value["result"]["protocolVersion"], 1);
-        assert!(
-            value["result"]["capabilities"]["watchKinds"]
-                .as_array()
-                .expect("watch kinds")
-                .is_empty()
+        assert_eq!(
+            value["result"]["capabilities"]["watchKinds"],
+            json!(["files", "git"])
         );
         assert_eq!(value["result"]["capabilities"]["fs"]["read"], true);
     }

--- a/AlasHelper/src/main.rs
+++ b/AlasHelper/src/main.rs
@@ -166,6 +166,7 @@ fn serve() -> io::Result<()> {
 
         match message {
             Some(ServerMessage::Request(line)) => {
+                flush_due_watch_events(&mut stdout, &state, &mut pending_events, &mut flush_at)?;
                 if line.trim().is_empty() {
                     continue;
                 }
@@ -191,6 +192,23 @@ fn serve() -> io::Result<()> {
         }
     }
     Ok(())
+}
+
+fn flush_due_watch_events(
+    stdout: &mut impl Write,
+    state: &HelperState,
+    pending: &mut HashMap<(String, WatchKind), HashSet<String>>,
+    flush_at: &mut Option<Instant>,
+) -> io::Result<bool> {
+    let Some(deadline) = *flush_at else {
+        return Ok(false);
+    };
+    if deadline > Instant::now() {
+        return Ok(false);
+    }
+    flush_watch_events(stdout, state, pending)?;
+    *flush_at = None;
+    Ok(true)
 }
 
 fn write_json_line(stdout: &mut impl Write, line: &str) -> io::Result<()> {
@@ -670,6 +688,30 @@ mod tests {
             )
             .is_none()
         );
+    }
+
+    #[test]
+    fn due_watch_events_flush_before_processing_more_requests() {
+        let mut state = HelperState::default();
+        state
+            .subscriptions
+            .insert("1".to_string(), PathBuf::from("/repo"));
+        let mut pending = HashMap::from([(
+            ("1".to_string(), WatchKind::Files),
+            HashSet::from(["/repo/file.txt".to_string()]),
+        )]);
+        let mut flush_at = Some(Instant::now() - Duration::from_millis(1));
+        let mut output = Vec::new();
+
+        let did_flush = flush_due_watch_events(&mut output, &state, &mut pending, &mut flush_at)
+            .expect("flush due watch events");
+
+        assert!(did_flush);
+        assert!(flush_at.is_none());
+        assert!(pending.is_empty());
+        let output = String::from_utf8(output).expect("utf8 output");
+        assert!(output.contains(r#""method":"watch/event""#));
+        assert!(output.contains("/repo/file.txt"));
     }
 
     #[test]

--- a/AlasHelper/src/watch.rs
+++ b/AlasHelper/src/watch.rs
@@ -211,7 +211,11 @@ fn is_relevant_git_path(path: &Path, info: &GitInfo) -> bool {
     };
     let relative = relative.to_string_lossy();
     let relative = relative.trim_matches('/');
-    if relative == "packed-refs" || relative.starts_with("refs/heads/") {
+    if relative == "packed-refs"
+        || relative == "refs/stash"
+        || relative == "logs/refs/stash"
+        || relative.starts_with("refs/heads/")
+    {
         return true;
     }
     if relative == "worktrees" {
@@ -286,6 +290,11 @@ mod tests {
         ));
         assert!(is_relevant_git_path(
             &root.join(".git/refs/heads/main"),
+            &info
+        ));
+        assert!(is_relevant_git_path(&root.join(".git/refs/stash"), &info));
+        assert!(is_relevant_git_path(
+            &root.join(".git/logs/refs/stash"),
             &info
         ));
         assert!(is_relevant_git_path(&root.join(".git/packed-refs"), &info));

--- a/AlasHelper/src/watch.rs
+++ b/AlasHelper/src/watch.rs
@@ -83,6 +83,14 @@ impl SubscriptionWatcher {
                     .watch(&info.common_dir, RecursiveMode::Recursive)
                     .map_err(|error| format!("watch git dir failed: {error}"))?;
             }
+            if info.worktree_dir != info.common_dir
+                && !info.worktree_dir.starts_with(&root)
+                && !info.worktree_dir.starts_with(&info.common_dir)
+            {
+                watcher
+                    .watch(&info.worktree_dir, RecursiveMode::Recursive)
+                    .map_err(|error| format!("watch worktree git dir failed: {error}"))?;
+            }
         }
         Ok(Self { _watcher: watcher })
     }
@@ -91,11 +99,12 @@ impl SubscriptionWatcher {
 #[derive(Clone, Debug)]
 struct GitInfo {
     common_dir: PathBuf,
+    worktree_dir: PathBuf,
 }
 
 fn resolve_git_info(root: &Path) -> Option<GitInfo> {
     let output = Command::new("git")
-        .args(["rev-parse", "--git-common-dir"])
+        .args(["rev-parse", "--git-common-dir", "--absolute-git-dir"])
         .current_dir(root)
         .output()
         .ok()?;
@@ -105,17 +114,24 @@ fn resolve_git_info(root: &Path) -> Option<GitInfo> {
     let stdout = String::from_utf8(output.stdout).ok()?;
     let mut lines = stdout.lines();
     let common = lines.next()?.trim();
-    if common.is_empty() {
+    let worktree = lines.next()?.trim();
+    if common.is_empty() || worktree.is_empty() {
         return None;
     }
-    let common_dir = if Path::new(common).is_absolute() {
-        PathBuf::from(common)
-    } else {
-        root.join(common)
-    };
     Some(GitInfo {
-        common_dir: canonical_or_normalized(&common_dir),
+        common_dir: resolve_git_path(root, common),
+        worktree_dir: resolve_git_path(root, worktree),
     })
+}
+
+fn resolve_git_path(root: &Path, path: &str) -> PathBuf {
+    let path = Path::new(path);
+    let resolved = if path.is_absolute() {
+        path.to_path_buf()
+    } else {
+        root.join(path)
+    };
+    canonical_or_normalized(&resolved)
 }
 
 fn canonical_or_normalized(path: &Path) -> PathBuf {
@@ -149,6 +165,7 @@ fn classify_paths(
         if kinds.contains(&WatchKind::Files)
             && path.starts_with(root)
             && !git_info.is_some_and(|info| path.starts_with(&info.common_dir))
+            && !git_info.is_some_and(|info| path.starts_with(&info.worktree_dir))
         {
             file_paths.insert(path.display().to_string());
         }
@@ -157,17 +174,27 @@ fn classify_paths(
 }
 
 fn is_relevant_git_path(path: &Path, info: &GitInfo) -> bool {
+    if path
+        .extension()
+        .is_some_and(|extension| extension == "lock")
+    {
+        return false;
+    }
+    if let Ok(relative) = path.strip_prefix(&info.worktree_dir) {
+        let relative = relative.to_string_lossy();
+        let relative = relative.trim_matches('/');
+        if matches!(
+            relative,
+            "HEAD" | "index" | "MERGE_HEAD" | "CHERRY_PICK_HEAD" | "REVERT_HEAD" | "REBASE_HEAD"
+        ) {
+            return true;
+        }
+    }
     let Ok(relative) = path.strip_prefix(&info.common_dir) else {
         return false;
     };
     let relative = relative.to_string_lossy();
     let relative = relative.trim_matches('/');
-    if relative.ends_with(".lock") {
-        return false;
-    }
-    if relative == "HEAD" {
-        return true;
-    }
     if relative == "packed-refs" || relative.starts_with("refs/heads/") {
         return true;
     }
@@ -188,6 +215,7 @@ mod tests {
     fn git_info(root: &Path) -> GitInfo {
         GitInfo {
             common_dir: root.join(".git"),
+            worktree_dir: root.join(".git"),
         }
     }
 
@@ -205,9 +233,32 @@ mod tests {
             &info
         ));
         assert!(is_relevant_git_path(&root.join(".git/packed-refs"), &info));
-        assert!(!is_relevant_git_path(&root.join(".git/index"), &info));
+        assert!(is_relevant_git_path(&root.join(".git/index"), &info));
+        assert!(is_relevant_git_path(&root.join(".git/MERGE_HEAD"), &info));
         assert!(!is_relevant_git_path(&root.join(".git/index.lock"), &info));
         assert!(!is_relevant_git_path(&root.join("src/main.rs"), &info));
+    }
+
+    #[test]
+    fn linked_worktree_index_and_operation_state_are_git_events() {
+        let root = Path::new("/repo");
+        let info = GitInfo {
+            common_dir: root.join(".git"),
+            worktree_dir: root.join(".git/worktrees/feature"),
+        };
+
+        assert!(is_relevant_git_path(
+            &root.join(".git/worktrees/feature/index"),
+            &info
+        ));
+        assert!(is_relevant_git_path(
+            &root.join(".git/worktrees/feature/CHERRY_PICK_HEAD"),
+            &info
+        ));
+        assert!(!is_relevant_git_path(
+            &root.join(".git/worktrees/other/index"),
+            &info
+        ));
     }
 
     #[test]
@@ -227,6 +278,12 @@ mod tests {
         );
 
         assert_eq!(files, HashSet::from(["/repo/README.md".to_string()]));
-        assert_eq!(git, HashSet::from(["/repo/.git/HEAD".to_string()]));
+        assert_eq!(
+            git,
+            HashSet::from([
+                "/repo/.git/HEAD".to_string(),
+                "/repo/.git/index".to_string()
+            ])
+        );
     }
 }

--- a/AlasHelper/src/watch.rs
+++ b/AlasHelper/src/watch.rs
@@ -211,10 +211,12 @@ fn is_relevant_git_path(path: &Path, info: &GitInfo) -> bool {
     };
     let relative = relative.to_string_lossy();
     let relative = relative.trim_matches('/');
-    if relative == "packed-refs"
+    if relative == "FETCH_HEAD"
+        || relative == "packed-refs"
         || relative == "refs/stash"
         || relative == "logs/refs/stash"
         || relative.starts_with("refs/heads/")
+        || relative.starts_with("refs/remotes/")
     {
         return true;
     }
@@ -290,6 +292,11 @@ mod tests {
         ));
         assert!(is_relevant_git_path(
             &root.join(".git/refs/heads/main"),
+            &info
+        ));
+        assert!(is_relevant_git_path(&root.join(".git/FETCH_HEAD"), &info));
+        assert!(is_relevant_git_path(
+            &root.join(".git/refs/remotes/origin/main"),
             &info
         ));
         assert!(is_relevant_git_path(&root.join(".git/refs/stash"), &info));

--- a/AlasHelper/src/watch.rs
+++ b/AlasHelper/src/watch.rs
@@ -1,0 +1,232 @@
+use notify::{Event, EventKind, RecommendedWatcher, RecursiveMode, Watcher};
+use std::collections::HashSet;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+use std::sync::mpsc::Sender;
+
+use crate::ServerMessage;
+
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+pub enum WatchKind {
+    Files,
+    Git,
+}
+
+impl WatchKind {
+    pub fn parse(value: &str) -> Option<Self> {
+        match value {
+            "files" => Some(Self::Files),
+            "git" => Some(Self::Git),
+            _ => None,
+        }
+    }
+
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Files => "files",
+            Self::Git => "git",
+        }
+    }
+}
+
+#[derive(Debug)]
+pub struct WatchNotification {
+    pub subscription_id: String,
+    pub kind: WatchKind,
+    pub paths: Vec<String>,
+}
+
+pub struct SubscriptionWatcher {
+    _watcher: RecommendedWatcher,
+}
+
+impl SubscriptionWatcher {
+    pub fn new(
+        subscription_id: String,
+        root: PathBuf,
+        kinds: HashSet<WatchKind>,
+        sender: Sender<ServerMessage>,
+    ) -> Result<Self, String> {
+        let git_info = resolve_git_info(&root);
+        let callback_root = root.clone();
+        let callback_git_info = git_info.clone();
+        let mut watcher = notify::recommended_watcher(move |result: notify::Result<Event>| {
+            let Ok(event) = result else { return };
+            if matches!(event.kind, EventKind::Access(_)) {
+                return;
+            }
+            let (file_paths, git_paths) = classify_paths(
+                event.paths,
+                &callback_root,
+                callback_git_info.as_ref(),
+                &kinds,
+            );
+            for (kind, paths) in [(WatchKind::Files, file_paths), (WatchKind::Git, git_paths)] {
+                if paths.is_empty() {
+                    continue;
+                }
+                let _ = sender.send(ServerMessage::Watch(WatchNotification {
+                    subscription_id: subscription_id.clone(),
+                    kind,
+                    paths: paths.into_iter().collect(),
+                }));
+            }
+        })
+        .map_err(|error| format!("watcher creation failed: {error}"))?;
+
+        watcher
+            .watch(&root, RecursiveMode::Recursive)
+            .map_err(|error| format!("watch root failed: {error}"))?;
+        if let Some(info) = git_info {
+            if !info.common_dir.starts_with(&root) {
+                watcher
+                    .watch(&info.common_dir, RecursiveMode::Recursive)
+                    .map_err(|error| format!("watch git dir failed: {error}"))?;
+            }
+        }
+        Ok(Self { _watcher: watcher })
+    }
+}
+
+#[derive(Clone, Debug)]
+struct GitInfo {
+    common_dir: PathBuf,
+}
+
+fn resolve_git_info(root: &Path) -> Option<GitInfo> {
+    let output = Command::new("git")
+        .args(["rev-parse", "--git-common-dir"])
+        .current_dir(root)
+        .output()
+        .ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    let stdout = String::from_utf8(output.stdout).ok()?;
+    let mut lines = stdout.lines();
+    let common = lines.next()?.trim();
+    if common.is_empty() {
+        return None;
+    }
+    let common_dir = if Path::new(common).is_absolute() {
+        PathBuf::from(common)
+    } else {
+        root.join(common)
+    };
+    Some(GitInfo {
+        common_dir: canonical_or_normalized(&common_dir),
+    })
+}
+
+fn canonical_or_normalized(path: &Path) -> PathBuf {
+    std::fs::canonicalize(path).unwrap_or_else(|_| normalize_event_path(path))
+}
+
+fn normalize_event_path(path: &Path) -> PathBuf {
+    if path.is_absolute() {
+        path.to_path_buf()
+    } else {
+        std::env::current_dir().unwrap_or_default().join(path)
+    }
+}
+
+fn classify_paths(
+    paths: Vec<PathBuf>,
+    root: &Path,
+    git_info: Option<&GitInfo>,
+    kinds: &HashSet<WatchKind>,
+) -> (HashSet<String>, HashSet<String>) {
+    let mut file_paths = HashSet::new();
+    let mut git_paths = HashSet::new();
+    for path in paths {
+        let path = normalize_event_path(&path);
+        if kinds.contains(&WatchKind::Git)
+            && git_info.is_some_and(|info| is_relevant_git_path(&path, info))
+        {
+            git_paths.insert(path.display().to_string());
+            continue;
+        }
+        if kinds.contains(&WatchKind::Files)
+            && path.starts_with(root)
+            && !git_info.is_some_and(|info| path.starts_with(&info.common_dir))
+        {
+            file_paths.insert(path.display().to_string());
+        }
+    }
+    (file_paths, git_paths)
+}
+
+fn is_relevant_git_path(path: &Path, info: &GitInfo) -> bool {
+    let Ok(relative) = path.strip_prefix(&info.common_dir) else {
+        return false;
+    };
+    let relative = relative.to_string_lossy();
+    let relative = relative.trim_matches('/');
+    if relative.ends_with(".lock") {
+        return false;
+    }
+    if relative == "HEAD" {
+        return true;
+    }
+    if relative == "packed-refs" || relative.starts_with("refs/heads/") {
+        return true;
+    }
+    if relative == "worktrees" {
+        return true;
+    }
+    if let Some(rest) = relative.strip_prefix("worktrees/") {
+        let parts: Vec<_> = rest.split('/').filter(|part| !part.is_empty()).collect();
+        return parts.len() == 1 || (parts.len() == 2 && parts[1] == "HEAD");
+    }
+    false
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn git_info(root: &Path) -> GitInfo {
+        GitInfo {
+            common_dir: root.join(".git"),
+        }
+    }
+
+    #[test]
+    fn git_filter_matches_local_head_and_topology_rules() {
+        let root = Path::new("/repo");
+        let info = git_info(root);
+        assert!(is_relevant_git_path(&root.join(".git/HEAD"), &info));
+        assert!(is_relevant_git_path(
+            &root.join(".git/worktrees/feature/HEAD"),
+            &info
+        ));
+        assert!(is_relevant_git_path(
+            &root.join(".git/refs/heads/main"),
+            &info
+        ));
+        assert!(is_relevant_git_path(&root.join(".git/packed-refs"), &info));
+        assert!(!is_relevant_git_path(&root.join(".git/index"), &info));
+        assert!(!is_relevant_git_path(&root.join(".git/index.lock"), &info));
+        assert!(!is_relevant_git_path(&root.join("src/main.rs"), &info));
+    }
+
+    #[test]
+    fn paths_are_partitioned_into_file_and_filtered_git_events() {
+        let root = Path::new("/repo");
+        let info = git_info(root);
+        let (files, git) = classify_paths(
+            vec![
+                root.join("README.md"),
+                root.join(".git/HEAD"),
+                root.join(".git/index"),
+                root.join(".git/index.lock"),
+            ],
+            root,
+            Some(&info),
+            &HashSet::from([WatchKind::Files, WatchKind::Git]),
+        );
+
+        assert_eq!(files, HashSet::from(["/repo/README.md".to_string()]));
+        assert_eq!(git, HashSet::from(["/repo/.git/HEAD".to_string()]));
+    }
+}

--- a/AlasHelper/src/watch.rs
+++ b/AlasHelper/src/watch.rs
@@ -186,7 +186,11 @@ fn is_relevant_git_path(path: &Path, info: &GitInfo) -> bool {
         if matches!(
             relative,
             "HEAD" | "index" | "MERGE_HEAD" | "CHERRY_PICK_HEAD" | "REVERT_HEAD" | "REBASE_HEAD"
-        ) {
+        ) || relative == "rebase-merge"
+            || relative.starts_with("rebase-merge/")
+            || relative == "rebase-apply"
+            || relative.starts_with("rebase-apply/")
+        {
             return true;
         }
     }
@@ -253,6 +257,14 @@ mod tests {
         ));
         assert!(is_relevant_git_path(
             &root.join(".git/worktrees/feature/CHERRY_PICK_HEAD"),
+            &info
+        ));
+        assert!(is_relevant_git_path(
+            &root.join(".git/worktrees/feature/rebase-merge/git-rebase-todo"),
+            &info
+        ));
+        assert!(is_relevant_git_path(
+            &root.join(".git/worktrees/feature/rebase-apply/rebasing"),
             &info
         ));
         assert!(!is_relevant_git_path(

--- a/AlasHelper/src/watch.rs
+++ b/AlasHelper/src/watch.rs
@@ -48,6 +48,7 @@ impl SubscriptionWatcher {
         sender: Sender<ServerMessage>,
     ) -> Result<Self, String> {
         let git_info = resolve_git_info(&root);
+        let paths_to_watch = watch_paths(&root, git_info.as_ref(), &kinds);
         let callback_root = root.clone();
         let callback_git_info = git_info.clone();
         let mut watcher = notify::recommended_watcher(move |result: notify::Result<Event>| {
@@ -74,23 +75,10 @@ impl SubscriptionWatcher {
         })
         .map_err(|error| format!("watcher creation failed: {error}"))?;
 
-        watcher
-            .watch(&root, RecursiveMode::Recursive)
-            .map_err(|error| format!("watch root failed: {error}"))?;
-        if let Some(info) = git_info {
-            if !info.common_dir.starts_with(&root) {
-                watcher
-                    .watch(&info.common_dir, RecursiveMode::Recursive)
-                    .map_err(|error| format!("watch git dir failed: {error}"))?;
-            }
-            if info.worktree_dir != info.common_dir
-                && !info.worktree_dir.starts_with(&root)
-                && !info.worktree_dir.starts_with(&info.common_dir)
-            {
-                watcher
-                    .watch(&info.worktree_dir, RecursiveMode::Recursive)
-                    .map_err(|error| format!("watch worktree git dir failed: {error}"))?;
-            }
+        for path in paths_to_watch {
+            watcher
+                .watch(&path, RecursiveMode::Recursive)
+                .map_err(|error| format!("watch path {} failed: {error}", path.display()))?;
         }
         Ok(Self { _watcher: watcher })
     }
@@ -143,6 +131,30 @@ fn normalize_event_path(path: &Path) -> PathBuf {
         path.to_path_buf()
     } else {
         std::env::current_dir().unwrap_or_default().join(path)
+    }
+}
+
+fn watch_paths(
+    root: &Path,
+    git_info: Option<&GitInfo>,
+    kinds: &HashSet<WatchKind>,
+) -> Vec<PathBuf> {
+    let mut paths = Vec::new();
+    if kinds.contains(&WatchKind::Files) {
+        push_unique_path(&mut paths, root);
+    }
+    if kinds.contains(&WatchKind::Git) {
+        if let Some(info) = git_info {
+            push_unique_path(&mut paths, &info.common_dir);
+            push_unique_path(&mut paths, &info.worktree_dir);
+        }
+    }
+    paths
+}
+
+fn push_unique_path(paths: &mut Vec<PathBuf>, path: &Path) {
+    if !paths.iter().any(|existing| existing == path) {
+        paths.push(path.to_path_buf());
     }
 }
 
@@ -221,6 +233,46 @@ mod tests {
             common_dir: root.join(".git"),
             worktree_dir: root.join(".git"),
         }
+    }
+
+    #[test]
+    fn file_only_watch_registers_root_without_git_dirs() {
+        let root = Path::new("/repo");
+        let info = git_info(root);
+
+        assert_eq!(
+            watch_paths(root, Some(&info), &HashSet::from([WatchKind::Files])),
+            vec![root.to_path_buf()]
+        );
+    }
+
+    #[test]
+    fn git_only_watch_registers_git_dirs_without_root() {
+        let root = Path::new("/repo");
+        let info = GitInfo {
+            common_dir: PathBuf::from("/repos/shared/.git"),
+            worktree_dir: PathBuf::from("/repos/shared/.git/worktrees/feature"),
+        };
+
+        assert_eq!(
+            watch_paths(root, Some(&info), &HashSet::from([WatchKind::Git])),
+            vec![info.common_dir.clone(), info.worktree_dir.clone()]
+        );
+    }
+
+    #[test]
+    fn file_and_git_watch_registers_root_and_git_dirs_once() {
+        let root = Path::new("/repo");
+        let info = git_info(root);
+
+        assert_eq!(
+            watch_paths(
+                root,
+                Some(&info),
+                &HashSet::from([WatchKind::Files, WatchKind::Git])
+            ),
+            vec![root.to_path_buf(), root.join(".git")]
+        );
     }
 
     #[test]

--- a/AlasTests/EditorBufferTests.swift
+++ b/AlasTests/EditorBufferTests.swift
@@ -37,6 +37,51 @@ struct EditorBufferTests {
         #expect(nextCheck)
     }
 
+    @Test func remoteHelperFileWatchMatchesCanonicalEventRootByRelativePath() {
+        let matcher = RemoteHelperFileWatchMatcher(
+            targetURL: URL(fileURLWithPath: "/symlinked/repo/Sources/App.swift"),
+            watchedRootURL: URL(fileURLWithPath: "/symlinked/repo/Sources")
+        )
+        let event = RemoteHelperWatchEvent(
+            subscriptionId: "sub",
+            root: "/real/repo/Sources",
+            kind: .files,
+            paths: ["/real/repo/Sources/App.swift"]
+        )
+
+        #expect(matcher.matches(event: event))
+    }
+
+    @Test func remoteHelperFileWatchIgnoresSiblingUnderCanonicalEventRoot() {
+        let matcher = RemoteHelperFileWatchMatcher(
+            targetURL: URL(fileURLWithPath: "/symlinked/repo/Sources/App.swift"),
+            watchedRootURL: URL(fileURLWithPath: "/symlinked/repo/Sources")
+        )
+        let event = RemoteHelperWatchEvent(
+            subscriptionId: "sub",
+            root: "/real/repo/Sources",
+            kind: .files,
+            paths: ["/real/repo/Sources/Other.swift"]
+        )
+
+        #expect(!matcher.matches(event: event))
+    }
+
+    @Test func remoteHelperFileWatchMatchesSameAbsolutePath() {
+        let matcher = RemoteHelperFileWatchMatcher(
+            targetURL: URL(fileURLWithPath: "/repo/Sources/App.swift"),
+            watchedRootURL: URL(fileURLWithPath: "/repo/Sources")
+        )
+        let event = RemoteHelperWatchEvent(
+            subscriptionId: "sub",
+            root: "/repo/Sources",
+            kind: .files,
+            paths: ["/repo/Sources/App.swift"]
+        )
+
+        #expect(matcher.matches(event: event))
+    }
+
     @Test func coldLoadCapturesContentMtimeAndPerms() async throws {
         let root = tempWorktree()
         let url = try writeFile(root, "a.txt", "hello\nworld\n", perms: 0o644)

--- a/AlasTests/EditorBufferTests.swift
+++ b/AlasTests/EditorBufferTests.swift
@@ -21,6 +21,22 @@ struct EditorBufferTests {
         return url
     }
 
+    @Test func remoteConflictChecksCoalesceAnOverlappingRequest() {
+        var checks = RemoteConflictCheckCoalescer()
+
+        let initialCheck = checks.beginOrMarkPending()
+        let overlappingCheck = checks.beginOrMarkPending()
+        let shouldRepeat = checks.finishCheck()
+        let isDrained = !checks.finishCheck()
+        let nextCheck = checks.beginOrMarkPending()
+
+        #expect(initialCheck)
+        #expect(!overlappingCheck)
+        #expect(shouldRepeat)
+        #expect(isDrained)
+        #expect(nextCheck)
+    }
+
     @Test func coldLoadCapturesContentMtimeAndPerms() async throws {
         let root = tempWorktree()
         let url = try writeFile(root, "a.txt", "hello\nworld\n", perms: 0o644)

--- a/AlasTests/SSH/RemoteHelperClientTests.swift
+++ b/AlasTests/SSH/RemoteHelperClientTests.swift
@@ -57,7 +57,7 @@ struct RemoteHelperClientTests {
         {"jsonrpc":"2.0","id":1,"result":{
           "name":"alas-helper",
           "protocolVersion":1,
-          "binaryVersion":"0.2.0",
+          "binaryVersion":"0.3.0",
           "capabilities":{"watchKinds":[],"fs":{"read":true,"write":true,"stat":true},"ping":true}
         }}
         """#.utf8))
@@ -95,6 +95,48 @@ struct RemoteHelperClientTests {
             kind: .files,
             paths: ["/srv/repo/README.md"]
         ))
+    }
+
+    @Test func subscriptionUpdatesUseStableClientIdAndReportChannelLoss() async throws {
+        let transport = FakeJSONRPCTransport()
+        let client = RemoteHelperClient(
+            host: "devbox",
+            idleShutdownNanoseconds: 0,
+            transportFactory: { transport }
+        )
+
+        let subscribe = Task {
+            try await client.subscribeWithUpdates(root: "/srv/repo", kinds: [.files, .git])
+        }
+        try await waitUntil { !transport.sentFrames.isEmpty }
+        let request = try #require(
+            JSONSerialization.jsonObject(with: transport.sentFrames[0]) as? [String: Any]
+        )
+        let requestId = try #require(request["id"] as? Int)
+        transport.send(frame: Data(#"{"jsonrpc":"2.0","id":\#(requestId),"result":{"subscriptionId":"helper-9"}}"#.utf8))
+
+        let handle = try await subscribe.value
+        #expect(handle.subscriptionId == "client-1")
+        var updates = handle.updates.makeAsyncIterator()
+        #expect(await updates.next() == .available)
+
+        transport.send(frame: Data(#"""
+        {"jsonrpc":"2.0","method":"watch/event","params":{
+          "subscriptionId":"helper-9",
+          "root":"/srv/repo",
+          "kind":"files",
+          "paths":["/srv/repo/README.md"]
+        }}
+        """#.utf8))
+        #expect(await updates.next() == .event(RemoteHelperWatchEvent(
+            subscriptionId: "client-1",
+            root: "/srv/repo",
+            kind: .files,
+            paths: ["/srv/repo/README.md"]
+        )))
+
+        transport.send(exitStatus: 1)
+        #expect(await updates.next() == .unavailable)
     }
 
     @Test func jsonrpcErrorResponseStillSchedulesIdleShutdown() async throws {

--- a/AlasTests/SSH/RemoteHelperClientTests.swift
+++ b/AlasTests/SSH/RemoteHelperClientTests.swift
@@ -12,6 +12,30 @@ struct RemoteHelperClientTests {
         #expect(invocation.args.last?.contains("alas-helper\" serve") == true)
     }
 
+    @Test func retryGateThrottlesFailedAttempts() {
+        let start = Date(timeIntervalSince1970: 1_000)
+        var gate = RemoteHelperRetryGate(retryInterval: 300)
+
+        #expect(gate.shouldAttempt(now: start))
+        gate.markAttempt(at: start)
+
+        #expect(!gate.shouldAttempt(now: start.addingTimeInterval(10)))
+        #expect(gate.shouldAttempt(now: start.addingTimeInterval(301)))
+    }
+
+    @Test func retryGateClearsThrottleAfterLiveHelperDrops() {
+        let start = Date(timeIntervalSince1970: 1_000)
+        var gate = RemoteHelperRetryGate(retryInterval: 300)
+
+        gate.markAttempt(at: start)
+        let becameAvailable = gate.setAvailable(true)
+        let becameUnavailable = gate.setAvailable(false)
+
+        #expect(becameAvailable)
+        #expect(becameUnavailable)
+        #expect(gate.shouldAttempt(now: start.addingTimeInterval(10)))
+    }
+
     @Test func pingUsesJSONRPCNewlineTransport() async throws {
         let transport = FakeJSONRPCTransport()
         let client = RemoteHelperClient(

--- a/AlasTests/SSH/RemoteHelperClientTests.swift
+++ b/AlasTests/SSH/RemoteHelperClientTests.swift
@@ -97,6 +97,39 @@ struct RemoteHelperClientTests {
         ))
     }
 
+    @Test func legacyWatchEventBufferDropsOldestEventsAtItsLimit() async throws {
+        let transport = FakeJSONRPCTransport()
+        let client = RemoteHelperClient(
+            host: "devbox",
+            idleShutdownNanoseconds: 0,
+            transportFactory: { transport }
+        )
+
+        let firstPing = Task { try await client.ping() }
+        try await waitUntil { transport.sentFrames.count == 1 }
+        transport.send(frame: Data(#"{"jsonrpc":"2.0","id":1,"result":{"ok":true}}"#.utf8))
+        _ = try await firstPing.value
+
+        for index in 0 ... RemoteHelperClient.legacyWatchEventBufferLimit {
+            transport.send(frame: Data(#"""
+            {"jsonrpc":"2.0","method":"watch/event","params":{
+              "subscriptionId":"sub-\#(index)",
+              "root":"/srv/repo",
+              "kind":"files",
+              "paths":["/srv/repo/file-\#(index)"]
+            }}
+            """#.utf8))
+        }
+
+        let barrierPing = Task { try await client.ping() }
+        try await waitUntil { transport.sentFrames.count == 2 }
+        transport.send(frame: Data(#"{"jsonrpc":"2.0","id":2,"result":{"ok":true}}"#.utf8))
+        _ = try await barrierPing.value
+
+        var iterator = client.watchEvents.makeAsyncIterator()
+        #expect(await iterator.next()?.subscriptionId == "sub-1")
+    }
+
     @Test func subscriptionUpdatesUseStableClientIdAndReportChannelLoss() async throws {
         let transport = FakeJSONRPCTransport()
         let client = RemoteHelperClient(

--- a/AlasTests/SSH/RemoteHelperClientTests.swift
+++ b/AlasTests/SSH/RemoteHelperClientTests.swift
@@ -706,6 +706,56 @@ struct RemoteHelperClientTests {
         #expect((try await secondRead.value).content == "ok")
     }
 
+    @Test func dropLocalSubscriptionRemovesStaleReplayBlocker() async throws {
+        let firstTransport = FakeJSONRPCTransport()
+        let secondTransport = FakeJSONRPCTransport()
+        let queue = RemoteHelperTransportQueue([firstTransport, secondTransport])
+        let client = RemoteHelperClient(
+            host: "devbox",
+            idleShutdownNanoseconds: 60_000_000_000,
+            transportFactory: { queue.next() }
+        )
+
+        let subscribe = Task {
+            try await client.subscribe(root: "/deleted-repo", kinds: [.files])
+        }
+        try await waitUntil { firstTransport.sentFrames.count == 1 }
+        firstTransport.send(frame: Data(#"{"jsonrpc":"2.0","id":1,"result":{"subscriptionId":"stale-sub"}}"#.utf8))
+        #expect((try await subscribe.value).subscriptionId == "client-1")
+
+        firstTransport.send(exitStatus: 1)
+        try await waitUntilAsync {
+            await client.lastObservedExitStatus() == 1
+        }
+
+        let failedRead = Task {
+            try await client.read(path: "/other-repo/file.txt")
+        }
+        try await waitUntil { secondTransport.sentFrames.count == 1 }
+        let failedReplay = try #require(
+            JSONSerialization.jsonObject(with: secondTransport.sentFrames[0]) as? [String: Any]
+        )
+        #expect(failedReplay["method"] as? String == "watch/subscribe")
+        let failedReplayId = try #require(failedReplay["id"] as? Int)
+        secondTransport.send(frame: Data(#"{"jsonrpc":"2.0","id":\#(failedReplayId),"error":{"code":-32010,"message":"invalid root"}}"#.utf8))
+        await #expect(throws: RemoteHelperClientError.self) {
+            try await failedRead.value
+        }
+
+        await client.dropLocalSubscription(subscriptionId: "client-1")
+        let read = Task {
+            try await client.read(path: "/other-repo/file.txt")
+        }
+        try await waitUntil { secondTransport.sentFrames.count == 2 }
+        let readRequest = try #require(
+            JSONSerialization.jsonObject(with: secondTransport.sentFrames[1]) as? [String: Any]
+        )
+        #expect(readRequest["method"] as? String == "fs/read")
+        let readId = try #require(readRequest["id"] as? Int)
+        secondTransport.send(frame: Data(#"{"jsonrpc":"2.0","id":\#(readId),"result":{"content":"ok","mtime":null}}"#.utf8))
+        #expect((try await read.value).content == "ok")
+    }
+
     @Test func unsubscribeAfterHelperExitDropsSubscriptionWithoutReplay() async throws {
         let firstTransport = FakeJSONRPCTransport()
         let secondTransport = FakeJSONRPCTransport()

--- a/AlasTests/SSH/RemoteWorktreePollTests.swift
+++ b/AlasTests/SSH/RemoteWorktreePollTests.swift
@@ -75,4 +75,21 @@ struct RemoteWorktreePollTests {
         let delta = RemoteWorktreePoll.classify(old: old, new: new)
         #expect(delta?.topologyChanged == true)
     }
+
+    @Test func tickGateCoalescesOverlappingTicks() {
+        var gate = RemoteProjectGitTickGate()
+        let firstBegin = gate.beginOrMarkPending()
+        let overlappingBegin = gate.beginOrMarkPending()
+        let firstFinishNeedsFollowUp = gate.finishTick()
+        let secondFinishReleases = gate.finishTick()
+        let secondBegin = gate.beginOrMarkPending()
+        let finalFinishReleases = gate.finishTick()
+
+        #expect(firstBegin)
+        #expect(!overlappingBegin)
+        #expect(firstFinishNeedsFollowUp)
+        #expect(!secondFinishReleases)
+        #expect(secondBegin)
+        #expect(!finalFinishReleases)
+    }
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### ✨ Features
+
+- Replace idle remote project polling with push-based helper file and git events (#752).
+
 ## [0.10.2] - 2026-07-13
 
 ### ✨ Features

--- a/docs/architecture/remote-helper-protocol.md
+++ b/docs/architecture/remote-helper-protocol.md
@@ -91,10 +91,11 @@ Notification:
 ```
 
 `files` events contain changed paths under the worktree root. `git` events are
-limited to the same meaningful changes as the local git watcher: main or linked
-worktree HEAD changes, worktree topology changes, branch refs, and packed refs.
-Transient lockfiles and unrelated git metadata are ignored. Events are grouped
-by subscription and kind for 250 ms before the helper sends one notification.
+limited to state that invalidates project or changes-pane data: main or linked
+worktree HEAD and index changes, merge/cherry-pick/revert state, worktree
+topology changes, branch refs, and packed refs. Transient lockfiles and
+unrelated git metadata are ignored. Events are grouped by subscription and kind
+for 250 ms before the helper sends one notification.
 
 `fs/read`
 

--- a/docs/architecture/remote-helper-protocol.md
+++ b/docs/architecture/remote-helper-protocol.md
@@ -92,7 +92,7 @@ Notification:
 
 `files` events contain changed paths under the worktree root. `git` events are
 limited to state that invalidates project or changes-pane data: main or linked
-worktree HEAD and index changes, merge/cherry-pick/revert state, worktree
+worktree HEAD and index changes, merge/rebase/cherry-pick/revert state, worktree
 topology changes, branch refs, and packed refs. Transient lockfiles and
 unrelated git metadata are ignored. Events are grouped by subscription and kind
 for 250 ms before the helper sends one notification.

--- a/docs/architecture/remote-helper-protocol.md
+++ b/docs/architecture/remote-helper-protocol.md
@@ -21,7 +21,9 @@ client replays those subscriptions before sending the next caller request. If
 the SSH channel exits with status `255`, the app reports a host connection
 failure through `RemoteHostStatusStore`. Other exits are treated as helper
 crashes: in-flight requests fail with a fallback-capable client error, but the
-host is not marked offline. The next request starts a new helper channel.
+host is not marked offline. Watch consumers are notified immediately so they
+resume their pre-helper polling cadence; the next retry starts a new helper
+channel and replays the active subscriptions.
 
 ## Handshake
 
@@ -37,9 +39,9 @@ Result:
 {
   "name": "alas-helper",
   "protocolVersion": 1,
-  "binaryVersion": "0.2.0",
+  "binaryVersion": "0.3.0",
   "capabilities": {
-    "watchKinds": [],
+    "watchKinds": ["files", "git"],
     "fs": {"read": true, "write": true, "stat": true},
     "ping": true
   }
@@ -61,10 +63,10 @@ Result: `{"ok": true}`
 Params: `{"root": "/srv/repo", "kinds": ["files", "git"]}`  
 Result: `{"subscriptionId": "1"}`
 
-The helper canonicalizes `root` and registers it as an allowed containment root.
-Future watcher implementations will emit `watch/event` notifications for the
-registered subscription and advertise their supported kinds in
-`hello.capabilities.watchKinds`.
+The helper canonicalizes `root`, registers it as an allowed containment root,
+and starts a native recursive watcher. Linux uses inotify and macOS uses
+FSEvents through `notify`. For git subscriptions the helper also resolves and
+watches the common git directory, including when it lives outside the worktree.
 
 `watch/unsubscribe`
 
@@ -87,6 +89,12 @@ Notification:
   }
 }
 ```
+
+`files` events contain changed paths under the worktree root. `git` events are
+limited to the same meaningful changes as the local git watcher: main or linked
+worktree HEAD changes, worktree topology changes, branch refs, and packed refs.
+Transient lockfiles and unrelated git metadata are ignored. Events are grouped
+by subscription and kind for 250 ms before the helper sends one notification.
 
 `fs/read`
 


### PR DESCRIPTION
## Summary

- add native inotify/FSEvents watching to the remote helper with server-side debounce and git event filtering
- deliver stable per-subscription events and helper availability changes through the shared remote helper client
- switch remote project topology, changes pane, and editor conflict updates to push events while preserving dynamic polling fallback and a five-minute safety poll
- bump the helper binary to 0.3.0 so existing remote installations upgrade automatically

## Validation

- `cargo fmt --check`
- `cargo test --offline --locked` (15 passed)
- direct macOS helper smoke test: file edit emitted `files`; `git checkout` emitted filtered `git`
- `xcodegen`
- `ALAS_FFF_TARGET_ARCH=arm64 xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -quiet build`
- focused `RemoteHelperClientTests` and `EditorBufferTests` passed
- full test target attempted; unrelated ACP queue persistence tests remain red and reproduced outside the #752 suites

Closes #752