### PR TITLE
fix(git): prevent worktree deletion launch crash

### DIFF
--- a/Alas/Sources/Git/Process+Git.swift
+++ b/Alas/Sources/Git/Process+Git.swift
@@ -191,10 +191,14 @@ extension Process {
         stdin: String? = nil,
         timeout: TimeInterval = Process.defaultTimeout
     ) async throws -> ProcessResult {
+        let host = RemoteHostRegistry.shared.host(forPath: cwd?.path)
+        if host == nil {
+            try validateWorkingDirectory(cwd)
+        }
         let invocation = GitInvocation.build(
             gitArgs: args,
             cwd: cwd,
-            host: RemoteHostRegistry.shared.host(forPath: cwd?.path)
+            host: host
         )
         return try await run(
             invocation.executable,
@@ -223,10 +227,14 @@ extension Process {
         cwd: URL? = nil,
         timeout: TimeInterval = Process.defaultTimeout
     ) async throws -> ProcessResultData {
+        let host = RemoteHostRegistry.shared.host(forPath: cwd?.path)
+        if host == nil {
+            try validateWorkingDirectory(cwd)
+        }
         let invocation = GitInvocation.build(
             gitArgs: args,
             cwd: cwd,
-            host: RemoteHostRegistry.shared.host(forPath: cwd?.path)
+            host: host
         )
         return try await runData(
             invocation.executable,
@@ -335,6 +343,10 @@ private func validateLaunchConfiguration(executable: String, cwd: URL?) throws {
         throw ProcessError.launchFailed("Executable is not runnable: \(executable)")
     }
 
+    try validateWorkingDirectory(cwd)
+}
+
+private func validateWorkingDirectory(_ cwd: URL?) throws {
     guard let cwd else { return }
     var isDirectory: ObjCBool = false
     guard FileManager.default.fileExists(atPath: cwd.path, isDirectory: &isDirectory), isDirectory.boolValue else {

--- a/Alas/Sources/SSH/GitInvocation.swift
+++ b/Alas/Sources/SSH/GitInvocation.swift
@@ -9,11 +9,15 @@ struct GitInvocation: Equatable {
 
     static func build(gitArgs: [String], cwd: URL?, host: String?) -> GitInvocation {
         guard let host else {
+            // Keep Foundation's launch cwd unset: a worktree can disappear after
+            // preflight, while `git -C` reports that race as a normal exit.
+            let localArgs = cwd.map { ["git", "-C", $0.path] + gitArgs }
+                ?? ["git"] + gitArgs
             return GitInvocation(
                 executable: "/usr/bin/env",
-                args: ["git"] + gitArgs,
+                args: localArgs,
                 env: Process.gitEnv(),
-                cwd: cwd
+                cwd: nil
             )
         }
 

--- a/AlasTests/ProcessGitTests.swift
+++ b/AlasTests/ProcessGitTests.swift
@@ -179,6 +179,33 @@ struct ProcessGitTests {
         #expect(result.stdout.contains("git version"))
     }
 
+    @Test func gitInvocationSurvivesWorkingDirectoryDeletionBeforeLaunch() async throws {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("alas-deleted-git-cwd-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        let invocation = GitInvocation.build(gitArgs: ["status", "--porcelain"], cwd: directory, host: nil)
+        try FileManager.default.removeItem(at: directory)
+
+        let result = try await Process.run(
+            invocation.executable,
+            args: invocation.args,
+            cwd: invocation.cwd,
+            env: invocation.env
+        )
+
+        #expect(result.exitCode != 0)
+        #expect(!result.stderr.isEmpty)
+    }
+
+    @Test func gitWithMissingWorkingDirectoryStillThrowsLaunchFailed() async throws {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("alas-missing-git-cwd-\(UUID().uuidString)")
+
+        await #expect(throws: ProcessError.self) {
+            _ = try await Process.git(["status", "--porcelain"], cwd: directory)
+        }
+    }
+
     @Test func gitEnvPrefersResolvedShellPath() {
         let prior = ShellEnvResolver.shared.resolvedPath
         ShellEnvResolver.shared.resolvedPath = "/custom/shell/bin"

--- a/AlasTests/SSH/GitInvocationTests.swift
+++ b/AlasTests/SSH/GitInvocationTests.swift
@@ -3,17 +3,24 @@ import Testing
 @testable import Alas
 
 struct GitInvocationTests {
-    @Test func localInvocationIsUnchangedFromToday() {
+    @Test func localInvocationUsesGitCWithoutProcessWorkingDirectory() {
         let inv = GitInvocation.build(
             gitArgs: ["status", "--porcelain=v2"],
             cwd: URL(fileURLWithPath: "/Users/n/repo"),
             host: nil
         )
         #expect(inv.executable == "/usr/bin/env")
-        #expect(inv.args == ["git", "status", "--porcelain=v2"])
-        #expect(inv.cwd == URL(fileURLWithPath: "/Users/n/repo"))
+        #expect(inv.args == ["git", "-C", "/Users/n/repo", "status", "--porcelain=v2"])
+        #expect(inv.cwd == nil)
         #expect(inv.env?["GIT_OPTIONAL_LOCKS"] == "0")
         #expect(inv.env?["LC_ALL"] == "C")
+    }
+
+    @Test func localInvocationWithoutCwdKeepsOriginalArguments() {
+        let inv = GitInvocation.build(gitArgs: ["--version"], cwd: nil, host: nil)
+
+        #expect(inv.args == ["git", "--version"])
+        #expect(inv.cwd == nil)
     }
 
     @Test func remoteInvocationRunsSSHBatch() {


### PR DESCRIPTION
## Summary

- run local Git commands with `git -C` instead of setting `Process.currentDirectoryURL`
- preserve launch errors for worktrees that are already missing while making post-preflight deletion a normal Git failure
- cover local invocation shape and the delete-before-launch race

## Testing

- `xcodegen`
- focused `GitInvocationTests`, `ProcessGitTests`, and `RightPaneStateBaseBranchTests`
- `ALAS_FFF_TARGET_ARCH=arm64 xcodebuild -project Alas.xcodeproj -scheme Alas -destination "platform=macOS" -quiet build`
- full local suite: 5,233 passed; 13 unrelated failures from opt-in SSH integration checks and existing ACP concurrency/process tests