### PR TITLE
feat(ssh): add interactive connection assistant

### DIFF
--- a/Alas/Sources/Dialogs/NewProjectDialog.swift
+++ b/Alas/Sources/Dialogs/NewProjectDialog.swift
@@ -26,6 +26,41 @@ private enum ProjectDialogMode {
     case edit(ProjectConfig)
 }
 
+private struct SSHConnectionIssue {
+    enum Kind: Equatable {
+        case needsInteraction
+        case nonInteractiveUnavailable
+    }
+
+    let kind: Kind
+    let detail: String
+
+    var title: String {
+        switch kind {
+        case .needsInteraction:
+            "SSH connection needs attention"
+        case .nonInteractiveUnavailable:
+            "Non-interactive SSH is unavailable"
+        }
+    }
+
+    var message: String {
+        switch kind {
+        case .needsInteraction:
+            "Connect in an Alas terminal to accept host keys or complete authentication."
+        case .nonInteractiveUnavailable:
+            "Alas connected interactively, but the server still rejected the non-interactive channel required for remote projects. The account may require a terminal for every command."
+        }
+    }
+}
+
+private enum SSHSetupStatus: Equatable {
+    case connecting
+    case verifying
+    case failed(String)
+    case incompatible(String)
+}
+
 private struct ProjectDialog: View {
     @Bindable var state: AppState
     @Binding var presented: Bool
@@ -63,6 +98,11 @@ private struct ProjectDialog: View {
     @State private var mcpManagerPresented = false
     @State private var isValidating = false
     @State private var errorMessage: String?
+    @State private var sshConnectionIssue: SSHConnectionIssue?
+    @State private var sshSetupPresented = false
+    @State private var sshSetupSurface: AlasGhostty.SurfaceView?
+    @State private var sshSetupStatus: SSHSetupStatus = .connecting
+    @State private var sshSetupAttemptID = UUID()
 
     private let palette = [
         "#5fb7c4", "#c89d6f", "#9789c7", "#7fb978", "#d77b88",
@@ -152,7 +192,9 @@ private struct ProjectDialog: View {
                     Divider().padding(.vertical, 4)
                     integrationsSection
                 }
-                if let errorMessage {
+                if let sshConnectionIssue {
+                    sshConnectionIssueField(sshConnectionIssue)
+                } else if let errorMessage {
                     errorField(errorMessage)
                 }
             },
@@ -180,8 +222,26 @@ private struct ProjectDialog: View {
                 loadSSHHosts()
             }
         }
+        .onChange(of: sshHost) { _, _ in
+            sshConnectionIssue = nil
+            errorMessage = nil
+        }
+        .onChange(of: location) { _, _ in
+            sshConnectionIssue = nil
+            errorMessage = nil
+        }
         .sheet(isPresented: $mcpManagerPresented) {
             ProjectMCPServerManager(servers: $mcpServers)
+        }
+        .sheet(isPresented: $sshSetupPresented, onDismiss: dismissSSHSetup) {
+            SSHConnectionAssistant(
+                host: sshHost.trimmingCharacters(in: .whitespacesAndNewlines),
+                surface: sshSetupSurface,
+                status: sshSetupStatus,
+                onCancel: { sshSetupPresented = false },
+                onRetry: startSSHSetup
+            )
+            .environment(\.theme, theme)
         }
     }
 
@@ -340,8 +400,69 @@ private struct ProjectDialog: View {
             .clipShape(RoundedRectangle(cornerRadius: 6))
     }
 
-    // Errors here can carry SSH stderr or a setup command the user needs to
-    // paste into a terminal, so the field is selectable with a Copy button.
+    private func sshConnectionIssueField(_ issue: SSHConnectionIssue) -> some View {
+        VStack(alignment: .leading, spacing: 8) {
+            HStack(alignment: .top, spacing: 10) {
+                Image(systemName: issue.kind == .needsInteraction ? "terminal" : "exclamationmark.triangle")
+                    .font(.system(size: 13, weight: .semibold))
+                    .foregroundColor(issue.kind == .needsInteraction ? theme.color("accent") : .red)
+                    .frame(width: 18, height: 18)
+                VStack(alignment: .leading, spacing: 3) {
+                    Text(issue.title)
+                        .font(.system(size: 12, weight: .semibold))
+                        .foregroundColor(theme.color("fg"))
+                    Text(issue.message)
+                        .font(.system(size: 11))
+                        .foregroundColor(theme.color("fg-muted"))
+                        .fixedSize(horizontal: false, vertical: true)
+                }
+                Spacer(minLength: 8)
+                if issue.kind == .needsInteraction {
+                    AlasButton(
+                        title: "Connect",
+                        icon: "terminal",
+                        style: .primary,
+                        action: startSSHSetup
+                    )
+                }
+            }
+            if !issue.detail.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+                DisclosureGroup("SSH details") {
+                    copyableSSHDetail(issue.detail)
+                        .padding(.top, 6)
+                }
+                .font(.system(size: 11))
+                .foregroundColor(theme.color("fg-dim"))
+            }
+        }
+        .padding(10)
+        .background(theme.color("bg-0"))
+        .overlay(
+            RoundedRectangle(cornerRadius: 6)
+                .strokeBorder(theme.color("line"), lineWidth: 0.5)
+        )
+        .clipShape(RoundedRectangle(cornerRadius: 6))
+    }
+
+    private func copyableSSHDetail(_ detail: String) -> some View {
+        HStack(alignment: .top, spacing: 8) {
+            Text(detail.trimmingCharacters(in: .whitespacesAndNewlines))
+                .font(.system(size: 10.5, design: .monospaced))
+                .foregroundColor(theme.color("fg-muted"))
+                .textSelection(.enabled)
+                .fixedSize(horizontal: false, vertical: true)
+                .frame(maxWidth: .infinity, alignment: .leading)
+            Button(action: { copyToPasteboard(detail) }) {
+                Image(systemName: "doc.on.doc")
+                    .font(.system(size: 11))
+                    .foregroundColor(theme.color("fg-dim"))
+            }
+            .buttonStyle(.plain)
+            .help("Copy SSH details")
+            .accessibilityLabel("Copy SSH details")
+        }
+    }
+
     private func errorField(_ message: String) -> some View {
         HStack(alignment: .top, spacing: 8) {
             Text(message)
@@ -351,8 +472,7 @@ private struct ProjectDialog: View {
                 .fixedSize(horizontal: false, vertical: true)
                 .frame(maxWidth: .infinity, alignment: .leading)
             Button(action: {
-                NSPasteboard.general.clearContents()
-                NSPasteboard.general.setString(message, forType: .string)
+                copyToPasteboard(message)
             }) {
                 Image(systemName: "doc.on.doc")
                     .font(.system(size: 11))
@@ -369,6 +489,11 @@ private struct ProjectDialog: View {
                 .strokeBorder(theme.color("line"), lineWidth: 0.5)
         )
         .clipShape(RoundedRectangle(cornerRadius: 6))
+    }
+
+    private func copyToPasteboard(_ value: String) {
+        NSPasteboard.general.clearContents()
+        NSPasteboard.general.setString(value, forType: .string)
     }
 
     private var startupScriptsSection: some View {
@@ -578,22 +703,9 @@ private struct ProjectDialog: View {
         case .add:
             isValidating = true
             errorMessage = nil
+            sshConnectionIssue = nil
             Task {
-                do {
-                    let url = URL(fileURLWithPath: path)
-                    try await state.addProject(
-                        path: url,
-                        displayName: name,
-                        icon: draftIcon,
-                        host: location == .remoteSSH
-                            ? sshHost.trimmingCharacters(in: .whitespacesAndNewlines)
-                            : nil,
-                        id: pendingProjectId
-                    )
-                    presented = false
-                } catch {
-                    errorMessage = error.localizedDescription
-                }
+                await addProject(afterInteractiveSetup: false)
                 isValidating = false
             }
         case .edit(let project):
@@ -617,6 +729,185 @@ private struct ProjectDialog: View {
                 mcpServers: mcpServers
             )
             presented = false
+        }
+    }
+
+    private func addProject(afterInteractiveSetup: Bool) async {
+        do {
+            let url = URL(fileURLWithPath: path)
+            try await state.addProject(
+                path: url,
+                displayName: name,
+                icon: draftIcon,
+                host: location == .remoteSSH
+                    ? sshHost.trimmingCharacters(in: .whitespacesAndNewlines)
+                    : nil,
+                id: pendingProjectId
+            )
+            sshSetupPresented = false
+            presented = false
+        } catch let validationError as RemoteRepoValidationError {
+            switch validationError {
+            case .connectionFailed(let detail):
+                let issue = SSHConnectionIssue(
+                    kind: afterInteractiveSetup ? .nonInteractiveUnavailable : .needsInteraction,
+                    detail: detail
+                )
+                sshConnectionIssue = issue
+                if afterInteractiveSetup {
+                    sshSetupStatus = .incompatible(issue.message)
+                }
+            case .notARepository:
+                sshConnectionIssue = nil
+                errorMessage = validationError.localizedDescription
+                sshSetupPresented = false
+            }
+        } catch {
+            sshConnectionIssue = nil
+            errorMessage = error.localizedDescription
+            sshSetupPresented = false
+        }
+    }
+
+    private func startSSHSetup() {
+        let host = sshHost.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !host.isEmpty else { return }
+
+        let attemptID = UUID()
+        sshSetupAttemptID = attemptID
+        sshSetupStatus = .connecting
+        errorMessage = nil
+        let invocation = RemoteRepoValidator.interactiveSetupInvocation(host: host)
+        do {
+            sshSetupSurface = try state.terminal.makeTransientSurface(
+                cfg: state.config.terminal,
+                theme: theme,
+                executable: invocation.executable,
+                args: invocation.args,
+                onExit: {
+                    Task { @MainActor in
+                        handleSSHSetupExit(attemptID: attemptID, host: host)
+                    }
+                }
+            )
+            sshSetupPresented = true
+        } catch {
+            sshConnectionIssue = nil
+            errorMessage = "Could not open the SSH connection terminal: \(error.localizedDescription)"
+        }
+    }
+
+    private func handleSSHSetupExit(attemptID: UUID, host: String) {
+        guard sshSetupAttemptID == attemptID, sshSetupStatus == .connecting else { return }
+        sshSetupStatus = .verifying
+        Task {
+            let connected = await RemoteRepoValidator.waitForActiveControlMaster(host: host)
+            guard sshSetupAttemptID == attemptID else { return }
+            guard connected else {
+                sshSetupStatus = .failed(
+                    "SSH did not establish a reusable connection. Review the terminal output and retry."
+                )
+                return
+            }
+            isValidating = true
+            await addProject(afterInteractiveSetup: true)
+            isValidating = false
+        }
+    }
+
+    private func dismissSSHSetup() {
+        sshSetupAttemptID = UUID()
+        sshSetupSurface?.processExitHandler = nil
+        sshSetupSurface = nil
+        if sshSetupStatus == .verifying {
+            sshSetupStatus = .connecting
+        }
+    }
+}
+
+private struct SSHConnectionAssistant: View {
+    let host: String
+    let surface: AlasGhostty.SurfaceView?
+    let status: SSHSetupStatus
+    let onCancel: () -> Void
+    let onRetry: () -> Void
+    @Environment(\.theme) private var theme
+
+    var body: some View {
+        DialogContainer(
+            title: "Connect to \(host)",
+            subtitle: "Complete the SSH prompts below. Alas will continue when the connection is ready.",
+            width: 760,
+            content: {
+                Group {
+                    if let surface {
+                        GhosttyHost(surface: surface)
+                    } else {
+                        ProgressView()
+                            .controlSize(.small)
+                            .frame(maxWidth: .infinity, maxHeight: .infinity)
+                    }
+                }
+                .frame(height: 380)
+                .background(Color.black)
+                .overlay(
+                    RoundedRectangle(cornerRadius: 4)
+                        .strokeBorder(theme.color("line"), lineWidth: 0.5)
+                )
+                .clipShape(RoundedRectangle(cornerRadius: 4))
+
+                statusView
+            },
+            cancelTitle: "Cancel",
+            confirmTitle: confirmTitle,
+            confirmStyle: confirmEnabled ? .primary : .normal,
+            onCancel: onCancel,
+            onConfirm: confirmAction,
+            confirmEnabled: confirmEnabled
+        )
+    }
+
+    @ViewBuilder
+    private var statusView: some View {
+        switch status {
+        case .connecting:
+            Label("Waiting for SSH", systemImage: "terminal")
+                .foregroundColor(theme.color("fg-muted"))
+        case .verifying:
+            HStack(spacing: 8) {
+                ProgressView().controlSize(.small)
+                Text("Verifying the non-interactive connection…")
+            }
+            .foregroundColor(theme.color("fg-muted"))
+        case .failed(let message):
+            Label(message, systemImage: "exclamationmark.triangle")
+                .foregroundColor(.red)
+        case .incompatible(let message):
+            Label(message, systemImage: "exclamationmark.triangle")
+                .foregroundColor(.red)
+        }
+    }
+
+    private var confirmTitle: String {
+        switch status {
+        case .failed: "Retry"
+        case .incompatible: "Close"
+        case .connecting, .verifying: "Waiting…"
+        }
+    }
+
+    private var confirmEnabled: Bool {
+        switch status {
+        case .failed, .incompatible: true
+        case .connecting, .verifying: false
+        }
+    }
+
+    private func confirmAction() {
+        switch status {
+        case .failed: onRetry()
+        case .incompatible: onCancel()
+        case .connecting, .verifying: break
         }
     }
 }

--- a/Alas/Sources/SSH/RemoteRepoValidator.swift
+++ b/Alas/Sources/SSH/RemoteRepoValidator.swift
@@ -1,12 +1,12 @@
 import Foundation
 
 enum RemoteRepoValidationError: LocalizedError {
-    case unreachable(String)
+    case connectionFailed(String)
     case notARepository(String)
 
     var errorDescription: String? {
         switch self {
-        case let .unreachable(detail):
+        case let .connectionFailed(detail):
             let message = detail.trimmingCharacters(in: .whitespacesAndNewlines)
             return message.isEmpty ? "Could not reach the host over SSH." : message
         case let .notARepository(path):
@@ -26,16 +26,6 @@ struct RemoteRepoValidator {
             try await Process.run(executable, args: args, timeout: timeout)
         }
     ) async throws {
-        let interactiveSSH = SSHCommand(host: host, mode: .interactive)
-        let preflight = try await runner(
-            SSHCommand.executable,
-            interactiveSSH.argv(remoteScript: SSHCommand.remoteScript(command: "true")),
-            30
-        )
-        guard preflight.exitCode == 0 else {
-            throw RemoteRepoValidationError.unreachable(firstContactFailureMessage(host: host, detail: preflight.stderr))
-        }
-
         let batchSSH = SSHCommand(host: host, mode: .batch)
         let command = "git -C \(SSHCommand.shellQuote(path)) rev-parse --is-inside-work-tree"
         let result = try await runner(
@@ -44,7 +34,7 @@ struct RemoteRepoValidator {
             30
         )
         if result.exitCode == 255 {
-            throw RemoteRepoValidationError.unreachable(firstContactFailureMessage(host: host, detail: result.stderr))
+            throw RemoteRepoValidationError.connectionFailed(result.stderr)
         }
         let output = result.stdout.trimmingCharacters(in: .whitespacesAndNewlines)
         guard result.exitCode == 0, output == "true" else {
@@ -52,21 +42,28 @@ struct RemoteRepoValidator {
         }
     }
 
-    static func firstContactFailureMessage(host: String, detail: String) -> String {
-        let trimmed = detail.trimmingCharacters(in: .whitespacesAndNewlines)
-        let setupCommand = ([SSHCommand.executable] + SSHCommand(host: host, mode: .interactive).argv(
-            remoteScript: SSHCommand.remoteScript(command: "true")
-        ))
-        .map(localShellQuote)
-        .joined(separator: " ")
-        let guidance = "SSH access to \(host) needs interactive setup before adding this remote project. Run `\(setupCommand)` from a terminal to accept host keys or complete authentication, then try again."
-        return trimmed.isEmpty ? guidance : "\(guidance)\n\(trimmed)"
+    static func interactiveSetupInvocation(host: String) -> RemoteExecInvocation {
+        RemoteTerminalScript.surfaceInvocation(host: host, script: "true")
     }
 
-    private static func localShellQuote(_ value: String) -> String {
-        if value.range(of: "[^A-Za-z0-9_/.@%+=,:~-]", options: .regularExpression) == nil {
-            return value
+    static func waitForActiveControlMaster(
+        host: String,
+        attempts: Int = 10,
+        retryDelay: Duration = .milliseconds(200),
+        runner: @escaping Runner = { executable, args, timeout in
+            try await Process.run(executable, args: args, timeout: timeout)
         }
-        return SSHCommand.shellQuote(value)
+    ) async -> Bool {
+        let argv = SSHCommand(host: host, mode: .batch).controlArgv(.check)
+        for attempt in 0..<max(1, attempts) {
+            if let result = try? await runner(SSHCommand.executable, argv, 5),
+               result.exitCode == 0 {
+                return true
+            }
+            if attempt + 1 < attempts {
+                try? await Task.sleep(for: retryDelay)
+            }
+        }
+        return false
     }
 }

--- a/Alas/Sources/SSH/SSHCommand.swift
+++ b/Alas/Sources/SSH/SSHCommand.swift
@@ -7,6 +7,10 @@ import Foundation
 /// one round trip instead of a TCP+auth handshake, and the user
 /// authenticates (password / 2FA / FIDO touch) at most once per idle window.
 struct SSHCommand: Equatable {
+    enum ControlCommand: String {
+        case check
+    }
+
     /// Background probes must never hang on an interactive prompt; they
     /// fail fast instead (`BatchMode=yes`, short connect timeout).
     /// Interactive invocations (terminal surfaces, first-time connects
@@ -19,6 +23,7 @@ struct SSHCommand: Equatable {
 
     static let executable = "/usr/bin/ssh"
     static let scpExecutable = "/usr/bin/scp"
+    private static let controlPath = "~/.ssh/alas-%C"
 
     let host: String
     let mode: Mode
@@ -54,6 +59,13 @@ struct SSHCommand: Equatable {
         optionArgs + [host, remoteScript]
     }
 
+    /// Address an existing multiplexed master without opening a new SSH
+    /// connection. Used to tell whether an interactive first-contact flow
+    /// actually established the connection needed by background commands.
+    func controlArgv(_ command: ControlCommand) -> [String] {
+        ["-o", "ControlPath=\(Self.controlPath)", "-O", command.rawValue, host]
+    }
+
     /// scp rides the same multiplexed batch connection as remote commands.
     /// The destination is home-relative because scp does not reliably expand
     /// a quoted `~` on every server implementation.
@@ -67,7 +79,7 @@ struct SSHCommand: Equatable {
             "-o", "ControlMaster=auto",
             // %C is a short hash of (host, port, user); keeps the socket
             // path well under the ~104-byte unix-socket limit.
-            "-o", "ControlPath=~/.ssh/alas-%C",
+            "-o", "ControlPath=\(Self.controlPath)",
             "-o", "ControlPersist=10m",
             // Dead-peer detection on every invocation that might become
             // the master: ~15s (3 missed 5s keepalives).

--- a/Alas/Sources/Terminal/GhosttyHost.swift
+++ b/Alas/Sources/Terminal/GhosttyHost.swift
@@ -7,8 +7,18 @@ import AppKit
 /// the surface to first responder on attach; with multiple panes per tab, only
 /// the focused leaf should grab keyboard focus.
 struct GhosttyHost: NSViewRepresentable {
-    let session: TerminalSession
+    let surface: AlasGhostty.SurfaceView
     var isFocused: Bool = true
+
+    init(session: TerminalSession, isFocused: Bool = true) {
+        self.surface = session.surface
+        self.isFocused = isFocused
+    }
+
+    init(surface: AlasGhostty.SurfaceView, isFocused: Bool = true) {
+        self.surface = surface
+        self.isFocused = isFocused
+    }
 
     @MainActor
     func makeNSView(context: Context) -> NSView {
@@ -36,29 +46,29 @@ struct GhosttyHost: NSViewRepresentable {
 
     @MainActor
     private func attach(_ container: NSView, mayStealFromOtherContainer: Bool) {
-        for subview in container.subviews where subview !== session.surface {
+        for subview in container.subviews where subview !== surface {
             subview.removeFromSuperview()
         }
 
-        if session.surface.superview !== container {
-            if session.surface.superview != nil && !mayStealFromOtherContainer {
+        if surface.superview !== container {
+            if surface.superview != nil && !mayStealFromOtherContainer {
                 // Another container owns the surface; we're a stale updateNSView.
                 return
             }
-            session.surface.removeFromSuperview()
-            session.surface.translatesAutoresizingMaskIntoConstraints = false
-            container.addSubview(session.surface)
+            surface.removeFromSuperview()
+            surface.translatesAutoresizingMaskIntoConstraints = false
+            container.addSubview(surface)
             NSLayoutConstraint.activate([
-                session.surface.topAnchor.constraint(equalTo: container.topAnchor),
-                session.surface.bottomAnchor.constraint(equalTo: container.bottomAnchor),
-                session.surface.leadingAnchor.constraint(equalTo: container.leadingAnchor),
-                session.surface.trailingAnchor.constraint(equalTo: container.trailingAnchor),
+                surface.topAnchor.constraint(equalTo: container.topAnchor),
+                surface.bottomAnchor.constraint(equalTo: container.bottomAnchor),
+                surface.leadingAnchor.constraint(equalTo: container.leadingAnchor),
+                surface.trailingAnchor.constraint(equalTo: container.trailingAnchor),
             ])
         }
         guard isFocused else { return }
         DispatchQueue.main.async { [weak container] in
-            guard let container, container.window?.firstResponder !== session.surface else { return }
-            container.window?.makeFirstResponder(session.surface)
+            guard let container, container.window?.firstResponder !== surface else { return }
+            container.window?.makeFirstResponder(surface)
         }
     }
 }

--- a/Alas/Sources/Terminal/TerminalService.swift
+++ b/Alas/Sources/Terminal/TerminalService.swift
@@ -81,6 +81,33 @@ final class TerminalService {
         }
     }
 
+    /// Create a short-lived terminal surface that is not registered as a
+    /// project session. First-contact SSH uses this to render OpenSSH's native
+    /// host-key, password, keyboard-interactive, and hardware-key prompts.
+    func makeTransientSurface(
+        cfg: AppConfig.Terminal,
+        theme: Theme,
+        executable: String,
+        args: [String],
+        onExit: @escaping () -> Void
+    ) throws -> AlasGhostty.SurfaceView {
+        try ensureApp(cfg: cfg, theme: theme)
+        guard let app else { throw NSError(domain: "TerminalService", code: 1) }
+
+        let surfaceConfig = GhosttyConfigBuilder.makeSurfaceConfiguration(
+            cwd: FileManager.default.homeDirectoryForCurrentUser,
+            env: ProcessInfo.processInfo.environment,
+            executable: executable,
+            args: args
+        )
+        let surface = AlasGhostty.SurfaceView(app: app, configuration: surfaceConfig)
+        surface.processExitHandler = { processAlive in
+            guard !processAlive else { return }
+            onExit()
+        }
+        return surface
+    }
+
     /// Create a new session for the given worktree and return it.
     /// `startupScriptSuffix`, when non-empty, is appended to the effective
     /// per-session startup script and runs after the user's normal init —

--- a/AlasTests/SSH/RemoteRepoValidatorTests.swift
+++ b/AlasTests/SSH/RemoteRepoValidatorTests.swift
@@ -3,9 +3,8 @@ import Testing
 @testable import Alas
 
 struct RemoteRepoValidatorTests {
-    @Test func validateRunsInteractivePreflightBeforeBatchRepoCheck() async throws {
+    @Test func validateRunsOnlyBatchRepoCheck() async throws {
         let recorder = RemoteRepoValidatorRunner(results: [
-            ProcessResult(exitCode: 0, stdout: "", stderr: ""),
             ProcessResult(exitCode: 0, stdout: "true\n", stderr: ""),
         ])
 
@@ -18,17 +17,13 @@ struct RemoteRepoValidatorTests {
         )
 
         let calls = await recorder.calls
-        #expect(calls.count == 2)
+        #expect(calls.count == 1)
         #expect(calls[0].timeout == 30)
-        #expect(!calls[0].args.contains("BatchMode=yes"))
-        #expect(calls[0].args.contains("ConnectTimeout=30"))
-        #expect(calls[0].args.last?.contains("true") == true)
-        #expect(calls[1].timeout == 30)
-        #expect(calls[1].args.contains("BatchMode=yes"))
-        #expect(calls[1].args.last?.contains("git -C") == true)
+        #expect(calls[0].args.contains("BatchMode=yes"))
+        #expect(calls[0].args.last?.contains("git -C") == true)
     }
 
-    @Test func preflightFailureTellsUserToConnectFirst() async throws {
+    @Test func connectionFailurePreservesSSHDetail() async throws {
         let recorder = RemoteRepoValidatorRunner(results: [
             ProcessResult(exitCode: 255, stdout: "", stderr: "Host key verification failed."),
         ])
@@ -43,15 +38,62 @@ struct RemoteRepoValidatorTests {
             )
             Issue.record("Expected validation to fail")
         } catch let error as RemoteRepoValidationError {
-            guard case let .unreachable(message) = error else {
-                Issue.record("Expected unreachable error")
+            guard case let .connectionFailed(message) = error else {
+                Issue.record("Expected connection failure")
                 return
             }
-            #expect(message.contains("Run `/usr/bin/ssh"))
-            #expect(message.contains("ControlMaster=auto"))
-            #expect(message.contains("devbox"))
-            #expect(message.contains("Host key verification failed."))
+            #expect(message == "Host key verification failed.")
         }
+    }
+
+    @Test func interactiveSetupForcesTTYAndSharesControlMaster() {
+        let invocation = RemoteRepoValidator.interactiveSetupInvocation(host: "devbox")
+
+        #expect(invocation.executable == "/usr/bin/ssh")
+        #expect(invocation.args.first == "-tt")
+        #expect(invocation.args.contains("ControlMaster=auto"))
+        #expect(invocation.args.contains("ControlPath=~/.ssh/alas-%C"))
+        #expect(!invocation.args.contains("BatchMode=yes"))
+        #expect(invocation.args.last?.contains("true") == true)
+    }
+
+    @Test func waitsForControlMasterUntilItBecomesAvailable() async {
+        let recorder = RemoteRepoValidatorRunner(results: [
+            ProcessResult(exitCode: 255, stdout: "", stderr: "No control socket"),
+            ProcessResult(exitCode: 0, stdout: "Master running", stderr: ""),
+        ])
+
+        let connected = await RemoteRepoValidator.waitForActiveControlMaster(
+            host: "devbox",
+            attempts: 2,
+            retryDelay: .zero,
+            runner: { executable, args, timeout in
+                await recorder.run(executable: executable, args: args, timeout: timeout)
+            }
+        )
+
+        #expect(connected)
+        let calls = await recorder.calls
+        #expect(calls.count == 2)
+        #expect(calls.allSatisfy { $0.timeout == 5 })
+        #expect(calls.allSatisfy { $0.args.contains("-O") && $0.args.contains("check") })
+        #expect(calls.allSatisfy { $0.args.last == "devbox" })
+    }
+
+    @Test func controlMasterWaitIsBounded() async {
+        let recorder = RemoteRepoValidatorRunner(results: [])
+
+        let connected = await RemoteRepoValidator.waitForActiveControlMaster(
+            host: "devbox",
+            attempts: 2,
+            retryDelay: .zero,
+            runner: { executable, args, timeout in
+                await recorder.run(executable: executable, args: args, timeout: timeout)
+            }
+        )
+
+        #expect(!connected)
+        #expect(await recorder.calls.count == 2)
     }
 }
 


### PR DESCRIPTION
## Summary
- replace headless first-contact SSH validation with a batch fast path and an embedded interactive terminal
- verify the shared ControlMaster connection before retrying project creation
- distinguish recoverable authentication failures from servers that reject required non-interactive channels

## Why
The existing interactive preflight only removed BatchMode while still running through Foundation.Process without a TTY. Password, host-key, keyboard-interactive, and hardware-key prompts could not render, so users had to copy a generated SSH command into another terminal.

## Validation
- `xcodegen`
- focused `RemoteRepoValidatorTests` and `SSHCommandTests`
- macOS quiet build
- full suite: 5,238 passed; four unrelated ACP queue persistence tests remain order-dependent and pass in isolation