### PR TITLE
feat(headless): low-latency fs and search ops

### DIFF
--- a/Alas/Sources/Code/Editor/EditorBuffer.swift
+++ b/Alas/Sources/Code/Editor/EditorBuffer.swift
@@ -1025,38 +1025,26 @@ final class EditorBuffer {
             try await verifyRemoteFileContained(host: host, path: path)
             priorOriginalText = originalText
             let baseline = originalMtime
-            let remoteMtime = try await RemoteFileAccess.mtime(host: host, path: path)
             let shouldOverwriteConflict = remoteOverwriteAfterConflict
-            if !shouldOverwriteConflict {
-                switch RemoteSaveGate.decision(
-                    originalMtime: baseline,
-                    remoteMtime: remoteMtime
-                ) {
-                case .conflict:
-                    guard remoteSaveGeneration == generation else { return }
-                    rollbackRemoteSave(to: priorOriginalText, conflict: .changedOnDisk)
-                    throw SaveError.remoteSaveConflict
-                case .targetDeleted:
-                    guard remoteSaveGeneration == generation else { return }
-                    rollbackRemoteSave(to: priorOriginalText, conflict: .deletedOnDisk)
-                    throw SaveError.remoteSaveConflict
-                case .proceed:
-                    break
-                }
-                if RemoteSaveGate.requiresContentCheck(originalMtime: baseline, remoteMtime: remoteMtime) {
-                    guard try await remoteContentsStillMatchBaseline(host: host, path: path, baseline: priorOriginalText) else {
-                        guard remoteSaveGeneration == generation else { return }
-                        rollbackRemoteSave(to: priorOriginalText, conflict: .changedOnDisk)
-                        throw SaveError.remoteSaveConflict
-                    }
-                }
+            let newMtime: Date
+            do {
+                newMtime = try await RemoteFileAccess.write(
+                    host: host,
+                    path: path,
+                    content: serialized,
+                    expectedMtime: shouldOverwriteConflict ? nil : baseline,
+                    expectedContent: shouldOverwriteConflict
+                        ? nil
+                        : lineEnding.normalize(priorOriginalText)
+                )
+            } catch RemoteFileAccessError.saveConflict(let conflict) {
+                guard remoteSaveGeneration == generation else { return }
+                rollbackRemoteSave(
+                    to: priorOriginalText,
+                    conflict: conflict == .deleted ? .deletedOnDisk : .changedOnDisk
+                )
+                throw SaveError.remoteSaveConflict
             }
-
-            let newMtime = try await RemoteFileAccess.write(
-                host: host,
-                path: path,
-                content: serialized
-            )
             guard remoteSaveGeneration == generation else {
                 originalText = canonical
                 originalMtime = newMtime
@@ -1078,18 +1066,6 @@ final class EditorBuffer {
         }
     }
 
-    private func remoteContentsStillMatchBaseline(host: String, path: String, baseline: String) async throws -> Bool {
-        switch try await RemoteFileAccess.read(host: host, path: path) {
-        case let .file(data, _):
-            guard let remoteText = String(data: data, encoding: .utf8) else { return false }
-            return remoteText == lineEnding.normalize(baseline)
-        case .missing:
-            return false
-        case .directory, .symlink, .unreadable:
-            return false
-        }
-    }
-
     private func rollbackRemoteSave(to originalText: String, conflict: Conflict) {
         self.originalText = originalText
         self.conflict = conflict
@@ -1102,6 +1078,8 @@ final class EditorBuffer {
             lastSaveError = "Unable to save remote file: \(detail)"
         case let RemoteFileAccessError.writeFailed(detail):
             lastSaveError = "Unable to save remote file: \(detail)"
+        case RemoteFileAccessError.saveConflict:
+            lastSaveError = "The remote file changed before it could be saved."
         default:
             lastSaveError = (error as NSError).localizedDescription
         }

--- a/Alas/Sources/Git/GitService.swift
+++ b/Alas/Sources/Git/GitService.swift
@@ -638,12 +638,11 @@ extension GitService {
             }
             if let host = RemoteHostRegistry.shared.host(forPath: worktreePath.path) {
                 let directory = path.isEmpty ? worktreePath.path : worktreePath.appendingPathComponent(path).path
-                if let result = try? await RemoteExec.run(host: host, cwd: nil, command: "ls -1Ap " + SSHCommand.shellQuote(directory)), result.exitCode == 0 {
-                    for entry in RemoteFileStats.parseLsEntries(result.stdout) where entry.name != ".git" {
-                        let fullPath = path.isEmpty ? entry.name : path + "/" + entry.name
-                        if entry.isDirectory { directories.insert(fullPath) }
-                        if !paths.contains(fullPath) { paths.append(fullPath) }
-                    }
+                for entry in await RemoteFileStats.directoryEntries(host: host, path: directory)
+                    where entry.name != ".git" {
+                    let fullPath = path.isEmpty ? entry.name : path + "/" + entry.name
+                    if entry.isDirectory { directories.insert(fullPath) }
+                    if !paths.contains(fullPath) { paths.append(fullPath) }
                 }
             }
             let lazyDirectories = path.isEmpty ? directories : directories.subtracting([path])

--- a/Alas/Sources/SSH/RemoteFileAccess.swift
+++ b/Alas/Sources/SSH/RemoteFileAccess.swift
@@ -175,7 +175,7 @@ enum RemoteFileAccess {
         expectedMtime: Date? = nil,
         expectedContent: String? = nil
     ) async throws -> Date {
-        if await helperIsInstalled(host: host) {
+        if await helperSupportsWrite(host: host, expectedContent: expectedContent) {
             let startedAt = CFAbsoluteTimeGetCurrent()
             do {
                 let client = await RemoteHelperClientPool.shared.client(for: host)
@@ -296,5 +296,12 @@ enum RemoteFileAccess {
 
     private static func helperIsInstalled(host: String) async -> Bool {
         await RemoteHostCapabilityStore.shared.capabilities(for: host)?.helperHandshake != nil
+    }
+
+    private static func helperSupportsWrite(host: String, expectedContent: String?) async -> Bool {
+        guard let handshake = await RemoteHostCapabilityStore.shared.capabilities(for: host)?.helperHandshake else {
+            return false
+        }
+        return expectedContent == nil || handshake.supportsExpectedContentWrite
     }
 }

--- a/Alas/Sources/SSH/RemoteFileAccess.swift
+++ b/Alas/Sources/SSH/RemoteFileAccess.swift
@@ -1,4 +1,5 @@
 import Foundation
+import OSLog
 
 enum RemoteReadResult: Equatable {
     case file(data: Data, mtime: Date)
@@ -11,6 +12,12 @@ enum RemoteReadResult: Equatable {
 enum RemoteFileAccessError: Error, Equatable {
     case connectionFailed(String)
     case writeFailed(String)
+    case saveConflict(RemoteSaveConflict)
+}
+
+enum RemoteSaveConflict: Equatable {
+    case changed
+    case deleted
 }
 
 /// Should a remote save proceed given the buffer's baseline mtime and the
@@ -35,9 +42,19 @@ enum RemoteSaveGate {
     }
 }
 
-/// File I/O over ssh, one round trip per operation. Scripts are POSIX
-/// portable (GNU and BSD remotes); `stat` flavors are chained instead of
-/// OS-gated. Exit-code contract for reads: 3 = directory, 4 = missing.
+enum RemoteOperationTiming {
+    private static let logger = Logger(subsystem: "app.alas", category: "RemoteOperations")
+
+    static func log(_ operation: String, host: String, transport: String, startedAt: CFAbsoluteTime) {
+        let milliseconds = (CFAbsoluteTimeGetCurrent() - startedAt) * 1_000
+        logger.debug(
+            "\(operation, privacy: .public) host=\(host, privacy: .public) transport=\(transport, privacy: .public) duration_ms=\(milliseconds, format: .fixed(precision: 1))"
+        )
+    }
+}
+
+/// Remote file I/O prefers the persistent helper channel. The POSIX ssh
+/// scripts remain the compatibility path for hosts without a usable helper.
 enum RemoteFileAccess {
     /// Chained GNU-then-BSD mtime probe, reused across scripts.
     private static let statMtime = "stat -c %Y -- \"$f\" 2>/dev/null || stat -f %m \"$f\""
@@ -62,6 +79,51 @@ enum RemoteFileAccess {
     }
 
     static func read(host: String, path: String) async throws -> RemoteReadResult {
+        if await helperIsInstalled(host: host) {
+            let startedAt = CFAbsoluteTimeGetCurrent()
+            do {
+                let client = await RemoteHelperClientPool.shared.client(for: host)
+                let result = try await client.read(path: path)
+                RemoteOperationTiming.log("fs/read", host: host, transport: "helper", startedAt: startedAt)
+                return readResult(from: result)
+            } catch let error as RemoteHelperClientError where !error.shouldFallbackToRemoteExec {
+                RemoteOperationTiming.log("fs/read", host: host, transport: "helper", startedAt: startedAt)
+                if case .jsonrpc(let rpcError) = error {
+                    return .unreadable(rpcError.message)
+                }
+                return .unreadable(String(describing: error))
+            } catch {
+                RemoteOperationTiming.log("fs/read", host: host, transport: "helper-fallback", startedAt: startedAt)
+            }
+        }
+        return try await readViaExec(host: host, path: path)
+    }
+
+    static func readResult(from result: RemoteHelperFSReadResult) -> RemoteReadResult {
+        switch result.kind {
+        case "missing":
+            return .missing
+        case "directory":
+            return .directory
+        case "symlink":
+            return .symlink
+        case "unreadable":
+            return .unreadable(result.detail ?? "remote helper could not read the file")
+        case "file", nil:
+            let data = result.contentBase64.flatMap { Data(base64Encoded: $0) }
+                ?? result.content.map { Data($0.utf8) }
+            guard let data, let seconds = result.mtime else {
+                return .unreadable("unexpected helper read payload")
+            }
+            return .file(data: data, mtime: Date(timeIntervalSince1970: seconds))
+        default:
+            return .unreadable("unexpected helper read kind")
+        }
+    }
+
+    private static func readViaExec(host: String, path: String) async throws -> RemoteReadResult {
+        let startedAt = CFAbsoluteTimeGetCurrent()
+        defer { RemoteOperationTiming.log("fs/read", host: host, transport: "exec", startedAt: startedAt) }
         let result = try await RemoteExec.runData(
             host: host,
             cwd: nil,
@@ -106,7 +168,74 @@ enum RemoteFileAccess {
             + statMtime
     }
 
-    static func write(host: String, path: String, content: String) async throws -> Date {
+    static func write(
+        host: String,
+        path: String,
+        content: String,
+        expectedMtime: Date? = nil,
+        expectedContent: String? = nil
+    ) async throws -> Date {
+        if await helperIsInstalled(host: host) {
+            let startedAt = CFAbsoluteTimeGetCurrent()
+            do {
+                let client = await RemoteHelperClientPool.shared.client(for: host)
+                let result = try await client.write(
+                    path: path,
+                    content: content,
+                    expectedMtime: expectedMtime?.timeIntervalSince1970
+                )
+                RemoteOperationTiming.log("fs/write", host: host, transport: "helper", startedAt: startedAt)
+                guard let seconds = result.mtime else {
+                    throw RemoteFileAccessError.writeFailed("unexpected helper write payload")
+                }
+                return Date(timeIntervalSince1970: seconds)
+            } catch let error as RemoteHelperClientError {
+                RemoteOperationTiming.log(
+                    "fs/write",
+                    host: host,
+                    transport: error.shouldFallbackToRemoteExec ? "helper-fallback" : "helper",
+                    startedAt: startedAt
+                )
+                if case .jsonrpc(let rpcError) = error, rpcError.code == -32030 {
+                    throw RemoteFileAccessError.saveConflict(
+                        rpcError.message.contains("missing") ? .deleted : .changed
+                    )
+                }
+                guard error.shouldFallbackToRemoteExec else {
+                    throw RemoteFileAccessError.writeFailed(String(describing: error))
+                }
+            } catch let error as RemoteFileAccessError {
+                throw error
+            } catch {
+                RemoteOperationTiming.log("fs/write", host: host, transport: "helper-fallback", startedAt: startedAt)
+            }
+        }
+
+        if let expectedMtime {
+            let remoteMtime = try await mtimeViaExec(host: host, path: path)
+            switch RemoteSaveGate.decision(originalMtime: expectedMtime, remoteMtime: remoteMtime) {
+            case .conflict:
+                throw RemoteFileAccessError.saveConflict(.changed)
+            case .targetDeleted:
+                throw RemoteFileAccessError.saveConflict(.deleted)
+            case .proceed:
+                break
+            }
+            if RemoteSaveGate.requiresContentCheck(originalMtime: expectedMtime, remoteMtime: remoteMtime),
+               let expectedContent {
+                guard case let .file(data, _) = try await readViaExec(host: host, path: path),
+                      String(data: data, encoding: .utf8) == expectedContent
+                else {
+                    throw RemoteFileAccessError.saveConflict(.changed)
+                }
+            }
+        }
+        return try await writeViaExec(host: host, path: path, content: content)
+    }
+
+    private static func writeViaExec(host: String, path: String, content: String) async throws -> Date {
+        let startedAt = CFAbsoluteTimeGetCurrent()
+        defer { RemoteOperationTiming.log("fs/write", host: host, transport: "exec", startedAt: startedAt) }
         let invocation = RemoteExec.invocation(
             host: host,
             cwd: nil,
@@ -132,6 +261,27 @@ enum RemoteFileAccess {
     /// Returns nil when the target does not exist. Throws only for an ssh
     /// connection failure.
     static func mtime(host: String, path: String) async throws -> Date? {
+        if await helperIsInstalled(host: host) {
+            let startedAt = CFAbsoluteTimeGetCurrent()
+            do {
+                let client = await RemoteHelperClientPool.shared.client(for: host)
+                let result = try await client.stat(paths: [path])
+                RemoteOperationTiming.log("fs/stat", host: host, transport: "helper", startedAt: startedAt)
+                guard let entry = result.entries.first, entry.exists else { return nil }
+                return entry.mtime.map(Date.init(timeIntervalSince1970:))
+            } catch let error as RemoteHelperClientError where !error.shouldFallbackToRemoteExec {
+                RemoteOperationTiming.log("fs/stat", host: host, transport: "helper", startedAt: startedAt)
+                return nil
+            } catch {
+                RemoteOperationTiming.log("fs/stat", host: host, transport: "helper-fallback", startedAt: startedAt)
+            }
+        }
+        return try await mtimeViaExec(host: host, path: path)
+    }
+
+    private static func mtimeViaExec(host: String, path: String) async throws -> Date? {
+        let startedAt = CFAbsoluteTimeGetCurrent()
+        defer { RemoteOperationTiming.log("fs/stat", host: host, transport: "exec", startedAt: startedAt) }
         let command = "f=\(SSHCommand.shellQuote(path)); \(statMtime)"
         let result = try await RemoteExec.run(host: host, cwd: nil, command: command)
         if RemoteExec.isConnectionFailure(exitCode: result.exitCode) {
@@ -141,5 +291,9 @@ enum RemoteFileAccess {
               let seconds = TimeInterval(result.stdout.trimmingCharacters(in: .whitespacesAndNewlines))
         else { return nil }
         return Date(timeIntervalSince1970: seconds)
+    }
+
+    private static func helperIsInstalled(host: String) async -> Bool {
+        await RemoteHostCapabilityStore.shared.capabilities(for: host)?.helperHandshake != nil
     }
 }

--- a/Alas/Sources/SSH/RemoteFileAccess.swift
+++ b/Alas/Sources/SSH/RemoteFileAccess.swift
@@ -182,7 +182,8 @@ enum RemoteFileAccess {
                 let result = try await client.write(
                     path: path,
                     content: content,
-                    expectedMtime: expectedMtime?.timeIntervalSince1970
+                    expectedMtime: expectedMtime?.timeIntervalSince1970,
+                    expectedContent: expectedContent
                 )
                 RemoteOperationTiming.log("fs/write", host: host, transport: "helper", startedAt: startedAt)
                 guard let seconds = result.mtime else {

--- a/Alas/Sources/SSH/RemoteFileAccess.swift
+++ b/Alas/Sources/SSH/RemoteFileAccess.swift
@@ -79,7 +79,7 @@ enum RemoteFileAccess {
     }
 
     static func read(host: String, path: String) async throws -> RemoteReadResult {
-        if await helperIsInstalled(host: host) {
+        if await helperSupportsRead(host: host) {
             let startedAt = CFAbsoluteTimeGetCurrent()
             do {
                 let client = await RemoteHelperClientPool.shared.client(for: host)
@@ -296,6 +296,12 @@ enum RemoteFileAccess {
 
     private static func helperIsInstalled(host: String) async -> Bool {
         await RemoteHostCapabilityStore.shared.capabilities(for: host)?.helperHandshake != nil
+    }
+
+    private static func helperSupportsRead(host: String) async -> Bool {
+        await RemoteHostCapabilityStore.shared.capabilities(for: host)?
+            .helperHandshake?
+            .supportsFilesystemV04Contract == true
     }
 
     private static func helperSupportsWrite(host: String, expectedContent: String?) async -> Bool {

--- a/Alas/Sources/SSH/RemoteFileStats.swift
+++ b/Alas/Sources/SSH/RemoteFileStats.swift
@@ -21,12 +21,58 @@ enum RemoteFileStats {
     }
 
     static func lineCounts(host: String, cwd: String, paths: [String]) async -> [String: Int] {
-        let paths = Array(paths.prefix(maxBatchedPaths))
-        guard let command = wcCommand(paths: paths),
+        guard !paths.isEmpty else { return [:] }
+        if await RemoteHostCapabilityStore.shared.capabilities(for: host)?.helperHandshake != nil {
+            let startedAt = CFAbsoluteTimeGetCurrent()
+            do {
+                let client = await RemoteHelperClientPool.shared.client(for: host)
+                let result = try await client.lineCounts(root: cwd, paths: paths)
+                RemoteOperationTiming.log("fs/line-counts", host: host, transport: "helper", startedAt: startedAt)
+                return Dictionary(uniqueKeysWithValues: result.entries.map { ($0.path, $0.lineCount) })
+            } catch let error as RemoteHelperClientError where !error.shouldFallbackToRemoteExec {
+                RemoteOperationTiming.log("fs/line-counts", host: host, transport: "helper", startedAt: startedAt)
+                logger.debug("helper line counts failed: \(String(describing: error), privacy: .public)")
+                return [:]
+            } catch {
+                RemoteOperationTiming.log("fs/line-counts", host: host, transport: "helper-fallback", startedAt: startedAt)
+            }
+        }
+
+        let fallbackPaths = Array(paths.prefix(maxBatchedPaths))
+        let startedAt = CFAbsoluteTimeGetCurrent()
+        defer { RemoteOperationTiming.log("fs/line-counts", host: host, transport: "exec", startedAt: startedAt) }
+        guard let command = wcCommand(paths: fallbackPaths),
               let result = try? await RemoteExec.run(host: host, cwd: cwd, command: command),
               !RemoteExec.isConnectionFailure(exitCode: result.exitCode)
         else { return [:] }
-        return parseWcOutput(result.stdout, requested: paths)
+        return parseWcOutput(result.stdout, requested: fallbackPaths)
+    }
+
+    static func directoryEntries(host: String, path: String) async -> [(name: String, isDirectory: Bool)] {
+        if await RemoteHostCapabilityStore.shared.capabilities(for: host)?.helperHandshake != nil {
+            let startedAt = CFAbsoluteTimeGetCurrent()
+            do {
+                let client = await RemoteHelperClientPool.shared.client(for: host)
+                let result = try await client.list(path: path)
+                RemoteOperationTiming.log("fs/list", host: host, transport: "helper", startedAt: startedAt)
+                return result.entries.map { ($0.name, $0.isDirectory) }
+            } catch let error as RemoteHelperClientError where !error.shouldFallbackToRemoteExec {
+                RemoteOperationTiming.log("fs/list", host: host, transport: "helper", startedAt: startedAt)
+                logger.debug("helper directory listing failed: \(String(describing: error), privacy: .public)")
+                return []
+            } catch {
+                RemoteOperationTiming.log("fs/list", host: host, transport: "helper-fallback", startedAt: startedAt)
+            }
+        }
+
+        let startedAt = CFAbsoluteTimeGetCurrent()
+        defer { RemoteOperationTiming.log("fs/list", host: host, transport: "exec", startedAt: startedAt) }
+        guard let result = try? await RemoteExec.run(
+            host: host,
+            cwd: nil,
+            command: "ls -1Ap " + SSHCommand.shellQuote(path)
+        ), result.exitCode == 0 else { return [] }
+        return parseLsEntries(result.stdout)
     }
 
     static func parseLsEntries(_ output: String) -> [(name: String, isDirectory: Bool)] {

--- a/Alas/Sources/SSH/RemoteFileStats.swift
+++ b/Alas/Sources/SSH/RemoteFileStats.swift
@@ -20,6 +20,12 @@ enum RemoteFileStats {
         }
     }
 
+    static func lineCountDictionary(_ entries: [RemoteHelperFSLineCountEntry]) -> [String: Int] {
+        entries.reduce(into: [:]) { counts, entry in
+            counts[entry.path] = entry.lineCount
+        }
+    }
+
     static func lineCounts(host: String, cwd: String, paths: [String]) async -> [String: Int] {
         guard !paths.isEmpty else { return [:] }
         if await RemoteHostCapabilityStore.shared.capabilities(for: host)?.helperHandshake != nil {
@@ -28,7 +34,7 @@ enum RemoteFileStats {
                 let client = await RemoteHelperClientPool.shared.client(for: host)
                 let result = try await client.lineCounts(root: cwd, paths: paths)
                 RemoteOperationTiming.log("fs/line-counts", host: host, transport: "helper", startedAt: startedAt)
-                return Dictionary(uniqueKeysWithValues: result.entries.map { ($0.path, $0.lineCount) })
+                return lineCountDictionary(result.entries)
             } catch let error as RemoteHelperClientError where !error.shouldFallbackToRemoteExec {
                 RemoteOperationTiming.log("fs/line-counts", host: host, transport: "helper", startedAt: startedAt)
                 logger.debug("helper line counts failed: \(String(describing: error), privacy: .public)")

--- a/Alas/Sources/SSH/RemoteHelperClient.swift
+++ b/Alas/Sources/SSH/RemoteHelperClient.swift
@@ -177,10 +177,20 @@ actor RemoteHelperClient {
         try await request(method: "fs/read", params: RemoteHelperFSReadParams(path: path, offset: offset))
     }
 
-    func write(path: String, content: String, expectedMtime: Double? = nil) async throws -> RemoteHelperFSWriteResult {
+    func write(
+        path: String,
+        content: String,
+        expectedMtime: Double? = nil,
+        expectedContent: String? = nil
+    ) async throws -> RemoteHelperFSWriteResult {
         try await request(
             method: "fs/write",
-            params: RemoteHelperFSWriteParams(path: path, content: content, expectedMtime: expectedMtime)
+            params: RemoteHelperFSWriteParams(
+                path: path,
+                content: content,
+                expectedMtime: expectedMtime,
+                expectedContent: expectedContent
+            )
         )
     }
 

--- a/Alas/Sources/SSH/RemoteHelperClient.swift
+++ b/Alas/Sources/SSH/RemoteHelperClient.swift
@@ -13,6 +13,10 @@ private struct ActiveRemoteHelperSubscription {
     let updatesContinuation: AsyncStream<RemoteHelperWatchUpdate>.Continuation
 }
 
+private struct ActiveRemoteHelperSearch {
+    let continuation: AsyncThrowingStream<RemoteHelperSearchEvent, Error>.Continuation
+}
+
 enum RemoteHelperClientError: Error, Equatable {
     case notRunning
     case unavailable(String)
@@ -23,7 +27,10 @@ enum RemoteHelperClientError: Error, Equatable {
         switch self {
         case .notRunning, .unavailable:
             return true
-        case .jsonrpc, .decoding:
+        case .jsonrpc(let error):
+            return error.code == -32601 || error.code == -32021
+                || error.code == -32022 || error.code == -32023
+        case .decoding:
             return false
         }
     }
@@ -49,6 +56,8 @@ actor RemoteHelperClient {
     private var nextClientSubscriptionId = 0
     private var pending: [JSONRPCID: CheckedContinuation<Data, Error>] = [:]
     private var activeSubscriptions: [String: ActiveRemoteHelperSubscription] = [:]
+    private var activeSearches: [String: ActiveRemoteHelperSearch] = [:]
+    private var earlySearchEvents: [String: [RemoteHelperSearchEvent]] = [:]
     private var subscriptionReplayTask: Task<Void, Error>?
     private var subscriptionsNeedReplay = false
     private var lastExitStatus: Int32?
@@ -179,6 +188,56 @@ actor RemoteHelperClient {
         try await request(method: "fs/stat", params: RemoteHelperFSStatParams(paths: paths))
     }
 
+    func lineCounts(root: String, paths: [String]) async throws -> RemoteHelperFSLineCountsResult {
+        try await request(
+            method: "fs/line-counts",
+            params: RemoteHelperFSLineCountsParams(root: root, paths: paths)
+        )
+    }
+
+    func list(path: String) async throws -> RemoteHelperFSListResult {
+        try await request(method: "fs/list", params: RemoteHelperFSListParams(path: path))
+    }
+
+    func search(
+        root: String,
+        query: String,
+        caseSensitive: Bool,
+        wholeWord: Bool,
+        regex: Bool
+    ) async throws -> RemoteHelperSearchHandle {
+        let result: RemoteHelperSearchStartResult = try await request(
+            method: "search/start",
+            params: RemoteHelperSearchStartParams(
+                root: root,
+                query: query,
+                caseSensitive: caseSensitive,
+                wholeWord: wholeWord,
+                regex: regex
+            )
+        )
+        var continuation: AsyncThrowingStream<RemoteHelperSearchEvent, Error>.Continuation!
+        let events = AsyncThrowingStream<RemoteHelperSearchEvent, Error> { continuation = $0 }
+        activeSearches[result.searchId] = ActiveRemoteHelperSearch(
+            continuation: continuation
+        )
+        for event in earlySearchEvents.removeValue(forKey: result.searchId) ?? [] {
+            continuation.yield(event)
+            if case .complete = event {
+                continuation.finish()
+                activeSearches.removeValue(forKey: result.searchId)
+            }
+        }
+        return RemoteHelperSearchHandle(searchId: result.searchId, events: events)
+    }
+
+    func cancelSearch(searchId: String) async throws {
+        let _: RemoteHelperSearchCancelResult = try await request(
+            method: "search/cancel",
+            params: RemoteHelperSearchCancelParams(searchId: searchId)
+        )
+    }
+
     func shutdown() {
         idleShutdownTask?.cancel()
         idleShutdownTask = nil
@@ -190,6 +249,11 @@ actor RemoteHelperClient {
             subscription.updatesContinuation.finish()
         }
         activeSubscriptions.removeAll()
+        for search in activeSearches.values {
+            search.continuation.finish(throwing: RemoteHelperClientError.notRunning)
+        }
+        activeSearches.removeAll()
+        earlySearchEvents.removeAll()
         drainPending(with: RemoteHelperClientError.notRunning)
         dispatchTask?.cancel()
         dispatchTask = nil
@@ -405,6 +469,22 @@ actor RemoteHelperClient {
             return
         }
 
+        if head.method == "search/event",
+           let env = try? JSONDecoder().decode(JSONRPCEnvelope<RemoteHelperSearchEventParams>.self, from: data),
+           let event = env.params {
+            emitSearchEvent(.line(event.line), searchId: event.searchId)
+            return
+        }
+        if head.method == "search/complete",
+           let env = try? JSONDecoder().decode(JSONRPCEnvelope<RemoteHelperSearchCompleteParams>.self, from: data),
+           let event = env.params {
+            emitSearchEvent(
+                .complete(exitCode: event.exitCode, stderr: event.stderr, cancelled: event.cancelled),
+                searchId: event.searchId
+            )
+            return
+        }
+
         guard head.method == "watch/event",
               let env = try? JSONDecoder().decode(JSONRPCEnvelope<RemoteHelperWatchEvent>.self, from: data),
               let event = env.params
@@ -428,6 +508,19 @@ actor RemoteHelperClient {
         subscription.updatesContinuation.yield(.event(stableEvent))
     }
 
+    private func emitSearchEvent(_ event: RemoteHelperSearchEvent, searchId: String) {
+        guard let search = activeSearches[searchId] else {
+            earlySearchEvents[searchId, default: []].append(event)
+            return
+        }
+        search.continuation.yield(event)
+        if case .complete = event {
+            search.continuation.finish()
+            activeSearches.removeValue(forKey: searchId)
+            scheduleIdleShutdownIfPossible()
+        }
+    }
+
     private func handleExit(_ status: Int32) {
         lastExitStatus = status
         transport = nil
@@ -439,6 +532,11 @@ actor RemoteHelperClient {
         for subscription in activeSubscriptions.values {
             subscription.updatesContinuation.yield(.unavailable)
         }
+        for search in activeSearches.values {
+            search.continuation.finish(throwing: RemoteHelperClientError.notRunning)
+        }
+        activeSearches.removeAll()
+        earlySearchEvents.removeAll()
         if RemoteExec.isConnectionFailure(exitCode: status) {
             Task { @MainActor [host] in
                 RemoteHostStatusStore.shared.reportConnectionFailure(host: host)
@@ -455,7 +553,11 @@ actor RemoteHelperClient {
     }
 
     private func scheduleIdleShutdownIfPossible() {
-        guard idleShutdownNanoseconds > 0, pending.isEmpty, activeSubscriptions.isEmpty, transport != nil else { return }
+        guard idleShutdownNanoseconds > 0,
+              pending.isEmpty,
+              activeSubscriptions.isEmpty,
+              activeSearches.isEmpty,
+              transport != nil else { return }
         idleShutdownTask?.cancel()
         let delay = idleShutdownNanoseconds
         idleShutdownTask = Task { [weak self] in
@@ -465,7 +567,7 @@ actor RemoteHelperClient {
     }
 
     private func shutdownIfIdle() {
-        guard pending.isEmpty, activeSubscriptions.isEmpty else { return }
+        guard pending.isEmpty, activeSubscriptions.isEmpty, activeSearches.isEmpty else { return }
         shutdown()
     }
 

--- a/Alas/Sources/SSH/RemoteHelperHandshake.swift
+++ b/Alas/Sources/SSH/RemoteHelperHandshake.swift
@@ -5,6 +5,15 @@ struct RemoteHelperHandshake: Codable, Equatable, Sendable {
     let protocolVersion: Int
     let binaryVersion: String
 
+    var supportsExpectedContentWrite: Bool {
+        let components = binaryVersion.split(separator: ".", omittingEmptySubsequences: false)
+        guard components.count >= 2,
+              let major = Int(components[0]),
+              let minor = Int(components[1])
+        else { return false }
+        return major > 0 || (major == 0 && minor >= 4)
+    }
+
     static func decode(_ value: String) -> RemoteHelperHandshake? {
         guard let data = value.data(using: .utf8) else { return nil }
         return try? JSONDecoder().decode(RemoteHelperHandshake.self, from: data)

--- a/Alas/Sources/SSH/RemoteHelperHandshake.swift
+++ b/Alas/Sources/SSH/RemoteHelperHandshake.swift
@@ -5,13 +5,17 @@ struct RemoteHelperHandshake: Codable, Equatable, Sendable {
     let protocolVersion: Int
     let binaryVersion: String
 
-    var supportsExpectedContentWrite: Bool {
+    var supportsFilesystemV04Contract: Bool {
         let components = binaryVersion.split(separator: ".", omittingEmptySubsequences: false)
         guard components.count >= 2,
               let major = Int(components[0]),
               let minor = Int(components[1])
         else { return false }
         return major > 0 || (major == 0 && minor >= 4)
+    }
+
+    var supportsExpectedContentWrite: Bool {
+        supportsFilesystemV04Contract
     }
 
     static func decode(_ value: String) -> RemoteHelperHandshake? {

--- a/Alas/Sources/SSH/RemoteHelperProtocol.swift
+++ b/Alas/Sources/SSH/RemoteHelperProtocol.swift
@@ -102,11 +102,13 @@ struct RemoteHelperFSWriteParams: Codable, Equatable, Sendable {
     let path: String
     let content: String
     let expectedMtime: Double?
+    let expectedContent: String?
 
-    init(path: String, content: String, expectedMtime: Double? = nil) {
+    init(path: String, content: String, expectedMtime: Double? = nil, expectedContent: String? = nil) {
         self.path = path
         self.content = content
         self.expectedMtime = expectedMtime
+        self.expectedContent = expectedContent
     }
 }
 

--- a/Alas/Sources/SSH/RemoteHelperProtocol.swift
+++ b/Alas/Sources/SSH/RemoteHelperProtocol.swift
@@ -24,6 +24,7 @@ struct RemoteHelperHelloResult: Codable, Equatable, Sendable {
 struct RemoteHelperCapabilities: Codable, Equatable, Sendable {
     let watchKinds: [RemoteHelperWatchKind]
     let fs: RemoteHelperFSCapabilities
+    let search: Bool?
     let ping: Bool
 }
 
@@ -31,6 +32,8 @@ struct RemoteHelperFSCapabilities: Codable, Equatable, Sendable {
     let read: Bool
     let write: Bool
     let stat: Bool
+    let lineCounts: Bool?
+    let list: Bool?
 }
 
 enum RemoteHelperWatchKind: String, Codable, Equatable, Sendable {
@@ -88,8 +91,11 @@ struct RemoteHelperFSReadParams: Codable, Equatable, Sendable {
 }
 
 struct RemoteHelperFSReadResult: Codable, Equatable, Sendable {
-    let content: String
+    let kind: String?
+    let content: String?
+    let contentBase64: String?
     let mtime: Double?
+    let detail: String?
 }
 
 struct RemoteHelperFSWriteParams: Codable, Equatable, Sendable {
@@ -123,4 +129,73 @@ struct RemoteHelperFSStatEntry: Codable, Equatable, Sendable {
     let isFile: Bool
     let size: UInt64?
     let mtime: Double?
+}
+
+struct RemoteHelperFSLineCountsParams: Codable, Equatable, Sendable {
+    let root: String
+    let paths: [String]
+}
+
+struct RemoteHelperFSLineCountsResult: Codable, Equatable, Sendable {
+    let entries: [RemoteHelperFSLineCountEntry]
+}
+
+struct RemoteHelperFSLineCountEntry: Codable, Equatable, Sendable {
+    let path: String
+    let lineCount: Int
+}
+
+struct RemoteHelperFSListParams: Codable, Equatable, Sendable {
+    let path: String
+}
+
+struct RemoteHelperFSListResult: Codable, Equatable, Sendable {
+    let entries: [RemoteHelperFSListEntry]
+}
+
+struct RemoteHelperFSListEntry: Codable, Equatable, Sendable {
+    let name: String
+    let isDirectory: Bool
+}
+
+struct RemoteHelperSearchStartParams: Codable, Equatable, Sendable {
+    let root: String
+    let query: String
+    let caseSensitive: Bool
+    let wholeWord: Bool
+    let regex: Bool
+}
+
+struct RemoteHelperSearchStartResult: Codable, Equatable, Sendable {
+    let searchId: String
+}
+
+struct RemoteHelperSearchCancelParams: Codable, Equatable, Sendable {
+    let searchId: String
+}
+
+struct RemoteHelperSearchCancelResult: Codable, Equatable, Sendable {
+    let ok: Bool
+}
+
+struct RemoteHelperSearchEventParams: Codable, Equatable, Sendable {
+    let searchId: String
+    let line: String
+}
+
+struct RemoteHelperSearchCompleteParams: Codable, Equatable, Sendable {
+    let searchId: String
+    let exitCode: Int32
+    let stderr: String
+    let cancelled: Bool
+}
+
+enum RemoteHelperSearchEvent: Equatable, Sendable {
+    case line(String)
+    case complete(exitCode: Int32, stderr: String, cancelled: Bool)
+}
+
+struct RemoteHelperSearchHandle: Sendable {
+    let searchId: String
+    let events: AsyncThrowingStream<RemoteHelperSearchEvent, Error>
 }

--- a/Alas/Sources/Search/ContentSearcher.swift
+++ b/Alas/Sources/Search/ContentSearcher.swift
@@ -119,6 +119,20 @@ final class ContentSearcher: Sendable {
                 )
                 return
             }
+            if capabilities?.helperHandshake != nil {
+                do {
+                    try await streamHelperRg(
+                        host: host,
+                        query: query,
+                        options: options,
+                        worktree: worktree,
+                        into: continuation
+                    )
+                    return
+                } catch let error as RemoteHelperClientError where error.shouldFallbackToRemoteExec {
+                    logger.debug("helper search unavailable; using exec: \(String(describing: error), privacy: .public)")
+                }
+            }
             let invocation = RemoteContentSearch.rgInvocation(
                 host: host,
                 cwd: worktree.absolutePath.path,
@@ -131,6 +145,14 @@ final class ContentSearcher: Sendable {
             process.executableURL = URL(fileURLWithPath: rg)
             process.arguments = args
             process.currentDirectoryURL = worktree.absolutePath
+        }
+
+        let execStartedAt = CFAbsoluteTimeGetCurrent()
+        let execHost = RemoteHostRegistry.shared.host(forPath: worktree.absolutePath.path)
+        defer {
+            if let execHost {
+                RemoteOperationTiming.log("search", host: execHost, transport: "exec", startedAt: execStartedAt)
+            }
         }
 
         let outPipe = Pipe()
@@ -192,22 +214,62 @@ final class ContentSearcher: Sendable {
 
         // ripgrep exits 0 on matches, 1 on no matches, 2+ on its own errors.
         // Skip the check if we cancelled the child ourselves.
-        if !Task.isCancelled,
-           process.terminationReason == .exit,
-           process.terminationStatus > 1 {
-            let stderr = stderrBuf.text
-            // rg's regex parse errors begin with "regex parse error" or
-            // mention unsupported look-around / backreference features.
-            // Distinguish those from soft I/O errors so the model can
-            // surface "Invalid regex pattern." instead of a generic banner.
-            let lower = stderr.lowercased()
-            if lower.contains("regex parse error")
-                || lower.contains("look-around")
-                || lower.contains("backreference") {
-                throw SearchError.regexInvalid
-            }
-            throw SearchError.rgFailed(exitCode: process.terminationStatus)
+        if !Task.isCancelled, process.terminationReason == .exit {
+            try validateRgExit(process.terminationStatus, stderr: stderrBuf.text)
         }
+    }
+
+    private func streamHelperRg(
+        host: String,
+        query: String,
+        options: SearchContentOptions,
+        worktree: SearchWorktree,
+        into continuation: AsyncThrowingStream<ContentSearchHit, Error>.Continuation
+    ) async throws {
+        let startedAt = CFAbsoluteTimeGetCurrent()
+        let client = await RemoteHelperClientPool.shared.client(for: host)
+        let handle = try await client.search(
+            root: worktree.absolutePath.path,
+            query: query,
+            caseSensitive: options.caseSensitive,
+            wholeWord: options.wholeWord,
+            regex: options.regex
+        )
+        defer {
+            RemoteOperationTiming.log("search", host: host, transport: "helper", startedAt: startedAt)
+        }
+
+        try await withTaskCancellationHandler {
+            for try await event in handle.events {
+                switch event {
+                case .line(let line):
+                    if let hit = parseRgLine(Data(line.utf8), worktree: worktree) {
+                        continuation.yield(hit)
+                    }
+                case let .complete(exitCode, stderr, cancelled):
+                    if cancelled || Task.isCancelled {
+                        throw CancellationError()
+                    }
+                    try validateRgExit(exitCode, stderr: stderr)
+                }
+            }
+        } onCancel: {
+            Task {
+                try? await client.cancelSearch(searchId: handle.searchId)
+            }
+        }
+        if Task.isCancelled { throw CancellationError() }
+    }
+
+    private func validateRgExit(_ exitCode: Int32, stderr: String) throws {
+        guard exitCode > 1 else { return }
+        let lower = stderr.lowercased()
+        if lower.contains("regex parse error")
+            || lower.contains("look-around")
+            || lower.contains("backreference") {
+            throw SearchError.regexInvalid
+        }
+        throw SearchError.rgFailed(exitCode: exitCode)
     }
 
     /// Read newline-delimited output from `handle`, yielding hits as soon as
@@ -227,6 +289,10 @@ final class ContentSearcher: Sendable {
     ) async throws {
         let result: ProcessResult
         if let host = RemoteHostRegistry.shared.host(forPath: worktree.absolutePath.path) {
+            let startedAt = CFAbsoluteTimeGetCurrent()
+            defer {
+                RemoteOperationTiming.log("search", host: host, transport: "git-exec", startedAt: startedAt)
+            }
             let invocation = RemoteContentSearch.cappedGitGrepInvocation(
                 host: host,
                 cwd: worktree.absolutePath.path,

--- a/AlasHelper/Cargo.lock
+++ b/AlasHelper/Cargo.lock
@@ -4,12 +4,19 @@ version = 4
 
 [[package]]
 name = "alas-helper"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
+ "base64",
  "notify",
  "serde",
  "serde_json",
 ]
+
+[[package]]
+name = "base64"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "bitflags"

--- a/AlasHelper/Cargo.toml
+++ b/AlasHelper/Cargo.toml
@@ -1,10 +1,11 @@
 [package]
 name = "alas-helper"
-version = "0.3.0"
+version = "0.4.0"
 edition = "2024"
 publish = false
 
 [dependencies]
+base64 = "0.22"
 notify = "8.2.0"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/AlasHelper/manifest.json
+++ b/AlasHelper/manifest.json
@@ -1,1 +1,1 @@
-{"name":"alas-helper","protocolVersion":1,"binaryVersion":"0.3.0"}
+{"name":"alas-helper","protocolVersion":1,"binaryVersion":"0.4.0"}

--- a/AlasHelper/src/main.rs
+++ b/AlasHelper/src/main.rs
@@ -1,11 +1,15 @@
 mod watch;
 
+use base64::Engine;
 use serde::{Deserialize, Serialize};
 use serde_json::{Value, json};
 use std::collections::{HashMap, HashSet};
-use std::io::{self, BufRead, Write};
+use std::io::{self, BufRead, BufReader, Read, Write};
 use std::path::{Path, PathBuf};
-use std::sync::mpsc::{self, RecvTimeoutError, Sender};
+use std::process::{Command, Stdio};
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::mpsc::{self, RecvTimeoutError, Sender, TryRecvError};
 use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 
 use watch::{SubscriptionWatcher, WatchKind, WatchNotification};
@@ -36,8 +40,10 @@ struct HelperError {
 #[derive(Default)]
 struct HelperState {
     next_subscription_id: u64,
+    next_search_id: u64,
     subscriptions: HashMap<String, PathBuf>,
     watchers: HashMap<String, SubscriptionWatcher>,
+    searches: HashMap<String, Arc<AtomicBool>>,
     event_sender: Option<Sender<ServerMessage>>,
 }
 
@@ -73,9 +79,50 @@ struct FsStatParams {
     paths: Vec<String>,
 }
 
+#[derive(Debug, Deserialize)]
+struct FsLineCountsParams {
+    root: String,
+    paths: Vec<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct FsListParams {
+    path: String,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct SearchStartParams {
+    root: String,
+    query: String,
+    case_sensitive: bool,
+    whole_word: bool,
+    regex: bool,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct SearchCancelParams {
+    search_id: String,
+}
+
+pub(crate) enum SearchNotification {
+    Line {
+        search_id: String,
+        line: String,
+    },
+    Complete {
+        search_id: String,
+        exit_code: i32,
+        stderr: String,
+        cancelled: bool,
+    },
+}
+
 pub(crate) enum ServerMessage {
     Request(String),
     Watch(WatchNotification),
+    Search(SearchNotification),
     InputClosed,
 }
 
@@ -93,8 +140,11 @@ fn capabilities() -> Value {
         "fs": {
             "read": true,
             "write": true,
-            "stat": true
+            "stat": true,
+            "lineCounts": true,
+            "list": true
         },
+        "search": true,
         "ping": true
     })
 }
@@ -181,6 +231,10 @@ fn serve() -> io::Result<()> {
                     .extend(notification.paths);
                 flush_at.get_or_insert_with(|| Instant::now() + DEBOUNCE);
             }
+            Some(ServerMessage::Search(notification)) => {
+                flush_due_watch_events(&mut stdout, &state, &mut pending_events, &mut flush_at)?;
+                write_search_notification(&mut stdout, &mut state, notification)?;
+            }
             Some(ServerMessage::InputClosed) => {
                 flush_watch_events(&mut stdout, &state, &mut pending_events)?;
                 break;
@@ -192,6 +246,39 @@ fn serve() -> io::Result<()> {
         }
     }
     Ok(())
+}
+
+fn write_search_notification(
+    stdout: &mut impl Write,
+    state: &mut HelperState,
+    notification: SearchNotification,
+) -> io::Result<()> {
+    let value = match notification {
+        SearchNotification::Line { search_id, line } => json!({
+            "jsonrpc": "2.0",
+            "method": "search/event",
+            "params": { "searchId": search_id, "line": line }
+        }),
+        SearchNotification::Complete {
+            search_id,
+            exit_code,
+            stderr,
+            cancelled,
+        } => {
+            state.searches.remove(&search_id);
+            json!({
+                "jsonrpc": "2.0",
+                "method": "search/complete",
+                "params": {
+                    "searchId": search_id,
+                    "exitCode": exit_code,
+                    "stderr": stderr,
+                    "cancelled": cancelled
+                }
+            })
+        }
+    };
+    write_json_line(stdout, &value.to_string())
 }
 
 fn flush_due_watch_events(
@@ -286,6 +373,10 @@ fn handle_request(
         "fs/read" => fs_read(state, params),
         "fs/write" => fs_write(state, params),
         "fs/stat" => fs_stat(state, params),
+        "fs/line-counts" => fs_line_counts(state, params),
+        "fs/list" => fs_list(state, params),
+        "search/start" => search_start(state, params),
+        "search/cancel" => search_cancel(state, params),
         _ => Err(jsonrpc_error(-32601, format!("method not found: {method}"))),
     }
 }
@@ -325,20 +416,37 @@ fn watch_unsubscribe(state: &mut HelperState, params: Option<Value>) -> Result<V
 
 fn fs_read(state: &HelperState, params: Option<Value>) -> Result<Value, HelperError> {
     let params: FsReadParams = decode_params(params)?;
-    let path = contained_existing_path(state, &params.path)?;
+    let path = match contained_existing_path(state, &params.path) {
+        Ok(path) => path,
+        Err(error) if error.code == -32021 => return Ok(json!({ "kind": "missing" })),
+        Err(error) => return Err(error),
+    };
+    let source_metadata = std::fs::symlink_metadata(&params.path)
+        .map_err(|error| jsonrpc_error(-32020, format!("metadata failed: {error}")))?;
+    if source_metadata.file_type().is_symlink() {
+        return Ok(json!({ "kind": "symlink" }));
+    }
     let metadata = std::fs::metadata(&path)
         .map_err(|error| jsonrpc_error(-32020, format!("metadata failed: {error}")))?;
+    if metadata.is_dir() {
+        return Ok(json!({ "kind": "directory" }));
+    }
     if !metadata.is_file() {
-        return Err(jsonrpc_error(-32025, "path is not a regular file"));
+        return Ok(json!({ "kind": "unreadable", "detail": "path is not a regular file" }));
     }
     let bytes = std::fs::read(&path)
         .map_err(|error| jsonrpc_error(-32020, format!("read failed: {error}")))?;
     let offset = params.offset.unwrap_or(0) as usize;
-    let content = std::str::from_utf8(bytes.get(offset..).unwrap_or_default())
-        .map_err(|error| jsonrpc_error(-32024, format!("invalid utf-8: {error}")))?
-        .to_string();
+    let body = bytes.get(offset..).unwrap_or_default();
+    let content = base64::engine::general_purpose::STANDARD.encode(body);
+    let legacy_content = std::str::from_utf8(body).ok();
     let mtime = modified_seconds(&metadata);
-    Ok(json!({ "content": content, "mtime": mtime }))
+    Ok(json!({
+        "kind": "file",
+        "content": legacy_content,
+        "contentBase64": content,
+        "mtime": mtime
+    }))
 }
 
 fn fs_write(state: &HelperState, params: Option<Value>) -> Result<Value, HelperError> {
@@ -352,10 +460,10 @@ fn fs_write(state: &HelperState, params: Option<Value>) -> Result<Value, HelperE
                 jsonrpc_error(-32020, format!("mtime failed: {error}"))
             }
         })?;
-        if let Some(actual) = modified_seconds(&metadata) {
-            if (actual - expected).abs() > 0.000_001 {
-                return Err(jsonrpc_error(-32030, "mtime mismatch"));
-            }
+        if let Some(actual) = modified_seconds(&metadata)
+            && (actual - expected).abs() > 0.000_001
+        {
+            return Err(jsonrpc_error(-32030, "mtime mismatch"));
         }
     }
     write_replacing_path(&path, &params.content)?;
@@ -396,6 +504,212 @@ fn fs_stat(state: &HelperState, params: Option<Value>) -> Result<Value, HelperEr
         }
     }
     Ok(json!({ "entries": entries }))
+}
+
+fn fs_line_counts(state: &HelperState, params: Option<Value>) -> Result<Value, HelperError> {
+    let params: FsLineCountsParams = decode_params(params)?;
+    let root = contained_directory(state, &params.root)?;
+    let mut entries = Vec::with_capacity(params.paths.len());
+    for relative in params.paths {
+        let requested = root.join(&relative);
+        let requested = requested.to_string_lossy().into_owned();
+        let path = match contained_existing_path(state, &requested) {
+            Ok(path) => path,
+            Err(error) if error.code == -32021 => continue,
+            Err(error) => return Err(error),
+        };
+        let metadata = std::fs::metadata(&path)
+            .map_err(|error| jsonrpc_error(-32020, format!("metadata failed: {error}")))?;
+        if !metadata.is_file() {
+            continue;
+        }
+        let mut file = std::fs::File::open(&path)
+            .map_err(|error| jsonrpc_error(-32020, format!("open failed: {error}")))?;
+        let mut buffer = [0_u8; 64 * 1024];
+        let mut count = 0_u64;
+        loop {
+            let read = file
+                .read(&mut buffer)
+                .map_err(|error| jsonrpc_error(-32020, format!("read failed: {error}")))?;
+            if read == 0 {
+                break;
+            }
+            count += buffer[..read].iter().filter(|byte| **byte == b'\n').count() as u64;
+        }
+        entries.push(json!({ "path": relative, "lineCount": count }));
+    }
+    Ok(json!({ "entries": entries }))
+}
+
+fn fs_list(state: &HelperState, params: Option<Value>) -> Result<Value, HelperError> {
+    let params: FsListParams = decode_params(params)?;
+    let path = contained_directory(state, &params.path)?;
+    let mut entries = Vec::new();
+    let directory = std::fs::read_dir(path)
+        .map_err(|error| jsonrpc_error(-32020, format!("list failed: {error}")))?;
+    for entry in directory {
+        let entry =
+            entry.map_err(|error| jsonrpc_error(-32020, format!("list failed: {error}")))?;
+        let file_type = entry
+            .file_type()
+            .map_err(|error| jsonrpc_error(-32020, format!("file type failed: {error}")))?;
+        entries.push(json!({
+            "name": entry.file_name().to_string_lossy(),
+            "isDirectory": file_type.is_dir()
+        }));
+    }
+    entries.sort_by(|left, right| left["name"].as_str().cmp(&right["name"].as_str()));
+    Ok(json!({ "entries": entries }))
+}
+
+fn contained_directory(state: &HelperState, path: &str) -> Result<PathBuf, HelperError> {
+    let path = contained_existing_path(state, path)?;
+    let metadata = std::fs::metadata(&path)
+        .map_err(|error| jsonrpc_error(-32020, format!("metadata failed: {error}")))?;
+    if !metadata.is_dir() {
+        return Err(jsonrpc_error(-32025, "path is not a directory"));
+    }
+    Ok(path)
+}
+
+fn search_start(state: &mut HelperState, params: Option<Value>) -> Result<Value, HelperError> {
+    let params: SearchStartParams = decode_params(params)?;
+    let root = contained_directory(state, &params.root)?;
+    let sender = state
+        .event_sender
+        .clone()
+        .ok_or_else(|| jsonrpc_error(-32040, "search channel unavailable"))?;
+    state.next_search_id += 1;
+    let search_id = state.next_search_id.to_string();
+    let cancelled = Arc::new(AtomicBool::new(false));
+    state.searches.insert(search_id.clone(), cancelled.clone());
+    spawn_search(search_id.clone(), root, params, cancelled, sender);
+    Ok(json!({ "searchId": search_id }))
+}
+
+fn search_cancel(state: &mut HelperState, params: Option<Value>) -> Result<Value, HelperError> {
+    let params: SearchCancelParams = decode_params(params)?;
+    if let Some(cancelled) = state.searches.get(&params.search_id) {
+        cancelled.store(true, Ordering::Release);
+    }
+    Ok(json!({ "ok": true }))
+}
+
+fn spawn_search(
+    search_id: String,
+    root: PathBuf,
+    params: SearchStartParams,
+    cancelled: Arc<AtomicBool>,
+    sender: Sender<ServerMessage>,
+) {
+    std::thread::spawn(move || {
+        let mut command = Command::new("rg");
+        command.current_dir(root).args([
+            "--json",
+            "--hidden",
+            "--glob",
+            "!.git",
+            "--max-count=200",
+            "--max-columns=400",
+        ]);
+        command.arg(if params.case_sensitive {
+            "--case-sensitive"
+        } else {
+            "--smart-case"
+        });
+        if params.whole_word {
+            command.arg("--word-regexp");
+        }
+        if !params.regex {
+            command.arg("--fixed-strings");
+        }
+        command
+            .arg("--")
+            .arg(params.query)
+            .arg(".")
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped());
+
+        let mut child = match command.spawn() {
+            Ok(child) => child,
+            Err(error) => {
+                let _ = sender.send(ServerMessage::Search(SearchNotification::Complete {
+                    search_id,
+                    exit_code: 127,
+                    stderr: error.to_string(),
+                    cancelled: false,
+                }));
+                return;
+            }
+        };
+        let stdout = child.stdout.take().expect("piped stdout");
+        let stderr = child.stderr.take().expect("piped stderr");
+        let (line_sender, line_receiver) = mpsc::channel();
+        std::thread::spawn(move || {
+            for line in BufReader::new(stdout).lines().map_while(Result::ok) {
+                if line_sender.send(line).is_err() {
+                    break;
+                }
+            }
+        });
+        let stderr_reader = std::thread::spawn(move || {
+            let mut reader = BufReader::new(stderr);
+            let mut bytes = Vec::new();
+            let mut chunk = [0_u8; 4096];
+            while let Ok(read) = reader.read(&mut chunk) {
+                if read == 0 {
+                    break;
+                }
+                let remaining = 8192_usize.saturating_sub(bytes.len());
+                bytes.extend_from_slice(&chunk[..read.min(remaining)]);
+            }
+            String::from_utf8_lossy(&bytes).into_owned()
+        });
+
+        let mut exit_code = None;
+        loop {
+            loop {
+                match line_receiver.try_recv() {
+                    Ok(line) => {
+                        let _ = sender.send(ServerMessage::Search(SearchNotification::Line {
+                            search_id: search_id.clone(),
+                            line,
+                        }));
+                    }
+                    Err(TryRecvError::Empty) => break,
+                    Err(TryRecvError::Disconnected) => break,
+                }
+            }
+            if cancelled.load(Ordering::Acquire) {
+                let _ = child.kill();
+            }
+            match child.try_wait() {
+                Ok(Some(status)) => {
+                    exit_code = Some(status.code().unwrap_or(2));
+                    break;
+                }
+                Ok(None) => std::thread::sleep(Duration::from_millis(20)),
+                Err(_) => {
+                    let _ = child.kill();
+                    break;
+                }
+            }
+        }
+        for line in line_receiver {
+            let _ = sender.send(ServerMessage::Search(SearchNotification::Line {
+                search_id: search_id.clone(),
+                line,
+            }));
+        }
+        let stderr = stderr_reader.join().unwrap_or_default();
+        let was_cancelled = cancelled.load(Ordering::Acquire);
+        let _ = sender.send(ServerMessage::Search(SearchNotification::Complete {
+            search_id,
+            exit_code: exit_code.unwrap_or(2),
+            stderr,
+            cancelled: was_cancelled,
+        }));
+    });
 }
 
 fn contained_existing_path(state: &HelperState, path: &str) -> Result<PathBuf, HelperError> {
@@ -792,7 +1106,7 @@ mod tests {
     }
 
     #[test]
-    fn read_rejects_invalid_utf8() {
+    fn read_returns_binary_content_as_base64() {
         let root = std::env::temp_dir().join(format!(
             "alas-helper-invalid-utf8-{}-{}",
             std::process::id(),
@@ -807,20 +1121,21 @@ mod tests {
             "1".to_string(),
             std::fs::canonicalize(&root).expect("canonical root"),
         );
-        let error = fs_read(
+        let result = fs_read(
             &state,
             Some(json!({
                 "path": file.display().to_string()
             })),
         )
-        .expect_err("invalid utf-8 should be rejected");
+        .expect("binary read");
 
-        assert_eq!(error.code, -32024);
+        assert_eq!(result["kind"], "file");
+        assert_eq!(result["contentBase64"], "//4=");
         let _ = std::fs::remove_dir_all(root);
     }
 
     #[test]
-    fn read_rejects_non_regular_file() {
+    fn read_identifies_directory() {
         let root = std::env::temp_dir().join(format!(
             "alas-helper-non-regular-{}-{}",
             std::process::id(),
@@ -834,16 +1149,99 @@ mod tests {
             "1".to_string(),
             std::fs::canonicalize(&root).expect("canonical root"),
         );
-        let error = fs_read(
+        let result = fs_read(
             &state,
             Some(json!({
                 "path": directory.display().to_string()
             })),
         )
-        .expect_err("non-regular files should be rejected");
+        .expect("directory result");
 
-        assert_eq!(error.code, -32025);
+        assert_eq!(result["kind"], "directory");
         let _ = std::fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn line_counts_are_unbounded_and_list_preserves_names() {
+        let root = std::env::temp_dir().join(format!(
+            "alas-helper-stats-{}-{}",
+            std::process::id(),
+            system_time_seconds(SystemTime::now()).unwrap()
+        ));
+        std::fs::create_dir_all(root.join("folder")).expect("root");
+        std::fs::write(root.join("a file.txt"), "one\ntwo\n").expect("file");
+
+        let mut state = HelperState::default();
+        state.subscriptions.insert(
+            "1".to_string(),
+            std::fs::canonicalize(&root).expect("canonical root"),
+        );
+        let counts = fs_line_counts(
+            &state,
+            Some(json!({
+                "root": root.display().to_string(),
+                "paths": ["a file.txt", "missing.txt"]
+            })),
+        )
+        .expect("line counts");
+        assert_eq!(
+            counts["entries"],
+            json!([{"path": "a file.txt", "lineCount": 2}])
+        );
+
+        let listing = fs_list(&state, Some(json!({ "path": root.display().to_string() })))
+            .expect("directory listing");
+        assert_eq!(listing["entries"][0]["name"], "a file.txt");
+        assert_eq!(listing["entries"][1]["name"], "folder");
+        assert_eq!(listing["entries"][1]["isDirectory"], true);
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn write_mtime_gate_rejects_changed_target_before_replace() {
+        let root = std::env::temp_dir().join(format!(
+            "alas-helper-mtime-conflict-{}-{}",
+            std::process::id(),
+            system_time_seconds(SystemTime::now()).unwrap()
+        ));
+        std::fs::create_dir_all(&root).expect("root");
+        let file = root.join("file.txt");
+        std::fs::write(&file, "external").expect("file");
+        let actual = modified_seconds(&std::fs::metadata(&file).expect("metadata")).unwrap();
+        let mut state = HelperState::default();
+        state.subscriptions.insert(
+            "1".to_string(),
+            std::fs::canonicalize(&root).expect("canonical root"),
+        );
+
+        let error = fs_write(
+            &state,
+            Some(json!({
+                "path": file.display().to_string(),
+                "content": "editor",
+                "expectedMtime": actual - 1.0
+            })),
+        )
+        .expect_err("stale mtime must conflict");
+
+        assert_eq!(error.code, -32030);
+        assert_eq!(std::fs::read_to_string(&file).expect("content"), "external");
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn search_cancel_marks_the_server_side_operation() {
+        let cancelled = Arc::new(AtomicBool::new(false));
+        let mut state = HelperState::default();
+        state
+            .searches
+            .insert("search-1".to_string(), cancelled.clone());
+
+        let result = search_cancel(&mut state, Some(json!({ "searchId": "search-1" })))
+            .expect("cancel response");
+
+        assert_eq!(result["ok"], true);
+        assert!(cancelled.load(Ordering::Acquire));
     }
 
     #[test]

--- a/AlasHelper/src/main.rs
+++ b/AlasHelper/src/main.rs
@@ -453,7 +453,18 @@ fn fs_read(state: &HelperState, params: Option<Value>) -> Result<Value, HelperEr
 fn fs_write(state: &HelperState, params: Option<Value>) -> Result<Value, HelperError> {
     let params: FsWriteParams = decode_params(params)?;
     let path = contained_write_path(state, &params.path)?;
-    if let Some(expected) = params.expected_mtime {
+    if let Some(expected) = params.expected_content.as_deref() {
+        let actual = std::fs::read(&path).map_err(|error| {
+            if error.kind() == io::ErrorKind::NotFound {
+                jsonrpc_error(-32030, "content target missing")
+            } else {
+                jsonrpc_error(-32020, format!("content check failed: {error}"))
+            }
+        })?;
+        if actual != expected.as_bytes() {
+            return Err(jsonrpc_error(-32030, "content mismatch"));
+        }
+    } else if let Some(expected) = params.expected_mtime {
         let metadata = std::fs::metadata(&path).map_err(|error| {
             if error.kind() == io::ErrorKind::NotFound {
                 jsonrpc_error(-32030, "mtime target missing")
@@ -465,18 +476,6 @@ fn fs_write(state: &HelperState, params: Option<Value>) -> Result<Value, HelperE
             && (actual - expected).abs() > 0.000_001
         {
             return Err(jsonrpc_error(-32030, "mtime mismatch"));
-        }
-    }
-    if let Some(expected) = params.expected_content {
-        let actual = std::fs::read(&path).map_err(|error| {
-            if error.kind() == io::ErrorKind::NotFound {
-                jsonrpc_error(-32030, "content target missing")
-            } else {
-                jsonrpc_error(-32020, format!("content check failed: {error}"))
-            }
-        })?;
-        if actual != expected.as_bytes() {
-            return Err(jsonrpc_error(-32030, "content mismatch"));
         }
     }
     write_replacing_path(&path, &params.content)?;
@@ -771,18 +770,7 @@ fn contained_write_path(state: &HelperState, path: &str) -> Result<PathBuf, Help
     let target = parent.join(file_name);
     match std::fs::symlink_metadata(&target) {
         Ok(metadata) if metadata.file_type().is_symlink() => {
-            let canonical = std::fs::canonicalize(&target).map_err(|error| {
-                jsonrpc_error(-32020, format!("symlink target failed: {error}"))
-            })?;
-            if state
-                .subscriptions
-                .values()
-                .any(|root| canonical.starts_with(root))
-            {
-                Ok(canonical)
-            } else {
-                Err(jsonrpc_error(-32023, "path outside registered roots"))
-            }
+            Err(jsonrpc_error(-32025, "path is a symbolic link"))
         }
         Ok(_) => Ok(target),
         Err(error) if error.kind() == io::ErrorKind::NotFound => Ok(target),
@@ -1276,6 +1264,75 @@ mod tests {
     }
 
     #[test]
+    fn write_content_gate_accepts_matching_content_with_coarse_mtime() {
+        let root = std::env::temp_dir().join(format!(
+            "alas-helper-coarse-mtime-{}-{}",
+            std::process::id(),
+            system_time_seconds(SystemTime::now()).unwrap()
+        ));
+        std::fs::create_dir_all(&root).expect("root");
+        let file = root.join("file.txt");
+        std::fs::write(&file, "baseline").expect("file");
+        let actual = modified_seconds(&std::fs::metadata(&file).expect("metadata")).unwrap();
+        let coarse = if actual.fract() == 0.0 {
+            actual - 0.5
+        } else {
+            actual.floor()
+        };
+        let mut state = HelperState::default();
+        state.subscriptions.insert(
+            "1".to_string(),
+            std::fs::canonicalize(&root).expect("canonical root"),
+        );
+
+        fs_write(
+            &state,
+            Some(json!({
+                "path": file.display().to_string(),
+                "content": "editor",
+                "expectedMtime": coarse,
+                "expectedContent": "baseline"
+            })),
+        )
+        .expect("matching content should tolerate mtime precision");
+
+        assert_eq!(std::fs::read_to_string(&file).expect("content"), "editor");
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn write_rejects_symlink_without_modifying_target() {
+        let root = std::env::temp_dir().join(format!(
+            "alas-helper-symlink-write-{}-{}",
+            std::process::id(),
+            system_time_seconds(SystemTime::now()).unwrap()
+        ));
+        std::fs::create_dir_all(&root).expect("root");
+        let target = root.join("target.txt");
+        let link = root.join("link.txt");
+        std::fs::write(&target, "target").expect("target");
+        std::os::unix::fs::symlink(&target, &link).expect("symlink");
+        let mut state = HelperState::default();
+        state.subscriptions.insert(
+            "1".to_string(),
+            std::fs::canonicalize(&root).expect("canonical root"),
+        );
+
+        let error = fs_write(
+            &state,
+            Some(json!({
+                "path": link.display().to_string(),
+                "content": "editor"
+            })),
+        )
+        .expect_err("symlink writes must be rejected");
+
+        assert_eq!(error.code, -32025);
+        assert_eq!(std::fs::read_to_string(&target).expect("content"), "target");
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    #[test]
     fn search_cancel_marks_the_server_side_operation() {
         let cancelled = Arc::new(AtomicBool::new(false));
         let mut state = HelperState::default();
@@ -1512,9 +1569,9 @@ mod tests {
                 "content": "changed"
             })),
         )
-        .expect_err("write should reject escaping symlink");
+        .expect_err("write should reject symlink");
 
-        assert_eq!(error.code, -32023);
+        assert_eq!(error.code, -32025);
         assert_eq!(
             std::fs::read_to_string(&outside_file).expect("outside content"),
             "original"

--- a/AlasHelper/src/main.rs
+++ b/AlasHelper/src/main.rs
@@ -72,6 +72,7 @@ struct FsWriteParams {
     path: String,
     content: String,
     expected_mtime: Option<f64>,
+    expected_content: Option<String>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -464,6 +465,18 @@ fn fs_write(state: &HelperState, params: Option<Value>) -> Result<Value, HelperE
             && (actual - expected).abs() > 0.000_001
         {
             return Err(jsonrpc_error(-32030, "mtime mismatch"));
+        }
+    }
+    if let Some(expected) = params.expected_content {
+        let actual = std::fs::read(&path).map_err(|error| {
+            if error.kind() == io::ErrorKind::NotFound {
+                jsonrpc_error(-32030, "content target missing")
+            } else {
+                jsonrpc_error(-32020, format!("content check failed: {error}"))
+            }
+        })?;
+        if actual != expected.as_bytes() {
+            return Err(jsonrpc_error(-32030, "content mismatch"));
         }
     }
     write_replacing_path(&path, &params.content)?;
@@ -1223,6 +1236,39 @@ mod tests {
             })),
         )
         .expect_err("stale mtime must conflict");
+
+        assert_eq!(error.code, -32030);
+        assert_eq!(std::fs::read_to_string(&file).expect("content"), "external");
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn write_content_gate_rejects_changed_target_with_matching_mtime() {
+        let root = std::env::temp_dir().join(format!(
+            "alas-helper-content-conflict-{}-{}",
+            std::process::id(),
+            system_time_seconds(SystemTime::now()).unwrap()
+        ));
+        std::fs::create_dir_all(&root).expect("root");
+        let file = root.join("file.txt");
+        std::fs::write(&file, "external").expect("file");
+        let actual = modified_seconds(&std::fs::metadata(&file).expect("metadata")).unwrap();
+        let mut state = HelperState::default();
+        state.subscriptions.insert(
+            "1".to_string(),
+            std::fs::canonicalize(&root).expect("canonical root"),
+        );
+
+        let error = fs_write(
+            &state,
+            Some(json!({
+                "path": file.display().to_string(),
+                "content": "editor",
+                "expectedMtime": actual,
+                "expectedContent": "baseline"
+            })),
+        )
+        .expect_err("changed content must conflict even when mtime matches");
 
         assert_eq!(error.code, -32030);
         assert_eq!(std::fs::read_to_string(&file).expect("content"), "external");

--- a/AlasHelper/src/main.rs
+++ b/AlasHelper/src/main.rs
@@ -452,13 +452,19 @@ fn fs_read(state: &HelperState, params: Option<Value>) -> Result<Value, HelperEr
 
 fn fs_write(state: &HelperState, params: Option<Value>) -> Result<Value, HelperError> {
     let params: FsWriteParams = decode_params(params)?;
-    let path = contained_write_path(state, &params.path)?;
+    let path = contained_write_path(state, &params.path).map_err(|error| {
+        if params.expected_content.is_some() && error.code == -32025 {
+            jsonrpc_error(-32030, "content target unreadable")
+        } else {
+            error
+        }
+    })?;
     if let Some(expected) = params.expected_content.as_deref() {
         let actual = std::fs::read(&path).map_err(|error| {
             if error.kind() == io::ErrorKind::NotFound {
                 jsonrpc_error(-32030, "content target missing")
             } else {
-                jsonrpc_error(-32020, format!("content check failed: {error}"))
+                jsonrpc_error(-32030, format!("content target unreadable: {error}"))
             }
         })?;
         if actual != expected.as_bytes() {
@@ -1301,6 +1307,36 @@ mod tests {
     }
 
     #[test]
+    fn write_content_gate_treats_directory_as_conflict() {
+        let root = std::env::temp_dir().join(format!(
+            "alas-helper-directory-conflict-{}-{}",
+            std::process::id(),
+            system_time_seconds(SystemTime::now()).unwrap()
+        ));
+        let directory = root.join("file.txt");
+        std::fs::create_dir_all(&directory).expect("directory");
+        let mut state = HelperState::default();
+        state.subscriptions.insert(
+            "1".to_string(),
+            std::fs::canonicalize(&root).expect("canonical root"),
+        );
+
+        let error = fs_write(
+            &state,
+            Some(json!({
+                "path": directory.display().to_string(),
+                "content": "editor",
+                "expectedContent": "baseline"
+            })),
+        )
+        .expect_err("unreadable baseline must conflict");
+
+        assert_eq!(error.code, -32030);
+        assert!(directory.is_dir());
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    #[test]
     fn write_rejects_symlink_without_modifying_target() {
         let root = std::env::temp_dir().join(format!(
             "alas-helper-symlink-write-{}-{}",
@@ -1328,6 +1364,16 @@ mod tests {
         .expect_err("symlink writes must be rejected");
 
         assert_eq!(error.code, -32025);
+        let guarded_error = fs_write(
+            &state,
+            Some(json!({
+                "path": link.display().to_string(),
+                "content": "editor",
+                "expectedContent": "target"
+            })),
+        )
+        .expect_err("guarded symlink writes must conflict");
+        assert_eq!(guarded_error.code, -32030);
         assert_eq!(std::fs::read_to_string(&target).expect("content"), "target");
         let _ = std::fs::remove_dir_all(root);
     }

--- a/AlasTests/SSH/RemoteFileAccessTests.swift
+++ b/AlasTests/SSH/RemoteFileAccessTests.swift
@@ -33,6 +33,32 @@ struct RemoteFileAccessTests {
         #expect(RemoteFileAccess.parseReadPayload(Data()) == nil)
     }
 
+    @Test func helperReadPayloadPreservesBinaryBytes() {
+        let result = RemoteHelperFSReadResult(
+            kind: "file",
+            content: nil,
+            contentBase64: "AP8KQg==",
+            mtime: 42,
+            detail: nil
+        )
+        #expect(RemoteFileAccess.readResult(from: result) == .file(
+            data: Data([0x00, 0xFF, 0x0A, 0x42]),
+            mtime: Date(timeIntervalSince1970: 42)
+        ))
+    }
+
+    @Test func helperReadPayloadMapsNonFileKinds() {
+        #expect(RemoteFileAccess.readResult(from: RemoteHelperFSReadResult(
+            kind: "missing", content: nil, contentBase64: nil, mtime: nil, detail: nil
+        )) == .missing)
+        #expect(RemoteFileAccess.readResult(from: RemoteHelperFSReadResult(
+            kind: "directory", content: nil, contentBase64: nil, mtime: nil, detail: nil
+        )) == .directory)
+        #expect(RemoteFileAccess.readResult(from: RemoteHelperFSReadResult(
+            kind: "symlink", content: nil, contentBase64: nil, mtime: nil, detail: nil
+        )) == .symlink)
+    }
+
     @Test func writeScriptPreservesPermissionsAndIsAtomic() {
         let script = RemoteFileAccess.writeScript(path: "/srv/repo/run.sh")
         #expect(script.contains("f='/srv/repo/run.sh'"))

--- a/AlasTests/SSH/RemoteFileStatsTests.swift
+++ b/AlasTests/SSH/RemoteFileStatsTests.swift
@@ -9,6 +9,13 @@ struct RemoteFileStatsTests {
     @Test func parsesWcOutput() {
         #expect(RemoteFileStats.parseWcOutput("      12 a.txt\n       0 b.txt\n      12 total", requested: ["a.txt", "b.txt"]) == ["a.txt": 12, "b.txt": 0])
     }
+    @Test func helperLineCountsMergeDuplicatePaths() {
+        let entries = [
+            RemoteHelperFSLineCountEntry(path: "file.txt", lineCount: 10),
+            RemoteHelperFSLineCountEntry(path: "file.txt", lineCount: 12),
+        ]
+        #expect(RemoteFileStats.lineCountDictionary(entries) == ["file.txt": 12])
+    }
     @Test func parsesLsEntries() {
         let entries = RemoteFileStats.parseLsEntries("src/\nREADME.md\n")
         #expect(entries.count == 2)

--- a/AlasTests/SSH/RemoteHelperClientTests.swift
+++ b/AlasTests/SSH/RemoteHelperClientTests.swift
@@ -273,10 +273,20 @@ struct RemoteHelperClientTests {
         )
 
         let write = Task {
-            try await client.write(path: "/repo/file.txt", content: "new", expectedMtime: 1)
+            try await client.write(
+                path: "/repo/file.txt",
+                content: "new",
+                expectedMtime: 1,
+                expectedContent: "old"
+            )
         }
 
         try await waitUntil { !transport.sentFrames.isEmpty }
+        let request = try #require(
+            JSONSerialization.jsonObject(with: transport.sentFrames[0]) as? [String: Any]
+        )
+        let params = try #require(request["params"] as? [String: Any])
+        #expect(params["expectedContent"] as? String == "old")
         transport.send(frame: Data(#"{"jsonrpc":"2.0","id":1,"error":{"code":-32030,"message":"mtime mismatch"}}"#.utf8))
         await #expect(throws: RemoteHelperClientError.self) {
             try await write.value

--- a/AlasTests/SSH/RemoteHelperClientTests.swift
+++ b/AlasTests/SSH/RemoteHelperClientTests.swift
@@ -90,6 +90,74 @@ struct RemoteHelperClientTests {
         #expect((try await hello.value).name == "alas-helper")
     }
 
+    @Test func searchStreamsEventsArrivingImmediatelyAfterStart() async throws {
+        let transport = FakeJSONRPCTransport()
+        let client = RemoteHelperClient(
+            host: "devbox",
+            idleShutdownNanoseconds: 0,
+            transportFactory: { transport }
+        )
+
+        let start = Task {
+            try await client.search(
+                root: "/srv/repo",
+                query: "needle",
+                caseSensitive: false,
+                wholeWord: true,
+                regex: false
+            )
+        }
+        try await waitUntil { transport.sentFrames.count == 1 }
+        let request = try #require(
+            JSONSerialization.jsonObject(with: transport.sentFrames[0]) as? [String: Any]
+        )
+        #expect(request["method"] as? String == "search/start")
+        let params = try #require(request["params"] as? [String: Any])
+        #expect(params["root"] as? String == "/srv/repo")
+        #expect(params["wholeWord"] as? Bool == true)
+
+        transport.send(frame: Data(#"{"jsonrpc":"2.0","id":1,"result":{"searchId":"search-1"}}"#.utf8))
+        transport.send(frame: Data(#"{"jsonrpc":"2.0","method":"search/event","params":{"searchId":"search-1","line":"{\"type\":\"begin\"}"}}"#.utf8))
+        transport.send(frame: Data(#"{"jsonrpc":"2.0","method":"search/complete","params":{"searchId":"search-1","exitCode":0,"stderr":"","cancelled":false}}"#.utf8))
+
+        let handle = try await start.value
+        var events: [RemoteHelperSearchEvent] = []
+        for try await event in handle.events {
+            events.append(event)
+        }
+        #expect(events == [
+            .line(#"{"type":"begin"}"#),
+            .complete(exitCode: 0, stderr: "", cancelled: false),
+        ])
+    }
+
+    @Test func statsMethodsUseSingleHelperRequests() async throws {
+        let transport = FakeJSONRPCTransport()
+        let client = RemoteHelperClient(
+            host: "devbox",
+            idleShutdownNanoseconds: 0,
+            transportFactory: { transport }
+        )
+
+        let counts = Task { try await client.lineCounts(root: "/srv/repo", paths: ["a", "b"]) }
+        try await waitUntil { transport.sentFrames.count == 1 }
+        let countsRequest = try #require(
+            JSONSerialization.jsonObject(with: transport.sentFrames[0]) as? [String: Any]
+        )
+        #expect(countsRequest["method"] as? String == "fs/line-counts")
+        transport.send(frame: Data(#"{"jsonrpc":"2.0","id":1,"result":{"entries":[{"path":"a","lineCount":3}]}}"#.utf8))
+        #expect((try await counts.value).entries == [RemoteHelperFSLineCountEntry(path: "a", lineCount: 3)])
+
+        let listing = Task { try await client.list(path: "/srv/repo") }
+        try await waitUntil { transport.sentFrames.count == 2 }
+        let listRequest = try #require(
+            JSONSerialization.jsonObject(with: transport.sentFrames[1]) as? [String: Any]
+        )
+        #expect(listRequest["method"] as? String == "fs/list")
+        transport.send(frame: Data(#"{"jsonrpc":"2.0","id":2,"result":{"entries":[{"name":"src","isDirectory":true}]}}"#.utf8))
+        #expect((try await listing.value).entries == [RemoteHelperFSListEntry(name: "src", isDirectory: true)])
+    }
+
     @Test func watchEventNotificationsAreYielded() async throws {
         let transport = FakeJSONRPCTransport()
         let client = RemoteHelperClient(

--- a/AlasTests/SSH/RemoteHostCapabilitiesTests.swift
+++ b/AlasTests/SSH/RemoteHostCapabilitiesTests.swift
@@ -66,6 +66,18 @@ struct RemoteHostCapabilitiesTests {
         #expect(RemoteHostCapabilities.parse("Linux\nhelper=not-json").helperHandshake == nil)
     }
 
+    @Test func expectedContentWritesRequireHelperVersionFour() {
+        func handshake(_ version: String) -> RemoteHelperHandshake {
+            RemoteHelperHandshake(name: "alas-helper", protocolVersion: 1, binaryVersion: version)
+        }
+
+        #expect(!handshake("0.3.9").supportsExpectedContentWrite)
+        #expect(handshake("0.4.0").supportsExpectedContentWrite)
+        #expect(handshake("0.10.0").supportsExpectedContentWrite)
+        #expect(handshake("1.0.0").supportsExpectedContentWrite)
+        #expect(!handshake("development").supportsExpectedContentWrite)
+    }
+
     @Test func parsesArchAndNormalizesArm64() {
         #expect(RemoteHostCapabilities.parse("Linux\narch=x86_64").arch == "x86_64")
         #expect(RemoteHostCapabilities.parse("Darwin\narch=arm64").arch == "aarch64")

--- a/AlasTests/SSH/RemoteHostCapabilitiesTests.swift
+++ b/AlasTests/SSH/RemoteHostCapabilitiesTests.swift
@@ -66,15 +66,20 @@ struct RemoteHostCapabilitiesTests {
         #expect(RemoteHostCapabilities.parse("Linux\nhelper=not-json").helperHandshake == nil)
     }
 
-    @Test func expectedContentWritesRequireHelperVersionFour() {
+    @Test func filesystemV04ContractRequiresHelperVersionFour() {
         func handshake(_ version: String) -> RemoteHelperHandshake {
             RemoteHelperHandshake(name: "alas-helper", protocolVersion: 1, binaryVersion: version)
         }
 
+        #expect(!handshake("0.3.9").supportsFilesystemV04Contract)
         #expect(!handshake("0.3.9").supportsExpectedContentWrite)
+        #expect(handshake("0.4.0").supportsFilesystemV04Contract)
         #expect(handshake("0.4.0").supportsExpectedContentWrite)
+        #expect(handshake("0.10.0").supportsFilesystemV04Contract)
         #expect(handshake("0.10.0").supportsExpectedContentWrite)
+        #expect(handshake("1.0.0").supportsFilesystemV04Contract)
         #expect(handshake("1.0.0").supportsExpectedContentWrite)
+        #expect(!handshake("development").supportsFilesystemV04Contract)
         #expect(!handshake("development").supportsExpectedContentWrite)
     }
 

--- a/docs/architecture/remote-helper-protocol.md
+++ b/docs/architecture/remote-helper-protocol.md
@@ -119,8 +119,8 @@ Result: `{"mtime": 1783940100.5}`
 `expectedMtime` and `expectedContent` are optional. When content is provided it
 is the authoritative baseline, avoiding false conflicts when a preceding exec
 read only observed integer-second mtimes. Otherwise the mtime is the baseline.
-When the selected baseline differs, or the target no longer exists, the helper
-returns an error instead of writing.
+When the selected baseline differs, cannot be read, or the target no longer
+exists, the helper returns a conflict error instead of writing.
 
 `fs/stat`
 

--- a/docs/architecture/remote-helper-protocol.md
+++ b/docs/architecture/remote-helper-protocol.md
@@ -111,14 +111,14 @@ or `unreadable`.
 Params:
 
 ```json
-{"path":"/srv/repo/README.md","content":"...","expectedMtime":1783940000.25}
+{"path":"/srv/repo/README.md","content":"...","expectedMtime":1783940000.25,"expectedContent":"old content"}
 ```
 
 Result: `{"mtime": 1783940100.5}`
 
-`expectedMtime` is optional. When provided and the existing file mtime differs,
-or the target file no longer exists, the helper returns an error instead of
-writing.
+`expectedMtime` and `expectedContent` are optional. When either provided baseline
+differs from the existing file, or the target file no longer exists, the helper
+returns an error instead of writing.
 
 `fs/stat`
 

--- a/docs/architecture/remote-helper-protocol.md
+++ b/docs/architecture/remote-helper-protocol.md
@@ -100,11 +100,11 @@ for 250 ms before the helper sends one notification.
 `fs/read`
 
 Params: `{"path": "/srv/repo/README.md", "offset": 0}`  
-Result: `{"content": "...", "mtime": 1783940000.25}`
+Result: `{"kind":"file","contentBase64":"Li4u","mtime":1783940000.25}`
 
-The helper only reads regular files and decodes content as strict UTF-8. Binary
-or otherwise invalid UTF-8 files return an error instead of lossy replacement
-text.
+File bytes are base64 encoded so images and other binary files use the same
+operation. Non-file results use `kind` values `missing`, `directory`, `symlink`,
+or `unreadable`.
 
 `fs/write`
 
@@ -138,10 +138,52 @@ Result:
 }
 ```
 
+`fs/line-counts`
+
+Params: `{"root":"/srv/repo","paths":["README.md","src/main.swift"]}`
+Result: `{"entries":[{"path":"README.md","lineCount":42}]}`
+
+Missing and non-regular files are omitted. The request is not subject to the
+exec fallback's argv cap.
+
+`fs/list`
+
+Params: `{"path":"/srv/repo/src"}`
+Result: `{"entries":[{"name":"main.swift","isDirectory":false}]}`
+
+`search/start`
+
+Params:
+
+```json
+{
+  "root": "/srv/repo",
+  "query": "needle",
+  "caseSensitive": false,
+  "wholeWord": false,
+  "regex": false
+}
+```
+
+Result: `{"searchId":"1"}`
+
+The helper runs `rg --json` and emits each output line as a `search/event`
+notification. It finishes with `search/complete`, including ripgrep's exit code,
+bounded stderr, and whether the operation was cancelled.
+
+`search/cancel`
+
+Params: `{"searchId":"1"}`
+Result: `{"ok":true}`
+
+Cancellation kills the server-side ripgrep child without closing the helper
+channel.
+
 ## Security
 
 The helper only serves paths under registered roots. `watch/subscribe` resolves
-the requested root with the remote host filesystem. `fs/read` and `fs/stat`
+the requested root with the remote host filesystem. Reads, stats, listings,
+line counts, and searches
 resolve existing target paths and require them to be under a registered root.
 `fs/write` resolves the parent directory and requires that parent to be under a
 registered root before writing. If the final path already exists as a symlink,
@@ -164,6 +206,5 @@ range:
 | `-32021` | path does not exist |
 | `-32022` | no containment roots have been registered |
 | `-32023` | path is outside registered roots |
-| `-32024` | file content is not valid UTF-8 |
 | `-32025` | path is not a regular file |
 | `-32030` | `expectedMtime` did not match |

--- a/docs/architecture/remote-helper-protocol.md
+++ b/docs/architecture/remote-helper-protocol.md
@@ -116,8 +116,10 @@ Params:
 
 Result: `{"mtime": 1783940100.5}`
 
-`expectedMtime` and `expectedContent` are optional. When either provided baseline
-differs from the existing file, or the target file no longer exists, the helper
+`expectedMtime` and `expectedContent` are optional. When content is provided it
+is the authoritative baseline, avoiding false conflicts when a preceding exec
+read only observed integer-second mtimes. Otherwise the mtime is the baseline.
+When the selected baseline differs, or the target no longer exists, the helper
 returns an error instead of writing.
 
 `fs/stat`
@@ -187,11 +189,11 @@ line counts, and searches
 resolve existing target paths and require them to be under a registered root.
 `fs/write` resolves the parent directory and requires that parent to be under a
 registered root before writing. If the final path already exists as a symlink,
-the helper resolves the symlink target and rejects writes outside registered
-roots. Writes use a sibling temporary file plus rename, preserving the existing
-target mode when replacing a file, so hardlinks inside a registered root are
-replaced instead of mutating an outside shared inode. This catches symlink and
-hardlink escapes on the host that lexical path checks cannot see.
+the helper rejects the write. Writes use a sibling temporary file plus rename,
+preserving the existing target mode when replacing a file, so hardlinks inside a
+registered root are replaced instead of mutating an outside shared inode. This
+catches symlink and hardlink escapes on the host that lexical path checks cannot
+see.
 
 ## Errors
 
@@ -207,4 +209,4 @@ range:
 | `-32022` | no containment roots have been registered |
 | `-32023` | path is outside registered roots |
 | `-32025` | path is not a regular file |
-| `-32030` | `expectedMtime` did not match |
+| `-32030` | expected content or mtime baseline did not match |


### PR DESCRIPTION
## Summary

- route remote reads, writes, stats, line counts, and directory listings through the persistent helper channel when available
- move the editor save conflict check into the helper's atomic write operation while preserving the existing SSH exec fallback
- stream `rg --json` search events over the helper channel with server-side cancellation and retain `git grep` on helper-less hosts
- add binary-safe reads, debug operation timing, protocol documentation, and focused Swift/Rust coverage

## Why

Remote file and search operations previously launched a separate SSH exec for every request. Even with ControlMaster, interactive workflows paid a round trip and remote process spawn per operation. The client-side stat-then-write save gate also left a race window before the write.

The persistent helper now owns these operations under registered roots. Older or unavailable helpers fall back to the existing exec implementations, so helper-less hosts keep the current behavior.

Closes #753.

## Validation

- `xcodegen`
- `ALAS_FFF_TARGET_ARCH=arm64 xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -quiet build`
- focused `RemoteHelperClientTests`, `RemoteFileAccessTests`, `RemoteFileStatsTests`, and `RemoteContentSearchTests` (43 tests passed)
- full non-integration suite with `-skip-testing:AlasTests/SSHIntegrationTests` (passed; 5,262 tests passed in the preceding full run)
- `cargo test --manifest-path AlasHelper/Cargo.toml` (23 tests passed)
- `cargo fmt --manifest-path AlasHelper/Cargo.toml`
- `git diff --check`

`SSHIntegrationTests` could not run because localhost SSH is unavailable on the development machine (`port 22: Connection refused`). The ungated full run passed 5,262 tests and failed only the eight tests that require `ALAS_SSH_INTEGRATION=1` plus key-authenticated localhost SSH.
