### PR TITLE
fix(acp): Bound ACP transcript restore window

### DIFF
--- a/Alas/Sources/ACP/Session/ACPSessionManager.swift
+++ b/Alas/Sources/ACP/Session/ACPSessionManager.swift
@@ -855,13 +855,13 @@ final class ACPSessionManager: ObservableObject {
         if let index = memory.anchorMessageIndex {
             let localIndex = index - messageIndexOffset
             guard localIndex >= 0, localIndex < session.transcript.messages.count else { return }
-            session.transcript.setVisibleHead(localIndex)
+            session.transcript.setVisibleWindow(containing: localIndex)
             return
         }
         guard let anchor = memory.anchorMessageId,
               let index = session.transcript.messages.firstIndex(where: { $0.stableId == anchor })
         else { return }
-        session.transcript.setVisibleHead(index)
+        session.transcript.setVisibleWindow(containing: index)
     }
 
     /// Drops the cached `ACPSession` when its refcount is zero AND no live

--- a/Alas/Sources/ACP/Session/ACPTranscript.swift
+++ b/Alas/Sources/ACP/Session/ACPTranscript.swift
@@ -41,17 +41,24 @@ final class ACPTranscript: ObservableObject {
     /// async load is still running.
     @Published var isBackfillingOlderMessages: Bool = false
 
-    /// Render window: `ACPMessageList` draws `messages[visibleHead...]`.
+    /// Render window: `ACPMessageList` draws `messages[visibleHead..<visibleTail]`.
     /// Reset to `max(0, messages.count - tailWindow)` after hydration so
     /// long transcripts paint quickly; user can scroll up or click the
     /// "Earlier messages…" affordance to reveal older rows in chunks of
     /// `tailWindow`.
     @Published var visibleHead: Int = 0
+    /// Exclusive upper bound of the render window. `nil` means the live tail.
+    /// Non-tail restored anchors use this to avoid asking SwiftUI to keep every
+    /// newer transcript row in a single lazy-stack layout pass.
+    @Published var visibleTail: Int?
 
     /// Number of rows revealed per backfill step. Tuned for chat-style
     /// content where a screenful is a few rows; bigger steps feel like
     /// loading state, smaller steps require too many clicks.
     static let tailWindow: Int = 30
+    /// Upper bound for non-tail render windows. A few chunks gives enough room
+    /// for natural scrolling while keeping `ForEach` input bounded.
+    static let maxVisibleRows: Int = tailWindow * 3
 
     /// Stable ids of streaming text rows whose prompt has completed. A
     /// later ACP text chunk must start a fresh row instead of appending
@@ -129,13 +136,43 @@ final class ACPTranscript: ObservableObject {
     /// after hydration applies a transcript. No-op for transcripts shorter
     /// than `tailWindow`.
     func resetWindowToTail() {
-        setVisibleHead(max(0, messages.count - Self.tailWindow))
+        setVisibleWindow(head: max(0, messages.count - Self.tailWindow), tail: nil)
     }
 
     /// Reveal one more `tailWindow`-sized chunk of older messages.
     /// Clamps at zero. Idempotent at the head.
     func stepHeadBack() {
-        visibleHead = max(0, visibleHead - Self.tailWindow)
+        let currentTail = visibleTailBound
+        let newHead = max(0, visibleHead - Self.tailWindow)
+        let boundedTail = min(messages.count, newHead + Self.maxVisibleRows)
+        setVisibleWindow(head: newHead, tail: min(currentTail, boundedTail))
+    }
+
+    /// Reveal one more chunk of newer messages while keeping the row currently
+    /// near the viewport top inside the bounded window when possible.
+    func stepTailForward(preserving preservedIndex: Int?) {
+        let currentTail = visibleTailBound
+        guard currentTail < messages.count else { return }
+        var newTail = min(messages.count, currentTail + Self.tailWindow)
+        if let preservedIndex,
+           preservedIndex >= visibleHead,
+           preservedIndex < currentTail {
+            let preservingTail = min(newTail, preservedIndex + Self.maxVisibleRows)
+            if preservingTail > currentTail {
+                newTail = preservingTail
+            }
+        }
+        guard newTail > currentTail else { return }
+        let boundedHead = max(0, newTail - Self.maxVisibleRows)
+        setVisibleWindow(head: boundedHead, tail: newTail)
+    }
+
+    /// Restore around a remembered non-tail row without rendering the entire
+    /// suffix from that row to the transcript tail.
+    func setVisibleWindow(containing index: Int) {
+        let head = max(0, min(index, messages.count))
+        let tail = min(messages.count, head + Self.maxVisibleRows)
+        setVisibleWindow(head: head, tail: tail)
     }
 
     /// Move the render window head, dropping markdown caches for any message
@@ -143,16 +180,7 @@ final class ACPTranscript: ObservableObject {
     /// than the current `visibleHead`. Use this instead of writing
     /// `visibleHead` directly when advancing the window.
     func setVisibleHead(_ newHead: Int) {
-        let clamped = max(0, min(newHead, messages.count))
-        guard clamped != visibleHead else { return }
-        guard clamped > visibleHead else {
-            visibleHead = clamped
-            return
-        }
-        for i in visibleHead..<clamped {
-            trimHiddenMessage(at: i)
-        }
-        visibleHead = clamped
+        setVisibleWindow(head: newHead, tail: nil)
     }
 
     /// Shift the render window after hidden messages are prepended at the
@@ -161,10 +189,37 @@ final class ACPTranscript: ObservableObject {
     func shiftVisibleHeadAfterPrepending(_ insertedCount: Int) {
         guard insertedCount > 0 else { return }
         let shiftedHead = max(0, min(visibleHead + insertedCount, messages.count))
+        let shiftedTail = visibleTail.map { max(shiftedHead, min($0 + insertedCount, messages.count)) }
         for i in 0..<shiftedHead {
             trimHiddenMessage(at: i)
         }
         visibleHead = shiftedHead
+        visibleTail = shiftedTail
+    }
+
+    var visibleTailBound: Int {
+        max(visibleHead, min(visibleTail ?? messages.count, messages.count))
+    }
+
+    private func setVisibleWindow(head newHead: Int, tail newTail: Int?) {
+        let clampedHead = max(0, min(newHead, messages.count))
+        let clampedTail = newTail.map { max(clampedHead, min($0, messages.count)) }
+        let normalizedTail = clampedTail
+        guard clampedHead != visibleHead || normalizedTail != visibleTail else { return }
+        if clampedHead > visibleHead {
+            for i in visibleHead..<clampedHead {
+                trimHiddenMessage(at: i)
+            }
+        }
+        let oldTail = visibleTailBound
+        let newTail = normalizedTail ?? messages.count
+        if newTail < oldTail {
+            for i in newTail..<oldTail {
+                trimHiddenMessage(at: i)
+            }
+        }
+        visibleHead = clampedHead
+        visibleTail = normalizedTail
     }
 
     private func trimHiddenMessage(at index: Int) {

--- a/Alas/Sources/ACP/UI/ACPMessageList.swift
+++ b/Alas/Sources/ACP/UI/ACPMessageList.swift
@@ -34,6 +34,7 @@ struct ACPMessageList: View {
     @State private var isRestoringTail = false
     @State private var headFrame: CGRect = .zero
     @State private var lastHeadStepAt: Date = .distantPast
+    @State private var lastTailStepAt: Date = .distantPast
     @State private var scrollViewRef = ACPWeakScrollViewRef()
     @State private var latestTopVisibleAnchor = ACPMutableScrollAnchor()
     @State private var latestRememberedScrollAnchorIndex: Int?
@@ -63,6 +64,7 @@ struct ACPMessageList: View {
         Self.visibleRows(
             messages: transcript.messages,
             visibleHead: transcript.visibleHead,
+            visibleTail: transcript.visibleTailBound,
             stableId: { transcript.stableId(for: $0) }
         )
     }
@@ -129,6 +131,12 @@ struct ACPMessageList: View {
                         }
                         ForEach(visibleRows) { row in
                             visibleRow(row)
+                        }
+                        if Self.shouldShowBottomPaginationSentinel(
+                            visibleTail: transcript.visibleTailBound,
+                            messageCount: transcript.messages.count
+                        ) {
+                            bottomPaginationSentinel
                         }
                         if transcript.pendingPermission != nil, let policy = policy {
                             ACPPermissionPrompt(session: session, policy: policy, scopeKey: scopeKey)
@@ -211,7 +219,7 @@ struct ACPMessageList: View {
                     onResolveScrollView: { scrollViewRef.scrollView = $0 },
                     onHeadFrame: { handleHeadFramePreference($0, proxy: proxy) },
                     onPaused: { setFollowsTranscriptTail(false) },
-                    onAtBottom: { setFollowsTranscriptTail(true) },
+                    onAtBottom: { handleAtBottom(proxy: proxy) },
                     onGeometry: { old, new in
                         handleScrollGeometry(
                             previousMinY: old.minY,
@@ -223,7 +231,7 @@ struct ACPMessageList: View {
                     }
                 ))
                 .modifier(ACPScrollTargetVisibilityTracking(
-                    onVisibleTargetIDs: handleVisibleTargetIDs
+                    onVisibleTargetIDs: { ids in handleVisibleTargetIDs(ids, proxy: proxy) }
                 ))
                 .onAppear {
                     restoreTailIfNeeded(proxy: proxy, animated: false)
@@ -458,8 +466,16 @@ struct ACPMessageList: View {
         restoredRememberedAnchor = anchor
     }
 
-    private func handleVisibleTargetIDs(_ ids: [String]) {
+    private func handleVisibleTargetIDs(_ ids: [String], proxy: ScrollViewProxy) {
         let lookup = visibleMessageLookup
+        if Self.shouldPageNewerRowsFromBottomSentinel(
+            isSentinelVisible: ids.contains(Self.bottomPaginationSentinelID),
+            isUserDriven: ACPUserScrollEvent.isUserDriven(NSApp.currentEvent?.type),
+            visibleTail: transcript.visibleTailBound,
+            messageCount: transcript.messages.count
+        ) {
+            stepTailForwardPreservingScroll(proxy: proxy, lookup: lookup)
+        }
         guard let anchor = Self.topVisibleScrollTargetID(
             in: ids,
             visibleMessageIds: lookup.ids
@@ -477,6 +493,50 @@ struct ACPMessageList: View {
         onRememberScrollAnchor(anchor, anchorIndex, false)
         latestRememberedScrollAnchorIndex = anchorIndex
         restoredRememberedAnchor = anchor
+    }
+
+    private func stepTailForwardPreservingScroll(
+        proxy: ScrollViewProxy,
+        lookup: VisibleMessageLookup
+    ) {
+        guard !isRestoringTail else { return }
+        guard transcript.visibleTailBound < transcript.messages.count else { return }
+        let now = Date()
+        guard now.timeIntervalSince(lastTailStepAt) > headStepDebounceInterval else { return }
+        lastTailStepAt = now
+        let anchorId = latestTopVisibleAnchor.value ?? lookup.firstStableId
+        let anchorIndex = lookup.transcriptIndex(for: anchorId)
+        isRestoringTail = true
+        transcript.stepTailForward(preserving: anchorIndex)
+        let updatedRows = Self.visibleRows(
+            messages: transcript.messages,
+            visibleHead: transcript.visibleHead,
+            visibleTail: transcript.visibleTailBound,
+            stableId: { transcript.stableId(for: $0) }
+        )
+        let updatedLookup = Self.visibleMessageLookup(rows: updatedRows.map { row in
+            (index: row.index, stableId: row.stableId)
+        })
+        let scrollTargetId = updatedLookup.contains(anchorId) ? anchorId : updatedLookup.firstStableId
+        DispatchQueue.main.async {
+            if let scrollTargetId {
+                proxy.scrollTo(scrollTargetId, anchor: .top)
+            }
+            DispatchQueue.main.async {
+                isRestoringTail = false
+            }
+        }
+    }
+
+    private func handleAtBottom(proxy: ScrollViewProxy) {
+        if Self.shouldResumeTailFollowAtBottom(
+            visibleTail: transcript.visibleTailBound,
+            messageCount: transcript.messages.count
+        ) {
+            setFollowsTranscriptTail(true)
+        } else {
+            stepTailForwardPreservingScroll(proxy: proxy, lookup: visibleMessageLookup)
+        }
     }
 
     @ViewBuilder
@@ -519,6 +579,14 @@ struct ACPMessageList: View {
         .frame(height: 1)
     }
 
+    private var bottomPaginationSentinel: some View {
+        Color.clear
+            .frame(height: 1)
+            .id(Self.bottomPaginationSentinelID)
+    }
+
+    private static let bottomPaginationSentinelID = "__transcript_later__"
+
     nonisolated static func topPaginationIndicator(
         visibleHead: Int,
         isBackfillingOlderMessages: Bool
@@ -535,6 +603,29 @@ struct ACPMessageList: View {
         case .sending:
             return false
         }
+    }
+
+    nonisolated static func shouldShowBottomPaginationSentinel(
+        visibleTail: Int,
+        messageCount: Int
+    ) -> Bool {
+        visibleTail < messageCount
+    }
+
+    nonisolated static func shouldResumeTailFollowAtBottom(
+        visibleTail: Int,
+        messageCount: Int
+    ) -> Bool {
+        visibleTail >= messageCount
+    }
+
+    nonisolated static func shouldPageNewerRowsFromBottomSentinel(
+        isSentinelVisible: Bool,
+        isUserDriven: Bool,
+        visibleTail: Int,
+        messageCount: Int
+    ) -> Bool {
+        isSentinelVisible && isUserDriven && visibleTail < messageCount
     }
 
     nonisolated static func queueHeaderCount(statuses: [QueuedPrompt.Status]) -> Int {
@@ -636,10 +727,12 @@ struct ACPMessageList: View {
     static func visibleRows(
         messages: [ACPMessage],
         visibleHead: Int,
+        visibleTail: Int,
         stableId: (ACPMessage) -> String
     ) -> [VisibleRow] {
         let head = min(visibleHead, messages.count)
-        return (head..<messages.count).compactMap { index in
+        let tail = max(head, min(visibleTail, messages.count))
+        return (head..<tail).compactMap { index in
             let message = messages[index]
             if case .plan = message { return nil }
             return VisibleRow(index: index, stableId: stableId(message))
@@ -752,7 +845,7 @@ struct ACPMessageList: View {
         )
         switch decision {
         case .userScrolledUp: setFollowsTranscriptTail(false)
-        case .userAtBottom: setFollowsTranscriptTail(true)
+        case .userAtBottom: handleAtBottom(proxy: proxy)
         case .noChange: break
         }
         if Self.shouldRestoreTailAfterContentGrowth(
@@ -805,28 +898,10 @@ struct ACPMessageList: View {
     /// Reveal an older chunk while keeping the viewport anchored to the same
     /// content.
     private func stepHeadBackPreservingScroll(proxy: ScrollViewProxy) {
-        // macOS 14: the ScrollView is NSScrollView-backed, so we preserve the
-        // exact reading position by shifting the clip-view origin by the height
-        // the prepended rows add.
-        if let scrollView = scrollViewRef.scrollView {
-            let clipView = scrollView.contentView
-            let oldOffset = clipView.bounds.origin.y
-            let oldContentHeight = scrollView.documentView?.bounds.height ?? 0
-            isRestoringTail = true
-            transcript.stepHeadBack()
-            DispatchQueue.main.async {
-                let newContentHeight = scrollView.documentView?.bounds.height ?? 0
-                let delta = newContentHeight - oldContentHeight
-                if delta > 0 {
-                    clipView.setBoundsOrigin(NSPoint(x: clipView.bounds.origin.x, y: oldOffset + delta))
-                }
-                DispatchQueue.main.async { isRestoringTail = false }
-            }
-            return
-        }
-        // macOS 15+: no reachable NSScrollView. Anchor the row currently at the
-        // top of the window and pin it back to the top after the older rows lay
-        // out, so the viewport doesn't jump.
+        // Anchor the row currently at the top of the window and pin it back after
+        // the older rows lay out. This works on both scroll-tracking paths and
+        // does not depend on net content-height changes when the bounded window
+        // also trims newer rows from the bottom.
         let anchorId = visibleMessageLookup.firstStableId
         isRestoringTail = true
         transcript.stepHeadBack()

--- a/AlasTests/ACP/Session/ACPSessionManagerHydrationTests.swift
+++ b/AlasTests/ACP/Session/ACPSessionManagerHydrationTests.swift
@@ -674,6 +674,41 @@ struct ACPSessionManagerHydrationTests {
         }
     }
 
+    @Test("remembered non-tail scroll anchor reopens with bounded newer rows")
+    func rememberedScrollAnchorRestoresBoundedWindow() async throws {
+        let path = tmpStorePath()
+        let store = try ACPSessionStore(path: path)
+        try store.upsertSession(.init(
+            id: "s", agentId: "claude", title: "t",
+            currentModel: nil, currentMode: nil, autoRun: false,
+            createdAt: 0, updatedAt: 0, lastOpenedAt: 0, archived: false))
+
+        var anchorId = ""
+        for i in 0..<200 {
+            let id = UUID(uuidString: String(format: "00000000-0000-0000-0000-%012d", i))!
+            if i == 40 { anchorId = id.uuidString }
+            let m: ACPMessage = .user(id: id, text: "m\(i)", attachments: [])
+            let payload = try ACPMessageCodec.encode(m)
+            try store.appendMessage(sessionId: "s", id: "m\(i)", kind: "user",
+                                    seq: Int64(i), payload: payload, createdAt: 0)
+        }
+
+        let mgr = ACPSessionManager(worktreeId: "wt", worktreePath: "/tmp/wt", store: store)
+        mgr.rememberTranscriptScrollAnchor(
+            sessionId: "s",
+            anchorMessageId: anchorId,
+            anchorMessageIndex: 40,
+            followsTail: false
+        )
+
+        let reopened = try #require(mgr.placeholderSession(id: "s"))
+        await mgr.hydrateIfNeeded(id: "s")
+        await mgr.awaitBackfill(id: "s")
+
+        #expect(reopened.transcript.visibleHead == 40)
+        #expect(reopened.transcript.visibleTail == 40 + ACPTranscript.maxVisibleRows)
+    }
+
     @Test("contextRestoreWarning sees the full transcript even when only tail is in memory")
     func contextRestoreWarningComputedFromFullWires() async throws {
         let path = tmpStorePath()

--- a/AlasTests/ACP/Session/ACPTranscriptMarkdownCacheEvictionTests.swift
+++ b/AlasTests/ACP/Session/ACPTranscriptMarkdownCacheEvictionTests.swift
@@ -81,6 +81,25 @@ struct ACPTranscriptMarkdownCacheEvictionTests {
         }
     }
 
+    @Test("stepping head back drops caches for rows trimmed from the tail")
+    func stepHeadBackDropsRowsTrimmedFromTail() {
+        let t = ACPTranscript()
+        for i in 0..<200 { t.messages.append(.systemNotice(id: UUID(), text: "\(i)")) }
+        let ids = t.messages.map(\.stableId)
+        for id in ids {
+            t.markdownCache(forMessage: id).update(with: id)
+        }
+
+        t.setVisibleWindow(containing: 110)
+        t.stepHeadBack()
+
+        #expect(t.visibleHead == 80)
+        #expect(t.visibleTail == 170)
+        for id in ids[170..<200] {
+            #expect(!t.hasMarkdownCacheForTests(messageId: id))
+        }
+    }
+
     @Test("resetMarkdownCaches empties the cache map")
     func resetClears() {
         let t = ACPTranscript()

--- a/AlasTests/ACP/Session/ACPTranscriptWindowTests.swift
+++ b/AlasTests/ACP/Session/ACPTranscriptWindowTests.swift
@@ -11,6 +11,11 @@ struct ACPTranscriptWindowTests {
         #expect(ACPTranscript.tailWindow == 30)
     }
 
+    @Test("maxVisibleRows spans three chunks")
+    func maxVisibleRowsConstant() {
+        #expect(ACPTranscript.maxVisibleRows == ACPTranscript.tailWindow * 3)
+    }
+
     @Test("visibleHead defaults to zero")
     func defaultHead() {
         let t = ACPTranscript()
@@ -25,6 +30,7 @@ struct ACPTranscriptWindowTests {
         }
         t.resetWindowToTail()
         #expect(t.visibleHead == 20) // 50 - 30
+        #expect(t.visibleTail == nil)
     }
 
     @Test("resetWindowToTail clamps to zero for short transcripts")
@@ -35,6 +41,7 @@ struct ACPTranscriptWindowTests {
         }
         t.resetWindowToTail()
         #expect(t.visibleHead == 0)
+        #expect(t.visibleTail == nil)
     }
 
     @Test("resetWindowToTail does not publish when head is already current")
@@ -70,7 +77,119 @@ struct ACPTranscriptWindowTests {
         #expect(t.visibleHead == 10)
         t.stepHeadBack()
         #expect(t.visibleHead == 0) // clamped
+        #expect(t.visibleTail == 90)
         t.stepHeadBack()
         #expect(t.visibleHead == 0) // still clamped
+        #expect(t.visibleTail == 90)
+    }
+
+    @Test("remembered anchor window caps newer rows")
+    func rememberedAnchorWindowCapsNewerRows() {
+        let t = ACPTranscript()
+        for _ in 0..<200 {
+            t.messages.append(.systemNotice(id: UUID(), text: "x"))
+        }
+
+        t.setVisibleWindow(containing: 40)
+
+        #expect(t.visibleHead == 40)
+        #expect(t.visibleTail == 40 + ACPTranscript.maxVisibleRows)
+    }
+
+    @Test("remembered anchor near the tail keeps an explicit finite tail")
+    func rememberedAnchorNearTailKeepsExplicitFiniteTail() {
+        let t = ACPTranscript()
+        for _ in 0..<100 {
+            t.messages.append(.systemNotice(id: UUID(), text: "x"))
+        }
+
+        t.setVisibleWindow(containing: 50)
+
+        #expect(t.visibleHead == 50)
+        #expect(t.visibleTail == 100)
+
+        t.messages.append(.systemNotice(id: UUID(), text: "new"))
+
+        #expect(t.visibleTail == 100)
+        #expect(t.visibleTailBound == 100)
+    }
+
+    @Test("tail forward reveals newer rows and keeps a bounded window")
+    func tailForwardRevealsNewerRows() {
+        let t = ACPTranscript()
+        for _ in 0..<200 {
+            t.messages.append(.systemNotice(id: UUID(), text: "x"))
+        }
+        t.setVisibleWindow(containing: 40)
+
+        t.stepTailForward(preserving: 110)
+
+        #expect(t.visibleTail == 160)
+        #expect(t.visibleHead == 70)
+        #expect(t.visibleTail! - t.visibleHead == ACPTranscript.maxVisibleRows)
+    }
+
+    @Test("tail forward keeps an older preserved anchor inside the bounded window")
+    func tailForwardKeepsOlderPreservedAnchorInsideBoundedWindow() {
+        let t = ACPTranscript()
+        for _ in 0..<200 {
+            t.messages.append(.systemNotice(id: UUID(), text: "x"))
+        }
+        t.setVisibleWindow(containing: 40)
+
+        t.stepTailForward(preserving: 50)
+
+        #expect(t.visibleTail == 140)
+        #expect(t.visibleHead == 50)
+        #expect(t.visibleTail! - t.visibleHead == ACPTranscript.maxVisibleRows)
+    }
+
+    @Test("tail forward advances when preserving the top row would stall")
+    func tailForwardAdvancesWhenPreservingTopRowWouldStall() {
+        let t = ACPTranscript()
+        for _ in 0..<200 {
+            t.messages.append(.systemNotice(id: UUID(), text: "x"))
+        }
+        t.setVisibleWindow(containing: 40)
+
+        t.stepTailForward(preserving: 40)
+
+        #expect(t.visibleTail == 160)
+        #expect(t.visibleHead == 70)
+        #expect(t.visibleTail! - t.visibleHead == ACPTranscript.maxVisibleRows)
+    }
+
+    @Test("prepended history shifts both sides of a bounded window")
+    func prependedHistoryShiftsBoundedWindow() {
+        let t = ACPTranscript()
+        for _ in 0..<120 {
+            t.messages.append(.systemNotice(id: UUID(), text: "x"))
+        }
+        t.setVisibleWindow(containing: 10)
+
+        t.messages.insert(contentsOf: (0..<20).map { _ in
+            ACPMessage.systemNotice(id: UUID(), text: "older")
+        }, at: 0)
+        t.shiftVisibleHeadAfterPrepending(20)
+
+        #expect(t.visibleHead == 30)
+        #expect(t.visibleTail == 120)
+    }
+
+    @Test("prepended history preserves an explicit tail at the old end")
+    func prependedHistoryPreservesExplicitTailAtOldEnd() {
+        let t = ACPTranscript()
+        for _ in 0..<100 {
+            t.messages.append(.systemNotice(id: UUID(), text: "x"))
+        }
+        t.setVisibleWindow(containing: 50)
+
+        t.messages.insert(contentsOf: (0..<10).map { _ in
+            ACPMessage.systemNotice(id: UUID(), text: "older")
+        }, at: 0)
+        t.shiftVisibleHeadAfterPrepending(10)
+
+        #expect(t.visibleHead == 60)
+        #expect(t.visibleTail == 110)
     }
 }

--- a/AlasTests/ACP/UI/ACPMessageListPaginationTests.swift
+++ b/AlasTests/ACP/UI/ACPMessageListPaginationTests.swift
@@ -225,12 +225,85 @@ struct ACPMessageListPaginationTests {
         let rows = ACPMessageList.visibleRows(
             messages: messages,
             visibleHead: 1,
+            visibleTail: messages.count,
             stableId: { $0.stableId }
         )
 
         #expect(rows == [
             ACPMessageList.VisibleRow(index: 2, stableId: "acp-agent:agent-1")
         ])
+    }
+
+    @Test("visible rows stop at the visible tail")
+    @MainActor
+    func visibleRowsStopAtVisibleTail() {
+        let messages: [ACPMessage] = [
+            .user(id: UUID(), messageId: "user-1", text: "one", attachments: []),
+            .user(id: UUID(), messageId: "user-2", text: "two", attachments: []),
+            .user(id: UUID(), messageId: "user-3", text: "three", attachments: []),
+            .user(id: UUID(), messageId: "user-4", text: "four", attachments: [])
+        ]
+
+        let rows = ACPMessageList.visibleRows(
+            messages: messages,
+            visibleHead: 1,
+            visibleTail: 3,
+            stableId: { $0.stableId }
+        )
+
+        #expect(rows.map(\.index) == [1, 2])
+    }
+
+    @Test("bottom pagination sentinel is shown only when newer rows are hidden")
+    func bottomPaginationSentinelReflectsVisibleTail() {
+        #expect(ACPMessageList.shouldShowBottomPaginationSentinel(
+            visibleTail: 90,
+            messageCount: 100
+        ))
+        #expect(!ACPMessageList.shouldShowBottomPaginationSentinel(
+            visibleTail: 100,
+            messageCount: 100
+        ))
+    }
+
+    @Test("bottom geometry resumes tail follow only at the live transcript tail")
+    func bottomGeometryResumesTailFollowOnlyAtLiveTail() {
+        #expect(!ACPMessageList.shouldResumeTailFollowAtBottom(
+            visibleTail: 90,
+            messageCount: 100
+        ))
+        #expect(ACPMessageList.shouldResumeTailFollowAtBottom(
+            visibleTail: 100,
+            messageCount: 100
+        ))
+    }
+
+    @Test("bottom sentinel pages newer rows only during user scroll")
+    func bottomSentinelPagesNewerRowsOnlyDuringUserScroll() {
+        #expect(!ACPMessageList.shouldPageNewerRowsFromBottomSentinel(
+            isSentinelVisible: true,
+            isUserDriven: false,
+            visibleTail: 90,
+            messageCount: 100
+        ))
+        #expect(ACPMessageList.shouldPageNewerRowsFromBottomSentinel(
+            isSentinelVisible: true,
+            isUserDriven: true,
+            visibleTail: 90,
+            messageCount: 100
+        ))
+        #expect(!ACPMessageList.shouldPageNewerRowsFromBottomSentinel(
+            isSentinelVisible: true,
+            isUserDriven: true,
+            visibleTail: 100,
+            messageCount: 100
+        ))
+        #expect(!ACPMessageList.shouldPageNewerRowsFromBottomSentinel(
+            isSentinelVisible: false,
+            isUserDriven: true,
+            visibleTail: 90,
+            messageCount: 100
+        ))
     }
 
     @Test("visible anchor memory accepts live anchors when the remembered id is stale")


### PR DESCRIPTION
## Summary

- Bound restored non-tail ACP transcript windows on both the older and newer sides.
- Page newer rows back in as the user scrolls down, preserving the current top anchor.
- Add regression coverage for bounded transcript windows, visible-row slicing, and remembered-anchor hydration.

## Root Cause

The beachball stackshot showed SwiftUI spending the main thread in lazy-stack placement and `ForEachState` while updating the ACP transcript. The previous tail-first rendering work bounded first paint at the tail, but restoring a remembered non-tail anchor could still render every newer row from that anchor to the transcript tail. On long sessions that made the lazy transcript stack too large during layout.

## Validation

- `rtk xcodegen`
- `ALAS_FFF_TARGET_ARCH=arm64 rtk xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -only-testing:AlasTests/ACPTranscriptWindowTests -only-testing:AlasTests/ACPMessageListPaginationTests -only-testing:AlasTests/ACPSessionManagerHydrationTests test`
- `ALAS_FFF_TARGET_ARCH=arm64 rtk xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -quiet build`

Full `ALAS_FFF_TARGET_ARCH=arm64 rtk xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' test` was also run; it reached the test phase and failed in unrelated existing/broad-suite cases: `ACPTerminalTests.releaseReachesOrphans()` and SSH integration tests requiring `ALAS_SSH_INTEGRATION=1`.