### PR TITLE
feat(acp): manage adapters on SSH hosts

### DIFF
--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -121,6 +121,7 @@
 		17DE066D4BDD1F30439DA629 /* TerminalPane.swift in Sources */ = {isa = PBXBuildFile; fileRef = FEB2EC20D23F9A4F50B1A6E3 /* TerminalPane.swift */; };
 		188D02B853162BF4533020E2 /* ChevronStabilityTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A42955D4178E97347B8C942A /* ChevronStabilityTests.swift */; };
 		18FEAA97EA576EC5276D2B28 /* HarnessPill.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0544FCFB9BC3E26FDB57CC96 /* HarnessPill.swift */; };
+		1901EE20123215C998400B25 /* ACPAdapterInstallCoordinatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE2F61CCAFB23F6C394ACD8D /* ACPAdapterInstallCoordinatorTests.swift */; };
 		190FA1E53291D6D94CC0086C /* SidebarHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8052B601A9C834365A9D880 /* SidebarHeaderView.swift */; };
 		195102F7D680452476D70329 /* GitLabCLIProviderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C371360F83FE318A5B8AEDBF /* GitLabCLIProviderTests.swift */; };
 		1A56FAF2DE8FFB95272EE948 /* ACPQuestionPromptTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 44ACE3DEC81C465524111058 /* ACPQuestionPromptTests.swift */; };
@@ -149,6 +150,7 @@
 		1F5AA7624BE0459338EE0EEC /* DragHandle.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7D398D06BDFFA5EDC24D3E6A /* DragHandle.swift */; };
 		1F84796DE0ABC832C0303B27 /* ACPSessionStoreDedupTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FADFC82400385AD76A200A2B /* ACPSessionStoreDedupTests.swift */; };
 		1F860C66D658B0DA5A0599F6 /* RemoteZmxInstaller.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B4239E76E57C63CD983437F /* RemoteZmxInstaller.swift */; };
+		1F867279ADAB2BAC843D3676 /* ACPRemoteAdapterManagementTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EAD81CB1D751F983C64191FF /* ACPRemoteAdapterManagementTests.swift */; };
 		1F89B774F2DC7DD818AD4E5B /* ACPSessionRunner.swift in Sources */ = {isa = PBXBuildFile; fileRef = F332906E17C5865856DBB90B /* ACPSessionRunner.swift */; };
 		20096441D4850614A3CB8187 /* ACPSessionStoreCRUDTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45D7C5464CA7B663A9A7BBFF /* ACPSessionStoreCRUDTests.swift */; };
 		208E237B41BA6F234151683D /* HTTPRequestParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = DAA7CD14A8FA2D335A59B062 /* HTTPRequestParser.swift */; };
@@ -183,6 +185,7 @@
 		2659BA65A6CABBE800A06AB3 /* tool-call-content-diff.json in Resources */ = {isa = PBXBuildFile; fileRef = 9A187BD52742E8F4A6E52667 /* tool-call-content-diff.json */; };
 		2661C51A093174D940CB5733 /* ProviderReviewActions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F9F77CC231E1131962F5A43 /* ProviderReviewActions.swift */; };
 		26F83C65E75B5F44024FEF1F /* ACPMentionPickerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E941397D0207F68135B3464D /* ACPMentionPickerTests.swift */; };
+		272EE1BE3B1A4A3BFA7B2703 /* ACPManagedAdapterDescriptor.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA89D4C70102BCF7B6B2450B /* ACPManagedAdapterDescriptor.swift */; };
 		2731B28802538E4FD7CBB0EA /* AgentDefinitionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FAC7D583D292BB6D72670F0A /* AgentDefinitionTests.swift */; };
 		2735F19DF0AD717CA3CF3B23 /* WorktreeServiceCreatedAtTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6BA2F208DBC024A64D0ED065 /* WorktreeServiceCreatedAtTests.swift */; };
 		279BAFE41DCB69286B64CFB9 /* AdapterUpdateState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F239EBD79AA346B7976B544 /* AdapterUpdateState.swift */; };
@@ -219,6 +222,7 @@
 		2E1D743806714BE4CD88A240 /* ContentSearcherTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C5E83B4DDF185280E01CA80A /* ContentSearcherTests.swift */; };
 		2E386BCE2DC24809A1B68244 /* ACPSessionPersistenceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0349ABD94031DE1BA929C8ED /* ACPSessionPersistenceTests.swift */; };
 		2E82C412B34A091035A7DB41 /* CommitMessageEditorView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D65BEFA85B6671FDE505A30D /* CommitMessageEditorView.swift */; };
+		2E8A92496DAE35CD1F2D05AA /* ACPAdapterTargetTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5BE3B261CC2B780A40B2EF4E /* ACPAdapterTargetTests.swift */; };
 		2E952C4C62784847AF4B7870 /* ZmxSessionName.swift in Sources */ = {isa = PBXBuildFile; fileRef = 89B23F35BE6FD53B74DD84ED /* ZmxSessionName.swift */; };
 		2EA0D9B6F711518ECBF14CF7 /* TabMergeConflictCodingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 14907D679267359B3FB8A848 /* TabMergeConflictCodingTests.swift */; };
 		2ED636DD3A179B95C061A9E6 /* InlineErrorStripTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A2345B9578E57D570FDB058B /* InlineErrorStripTests.swift */; };
@@ -297,6 +301,7 @@
 		3D711A767050DB05E4C77548 /* SurfaceViewKeyboardTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF5143046167375A802ED378 /* SurfaceViewKeyboardTests.swift */; };
 		3D98C4F5EE2C0B1203C76752 /* ACPImageChipAttachment.swift in Sources */ = {isa = PBXBuildFile; fileRef = A7FB37A9430467B477E40819 /* ACPImageChipAttachment.swift */; };
 		3DB85FF0D4965BF78AD2B010 /* MergeSidePane.swift in Sources */ = {isa = PBXBuildFile; fileRef = 52C55C85672956E1340B03B1 /* MergeSidePane.swift */; };
+		3DBBAB113CDB6FEEB01C588E /* ACPManagedAdapterDescriptorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB73E99357B77163006FA511 /* ACPManagedAdapterDescriptorTests.swift */; };
 		3DC03A7B9F9959155AE2B60E /* DiffReviewContextProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD6385E6DE02E97B0041616F /* DiffReviewContextProvider.swift */; };
 		3E0A4613EB8F41DA8C182C36 /* FormatOnSaveTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5BEBDB5A6617C62D0F1C0D1 /* FormatOnSaveTests.swift */; };
 		3E0AA46F17D152BFDA52A79D /* NotificationServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C2AEA30B7C74A39A46448AF5 /* NotificationServiceTests.swift */; };
@@ -511,6 +516,7 @@
 		6A6FC93066027CBC0406C41D /* RemoteHelperClientTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9D1D9C02088B9B4C15D88D57 /* RemoteHelperClientTests.swift */; };
 		6AA812880B9E28C4AE9A6BFC /* GitHubCLIProviderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8C28D64372B5B4C734A92533 /* GitHubCLIProviderTests.swift */; };
 		6AB631ACAD28A187F15282AB /* FileSnapshotTabView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D28AEE8E4821977FDAF13960 /* FileSnapshotTabView.swift */; };
+		6ABA4642C1AEB8502DCE5EA1 /* ACPRemoteNodeEnvironmentTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4EDBC153EAE419F270EFF948 /* ACPRemoteNodeEnvironmentTests.swift */; };
 		6AD85D472EF03EAE992D65D0 /* session-new-response.json in Resources */ = {isa = PBXBuildFile; fileRef = E7C070765F0474DF1C4ACEF0 /* session-new-response.json */; };
 		6AE129E340CA74CC26B34B66 /* ACPMarkdownLiveStyler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2AE565966DD010FDFD7DFF50 /* ACPMarkdownLiveStyler.swift */; };
 		6AE8EFD251D182A476F90E4B /* RemoteHostStatusStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 621C13FD3A997CCB29273993 /* RemoteHostStatusStoreTests.swift */; };
@@ -609,6 +615,7 @@
 		81214C5FDACA47C2FFC15E9E /* HoverWindowController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8149AEEF45B05C60E06888E5 /* HoverWindowController.swift */; };
 		814193F0CC55B784481AA40A /* InstallSourceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A27D815CB567E3FEF2D3E6B /* InstallSourceTests.swift */; };
 		8147BF86F2E77D81BE885B8F /* ChangedRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3E10A1919A8DDC6A8DBB8B97 /* ChangedRow.swift */; };
+		81D04C212B3AAA34F55069C5 /* ACPRemoteAdapterManagement.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC147F9FE645065318A7B175 /* ACPRemoteAdapterManagement.swift */; };
 		82124EF86A6964D12F3892D2 /* MonospaceFontCatalog.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0B2F41880B917155F7ADE622 /* MonospaceFontCatalog.swift */; };
 		823AA3E801A11C535C9438BD /* ACPPermissionScope.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4457B30E0C8A22BF06D0BC4B /* ACPPermissionScope.swift */; };
 		82544FFCF9960E0BA0FD2C7F /* ProcessMemoryProbeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9830BAAE86AA0A20A77731D /* ProcessMemoryProbeTests.swift */; };
@@ -788,6 +795,7 @@
 		A39D44E69D8BEF98C8934DF7 /* AppStateCLIRoutingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08F7B16F39935718801DAA95 /* AppStateCLIRoutingTests.swift */; };
 		A3EE2DE5C01EB87DE7BCC801 /* ACPStdioClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4D20C843AB88A6EB14D2A1BD /* ACPStdioClient.swift */; };
 		A3F27DE52BAC71EFFA69938A /* ACPTranscriptWindowTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7DCF803DF778CF9C06AC1579 /* ACPTranscriptWindowTests.swift */; };
+		A4332DDA952EEA92D137D10F /* ACPRemoteNodeEnvironment.swift in Sources */ = {isa = PBXBuildFile; fileRef = 567E1895FBD42067D10C8C5E /* ACPRemoteNodeEnvironment.swift */; };
 		A4476A509577896F9DADE5CB /* ACPSessionVisibleQueueTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EAA78FF7BA562DC4423AC35D /* ACPSessionVisibleQueueTests.swift */; };
 		A45A26B8B43E49BC8F952CD6 /* RemoteHostRegistryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1854EA4072F4F45DA70854D0 /* RemoteHostRegistryTests.swift */; };
 		A4AB930CA0EEA2CEF0302646 /* ImageCheckerboardBackground.swift in Sources */ = {isa = PBXBuildFile; fileRef = 206F1DBCB1C34D71BEBB7DE4 /* ImageCheckerboardBackground.swift */; };
@@ -905,6 +913,7 @@
 		BAE4D422FC3950E61FEE1D15 /* AppIntents.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = CA43AA9C8462D579E733B46C /* AppIntents.framework */; };
 		BAE6B1D93387807ADD7ED0CC /* ACPImageThumbnail.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5E1462C85D0E49127BCED81 /* ACPImageThumbnail.swift */; };
 		BB565B8EE9BA20EE961B32FB /* ThemeSidebarContrastTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B70ED4990428C46B69784970 /* ThemeSidebarContrastTests.swift */; };
+		BB924C35D21B87B46A47C5FA /* ACPAdapterTarget.swift in Sources */ = {isa = PBXBuildFile; fileRef = 818B29F6B58D4FFC80603AAD /* ACPAdapterTarget.swift */; };
 		BBACA7DCC1EFA6D55AEB38CE /* ACPMCPStatusControl.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1936C815E64C7DB204340469 /* ACPMCPStatusControl.swift */; };
 		BC0EC69E1BC62514BBE129E7 /* OpenSessionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEFCC9CAC7B3254708748815 /* OpenSessionsTests.swift */; };
 		BC19B95DAAC3943FF1BE5817 /* CommitTabView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 59DBB72EE97F0E906442919B /* CommitTabView.swift */; };
@@ -971,6 +980,7 @@
 		C82A2082E6E61069068B8FAB /* SQLiteStatement.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A442AC7909A919582DF4372 /* SQLiteStatement.swift */; };
 		C85FF0853DE69CE2EB59633E /* ACPRecoveryPill.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE35206EEBD7E3A35C3421EA /* ACPRecoveryPill.swift */; };
 		C893CA3167A5CC6637FCD8C8 /* light.json in Resources */ = {isa = PBXBuildFile; fileRef = 1688AB1B49758FAB5BF0AF2F /* light.json */; };
+		C8BF4593D35403A93FC05D50 /* ACPAdapterInstallCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 60C99F8D1A0A37DC4A6DBAEE /* ACPAdapterInstallCoordinator.swift */; };
 		C9004250BC974548165BE5B3 /* ACPSessionRecoveryIntegrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3E0616B1F0B84C45792C804E /* ACPSessionRecoveryIntegrationTests.swift */; };
 		C91AE8901B9D4B16A1EE67FB /* EditorBufferTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C6E896FEA37B4691BD16E2DD /* EditorBufferTests.swift */; };
 		C99FAC8BF1908B490E058FDA /* RemoteAccessPolicyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 53EEBEEB1AC6532031BDE17F /* RemoteAccessPolicyTests.swift */; };
@@ -1045,6 +1055,7 @@
 		D6A8D3925ACCB69DAC380B95 /* AgentPath.swift in Sources */ = {isa = PBXBuildFile; fileRef = B58DD85A6E01972B39F2D8AD /* AgentPath.swift */; };
 		D6B39CE8878BB196FF2277B6 /* AgentDefinition.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF2F716F911BB20B3E78C40B /* AgentDefinition.swift */; };
 		D6F28C27DB02285A62C969A4 /* ReleaseInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 35004DC60214F616FA84ED8B /* ReleaseInfo.swift */; };
+		D7201A9F55E26C033F188DE8 /* ACPRemoteAdapterInstallerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 28E0789D49881A17137010D0 /* ACPRemoteAdapterInstallerTests.swift */; };
 		D76AE9874386832FF4C89E6E /* initialize-request.json in Resources */ = {isa = PBXBuildFile; fileRef = 3253B229B757C725B7747249 /* initialize-request.json */; };
 		D7A0A35396E440B31711F9D9 /* RepoSelectorModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 822D37F962CC1C97981533A3 /* RepoSelectorModel.swift */; };
 		D7D45D387EEF0436834DF7AD /* ThemeStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 05EE713DD3CACF29F206553C /* ThemeStore.swift */; };
@@ -1436,6 +1447,7 @@
 		27EEC16C786CE9430C1AC174 /* DiffReviewFileSectionEqualityTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiffReviewFileSectionEqualityTests.swift; sourceTree = "<group>"; };
 		283613E170E25F69521F64ED /* DiffDisplaySignatureTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiffDisplaySignatureTests.swift; sourceTree = "<group>"; };
 		28777B087266D8AE174BA233 /* SpaceEmojiPickerSelectionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpaceEmojiPickerSelectionTests.swift; sourceTree = "<group>"; };
+		28E0789D49881A17137010D0 /* ACPRemoteAdapterInstallerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPRemoteAdapterInstallerTests.swift; sourceTree = "<group>"; };
 		292B5DA9EC17ED07588C48FD /* OpenCodeInstallerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OpenCodeInstallerTests.swift; sourceTree = "<group>"; };
 		29313DDC46A0CCA2FA42CDE9 /* Icon.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Icon.swift; sourceTree = "<group>"; };
 		2942AD875C0E7AB71E8E3CAD /* VerdictSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VerdictSheet.swift; sourceTree = "<group>"; };
@@ -1643,6 +1655,7 @@
 		4DC787CE0F5625F8114C9F6F /* MergeResultPane.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MergeResultPane.swift; sourceTree = "<group>"; };
 		4E340D23D2484C570F8E4B7F /* FakeJSONRPCTransport.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FakeJSONRPCTransport.swift; sourceTree = "<group>"; };
 		4EC688020FD7B6A2A4393B72 /* ReviewLoopHandoffBuilderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReviewLoopHandoffBuilderTests.swift; sourceTree = "<group>"; };
+		4EDBC153EAE419F270EFF948 /* ACPRemoteNodeEnvironmentTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPRemoteNodeEnvironmentTests.swift; sourceTree = "<group>"; };
 		4F5B91F414F99741818BCB17 /* ProjectsManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProjectsManagerTests.swift; sourceTree = "<group>"; };
 		4FB0C89AA6E07A2402934FD2 /* DraftCommitTabsManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DraftCommitTabsManagerTests.swift; sourceTree = "<group>"; };
 		4FE58EF9CF8EC461667D9430 /* AppConfig.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppConfig.swift; sourceTree = "<group>"; };
@@ -1678,6 +1691,7 @@
 		561094BA96058468F12002A1 /* ConflictsSection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConflictsSection.swift; sourceTree = "<group>"; };
 		563B664D082A9523260AA2EF /* RepoDot.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RepoDot.swift; sourceTree = "<group>"; };
 		56780EE994E2CA14A3ABBA7B /* MergeActionGutter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MergeActionGutter.swift; sourceTree = "<group>"; };
+		567E1895FBD42067D10C8C5E /* ACPRemoteNodeEnvironment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPRemoteNodeEnvironment.swift; sourceTree = "<group>"; };
 		56BF141F589820AA91674BD0 /* TreeSitterJavaScript */ = {isa = PBXFileReference; lastKnownFileType = folder; name = TreeSitterJavaScript; path = ThirdParty/TreeSitterJavaScript; sourceTree = SOURCE_ROOT; };
 		56C7878101DA7532B9850D13 /* ProjectIconView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProjectIconView.swift; sourceTree = "<group>"; };
 		56D1AC9E1E00C3C5C234382C /* TouchTargetSmokeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TouchTargetSmokeTests.swift; sourceTree = "<group>"; };
@@ -1705,6 +1719,7 @@
 		5B9583B34B9AAD4454C558E5 /* GitService+Pull.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "GitService+Pull.swift"; sourceTree = "<group>"; };
 		5BAC89A6B9D5DC926AC18E13 /* MergeConflictTabView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MergeConflictTabView.swift; sourceTree = "<group>"; };
 		5BB6172AE118D2F9A40FD534 /* AgentsPane.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentsPane.swift; sourceTree = "<group>"; };
+		5BE3B261CC2B780A40B2EF4E /* ACPAdapterTargetTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPAdapterTargetTests.swift; sourceTree = "<group>"; };
 		5C8BF1EC24E449A302A1E25C /* CopyFeedbackState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CopyFeedbackState.swift; sourceTree = "<group>"; };
 		5C96772DABFBCF15691FFB37 /* DiffDisplayPreferences.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiffDisplayPreferences.swift; sourceTree = "<group>"; };
 		5CC16D06302D9AD3C9F0BE3C /* TreeSitterHighlighter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TreeSitterHighlighter.swift; sourceTree = "<group>"; };
@@ -1725,6 +1740,7 @@
 		6033DBD8BF13A76978A653A3 /* EditorFindControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditorFindControllerTests.swift; sourceTree = "<group>"; };
 		6048519B4C444FCB46A11E49 /* ACPMessageStableIdTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPMessageStableIdTests.swift; sourceTree = "<group>"; };
 		606DD97D8F66AC2B5883F984 /* TerminalIntegrationActionsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TerminalIntegrationActionsTests.swift; sourceTree = "<group>"; };
+		60C99F8D1A0A37DC4A6DBAEE /* ACPAdapterInstallCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPAdapterInstallCoordinator.swift; sourceTree = "<group>"; };
 		60F628A45666E477DD695AD7 /* ShortcutRecorderValidationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShortcutRecorderValidationTests.swift; sourceTree = "<group>"; };
 		615B4D8618F0BDEAEB216942 /* DraftReviewRequestDiffSessionBuilder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DraftReviewRequestDiffSessionBuilder.swift; sourceTree = "<group>"; };
 		6181842BEA798CB8606F222B /* DiffDisplayModelBuilderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiffDisplayModelBuilderTests.swift; sourceTree = "<group>"; };
@@ -1872,6 +1888,7 @@
 		8149AEEF45B05C60E06888E5 /* HoverWindowController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HoverWindowController.swift; sourceTree = "<group>"; };
 		81773A01826A91080F5A2E95 /* ACPCodeBlockHighlighterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPCodeBlockHighlighterTests.swift; sourceTree = "<group>"; };
 		817DF0174BF04CF5DA288E99 /* ACPRemoteFileServer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPRemoteFileServer.swift; sourceTree = "<group>"; };
+		818B29F6B58D4FFC80603AAD /* ACPAdapterTarget.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPAdapterTarget.swift; sourceTree = "<group>"; };
 		81E981C10B13C43CE65DA74D /* ProjectMCPServer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProjectMCPServer.swift; sourceTree = "<group>"; };
 		822D37F962CC1C97981533A3 /* RepoSelectorModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RepoSelectorModel.swift; sourceTree = "<group>"; };
 		82387CFDFFBF52E639095C65 /* GitServiceBehindStatusTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GitServiceBehindStatusTests.swift; sourceTree = "<group>"; };
@@ -2119,6 +2136,7 @@
 		BAE3E5634CC9BA68765EA539 /* ANSIStream.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ANSIStream.swift; sourceTree = "<group>"; };
 		BB6A90FAE1D410744D02A454 /* CommitPromptEditorWindow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommitPromptEditorWindow.swift; sourceTree = "<group>"; };
 		BBBEFD27FD7013D458435779 /* ACPSession.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPSession.swift; sourceTree = "<group>"; };
+		BC147F9FE645065318A7B175 /* ACPRemoteAdapterManagement.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPRemoteAdapterManagement.swift; sourceTree = "<group>"; };
 		BC3CA543A17D1C3DFA70A80C /* DraftCommitTabView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DraftCommitTabView.swift; sourceTree = "<group>"; };
 		BCA505FF2E6CFA8278C95C6E /* GhosttyConfigBuilder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GhosttyConfigBuilder.swift; sourceTree = "<group>"; };
 		BCA9015C063CDD90D021D928 /* TreeSitterCSS */ = {isa = PBXFileReference; lastKnownFileType = folder; name = TreeSitterCSS; path = ThirdParty/TreeSitterCSS; sourceTree = SOURCE_ROOT; };
@@ -2287,6 +2305,7 @@
 		D9E6D61B213F3378243B4A26 /* AlasField.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlasField.swift; sourceTree = "<group>"; };
 		DA09B830D18CCEE251D0E10A /* EmptyTabViewTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EmptyTabViewTests.swift; sourceTree = "<group>"; };
 		DA5A64AEDC7F12F08DA8D2A5 /* RepoSelectorRow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RepoSelectorRow.swift; sourceTree = "<group>"; };
+		DA89D4C70102BCF7B6B2450B /* ACPManagedAdapterDescriptor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPManagedAdapterDescriptor.swift; sourceTree = "<group>"; };
 		DAA7CD14A8FA2D335A59B062 /* HTTPRequestParser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HTTPRequestParser.swift; sourceTree = "<group>"; };
 		DB5A2BDAA7ABD74C42BC51F8 /* CommitDetailsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommitDetailsTests.swift; sourceTree = "<group>"; };
 		DBA6A9F78C8E8CDF6D170BDD /* StatusParserTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StatusParserTests.swift; sourceTree = "<group>"; };
@@ -2299,6 +2318,7 @@
 		DD1F34E025D235A5CECCE36E /* ACPSessionUpdate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPSessionUpdate.swift; sourceTree = "<group>"; };
 		DDE8B45ECF898B83A616586D /* SubHeader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SubHeader.swift; sourceTree = "<group>"; };
 		DE2AC16E9220C05F670BE3EB /* ACPMarkdownText.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPMarkdownText.swift; sourceTree = "<group>"; };
+		DE2F61CCAFB23F6C394ACD8D /* ACPAdapterInstallCoordinatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPAdapterInstallCoordinatorTests.swift; sourceTree = "<group>"; };
 		DE74A483930F70A0C79CC3E8 /* CodeHostRemoteDetectorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CodeHostRemoteDetectorTests.swift; sourceTree = "<group>"; };
 		DE7675D7F75E36E9C81193C8 /* LSPMessagesTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LSPMessagesTests.swift; sourceTree = "<group>"; };
 		DEFCC9CAC7B3254708748815 /* OpenSessionsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OpenSessionsTests.swift; sourceTree = "<group>"; };
@@ -2360,6 +2380,7 @@
 		E941397D0207F68135B3464D /* ACPMentionPickerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPMentionPickerTests.swift; sourceTree = "<group>"; };
 		E98FAFF3AE36A17EE6AD029C /* EditorTabStateMarkdownCodableTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditorTabStateMarkdownCodableTests.swift; sourceTree = "<group>"; };
 		EAA78FF7BA562DC4423AC35D /* ACPSessionVisibleQueueTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPSessionVisibleQueueTests.swift; sourceTree = "<group>"; };
+		EAD81CB1D751F983C64191FF /* ACPRemoteAdapterManagementTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPRemoteAdapterManagementTests.swift; sourceTree = "<group>"; };
 		EB1E14CFAC880D31CE8FBE8F /* ChangesPane.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChangesPane.swift; sourceTree = "<group>"; };
 		EB44F87B415733A4B2F2A990 /* DraftCommitTabStateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DraftCommitTabStateTests.swift; sourceTree = "<group>"; };
 		EB52B59655B85764D85CFB7F /* LineEndingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LineEndingTests.swift; sourceTree = "<group>"; };
@@ -2438,6 +2459,7 @@
 		FB02326DBD7A82431A33C50F /* DraftAmendPrefillTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DraftAmendPrefillTests.swift; sourceTree = "<group>"; };
 		FB19F036D793E5DFBBD3C675 /* AgentHookSocketServerCLITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentHookSocketServerCLITests.swift; sourceTree = "<group>"; };
 		FB5B73ECBD730B5BB24E2240 /* ACPSessionManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPSessionManagerTests.swift; sourceTree = "<group>"; };
+		FB73E99357B77163006FA511 /* ACPManagedAdapterDescriptorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPManagedAdapterDescriptorTests.swift; sourceTree = "<group>"; };
 		FB9E78C70091168556C9669B /* ReviewChangesTabViewTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReviewChangesTabViewTests.swift; sourceTree = "<group>"; };
 		FBB8BF6C61840B9F972ABACC /* RemoteFileStats.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteFileStats.swift; sourceTree = "<group>"; };
 		FBC01971BF41E6D0B9B317CF /* CodeTextView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CodeTextView.swift; sourceTree = "<group>"; };
@@ -2589,13 +2611,16 @@
 		0A9B6A8C7372DB9E6C627A0E /* Adapter */ = {
 			isa = PBXGroup;
 			children = (
+				60C99F8D1A0A37DC4A6DBAEE /* ACPAdapterInstallCoordinator.swift */,
 				FFAFB40F5FACBC726C7E4172 /* ACPAdapterInstaller.swift */,
+				818B29F6B58D4FFC80603AAD /* ACPAdapterTarget.swift */,
 				3111744632DAC342A40DB62A /* ACPAdapterUpdateBannerDecider.swift */,
 				7DED8CE500F7170B1C0857FE /* ACPAdapterUpdateStore.swift */,
 				15630570F849AC577CA0D379 /* ACPAdapterVersionChecker.swift */,
 				2E669FEBE09BC250B477B335 /* ACPLaunchCatalog.swift */,
 				53C0EBA9F81668C89977770E /* ACPLaunchPathResolver.swift */,
 				8528D2A61E1FC9F51296C9F6 /* ACPLaunchSpec.swift */,
+				DA89D4C70102BCF7B6B2450B /* ACPManagedAdapterDescriptor.swift */,
 				FC8E722C16FFBEEEC43337D5 /* ACPSetupCheck.swift */,
 				3E9864A515B0ED49C68739B6 /* ACPSetupChecker.swift */,
 				3F239EBD79AA346B7976B544 /* AdapterUpdateState.swift */,
@@ -3631,9 +3656,11 @@
 			isa = PBXGroup;
 			children = (
 				D020BC9CC6586ECAB8A38042 /* ACPReconnectPolicy.swift */,
+				BC147F9FE645065318A7B175 /* ACPRemoteAdapterManagement.swift */,
 				817DF0174BF04CF5DA288E99 /* ACPRemoteFileServer.swift */,
 				B5DC5AC55D5FF5BF7FECAD2F /* ACPRemoteLaunch.swift */,
 				0CB5D1C8046EF9B6A95C41CD /* ACPRemoteMCPFilter.swift */,
+				567E1895FBD42067D10C8C5E /* ACPRemoteNodeEnvironment.swift */,
 				F83370751580C42D5DE93F80 /* GitInvocation.swift */,
 				43C24D126BC74FF514F19E5D /* RemoteContentSearch.swift */,
 				6DF3C93B3FB8B2FDDD8E859D /* RemoteExec.swift */,
@@ -4127,9 +4154,12 @@
 			isa = PBXGroup;
 			children = (
 				8C040E975A14DE31446BCEB7 /* ACPReconnectPolicyTests.swift */,
+				28E0789D49881A17137010D0 /* ACPRemoteAdapterInstallerTests.swift */,
+				EAD81CB1D751F983C64191FF /* ACPRemoteAdapterManagementTests.swift */,
 				D2BDAB5BEDF7FE5EBFBFE9A2 /* ACPRemoteFileServerTests.swift */,
 				8CA0EE530F852A921942B04C /* ACPRemoteLaunchTests.swift */,
 				09140CEE45083CFDCE8D262B /* ACPRemoteMCPFilterTests.swift */,
+				4EDBC153EAE419F270EFF948 /* ACPRemoteNodeEnvironmentTests.swift */,
 				CF798A386DD56B4127D5272A /* ACPTerminalCRLFTests.swift */,
 				03A4B0CD519C39CCB197CBD4 /* GitInvocationTests.swift */,
 				BD8249F7BF5F86B0AFD5CAB8 /* RemoteContentSearchTests.swift */,
@@ -4199,6 +4229,8 @@
 		C1CE17139DAF0E60FE9D92C2 /* Adapter */ = {
 			isa = PBXGroup;
 			children = (
+				DE2F61CCAFB23F6C394ACD8D /* ACPAdapterInstallCoordinatorTests.swift */,
+				5BE3B261CC2B780A40B2EF4E /* ACPAdapterTargetTests.swift */,
 				1F9B399B5355B20890D8E42C /* ACPAdapterUpdateBannerDeciderTests.swift */,
 				A1BC298112812E38C99E0B71 /* ACPAdapterUpdateStoreTests.swift */,
 				5EF6536F169B7C7B2C339B1C /* ACPAdapterVersionCheckerTests.swift */,
@@ -4207,6 +4239,7 @@
 				2D911D138AF8A0E99191C862 /* ACPLaunchPathResolverTests.swift */,
 				6BDB3231FFACC0398F973876 /* ACPLaunchSpecNpmPackageTests.swift */,
 				C3B53E3E92FA696866F44FDD /* ACPLaunchSpecTests.swift */,
+				FB73E99357B77163006FA511 /* ACPManagedAdapterDescriptorTests.swift */,
 				490AFAD12616D61858A19A31 /* ACPSetupCheckerTests.swift */,
 				4B2FAABB50C8BE2321A1B1DD /* ClaudeCodeACPInstallerTests.swift */,
 				A203964F9055BEF3F6142684 /* CodexACPInstallerTests.swift */,
@@ -4858,7 +4891,9 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				C8BF4593D35403A93FC05D50 /* ACPAdapterInstallCoordinator.swift in Sources */,
 				1E5EA96E9798649521CE1427 /* ACPAdapterInstaller.swift in Sources */,
+				BB924C35D21B87B46A47C5FA /* ACPAdapterTarget.swift in Sources */,
 				B0AECC4F3D22B2C863752CF8 /* ACPAdapterUpdateBannerDecider.swift in Sources */,
 				B140AFAD75EC181870BDC0D1 /* ACPAdapterUpdateStore.swift in Sources */,
 				C245B74D0083CE00B6CD392C /* ACPAdapterVersionChecker.swift in Sources */,
@@ -4906,6 +4941,7 @@
 				6294D44BE2DC7F96933F7C4B /* ACPMCPServer.swift in Sources */,
 				BBACA7DCC1EFA6D55AEB38CE /* ACPMCPStatusControl.swift in Sources */,
 				D0F370E528AA4D07814AEB15 /* ACPMCPStatusPolicy.swift in Sources */,
+				272EE1BE3B1A4A3BFA7B2703 /* ACPManagedAdapterDescriptor.swift in Sources */,
 				B1665774383C03F0C0765A43 /* ACPMarkdownBlockCache.swift in Sources */,
 				7ABF2BE84D6677FE5BCC8ED1 /* ACPMarkdownInlineRenderer.swift in Sources */,
 				88C1A4EBC12F7F7BA7FE9B06 /* ACPMarkdownInlineTextView.swift in Sources */,
@@ -4939,9 +4975,11 @@
 				518F761277C4C5E4E6C512A3 /* ACPQueuedBubble.swift in Sources */,
 				96BE44DEEDA6FDF72BD51173 /* ACPReconnectPolicy.swift in Sources */,
 				C85FF0853DE69CE2EB59633E /* ACPRecoveryPill.swift in Sources */,
+				81D04C212B3AAA34F55069C5 /* ACPRemoteAdapterManagement.swift in Sources */,
 				86B6F59A54E8A3029C8A1656 /* ACPRemoteFileServer.swift in Sources */,
 				99FA2F1F9D41CA81E59B20E5 /* ACPRemoteLaunch.swift in Sources */,
 				D02BB257817B709817CAB2B6 /* ACPRemoteMCPFilter.swift in Sources */,
+				A4332DDA952EEA92D137D10F /* ACPRemoteNodeEnvironment.swift in Sources */,
 				502B274A6E7E801B76B8564A /* ACPScrollDirectionClassifier.swift in Sources */,
 				900A70EF9D41AEF3953CABBB /* ACPSelectChip.swift in Sources */,
 				8BF52AFF90954B767B9D7E65 /* ACPSession.swift in Sources */,
@@ -5512,6 +5550,8 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				1901EE20123215C998400B25 /* ACPAdapterInstallCoordinatorTests.swift in Sources */,
+				2E8A92496DAE35CD1F2D05AA /* ACPAdapterTargetTests.swift in Sources */,
 				3CFC291E5868CCD147D573E7 /* ACPAdapterUpdateBannerDeciderTests.swift in Sources */,
 				BE7FA8E07C4A1FC48267C64D /* ACPAdapterUpdateStoreTests.swift in Sources */,
 				481DEBE64E91C54A81185D09 /* ACPAdapterVersionCheckerTests.swift in Sources */,
@@ -5553,6 +5593,7 @@
 				7433DB9396574A02DBF9953D /* ACPLaunchSpecTests.swift in Sources */,
 				BD0DE08853936F416EFD377C /* ACPMCPServerTests.swift in Sources */,
 				847356E199302CCFDA9172DA /* ACPMCPStatusPolicyTests.swift in Sources */,
+				3DBBAB113CDB6FEEB01C588E /* ACPManagedAdapterDescriptorTests.swift in Sources */,
 				965621529CB4BD82DD646B76 /* ACPManagerAccessorsTests.swift in Sources */,
 				21A94ADFA16F85C7ACAB4DA1 /* ACPMarkdownBlockCacheTests.swift in Sources */,
 				BDA40E9BFA15217CDED5B2F0 /* ACPMarkdownInlineRendererTests.swift in Sources */,
@@ -5575,9 +5616,12 @@
 				1A56FAF2DE8FFB95272EE948 /* ACPQuestionPromptTests.swift in Sources */,
 				23F92214B30096D070419921 /* ACPQueuedBubbleActionMetricsTests.swift in Sources */,
 				C7658D1AF7744BB694D2388A /* ACPReconnectPolicyTests.swift in Sources */,
+				D7201A9F55E26C033F188DE8 /* ACPRemoteAdapterInstallerTests.swift in Sources */,
+				1F867279ADAB2BAC843D3676 /* ACPRemoteAdapterManagementTests.swift in Sources */,
 				018F0BE1174B9020C52007BE /* ACPRemoteFileServerTests.swift in Sources */,
 				F35B489DCC169F2B77DB6F3F /* ACPRemoteLaunchTests.swift in Sources */,
 				5E22B20F69866FAEDABA2812 /* ACPRemoteMCPFilterTests.swift in Sources */,
+				6ABA4642C1AEB8502DCE5EA1 /* ACPRemoteNodeEnvironmentTests.swift in Sources */,
 				A383F1C9B0B00B2805576209 /* ACPScrollDirectionClassifierTests.swift in Sources */,
 				F57297D50FC237F7993F7B81 /* ACPSelectChipMetricsTests.swift in Sources */,
 				702EC5CB48F37FC8B6F27FA4 /* ACPSelectChipTests.swift in Sources */,

--- a/Alas/Sources/ACP/Adapter/ACPAdapterInstallCoordinator.swift
+++ b/Alas/Sources/ACP/Adapter/ACPAdapterInstallCoordinator.swift
@@ -1,0 +1,50 @@
+import Foundation
+
+actor ACPAdapterInstallCoordinator {
+    typealias LocalInstall = @Sendable (_ agentID: String) async throws -> Void
+    typealias RemoteInstall = @Sendable (
+        _ host: String,
+        _ descriptor: ACPManagedAdapterDescriptor
+    ) async throws -> Void
+
+    private let localInstall: LocalInstall
+    private let remoteInstall: RemoteInstall
+    private var inFlight: [ACPAdapterUpdateKey: Task<Void, Error>] = [:]
+
+    init(
+        localInstall: @escaping LocalInstall = { agentID in
+            try await ACPInstallerRegistry.install(agentID: agentID)
+        },
+        remoteInstall: @escaping RemoteInstall = { host, descriptor in
+            try await ACPRemoteAdapterManagement().install(host: host, descriptor: descriptor)
+        }
+    ) {
+        self.localInstall = localInstall
+        self.remoteInstall = remoteInstall
+    }
+
+    func install(target: ACPAdapterTarget, agentID: String) async throws {
+        let key = ACPAdapterUpdateKey(target: target, agentID: agentID)
+        if let task = inFlight[key] {
+            return try await task.value
+        }
+
+        let task: Task<Void, Error>
+        switch target {
+        case .local:
+            task = Task { try await localInstall(agentID) }
+        case .ssh(let host):
+            guard let descriptor = ACPManagedAdapterDescriptor.descriptor(for: agentID) else {
+                throw ACPRemoteAdapterInstallError.unsupportedAgent(agentID)
+            }
+            task = Task { try await remoteInstall(host, descriptor) }
+        }
+        inFlight[key] = task
+        defer { inFlight[key] = nil }
+        try await task.value
+    }
+
+    func isInstalling(target: ACPAdapterTarget, agentID: String) -> Bool {
+        inFlight[ACPAdapterUpdateKey(target: target, agentID: agentID)] != nil
+    }
+}

--- a/Alas/Sources/ACP/Adapter/ACPAdapterInstaller.swift
+++ b/Alas/Sources/ACP/Adapter/ACPAdapterInstaller.swift
@@ -7,9 +7,11 @@ protocol ACPAdapterInstaller {
 }
 
 enum ACPInstallError: LocalizedError {
+    case unsupportedAgent(String)
     case nonZeroExit(Int32, stderr: String)
     var errorDescription: String? {
         switch self {
+        case .unsupportedAgent(let agentID): return "No ACP adapter installer is available for \(agentID)."
         case .nonZeroExit(let code, let stderr): return "install failed (exit \(code)): \(stderr)"
         }
     }
@@ -52,5 +54,12 @@ enum ACPInstallerRegistry {
         case "pi":     return PiACPInstaller()
         default: return nil
         }
+    }
+
+    static func install(agentID: String) async throws {
+        guard let installer = installer(for: agentID) else {
+            throw ACPInstallError.unsupportedAgent(agentID)
+        }
+        try await installer.install()
     }
 }

--- a/Alas/Sources/ACP/Adapter/ACPAdapterTarget.swift
+++ b/Alas/Sources/ACP/Adapter/ACPAdapterTarget.swift
@@ -1,0 +1,26 @@
+import Foundation
+
+/// Identifies the machine that owns an ACP adapter installation.
+enum ACPAdapterTarget: Hashable, Sendable {
+    case local
+    case ssh(host: String)
+}
+
+/// Stable identity for update state belonging to one adapter on one target.
+struct ACPAdapterUpdateKey: Hashable, Sendable {
+    let target: ACPAdapterTarget
+    let agentID: String
+
+    var storageKey: String {
+        switch target {
+        case .local:
+            "v2|local|\(Self.field(agentID))"
+        case .ssh(let host):
+            "v2|ssh|\(Self.field(host))|\(Self.field(agentID))"
+        }
+    }
+
+    private static func field(_ value: String) -> String {
+        "\(value.utf8.count):\(value)"
+    }
+}

--- a/Alas/Sources/ACP/Adapter/ACPAdapterUpdateStore.swift
+++ b/Alas/Sources/ACP/Adapter/ACPAdapterUpdateStore.swift
@@ -1,12 +1,12 @@
 import Foundation
 
-/// Per-`agentID` store for ACP adapter update checks.
+/// Per-target, per-`agentID` store for ACP adapter update checks.
 ///
 /// Owns three things:
 ///   1. TTL-cached results of the last version check (success = 24h, failure = 30m).
-///   2. Per-agent dismissal of a specific `latest` version (banner stays hidden
+///   2. Per-target dismissal of a specific `latest` version (banner stays hidden
 ///      until npm publishes something newer than the dismissed version).
-///   3. Coalescing of concurrent in-flight version checks per `agentID`.
+///   3. Coalescing of concurrent in-flight version checks per target and `agentID`.
 ///
 /// Backed by a small JSON file under Application Support.
 actor ACPAdapterUpdateStore {
@@ -44,40 +44,43 @@ actor ACPAdapterUpdateStore {
 
     // MARK: - Public API
 
-    func read(agentID: String) -> AdapterUpdateState? {
+    func read(key: ACPAdapterUpdateKey) -> AdapterUpdateState? {
         loadIfNeeded()
-        guard let entry = entries[agentID] else { return nil }
+        guard let entry = entry(for: key) else { return nil }
         let ttl: TimeInterval = (entry.state == .unknown) ? failureTTL : successTTL
         if now().timeIntervalSince(entry.checkedAt) > ttl { return nil }
         return entry.state
     }
 
-    func write(agentID: String, state: AdapterUpdateState) {
+    func write(key: ACPAdapterUpdateKey, state: AdapterUpdateState) {
         loadIfNeeded()
         let timestamp = now()
-        var entry = entries[agentID] ?? Entry(checkedAt: timestamp, state: state, dismissedLatest: nil)
+        var entry = entry(for: key) ?? Entry(checkedAt: timestamp, state: state, dismissedLatest: nil)
         entry.checkedAt = timestamp
         entry.state = state
-        entries[agentID] = entry
+        entries[key.storageKey] = entry
         persist()
     }
 
-    func dismiss(agentID: String, latest: String) {
+    func dismiss(key: ACPAdapterUpdateKey, latest: String) {
         loadIfNeeded()
-        var entry = entries[agentID] ?? Entry(checkedAt: now(), state: .unknown, dismissedLatest: nil)
+        var entry = entry(for: key) ?? Entry(checkedAt: now(), state: .unknown, dismissedLatest: nil)
         entry.dismissedLatest = latest
-        entries[agentID] = entry
+        entries[key.storageKey] = entry
         persist()
     }
 
-    func isDismissed(agentID: String, latest: String) -> Bool {
+    func isDismissed(key: ACPAdapterUpdateKey, latest: String) -> Bool {
         loadIfNeeded()
-        return entries[agentID]?.dismissedLatest == latest
+        return entry(for: key)?.dismissedLatest == latest
     }
 
-    func clear(agentID: String) {
+    func clear(key: ACPAdapterUpdateKey) {
         loadIfNeeded()
-        entries.removeValue(forKey: agentID)
+        entries.removeValue(forKey: key.storageKey)
+        if key.target == .local {
+            entries.removeValue(forKey: key.agentID)
+        }
         persist()
     }
 
@@ -85,20 +88,52 @@ actor ACPAdapterUpdateStore {
     /// the result, and returns it. Concurrent callers for the same
     /// `agentID` share one in-flight task.
     func checkOrCompute(
-        agentID: String,
+        key: ACPAdapterUpdateKey,
         compute: @Sendable @escaping () async -> AdapterUpdateState
     ) async -> AdapterUpdateState {
-        if let cached = read(agentID: agentID) { return cached }
-        if let existing = inFlight[agentID] { return await existing.value }
+        if let cached = read(key: key) { return cached }
+        let storageKey = key.storageKey
+        if let existing = inFlight[storageKey] { return await existing.value }
 
         let task = Task { @Sendable in await compute() }
-        inFlight[agentID] = task
+        inFlight[storageKey] = task
         let result = await task.value
         // removeValue and write run in one synchronous actor turn — no suspension between them,
         // so a third caller cannot observe a state where inFlight is empty and the cache is stale.
-        inFlight.removeValue(forKey: agentID)
-        write(agentID: agentID, state: result)
+        inFlight.removeValue(forKey: storageKey)
+        write(key: key, state: result)
         return result
+    }
+
+    // Local-only overloads preserve existing call sites while target-aware
+    // routing is introduced incrementally.
+    func read(agentID: String) -> AdapterUpdateState? {
+        read(key: .init(target: .local, agentID: agentID))
+    }
+
+    func write(agentID: String, state: AdapterUpdateState) {
+        write(key: .init(target: .local, agentID: agentID), state: state)
+    }
+
+    func dismiss(agentID: String, latest: String) {
+        dismiss(key: .init(target: .local, agentID: agentID), latest: latest)
+    }
+
+    func isDismissed(agentID: String, latest: String) -> Bool {
+        isDismissed(key: .init(target: .local, agentID: agentID), latest: latest)
+    }
+
+    func clear(agentID: String) {
+        clear(key: .init(target: .local, agentID: agentID))
+    }
+
+    func checkOrCompute(
+        agentID: String,
+        compute: @Sendable @escaping () async -> AdapterUpdateState
+    ) async -> AdapterUpdateState {
+        await checkOrCompute(
+            key: .init(target: .local, agentID: agentID),
+            compute: compute)
     }
 
     // MARK: - Persistence
@@ -110,6 +145,14 @@ actor ACPAdapterUpdateStore {
               let shape = try? JSONDecoder.iso8601.decode(DiskShape.self, from: data)
         else { return }
         entries = shape.entries
+    }
+
+    private func entry(for key: ACPAdapterUpdateKey) -> Entry? {
+        if let current = entries[key.storageKey] {
+            return current
+        }
+        guard key.target == .local else { return nil }
+        return entries[key.agentID]
     }
 
     private func persist() {

--- a/Alas/Sources/ACP/Adapter/ACPAdapterVersionChecker.swift
+++ b/Alas/Sources/ACP/Adapter/ACPAdapterVersionChecker.swift
@@ -2,13 +2,42 @@ import Foundation
 
 struct ACPAdapterVersionChecker: Sendable {
     typealias Runner = @Sendable (_ command: String, _ args: [String]) async throws -> (status: Int32, stdout: String)
+    typealias RemoteRunner = @Sendable (
+        _ host: String,
+        _ cwd: String?,
+        _ command: String,
+        _ pathPolicy: SSHCommand.PathPolicy
+    ) async throws -> ProcessResult
+    typealias NodeResolver = @Sendable (_ host: String) async throws -> ACPRemoteNodeEnvironment
+
+    static let managedSourceExitCode: Int32 = 0
+    static let globalSourceExitCode: Int32 = 40
+    static let malformedSourceExitCode: Int32 = 41
 
     let timeout: TimeInterval
     let runner: Runner
+    let remoteRunner: RemoteRunner
+    let nodeResolver: NodeResolver
 
-    init(timeout: TimeInterval = 5, runner: @escaping Runner = ACPAdapterVersionChecker.defaultRunner) {
+    init(
+        timeout: TimeInterval = 5,
+        runner: @escaping Runner = ACPAdapterVersionChecker.defaultRunner,
+        remoteRunner: @escaping RemoteRunner = { host, cwd, command, pathPolicy in
+            try await RemoteExec.run(
+                host: host,
+                cwd: cwd,
+                command: command,
+                pathPolicy: pathPolicy
+            )
+        },
+        nodeResolver: @escaping NodeResolver = { host in
+            try await ACPRemoteNodeEnvironmentResolver().resolve(host: host)
+        }
+    ) {
         self.timeout = timeout
         self.runner = runner
+        self.remoteRunner = remoteRunner
+        self.nodeResolver = nodeResolver
     }
 
     func check(packageName: String) async -> AdapterUpdateState {
@@ -22,6 +51,101 @@ struct ACPAdapterVersionChecker: Sendable {
         }
         guard let r = result else { return .unknown }
         return Self.parse(packageName: packageName, status: r.status, stdout: r.stdout)
+    }
+
+    func check(host: String, descriptor: ACPManagedAdapterDescriptor) async -> AdapterUpdateState {
+        let environment: ACPRemoteNodeEnvironment
+        do {
+            environment = try await nodeResolver(host)
+        } catch {
+            return .unknown
+        }
+
+        let sourceResult: ProcessResult
+        do {
+            sourceResult = try await remoteRunner(
+                host,
+                nil,
+                Self.remoteSourceProbeCommand(descriptor: descriptor),
+                .inherited
+            )
+        } catch {
+            return .unknown
+        }
+        guard !RemoteExec.isConnectionFailure(exitCode: sourceResult.exitCode) else {
+            return .unknown
+        }
+
+        let command: String
+        switch sourceResult.exitCode {
+        case Self.managedSourceExitCode:
+            command = Self.remoteManagedCheckCommand(
+                descriptor: descriptor,
+                environment: environment
+            )
+        case Self.globalSourceExitCode:
+            command = Self.remoteGlobalCheckCommand(
+                descriptor: descriptor,
+                environment: environment
+            )
+        default:
+            return .unknown
+        }
+
+        let result: ProcessResult
+        do {
+            result = try await remoteRunner(host, nil, command, .inherited)
+        } catch {
+            return .unknown
+        }
+        guard !RemoteExec.isConnectionFailure(exitCode: result.exitCode) else {
+            return .unknown
+        }
+        return Self.parse(
+            packageName: descriptor.packageName,
+            status: result.exitCode,
+            stdout: result.stdout
+        )
+    }
+
+    static func remoteSourceProbeCommand(descriptor: ACPManagedAdapterDescriptor) -> String {
+        let prefix = ACPRemoteAdapterManagement.managedPrefix(for: descriptor)
+        return """
+        prefix=\(prefix)
+        package=\(SSHCommand.shellQuote(descriptor.packageName))
+        candidate="$prefix/lib/node_modules/$package"
+        if [ -d "$candidate" ]; then
+            exit \(managedSourceExitCode)
+        fi
+        if [ -e "$candidate" ] || [ -L "$candidate" ]; then
+            exit \(malformedSourceExitCode)
+        fi
+        exit \(globalSourceExitCode)
+        """
+    }
+
+    static func remoteManagedCheckCommand(
+        descriptor: ACPManagedAdapterDescriptor,
+        environment: ACPRemoteNodeEnvironment
+    ) -> String {
+        let prefix = ACPRemoteAdapterManagement.managedPrefix(for: descriptor)
+        return """
+        PATH=\(SSHCommand.shellQuote(environment.binDirectory)):"$PATH"
+        export PATH
+        prefix=\(prefix)
+        \(SSHCommand.shellQuote(environment.npmPath)) outdated -g \(SSHCommand.shellQuote(descriptor.packageName)) --json --prefix "$prefix"
+        """
+    }
+
+    static func remoteGlobalCheckCommand(
+        descriptor: ACPManagedAdapterDescriptor,
+        environment: ACPRemoteNodeEnvironment
+    ) -> String {
+        """
+        PATH=\(SSHCommand.shellQuote(environment.binDirectory)):"$PATH"
+        export PATH
+        \(SSHCommand.shellQuote(environment.npmPath)) outdated -g \(SSHCommand.shellQuote(descriptor.packageName)) --json
+        """
     }
 
     /// Pure parser exposed for tests and reuse.

--- a/Alas/Sources/ACP/Adapter/ACPLaunchCatalog.swift
+++ b/Alas/Sources/ACP/Adapter/ACPLaunchCatalog.swift
@@ -9,13 +9,13 @@ enum ACPLaunchCatalog {
         // claude-agent-sdk and so advertises opus-4-7 / sonnet-4-6 /
         // haiku-4-6). The binary on PATH is `claude-agent-acp`.
         ACPLaunchSpec(
-            agentID: "claude",
-            command: "claude-agent-acp",
+            agentID: ACPManagedAdapterDescriptor.claude.agentID,
+            command: ACPManagedAdapterDescriptor.claude.binaryName,
             arguments: [],
             extraEnv: [:],
             setupCheck: .binaryOnPathOrNpmPackage(
-                binary: "claude-agent-acp",
-                npmPackage: "@agentclientprotocol/claude-agent-acp"),
+                binary: ACPManagedAdapterDescriptor.claude.binaryName,
+                npmPackage: ACPManagedAdapterDescriptor.claude.packageName),
             supportsModelSelection: true,
             supportsModeSelection: true),
 
@@ -65,11 +65,11 @@ enum ACPLaunchCatalog {
         // (The claude rename above didn't need this — its binary name changed.)
         // Requires OPENAI_API_KEY or CODEX_API_KEY in the environment.
         ACPLaunchSpec(
-            agentID: "codex",
-            command: "codex-acp",
+            agentID: ACPManagedAdapterDescriptor.codex.agentID,
+            command: ACPManagedAdapterDescriptor.codex.binaryName,
             arguments: [],
             extraEnv: [:],
-            setupCheck: .npxPackage(name: "@agentclientprotocol/codex-acp"),
+            setupCheck: .npxPackage(name: ACPManagedAdapterDescriptor.codex.packageName),
             supportsModelSelection: false,
             supportsModeSelection: false),
 
@@ -90,13 +90,13 @@ enum ACPLaunchCatalog {
         // to ACP over stdio. Internally spawns `pi --mode rpc`.
         // First-time auth via `pi-acp --terminal-login`.
         ACPLaunchSpec(
-            agentID: "pi",
-            command: "pi-acp",
+            agentID: ACPManagedAdapterDescriptor.pi.agentID,
+            command: ACPManagedAdapterDescriptor.pi.binaryName,
             arguments: [],
             extraEnv: [:],
             setupCheck: .binaryOnPathOrNpmPackage(
-                binary: "pi-acp",
-                npmPackage: "pi-acp"),
+                binary: ACPManagedAdapterDescriptor.pi.binaryName,
+                npmPackage: ACPManagedAdapterDescriptor.pi.packageName),
             supportsModelSelection: false,
             supportsModeSelection: false),
     ]

--- a/Alas/Sources/ACP/Adapter/ACPLaunchSpec.swift
+++ b/Alas/Sources/ACP/Adapter/ACPLaunchSpec.swift
@@ -8,6 +8,27 @@ struct ACPLaunchSpec: Equatable {
     let setupCheck: ACPSetupCheck
     let supportsModelSelection: Bool
     let supportsModeSelection: Bool
+    let remoteNodeBinDirectory: String?
+
+    init(
+        agentID: String,
+        command: String,
+        arguments: [String],
+        extraEnv: [String: String],
+        setupCheck: ACPSetupCheck,
+        supportsModelSelection: Bool,
+        supportsModeSelection: Bool,
+        remoteNodeBinDirectory: String? = nil
+    ) {
+        self.agentID = agentID
+        self.command = command
+        self.arguments = arguments
+        self.extraEnv = extraEnv
+        self.setupCheck = setupCheck
+        self.supportsModelSelection = supportsModelSelection
+        self.supportsModeSelection = supportsModeSelection
+        self.remoteNodeBinDirectory = remoteNodeBinDirectory
+    }
 
     /// The npm package that installs/updates this adapter, when the setup
     /// check exposes one. Binary-only adapters (gemini, opencode,
@@ -23,7 +44,10 @@ struct ACPLaunchSpec: Equatable {
     /// A copy of this spec with `command` replaced and all other fields
     /// unchanged. Used to launch a resolved absolute path through the
     /// launcher's existing absolute-path branch.
-    func overridingCommand(_ command: String) -> ACPLaunchSpec {
+    func overridingCommand(
+        _ command: String,
+        remoteNodeBinDirectory: String? = nil
+    ) -> ACPLaunchSpec {
         ACPLaunchSpec(
             agentID: agentID,
             command: command,
@@ -31,6 +55,7 @@ struct ACPLaunchSpec: Equatable {
             extraEnv: extraEnv,
             setupCheck: setupCheck,
             supportsModelSelection: supportsModelSelection,
-            supportsModeSelection: supportsModeSelection)
+            supportsModeSelection: supportsModeSelection,
+            remoteNodeBinDirectory: remoteNodeBinDirectory)
     }
 }

--- a/Alas/Sources/ACP/Adapter/ACPManagedAdapterDescriptor.swift
+++ b/Alas/Sources/ACP/Adapter/ACPManagedAdapterDescriptor.swift
@@ -1,0 +1,38 @@
+import Foundation
+
+struct ACPManagedAdapterDescriptor: Equatable, Sendable {
+    let agentID: String
+    let packageName: String
+    let binaryName: String
+    let legacyPackageNames: [String]
+
+    static let claude = ACPManagedAdapterDescriptor(
+        agentID: "claude",
+        packageName: "@agentclientprotocol/claude-agent-acp",
+        binaryName: "claude-agent-acp",
+        legacyPackageNames: ["@zed-industries/claude-code-acp"]
+    )
+
+    static let codex = ACPManagedAdapterDescriptor(
+        agentID: "codex",
+        packageName: "@agentclientprotocol/codex-acp",
+        binaryName: "codex-acp",
+        legacyPackageNames: ["@zed-industries/codex-acp"]
+    )
+
+    static let pi = ACPManagedAdapterDescriptor(
+        agentID: "pi",
+        packageName: "pi-acp",
+        binaryName: "pi-acp",
+        legacyPackageNames: []
+    )
+
+    static func descriptor(for agentID: String) -> ACPManagedAdapterDescriptor? {
+        switch agentID {
+        case claude.agentID: claude
+        case codex.agentID: codex
+        case pi.agentID: pi
+        default: nil
+        }
+    }
+}

--- a/Alas/Sources/ACP/Adapter/ClaudeCodeACPInstaller.swift
+++ b/Alas/Sources/ACP/Adapter/ClaudeCodeACPInstaller.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 struct ClaudeCodeACPInstaller: ACPAdapterInstaller {
-    let agentID = "claude"
+    let agentID = ACPManagedAdapterDescriptor.claude.agentID
     let runner: (_ command: String, _ args: [String]) async throws -> (status: Int32, stderr: String)
 
     init(runner: @escaping (String, [String]) async throws -> (status: Int32, stderr: String) = ClaudeCodeACPInstaller.defaultRunner) {
@@ -11,12 +11,13 @@ struct ClaudeCodeACPInstaller: ACPAdapterInstaller {
     func installState() async -> ACPSetupResult {
         await ACPSetupChecker(env: ProcessInfo.processInfo.environment)
             .evaluate(.binaryOnPathOrNpmPackage(
-                binary: "claude-agent-acp",
-                npmPackage: "@agentclientprotocol/claude-agent-acp"))
+                binary: ACPManagedAdapterDescriptor.claude.binaryName,
+                npmPackage: ACPManagedAdapterDescriptor.claude.packageName))
     }
 
     func install() async throws {
-        let (status, stderr) = try await runner("npm", ["install", "-g", "@agentclientprotocol/claude-agent-acp"])
+        let (status, stderr) = try await runner(
+            "npm", ["install", "-g", ACPManagedAdapterDescriptor.claude.packageName])
         if status != 0 { throw ACPInstallError.nonZeroExit(status, stderr: stderr) }
     }
 

--- a/Alas/Sources/ACP/Adapter/CodexACPInstaller.swift
+++ b/Alas/Sources/ACP/Adapter/CodexACPInstaller.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 struct CodexACPInstaller: ACPAdapterInstaller {
-    let agentID = "codex"
+    let agentID = ACPManagedAdapterDescriptor.codex.agentID
     let runner: (_ command: String, _ args: [String]) async throws -> (status: Int32, stderr: String)
 
     init(runner: @escaping (String, [String]) async throws -> (status: Int32, stderr: String) = ClaudeCodeACPInstaller.defaultRunner) {
@@ -10,7 +10,7 @@ struct CodexACPInstaller: ACPAdapterInstaller {
 
     func installState() async -> ACPSetupResult {
         await ACPSetupChecker(env: ProcessInfo.processInfo.environment)
-            .evaluate(.npxPackage(name: "@agentclientprotocol/codex-acp"))
+            .evaluate(.npxPackage(name: ACPManagedAdapterDescriptor.codex.packageName))
     }
 
     func install() async throws {
@@ -18,8 +18,11 @@ struct CodexACPInstaller: ACPAdapterInstaller {
         // `codex-acp` bin; npm (v7+) refuses to clobber another package's bin
         // and fails with EEXIST. Remove the old package first — best-effort,
         // since it may not be present — then install the active fork.
-        _ = try? await runner("npm", ["uninstall", "-g", "@zed-industries/codex-acp"])
-        let (status, stderr) = try await runner("npm", ["install", "-g", "@agentclientprotocol/codex-acp"])
+        for packageName in ACPManagedAdapterDescriptor.codex.legacyPackageNames {
+            _ = try? await runner("npm", ["uninstall", "-g", packageName])
+        }
+        let (status, stderr) = try await runner(
+            "npm", ["install", "-g", ACPManagedAdapterDescriptor.codex.packageName])
         if status != 0 { throw ACPInstallError.nonZeroExit(status, stderr: stderr) }
     }
 }

--- a/Alas/Sources/ACP/Adapter/PiACPInstaller.swift
+++ b/Alas/Sources/ACP/Adapter/PiACPInstaller.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 struct PiACPInstaller: ACPAdapterInstaller {
-    let agentID = "pi"
+    let agentID = ACPManagedAdapterDescriptor.pi.agentID
     let runner: (_ command: String, _ args: [String]) async throws -> (status: Int32, stderr: String)
 
     init(runner: @escaping (String, [String]) async throws -> (status: Int32, stderr: String) = ClaudeCodeACPInstaller.defaultRunner) {
@@ -11,12 +11,13 @@ struct PiACPInstaller: ACPAdapterInstaller {
     func installState() async -> ACPSetupResult {
         await ACPSetupChecker(env: ProcessInfo.processInfo.environment)
             .evaluate(.binaryOnPathOrNpmPackage(
-                binary: "pi-acp",
-                npmPackage: "pi-acp"))
+                binary: ACPManagedAdapterDescriptor.pi.binaryName,
+                npmPackage: ACPManagedAdapterDescriptor.pi.packageName))
     }
 
     func install() async throws {
-        let (status, stderr) = try await runner("npm", ["install", "-g", "pi-acp"])
+        let (status, stderr) = try await runner(
+            "npm", ["install", "-g", ACPManagedAdapterDescriptor.pi.packageName])
         if status != 0 { throw ACPInstallError.nonZeroExit(status, stderr: stderr) }
     }
 }

--- a/Alas/Sources/ACP/Session/ACPSessionManager.swift
+++ b/Alas/Sources/ACP/Session/ACPSessionManager.swift
@@ -17,6 +17,11 @@ private enum ACPMirrorRefreshPolicy {
 @MainActor
 final class ACPSessionManager: ObservableObject {
     typealias ACPSetupEvaluator = @MainActor (_ spec: ACPLaunchSpec) async -> ACPSetupResult
+    typealias ACPRemoteAdapterResolver = @MainActor (
+        _ host: String,
+        _ descriptor: ACPManagedAdapterDescriptor,
+        _ setupCheck: ACPSetupCheck
+    ) async -> ACPRemoteAdapterResolution
     typealias ACPConnectionFactory = @MainActor (
         _ spec: ACPLaunchSpec,
         _ host: String?,
@@ -219,7 +224,9 @@ final class ACPSessionManager: ObservableObject {
     private var draftFlushHandoffs: [ACPSession.ID: DraftFlushHandoff] = [:]
     private static let draftDebounceNanos: UInt64 = 300_000_000
     private let setupEvaluator: ACPSetupEvaluator
+    private let remoteAdapterResolver: ACPRemoteAdapterResolver
     private let connectionFactory: ACPConnectionFactory
+    private var resolvedRemoteAdapters: [String: ACPResolvedRemoteAdapter] = [:]
     private var inFlightHydrations: [ACPSession.ID: Task<Void, Never>] = [:]
     /// Per-session task that prepends pre-tail messages after the initial
     /// tail-only paint applied by `applyHydration`. Tracked so tests (and
@@ -278,6 +285,7 @@ final class ACPSessionManager: ObservableObject {
          onInputAwaiting: ((ACPSession, ACPUserInputRequest) -> Void)? = nil,
          changeNotifier: ACPChangeNotifier? = nil,
          setupEvaluator: ACPSetupEvaluator? = nil,
+         remoteAdapterResolver: ACPRemoteAdapterResolver? = nil,
          connectionFactory: ACPConnectionFactory? = nil,
          mcpProjectContextProvider: MCPProjectContextProvider? = nil)
     {
@@ -299,6 +307,13 @@ final class ACPSessionManager: ObservableObject {
             let checker = ACPSetupChecker(env: ProcessInfo.processInfo.environment)
             return await checker.evaluate(spec.setupCheck)
         }
+        self.remoteAdapterResolver = remoteAdapterResolver ?? { host, descriptor, setupCheck in
+            await ACPRemoteAdapterManagement().resolve(
+                host: host,
+                descriptor: descriptor,
+                setupCheck: setupCheck
+            )
+        }
         self.connectionFactory = connectionFactory ?? { spec, host, worktreePath in
             let client: ACPStdioClient
             if let host {
@@ -306,7 +321,8 @@ final class ACPSessionManager: ObservableObject {
                     host: host,
                     worktreePath: worktreePath,
                     command: spec.command,
-                    arguments: spec.arguments
+                    arguments: spec.arguments,
+                    nodeBinDirectory: spec.remoteNodeBinDirectory
                 )
                 // Keep ssh's parent environment intact for SSH_AUTH_SOCK,
                 // HOME, and any host-specific connection configuration.
@@ -2531,6 +2547,16 @@ extension ACPSessionManager {
     /// launch falls back to PATH-based `/usr/bin/env <command>`.
     private func resolvedLaunchSpec(for spec: ACPLaunchSpec, host: String?) async -> ACPLaunchSpec {
         if let host {
+            if ACPManagedAdapterDescriptor.descriptor(for: spec.agentID) != nil {
+                let key = remoteAdapterKey(host: host, agentID: spec.agentID)
+                guard let resolved = resolvedRemoteAdapters[key] else {
+                    return spec
+                }
+                return spec.overridingCommand(
+                    resolved.adapterPath,
+                    remoteNodeBinDirectory: resolved.nodeBinDirectory
+                )
+            }
             guard let command = ACPRemoteLaunch.launchPathProbeCommand(for: spec),
                   let probe = try? await RemoteExec.run(host: host, cwd: nil, command: command),
                   probe.exitCode == 0
@@ -2555,6 +2581,22 @@ extension ACPSessionManager {
             return await setupEvaluator(spec)
         }
 
+        if let descriptor = ACPManagedAdapterDescriptor.descriptor(for: spec.agentID) {
+            let key = remoteAdapterKey(host: host, agentID: spec.agentID)
+            let resolution = await remoteAdapterResolver(host, descriptor, spec.setupCheck)
+            switch resolution {
+            case .ready(let resolved):
+                resolvedRemoteAdapters[key] = resolved
+                return .ready
+            case .missing(let reason):
+                resolvedRemoteAdapters.removeValue(forKey: key)
+                return .missing(reason: reason)
+            case .error(let message):
+                resolvedRemoteAdapters.removeValue(forKey: key)
+                return .error(message: message)
+            }
+        }
+
         do {
             let probe = try await RemoteExec.run(
                 host: host,
@@ -2568,6 +2610,10 @@ extension ACPSessionManager {
         } catch {
             return .error(message: "Could not verify \(spec.command) on \(host): \(error.localizedDescription)")
         }
+    }
+
+    private func remoteAdapterKey(host: String, agentID: String) -> String {
+        "\(host)\u{0}\(agentID)"
     }
 
     private func handleAuthRequiredRunner(

--- a/Alas/Sources/ACP/UI/ACPSetupNudgeBanner.swift
+++ b/Alas/Sources/ACP/UI/ACPSetupNudgeBanner.swift
@@ -7,28 +7,43 @@ enum ACPSetupNudgeMode: Equatable {
 
 /// Kept out of the SwiftUI struct so tests can call it without a view hierarchy.
 enum ACPSetupNudgeBannerCopy {
-    static func idleMessage(mode: ACPSetupNudgeMode, agentDisplayName: String) -> String {
+    static func idleMessage(
+        mode: ACPSetupNudgeMode,
+        agentDisplayName: String,
+        targetHost: String? = nil
+    ) -> String {
+        let target = targetHost.map { " on \($0)" } ?? ""
         switch mode {
         case .install:
-            return "\(agentDisplayName) requires the ACP adapter to be installed."
+            return "\(agentDisplayName) requires the ACP adapter to be installed\(target)."
         case .update(let current, let latest):
-            return "\(agentDisplayName) adapter update available (\(current) → \(latest))."
+            return "\(agentDisplayName) adapter update\(target) available (\(current) → \(latest))."
         }
     }
 
-    static func installedMessage(mode: ACPSetupNudgeMode, agentDisplayName: String) -> String {
+    static func installedMessage(
+        mode: ACPSetupNudgeMode,
+        agentDisplayName: String,
+        targetHost: String? = nil
+    ) -> String {
+        let target = targetHost.map { " on \($0)" } ?? ""
         switch mode {
         case .install:
-            return "\(agentDisplayName) adapter installed — connecting…"
+            return "\(agentDisplayName) adapter installed\(target) — connecting…"
         case .update:
-            return "\(agentDisplayName) adapter updated — reconnecting…"
+            return "\(agentDisplayName) adapter updated\(target) — reconnecting…"
         }
     }
 
-    static func installingMessage(mode: ACPSetupNudgeMode, agentDisplayName: String) -> String {
+    static func installingMessage(
+        mode: ACPSetupNudgeMode,
+        agentDisplayName: String,
+        targetHost: String? = nil
+    ) -> String {
+        let target = targetHost.map { " on \($0)" } ?? ""
         switch mode {
-        case .install: return "Installing \(agentDisplayName) adapter…"
-        case .update:  return "Updating \(agentDisplayName) adapter…"
+        case .install: return "Installing \(agentDisplayName) adapter\(target)…"
+        case .update:  return "Updating \(agentDisplayName) adapter\(target)…"
         }
     }
 
@@ -51,7 +66,8 @@ enum ACPSetupNudgeBannerCopy {
 struct ACPSetupNudgeBanner: View {
     let agentID: String
     let agentDisplayName: String
-    let installer: ACPAdapterInstaller
+    let targetHost: String?
+    let install: () async throws -> Void
     let mode: ACPSetupNudgeMode
     let onDismiss: () -> Void
     /// Called after a successful install. Lets the parent re-run setup
@@ -66,16 +82,18 @@ struct ACPSetupNudgeBanner: View {
     init(
         agentID: String,
         agentDisplayName: String,
-        installer: ACPAdapterInstaller,
+        targetHost: String? = nil,
         mode: ACPSetupNudgeMode = .install,
         onDismiss: @escaping () -> Void,
+        install: @escaping () async throws -> Void,
         onInstalled: @escaping () async -> Void
     ) {
         self.agentID = agentID
         self.agentDisplayName = agentDisplayName
-        self.installer = installer
+        self.targetHost = targetHost
         self.mode = mode
         self.onDismiss = onDismiss
+        self.install = install
         self.onInstalled = onInstalled
     }
 
@@ -135,11 +153,14 @@ struct ACPSetupNudgeBanner: View {
     private var message: String {
         switch status {
         case .idle:
-            return ACPSetupNudgeBannerCopy.idleMessage(mode: mode, agentDisplayName: agentDisplayName)
+            return ACPSetupNudgeBannerCopy.idleMessage(
+                mode: mode, agentDisplayName: agentDisplayName, targetHost: targetHost)
         case .installing:
-            return ACPSetupNudgeBannerCopy.installingMessage(mode: mode, agentDisplayName: agentDisplayName)
+            return ACPSetupNudgeBannerCopy.installingMessage(
+                mode: mode, agentDisplayName: agentDisplayName, targetHost: targetHost)
         case .installed:
-            return ACPSetupNudgeBannerCopy.installedMessage(mode: mode, agentDisplayName: agentDisplayName)
+            return ACPSetupNudgeBannerCopy.installedMessage(
+                mode: mode, agentDisplayName: agentDisplayName, targetHost: targetHost)
         case .error(let detail):
             return ACPSetupNudgeBannerCopy.errorMessage(mode: mode, detail: detail)
         }
@@ -163,7 +184,7 @@ struct ACPSetupNudgeBanner: View {
         status = .installing
         Task {
             do {
-                try await installer.install()
+                try await install()
                 await MainActor.run { status = .installed }
                 await onInstalled()
             } catch {

--- a/Alas/Sources/ACP/UI/ACPTabView.swift
+++ b/Alas/Sources/ACP/UI/ACPTabView.swift
@@ -105,6 +105,22 @@ private struct ACPSessionView: View {
     @State private var suppressRestoredPlanSidebarPlanChange: Bool = false
     @State private var composerFocusRequest: Int = 0
 
+    private var adapterTarget: ACPAdapterTarget {
+        guard let host = RemoteHostRegistry.shared.host(forPath: worktree.path.path) else {
+            return .local
+        }
+        return .ssh(host: host)
+    }
+
+    private var adapterUpdateKey: ACPAdapterUpdateKey {
+        ACPAdapterUpdateKey(target: adapterTarget, agentID: session.agentId)
+    }
+
+    private var adapterTargetHost: String? {
+        guard case .ssh(let host) = adapterTarget else { return nil }
+        return host
+    }
+
     /// Re-evaluated on every width / plan change. Pure call into the
     /// hysteresis reducer; the `.spring` wrap lives at the call site.
     ///
@@ -568,7 +584,10 @@ private struct ACPSessionView: View {
                 onReconnect: { Task { await reattachAndRefreshAdapterUpdateState() } }
             )
         } else {
-            let dismissedSetup = state.config.harness.dismissedACPSetupNudges.contains(session.agentId)
+            let dismissedSetup = ACPSetupNudgeDismissal.isDismissed(
+                state.config.harness.dismissedACPSetupNudges,
+                key: adapterUpdateKey
+            )
             let decision = ACPAdapterUpdateBannerDecider.decide(
                 setupState: session.setupState,
                 updateState: updateState,
@@ -576,33 +595,37 @@ private struct ACPSessionView: View {
 
             switch decision {
             case .showInstall where !dismissedSetup:
-                if let installer = ACPInstallerRegistry.installer(for: session.agentId) {
+                if ACPManagedAdapterDescriptor.descriptor(for: session.agentId) != nil {
                     ACPSetupNudgeBanner(
                         agentID: session.agentId,
                         agentDisplayName: AgentBuiltins.entry(id: session.agentId)?.displayName ?? session.agentId,
-                        installer: installer,
+                        targetHost: adapterTargetHost,
                         mode: .install,
                         onDismiss: { dismissNudge() },
-                        onInstalled: { await reattach() }
+                        install: { try await installAdapter() },
+                        onInstalled: { await reattachAfterAdapterChange() }
                     )
                 } else if case .needsSetup(let reason) = session.setupState {
                     setupReasonBanner(reason: reason)
                 }
             case .none:
                 if case .setupError(let reason) = session.setupState {
-                    setupReasonBanner(reason: reason)
+                    setupReasonBanner(reason: reason) {
+                        Task { await reattachAndRefreshAdapterUpdateState() }
+                    }
                 } else {
                     EmptyView()
                 }
             case .showUpdate(let current, let latest):
-                if let installer = ACPInstallerRegistry.installer(for: session.agentId) {
+                if ACPManagedAdapterDescriptor.descriptor(for: session.agentId) != nil {
                     ACPSetupNudgeBanner(
                         agentID: session.agentId,
                         agentDisplayName: AgentBuiltins.entry(id: session.agentId)?.displayName ?? session.agentId,
-                        installer: installer,
+                        targetHost: adapterTargetHost,
                         mode: .update(current: current, latest: latest),
                         onDismiss: { dismissUpdate(latest: latest) },
-                        onInstalled: { await reattachAfterUpdate() }
+                        install: { try await installAdapter() },
+                        onInstalled: { await reattachAfterAdapterChange() }
                     )
                 }
             default:
@@ -714,22 +737,31 @@ private struct ACPSessionView: View {
 
     private func dismissNudge() {
         var dismissed = state.config.harness.dismissedACPSetupNudges
-        if !dismissed.contains(session.agentId) {
-            dismissed.append(session.agentId)
+        let key = adapterUpdateKey
+        if !ACPSetupNudgeDismissal.isDismissed(dismissed, key: key) {
+            dismissed.append(ACPSetupNudgeDismissal.storageKey(for: key))
             state.config.harness.dismissedACPSetupNudges = dismissed
             _ = state.saveConfig()
         }
     }
 
     private func dismissUpdate(latest: String) {
+        let key = adapterUpdateKey
         Task {
-            await state.acpAdapterUpdateStore.dismiss(agentID: session.agentId, latest: latest)
+            await state.acpAdapterUpdateStore.dismiss(key: key, latest: latest)
             await MainActor.run { dismissedLatest = latest }
         }
     }
 
-    private func reattachAfterUpdate() async {
-        await state.acpAdapterUpdateStore.clear(agentID: session.agentId)
+    private func installAdapter() async throws {
+        try await state.acpAdapterInstallCoordinator.install(
+            target: adapterTarget,
+            agentID: session.agentId
+        )
+    }
+
+    private func reattachAfterAdapterChange() async {
+        await state.acpAdapterUpdateStore.clear(key: adapterUpdateKey)
         await MainActor.run {
             updateState = nil
             dismissedLatest = nil
@@ -743,11 +775,19 @@ private struct ACPSessionView: View {
         await refreshAdapterUpdateState()
     }
 
-    private func setupReasonBanner(reason: String) -> some View {
+    private func setupReasonBanner(
+        reason: String,
+        onRetry: (() -> Void)? = nil
+    ) -> some View {
         HStack(spacing: 8) {
             Image(systemName: "info.circle").foregroundStyle(theme.color("fg-faint"))
             Text(reason).font(.system(size: 12)).foregroundStyle(theme.color("fg-muted"))
             Spacer()
+            if let onRetry {
+                Button("Retry", action: onRetry)
+                    .buttonStyle(.borderless)
+                    .controlSize(.small)
+            }
         }
         .padding(.horizontal, 12).padding(.vertical, 8)
         .background(theme.color("bg-1").opacity(0.6))
@@ -783,12 +823,21 @@ private struct ACPSessionView: View {
 
         let store = state.acpAdapterUpdateStore
         let checker = ACPAdapterVersionChecker()
-        let result = await store.checkOrCompute(agentID: session.agentId) {
-            await checker.check(packageName: pkg)
+        let key = adapterUpdateKey
+        let result = await store.checkOrCompute(key: key) {
+            switch key.target {
+            case .local:
+                return await checker.check(packageName: pkg)
+            case .ssh(let host):
+                guard let descriptor = ACPManagedAdapterDescriptor.descriptor(for: key.agentID) else {
+                    return .unknown
+                }
+                return await checker.check(host: host, descriptor: descriptor)
+            }
         }
         var dismissed: String? = nil
         if case .available(_, let latest) = result,
-           await store.isDismissed(agentID: session.agentId, latest: latest) {
+           await store.isDismissed(key: key, latest: latest) {
             dismissed = latest
         }
 
@@ -850,5 +899,18 @@ private struct ACPSessionView: View {
         .overlay(alignment: .bottom) {
             Rectangle().fill(theme.color("del").opacity(0.3)).frame(height: 0.5)
         }
+    }
+}
+
+enum ACPSetupNudgeDismissal {
+    static func storageKey(for key: ACPAdapterUpdateKey) -> String {
+        key.storageKey
+    }
+
+    static func isDismissed(_ values: [String], key: ACPAdapterUpdateKey) -> Bool {
+        if values.contains(storageKey(for: key)) { return true }
+        // Existing agent-only values predate target identity and therefore
+        // retain their old behavior only for local ACP sessions.
+        return key.target == .local && values.contains(key.agentID)
     }
 }

--- a/Alas/Sources/App/AppState.swift
+++ b/Alas/Sources/App/AppState.swift
@@ -60,6 +60,7 @@ final class AppState {
     let rightPaneStore = RightPaneStore()
     let harness = HarnessService()
     let acpAdapterUpdateStore = ACPAdapterUpdateStore()
+    let acpAdapterInstallCoordinator = ACPAdapterInstallCoordinator()
 
     // MARK: Remote control
     /// Paired-device registry backed by an on-disk JSON store. Lazy so the

--- a/Alas/Sources/SSH/ACPRemoteAdapterManagement.swift
+++ b/Alas/Sources/SSH/ACPRemoteAdapterManagement.swift
@@ -1,0 +1,598 @@
+import Foundation
+
+struct ACPResolvedRemoteAdapter: Equatable, Sendable {
+    let adapterPath: String
+    let nodeBinDirectory: String
+}
+
+enum ACPRemoteAdapterResolution: Equatable, Sendable {
+    case ready(ACPResolvedRemoteAdapter)
+    case missing(reason: String)
+    case error(message: String)
+}
+
+enum ACPRemoteAdapterInstallError: Error, Equatable, Sendable {
+    case unsupportedAgent(String)
+    case prerequisite(String)
+    case connectionFailure(String)
+    case executionFailure(exitCode: Int32?, detail: String)
+}
+
+extension ACPRemoteAdapterInstallError: LocalizedError {
+    var errorDescription: String? {
+        switch self {
+        case .unsupportedAgent(let agentID):
+            return "Alas cannot install an ACP adapter for \(agentID)."
+        case .prerequisite(let detail), .connectionFailure(let detail):
+            return detail
+        case .executionFailure(let exitCode, let detail):
+            let prefix = exitCode.map { "Remote ACP adapter installation failed (exit \($0))." }
+                ?? "Remote ACP adapter installation failed."
+            return detail.isEmpty ? prefix : "\(prefix) \(detail)"
+        }
+    }
+}
+
+struct ACPRemoteAdapterManagement {
+    typealias Runner = @Sendable (
+        _ host: String,
+        _ cwd: String?,
+        _ command: String,
+        _ pathPolicy: SSHCommand.PathPolicy,
+        _ timeout: TimeInterval
+    ) async throws -> ProcessResult
+    typealias NodeResolver = @Sendable (_ host: String) async throws -> ACPRemoteNodeEnvironment
+
+    static let managedPrefixRoot = "$HOME/.alas/acp"
+    static let protocolBegin = "ALAS_ACP_ADAPTER_V1_BEGIN"
+    static let protocolEnd = "ALAS_ACP_ADAPTER_V1_END"
+    static let absentExitCode: Int32 = 30
+    static let missingExitCode: Int32 = 31
+    static let prerequisiteExitCode: Int32 = 32
+    static let corruptExitCode: Int32 = 33
+    static let stagingExitCode: Int32 = 34
+    static let npmInstallExitCode: Int32 = 35
+    static let stagedPackageExitCode: Int32 = 36
+    static let stagedBinaryExitCode: Int32 = 37
+    static let backupExitCode: Int32 = 38
+    static let promotionExitCode: Int32 = 39
+    static let promotedValidationExitCode: Int32 = 40
+    static let rollbackExitCode: Int32 = 41
+    static let backupCleanupExitCode: Int32 = 42
+    static let promotionLockExitCode: Int32 = 43
+    static let maximumInstallDetailLength = 2_048
+    static let installTimeout: TimeInterval = 5 * 60
+
+    private let runner: Runner
+    private let nodeResolver: NodeResolver
+
+    init(
+        runner: @escaping Runner = { host, cwd, command, pathPolicy, timeout in
+            try await RemoteExec.run(
+                host: host,
+                cwd: cwd,
+                command: command,
+                timeout: timeout,
+                pathPolicy: pathPolicy
+            )
+        },
+        nodeResolver: @escaping NodeResolver = { host in
+            try await ACPRemoteNodeEnvironmentResolver().resolve(host: host)
+        }
+    ) {
+        self.runner = runner
+        self.nodeResolver = nodeResolver
+    }
+
+    func resolve(
+        host: String,
+        descriptor: ACPManagedAdapterDescriptor,
+        setupCheck: ACPSetupCheck
+    ) async -> ACPRemoteAdapterResolution {
+        let environmentResult: Result<ACPRemoteNodeEnvironment, Error>
+        do {
+            environmentResult = .success(try await nodeResolver(host))
+        } catch {
+            environmentResult = .failure(error)
+        }
+        let managedNodeBin: String?
+        if case .success(let environment) = environmentResult {
+            managedNodeBin = environment.binDirectory
+        } else {
+            // A managed adapter can still run with Node on PATH when npm is
+            // unavailable. Keep this fallback for existing installations.
+            managedNodeBin = nil
+        }
+        let managedResult = await runProbe(
+            host: host,
+            command: Self.managedProbeCommand(
+                descriptor: descriptor,
+                nodeBinDirectory: managedNodeBin
+            )
+        )
+        let managedResolution = classifyManagedProbe(
+            managedResult,
+            descriptor: descriptor,
+            host: host
+        )
+        switch managedResolution {
+        case .ready, .missing, .error:
+            return managedResolution!
+        case nil:
+            break
+        }
+
+        let environment: ACPRemoteNodeEnvironment
+        switch environmentResult {
+        case .success(let resolved):
+            environment = resolved
+        case .failure(let error):
+            guard Self.allowsPathFallback(descriptor: descriptor, setupCheck: setupCheck) else {
+                return .error(message: error.localizedDescription)
+            }
+            let pathResult = await runProbe(
+                host: host,
+                command: Self.pathProbeCommand(descriptor: descriptor),
+                pathPolicy: .augmented
+            )
+            let pathResolution = classifyAdapterProbe(pathResult, descriptor: descriptor, host: host)
+            if case .ready = pathResolution {
+                return pathResolution
+            }
+            return .error(message: error.localizedDescription)
+        }
+
+        let globalResult = await runProbe(
+            host: host,
+            command: Self.globalProbeCommand(
+                descriptor: descriptor,
+                setupCheck: setupCheck,
+                environment: environment
+            )
+        )
+        return classifyAdapterProbe(globalResult, descriptor: descriptor, host: host)
+    }
+
+    func install(host: String, descriptor: ACPManagedAdapterDescriptor) async throws {
+        let environment: ACPRemoteNodeEnvironment
+        do {
+            environment = try await nodeResolver(host)
+        } catch let error as ACPRemoteNodeEnvironmentError {
+            throw Self.installPrerequisiteError(error)
+        } catch {
+            throw ACPRemoteAdapterInstallError.prerequisite(
+                Self.safeInstallDetail(error.localizedDescription, fallback: "Node.js and npm are required on \(host).")
+            )
+        }
+
+        let command = Self.installCommand(
+            descriptor: descriptor,
+            environment: environment,
+            transactionID: UUID().uuidString.lowercased()
+        )
+        let result: ProcessResult
+        do {
+            result = try await runner(host, nil, command, .inherited, Self.installTimeout)
+        } catch {
+            throw ACPRemoteAdapterInstallError.executionFailure(
+                exitCode: nil,
+                detail: Self.safeInstallDetail(error.localizedDescription)
+            )
+        }
+        if RemoteExec.isConnectionFailure(exitCode: result.exitCode) {
+            throw ACPRemoteAdapterInstallError.connectionFailure(
+                Self.safeInstallDetail(result.stderr, fallback: "Could not reach \(host) over SSH.")
+            )
+        }
+        guard result.exitCode == 0 else {
+            throw ACPRemoteAdapterInstallError.executionFailure(
+                exitCode: result.exitCode,
+                detail: Self.safeInstallDetail(result.stderr)
+            )
+        }
+    }
+
+    static func managedPrefix(for descriptor: ACPManagedAdapterDescriptor) -> String {
+        "\(managedPrefixRoot)/\(descriptor.agentID)"
+    }
+
+    static func installCommand(
+        descriptor: ACPManagedAdapterDescriptor,
+        environment: ACPRemoteNodeEnvironment,
+        transactionID: String
+    ) -> String {
+        let npm = SSHCommand.shellQuote(environment.npmPath)
+        let nodeBin = SSHCommand.shellQuote(environment.binDirectory)
+        let package = SSHCommand.shellQuote(descriptor.packageName)
+        let binary = SSHCommand.shellQuote(descriptor.binaryName)
+        let agent = SSHCommand.shellQuote(descriptor.agentID)
+        let legacyCleanup = descriptor.legacyPackageNames.map {
+            "\(npm) --prefix \"$stage\" uninstall -g \(SSHCommand.shellQuote($0)) >/dev/null 2>&1 || :"
+        }.joined(separator: "\n")
+
+        return """
+        PATH=\(nodeBin):"$PATH"
+        export PATH
+        staging_root=$HOME/.alas/acp/.staging
+        live=$HOME/.alas/acp/\(agent)
+        stage="$staging_root/\(descriptor.agentID)-\(transactionID)"
+        backup="$staging_root/\(descriptor.agentID)-backup-\(transactionID)"
+        lock="$staging_root/.locks/\(descriptor.agentID).lock"
+        lock_acquired=0
+        package=\(package)
+        binary=\(binary)
+        cleanup_stage() {
+            rm -rf "$stage" >/dev/null 2>&1 || :
+            if [ "$lock_acquired" -eq 1 ]; then
+                rm -f "$lock/pid" >/dev/null 2>&1 || :
+                rmdir "$lock" >/dev/null 2>&1 || :
+            fi
+        }
+        acquire_promotion_lock() {
+            if mkdir "$lock"; then
+                printf '%s\n' "$$" > "$lock/pid" || {
+                    rm -f "$lock/pid" >/dev/null 2>&1 || :
+                    rmdir "$lock" >/dev/null 2>&1 || :
+                    return 1
+                }
+                return 0
+            fi
+            owner=$(cat "$lock/pid" 2>/dev/null || :)
+            case "$owner" in
+                *[!0-9]*|'')
+                    printf '%s\n' "Remote ACP adapter install lock is initializing; retry shortly." >&2
+                    ;;
+                *)
+                    if kill -0 "$owner" 2>/dev/null; then
+                        printf '%s\n' "Remote ACP adapter install is already in progress." >&2
+                    else
+                        printf '%s\n' "A previous remote ACP adapter install was interrupted. Remove $lock after confirming no other Alas instance is installing this adapter, then retry." >&2
+                    fi
+                    ;;
+            esac
+            return 1
+        }
+        trap cleanup_stage EXIT
+        trap 'exit 1' HUP INT TERM
+        mkdir -p "$staging_root" || exit \(stagingExitCode)
+        rm -rf "$stage" "$backup" >/dev/null 2>&1 || :
+        mkdir "$stage" || exit \(stagingExitCode)
+        \(legacyCleanup)
+        \(npm) --prefix "$stage" install -g \(package) || exit \(npmInstallExitCode)
+        [ -d "$stage/lib/node_modules/$package" ] || exit \(stagedPackageExitCode)
+        [ -x "$stage/bin/$binary" ] && [ ! -d "$stage/bin/$binary" ] || exit \(stagedBinaryExitCode)
+
+        mkdir -p "$staging_root/.locks" || exit \(stagingExitCode)
+        acquire_promotion_lock || exit \(promotionLockExitCode)
+        lock_acquired=1
+        had_live=0
+        if [ -e "$live" ] || [ -L "$live" ]; then
+            mv "$live" "$backup" || exit \(backupExitCode)
+            had_live=1
+        fi
+        if ! mv "$stage" "$live"; then
+            rm -rf "$live" >/dev/null 2>&1 || :
+            if [ "$had_live" -eq 1 ]; then
+                mv "$backup" "$live" || exit \(rollbackExitCode)
+            fi
+            exit \(promotionExitCode)
+        fi
+        if [ ! -d "$live/lib/node_modules/$package" ] \
+            || [ ! -x "$live/bin/$binary" ] \
+            || [ -d "$live/bin/$binary" ]; then
+            rm -rf "$live" >/dev/null 2>&1 || :
+            if [ "$had_live" -eq 1 ]; then
+                mv "$backup" "$live" || exit \(rollbackExitCode)
+            fi
+            exit \(promotedValidationExitCode)
+        fi
+        if [ "$had_live" -eq 1 ]; then
+            rm -rf "$backup" || exit \(backupCleanupExitCode)
+        fi
+        trap - EXIT
+        cleanup_stage
+        """
+    }
+
+    static func managedProbeCommand(
+        descriptor: ACPManagedAdapterDescriptor,
+        nodeBinDirectory: String? = nil
+    ) -> String {
+        let prefix = managedPrefix(for: descriptor)
+        let nodeLookup: String
+        if let nodeBinDirectory {
+            nodeLookup = """
+            node_bin=\(SSHCommand.shellQuote(nodeBinDirectory))
+            node="$node_bin/node"
+            """
+        } else {
+            nodeLookup = """
+            node=$(command -v node 2>/dev/null || :)
+            case "$node" in
+                /*/node) ;;
+                *) \(emit(status: "prerequisite")); exit \(prerequisiteExitCode) ;;
+            esac
+            node_bin=${node%/node}
+            """
+        }
+        return """
+        prefix=\(prefix)
+        adapter="$prefix/bin/\(descriptor.binaryName)"
+        if [ ! -e "$prefix" ] && [ ! -L "$prefix" ]; then
+            \(emit(status: "absent"))
+            exit \(absentExitCode)
+        fi
+        if [ ! -d "$prefix" ] || [ ! -x "$adapter" ] || [ -d "$adapter" ]; then
+            \(emit(status: "corrupt"))
+            exit \(corruptExitCode)
+        fi
+        \(nodeLookup)
+        [ -x "$node" ] && [ ! -d "$node" ] || {
+            \(emit(status: "prerequisite"))
+            exit \(prerequisiteExitCode)
+        }
+        \(emitReady(adapterExpression: "$adapter", nodeBinExpression: "$node_bin"))
+        """
+    }
+
+    static func globalProbeCommand(
+        descriptor: ACPManagedAdapterDescriptor,
+        setupCheck: ACPSetupCheck,
+        environment: ACPRemoteNodeEnvironment
+    ) -> String {
+        let npm = SSHCommand.shellQuote(environment.npmPath)
+        let nodeBin = SSHCommand.shellQuote(environment.binDirectory)
+        let package = SSHCommand.shellQuote(descriptor.packageName)
+        let binary = SSHCommand.shellQuote(descriptor.binaryName)
+        let allowsPathFallback = allowsPathFallback(descriptor: descriptor, setupCheck: setupCheck)
+
+        let pathFallback = allowsPathFallback ? """
+        path_adapter=$(command -v \(binary) 2>/dev/null || :)
+        case "$path_adapter" in
+            /*) [ -x "$path_adapter" ] && [ ! -d "$path_adapter" ] && {
+                \(emitReady(adapterExpression: "$path_adapter", nodeBinExpression: "$node_bin"))
+            } ;;
+        esac
+        """ : ""
+
+        return """
+        PATH=\(nodeBin):"$PATH"
+        export PATH
+        node_bin=\(nodeBin)
+        root=$(\(npm) root -g 2>/dev/null) || {
+            \(emit(status: "prerequisite"))
+            exit \(prerequisiteExitCode)
+        }
+        prefix=$(\(npm) prefix -g 2>/dev/null) || {
+            \(emit(status: "prerequisite"))
+            exit \(prerequisiteExitCode)
+        }
+        package=\(package)
+        binary=\(binary)
+        if [ -n "$root" ] && [ -d "$root/$package" ] && [ -n "$prefix" ]; then
+            global_adapter="$prefix/bin/$binary"
+            if [ -x "$global_adapter" ] && [ ! -d "$global_adapter" ]; then
+                \(emitReady(adapterExpression: "$global_adapter", nodeBinExpression: "$node_bin"))
+            fi
+            \(emit(status: "corrupt"))
+            exit \(corruptExitCode)
+        fi
+        \(pathFallback)
+        \(emit(status: "missing"))
+        exit \(missingExitCode)
+        """
+    }
+
+    static func pathProbeCommand(descriptor: ACPManagedAdapterDescriptor) -> String {
+        let binary = SSHCommand.shellQuote(descriptor.binaryName)
+        return """
+        path_adapter=$(command -v \(binary) 2>/dev/null || :)
+        node=$(command -v node 2>/dev/null || :)
+        case "$path_adapter:$node" in
+            /*:/*/node)
+                if [ -x "$path_adapter" ] && [ ! -d "$path_adapter" ] &&
+                    [ -x "$node" ] && [ ! -d "$node" ]; then
+                    node_bin=${node%/node}
+                    \(emitReady(adapterExpression: "$path_adapter", nodeBinExpression: "$node_bin"))
+                fi
+                ;;
+        esac
+        \(emit(status: "missing"))
+        exit \(missingExitCode)
+        """
+    }
+
+    private static func allowsPathFallback(
+        descriptor: ACPManagedAdapterDescriptor,
+        setupCheck: ACPSetupCheck
+    ) -> Bool {
+        guard case .binaryOnPathOrNpmPackage(let candidate, let npmPackage) = setupCheck else {
+            return false
+        }
+        return candidate == descriptor.binaryName && npmPackage == descriptor.packageName
+    }
+
+    private func runProbe(
+        host: String,
+        command: String,
+        pathPolicy: SSHCommand.PathPolicy = .inherited
+    ) async -> Result<ProcessResult, Error> {
+        do {
+            return .success(try await runner(
+                host,
+                nil,
+                command,
+                pathPolicy,
+                Process.defaultTimeout
+            ))
+        } catch {
+            return .failure(error)
+        }
+    }
+
+    private func classifyManagedProbe(
+        _ result: Result<ProcessResult, Error>,
+        descriptor: ACPManagedAdapterDescriptor,
+        host: String
+    ) -> ACPRemoteAdapterResolution? {
+        switch result {
+        case .failure(let error):
+            return .error(message: "Could not inspect \(descriptor.binaryName) on \(host): \(error.localizedDescription)")
+        case .success(let result):
+            if RemoteExec.isConnectionFailure(exitCode: result.exitCode) {
+                return .error(message: connectionMessage(result.stderr, host: host))
+            }
+            switch result.exitCode {
+            case 0:
+                return parseReady(result.stdout).map(ACPRemoteAdapterResolution.ready)
+                    ?? .error(message: malformedMessage(descriptor, host: host))
+            case Self.absentExitCode:
+                return hasStatus("absent", output: result.stdout)
+                    ? nil
+                    : .error(message: malformedMessage(descriptor, host: host))
+            case Self.prerequisiteExitCode:
+                return hasStatus("prerequisite", output: result.stdout)
+                    ? .error(message: "Node.js is required to run \(descriptor.binaryName) on \(host).")
+                    : .error(message: malformedMessage(descriptor, host: host))
+            case Self.corruptExitCode:
+                return hasStatus("corrupt", output: result.stdout)
+                    ? .error(message: "The managed \(descriptor.binaryName) installation on \(host) is incomplete.")
+                    : .error(message: malformedMessage(descriptor, host: host))
+            default:
+                return .error(message: executionMessage(result, descriptor: descriptor, host: host))
+            }
+        }
+    }
+
+    private func classifyAdapterProbe(
+        _ result: Result<ProcessResult, Error>,
+        descriptor: ACPManagedAdapterDescriptor,
+        host: String
+    ) -> ACPRemoteAdapterResolution {
+        switch result {
+        case .failure(let error):
+            return .error(message: "Could not inspect \(descriptor.binaryName) on \(host): \(error.localizedDescription)")
+        case .success(let result):
+            if RemoteExec.isConnectionFailure(exitCode: result.exitCode) {
+                return .error(message: connectionMessage(result.stderr, host: host))
+            }
+            switch result.exitCode {
+            case 0:
+                return parseReady(result.stdout).map(ACPRemoteAdapterResolution.ready)
+                    ?? .error(message: malformedMessage(descriptor, host: host))
+            case Self.missingExitCode:
+                return hasStatus("missing", output: result.stdout)
+                    ? .missing(reason: "\(descriptor.binaryName) is not installed on \(host).")
+                    : .error(message: malformedMessage(descriptor, host: host))
+            case Self.prerequisiteExitCode:
+                return hasStatus("prerequisite", output: result.stdout)
+                    ? .error(message: "The remote Node.js/npm environment on \(host) is unusable.")
+                    : .error(message: malformedMessage(descriptor, host: host))
+            case Self.corruptExitCode:
+                return hasStatus("corrupt", output: result.stdout)
+                    ? .error(message: "The global \(descriptor.packageName) installation on \(host) is incomplete.")
+                    : .error(message: malformedMessage(descriptor, host: host))
+            default:
+                return .error(message: executionMessage(result, descriptor: descriptor, host: host))
+            }
+        }
+    }
+
+    private func parseReady(_ output: String) -> ACPResolvedRemoteAdapter? {
+        guard let fields = parseFields(output), fields.count == 3,
+              fields["status"] == "ready",
+              let adapter = fields["adapter"], isAbsolutePath(adapter),
+              let nodeBin = fields["nodeBin"], isAbsolutePath(nodeBin)
+        else { return nil }
+        return ACPResolvedRemoteAdapter(adapterPath: adapter, nodeBinDirectory: nodeBin)
+    }
+
+    private func hasStatus(_ status: String, output: String) -> Bool {
+        guard let fields = parseFields(output) else { return false }
+        return fields.count == 1 && fields["status"] == status
+    }
+
+    private func parseFields(_ output: String) -> [String: String]? {
+        guard !output.contains("\r") else { return nil }
+        var lines = output.split(separator: "\n", omittingEmptySubsequences: false).map(String.init)
+        if lines.last == "" { lines.removeLast() }
+        guard lines.count >= 3, lines.first == Self.protocolBegin, lines.last == Self.protocolEnd else {
+            return nil
+        }
+        var fields: [String: String] = [:]
+        for line in lines.dropFirst().dropLast() {
+            guard let separator = line.firstIndex(of: "="), separator != line.startIndex else { return nil }
+            let key = String(line[..<separator])
+            let value = String(line[line.index(after: separator)...])
+            guard !value.isEmpty, fields[key] == nil else { return nil }
+            fields[key] = value
+        }
+        return fields
+    }
+
+    private func isAbsolutePath(_ path: String) -> Bool {
+        path.hasPrefix("/") && path != "/" && !path.contains("\n")
+    }
+
+    private func malformedMessage(_ descriptor: ACPManagedAdapterDescriptor, host: String) -> String {
+        "Remote \(descriptor.binaryName) discovery returned malformed output from \(host)."
+    }
+
+    private func connectionMessage(_ stderr: String, host: String) -> String {
+        let detail = stderr.trimmingCharacters(in: .whitespacesAndNewlines)
+        return detail.isEmpty ? "Could not reach \(host) over SSH." : detail
+    }
+
+    private func executionMessage(
+        _ result: ProcessResult,
+        descriptor: ACPManagedAdapterDescriptor,
+        host: String
+    ) -> String {
+        let detail = result.stderr.trimmingCharacters(in: .whitespacesAndNewlines)
+        return detail.isEmpty
+            ? "Remote \(descriptor.binaryName) discovery failed on \(host) (exit \(result.exitCode))."
+            : detail
+    }
+
+    private static func emit(status: String) -> String {
+        "printf '%s\\n' '\(protocolBegin)' 'status=\(status)' '\(protocolEnd)'"
+    }
+
+    private static func installPrerequisiteError(
+        _ error: ACPRemoteNodeEnvironmentError
+    ) -> ACPRemoteAdapterInstallError {
+        switch error {
+        case .connectionFailure(let detail):
+            return .connectionFailure(safeInstallDetail(detail, fallback: "Could not reach the host over SSH."))
+        case .missing:
+            return .prerequisite("Node.js and npm are required on the remote host.")
+        case .executionFailure, .malformedOutput:
+            return .prerequisite(safeInstallDetail(error.localizedDescription))
+        }
+    }
+
+    private static func safeInstallDetail(_ value: String, fallback: String = "") -> String {
+        let sanitized = value.unicodeScalars.map { scalar -> Character in
+            if scalar == "\n" || scalar == "\t" || scalar.value >= 0x20 {
+                return Character(scalar)
+            }
+            return " "
+        }
+        let detail = String(sanitized)
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        let bounded = String(detail.prefix(maximumInstallDetailLength))
+        return bounded.isEmpty ? fallback : bounded
+    }
+
+    private static func emitReady(adapterExpression: String, nodeBinExpression: String) -> String {
+        """
+        printf '%s\\n' \\
+            '\(protocolBegin)' \\
+            'status=ready' \\
+            "adapter=\(adapterExpression)" \\
+            "nodeBin=\(nodeBinExpression)" \\
+            '\(protocolEnd)'
+        exit 0
+        """
+    }
+}

--- a/Alas/Sources/SSH/ACPRemoteLaunch.swift
+++ b/Alas/Sources/SSH/ACPRemoteLaunch.swift
@@ -14,22 +14,34 @@ enum ACPRemoteLaunch {
         "CLAUDE_CODE_ENTRYPOINT", "CLAUDE_SESSION_ID",
     ]
 
-    static func agentCommand(command: String, arguments: [String]) -> String {
+    static func agentCommand(
+        command: String,
+        arguments: [String],
+        nodeBinDirectory: String? = nil
+    ) -> String {
         let scrub = markerScrub.map { "-u \($0)" }.joined(separator: " ")
         let argv = ([command] + arguments).map(SSHCommand.shellQuote).joined(separator: " ")
-        return "env \(scrub) \(argv)"
+        let pathPrefix = nodeBinDirectory.map {
+            "PATH=\(SSHCommand.shellQuote($0)):\"$PATH\" && export PATH && "
+        } ?? ""
+        return "\(pathPrefix)env \(scrub) \(argv)"
     }
 
     static func channelInvocation(
         host: String,
         worktreePath: String,
         command: String,
-        arguments: [String]
+        arguments: [String],
+        nodeBinDirectory: String? = nil
     ) -> RemoteExecInvocation {
         RemoteExec.invocation(
             host: host,
             cwd: worktreePath,
-            command: agentCommand(command: command, arguments: arguments)
+            command: agentCommand(
+                command: command,
+                arguments: arguments,
+                nodeBinDirectory: nodeBinDirectory
+            )
         )
     }
 

--- a/Alas/Sources/SSH/ACPRemoteNodeEnvironment.swift
+++ b/Alas/Sources/SSH/ACPRemoteNodeEnvironment.swift
@@ -1,0 +1,275 @@
+import Foundation
+
+struct ACPRemoteNodeEnvironment: Equatable, Sendable {
+    let npmPath: String
+    let nodePath: String
+    let binDirectory: String
+}
+
+enum ACPRemoteNodeEnvironmentError: Error, Equatable, Sendable {
+    case missing
+    case connectionFailure(String)
+    case executionFailure(exitCode: Int32?, detail: String)
+    case malformedOutput
+}
+
+extension ACPRemoteNodeEnvironmentError: LocalizedError {
+    var errorDescription: String? {
+        switch self {
+        case .missing:
+            return "Node.js and npm are not available on the remote host."
+        case let .connectionFailure(detail):
+            return detail.isEmpty ? "Could not reach the host over SSH." : detail
+        case let .executionFailure(_, detail):
+            return detail.isEmpty ? "Remote Node.js discovery failed." : detail
+        case .malformedOutput:
+            return "Remote Node.js discovery returned malformed output."
+        }
+    }
+}
+
+struct ACPRemoteNodeEnvironmentResolver {
+    typealias Runner = @Sendable (
+        _ host: String,
+        _ cwd: String?,
+        _ command: String,
+        _ pathPolicy: SSHCommand.PathPolicy
+    ) async throws -> ProcessResult
+
+    static let missingExitCode: Int32 = 20
+    static let protocolBegin = "ALAS_NODE_ENV_V1_BEGIN"
+    static let protocolEnd = "ALAS_NODE_ENV_V1_END"
+
+    private let runner: Runner
+
+    init(runner: @escaping Runner = { host, cwd, command, pathPolicy in
+        try await RemoteExec.run(
+            host: host,
+            cwd: cwd,
+            command: command,
+            pathPolicy: pathPolicy
+        )
+    }) {
+        self.runner = runner
+    }
+
+    func resolve(host: String) async throws -> ACPRemoteNodeEnvironment {
+        let result: ProcessResult
+        do {
+            result = try await runner(host, nil, Self.discoveryCommand, .inherited)
+        } catch {
+            throw ACPRemoteNodeEnvironmentError.executionFailure(
+                exitCode: nil,
+                detail: error.localizedDescription
+            )
+        }
+
+        if RemoteExec.isConnectionFailure(exitCode: result.exitCode) {
+            throw ACPRemoteNodeEnvironmentError.connectionFailure(Self.trimmed(result.stderr))
+        }
+
+        switch result.exitCode {
+        case 0:
+            return try Self.parseResolved(result.stdout)
+        case Self.missingExitCode:
+            guard Self.isValidMissingOutput(result.stdout) else {
+                throw ACPRemoteNodeEnvironmentError.malformedOutput
+            }
+            throw ACPRemoteNodeEnvironmentError.missing
+        default:
+            throw ACPRemoteNodeEnvironmentError.executionFailure(
+                exitCode: result.exitCode,
+                detail: Self.trimmed(result.stderr)
+            )
+        }
+    }
+
+    static let discoveryCommand: String = {
+        let commonDirectories = [
+            "$HOME/.local/bin",
+            "$HOME/.npm-global/bin",
+            "/opt/homebrew/bin",
+            "/usr/local/bin",
+            "/home/linuxbrew/.linuxbrew/bin",
+            "/usr/bin",
+            "/bin",
+        ]
+        let commonChecks = commonDirectories.map { directory in
+            if directory.hasPrefix("$HOME") {
+                return "try_dir \"\(directory)\""
+            }
+            return "try_dir \(SSHCommand.shellQuote(directory))"
+        }.joined(separator: "\n")
+
+        return """
+        try_dir() {
+            d=${1%/}
+            case "$d" in
+                /*) ;;
+                *) return 1 ;;
+            esac
+            case "$d" in
+                *'
+        '*) return 1 ;;
+            esac
+            [ -x "$d/npm" ] && [ ! -d "$d/npm" ] || return 1
+            [ -x "$d/node" ] && [ ! -d "$d/node" ] || return 1
+            printf '%s\n' \
+                '\(protocolBegin)' \
+                'status=ok' \
+                "npm=$d/npm" \
+                "node=$d/node" \
+                "bin=$d" \
+                '\(protocolEnd)'
+            exit 0
+        }
+
+        try_env_dir() {
+            eval_value=$1
+            [ -n "$eval_value" ] || return 1
+            try_dir "$eval_value"
+        }
+
+        version_is_numeric() {
+            LC_ALL=C awk -v version="$1" 'BEGIN {
+                exit(version ~ /^[0-9]+([.][0-9]+)*$/ ? 0 : 1)
+            }'
+        }
+
+        version_is_greater() {
+            LC_ALL=C awk -v lhs="$1" -v rhs="$2" 'BEGIN {
+                lhsCount = split(lhs, lhsParts, ".")
+                rhsCount = split(rhs, rhsParts, ".")
+                count = lhsCount > rhsCount ? lhsCount : rhsCount
+                for (part = 1; part <= count; part++) {
+                    lhsValue = part <= lhsCount ? lhsParts[part] + 0 : 0
+                    rhsValue = part <= rhsCount ? rhsParts[part] + 0 : 0
+                    if (lhsValue > rhsValue) exit 0
+                    if (lhsValue < rhsValue) exit 1
+                }
+                exit 1
+            }'
+        }
+
+        try_latest_version() {
+            root=$1
+            [ -d "$root" ] || return 1
+            attempted='|'
+            while :; do
+                best_path=
+                best_version=
+                for candidate in "$root"/*; do
+                    [ -d "$candidate" ] || continue
+                    version=${candidate##*/}
+                    version=${version#v}
+                    version_is_numeric "$version" || continue
+                    case "$attempted" in
+                        *"|$version|"*) continue ;;
+                    esac
+                    if [ -z "$best_version" ] || version_is_greater "$version" "$best_version"; then
+                        best_path=$candidate
+                        best_version=$version
+                    fi
+                done
+                [ -n "$best_path" ] || return 1
+                try_dir "$best_path/bin"
+                attempted="${attempted}${best_version}|"
+            done
+        }
+
+        path_npm=$(command -v npm 2>/dev/null || :)
+        case "$path_npm" in
+            /*/npm) try_dir "${path_npm%/npm}" ;;
+        esac
+
+        try_env_dir "$NVM_BIN"
+        if [ -n "$VOLTA_HOME" ]; then try_dir "$VOLTA_HOME/bin"; fi
+
+        mise_root=${MISE_DATA_DIR:-"$HOME/.local/share/mise"}
+        asdf_root=${ASDF_DATA_DIR:-"$HOME/.asdf"}
+        volta_root=${VOLTA_HOME:-"$HOME/.volta"}
+        nvm_root=${NVM_DIR:-"$HOME/.nvm"}
+
+        try_dir "$mise_root/shims"
+        try_dir "$asdf_root/shims"
+        try_dir "$volta_root/bin"
+        try_dir "$nvm_root/current/bin"
+        try_latest_version "$mise_root/installs/node"
+        try_latest_version "$asdf_root/installs/nodejs"
+        try_latest_version "$nvm_root/versions/node"
+
+        \(commonChecks)
+
+        printf '%s\n' \
+            '\(protocolBegin)' \
+            'status=missing' \
+            '\(protocolEnd)'
+        exit \(missingExitCode)
+        """
+    }()
+
+    private static func parseResolved(_ output: String) throws -> ACPRemoteNodeEnvironment {
+        let fields = try parseFields(output)
+        guard fields["status"] == "ok",
+              fields.count == 4,
+              let npmPath = fields["npm"],
+              let nodePath = fields["node"],
+              let binDirectory = fields["bin"],
+              isValidAbsolutePath(npmPath),
+              isValidAbsolutePath(nodePath),
+              isValidAbsolutePath(binDirectory),
+              npmPath == binDirectory + "/npm",
+              nodePath == binDirectory + "/node"
+        else {
+            throw ACPRemoteNodeEnvironmentError.malformedOutput
+        }
+        return ACPRemoteNodeEnvironment(
+            npmPath: npmPath,
+            nodePath: nodePath,
+            binDirectory: binDirectory
+        )
+    }
+
+    private static func isValidMissingOutput(_ output: String) -> Bool {
+        guard let fields = try? parseFields(output) else { return false }
+        return fields.count == 1 && fields["status"] == "missing"
+    }
+
+    private static func parseFields(_ output: String) throws -> [String: String] {
+        guard !output.contains("\r") else {
+            throw ACPRemoteNodeEnvironmentError.malformedOutput
+        }
+        var lines = output.split(separator: "\n", omittingEmptySubsequences: false).map(String.init)
+        if lines.last == "" {
+            lines.removeLast()
+        }
+        guard lines.count >= 3,
+              lines.first == protocolBegin,
+              lines.last == protocolEnd
+        else {
+            throw ACPRemoteNodeEnvironmentError.malformedOutput
+        }
+
+        var fields: [String: String] = [:]
+        for line in lines.dropFirst().dropLast() {
+            guard !line.isEmpty, let separator = line.firstIndex(of: "=") else {
+                throw ACPRemoteNodeEnvironmentError.malformedOutput
+            }
+            let key = String(line[..<separator])
+            let value = String(line[line.index(after: separator)...])
+            guard !key.isEmpty, !value.isEmpty, fields[key] == nil else {
+                throw ACPRemoteNodeEnvironmentError.malformedOutput
+            }
+            fields[key] = value
+        }
+        return fields
+    }
+
+    private static func isValidAbsolutePath(_ path: String) -> Bool {
+        path.hasPrefix("/") && !path.contains("\n") && path != "/"
+    }
+
+    private static func trimmed(_ value: String) -> String {
+        value.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+}

--- a/Alas/Sources/SSH/RemoteExec.swift
+++ b/Alas/Sources/SSH/RemoteExec.swift
@@ -9,9 +9,15 @@ struct RemoteExecInvocation: Equatable {
 /// through `Process.git` (host-aware via `RemoteHostRegistry`); this is for
 /// everything else a remote project needs: capability probes, `ls`, `wc`.
 enum RemoteExec {
-    static func invocation(host: String, cwd: String?, command: String) -> RemoteExecInvocation {
-        let script = cwd.map { SSHCommand.remoteScript(cwd: $0, command: command) }
-            ?? SSHCommand.remoteScript(command: command)
+    static func invocation(
+        host: String,
+        cwd: String?,
+        command: String,
+        pathPolicy: SSHCommand.PathPolicy = .augmented
+    ) -> RemoteExecInvocation {
+        let script = cwd.map {
+            SSHCommand.remoteScript(cwd: $0, command: command, pathPolicy: pathPolicy)
+        } ?? SSHCommand.remoteScript(command: command, pathPolicy: pathPolicy)
         let ssh = SSHCommand(host: host, mode: .batch)
         return RemoteExecInvocation(
             executable: SSHCommand.executable,
@@ -23,9 +29,15 @@ enum RemoteExec {
         host: String,
         cwd: String?,
         command: String,
-        timeout: TimeInterval = Process.defaultTimeout
+        timeout: TimeInterval = Process.defaultTimeout,
+        pathPolicy: SSHCommand.PathPolicy = .augmented
     ) async throws -> ProcessResult {
-        let invocation = invocation(host: host, cwd: cwd, command: command)
+        let invocation = invocation(
+            host: host,
+            cwd: cwd,
+            command: command,
+            pathPolicy: pathPolicy
+        )
         return try await Process.run(invocation.executable, args: invocation.args, timeout: timeout)
     }
 
@@ -34,9 +46,15 @@ enum RemoteExec {
         host: String,
         cwd: String?,
         command: String,
-        timeout: TimeInterval = Process.defaultTimeout
+        timeout: TimeInterval = Process.defaultTimeout,
+        pathPolicy: SSHCommand.PathPolicy = .augmented
     ) async throws -> ProcessResultData {
-        let invocation = invocation(host: host, cwd: cwd, command: command)
+        let invocation = invocation(
+            host: host,
+            cwd: cwd,
+            command: command,
+            pathPolicy: pathPolicy
+        )
         return try await Process.runData(
             invocation.executable,
             args: invocation.args,

--- a/Alas/Sources/SSH/SSHCommand.swift
+++ b/Alas/Sources/SSH/SSHCommand.swift
@@ -21,6 +21,11 @@ struct SSHCommand: Equatable {
         case interactive
     }
 
+    enum PathPolicy: Equatable, Sendable {
+        case augmented
+        case inherited
+    }
+
     static let executable = "/usr/bin/ssh"
     static let scpExecutable = "/usr/bin/scp"
     private static let controlPath = "~/.ssh/alas-%C"
@@ -40,14 +45,25 @@ struct SSHCommand: Equatable {
     /// it reaches our script. Keep that layer to a simple `/bin/sh` launch
     /// so users with fish/csh login shells can still run the POSIX snippets
     /// generated throughout the remote stack.
-    static func remoteScript(cwd: String, command: String) -> String {
-        remoteScript(command: "cd \(shellQuote(cwd)) && \(command)")
+    static func remoteScript(
+        cwd: String,
+        command: String,
+        pathPolicy: PathPolicy = .augmented
+    ) -> String {
+        remoteScript(
+            command: "cd \(shellQuote(cwd)) && \(command)",
+            pathPolicy: pathPolicy
+        )
     }
 
     /// Remote-side script without a working-directory change (probes that
     /// must not assume `cwd` exists, e.g. repo validation via `git -C`).
-    static func remoteScript(command: String) -> String {
-        "/bin/sh -c \(shellQuote(remotePathPrelude + command))"
+    static func remoteScript(
+        command: String,
+        pathPolicy: PathPolicy = .augmented
+    ) -> String {
+        let prelude = pathPolicy == .augmented ? remotePathPrelude : ""
+        return "/bin/sh -c \(shellQuote(prelude + command))"
     }
 
     private static let remotePathPrelude =

--- a/AlasTests/ACP/Adapter/ACPAdapterInstallCoordinatorTests.swift
+++ b/AlasTests/ACP/Adapter/ACPAdapterInstallCoordinatorTests.swift
@@ -1,0 +1,112 @@
+import Foundation
+import Testing
+@testable import Alas
+
+@Suite("ACPAdapterInstallCoordinator")
+struct ACPAdapterInstallCoordinatorTests {
+    @Test("local and SSH installs route to separate implementations")
+    func routesByTarget() async throws {
+        let recorder = CoordinatorInstallRecorder()
+        let coordinator = makeCoordinator(recorder)
+
+        try await coordinator.install(target: .local, agentID: "codex")
+        try await coordinator.install(target: .ssh(host: "buildbox"), agentID: "codex")
+
+        #expect(await recorder.localAgentIDs == ["codex"])
+        #expect(await recorder.remoteRequests == ["buildbox|codex"])
+    }
+
+    @Test("same target and agent coalesce into one task")
+    func sameKeyCoalesces() async throws {
+        let recorder = CoordinatorInstallRecorder(delay: .milliseconds(100))
+        let coordinator = makeCoordinator(recorder)
+
+        async let first: Void = coordinator.install(target: .ssh(host: "buildbox"), agentID: "codex")
+        async let second: Void = coordinator.install(target: .ssh(host: "buildbox"), agentID: "codex")
+        _ = try await (first, second)
+
+        #expect(await recorder.remoteRequests == ["buildbox|codex"])
+        #expect(await coordinator.isInstalling(target: .ssh(host: "buildbox"), agentID: "codex") == false)
+    }
+
+    @Test("different target-agent keys run independently")
+    func differentKeysAreIndependent() async throws {
+        let recorder = CoordinatorInstallRecorder(delay: .milliseconds(100))
+        let coordinator = makeCoordinator(recorder)
+
+        async let first: Void = coordinator.install(target: .ssh(host: "one"), agentID: "codex")
+        async let second: Void = coordinator.install(target: .ssh(host: "two"), agentID: "pi")
+        _ = try await (first, second)
+
+        #expect(await recorder.maximumActiveRemoteInstalls == 2)
+        #expect(Set(await recorder.remoteRequests) == ["one|codex", "two|pi"])
+    }
+
+    @Test("a failed task is removed so retry can proceed")
+    func failureClearsInFlight() async throws {
+        let recorder = CoordinatorInstallRecorder(failuresRemaining: 1)
+        let coordinator = makeCoordinator(recorder)
+
+        await #expect(throws: CoordinatorTestError.failed) {
+            try await coordinator.install(target: .ssh(host: "buildbox"), agentID: "codex")
+        }
+        try await coordinator.install(target: .ssh(host: "buildbox"), agentID: "codex")
+
+        #expect(await recorder.remoteRequests.count == 2)
+    }
+
+    @Test("unsupported remote agents never touch the local registry")
+    func unsupportedRemoteDoesNotRouteLocally() async {
+        let recorder = CoordinatorInstallRecorder()
+        let coordinator = makeCoordinator(recorder)
+
+        await #expect(throws: ACPRemoteAdapterInstallError.unsupportedAgent("custom")) {
+            try await coordinator.install(target: .ssh(host: "buildbox"), agentID: "custom")
+        }
+        #expect(await recorder.localAgentIDs.isEmpty)
+        #expect(await recorder.remoteRequests.isEmpty)
+    }
+
+    private func makeCoordinator(_ recorder: CoordinatorInstallRecorder) -> ACPAdapterInstallCoordinator {
+        ACPAdapterInstallCoordinator(
+            localInstall: { agentID in try await recorder.installLocal(agentID) },
+            remoteInstall: { host, descriptor in try await recorder.installRemote(host, descriptor) }
+        )
+    }
+}
+
+private enum CoordinatorTestError: Error {
+    case failed
+}
+
+private actor CoordinatorInstallRecorder {
+    private let delay: Duration
+    private var failuresRemaining: Int
+    private(set) var localAgentIDs: [String] = []
+    private(set) var remoteRequests: [String] = []
+    private var activeRemoteInstalls = 0
+    private(set) var maximumActiveRemoteInstalls = 0
+
+    init(delay: Duration = .zero, failuresRemaining: Int = 0) {
+        self.delay = delay
+        self.failuresRemaining = failuresRemaining
+    }
+
+    func installLocal(_ agentID: String) async throws {
+        localAgentIDs.append(agentID)
+    }
+
+    func installRemote(_ host: String, _ descriptor: ACPManagedAdapterDescriptor) async throws {
+        remoteRequests.append("\(host)|\(descriptor.agentID)")
+        activeRemoteInstalls += 1
+        maximumActiveRemoteInstalls = max(maximumActiveRemoteInstalls, activeRemoteInstalls)
+        defer { activeRemoteInstalls -= 1 }
+        if delay != .zero {
+            try await Task.sleep(for: delay)
+        }
+        if failuresRemaining > 0 {
+            failuresRemaining -= 1
+            throw CoordinatorTestError.failed
+        }
+    }
+}

--- a/AlasTests/ACP/Adapter/ACPAdapterTargetTests.swift
+++ b/AlasTests/ACP/Adapter/ACPAdapterTargetTests.swift
@@ -1,0 +1,40 @@
+import Testing
+@testable import Alas
+
+@Suite("ACPAdapterTarget")
+struct ACPAdapterTargetTests {
+    @Test("local and SSH targets have distinct identities")
+    func targetIdentity() {
+        let local = ACPAdapterTarget.local
+        let hostA = ACPAdapterTarget.ssh(host: "build-a")
+        let hostB = ACPAdapterTarget.ssh(host: "build-b")
+
+        #expect(local != hostA)
+        #expect(hostA != hostB)
+        #expect(Set([local, hostA, hostB]).count == 3)
+    }
+
+    @Test("storage keys are stable and include the target identity")
+    func stableStorageKeys() {
+        #expect(
+            ACPAdapterUpdateKey(target: .local, agentID: "codex").storageKey
+                == "v2|local|5:codex")
+        #expect(
+            ACPAdapterUpdateKey(
+                target: .ssh(host: "dev.user+ci@host:22"),
+                agentID: "codex"
+            ).storageKey == "v2|ssh|19:dev.user+ci@host:22|5:codex")
+    }
+
+    @Test("punctuation cannot create storage-key collisions")
+    func punctuationIsCollisionSafe() {
+        let keys = [
+            ACPAdapterUpdateKey(target: .ssh(host: "a|1:b"), agentID: "c/d"),
+            ACPAdapterUpdateKey(target: .ssh(host: "a"), agentID: "1:b|c/d"),
+            ACPAdapterUpdateKey(target: .ssh(host: "user@a:22"), agentID: "codex"),
+            ACPAdapterUpdateKey(target: .ssh(host: "user"), agentID: "a:22|codex"),
+        ].map(\.storageKey)
+
+        #expect(Set(keys).count == keys.count)
+    }
+}

--- a/AlasTests/ACP/Adapter/ACPAdapterUpdateStoreTests.swift
+++ b/AlasTests/ACP/Adapter/ACPAdapterUpdateStoreTests.swift
@@ -116,6 +116,71 @@ struct ACPAdapterUpdateStoreTests {
         #expect(await counter.value() == 1)
     }
 
+    @Test("checkOrCompute coalesces the same target and agent key")
+    func targetAwareCheckOrComputeCoalesces() async {
+        let store = ACPAdapterUpdateStore(
+            fileURL: tempFile(),
+            successTTL: 60, failureTTL: 60,
+            now: { Date() })
+        let key = ACPAdapterUpdateKey(target: .ssh(host: "build-a"), agentID: "codex")
+
+        actor Counter {
+            var n = 0
+            func inc() { n += 1 }
+            func value() -> Int { n }
+        }
+        let counter = Counter()
+
+        async let a = store.checkOrCompute(key: key) {
+            await counter.inc()
+            try? await Task.sleep(for: .milliseconds(50))
+            return .upToDate
+        }
+        async let b = store.checkOrCompute(key: key) {
+            await counter.inc()
+            try? await Task.sleep(for: .milliseconds(50))
+            return .upToDate
+        }
+
+        let results = await (a, b)
+        #expect(results.0 == .upToDate)
+        #expect(results.1 == .upToDate)
+        #expect(await counter.value() == 1)
+    }
+
+    @Test("checkOrCompute runs independently for the same agent on two SSH hosts")
+    func targetAwareCheckOrComputeIsIndependent() async {
+        let store = ACPAdapterUpdateStore(
+            fileURL: tempFile(),
+            successTTL: 60, failureTTL: 60,
+            now: { Date() })
+        let hostA = ACPAdapterUpdateKey(target: .ssh(host: "build-a"), agentID: "codex")
+        let hostB = ACPAdapterUpdateKey(target: .ssh(host: "build-b"), agentID: "codex")
+
+        actor Counter {
+            var n = 0
+            func inc() { n += 1 }
+            func value() -> Int { n }
+        }
+        let counter = Counter()
+
+        async let a = store.checkOrCompute(key: hostA) {
+            await counter.inc()
+            try? await Task.sleep(for: .milliseconds(50))
+            return .upToDate
+        }
+        async let b = store.checkOrCompute(key: hostB) {
+            await counter.inc()
+            try? await Task.sleep(for: .milliseconds(50))
+            return .available(current: "1", latest: "2")
+        }
+
+        let results = await (a, b)
+        #expect(results.0 == .upToDate)
+        #expect(results.1 == .available(current: "1", latest: "2"))
+        #expect(await counter.value() == 2)
+    }
+
     @Test("corrupt on-disk JSON is treated as missing, not fatal")
     func corruptFileIsRecovered() async throws {
         let url = tempFile()
@@ -143,5 +208,107 @@ struct ACPAdapterUpdateStoreTests {
         let b = ACPAdapterUpdateStore(fileURL: url, successTTL: 60, failureTTL: 60, now: now)
         #expect(await b.read(agentID: "claude") == .available(current: "1", latest: "2"))
         #expect(await b.isDismissed(agentID: "claude", latest: "2"))
+    }
+
+    @Test("remote target state persists across store instances")
+    func remoteStatePersistsAcrossInstances() async {
+        let url = tempFile()
+        let now = { Date() }
+        let key = ACPAdapterUpdateKey(target: .ssh(host: "dev.user@host:22"), agentID: "codex")
+        let a = ACPAdapterUpdateStore(fileURL: url, successTTL: 60, failureTTL: 60, now: now)
+        await a.write(key: key, state: .available(current: "1", latest: "2"))
+        await a.dismiss(key: key, latest: "2")
+
+        let b = ACPAdapterUpdateStore(fileURL: url, successTTL: 60, failureTTL: 60, now: now)
+        #expect(await b.read(key: key) == .available(current: "1", latest: "2"))
+        #expect(await b.isDismissed(key: key, latest: "2"))
+        #expect(await b.read(key: .init(target: .local, agentID: "codex")) == nil)
+    }
+
+    @Test("cache entries are isolated by target")
+    func cacheIsTargetIsolated() async {
+        let store = ACPAdapterUpdateStore(
+            fileURL: tempFile(),
+            successTTL: 60, failureTTL: 60,
+            now: { Date() })
+        let local = ACPAdapterUpdateKey(target: .local, agentID: "codex")
+        let hostA = ACPAdapterUpdateKey(target: .ssh(host: "host-a"), agentID: "codex")
+        let hostB = ACPAdapterUpdateKey(target: .ssh(host: "host-b"), agentID: "codex")
+
+        await store.write(key: local, state: .upToDate)
+        await store.write(key: hostA, state: .available(current: "1", latest: "2"))
+
+        #expect(await store.read(key: local) == .upToDate)
+        #expect(await store.read(key: hostA) == .available(current: "1", latest: "2"))
+        #expect(await store.read(key: hostB) == nil)
+    }
+
+    @Test("dismissals are isolated by target")
+    func dismissalsAreTargetIsolated() async {
+        let store = ACPAdapterUpdateStore(
+            fileURL: tempFile(),
+            successTTL: 60, failureTTL: 60,
+            now: { Date() })
+        let local = ACPAdapterUpdateKey(target: .local, agentID: "codex")
+        let remote = ACPAdapterUpdateKey(target: .ssh(host: "dev@host:22"), agentID: "codex")
+
+        await store.dismiss(key: remote, latest: "1.2.3")
+
+        #expect(await store.isDismissed(key: remote, latest: "1.2.3"))
+        #expect(await store.isDismissed(key: local, latest: "1.2.3") == false)
+    }
+
+    @Test("TTL timestamps are independent by target")
+    func ttlIsTargetIsolated() async {
+        var clock = Date(timeIntervalSince1970: 1_000)
+        let store = ACPAdapterUpdateStore(
+            fileURL: tempFile(),
+            successTTL: 10, failureTTL: 5,
+            now: { clock })
+        let hostA = ACPAdapterUpdateKey(target: .ssh(host: "host-a"), agentID: "codex")
+        let hostB = ACPAdapterUpdateKey(target: .ssh(host: "host-b"), agentID: "codex")
+
+        await store.write(key: hostA, state: .upToDate)
+        clock = clock.addingTimeInterval(6)
+        await store.write(key: hostB, state: .upToDate)
+        clock = clock.addingTimeInterval(5)
+
+        #expect(await store.read(key: hostA) == nil)
+        #expect(await store.read(key: hostB) == .upToDate)
+    }
+
+    @Test("existing agent-only local entries remain readable and preserve dismissal state")
+    func readsLegacyLocalEntry() async throws {
+        let url = tempFile()
+        let checkedAt = Date(timeIntervalSince1970: 1_000)
+        let legacyJSON = """
+        {
+          "entries" : {
+            "codex" : {
+              "checkedAt" : "1970-01-01T00:16:40Z",
+              "dismissedLatest" : "2.0.0",
+              "state" : { "kind" : "upToDate" }
+            }
+          }
+        }
+        """
+        try #require(legacyJSON.data(using: .utf8)).write(to: url)
+        let store = ACPAdapterUpdateStore(
+            fileURL: url,
+            successTTL: 60, failureTTL: 60,
+            now: { checkedAt })
+        let local = ACPAdapterUpdateKey(target: .local, agentID: "codex")
+        let remote = ACPAdapterUpdateKey(target: .ssh(host: "host-a"), agentID: "codex")
+
+        #expect(await store.read(key: local) == .upToDate)
+        #expect(await store.isDismissed(key: local, latest: "2.0.0"))
+        #expect(await store.read(key: remote) == nil)
+
+        await store.write(key: local, state: .available(current: "1", latest: "2"))
+        #expect(await store.isDismissed(key: local, latest: "2.0.0"))
+
+        let persisted = try JSONSerialization.jsonObject(with: Data(contentsOf: url)) as? [String: Any]
+        let entries = persisted?["entries"] as? [String: Any]
+        #expect(entries?[local.storageKey] != nil)
     }
 }

--- a/AlasTests/ACP/Adapter/ACPAdapterVersionCheckerTests.swift
+++ b/AlasTests/ACP/Adapter/ACPAdapterVersionCheckerTests.swift
@@ -4,6 +4,27 @@ import Testing
 
 @Suite("ACPAdapterVersionChecker")
 struct ACPAdapterVersionCheckerTests {
+    private actor RemoteCalls {
+        struct Call: Equatable {
+            let host: String
+            let cwd: String?
+            let command: String
+            let pathPolicy: SSHCommand.PathPolicy
+        }
+
+        private(set) var values: [Call] = []
+
+        func append(_ call: Call) {
+            values.append(call)
+        }
+    }
+
+    private let remoteEnvironment = ACPRemoteNodeEnvironment(
+        npmPath: "/opt/node/bin/npm",
+        nodePath: "/opt/node/bin/node",
+        binDirectory: "/opt/node/bin"
+    )
+
     private func checker(
         status: Int32 = 0,
         stdout: String = "",
@@ -117,8 +138,8 @@ struct ACPAdapterVersionCheckerTests {
         #expect(r == .unknown)
     }
 
-    @Test("runner is invoked with `npm outdated -g <pkg> --json`")
-    func passesNpmArgs() async {
+    @Test("local runner argv remains exactly `npm outdated -g <pkg> --json`")
+    func localArgvIsUnchanged() async {
         var captured: [String] = []
         let c = ACPAdapterVersionChecker(
             timeout: 5,
@@ -128,6 +149,79 @@ struct ACPAdapterVersionCheckerTests {
             })
         _ = await c.check(packageName: "pi-acp")
         #expect(captured == ["npm", "outdated", "-g", "pi-acp", "--json"])
+    }
+
+    @Test("remote managed package uses its private prefix and resolved Node environment")
+    func remoteManagedPrefixCommand() async {
+        let calls = RemoteCalls()
+        let json = #"{"@agentclientprotocol/codex-acp":{"current":"1.0.0","latest":"1.1.0"}}"#
+        let checker = ACPAdapterVersionChecker(
+            remoteRunner: { host, cwd, command, pathPolicy in
+                await calls.append(.init(host: host, cwd: cwd, command: command, pathPolicy: pathPolicy))
+                let count = await calls.values.count
+                return count == 1
+                    ? ProcessResult(exitCode: ACPAdapterVersionChecker.managedSourceExitCode, stdout: "", stderr: "")
+                    : ProcessResult(exitCode: 1, stdout: json, stderr: "")
+            },
+            nodeResolver: { _ in remoteEnvironment }
+        )
+
+        let result = await checker.check(host: "dev@example", descriptor: .codex)
+        let recorded = await calls.values
+
+        #expect(result == .available(current: "1.0.0", latest: "1.1.0"))
+        #expect(recorded.count == 2)
+        #expect(recorded.allSatisfy { $0.host == "dev@example" && $0.cwd == nil && $0.pathPolicy == .inherited })
+        #expect(recorded[0].command.contains("$prefix/lib/node_modules/$package"))
+        #expect(recorded[1].command == """
+        PATH='/opt/node/bin':"$PATH"
+        export PATH
+        prefix=$HOME/.alas/acp/codex
+        '/opt/node/bin/npm' outdated -g '@agentclientprotocol/codex-acp' --json --prefix "$prefix"
+        """)
+    }
+
+    @Test("remote absent managed package falls back to the global command")
+    func remoteGlobalFallbackCommand() async {
+        let calls = RemoteCalls()
+        let checker = ACPAdapterVersionChecker(
+            remoteRunner: { host, cwd, command, pathPolicy in
+                await calls.append(.init(host: host, cwd: cwd, command: command, pathPolicy: pathPolicy))
+                let count = await calls.values.count
+                return count == 1
+                    ? ProcessResult(exitCode: ACPAdapterVersionChecker.globalSourceExitCode, stdout: "", stderr: "")
+                    : ProcessResult(exitCode: 0, stdout: "{}", stderr: "")
+            },
+            nodeResolver: { _ in remoteEnvironment }
+        )
+
+        let result = await checker.check(host: "build-host", descriptor: .pi)
+        let recorded = await calls.values
+
+        #expect(result == .upToDate)
+        #expect(recorded.count == 2)
+        #expect(recorded[1].command == """
+        PATH='/opt/node/bin':"$PATH"
+        export PATH
+        '/opt/node/bin/npm' outdated -g 'pi-acp' --json
+        """)
+    }
+
+    @Test("remote registry failure is unknown")
+    func remoteRegistryFailureIsUnknown() async {
+        let calls = RemoteCalls()
+        let checker = ACPAdapterVersionChecker(
+            remoteRunner: { host, cwd, command, pathPolicy in
+                await calls.append(.init(host: host, cwd: cwd, command: command, pathPolicy: pathPolicy))
+                let count = await calls.values.count
+                return count == 1
+                    ? ProcessResult(exitCode: ACPAdapterVersionChecker.globalSourceExitCode, stdout: "", stderr: "")
+                    : ProcessResult(exitCode: 2, stdout: "", stderr: "registry unavailable")
+            },
+            nodeResolver: { _ in remoteEnvironment }
+        )
+
+        #expect(await checker.check(host: "offline-host", descriptor: .claude) == .unknown)
     }
 }
 

--- a/AlasTests/ACP/Adapter/ACPManagedAdapterDescriptorTests.swift
+++ b/AlasTests/ACP/Adapter/ACPManagedAdapterDescriptorTests.swift
@@ -1,0 +1,40 @@
+import Testing
+@testable import Alas
+
+@Suite("ACP managed adapter descriptors")
+struct ACPManagedAdapterDescriptorTests {
+    @Test("catalog contains the adapters Alas manages")
+    func catalogContainsManagedAdapters() throws {
+        let claude = try #require(ACPManagedAdapterDescriptor.descriptor(for: "claude"))
+        #expect(claude.packageName == "@agentclientprotocol/claude-agent-acp")
+        #expect(claude.binaryName == "claude-agent-acp")
+        #expect(claude.legacyPackageNames == ["@zed-industries/claude-code-acp"])
+
+        let codex = try #require(ACPManagedAdapterDescriptor.descriptor(for: "codex"))
+        #expect(codex.packageName == "@agentclientprotocol/codex-acp")
+        #expect(codex.binaryName == "codex-acp")
+        #expect(codex.legacyPackageNames == ["@zed-industries/codex-acp"])
+
+        let pi = try #require(ACPManagedAdapterDescriptor.descriptor(for: "pi"))
+        #expect(pi.packageName == "pi-acp")
+        #expect(pi.binaryName == "pi-acp")
+        #expect(pi.legacyPackageNames.isEmpty)
+    }
+
+    @Test("unmanaged agents have no descriptor")
+    func unmanagedAgentsHaveNoDescriptor() {
+        for agentID in ["gemini", "opencode", "cursor-agent", "copilot"] {
+            #expect(ACPManagedAdapterDescriptor.descriptor(for: agentID) == nil)
+        }
+    }
+
+    @Test("launch catalog uses descriptor package and binary names")
+    func launchCatalogMatchesDescriptors() throws {
+        for agentID in ["claude", "codex", "pi"] {
+            let descriptor = try #require(ACPManagedAdapterDescriptor.descriptor(for: agentID))
+            let spec = try #require(ACPLaunchCatalog.spec(for: agentID))
+            #expect(spec.command == descriptor.binaryName)
+            #expect(spec.npmPackageName == descriptor.packageName)
+        }
+    }
+}

--- a/AlasTests/ACP/Adapter/ClaudeCodeACPInstallerTests.swift
+++ b/AlasTests/ACP/Adapter/ClaudeCodeACPInstallerTests.swift
@@ -12,9 +12,8 @@ struct ClaudeCodeACPInstallerTests {
             return (status: 0, stderr: "")
         })
         try? await installer.install()
-        #expect(capturedCommand.contains("npm"))
-        #expect(capturedCommand.contains("install"))
-        #expect(capturedCommand.contains("-g"))
-        #expect(capturedCommand.contains("@agentclientprotocol/claude-agent-acp"))
+        #expect(capturedCommand == [
+            "npm", "install", "-g", "@agentclientprotocol/claude-agent-acp",
+        ])
     }
 }

--- a/AlasTests/ACP/Adapter/PiACPInstallerTests.swift
+++ b/AlasTests/ACP/Adapter/PiACPInstallerTests.swift
@@ -12,9 +12,6 @@ struct PiACPInstallerTests {
             return (status: 0, stderr: "")
         })
         try? await installer.install()
-        #expect(capturedCommand.contains("npm"))
-        #expect(capturedCommand.contains("install"))
-        #expect(capturedCommand.contains("-g"))
-        #expect(capturedCommand.contains("pi-acp"))
+        #expect(capturedCommand == ["npm", "install", "-g", "pi-acp"])
     }
 }

--- a/AlasTests/ACP/Session/ACPSessionManagerAttachRestoreTests.swift
+++ b/AlasTests/ACP/Session/ACPSessionManagerAttachRestoreTests.swift
@@ -830,6 +830,92 @@ struct ACPSessionManagerAttachRestoreTests {
         #expect(session.contextRestoreWarning == nil)
     }
 
+    @Test("remote managed adapter absence maps to needs setup")
+    func remoteManagedAdapterAbsenceMapsToNeedsSetup() async throws {
+        let root = "/srv/task4-missing-\(UUID().uuidString)"
+        RemoteHostRegistry.shared.register(root: root, host: "devbox")
+        defer { RemoteHostRegistry.shared.unregister(root: root) }
+        let store = try ACPSessionStore(path: tmpStorePath())
+        let manager = ACPSessionManager(
+            worktreeId: "wt",
+            worktreePath: root,
+            store: store,
+            remoteAdapterResolver: { _, _, _ in
+                .missing(reason: "codex-acp is not installed on devbox.")
+            }
+        )
+        let session = manager.createSession(agentId: "codex")
+
+        await manager.attach(to: session.id, freshlyCreated: false)
+
+        #expect(session.setupState == .needsSetup(reason: "codex-acp is not installed on devbox."))
+        #expect(session.agentState == .failed("codex-acp is not installed on devbox."))
+    }
+
+    @Test("remote prerequisite failure maps to setup error")
+    func remotePrerequisiteFailureMapsToSetupError() async throws {
+        let root = "/srv/task4-error-\(UUID().uuidString)"
+        RemoteHostRegistry.shared.register(root: root, host: "devbox")
+        defer { RemoteHostRegistry.shared.unregister(root: root) }
+        let store = try ACPSessionStore(path: tmpStorePath())
+        let manager = ACPSessionManager(
+            worktreeId: "wt",
+            worktreePath: root,
+            store: store,
+            remoteAdapterResolver: { _, _, _ in
+                .error(message: "Node.js and npm are unavailable.")
+            }
+        )
+        let session = manager.createSession(agentId: "codex")
+
+        await manager.attach(to: session.id, freshlyCreated: false)
+
+        #expect(session.setupState == .setupError(reason: "Node.js and npm are unavailable."))
+        #expect(session.agentState == .failed("Node.js and npm are unavailable."))
+    }
+
+    @Test("remote setup resolution is reused for absolute launch")
+    func remoteSetupResolutionIsReusedForAbsoluteLaunch() async throws {
+        let root = "/srv/task4-ready-\(UUID().uuidString)"
+        RemoteHostRegistry.shared.register(root: root, host: "devbox")
+        defer { RemoteHostRegistry.shared.unregister(root: root) }
+        let store = try ACPSessionStore(path: tmpStorePath())
+        let client = ACPMockClient()
+        scriptInitialize(client)
+        scriptSessionResult(client, method: "session/new", sessionId: "remote-new")
+        final class Capture {
+            var resolverCalls = 0
+            var launchSpec: ACPLaunchSpec?
+        }
+        let capture = Capture()
+        let manager = ACPSessionManager(
+            worktreeId: "wt",
+            worktreePath: root,
+            store: store,
+            remoteAdapterResolver: { _, descriptor, _ in
+                capture.resolverCalls += 1
+                #expect(descriptor == .codex)
+                return .ready(.init(
+                    adapterPath: "/home/dev/.alas/acp/codex/bin/codex-acp",
+                    nodeBinDirectory: "/home/dev/node/v22/bin"
+                ))
+            },
+            connectionFactory: { spec, host, _ in
+                #expect(host == "devbox")
+                capture.launchSpec = spec
+                return ACPConnection(client: client)
+            }
+        )
+        let session = manager.createSession(agentId: "codex")
+
+        await manager.attach(to: session.id, freshlyCreated: true)
+
+        #expect(capture.resolverCalls == 1)
+        #expect(capture.launchSpec?.command == "/home/dev/.alas/acp/codex/bin/codex-acp")
+        #expect(capture.launchSpec?.remoteNodeBinDirectory == "/home/dev/node/v22/bin")
+        #expect(session.setupState == .ready)
+    }
+
     @Test("load failure followed by new failure leaves stale warning cleared")
     func loadFailureFollowedByNewFailureLeavesStaleWarningCleared() async throws {
         let store = try ACPSessionStore(path: tmpStorePath())

--- a/AlasTests/ACP/UI/ACPSetupNudgeBannerModeTests.swift
+++ b/AlasTests/ACP/UI/ACPSetupNudgeBannerModeTests.swift
@@ -12,6 +12,39 @@ struct ACPSetupNudgeBannerModeTests {
         #expect(copy == "Claude Code requires the ACP adapter to be installed.")
     }
 
+    @Test("remote copy names the SSH host")
+    func remoteHostCopy() {
+        #expect(ACPSetupNudgeBannerCopy.idleMessage(
+            mode: .install,
+            agentDisplayName: "Codex",
+            targetHost: "mini.lan"
+        ) == "Codex requires the ACP adapter to be installed on mini.lan.")
+        #expect(ACPSetupNudgeBannerCopy.installingMessage(
+            mode: .update(current: "1.0.0", latest: "1.1.0"),
+            agentDisplayName: "Codex",
+            targetHost: "mini.lan"
+        ) == "Updating Codex adapter on mini.lan…")
+        #expect(ACPSetupNudgeBannerCopy.installedMessage(
+            mode: .install,
+            agentDisplayName: "Codex",
+            targetHost: "mini.lan"
+        ) == "Codex adapter installed on mini.lan — connecting…")
+    }
+
+    @Test("setup dismissals are isolated by adapter target")
+    func targetAwareDismissals() {
+        let local = ACPAdapterUpdateKey(target: .local, agentID: "codex")
+        let hostA = ACPAdapterUpdateKey(target: .ssh(host: "host-a"), agentID: "codex")
+        let hostB = ACPAdapterUpdateKey(target: .ssh(host: "host-b"), agentID: "codex")
+
+        let values = [ACPSetupNudgeDismissal.storageKey(for: hostA)]
+        #expect(ACPSetupNudgeDismissal.isDismissed(values, key: hostA))
+        #expect(!ACPSetupNudgeDismissal.isDismissed(values, key: hostB))
+        #expect(!ACPSetupNudgeDismissal.isDismissed(values, key: local))
+        #expect(ACPSetupNudgeDismissal.isDismissed(["codex"], key: local))
+        #expect(!ACPSetupNudgeDismissal.isDismissed(["codex"], key: hostA))
+    }
+
     @Test("update mode idle copy shows both versions")
     func updateIdleCopy() {
         let copy = ACPSetupNudgeBannerCopy.idleMessage(

--- a/AlasTests/SSH/ACPRemoteAdapterInstallerTests.swift
+++ b/AlasTests/SSH/ACPRemoteAdapterInstallerTests.swift
@@ -1,0 +1,193 @@
+import Foundation
+import Testing
+@testable import Alas
+
+@Suite("ACPRemoteAdapterInstaller")
+struct ACPRemoteAdapterInstallerTests {
+    private let environment = ACPRemoteNodeEnvironment(
+        npmPath: "/opt/node 22/bin/npm",
+        nodePath: "/opt/node 22/bin/node",
+        binDirectory: "/opt/node 22/bin"
+    )
+
+    @Test("install uses a unique private staging prefix and pinned Node environment")
+    func stagedInstallCommand() async throws {
+        let runner = RemoteInstallRunner(results: [success(), success()])
+        let management = makeManagement(runner)
+
+        try await management.install(host: "buildbox", descriptor: .codex)
+        try await management.install(host: "buildbox", descriptor: .codex)
+
+        let commands = await runner.commands
+        #expect(commands.count == 2)
+        #expect(commands[0] != commands[1])
+        #expect(await runner.timeouts == [
+            ACPRemoteAdapterManagement.installTimeout,
+            ACPRemoteAdapterManagement.installTimeout,
+        ])
+        let command = commands[0]
+        #expect(command.contains("PATH='/opt/node 22/bin':\"$PATH\""))
+        #expect(command.contains("'/opt/node 22/bin/npm' --prefix \"$stage\" install -g '@agentclientprotocol/codex-acp'"))
+        #expect(command.contains("staging_root=$HOME/.alas/acp/.staging"))
+        #expect(command.contains("live=$HOME/.alas/acp/'codex'"))
+        #expect(command.contains("stage=\"$staging_root/codex-"))
+        #expect(command.contains("uninstall -g '@zed-industries/codex-acp' >/dev/null 2>&1 || :"))
+        #expect(command.contains("[ -d \"$stage/lib/node_modules/$package\" ]"))
+        #expect(command.contains("[ -x \"$stage/bin/$binary\" ]"))
+        #expect(command.contains("trap cleanup_stage EXIT"))
+        #expect(command.contains("lock=\"$staging_root/.locks/codex.lock\""))
+        #expect(command.contains("acquire_promotion_lock || exit 43"))
+        #expect(command.contains("mkdir \"$lock\""))
+        #expect(command.contains("\"$$\" > \"$lock/pid\""))
+        #expect(command.contains("rm -f \"$lock/pid\" >/dev/null 2>&1 || :"))
+        #expect(command.contains("rmdir \"$lock\" >/dev/null 2>&1 || :"))
+        #expect(command.contains("owner=$(cat \"$lock/pid\" 2>/dev/null || :)"))
+        #expect(command.contains("kill -0 \"$owner\" 2>/dev/null"))
+        #expect(command.contains("was interrupted. Remove $lock"))
+        #expect(!command.contains("rm -rf \"$lock\""))
+    }
+
+    @Test("promotion transaction backs up, validates, rolls back, then cleans backup")
+    func promotionTransactionOrder() throws {
+        let command = ACPRemoteAdapterManagement.installCommand(
+            descriptor: .claude,
+            environment: environment,
+            transactionID: "transaction-1"
+        )
+
+        let backup = try #require(command.range(of: "mv \"$live\" \"$backup\""))
+        let lock = try #require(command.range(of: "acquire_promotion_lock || exit 43"))
+        let promotion = try #require(command.range(of: "mv \"$stage\" \"$live\""))
+        let finalValidation = try #require(command.range(of: "[ ! -d \"$live/lib/node_modules/$package\" ]"))
+        let rollback = try #require(command.range(
+            of: "mv \"$backup\" \"$live\" || exit 41",
+            range: finalValidation.upperBound..<command.endIndex
+        ))
+        let backupCleanup = try #require(command.range(of: "rm -rf \"$backup\" || exit 42"))
+
+        #expect(lock.lowerBound < backup.lowerBound)
+        #expect(backup.lowerBound < promotion.lowerBound)
+        #expect(promotion.lowerBound < finalValidation.lowerBound)
+        #expect(finalValidation.lowerBound < rollback.lowerBound)
+        #expect(rollback.lowerBound < backupCleanup.lowerBound)
+        #expect(command.contains("if ! mv \"$stage\" \"$live\"; then"))
+        #expect(command.contains("exit 39"))
+        #expect(command.contains("exit 40"))
+        #expect(command.contains("exit 41"))
+    }
+
+    @Test("transaction exit codes are reserved above discovery codes")
+    func transactionExitCodes() {
+        let codes: [Int32] = [
+            ACPRemoteAdapterManagement.stagingExitCode,
+            ACPRemoteAdapterManagement.npmInstallExitCode,
+            ACPRemoteAdapterManagement.stagedPackageExitCode,
+            ACPRemoteAdapterManagement.stagedBinaryExitCode,
+            ACPRemoteAdapterManagement.backupExitCode,
+            ACPRemoteAdapterManagement.promotionExitCode,
+            ACPRemoteAdapterManagement.promotedValidationExitCode,
+            ACPRemoteAdapterManagement.rollbackExitCode,
+            ACPRemoteAdapterManagement.backupCleanupExitCode,
+            ACPRemoteAdapterManagement.promotionLockExitCode,
+        ]
+        #expect(codes.allSatisfy { $0 > ACPRemoteAdapterManagement.corruptExitCode })
+        #expect(Set(codes).count == codes.count)
+    }
+
+    @Test("stderr is sanitized and bounded")
+    func boundedFailureDetail() async {
+        let stderr = "bad\u{0}detail" + String(repeating: "x", count: 5_000)
+        let runner = RemoteInstallRunner(results: [
+            ProcessResult(exitCode: ACPRemoteAdapterManagement.npmInstallExitCode, stdout: "", stderr: stderr),
+        ])
+
+        do {
+            try await makeManagement(runner).install(host: "buildbox", descriptor: .pi)
+            Issue.record("Expected installation failure")
+        } catch let error as ACPRemoteAdapterInstallError {
+            guard case .executionFailure(let code, let detail) = error else {
+                Issue.record("Expected typed execution failure")
+                return
+            }
+            #expect(code == ACPRemoteAdapterManagement.npmInstallExitCode)
+            #expect(detail.count <= ACPRemoteAdapterManagement.maximumInstallDetailLength)
+            #expect(!detail.contains("\u{0}"))
+        } catch {
+            Issue.record("Unexpected error: \(error)")
+        }
+    }
+
+    @Test("SSH and prerequisite failures remain distinct")
+    func typedFailures() async {
+        let sshRunner = RemoteInstallRunner(results: [
+            ProcessResult(exitCode: 255, stdout: "", stderr: "Host key failed"),
+        ])
+        do {
+            try await makeManagement(sshRunner).install(host: "buildbox", descriptor: .pi)
+            Issue.record("Expected SSH failure")
+        } catch let error as ACPRemoteAdapterInstallError {
+            #expect(error == .connectionFailure("Host key failed"))
+        } catch {
+            Issue.record("Unexpected error: \(error)")
+        }
+
+        let management = ACPRemoteAdapterManagement(
+            runner: { _, _, _, _, _ in Self.success() },
+            nodeResolver: { _ in throw ACPRemoteNodeEnvironmentError.missing }
+        )
+        do {
+            try await management.install(host: "buildbox", descriptor: .pi)
+            Issue.record("Expected prerequisite failure")
+        } catch let error as ACPRemoteAdapterInstallError {
+            guard case .prerequisite = error else {
+                Issue.record("Expected prerequisite error")
+                return
+            }
+        } catch {
+            Issue.record("Unexpected error: \(error)")
+        }
+    }
+
+    private func makeManagement(_ runner: RemoteInstallRunner) -> ACPRemoteAdapterManagement {
+        ACPRemoteAdapterManagement(
+            runner: { host, cwd, command, pathPolicy, timeout in
+                await runner.run(
+                    host: host,
+                    cwd: cwd,
+                    command: command,
+                    pathPolicy: pathPolicy,
+                    timeout: timeout
+                )
+            },
+            nodeResolver: { _ in environment }
+        )
+    }
+
+    private static func success() -> ProcessResult {
+        ProcessResult(exitCode: 0, stdout: "", stderr: "")
+    }
+
+    private func success() -> ProcessResult { Self.success() }
+}
+
+private actor RemoteInstallRunner {
+    private var results: [ProcessResult]
+    private(set) var commands: [String] = []
+    private(set) var timeouts: [TimeInterval] = []
+
+    init(results: [ProcessResult]) {
+        self.results = results
+    }
+
+    func run(
+        host: String,
+        cwd: String?,
+        command: String,
+        pathPolicy: SSHCommand.PathPolicy,
+        timeout: TimeInterval
+    ) -> ProcessResult {
+        commands.append(command)
+        timeouts.append(timeout)
+        return results.removeFirst()
+    }
+}

--- a/AlasTests/SSH/ACPRemoteAdapterManagementTests.swift
+++ b/AlasTests/SSH/ACPRemoteAdapterManagementTests.swift
@@ -1,0 +1,335 @@
+import Foundation
+import Testing
+@testable import Alas
+
+struct ACPRemoteAdapterManagementTests {
+    private let environment = ACPRemoteNodeEnvironment(
+        npmPath: "/opt/node/bin/npm",
+        nodePath: "/opt/node/bin/node",
+        binDirectory: "/opt/node/bin"
+    )
+
+    @Test func managedAdapterWinsWithoutNpm() async {
+        let runner = AdapterProbeRunner(results: [
+            .init(exitCode: 0, stdout: taggedReady(
+                adapter: "/home/dev/.alas/acp/codex/bin/codex-acp",
+                nodeBin: "/home/dev/.nvm/versions/node/v22/bin"
+            ), stderr: ""),
+        ])
+        let management = ACPRemoteAdapterManagement(
+            runner: { host, cwd, command, pathPolicy, _ in
+                await runner.run(host: host, cwd: cwd, command: command, pathPolicy: pathPolicy)
+            },
+            nodeResolver: { _ in throw ACPRemoteNodeEnvironmentError.missing }
+        )
+
+        let resolution = await management.resolve(
+            host: "devbox",
+            descriptor: .codex,
+            setupCheck: .npxPackage(name: ACPManagedAdapterDescriptor.codex.packageName)
+        )
+
+        #expect(resolution == .ready(.init(
+            adapterPath: "/home/dev/.alas/acp/codex/bin/codex-acp",
+            nodeBinDirectory: "/home/dev/.nvm/versions/node/v22/bin"
+        )))
+        #expect(await runner.callCount == 1)
+    }
+
+    @Test func managedPrefixTakesPrecedenceOverGlobalAdapter() async {
+        let runner = AdapterProbeRunner(results: [
+            .init(exitCode: 0, stdout: taggedReady(
+                adapter: "/home/dev/.alas/acp/claude/bin/claude-agent-acp",
+                nodeBin: "/managed/node/bin"
+            ), stderr: ""),
+            .init(exitCode: 0, stdout: taggedReady(
+                adapter: "/usr/local/bin/claude-agent-acp",
+                nodeBin: "/global/node/bin"
+            ), stderr: ""),
+        ])
+        let management = makeManagement(runner: runner)
+
+        let resolution = await management.resolve(
+            host: "devbox",
+            descriptor: .claude,
+            setupCheck: managedCheck(.claude)
+        )
+
+        #expect(resolution == .ready(.init(
+            adapterPath: "/home/dev/.alas/acp/claude/bin/claude-agent-acp",
+            nodeBinDirectory: "/managed/node/bin"
+        )))
+        #expect(await runner.callCount == 1)
+    }
+
+    @Test func matchingGlobalPackageResolvesAbsoluteBinary() async {
+        let runner = AdapterProbeRunner(results: [
+            absentResult(),
+            .init(exitCode: 0, stdout: taggedReady(
+                adapter: "/opt/node/bin/pi-acp",
+                nodeBin: "/opt/node/bin"
+            ), stderr: ""),
+        ])
+        let management = makeManagement(runner: runner)
+
+        let resolution = await management.resolve(
+            host: "devbox",
+            descriptor: .pi,
+            setupCheck: managedCheck(.pi)
+        )
+
+        #expect(resolution == .ready(.init(
+            adapterPath: "/opt/node/bin/pi-acp",
+            nodeBinDirectory: "/opt/node/bin"
+        )))
+        let globalCommand = try? #require(await runner.commands.last)
+        #expect(globalCommand?.contains("'pi-acp'") == true)
+        #expect(globalCommand?.contains("'pi-acp'") == true)
+        #expect(globalCommand?.contains("command -v 'pi-acp'") == true)
+    }
+
+    @Test func allowedPathFallbackComesAfterMatchingPackageCheck() async throws {
+        let runner = AdapterProbeRunner(results: [absentResult(), missingResult()])
+        let management = makeManagement(runner: runner)
+
+        _ = await management.resolve(
+            host: "devbox",
+            descriptor: .claude,
+            setupCheck: managedCheck(.claude)
+        )
+
+        let command = try #require(await runner.commands.last)
+        let packageCheck = try #require(command.range(of: "[ -d \"$root/$package\" ]"))
+        let pathCheck = try #require(command.range(of: "command -v 'claude-agent-acp'"))
+        #expect(packageCheck.lowerBound < pathCheck.lowerBound)
+    }
+
+    @Test func globalProbeQuotesNodeBinBeforeEmittingReadyRecord() {
+        let environment = ACPRemoteNodeEnvironment(
+            npmPath: "/tmp/$(touch pwn)/bin/npm",
+            nodePath: "/tmp/$(touch pwn)/bin/node",
+            binDirectory: "/tmp/$(touch pwn)/bin"
+        )
+
+        let command = ACPRemoteAdapterManagement.globalProbeCommand(
+            descriptor: .claude,
+            setupCheck: managedCheck(.claude),
+            environment: environment
+        )
+
+        #expect(command.contains("node_bin='/tmp/$(touch pwn)/bin'"))
+        #expect(command.contains("\"nodeBin=$node_bin\""))
+        #expect(!command.contains("\"nodeBin=/tmp/$(touch pwn)/bin\""))
+    }
+
+    @Test func codexRejectsStalePathOnlyBinary() async throws {
+        let runner = AdapterProbeRunner(results: [absentResult(), missingResult()])
+        let management = makeManagement(runner: runner)
+
+        let resolution = await management.resolve(
+            host: "devbox",
+            descriptor: .codex,
+            setupCheck: .npxPackage(name: ACPManagedAdapterDescriptor.codex.packageName)
+        )
+
+        guard case .missing = resolution else {
+            Issue.record("Expected a confirmed missing adapter")
+            return
+        }
+        let command = try #require(await runner.commands.last)
+        #expect(!command.contains("command -v 'codex-acp'"))
+        #expect(command.contains("'@agentclientprotocol/codex-acp'"))
+    }
+
+    @Test func confirmedAbsenceWithUsablePrerequisitesIsMissing() async {
+        let runner = AdapterProbeRunner(results: [absentResult(), missingResult()])
+        let resolution = await makeManagement(runner: runner).resolve(
+            host: "devbox",
+            descriptor: .codex,
+            setupCheck: .npxPackage(name: ACPManagedAdapterDescriptor.codex.packageName)
+        )
+
+        #expect(resolution == .missing(reason: "codex-acp is not installed on devbox."))
+    }
+
+    @Test func missingNodeOrNpmIsAnError() async {
+        let runner = AdapterProbeRunner(results: [absentResult()])
+        let management = ACPRemoteAdapterManagement(
+            runner: { host, cwd, command, pathPolicy, _ in
+                await runner.run(host: host, cwd: cwd, command: command, pathPolicy: pathPolicy)
+            },
+            nodeResolver: { _ in throw ACPRemoteNodeEnvironmentError.missing }
+        )
+
+        let resolution = await management.resolve(
+            host: "devbox",
+            descriptor: .codex,
+            setupCheck: .npxPackage(name: ACPManagedAdapterDescriptor.codex.packageName)
+        )
+
+        guard case .error(let message) = resolution else {
+            Issue.record("Expected prerequisite failure")
+            return
+        }
+        #expect(message.contains("Node.js and npm"))
+    }
+
+    @Test func pathOnlyAdapterResolvesWhenNpmIsUnavailable() async {
+        let runner = AdapterProbeRunner(results: [
+            absentResult(),
+            .init(exitCode: 0, stdout: taggedReady(
+                adapter: "/usr/local/bin/claude-agent-acp",
+                nodeBin: "/usr/local/bin"
+            ), stderr: ""),
+        ])
+        let management = ACPRemoteAdapterManagement(
+            runner: { host, cwd, command, pathPolicy, _ in
+                await runner.run(host: host, cwd: cwd, command: command, pathPolicy: pathPolicy)
+            },
+            nodeResolver: { _ in throw ACPRemoteNodeEnvironmentError.missing }
+        )
+
+        let resolution = await management.resolve(
+            host: "devbox",
+            descriptor: .claude,
+            setupCheck: managedCheck(.claude)
+        )
+
+        #expect(resolution == .ready(.init(
+            adapterPath: "/usr/local/bin/claude-agent-acp",
+            nodeBinDirectory: "/usr/local/bin"
+        )))
+        let command = try? #require(await runner.commands.last)
+        #expect(command?.contains("command -v 'claude-agent-acp'") == true)
+        #expect(command?.contains("command -v node") == true)
+        #expect(command?.contains("npm root -g") == false)
+        #expect(await runner.pathPolicies.last == .augmented)
+    }
+
+    @Test func sshFailureAndMalformedOutputAreErrors() async {
+        let sshRunner = AdapterProbeRunner(results: [
+            .init(exitCode: 255, stdout: "", stderr: "Host key verification failed"),
+        ])
+        let malformedRunner = AdapterProbeRunner(results: [
+            .init(exitCode: 0, stdout: "not tagged", stderr: ""),
+        ])
+
+        let ssh = await makeManagement(runner: sshRunner).resolve(
+            host: "devbox", descriptor: .pi, setupCheck: managedCheck(.pi)
+        )
+        let malformed = await makeManagement(runner: malformedRunner).resolve(
+            host: "devbox", descriptor: .pi, setupCheck: managedCheck(.pi)
+        )
+
+        #expect(ssh == .error(message: "Host key verification failed"))
+        guard case .error(let message) = malformed else {
+            Issue.record("Expected malformed output to be an error")
+            return
+        }
+        #expect(message.contains("malformed"))
+    }
+
+    @Test func corruptManagedPrefixDoesNotFallThrough() async {
+        let runner = AdapterProbeRunner(results: [
+            .init(
+                exitCode: ACPRemoteAdapterManagement.corruptExitCode,
+                stdout: taggedStatus("corrupt"),
+                stderr: ""
+            ),
+        ])
+        let resolution = await makeManagement(runner: runner).resolve(
+            host: "devbox", descriptor: .pi, setupCheck: managedCheck(.pi)
+        )
+
+        guard case .error(let message) = resolution else {
+            Issue.record("Expected corrupt prefix to be an error")
+            return
+        }
+        #expect(message.contains("managed"))
+        #expect(await runner.callCount == 1)
+    }
+
+    @Test func managedPathsAreAgentIsolated() {
+        #expect(ACPRemoteAdapterManagement.managedPrefix(for: .claude) == "$HOME/.alas/acp/claude")
+        #expect(ACPRemoteAdapterManagement.managedPrefix(for: .codex) == "$HOME/.alas/acp/codex")
+        #expect(ACPRemoteAdapterManagement.managedPrefix(for: .pi) == "$HOME/.alas/acp/pi")
+    }
+
+    @Test func managedProbePinsResolvedNodeDirectory() {
+        let command = ACPRemoteAdapterManagement.managedProbeCommand(
+            descriptor: .codex,
+            nodeBinDirectory: "/home/dev/.nvm/versions/node/v22/bin"
+        )
+
+        #expect(command.contains("node_bin='/home/dev/.nvm/versions/node/v22/bin'"))
+        #expect(command.contains("node=\"$node_bin/node\""))
+        #expect(!command.contains("command -v node"))
+    }
+
+    private func makeManagement(runner: AdapterProbeRunner) -> ACPRemoteAdapterManagement {
+        ACPRemoteAdapterManagement(
+            runner: { host, cwd, command, pathPolicy, _ in
+                await runner.run(host: host, cwd: cwd, command: command, pathPolicy: pathPolicy)
+            },
+            nodeResolver: { _ in environment }
+        )
+    }
+
+    private func managedCheck(_ descriptor: ACPManagedAdapterDescriptor) -> ACPSetupCheck {
+        .binaryOnPathOrNpmPackage(
+            binary: descriptor.binaryName,
+            npmPackage: descriptor.packageName
+        )
+    }
+}
+
+private func taggedReady(adapter: String, nodeBin: String) -> String {
+    ([ACPRemoteAdapterManagement.protocolBegin, "status=ready", "adapter=\(adapter)",
+      "nodeBin=\(nodeBin)", ACPRemoteAdapterManagement.protocolEnd]).joined(separator: "\n") + "\n"
+}
+
+private func taggedStatus(_ status: String) -> String {
+    ([ACPRemoteAdapterManagement.protocolBegin, "status=\(status)",
+      ACPRemoteAdapterManagement.protocolEnd]).joined(separator: "\n") + "\n"
+}
+
+private func absentResult() -> ProcessResult {
+    ProcessResult(
+        exitCode: ACPRemoteAdapterManagement.absentExitCode,
+        stdout: taggedStatus("absent"),
+        stderr: ""
+    )
+}
+
+private func missingResult() -> ProcessResult {
+    ProcessResult(
+        exitCode: ACPRemoteAdapterManagement.missingExitCode,
+        stdout: taggedStatus("missing"),
+        stderr: ""
+    )
+}
+
+private actor AdapterProbeRunner {
+    private var results: [ProcessResult]
+    private(set) var commands: [String] = []
+    private(set) var pathPolicies: [SSHCommand.PathPolicy] = []
+
+    init(results: [ProcessResult]) {
+        self.results = results
+    }
+
+    var callCount: Int { commands.count }
+
+    func run(
+        host: String,
+        cwd: String?,
+        command: String,
+        pathPolicy: SSHCommand.PathPolicy
+    ) -> ProcessResult {
+        commands.append(command)
+        pathPolicies.append(pathPolicy)
+        return results.isEmpty
+            ? ProcessResult(exitCode: 99, stdout: "", stderr: "Unexpected probe")
+            : results.removeFirst()
+    }
+}

--- a/AlasTests/SSH/ACPRemoteLaunchTests.swift
+++ b/AlasTests/SSH/ACPRemoteLaunchTests.swift
@@ -30,6 +30,34 @@ struct ACPRemoteLaunchTests {
         #expect(script.contains("'codex-acp'"))
     }
 
+    @Test func resolvedAdapterPrependsExactNodeBinAndStillScrubsMarkers() {
+        let command = ACPRemoteLaunch.agentCommand(
+            command: "/home/dev/.alas/acp/codex/bin/codex-acp",
+            arguments: [],
+            nodeBinDirectory: "/home/dev/node versions/v22/bin"
+        )
+
+        #expect(command.hasPrefix("PATH='/home/dev/node versions/v22/bin':\"$PATH\" && export PATH && env "))
+        #expect(command.contains("-u CLAUDECODE"))
+        #expect(command.hasSuffix("'/home/dev/.alas/acp/codex/bin/codex-acp'"))
+    }
+
+    @Test func resolvedAdapterKeepsNodePathInCwdAndList() {
+        let invocation = ACPRemoteLaunch.channelInvocation(
+            host: "devbox",
+            worktreePath: "/srv/repo",
+            command: "codex-acp",
+            arguments: [],
+            nodeBinDirectory: "/managed/node/bin"
+        )
+
+        let script = invocation.args.last ?? ""
+        #expect(script.contains(
+            "cd '\\''/srv/repo'\\'' && PATH='\\''/managed/node/bin'\\'':\"$PATH\" && export PATH && env "
+        ))
+        #expect(!script.contains("cd '\\''/srv/repo'\\'' && PATH='\\''/managed/node/bin'\\'':\"$PATH\";"))
+    }
+
     @Test func setupProbeUsesFirstWordOfCommand() {
         #expect(ACPRemoteLaunch.setupProbeCommand(command: "gemini --experimental-acp")
             == "command -v 'gemini'")

--- a/AlasTests/SSH/ACPRemoteNodeEnvironmentTests.swift
+++ b/AlasTests/SSH/ACPRemoteNodeEnvironmentTests.swift
@@ -1,0 +1,221 @@
+import Foundation
+import Testing
+@testable import Alas
+
+struct ACPRemoteNodeEnvironmentTests {
+    @Test func discoveryUsesInheritedPathWithoutWorkingDirectory() async throws {
+        let recorder = NodeEnvironmentRunner(result: .resolved())
+        let resolver = ACPRemoteNodeEnvironmentResolver { host, cwd, command, pathPolicy in
+            await recorder.run(host: host, cwd: cwd, command: command, pathPolicy: pathPolicy)
+        }
+
+        let environment = try await resolver.resolve(host: "builder")
+
+        #expect(environment == ACPRemoteNodeEnvironment(
+            npmPath: "/opt/node/bin/npm",
+            nodePath: "/opt/node/bin/node",
+            binDirectory: "/opt/node/bin"
+        ))
+        let call = try #require(await recorder.call)
+        #expect(call.host == "builder")
+        #expect(call.cwd == nil)
+        #expect(call.pathPolicy == .inherited)
+        #expect(call.command == ACPRemoteNodeEnvironmentResolver.discoveryCommand)
+    }
+
+    @Test func discoveryCommandChecksPathBeforeKnownLocations() {
+        let command = ACPRemoteNodeEnvironmentResolver.discoveryCommand
+        let pathCheck = command.range(of: "path_npm=$(command -v npm")
+        let nvmCheck = command.range(of: "try_env_dir \"$NVM_BIN\"")
+        let homebrewCheck = command.range(of: "try_dir '/opt/homebrew/bin'")
+        #expect(pathCheck != nil)
+        #expect(nvmCheck != nil)
+        #expect(homebrewCheck != nil)
+        if let pathCheck, let nvmCheck, let homebrewCheck {
+            #expect(pathCheck.lowerBound < nvmCheck.lowerBound)
+            #expect(nvmCheck.lowerBound < homebrewCheck.lowerBound)
+        }
+    }
+
+    @Test func discoveryCommandCoversSupportedManagersAndCommonPaths() {
+        let command = ACPRemoteNodeEnvironmentResolver.discoveryCommand
+        for expected in [
+            "$NVM_BIN",
+            "$VOLTA_HOME/bin",
+            "$mise_root/shims",
+            "$asdf_root/shims",
+            "$volta_root/bin",
+            "$nvm_root/current/bin",
+            "$mise_root/installs/node",
+            "$asdf_root/installs/nodejs",
+            "$nvm_root/versions/node",
+            "$HOME/.local/bin",
+            "$HOME/.npm-global/bin",
+            "/opt/homebrew/bin",
+            "/usr/local/bin",
+            "/home/linuxbrew/.linuxbrew/bin",
+            "/usr/bin",
+        ] {
+            #expect(command.contains(expected), "Missing discovery candidate: \(expected)")
+        }
+        #expect(!command.contains("source "))
+        #expect(!command.contains("readlink"))
+        #expect(!command.contains("realpath"))
+        #expect(!command.contains("sort -V"))
+    }
+
+    @Test func discoveryCommandUsesPortableAwkAndRetriesIncompleteVersions() {
+        let command = ACPRemoteNodeEnvironmentResolver.discoveryCommand
+        #expect(command.contains("for (part = 1; part <= count; part++)"))
+        #expect(!command.contains("for (index ="))
+        #expect(command.contains("attempted=\u{27}|\u{27}"))
+        #expect(command.contains("attempted=\"${attempted}${best_version}|\""))
+    }
+
+    @Test func parsesPathsContainingSpacesAndEqualsSigns() async throws {
+        let result = ProcessResult.resolved(bin: "/Users/build tools/node=22/bin")
+        let resolver = resolver(returning: result)
+
+        let environment = try await resolver.resolve(host: "builder")
+
+        #expect(environment.binDirectory == "/Users/build tools/node=22/bin")
+        #expect(environment.npmPath == "/Users/build tools/node=22/bin/npm")
+    }
+
+    @Test func missingStatusAndReservedExitClassifyMissing() async {
+        let resolver = resolver(returning: ProcessResult(
+            exitCode: ACPRemoteNodeEnvironmentResolver.missingExitCode,
+            stdout: nodeEnvironmentTagged("status=missing"),
+            stderr: ""
+        ))
+        await expectError(.missing, from: resolver)
+    }
+
+    @Test func exit255ClassifiesConnectionFailureBeforeParsing() async {
+        let resolver = resolver(returning: ProcessResult(
+            exitCode: 255,
+            stdout: "not protocol output",
+            stderr: "  Host key verification failed.\n"
+        ))
+        await expectError(.connectionFailure("Host key verification failed."), from: resolver)
+    }
+
+    @Test func otherExitClassifiesExecutionFailure() async {
+        let resolver = resolver(returning: ProcessResult(
+            exitCode: 7,
+            stdout: nodeEnvironmentTagged("status=missing"),
+            stderr: "  awk failed\n"
+        ))
+        await expectError(.executionFailure(exitCode: 7, detail: "awk failed"), from: resolver)
+    }
+
+    @Test func thrownRunnerErrorClassifiesExecutionFailure() async {
+        struct SampleError: LocalizedError {
+            var errorDescription: String? { "process launch failed" }
+        }
+        let resolver = ACPRemoteNodeEnvironmentResolver { _, _, _, _ in
+            throw SampleError()
+        }
+        await expectError(
+            .executionFailure(exitCode: nil, detail: "process launch failed"),
+            from: resolver
+        )
+    }
+
+    @Test(arguments: [
+        "",
+        "noise\n" + nodeEnvironmentTagged("status=missing"),
+        nodeEnvironmentTagged("status=ok", "npm=/x/bin/npm", "node=/x/bin/node"),
+        nodeEnvironmentTagged("status=ok", "npm=relative/npm", "node=relative/node", "bin=relative"),
+        nodeEnvironmentTagged("status=ok", "npm=/x/bin/npm", "node=/other/bin/node", "bin=/x/bin"),
+        nodeEnvironmentTagged("status=ok", "npm=/x/bin/npm", "npm=/x/bin/npm", "node=/x/bin/node", "bin=/x/bin"),
+        nodeEnvironmentTagged("status=ok", "npm=/x/bin/npm", "node=/x/bin/node", "bin=/x/bin")
+            + "\n" + nodeEnvironmentTagged("status=ok", "npm=/y/bin/npm", "node=/y/bin/node", "bin=/y/bin"),
+        nodeEnvironmentTagged("status=ok", "npm=/x/bin/npm", "node=/x/bin/node", "bin=/x/bin", "extra=value"),
+        "ALAS_NODE_ENV_V1_BEGIN\r\nstatus=missing\r\nALAS_NODE_ENV_V1_END\r\n",
+    ])
+    func rejectsMalformedResolvedOutput(_ output: String) async {
+        let resolver = resolver(returning: ProcessResult(exitCode: 0, stdout: output, stderr: ""))
+        await expectError(.malformedOutput, from: resolver)
+    }
+
+    @Test(arguments: [
+        nodeEnvironmentTagged("status=ok", "npm=/x/bin/npm", "node=/x/bin/node", "bin=/x/bin"),
+        nodeEnvironmentTagged("status=missing", "extra=value"),
+        nodeEnvironmentTagged("status=missing", "status=missing"),
+        "status=missing\n",
+    ])
+    func rejectsMalformedMissingOutput(_ output: String) async {
+        let resolver = resolver(returning: ProcessResult(
+            exitCode: ACPRemoteNodeEnvironmentResolver.missingExitCode,
+            stdout: output,
+            stderr: ""
+        ))
+        await expectError(.malformedOutput, from: resolver)
+    }
+
+    private func resolver(returning result: ProcessResult) -> ACPRemoteNodeEnvironmentResolver {
+        ACPRemoteNodeEnvironmentResolver { _, _, _, _ in result }
+    }
+
+    private func expectError(
+        _ expected: ACPRemoteNodeEnvironmentError,
+        from resolver: ACPRemoteNodeEnvironmentResolver
+    ) async {
+        do {
+            _ = try await resolver.resolve(host: "builder")
+            Issue.record("Expected remote Node environment resolution to fail")
+        } catch let error as ACPRemoteNodeEnvironmentError {
+            #expect(error == expected)
+        } catch {
+            Issue.record("Unexpected error: \(error)")
+        }
+    }
+}
+
+private func nodeEnvironmentTagged(_ fields: String...) -> String {
+    ([ACPRemoteNodeEnvironmentResolver.protocolBegin] + fields + [
+        ACPRemoteNodeEnvironmentResolver.protocolEnd,
+    ]).joined(separator: "\n") + "\n"
+}
+
+private extension ProcessResult {
+    static func resolved(bin: String = "/opt/node/bin") -> ProcessResult {
+        ProcessResult(
+            exitCode: 0,
+            stdout: nodeEnvironmentTagged(
+                "status=ok",
+                "npm=\(bin)/npm",
+                "node=\(bin)/node",
+                "bin=\(bin)"
+            ),
+            stderr: ""
+        )
+    }
+}
+
+private actor NodeEnvironmentRunner {
+    struct Call: Sendable {
+        let host: String
+        let cwd: String?
+        let command: String
+        let pathPolicy: SSHCommand.PathPolicy
+    }
+
+    private(set) var call: Call?
+    private let result: ProcessResult
+
+    init(result: ProcessResult) {
+        self.result = result
+    }
+
+    func run(
+        host: String,
+        cwd: String?,
+        command: String,
+        pathPolicy: SSHCommand.PathPolicy
+    ) -> ProcessResult {
+        call = Call(host: host, cwd: cwd, command: command, pathPolicy: pathPolicy)
+        return result
+    }
+}

--- a/AlasTests/SSH/RemoteExecTests.swift
+++ b/AlasTests/SSH/RemoteExecTests.swift
@@ -18,6 +18,22 @@ struct RemoteExecTests {
         #expect(invocation.args == expected)
     }
 
+    @Test func inheritedPathInvocationOmitsAugmentedPrelude() {
+        let invocation = RemoteExec.invocation(
+            host: "devbox",
+            cwd: nil,
+            command: "command -v npm",
+            pathPolicy: .inherited
+        )
+        let expected = SSHCommand(host: "devbox", mode: .batch)
+            .argv(remoteScript: SSHCommand.remoteScript(
+                command: "command -v npm",
+                pathPolicy: .inherited
+            ))
+        #expect(invocation.args == expected)
+        #expect(invocation.args.last?.contains(".alas/bin") == false)
+    }
+
     @Test func exit255IsConnectionFailure() {
         #expect(RemoteExec.isConnectionFailure(exitCode: 255))
         #expect(!RemoteExec.isConnectionFailure(exitCode: 0))

--- a/AlasTests/SSH/SSHCommandTests.swift
+++ b/AlasTests/SSH/SSHCommandTests.swift
@@ -29,6 +29,25 @@ struct SSHCommandTests {
         #expect(script == "/bin/sh -c 'PATH=\"$HOME/.alas/bin:$HOME/.local/bin:$HOME/bin:/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:$PATH\"; export PATH; git --version'")
     }
 
+    @Test func inheritedPathPolicyOmitsAugmentedPathPrelude() {
+        let script = SSHCommand.remoteScript(
+            command: "command -v npm",
+            pathPolicy: .inherited
+        )
+        #expect(script == "/bin/sh -c 'command -v npm'")
+        #expect(!script.contains(".alas/bin"))
+    }
+
+    @Test func inheritedPathPolicyWithCwdStillUsesPOSIXShell() {
+        let script = SSHCommand.remoteScript(
+            cwd: "/srv/repo",
+            command: "command -v npm",
+            pathPolicy: .inherited
+        )
+        let innerCommand = "cd \(SSHCommand.shellQuote("/srv/repo")) && command -v npm"
+        #expect(script == "/bin/sh -c \(SSHCommand.shellQuote(innerCommand))")
+    }
+
     @Test func remoteScriptTopLevelIsSafeForNonPOSIXLoginShells() {
         let script = SSHCommand.remoteScript(command: "f='x'; [ -e \"$f\" ]")
         #expect(script.hasPrefix("/bin/sh -c "))


### PR DESCRIPTION
## Summary
- manage catalog ACP adapters on SSH hosts in isolated per-agent prefixes
- resolve one remote Node/npm environment for setup, install, updates, and launch
- surface host-aware install, update, retry, and target-isolated cache behavior

## Root Cause
Alas checked and launched ACP adapters on SSH hosts but its installers and update checks still ran only on the local Mac.

## Validation
- `xcodegen`
- focused ACP/SSH regression suite
- `xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -quiet build`\n- full test suite: 5,309 passed; the 8 opt-in localhost SSH integration tests require `ALAS_SSH_INTEGRATION=1`

Closes #768 