### PR TITLE
feat(changes): auto comparison-base mode (Auto · Branch upstream · Manual)

### DIFF
--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -266,6 +266,7 @@
 		38DCAD9DA4B9418906700A25 /* MergeView3Way.swift in Sources */ = {isa = PBXBuildFile; fileRef = 695C887147631ACF1FA73C3F /* MergeView3Way.swift */; };
 		38EB2BAA50A7B7B37DDE2A4C /* RightPaneStateBaseBranchTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6713F5A8712C0962BED1EFEA /* RightPaneStateBaseBranchTests.swift */; };
 		3910AEED9AC1888582616BEA /* FileTreeRowIndentationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 431BECA1461B76DF86BBFBDF /* FileTreeRowIndentationTests.swift */; };
+		392B71BE02DAAAEC07CFD528 /* BaseResolutionMapping.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF68BCA1222E7C06DA4AC595 /* BaseResolutionMapping.swift */; };
 		395276FB3018E0B9E68A7D81 /* ACPMockClientTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11BA9F25CB0A6A2BFDB390EE /* ACPMockClientTests.swift */; };
 		395A56C7C48EDDDE1F39F335 /* RemoteHostCapabilitiesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 843E7D6E8972C01B3DC924F2 /* RemoteHostCapabilitiesTests.swift */; };
 		395BC74AF07FD44D67DBE579 /* EditorOverlayPanel.swift in Sources */ = {isa = PBXBuildFile; fileRef = F6883364648BF4B9F5DA131F /* EditorOverlayPanel.swift */; };
@@ -859,6 +860,7 @@
 		B1665774383C03F0C0765A43 /* ACPMarkdownBlockCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = 70255847CE81CE85E0117A85 /* ACPMarkdownBlockCache.swift */; };
 		B1A6F39D02409339072EC164 /* HarnessDetector.swift in Sources */ = {isa = PBXBuildFile; fileRef = F9F85B92952C963DCF136315 /* HarnessDetector.swift */; };
 		B1CC27484E05C5B3DEB54857 /* MergeConflictMinimap.swift in Sources */ = {isa = PBXBuildFile; fileRef = E5788263AE679D146F9BF49C /* MergeConflictMinimap.swift */; };
+		B3240B739972444A6CB14F7C /* BaseResolutionMappingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 652C404D30685CB2FE79BD81 /* BaseResolutionMappingTests.swift */; };
 		B339F5B376407CFD88B0E7B8 /* ACPAttachmentMimeTypeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AD85FA11903B85EA889596A3 /* ACPAttachmentMimeTypeTests.swift */; };
 		B34227BF866AFDACB3194333 /* WorktreeCodableTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B94010802299E6AC5597E85 /* WorktreeCodableTests.swift */; };
 		B35BD3304D3A9EC5BABBC56E /* CommitRowTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6D46BDE72E52818061452ECB /* CommitRowTests.swift */; };
@@ -1740,6 +1742,7 @@
 		64CE9A3DB2C89A5B9C970ED3 /* EnvBuilderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EnvBuilderTests.swift; sourceTree = "<group>"; };
 		64E96E26D5F53F217BFD1F49 /* EditorBuffer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditorBuffer.swift; sourceTree = "<group>"; };
 		650B300A5337E2A9149CF083 /* UnionCanvasGeometry.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UnionCanvasGeometry.swift; sourceTree = "<group>"; };
+		652C404D30685CB2FE79BD81 /* BaseResolutionMappingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BaseResolutionMappingTests.swift; sourceTree = "<group>"; };
 		6561C6DA70F49EDBC69BA854 /* DiffInlineHighlighter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiffInlineHighlighter.swift; sourceTree = "<group>"; };
 		65A1EB96EBED0DEDCA5CD094 /* JSONRPCStdioTransport.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JSONRPCStdioTransport.swift; sourceTree = "<group>"; };
 		65B5815D9BE36D3F835B5456 /* DiffReviewFileSection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiffReviewFileSection.swift; sourceTree = "<group>"; };
@@ -2461,6 +2464,7 @@
 		FEB2EC20D23F9A4F50B1A6E3 /* TerminalPane.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TerminalPane.swift; sourceTree = "<group>"; };
 		FEC68B05B719B9235865027F /* ThreePaneSizing.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThreePaneSizing.swift; sourceTree = "<group>"; };
 		FED0AAD3FE0E143D409A3E8B /* AppStateRemoteWorktreePathTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppStateRemoteWorktreePathTests.swift; sourceTree = "<group>"; };
+		FF68BCA1222E7C06DA4AC595 /* BaseResolutionMapping.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BaseResolutionMapping.swift; sourceTree = "<group>"; };
 		FF71AF50DF50AA4158A96177 /* DiffContextExpansion.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiffContextExpansion.swift; sourceTree = "<group>"; };
 		FF741B889D6DC8B1F4EB350F /* ProcessGitDataTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProcessGitDataTests.swift; sourceTree = "<group>"; };
 		FFAFB40F5FACBC726C7E4172 /* ACPAdapterInstaller.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPAdapterInstaller.swift; sourceTree = "<group>"; };
@@ -2670,6 +2674,7 @@
 				EFDB90A7F9E58F4C1A258D23 /* AppStateSpacesTests.swift */,
 				279D43D7F43C40A004A2C4AC /* AppStateTabAvailabilityTests.swift */,
 				6CB9643BE01E416D3D2F4454 /* BaseBranchSelectorTests.swift */,
+				652C404D30685CB2FE79BD81 /* BaseResolutionMappingTests.swift */,
 				D0EE31A4EB90FFE45DC46420 /* BuildIdentityTests.swift */,
 				71A2A074CEB9C9BA2AD34DD7 /* CenterSelectionStateResolverTests.swift */,
 				E7D49EBCE99D6F1690646F80 /* ChangesTreeBuilderTests.swift */,
@@ -3224,6 +3229,7 @@
 			isa = PBXGroup;
 			children = (
 				002C8D5C52466955E0A90606 /* BaseBranchSelector.swift */,
+				FF68BCA1222E7C06DA4AC595 /* BaseResolutionMapping.swift */,
 				6BAD20759A17B6EFE3AC0C81 /* BranchOpsMenu.swift */,
 				7554DEF788B5448132F2B93F /* BulkConflictResolveReport.swift */,
 				3E10A1919A8DDC6A8DBB8B97 /* ChangedRow.swift */,
@@ -5026,6 +5032,7 @@
 				8FE765355607C57A9D3D6CEE /* AppState.swift in Sources */,
 				3B0629E55CC38A713F763AA8 /* AppearancePane.swift in Sources */,
 				4200B95D724A2433F50C1B7C /* BaseBranchSelector.swift in Sources */,
+				392B71BE02DAAAEC07CFD528 /* BaseResolutionMapping.swift in Sources */,
 				A9AD5B31C3A9FCBE76A15179 /* BlockedLanguageServerNudgeResolver.swift in Sources */,
 				73480309CF2CBA78879268DD /* BlockedNudgeBanner.swift in Sources */,
 				ACDDE4B18A94164BDFEED06B /* BranchOpsMenu.swift in Sources */,
@@ -5684,6 +5691,7 @@
 				07385C7266A0694AB7F4E872 /* AppStateSpacesTests.swift in Sources */,
 				956B221EC4FF3A18C713A64F /* AppStateTabAvailabilityTests.swift in Sources */,
 				A5742BE7348C02324B8119D0 /* BaseBranchSelectorTests.swift in Sources */,
+				B3240B739972444A6CB14F7C /* BaseResolutionMappingTests.swift in Sources */,
 				CF3567FA9501C1358D754D42 /* BlockedLanguageServerNudgeResolverTests.swift in Sources */,
 				5026424BC4EA8196D12E6F46 /* BuildIdentityTests.swift in Sources */,
 				F8143610563C28604A23B89A /* CenterSelectionStateResolverTests.swift in Sources */,

--- a/Alas/Sources/App/AppState.swift
+++ b/Alas/Sources/App/AppState.swift
@@ -4405,7 +4405,7 @@ extension AppState: RemoteSessionsProvider {
             async let commits = git.commitsAhead(
                 at: worktree.path,
                 baseBranch: config.worktrees.baseBranch,
-                ignoreUpstream: !config.changes.trackUpstreamForCommits
+                resolution: config.changes.trackUpstreamForCommits ? .upstreamThenBase : .baseLocalFirst
             )
             let (changes, commitResult) = try await (status, commits)
             return RemoteWorktreeSummaryBuilder.make(

--- a/Alas/Sources/App/AppState.swift
+++ b/Alas/Sources/App/AppState.swift
@@ -3208,7 +3208,7 @@ final class AppState {
         let rps = rightPaneStore.state(
             for: worktree,
             baseBranch: config.worktrees.baseBranch,
-            trackUpstreamForCommits: config.changes.trackUpstreamForCommits
+            comparisonMode: config.changes.comparisonMode
         )
         rps.reveal(path: path)
     }
@@ -3572,7 +3572,7 @@ final class AppState {
             let baseBranch = rightPaneStore.state(
                 for: worktree,
                 baseBranch: config.worktrees.baseBranch,
-                trackUpstreamForCommits: config.changes.trackUpstreamForCommits
+                comparisonMode: config.changes.comparisonMode
             ).baseBranch
             let preferredRemoteName = CodeHostRemoteDetector.preferredRemoteName(
                 forBaseBranch: baseBranch,
@@ -4405,7 +4405,9 @@ extension AppState: RemoteSessionsProvider {
             async let commits = git.commitsAhead(
                 at: worktree.path,
                 baseBranch: config.worktrees.baseBranch,
-                resolution: config.changes.trackUpstreamForCommits ? .upstreamThenBase : .baseLocalFirst
+                resolution: GitService.BaseResolution.forCommits(
+                    mode: config.changes.comparisonMode, userOverrodeBaseBranch: false
+                )
             )
             let (changes, commitResult) = try await (status, commits)
             return RemoteWorktreeSummaryBuilder.make(

--- a/Alas/Sources/Center/CenterPaneView.swift
+++ b/Alas/Sources/Center/CenterPaneView.swift
@@ -303,7 +303,7 @@ struct CenterPaneView: View {
     }
 
     private var rightPaneActivationKey: String {
-        "\(worktree.id)\u{0000}\(worktree.branch)\u{0000}\(state.config.worktrees.baseBranch)\u{0000}\(state.config.changes.trackUpstreamForCommits)"
+        "\(worktree.id)\u{0000}\(worktree.branch)\u{0000}\(state.config.worktrees.baseBranch)\u{0000}\(state.config.changes.comparisonMode.rawValue)"
     }
 
     @discardableResult
@@ -311,7 +311,7 @@ struct CenterPaneView: View {
         state.rightPaneStore.state(
             for: worktree,
             baseBranch: state.config.worktrees.baseBranch,
-            trackUpstreamForCommits: state.config.changes.trackUpstreamForCommits
+            comparisonMode: state.config.changes.comparisonMode
         )
     }
 

--- a/Alas/Sources/Center/Commit/CommitEditorTabView.swift
+++ b/Alas/Sources/Center/Commit/CommitEditorTabView.swift
@@ -372,7 +372,8 @@ struct CommitEditorTabView: View {
         let currentSha = tabState.currentSha
         let baseRef = tabState.baseRef
         let prompt = appState.config.changes.prompt
-        let ignoreUpstream = !appState.config.changes.trackUpstreamForCommits
+        let commitsResolution: GitService.BaseResolution =
+            appState.config.changes.trackUpstreamForCommits ? .upstreamThenBase : .baseLocalFirst
 
         busy = true
         error = nil
@@ -387,7 +388,7 @@ struct CommitEditorTabView: View {
                 let nearbyCommits = try await git.commitsAhead(
                     at: worktreePath,
                     baseBranch: baseRef,
-                    ignoreUpstream: ignoreUpstream
+                    resolution: commitsResolution
                 ).commits
                 let payload = CommitContextBuilder.buildForCommitEdit(
                     branch: branch,

--- a/Alas/Sources/Center/Commit/CommitEditorTabView.swift
+++ b/Alas/Sources/Center/Commit/CommitEditorTabView.swift
@@ -372,9 +372,14 @@ struct CommitEditorTabView: View {
         let currentSha = tabState.currentSha
         let baseRef = tabState.baseRef
         let prompt = appState.config.changes.prompt
-        let commitsResolution = GitService.BaseResolution.forCommits(
-            mode: appState.config.changes.comparisonMode, userOverrodeBaseBranch: false
-        )
+        // The editor compares against the tab's already-selected `baseRef`, so
+        // it uses that ref as given (local-first) instead of re-resolving it
+        // origin-first the way Auto does for the Commits list — otherwise a
+        // manual override like `develop` would silently become `origin/develop`
+        // and change the nearby-commit context. Branch-upstream mode still
+        // compares against the branch's own upstream.
+        let commitsResolution: GitService.BaseResolution =
+            appState.config.changes.comparisonMode == .branchUpstream ? .upstreamThenBase : .baseLocalFirst
 
         busy = true
         error = nil

--- a/Alas/Sources/Center/Commit/CommitEditorTabView.swift
+++ b/Alas/Sources/Center/Commit/CommitEditorTabView.swift
@@ -372,8 +372,9 @@ struct CommitEditorTabView: View {
         let currentSha = tabState.currentSha
         let baseRef = tabState.baseRef
         let prompt = appState.config.changes.prompt
-        let commitsResolution: GitService.BaseResolution =
-            appState.config.changes.trackUpstreamForCommits ? .upstreamThenBase : .baseLocalFirst
+        let commitsResolution = GitService.BaseResolution.forCommits(
+            mode: appState.config.changes.comparisonMode, userOverrodeBaseBranch: false
+        )
 
         busy = true
         error = nil

--- a/Alas/Sources/Git/GitService.swift
+++ b/Alas/Sources/Git/GitService.swift
@@ -1232,7 +1232,14 @@ extension GitService {
         var baseName: String? = nil
         if upstreamName == nil, let base = baseBranch, !base.isEmpty {
             if base.contains("/") {
-                if try await refExists("refs/heads/\(base)") {
+                // Auto prefers the canonical remote ref even for slash-named
+                // bases (e.g. `release/1.0`), so a stale local branch of the
+                // same name doesn't reintroduce rebase instability. Other
+                // resolutions keep the local-first behavior for ambiguous
+                // slash names.
+                if resolution == .baseOriginFirst, try await refExists("refs/remotes/origin/\(base)") {
+                    baseName = "origin/\(base)"
+                } else if try await refExists("refs/heads/\(base)") {
                     baseName = base
                 } else if try await refExists("refs/remotes/\(base)") {
                     baseName = base

--- a/Alas/Sources/Git/GitService.swift
+++ b/Alas/Sources/Git/GitService.swift
@@ -1225,22 +1225,22 @@ extension GitService {
         // Step 2: If no upstream ref was chosen, resolve the base branch.
         // Slash-named bases are ambiguous, so always resolve local first for
         // them; simple names follow the requested preference.
-        func refExists(_ ref: String) async -> Bool {
-            let r = try? await Process.git(["show-ref", "--verify", "--quiet", ref], cwd: worktree)
-            return r?.exitCode == 0
+        func refExists(_ ref: String) async throws -> Bool {
+            let r = try await Process.git(["show-ref", "--verify", "--quiet", ref], cwd: worktree)
+            return r.exitCode == 0
         }
         var baseName: String? = nil
         if upstreamName == nil, let base = baseBranch, !base.isEmpty {
             if base.contains("/") {
-                if await refExists("refs/heads/\(base)") {
+                if try await refExists("refs/heads/\(base)") {
                     baseName = base
-                } else if await refExists("refs/remotes/\(base)") {
+                } else if try await refExists("refs/remotes/\(base)") {
                     baseName = base
                 }
             }
             if baseName == nil {
-                let localExists = await refExists("refs/heads/\(base)")
-                let originExists = await refExists("refs/remotes/origin/\(base)")
+                let localExists = try await refExists("refs/heads/\(base)")
+                let originExists = try await refExists("refs/remotes/origin/\(base)")
                 switch resolution {
                 case .baseLocalFirst:
                     if localExists { baseName = base }

--- a/Alas/Sources/Git/GitService.swift
+++ b/Alas/Sources/Git/GitService.swift
@@ -1177,6 +1177,19 @@ extension GitService {
 }
 
 extension GitService {
+    /// How `commitsAhead` chooses the ref it compares `HEAD` against.
+    /// - `upstreamThenBase`: use the branch's own upstream `@{u}` when it
+    ///   resolves, otherwise the base branch (origin-qualified, then local).
+    /// - `baseOriginFirst`: never use `@{u}`; prefer `origin/<base>`, then
+    ///   local `<base>`. Rebase-stable ("Auto").
+    /// - `baseLocalFirst`: never use `@{u}`; prefer local `<base>`, then
+    ///   `origin/<base>` ("Manual").
+    enum BaseResolution: Equatable {
+        case upstreamThenBase
+        case baseOriginFirst
+        case baseLocalFirst
+    }
+
     /// Commits on the current branch but not on a comparison ref, using a
     /// 2-step cascade to pick the ref:
     ///   1. `@{u}..HEAD` if an upstream tracking branch is configured.
@@ -1187,12 +1200,16 @@ extension GitService {
     ///
     /// One `git log` invocation parses subject + author + ISO date +
     /// per-commit numstat in a single pass to avoid N round-trips.
-    func commitsAhead(at worktree: URL, baseBranch: String? = nil, ignoreUpstream: Bool = false) async throws -> (commits: [CommitInfo], comparisonRef: String?) {
+    func commitsAhead(
+        at worktree: URL,
+        baseBranch: String? = nil,
+        resolution: BaseResolution = .upstreamThenBase
+    ) async throws -> (commits: [CommitInfo], comparisonRef: String?) {
         // Step 1: Resolve upstream first. `--symbolic-full-name @{u}` returns
         // `refs/remotes/origin/main`; `--abbrev-ref @{u}` returns
         // `origin/main`. Use the abbreviated form for display.
         var upstreamName: String? = nil
-        if !ignoreUpstream {
+        if resolution == .upstreamThenBase {
             let up = try await Process.git(
                 ["rev-parse", "--abbrev-ref", "--symbolic-full-name", "@{u}"],
                 cwd: worktree
@@ -1205,49 +1222,32 @@ extension GitService {
             }
         }
 
-        // Step 2: If no upstream, try the base branch. Prefer `origin/<base>`
-        // over local `<base>` for simple branch names. Slash-named bases are
-        // ambiguous, so resolve local refs first before treating them as
-        // remote-qualified refs.
+        // Step 2: If no upstream ref was chosen, resolve the base branch.
+        // Slash-named bases are ambiguous, so always resolve local first for
+        // them; simple names follow the requested preference.
+        func refExists(_ ref: String) async -> Bool {
+            let r = try? await Process.git(["show-ref", "--verify", "--quiet", ref], cwd: worktree)
+            return r?.exitCode == 0
+        }
         var baseName: String? = nil
         if upstreamName == nil, let base = baseBranch, !base.isEmpty {
             if base.contains("/") {
-                let local = try await Process.git(
-                    ["show-ref", "--verify", "--quiet", "refs/heads/\(base)"],
-                    cwd: worktree
-                )
-                if local.exitCode == 0 {
+                if await refExists("refs/heads/\(base)") {
                     baseName = base
-                } else {
-                    let direct = try await Process.git(
-                        ["show-ref", "--verify", "--quiet", "refs/remotes/\(base)"],
-                        cwd: worktree
-                    )
-                    if direct.exitCode == 0 { baseName = base }
+                } else if await refExists("refs/remotes/\(base)") {
+                    baseName = base
                 }
             }
             if baseName == nil {
-                if ignoreUpstream {
-                    let local = try await Process.git(
-                        ["show-ref", "--verify", "--quiet", "refs/heads/\(base)"],
-                        cwd: worktree
-                    )
-                    if local.exitCode == 0 { baseName = base }
-                }
-                if baseName == nil {
-                    let origin = try await Process.git(
-                        ["show-ref", "--verify", "--quiet", "refs/remotes/origin/\(base)"],
-                        cwd: worktree
-                    )
-                    if origin.exitCode == 0 {
-                        baseName = "origin/\(base)"
-                    } else if !ignoreUpstream {
-                        let local = try await Process.git(
-                            ["show-ref", "--verify", "--quiet", "refs/heads/\(base)"],
-                            cwd: worktree
-                        )
-                        if local.exitCode == 0 { baseName = base }
-                    }
+                let localExists = await refExists("refs/heads/\(base)")
+                let originExists = await refExists("refs/remotes/origin/\(base)")
+                switch resolution {
+                case .baseLocalFirst:
+                    if localExists { baseName = base }
+                    else if originExists { baseName = "origin/\(base)" }
+                case .baseOriginFirst, .upstreamThenBase:
+                    if originExists { baseName = "origin/\(base)" }
+                    else if localExists { baseName = base }
                 }
             }
         }

--- a/Alas/Sources/Persistence/AppConfig.swift
+++ b/Alas/Sources/Persistence/AppConfig.swift
@@ -304,12 +304,6 @@ struct AppConfig: Codable, Equatable {
         /// appended verbatim by `MergeAgent`. `{filePath}` and
         /// `{language}` are substituted; anything else passes through.
         var mergeSingleResolvePrompt: String
-        /// When true, the Commits section uses the branch's upstream
-        /// tracking ref (`@{u}`) as the comparison base once one exists,
-        /// matching git's own "ahead/behind" semantics. When false
-        /// (default), it always compares against `worktrees.baseBranch`,
-        /// so the list stays stable across pushes.
-        var trackUpstreamForCommits: Bool
         /// How the Commits section chooses its comparison base.
         /// - `auto` (default): compare against `origin/<base>` (falls back to
         ///   local `<base>`); stable across rebases.
@@ -327,9 +321,15 @@ struct AppConfig: Codable, Equatable {
 
         enum CodingKeys: String, CodingKey {
             case aiToolId, prompt, reviewRequestPrompt, mergeBulkResolvePrompt,
-                 mergeSingleResolvePrompt, trackUpstreamForCommits, comparisonMode,
+                 mergeSingleResolvePrompt, comparisonMode,
                  diffLayoutMode, diffWrapLines, diffShowWhitespace
         }
+    }
+
+    /// Legacy key retained only so `AppConfig.init(from:)` can migrate
+    /// pre-`comparisonMode` configs; no stored property backs it.
+    private enum LegacyChangesKey: String, CodingKey {
+        case trackUpstreamForCommits
     }
 
     struct Agents: Codable, Equatable {
@@ -441,7 +441,6 @@ struct AppConfig: Codable, Equatable {
             reviewRequestPrompt: AppConfig.defaultReviewRequestPrompt,
             mergeBulkResolvePrompt: AppConfig.defaultMergeBulkResolvePrompt,
             mergeSingleResolvePrompt: AppConfig.defaultMergeSingleResolvePrompt,
-            trackUpstreamForCommits: false,
             comparisonMode: .auto,
             diffLayoutMode: .split,
             diffWrapLines: false,
@@ -670,12 +669,15 @@ extension AppConfig {
                 ?? AppConfig.defaultMergeBulkResolvePrompt
             let singleResolve = (try? changesContainer.decode(String.self, forKey: .mergeSingleResolvePrompt))
                 ?? AppConfig.defaultMergeSingleResolvePrompt
-            let trackUpstream = (try? changesContainer.decode(Bool.self, forKey: .trackUpstreamForCommits)) ?? false
+            let legacyTrackUpstream: Bool? = {
+                guard let legacy = try? c.nestedContainer(keyedBy: LegacyChangesKey.self, forKey: .changes) else { return nil }
+                return try? legacy.decode(Bool.self, forKey: .trackUpstreamForCommits)
+            }()
             let comparisonMode: Changes.ChangesComparisonMode = {
                 if let explicit = try? changesContainer.decode(Changes.ChangesComparisonMode.self, forKey: .comparisonMode) {
                     return explicit
                 }
-                return trackUpstream ? .branchUpstream : .auto
+                return (legacyTrackUpstream == true) ? .branchUpstream : .auto
             }()
             let diffLayoutMode = (try? changesContainer.decode(DiffLayoutMode.self, forKey: .diffLayoutMode)) ?? .split
             let diffWrapLines = (try? changesContainer.decode(Bool.self, forKey: .diffWrapLines)) ?? false
@@ -686,7 +688,6 @@ extension AppConfig {
                 reviewRequestPrompt: reviewRequestPrompt,
                 mergeBulkResolvePrompt: bulkResolve,
                 mergeSingleResolvePrompt: singleResolve,
-                trackUpstreamForCommits: trackUpstream,
                 comparisonMode: comparisonMode,
                 diffLayoutMode: diffLayoutMode,
                 diffWrapLines: diffWrapLines,
@@ -699,7 +700,6 @@ extension AppConfig {
                 reviewRequestPrompt: AppConfig.defaultReviewRequestPrompt,
                 mergeBulkResolvePrompt: AppConfig.defaultMergeBulkResolvePrompt,
                 mergeSingleResolvePrompt: AppConfig.defaultMergeSingleResolvePrompt,
-                trackUpstreamForCommits: false,
                 comparisonMode: .auto,
                 diffLayoutMode: .split,
                 diffWrapLines: false,

--- a/Alas/Sources/Persistence/AppConfig.swift
+++ b/Alas/Sources/Persistence/AppConfig.swift
@@ -310,13 +310,24 @@ struct AppConfig: Codable, Equatable {
         /// (default), it always compares against `worktrees.baseBranch`,
         /// so the list stays stable across pushes.
         var trackUpstreamForCommits: Bool
+        /// How the Commits section chooses its comparison base.
+        /// - `auto` (default): compare against `origin/<base>` (falls back to
+        ///   local `<base>`); stable across rebases.
+        /// - `branchUpstream`: compare against the branch's own `@{u}`.
+        /// - `manual`: compare against the per-worktree selected base branch.
+        enum ChangesComparisonMode: String, Codable {
+            case auto
+            case branchUpstream
+            case manual
+        }
+        var comparisonMode: ChangesComparisonMode
         var diffLayoutMode: DiffLayoutMode
         var diffWrapLines: Bool
         var diffShowWhitespace: Bool
 
         enum CodingKeys: String, CodingKey {
             case aiToolId, prompt, reviewRequestPrompt, mergeBulkResolvePrompt,
-                 mergeSingleResolvePrompt, trackUpstreamForCommits,
+                 mergeSingleResolvePrompt, trackUpstreamForCommits, comparisonMode,
                  diffLayoutMode, diffWrapLines, diffShowWhitespace
         }
     }
@@ -431,6 +442,7 @@ struct AppConfig: Codable, Equatable {
             mergeBulkResolvePrompt: AppConfig.defaultMergeBulkResolvePrompt,
             mergeSingleResolvePrompt: AppConfig.defaultMergeSingleResolvePrompt,
             trackUpstreamForCommits: false,
+            comparisonMode: .auto,
             diffLayoutMode: .split,
             diffWrapLines: false,
             diffShowWhitespace: false
@@ -659,6 +671,12 @@ extension AppConfig {
             let singleResolve = (try? changesContainer.decode(String.self, forKey: .mergeSingleResolvePrompt))
                 ?? AppConfig.defaultMergeSingleResolvePrompt
             let trackUpstream = (try? changesContainer.decode(Bool.self, forKey: .trackUpstreamForCommits)) ?? false
+            let comparisonMode: Changes.ChangesComparisonMode = {
+                if let explicit = try? changesContainer.decode(Changes.ChangesComparisonMode.self, forKey: .comparisonMode) {
+                    return explicit
+                }
+                return trackUpstream ? .branchUpstream : .auto
+            }()
             let diffLayoutMode = (try? changesContainer.decode(DiffLayoutMode.self, forKey: .diffLayoutMode)) ?? .split
             let diffWrapLines = (try? changesContainer.decode(Bool.self, forKey: .diffWrapLines)) ?? false
             let diffShowWhitespace = (try? changesContainer.decode(Bool.self, forKey: .diffShowWhitespace)) ?? false
@@ -669,6 +687,7 @@ extension AppConfig {
                 mergeBulkResolvePrompt: bulkResolve,
                 mergeSingleResolvePrompt: singleResolve,
                 trackUpstreamForCommits: trackUpstream,
+                comparisonMode: comparisonMode,
                 diffLayoutMode: diffLayoutMode,
                 diffWrapLines: diffWrapLines,
                 diffShowWhitespace: diffShowWhitespace
@@ -681,6 +700,7 @@ extension AppConfig {
                 mergeBulkResolvePrompt: AppConfig.defaultMergeBulkResolvePrompt,
                 mergeSingleResolvePrompt: AppConfig.defaultMergeSingleResolvePrompt,
                 trackUpstreamForCommits: false,
+                comparisonMode: .auto,
                 diffLayoutMode: .split,
                 diffWrapLines: false,
                 diffShowWhitespace: false

--- a/Alas/Sources/Right/BaseResolutionMapping.swift
+++ b/Alas/Sources/Right/BaseResolutionMapping.swift
@@ -1,0 +1,28 @@
+import Foundation
+
+extension GitService.BaseResolution {
+    /// The resolution for the Commits section, given the global mode and
+    /// whether this worktree has a manual per-worktree base override.
+    static func forCommits(
+        mode: AppConfig.Changes.ChangesComparisonMode,
+        userOverrodeBaseBranch: Bool
+    ) -> GitService.BaseResolution {
+        if userOverrodeBaseBranch { return .baseLocalFirst }
+        switch mode {
+        case .auto: return .baseOriginFirst
+        case .branchUpstream: return .upstreamThenBase
+        case .manual: return .baseLocalFirst
+        }
+    }
+
+    /// The resolution for the review-loop base. It never uses the branch's own
+    /// upstream — it wants a stable remote base — so every non-Manual mode maps
+    /// to origin-first.
+    static func forReviewLoopBase(
+        mode: AppConfig.Changes.ChangesComparisonMode,
+        userOverrodeBaseBranch: Bool
+    ) -> GitService.BaseResolution {
+        if userOverrodeBaseBranch { return .baseLocalFirst }
+        return mode == .manual ? .baseLocalFirst : .baseOriginFirst
+    }
+}

--- a/Alas/Sources/Right/RightPaneState.swift
+++ b/Alas/Sources/Right/RightPaneState.swift
@@ -167,12 +167,10 @@ final class RightPaneState {
     @ObservationIgnored
     var isAwaitingBaseBranchProbe: Bool = false
 
-    /// Mirrors `AppConfig.changes.trackUpstreamForCommits`. Synced by
-    /// `RightPaneStore` on every `state(for:)` call. When false (the
-    /// default) — or when `userOverrodeBaseBranch` is true — `refresh()`
-    /// passes `resolution: .baseLocalFirst` to `commitsAhead`, so the
-    /// Commits section compares HEAD against the base branch instead of `@{u}`.
-    var trackUpstreamForCommits: Bool = false
+    /// Mirrors `AppConfig.changes.comparisonMode`. Synced by `RightPaneStore`
+    /// on every `state(for:)` call. Combined with `userOverrodeBaseBranch`, it
+    /// selects the `BaseResolution` `refresh()` passes to `commitsAhead`.
+    var comparisonMode: AppConfig.Changes.ChangesComparisonMode = .auto
 
     var pendingDiscard: PendingDiscard? = nil
     var pendingCherryPickSHA: String? = nil
@@ -587,8 +585,12 @@ final class RightPaneState {
             self.olderCommits = []
             self.hasMoreOlder = true
             self.isLoadingOlder = false
-            let ignoreUpstream = userOverrodeBaseBranch || !trackUpstreamForCommits
-            let commitsResolution: GitService.BaseResolution = ignoreUpstream ? .baseLocalFirst : .upstreamThenBase
+            let commitsResolution = GitService.BaseResolution.forCommits(
+                mode: comparisonMode, userOverrodeBaseBranch: userOverrodeBaseBranch
+            )
+            let reviewLoopResolution = GitService.BaseResolution.forReviewLoopBase(
+                mode: comparisonMode, userOverrodeBaseBranch: userOverrodeBaseBranch
+            )
             async let s = git.status(worktreePath: worktree.path)
             async let statusRaw = Process.git(
                 ["status", "--porcelain=v2", "-z", "--untracked-files=all"],
@@ -602,7 +604,7 @@ final class RightPaneState {
             async let reviewLoopBase = git.commitsAhead(
                 at: worktree.path,
                 baseBranch: baseBranch,
-                resolution: .baseLocalFirst
+                resolution: reviewLoopResolution
             )
             async let br = git.currentBranch(worktreePath: worktree.path)
             async let upstream = git.resolveUpstreamRef(worktreePath: worktree.path)

--- a/Alas/Sources/Right/RightPaneState.swift
+++ b/Alas/Sources/Right/RightPaneState.swift
@@ -170,8 +170,8 @@ final class RightPaneState {
     /// Mirrors `AppConfig.changes.trackUpstreamForCommits`. Synced by
     /// `RightPaneStore` on every `state(for:)` call. When false (the
     /// default) — or when `userOverrodeBaseBranch` is true — `refresh()`
-    /// passes `ignoreUpstream: true` to `commitsAhead`, so the Commits
-    /// section compares HEAD against the base branch instead of `@{u}`.
+    /// passes `resolution: .baseLocalFirst` to `commitsAhead`, so the
+    /// Commits section compares HEAD against the base branch instead of `@{u}`.
     var trackUpstreamForCommits: Bool = false
 
     var pendingDiscard: PendingDiscard? = nil
@@ -588,6 +588,7 @@ final class RightPaneState {
             self.hasMoreOlder = true
             self.isLoadingOlder = false
             let ignoreUpstream = userOverrodeBaseBranch || !trackUpstreamForCommits
+            let commitsResolution: GitService.BaseResolution = ignoreUpstream ? .baseLocalFirst : .upstreamThenBase
             async let s = git.status(worktreePath: worktree.path)
             async let statusRaw = Process.git(
                 ["status", "--porcelain=v2", "-z", "--untracked-files=all"],
@@ -596,12 +597,12 @@ final class RightPaneState {
             async let c = git.commitsAhead(
                 at: worktree.path,
                 baseBranch: baseBranch,
-                ignoreUpstream: ignoreUpstream
+                resolution: commitsResolution
             )
             async let reviewLoopBase = git.commitsAhead(
                 at: worktree.path,
                 baseBranch: baseBranch,
-                ignoreUpstream: true
+                resolution: .baseLocalFirst
             )
             async let br = git.currentBranch(worktreePath: worktree.path)
             async let upstream = git.resolveUpstreamRef(worktreePath: worktree.path)

--- a/Alas/Sources/Right/RightPaneStore.swift
+++ b/Alas/Sources/Right/RightPaneStore.swift
@@ -61,12 +61,12 @@ final class RightPaneStore {
 
     private let logger = Logger(subsystem: "io.nlopez.alas", category: "right-pane-store")
 
-    func state(for worktree: Worktree, baseBranch: String, trackUpstreamForCommits: Bool) -> RightPaneState {
+    func state(for worktree: Worktree, baseBranch: String, comparisonMode: AppConfig.Changes.ChangesComparisonMode) -> RightPaneState {
         let id = worktree.id
         let result: RightPaneState
         let rawDefault = Self.effectiveBaseBranch(worktree: worktree, baseBranch: baseBranch)
         if let existing = states[id] {
-            let trackUpstreamChanged = existing.trackUpstreamForCommits != trackUpstreamForCommits
+            let comparisonModeChanged = existing.comparisonMode != comparisonMode
 
             // Settings change: the configured base branch changed. Reset to the
             // new default unless the user picked a branch themselves.
@@ -117,8 +117,8 @@ final class RightPaneStore {
                     )
                 }
             }
-            if trackUpstreamChanged {
-                existing.trackUpstreamForCommits = trackUpstreamForCommits
+            if comparisonModeChanged {
+                existing.comparisonMode = comparisonMode
                 Task { @MainActor in await existing.refresh() }
             }
             result = existing
@@ -134,7 +134,7 @@ final class RightPaneStore {
             new.baseBranch = rawDefault
             new.lastConfigBaseBranch = baseBranch
             new.lastEffectiveBaseBranch = rawDefault
-            new.trackUpstreamForCommits = trackUpstreamForCommits
+            new.comparisonMode = comparisonMode
             new.isAwaitingBaseBranchProbe = shouldDeferInitialRefresh
             new.closeDiffTabs = { [weak self] paths in
                 guard let app = self?.appState else { return }

--- a/Alas/Sources/Right/RightPaneView.swift
+++ b/Alas/Sources/Right/RightPaneView.swift
@@ -185,14 +185,14 @@ struct RightPaneView: View {
         // expected escape hatch — switching away and back should surface current
         // state. Activation happens inside the task, not during body evaluation,
         // so `RightPaneStore` mutations don't run inside a view update.
-        .task(id: "\(worktree.id)\u{0000}\(worktree.branch)\u{0000}\(state.config.worktrees.baseBranch)\u{0000}\(state.config.changes.trackUpstreamForCommits)") {
+        .task(id: "\(worktree.id)\u{0000}\(worktree.branch)\u{0000}\(state.config.worktrees.baseBranch)\u{0000}\(state.config.changes.comparisonMode.rawValue)") {
             if rps?.worktree.id != worktree.id {
                 rps = nil
             }
             let activated = state.rightPaneStore.state(
                 for: worktree,
                 baseBranch: state.config.worktrees.baseBranch,
-                trackUpstreamForCommits: state.config.changes.trackUpstreamForCommits
+                comparisonMode: state.config.changes.comparisonMode
             )
             rps = activated
             await activated.refresh()

--- a/Alas/Sources/Settings/ChangesPane.swift
+++ b/Alas/Sources/Settings/ChangesPane.swift
@@ -13,12 +13,18 @@ struct ChangesPane: View {
                     .font(.system(size: 12.5)).foregroundColor(theme.color("fg-dim"))
                     .padding(.bottom, 12)
 
-                SettingsGroup(title: "Commits section") {
+                SettingsGroup(title: "Comparison base") {
                     SettingsRow(
-                        name: "Track upstream branch",
-                        desc: "When on, the Commits section compares against your branch's remote tracking ref once you push, so it only lists unpushed commits. When off, it always compares against the base branch — you'll see every commit on this branch since it diverged from main."
+                        name: "Compare commits against",
+                        desc: comparisonModeDescription
                     ) {
-                        AlasToggle(on: state.bind(\.changes.trackUpstreamForCommits))
+                        Picker("", selection: state.bind(\.changes.comparisonMode)) {
+                            Text("Auto").tag(AppConfig.Changes.ChangesComparisonMode.auto)
+                            Text("Branch upstream").tag(AppConfig.Changes.ChangesComparisonMode.branchUpstream)
+                            Text("Manual").tag(AppConfig.Changes.ChangesComparisonMode.manual)
+                        }
+                        .pickerStyle(.segmented)
+                        .labelsHidden()
                     }
                 }
 
@@ -70,6 +76,17 @@ struct ChangesPane: View {
                 }
             }
             .padding(.horizontal, 32).padding(.vertical, 24)
+        }
+    }
+
+    private var comparisonModeDescription: String {
+        switch state.config.changes.comparisonMode {
+        case .auto:
+            return "Compares against origin/<base> (falls back to your local base branch). Always shows this branch's own work and stays stable across rebases."
+        case .branchUpstream:
+            return "Compares against this branch's own remote tracking ref, so it only lists unpushed commits once you push."
+        case .manual:
+            return "Compares against the base branch you pick per worktree (via the base-branch selector), resolved locally first."
         }
     }
 

--- a/AlasTests/AppConfigChangesTests.swift
+++ b/AlasTests/AppConfigChangesTests.swift
@@ -167,6 +167,34 @@ struct AppConfigChangesTests {
         #expect(decoded.changes.trackUpstreamForCommits == true)
     }
 
+    private func decodeChanges(mutating: ([String: Any]) -> [String: Any]) throws -> AppConfig.Changes {
+        let data = try JSONEncoder().encode(AppConfig.defaults)
+        var obj = try JSONSerialization.jsonObject(with: data) as! [String: Any]
+        obj["changes"] = mutating(obj["changes"] as! [String: Any])
+        let mutated = try JSONSerialization.data(withJSONObject: obj)
+        return try JSONDecoder().decode(AppConfig.self, from: mutated).changes
+    }
+
+    @Test func migratesLegacyTrackUpstreamTrueToBranchUpstream() throws {
+        let changes = try decodeChanges { var c = $0; c.removeValue(forKey: "comparisonMode"); c["trackUpstreamForCommits"] = true; return c }
+        #expect(changes.comparisonMode == .branchUpstream)
+    }
+
+    @Test func migratesLegacyTrackUpstreamFalseToAuto() throws {
+        let changes = try decodeChanges { var c = $0; c.removeValue(forKey: "comparisonMode"); c["trackUpstreamForCommits"] = false; return c }
+        #expect(changes.comparisonMode == .auto)
+    }
+
+    @Test func defaultsToAutoWhenNeitherKeyPresent() throws {
+        let changes = try decodeChanges { var c = $0; c.removeValue(forKey: "comparisonMode"); c.removeValue(forKey: "trackUpstreamForCommits"); return c }
+        #expect(changes.comparisonMode == .auto)
+    }
+
+    @Test func explicitComparisonModeWinsOverLegacyBool() throws {
+        let changes = try decodeChanges { var c = $0; c["comparisonMode"] = "manual"; c["trackUpstreamForCommits"] = true; return c }
+        #expect(changes.comparisonMode == .manual)
+    }
+
     @Test func defaultsHaveDiffDisplayPreferences() {
         #expect(AppConfig.defaults.changes.diffLayoutMode == .split)
         #expect(AppConfig.defaults.changes.diffWrapLines == false)

--- a/AlasTests/AppConfigChangesTests.swift
+++ b/AlasTests/AppConfigChangesTests.swift
@@ -164,22 +164,34 @@ struct AppConfigChangesTests {
     }
 
     @Test func migratesLegacyTrackUpstreamTrueToBranchUpstream() throws {
-        let changes = try decodeChanges { var c = $0; c.removeValue(forKey: "comparisonMode"); c["trackUpstreamForCommits"] = true; return c }
+        let changes = try decodeChanges { var c = $0
+        c.removeValue(forKey: "comparisonMode")
+        c["trackUpstreamForCommits"] = true
+        return c }
         #expect(changes.comparisonMode == .branchUpstream)
     }
 
     @Test func migratesLegacyTrackUpstreamFalseToAuto() throws {
-        let changes = try decodeChanges { var c = $0; c.removeValue(forKey: "comparisonMode"); c["trackUpstreamForCommits"] = false; return c }
+        let changes = try decodeChanges { var c = $0
+        c.removeValue(forKey: "comparisonMode")
+        c["trackUpstreamForCommits"] = false
+        return c }
         #expect(changes.comparisonMode == .auto)
     }
 
     @Test func defaultsToAutoWhenNeitherKeyPresent() throws {
-        let changes = try decodeChanges { var c = $0; c.removeValue(forKey: "comparisonMode"); c.removeValue(forKey: "trackUpstreamForCommits"); return c }
+        let changes = try decodeChanges { var c = $0
+        c.removeValue(forKey: "comparisonMode")
+        c.removeValue(forKey: "trackUpstreamForCommits")
+        return c }
         #expect(changes.comparisonMode == .auto)
     }
 
     @Test func explicitComparisonModeWinsOverLegacyBool() throws {
-        let changes = try decodeChanges { var c = $0; c["comparisonMode"] = "manual"; c["trackUpstreamForCommits"] = true; return c }
+        let changes = try decodeChanges { var c = $0
+        c["comparisonMode"] = "manual"
+        c["trackUpstreamForCommits"] = true
+        return c }
         #expect(changes.comparisonMode == .manual)
     }
 

--- a/AlasTests/AppConfigChangesTests.swift
+++ b/AlasTests/AppConfigChangesTests.swift
@@ -112,10 +112,6 @@ struct AppConfigChangesTests {
         #expect(decoded.changes.reviewRequestPrompt == "custom review request prompt")
     }
 
-    @Test func defaultsHaveTrackUpstreamForCommitsOff() {
-        #expect(AppConfig.defaults.changes.trackUpstreamForCommits == false)
-    }
-
     @Test func decodesLegacyChangesWithoutTrackUpstreamForCommits() throws {
         // A config blob with a `changes` section that predates the new key.
         let json = """
@@ -156,15 +152,7 @@ struct AppConfigChangesTests {
         """
         let cfg = try JSONDecoder().decode(AppConfig.self, from: Data(json.utf8))
         #expect(cfg.changes.aiToolId == "claude")
-        #expect(cfg.changes.trackUpstreamForCommits == false)
-    }
-
-    @Test func roundTripsTrackUpstreamForCommits() throws {
-        var cfg = AppConfig.defaults
-        cfg.changes.trackUpstreamForCommits = true
-        let data = try JSONEncoder().encode(cfg)
-        let decoded = try JSONDecoder().decode(AppConfig.self, from: data)
-        #expect(decoded.changes.trackUpstreamForCommits == true)
+        #expect(cfg.changes.comparisonMode == .auto)
     }
 
     private func decodeChanges(mutating: ([String: Any]) -> [String: Any]) throws -> AppConfig.Changes {

--- a/AlasTests/BaseResolutionMappingTests.swift
+++ b/AlasTests/BaseResolutionMappingTests.swift
@@ -1,0 +1,26 @@
+import Testing
+@testable import Alas
+
+struct BaseResolutionMappingTests {
+    typealias Mode = AppConfig.Changes.ChangesComparisonMode
+
+    @Test func autoMapsToOriginFirst() {
+        #expect(GitService.BaseResolution.forCommits(mode: .auto, userOverrodeBaseBranch: false) == .baseOriginFirst)
+    }
+    @Test func branchUpstreamMapsToUpstreamThenBase() {
+        #expect(GitService.BaseResolution.forCommits(mode: .branchUpstream, userOverrodeBaseBranch: false) == .upstreamThenBase)
+    }
+    @Test func manualMapsToLocalFirst() {
+        #expect(GitService.BaseResolution.forCommits(mode: .manual, userOverrodeBaseBranch: false) == .baseLocalFirst)
+    }
+    @Test func perWorktreeOverrideForcesLocalFirstRegardlessOfMode() {
+        #expect(GitService.BaseResolution.forCommits(mode: .auto, userOverrodeBaseBranch: true) == .baseLocalFirst)
+        #expect(GitService.BaseResolution.forCommits(mode: .branchUpstream, userOverrodeBaseBranch: true) == .baseLocalFirst)
+    }
+    @Test func reviewLoopBaseIsOriginFirstExceptManualAndOverride() {
+        #expect(GitService.BaseResolution.forReviewLoopBase(mode: .auto, userOverrodeBaseBranch: false) == .baseOriginFirst)
+        #expect(GitService.BaseResolution.forReviewLoopBase(mode: .branchUpstream, userOverrodeBaseBranch: false) == .baseOriginFirst)
+        #expect(GitService.BaseResolution.forReviewLoopBase(mode: .manual, userOverrodeBaseBranch: false) == .baseLocalFirst)
+        #expect(GitService.BaseResolution.forReviewLoopBase(mode: .auto, userOverrodeBaseBranch: true) == .baseLocalFirst)
+    }
+}

--- a/AlasTests/CommitsAheadTests.swift
+++ b/AlasTests/CommitsAheadTests.swift
@@ -180,7 +180,7 @@ struct CommitsAheadTests {
         #expect(refDefault == "origin/main")
 
         // With ignoreUpstream, upstream is skipped; nonexistent base returns nil.
-        let (_, refIgnored) = try await svc.commitsAhead(at: worktree, baseBranch: "nonexistent", ignoreUpstream: true)
+        let (_, refIgnored) = try await svc.commitsAhead(at: worktree, baseBranch: "nonexistent", resolution: .baseLocalFirst)
         #expect(refIgnored == nil)
     }
 
@@ -198,7 +198,7 @@ struct CommitsAheadTests {
         _ = try await Process.git(["commit", "-q", "--allow-empty", "-m", "feat: feature work"], cwd: worktree)
 
         let svc = GitService()
-        let (_, comparisonRef) = try await svc.commitsAhead(at: worktree, baseBranch: "team/main", ignoreUpstream: true)
+        let (_, comparisonRef) = try await svc.commitsAhead(at: worktree, baseBranch: "team/main", resolution: .baseLocalFirst)
 
         #expect(comparisonRef == "team/main")
     }
@@ -210,8 +210,45 @@ struct CommitsAheadTests {
         _ = try await Process.git(["commit", "-q", "--allow-empty", "-m", "feat: feature work"], cwd: worktree)
 
         let svc = GitService()
-        let (_, comparisonRef) = try await svc.commitsAhead(at: worktree, baseBranch: "main", ignoreUpstream: true)
+        let (_, comparisonRef) = try await svc.commitsAhead(at: worktree, baseBranch: "main", resolution: .baseLocalFirst)
 
         #expect(comparisonRef == "main")
+    }
+
+    @Test func baseOriginFirstPrefersOriginOverLocalBase() async throws {
+        let (worktree, _) = try await makeRepoWithUpstream()
+        defer { try? FileManager.default.removeItem(at: worktree.deletingLastPathComponent()) }
+        _ = try await Process.git(["checkout", "-q", "-b", "feature"], cwd: worktree)
+        _ = try await Process.git(["commit", "-q", "--allow-empty", "-m", "feat: feature work"], cwd: worktree)
+
+        let svc = GitService()
+        // Local `main` and `origin/main` both exist; Auto prefers origin.
+        let (_, comparisonRef) = try await svc.commitsAhead(
+            at: worktree, baseBranch: "main", resolution: .baseOriginFirst
+        )
+        #expect(comparisonRef == "origin/main")
+    }
+
+    @Test func baseOriginFirstComparesAgainstOriginBaseNotBranchUpstream() async throws {
+        let (worktree, _) = try await makeRepoWithUpstream()
+        defer { try? FileManager.default.removeItem(at: worktree.deletingLastPathComponent()) }
+        _ = try await Process.git(["checkout", "-q", "-b", "feature"], cwd: worktree)
+        _ = try await Process.git(["commit", "-q", "--allow-empty", "-m", "feat: work"], cwd: worktree)
+        _ = try await Process.git(["push", "-q", "-u", "origin", "feature"], cwd: worktree)
+
+        let svc = GitService()
+        // Upstream mode compares vs origin/feature -> nothing ahead.
+        let (up, upRef) = try await svc.commitsAhead(
+            at: worktree, baseBranch: "main", resolution: .upstreamThenBase
+        )
+        #expect(upRef == "origin/feature")
+        #expect(up.isEmpty)
+        // Auto compares vs origin/main -> lists the branch's own work.
+        let (auto, autoRef) = try await svc.commitsAhead(
+            at: worktree, baseBranch: "main", resolution: .baseOriginFirst
+        )
+        #expect(autoRef == "origin/main")
+        #expect(auto.count == 1)
+        #expect(auto[0].subject == "work")
     }
 }

--- a/AlasTests/CommitsAheadTests.swift
+++ b/AlasTests/CommitsAheadTests.swift
@@ -251,4 +251,28 @@ struct CommitsAheadTests {
         #expect(auto.count == 1)
         #expect(auto[0].subject == "work")
     }
+
+    @Test func baseOriginFirstPrefersOriginForSlashNamedBase() async throws {
+        let (worktree, _) = try await makeRepoWithUpstream()
+        defer { try? FileManager.default.removeItem(at: worktree.deletingLastPathComponent()) }
+        // Create a slash-named base that exists both locally and on origin.
+        _ = try await Process.git(["checkout", "-q", "-b", "release/1.0"], cwd: worktree)
+        _ = try await Process.git(["commit", "-q", "--allow-empty", "-m", "chore: release base"], cwd: worktree)
+        _ = try await Process.git(["push", "-q", "-u", "origin", "release/1.0"], cwd: worktree)
+        _ = try await Process.git(["checkout", "-q", "-b", "feature"], cwd: worktree)
+        _ = try await Process.git(["commit", "-q", "--allow-empty", "-m", "feat: feature work"], cwd: worktree)
+
+        let svc = GitService()
+        // Auto must prefer origin/release/1.0 even though the local branch exists,
+        // so a stale local release branch doesn't reintroduce rebase instability.
+        let (_, autoRef) = try await svc.commitsAhead(
+            at: worktree, baseBranch: "release/1.0", resolution: .baseOriginFirst
+        )
+        #expect(autoRef == "origin/release/1.0")
+        // Manual (local-first) still resolves the local slash-named branch.
+        let (_, manualRef) = try await svc.commitsAhead(
+            at: worktree, baseBranch: "release/1.0", resolution: .baseLocalFirst
+        )
+        #expect(manualRef == "release/1.0")
+    }
 }

--- a/AlasTests/RightPaneStateBaseBranchTests.swift
+++ b/AlasTests/RightPaneStateBaseBranchTests.swift
@@ -200,7 +200,7 @@ struct RightPaneStateBaseBranchTests {
         defer { try? FileManager.default.removeItem(at: root) }
         let wt = makeWorktree(at: repo, branch: "feature")
         let state = RightPaneState(worktree: wt, baseBranch: "main")
-        state.trackUpstreamForCommits = true
+        state.comparisonMode = .branchUpstream
 
         await state.refresh()
 
@@ -212,7 +212,7 @@ struct RightPaneStateBaseBranchTests {
         defer { try? FileManager.default.removeItem(at: repo) }
         let wt = makeWorktree(at: repo, branch: "feature")
         let state = RightPaneState(worktree: wt, baseBranch: "main")
-        state.trackUpstreamForCommits = true
+        state.comparisonMode = .branchUpstream
 
         await state.refresh()
 
@@ -240,33 +240,33 @@ struct RightPaneStateBaseBranchTests {
         defer { try? FileManager.default.removeItem(at: root) }
         let wt = makeWorktree(at: repo, branch: "feature")
         let store = RightPaneStore()
-        let state = store.state(for: wt, baseBranch: "main", trackUpstreamForCommits: true)
+        let state = store.state(for: wt, baseBranch: "main", comparisonMode: .branchUpstream)
 
         state.selectBaseBranch("develop")
         try await Task.sleep(for: .milliseconds(200))
         #expect(state.baseBranch == "develop")
         #expect(state.userOverrodeBaseBranch)
 
-        _ = store.state(for: wt, baseBranch: "develop", trackUpstreamForCommits: true)
+        _ = store.state(for: wt, baseBranch: "develop", comparisonMode: .branchUpstream)
         try await Task.sleep(for: .milliseconds(600))
 
         #expect(!state.userOverrodeBaseBranch)
         #expect(state.comparisonRef == "origin/feature")
     }
 
-    @Test func storeRefreshesWhenTrackUpstreamForCommitsToggles() async throws {
+    @Test func storeRefreshesWhenComparisonModeToggles() async throws {
         let (repo, root) = try await createTestRepoWithUpstream()
         defer { try? FileManager.default.removeItem(at: root) }
         let wt = makeWorktree(at: repo, branch: "feature")
         let store = RightPaneStore()
-        let state = store.state(for: wt, baseBranch: "master", trackUpstreamForCommits: true)
+        let state = store.state(for: wt, baseBranch: "master", comparisonMode: .branchUpstream)
         try await waitUntil { state.comparisonRef == "origin/feature" }
         #expect(state.comparisonRef == "origin/feature")
 
-        _ = store.state(for: wt, baseBranch: "master", trackUpstreamForCommits: false)
+        _ = store.state(for: wt, baseBranch: "master", comparisonMode: .manual)
         try await waitUntil { state.comparisonRef == "master" }
         #expect(state.comparisonRef == "master")
-        #expect(state.trackUpstreamForCommits == false)
+        #expect(state.comparisonMode == .manual)
     }
 
     @Test func commitEditorComparisonRefReturnsOnlyResolvedRef() async throws {
@@ -274,7 +274,7 @@ struct RightPaneStateBaseBranchTests {
         defer { try? FileManager.default.removeItem(at: tmp) }
         let wt = makeWorktree(at: tmp, branch: "feature")
         let store = RightPaneStore()
-        let state = store.state(for: wt, baseBranch: "main", trackUpstreamForCommits: false)
+        let state = store.state(for: wt, baseBranch: "main", comparisonMode: .manual)
 
         #expect(store.commitEditorComparisonRef(worktreeId: wt.id) == nil)
 
@@ -289,7 +289,7 @@ struct RightPaneStateBaseBranchTests {
         try "dirty\n".write(to: tmp.appendingPathComponent("stale.txt"), atomically: true, encoding: .utf8)
         let wt = makeWorktree(at: tmp, branch: "main")
         let store = RightPaneStore()
-        let state = store.state(for: wt, baseBranch: "main", trackUpstreamForCommits: false)
+        let state = store.state(for: wt, baseBranch: "main", comparisonMode: .manual)
         try await waitUntil { state.hasLoadedSnapshot && !state.displayChanges.isEmpty }
 
         store.invalidateSnapshot(worktreeId: wt.id)

--- a/AlasTests/RightPaneStoreBaseBranchTests.swift
+++ b/AlasTests/RightPaneStoreBaseBranchTests.swift
@@ -58,7 +58,7 @@ struct RightPaneStoreBaseBranchTests {
         _ = try await Process.git(["update-ref", "refs/remotes/origin/release/1.0", head], cwd: repo)
 
         let store = RightPaneStore(git: GitService())
-        let state = store.state(for: makeWorktree(at: repo, branch: "release/1.0"), baseBranch: "release/1.0", trackUpstreamForCommits: false)
+        let state = store.state(for: makeWorktree(at: repo, branch: "release/1.0"), baseBranch: "release/1.0", comparisonMode: .manual)
         #expect(state.baseBranch == "origin/release/1.0")
 
         try await Task.sleep(nanoseconds: 200_000_000)
@@ -73,7 +73,7 @@ struct RightPaneStoreBaseBranchTests {
         // resolver would return the local branch; our direct origin probe must
         // fall back to the configured base branch instead.
         let store = RightPaneStore(git: GitService())
-        let state = store.state(for: makeWorktree(at: repo, branch: "release/1.0"), baseBranch: "release/1.0", trackUpstreamForCommits: false)
+        let state = store.state(for: makeWorktree(at: repo, branch: "release/1.0"), baseBranch: "release/1.0", comparisonMode: .manual)
         #expect(state.baseBranch == "origin/release/1.0")
 
         try await Task.sleep(nanoseconds: 200_000_000)
@@ -86,7 +86,7 @@ struct RightPaneStoreBaseBranchTests {
 
         let store = RightPaneStore(git: GitService())
         let wt = makeWorktree(at: repo, branch: "main")
-        let state = store.state(for: wt, baseBranch: "main", trackUpstreamForCommits: false)
+        let state = store.state(for: wt, baseBranch: "main", comparisonMode: .manual)
         #expect(state.baseBranch == "origin/main")
         #expect(state.lastConfigBaseBranch == "main")
 
@@ -98,7 +98,7 @@ struct RightPaneStoreBaseBranchTests {
         // store must not reset baseBranch back to the non-existent origin/main
         // or re-trigger fallback probes each time.
         for _ in 0..<3 {
-            _ = store.state(for: wt, baseBranch: "main", trackUpstreamForCommits: false)
+            _ = store.state(for: wt, baseBranch: "main", comparisonMode: .manual)
             try await Task.sleep(nanoseconds: 50_000_000)
             #expect(state.baseBranch == "main")
             #expect(state.lastConfigBaseBranch == "main")
@@ -114,7 +114,7 @@ struct RightPaneStoreBaseBranchTests {
         _ = try await Process.git(["update-ref", "refs/remotes/origin/main", head], cwd: repo)
 
         let store = RightPaneStore(git: GitService())
-        let state = store.state(for: makeWorktree(at: repo, branch: "main"), baseBranch: "main", trackUpstreamForCommits: false)
+        let state = store.state(for: makeWorktree(at: repo, branch: "main"), baseBranch: "main", comparisonMode: .manual)
         #expect(state.baseBranch == "origin/main")
 
         try await Task.sleep(nanoseconds: 200_000_000)
@@ -126,7 +126,7 @@ struct RightPaneStoreBaseBranchTests {
         defer { try? FileManager.default.removeItem(at: repo) }
 
         let store = RightPaneStore(git: GitService())
-        let state = store.state(for: makeWorktree(at: repo, branch: "main"), baseBranch: "main", trackUpstreamForCommits: false)
+        let state = store.state(for: makeWorktree(at: repo, branch: "main"), baseBranch: "main", comparisonMode: .manual)
         #expect(state.baseBranch == "origin/main")
 
         try await Task.sleep(nanoseconds: 200_000_000)
@@ -142,7 +142,7 @@ struct RightPaneStoreBaseBranchTests {
         _ = try await Process.git(["branch", "develop"], cwd: repo)
 
         let store = RightPaneStore(git: GitService())
-        let state = store.state(for: makeWorktree(at: repo, branch: "main"), baseBranch: "main", trackUpstreamForCommits: false)
+        let state = store.state(for: makeWorktree(at: repo, branch: "main"), baseBranch: "main", comparisonMode: .manual)
         #expect(state.baseBranch == "origin/main")
 
         state.selectBaseBranch("develop")

--- a/docs/superpowers/plans/2026-07-13-changes-comparison-base-mode.md
+++ b/docs/superpowers/plans/2026-07-13-changes-comparison-base-mode.md
@@ -1,0 +1,715 @@
+# Changes tab comparison-base mode — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace the Changes tab's on/off "track upstream" checkbox with a three-way mode — **Auto** (compare against `origin/<base>`, rebase-stable, new default) · **Branch upstream** (compare against the branch's own `@{u}`) · **Manual** (compare against a per-worktree-selected base) — surfaced as a segmented control in Settings.
+
+**Architecture:** Introduce a `GitService.BaseResolution` enum that makes the three base-ref resolution strategies first-class (`upstreamThenBase`, `baseOriginFirst`, `baseLocalFirst`), replacing the old `ignoreUpstream: Bool` parameter on `commitsAhead`. Replace the persisted `changes.trackUpstreamForCommits: Bool` with a `changes.comparisonMode: ChangesComparisonMode` enum (migrating legacy configs: `true → .branchUpstream`, `false`/absent → `.auto`). A pure mapping (`BaseResolution.forCommits` / `.forReviewLoopBase`) turns `(mode, userOverrodeBaseBranch)` into a resolution at every call site.
+
+**Tech Stack:** Swift 5.9+, SwiftUI (macOS), Swift Testing (`import Testing`), git via `Process.git`.
+
+## Global Constraints
+
+- All code, comments, logs, and UI strings in English.
+- Tests use the Swift Testing framework (`import Testing`), not XCTest.
+- No agent attributions anywhere (no `Co-Authored-By`, no "Generated with", no 🤖) in commits, PRs, code, or docs.
+- Do not edit `Info.plist` directly; pinned keys live in `project.yml`. (Not expected to change here.)
+- No new files are added to the Xcode target without regenerating via `xcodegen` (Task 3 adds one file — regenerate + commit `project.yml`/`Alas.xcodeproj` if the new file is not picked up by the existing glob).
+- Build/test commands:
+  - `xcodegen`
+  - `xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -quiet build`
+  - `xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' test`
+- Each task must leave the project **building and all tests green** before its commit.
+
+## File map
+
+- `Alas/Sources/Git/GitService.swift` — `BaseResolution` enum + `commitsAhead` signature/logic (Task 1).
+- `AlasTests/CommitsAheadTests.swift` — update 3 existing `ignoreUpstream:` call sites; add Auto-mode tests (Task 1).
+- `Alas/Sources/Persistence/AppConfig.swift` — `ChangesComparisonMode` enum, `comparisonMode` property, migration decoder; legacy bool removal (Tasks 2 & 5).
+- `AlasTests/AppConfigChangesTests.swift` — migration tests (Task 2).
+- `Alas/Sources/Right/BaseResolutionMapping.swift` — **new**: pure `(mode, override) → BaseResolution` mapping (Task 3).
+- `AlasTests/BaseResolutionMappingTests.swift` — **new**: mapping unit tests (Task 3).
+- `Alas/Sources/Right/RightPaneState.swift` — resolution derivation + mirror property (Tasks 1 & 3).
+- `Alas/Sources/Right/RightPaneStore.swift` — `state(for:)` signature + sync (Task 3).
+- `Alas/Sources/Right/RightPaneView.swift`, `Alas/Sources/Center/CenterPaneView.swift` — `.task(id:)` keys + `state(for:)` calls (Task 3).
+- `Alas/Sources/App/AppState.swift` — two `state(for:)` calls + direct `commitsAhead` (Tasks 1 & 3).
+- `Alas/Sources/Center/Commit/CommitEditorTabView.swift` — resolution derivation (Tasks 1 & 3).
+- `Alas/Sources/Settings/ChangesPane.swift` — segmented control UI (Task 4).
+
+---
+
+### Task 1: `BaseResolution` enum in GitService (behavior-preserving refactor + new `.baseOriginFirst`)
+
+Replace the `ignoreUpstream: Bool` parameter on `commitsAhead` with an explicit
+`BaseResolution` enum. `.upstreamThenBase` and `.baseLocalFirst` reproduce
+today's `ignoreUpstream: false` / `true` behavior exactly; `.baseOriginFirst` is
+new (skip upstream, prefer `origin/<base>` over local `<base>`). All existing
+runtime call sites keep their current behavior by deriving the enum from the
+still-present `trackUpstreamForCommits` bool.
+
+**Files:**
+- Modify: `Alas/Sources/Git/GitService.swift` (enum near `commitsAhead`; signature/body at ~1191–1259)
+- Modify: `Alas/Sources/Right/RightPaneState.swift:553–568`
+- Modify: `Alas/Sources/App/AppState.swift:4405–4409`
+- Modify: `Alas/Sources/Center/Commit/CommitEditorTabView.swift:375,390`
+- Test: `AlasTests/CommitsAheadTests.swift`
+
+**Interfaces:**
+- Produces:
+  - `enum GitService.BaseResolution { case upstreamThenBase, baseOriginFirst, baseLocalFirst }`
+  - `func commitsAhead(at: URL, baseBranch: String? = nil, resolution: BaseResolution = .upstreamThenBase) async throws -> (commits: [CommitInfo], comparisonRef: String?)`
+
+- [ ] **Step 1: Update the 3 existing `ignoreUpstream: true` call sites in the test to the new enum, and add the two Auto-mode tests (failing — enum/param don't exist yet).**
+
+In `AlasTests/CommitsAheadTests.swift`, change the three existing calls:
+- Line ~183: `ignoreUpstream: true` → `resolution: .baseLocalFirst`
+- Line ~201: `ignoreUpstream: true` → `resolution: .baseLocalFirst`
+- Line ~213: `ignoreUpstream: true` → `resolution: .baseLocalFirst`
+
+Then add these tests to the `CommitsAheadTests` suite:
+
+```swift
+@Test func baseOriginFirstPrefersOriginOverLocalBase() async throws {
+    let (worktree, _) = try await makeRepoWithUpstream()
+    defer { try? FileManager.default.removeItem(at: worktree.deletingLastPathComponent()) }
+    _ = try await Process.git(["checkout", "-q", "-b", "feature"], cwd: worktree)
+    _ = try await Process.git(["commit", "-q", "--allow-empty", "-m", "feat: feature work"], cwd: worktree)
+
+    let svc = GitService()
+    // Local `main` and `origin/main` both exist; Auto prefers origin.
+    let (_, comparisonRef) = try await svc.commitsAhead(
+        at: worktree, baseBranch: "main", resolution: .baseOriginFirst
+    )
+    #expect(comparisonRef == "origin/main")
+}
+
+@Test func baseOriginFirstComparesAgainstOriginBaseNotBranchUpstream() async throws {
+    let (worktree, _) = try await makeRepoWithUpstream()
+    defer { try? FileManager.default.removeItem(at: worktree.deletingLastPathComponent()) }
+    _ = try await Process.git(["checkout", "-q", "-b", "feature"], cwd: worktree)
+    _ = try await Process.git(["commit", "-q", "--allow-empty", "-m", "feat: work"], cwd: worktree)
+    _ = try await Process.git(["push", "-q", "-u", "origin", "feature"], cwd: worktree)
+
+    let svc = GitService()
+    // Upstream mode compares vs origin/feature -> nothing ahead.
+    let (up, upRef) = try await svc.commitsAhead(
+        at: worktree, baseBranch: "main", resolution: .upstreamThenBase
+    )
+    #expect(upRef == "origin/feature")
+    #expect(up.isEmpty)
+    // Auto compares vs origin/main -> lists the branch's own work.
+    let (auto, autoRef) = try await svc.commitsAhead(
+        at: worktree, baseBranch: "main", resolution: .baseOriginFirst
+    )
+    #expect(autoRef == "origin/main")
+    #expect(auto.count == 1)
+    #expect(auto[0].subject == "work")
+}
+```
+
+- [ ] **Step 2: Run the new tests to confirm they fail to compile / fail.**
+
+Run: `xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' test -only-testing:AlasTests/CommitsAheadTests 2>&1 | tail -30`
+Expected: compile failure — `commitsAhead` has no `resolution:` parameter / `BaseResolution` undefined.
+
+- [ ] **Step 3: Add the `BaseResolution` enum and rewrite `commitsAhead` to switch on it.**
+
+In `Alas/Sources/Git/GitService.swift`, add the enum just above `commitsAhead` (inside `GitService`):
+
+```swift
+/// How `commitsAhead` chooses the ref it compares `HEAD` against.
+/// - `upstreamThenBase`: use the branch's own upstream `@{u}` when it
+///   resolves, otherwise the base branch (origin-qualified, then local).
+/// - `baseOriginFirst`: never use `@{u}`; prefer `origin/<base>`, then local
+///   `<base>`. Rebase-stable ("Auto").
+/// - `baseLocalFirst`: never use `@{u}`; prefer local `<base>`, then
+///   `origin/<base>` ("Manual").
+enum BaseResolution {
+    case upstreamThenBase
+    case baseOriginFirst
+    case baseLocalFirst
+}
+```
+
+Change the signature (line ~1191):
+
+```swift
+func commitsAhead(
+    at worktree: URL,
+    baseBranch: String? = nil,
+    resolution: BaseResolution = .upstreamThenBase
+) async throws -> (commits: [CommitInfo], comparisonRef: String?) {
+```
+
+Replace Step 1's guard `if !ignoreUpstream {` (line ~1196) with:
+
+```swift
+        var upstreamName: String? = nil
+        if resolution == .upstreamThenBase {
+```
+
+Replace the entire Step 2 base-resolution block (the `var baseName: String? = nil` block, lines ~1213–1254) with:
+
+```swift
+        // Step 2: If no upstream ref was chosen, resolve the base branch.
+        // Slash-named bases are ambiguous, so always resolve local first for
+        // them; simple names follow the requested preference.
+        func refExists(_ ref: String) async -> Bool {
+            let r = try? await Process.git(["show-ref", "--verify", "--quiet", ref], cwd: worktree)
+            return r?.exitCode == 0
+        }
+        var baseName: String? = nil
+        if upstreamName == nil, let base = baseBranch, !base.isEmpty {
+            if base.contains("/") {
+                if await refExists("refs/heads/\(base)") {
+                    baseName = base
+                } else if await refExists("refs/remotes/\(base)") {
+                    baseName = base
+                }
+            }
+            if baseName == nil {
+                let localExists = await refExists("refs/heads/\(base)")
+                let originExists = await refExists("refs/remotes/origin/\(base)")
+                switch resolution {
+                case .baseLocalFirst:
+                    if localExists { baseName = base }
+                    else if originExists { baseName = "origin/\(base)" }
+                case .baseOriginFirst, .upstreamThenBase:
+                    if originExists { baseName = "origin/\(base)" }
+                    else if localExists { baseName = base }
+                }
+            }
+        }
+```
+
+(Note: `.baseOriginFirst` and `.upstreamThenBase` share identical *base* ordering — origin then local. They differ only in whether Step 1 consulted `@{u}`. This matches today's behavior for `.upstreamThenBase`.)
+
+- [ ] **Step 4: Update the four runtime call sites to derive the enum from the existing bool (behavior-preserving).**
+
+`Alas/Sources/Right/RightPaneState.swift` — replace lines ~553 and the two `commitsAhead` calls (~559–568):
+
+```swift
+            let ignoreUpstream = userOverrodeBaseBranch || !trackUpstreamForCommits
+            let commitsResolution: GitService.BaseResolution = ignoreUpstream ? .baseLocalFirst : .upstreamThenBase
+            async let s = git.status(worktreePath: worktree.path)
+            async let statusRaw = Process.git(
+                ["status", "--porcelain=v2", "-z", "--untracked-files=all"],
+                cwd: worktree.path
+            )
+            async let c = git.commitsAhead(
+                at: worktree.path,
+                baseBranch: baseBranch,
+                resolution: commitsResolution
+            )
+            async let reviewLoopBase = git.commitsAhead(
+                at: worktree.path,
+                baseBranch: baseBranch,
+                resolution: .baseLocalFirst
+            )
+```
+
+`Alas/Sources/App/AppState.swift` — replace line ~4408:
+
+```swift
+            async let commits = git.commitsAhead(
+                at: worktree.path,
+                baseBranch: config.worktrees.baseBranch,
+                resolution: config.changes.trackUpstreamForCommits ? .upstreamThenBase : .baseLocalFirst
+            )
+```
+
+`Alas/Sources/Center/Commit/CommitEditorTabView.swift` — replace line ~375 and the call at ~390:
+
+```swift
+        let commitsResolution: GitService.BaseResolution =
+            appState.config.changes.trackUpstreamForCommits ? .upstreamThenBase : .baseLocalFirst
+```
+
+and at the call site (~390) replace `ignoreUpstream: ignoreUpstream` with `resolution: commitsResolution`.
+
+- [ ] **Step 5: Build and run the full test suite.**
+
+Run: `xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -quiet build && xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' test 2>&1 | tail -20`
+Expected: build succeeds; all tests pass (existing `CommitsAheadTests` still green with `.baseLocalFirst`; the two new Auto tests pass).
+
+- [ ] **Step 6: Commit.**
+
+```bash
+git add Alas/Sources/Git/GitService.swift Alas/Sources/Right/RightPaneState.swift Alas/Sources/App/AppState.swift Alas/Sources/Center/Commit/CommitEditorTabView.swift AlasTests/CommitsAheadTests.swift
+git commit -m "refactor(git): replace commitsAhead ignoreUpstream flag with BaseResolution enum"
+```
+
+---
+
+### Task 2: `ChangesComparisonMode` config enum + migration (coexisting with the legacy bool)
+
+Add the persisted mode enum and its migration alongside the existing
+`trackUpstreamForCommits` bool. Nothing reads the new field at runtime yet; this
+task is purely the config surface + migration so it can be tested in isolation.
+
+**Files:**
+- Modify: `Alas/Sources/Persistence/AppConfig.swift` (Changes struct ~294–321; defaults ~427–437; decoder ~652–688)
+- Test: `AlasTests/AppConfigChangesTests.swift`
+
+**Interfaces:**
+- Produces:
+  - `enum AppConfig.ChangesComparisonMode: String, Codable { case auto, branchUpstream, manual }`
+  - `AppConfig.Changes.comparisonMode: ChangesComparisonMode` (default `.auto`)
+
+- [ ] **Step 1: Write failing migration tests.**
+
+Add to `AlasTests/AppConfigChangesTests.swift` (a helper plus four tests). The helper round-trips `AppConfig.defaults` through JSON, mutating only the `changes` object, so the full-config decode path (which requires e.g. `harness`) stays valid:
+
+```swift
+    private func decodeChanges(mutating: ([String: Any]) -> [String: Any]) throws -> AppConfig.Changes {
+        let data = try JSONEncoder().encode(AppConfig.defaults)
+        var obj = try JSONSerialization.jsonObject(with: data) as! [String: Any]
+        obj["changes"] = mutating(obj["changes"] as! [String: Any])
+        let mutated = try JSONSerialization.data(withJSONObject: obj)
+        return try JSONDecoder().decode(AppConfig.self, from: mutated).changes
+    }
+
+    @Test func migratesLegacyTrackUpstreamTrueToBranchUpstream() throws {
+        let changes = try decodeChanges { var c = $0; c.removeValue(forKey: "comparisonMode"); c["trackUpstreamForCommits"] = true; return c }
+        #expect(changes.comparisonMode == .branchUpstream)
+    }
+
+    @Test func migratesLegacyTrackUpstreamFalseToAuto() throws {
+        let changes = try decodeChanges { var c = $0; c.removeValue(forKey: "comparisonMode"); c["trackUpstreamForCommits"] = false; return c }
+        #expect(changes.comparisonMode == .auto)
+    }
+
+    @Test func defaultsToAutoWhenNeitherKeyPresent() throws {
+        let changes = try decodeChanges { var c = $0; c.removeValue(forKey: "comparisonMode"); c.removeValue(forKey: "trackUpstreamForCommits"); return c }
+        #expect(changes.comparisonMode == .auto)
+    }
+
+    @Test func explicitComparisonModeWinsOverLegacyBool() throws {
+        let changes = try decodeChanges { var c = $0; c["comparisonMode"] = "manual"; c["trackUpstreamForCommits"] = true; return c }
+        #expect(changes.comparisonMode == .manual)
+    }
+```
+
+- [ ] **Step 2: Run the tests to confirm they fail.**
+
+Run: `xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' test -only-testing:AlasTests/AppConfigChangesTests 2>&1 | tail -30`
+Expected: compile failure — `comparisonMode` / `ChangesComparisonMode` undefined.
+
+- [ ] **Step 3: Add the enum + property + CodingKey.**
+
+In `Alas/Sources/Persistence/AppConfig.swift`, inside `struct Changes` add the enum and property (keep `trackUpstreamForCommits` for now):
+
+```swift
+        /// How the Commits section chooses its comparison base.
+        /// - `auto` (default): compare against `origin/<base>` (falls back to
+        ///   local `<base>`); stable across rebases.
+        /// - `branchUpstream`: compare against the branch's own `@{u}`.
+        /// - `manual`: compare against the per-worktree selected base branch.
+        enum ChangesComparisonMode: String, Codable {
+            case auto
+            case branchUpstream
+            case manual
+        }
+        var comparisonMode: ChangesComparisonMode
+```
+
+Add `comparisonMode` to the `CodingKeys` enum (line ~317–320):
+
+```swift
+        enum CodingKeys: String, CodingKey {
+            case aiToolId, prompt, reviewRequestPrompt, mergeBulkResolvePrompt,
+                 mergeSingleResolvePrompt, trackUpstreamForCommits, comparisonMode,
+                 diffLayoutMode, diffWrapLines, diffShowWhitespace
+        }
+```
+
+- [ ] **Step 4: Set the default and both decoder branches, with migration.**
+
+In the defaults factory (`Changes(` at ~427), add after `trackUpstreamForCommits: false,`:
+
+```swift
+            comparisonMode: .auto,
+```
+
+In the decoder's `if let changesContainer` branch, after the `trackUpstream` line (~661) add:
+
+```swift
+            let comparisonMode: Changes.ChangesComparisonMode = {
+                if let explicit = try? changesContainer.decode(Changes.ChangesComparisonMode.self, forKey: .comparisonMode) {
+                    return explicit
+                }
+                return trackUpstream ? .branchUpstream : .auto
+            }()
+```
+
+and pass `comparisonMode: comparisonMode,` into the `Changes(` initializer (after `trackUpstreamForCommits: trackUpstream,`).
+
+In the `else` branch (~677 `Changes(`), add `comparisonMode: .auto,` after `trackUpstreamForCommits: false,`.
+
+- [ ] **Step 5: Build and run the tests.**
+
+Run: `xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -quiet build && xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' test -only-testing:AlasTests/AppConfigChangesTests 2>&1 | tail -20`
+Expected: build succeeds; all four migration tests pass.
+
+- [ ] **Step 6: Commit.**
+
+```bash
+git add Alas/Sources/Persistence/AppConfig.swift AlasTests/AppConfigChangesTests.swift
+git commit -m "feat(config): add changes.comparisonMode with legacy trackUpstream migration"
+```
+
+---
+
+### Task 3: Route runtime readers through `comparisonMode`
+
+Introduce the pure `(mode, override) → BaseResolution` mapping and switch every
+runtime reader from the bool to `comparisonMode`. This is where Auto's
+`.baseOriginFirst` and the per-worktree-override → Manual rule take effect at
+runtime. Also switch the review-loop base to mirror the mode's base flavor
+(`.baseOriginFirst` except Manual/override → `.baseLocalFirst`).
+
+**Files:**
+- Create: `Alas/Sources/Right/BaseResolutionMapping.swift`
+- Test: `AlasTests/BaseResolutionMappingTests.swift`
+- Modify: `Alas/Sources/Right/RightPaneState.swift` (mirror prop ~175; derivation ~553–568)
+- Modify: `Alas/Sources/Right/RightPaneStore.swift` (~64, 69, 121, 137; and the mirror sync)
+- Modify: `Alas/Sources/Right/RightPaneView.swift:188–196`
+- Modify: `Alas/Sources/Center/CenterPaneView.swift:306,314`
+- Modify: `Alas/Sources/App/AppState.swift:3208–3212, 3572–3576, 4405–4409`
+- Modify: `Alas/Sources/Center/Commit/CommitEditorTabView.swift:375`
+
+**Interfaces:**
+- Consumes: `GitService.BaseResolution` (Task 1), `AppConfig.Changes.ChangesComparisonMode` (Task 2).
+- Produces:
+  - `GitService.BaseResolution.forCommits(mode:userOverrodeBaseBranch:) -> BaseResolution`
+  - `GitService.BaseResolution.forReviewLoopBase(mode:userOverrodeBaseBranch:) -> BaseResolution`
+  - `RightPaneStore.state(for:baseBranch:comparisonMode:)` (renamed param)
+  - `RightPaneState.comparisonMode: AppConfig.Changes.ChangesComparisonMode`
+
+- [ ] **Step 1: Write failing mapping tests.**
+
+Create `AlasTests/BaseResolutionMappingTests.swift`:
+
+```swift
+import Testing
+@testable import Alas
+
+struct BaseResolutionMappingTests {
+    typealias Mode = AppConfig.Changes.ChangesComparisonMode
+
+    @Test func autoMapsToOriginFirst() {
+        #expect(GitService.BaseResolution.forCommits(mode: .auto, userOverrodeBaseBranch: false) == .baseOriginFirst)
+    }
+    @Test func branchUpstreamMapsToUpstreamThenBase() {
+        #expect(GitService.BaseResolution.forCommits(mode: .branchUpstream, userOverrodeBaseBranch: false) == .upstreamThenBase)
+    }
+    @Test func manualMapsToLocalFirst() {
+        #expect(GitService.BaseResolution.forCommits(mode: .manual, userOverrodeBaseBranch: false) == .baseLocalFirst)
+    }
+    @Test func perWorktreeOverrideForcesLocalFirstRegardlessOfMode() {
+        #expect(GitService.BaseResolution.forCommits(mode: .auto, userOverrodeBaseBranch: true) == .baseLocalFirst)
+        #expect(GitService.BaseResolution.forCommits(mode: .branchUpstream, userOverrodeBaseBranch: true) == .baseLocalFirst)
+    }
+    @Test func reviewLoopBaseIsOriginFirstExceptManualAndOverride() {
+        #expect(GitService.BaseResolution.forReviewLoopBase(mode: .auto, userOverrodeBaseBranch: false) == .baseOriginFirst)
+        #expect(GitService.BaseResolution.forReviewLoopBase(mode: .branchUpstream, userOverrodeBaseBranch: false) == .baseOriginFirst)
+        #expect(GitService.BaseResolution.forReviewLoopBase(mode: .manual, userOverrodeBaseBranch: false) == .baseLocalFirst)
+        #expect(GitService.BaseResolution.forReviewLoopBase(mode: .auto, userOverrodeBaseBranch: true) == .baseLocalFirst)
+    }
+}
+```
+
+For these to compile, `GitService.BaseResolution` must be `Equatable`. Add `: Equatable` to the enum in `GitService.swift` if not already (it is a payload-free enum, so `enum BaseResolution: Equatable`).
+
+- [ ] **Step 2: Run to confirm failure.**
+
+Run: `xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' test -only-testing:AlasTests/BaseResolutionMappingTests 2>&1 | tail -30`
+Expected: compile failure — `forCommits` / `forReviewLoopBase` undefined.
+
+- [ ] **Step 3: Create the mapping.**
+
+Create `Alas/Sources/Right/BaseResolutionMapping.swift`:
+
+```swift
+import Foundation
+
+extension GitService.BaseResolution {
+    /// The resolution for the Commits section, given the global mode and
+    /// whether this worktree has a manual per-worktree base override.
+    static func forCommits(
+        mode: AppConfig.Changes.ChangesComparisonMode,
+        userOverrodeBaseBranch: Bool
+    ) -> GitService.BaseResolution {
+        if userOverrodeBaseBranch { return .baseLocalFirst }
+        switch mode {
+        case .auto: return .baseOriginFirst
+        case .branchUpstream: return .upstreamThenBase
+        case .manual: return .baseLocalFirst
+        }
+    }
+
+    /// The resolution for the review-loop base. It never uses the branch's own
+    /// upstream — it wants a stable remote base — so every non-Manual mode maps
+    /// to origin-first.
+    static func forReviewLoopBase(
+        mode: AppConfig.Changes.ChangesComparisonMode,
+        userOverrodeBaseBranch: Bool
+    ) -> GitService.BaseResolution {
+        if userOverrodeBaseBranch { return .baseLocalFirst }
+        return mode == .manual ? .baseLocalFirst : .baseOriginFirst
+    }
+}
+```
+
+If the build does not pick this file up automatically, run `xcodegen` and commit the regenerated `Alas.xcodeproj` alongside this task.
+
+- [ ] **Step 4: Add the `comparisonMode` mirror to `RightPaneState` and use the mapping.**
+
+In `Alas/Sources/Right/RightPaneState.swift`, replace the `trackUpstreamForCommits` mirror property (~170–175) with:
+
+```swift
+    /// Mirrors `AppConfig.changes.comparisonMode`. Synced by `RightPaneStore`
+    /// on every `state(for:)` call. Combined with `userOverrodeBaseBranch`, it
+    /// selects the `BaseResolution` `refresh()` passes to `commitsAhead`.
+    var comparisonMode: AppConfig.Changes.ChangesComparisonMode = .auto
+```
+
+Replace the derivation added in Task 1 (the `ignoreUpstream` / `commitsResolution` lines and the two `commitsAhead` calls, ~553–568) with:
+
+```swift
+            let commitsResolution = GitService.BaseResolution.forCommits(
+                mode: comparisonMode, userOverrodeBaseBranch: userOverrodeBaseBranch
+            )
+            let reviewLoopResolution = GitService.BaseResolution.forReviewLoopBase(
+                mode: comparisonMode, userOverrodeBaseBranch: userOverrodeBaseBranch
+            )
+            async let s = git.status(worktreePath: worktree.path)
+            async let statusRaw = Process.git(
+                ["status", "--porcelain=v2", "-z", "--untracked-files=all"],
+                cwd: worktree.path
+            )
+            async let c = git.commitsAhead(
+                at: worktree.path,
+                baseBranch: baseBranch,
+                resolution: commitsResolution
+            )
+            async let reviewLoopBase = git.commitsAhead(
+                at: worktree.path,
+                baseBranch: baseBranch,
+                resolution: reviewLoopResolution
+            )
+```
+
+- [ ] **Step 5: Update `RightPaneStore.state(for:)`.**
+
+In `Alas/Sources/Right/RightPaneStore.swift`:
+- Line ~64 signature: `func state(for worktree: Worktree, baseBranch: String, comparisonMode: AppConfig.Changes.ChangesComparisonMode) -> RightPaneState {`
+- Line ~69: `let trackUpstreamChanged = existing.comparisonMode != comparisonMode`
+- Line ~121: `existing.comparisonMode = comparisonMode`
+- Line ~137: `new.comparisonMode = comparisonMode`
+- Rename the local `trackUpstreamChanged` usages consistently (keep the variable name or rename to `comparisonModeChanged`; if renamed, update its one `if` usage at ~120).
+
+- [ ] **Step 6: Update the four `state(for:)` / `commitsAhead` call sites and CommitEditorTabView.**
+
+`Alas/Sources/Right/RightPaneView.swift` — `.task(id:)` (~188) and call (~192–196):
+
+```swift
+        .task(id: "\(worktree.id)\u{0000}\(worktree.branch)\u{0000}\(state.config.worktrees.baseBranch)\u{0000}\(state.config.changes.comparisonMode.rawValue)") {
+            if rps?.worktree.id != worktree.id {
+                rps = nil
+            }
+            let activated = state.rightPaneStore.state(
+                for: worktree,
+                baseBranch: state.config.worktrees.baseBranch,
+                comparisonMode: state.config.changes.comparisonMode
+            )
+            rps = activated
+            await activated.refresh()
+        }
+```
+
+`Alas/Sources/Center/CenterPaneView.swift` — key (~306) and call (~311–315):
+
+```swift
+    private var rightPaneActivationKey: String {
+        "\(worktree.id)\u{0000}\(worktree.branch)\u{0000}\(state.config.worktrees.baseBranch)\u{0000}\(state.config.changes.comparisonMode.rawValue)"
+    }
+```
+```swift
+        state.rightPaneStore.state(
+            for: worktree,
+            baseBranch: state.config.worktrees.baseBranch,
+            comparisonMode: state.config.changes.comparisonMode
+        )
+```
+
+`Alas/Sources/App/AppState.swift` — the two store calls (~3208–3212 and ~3572–3576) replace `trackUpstreamForCommits: config.changes.trackUpstreamForCommits` with `comparisonMode: config.changes.comparisonMode`. Replace the direct `commitsAhead` (~4405–4409):
+
+```swift
+            async let commits = git.commitsAhead(
+                at: worktree.path,
+                baseBranch: config.worktrees.baseBranch,
+                resolution: GitService.BaseResolution.forCommits(
+                    mode: config.changes.comparisonMode, userOverrodeBaseBranch: false
+                )
+            )
+```
+
+`Alas/Sources/Center/Commit/CommitEditorTabView.swift` — replace the `commitsResolution` line from Task 1 (~375):
+
+```swift
+        let commitsResolution = GitService.BaseResolution.forCommits(
+            mode: appState.config.changes.comparisonMode, userOverrodeBaseBranch: false
+        )
+```
+
+- [ ] **Step 7: Build and run the full suite.**
+
+Run: `xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -quiet build && xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' test 2>&1 | tail -20`
+Expected: build succeeds; all tests pass, including `BaseResolutionMappingTests`. (`ChangesPane` still binds the legacy bool and still compiles — it is switched in Task 4.)
+
+- [ ] **Step 8: Commit.**
+
+```bash
+git add Alas/Sources/Right/BaseResolutionMapping.swift AlasTests/BaseResolutionMappingTests.swift Alas/Sources/Right/RightPaneState.swift Alas/Sources/Right/RightPaneStore.swift Alas/Sources/Right/RightPaneView.swift Alas/Sources/Center/CenterPaneView.swift Alas/Sources/App/AppState.swift Alas/Sources/Center/Commit/CommitEditorTabView.swift Alas.xcodeproj project.yml
+git commit -m "feat(changes): drive comparison base from comparisonMode at runtime"
+```
+
+(Include `Alas.xcodeproj`/`project.yml` in the commit only if `xcodegen` changed them.)
+
+---
+
+### Task 4: Segmented control in Settings
+
+Replace the "Track upstream branch" toggle with a three-way segmented control
+bound to `comparisonMode`, plus a per-selection description explaining what each
+mode compares against.
+
+**Files:**
+- Modify: `Alas/Sources/Settings/ChangesPane.swift:16–23`
+
+**Interfaces:**
+- Consumes: `AppConfig.Changes.ChangesComparisonMode`, `state.bind(_:)`.
+
+- [ ] **Step 1: Replace the toggle row with a segmented `Picker` + dynamic description.**
+
+In `Alas/Sources/Settings/ChangesPane.swift`, replace the `SettingsGroup(title: "Commits section")` block (lines ~16–23) with:
+
+```swift
+                SettingsGroup(title: "Comparison base") {
+                    SettingsRow(
+                        name: "Compare commits against",
+                        desc: comparisonModeDescription
+                    ) {
+                        Picker("", selection: state.bind(\.changes.comparisonMode)) {
+                            Text("Auto").tag(AppConfig.Changes.ChangesComparisonMode.auto)
+                            Text("Branch upstream").tag(AppConfig.Changes.ChangesComparisonMode.branchUpstream)
+                            Text("Manual").tag(AppConfig.Changes.ChangesComparisonMode.manual)
+                        }
+                        .pickerStyle(.segmented)
+                        .labelsHidden()
+                    }
+                }
+```
+
+Add this computed property to `ChangesPane` (near `body`):
+
+```swift
+    private var comparisonModeDescription: String {
+        switch state.config.changes.comparisonMode {
+        case .auto:
+            return "Compares against origin/<base> (falls back to your local base branch). Always shows this branch's own work and stays stable across rebases."
+        case .branchUpstream:
+            return "Compares against this branch's own remote tracking ref, so it only lists unpushed commits once you push."
+        case .manual:
+            return "Compares against the base branch you pick per worktree (via the base-branch selector), resolved locally first."
+        }
+    }
+```
+
+- [ ] **Step 2: Build.**
+
+Run: `xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -quiet build 2>&1 | tail -20`
+Expected: build succeeds.
+
+- [ ] **Step 3: Verify the control end-to-end.**
+
+Launch the app (see the `/run` skill or `xcodebuild ... -destination 'platform=macOS'` run), open Settings → Changes, confirm the segmented control shows Auto · Branch upstream · Manual, that the description updates per selection, and that switching it re-drives the Commits section comparison. Confirm the change persists across relaunch (config round-trip). Note the result of this manual check in the commit body or task notes.
+
+- [ ] **Step 4: Commit.**
+
+```bash
+git add Alas/Sources/Settings/ChangesPane.swift
+git commit -m "feat(settings): segmented comparison-base control for the Changes tab"
+```
+
+---
+
+### Task 5: Remove the legacy `trackUpstreamForCommits` bool
+
+Nothing reads the bool at runtime anymore. Remove it from the config surface,
+keeping the decoder's ability to read the legacy key for migration via a local
+legacy-key container (so `Changes`'s synthesized `Codable` stays valid without a
+matching stored property).
+
+**Files:**
+- Modify: `Alas/Sources/Persistence/AppConfig.swift`
+
+**Interfaces:**
+- Removes: `AppConfig.Changes.trackUpstreamForCommits`.
+
+- [ ] **Step 1: Confirm no runtime readers remain.**
+
+Run: `grep -rn "trackUpstreamForCommits" Alas/Sources`
+Expected: only occurrences inside `AppConfig.swift` (schema, CodingKeys, defaults, decoder). If any other file still references it, that file was missed in Task 3 — fix it before proceeding.
+
+- [ ] **Step 2: Add a legacy-key container and drop the property/key.**
+
+In `AppConfig.swift`:
+
+1. Delete the `var trackUpstreamForCommits: Bool` property (~312) and its doc comment.
+2. Remove `trackUpstreamForCommits` from `Changes.CodingKeys` (~318).
+3. Add a private legacy key type (top-level within `AppConfig` or file scope):
+
+```swift
+private enum LegacyChangesKey: String, CodingKey {
+    case trackUpstreamForCommits
+}
+```
+
+4. In the decoder's `if let changesContainer` branch, replace the `trackUpstream` decode (~661) so it reads through a *separate* container keyed by the legacy key (the `changesContainer` no longer knows this key):
+
+```swift
+            let legacyTrackUpstream: Bool? = {
+                guard let legacy = try? c.nestedContainer(keyedBy: LegacyChangesKey.self, forKey: .changes) else { return nil }
+                return try? legacy.decode(Bool.self, forKey: .trackUpstreamForCommits)
+            }()
+            let comparisonMode: Changes.ChangesComparisonMode = {
+                if let explicit = try? changesContainer.decode(Changes.ChangesComparisonMode.self, forKey: .comparisonMode) {
+                    return explicit
+                }
+                return (legacyTrackUpstream == true) ? .branchUpstream : .auto
+            }()
+```
+
+5. Remove `trackUpstreamForCommits: ...,` from all three `Changes(` initializers (defaults ~433, decoder `if` branch ~671, decoder `else` branch ~683).
+
+- [ ] **Step 3: Build and run the full suite (migration tests must still pass).**
+
+Run: `xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -quiet build && xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' test 2>&1 | tail -20`
+Expected: build succeeds; `AppConfigChangesTests` (including the four migration tests) all pass — the legacy `true → .branchUpstream` / `false`/absent `→ .auto` behavior still works through the legacy-key container.
+
+- [ ] **Step 4: Commit.**
+
+```bash
+git add Alas/Sources/Persistence/AppConfig.swift
+git commit -m "chore(config): drop legacy trackUpstreamForCommits bool"
+```
+
+---
+
+## Self-review notes
+
+- **Spec coverage:** Auto/Upstream/Manual modes (Tasks 1+3), `origin/<base>`-first Auto resolution (Task 1 `.baseOriginFirst`), config enum + migration OFF→Auto / ON→Branch upstream (Tasks 2, 5), per-worktree override → Manual (`forCommits` override branch, Task 3), review-loop base mirrors mode (`forReviewLoopBase`, Task 3), segmented UI with per-mode description (Task 4), all ~15 call sites threaded (Tasks 1, 3), test coverage for migration + resolution + mapping (Tasks 1–3). No non-goals implemented (no override persistence, no diff two/three-dot change).
+- **Type consistency:** `BaseResolution` (cases `upstreamThenBase`/`baseOriginFirst`/`baseLocalFirst`, `Equatable`) is defined in Task 1 and consumed unchanged in Task 3; `ChangesComparisonMode` (cases `auto`/`branchUpstream`/`manual`) defined in Task 2, consumed in Tasks 3–5; `state(for:baseBranch:comparisonMode:)` renamed once (Task 3) and all four callers updated in the same task.
+- **Green between tasks:** the legacy bool intentionally coexists with `comparisonMode` from Task 2 until Task 5 so every intermediate task builds and tests clean; `ChangesPane` keeps binding the bool until Task 4, and the bool is only removed once nothing reads it (Task 5 Step 1 guards this).

--- a/docs/superpowers/specs/2026-07-13-changes-comparison-base-mode-design.md
+++ b/docs/superpowers/specs/2026-07-13-changes-comparison-base-mode-design.md
@@ -1,0 +1,211 @@
+# Changes tab: comparison-base mode
+
+## Problem
+
+The Changes tab compares the current worktree's `HEAD` against a base ref to
+list "commits ahead" and drive per-file range diffs. Today there are two
+behaviors, toggled by a single `Bool` (`changes.trackUpstreamForCommits`):
+
+- **Checkbox OFF** (default): compare against **local `<base>`** — resolution
+  prefers `refs/heads/<base>`, only falling back to `origin/<base>` when no
+  local ref exists. Fragile across rebases: after rebasing your branch onto a
+  moved `origin/main`, a stale local `main` makes other people's merged commits
+  appear as "your work."
+- **Checkbox ON**: compare against the branch's own upstream `@{u}`
+  (`origin/<this-branch>`) once pushed, falling back to `origin/<base>` before
+  the branch is pushed. Hides your work once it's pushed — the opposite of
+  "always show what this worktree did."
+
+Neither reliably answers "show me the work actually done in this worktree,
+regardless of rebases." We want a third behavior that always compares against
+the canonical remote base and is stable across rebases, plus a clearer settings
+control than a single checkbox.
+
+## Goals
+
+- Add an **Auto** comparison mode that always shows the branch's own work versus
+  the canonical remote base, stable across rebases.
+- Replace the checkbox with a three-way segmented control: **Auto · Branch
+  upstream · Manual**.
+- Make **Auto** the new default; migrate existing configs without surprising
+  users who explicitly opted into upstream tracking.
+- Keep the per-worktree base override (`BaseBranchSelector`) working as the
+  natural "Manual" path.
+
+## Non-goals
+
+- Persisting the per-worktree manual base override across app restarts (stays
+  in-session, as today).
+- Changing the diff computation itself (two-dot vs three-dot / merge-base
+  behavior is unchanged).
+- Reworking the global `worktrees.baseBranch` setting UX.
+
+## Behavior model
+
+Resolution is a **per-worktree effective mode**:
+
+- If the worktree has a manual base override (the user picked a branch in
+  `BaseBranchSelector`, i.e. `userOverrodeBaseBranch == true`) → **Manual**
+  against that branch, regardless of the global mode.
+- Otherwise → the **global mode** from settings.
+
+The three modes resolve the comparison ref used for `git log <ref>..HEAD`:
+
+| Mode | Resolution | Shows |
+|---|---|---|
+| **Auto** *(new default)* | `origin/<base>` if it resolves, else local `<base>`. Never consults the branch's own upstream `@{u}`. | The branch's full work vs the canonical remote base; stable across rebases. |
+| **Branch upstream** | `@{u}` (`origin/<this-branch>`) if the branch is pushed, else `origin/<base>`. *(= today's checkbox ON)* | Only unpushed commits once the branch is pushed. |
+| **Manual** | The configured / per-worktree-selected base, **local-first** (local `<base>`, else `origin/<base>`). *(= today's checkbox OFF)* | Everything since the local base. |
+
+`<base>` is `config.worktrees.baseBranch` (default `main`) for the global modes,
+or the branch chosen in `BaseBranchSelector` for a per-worktree override.
+
+Rebase-robustness rationale: after rebasing a pushed branch onto a moved
+`origin/main`, comparing two-dot against `origin/main` (Auto) yields exactly the
+branch's own commits, whereas comparing against a stale local `main` also lists
+the newly-merged upstream commits.
+
+## Config schema and migration
+
+In `AppConfig.Changes` (`Alas/Sources/Persistence/AppConfig.swift`), replace:
+
+```swift
+var trackUpstreamForCommits: Bool   // default false
+```
+
+with:
+
+```swift
+enum ChangesComparisonMode: String, Codable {
+    case auto
+    case branchUpstream
+    case manual
+}
+
+var comparisonMode: ChangesComparisonMode   // default .auto
+```
+
+The custom `Codable` conformance for `Changes` (decoder around
+AppConfig.swift:661) migrates:
+
+1. If the new `comparisonMode` key is present → use it.
+2. Else if the legacy `trackUpstreamForCommits` key is present:
+   - `true`  → `.branchUpstream`
+   - `false` → `.auto`
+3. Else (neither key) → `.auto`.
+
+Effect: users who never touched the setting, or explicitly had it OFF, silently
+upgrade to Auto; users who opted into upstream tracking keep it. Update the
+default factory (AppConfig.swift:433) and both decoder branches (661, 683) to
+the enum.
+
+## Git resolution
+
+Replace the boolean parameter on `commitsAhead` with an explicit strategy enum
+so the three base flavors are first-class rather than encoded in a `Bool`.
+
+In `Alas/Sources/Git/GitService.swift`:
+
+```swift
+enum BaseResolution {
+    case upstreamThenBase   // existing ignoreUpstream: false path
+    case baseOriginFirst    // NEW: skip @{u}, resolve origin/<base> first
+    case baseLocalFirst     // existing ignoreUpstream: true path (local-first)
+}
+
+func commitsAhead(
+    at worktree: URL,
+    baseBranch: String? = nil,
+    resolution: BaseResolution
+) async throws -> (commits: [CommitInfo], comparisonRef: String?)
+```
+
+`commitsAhead` internals map to today's cascade (GitService.swift:1191):
+
+- `.upstreamThenBase`: Step 1 resolves `@{u}`; Step 2 base fallback unchanged.
+- `.baseLocalFirst`: skip Step 1; Step 2 resolves local `<base>` first, then
+  `origin/<base>` (today's `ignoreUpstream: true` behavior).
+- `.baseOriginFirst` **(new)**: skip Step 1; Step 2 resolves `origin/<base>`
+  first (via the existing `refs/remotes/origin/<base>` probe used by
+  `resolveEffectiveBaseBranch`), falling back to local `<base>`.
+
+The resolved `comparisonRef` is stored on `RightPaneState` and already drives
+per-file `rangeDiff` and the review-loop base, so diffs follow automatically.
+The separate review-loop base call (RightPaneState.swift:564, currently
+`ignoreUpstream: true`) mirrors the mode's base flavor — `.baseOriginFirst` for
+Auto, `.baseLocalFirst` for Manual, and `.baseOriginFirst` for Branch upstream
+(so the review base is a stable remote base, never the branch's own upstream).
+
+## Deriving `BaseResolution` per worktree
+
+Central mapping (used at each call site that currently derives `ignoreUpstream`):
+
+```
+effectiveMode = userOverrodeBaseBranch ? .manual : config.changes.comparisonMode
+
+BaseResolution:
+  .manual         -> .baseLocalFirst
+  .auto           -> .baseOriginFirst
+  .branchUpstream -> .upstreamThenBase
+```
+
+This replaces `let ignoreUpstream = userOverrodeBaseBranch || !trackUpstreamForCommits`
+at RightPaneState.swift:553 and the equivalent derivations elsewhere.
+
+## UI
+
+In `Alas/Sources/Settings/ChangesPane.swift`, replace the `AlasToggle` row
+(currently inside the "Commits section" group) with a segmented `Picker`
+(`.pickerStyle(.segmented)`, matching `ReviewScopePicker` /
+`RemoteServerPane`), bound to `state.bind(\.changes.comparisonMode)`:
+
+- Segments: **Auto · Branch upstream · Manual**.
+- Group title: "Comparison base".
+- A description line below the control updates per selection, explaining what
+  each mode compares against (mirrors the table above in plain language).
+
+## Call-site threading
+
+Thread `comparisonMode` (deriving `BaseResolution` via the mapping above)
+through every site that currently touches `trackUpstreamForCommits`:
+
+- `Alas/Sources/Persistence/AppConfig.swift` — schema, default, `Codable`
+  (schema :312, keys :319, default :433, decode :661/671/683).
+- `Alas/Sources/Right/RightPaneState.swift` — mirror property (:175), the
+  `ignoreUpstream` derivation (:553), both `commitsAhead` calls (:559, :564).
+- `Alas/Sources/Right/RightPaneStore.swift` — `state(for:...)` signature and
+  the change-detection / assignment sites (:64, :69, :121, :137).
+- `Alas/Sources/Right/RightPaneView.swift` — `.task(id:)` key (:188) and the
+  `state(for:...)` call (:195).
+- `Alas/Sources/Center/CenterPaneView.swift` — `.task(id:)` key (:306) and the
+  `state(for:...)` call (:314).
+- `Alas/Sources/App/AppState.swift` — two `state(for:...)` calls (:3211,
+  :3575) and the direct `commitsAhead` call (:4408).
+- `Alas/Sources/Center/Commit/CommitEditorTabView.swift` — the direct
+  `ignoreUpstream` derivation (:375).
+
+The per-worktree override (`userOverrodeBaseBranch`, set by
+`RightPaneState.selectBaseBranch(_:)`) forces `.baseLocalFirst` regardless of
+global mode. Its lifetime is unchanged (in-session).
+
+## Testing (Swift Testing)
+
+- **Config migration**: decode legacy configs with `trackUpstreamForCommits`
+  `true` → `.branchUpstream`, `false` → `.auto`, and absent → `.auto`; decode a
+  config with an explicit `comparisonMode` and confirm it wins.
+- **`BaseResolution` ref resolution** against a fixture repo:
+  - `.baseOriginFirst` picks `origin/<base>` when present, local `<base>`
+    otherwise.
+  - `.baseLocalFirst` picks local `<base>` first.
+  - `.upstreamThenBase` picks `@{u}` when the branch is pushed, else the base.
+  - Rebase scenario: a pushed branch rebased onto a moved `origin/main` lists
+    only its own commits under `.baseOriginFirst`.
+- **Per-worktree override** forces Manual (`.baseLocalFirst`) even when the
+  global mode is Auto or Branch upstream.
+
+## Rollout / compatibility
+
+Purely local config + git-resolution change; no schema versioning bump beyond
+the additive migration. Old builds reading a config written by a new build will
+ignore the unknown `comparisonMode` key and fall back to their own
+`trackUpstreamForCommits` default — acceptable for a personal-tool config.


### PR DESCRIPTION
## Summary

Replaces the Changes tab's on/off "Track upstream branch" checkbox with a three-way comparison-base **mode**, and adds a new default that always shows the branch's own work regardless of rebases.

- **Auto** (new default) — compares commits against `origin/<base>` (falls back to local `<base>` offline). Never uses the branch's own upstream, so it stays stable across rebases and always shows this branch's work versus the canonical remote base.
- **Branch upstream** — compares against the branch's own tracking ref (`@{u}`); only unpushed commits after you push. (The old checkbox = on.)
- **Manual** — compares against a base branch you pick per worktree; a per-worktree base override forces this mode for that worktree. (The old checkbox = off.)

## Details

- New `GitService.BaseResolution` enum (`upstreamThenBase` / `baseOriginFirst` / `baseLocalFirst`) replaces the `ignoreUpstream: Bool` flag on `commitsAhead`, making the three base-ref strategies first-class. The two pre-existing behaviors are preserved exactly.
- New persisted setting `changes.comparisonMode` (enum, default `.auto`) replaces `changes.trackUpstreamForCommits`. Legacy configs migrate: `true → branchUpstream`, `false`/absent → `auto`; an explicit mode always wins. The legacy bool is removed; its JSON key is still read for migration.
- A pure `BaseResolution.forCommits` / `.forReviewLoopBase` mapping turns `(mode, per-worktree override)` into a resolution at every call site. The review-loop base uses a stable remote base for all non-Manual modes.
- Settings → Changes shows a segmented control (Auto · Branch upstream · Manual) with a per-selection description.

## Testing

- `CommitsAheadTests` — resolution per mode, incl. a test proving Auto lists the branch's own commits vs `origin/main` where upstream mode would show none.
- `AppConfigChangesTests` — migration for legacy true/false/absent and explicit-mode-wins.
- `BaseResolutionMappingTests` — the `(mode, override) → resolution` mapping incl. override precedence and review-loop flavor.
- Existing `RightPaneState`/`RightPaneStore` base-branch suites updated for the renamed API.
- Full suite green except pre-existing SSH/remote integration tests that require a live SSH-to-localhost environment (unrelated to this change).

Design + plan: `docs/superpowers/specs/2026-07-13-changes-comparison-base-mode-design.md`, `docs/superpowers/plans/2026-07-13-changes-comparison-base-mode.md`.
