### PR TITLE
feat(headless): Keep remote ACP agents alive in helper

### DIFF
--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -627,6 +627,7 @@
 		832BDA6FD48E68F76E46D786 /* ACPSessionQueueAPITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0B057D23BD5B72E06E790C5B /* ACPSessionQueueAPITests.swift */; };
 		8352A6C0D7AE371907E50217 /* TreeSitterPython in Frameworks */ = {isa = PBXBuildFile; productRef = 7D55FFC5D9F65DAD0178FB0E /* TreeSitterPython */; };
 		835AFE4A9EA0889E0AF316BD /* ChangeSummaryVisibilityTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E4E465A2468376AA840ADFBC /* ChangeSummaryVisibilityTests.swift */; };
+		837559FFC9F1A560B58069A4 /* RemoteHelperACPTransport.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03E54D3FBA0EB8B5DCF52179 /* RemoteHelperACPTransport.swift */; };
 		839AF384DDFF728207769920 /* ACPContentBlockImageTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4D4DEBF2A9CFDCFDAD288499 /* ACPContentBlockImageTests.swift */; };
 		83A76F6425CD1406DA85B0E9 /* ACPUserScrollEventTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0535D92433898E76670B9FF0 /* ACPUserScrollEventTests.swift */; };
 		84103C99FE430DB2B36982D1 /* OpenSessionsSection.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE35A47BA74E306A4699B27D /* OpenSessionsSection.swift */; };
@@ -1293,6 +1294,7 @@
 		039C5E652B7A9457EB13BD70 /* ReviewRequestContextBuilder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReviewRequestContextBuilder.swift; sourceTree = "<group>"; };
 		03A4B0CD519C39CCB197CBD4 /* GitInvocationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GitInvocationTests.swift; sourceTree = "<group>"; };
 		03D901BF4399752A3FC658F8 /* ACPSessionStoreQueueTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPSessionStoreQueueTests.swift; sourceTree = "<group>"; };
+		03E54D3FBA0EB8B5DCF52179 /* RemoteHelperACPTransport.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteHelperACPTransport.swift; sourceTree = "<group>"; };
 		0452819DD42784CF60D466A4 /* AlasApplicationDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlasApplicationDelegate.swift; sourceTree = "<group>"; };
 		04B44F1DD775D2543439D508 /* ACPTranscriptMarkdown.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPTranscriptMarkdown.swift; sourceTree = "<group>"; };
 		0535D92433898E76670B9FF0 /* ACPUserScrollEventTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPUserScrollEventTests.swift; sourceTree = "<group>"; };
@@ -3673,6 +3675,7 @@
 				0046CA3B9FF996E55A85D853 /* RemoteFileAccess.swift */,
 				9B44E54236211F972F3D1C24 /* RemoteFileOps.swift */,
 				FBB8BF6C61840B9F972ABACC /* RemoteFileStats.swift */,
+				03E54D3FBA0EB8B5DCF52179 /* RemoteHelperACPTransport.swift */,
 				C42BD0252E4292E53150CB8C /* RemoteHelperClient.swift */,
 				C9042DA34C7025958BCFEE08 /* RemoteHelperHandshake.swift */,
 				0EE8745F3A4C6F0645D1D44A /* RemoteHelperInstaller.swift */,
@@ -5383,6 +5386,7 @@
 				DE207C4CFA1A45866FCB4E22 /* RemoteFileOps.swift in Sources */,
 				30582A6DE1CFD0B9D5CB2E14 /* RemoteFileStats.swift in Sources */,
 				C9C01E8A89C6767524FAC63B /* RemoteHTTPResponder.swift in Sources */,
+				837559FFC9F1A560B58069A4 /* RemoteHelperACPTransport.swift in Sources */,
 				3CEE8409AAAAAE34D469B19D /* RemoteHelperClient.swift in Sources */,
 				B0C493B1DE30CD22F1BAD24C /* RemoteHelperHandshake.swift in Sources */,
 				40C56ABCF57F6F3F7D40E020 /* RemoteHelperInstaller.swift in Sources */,

--- a/Alas/Sources/ACP/Adapter/ACPAdapterInstaller.swift
+++ b/Alas/Sources/ACP/Adapter/ACPAdapterInstaller.swift
@@ -44,6 +44,12 @@ enum ACPProcessEnvironment {
         for (k, v) in extra { env[k] = v }
         return env
     }
+
+    static func remoteOverridesForACP(extra: [String: String]) -> [String: String] {
+        extra.filter { key, _ in
+            !agentSessionMarkerKeys.contains(key)
+        }
+    }
 }
 
 enum ACPInstallerRegistry {

--- a/Alas/Sources/ACP/Protocol/ACPClient.swift
+++ b/Alas/Sources/ACP/Protocol/ACPClient.swift
@@ -1,5 +1,7 @@
 import Foundation
 
+typealias ACPDurableConsumptionAcknowledgement = @Sendable () -> Void
+
 struct ACPRequest {
     let method: String
     let params: Encodable?
@@ -9,6 +11,19 @@ struct ACPRequest {
 
 struct ACPResponse {
     let body: Data
+    let durableConsumptionAcknowledgement: ACPDurableConsumptionAcknowledgement?
+
+    init(
+        body: Data,
+        durableConsumptionAcknowledgement: ACPDurableConsumptionAcknowledgement? = nil
+    ) {
+        self.body = body
+        self.durableConsumptionAcknowledgement = durableConsumptionAcknowledgement
+    }
+
+    func acknowledgeDurableConsumption() {
+        durableConsumptionAcknowledgement?()
+    }
 }
 
 enum ACPClientError: LocalizedError {

--- a/Alas/Sources/ACP/Protocol/ACPConnection.swift
+++ b/Alas/Sources/ACP/Protocol/ACPConnection.swift
@@ -12,6 +12,8 @@ struct ACPInitializeOutcome: Equatable {
 /// methods for the messages we send.
 final class ACPConnection: @unchecked Sendable {
     let client: ACPClient
+    private let durableResponseLock = NSLock()
+    private var pendingDurableSessionResponses: [ACPDurableConsumptionAcknowledgement] = []
 
     init(client: ACPClient) { self.client = client }
 
@@ -26,6 +28,7 @@ final class ACPConnection: @unchecked Sendable {
                                     fs: .init(readTextFile: true, writeTextFile: true),
                                     terminal: true)))
         let resp = try await client.send(req)
+        defer { resp.acknowledgeDurableConsumption() }
         let result = try JSONDecoder().decode(ACPInitializeResult.self, from: resp.body)
         return ACPInitializeOutcome(
             promptCapabilities: result.agentCapabilities?.promptCapabilities ?? .init(),
@@ -47,14 +50,16 @@ final class ACPConnection: @unchecked Sendable {
                 debugDescription: "session/new response is missing sessionId"
             ))
         }
+        deferDurableSessionResponse(resp)
         return result
     }
 
     func authenticate(methodId: String) async throws {
-        _ = try await client.send(ACPRequest(
+        let resp = try await client.send(ACPRequest(
             method: "authenticate",
             params: ACPAuthenticateParams(methodId: methodId)
         ))
+        resp.acknowledgeDurableConsumption()
     }
 
     func loadSession(cwd: String, sessionId: String, mcpServers: [ACPMCPServer]) async throws -> ACPSessionNewResult {
@@ -62,6 +67,7 @@ final class ACPConnection: @unchecked Sendable {
                              params: ACPSessionLoadParams(cwd: cwd, sessionId: sessionId, mcpServers: mcpServers))
         let resp = try await client.send(req)
         let result = try JSONDecoder().decode(ACPSessionNewResult.self, from: resp.body)
+        deferDurableSessionResponse(resp)
         return result.sessionId.isEmpty ? result.withSessionId(sessionId) : result
     }
 
@@ -72,6 +78,7 @@ final class ACPConnection: @unchecked Sendable {
         )
         let resp = try await client.send(req)
         let result = try JSONDecoder().decode(ACPSessionNewResult.self, from: resp.body)
+        deferDurableSessionResponse(resp)
         return result.sessionId.isEmpty ? result.withSessionId(sessionId) : result
     }
 
@@ -81,6 +88,7 @@ final class ACPConnection: @unchecked Sendable {
             params: ACPSessionListParams(cwd: cwd, cursor: cursor)
         )
         let resp = try await client.send(req)
+        defer { resp.acknowledgeDurableConsumption() }
         return try JSONDecoder().decode(ACPSessionListResult.self, from: resp.body)
     }
 
@@ -90,6 +98,7 @@ final class ACPConnection: @unchecked Sendable {
             params: ACPSessionForkParams(cwd: cwd, sessionId: sessionId, mcpServers: mcpServers)
         )
         let resp = try await client.send(req)
+        defer { resp.acknowledgeDurableConsumption() }
         return try JSONDecoder().decode(ACPSessionNewResult.self, from: resp.body)
     }
 
@@ -107,13 +116,15 @@ final class ACPConnection: @unchecked Sendable {
     // method-not-found camelCase variants, which previously left Alas
     // showing the new selection while the agent stayed on the old one.
     func setMode(sessionId: String, modeId: String) async throws {
-        _ = try await client.send(ACPRequest(method: "session/set_mode",
-                                             params: ACPSessionSetModeParams(sessionId: sessionId, modeId: modeId)))
+        let resp = try await client.send(ACPRequest(method: "session/set_mode",
+                                                    params: ACPSessionSetModeParams(sessionId: sessionId, modeId: modeId)))
+        resp.acknowledgeDurableConsumption()
     }
 
     func setModel(sessionId: String, modelId: String) async throws {
-        _ = try await client.send(ACPRequest(method: "session/set_model",
-                                             params: ACPSessionSetModelParams(sessionId: sessionId, modelId: modelId)))
+        let resp = try await client.send(ACPRequest(method: "session/set_model",
+                                                    params: ACPSessionSetModelParams(sessionId: sessionId, modelId: modelId)))
+        resp.acknowledgeDurableConsumption()
     }
 
     /// Sends a config-option change and returns the agent's refreshed
@@ -129,13 +140,32 @@ final class ACPConnection: @unchecked Sendable {
                                                         sessionId: sessionId,
                                                         configId: configId,
                                                         value: value)))
+        defer { resp.acknowledgeDurableConsumption() }
         let result = try? JSONDecoder().decode(ACPSessionSetConfigOptionResult.self, from: resp.body)
         return result?.configOptions ?? []
     }
 
     func prompt(sessionId: String, blocks: [ACPContentBlock]) async throws {
-        _ = try await client.send(ACPRequest(method: "session/prompt",
-                                             params: ACPSessionPromptParams(sessionId: sessionId, prompt: blocks)))
+        let resp = try await client.send(ACPRequest(method: "session/prompt",
+                                                    params: ACPSessionPromptParams(sessionId: sessionId, prompt: blocks)))
+        resp.acknowledgeDurableConsumption()
+    }
+
+    func acknowledgeDurableSessionResponses() {
+        durableResponseLock.lock()
+        let acknowledgements = pendingDurableSessionResponses
+        pendingDurableSessionResponses.removeAll(keepingCapacity: true)
+        durableResponseLock.unlock()
+        for acknowledgement in acknowledgements {
+            acknowledgement()
+        }
+    }
+
+    private func deferDurableSessionResponse(_ response: ACPResponse) {
+        guard let acknowledgement = response.durableConsumptionAcknowledgement else { return }
+        durableResponseLock.lock()
+        pendingDurableSessionResponses.append(acknowledgement)
+        durableResponseLock.unlock()
     }
 
     func shutdown() async { await client.shutdown() }

--- a/Alas/Sources/ACP/Protocol/ACPSessionUpdate.swift
+++ b/Alas/Sources/ACP/Protocol/ACPSessionUpdate.swift
@@ -1,7 +1,5 @@
 import Foundation
 
-typealias ACPDurableConsumptionAcknowledgement = @Sendable () -> Void
-
 struct ACPSessionUpdateParams: Codable, Equatable {
     let sessionId: String
     let update: ACPSessionUpdate

--- a/Alas/Sources/ACP/Protocol/ACPSessionUpdate.swift
+++ b/Alas/Sources/ACP/Protocol/ACPSessionUpdate.swift
@@ -1,8 +1,42 @@
 import Foundation
 
+typealias ACPDurableConsumptionAcknowledgement = @Sendable () -> Void
+
 struct ACPSessionUpdateParams: Codable, Equatable {
     let sessionId: String
     let update: ACPSessionUpdate
+    let durableConsumptionAcknowledgement: ACPDurableConsumptionAcknowledgement?
+
+    init(
+        sessionId: String,
+        update: ACPSessionUpdate,
+        durableConsumptionAcknowledgement: ACPDurableConsumptionAcknowledgement? = nil
+    ) {
+        self.sessionId = sessionId
+        self.update = update
+        self.durableConsumptionAcknowledgement = durableConsumptionAcknowledgement
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case sessionId, update
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        sessionId = try container.decode(String.self, forKey: .sessionId)
+        update = try container.decode(ACPSessionUpdate.self, forKey: .update)
+        durableConsumptionAcknowledgement = nil
+    }
+
+    func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(sessionId, forKey: .sessionId)
+        try container.encode(update, forKey: .update)
+    }
+
+    static func == (lhs: ACPSessionUpdateParams, rhs: ACPSessionUpdateParams) -> Bool {
+        lhs.sessionId == rhs.sessionId && lhs.update == rhs.update
+    }
 }
 
 enum ACPSessionUpdate: Codable, Equatable {

--- a/Alas/Sources/ACP/Protocol/ACPStdioClient.swift
+++ b/Alas/Sources/ACP/Protocol/ACPStdioClient.swift
@@ -28,7 +28,8 @@ final class ACPStdioClient: ACPClient, @unchecked Sendable {
     private let stateLock = NSLock()
     private var nextId: Int = 0
     private var _yieldedUpdateCount = 0
-    private var pending: [JSONRPCID: CheckedContinuation<Data, Error>] = [:]
+    private var pending: [JSONRPCID: CheckedContinuation<ACPResponse, Error>] = [:]
+    private var pendingInboundConsumptions: [JSONRPCID: ACPDurableConsumptionAcknowledgement] = [:]
     private var didDrainPending = false
     private var dispatchTask: Task<Void, Never>?
 
@@ -174,7 +175,11 @@ final class ACPStdioClient: ACPClient, @unchecked Sendable {
                 return
             }
             if let raw = Self.extractResultBytes(from: data) {
-                cont.resume(returning: raw)
+                acknowledgeAfterDispatch = false
+                cont.resume(returning: ACPResponse(
+                    body: raw,
+                    durableConsumptionAcknowledgement: onConsumed
+                ))
             } else {
                 cont.resume(throwing: ACPClientError.decoding("no result/error in response"))
             }
@@ -197,15 +202,25 @@ final class ACPStdioClient: ACPClient, @unchecked Sendable {
             }
         case "session/request_permission":
             if let env = try? JSONDecoder().decode(JSONRPCEnvelope<ACPPermissionRequestParams>.self, from: data),
-               let id = env.id, let p = env.params { permsCont.yield((id, p)) }
+               let id = env.id, let p = env.params {
+                acknowledgeAfterDispatch = false
+                deferInboundConsumption(id: id, acknowledgement: onConsumed)
+                permsCont.yield((id, p))
+            }
         case "cursor/ask_question":
             if let env = try? JSONDecoder().decode(JSONRPCEnvelope<ACPQuestionRequestParams>.self, from: data),
-               let id = env.id, let p = env.params { questionsCont.yield(.init(id: id, params: p)) }
+               let id = env.id, let p = env.params {
+                acknowledgeAfterDispatch = false
+                deferInboundConsumption(id: id, acknowledgement: onConsumed)
+                questionsCont.yield(.init(id: id, params: p))
+            }
         case "elicitation/create":
             if let env = try? JSONDecoder().decode(
                 JSONRPCEnvelope<ACPElicitationRequestParams>.self,
                 from: data
             ), let id = env.id, let p = env.params {
+                acknowledgeAfterDispatch = false
+                deferInboundConsumption(id: id, acknowledgement: onConsumed)
                 elicitationsCont.yield(.init(id: id, params: p))
             }
         case "elicitation/complete":
@@ -217,25 +232,53 @@ final class ACPStdioClient: ACPClient, @unchecked Sendable {
             }
         case "fs/read_text_file":
             if let env = try? JSONDecoder().decode(JSONRPCEnvelope<ACPFsReadParams>.self, from: data),
-               let id = env.id, let p = env.params { filesCont.yield(.read(id: id, params: p)) }
+               let id = env.id, let p = env.params {
+                acknowledgeAfterDispatch = false
+                deferInboundConsumption(id: id, acknowledgement: onConsumed)
+                filesCont.yield(.read(id: id, params: p))
+            }
         case "fs/write_text_file":
             if let env = try? JSONDecoder().decode(JSONRPCEnvelope<ACPFsWriteParams>.self, from: data),
-               let id = env.id, let p = env.params { filesCont.yield(.write(id: id, params: p)) }
+               let id = env.id, let p = env.params {
+                acknowledgeAfterDispatch = false
+                deferInboundConsumption(id: id, acknowledgement: onConsumed)
+                filesCont.yield(.write(id: id, params: p))
+            }
         case "terminal/create":
             if let env = try? JSONDecoder().decode(JSONRPCEnvelope<ACPTerminalCreateParams>.self, from: data),
-               let id = env.id, let p = env.params { terminalsCont.yield(.create(id: id, params: p)) }
+               let id = env.id, let p = env.params {
+                acknowledgeAfterDispatch = false
+                deferInboundConsumption(id: id, acknowledgement: onConsumed)
+                terminalsCont.yield(.create(id: id, params: p))
+            }
         case "terminal/output":
             if let env = try? JSONDecoder().decode(JSONRPCEnvelope<ACPTerminalOutputParams>.self, from: data),
-               let id = env.id, let p = env.params { terminalsCont.yield(.output(id: id, params: p)) }
+               let id = env.id, let p = env.params {
+                acknowledgeAfterDispatch = false
+                deferInboundConsumption(id: id, acknowledgement: onConsumed)
+                terminalsCont.yield(.output(id: id, params: p))
+            }
         case "terminal/wait_for_exit":
             if let env = try? JSONDecoder().decode(JSONRPCEnvelope<ACPTerminalIdParams>.self, from: data),
-               let id = env.id, let p = env.params { terminalsCont.yield(.waitForExit(id: id, params: p)) }
+               let id = env.id, let p = env.params {
+                acknowledgeAfterDispatch = false
+                deferInboundConsumption(id: id, acknowledgement: onConsumed)
+                terminalsCont.yield(.waitForExit(id: id, params: p))
+            }
         case "terminal/kill":
             if let env = try? JSONDecoder().decode(JSONRPCEnvelope<ACPTerminalIdParams>.self, from: data),
-               let id = env.id, let p = env.params { terminalsCont.yield(.kill(id: id, params: p)) }
+               let id = env.id, let p = env.params {
+                acknowledgeAfterDispatch = false
+                deferInboundConsumption(id: id, acknowledgement: onConsumed)
+                terminalsCont.yield(.kill(id: id, params: p))
+            }
         case "terminal/release":
             if let env = try? JSONDecoder().decode(JSONRPCEnvelope<ACPTerminalIdParams>.self, from: data),
-               let id = env.id, let p = env.params { terminalsCont.yield(.release(id: id, params: p)) }
+               let id = env.id, let p = env.params {
+                acknowledgeAfterDispatch = false
+                deferInboundConsumption(id: id, acknowledgement: onConsumed)
+                terminalsCont.yield(.release(id: id, params: p))
+            }
         default:
             break
         }
@@ -252,13 +295,10 @@ final class ACPStdioClient: ACPClient, @unchecked Sendable {
     // MARK: - Outbound
 
     func send(_ request: ACPRequest) async throws -> ACPResponse {
-        stateLock.lock()
-        nextId += 1
-        let id = JSONRPCID.number(nextId)
-        stateLock.unlock()
+        let id = nextRequestID()
 
         let body = try Self.encode(envelopeFor: request, id: id)
-        let data: Data = try await withCheckedThrowingContinuation { (cont: CheckedContinuation<Data, Error>) in
+        return try await withCheckedThrowingContinuation { (cont: CheckedContinuation<ACPResponse, Error>) in
             stateLock.lock()
             if didDrainPending {
                 stateLock.unlock()
@@ -280,7 +320,13 @@ final class ACPStdioClient: ACPClient, @unchecked Sendable {
                 if stillPending { cont.resume(throwing: error) }
             }
         }
-        return ACPResponse(body: data)
+    }
+
+    private func nextRequestID() -> JSONRPCID {
+        stateLock.lock()
+        defer { stateLock.unlock() }
+        nextId += 1
+        return .number(nextId)
     }
 
     private static func encode(envelopeFor request: ACPRequest, id: JSONRPCID) throws -> Data {
@@ -369,7 +415,9 @@ final class ACPStdioClient: ACPClient, @unchecked Sendable {
         var dict: [String: Any] = ["jsonrpc": "2.0", "id": id.asJSON]
         dict["result"] = try JSONSerialization.jsonObject(with: body)
         let payload = try JSONSerialization.data(withJSONObject: dict)
-        try transport.send(payload)
+        try transport.send(payload, onWritten: { [weak self] in
+            self?.acknowledgeInboundConsumption(id: id)
+        })
     }
 
     private func respondFile(id: JSONRPCID, result: Result<Data, JSONRPCError>) {
@@ -389,8 +437,30 @@ final class ACPStdioClient: ACPClient, @unchecked Sendable {
             case .failure(let err):
                 dict["error"] = ["code": err.code, "message": err.message]
             }
-            try transport.send(try JSONSerialization.data(withJSONObject: dict))
+            let payload = try JSONSerialization.data(withJSONObject: dict)
+            try transport.send(payload, onWritten: { [weak self] in
+                self?.acknowledgeInboundConsumption(id: id)
+            })
         } catch {}
+    }
+
+    private func deferInboundConsumption(
+        id: JSONRPCID,
+        acknowledgement: ACPDurableConsumptionAcknowledgement?
+    ) {
+        guard let acknowledgement else { return }
+        stateLock.lock()
+        if pendingInboundConsumptions[id] == nil {
+            pendingInboundConsumptions[id] = acknowledgement
+        }
+        stateLock.unlock()
+    }
+
+    private func acknowledgeInboundConsumption(id: JSONRPCID) {
+        stateLock.lock()
+        let acknowledgement = pendingInboundConsumptions.removeValue(forKey: id)
+        stateLock.unlock()
+        acknowledgement?()
     }
 
     /// Resumes and clears every pending outbound continuation exactly once.
@@ -417,6 +487,13 @@ final class ACPStdioClient: ACPClient, @unchecked Sendable {
         drainPending(with: ACPClientError.notRunning)
         transport.terminate()
         dispatchTask?.cancel()
+        discardPendingInboundConsumptions()
+    }
+
+    private func discardPendingInboundConsumptions() {
+        stateLock.lock()
+        defer { stateLock.unlock() }
+        pendingInboundConsumptions.removeAll()
     }
 }
 

--- a/Alas/Sources/ACP/Protocol/ACPStdioClient.swift
+++ b/Alas/Sources/ACP/Protocol/ACPStdioClient.swift
@@ -133,8 +133,8 @@ final class ACPStdioClient: ACPClient, @unchecked Sendable {
 
     private func handle(_ event: JSONRPCStdioTransport.Incoming) {
         switch event {
-        case .frame(let data):
-            handleFrame(data)
+        case .frame(let data, let onConsumed):
+            handleFrame(data, onConsumed: onConsumed)
         case .stderr(let data):
             stderrCont.yield(data)
         case .exited:
@@ -155,7 +155,13 @@ final class ACPStdioClient: ACPClient, @unchecked Sendable {
         let method: String?
     }
 
-    private func handleFrame(_ data: Data) {
+    private func handleFrame(_ data: Data, onConsumed: (@Sendable () -> Void)?) {
+        var acknowledgeAfterDispatch = true
+        defer {
+            if acknowledgeAfterDispatch {
+                onConsumed?()
+            }
+        }
         guard let head = try? JSONDecoder().decode(AnyEnvelopeHead.self, from: data) else { return }
         if let id = head.id, head.method == nil {
             stateLock.lock()
@@ -182,7 +188,12 @@ final class ACPStdioClient: ACPClient, @unchecked Sendable {
                 stateLock.lock()
                 _yieldedUpdateCount += 1
                 stateLock.unlock()
-                updatesCont.yield(p)
+                acknowledgeAfterDispatch = false
+                updatesCont.yield(.init(
+                    sessionId: p.sessionId,
+                    update: p.update,
+                    durableConsumptionAcknowledgement: onConsumed
+                ))
             }
         case "session/request_permission":
             if let env = try? JSONDecoder().decode(JSONRPCEnvelope<ACPPermissionRequestParams>.self, from: data),

--- a/Alas/Sources/ACP/Protocol/ACPStdioClient.swift
+++ b/Alas/Sources/ACP/Protocol/ACPStdioClient.swift
@@ -326,6 +326,9 @@ final class ACPStdioClient: ACPClient, @unchecked Sendable {
         stateLock.lock()
         defer { stateLock.unlock() }
         nextId += 1
+        if let prefix = transport.requestIDPrefix {
+            return .string("\(prefix):\(nextId)")
+        }
         return .number(nextId)
     }
 

--- a/Alas/Sources/ACP/Session/ACPSessionManager.swift
+++ b/Alas/Sources/ACP/Session/ACPSessionManager.swift
@@ -226,6 +226,7 @@ final class ACPSessionManager: ObservableObject {
     private let setupEvaluator: ACPSetupEvaluator
     private let remoteAdapterResolver: ACPRemoteAdapterResolver
     private let connectionFactory: ACPConnectionFactory
+    private let injectedConnectionFactory: ACPConnectionFactory?
     private var resolvedRemoteAdapters: [String: ACPResolvedRemoteAdapter] = [:]
     private var inFlightHydrations: [ACPSession.ID: Task<Void, Never>] = [:]
     /// Per-session task that prepends pre-tail messages after the initial
@@ -314,37 +315,8 @@ final class ACPSessionManager: ObservableObject {
                 setupCheck: setupCheck
             )
         }
-        self.connectionFactory = connectionFactory ?? { spec, host, worktreePath in
-            let client: ACPStdioClient
-            if let host {
-                let invocation = ACPRemoteLaunch.channelInvocation(
-                    host: host,
-                    worktreePath: worktreePath,
-                    command: spec.command,
-                    arguments: spec.arguments,
-                    nodeBinDirectory: spec.remoteNodeBinDirectory
-                )
-                // Keep ssh's parent environment intact for SSH_AUTH_SOCK,
-                // HOME, and any host-specific connection configuration.
-                client = try ACPStdioClient(
-                    executable: URL(fileURLWithPath: invocation.executable),
-                    arguments: invocation.args,
-                    environment: nil
-                )
-            } else if spec.command.hasPrefix("/") {
-                client = try ACPStdioClient(
-                    executable: URL(fileURLWithPath: spec.command),
-                    arguments: spec.arguments,
-                    environment: ACPProcessEnvironment.sanitizedForACP(extra: spec.extraEnv))
-            } else {
-                client = try ACPStdioClient(
-                    executable: URL(fileURLWithPath: "/usr/bin/env"),
-                    arguments: [spec.command] + spec.arguments,
-                    environment: ACPProcessEnvironment.sanitizedForACP(extra: spec.extraEnv))
-            }
-            try client.start()
-            return ACPConnection(client: client)
-        }
+        self.injectedConnectionFactory = connectionFactory
+        self.connectionFactory = connectionFactory ?? Self.makeStdioConnection
         let initialRecent = store.flatMap { try? $0.recentSessions() } ?? []
         self.recent = initialRecent
         self.persistedRows = Dictionary(uniqueKeysWithValues: initialRecent.map { ($0.id, $0) })
@@ -762,6 +734,7 @@ final class ACPSessionManager: ObservableObject {
     }
 
     func deleteSession(id: ACPSession.ID) {
+        killRemoteHelperACPProcIfPossible(sessionId: id)
         autoReconnectTasks.removeValue(forKey: id)?.cancel()
         cancelPendingDraftWrite(for: id)
         inFlightBackfills[id]?.cancel()
@@ -1258,6 +1231,15 @@ final class ACPSessionManager: ObservableObject {
         }
     }
 
+    private func killRemoteHelperACPProcIfPossible(sessionId: ACPSession.ID) {
+        guard let host = RemoteHostRegistry.shared.host(forPath: worktreePath) else { return }
+        let procId = Self.helperACPProcId(sessionId: sessionId)
+        Task {
+            let client = await RemoteHelperClientPool.shared.client(for: host)
+            try? await client.killProc(procId: procId)
+        }
+    }
+
     private func replaceRecentRow(_ row: ACPSessionRow) {
         recent.removeAll { $0.id == row.id }
         guard !row.archived else { return }
@@ -1352,6 +1334,89 @@ final class ACPSessionManager: ObservableObject {
     /// the payload can't be decoded.
     func reloadFullToolCallContent(sessionId: ACPSession.ID, toolCallId: String) async -> String? {
         try? await persistence.loadToolCallContent(sessionId: sessionId, toolCallId: toolCallId)
+    }
+
+    private static func makeStdioConnection(
+        spec: ACPLaunchSpec,
+        host: String?,
+        worktreePath: String
+    ) throws -> ACPConnection {
+        try makeDefaultConnection(
+            spec: spec,
+            host: host,
+            worktreePath: worktreePath,
+            sessionId: nil,
+            useHelperProc: false
+        )
+    }
+
+    private static func makeDefaultConnection(
+        spec: ACPLaunchSpec,
+        host: String?,
+        worktreePath: String,
+        sessionId: ACPSession.ID?,
+        useHelperProc: Bool
+    ) throws -> ACPConnection {
+        let client: ACPStdioClient
+        if let host, useHelperProc, let sessionId {
+            let transport = RemoteHelperACPTransport(
+                host: host,
+                procId: helperACPProcId(sessionId: sessionId),
+                command: spec.command,
+                arguments: spec.arguments,
+                cwd: worktreePath,
+                environment: ACPProcessEnvironment.sanitizedForACP(extra: spec.extraEnv)
+            )
+            client = ACPStdioClient.makeForTesting(transport: transport)
+        } else if let host {
+            let invocation = ACPRemoteLaunch.channelInvocation(
+                host: host,
+                worktreePath: worktreePath,
+                command: spec.command,
+                arguments: spec.arguments
+            )
+            // Keep ssh's parent environment intact for SSH_AUTH_SOCK,
+            // HOME, and any host-specific connection configuration.
+            client = try ACPStdioClient(
+                executable: URL(fileURLWithPath: invocation.executable),
+                arguments: invocation.args,
+                environment: nil
+            )
+        } else if spec.command.hasPrefix("/") {
+            client = try ACPStdioClient(
+                executable: URL(fileURLWithPath: spec.command),
+                arguments: spec.arguments,
+                environment: ACPProcessEnvironment.sanitizedForACP(extra: spec.extraEnv))
+        } else {
+            client = try ACPStdioClient(
+                executable: URL(fileURLWithPath: "/usr/bin/env"),
+                arguments: [spec.command] + spec.arguments,
+                environment: ACPProcessEnvironment.sanitizedForACP(extra: spec.extraEnv))
+        }
+        try client.start()
+        return ACPConnection(client: client)
+    }
+
+    private static func helperACPProcId(sessionId: ACPSession.ID) -> String {
+        let allowed = sessionId.map { char -> Character in
+            if char.isLetter || char.isNumber || char == "-" || char == "_" {
+                return char
+            }
+            return "-"
+        }
+        return "acp-" + String(allowed)
+    }
+
+    private func remoteHelperSupportsProc(host: String) async -> Bool {
+        if await RemoteHostCapabilityStore.shared.capabilities(for: host)?.helperHandshake == nil {
+            return false
+        }
+        do {
+            let client = await RemoteHelperClientPool.shared.client(for: host)
+            return try await client.hello().capabilities.proc == true
+        } catch {
+            return false
+        }
     }
 }
 
@@ -1991,7 +2056,22 @@ extension ACPSessionManager {
         do {
             let host = RemoteHostRegistry.shared.host(forPath: worktreePath)
             let launchSpec = await resolvedLaunchSpec(for: spec, host: host)
-            connection = try connectionFactory(launchSpec, host, worktreePath)
+            if let injectedConnectionFactory {
+                connection = try injectedConnectionFactory(launchSpec, host, worktreePath)
+            } else {
+                let useHelperProc = if let host {
+                    await remoteHelperSupportsProc(host: host)
+                } else {
+                    false
+                }
+                connection = try Self.makeDefaultConnection(
+                    spec: launchSpec,
+                    host: host,
+                    worktreePath: worktreePath,
+                    sessionId: sessionId,
+                    useHelperProc: useHelperProc
+                )
+            }
         } catch {
             let msg = "Failed to launch agent: \(error.localizedDescription)"
             session.lastError = msg

--- a/Alas/Sources/ACP/Session/ACPSessionManager.swift
+++ b/Alas/Sources/ACP/Session/ACPSessionManager.swift
@@ -2159,10 +2159,11 @@ extension ACPSessionManager {
                 hasLocalTranscript: session.hasConversationTranscript
             )
             let shouldSuppressLoadReplay = (restoreOperation == .loadWithRecovery
-                || restoreOperation == .loadStrict)
+                || restoreOperation == .loadStrict
+                || restoreOperation == .resume)
                 && !freshlyCreated
                 && session.hydrationState == .ready
-                && session.hasConversationTranscript
+                && !session.transcript.messages.isEmpty
                 && !(session.remoteSessionId ?? "").isEmpty
             let runner = ACPSessionRunner(session: session, connection: connection,
                                           sessionId: sessionId,
@@ -2240,6 +2241,9 @@ extension ACPSessionManager {
                     do {
                         result = try await connection.resumeSession(
                             cwd: worktreePath, sessionId: remoteId, mcpServers: wireMCPServers)
+                        runner.finishSuppressingLoadReplay(
+                            throughYieldedUpdateCount: connection.client.yieldedUpdateCount
+                        )
                         if !pendingRecovery {
                             session.contextRecoveryStatus = nil
                         }
@@ -2250,6 +2254,9 @@ extension ACPSessionManager {
                             )
                         }
                     } catch {
+                        runner.finishSuppressingLoadReplay(
+                            throughYieldedUpdateCount: connection.client.yieldedUpdateCount
+                        )
                         guard session.origin == .alasCreated,
                               ACPAuthFailure.message(from: error) == nil
                         else { throw error }

--- a/Alas/Sources/ACP/Session/ACPSessionManager.swift
+++ b/Alas/Sources/ACP/Session/ACPSessionManager.swift
@@ -1365,7 +1365,7 @@ final class ACPSessionManager: ObservableObject {
                 command: spec.command,
                 arguments: spec.arguments,
                 cwd: worktreePath,
-                environment: ACPProcessEnvironment.sanitizedForACP(extra: spec.extraEnv)
+                environment: ACPProcessEnvironment.remoteOverridesForACP(extra: spec.extraEnv)
             )
             client = ACPStdioClient.makeForTesting(transport: transport)
         } else if let host {

--- a/Alas/Sources/ACP/Session/ACPSessionManager.swift
+++ b/Alas/Sources/ACP/Session/ACPSessionManager.swift
@@ -345,6 +345,28 @@ final class ACPSessionManager: ObservableObject {
         return task
     }
 
+    private func enqueuePersistenceResult<Result: Sendable>(
+        _ operation: @escaping @Sendable (ACPSessionPersistence) async throws -> Result
+    ) -> Task<Result?, Never> {
+        let previous = persistenceTail
+        let persistence = persistence
+        persistenceGeneration += 1
+        let resultTask = Task<Result?, Never> { @MainActor [weak self] in
+            await previous?.value
+            guard !Task.isCancelled else { return nil }
+            do {
+                return try await operation(persistence)
+            } catch {
+                self?.persistenceError = error.localizedDescription
+                return nil
+            }
+        }
+        persistenceTail = Task { @MainActor in
+            _ = await resultTask.value
+        }
+        return resultTask
+    }
+
     func flushPersistence() async {
         while let tail = persistenceTail {
             let generation = persistenceGeneration
@@ -952,16 +974,21 @@ final class ACPSessionManager: ObservableObject {
         }
     }
 
-    private func persistSessionRemoteId(_ s: ACPSession) {
-        guard var row = persistedRows[s.id] else { return }
+    private func persistSessionRemoteId(_ s: ACPSession) async -> Bool {
+        guard var row = persistedRows[s.id] else { return false }
         row.remoteSessionId = s.remoteSessionId
-        persistedRows[s.id] = row
-        replaceRecentRow(row)
         let rowToPersist = row
         let fence = leaseFence(sessionId: s.id)
-        enqueuePersistence { persistence in
-            _ = try await persistence.upsertSession(rowToPersist, fence: fence)
+        let result = await enqueuePersistenceResult { persistence in
+            try await persistence.upsertSession(rowToPersist, fence: fence)
+        }.value
+        guard result == true else { return false }
+        if var currentRow = persistedRows[s.id] {
+            currentRow.remoteSessionId = s.remoteSessionId
+            persistedRows[s.id] = currentRow
+            replaceRecentRow(currentRow)
         }
+        return true
     }
 
     private func persistContextRecoveryPending(sessionId: ACPSession.ID, pending: Bool) {
@@ -2464,8 +2491,16 @@ extension ACPSessionManager {
             session.promptSuggestions = result.promptSuggestions
             session.availableConfigOptions = result.configOptions
             session.contextRestoreWarning = restoreWarning
-            persistSessionRemoteId(session)
-            await flushPersistence()
+            guard await persistSessionRemoteId(session) else {
+                session.remoteSessionId = persistedRows[sessionId]?.remoteSessionId
+                await connection.shutdown()
+                startedRunner?.stop()
+                await startedRunner?.flushPersistence()
+                session.agentState = .idle
+                if !isDisposed { beginMirroring(sessionId: sessionId) }
+                await releaseWriterLease(sessionId: sessionId)
+                return
+            }
             connection.acknowledgeDurableSessionResponses()
             startRunnerIfNeeded()
             runners[sessionId] = runner

--- a/Alas/Sources/ACP/Session/ACPSessionManager.swift
+++ b/Alas/Sources/ACP/Session/ACPSessionManager.swift
@@ -1365,7 +1365,8 @@ final class ACPSessionManager: ObservableObject {
                 command: spec.command,
                 arguments: spec.arguments,
                 cwd: worktreePath,
-                environment: ACPProcessEnvironment.remoteOverridesForACP(extra: spec.extraEnv)
+                environment: ACPProcessEnvironment.remoteOverridesForACP(extra: spec.extraEnv),
+                pathPrefixDirectories: spec.remoteNodeBinDirectory.map { [$0] } ?? []
             )
             client = ACPStdioClient.makeForTesting(transport: transport)
         } else if let host {
@@ -1373,7 +1374,8 @@ final class ACPSessionManager: ObservableObject {
                 host: host,
                 worktreePath: worktreePath,
                 command: spec.command,
-                arguments: spec.arguments
+                arguments: spec.arguments,
+                nodeBinDirectory: spec.remoteNodeBinDirectory
             )
             // Keep ssh's parent environment intact for SSH_AUTH_SOCK,
             // HOME, and any host-specific connection configuration.

--- a/Alas/Sources/ACP/Session/ACPSessionManager.swift
+++ b/Alas/Sources/ACP/Session/ACPSessionManager.swift
@@ -979,6 +979,36 @@ final class ACPSessionManager: ObservableObject {
         }
     }
 
+    private func persistHelperProcOffsets(
+        sessionId: ACPSession.ID,
+        offsets: RemoteHelperACPTransport.OutputOffsets
+    ) {
+        guard !isMirror(sessionId: sessionId) else { return }
+        let stdoutOffset = offsets.stdout.flatMap(Self.sqliteOffset)
+        let stderrOffset = offsets.stderr.flatMap(Self.sqliteOffset)
+        guard stdoutOffset != nil || stderrOffset != nil else { return }
+        if var row = persistedRows[sessionId] {
+            if let stdoutOffset,
+               row.helperProcStdoutOffset == nil || row.helperProcStdoutOffset! < stdoutOffset {
+                row.helperProcStdoutOffset = stdoutOffset
+            }
+            if let stderrOffset,
+               row.helperProcStderrOffset == nil || row.helperProcStderrOffset! < stderrOffset {
+                row.helperProcStderrOffset = stderrOffset
+            }
+            persistedRows[sessionId] = row
+        }
+        let fence = leaseFence(sessionId: sessionId)
+        enqueuePersistence { persistence in
+            _ = try await persistence.updateHelperProcOffsets(
+                sessionId: sessionId,
+                stdoutOffset: stdoutOffset,
+                stderrOffset: stderrOffset,
+                fence: fence
+            )
+        }
+    }
+
     /// Rename a session with the given title and source. Updates both
     /// the in-memory session and SQLite in one call. No-ops only when
     /// another live instance owns the writer lease (this pane is a mirror).
@@ -1355,7 +1385,9 @@ final class ACPSessionManager: ObservableObject {
         host: String?,
         worktreePath: String,
         sessionId: ACPSession.ID?,
-        useHelperProc: Bool
+        useHelperProc: Bool,
+        initialHelperProcOffsets: RemoteHelperACPTransport.OutputOffsets? = nil,
+        onHelperProcOffsetsChanged: @escaping @MainActor @Sendable (RemoteHelperACPTransport.OutputOffsets) -> Void = { _ in }
     ) throws -> ACPConnection {
         let client: ACPStdioClient
         if let host, useHelperProc, let sessionId {
@@ -1366,7 +1398,9 @@ final class ACPSessionManager: ObservableObject {
                 arguments: spec.arguments,
                 cwd: worktreePath,
                 environment: ACPProcessEnvironment.remoteOverridesForACP(extra: spec.extraEnv),
-                pathPrefixDirectories: spec.remoteNodeBinDirectory.map { [$0] } ?? []
+                pathPrefixDirectories: spec.remoteNodeBinDirectory.map { [$0] } ?? [],
+                initialOutputOffsets: initialHelperProcOffsets,
+                onOutputOffsetsChanged: onHelperProcOffsetsChanged
             )
             client = ACPStdioClient.makeForTesting(transport: transport)
         } else if let host {
@@ -1407,6 +1441,19 @@ final class ACPSessionManager: ObservableObject {
             return "-"
         }
         return "acp-" + String(allowed)
+    }
+
+    private static func helperProcOffsets(from row: ACPSessionRow?) -> RemoteHelperACPTransport.OutputOffsets? {
+        guard let row else { return nil }
+        let stdout = row.helperProcStdoutOffset.flatMap { $0 >= 0 ? UInt64($0) : nil }
+        let stderr = row.helperProcStderrOffset.flatMap { $0 >= 0 ? UInt64($0) : nil }
+        guard stdout != nil || stderr != nil else { return nil }
+        return RemoteHelperACPTransport.OutputOffsets(stdout: stdout, stderr: stderr)
+    }
+
+    private static func sqliteOffset(_ offset: UInt64) -> Int64? {
+        guard offset <= UInt64(Int64.max) else { return nil }
+        return Int64(offset)
     }
 
     private func remoteHelperSupportsProc(host: String) async -> Bool {
@@ -2071,7 +2118,11 @@ extension ACPSessionManager {
                     host: host,
                     worktreePath: worktreePath,
                     sessionId: sessionId,
-                    useHelperProc: useHelperProc
+                    useHelperProc: useHelperProc,
+                    initialHelperProcOffsets: Self.helperProcOffsets(from: persistedRows[sessionId]),
+                    onHelperProcOffsetsChanged: { [weak self] offsets in
+                        self?.persistHelperProcOffsets(sessionId: sessionId, offsets: offsets)
+                    }
                 )
             }
         } catch {

--- a/Alas/Sources/ACP/Session/ACPSessionManager.swift
+++ b/Alas/Sources/ACP/Session/ACPSessionManager.swift
@@ -2466,6 +2466,7 @@ extension ACPSessionManager {
             session.contextRestoreWarning = restoreWarning
             persistSessionRemoteId(session)
             await flushPersistence()
+            connection.acknowledgeDurableSessionResponses()
             startRunnerIfNeeded()
             runners[sessionId] = runner
             keepElicitationCoordinator = true

--- a/Alas/Sources/ACP/Session/ACPSessionManager.swift
+++ b/Alas/Sources/ACP/Session/ACPSessionManager.swift
@@ -1009,6 +1009,23 @@ final class ACPSessionManager: ObservableObject {
         }
     }
 
+    private func resetHelperProcOffsets(sessionId: ACPSession.ID) async {
+        guard !isMirror(sessionId: sessionId) else { return }
+        if var row = persistedRows[sessionId] {
+            row.helperProcStdoutOffset = 0
+            row.helperProcStderrOffset = 0
+            persistedRows[sessionId] = row
+        }
+        let fence = leaseFence(sessionId: sessionId)
+        let task = enqueuePersistence { persistence in
+            _ = try await persistence.resetHelperProcOffsets(
+                sessionId: sessionId,
+                fence: fence
+            )
+        }
+        await task.value
+    }
+
     /// Rename a session with the given title and source. Updates both
     /// the in-memory session and SQLite in one call. No-ops only when
     /// another live instance owns the writer lease (this pane is a mirror).
@@ -1387,6 +1404,7 @@ final class ACPSessionManager: ObservableObject {
         sessionId: ACPSession.ID?,
         useHelperProc: Bool,
         initialHelperProcOffsets: RemoteHelperACPTransport.OutputOffsets? = nil,
+        onFreshHelperProcSpawn: @escaping @MainActor @Sendable () async -> Void = {},
         onHelperProcOffsetsChanged: @escaping @MainActor @Sendable (RemoteHelperACPTransport.OutputOffsets) -> Void = { _ in }
     ) throws -> ACPConnection {
         let client: ACPStdioClient
@@ -1400,6 +1418,7 @@ final class ACPSessionManager: ObservableObject {
                 environment: ACPProcessEnvironment.remoteOverridesForACP(extra: spec.extraEnv),
                 pathPrefixDirectories: spec.remoteNodeBinDirectory.map { [$0] } ?? [],
                 initialOutputOffsets: initialHelperProcOffsets,
+                onFreshProcSpawn: onFreshHelperProcSpawn,
                 onOutputOffsetsChanged: onHelperProcOffsetsChanged
             )
             client = ACPStdioClient.makeForTesting(transport: transport)
@@ -2120,6 +2139,9 @@ extension ACPSessionManager {
                     sessionId: sessionId,
                     useHelperProc: useHelperProc,
                     initialHelperProcOffsets: Self.helperProcOffsets(from: persistedRows[sessionId]),
+                    onFreshHelperProcSpawn: { [weak self] in
+                        await self?.resetHelperProcOffsets(sessionId: sessionId)
+                    },
                     onHelperProcOffsetsChanged: { [weak self] offsets in
                         self?.persistHelperProcOffsets(sessionId: sessionId, offsets: offsets)
                     }

--- a/Alas/Sources/ACP/Session/ACPSessionPersistence.swift
+++ b/Alas/Sources/ACP/Session/ACPSessionPersistence.swift
@@ -116,6 +116,25 @@ actor ACPSessionPersistence {
     }
 
     @discardableResult
+    func updateHelperProcOffsets(
+        sessionId: String,
+        stdoutOffset: Int64?,
+        stderrOffset: Int64?,
+        fence: ACPSessionLeaseFence?
+    ) throws -> Bool {
+        let store = try openedStore()
+        let operation = {
+            try store.updateHelperProcOffsets(
+                sessionId: sessionId,
+                stdoutOffset: stdoutOffset,
+                stderrOffset: stderrOffset
+            )
+        }
+        if let fence { return try store.withLeaseFence(fence, operation) ?? false }
+        return try operation()
+    }
+
+    @discardableResult
     func setContextRecoveryPending(
         sessionId: String,
         pending: Bool,

--- a/Alas/Sources/ACP/Session/ACPSessionPersistence.swift
+++ b/Alas/Sources/ACP/Session/ACPSessionPersistence.swift
@@ -135,6 +135,17 @@ actor ACPSessionPersistence {
     }
 
     @discardableResult
+    func resetHelperProcOffsets(
+        sessionId: String,
+        fence: ACPSessionLeaseFence?
+    ) throws -> Bool {
+        let store = try openedStore()
+        let operation = { try store.resetHelperProcOffsets(sessionId: sessionId) }
+        if let fence { return try store.withLeaseFence(fence, operation) ?? false }
+        return try operation()
+    }
+
+    @discardableResult
     func setContextRecoveryPending(
         sessionId: String,
         pending: Bool,

--- a/Alas/Sources/ACP/Session/ACPSessionRunner.swift
+++ b/Alas/Sources/ACP/Session/ACPSessionRunner.swift
@@ -74,6 +74,7 @@ final class ACPSessionRunner {
     private var pendingStreamingPersistRevisions: [Int: Int] = [:]
     private var streamingPersistInFlightIndices: Set<Int> = []
     private var pendingStreamingPersistSnapshots: [Int: StreamingPersistSnapshot] = [:]
+    private var pendingStreamingPersistAcknowledgements: [ACPDurableConsumptionAcknowledgement] = []
     /// The exact payload bytes this runner last wrote for each message row.
     /// Used as the compare-and-swap base when a takeover forces a stand-down
     /// flush, so the CAS never reads the (potentially growing) payload blob
@@ -534,6 +535,7 @@ final class ACPSessionRunner {
         flushQueueWhenBoundaryReady: Bool = true,
         treatBufferedUpdatesAsPromptOwned: Bool = false
     ) {
+        let durableConsumptionAcknowledgement = params.durableConsumptionAcknowledgement
         observedUpdateCount += 1
         appliedUpdateCount += 1
         let preAppliedSessionInfoDirty: Set<Int>?
@@ -546,9 +548,13 @@ final class ACPSessionRunner {
         }
         if suppressingLoadReplay {
             if let dirty = preAppliedSessionInfoDirty {
-                persistIndices(dirty)
+                persistIndices(
+                    dirty,
+                    completion: persistenceCompletion(acknowledging: durableConsumptionAcknowledgement)
+                )
             } else {
                 _ = session.applySuppressedReplaySideEffects(params.update)
+                durableConsumptionAcknowledgement?()
             }
             if let target = loadReplaySuppressionTarget,
                observedUpdateCount >= target {
@@ -557,7 +563,10 @@ final class ACPSessionRunner {
             return
         }
         if let dirty = preAppliedSessionInfoDirty {
-            persistIndices(dirty)
+            persistIndices(
+                dirty,
+                completion: persistenceCompletion(acknowledging: durableConsumptionAcknowledgement)
+            )
         } else {
             let isPromptCompletionDrainUpdate = pendingCompletedOutputBoundaryUpdateCount
                 .map { appliedUpdateCount <= $0 } ?? false
@@ -583,16 +592,34 @@ final class ACPSessionRunner {
                 }
                 let dirty = session.apply(params.update)
                 if !streamingLeaseLost {
-                    scheduleStreamingPersist(dirty, mayCapturePersistedBases: holdsLease)
+                    scheduleStreamingPersist(
+                        dirty,
+                        mayCapturePersistedBases: holdsLease,
+                        durableConsumptionAcknowledgement: durableConsumptionAcknowledgement
+                    )
                 }
             } else {
                 let dirty = session.apply(params.update)
                 flushStreamingPersist()
-                persistIndices(dirty)
+                persistIndices(
+                    dirty,
+                    completion: persistenceCompletion(acknowledging: durableConsumptionAcknowledgement)
+                )
             }
         }
         if applyPendingCompletedOutputBoundaryIfReady(), flushQueueWhenBoundaryReady {
             flushQueueIfIdle()
+        }
+    }
+
+    private func persistenceCompletion(
+        acknowledging acknowledgement: ACPDurableConsumptionAcknowledgement?
+    ) -> ((Bool) -> Void)? {
+        guard let acknowledgement else { return nil }
+        return { succeeded in
+            if succeeded {
+                acknowledgement()
+            }
         }
     }
 
@@ -1766,8 +1793,15 @@ extension ACPSessionRunner {
         }
     }
 
-    private func scheduleStreamingPersist(_ indices: Set<Int>, mayCapturePersistedBases: Bool = true) {
-        guard !indices.isEmpty else { return }
+    private func scheduleStreamingPersist(
+        _ indices: Set<Int>,
+        mayCapturePersistedBases: Bool = true,
+        durableConsumptionAcknowledgement: ACPDurableConsumptionAcknowledgement? = nil
+    ) {
+        guard !indices.isEmpty else {
+            durableConsumptionAcknowledgement?()
+            return
+        }
         // Per-chunk work is intentionally cheap: record the dirty indices and
         // arm the debounce. Encoding the (growing) message and reading its
         // stored payload happen once per debounce window in the flush, not
@@ -1788,6 +1822,9 @@ extension ACPSessionRunner {
             }
         }
         pendingStreamingPersistIndices.formUnion(indices)
+        if let durableConsumptionAcknowledgement {
+            pendingStreamingPersistAcknowledgements.append(durableConsumptionAcknowledgement)
+        }
         for index in indices {
             pendingStreamingPersistRevisions[index, default: 0] += 1
         }
@@ -1837,6 +1874,7 @@ extension ACPSessionRunner {
         pendingStreamingPersistRevisions.removeAll()
         streamingPersistInFlightIndices.removeAll()
         pendingStreamingPersistSnapshots.removeAll()
+        pendingStreamingPersistAcknowledgements.removeAll()
     }
 
     /// Bound the compare-and-swap base cache to the recent tail so it can't
@@ -1874,11 +1912,16 @@ extension ACPSessionRunner {
         let revisions = Dictionary(uniqueKeysWithValues: indices.map {
             ($0, pendingStreamingPersistRevisions[$0, default: 0])
         })
+        let acknowledgements = pendingStreamingPersistAcknowledgements
+        pendingStreamingPersistAcknowledgements.removeAll(keepingCapacity: true)
         streamingPersistInFlightIndices.formUnion(indices)
         if persistIndices(indices, requiresLease: true, completion: { [weak self] succeeded in
             guard let self else { return }
             self.streamingPersistInFlightIndices.subtract(indices)
             if succeeded {
+                for acknowledgement in acknowledgements {
+                    acknowledgement()
+                }
                 for index in indices where self.pendingStreamingPersistRevisions[index] == revisions[index] {
                     self.pendingStreamingPersistIndices.remove(index)
                     self.pendingStreamingPersistRevisions.removeValue(forKey: index)

--- a/Alas/Sources/ACP/Session/ACPSessionStore.swift
+++ b/Alas/Sources/ACP/Session/ACPSessionStore.swift
@@ -382,6 +382,15 @@ extension ACPSessionStore {
         ]) > 0
     }
 
+    func resetHelperProcOffsets(sessionId: String) throws -> Bool {
+        try db.execChanges("""
+        UPDATE sessions
+        SET helper_proc_stdout_offset = 0,
+            helper_proc_stderr_offset = 0
+        WHERE id = ?
+        """, bindings: [sessionId]) > 0
+    }
+
     func recentSessions(limit: Int = 50) throws -> [ACPSessionRow] {
         let rows = try db.query("""
         SELECT * FROM sessions WHERE archived = 0 ORDER BY last_opened_at DESC LIMIT ?

--- a/Alas/Sources/ACP/Session/ACPSessionStore.swift
+++ b/Alas/Sources/ACP/Session/ACPSessionStore.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 final class ACPSessionStore {
-    static let targetSchemaVersion = 11
+    static let targetSchemaVersion = 12
     let path: String
     let db: SQLiteDatabase
 
@@ -38,6 +38,7 @@ final class ACPSessionStore {
         if current < 9 { try migrate_to_v9() }
         if current < 10 { try migrate_to_v10() }
         if current < 11 { try migrate_to_v11() }
+        if current < 12 { try migrate_to_v12() }
         try recoverFromConcurrentWriters()
         if current == 0 {
             try db.exec("INSERT INTO schema_version (version) VALUES (?)", bindings: [Int64(Self.targetSchemaVersion)])
@@ -192,6 +193,17 @@ final class ACPSessionStore {
         guard !columns.contains(where: { ($0["name"] as? String) == "lease_token" }) else { return }
         try db.exec("ALTER TABLE session_leases ADD COLUMN lease_token TEXT NOT NULL DEFAULT ''")
     }
+
+    private func migrate_to_v12() throws {
+        let columns = try db.query("PRAGMA table_info(sessions)")
+        let names = Set(columns.compactMap { $0["name"] as? String })
+        if !names.contains("helper_proc_stdout_offset") {
+            try db.exec("ALTER TABLE sessions ADD COLUMN helper_proc_stdout_offset INTEGER")
+        }
+        if !names.contains("helper_proc_stderr_offset") {
+            try db.exec("ALTER TABLE sessions ADD COLUMN helper_proc_stderr_offset INTEGER")
+        }
+    }
 }
 
 struct ACPSessionLease: Equatable, Sendable {
@@ -226,6 +238,8 @@ struct ACPSessionRow: Equatable, Sendable {
     var currentModel: String?
     var currentMode: String?
     var autoRun: Bool
+    var helperProcStdoutOffset: Int64? = nil
+    var helperProcStderrOffset: Int64? = nil
     let createdAt: Int64
     var updatedAt: Int64
     var lastOpenedAt: Int64
@@ -286,8 +300,9 @@ extension ACPSessionStore {
     func upsertSession(_ s: ACPSessionRow, preserveTitle: Bool = false) throws {
         try db.exec("""
         INSERT INTO sessions (id, agent_id, title, title_source, remote_session_id, origin, context_recovery_pending,
-                              current_model, current_mode, auto_run, created_at, updated_at, last_opened_at, archived)
-        VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?)
+                              current_model, current_mode, auto_run, helper_proc_stdout_offset,
+                              helper_proc_stderr_offset, created_at, updated_at, last_opened_at, archived)
+        VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)
         ON CONFLICT(id) DO UPDATE SET
             title = CASE WHEN ? THEN sessions.title ELSE excluded.title END,
             title_source = CASE WHEN ? THEN sessions.title_source ELSE excluded.title_source END,
@@ -297,6 +312,8 @@ extension ACPSessionStore {
             current_model = excluded.current_model,
             current_mode = excluded.current_mode,
             auto_run = excluded.auto_run,
+            helper_proc_stdout_offset = COALESCE(excluded.helper_proc_stdout_offset, sessions.helper_proc_stdout_offset),
+            helper_proc_stderr_offset = COALESCE(excluded.helper_proc_stderr_offset, sessions.helper_proc_stderr_offset),
             updated_at = excluded.updated_at,
             last_opened_at = excluded.last_opened_at,
             archived = excluded.archived
@@ -304,6 +321,7 @@ extension ACPSessionStore {
             s.id, s.agentId, s.title, s.titleSource.rawValue, s.remoteSessionId, s.origin.rawValue,
             s.contextRecoveryPending ? 1 : 0,
             s.currentModel, s.currentMode, s.autoRun ? 1 : 0,
+            s.helperProcStdoutOffset, s.helperProcStderrOffset,
             s.createdAt, s.updatedAt, s.lastOpenedAt, s.archived ? 1 : 0,
             preserveTitle ? 1 : 0,
             preserveTitle ? 1 : 0
@@ -341,6 +359,27 @@ extension ACPSessionStore {
             "UPDATE sessions SET context_recovery_pending = ? WHERE id = ?",
             bindings: [pending ? 1 : 0, sessionId]
         )
+    }
+
+    func updateHelperProcOffsets(sessionId: String, stdoutOffset: Int64?, stderrOffset: Int64?) throws -> Bool {
+        try db.execChanges("""
+        UPDATE sessions
+        SET helper_proc_stdout_offset = CASE
+                WHEN ? IS NULL THEN helper_proc_stdout_offset
+                WHEN helper_proc_stdout_offset IS NULL OR helper_proc_stdout_offset < ? THEN ?
+                ELSE helper_proc_stdout_offset
+            END,
+            helper_proc_stderr_offset = CASE
+                WHEN ? IS NULL THEN helper_proc_stderr_offset
+                WHEN helper_proc_stderr_offset IS NULL OR helper_proc_stderr_offset < ? THEN ?
+                ELSE helper_proc_stderr_offset
+            END
+        WHERE id = ?
+        """, bindings: [
+            stdoutOffset, stdoutOffset, stdoutOffset,
+            stderrOffset, stderrOffset, stderrOffset,
+            sessionId
+        ]) > 0
     }
 
     func recentSessions(limit: Int = 50) throws -> [ACPSessionRow] {
@@ -617,6 +656,8 @@ extension ACPSessionStore {
             currentModel: r["current_model"] as? String,
             currentMode: r["current_mode"] as? String,
             autoRun: ((r["auto_run"] as? Int64) ?? 0) != 0,
+            helperProcStdoutOffset: r["helper_proc_stdout_offset"] as? Int64,
+            helperProcStderrOffset: r["helper_proc_stderr_offset"] as? Int64,
             createdAt: (r["created_at"] as? Int64) ?? 0,
             updatedAt: (r["updated_at"] as? Int64) ?? 0,
             lastOpenedAt: (r["last_opened_at"] as? Int64) ?? 0,

--- a/Alas/Sources/JSONRPC/JSONRPCStdioTransport.swift
+++ b/Alas/Sources/JSONRPC/JSONRPCStdioTransport.swift
@@ -10,7 +10,15 @@ protocol JSONRPCStdioTransporting: AnyObject, Sendable {
     var incoming: AsyncStream<JSONRPCStdioTransport.Incoming> { get }
     func start() throws
     func send(_ data: Data) throws
+    func send(_ data: Data, onWritten: @escaping @Sendable () -> Void) throws
     func terminate()
+}
+
+extension JSONRPCStdioTransporting {
+    func send(_ data: Data, onWritten: @escaping @Sendable () -> Void) throws {
+        try send(data)
+        onWritten()
+    }
 }
 
 final class JSONRPCStdioTransport: @unchecked Sendable, JSONRPCStdioTransporting {

--- a/Alas/Sources/JSONRPC/JSONRPCStdioTransport.swift
+++ b/Alas/Sources/JSONRPC/JSONRPCStdioTransport.swift
@@ -15,7 +15,7 @@ protocol JSONRPCStdioTransporting: AnyObject, Sendable {
 
 final class JSONRPCStdioTransport: @unchecked Sendable, JSONRPCStdioTransporting {
     enum Incoming: Sendable {
-        case frame(Data)
+        case frame(Data, onConsumed: (@Sendable () -> Void)? = nil)
         case stderr(Data)
         case exited(Int32)
     }

--- a/Alas/Sources/JSONRPC/JSONRPCStdioTransport.swift
+++ b/Alas/Sources/JSONRPC/JSONRPCStdioTransport.swift
@@ -8,6 +8,7 @@ enum JSONRPCFraming {
 
 protocol JSONRPCStdioTransporting: AnyObject, Sendable {
     var incoming: AsyncStream<JSONRPCStdioTransport.Incoming> { get }
+    var requestIDPrefix: String? { get }
     func start() throws
     func send(_ data: Data) throws
     func send(_ data: Data, onWritten: @escaping @Sendable () -> Void) throws
@@ -15,6 +16,8 @@ protocol JSONRPCStdioTransporting: AnyObject, Sendable {
 }
 
 extension JSONRPCStdioTransporting {
+    var requestIDPrefix: String? { nil }
+
     func send(_ data: Data, onWritten: @escaping @Sendable () -> Void) throws {
         try send(data)
         onWritten()

--- a/Alas/Sources/SSH/RemoteHelperACPTransport.swift
+++ b/Alas/Sources/SSH/RemoteHelperACPTransport.swift
@@ -149,7 +149,7 @@ final class RemoteHelperACPTransport: @unchecked Sendable, JSONRPCStdioTransport
                 continuation?.finish()
                 return
             } catch {
-                state.requeue(next)
+                state.requeueForOffsetGuardedRetry(next)
                 return
             }
         }
@@ -247,7 +247,7 @@ final class RemoteHelperACPTransport: @unchecked Sendable, JSONRPCStdioTransport
             isFlushingWrites = false
         }
 
-        func requeue(_ data: Data) {
+        func requeueForOffsetGuardedRetry(_ data: Data) {
             lock.lock()
             defer { lock.unlock() }
             guard !terminated else { return }

--- a/Alas/Sources/SSH/RemoteHelperACPTransport.swift
+++ b/Alas/Sources/SSH/RemoteHelperACPTransport.swift
@@ -13,6 +13,7 @@ final class RemoteHelperACPTransport: @unchecked Sendable, JSONRPCStdioTransport
     private let cwd: String
     private let environment: [String: String]
     private let pathPrefixDirectories: [String]
+    private let onFreshProcSpawn: @MainActor @Sendable () async -> Void
     private let onOutputOffsetsChanged: @MainActor @Sendable (OutputOffsets) -> Void
     private let attachmentId = UUID().uuidString
     private let state = State()
@@ -33,6 +34,7 @@ final class RemoteHelperACPTransport: @unchecked Sendable, JSONRPCStdioTransport
         environment: [String: String],
         pathPrefixDirectories: [String] = [],
         initialOutputOffsets: OutputOffsets? = nil,
+        onFreshProcSpawn: @escaping @MainActor @Sendable () async -> Void = {},
         onOutputOffsetsChanged: @escaping @MainActor @Sendable (OutputOffsets) -> Void = { _ in }
     ) {
         self.host = host
@@ -42,6 +44,7 @@ final class RemoteHelperACPTransport: @unchecked Sendable, JSONRPCStdioTransport
         self.cwd = cwd
         self.environment = environment
         self.pathPrefixDirectories = pathPrefixDirectories
+        self.onFreshProcSpawn = onFreshProcSpawn
         self.onOutputOffsetsChanged = onOutputOffsetsChanged
         stdoutOffset = initialOutputOffsets?.stdout
         stderrOffset = initialOutputOffsets?.stderr
@@ -105,6 +108,9 @@ final class RemoteHelperACPTransport: @unchecked Sendable, JSONRPCStdioTransport
                             pathPrefixDirectories: pathPrefixDirectories
                         )
                         attachFreshSpawnFromStart = status.spawned == true
+                        if attachFreshSpawnFromStart {
+                            await onFreshProcSpawn()
+                        }
                     } catch {
                         guard Self.shouldRetrySpawnFailure(error) else {
                             state.setWritesEnabled(false)

--- a/Alas/Sources/SSH/RemoteHelperACPTransport.swift
+++ b/Alas/Sources/SSH/RemoteHelperACPTransport.swift
@@ -1,6 +1,8 @@
 import Foundation
 
 final class RemoteHelperACPTransport: @unchecked Sendable, JSONRPCStdioTransporting {
+    private static let attachAtEndOffset = UInt64.max
+
     private let host: String
     private let procId: String
     private let command: String
@@ -95,11 +97,12 @@ final class RemoteHelperACPTransport: @unchecked Sendable, JSONRPCStdioTransport
                     }
                     didSpawn = true
                 }
-                let handle = try await client.attachProc(
-                    procId: procId,
-                    stdoutOffset: stdoutOffset,
-                    stderrOffset: stderrOffset
-                )
+                    let requestedStdoutOffset = stdoutOffset == 0 ? Self.attachAtEndOffset : stdoutOffset
+                    let handle = try await client.attachProc(
+                        procId: procId,
+                        stdoutOffset: requestedStdoutOffset,
+                        stderrOffset: stderrOffset
+                    )
                 stdinOffset = handle.stdinOffset
                 attempt = 0
                 for await event in handle.events {

--- a/Alas/Sources/SSH/RemoteHelperACPTransport.swift
+++ b/Alas/Sources/SSH/RemoteHelperACPTransport.swift
@@ -164,12 +164,13 @@ final class RemoteHelperACPTransport: @unchecked Sendable, JSONRPCStdioTransport
                     ownsFlush = false
                     return
                 }
+                let expectedStdinOffset = next.expectedStdinOffset ?? stdinOffset
                 do {
                     let client = await RemoteHelperClientPool.shared.client(for: host)
                     stdinOffset = try await client.writeProc(
                         procId: procId,
-                        data: Self.frameForProcWrite(next),
-                        expectedStdinOffset: stdinOffset
+                        data: Self.frameForProcWrite(next.data),
+                        expectedStdinOffset: expectedStdinOffset
                     )
                 } catch RemoteHelperClientError.jsonrpc(let error) {
                     _ = state.markTerminated()
@@ -181,7 +182,7 @@ final class RemoteHelperACPTransport: @unchecked Sendable, JSONRPCStdioTransport
                     ownsFlush = false
                     return
                 } catch {
-                    state.requeueForOffsetGuardedRetry(next)
+                    state.requeueForOffsetGuardedRetry(next.withExpectedStdinOffset(expectedStdinOffset))
                     state.endFlushingWrites()
                     ownsFlush = false
                     return
@@ -219,7 +220,7 @@ final class RemoteHelperACPTransport: @unchecked Sendable, JSONRPCStdioTransport
         private var terminated = false
         private var canWrite = false
         private var isFlushingWrites = false
-        private var pendingWrites: [Data] = []
+        private var pendingWrites: [PendingProcWrite] = []
 
         var isTerminated: Bool {
             lock.lock()
@@ -260,11 +261,11 @@ final class RemoteHelperACPTransport: @unchecked Sendable, JSONRPCStdioTransport
             lock.lock()
             defer { lock.unlock() }
             guard !terminated else { return false }
-            pendingWrites.append(data)
+            pendingWrites.append(PendingProcWrite(data: data, expectedStdinOffset: nil))
             return true
         }
 
-        func takeNextWrite() -> Data? {
+        func takeNextWrite() -> PendingProcWrite? {
             lock.lock()
             defer { lock.unlock() }
             guard !pendingWrites.isEmpty else { return nil }
@@ -292,11 +293,20 @@ final class RemoteHelperACPTransport: @unchecked Sendable, JSONRPCStdioTransport
             return canWrite && !terminated && !pendingWrites.isEmpty
         }
 
-        func requeueForOffsetGuardedRetry(_ data: Data) {
+        func requeueForOffsetGuardedRetry(_ write: PendingProcWrite) {
             lock.lock()
             defer { lock.unlock() }
             guard !terminated else { return }
-            pendingWrites.insert(data, at: 0)
+            pendingWrites.insert(write, at: 0)
+        }
+    }
+
+    private struct PendingProcWrite {
+        let data: Data
+        let expectedStdinOffset: UInt64?
+
+        func withExpectedStdinOffset(_ offset: UInt64) -> PendingProcWrite {
+            PendingProcWrite(data: data, expectedStdinOffset: offset)
         }
     }
 }

--- a/Alas/Sources/SSH/RemoteHelperACPTransport.swift
+++ b/Alas/Sources/SSH/RemoteHelperACPTransport.swift
@@ -12,6 +12,7 @@ final class RemoteHelperACPTransport: @unchecked Sendable, JSONRPCStdioTransport
     private var attachTask: Task<Void, Never>?
     private var stdoutOffset: UInt64 = 0
     private var stderrOffset: UInt64 = 0
+    private var stdinOffset: UInt64 = 0
 
     let incoming: AsyncStream<JSONRPCStdioTransport.Incoming>
 
@@ -51,10 +52,6 @@ final class RemoteHelperACPTransport: @unchecked Sendable, JSONRPCStdioTransport
     func terminate() {
         guard state.markTerminated() else { return }
         attachTask?.cancel()
-        Task { [host, procId] in
-            let client = await RemoteHelperClientPool.shared.client(for: host)
-            try? await client.killProc(procId: procId)
-        }
         continuation?.yield(.exited(0))
         continuation?.finish()
     }
@@ -131,13 +128,26 @@ final class RemoteHelperACPTransport: @unchecked Sendable, JSONRPCStdioTransport
     }
 
     private func flushPendingWrites() async {
+        guard state.beginFlushingWrites() else { return }
+        defer { state.endFlushingWrites() }
         while !Task.isCancelled && !state.isTerminated {
             guard state.writesEnabled else { return }
             let next = state.takeNextWrite()
             guard let next else { return }
             do {
                 let client = await RemoteHelperClientPool.shared.client(for: host)
-                try await client.writeProc(procId: procId, data: Self.frameForProcWrite(next))
+                stdinOffset = try await client.writeProc(
+                    procId: procId,
+                    data: Self.frameForProcWrite(next),
+                    expectedStdinOffset: stdinOffset
+                )
+            } catch RemoteHelperClientError.jsonrpc(let error) {
+                _ = state.markTerminated()
+                let message = "Remote helper failed to write ACP input: \(error.message)\n"
+                continuation?.yield(.stderr(Data(message.utf8)))
+                continuation?.yield(.exited(127))
+                continuation?.finish()
+                return
             } catch {
                 state.requeue(next)
                 return
@@ -170,6 +180,7 @@ final class RemoteHelperACPTransport: @unchecked Sendable, JSONRPCStdioTransport
         private var started = false
         private var terminated = false
         private var canWrite = false
+        private var isFlushingWrites = false
         private var pendingWrites: [Data] = []
 
         var isTerminated: Bool {
@@ -220,6 +231,20 @@ final class RemoteHelperACPTransport: @unchecked Sendable, JSONRPCStdioTransport
             defer { lock.unlock() }
             guard !pendingWrites.isEmpty else { return nil }
             return pendingWrites.removeFirst()
+        }
+
+        func beginFlushingWrites() -> Bool {
+            lock.lock()
+            defer { lock.unlock() }
+            guard !isFlushingWrites, !terminated else { return false }
+            isFlushingWrites = true
+            return true
+        }
+
+        func endFlushingWrites() {
+            lock.lock()
+            defer { lock.unlock() }
+            isFlushingWrites = false
         }
 
         func requeue(_ data: Data) {

--- a/Alas/Sources/SSH/RemoteHelperACPTransport.swift
+++ b/Alas/Sources/SSH/RemoteHelperACPTransport.swift
@@ -104,8 +104,7 @@ final class RemoteHelperACPTransport: @unchecked Sendable, JSONRPCStdioTransport
                 let handle = try await client.attachProc(
                     procId: procId,
                     stdoutOffset: requestedStdoutOffset,
-                    stderrOffset: requestedStderrOffset,
-                    attachAtEndIfOffsetUnknown: true
+                    stderrOffset: requestedStderrOffset
                 )
                 stdinOffset = handle.stdinOffset
                 attempt = 0

--- a/Alas/Sources/SSH/RemoteHelperACPTransport.swift
+++ b/Alas/Sources/SSH/RemoteHelperACPTransport.swift
@@ -1,8 +1,6 @@
 import Foundation
 
 final class RemoteHelperACPTransport: @unchecked Sendable, JSONRPCStdioTransporting {
-    private static let attachAtEndOffset = UInt64.max
-
     private let host: String
     private let procId: String
     private let command: String
@@ -57,6 +55,10 @@ final class RemoteHelperACPTransport: @unchecked Sendable, JSONRPCStdioTransport
     func terminate() {
         guard state.markTerminated() else { return }
         attachTask?.cancel()
+        Task { [host, procId, stdoutOffset, stderrOffset] in
+            let client = await RemoteHelperClientPool.shared.client(for: host)
+            await client.detachProc(procId: procId, stdoutOffset: stdoutOffset, stderrOffset: stderrOffset)
+        }
         continuation?.yield(.exited(0))
         continuation?.finish()
     }
@@ -97,12 +99,14 @@ final class RemoteHelperACPTransport: @unchecked Sendable, JSONRPCStdioTransport
                     }
                     didSpawn = true
                 }
-                    let requestedStdoutOffset = stdoutOffset == 0 ? Self.attachAtEndOffset : stdoutOffset
-                    let handle = try await client.attachProc(
-                        procId: procId,
-                        stdoutOffset: requestedStdoutOffset,
-                        stderrOffset: stderrOffset
-                    )
+                let requestedStdoutOffset = stdoutOffset == 0 ? nil : stdoutOffset
+                let requestedStderrOffset = stderrOffset == 0 ? nil : stderrOffset
+                let handle = try await client.attachProc(
+                    procId: procId,
+                    stdoutOffset: requestedStdoutOffset,
+                    stderrOffset: requestedStderrOffset,
+                    attachAtEndIfOffsetUnknown: true
+                )
                 stdinOffset = handle.stdinOffset
                 attempt = 0
                 for await event in handle.events {

--- a/Alas/Sources/SSH/RemoteHelperACPTransport.swift
+++ b/Alas/Sources/SSH/RemoteHelperACPTransport.swift
@@ -116,8 +116,7 @@ final class RemoteHelperACPTransport: @unchecked Sendable, JSONRPCStdioTransport
                     procId: procId,
                     attachmentId: attachmentId,
                     stdoutOffset: requestedOffsets.stdout,
-                    stderrOffset: requestedOffsets.stderr,
-                    attachAtEndIfOffsetUnknown: requestedOffsets.attachAtEndIfOffsetUnknown
+                    stderrOffset: requestedOffsets.stderr
                 )
                 stdinOffset = handle.stdinOffset
                 stdoutOffset = handle.stdoutOffset
@@ -133,10 +132,12 @@ final class RemoteHelperACPTransport: @unchecked Sendable, JSONRPCStdioTransport
                 }
                 attempt = 0
                 attachFreshSpawnFromStart = false
+                var didBecomeAvailable = false
                 for await event in handle.events {
                     guard !Task.isCancelled, !state.isTerminated else { return }
                     switch event {
                     case .available:
+                        didBecomeAvailable = true
                         state.setWritesEnabled(true)
                         await flushPendingWrites()
                     case .unavailable:
@@ -144,6 +145,9 @@ final class RemoteHelperACPTransport: @unchecked Sendable, JSONRPCStdioTransport
                         throw RemoteHelperClientError.notRunning
                     case .stdout(let data, let offset):
                         stdoutOffset = offset
+                        if !didBecomeAvailable, Self.shouldSuppressPreAvailableReplayFrame(data) {
+                            continue
+                        }
                         continuation?.yield(.frame(data))
                     case .stderr(let data, let offset):
                         stderrOffset = offset
@@ -167,15 +171,21 @@ final class RemoteHelperACPTransport: @unchecked Sendable, JSONRPCStdioTransport
         stdoutOffset: UInt64,
         stderrOffset: UInt64,
         attachFreshSpawnFromStart: Bool
-    ) -> (stdout: UInt64?, stderr: UInt64?, attachAtEndIfOffsetUnknown: Bool) {
+    ) -> (stdout: UInt64?, stderr: UInt64?) {
         if attachFreshSpawnFromStart {
-            return (0, 0, false)
+            return (0, 0)
         }
         return (
             stdoutOffset == 0 ? nil : stdoutOffset,
-            stderrOffset == 0 ? nil : stderrOffset,
-            true
+            stderrOffset == 0 ? nil : stderrOffset
         )
+    }
+
+    static func shouldSuppressPreAvailableReplayFrame(_ data: Data) -> Bool {
+        guard let object = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+            return false
+        }
+        return object["id"] != nil && object["method"] == nil
     }
 
     private func flushPendingWrites() async {

--- a/Alas/Sources/SSH/RemoteHelperACPTransport.swift
+++ b/Alas/Sources/SSH/RemoteHelperACPTransport.swift
@@ -64,6 +64,7 @@ final class RemoteHelperACPTransport: @unchecked Sendable, JSONRPCStdioTransport
         var attempt = 0
         while !Task.isCancelled && !state.isTerminated {
             do {
+                state.setWritesEnabled(false)
                 let client = await RemoteHelperClientPool.shared.client(for: host)
                 if !didSpawn {
                     let hello = try await client.hello()
@@ -87,13 +88,14 @@ final class RemoteHelperACPTransport: @unchecked Sendable, JSONRPCStdioTransport
                     stderrOffset: stderrOffset
                 )
                 attempt = 0
-                await flushPendingWrites()
                 for await event in handle.events {
                     guard !Task.isCancelled, !state.isTerminated else { return }
                     switch event {
                     case .available:
+                        state.setWritesEnabled(true)
                         await flushPendingWrites()
                     case .unavailable:
+                        state.setWritesEnabled(false)
                         throw RemoteHelperClientError.notRunning
                     case .stdout(let data, let offset):
                         stdoutOffset = offset
@@ -102,6 +104,7 @@ final class RemoteHelperACPTransport: @unchecked Sendable, JSONRPCStdioTransport
                         stderrOffset = offset
                         continuation?.yield(.stderr(data))
                     case .exited(let code):
+                        state.setWritesEnabled(false)
                         continuation?.yield(.exited(code ?? 0))
                         continuation?.finish()
                         return
@@ -109,6 +112,7 @@ final class RemoteHelperACPTransport: @unchecked Sendable, JSONRPCStdioTransport
                 }
             } catch {
                 guard !Task.isCancelled, !state.isTerminated else { return }
+                state.setWritesEnabled(false)
                 let delay = ACPReconnectPolicy.delay(forAttempt: attempt) ?? 5
                 attempt += 1
                 try? await Task.sleep(nanoseconds: UInt64(delay * 1_000_000_000))
@@ -118,6 +122,7 @@ final class RemoteHelperACPTransport: @unchecked Sendable, JSONRPCStdioTransport
 
     private func flushPendingWrites() async {
         while !Task.isCancelled && !state.isTerminated {
+            guard state.writesEnabled else { return }
             let next = state.takeNextWrite()
             guard let next else { return }
             do {
@@ -138,12 +143,19 @@ final class RemoteHelperACPTransport: @unchecked Sendable, JSONRPCStdioTransport
         private let lock = NSLock()
         private var started = false
         private var terminated = false
+        private var canWrite = false
         private var pendingWrites: [Data] = []
 
         var isTerminated: Bool {
             lock.lock()
             defer { lock.unlock() }
             return terminated
+        }
+
+        var writesEnabled: Bool {
+            lock.lock()
+            defer { lock.unlock() }
+            return canWrite && !terminated
         }
 
         func markStarted() -> Bool {
@@ -159,7 +171,14 @@ final class RemoteHelperACPTransport: @unchecked Sendable, JSONRPCStdioTransport
             defer { lock.unlock() }
             guard !terminated else { return false }
             terminated = true
+            canWrite = false
             return true
+        }
+
+        func setWritesEnabled(_ enabled: Bool) {
+            lock.lock()
+            defer { lock.unlock() }
+            canWrite = enabled && !terminated
         }
 
         func enqueue(_ data: Data) -> Bool {

--- a/Alas/Sources/SSH/RemoteHelperACPTransport.swift
+++ b/Alas/Sources/SSH/RemoteHelperACPTransport.swift
@@ -23,6 +23,7 @@ final class RemoteHelperACPTransport: @unchecked Sendable, JSONRPCStdioTransport
     private var stdinOffset: UInt64 = 0
 
     let incoming: AsyncStream<JSONRPCStdioTransport.Incoming>
+    var requestIDPrefix: String? { attachmentId }
 
     init(
         host: String,

--- a/Alas/Sources/SSH/RemoteHelperACPTransport.swift
+++ b/Alas/Sources/SSH/RemoteHelperACPTransport.swift
@@ -8,6 +8,7 @@ final class RemoteHelperACPTransport: @unchecked Sendable, JSONRPCStdioTransport
     private let cwd: String
     private let environment: [String: String]
     private let pathPrefixDirectories: [String]
+    private let attachmentId = UUID().uuidString
     private let state = State()
     private var continuation: AsyncStream<JSONRPCStdioTransport.Incoming>.Continuation?
     private var attachTask: Task<Void, Never>?
@@ -55,9 +56,14 @@ final class RemoteHelperACPTransport: @unchecked Sendable, JSONRPCStdioTransport
     func terminate() {
         guard state.markTerminated() else { return }
         attachTask?.cancel()
-        Task { [host, procId, stdoutOffset, stderrOffset] in
+        Task { [host, procId, attachmentId, stdoutOffset, stderrOffset] in
             let client = await RemoteHelperClientPool.shared.client(for: host)
-            await client.detachProc(procId: procId, stdoutOffset: stdoutOffset, stderrOffset: stderrOffset)
+            await client.detachProc(
+                procId: procId,
+                attachmentId: attachmentId,
+                stdoutOffset: stdoutOffset,
+                stderrOffset: stderrOffset
+            )
         }
         continuation?.yield(.exited(0))
         continuation?.finish()
@@ -103,10 +109,22 @@ final class RemoteHelperACPTransport: @unchecked Sendable, JSONRPCStdioTransport
                 let requestedStderrOffset = stderrOffset == 0 ? nil : stderrOffset
                 let handle = try await client.attachProc(
                     procId: procId,
+                    attachmentId: attachmentId,
                     stdoutOffset: requestedStdoutOffset,
                     stderrOffset: requestedStderrOffset
                 )
                 stdinOffset = handle.stdinOffset
+                stdoutOffset = handle.stdoutOffset
+                stderrOffset = handle.stderrOffset
+                guard !Task.isCancelled, !state.isTerminated else {
+                    await client.detachProc(
+                        procId: procId,
+                        attachmentId: attachmentId,
+                        stdoutOffset: stdoutOffset,
+                        stderrOffset: stderrOffset
+                    )
+                    return
+                }
                 attempt = 0
                 for await event in handle.events {
                     guard !Task.isCancelled, !state.isTerminated else { return }

--- a/Alas/Sources/SSH/RemoteHelperACPTransport.swift
+++ b/Alas/Sources/SSH/RemoteHelperACPTransport.swift
@@ -1,7 +1,10 @@
 import Foundation
 
 final class RemoteHelperACPTransport: @unchecked Sendable, JSONRPCStdioTransporting {
-    private static let attachAtEndOffset = UInt64.max
+    struct OutputOffsets: Equatable, Sendable {
+        let stdout: UInt64?
+        let stderr: UInt64?
+    }
 
     private let host: String
     private let procId: String
@@ -10,12 +13,13 @@ final class RemoteHelperACPTransport: @unchecked Sendable, JSONRPCStdioTransport
     private let cwd: String
     private let environment: [String: String]
     private let pathPrefixDirectories: [String]
+    private let onOutputOffsetsChanged: @MainActor @Sendable (OutputOffsets) -> Void
     private let attachmentId = UUID().uuidString
     private let state = State()
     private var continuation: AsyncStream<JSONRPCStdioTransport.Incoming>.Continuation?
     private var attachTask: Task<Void, Never>?
-    private var stdoutOffset: UInt64 = 0
-    private var stderrOffset: UInt64 = 0
+    private var stdoutOffset: UInt64?
+    private var stderrOffset: UInt64?
     private var stdinOffset: UInt64 = 0
 
     let incoming: AsyncStream<JSONRPCStdioTransport.Incoming>
@@ -27,7 +31,9 @@ final class RemoteHelperACPTransport: @unchecked Sendable, JSONRPCStdioTransport
         arguments: [String],
         cwd: String,
         environment: [String: String],
-        pathPrefixDirectories: [String] = []
+        pathPrefixDirectories: [String] = [],
+        initialOutputOffsets: OutputOffsets? = nil,
+        onOutputOffsetsChanged: @escaping @MainActor @Sendable (OutputOffsets) -> Void = { _ in }
     ) {
         self.host = host
         self.procId = procId
@@ -36,6 +42,9 @@ final class RemoteHelperACPTransport: @unchecked Sendable, JSONRPCStdioTransport
         self.cwd = cwd
         self.environment = environment
         self.pathPrefixDirectories = pathPrefixDirectories
+        self.onOutputOffsetsChanged = onOutputOffsetsChanged
+        stdoutOffset = initialOutputOffsets?.stdout
+        stderrOffset = initialOutputOffsets?.stderr
         var continuation: AsyncStream<JSONRPCStdioTransport.Incoming>.Continuation!
         self.incoming = AsyncStream { continuation = $0 }
         self.continuation = continuation
@@ -63,8 +72,8 @@ final class RemoteHelperACPTransport: @unchecked Sendable, JSONRPCStdioTransport
             await client.detachProc(
                 procId: procId,
                 attachmentId: attachmentId,
-                stdoutOffset: stdoutOffset,
-                stderrOffset: stderrOffset
+                stdoutOffset: stdoutOffset ?? 0,
+                stderrOffset: stderrOffset ?? 0
             )
         }
         continuation?.yield(.exited(0))
@@ -121,14 +130,12 @@ final class RemoteHelperACPTransport: @unchecked Sendable, JSONRPCStdioTransport
                     stderrOffset: requestedOffsets.stderr
                 )
                 stdinOffset = handle.stdinOffset
-                stdoutOffset = handle.stdoutOffset
-                stderrOffset = handle.stderrOffset
                 guard !Task.isCancelled, !state.isTerminated else {
                     await client.detachProc(
                         procId: procId,
                         attachmentId: attachmentId,
-                        stdoutOffset: stdoutOffset,
-                        stderrOffset: stderrOffset
+                        stdoutOffset: stdoutOffset ?? 0,
+                        stderrOffset: stderrOffset ?? 0
                     )
                     return
                 }
@@ -147,6 +154,7 @@ final class RemoteHelperACPTransport: @unchecked Sendable, JSONRPCStdioTransport
                         throw RemoteHelperClientError.notRunning
                     case .stdout(let data, let offset):
                         stdoutOffset = offset
+                        publishOutputOffsets()
                         if !didBecomeAvailable,
                            Self.shouldSuppressPreAvailableReplayFrame(
                                data,
@@ -157,6 +165,7 @@ final class RemoteHelperACPTransport: @unchecked Sendable, JSONRPCStdioTransport
                         continuation?.yield(.frame(data))
                     case .stderr(let data, let offset):
                         stderrOffset = offset
+                        publishOutputOffsets()
                         continuation?.yield(.stderr(data))
                     case .exited(let code):
                         state.setWritesEnabled(false)
@@ -174,17 +183,21 @@ final class RemoteHelperACPTransport: @unchecked Sendable, JSONRPCStdioTransport
     }
 
     static func attachReplayOffsets(
-        stdoutOffset: UInt64,
-        stderrOffset: UInt64,
+        stdoutOffset: UInt64?,
+        stderrOffset: UInt64?,
         attachFreshSpawnFromStart: Bool
     ) -> (stdout: UInt64?, stderr: UInt64?) {
         if attachFreshSpawnFromStart {
             return (0, 0)
         }
-        return (
-            stdoutOffset == 0 ? attachAtEndOffset : stdoutOffset,
-            stderrOffset == 0 ? attachAtEndOffset : stderrOffset
-        )
+        return (stdoutOffset, stderrOffset)
+    }
+
+    private func publishOutputOffsets() {
+        let offsets = OutputOffsets(stdout: stdoutOffset, stderr: stderrOffset)
+        Task { @MainActor [onOutputOffsetsChanged] in
+            onOutputOffsetsChanged(offsets)
+        }
     }
 
     static func shouldSuppressPreAvailableReplayFrame(_ data: Data, mayHaveDurableProcInput: Bool) -> Bool {

--- a/Alas/Sources/SSH/RemoteHelperACPTransport.swift
+++ b/Alas/Sources/SSH/RemoteHelperACPTransport.swift
@@ -1,6 +1,8 @@
 import Foundation
 
 final class RemoteHelperACPTransport: @unchecked Sendable, JSONRPCStdioTransporting {
+    private static let attachAtEndOffset = UInt64.max
+
     private let host: String
     private let procId: String
     private let command: String
@@ -180,8 +182,8 @@ final class RemoteHelperACPTransport: @unchecked Sendable, JSONRPCStdioTransport
             return (0, 0)
         }
         return (
-            stdoutOffset == 0 ? nil : stdoutOffset,
-            stderrOffset == 0 ? nil : stderrOffset
+            stdoutOffset == 0 ? attachAtEndOffset : stdoutOffset,
+            stderrOffset == 0 ? attachAtEndOffset : stderrOffset
         )
     }
 

--- a/Alas/Sources/SSH/RemoteHelperACPTransport.swift
+++ b/Alas/Sources/SSH/RemoteHelperACPTransport.swift
@@ -15,12 +15,11 @@ final class RemoteHelperACPTransport: @unchecked Sendable, JSONRPCStdioTransport
     private let pathPrefixDirectories: [String]
     private let onFreshProcSpawn: @MainActor @Sendable () async -> Void
     private let onOutputOffsetsChanged: @MainActor @Sendable (OutputOffsets) -> Void
+    private let outputConsumption: OutputConsumptionTracker
     private let attachmentId = UUID().uuidString
     private let state = State()
     private var continuation: AsyncStream<JSONRPCStdioTransport.Incoming>.Continuation?
     private var attachTask: Task<Void, Never>?
-    private var stdoutOffset: UInt64?
-    private var stderrOffset: UInt64?
     private var stdinOffset: UInt64 = 0
 
     let incoming: AsyncStream<JSONRPCStdioTransport.Incoming>
@@ -46,8 +45,10 @@ final class RemoteHelperACPTransport: @unchecked Sendable, JSONRPCStdioTransport
         self.pathPrefixDirectories = pathPrefixDirectories
         self.onFreshProcSpawn = onFreshProcSpawn
         self.onOutputOffsetsChanged = onOutputOffsetsChanged
-        stdoutOffset = initialOutputOffsets?.stdout
-        stderrOffset = initialOutputOffsets?.stderr
+        self.outputConsumption = OutputConsumptionTracker(
+            stdoutOffset: initialOutputOffsets?.stdout,
+            stderrOffset: initialOutputOffsets?.stderr
+        )
         var continuation: AsyncStream<JSONRPCStdioTransport.Incoming>.Continuation!
         self.incoming = AsyncStream { continuation = $0 }
         self.continuation = continuation
@@ -70,13 +71,14 @@ final class RemoteHelperACPTransport: @unchecked Sendable, JSONRPCStdioTransport
     func terminate() {
         guard state.markTerminated() else { return }
         attachTask?.cancel()
-        Task { [host, procId, attachmentId, stdoutOffset, stderrOffset] in
+        let offsets = outputConsumption.snapshot()
+        Task { [host, procId, attachmentId, offsets] in
             let client = await RemoteHelperClientPool.shared.client(for: host)
             await client.detachProc(
                 procId: procId,
                 attachmentId: attachmentId,
-                stdoutOffset: stdoutOffset ?? 0,
-                stderrOffset: stderrOffset ?? 0
+                stdoutOffset: offsets.stdout ?? 0,
+                stderrOffset: offsets.stderr ?? 0
             )
         }
         continuation?.yield(.exited(0))
@@ -110,6 +112,7 @@ final class RemoteHelperACPTransport: @unchecked Sendable, JSONRPCStdioTransport
                         attachFreshSpawnFromStart = status.spawned == true
                         if attachFreshSpawnFromStart {
                             await onFreshProcSpawn()
+                            outputConsumption.reset(stdoutOffset: 0, stderrOffset: 0)
                         }
                     } catch {
                         guard Self.shouldRetrySpawnFailure(error) else {
@@ -124,9 +127,10 @@ final class RemoteHelperACPTransport: @unchecked Sendable, JSONRPCStdioTransport
                     }
                     didSpawn = true
                 }
+                let consumedOffsets = outputConsumption.snapshot()
                 let requestedOffsets = Self.attachReplayOffsets(
-                    stdoutOffset: stdoutOffset,
-                    stderrOffset: stderrOffset,
+                    stdoutOffset: consumedOffsets.stdout,
+                    stderrOffset: consumedOffsets.stderr,
                     attachFreshSpawnFromStart: attachFreshSpawnFromStart
                 )
                 let handle = try await client.attachProc(
@@ -137,11 +141,12 @@ final class RemoteHelperACPTransport: @unchecked Sendable, JSONRPCStdioTransport
                 )
                 stdinOffset = handle.stdinOffset
                 guard !Task.isCancelled, !state.isTerminated else {
+                    let offsets = outputConsumption.snapshot()
                     await client.detachProc(
                         procId: procId,
                         attachmentId: attachmentId,
-                        stdoutOffset: stdoutOffset ?? 0,
-                        stderrOffset: stderrOffset ?? 0
+                        stdoutOffset: offsets.stdout ?? 0,
+                        stderrOffset: offsets.stderr ?? 0
                     )
                     return
                 }
@@ -159,19 +164,20 @@ final class RemoteHelperACPTransport: @unchecked Sendable, JSONRPCStdioTransport
                         state.setWritesEnabled(false)
                         throw RemoteHelperClientError.notRunning
                     case .stdout(let data, let offset):
-                        stdoutOffset = offset
-                        publishOutputOffsets()
+                        let consumptionToken = outputConsumption.registerStdout(offset: offset)
                         if !didBecomeAvailable,
                            Self.shouldSuppressPreAvailableReplayFrame(
                                data,
                                mayHaveDurableProcInput: state.mayHaveDurableProcInput
                            ) {
+                            acknowledgeStdout(consumptionToken)
                             continue
                         }
-                        continuation?.yield(.frame(data))
+                        continuation?.yield(.frame(data, onConsumed: { [weak self] in
+                            self?.acknowledgeStdout(consumptionToken)
+                        }))
                     case .stderr(let data, let offset):
-                        stderrOffset = offset
-                        publishOutputOffsets()
+                        publishOutputOffsets(outputConsumption.consumeStderr(offset: offset))
                         continuation?.yield(.stderr(data))
                     case .exited(let code):
                         state.setWritesEnabled(false)
@@ -199,8 +205,12 @@ final class RemoteHelperACPTransport: @unchecked Sendable, JSONRPCStdioTransport
         return (stdoutOffset, stderrOffset)
     }
 
-    private func publishOutputOffsets() {
-        let offsets = OutputOffsets(stdout: stdoutOffset, stderr: stderrOffset)
+    private func acknowledgeStdout(_ token: OutputConsumptionTracker.StdoutToken?) {
+        guard let token, let offsets = outputConsumption.consumeStdout(token: token) else { return }
+        publishOutputOffsets(offsets)
+    }
+
+    private func publishOutputOffsets(_ offsets: OutputOffsets) {
         Task { @MainActor [onOutputOffsetsChanged] in
             onOutputOffsetsChanged(offsets)
         }
@@ -289,6 +299,83 @@ final class RemoteHelperACPTransport: @unchecked Sendable, JSONRPCStdioTransport
         let delay = ACPReconnectPolicy.delay(forAttempt: attempt) ?? 5
         attempt += 1
         try? await Task.sleep(nanoseconds: UInt64(delay * 1_000_000_000))
+    }
+
+    final class OutputConsumptionTracker: @unchecked Sendable {
+        struct StdoutToken: Equatable, Sendable {
+            let generation: UInt64
+            let offset: UInt64
+        }
+
+        private struct PendingStdout {
+            let token: StdoutToken
+            var consumed: Bool
+        }
+
+        private let lock = NSLock()
+        private var stdoutOffset: UInt64?
+        private var stderrOffset: UInt64?
+        private var pendingStdout: [PendingStdout] = []
+        private var generation: UInt64 = 0
+
+        init(stdoutOffset: UInt64?, stderrOffset: UInt64?) {
+            self.stdoutOffset = stdoutOffset
+            self.stderrOffset = stderrOffset
+        }
+
+        func reset(stdoutOffset: UInt64?, stderrOffset: UInt64?) {
+            lock.lock()
+            defer { lock.unlock() }
+            self.stdoutOffset = stdoutOffset
+            self.stderrOffset = stderrOffset
+            pendingStdout.removeAll(keepingCapacity: true)
+            generation &+= 1
+        }
+
+        func snapshot() -> OutputOffsets {
+            lock.lock()
+            defer { lock.unlock() }
+            return OutputOffsets(stdout: stdoutOffset, stderr: stderrOffset)
+        }
+
+        func registerStdout(offset: UInt64) -> StdoutToken? {
+            lock.lock()
+            defer { lock.unlock() }
+            if let stdoutOffset, stdoutOffset >= offset { return nil }
+            if let pending = pendingStdout.first(where: { $0.token.offset == offset }) {
+                return pending.token
+            }
+            let token = StdoutToken(generation: generation, offset: offset)
+            pendingStdout.append(.init(token: token, consumed: false))
+            return token
+        }
+
+        func consumeStdout(token: StdoutToken) -> OutputOffsets? {
+            lock.lock()
+            defer { lock.unlock() }
+            guard token.generation == generation,
+                  let index = pendingStdout.firstIndex(where: { $0.token == token && !$0.consumed })
+            else {
+                return nil
+            }
+            pendingStdout[index].consumed = true
+            var advanced = false
+            while pendingStdout.first?.consumed == true {
+                stdoutOffset = pendingStdout.removeFirst().token.offset
+                advanced = true
+            }
+            guard advanced else { return nil }
+            return OutputOffsets(stdout: stdoutOffset, stderr: stderrOffset)
+        }
+
+        func consumeStderr(offset: UInt64) -> OutputOffsets {
+            lock.lock()
+            defer { lock.unlock() }
+            if stderrOffset == nil || stderrOffset! < offset {
+                stderrOffset = offset
+            }
+            return OutputOffsets(stdout: stdoutOffset, stderr: stderrOffset)
+        }
     }
 
     private final class State: @unchecked Sendable {

--- a/Alas/Sources/SSH/RemoteHelperACPTransport.swift
+++ b/Alas/Sources/SSH/RemoteHelperACPTransport.swift
@@ -145,7 +145,11 @@ final class RemoteHelperACPTransport: @unchecked Sendable, JSONRPCStdioTransport
                         throw RemoteHelperClientError.notRunning
                     case .stdout(let data, let offset):
                         stdoutOffset = offset
-                        if !didBecomeAvailable, Self.shouldSuppressPreAvailableReplayFrame(data) {
+                        if !didBecomeAvailable,
+                           Self.shouldSuppressPreAvailableReplayFrame(
+                               data,
+                               mayHaveDurableProcInput: state.mayHaveDurableProcInput
+                           ) {
                             continue
                         }
                         continuation?.yield(.frame(data))
@@ -181,7 +185,8 @@ final class RemoteHelperACPTransport: @unchecked Sendable, JSONRPCStdioTransport
         )
     }
 
-    static func shouldSuppressPreAvailableReplayFrame(_ data: Data) -> Bool {
+    static func shouldSuppressPreAvailableReplayFrame(_ data: Data, mayHaveDurableProcInput: Bool) -> Bool {
+        guard !mayHaveDurableProcInput else { return false }
         guard let object = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {
             return false
         }
@@ -221,6 +226,7 @@ final class RemoteHelperACPTransport: @unchecked Sendable, JSONRPCStdioTransport
                         data: Self.frameForProcWrite(next.data),
                         expectedStdinOffset: expectedStdinOffset
                     )
+                    state.markMayHaveDurableProcInput()
                 } catch RemoteHelperClientError.jsonrpc(let error) {
                     _ = state.markTerminated()
                     let message = "Remote helper failed to write ACP input: \(error.message)\n"
@@ -231,6 +237,7 @@ final class RemoteHelperACPTransport: @unchecked Sendable, JSONRPCStdioTransport
                     ownsFlush = false
                     return
                 } catch {
+                    state.markMayHaveDurableProcInput()
                     state.requeueForOffsetGuardedRetry(next.withExpectedStdinOffset(expectedStdinOffset))
                     state.endFlushingWrites()
                     ownsFlush = false
@@ -269,6 +276,7 @@ final class RemoteHelperACPTransport: @unchecked Sendable, JSONRPCStdioTransport
         private var terminated = false
         private var canWrite = false
         private var isFlushingWrites = false
+        private var mayHaveDurableInput = false
         private var pendingWrites: [PendingProcWrite] = []
 
         var isTerminated: Bool {
@@ -281,6 +289,12 @@ final class RemoteHelperACPTransport: @unchecked Sendable, JSONRPCStdioTransport
             lock.lock()
             defer { lock.unlock() }
             return canWrite && !terminated
+        }
+
+        var mayHaveDurableProcInput: Bool {
+            lock.lock()
+            defer { lock.unlock() }
+            return mayHaveDurableInput
         }
 
         func markStarted() -> Bool {
@@ -304,6 +318,12 @@ final class RemoteHelperACPTransport: @unchecked Sendable, JSONRPCStdioTransport
             lock.lock()
             defer { lock.unlock() }
             canWrite = enabled && !terminated
+        }
+
+        func markMayHaveDurableProcInput() {
+            lock.lock()
+            defer { lock.unlock() }
+            mayHaveDurableInput = true
         }
 
         func enqueue(_ data: Data) -> Bool {

--- a/Alas/Sources/SSH/RemoteHelperACPTransport.swift
+++ b/Alas/Sources/SSH/RemoteHelperACPTransport.swift
@@ -172,7 +172,9 @@ final class RemoteHelperACPTransport: @unchecked Sendable, JSONRPCStdioTransport
                         state.setWritesEnabled(false)
                         throw RemoteHelperClientError.notRunning
                     case .stdout(let data, let offset):
-                        let consumptionToken = outputConsumption.registerStdout(offset: offset)
+                        guard let consumptionToken = outputConsumption.registerStdout(offset: offset) else {
+                            continue
+                        }
                         if !didBecomeAvailable,
                            Self.shouldSuppressPreAvailableReplayFrame(
                                data,
@@ -213,8 +215,8 @@ final class RemoteHelperACPTransport: @unchecked Sendable, JSONRPCStdioTransport
         return (stdoutOffset, stderrOffset)
     }
 
-    private func acknowledgeStdout(_ token: OutputConsumptionTracker.StdoutToken?) {
-        guard let token, let offsets = outputConsumption.consumeStdout(token: token) else { return }
+    private func acknowledgeStdout(_ token: OutputConsumptionTracker.StdoutToken) {
+        guard let offsets = outputConsumption.consumeStdout(token: token) else { return }
         publishOutputOffsets(offsets)
     }
 
@@ -351,9 +353,7 @@ final class RemoteHelperACPTransport: @unchecked Sendable, JSONRPCStdioTransport
             lock.lock()
             defer { lock.unlock() }
             if let stdoutOffset, stdoutOffset >= offset { return nil }
-            if let pending = pendingStdout.first(where: { $0.token.offset == offset }) {
-                return pending.token
-            }
+            if pendingStdout.contains(where: { $0.token.offset == offset }) { return nil }
             let token = StdoutToken(generation: generation, offset: offset)
             pendingStdout.append(.init(token: token, consumed: false))
             return token

--- a/Alas/Sources/SSH/RemoteHelperACPTransport.swift
+++ b/Alas/Sources/SSH/RemoteHelperACPTransport.swift
@@ -122,12 +122,16 @@ final class RemoteHelperACPTransport: @unchecked Sendable, JSONRPCStdioTransport
             guard let next else { return }
             do {
                 let client = await RemoteHelperClientPool.shared.client(for: host)
-                try await client.writeProc(procId: procId, data: next)
+                try await client.writeProc(procId: procId, data: Self.frameForProcWrite(next))
             } catch {
                 state.requeue(next)
                 return
             }
         }
+    }
+
+    static func frameForProcWrite(_ data: Data) -> Data {
+        JSONRPCNewlineFramer.encode(data)
     }
 
     private final class State: @unchecked Sendable {

--- a/Alas/Sources/SSH/RemoteHelperACPTransport.swift
+++ b/Alas/Sources/SSH/RemoteHelperACPTransport.swift
@@ -1,0 +1,183 @@
+import Foundation
+
+final class RemoteHelperACPTransport: @unchecked Sendable, JSONRPCStdioTransporting {
+    private let host: String
+    private let procId: String
+    private let command: String
+    private let arguments: [String]
+    private let cwd: String
+    private let environment: [String: String]
+    private let state = State()
+    private var continuation: AsyncStream<JSONRPCStdioTransport.Incoming>.Continuation?
+    private var attachTask: Task<Void, Never>?
+    private var stdoutOffset: UInt64 = 0
+    private var stderrOffset: UInt64 = 0
+
+    let incoming: AsyncStream<JSONRPCStdioTransport.Incoming>
+
+    init(
+        host: String,
+        procId: String,
+        command: String,
+        arguments: [String],
+        cwd: String,
+        environment: [String: String]
+    ) {
+        self.host = host
+        self.procId = procId
+        self.command = command
+        self.arguments = arguments
+        self.cwd = cwd
+        self.environment = environment
+        var continuation: AsyncStream<JSONRPCStdioTransport.Incoming>.Continuation!
+        self.incoming = AsyncStream { continuation = $0 }
+        self.continuation = continuation
+    }
+
+    func start() throws {
+        guard state.markStarted() else { return }
+        attachTask = Task { [weak self] in
+            await self?.runAttachLoop()
+        }
+    }
+
+    func send(_ data: Data) throws {
+        guard state.enqueue(data) else { throw ACPClientError.notRunning }
+        Task { [weak self] in
+            await self?.flushPendingWrites()
+        }
+    }
+
+    func terminate() {
+        guard state.markTerminated() else { return }
+        attachTask?.cancel()
+        Task { [host, procId] in
+            let client = await RemoteHelperClientPool.shared.client(for: host)
+            try? await client.killProc(procId: procId)
+        }
+        continuation?.yield(.exited(0))
+        continuation?.finish()
+    }
+
+    private func runAttachLoop() async {
+        var didSpawn = false
+        var attempt = 0
+        while !Task.isCancelled && !state.isTerminated {
+            do {
+                let client = await RemoteHelperClientPool.shared.client(for: host)
+                if !didSpawn {
+                    let hello = try await client.hello()
+                    guard hello.capabilities.proc == true else {
+                        continuation?.yield(.exited(127))
+                        continuation?.finish()
+                        return
+                    }
+                    _ = try await client.spawnProc(
+                        procId: procId,
+                        command: command,
+                        args: arguments,
+                        cwd: cwd,
+                        env: environment
+                    )
+                    didSpawn = true
+                }
+                let handle = try await client.attachProc(
+                    procId: procId,
+                    stdoutOffset: stdoutOffset,
+                    stderrOffset: stderrOffset
+                )
+                attempt = 0
+                await flushPendingWrites()
+                for await event in handle.events {
+                    guard !Task.isCancelled, !state.isTerminated else { return }
+                    switch event {
+                    case .available:
+                        await flushPendingWrites()
+                    case .unavailable:
+                        throw RemoteHelperClientError.notRunning
+                    case .stdout(let data, let offset):
+                        stdoutOffset = offset
+                        continuation?.yield(.frame(data))
+                    case .stderr(let data, let offset):
+                        stderrOffset = offset
+                        continuation?.yield(.stderr(data))
+                    case .exited(let code):
+                        continuation?.yield(.exited(code ?? 0))
+                        continuation?.finish()
+                        return
+                    }
+                }
+            } catch {
+                guard !Task.isCancelled, !state.isTerminated else { return }
+                let delay = ACPReconnectPolicy.delay(forAttempt: attempt) ?? 5
+                attempt += 1
+                try? await Task.sleep(nanoseconds: UInt64(delay * 1_000_000_000))
+            }
+        }
+    }
+
+    private func flushPendingWrites() async {
+        while !Task.isCancelled && !state.isTerminated {
+            let next = state.takeNextWrite()
+            guard let next else { return }
+            do {
+                let client = await RemoteHelperClientPool.shared.client(for: host)
+                try await client.writeProc(procId: procId, data: next)
+            } catch {
+                state.requeue(next)
+                return
+            }
+        }
+    }
+
+    private final class State: @unchecked Sendable {
+        private let lock = NSLock()
+        private var started = false
+        private var terminated = false
+        private var pendingWrites: [Data] = []
+
+        var isTerminated: Bool {
+            lock.lock()
+            defer { lock.unlock() }
+            return terminated
+        }
+
+        func markStarted() -> Bool {
+            lock.lock()
+            defer { lock.unlock() }
+            guard !started else { return false }
+            started = true
+            return true
+        }
+
+        func markTerminated() -> Bool {
+            lock.lock()
+            defer { lock.unlock() }
+            guard !terminated else { return false }
+            terminated = true
+            return true
+        }
+
+        func enqueue(_ data: Data) -> Bool {
+            lock.lock()
+            defer { lock.unlock() }
+            guard !terminated else { return false }
+            pendingWrites.append(data)
+            return true
+        }
+
+        func takeNextWrite() -> Data? {
+            lock.lock()
+            defer { lock.unlock() }
+            guard !pendingWrites.isEmpty else { return nil }
+            return pendingWrites.removeFirst()
+        }
+
+        func requeue(_ data: Data) {
+            lock.lock()
+            defer { lock.unlock() }
+            guard !terminated else { return }
+            pendingWrites.insert(data, at: 0)
+        }
+    }
+}

--- a/Alas/Sources/SSH/RemoteHelperACPTransport.swift
+++ b/Alas/Sources/SSH/RemoteHelperACPTransport.swift
@@ -7,6 +7,7 @@ final class RemoteHelperACPTransport: @unchecked Sendable, JSONRPCStdioTransport
     private let arguments: [String]
     private let cwd: String
     private let environment: [String: String]
+    private let pathPrefixDirectories: [String]
     private let state = State()
     private var continuation: AsyncStream<JSONRPCStdioTransport.Incoming>.Continuation?
     private var attachTask: Task<Void, Never>?
@@ -22,7 +23,8 @@ final class RemoteHelperACPTransport: @unchecked Sendable, JSONRPCStdioTransport
         command: String,
         arguments: [String],
         cwd: String,
-        environment: [String: String]
+        environment: [String: String],
+        pathPrefixDirectories: [String] = []
     ) {
         self.host = host
         self.procId = procId
@@ -30,6 +32,7 @@ final class RemoteHelperACPTransport: @unchecked Sendable, JSONRPCStdioTransport
         self.arguments = arguments
         self.cwd = cwd
         self.environment = environment
+        self.pathPrefixDirectories = pathPrefixDirectories
         var continuation: AsyncStream<JSONRPCStdioTransport.Incoming>.Continuation!
         self.incoming = AsyncStream { continuation = $0 }
         self.continuation = continuation
@@ -76,7 +79,8 @@ final class RemoteHelperACPTransport: @unchecked Sendable, JSONRPCStdioTransport
                             command: command,
                             args: arguments,
                             cwd: cwd,
-                            env: environment
+                            env: environment,
+                            pathPrefixDirectories: pathPrefixDirectories
                         )
                     } catch {
                         guard Self.shouldRetrySpawnFailure(error) else {

--- a/Alas/Sources/SSH/RemoteHelperACPTransport.swift
+++ b/Alas/Sources/SSH/RemoteHelperACPTransport.swift
@@ -116,7 +116,8 @@ final class RemoteHelperACPTransport: @unchecked Sendable, JSONRPCStdioTransport
                     procId: procId,
                     attachmentId: attachmentId,
                     stdoutOffset: requestedOffsets.stdout,
-                    stderrOffset: requestedOffsets.stderr
+                    stderrOffset: requestedOffsets.stderr,
+                    attachAtEndIfOffsetUnknown: requestedOffsets.attachAtEndIfOffsetUnknown
                 )
                 stdinOffset = handle.stdinOffset
                 stdoutOffset = handle.stdoutOffset
@@ -166,13 +167,14 @@ final class RemoteHelperACPTransport: @unchecked Sendable, JSONRPCStdioTransport
         stdoutOffset: UInt64,
         stderrOffset: UInt64,
         attachFreshSpawnFromStart: Bool
-    ) -> (stdout: UInt64?, stderr: UInt64?) {
+    ) -> (stdout: UInt64?, stderr: UInt64?, attachAtEndIfOffsetUnknown: Bool) {
         if attachFreshSpawnFromStart {
-            return (0, 0)
+            return (0, 0, false)
         }
         return (
             stdoutOffset == 0 ? nil : stdoutOffset,
-            stderrOffset == 0 ? nil : stderrOffset
+            stderrOffset == 0 ? nil : stderrOffset,
+            true
         )
     }
 

--- a/Alas/Sources/SSH/RemoteHelperACPTransport.swift
+++ b/Alas/Sources/SSH/RemoteHelperACPTransport.swift
@@ -62,7 +62,15 @@ final class RemoteHelperACPTransport: @unchecked Sendable, JSONRPCStdioTransport
     }
 
     func send(_ data: Data) throws {
-        guard state.enqueue(data) else { throw ACPClientError.notRunning }
+        try enqueue(data, onWritten: nil)
+    }
+
+    func send(_ data: Data, onWritten: @escaping @Sendable () -> Void) throws {
+        try enqueue(data, onWritten: onWritten)
+    }
+
+    private func enqueue(_ data: Data, onWritten: (@Sendable () -> Void)?) throws {
+        guard state.enqueue(data, onWritten: onWritten) else { throw ACPClientError.notRunning }
         Task { [weak self] in
             await self?.flushPendingWrites()
         }
@@ -257,6 +265,7 @@ final class RemoteHelperACPTransport: @unchecked Sendable, JSONRPCStdioTransport
                         data: Self.frameForProcWrite(next.data),
                         expectedStdinOffset: expectedStdinOffset
                     )
+                    next.onWritten?()
                     state.markMayHaveDurableProcInput()
                 } catch RemoteHelperClientError.jsonrpc(let error) {
                     _ = state.markTerminated()
@@ -434,11 +443,15 @@ final class RemoteHelperACPTransport: @unchecked Sendable, JSONRPCStdioTransport
             mayHaveDurableInput = true
         }
 
-        func enqueue(_ data: Data) -> Bool {
+        func enqueue(_ data: Data, onWritten: (@Sendable () -> Void)?) -> Bool {
             lock.lock()
             defer { lock.unlock() }
             guard !terminated else { return false }
-            pendingWrites.append(PendingProcWrite(data: data, expectedStdinOffset: nil))
+            pendingWrites.append(PendingProcWrite(
+                data: data,
+                expectedStdinOffset: nil,
+                onWritten: onWritten
+            ))
             return true
         }
 
@@ -481,9 +494,10 @@ final class RemoteHelperACPTransport: @unchecked Sendable, JSONRPCStdioTransport
     private struct PendingProcWrite {
         let data: Data
         let expectedStdinOffset: UInt64?
+        let onWritten: (@Sendable () -> Void)?
 
         func withExpectedStdinOffset(_ offset: UInt64) -> PendingProcWrite {
-            PendingProcWrite(data: data, expectedStdinOffset: offset)
+            PendingProcWrite(data: data, expectedStdinOffset: offset, onWritten: onWritten)
         }
     }
 }

--- a/Alas/Sources/SSH/RemoteHelperACPTransport.swift
+++ b/Alas/Sources/SSH/RemoteHelperACPTransport.swift
@@ -125,9 +125,7 @@ final class RemoteHelperACPTransport: @unchecked Sendable, JSONRPCStdioTransport
             } catch {
                 guard !Task.isCancelled, !state.isTerminated else { return }
                 state.setWritesEnabled(false)
-                let delay = ACPReconnectPolicy.delay(forAttempt: attempt) ?? 5
-                attempt += 1
-                try? await Task.sleep(nanoseconds: UInt64(delay * 1_000_000_000))
+                await Self.sleepBeforeRetry(attempt: &attempt)
             }
         }
     }
@@ -159,6 +157,12 @@ final class RemoteHelperACPTransport: @unchecked Sendable, JSONRPCStdioTransport
         case .jsonrpc, .decoding:
             return false
         }
+    }
+
+    private static func sleepBeforeRetry(attempt: inout Int) async {
+        let delay = ACPReconnectPolicy.delay(forAttempt: attempt) ?? 5
+        attempt += 1
+        try? await Task.sleep(nanoseconds: UInt64(delay * 1_000_000_000))
     }
 
     private final class State: @unchecked Sendable {

--- a/Alas/Sources/SSH/RemoteHelperACPTransport.swift
+++ b/Alas/Sources/SSH/RemoteHelperACPTransport.swift
@@ -96,6 +96,7 @@ final class RemoteHelperACPTransport: @unchecked Sendable, JSONRPCStdioTransport
                     stdoutOffset: stdoutOffset,
                     stderrOffset: stderrOffset
                 )
+                stdinOffset = handle.stdinOffset
                 attempt = 0
                 for await event in handle.events {
                     guard !Task.isCancelled, !state.isTerminated else { return }
@@ -128,30 +129,56 @@ final class RemoteHelperACPTransport: @unchecked Sendable, JSONRPCStdioTransport
     }
 
     private func flushPendingWrites() async {
-        guard state.beginFlushingWrites() else { return }
-        defer { state.endFlushingWrites() }
-        while !Task.isCancelled && !state.isTerminated {
-            guard state.writesEnabled else { return }
-            let next = state.takeNextWrite()
-            guard let next else { return }
-            do {
-                let client = await RemoteHelperClientPool.shared.client(for: host)
-                stdinOffset = try await client.writeProc(
-                    procId: procId,
-                    data: Self.frameForProcWrite(next),
-                    expectedStdinOffset: stdinOffset
-                )
-            } catch RemoteHelperClientError.jsonrpc(let error) {
-                _ = state.markTerminated()
-                let message = "Remote helper failed to write ACP input: \(error.message)\n"
-                continuation?.yield(.stderr(Data(message.utf8)))
-                continuation?.yield(.exited(127))
-                continuation?.finish()
-                return
-            } catch {
-                state.requeueForOffsetGuardedRetry(next)
-                return
+        var ownsFlush = false
+        defer {
+            if ownsFlush {
+                state.endFlushingWrites()
             }
+        }
+        flushLoop: while !Task.isCancelled && !state.isTerminated {
+            guard state.beginFlushingWrites() else { return }
+            ownsFlush = true
+            while !Task.isCancelled && !state.isTerminated {
+                guard state.writesEnabled else {
+                    state.endFlushingWrites()
+                    ownsFlush = false
+                    return
+                }
+                let next = state.takeNextWrite()
+                guard let next else {
+                    if state.endFlushingWritesAndShouldRestart() {
+                        ownsFlush = false
+                        continue flushLoop
+                    }
+                    ownsFlush = false
+                    return
+                }
+                do {
+                    let client = await RemoteHelperClientPool.shared.client(for: host)
+                    stdinOffset = try await client.writeProc(
+                        procId: procId,
+                        data: Self.frameForProcWrite(next),
+                        expectedStdinOffset: stdinOffset
+                    )
+                } catch RemoteHelperClientError.jsonrpc(let error) {
+                    _ = state.markTerminated()
+                    let message = "Remote helper failed to write ACP input: \(error.message)\n"
+                    continuation?.yield(.stderr(Data(message.utf8)))
+                    continuation?.yield(.exited(127))
+                    continuation?.finish()
+                    state.endFlushingWrites()
+                    ownsFlush = false
+                    return
+                } catch {
+                    state.requeueForOffsetGuardedRetry(next)
+                    state.endFlushingWrites()
+                    ownsFlush = false
+                    return
+                }
+            }
+            state.endFlushingWrites()
+            ownsFlush = false
+            return
         }
     }
 
@@ -245,6 +272,13 @@ final class RemoteHelperACPTransport: @unchecked Sendable, JSONRPCStdioTransport
             lock.lock()
             defer { lock.unlock() }
             isFlushingWrites = false
+        }
+
+        func endFlushingWritesAndShouldRestart() -> Bool {
+            lock.lock()
+            defer { lock.unlock() }
+            isFlushingWrites = false
+            return canWrite && !terminated && !pendingWrites.isEmpty
         }
 
         func requeueForOffsetGuardedRetry(_ data: Data) {

--- a/Alas/Sources/SSH/RemoteHelperACPTransport.swift
+++ b/Alas/Sources/SSH/RemoteHelperACPTransport.swift
@@ -71,6 +71,7 @@ final class RemoteHelperACPTransport: @unchecked Sendable, JSONRPCStdioTransport
 
     private func runAttachLoop() async {
         var didSpawn = false
+        var attachFreshSpawnFromStart = false
         var attempt = 0
         while !Task.isCancelled && !state.isTerminated {
             do {
@@ -84,7 +85,7 @@ final class RemoteHelperACPTransport: @unchecked Sendable, JSONRPCStdioTransport
                         return
                     }
                     do {
-                        _ = try await client.spawnProc(
+                        let status = try await client.spawnProc(
                             procId: procId,
                             command: command,
                             args: arguments,
@@ -92,6 +93,7 @@ final class RemoteHelperACPTransport: @unchecked Sendable, JSONRPCStdioTransport
                             env: environment,
                             pathPrefixDirectories: pathPrefixDirectories
                         )
+                        attachFreshSpawnFromStart = status.spawned == true
                     } catch {
                         guard Self.shouldRetrySpawnFailure(error) else {
                             state.setWritesEnabled(false)
@@ -105,13 +107,16 @@ final class RemoteHelperACPTransport: @unchecked Sendable, JSONRPCStdioTransport
                     }
                     didSpawn = true
                 }
-                let requestedStdoutOffset = stdoutOffset == 0 ? nil : stdoutOffset
-                let requestedStderrOffset = stderrOffset == 0 ? nil : stderrOffset
+                let requestedOffsets = Self.attachReplayOffsets(
+                    stdoutOffset: stdoutOffset,
+                    stderrOffset: stderrOffset,
+                    attachFreshSpawnFromStart: attachFreshSpawnFromStart
+                )
                 let handle = try await client.attachProc(
                     procId: procId,
                     attachmentId: attachmentId,
-                    stdoutOffset: requestedStdoutOffset,
-                    stderrOffset: requestedStderrOffset
+                    stdoutOffset: requestedOffsets.stdout,
+                    stderrOffset: requestedOffsets.stderr
                 )
                 stdinOffset = handle.stdinOffset
                 stdoutOffset = handle.stdoutOffset
@@ -126,6 +131,7 @@ final class RemoteHelperACPTransport: @unchecked Sendable, JSONRPCStdioTransport
                     return
                 }
                 attempt = 0
+                attachFreshSpawnFromStart = false
                 for await event in handle.events {
                     guard !Task.isCancelled, !state.isTerminated else { return }
                     switch event {
@@ -154,6 +160,20 @@ final class RemoteHelperACPTransport: @unchecked Sendable, JSONRPCStdioTransport
                 await Self.sleepBeforeRetry(attempt: &attempt)
             }
         }
+    }
+
+    static func attachReplayOffsets(
+        stdoutOffset: UInt64,
+        stderrOffset: UInt64,
+        attachFreshSpawnFromStart: Bool
+    ) -> (stdout: UInt64?, stderr: UInt64?) {
+        if attachFreshSpawnFromStart {
+            return (0, 0)
+        }
+        return (
+            stdoutOffset == 0 ? nil : stdoutOffset,
+            stderrOffset == 0 ? nil : stderrOffset
+        )
     }
 
     private func flushPendingWrites() async {

--- a/Alas/Sources/SSH/RemoteHelperACPTransport.swift
+++ b/Alas/Sources/SSH/RemoteHelperACPTransport.swift
@@ -73,13 +73,25 @@ final class RemoteHelperACPTransport: @unchecked Sendable, JSONRPCStdioTransport
                         continuation?.finish()
                         return
                     }
-                    _ = try await client.spawnProc(
-                        procId: procId,
-                        command: command,
-                        args: arguments,
-                        cwd: cwd,
-                        env: environment
-                    )
+                    do {
+                        _ = try await client.spawnProc(
+                            procId: procId,
+                            command: command,
+                            args: arguments,
+                            cwd: cwd,
+                            env: environment
+                        )
+                    } catch {
+                        guard Self.shouldRetrySpawnFailure(error) else {
+                            state.setWritesEnabled(false)
+                            let message = "Remote helper failed to launch ACP process: \(error.localizedDescription)\n"
+                            continuation?.yield(.stderr(Data(message.utf8)))
+                            continuation?.yield(.exited(127))
+                            continuation?.finish()
+                            return
+                        }
+                        throw error
+                    }
                     didSpawn = true
                 }
                 let handle = try await client.attachProc(
@@ -137,6 +149,16 @@ final class RemoteHelperACPTransport: @unchecked Sendable, JSONRPCStdioTransport
 
     static func frameForProcWrite(_ data: Data) -> Data {
         JSONRPCNewlineFramer.encode(data)
+    }
+
+    static func shouldRetrySpawnFailure(_ error: Error) -> Bool {
+        guard let error = error as? RemoteHelperClientError else { return false }
+        switch error {
+        case .notRunning, .unavailable:
+            return true
+        case .jsonrpc, .decoding:
+            return false
+        }
     }
 
     private final class State: @unchecked Sendable {

--- a/Alas/Sources/SSH/RemoteHelperClient.swift
+++ b/Alas/Sources/SSH/RemoteHelperClient.swift
@@ -298,13 +298,10 @@ actor RemoteHelperClient {
     func attachProc(
         procId: String,
         stdoutOffset: UInt64? = nil,
-        stderrOffset: UInt64? = nil,
-        attachAtEndIfOffsetUnknown: Bool = false
+        stderrOffset: UInt64? = nil
     ) async throws -> RemoteHelperProcAttachHandle {
         let rememberedOffsets = procOffsets[procId]
-        let requestedStdoutOffset = stdoutOffset
-            ?? rememberedOffsets?.stdout
-            ?? (attachAtEndIfOffsetUnknown ? UInt64.max : nil)
+        let requestedStdoutOffset = stdoutOffset ?? rememberedOffsets?.stdout
         let requestedStderrOffset = stderrOffset ?? rememberedOffsets?.stderr
         let result: RemoteHelperProcAttachResult = try await request(
             method: "proc/attach",

--- a/Alas/Sources/SSH/RemoteHelperClient.swift
+++ b/Alas/Sources/SSH/RemoteHelperClient.swift
@@ -299,14 +299,14 @@ actor RemoteHelperClient {
                 continuation.yield(.stderr(data, offset: chunk.offset))
             }
         }
-        var didExit = false
+        var replayedExit = false
         for event in earlyProcEvents.removeValue(forKey: procId) ?? [] {
             continuation.yield(event)
             if case .exited = event {
-                didExit = true
+                replayedExit = true
             }
         }
-        if didExit {
+        if replayedExit {
             continuation.finish()
             activeProcAttachments.removeValue(forKey: procId)
             scheduleIdleShutdownIfPossible()

--- a/Alas/Sources/SSH/RemoteHelperClient.swift
+++ b/Alas/Sources/SSH/RemoteHelperClient.swift
@@ -300,16 +300,11 @@ actor RemoteHelperClient {
         procId: String,
         attachmentId: String = UUID().uuidString,
         stdoutOffset: UInt64? = nil,
-        stderrOffset: UInt64? = nil,
-        attachAtEndIfOffsetUnknown: Bool = false
+        stderrOffset: UInt64? = nil
     ) async throws -> RemoteHelperProcAttachHandle {
         let rememberedOffsets = procOffsets[procId]
-        let requestedStdoutOffset = stdoutOffset
-            ?? rememberedOffsets?.stdout
-            ?? (attachAtEndIfOffsetUnknown ? UInt64.max : nil)
-        let requestedStderrOffset = stderrOffset
-            ?? rememberedOffsets?.stderr
-            ?? (attachAtEndIfOffsetUnknown ? UInt64.max : nil)
+        let requestedStdoutOffset = stdoutOffset ?? rememberedOffsets?.stdout
+        let requestedStderrOffset = stderrOffset ?? rememberedOffsets?.stderr
         let wasDetached = detachedProcIds.remove(procId) != nil
         let result: RemoteHelperProcAttachResult
         do {

--- a/Alas/Sources/SSH/RemoteHelperClient.swift
+++ b/Alas/Sources/SSH/RemoteHelperClient.swift
@@ -343,6 +343,13 @@ actor RemoteHelperClient {
         rememberProcOffsets(procId: procId, stdout: result.stdoutOffset, stderr: result.stderrOffset)
         var replayedExit = false
         for event in earlyProcEvents.removeValue(forKey: procId) ?? [] {
+            if Self.procEventIsCoveredByAttachResult(
+                event,
+                stdoutOffset: result.stdoutOffset,
+                stderrOffset: result.stderrOffset
+            ) {
+                continue
+            }
             rememberProcOffsetIfNeeded(event, procId: procId)
             continuation.yield(event)
             if case .exited = event {
@@ -369,6 +376,21 @@ actor RemoteHelperClient {
             stderrOffset: result.stderrOffset,
             events: events
         )
+    }
+
+    private static func procEventIsCoveredByAttachResult(
+        _ event: RemoteHelperProcEvent,
+        stdoutOffset: UInt64,
+        stderrOffset: UInt64
+    ) -> Bool {
+        switch event {
+        case .stdout(_, let offset):
+            return offset <= stdoutOffset
+        case .stderr(_, let offset):
+            return offset <= stderrOffset
+        case .available, .unavailable, .exited:
+            return false
+        }
     }
 
     func detachProc(

--- a/Alas/Sources/SSH/RemoteHelperClient.swift
+++ b/Alas/Sources/SSH/RemoteHelperClient.swift
@@ -272,7 +272,8 @@ actor RemoteHelperClient {
         command: String,
         args: [String],
         cwd: String,
-        env: [String: String]
+        env: [String: String],
+        pathPrefixDirectories: [String] = []
     ) async throws -> RemoteHelperProcStatus {
         try await request(
             method: "proc/spawn",
@@ -281,7 +282,8 @@ actor RemoteHelperClient {
                 command: command,
                 args: args,
                 cwd: cwd,
-                env: env
+                env: env,
+                pathPrefixDirectories: pathPrefixDirectories
             )
         )
     }

--- a/Alas/Sources/SSH/RemoteHelperClient.swift
+++ b/Alas/Sources/SSH/RemoteHelperClient.swift
@@ -300,11 +300,16 @@ actor RemoteHelperClient {
         procId: String,
         attachmentId: String = UUID().uuidString,
         stdoutOffset: UInt64? = nil,
-        stderrOffset: UInt64? = nil
+        stderrOffset: UInt64? = nil,
+        attachAtEndIfOffsetUnknown: Bool = false
     ) async throws -> RemoteHelperProcAttachHandle {
         let rememberedOffsets = procOffsets[procId]
-        let requestedStdoutOffset = stdoutOffset ?? rememberedOffsets?.stdout
-        let requestedStderrOffset = stderrOffset ?? rememberedOffsets?.stderr
+        let requestedStdoutOffset = stdoutOffset
+            ?? rememberedOffsets?.stdout
+            ?? (attachAtEndIfOffsetUnknown ? UInt64.max : nil)
+        let requestedStderrOffset = stderrOffset
+            ?? rememberedOffsets?.stderr
+            ?? (attachAtEndIfOffsetUnknown ? UInt64.max : nil)
         let wasDetached = detachedProcIds.remove(procId) != nil
         let result: RemoteHelperProcAttachResult
         do {

--- a/Alas/Sources/SSH/RemoteHelperClient.swift
+++ b/Alas/Sources/SSH/RemoteHelperClient.swift
@@ -331,7 +331,11 @@ actor RemoteHelperClient {
             activeProcAttachments.removeValue(forKey: procId)
             scheduleIdleShutdownIfPossible()
         }
-        return RemoteHelperProcAttachHandle(procId: procId, events: events)
+        return RemoteHelperProcAttachHandle(
+            procId: procId,
+            stdinOffset: result.stdinOffset,
+            events: events
+        )
     }
 
     func writeProc(procId: String, data: Data, expectedStdinOffset: UInt64? = nil) async throws -> UInt64 {

--- a/Alas/Sources/SSH/RemoteHelperClient.swift
+++ b/Alas/Sources/SSH/RemoteHelperClient.swift
@@ -18,6 +18,7 @@ private struct ActiveRemoteHelperSearch {
 }
 
 private struct ActiveRemoteHelperProcAttachment {
+    let id: String
     let continuation: AsyncStream<RemoteHelperProcEvent>.Continuation
 }
 
@@ -297,24 +298,36 @@ actor RemoteHelperClient {
 
     func attachProc(
         procId: String,
+        attachmentId: String = UUID().uuidString,
         stdoutOffset: UInt64? = nil,
         stderrOffset: UInt64? = nil
     ) async throws -> RemoteHelperProcAttachHandle {
         let rememberedOffsets = procOffsets[procId]
         let requestedStdoutOffset = stdoutOffset ?? rememberedOffsets?.stdout
         let requestedStderrOffset = stderrOffset ?? rememberedOffsets?.stderr
-        let result: RemoteHelperProcAttachResult = try await request(
-            method: "proc/attach",
-            params: RemoteHelperProcAttachParams(
-                procId: procId,
-                stdoutOffset: requestedStdoutOffset,
-                stderrOffset: requestedStderrOffset
+        let wasDetached = detachedProcIds.remove(procId) != nil
+        let result: RemoteHelperProcAttachResult
+        do {
+            result = try await request(
+                method: "proc/attach",
+                params: RemoteHelperProcAttachParams(
+                    procId: procId,
+                    stdoutOffset: requestedStdoutOffset,
+                    stderrOffset: requestedStderrOffset
+                )
             )
-        )
+        } catch {
+            if wasDetached {
+                detachedProcIds.insert(procId)
+            }
+            throw error
+        }
         var continuation: AsyncStream<RemoteHelperProcEvent>.Continuation!
         let events = AsyncStream<RemoteHelperProcEvent> { continuation = $0 }
-        detachedProcIds.remove(procId)
-        activeProcAttachments[procId] = ActiveRemoteHelperProcAttachment(continuation: continuation)
+        activeProcAttachments[procId] = ActiveRemoteHelperProcAttachment(
+            id: attachmentId,
+            continuation: continuation
+        )
         for frame in result.stdoutFrames {
             if let data = Data(base64Encoded: frame.dataBase64) {
                 rememberProcOffset(procId: procId, stream: "stdout", offset: frame.offset)
@@ -350,12 +363,24 @@ actor RemoteHelperClient {
         }
         return RemoteHelperProcAttachHandle(
             procId: procId,
+            attachmentId: attachmentId,
             stdinOffset: result.stdinOffset,
+            stdoutOffset: result.stdoutOffset,
+            stderrOffset: result.stderrOffset,
             events: events
         )
     }
 
-    func detachProc(procId: String, stdoutOffset: UInt64, stderrOffset: UInt64) {
+    func detachProc(
+        procId: String,
+        attachmentId: String? = nil,
+        stdoutOffset: UInt64,
+        stderrOffset: UInt64
+    ) {
+        if let attachmentId,
+           activeProcAttachments[procId]?.id != attachmentId {
+            return
+        }
         rememberProcOffsets(procId: procId, stdout: stdoutOffset, stderr: stderrOffset)
         earlyProcEvents.removeValue(forKey: procId)
         detachedProcIds.insert(procId)

--- a/Alas/Sources/SSH/RemoteHelperClient.swift
+++ b/Alas/Sources/SSH/RemoteHelperClient.swift
@@ -306,12 +306,17 @@ actor RemoteHelperClient {
                 didExit = true
             }
         }
-        if result.running, !didExit {
+        if didExit {
+            continuation.finish()
+            activeProcAttachments.removeValue(forKey: procId)
+            scheduleIdleShutdownIfPossible()
+        } else if result.running {
             continuation.yield(.available)
-        } else if !didExit {
+        } else {
             continuation.yield(.exited(result.exitCode))
             continuation.finish()
             activeProcAttachments.removeValue(forKey: procId)
+            scheduleIdleShutdownIfPossible()
         }
         return RemoteHelperProcAttachHandle(procId: procId, events: events)
     }

--- a/Alas/Sources/SSH/RemoteHelperClient.swift
+++ b/Alas/Sources/SSH/RemoteHelperClient.swift
@@ -289,7 +289,6 @@ actor RemoteHelperClient {
         var continuation: AsyncStream<RemoteHelperProcEvent>.Continuation!
         let events = AsyncStream<RemoteHelperProcEvent> { continuation = $0 }
         activeProcAttachments[procId] = ActiveRemoteHelperProcAttachment(continuation: continuation)
-        continuation.yield(.available)
         for frame in result.stdoutFrames {
             if let data = Data(base64Encoded: frame.dataBase64) {
                 continuation.yield(.stdout(data, offset: frame.offset))
@@ -300,11 +299,19 @@ actor RemoteHelperClient {
                 continuation.yield(.stderr(data, offset: chunk.offset))
             }
         }
+        var didExit = false
         for event in earlyProcEvents.removeValue(forKey: procId) ?? [] {
             continuation.yield(event)
+            if case .exited = event {
+                didExit = true
+            }
         }
-        if !result.running {
+        if result.running, !didExit {
+            continuation.yield(.available)
+        } else if !didExit {
             continuation.yield(.exited(result.exitCode))
+            continuation.finish()
+            activeProcAttachments.removeValue(forKey: procId)
         }
         return RemoteHelperProcAttachHandle(procId: procId, events: events)
     }

--- a/Alas/Sources/SSH/RemoteHelperClient.swift
+++ b/Alas/Sources/SSH/RemoteHelperClient.swift
@@ -334,15 +334,17 @@ actor RemoteHelperClient {
         return RemoteHelperProcAttachHandle(procId: procId, events: events)
     }
 
-    func writeProc(procId: String, data: Data) async throws {
-        let _: RemoteHelperProcWriteResult = try await request(
+    func writeProc(procId: String, data: Data, expectedStdinOffset: UInt64? = nil) async throws -> UInt64 {
+        let result: RemoteHelperProcWriteResult = try await request(
             method: "proc/write",
             params: RemoteHelperProcWriteParams(
                 procId: procId,
-                dataBase64: data.base64EncodedString()
+                dataBase64: data.base64EncodedString(),
+                expectedStdinOffset: expectedStdinOffset
             ),
             replaySubscriptionsOnStart: false
         )
+        return result.stdinOffset
     }
 
     func killProc(procId: String) async throws {

--- a/Alas/Sources/SSH/RemoteHelperClient.swift
+++ b/Alas/Sources/SSH/RemoteHelperClient.swift
@@ -637,7 +637,7 @@ actor RemoteHelperClient {
     private func handle(_ event: JSONRPCStdioTransport.Incoming, generation eventGeneration: Int) {
         guard eventGeneration == generation else { return }
         switch event {
-        case .frame(let data):
+        case .frame(let data, _):
             handleFrame(data)
         case .stderr:
             break

--- a/Alas/Sources/SSH/RemoteHelperClient.swift
+++ b/Alas/Sources/SSH/RemoteHelperClient.swift
@@ -705,14 +705,15 @@ actor RemoteHelperClient {
     }
 
     private func emitProcEvent(_ event: RemoteHelperProcEvent, procId: String) {
-        rememberProcOffsetIfNeeded(event, procId: procId)
         guard let attachment = activeProcAttachments[procId] else {
             if detachedProcIds.contains(procId) {
                 return
             }
+            rememberProcOffsetIfNeeded(event, procId: procId)
             earlyProcEvents[procId, default: []].append(event)
             return
         }
+        rememberProcOffsetIfNeeded(event, procId: procId)
         attachment.continuation.yield(event)
         if case .exited = event {
             attachment.continuation.finish()

--- a/Alas/Sources/SSH/RemoteHelperClient.swift
+++ b/Alas/Sources/SSH/RemoteHelperClient.swift
@@ -21,7 +21,7 @@ private struct ActiveRemoteHelperProcAttachment {
     let continuation: AsyncStream<RemoteHelperProcEvent>.Continuation
 }
 
-enum RemoteHelperClientError: Error, Equatable {
+enum RemoteHelperClientError: LocalizedError, Equatable {
     case notRunning
     case unavailable(String)
     case jsonrpc(JSONRPCError)
@@ -36,6 +36,19 @@ enum RemoteHelperClientError: Error, Equatable {
                 || error.code == -32022 || error.code == -32023
         case .decoding:
             return false
+        }
+    }
+
+    var errorDescription: String? {
+        switch self {
+        case .notRunning:
+            return "Remote helper is not running."
+        case .unavailable(let message):
+            return message
+        case .jsonrpc(let error):
+            return "Remote helper error \(error.code): \(error.message)"
+        case .decoding(let message):
+            return "Remote helper decoding failed: \(message)"
         }
     }
 }

--- a/Alas/Sources/SSH/RemoteHelperClient.swift
+++ b/Alas/Sources/SSH/RemoteHelperClient.swift
@@ -21,6 +21,11 @@ private struct ActiveRemoteHelperProcAttachment {
     let continuation: AsyncStream<RemoteHelperProcEvent>.Continuation
 }
 
+private struct RemoteHelperProcOffsets {
+    var stdout: UInt64
+    var stderr: UInt64
+}
+
 enum RemoteHelperClientError: LocalizedError, Equatable {
     case notRunning
     case unavailable(String)
@@ -77,6 +82,8 @@ actor RemoteHelperClient {
     private var earlySearchEvents: [String: [RemoteHelperSearchEvent]] = [:]
     private var activeProcAttachments: [String: ActiveRemoteHelperProcAttachment] = [:]
     private var earlyProcEvents: [String: [RemoteHelperProcEvent]] = [:]
+    private var procOffsets: [String: RemoteHelperProcOffsets] = [:]
+    private var detachedProcIds: Set<String> = []
     private var subscriptionReplayTask: Task<Void, Error>?
     private var subscriptionsNeedReplay = false
     private var lastExitStatus: Int32?
@@ -291,31 +298,42 @@ actor RemoteHelperClient {
     func attachProc(
         procId: String,
         stdoutOffset: UInt64? = nil,
-        stderrOffset: UInt64? = nil
+        stderrOffset: UInt64? = nil,
+        attachAtEndIfOffsetUnknown: Bool = false
     ) async throws -> RemoteHelperProcAttachHandle {
+        let rememberedOffsets = procOffsets[procId]
+        let requestedStdoutOffset = stdoutOffset
+            ?? rememberedOffsets?.stdout
+            ?? (attachAtEndIfOffsetUnknown ? UInt64.max : nil)
+        let requestedStderrOffset = stderrOffset ?? rememberedOffsets?.stderr
         let result: RemoteHelperProcAttachResult = try await request(
             method: "proc/attach",
             params: RemoteHelperProcAttachParams(
                 procId: procId,
-                stdoutOffset: stdoutOffset,
-                stderrOffset: stderrOffset
+                stdoutOffset: requestedStdoutOffset,
+                stderrOffset: requestedStderrOffset
             )
         )
         var continuation: AsyncStream<RemoteHelperProcEvent>.Continuation!
         let events = AsyncStream<RemoteHelperProcEvent> { continuation = $0 }
+        detachedProcIds.remove(procId)
         activeProcAttachments[procId] = ActiveRemoteHelperProcAttachment(continuation: continuation)
         for frame in result.stdoutFrames {
             if let data = Data(base64Encoded: frame.dataBase64) {
+                rememberProcOffset(procId: procId, stream: "stdout", offset: frame.offset)
                 continuation.yield(.stdout(data, offset: frame.offset))
             }
         }
         for chunk in result.stderrChunks {
             if let data = Data(base64Encoded: chunk.dataBase64) {
+                rememberProcOffset(procId: procId, stream: "stderr", offset: chunk.offset)
                 continuation.yield(.stderr(data, offset: chunk.offset))
             }
         }
+        rememberProcOffsets(procId: procId, stdout: result.stdoutOffset, stderr: result.stderrOffset)
         var replayedExit = false
         for event in earlyProcEvents.removeValue(forKey: procId) ?? [] {
+            rememberProcOffsetIfNeeded(event, procId: procId)
             continuation.yield(event)
             if case .exited = event {
                 replayedExit = true
@@ -338,6 +356,16 @@ actor RemoteHelperClient {
             stdinOffset: result.stdinOffset,
             events: events
         )
+    }
+
+    func detachProc(procId: String, stdoutOffset: UInt64, stderrOffset: UInt64) {
+        rememberProcOffsets(procId: procId, stdout: stdoutOffset, stderr: stderrOffset)
+        earlyProcEvents.removeValue(forKey: procId)
+        detachedProcIds.insert(procId)
+        if let attachment = activeProcAttachments.removeValue(forKey: procId) {
+            attachment.continuation.finish()
+        }
+        scheduleIdleShutdownIfPossible()
     }
 
     func writeProc(procId: String, data: Data, expectedStdinOffset: UInt64? = nil) async throws -> UInt64 {
@@ -387,6 +415,7 @@ actor RemoteHelperClient {
         }
         activeProcAttachments.removeAll()
         earlyProcEvents.removeAll()
+        detachedProcIds.removeAll()
         drainPending(with: RemoteHelperClientError.notRunning)
         dispatchTask?.cancel()
         dispatchTask = nil
@@ -679,7 +708,11 @@ actor RemoteHelperClient {
     }
 
     private func emitProcEvent(_ event: RemoteHelperProcEvent, procId: String) {
+        rememberProcOffsetIfNeeded(event, procId: procId)
         guard let attachment = activeProcAttachments[procId] else {
+            if detachedProcIds.contains(procId) {
+                return
+            }
             earlyProcEvents[procId, default: []].append(event)
             return
         }
@@ -712,11 +745,43 @@ actor RemoteHelperClient {
         }
         activeProcAttachments.removeAll()
         earlyProcEvents.removeAll()
+        detachedProcIds.removeAll()
         if RemoteExec.isConnectionFailure(exitCode: status) {
             Task { @MainActor [host] in
                 RemoteHostStatusStore.shared.reportConnectionFailure(host: host)
             }
         }
+    }
+
+    private func rememberProcOffsetIfNeeded(_ event: RemoteHelperProcEvent, procId: String) {
+        switch event {
+        case .stdout(_, let offset):
+            rememberProcOffset(procId: procId, stream: "stdout", offset: offset)
+        case .stderr(_, let offset):
+            rememberProcOffset(procId: procId, stream: "stderr", offset: offset)
+        case .available, .unavailable, .exited:
+            break
+        }
+    }
+
+    private func rememberProcOffset(procId: String, stream: String, offset: UInt64) {
+        var offsets = procOffsets[procId] ?? RemoteHelperProcOffsets(stdout: 0, stderr: 0)
+        switch stream {
+        case "stdout":
+            offsets.stdout = offset
+        case "stderr":
+            offsets.stderr = offset
+        default:
+            return
+        }
+        procOffsets[procId] = offsets
+    }
+
+    private func rememberProcOffsets(procId: String, stdout: UInt64, stderr: UInt64) {
+        var offsets = procOffsets[procId] ?? RemoteHelperProcOffsets(stdout: 0, stderr: 0)
+        offsets.stdout = stdout
+        offsets.stderr = stderr
+        procOffsets[procId] = offsets
     }
 
     private func drainPending(with error: Error) {

--- a/Alas/Sources/SSH/RemoteHelperClient.swift
+++ b/Alas/Sources/SSH/RemoteHelperClient.swift
@@ -330,17 +330,14 @@ actor RemoteHelperClient {
         )
         for frame in result.stdoutFrames {
             if let data = Data(base64Encoded: frame.dataBase64) {
-                rememberProcOffset(procId: procId, stream: "stdout", offset: frame.offset)
                 continuation.yield(.stdout(data, offset: frame.offset))
             }
         }
         for chunk in result.stderrChunks {
             if let data = Data(base64Encoded: chunk.dataBase64) {
-                rememberProcOffset(procId: procId, stream: "stderr", offset: chunk.offset)
                 continuation.yield(.stderr(data, offset: chunk.offset))
             }
         }
-        rememberProcOffsets(procId: procId, stdout: result.stdoutOffset, stderr: result.stderrOffset)
         var replayedExit = false
         for event in earlyProcEvents.removeValue(forKey: procId) ?? [] {
             if Self.procEventIsCoveredByAttachResult(

--- a/Alas/Sources/SSH/RemoteHelperClient.swift
+++ b/Alas/Sources/SSH/RemoteHelperClient.swift
@@ -17,6 +17,10 @@ private struct ActiveRemoteHelperSearch {
     let continuation: AsyncThrowingStream<RemoteHelperSearchEvent, Error>.Continuation
 }
 
+private struct ActiveRemoteHelperProcAttachment {
+    let continuation: AsyncStream<RemoteHelperProcEvent>.Continuation
+}
+
 enum RemoteHelperClientError: Error, Equatable {
     case notRunning
     case unavailable(String)
@@ -58,6 +62,8 @@ actor RemoteHelperClient {
     private var activeSubscriptions: [String: ActiveRemoteHelperSubscription] = [:]
     private var activeSearches: [String: ActiveRemoteHelperSearch] = [:]
     private var earlySearchEvents: [String: [RemoteHelperSearchEvent]] = [:]
+    private var activeProcAttachments: [String: ActiveRemoteHelperProcAttachment] = [:]
+    private var earlyProcEvents: [String: [RemoteHelperProcEvent]] = [:]
     private var subscriptionReplayTask: Task<Void, Error>?
     private var subscriptionsNeedReplay = false
     private var lastExitStatus: Int32?
@@ -248,6 +254,84 @@ actor RemoteHelperClient {
         )
     }
 
+    func spawnProc(
+        procId: String,
+        command: String,
+        args: [String],
+        cwd: String,
+        env: [String: String]
+    ) async throws -> RemoteHelperProcStatus {
+        try await request(
+            method: "proc/spawn",
+            params: RemoteHelperProcSpawnParams(
+                procId: procId,
+                command: command,
+                args: args,
+                cwd: cwd,
+                env: env
+            )
+        )
+    }
+
+    func attachProc(
+        procId: String,
+        stdoutOffset: UInt64? = nil,
+        stderrOffset: UInt64? = nil
+    ) async throws -> RemoteHelperProcAttachHandle {
+        let result: RemoteHelperProcAttachResult = try await request(
+            method: "proc/attach",
+            params: RemoteHelperProcAttachParams(
+                procId: procId,
+                stdoutOffset: stdoutOffset,
+                stderrOffset: stderrOffset
+            )
+        )
+        var continuation: AsyncStream<RemoteHelperProcEvent>.Continuation!
+        let events = AsyncStream<RemoteHelperProcEvent> { continuation = $0 }
+        activeProcAttachments[procId] = ActiveRemoteHelperProcAttachment(continuation: continuation)
+        continuation.yield(.available)
+        for frame in result.stdoutFrames {
+            if let data = Data(base64Encoded: frame.dataBase64) {
+                continuation.yield(.stdout(data, offset: frame.offset))
+            }
+        }
+        for chunk in result.stderrChunks {
+            if let data = Data(base64Encoded: chunk.dataBase64) {
+                continuation.yield(.stderr(data, offset: chunk.offset))
+            }
+        }
+        for event in earlyProcEvents.removeValue(forKey: procId) ?? [] {
+            continuation.yield(event)
+        }
+        if !result.running {
+            continuation.yield(.exited(result.exitCode))
+        }
+        return RemoteHelperProcAttachHandle(procId: procId, events: events)
+    }
+
+    func writeProc(procId: String, data: Data) async throws {
+        let _: RemoteHelperProcWriteResult = try await request(
+            method: "proc/write",
+            params: RemoteHelperProcWriteParams(
+                procId: procId,
+                dataBase64: data.base64EncodedString()
+            ),
+            replaySubscriptionsOnStart: false
+        )
+    }
+
+    func killProc(procId: String) async throws {
+        let _: RemoteHelperProcKillResult = try await request(
+            method: "proc/kill",
+            params: RemoteHelperProcKillParams(procId: procId),
+            replaySubscriptionsOnStart: false
+        )
+    }
+
+    func listProcs() async throws -> RemoteHelperProcListResult {
+        try await request(method: "proc/list", params: RemoteHelperNoParams())
+    }
+
     func shutdown() {
         idleShutdownTask?.cancel()
         idleShutdownTask = nil
@@ -264,6 +348,12 @@ actor RemoteHelperClient {
         }
         activeSearches.removeAll()
         earlySearchEvents.removeAll()
+        for proc in activeProcAttachments.values {
+            proc.continuation.yield(.unavailable)
+            proc.continuation.finish()
+        }
+        activeProcAttachments.removeAll()
+        earlyProcEvents.removeAll()
         drainPending(with: RemoteHelperClientError.notRunning)
         dispatchTask?.cancel()
         dispatchTask = nil
@@ -494,6 +584,18 @@ actor RemoteHelperClient {
             )
             return
         }
+        if head.method == "proc/output",
+           let env = try? JSONDecoder().decode(JSONRPCEnvelope<RemoteHelperProcOutputParams>.self, from: data),
+           let event = env.params {
+            emitProcOutput(event)
+            return
+        }
+        if head.method == "proc/exit",
+           let env = try? JSONDecoder().decode(JSONRPCEnvelope<RemoteHelperProcExitParams>.self, from: data),
+           let event = env.params {
+            emitProcEvent(.exited(event.exitCode), procId: event.procId)
+            return
+        }
 
         guard head.method == "watch/event",
               let env = try? JSONDecoder().decode(JSONRPCEnvelope<RemoteHelperWatchEvent>.self, from: data),
@@ -531,6 +633,31 @@ actor RemoteHelperClient {
         }
     }
 
+    private func emitProcOutput(_ output: RemoteHelperProcOutputParams) {
+        guard let data = Data(base64Encoded: output.dataBase64) else { return }
+        switch output.stream {
+        case "stdout":
+            emitProcEvent(.stdout(data, offset: output.offset), procId: output.procId)
+        case "stderr":
+            emitProcEvent(.stderr(data, offset: output.offset), procId: output.procId)
+        default:
+            break
+        }
+    }
+
+    private func emitProcEvent(_ event: RemoteHelperProcEvent, procId: String) {
+        guard let attachment = activeProcAttachments[procId] else {
+            earlyProcEvents[procId, default: []].append(event)
+            return
+        }
+        attachment.continuation.yield(event)
+        if case .exited = event {
+            attachment.continuation.finish()
+            activeProcAttachments.removeValue(forKey: procId)
+            scheduleIdleShutdownIfPossible()
+        }
+    }
+
     private func handleExit(_ status: Int32) {
         lastExitStatus = status
         transport = nil
@@ -547,6 +674,11 @@ actor RemoteHelperClient {
         }
         activeSearches.removeAll()
         earlySearchEvents.removeAll()
+        for proc in activeProcAttachments.values {
+            proc.continuation.yield(.unavailable)
+        }
+        activeProcAttachments.removeAll()
+        earlyProcEvents.removeAll()
         if RemoteExec.isConnectionFailure(exitCode: status) {
             Task { @MainActor [host] in
                 RemoteHostStatusStore.shared.reportConnectionFailure(host: host)
@@ -567,6 +699,7 @@ actor RemoteHelperClient {
               pending.isEmpty,
               activeSubscriptions.isEmpty,
               activeSearches.isEmpty,
+              activeProcAttachments.isEmpty,
               transport != nil else { return }
         idleShutdownTask?.cancel()
         let delay = idleShutdownNanoseconds
@@ -577,7 +710,10 @@ actor RemoteHelperClient {
     }
 
     private func shutdownIfIdle() {
-        guard pending.isEmpty, activeSubscriptions.isEmpty, activeSearches.isEmpty else { return }
+        guard pending.isEmpty,
+              activeSubscriptions.isEmpty,
+              activeSearches.isEmpty,
+              activeProcAttachments.isEmpty else { return }
         shutdown()
     }
 

--- a/Alas/Sources/SSH/RemoteHelperProtocol.swift
+++ b/Alas/Sources/SSH/RemoteHelperProtocol.swift
@@ -216,6 +216,7 @@ struct RemoteHelperProcStatus: Codable, Equatable, Sendable {
     let procId: String
     let running: Bool
     let exitCode: Int32?
+    let spawned: Bool?
 }
 
 struct RemoteHelperProcAttachParams: Codable, Equatable, Sendable {

--- a/Alas/Sources/SSH/RemoteHelperProtocol.swift
+++ b/Alas/Sources/SSH/RemoteHelperProtocol.swift
@@ -25,6 +25,7 @@ struct RemoteHelperCapabilities: Codable, Equatable, Sendable {
     let watchKinds: [RemoteHelperWatchKind]
     let fs: RemoteHelperFSCapabilities
     let search: Bool?
+    let proc: Bool?
     let ping: Bool
 }
 
@@ -200,4 +201,85 @@ enum RemoteHelperSearchEvent: Equatable, Sendable {
 struct RemoteHelperSearchHandle: Sendable {
     let searchId: String
     let events: AsyncThrowingStream<RemoteHelperSearchEvent, Error>
+}
+
+struct RemoteHelperProcSpawnParams: Codable, Equatable, Sendable {
+    let procId: String
+    let command: String
+    let args: [String]
+    let cwd: String
+    let env: [String: String]
+}
+
+struct RemoteHelperProcStatus: Codable, Equatable, Sendable {
+    let procId: String
+    let running: Bool
+    let exitCode: Int32?
+}
+
+struct RemoteHelperProcAttachParams: Codable, Equatable, Sendable {
+    let procId: String
+    let stdoutOffset: UInt64?
+    let stderrOffset: UInt64?
+}
+
+struct RemoteHelperProcReplayFrame: Codable, Equatable, Sendable {
+    let offset: UInt64
+    let dataBase64: String
+}
+
+struct RemoteHelperProcAttachResult: Codable, Equatable, Sendable {
+    let procId: String
+    let running: Bool
+    let exitCode: Int32?
+    let stdoutOffset: UInt64
+    let stderrOffset: UInt64
+    let stdoutFrames: [RemoteHelperProcReplayFrame]
+    let stderrChunks: [RemoteHelperProcReplayFrame]
+}
+
+struct RemoteHelperProcWriteParams: Codable, Equatable, Sendable {
+    let procId: String
+    let dataBase64: String
+}
+
+struct RemoteHelperProcWriteResult: Codable, Equatable, Sendable {
+    let ok: Bool
+}
+
+struct RemoteHelperProcKillParams: Codable, Equatable, Sendable {
+    let procId: String
+}
+
+struct RemoteHelperProcKillResult: Codable, Equatable, Sendable {
+    let ok: Bool
+}
+
+struct RemoteHelperProcListResult: Codable, Equatable, Sendable {
+    let entries: [RemoteHelperProcStatus]
+}
+
+struct RemoteHelperProcOutputParams: Codable, Equatable, Sendable {
+    let procId: String
+    let stream: String
+    let offset: UInt64
+    let dataBase64: String
+}
+
+struct RemoteHelperProcExitParams: Codable, Equatable, Sendable {
+    let procId: String
+    let exitCode: Int32?
+}
+
+enum RemoteHelperProcEvent: Equatable, Sendable {
+    case available
+    case unavailable
+    case stdout(Data, offset: UInt64)
+    case stderr(Data, offset: UInt64)
+    case exited(Int32?)
+}
+
+struct RemoteHelperProcAttachHandle: Sendable {
+    let procId: String
+    let events: AsyncStream<RemoteHelperProcEvent>
 }

--- a/Alas/Sources/SSH/RemoteHelperProtocol.swift
+++ b/Alas/Sources/SSH/RemoteHelperProtocol.swift
@@ -232,6 +232,7 @@ struct RemoteHelperProcAttachResult: Codable, Equatable, Sendable {
     let procId: String
     let running: Bool
     let exitCode: Int32?
+    let stdinOffset: UInt64
     let stdoutOffset: UInt64
     let stderrOffset: UInt64
     let stdoutFrames: [RemoteHelperProcReplayFrame]
@@ -283,5 +284,6 @@ enum RemoteHelperProcEvent: Equatable, Sendable {
 
 struct RemoteHelperProcAttachHandle: Sendable {
     let procId: String
+    let stdinOffset: UInt64
     let events: AsyncStream<RemoteHelperProcEvent>
 }

--- a/Alas/Sources/SSH/RemoteHelperProtocol.swift
+++ b/Alas/Sources/SSH/RemoteHelperProtocol.swift
@@ -285,6 +285,9 @@ enum RemoteHelperProcEvent: Equatable, Sendable {
 
 struct RemoteHelperProcAttachHandle: Sendable {
     let procId: String
+    let attachmentId: String
     let stdinOffset: UInt64
+    let stdoutOffset: UInt64
+    let stderrOffset: UInt64
     let events: AsyncStream<RemoteHelperProcEvent>
 }

--- a/Alas/Sources/SSH/RemoteHelperProtocol.swift
+++ b/Alas/Sources/SSH/RemoteHelperProtocol.swift
@@ -209,6 +209,7 @@ struct RemoteHelperProcSpawnParams: Codable, Equatable, Sendable {
     let args: [String]
     let cwd: String
     let env: [String: String]
+    let pathPrefixDirectories: [String]
 }
 
 struct RemoteHelperProcStatus: Codable, Equatable, Sendable {

--- a/Alas/Sources/SSH/RemoteHelperProtocol.swift
+++ b/Alas/Sources/SSH/RemoteHelperProtocol.swift
@@ -241,10 +241,12 @@ struct RemoteHelperProcAttachResult: Codable, Equatable, Sendable {
 struct RemoteHelperProcWriteParams: Codable, Equatable, Sendable {
     let procId: String
     let dataBase64: String
+    let expectedStdinOffset: UInt64?
 }
 
 struct RemoteHelperProcWriteResult: Codable, Equatable, Sendable {
     let ok: Bool
+    let stdinOffset: UInt64
 }
 
 struct RemoteHelperProcKillParams: Codable, Equatable, Sendable {

--- a/AlasHelper/Cargo.lock
+++ b/AlasHelper/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "alas-helper"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "base64",
  "notify",

--- a/AlasHelper/Cargo.toml
+++ b/AlasHelper/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "alas-helper"
-version = "0.4.0"
+version = "0.5.0"
 edition = "2024"
 publish = false
 

--- a/AlasHelper/manifest.json
+++ b/AlasHelper/manifest.json
@@ -1,1 +1,1 @@
-{"name":"alas-helper","protocolVersion":1,"binaryVersion":"0.4.0"}
+{"name":"alas-helper","protocolVersion":1,"binaryVersion":"0.5.0"}

--- a/AlasHelper/src/main.rs
+++ b/AlasHelper/src/main.rs
@@ -868,6 +868,12 @@ fn proc_spawn(state: &mut HelperState, params: Option<Value>) -> Result<Value, H
             "exitCode": null
         }));
     }
+    state
+        .proc_tailers
+        .remove(&format!("{}:stdout", params.proc_id));
+    state
+        .proc_tailers
+        .remove(&format!("{}:stderr", params.proc_id));
 
     let stdin_path = dir.join("stdin.log");
     let stdout_path = dir.join("stdout.log");
@@ -1276,10 +1282,11 @@ fn spawn_proc_stdout_tail(
                 }
                 Err(_) => return,
             }
-            if proc_status_in_dir(&dir).exit_code.is_some() {
+            let status = proc_status_in_dir(&dir);
+            if !status.running {
                 let _ = sender.send(ServerMessage::Proc(ProcNotification::Exit {
                     proc_id,
-                    exit_code: proc_status_in_dir(&dir).exit_code,
+                    exit_code: status.exit_code,
                 }));
                 return;
             }
@@ -1313,7 +1320,7 @@ fn spawn_proc_stderr_tail(
                 Ok(None) => {}
                 Err(_) => return,
             }
-            if proc_status_in_dir(&dir).exit_code.is_some() {
+            if !proc_status_in_dir(&dir).running {
                 return;
             }
             thread::sleep(Duration::from_millis(100));

--- a/AlasHelper/src/main.rs
+++ b/AlasHelper/src/main.rs
@@ -885,11 +885,7 @@ fn spawn_search(
 fn proc_spawn(state: &mut HelperState, params: Option<Value>) -> Result<Value, HelperError> {
     let params: ProcSpawnParams = decode_params(params)?;
     validate_proc_id(&params.proc_id)?;
-    let cwd = std::fs::canonicalize(&params.cwd)
-        .map_err(|error| jsonrpc_error(-32050, format!("invalid cwd: {error}")))?;
-    if !cwd.is_dir() {
-        return Err(jsonrpc_error(-32050, "cwd is not a directory"));
-    }
+    let cwd = validated_proc_cwd(&params.cwd)?;
     let dir = proc_dir(&params.proc_id)?;
     std::fs::create_dir_all(&dir)
         .map_err(|error| jsonrpc_error(-32050, format!("proc dir failed: {error}")))?;
@@ -962,6 +958,16 @@ fn proc_spawn(state: &mut HelperState, params: Option<Value>) -> Result<Value, H
         "exitCode": status.exit_code,
         "spawned": true
     }))
+}
+
+fn validated_proc_cwd(requested_cwd: &str) -> Result<PathBuf, HelperError> {
+    let cwd = PathBuf::from(requested_cwd);
+    let metadata = std::fs::metadata(&cwd)
+        .map_err(|error| jsonrpc_error(-32050, format!("invalid cwd: {error}")))?;
+    if !metadata.is_dir() {
+        return Err(jsonrpc_error(-32050, "cwd is not a directory"));
+    }
+    Ok(cwd)
 }
 
 fn spawn_proc_supervisor(dir: &Path) -> Result<(), HelperError> {
@@ -2078,6 +2084,31 @@ mod tests {
             !input_log_already_contains(&mut file, 20, b"later\n").expect("contains beyond eof")
         );
 
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn proc_cwd_validation_preserves_symlink_path() {
+        use std::os::unix::fs::symlink;
+
+        let root = std::env::temp_dir().join(format!(
+            "alas-helper-proc-cwd-{}-{}",
+            std::process::id(),
+            SystemTime::now()
+                .duration_since(SystemTime::UNIX_EPOCH)
+                .expect("time after epoch")
+                .as_nanos()
+        ));
+        let target = root.join("target");
+        let link = root.join("link");
+        std::fs::create_dir_all(&target).expect("target cwd");
+        symlink(&target, &link).expect("cwd symlink");
+
+        let validated = validated_proc_cwd(link.to_str().expect("utf8 path"))
+            .expect("symlink cwd should be valid");
+
+        assert_eq!(validated, link);
         let _ = std::fs::remove_dir_all(root);
     }
 

--- a/AlasHelper/src/main.rs
+++ b/AlasHelper/src/main.rs
@@ -150,6 +150,15 @@ struct ProcMetadata {
     cwd: String,
 }
 
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct ProcSupervisorLaunch {
+    command: String,
+    args: Vec<String>,
+    cwd: String,
+    env: HashMap<String, String>,
+}
+
 #[derive(Debug)]
 struct ProcReplayFrame {
     offset: u64,
@@ -219,7 +228,9 @@ fn capabilities() -> Value {
 }
 
 fn main() {
-    let command = std::env::args().nth(1);
+    let mut args = std::env::args();
+    let _program = args.next();
+    let command = args.next();
     match command.as_deref() {
         None | Some("version") => {
             println!(
@@ -230,6 +241,16 @@ fn main() {
         Some("serve") => {
             if let Err(error) = serve() {
                 eprintln!("alas-helper: {error}");
+                std::process::exit(1);
+            }
+        }
+        Some("proc-supervise") => {
+            let Some(dir) = args.next() else {
+                eprintln!("usage: alas-helper proc-supervise <proc-dir>");
+                std::process::exit(2);
+            };
+            if let Err(error) = proc_supervise(PathBuf::from(dir)) {
+                eprintln!("alas-helper proc-supervise: {}", error.message);
                 std::process::exit(1);
             }
         }
@@ -881,12 +902,10 @@ fn proc_spawn(state: &mut HelperState, params: Option<Value>) -> Result<Value, H
     let exit_path = dir.join("exit");
     let pid_path = dir.join("pid");
     let _ = std::fs::remove_file(&exit_path);
-    std::fs::File::create(&stdin_path)
-        .map_err(|error| jsonrpc_error(-32050, format!("stdin create failed: {error}")))?;
-    std::fs::File::create(&stdout_path)
-        .map_err(|error| jsonrpc_error(-32050, format!("stdout create failed: {error}")))?;
-    std::fs::File::create(&stderr_path)
-        .map_err(|error| jsonrpc_error(-32050, format!("stderr create failed: {error}")))?;
+    let _ = std::fs::remove_file(&pid_path);
+    create_restrictive_empty_file(&stdin_path, "stdin")?;
+    create_restrictive_empty_file(&stdout_path, "stdout")?;
+    create_restrictive_empty_file(&stderr_path, "stderr")?;
     let metadata = ProcMetadata {
         proc_id: params.proc_id.clone(),
         command: params.command.clone(),
@@ -899,40 +918,80 @@ fn proc_spawn(state: &mut HelperState, params: Option<Value>) -> Result<Value, H
     )
     .map_err(|error| jsonrpc_error(-32050, format!("metadata write failed: {error}")))?;
 
-    let mut env_parts: Vec<String> = vec!["env".to_string()];
-    env_parts.extend(
-        ACP_REMOTE_MARKER_SCRUB
-            .iter()
-            .flat_map(|key| ["-u".to_string(), (*key).to_string()]),
-    );
-    let mut env_keys: Vec<_> = params.env.keys().collect();
-    env_keys.sort();
-    for key in env_keys {
+    for key in params.env.keys() {
         if !is_safe_env_key(key) {
             return Err(jsonrpc_error(-32602, format!("invalid env key: {key}")));
         }
-        let value = params.env.get(key).expect("key from map");
-        env_parts.push(format!("{}={}", key, shell_quote(value)));
     }
-    let argv = std::iter::once(params.command.as_str())
-        .chain(params.args.iter().map(String::as_str))
-        .map(shell_quote)
-        .collect::<Vec<_>>()
-        .join(" ");
-    let env_command = env_parts.join(" ");
-    let script = format!(
-        "cd {cwd} && exec {env_command} {argv}",
-        cwd = shell_quote(cwd.to_string_lossy().as_ref()),
-        env_command = env_command,
-        argv = argv,
-    );
+    let launch = ProcSupervisorLaunch {
+        command: params.command,
+        args: params.args,
+        cwd: cwd.display().to_string(),
+        env: params.env,
+    };
+    write_restrictive_bytes(
+        &dir.join("launch.json"),
+        &serde_json::to_vec(&launch).expect("launch serialization must succeed"),
+        "launch",
+    )?;
+    spawn_proc_supervisor(&dir)?;
+    state
+        .subscriptions
+        .insert(format!("proc:{}", params.proc_id), cwd);
+    let status = proc_status_in_dir(&dir);
+    Ok(json!({
+        "procId": params.proc_id,
+        "running": status.running,
+        "exitCode": status.exit_code
+    }))
+}
+
+fn spawn_proc_supervisor(dir: &Path) -> Result<(), HelperError> {
+    let exe = std::env::current_exe()
+        .map_err(|error| jsonrpc_error(-32050, format!("helper path failed: {error}")))?;
+    let mut command = Command::new(exe);
+    command
+        .arg("proc-supervise")
+        .arg(dir)
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null());
+    #[cfg(unix)]
+    {
+        use std::os::unix::process::CommandExt;
+        command.process_group(0);
+    }
+    command
+        .spawn()
+        .map_err(|error| jsonrpc_error(-32050, format!("supervisor spawn failed: {error}")))?;
+
+    let deadline = Instant::now() + Duration::from_secs(2);
+    while Instant::now() < deadline {
+        if dir.join("pid").is_file() || dir.join("exit").is_file() {
+            return Ok(());
+        }
+        thread::sleep(Duration::from_millis(20));
+    }
+    Err(jsonrpc_error(-32050, "supervisor did not start process"))
+}
+
+fn proc_supervise(dir: PathBuf) -> Result<(), HelperError> {
+    let launch_path = dir.join("launch.json");
+    let launch: ProcSupervisorLaunch = serde_json::from_slice(
+        &std::fs::read(&launch_path)
+            .map_err(|error| jsonrpc_error(-32050, format!("launch read failed: {error}")))?,
+    )
+    .map_err(|error| jsonrpc_error(-32050, format!("launch decode failed: {error}")))?;
+    let _ = std::fs::remove_file(&launch_path);
+
+    let script = proc_launch_script(&launch.cwd, &launch.command, &launch.args, &launch.env)?;
     let stdout_file = std::fs::OpenOptions::new()
         .append(true)
-        .open(&stdout_path)
+        .open(dir.join("stdout.log"))
         .map_err(|error| jsonrpc_error(-32050, format!("stdout open failed: {error}")))?;
     let stderr_file = std::fs::OpenOptions::new()
         .append(true)
-        .open(&stderr_path)
+        .open(dir.join("stderr.log"))
         .map_err(|error| jsonrpc_error(-32050, format!("stderr open failed: {error}")))?;
     let mut command = Command::new("/bin/sh");
     command
@@ -950,19 +1009,90 @@ fn proc_spawn(state: &mut HelperState, params: Option<Value>) -> Result<Value, H
         .spawn()
         .map_err(|error| jsonrpc_error(-32050, format!("spawn failed: {error}")))?;
     let child_stdin = child.stdin.take();
-    std::fs::write(&pid_path, format!("{}\n", child.id()))
+    std::fs::write(dir.join("pid"), format!("{}\n", child.id()))
         .map_err(|error| jsonrpc_error(-32050, format!("pid write failed: {error}")))?;
-    thread::spawn(move || {
-        pump_proc_stdin_and_record_exit(child, child_stdin, stdin_path, exit_path);
-    });
-    state
-        .subscriptions
-        .insert(format!("proc:{}", params.proc_id), cwd);
-    Ok(json!({
-        "procId": params.proc_id,
-        "running": true,
-        "exitCode": null
-    }))
+    pump_proc_stdin_and_record_exit(child, child_stdin, dir.join("stdin.log"), dir.join("exit"));
+    Ok(())
+}
+
+fn proc_launch_script(
+    cwd: &str,
+    command: &str,
+    args: &[String],
+    env: &HashMap<String, String>,
+) -> Result<String, HelperError> {
+    let mut env_parts: Vec<String> = vec!["env".to_string()];
+    env_parts.extend(
+        ACP_REMOTE_MARKER_SCRUB
+            .iter()
+            .flat_map(|key| ["-u".to_string(), (*key).to_string()]),
+    );
+    let mut env_keys: Vec<_> = env.keys().collect();
+    env_keys.sort();
+    for key in env_keys {
+        if !is_safe_env_key(key) {
+            return Err(jsonrpc_error(-32602, format!("invalid env key: {key}")));
+        }
+        let value = env.get(key).expect("key from map");
+        env_parts.push(format!("{}={}", key, shell_quote(value)));
+    }
+    let argv = std::iter::once(command)
+        .chain(args.iter().map(String::as_str))
+        .map(shell_quote)
+        .collect::<Vec<_>>()
+        .join(" ");
+    Ok(format!(
+        "cd {cwd} && exec {env_command} {argv}",
+        cwd = shell_quote(cwd),
+        env_command = env_parts.join(" "),
+        argv = argv,
+    ))
+}
+
+fn create_restrictive_empty_file(path: &Path, label: &str) -> Result<(), HelperError> {
+    let mut options = std::fs::OpenOptions::new();
+    options.write(true).create(true).truncate(true);
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::OpenOptionsExt;
+        options.mode(0o600);
+    }
+    let file = options
+        .open(path)
+        .map_err(|error| jsonrpc_error(-32050, format!("{label} create failed: {error}")))?;
+    drop(file);
+    set_restrictive_file_permissions(path, label)
+}
+
+fn write_restrictive_bytes(path: &Path, bytes: &[u8], label: &str) -> Result<(), HelperError> {
+    let mut options = std::fs::OpenOptions::new();
+    options.write(true).create(true).truncate(true);
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::OpenOptionsExt;
+        options.mode(0o600);
+    }
+    let mut file = options
+        .open(path)
+        .map_err(|error| jsonrpc_error(-32050, format!("{label} create failed: {error}")))?;
+    file.write_all(bytes)
+        .map_err(|error| jsonrpc_error(-32050, format!("{label} write failed: {error}")))?;
+    file.flush()
+        .map_err(|error| jsonrpc_error(-32050, format!("{label} flush failed: {error}")))?;
+    drop(file);
+    set_restrictive_file_permissions(path, label)
+}
+
+#[cfg(unix)]
+fn set_restrictive_file_permissions(path: &Path, label: &str) -> Result<(), HelperError> {
+    use std::os::unix::fs::PermissionsExt;
+    std::fs::set_permissions(path, std::fs::Permissions::from_mode(0o600))
+        .map_err(|error| jsonrpc_error(-32050, format!("{label} chmod failed: {error}")))
+}
+
+#[cfg(not(unix))]
+fn set_restrictive_file_permissions(_path: &Path, _label: &str) -> Result<(), HelperError> {
+    Ok(())
 }
 
 fn proc_attach(state: &mut HelperState, params: Option<Value>) -> Result<Value, HelperError> {
@@ -2248,6 +2378,58 @@ mod tests {
 
         let mode = std::fs::metadata(&temp)
             .expect("temp metadata")
+            .permissions()
+            .mode();
+        assert_eq!(mode & 0o777, 0o600);
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn proc_log_creation_forces_restrictive_permissions() {
+        use std::os::unix::fs::{OpenOptionsExt, PermissionsExt};
+
+        let root = std::env::temp_dir().join(format!(
+            "alas-helper-proc-log-mode-{}-{}",
+            std::process::id(),
+            system_time_seconds(SystemTime::now()).unwrap()
+        ));
+        std::fs::create_dir_all(&root).expect("root");
+        let path = root.join("stdin.log");
+        let file = std::fs::OpenOptions::new()
+            .write(true)
+            .create_new(true)
+            .mode(0o666)
+            .open(&path)
+            .expect("permissive input log");
+        drop(file);
+
+        create_restrictive_empty_file(&path, "stdin").expect("restrictive log");
+
+        let metadata = std::fs::metadata(&path).expect("log metadata");
+        assert_eq!(metadata.permissions().mode() & 0o777, 0o600);
+        assert_eq!(metadata.len(), 0);
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn proc_launch_file_uses_restrictive_permissions() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let root = std::env::temp_dir().join(format!(
+            "alas-helper-proc-launch-mode-{}-{}",
+            std::process::id(),
+            system_time_seconds(SystemTime::now()).unwrap()
+        ));
+        std::fs::create_dir_all(&root).expect("root");
+        let path = root.join("launch.json");
+
+        write_restrictive_bytes(&path, br#"{"env":{"TOKEN":"secret"}}"#, "launch")
+            .expect("launch write");
+
+        let mode = std::fs::metadata(&path)
+            .expect("launch metadata")
             .permissions()
             .mode();
         assert_eq!(mode & 0o777, 0o600);

--- a/AlasHelper/src/main.rs
+++ b/AlasHelper/src/main.rs
@@ -893,6 +893,9 @@ fn proc_spawn(state: &mut HelperState, params: Option<Value>) -> Result<Value, H
     }
     state
         .proc_tailers
+        .remove(&proc_tailer_key(&params.proc_id, "io"));
+    state
+        .proc_tailers
         .remove(&proc_tailer_key(&params.proc_id, "stdout"));
     state
         .proc_tailers
@@ -914,11 +917,11 @@ fn proc_spawn(state: &mut HelperState, params: Option<Value>) -> Result<Value, H
         args: params.args.clone(),
         cwd: cwd.display().to_string(),
     };
-    std::fs::write(
-        dir.join("meta.json"),
-        serde_json::to_vec(&metadata).expect("metadata serialization must succeed"),
-    )
-    .map_err(|error| jsonrpc_error(-32050, format!("metadata write failed: {error}")))?;
+    write_restrictive_bytes(
+        &dir.join("meta.json"),
+        &serde_json::to_vec(&metadata).expect("metadata serialization must succeed"),
+        "metadata",
+    )?;
 
     for key in params.env.keys() {
         if !is_safe_env_key(key) {
@@ -1003,12 +1006,8 @@ fn proc_supervise(dir: PathBuf) -> Result<(), HelperError> {
         .open(dir.join("stderr.log"))
         .map_err(|error| jsonrpc_error(-32050, format!("stderr open failed: {error}")))?;
     let mut command = Command::new("/bin/sh");
-    command
-        .arg("-c")
-        .arg(script)
-        .stdin(Stdio::piped())
-        .stdout(Stdio::from(stdout_file))
-        .stderr(Stdio::from(stderr_file));
+    command.arg("-c").arg(script);
+    configure_proc_child_stdio(&mut command, stdout_file, stderr_file);
     #[cfg(unix)]
     {
         use std::os::unix::process::CommandExt;
@@ -1021,6 +1020,17 @@ fn proc_supervise(dir: PathBuf) -> Result<(), HelperError> {
         .map_err(|error| jsonrpc_error(-32050, format!("pid write failed: {error}")))?;
     run_supervised_proc_child(child, dir.join("stdin.log"), dir.join("exit"));
     Ok(())
+}
+
+fn configure_proc_child_stdio(
+    command: &mut Command,
+    stdout_file: std::fs::File,
+    stderr_file: std::fs::File,
+) {
+    command
+        .stdin(Stdio::piped())
+        .stdout(Stdio::from(stdout_file))
+        .stderr(Stdio::from(stderr_file));
 }
 
 fn run_supervised_proc_child(
@@ -1189,24 +1199,11 @@ fn ensure_proc_tailers(
     stderr_offset: u64,
     sender: Sender<ServerMessage>,
 ) {
-    if state
-        .proc_tailers
-        .insert(proc_tailer_key(proc_id, "stdout"))
-    {
-        spawn_proc_stdout_tail(
+    if state.proc_tailers.insert(proc_tailer_key(proc_id, "io")) {
+        spawn_proc_tail(
             proc_id.to_string(),
             dir.to_path_buf(),
             stdout_offset,
-            sender.clone(),
-        );
-    }
-    if state
-        .proc_tailers
-        .insert(proc_tailer_key(proc_id, "stderr"))
-    {
-        spawn_proc_stderr_tail(
-            proc_id.to_string(),
-            dir.to_path_buf(),
             stderr_offset,
             sender,
         );
@@ -1432,35 +1429,35 @@ fn read_file_tail(path: &Path, offset: u64) -> Result<Option<(u64, Vec<u8>)>, He
     }
 }
 
-fn spawn_proc_stdout_tail(
+fn spawn_proc_tail(
     proc_id: String,
     dir: PathBuf,
-    mut offset: u64,
+    mut stdout_offset: u64,
+    mut stderr_offset: u64,
     sender: Sender<ServerMessage>,
 ) {
     thread::spawn(move || {
         loop {
-            match read_stdout_frames(&dir.join("stdout.log"), offset) {
-                Ok(frames) if frames.is_empty() => {}
-                Ok(frames) => {
-                    for frame in frames {
-                        offset = frame.offset;
-                        if sender
-                            .send(ServerMessage::Proc(ProcNotification::Stdout {
-                                proc_id: proc_id.clone(),
-                                offset,
-                                data: frame.data,
-                            }))
-                            .is_err()
-                        {
-                            return;
-                        }
-                    }
-                }
-                Err(_) => return,
+            if drain_proc_output_once(
+                &proc_id,
+                &dir,
+                &sender,
+                &mut stdout_offset,
+                &mut stderr_offset,
+            )
+            .is_err()
+            {
+                return;
             }
             let status = proc_status_in_dir(&dir);
             if !status.running {
+                let _ = drain_proc_output_once(
+                    &proc_id,
+                    &dir,
+                    &sender,
+                    &mut stdout_offset,
+                    &mut stderr_offset,
+                );
                 let _ = sender.send(ServerMessage::Proc(ProcNotification::Exit {
                     proc_id,
                     exit_code: status.exit_code,
@@ -1472,41 +1469,47 @@ fn spawn_proc_stdout_tail(
     });
 }
 
-fn proc_tailer_key(proc_id: &str, stream: &str) -> String {
-    format!("{proc_id}:{stream}")
+fn drain_proc_output_once(
+    proc_id: &str,
+    dir: &Path,
+    sender: &Sender<ServerMessage>,
+    stdout_offset: &mut u64,
+    stderr_offset: &mut u64,
+) -> Result<(), ()> {
+    match read_stdout_frames(&dir.join("stdout.log"), *stdout_offset) {
+        Ok(frames) => {
+            for frame in frames {
+                *stdout_offset = frame.offset;
+                sender
+                    .send(ServerMessage::Proc(ProcNotification::Stdout {
+                        proc_id: proc_id.to_string(),
+                        offset: *stdout_offset,
+                        data: frame.data,
+                    }))
+                    .map_err(|_| ())?;
+            }
+        }
+        Err(_) => return Err(()),
+    }
+    match read_file_tail(&dir.join("stderr.log"), *stderr_offset) {
+        Ok(Some((next_offset, data))) => {
+            *stderr_offset = next_offset;
+            sender
+                .send(ServerMessage::Proc(ProcNotification::Stderr {
+                    proc_id: proc_id.to_string(),
+                    offset: *stderr_offset,
+                    data,
+                }))
+                .map_err(|_| ())?;
+        }
+        Ok(None) => {}
+        Err(_) => return Err(()),
+    }
+    Ok(())
 }
 
-fn spawn_proc_stderr_tail(
-    proc_id: String,
-    dir: PathBuf,
-    mut offset: u64,
-    sender: Sender<ServerMessage>,
-) {
-    thread::spawn(move || {
-        loop {
-            match read_file_tail(&dir.join("stderr.log"), offset) {
-                Ok(Some((next_offset, data))) => {
-                    offset = next_offset;
-                    if sender
-                        .send(ServerMessage::Proc(ProcNotification::Stderr {
-                            proc_id: proc_id.clone(),
-                            offset,
-                            data,
-                        }))
-                        .is_err()
-                    {
-                        return;
-                    }
-                }
-                Ok(None) => {}
-                Err(_) => return,
-            }
-            if !proc_status_in_dir(&dir).running {
-                return;
-            }
-            thread::sleep(Duration::from_millis(100));
-        }
-    });
+fn proc_tailer_key(proc_id: &str, stream: &str) -> String {
+    format!("{proc_id}:{stream}")
 }
 
 const ACP_REMOTE_MARKER_SCRUB: &[&str] = &[
@@ -2459,6 +2462,40 @@ mod tests {
 
         let mode = std::fs::metadata(&path)
             .expect("launch metadata")
+            .permissions()
+            .mode();
+        assert_eq!(mode & 0o777, 0o600);
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn proc_metadata_file_uses_restrictive_permissions() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let root = std::env::temp_dir().join(format!(
+            "alas-helper-proc-meta-mode-{}-{}",
+            std::process::id(),
+            system_time_seconds(SystemTime::now()).unwrap()
+        ));
+        std::fs::create_dir_all(&root).expect("root");
+        let path = root.join("meta.json");
+
+        let metadata = ProcMetadata {
+            proc_id: "acp-session-1".to_string(),
+            command: "codex-acp".to_string(),
+            args: vec!["--stdio".to_string()],
+            cwd: "/private/repo".to_string(),
+        };
+        write_restrictive_bytes(
+            &path,
+            &serde_json::to_vec(&metadata).expect("metadata"),
+            "metadata",
+        )
+        .expect("metadata write");
+
+        let mode = std::fs::metadata(&path)
+            .expect("metadata file")
             .permissions()
             .mode();
         assert_eq!(mode & 0o777, 0o600);

--- a/AlasHelper/src/main.rs
+++ b/AlasHelper/src/main.rs
@@ -1154,7 +1154,7 @@ fn proc_attach(state: &mut HelperState, params: Option<Value>) -> Result<Value, 
         return Err(jsonrpc_error(-32051, "process not found"));
     }
     let stdout_offset = requested_log_offset(&dir.join("stdout.log"), params.stdout_offset);
-    let stderr_offset = params.stderr_offset.unwrap_or(0);
+    let stderr_offset = requested_log_offset(&dir.join("stderr.log"), params.stderr_offset);
     let stdout_frames = read_stdout_frames(&dir.join("stdout.log"), stdout_offset)?;
     let stderr_chunk = read_file_tail(&dir.join("stderr.log"), stderr_offset)?;
     let stdin_offset = std::fs::metadata(dir.join("stdin.log"))

--- a/AlasHelper/src/main.rs
+++ b/AlasHelper/src/main.rs
@@ -990,28 +990,14 @@ fn proc_attach(state: &mut HelperState, params: Option<Value>) -> Result<Value, 
     let status = proc_status_in_dir(&dir);
     if status.running {
         if let Some(sender) = state.event_sender.clone() {
-            if state
-                .proc_tailers
-                .insert(proc_tailer_key(&params.proc_id, "stdout"))
-            {
-                spawn_proc_stdout_tail(
-                    params.proc_id.clone(),
-                    dir.clone(),
-                    stdout_next_offset,
-                    sender.clone(),
-                );
-            }
-            if state
-                .proc_tailers
-                .insert(proc_tailer_key(&params.proc_id, "stderr"))
-            {
-                spawn_proc_stderr_tail(
-                    params.proc_id.clone(),
-                    dir.clone(),
-                    stderr_next_offset,
-                    sender,
-                );
-            }
+            ensure_proc_tailers(
+                state,
+                &params.proc_id,
+                &dir,
+                stdout_next_offset,
+                stderr_next_offset,
+                sender,
+            );
         }
     }
     Ok(json!({
@@ -1034,6 +1020,38 @@ fn proc_attach(state: &mut HelperState, params: Option<Value>) -> Result<Value, 
             })
         }).collect::<Vec<_>>()
     }))
+}
+
+fn ensure_proc_tailers(
+    state: &mut HelperState,
+    proc_id: &str,
+    dir: &Path,
+    stdout_offset: u64,
+    stderr_offset: u64,
+    sender: Sender<ServerMessage>,
+) {
+    if state
+        .proc_tailers
+        .insert(proc_tailer_key(proc_id, "stdout"))
+    {
+        spawn_proc_stdout_tail(
+            proc_id.to_string(),
+            dir.to_path_buf(),
+            stdout_offset,
+            sender.clone(),
+        );
+    }
+    if state
+        .proc_tailers
+        .insert(proc_tailer_key(proc_id, "stderr"))
+    {
+        spawn_proc_stderr_tail(
+            proc_id.to_string(),
+            dir.to_path_buf(),
+            stderr_offset,
+            sender,
+        );
+    }
 }
 
 fn proc_write(params: Option<Value>) -> Result<Value, HelperError> {

--- a/AlasHelper/src/main.rs
+++ b/AlasHelper/src/main.rs
@@ -870,10 +870,10 @@ fn proc_spawn(state: &mut HelperState, params: Option<Value>) -> Result<Value, H
     }
     state
         .proc_tailers
-        .remove(&format!("{}:stdout", params.proc_id));
+        .remove(&proc_tailer_key(&params.proc_id, "stdout"));
     state
         .proc_tailers
-        .remove(&format!("{}:stderr", params.proc_id));
+        .remove(&proc_tailer_key(&params.proc_id, "stderr"));
 
     let stdin_path = dir.join("stdin.log");
     let stdout_path = dir.join("stdout.log");
@@ -992,7 +992,7 @@ fn proc_attach(state: &mut HelperState, params: Option<Value>) -> Result<Value, 
         if let Some(sender) = state.event_sender.clone() {
             if state
                 .proc_tailers
-                .insert(format!("{}:stdout", params.proc_id))
+                .insert(proc_tailer_key(&params.proc_id, "stdout"))
             {
                 spawn_proc_stdout_tail(
                     params.proc_id.clone(),
@@ -1003,7 +1003,7 @@ fn proc_attach(state: &mut HelperState, params: Option<Value>) -> Result<Value, 
             }
             if state
                 .proc_tailers
-                .insert(format!("{}:stderr", params.proc_id))
+                .insert(proc_tailer_key(&params.proc_id, "stderr"))
             {
                 spawn_proc_stderr_tail(
                     params.proc_id.clone(),
@@ -1293,6 +1293,10 @@ fn spawn_proc_stdout_tail(
             thread::sleep(Duration::from_millis(50));
         }
     });
+}
+
+fn proc_tailer_key(proc_id: &str, stream: &str) -> String {
+    format!("{proc_id}:{stream}")
 }
 
 fn spawn_proc_stderr_tail(

--- a/AlasHelper/src/main.rs
+++ b/AlasHelper/src/main.rs
@@ -4,7 +4,7 @@ use base64::Engine;
 use serde::{Deserialize, Serialize};
 use serde_json::{Value, json};
 use std::collections::{HashMap, HashSet};
-use std::io::{self, BufRead, BufReader, Read, Write};
+use std::io::{self, BufRead, BufReader, Read, Seek, SeekFrom, Write};
 use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
 use std::sync::Arc;
@@ -131,6 +131,7 @@ struct ProcAttachParams {
 struct ProcWriteParams {
     proc_id: String,
     data_base64: String,
+    expected_stdin_offset: Option<u64>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -913,22 +914,26 @@ fn proc_spawn(state: &mut HelperState, params: Option<Value>) -> Result<Value, H
         .join(" ");
     let env_command = env_parts.join(" ");
     let script = format!(
-        "cd {cwd} && tail -n +1 -f {stdin} | {env_command} {argv} > {stdout} 2> {stderr}; status=$?; printf '%s\\n' \"$status\" > {exit}",
+        "cd {cwd} && exec {env_command} {argv}",
         cwd = shell_quote(cwd.to_string_lossy().as_ref()),
-        stdin = shell_quote(stdin_path.to_string_lossy().as_ref()),
-        stdout = shell_quote(stdout_path.to_string_lossy().as_ref()),
-        stderr = shell_quote(stderr_path.to_string_lossy().as_ref()),
-        exit = shell_quote(exit_path.to_string_lossy().as_ref()),
         env_command = env_command,
         argv = argv,
     );
+    let stdout_file = std::fs::OpenOptions::new()
+        .append(true)
+        .open(&stdout_path)
+        .map_err(|error| jsonrpc_error(-32050, format!("stdout open failed: {error}")))?;
+    let stderr_file = std::fs::OpenOptions::new()
+        .append(true)
+        .open(&stderr_path)
+        .map_err(|error| jsonrpc_error(-32050, format!("stderr open failed: {error}")))?;
     let mut command = Command::new("/bin/sh");
     command
         .arg("-c")
         .arg(script)
-        .stdin(Stdio::null())
-        .stdout(Stdio::null())
-        .stderr(Stdio::null());
+        .stdin(Stdio::piped())
+        .stdout(Stdio::from(stdout_file))
+        .stderr(Stdio::from(stderr_file));
     #[cfg(unix)]
     {
         use std::os::unix::process::CommandExt;
@@ -937,10 +942,11 @@ fn proc_spawn(state: &mut HelperState, params: Option<Value>) -> Result<Value, H
     let mut child = command
         .spawn()
         .map_err(|error| jsonrpc_error(-32050, format!("spawn failed: {error}")))?;
+    let child_stdin = child.stdin.take();
     std::fs::write(&pid_path, format!("{}\n", child.id()))
         .map_err(|error| jsonrpc_error(-32050, format!("pid write failed: {error}")))?;
     thread::spawn(move || {
-        let _ = child.wait();
+        pump_proc_stdin_and_record_exit(child, child_stdin, stdin_path, exit_path);
     });
     state
         .subscriptions
@@ -1019,15 +1025,108 @@ fn proc_write(params: Option<Value>) -> Result<Value, HelperError> {
     let bytes = base64::engine::general_purpose::STANDARD
         .decode(params.data_base64.as_bytes())
         .map_err(|error| jsonrpc_error(-32602, format!("invalid base64: {error}")))?;
+    let stdin_path = dir.join("stdin.log");
     let mut file = std::fs::OpenOptions::new()
+        .read(true)
         .append(true)
-        .open(dir.join("stdin.log"))
+        .open(&stdin_path)
         .map_err(|error| jsonrpc_error(-32052, format!("stdin open failed: {error}")))?;
+    let current_offset = file
+        .metadata()
+        .map_err(|error| jsonrpc_error(-32052, format!("stdin metadata failed: {error}")))?
+        .len();
+    if let Some(expected_offset) = params.expected_stdin_offset {
+        if current_offset != expected_offset {
+            if input_log_already_contains(&mut file, expected_offset, &bytes)? {
+                return Ok(
+                    json!({ "ok": true, "stdinOffset": expected_offset + bytes.len() as u64 }),
+                );
+            }
+            return Err(jsonrpc_error(
+                -32053,
+                format!(
+                    "stdin offset mismatch: expected {expected_offset}, found {current_offset}"
+                ),
+            ));
+        }
+    }
     file.write_all(&bytes)
         .map_err(|error| jsonrpc_error(-32052, format!("stdin write failed: {error}")))?;
     file.flush()
         .map_err(|error| jsonrpc_error(-32052, format!("stdin flush failed: {error}")))?;
-    Ok(json!({ "ok": true }))
+    Ok(json!({ "ok": true, "stdinOffset": current_offset + bytes.len() as u64 }))
+}
+
+fn pump_proc_stdin_and_record_exit(
+    mut child: std::process::Child,
+    mut child_stdin: Option<std::process::ChildStdin>,
+    stdin_path: PathBuf,
+    exit_path: PathBuf,
+) {
+    let mut stdin_offset = 0_u64;
+    let mut buffer = [0_u8; 8192];
+    loop {
+        if let Some(stdin) = child_stdin.as_mut() {
+            if pump_proc_stdin_once(&stdin_path, &mut stdin_offset, stdin, &mut buffer).is_err() {
+                child_stdin = None;
+            }
+        }
+        match child.try_wait() {
+            Ok(Some(status)) => {
+                drop(child_stdin.take());
+                let code = status.code().unwrap_or(2);
+                let _ = std::fs::write(&exit_path, format!("{code}\n"));
+                break;
+            }
+            Ok(None) => thread::sleep(Duration::from_millis(20)),
+            Err(_) => {
+                drop(child_stdin.take());
+                let _ = child.kill();
+                let _ = std::fs::write(&exit_path, "2\n");
+                break;
+            }
+        }
+    }
+}
+
+fn pump_proc_stdin_once(
+    path: &Path,
+    offset: &mut u64,
+    stdin: &mut std::process::ChildStdin,
+    buffer: &mut [u8],
+) -> io::Result<()> {
+    let mut file = std::fs::File::open(path)?;
+    file.seek(SeekFrom::Start(*offset))?;
+    loop {
+        let read = file.read(buffer)?;
+        if read == 0 {
+            break;
+        }
+        stdin.write_all(&buffer[..read])?;
+        *offset += read as u64;
+    }
+    stdin.flush()
+}
+
+fn input_log_already_contains(
+    file: &mut std::fs::File,
+    offset: u64,
+    bytes: &[u8],
+) -> Result<bool, HelperError> {
+    let end = offset + bytes.len() as u64;
+    let len = file
+        .metadata()
+        .map_err(|error| jsonrpc_error(-32052, format!("stdin metadata failed: {error}")))?
+        .len();
+    if len < end {
+        return Ok(false);
+    }
+    file.seek(SeekFrom::Start(offset))
+        .map_err(|error| jsonrpc_error(-32052, format!("stdin seek failed: {error}")))?;
+    let mut existing = vec![0_u8; bytes.len()];
+    file.read_exact(&mut existing)
+        .map_err(|error| jsonrpc_error(-32052, format!("stdin read failed: {error}")))?;
+    Ok(existing == bytes)
 }
 
 fn proc_kill(params: Option<Value>) -> Result<Value, HelperError> {
@@ -1564,6 +1663,31 @@ mod tests {
             )
             .is_none()
         );
+    }
+
+    #[test]
+    fn input_log_already_contains_detects_idempotent_retry() {
+        let root = std::env::temp_dir().join(format!(
+            "alas-helper-proc-input-{}-{}",
+            std::process::id(),
+            system_time_seconds(SystemTime::now()).unwrap()
+        ));
+        std::fs::create_dir_all(&root).expect("root");
+        let path = root.join("stdin.log");
+        std::fs::write(&path, b"first\nsecond\n").expect("input log");
+        let mut file = std::fs::OpenOptions::new()
+            .read(true)
+            .append(true)
+            .open(&path)
+            .expect("open input log");
+
+        assert!(input_log_already_contains(&mut file, 6, b"second\n").expect("contains check"));
+        assert!(!input_log_already_contains(&mut file, 6, b"other\n").expect("contains mismatch"));
+        assert!(
+            !input_log_already_contains(&mut file, 20, b"later\n").expect("contains beyond eof")
+        );
+
+        let _ = std::fs::remove_dir_all(root);
     }
 
     #[test]

--- a/AlasHelper/src/main.rs
+++ b/AlasHelper/src/main.rs
@@ -891,6 +891,7 @@ fn proc_spawn(state: &mut HelperState, params: Option<Value>) -> Result<Value, H
         .map_err(|error| jsonrpc_error(-32050, format!("proc dir failed: {error}")))?;
     let status = proc_status_in_dir(&dir);
     if status.running {
+        register_proc_cwd(state, &params.proc_id, cwd);
         return Ok(json!({
             "procId": params.proc_id,
             "running": true,
@@ -948,9 +949,7 @@ fn proc_spawn(state: &mut HelperState, params: Option<Value>) -> Result<Value, H
         "launch",
     )?;
     spawn_proc_supervisor(&dir)?;
-    state
-        .subscriptions
-        .insert(format!("proc:{}", params.proc_id), cwd);
+    register_proc_cwd(state, &params.proc_id, cwd);
     let status = proc_status_in_dir(&dir);
     Ok(json!({
         "procId": params.proc_id,
@@ -968,6 +967,10 @@ fn validated_proc_cwd(requested_cwd: &str) -> Result<PathBuf, HelperError> {
         return Err(jsonrpc_error(-32050, "cwd is not a directory"));
     }
     Ok(cwd)
+}
+
+fn register_proc_cwd(state: &mut HelperState, proc_id: &str, cwd: PathBuf) {
+    state.subscriptions.insert(format!("proc:{proc_id}"), cwd);
 }
 
 fn spawn_proc_supervisor(dir: &Path) -> Result<(), HelperError> {
@@ -1270,6 +1273,13 @@ fn proc_write(params: Option<Value>) -> Result<Value, HelperError> {
     let dir = proc_dir(&params.proc_id)?;
     if !dir.is_dir() {
         return Err(jsonrpc_error(-32051, "process not found"));
+    }
+    proc_write_in_dir(&dir, &params)
+}
+
+fn proc_write_in_dir(dir: &Path, params: &ProcWriteParams) -> Result<Value, HelperError> {
+    if !proc_status_in_dir(dir).running {
+        return Err(jsonrpc_error(-32051, "process not running"));
     }
     let bytes = base64::engine::general_purpose::STANDARD
         .decode(params.data_base64.as_bytes())
@@ -2109,6 +2119,45 @@ mod tests {
             .expect("symlink cwd should be valid");
 
         assert_eq!(validated, link);
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn proc_cwd_registration_uses_proc_subscription_key() {
+        let mut state = HelperState::default();
+        let cwd = PathBuf::from("/repo/link");
+
+        register_proc_cwd(&mut state, "session-1", cwd.clone());
+
+        assert_eq!(state.subscriptions.get("proc:session-1"), Some(&cwd));
+    }
+
+    #[test]
+    fn proc_write_rejects_exited_process_without_appending() {
+        let root = std::env::temp_dir().join(format!(
+            "alas-helper-proc-write-exited-{}-{}",
+            std::process::id(),
+            SystemTime::now()
+                .duration_since(SystemTime::UNIX_EPOCH)
+                .expect("time after epoch")
+                .as_nanos()
+        ));
+        std::fs::create_dir_all(&root).expect("proc dir");
+        std::fs::write(root.join("stdin.log"), b"existing\n").expect("stdin log");
+        std::fs::write(root.join("exit"), b"0\n").expect("exit status");
+        let params = ProcWriteParams {
+            proc_id: "session-1".to_string(),
+            data_base64: base64::engine::general_purpose::STANDARD.encode(b"prompt\n"),
+            expected_stdin_offset: Some(9),
+        };
+
+        let error = proc_write_in_dir(&root, &params).expect_err("exited proc must reject writes");
+
+        assert_eq!(error.code, -32051);
+        assert_eq!(
+            std::fs::read(root.join("stdin.log")).expect("stdin contents"),
+            b"existing\n"
+        );
         let _ = std::fs::remove_dir_all(root);
     }
 

--- a/AlasHelper/src/main.rs
+++ b/AlasHelper/src/main.rs
@@ -167,6 +167,7 @@ struct ProcReplayFrame {
     data: Vec<u8>,
 }
 
+#[derive(Debug)]
 pub(crate) enum SearchNotification {
     Line {
         search_id: String,
@@ -180,6 +181,7 @@ pub(crate) enum SearchNotification {
     },
 }
 
+#[derive(Debug)]
 pub(crate) enum ProcNotification {
     Stdout {
         proc_id: String,
@@ -197,6 +199,7 @@ pub(crate) enum ProcNotification {
     },
 }
 
+#[derive(Debug)]
 pub(crate) enum ServerMessage {
     Request(String),
     Watch(WatchNotification),
@@ -1451,22 +1454,34 @@ fn spawn_proc_tail(
             }
             let status = proc_status_in_dir(&dir);
             if !status.running {
-                let _ = drain_proc_output_once(
+                finish_proc_tail(
                     &proc_id,
                     &dir,
                     &sender,
                     &mut stdout_offset,
                     &mut stderr_offset,
+                    status.exit_code,
                 );
-                let _ = sender.send(ServerMessage::Proc(ProcNotification::Exit {
-                    proc_id,
-                    exit_code: status.exit_code,
-                }));
                 return;
             }
             thread::sleep(Duration::from_millis(50));
         }
     });
+}
+
+fn finish_proc_tail(
+    proc_id: &str,
+    dir: &Path,
+    sender: &Sender<ServerMessage>,
+    stdout_offset: &mut u64,
+    stderr_offset: &mut u64,
+    exit_code: Option<i32>,
+) {
+    let _ = drain_proc_output_once(proc_id, dir, sender, stdout_offset, stderr_offset);
+    let _ = sender.send(ServerMessage::Proc(ProcNotification::Exit {
+        proc_id: proc_id.to_string(),
+        exit_code,
+    }));
 }
 
 fn drain_proc_output_once(
@@ -2518,6 +2533,63 @@ mod tests {
         ));
         assert!(script.contains("-u CLAUDECODE"));
         assert!(script.ends_with("'codex-acp'"));
+    }
+
+    #[test]
+    fn proc_tail_finishes_after_draining_stdout_and_stderr() {
+        let root = std::env::temp_dir().join(format!(
+            "alas-helper-proc-tail-finish-{}-{}",
+            std::process::id(),
+            system_time_seconds(SystemTime::now()).unwrap()
+        ));
+        std::fs::create_dir_all(&root).expect("root");
+        std::fs::write(root.join("stdout.log"), b"out\n").expect("stdout");
+        std::fs::write(root.join("stderr.log"), b"err").expect("stderr");
+        let (sender, receiver) = mpsc::channel();
+        let mut stdout_offset = 0;
+        let mut stderr_offset = 0;
+
+        finish_proc_tail(
+            "acp-session-1",
+            &root,
+            &sender,
+            &mut stdout_offset,
+            &mut stderr_offset,
+            Some(7),
+        );
+
+        match receiver.try_recv().expect("stdout message") {
+            ServerMessage::Proc(ProcNotification::Stdout {
+                proc_id,
+                offset,
+                data,
+            }) => {
+                assert_eq!(proc_id, "acp-session-1");
+                assert_eq!(offset, 4);
+                assert_eq!(data, b"out");
+            }
+            other => panic!("unexpected first message: {other:?}"),
+        }
+        match receiver.try_recv().expect("stderr message") {
+            ServerMessage::Proc(ProcNotification::Stderr {
+                proc_id,
+                offset,
+                data,
+            }) => {
+                assert_eq!(proc_id, "acp-session-1");
+                assert_eq!(offset, 3);
+                assert_eq!(data, b"err");
+            }
+            other => panic!("unexpected second message: {other:?}"),
+        }
+        match receiver.try_recv().expect("exit message") {
+            ServerMessage::Proc(ProcNotification::Exit { proc_id, exit_code }) => {
+                assert_eq!(proc_id, "acp-session-1");
+                assert_eq!(exit_code, Some(7));
+            }
+            other => panic!("unexpected third message: {other:?}"),
+        }
+        let _ = std::fs::remove_dir_all(root);
     }
 
     #[cfg(unix)]

--- a/AlasHelper/src/main.rs
+++ b/AlasHelper/src/main.rs
@@ -211,8 +211,8 @@ fn capabilities() -> Value {
             "list": true
         },
         "search": true,
-        "proc": true,
-        "ping": true
+        "ping": true,
+        "proc": true
     })
 }
 

--- a/AlasHelper/src/main.rs
+++ b/AlasHelper/src/main.rs
@@ -153,6 +153,13 @@ struct ProcMetadata {
 
 #[derive(Debug, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
+struct ProcPidMetadata {
+    pid: u32,
+    process_group_id: Option<u32>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
 struct ProcSupervisorLaunch {
     command: String,
     args: Vec<String>,
@@ -1022,8 +1029,7 @@ fn proc_supervise(dir: PathBuf) -> Result<(), HelperError> {
     let child = command
         .spawn()
         .map_err(|error| jsonrpc_error(-32050, format!("spawn failed: {error}")))?;
-    std::fs::write(dir.join("pid"), format!("{}\n", child.id()))
-        .map_err(|error| jsonrpc_error(-32050, format!("pid write failed: {error}")))?;
+    write_proc_pid(&dir, child.id())?;
     run_supervised_proc_child(child, dir.join("stdin.log"), dir.join("exit"));
     Ok(())
 }
@@ -1334,7 +1340,7 @@ fn proc_kill(params: Option<Value>) -> Result<Value, HelperError> {
     let params: ProcKillParams = decode_params(params)?;
     validate_proc_id(&params.proc_id)?;
     let dir = proc_dir(&params.proc_id)?;
-    if let Some(pid) = read_pid(&dir) {
+    if let Some(pid) = verified_proc_pid(&dir) {
         kill_process_group(pid);
     }
     Ok(json!({ "ok": true }))
@@ -1373,7 +1379,7 @@ fn proc_status_in_dir(dir: &Path) -> ProcStatus {
     let exit_code = std::fs::read_to_string(dir.join("exit"))
         .ok()
         .and_then(|value| value.trim().parse::<i32>().ok());
-    let running = exit_code.is_none() && read_pid(dir).map(pid_is_alive).unwrap_or(false);
+    let running = exit_code.is_none() && verified_proc_pid(dir).is_some();
     ProcStatus { running, exit_code }
 }
 
@@ -1563,7 +1569,55 @@ fn proc_dir(proc_id: &str) -> Result<PathBuf, HelperError> {
 fn read_pid(dir: &Path) -> Option<u32> {
     std::fs::read_to_string(dir.join("pid"))
         .ok()
-        .and_then(|value| value.trim().parse::<u32>().ok())
+        .and_then(|value| value.split_whitespace().next()?.parse::<u32>().ok())
+}
+
+fn write_proc_pid(dir: &Path, pid: u32) -> Result<(), HelperError> {
+    write_restrictive_bytes(
+        dir.join("pid").as_path(),
+        format!("{pid}\n").as_bytes(),
+        "pid",
+    )?;
+    let metadata = ProcPidMetadata {
+        pid,
+        process_group_id: current_process_group_id(pid),
+    };
+    write_restrictive_bytes(
+        dir.join("pid.json").as_path(),
+        &serde_json::to_vec(&metadata).expect("pid metadata serialization must succeed"),
+        "pid metadata",
+    )
+}
+
+fn read_proc_pid_metadata(dir: &Path) -> Option<ProcPidMetadata> {
+    serde_json::from_slice(&std::fs::read(dir.join("pid.json")).ok()?).ok()
+}
+
+fn verified_proc_pid(dir: &Path) -> Option<u32> {
+    let pid = read_pid(dir)?;
+    if !pid_is_alive(pid) {
+        mark_stale_proc_pid(dir);
+        return None;
+    }
+    let Some(metadata) = read_proc_pid_metadata(dir) else {
+        return Some(pid);
+    };
+    if metadata.pid != pid {
+        mark_stale_proc_pid(dir);
+        return None;
+    }
+    if let Some(expected_pgid) = metadata.process_group_id {
+        if current_process_group_id(pid) != Some(expected_pgid) {
+            mark_stale_proc_pid(dir);
+            return None;
+        }
+    }
+    Some(pid)
+}
+
+fn mark_stale_proc_pid(dir: &Path) {
+    let _ = std::fs::remove_file(dir.join("pid"));
+    let _ = std::fs::remove_file(dir.join("pid.json"));
 }
 
 fn file_len(path: &Path) -> io::Result<u64> {
@@ -1571,9 +1625,10 @@ fn file_len(path: &Path) -> io::Result<u64> {
 }
 
 fn requested_log_offset(path: &Path, requested_offset: Option<u64>) -> u64 {
+    let len = file_len(path).unwrap_or(0);
     match requested_offset {
-        Some(u64::MAX) => file_len(path).unwrap_or(0),
-        Some(offset) => offset,
+        Some(u64::MAX) => len,
+        Some(offset) => offset.min(len),
         None => 0,
     }
 }
@@ -1589,6 +1644,17 @@ fn pid_is_alive(_pid: u32) -> bool {
 }
 
 #[cfg(unix)]
+fn current_process_group_id(pid: u32) -> Option<u32> {
+    let pgid = unsafe { libc_getpgid(pid as i32) };
+    if pgid >= 0 { Some(pgid as u32) } else { None }
+}
+
+#[cfg(not(unix))]
+fn current_process_group_id(_pid: u32) -> Option<u32> {
+    None
+}
+
+#[cfg(unix)]
 fn kill_process_group(pid: u32) {
     unsafe {
         let _ = libc_kill(-(pid as i32), 15);
@@ -1601,11 +1667,17 @@ fn kill_process_group(_pid: u32) {}
 #[cfg(unix)]
 unsafe extern "C" {
     fn kill(pid: i32, sig: i32) -> i32;
+    fn getpgid(pid: i32) -> i32;
 }
 
 #[cfg(unix)]
 unsafe fn libc_kill(pid: i32, sig: i32) -> i32 {
     unsafe { kill(pid, sig) }
+}
+
+#[cfg(unix)]
+unsafe fn libc_getpgid(pid: i32) -> i32 {
+    unsafe { getpgid(pid) }
 }
 
 fn shell_quote(value: &str) -> String {
@@ -2620,7 +2692,71 @@ mod tests {
 
         assert_eq!(requested_log_offset(&path, Some(u64::MAX)), 13);
         assert_eq!(requested_log_offset(&path, Some(4)), 4);
+        assert_eq!(requested_log_offset(&path, Some(99)), 13);
         assert_eq!(requested_log_offset(&path, None), 0);
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn proc_pid_metadata_uses_restrictive_permissions() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let root = std::env::temp_dir().join(format!(
+            "alas-helper-proc-pid-mode-{}-{}",
+            std::process::id(),
+            system_time_seconds(SystemTime::now()).unwrap()
+        ));
+        std::fs::create_dir_all(&root).expect("root");
+
+        write_proc_pid(&root, std::process::id()).expect("pid write");
+
+        let pid_mode = std::fs::metadata(root.join("pid"))
+            .expect("pid metadata")
+            .permissions()
+            .mode();
+        let pid_json_mode = std::fs::metadata(root.join("pid.json"))
+            .expect("pid json metadata")
+            .permissions()
+            .mode();
+        assert_eq!(pid_mode & 0o777, 0o600);
+        assert_eq!(pid_json_mode & 0o777, 0o600);
+        assert_eq!(verified_proc_pid(&root), Some(std::process::id()));
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn proc_status_rejects_pid_with_mismatched_process_group() {
+        let root = std::env::temp_dir().join(format!(
+            "alas-helper-proc-stale-pid-{}-{}",
+            std::process::id(),
+            system_time_seconds(SystemTime::now()).unwrap()
+        ));
+        std::fs::create_dir_all(&root).expect("root");
+        let pid = std::process::id();
+        write_restrictive_bytes(
+            root.join("pid").as_path(),
+            format!("{pid}\n").as_bytes(),
+            "pid",
+        )
+        .expect("pid write");
+        let wrong_group = current_process_group_id(pid).unwrap_or(pid).wrapping_add(1);
+        let metadata = ProcPidMetadata {
+            pid,
+            process_group_id: Some(wrong_group),
+        };
+        write_restrictive_bytes(
+            root.join("pid.json").as_path(),
+            &serde_json::to_vec(&metadata).expect("pid metadata"),
+            "pid metadata",
+        )
+        .expect("pid metadata write");
+
+        let status = proc_status_in_dir(&root);
+        assert!(!status.running);
+        assert!(!root.join("pid").exists());
+        assert!(!root.join("pid.json").exists());
         let _ = std::fs::remove_dir_all(root);
     }
 

--- a/AlasHelper/src/main.rs
+++ b/AlasHelper/src/main.rs
@@ -46,6 +46,7 @@ struct HelperState {
     watchers: HashMap<String, SubscriptionWatcher>,
     searches: HashMap<String, Arc<AtomicBool>>,
     event_sender: Option<Sender<ServerMessage>>,
+    proc_tailers: HashSet<String>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -969,6 +970,9 @@ fn proc_attach(state: &mut HelperState, params: Option<Value>) -> Result<Value, 
     let stderr_offset = params.stderr_offset.unwrap_or(0);
     let stdout_frames = read_stdout_frames(&dir.join("stdout.log"), stdout_offset)?;
     let stderr_chunk = read_file_tail(&dir.join("stderr.log"), stderr_offset)?;
+    let stdin_offset = std::fs::metadata(dir.join("stdin.log"))
+        .map(|metadata| metadata.len())
+        .unwrap_or(0);
     let stdout_next_offset = stdout_frames
         .last()
         .map(|frame| frame.offset)
@@ -980,24 +984,35 @@ fn proc_attach(state: &mut HelperState, params: Option<Value>) -> Result<Value, 
     let status = proc_status_in_dir(&dir);
     if status.running {
         if let Some(sender) = state.event_sender.clone() {
-            spawn_proc_stdout_tail(
-                params.proc_id.clone(),
-                dir.clone(),
-                stdout_next_offset,
-                sender.clone(),
-            );
-            spawn_proc_stderr_tail(
-                params.proc_id.clone(),
-                dir.clone(),
-                stderr_next_offset,
-                sender,
-            );
+            if state
+                .proc_tailers
+                .insert(format!("{}:stdout", params.proc_id))
+            {
+                spawn_proc_stdout_tail(
+                    params.proc_id.clone(),
+                    dir.clone(),
+                    stdout_next_offset,
+                    sender.clone(),
+                );
+            }
+            if state
+                .proc_tailers
+                .insert(format!("{}:stderr", params.proc_id))
+            {
+                spawn_proc_stderr_tail(
+                    params.proc_id.clone(),
+                    dir.clone(),
+                    stderr_next_offset,
+                    sender,
+                );
+            }
         }
     }
     Ok(json!({
         "procId": params.proc_id,
         "running": status.running,
         "exitCode": status.exit_code,
+        "stdinOffset": stdin_offset,
         "stdoutOffset": stdout_next_offset,
         "stderrOffset": stderr_next_offset,
         "stdoutFrames": stdout_frames.into_iter().map(|frame| {

--- a/AlasHelper/src/main.rs
+++ b/AlasHelper/src/main.rs
@@ -973,6 +973,22 @@ fn register_proc_cwd(state: &mut HelperState, proc_id: &str, cwd: PathBuf) {
     state.subscriptions.insert(format!("proc:{proc_id}"), cwd);
 }
 
+fn register_persisted_proc_cwd(state: &mut HelperState, proc_id: &str, dir: &Path) {
+    let Ok(bytes) = std::fs::read(dir.join("meta.json")) else {
+        return;
+    };
+    let Ok(metadata) = serde_json::from_slice::<ProcMetadata>(&bytes) else {
+        return;
+    };
+    if metadata.proc_id != proc_id {
+        return;
+    }
+    let Ok(cwd) = validated_proc_cwd(&metadata.cwd) else {
+        return;
+    };
+    register_proc_cwd(state, proc_id, cwd);
+}
+
 fn spawn_proc_supervisor(dir: &Path) -> Result<(), HelperError> {
     let exe = std::env::current_exe()
         .map_err(|error| jsonrpc_error(-32050, format!("helper path failed: {error}")))?;
@@ -1164,6 +1180,7 @@ fn proc_attach(state: &mut HelperState, params: Option<Value>) -> Result<Value, 
     if !dir.is_dir() {
         return Err(jsonrpc_error(-32051, "process not found"));
     }
+    register_persisted_proc_cwd(state, &params.proc_id, &dir);
     let stdout_offset = requested_log_offset(&dir.join("stdout.log"), params.stdout_offset);
     let stderr_offset = requested_log_offset(&dir.join("stderr.log"), params.stderr_offset);
     let mut stdout_frames = Vec::new();
@@ -2130,6 +2147,36 @@ mod tests {
         register_proc_cwd(&mut state, "session-1", cwd.clone());
 
         assert_eq!(state.subscriptions.get("proc:session-1"), Some(&cwd));
+    }
+
+    #[test]
+    fn proc_attach_restores_cwd_registration_from_metadata() {
+        let root = std::env::temp_dir().join(format!(
+            "alas-helper-proc-attach-cwd-{}-{}",
+            std::process::id(),
+            system_time_seconds(SystemTime::now()).unwrap()
+        ));
+        let cwd = root.join("repo");
+        let proc_dir = root.join("proc");
+        std::fs::create_dir_all(&cwd).expect("cwd");
+        std::fs::create_dir_all(&proc_dir).expect("proc dir");
+        let metadata = ProcMetadata {
+            proc_id: "session-1".to_string(),
+            command: "codex-acp".to_string(),
+            args: Vec::new(),
+            cwd: cwd.display().to_string(),
+        };
+        std::fs::write(
+            proc_dir.join("meta.json"),
+            serde_json::to_vec(&metadata).expect("metadata"),
+        )
+        .expect("metadata file");
+        let mut state = HelperState::default();
+
+        register_persisted_proc_cwd(&mut state, "session-1", &proc_dir);
+
+        assert_eq!(state.subscriptions.get("proc:session-1"), Some(&cwd));
+        let _ = std::fs::remove_dir_all(root);
     }
 
     #[test]

--- a/AlasHelper/src/main.rs
+++ b/AlasHelper/src/main.rs
@@ -1155,19 +1155,20 @@ fn proc_attach(state: &mut HelperState, params: Option<Value>) -> Result<Value, 
     }
     let stdout_offset = requested_log_offset(&dir.join("stdout.log"), params.stdout_offset);
     let stderr_offset = requested_log_offset(&dir.join("stderr.log"), params.stderr_offset);
-    let stdout_frames = read_stdout_frames(&dir.join("stdout.log"), stdout_offset)?;
-    let stderr_chunk = read_file_tail(&dir.join("stderr.log"), stderr_offset)?;
+    let mut stdout_frames = Vec::new();
+    let mut stderr_chunk = None;
+    let mut stdout_next_offset = stdout_offset;
+    let mut stderr_next_offset = stderr_offset;
+    collect_proc_replay(
+        &dir,
+        &mut stdout_next_offset,
+        &mut stderr_next_offset,
+        &mut stdout_frames,
+        &mut stderr_chunk,
+    )?;
     let stdin_offset = std::fs::metadata(dir.join("stdin.log"))
         .map(|metadata| metadata.len())
         .unwrap_or(0);
-    let stdout_next_offset = stdout_frames
-        .last()
-        .map(|frame| frame.offset)
-        .unwrap_or(stdout_offset);
-    let stderr_next_offset = stderr_chunk
-        .as_ref()
-        .map(|(offset, _)| *offset)
-        .unwrap_or(stderr_offset);
     let status = proc_status_in_dir(&dir);
     if status.running {
         if let Some(sender) = state.event_sender.clone() {
@@ -1180,6 +1181,14 @@ fn proc_attach(state: &mut HelperState, params: Option<Value>) -> Result<Value, 
                 sender,
             );
         }
+    } else {
+        collect_proc_replay(
+            &dir,
+            &mut stdout_next_offset,
+            &mut stderr_next_offset,
+            &mut stdout_frames,
+            &mut stderr_chunk,
+        )?;
     }
     Ok(json!({
         "procId": params.proc_id,
@@ -1201,6 +1210,31 @@ fn proc_attach(state: &mut HelperState, params: Option<Value>) -> Result<Value, 
             })
         }).collect::<Vec<_>>()
     }))
+}
+
+fn collect_proc_replay(
+    dir: &Path,
+    stdout_offset: &mut u64,
+    stderr_offset: &mut u64,
+    stdout_frames: &mut Vec<ProcReplayFrame>,
+    stderr_chunk: &mut Option<(u64, Vec<u8>)>,
+) -> Result<(), HelperError> {
+    let frames = read_stdout_frames(&dir.join("stdout.log"), *stdout_offset)?;
+    if let Some(frame) = frames.last() {
+        *stdout_offset = frame.offset;
+    }
+    stdout_frames.extend(frames);
+
+    if let Some((next_offset, data)) = read_file_tail(&dir.join("stderr.log"), *stderr_offset)? {
+        *stderr_offset = next_offset;
+        if let Some((offset, existing)) = stderr_chunk.as_mut() {
+            *offset = next_offset;
+            existing.extend(data);
+        } else {
+            *stderr_chunk = Some((next_offset, data));
+        }
+    }
+    Ok(())
 }
 
 fn ensure_proc_tailers(
@@ -1936,6 +1970,11 @@ fn system_time_seconds(time: SystemTime) -> Option<f64> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn append_to_file(path: &Path, bytes: &[u8]) -> io::Result<()> {
+        let mut file = std::fs::OpenOptions::new().append(true).open(path)?;
+        file.write_all(bytes)
+    }
 
     #[test]
     fn bundled_manifest_matches_handshake() {
@@ -2676,6 +2715,49 @@ mod tests {
             }
             other => panic!("unexpected third message: {other:?}"),
         }
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn proc_replay_can_be_collected_again_before_terminal_attach_returns() {
+        let root = std::env::temp_dir().join(format!(
+            "alas-helper-proc-terminal-replay-{}-{}",
+            std::process::id(),
+            system_time_seconds(SystemTime::now()).unwrap()
+        ));
+        std::fs::create_dir_all(&root).expect("root");
+        std::fs::write(root.join("stdout.log"), b"early\n").expect("stdout");
+        std::fs::write(root.join("stderr.log"), b"early err").expect("stderr");
+        let mut stdout_offset = 0;
+        let mut stderr_offset = 0;
+        let mut stdout_frames = Vec::new();
+        let mut stderr_chunk = None;
+
+        collect_proc_replay(
+            &root,
+            &mut stdout_offset,
+            &mut stderr_offset,
+            &mut stdout_frames,
+            &mut stderr_chunk,
+        )
+        .expect("initial replay");
+        append_to_file(&root.join("stdout.log"), b"final\n").expect("stdout append");
+        append_to_file(&root.join("stderr.log"), b" final err").expect("stderr append");
+        collect_proc_replay(
+            &root,
+            &mut stdout_offset,
+            &mut stderr_offset,
+            &mut stdout_frames,
+            &mut stderr_chunk,
+        )
+        .expect("terminal replay");
+
+        assert_eq!(stdout_frames.len(), 2);
+        assert_eq!(stdout_frames[0].offset, 6);
+        assert_eq!(stdout_frames[0].data, b"early");
+        assert_eq!(stdout_frames[1].offset, 12);
+        assert_eq!(stdout_frames[1].data, b"final");
+        assert_eq!(stderr_chunk, Some((19, b"early err final err".to_vec())));
         let _ = std::fs::remove_dir_all(root);
     }
 

--- a/AlasHelper/src/main.rs
+++ b/AlasHelper/src/main.rs
@@ -898,7 +898,8 @@ fn proc_spawn(state: &mut HelperState, params: Option<Value>) -> Result<Value, H
         return Ok(json!({
             "procId": params.proc_id,
             "running": true,
-            "exitCode": null
+            "exitCode": null,
+            "spawned": false
         }));
     }
     state
@@ -958,7 +959,8 @@ fn proc_spawn(state: &mut HelperState, params: Option<Value>) -> Result<Value, H
     Ok(json!({
         "procId": params.proc_id,
         "running": status.running,
-        "exitCode": status.exit_code
+        "exitCode": status.exit_code,
+        "spawned": true
     }))
 }
 
@@ -1377,7 +1379,19 @@ fn proc_kill(params: Option<Value>) -> Result<Value, HelperError> {
     if let Some(pid) = verified_proc_pid(&dir) {
         kill_process_group(pid);
     }
+    remove_proc_directory(&dir)?;
     Ok(json!({ "ok": true }))
+}
+
+fn remove_proc_directory(dir: &Path) -> Result<(), HelperError> {
+    match std::fs::remove_dir_all(dir) {
+        Ok(()) => Ok(()),
+        Err(error) if error.kind() == io::ErrorKind::NotFound => Ok(()),
+        Err(error) => Err(jsonrpc_error(
+            -32050,
+            format!("proc cleanup failed: {error}"),
+        )),
+    }
 }
 
 fn proc_list() -> Result<Value, HelperError> {
@@ -2759,6 +2773,24 @@ mod tests {
         assert_eq!(stdout_frames[1].data, b"final");
         assert_eq!(stderr_chunk, Some((19, b"early err final err".to_vec())));
         let _ = std::fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn remove_proc_directory_deletes_logs_and_metadata() {
+        let root = std::env::temp_dir().join(format!(
+            "alas-helper-proc-cleanup-{}-{}",
+            std::process::id(),
+            system_time_seconds(SystemTime::now()).unwrap()
+        ));
+        std::fs::create_dir_all(&root).expect("root");
+        std::fs::write(root.join("stdin.log"), b"request").expect("stdin");
+        std::fs::write(root.join("stdout.log"), b"response").expect("stdout");
+        std::fs::write(root.join("stderr.log"), b"error").expect("stderr");
+        std::fs::write(root.join("meta.json"), b"{}").expect("metadata");
+
+        remove_proc_directory(&root).expect("cleanup");
+
+        assert!(!root.exists());
     }
 
     #[test]

--- a/AlasHelper/src/main.rs
+++ b/AlasHelper/src/main.rs
@@ -970,9 +970,12 @@ fn spawn_proc_supervisor(dir: &Path) -> Result<(), HelperError> {
         use std::os::unix::process::CommandExt;
         command.process_group(0);
     }
-    command
+    let mut supervisor = command
         .spawn()
         .map_err(|error| jsonrpc_error(-32050, format!("supervisor spawn failed: {error}")))?;
+    thread::spawn(move || {
+        let _ = supervisor.wait();
+    });
 
     let deadline = Instant::now() + Duration::from_secs(2);
     while Instant::now() < deadline {
@@ -1144,7 +1147,7 @@ fn proc_attach(state: &mut HelperState, params: Option<Value>) -> Result<Value, 
     if !dir.is_dir() {
         return Err(jsonrpc_error(-32051, "process not found"));
     }
-    let stdout_offset = params.stdout_offset.unwrap_or(0);
+    let stdout_offset = requested_log_offset(&dir.join("stdout.log"), params.stdout_offset);
     let stderr_offset = params.stderr_offset.unwrap_or(0);
     let stdout_frames = read_stdout_frames(&dir.join("stdout.log"), stdout_offset)?;
     let stderr_chunk = read_file_tail(&dir.join("stderr.log"), stderr_offset)?;
@@ -1561,6 +1564,18 @@ fn read_pid(dir: &Path) -> Option<u32> {
     std::fs::read_to_string(dir.join("pid"))
         .ok()
         .and_then(|value| value.trim().parse::<u32>().ok())
+}
+
+fn file_len(path: &Path) -> io::Result<u64> {
+    Ok(std::fs::metadata(path)?.len())
+}
+
+fn requested_log_offset(path: &Path, requested_offset: Option<u64>) -> u64 {
+    match requested_offset {
+        Some(u64::MAX) => file_len(path).unwrap_or(0),
+        Some(offset) => offset,
+        None => 0,
+    }
 }
 
 #[cfg(unix)]
@@ -2589,6 +2604,23 @@ mod tests {
             }
             other => panic!("unexpected third message: {other:?}"),
         }
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn max_requested_log_offset_attaches_at_current_end() {
+        let root = std::env::temp_dir().join(format!(
+            "alas-helper-proc-offset-end-{}-{}",
+            std::process::id(),
+            system_time_seconds(SystemTime::now()).unwrap()
+        ));
+        std::fs::create_dir_all(&root).expect("root");
+        let path = root.join("stdout.log");
+        std::fs::write(&path, b"old response\n").expect("stdout");
+
+        assert_eq!(requested_log_offset(&path, Some(u64::MAX)), 13);
+        assert_eq!(requested_log_offset(&path, Some(4)), 4);
+        assert_eq!(requested_log_offset(&path, None), 0);
         let _ = std::fs::remove_dir_all(root);
     }
 

--- a/AlasHelper/src/main.rs
+++ b/AlasHelper/src/main.rs
@@ -10,6 +10,7 @@ use std::process::{Command, Stdio};
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::mpsc::{self, RecvTimeoutError, Sender, TryRecvError};
+use std::thread;
 use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 
 use watch::{SubscriptionWatcher, WatchKind, WatchNotification};
@@ -107,6 +108,52 @@ struct SearchCancelParams {
     search_id: String,
 }
 
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct ProcSpawnParams {
+    proc_id: String,
+    command: String,
+    args: Vec<String>,
+    cwd: String,
+    env: HashMap<String, String>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct ProcAttachParams {
+    proc_id: String,
+    stdout_offset: Option<u64>,
+    stderr_offset: Option<u64>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct ProcWriteParams {
+    proc_id: String,
+    data_base64: String,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct ProcKillParams {
+    proc_id: String,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct ProcMetadata {
+    proc_id: String,
+    command: String,
+    args: Vec<String>,
+    cwd: String,
+}
+
+#[derive(Debug)]
+struct ProcReplayFrame {
+    offset: u64,
+    data: Vec<u8>,
+}
+
 pub(crate) enum SearchNotification {
     Line {
         search_id: String,
@@ -120,10 +167,28 @@ pub(crate) enum SearchNotification {
     },
 }
 
+pub(crate) enum ProcNotification {
+    Stdout {
+        proc_id: String,
+        offset: u64,
+        data: Vec<u8>,
+    },
+    Stderr {
+        proc_id: String,
+        offset: u64,
+        data: Vec<u8>,
+    },
+    Exit {
+        proc_id: String,
+        exit_code: Option<i32>,
+    },
+}
+
 pub(crate) enum ServerMessage {
     Request(String),
     Watch(WatchNotification),
     Search(SearchNotification),
+    Proc(ProcNotification),
     InputClosed,
 }
 
@@ -146,6 +211,7 @@ fn capabilities() -> Value {
             "list": true
         },
         "search": true,
+        "proc": true,
         "ping": true
     })
 }
@@ -236,6 +302,10 @@ fn serve() -> io::Result<()> {
                 flush_due_watch_events(&mut stdout, &state, &mut pending_events, &mut flush_at)?;
                 write_search_notification(&mut stdout, &mut state, notification)?;
             }
+            Some(ServerMessage::Proc(notification)) => {
+                flush_due_watch_events(&mut stdout, &state, &mut pending_events, &mut flush_at)?;
+                write_proc_notification(&mut stdout, notification)?;
+            }
             Some(ServerMessage::InputClosed) => {
                 flush_watch_events(&mut stdout, &state, &mut pending_events)?;
                 break;
@@ -247,6 +317,48 @@ fn serve() -> io::Result<()> {
         }
     }
     Ok(())
+}
+
+fn write_proc_notification(
+    stdout: &mut impl Write,
+    notification: ProcNotification,
+) -> io::Result<()> {
+    let value = match notification {
+        ProcNotification::Stdout {
+            proc_id,
+            offset,
+            data,
+        } => json!({
+            "jsonrpc": "2.0",
+            "method": "proc/output",
+            "params": {
+                "procId": proc_id,
+                "stream": "stdout",
+                "offset": offset,
+                "dataBase64": base64::engine::general_purpose::STANDARD.encode(data)
+            }
+        }),
+        ProcNotification::Stderr {
+            proc_id,
+            offset,
+            data,
+        } => json!({
+            "jsonrpc": "2.0",
+            "method": "proc/output",
+            "params": {
+                "procId": proc_id,
+                "stream": "stderr",
+                "offset": offset,
+                "dataBase64": base64::engine::general_purpose::STANDARD.encode(data)
+            }
+        }),
+        ProcNotification::Exit { proc_id, exit_code } => json!({
+            "jsonrpc": "2.0",
+            "method": "proc/exit",
+            "params": { "procId": proc_id, "exitCode": exit_code }
+        }),
+    };
+    write_json_line(stdout, &value.to_string())
 }
 
 fn write_search_notification(
@@ -378,6 +490,11 @@ fn handle_request(
         "fs/list" => fs_list(state, params),
         "search/start" => search_start(state, params),
         "search/cancel" => search_cancel(state, params),
+        "proc/spawn" => proc_spawn(state, params),
+        "proc/attach" => proc_attach(state, params),
+        "proc/write" => proc_write(params),
+        "proc/kill" => proc_kill(params),
+        "proc/list" => proc_list(),
         _ => Err(jsonrpc_error(-32601, format!("method not found: {method}"))),
     }
 }
@@ -728,6 +845,430 @@ fn spawn_search(
             cancelled: was_cancelled,
         }));
     });
+}
+
+fn proc_spawn(state: &mut HelperState, params: Option<Value>) -> Result<Value, HelperError> {
+    let params: ProcSpawnParams = decode_params(params)?;
+    validate_proc_id(&params.proc_id)?;
+    let cwd = std::fs::canonicalize(&params.cwd)
+        .map_err(|error| jsonrpc_error(-32050, format!("invalid cwd: {error}")))?;
+    if !cwd.is_dir() {
+        return Err(jsonrpc_error(-32050, "cwd is not a directory"));
+    }
+    let dir = proc_dir(&params.proc_id)?;
+    std::fs::create_dir_all(&dir)
+        .map_err(|error| jsonrpc_error(-32050, format!("proc dir failed: {error}")))?;
+    let status = proc_status_in_dir(&dir);
+    if status.running {
+        return Ok(json!({
+            "procId": params.proc_id,
+            "running": true,
+            "exitCode": null
+        }));
+    }
+
+    let stdin_path = dir.join("stdin.log");
+    let stdout_path = dir.join("stdout.log");
+    let stderr_path = dir.join("stderr.log");
+    let exit_path = dir.join("exit");
+    let pid_path = dir.join("pid");
+    let _ = std::fs::remove_file(&exit_path);
+    std::fs::File::create(&stdin_path)
+        .map_err(|error| jsonrpc_error(-32050, format!("stdin create failed: {error}")))?;
+    std::fs::File::create(&stdout_path)
+        .map_err(|error| jsonrpc_error(-32050, format!("stdout create failed: {error}")))?;
+    std::fs::File::create(&stderr_path)
+        .map_err(|error| jsonrpc_error(-32050, format!("stderr create failed: {error}")))?;
+    let metadata = ProcMetadata {
+        proc_id: params.proc_id.clone(),
+        command: params.command.clone(),
+        args: params.args.clone(),
+        cwd: cwd.display().to_string(),
+    };
+    std::fs::write(
+        dir.join("meta.json"),
+        serde_json::to_vec(&metadata).expect("metadata serialization must succeed"),
+    )
+    .map_err(|error| jsonrpc_error(-32050, format!("metadata write failed: {error}")))?;
+
+    let mut env_parts: Vec<String> = vec!["env".to_string()];
+    env_parts.extend(
+        ACP_REMOTE_MARKER_SCRUB
+            .iter()
+            .flat_map(|key| ["-u".to_string(), (*key).to_string()]),
+    );
+    let mut env_keys: Vec<_> = params.env.keys().collect();
+    env_keys.sort();
+    for key in env_keys {
+        if !is_safe_env_key(key) {
+            return Err(jsonrpc_error(-32602, format!("invalid env key: {key}")));
+        }
+        let value = params.env.get(key).expect("key from map");
+        env_parts.push(format!("{}={}", key, shell_quote(value)));
+    }
+    let argv = std::iter::once(params.command.as_str())
+        .chain(params.args.iter().map(String::as_str))
+        .map(shell_quote)
+        .collect::<Vec<_>>()
+        .join(" ");
+    let env_command = env_parts.join(" ");
+    let script = format!(
+        "cd {cwd} && tail -n +1 -f {stdin} | {env_command} {argv} > {stdout} 2> {stderr}; status=$?; printf '%s\\n' \"$status\" > {exit}",
+        cwd = shell_quote(cwd.to_string_lossy().as_ref()),
+        stdin = shell_quote(stdin_path.to_string_lossy().as_ref()),
+        stdout = shell_quote(stdout_path.to_string_lossy().as_ref()),
+        stderr = shell_quote(stderr_path.to_string_lossy().as_ref()),
+        exit = shell_quote(exit_path.to_string_lossy().as_ref()),
+        env_command = env_command,
+        argv = argv,
+    );
+    let mut command = Command::new("/bin/sh");
+    command
+        .arg("-c")
+        .arg(script)
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null());
+    #[cfg(unix)]
+    {
+        use std::os::unix::process::CommandExt;
+        command.process_group(0);
+    }
+    let mut child = command
+        .spawn()
+        .map_err(|error| jsonrpc_error(-32050, format!("spawn failed: {error}")))?;
+    std::fs::write(&pid_path, format!("{}\n", child.id()))
+        .map_err(|error| jsonrpc_error(-32050, format!("pid write failed: {error}")))?;
+    thread::spawn(move || {
+        let _ = child.wait();
+    });
+    state
+        .subscriptions
+        .insert(format!("proc:{}", params.proc_id), cwd);
+    Ok(json!({
+        "procId": params.proc_id,
+        "running": true,
+        "exitCode": null
+    }))
+}
+
+fn proc_attach(state: &mut HelperState, params: Option<Value>) -> Result<Value, HelperError> {
+    let params: ProcAttachParams = decode_params(params)?;
+    validate_proc_id(&params.proc_id)?;
+    let dir = proc_dir(&params.proc_id)?;
+    if !dir.is_dir() {
+        return Err(jsonrpc_error(-32051, "process not found"));
+    }
+    let stdout_offset = params.stdout_offset.unwrap_or(0);
+    let stderr_offset = params.stderr_offset.unwrap_or(0);
+    let stdout_frames = read_stdout_frames(&dir.join("stdout.log"), stdout_offset)?;
+    let stderr_chunk = read_file_tail(&dir.join("stderr.log"), stderr_offset)?;
+    let stdout_next_offset = stdout_frames
+        .last()
+        .map(|frame| frame.offset)
+        .unwrap_or(stdout_offset);
+    let stderr_next_offset = stderr_chunk
+        .as_ref()
+        .map(|(offset, _)| *offset)
+        .unwrap_or(stderr_offset);
+    if let Some(sender) = state.event_sender.clone() {
+        spawn_proc_stdout_tail(
+            params.proc_id.clone(),
+            dir.clone(),
+            stdout_next_offset,
+            sender.clone(),
+        );
+        spawn_proc_stderr_tail(params.proc_id.clone(), dir.clone(), stderr_next_offset, sender);
+    }
+    let status = proc_status_in_dir(&dir);
+    Ok(json!({
+        "procId": params.proc_id,
+        "running": status.running,
+        "exitCode": status.exit_code,
+        "stdoutOffset": stdout_next_offset,
+        "stderrOffset": stderr_next_offset,
+        "stdoutFrames": stdout_frames.into_iter().map(|frame| {
+            json!({
+                "offset": frame.offset,
+                "dataBase64": base64::engine::general_purpose::STANDARD.encode(frame.data)
+            })
+        }).collect::<Vec<_>>(),
+        "stderrChunks": stderr_chunk.into_iter().map(|(offset, data)| {
+            json!({
+                "offset": offset,
+                "dataBase64": base64::engine::general_purpose::STANDARD.encode(data)
+            })
+        }).collect::<Vec<_>>()
+    }))
+}
+
+fn proc_write(params: Option<Value>) -> Result<Value, HelperError> {
+    let params: ProcWriteParams = decode_params(params)?;
+    validate_proc_id(&params.proc_id)?;
+    let dir = proc_dir(&params.proc_id)?;
+    if !dir.is_dir() {
+        return Err(jsonrpc_error(-32051, "process not found"));
+    }
+    let bytes = base64::engine::general_purpose::STANDARD
+        .decode(params.data_base64.as_bytes())
+        .map_err(|error| jsonrpc_error(-32602, format!("invalid base64: {error}")))?;
+    let mut file = std::fs::OpenOptions::new()
+        .append(true)
+        .open(dir.join("stdin.log"))
+        .map_err(|error| jsonrpc_error(-32052, format!("stdin open failed: {error}")))?;
+    file.write_all(&bytes)
+        .map_err(|error| jsonrpc_error(-32052, format!("stdin write failed: {error}")))?;
+    file.flush()
+        .map_err(|error| jsonrpc_error(-32052, format!("stdin flush failed: {error}")))?;
+    Ok(json!({ "ok": true }))
+}
+
+fn proc_kill(params: Option<Value>) -> Result<Value, HelperError> {
+    let params: ProcKillParams = decode_params(params)?;
+    validate_proc_id(&params.proc_id)?;
+    let dir = proc_dir(&params.proc_id)?;
+    if let Some(pid) = read_pid(&dir) {
+        kill_process_group(pid);
+    }
+    Ok(json!({ "ok": true }))
+}
+
+fn proc_list() -> Result<Value, HelperError> {
+    let root = proc_root()?;
+    let mut entries = Vec::new();
+    let Ok(read_dir) = std::fs::read_dir(root) else {
+        return Ok(json!({ "entries": entries }));
+    };
+    for entry in read_dir.flatten() {
+        let dir = entry.path();
+        if !dir.is_dir() {
+            continue;
+        }
+        let Some(proc_id) = entry.file_name().to_str().map(str::to_string) else {
+            continue;
+        };
+        let status = proc_status_in_dir(&dir);
+        entries.push(json!({
+            "procId": proc_id,
+            "running": status.running,
+            "exitCode": status.exit_code
+        }));
+    }
+    Ok(json!({ "entries": entries }))
+}
+
+struct ProcStatus {
+    running: bool,
+    exit_code: Option<i32>,
+}
+
+fn proc_status_in_dir(dir: &Path) -> ProcStatus {
+    let exit_code = std::fs::read_to_string(dir.join("exit"))
+        .ok()
+        .and_then(|value| value.trim().parse::<i32>().ok());
+    let running = exit_code.is_none()
+        && read_pid(dir)
+            .map(pid_is_alive)
+            .unwrap_or(false);
+    ProcStatus { running, exit_code }
+}
+
+fn read_stdout_frames(path: &Path, offset: u64) -> Result<Vec<ProcReplayFrame>, HelperError> {
+    use std::io::{Read, Seek};
+    let mut file = match std::fs::File::open(path) {
+        Ok(file) => file,
+        Err(error) if error.kind() == io::ErrorKind::NotFound => return Ok(Vec::new()),
+        Err(error) => return Err(jsonrpc_error(-32053, format!("stdout open failed: {error}"))),
+    };
+    file.seek(io::SeekFrom::Start(offset))
+        .map_err(|error| jsonrpc_error(-32053, format!("stdout seek failed: {error}")))?;
+    let mut data = Vec::new();
+    file.read_to_end(&mut data)
+        .map_err(|error| jsonrpc_error(-32053, format!("stdout read failed: {error}")))?;
+    let mut frames = Vec::new();
+    let mut start = 0;
+    for (index, byte) in data.iter().enumerate() {
+        if *byte != b'\n' {
+            continue;
+        }
+        let end = index + 1;
+        let frame = data[start..index].to_vec();
+        frames.push(ProcReplayFrame {
+            offset: offset + end as u64,
+            data: frame,
+        });
+        start = end;
+    }
+    Ok(frames)
+}
+
+fn read_file_tail(path: &Path, offset: u64) -> Result<Option<(u64, Vec<u8>)>, HelperError> {
+    use std::io::{Read, Seek};
+    let mut file = match std::fs::File::open(path) {
+        Ok(file) => file,
+        Err(error) if error.kind() == io::ErrorKind::NotFound => return Ok(None),
+        Err(error) => return Err(jsonrpc_error(-32053, format!("stderr open failed: {error}"))),
+    };
+    file.seek(io::SeekFrom::Start(offset))
+        .map_err(|error| jsonrpc_error(-32053, format!("stderr seek failed: {error}")))?;
+    let mut data = Vec::new();
+    file.read_to_end(&mut data)
+        .map_err(|error| jsonrpc_error(-32053, format!("stderr read failed: {error}")))?;
+    if data.is_empty() {
+        Ok(None)
+    } else {
+        Ok(Some((offset + data.len() as u64, data)))
+    }
+}
+
+fn spawn_proc_stdout_tail(
+    proc_id: String,
+    dir: PathBuf,
+    mut offset: u64,
+    sender: Sender<ServerMessage>,
+) {
+    thread::spawn(move || {
+        loop {
+            match read_stdout_frames(&dir.join("stdout.log"), offset) {
+                Ok(frames) if frames.is_empty() => {}
+                Ok(frames) => {
+                    for frame in frames {
+                        offset = frame.offset;
+                        if sender
+                            .send(ServerMessage::Proc(ProcNotification::Stdout {
+                                proc_id: proc_id.clone(),
+                                offset,
+                                data: frame.data,
+                            }))
+                            .is_err()
+                        {
+                            return;
+                        }
+                    }
+                }
+                Err(_) => return,
+            }
+            if proc_status_in_dir(&dir).exit_code.is_some() {
+                let _ = sender.send(ServerMessage::Proc(ProcNotification::Exit {
+                    proc_id,
+                    exit_code: proc_status_in_dir(&dir).exit_code,
+                }));
+                return;
+            }
+            thread::sleep(Duration::from_millis(50));
+        }
+    });
+}
+
+fn spawn_proc_stderr_tail(
+    proc_id: String,
+    dir: PathBuf,
+    mut offset: u64,
+    sender: Sender<ServerMessage>,
+) {
+    thread::spawn(move || {
+        loop {
+            match read_file_tail(&dir.join("stderr.log"), offset) {
+                Ok(Some((next_offset, data))) => {
+                    offset = next_offset;
+                    if sender
+                        .send(ServerMessage::Proc(ProcNotification::Stderr {
+                            proc_id: proc_id.clone(),
+                            offset,
+                            data,
+                        }))
+                        .is_err()
+                    {
+                        return;
+                    }
+                }
+                Ok(None) => {}
+                Err(_) => return,
+            }
+            if proc_status_in_dir(&dir).exit_code.is_some() {
+                return;
+            }
+            thread::sleep(Duration::from_millis(100));
+        }
+    });
+}
+
+const ACP_REMOTE_MARKER_SCRUB: &[&str] = &[
+    "CLAUDECODE",
+    "CLAUDE_CODE",
+    "CLAUDE_PROJECT_DIR",
+    "CLAUDE_CODE_ENTRYPOINT",
+    "CLAUDE_SESSION_ID",
+];
+
+fn validate_proc_id(proc_id: &str) -> Result<(), HelperError> {
+    if proc_id.is_empty()
+        || proc_id.len() > 128
+        || !proc_id
+            .bytes()
+            .all(|b| b.is_ascii_alphanumeric() || b == b'-' || b == b'_')
+    {
+        return Err(jsonrpc_error(-32602, "invalid procId"));
+    }
+    Ok(())
+}
+
+fn proc_root() -> Result<PathBuf, HelperError> {
+    let home = std::env::var("HOME").map_err(|_| jsonrpc_error(-32050, "HOME is not set"))?;
+    Ok(PathBuf::from(home).join(".alas").join("procs"))
+}
+
+fn proc_dir(proc_id: &str) -> Result<PathBuf, HelperError> {
+    validate_proc_id(proc_id)?;
+    Ok(proc_root()?.join(proc_id))
+}
+
+fn read_pid(dir: &Path) -> Option<u32> {
+    std::fs::read_to_string(dir.join("pid"))
+        .ok()
+        .and_then(|value| value.trim().parse::<u32>().ok())
+}
+
+#[cfg(unix)]
+fn pid_is_alive(pid: u32) -> bool {
+    unsafe { libc_kill(pid as i32, 0) == 0 }
+}
+
+#[cfg(not(unix))]
+fn pid_is_alive(_pid: u32) -> bool {
+    false
+}
+
+#[cfg(unix)]
+fn kill_process_group(pid: u32) {
+    unsafe {
+        let _ = libc_kill(-(pid as i32), 15);
+    }
+}
+
+#[cfg(not(unix))]
+fn kill_process_group(_pid: u32) {}
+
+#[cfg(unix)]
+unsafe extern "C" {
+    fn kill(pid: i32, sig: i32) -> i32;
+}
+
+#[cfg(unix)]
+unsafe fn libc_kill(pid: i32, sig: i32) -> i32 {
+    unsafe { kill(pid, sig) }
+}
+
+fn shell_quote(value: &str) -> String {
+    format!("'{}'", value.replace('\'', "'\\''"))
+}
+
+fn is_safe_env_key(key: &str) -> bool {
+    !key.is_empty()
+        && key
+            .bytes()
+            .all(|b| b.is_ascii_uppercase() || b.is_ascii_digit() || b == b'_')
+        && !key.as_bytes()[0].is_ascii_digit()
 }
 
 fn contained_existing_path(state: &HelperState, path: &str) -> Result<PathBuf, HelperError> {

--- a/AlasHelper/src/main.rs
+++ b/AlasHelper/src/main.rs
@@ -117,6 +117,7 @@ struct ProcSpawnParams {
     args: Vec<String>,
     cwd: String,
     env: HashMap<String, String>,
+    path_prefix_directories: Option<Vec<String>>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -157,6 +158,7 @@ struct ProcSupervisorLaunch {
     args: Vec<String>,
     cwd: String,
     env: HashMap<String, String>,
+    path_prefix_directories: Vec<String>,
 }
 
 #[derive(Debug)]
@@ -928,6 +930,7 @@ fn proc_spawn(state: &mut HelperState, params: Option<Value>) -> Result<Value, H
         args: params.args,
         cwd: cwd.display().to_string(),
         env: params.env,
+        path_prefix_directories: params.path_prefix_directories.unwrap_or_default(),
     };
     write_restrictive_bytes(
         &dir.join("launch.json"),
@@ -984,7 +987,13 @@ fn proc_supervise(dir: PathBuf) -> Result<(), HelperError> {
     .map_err(|error| jsonrpc_error(-32050, format!("launch decode failed: {error}")))?;
     let _ = std::fs::remove_file(&launch_path);
 
-    let script = proc_launch_script(&launch.cwd, &launch.command, &launch.args, &launch.env)?;
+    let script = proc_launch_script(
+        &launch.cwd,
+        &launch.command,
+        &launch.args,
+        &launch.env,
+        &launch.path_prefix_directories,
+    )?;
     let stdout_file = std::fs::OpenOptions::new()
         .append(true)
         .open(dir.join("stdout.log"))
@@ -1005,14 +1014,22 @@ fn proc_supervise(dir: PathBuf) -> Result<(), HelperError> {
         use std::os::unix::process::CommandExt;
         command.process_group(0);
     }
-    let mut child = command
+    let child = command
         .spawn()
         .map_err(|error| jsonrpc_error(-32050, format!("spawn failed: {error}")))?;
-    let child_stdin = child.stdin.take();
     std::fs::write(dir.join("pid"), format!("{}\n", child.id()))
         .map_err(|error| jsonrpc_error(-32050, format!("pid write failed: {error}")))?;
-    pump_proc_stdin_and_record_exit(child, child_stdin, dir.join("stdin.log"), dir.join("exit"));
+    run_supervised_proc_child(child, dir.join("stdin.log"), dir.join("exit"));
     Ok(())
+}
+
+fn run_supervised_proc_child(
+    mut child: std::process::Child,
+    stdin_path: PathBuf,
+    exit_path: PathBuf,
+) {
+    let child_stdin = Option::take(&mut child.stdin);
+    pump_proc_stdin_and_record_exit(child, child_stdin, stdin_path, exit_path);
 }
 
 fn proc_launch_script(
@@ -1020,6 +1037,7 @@ fn proc_launch_script(
     command: &str,
     args: &[String],
     env: &HashMap<String, String>,
+    path_prefix_directories: &[String],
 ) -> Result<String, HelperError> {
     let mut env_parts: Vec<String> = vec!["env".to_string()];
     env_parts.extend(
@@ -1041,9 +1059,20 @@ fn proc_launch_script(
         .map(shell_quote)
         .collect::<Vec<_>>()
         .join(" ");
+    let path_prefix = if path_prefix_directories.is_empty() {
+        String::new()
+    } else {
+        let joined = path_prefix_directories
+            .iter()
+            .map(|directory| shell_quote(directory))
+            .collect::<Vec<_>>()
+            .join(":");
+        format!("PATH={joined}:\"$PATH\" && export PATH && ")
+    };
     Ok(format!(
-        "cd {cwd} && exec {env_command} {argv}",
+        "cd {cwd} && {path_prefix}exec {env_command} {argv}",
         cwd = shell_quote(cwd),
+        path_prefix = path_prefix,
         env_command = env_parts.join(" "),
         argv = argv,
     ))
@@ -2434,6 +2463,24 @@ mod tests {
             .mode();
         assert_eq!(mode & 0o777, 0o600);
         let _ = std::fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn proc_launch_script_prepends_path_prefix_before_scrubbed_env() {
+        let script = proc_launch_script(
+            "/srv/repo",
+            "codex-acp",
+            &[],
+            &HashMap::new(),
+            &["/managed/node/bin".to_string()],
+        )
+        .expect("script");
+
+        assert!(script.starts_with(
+            "cd '/srv/repo' && PATH='/managed/node/bin':\"$PATH\" && export PATH && exec env "
+        ));
+        assert!(script.contains("-u CLAUDECODE"));
+        assert!(script.ends_with("'codex-acp'"));
     }
 
     #[cfg(unix)]

--- a/AlasHelper/src/main.rs
+++ b/AlasHelper/src/main.rs
@@ -971,16 +971,23 @@ fn proc_attach(state: &mut HelperState, params: Option<Value>) -> Result<Value, 
         .as_ref()
         .map(|(offset, _)| *offset)
         .unwrap_or(stderr_offset);
-    if let Some(sender) = state.event_sender.clone() {
-        spawn_proc_stdout_tail(
-            params.proc_id.clone(),
-            dir.clone(),
-            stdout_next_offset,
-            sender.clone(),
-        );
-        spawn_proc_stderr_tail(params.proc_id.clone(), dir.clone(), stderr_next_offset, sender);
-    }
     let status = proc_status_in_dir(&dir);
+    if status.running {
+        if let Some(sender) = state.event_sender.clone() {
+            spawn_proc_stdout_tail(
+                params.proc_id.clone(),
+                dir.clone(),
+                stdout_next_offset,
+                sender.clone(),
+            );
+            spawn_proc_stderr_tail(
+                params.proc_id.clone(),
+                dir.clone(),
+                stderr_next_offset,
+                sender,
+            );
+        }
+    }
     Ok(json!({
         "procId": params.proc_id,
         "running": status.running,
@@ -1066,10 +1073,7 @@ fn proc_status_in_dir(dir: &Path) -> ProcStatus {
     let exit_code = std::fs::read_to_string(dir.join("exit"))
         .ok()
         .and_then(|value| value.trim().parse::<i32>().ok());
-    let running = exit_code.is_none()
-        && read_pid(dir)
-            .map(pid_is_alive)
-            .unwrap_or(false);
+    let running = exit_code.is_none() && read_pid(dir).map(pid_is_alive).unwrap_or(false);
     ProcStatus { running, exit_code }
 }
 
@@ -1078,7 +1082,12 @@ fn read_stdout_frames(path: &Path, offset: u64) -> Result<Vec<ProcReplayFrame>, 
     let mut file = match std::fs::File::open(path) {
         Ok(file) => file,
         Err(error) if error.kind() == io::ErrorKind::NotFound => return Ok(Vec::new()),
-        Err(error) => return Err(jsonrpc_error(-32053, format!("stdout open failed: {error}"))),
+        Err(error) => {
+            return Err(jsonrpc_error(
+                -32053,
+                format!("stdout open failed: {error}"),
+            ));
+        }
     };
     file.seek(io::SeekFrom::Start(offset))
         .map_err(|error| jsonrpc_error(-32053, format!("stdout seek failed: {error}")))?;
@@ -1107,7 +1116,12 @@ fn read_file_tail(path: &Path, offset: u64) -> Result<Option<(u64, Vec<u8>)>, He
     let mut file = match std::fs::File::open(path) {
         Ok(file) => file,
         Err(error) if error.kind() == io::ErrorKind::NotFound => return Ok(None),
-        Err(error) => return Err(jsonrpc_error(-32053, format!("stderr open failed: {error}"))),
+        Err(error) => {
+            return Err(jsonrpc_error(
+                -32053,
+                format!("stderr open failed: {error}"),
+            ));
+        }
     };
     file.seek(io::SeekFrom::Start(offset))
         .map_err(|error| jsonrpc_error(-32053, format!("stderr seek failed: {error}")))?;

--- a/AlasHelper/src/main.rs
+++ b/AlasHelper/src/main.rs
@@ -1377,7 +1377,7 @@ fn proc_kill(params: Option<Value>) -> Result<Value, HelperError> {
     validate_proc_id(&params.proc_id)?;
     let dir = proc_dir(&params.proc_id)?;
     if let Some(pid) = verified_proc_pid(&dir) {
-        kill_process_group(pid);
+        terminate_process_group_and_wait(&dir, pid)?;
     }
     remove_proc_directory(&dir)?;
     Ok(json!({ "ok": true }))
@@ -1703,14 +1703,44 @@ fn current_process_group_id(_pid: u32) -> Option<u32> {
 }
 
 #[cfg(unix)]
-fn kill_process_group(pid: u32) {
-    unsafe {
-        let _ = libc_kill(-(pid as i32), 15);
+fn terminate_process_group_and_wait(dir: &Path, pid: u32) -> Result<(), HelperError> {
+    signal_process_group(pid, 15);
+    if wait_for_proc_to_stop(dir, Duration::from_millis(500)) {
+        return Ok(());
     }
+    signal_process_group(pid, 9);
+    if wait_for_proc_to_stop(dir, Duration::from_secs(2)) {
+        return Ok(());
+    }
+    Err(jsonrpc_error(
+        -32050,
+        "process did not exit after kill signal",
+    ))
 }
 
 #[cfg(not(unix))]
-fn kill_process_group(_pid: u32) {}
+fn terminate_process_group_and_wait(_dir: &Path, _pid: u32) -> Result<(), HelperError> {
+    Ok(())
+}
+
+#[cfg(unix)]
+fn signal_process_group(pid: u32, signal: i32) {
+    unsafe {
+        let _ = libc_kill(-(pid as i32), signal);
+    }
+}
+
+#[cfg(unix)]
+fn wait_for_proc_to_stop(dir: &Path, timeout: Duration) -> bool {
+    let deadline = Instant::now() + timeout;
+    while Instant::now() < deadline {
+        if proc_status_in_dir(dir).exit_code.is_some() || verified_proc_pid(dir).is_none() {
+            return true;
+        }
+        thread::sleep(Duration::from_millis(20));
+    }
+    proc_status_in_dir(dir).exit_code.is_some() || verified_proc_pid(dir).is_none()
+}
 
 #[cfg(unix)]
 unsafe extern "C" {
@@ -2790,6 +2820,33 @@ mod tests {
 
         remove_proc_directory(&root).expect("cleanup");
 
+        assert!(!root.exists());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn terminate_process_group_escalates_before_cleanup() {
+        use std::os::unix::process::CommandExt;
+
+        let root = std::env::temp_dir().join(format!(
+            "alas-helper-proc-kill-{}-{}",
+            std::process::id(),
+            system_time_seconds(SystemTime::now()).unwrap()
+        ));
+        std::fs::create_dir_all(&root).expect("root");
+        let mut child = Command::new("/bin/sh");
+        child
+            .arg("-c")
+            .arg("trap '' TERM; sleep 30")
+            .process_group(0);
+        let mut child = child.spawn().expect("child");
+        write_proc_pid(&root, child.id()).expect("pid metadata");
+
+        terminate_process_group_and_wait(&root, child.id()).expect("terminated");
+        remove_proc_directory(&root).expect("cleanup");
+
+        let status = child.wait().expect("wait");
+        assert!(!status.success());
         assert!(!root.exists());
     }
 

--- a/AlasTests/ACP/Adapter/ACPLaunchSpecTests.swift
+++ b/AlasTests/ACP/Adapter/ACPLaunchSpecTests.swift
@@ -39,4 +39,20 @@ struct ACPLaunchSpecTests {
         #expect(overridden.supportsModeSelection == true)
         #expect(overridden.npmPackageName == "@agentclientprotocol/codex-acp")
     }
+
+    @Test("remote ACP env preserves the remote shell environment")
+    func remoteOverridesForACP() {
+        let overrides = ACPProcessEnvironment.remoteOverridesForACP(extra: [
+            "PATH": "/remote/tool/bin",
+            "HOME": "/remote/home",
+            "CLAUDECODE": "1",
+            "CUSTOM": "value",
+        ])
+
+        #expect(overrides == [
+            "PATH": "/remote/tool/bin",
+            "HOME": "/remote/home",
+            "CUSTOM": "value",
+        ])
+    }
 }

--- a/AlasTests/ACP/Protocol/ACPStdioClientTests.swift
+++ b/AlasTests/ACP/Protocol/ACPStdioClientTests.swift
@@ -74,6 +74,81 @@ struct ACPStdioClientTests {
         await client.shutdown()
     }
 
+    @Test("response defers frame consumption until the caller acknowledges handling")
+    func responseDefersFrameConsumption() async throws {
+        let transport = FakeJSONRPCTransport()
+        let client = ACPStdioClient.makeForTesting(transport: transport)
+        try client.start()
+        let consumed = ResultBox<Bool>()
+        let responseTask = Task {
+            try await client.send(ACPRequest(method: "initialize"))
+        }
+        try await Task.sleep(for: .milliseconds(20))
+
+        transport.send(frame: Data(#"{"jsonrpc":"2.0","id":1,"result":{"ok":true}}"#.utf8)) {
+            consumed.set(true)
+        }
+
+        let response = try await responseTask.value
+        #expect(consumed.get() == nil)
+        response.acknowledgeDurableConsumption()
+        #expect(consumed.get() == true)
+        await client.shutdown()
+    }
+
+    @Test("inbound request defers frame consumption until its response is sent")
+    func inboundRequestDefersFrameConsumption() async throws {
+        let transport = FakeJSONRPCTransport()
+        transport.deferWriteCompletions = true
+        let client = ACPStdioClient.makeForTesting(transport: transport)
+        try client.start()
+        let consumed = ResultBox<Bool>()
+
+        transport.send(frame: Data(#"{"jsonrpc":"2.0","id":7,"method":"fs/read_text_file","params":{"sessionId":"s","path":"/tmp/a","line":null,"limit":null}}"#.utf8)) {
+            consumed.set(true)
+        }
+
+        var iterator = client.fileRequests.makeAsyncIterator()
+        guard case .read(let id, _) = try #require(await iterator.next()) else {
+            Issue.record("expected read request")
+            return
+        }
+        #expect(consumed.get() == nil)
+        client.respondToFileRequest(
+            id: id,
+            result: .success(try JSONEncoder().encode(ACPFsReadResult(content: "ok")))
+        )
+        try await Task.sleep(for: .milliseconds(20))
+        #expect(consumed.get() == nil)
+        transport.completePendingWrites()
+        #expect(consumed.get() == true)
+        await client.shutdown()
+    }
+
+    @Test("session response remains unconsumed until persisted state is acknowledged")
+    func sessionResponseWaitsForPersistenceAcknowledgement() async throws {
+        let transport = FakeJSONRPCTransport()
+        let client = ACPStdioClient.makeForTesting(transport: transport)
+        let connection = ACPConnection(client: client)
+        try client.start()
+        let consumed = ResultBox<Bool>()
+        let responseTask = Task {
+            try await connection.newSession(cwd: "/tmp", mcpServers: [])
+        }
+        try await Task.sleep(for: .milliseconds(20))
+
+        transport.send(frame: Data(#"{"jsonrpc":"2.0","id":1,"result":{"sessionId":"remote-1"}}"#.utf8)) {
+            consumed.set(true)
+        }
+
+        let result = try await responseTask.value
+        #expect(result.sessionId == "remote-1")
+        #expect(consumed.get() == nil)
+        connection.acknowledgeDurableSessionResponses()
+        #expect(consumed.get() == true)
+        await connection.shutdown()
+    }
+
     private final class ResultBox<T>: @unchecked Sendable {
         private let lock = NSLock()
         private var value: T?

--- a/AlasTests/ACP/Protocol/ACPStdioClientTests.swift
+++ b/AlasTests/ACP/Protocol/ACPStdioClientTests.swift
@@ -54,6 +54,26 @@ struct ACPStdioClientTests {
         await client.shutdown()
     }
 
+    @Test("session update defers frame consumption until durable acknowledgement")
+    func sessionUpdateDefersFrameConsumption() async throws {
+        let transport = FakeJSONRPCTransport()
+        let client = ACPStdioClient.makeForTesting(transport: transport)
+        try client.start()
+        let consumed = ResultBox<Bool>()
+
+        transport.send(frame: Data(#"{"jsonrpc":"2.0","method":"session/update","params":{"sessionId":"s","update":{"sessionUpdate":"agent_message_chunk","content":{"type":"text","text":"hi"}}}}"#.utf8)) {
+            consumed.set(true)
+        }
+
+        var iterator = client.incomingUpdates.makeAsyncIterator()
+        let update = try #require(await iterator.next())
+        #expect(consumed.get() == nil)
+
+        update.durableConsumptionAcknowledgement?()
+        #expect(consumed.get() == true)
+        await client.shutdown()
+    }
+
     private final class ResultBox<T>: @unchecked Sendable {
         private let lock = NSLock()
         private var value: T?

--- a/AlasTests/ACP/Protocol/ACPStdioClientTests.swift
+++ b/AlasTests/ACP/Protocol/ACPStdioClientTests.swift
@@ -96,6 +96,27 @@ struct ACPStdioClientTests {
         await client.shutdown()
     }
 
+    @Test("transport request ID prefix namespaces outbound requests")
+    func requestIDPrefixNamespacesOutboundRequests() async throws {
+        let transport = FakeJSONRPCTransport()
+        transport.requestIDPrefix = "attachment-1"
+        let client = ACPStdioClient.makeForTesting(transport: transport)
+        try client.start()
+        let responseTask = Task {
+            try await client.send(ACPRequest(method: "initialize"))
+        }
+        try await Task.sleep(for: .milliseconds(20))
+
+        let frame = try #require(transport.sentFrames.first)
+        let request = try #require(JSONSerialization.jsonObject(with: frame) as? [String: Any])
+        #expect(request["id"] as? String == "attachment-1:1")
+        transport.send(frame: Data(#"{"jsonrpc":"2.0","id":"attachment-1:1","result":{"ok":true}}"#.utf8))
+
+        let response = try await responseTask.value
+        response.acknowledgeDurableConsumption()
+        await client.shutdown()
+    }
+
     @Test("inbound request defers frame consumption until its response is sent")
     func inboundRequestDefersFrameConsumption() async throws {
         let transport = FakeJSONRPCTransport()

--- a/AlasTests/ACP/Protocol/FakeJSONRPCTransport.swift
+++ b/AlasTests/ACP/Protocol/FakeJSONRPCTransport.swift
@@ -7,6 +7,7 @@ import Foundation
 final class FakeJSONRPCTransport: JSONRPCStdioTransporting, @unchecked Sendable {
     private let cont: AsyncStream<JSONRPCStdioTransport.Incoming>.Continuation
     let incoming: AsyncStream<JSONRPCStdioTransport.Incoming>
+    var requestIDPrefix: String?
     private(set) var sentFrames: [Data] = []
     private(set) var terminateCount = 0
     var deferWriteCompletions = false

--- a/AlasTests/ACP/Protocol/FakeJSONRPCTransport.swift
+++ b/AlasTests/ACP/Protocol/FakeJSONRPCTransport.swift
@@ -9,6 +9,8 @@ final class FakeJSONRPCTransport: JSONRPCStdioTransporting, @unchecked Sendable 
     let incoming: AsyncStream<JSONRPCStdioTransport.Incoming>
     private(set) var sentFrames: [Data] = []
     private(set) var terminateCount = 0
+    var deferWriteCompletions = false
+    private var pendingWriteCompletions: [@Sendable () -> Void] = []
 
     init() {
         var c: AsyncStream<JSONRPCStdioTransport.Incoming>.Continuation!
@@ -22,6 +24,23 @@ final class FakeJSONRPCTransport: JSONRPCStdioTransporting, @unchecked Sendable 
 
     func send(_ data: Data) throws {
         sentFrames.append(data)
+    }
+
+    func send(_ data: Data, onWritten: @escaping @Sendable () -> Void) throws {
+        try send(data)
+        if deferWriteCompletions {
+            pendingWriteCompletions.append(onWritten)
+        } else {
+            onWritten()
+        }
+    }
+
+    func completePendingWrites() {
+        let completions = pendingWriteCompletions
+        pendingWriteCompletions.removeAll()
+        for completion in completions {
+            completion()
+        }
     }
 
     /// When false, `terminate()` does not synthesise an `.exited` event —

--- a/AlasTests/ACP/Protocol/FakeJSONRPCTransport.swift
+++ b/AlasTests/ACP/Protocol/FakeJSONRPCTransport.swift
@@ -42,6 +42,10 @@ final class FakeJSONRPCTransport: JSONRPCStdioTransporting, @unchecked Sendable 
         cont.yield(.frame(frame))
     }
 
+    func send(frame: Data, onConsumed: @escaping @Sendable () -> Void) {
+        cont.yield(.frame(frame, onConsumed: onConsumed))
+    }
+
     func send(exitStatus: Int32) {
         cont.yield(.exited(exitStatus))
         cont.finish()

--- a/AlasTests/ACP/Session/ACPSessionManagerRemoteRestoreTests.swift
+++ b/AlasTests/ACP/Session/ACPSessionManagerRemoteRestoreTests.swift
@@ -22,6 +22,48 @@ struct ACPSessionManagerRemoteRestoreTests {
         await manager.detach(sessionId: session.id)
     }
 
+    @Test("Alas-owned resume suppresses helper stdout replay when locally hydrated")
+    func localSessionResumeSuppressesHydratedHelperReplay() async throws {
+        let persistedToolCall = ACPMessage.toolCall(.init(
+            toolCallId: "tool-1",
+            title: "Read file",
+            kind: "read",
+            status: "completed",
+            content: "done"
+        ))
+        let (manager, store, client, session) = try fixture(
+            origin: .alasCreated,
+            localMessage: persistedToolCall
+        )
+        scriptInitialize(client, canLoad: true, canResume: true)
+        client.scriptAsync(method: "session/resume") { _ in
+            client.emit(.init(sessionId: "remote-id", update: .toolCall(.init(
+                toolCallId: "tool-1",
+                title: "Read file",
+                kind: "read",
+                status: "completed",
+                content: [.content(.text("done"))],
+                locations: nil,
+                rawInput: nil,
+                rawOutput: nil
+            ))))
+            return Data("{}".utf8)
+        }
+
+        await manager.hydrateIfNeeded(id: session.id)
+        await manager.attach(to: session.id, freshlyCreated: false)
+        try await Task.sleep(nanoseconds: 100_000_000)
+
+        #expect(client.sent.map(\.method).contains("session/resume"))
+        #expect(client.yieldedUpdateCount == 1)
+        #expect(session.transcript.messages.count == 1)
+        #expect(try store.messageCount(sessionId: session.id) == 1)
+
+        client.emit(.init(sessionId: "remote-id", update: .agentMessageChunk(.text("live follow-up"))))
+        try await waitUntil { session.transcript.messages.count == 2 }
+        await manager.detach(sessionId: session.id)
+    }
+
     @Test("Alas-owned sessions recover locally when resume fails")
     func localSessionResumeFailureRecoversWithNewSession() async throws {
         let (manager, store, client, session) = try fixture(

--- a/AlasTests/ACP/Session/ACPSessionRunnerTests.swift
+++ b/AlasTests/ACP/Session/ACPSessionRunnerTests.swift
@@ -1102,7 +1102,8 @@ struct ACPSessionRunnerTests {
             currentModel: nil, currentMode: nil, autoRun: false,
             createdAt: 0, updatedAt: 0, lastOpenedAt: 0, archived: false))
 
-        let mock = StreamingBatchACPClient()
+        let acknowledgement = DurableAcknowledgementRecorder()
+        let mock = StreamingBatchACPClient(chunkAcknowledgementRecorder: acknowledgement)
         let session = ACPSession(id: "s", agentId: "claude", worktreeId: "wt", title: "t")
         session.agentState = .ready
         let runner = ACPSessionRunner(
@@ -1134,12 +1135,14 @@ struct ACPSessionRunnerTests {
         #expect(inMemoryAgentMessages.count == 1)
         let rowsBeforeCompletion = try store.loadMessages(sessionId: "s")
         #expect(!rowsBeforeCompletion.contains { $0.kind == "agent" })
+        #expect(acknowledgement.recordedCount == 0)
 
         await mock.finishPrompt()
         #expect(await completed.value)
         await runner.flushPersistence()
 
         let rows = try store.loadMessages(sessionId: "s")
+        #expect(acknowledgement.recordedCount == 2)
         let agentRow = try #require(rows.first(where: { $0.kind == "agent" }))
         let decoded = try ACPMessageCodec.decode(kind: agentRow.kind, payload: agentRow.payload)
         guard case .agent(_, _, let text) = decoded else {
@@ -1147,6 +1150,35 @@ struct ACPSessionRunnerTests {
             return
         }
         #expect(text.value == "hello world")
+    }
+
+    @Test("incoming update is acknowledged only after message persistence")
+    func incomingUpdateAcknowledgesAfterPersistence() async throws {
+        let url = FileManager.default.temporaryDirectory.appendingPathComponent("rn-\(UUID()).sqlite")
+        let store = try ACPSessionStore(path: url.path)
+        try store.upsertSession(.init(id: "s", agentId: "claude", title: "t",
+            currentModel: nil, currentMode: nil, autoRun: false,
+            createdAt: 0, updatedAt: 0, lastOpenedAt: 0, archived: false))
+        let session = ACPSession(id: "s", agentId: "claude", worktreeId: "wt", title: "t")
+        let runner = ACPSessionRunner(
+            session: session,
+            connection: ACPConnection(client: ACPMockClient()),
+            store: store,
+            sessionId: "s",
+            worktreePath: FileManager.default.temporaryDirectory.path
+        )
+        let acknowledgement = DurableAcknowledgementRecorder()
+
+        runner.applyIncomingUpdateForTesting(.init(
+            sessionId: "s",
+            update: .agentMessageChunk(.text("durable")),
+            durableConsumptionAcknowledgement: { acknowledgement.record() }
+        ))
+
+        #expect(!acknowledgement.wasRecorded)
+        await runner.flushPersistence()
+        #expect(acknowledgement.wasRecorded)
+        #expect(try store.loadMessages(sessionId: "s").contains { $0.kind == "agent" })
     }
 
     @Test("incoming streaming chunks are coalesced before applying")
@@ -3149,6 +3181,7 @@ private final class StreamingBatchACPClient: ACPClient {
     private let updatesCont: AsyncStream<ACPSessionUpdateParams>.Continuation
     private let chunksEmitted = AsyncGate()
     private let promptCanFinish = AsyncGate()
+    private let chunkAcknowledgementRecorder: DurableAcknowledgementRecorder?
 
     let incomingUpdates: AsyncStream<ACPSessionUpdateParams>
     let permissionRequests = AsyncStream<(id: JSONRPCID, params: ACPPermissionRequestParams)> { $0.finish() }
@@ -3157,18 +3190,32 @@ private final class StreamingBatchACPClient: ACPClient {
     let questionRequests = AsyncStream<ACPQuestionRequest> { $0.finish() }
     var yieldedUpdateCount: Int { 2 }
 
-    init() {
+    init(chunkAcknowledgementRecorder: DurableAcknowledgementRecorder? = nil) {
+        self.chunkAcknowledgementRecorder = chunkAcknowledgementRecorder
         var updatesCont: AsyncStream<ACPSessionUpdateParams>.Continuation!
         incomingUpdates = AsyncStream { updatesCont = $0 }
         self.updatesCont = updatesCont
+    }
+
+    private func chunkAcknowledgement() -> ACPDurableConsumptionAcknowledgement? {
+        guard let chunkAcknowledgementRecorder else { return nil }
+        return { chunkAcknowledgementRecorder.record() }
     }
 
     func send(_ request: ACPRequest) async throws -> ACPResponse {
         guard request.method == "session/prompt" else {
             throw ACPClientError.noScript(method: request.method)
         }
-        updatesCont.yield(.init(sessionId: "s", update: .agentMessageChunk(.text("hello "))))
-        updatesCont.yield(.init(sessionId: "s", update: .agentMessageChunk(.text("world"))))
+        updatesCont.yield(.init(
+            sessionId: "s",
+            update: .agentMessageChunk(.text("hello ")),
+            durableConsumptionAcknowledgement: chunkAcknowledgement()
+        ))
+        updatesCont.yield(.init(
+            sessionId: "s",
+            update: .agentMessageChunk(.text("world")),
+            durableConsumptionAcknowledgement: chunkAcknowledgement()
+        ))
         await chunksEmitted.open()
         await promptCanFinish.wait()
         return ACPResponse(body: Data("{}".utf8))
@@ -3235,5 +3282,26 @@ private actor AsyncCounter {
     func next() -> Int {
         value += 1
         return value
+    }
+}
+
+private final class DurableAcknowledgementRecorder: @unchecked Sendable {
+    private let lock = NSLock()
+    private var count = 0
+
+    var wasRecorded: Bool {
+        recordedCount > 0
+    }
+
+    var recordedCount: Int {
+        lock.lock()
+        defer { lock.unlock() }
+        return count
+    }
+
+    func record() {
+        lock.lock()
+        count += 1
+        lock.unlock()
     }
 }

--- a/AlasTests/ACP/Session/ACPSessionStoreCRUDTests.swift
+++ b/AlasTests/ACP/Session/ACPSessionStoreCRUDTests.swift
@@ -89,6 +89,39 @@ struct ACPSessionStoreCRUDTests {
         #expect(row.currentModel == "opus")
     }
 
+    @Test("helper proc offsets persist monotonically")
+    func helperProcOffsetsPersistMonotonically() throws {
+        let store = try tmp()
+        try store.upsertSession(.init(
+            id: "local-1",
+            agentId: "claude",
+            title: "Remote",
+            titleSource: .manual,
+            currentModel: nil,
+            currentMode: nil,
+            autoRun: true,
+            createdAt: 1,
+            updatedAt: 2,
+            lastOpenedAt: 3,
+            archived: false
+        ))
+
+        #expect(try store.updateHelperProcOffsets(
+            sessionId: "local-1",
+            stdoutOffset: 20,
+            stderrOffset: nil
+        ))
+        #expect(try store.updateHelperProcOffsets(
+            sessionId: "local-1",
+            stdoutOffset: 12,
+            stderrOffset: 4
+        ))
+
+        let row = try #require(try store.loadSession(id: "local-1"))
+        #expect(row.helperProcStdoutOffset == 20)
+        #expect(row.helperProcStderrOffset == 4)
+    }
+
     @Test("metadata-only upsert can preserve stored title")
     func sessionMetadataUpsertPreservesStoredTitleWhenRequested() throws {
         let store = try tmp()

--- a/AlasTests/ACP/Session/ACPSessionStoreCRUDTests.swift
+++ b/AlasTests/ACP/Session/ACPSessionStoreCRUDTests.swift
@@ -89,8 +89,8 @@ struct ACPSessionStoreCRUDTests {
         #expect(row.currentModel == "opus")
     }
 
-    @Test("helper proc offsets persist monotonically")
-    func helperProcOffsetsPersistMonotonically() throws {
+    @Test("helper proc offsets persist monotonically within each proc generation")
+    func helperProcOffsetsPersistMonotonicallyWithinGeneration() throws {
         let store = try tmp()
         try store.upsertSession(.init(
             id: "local-1",
@@ -120,6 +120,17 @@ struct ACPSessionStoreCRUDTests {
         let row = try #require(try store.loadSession(id: "local-1"))
         #expect(row.helperProcStdoutOffset == 20)
         #expect(row.helperProcStderrOffset == 4)
+
+        #expect(try store.resetHelperProcOffsets(sessionId: "local-1"))
+        #expect(try store.updateHelperProcOffsets(
+            sessionId: "local-1",
+            stdoutOffset: 3,
+            stderrOffset: 1
+        ))
+
+        let respawnedRow = try #require(try store.loadSession(id: "local-1"))
+        #expect(respawnedRow.helperProcStdoutOffset == 3)
+        #expect(respawnedRow.helperProcStderrOffset == 1)
     }
 
     @Test("metadata-only upsert can preserve stored title")

--- a/AlasTests/ACP/Session/ACPSessionStoreTests.swift
+++ b/AlasTests/ACP/Session/ACPSessionStoreTests.swift
@@ -34,7 +34,10 @@ struct ACPSessionStoreSchemaTests {
         let store = try ACPSessionStore(path: url.path)
         let columns = try store.db.query("PRAGMA table_info(session_leases)")
         #expect(columns.contains { ($0["name"] as? String) == "lease_token" })
-        #expect(try store.currentSchemaVersion() == 11)
+        let sessionColumns = try store.db.query("PRAGMA table_info(sessions)")
+        #expect(sessionColumns.contains { ($0["name"] as? String) == "helper_proc_stdout_offset" })
+        #expect(sessionColumns.contains { ($0["name"] as? String) == "helper_proc_stderr_offset" })
+        #expect(try store.currentSchemaVersion() == ACPSessionStore.targetSchemaVersion)
 
         _ = try ACPSessionStore(path: url.path)
     }

--- a/AlasTests/SSH/RemoteHelperClientTests.swift
+++ b/AlasTests/SSH/RemoteHelperClientTests.swift
@@ -166,6 +166,42 @@ struct RemoteHelperClientTests {
         #expect(await iterator.next() == .stdout(Data(#"{"method":"session/update"}"#.utf8), offset: 52))
     }
 
+    @Test func procAttachFinishesAfterReplayingEarlyExit() async throws {
+        let transport = FakeJSONRPCTransport()
+        let client = RemoteHelperClient(
+            host: "devbox",
+            idleShutdownNanoseconds: 0,
+            transportFactory: { transport }
+        )
+
+        let attach = Task {
+            try await client.attachProc(procId: "acp-session-1", stdoutOffset: 0, stderrOffset: 0)
+        }
+        try await waitUntil { transport.sentFrames.count == 1 }
+        transport.send(frame: Data(#"""
+        {"jsonrpc":"2.0","method":"proc/exit","params":{
+          "procId":"acp-session-1",
+          "exitCode":7
+        }}
+        """#.utf8))
+        transport.send(frame: Data(#"""
+        {"jsonrpc":"2.0","id":1,"result":{
+          "procId":"acp-session-1",
+          "running":true,
+          "exitCode":null,
+          "stdoutOffset":0,
+          "stderrOffset":0,
+          "stdoutFrames":[],
+          "stderrChunks":[]
+        }}
+        """#.utf8))
+
+        let handle = try await attach.value
+        var iterator = handle.events.makeAsyncIterator()
+        #expect(await iterator.next() == .exited(7))
+        #expect(await iterator.next() == nil)
+    }
+
     @Test func remoteHelperACPTransportFramesWritesAsNewlineDelimitedACP() {
         let framed = RemoteHelperACPTransport.frameForProcWrite(Data(#"{"id":1}"#.utf8))
         #expect(framed == Data("{\"id\":1}\n".utf8))

--- a/AlasTests/SSH/RemoteHelperClientTests.swift
+++ b/AlasTests/SSH/RemoteHelperClientTests.swift
@@ -90,6 +90,82 @@ struct RemoteHelperClientTests {
         #expect((try await hello.value).name == "alas-helper")
     }
 
+    @Test func procSpawnEncodesHelperOwnedProcessRequest() async throws {
+        let transport = FakeJSONRPCTransport()
+        let client = RemoteHelperClient(
+            host: "devbox",
+            idleShutdownNanoseconds: 0,
+            transportFactory: { transport }
+        )
+
+        let spawn = Task {
+            try await client.spawnProc(
+                procId: "acp-session-1",
+                command: "codex-acp",
+                args: ["--stdio"],
+                cwd: "/srv/repo",
+                env: ["PATH": "/usr/bin"]
+            )
+        }
+
+        try await waitUntil { transport.sentFrames.count == 1 }
+        let request = try #require(
+            JSONSerialization.jsonObject(with: transport.sentFrames[0]) as? [String: Any]
+        )
+        #expect(request["method"] as? String == "proc/spawn")
+        let params = try #require(request["params"] as? [String: Any])
+        #expect(params["procId"] as? String == "acp-session-1")
+        #expect(params["command"] as? String == "codex-acp")
+        #expect(params["cwd"] as? String == "/srv/repo")
+
+        transport.send(frame: Data(#"{"jsonrpc":"2.0","id":1,"result":{"procId":"acp-session-1","running":true,"exitCode":null}}"#.utf8))
+        #expect(try await spawn.value == RemoteHelperProcStatus(
+            procId: "acp-session-1",
+            running: true,
+            exitCode: nil
+        ))
+    }
+
+    @Test func procAttachReplaysFramesAndRoutesLiveOutput() async throws {
+        let transport = FakeJSONRPCTransport()
+        let client = RemoteHelperClient(
+            host: "devbox",
+            idleShutdownNanoseconds: 0,
+            transportFactory: { transport }
+        )
+
+        let attach = Task {
+            try await client.attachProc(procId: "acp-session-1", stdoutOffset: 10, stderrOffset: 0)
+        }
+        try await waitUntil { transport.sentFrames.count == 1 }
+        transport.send(frame: Data(#"""
+        {"jsonrpc":"2.0","id":1,"result":{
+          "procId":"acp-session-1",
+          "running":true,
+          "exitCode":null,
+          "stdoutOffset":25,
+          "stderrOffset":0,
+          "stdoutFrames":[{"offset":25,"dataBase64":"eyJqc29ucnBjIjoiMi4wIn0="}],
+          "stderrChunks":[]
+        }}
+        """#.utf8))
+
+        let handle = try await attach.value
+        var iterator = handle.events.makeAsyncIterator()
+        #expect(await iterator.next() == .available)
+        #expect(await iterator.next() == .stdout(Data(#"{"jsonrpc":"2.0"}"#.utf8), offset: 25))
+
+        transport.send(frame: Data(#"""
+        {"jsonrpc":"2.0","method":"proc/output","params":{
+          "procId":"acp-session-1",
+          "stream":"stdout",
+          "offset":52,
+          "dataBase64":"eyJtZXRob2QiOiJzZXNzaW9uL3VwZGF0ZSJ9"
+        }}
+        """#.utf8))
+        #expect(await iterator.next() == .stdout(Data(#"{"method":"session/update"}"#.utf8), offset: 52))
+    }
+
     @Test func searchStreamsEventsArrivingImmediatelyAfterStart() async throws {
         let transport = FakeJSONRPCTransport()
         let client = RemoteHelperClient(

--- a/AlasTests/SSH/RemoteHelperClientTests.swift
+++ b/AlasTests/SSH/RemoteHelperClientTests.swift
@@ -338,6 +338,134 @@ struct RemoteHelperClientTests {
         #expect(await reattachIterator.next() == .available)
     }
 
+    @Test func procReattachBuffersOutputBeforeAttachResultReturns() async throws {
+        let transport = FakeJSONRPCTransport()
+        let client = RemoteHelperClient(
+            host: "devbox",
+            idleShutdownNanoseconds: 0,
+            transportFactory: { transport }
+        )
+
+        let attach = Task {
+            try await client.attachProc(procId: "acp-session-1", stdoutOffset: 0, stderrOffset: 0)
+        }
+        try await waitUntil { transport.sentFrames.count == 1 }
+        transport.send(frame: Data(#"""
+        {"jsonrpc":"2.0","id":1,"result":{
+          "procId":"acp-session-1",
+          "running":true,
+          "exitCode":null,
+          "stdinOffset":0,
+          "stdoutOffset":12,
+          "stderrOffset":0,
+          "stdoutFrames":[],
+          "stderrChunks":[]
+        }}
+        """#.utf8))
+        let handle = try await attach.value
+        var iterator = handle.events.makeAsyncIterator()
+        #expect(await iterator.next() == .available)
+
+        await client.detachProc(procId: "acp-session-1", stdoutOffset: 12, stderrOffset: 0)
+        #expect(await iterator.next() == nil)
+
+        let reattach = Task {
+            try await client.attachProc(procId: "acp-session-1")
+        }
+        try await waitUntil { transport.sentFrames.count == 2 }
+        transport.send(frame: Data(#"""
+        {"jsonrpc":"2.0","method":"proc/output","params":{
+          "procId":"acp-session-1",
+          "stream":"stdout",
+          "offset":30,
+          "dataBase64":"bGl2ZQ=="
+        }}
+        """#.utf8))
+        transport.send(frame: Data(#"""
+        {"jsonrpc":"2.0","id":2,"result":{
+          "procId":"acp-session-1",
+          "running":true,
+          "exitCode":null,
+          "stdinOffset":0,
+          "stdoutOffset":12,
+          "stderrOffset":0,
+          "stdoutFrames":[],
+          "stderrChunks":[]
+        }}
+        """#.utf8))
+
+        let reattachHandle = try await reattach.value
+        var reattachIterator = reattachHandle.events.makeAsyncIterator()
+        #expect(await reattachIterator.next() == .stdout(Data("live".utf8), offset: 30))
+        #expect(await reattachIterator.next() == .available)
+    }
+
+    @Test func staleProcDetachDoesNotCloseFreshAttachment() async throws {
+        let transport = FakeJSONRPCTransport()
+        let client = RemoteHelperClient(
+            host: "devbox",
+            idleShutdownNanoseconds: 0,
+            transportFactory: { transport }
+        )
+
+        let firstAttach = Task {
+            try await client.attachProc(procId: "acp-session-1", stdoutOffset: 0, stderrOffset: 0)
+        }
+        try await waitUntil { transport.sentFrames.count == 1 }
+        transport.send(frame: Data(#"""
+        {"jsonrpc":"2.0","id":1,"result":{
+          "procId":"acp-session-1",
+          "running":true,
+          "exitCode":null,
+          "stdinOffset":0,
+          "stdoutOffset":12,
+          "stderrOffset":0,
+          "stdoutFrames":[],
+          "stderrChunks":[]
+        }}
+        """#.utf8))
+        let firstHandle = try await firstAttach.value
+        var firstIterator = firstHandle.events.makeAsyncIterator()
+        #expect(await firstIterator.next() == .available)
+
+        let secondAttach = Task {
+            try await client.attachProc(procId: "acp-session-1", attachmentId: "fresh-attachment")
+        }
+        try await waitUntil { transport.sentFrames.count == 2 }
+        transport.send(frame: Data(#"""
+        {"jsonrpc":"2.0","id":2,"result":{
+          "procId":"acp-session-1",
+          "running":true,
+          "exitCode":null,
+          "stdinOffset":0,
+          "stdoutOffset":12,
+          "stderrOffset":0,
+          "stdoutFrames":[],
+          "stderrChunks":[]
+        }}
+        """#.utf8))
+        let secondHandle = try await secondAttach.value
+        var secondIterator = secondHandle.events.makeAsyncIterator()
+        #expect(await secondIterator.next() == .available)
+
+        await client.detachProc(
+            procId: "acp-session-1",
+            attachmentId: firstHandle.attachmentId,
+            stdoutOffset: 12,
+            stderrOffset: 0
+        )
+        transport.send(frame: Data(#"""
+        {"jsonrpc":"2.0","method":"proc/output","params":{
+          "procId":"acp-session-1",
+          "stream":"stdout",
+          "offset":30,
+          "dataBase64":"ZnJlc2g="
+        }}
+        """#.utf8))
+
+        #expect(await secondIterator.next() == .stdout(Data("fresh".utf8), offset: 30))
+    }
+
     @Test func procAttachWithoutRememberedOffsetRequestsReplayFromStart() async throws {
         let transport = FakeJSONRPCTransport()
         let client = RemoteHelperClient(

--- a/AlasTests/SSH/RemoteHelperClientTests.swift
+++ b/AlasTests/SSH/RemoteHelperClientTests.swift
@@ -247,7 +247,7 @@ struct RemoteHelperClientTests {
 
         await client.detachProc(procId: "acp-session-1", stdoutOffset: 52, stderrOffset: 3)
         let secondAttach = Task {
-            try await client.attachProc(procId: "acp-session-1", attachAtEndIfOffsetUnknown: true)
+            try await client.attachProc(procId: "acp-session-1")
         }
         try await waitUntil { transport.sentFrames.count == 2 }
         let request = try #require(
@@ -313,7 +313,7 @@ struct RemoteHelperClientTests {
         """#.utf8))
 
         let reattach = Task {
-            try await client.attachProc(procId: "acp-session-1", attachAtEndIfOffsetUnknown: true)
+            try await client.attachProc(procId: "acp-session-1")
         }
         try await waitUntil { transport.sentFrames.count == 2 }
         transport.send(frame: Data(#"""
@@ -331,6 +331,40 @@ struct RemoteHelperClientTests {
         let reattachHandle = try await reattach.value
         var reattachIterator = reattachHandle.events.makeAsyncIterator()
         #expect(await reattachIterator.next() == .available)
+    }
+
+    @Test func procAttachWithoutRememberedOffsetRequestsReplayFromStart() async throws {
+        let transport = FakeJSONRPCTransport()
+        let client = RemoteHelperClient(
+            host: "devbox",
+            idleShutdownNanoseconds: 0,
+            transportFactory: { transport }
+        )
+
+        let attach = Task {
+            try await client.attachProc(procId: "acp-session-1")
+        }
+        try await waitUntil { transport.sentFrames.count == 1 }
+        let request = try #require(
+            JSONSerialization.jsonObject(with: transport.sentFrames[0]) as? [String: Any]
+        )
+        let params = try #require(request["params"] as? [String: Any])
+        #expect(params["stdoutOffset"] == nil)
+        #expect(params["stderrOffset"] == nil)
+
+        transport.send(frame: Data(#"""
+        {"jsonrpc":"2.0","id":1,"result":{
+          "procId":"acp-session-1",
+          "running":true,
+          "exitCode":null,
+          "stdinOffset":0,
+          "stdoutOffset":0,
+          "stderrOffset":0,
+          "stdoutFrames":[],
+          "stderrChunks":[]
+        }}
+        """#.utf8))
+        _ = try await attach.value
     }
 
     @Test func remoteHelperACPTransportFramesWritesAsNewlineDelimitedACP() {

--- a/AlasTests/SSH/RemoteHelperClientTests.swift
+++ b/AlasTests/SSH/RemoteHelperClientTests.swift
@@ -143,6 +143,7 @@ struct RemoteHelperClientTests {
           "procId":"acp-session-1",
           "running":true,
           "exitCode":null,
+          "stdinOffset":40,
           "stdoutOffset":25,
           "stderrOffset":0,
           "stdoutFrames":[{"offset":25,"dataBase64":"eyJqc29ucnBjIjoiMi4wIn0="}],
@@ -151,6 +152,7 @@ struct RemoteHelperClientTests {
         """#.utf8))
 
         let handle = try await attach.value
+        #expect(handle.stdinOffset == 40)
         var iterator = handle.events.makeAsyncIterator()
         #expect(await iterator.next() == .stdout(Data(#"{"jsonrpc":"2.0"}"#.utf8), offset: 25))
         #expect(await iterator.next() == .available)
@@ -189,6 +191,7 @@ struct RemoteHelperClientTests {
           "procId":"acp-session-1",
           "running":true,
           "exitCode":null,
+          "stdinOffset":0,
           "stdoutOffset":0,
           "stderrOffset":0,
           "stdoutFrames":[],

--- a/AlasTests/SSH/RemoteHelperClientTests.swift
+++ b/AlasTests/SSH/RemoteHelperClientTests.swift
@@ -207,6 +207,132 @@ struct RemoteHelperClientTests {
         #expect(await iterator.next() == nil)
     }
 
+    @Test func procAttachUsesRememberedOffsetsWhenReattaching() async throws {
+        let transport = FakeJSONRPCTransport()
+        let client = RemoteHelperClient(
+            host: "devbox",
+            idleShutdownNanoseconds: 0,
+            transportFactory: { transport }
+        )
+
+        let firstAttach = Task {
+            try await client.attachProc(procId: "acp-session-1", stdoutOffset: 0, stderrOffset: 0)
+        }
+        try await waitUntil { transport.sentFrames.count == 1 }
+        transport.send(frame: Data(#"""
+        {"jsonrpc":"2.0","id":1,"result":{
+          "procId":"acp-session-1",
+          "running":true,
+          "exitCode":null,
+          "stdinOffset":0,
+          "stdoutOffset":20,
+          "stderrOffset":3,
+          "stdoutFrames":[],
+          "stderrChunks":[]
+        }}
+        """#.utf8))
+        let firstHandle = try await firstAttach.value
+        var firstIterator = firstHandle.events.makeAsyncIterator()
+        #expect(await firstIterator.next() == .available)
+
+        transport.send(frame: Data(#"""
+        {"jsonrpc":"2.0","method":"proc/output","params":{
+          "procId":"acp-session-1",
+          "stream":"stdout",
+          "offset":52,
+          "dataBase64":"eyJtZXRob2QiOiJzZXNzaW9uL3VwZGF0ZSJ9"
+        }}
+        """#.utf8))
+        #expect(await firstIterator.next() == .stdout(Data(#"{"method":"session/update"}"#.utf8), offset: 52))
+
+        await client.detachProc(procId: "acp-session-1", stdoutOffset: 52, stderrOffset: 3)
+        let secondAttach = Task {
+            try await client.attachProc(procId: "acp-session-1", attachAtEndIfOffsetUnknown: true)
+        }
+        try await waitUntil { transport.sentFrames.count == 2 }
+        let request = try #require(
+            JSONSerialization.jsonObject(with: transport.sentFrames[1]) as? [String: Any]
+        )
+        let params = try #require(request["params"] as? [String: Any])
+        #expect(params["stdoutOffset"] as? Int == 52)
+        #expect(params["stderrOffset"] as? Int == 3)
+
+        transport.send(frame: Data(#"""
+        {"jsonrpc":"2.0","id":2,"result":{
+          "procId":"acp-session-1",
+          "running":true,
+          "exitCode":null,
+          "stdinOffset":0,
+          "stdoutOffset":52,
+          "stderrOffset":3,
+          "stdoutFrames":[],
+          "stderrChunks":[]
+        }}
+        """#.utf8))
+        _ = try await secondAttach.value
+    }
+
+    @Test func procDetachDropsLocalAttachmentWithoutBufferingOutput() async throws {
+        let transport = FakeJSONRPCTransport()
+        let client = RemoteHelperClient(
+            host: "devbox",
+            idleShutdownNanoseconds: 0,
+            transportFactory: { transport }
+        )
+
+        let attach = Task {
+            try await client.attachProc(procId: "acp-session-1", stdoutOffset: 0, stderrOffset: 0)
+        }
+        try await waitUntil { transport.sentFrames.count == 1 }
+        transport.send(frame: Data(#"""
+        {"jsonrpc":"2.0","id":1,"result":{
+          "procId":"acp-session-1",
+          "running":true,
+          "exitCode":null,
+          "stdinOffset":0,
+          "stdoutOffset":12,
+          "stderrOffset":0,
+          "stdoutFrames":[],
+          "stderrChunks":[]
+        }}
+        """#.utf8))
+        let handle = try await attach.value
+        var iterator = handle.events.makeAsyncIterator()
+        #expect(await iterator.next() == .available)
+
+        await client.detachProc(procId: "acp-session-1", stdoutOffset: 12, stderrOffset: 0)
+        #expect(await iterator.next() == nil)
+
+        transport.send(frame: Data(#"""
+        {"jsonrpc":"2.0","method":"proc/output","params":{
+          "procId":"acp-session-1",
+          "stream":"stdout",
+          "offset":30,
+          "dataBase64":"c3RhbGU="
+        }}
+        """#.utf8))
+
+        let reattach = Task {
+            try await client.attachProc(procId: "acp-session-1", attachAtEndIfOffsetUnknown: true)
+        }
+        try await waitUntil { transport.sentFrames.count == 2 }
+        transport.send(frame: Data(#"""
+        {"jsonrpc":"2.0","id":2,"result":{
+          "procId":"acp-session-1",
+          "running":true,
+          "exitCode":null,
+          "stdinOffset":0,
+          "stdoutOffset":30,
+          "stderrOffset":0,
+          "stdoutFrames":[],
+          "stderrChunks":[]
+        }}
+        """#.utf8))
+        let reattachHandle = try await reattach.value
+        var reattachIterator = reattachHandle.events.makeAsyncIterator()
+        #expect(await reattachIterator.next() == .available)
+    }
+
     @Test func remoteHelperACPTransportFramesWritesAsNewlineDelimitedACP() {
         let framed = RemoteHelperACPTransport.frameForProcWrite(Data(#"{"id":1}"#.utf8))
         #expect(framed == Data("{\"id\":1}\n".utf8))

--- a/AlasTests/SSH/RemoteHelperClientTests.swift
+++ b/AlasTests/SSH/RemoteHelperClientTests.swift
@@ -104,7 +104,8 @@ struct RemoteHelperClientTests {
                 command: "codex-acp",
                 args: ["--stdio"],
                 cwd: "/srv/repo",
-                env: ["PATH": "/usr/bin"]
+                env: ["PATH": "/usr/bin"],
+                pathPrefixDirectories: ["/managed/node/bin"]
             )
         }
 
@@ -117,6 +118,7 @@ struct RemoteHelperClientTests {
         #expect(params["procId"] as? String == "acp-session-1")
         #expect(params["command"] as? String == "codex-acp")
         #expect(params["cwd"] as? String == "/srv/repo")
+        #expect(params["pathPrefixDirectories"] as? [String] == ["/managed/node/bin"])
 
         transport.send(frame: Data(#"{"jsonrpc":"2.0","id":1,"result":{"procId":"acp-session-1","running":true,"exitCode":null}}"#.utf8))
         #expect(try await spawn.value == RemoteHelperProcStatus(

--- a/AlasTests/SSH/RemoteHelperClientTests.swift
+++ b/AlasTests/SSH/RemoteHelperClientTests.swift
@@ -568,12 +568,12 @@ struct RemoteHelperClientTests {
         #expect(freshOffsets.stderr == 0)
 
         let unknownNonFreshOffsets = RemoteHelperACPTransport.attachReplayOffsets(
-            stdoutOffset: 0,
-            stderrOffset: 0,
+            stdoutOffset: nil,
+            stderrOffset: nil,
             attachFreshSpawnFromStart: false
         )
-        #expect(unknownNonFreshOffsets.stdout == UInt64.max)
-        #expect(unknownNonFreshOffsets.stderr == UInt64.max)
+        #expect(unknownNonFreshOffsets.stdout == nil)
+        #expect(unknownNonFreshOffsets.stderr == nil)
 
         let rememberedOffsets = RemoteHelperACPTransport.attachReplayOffsets(
             stdoutOffset: 14,

--- a/AlasTests/SSH/RemoteHelperClientTests.swift
+++ b/AlasTests/SSH/RemoteHelperClientTests.swift
@@ -207,6 +207,36 @@ struct RemoteHelperClientTests {
         #expect(framed == Data("{\"id\":1}\n".utf8))
     }
 
+    @Test func procWriteUsesExpectedOffsetAndReturnsAcknowledgedOffset() async throws {
+        let transport = FakeJSONRPCTransport()
+        let client = RemoteHelperClient(
+            host: "devbox",
+            idleShutdownNanoseconds: 0,
+            transportFactory: { transport }
+        )
+
+        let write = Task {
+            try await client.writeProc(
+                procId: "acp-session-1",
+                data: Data("hello\n".utf8),
+                expectedStdinOffset: 42
+            )
+        }
+
+        try await waitUntil { transport.sentFrames.count == 1 }
+        let request = try #require(
+            JSONSerialization.jsonObject(with: transport.sentFrames[0]) as? [String: Any]
+        )
+        #expect(request["method"] as? String == "proc/write")
+        let params = try #require(request["params"] as? [String: Any])
+        #expect(params["procId"] as? String == "acp-session-1")
+        #expect(params["expectedStdinOffset"] as? Int == 42)
+        #expect(params["dataBase64"] as? String == Data("hello\n".utf8).base64EncodedString())
+
+        transport.send(frame: Data(#"{"jsonrpc":"2.0","id":1,"result":{"ok":true,"stdinOffset":48}}"#.utf8))
+        #expect(try await write.value == 48)
+    }
+
     @Test func remoteHelperACPTransportOnlyRetriesTransientSpawnFailures() {
         #expect(RemoteHelperACPTransport.shouldRetrySpawnFailure(RemoteHelperClientError.notRunning))
         #expect(RemoteHelperACPTransport.shouldRetrySpawnFailure(RemoteHelperClientError.unavailable("ssh closed")))

--- a/AlasTests/SSH/RemoteHelperClientTests.swift
+++ b/AlasTests/SSH/RemoteHelperClientTests.swift
@@ -501,6 +501,40 @@ struct RemoteHelperClientTests {
         _ = try await attach.value
     }
 
+    @Test func procAttachCanRequestEndWhenOffsetIsUnknown() async throws {
+        let transport = FakeJSONRPCTransport()
+        let client = RemoteHelperClient(
+            host: "devbox",
+            idleShutdownNanoseconds: 0,
+            transportFactory: { transport }
+        )
+
+        let attach = Task {
+            try await client.attachProc(
+                procId: "acp-session-1",
+                attachAtEndIfOffsetUnknown: true
+            )
+        }
+        try await waitUntil { transport.sentFrames.count == 1 }
+        let request = String(data: transport.sentFrames[0], encoding: .utf8) ?? ""
+        #expect(request.contains(#""stdoutOffset":18446744073709551615"#))
+        #expect(request.contains(#""stderrOffset":18446744073709551615"#))
+
+        transport.send(frame: Data(#"""
+        {"jsonrpc":"2.0","id":1,"result":{
+          "procId":"acp-session-1",
+          "running":true,
+          "exitCode":null,
+          "stdinOffset":0,
+          "stdoutOffset":30,
+          "stderrOffset":0,
+          "stdoutFrames":[],
+          "stderrChunks":[]
+        }}
+        """#.utf8))
+        _ = try await attach.value
+    }
+
     @Test func remoteHelperACPTransportFramesWritesAsNewlineDelimitedACP() {
         let framed = RemoteHelperACPTransport.frameForProcWrite(Data(#"{"id":1}"#.utf8))
         #expect(framed == Data("{\"id\":1}\n".utf8))
@@ -514,6 +548,7 @@ struct RemoteHelperClientTests {
         )
         #expect(freshOffsets.stdout == 0)
         #expect(freshOffsets.stderr == 0)
+        #expect(!freshOffsets.attachAtEndIfOffsetUnknown)
 
         let rememberedOffsets = RemoteHelperACPTransport.attachReplayOffsets(
             stdoutOffset: 0,
@@ -522,6 +557,7 @@ struct RemoteHelperClientTests {
         )
         #expect(rememberedOffsets.stdout == nil)
         #expect(rememberedOffsets.stderr == nil)
+        #expect(rememberedOffsets.attachAtEndIfOffsetUnknown)
     }
 
     @Test func procWriteUsesExpectedOffsetAndReturnsAcknowledgedOffset() async throws {

--- a/AlasTests/SSH/RemoteHelperClientTests.swift
+++ b/AlasTests/SSH/RemoteHelperClientTests.swift
@@ -567,13 +567,21 @@ struct RemoteHelperClientTests {
         #expect(freshOffsets.stdout == 0)
         #expect(freshOffsets.stderr == 0)
 
-        let rememberedOffsets = RemoteHelperACPTransport.attachReplayOffsets(
+        let unknownNonFreshOffsets = RemoteHelperACPTransport.attachReplayOffsets(
             stdoutOffset: 0,
             stderrOffset: 0,
             attachFreshSpawnFromStart: false
         )
-        #expect(rememberedOffsets.stdout == nil)
-        #expect(rememberedOffsets.stderr == nil)
+        #expect(unknownNonFreshOffsets.stdout == UInt64.max)
+        #expect(unknownNonFreshOffsets.stderr == UInt64.max)
+
+        let rememberedOffsets = RemoteHelperACPTransport.attachReplayOffsets(
+            stdoutOffset: 14,
+            stderrOffset: 3,
+            attachFreshSpawnFromStart: false
+        )
+        #expect(rememberedOffsets.stdout == 14)
+        #expect(rememberedOffsets.stderr == 3)
     }
 
     @Test func remoteHelperACPTransportSuppressesPreAvailableResponsesUntilProcInputMayHaveBeenWritten() {

--- a/AlasTests/SSH/RemoteHelperClientTests.swift
+++ b/AlasTests/SSH/RemoteHelperClientTests.swift
@@ -171,6 +171,58 @@ struct RemoteHelperClientTests {
         #expect(await iterator.next() == .stdout(Data(#"{"method":"session/update"}"#.utf8), offset: 52))
     }
 
+    @Test func procAttachDoesNotRememberReplayOffsetsBeforeDrain() async throws {
+        let transport = FakeJSONRPCTransport()
+        let client = RemoteHelperClient(
+            host: "devbox",
+            idleShutdownNanoseconds: 0,
+            transportFactory: { transport }
+        )
+
+        let firstAttach = Task {
+            try await client.attachProc(procId: "acp-session-1", attachmentId: "first")
+        }
+        try await waitUntil { transport.sentFrames.count == 1 }
+        transport.send(frame: Data(#"""
+        {"jsonrpc":"2.0","id":1,"result":{
+          "procId":"acp-session-1",
+          "running":true,
+          "exitCode":null,
+          "stdinOffset":40,
+          "stdoutOffset":25,
+          "stderrOffset":0,
+          "stdoutFrames":[{"offset":25,"dataBase64":"cmVwbGF5"}],
+          "stderrChunks":[]
+        }}
+        """#.utf8))
+        _ = try await firstAttach.value
+
+        let secondAttach = Task {
+            try await client.attachProc(procId: "acp-session-1", attachmentId: "second")
+        }
+        try await waitUntil { transport.sentFrames.count == 2 }
+        let secondRequest = try #require(
+            JSONSerialization.jsonObject(with: transport.sentFrames[1]) as? [String: Any]
+        )
+        let params = try #require(secondRequest["params"] as? [String: Any])
+        #expect(params["stdoutOffset"] == nil)
+        #expect(params["stderrOffset"] == nil)
+
+        transport.send(frame: Data(#"""
+        {"jsonrpc":"2.0","id":2,"result":{
+          "procId":"acp-session-1",
+          "running":true,
+          "exitCode":null,
+          "stdinOffset":40,
+          "stdoutOffset":25,
+          "stderrOffset":0,
+          "stdoutFrames":[],
+          "stderrChunks":[]
+        }}
+        """#.utf8))
+        _ = try await secondAttach.value
+    }
+
     @Test func procAttachFinishesAfterReplayingEarlyExit() async throws {
         let transport = FakeJSONRPCTransport()
         let client = RemoteHelperClient(

--- a/AlasTests/SSH/RemoteHelperClientTests.swift
+++ b/AlasTests/SSH/RemoteHelperClientTests.swift
@@ -207,6 +207,17 @@ struct RemoteHelperClientTests {
         #expect(framed == Data("{\"id\":1}\n".utf8))
     }
 
+    @Test func remoteHelperACPTransportOnlyRetriesTransientSpawnFailures() {
+        #expect(RemoteHelperACPTransport.shouldRetrySpawnFailure(RemoteHelperClientError.notRunning))
+        #expect(RemoteHelperACPTransport.shouldRetrySpawnFailure(RemoteHelperClientError.unavailable("ssh closed")))
+        #expect(!RemoteHelperACPTransport.shouldRetrySpawnFailure(RemoteHelperClientError.decoding("bad response")))
+        #expect(!RemoteHelperACPTransport.shouldRetrySpawnFailure(RemoteHelperClientError.jsonrpc(JSONRPCError(
+            code: -32050,
+            message: "spawn failed",
+            data: nil
+        ))))
+    }
+
     @Test func searchStreamsEventsArrivingImmediatelyAfterStart() async throws {
         let transport = FakeJSONRPCTransport()
         let client = RemoteHelperClient(

--- a/AlasTests/SSH/RemoteHelperClientTests.swift
+++ b/AlasTests/SSH/RemoteHelperClientTests.swift
@@ -166,6 +166,11 @@ struct RemoteHelperClientTests {
         #expect(await iterator.next() == .stdout(Data(#"{"method":"session/update"}"#.utf8), offset: 52))
     }
 
+    @Test func remoteHelperACPTransportFramesWritesAsNewlineDelimitedACP() {
+        let framed = RemoteHelperACPTransport.frameForProcWrite(Data(#"{"id":1}"#.utf8))
+        #expect(framed == Data("{\"id\":1}\n".utf8))
+    }
+
     @Test func searchStreamsEventsArrivingImmediatelyAfterStart() async throws {
         let transport = FakeJSONRPCTransport()
         let client = RemoteHelperClient(

--- a/AlasTests/SSH/RemoteHelperClientTests.swift
+++ b/AlasTests/SSH/RemoteHelperClientTests.swift
@@ -584,6 +584,24 @@ struct RemoteHelperClientTests {
         #expect(rememberedOffsets.stderr == 3)
     }
 
+    @Test func helperOutputConsumptionAdvancesOnlyThroughContiguousFrames() throws {
+        let tracker = RemoteHelperACPTransport.OutputConsumptionTracker(
+            stdoutOffset: 10,
+            stderrOffset: 2
+        )
+        let first = try #require(tracker.registerStdout(offset: 20))
+        let second = try #require(tracker.registerStdout(offset: 30))
+
+        #expect(tracker.consumeStdout(token: second) == nil)
+        #expect(tracker.snapshot() == .init(stdout: 10, stderr: 2))
+        #expect(tracker.consumeStdout(token: first) == .init(stdout: 30, stderr: 2))
+
+        tracker.reset(stdoutOffset: 0, stderrOffset: 0)
+        let respawned = try #require(tracker.registerStdout(offset: 20))
+        #expect(tracker.consumeStdout(token: first) == nil)
+        #expect(tracker.consumeStdout(token: respawned) == .init(stdout: 20, stderr: 0))
+    }
+
     @Test func remoteHelperACPTransportSuppressesPreAvailableResponsesUntilProcInputMayHaveBeenWritten() {
         #expect(RemoteHelperACPTransport.shouldSuppressPreAvailableReplayFrame(
             Data(#"{"jsonrpc":"2.0","id":1,"result":{"ok":true}}"#.utf8),

--- a/AlasTests/SSH/RemoteHelperClientTests.swift
+++ b/AlasTests/SSH/RemoteHelperClientTests.swift
@@ -584,12 +584,13 @@ struct RemoteHelperClientTests {
         #expect(rememberedOffsets.stderr == 3)
     }
 
-    @Test func helperOutputConsumptionAdvancesOnlyThroughContiguousFrames() throws {
+    @Test func helperOutputConsumptionRejectsPendingDuplicatesAndAdvancesContiguousFrames() throws {
         let tracker = RemoteHelperACPTransport.OutputConsumptionTracker(
             stdoutOffset: 10,
             stderrOffset: 2
         )
         let first = try #require(tracker.registerStdout(offset: 20))
+        #expect(tracker.registerStdout(offset: 20) == nil)
         let second = try #require(tracker.registerStdout(offset: 30))
 
         #expect(tracker.consumeStdout(token: second) == nil)

--- a/AlasTests/SSH/RemoteHelperClientTests.swift
+++ b/AlasTests/SSH/RemoteHelperClientTests.swift
@@ -152,8 +152,8 @@ struct RemoteHelperClientTests {
 
         let handle = try await attach.value
         var iterator = handle.events.makeAsyncIterator()
-        #expect(await iterator.next() == .available)
         #expect(await iterator.next() == .stdout(Data(#"{"jsonrpc":"2.0"}"#.utf8), offset: 25))
+        #expect(await iterator.next() == .available)
 
         transport.send(frame: Data(#"""
         {"jsonrpc":"2.0","method":"proc/output","params":{

--- a/AlasTests/SSH/RemoteHelperClientTests.swift
+++ b/AlasTests/SSH/RemoteHelperClientTests.swift
@@ -120,11 +120,12 @@ struct RemoteHelperClientTests {
         #expect(params["cwd"] as? String == "/srv/repo")
         #expect(params["pathPrefixDirectories"] as? [String] == ["/managed/node/bin"])
 
-        transport.send(frame: Data(#"{"jsonrpc":"2.0","id":1,"result":{"procId":"acp-session-1","running":true,"exitCode":null}}"#.utf8))
+        transport.send(frame: Data(#"{"jsonrpc":"2.0","id":1,"result":{"procId":"acp-session-1","running":true,"exitCode":null,"spawned":true}}"#.utf8))
         #expect(try await spawn.value == RemoteHelperProcStatus(
             procId: "acp-session-1",
             running: true,
-            exitCode: nil
+            exitCode: nil,
+            spawned: true
         ))
     }
 
@@ -503,6 +504,24 @@ struct RemoteHelperClientTests {
     @Test func remoteHelperACPTransportFramesWritesAsNewlineDelimitedACP() {
         let framed = RemoteHelperACPTransport.frameForProcWrite(Data(#"{"id":1}"#.utf8))
         #expect(framed == Data("{\"id\":1}\n".utf8))
+    }
+
+    @Test func remoteHelperACPTransportAttachesFreshSpawnFromStart() {
+        let freshOffsets = RemoteHelperACPTransport.attachReplayOffsets(
+            stdoutOffset: 0,
+            stderrOffset: 0,
+            attachFreshSpawnFromStart: true
+        )
+        #expect(freshOffsets.stdout == 0)
+        #expect(freshOffsets.stderr == 0)
+
+        let rememberedOffsets = RemoteHelperACPTransport.attachReplayOffsets(
+            stdoutOffset: 0,
+            stderrOffset: 0,
+            attachFreshSpawnFromStart: false
+        )
+        #expect(rememberedOffsets.stdout == nil)
+        #expect(rememberedOffsets.stderr == nil)
     }
 
     @Test func procWriteUsesExpectedOffsetAndReturnsAcknowledgedOffset() async throws {

--- a/AlasTests/SSH/RemoteHelperClientTests.swift
+++ b/AlasTests/SSH/RemoteHelperClientTests.swift
@@ -524,18 +524,26 @@ struct RemoteHelperClientTests {
         #expect(rememberedOffsets.stderr == nil)
     }
 
-    @Test func remoteHelperACPTransportSuppressesPreAvailableResponsesOnly() {
+    @Test func remoteHelperACPTransportSuppressesPreAvailableResponsesUntilProcInputMayHaveBeenWritten() {
         #expect(RemoteHelperACPTransport.shouldSuppressPreAvailableReplayFrame(
-            Data(#"{"jsonrpc":"2.0","id":1,"result":{"ok":true}}"#.utf8)
+            Data(#"{"jsonrpc":"2.0","id":1,"result":{"ok":true}}"#.utf8),
+            mayHaveDurableProcInput: false
         ))
         #expect(RemoteHelperACPTransport.shouldSuppressPreAvailableReplayFrame(
-            Data(#"{"jsonrpc":"2.0","id":1,"error":{"code":-1,"message":"old"}}"#.utf8)
+            Data(#"{"jsonrpc":"2.0","id":1,"error":{"code":-1,"message":"old"}}"#.utf8),
+            mayHaveDurableProcInput: false
         ))
         #expect(!RemoteHelperACPTransport.shouldSuppressPreAvailableReplayFrame(
-            Data(#"{"jsonrpc":"2.0","method":"session/update","params":{}}"#.utf8)
+            Data(#"{"jsonrpc":"2.0","method":"session/update","params":{}}"#.utf8),
+            mayHaveDurableProcInput: false
         ))
         #expect(!RemoteHelperACPTransport.shouldSuppressPreAvailableReplayFrame(
-            Data("not json".utf8)
+            Data("not json".utf8),
+            mayHaveDurableProcInput: false
+        ))
+        #expect(!RemoteHelperACPTransport.shouldSuppressPreAvailableReplayFrame(
+            Data(#"{"jsonrpc":"2.0","id":1,"result":{"ok":true}}"#.utf8),
+            mayHaveDurableProcInput: true
         ))
     }
 

--- a/AlasTests/SSH/RemoteHelperClientTests.swift
+++ b/AlasTests/SSH/RemoteHelperClientTests.swift
@@ -501,40 +501,6 @@ struct RemoteHelperClientTests {
         _ = try await attach.value
     }
 
-    @Test func procAttachCanRequestEndWhenOffsetIsUnknown() async throws {
-        let transport = FakeJSONRPCTransport()
-        let client = RemoteHelperClient(
-            host: "devbox",
-            idleShutdownNanoseconds: 0,
-            transportFactory: { transport }
-        )
-
-        let attach = Task {
-            try await client.attachProc(
-                procId: "acp-session-1",
-                attachAtEndIfOffsetUnknown: true
-            )
-        }
-        try await waitUntil { transport.sentFrames.count == 1 }
-        let request = String(data: transport.sentFrames[0], encoding: .utf8) ?? ""
-        #expect(request.contains(#""stdoutOffset":18446744073709551615"#))
-        #expect(request.contains(#""stderrOffset":18446744073709551615"#))
-
-        transport.send(frame: Data(#"""
-        {"jsonrpc":"2.0","id":1,"result":{
-          "procId":"acp-session-1",
-          "running":true,
-          "exitCode":null,
-          "stdinOffset":0,
-          "stdoutOffset":30,
-          "stderrOffset":0,
-          "stdoutFrames":[],
-          "stderrChunks":[]
-        }}
-        """#.utf8))
-        _ = try await attach.value
-    }
-
     @Test func remoteHelperACPTransportFramesWritesAsNewlineDelimitedACP() {
         let framed = RemoteHelperACPTransport.frameForProcWrite(Data(#"{"id":1}"#.utf8))
         #expect(framed == Data("{\"id\":1}\n".utf8))
@@ -548,7 +514,6 @@ struct RemoteHelperClientTests {
         )
         #expect(freshOffsets.stdout == 0)
         #expect(freshOffsets.stderr == 0)
-        #expect(!freshOffsets.attachAtEndIfOffsetUnknown)
 
         let rememberedOffsets = RemoteHelperACPTransport.attachReplayOffsets(
             stdoutOffset: 0,
@@ -557,7 +522,21 @@ struct RemoteHelperClientTests {
         )
         #expect(rememberedOffsets.stdout == nil)
         #expect(rememberedOffsets.stderr == nil)
-        #expect(rememberedOffsets.attachAtEndIfOffsetUnknown)
+    }
+
+    @Test func remoteHelperACPTransportSuppressesPreAvailableResponsesOnly() {
+        #expect(RemoteHelperACPTransport.shouldSuppressPreAvailableReplayFrame(
+            Data(#"{"jsonrpc":"2.0","id":1,"result":{"ok":true}}"#.utf8)
+        ))
+        #expect(RemoteHelperACPTransport.shouldSuppressPreAvailableReplayFrame(
+            Data(#"{"jsonrpc":"2.0","id":1,"error":{"code":-1,"message":"old"}}"#.utf8)
+        ))
+        #expect(!RemoteHelperACPTransport.shouldSuppressPreAvailableReplayFrame(
+            Data(#"{"jsonrpc":"2.0","method":"session/update","params":{}}"#.utf8)
+        ))
+        #expect(!RemoteHelperACPTransport.shouldSuppressPreAvailableReplayFrame(
+            Data("not json".utf8)
+        ))
     }
 
     @Test func procWriteUsesExpectedOffsetAndReturnsAcknowledgedOffset() async throws {

--- a/AlasTests/SSH/RemoteHelperClientTests.swift
+++ b/AlasTests/SSH/RemoteHelperClientTests.swift
@@ -316,6 +316,11 @@ struct RemoteHelperClientTests {
             try await client.attachProc(procId: "acp-session-1")
         }
         try await waitUntil { transport.sentFrames.count == 2 }
+        let request = try #require(
+            JSONSerialization.jsonObject(with: transport.sentFrames[1]) as? [String: Any]
+        )
+        let params = try #require(request["params"] as? [String: Any])
+        #expect(params["stdoutOffset"] as? Int == 12)
         transport.send(frame: Data(#"""
         {"jsonrpc":"2.0","id":2,"result":{
           "procId":"acp-session-1",


### PR DESCRIPTION
## Summary

- Add helper-owned process RPCs (`proc/spawn`, `proc/attach`, `proc/write`, `proc/kill`, `proc/list`) to the remote helper.
- Route remote ACP sessions through a durable helper-backed transport when the helper advertises process support, with reconnect/replay handling and fallback to the existing SSH stdio path.
- Kill helper-owned ACP processes when sessions are deleted, and cover the new client protocol with tests.

## Validation

- `rtk cargo test` in `AlasHelper`
- `rtk env ALAS_FFF_TARGET_ARCH=arm64 xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -quiet build`
- `rtk env ALAS_FFF_TARGET_ARCH=arm64 xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -only-testing:AlasTests/RemoteHelperClientTests -quiet test`
- `rtk env ALAS_FFF_TARGET_ARCH=arm64 xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -skip-testing:AlasTests/SSHIntegrationTests test`

The unskipped full suite was also run once; its only failures were the opt-in `SSHIntegrationTests` checks requiring `ALAS_SSH_INTEGRATION=1`.

Closes #754 